### PR TITLE
[EZ] Replace `pytorch-labs` with `meta-pytorch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This repository aims to provide a playground for experimenting with various atte
 ### Installation
 
 ```bash
-git clone https://github.com/pytorch-labs/attention-gym.git
+git clone https://github.com/meta-pytorch/attention-gym.git
 cd attention-gym
 pip install .
 ```

--- a/attn_gym/paged_attention/model.py
+++ b/attn_gym/paged_attention/model.py
@@ -7,7 +7,7 @@ from typing import Dict, Optional
 
 class NonPagedAttentionLayer(torch.nn.Module):
     """An attention layer without paged attention, ported from GPT-Fast:
-    https://github.com/pytorch-labs/gpt-fast/blob/main/model.py#L180-L227
+    https://github.com/meta-pytorch/gpt-fast/blob/main/model.py#L180-L227
     """
 
     def __init__(self, bsz, n_heads, max_seq_len, head_dim, dtype, block_size: int = 32768):


### PR DESCRIPTION
This PR replaces all instances of `pytorch-labs` with `meta-pytorch` in this repository now that the `pytorch-labs` org has been renamed to `meta-pytorch`

## Changes Made
- Replaced all occurrences of `pytorch-labs` with `meta-pytorch`
- Skipped binary files and files larger than 1MB due to GitHub api payload limits in the script to cover all repos in this org. Will do a more manual second pass later to cover any larger files

## Files Modified
This PR updates files that contained the target text.

Generated by automated script on 2025-08-22T23:26:34.451325+00:00Z