### PR TITLE
Grab flex autotune logs: add replay script

### DIFF
--- a/attn_gym/utils.py
+++ b/attn_gym/utils.py
@@ -16,8 +16,17 @@ try:
 except ImportError:
     from torch._higher_order_ops.flex_attention import TransformGetItemToIndex
 from contextlib import nullcontext
+from torch._inductor.utils import do_bench_using_profiling
+from collections.abc import Callable
 
 Tensor = torch.Tensor
+
+
+def benchmark_cuda_function_in_microseconds(func: Callable, *args, **kwargs) -> float:
+    """Thin wrapper around do_bench_using_profiling"""
+    no_args = lambda: func(*args, **kwargs)
+    time = do_bench_using_profiling(no_args)
+    return time * 1e3
 
 
 def create_score_mod(

--- a/examples/flex_autotune_replay.py
+++ b/examples/flex_autotune_replay.py
@@ -1,0 +1,132 @@
+import json
+import os
+import tempfile
+from unittest.mock import patch
+
+import torch
+from torch.nn.attention.flex_attention import flex_attention, FlexKernelOptions, create_block_mask
+from attn_gym.utils import benchmark_cuda_function_in_microseconds
+from attn_gym.masks import causal_mask
+
+torch.compiler.config.force_disable_caches = True
+torch._functorch.config.donated_buffer = False
+
+
+def run_autotune(log_file: str):
+    """
+    Runs flex_attention with max-autotune to generate kernel tuning logs.
+    """
+    print("Running autotuning phase...")
+    query = torch.randn(2, 2, 8192, 64, device="cuda", dtype=torch.float16, requires_grad=True)
+    key = torch.randn(2, 2, 8192, 64, device="cuda", dtype=torch.float16, requires_grad=True)
+    value = torch.randn(2, 2, 8192, 64, device="cuda", dtype=torch.float16, requires_grad=True)
+
+    block_mask = torch.compile(create_block_mask)(
+        causal_mask, None, None, 8192, 8192, device="cuda"
+    )
+
+    compiled_flex = torch.compile(flex_attention, mode="max-autotune-no-cudagraphs")
+
+    with patch.dict(os.environ, {"TORCHINDUCTOR_FLEX_ATTENTION_LOGGING_FILE": log_file}):
+        out = compiled_flex(
+            query=query,
+            key=key,
+            value=value,
+            block_mask=block_mask,
+        )
+        out.sum().backward()
+    print(f"Autotuning logs saved to {log_file}.json")
+
+
+def parse_log_and_get_best_options(log_file: str) -> FlexKernelOptions:
+    """
+    Parses the autotuning log and returns the best kernel options.
+    """
+    print("\nParsing autotuning logs...")
+    json_file = log_file + ".json"
+    with open(json_file) as f:
+        log_data = json.load(f)
+
+    best_options: FlexKernelOptions = {}
+    for entry in log_data:
+        dims_key, choices = next(iter(entry.items()))
+        kernel_type = eval(dims_key)[0]  # 'forward' or 'backward'
+        best_choice = choices[0]  # The list is sorted by time
+
+        prefix = "fwd_" if kernel_type == "forward" else "bwd_"
+
+        for key, value in best_choice.items():
+            if key not in ["type", "time"]:
+                # Ensure the key is valid for FlexKernelOptions
+                if key in FlexKernelOptions.__annotations__:
+                    best_options[f"{prefix}{key}"] = value
+    print("Best kernel options extracted from logs:")
+    print(json.dumps(best_options, indent=2))
+    return best_options
+
+
+def run_with_best_options(kernel_options: FlexKernelOptions):
+    """
+    Runs flex_attention with the provided kernel options.
+    """
+    print("\nRunning with pre-compiled best options...")
+    query = torch.randn(2, 2, 8192, 64, device="cuda", dtype=torch.float16, requires_grad=True)
+    key = torch.randn(2, 2, 8192, 64, device="cuda", dtype=torch.float16, requires_grad=True)
+    value = torch.randn(2, 2, 8192, 64, device="cuda", dtype=torch.float16, requires_grad=True)
+
+    block_mask = torch.compile(create_block_mask)(
+        causal_mask, None, None, 8192, 8192, device="cuda"
+    )
+
+    # Note: We are not using max-autotune here
+    compiled_flex = torch.compile(flex_attention)
+
+    # Make sure we are not logging this run
+    if "TORCHINDUCTOR_FLEX_ATTENTION_LOGGING_FILE" in os.environ:
+        del os.environ["TORCHINDUCTOR_FLEX_ATTENTION_LOGGING_FILE"]
+
+    def run_fwd():
+        return compiled_flex(
+            query=query,
+            key=key,
+            value=value,
+            block_mask=block_mask,
+            kernel_options=kernel_options,
+        )
+
+    # Warmup
+    for _ in range(3):
+        run_fwd()
+    fwd_time = benchmark_cuda_function_in_microseconds(run_fwd)
+    print(f"Execution time with best options: {fwd_time / 1000:.3f} ms")
+
+    out = run_fwd()
+    loss = out.sum()
+
+    def run_bwd():
+        loss.backward(retain_graph=True)
+
+    # Warmup
+    for _ in range(3):
+        run_bwd()
+
+    bwd_time = benchmark_cuda_function_in_microseconds(run_bwd)
+    print(f"Backward execution time with best options: {bwd_time / 1000:.3f} ms")
+
+
+def main():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        log_file_path = os.path.join(tmpdir, "flex_attention_configs")
+
+        # 1. Run autotuning
+        run_autotune(log_file_path)
+
+        # 2. Parse the log file to get the best options
+        best_kernel_options = parse_log_and_get_best_options(log_file_path)
+
+        # 3. Run with the best options
+        run_with_best_options(best_kernel_options)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
See: https://github.com/pytorch/pytorch/pull/165817

Sample output:

```Shell
❯ python examples/flex_autotune_replay.py
Running autotuning phase...
/home/dev/meta/pytorch/torch/_dynamo/pgo.py:539: UserWarning: dynamo_pgo force disabled by torch.compiler.config.force_disable_caches
  warn_once(
/home/dev/meta/pytorch/torch/__init__.py:1549: UserWarning: Please use the new API settings to control TF32 behavior, such as torch.backends.cudnn.conv.fp32_precision = 'tf32' or torch.backends.cuda.matmul.fp32_precision = 'ieee'. Old settings, e.g, torch.backends.cuda.matmul.allow_tf32 = True, torch.backends.cudnn.allow_tf32 = True, allowTF32CuDNN() and allowTF32CuBLAS() will be deprecated after Pytorch 2.9. Please see https://pytorch.org/docs/main/notes/cuda.html#tensorfloat-32-tf32-on-ampere-and-later-devices (Triggered internally at /home/dev/meta/pytorch/aten/src/ATen/Context.cpp:45.)
  return _C._get_float32_matmul_precision()
Autotune Choices Stats:
{"num_choices": 5, "num_triton_choices": 5, "best_kernel": "triton_flex_attention_0", "best_kernel_desc": "BLOCKS_ARE_CONTIGUOUS=False, BLOCK_M=128, BLOCK_N=64, FLOAT32_PRECISION=\"'ieee'\", GQA_SHARED_HEADS=1, HAS_FULL_BLOCKS=True, IS_DIVISIBLE=True, OUTPUT_LOGSUMEXP=True, OUTPUT_MAX=False, PRESCALE_QK=False, QK_HEAD_DIM=64, QK_HEAD_DIM_ROUNDED=64, ROWS_GUARANTEED_SAFE=False, SAFE_HEAD_DIM=True, SM_SCALE=0.125, SPARSE_KV_BLOCK_SIZE=128, SPARSE_Q_BLOCK_SIZE=128, USE_TMA=False, V_HEAD_DIM=64, V_HEAD_DIM_ROUNDED=64, WRITE_DQ=True, num_stages=3, num_warps=4", "best_time": 0.36745598912239075, "best_triton_pos": 0}
AUTOTUNE flex_attention(2x2x8192x64, 2x2x8192x64, 2x2x8192x64, 2x2x8192, 2x2x8192, 1x1x64, 1x1x64x64, 1x1x64, 1x1x64x64)
strides: [1048576, 524288, 64, 1], [1048576, 524288, 64, 1], [1048576, 524288, 64, 1], [16384, 8192, 1], [16384, 8192, 1], [64, 64, 1], [4096, 4096, 64, 1], [64, 64, 1], [4096, 4096, 64, 1]
dtypes: torch.float16, torch.float16, torch.float16, torch.float32, torch.float32, torch.int32, torch.int32, torch.int32, torch.int32
  triton_flex_attention_0 0.3675 ms 100.0% BLOCKS_ARE_CONTIGUOUS=False, BLOCK_M=128, BLOCK_N=64, FLOAT32_PRECISION="'ieee'", GQA_SHARED_HEADS=1, HAS_FULL_BLOCKS=True, IS_DIVISIBLE=True, OUTPUT_LOGSUMEXP=True, OUTPUT_MAX=False, PRESCALE_QK=False, QK_HEAD_DIM=64, QK_HEAD_DIM_ROUNDED=64, ROWS_GUARANTEED_SAFE=False, SAFE_HEAD_DIM=True, SM_SCALE=0.125, SPARSE_KV_BLOCK_SIZE=128, SPARSE_Q_BLOCK_SIZE=128, USE_TMA=False, V_HEAD_DIM=64, V_HEAD_DIM_ROUNDED=64, WRITE_DQ=True, num_stages=3, num_warps=4
  triton_flex_attention_3 0.4166 ms 88.2% BLOCKS_ARE_CONTIGUOUS=False, BLOCK_M=64, BLOCK_N=128, FLOAT32_PRECISION="'ieee'", GQA_SHARED_HEADS=1, HAS_FULL_BLOCKS=True, IS_DIVISIBLE=True, OUTPUT_LOGSUMEXP=True, OUTPUT_MAX=False, PRESCALE_QK=False, QK_HEAD_DIM=64, QK_HEAD_DIM_ROUNDED=64, ROWS_GUARANTEED_SAFE=False, SAFE_HEAD_DIM=True, SM_SCALE=0.125, SPARSE_KV_BLOCK_SIZE=128, SPARSE_Q_BLOCK_SIZE=128, USE_TMA=False, V_HEAD_DIM=64, V_HEAD_DIM_ROUNDED=64, WRITE_DQ=True, num_stages=3, num_warps=4
  triton_flex_attention_4 0.4761 ms 77.2% BLOCKS_ARE_CONTIGUOUS=False, BLOCK_M=64, BLOCK_N=64, FLOAT32_PRECISION="'ieee'", GQA_SHARED_HEADS=1, HAS_FULL_BLOCKS=True, IS_DIVISIBLE=True, OUTPUT_LOGSUMEXP=True, OUTPUT_MAX=False, PRESCALE_QK=False, QK_HEAD_DIM=64, QK_HEAD_DIM_ROUNDED=64, ROWS_GUARANTEED_SAFE=False, SAFE_HEAD_DIM=True, SM_SCALE=0.125, SPARSE_KV_BLOCK_SIZE=128, SPARSE_Q_BLOCK_SIZE=128, USE_TMA=False, V_HEAD_DIM=64, V_HEAD_DIM_ROUNDED=64, WRITE_DQ=True, num_stages=3, num_warps=4
  triton_flex_attention_1 0.7097 ms 51.8% BLOCKS_ARE_CONTIGUOUS=False, BLOCK_M=128, BLOCK_N=128, FLOAT32_PRECISION="'ieee'", GQA_SHARED_HEADS=1, HAS_FULL_BLOCKS=True, IS_DIVISIBLE=True, OUTPUT_LOGSUMEXP=True, OUTPUT_MAX=False, PRESCALE_QK=False, QK_HEAD_DIM=64, QK_HEAD_DIM_ROUNDED=64, ROWS_GUARANTEED_SAFE=False, SAFE_HEAD_DIM=True, SM_SCALE=0.125, SPARSE_KV_BLOCK_SIZE=128, SPARSE_Q_BLOCK_SIZE=128, USE_TMA=False, V_HEAD_DIM=64, V_HEAD_DIM_ROUNDED=64, WRITE_DQ=True, num_stages=3, num_warps=4
  triton_flex_attention_2 0.7138 ms 51.5% BLOCKS_ARE_CONTIGUOUS=False, BLOCK_M=128, BLOCK_N=128, FLOAT32_PRECISION="'ieee'", GQA_SHARED_HEADS=1, HAS_FULL_BLOCKS=True, IS_DIVISIBLE=True, OUTPUT_LOGSUMEXP=True, OUTPUT_MAX=False, PRESCALE_QK=False, QK_HEAD_DIM=64, QK_HEAD_DIM_ROUNDED=64, ROWS_GUARANTEED_SAFE=False, SAFE_HEAD_DIM=True, SM_SCALE=0.125, SPARSE_KV_BLOCK_SIZE=128, SPARSE_Q_BLOCK_SIZE=128, USE_TMA=False, V_HEAD_DIM=64, V_HEAD_DIM_ROUNDED=64, WRITE_DQ=True, num_stages=2, num_warps=8
SingleProcess AUTOTUNE benchmarking takes 0.2192 seconds and 1.9980 seconds precompiling for 5 choices
Autotune Choices Stats:
{"num_choices": 28, "num_triton_choices": 28, "best_kernel": "triton_flex_attention_backward_10", "best_kernel_desc": "BLOCKS_ARE_CONTIGUOUS=False, BLOCK_M1=32, BLOCK_M2=64, BLOCK_N1=64, BLOCK_N2=32, FLOAT32_PRECISION=\"'ieee'\", GQA_SHARED_HEADS=1, HAS_FULL_BLOCKS=True, IS_DIVISIBLE=True, OUTPUT_LOGSUMEXP=True, OUTPUT_MAX=False, PRESCALE_QK=False, QK_HEAD_DIM=64, QK_HEAD_DIM_ROUNDED=64, ROWS_GUARANTEED_SAFE=False, SAFE_HEAD_DIM=True, SM_SCALE=0.125, SPARSE_KV_BLOCK_SIZE=128, SPARSE_Q_BLOCK_SIZE=128, V_HEAD_DIM=64, V_HEAD_DIM_ROUNDED=64, WRITE_DQ=True, num_stages=3, num_warps=4", "best_time": 1.0371520519256592, "best_triton_pos": 0}
AUTOTUNE flex_attention_backward(2x2x8192x64, 2x2x8192x64, 2x2x8192x64, 2x2x8192, 2x2x8192, 2x2x8192x64, 2x2x8192x64, 2x2x8192x64, 1x1x64, 1x1x64x64, 1x1x64, 1x1x64x64, 1x1x64, 1x1x64x64, 1x1x64, 1x1x64x64)
strides: [1048576, 524288, 64, 1], [1048576, 524288, 64, 1], [1048576, 524288, 64, 1], [16384, 8192, 1], [16384, 8192, 1], [1048576, 524288, 64, 1], [1048576, 524288, 64, 1], [1048576, 524288, 64, 1], [64, 64, 1], [4096, 4096, 64, 1], [64, 64, 1], [4096, 4096, 64, 1], [64, 64, 1], [4096, 4096, 64, 1], [64, 64, 1], [4096, 4096, 64, 1]
dtypes: torch.float16, torch.float16, torch.float16, torch.float32, torch.float32, torch.float16, torch.float16, torch.float16, torch.int32, torch.int32, torch.int32, torch.int32, torch.int32, torch.int32, torch.int32, torch.int32
  triton_flex_attention_backward_10 1.0372 ms 100.0% BLOCKS_ARE_CONTIGUOUS=False, BLOCK_M1=32, BLOCK_M2=64, BLOCK_N1=64, BLOCK_N2=32, FLOAT32_PRECISION="'ieee'", GQA_SHARED_HEADS=1, HAS_FULL_BLOCKS=True, IS_DIVISIBLE=True, OUTPUT_LOGSUMEXP=True, OUTPUT_MAX=False, PRESCALE_QK=False, QK_HEAD_DIM=64, QK_HEAD_DIM_ROUNDED=64, ROWS_GUARANTEED_SAFE=False, SAFE_HEAD_DIM=True, SM_SCALE=0.125, SPARSE_KV_BLOCK_SIZE=128, SPARSE_Q_BLOCK_SIZE=128, V_HEAD_DIM=64, V_HEAD_DIM_ROUNDED=64, WRITE_DQ=True, num_stages=3, num_warps=4
  triton_flex_attention_backward_23 1.1644 ms 89.1% BLOCKS_ARE_CONTIGUOUS=False, BLOCK_M1=64, BLOCK_M2=64, BLOCK_N1=64, BLOCK_N2=64, FLOAT32_PRECISION="'ieee'", GQA_SHARED_HEADS=1, HAS_FULL_BLOCKS=True, IS_DIVISIBLE=True, OUTPUT_LOGSUMEXP=True, OUTPUT_MAX=False, PRESCALE_QK=False, QK_HEAD_DIM=64, QK_HEAD_DIM_ROUNDED=64, ROWS_GUARANTEED_SAFE=False, SAFE_HEAD_DIM=True, SM_SCALE=0.125, SPARSE_KV_BLOCK_SIZE=128, SPARSE_Q_BLOCK_SIZE=128, V_HEAD_DIM=64, V_HEAD_DIM_ROUNDED=64, WRITE_DQ=True, num_stages=4, num_warps=4
  triton_flex_attention_backward_22 1.1652 ms 89.0% BLOCKS_ARE_CONTIGUOUS=False, BLOCK_M1=64, BLOCK_M2=64, BLOCK_N1=64, BLOCK_N2=64, FLOAT32_PRECISION="'ieee'", GQA_SHARED_HEADS=1, HAS_FULL_BLOCKS=True, IS_DIVISIBLE=True, OUTPUT_LOGSUMEXP=True, OUTPUT_MAX=False, PRESCALE_QK=False, QK_HEAD_DIM=64, QK_HEAD_DIM_ROUNDED=64, ROWS_GUARANTEED_SAFE=False, SAFE_HEAD_DIM=True, SM_SCALE=0.125, SPARSE_KV_BLOCK_SIZE=128, SPARSE_Q_BLOCK_SIZE=128, V_HEAD_DIM=64, V_HEAD_DIM_ROUNDED=64, WRITE_DQ=True, num_stages=3, num_warps=4
  triton_flex_attention_backward_15 1.2051 ms 86.1% BLOCKS_ARE_CONTIGUOUS=False, BLOCK_M1=32, BLOCK_M2=128, BLOCK_N1=128, BLOCK_N2=32, FLOAT32_PRECISION="'ieee'", GQA_SHARED_HEADS=1, HAS_FULL_BLOCKS=True, IS_DIVISIBLE=True, OUTPUT_LOGSUMEXP=True, OUTPUT_MAX=False, PRESCALE_QK=False, QK_HEAD_DIM=64, QK_HEAD_DIM_ROUNDED=64, ROWS_GUARANTEED_SAFE=False, SAFE_HEAD_DIM=True, SM_SCALE=0.125, SPARSE_KV_BLOCK_SIZE=128, SPARSE_Q_BLOCK_SIZE=128, V_HEAD_DIM=64, V_HEAD_DIM_ROUNDED=64, WRITE_DQ=True, num_stages=3, num_warps=4
  triton_flex_attention_backward_17 1.2421 ms 83.5% BLOCKS_ARE_CONTIGUOUS=False, BLOCK_M1=32, BLOCK_M2=128, BLOCK_N1=128, BLOCK_N2=32, FLOAT32_PRECISION="'ieee'", GQA_SHARED_HEADS=1, HAS_FULL_BLOCKS=True, IS_DIVISIBLE=True, OUTPUT_LOGSUMEXP=True, OUTPUT_MAX=False, PRESCALE_QK=False, QK_HEAD_DIM=64, QK_HEAD_DIM_ROUNDED=64, ROWS_GUARANTEED_SAFE=False, SAFE_HEAD_DIM=True, SM_SCALE=0.125, SPARSE_KV_BLOCK_SIZE=128, SPARSE_Q_BLOCK_SIZE=128, V_HEAD_DIM=64, V_HEAD_DIM_ROUNDED=64, WRITE_DQ=True, num_stages=4, num_warps=4
  triton_flex_attention_backward_12 1.2503 ms 82.9% BLOCKS_ARE_CONTIGUOUS=False, BLOCK_M1=32, BLOCK_M2=64, BLOCK_N1=64, BLOCK_N2=32, FLOAT32_PRECISION="'ieee'", GQA_SHARED_HEADS=1, HAS_FULL_BLOCKS=True, IS_DIVISIBLE=True, OUTPUT_LOGSUMEXP=True, OUTPUT_MAX=False, PRESCALE_QK=False, QK_HEAD_DIM=64, QK_HEAD_DIM_ROUNDED=64, ROWS_GUARANTEED_SAFE=False, SAFE_HEAD_DIM=True, SM_SCALE=0.125, SPARSE_KV_BLOCK_SIZE=128, SPARSE_Q_BLOCK_SIZE=128, V_HEAD_DIM=64, V_HEAD_DIM_ROUNDED=64, WRITE_DQ=True, num_stages=5, num_warps=4
  triton_flex_attention_backward_19 1.2534 ms 82.7% BLOCKS_ARE_CONTIGUOUS=False, BLOCK_M1=32, BLOCK_M2=128, BLOCK_N1=128, BLOCK_N2=32, FLOAT32_PRECISION="'ieee'", GQA_SHARED_HEADS=1, HAS_FULL_BLOCKS=True, IS_DIVISIBLE=True, OUTPUT_LOGSUMEXP=True, OUTPUT_MAX=False, PRESCALE_QK=False, QK_HEAD_DIM=64, QK_HEAD_DIM_ROUNDED=64, ROWS_GUARANTEED_SAFE=False, SAFE_HEAD_DIM=True, SM_SCALE=0.125, SPARSE_KV_BLOCK_SIZE=128, SPARSE_Q_BLOCK_SIZE=128, V_HEAD_DIM=64, V_HEAD_DIM_ROUNDED=64, WRITE_DQ=True, num_stages=5, num_warps=4
  triton_flex_attention_backward_11 1.2780 ms 81.2% BLOCKS_ARE_CONTIGUOUS=False, BLOCK_M1=32, BLOCK_M2=64, BLOCK_N1=64, BLOCK_N2=32, FLOAT32_PRECISION="'ieee'", GQA_SHARED_HEADS=1, HAS_FULL_BLOCKS=True, IS_DIVISIBLE=True, OUTPUT_LOGSUMEXP=True, OUTPUT_MAX=False, PRESCALE_QK=False, QK_HEAD_DIM=64, QK_HEAD_DIM_ROUNDED=64, ROWS_GUARANTEED_SAFE=False, SAFE_HEAD_DIM=True, SM_SCALE=0.125, SPARSE_KV_BLOCK_SIZE=128, SPARSE_Q_BLOCK_SIZE=128, V_HEAD_DIM=64, V_HEAD_DIM_ROUNDED=64, WRITE_DQ=True, num_stages=4, num_warps=4
  triton_flex_attention_backward_18 1.3425 ms 77.3% BLOCKS_ARE_CONTIGUOUS=False, BLOCK_M1=32, BLOCK_M2=128, BLOCK_N1=128, BLOCK_N2=32, FLOAT32_PRECISION="'ieee'", GQA_SHARED_HEADS=1, HAS_FULL_BLOCKS=True, IS_DIVISIBLE=True, OUTPUT_LOGSUMEXP=True, OUTPUT_MAX=False, PRESCALE_QK=False, QK_HEAD_DIM=64, QK_HEAD_DIM_ROUNDED=64, ROWS_GUARANTEED_SAFE=False, SAFE_HEAD_DIM=True, SM_SCALE=0.125, SPARSE_KV_BLOCK_SIZE=128, SPARSE_Q_BLOCK_SIZE=128, V_HEAD_DIM=64, V_HEAD_DIM_ROUNDED=64, WRITE_DQ=True, num_stages=4, num_warps=8
  triton_flex_attention_backward_16 1.3540 ms 76.6% BLOCKS_ARE_CONTIGUOUS=False, BLOCK_M1=32, BLOCK_M2=128, BLOCK_N1=128, BLOCK_N2=32, FLOAT32_PRECISION="'ieee'", GQA_SHARED_HEADS=1, HAS_FULL_BLOCKS=True, IS_DIVISIBLE=True, OUTPUT_LOGSUMEXP=True, OUTPUT_MAX=False, PRESCALE_QK=False, QK_HEAD_DIM=64, QK_HEAD_DIM_ROUNDED=64, ROWS_GUARANTEED_SAFE=False, SAFE_HEAD_DIM=True, SM_SCALE=0.125, SPARSE_KV_BLOCK_SIZE=128, SPARSE_Q_BLOCK_SIZE=128, V_HEAD_DIM=64, V_HEAD_DIM_ROUNDED=64, WRITE_DQ=True, num_stages=3, num_warps=8
SingleProcess AUTOTUNE benchmarking takes 1.4277 seconds and 2.9633 seconds precompiling for 28 choices
Autotuning logs saved to /tmp/tmp23wkbqgd/flex_attention_configs.json

Parsing autotuning logs...
Best kernel options extracted from logs:
{
  "fwd_kpack": 2,
  "fwd_num_warps": 4,
  "fwd_BLOCK_N": 64,
  "fwd_matrix_instr_nonkdim": 0,
  "fwd_waves_per_eu": 0,
  "fwd_num_stages": 3,
  "fwd_BLOCK_M": 128,
  "fwd_USE_TMA": false,
  "bwd_BLOCK_M2": 64,
  "bwd_BLOCK_M1": 32,
  "bwd_BLOCK_N1": 64,
  "bwd_BLOCK_N2": 32,
  "bwd_kpack": 2,
  "bwd_num_warps": 4,
  "bwd_matrix_instr_nonkdim": 0,
  "bwd_waves_per_eu": 0,
  "bwd_num_stages": 3
}

Running with pre-compiled best options...
Execution time with best options: 0.151 ms
Backward execution time with best options: 0.332 ms

```
