### PR TITLE
Fix hard-coded seq len in run_document_masking

### DIFF
--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -218,7 +218,7 @@ def run_document_masking(max_seq_len: int, num_docs: int):
     lengths = generate_random_lengths(max_seq_len, num_docs)
     offsets = length_to_offsets(lengths, "cuda")
     document_causal_mask = generate_doc_mask_mod(causal_mask, offsets)
-    test_mask(mask_mod=document_causal_mask, S=32768)
+    test_mask(mask_mod=document_causal_mask, S=max_seq_len)
 
 
 def main(examples: List[str] = ["all"]):


### PR DESCRIPTION
Fixes #124.

Agent made this on my request

`run_document_masking(max_seq_len, num_docs)` generated document lengths/offsets from `max_seq_len` but then called `test_mask(..., S=32768)` with a hard-coded size, so any custom `max_seq_len` was silently ignored (and mismatched offsets vs `S` break the doc mask). One-line fix: pass `S=max_seq_len`.

Validated:
- `python examples/benchmark.py --examples document` (default 32768 path, unchanged behavior) runs clean
- `run_document_masking(max_seq_len=4096, num_docs=4)` (the previously-broken custom path) passes the correctness check
- ruff check/format + pre-commit clean