### PR TITLE
Add Longformer-style global + sliding window mask

### DIFF
--- a/attn_gym/masks/__init__.py
+++ b/attn_gym/masks/__init__.py
@@ -1,5 +1,6 @@
 from attn_gym.masks.causal import causal_mask
 from attn_gym.masks.sliding_window import generate_sliding_window
+from attn_gym.masks.global_sliding_window import generate_global_sliding_window
 from attn_gym.masks.prefix_lm import generate_prefix_lm_mask
 from attn_gym.masks.shared_prefix import generate_shared_prefix_mask_mod
 from attn_gym.masks.document_mask import generate_doc_mask_mod, generate_packed_causal_doc_mask_mod

--- a/attn_gym/masks/global_sliding_window.py
+++ b/attn_gym/masks/global_sliding_window.py
@@ -1,0 +1,72 @@
+"""Generates a Longformer-style global + sliding window attention mask.
+
+Based on the Longformer paper: https://arxiv.org/abs/2004.05150
+"""
+
+import torch
+from torch import Tensor
+from torch.nn.attention.flex_attention import _mask_mod_signature, or_masks
+
+
+def generate_global_sliding_window(window_size: int, is_global: Tensor) -> _mask_mod_signature:
+    """Generates a Longformer-style global + sliding window attention mask.
+
+    Args:
+        window_size: The symmetric sliding window radius; position i attends to
+            positions j with abs(i - j) <= window_size.
+        is_global: Boolean tensor of shape [SEQ_LEN] marking global tokens
+            (e.g. CLS or task tokens). Global tokens attend to all positions and
+            all positions attend to them.
+
+    Note:
+        Following the Longformer paper, attention is bidirectional: local
+        attention is a window centered on each position, and global attention is
+        symmetric. Compose with a causal mask via `and_masks` for decoder use.
+    """
+
+    def sliding_window(b, h, q_idx, kv_idx):
+        return (q_idx - kv_idx).abs() <= window_size
+
+    def global_attention(b, h, q_idx, kv_idx):
+        return is_global[q_idx] | is_global[kv_idx]
+
+    global_sliding_window_mask = or_masks(sliding_window, global_attention)
+    global_sliding_window_mask.__name__ = f"global_sliding_window_{window_size}"
+    return global_sliding_window_mask
+
+
+def main(device: str = "cpu"):
+    """Visualize the attention scores of the global + sliding window mask mod.
+
+    Args:
+        device (str): Device to use for computation.
+    """
+    from attn_gym import visualize_attention_scores
+
+    B, H, SEQ_LEN, HEAD_DIM = 1, 1, 16, 8
+
+    def make_tensor():
+        return torch.ones(B, H, SEQ_LEN, HEAD_DIM, device=device)
+
+    query, key = make_tensor(), make_tensor()
+
+    is_global = torch.zeros(SEQ_LEN, dtype=torch.bool, device=device)
+    is_global[0] = True
+    is_global[8] = True
+
+    global_sliding_window_mask = generate_global_sliding_window(3, is_global)
+    visualize_attention_scores(
+        query,
+        key,
+        mask_mod=global_sliding_window_mask,
+        device=device,
+        name="global_sliding_window_mask",
+    )
+
+
+if __name__ == "__main__":
+    try:
+        from jsonargparse import CLI
+    except ImportError:
+        raise ImportError("Be sure to run: pip install -e .'[viz]'")
+    CLI(main)

--- a/docs/masks.md
+++ b/docs/masks.md
@@ -35,6 +35,22 @@ Sliding window with dilation — attends to every `dilation`-th token within the
 
 ::: attn_gym.masks.dilated_sliding_window.generate_dilated_sliding_window
 
+## Global + Sliding Window
+
+Longformer-style attention ([paper](https://arxiv.org/abs/2004.05150)): a bidirectional sliding window plus designated global tokens (e.g. CLS) that attend to and are attended by every position.
+
+```python
+import torch
+from attn_gym.masks import generate_global_sliding_window
+
+is_global = torch.zeros(S, dtype=torch.bool, device=device)
+is_global[0] = True  # CLS token
+mask_mod = generate_global_sliding_window(window_size=512, is_global=is_global)
+block_mask = create_block_mask(mask_mod, B, H, S, S, device=device)
+```
+
+::: attn_gym.masks.global_sliding_window.generate_global_sliding_window
+
 ## Prefix LM
 
 Bidirectional attention over a prefix, causal attention over the rest.

--- a/test/test_global_sliding_window.py
+++ b/test/test_global_sliding_window.py
@@ -1,0 +1,50 @@
+import pytest
+import torch
+import torch.nn.functional as F
+
+from attn_gym.masks import generate_global_sliding_window
+
+
+def reference_mask(window_size: int, is_global: torch.Tensor) -> torch.Tensor:
+    seq_len = is_global.shape[0]
+    idx = torch.arange(seq_len, device=is_global.device)
+    window = (idx.view(-1, 1) - idx.view(1, -1)).abs() <= window_size
+    return window | is_global.view(-1, 1) | is_global.view(1, -1)
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+@pytest.mark.parametrize("window_size", [1, 3, 8])
+@pytest.mark.parametrize("global_positions", [[], [0], [0, 7, 15]])
+def test_global_sliding_window_matches_reference(device, window_size, global_positions):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    seq_len = 16
+    is_global = torch.zeros(seq_len, dtype=torch.bool, device=device)
+    is_global[global_positions] = True
+
+    mask_mod = generate_global_sliding_window(window_size, is_global)
+    q_idx = torch.arange(seq_len, device=device).view(-1, 1)
+    kv_idx = torch.arange(seq_len, device=device).view(1, -1)
+    b = h = torch.tensor(0, device=device)
+
+    assert torch.equal(mask_mod(b, h, q_idx, kv_idx), reference_mask(window_size, is_global))
+
+
+def test_global_sliding_window_flex_matches_sdpa():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    from torch.nn.attention.flex_attention import create_block_mask, flex_attention
+
+    device, seq_len, window_size = "cuda", 256, 16
+    is_global = torch.zeros(seq_len, dtype=torch.bool, device=device)
+    is_global[[0, 100]] = True
+
+    mask_mod = generate_global_sliding_window(window_size, is_global)
+    block_mask = create_block_mask(mask_mod, None, None, seq_len, seq_len, device=device)
+
+    torch.manual_seed(0)
+    q, k, v = (torch.randn(1, 4, seq_len, 64, device=device) for _ in range(3))
+    out = torch.compile(flex_attention)(q, k, v, block_mask=block_mask)
+    ref = F.scaled_dot_product_attention(q, k, v, attn_mask=reference_mask(window_size, is_global))
+    torch.testing.assert_close(out, ref, rtol=2e-3, atol=2e-3)


### PR DESCRIPTION
Fixes #3.

Adds `generate_global_sliding_window(window_size, is_global)` to `attn_gym/masks/` — Longformer-style attention ([arXiv 2004.05150](https://arxiv.org/abs/2004.05150)): a bidirectional sliding window `or_masks`'d with symmetric global attention. Global tokens are marked by a captured `is_global` bool tensor, so positions are data-dependent (CLS, question tokens, ...) rather than a hardcoded prefix; compose with a causal mask via `and_masks` for decoder use.

Included:
- `attn_gym/masks/global_sliding_window.py` — standalone-runnable with visualization, repo-style
- `test/test_global_sliding_window.py` — parametrized (device x window_size x global positions) equality vs a dense reference mask, plus a compiled `flex_attention` vs SDPA-with-dense-mask correctness check on nontrivial random inputs (19 tests, all passing locally on CUDA)
- export in `attn_gym/masks/__init__.py` and a `docs/masks.md` section

Visualization (`python attn_gym/masks/global_sliding_window.py`) shows window=3 with global tokens at positions 0 and 8.