### PR TITLE
Add Sandwich score mod

### DIFF
--- a/attn_gym/mods/__init__.py
+++ b/attn_gym/mods/__init__.py
@@ -1,3 +1,4 @@
 from attn_gym.mods.activation import generate_activation_score_mod, undo_softmax
 from attn_gym.mods.alibi import generate_alibi_bias
+from attn_gym.mods.sandwich import generate_sandwich_bias
 from attn_gym.mods.softcapping import generate_tanh_softcap

--- a/attn_gym/mods/sandwich.py
+++ b/attn_gym/mods/sandwich.py
@@ -1,0 +1,81 @@
+"""Implementation of the Sandwich score mod from the paper Dissecting Transformer Length
+Extrapolation via the Lens of Receptive Field Analysis: https://arxiv.org/abs/2212.10356"""
+
+import torch
+from torch import Tensor
+from torch.nn.attention.flex_attention import _score_mod_signature
+
+
+def generate_sandwich_bias(
+    H: int, max_seq_len: int, d_bar: int = 128, device: str | torch.device = "cpu"
+) -> _score_mod_signature:
+    """Returns a Sandwich bias score_mod.
+
+    Sandwich keeps only the position-position inner product of sinusoidal embeddings:
+    bias[h, m, n] = sum_i cos((m - n) * w_i) / ratio_h with w_i = 1/10000^(2i/d_bar)
+    and ALiBi-style per-head compression ratios ratio_h = 8(h+1)/H. The bias is
+    precomputed as a 1-D relative-distance table, padded to a multiple of 8 for
+    vector-load-friendly indexing, and the per-head ratio is applied via a small
+    lookup table (uniform loads let the FLASH backend vectorize the score_mod).
+
+    Args:
+        H: number of heads.
+        max_seq_len: maximum sequence length the bias will be used with.
+        d_bar: Sandwich shape hyperparameter (paper uses 128).
+        device: device for the precomputed bias table.
+
+    Returns:
+        sandwich_bias: sandwich bias score_mod
+    """
+    freqs = 1.0 / 10000 ** (
+        2 * torch.arange(d_bar // 2, device=device, dtype=torch.float32) / d_bar
+    )
+    padded_len = -(-(2 * max_seq_len - 1) // 8) * 8
+    distances = torch.arange(padded_len, device=device, dtype=torch.float32) - (max_seq_len - 1)
+    rel_bias = torch.cos(distances.abs()[:, None] * freqs).sum(dim=-1)
+    offset = max_seq_len - 1
+    head_scale = H / (8.0 * torch.arange(1, H + 1, device=device, dtype=torch.float32))
+
+    def sandwich_mod(score: Tensor, b: Tensor, h: Tensor, q_idx: Tensor, kv_idx: Tensor):
+        return score + rel_bias[q_idx - kv_idx + offset] * head_scale[h]
+
+    return sandwich_mod
+
+
+def main(device: str = "cpu", causal: bool = True):
+    """Visualize the attention scores of the sandwich bias score mod.
+
+    Args:
+        device (str): Device to use for computation.
+        causal (bool): Whether to combine with a causal mask.
+    """
+    from attn_gym import visualize_attention_scores
+
+    B, H, SEQ_LEN, HEAD_DIM = 1, 1, 12, 8
+
+    def make_tensor():
+        return torch.ones(B, H, SEQ_LEN, HEAD_DIM, device=device)
+
+    query, key = make_tensor(), make_tensor()
+
+    sandwich_score_mod = generate_sandwich_bias(H, SEQ_LEN, device=device)
+
+    def causal_mask(b, h, q_idx, kv_idx):
+        return q_idx >= kv_idx
+
+    visualize_attention_scores(
+        query,
+        key,
+        score_mod=sandwich_score_mod,
+        mask_mod=causal_mask if causal else None,
+        device=device,
+        name=f"sandwich_score_mod_{'causal' if causal else 'non-causal'}",
+    )
+
+
+if __name__ == "__main__":
+    try:
+        from jsonargparse import CLI
+    except ImportError:
+        raise ImportError("Be sure to run: pip install -e .'[viz]'")
+    CLI(main)

--- a/docs/mods.md
+++ b/docs/mods.md
@@ -34,6 +34,19 @@ out = flex_attention(query, key, value, score_mod=softcap)
 
 ::: attn_gym.mods.softcapping.generate_tanh_softcap
 
+## Sandwich
+
+Sandwich relative positional bias ([paper](https://arxiv.org/abs/2212.10356)) — the position-position inner product of sinusoidal embeddings with ALiBi-style per-head compression ratios, enabling length extrapolation without learned parameters.
+
+```python
+from attn_gym.mods import generate_sandwich_bias
+
+sandwich = generate_sandwich_bias(H=num_heads, max_seq_len=S, device=device)
+out = flex_attention(query, key, value, score_mod=sandwich)
+```
+
+::: attn_gym.mods.sandwich.generate_sandwich_bias
+
 ## Activation Score Mod
 
 Wraps an activation function to operate in log-space on attention scores.

--- a/test/test_sandwich.py
+++ b/test/test_sandwich.py
@@ -1,0 +1,88 @@
+import pytest
+import torch
+import torch.nn.functional as F
+from torch.autograd import grad
+from torch.nn.attention.flex_attention import create_block_mask, flex_attention
+
+from attn_gym.mods import generate_sandwich_bias
+
+
+def reference_sandwich_bias(H: int, seq_len: int, d_bar: int = 128) -> torch.Tensor:
+    """Paper's reference construction (appendix E): inner products of sinusoidal embeddings."""
+    positions = torch.arange(seq_len, dtype=torch.float64)[:, None]
+    i = torch.arange(d_bar // 2, dtype=torch.float64)
+    angles = positions / 10000 ** (2 * i / d_bar)
+    pos_embs = torch.cat([angles.sin(), angles.cos()], dim=-1)
+    sandwich = pos_embs @ pos_embs.T
+    compression_ratio = torch.arange(1, H + 1, dtype=torch.float64) * 8 / H
+    return sandwich[None] / compression_ratio[:, None, None]
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_sandwich_matches_paper_reference(device):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    H, seq_len = 8, 64
+    score_mod = generate_sandwich_bias(H, seq_len, device=device)
+    ref = reference_sandwich_bias(H, seq_len).to(device)
+
+    q_idx = torch.arange(seq_len, device=device).view(-1, 1)
+    kv_idx = torch.arange(seq_len, device=device).view(1, -1)
+    zero = torch.zeros(seq_len, seq_len, device=device)
+    b = torch.tensor(0, device=device)
+    for h in range(H):
+        bias = score_mod(zero, b, torch.tensor(h, device=device), q_idx, kv_idx)
+        torch.testing.assert_close(bias, ref[h].float(), rtol=1e-4, atol=1e-4)
+
+
+def test_sandwich_flex_matches_sdpa_with_grads():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    torch.manual_seed(0)
+    B, H, S, D = 2, 8, 256, 64
+    device = "cuda"
+    score_mod = generate_sandwich_bias(H, S, device=device)
+    block_mask = create_block_mask(lambda b, h, q, kv: q >= kv, None, None, S, S, device=device)
+
+    q, k, v = (torch.randn(B, H, S, D, device=device, requires_grad=True) for _ in range(3))
+    out = torch.compile(flex_attention)(q, k, v, score_mod=score_mod, block_mask=block_mask)
+
+    causal = torch.tril(torch.ones(S, S, device=device, dtype=torch.bool))
+    bias = reference_sandwich_bias(H, S).to(device).float()
+    ref = F.scaled_dot_product_attention(
+        q, k, v, attn_mask=bias.masked_fill(~causal, float("-inf"))
+    )
+    torch.testing.assert_close(out, ref, rtol=2e-3, atol=2e-3)
+
+    grads = grad(out.sum(), (q, k, v), retain_graph=True)
+    ref_grads = grad(ref.sum(), (q, k, v))
+    for g, rg in zip(grads, ref_grads):
+        torch.testing.assert_close(g, rg, rtol=2e-3, atol=2e-3)
+
+
+def test_sandwich_flex_flash_backend():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    pytest.importorskip("flash_attn.cute", reason="flex FLASH backend needs flash-attn CuTeDSL")
+
+    torch.manual_seed(0)
+    B, H, S, D = 2, 8, 512, 64
+    device, dtype = "cuda", torch.bfloat16
+    score_mod = generate_sandwich_bias(H, S, device=device)
+    block_mask = create_block_mask(
+        lambda b, h, q, kv: q >= kv, None, None, S, S, device=device, BLOCK_SIZE=(256, 128)
+    )
+
+    q, k, v = (torch.randn(B, H, S, D, device=device, dtype=dtype) for _ in range(3))
+    out = torch.compile(flex_attention)(
+        q, k, v, score_mod=score_mod, block_mask=block_mask, kernel_options={"BACKEND": "FLASH"}
+    )
+
+    causal = torch.tril(torch.ones(S, S, device=device, dtype=torch.bool))
+    bias = reference_sandwich_bias(H, S).to(device).float()
+    ref = F.scaled_dot_product_attention(
+        q.float(), k.float(), v.float(), attn_mask=bias.masked_fill(~causal, float("-inf"))
+    )
+    torch.testing.assert_close(out.float(), ref, rtol=2e-2, atol=2e-2)


### PR DESCRIPTION
Fixes #1.
<img width="1026" height="914" alt="image" src="https://github.com/user-attachments/assets/29873361-3985-4103-ad62-42e422c2cd71" />




Adds `generate_sandwich_bias(H, max_seq_len, d_bar=128, device=...)` to `attn_gym/mods/` — the Sandwich relative positional bias ([arXiv 2212.10356](https://arxiv.org/abs/2212.10356)): the position-position inner product of sinusoidal embeddings with ALiBi-style per-head compression ratios (paper appendix E construction).

## Implementation choice, benchmarked

Unlike ALiBi, Sandwich **cannot** be computed on the fly: the bias is a sum of `d_bar/2` cosines with no closed form, and reductions can't lower inside a score_mod (`SubgraphLoweringException`). So some precomputation is mandatory. Measured options (B200, B=2 H=16 S=4096 D=64 bf16 causal, compiled flex, fwd via profiler timing / bwd isolated via CUDA-event-timed `autograd.grad`):

| impl | table mem | fwd µs | bwd µs |
|---|---|---|---|
| no score_mod (baseline) | — | 320 | 661 |
| **1-D rel-distance table (this PR)** | O(S) | **562** | 2872 |
| 2-D `[S,S]` table | O(S²) | 937 | 1068 |
| 3-D `[H,S,S]` table | O(H·S²) | 1403 | 1046 |

The 1-D table is the memory-sane default (16 KiB at S=4k vs 64 MiB / 1 GiB).

Shipped implementation on both backends (same contract; FLASH = FA4/CuTeDSL backend via `kernel_options={"BACKEND": "FLASH"}` with a `BLOCK_SIZE=(256, 128)` mask):

| backend | score_mod | fwd µs | bwd µs |
|---|---|---|---|
| TRITON | none | 320 | 663 |
| TRITON | sandwich | 534 | 2843 |
| FLASH | none | 127 | 343 |
| FLASH | sandwich | **1396** | **825** |

With the per-head ratio applied via a small lookup table (`* head_scale[h]` instead of inline division), the lane-uniform load lets the FLASH backend vectorize the score_mod group (`__vec_size__ = 8`), making FLASH the fastest full-step backend for this mod (2221 µs vs 3377 TRITON). The remaining FLASH fwd gap vs baseline is the rel-pos gather falling back to scalar per-lane loads (alignment not provable for `q_idx - kv_idx` indexing); the table is padded to a multiple of 8 so it benefits automatically from future upstream vectorization work.

**Note**: the FLASH numbers and the FLASH-backend test require pytorch/pytorch#188876 (in flight, landing before this), which fixes index-dtype and lane-classification bugs in the CuTeDSL score_mod codegen that this exact pattern exercises — found while writing this PR (pytorch/pytorch#188871, pytorch/pytorch#188878).

Three codegen-informed details in the implementation:
- **shifted affine index** instead of `.abs()`/`.clamp()` — non-affine index forms are ~5x slower in the generated Triton (2962 vs 562 µs), and the shift also makes non-causal use safe
- **per-head ratio as a lookup table** — uniform loads enable vectorized score_mod groups on FLASH (1.7x fwd / 1.4x bwd vs inline division)
- **table padded to a multiple of 8** so vectorized captured-buffer loads aren't ruled out by an odd table length

## Tests

- `test_sandwich_matches_paper_reference` — bias values vs the paper's appendix-E reference construction (fp64), CPU + CUDA
- `test_sandwich_flex_matches_sdpa_with_grads` — compiled flex vs SDPA with the materialized bias, outputs **and** q/k/v gradients, random inputs
- `test_sandwich_flex_flash_backend` — FLASH (FA4/CuTeDSL) backend vs fp32 reference (skips without flash-attn CuTeDSL); note this test currently requires pytorch/pytorch#188871's fix for dynamic-shape index codegen, which is in flight

All 4 pass locally on B200 (torch nightly + the #188871 fix); full repo suite 133 passed. Standalone visualization: `python attn_gym/mods/sandwich.py`.



