### PR TITLE
Test deterministic Inductor mode in determinism example

### DIFF
--- a/examples/flex_determinism.py
+++ b/examples/flex_determinism.py
@@ -196,7 +196,7 @@ def main():
         {"dynamic": False, "backend": "inductor", "mode": "default"},
 
         # Using Inductor's deterministic mode also enforces consistent reduction loops
-        # {"dynamic": False, "backend": "inductor", "mode": "default", "inductor_config": {"deterministic": True}},
+        {"dynamic": False, "backend": "inductor", "mode": "default", "inductor_config": {"deterministic": True}},
 
         # Noisy neighbor problem also can be found here
         # Not running since takes some time


### PR DESCRIPTION
## Summary
- enable the `torch._inductor.config.deterministic = True` case in `flex_determinism.py`
- make the reproduction script exercise the setting recommended by the determinism guide
- follow up on the review feedback in #219

## Validation
- `.venv/bin/prek run --all-files`
- `.venv/bin/python -m py_compile examples/flex_determinism.py`
- exercised the deterministic case on an H100 with PyTorch 2.12.0 (`7661cd9c6b84`)

The GPU run confirmed that this coverage is useful: the standard shape was bitwise deterministic, while the decode shapes exposed non-deterministic `grad_q`/`grad_k` on that newer build.