### PR TITLE
Support padded VSA tiles in Flex FLASH

### DIFF
--- a/attn_gym/masks/vsa.py
+++ b/attn_gym/masks/vsa.py
@@ -551,8 +551,9 @@ def create_vsa_flash_block_mask(
     tile_numel: int,
     num_kv_tiles: int,
     kv_block_size: int = 128,
+    variable_block_sizes: Tensor | None = None,
 ) -> BlockMask:
-    """Build the all-full-block VSA mask representation required by Flex FLASH.
+    """Build the VSA block representation required by Flex FLASH.
 
     Args:
         topk_indices: Selected KV tile ids with shape ``(B, H, Q_TILES, TOP_K)``.
@@ -563,10 +564,13 @@ def create_vsa_flash_block_mask(
             each selected VSA tile is expanded into ``tile_numel // kv_block_size``
             consecutive KV blocks. The Q block size stays ``tile_numel`` because FA4
             only requires it to be a multiple of its effective Q tile.
+        variable_block_sizes: Optional real-token counts for each padded KV tile.
+            Fully valid FA4 KV subblocks are emitted as ``full_kv_*`` blocks, while
+            partially valid subblocks are emitted as normal ``kv_*`` blocks so the
+            padding ``mask_mod`` is applied inside Flex FLASH.
 
     Returns:
-        A full-block ``BlockMask`` plus a tile-level mask_mod. Current Flex FLASH
-        needs both to represent sparse full blocks correctly.
+        A ``BlockMask`` suitable for ``kernel_options={"BACKEND": "FLASH"}``.
 
     Raises:
         ValueError: If rank or static shape arguments are invalid.
@@ -590,11 +594,35 @@ def create_vsa_flash_block_mask(
     if top_k > num_kv_tiles:
         raise ValueError(f"TOP_K must be <= num_kv_tiles, got {top_k} and {num_kv_tiles}")
 
+    if variable_block_sizes is None:
+        variable_block_sizes = torch.full(
+            (num_kv_tiles,), tile_numel, device=selected_indices.device, dtype=torch.int32
+        )
+    else:
+        variable_block_sizes = variable_block_sizes.to(
+            device=selected_indices.device, dtype=torch.int32
+        )
+        if variable_block_sizes.shape != (num_kv_tiles,):
+            raise ValueError(
+                f"variable_block_sizes must have shape ({num_kv_tiles},), got "
+                f"{tuple(variable_block_sizes.shape)}"
+            )
+
     kv_factor = tile_numel // kv_block_size
-    expanded_indices = (
-        selected_indices[..., None] * kv_factor
-        + torch.arange(kv_factor, device=selected_indices.device, dtype=torch.int32)
-    ).flatten(-2)
+    selected_sizes = variable_block_sizes[selected_indices.long()]
+    subblock_offsets = torch.arange(kv_factor, device=selected_indices.device, dtype=torch.int32)
+    subblock_starts = subblock_offsets * kv_block_size
+    subblock_ends = subblock_starts + kv_block_size
+    expanded_indices = (selected_indices[..., None] * kv_factor + subblock_offsets).flatten(-2)
+    valid_subblocks = (selected_sizes[..., None] > subblock_starts).flatten(-2)
+    full_subblocks = (selected_sizes[..., None] >= subblock_ends).flatten(-2)
+    partial_subblocks = valid_subblocks & ~full_subblocks
+
+    full_order = torch.argsort((~full_subblocks).to(torch.int32), dim=-1, stable=True)
+    partial_order = torch.argsort((~partial_subblocks).to(torch.int32), dim=-1, stable=True)
+    packed_full = torch.gather(expanded_indices, -1, full_order)
+    packed_partial = torch.gather(expanded_indices, -1, partial_order)
+
     kv_indices = torch.zeros(
         *selected_indices.shape[:-1],
         num_kv_tiles * kv_factor,
@@ -602,27 +630,17 @@ def create_vsa_flash_block_mask(
         device=selected_indices.device,
     )
     full_kv_indices = torch.zeros_like(kv_indices)
-    full_kv_indices[..., : top_k * kv_factor] = expanded_indices
-    full_kv_num_blocks = torch.full(
-        selected_indices.shape[:-1],
-        top_k * kv_factor,
-        dtype=torch.int32,
-        device=selected_indices.device,
-    )
-    block_map = torch.zeros(
-        *selected_indices.shape[:-1],
-        num_kv_tiles,
-        dtype=torch.bool,
-        device=selected_indices.device,
-    )
-    block_map.scatter_(-1, selected_indices.long(), True)
+    kv_indices[..., : top_k * kv_factor] = packed_partial
+    full_kv_indices[..., : top_k * kv_factor] = packed_full
+    kv_num_blocks = partial_subblocks.sum(dim=-1).to(torch.int32)
+    full_kv_num_blocks = full_subblocks.sum(dim=-1).to(torch.int32)
     return BlockMask.from_kv_blocks(
-        kv_num_blocks=torch.zeros_like(full_kv_num_blocks),
+        kv_num_blocks=kv_num_blocks,
         kv_indices=kv_indices,
         full_kv_num_blocks=full_kv_num_blocks,
         full_kv_indices=full_kv_indices,
         BLOCK_SIZE=(tile_numel, kv_block_size),
-        mask_mod=generate_vsa_block_map_mask_mod(block_map, tile_numel),
+        mask_mod=generate_vsa_padding_mask_mod(variable_block_sizes, tile_numel),
         seq_lengths=(selected_indices.shape[-2] * tile_numel, num_kv_tiles * tile_numel),
     )
 

--- a/examples/fastwan_vsa.py
+++ b/examples/fastwan_vsa.py
@@ -187,7 +187,10 @@ class SparseVSAAttention:
             q, k, v, tile_numel=self.tile_numel, top_k=self.top_k
         )
         block_mask = create_vsa_flash_block_mask(
-            coarse.topk_indices, tile_numel=self.tile_numel, num_kv_tiles=self.num_tiles
+            coarse.topk_indices,
+            tile_numel=self.tile_numel,
+            num_kv_tiles=self.num_tiles,
+            variable_block_sizes=self.variable_block_sizes,
         )
         fine = flex_attention(q, k, v, block_mask=block_mask, kernel_options={"BACKEND": "FLASH"})
         return vsa_additive_combine(fine, coarse.output, gate, tile_numel=self.tile_numel)

--- a/examples/vsa.py
+++ b/examples/vsa.py
@@ -107,6 +107,7 @@ def main(
             coarse.topk_indices,
             tile_numel=metadata.tile_numel,
             num_kv_tiles=num_kv_tiles,
+            variable_block_sizes=metadata.variable_block_sizes,
         )
     else:
         block_mask = create_vsa_block_mask(

--- a/test/test_vsa.py
+++ b/test/test_vsa.py
@@ -339,6 +339,51 @@ def test_vsa_flex_flash_backend_sm100_matches_reference():
     torch.testing.assert_close(actual, expected, atol=5e-2, rtol=5e-2)
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_vsa_flex_flash_backend_sm100_masks_partial_kv_subblocks():
+    if torch.cuda.get_device_capability()[0] < 10:
+        pytest.skip("Flex FLASH block-sparse path requires SM100+")
+    flex_flash = pytest.importorskip("torch._inductor.kernel.flex.flex_flash_attention")
+    if not flex_flash.ensure_flash_available():
+        pytest.skip("Flex FLASH backend is not available")
+
+    torch.manual_seed(0)
+    batch, heads, q_tiles, kv_tiles, tile_numel, head_dim = 1, 2, 2, 2, 256, 128
+    q = torch.randn(
+        batch, heads, q_tiles * tile_numel, head_dim, device="cuda", dtype=torch.bfloat16
+    )
+    k = torch.randn(
+        batch, heads, kv_tiles * tile_numel, head_dim, device="cuda", dtype=torch.bfloat16
+    )
+    v = torch.randn(
+        batch, heads, kv_tiles * tile_numel, head_dim, device="cuda", dtype=torch.bfloat16
+    )
+    variable_block_sizes = torch.tensor([tile_numel, 64], device="cuda", dtype=torch.long)
+    topk_indices = torch.tensor(
+        [[[[0, 1], [0, 1]], [[0, 1], [0, 1]]]], device="cuda", dtype=torch.int32
+    )
+    block_mask = create_vsa_flash_block_mask(
+        topk_indices,
+        tile_numel=tile_numel,
+        num_kv_tiles=kv_tiles,
+        variable_block_sizes=variable_block_sizes,
+    )
+    attention = torch.compile(
+        partial(flex_attention, kernel_options={"BACKEND": "FLASH"}), dynamic=False
+    )
+
+    actual = attention(q, k, v, block_mask=block_mask)
+    mask = dense_vsa_token_mask(
+        topk_indices,
+        tile_numel=tile_numel,
+        num_kv_tiles=kv_tiles,
+        variable_block_sizes=variable_block_sizes,
+    )
+    expected = masked_reference_attention(q, k, v, mask)
+
+    torch.testing.assert_close(actual, expected, atol=5e-2, rtol=5e-2)
+
+
 def test_vsa_additive_combine_matches_manual_lift():
     torch.manual_seed(0)
     fine_output = torch.randn(1, 2, 12, 4)


### PR DESCRIPTION
## Summary

Support padded VSA KV tiles in the Flex FLASH block-mask path by splitting each selected VSA tile into FA4-sized KV subblocks:

- fully valid KV subblocks are emitted through `full_kv_*` metadata
- partially valid KV subblocks are emitted through normal `kv_*` metadata so the padding `mask_mod` is applied
- padding-only subblocks are omitted

This lets `create_vsa_flash_block_mask` handle `variable_block_sizes` instead of only all-full selected tiles. The VSA examples now pass tile metadata through to the FLASH mask builder.

## Tests

- `~/.venvs/nightly/bin/python -m pytest test/test_vsa.py -q`
- `~/.venvs/nightly/bin/python examples/vsa.py --device cuda --backend FLASH --use_compile true`
