### PR TITLE
Fix FlexAttention test isolation

### DIFF
--- a/test/test_mods.py
+++ b/test/test_mods.py
@@ -7,6 +7,7 @@ from attn_gym.mods import generate_tanh_softcap
 
 
 def test_tanh_approx():
+    torch.compiler.reset()
     softcap_mod = generate_tanh_softcap(30, approx=False)
     softcap_mod_approx = generate_tanh_softcap(30, approx=True)
     make_tensor = partial(

--- a/test/test_natten.py
+++ b/test/test_natten.py
@@ -76,6 +76,7 @@ def test_natten_masks(
     T_W=8,
     print_mask=True,
 ):
+    torch.compiler.reset()
     query = torch.randn(B, H, W, W, D, device="cuda", dtype=torch.float16, requires_grad=True)
     key = torch.randn(B, H, W, W, D, device="cuda", dtype=torch.float16, requires_grad=True)
     value = torch.randn(B, H, W, W, D, device="cuda", dtype=torch.float16, requires_grad=True)

--- a/test/test_sandwich.py
+++ b/test/test_sandwich.py
@@ -56,7 +56,7 @@ def test_sandwich_flex_matches_sdpa_with_grads():
     )
     torch.testing.assert_close(out, ref, rtol=2e-3, atol=2e-3)
 
-    grads = grad(out.sum(), (q, k, v), retain_graph=True)
+    grads = grad(out.sum(), (q, k, v))
     ref_grads = grad(ref.sum(), (q, k, v))
     for g, rg in zip(grads, ref_grads):
         torch.testing.assert_close(g, rg, rtol=2e-3, atol=2e-3)


### PR DESCRIPTION
## Summary

- reset `torch.compile` state before compilation-heavy tanh and NATTEN tests
- prevent recompilation-limit fallback to unfused FlexAttention, which caused unsupported `vmap` and a 256 GiB dense allocation
- remove unnecessary `retain_graph=True` from the compiled Sandwich backward so donated buffers remain enabled

## Validation

- `pytest -q --tb=short`: 179 passed
- `ruff check test/test_mods.py test/test_natten.py test/test_sandwich.py`
- `git diff --check`
