### PR TITLE
Clean up repository metadata and tooling

### DIFF
--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -12,4 +12,4 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Run prek
-      uses: j178/prek-action@v1
+      uses: j178/prek-action@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for available hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -11,7 +11,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.5.6
+    rev: v0.15.22
     hooks:
       # Run the linter.
       - id: ruff

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This repository aims to provide a playground for experimenting with various atte
 ## 🎯 Features
 
 - Implementations of various attention mechanisms using FlexAttention
+- Reference implementations for linear-attention recurrences
 - Utility functions for creating and combining attention masks
 - Examples of how to use FlexAttention in real-world scenarios
 
@@ -70,6 +71,7 @@ Attention Gym is organized for easy exploration of attention mechanisms:
 
 - `attn_gym.masks`: Examples creating `BlockMasks`
 - `attn_gym.mods`: Examples creating `score_mods`
+- `attn_gym.linear`: Reference linear-attention implementations
 - `examples/`: Detailed implementations using FlexAttention
 - `examples/paged_attention`: Paged KV-cache examples using FlexAttention
 
@@ -80,9 +82,11 @@ Install dev requirements
 pip install -e ".[dev]"
 ```
 
-Install pre-commit hooks
+Install and run the repository hooks:
+
 ```bash
-pre-commit install
+prek install
+prek run --all-files
 ```
 
 ## 🤝 Contributing
@@ -93,7 +97,7 @@ We welcome contributions to Attention Gym, especially new Masks or score mods! H
 1. Create a new file in the [attn_gym/masks/](attn_gym/masks) for mask_mods or [attn_gym/mods/](attn_gym/mods) for score_mods.
 2. Implement your function, and add a simple main function that showcases your new function.
 3. Update the `attn_gym/*/__init__.py` file to include your new function.
-5. [Optinally] Add an end to end example using your new func in the [examples/](examples/) directory.
+4. Optionally, add an end-to-end example using your new function in the [examples/](examples/) directory.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for more details.
 

--- a/attn_gym/masks/__init__.py
+++ b/attn_gym/masks/__init__.py
@@ -1,13 +1,16 @@
+from attn_gym.masks.batchify import batchify_mask_mod
 from attn_gym.masks.causal import causal_mask
 from attn_gym.masks.sliding_window import generate_sliding_window
 from attn_gym.masks.global_sliding_window import generate_global_sliding_window
 from attn_gym.masks.prefix_lm import generate_prefix_lm_mask
 from attn_gym.masks.shared_prefix import generate_shared_prefix_mask_mod
 from attn_gym.masks.document_mask import generate_doc_mask_mod, generate_packed_causal_doc_mask_mod
+from attn_gym.masks.flamingo import generate_vision_cross_attention_mask_mod
 from attn_gym.masks.dilated_sliding_window import generate_dilated_sliding_window
 from attn_gym.masks.block_diffusion import generate_block_diffusion_mask
 from attn_gym.masks.natten import generate_natten, generate_tiled_natten, generate_morton_natten
 from attn_gym.masks.sta import generate_sta_mask_mod_2d, generate_sta_mask_mod_3d
+from attn_gym.masks.svg import generate_spatial_head_mask_mod, generate_temporal_head_mask_mod
 from attn_gym.masks.jetspec import (
     build_tree_ancestor_matrix,
     generate_jetspec_training_mask_mod,

--- a/attn_gym/masks/batchify.py
+++ b/attn_gym/masks/batchify.py
@@ -3,7 +3,8 @@
 import torch
 from torch import Tensor
 from torch.nn.attention.flex_attention import _mask_mod_signature, noop_mask
-from attn_gym.masks import causal_mask
+
+from attn_gym.masks.causal import causal_mask
 
 
 def batchify_mask_mod(mask_mod: _mask_mod_signature, batchify_size: int) -> _mask_mod_signature:

--- a/attn_gym/masks/sta.py
+++ b/attn_gym/masks/sta.py
@@ -24,18 +24,18 @@ def generate_sta_mask_mod_2d(
     kernel_h, kernel_w = kernel_hw
     tile_h, tile_w = tile_hw
     tile_numel = tile_h * tile_w
-    assert (
-        canvas_h % tile_h == 0
-    ), f"Canvas height {canvas_h} is not divisible by tile height {tile_h}"
-    assert (
-        canvas_w % tile_w == 0
-    ), f"Canvas width {canvas_w} is not divisible by tile width {tile_w}"
-    assert (
-        kernel_h % tile_h == 0
-    ), f"Kernel height {kernel_h} is not divisible by tile height {tile_h}"
-    assert (
-        kernel_w % tile_w == 0
-    ), f"Kernel width {kernel_w} is not divisible by tile width {tile_w}"
+    assert canvas_h % tile_h == 0, (
+        f"Canvas height {canvas_h} is not divisible by tile height {tile_h}"
+    )
+    assert canvas_w % tile_w == 0, (
+        f"Canvas width {canvas_w} is not divisible by tile width {tile_w}"
+    )
+    assert kernel_h % tile_h == 0, (
+        f"Kernel height {kernel_h} is not divisible by tile height {tile_h}"
+    )
+    assert kernel_w % tile_w == 0, (
+        f"Kernel width {kernel_w} is not divisible by tile width {tile_w}"
+    )
     canvas_tile_h, canvas_tile_w = canvas_h // tile_h, canvas_w // tile_w
     kernel_tile_h, kernel_tile_w = kernel_h // tile_h, kernel_w // tile_w
     vision_seq_len = canvas_h * canvas_w
@@ -103,19 +103,19 @@ def generate_sta_mask_mod_3d(
     tile_t, tile_h, tile_w = tile_twh
     tile_numel = tile_t * tile_h * tile_w
     assert canvas_t % tile_t == 0, f"Canvas time {canvas_t} is not divisible by tile time {tile_t}"
-    assert (
-        canvas_h % tile_h == 0
-    ), f"Canvas height {canvas_h} is not divisible by tile height {tile_h}"
-    assert (
-        canvas_w % tile_w == 0
-    ), f"Canvas width {canvas_w} is not divisible by tile width {tile_w}"
+    assert canvas_h % tile_h == 0, (
+        f"Canvas height {canvas_h} is not divisible by tile height {tile_h}"
+    )
+    assert canvas_w % tile_w == 0, (
+        f"Canvas width {canvas_w} is not divisible by tile width {tile_w}"
+    )
     assert kernel_t % tile_t == 0, f"Kernel time {kernel_t} is not divisible by tile time {tile_t}"
-    assert (
-        kernel_h % tile_h == 0
-    ), f"Kernel height {kernel_h} is not divisible by tile height {tile_h}"
-    assert (
-        kernel_w % tile_w == 0
-    ), f"Kernel width {kernel_w} is not divisible by tile width {tile_w}"
+    assert kernel_h % tile_h == 0, (
+        f"Kernel height {kernel_h} is not divisible by tile height {tile_h}"
+    )
+    assert kernel_w % tile_w == 0, (
+        f"Kernel width {kernel_w} is not divisible by tile width {tile_w}"
+    )
     canvas_tile_t, canvas_tile_h, canvas_tile_w = (
         canvas_t // tile_t,
         canvas_h // tile_h,

--- a/attn_gym/mods/__init__.py
+++ b/attn_gym/mods/__init__.py
@@ -6,5 +6,6 @@ from attn_gym.mods.graphormer import (
     shortest_path_distances,
     shortest_path_edge_types,
 )
+from attn_gym.mods.latent_attention import generate_mla_rope_score_mod
 from attn_gym.mods.sandwich import generate_sandwich_bias
 from attn_gym.mods.softcapping import generate_tanh_softcap

--- a/attn_gym/utils.py
+++ b/attn_gym/utils.py
@@ -137,9 +137,9 @@ def visualize_attention_scores(
     """
     import matplotlib.pyplot as plt
 
-    assert (
-        score_mod is not None or mask_mod is not None
-    ), "Must provide either score_mod or mask_mod"
+    assert score_mod is not None or mask_mod is not None, (
+        "Must provide either score_mod or mask_mod"
+    )
     query = query[batch_idx, head_idx, :, :]
     key = key[batch_idx, head_idx, :, :]
     scores_viz = create_score_mod(
@@ -240,9 +240,9 @@ def plot_attention_scores(
     """
     import matplotlib.pyplot as plt
 
-    assert (
-        score_mod is not None or mask_mod is not None
-    ), "Must provide either score_mod or mask_mod"
+    assert score_mod is not None or mask_mod is not None, (
+        "Must provide either score_mod or mask_mod"
+    )
     query = query[batch_idx, head_idx, :, :]
     key = key[batch_idx, head_idx, :, :]
     scores_viz = create_score_mod(

--- a/benchmarks/bench_block_mask.py
+++ b/benchmarks/bench_block_mask.py
@@ -208,8 +208,8 @@ def print_results(experiments: List[Experiment]):
                 experiment.config.N,
                 experiment.config.mask_mod_name,
                 f"{experiment.result.creation_time_ms:.4f}",
-                f"{experiment.result.memory_bytes/(1024**3):.4f}",
-                f"{experiment.result.max_memory_usage/(1024**3):.4f}",
+                f"{experiment.result.memory_bytes / (1024**3):.4f}",
+                f"{experiment.result.max_memory_usage / (1024**3):.4f}",
             ]
         )
     # Sort rows for better readability (e.g., by B, H, M, N)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Python 3.9+
+- Python 3.10+
 - PyTorch 2.5+ (for FlexAttention support)
 
 ## Installation

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ It provides ready-to-use **mask functions** and **score mods** that you can comp
 - **[Concepts](concepts.md)** — how `mask_mod`, `score_mod`, and `BlockMask` work together
 - **[Masks](masks.md)** — `mask_mod` functions for causal, sliding window, document-level, neighborhood attention, and more
 - **[Score Mods](mods.md)** — `score_mod` functions like ALiBi, soft-capping, and latent attention
+- **[Linear Attention](linear.md)** — gated-delta-rule reference implementations
 - **[Examples](examples.md)** — benchmarks, MLA, paged attention, determinism testing, and advanced patterns
 - **[Utilities](utilities.md)** — visualization, benchmarking, and profiling helpers
 

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -1,0 +1,28 @@
+# Linear Attention
+
+Attention Gym includes reference implementations for experimenting with linear-attention recurrences.
+
+## Gated Delta Rule
+
+`naive_recurrent_gated_delta_rule` is a direct token-by-token reference. `naive_chunk_gated_delta_rule` computes the same recurrence in chunks and supports sequence lengths that are not divisible by the chunk size. Both functions optionally accept an initial state and return the final state.
+
+```python
+from attn_gym.linear import naive_chunk_gated_delta_rule
+
+output, final_state = naive_chunk_gated_delta_rule(
+    q,
+    k,
+    v,
+    g,
+    beta,
+    chunk_size=64,
+    output_final_state=True,
+)
+```
+
+::: attn_gym.linear.naive_recurrent_gated_delta_rule
+
+::: attn_gym.linear.naive_chunk_gated_delta_rule
+
+!!! warning "Reference implementation"
+    `fused_recurrent_gated_delta_rule` is currently an explicit stub. It raises `NotImplementedError` until the optimized decode kernel is implemented.

--- a/examples/flex_flash_attention.py
+++ b/examples/flex_flash_attention.py
@@ -232,7 +232,7 @@ def run_benchmark(
 
     print(f"Config: B={B}, H={H}, S={S}, D={D}, dtype={dtype}")
     if use_mask:
-        print(f"Mask: causal, sparsity={sparsity*100:.1f}%")
+        print(f"Mask: causal, sparsity={sparsity * 100:.1f}%")
 
     def make_qkv():
         q = torch.randn(B, H, S, D, device=device, dtype=dtype, requires_grad=True)

--- a/examples/flex_grid_sweep.py
+++ b/examples/flex_grid_sweep.py
@@ -324,13 +324,13 @@ def sweep_forward_configs(
         if success and time_us < best_time:
             best_time = time_us
             best_config = config
-            tqdm.write(f"  New best! {config} -> {time_us/1000:.3f} ms")
+            tqdm.write(f"  New best! {config} -> {time_us / 1000:.3f} ms")
 
     # Sort results by time
     results.sort(key=lambda x: x["time_us"] if x["success"] else float("inf"))
 
     print(f"\n✓ Best forward config: {best_config}")
-    print(f"✓ Best time: {best_time/1000:.3f} ms")
+    print(f"✓ Best time: {best_time / 1000:.3f} ms")
 
     return best_config, best_time, results
 
@@ -390,13 +390,13 @@ def sweep_backward_configs(
         if success and time_us < best_time:
             best_time = time_us
             best_config = config
-            tqdm.write(f"  New best! {config} -> {time_us/1000:.3f} ms")
+            tqdm.write(f"  New best! {config} -> {time_us / 1000:.3f} ms")
 
     # Sort results by time
     results.sort(key=lambda x: x["time_us"] if x["success"] else float("inf"))
 
     print(f"\n✓ Best backward config: {best_config}")
-    print(f"✓ Best time: {best_time/1000:.3f} ms")
+    print(f"✓ Best time: {best_time / 1000:.3f} ms")
 
     return best_config, best_time, results
 
@@ -498,9 +498,9 @@ def main(
     print("=" * 80)
     print("\nBest FlexKernelOptions:")
     print(json.dumps(best_kernel_options, indent=2))
-    print(f"\nForward time: {best_fwd_time/1000:.3f} ms")
-    print(f"Backward time: {best_bwd_time/1000:.3f} ms")
-    print(f"Total time: {(best_fwd_time + best_bwd_time)/1000:.3f} ms")
+    print(f"\nForward time: {best_fwd_time / 1000:.3f} ms")
+    print(f"Backward time: {best_bwd_time / 1000:.3f} ms")
+    print(f"Total time: {(best_fwd_time + best_bwd_time) / 1000:.3f} ms")
 
     # Save results
     output = {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
   - Determinism: determinism.md
   - Masks: masks.md
   - Score Mods: mods.md
+  - Linear Attention: linear.md
   - Examples: examples.md
   - Utilities: utilities.md
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,12 @@ authors = [{ name = "Driss Guessous", email = "drisspguessous@gmail.com" }]
 description = "Helpful tools and examples for working with flex-attention"
 readme = "README.md"
 dynamic = ["version"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
 ]
@@ -24,8 +27,6 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "prek",
-    "bumpver",
-    "pip-tools",
     "pytest",
     "ruff",
     "jsonargparse",

--- a/test/test_block_diffusion.py
+++ b/test/test_block_diffusion.py
@@ -49,9 +49,9 @@ def test_block_diffusion_structure():
         torch.block_diag(*[torch.ones(block_size, block_size, dtype=torch.bool)] * 2),
     )
     assert noised[block_size, seq_len : seq_len + block_size].all()
-    assert not noised[
-        block_size - 1, seq_len:
-    ].any(), "first-block noised tokens have no clean context"
+    assert not noised[block_size - 1, seq_len:].any(), (
+        "first-block noised tokens have no clean context"
+    )
     assert clean[block_size, seq_len : seq_len + block_size + 1].all()
     assert not clean[block_size - 1, seq_len + block_size :].any()
 

--- a/test/test_causal_block_mask.py
+++ b/test/test_causal_block_mask.py
@@ -97,15 +97,15 @@ class TestCausalBlockMask:
         )
 
         # Check that gradients match
-        assert torch.allclose(
-            grads_fast[0], grads_standard[0], atol=1e-5, rtol=1e-4
-        ), "Query gradients don't match"
-        assert torch.allclose(
-            grads_fast[1], grads_standard[1], atol=1e-5, rtol=1e-4
-        ), "Key gradients don't match"
-        assert torch.allclose(
-            grads_fast[2], grads_standard[2], atol=1e-5, rtol=1e-4
-        ), "Value gradients don't match"
+        assert torch.allclose(grads_fast[0], grads_standard[0], atol=1e-5, rtol=1e-4), (
+            "Query gradients don't match"
+        )
+        assert torch.allclose(grads_fast[1], grads_standard[1], atol=1e-5, rtol=1e-4), (
+            "Key gradients don't match"
+        )
+        assert torch.allclose(grads_fast[2], grads_standard[2], atol=1e-5, rtol=1e-4), (
+            "Value gradients don't match"
+        )
 
     def test_causal_block_mask_edge_cases(self):
         """Test edge cases for the efficient causal block mask."""

--- a/test/test_linear.py
+++ b/test/test_linear.py
@@ -1,0 +1,64 @@
+import pytest
+import torch
+import torch.nn.functional as F
+
+from attn_gym.linear import (
+    fused_recurrent_gated_delta_rule,
+    naive_chunk_gated_delta_rule,
+    naive_recurrent_gated_delta_rule,
+)
+
+
+def make_inputs(seq_len: int) -> tuple[torch.Tensor, ...]:
+    """Create stable gated-delta-rule inputs with normalized keys."""
+    torch.manual_seed(0)
+    batch, heads, key_dim, value_dim = 2, 3, 4, 5
+    q = torch.randn(batch, seq_len, heads, key_dim)
+    k = F.normalize(torch.randn_like(q), dim=-1)
+    v = torch.randn(batch, seq_len, heads, value_dim)
+    g = F.logsigmoid(torch.randn(batch, seq_len, heads))
+    beta = torch.sigmoid(torch.randn(batch, seq_len, heads))
+    initial_state = torch.randn(batch, heads, key_dim, value_dim)
+    return q, k, v, g, beta, initial_state
+
+
+@pytest.mark.parametrize("seq_len,chunk_size", [(1, 4), (7, 4), (8, 4), (17, 8)])
+@pytest.mark.parametrize("use_initial_state", [False, True])
+def test_naive_chunk_matches_recurrent(seq_len, chunk_size, use_initial_state):
+    inputs = make_inputs(seq_len)
+    initial_state = inputs[-1] if use_initial_state else None
+    recurrent_output, recurrent_state = naive_recurrent_gated_delta_rule(
+        *inputs[:-1], initial_state=initial_state, output_final_state=True
+    )
+    chunk_output, chunk_state = naive_chunk_gated_delta_rule(
+        *inputs[:-1],
+        initial_state=initial_state,
+        output_final_state=True,
+        chunk_size=chunk_size,
+    )
+
+    torch.testing.assert_close(chunk_output, recurrent_output, atol=1e-6, rtol=1e-5)
+    torch.testing.assert_close(chunk_state, recurrent_state, atol=1e-6, rtol=1e-5)
+
+
+def test_naive_chunk_gradients_match_recurrent():
+    inputs = make_inputs(seq_len=7)[:-1]
+    gradients = []
+    for function in (naive_recurrent_gated_delta_rule, naive_chunk_gated_delta_rule):
+        differentiable_inputs = [value.clone().requires_grad_() for value in inputs]
+        kwargs = {"chunk_size": 4} if function is naive_chunk_gated_delta_rule else {}
+        output, state = function(*differentiable_inputs, output_final_state=True, **kwargs)
+        gradients.append(
+            torch.autograd.grad(
+                output.square().mean() + state.square().mean(), differentiable_inputs
+            )
+        )
+
+    for chunk_gradient, recurrent_gradient in zip(gradients[1], gradients[0]):
+        torch.testing.assert_close(chunk_gradient, recurrent_gradient, atol=1e-6, rtol=1e-5)
+
+
+def test_fused_recurrent_stub_is_explicit():
+    inputs = make_inputs(seq_len=1)
+    with pytest.raises(NotImplementedError, match="Triton kernel not implemented"):
+        fused_recurrent_gated_delta_rule(*inputs[:-1])

--- a/test/test_namespaces.py
+++ b/test/test_namespaces.py
@@ -1,6 +1,13 @@
 import attn_gym
 import attn_gym.linear
 import attn_gym.sparse
+from attn_gym.masks import (
+    batchify_mask_mod,
+    generate_spatial_head_mask_mod,
+    generate_temporal_head_mask_mod,
+    generate_vision_cross_attention_mask_mod,
+)
+from attn_gym.mods import generate_mla_rope_score_mod
 
 
 def test_attention_namespaces_are_exported():
@@ -9,3 +16,16 @@ def test_attention_namespaces_are_exported():
     assert "linear" in attn_gym.__all__
     assert "sparse" in attn_gym.__all__
     assert "paged_attention" not in attn_gym.__all__
+
+
+def test_documented_mask_and_score_mods_are_exported():
+    assert all(
+        callable(function)
+        for function in (
+            batchify_mask_mod,
+            generate_spatial_head_mask_mod,
+            generate_temporal_head_mask_mod,
+            generate_vision_cross_attention_mask_mod,
+            generate_mla_rope_score_mod,
+        )
+    )


### PR DESCRIPTION
## Summary

- align Python package metadata with the syntax used by the codebase while leaving the `torch` dependency unpinned
- remove unused `bumpver` and `pip-tools` development dependencies; publishing continues to use Git tags, `hatch-vcs`, and `pypa/build`
- expose documented mask and score-mod helpers from their public namespaces
- add documentation and reference coverage for the existing gated-delta-rule linear attention implementations
- update prek, Ruff, and standard hook pins, including the resulting Ruff formatting changes
- refresh the contributor instructions to use `prek`

## Validation

- `PYTHONPATH=$PWD /home/dev/.venvs/dev/bin/pytest -q --tb=short` (190 passed)
- `prek run --all-files`
- `uv run --with mkdocs-material --with "mkdocstrings[python]" --with numpy mkdocs build --strict`
- `uv build`
