### PR TITLE
Use CUDA 13.2 nightly and FlashAttention 4 in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test_cuda130_h100:
-    name: test-cuda13.0-py${{ matrix.python-version }}-h100
+  test_cuda132_h100:
+    name: test-cuda13.2-py${{ matrix.python-version }}-h100
     strategy:
       fail-fast: true
       matrix:
@@ -21,9 +21,9 @@ jobs:
         include:
           - name: H100
             runs-on: mt-l-x86iamx-22-225-h100
-            torch-spec: '--pre torch --index-url https://download.pytorch.org/whl/nightly/cu130'
+            torch-spec: '--pre torch --index-url https://download.pytorch.org/whl/nightly/cu132'
             gpu-arch-type: "cuda"
-            gpu-arch-version: "13.0"
+            gpu-arch-version: "13.2"
     permissions:
       id-token: write
       contents: read
@@ -41,11 +41,6 @@ jobs:
         uv venv --python ${{ matrix.python-version }}
         export VIRTUAL_ENV="$PWD/.venv"
         export PATH="$VIRTUAL_ENV/bin:$PATH"
-        pure_python_deps=(
-          filelock typing-extensions "setuptools<82" sympy networkx jinja2 fsspec numpy
-          pillow spmd-types
-        )
-        uv pip install "${pure_python_deps[@]}"
         PIP_EXTRA_INDEX_URL= UV_EXTRA_INDEX_URL= uv pip install ${{ matrix.torch-spec }}
-        uv pip install '.[dev]'
+        uv pip install '.[tests]'
         uv run --no-sync pytest test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,5 +42,5 @@ jobs:
         export VIRTUAL_ENV="$PWD/.venv"
         export PATH="$VIRTUAL_ENV/bin:$PATH"
         PIP_EXTRA_INDEX_URL= UV_EXTRA_INDEX_URL= uv pip install ${{ matrix.torch-spec }}
-        uv pip install '.[tests]'
+        uv pip install --prerelease allow '.[tests]'
         uv run --no-sync pytest test

--- a/modal_tests.py
+++ b/modal_tests.py
@@ -9,7 +9,9 @@ PYTORCH_NIGHTLY_INDEX = "https://download.pytorch.org/whl/nightly/cu132"
 image = (
     modal.Image.debian_slim(python_version="3.12")
     .pip_install("torch", pre=True, index_url=PYTORCH_NIGHTLY_INDEX, force_build=True)
-    .pip_install_from_pyproject(str(ROOT_PATH / "pyproject.toml"), optional_dependencies=["tests"])
+    .pip_install_from_pyproject(
+        str(ROOT_PATH / "pyproject.toml"), optional_dependencies=["tests"], pre=True
+    )
     .add_local_python_source("attn_gym")
     .add_local_dir(ROOT_PATH / "test", remote_path="/root/test")
 )

--- a/modal_tests.py
+++ b/modal_tests.py
@@ -4,24 +4,12 @@ from pathlib import Path
 import modal
 
 ROOT_PATH = Path(__file__).parent
-PYTORCH_NIGHTLY_INDEX = "https://download.pytorch.org/whl/nightly/cu130"
+PYTORCH_NIGHTLY_INDEX = "https://download.pytorch.org/whl/nightly/cu132"
 
 image = (
     modal.Image.debian_slim(python_version="3.12")
-    .pip_install(
-        "filelock",
-        "typing-extensions",
-        "setuptools<82",
-        "sympy",
-        "networkx",
-        "jinja2",
-        "fsspec",
-        "numpy",
-        "pillow",
-        "spmd-types",
-    )
     .pip_install("torch", pre=True, index_url=PYTORCH_NIGHTLY_INDEX, force_build=True)
-    .pip_install("pytest", "jsonargparse", "docstring-parser")
+    .pip_install_from_pyproject(str(ROOT_PATH / "pyproject.toml"), optional_dependencies=["tests"])
     .add_local_python_source("attn_gym")
     .add_local_dir(ROOT_PATH / "test", remote_path="/root/test")
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ tests = [
     "jsonargparse",
     "docstring-parser",
     "numpy",
+    "flash-attn-4[cu13]~=4.0.0b23; sys_platform == 'linux' and platform_machine == 'x86_64'",
 ]
 
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,13 +25,20 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+tests = [
+    "pytest",
+    "jsonargparse",
+    "docstring-parser",
+    "numpy",
+]
+
 dev = [
     "prek",
     "pytest",
     "ruff",
     "jsonargparse",
     "docstring-parser",
-    "numpy"
+    "numpy",
 ]
 
 viz = [


### PR DESCRIPTION
## Summary

- update the H100 and Modal test environments to the CUDA 13.2 PyTorch nightly
- install test dependencies through the `tests` project extra
- add the CUDA 13 FlashAttention 4 prerelease dependency with a compatible `4.0.x` range
- allow prerelease dependency resolution in both CI environments

## Testing

- `prek run --files pyproject.toml modal_tests.py .github/workflows/test.yml`
- built the wheel and verified its `tests` extra metadata
- resolved the Linux Python 3.12 test environment with prereleases enabled
- ran on an NVIDIA B200 with PyTorch `2.14.0.dev20260723+cu132` and FlashAttention `4.0.0b23`
- compiled and numerically validated an FA4 causal-attention kernel against PyTorch SDPA
- full B200 suite: 189 passed, 1 known pre-existing NATTEN failure (`test/test_natten.py::test_natten_masks`)
