### PR TITLE
Run Modal tests on main

### DIFF
--- a/.github/workflows/modal-tests.yml
+++ b/.github/workflows/modal-tests.yml
@@ -1,6 +1,9 @@
 name: modal-tests
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:
@@ -8,7 +11,6 @@ permissions:
 
 jobs:
   pytest:
-    if: github.actor == 'drisspg' && github.triggering_actor == 'drisspg'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
   push:
     branches:
-      - main
       - release/*
 
 concurrency:


### PR DESCRIPTION
## Summary
- run the Modal B200 test workflow after every push to `main`
- keep manual Modal workflow dispatches available
- stop launching the unavailable H100 runner workflow on pushes to `main`
- retain the H100 workflow for pull requests and release branches

## Validation
- `prek run check-yaml --files .github/workflows/modal-tests.yml .github/workflows/test.yml`
- `git diff --check`
