### PR TITLE
Update Ruff to 0.16.1 and apply new lint rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.15.22
+    rev: v0.16.1
     hooks:
       # Run the linter.
       - id: ruff

--- a/attn_gym/__init__.py
+++ b/attn_gym/__init__.py
@@ -1,23 +1,23 @@
-from attn_gym.utils import (
-    visualize_attention_scores,
-    get_flash_block_size,
-    calculate_tflops,
-    benchmark_cuda_function_in_microseconds,
-    cuda_kernel_profiler,
-)
 import attn_gym.linear
 import attn_gym.masks
 import attn_gym.mods
 import attn_gym.sparse
+from attn_gym.utils import (
+    benchmark_cuda_function_in_microseconds,
+    calculate_tflops,
+    cuda_kernel_profiler,
+    get_flash_block_size,
+    visualize_attention_scores,
+)
 
 __all__ = [
-    "visualize_attention_scores",
-    "get_flash_block_size",
-    "calculate_tflops",
     "benchmark_cuda_function_in_microseconds",
+    "calculate_tflops",
     "cuda_kernel_profiler",
+    "get_flash_block_size",
     "linear",
     "masks",
     "mods",
     "sparse",
+    "visualize_attention_scores",
 ]

--- a/attn_gym/linear/gdn/api.py
+++ b/attn_gym/linear/gdn/api.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Literal, NamedTuple
 
 import torch
+
 from attn_gym.linear.gdn.impl.reference import forward
 
 Mode = Literal["auto", "chunked", "recurrent"]

--- a/attn_gym/linear/gdn/impl/reference.py
+++ b/attn_gym/linear/gdn/impl/reference.py
@@ -121,9 +121,9 @@ def chunked_forward(
     value = value * beta[..., None]
     beta_key = key * beta[..., None]
 
-    query, key, value, beta_key = map(
-        lambda tensor: tensor.reshape(batch, heads, chunk_count, chunk_size, tensor.shape[-1]),
-        (query, key, value, beta_key),
+    query, key, value, beta_key = (
+        tensor.reshape(batch, heads, chunk_count, chunk_size, tensor.shape[-1])
+        for tensor in (query, key, value, beta_key)
     )
     cumulative_decay = log_decay.reshape(batch, heads, chunk_count, chunk_size).cumsum(-1)
 

--- a/attn_gym/masks/__init__.py
+++ b/attn_gym/masks/__init__.py
@@ -1,21 +1,21 @@
 from attn_gym.masks.batchify import batchify_mask_mod
+from attn_gym.masks.block_diffusion import generate_block_diffusion_mask
 from attn_gym.masks.causal import causal_mask
-from attn_gym.masks.sliding_window import generate_sliding_window
-from attn_gym.masks.global_sliding_window import generate_global_sliding_window
-from attn_gym.masks.prefix_lm import generate_prefix_lm_mask
-from attn_gym.masks.shared_prefix import generate_shared_prefix_mask_mod
+from attn_gym.masks.dilated_sliding_window import generate_dilated_sliding_window
 from attn_gym.masks.document_mask import generate_doc_mask_mod, generate_packed_causal_doc_mask_mod
 from attn_gym.masks.flamingo import generate_vision_cross_attention_mask_mod
-from attn_gym.masks.dilated_sliding_window import generate_dilated_sliding_window
-from attn_gym.masks.block_diffusion import generate_block_diffusion_mask
-from attn_gym.masks.natten import generate_natten, generate_tiled_natten, generate_morton_natten
-from attn_gym.masks.sta import generate_sta_mask_mod_2d, generate_sta_mask_mod_3d
-from attn_gym.masks.svg import generate_spatial_head_mask_mod, generate_temporal_head_mask_mod
+from attn_gym.masks.global_sliding_window import generate_global_sliding_window
 from attn_gym.masks.jetspec import (
     build_tree_ancestor_matrix,
     generate_jetspec_training_mask_mod,
     generate_jetspec_tree_causal_mask_mod,
 )
+from attn_gym.masks.natten import generate_morton_natten, generate_natten, generate_tiled_natten
+from attn_gym.masks.prefix_lm import generate_prefix_lm_mask
+from attn_gym.masks.shared_prefix import generate_shared_prefix_mask_mod
+from attn_gym.masks.sliding_window import generate_sliding_window
+from attn_gym.masks.sta import generate_sta_mask_mod_2d, generate_sta_mask_mod_3d
+from attn_gym.masks.svg import generate_spatial_head_mask_mod, generate_temporal_head_mask_mod
 from attn_gym.masks.vsa import (
     VSACoarseResult,
     VSATileMetadata,
@@ -30,8 +30,8 @@ from attn_gym.masks.vsa import (
     pool_to_vsa_tiles,
     tile_vsa_sequence,
     untile_vsa_sequence,
+    validate_vsa_block_mask_inputs,
     vsa_additive_combine,
     vsa_gated_mix,
-    validate_vsa_block_mask_inputs,
     vsa_topk_from_sparsity,
 )

--- a/attn_gym/masks/batchify.py
+++ b/attn_gym/masks/batchify.py
@@ -38,8 +38,9 @@ def main(device: str = "cpu", causal: bool = False):
     Args:
         device (str): Device to use for computation. Defaults to "cpu".
     """
-    from attn_gym import visualize_attention_scores
     import random
+
+    from attn_gym import visualize_attention_scores
 
     random.seed(0)
 

--- a/attn_gym/masks/causal.py
+++ b/attn_gym/masks/causal.py
@@ -2,6 +2,7 @@
 
 import torch
 from torch.nn.attention.flex_attention import BlockMask
+
 from attn_gym.utils import cdiv
 
 
@@ -129,6 +130,7 @@ def main(device: str = "cpu"):
         device (str): Device to use for computation. Defaults
     """
     import torch
+
     from attn_gym import visualize_attention_scores
 
     B, H, SEQ_LEN, HEAD_DIM = 1, 1, 12, 8

--- a/attn_gym/masks/document_mask.py
+++ b/attn_gym/masks/document_mask.py
@@ -1,11 +1,11 @@
 """Generates a document causal attention mask based on a document ID tensor"""
 
 import random
-from typing import List, Union
 
 import torch
 from torch import Tensor
 from torch.nn.attention.flex_attention import _mask_mod_signature, noop_mask
+
 from attn_gym.masks import causal_mask
 
 
@@ -17,7 +17,7 @@ def _offsets_to_doc_ids_tensor(offsets):
     )
 
 
-def length_to_offsets(lengths: List[int], device: Union[str, torch.device]) -> Tensor:
+def length_to_offsets(lengths: list[int], device: str | torch.device) -> Tensor:
     """Converts a list of lengths to a list of offsets.
 
     Args:

--- a/attn_gym/masks/natten.py
+++ b/attn_gym/masks/natten.py
@@ -1,9 +1,8 @@
 """Generates a NATTEN mask"""
 
 import torch
-from torch import IntTensor, BoolTensor
+from torch import BoolTensor, IntTensor
 from torch.nn.attention.flex_attention import _mask_mod_signature
-from typing import Tuple
 
 
 def generate_natten(
@@ -20,7 +19,7 @@ def generate_natten(
         kernel_h: The height of the kernel.
     """
 
-    def get_x_y(idx: IntTensor) -> Tuple[IntTensor, IntTensor]:
+    def get_x_y(idx: IntTensor) -> tuple[IntTensor, IntTensor]:
         return idx // canvas_w, idx % canvas_w
 
     def natten_mask_mod(
@@ -61,7 +60,7 @@ def generate_tiled_natten(
         T_H: The height of the tile.
     """
 
-    def get_x_y_tiled(idx: IntTensor) -> Tuple[IntTensor, IntTensor]:
+    def get_x_y_tiled(idx: IntTensor) -> tuple[IntTensor, IntTensor]:
         """
         Map 1-D index to 2-D coordinates for static tiles of T_H x T_W.
         """

--- a/attn_gym/masks/prefix_lm.py
+++ b/attn_gym/masks/prefix_lm.py
@@ -2,6 +2,7 @@
 
 import torch
 from torch.nn.attention.flex_attention import _mask_mod_signature, or_masks
+
 from attn_gym.masks import causal_mask
 
 

--- a/attn_gym/masks/sliding_window.py
+++ b/attn_gym/masks/sliding_window.py
@@ -2,6 +2,7 @@
 
 import torch
 from torch.nn.attention.flex_attention import _mask_mod_signature, and_masks
+
 from attn_gym.masks import causal_mask
 
 

--- a/attn_gym/masks/sta.py
+++ b/attn_gym/masks/sta.py
@@ -1,15 +1,14 @@
 """Generates a STA mask"""
 
 import torch
-from torch import IntTensor, BoolTensor
+from torch import BoolTensor, IntTensor
 from torch.nn.attention.flex_attention import _mask_mod_signature
-from typing import Tuple
 
 
 def generate_sta_mask_mod_2d(
-    canvas_hw: Tuple[int, int],
-    kernel_hw: Tuple[int, int],
-    tile_hw: Tuple[int, int],
+    canvas_hw: tuple[int, int],
+    kernel_hw: tuple[int, int],
+    tile_hw: tuple[int, int],
     text_seq_len: int = 0,
 ) -> _mask_mod_signature:
     """Generates a 2D STA mask with a given kernel size.
@@ -40,13 +39,13 @@ def generate_sta_mask_mod_2d(
     kernel_tile_h, kernel_tile_w = kernel_h // tile_h, kernel_w // tile_w
     vision_seq_len = canvas_h * canvas_w
 
-    def get_h_w_idx_tiled(idx: IntTensor) -> Tuple[IntTensor, IntTensor]:
+    def get_h_w_idx_tiled(idx: IntTensor) -> tuple[IntTensor, IntTensor]:
         tile_id = idx // tile_numel
         tile_h_idx = tile_id // canvas_tile_w
         tile_w_idx = tile_id % canvas_tile_w
         return tile_h_idx, tile_w_idx
 
-    def get_border(kernel_size: IntTensor) -> Tuple[IntTensor, IntTensor]:
+    def get_border(kernel_size: IntTensor) -> tuple[IntTensor, IntTensor]:
         left_border = kernel_size // 2
         right_border = kernel_size // 2 + (kernel_size % 2 - 1)
         return left_border, right_border
@@ -85,9 +84,9 @@ def generate_sta_mask_mod_2d(
 
 
 def generate_sta_mask_mod_3d(
-    canvas_twh: Tuple[int, int, int],
-    kernel_twh: Tuple[int, int, int],
-    tile_twh: Tuple[int, int, int],
+    canvas_twh: tuple[int, int, int],
+    kernel_twh: tuple[int, int, int],
+    tile_twh: tuple[int, int, int],
     text_seq_len: int = 0,
 ) -> _mask_mod_signature:
     """Generates a 3D STA mask with a given kernel size.
@@ -128,14 +127,14 @@ def generate_sta_mask_mod_3d(
     )
     vision_seq_len = canvas_t * canvas_h * canvas_w
 
-    def get_t_h_w_idx_tiled(idx: IntTensor) -> Tuple[IntTensor, IntTensor, IntTensor]:
+    def get_t_h_w_idx_tiled(idx: IntTensor) -> tuple[IntTensor, IntTensor, IntTensor]:
         tile_id = idx // tile_numel
         tile_t_idx = tile_id // (canvas_tile_h * canvas_tile_w)
         tile_h_idx = (tile_id % (canvas_tile_h * canvas_tile_w)) // canvas_tile_w
         tile_w_idx = tile_id % canvas_tile_w
         return tile_t_idx, tile_h_idx, tile_w_idx
 
-    def get_border(kernel_size: IntTensor) -> Tuple[IntTensor, IntTensor]:
+    def get_border(kernel_size: IntTensor) -> tuple[IntTensor, IntTensor]:
         left_border = kernel_size // 2
         right_border = kernel_size // 2 + (kernel_size % 2 - 1)
         return left_border, right_border

--- a/attn_gym/masks/svg.py
+++ b/attn_gym/masks/svg.py
@@ -91,8 +91,9 @@ def main(device: str = "cpu", causal: bool = True):
     Args:
         device (str): Device to use for computation. Defaults to "cpu".
     """
-    from attn_gym import visualize_attention_scores
     import random
+
+    from attn_gym import visualize_attention_scores
 
     random.seed(0)
 

--- a/attn_gym/masks/vsa.py
+++ b/attn_gym/masks/vsa.py
@@ -6,8 +6,8 @@ remain ordinary PyTorch work around the FlexAttention call rather than fused int
 single kernel.
 """
 
-from dataclasses import dataclass
 import math
+from dataclasses import dataclass
 
 import torch
 from torch import Tensor

--- a/attn_gym/mods/__init__.py
+++ b/attn_gym/mods/__init__.py
@@ -1,8 +1,8 @@
 from attn_gym.mods.activation import generate_activation_score_mod, undo_softmax
 from attn_gym.mods.alibi import generate_alibi_bias
 from attn_gym.mods.graphormer import (
-    generate_graphormer_spatial_bias,
     generate_graphormer_edge_bias,
+    generate_graphormer_spatial_bias,
     shortest_path_distances,
     shortest_path_edge_types,
 )

--- a/attn_gym/mods/activation.py
+++ b/attn_gym/mods/activation.py
@@ -14,12 +14,12 @@ return_aux=AuxRequest(lse=True) to retrieve log(ell), we can recover:
     f(S) @ V = O' * ell - N * sum_j(V_j)
 """
 
-import torch
-from torch import Tensor
-from torch.nn.attention.flex_attention import AuxRequest, _score_mod_signature
 from collections.abc import Callable
 
+import torch
 import torch.nn.functional as F
+from torch import Tensor
+from torch.nn.attention.flex_attention import AuxRequest, _score_mod_signature
 
 
 def generate_activation_score_mod(
@@ -68,6 +68,7 @@ def undo_softmax(
 def main(device: str = "cuda", compile: bool = False):
     """Demonstrate non-softmax attention via FlexAttention with correctness check."""
     import math
+
     from torch.nn.attention.flex_attention import flex_attention
 
     flex_fn = torch.compile(flex_attention) if compile else flex_attention

--- a/attn_gym/mods/alibi.py
+++ b/attn_gym/mods/alibi.py
@@ -29,6 +29,7 @@ def main(device: str = "cpu", causal: bool = True):
         device (str): Device to use for computation. Defaults
     """
     import torch
+
     from attn_gym import visualize_attention_scores
 
     B, H, SEQ_LEN, HEAD_DIM = 1, 1, 12, 8

--- a/attn_gym/mods/softcapping.py
+++ b/attn_gym/mods/softcapping.py
@@ -1,13 +1,14 @@
 """Implementation of tanh softcapping score mod popularized in Gemma2 and Grok-1"""
 
+from functools import partial
+
 import torch
 from torch import Tensor
-from torch.nn.attention.flex_attention import _score_mod_signature
 from torch._inductor.lowering import make_pointwise, register_lowering
 
 # Some internal torch.compile details
 from torch._inductor.virtualized import ops
-from functools import partial
+from torch.nn.attention.flex_attention import _score_mod_signature
 
 
 @torch.library.custom_op("approx::tanh", mutates_args=())
@@ -35,7 +36,7 @@ class _TanhApprox(torch.autograd.Function):
 
     @staticmethod
     def setup_context(ctx, inputs, output):
-        (x,) = inputs
+        (_x,) = inputs
         result = output
         ctx.save_for_backward(result)
 
@@ -80,6 +81,7 @@ def main(device: str = "cpu"):
         device (str): Device to use for computation. Defaults
     """
     import torch
+
     from attn_gym import visualize_attention_scores
 
     B, H, SEQ_LEN, HEAD_DIM = 1, 1, 12, 8

--- a/attn_gym/utils.py
+++ b/attn_gym/utils.py
@@ -1,25 +1,26 @@
-import torch
-from typing import Optional
-from pathlib import Path
-from contextlib import contextmanager, nullcontext
-import numpy as np
 import math
+from contextlib import contextmanager, nullcontext
+from pathlib import Path
+
+import numpy as np
+import torch
 from torch.nn.attention.flex_attention import (
-    _score_mod_signature,
-    _mask_mod_signature,
-    _vmap_for_bhqkv,
-    _ModificationType,
     _DEFAULT_SPARSE_BLOCK_SIZE,
+    _mask_mod_signature,
+    _ModificationType,
+    _score_mod_signature,
+    _vmap_for_bhqkv,
 )
-from torch.profiler import profile, ProfilerActivity
+from torch.profiler import ProfilerActivity, profile
 
 # TODO This was moved on nightly, this enables 2.5 and 2.6 | we should remove this once 2.5 is no longer supported
 try:
     from torch._dynamo._trace_wrapped_higher_order_op import TransformGetItemToIndex
 except ImportError:
     from torch._higher_order_ops.flex_attention import TransformGetItemToIndex
-from torch._inductor.utils import do_bench_using_profiling
 from collections.abc import Callable
+
+from torch._inductor.utils import do_bench_using_profiling
 
 Tensor = torch.Tensor
 
@@ -59,11 +60,11 @@ def merge_attention(
 def create_score_mod(
     query: torch.Tensor,
     key: torch.Tensor,
-    score_mod: Optional[_score_mod_signature],
-    mask_mod: Optional[_mask_mod_signature],
+    score_mod: _score_mod_signature | None,
+    mask_mod: _mask_mod_signature | None,
     device: str = "cuda",
     _compile: bool = False,
-    scale: Optional[float] = None,
+    scale: float | None = None,
     batch_idx: int = 0,
     head_idx: int = 0,
 ) -> torch.Tensor:
@@ -108,14 +109,14 @@ def _name_to_title(name: str) -> str:
 def visualize_attention_scores(
     query: Tensor,
     key: Tensor,
-    score_mod: Optional[_score_mod_signature] = None,
-    mask_mod: Optional[_mask_mod_signature] = None,
+    score_mod: _score_mod_signature | None = None,
+    mask_mod: _mask_mod_signature | None = None,
     device: str = "cuda",
     name: str = "attention_scores",
-    path: Optional[Path] = None,
+    path: Path | None = None,
     batch_idx: int = 0,
     head_idx: int = 0,
-    scale: Optional[float] = None,
+    scale: float | None = None,
 ) -> None:
     """
     Generate and save a visualization of attention scores.
@@ -211,13 +212,13 @@ def visualize_attention_scores(
 def plot_attention_scores(
     query: Tensor,
     key: Tensor,
-    score_mod: Optional[_score_mod_signature] = None,
-    mask_mod: Optional[_mask_mod_signature] = None,
+    score_mod: _score_mod_signature | None = None,
+    mask_mod: _mask_mod_signature | None = None,
     device: str = "cuda",
     name: str = "attention_scores",
     batch_idx: int = 0,
     head_idx: int = 0,
-    scale: Optional[float] = None,
+    scale: float | None = None,
     figsize: tuple = (12, 10),
 ):
     """

--- a/benchmarks/bench_block_mask.py
+++ b/benchmarks/bench_block_mask.py
@@ -1,23 +1,22 @@
-import itertools
-from dataclasses import dataclass
-from typing import List
 import importlib
+import itertools
 import sys
+from dataclasses import dataclass
 
 import torch
 from tabulate import tabulate
+from torch.nn.attention.flex_attention import _mask_mod_signature, create_block_mask, noop_mask
 from tqdm import tqdm
+
 from attn_gym.masks import (
     causal_mask,
-    generate_sliding_window,
-    generate_prefix_lm_mask,
-    generate_doc_mask_mod,
     generate_dilated_sliding_window,
+    generate_doc_mask_mod,
+    generate_prefix_lm_mask,
+    generate_sliding_window,
 )
 from attn_gym.masks.causal import create_causal_block_mask_fast
 from attn_gym.masks.document_mask import generate_random_lengths, length_to_offsets
-
-from torch.nn.attention.flex_attention import create_block_mask, _mask_mod_signature, noop_mask
 
 has_nuggies = importlib.util.find_spec("transformer_nuggets")
 if not has_nuggies:
@@ -28,10 +27,10 @@ if not has_nuggies:
     # Exit if the dependency is missing
     sys.exit(1)
 
-from transformer_nuggets.utils import (  # noqa: E402
-    max_memory_usage,
-    cuda_memory_usage,
+from transformer_nuggets.utils import (
     benchmark_cuda_function_in_microseconds_triton,
+    cuda_memory_usage,
+    max_memory_usage,
 )
 
 device = torch.device("cuda")
@@ -92,11 +91,11 @@ def get_mask_mod(c: ExperimentConfig) -> _mask_mod_signature:
 
 
 def get_configs(
-    mask_types: List[str] | None,
-    batch_sizes: List[int],
-    num_heads: List[int],
-    seq_lens: List[int],
-) -> List[ExperimentConfig]:
+    mask_types: list[str] | None,
+    batch_sizes: list[int],
+    num_heads: list[int],
+    seq_lens: list[int],
+) -> list[ExperimentConfig]:
     # Map string names to mask functions
     all_available_masks = list(FUNCTION_BASED_CREATORS.keys()) + list(CUSTOM_CREATORS.keys())
 
@@ -187,7 +186,7 @@ def run_experiment(config: ExperimentConfig) -> ExperimentResult:
     )
 
 
-def print_results(experiments: List[Experiment]):
+def print_results(experiments: list[Experiment]):
     headers = [
         "B",
         "H",
@@ -218,10 +217,10 @@ def print_results(experiments: List[Experiment]):
 
 
 def main(
-    mask_types: List[str] | None = None,
-    batch_sizes: List[int] | None = None,
-    num_heads: List[int] | None = None,
-    seq_lens: List[int] | None = None,
+    mask_types: list[str] | None = None,
+    batch_sizes: list[int] | None = None,
+    num_heads: list[int] | None = None,
+    seq_lens: list[int] | None = None,
 ):
     """
     Run block mask benchmarks.
@@ -252,7 +251,7 @@ def main(
         try:
             result = run_experiment(config)
             results.append(Experiment(config=config, result=result))
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             print(f"Failed to run config {config}: {e}")
 
     print_results(results)

--- a/benchmarks/flex_perf.py
+++ b/benchmarks/flex_perf.py
@@ -2,21 +2,21 @@ import csv
 import gc
 import itertools
 import random
+import warnings
 from collections import defaultdict
+from collections.abc import Callable
 from contextlib import nullcontext
 from dataclasses import asdict, dataclass
 from functools import partial, wraps
-from typing import Callable, Optional, Union, Literal
-
-from jsonargparse import CLI
+from typing import Literal
 
 import numpy as np
-from tabulate import tabulate
-from tqdm import tqdm
-
 import torch
 import torch.nn.functional as F
-from torch.nn.attention import sdpa_kernel, SDPBackend, activate_flash_attention_impl
+from jsonargparse import CLI
+from tabulate import tabulate
+from torch._inductor.runtime.benchmarking import benchmarker
+from torch.nn.attention import SDPBackend, activate_flash_attention_impl, sdpa_kernel
 from torch.nn.attention.flex_attention import (
     BlockMask,
     create_block_mask,
@@ -24,9 +24,7 @@ from torch.nn.attention.flex_attention import (
     flex_attention,
     noop_mask,
 )
-from torch._inductor.runtime.benchmarking import benchmarker
-
-import warnings
+from tqdm import tqdm
 
 warnings.filterwarnings("ignore", message=".*dynamo_pgo force disabled.*")
 warnings.filterwarnings("ignore", message=".*Please use the new API settings to control TF32.*")
@@ -52,7 +50,7 @@ def safe_backend(backend_name=None):
             except torch.OutOfMemoryError:
                 print(f"[SKIP] OOM for {backend_name or func.__name__} with shape {config.shape}")
                 cleanup_memory()
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 print(
                     f"[SKIP] Error for {backend_name or func.__name__} with shape {config.shape}: {e}"
                 )
@@ -128,12 +126,12 @@ class Times:
 @dataclass(frozen=True)
 class ExperimentResults:
     fwd_time: float
-    bwd_time: Optional[float]
-    sparsity: Optional[float] = None
-    fwd_tflops: Optional[float] = None
-    fwd_bandwidth: Optional[float] = None
-    bwd_tflops: Optional[float] = None
-    bwd_bandwidth: Optional[float] = None
+    bwd_time: float | None
+    sparsity: float | None = None
+    fwd_tflops: float | None = None
+    fwd_bandwidth: float | None = None
+    bwd_tflops: float | None = None
+    bwd_bandwidth: float | None = None
 
 
 @dataclass(frozen=True)
@@ -192,11 +190,9 @@ def generate_jagged_inputs(
     value: torch.Tensor,
     offsets: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    B, Hq, M, Hkv, N, D = shape
+    _B, _Hq, _M, _Hkv, _N, _D = shape
 
-    def offsets_to_lengths(
-        offsets: torch.Tensor, device: Union[str, torch.device]
-    ) -> torch.Tensor:
+    def offsets_to_lengths(offsets: torch.Tensor, device: str | torch.device) -> torch.Tensor:
         """Converts a list of offsets to a list of lengths. Reverse op of attn_gym.masks.document_mask.length_to_offsets
 
         Args:
@@ -234,7 +230,7 @@ def query_key_value_clones(
     query: torch.Tensor,
     key: torch.Tensor,
     value: torch.Tensor,
-    dtype: Optional[torch.dtype] = None,
+    dtype: torch.dtype | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Clones the query, key, and value tensors and moves them to the specified dtype."""
     if dtype is None:
@@ -252,8 +248,8 @@ def run_single_backend_sdpa(
     key: torch.Tensor,
     value: torch.Tensor,
     out_compile: torch.Tensor,
-    score_mod: Optional[Callable],
-    block_mask: Optional[BlockMask],
+    score_mod: Callable | None,
+    block_mask: BlockMask | None,
     mask_kwargs: dict,
     backend: Backend,
 ) -> ExperimentResults:
@@ -285,7 +281,7 @@ def run_single_backend_sdpa(
         if config.calculate_bwd_time:
             out_eager = eager_sdpa(q_eager, k_eager, v_eager)
             # TODO: debug backward pass for njt
-            if not config.attn_type == "document_mask":
+            if config.attn_type != "document_mask":
                 d_out = torch.randn_like(out_eager.transpose(1, 2)).transpose(1, 2)
                 backward_eager_time = benchmark_torch_function_in_microseconds(
                     out_eager.backward, d_out, retain_graph=True
@@ -307,8 +303,8 @@ def run_single_backend_FA(
     key: torch.Tensor,
     value: torch.Tensor,
     out_compile: torch.Tensor,
-    score_mod: Optional[Callable],
-    block_mask: Optional[BlockMask],
+    score_mod: Callable | None,
+    block_mask: BlockMask | None,
     mask_kwargs: dict,
     backend: Backend,
 ) -> ExperimentResults:
@@ -359,9 +355,9 @@ def run_flex_attention(
     query: torch.Tensor,
     key: torch.Tensor,
     value: torch.Tensor,
-    score_mod: Optional[Callable],
-    block_mask: Optional[BlockMask],
-    kernel_options: Optional[dict] = None,
+    score_mod: Callable | None,
+    block_mask: BlockMask | None,
+    kernel_options: dict | None = None,
     dynamic: bool = False,
     max_autotune: bool = False,
 ) -> ExperimentResults:
@@ -400,7 +396,7 @@ def run_flex_attention(
             backward_compile_time = benchmark_torch_function_in_microseconds(
                 out_compile.backward, d_out, retain_graph=True
             )
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             print(f"[SKIP] Backward pass failed for flex_attention with shape {config.shape}: {e}")
             cleanup_memory()
             backward_compile_time = float("nan")
@@ -420,7 +416,7 @@ def run_single_experiment(
     config: ExperimentConfig,
     dynamic=False,
     max_autotune=False,
-    kernel_options_override: Optional[dict] = None,
+    kernel_options_override: dict | None = None,
     block_q: int | None = None,
     block_kv: int | None = None,
 ) -> dict[str, ExperimentResults]:
@@ -462,7 +458,7 @@ def run_single_experiment(
             "global",
         }
         if isinstance(kernel_options_override, dict) and any(
-            k in attn_keys for k in kernel_options_override.keys()
+            k in attn_keys for k in kernel_options_override
         ):
             selected_override = kernel_options_override.get(
                 config.attn_type, kernel_options_override.get("global")
@@ -539,7 +535,7 @@ def run_single_experiment(
             backward_compile_time = benchmark_torch_function_in_microseconds(
                 out_compile.backward, d_out, retain_graph=True
             )
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             print(
                 f"[SKIP] Backward pass failed for {config.attn_type} with shape {config.shape}: {e}"
             )
@@ -641,7 +637,7 @@ def calculate_bandwidth(
 def calculate_tflops(
     config: ExperimentConfig, results: ExperimentResults, type: SpeedupType
 ) -> float:
-    (B, Hq, M, Hkv, N, D) = config.shape
+    (B, Hq, M, _Hkv, N, D) = config.shape
     sparsity = results.sparsity if results.sparsity is not None else 0.0
 
     # Forward pass FLOPs
@@ -726,7 +722,7 @@ def get_average_speedups(
 
 
 def print_results(
-    results: list[Experiment], save_path: Optional[str] = None, show_speedups: bool = False
+    results: list[Experiment], save_path: str | None = None, show_speedups: bool = False
 ):
     table_data = defaultdict(list)
 
@@ -818,8 +814,8 @@ dropout_p = 0.0
 
 def generate_score_mod(
     attn_type: AttentionType, shape: tuple[int, int, int, int, int, int]
-) -> Optional[Callable]:
-    B, Hq, M, Hkv, N, D = shape
+) -> Callable | None:
+    _B, Hq, M, _Hkv, N, _D = shape
     is_decoding = M == 1
     from attn_gym.mods import generate_alibi_bias, generate_tanh_softcap
 
@@ -866,7 +862,7 @@ def generate_block_mask(
     block_q: int | None = None,
     block_kv: int | None = None,
 ) -> tuple[BlockMask, dict]:
-    B, Hq, M, Hkv, N, D = shape
+    B, _Hq, M, _Hkv, N, _D = shape
     is_decoding = M == 1
 
     def causal(b, h, m, n):
@@ -902,7 +898,7 @@ def generate_block_mask(
     if attn_type == "document_mask":
         random.seed(0)
         lengths = generate_random_lengths(N * B, B)
-        mask_mod_kwargs = dict(offsets=length_to_offsets(lengths, "cuda"))
+        mask_mod_kwargs = {"offsets": length_to_offsets(lengths, "cuda")}
 
     mask_mod_dict = {
         "noop": None,
@@ -948,8 +944,8 @@ def generate_block_mask(
 
 def get_kernel_options(
     attn_type: AttentionType, shape: tuple[int, int, int, int, int, int]
-) -> Optional[dict]:
-    B, Hq, M, Hkv, N, D = shape
+) -> dict | None:
+    B, _Hq, M, Hkv, N, D = shape
     is_decoding = M == 1
     kernel_opt_training_dict = {
         "noop": None,
@@ -1039,7 +1035,7 @@ def generate_FA_callable(
     dtype: torch.dtype,
     backend: Backend,
     **kwargs,
-) -> Optional[Callable]:
+) -> Callable | None:
     if dtype not in [torch.float16, torch.bfloat16]:
         return None
     if backend == "fav2":
@@ -1069,20 +1065,18 @@ def generate_FA_callable(
         print("Unknown backend " + backend)
         return None
 
-    B, Hq, M, Hkv, N, D = shape
+    _B, Hq, _M, _Hkv, _N, _D = shape
 
     FA_kwargs = {}
     if attn_type == "alibi":
         h = torch.arange(Hq, dtype=torch.float32, device="cuda")
         alibi_slopes = torch.exp2(-((h + 1) * 8.0 / Hq))
-        FA_kwargs = dict(alibi_slopes=alibi_slopes)
+        FA_kwargs = {"alibi_slopes": alibi_slopes}
     elif attn_type == "document_mask":
         FA_kwargs["cu_seqlens_q"] = kwargs["offsets"].to(torch.int32)
         FA_kwargs["cu_seqlens_k"] = kwargs["offsets"].to(torch.int32)
 
-        def offsets_to_lengths(
-            offsets: torch.Tensor, device: Union[str, torch.device]
-        ) -> torch.Tensor:
+        def offsets_to_lengths(offsets: torch.Tensor, device: str | torch.device) -> torch.Tensor:
             lengths = offsets[1:] - offsets[:-1]
             return lengths
 
@@ -1110,7 +1104,7 @@ def generate_FA_callable(
 
 def generate_FD_callable(
     attn_type: AttentionType, shape: tuple[int, int, int, int, int, int], dtype: torch.dtype
-) -> Optional[Callable]:
+) -> Callable | None:
     if dtype not in [torch.float16, torch.bfloat16]:
         return None
     try:
@@ -1119,7 +1113,7 @@ def generate_FD_callable(
         print("Flash attention 2 is not installed. Please install it to run fakv backend. ")
         raise
 
-    B, Hq, M, Hkv, N, D = shape
+    _B, Hq, M, _Hkv, N, _D = shape
 
     assert M == 1
 
@@ -1130,7 +1124,7 @@ def generate_FD_callable(
     if attn_type == "alibi":
         h = torch.arange(Hq, dtype=torch.float32, device="cuda")
         alibi_slopes = torch.exp2(-((h + 1) * 8.0 / Hq))
-        FA_kwargs = dict(alibi_slopes=alibi_slopes)
+        FA_kwargs = {"alibi_slopes": alibi_slopes}
 
     FD_dict = {
         "noop": partial(flash_attn_with_kvcache_renamed, causal=False),
@@ -1156,7 +1150,7 @@ def generate_attn_mask_linear_score_mod(
     block_mask: BlockMask,
     score_mod: Callable,
     dtype: torch.dtype,
-) -> Optional[torch.Tensor]:
+) -> torch.Tensor | None:
     B, Hq, M, N = shape
     if block_mask is None and score_mod is None:
         return None
@@ -1182,11 +1176,11 @@ def generate_eager_sdpa(
     attn_type: AttentionType,
     shape: tuple[int, int, int, int, int, int],
     dtype: torch.dtype,
-    block_mask: Optional[BlockMask],
-    score_mod: Optional[Callable] = None,
+    block_mask: BlockMask | None,
+    score_mod: Callable | None = None,
     **kwargs,
-) -> Optional[Callable]:
-    B, Hq, M, Hkv, N, D = shape
+) -> Callable | None:
+    _B, Hq, M, Hkv, N, _D = shape
     is_decoding = M == 1
     if attn_type == "sliding_window" or attn_type == "prefix_lm":
         assert block_mask is not None
@@ -1246,7 +1240,7 @@ def generate_experiment_configs(
     head_dims: list[int],
     score_mods_str: list[AttentionType],
     decoding: bool,
-    kv_cache_size: Optional[list[int]],
+    kv_cache_size: list[int] | None,
     cal_bandwidth: bool,
     backends: list[Backend],
 ) -> list[ExperimentConfig]:
@@ -1265,7 +1259,7 @@ def generate_experiment_configs(
         (q_seq_len, kv_seq_len),
         head_dim,
         attn_type,
-        dtype,
+        torch_dtype,
     ) in itertools.product(
         kv_cache_size if kv_cache_size else batch_sizes,
         num_heads,
@@ -1275,7 +1269,7 @@ def generate_experiment_configs(
         dtypes,
     ):
         if kv_cache_size:
-            head_size_bytes = torch.finfo(dtype).bits / 8 * head_dim
+            head_size_bytes = torch.finfo(torch_dtype).bits / 8 * head_dim
             bsz = int((bsz * 1024 * 1024) // (kv_heads * kv_seq_len * head_size_bytes * 2))
             if bsz <= 0:
                 continue
@@ -1286,7 +1280,7 @@ def generate_experiment_configs(
             ExperimentConfig(
                 shape=(bsz, q_heads, q_seq_len, kv_heads, kv_seq_len, head_dim),
                 attn_type=attn_type,
-                dtype=dtype,
+                dtype=torch_dtype,
                 calculate_bwd_time=calculate_bwd,
                 cal_bandwidth=cal_bandwidth,
                 backends=backends,
@@ -1308,19 +1302,19 @@ def main(
     dynamic: bool = False,
     calculate_bwd: bool = False,
     dtype: DtypeString = "bfloat16",
-    b: list[int] = [2, 8, 16],
-    nh: list[str] = ["16,16", "16,2"],
-    s: list[int] = [512, 1024, 4096],
-    d: list[int] = [64, 128],
-    mods: list[AttentionType] = ["noop", "causal", "alibi", "sliding_window"],
-    backend: list[Backend] = ["efficient"],
+    b: list[int] | None = None,
+    nh: list[str] | None = None,
+    s: list[int] | None = None,
+    d: list[int] | None = None,
+    mods: list[AttentionType] | None = None,
+    backend: list[Backend] | None = None,
     max_autotune: bool = False,
     decoding: bool = False,
-    kv_size: Optional[list[int]] = None,
+    kv_size: list[int] | None = None,
     throughput: bool = True,
     show_speedups: bool = False,
-    save_path: Optional[str] = None,
-    kernel_options: Optional[dict] = None,
+    save_path: str | None = None,
+    kernel_options: dict | None = None,
     block_q: int | None = None,
     block_kv: int | None = None,
 ) -> None:
@@ -1370,6 +1364,18 @@ def main(
     # Convert dtype string to torch dtype
     import torch
 
+    if backend is None:
+        backend = ["efficient"]
+    if mods is None:
+        mods = ["noop", "causal", "alibi", "sliding_window"]
+    if d is None:
+        d = [64, 128]
+    if s is None:
+        s = [512, 1024, 4096]
+    if nh is None:
+        nh = ["16,16", "16,2"]
+    if b is None:
+        b = [2, 8, 16]
     dtype = getattr(torch, dtype)
 
     # Parse head configurations
@@ -1382,21 +1388,23 @@ def main(
     np.random.seed(seed)
     torch.manual_seed(seed)
     results = []
-    experiment_count = 0
-    for exp_config in tqdm(
-        generate_experiment_configs(
-            calculate_bwd,
-            dtype,
-            b,
-            nh_parsed,
-            s,
-            d,
-            mods,
-            decoding,
-            kv_size,
-            throughput,
-            backend,
-        )
+    for experiment_count, exp_config in enumerate(
+        tqdm(
+            generate_experiment_configs(
+                calculate_bwd,
+                dtype,
+                b,
+                nh_parsed,
+                s,
+                d,
+                mods,
+                decoding,
+                kv_size,
+                throughput,
+                backend,
+            )
+        ),
+        start=1,
     ):
         experiment_result = run_single_experiment(
             exp_config,
@@ -1408,7 +1416,6 @@ def main(
         )
         results.append(Experiment(exp_config, experiment_result))
 
-        experiment_count += 1
         # Periodic memory cleanup every 10 experiments
         if experiment_count % 10 == 0:
             cleanup_memory()

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -52,6 +52,7 @@ from torch.nn.attention.flex_attention import and_masks, or_masks
 # Sliding window + causal
 sliding_causal = and_masks(causal_mask, sliding_window_mask)
 
+
 # Or combine inline
 def my_mask(b, h, q_idx, kv_idx):
     return (q_idx >= kv_idx) & (q_idx - kv_idx <= window_size)
@@ -88,8 +89,8 @@ from attn_gym.masks import causal_mask
 
 block_mask = create_block_mask(causal_mask, B=1, H=1, Q_LEN=2048, KV_LEN=2048, device="cuda")
 
-print(block_mask)            # ASCII visualization of the sparsity pattern
-print(block_mask.sparsity()) # percentage of blocks that are empty
+print(block_mask)  # ASCII visualization of the sparsity pattern
+print(block_mask.sparsity())  # percentage of blocks that are empty
 ```
 
 The `print` output shows a grid where `██` = full block, `░░` = partial block, and blank = empty (skipped). For causal attention this is the lower triangle.
@@ -112,6 +113,7 @@ When debugging, use `torch._C._functorch.get_unwrapped` to inspect tensor values
 
 ```python
 unwrap = torch._C._functorch.get_unwrapped
+
 
 def my_score_mod(score, b, h, q_idx, kv_idx):
     distance = q_idx - kv_idx

--- a/examples/aoti_create_block_mask.py
+++ b/examples/aoti_create_block_mask.py
@@ -1,17 +1,18 @@
 import os
-import torch
-from torch import Tensor
-from torch.nn.attention.flex_attention import (
-    BlockMask,
-    create_block_mask,
-    _DEFAULT_SPARSE_BLOCK_SIZE,
-)
-from torch.export import Dim
-from typing import Callable
-from attn_gym.masks.causal import causal_mask
+import warnings
+from collections.abc import Callable
 from functools import lru_cache
 
-import warnings
+import torch
+from torch import Tensor
+from torch.export import Dim
+from torch.nn.attention.flex_attention import (
+    _DEFAULT_SPARSE_BLOCK_SIZE,
+    BlockMask,
+    create_block_mask,
+)
+
+from attn_gym.masks.causal import causal_mask
 
 # Suppress FutureWarning about LeafSpec deprecation in torch._dynamo
 warnings.filterwarnings(

--- a/examples/aoti_flex_attention.py
+++ b/examples/aoti_flex_attention.py
@@ -1,4 +1,3 @@
-from torch import _TorchCompileAOTInductorWrapper, _TorchCompileInductorWrapper
 import argparse
 import warnings
 from contextlib import nullcontext
@@ -6,6 +5,7 @@ from pathlib import Path
 
 import torch
 from tabulate import tabulate
+from torch import _TorchCompileAOTInductorWrapper, _TorchCompileInductorWrapper
 from torch._dynamo.aot_compile import AOTCompiledModel, ModelInput, aot_compile_module
 from torch._dynamo.hooks import Hooks
 from torch.nn.attention.flex_attention import (
@@ -14,7 +14,6 @@ from torch.nn.attention.flex_attention import (
     create_block_mask,
     flex_attention,
 )
-
 
 warnings.filterwarnings(
     "ignore",

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -1,30 +1,26 @@
 from functools import lru_cache
-from typing import Optional, List
 
 import torch
 import torch.nn.functional as F
-
 from tabulate import tabulate
 from torch.nn.attention.flex_attention import (
     _DEFAULT_SPARSE_BLOCK_SIZE,
+    _mask_mod_signature,
+    _score_mod_signature,
     create_block_mask,
     create_mask,
     flex_attention,
-    _score_mod_signature,
-    _mask_mod_signature,
 )
-
 from triton.testing import do_bench
 
-from attn_gym.masks.document_mask import length_to_offsets
 from attn_gym.masks import (
     causal_mask,
-    generate_sliding_window,
-    generate_prefix_lm_mask,
     generate_doc_mask_mod,
+    generate_prefix_lm_mask,
+    generate_sliding_window,
 )
+from attn_gym.masks.document_mask import length_to_offsets
 from attn_gym.mods import generate_alibi_bias, generate_tanh_softcap
-
 
 AVAILABLE_EXAMPLES = {
     "causal": lambda: test_mask(mask_mod=causal_mask),
@@ -76,8 +72,8 @@ def print_header(text):
 
 
 def test_mask(
-    score_mod: Optional[_score_mod_signature] = None,
-    mask_mod: Optional[_mask_mod_signature] = None,
+    score_mod: _score_mod_signature | None = None,
+    mask_mod: _mask_mod_signature | None = None,
     B: int = 16,
     H: int = 16,
     S: int = 8192,
@@ -116,7 +112,7 @@ def test_mask(
     for attn in (causal_fa2, sdpa_mask, flex_attention_call):
         fwd_time = do_bench(attn)
         fwd_out = attn()
-        bwd_time = do_bench(lambda: fwd_out.backward(gradOut, retain_graph=True))  # noqa: F821
+        bwd_time = do_bench(lambda fwd_out=fwd_out: fwd_out.backward(gradOut, retain_graph=True))
         times.append((fwd_time, bwd_time))
 
         del fwd_out
@@ -221,13 +217,15 @@ def run_document_masking(max_seq_len: int, num_docs: int):
     test_mask(mask_mod=document_causal_mask, S=max_seq_len)
 
 
-def main(examples: List[str] = ["all"]):
+def main(examples: list[str] | None = None):
     """Run the benchmark with the given examples.
 
     Args:
         examples: List of examples to run. If "all" is specified, all examples will be run.
     """
 
+    if examples is None:
+        examples = ["all"]
     if "all" in examples:
         ex_to_run = list(AVAILABLE_EXAMPLES.keys())
     else:

--- a/examples/debug_score_mod.py
+++ b/examples/debug_score_mod.py
@@ -24,7 +24,6 @@ def _(mo):
     actual tensor values!
     """
     )
-    return
 
 
 @app.cell
@@ -46,7 +45,6 @@ def _(mo):
     Let's start with a "broken" implementation that's hard to debug:
     """
     )
-    return
 
 
 @app.cell
@@ -93,7 +91,6 @@ def _(mo):
     It outputs a tensor, so probaly fine. But we can't see the actual attention scores or how they change with different inputs. Lets do the old way and look at the attention scores graph
     """
     )
-    return
 
 
 @app.cell
@@ -104,7 +101,7 @@ def _(broken_score_mod, k, q):
         query=q, key=k, score_mod=broken_score_mod, device="cpu", figsize=(8, 8)
     )
 
-    graph
+    graph  # noqa: B018
     return (plot_attention_scores,)
 
 
@@ -126,7 +123,6 @@ def _(mo):
     This was time-consuming and error-prone!
     """
     )
-    return
 
 
 @app.cell
@@ -148,7 +144,6 @@ def _(flex_attention, k, q, torch, v):
         flex_attention(q, k, v, score_mod=create_broken_mod_2(4))
 
     # The dreaded : It looks like you're calling .item() on a Tensor!!
-    return
 
 
 @app.cell(hide_code=True)
@@ -160,7 +155,6 @@ def _(mo):
     Now we can use FlexAttention's debug flag to set breakpoints and inspect values:
     """
     )
-    return
 
 
 @app.cell
@@ -190,8 +184,6 @@ def _(fa, flex_attention, k, q, torch, v):
     with torch.no_grad():
         flex_attention(q, k, v, score_mod=create_broken_mod_3)
 
-    return
-
 
 @app.cell
 def _(flex_attention, k, plot_attention_scores, q, torch, v):
@@ -215,8 +207,7 @@ def _(flex_attention, k, plot_attention_scores, q, torch, v):
     flex_viz = plot_attention_scores(
         query=q, key=k, score_mod=create_broken_mod_4, device="cpu", figsize=(8, 8)
     )
-    flex_viz
-    return
+    flex_viz  # noqa: B018
 
 
 @app.cell(hide_code=True)
@@ -254,7 +245,6 @@ def _(mo):
     So if you if you need to debug an expression involving score you will need 4 unwraps to get to the innner `tensor` and 1 for expressions on the indices.
     """
     )
-    return
 
 
 @app.cell(hide_code=True)
@@ -270,7 +260,6 @@ def _(mo):
     - **Requires PyTorch 2.9 nightly or later**
     """
     )
-    return
 
 
 if __name__ == "__main__":

--- a/examples/fastwan_vsa.py
+++ b/examples/fastwan_vsa.py
@@ -64,7 +64,7 @@ def load_gate_weights(model_dir: Path, device, dtype) -> dict[int, tuple[Tensor,
     pending: dict[str, Tensor] = {}
     for shard in shards:
         with safe_open(shard, framework="pt") as f:
-            for key in f.keys():
+            for key in f.keys():  # noqa: SIM118
                 if "to_gate_compress" in key:
                     pending[key] = f.get_tensor(key).to(device=device, dtype=dtype)
     for key, weight in pending.items():
@@ -106,7 +106,7 @@ def maybe_fix_14b_transformer(model_dir: Path) -> None:
     state: dict[str, Tensor] = {}
     for shard in shards:
         with safe_open(shard, framework="pt") as f:
-            for key in f.keys():
+            for key in f.keys():  # noqa: SIM118
                 state[key] = f.get_tensor(key).to(torch.bfloat16)
 
     def diffusers_key(key: str) -> str:

--- a/examples/flex_autotune_replay.py
+++ b/examples/flex_autotune_replay.py
@@ -4,9 +4,10 @@ import tempfile
 from unittest.mock import patch
 
 import torch
-from torch.nn.attention.flex_attention import flex_attention, FlexKernelOptions, create_block_mask
-from attn_gym.utils import benchmark_cuda_function_in_microseconds
+from torch.nn.attention.flex_attention import FlexKernelOptions, create_block_mask, flex_attention
+
 from attn_gym.masks import causal_mask
+from attn_gym.utils import benchmark_cuda_function_in_microseconds
 
 torch.compiler.config.force_disable_caches = True
 torch._functorch.config.donated_buffer = False
@@ -56,10 +57,8 @@ def parse_log_and_get_best_options(log_file: str) -> FlexKernelOptions:
         prefix = "fwd_" if kernel_type == "forward" else "bwd_"
 
         for key, value in best_choice.items():
-            if key not in ["type", "time"]:
-                # Ensure the key is valid for FlexKernelOptions
-                if key in FlexKernelOptions.__annotations__:
-                    best_options[f"{prefix}{key}"] = value
+            if key not in ["type", "time"] and key in FlexKernelOptions.__annotations__:
+                best_options[f"{prefix}{key}"] = value
     print("Best kernel options extracted from logs:")
     print(json.dumps(best_options, indent=2))
     return best_options

--- a/examples/flex_determinism.py
+++ b/examples/flex_determinism.py
@@ -1,11 +1,13 @@
+import sys
+import warnings
+from dataclasses import asdict, dataclass
+
 import torch
-from torch.nn.attention import flex_attention
-from tabulate import tabulate
 import torch._inductor.config
 import torch._inductor.utils
-import warnings
+from tabulate import tabulate
+from torch.nn.attention import flex_attention
 from tqdm import tqdm
-from dataclasses import dataclass, asdict
 
 warnings.filterwarnings("ignore", message=".*dynamo_pgo force disabled.*")
 warnings.filterwarnings("ignore", message=".*Please use the new API settings to control TF32.*")
@@ -263,4 +265,4 @@ def main():
 
 if __name__ == "__main__":
     success = main()
-    exit(0 if success else 1)
+    sys.exit(0 if success else 1)

--- a/examples/flex_flash_attention.py
+++ b/examples/flex_flash_attention.py
@@ -14,18 +14,20 @@ Usage:
     python flex_flash_attention.py --mode compare     # Just numerical comparison
 """
 
-import torch
 import warnings
+from collections.abc import Callable
 from functools import partial
-from typing import Callable, Optional, Literal
+from typing import Literal
 
-from tqdm import tqdm
-from torch.nn.attention.flex_attention import flex_attention, create_block_mask, BlockMask
-from torch._inductor.utils import do_bench_using_profiling
+import torch
 from tabulate import tabulate
+from torch._inductor.utils import do_bench_using_profiling
+from torch.nn.attention.flex_attention import BlockMask, create_block_mask, flex_attention
+from tqdm import tqdm
+
 from attn_gym.masks import causal_mask
 from attn_gym.mods import generate_alibi_bias, generate_tanh_softcap
-from attn_gym.utils import get_flash_block_size, calculate_tflops, cuda_kernel_profiler
+from attn_gym.utils import calculate_tflops, cuda_kernel_profiler, get_flash_block_size
 
 # Suppress noisy profiler warning
 warnings.filterwarnings("ignore", message=".*Profiler clears events.*")
@@ -70,8 +72,8 @@ def compare_backends(
     *,
     flex_flash: Callable,
     flex_triton: Callable,
-    score_mod: Optional[Callable] = None,
-    block_mask: Optional[BlockMask] = None,
+    score_mod: Callable | None = None,
+    block_mask: BlockMask | None = None,
     backward: bool = False,
 ) -> tuple[float, float, float, float]:
     """Compare Flash vs Triton error against FP32 reference (forward and optionally backward)."""

--- a/examples/flex_grid_sweep.py
+++ b/examples/flex_grid_sweep.py
@@ -21,16 +21,15 @@ Example score_mod configurations:
 """
 
 import json
+import warnings
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
 
 import torch
 from torch.nn.attention.flex_attention import FlexKernelOptions, create_block_mask, flex_attention
-from attn_gym.utils import benchmark_cuda_function_in_microseconds
 from tqdm import tqdm
 
-import warnings
+from attn_gym.utils import benchmark_cuda_function_in_microseconds
 
 warnings.filterwarnings("ignore", message=".*dynamo_pgo force disabled.*")
 warnings.filterwarnings("ignore", message=".*Please use the new API settings to control TF32.*")
@@ -136,7 +135,7 @@ def generate_reduced_bwd_configs() -> list[FlexBwdConfig]:
 
 
 def config_to_kernel_options(
-    fwd_config: Optional[FlexConfig] = None, bwd_config: Optional[FlexBwdConfig] = None
+    fwd_config: FlexConfig | None = None, bwd_config: FlexBwdConfig | None = None
 ) -> FlexKernelOptions:
     """Convert config objects to FlexKernelOptions dict."""
     options: FlexKernelOptions = {}
@@ -202,7 +201,7 @@ def benchmark_fwd_config(
 
         return time_us, True
 
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         print(f"  Failed: {e}")
         # Clean up on failure
         torch.cuda.empty_cache()
@@ -215,7 +214,7 @@ def benchmark_bwd_config(
     value: torch.Tensor,
     block_mask,
     bwd_config: FlexBwdConfig,
-    fwd_config: Optional[FlexConfig] = None,
+    fwd_config: FlexConfig | None = None,
     score_mod=None,
     warmup_iters: int = 3,
 ) -> tuple[float, bool]:
@@ -272,7 +271,7 @@ def benchmark_bwd_config(
 
         return time_us, True
 
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         print(f"  Failed: {e}")
         # Clean up on failure
         query.grad = None
@@ -288,7 +287,7 @@ def sweep_forward_configs(
     value: torch.Tensor,
     block_mask,
     score_mod=None,
-    configs: Optional[list[FlexConfig]] = None,
+    configs: list[FlexConfig] | None = None,
 ) -> tuple[FlexConfig, float, list[dict]]:
     """
     Sweep all forward configs and find the best one.
@@ -340,8 +339,8 @@ def sweep_backward_configs(
     key: torch.Tensor,
     value: torch.Tensor,
     block_mask,
-    best_fwd_config: Optional[FlexConfig] = None,
-    configs: Optional[list[FlexBwdConfig]] = None,
+    best_fwd_config: FlexConfig | None = None,
+    configs: list[FlexBwdConfig] | None = None,
     use_reduced: bool = True,
     score_mod=None,
 ) -> tuple[FlexBwdConfig, float, list[dict]]:

--- a/examples/mla.py
+++ b/examples/mla.py
@@ -1,12 +1,11 @@
-import torch
-
-from torch.nn.attention.flex_attention import flex_attention
-from typing import Optional, Tuple
-from torch import nn
-import torch.nn.functional as F
 import math
-from attn_gym.mods.latent_attention import generate_mla_rope_score_mod
 
+import torch
+import torch.nn.functional as F
+from torch import nn
+from torch.nn.attention.flex_attention import flex_attention
+
+from attn_gym.mods.latent_attention import generate_mla_rope_score_mod
 
 torch._inductor.config.unroll_reductions_threshold = 65
 
@@ -56,7 +55,7 @@ def precompute_freqs_cis(dim: int, end: int, theta: float = 10000.0, use_scaled:
 
 def reshape_for_broadcast(freqs_cis: torch.Tensor, x: torch.Tensor):
     ndim = x.ndim
-    assert 0 <= 1 < ndim
+    assert 1 < ndim
     assert freqs_cis.shape == (x.shape[1], x.shape[-1])
     shape = [d if i == 1 or i == ndim - 1 else 1 for i, d in enumerate(x.shape)]
     return freqs_cis.view(*shape)
@@ -66,7 +65,7 @@ def apply_rotary_emb(
     xq: torch.Tensor,
     xk: torch.Tensor,
     freqs_cis: torch.Tensor,
-) -> Tuple[torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor]:
     xq_ = torch.view_as_complex(xq.float().reshape(*xq.shape[:-1], -1, 2))
     xk_ = torch.view_as_complex(xk.float().reshape(*xk.shape[:-1], -1, 2))
     freqs_cis = reshape_for_broadcast(freqs_cis, xq_)
@@ -153,7 +152,7 @@ class DeepseekV2AttentionVanilla(nn.Module):
         hidden_states: torch.Tensor,
         compressed_kv_normed_cache: torch.Tensor,
         k_pe_cache: torch.Tensor,
-    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
+    ) -> tuple[torch.Tensor, torch.Tensor | None, tuple[torch.Tensor] | None]:
         bsz, q_len, _ = hidden_states.size()
         if q_len != 1:
             raise ValueError(f"Only support decode, but got hidden_states[{hidden_states.size()}]")
@@ -292,7 +291,7 @@ class DeepseekV2AttentionMatAbsorbDecode(nn.Module):
         k_pe_cache: torch.Tensor,
         use_flex: bool,
         compile: bool,
-    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
+    ) -> tuple[torch.Tensor, torch.Tensor | None, tuple[torch.Tensor] | None]:
         bsz, _ = hidden_states.size()
 
         c_Q = torch.matmul(hidden_states, self.W_DQ)
@@ -464,11 +463,12 @@ def run_performance_test(
     compressed_kv_normed_cache: torch.Tensor,
     k_pe_cache: torch.Tensor,
 ):
+    from pathlib import Path
+
     from transformer_nuggets.utils.benchmark import (
         benchmark_cuda_function_in_microseconds,
         profiler,
     )
-    from pathlib import Path
 
     mla_mat_absorb = DeepseekV2AttentionMatAbsorbDecode(mla_vanilla).cuda(device=dev_id)
 

--- a/examples/paged_attention/latency.py
+++ b/examples/paged_attention/latency.py
@@ -6,13 +6,12 @@ Command:
 """
 
 import torch
+from torch._inductor.runtime.benchmarking import benchmarker
 from torch.nn.attention.flex_attention import (
     create_block_mask,
     noop_mask,
 )
-from torch._inductor.runtime.benchmarking import benchmarker
-
-from utils import random_init_paged_attention, gen_offset, generate_score_mod
+from utils import gen_offset, generate_score_mod, random_init_paged_attention
 
 dtype = torch.bfloat16
 

--- a/examples/paged_attention/model.py
+++ b/examples/paged_attention/model.py
@@ -1,8 +1,8 @@
-import torch
 import math
-from torch.nn.attention.flex_attention import BlockMask, flex_attention, _score_mod_signature
+
+import torch
 from torch import Tensor
-from typing import Dict, Optional
+from torch.nn.attention.flex_attention import BlockMask, _score_mod_signature, flex_attention
 
 
 class NonPagedAttentionLayer(torch.nn.Module):
@@ -135,7 +135,7 @@ class PagedAttentionLayer(torch.nn.Module):
         q = apply_rotary_emb(q, freqs_cis)
         k = apply_rotary_emb(k, freqs_cis)
 
-        q, k, v = map(lambda x: x.transpose(1, 2), (q, k, v))
+        q, k, v = (x.transpose(1, 2) for x in (q, k, v))
 
         # Comparing with NonPagedAttention, here is the only change for updating kv cache
         self.paged_attention.assign(
@@ -174,7 +174,7 @@ def apply_rotary_emb(x: Tensor, freqs_cis: Tensor) -> Tensor:
     return x_out2.type_as(x)
 
 
-def apply_rope_scaling(freqs: torch.Tensor, rope_scaling: Dict):
+def apply_rope_scaling(freqs: torch.Tensor, rope_scaling: dict):
     factor = rope_scaling["factor"]
     low_freq_factor = rope_scaling["low_freq_factor"]
     high_freq_factor = rope_scaling["high_freq_factor"]
@@ -203,7 +203,7 @@ def precompute_freqs_cis(
     n_elem: int,
     base: int = 10000,
     dtype: torch.dtype = torch.bfloat16,
-    rope_scaling: Optional[dict] = None,
+    rope_scaling: dict | None = None,
 ) -> Tensor:
     freqs = 1.0 / (base ** (torch.arange(0, n_elem, 2)[: (n_elem // 2)].float() / n_elem))
     if rope_scaling is not None:

--- a/examples/paged_attention/paged_attention.py
+++ b/examples/paged_attention/paged_attention.py
@@ -1,16 +1,14 @@
-from typing import Optional, Union
-
 import torch
 from torch.nn.attention.flex_attention import (
+    BlockMask,
     _identity,
     _mask_mod_signature,
     _score_mod_signature,
-    BlockMask,
     noop_mask,
 )
 
 
-def _cdiv(x: Union[int, float, torch.Tensor], multiple: Union[int, float, torch.Tensor]):
+def _cdiv(x: float | torch.Tensor, multiple: float | torch.Tensor):
     return (x + multiple - 1) // multiple
 
 
@@ -182,7 +180,7 @@ class PagedAttention:
     def convert_logical_block_mask(
         self,
         block_mask: BlockMask,
-        batch_idx: Optional[torch.Tensor] = None,
+        batch_idx: torch.Tensor | None = None,
     ) -> BlockMask:
         """
         Converts a logical block mask by mapping its logical kv indices to the corresponding
@@ -256,7 +254,7 @@ class PagedAttention:
         )
 
     def get_mask_mod(
-        self, mask_mod: Optional[_mask_mod_signature], batch_idx: Optional[torch.Tensor] = None
+        self, mask_mod: _mask_mod_signature | None, batch_idx: torch.Tensor | None = None
     ) -> _mask_mod_signature:
         """
         Converts a mask_mod based on mapping from the physical block index to the logical
@@ -291,7 +289,7 @@ class PagedAttention:
         return new_mask_mod
 
     def get_score_mod(
-        self, score_mod: Optional[_score_mod_signature], batch_idx: Optional[torch.Tensor] = None
+        self, score_mod: _score_mod_signature | None, batch_idx: torch.Tensor | None = None
     ) -> _score_mod_signature:
         """
         Converts a score_mod based on mapping from the physical block index to the logical

--- a/examples/paged_attention/throughput.py
+++ b/examples/paged_attention/throughput.py
@@ -22,19 +22,19 @@ We empirically observe that the max batch size to serve is 2448, which is 76x of
 max batch size without paged attention.
 """
 
-import torch
-from torch.nn.attention.flex_attention import (
-    _identity,
-    BlockMask,
-    create_block_mask,
-)
-from datasets import load_dataset
 import random
 from collections import deque
-from typing import Tuple
-from utils import gen_offset, slice_block_mask
+
+import torch
+from datasets import load_dataset
 from model import PagedAttentionLayer
 from paged_attention import PagedAttention
+from torch.nn.attention.flex_attention import (
+    BlockMask,
+    _identity,
+    create_block_mask,
+)
+from utils import gen_offset, slice_block_mask
 
 create_block_mask = torch.compile(create_block_mask)
 
@@ -85,7 +85,7 @@ class Server:
         # assume we know prompt length and response length in advance.
         self.request_queue.append((prompt_len, response_len))
 
-    def can_schedule(self, request: Tuple[int, int]) -> bool:
+    def can_schedule(self, request: tuple[int, int]) -> bool:
         return len(self.paged_attention.empty_pages) * self.paged_attention.page_size >= sum(
             request
         )

--- a/examples/paged_attention/utils.py
+++ b/examples/paged_attention/utils.py
@@ -1,9 +1,9 @@
 import torch
-from torch.nn.attention.flex_attention import (
-    _identity,
-    BlockMask,
-)
 from paged_attention import PagedAttention
+from torch.nn.attention.flex_attention import (
+    BlockMask,
+    _identity,
+)
 
 
 def batch_reserve(paged_attention: PagedAttention, target_seq_len: torch.Tensor):

--- a/examples/ring_attention.py
+++ b/examples/ring_attention.py
@@ -15,7 +15,6 @@ import torch.distributed as dist
 from torch._dynamo import config as dynamo_config
 from torch.nn.attention.flex_attention import AuxRequest, create_block_mask, flex_attention
 
-
 dynamo_config.skip_guards_on_constant_func_defaults = False
 
 LN2 = math.log(2)

--- a/examples/rows_guaranteed_safe_demo.py
+++ b/examples/rows_guaranteed_safe_demo.py
@@ -15,10 +15,9 @@ from __future__ import annotations
 
 import warnings
 
-from tabulate import tabulate
-
 import torch
 import torch.nn.attention.flex_attention as fa
+from tabulate import tabulate
 
 Q_LEN = 128
 KV_LEN = 256

--- a/examples/shared_prefix_split_attention.py
+++ b/examples/shared_prefix_split_attention.py
@@ -90,7 +90,7 @@ def main(device: str = "cpu"):
 
     for response_slice in response_slices:
         split_out = split_prefix_response_attention(q, k, v, prefix_slice, response_slice)
-        duplicated_indices = list(range(0, 3)) + list(
+        duplicated_indices = list(range(3)) + list(
             range(response_slice.start, response_slice.stop)
         )
         duplicated_out = duplicated_causal_attention(q, k, v, duplicated_indices)

--- a/examples/vsa.py
+++ b/examples/vsa.py
@@ -1,7 +1,7 @@
 """Demonstrates Video Sparse Attention top-k tiles with FlexAttention."""
 
-from functools import partial
 import math
+from functools import partial
 from typing import Literal
 
 import torch

--- a/modal_tests.py
+++ b/modal_tests.py
@@ -37,8 +37,10 @@ def format_pytest_summary(report_path: Path) -> str:
     lines = [
         "## B200 pytest summary",
         "",
-        f"**{passed} passed, {failures} failed, {errors} errors, {skipped} skipped** "
-        f"in {duration:.2f}s.",
+        (
+            f"**{passed} passed, {failures} failed, {errors} errors, {skipped} skipped** "
+            f"in {duration:.2f}s."
+        ),
     ]
 
     failed_tests = []
@@ -67,6 +69,7 @@ def run_pytest() -> tuple[int, str]:
     result = subprocess.run(
         ["python", "-m", "pytest", "test", "-ra", "--tb=short", f"--junitxml={report_path}"],
         cwd="/root",
+        check=False,
     )
     return result.returncode, format_pytest_summary(report_path)
 

--- a/test/test_graphormer.py
+++ b/test/test_graphormer.py
@@ -113,7 +113,9 @@ def test_graphormer_flex_matches_sdpa_with_learnable_bias_grads(compile_flex):
     ref_grads = grad(ref, (q, k, v, spatial_bias), grad_out)
     for g, rg, name in zip(grads, ref_grads, ("q", "k", "v", "spatial_bias")):
         assert g.abs().sum() > 0, f"grad_{name} is all zeros"
-        torch.testing.assert_close(g, rg, rtol=2e-2, atol=2e-2, msg=lambda m: f"grad_{name}: {m}")
+        torch.testing.assert_close(
+            g, rg, rtol=2e-2, atol=2e-2, msg=lambda m, name=name: f"grad_{name}: {m}"
+        )
 
 
 @pytest.mark.parametrize("compile_flex", [False, True], ids=["eager", "compiled"])
@@ -145,7 +147,9 @@ def test_graphormer_edge_bias_flex_matches_sdpa_with_grads(compile_flex):
     ref_grads = grad(ref, (q, k, v, edge_bias), grad_out)
     for g, rg, name in zip(grads, ref_grads, ("q", "k", "v", "edge_bias")):
         assert g.abs().sum() > 0, f"grad_{name} is all zeros"
-        torch.testing.assert_close(g, rg, rtol=2e-2, atol=2e-2, msg=lambda m: f"grad_{name}: {m}")
+        torch.testing.assert_close(
+            g, rg, rtol=2e-2, atol=2e-2, msg=lambda m, name=name: f"grad_{name}: {m}"
+        )
 
 
 def test_graphormer_combined_spatial_and_edge_bias():
@@ -184,4 +188,6 @@ def test_graphormer_combined_spatial_and_edge_bias():
     ref_grads = grad(ref, (spatial_bias, edge_bias), grad_out)
     for g, rg, name in zip(grads, ref_grads, ("spatial_bias", "edge_bias")):
         assert g.abs().sum() > 0, f"grad_{name} is all zeros"
-        torch.testing.assert_close(g, rg, rtol=2e-2, atol=2e-2, msg=lambda m: f"grad_{name}: {m}")
+        torch.testing.assert_close(
+            g, rg, rtol=2e-2, atol=2e-2, msg=lambda m, name=name: f"grad_{name}: {m}"
+        )

--- a/test/test_mods.py
+++ b/test/test_mods.py
@@ -1,8 +1,10 @@
+from functools import partial
+
+import pytest
 import torch
 from torch.autograd import grad
 from torch.nn.attention.flex_attention import flex_attention
-import pytest
-from functools import partial
+
 from attn_gym.mods import generate_tanh_softcap
 
 

--- a/test/test_natten.py
+++ b/test/test_natten.py
@@ -1,7 +1,8 @@
-import torch
-from torch.nn.attention.flex_attention import flex_attention, create_block_mask
 import pytest
-from attn_gym.masks import generate_natten, generate_tiled_natten, generate_morton_natten
+import torch
+from torch.nn.attention.flex_attention import create_block_mask, flex_attention
+
+from attn_gym.masks import generate_morton_natten, generate_natten, generate_tiled_natten
 from attn_gym.masks.natten import morton_decode, morton_encode
 
 

--- a/test/test_selected_attention_semantics.py
+++ b/test/test_selected_attention_semantics.py
@@ -272,9 +272,9 @@ def test_sink_large_absorbs_probability(backend):
     )
 
     # Output should be near zero (sink absorbs essentially all probability)
-    assert (
-        out.abs().max().item() < 0.01
-    ), f"With large sink, output should be near zero, got max={out.abs().max().item()}"
+    assert out.abs().max().item() < 0.01, (
+        f"With large sink, output should be near zero, got max={out.abs().max().item()}"
+    )
 
 
 @pytest.mark.parametrize("backend", BACKENDS)

--- a/test/test_shared_prefix.py
+++ b/test/test_shared_prefix.py
@@ -19,9 +19,9 @@ def test_shared_prefix_matches_duplicated_causal_samples_cuda():
     device = "cuda"
 
     prefix_response_docs = [
-        (range(0, 3), range(3, 5)),
-        (range(0, 3), range(5, 7)),
-        (range(0, 3), range(7, 9)),
+        (range(3), range(3, 5)),
+        (range(3), range(5, 7)),
+        (range(3), range(7, 9)),
         (range(9, 12), range(12, 14)),
         (range(9, 12), range(14, 16)),
         (range(9, 12), range(16, 18)),

--- a/test/test_shared_prefix_split_attention.py
+++ b/test/test_shared_prefix_split_attention.py
@@ -1,5 +1,5 @@
-import torch
 import pytest
+import torch
 from torch.nn.attention.flex_attention import AuxRequest, create_block_mask, flex_attention
 
 from attn_gym.masks.causal import causal_mask

--- a/test/test_vsa.py
+++ b/test/test_vsa.py
@@ -1,5 +1,5 @@
-from functools import partial
 import math
+from functools import partial
 
 import pytest
 import torch


### PR DESCRIPTION
Human Note

Agent note
Update the Ruff pre-commit hook from 0.15.22 to 0.16.1 and apply its formatter and newly enabled
lint fixes across the repository. This includes the formatting fix needed after #232 landed, so the
`prek` workflow is clean again.

The automated pass surfaced one invalid suggestion: Ruff proposed iterating directly over a
`safetensors.safe_open` handle, but that type exposes `keys()` and is not iterable. Those two call
sites retain `.keys()` with narrow `SIM118` suppressions. Broad exception handling is also retained
where benchmark sweeps intentionally skip unsupported configurations.

The full local suite completed with 241 passed and 1 skipped. Two eager `torch.compile` tests were
blocked by the ARM host toolchain before generated code ran: the installed GCC rejects PyTorch's
ARMv9 `-march` target, while the Clang retry lacks `omp.h`. The corresponding Triton variants and
all other tests passed.

Test Plan:

```bash
~/.venvs/nightly/bin/python -m compileall -q attn_gym benchmarks examples modal_tests.py test
prek run --all-files --show-diff-on-failure
git diff --check
gpu-run 0 -- ~/.venvs/nightly/bin/pytest test -ra --tb=short
CXX=$(command -v clang++) CC=$(command -v clang) ~/.venvs/nightly/bin/pytest test/test_selected_attention_semantics.py::test_torch_compile_fullgraph_forward test/test_selected_attention_semantics.py::test_torch_compile_fullgraph_backward -k eager -ra --tb=short
```
