### PR TITLE
open source mslk kda kernels

### DIFF
--- a/attn_gym/linear/__init__.py
+++ b/attn_gym/linear/__init__.py
@@ -1,5 +1,14 @@
 """Linear attention operations."""
 
 from attn_gym.linear.gdn import GatedDeltaRuleOutput, gated_delta_rule
+from attn_gym.linear.kda import (
+    naive_chunk_kda,
+    naive_recurrent_kda,
+)
 
-__all__ = ["GatedDeltaRuleOutput", "gated_delta_rule"]
+__all__ = [
+    "GatedDeltaRuleOutput",
+    "gated_delta_rule",
+    "naive_chunk_kda",
+    "naive_recurrent_kda",
+]

--- a/attn_gym/linear/kda/__init__.py
+++ b/attn_gym/linear/kda/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""KDA (Kimi Delta Attention) CuTe-DSL kernels for SM100 / Blackwell."""
+
+from attn_gym.linear.kda.naive import (
+    naive_chunk_kda,
+    naive_recurrent_kda,
+)
+
+__all__ = [
+    "naive_chunk_kda",
+    "naive_recurrent_kda",
+]

--- a/attn_gym/linear/kda/bwd/__init__.py
+++ b/attn_gym/linear/kda/bwd/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/attn_gym/linear/kda/bwd/cute/__init__.py
+++ b/attn_gym/linear/kda/bwd/cute/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/attn_gym/linear/kda/bwd/cute/chunk_delta_h_bwd_v1.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_delta_h_bwd_v1.py
@@ -1,0 +1,2091 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-ignore-all-errors
+
+"""
+BlackwellDeltaHBwdV1 — SM100 warp-specialized kernel for KDA backward dhu recurrence.
+
+Implements the backward hidden-state gradient update across chunks (reverse order):
+
+    dh_out[c]  = snapshot(dh)
+    dv[c]      = GEMM_DV(K[c], dh) * gate + dv_intra[c]
+    dh         = diag(exp2(gk_last[c] + g_last[c])) @ dh
+                 + GEMM_QDO(Q[c]^T, do[c]) * scale
+                 - GEMM_WDV(W[c], dv[c])
+
+Architecture follows FMHA/MSLK Blackwell patterns:
+  - 8-warp CTA (256 threads), occupancy 1 for maximum SMEM/regs
+  - Separate warp roles: CUDA(0-3), Load(4), GK(5), MMA(6), Store(7)
+  - SS-mode MMA: both operands from SMEM, accumulators in TMEM
+  - 3 MMAs per chunk: MMA1(k@dh→dv), MMA2(q^T@do→qdo), MMA3(w@dv2→wdv)
+  - MMA2 uses MN-major B-operand for direct TMA loading of do
+  - Reverse chunk iteration: NT-1 down to 0
+"""
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.pipeline as pipeline
+import cutlass.utils as utils
+import cutlass.utils.blackwell_helpers as sm100_utils
+import torch
+import torch.nn.functional as F
+import triton
+from cutlass.cute.nvgpu import cpasync, tcgen05
+from cutlass.cute.runtime import make_fake_compact_tensor, make_fake_stream
+from cutlass.cute.typing import Float32, Int32, Int64
+from cutlass.utils.hardware_info import HardwareInfo
+from attn_gym.linear.kda.utils import (
+    prepare_chunk_indices,
+    prepare_lens,
+    tensor_cache,
+)
+from torch._guards import active_fake_mode
+
+
+# Simple JIT cache (no external dependency)
+def get_jit_cache(name):
+    """In-memory compilation cache."""
+    return {}
+
+
+@tensor_cache
+def _cumulative_chunk_offsets(cu_seqlens, chunk_size):
+    return (
+        F.pad(triton.cdiv(prepare_lens(cu_seqlens), chunk_size), (1, 0), value=0)
+        .cumsum(-1)
+        .int()
+    )
+
+
+# ============================================================================
+# BlackwellDeltaHBwdV1 — warp-specialized backward inter-chunk recurrence
+# ============================================================================
+
+
+class BlackwellDeltaHBwdV1:
+    """
+    Warp-specialized SM100 kernel for gated delta rule backward dhu recurrence.
+
+    dh state persists in CUDA warp registers (FP32) across all chunks — zero
+    GMEM round-trips.  SS-mode (both operands from SMEM) with BV=16.
+
+    3 MMA operations per chunk:
+      MMA1: k @ dh → dv          (BT=64,  BV=16, K=128)
+      MMA2: q^T @ do → qdo       (BK=128, BV=16, K=64)
+      MMA3: w @ dv2 → wdv        (BK=128, BV=16, K=64)
+    """
+
+    # Warp role assignment (8 warps total)
+    CUDA_WARP_IDS = (0, 1, 2, 3)
+    LOAD_WARP_ID = 4  # TMA G2S producer
+    GK_WARP_ID = 5  # dedicated gk+g exp2 precompute
+    MMA_WARP_ID = 6  # tcgen05 3×GEMM
+    STORE_WARP_ID = 7  # TMA S2G consumer
+    WARP_SZ = 32
+    N_WARPS = 8
+    CTA_THREADS = N_WARPS * WARP_SZ  # 256
+
+    def __init__(
+        self,
+        chunk_size: int = 64,
+        head_k: int = 128,
+        head_v: int = 128,
+        head_bv: int = 16,
+        acc_type=cutlass.Float32,
+        io_type=cutlass.BFloat16,
+        varlen: bool = False,
+    ):
+        assert head_k == 128 and head_v == 128, (
+            f"Only head_k=head_v=128 supported, got {head_k},{head_v}"
+        )
+        assert head_bv in (16, 32), f"BV must be 16 or 32, got {head_bv}"
+        self.chunk_size = chunk_size
+        self.head_k = head_k
+        self.head_v = head_v
+        self.acc_type = acc_type
+        self.io_type = io_type
+        self.varlen = varlen
+
+        # Tile dimensions
+        self.BT = chunk_size  # 64
+        self.BK = head_k  # 128
+        self.BV = head_bv  # N-dim for SS-mode MMA (16 or 32)
+
+        # Register budget per thread — BV=32 needs more for wider dh state
+        self.cuda_regs = 128 if head_bv <= 16 else 160
+        self.aux_regs = 40  # MMA/Load/Store/GK: minimal
+
+        self.min_occ = 1
+
+        # MMA tile shapes (M, N, K)
+        # MMA1: k @ dh → dv — k is (BT,BK) K-major, dh is (BK,BV) K-major
+        self.dv_tile = (self.BT, self.BV, self.BK)
+        # MMA2: q^T @ do → qdo — q^T is (BK,BT) MN-major, do is (BT,BV) MN-major
+        self.qdo_tile = (self.BK, self.BV, self.BT)
+        # MMA3: w @ dv2 → wdv — w is (BK,BT) MN-major, dv2 is (BT,BV) K-major
+        self.wdv_tile = (self.BK, self.BV, self.BT)
+
+        # Pipeline depths — BV=32 uses shallower k pipeline to fit SMEM
+        self.k_depth = 6 if head_bv <= 16 else 4
+        self.q_depth = 2
+        self.w_depth = 2
+        self.do_depth = 2  # do B-operand (MN-major TMA)
+        self.dv_in_depth = 2  # dv_intra load
+        self.gk_depth = 2
+        self.dh_epi_depth = 2  # dh snapshot store
+        self.dv2_epi_depth = 2  # dv2 store
+        self.dv_acc_depth = 1  # MMA1 accumulator
+        self.qdo_acc_depth = 1
+        self.wdv_acc_depth = 1
+
+        self.cluster = (1, 1, 1)
+        self.cta_group = tcgen05.CtaGroup.ONE
+
+        # Named barriers
+        self.tmem_free_bar = pipeline.NamedBarrier(
+            barrier_id=2,
+            num_threads=self.CTA_THREADS,
+        )
+        self.align = 1024
+
+    # ------------------------------------------------------------------
+    # Host-side setup (__call__): GMEM layouts → TMA → SMEM → launch
+    # ------------------------------------------------------------------
+
+    @cute.jit
+    def __call__(
+        self,
+        q_in: cute.Tensor,
+        k_in: cute.Tensor,
+        w_in: cute.Tensor,
+        do_in: cute.Tensor,
+        dv_in: cute.Tensor,
+        gk_in: cute.Tensor,
+        dht_in: cute.Tensor,
+        dh0_in: cute.Tensor,
+        dh_out_in: cute.Tensor,
+        dv2_out_in: cute.Tensor,
+        cu_seqlens_in: cute.Tensor,
+        chunk_offsets_in: cute.Tensor,
+        num_seqs_in: cute.Tensor,
+        problem_shape: tuple[Int32, Int32, Int32, Int32, Int32],
+        total_nt: Int32,
+        scale: Float32,
+        use_gk: Int32,
+        use_dht: Int32,
+        use_dh0: Int32,
+        stream,
+    ):
+        # --- Extract raw pointers ---
+        qp = q_in.iterator
+        kp = k_in.iterator
+        wp = w_in.iterator
+        dop = do_in.iterator
+        dvp = dv_in.iterator
+        gkp = gk_in.iterator
+        dhtp = dht_in.iterator
+        dh0p = dh0_in.iterator
+        dhop = dh_out_in.iterator
+        dv2p = dv2_out_in.iterator
+        cup = cu_seqlens_in.iterator
+        cop = chunk_offsets_in.iterator
+        nsp = num_seqs_in.iterator
+
+        B, T, H, K, V = problem_shape
+        if cutlass.const_expr(self.varlen):
+            dB = Int32(1)
+            NT = total_nt
+        else:
+            dB = B
+            NT = (T + self.BT - 1) // self.BT
+
+        # --- GMEM tensor construction ---
+        # K: (T, K, (H, dB)) — K-contiguous for MMA1 A-operand (k is K-major)
+        g_k = cute.make_tensor(
+            kp,
+            cute.make_layout((T, K, (H, dB)), stride=(H * K, 1, (K, T * H * K))),
+        )
+        # Q^T: (K, T, (H, dB)) — K-contiguous, then transposed for MMA2 A-operand
+        g_qt = cute.make_tensor(
+            qp,
+            cute.make_layout((K, T, (H, dB)), stride=(1, H * K, (K, T * H * K))),
+        )
+        # W: (K, T, (H, dB)) — K-contiguous for MMA3 A-operand (w^T)
+        g_wt = cute.make_tensor(
+            wp,
+            cute.make_layout((K, T, (H, dB)), stride=(1, H * K, (K, T * H * K))),
+        )
+        # do transposed: (V, T, (H, dB)) — V-contiguous for MMA2 MN-major B-operand TMA
+        g_do_vt = cute.make_tensor(
+            dop,
+            cute.make_layout((V, T, (H, dB)), stride=(1, H * V, (V, T * H * V))),
+        )
+        # dv_in: (T, V, (H, dB)) — V-contiguous
+        dv_lay = cute.make_layout((T, V, (H, dB)), stride=(H * V, 1, (V, T * H * V)))
+        # dv_in transposed: (V, T, (H, dB))
+        g_dv_in_t = cute.make_tensor(
+            dvp,
+            cute.make_layout((V, T, (H, dB)), stride=(1, H * V, (V, T * H * V))),
+        )
+        # dv2_out: (T, V, (H, dB))
+        g_dv2 = cute.make_tensor(dv2p, dv_lay)
+        # dv2_out transposed: (V, T, (H, dB))
+        g_dv2_t = cute.make_tensor(
+            dv2p,
+            cute.make_layout((V, T, (H, dB)), stride=(1, H * V, (V, T * H * V))),
+        )
+
+        # dh_out transposed for TMA store: (V, K, (NT, H, dB))
+        g_dh_out_t = cute.make_tensor(
+            dhop,
+            cute.make_layout(
+                (V, K, (NT, H, dB)),
+                stride=(1, V, (H * K * V, K * V, NT * H * K * V)),
+            ),
+        )
+
+        # dht: (K, V, (H, B)) — final state gradient input
+        g_dht = cute.make_tensor(
+            dhtp,
+            cute.make_layout((K, V, (H, B)), stride=(V, 1, (K * V, H * K * V))),
+        )
+        # dh0 transposed for store: (V, K, (H, B))
+        g_dh0_t = cute.make_tensor(
+            dh0p,
+            cute.make_layout((V, K, (H, B)), stride=(1, V, (K * V, H * K * V))),
+        )
+
+        # gk K-contiguous: (K, T, (H, dB))
+        g_gk_k = cute.make_tensor(
+            gkp,
+            cute.make_layout((K, T, (H, dB)), stride=(1, H * K, (K, T * H * K))),
+        )
+
+        # --- MMA configurations (SS-mode: both operands from SMEM) ---
+        # MMA1: k @ dh → dv  — k is (BT,BK) as A K-major, dh is (BK,BV) as B K-major
+        mma_dv = sm100_utils.make_trivial_tiled_mma(
+            self.io_type,
+            tcgen05.OperandMajorMode.K,  # A (k): K-major
+            tcgen05.OperandMajorMode.K,  # B (dh): K-major
+            self.acc_type,
+            self.cta_group,
+            self.dv_tile[:2],  # (BT=64, BV=16)
+            tcgen05.OperandSource.SMEM,
+        )
+        # MMA2: q^T @ do → qdo  — q^T is (BK,BT) A MN-major, do is (BT,BV) B MN-major
+        mma_qdo = sm100_utils.make_trivial_tiled_mma(
+            self.io_type,
+            tcgen05.OperandMajorMode.MN,  # A (q^T): MN-major
+            tcgen05.OperandMajorMode.MN,  # B (do): MN-major (V-contiguous)
+            self.acc_type,
+            self.cta_group,
+            self.qdo_tile[:2],  # (BK=128, BV=16)
+            tcgen05.OperandSource.SMEM,
+        )
+        # MMA3: w @ dv2 → wdv  — w is (BK,BT) A MN-major, dv2 is (BT,BV) B K-major
+        mma_wdv = sm100_utils.make_trivial_tiled_mma(
+            self.io_type,
+            tcgen05.OperandMajorMode.MN,  # A (w^T): MN-major
+            tcgen05.OperandMajorMode.K,  # B (dv2): K-major
+            self.acc_type,
+            self.cta_group,
+            self.wdv_tile[:2],  # (BK=128, BV=16)
+            tcgen05.OperandSource.SMEM,
+        )
+
+        # Plan TMEM column allocation (3 separate accumulator regions)
+        (self.tm_dv, self.tm_qdo, self.tm_wdv, self.tm_tot) = self._plan_tmem(
+            mma_dv,
+            self.dv_tile,
+            self.dv_acc_depth,
+            mma_qdo,
+            self.qdo_tile,
+            self.qdo_acc_depth,
+            mma_wdv,
+            self.wdv_tile,
+            self.wdv_acc_depth,
+        )
+
+        # --- SMEM staged layouts ---
+        tma_ld = cpasync.CopyBulkTensorTileG2SOp(self.cta_group)
+        tma_st = cpasync.CopyBulkTensorTileS2GOp()
+
+        # MMA1 A-operand: k — (BT, BK) K-major staged
+        s_k_staged = sm100_utils.make_smem_layout_a(
+            mma_dv,
+            self.dv_tile,
+            self.io_type,
+            self.k_depth,
+        )
+        # MMA1 B-operand: dh — (BK, BV) K-major, 1-stage (CUDA R2S)
+        s_dhb_staged = sm100_utils.make_smem_layout_b(
+            mma_dv,
+            self.dv_tile,
+            self.io_type,
+            1,
+        )
+        # R2S store view for dh B-operand
+        s_dhb_store_staged = sm100_utils.make_smem_layout_epi(
+            self.io_type,
+            utils.LayoutEnum.COL_MAJOR,
+            (self.BK, self.BV),
+            1,
+        )
+
+        # MMA2 A-operand: q^T — (BK, BT) MN-major staged
+        s_q_staged = sm100_utils.make_smem_layout_a(
+            mma_qdo,
+            self.qdo_tile,
+            self.io_type,
+            self.q_depth,
+        )
+        # MMA2 B-operand: do — (BT, BV) MN-major, 1-stage (CUDA R2S, masked).
+        # Mirrors the dv2 B-operand path but MN-major: TMA loads do into sDoEpi,
+        # the COMPUTE warp masks the partial-chunk over-read in registers and
+        # R2S's into sDo, so the MMA warp does no masking on its critical path.
+        s_do_staged = sm100_utils.make_smem_layout_b(
+            mma_qdo,
+            self.qdo_tile,
+            self.io_type,
+            1,
+        )
+        # R2S store view for do B-operand. do is MN-major (N=BV contiguous), so
+        # the alias is ROW_MAJOR (BV inner) — NOT COL_MAJOR like the K-major dh/
+        # dv2 B-operands. This matches the make_smem_layout_b swizzle (SW32 for
+        # bv16 / SW64 for bv32).
+        s_do_store_staged = sm100_utils.make_smem_layout_epi(
+            self.io_type,
+            utils.LayoutEnum.ROW_MAJOR,
+            (self.BT, self.BV),
+            1,
+        )
+        # do load: (V, T) epilogue layout for TMA load into CUDA warps
+        s_doepi_staged = sm100_utils.make_smem_layout_epi(
+            self.io_type,
+            utils.LayoutEnum.COL_MAJOR,
+            (self.BV, self.BT),
+            self.do_depth,
+        )
+
+        # MMA3 A-operand: w^T — (BK, BT) MN-major staged
+        s_w_staged = sm100_utils.make_smem_layout_a(
+            mma_wdv,
+            self.wdv_tile,
+            self.io_type,
+            self.w_depth,
+        )
+        # MMA3 B-operand: dv2 — (BT, BV) K-major, 1-stage (CUDA R2S)
+        s_dv2b_staged = sm100_utils.make_smem_layout_b(
+            mma_wdv,
+            self.wdv_tile,
+            self.io_type,
+            1,
+        )
+        # R2S store view for dv2 B-operand
+        s_dv2b_store_staged = sm100_utils.make_smem_layout_epi(
+            self.io_type,
+            utils.LayoutEnum.COL_MAJOR,
+            (self.BT, self.BV),
+            1,
+        )
+
+        # dv_in load: (V, T) epilogue layout for TMA load into CUDA warps
+        s_dvin_staged = sm100_utils.make_smem_layout_epi(
+            self.io_type,
+            utils.LayoutEnum.COL_MAJOR,
+            (self.BV, self.BT),
+            self.dv_in_depth,
+        )
+
+        # dh snapshot epilogue: (V, K) for Store warp TMA S2G
+        s_dh_epi_staged = sm100_utils.make_smem_layout_epi(
+            self.io_type,
+            utils.LayoutEnum.COL_MAJOR,
+            (self.BV, self.BK),
+            self.dh_epi_depth,
+        )
+        # R2S dh → sH_epi (ROW_MAJOR transposed for stmatrix)
+        s_dh_r2s_staged = sm100_utils.make_smem_layout_epi(
+            self.io_type,
+            utils.LayoutEnum.ROW_MAJOR,
+            (self.BK, self.BV),
+            self.dh_epi_depth,
+        )
+
+        # dv2 epilogue: (V, T) for Store warp TMA S2G
+        s_dv2_epi_staged = sm100_utils.make_smem_layout_epi(
+            self.io_type,
+            utils.LayoutEnum.COL_MAJOR,
+            (self.BV, self.BT),
+            self.dv2_epi_depth,
+        )
+        # R2S dv → sVst (ROW_MAJOR transposed for stmatrix)
+        s_dv2_r2s_staged = sm100_utils.make_smem_layout_epi(
+            self.io_type,
+            utils.LayoutEnum.ROW_MAJOR,
+            (self.BT, self.BV),
+            self.dv2_epi_depth,
+        )
+
+        clust_lay = cute.tiled_divide(
+            cute.make_layout(self.cluster),
+            (mma_dv.thr_id.shape,),
+        )
+
+        # --- TMA descriptors ---
+        # k: A-operand of MMA1 (K-major)
+        s_k_one = cute.select(s_k_staged, mode=[0, 1, 2])
+        atom_k, desc_k = cute.nvgpu.make_tiled_tma_atom_A(
+            tma_ld,
+            g_k,
+            s_k_one,
+            self.dv_tile,
+            mma_dv,
+            clust_lay.shape,
+        )
+        # q^T: A-operand of MMA2 (MN-major)
+        s_q_one = cute.select(s_q_staged, mode=[0, 1, 2])
+        atom_q, desc_q = cute.nvgpu.make_tiled_tma_atom_A(
+            tma_ld,
+            g_qt,
+            s_q_one,
+            self.qdo_tile,
+            mma_qdo,
+            clust_lay.shape,
+        )
+        # do: epilogue-style TMA load into sDoEpi (masked + R2S → sDo for MMA2)
+        s_doepi_one = cute.select(s_doepi_staged, mode=[0, 1])
+        atom_doepi, desc_doepi = cpasync.make_tiled_tma_atom(
+            tma_ld,
+            g_do_vt,
+            s_doepi_one,
+            (self.BV, self.BT),
+        )
+        # w^T: A-operand of MMA3 (MN-major)
+        s_w_one = cute.select(s_w_staged, mode=[0, 1, 2])
+        atom_w, desc_w = cute.nvgpu.make_tiled_tma_atom_A(
+            tma_ld,
+            g_wt,
+            s_w_one,
+            self.wdv_tile,
+            mma_wdv,
+            clust_lay.shape,
+        )
+
+        # dv_in: epilogue-style TMA load
+        s_dvin_one = cute.select(s_dvin_staged, mode=[0, 1])
+        atom_dvin, desc_dvin = cpasync.make_tiled_tma_atom(
+            tma_ld,
+            g_dv_in_t,
+            s_dvin_one,
+            (self.BV, self.BT),
+        )
+
+        # dh_out store TMA
+        s_dh_epi_one = cute.select(s_dh_epi_staged, mode=[0, 1])
+        atom_dhst, desc_dhst = cpasync.make_tiled_tma_atom(
+            tma_st,
+            g_dh_out_t,
+            s_dh_epi_one,
+            (self.BV, self.BK),
+        )
+
+        # dv2 store TMA
+        s_dv2_epi_one = cute.select(s_dv2_epi_staged, mode=[0, 1])
+        atom_dv2st, desc_dv2st = cpasync.make_tiled_tma_atom(
+            tma_st,
+            g_dv2_t,
+            s_dv2_epi_one,
+            (self.BV, self.BT),
+        )
+
+        # gk TMA: BK×1 fp32 tile (last timestep per chunk)
+        s_gk_2d = cute.make_layout((self.BK, 1))
+        atom_gk, desc_gk = cpasync.make_tiled_tma_atom(
+            tma_ld,
+            g_gk_k,
+            s_gk_2d,
+            (self.BK, 1),
+        )
+
+        # CopyUniversal for varlen partial-chunk dv2 store
+        cp_bits = 128
+        cp_elems = cp_bits // self.io_type.width
+        copy_atom_uni = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(),
+            self.io_type,
+            num_bits_per_copy=cp_bits,
+        )
+        vn_thr_d0 = self.BV // cp_elems
+        vn_thr_d1 = self.WARP_SZ // vn_thr_d0
+        vn_thr_lay = cute.make_ordered_layout((vn_thr_d0, vn_thr_d1), order=(0, 1))
+        vn_val_lay = cute.make_layout((cp_elems, 1))
+        copy_dv2_tiled = cute.make_tiled_copy_tv(copy_atom_uni, vn_thr_lay, vn_val_lay)
+
+        cu_lens = cute.make_tensor(cup, cute.make_layout((B + 1,)))
+        ch_offs = cute.make_tensor(cop, cute.make_layout((B + 1,)))
+        ns_t = cute.make_tensor(nsp, cute.make_layout((1,)))
+
+        # TMA byte counts
+        self.k_bytes = cute.size_in_bytes(self.io_type, s_k_one)
+        self.q_bytes = cute.size_in_bytes(self.io_type, s_q_one)
+        self.do_bytes = cute.size_in_bytes(self.io_type, s_doepi_one)
+        self.w_bytes = cute.size_in_bytes(self.io_type, s_w_one)
+        self.dvin_bytes = cute.size_in_bytes(self.io_type, s_dvin_one)
+        self.gk_bytes = self.BK * 4  # 512 bytes
+
+        # --- SharedStorage struct ---
+        @cute.struct
+        class Shared:
+            # Pipeline barriers (each needs depth * 2 Int64s)
+            bar_k: cute.struct.MemRange[Int64, self.k_depth * 2]
+            bar_q: cute.struct.MemRange[Int64, self.q_depth * 2]
+            bar_doepi: cute.struct.MemRange[Int64, self.do_depth * 2]
+            bar_w: cute.struct.MemRange[Int64, self.w_depth * 2]
+            bar_dvin: cute.struct.MemRange[Int64, self.dv_in_depth * 2]
+            bar_gk: cute.struct.MemRange[Int64, self.gk_depth * 2]
+            bar_gk_rdy: cute.struct.MemRange[Int64, self.gk_depth * 2]
+            bar_dhb: cute.struct.MemRange[Int64, 1 * 2]  # dh B-operand CUDA→MMA
+            bar_dv: cute.struct.MemRange[Int64, self.dv_acc_depth * 2]  # MMA1 done
+            bar_qdo: cute.struct.MemRange[Int64, self.qdo_acc_depth * 2]  # MMA2 done
+            bar_dob: cute.struct.MemRange[Int64, 1 * 2]  # do B-operand CUDA→MMA
+            bar_dv2b: cute.struct.MemRange[Int64, 1 * 2]  # dv2 B-operand CUDA→MMA
+            bar_wdv: cute.struct.MemRange[Int64, self.wdv_acc_depth * 2]  # MMA3 done
+            bar_dh_epi: cute.struct.MemRange[Int64, self.dh_epi_depth * 2]
+            bar_dv2_epi: cute.struct.MemRange[Int64, self.dv2_epi_depth * 2]
+            tmem_buf: Int32
+            # SMEM data buffers
+            sK: cute.struct.Align[
+                cute.struct.MemRange[self.io_type, cute.cosize(s_k_staged)], self.align
+            ]
+            sDhb: cute.struct.Align[
+                cute.struct.MemRange[self.io_type, cute.cosize(s_dhb_staged)],
+                self.align,
+            ]
+            sQ: cute.struct.Align[
+                cute.struct.MemRange[self.io_type, cute.cosize(s_q_staged)], self.align
+            ]
+            sDo: cute.struct.Align[
+                cute.struct.MemRange[self.io_type, cute.cosize(s_do_staged)], self.align
+            ]
+            sDoEpi: cute.struct.Align[
+                cute.struct.MemRange[self.io_type, cute.cosize(s_doepi_staged)],
+                self.align,
+            ]
+            sW: cute.struct.Align[
+                cute.struct.MemRange[self.io_type, cute.cosize(s_w_staged)], self.align
+            ]
+            sDv2b: cute.struct.Align[
+                cute.struct.MemRange[self.io_type, cute.cosize(s_dv2b_staged)],
+                self.align,
+            ]
+            sDvIn: cute.struct.Align[
+                cute.struct.MemRange[self.io_type, cute.cosize(s_dvin_staged)],
+                self.align,
+            ]
+            sDhEpi: cute.struct.Align[
+                cute.struct.MemRange[self.io_type, cute.cosize(s_dh_epi_staged)],
+                self.align,
+            ]
+            sDv2Epi: cute.struct.Align[
+                cute.struct.MemRange[self.io_type, cute.cosize(s_dv2_epi_staged)],
+                self.align,
+            ]
+            sGK: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, self.BK * self.gk_depth], 128
+            ]
+            sGK_exp: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, self.BK * self.gk_depth], 128
+            ]
+
+        self.shared_type = Shared
+        self.grid = self._launch_grid(B, H, V)
+
+        self.kernel(
+            mma_dv,
+            mma_qdo,
+            mma_wdv,
+            atom_k,
+            desc_k,
+            atom_q,
+            desc_q,
+            atom_doepi,
+            desc_doepi,
+            atom_w,
+            desc_w,
+            atom_dvin,
+            desc_dvin,
+            atom_dhst,
+            desc_dhst,
+            atom_dv2st,
+            desc_dv2st,
+            atom_gk,
+            desc_gk,
+            copy_dv2_tiled,
+            g_dht,
+            g_dh0_t,
+            g_dv2,
+            s_k_staged,
+            s_dhb_staged,
+            s_dhb_store_staged,
+            s_q_staged,
+            s_do_staged,
+            s_do_store_staged,
+            s_doepi_staged,
+            s_w_staged,
+            s_dv2b_staged,
+            s_dv2b_store_staged,
+            s_dvin_staged,
+            s_dh_epi_staged,
+            s_dh_r2s_staged,
+            s_dv2_epi_staged,
+            s_dv2_r2s_staged,
+            cu_lens,
+            ch_offs,
+            ns_t,
+            problem_shape,
+            scale,
+            use_gk,
+            use_dht,
+            use_dh0,
+        ).launch(
+            grid=self.grid,
+            block=[self.CTA_THREADS, 1, 1],
+            cluster=self.cluster,
+            stream=stream,
+            min_blocks_per_mp=self.min_occ,
+        )
+
+    # ------------------------------------------------------------------
+    # Device kernel: warp-specialized backward recurrence
+    # ------------------------------------------------------------------
+
+    @cute.kernel
+    def kernel(
+        self,
+        mma_dv: cute.TiledMma,
+        mma_qdo: cute.TiledMma,
+        mma_wdv: cute.TiledMma,
+        atom_k: cute.CopyAtom,
+        desc_k: cute.Tensor,
+        atom_q: cute.CopyAtom,
+        desc_q: cute.Tensor,
+        atom_doepi: cute.CopyAtom,
+        desc_doepi: cute.Tensor,
+        atom_w: cute.CopyAtom,
+        desc_w: cute.Tensor,
+        atom_dvin: cute.CopyAtom,
+        desc_dvin: cute.Tensor,
+        atom_dhst: cute.CopyAtom,
+        desc_dhst: cute.Tensor,
+        atom_dv2st: cute.CopyAtom,
+        desc_dv2st: cute.Tensor,
+        atom_gk: cute.CopyAtom,
+        desc_gk: cute.Tensor,
+        copy_dv2_tiled: cute.TiledCopy,
+        g_dht: cute.Tensor,
+        g_dh0_t: cute.Tensor,
+        g_dv2: cute.Tensor,
+        s_k_staged: cute.ComposedLayout,
+        s_dhb_staged: cute.ComposedLayout,
+        s_dhb_store_staged: cute.ComposedLayout,
+        s_q_staged: cute.ComposedLayout,
+        s_do_staged: cute.ComposedLayout,
+        s_do_store_staged: cute.ComposedLayout,
+        s_doepi_staged: cute.ComposedLayout,
+        s_w_staged: cute.ComposedLayout,
+        s_dv2b_staged: cute.ComposedLayout,
+        s_dv2b_store_staged: cute.ComposedLayout,
+        s_dvin_staged: cute.ComposedLayout,
+        s_dh_epi_staged: cute.ComposedLayout,
+        s_dh_r2s_staged: cute.ComposedLayout,
+        s_dv2_epi_staged: cute.ComposedLayout,
+        s_dv2_r2s_staged: cute.ComposedLayout,
+        cu_seqlens: cute.Tensor,
+        chunk_offsets: cute.Tensor,
+        num_seqs: cute.Tensor,
+        problem_shape: tuple[Int32, Int32, Int32, Int32, Int32],
+        scale: Float32,
+        use_gk: Int32,
+        use_dht: Int32,
+        use_dh0: Int32,
+    ):
+        warp_id = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        tid, _, _ = cute.arch.thread_idx()
+
+        # Prefetch TMA descriptors (load warp)
+        if warp_id == self.LOAD_WARP_ID:
+            cpasync.prefetch_descriptor(atom_k)
+            cpasync.prefetch_descriptor(atom_q)
+            cpasync.prefetch_descriptor(atom_doepi)
+            cpasync.prefetch_descriptor(atom_w)
+            cpasync.prefetch_descriptor(atom_dvin)
+            cpasync.prefetch_descriptor(atom_gk)
+
+        # SMEM allocation
+        sa = utils.SmemAllocator()
+        sm = sa.allocate(self.shared_type)
+
+        gk_buf = sm.sGK.get_tensor(cute.make_layout((self.BK, self.gk_depth)))
+        gk_exp_buf = sm.sGK_exp.get_tensor(cute.make_layout((self.BK, self.gk_depth)))
+        gk_3d = sm.sGK.get_tensor(
+            cute.make_layout(
+                (self.BK, 1, self.gk_depth),
+                stride=(1, self.BK, self.BK),
+            )
+        )
+
+        # #
+        # Pipeline creation
+        #
+
+        # k → MMA1 (TmaUmma, deep pipeline)
+        pk_P, pk_C = pipeline.PipelineTmaUmma.create(
+            num_stages=self.k_depth,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            tx_count=self.k_bytes,
+            barrier_storage=sm.bar_k.data_ptr(),
+        ).make_participants()
+
+        # dh B-operand → MMA1 (AsyncUmma, 1-stage: CUDA R2S → MMA reads)
+        pdhb_P, pdhb_C = pipeline.PipelineAsyncUmma.create(
+            num_stages=1,
+            producer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, self.WARP_SZ * len(self.CUDA_WARP_IDS)
+            ),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            barrier_storage=sm.bar_dhb.data_ptr(),
+        ).make_participants()
+
+        # MMA1 done → CUDA (UmmaAsync)
+        pdv_P, pdv_C = pipeline.PipelineUmmaAsync.create(
+            num_stages=self.dv_acc_depth,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, self.WARP_SZ * len(self.CUDA_WARP_IDS)
+            ),
+            barrier_storage=sm.bar_dv.data_ptr(),
+        ).make_participants()
+
+        # q → MMA2 (TmaUmma)
+        pq_P, pq_C = pipeline.PipelineTmaUmma.create(
+            num_stages=self.q_depth,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            tx_count=self.q_bytes,
+            barrier_storage=sm.bar_q.data_ptr(),
+        ).make_participants()
+
+        # do → CUDA (TmaAsync): TMA loads do into sDoEpi for the COMPUTE warp
+        pdoepi_P, pdoepi_C = pipeline.PipelineTmaAsync.create(
+            num_stages=self.do_depth,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, len(self.CUDA_WARP_IDS)
+            ),
+            tx_count=self.do_bytes,
+            barrier_storage=sm.bar_doepi.data_ptr(),
+        ).make_participants()
+
+        # do B-operand → MMA2 (AsyncUmma, 1-stage: CUDA R2S → MMA reads)
+        pdob_P, pdob_C = pipeline.PipelineAsyncUmma.create(
+            num_stages=1,
+            producer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, self.WARP_SZ * len(self.CUDA_WARP_IDS)
+            ),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            barrier_storage=sm.bar_dob.data_ptr(),
+        ).make_participants()
+
+        # MMA2 done → CUDA (UmmaAsync)
+        pqdo_P, pqdo_C = pipeline.PipelineUmmaAsync.create(
+            num_stages=self.qdo_acc_depth,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, self.WARP_SZ * len(self.CUDA_WARP_IDS)
+            ),
+            barrier_storage=sm.bar_qdo.data_ptr(),
+        ).make_participants()
+
+        # w → MMA3 (TmaUmma)
+        pw_P, pw_C = pipeline.PipelineTmaUmma.create(
+            num_stages=self.w_depth,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            tx_count=self.w_bytes,
+            barrier_storage=sm.bar_w.data_ptr(),
+        ).make_participants()
+
+        # dv2 B-operand → MMA3 (AsyncUmma, 1-stage: CUDA R2S → MMA reads)
+        pdv2b_P, pdv2b_C = pipeline.PipelineAsyncUmma.create(
+            num_stages=1,
+            producer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, self.WARP_SZ * len(self.CUDA_WARP_IDS)
+            ),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            barrier_storage=sm.bar_dv2b.data_ptr(),
+        ).make_participants()
+
+        # MMA3 done → CUDA (UmmaAsync)
+        pwdv_P, pwdv_C = pipeline.PipelineUmmaAsync.create(
+            num_stages=self.wdv_acc_depth,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, self.WARP_SZ * len(self.CUDA_WARP_IDS)
+            ),
+            barrier_storage=sm.bar_wdv.data_ptr(),
+        ).make_participants()
+
+        # dv_in load → CUDA (TmaAsync)
+        # NOTE: PipelineTmaAsync uses warp-elected barrier arrives in release(),
+        # so consumer_group = num_warps (4), NOT num_threads (128).
+        pdvin_P, pdvin_C = pipeline.PipelineTmaAsync.create(
+            num_stages=self.dv_in_depth,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, len(self.CUDA_WARP_IDS)
+            ),
+            tx_count=self.dvin_bytes,
+            barrier_storage=sm.bar_dvin.data_ptr(),
+        ).make_participants()
+
+        # dh epi → Store warp (Async, 2-stage)
+        pdh_epi_P, pdh_epi_C = pipeline.PipelineAsync.create(
+            num_stages=self.dh_epi_depth,
+            producer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, self.WARP_SZ * len(self.CUDA_WARP_IDS)
+            ),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, self.WARP_SZ
+            ),
+            barrier_storage=sm.bar_dh_epi.data_ptr(),
+        ).make_participants()
+
+        # dv2 epi → Store warp (Async, 2-stage)
+        pdv2_epi_P, pdv2_epi_C = pipeline.PipelineAsync.create(
+            num_stages=self.dv2_epi_depth,
+            producer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, self.WARP_SZ * len(self.CUDA_WARP_IDS)
+            ),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, self.WARP_SZ
+            ),
+            barrier_storage=sm.bar_dv2_epi.data_ptr(),
+        ).make_participants()
+
+        # gk TMA → GK warp (TmaAsync, 2-stage)
+        pgk_P, pgk_C = pipeline.PipelineTmaAsync.create(
+            num_stages=self.gk_depth,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            tx_count=self.gk_bytes,
+            barrier_storage=sm.bar_gk.data_ptr(),
+        ).make_participants()
+
+        # gk ready → CUDA (Async, 2-stage)
+        pgk_rdy_P, pgk_rdy_C = pipeline.PipelineAsync.create(
+            num_stages=self.gk_depth,
+            producer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, self.WARP_SZ
+            ),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, self.WARP_SZ * len(self.CUDA_WARP_IDS)
+            ),
+            barrier_storage=sm.bar_gk_rdy.data_ptr(),
+        ).make_participants()
+
+        # #
+        # TMEM allocation
+        #
+        tmem_bar = pipeline.NamedBarrier(barrier_id=1, num_threads=self.CTA_THREADS)
+        tmem = utils.TmemAllocator(
+            sm.tmem_buf,
+            barrier_for_retrieve=tmem_bar,
+            allocator_warp_id=self.LOAD_WARP_ID,
+        )
+        tmem.allocate(self.tm_tot)
+        tmem.wait_for_alloc()
+        tp = tmem.retrieve_ptr(self.acc_type)
+
+        # #
+        # SMEM view tensors
+        #
+        sK = sm.sK.get_tensor(s_k_staged.outer, swizzle=s_k_staged.inner)
+        sDhb = sm.sDhb.get_tensor(s_dhb_staged.outer, swizzle=s_dhb_staged.inner)
+        sDhb_store = sm.sDhb.get_tensor(
+            s_dhb_store_staged.outer, swizzle=s_dhb_store_staged.inner
+        )
+        sQ = sm.sQ.get_tensor(s_q_staged.outer, swizzle=s_q_staged.inner)
+        sDo = sm.sDo.get_tensor(s_do_staged.outer, swizzle=s_do_staged.inner)
+        sDo_store = sm.sDo.get_tensor(
+            s_do_store_staged.outer, swizzle=s_do_store_staged.inner
+        )
+        sDoEpi = sm.sDoEpi.get_tensor(
+            s_doepi_staged.outer, swizzle=s_doepi_staged.inner
+        )
+        sW = sm.sW.get_tensor(s_w_staged.outer, swizzle=s_w_staged.inner)
+        sDv2b = sm.sDv2b.get_tensor(s_dv2b_staged.outer, swizzle=s_dv2b_staged.inner)
+        sDv2b_store = sm.sDv2b.get_tensor(
+            s_dv2b_store_staged.outer, swizzle=s_dv2b_store_staged.inner
+        )
+        sDvIn = sm.sDvIn.get_tensor(s_dvin_staged.outer, swizzle=s_dvin_staged.inner)
+        sDhEpi = sm.sDhEpi.get_tensor(
+            s_dh_epi_staged.outer, swizzle=s_dh_epi_staged.inner
+        )
+        sDhEpi_store = sm.sDhEpi.get_tensor(
+            s_dh_r2s_staged.outer, swizzle=s_dh_r2s_staged.inner
+        )
+        sDv2Epi = sm.sDv2Epi.get_tensor(
+            s_dv2_epi_staged.outer, swizzle=s_dv2_epi_staged.inner
+        )
+        sDv2Epi_store = sm.sDv2Epi.get_tensor(
+            s_dv2_r2s_staged.outer, swizzle=s_dv2_r2s_staged.inner
+        )
+
+        # #
+        # MMA fragments — SS-mode: both A and B from SMEM, accumulators in TMEM
+        #
+
+        # MMA1: k (A) × dh (B) → dv_acc
+        t_k_a = mma_dv.make_fragment_A(sK)
+        t_dhb_b = mma_dv.make_fragment_B(sDhb)
+        dv_sh = mma_dv.partition_shape_C(self.dv_tile[:2])
+        dv_fk = mma_dv.make_fragment_C(cute.append(dv_sh, self.dv_acc_depth))
+        t_dv_acc = cute.make_tensor(tp + self.tm_dv, dv_fk.layout)
+
+        # MMA2: q^T (A) × do (B) → qdo_acc
+        t_q_a = mma_qdo.make_fragment_A(sQ)
+        t_do_b = mma_qdo.make_fragment_B(sDo)
+        qdo_sh = mma_qdo.partition_shape_C(self.qdo_tile[:2])
+        qdo_fk = mma_qdo.make_fragment_C(cute.append(qdo_sh, self.qdo_acc_depth))
+        t_qdo_acc = cute.make_tensor(tp + self.tm_qdo, qdo_fk.layout)
+
+        # MMA3: w (A) × dv2 (B) → wdv_acc
+        t_w_a = mma_wdv.make_fragment_A(sW)
+        t_dv2b_b = mma_wdv.make_fragment_B(sDv2b)
+        wdv_sh = mma_wdv.partition_shape_C(self.wdv_tile[:2])
+        wdv_fk = mma_wdv.make_fragment_C(cute.append(wdv_sh, self.wdv_acc_depth))
+        t_wdv_acc = cute.make_tensor(tp + self.tm_wdv, wdv_fk.layout)
+
+        # #
+        # Block indices
+        #
+        B, T, H, K, V = problem_shape
+        BT = self.BT
+
+        # Persistent 1D grid for both varlen and non-varlen (CUDA graph compatible)
+        bx = cute.arch.block_idx()[0]
+        gdx = cute.arch.grid_dim()[0]
+        n_vtiles = (V + self.BV - 1) // self.BV
+
+        if cutlass.const_expr(self.varlen):
+            actual_seqs = num_seqs[0]
+            w_tiles = n_vtiles * H * actual_seqs
+        else:
+            w_tiles = n_vtiles * H * B
+
+        n_iters = (w_tiles - bx + gdx - 1) // gdx
+        w_idx = Int32(0)
+        v_tile = Int32(0)
+        h_idx = Int32(0)
+        seq_idx = Int32(0)
+        bos = Int32(0)
+        seq_len = Int32(0)
+        NT = Int32(0)
+        db = Int32(0)
+        co = Int32(0)
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  CUDA CORE (warps 0-3) — dh state owner
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_id in self.CUDA_WARP_IDS:
+            cute.arch.setmaxregister_increase(self.cuda_regs)
+            local_tid = tid % (self.WARP_SZ * len(self.CUDA_WARP_IDS))
+
+            # --- T2R setup: read MMA1 (dv) accumulator (BT,BV fp32) from TMEM ---
+            t2r_dv_atom = cute.make_copy_atom(
+                tcgen05.Ld16x256bOp(
+                    tcgen05.Repetition(self.BV // 8), tcgen05.Pack.NONE
+                ),
+                self.acc_type,
+            )
+            dv_flat = t_dv_acc[((None, None), 0, 0, None)]
+            fake_s_dv = cute.make_tensor(
+                cute.make_ptr(self.io_type, 0, cute.AddressSpace.smem),
+                cute.dice(self.dv_tile, (1, 1, None)),
+            )
+            tc_t2r_dv = tcgen05.make_tmem_copy(t2r_dv_atom, dv_flat[(None, None, 0)])
+            sl_dv = tc_t2r_dv.get_slice(local_tid)
+            p_t_dv = sl_dv.partition_S(dv_flat)
+            p_s_dv = sl_dv.partition_D(fake_s_dv)
+
+            # --- T2R setup: read MMA2 (qdo) accumulator (BK,BV fp32) from TMEM ---
+            t2r_qdo_atom = cute.make_copy_atom(
+                tcgen05.Ld16x256bOp(
+                    tcgen05.Repetition(self.BV // 8), tcgen05.Pack.NONE
+                ),
+                self.acc_type,
+            )
+            qdo_flat = t_qdo_acc[((None, None), 0, 0, None)]
+            fake_s_qdo = cute.make_tensor(
+                cute.make_ptr(self.io_type, 0, cute.AddressSpace.smem),
+                cute.dice(self.qdo_tile, (1, 1, None)),
+            )
+            tc_t2r_qdo = tcgen05.make_tmem_copy(t2r_qdo_atom, qdo_flat[(None, None, 0)])
+            sl_qdo = tc_t2r_qdo.get_slice(local_tid)
+            p_t_qdo = sl_qdo.partition_S(qdo_flat)
+            p_s_qdo = sl_qdo.partition_D(fake_s_qdo)
+
+            # --- T2R setup: read MMA3 (wdv) accumulator (BK,BV fp32) from TMEM ---
+            t2r_wdv_atom = cute.make_copy_atom(
+                tcgen05.Ld16x256bOp(
+                    tcgen05.Repetition(self.BV // 8), tcgen05.Pack.NONE
+                ),
+                self.acc_type,
+            )
+            wdv_flat = t_wdv_acc[((None, None), 0, 0, None)]
+            fake_s_wdv = cute.make_tensor(
+                cute.make_ptr(self.io_type, 0, cute.AddressSpace.smem),
+                cute.dice(self.wdv_tile, (1, 1, None)),
+            )
+            tc_t2r_wdv = tcgen05.make_tmem_copy(t2r_wdv_atom, wdv_flat[(None, None, 0)])
+            sl_wdv = tc_t2r_wdv.get_slice(local_tid)
+            p_t_wdv = sl_wdv.partition_S(wdv_flat)
+            p_s_wdv = sl_wdv.partition_D(fake_s_wdv)
+
+            # dh state lives in registers partitioned like qdo/wdv (BK, BV)
+            st = cute.make_rmem_tensor(p_s_qdo.shape, self.acc_type)
+
+            # Identity tensors for coordinate mapping
+            # dv tile: (BT, BV) coords
+            id_tv = cute.make_identity_tensor(cute.dice(self.dv_tile, (1, 1, None)))
+            coords_tv = sl_dv.partition_D(id_tv)
+            # qdo/wdv tile: (BK, BV) coords — dh state uses this
+            id_kv = cute.make_identity_tensor(cute.dice(self.qdo_tile, (1, 1, None)))
+            coords_kv = sl_qdo.partition_D(id_kv)
+
+            # R2S dh → sDhb (COL_MAJOR, partition matches T2R qdo)
+            r2s_atom_dhb = sm100_utils.get_smem_store_op(
+                utils.LayoutEnum.COL_MAJOR,
+                self.io_type,
+                self.acc_type,
+                tc_t2r_qdo,
+            )
+            tc_r2s_dhb = cute.make_tiled_copy_D(r2s_atom_dhb, tc_t2r_qdo)
+            thr_r2s_dhb = tc_r2s_dhb.get_slice(local_tid)
+
+            # R2S dh → sDhEpi (ROW_MAJOR, transposed for TMA store)
+            r2s_atom_dh_epi = sm100_utils.get_smem_store_op(
+                utils.LayoutEnum.ROW_MAJOR,
+                self.io_type,
+                self.acc_type,
+                tc_t2r_qdo,
+            )
+            tc_r2s_dh_epi = cute.make_tiled_copy_D(r2s_atom_dh_epi, tc_t2r_qdo)
+            thr_r2s_dh_epi = tc_r2s_dh_epi.get_slice(local_tid)
+
+            # R2S dv2 → sDv2b (COL_MAJOR, partition matches T2R dv)
+            r2s_atom_dv2b = sm100_utils.get_smem_store_op(
+                utils.LayoutEnum.COL_MAJOR,
+                self.io_type,
+                self.acc_type,
+                tc_t2r_dv,
+            )
+            tc_r2s_dv2b = cute.make_tiled_copy_D(r2s_atom_dv2b, tc_t2r_dv)
+            thr_r2s_dv2b = tc_r2s_dv2b.get_slice(local_tid)
+
+            # R2S dv2 → sDv2Epi (ROW_MAJOR, transposed for TMA store)
+            r2s_atom_dv2_epi = sm100_utils.get_smem_store_op(
+                utils.LayoutEnum.ROW_MAJOR,
+                self.io_type,
+                self.acc_type,
+                tc_t2r_dv,
+            )
+            tc_r2s_dv2_epi = cute.make_tiled_copy_D(r2s_atom_dv2_epi, tc_t2r_dv)
+            thr_r2s_dv2_epi = tc_r2s_dv2_epi.get_slice(local_tid)
+
+            # ========== Tile loop ==========
+            tile_idx = Int32(0)
+            has_work = tile_idx < n_iters
+
+            while has_work:
+                # Decode work-unit → tile coordinates (persistent scheduling)
+                w_idx = bx + tile_idx * gdx
+                v_tile = w_idx % n_vtiles
+                tmp = w_idx // n_vtiles
+                h_idx = tmp % H
+                seq_idx = tmp // H
+                if cutlass.const_expr(self.varlen):
+                    bos = cu_seqlens[seq_idx]
+                    seq_len = cu_seqlens[seq_idx + 1] - bos
+                else:
+                    bos = Int32(0)
+                    seq_len = T
+                NT = (seq_len + BT - 1) // BT
+                db = Int32(0) if cutlass.const_expr(self.varlen) else seq_idx
+
+                # Initialize dh from dht or zeros
+                if use_dht:
+                    gDht_slice = g_dht[None, None, (h_idx, seq_idx)]
+                    for ei in cutlass.range(cute.size(st), unroll_full=True):
+                        kc, vc = coords_kv[ei]
+                        st[ei] = gDht_slice[(kc, vc % self.BV + v_tile * self.BV)]
+                else:
+                    for ei in cutlass.range(cute.size(st), unroll_full=True):
+                        st[ei] = Float32(0.0)
+
+                # ========== Chunk loop: reverse order (NT-1 down to 0) ==========
+                for ct in cutlass.range(0, NT, unroll=0):
+                    rev_ct = NT - 1 - ct  # reverse index
+
+                    # ---- Phase 1: R2S dh→sDhb + sDhEpi (snapshot dh state) ----
+                    dhb_h = pdhb_P.acquire_and_advance()
+                    dh_epi_h = pdh_epi_P.acquire_and_advance()
+                    st_bf16 = cute.make_rmem_tensor(st.shape, self.io_type)
+                    st_bf16.store(st.load().to(self.io_type))
+
+                    # R2S dh → sDhb (B-operand for MMA1)
+                    r2s_src_dhb = tc_r2s_dhb.retile(st_bf16)
+                    dst_dhb = thr_r2s_dhb.partition_D(sDhb_store[(None, None, 0)])
+                    cute.copy(tc_r2s_dhb, r2s_src_dhb, dst_dhb)
+                    cute.arch.fence_proxy("async.shared", space="cta")
+                    dhb_h.commit()
+
+                    # R2S dh → sDhEpi (for Store warp TMA S2G)
+                    r2s_src_dh = tc_r2s_dh_epi.retile(st_bf16)
+                    dst_dh = thr_r2s_dh_epi.partition_D(
+                        sDhEpi_store[(None, None, dh_epi_h.index)]
+                    )
+                    cute.copy(tc_r2s_dh_epi, r2s_src_dh, dst_dh)
+                    cute.arch.fence_proxy("async.shared", space="cta")
+                    dh_epi_h.commit()
+
+                    # ---- Produce masked do B-operand for MMA2 ----
+                    # Mirrors the dv2 mask: read the TMA-loaded do tile, zero the
+                    # partial chunk's over-read token rows in registers (reusing
+                    # valid/coords_tv from the dv_reg mask), then R2S into sDo.
+                    # do is MN-major, so we use the ROW_MAJOR R2S atom
+                    # tc_r2s_dv2_epi (the same one used for the dv2 epi store), not
+                    # the COL_MAJOR tc_r2s_dv2b used for the K-major dv2 B-operand.
+                    dob_h = pdob_P.acquire_and_advance()
+                    doepi_h = pdoepi_C.wait_and_advance()
+                    do_reg = cute.make_rmem_tensor(p_s_dv.shape, self.acc_type)
+                    for ei in cutlass.range_constexpr(cute.size(coords_tv)):
+                        tc, vc = coords_tv[ei]
+                        do_reg[ei] = sDoEpi[(vc, tc, doepi_h.index)].to(self.acc_type)
+                    doepi_h.release()
+                    if cutlass.const_expr(self.varlen):
+                        valid = seq_len - rev_ct * self.BT
+                        if valid < self.BT:
+                            for ei in cutlass.range_constexpr(cute.size(coords_tv)):
+                                tc, vc = coords_tv[ei]
+                                if tc >= valid:
+                                    do_reg[ei] = Float32(0.0)
+                    do_bf16 = cute.make_rmem_tensor(do_reg.shape, self.io_type)
+                    do_bf16.store(do_reg.load().to(self.io_type))
+                    r2s_src_dob = tc_r2s_dv2_epi.retile(do_bf16)
+                    dst_dob = thr_r2s_dv2_epi.partition_D(sDo_store[(None, None, 0)])
+                    cute.copy(tc_r2s_dv2_epi, r2s_src_dob, dst_dob)
+                    cute.arch.fence_proxy("async.shared", space="cta")
+                    dob_h.commit()
+
+                    # ---- Phase 2: T2R dv result from MMA1, gate, add dv_in ----
+                    dvh = pdv_C.wait_and_advance()
+                    dv_reg = cute.make_rmem_tensor(p_s_dv.shape, self.acc_type)
+                    cute.copy(tc_t2r_dv, p_t_dv[(None, None, None, dvh.index)], dv_reg)
+                    cute.arch.fence_view_async_tmem_load()
+                    dvh.release()
+
+                    # Load dv_in from SMEM (TMA loaded by load warp)
+                    dvin_h = pdvin_C.wait_and_advance()
+                    dvin_reg = cute.make_rmem_tensor(p_s_dv.shape, self.acc_type)
+                    for ei in cutlass.range_constexpr(cute.size(coords_tv)):
+                        tc, vc = coords_tv[ei]
+                        dvin_reg[ei] = sDvIn[(vc, tc, dvin_h.index)].to(self.acc_type)
+                    dvin_h.release()
+
+                    # Combine: dv = dv_mma + dv_in
+                    # Note: per-timestep g gating (exp2(g_last-g[t])) is NOT applied here;
+                    # only gk-based gating is supported in v1 (matching forward cuteDSL).
+                    for ei in cutlass.range_constexpr(cute.size(dv_reg)):
+                        dv_reg[ei] = dv_reg[ei] + dvin_reg[ei]
+
+                    # Mask partial chunk for varlen
+                    if cutlass.const_expr(self.varlen):
+                        valid = seq_len - rev_ct * self.BT
+                        if valid < self.BT:
+                            for ei in cutlass.range_constexpr(cute.size(coords_tv)):
+                                tc, vc = coords_tv[ei]
+                                if tc >= valid:
+                                    dv_reg[ei] = Float32(0.0)
+
+                    # ---- Phase 3: R2S dv2→sDv2b + sDv2Epi ----
+                    dv2b_h = pdv2b_P.acquire_and_advance()
+                    dv2_epi_h = pdv2_epi_P.acquire_and_advance()
+                    dv_bf16 = cute.make_rmem_tensor(dv_reg.shape, self.io_type)
+                    dv_bf16.store(dv_reg.load().to(self.io_type))
+
+                    # R2S dv2 → sDv2b (B-operand for MMA3)
+                    r2s_src_dv2b = tc_r2s_dv2b.retile(dv_bf16)
+                    dst_dv2b = thr_r2s_dv2b.partition_D(sDv2b_store[(None, None, 0)])
+                    cute.copy(tc_r2s_dv2b, r2s_src_dv2b, dst_dv2b)
+                    cute.arch.fence_proxy("async.shared", space="cta")
+                    dv2b_h.commit()
+
+                    # R2S dv2 → sDv2Epi (for Store warp TMA S2G)
+                    r2s_src_dv2 = tc_r2s_dv2_epi.retile(dv_bf16)
+                    dst_dv2 = thr_r2s_dv2_epi.partition_D(
+                        sDv2Epi_store[(None, None, dv2_epi_h.index)]
+                    )
+                    cute.copy(tc_r2s_dv2_epi, r2s_src_dv2, dst_dv2)
+                    cute.arch.fence_proxy("async.shared", space="cta")
+                    dv2_epi_h.commit()
+
+                    # ---- Phase 4: Decay dh and apply qdo, wdv updates ----
+                    # Decay: dh *= exp2(gk_last[k])
+                    if use_gk:
+                        gk_rdy2 = pgk_rdy_C.wait_and_advance()
+                        for ei in cutlass.range(cute.size(st), unroll_full=True):
+                            kc, vc = coords_kv[ei]
+                            st[ei] = st[ei] * gk_exp_buf[(kc, gk_rdy2.index)]
+                        gk_rdy2.release()
+
+                    # T2R qdo result from MMA2
+                    qdoh = pqdo_C.wait_and_advance()
+                    qdo_reg = cute.make_rmem_tensor(p_s_qdo.shape, self.acc_type)
+                    cute.copy(
+                        tc_t2r_qdo, p_t_qdo[(None, None, None, qdoh.index)], qdo_reg
+                    )
+                    cute.arch.fence_view_async_tmem_load()
+                    qdoh.release()
+
+                    # T2R wdv result from MMA3
+                    wdvh = pwdv_C.wait_and_advance()
+                    wdv_reg = cute.make_rmem_tensor(p_s_wdv.shape, self.acc_type)
+                    cute.copy(
+                        tc_t2r_wdv, p_t_wdv[(None, None, None, wdvh.index)], wdv_reg
+                    )
+                    cute.arch.fence_view_async_tmem_load()
+                    wdvh.release()
+
+                    # dh += qdo * scale - wdv
+                    for ei in cutlass.range_constexpr(cute.size(st)):
+                        st[ei] = st[ei] + qdo_reg[ei] * scale - wdv_reg[ei]
+
+                # ========== Store dh0 (initial state gradient) ==========
+                if use_dh0:
+                    gDh0 = g_dh0_t[None, None, (h_idx, seq_idx)]
+                    for ei in cutlass.range(cute.size(st), unroll_full=True):
+                        kc, vc = coords_kv[ei]
+                        gDh0[vc % self.BV + v_tile * self.BV, kc] = st[ei]
+
+                tile_idx = tile_idx + 1
+                has_work = tile_idx < n_iters
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  MMA (warp 6) — 3 sequential GEMMs per chunk
+        # ///////////////////////////////////////////////////////////////////////////////
+        elif warp_id == self.MMA_WARP_ID:
+            cute.arch.setmaxregister_decrease(self.aux_regs)
+
+            tile_idx = Int32(0)
+            has_work = tile_idx < n_iters
+
+            while has_work:
+                w_idx = bx + tile_idx * gdx
+                bi_m = (w_idx // ((V + self.BV - 1) // self.BV)) // H
+                if cutlass.const_expr(self.varlen):
+                    tok_m = cu_seqlens[bi_m]
+                    NT = (cu_seqlens[bi_m + 1] - tok_m + BT - 1) // BT
+                else:
+                    NT = (T + BT - 1) // BT
+
+                for _ct in cutlass.range(0, NT, unroll=0):
+                    # --- MMA1: k(SMEM A) × dh(SMEM B) → dv_acc(TMEM) ---
+                    dhbh = pdhb_C.wait_and_advance()
+                    kh = pk_C.wait_and_advance()
+                    dvd = pdv_P.acquire_and_advance()
+                    for kp in cutlass.range(
+                        cute.size(t_k_a, mode=[2]), unroll_full=True
+                    ):
+                        mma_dv.set(tcgen05.Field.ACCUMULATE, cutlass.Boolean(kp != 0))
+                        cute.gemm(
+                            mma_dv,
+                            t_dv_acc[None, None, None, dvd.index],
+                            t_k_a[None, None, kp, kh.index],
+                            t_dhb_b[None, None, kp, dhbh.index],
+                            t_dv_acc[None, None, None, dvd.index],
+                        )
+                    dvd.commit()
+                    kh.release()
+                    dhbh.release()
+
+                    # --- MMA2: q^T(SMEM A) × do(SMEM B) → qdo_acc(TMEM) ---
+                    # do is the COMPUTE-warp-produced, partial-chunk-masked
+                    # B-operand (1-stage R2S), mirroring dv2/MMA3 -- so the over-
+                    # read mask is off the MMA warp's critical path entirely.
+                    qh = pq_C.wait_and_advance()
+                    doh = pdob_C.wait_and_advance()
+                    qdod = pqdo_P.acquire_and_advance()
+                    for kp in cutlass.range(
+                        cute.size(t_q_a, mode=[2]), unroll_full=True
+                    ):
+                        mma_qdo.set(tcgen05.Field.ACCUMULATE, cutlass.Boolean(kp != 0))
+                        cute.gemm(
+                            mma_qdo,
+                            t_qdo_acc[None, None, None, qdod.index],
+                            t_q_a[None, None, kp, qh.index],
+                            t_do_b[None, None, kp, doh.index],
+                            t_qdo_acc[None, None, None, qdod.index],
+                        )
+                    qdod.commit()
+                    qh.release()
+                    doh.release()
+
+                    # --- MMA3: w(SMEM A) × dv2(SMEM B) → wdv_acc(TMEM) ---
+                    dv2bh = pdv2b_C.wait_and_advance()
+                    wh = pw_C.wait_and_advance()
+                    wdvd = pwdv_P.acquire_and_advance()
+                    for kp in cutlass.range(
+                        cute.size(t_w_a, mode=[2]), unroll_full=True
+                    ):
+                        mma_wdv.set(tcgen05.Field.ACCUMULATE, cutlass.Boolean(kp != 0))
+                        cute.gemm(
+                            mma_wdv,
+                            t_wdv_acc[None, None, None, wdvd.index],
+                            t_w_a[None, None, kp, wh.index],
+                            t_dv2b_b[None, None, kp, dv2bh.index],
+                            t_wdv_acc[None, None, None, wdvd.index],
+                        )
+                    wdvd.commit()
+                    wh.release()
+                    dv2bh.release()
+
+                tile_idx = tile_idx + 1
+                has_work = tile_idx < n_iters
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  STORE (warp 7) — TMA S2G for dh snapshot and dv2
+        # ///////////////////////////////////////////////////////////////////////////////
+        elif warp_id == self.STORE_WARP_ID:
+            cute.arch.setmaxregister_decrease(self.aux_regs)
+            cpasync.prefetch_descriptor(atom_dhst)
+            cpasync.prefetch_descriptor(atom_dv2st)
+            st_ltid = tid - self.STORE_WARP_ID * self.WARP_SZ
+
+            tile_idx = Int32(0)
+            has_work = tile_idx < n_iters
+
+            while has_work:
+                w_idx = bx + tile_idx * gdx
+                v_tile = w_idx % ((V + self.BV - 1) // self.BV)
+                tmp = w_idx // ((V + self.BV - 1) // self.BV)
+                h_idx = tmp % H
+                seq_idx = tmp // H
+                if cutlass.const_expr(self.varlen):
+                    bos = cu_seqlens[seq_idx]
+                    seq_len = cu_seqlens[seq_idx + 1] - bos
+                    NT = (seq_len + BT - 1) // BT
+                    db = Int32(0)
+                    co = chunk_offsets[seq_idx]
+                else:
+                    bos = Int32(0)
+                    seq_len = T
+                    NT = (T + BT - 1) // BT
+                    db = seq_idx
+                    co = Int32(0)
+
+                # Domain-offset store TMA descriptors
+                if cutlass.const_expr(self.varlen):
+                    ddh = cute.domain_offset((0, 0, (co, 0, 0)), desc_dhst)
+                    ddv2 = cute.domain_offset((0, bos, (0, 0)), desc_dv2st)
+                else:
+                    ddh = desc_dhst
+                    ddv2 = desc_dv2st
+
+                gDH_s = ddh[None, None, (None, h_idx, db)]
+                a_dhst, sDHst, gDHst = self._part_epi(
+                    atom_dhst, gDH_s, (self.BV, self.BK), sDhEpi
+                )
+
+                gDV2_s = ddv2[None, None, (h_idx, db)]
+                a_dv2st, sDV2st, gDV2st = self._part_epi(
+                    atom_dv2st, gDV2_s, (self.BV, self.BT), sDv2Epi
+                )
+
+                for ct in cutlass.range(0, NT, unroll=0):
+                    rev_ct = NT - 1 - ct  # reverse index matching CUDA warp
+
+                    # Store dh snapshot via TMA S2G
+                    dhh = pdh_epi_C.wait_and_advance()
+                    cute.copy(
+                        a_dhst, sDHst[None, dhh.index], gDHst[(None, v_tile, 0, rev_ct)]
+                    )
+                    cute.arch.cp_async_bulk_commit_group()
+                    cute.arch.cp_async_bulk_wait_group(0, read=True)
+                    dhh.release()
+
+                    # Store dv2 via TMA S2G (with varlen partial-chunk fallback)
+                    dv2h = pdv2_epi_C.wait_and_advance()
+                    if cutlass.const_expr(self.varlen):
+                        rem = seq_len - rev_ct * self.BT
+                        if rem >= self.BT:
+                            cute.copy(
+                                a_dv2st,
+                                sDV2st[None, dv2h.index],
+                                gDV2st[(None, v_tile, rev_ct)],
+                            )
+                            cute.arch.cp_async_bulk_commit_group()
+                            cute.arch.cp_async_bulk_wait_group(0, read=True)
+                        else:
+                            # Partial chunk: element-wise store with bounds check
+                            sVn_slice = sDv2Epi[None, None, dv2h.index]
+                            thr_cp = copy_dv2_tiled.get_slice(st_ltid)
+                            tOs = thr_cp.partition_S(sVn_slice)
+                            cVn = cute.make_identity_tensor((self.BV, self.BT))
+                            tOc = thr_cp.partition_S(cVn)
+                            tOr = cute.make_fragment_like(tOs, self.io_type)
+                            cute.autovec_copy(tOs, tOr)
+
+                            vn_raw = (
+                                g_dv2.iterator
+                                + (bos + rev_ct * BT) * H * V
+                                + h_idx * V
+                                + v_tile * self.BV
+                            )
+                            vn_ptr = cute.make_ptr(
+                                self.io_type,
+                                vn_raw.toint(),
+                                cute.AddressSpace.gmem,
+                                assumed_align=16,
+                            )
+                            vn_stride = cute.assume(
+                                H * V,
+                                divby=128 // self.io_type.width,
+                            )
+                            gVn_chunk = cute.make_tensor(
+                                vn_ptr,
+                                cute.make_layout(
+                                    (self.BV, self.BT), stride=(1, vn_stride)
+                                ),
+                            )
+                            tOg = thr_cp.partition_D(gVn_chunk)
+                            for rb in cutlass.range_constexpr(cute.size(tOr.shape[2])):
+                                bt_c = tOc[0, 0, rb][1]
+                                if bt_c < rem:
+                                    cute.copy(
+                                        copy_dv2_tiled,
+                                        tOr[None, None, rb],
+                                        tOg[None, None, rb],
+                                    )
+                    else:
+                        cute.copy(
+                            a_dv2st,
+                            sDV2st[None, dv2h.index],
+                            gDV2st[(None, v_tile, rev_ct)],
+                        )
+                        cute.arch.cp_async_bulk_commit_group()
+                        cute.arch.cp_async_bulk_wait_group(0, read=True)
+                    dv2h.release()
+
+                tile_idx = tile_idx + 1
+                has_work = tile_idx < n_iters
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  LOAD (warp 4) — reverse TMA prefetch
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_id == self.LOAD_WARP_ID:
+            cute.arch.setmaxregister_decrease(self.aux_regs)
+
+            tile_idx = Int32(0)
+            has_work = tile_idx < n_iters
+
+            while has_work:
+                w_idx = bx + tile_idx * gdx
+                v_tile = w_idx % ((V + self.BV - 1) // self.BV)
+                tmp = w_idx // ((V + self.BV - 1) // self.BV)
+                h_idx = tmp % H
+                seq_idx = tmp // H
+                if cutlass.const_expr(self.varlen):
+                    bos = cu_seqlens[seq_idx]
+                    seq_len = cu_seqlens[seq_idx + 1] - bos
+                    NT = (seq_len + BT - 1) // BT
+                    db = Int32(0)
+                else:
+                    bos = Int32(0)
+                    seq_len = T
+                    NT = (T + BT - 1) // BT
+                    db = seq_idx
+
+                # Domain-offset TMA descriptors for varlen
+                if cutlass.const_expr(self.varlen):
+                    dk = cute.domain_offset((bos, 0, (0, 0)), desc_k)
+                    dq = cute.domain_offset((0, bos, (0, 0)), desc_q)
+                    dw_desc = cute.domain_offset((0, bos, (0, 0)), desc_w)
+                    ddo = cute.domain_offset((0, bos, (0, 0)), desc_doepi)
+                    ddvin = cute.domain_offset((0, bos, (0, 0)), desc_dvin)
+                    dgk = cute.domain_offset((0, bos, (0, 0)), desc_gk)
+                else:
+                    dk = desc_k
+                    dq = desc_q
+                    dw_desc = desc_w
+                    ddo = desc_doepi
+                    ddvin = desc_dvin
+                    dgk = desc_gk
+
+                # Partition TMA operands
+                tKs, tKg = self._part_a(atom_k, dk, sK, self.dv_tile, mma_dv, db, h_idx)
+                tQs, tQg = self._part_a(
+                    atom_q, dq, sQ, self.qdo_tile, mma_qdo, db, h_idx
+                )
+                gDo_l = ddo[None, None, (h_idx, db)]
+                _, sSDoEpi, gSDoEpi = self._part_epi(
+                    atom_doepi, gDo_l, (self.BV, self.BT), sDoEpi
+                )
+                tWs, tWg = self._part_a(
+                    atom_w, dw_desc, sW, self.wdv_tile, mma_wdv, db, h_idx
+                )
+
+                gDvIn_l = ddvin[None, None, (h_idx, db)]
+                _, sSDvIn, gSDvIn = self._part_epi(
+                    atom_dvin, gDvIn_l, (self.BV, self.BT), sDvIn
+                )
+
+                gGK_l = dgk[None, None, (h_idx, db)]
+                _, sSGK, gSGK = self._part_epi(atom_gk, gGK_l, (self.BK, 1), gk_3d)
+
+                # ---------- Chunk loop (reverse TMA loads) ----------
+                for ct in cutlass.range(0, NT, unroll=0):
+                    rev_ct = NT - 1 - ct
+
+                    # gk load FIRST (last timestep of chunk, clamped for partial)
+                    if use_gk:
+                        gk_t = rev_ct * self.BT + self.BT - 1
+                        rem = seq_len - rev_ct * self.BT
+                        if rem < self.BT:
+                            gk_t = seq_len - 1
+                        gkh = pgk_P.acquire_and_advance()
+                        cute.copy(
+                            atom=atom_gk,
+                            src=gSGK[(None, 0, gk_t)],
+                            dst=sSGK[None, gkh.index],
+                            tma_bar_ptr=gkh.barrier,
+                        )
+
+                    # k load (A-operand for MMA1)
+                    kh = pk_P.acquire_and_advance()
+                    cute.copy(
+                        atom=atom_k,
+                        src=tKg[None, rev_ct, 0],
+                        dst=tKs[None, kh.index],
+                        tma_bar_ptr=kh.barrier,
+                    )
+                    # q^T load (A-operand for MMA2)
+                    qh = pq_P.acquire_and_advance()
+                    cute.copy(
+                        atom=atom_q,
+                        src=tQg[None, 0, rev_ct],
+                        dst=tQs[None, qh.index],
+                        tma_bar_ptr=qh.barrier,
+                    )
+                    # do load (epi → sDoEpi; COMPUTE masks + R2S → sDo for MMA2)
+                    doepih = pdoepi_P.acquire_and_advance()
+                    cute.copy(
+                        atom=atom_doepi,
+                        src=gSDoEpi[(None, v_tile, rev_ct)],
+                        dst=sSDoEpi[None, doepih.index],
+                        tma_bar_ptr=doepih.barrier,
+                    )
+                    # w^T load (A-operand for MMA3)
+                    wh = pw_P.acquire_and_advance()
+                    cute.copy(
+                        atom=atom_w,
+                        src=tWg[None, 0, rev_ct],
+                        dst=tWs[None, wh.index],
+                        tma_bar_ptr=wh.barrier,
+                    )
+                    # dv_in load
+                    dvinh = pdvin_P.acquire_and_advance()
+                    cute.copy(
+                        atom=atom_dvin,
+                        src=gSDvIn[(None, v_tile, rev_ct)],
+                        dst=sSDvIn[None, dvinh.index],
+                        tma_bar_ptr=dvinh.barrier,
+                    )
+
+                tile_idx = tile_idx + 1
+                has_work = tile_idx < n_iters
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  GK PRECOMPUTE (warp 5) — dedicated exp2 precompute
+        # ///////////////////////////////////////////////////////////////////////////////
+        elif warp_id == self.GK_WARP_ID:
+            cute.arch.setmaxregister_decrease(self.aux_regs)
+            gk_tid = tid - self.GK_WARP_ID * self.WARP_SZ
+
+            tile_idx = Int32(0)
+            has_work = tile_idx < n_iters
+
+            while has_work:
+                w_idx = bx + tile_idx * gdx
+                bi_h = (w_idx // ((V + self.BV - 1) // self.BV)) // H
+                if cutlass.const_expr(self.varlen):
+                    tok_h = cu_seqlens[bi_h]
+                    NT = (cu_seqlens[bi_h + 1] - tok_h + BT - 1) // BT
+                else:
+                    NT = (T + BT - 1) // BT
+
+                for _ct in cutlass.range(0, NT, unroll=0):
+                    if use_gk:
+                        gkh = pgk_C.wait_and_advance()
+                        gk_rdy = pgk_rdy_P.acquire_and_advance()
+                        for i in cutlass.range(4, unroll_full=True):
+                            idx = gk_tid * 4 + i
+                            gk_exp_buf[(idx, gk_rdy.index)] = cute.exp2(
+                                gk_buf[(idx, gkh.index)]
+                            )
+                        gkh.release()
+                        cute.arch.fence_proxy("async.shared", space="cta")
+                        gk_rdy.commit()
+
+                tile_idx = tile_idx + 1
+                has_work = tile_idx < n_iters
+
+        # TMEM teardown (all warps)
+        tmem.relinquish_alloc_permit()
+        self.tmem_free_bar.arrive_and_wait()
+        tmem.free(tp)
+
+    # ------------------------------------------------------------------
+    # TMA partition helpers
+    # ------------------------------------------------------------------
+
+    @cute.jit
+    def _part_a(self, atom, desc, smem, tile, mma, batch, head):
+        """Partition A-operand for TMA copy (SS-mode)."""
+        g = cute.local_tile(
+            desc, cute.slice_(tile, (None, 0, None)), (None, None, (head, batch))
+        )
+        thr = mma.get_slice(0)
+        part = thr.partition_A(g)
+        s, d = cpasync.tma_partition(
+            atom,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(smem, 0, 3),
+            cute.group_modes(part, 0, 3),
+        )
+        return s, d
+
+    @cute.jit
+    def _part_b(self, atom, desc, smem, tile, mma, batch, head):
+        """Partition B-operand for TMA copy."""
+        g = cute.local_tile(
+            desc, cute.slice_(tile, (0, None, None)), (None, None, (head, batch))
+        )
+        thr = mma.get_slice(0)
+        part = thr.partition_B(g)
+        s, d = cpasync.tma_partition(
+            atom,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(smem, 0, 3),
+            cute.group_modes(part, 0, 3),
+        )
+        return s, d
+
+    @cute.jit
+    def _part_epi(self, atom, g_mnl, tile, s_buf):
+        """Partition for epilogue-style TMA."""
+        g_div = cute.flat_divide(g_mnl, tile)
+        sg = cute.group_modes(s_buf, 0, 2)
+        gg = cute.group_modes(g_div, 0, 2)
+        ss, gs = cpasync.tma_partition(atom, 0, cute.make_layout(1), sg, gg)
+        return atom, ss, gs
+
+    @staticmethod
+    def _plan_tmem(
+        mma_dv,
+        tile_dv,
+        dv_depth,
+        mma_qdo,
+        tile_qdo,
+        qdo_depth,
+        mma_wdv,
+        tile_wdv,
+        wdv_depth,
+    ):
+        """SS-mode: TMEM only for 3 accumulator regions."""
+        CAP = 512
+        dv_c = mma_dv.partition_shape_C(tile_dv[:2])
+        n_dv = tcgen05.find_tmem_tensor_col_offset(
+            mma_dv.make_fragment_C(cute.append(dv_c, dv_depth))
+        )
+        qdo_c = mma_qdo.partition_shape_C(tile_qdo[:2])
+        n_qdo = tcgen05.find_tmem_tensor_col_offset(
+            mma_qdo.make_fragment_C(cute.append(qdo_c, qdo_depth))
+        )
+        wdv_c = mma_wdv.partition_shape_C(tile_wdv[:2])
+        n_wdv = tcgen05.find_tmem_tensor_col_offset(
+            mma_wdv.make_fragment_C(cute.append(wdv_c, wdv_depth))
+        )
+        o_dv = 0
+        o_qdo = o_dv + n_dv
+        o_wdv = o_qdo + n_qdo
+        raw = o_wdv + n_wdv
+        total = 1
+        while total < raw:
+            total *= 2
+        assert total <= CAP, f"TMEM overflow: {total}>{CAP}"
+        return o_dv, o_qdo, o_wdv, total
+
+    def _launch_grid(self, B, H, V):
+        # Fixed grid = SM_count for CUDA graph compatibility
+        sm_count = HardwareInfo().get_device_multiprocessor_count()
+        return (sm_count, 1, 1)
+
+
+# ============================================================================
+# Compile cache + TVM-FFI
+# ============================================================================
+
+_bwd_dhu_cache = get_jit_cache("kda_delta_h_bwd")
+
+
+def _compile_bwd_dhu(varlen, H, K, V, chunk_size, bv=16):
+    """Compile one BlackwellDeltaHBwdV1 variant."""
+    kern = BlackwellDeltaHBwdV1(
+        chunk_size=chunk_size,
+        head_k=K,
+        head_v=V,
+        head_bv=bv,
+        varlen=varlen,
+    )
+    sa, sb, snt, sn, sns = (cute.sym_int() for _ in range(5))
+
+    if varlen:
+        qf = make_fake_compact_tensor(
+            cutlass.BFloat16, (sa, H, K), stride_order=(2, 1, 0), assumed_align=128
+        )
+        kf = make_fake_compact_tensor(
+            cutlass.BFloat16, (sa, H, K), stride_order=(2, 1, 0), assumed_align=128
+        )
+        wf = make_fake_compact_tensor(
+            cutlass.BFloat16, (sa, H, K), stride_order=(2, 1, 0), assumed_align=128
+        )
+        dof = make_fake_compact_tensor(
+            cutlass.BFloat16, (sa, H, V), stride_order=(2, 1, 0), assumed_align=128
+        )
+        dvf = make_fake_compact_tensor(
+            cutlass.BFloat16, (sa, H, V), stride_order=(2, 1, 0), assumed_align=128
+        )
+        gkf = make_fake_compact_tensor(
+            cutlass.Float32, (sa, H, K), stride_order=(2, 1, 0), assumed_align=128
+        )
+        dhtf = make_fake_compact_tensor(
+            cutlass.Float32,
+            (sns, H, K, V),
+            stride_order=(3, 2, 1, 0),
+            assumed_align=128,
+        )
+        dh0f = make_fake_compact_tensor(
+            cutlass.Float32,
+            (sns, H, K, V),
+            stride_order=(3, 2, 1, 0),
+            assumed_align=128,
+        )
+        dhof = make_fake_compact_tensor(
+            cutlass.BFloat16,
+            (snt, H, K, V),
+            stride_order=(3, 2, 1, 0),
+            assumed_align=128,
+        )
+        dv2f = make_fake_compact_tensor(
+            cutlass.BFloat16, (sa, H, V), stride_order=(2, 1, 0), assumed_align=128
+        )
+    else:
+        qf = make_fake_compact_tensor(
+            cutlass.BFloat16,
+            (sa, sb, H, K),
+            stride_order=(3, 2, 1, 0),
+            assumed_align=128,
+        )
+        kf = make_fake_compact_tensor(
+            cutlass.BFloat16,
+            (sa, sb, H, K),
+            stride_order=(3, 2, 1, 0),
+            assumed_align=128,
+        )
+        wf = make_fake_compact_tensor(
+            cutlass.BFloat16,
+            (sa, sb, H, K),
+            stride_order=(3, 2, 1, 0),
+            assumed_align=128,
+        )
+        dof = make_fake_compact_tensor(
+            cutlass.BFloat16,
+            (sa, sb, H, V),
+            stride_order=(3, 2, 1, 0),
+            assumed_align=128,
+        )
+        dvf = make_fake_compact_tensor(
+            cutlass.BFloat16,
+            (sa, sb, H, V),
+            stride_order=(3, 2, 1, 0),
+            assumed_align=128,
+        )
+        gkf = make_fake_compact_tensor(
+            cutlass.Float32,
+            (sa, sb, H, K),
+            stride_order=(3, 2, 1, 0),
+            assumed_align=128,
+        )
+        dhtf = make_fake_compact_tensor(
+            cutlass.Float32,
+            (sns, H, K, V),
+            stride_order=(3, 2, 1, 0),
+            assumed_align=128,
+        )
+        dh0f = make_fake_compact_tensor(
+            cutlass.Float32,
+            (sns, H, K, V),
+            stride_order=(3, 2, 1, 0),
+            assumed_align=128,
+        )
+        dhof = make_fake_compact_tensor(
+            cutlass.BFloat16,
+            (sa, snt, H, K, V),
+            stride_order=(4, 3, 2, 1, 0),
+            assumed_align=128,
+        )
+        dv2f = make_fake_compact_tensor(
+            cutlass.BFloat16,
+            (sa, sb, H, V),
+            stride_order=(3, 2, 1, 0),
+            assumed_align=128,
+        )
+
+    cuf = make_fake_compact_tensor(cutlass.Int32, (sn,), assumed_align=128)
+    cof = make_fake_compact_tensor(cutlass.Int32, (sn,), assumed_align=128)
+    nsf = make_fake_compact_tensor(cutlass.Int32, (1,), assumed_align=128)
+    stf = make_fake_stream(use_tvm_ffi_env_stream=True)
+
+    return cute.compile(
+        kern,
+        qf,
+        kf,
+        wf,
+        dof,
+        dvf,
+        gkf,
+        dhtf,
+        dh0f,
+        dhof,
+        dv2f,
+        cuf,
+        cof,
+        nsf,
+        (Int32(1), Int32(1), Int32(H), Int32(K), Int32(V)),
+        Int32(1),
+        Float32(1.0),
+        Int32(0),
+        Int32(0),
+        Int32(0),
+        stf,
+        options="--enable-tvm-ffi",
+    )
+
+
+def _is_fake_mode() -> bool:
+    """True when torch.compile is tracing (FakeTensorMode active)."""
+    return active_fake_mode() is not None
+
+
+def _get_bwd_dhu(varlen, H, K, V, chunk_size, bv=16):
+    key = (varlen, H, K, V, chunk_size, bv)
+    if key not in _bwd_dhu_cache:
+        _bwd_dhu_cache[key] = _compile_bwd_dhu(varlen, H, K, V, chunk_size, bv)
+    return _bwd_dhu_cache[key]
+
+
+# ============================================================================
+# Public API wrapper
+# ============================================================================
+
+_dummy_cache: dict[tuple, torch.Tensor] = {}
+
+
+def _get_dummy(shape, dtype, device) -> torch.Tensor:
+    key = (shape, dtype, device)
+    if key not in _dummy_cache:
+        _dummy_cache[key] = torch.empty(shape, dtype=dtype, device=device)
+    return _dummy_cache[key]
+
+
+def blackwell_delta_h_bwd_dhu_v1(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    w: torch.Tensor,
+    do: torch.Tensor,
+    dv: torch.Tensor,
+    gk: torch.Tensor | None = None,
+    h0: torch.Tensor | None = None,
+    dht: torch.Tensor | None = None,
+    scale: float = 1.0,
+    cu_seqlens: torch.Tensor | None = None,
+    chunk_size: int = 64,
+    dv2_out: torch.Tensor | None = None,
+    chunk_offsets: torch.Tensor | None = None,
+    num_seqs: torch.Tensor | int | None = None,
+    bv: int = 16,
+    N: int | None = None,
+    NT: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+    BlackwellDeltaHBwd backward dhu — cuteDSL SM100 kernel.
+
+    Returns (dh, dh0, dv2).
+    """
+    B, T, H, K = q.shape
+    V = do.shape[-1]
+    BT = chunk_size
+    is_vl = cu_seqlens is not None
+    dev = q.device
+
+    assert K == 128, "BlackwellDeltaHBwd requires head_k=128"
+
+    if cu_seqlens is None:
+        N = N if N is not None else B
+        NT = NT if NT is not None else (T + BT - 1) // BT
+        ch_offs = None
+    else:
+        # Accept pre-computed N and NT from the dispatch to avoid redundant
+        # prepare_chunk_indices on padded cu_seqlens (breaks CUDA graph capture
+        # and wastes CPU time).
+        if N is None:
+            N = len(cu_seqlens) - 1
+        if NT is None:
+            chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+            NT = len(chunk_indices)
+        ch_offs = (
+            chunk_offsets
+            if chunk_offsets is not None
+            else _cumulative_chunk_offsets(cu_seqlens, BT)
+        )
+
+    tot_nt = B * NT
+
+    fgk = 1 if gk is not None else 0
+    fdht = 1 if dht is not None else 0
+    fdh0 = 1 if h0 is not None else 0
+
+    dh_out = q.new_empty(B, NT, H, K, V)
+    dh0_out = torch.empty_like(h0, dtype=torch.float32) if h0 is not None else None
+    dv2 = dv2_out if dv2_out is not None else torch.empty_like(dv)
+
+    if _is_fake_mode():
+        return dh_out, dh0_out, dv2
+
+    if is_vl:
+        assert B == 1, "varlen requires B=1"
+        cu_i32 = cu_seqlens.int() if cu_seqlens.dtype != torch.int32 else cu_seqlens
+        co_i32 = (
+            ch_offs.int()
+            if ch_offs is not None and ch_offs.dtype != torch.int32
+            else ch_offs
+        )
+        q_k, k_k, w_k = q[0], k[0], w[0]
+        do_k, dv_k = do[0], dv[0]
+        gk_k = gk[0] if gk is not None else _get_dummy((T, H, K), torch.float32, dev)
+        dht_k = dht if dht is not None else _get_dummy((N, H, K, V), torch.float32, dev)
+        dh0_k = (
+            dh0_out
+            if dh0_out is not None
+            else _get_dummy((N, H, K, V), torch.float32, dev)
+        )
+        dho = dh_out[0]  # (NT, H, K, V)
+        dv2_k = dv2[0]
+        if num_seqs is None:
+            ns_tensor = torch.tensor([N], dtype=torch.int32, device=dev)
+        elif isinstance(num_seqs, int):
+            ns_tensor = torch.tensor([num_seqs], dtype=torch.int32, device=dev)
+        else:
+            ns_tensor = num_seqs.int() if num_seqs.dtype != torch.int32 else num_seqs
+            if ns_tensor.dim() == 0:
+                ns_tensor = ns_tensor.unsqueeze(0)
+
+        ps = (Int32(N), Int32(T), Int32(H), Int32(K), Int32(V))
+        fn = _get_bwd_dhu(True, H, K, V, chunk_size, bv)
+        fn(
+            q_k,
+            k_k,
+            w_k,
+            do_k,
+            dv_k,
+            gk_k,
+            dht_k,
+            dh0_k,
+            dho,
+            dv2_k,
+            cu_i32,
+            co_i32,
+            ns_tensor,
+            ps,
+            Int32(tot_nt),
+            Float32(scale),
+            Int32(fgk),
+            Int32(fdht),
+            Int32(fdh0),
+        )
+
+        return (
+            dh_out,
+            (dh0_out if h0 is not None else None),
+            dv2,
+        )
+    else:
+        gk_k = gk if gk is not None else _get_dummy((B, T, H, K), torch.float32, dev)
+        dht_k = dht if dht is not None else _get_dummy((B, H, K, V), torch.float32, dev)
+        dh0_k = (
+            dh0_out
+            if dh0_out is not None
+            else _get_dummy((B, H, K, V), torch.float32, dev)
+        )
+        cu_d = _get_dummy((2,), torch.int32, dev)
+        co_d = _get_dummy((2,), torch.int32, dev)
+        ns_d = _get_dummy((1,), torch.int32, dev)
+
+        ps = (Int32(B), Int32(T), Int32(H), Int32(K), Int32(V))
+        fn = _get_bwd_dhu(False, H, K, V, chunk_size, bv)
+        fn(
+            q,
+            k,
+            w,
+            do,
+            dv,
+            gk_k,
+            dht_k,
+            dh0_k,
+            dh_out,
+            dv2,
+            cu_d,
+            co_d,
+            ns_d,
+            ps,
+            Int32(NT),
+            Float32(scale),
+            Int32(fgk),
+            Int32(fdht),
+            Int32(fdh0),
+        )
+
+        return (
+            dh_out,
+            (dh0_out if h0 is not None else None),
+            dv2,
+        )

--- a/attn_gym/linear/kda/bwd/cute/chunk_delta_h_bwd_v1_dispatch.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_delta_h_bwd_v1_dispatch.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-ignore-all-errors
+
+"""
+Dispatch wrapper for BlackwellDeltaHBwd V1 — selects BV=16 or BV=32 SS-mode
+based on the total V-tile CTA count relative to the device SM count.
+
+Heuristic (empirically validated on GH200, SM=132):
+    w_tiles_bv16 = ceil(V / 16) * H * B
+    if w_tiles_bv16 > sm_count  →  BV=32  (fewer waves, more work per CTA)
+    else                        →  BV=16  (fills SMs without wasting any)
+
+Crossover point: w_tiles_bv16 = SM_count ≈ 132 on GH200.
+  - H=16, B=1: w16=128 ≤ 132 → BV=16 (0.230ms)
+  - H=24, B=1: w16=192 > 132 → BV=32 (0.270ms)
+  - H=16, B=2: w16=256 > 132 → BV=32 (0.270ms)
+"""
+
+import torch
+from attn_gym.linear.kda.bwd.cute.chunk_delta_h_bwd_v1 import (
+    blackwell_delta_h_bwd_dhu_v1,
+)
+
+
+def blackwell_delta_h_bwd_dhu_dispatch(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    w: torch.Tensor,
+    do: torch.Tensor,
+    dv: torch.Tensor,
+    gk: torch.Tensor | None = None,
+    h0: torch.Tensor | None = None,
+    dht: torch.Tensor | None = None,
+    scale: float = 1.0,
+    cu_seqlens: torch.Tensor | None = None,
+    chunk_size: int = 64,
+    dv2_out: torch.Tensor | None = None,
+    chunk_offsets: torch.Tensor | None = None,
+    num_seqs: torch.Tensor | int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+    BlackwellDeltaHBwd backward dhu — auto-dispatches BV=16 or BV=32.
+
+    Returns (dh, dh0, dv2).
+    """
+    B, _T, H, _K = q.shape
+    V = do.shape[-1]
+
+    w_tiles_bv16 = ((V + 15) // 16) * H * B
+    sm_count = torch.cuda.get_device_properties(q.device).multi_processor_count
+
+    bv = 32 if w_tiles_bv16 > sm_count else 16
+
+    return blackwell_delta_h_bwd_dhu_v1(
+        q=q,
+        k=k,
+        w=w,
+        do=do,
+        dv=dv,
+        gk=gk,
+        h0=h0,
+        dht=dht,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+        dv2_out=dv2_out,
+        chunk_offsets=chunk_offsets,
+        num_seqs=num_seqs,
+        bv=bv,
+    )

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_intra.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_intra.py
@@ -1,0 +1,2001 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-ignore-all-errors
+# NOTE: do NOT use `from __future__ import annotations` — cute.struct
+# requires eager-evaluated annotations.
+
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+from cutlass import Boolean, Float32, Int32
+from cutlass._mlir import ir
+from cutlass._mlir.dialects import llvm
+from cutlass.cute.runtime import from_dlpack
+from cutlass.cutlass_dsl import Constexpr, dsl_user_op, T
+
+BT = 64  # chunk_size
+SUBCHUNKS = 4
+BC = BT // SUBCHUNKS
+KEY_DIM = 128  # full head_dim
+KEY_DIM_PER_CTA = 32  # head_dim per K phase
+K_PHASES = KEY_DIM // KEY_DIM_PER_CTA  # four 32-wide head-dim phases
+KC_TOTAL = K_PHASES * SUBCHUNKS  # work items per (chunk, head): 16
+
+# Kernel phase map:
+# 1. Host wrapper validates tensors and prepares caller-owned varlen metadata.
+# 2. Launcher compiles the HMMA-grid CuTe kernel for the tensor signature.
+# 3. Kernel maps the grid to (k_phase, subchunk, chunk_block, head_idx).
+# 4. Kernel stages Q/K/G, runs the HMMA loops, then writes dq/dk/db/dg.
+
+
+def to_cute_tensor_plain(t, assumed_align=16) -> cute.Tensor:
+    return from_dlpack(t.detach(), assumed_align=assumed_align, enable_tvm_ffi=True)
+
+
+@dsl_user_op
+def _mma_tf32_m16n8k8(
+    a0,
+    a1,
+    a2,
+    a3,
+    b0,
+    b1,
+    c0,
+    c1,
+    c2,
+    c3,
+    *,
+    loc=None,
+    ip=None,
+):
+    """Warp-level TF32 MMA matching Triton's dot lowering."""
+    a0b = llvm.bitcast(T.i32(), a0.ir_value(loc=loc, ip=ip), loc=loc, ip=ip)
+    a1b = llvm.bitcast(T.i32(), a1.ir_value(loc=loc, ip=ip), loc=loc, ip=ip)
+    a2b = llvm.bitcast(T.i32(), a2.ir_value(loc=loc, ip=ip), loc=loc, ip=ip)
+    a3b = llvm.bitcast(T.i32(), a3.ir_value(loc=loc, ip=ip), loc=loc, ip=ip)
+    b0b = llvm.bitcast(T.i32(), b0.ir_value(loc=loc, ip=ip), loc=loc, ip=ip)
+    b1b = llvm.bitcast(T.i32(), b1.ir_value(loc=loc, ip=ip), loc=loc, ip=ip)
+    result = llvm.inline_asm(
+        ir.Type.parse("!llvm.struct<(f32, f32, f32, f32)>"),
+        [
+            a0b,
+            a1b,
+            a2b,
+            a3b,
+            b0b,
+            b1b,
+            c0.ir_value(loc=loc, ip=ip),
+            c1.ir_value(loc=loc, ip=ip),
+            c2.ir_value(loc=loc, ip=ip),
+            c3.ir_value(loc=loc, ip=ip),
+        ],
+        """{
+            mma.sync.aligned.m16n8k8.row.col.f32.tf32.tf32.f32
+                {$0, $1, $2, $3},
+                {$4, $5, $6, $7},
+                {$8, $9},
+                {$10, $11, $12, $13};
+        }""",
+        "=f,=f,=f,=f,r,r,r,r,r,r,f,f,f,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    d0 = cutlass.Float32(llvm.extractvalue(T.f32(), result, [0], loc=loc, ip=ip))
+    d1 = cutlass.Float32(llvm.extractvalue(T.f32(), result, [1], loc=loc, ip=ip))
+    d2 = cutlass.Float32(llvm.extractvalue(T.f32(), result, [2], loc=loc, ip=ip))
+    d3 = cutlass.Float32(llvm.extractvalue(T.f32(), result, [3], loc=loc, ip=ip))
+    return d0, d1, d2, d3
+
+
+@dsl_user_op
+def _cp_async_cg_g2s_16b(
+    gmem_ptr: cute.Pointer,
+    smem_ptr: cute.Pointer,
+    src_bytes: Int32,
+    *,
+    loc=None,
+    ip=None,
+):
+    """Issue one 16-byte cp.async from global to shared memory."""
+    gmem_addr = gmem_ptr.toint(loc=loc, ip=ip).ir_value()
+    smem_addr = smem_ptr.toint(loc=loc, ip=ip).ir_value()
+    llvm.inline_asm(
+        None,
+        [
+            smem_addr,
+            gmem_addr,
+            src_bytes.ir_value(loc=loc, ip=ip),
+        ],
+        "cp.async.cg.shared.global [$0], [$1], 0x10, $2;",
+        "r,l,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def _ldmatrix_x4_b16(smem_ptr: cute.Pointer, *, loc=None, ip=None):
+    smem_addr = smem_ptr.toint(loc=loc, ip=ip).ir_value()
+    result = llvm.inline_asm(
+        ir.Type.parse("!llvm.struct<(i32, i32, i32, i32)>"),
+        [smem_addr],
+        "ldmatrix.sync.aligned.x4.m8n8.shared.b16 {$0, $1, $2, $3}, [$4];",
+        "=r,=r,=r,=r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return (
+        Int32(llvm.extractvalue(T.i32(), result, [0], loc=loc, ip=ip)),
+        Int32(llvm.extractvalue(T.i32(), result, [1], loc=loc, ip=ip)),
+        Int32(llvm.extractvalue(T.i32(), result, [2], loc=loc, ip=ip)),
+        Int32(llvm.extractvalue(T.i32(), result, [3], loc=loc, ip=ip)),
+    )
+
+
+@dsl_user_op
+def _ldmatrix_x4_trans_b16(smem_ptr: cute.Pointer, *, loc=None, ip=None):
+    smem_addr = smem_ptr.toint(loc=loc, ip=ip).ir_value()
+    result = llvm.inline_asm(
+        ir.Type.parse("!llvm.struct<(i32, i32, i32, i32)>"),
+        [smem_addr],
+        "ldmatrix.sync.aligned.x4.trans.m8n8.shared.b16 {$0, $1, $2, $3}, [$4];",
+        "=r,=r,=r,=r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return (
+        Int32(llvm.extractvalue(T.i32(), result, [0], loc=loc, ip=ip)),
+        Int32(llvm.extractvalue(T.i32(), result, [1], loc=loc, ip=ip)),
+        Int32(llvm.extractvalue(T.i32(), result, [2], loc=loc, ip=ip)),
+        Int32(llvm.extractvalue(T.i32(), result, [3], loc=loc, ip=ip)),
+    )
+
+
+@dsl_user_op
+def _stmatrix_x4_b16_f32(
+    smem_ptr: cute.Pointer,
+    a: Float32,
+    b: Float32,
+    c: Float32,
+    d: Float32,
+    *,
+    loc=None,
+    ip=None,
+) -> None:
+    smem_addr = smem_ptr.toint(loc=loc, ip=ip).ir_value()
+    llvm.inline_asm(
+        None,
+        [
+            smem_addr,
+            a.ir_value(loc=loc, ip=ip),
+            b.ir_value(loc=loc, ip=ip),
+            c.ir_value(loc=loc, ip=ip),
+            d.ir_value(loc=loc, ip=ip),
+        ],
+        "stmatrix.sync.aligned.x4.m8n8.shared.b16 [$0], {$1, $2, $3, $4};",
+        "r,r,r,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def _ld_shared_u32x4(smem_ptr: cute.Pointer, *, loc=None, ip=None):
+    smem_addr = smem_ptr.toint(loc=loc, ip=ip).ir_value()
+    result = llvm.inline_asm(
+        ir.Type.parse("!llvm.struct<(i32, i32, i32, i32)>"),
+        [smem_addr],
+        "ld.shared.v4.b32 {$0, $1, $2, $3}, [$4];",
+        "=r,=r,=r,=r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return (
+        Int32(llvm.extractvalue(T.i32(), result, [0], loc=loc, ip=ip)),
+        Int32(llvm.extractvalue(T.i32(), result, [1], loc=loc, ip=ip)),
+        Int32(llvm.extractvalue(T.i32(), result, [2], loc=loc, ip=ip)),
+        Int32(llvm.extractvalue(T.i32(), result, [3], loc=loc, ip=ip)),
+    )
+
+
+@dsl_user_op
+def _ld_shared_u32(smem_ptr: cute.Pointer, *, loc=None, ip=None):
+    smem_addr = smem_ptr.toint(loc=loc, ip=ip).ir_value()
+    result = llvm.inline_asm(
+        T.i32(),
+        [smem_addr],
+        "ld.shared.b32 $0, [$1];",
+        "=r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return Int32(result)
+
+
+@dsl_user_op
+def _bitcast_i32_to_f32(x: Int32, *, loc=None, ip=None):
+    return cutlass.Float32(
+        llvm.bitcast(T.f32(), x.ir_value(loc=loc, ip=ip), loc=loc, ip=ip)
+    )
+
+
+@dsl_user_op
+def _bf16x2_to_f32_pair(x: Int32, *, loc=None, ip=None):
+    result = llvm.inline_asm(
+        ir.Type.parse("!llvm.struct<(f32, f32)>"),
+        [x.ir_value(loc=loc, ip=ip)],
+        "{\n\t"
+        ".reg .u32 lo, hi, lo_f32, hi_f32;\n\t"
+        "and.b32 lo, $2, 0x0000ffff;\n\t"
+        "shr.u32 hi, $2, 16;\n\t"
+        "shl.b32 lo_f32, lo, 16;\n\t"
+        "shl.b32 hi_f32, hi, 16;\n\t"
+        "mov.b32 $0, lo_f32;\n\t"
+        "mov.b32 $1, hi_f32;\n\t"
+        "}\n",
+        "=f,=f,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return (
+        cutlass.Float32(llvm.extractvalue(T.f32(), result, [0], loc=loc, ip=ip)),
+        cutlass.Float32(llvm.extractvalue(T.f32(), result, [1], loc=loc, ip=ip)),
+    )
+
+
+@dsl_user_op
+def _ld_global_f32_b32_pred(
+    gmem_ptr: cute.Pointer,
+    pred: Boolean,
+    *,
+    loc=None,
+    ip=None,
+):
+    ptr_i64 = gmem_ptr.toint(loc=loc, ip=ip).ir_value()
+    bits = llvm.inline_asm(
+        T.i32(),
+        [
+            ptr_i64,
+            Int32(pred).ir_value(loc=loc, ip=ip),
+        ],
+        "{\n\t"
+        ".reg .pred p;\n\t"
+        "mov.b32 $0, 0;\n\t"
+        "setp.ne.b32 p, $2, 0;\n\t"
+        "@p ld.global.b32 $0, [$1];\n\t"
+        "}\n",
+        "=r,l,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return cutlass.Float32(llvm.bitcast(T.f32(), bits, loc=loc, ip=ip))
+
+
+@dsl_user_op
+def _ld_global_f32x2_pred(
+    gmem_ptr: cute.Pointer,
+    pred: Boolean,
+    *,
+    loc=None,
+    ip=None,
+):
+    ptr_i64 = gmem_ptr.toint(loc=loc, ip=ip).ir_value()
+    result = llvm.inline_asm(
+        ir.Type.parse("!llvm.struct<(i32, i32)>"),
+        [
+            ptr_i64,
+            Int32(pred).ir_value(loc=loc, ip=ip),
+        ],
+        "{\n\t"
+        ".reg .pred p;\n\t"
+        "mov.b32 $0, 0;\n\t"
+        "mov.b32 $1, 0;\n\t"
+        "setp.ne.b32 p, $3, 0;\n\t"
+        "@p ld.global.v2.b32 {$0, $1}, [$2];\n\t"
+        "}\n",
+        "=r,=r,l,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    v0 = llvm.extractvalue(T.i32(), result, [0], loc=loc, ip=ip)
+    v1 = llvm.extractvalue(T.i32(), result, [1], loc=loc, ip=ip)
+    return (
+        cutlass.Float32(llvm.bitcast(T.f32(), v0, loc=loc, ip=ip)),
+        cutlass.Float32(llvm.bitcast(T.f32(), v1, loc=loc, ip=ip)),
+    )
+
+
+@dsl_user_op
+def _ld_global_f32x4_lo2_pred(
+    gmem_ptr: cute.Pointer,
+    pred: Boolean,
+    *,
+    loc=None,
+    ip=None,
+):
+    ptr_i64 = gmem_ptr.toint(loc=loc, ip=ip).ir_value()
+    result = llvm.inline_asm(
+        ir.Type.parse("!llvm.struct<(i32, i32)>"),
+        [
+            ptr_i64,
+            Int32(pred).ir_value(loc=loc, ip=ip),
+        ],
+        "{\n\t"
+        ".reg .pred p;\n\t"
+        ".reg .b32 unused0;\n\t"
+        ".reg .b32 unused1;\n\t"
+        "mov.b32 $0, 0;\n\t"
+        "mov.b32 $1, 0;\n\t"
+        "setp.ne.b32 p, $3, 0;\n\t"
+        "@p ld.global.v4.b32 {$0, $1, unused0, unused1}, [$2];\n\t"
+        "}\n",
+        "=r,=r,l,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    v0 = llvm.extractvalue(T.i32(), result, [0], loc=loc, ip=ip)
+    v1 = llvm.extractvalue(T.i32(), result, [1], loc=loc, ip=ip)
+    return (
+        cutlass.Float32(llvm.bitcast(T.f32(), v0, loc=loc, ip=ip)),
+        cutlass.Float32(llvm.bitcast(T.f32(), v1, loc=loc, ip=ip)),
+    )
+
+
+@dsl_user_op
+def _add_f32x2(
+    a0: Float32,
+    a1: Float32,
+    b0: Float32,
+    b1: Float32,
+    *,
+    loc=None,
+    ip=None,
+):
+    result = llvm.inline_asm(
+        ir.Type.parse("!llvm.struct<(f32, f32)>"),
+        [
+            Float32(a0).ir_value(loc=loc, ip=ip),
+            Float32(a1).ir_value(loc=loc, ip=ip),
+            Float32(b0).ir_value(loc=loc, ip=ip),
+            Float32(b1).ir_value(loc=loc, ip=ip),
+        ],
+        "{\n\t"
+        ".reg .b64 lhs, rhs, out;\n\t"
+        "mov.b64 lhs, {$2, $3};\n\t"
+        "mov.b64 rhs, {$4, $5};\n\t"
+        "add.f32x2 out, lhs, rhs;\n\t"
+        "mov.b64 {$0, $1}, out;\n\t"
+        "}\n",
+        "=f,=f,f,f,f,f",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return (
+        cutlass.Float32(llvm.extractvalue(T.f32(), result, [0], loc=loc, ip=ip)),
+        cutlass.Float32(llvm.extractvalue(T.f32(), result, [1], loc=loc, ip=ip)),
+    )
+
+
+@dsl_user_op
+def _cvt_bf16x2_f32(
+    a: Float32,
+    b: Float32,
+    *,
+    loc=None,
+    ip=None,
+) -> Int32:
+    packed = llvm.inline_asm(
+        T.i32(),
+        [
+            Float32(a).ir_value(loc=loc, ip=ip),
+            Float32(b).ir_value(loc=loc, ip=ip),
+        ],
+        "cvt.rn.bf16x2.f32 $0, $2, $1;",
+        "=r,f,f",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return Int32(packed)
+
+
+@dsl_user_op
+def _st_shared_f32x4_v2_b64(
+    smem_ptr: cute.Pointer,
+    a: Float32,
+    b: Float32,
+    c: Float32,
+    d: Float32,
+    *,
+    loc=None,
+    ip=None,
+) -> None:
+    smem_addr = smem_ptr.toint(loc=loc, ip=ip).ir_value()
+    a_bits = llvm.bitcast(T.i32(), Float32(a).ir_value(loc=loc, ip=ip), loc=loc, ip=ip)
+    b_bits = llvm.bitcast(T.i32(), Float32(b).ir_value(loc=loc, ip=ip), loc=loc, ip=ip)
+    c_bits = llvm.bitcast(T.i32(), Float32(c).ir_value(loc=loc, ip=ip), loc=loc, ip=ip)
+    d_bits = llvm.bitcast(T.i32(), Float32(d).ir_value(loc=loc, ip=ip), loc=loc, ip=ip)
+    llvm.inline_asm(
+        None,
+        [
+            smem_addr,
+            a_bits,
+            b_bits,
+            c_bits,
+            d_bits,
+        ],
+        "{\n\t"
+        ".reg .b64 p0;\n\t"
+        ".reg .b64 p1;\n\t"
+        "mov.b64 p0, {$1, $2};\n\t"
+        "mov.b64 p1, {$3, $4};\n\t"
+        "st.shared.v2.b64 [$0], {p0, p1};\n\t"
+        "}\n",
+        "r,r,r,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def _st_shared_u32x4(
+    smem_ptr: cute.Pointer,
+    a: Int32,
+    b: Int32,
+    c: Int32,
+    d: Int32,
+    *,
+    loc=None,
+    ip=None,
+) -> None:
+    smem_addr = smem_ptr.toint(loc=loc, ip=ip).ir_value()
+    llvm.inline_asm(
+        None,
+        [
+            smem_addr,
+            a.ir_value(loc=loc, ip=ip),
+            b.ir_value(loc=loc, ip=ip),
+            c.ir_value(loc=loc, ip=ip),
+            d.ir_value(loc=loc, ip=ip),
+        ],
+        "st.shared.v4.b32 [$0], {$1, $2, $3, $4};",
+        "r,r,r,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def _st_global_u32x4_pred(
+    gmem_ptr: cute.Pointer,
+    a: Int32,
+    b: Int32,
+    c: Int32,
+    d: Int32,
+    pred: Boolean,
+    *,
+    loc=None,
+    ip=None,
+) -> None:
+    ptr_i64 = gmem_ptr.toint(loc=loc, ip=ip).ir_value()
+    llvm.inline_asm(
+        None,
+        [
+            ptr_i64,
+            a.ir_value(loc=loc, ip=ip),
+            b.ir_value(loc=loc, ip=ip),
+            c.ir_value(loc=loc, ip=ip),
+            d.ir_value(loc=loc, ip=ip),
+            Int32(pred).ir_value(loc=loc, ip=ip),
+        ],
+        "{\n\t"
+        ".reg .pred p;\n\t"
+        "setp.ne.b32 p, $5, 0;\n\t"
+        "@p st.global.v4.b32 [$0], {$1, $2, $3, $4};\n\t"
+        "}\n",
+        "l,r,r,r,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def _bar_warp_sync(*, loc=None, ip=None) -> None:
+    llvm.inline_asm(
+        None,
+        [],
+        "bar.warp.sync -1;",
+        "",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@cute.jit
+def _st_global_bf16_ldmatrix_epilogue_16x32(
+    sEpi_tile,
+    gmem_ptr,
+    top0: Int32,
+    top1: Int32,
+    top2: Int32,
+    top3: Int32,
+    bottom0: Int32,
+    bottom1: Int32,
+    bottom2: Int32,
+    bottom3: Int32,
+    tidx: Int32,
+    *,
+    row_base,
+    valid,
+    row_stride,
+):
+    lane = tidx & 31
+    r11 = lane & 3
+    r14 = lane & 28
+    r15 = lane & 24
+    r20 = (lane & 7) << 4
+    store_bytes = ((r11 << 5) | (r15 << 4)) ^ (r14 << 2)
+    load_bytes = (((lane << 6) & 384) | r20) ^ (r15 << 2)
+    out_row0 = (lane >> 2) & 7
+    out_col = (lane & 3) * 8
+    row_valid0 = (row_base + out_row0) < valid
+    row_valid1 = (row_base + out_row0 + 8) < valid
+
+    _bar_warp_sync()
+    _st_shared_u32x4(sEpi_tile.iterator + store_bytes // 2, top0, top1, top2, top3)
+    _bar_warp_sync()
+    v0, v1, v2, v3 = _ldmatrix_x4_b16(sEpi_tile.iterator + load_bytes // 2)
+    _bar_warp_sync()
+    _st_shared_u32x4(
+        sEpi_tile.iterator + store_bytes // 2,
+        bottom0,
+        bottom1,
+        bottom2,
+        bottom3,
+    )
+    _bar_warp_sync()
+    v4, v5, v6, v7 = _ldmatrix_x4_b16(sEpi_tile.iterator + load_bytes // 2)
+    _st_global_u32x4_pred(
+        gmem_ptr + out_row0 * row_stride + out_col,
+        v0,
+        v1,
+        v2,
+        v3,
+        Boolean(row_valid0),
+    )
+    _st_global_u32x4_pred(
+        gmem_ptr + (out_row0 + 8) * row_stride + out_col,
+        v4,
+        v5,
+        v6,
+        v7,
+        Boolean(row_valid1),
+    )
+    _bar_warp_sync()
+
+
+@cute.jit
+def _st_shared_dg_triton_swizzle(
+    sEpi_tile,
+    group: Constexpr,
+    top0: Float32,
+    top1: Float32,
+    bottom0: Float32,
+    bottom1: Float32,
+    tidx: Int32,
+):
+    lane = tidx & 31
+    lane_odd = lane & 1
+    lane_bit1 = lane & 2
+    lane_bit2 = (lane >> 2) & 1
+    lane_high = lane & 24
+    row_half = Int32(0)
+    if lane_odd != 0:
+        row_half = Int32(1088)
+    col_pair = lane_bit1 << 3
+    quad_half = Int32(0)
+    if lane_bit2 != 0:
+        quad_half = Int32(544)
+    high_half = lane_high << 4
+    store_bytes = (row_half | col_pair | quad_half | high_half) ^ Int32(group * 32)
+    _st_shared_f32x4_v2_b64(
+        sEpi_tile.iterator + store_bytes // 2,
+        top0,
+        top1,
+        bottom0,
+        bottom1,
+    )
+
+
+@cute.jit
+def _st_global_f32_triton_shared_epilogue_16x32(
+    sEpi_tile,
+    gmem_ptr,
+    tidx: Int32,
+    *,
+    row_base,
+    valid,
+    row_stride,
+):
+    _bar_warp_sync()
+    lane = tidx & 31
+    low3 = lane & 7
+    lane_bit3 = lane & 8
+    lane_bit4 = lane & 16
+    row_xor = Int32(0)
+    if lane_bit3 != 0:
+        row_xor = Int32(544)
+    load_base = (row_xor ^ (low3 << 4)) | (lane_bit4 << 3)
+    v0, v1, v2, v3 = _ld_shared_u32x4(sEpi_tile.iterator + load_base // 2)
+    v4, v5, v6, v7 = _ld_shared_u32x4(sEpi_tile.iterator + (load_base + 256) // 2)
+    v8, v9, v10, v11 = _ld_shared_u32x4(
+        sEpi_tile.iterator + ((load_base ^ Int32(64)) + 1024) // 2
+    )
+    v12, v13, v14, v15 = _ld_shared_u32x4(
+        sEpi_tile.iterator + ((load_base ^ Int32(64)) + 1280) // 2
+    )
+    out_row0 = (lane >> 3) & 3
+    out_col = low3 * 4
+    row_valid0 = (row_base + out_row0) < valid
+    row_valid1 = (row_base + out_row0 + 4) < valid
+    row_valid2 = (row_base + out_row0 + 8) < valid
+    row_valid3 = (row_base + out_row0 + 12) < valid
+    _st_global_u32x4_pred(
+        gmem_ptr + out_row0 * row_stride + out_col,
+        v0,
+        v1,
+        v8,
+        v9,
+        Boolean(row_valid0),
+    )
+    _st_global_u32x4_pred(
+        gmem_ptr + (out_row0 + 4) * row_stride + out_col,
+        v4,
+        v5,
+        v12,
+        v13,
+        Boolean(row_valid1),
+    )
+    _st_global_u32x4_pred(
+        gmem_ptr + (out_row0 + 8) * row_stride + out_col,
+        v2,
+        v3,
+        v10,
+        v11,
+        Boolean(row_valid2),
+    )
+    _st_global_u32x4_pred(
+        gmem_ptr + (out_row0 + 12) * row_stride + out_col,
+        v6,
+        v7,
+        v14,
+        v15,
+        Boolean(row_valid3),
+    )
+    _bar_warp_sync()
+
+
+@dsl_user_op
+def _st_global_f32_b32_pred(
+    gmem_ptr: cute.Pointer,
+    a: Float32,
+    pred: Boolean,
+    *,
+    loc=None,
+    ip=None,
+) -> None:
+    ptr_i64 = gmem_ptr.toint(loc=loc, ip=ip).ir_value()
+    a_bits = llvm.bitcast(T.i32(), Float32(a).ir_value(loc=loc, ip=ip), loc=loc, ip=ip)
+    llvm.inline_asm(
+        None,
+        [ptr_i64, a_bits, Int32(pred).ir_value(loc=loc, ip=ip)],
+        "{\n\t"
+        ".reg .pred p;\n\t"
+        "setp.ne.b32 p, $2, 0;\n\t"
+        "@p st.global.b32 [$0], $1;\n\t"
+        "}\n",
+        "l,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@cute.jit
+def _hmma_load_b_groups_smem_ldmatrix(sB, row_base, k_outer, tidx):
+    lane8 = tidx & 7
+    group8 = tidx // 8
+    smem_ptr = (
+        sB.iterator + (row_base + k_outer * 8 + lane8) * KEY_DIM_PER_CTA + group8 * 8
+    )
+    r0, r1, r2, r3 = _ldmatrix_x4_trans_b16(smem_ptr)
+    b00, b01 = _bf16x2_to_f32_pair(r0)
+    b10, b11 = _bf16x2_to_f32_pair(r1)
+    b20, b21 = _bf16x2_to_f32_pair(r2)
+    b30, b31 = _bf16x2_to_f32_pair(r3)
+    return b00, b01, b10, b11, b20, b21, b30, b31
+
+
+@cute.jit
+def _hmma_stmatrix_source_from_lane_values(b0, b1, tidx, source_reg: Constexpr):
+    target_l8 = ((tidx & 6) // 2) + (Int32(4) if (tidx & 16) != 0 else Int32(0))
+    src_lane = source_reg * 8 + target_l8
+    src_b0 = cute.arch.shuffle_sync(b0, src_lane)
+    src_b1 = cute.arch.shuffle_sync(b1, src_lane)
+    return src_b1 if (tidx & 8) != 0 else src_b0
+
+
+@cute.jit
+def _hmma_stage_b_group_stmatrix(sB, b0, b1, tidx):
+    store_bytes = ((tidx << 4) & 368) ^ (Int32(160) if (tidx & 8) != 0 else Int32(0))
+    _stmatrix_x4_b16_f32(
+        sB.iterator + (store_bytes // 2),
+        _hmma_stmatrix_source_from_lane_values(b0, b1, tidx, 0),
+        _hmma_stmatrix_source_from_lane_values(b0, b1, tidx, 1),
+        _hmma_stmatrix_source_from_lane_values(b0, b1, tidx, 2),
+        _hmma_stmatrix_source_from_lane_values(b0, b1, tidx, 3),
+    )
+
+
+@cute.jit
+def _hmma_load_b_group_stmatrix(sB, tidx):
+    load_bytes = ((tidx << 4) & 320) | ((tidx & 3) * 8)
+    load_bytes = load_bytes | (Int32(160) if (tidx & 8) != 0 else Int32(0))
+    packed0 = _ld_shared_u32(sB.iterator + (load_bytes // 2))
+    packed1 = _ld_shared_u32(sB.iterator + ((load_bytes ^ 32) // 2))
+    return _bitcast_i32_to_f32(packed0), _bitcast_i32_to_f32(packed1)
+
+
+@cute.jit
+def _hmma_load_da(mdA, row_start, head_idx, row, col, valid):
+    return _ld_global_f32_b32_pred(
+        mdA.iterator
+        + (row_start + row) * mdA.layout.stride[1]
+        + head_idx * mdA.layout.stride[2]
+        + col,
+        Boolean((row < valid) & (col < valid)),
+    )
+
+
+@cute.jit
+def _hmma_load_da_pred(mdA, row_start, head_idx, row, col, valid, pred):
+    return _ld_global_f32_b32_pred(
+        mdA.iterator
+        + (row_start + row) * mdA.layout.stride[1]
+        + head_idx * mdA.layout.stride[2]
+        + col,
+        Boolean(pred & (row < valid) & (col < valid)),
+    )
+
+
+@cute.jit
+def _hmma_load_da_pair(
+    mdA, row_start, head_idx, row, col, valid, row_stride, head_stride
+):
+    v0, v1 = _ld_global_f32x4_lo2_pred(
+        mdA.iterator + (row_start + row) * row_stride + head_idx * head_stride + col,
+        Boolean((row < valid) & (col < valid)),
+    )
+    v1 = v1 if (col + 1) < valid else Float32(0.0)
+    return v0, v1
+
+
+@cute.jit
+def _hmma_load_da_pair_pred(
+    mdA,
+    row_start,
+    head_idx,
+    row,
+    col,
+    valid,
+    row_stride,
+    head_stride,
+    pred0,
+    pred1,
+):
+    v0, v1 = _ld_global_f32x4_lo2_pred(
+        mdA.iterator + (row_start + row) * row_stride + head_idx * head_stride + col,
+        Boolean(pred0 & (row < valid) & (col < valid)),
+    )
+    v1 = v1 if pred1 & ((col + 1) < valid) else Float32(0.0)
+    return v0, v1
+
+
+@cute.jit
+def _copy_qkg_smem_cpasync(
+    sQ,
+    sK,
+    sG,
+    mQ,
+    mK,
+    mG,
+    row_start,
+    head_idx,
+    k_start,
+    valid,
+    tidx,
+):
+    q_row_stride = mQ.layout.stride[1]
+    q_head_stride = mQ.layout.stride[2]
+    k_row_stride = mK.layout.stride[1]
+    k_head_stride = mK.layout.stride[2]
+    g_row_stride = mG.layout.stride[1]
+    g_head_stride = mG.layout.stride[2]
+
+    for i in cutlass.range_constexpr(8):
+        elem = tidx * 8 + i * 32 * 8
+        row = elem // KEY_DIM_PER_CTA
+        col = elem - row * KEY_DIM_PER_CTA
+        src_bytes = Int32(16) if row < valid else Int32(0)
+        _cp_async_cg_g2s_16b(
+            mQ.iterator
+            + (row_start + row) * q_row_stride
+            + head_idx * q_head_stride
+            + k_start
+            + col,
+            sQ.iterator + elem,
+            src_bytes,
+        )
+        _cp_async_cg_g2s_16b(
+            mK.iterator
+            + (row_start + row) * k_row_stride
+            + head_idx * k_head_stride
+            + k_start
+            + col,
+            sK.iterator + elem,
+            src_bytes,
+        )
+
+    for i in cutlass.range_constexpr(16):
+        elem = tidx * 4 + i * 32 * 4
+        row = elem // KEY_DIM_PER_CTA
+        col = elem - row * KEY_DIM_PER_CTA
+        src_bytes = Int32(16) if row < valid else Int32(0)
+        _cp_async_cg_g2s_16b(
+            mG.iterator
+            + (row_start + row) * g_row_stride
+            + head_idx * g_head_stride
+            + k_start
+            + col,
+            sG.iterator + elem,
+            src_bytes,
+        )
+
+    cute.arch.cp_async_commit_group()
+    cute.arch.cp_async_wait_group(0)
+    cute.arch.barrier()
+
+
+@cute.kernel
+def _chunk_kda_bwd_intra_hmma_grid_kernel(  # noqa: C901
+    mQ: cute.Tensor,
+    mK: cute.Tensor,
+    mG: cute.Tensor,
+    mBeta: cute.Tensor,
+    mdAqk: cute.Tensor,
+    mdAkk: cute.Tensor,
+    mDq: cute.Tensor,
+    mDk: cute.Tensor,
+    mDb2: cute.Tensor,
+    mDg: cute.Tensor,
+    mDq2: cute.Tensor,
+    mDk2: cute.Tensor,
+    mDg2: cute.Tensor,
+    mCuSeqlens: cute.Tensor,
+    mChunkIndices: cute.Tensor,
+    mNumChunks: cute.Tensor,
+    use_i32_metadata: Constexpr,
+    grid_chunks: Constexpr,
+):
+    tidx, _, _ = cute.arch.thread_idx()
+    # Grid is (KC_TOTAL, grid_chunks, H), mirroring Triton's for-loop variant.
+    # kc and head are real grid axes; only the chunk axis is capped at
+    # grid_chunks and walked by each CTA. These per-(kc, head) coordinates are
+    # loop-invariant, so they are computed once outside the chunk loop.
+    kc_idx, chunk_start, head_idx = cute.arch.block_idx()
+    gid = tidx // 4
+    tid = tidx % 4
+    k_phase = kc_idx // SUBCHUNKS
+    subchunk_idx = kc_idx - k_phase * SUBCHUNKS
+    k_start = k_phase * KEY_DIM_PER_CTA
+    row_base = subchunk_idx * BC
+    row0 = row_base + gid
+    row1 = row0 + 8
+
+    # num_chunks is a runtime device scalar, so the chunk axis is a fixed cap
+    # (grid_chunks) and each CTA strides chunk_start, chunk_start + grid_chunks,
+    # ... while < num_chunks. This replaces the old grid that was sized by the
+    # padded chunk_indices.shape[0] (often ~16x the live chunk count). The
+    # numerator stays >= 0 because chunk_start < grid_chunks.
+    num_chunks_runtime = mNumChunks[0].to(Int32)
+    iters = (num_chunks_runtime - chunk_start + grid_chunks - 1) // grid_chunks
+
+    # SMEM is allocated once and reused across the chunk-loop iterations.
+    smem = cutlass.utils.SmemAllocator()
+    sQ_tile = smem.allocate_tensor(
+        element_type=cutlass.BFloat16,
+        layout=cute.make_layout((BT * KEY_DIM_PER_CTA,), stride=(1,)),
+        byte_alignment=128,
+        swizzle=None,
+    )
+    sK_tile = smem.allocate_tensor(
+        element_type=cutlass.BFloat16,
+        layout=cute.make_layout((BT * KEY_DIM_PER_CTA,), stride=(1,)),
+        byte_alignment=128,
+        swizzle=None,
+    )
+    sG_tile = smem.allocate_tensor(
+        element_type=cutlass.Float32,
+        layout=cute.make_layout((BT * KEY_DIM_PER_CTA,), stride=(1,)),
+        byte_alignment=128,
+        swizzle=None,
+    )
+    sBeta_tile = smem.allocate_tensor(
+        element_type=cutlass.Float32,
+        layout=cute.make_layout((BT,), stride=(1,)),
+        byte_alignment=128,
+        swizzle=None,
+    )
+    sEpi_tile = smem.allocate_tensor(
+        element_type=cutlass.BFloat16,
+        layout=cute.make_layout((2048,), stride=(1,)),
+        byte_alignment=128,
+        swizzle=None,
+    )
+
+    for chunk_iter in cutlass.range(iters, unroll=1):
+        chunk_block = chunk_start + chunk_iter * grid_chunks
+        seq_idx = Int32(0)
+        chunk_idx = Int32(0)
+        bos = Int32(0)
+        eos = Int32(0)
+        if use_i32_metadata:
+            seq_idx = mChunkIndices[chunk_block, 0].to(Int32)
+            chunk_idx = mChunkIndices[chunk_block, 1].to(Int32)
+            bos = mCuSeqlens[seq_idx].to(Int32)
+            eos = mCuSeqlens[seq_idx + 1].to(Int32)
+        else:
+            seq_idx = mChunkIndices[chunk_block, 0].to(Int32)
+            chunk_idx = mChunkIndices[chunk_block, 1].to(Int32)
+            bos = mCuSeqlens[seq_idx].to(Int32)
+            eos = mCuSeqlens[seq_idx + 1].to(Int32)
+        row_start = bos + chunk_idx * BT
+        valid = cutlass.min(eos - row_start, Int32(BT))
+        # Match Triton's default safe-gate normalization reference
+        # (causal_gate_normref=False): use the middle row of this BC subchunk,
+        # clamped for partial chunks. This keeps local diagonal dA scaling
+        # finite for dense causal dA without relying on a near-diagonal dA
+        # property.
+        ref_prev = cutlass.min(row_base, valid - 1)
+        ref_qk = cutlass.min(row_base + BC // 2, valid - 1)
+        ref_future = cutlass.min(row_base + BC, valid) - 1
+        daqk_row_stride = mdAqk.layout.stride[1]
+        daqk_head_stride = mdAqk.layout.stride[2]
+        dakk_row_stride = mdAkk.layout.stride[1]
+        dakk_head_stride = mdAkk.layout.stride[2]
+        dq_row_stride = mDq.layout.stride[1]
+        dq_head_stride = mDq.layout.stride[2]
+        dq2_row_stride = mDq2.layout.stride[1]
+        dq2_head_stride = mDq2.layout.stride[2]
+        dk_row_stride = mDk.layout.stride[1]
+        dk_head_stride = mDk.layout.stride[2]
+        dk2_row_stride = mDk2.layout.stride[1]
+        dk2_head_stride = mDk2.layout.stride[2]
+        dg_row_stride = mDg.layout.stride[1]
+        dg_head_stride = mDg.layout.stride[2]
+        dg2_row_stride = mDg2.layout.stride[1]
+        dg2_head_stride = mDg2.layout.stride[2]
+        db2_k_stride = mDb2.layout.stride[0]
+        db2_row_stride = mDb2.layout.stride[1]
+        db2_head_stride = mDb2.layout.stride[2]
+
+        z = Float32(0.0)
+        beta_row0 = tidx
+        beta_row1 = tidx + 32
+        beta_val0 = z
+        beta_val1 = z
+        if (beta_row0 >= row_base) & (beta_row0 < valid):
+            beta_val0 = mBeta[0, row_start + beta_row0, head_idx]
+        if (beta_row1 >= row_base) & (beta_row1 < valid):
+            beta_val1 = mBeta[0, row_start + beta_row1, head_idx]
+        sBeta_tile[beta_row0] = beta_val0
+        sBeta_tile[beta_row1] = beta_val1
+        _copy_qkg_smem_cpasync(
+            sQ_tile,
+            sK_tile,
+            sG_tile,
+            mQ,
+            mK,
+            mG,
+            row_start,
+            head_idx,
+            k_start,
+            valid,
+            tidx,
+        )
+        gref_qk0 = sG_tile[ref_qk * KEY_DIM_PER_CTA + gid]
+        gref_qk1 = sG_tile[ref_qk * KEY_DIM_PER_CTA + 8 + gid]
+        gref_qk2 = sG_tile[ref_qk * KEY_DIM_PER_CTA + 16 + gid]
+        gref_qk3 = sG_tile[ref_qk * KEY_DIM_PER_CTA + 24 + gid]
+        gref_prev0 = sG_tile[ref_prev * KEY_DIM_PER_CTA + gid]
+        gref_prev1 = sG_tile[ref_prev * KEY_DIM_PER_CTA + 8 + gid]
+        gref_prev2 = sG_tile[ref_prev * KEY_DIM_PER_CTA + 16 + gid]
+        gref_prev3 = sG_tile[ref_prev * KEY_DIM_PER_CTA + 24 + gid]
+        gref_future0 = sG_tile[ref_future * KEY_DIM_PER_CTA + gid]
+        gref_future1 = sG_tile[ref_future * KEY_DIM_PER_CTA + 8 + gid]
+        gref_future2 = sG_tile[ref_future * KEY_DIM_PER_CTA + 16 + gid]
+        gref_future3 = sG_tile[ref_future * KEY_DIM_PER_CTA + 24 + gid]
+        q00 = z
+        q01 = z
+        q02 = z
+        q03 = z
+        q10 = z
+        q11 = z
+        q12 = z
+        q13 = z
+        q20 = z
+        q21 = z
+        q22 = z
+        q23 = z
+        q30 = z
+        q31 = z
+        q32 = z
+        q33 = z
+        k00 = z
+        k01 = z
+        k02 = z
+        k03 = z
+        k10 = z
+        k11 = z
+        k12 = z
+        k13 = z
+        k20 = z
+        k21 = z
+        k22 = z
+        k23 = z
+        k30 = z
+        k31 = z
+        k32 = z
+        k33 = z
+        qd00 = z
+        qd01 = z
+        qd02 = z
+        qd03 = z
+        qd10 = z
+        qd11 = z
+        qd12 = z
+        qd13 = z
+        qd20 = z
+        qd21 = z
+        qd22 = z
+        qd23 = z
+        qd30 = z
+        qd31 = z
+        qd32 = z
+        qd33 = z
+        kd00 = z
+        kd01 = z
+        kd02 = z
+        kd03 = z
+        kd10 = z
+        kd11 = z
+        kd12 = z
+        kd13 = z
+        kd20 = z
+        kd21 = z
+        kd22 = z
+        kd23 = z
+        kd30 = z
+        kd31 = z
+        kd32 = z
+        kd33 = z
+        t00 = z
+        t01 = z
+        t02 = z
+        t03 = z
+        t10 = z
+        t11 = z
+        t12 = z
+        t13 = z
+        t20 = z
+        t21 = z
+        t22 = z
+        t23 = z
+        t30 = z
+        t31 = z
+        t32 = z
+        t33 = z
+        d00 = z
+        d01 = z
+        d02 = z
+        d03 = z
+        d10 = z
+        d11 = z
+        d12 = z
+        d13 = z
+        d20 = z
+        d21 = z
+        d22 = z
+        d23 = z
+        d30 = z
+        d31 = z
+        d32 = z
+        d33 = z
+
+        for j_block in cutlass.range(subchunk_idx):
+            key_base = j_block * BC
+            for k_outer in cutlass.range_constexpr(2):
+                key0 = key_base + k_outer * 8 + 2 * tid
+                key1 = key0 + 1
+                aq0, aq2 = _hmma_load_da_pair(
+                    mdAqk,
+                    row_start,
+                    head_idx,
+                    row0,
+                    key0,
+                    valid,
+                    daqk_row_stride,
+                    daqk_head_stride,
+                )
+                ak0, ak2 = _hmma_load_da_pair(
+                    mdAkk,
+                    row_start,
+                    head_idx,
+                    row0,
+                    key0,
+                    valid,
+                    dakk_row_stride,
+                    dakk_head_stride,
+                )
+                aq1, aq3 = _hmma_load_da_pair(
+                    mdAqk,
+                    row_start,
+                    head_idx,
+                    row1,
+                    key0,
+                    valid,
+                    daqk_row_stride,
+                    daqk_head_stride,
+                )
+                ak1, ak3 = _hmma_load_da_pair(
+                    mdAkk,
+                    row_start,
+                    head_idx,
+                    row1,
+                    key0,
+                    valid,
+                    dakk_row_stride,
+                    dakk_head_stride,
+                )
+                kb00, kb01, kb10, kb11, kb20, kb21, kb30, kb31 = (
+                    _hmma_load_b_groups_smem_ldmatrix(sK_tile, key_base, k_outer, tidx)
+                )
+
+                for group in cutlass.range_constexpr(4):
+                    col_a = group * 8
+                    col_load = col_a + gid
+                    gref = gref_prev0
+                    if group == 1:
+                        gref = gref_prev1
+                    if group == 2:
+                        gref = gref_prev2
+                    if group == 3:
+                        gref = gref_prev3
+                    gk0 = sG_tile[key0 * KEY_DIM_PER_CTA + col_load]
+                    gk1 = sG_tile[key1 * KEY_DIM_PER_CTA + col_load]
+                    kb0 = kb00
+                    kb1 = kb01
+                    if group == 1:
+                        kb0 = kb10
+                        kb1 = kb11
+                    if group == 2:
+                        kb0 = kb20
+                        kb1 = kb21
+                    if group == 3:
+                        kb0 = kb30
+                        kb1 = kb31
+                    b0 = kb0 * cute.math.exp2(gref - gk0, fastmath=True)
+                    b1 = kb1 * cute.math.exp2(gref - gk1, fastmath=True)
+                    b0 = b0 if key0 < valid else z
+                    b1 = b1 if key1 < valid else z
+                    _hmma_stage_b_group_stmatrix(sEpi_tile, b0, b1, tidx)
+                    _bar_warp_sync()
+                    b0, b1 = _hmma_load_b_group_stmatrix(sEpi_tile, tidx)
+                    if group == 0:
+                        q00, q01, q02, q03 = _mma_tf32_m16n8k8(
+                            aq0, aq1, aq2, aq3, b0, b1, q00, q01, q02, q03
+                        )
+                        k00, k01, k02, k03 = _mma_tf32_m16n8k8(
+                            ak0, ak1, ak2, ak3, b0, b1, k00, k01, k02, k03
+                        )
+                    if group == 1:
+                        q10, q11, q12, q13 = _mma_tf32_m16n8k8(
+                            aq0, aq1, aq2, aq3, b0, b1, q10, q11, q12, q13
+                        )
+                        k10, k11, k12, k13 = _mma_tf32_m16n8k8(
+                            ak0, ak1, ak2, ak3, b0, b1, k10, k11, k12, k13
+                        )
+                    if group == 2:
+                        q20, q21, q22, q23 = _mma_tf32_m16n8k8(
+                            aq0, aq1, aq2, aq3, b0, b1, q20, q21, q22, q23
+                        )
+                        k20, k21, k22, k23 = _mma_tf32_m16n8k8(
+                            ak0, ak1, ak2, ak3, b0, b1, k20, k21, k22, k23
+                        )
+                    if group == 3:
+                        q30, q31, q32, q33 = _mma_tf32_m16n8k8(
+                            aq0, aq1, aq2, aq3, b0, b1, q30, q31, q32, q33
+                        )
+                        k30, k31, k32, k33 = _mma_tf32_m16n8k8(
+                            ak0, ak1, ak2, ak3, b0, b1, k30, k31, k32, k33
+                        )
+
+        key_base = row_base
+        for k_outer in cutlass.range_constexpr(2):
+            key0 = key_base + k_outer * 8 + 2 * tid
+            key1 = key0 + 1
+            keep00 = (k_outer * 8 + 2 * tid) <= gid
+            keep01 = (k_outer * 8 + 2 * tid + 1) <= gid
+            keep10 = (k_outer * 8 + 2 * tid) <= (gid + 8)
+            keep11 = (k_outer * 8 + 2 * tid + 1) <= (gid + 8)
+            aq0, aq2 = _hmma_load_da_pair_pred(
+                mdAqk,
+                row_start,
+                head_idx,
+                row0,
+                key0,
+                valid,
+                daqk_row_stride,
+                daqk_head_stride,
+                keep00,
+                keep01,
+            )
+            ak0, ak2 = _hmma_load_da_pair_pred(
+                mdAkk,
+                row_start,
+                head_idx,
+                row0,
+                key0,
+                valid,
+                dakk_row_stride,
+                dakk_head_stride,
+                keep00,
+                keep01,
+            )
+            aq1, aq3 = _hmma_load_da_pair_pred(
+                mdAqk,
+                row_start,
+                head_idx,
+                row1,
+                key0,
+                valid,
+                daqk_row_stride,
+                daqk_head_stride,
+                keep10,
+                keep11,
+            )
+            ak1, ak3 = _hmma_load_da_pair_pred(
+                mdAkk,
+                row_start,
+                head_idx,
+                row1,
+                key0,
+                valid,
+                dakk_row_stride,
+                dakk_head_stride,
+                keep10,
+                keep11,
+            )
+            kb00, kb01, kb10, kb11, kb20, kb21, kb30, kb31 = (
+                _hmma_load_b_groups_smem_ldmatrix(sK_tile, key_base, k_outer, tidx)
+            )
+
+            for group in cutlass.range_constexpr(4):
+                col_a = group * 8
+                col_load = col_a + gid
+                gref = gref_qk0
+                if group == 1:
+                    gref = gref_qk1
+                if group == 2:
+                    gref = gref_qk2
+                if group == 3:
+                    gref = gref_qk3
+                gk0 = sG_tile[key0 * KEY_DIM_PER_CTA + col_load]
+                gk1 = sG_tile[key1 * KEY_DIM_PER_CTA + col_load]
+                kb0 = kb00
+                kb1 = kb01
+                if group == 1:
+                    kb0 = kb10
+                    kb1 = kb11
+                if group == 2:
+                    kb0 = kb20
+                    kb1 = kb21
+                if group == 3:
+                    kb0 = kb30
+                    kb1 = kb31
+                b0 = kb0 * cute.math.exp2(gref - gk0, fastmath=True)
+                b1 = kb1 * cute.math.exp2(gref - gk1, fastmath=True)
+                b0 = b0 if key0 < valid else z
+                b1 = b1 if key1 < valid else z
+                _hmma_stage_b_group_stmatrix(sEpi_tile, b0, b1, tidx)
+                _bar_warp_sync()
+                b0, b1 = _hmma_load_b_group_stmatrix(sEpi_tile, tidx)
+                if group == 0:
+                    qd00, qd01, qd02, qd03 = _mma_tf32_m16n8k8(
+                        aq0, aq1, aq2, aq3, b0, b1, qd00, qd01, qd02, qd03
+                    )
+                    kd00, kd01, kd02, kd03 = _mma_tf32_m16n8k8(
+                        ak0, ak1, ak2, ak3, b0, b1, kd00, kd01, kd02, kd03
+                    )
+                if group == 1:
+                    qd10, qd11, qd12, qd13 = _mma_tf32_m16n8k8(
+                        aq0, aq1, aq2, aq3, b0, b1, qd10, qd11, qd12, qd13
+                    )
+                    kd10, kd11, kd12, kd13 = _mma_tf32_m16n8k8(
+                        ak0, ak1, ak2, ak3, b0, b1, kd10, kd11, kd12, kd13
+                    )
+                if group == 2:
+                    qd20, qd21, qd22, qd23 = _mma_tf32_m16n8k8(
+                        aq0, aq1, aq2, aq3, b0, b1, qd20, qd21, qd22, qd23
+                    )
+                    kd20, kd21, kd22, kd23 = _mma_tf32_m16n8k8(
+                        ak0, ak1, ak2, ak3, b0, b1, kd20, kd21, kd22, kd23
+                    )
+                if group == 3:
+                    qd30, qd31, qd32, qd33 = _mma_tf32_m16n8k8(
+                        aq0, aq1, aq2, aq3, b0, b1, qd30, qd31, qd32, qd33
+                    )
+                    kd30, kd31, kd32, kd33 = _mma_tf32_m16n8k8(
+                        ak0, ak1, ak2, ak3, b0, b1, kd30, kd31, kd32, kd33
+                    )
+
+        for j_block in cutlass.range(subchunk_idx + 1, SUBCHUNKS):
+            q_base = j_block * BC
+            for k_outer in cutlass.range_constexpr(2):
+                query0 = q_base + k_outer * 8 + 2 * tid
+                query1 = query0 + 1
+                aq0 = _hmma_load_da(mdAqk, row_start, head_idx, query0, row0, valid)
+                aq1 = _hmma_load_da(mdAqk, row_start, head_idx, query0, row1, valid)
+                aq2 = _hmma_load_da(mdAqk, row_start, head_idx, query1, row0, valid)
+                aq3 = _hmma_load_da(mdAqk, row_start, head_idx, query1, row1, valid)
+                ak0 = _hmma_load_da(mdAkk, row_start, head_idx, query0, row0, valid)
+                ak1 = _hmma_load_da(mdAkk, row_start, head_idx, query0, row1, valid)
+                ak2 = _hmma_load_da(mdAkk, row_start, head_idx, query1, row0, valid)
+                ak3 = _hmma_load_da(mdAkk, row_start, head_idx, query1, row1, valid)
+                bq0 = sBeta_tile[query0]
+                bq1 = sBeta_tile[query1]
+                qq00, qq01, qq10, qq11, qq20, qq21, qq30, qq31 = (
+                    _hmma_load_b_groups_smem_ldmatrix(sQ_tile, q_base, k_outer, tidx)
+                )
+                kk00, kk01, kk10, kk11, kk20, kk21, kk30, kk31 = (
+                    _hmma_load_b_groups_smem_ldmatrix(sK_tile, q_base, k_outer, tidx)
+                )
+
+                for group in cutlass.range_constexpr(4):
+                    col_a = group * 8
+                    col_load = col_a + gid
+                    gref = gref_future0
+                    if group == 1:
+                        gref = gref_future1
+                    if group == 2:
+                        gref = gref_future2
+                    if group == 3:
+                        gref = gref_future3
+                    gq0 = sG_tile[query0 * KEY_DIM_PER_CTA + col_load]
+                    gq1 = sG_tile[query1 * KEY_DIM_PER_CTA + col_load]
+                    qq0 = qq00
+                    qq1 = qq01
+                    kk0 = kk00
+                    kk1 = kk01
+                    if group == 1:
+                        qq0 = qq10
+                        qq1 = qq11
+                        kk0 = kk10
+                        kk1 = kk11
+                    if group == 2:
+                        qq0 = qq20
+                        qq1 = qq21
+                        kk0 = kk20
+                        kk1 = kk21
+                    if group == 3:
+                        qq0 = qq30
+                        qq1 = qq31
+                        kk0 = kk30
+                        kk1 = kk31
+                    e0 = cute.math.exp2(gq0 - gref, fastmath=True)
+                    e1 = cute.math.exp2(gq1 - gref, fastmath=True)
+                    b0 = qq0 * e0
+                    b1 = qq1 * e1
+                    c0 = kk0 * bq0 * e0
+                    c1 = kk1 * bq1 * e1
+                    b0 = b0 if query0 < valid else z
+                    b1 = b1 if query1 < valid else z
+                    c0 = c0 if query0 < valid else z
+                    c1 = c1 if query1 < valid else z
+                    if group == 0:
+                        t00, t01, t02, t03 = _mma_tf32_m16n8k8(
+                            aq0, aq1, aq2, aq3, b0, b1, t00, t01, t02, t03
+                        )
+                        t00, t01, t02, t03 = _mma_tf32_m16n8k8(
+                            ak0, ak1, ak2, ak3, c0, c1, t00, t01, t02, t03
+                        )
+                    if group == 1:
+                        t10, t11, t12, t13 = _mma_tf32_m16n8k8(
+                            aq0, aq1, aq2, aq3, b0, b1, t10, t11, t12, t13
+                        )
+                        t10, t11, t12, t13 = _mma_tf32_m16n8k8(
+                            ak0, ak1, ak2, ak3, c0, c1, t10, t11, t12, t13
+                        )
+                    if group == 2:
+                        t20, t21, t22, t23 = _mma_tf32_m16n8k8(
+                            aq0, aq1, aq2, aq3, b0, b1, t20, t21, t22, t23
+                        )
+                        t20, t21, t22, t23 = _mma_tf32_m16n8k8(
+                            ak0, ak1, ak2, ak3, c0, c1, t20, t21, t22, t23
+                        )
+                    if group == 3:
+                        t30, t31, t32, t33 = _mma_tf32_m16n8k8(
+                            aq0, aq1, aq2, aq3, b0, b1, t30, t31, t32, t33
+                        )
+                        t30, t31, t32, t33 = _mma_tf32_m16n8k8(
+                            ak0, ak1, ak2, ak3, c0, c1, t30, t31, t32, t33
+                        )
+
+        for k_outer in cutlass.range_constexpr(2):
+            query0 = row_base + k_outer * 8 + 2 * tid
+            query1 = query0 + 1
+            keep00 = gid <= (k_outer * 8 + 2 * tid)
+            keep01 = gid <= (k_outer * 8 + 2 * tid + 1)
+            keep10 = (gid + 8) <= (k_outer * 8 + 2 * tid)
+            keep11 = (gid + 8) <= (k_outer * 8 + 2 * tid + 1)
+            aq0 = _hmma_load_da_pred(
+                mdAqk, row_start, head_idx, query0, row0, valid, keep00
+            )
+            aq1 = _hmma_load_da_pred(
+                mdAqk, row_start, head_idx, query0, row1, valid, keep10
+            )
+            aq2 = _hmma_load_da_pred(
+                mdAqk, row_start, head_idx, query1, row0, valid, keep01
+            )
+            aq3 = _hmma_load_da_pred(
+                mdAqk, row_start, head_idx, query1, row1, valid, keep11
+            )
+            ak0 = _hmma_load_da_pred(
+                mdAkk, row_start, head_idx, query0, row0, valid, keep00
+            )
+            ak1 = _hmma_load_da_pred(
+                mdAkk, row_start, head_idx, query0, row1, valid, keep10
+            )
+            ak2 = _hmma_load_da_pred(
+                mdAkk, row_start, head_idx, query1, row0, valid, keep01
+            )
+            ak3 = _hmma_load_da_pred(
+                mdAkk, row_start, head_idx, query1, row1, valid, keep11
+            )
+            bq0 = sBeta_tile[query0]
+            bq1 = sBeta_tile[query1]
+            qq00, qq01, qq10, qq11, qq20, qq21, qq30, qq31 = (
+                _hmma_load_b_groups_smem_ldmatrix(sQ_tile, row_base, k_outer, tidx)
+            )
+            kk00, kk01, kk10, kk11, kk20, kk21, kk30, kk31 = (
+                _hmma_load_b_groups_smem_ldmatrix(sK_tile, row_base, k_outer, tidx)
+            )
+
+            for group in cutlass.range_constexpr(4):
+                col_a = group * 8
+                col_load = col_a + gid
+                gref = gref_qk0
+                if group == 1:
+                    gref = gref_qk1
+                if group == 2:
+                    gref = gref_qk2
+                if group == 3:
+                    gref = gref_qk3
+                gq0 = sG_tile[query0 * KEY_DIM_PER_CTA + col_load]
+                gq1 = sG_tile[query1 * KEY_DIM_PER_CTA + col_load]
+                qq0 = qq00
+                qq1 = qq01
+                kk0 = kk00
+                kk1 = kk01
+                if group == 1:
+                    qq0 = qq10
+                    qq1 = qq11
+                    kk0 = kk10
+                    kk1 = kk11
+                if group == 2:
+                    qq0 = qq20
+                    qq1 = qq21
+                    kk0 = kk20
+                    kk1 = kk21
+                if group == 3:
+                    qq0 = qq30
+                    qq1 = qq31
+                    kk0 = kk30
+                    kk1 = kk31
+                e0 = cute.math.exp2(gq0 - gref, fastmath=True)
+                e1 = cute.math.exp2(gq1 - gref, fastmath=True)
+                b0 = qq0 * e0
+                b1 = qq1 * e1
+                c0 = kk0 * bq0 * e0
+                c1 = kk1 * bq1 * e1
+                b0 = b0 if query0 < valid else z
+                b1 = b1 if query1 < valid else z
+                c0 = c0 if query0 < valid else z
+                c1 = c1 if query1 < valid else z
+                if group == 0:
+                    d00, d01, d02, d03 = _mma_tf32_m16n8k8(
+                        aq0, aq1, aq2, aq3, b0, b1, d00, d01, d02, d03
+                    )
+                    d00, d01, d02, d03 = _mma_tf32_m16n8k8(
+                        ak0, ak1, ak2, ak3, c0, c1, d00, d01, d02, d03
+                    )
+                if group == 1:
+                    d10, d11, d12, d13 = _mma_tf32_m16n8k8(
+                        aq0, aq1, aq2, aq3, b0, b1, d10, d11, d12, d13
+                    )
+                    d10, d11, d12, d13 = _mma_tf32_m16n8k8(
+                        ak0, ak1, ak2, ak3, c0, c1, d10, d11, d12, d13
+                    )
+                if group == 2:
+                    d20, d21, d22, d23 = _mma_tf32_m16n8k8(
+                        aq0, aq1, aq2, aq3, b0, b1, d20, d21, d22, d23
+                    )
+                    d20, d21, d22, d23 = _mma_tf32_m16n8k8(
+                        ak0, ak1, ak2, ak3, c0, c1, d20, d21, d22, d23
+                    )
+                if group == 3:
+                    d30, d31, d32, d33 = _mma_tf32_m16n8k8(
+                        aq0, aq1, aq2, aq3, b0, b1, d30, d31, d32, d33
+                    )
+                    d30, d31, d32, d33 = _mma_tf32_m16n8k8(
+                        ak0, ak1, ak2, ak3, c0, c1, d30, d31, d32, d33
+                    )
+
+        db_acc0 = z
+        db_acc1 = z
+        dq_top0 = Int32(0)
+        dq_top1 = Int32(0)
+        dq_top2 = Int32(0)
+        dq_top3 = Int32(0)
+        dq_bottom0 = Int32(0)
+        dq_bottom1 = Int32(0)
+        dq_bottom2 = Int32(0)
+        dq_bottom3 = Int32(0)
+        dk_top0 = Int32(0)
+        dk_top1 = Int32(0)
+        dk_top2 = Int32(0)
+        dk_top3 = Int32(0)
+        dk_bottom0 = Int32(0)
+        dk_bottom1 = Int32(0)
+        dk_bottom2 = Int32(0)
+        dk_bottom3 = Int32(0)
+        dg_top00 = z
+        dg_top01 = z
+        dg_top10 = z
+        dg_top11 = z
+        dg_top20 = z
+        dg_top21 = z
+        dg_top30 = z
+        dg_top31 = z
+        dg_bottom00 = z
+        dg_bottom01 = z
+        dg_bottom10 = z
+        dg_bottom11 = z
+        dg_bottom20 = z
+        dg_bottom21 = z
+        dg_bottom30 = z
+        dg_bottom31 = z
+        for group in cutlass.range_constexpr(4):
+            col_a = group * 8
+            col0 = k_start + col_a + 2 * tid
+            local_col0 = col_a + 2 * tid
+            dq_word0 = Int32(0)
+            dq_word1 = Int32(0)
+            dk_word0 = Int32(0)
+            dk_word1 = Int32(0)
+            dg_top0 = z
+            dg_top1 = z
+            dg_bottom0 = z
+            dg_bottom1 = z
+            gref_prev_offset = ref_prev * KEY_DIM_PER_CTA + local_col0
+            gref_qk_offset = ref_qk * KEY_DIM_PER_CTA + local_col0
+            gref_t_offset = ref_future * KEY_DIM_PER_CTA + local_col0
+            gref_prev0 = sG_tile[gref_prev_offset]
+            gref_prev1 = sG_tile[gref_prev_offset + 1]
+            gref_qk0 = sG_tile[gref_qk_offset]
+            gref_qk1 = sG_tile[gref_qk_offset + 1]
+            gref_t0 = sG_tile[gref_t_offset]
+            gref_t1 = sG_tile[gref_t_offset + 1]
+            qk_from_prev0 = cute.math.exp2(gref_prev0 - gref_qk0, fastmath=True)
+            qk_from_prev1 = cute.math.exp2(gref_prev1 - gref_qk1, fastmath=True)
+            tref0 = cute.math.exp2(gref_t0 - gref_qk0, fastmath=True)
+            tref1 = cute.math.exp2(gref_t1 - gref_qk1, fastmath=True)
+
+            for lane_row in cutlass.range_constexpr(2):
+                row = row0 if lane_row == 0 else row1
+                q_acc0 = q00 if lane_row == 0 else q02
+                q_acc1 = q01 if lane_row == 0 else q03
+                k_acc0 = k00 if lane_row == 0 else k02
+                k_acc1 = k01 if lane_row == 0 else k03
+                q_diag0 = qd00 if lane_row == 0 else qd02
+                q_diag1 = qd01 if lane_row == 0 else qd03
+                k_diag0 = kd00 if lane_row == 0 else kd02
+                k_diag1 = kd01 if lane_row == 0 else kd03
+                t_acc0 = t00 if lane_row == 0 else t02
+                t_acc1 = t01 if lane_row == 0 else t03
+                d_acc0 = d00 if lane_row == 0 else d02
+                d_acc1 = d01 if lane_row == 0 else d03
+                if group == 1:
+                    q_acc0 = q10 if lane_row == 0 else q12
+                    q_acc1 = q11 if lane_row == 0 else q13
+                    k_acc0 = k10 if lane_row == 0 else k12
+                    k_acc1 = k11 if lane_row == 0 else k13
+                    q_diag0 = qd10 if lane_row == 0 else qd12
+                    q_diag1 = qd11 if lane_row == 0 else qd13
+                    k_diag0 = kd10 if lane_row == 0 else kd12
+                    k_diag1 = kd11 if lane_row == 0 else kd13
+                    t_acc0 = t10 if lane_row == 0 else t12
+                    t_acc1 = t11 if lane_row == 0 else t13
+                    d_acc0 = d10 if lane_row == 0 else d12
+                    d_acc1 = d11 if lane_row == 0 else d13
+                if group == 2:
+                    q_acc0 = q20 if lane_row == 0 else q22
+                    q_acc1 = q21 if lane_row == 0 else q23
+                    k_acc0 = k20 if lane_row == 0 else k22
+                    k_acc1 = k21 if lane_row == 0 else k23
+                    q_diag0 = qd20 if lane_row == 0 else qd22
+                    q_diag1 = qd21 if lane_row == 0 else qd23
+                    k_diag0 = kd20 if lane_row == 0 else kd22
+                    k_diag1 = kd21 if lane_row == 0 else kd23
+                    t_acc0 = t20 if lane_row == 0 else t22
+                    t_acc1 = t21 if lane_row == 0 else t23
+                    d_acc0 = d20 if lane_row == 0 else d22
+                    d_acc1 = d21 if lane_row == 0 else d23
+                if group == 3:
+                    q_acc0 = q30 if lane_row == 0 else q32
+                    q_acc1 = q31 if lane_row == 0 else q33
+                    k_acc0 = k30 if lane_row == 0 else k32
+                    k_acc1 = k31 if lane_row == 0 else k33
+                    q_diag0 = qd30 if lane_row == 0 else qd32
+                    q_diag1 = qd31 if lane_row == 0 else qd33
+                    k_diag0 = kd30 if lane_row == 0 else kd32
+                    k_diag1 = kd31 if lane_row == 0 else kd33
+                    t_acc0 = t30 if lane_row == 0 else t32
+                    t_acc1 = t31 if lane_row == 0 else t33
+                    d_acc0 = d30 if lane_row == 0 else d32
+                    d_acc1 = d31 if lane_row == 0 else d33
+
+                row_valid = Boolean(row < valid)
+                out_row = row_start + row
+                row_offset = row * KEY_DIM_PER_CTA + local_col0
+                qval0 = sQ_tile[row_offset].to(Float32)
+                qval1 = sQ_tile[row_offset + 1].to(Float32)
+                kval0 = sK_tile[row_offset].to(Float32)
+                kval1 = sK_tile[row_offset + 1].to(Float32)
+                grow0 = sG_tile[row_offset]
+                grow1 = sG_tile[row_offset + 1]
+                beta_row = sBeta_tile[row]
+                qscale_prev0 = cute.math.exp2(grow0 - gref_prev0, fastmath=True)
+                qscale_prev1 = cute.math.exp2(grow1 - gref_prev1, fastmath=True)
+                qscale_diag0 = qscale_prev0 * qk_from_prev0
+                qscale_diag1 = qscale_prev1 * qk_from_prev1
+                dscale0 = cute.math.exp2(gref_qk0 - grow0, fastmath=True)
+                dscale1 = cute.math.exp2(gref_qk1 - grow1, fastmath=True)
+                tscale0 = dscale0 * tref0
+                tscale1 = dscale1 * tref1
+                dq_in0, dq_in1 = _ld_global_f32x4_lo2_pred(
+                    mDq.iterator
+                    + out_row * dq_row_stride
+                    + head_idx * dq_head_stride
+                    + col0,
+                    row_valid,
+                )
+                dk_in0, dk_in1 = _ld_global_f32x4_lo2_pred(
+                    mDk.iterator
+                    + out_row * dk_row_stride
+                    + head_idx * dk_head_stride
+                    + col0,
+                    row_valid,
+                )
+                dg_in0, dg_in1 = _ld_global_f32x2_pred(
+                    mDg.iterator
+                    + out_row * dg_row_stride
+                    + head_idx * dg_head_stride
+                    + col0,
+                    row_valid,
+                )
+                dq_add0 = q_acc0 * qscale_prev0 + q_diag0 * qscale_diag0
+                dq_add1 = q_acc1 * qscale_prev1 + q_diag1 * qscale_diag1
+                dq_out0, dq_out1 = _add_f32x2(dq_in0, dq_in1, dq_add0, dq_add1)
+                if lane_row == 0:
+                    dq_word0 = _cvt_bf16x2_f32(dq_out0, dq_out1)
+                else:
+                    dq_word1 = _cvt_bf16x2_f32(dq_out0, dq_out1)
+                dk_qk0 = k_acc0 * qscale_prev0 + k_diag0 * qscale_diag0
+                dk_qk1 = k_acc1 * qscale_prev1 + k_diag1 * qscale_diag1
+                dkt0 = d_acc0 * dscale0 + t_acc0 * tscale0
+                dkt1 = d_acc1 * dscale1 + t_acc1 * tscale1
+                dk_beta0 = dk_qk0 * beta_row
+                dk_beta1 = dk_qk1 * beta_row
+                dk_add0 = dk_beta0 + dkt0
+                dk_add1 = dk_beta1 + dkt1
+                dk_out0, dk_out1 = _add_f32x2(dk_in0, dk_in1, dk_add0, dk_add1)
+                if lane_row == 0:
+                    dk_word0 = _cvt_bf16x2_f32(dk_out0, dk_out1)
+                else:
+                    dk_word1 = _cvt_bf16x2_f32(dk_out0, dk_out1)
+                dg_out0 = dg_in0 + dq_add0 * qval0 + (dk_beta0 - dkt0) * kval0
+                dg_out1 = dg_in1 + dq_add1 * qval1 + (dk_beta1 - dkt1) * kval1
+                if lane_row == 0:
+                    dg_top0 = dg_out0
+                    dg_top1 = dg_out1
+                else:
+                    dg_bottom0 = dg_out0
+                    dg_bottom1 = dg_out1
+                db_pair = dk_qk0 * kval0 + dk_qk1 * kval1
+                if lane_row == 0:
+                    db_acc0 = db_acc0 + db_pair
+                else:
+                    db_acc1 = db_acc1 + db_pair
+
+            if group == 0:
+                dq_top0 = dq_word0
+                dq_bottom0 = dq_word1
+                dk_top0 = dk_word0
+                dk_bottom0 = dk_word1
+                dg_top00 = dg_top0
+                dg_top01 = dg_top1
+                dg_bottom00 = dg_bottom0
+                dg_bottom01 = dg_bottom1
+            if group == 1:
+                dq_top1 = dq_word0
+                dq_bottom1 = dq_word1
+                dk_top1 = dk_word0
+                dk_bottom1 = dk_word1
+                dg_top10 = dg_top0
+                dg_top11 = dg_top1
+                dg_bottom10 = dg_bottom0
+                dg_bottom11 = dg_bottom1
+            if group == 2:
+                dq_top2 = dq_word0
+                dq_bottom2 = dq_word1
+                dk_top2 = dk_word0
+                dk_bottom2 = dk_word1
+                dg_top20 = dg_top0
+                dg_top21 = dg_top1
+                dg_bottom20 = dg_bottom0
+                dg_bottom21 = dg_bottom1
+            if group == 3:
+                dq_top3 = dq_word0
+                dq_bottom3 = dq_word1
+                dk_top3 = dk_word0
+                dk_bottom3 = dk_word1
+                dg_top30 = dg_top0
+                dg_top31 = dg_top1
+                dg_bottom30 = dg_bottom0
+                dg_bottom31 = dg_bottom1
+
+        _st_shared_dg_triton_swizzle(
+            sEpi_tile,
+            0,
+            dg_top00,
+            dg_top01,
+            dg_bottom00,
+            dg_bottom01,
+            tidx,
+        )
+        _st_shared_dg_triton_swizzle(
+            sEpi_tile,
+            1,
+            dg_top10,
+            dg_top11,
+            dg_bottom10,
+            dg_bottom11,
+            tidx,
+        )
+        _st_shared_dg_triton_swizzle(
+            sEpi_tile,
+            2,
+            dg_top20,
+            dg_top21,
+            dg_bottom20,
+            dg_bottom21,
+            tidx,
+        )
+        _st_shared_dg_triton_swizzle(
+            sEpi_tile,
+            3,
+            dg_top30,
+            dg_top31,
+            dg_bottom30,
+            dg_bottom31,
+            tidx,
+        )
+
+        _st_global_f32_triton_shared_epilogue_16x32(
+            sEpi_tile,
+            mDg2.iterator
+            + (row_start + row_base) * dg2_row_stride
+            + head_idx * dg2_head_stride
+            + k_start,
+            tidx,
+            row_base=row_base,
+            valid=valid,
+            row_stride=dg2_row_stride,
+        )
+        _st_global_bf16_ldmatrix_epilogue_16x32(
+            sEpi_tile,
+            mDq2.iterator
+            + (row_start + row_base) * dq2_row_stride
+            + head_idx * dq2_head_stride
+            + k_start,
+            dq_top0,
+            dq_top1,
+            dq_top2,
+            dq_top3,
+            dq_bottom0,
+            dq_bottom1,
+            dq_bottom2,
+            dq_bottom3,
+            tidx,
+            row_base=row_base,
+            valid=valid,
+            row_stride=dq2_row_stride,
+        )
+        _st_global_bf16_ldmatrix_epilogue_16x32(
+            sEpi_tile,
+            mDk2.iterator
+            + (row_start + row_base) * dk2_row_stride
+            + head_idx * dk2_head_stride
+            + k_start,
+            dk_top0,
+            dk_top1,
+            dk_top2,
+            dk_top3,
+            dk_bottom0,
+            dk_bottom1,
+            dk_bottom2,
+            dk_bottom3,
+            tidx,
+            row_base=row_base,
+            valid=valid,
+            row_stride=dk2_row_stride,
+        )
+
+        db_acc0 = db_acc0 + cute.arch.shuffle_sync_bfly(db_acc0, 1)
+        db_acc0 = db_acc0 + cute.arch.shuffle_sync_bfly(db_acc0, 2)
+        db_acc1 = db_acc1 + cute.arch.shuffle_sync_bfly(db_acc1, 1)
+        db_acc1 = db_acc1 + cute.arch.shuffle_sync_bfly(db_acc1, 2)
+        _st_global_f32_b32_pred(
+            mDb2.iterator
+            + k_phase * db2_k_stride
+            + (row_start + row0) * db2_row_stride
+            + head_idx * db2_head_stride,
+            db_acc0,
+            Boolean((tid == 0) & (row0 < valid)),
+        )
+        _st_global_f32_b32_pred(
+            mDb2.iterator
+            + k_phase * db2_k_stride
+            + (row_start + row1) * db2_row_stride
+            + head_idx * db2_head_stride,
+            db_acc1,
+            Boolean((tid == 0) & (row1 < valid)),
+        )
+
+        # Reused SMEM (sQ/sK/sG/sBeta/sEpi) is overwritten by the next
+        # persistent iteration's staging; fence reads of this iteration first.
+        cute.arch.barrier()
+
+
+class ChunkKdaBwdIntraHmmaGrid:
+    def __init__(self, use_i32_metadata: bool, grid_chunks: int):
+        self.use_i32_metadata = use_i32_metadata
+        self.grid_chunks = grid_chunks
+
+    @cute.jit
+    def __call__(
+        self,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mG: cute.Tensor,
+        mBeta: cute.Tensor,
+        mdAqk: cute.Tensor,
+        mdAkk: cute.Tensor,
+        mDq: cute.Tensor,
+        mDk: cute.Tensor,
+        mDb2: cute.Tensor,
+        mDg: cute.Tensor,
+        mDq2: cute.Tensor,
+        mDk2: cute.Tensor,
+        mDg2: cute.Tensor,
+        mCuSeqlens: cute.Tensor,
+        mChunkIndices: cute.Tensor,
+        mNumChunks: cute.Tensor,
+        stream: cuda.CUstream = None,
+    ):
+        _chunk_kda_bwd_intra_hmma_grid_kernel.set_name_prefix(
+            "cutlass_dsl_chunk_kda_bwd_intra"
+        )
+        _chunk_kda_bwd_intra_hmma_grid_kernel(
+            mQ,
+            mK,
+            mG,
+            mBeta,
+            mdAqk,
+            mdAkk,
+            mDq,
+            mDk,
+            mDb2,
+            mDg,
+            mDq2,
+            mDk2,
+            mDg2,
+            mCuSeqlens,
+            mChunkIndices,
+            mNumChunks,
+            self.use_i32_metadata,
+            self.grid_chunks,
+        ).launch(
+            grid=(KC_TOTAL, self.grid_chunks, cute.size(mQ.shape[2])),
+            block=(32, 1, 1),
+            stream=stream,
+        )
+

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_wy_dqkg_fused.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_wy_dqkg_fused.py
@@ -1,0 +1,4713 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# CuTe DSL fused WY / (I-Akk)^-1 chunk-level backward for KDA on SM100 / GB200.
+# Adapted from the cuLA TMA/UMMA implementation and wrapped in the MSLK KDA API.
+#
+# pyre-ignore-all-errors
+
+import os
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.pipeline as pipeline
+import cutlass.utils as utils
+import cutlass.utils.blackwell_helpers as sm100_utils
+import torch
+from cutlass.cute.arch import (
+    elect_one,
+    mbarrier_arrive,
+    mbarrier_arrive_and_expect_tx,
+    mbarrier_init,
+    mbarrier_init_fence,
+    mbarrier_wait,
+)
+from cutlass.cute.nvgpu import cpasync, tcgen05
+from cutlass.cute.nvgpu.tcgen05 import make_umma_smem_desc, smem_descriptor_to_int
+from cutlass.cute.tensor import TensorSSA
+from cutlass.cute.typing import BFloat16, Float32, Int32, Int64
+
+
+# ============================================================================
+# Inlined SM100 tcgen05 helper wrappers
+# ============================================================================
+
+# ---- ptx_umma_ext.py ----
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+#
+# Adapted from cuLA's SM100 tcgen05 MMA extension wrappers.
+#
+# Copyright (c) 2025 ANTGROUP. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CuteDSL UMMA extension wrappers for SM100 (Blackwell) ``tcgen05.mma``.
+
+CuteDSL's high-level ``cute.gemm()`` / ``make_tiled_mma()`` API does not
+expose all ``tcgen05.mma`` instruction variants.  This module provides
+low-level wrappers for the two categories currently needed:
+
+1. **Masked MMA** – SS and TS forms with the 128-bit ``disable-output-lane``
+   mask operand (``{m0, m1, m2, m3}``).  Implemented via the native
+   ``nvvm.tcgen05_mma`` MLIR op with its ``write_disable_mask`` parameter
+   (``vector<4xi32>``).
+
+2. **Weight-stationary (WS) MMA** – ``tcgen05.mma.ws`` SS / TS forms for
+   both ``kind::tf32`` and ``kind::f16``.  Implemented via
+   ``llvm.inline_asm``.
+
+----------------------------------------------------------------------
+PTX instruction forms
+----------------------------------------------------------------------
+SS (SMEM A, SMEM B):
+    tcgen05.mma.cta_group::1.kind::tf32  [tmem_c], desc_a, desc_b,
+                                          desc_val, {m0,m1,m2,m3}, p;
+
+TS (TMEM A, SMEM B):
+    tcgen05.mma.cta_group::1.kind::tf32  [tmem_c], [tmem_a], desc_b,
+                                          desc_val, {m0,m1,m2,m3}, p;
+
+WS_SS (weight-stationary, SMEM A, SMEM B):
+    tcgen05.mma.ws.cta_group::1.kind::tf32  [tmem_c], desc_a, desc_b,
+                                             desc_val, p;
+    tcgen05.mma.ws.cta_group::1.kind::f16   [tmem_c], desc_a, desc_b,
+                                             desc_val, p;
+
+WS_TS (weight-stationary, TMEM A, SMEM B):
+    tcgen05.mma.ws.cta_group::1.kind::tf32  [tmem_c], [tmem_a], desc_b,
+                                             desc_val, p;
+    tcgen05.mma.ws.cta_group::1.kind::f16   [tmem_c], [tmem_a], desc_b,
+                                             desc_val, p;
+
+----------------------------------------------------------------------
+Disable-output-lane mask layout (4 × uint32 = 128 bits)
+----------------------------------------------------------------------
+Each uint32 covers 32 M-dimension rows (8 rows × 4 elements per group).
+  0x00000000  → group is ACTIVE    (output written)
+  0xFFFFFFFF  → group is DISABLED  (output suppressed)
+
+Predefined SS mask constants (SMEM A variants):
+  SS_NO_MASK  = (0, 0, 0, 0)                       all rows active
+  SS_MASK0    = (0, 0xFF…, 0, 0xFF…)               odd groups disabled
+  SS_MASK1    = (0xFF…, 0, 0xFF…, 0)               even groups disabled
+  SS_MASK2    = (0xFF…, 0xFF…, 0, 0xFF…)           group 2 only active
+  SS_MASK3    = (0xFF…, 0xFF…, 0xFF…, 0)           group 3 only active
+
+Predefined TS mask constants (TMEM A variants):
+  TS_NO_MASK  = (0, 0, 0, 0)                       all rows active
+  TS_MASK0    = (0, 0xFF…, 0xFF…, 0xFF…)           group 0 only active
+  TS_MASK1    = (0xFF…, 0, 0xFF…, 0xFF…)           group 1 only active
+  TS_MASK2    = (0xFF…, 0xFF…, 0, 0xFF…)           group 2 only active
+  TS_MASK3    = (0xFF…, 0xFF…, 0xFF…, 0)           group 3 only active
+  TS_MASK02   = (0, 0xFF…, 0, 0xFF…)               groups 0,2 only active
+  TS_MASK13   = (0xFF…, 0, 0xFF…, 0)               groups 1,3 only active
+
+Public API (all decorated with @cute.jit)
+----------------------------------------------------------------------
+Descriptor helpers (call inside @cute.jit):
+    Tcgen05SmemDescriptor          — 64-bit SMEM descriptor object
+    initialize_tcgen05_descriptor  — fill descriptor bitfields
+
+Low-level primitives (pass mask words explicitly):
+    tcgen05mma_ss(desc_a, desc_b, tmem_c, desc_val, scale_out,
+                  mask0, mask1, mask2, mask3)
+    tcgen05mma_ts(tmem_a, desc_b, tmem_c, desc_val, scale_out,
+                  mask0, mask1, mask2, mask3)
+    tcgen05mma_ws_ss_tf32(desc_a, desc_b, tmem_c, desc_val, scale_out)
+    tcgen05mma_ws_ts_tf32(tmem_a, desc_b, tmem_c, desc_val, scale_out)
+    tcgen05mma_ws_ss_f16(desc_a, desc_b, tmem_c, desc_val, scale_out)
+    tcgen05mma_ws_ts_f16(tmem_a, desc_b, tmem_c, desc_val, scale_out)
+
+Named convenience wrappers (pre-set masks, pass only MMA operands):
+    tcgen05mma_ss_no_mask / tcgen05mma_ss_mask0 / …mask1 / …mask2 / …mask3
+    tcgen05mma_ts_no_mask / tcgen05mma_ts_mask0 / …mask1 / …mask2 / …mask3
+    tcgen05mma_ts_mask02  / tcgen05mma_ts_mask13
+"""
+
+__all__ = [
+    # descriptor helpers
+    "Tcgen05SmemDescriptor",
+    "initialize_tcgen05_descriptor",
+    # low-level primitives
+    "tcgen05mma_ss",
+    "tcgen05mma_ts",
+    "tcgen05mma_ws_ss_tf32",
+    "tcgen05mma_ws_ts_tf32",
+    "tcgen05mma_ws_ss_f16",
+    "tcgen05mma_ws_ts_f16",
+    # SS named wrappers
+    "tcgen05mma_ss_no_mask",
+    "tcgen05mma_ss_mask0",
+    "tcgen05mma_ss_mask1",
+    "tcgen05mma_ss_mask2",
+    "tcgen05mma_ss_mask3",
+    # TS named wrappers
+    "tcgen05mma_ts_no_mask",
+    "tcgen05mma_ts_mask0",
+    "tcgen05mma_ts_mask1",
+    "tcgen05mma_ts_mask2",
+    "tcgen05mma_ts_mask3",
+    "tcgen05mma_ts_mask02",
+    "tcgen05mma_ts_mask13",
+    # collector enums (re-exported for convenience)
+    "CollectorBBuffer",
+    "CollectorOp",
+]
+
+import cutlass
+import cutlass.cute as cute
+from cutlass._mlir import ir
+from cutlass._mlir.dialects import arith as _arith, llvm, nvvm as _nvvm
+from cutlass.cutlass_dsl import dsl_user_op
+
+# Re-export collector enums for caller convenience.
+CollectorBBuffer = _nvvm.Tcgen05MMACollectorBBuffer
+CollectorOp = _nvvm.Tcgen05MMACollectorOp
+
+# ---------------------------------------------------------------------------
+# Mask constants (4 × uint32).  0 = ACTIVE, 0xFFFFFFFF = DISABLED.
+# ---------------------------------------------------------------------------
+_ALL_ACTIVE = 0x00000000
+_ALL_OFF = 0xFFFFFFFF
+
+# SS masks (SMEM A, SMEM B)
+SS_NO_MASK = (_ALL_ACTIVE, _ALL_ACTIVE, _ALL_ACTIVE, _ALL_ACTIVE)
+SS_MASK0 = (_ALL_ACTIVE, _ALL_OFF, _ALL_ACTIVE, _ALL_OFF)  # {0,F,0,F}
+SS_MASK1 = (_ALL_OFF, _ALL_ACTIVE, _ALL_OFF, _ALL_ACTIVE)  # {F,0,F,0}
+SS_MASK2 = (_ALL_OFF, _ALL_OFF, _ALL_ACTIVE, _ALL_OFF)  # {F,F,0,F}
+SS_MASK3 = (_ALL_OFF, _ALL_OFF, _ALL_OFF, _ALL_ACTIVE)  # {F,F,F,0}
+
+# TS masks (TMEM A, SMEM B)
+TS_NO_MASK = (_ALL_ACTIVE, _ALL_ACTIVE, _ALL_ACTIVE, _ALL_ACTIVE)
+TS_MASK0 = (_ALL_ACTIVE, _ALL_OFF, _ALL_OFF, _ALL_OFF)  # {0,F,F,F}
+TS_MASK1 = (_ALL_OFF, _ALL_ACTIVE, _ALL_OFF, _ALL_OFF)  # {F,0,F,F}
+TS_MASK2 = (_ALL_OFF, _ALL_OFF, _ALL_ACTIVE, _ALL_OFF)  # {F,F,0,F}
+TS_MASK3 = (_ALL_OFF, _ALL_OFF, _ALL_OFF, _ALL_ACTIVE)  # {F,F,F,0}
+TS_MASK02 = (_ALL_ACTIVE, _ALL_OFF, _ALL_ACTIVE, _ALL_OFF)  # {0,F,0,F}
+TS_MASK13 = (_ALL_OFF, _ALL_ACTIVE, _ALL_OFF, _ALL_ACTIVE)  # {F,0,F,0}
+
+
+# ---------------------------------------------------------------------------
+# Tcgen05SmemDescriptor — 64-bit SMEM descriptor stored as 2×Int32
+# ---------------------------------------------------------------------------
+
+
+class Tcgen05SmemDescriptor:
+    """64-bit shared-memory descriptor for tcgen05 MMA (Blackwell / SM100).
+
+    The descriptor encodes SMEM base address, leading/stride byte offsets,
+    swizzle mode, and other fields required by the ``tcgen05.mma`` PTX
+    instruction to locate a matrix tile in shared memory.
+
+    64-bit layout (PTX ISA Table 40)::
+
+      Bit 63                                                      Bit 0
+      ┌──────────┬────────┬─────┬──────────┬────┬──────────┬──────┬──────────────┐
+      │ 63    61 │ 60  53 │  52 │ 51    49 │ 48 │ 45    32 │31 30 │ 29   16│15 14│ 13     0│
+      │layout_typ│ reservd│l_abs│base_offst│ 46 │   SBO    │ rsvd │  LBO   │rsvd │start_adr│
+      │  (3 bit) │ (8 bit)│(1b) │  (3 bit) │=0b001│(14 bit)│(2 b) │(14 bit)│(2b) │(14 bit) │
+      └──────────┴────────┴─────┴──────────┴────┴──────────┴──────┴────────┴─────┴─────────┘
+
+    Field descriptions:
+
+    - **start_address** [bits 0-13]: SMEM base pointer, encoded as
+      ``smem_ptr >> 4`` (16-byte aligned). The hardware reconstructs the
+      full address as ``encoded_value << 4``.
+
+    - **LBO** (Leading Byte Offset) [bits 16-29]: distance in bytes between
+      consecutive elements along the leading dimension, encoded as
+      ``lbo_bytes >> 4``.  When ``lbo_mode=1`` this is an absolute byte
+      address rather than a relative offset.
+
+    - **SBO** (Stride Byte Offset) [bits 32-45]: distance in bytes between
+      consecutive elements along the stride dimension, encoded as
+      ``sbo_bytes >> 4``.
+
+    - **version** [bits 46-48]: fixed constant ``0b001`` (= 1).
+
+    - **base_offset** [bits 49-51]: 3-bit alignment correction when the
+      SMEM tile does not start at a natural swizzle-pattern boundary
+      (1024B for 128B swizzle, 512B for 64B, 256B for 32B).
+      Computed as ``(start_addr >> 7) & 0x7``.  Usually 0.
+
+    - **lbo_mode** (leading_abs) [bit 52]: 0 → LBO is a relative byte
+      offset; 1 → LBO is an absolute byte address.
+
+    - **layout_type** (swizzle_mode) [bits 61-63]:
+        - 0 = SWIZZLE_NONE
+        - 1 = SWIZZLE_128B_BASE32B  (128-byte pattern, 32-byte atom)
+        - 2 = SWIZZLE_128B          (128-byte pattern)
+        - 4 = SWIZZLE_64B           (64-byte pattern)
+        - 6 = SWIZZLE_32B           (32-byte pattern)
+
+    Storage: two Int32 registers (desc[0] = low 32 bits, desc[1] = high 32
+    bits), recast to a single Int64 for the PTX ``l``-constraint operand.
+
+    Usage inside a @cute.jit kernel::
+
+        desc = Tcgen05SmemDescriptor()
+        initialize_tcgen05_descriptor(desc, smem_ptr, lbo, sbo, 0, True, swizzle)
+    """
+
+    def __init__(self, desc_64: cute.Int64 = None):
+        # desc[0]: low  32 bits → start_address[0:14] | LBO[16:30]
+        # desc[1]: high 32 bits → SBO[0:14] | version[14:16] | base_offset[17:20]
+        #                         | lbo_mode[20] | layout_type[29:32]
+        self.desc = cute.make_rmem_tensor((2,), dtype=cutlass.Int32)
+        # Alias the 2×i32 as 1×i64 for PTX "l" constraint (64-bit operand)
+        self.desc_i64 = cute.make_tensor(
+            cute.recast_ptr(self.desc.iterator, dtype=cute.Int64), (1,)
+        )
+        if desc_64 is not None:
+            self.desc_i64[0] = desc_64
+
+    def __add__(self, byte_offset):
+        """Return a new descriptor offset by ``byte_offset`` bytes.
+
+        Only the start_address field (bits 0-13 of desc[0]) is modified.
+        Since it is stored in 16-byte units, we add ``byte_offset >> 4``.
+        All other fields (LBO, SBO, swizzle, etc.) are copied unchanged.
+        """
+        res = cute.make_rmem_tensor((2,), dtype=cutlass.Int32)
+        res_i64 = cute.make_tensor(cute.recast_ptr(res.iterator, dtype=cute.Int64), (1,))
+        res[0] = self.desc[0] + (byte_offset >> 4)  # adjust start_address
+        res[1] = self.desc[1]  # high word unchanged
+        return Tcgen05SmemDescriptor(res_i64[0])
+
+
+# ---------------------------------------------------------------------------
+# initialize_tcgen05_descriptor
+# ---------------------------------------------------------------------------
+
+
+def initialize_tcgen05_descriptor(
+    desc,
+    start_address,
+    leading_byte_offset,
+    stride_byte_offset,
+    base_offset,
+    leading_abs,
+    swizzle_mode,
+):
+    """Pack SMEM descriptor bitfields into *desc* (a Tcgen05SmemDescriptor).
+
+    Constructs the 64-bit descriptor in two 32-bit halves (desc[0] and desc[1]).
+    All address/offset fields must be pre-divided by 16 (``>> 4``) before
+    passing, because the hardware stores them in 16-byte granularity.
+
+    Low 32 bits — desc[0]::
+
+      ┌────────────────┬──────┬──────────────────┐
+      │ bits 29…16     │15…14 │ bits 13…0        │
+      │ LBO (14 bits)  │ rsvd │ start_addr >> 4   │
+      └────────────────┴──────┴──────────────────┘
+
+      - [0:14)   start_address >> 4  — SMEM tile base pointer in 16B units.
+      - [14:16)  reserved (0).
+      - [16:30)  leading_byte_offset — LBO in 16B units (caller passes >> 4).
+
+    High 32 bits — desc[1]::
+
+      ┌────────┬────────┬─────┬──────────┬────────┬──────────────────┐
+      │ 31…29  │ 28…21  │  20 │ 19…17    │ 16…14  │ bits 13…0        │
+      │ layout │  rsvd  │l_abs│base_off  │version │ SBO (14 bits)    │
+      │ (3 bit)│ (8 bit)│(1b) │  (3 bit) │=0b001  │                  │
+      └────────┴────────┴─────┴──────────┴────────┴──────────────────┘
+
+      - [0:14)   stride_byte_offset — SBO in 16B units (caller passes >> 4).
+      - [14:16)  version = 1 (fixed constant 0b001, only bit 14 set).
+      - [17:20)  base_offset & 0x7 — swizzle alignment correction.
+                 Typically 0.  Non-zero when the tile doesn't start at
+                 the natural swizzle boundary (1024B/512B/256B).
+      - [20:21)  lbo_mode — 0 = LBO is relative offset, 1 = absolute address.
+      - [29:32)  layout_type (swizzle_mode & 0x7):
+                   0 = SWIZZLE_NONE
+                   1 = SWIZZLE_128B_BASE32B  (Swizzle<2,5,2>)
+                   2 = SWIZZLE_128B          (Swizzle<3,4,3>)
+                   4 = SWIZZLE_64B           (Swizzle<2,4,3>)
+                   6 = SWIZZLE_32B           (Swizzle<1,4,3>)
+
+    Args:
+        desc:                 Tcgen05SmemDescriptor to fill.
+        start_address:        CuTeDSL Pointer to the SMEM tile start.
+        leading_byte_offset:  Leading-dimension byte offset, already >> 4.
+        stride_byte_offset:   Stride  byte offset, already >> 4.
+        base_offset:          Swizzle alignment correction (raw int, bits 17-19).
+        leading_abs:          Bool — True → LBO is absolute address.
+        swizzle_mode:         Swizzle layout_type integer (bits 29-31).
+    """
+    # Encode start_address: take SMEM pointer, shift right by 4 to get 16B units
+    ptr_val = start_address.toint() >> 4
+
+    # --- Low 32 bits (desc[0]) ---
+    # bits [0:14)  = start_address >> 4
+    # bits [16:30) = leading_byte_offset (already in 16B units)
+    desc.desc[0] = cutlass.Int32(ptr_val) | cutlass.Int32(cutlass.Int32(leading_byte_offset) << 16)
+
+    # --- High 32 bits (desc[1]) ---
+    # bits [0:14)  = stride_byte_offset (already in 16B units)
+    # bit  [14]    = version = 1  (fixed)
+    # bits [17:20) = base_offset & 0x7  (swizzle alignment correction)
+    # bit  [20]    = lbo_mode  (0=relative, 1=absolute)
+    # bits [29:32) = layout_type  (swizzle mode)
+    desc.desc[1] = (
+        cutlass.Int32(stride_byte_offset)
+        | cutlass.Int32(1 << 14)  # version = 1
+        | cutlass.Int32(cutlass.Int32(base_offset & 0x7) << 17)
+        | cutlass.Int32(cutlass.Int32(int(leading_abs)) << 20)
+        | cutlass.Int32(cutlass.Int32(swizzle_mode & 0x7) << 29)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helper
+# ---------------------------------------------------------------------------
+
+
+def _ir(val, loc=None, ip=None):
+    """Extract raw MLIR IR value from a CuTeDSL wrapper."""
+    return val.ir_value(loc=loc, ip=ip) if hasattr(val, "ir_value") else val
+
+
+# ===========================================================================
+# Low-level primitives
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# tcgen05mma_ss  —  SMEM A, SMEM B (non-warp-specialised)
+# ---------------------------------------------------------------------------
+
+
+@cute.jit
+def tcgen05mma_ss(
+    desc_a: Tcgen05SmemDescriptor,
+    desc_b: Tcgen05SmemDescriptor,
+    tmem_c: int,
+    desc_val: int,
+    scale_out: int,
+    mask0: int,
+    mask1: int,
+    mask2: int,
+    mask3: int,
+):
+    """Issue ``tcgen05.mma.cta_group::1.kind::tf32`` with SMEM operands.
+
+    ``mask{0-3}`` are the four uint32 words of the 128-bit
+    ``disable-output-lane`` mask (0=active, 0xFFFFFFFF=disabled).
+
+    Caller must ensure single-thread execution (e.g. via ``elect_one``);
+    no internal ``elect.sync`` is performed.
+
+    Args:
+        desc_a:    64-bit SMEM descriptor for matrix A.
+        desc_b:    64-bit SMEM descriptor for matrix B.
+        tmem_c:    TMEM base address (uint32) for accumulators C/D.
+        desc_val:  High 32 bits of the UMMA instruction descriptor (idescE>>32).
+        scale_out: 1 → accumulate into C, 0 → overwrite C (clear accumulators).
+        mask0-3:   Four uint32 words of the disable-output-lane mask.
+    """
+
+    @dsl_user_op
+    def _do(
+        c_val,
+        da_val,
+        db_val,
+        dv_val,
+        sc_val,
+        m0_val,
+        m1_val,
+        m2_val,
+        m3_val,
+        *,
+        loc=None,
+        ip=None,
+    ):
+        ptr6_ty = llvm.PointerType.get(address_space=6)
+        i32_ty = ir.IntegerType.get_signless(32)
+        i1_ty = ir.IntegerType.get_signless(1)
+        vec4i32_ty = ir.VectorType.get([4], i32_ty)
+
+        c_ir = _ir(c_val, loc, ip)
+        d_ptr = llvm.inttoptr(ptr6_ty, c_ir, loc=loc, ip=ip)
+        da_ir = _ir(da_val, loc, ip)  # i64 SMEM descriptor
+        db_ir = _ir(db_val, loc, ip)  # i64 SMEM descriptor
+        dv_ir = _ir(dv_val, loc, ip)
+        sc_ir = _ir(sc_val, loc, ip)
+        enable_d = _arith.trunci(i1_ty, sc_ir, loc=loc, ip=ip)
+
+        m0_ir = _ir(m0_val, loc, ip)
+        m1_ir = _ir(m1_val, loc, ip)
+        m2_ir = _ir(m2_val, loc, ip)
+        m3_ir = _ir(m3_val, loc, ip)
+
+        undef = llvm.mlir_undef(vec4i32_ty, loc=loc, ip=ip)
+        idx0 = _arith.constant(i32_ty, 0, loc=loc, ip=ip)
+        idx1 = _arith.constant(i32_ty, 1, loc=loc, ip=ip)
+        idx2 = _arith.constant(i32_ty, 2, loc=loc, ip=ip)
+        idx3 = _arith.constant(i32_ty, 3, loc=loc, ip=ip)
+        v = llvm.InsertElementOp(undef, m0_ir, idx0, loc=loc, ip=ip)
+        v = llvm.InsertElementOp(v, m1_ir, idx1, loc=loc, ip=ip)
+        v = llvm.InsertElementOp(v, m2_ir, idx2, loc=loc, ip=ip)
+        mask = llvm.InsertElementOp(v, m3_ir, idx3, loc=loc, ip=ip)
+
+        _nvvm.tcgen05_mma(
+            mma_kind=_nvvm.Tcgen05MMAKind.TF32,
+            cta_group=_nvvm.Tcgen05GroupKind.CTA_1,
+            d=d_ptr,
+            a=da_ir,
+            b=db_ir,
+            idesc=dv_ir,
+            enable_input_d=enable_d,
+            write_disable_mask=mask,
+            loc=loc,
+            ip=ip,
+        )
+
+    _do(
+        cutlass.Int32(tmem_c),
+        desc_a.desc_i64[0],
+        desc_b.desc_i64[0],
+        cutlass.Int32(desc_val),
+        cutlass.Int32(scale_out),
+        cutlass.Int32(mask0),
+        cutlass.Int32(mask1),
+        cutlass.Int32(mask2),
+        cutlass.Int32(mask3),
+    )
+
+
+# ---------------------------------------------------------------------------
+# tcgen05mma_ts  —  TMEM A, SMEM B (non-warp-specialised)
+# ---------------------------------------------------------------------------
+
+
+@cute.jit
+def tcgen05mma_ts(
+    tmem_a: int,
+    desc_b: Tcgen05SmemDescriptor,
+    tmem_c: int,
+    desc_val: int,
+    scale_out: int,
+    mask0: int,
+    mask1: int,
+    mask2: int,
+    mask3: int,
+):
+    """Issue ``tcgen05.mma.cta_group::1.kind::tf32`` with TMEM A operand.
+
+    Matrix A is read from TMEM via indirect addressing ``[tmem_a]``.
+    Matrix B is read from SMEM via descriptor.
+    Caller must ensure single-thread execution (e.g. via ``elect_one``).
+
+    Args:
+        tmem_a:    TMEM base address (uint32) for matrix A.
+        desc_b:    64-bit SMEM descriptor for matrix B.
+        tmem_c:    TMEM base address (uint32) for accumulators C/D.
+        desc_val:  High 32 bits of the UMMA instruction descriptor (idescE>>32).
+        scale_out: 1 → accumulate into C, 0 → overwrite C.
+        mask0-3:   Four uint32 words of the disable-output-lane mask.
+    """
+
+    @dsl_user_op
+    def _do(
+        c_val,
+        a_val,
+        db_val,
+        dv_val,
+        sc_val,
+        m0_val,
+        m1_val,
+        m2_val,
+        m3_val,
+        *,
+        loc=None,
+        ip=None,
+    ):
+        ptr6_ty = llvm.PointerType.get(address_space=6)
+        i32_ty = ir.IntegerType.get_signless(32)
+        i1_ty = ir.IntegerType.get_signless(1)
+        vec4i32_ty = ir.VectorType.get([4], i32_ty)
+
+        c_ir = _ir(c_val, loc, ip)
+        a_ir = _ir(a_val, loc, ip)
+        d_ptr = llvm.inttoptr(ptr6_ty, c_ir, loc=loc, ip=ip)
+        a_ptr = llvm.inttoptr(ptr6_ty, a_ir, loc=loc, ip=ip)
+        b_ir = _ir(db_val, loc, ip)
+        dv_ir = _ir(dv_val, loc, ip)
+        sc_ir = _ir(sc_val, loc, ip)
+        enable_d = _arith.trunci(i1_ty, sc_ir, loc=loc, ip=ip)
+
+        m0_ir = _ir(m0_val, loc, ip)
+        m1_ir = _ir(m1_val, loc, ip)
+        m2_ir = _ir(m2_val, loc, ip)
+        m3_ir = _ir(m3_val, loc, ip)
+
+        undef = llvm.mlir_undef(vec4i32_ty, loc=loc, ip=ip)
+        idx0 = _arith.constant(i32_ty, 0, loc=loc, ip=ip)
+        idx1 = _arith.constant(i32_ty, 1, loc=loc, ip=ip)
+        idx2 = _arith.constant(i32_ty, 2, loc=loc, ip=ip)
+        idx3 = _arith.constant(i32_ty, 3, loc=loc, ip=ip)
+        v = llvm.InsertElementOp(undef, m0_ir, idx0, loc=loc, ip=ip)
+        v = llvm.InsertElementOp(v, m1_ir, idx1, loc=loc, ip=ip)
+        v = llvm.InsertElementOp(v, m2_ir, idx2, loc=loc, ip=ip)
+        mask = llvm.InsertElementOp(v, m3_ir, idx3, loc=loc, ip=ip)
+
+        _nvvm.tcgen05_mma(
+            mma_kind=_nvvm.Tcgen05MMAKind.TF32,
+            cta_group=_nvvm.Tcgen05GroupKind.CTA_1,
+            d=d_ptr,
+            a=a_ptr,
+            b=b_ir,
+            idesc=dv_ir,
+            enable_input_d=enable_d,
+            write_disable_mask=mask,
+            loc=loc,
+            ip=ip,
+        )
+
+    _do(
+        cutlass.Int32(tmem_c),
+        cutlass.Int32(tmem_a),
+        desc_b.desc_i64[0],
+        cutlass.Int32(desc_val),
+        cutlass.Int32(scale_out),
+        cutlass.Int32(mask0),
+        cutlass.Int32(mask1),
+        cutlass.Int32(mask2),
+        cutlass.Int32(mask3),
+    )
+
+
+# ---------------------------------------------------------------------------
+# tcgen05mma_ws_ss_tf32  —  weight-stationary, SMEM A, SMEM B, kind::tf32
+# ---------------------------------------------------------------------------
+
+
+@cute.jit
+def tcgen05mma_ws_ss_tf32(
+    desc_a: Tcgen05SmemDescriptor,
+    desc_b: Tcgen05SmemDescriptor,
+    tmem_c: int,
+    desc_val: int,
+    scale_out: int,
+    collector_b_buffer=None,
+    collector_op=None,
+):
+    """Issue ``tcgen05.mma.ws.cta_group::1.kind::tf32`` (weight-stationary form).
+
+    This variant does NOT take a ``disable-output-lane`` mask; the
+    optional ``zero-column-mask-desc`` operand is omitted.
+
+    Args:
+        desc_a:    64-bit SMEM descriptor for matrix A.
+        desc_b:    64-bit SMEM descriptor for matrix B.
+        tmem_c:    TMEM base address (uint32) for accumulators C/D.
+        desc_val:  High 32 bits of the UMMA instruction descriptor (idescE>>32).
+        scale_out: 1 → accumulate, 0 → overwrite.
+        collector_b_buffer: Optional ``CollectorBBuffer`` enum (B0–B3).
+                            Defaults to None (hardware default: ``b0::discard``).
+        collector_op: Optional ``CollectorOp`` enum (FILL/USE/LASTUSE/DISCARD).
+                      Defaults to None (hardware default: discard).
+    """
+
+    @dsl_user_op
+    def _do(c_val, da_val, db_val, dv_val, sc_val, *, loc=None, ip=None):
+        ptr6_ty = llvm.PointerType.get(address_space=6)
+        i1_ty = ir.IntegerType.get_signless(1)
+
+        c_ir = _ir(c_val, loc, ip)
+        d_ptr = llvm.inttoptr(ptr6_ty, c_ir, loc=loc, ip=ip)
+        da_ir = _ir(da_val, loc, ip)
+        db_ir = _ir(db_val, loc, ip)
+        dv_ir = _ir(dv_val, loc, ip)
+        sc_ir = _ir(sc_val, loc, ip)
+        enable_d = _arith.trunci(i1_ty, sc_ir, loc=loc, ip=ip)
+
+        _nvvm.tcgen05_mma_ws(
+            mma_kind=_nvvm.Tcgen05MMAKind.TF32,
+            d=d_ptr,
+            a=da_ir,
+            b=db_ir,
+            idesc=dv_ir,
+            enable_input_d=enable_d,
+            collector_b_buffer=collector_b_buffer,
+            collector_op=collector_op,
+            loc=loc,
+            ip=ip,
+        )
+
+    _do(
+        cutlass.Int32(tmem_c),
+        desc_a.desc_i64[0],
+        desc_b.desc_i64[0],
+        cutlass.Int32(desc_val),
+        cutlass.Int32(scale_out),
+    )
+
+
+# ---------------------------------------------------------------------------
+# tcgen05mma_ws_ss_f16  —  weight-stationary, SMEM A, SMEM B, kind::f16
+# ---------------------------------------------------------------------------
+
+
+@cute.jit
+def tcgen05mma_ws_ss_f16(
+    desc_a: Tcgen05SmemDescriptor,
+    desc_b: Tcgen05SmemDescriptor,
+    tmem_c: int,
+    desc_val: int,
+    scale_out: int,
+    collector_b_buffer=None,
+    collector_op=None,
+):
+    """Issue ``tcgen05.mma.ws.cta_group::1.kind::f16`` (weight-stationary form).
+
+    Same as the tf32 variant but uses ``.kind::f16`` for half-precision
+    input types (f16 / bf16).  K dimension is 16 instead of 8.
+
+    This variant does NOT take a ``disable-output-lane`` mask; the
+    optional ``zero-column-mask-desc`` operand is omitted.
+
+    Args:
+        desc_a:    64-bit SMEM descriptor for matrix A.
+        desc_b:    64-bit SMEM descriptor for matrix B.
+        tmem_c:    TMEM base address (uint32) for accumulators C/D.
+        desc_val:  High 32 bits of the UMMA instruction descriptor (idescE>>32).
+        scale_out: 1 → accumulate, 0 → overwrite.
+        collector_b_buffer: Optional ``CollectorBBuffer`` enum (B0–B3).
+                            Defaults to None (hardware default: ``b0::discard``).
+        collector_op: Optional ``CollectorOp`` enum (FILL/USE/LASTUSE/DISCARD).
+                      Defaults to None (hardware default: discard).
+    """
+
+    @dsl_user_op
+    def _do(c_val, da_val, db_val, dv_val, sc_val, *, loc=None, ip=None):
+        ptr6_ty = llvm.PointerType.get(address_space=6)
+        i1_ty = ir.IntegerType.get_signless(1)
+
+        c_ir = _ir(c_val, loc, ip)
+        d_ptr = llvm.inttoptr(ptr6_ty, c_ir, loc=loc, ip=ip)
+        da_ir = _ir(da_val, loc, ip)
+        db_ir = _ir(db_val, loc, ip)
+        dv_ir = _ir(dv_val, loc, ip)
+        sc_ir = _ir(sc_val, loc, ip)
+        enable_d = _arith.trunci(i1_ty, sc_ir, loc=loc, ip=ip)
+
+        _nvvm.tcgen05_mma_ws(
+            mma_kind=_nvvm.Tcgen05MMAKind.F16,
+            d=d_ptr,
+            a=da_ir,
+            b=db_ir,
+            idesc=dv_ir,
+            enable_input_d=enable_d,
+            collector_b_buffer=collector_b_buffer,
+            collector_op=collector_op,
+            loc=loc,
+            ip=ip,
+        )
+
+    _do(
+        cutlass.Int32(tmem_c),
+        desc_a.desc_i64[0],
+        desc_b.desc_i64[0],
+        cutlass.Int32(desc_val),
+        cutlass.Int32(scale_out),
+    )
+
+
+# ---------------------------------------------------------------------------
+# tcgen05mma_ws_ts_tf32  —  weight-stationary, TMEM A, SMEM B, kind::tf32
+# ---------------------------------------------------------------------------
+
+
+@cute.jit
+def tcgen05mma_ws_ts_tf32(
+    tmem_a: int,
+    desc_b: Tcgen05SmemDescriptor,
+    tmem_c: int,
+    desc_val: int,
+    scale_out: int,
+    collector_b_buffer=None,
+    collector_op=None,
+):
+    """Issue ``tcgen05.mma.ws.cta_group::1.kind::tf32`` with TMEM A (weight-stationary).
+
+    Matrix A is read from TMEM via indirect addressing ``[tmem_a]``.
+    Matrix B is read from SMEM via descriptor.
+    This variant does NOT take a ``disable-output-lane`` mask; the
+    optional ``zero-column-mask-desc`` operand is omitted.
+
+    Args:
+        tmem_a:    TMEM base address (uint32) for matrix A.
+        desc_b:    64-bit SMEM descriptor for matrix B.
+        tmem_c:    TMEM base address (uint32) for accumulators C/D.
+        desc_val:  High 32 bits of the UMMA instruction descriptor (idescE>>32).
+        scale_out: 1 → accumulate, 0 → overwrite.
+        collector_b_buffer: Optional ``CollectorBBuffer`` enum (B0–B3).
+                            Defaults to None (hardware default: ``b0::discard``).
+        collector_op: Optional ``CollectorOp`` enum (FILL/USE/LASTUSE/DISCARD).
+                      Defaults to None (hardware default: discard).
+    """
+
+    @dsl_user_op
+    def _do(c_val, a_val, db_val, dv_val, sc_val, *, loc=None, ip=None):
+        ptr6_ty = llvm.PointerType.get(address_space=6)
+        i1_ty = ir.IntegerType.get_signless(1)
+
+        c_ir = _ir(c_val, loc, ip)
+        d_ptr = llvm.inttoptr(ptr6_ty, c_ir, loc=loc, ip=ip)
+        a_ir = _ir(a_val, loc, ip)
+        a_ptr = llvm.inttoptr(ptr6_ty, a_ir, loc=loc, ip=ip)
+        db_ir = _ir(db_val, loc, ip)
+        dv_ir = _ir(dv_val, loc, ip)
+        sc_ir = _ir(sc_val, loc, ip)
+        enable_d = _arith.trunci(i1_ty, sc_ir, loc=loc, ip=ip)
+
+        _nvvm.tcgen05_mma_ws(
+            mma_kind=_nvvm.Tcgen05MMAKind.TF32,
+            d=d_ptr,
+            a=a_ptr,
+            b=db_ir,
+            idesc=dv_ir,
+            enable_input_d=enable_d,
+            collector_b_buffer=collector_b_buffer,
+            collector_op=collector_op,
+            loc=loc,
+            ip=ip,
+        )
+
+    _do(
+        cutlass.Int32(tmem_c),
+        cutlass.Int32(tmem_a),
+        desc_b.desc_i64[0],
+        cutlass.Int32(desc_val),
+        cutlass.Int32(scale_out),
+    )
+
+
+# ---------------------------------------------------------------------------
+# tcgen05mma_ws_ts_f16  —  weight-stationary, TMEM A, SMEM B, kind::f16
+# ---------------------------------------------------------------------------
+
+
+@cute.jit
+def tcgen05mma_ws_ts_f16(
+    tmem_a: int,
+    desc_b: Tcgen05SmemDescriptor,
+    tmem_c: int,
+    desc_val: int,
+    scale_out: int,
+    collector_b_buffer=None,
+    collector_op=None,
+):
+    """Issue ``tcgen05.mma.ws.cta_group::1.kind::f16`` with TMEM A (weight-stationary).
+
+    Same as the tf32 variant but uses ``.kind::f16`` for half-precision
+    input types (f16 / bf16).  K dimension is 16 instead of 8.
+
+    Matrix A is read from TMEM via indirect addressing ``[tmem_a]``.
+    Matrix B is read from SMEM via descriptor.
+    This variant does NOT take a ``disable-output-lane`` mask; the
+    optional ``zero-column-mask-desc`` operand is omitted.
+
+    Args:
+        tmem_a:    TMEM base address (uint32) for matrix A.
+        desc_b:    64-bit SMEM descriptor for matrix B.
+        tmem_c:    TMEM base address (uint32) for accumulators C/D.
+        desc_val:  High 32 bits of the UMMA instruction descriptor (idescE>>32).
+        scale_out: 1 → accumulate, 0 → overwrite.
+        collector_b_buffer: Optional ``CollectorBBuffer`` enum (B0–B3).
+                            Defaults to None (hardware default: ``b0::discard``).
+        collector_op: Optional ``CollectorOp`` enum (FILL/USE/LASTUSE/DISCARD).
+                      Defaults to None (hardware default: discard).
+    """
+
+    @dsl_user_op
+    def _do(c_val, a_val, db_val, dv_val, sc_val, *, loc=None, ip=None):
+        ptr6_ty = llvm.PointerType.get(address_space=6)
+        i1_ty = ir.IntegerType.get_signless(1)
+
+        c_ir = _ir(c_val, loc, ip)
+        d_ptr = llvm.inttoptr(ptr6_ty, c_ir, loc=loc, ip=ip)
+        a_ir = _ir(a_val, loc, ip)
+        a_ptr = llvm.inttoptr(ptr6_ty, a_ir, loc=loc, ip=ip)
+        db_ir = _ir(db_val, loc, ip)
+        dv_ir = _ir(dv_val, loc, ip)
+        sc_ir = _ir(sc_val, loc, ip)
+        enable_d = _arith.trunci(i1_ty, sc_ir, loc=loc, ip=ip)
+
+        _nvvm.tcgen05_mma_ws(
+            mma_kind=_nvvm.Tcgen05MMAKind.F16,
+            d=d_ptr,
+            a=a_ptr,
+            b=db_ir,
+            idesc=dv_ir,
+            enable_input_d=enable_d,
+            collector_b_buffer=collector_b_buffer,
+            collector_op=collector_op,
+            loc=loc,
+            ip=ip,
+        )
+
+    _do(
+        cutlass.Int32(tmem_c),
+        cutlass.Int32(tmem_a),
+        desc_b.desc_i64[0],
+        cutlass.Int32(desc_val),
+        cutlass.Int32(scale_out),
+    )
+
+
+# ===========================================================================
+# Named convenience wrappers
+# ===========================================================================
+# These call the low-level primitives with pre-set mask constants so callers
+# do not need to repeat the literal values.  Signature: same as the base
+# function but without the mask0-3 args.
+
+# ---------------------------------------------------------------------------
+# SS named wrappers  (SMEM A)
+# ---------------------------------------------------------------------------
+
+
+@cute.jit
+def tcgen05mma_ss_no_mask(
+    desc_a: Tcgen05SmemDescriptor,
+    desc_b: Tcgen05SmemDescriptor,
+    tmem_c: int,
+    desc_val: int,
+    scale_out: int,
+):
+    """SS MMA with no output-lane disable (all rows active)."""
+    tcgen05mma_ss(
+        desc_a,
+        desc_b,
+        tmem_c,
+        desc_val,
+        scale_out,
+        SS_NO_MASK[0],
+        SS_NO_MASK[1],
+        SS_NO_MASK[2],
+        SS_NO_MASK[3],
+    )
+
+
+@cute.jit
+def tcgen05mma_ss_mask0(
+    desc_a: Tcgen05SmemDescriptor,
+    desc_b: Tcgen05SmemDescriptor,
+    tmem_c: int,
+    desc_val: int,
+    scale_out: int,
+):
+    """SS MMA: mask={0, 0xF…, 0, 0xF…} — groups 0,2 active (1,3 disabled)."""
+    tcgen05mma_ss(
+        desc_a,
+        desc_b,
+        tmem_c,
+        desc_val,
+        scale_out,
+        SS_MASK0[0],
+        SS_MASK0[1],
+        SS_MASK0[2],
+        SS_MASK0[3],
+    )
+
+
+@cute.jit
+def tcgen05mma_ss_mask1(
+    desc_a: Tcgen05SmemDescriptor,
+    desc_b: Tcgen05SmemDescriptor,
+    tmem_c: int,
+    desc_val: int,
+    scale_out: int,
+):
+    """SS MMA: mask={0xF…, 0, 0xF…, 0} — groups 1,3 active (0,2 disabled)."""
+    tcgen05mma_ss(
+        desc_a,
+        desc_b,
+        tmem_c,
+        desc_val,
+        scale_out,
+        SS_MASK1[0],
+        SS_MASK1[1],
+        SS_MASK1[2],
+        SS_MASK1[3],
+    )
+
+
+@cute.jit
+def tcgen05mma_ss_mask2(
+    desc_a: Tcgen05SmemDescriptor,
+    desc_b: Tcgen05SmemDescriptor,
+    tmem_c: int,
+    desc_val: int,
+    scale_out: int,
+):
+    """SS MMA: mask={0xF…, 0xF…, 0, 0xF…} — group 2 only active."""
+    tcgen05mma_ss(
+        desc_a,
+        desc_b,
+        tmem_c,
+        desc_val,
+        scale_out,
+        SS_MASK2[0],
+        SS_MASK2[1],
+        SS_MASK2[2],
+        SS_MASK2[3],
+    )
+
+
+@cute.jit
+def tcgen05mma_ss_mask3(
+    desc_a: Tcgen05SmemDescriptor,
+    desc_b: Tcgen05SmemDescriptor,
+    tmem_c: int,
+    desc_val: int,
+    scale_out: int,
+):
+    """SS MMA: mask={0xF…, 0xF…, 0xF…, 0} — group 3 only active."""
+    tcgen05mma_ss(
+        desc_a,
+        desc_b,
+        tmem_c,
+        desc_val,
+        scale_out,
+        SS_MASK3[0],
+        SS_MASK3[1],
+        SS_MASK3[2],
+        SS_MASK3[3],
+    )
+
+
+# ---------------------------------------------------------------------------
+# TS named wrappers  (TMEM A)
+# ---------------------------------------------------------------------------
+
+
+@cute.jit
+def tcgen05mma_ts_no_mask(
+    tmem_a: int,
+    desc_b: Tcgen05SmemDescriptor,
+    tmem_c: int,
+    desc_val: int,
+    scale_out: int,
+):
+    """TS MMA with no output-lane disable (all rows active)."""
+    tcgen05mma_ts(
+        tmem_a,
+        desc_b,
+        tmem_c,
+        desc_val,
+        scale_out,
+        TS_NO_MASK[0],
+        TS_NO_MASK[1],
+        TS_NO_MASK[2],
+        TS_NO_MASK[3],
+    )
+
+
+@cute.jit
+def tcgen05mma_ts_mask0(
+    tmem_a: int,
+    desc_b: Tcgen05SmemDescriptor,
+    tmem_c: int,
+    desc_val: int,
+    scale_out: int,
+):
+    """TS MMA: mask={0, 0xF…, 0xF…, 0xF…} — group 0 only active."""
+    tcgen05mma_ts(
+        tmem_a,
+        desc_b,
+        tmem_c,
+        desc_val,
+        scale_out,
+        TS_MASK0[0],
+        TS_MASK0[1],
+        TS_MASK0[2],
+        TS_MASK0[3],
+    )
+
+
+@cute.jit
+def tcgen05mma_ts_mask1(
+    tmem_a: int,
+    desc_b: Tcgen05SmemDescriptor,
+    tmem_c: int,
+    desc_val: int,
+    scale_out: int,
+):
+    """TS MMA: mask={0xF…, 0, 0xF…, 0xF…} — group 1 only active."""
+    tcgen05mma_ts(
+        tmem_a,
+        desc_b,
+        tmem_c,
+        desc_val,
+        scale_out,
+        TS_MASK1[0],
+        TS_MASK1[1],
+        TS_MASK1[2],
+        TS_MASK1[3],
+    )
+
+
+@cute.jit
+def tcgen05mma_ts_mask2(
+    tmem_a: int,
+    desc_b: Tcgen05SmemDescriptor,
+    tmem_c: int,
+    desc_val: int,
+    scale_out: int,
+):
+    """TS MMA: mask={0xF…, 0xF…, 0, 0xF…} — group 2 only active."""
+    tcgen05mma_ts(
+        tmem_a,
+        desc_b,
+        tmem_c,
+        desc_val,
+        scale_out,
+        TS_MASK2[0],
+        TS_MASK2[1],
+        TS_MASK2[2],
+        TS_MASK2[3],
+    )
+
+
+@cute.jit
+def tcgen05mma_ts_mask3(
+    tmem_a: int,
+    desc_b: Tcgen05SmemDescriptor,
+    tmem_c: int,
+    desc_val: int,
+    scale_out: int,
+):
+    """TS MMA: mask={0xF…, 0xF…, 0xF…, 0} — group 3 only active."""
+    tcgen05mma_ts(
+        tmem_a,
+        desc_b,
+        tmem_c,
+        desc_val,
+        scale_out,
+        TS_MASK3[0],
+        TS_MASK3[1],
+        TS_MASK3[2],
+        TS_MASK3[3],
+    )
+
+
+@cute.jit
+def tcgen05mma_ts_mask02(
+    tmem_a: int,
+    desc_b: Tcgen05SmemDescriptor,
+    tmem_c: int,
+    desc_val: int,
+    scale_out: int,
+):
+    """TS MMA: mask={0, 0xF…, 0, 0xF…} — groups 0,2 active (1,3 disabled).
+
+    Used in the KDA intra-chunk backward kernel for the QK/KG phase where
+    only even row-groups of the M tile contribute to the triangular region.
+    """
+    tcgen05mma_ts(
+        tmem_a,
+        desc_b,
+        tmem_c,
+        desc_val,
+        scale_out,
+        TS_MASK02[0],
+        TS_MASK02[1],
+        TS_MASK02[2],
+        TS_MASK02[3],
+    )
+
+
+@cute.jit
+def tcgen05mma_ts_mask13(
+    tmem_a: int,
+    desc_b: Tcgen05SmemDescriptor,
+    tmem_c: int,
+    desc_val: int,
+    scale_out: int,
+):
+    """TS MMA: mask={0xF…, 0, 0xF…, 0} — groups 1,3 active (0,2 disabled).
+
+    Used in the KDA intra-chunk backward kernel for the QK/KG phase where
+    only odd row-groups of the M tile contribute to the triangular region.
+    """
+    tcgen05mma_ts(
+        tmem_a,
+        desc_b,
+        tmem_c,
+        desc_val,
+        scale_out,
+        TS_MASK13[0],
+        TS_MASK13[1],
+        TS_MASK13[2],
+        TS_MASK13[3],
+    )
+
+
+# ---- intrinsics_sm100.py ----
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+#
+# Adapted from cuLA's SM100 Tensor Memory intrinsic wrappers.
+#
+# Copyright 2025-2026 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NVVM wrappers for SM100 (Blackwell) Tensor Memory intrinsics.
+
+Provides low-level, CuteDSL-compatible helpers that move data between
+Tensor Memory (TMEM) and registers / shared memory via the native
+``nvvm.tcgen05.*`` MLIR ops.
+
+**T2R / R2T** – ``tcgen05.ld`` / ``tcgen05.st`` with ``.32x32b`` shape.
+**S2T**       – ``tcgen05.cp`` with ``.128x256b`` shape (SMEM → TMEM)
+PTX reference
+-------------
+    tcgen05.ld.sync.aligned.32x32b.xN.b32  {r0, ..., rN-1}, [taddr];
+    tcgen05.st.sync.aligned.32x32b.xN.b32  [taddr], {r0, ..., rN-1};
+
+where ``N ∈ {2, 4, 8, 16, 32, 64, 128}`` and each ``r`` is a 32-bit
+register.  ``taddr`` encodes both the TMEM column index (bits [15:0])
+and the lane index (bits [31:16]).
+
+See https://docs.nvidia.com/cuda/parallel-thread-execution/#tcgen05-instructions-tcgen05-ld
+
+Usage inside a ``@cute.kernel`` or ``@cute.jit`` function::
+
+    from this file's inlined SM100 helper wrappers import (
+        tcgen05_ld_32x32b, tcgen05_st_32x32b,
+        reinterpret_cast, subvec, store_256b,
+    )
+    from cutlass.cute.typing import Float32, Int32
+
+    # Load 32 × 32-bit values from TMEM → opaque vector<32 x i32>
+    vec_i32 = tcgen05_ld_32x32b(32, taddr)
+
+    # Zero-cost reinterpret as f32 (single vector.bitcast, no instructions)
+    vec_f32 = reinterpret_cast(vec_i32, Int32, 32, Float32)
+
+    # Store to global via store_256b (4 × 256-bit stores)
+    # store_256b takes vector<8 x i32>, so reinterpret back and slice
+    vec_i32_back = reinterpret_cast(vec_f32, Float32, 32, Int32)
+    for chunk in range(4):  # 32 / 8 = 4 chunks
+        store_256b(gmem_addr + chunk * 32, subvec(vec_i32_back, chunk * 8, 8))
+
+    # Store back to TMEM
+    tcgen05_st_32x32b(32, taddr, vec_i32_back)
+"""
+
+__all__ = [
+    "tcgen05_ld_32x32b",
+    "tcgen05_st_32x32b",
+    "tcgen05_cp_128x256b",
+    "reinterpret_cast",
+    "subvec",
+    "store_256b",
+    "umma_arrive",
+    "umma_arrive_noelect",
+]
+
+import cutlass.cute as cute
+from cutlass._mlir import ir as _ir_mod
+from cutlass._mlir.dialects import (
+    arith as _arith,
+    llvm,
+    nvvm as _nvvm,
+    vector as _vector,
+)
+from cutlass.cute.arch import elect_one
+from cutlass.cute.nvgpu import tcgen05
+from cutlass.cute.typing import Int32
+from cutlass.cutlass_dsl import dsl_user_op
+
+
+def _to_ir(val, loc=None, ip=None):
+    """Extract raw MLIR IR value from a CuteDSL wrapper."""
+    return val.ir_value(loc=loc, ip=ip) if hasattr(val, "ir_value") else val
+
+
+# ---------------------------------------------------------------------------
+# tcgen05.ld.sync.aligned.32x32b.xN.b32  (via nvvm.tcgen05.ld)
+# ---------------------------------------------------------------------------
+
+
+@cute.jit
+def tcgen05_ld_32x32b(num: int, taddr: int):
+    """Load *num* × 32-bit values from TMEM → an opaque ``vector<N x i32>``.
+
+    ``num`` must be a **compile-time constant** in {2, 4, 8, 16, 32, 64, 128}.
+    Returns a single opaque MLIR vector value (``vector<num x i32>``).
+
+    Use :func:`reinterpret_cast` to reinterpret the element type (zero-cost),
+    and :func:`subvec` to slice a contiguous sub-vector.
+
+    Parameters
+    ----------
+    num : int
+        Number of 32-bit registers to load.  Must be a compile-time constant.
+    taddr : int
+        TMEM address (bits [31:16] = lane, bits [15:0] = column).
+    """
+
+    @dsl_user_op
+    def _do(addr_val, *, loc=None, ip=None):
+        i32_ty = _ir_mod.IntegerType.get_signless(32)
+        ptr6_ty = llvm.PointerType.get(address_space=6)
+        tmem_ptr = llvm.inttoptr(ptr6_ty, _to_ir(addr_val, loc, ip), loc=loc, ip=ip)
+        vec_i32_ty = _ir_mod.VectorType.get([num], i32_ty)
+        return _nvvm.tcgen05_ld(
+            res=vec_i32_ty,
+            shape=_nvvm.Tcgen05LdStShape.SHAPE_32X32B,
+            num=num,
+            tmem_addr=tmem_ptr,
+            loc=loc,
+            ip=ip,
+        )
+
+    return _do(Int32(taddr))
+
+
+# ---------------------------------------------------------------------------
+# tcgen05.st.sync.aligned.32x32b.xN.b32  (via nvvm.tcgen05.st)
+# ---------------------------------------------------------------------------
+
+
+@cute.jit
+def tcgen05_st_32x32b(num: int, taddr: int, vec):
+    """Store *num* × 32-bit values from an opaque vector → TMEM.
+
+    ``num`` must be a **compile-time constant** in {2, 4, 8, 16, 32, 64, 128}.
+
+    Parameters
+    ----------
+    num : int
+        Number of 32-bit registers to store.  Must be a compile-time constant.
+    taddr : int
+        TMEM address (bits [31:16] = lane, bits [15:0] = column).
+    vec : opaque vector
+        An opaque ``vector<num x i32>`` value (from :func:`tcgen05_ld_32x32b`
+        or :func:`reinterpret_cast`).
+    """
+
+    @dsl_user_op
+    def _do(addr_val, vec_val, *, loc=None, ip=None):
+        ptr6_ty = llvm.PointerType.get(address_space=6)
+        tmem_ptr = llvm.inttoptr(ptr6_ty, _to_ir(addr_val, loc, ip), loc=loc, ip=ip)
+        _nvvm.tcgen05_st(
+            shape=_nvvm.Tcgen05LdStShape.SHAPE_32X32B,
+            num=num,
+            tmem_addr=tmem_ptr,
+            r=_to_ir(vec_val, loc, ip),
+            loc=loc,
+            ip=ip,
+        )
+
+    _do(Int32(taddr), vec)
+
+
+# ---------------------------------------------------------------------------
+# reinterpret_cast  (zero-cost vector.bitcast)
+# ---------------------------------------------------------------------------
+
+
+@cute.jit
+def reinterpret_cast(vec, src_type, src_num, tgt_type):
+    """Zero-cost reinterpret of a vector's element type (single ``vector.bitcast``).
+
+    Analogous to C++ ``reinterpret_cast``: no instructions emitted, just
+    re-labels the bits.  The total bit-width is preserved:
+    ``src_num * src_type.width == tgt_num * tgt_type.width``.
+
+    Parameters
+    ----------
+    vec : opaque vector
+        Source vector (e.g. ``vector<N x i32>`` from :func:`tcgen05_ld_32x32b`).
+    src_type : CuTeDSL type
+        Element type of *vec* (e.g. ``Int32``).
+    src_num : int
+        Number of elements in *vec* (compile-time constant).
+    tgt_type : CuTeDSL type
+        Desired element type (e.g. ``Float32``, ``BFloat16``, ``Float16``).
+
+    Returns
+    -------
+    opaque vector
+        ``vector<M x tgt_type>`` where ``M = src_num * src_type.width // tgt_type.width``.
+
+    Examples
+    --------
+    ::
+
+        vec_i32  = tcgen05_ld_32x32b(8, taddr)                     # vector<8 x i32>
+        vec_f32  = reinterpret_cast(vec_i32, Int32, 8, Float32)    # vector<8 x f32>
+        vec_bf16 = reinterpret_cast(vec_i32, Int32, 8, BFloat16)   # vector<16 x bf16>
+        vec_back = reinterpret_cast(vec_bf16, BFloat16, 16, Int32) # vector<8 x i32>
+    """
+    tgt_num = src_num * src_type.width // tgt_type.width
+
+    @dsl_user_op
+    def _do(v, *, loc=None, ip=None):
+        tgt_vec_ty = _ir_mod.VectorType.get([tgt_num], tgt_type.mlir_type)
+        return _vector.bitcast(tgt_vec_ty, _to_ir(v, loc, ip), loc=loc, ip=ip)
+
+    return _do(vec)
+
+
+# ---------------------------------------------------------------------------
+# subvec  (extract a contiguous sub-vector)
+# ---------------------------------------------------------------------------
+
+
+@cute.jit
+def subvec(vec, offset, size):
+    """Extract a contiguous sub-vector (``vector.extract_strided_slice``).
+
+    Parameters
+    ----------
+    vec : opaque vector
+        Source vector.
+    offset : int
+        Starting element index (compile-time constant).
+    size : int
+        Number of elements to extract (compile-time constant).
+
+    Returns
+    -------
+    opaque vector
+        ``vector<size x elem_type>``.
+    """
+
+    @dsl_user_op
+    def _do(v, *, loc=None, ip=None):
+        ir_v = _to_ir(v, loc, ip)
+        elem_ty = _ir_mod.VectorType(ir_v.type).element_type
+        res_ty = _ir_mod.VectorType.get([size], elem_ty)
+        return _vector.extract_strided_slice(
+            res_ty,
+            ir_v,
+            offsets=[offset],
+            sizes=[size],
+            strides=[1],
+            loc=loc,
+            ip=ip,
+        )
+
+    return _do(vec)
+
+
+# ---------------------------------------------------------------------------
+# st.global.L1::no_allocate.v8.f32  (256-bit direct R2G store)
+# ---------------------------------------------------------------------------
+
+_STORE_256B_ASM = "st.global.L1::no_allocate.v8.f32 [$0], {$1, $2, $3, $4, $5, $6, $7, $8};"
+_STORE_256B_CONSTRAINTS = "l,r,r,r,r,r,r,r,r"
+
+
+@cute.jit
+def store_256b(gmem_ptr, vec):
+    """Store 256 bits (8 × 32-bit) to global memory, bypassing L1 allocation.
+
+    Issues ``st.global.L1::no_allocate.v8.f32`` with ``"r"`` (integer register)
+    constraints — type-agnostic, just like C++ ``reinterpret_cast<uint32_t*>``.
+
+    Parameters
+    ----------
+    gmem_ptr : pointer
+        Global-memory destination address (must be 32-byte aligned).
+    vec : opaque vector
+        A ``vector<8 x i32>`` (use :func:`subvec` to slice from a larger vector).
+    """
+
+    @dsl_user_op
+    def _do(addr, v, *, loc=None, ip=None):
+        i32_ty = _ir_mod.IntegerType.get_signless(32)
+        ir_v = _to_ir(v, loc, ip)
+        elems = [
+            _vector.extractelement(
+                ir_v,
+                position=_arith.constant(i32_ty, i, loc=loc, ip=ip),
+                loc=loc,
+                ip=ip,
+            )
+            for i in range(8)
+        ]
+        operands = [_to_ir(addr, loc, ip)] + elems
+        llvm.inline_asm(
+            _ir_mod.Type.parse("!llvm.void"),
+            operands,
+            _STORE_256B_ASM,
+            _STORE_256B_CONSTRAINTS,
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+
+    _do(gmem_ptr, vec)
+
+
+# ---------------------------------------------------------------------------
+# tcgen05.cp.cta_group::1.128x256b  (via nvvm.tcgen05.cp)
+# ---------------------------------------------------------------------------
+
+
+@cute.jit
+def tcgen05_cp_128x256b(taddr: int, smem_desc: Tcgen05SmemDescriptor):
+    """Async copy SMEM → TMEM with shape ``128x256b`` (``cta_group::1``).
+
+    Issues ``tcgen05.cp.cta_group::1.128x256b  [taddr], s-desc;``
+    via the native ``nvvm.tcgen05.cp`` MLIR op.
+
+    The instruction copies a 128-row × 256-bit tile from shared memory
+    (described by *smem_desc*) into Tensor Memory at *taddr*.  The copy
+    is **asynchronous** — use ``tcgen05.commit`` + ``mbarrier.wait`` to
+    synchronize.
+
+    PTX reference
+    -------------
+        tcgen05.cp.cta_group::1.128x256b  [taddr], s-desc;
+
+    Parameters
+    ----------
+    taddr : int
+        TMEM destination address (uint32, passed as ``!llvm.ptr<6>``).
+    smem_desc : Tcgen05SmemDescriptor
+        64-bit SMEM matrix descriptor (same format as ``tcgen05.mma``
+        descriptors — see ``Tcgen05SmemDescriptor``).
+    """
+
+    @dsl_user_op
+    def _do(addr_val, desc_val, *, loc=None, ip=None):
+        ptr6_ty = llvm.PointerType.get(address_space=6)
+        tmem_ptr = llvm.inttoptr(ptr6_ty, _to_ir(addr_val, loc, ip), loc=loc, ip=ip)
+        _nvvm.tcgen05_cp(
+            shape=_nvvm.Tcgen05CpShape.SHAPE_128x256b,
+            taddr=tmem_ptr,
+            smem_desc=_to_ir(desc_val, loc, ip),
+            cta_group=_nvvm.Tcgen05GroupKind.CTA_1,
+            loc=loc,
+            ip=ip,
+        )
+
+    _do(Int32(taddr), smem_desc.desc_i64[0])
+
+
+@cute.jit
+def tcgen05_cp_128x128b(taddr: int, smem_desc: Tcgen05SmemDescriptor):
+    """Async copy SMEM → TMEM with shape ``128x128b`` (``cta_group::1``).
+
+    Issues ``tcgen05.cp.cta_group::1.128x128b  [taddr], s-desc;``
+    via the native ``nvvm.tcgen05.cp`` MLIR op.
+
+    The instruction copies a 128-row × 128-bit tile from shared memory
+    (described by *smem_desc*) into Tensor Memory at *taddr*.  The copy
+    is **asynchronous** — use ``tcgen05.commit`` + ``mbarrier.wait`` to
+    synchronize.
+
+    PTX reference
+    -------------
+        tcgen05.cp.cta_group::1.128x128b  [taddr], s-desc;
+
+    Parameters
+    ----------
+    taddr : int
+        TMEM destination address (uint32, passed as ``!llvm.ptr<6>``).
+    smem_desc : Tcgen05SmemDescriptor
+        64-bit SMEM matrix descriptor (same format as ``tcgen05.mma``
+        descriptors — see ``Tcgen05SmemDescriptor``).
+    """
+
+    @dsl_user_op
+    def _do(addr_val, desc_val, *, loc=None, ip=None):
+        ptr6_ty = llvm.PointerType.get(address_space=6)
+        tmem_ptr = llvm.inttoptr(ptr6_ty, _to_ir(addr_val, loc, ip), loc=loc, ip=ip)
+        _nvvm.tcgen05_cp(
+            shape=_nvvm.Tcgen05CpShape.SHAPE_128x128b,
+            taddr=tmem_ptr,
+            smem_desc=_to_ir(desc_val, loc, ip),
+            cta_group=_nvvm.Tcgen05GroupKind.CTA_1,
+            loc=loc,
+            ip=ip,
+        )
+
+    _do(Int32(taddr), smem_desc.desc_i64[0])
+
+
+@cute.jit
+def tcgen05_fence_before():
+    """tcgen05.fence::before_thread_sync — non-blocking ordering fence."""
+    _nvvm.tcgen05_fence(kind=_nvvm.Tcgen05FenceKind.BEFORE_THREAD_SYNC)
+
+
+@cute.jit
+def tcgen05_fence_after():
+    """tcgen05.fence::after_thread_sync — non-blocking ordering fence."""
+    _nvvm.tcgen05_fence(kind=_nvvm.Tcgen05FenceKind.AFTER_THREAD_SYNC)
+
+
+@cute.jit
+def umma_arrive(mbar_ptr: cute.Pointer):
+    """tcgen05.commit.cta_group::1.mbarrier::arrive::one — signal MMA done."""
+    with elect_one():
+        tcgen05.commit(mbar_ptr, cta_group=tcgen05.CtaGroup.ONE)
+
+
+@cute.jit
+def umma_arrive_noelect(mbar_ptr: cute.Pointer):
+    """tcgen05.commit.cta_group::1.mbarrier::arrive::one — signal MMA done."""
+    tcgen05.commit(mbar_ptr, cta_group=tcgen05.CtaGroup.ONE)
+
+
+PRINT_DEBUG = False
+
+LN2 = 0.6931471805599453
+RCP_LN2 = 1.4426950408889634
+
+COMPILE_OPTIONS = "--enable-tvm-ffi"
+USE_FAST_MATH: bool = os.getenv("MSLK_USE_FAST_MATH", "1") == "1"
+
+# Mapping from torch dtype to cutlass dtype (for beta_dtype conversion)
+_torch_to_cutlass_dtype = {
+    torch.bfloat16: cutlass.BFloat16,
+    torch.float32: cutlass.Float32,
+}
+
+
+def assert_blackwell(device: torch.device | str | int | None = None) -> None:
+    if device is None:
+        device = torch.cuda.current_device()
+    props = torch.cuda.get_device_properties(device)
+    if not (props.major == 10 and props.minor in (0, 3)):
+        raise RuntimeError(
+            "chunk_kda_bwd_wy_dqkg_fused requires Blackwell "
+            f"(SM100/SM103), got sm_{props.major}{props.minor}"
+        )
+
+
+def make_thread_cooperative_group(size: int):
+    return pipeline.CooperativeGroup(pipeline.Agent.Thread, size)
+
+
+def _exclusive_cumsum(a: list[int]):
+    r = [0]
+    for v in a:
+        r.append(r[-1] + v)
+    return r
+
+
+# ── TMEM column offset constants (cta_group::1, M=64, .ws Layout E) ──
+TMEM_DA_ACC_OFF = 0  # [0,32)   32 cols  dA fp32 acc; Phase 3: [0,16) overwritten by dA_bf16
+TMEM_DQ_ACC_OFF = 32  # [32,96)  64 cols  dq fp32 acc; Phase 3: step2/step3 result [32,64)
+TMEM_DK_ACC_OFF = 96  # [96,160) 64 cols  dk fp32 acc
+TMEM_DW_ACC_OFF = 160  # [160,224] 64 cols dw fp32 acc
+TMEM_FLEX_OFF = 224  # [224,256) 32 cols  dvb time-shared
+TMEM_A_BF16_OFF = 256  # [256,272) 16 cols  A_bf16 TS opA (persistent) (not used currently)
+TMEM_DKGB_ACC_OFF = 272  # [272,336) 64 cols, dkgb fp32 acc
+TMEM_DA2_ACC_OFF = 336  # [336,368) 32 cols  dA fp32 acc, used for dA=dA@A and dA=A@dA
+TMEM_DQ_SCALED_OFF = 368  # [368,432) 64 cols  dq_scaled (stored for dg)
+TMEM_TOTAL = 512
+
+# Instruction descriptor for M=64, N=64, BF16, dense, TransposeB=1
+# Bits: M>>4=4 at [24:28], N>>3=8 at [17:22], TransposeB at [16],
+#       btype=bf16(1) at [10:12], atype=bf16(1) at [7:9], dtype=f32(1) at [4:5]
+IDESC_F16_M64_N64_K_MN = (4 << 24) | (8 << 17) | (1 << 16) | (1 << 10) | (1 << 7) | (1 << 4)
+
+# Instruction descriptor for M=64, N=128, BF16, dense, TransposeB=1
+# Bits: M>>4=4 at [24:28], N>>3=16 at [17:22], TransposeB at [16],
+#       btype=bf16(1) at [10:12], atype=bf16(1) at [7:9], dtype=f32(1) at [4:5]
+IDESC_F16_M64_N128_K_MN = (4 << 24) | (16 << 17) | (1 << 16) | (1 << 10) | (1 << 7) | (1 << 4)
+
+# Instruction descriptor for M=64, N=128, BF16, dense
+# Bits: M>>4=4 at [24:28], N>>3=16 at [17:22],
+#       btype=bf16(1) at [10:12], atype=bf16(1) at [7:9], dtype=f32(1) at [4:5]
+IDESC_F16_M64_N128_K_K = (4 << 24) | (16 << 17) | (1 << 10) | (1 << 7) | (1 << 4)
+
+# Instruction descriptor for M=64, N=128, BF16, dense, TransposeA=1, TransposeB=1
+# Bits: M>>4=4 at [24:28], N>>3=16 at [17:22],
+#       TransposeB at [16], TransposeA at [15],
+#       btype=bf16(1) at [10:12], atype=bf16(1) at [7:9], dtype=f32(1) at [4:5]
+IDESC_F16_M64_N128_MN_MN = (
+    (4 << 24) | (16 << 17) | (1 << 16) | (1 << 15) | (1 << 10) | (1 << 7) | (1 << 4)
+)
+
+# Instruction descriptor for M=64, N=64, BF16, dense, TransposeA=1, TransposeB=1
+# Bits: M>>4=4 at [24:28], N>>3=8 at [17:22],
+#       TransposeB at [16], TransposeA at [15],
+#       btype=bf16(1) at [10:12], atype=bf16(1) at [7:9], dtype=f32(1) at [4:5]
+IDESC_F16_M64_N64_MN_MN = (
+    (4 << 24) | (8 << 17) | (1 << 16) | (1 << 15) | (1 << 10) | (1 << 7) | (1 << 4)
+)
+
+# Instruction descriptor for M=64, N=64, BF16, dense
+# Bits: M>>4=4 at [24:28], N>>3=8 at [17:22],
+#       TransposeB at [16], TransposeA at [15],
+#       btype=bf16(1) at [10:12], atype=bf16(1) at [7:9], dtype=f32(1) at [4:5]
+IDESC_F16_M64_N64_K_K = (4 << 24) | (8 << 17) | (1 << 10) | (1 << 7) | (1 << 4)
+
+ELEM_BYTES_BF16 = BFloat16.width // 8
+
+
+@cute.jit
+def smem_load_bf16x8_sw128(raw_ptr: cute.Pointer, row: Int32, col_base: Int32):
+    """
+    Load 8 consecutive bfloat16 from SMEM with Swizzle<3,4,3> layout.
+    raw_ptr: BFloat16 SMEM base pointer (NOT recast_ptr — raw buffer start)
+    row: row index in [0, T_TILE=64)
+    col_base: 8-aligned column index in [0, K_TILE=128)
+    Logical layout: [BT=64, BV=128] K-major, with the BV=128 dim split into
+    two halves of 64 elements (high half offset by 4096 elements).
+    Swizzle<3,4,3> on bf16: phys_elem = elem ^ ((row & 7) << 3) within a half.
+    Returns an 8-element rmem fragment (bf16).
+    """
+    half = col_base >> Int32(6)
+    k_inner = col_base & Int32(63)
+    swizzled = k_inner ^ ((row & Int32(7)) << Int32(3))
+    elem_off = half * Int32(4096) + row * Int32(64) + swizzled
+    aligned_ptr = cute.make_ptr(
+        BFloat16,
+        (raw_ptr + elem_off).toint(),
+        cute.AddressSpace.smem,
+        assumed_align=16,
+    )
+    smem_t = cute.make_tensor(aligned_ptr, cute.make_layout((8,), stride=(1,)))
+    rmem_t = cute.make_fragment_like(smem_t)
+    cute.autovec_copy(smem_t, rmem_t)
+    return rmem_t
+
+
+@cute.jit
+def smem_store_bf16x8_sw128(raw_ptr: cute.Pointer, row: Int32, col_base: Int32, data: cute.Tensor):
+    """
+    Store 8 consecutive bfloat16 to SMEM with Swizzle<3,4,3> layout.
+    raw_ptr: BFloat16 SMEM base pointer (NOT recast_ptr — raw buffer start)
+    row: row index in [0, T_TILE=64)
+    col_base: 8-aligned column index in [0, K_TILE=128)
+    data: 8-element rmem fragment (bf16) to store.
+
+    NOTE: For the K-major→MN-major dv re-swizzle, source layout
+    `(BT,BV) K-major Swizzle<3,4,3>` and destination layout
+    `(BV,BT) MN-major Swizzle<3,4,3>` produce **identical** physical
+    addresses for the same (row=t, col=v). So this helper uses the same
+    address formula as the load helper, and the caller passes (row=t, col=v)
+    for both load (src K-maj) and store (dst MN-maj), implicitly transposing.
+    """
+    half = col_base >> Int32(6)
+    k_inner = col_base & Int32(63)
+    swizzled = k_inner ^ ((row & Int32(7)) << Int32(3))
+    elem_off = half * Int32(4096) + row * Int32(64) + swizzled
+    smem_ptr = cute.make_ptr(
+        BFloat16,
+        (raw_ptr + elem_off).toint(),
+        cute.AddressSpace.smem,
+        assumed_align=16,
+    )
+    smem_t = cute.make_tensor(smem_ptr, cute.make_layout((8,), stride=(1,)))
+    cute.autovec_copy(data, smem_t)
+
+
+@cute.jit
+def smem_load_f32x4_sw128(raw_ptr: cute.Pointer, row: Int32, col_base: Int32):
+    """
+    Load 4 consecutive float32 from SMEM with K_SW128 layout.
+    Logical layout: [BT=64, BK=128] ROW_MAJOR, tiled over a Float32 K_SW128 atom.
+    The atom provides a 32-element row stride. The 128-element column is broken
+    into 4 blocks of 32 elements.
+    PyCutlass tiles this such that outer blocks stride by 2048 elements:
+      elem_idx = row * 32 + (col_base % 32) + (col_base / 32) * 2048
+
+    The TMA hardware performs a 128B Swizzle on physical byte addresses:
+      byte_idx = elem_idx * 4
+      swizzled_byte = byte_idx ^ (((byte_idx >> 7) & 7) << 4)
+    Dividing by 4 yields the element XOR offset:
+      elem_xor = ((elem_idx >> 5) & 7) << 2
+    Because (elem_idx >> 5) simplifies to 'row + (col_outer * 64)',
+    the XOR offset simplifies exactly to ((row & 7) << 2).
+    This only affects the inner 32-element column block.
+    """
+    c_inner = col_base & Int32(31)
+    c_outer = col_base >> Int32(5)
+    swizzled_inner = c_inner ^ ((row & Int32(7)) << Int32(2))
+
+    elem_offset = row * Int32(32) + swizzled_inner + c_outer * Int32(2048)
+
+    aligned_ptr = cute.make_ptr(
+        Float32,
+        (raw_ptr + elem_offset).toint(),
+        cute.AddressSpace.smem,
+        assumed_align=16,
+    )
+    t = cute.make_tensor(aligned_ptr, cute.make_layout((4,), stride=(1,)))
+    vals = t.load()
+    return (vals[0], vals[1], vals[2], vals[3])
+
+
+@cute.jit
+def smem_store_f32x4_sw128(raw_ptr: cute.Pointer, row: Int32, col_base: Int32, data: cute.Tensor):
+    """
+    Store 4 consecutive float32 to SMEM with K_SW128 layout.
+    Inverse of smem_load_f32x4_sw128 — same address formula, write path.
+    raw_ptr: Float32 SMEM base pointer (raw buffer start)
+    row: row index in [0, BT)
+    col_base: 4-aligned column index (multiples of 4)
+    data: 4-element rmem fragment (f32) to store.
+    """
+    c_inner = col_base & Int32(31)
+    c_outer = col_base >> Int32(5)
+    swizzled_inner = c_inner ^ ((row & Int32(7)) << Int32(2))
+    elem_offset = row * Int32(32) + swizzled_inner + c_outer * Int32(2048)
+    smem_ptr = cute.make_ptr(
+        Float32,
+        (raw_ptr + elem_offset).toint(),
+        cute.AddressSpace.smem,
+        assumed_align=16,
+    )
+    smem_t = cute.make_tensor(smem_ptr, cute.make_layout((4,), stride=(1,)))
+    cute.autovec_copy(data, smem_t)
+
+
+@cute.jit
+def mma_ws_ss_m64n128_call(
+    a_smem_layout: cute.Layout,
+    desc_a_base: Tcgen05SmemDescriptor,
+    b_smem_layout: cute.Layout,
+    desc_b_base: Tcgen05SmemDescriptor,
+    tmem_c: Int32,
+    K: Int32,
+    is_accum: bool = False,
+):
+    with elect_one():
+        a_outer = a_smem_layout.outer
+        b_outer = b_smem_layout.outer
+        scale = 0 if not is_accum else 1
+        for ks in cutlass.range_constexpr(K // 16):
+            a_off = cute.crd2idx(((0, 0), 0, ks, 0), a_outer) * ELEM_BYTES_BF16
+            b_off = cute.crd2idx(((0, 0), 0, ks, 0), b_outer) * ELEM_BYTES_BF16
+            desc_a = desc_a_base + a_off
+            desc_b = desc_b_base + b_off
+            tcgen05mma_ws_ss_f16(desc_a, desc_b, tmem_c, IDESC_F16_M64_N128_K_MN, scale)
+            scale = 1
+
+
+@cute.jit
+def mma_ws_ss_m64n128_k_k_call(
+    a_smem_layout: cute.Layout,
+    desc_a_base: Tcgen05SmemDescriptor,
+    b_smem_layout: cute.Layout,
+    desc_b_base: Tcgen05SmemDescriptor,
+    tmem_c: Int32,
+    K: Int32,
+    is_accum: bool = False,
+):
+    with elect_one():
+        a_outer = a_smem_layout.outer
+        b_outer = b_smem_layout.outer
+        scale = 0 if not is_accum else 1
+        for ks in cutlass.range_constexpr(K // 16):
+            a_off = cute.crd2idx(((0, 0), 0, ks, 0), a_outer) * ELEM_BYTES_BF16
+            b_off = cute.crd2idx(((0, 0), 0, ks, 0), b_outer) * ELEM_BYTES_BF16
+            desc_a = desc_a_base + a_off
+            desc_b = desc_b_base + b_off
+            tcgen05mma_ws_ss_f16(desc_a, desc_b, tmem_c, IDESC_F16_M64_N128_K_K, scale)
+            scale = 1
+
+
+@cute.jit
+def mma_ws_ss_m64n128_mn_mn_call(
+    a_smem_layout: cute.Layout,
+    desc_a_base: Tcgen05SmemDescriptor,
+    b_smem_layout: cute.Layout,
+    desc_b_base: Tcgen05SmemDescriptor,
+    tmem_c: Int32,
+    K: Int32,
+    is_accum: bool = False,
+):
+    with elect_one():
+        a_outer = a_smem_layout.outer
+        b_outer = b_smem_layout.outer
+        scale = 0 if not is_accum else 1
+        for ks in cutlass.range_constexpr(K // 16):
+            a_off = cute.crd2idx(((0, 0), 0, ks, 0), a_outer) * ELEM_BYTES_BF16
+            b_off = cute.crd2idx(((0, 0), 0, ks, 0), b_outer) * ELEM_BYTES_BF16
+            desc_a = desc_a_base + a_off
+            desc_b = desc_b_base + b_off
+            tcgen05mma_ws_ss_f16(desc_a, desc_b, tmem_c, IDESC_F16_M64_N128_MN_MN, scale)
+            scale = 1
+
+
+@cute.jit
+def mma_ws_ss_m64n64_k_k_call(
+    a_smem_layout: cute.Layout,
+    desc_a_base: Tcgen05SmemDescriptor,
+    b_smem_layout: cute.Layout,
+    desc_b_base: Tcgen05SmemDescriptor,
+    tmem_c: Int32,
+    K: Int32,
+    is_accum: bool = False,
+):
+    with elect_one():
+        a_outer = a_smem_layout.outer
+        b_outer = b_smem_layout.outer
+        scale = 0 if not is_accum else 1
+        for ks in cutlass.range_constexpr(K // 16):
+            a_off = cute.crd2idx(((0, 0), 0, ks, 0), a_outer) * ELEM_BYTES_BF16
+            b_off = cute.crd2idx(((0, 0), 0, ks, 0), b_outer) * ELEM_BYTES_BF16
+            desc_a = desc_a_base + a_off
+            desc_b = desc_b_base + b_off
+            tcgen05mma_ws_ss_f16(desc_a, desc_b, tmem_c, IDESC_F16_M64_N64_K_K, scale)
+            scale = 1
+
+
+@cute.jit
+def mma_ws_ss_m64n64_mn_mn_call(
+    a_smem_layout: cute.Layout,
+    desc_a_base: Tcgen05SmemDescriptor,
+    b_smem_layout: cute.Layout,
+    desc_b_base: Tcgen05SmemDescriptor,
+    tmem_c: Int32,
+    K: Int32,
+    is_accum: bool = False,
+):
+    with elect_one():
+        a_outer = a_smem_layout.outer
+        b_outer = b_smem_layout.outer
+        scale = 0 if not is_accum else 1
+        for ks in cutlass.range_constexpr(K // 16):
+            a_off = cute.crd2idx(((0, 0), 0, ks, 0), a_outer) * ELEM_BYTES_BF16
+            b_off = cute.crd2idx(((0, 0), 0, ks, 0), b_outer) * ELEM_BYTES_BF16
+            desc_a = desc_a_base + a_off
+            desc_b = desc_b_base + b_off
+            tcgen05mma_ws_ss_f16(desc_a, desc_b, tmem_c, IDESC_F16_M64_N64_MN_MN, scale)
+            scale = 1
+
+
+class ChunkKdaBwdWyDqkgFused:
+    """
+    CuTe DSL kernel for chunk_kda_bwd_kernel_wy_dqkg_fused.
+
+    Computes backward gradients dq, dk, dv2, dg, db, dA for the KDA
+    chunkwise delta-rule backward pass.
+
+    Architecture: 1 CudaCore WG + 1 MMA warp + TMA/Aux warps.
+    """
+
+    def __init__(
+        self,
+        chunk_size: int = 64,
+        head_dim_k: int = 128,
+        head_dim_v: int = 128,
+        acc_dtype: type[cutlass.Numeric] = cutlass.Float32,
+        io_dtype: type[cutlass.Numeric] = cutlass.BFloat16,
+        g_dtype: type[cutlass.Numeric] = cutlass.Float32,
+        beta_dtype: type[cutlass.Numeric] = cutlass.Float32,
+        scale: float = 1.0,
+        min_occupancy: int = 1,
+        use_fast_math: bool = True,
+    ):
+        assert chunk_size == 64, "chunk_size must be 64"
+        assert head_dim_k == 128 and head_dim_v == 128, (
+            f"head_dim_k and head_dim_v must both be 128, got head_dim_k={head_dim_k}, head_dim_v={head_dim_v}"
+        )
+        assert_blackwell()
+
+        self.use_fast_math = use_fast_math
+        self.chunk_size = chunk_size
+        self.head_dim_k = head_dim_k
+        self.head_dim_v = head_dim_v
+        self.acc_dtype = acc_dtype
+        self.io_dtype = io_dtype
+        self.g_dtype = g_dtype
+        self.beta_dtype = beta_dtype
+        self.scale = scale
+
+        # Tile sizes
+        self.BT = chunk_size  # 64
+        self.BK = 128  # K tiling for V-loop GEMM (single K tile)
+        self.BV = 64  # V tiling for V-loop GEMM (single V tile)
+
+        # Warp layout: WG0/WG1 (8 CudaCore warps) + WG2 (MMA/Load/Aux/Store)
+        self.threads_per_warp = 32
+        self.cuda_warp_ids = (0, 1, 2, 3)  # WG0: CudaCore + Store
+        self.cuda2_warp_ids = (4, 5, 6, 7)  # WG1: CudaCore + Store
+        self.mma_warp_id = 8  # WG2: MMA dispatch
+        self.load_warp_id = 9  # WG2: TMA Load
+        self.aux_warp_ids = (10, 11)  # WG2: Aux/Load/Store Aux
+        self.threads_per_cta = self.threads_per_warp * 12  # 384 threads (3 WGs)
+
+        self.num_regs_cuda = 208
+        self.num_regs_others = 88
+        self.min_occupancy = min_occupancy
+
+        self.cluster_shape_mnk = (1, 1, 1)
+        self.cta_group = tcgen05.CtaGroup.ONE
+
+        # Number of K/V tiles
+        self.num_k_tiles = (head_dim_k + self.BK - 1) // self.BK  # 128/128 = 1
+        self.num_v_tiles = (head_dim_v + self.BV - 1) // self.BV  # 128/64 = 2
+
+        # ── Pipeline stages ──
+        # V-loop TMA: 2-stage double buffer
+        self.vloop_stage = 2
+        self.kloop_stage = 1
+        self.a_stage = 2
+        self.mma_stage = 1
+
+        # ── MMA tiler shapes ──
+        # V-loop GEMMs: [BT, BV] × [BV, BK] → [BT, BK]
+        # dq = do @ h :       (BT, BK, BV)  — M=BT, N=BK, K=BV
+        # dk = v_new @ dh :   (BT, BK, BV)
+        # dw = dv @ h :       (BT, BK, BV)
+        self.vloop_gemm_tiler = (self.BT, self.BK, self.BV)
+
+        # V-loop i_k==0 GEMMs: [BT, BV] × [BV, BT] → [BT, BT]
+        # dA = dv @ v^T :     (BT, BT, BV)
+        self.dA_vloop_tiler = (self.BT, self.BT, self.BV)
+
+        # V-loop i_k==0: A @ dv : [BT, BT] × [BT, BV] → [BT, BV]
+        self.dvb_tiler = (self.BT, self.BV, self.BT)
+
+        # K-loop GEMMs:
+        # dA += dw @ kg^T :  [BT, BK] × [BK, BT] → [BT, BT]  →  (BT, BT, BK)
+        self.kloop_dA_tiler = (self.BT, self.BT, self.BK)
+        # dkgb = A @ dw :    [BT, BT] × [BT, BK] → [BT, BK]  →  (BT, BK, BT)
+        self.kloop_dkgb_tiler = (self.BT, self.BK, self.BT)
+
+        # dA-post GEMMs:
+        # dA @ A :  [BT, BT] × [BT, BT] → [BT, BT]  →  (BT, BT, BT)
+        # A @ dA :  same
+        self.dApost_tiler = (self.BT, self.BT, self.BT)
+
+        # Named barriers
+        self.tmem_dealloc_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=2,
+            num_threads=self.threads_per_cta,
+        )
+        self.cuda_wg_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=3,
+            num_threads=32 * 8,
+        )
+        self.buffer_align_bytes = 1024
+
+        # Persistent scheduling
+        self.persistent = True
+        hardware_info = cutlass.utils.HardwareInfo()
+        self.num_sm = hardware_info.get_device_multiprocessor_count()
+
+    def _compute_grid(self, B, T, HV, total_nt=None):
+        """Compute grid dimensions for persistent kernel launch.
+
+        Grid: (min(num_sm * min_occupancy, total_tiles), 1, 1)
+        Each CTA handles multiple tiles via stride-by-gridDim.x loop.
+        """
+        assert total_nt is not None
+        total_tiles = total_nt * HV
+        grid_x = cutlass.min(Int32(self.num_sm * self.min_occupancy), total_tiles)
+        return (grid_x, Int32(1), Int32(1))
+
+    @cute.jit
+    def __call__(
+        self,
+        # ── Inputs ──
+        q_in: cute.Tensor,  # [B, T, H, K] bf16
+        k_in: cute.Tensor,  # [B, T, H, K] bf16
+        v_in: cute.Tensor,  # [B, T, HV, V] bf16
+        v_new_in: cute.Tensor,  # [B, T, HV, V] bf16
+        g_in: cute.Tensor,  # [B, T, HV, K] fp32
+        beta_in: cute.Tensor,  # [B, T, HV]   fp32
+        A_in: cute.Tensor,  # [B, T, HV, BT] bf16
+        h_in: cute.Tensor,  # [B, NT, HV, K, V] bf16
+        do_in: cute.Tensor,  # [B, T, HV, V] bf16
+        dh_in: cute.Tensor,  # [B, NT, HV, K, V] bf16
+        dv_in: cute.Tensor,  # [B, T, HV, V] bf16
+        # ── Outputs ──
+        dq_in: cute.Tensor,  # [B, T, HV, K] fp32
+        dk_in: cute.Tensor,  # [B, T, HV, K] fp32
+        dv2_in: cute.Tensor,  # [B, T, HV, V] bf16
+        dg_in: cute.Tensor,  # [B, T, HV, K] fp32
+        db_in: cute.Tensor,  # [B, T, HV]    fp32
+        dA_in: cute.Tensor,  # [B, T, HV, BT] fp32
+        # ── Metadata ──
+        cu_seqlens_in: cute.Tensor,  # [N+1] int32
+        chunk_indices_in: cute.Tensor,  # [NT, 2] int32
+        problem_size: tuple[Int32, Int32, Int32, Int32, Int32, Int32],  # (B, T, H, HV, K, V)
+        total_nt: Int32,
+        stream,
+    ):
+        # ── Extract pointers ──
+        q_ptr = q_in.iterator
+        k_ptr = k_in.iterator
+        v_ptr = v_in.iterator
+        v_new_ptr = v_new_in.iterator
+        g_ptr = g_in.iterator
+        beta_ptr = beta_in.iterator
+        A_ptr = A_in.iterator
+        h_ptr = h_in.iterator
+        do_ptr = do_in.iterator
+        dh_ptr = dh_in.iterator
+        dv_ptr = dv_in.iterator
+        dq_ptr = dq_in.iterator
+        dk_ptr = dk_in.iterator
+        dv2_ptr = dv2_in.iterator
+        dg_ptr = dg_in.iterator
+        db_ptr = db_in.iterator
+        dA_ptr = dA_in.iterator
+        cu_seqlens_ptr = cu_seqlens_in.iterator
+        chunk_indices_ptr = chunk_indices_in.iterator
+
+        B, T, H, HV, K, V = problem_size
+        BT = self.BT
+
+        data_B = Int32(1)
+        NT = total_nt
+
+        # ===================== GMEM layouts =====================
+        # Token-indexed tensors: (T, dim, (H, data_B))
+        # q, k: (T, K, (H, data_B)) bf16
+        qk_layout = cute.make_layout(
+            (T, K, (H, data_B)),
+            stride=(H * K, 1, (K, T * H * K)),
+        )
+        q = cute.make_tensor(q_ptr, qk_layout)
+        k = cute.make_tensor(k_ptr, qk_layout)
+
+        # v, v_new, do, dv, dv2: (T, V, (HV, data_B)) bf16
+        tv_layout = cute.make_layout(
+            (T, V, (HV, data_B)),
+            stride=(HV * V, 1, (V, T * HV * V)),
+        )
+        v = cute.make_tensor(v_ptr, tv_layout)
+        v_new = cute.make_tensor(v_new_ptr, tv_layout)
+        do = cute.make_tensor(do_ptr, tv_layout)
+        dv = cute.make_tensor(dv_ptr, tv_layout)
+        dv2 = cute.make_tensor(dv2_ptr, tv_layout)
+
+        # g: (T, K, (HV, data_B)) fp32
+        g_layout = cute.make_layout(
+            (T, K, (HV, data_B)),
+            stride=(HV * K, 1, (K, T * HV * K)),
+        )
+        g = cute.make_tensor(g_ptr, g_layout)
+
+        # beta: (T, (HV, data_B)) fp32
+        beta_layout = cute.make_layout(
+            (T, (HV, data_B)),
+            stride=(HV, (1, T * HV)),
+        )
+        beta = cute.make_tensor(beta_ptr, beta_layout)
+
+        # A: (T, BT, (HV, data_B)) bf16
+        # NOTE: for A as operand A, A is loaded as transposed view to do MMA
+        a_t_layout = cute.make_layout(
+            (BT, T, (HV, data_B)),
+            stride=(1, HV * BT, (BT, T * HV * BT)),
+        )
+        A_T = cute.make_tensor(A_ptr, a_t_layout)
+
+        # dq, dk: (T, K, (HV, data_B)) fp32
+        dqk_layout = cute.make_layout(
+            (T, K, (HV, data_B)),
+            stride=(HV * K, 1, (K, T * HV * K)),
+        )
+        dq = cute.make_tensor(dq_ptr, dqk_layout)
+        dk = cute.make_tensor(dk_ptr, dqk_layout)
+
+        # dg: (T, K, (HV, data_B)) fp32
+        dg = cute.make_tensor(dg_ptr, dqk_layout)
+
+        # db: (T, (HV, data_B)) fp32
+        db = cute.make_tensor(db_ptr, beta_layout)
+
+        # dA: (T, BT, (HV, data_B)) fp32
+        dA_layout = cute.make_layout(
+            (T, BT, (HV, data_B)),
+            stride=(HV * BT, 1, (BT, T * HV * BT)),
+        )
+        dA_out = cute.make_tensor(dA_ptr, dA_layout)
+
+        h_nt_total = NT
+
+        # h row-major: (K, V, (h_nt_total, HV)) as operand B
+        h_layout = cute.make_layout(
+            (K, V, (h_nt_total, HV)),
+            stride=(V, 1, (HV * K * V, K * V)),
+        )
+        h = cute.make_tensor(h_ptr, h_layout)
+        dh = cute.make_tensor(dh_ptr, h_layout)
+
+        # ===================== MMA setup (4 objects) =====================
+        # All use tcgen05.mma.ws (Layout E, M=64, cta_group::1).
+        # 1. vloop_tiled_mma: SS K,K (64,128) — dq, dk, dw
+        #    dq += do @ h, dk += vnew @ dh, dw += dv @ h
+        vloop_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            self.io_dtype,
+            tcgen05.OperandMajorMode.K,  # A: K-major
+            tcgen05.OperandMajorMode.K,  # B: K-major
+            self.acc_dtype,
+            self.cta_group,
+            self.vloop_gemm_tiler[:2],  # (64, 128)
+            # default a_source=OperandSource.SMEM → SS mode
+        )
+
+        # 2. dA_vloop_tiled_mma: SS K,K (64,64) — dA vloop + kpost_dA
+        #    dA += dv @ v^T, dA += dw @ kg^T
+        dA_vloop_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            self.io_dtype,
+            tcgen05.OperandMajorMode.K,
+            tcgen05.OperandMajorMode.K,
+            self.acc_dtype,
+            self.cta_group,
+            self.dA_vloop_tiler[:2],  # (64, 64)
+            # default a_source=OperandSource.SMEM → SS mode
+        )
+
+        # 3. dvb_tiled_mma: SS MN,MN (64,64) — dvb + dkgb
+        #    dvb = A @ dv, dkgb = A @ dw
+        dvb_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            self.io_dtype,
+            tcgen05.OperandMajorMode.MN,
+            tcgen05.OperandMajorMode.MN,
+            self.acc_dtype,
+            self.cta_group,
+            self.dvb_tiler[:2],  # (64, 64)
+        )
+
+        # dkgb_tiled_mma: SS MN,MN (64,128) - dkgb
+        dkgb_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            self.io_dtype,
+            tcgen05.OperandMajorMode.MN,
+            tcgen05.OperandMajorMode.MN,
+            self.acc_dtype,
+            self.cta_group,
+            self.kloop_dkgb_tiler[:2],  # (64, 128)
+        )
+
+        # dA_kloop_tiled_mma: SS K,K (64, 64)
+        # dA += dw @ kg^T
+        dA_kloop_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            self.io_dtype,
+            tcgen05.OperandMajorMode.K,
+            tcgen05.OperandMajorMode.K,
+            self.acc_dtype,
+            self.cta_group,
+            self.kloop_dA_tiler[:2],  # (64, 64)
+        )
+
+        # dA2post_tiled_mma: SS K,K (64,64)
+        # dA = dA @ A
+        dA2post_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            self.io_dtype,
+            tcgen05.OperandMajorMode.K,
+            tcgen05.OperandMajorMode.K,
+            self.acc_dtype,
+            self.cta_group,
+            self.dApost_tiler[:2],  # (64, 64)
+            # tcgen05.OperandSource.SMEM,  # SS mode
+        )
+
+        # dA3post_tiled_mma: SS MN,MN (64,64)
+        # dA = A @ dA
+        dA3post_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            self.io_dtype,
+            tcgen05.OperandMajorMode.MN,
+            tcgen05.OperandMajorMode.MN,
+            self.acc_dtype,
+            self.cta_group,
+            self.dApost_tiler[:2],  # (64, 64)
+            # tcgen05.OperandSource.SMEM,  # SS mode
+        )
+
+        # ===================== SMEM layouts =====================
+        tma_load_op = cpasync.CopyBulkTensorTileG2SOp(self.cta_group)
+        tma_store_op = cute.nvgpu.cpasync.CopyBulkTensorTileS2GOp()
+
+        # SS opA layout: do/vnew/dv [BT,BV]=[64,64] K-major
+        vloop_opA_smem = sm100_utils.make_smem_layout_a(
+            vloop_tiled_mma,
+            self.vloop_gemm_tiler,
+            self.io_dtype,
+            self.vloop_stage,
+        )
+
+        # SS opB layout: h/dh [BK,BV]=[128,64] K-major
+        vloop_opB_smem = sm100_utils.make_smem_layout_b(
+            vloop_tiled_mma,
+            self.vloop_gemm_tiler,
+            self.io_dtype,
+            self.vloop_stage,
+        )
+
+        # SS opB layout: v [BV,BT]=[128,64] K-major (dA vloop)
+        v_opB_smem = sm100_utils.make_smem_layout_b(
+            dA_vloop_tiled_mma,
+            self.dA_vloop_tiler,
+            self.io_dtype,
+            self.vloop_stage,
+        )
+
+        # SS opA layout: A MN-major [BT,BT]=[64,64]
+        A_mn_opA_smem = sm100_utils.make_smem_layout_a(
+            dvb_tiled_mma,
+            self.dvb_tiler,
+            self.io_dtype,
+            self.a_stage,
+        )
+
+        # opB: dv MN-major [BV,BT]=[64,64]
+        dv_mn_opB_smem = sm100_utils.make_smem_layout_b(
+            dvb_tiled_mma,
+            self.dvb_tiler,
+            self.io_dtype,
+            self.vloop_stage,
+        )
+
+        # opA: dw K-major [BT,BK]=[64,128]
+        dw_k_opA_smem = sm100_utils.make_smem_layout_a(
+            dA_vloop_tiled_mma,
+            self.kloop_dA_tiler,
+            self.io_dtype,
+            self.kloop_stage,
+        )
+
+        # opB: dw MN-major [BK,BT]
+        dw_mn_opB_smem = sm100_utils.make_smem_layout_b(
+            dkgb_tiled_mma,
+            self.kloop_dkgb_tiler,
+            self.io_dtype,
+            self.kloop_stage,
+        )
+
+        # opB: kg^T K-major [BT, BK]
+        kg_k_opB_smem = sm100_utils.make_smem_layout_b(
+            dA_kloop_tiled_mma,
+            self.kloop_dA_tiler,
+            self.io_dtype,
+            self.kloop_stage,
+        )
+
+        # opA: dA K-major [BT,BT]
+        dA_k_opA_smem = sm100_utils.make_smem_layout_a(
+            dA2post_tiled_mma,
+            self.dApost_tiler,
+            self.io_dtype,
+            self.mma_stage,
+        )
+
+        # opB: A K-major [BT,BT]
+        A_k_opB_smem = sm100_utils.make_smem_layout_b(
+            dA2post_tiled_mma,
+            self.dApost_tiler,
+            self.io_dtype,
+            self.a_stage,
+        )
+
+        # opB: dA MN-major [BT,BT]
+        dA_mn_opB_smem = sm100_utils.make_smem_layout_b(
+            dA3post_tiled_mma,
+            self.dApost_tiler,
+            self.io_dtype,
+            self.mma_stage,
+        )
+
+        # --- Epilogue (non-MMA) layouts ---
+        g_epi_smem_layout = sm100_utils.make_smem_layout_epi(
+            self.g_dtype,
+            utils.LayoutEnum.ROW_MAJOR,
+            (self.BT, self.BK),
+            self.kloop_stage,
+        )
+
+        k_epi_smem_layout = sm100_utils.make_smem_layout_epi(
+            self.io_dtype,
+            utils.LayoutEnum.ROW_MAJOR,
+            (self.BT, self.BK),
+            self.kloop_stage,
+        )
+
+        q_epi_smem_layout = sm100_utils.make_smem_layout_epi(
+            self.io_dtype,
+            utils.LayoutEnum.ROW_MAJOR,
+            (self.BT, self.BK),
+            1,
+        )
+
+        dg_epi_smem_layout = sm100_utils.make_smem_layout_epi(
+            self.g_dtype,
+            utils.LayoutEnum.ROW_MAJOR,
+            (self.BT, self.BK),
+            self.kloop_stage,
+        )
+
+        # ===================== Cluster layout =====================
+        cluster_layout = cute.tiled_divide(
+            cute.make_layout(self.cluster_shape_mnk),
+            (vloop_tiled_mma.thr_id.shape,),
+        )
+
+        # ===================== TMA descriptors =====================
+        # Strip stage dimension for TMA atom creation (expects 3 modes, not 4)
+        vloop_opA_smem_no_stage = cute.select(vloop_opA_smem, mode=[0, 1, 2])
+        vloop_opB_smem_no_stage = cute.select(vloop_opB_smem, mode=[0, 1, 2])
+        v_opB_smem_no_stage = cute.select(v_opB_smem, mode=[0, 1, 2])
+        A_mn_opA_smem_no_stage = cute.select(A_mn_opA_smem, mode=[0, 1, 2])
+
+        tma_atom_dv, tma_tensor_dv = cute.nvgpu.make_tiled_tma_atom_A(
+            tma_load_op,
+            dv,
+            vloop_opA_smem_no_stage,
+            self.vloop_gemm_tiler,
+            vloop_tiled_mma,
+            cluster_layout.shape,
+        )
+
+        tma_atom_A, tma_tensor_A = cute.nvgpu.make_tiled_tma_atom_A(
+            tma_load_op,
+            A_T,
+            A_mn_opA_smem_no_stage,
+            self.dvb_tiler,
+            dvb_tiled_mma,
+            cluster_layout.shape,
+        )
+
+        tma_atom_h, tma_tensor_h = cute.nvgpu.make_tiled_tma_atom_B(
+            tma_load_op,
+            h,
+            vloop_opB_smem_no_stage,
+            self.vloop_gemm_tiler,
+            vloop_tiled_mma,
+            cluster_layout.shape,
+        )
+
+        tma_atom_dh, tma_tensor_dh = cute.nvgpu.make_tiled_tma_atom_B(
+            tma_load_op,
+            dh,
+            vloop_opB_smem_no_stage,
+            self.vloop_gemm_tiler,
+            vloop_tiled_mma,
+            cluster_layout.shape,
+        )
+
+        tma_atom_do, tma_tensor_do = cute.nvgpu.make_tiled_tma_atom_A(
+            tma_load_op,
+            do,
+            vloop_opA_smem_no_stage,
+            self.vloop_gemm_tiler,
+            vloop_tiled_mma,
+            cluster_layout.shape,
+        )
+
+        tma_atom_vnew, tma_tensor_vnew = cute.nvgpu.make_tiled_tma_atom_A(
+            tma_load_op,
+            v_new,
+            vloop_opA_smem_no_stage,
+            self.vloop_gemm_tiler,
+            vloop_tiled_mma,
+            cluster_layout.shape,
+        )
+
+        tma_atom_v, tma_tensor_v = cute.nvgpu.make_tiled_tma_atom_B(
+            tma_load_op,
+            v,
+            v_opB_smem_no_stage,
+            self.dA_vloop_tiler,
+            dA_vloop_tiled_mma,
+            cluster_layout.shape,
+        )
+
+        g_epi_smem_no_stage = cute.select(g_epi_smem_layout, mode=[0, 1])
+        tma_atom_g, tma_tensor_g = cpasync.make_tiled_tma_atom(
+            tma_load_op,
+            g,
+            g_epi_smem_no_stage,
+            (self.BT, self.BK),
+        )
+
+        k_epi_smem_no_stage = cute.select(k_epi_smem_layout, mode=[0, 1])
+        tma_atom_k, tma_tensor_k = cpasync.make_tiled_tma_atom(
+            tma_load_op,
+            k,
+            k_epi_smem_no_stage,
+            (self.BT, self.BK),
+        )
+
+        q_epi_smem_no_stage = cute.select(q_epi_smem_layout, mode=[0, 1])
+        tma_atom_q, tma_tensor_q = cpasync.make_tiled_tma_atom(
+            tma_load_op,
+            q,
+            q_epi_smem_no_stage,
+            (self.BT, self.BK),
+        )
+
+        dg_epi_smem_no_stage = cute.select(dg_epi_smem_layout, mode=[0, 1])
+        tma_atom_dg, tma_tensor_dg = cpasync.make_tiled_tma_atom(
+            tma_store_op,
+            dg,
+            dg_epi_smem_no_stage,
+            (self.BT, self.BK),
+        )
+
+        # ===================== TMA byte counts =====================
+        self.tma_bytes_A = cute.size_in_bytes(self.io_dtype, A_mn_opA_smem_no_stage)
+        self.tma_bytes_dv = cute.size_in_bytes(self.io_dtype, vloop_opA_smem_no_stage)
+        self.tma_bytes_h = cute.size_in_bytes(self.io_dtype, vloop_opB_smem_no_stage)
+        self.tma_bytes_dh = cute.size_in_bytes(self.io_dtype, vloop_opB_smem_no_stage)
+        self.tma_bytes_do = cute.size_in_bytes(self.io_dtype, vloop_opA_smem_no_stage)
+        self.tma_bytes_vnew = cute.size_in_bytes(self.io_dtype, vloop_opA_smem_no_stage)
+        self.tma_bytes_g = cute.size_in_bytes(self.g_dtype, g_epi_smem_no_stage)
+        self.tma_bytes_v = cute.size_in_bytes(self.io_dtype, v_opB_smem_no_stage)
+        self.tma_bytes_k = cute.size_in_bytes(self.io_dtype, k_epi_smem_no_stage)
+        self.tma_bytes_q = cute.size_in_bytes(self.io_dtype, q_epi_smem_no_stage)
+
+        # ===================== SharedStorage =====================
+        @cute.struct
+        class SharedStorage:
+            # ======= mbarrier =======
+            bar_load_A: cute.struct.MemRange[Int64, self.a_stage * 2]
+            bar_load_dv: cute.struct.MemRange[Int64, self.vloop_stage * 2]
+            bar_mma_dvb: cute.struct.MemRange[Int64, self.mma_stage * 2]
+            bar_load_beta: cute.struct.MemRange[Int64, 1 * 2]
+            bar_tma_h: cute.struct.MemRange[Int64, self.vloop_stage]
+            bar_mma_cuda_h: cute.struct.MemRange[Int64, self.vloop_stage]
+            bar_tma_dh: cute.struct.MemRange[Int64, self.vloop_stage]
+            bar_mma_cuda_dh: cute.struct.MemRange[Int64, self.vloop_stage]
+            bar_tma_v: cute.struct.MemRange[Int64, self.vloop_stage]
+            bar_mma_cuda_v: cute.struct.MemRange[Int64, self.vloop_stage]
+            bar_load_do: cute.struct.MemRange[Int64, self.vloop_stage * 2]
+            bar_load_g: cute.struct.MemRange[Int64, self.kloop_stage * 2]
+            bar_load_vnew: cute.struct.MemRange[Int64, self.vloop_stage * 2]
+            bar_load_q: cute.struct.MemRange[Int64, self.kloop_stage * 2]
+            bar_load_k: cute.struct.MemRange[Int64, self.kloop_stage * 2]
+            bar_mma_dq: cute.struct.MemRange[Int64, self.mma_stage * 2]
+            bar_mma_dw: cute.struct.MemRange[Int64, self.mma_stage * 2]
+            bar_mma_dk: cute.struct.MemRange[Int64, self.mma_stage * 2]
+            bar_mma_dkgb: cute.struct.MemRange[Int64, self.mma_stage * 2]
+            bar_mma_dA: cute.struct.MemRange[Int64, self.mma_stage * 2]
+            bar_mma_dA2: cute.struct.MemRange[Int64, self.mma_stage * 2]
+            bar_mma_dA3: cute.struct.MemRange[Int64, self.mma_stage * 2]
+            bar_mma_done_vloop: cute.struct.MemRange[Int64, self.mma_stage]
+            bar_prologue_dw: cute.struct.MemRange[Int64, self.kloop_stage * 2]
+            bar_prologue_kg: cute.struct.MemRange[Int64, self.kloop_stage * 2]
+            bar_prologue_dA2: cute.struct.MemRange[Int64, self.mma_stage * 2]
+            bar_prologue_dA3: cute.struct.MemRange[Int64, self.mma_stage * 2]
+            bar_store_dg: cute.struct.MemRange[Int64, self.kloop_stage * 2]
+            # TMEM holding buffer
+            tmem_holding_buf: Int32
+            # A, stage=2, [BT,BT], 16KB
+            buf_A: cute.struct.Align[
+                cute.struct.MemRange[self.io_dtype, cute.cosize(A_mn_opA_smem)],
+                self.buffer_align_bytes,
+            ]
+            # k, stage=1, [BT,BK], 16KB
+            buf_k: cute.struct.Align[
+                cute.struct.MemRange[self.io_dtype, cute.cosize(k_epi_smem_layout)],
+                self.buffer_align_bytes,
+            ]
+            # g, stage=1, [BT,BK], 32KB
+            buf_g: cute.struct.Align[
+                cute.struct.MemRange[self.g_dtype, cute.cosize(g_epi_smem_layout)],
+                self.buffer_align_bytes,
+            ]
+            # q, stage=1, [BT,BK], 16KB
+            buf_q: cute.struct.Align[
+                cute.struct.MemRange[self.io_dtype, cute.cosize(q_epi_smem_layout)],
+                self.buffer_align_bytes,
+            ]
+            # V-loop buffers, stage=2
+            # h, dh, [BK,BV] 32KB*2
+            buf_h: cute.struct.Align[
+                cute.struct.MemRange[self.io_dtype, cute.cosize(vloop_opB_smem)],
+                self.buffer_align_bytes,
+            ]
+            buf_dh: cute.struct.Align[
+                cute.struct.MemRange[self.io_dtype, cute.cosize(vloop_opB_smem)],
+                self.buffer_align_bytes,
+            ]
+            # do, dv, v_new, v, [BT,BV] 16KB*4
+            buf_do: cute.struct.Align[
+                cute.struct.MemRange[self.io_dtype, cute.cosize(vloop_opA_smem)],
+                self.buffer_align_bytes,
+            ]
+            buf_dv: cute.struct.Align[
+                cute.struct.MemRange[self.io_dtype, cute.cosize(vloop_opA_smem)],
+                self.buffer_align_bytes,
+            ]
+            buf_vnew: cute.struct.Align[
+                cute.struct.MemRange[self.io_dtype, cute.cosize(vloop_opA_smem)],
+                self.buffer_align_bytes,
+            ]
+            buf_v: cute.struct.Align[
+                cute.struct.MemRange[self.io_dtype, cute.cosize(v_opB_smem)],
+                self.buffer_align_bytes,
+            ]
+
+            # dw, stage=1, [BT,BK] 16KB
+            buf_dw: cute.struct.Align[
+                cute.struct.MemRange[self.io_dtype, cute.cosize(dw_k_opA_smem)],
+                self.buffer_align_bytes,
+            ]
+            # Scalars
+            s_beta: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, self.BT],
+                128,
+            ]
+            # 2 slots per row, one per warpgroup, for deterministic db reduction
+            # (avoids cross-wg fp32 atomicAdd on shared memory).
+            s_db: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, self.BT * 2],
+                128,
+            ]
+            s_gn: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, self.BK],
+                128,
+            ]
+            s_dgk: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, self.BK],
+                128,
+            ]
+
+        self.shared_storage = SharedStorage
+
+        # ===================== cu_seqlens / chunk_indices tensors =====================
+        cu_seqlens = cute.make_tensor(cu_seqlens_ptr, cute.make_layout((B + 1,)))
+        chunk_indices = cute.make_tensor(
+            chunk_indices_ptr, cute.make_layout((total_nt, 2), stride=(2, 1))
+        )
+
+        # ===================== Grid =====================
+        grid = self._compute_grid(B, T, HV, total_nt=total_nt)
+
+        # ===================== Launch kernel =====================
+        self.kernel(
+            # MMA objects (4)
+            vloop_tiled_mma,
+            dA_vloop_tiled_mma,
+            dvb_tiled_mma,
+            dA_kloop_tiled_mma,
+            dA2post_tiled_mma,
+            dA3post_tiled_mma,
+            # TMA atoms
+            tma_atom_dv,
+            tma_tensor_dv,
+            tma_atom_A,
+            tma_tensor_A,
+            tma_atom_h,
+            tma_tensor_h,
+            tma_atom_dh,
+            tma_tensor_dh,
+            tma_atom_do,
+            tma_tensor_do,
+            tma_atom_g,
+            tma_tensor_g,
+            tma_atom_v,
+            tma_tensor_v,
+            tma_atom_k,
+            tma_tensor_k,
+            tma_atom_vnew,
+            tma_tensor_vnew,
+            tma_atom_q,
+            tma_tensor_q,
+            tma_atom_dg,
+            tma_tensor_dg,
+            # SMEM layouts
+            vloop_opA_smem,
+            vloop_opB_smem,
+            v_opB_smem,
+            A_mn_opA_smem,
+            dv_mn_opB_smem,
+            dw_k_opA_smem,
+            dw_mn_opB_smem,
+            kg_k_opB_smem,
+            A_k_opB_smem,
+            dA_k_opA_smem,
+            dA_mn_opB_smem,
+            g_epi_smem_layout,
+            k_epi_smem_layout,
+            q_epi_smem_layout,
+            # GMEM tensors
+            q,
+            k,
+            g,
+            beta,
+            dq,
+            dk,
+            dv2,
+            dg,
+            db,
+            dA_out,
+            # Metadata
+            cu_seqlens,
+            chunk_indices,
+            problem_size,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=self.cluster_shape_mnk,
+            stream=stream,
+            min_blocks_per_mp=self.min_occupancy,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        # MMA objects (4)
+        vloop_tiled_mma: cute.TiledMma,
+        dA_vloop_tiled_mma: cute.TiledMma,
+        dvb_tiled_mma: cute.TiledMma,
+        dA_kloop_tiled_mma: cute.TiledMma,
+        dA2post_tiled_mma: cute.TiledMma,
+        dA3post_tiled_mma: cute.TiledMma,
+        # TMA atoms + tensors
+        tma_atom_dv: cute.CopyAtom,
+        tma_tensor_dv: cute.Tensor,
+        tma_atom_A: cute.CopyAtom,
+        tma_tensor_A: cute.Tensor,
+        tma_atom_h: cute.CopyAtom,
+        tma_tensor_h: cute.Tensor,
+        tma_atom_dh: cute.CopyAtom,
+        tma_tensor_dh: cute.Tensor,
+        tma_atom_do: cute.CopyAtom,
+        tma_tensor_do: cute.Tensor,
+        tma_atom_g: cute.CopyAtom,
+        tma_tensor_g: cute.Tensor,
+        tma_atom_v: cute.CopyAtom,
+        tma_tensor_v: cute.Tensor,
+        tma_atom_k: cute.CopyAtom,
+        tma_tensor_k: cute.Tensor,
+        tma_atom_vnew: cute.CopyAtom,
+        tma_tensor_vnew: cute.Tensor,
+        tma_atom_q: cute.CopyAtom,
+        tma_tensor_q: cute.Tensor,
+        tma_atom_dg: cute.CopyAtom,
+        tma_tensor_dg: cute.Tensor,
+        # SMEM layouts
+        vloop_opA_smem: cute.ComposedLayout,
+        vloop_opB_smem: cute.ComposedLayout,
+        v_opB_smem: cute.ComposedLayout,
+        A_mn_opA_smem: cute.ComposedLayout,
+        dv_mn_opB_smem: cute.ComposedLayout,
+        dw_k_opA_smem: cute.ComposedLayout,
+        dw_mn_opB_smem: cute.ComposedLayout,
+        kg_k_opB_smem: cute.ComposedLayout,
+        A_k_opB_smem: cute.ComposedLayout,
+        dA_k_opA_smem: cute.ComposedLayout,
+        dA_mn_opB_smem: cute.ComposedLayout,
+        g_epi_smem_layout: cute.ComposedLayout,
+        k_epi_smem_layout: cute.ComposedLayout,
+        q_epi_smem_layout: cute.ComposedLayout,
+        # GMEM tensors
+        q_gmem: cute.Tensor,
+        k_gmem: cute.Tensor,
+        g_gmem: cute.Tensor,
+        beta_gmem: cute.Tensor,
+        dq_gmem: cute.Tensor,
+        dk_gmem: cute.Tensor,
+        dv2_gmem: cute.Tensor,
+        dg_gmem: cute.Tensor,
+        db_gmem: cute.Tensor,
+        dA_gmem: cute.Tensor,
+        # Metadata
+        cu_seqlens: cute.Tensor,
+        chunk_indices: cute.Tensor,
+        problem_size: tuple[Int32, Int32, Int32, Int32, Int32, Int32],  # (B, T, H, HV, K, V)
+    ):
+        B, T, H, HV, K, V = problem_size
+        BT = self.BT
+
+        # ===================== Persistent work decode =====================
+        # Grid: (min(num_sm * occ, total_tiles), 1, 1) — persistent
+        block_idx_x = cute.arch.block_idx()[0]
+        grid_dim_x = cute.arch.grid_dim()[0]
+        thread_idx = cute.arch.thread_idx()[0]
+        lane_idx = thread_idx % 32
+
+        total_work_units = chunk_indices.layout.shape[0] * HV
+        num_iters = (total_work_units - block_idx_x + grid_dim_x - 1) // grid_dim_x
+
+        num_cuda_warps_total = len(self.cuda_warp_ids) + len(self.cuda2_warp_ids)
+
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        tidx, _, _ = cute.arch.thread_idx()
+
+        if warp_idx == self.load_warp_id:
+            cpasync.prefetch_descriptor(tma_atom_A)
+            cpasync.prefetch_descriptor(tma_atom_dv)
+            cpasync.prefetch_descriptor(tma_atom_h)
+            cpasync.prefetch_descriptor(tma_atom_dh)
+            cpasync.prefetch_descriptor(tma_atom_do)
+            cpasync.prefetch_descriptor(tma_atom_g)
+            cpasync.prefetch_descriptor(tma_atom_v)
+            cpasync.prefetch_descriptor(tma_atom_vnew)
+            cpasync.prefetch_descriptor(tma_atom_k)
+            cpasync.prefetch_descriptor(tma_atom_q)
+            cpasync.prefetch_descriptor(tma_atom_dg)
+
+        # ===================== SMEM allocation =====================
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage)
+
+        # Barrier Initialization
+        bar_mma_done_vloop_ptr = storage.bar_mma_done_vloop.data_ptr()
+        # NOTE: for h, dh and v, consumer contains both MMA and CUDA Core, so we use original mbarrier declaration instead of pipeline utils
+        bar_tma_h_ptr = storage.bar_tma_h.data_ptr()
+        bar_mma_cuda_h_ptr = storage.bar_mma_cuda_h.data_ptr()
+        bar_tma_dh_ptr = storage.bar_tma_dh.data_ptr()
+        bar_mma_cuda_dh_ptr = storage.bar_mma_cuda_dh.data_ptr()
+        bar_tma_v_ptr = storage.bar_tma_v.data_ptr()
+        bar_mma_cuda_v_ptr = storage.bar_mma_cuda_v.data_ptr()
+        if warp_idx == 0:
+            with elect_one():
+                for i in cutlass.range(self.mma_stage, unroll_full=True):
+                    mbarrier_init(bar_mma_done_vloop_ptr + i, 1)
+                for i in cutlass.range(self.vloop_stage, unroll_full=True):
+                    mbarrier_init(bar_tma_h_ptr + i, 1)
+                    mbarrier_init(bar_mma_cuda_h_ptr + i, num_cuda_warps_total * 32 + 1)
+                    mbarrier_init(bar_tma_dh_ptr + i, 1)
+                    mbarrier_init(bar_mma_cuda_dh_ptr + i, num_cuda_warps_total * 32 + 1)
+                    mbarrier_init(bar_tma_v_ptr + i, 1)
+                    mbarrier_init(bar_mma_cuda_v_ptr + i, num_cuda_warps_total * 32 + 1)
+                mbarrier_init_fence()
+
+        # ====== Pipeline Definition ======
+        pipeline_load_A = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.bar_load_A.data_ptr(),
+            num_stages=self.a_stage,
+            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            tx_count=self.tma_bytes_A,
+        )
+        pipeline_load_dv = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.bar_load_dv.data_ptr(),
+            num_stages=self.vloop_stage,
+            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            tx_count=self.tma_bytes_dv,
+        )
+        pipeline_load_do = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.bar_load_do.data_ptr(),
+            num_stages=self.vloop_stage,
+            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            tx_count=self.tma_bytes_do,
+        )
+        pipeline_load_vnew = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.bar_load_vnew.data_ptr(),
+            num_stages=self.vloop_stage,
+            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            tx_count=self.tma_bytes_vnew,
+        )
+        pipeline_load_g = pipeline.PipelineTmaAsync.create(
+            barrier_storage=storage.bar_load_g.data_ptr(),
+            num_stages=self.kloop_stage,
+            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
+            consumer_group=make_thread_cooperative_group(
+                num_cuda_warps_total + len(self.aux_warp_ids)
+            ),
+            tx_count=self.tma_bytes_g,
+        )
+        pipeline_load_k = pipeline.PipelineTmaAsync.create(
+            barrier_storage=storage.bar_load_k.data_ptr(),
+            num_stages=self.kloop_stage,
+            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
+            consumer_group=make_thread_cooperative_group(num_cuda_warps_total),
+            tx_count=self.tma_bytes_k,
+        )
+        pipeline_load_q = pipeline.PipelineTmaAsync.create(
+            barrier_storage=storage.bar_load_q.data_ptr(),
+            num_stages=self.kloop_stage,
+            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
+            consumer_group=make_thread_cooperative_group(num_cuda_warps_total),
+            tx_count=self.tma_bytes_q,
+        )
+        pipeline_mma_dvb = pipeline.PipelineUmmaAsync.create(
+            barrier_storage=storage.bar_mma_dvb.data_ptr(),
+            num_stages=self.mma_stage,
+            producer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            consumer_group=make_thread_cooperative_group(num_cuda_warps_total * 32),
+        )
+        pipeline_mma_dq = pipeline.PipelineUmmaAsync.create(
+            barrier_storage=storage.bar_mma_dq.data_ptr(),
+            num_stages=self.mma_stage,
+            producer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            consumer_group=make_thread_cooperative_group(num_cuda_warps_total * 32),
+        )
+        pipeline_mma_dk = pipeline.PipelineUmmaAsync.create(
+            barrier_storage=storage.bar_mma_dk.data_ptr(),
+            num_stages=self.mma_stage,
+            producer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            consumer_group=make_thread_cooperative_group(num_cuda_warps_total * 32),
+        )
+        pipeline_mma_dw = pipeline.PipelineUmmaAsync.create(
+            barrier_storage=storage.bar_mma_dw.data_ptr(),
+            num_stages=self.mma_stage,
+            producer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            consumer_group=make_thread_cooperative_group(num_cuda_warps_total * 32),
+        )
+        pipeline_mma_dA = pipeline.PipelineUmmaAsync.create(
+            barrier_storage=storage.bar_mma_dA.data_ptr(),
+            num_stages=self.mma_stage,
+            producer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            consumer_group=make_thread_cooperative_group(num_cuda_warps_total * 32),
+        )
+        pipeline_mma_dA2 = pipeline.PipelineUmmaAsync.create(
+            barrier_storage=storage.bar_mma_dA2.data_ptr(),
+            num_stages=self.mma_stage,
+            producer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            consumer_group=make_thread_cooperative_group(num_cuda_warps_total * 32),
+        )
+        pipeline_mma_dA3 = pipeline.PipelineUmmaAsync.create(
+            barrier_storage=storage.bar_mma_dA3.data_ptr(),
+            num_stages=self.mma_stage,
+            producer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            consumer_group=make_thread_cooperative_group(num_cuda_warps_total * 32),
+        )
+        pipeline_prologue_dw = pipeline.PipelineAsyncUmma.create(
+            barrier_storage=storage.bar_prologue_dw.data_ptr(),
+            num_stages=self.kloop_stage,
+            producer_group=make_thread_cooperative_group(num_cuda_warps_total * 32),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+        )
+        pipeline_prologue_kg = pipeline.PipelineAsyncUmma.create(
+            barrier_storage=storage.bar_prologue_kg.data_ptr(),
+            num_stages=self.kloop_stage,
+            producer_group=make_thread_cooperative_group(num_cuda_warps_total * 32),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+        )
+        pipeline_prologue_dA2 = pipeline.PipelineAsyncUmma.create(
+            barrier_storage=storage.bar_prologue_dA2.data_ptr(),
+            num_stages=self.mma_stage,
+            producer_group=make_thread_cooperative_group(num_cuda_warps_total * 32),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+        )
+        pipeline_prologue_dA3 = pipeline.PipelineAsyncUmma.create(
+            barrier_storage=storage.bar_prologue_dA3.data_ptr(),
+            num_stages=self.mma_stage,
+            producer_group=make_thread_cooperative_group(num_cuda_warps_total * 32),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+        )
+        pipeline_mma_dkgb = pipeline.PipelineUmmaAsync.create(
+            barrier_storage=storage.bar_mma_dkgb.data_ptr(),
+            num_stages=self.mma_stage,
+            producer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            consumer_group=make_thread_cooperative_group(num_cuda_warps_total * 32),
+        )
+        pipeline_load_beta = pipeline.PipelineAsync.create(
+            barrier_storage=storage.bar_load_beta.data_ptr(),
+            num_stages=1,
+            producer_group=make_thread_cooperative_group(len(self.aux_warp_ids) * 32),
+            consumer_group=make_thread_cooperative_group(num_cuda_warps_total * 32),
+        )
+        pipeline_store_dg = pipeline.PipelineAsync.create(
+            barrier_storage=storage.bar_store_dg.data_ptr(),
+            num_stages=self.kloop_stage,
+            producer_group=make_thread_cooperative_group(num_cuda_warps_total * 32),
+            consumer_group=make_thread_cooperative_group(len(self.aux_warp_ids) * 32),
+        )
+
+        # ===================== TMEM allocation =====================
+        tmem_alloc_bar = pipeline.NamedBarrier(barrier_id=1, num_threads=self.threads_per_cta)
+        tmem = utils.TmemAllocator(
+            storage.tmem_holding_buf,
+            barrier_for_retrieve=tmem_alloc_bar,
+            allocator_warp_id=self.load_warp_id,
+        )
+        # Cluster arrive after barrier init
+        pipeline.pipeline_init_arrive(cluster_shape_mn=self.cluster_shape_mnk, is_relaxed=True)
+
+        vloop_opA_smem_no_stage = cute.select(vloop_opA_smem, mode=[0, 1, 2])
+        vloop_opB_smem_no_stage = cute.select(vloop_opB_smem, mode=[0, 1, 2])
+        A_mn_opA_smem_no_stage = cute.select(A_mn_opA_smem, mode=[0, 1, 2])
+        v_opB_smem_no_stage = cute.select(v_opB_smem, mode=[0, 1, 2])
+
+        sA = storage.buf_A.get_tensor(A_mn_opA_smem.outer, swizzle=A_mn_opA_smem.inner)
+        sDv = storage.buf_dv.get_tensor(vloop_opA_smem.outer, swizzle=vloop_opA_smem.inner)
+        sH = storage.buf_h.get_tensor(vloop_opB_smem.outer, swizzle=vloop_opB_smem.inner)
+        sDh = storage.buf_dh.get_tensor(vloop_opB_smem.outer, swizzle=vloop_opB_smem.inner)
+        sDo = storage.buf_do.get_tensor(vloop_opA_smem.outer, swizzle=vloop_opA_smem.inner)
+        sVnew = storage.buf_vnew.get_tensor(vloop_opA_smem.outer, swizzle=vloop_opA_smem.inner)
+        sV = storage.buf_v.get_tensor(v_opB_smem.outer, swizzle=v_opB_smem.inner)
+
+        sDv_ptr_base = storage.buf_dv.data_ptr().toint()
+        vloop_opA_bytes_per_stage = cute.size_in_bytes(self.io_dtype, vloop_opA_smem_no_stage)
+        sDo_ptr_base = storage.buf_do.data_ptr().toint()
+        sVnew_ptr_base = storage.buf_vnew.data_ptr().toint()
+        sV_ptr_base = storage.buf_v.data_ptr().toint()
+        v_opB_bytes_per_stage = cute.size_in_bytes(self.io_dtype, v_opB_smem_no_stage)
+        sH_ptr_base = storage.buf_h.data_ptr().toint()
+        sDh_ptr_base = storage.buf_dh.data_ptr().toint()
+        vloop_opB_bytes_per_stage = cute.size_in_bytes(self.io_dtype, vloop_opB_smem_no_stage)
+        sA_ptr_base = storage.buf_A.data_ptr().toint()
+        A_bytes_per_stage = cute.size_in_bytes(self.io_dtype, A_mn_opA_smem_no_stage)
+
+        # NOTE: make_umma_smem_desc requires the iterator to carry the swizzle
+        # (and ≥16B alignment). When constructing a tensor over a ComposedLayout
+        # via make_ptr+make_tensor, the swizzle ends up composed on the layout
+        # rather than the iterator, which breaks make_umma_smem_desc. Use
+        # recast_ptr to move the swizzle onto the iterator and pair it with the
+        # underlying (non-swizzle) outer layout.
+        sDv_mn = cute.make_tensor(
+            cute.recast_ptr(
+                cute.make_ptr(
+                    self.io_dtype,
+                    storage.buf_dv.data_ptr().toint(),
+                    cute.AddressSpace.smem,
+                    assumed_align=128,
+                ),
+                swizzle_=dv_mn_opB_smem.inner,
+                dtype=self.io_dtype,
+            ),
+            dv_mn_opB_smem.outer,
+        )
+        sDw_mn = cute.make_tensor(
+            cute.recast_ptr(
+                cute.make_ptr(
+                    self.io_dtype,
+                    storage.buf_dw.data_ptr().toint(),
+                    cute.AddressSpace.smem,
+                    assumed_align=128,
+                ),
+                swizzle_=dw_mn_opB_smem.inner,
+                dtype=self.io_dtype,
+            ),
+            dw_mn_opB_smem.outer,
+        )
+        sDw_k = cute.make_tensor(
+            cute.recast_ptr(
+                cute.make_ptr(
+                    self.io_dtype,
+                    storage.buf_dw.data_ptr().toint(),
+                    cute.AddressSpace.smem,
+                    assumed_align=128,
+                ),
+                swizzle_=dw_k_opA_smem.inner,
+                dtype=self.io_dtype,
+            ),
+            dw_k_opA_smem.outer,
+        )
+        sDv_k = cute.make_tensor(
+            cute.recast_ptr(
+                cute.make_ptr(
+                    self.io_dtype,
+                    storage.buf_dv.data_ptr().toint(),
+                    cute.AddressSpace.smem,
+                    assumed_align=128,
+                ),
+                swizzle_=vloop_opA_smem.inner,
+                dtype=self.io_dtype,
+            ),
+            vloop_opA_smem.outer,
+        )
+        sV_k = cute.make_tensor(
+            cute.recast_ptr(
+                cute.make_ptr(
+                    self.io_dtype,
+                    storage.buf_v.data_ptr().toint(),
+                    cute.AddressSpace.smem,
+                    assumed_align=128,
+                ),
+                swizzle_=v_opB_smem.inner,
+                dtype=self.io_dtype,
+            ),
+            v_opB_smem.outer,
+        )
+        sA_mn = cute.make_tensor(
+            cute.recast_ptr(
+                cute.make_ptr(
+                    self.io_dtype,
+                    storage.buf_A.data_ptr().toint(),
+                    cute.AddressSpace.smem,
+                    assumed_align=128,
+                ),
+                swizzle_=A_mn_opA_smem.inner,
+                dtype=self.io_dtype,
+            ),
+            A_mn_opA_smem.outer,
+        )
+        sDo_k = cute.make_tensor(
+            cute.recast_ptr(
+                cute.make_ptr(
+                    self.io_dtype,
+                    storage.buf_do.data_ptr().toint(),
+                    cute.AddressSpace.smem,
+                    assumed_align=128,
+                ),
+                swizzle_=vloop_opA_smem.inner,
+                dtype=self.io_dtype,
+            ),
+            vloop_opA_smem.outer,
+        )
+        sVnew_k = cute.make_tensor(
+            cute.recast_ptr(
+                cute.make_ptr(
+                    self.io_dtype,
+                    storage.buf_vnew.data_ptr().toint(),
+                    cute.AddressSpace.smem,
+                    assumed_align=128,
+                ),
+                swizzle_=vloop_opA_smem.inner,
+                dtype=self.io_dtype,
+            ),
+            vloop_opA_smem.outer,
+        )
+        sH_k = cute.make_tensor(
+            cute.recast_ptr(
+                cute.make_ptr(
+                    self.io_dtype,
+                    storage.buf_h.data_ptr().toint(),
+                    cute.AddressSpace.smem,
+                    assumed_align=128,
+                ),
+                swizzle_=vloop_opB_smem.inner,
+                dtype=self.io_dtype,
+            ),
+            vloop_opB_smem.outer,
+        )
+        sDh_k = cute.make_tensor(
+            cute.recast_ptr(
+                cute.make_ptr(
+                    self.io_dtype,
+                    storage.buf_dh.data_ptr().toint(),
+                    cute.AddressSpace.smem,
+                    assumed_align=128,
+                ),
+                swizzle_=vloop_opB_smem.inner,
+                dtype=self.io_dtype,
+            ),
+            vloop_opB_smem.outer,
+        )
+        sKG_k = cute.make_tensor(
+            cute.recast_ptr(
+                cute.make_ptr(
+                    self.io_dtype,
+                    storage.buf_k.data_ptr().toint(),
+                    cute.AddressSpace.smem,
+                    assumed_align=128,
+                ),
+                swizzle_=kg_k_opB_smem.inner,
+                dtype=self.io_dtype,
+            ),
+            kg_k_opB_smem.outer,
+        )
+        sA_k = cute.make_tensor(
+            cute.recast_ptr(
+                cute.make_ptr(
+                    self.io_dtype,
+                    storage.buf_A.data_ptr().toint(),
+                    cute.AddressSpace.smem,
+                    assumed_align=128,
+                ),
+                swizzle_=A_k_opB_smem.inner,
+                dtype=self.io_dtype,
+            ),
+            A_k_opB_smem.outer,
+        )
+        sDA_mn = cute.make_tensor(
+            cute.recast_ptr(
+                cute.make_ptr(
+                    self.io_dtype,
+                    storage.buf_q.data_ptr().toint(),
+                    cute.AddressSpace.smem,
+                    assumed_align=128,
+                ),
+                swizzle_=dA_mn_opB_smem.inner,
+                dtype=self.io_dtype,
+            ),
+            dA_mn_opB_smem.outer,
+        )
+        sDA_k = cute.make_tensor(
+            cute.recast_ptr(
+                cute.make_ptr(
+                    self.io_dtype,
+                    storage.buf_q.data_ptr().toint(),
+                    cute.AddressSpace.smem,
+                    assumed_align=128,
+                ),
+                swizzle_=dA_k_opA_smem.inner,
+                dtype=self.io_dtype,
+            ),
+            dA_k_opA_smem.outer,
+        )
+        sG_raw = cute.make_tensor(
+            cute.recast_ptr(
+                cute.make_ptr(
+                    self.g_dtype,
+                    storage.buf_g.data_ptr().toint(),
+                    cute.AddressSpace.smem,
+                    assumed_align=128,
+                ),
+                swizzle_=g_epi_smem_layout.inner,
+                dtype=self.g_dtype,
+            ),
+            g_epi_smem_layout.outer,
+        )
+        sG_raw_ptr = cute.make_ptr(
+            self.g_dtype, storage.buf_g.data_ptr().toint(), cute.AddressSpace.smem
+        )
+        sK_raw = cute.make_tensor(
+            cute.recast_ptr(
+                cute.make_ptr(
+                    self.io_dtype,
+                    storage.buf_k.data_ptr().toint(),
+                    cute.AddressSpace.smem,
+                    assumed_align=128,
+                ),
+                swizzle_=k_epi_smem_layout.inner,
+                dtype=self.io_dtype,
+            ),
+            k_epi_smem_layout.outer,
+        )
+        sK_raw_ptr = cute.make_ptr(
+            self.io_dtype, storage.buf_k.data_ptr().toint(), cute.AddressSpace.smem
+        )
+        sDw_raw_ptr = cute.make_ptr(
+            self.io_dtype, storage.buf_dw.data_ptr().toint(), cute.AddressSpace.smem
+        )
+        sQ_raw = cute.make_tensor(
+            cute.recast_ptr(
+                cute.make_ptr(
+                    self.io_dtype,
+                    storage.buf_q.data_ptr().toint(),
+                    cute.AddressSpace.smem,
+                    assumed_align=128,
+                ),
+                swizzle_=q_epi_smem_layout.inner,
+                dtype=self.io_dtype,
+            ),
+            q_epi_smem_layout.outer,
+        )
+        sQ_raw_ptr = cute.make_ptr(
+            self.io_dtype, storage.buf_q.data_ptr().toint(), cute.AddressSpace.smem
+        )
+
+        # Scalar SMEM buffers (plain layouts, no swizzle)
+        sBeta = cute.make_tensor(
+            cute.make_ptr(Float32, storage.s_beta.data_ptr().toint(), cute.AddressSpace.smem),
+            cute.make_layout((self.BT,), stride=(1,)),
+        )
+        # sDb layout: (BT, 2). Inner dim = wg_idx slot. Stride (1, BT) so each
+        # wg's column is contiguous (better for the reduce in Phase 3).
+        sDb = cute.make_tensor(
+            cute.make_ptr(Float32, storage.s_db.data_ptr().toint(), cute.AddressSpace.smem),
+            cute.make_layout((self.BT, 2), stride=(1, self.BT)),
+        )
+        sDgk = cute.make_tensor(
+            cute.make_ptr(Float32, storage.s_dgk.data_ptr().toint(), cute.AddressSpace.smem),
+            cute.make_layout((self.BK,), stride=(1,)),
+        )
+        sGn = cute.make_tensor(
+            cute.make_ptr(Float32, storage.s_gn.data_ptr().toint(), cute.AddressSpace.smem),
+            cute.make_layout((self.BK,), stride=(1,)),
+        )
+
+        #
+        # Cluster wait before tensor memory alloc
+        #
+        pipeline.pipeline_init_wait(cluster_shape_mn=self.cluster_shape_mnk)
+
+        tmem.allocate(TMEM_TOTAL)
+        tmem.wait_for_alloc()
+        tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+
+        # ===================== Warp dispatch =====================
+        # CUDA Core loop body
+        if warp_idx in self.cuda_warp_ids or warp_idx in self.cuda2_warp_ids:
+            cute.arch.setmaxregister_increase(self.num_regs_cuda)
+
+            load_beta_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, 1
+            )
+            load_g_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.kloop_stage
+            )
+            mma_dvb_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.mma_stage
+            )
+            mma_dq_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.mma_stage
+            )
+            mma_dw_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.mma_stage
+            )
+            mma_dk_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.mma_stage
+            )
+            load_k_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.kloop_stage
+            )
+            prologue_dw_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.kloop_stage
+            )
+            prologue_kg_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.kloop_stage
+            )
+            mma_dgkb_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.mma_stage
+            )
+            load_q_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.kloop_stage
+            )
+            mma_dA_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.mma_stage
+            )
+            mma_dA2_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.mma_stage
+            )
+            mma_dA3_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.mma_stage
+            )
+            prologue_dA2_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.mma_stage
+            )
+            prologue_dA3_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.mma_stage
+            )
+            store_dg_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.kloop_stage
+            )
+
+            wg_idx = tidx // 128
+            local_tidx = tidx % 128
+            warp_id = local_tidx // 32
+            warp_row_tile = warp_id % 2
+            warp_col_tile = warp_id // 2
+            row = warp_row_tile * 32 + lane_idx  # BT1
+            bk_num_cols = self.BK // 2
+            bv_num_cols = self.BV // 2
+            bk_num_cols_per_wg = bk_num_cols // 2
+            bv_num_cols_per_wg = bv_num_cols // 2
+            bt_num_cols_per_wg = self.BT // 4
+            # ref: https://docs.nvidia.com/cuda/parallel-thread-execution/#tcgen05-data-path-layout-e
+            bv_col_base = warp_col_tile * (self.BV // 2) + wg_idx * bv_num_cols_per_wg
+            bk_col_base = warp_col_tile * (self.BK // 2) + wg_idx * bk_num_cols_per_wg
+            bt_col_base = warp_col_tile * (self.BT // 2) + wg_idx * bt_num_cols_per_wg
+            # 8 fp32 store each time for store_256b
+            num_stores_f32 = bk_num_cols_per_wg // 8
+
+            vloop_stage_idx = 0
+            vloop_phase = 0
+            for wu_iter in cutlass.range(0, num_iters, unroll=0):
+                work_idx = block_idx_x + wu_iter * grid_dim_x
+                G = HV // H
+                i_t = work_idx // HV  # chunk index (global)
+                i_hv = work_idx % HV  # value-head index
+                i_h = i_hv // G  # q/k head index
+                # Decode chunk_indices
+                batch_idx = chunk_indices[(i_t, 0)]
+                tile_idx = chunk_indices[(i_t, 1)]
+                tok_offset = cu_seqlens[(batch_idx,)]
+                seq_len = cu_seqlens[(batch_idx + 1,)] - tok_offset
+                sub_seq_len = min(self.BT, seq_len - tile_idx * self.BT)
+
+                # NOTE: must sync before next wu_iter's `sDgk[local_tidx] = 0`
+                # init, otherwise WG0 of next iter may overwrite sDgk while
+                # WG1 of this iter (row == sub_seq_len - 1 lane) is still
+                # reading sDgk[col] above. This was the source of the
+                # non-deterministic dg accuracy bug.
+                self.cuda_wg_sync_barrier.arrive_and_wait()
+                # fill db, dgk to 0. Each wg zeroes its own sDb column.
+                if local_tidx < self.BT:
+                    sDb[local_tidx, 0] = Float32(0.0)
+                    sDb[local_tidx, 1] = Float32(0.0)
+                if local_tidx < self.BK:
+                    sDgk[local_tidx] = Float32(0.0)
+                self.cuda_wg_sync_barrier.arrive_and_wait()
+
+                pipeline_load_beta.consumer_wait(load_beta_consumer_state)
+                cute.arch.fence_proxy("async.shared", space="cta")
+
+                beta_val = sBeta[(row,)]
+                db_val = Float32(0.0)
+                for v_iter in cutlass.range(self.num_v_tiles):
+                    # dgk += sum(h * dh, axis=0)
+                    mbarrier_wait(bar_tma_h_ptr + vloop_stage_idx, vloop_phase)
+                    mbarrier_wait(bar_tma_dh_ptr + vloop_stage_idx, vloop_phase)
+
+                    sH_raw_ptr = cute.make_ptr(
+                        self.io_dtype,
+                        sH_ptr_base + vloop_stage_idx * vloop_opB_bytes_per_stage,
+                        cute.AddressSpace.smem,
+                    )
+                    sDh_raw_ptr = cute.make_ptr(
+                        self.io_dtype,
+                        sDh_ptr_base + vloop_stage_idx * vloop_opB_bytes_per_stage,
+                        cute.AddressSpace.smem,
+                    )
+                    # each thread in one WG processes one row
+                    self.cuda_wg_sync_barrier.arrive_and_wait()
+                    if wg_idx == 0:
+                        for i in cutlass.range_constexpr(self.BV // 8):
+                            col = i * 8
+                            h_vals = smem_load_bf16x8_sw128(sH_raw_ptr, local_tidx, col)
+                            dh_vals = smem_load_bf16x8_sw128(sDh_raw_ptr, local_tidx, col)
+                            h_dh_vals = cute.make_rmem_tensor((8,), Float32)
+                            h_dh_vals.store(h_vals.load().to(Float32) * dh_vals.load().to(Float32))
+                            for j in cutlass.range_constexpr(8):
+                                sDgk[(local_tidx,)] += h_dh_vals[j]
+
+                    mbarrier_arrive(bar_mma_cuda_h_ptr + vloop_stage_idx)
+                    mbarrier_arrive(bar_mma_cuda_dh_ptr + vloop_stage_idx)
+
+                    pipeline_mma_dvb.consumer_wait(mma_dvb_consumer_state)
+                    tcgen05_fence_after()
+                    dvb_i32 = tcgen05_ld_32x32b(
+                        bv_num_cols_per_wg, TMEM_FLEX_OFF + wg_idx * bv_num_cols_per_wg
+                    )
+                    tcgen05_fence_before()
+                    cute.arch.fence_view_async_tmem_load()
+
+                    pipeline_mma_dvb.consumer_release(mma_dvb_consumer_state)
+                    mma_dvb_consumer_state.advance()
+
+                    dvb_f32 = reinterpret_cast(dvb_i32, Int32, bv_num_cols_per_wg, Float32)
+                    dvb_f32_val = TensorSSA(dvb_f32, (bv_num_cols_per_wg,), Float32)
+
+                    # db += sum(dvb * v, axis=1)
+                    mbarrier_wait(bar_tma_v_ptr + vloop_stage_idx, vloop_phase)
+                    rV_bf16 = cute.make_rmem_tensor((bv_num_cols_per_wg,), self.io_dtype)
+                    sV_raw_ptr_cur = cute.make_ptr(
+                        self.io_dtype,
+                        sV_ptr_base + vloop_stage_idx * v_opB_bytes_per_stage,
+                        cute.AddressSpace.smem,
+                    )
+                    if row < sub_seq_len:
+                        for i in cutlass.range_constexpr(bv_num_cols_per_wg // 8):
+                            col_base = bv_col_base + i * 8
+                            vals = smem_load_bf16x8_sw128(sV_raw_ptr_cur, row, col_base)
+                            rV_bf16[i * 8 + 0] = vals[0]
+                            rV_bf16[i * 8 + 1] = vals[1]
+                            rV_bf16[i * 8 + 2] = vals[2]
+                            rV_bf16[i * 8 + 3] = vals[3]
+                            rV_bf16[i * 8 + 4] = vals[4]
+                            rV_bf16[i * 8 + 5] = vals[5]
+                            rV_bf16[i * 8 + 6] = vals[6]
+                            rV_bf16[i * 8 + 7] = vals[7]
+                    else:
+                        rV_bf16.fill(BFloat16(0.0))
+                    rV_fp32 = cute.make_rmem_tensor((bv_num_cols_per_wg,), Float32)
+                    rV_fp32.store(rV_bf16.load().to(Float32))
+                    rV_fp32.store(rV_fp32.load() * dvb_f32_val)
+                    if row < sub_seq_len:
+                        for i in cutlass.range_constexpr(bv_num_cols_per_wg):
+                            db_val += rV_fp32[i]
+
+                    mbarrier_arrive(bar_mma_cuda_v_ptr + vloop_stage_idx)
+
+                    # ── dv2 epilogue: dv2 = dvb * beta, cast to bf16, store to gmem ──
+                    dvb_f32_rmem = cute.make_rmem_tensor((bv_num_cols_per_wg,), Float32)
+                    dvb_f32_rmem.store(dvb_f32_val * beta_val)
+
+                    dvb_bf16_rmem = cute.make_rmem_tensor((bv_num_cols_per_wg,), self.io_dtype)
+                    dvb_bf16_rmem.store(dvb_f32_rmem.load().to(self.io_dtype))
+
+                    # bf16 vector → i32 vector for store_256b (8 i32 = 16 bf16 = 32 bytes per store).
+                    dvb_bf16_val = dvb_bf16_rmem.load()
+                    dvb_i32_vec = reinterpret_cast(
+                        dvb_bf16_val, self.io_dtype, bv_num_cols_per_wg, Int32
+                    )
+                    # bv_num_cols bf16 = bv_num_cols // 16 stores of 256b each.
+                    num_stores_per_row = bv_num_cols_per_wg // 16  # = 4 for BV=128
+
+                    base_addr = (
+                        dv2_gmem.iterator
+                        + (tok_offset + tile_idx * self.BT + row) * HV * V
+                        + i_hv * V
+                        + v_iter * self.BV
+                        + bv_col_base
+                    ).toint()
+                    if row < sub_seq_len:
+                        for s in cutlass.range_constexpr(num_stores_per_row):
+                            chunk = subvec(dvb_i32_vec, s * 8, 8)
+                            store_256b(base_addr + s * 32, chunk)
+
+                    vloop_stage_idx = (vloop_stage_idx + 1) % self.vloop_stage
+                vloop_phase ^= 1
+
+                # gk_exp = exp2(g)
+                pipeline_load_g.consumer_wait(load_g_consumer_state)
+                # write to gn
+                sGn[local_tidx] = sG_raw[(sub_seq_len - 1, local_tidx, 0)]
+
+                # row-major load, match TMEM layout
+                rG = cute.make_rmem_tensor((self.BK // 4,), self.g_dtype)
+                if row < sub_seq_len:
+                    for i in cutlass.range_constexpr(self.BK // 4 // 4):
+                        col_base = bk_col_base + i * 4
+                        vals = smem_load_f32x4_sw128(sG_raw_ptr, row, col_base)
+                        rG[i * 4 + 0] = vals[0]
+                        rG[i * 4 + 1] = vals[1]
+                        rG[i * 4 + 2] = vals[2]
+                        rG[i * 4 + 3] = vals[3]
+                else:
+                    rG.fill(Float32(0.0))
+                rG_val = rG.load()
+                rG_exp_val = cute.exp2(rG_val, fastmath=self.use_fast_math)
+
+                # wait for dq, dq=dq*gk_exp*scale, GMEM store
+                pipeline_mma_dq.consumer_wait(mma_dq_consumer_state)
+                tcgen05_fence_after()
+                dq_i32 = tcgen05_ld_32x32b(
+                    bk_num_cols_per_wg, TMEM_DQ_ACC_OFF + wg_idx * bk_num_cols_per_wg
+                )
+                tcgen05_fence_before()
+                cute.arch.fence_view_async_tmem_load()
+
+                pipeline_mma_dq.consumer_release(mma_dq_consumer_state)
+                mma_dq_consumer_state.advance()
+
+                dq_f32 = reinterpret_cast(dq_i32, Int32, bk_num_cols_per_wg, Float32)
+                dq_f32_val = TensorSSA(dq_f32, (bk_num_cols_per_wg,), Float32)
+
+                rDq = cute.make_rmem_tensor((bk_num_cols_per_wg,), Float32)
+                rDq.store(dq_f32_val * rG_exp_val * Float32(self.scale))
+
+                dq_f32_val_store = rDq.load()
+                dq_i32_vec = reinterpret_cast(dq_f32_val_store, Float32, bk_num_cols_per_wg, Int32)
+                # store to TMEM first to reduce register usage
+                tcgen05_st_32x32b(
+                    bk_num_cols_per_wg,
+                    TMEM_DQ_SCALED_OFF + wg_idx * bk_num_cols_per_wg,
+                    dq_i32_vec,
+                )
+                cute.arch.fence_view_async_tmem_store()
+                dq_base_addr = (
+                    dq_gmem.iterator
+                    + (tok_offset + tile_idx * self.BT + row) * HV * K
+                    + i_hv * K
+                    + bk_col_base
+                ).toint()
+                if row < sub_seq_len:
+                    for s in cutlass.range_constexpr(num_stores_f32):
+                        chunk = subvec(dq_i32_vec, s * 8, 8)
+                        store_256b(dq_base_addr + s * 32, chunk)
+
+                # wait for dw
+                pipeline_mma_dw.consumer_wait(mma_dw_consumer_state)
+                tcgen05_fence_after()
+                dw_i32 = tcgen05_ld_32x32b(
+                    bk_num_cols_per_wg, TMEM_DW_ACC_OFF + wg_idx * bk_num_cols_per_wg
+                )
+                tcgen05_fence_before()
+                cute.arch.fence_view_async_tmem_load()
+
+                pipeline_mma_dw.consumer_release(mma_dw_consumer_state)
+                mma_dw_consumer_state.advance()
+
+                # dw = -dw, convert to bf16, write to smem
+                dw_f32 = reinterpret_cast(dw_i32, Int32, bk_num_cols_per_wg, Float32)
+                dw_f32_val = TensorSSA(dw_f32, (bk_num_cols_per_wg,), Float32)
+
+                dw_bf16_rmem = cute.make_rmem_tensor((bk_num_cols_per_wg,), BFloat16)
+                if row < sub_seq_len:
+                    dw_bf16_rmem.store((-dw_f32_val).to(BFloat16))
+                else:
+                    dw_bf16_rmem.fill(BFloat16(0.0))
+
+                pipeline_prologue_dw.producer_acquire(prologue_dw_producer_state)
+                # store bf16x8 each time
+                dw_smem_num_stores = bk_num_cols_per_wg // 8
+                for i in cutlass.range_constexpr(dw_smem_num_stores):
+                    col_base = bk_col_base + i * 8
+                    chunk = cute.local_tile(dw_bf16_rmem, (8,), (i,))
+                    smem_store_bf16x8_sw128(sDw_raw_ptr, row, col_base, chunk)
+
+                cute.arch.fence_proxy("async.shared", space="cta")
+                pipeline_prologue_dw.producer_commit(prologue_dw_producer_state)
+                prologue_dw_producer_state.advance()
+
+                pipeline_load_k.consumer_wait(load_k_consumer_state)
+                # compute kg = k * gk_exp
+                rK = cute.make_rmem_tensor((self.BK // 4,), self.io_dtype)
+                if row < sub_seq_len:
+                    for i in cutlass.range_constexpr(self.BK // 4 // 8):
+                        col_base = bk_col_base + i * 8
+                        vals = smem_load_bf16x8_sw128(sK_raw_ptr, row, col_base)
+                        rK[i * 8 + 0] = vals[0]
+                        rK[i * 8 + 1] = vals[1]
+                        rK[i * 8 + 2] = vals[2]
+                        rK[i * 8 + 3] = vals[3]
+                        rK[i * 8 + 4] = vals[4]
+                        rK[i * 8 + 5] = vals[5]
+                        rK[i * 8 + 6] = vals[6]
+                        rK[i * 8 + 7] = vals[7]
+                else:
+                    rK.fill(BFloat16(0.0))
+                rK_fp32 = cute.make_rmem_tensor((self.BK // 4,), Float32)
+                rK_fp32.store(rK.load().to(Float32))
+                rK_fp32_val = rK_fp32.load()
+                rKG_val = rK_fp32_val * rG_exp_val
+
+                # write kg to K smem,
+                # notify dA += dw @ kg^T
+                rKG_bf16 = cute.make_rmem_tensor((self.BK // 4,), BFloat16)
+                rKG_bf16.store(rKG_val.to(BFloat16))
+
+                pipeline_prologue_kg.producer_acquire(prologue_kg_producer_state)
+                for i in cutlass.range_constexpr(self.BK // 4 // 8):
+                    col_base = bk_col_base + i * 8
+                    chunk_kg = cute.local_tile(rKG_bf16, (8,), (i,))
+                    smem_store_bf16x8_sw128(sK_raw_ptr, row, col_base, chunk_kg)
+
+                cute.arch.fence_proxy("async.shared", space="cta")
+                pipeline_prologue_kg.producer_commit(prologue_kg_producer_state)
+                prologue_kg_producer_state.advance()
+
+                # wait for dkgb
+                pipeline_mma_dkgb.consumer_wait(mma_dgkb_consumer_state)
+                tcgen05_fence_after()
+                dkgb_i32 = tcgen05_ld_32x32b(
+                    bk_num_cols_per_wg, TMEM_DKGB_ACC_OFF + wg_idx * bk_num_cols_per_wg
+                )
+                tcgen05_fence_before()
+                cute.arch.fence_view_async_tmem_load()
+
+                pipeline_mma_dkgb.consumer_release(mma_dgkb_consumer_state)
+                mma_dgkb_consumer_state.advance()
+
+                # db += sum(dkgb * kg, axis=1)
+                dkgb_f32 = reinterpret_cast(dkgb_i32, Int32, bk_num_cols_per_wg, Float32)
+                dkgb_f32_val = TensorSSA(dkgb_f32, (bk_num_cols_per_wg,), Float32)
+                rKgb_kg = cute.make_rmem_tensor((bk_num_cols_per_wg,), Float32)
+                rKgb_kg.store(dkgb_f32_val * rKG_val)
+
+                if row < sub_seq_len:
+                    for i in cutlass.range_constexpr(bk_num_cols_per_wg):
+                        db_val += rKgb_kg[i]
+
+                # Deterministic db reduction without atomicAdd.
+                # 4 partitions per row come from 4 warps (warp_row_tile in {0,1},
+                # warp_col_tile in {0,1}) x 2 wgs. Reduce in a fixed order so
+                # the result is bitwise reproducible across launches:
+                #   Phase 1: warp_col_tile==0 writes its db_val into
+                #            sDb[row, wg_idx]   (single writer per slot)
+                #   Phase 2: warp_col_tile==1 RMW-adds its db_val into the
+                #            same slot          (still single writer per slot)
+                #   Phase 3: WG0 sums the 2 wg-slots in fixed order and stores
+                #            to GMEM.
+                # No race, no atomic, no fp ordering nondeterminism.
+                if warp_col_tile == 0 and row < sub_seq_len:
+                    sDb[row, wg_idx] = db_val
+                self.cuda_wg_sync_barrier.arrive_and_wait()
+                if warp_col_tile == 1 and row < sub_seq_len:
+                    sDb[row, wg_idx] = sDb[row, wg_idx] + db_val
+                self.cuda_wg_sync_barrier.arrive_and_wait()
+                # store db to GMEM (WG0 only). Sum order is fixed (slot 0 + slot 1).
+                if wg_idx == 0 and local_tidx < sub_seq_len:
+                    db_sum = sDb[(local_tidx, 0)] + sDb[(local_tidx, 1)]
+                    db_gmem[(tok_offset + tile_idx * self.BT + local_tidx, (i_hv, Int32(0)))] = (
+                        db_sum
+                    )
+
+                # dk = dk * exp2(gn[None, :] - g)
+                pipeline_mma_dk.consumer_wait(mma_dk_consumer_state)
+                tcgen05_fence_after()
+                dk_i32 = tcgen05_ld_32x32b(
+                    bk_num_cols_per_wg, TMEM_DK_ACC_OFF + wg_idx * bk_num_cols_per_wg
+                )
+                tcgen05_fence_before()
+                cute.arch.fence_view_async_tmem_load()
+
+                pipeline_mma_dk.consumer_release(mma_dk_consumer_state)
+                mma_dk_consumer_state.advance()
+
+                dk_f32 = reinterpret_cast(dk_i32, Int32, bk_num_cols_per_wg, Float32)
+                dk_f32_val = TensorSSA(dk_f32, (bk_num_cols_per_wg,), Float32)
+
+                rDk = cute.make_rmem_tensor((bk_num_cols_per_wg,), Float32)
+                if row < sub_seq_len:
+                    for i in cutlass.range_constexpr(bk_num_cols_per_wg):
+                        exp_g_gn = cute.exp2(
+                            sGn[(bk_col_base + i,)] - rG_val[i],
+                            fastmath=self.use_fast_math,
+                        )
+                        rDk[i] = dk_f32_val[i] * exp_g_gn
+                else:
+                    rDk.fill(Float32(0.0))
+
+                # kdk = k * dk
+                rKdk = cute.make_rmem_tensor((bk_num_cols_per_wg,), Float32)
+                rKdk.store(rK_fp32.load() * rDk.load())
+
+                # gb = gk_exp * beta[:, None]
+                rGb = cute.make_rmem_tensor((bk_num_cols_per_wg,), Float32)
+                rGb.store(rG_exp_val * beta_val)
+
+                # dk = dk + dkgb * gb
+                rDk.store(rDk.load() + dkgb_f32_val * rGb.load())
+                rDk_val = rDk.load()
+                dk_i32_vec = reinterpret_cast(rDk_val, Float32, bk_num_cols_per_wg, Int32)
+                # GMEM store dk
+                # 8 fp32 store each time for store_256b
+                dk_base_addr = (
+                    dk_gmem.iterator
+                    + (tok_offset + tile_idx * self.BT + row) * HV * K
+                    + i_hv * K
+                    + bk_col_base
+                ).toint()
+                if row < sub_seq_len:
+                    for s in cutlass.range_constexpr(num_stores_f32):
+                        chunk_dk = subvec(dk_i32_vec, s * 8, 8)
+                        store_256b(dk_base_addr + s * 32, chunk_dk)
+
+                # dgk += sum(kdk, axis=0)
+                # write kdk to G SMEM then do BT-dim reduce
+                for i in cutlass.range_constexpr(self.BK // 4 // 4):
+                    col_base = bk_col_base + i * 4
+                    chunk_kdk = cute.local_tile(rKdk, (4,), (i,))
+                    smem_store_f32x4_sw128(sG_raw_ptr, row, col_base, chunk_kdk)
+                self.cuda_wg_sync_barrier.arrive_and_wait()
+
+                # dgk *= exp2(gn)
+                if wg_idx == 0:
+                    sDgk[(local_tidx,)] *= cute.exp2(
+                        sGn[(local_tidx,)], fastmath=self.use_fast_math
+                    )
+
+                self.cuda_wg_sync_barrier.arrive_and_wait()
+                if wg_idx == 0:
+                    sum = Float32(0.0)
+                    for r in cutlass.range(self.BT, unroll_full=True):
+                        sum += sG_raw[(r, local_tidx, 0)]
+                    sDgk[(local_tidx,)] += sum
+
+                # dg1 = kg * dkgb * beta[:, None], can reuse kg RMEM
+                rDg = cute.make_rmem_tensor((bk_num_cols_per_wg,), Float32)
+                rDg.store(rKG_val * dkgb_f32_val * beta_val)
+
+                pipeline_load_q.consumer_wait(load_q_consumer_state)
+                # dg2 = q * dq - kdk + dg1
+                rQ = cute.make_rmem_tensor((bk_num_cols_per_wg,), self.io_dtype)
+                if row < sub_seq_len:
+                    for i in cutlass.range_constexpr(self.BK // 4 // 8):
+                        col_base = bk_col_base + i * 8
+                        vals = smem_load_bf16x8_sw128(sQ_raw_ptr, row, col_base)
+                        rQ[i * 8 + 0] = vals[0]
+                        rQ[i * 8 + 1] = vals[1]
+                        rQ[i * 8 + 2] = vals[2]
+                        rQ[i * 8 + 3] = vals[3]
+                        rQ[i * 8 + 4] = vals[4]
+                        rQ[i * 8 + 5] = vals[5]
+                        rQ[i * 8 + 6] = vals[6]
+                        rQ[i * 8 + 7] = vals[7]
+                else:
+                    rQ.fill(BFloat16(0.0))
+                dq_scaled_i32 = tcgen05_ld_32x32b(
+                    bk_num_cols_per_wg, TMEM_DQ_SCALED_OFF + wg_idx * bk_num_cols_per_wg
+                )
+                cute.arch.fence_view_async_tmem_load()
+                dq_scaled_f32 = reinterpret_cast(dq_scaled_i32, Int32, bk_num_cols_per_wg, Float32)
+                dq_scaled_f32_val = TensorSSA(dq_scaled_f32, (bk_num_cols_per_wg,), Float32)
+                rDg.store(rQ.load().to(Float32) * dq_scaled_f32_val + rDg.load() - rKdk.load())
+
+                self.cuda_wg_sync_barrier.arrive_and_wait()
+                # dg = dg2 + m_last * dgk, GMEM store dg
+                if row == sub_seq_len - 1:
+                    for i in cutlass.range_constexpr(bk_num_cols_per_wg):
+                        col = bk_col_base + i
+                        rDg[i] += sDgk[(col,)]
+
+                # Stage dg to SMEM first. A dedicated store warp later does
+                # SMEM -> RMEM -> GMEM with store_256b, keeping GMEM store
+                # address/vector live ranges out of the high-register CC path.
+                pipeline_store_dg.producer_acquire(store_dg_producer_state)
+                if row < sub_seq_len:
+                    for i in cutlass.range_constexpr(bk_num_cols_per_wg // 4):
+                        col_base = bk_col_base + i * 4
+                        chunk_dg = cute.local_tile(rDg, (4,), (i,))
+                        smem_store_f32x4_sw128(sG_raw_ptr, row, col_base, chunk_dg)
+
+                cute.arch.fence_proxy("async.shared", space="cta")
+                pipeline_store_dg.producer_commit(store_dg_producer_state)
+                store_dg_producer_state.advance()
+
+                pipeline_load_g.consumer_release(load_g_consumer_state)
+                load_g_consumer_state.advance()
+
+                pipeline_mma_dA.consumer_wait(mma_dA_consumer_state)
+                tcgen05_fence_after()
+                dA_i32 = tcgen05_ld_32x32b(
+                    bt_num_cols_per_wg, TMEM_DA_ACC_OFF + wg_idx * bt_num_cols_per_wg
+                )
+                tcgen05_fence_before()
+                cute.arch.fence_view_async_tmem_load()
+
+                pipeline_mma_dA.consumer_release(mma_dA_consumer_state)
+                mma_dA_consumer_state.advance()
+                # NOTE: only release k smem after dA finished, because kg reuses k smem in dA += dw @ kg^T
+                pipeline_load_k.consumer_release(load_k_consumer_state)
+                load_k_consumer_state.advance()
+
+                # dA = dA * beta[None, :], apply strict lower-triangular mask.
+                # Triton reference multiplies by the column beta (`b_beta[None, :]`)
+                # and keeps only `row > col`.
+                dA_f32 = reinterpret_cast(dA_i32, Int32, bt_num_cols_per_wg, Float32)
+                dA_f32_val = TensorSSA(dA_f32, (bt_num_cols_per_wg,), Float32)
+                rDA = cute.make_rmem_tensor((bt_num_cols_per_wg,), BFloat16)
+                for i in cutlass.range_constexpr(bt_num_cols_per_wg):
+                    col = bt_col_base + i
+                    beta_col = sBeta[(col,)]
+                    dA_scaled = (dA_f32_val[i] * beta_col).to(BFloat16)
+                    if col < row:
+                        rDA[i] = dA_scaled
+                    else:
+                        rDA[i] = BFloat16(0.0)
+                if row >= sub_seq_len:
+                    rDA.fill(BFloat16(0.0))
+
+                pipeline_prologue_dA2.producer_acquire(prologue_dA2_producer_state)
+
+                for i in cutlass.range_constexpr(bt_num_cols_per_wg // 8):
+                    col_base = bt_col_base + i * 8
+                    chunk_dA = cute.local_tile(rDA, (8,), (i,))
+                    smem_store_bf16x8_sw128(sQ_raw_ptr, row, col_base, chunk_dA)
+                # notify dA2 = dA @ A
+                cute.arch.fence_proxy("async.shared", space="cta")
+                pipeline_prologue_dA2.producer_commit(prologue_dA2_producer_state)
+                prologue_dA2_producer_state.advance()
+
+                pipeline_load_beta.consumer_release(load_beta_consumer_state)
+                load_beta_consumer_state.advance()
+
+                # wait for dA2
+                pipeline_mma_dA2.consumer_wait(mma_dA2_consumer_state)
+                tcgen05_fence_after()
+                dA2_i32 = tcgen05_ld_32x32b(
+                    bt_num_cols_per_wg, TMEM_DA2_ACC_OFF + wg_idx * bt_num_cols_per_wg
+                )
+                tcgen05_fence_before()
+                cute.arch.fence_view_async_tmem_load()
+
+                pipeline_prologue_dA3.producer_acquire(prologue_dA3_producer_state)
+                # write dA2 to smem notify dA2 = A @ dA2
+                dA2_f32 = reinterpret_cast(dA2_i32, Int32, bt_num_cols_per_wg, Float32)
+                dA2_f32_val = TensorSSA(dA2_f32, (bt_num_cols_per_wg,), Float32)
+                rDA2 = cute.make_rmem_tensor((bt_num_cols_per_wg,), BFloat16)
+                if row < sub_seq_len:
+                    rDA2.store(dA2_f32_val.to(BFloat16))
+                else:
+                    rDA2.fill(BFloat16(0.0))
+                for i in cutlass.range_constexpr(bt_num_cols_per_wg // 8):
+                    col_base = bt_col_base + i * 8
+                    chunk_dA2 = cute.local_tile(rDA2, (8,), (i,))
+                    smem_store_bf16x8_sw128(sQ_raw_ptr, row, col_base, chunk_dA2)
+
+                cute.arch.fence_proxy("async.shared", space="cta")
+                pipeline_prologue_dA3.producer_commit(prologue_dA3_producer_state)
+                prologue_dA3_producer_state.advance()
+
+                # wait for dA2
+                pipeline_mma_dA3.consumer_wait(mma_dA3_consumer_state)
+                tcgen05_fence_after()
+                dA3_i32 = tcgen05_ld_32x32b(
+                    bt_num_cols_per_wg, TMEM_DA2_ACC_OFF + wg_idx * bt_num_cols_per_wg
+                )
+                tcgen05_fence_before()
+                cute.arch.fence_view_async_tmem_load()
+
+                # release mma dA2 after dA3 is finished, protect DA2 TMEM
+                pipeline_mma_dA2.consumer_release(mma_dA2_consumer_state)
+                mma_dA2_consumer_state.advance()
+                pipeline_mma_dA3.consumer_release(mma_dA3_consumer_state)
+                mma_dA3_consumer_state.advance()
+                # NOTE: release smem Q because we reuse to store bf16 dA
+                pipeline_load_q.consumer_release(load_q_consumer_state)
+                load_q_consumer_state.advance()
+
+                # dA = -dA, apply strict lower-triangular mask
+                dA3_f32 = reinterpret_cast(dA3_i32, Int32, bt_num_cols_per_wg, Float32)
+                dA3_f32_val = TensorSSA(dA3_f32, (bt_num_cols_per_wg,), Float32)
+                rDA3 = cute.make_rmem_tensor((bt_num_cols_per_wg,), Float32)
+                rDA3.store(-dA3_f32_val)
+                for i in cutlass.range_constexpr(bt_num_cols_per_wg):
+                    col = bt_col_base + i
+                    if col >= row:
+                        rDA3[i] = Float32(0.0)
+                rDA3_val = rDA3.load()
+                dA3_i32_vec = reinterpret_cast(rDA3_val, Float32, bt_num_cols_per_wg, Int32)
+                # GMEM store dA
+                num_stores_dA = bt_num_cols_per_wg // 8
+                dA_base_addr = (
+                    dA_gmem.iterator
+                    + (tok_offset + tile_idx * self.BT + row) * HV * BT
+                    + i_hv * BT
+                    + bt_col_base
+                ).toint()
+                if row < sub_seq_len:
+                    for s in cutlass.range_constexpr(num_stores_dA):
+                        chunk_dA_store = subvec(dA3_i32_vec, s * 8, 8)
+                        store_256b(dA_base_addr + s * 32, chunk_dA_store)
+
+        # Load loop body
+        elif warp_idx == self.load_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_others)
+
+            load_A_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.a_stage
+            )
+            load_dv_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.vloop_stage
+            )
+            load_do_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.vloop_stage
+            )
+            load_vnew_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.vloop_stage
+            )
+            load_g_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.kloop_stage
+            )
+            load_k_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.kloop_stage
+            )
+            load_q_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.kloop_stage
+            )
+
+            vloop_stage_idx = 0
+            vloop_phase = 1  # init as 1 for producer
+            for wu_iter in cutlass.range(0, num_iters, unroll=0):
+                work_idx = block_idx_x + wu_iter * grid_dim_x
+                G = HV // H
+                i_t = work_idx // HV  # chunk index (global)
+                i_hv = work_idx % HV  # value-head index
+                i_h = i_hv // G  # q/k head index
+
+                # Decode chunk_indices
+                batch_idx = chunk_indices[(i_t, 0)]
+                tile_idx = chunk_indices[(i_t, 1)]
+                tok_offset = cu_seqlens[(batch_idx,)]
+                seq_len = cu_seqlens[(batch_idx + 1,)] - tok_offset
+                sub_seq_len = min(self.BT, seq_len - tile_idx * self.BT)
+
+                # Load A
+                tma_A_v = cute.domain_offset((0, tok_offset, (0, 0)), tma_tensor_A)
+                tAsA, tAgA = self._tma_partition_A(
+                    tma_atom_A,
+                    tma_A_v,
+                    sA,
+                    self.dvb_tiler,  # [BT, BV, BT]
+                    dvb_tiled_mma,
+                    Int32(0),
+                    i_hv,
+                )
+                pipeline_load_A.producer_acquire(load_A_producer_state)
+                cute.copy(
+                    tma_atom_A,
+                    tAgA[(None, 0, tile_idx)],
+                    tAsA[(None, load_A_producer_state.index)],
+                    tma_bar_ptr=pipeline_load_A.producer_get_barrier(load_A_producer_state),
+                )
+                load_A_producer_state.advance()
+
+                # V-loop
+                for v_iter in cutlass.range(self.num_v_tiles):
+                    tma_h_v = cute.domain_offset((0, v_iter * self.BV, (0, 0)), tma_tensor_h)
+                    tHsH, tHgH = self._tma_partition_B(
+                        tma_atom_h,
+                        tma_h_v,
+                        sH,
+                        self.vloop_gemm_tiler,  # [BT, BK, BV]
+                        vloop_tiled_mma,
+                        i_hv,
+                        i_t,
+                    )
+                    mbarrier_wait(bar_mma_cuda_h_ptr + vloop_stage_idx, vloop_phase)
+                    with elect_one():
+                        mbarrier_arrive_and_expect_tx(
+                            bar_tma_h_ptr + vloop_stage_idx, self.tma_bytes_h
+                        )
+                    cute.copy(
+                        tma_atom_h,
+                        tHgH[(None, 0, 0)],
+                        tHsH[(None, vloop_stage_idx)],
+                        tma_bar_ptr=bar_tma_h_ptr + vloop_stage_idx,
+                    )
+
+                    tma_dh_v = cute.domain_offset((0, v_iter * self.BV, (0, 0)), tma_tensor_dh)
+                    tDHsDH, tDHgDH = self._tma_partition_B(
+                        tma_atom_dh,
+                        tma_dh_v,
+                        sDh,
+                        self.vloop_gemm_tiler,  # [BT, BK, BV]
+                        vloop_tiled_mma,
+                        i_hv,
+                        i_t,
+                    )
+                    mbarrier_wait(bar_mma_cuda_dh_ptr + vloop_stage_idx, vloop_phase)
+                    with elect_one():
+                        mbarrier_arrive_and_expect_tx(
+                            bar_tma_dh_ptr + vloop_stage_idx, self.tma_bytes_dh
+                        )
+                    cute.copy(
+                        tma_atom_dh,
+                        tDHgDH[(None, 0, 0)],
+                        tDHsDH[(None, vloop_stage_idx)],
+                        tma_bar_ptr=bar_tma_dh_ptr + vloop_stage_idx,
+                    )
+
+                    tma_do_v = cute.domain_offset(
+                        (tok_offset, v_iter * self.BV, (0, 0)), tma_tensor_do
+                    )
+                    tDOsDo, tDOgDo = self._tma_partition_A(
+                        tma_atom_do,
+                        tma_do_v,
+                        sDo,
+                        self.vloop_gemm_tiler,  # [BT, BK, BV]
+                        vloop_tiled_mma,
+                        Int32(0),
+                        i_hv,
+                    )
+                    pipeline_load_do.producer_acquire(load_do_producer_state)
+                    cute.copy(
+                        tma_atom_do,
+                        tDOgDo[(None, tile_idx, 0)],
+                        tDOsDo[(None, vloop_stage_idx)],
+                        tma_bar_ptr=pipeline_load_do.producer_get_barrier(load_do_producer_state),
+                    )
+                    load_do_producer_state.advance()
+
+                    tma_dv_v = cute.domain_offset(
+                        (tok_offset, v_iter * self.BV, (0, 0)), tma_tensor_dv
+                    )
+                    tDVsDv, tDVgDV = self._tma_partition_A(
+                        tma_atom_dv,
+                        tma_dv_v,
+                        sDv,
+                        self.vloop_gemm_tiler,  # [BT, BK, BV]
+                        vloop_tiled_mma,
+                        Int32(0),
+                        i_hv,
+                    )
+                    pipeline_load_dv.producer_acquire(load_dv_producer_state)
+                    cute.copy(
+                        tma_atom_dv,
+                        tDVgDV[(None, tile_idx, 0)],
+                        tDVsDv[(None, vloop_stage_idx)],
+                        tma_bar_ptr=pipeline_load_dv.producer_get_barrier(load_dv_producer_state),
+                    )
+                    load_dv_producer_state.advance()
+
+                    tma_v_v = cute.domain_offset(
+                        (tok_offset, v_iter * self.BV, (0, 0)), tma_tensor_v
+                    )
+                    tVsV, tVgV = self._tma_partition_B(
+                        tma_atom_v,
+                        tma_v_v,
+                        sV,
+                        self.dA_vloop_tiler,  # [BT, BT, BV]
+                        dA_vloop_tiled_mma,
+                        Int32(0),
+                        i_hv,
+                    )
+                    mbarrier_wait(bar_mma_cuda_v_ptr + vloop_stage_idx, vloop_phase)
+                    with elect_one():
+                        mbarrier_arrive_and_expect_tx(
+                            bar_tma_v_ptr + vloop_stage_idx, self.tma_bytes_v
+                        )
+                    cute.copy(
+                        tma_atom_v,
+                        tVgV[(None, tile_idx, 0)],
+                        tVsV[(None, vloop_stage_idx)],
+                        tma_bar_ptr=bar_tma_v_ptr + vloop_stage_idx,
+                    )
+
+                    # load v_new
+                    tma_vnew_v = cute.domain_offset(
+                        (tok_offset, v_iter * self.BV, (0, 0)), tma_tensor_vnew
+                    )
+                    tVnewsVnew, tVnewgVnew = self._tma_partition_A(
+                        tma_atom_vnew,
+                        tma_vnew_v,
+                        sVnew,
+                        self.vloop_gemm_tiler,  # [BT, BK, BV]
+                        vloop_tiled_mma,
+                        Int32(0),
+                        i_hv,
+                    )
+                    pipeline_load_vnew.producer_acquire(load_vnew_producer_state)
+                    cute.copy(
+                        tma_atom_vnew,
+                        tVnewgVnew[(None, tile_idx, 0)],
+                        tVnewsVnew[(None, vloop_stage_idx)],
+                        tma_bar_ptr=pipeline_load_vnew.producer_get_barrier(
+                            load_vnew_producer_state
+                        ),
+                    )
+                    load_vnew_producer_state.advance()
+
+                    vloop_stage_idx = (vloop_stage_idx + 1) % self.vloop_stage
+                vloop_phase ^= 1
+
+                # Load g
+                tma_g_v = cute.domain_offset((tok_offset, 0, (0, 0)), tma_tensor_g)
+                tGsG, tGgG = self._epilog_partition_varlen(
+                    tma_atom_g,
+                    tma_g_v[None, None, (i_hv, Int32(0))],
+                    (self.BT, self.BK),
+                    sG_raw,
+                )
+                pipeline_load_g.producer_acquire(load_g_producer_state)
+                cute.copy(
+                    tma_atom_g,
+                    tGgG[(None, tile_idx, 0)],
+                    tGsG[(None, 0)],  # hardcode stage to 0 because kloop_stage is 1
+                    tma_bar_ptr=pipeline_load_g.producer_get_barrier(load_g_producer_state),
+                )
+                load_g_producer_state.advance()
+
+                # Load k
+                tma_k_v = cute.domain_offset((tok_offset, 0, (0, 0)), tma_tensor_k)
+                tKsK, tKgK = self._epilog_partition_varlen(
+                    tma_atom_k,
+                    tma_k_v[None, None, (i_h, Int32(0))],
+                    (self.BT, self.BK),
+                    sK_raw,
+                )
+                pipeline_load_k.producer_acquire(load_k_producer_state)
+                cute.copy(
+                    tma_atom_k,
+                    tKgK[(None, tile_idx, 0)],
+                    tKsK[(None, 0)],  # hardcode stage to 0 because kloop_stage is 1
+                    tma_bar_ptr=pipeline_load_k.producer_get_barrier(load_k_producer_state),
+                )
+                load_k_producer_state.advance()
+
+                tma_q_v = cute.domain_offset((tok_offset, 0, (0, 0)), tma_tensor_q)
+                tQsQ, tQgQ = self._epilog_partition_varlen(
+                    tma_atom_q,
+                    tma_q_v[None, None, (i_h, Int32(0))],
+                    (self.BT, self.BK),
+                    sQ_raw,
+                )
+                pipeline_load_q.producer_acquire(load_q_producer_state)
+                cute.copy(
+                    tma_atom_q,
+                    tQgQ[(None, tile_idx, 0)],
+                    tQsQ[(None, 0)],  # hardcode stage to 0 because kloop_stage is 1
+                    tma_bar_ptr=pipeline_load_q.producer_get_barrier(load_q_producer_state),
+                )
+                load_q_producer_state.advance()
+
+        # MMA loop body
+        elif warp_idx == self.mma_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_others)
+
+            load_A_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.a_stage
+            )
+            load_dv_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.vloop_stage
+            )
+            mma_dvb_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.mma_stage
+            )
+            load_do_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.vloop_stage
+            )
+            load_vnew_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.vloop_stage
+            )
+            mma_dq_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.mma_stage
+            )
+            mma_dk_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.mma_stage
+            )
+            mma_dw_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.mma_stage
+            )
+            prologue_dw_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.kloop_stage
+            )
+            prologue_kg_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.kloop_stage
+            )
+            mma_dgkb_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.mma_stage
+            )
+            mma_dA_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.mma_stage
+            )
+            mma_dA2_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.mma_stage
+            )
+            mma_dA3_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.mma_stage
+            )
+            prologue_dA2_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.mma_stage
+            )
+            prologue_dA3_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.mma_stage
+            )
+
+            vloop_stage_idx = 0
+            a_stage_idx = 0
+            mma_vloop_phase = 0
+            vloop_phase = 0
+            for wu_iter in cutlass.range(0, num_iters, unroll=0):
+                work_idx = block_idx_x + wu_iter * grid_dim_x
+                G = HV // H
+                i_t = work_idx // HV  # chunk index (global)
+                i_hv = work_idx % HV  # value-head index (unused in MMA warp)
+                i_h = i_hv // G  # q/k head index (unused in MMA warp)
+
+                # Decode chunk_indices
+                batch_idx = chunk_indices[(i_t, 0)]
+                tile_idx = chunk_indices[(i_t, 1)]
+                tok_offset = cu_seqlens[(batch_idx,)]
+                seq_len = cu_seqlens[(batch_idx + 1,)] - tok_offset
+                sub_seq_len = min(self.BT, seq_len - tile_idx * self.BT)
+
+                zeros8 = cute.make_rmem_tensor((8,), dtype=self.io_dtype)
+                zeros8.fill(BFloat16(0.0))
+
+                pipeline_load_A.consumer_wait(load_A_consumer_state)
+                sA_raw_ptr = cute.make_ptr(
+                    self.io_dtype,
+                    sA_ptr_base + a_stage_idx * A_bytes_per_stage,
+                    cute.AddressSpace.smem,
+                )
+                if sub_seq_len < self.BT:
+                    for i in cutlass.range_constexpr(self.BT // 32):
+                        row = i * 32 + lane_idx
+                        if row >= sub_seq_len:
+                            for col in cutlass.range_constexpr(self.BT // 8):
+                                # A tile is MN_SW128 in shared memory; use raw swizzled
+                                # address stores to avoid layout-coordinate ambiguity.
+                                smem_store_bf16x8_sw128(sA_raw_ptr, row, col * 8, zeros8)
+                    # Make generic-proxy SMEM stores visible to UMMA async-proxy readers.
+                    cute.arch.fence_proxy("async.shared", space="cta")
+
+                for v_iter in cutlass.range(self.num_v_tiles):
+                    is_accum = False if v_iter == 0 else True
+                    mbarrier_wait(bar_tma_h_ptr + vloop_stage_idx, vloop_phase)
+                    pipeline_load_do.consumer_wait(load_do_consumer_state)
+                    sDo_raw_ptr = cute.make_ptr(
+                        self.io_dtype,
+                        sDo_ptr_base + vloop_stage_idx * vloop_opA_bytes_per_stage,
+                        cute.AddressSpace.smem,
+                    )
+                    if sub_seq_len < self.BT:
+                        for i in cutlass.range_constexpr(self.BT // 32):
+                            row = i * 32 + lane_idx
+                            if row >= sub_seq_len:
+                                for col in cutlass.range_constexpr(self.BV // 8):
+                                    # dv tile uses the same Swizzle<3,4,3> physical mapping.
+                                    smem_store_bf16x8_sw128(sDo_raw_ptr, row, col * 8, zeros8)
+                        cute.arch.fence_proxy("async.shared", space="cta")
+
+                    if v_iter == 0:
+                        pipeline_mma_dq.producer_acquire(mma_dq_producer_state)
+
+                    # dq+=do@h
+                    sDo_k_cur = sDo_k[(None, None, None, vloop_stage_idx)]
+                    sH_k_cur = sH_k[(None, None, None, vloop_stage_idx)]
+                    desc_a_i64 = smem_descriptor_to_int(
+                        make_umma_smem_desc(sDo_k_cur.iterator, sDo_k_cur.layout, "k")
+                    )
+                    desc_b_i64 = smem_descriptor_to_int(
+                        make_umma_smem_desc(sH_k_cur.iterator, sH_k_cur.layout, "k")
+                    )
+                    desc_a_base = Tcgen05SmemDescriptor(desc_a_i64)
+                    desc_b_base = Tcgen05SmemDescriptor(desc_b_i64)
+                    mma_ws_ss_m64n128_k_k_call(
+                        vloop_opA_smem,
+                        desc_a_base,
+                        vloop_opB_smem,
+                        desc_b_base,
+                        TMEM_DQ_ACC_OFF,
+                        self.BV,
+                        is_accum,
+                    )
+
+                    pipeline_load_do.consumer_release(load_do_consumer_state)
+                    load_do_consumer_state.advance()
+
+                    if v_iter == self.num_v_tiles - 1:
+                        pipeline_mma_dq.producer_commit(mma_dq_producer_state)
+                        mma_dq_producer_state.advance()
+
+                    pipeline_load_dv.consumer_wait(load_dv_consumer_state)
+                    sDv_raw = cute.make_ptr(
+                        self.io_dtype,
+                        sDv_ptr_base + vloop_stage_idx * vloop_opA_bytes_per_stage,
+                        cute.AddressSpace.smem,
+                    )
+                    if sub_seq_len < self.BT:
+                        for i in cutlass.range_constexpr(self.BT // 32):
+                            row = i * 32 + lane_idx
+                            if row >= sub_seq_len:
+                                for col in cutlass.range_constexpr(self.BV // 8):
+                                    # dv tile uses the same Swizzle<3,4,3> physical mapping.
+                                    smem_store_bf16x8_sw128(sDv_raw, row, col * 8, zeros8)
+                        cute.arch.fence_proxy("async.shared", space="cta")
+
+                    # if lane_idx == 0:
+                    #     cute.printf("V_iter", v_iter)
+                    #     cute.print_tensor(sDv[None, None, None, vloop_stage_idx])
+                    pipeline_mma_dvb.producer_acquire(mma_dvb_producer_state)
+                    sDv_mn_cur = sDv_mn[(None, None, None, vloop_stage_idx)]
+                    sA_mn_cur = sA_mn[(None, None, None, a_stage_idx)]
+                    desc_a_i64 = smem_descriptor_to_int(
+                        make_umma_smem_desc(sA_mn_cur.iterator, sA_mn_cur.layout, "mn")
+                    )
+                    desc_b_i64 = smem_descriptor_to_int(
+                        make_umma_smem_desc(sDv_mn_cur.iterator, sDv_mn_cur.layout, "mn")
+                    )
+                    desc_a_base = Tcgen05SmemDescriptor(desc_a_i64)
+                    desc_b_base = Tcgen05SmemDescriptor(desc_b_i64)
+                    mma_ws_ss_m64n64_mn_mn_call(
+                        A_mn_opA_smem,
+                        desc_a_base,
+                        dv_mn_opB_smem,
+                        desc_b_base,
+                        TMEM_FLEX_OFF,
+                        self.BT,
+                    )
+
+                    pipeline_mma_dvb.producer_commit(mma_dvb_producer_state)
+                    mma_dvb_producer_state.advance()
+
+                    # dw += dv @ h
+                    if v_iter == 0:
+                        pipeline_mma_dw.producer_acquire(mma_dw_producer_state)
+
+                    sDv_k_cur = sDv_k[(None, None, None, vloop_stage_idx)]
+                    desc_a_i64 = smem_descriptor_to_int(
+                        make_umma_smem_desc(sDv_k_cur.iterator, sDv_k_cur.layout, "k")
+                    )
+                    desc_b_i64 = smem_descriptor_to_int(
+                        make_umma_smem_desc(sH_k_cur.iterator, sH_k_cur.layout, "k")
+                    )
+                    desc_a_base = Tcgen05SmemDescriptor(desc_a_i64)
+                    desc_b_base = Tcgen05SmemDescriptor(desc_b_i64)
+                    mma_ws_ss_m64n128_k_k_call(
+                        vloop_opA_smem,
+                        desc_a_base,
+                        vloop_opB_smem,
+                        desc_b_base,
+                        TMEM_DW_ACC_OFF,
+                        self.BV,
+                        is_accum,
+                    )
+
+                    # dA += dv @ v^T
+                    mbarrier_wait(bar_tma_v_ptr + vloop_stage_idx, vloop_phase)
+                    sV_raw = cute.make_ptr(
+                        self.io_dtype,
+                        sV_ptr_base + vloop_stage_idx * v_opB_bytes_per_stage,
+                        cute.AddressSpace.smem,
+                    )
+                    if sub_seq_len < self.BT:
+                        for i in cutlass.range_constexpr(self.BT // 32):
+                            row = i * 32 + lane_idx
+                            if row >= sub_seq_len:
+                                for col in cutlass.range_constexpr(self.BV // 8):
+                                    # dv tile uses the same Swizzle<3,4,3> physical mapping.
+                                    smem_store_bf16x8_sw128(sV_raw, row, col * 8, zeros8)
+                        cute.arch.fence_proxy("async.shared", space="cta")
+
+                    if v_iter == 0:
+                        pipeline_mma_dA.producer_acquire(mma_dA_producer_state)
+
+                    sV_k_cur = sV_k[(None, None, None, vloop_stage_idx)]
+                    desc_a_i64 = smem_descriptor_to_int(
+                        make_umma_smem_desc(sDv_k_cur.iterator, sDv_k_cur.layout, "k")
+                    )
+                    desc_b_i64 = smem_descriptor_to_int(
+                        make_umma_smem_desc(sV_k_cur.iterator, sV_k_cur.layout, "k")
+                    )
+                    desc_a_base = Tcgen05SmemDescriptor(desc_a_i64)
+                    desc_b_base = Tcgen05SmemDescriptor(desc_b_i64)
+                    mma_ws_ss_m64n64_k_k_call(
+                        vloop_opA_smem,
+                        desc_a_base,
+                        v_opB_smem,
+                        desc_b_base,
+                        TMEM_DA_ACC_OFF,
+                        self.BV,
+                        is_accum,
+                    )
+
+                    # dv pipeline calls tcgen05.commit for dv@h and dv@v^T
+                    pipeline_load_dv.consumer_release(load_dv_consumer_state)
+                    load_dv_consumer_state.advance()
+
+                    if v_iter == self.num_v_tiles - 1:
+                        pipeline_mma_dw.producer_commit(mma_dw_producer_state)
+                        mma_dw_producer_state.advance()
+
+                    umma_arrive(bar_mma_cuda_h_ptr + vloop_stage_idx)
+                    umma_arrive(bar_mma_cuda_v_ptr + vloop_stage_idx)
+
+                    # dk += v_new @ dh
+                    pipeline_load_vnew.consumer_wait(load_vnew_consumer_state)
+                    sDvnew_raw_ptr = cute.make_ptr(
+                        self.io_dtype,
+                        sVnew_ptr_base + vloop_stage_idx * vloop_opA_bytes_per_stage,
+                        cute.AddressSpace.smem,
+                    )
+                    if sub_seq_len < self.BT:
+                        for i in cutlass.range_constexpr(self.BT // 32):
+                            row = i * 32 + lane_idx
+                            if row >= sub_seq_len:
+                                for col in cutlass.range_constexpr(self.BV // 8):
+                                    # dv tile uses the same Swizzle<3,4,3> physical mapping.
+                                    smem_store_bf16x8_sw128(sDvnew_raw_ptr, row, col * 8, zeros8)
+                        cute.arch.fence_proxy("async.shared", space="cta")
+
+                    mbarrier_wait(bar_tma_dh_ptr + vloop_stage_idx, vloop_phase)
+                    if v_iter == 0:
+                        pipeline_mma_dk.producer_acquire(mma_dk_producer_state)
+
+                    sVnew_k_cur = sVnew_k[(None, None, None, vloop_stage_idx)]
+                    sDh_k_cur = sDh_k[(None, None, None, vloop_stage_idx)]
+                    desc_a_i64 = smem_descriptor_to_int(
+                        make_umma_smem_desc(sVnew_k_cur.iterator, sVnew_k_cur.layout, "k")
+                    )
+                    desc_b_i64 = smem_descriptor_to_int(
+                        make_umma_smem_desc(sDh_k_cur.iterator, sDh_k_cur.layout, "k")
+                    )
+                    desc_a_base = Tcgen05SmemDescriptor(desc_a_i64)
+                    desc_b_base = Tcgen05SmemDescriptor(desc_b_i64)
+                    mma_ws_ss_m64n128_k_k_call(
+                        vloop_opA_smem,
+                        desc_a_base,
+                        vloop_opB_smem,
+                        desc_b_base,
+                        TMEM_DK_ACC_OFF,
+                        self.BV,
+                        is_accum,
+                    )
+
+                    # vnew pipeline calls tcgen05.commit
+                    pipeline_load_vnew.consumer_release(load_vnew_consumer_state)
+                    load_vnew_consumer_state.advance()
+
+                    if v_iter == self.num_v_tiles - 1:
+                        pipeline_mma_dk.producer_commit(mma_dk_producer_state)
+                        mma_dk_producer_state.advance()
+
+                    umma_arrive(bar_mma_cuda_dh_ptr + vloop_stage_idx)
+
+                    # add tcgen05.commit and mbar.wait to make sure dq/dk/dw MMA finished
+                    umma_arrive(bar_mma_done_vloop_ptr + 0)
+                    mbarrier_wait(bar_mma_done_vloop_ptr + 0, mma_vloop_phase)
+                    mma_vloop_phase ^= 1
+
+                    vloop_stage_idx = (vloop_stage_idx + 1) % self.vloop_stage
+                vloop_phase ^= 1
+
+                pipeline_prologue_dw.consumer_wait(prologue_dw_consumer_state)
+                cute.arch.fence_proxy("async.shared", space="cta")
+                # dkgb = A @ dw
+                pipeline_mma_dkgb.producer_acquire(mma_dgkb_producer_state)
+                sA_mn_cur = sA_mn[(None, None, None, a_stage_idx)]
+                sDw_mn_cur = sDw_mn[(None, None, None, 0)]
+                desc_a_i64 = smem_descriptor_to_int(
+                    make_umma_smem_desc(sA_mn_cur.iterator, sA_mn_cur.layout, "mn")
+                )
+                desc_b_i64 = smem_descriptor_to_int(
+                    make_umma_smem_desc(sDw_mn_cur.iterator, sDw_mn_cur.layout, "mn")
+                )
+                desc_a_base = Tcgen05SmemDescriptor(desc_a_i64)
+                desc_b_base = Tcgen05SmemDescriptor(desc_b_i64)
+                mma_ws_ss_m64n128_mn_mn_call(
+                    A_mn_opA_smem,
+                    desc_a_base,
+                    dw_mn_opB_smem,
+                    desc_b_base,
+                    TMEM_DKGB_ACC_OFF,
+                    self.BT,
+                )
+
+                pipeline_mma_dkgb.producer_commit(mma_dgkb_producer_state)
+                mma_dgkb_producer_state.advance()
+
+                pipeline_prologue_kg.consumer_wait(prologue_kg_consumer_state)
+                cute.arch.fence_proxy("async.shared", space="cta")
+                # dA += dw @ kg^T
+                sDw_k_cur = sDw_k[(None, None, None, 0)]
+                sKG_k_cur = sKG_k[(None, None, None, 0)]
+                desc_a_i64 = smem_descriptor_to_int(
+                    make_umma_smem_desc(sDw_k_cur.iterator, sDw_k_cur.layout, "k")
+                )
+                desc_b_i64 = smem_descriptor_to_int(
+                    make_umma_smem_desc(sKG_k_cur.iterator, sKG_k_cur.layout, "k")
+                )
+                desc_a_base = Tcgen05SmemDescriptor(desc_a_i64)
+                desc_b_base = Tcgen05SmemDescriptor(desc_b_i64)
+                mma_ws_ss_m64n64_k_k_call(
+                    dw_k_opA_smem,
+                    desc_a_base,
+                    kg_k_opB_smem,
+                    desc_b_base,
+                    TMEM_DA_ACC_OFF,
+                    self.BK,
+                    True,
+                )
+
+                pipeline_mma_dA.producer_commit(mma_dA_producer_state)
+                mma_dA_producer_state.advance()
+                pipeline_prologue_kg.consumer_release(prologue_kg_consumer_state)
+                prologue_kg_consumer_state.advance()
+
+                pipeline_prologue_dw.consumer_release(prologue_dw_consumer_state)
+                prologue_dw_consumer_state.advance()
+
+                # dA2 = dA @ A
+                pipeline_mma_dA2.producer_acquire(mma_dA2_producer_state)
+                pipeline_prologue_dA2.consumer_wait(prologue_dA2_consumer_state)
+                cute.arch.fence_proxy("async.shared", space="cta")
+
+                sDA_k_cur = sDA_k[(None, None, None, 0)]
+                sA_k_cur = sA_k[(None, None, None, a_stage_idx)]
+                desc_a_i64 = smem_descriptor_to_int(
+                    make_umma_smem_desc(sDA_k_cur.iterator, sDA_k_cur.layout, "k")
+                )
+                desc_b_i64 = smem_descriptor_to_int(
+                    make_umma_smem_desc(sA_k_cur.iterator, sA_k_cur.layout, "k")
+                )
+                desc_a_base = Tcgen05SmemDescriptor(desc_a_i64)
+                desc_b_base = Tcgen05SmemDescriptor(desc_b_i64)
+                mma_ws_ss_m64n64_k_k_call(
+                    dA_k_opA_smem,
+                    desc_a_base,
+                    A_k_opB_smem,
+                    desc_b_base,
+                    TMEM_DA2_ACC_OFF,
+                    self.BT,
+                )
+
+                pipeline_mma_dA2.producer_commit(mma_dA2_producer_state)
+                mma_dA2_producer_state.advance()
+                pipeline_prologue_dA2.consumer_release(prologue_dA2_consumer_state)
+                prologue_dA2_consumer_state.advance()
+
+                # dA3 = A @ dA2
+                pipeline_mma_dA3.producer_acquire(mma_dA3_producer_state)
+                pipeline_prologue_dA3.consumer_wait(prologue_dA3_consumer_state)
+                cute.arch.fence_proxy("async.shared", space="cta")
+
+                sA_mn_cur = sA_mn[(None, None, None, a_stage_idx)]
+                sDA_mn_cur = sDA_mn[(None, None, None, 0)]
+                desc_a_i64 = smem_descriptor_to_int(
+                    make_umma_smem_desc(sA_mn_cur.iterator, sA_mn_cur.layout, "mn")
+                )
+                desc_b_i64 = smem_descriptor_to_int(
+                    make_umma_smem_desc(sDA_mn_cur.iterator, sDA_mn_cur.layout, "mn")
+                )
+                desc_a_base = Tcgen05SmemDescriptor(desc_a_i64)
+                desc_b_base = Tcgen05SmemDescriptor(desc_b_i64)
+                mma_ws_ss_m64n64_mn_mn_call(
+                    A_mn_opA_smem,
+                    desc_a_base,
+                    dA_mn_opB_smem,
+                    desc_b_base,
+                    TMEM_DA2_ACC_OFF,
+                    self.BT,
+                )
+
+                pipeline_mma_dA3.producer_commit(mma_dA3_producer_state)
+                mma_dA3_producer_state.advance()
+                pipeline_prologue_dA3.consumer_release(prologue_dA3_consumer_state)
+                prologue_dA3_consumer_state.advance()
+
+                pipeline_load_A.consumer_release(load_A_consumer_state)
+                load_A_consumer_state.advance()
+
+                a_stage_idx = (a_stage_idx + 1) % self.a_stage
+
+        # Load aux loop body
+        elif warp_idx in self.aux_warp_ids:
+            cute.arch.setmaxregister_decrease(self.num_regs_others)
+            tidx = thread_idx - (self.threads_per_cta - 64)
+
+            load_beta_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, 1
+            )
+            load_g_store_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.kloop_stage
+            )
+            store_dg_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.kloop_stage
+            )
+
+            for wu_iter in cutlass.range(0, num_iters, unroll=0):
+                work_idx = block_idx_x + wu_iter * grid_dim_x
+                G = HV // H
+                i_t = work_idx // HV  # chunk index (global)
+                i_hv = work_idx % HV  # value-head index
+                i_h = i_hv // G  # q/k head index (unused in aux warp)
+
+                # Decode chunk_indices
+                batch_idx = chunk_indices[(i_t, 0)]
+                tile_idx = chunk_indices[(i_t, 1)]
+                tok_offset = cu_seqlens[(batch_idx,)]
+                seq_len = cu_seqlens[(batch_idx + 1,)] - tok_offset
+                sub_seq_len = min(self.BT, seq_len - tile_idx * self.BT)
+
+                pipeline_load_beta.producer_acquire(load_beta_producer_state)
+                beta_f32 = Float32(0.0)
+                if tidx < sub_seq_len:
+                    beta_f32 = Float32(
+                        beta_gmem[(tok_offset + tile_idx * self.BT + tidx, (i_hv, Int32(0)))]
+                    )
+                sBeta[(tidx,)] = beta_f32
+
+                cute.arch.fence_proxy("async.shared", space="cta")
+                pipeline_load_beta.producer_commit(load_beta_producer_state)
+                load_beta_producer_state.advance()
+
+                pipeline_load_g.consumer_wait(load_g_store_consumer_state)
+                pipeline_store_dg.consumer_wait(store_dg_consumer_state)
+
+                tma_dg_v = cute.domain_offset((tok_offset, 0, (0, 0)), tma_tensor_dg)
+                tDGsDG, tDGgDG = self._epilog_partition_varlen(
+                    tma_atom_dg,
+                    tma_dg_v[None, None, (i_hv, Int32(0))],
+                    (self.BT, self.BK),
+                    sG_raw,
+                )
+                if sub_seq_len < self.BT:
+                    # Tail chunk, direct store
+                    store_lane_row = tidx >> Int32(4)  # 0..3
+                    store_col_base = (tidx & Int32(15)) * Int32(8)  # 0,8,...,120
+                    for row_quad in cutlass.range_constexpr(self.BT // 4):
+                        store_row = row_quad * 4 + store_lane_row
+                        if store_row < sub_seq_len:
+                            vals0 = smem_load_f32x4_sw128(sG_raw_ptr, store_row, store_col_base)
+                            vals1 = smem_load_f32x4_sw128(
+                                sG_raw_ptr, store_row, store_col_base + Int32(4)
+                            )
+                            dg_store_rmem = cute.make_rmem_tensor((8,), Float32)
+                            dg_store_rmem[0] = vals0[0]
+                            dg_store_rmem[1] = vals0[1]
+                            dg_store_rmem[2] = vals0[2]
+                            dg_store_rmem[3] = vals0[3]
+                            dg_store_rmem[4] = vals1[0]
+                            dg_store_rmem[5] = vals1[1]
+                            dg_store_rmem[6] = vals1[2]
+                            dg_store_rmem[7] = vals1[3]
+                            dg_store_i32_vec = reinterpret_cast(
+                                dg_store_rmem.load(), Float32, 8, Int32
+                            )
+                            dg_base_addr = (
+                                dg_gmem.iterator
+                                + (tok_offset + tile_idx * self.BT + store_row) * HV * K
+                                + i_hv * K
+                                + store_col_base
+                            ).toint()
+                            store_256b(dg_base_addr, dg_store_i32_vec)
+                else:
+                    # Non-tail chunk, TMA store
+                    cute.arch.fence_proxy("async.shared", space="cta")
+                    cute.copy(
+                        tma_atom_dg,
+                        tDGsDG[(None, 0)],  # hardcode stage to 0 because kloop_stage is 1
+                        tDGgDG[(None, tile_idx, 0)],
+                    )
+                    cute.arch.cp_async_bulk_commit_group()
+                    cute.arch.cp_async_bulk_wait_group(0, read=True)
+
+                pipeline_store_dg.consumer_release(store_dg_consumer_state)
+                store_dg_consumer_state.advance()
+                pipeline_load_g.consumer_release(load_g_store_consumer_state)
+                load_g_store_consumer_state.advance()
+
+        # ===================== TMEM cleanup =====================
+        tmem.relinquish_alloc_permit()
+        self.tmem_dealloc_sync_barrier.arrive_and_wait()
+        tmem.free(tmem_ptr, TMEM_TOTAL)
+
+    @cute.jit
+    def _tma_partition_A(self, tma_atom, tma_tensor, smem, tile_shape, tiled_mma, batch_idx, hidx):
+        """Partition a TMA tensor as MMA A-operand (M,K dims).
+
+        ``tma_tensor`` should already have domain_offset applied for varlen.
+
+        For tile_shape = (BT, BK, BV) = (M, N, K):
+          coord = (None, 0, None) — slices out the N-tile axis (mode 1) at 0,
+          leaving mode 0 (M=BT) and mode 2 (K=BV) free for TMA to iterate.
+
+        Returns (tXsX, tXgX) — SMEM partition and GMEM coordinate partition.
+        """
+        coord = (None, 0, None)
+        gX = cute.local_tile(
+            tma_tensor, cute.slice_(tile_shape, coord), (None, None, (hidx, batch_idx))
+        )
+        thr_mma = tiled_mma.get_slice(0)
+        tCgX = thr_mma.partition_A(gX)
+        tXsX, tXgX = cpasync.tma_partition(
+            tma_atom,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(smem, 0, 3),
+            cute.group_modes(tCgX, 0, 3),
+        )
+        return tXsX, tXgX
+
+    @cute.jit
+    def _tma_partition_B(self, tma_atom, tma_tensor, smem, tile_shape, tiled_mma, batch_idx, hidx):
+        """Partition a TMA tensor as MMA B-operand (N,K dims).
+
+        Mirrors the identical helper in recompute_wu.py / fwd_o.py.
+        ``tma_tensor`` should already have domain_offset applied for varlen.
+
+        For tile_shape = (BT, BK, BV) = (M, N, K):
+          coord = (0, None, None) — slices out the M-tile axis (mode 0) at 0,
+          leaving mode 1 (N=BK) and mode 2 (K=BV) free for TMA to iterate.
+
+        Returns (tXsX, tXgX) — SMEM partition and GMEM coordinate partition.
+        """
+        coord = (0, None, None)
+        gX = cute.local_tile(
+            tma_tensor, cute.slice_(tile_shape, coord), (None, None, (hidx, batch_idx))
+        )
+        thr_mma = tiled_mma.get_slice(0)
+        tCgX = thr_mma.partition_B(gX)
+        tXsX, tXgX = cpasync.tma_partition(
+            tma_atom,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(smem, 0, 3),
+            cute.group_modes(tCgX, 0, 3),
+        )
+        return tXsX, tXgX
+
+    @cute.jit
+    def _epilog_partition_varlen(self, atom, gC_2d, epi_tile, sC):
+        """Partition for varlen epilog TMA load (2D tensor with domain_offset).
+
+        Uses local_tile instead of flat_divide to correctly preserve TMA basis
+        stride coordinates through domain_offset.  Matches Flash Attention's
+        pattern: slice mode2 → domain_offset(2D) → local_tile → tma_partition.
+
+        Uses (None, None) to keep all tile-count modes, producing the same
+        rank as _epilog_partition (flat_divide) so copy indexing is unchanged.
+        """
+        gC_tiled = cute.local_tile(gC_2d, epi_tile, (None, None))
+        sC_g = cute.group_modes(sC, 0, 2)
+        gC_g = cute.group_modes(gC_tiled, 0, 2)
+        bSG_sC, bSG_gC = cpasync.tma_partition(
+            atom,
+            0,
+            cute.make_layout(1),
+            sC_g,
+            gC_g,
+        )
+        return bSG_sC, bSG_gC

--- a/attn_gym/linear/kda/bwd/triton/__init__.py
+++ b/attn_gym/linear/kda/bwd/triton/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/attn_gym/linear/kda/bwd/triton/chunk_kda_bwd_dAv.py
+++ b/attn_gym/linear/kda/bwd/triton/chunk_kda_bwd_dAv.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Triton dAv backward for KDA (the intra-chunk ``Aqk @ v_new`` path). This is
+# the one KDA backward compute stage with no CuTe implementation, so it ships as
+# Triton. Ported verbatim; only the header and utility imports were rewritten.
+#
+# Original source: genai/llama4x/llama4x/ops/fla/ops/kda/chunk_bwd.py
+
+from __future__ import annotations
+
+import triton
+import triton.language as tl
+from attn_gym.linear.kda.utils import (
+    autotune_cache_kwargs,
+)
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+        "HAS_NUM_CHUNKS": lambda args: args["num_chunks"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=2, num_stages=2),
+    ],
+    key=["H", "K", "V", "BT", "BK", "BV"],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["T", "num_chunks"])
+def chunk_kda_bwd_kernel_dAv(
+    q,
+    k,
+    v,
+    A,
+    do,
+    dv,
+    dA,
+    cu_seqlens,
+    chunk_indices,
+    num_chunks,
+    scale,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    HAS_NUM_CHUNKS: tl.constexpr,
+):
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        if HAS_NUM_CHUNKS:
+            if i_t >= tl.load(num_chunks):
+                return
+        i_n, i_t = (
+            tl.load(chunk_indices + i_t * 2).to(tl.int32),
+            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32),
+        )
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int32),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+        )
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    # offset calculation
+    q += (bos * H + i_h) * K
+    k += (bos * H + i_h) * K
+    v += (bos * H + i_h) * V
+    do += (bos * H + i_h) * V
+    dv += (bos * H + i_h) * V
+    dA += (bos * H + i_h) * BT
+
+    p_A = tl.make_block_ptr(
+        A + (bos * H + i_h) * BT, (BT, T), (1, H * BT), (0, i_t * BT), (BT, BT), (0, 1)
+    )
+    b_A = tl.load(p_A, boundary_check=(0, 1))
+
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
+    m_A = (o_t[:, None] <= o_t[None, :]) & (m_t[:, None] & m_t)
+    b_A = tl.where(m_A, b_A, 0).to(do.dtype.element_ty)
+
+    b_dA = tl.zeros([BT, BT], dtype=tl.float32)
+    for i_v in range(tl.cdiv(V, BV)):
+        p_v = tl.make_block_ptr(
+            v, (V, T), (1, H * V), (i_v * BV, i_t * BT), (BV, BT), (0, 1)
+        )
+        p_do = tl.make_block_ptr(
+            do, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+        )
+        p_dv = tl.make_block_ptr(
+            dv, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+        )
+        # [BV, BT]
+        b_v = tl.load(p_v, boundary_check=(0, 1))
+        # [BT, BV]
+        b_do = tl.load(p_do, boundary_check=(0, 1))
+        # [BT, BT]
+        b_dA += tl.dot(b_do, b_v)
+        # [BT, BV]
+        b_dv = tl.dot(b_A.to(b_do.dtype), b_do)
+        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+
+    p_dA = tl.make_block_ptr(dA, (T, BT), (H * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    b_dA = tl.where(o_t[:, None] >= o_t, b_dA * scale, 0.0)
+    tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
+

--- a/attn_gym/linear/kda/bwd/triton/cumsum.py
+++ b/attn_gym/linear/kda/bwd/triton/cumsum.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Chunk-local cumulative sum along the time axis. In the KDA backward pass the
+# per-channel decay gate is accumulated *in reverse* within each chunk (the
+# adjoint of a forward prefix-sum is a reverse prefix-sum), so both directions
+# are supported.
+#
+# Two layouts are handled:
+#   * scalar gates  (B, T, H)      -> chunk_local_cumsum_scalar_kernel
+#   * vector gates  (B, T, H, S)   -> chunk_local_cumsum_vector_kernel
+# with optional variable-length packing via (cu_seqlens, chunk_indices) and an
+# optional output scale.
+
+import triton
+import triton.language as tl
+
+from attn_gym.linear.kda.utils import autotune_cache_kwargs, check_shared_mem
+
+BS_LIST = [32, 64] if check_shared_mem() else [16, 32]
+
+
+@triton.heuristics(
+    {
+        "HAS_SCALE": lambda args: args["scale"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[triton.Config({}, num_warps=w) for w in [1, 2, 4, 8]],
+    key=["B", "H", "BT", "IS_VARLEN", "REVERSE"],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_local_cumsum_scalar_kernel(
+    s,
+    o,
+    scale,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    B: tl.constexpr,
+    H: tl.constexpr,
+    BT: tl.constexpr,
+    REVERSE: tl.constexpr,
+    HAS_SCALE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    HEAD_FIRST: tl.constexpr,
+):
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1).to(tl.int64)
+    i_b, i_h = i_bh // H, i_bh % H
+
+    # Resolve the row span of this chunk (constant time for the fixed-length
+    # case, or looked up from the packing metadata for varlen batches).
+    if IS_VARLEN:
+        i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
+        i_t = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
+        bos = tl.load(cu_seqlens + i_n).to(tl.int64)
+        eos = tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = eos - bos
+    else:
+        bos = i_b * T
+
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
+    if HEAD_FIRST:
+        off = bos * H + i_h * T + o_t
+    else:
+        off = bos * H + i_h + o_t * H
+
+    b_s = tl.load(s + off, mask=m_t, other=0.0).to(tl.float32)
+    b_o = tl.cumsum(b_s, axis=0, reverse=REVERSE)
+    if HAS_SCALE:
+        b_o = b_o * scale
+    tl.store(o + off, b_o.to(o.dtype.element_ty), mask=m_t)
+
+
+@triton.heuristics(
+    {
+        "HAS_SCALE": lambda args: args["scale"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[triton.Config({"BS": bs}, num_warps=w) for bs in BS_LIST for w in [2, 4, 8]],
+    key=["B", "H", "S", "BT", "IS_VARLEN", "REVERSE"],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_local_cumsum_vector_kernel(
+    s,
+    o,
+    scale,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    B: tl.constexpr,
+    H: tl.constexpr,
+    S: tl.constexpr,
+    BT: tl.constexpr,
+    BS: tl.constexpr,
+    REVERSE: tl.constexpr,
+    HAS_SCALE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    HEAD_FIRST: tl.constexpr,
+):
+    i_s = tl.program_id(0)
+    i_t = tl.program_id(1).to(tl.int64)
+    i_bh = tl.program_id(2).to(tl.int64)
+    i_b, i_h = i_bh // H, i_bh % H
+
+    if IS_VARLEN:
+        i_n = tl.load(chunk_indices + i_t * 2).to(tl.int32)
+        i_t = tl.load(chunk_indices + i_t * 2 + 1).to(tl.int64)
+        bos = tl.load(cu_seqlens + i_n).to(tl.int64)
+        eos = tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+        T = eos - bos
+    else:
+        bos = i_b * T
+
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_s = i_s * BS + tl.arange(0, BS)
+    m = (o_t[:, None] < T) & (o_s[None, :] < S)
+    # (B, T, H, S) row-major: token stride H*S, head offset i_h*S (or i_h*T*S
+    # when the head axis precedes time in a head-first packing).
+    if HEAD_FIRST:
+        off = (bos * H + i_h * T) * S + o_t[:, None] * S + o_s[None, :]
+    else:
+        off = (bos * H + i_h) * S + o_t[:, None] * (H * S) + o_s[None, :]
+
+    b_s = tl.load(s + off, mask=m, other=0.0).to(tl.float32)
+    b_o = tl.cumsum(b_s, axis=0, reverse=REVERSE)
+    if HAS_SCALE:
+        b_o = b_o * scale
+    tl.store(o + off, b_o.to(o.dtype.element_ty), mask=m)

--- a/attn_gym/linear/kda/bwd/triton/gate_bwd.py
+++ b/attn_gym/linear/kda/bwd/triton/gate_bwd.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Backward for the KDA per-channel gate (the pre-cumsum gate value).
+#
+# Forward, per (token t, head h, channel d):
+#     z = g + dt_bias                    (dt_bias broadcast over tokens, per h,d)
+#     A = exp(A_log)                     (A_log is a per-head scalar)
+#   no lower bound : yg = -A * softplus(z)
+#   lower bound LB : yg =  LB * sigmoid(A * z)
+#
+# Given the upstream gradient dyg = dL/dyg:
+#   no bound :  dyg/dz    = -A * sigmoid(z)         (softplus'(z) = sigmoid(z))
+#               dyg/dA_log = yg                      (since A * dsoftplus/dA_log = A)
+#   bounded  :  s = sigmoid(A z)
+#               dyg/dz    = LB * A * s * (1 - s)
+#               dyg/dA_log = LB * A * z * s (1 - s) = dg * z
+# Therefore dg = dyg * (dyg/dz), and the per-head A_log gradient is a full
+# reduction of dyg * (dyg/dA_log) over every token and channel. Each program
+# emits its block's partial sum into dA[i_t, i_h]; the caller reduces over the
+# time-block axis. The dt_bias gradient is sum_t dg, also reduced by the caller.
+
+import triton
+import triton.language as tl
+
+from attn_gym.linear.kda.utils import autotune_cache_kwargs
+
+NUM_WARPS_AUTOTUNE = [4, 8, 16, 32]
+
+
+@triton.jit
+def _softplus(x):
+    # log(1 + exp(x)), stable for large x where exp(x) would overflow.
+    return tl.where(x > 20.0, x, tl.log(1.0 + tl.exp(x)))
+
+
+@triton.heuristics(
+    {
+        "HAS_BIAS": lambda args: args["dt_bias"] is not None,
+        "USE_LOWER_BOUND": lambda args: args["lower_bound"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=w, num_stages=st) for w in NUM_WARPS_AUTOTUNE for st in [2, 3]
+    ],
+    key=["H", "D"],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["T"])
+def kda_gate_bwd_kernel(
+    g,
+    A_log,
+    dt_bias,
+    dyg,
+    dg,
+    dA,
+    lower_bound,
+    T,
+    H: tl.constexpr,
+    D: tl.constexpr,
+    BT: tl.constexpr,
+    BD: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
+    USE_LOWER_BOUND: tl.constexpr,
+):
+    i_t, i_h = tl.program_id(0).to(tl.int64), tl.program_id(1)
+
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_d = tl.arange(0, BD)
+    m_t = o_t < T
+    m = m_t[:, None] & (o_d[None, :] < D)
+    # (B*T, H, D) row-major: token stride H*D, head offset i_h*D.
+    off = i_h * D + o_t[:, None] * (H * D) + o_d[None, :]
+
+    b_g = tl.load(g + off, mask=m, other=0.0).to(tl.float32)
+    b_dy = tl.load(dyg + off, mask=m, other=0.0).to(tl.float32)
+    if HAS_BIAS:
+        o_b = i_h * D + o_d
+        b_g = b_g + tl.load(dt_bias + o_b, mask=o_b < H * D, other=0.0).to(tl.float32)
+
+    b_alog = tl.load(A_log + i_h).to(tl.float32)
+    if USE_LOWER_BOUND:
+        b_a = tl.exp(b_alog)
+        b_s = tl.sigmoid(b_a * b_g)
+        b_dg = b_dy * (lower_bound * b_a * b_s * (1.0 - b_s))
+        # dyg/dA_log = dg * z, reduced over the whole block.
+        b_dalog = tl.sum(tl.sum(b_dg * b_g, 1), 0)
+    else:
+        b_a = -tl.exp(b_alog)
+        b_yg = b_a * _softplus(b_g)
+        b_dg = b_dy * (b_a * tl.sigmoid(b_g))
+        # dyg/dA_log = yg; masked lanes carry b_dy == 0 and drop out of the sum.
+        b_dalog = tl.sum(tl.sum(b_dy * b_yg, 1), 0)
+
+    tl.store(dg + off, b_dg.to(dg.dtype.element_ty), mask=m)
+    tl.store(dA + i_t * H + i_h, b_dalog)

--- a/attn_gym/linear/kda/bwd/triton/l2norm_bwd.py
+++ b/attn_gym/linear/kda/bwd/triton/l2norm_bwd.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Backward for L2 normalization.
+#
+# Forward (per row, over the D feature channels):
+#     rstd = 1 / sqrt(sum_d x_d^2 + eps)
+#     y_d  = x_d * rstd
+#
+# Differentiating y w.r.t. x gives the Jacobian
+#     dy_i/dx_j = rstd * delta_ij - rstd^3 * x_i * x_j ,
+# and contracting with the upstream gradient dy, then substituting x = y / rstd,
+# collapses to the row-local rule
+#     dx = rstd * (dy - y * <dy, y>),      <dy, y> = sum_d dy_d * y_d.
+# Only y and rstd (both produced by the forward) are needed -- x is not.
+
+from __future__ import annotations
+
+import triton
+import triton.language as tl
+
+from attn_gym.linear.kda.utils import autotune_cache_kwargs
+
+_WARPS = [1, 2, 4, 8, 16, 32]
+_BT_LIST = [8, 16, 32, 64, 128]
+
+
+@triton.autotune(
+    configs=[triton.Config({}, num_warps=w) for w in _WARPS],
+    key=["D"],
+    **autotune_cache_kwargs,
+)
+@triton.jit
+def l2norm_bwd_kernel1(
+    y,
+    rstd,
+    dy,
+    dx,
+    eps,
+    D,
+    BD: tl.constexpr,
+):
+    # One program per row; the entire feature vector fits in a single [BD] tile.
+    i_t = tl.program_id(0).to(tl.int64)
+    base = i_t * D
+    cols = tl.arange(0, BD)
+    mask = cols < D
+
+    b_y = tl.load(y + base + cols, mask=mask, other=0.0).to(tl.float32)
+    b_dy = tl.load(dy + base + cols, mask=mask, other=0.0).to(tl.float32)
+    b_rstd = tl.load(rstd + i_t).to(tl.float32)
+
+    b_dot = tl.sum(b_dy * b_y)
+    b_dx = b_rstd * (b_dy - b_y * b_dot)
+    tl.store(dx + base + cols, b_dx, mask=mask)
+
+
+@triton.autotune(
+    configs=[triton.Config({"BT": bt}, num_warps=w) for w in [1, 2, 4, 8, 16] for bt in _BT_LIST],
+    key=["D", "NB"],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["T"])
+def l2norm_bwd_kernel(
+    y,
+    rstd,
+    dy,
+    dx,
+    eps,
+    T,
+    D: tl.constexpr,
+    BD: tl.constexpr,
+    NB: tl.constexpr,
+    BT: tl.constexpr,
+):
+    # One program per [BT] block of rows; each row is normalized over [BD].
+    i_t = tl.program_id(0).to(tl.int64)
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_d = tl.arange(0, BD)
+    m_t = o_t < T
+    m_x = m_t[:, None] & (o_d[None, :] < D)
+    off = o_t[:, None] * D + o_d[None, :]
+
+    b_y = tl.load(y + off, mask=m_x, other=0.0).to(tl.float32)
+    b_dy = tl.load(dy + off, mask=m_x, other=0.0).to(tl.float32)
+    b_rstd = tl.load(rstd + o_t, mask=m_t, other=0.0).to(tl.float32)
+
+    b_dot = tl.sum(b_dy * b_y, 1)
+    b_dx = b_rstd[:, None] * (b_dy - b_y * b_dot[:, None])
+    tl.store(dx + off, b_dx.to(dx.dtype.element_ty), mask=m_x)

--- a/attn_gym/linear/kda/fwd/__init__.py
+++ b/attn_gym/linear/kda/fwd/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/attn_gym/linear/kda/fwd/cute/__init__.py
+++ b/attn_gym/linear/kda/fwd/cute/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_inter_solve.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_inter_solve.py
@@ -1,0 +1,155 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# CuTe DSL KDA forward inter-solve stage.
+#
+# This is the isolated K3b+K4b replacement for Triton's
+# chunk_kda_fwd_kernel_inter_solve_fused_forloop. The caller supplies the
+# already-computed diagonal inverse blocks (Akkd); this helper only computes the
+# off-diagonal Aqk blocks and final solved Akk blocks.
+
+from __future__ import annotations
+
+import cutlass
+import torch
+import triton
+from cuda.bindings import driver as cuda_drv
+from cutlass.cute.runtime import from_dlpack
+from attn_gym.linear.kda.utils import (
+    DEFAULT_CHUNK_SIZE,
+    prepare_chunk_indices,
+)
+from attn_gym.linear.kda.fwd.cute.chunk_kda_k3b_offdiag_cutedsl import (
+    ChunkKDAFwdK3bOffdiagCuteDSL,
+)
+from attn_gym.linear.kda.fwd.cute.chunk_kda_k4b_inverse_cutedsl import (
+    ChunkKDAFwdK4bInverseCuteDSL,
+)
+from torch._subclasses.fake_tensor import FakeTensor
+
+
+def _to_cute_tensor(tensor: torch.Tensor, assumed_align: int = 16):
+    return from_dlpack(tensor.detach(), assumed_align=assumed_align)
+
+
+def chunk_kda_fwd_inter_solve_cute(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    gk: torch.Tensor,
+    beta: torch.Tensor,
+    Akkd: torch.Tensor,
+    scale: float,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = DEFAULT_CHUNK_SIZE,
+    chunk_indices: torch.LongTensor | None = None,
+    num_chunks: int | torch.Tensor | None = None,
+    Aqk: torch.Tensor | None = None,
+    Akk: torch.Tensor | None = None,
+    AkkOD: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    del num_chunks
+
+    assert chunk_size == 64, "chunk_kda_fwd_inter_solve_cute requires chunk_size=64"
+    B, T, H, K = k.shape
+    BT = chunk_size
+    BC = 16
+    assert B == 1, f"chunk_kda_fwd_inter_solve_cute requires B=1, got B={B}"
+    assert K == 128, f"chunk_kda_fwd_inter_solve_cute requires K=128, got K={K}"
+    assert Akkd.shape == (B, T, H, BC), (
+        f"Akkd must have shape {(B, T, H, BC)}, got {tuple(Akkd.shape)}"
+    )
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+
+    if Aqk is None:
+        Aqk_flat = torch.empty(B * T, H * BT, device=k.device, dtype=k.dtype)
+        Aqk = Aqk_flat.reshape(B, T, H, BT)
+    else:
+        assert Aqk.shape == (B, T, H, BT), (
+            f"Aqk must have shape {(B, T, H, BT)}, got {tuple(Aqk.shape)}"
+        )
+        Aqk_flat = Aqk.reshape(B * T, H * BT)
+
+    if Akk is None:
+        Akk_flat = torch.empty(B * T, H * BT, device=k.device, dtype=k.dtype)
+        Akk = Akk_flat.reshape(B, T, H, BT)
+    else:
+        assert Akk.shape == (B, T, H, BT), (
+            f"Akk must have shape {(B, T, H, BT)}, got {tuple(Akk.shape)}"
+        )
+        Akk_flat = Akk.reshape(B * T, H * BT)
+
+    if isinstance(k, FakeTensor):
+        return Aqk, Akk
+
+    q_flat = q.reshape(B * T, H * K).contiguous()
+    k_flat = k.reshape(B * T, H * K).contiguous()
+    g_flat = gk.reshape(B * T, H * K).contiguous()
+    beta_flat = beta.reshape(B * T, H).contiguous()
+    akkd_flat = Akkd.reshape(B * T, H * BC).contiguous()
+    if AkkOD is None:
+        akk_od = torch.empty(NT * 6, H * BC * BC, device=k.device, dtype=torch.float32)
+    else:
+        assert AkkOD.shape == (NT * 6, H * BC * BC), (
+            f"AkkOD must have shape {(NT * 6, H * BC * BC)}, got {tuple(AkkOD.shape)}"
+        )
+        akk_od = AkkOD
+
+    m_q = _to_cute_tensor(q_flat)
+    m_k = _to_cute_tensor(k_flat)
+    m_g = _to_cute_tensor(g_flat)
+    m_beta = _to_cute_tensor(beta_flat)
+    m_aqk = _to_cute_tensor(Aqk_flat)
+    m_akk_od = _to_cute_tensor(akk_od)
+    m_akkd = _to_cute_tensor(akkd_flat)
+    m_akk = _to_cute_tensor(Akk_flat)
+
+    m_cu_seqlens = None
+    m_chunk_indices = None
+    if cu_seqlens is not None:
+        assert chunk_indices is not None
+        cu_seqlens_i32 = cu_seqlens.to(torch.int32).contiguous()
+        chunk_indices_i32 = chunk_indices.to(torch.int32).flatten().contiguous()
+        m_cu_seqlens = _to_cute_tensor(cu_seqlens_i32, assumed_align=4)
+        m_chunk_indices = _to_cute_tensor(chunk_indices_i32, assumed_align=4)
+
+    stream = cuda_drv.CUstream(torch.cuda.current_stream().cuda_stream)
+    k3b = ChunkKDAFwdK3bOffdiagCuteDSL(BC=BC, D=K)
+    # The repo's diagonal sub-chunk stage already stores (I - Akkd)^-1. The
+    # standalone prototype passed raw diagonal blocks, so K4b's default mode
+    # performs that diagonal forward substitution internally. Use the
+    # pre-inverted mode here to avoid inverting/sign-flipping Akkd twice.
+    k4b = ChunkKDAFwdK4bInverseCuteDSL(BC=BC, BK=64, fwd_sub_mode="preinverted")
+    k3b(
+        m_q,
+        m_k,
+        m_g,
+        m_beta,
+        m_aqk,
+        m_akk_od,
+        cutlass.Float32(scale),
+        int(H),
+        int(NT),
+        stream,
+        cu_seqlens=m_cu_seqlens,
+        chunk_indices=m_chunk_indices,
+    )
+    k4b(
+        m_akk_od,
+        m_akkd,
+        m_akk,
+        int(H),
+        int(NT),
+        stream,
+        cu_seqlens=m_cu_seqlens,
+        chunk_indices=m_chunk_indices,
+    )
+    return Aqk, Akk
+
+
+__all__ = ["chunk_kda_fwd_inter_solve_cute"]

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_intra.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_intra.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# CuTe DSL KDA forward intra-chunk path.
+#
+# This wrapper keeps the full forward-intra pipeline and delegates the
+# inter-solve stage to the isolated K3b+K4b CuTe helper.
+
+from __future__ import annotations
+
+import torch
+import triton
+from attn_gym.linear.kda.utils import (
+    DEFAULT_CHUNK_SIZE,
+    IS_GATHER_SUPPORTED,
+    prepare_chunk_indices,
+)
+from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd_inter_solve import (
+    chunk_kda_fwd_inter_solve_cute,
+)
+from attn_gym.linear.kda.fwd.triton.chunk_kda_fwd_intra_sub_chunk_forloop import (
+    chunk_kda_fwd_kernel_intra_sub_chunk_forloop,
+)
+from attn_gym.linear.kda.fwd.cute.recompute_w_u_fwd import recompute_w_u_fwd
+from torch._subclasses.fake_tensor import FakeTensor
+
+
+def chunk_kda_fwd_intra(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gk: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = DEFAULT_CHUNK_SIZE,
+    chunk_indices: torch.LongTensor | None = None,
+    num_seqs: int | None = None,
+    num_chunks: int | torch.Tensor | None = None,
+    safe_gate: bool = False,
+    causal_gate_normref: bool = False,
+    disable_recompute: bool = False,
+    tf32x3_in_chunk_intra: bool = True,
+    max_num_grid: int | None = None,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor | None,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    del num_seqs
+    del tf32x3_in_chunk_intra
+
+    assert safe_gate, "chunk_kda_fwd_intra CuTe path requires safe_gate=True"
+    assert chunk_size == 64, "chunk_kda_fwd_intra CuTe path requires chunk_size=64"
+
+    if max_num_grid is None:
+        max_num_grid = torch.cuda.get_device_properties(k.device).multi_processor_count
+    if num_chunks is not None and not isinstance(num_chunks, torch.Tensor):
+        num_chunks = torch.tensor(num_chunks, dtype=torch.int64, device=k.device)
+
+    B, T, H, K = k.shape
+    _, _, _, V = v.shape
+    BT = chunk_size
+    BC = 16
+    BK = triton.next_power_of_2(K)
+    NC = triton.cdiv(BT, BC)
+    assert B == 1, f"chunk_kda_fwd_intra CuTe path requires B=1, got B={B}"
+    assert K == 128, f"chunk_kda_fwd_intra CuTe path requires K=128, got K={K}"
+    assert V == 128, f"chunk_kda_fwd_intra CuTe path requires V=128, got V={V}"
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    grid_NT = min(max_num_grid, NT)
+
+    Aqk_flat = torch.empty(B * T, H * BT, device=k.device, dtype=k.dtype)
+    Aqk = Aqk_flat.reshape(B, T, H, BT)
+    Akkd_flat = torch.empty(B * T, H * BC, device=k.device, dtype=torch.float32)
+    Akkd = Akkd_flat.reshape(B, T, H, BC)
+
+    if not isinstance(k, FakeTensor):
+        chunk_kda_fwd_kernel_intra_sub_chunk_forloop[(grid_NT, NC, B * H)](
+            q=q,
+            k=k,
+            g=gk,
+            beta=beta,
+            Aqk=Aqk,
+            Akk=Akkd,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            num_chunks=num_chunks,
+            T=T,
+            H=H,
+            K=K,
+            BT=BT,
+            BC=BC,
+            BK=BK,
+            USE_GATHER=IS_GATHER_SUPPORTED,
+            CAUSAL_NORMREF=causal_gate_normref,
+            GRID_NT=grid_NT,
+            MAX_NT=NT,
+        )
+
+    Akk = torch.empty(B, T, H, BT, device=k.device, dtype=k.dtype)
+    Aqk, Akk = chunk_kda_fwd_inter_solve_cute(
+        q=q,
+        k=k,
+        gk=gk,
+        beta=beta,
+        Akkd=Akkd,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_size=BT,
+        chunk_indices=chunk_indices,
+        num_chunks=num_chunks,
+        Aqk=Aqk,
+        Akk=Akk,
+    )
+
+    w, u, qg, kg = recompute_w_u_fwd(
+        k=k,
+        v=v,
+        beta=beta,
+        A=Akk,
+        q=q if disable_recompute else None,
+        gk=gk,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        num_chunks=num_chunks,
+    )
+    return w, u, qg, kg, Aqk, Akk
+
+
+__all__ = ["chunk_kda_fwd_intra"]

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_k3b_offdiag_cutedsl.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_k3b_offdiag_cutedsl.py
@@ -1,0 +1,368 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+CuTe DSL K3b: Off-diagonal gated matmul, one pair per CTA, 4 warps.
+
+Matches NV C++ kernel_3b_offdiag_matmul.cu architecture:
+  Grid: (total_chunks * 6, H, 1) — one CTA per (pair, head)
+  128 threads (4 warps):
+      All warps: Phase 1 — fused gating into SMEM
+      Warp 0:    Phase 2 — Aqk = sQg @ sKn^T  (MMA)
+      Warp 1:    Phase 2 — Akk = sKp @ sKn^T  (MMA)
+      All warps: Phase 3 — scaled stores to GMEM
+
+Single-kernel varlen (no is_partial split, no bulk+cleanup dispatch):
+  Non-varlen: constexpr-unrolled gating loops, zero guard overhead.
+  Varlen: predicated constexpr-offset loads (R2P-style).
+          Uses ti_row + _r (constexpr offset) inside predicated blocks:
+          loads only execute when _r < actual_row. Invalid loads are
+          suppressed at the PTX level (@p LDG) — the address is never
+          accessed, so no padding required. Variables default to safe
+          values (0 for Q/K, g_ref for G) ensuring exp2(0)=1 and 0*1=0.
+"""
+
+from typing import Optional, Type
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.nvgpu import cpasync, warp
+
+
+class ChunkKDAFwdK3bOffdiagCuteDSL:
+    NC = 4
+    WARP_SIZE = 32
+
+    def __init__(self, BC: int = 16, D: int = 128):
+        self.BC = BC
+        self.D = D
+        self.BT = self.NC * BC
+        self.num_threads = 128
+        self.mma_inst_shape = (16, 8, 16)
+        self.atom_layout_mnk = (1, 1, 1)
+
+    @cute.jit
+    def __call__(
+        self,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mG: cute.Tensor,
+        mBeta: cute.Tensor,
+        mAqk: cute.Tensor,
+        mAkkOD: cute.Tensor,
+        scale: cutlass.Float32,
+        H: int,
+        total_chunks: int,
+        stream,
+        cu_seqlens: Optional[cute.Tensor] = None,
+        chunk_indices: Optional[cute.Tensor] = None,
+    ):
+        self._dtype: Type[cutlass.Numeric] = mQ.element_type
+
+        if cutlass.const_expr(cu_seqlens is not None):
+            NT = cute.size(chunk_indices, mode=[0]) // 2
+            num_pairs = NT * 6
+        else:
+            num_pairs = total_chunks * 6
+        grid = (num_pairs, H, 1)
+
+        smem_k_block_size = 64
+        swizzle_bits = 3
+        sQK_layout_atom = cute.make_composed_layout(
+            cute.make_swizzle(swizzle_bits, 3, 3),
+            0,
+            cute.make_layout((8, smem_k_block_size), stride=(smem_k_block_size, 1)),
+        )
+        sGated_layout = cute.tile_to_shape(sQK_layout_atom, (self.BC, self.D), (0, 1))
+        sGref_layout = cute.make_layout((self.D,), stride=(1,))
+        sBeta_layout = cute.make_layout((self.BC,), stride=(1,))
+
+        @cute.struct
+        class SharedStorage:
+            sQg: cute.struct.Align[
+                cute.struct.MemRange[self._dtype, cute.cosize(sGated_layout)], 128
+            ]
+            sKp: cute.struct.Align[
+                cute.struct.MemRange[self._dtype, cute.cosize(sGated_layout)], 128
+            ]
+            sKn: cute.struct.Align[
+                cute.struct.MemRange[self._dtype, cute.cosize(sGated_layout)], 128
+            ]
+            sGref: cute.struct.Align[cute.struct.MemRange[cutlass.Float32, self.D], 128]
+            sBeta: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, self.BC], 128
+            ]
+
+        tiled_mma = cute.make_tiled_mma(
+            warp.MmaF16BF16Op(self._dtype, cutlass.Float32, self.mma_inst_shape),
+            self.atom_layout_mnk,
+            permutation_mnk=(
+                self.atom_layout_mnk[0] * self.mma_inst_shape[0],
+                self.atom_layout_mnk[1] * self.mma_inst_shape[1] * 2,
+                self.mma_inst_shape[2],
+            ),
+        )
+
+        smem_copy_A = cute.make_tiled_copy_A(
+            cute.make_copy_atom(
+                warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4), self._dtype
+            ),
+            tiled_mma,
+        )
+        smem_copy_B = cute.make_tiled_copy_B(
+            cute.make_copy_atom(
+                warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4), self._dtype
+            ),
+            tiled_mma,
+        )
+
+        self.kernel(
+            mQ,
+            mK,
+            mG,
+            mBeta,
+            mAqk,
+            mAkkOD,
+            scale,
+            cu_seqlens,
+            chunk_indices,
+            sGated_layout,
+            sGref_layout,
+            sBeta_layout,
+            smem_copy_A,
+            smem_copy_B,
+            tiled_mma,
+            SharedStorage,
+        ).launch(grid=grid, block=[self.num_threads, 1, 1], stream=stream)
+
+    @cute.kernel
+    def kernel(
+        self,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mG: cute.Tensor,
+        mBeta: cute.Tensor,
+        mAqk: cute.Tensor,
+        mAkkOD: cute.Tensor,
+        scale: cutlass.Float32,
+        cu_seqlens,
+        chunk_indices,
+        sGated_layout: cute.ComposedLayout,
+        sGref_layout: cute.Layout,
+        sBeta_layout: cute.Layout,
+        smem_copy_A: cute.TiledCopy,
+        smem_copy_B: cute.TiledCopy,
+        tiled_mma: cute.TiledMma,
+        SharedStorage: cutlass.Constexpr,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        block_idx, head_idx, _ = cute.arch.block_idx()
+        warp_idx = tidx // self.WARP_SIZE
+        lane_idx = tidx % self.WARP_SIZE
+
+        # ── Decompose block_idx into chunk and pair ──
+        chunk_idx = block_idx // 6
+        pair_idx = block_idx % 6
+
+        ri = 1
+        if pair_idx >= 1:
+            ri = 2
+        if pair_idx >= 3:
+            ri = 3
+        ci = pair_idx - (ri * (ri - 1)) // 2
+
+        # ── Varlen resolution ──
+        if cutlass.const_expr(cu_seqlens is not None):
+            i_n = chunk_indices[chunk_idx * 2]
+            i_t = chunk_indices[chunk_idx * 2 + 1]
+            bos = cu_seqlens[i_n]
+            eos = cu_seqlens[i_n + 1]
+            chunk_base = bos + i_t * self.BT
+        else:
+            chunk_base = chunk_idx * self.BT
+            eos = cute.size(mQ, mode=[0])
+
+        ti_row = chunk_base + ri * self.BC
+        ti_col = chunk_base + ci * self.BC
+        h_offset = head_idx * self.D
+
+        # ── Shared memory ──
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+        sQg = storage.sQg.get_tensor(sGated_layout)
+        sKp = storage.sKp.get_tensor(sGated_layout)
+        sKn = storage.sKn.get_tensor(sGated_layout)
+        sGref = storage.sGref.get_tensor(sGref_layout)
+        sBeta = storage.sBeta.get_tensor(sBeta_layout)
+
+        # ══════════════════════════════════════════════════════════
+        # Phase 1: Gating into SMEM
+        # ══════════════════════════════════════════════════════════
+        if cutlass.const_expr(cu_seqlens is not None):
+            col = tidx
+            h_col = h_offset + col
+            if chunk_base + self.BT <= eos:
+                if tidx < self.D:
+                    sGref[tidx] = mG[ti_row, h_col]
+                if tidx < self.BC:
+                    sBeta[tidx] = cutlass.Float32(mBeta[ti_row + tidx, head_idx])
+                for _r in cutlass.range_constexpr(self.BC):
+                    g_ref_val = sGref[col]
+                    q_val = cutlass.Float32(mQ[ti_row + _r, h_col])
+                    k_val_r = cutlass.Float32(mK[ti_row + _r, h_col])
+                    g_val_r = mG[ti_row + _r, h_col]
+                    gate_r = cute.math.exp2(g_val_r - g_ref_val, fastmath=True)
+                    sQg[_r, col] = self._dtype(q_val * gate_r)
+                    sKp[_r, col] = self._dtype(k_val_r * gate_r)
+
+                    k_val_c = cutlass.Float32(mK[ti_col + _r, h_col])
+                    g_val_c = mG[ti_col + _r, h_col]
+                    gate_c = cute.math.exp2(g_ref_val - g_val_c, fastmath=True)
+                    sKn[_r, col] = self._dtype(k_val_c * gate_c)
+            else:
+                # ── Varlen tail: predicated constexpr-offset loads (R2P-style) ──
+                actual_row = cutlass.min(self.BC, cutlass.max(eos - ti_row, 0))
+                actual_col = cutlass.min(self.BC, cutlass.max(eos - ti_col, 0))
+                safe_ti_row = cutlass.min(ti_row, cutlass.max(eos - 1, 0))
+
+                if tidx < self.D:
+                    sGref[tidx] = mG[safe_ti_row, h_col]
+                if tidx < self.BC:
+                    beta_val = cutlass.Float32(0.0)
+                    if tidx < actual_row:
+                        beta_val = cutlass.Float32(mBeta[ti_row + tidx, head_idx])
+                    sBeta[tidx] = beta_val
+
+                for _r in cutlass.range_constexpr(self.BC):
+                    g_ref_val = sGref[col]
+
+                    q_val = cutlass.Float32(0.0)
+                    k_val_r = cutlass.Float32(0.0)
+                    g_val_r = g_ref_val
+                    if _r < actual_row:
+                        q_val = cutlass.Float32(mQ[ti_row + _r, h_col])
+                        k_val_r = cutlass.Float32(mK[ti_row + _r, h_col])
+                        g_val_r = mG[ti_row + _r, h_col]
+                    gate_r = cute.math.exp2(g_val_r - g_ref_val, fastmath=True)
+                    sQg[_r, col] = self._dtype(q_val * gate_r)
+                    sKp[_r, col] = self._dtype(k_val_r * gate_r)
+
+                    k_val_c = cutlass.Float32(0.0)
+                    g_val_c = g_ref_val
+                    if _r < actual_col:
+                        k_val_c = cutlass.Float32(mK[ti_col + _r, h_col])
+                        g_val_c = mG[ti_col + _r, h_col]
+                    gate_c = cute.math.exp2(g_ref_val - g_val_c, fastmath=True)
+                    sKn[_r, col] = self._dtype(k_val_c * gate_c)
+        else:
+            # ── Non-varlen: constexpr-unrolled, zero guards ──
+            if tidx < self.D:
+                sGref[tidx] = mG[ti_row, h_offset + tidx]
+            if tidx < self.BC:
+                sBeta[tidx] = cutlass.Float32(mBeta[ti_row + tidx, head_idx])
+            for _r in cutlass.range_constexpr(self.BC):
+                col = tidx
+                g_ref_val = sGref[col]
+                q_val = cutlass.Float32(mQ[ti_row + _r, h_offset + col])
+                k_val_r = cutlass.Float32(mK[ti_row + _r, h_offset + col])
+                g_val_r = mG[ti_row + _r, h_offset + col]
+                gate_r = cute.math.exp2(g_val_r - g_ref_val, fastmath=True)
+                sQg[_r, col] = self._dtype(q_val * gate_r)
+                sKp[_r, col] = self._dtype(k_val_r * gate_r)
+                k_val_c = cutlass.Float32(mK[ti_col + _r, h_offset + col])
+                g_val_c = mG[ti_col + _r, h_offset + col]
+                gate_c = cute.math.exp2(g_ref_val - g_val_c, fastmath=True)
+                sKn[_r, col] = self._dtype(k_val_c * gate_c)
+
+        cute.arch.barrier(barrier_id=1, number_of_threads=self.num_threads)
+
+        # ══════════════════════════════════════════════════════════
+        # Phase 2: MMA — Warp 0: Aqk = sQg @ sKn^T
+        #                  Warp 1: Akk = sKp @ sKn^T
+        # ══════════════════════════════════════════════════════════
+        thr_mma = tiled_mma.get_slice(lane_idx)
+
+        thrA = smem_copy_A.get_slice(lane_idx)
+        _tCsQg = thrA.partition_S(sQg)
+        _tCsKp = thrA.partition_S(sKp)
+        _tMmaQg = thr_mma.partition_A(sQg)
+        _tMmaKp = thr_mma.partition_A(sKp)
+        tCrQg = thr_mma.make_fragment_A(_tMmaQg)
+        tCrKp = thr_mma.make_fragment_A(_tMmaKp)
+        tCrQgc = thrA.retile(tCrQg)
+        tCrKpc = thrA.retile(tCrKp)
+
+        thrB = smem_copy_B.get_slice(lane_idx)
+        _tCsKn_B = thrB.partition_S(sKn)
+        _tMmaKn = thr_mma.partition_B(sKn)
+        tCrKn = thr_mma.make_fragment_B(_tMmaKn)
+        tCrKnc = thrB.retile(tCrKn)
+
+        acc_shape = thr_mma.partition_shape_C((self.BC, self.BC))
+        acc_Aqk = cute.make_rmem_tensor(acc_shape, cutlass.Float32)
+        acc_Akk = cute.make_rmem_tensor(acc_shape, cutlass.Float32)
+        acc_Aqk.fill(0.0)
+        acc_Akk.fill(0.0)
+
+        num_k_blocks = cute.size(_tCsQg, mode=[2])
+
+        if warp_idx == 0:
+            for kb in cutlass.range_constexpr(num_k_blocks):
+                cute.copy(smem_copy_A, _tCsQg[None, None, kb], tCrQgc[None, None, kb])
+                cute.copy(smem_copy_B, _tCsKn_B[None, None, kb], tCrKnc[None, None, kb])
+                cute.gemm(
+                    tiled_mma,
+                    acc_Aqk,
+                    tCrQg[None, None, kb],
+                    tCrKn[None, None, kb],
+                    acc_Aqk,
+                )
+        elif warp_idx == 1:
+            for kb in cutlass.range_constexpr(num_k_blocks):
+                cute.copy(smem_copy_A, _tCsKp[None, None, kb], tCrKpc[None, None, kb])
+                cute.copy(smem_copy_B, _tCsKn_B[None, None, kb], tCrKnc[None, None, kb])
+                cute.gemm(
+                    tiled_mma,
+                    acc_Akk,
+                    tCrKp[None, None, kb],
+                    tCrKn[None, None, kb],
+                    acc_Akk,
+                )
+
+        # ══════════════════════════════════════════════════════════
+        # Phase 3: Scaled stores to GMEM
+        # ══════════════════════════════════════════════════════════
+        cC = cute.make_identity_tensor((self.BC, self.BC))
+        tCcC = thr_mma.partition_C(cC)
+
+        od_row = chunk_idx * 6 + pair_idx
+
+        if warp_idx == 0:
+            out_dtype = mAqk.element_type
+            for i in cutlass.range_constexpr(cute.size(acc_Aqk)):
+                row = tCcC[i][0]
+                col = tCcC[i][1]
+                if cutlass.const_expr(cu_seqlens is not None):
+                    if chunk_base + self.BT <= eos:
+                        mAqk[ti_row + row, head_idx * self.BT + ci * self.BC + col] = (
+                            out_dtype(acc_Aqk[i] * scale)
+                        )
+                    elif ti_row + row < eos:
+                        mAqk[ti_row + row, head_idx * self.BT + ci * self.BC + col] = (
+                            out_dtype(acc_Aqk[i] * scale)
+                        )
+                else:
+                    mAqk[ti_row + row, head_idx * self.BT + ci * self.BC + col] = (
+                        out_dtype(acc_Aqk[i] * scale)
+                    )
+        elif warp_idx == 1:
+            for i in cutlass.range_constexpr(cute.size(acc_Akk)):
+                row = tCcC[i][0]
+                col = tCcC[i][1]
+                beta_val = sBeta[row]
+                mAkkOD[od_row, head_idx * self.BC * self.BC + row * self.BC + col] = (
+                    acc_Akk[i] * beta_val
+                )

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_k4b_inverse_cutedsl.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_k4b_inverse_cutedsl.py
@@ -1,0 +1,645 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+CuTe DSL K4b: 4×4 block lower-triangular matrix inverse.
+
+Grid: (total_chunks, H, 1) — one CTA per (chunk, head).
+128 threads (4 warps):
+    Phase 1: Per-warp OD register load + parallel forward substitution
+    Phase 2a: Warps 0-2 parallel Schur L1 (Ai10, Ai21, Ai32), Warp 3 stores diags
+    Phase 2b+c: Warp 0 interleaved Schur L2+L3 with B-fragment reuse
+    Phase 2b: Warp 1 Schur L2 (Ai31) with B-fragment reuse
+
+Input:  mAkkOD (fp32, off-diag from K3b), mAkkd (fp32, diagonal Akk blocks)
+Output: mAkk (bf16, full 4×4 block inverse)
+
+Optimizations:
+  - 4 warps (128 threads) with parallel Schur complement (9-GEMM critical path vs 16)
+  - OD blocks in registers (zero-latency staging reads, 6KB SMEM saved)
+  - B-fragment reuse: GEMMs 2→3→6' share B=sAi0_T, GEMMs 4→7 share B=Ai10
+  - Parallel forward substitution (4 blocks simultaneously)
+  - Overlapped diagonal stores (warp 3 stores while warps 0-2 compute)
+  - Flat padded SMEM layout (no swizzle) for reduced address computation
+"""
+
+from typing import Optional, Type
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.nvgpu import warp
+
+
+class ChunkKDAFwdK4bInverseCuteDSL:
+    NC = 4
+    WARP_SIZE = 32
+
+    def __init__(
+        self,
+        BC: int = 16,
+        BK: int = 64,
+        fwd_sub_mode: str = "cute_recurrence",
+        skip_fwd_sub: bool = False,
+    ):
+        self.BC = BC
+        self.BK = BK
+        self.BT = self.NC * BC
+        self.num_threads = 128
+        self.mma_inst_shape = (16, 8, 16)
+        self.atom_layout_mnk = (1, 1, 1)
+        self.fwd_sub_mode = "skip" if skip_fwd_sub else fwd_sub_mode
+
+    @cute.jit
+    def _fwd_sub_block(self, mAkkd, sAi, block_start, tidx, akkd_col_off, valid_rows):
+        """Forward substitution: inverse of (I - L) for a single BC×BC diagonal block."""
+        if cutlass.const_expr(self.fwd_sub_mode == "preinverted"):
+            for k in cutlass.range_constexpr(self.BC * self.BC // 32):
+                linear_idx = tidx + k * 32
+                row = linear_idx // self.BC
+                col = linear_idx % self.BC
+                if row < valid_rows:
+                    sAi[row, col] = self._sai_dtype(
+                        mAkkd[block_start + row, akkd_col_off + col]
+                    )
+                else:
+                    sAi[row, col] = self._sai_dtype(0.0)
+            cute.arch.sync_warp()
+            return
+
+        for k in cutlass.range_constexpr(self.BC * self.BC // 32):
+            linear_idx = tidx + k * 32
+            row = linear_idx // self.BC
+            col = linear_idx % self.BC
+            if row < valid_rows:
+                val = mAkkd[block_start + row, akkd_col_off + col]
+                if row > col:
+                    sAi[row, col] = -val
+                else:
+                    sAi[row, col] = 0.0
+            else:
+                sAi[row, col] = 0.0
+        cute.arch.sync_warp()
+
+        if cutlass.const_expr(self.fwd_sub_mode == "cute_recurrence"):
+            for i in cutlass.range_constexpr(2, self.BC):
+                if tidx < self.BC:
+                    my_col = tidx
+                    acc = sAi[i, my_col]
+                    for j in cutlass.range_constexpr(i):
+                        acc = acc + sAi[i, j] * sAi[j, my_col]
+                    sAi[i, my_col] = acc
+                cute.arch.sync_warp()
+
+        if tidx < self.BC:
+            sAi[tidx, tidx] = sAi[tidx, tidx] + 1.0
+        cute.arch.sync_warp()
+
+    @cute.jit
+    def __call__(
+        self,
+        mAkkOD: cute.Tensor,
+        mAkkd: cute.Tensor,
+        mAkk: cute.Tensor,
+        H: int,
+        total_chunks: int,
+        stream,
+        cu_seqlens: Optional[cute.Tensor] = None,
+        chunk_indices: Optional[cute.Tensor] = None,
+    ):
+        self._dtype: Type[cutlass.Numeric] = mAkk.element_type
+        self._sai_dtype: Type[cutlass.Numeric] = cutlass.Float32
+        self._sai_stride = self.BC + 1
+        if cutlass.const_expr(self.fwd_sub_mode == "preinverted"):
+            self._sai_dtype = self._dtype
+            self._sai_stride = self.BC
+
+        if cutlass.const_expr(cu_seqlens is not None):
+            NT = cute.size(chunk_indices, mode=[0]) // 2
+            grid = (NT, H, 1)
+        else:
+            grid = (total_chunks, H, 1)
+
+        sSchurA_layout = cute.make_layout((self.BC, self.BC), stride=(self.BC + 8, 1))
+        sAi_layout = cute.make_layout((self.BC, self.BC), stride=(self._sai_stride, 1))
+        sSchurB_layout = cute.make_layout((self.BC, self.BC), stride=(self.BC + 8, 1))
+
+        @cute.struct
+        class SharedStorage:
+            sAi0: cute.struct.Align[
+                cute.struct.MemRange[self._sai_dtype, self.BC * self._sai_stride], 128
+            ]
+            sAi1: cute.struct.Align[
+                cute.struct.MemRange[self._sai_dtype, self.BC * self._sai_stride], 128
+            ]
+            sAi2: cute.struct.Align[
+                cute.struct.MemRange[self._sai_dtype, self.BC * self._sai_stride], 128
+            ]
+            sAi3: cute.struct.Align[
+                cute.struct.MemRange[self._sai_dtype, self.BC * self._sai_stride], 128
+            ]
+            sSchurA0: cute.struct.Align[
+                cute.struct.MemRange[self._dtype, self.BC * (self.BC + 8)], 128
+            ]
+            sSchurB0: cute.struct.Align[
+                cute.struct.MemRange[self._dtype, self.BC * (self.BC + 8)], 128
+            ]
+            sSchurA1: cute.struct.Align[
+                cute.struct.MemRange[self._dtype, self.BC * (self.BC + 8)], 128
+            ]
+            sSchurB1: cute.struct.Align[
+                cute.struct.MemRange[self._dtype, self.BC * (self.BC + 8)], 128
+            ]
+            sSchurA2: cute.struct.Align[
+                cute.struct.MemRange[self._dtype, self.BC * (self.BC + 8)], 128
+            ]
+            sSchurB2: cute.struct.Align[
+                cute.struct.MemRange[self._dtype, self.BC * (self.BC + 8)], 128
+            ]
+
+        tiled_mma = cute.make_tiled_mma(
+            warp.MmaF16BF16Op(self._dtype, cutlass.Float32, self.mma_inst_shape),
+            self.atom_layout_mnk,
+            permutation_mnk=(
+                self.atom_layout_mnk[0] * self.mma_inst_shape[0],
+                self.atom_layout_mnk[1] * self.mma_inst_shape[1] * 2,
+                self.mma_inst_shape[2],
+            ),
+        )
+
+        smem_copy_A = cute.make_tiled_copy_A(
+            cute.make_copy_atom(
+                warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4), self._dtype
+            ),
+            tiled_mma,
+        )
+        smem_copy_B = cute.make_tiled_copy_B(
+            cute.make_copy_atom(
+                warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4), self._dtype
+            ),
+            tiled_mma,
+        )
+
+        self.kernel(
+            mAkkOD,
+            mAkkd,
+            mAkk,
+            cu_seqlens,
+            chunk_indices,
+            sSchurA_layout,
+            sAi_layout,
+            sSchurB_layout,
+            smem_copy_A,
+            smem_copy_B,
+            tiled_mma,
+            SharedStorage,
+        ).launch(grid=grid, block=[self.num_threads, 1, 1], stream=stream)
+
+    @cute.kernel
+    def kernel(
+        self,
+        mAkkOD: cute.Tensor,
+        mAkkd: cute.Tensor,
+        mAkk: cute.Tensor,
+        cu_seqlens,
+        chunk_indices,
+        sSchurA_layout: cute.Layout,
+        sAi_layout: cute.Layout,
+        sSchurB_layout: cute.Layout,
+        smem_copy_A: cute.TiledCopy,
+        smem_copy_B: cute.TiledCopy,
+        tiled_mma: cute.TiledMma,
+        SharedStorage: cutlass.Constexpr,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        chunk_idx, head_idx, _ = cute.arch.block_idx()
+        warp_idx = tidx // self.WARP_SIZE
+        lane_idx = tidx % self.WARP_SIZE
+
+        if cutlass.const_expr(cu_seqlens is not None):
+            i_n = chunk_indices[chunk_idx * 2]
+            i_t = chunk_indices[chunk_idx * 2 + 1]
+            bos = cu_seqlens[i_n]
+            eos = cu_seqlens[i_n + 1]
+            chunk_base = bos + i_t * self.BT
+        else:
+            chunk_base = chunk_idx * self.BT
+            eos = cute.size(mAkk, mode=[0])
+
+        i_tc0 = chunk_base
+        i_tc1 = chunk_base + self.BC
+        i_tc2 = chunk_base + 2 * self.BC
+        i_tc3 = chunk_base + 3 * self.BC
+
+        h_akkd_col = head_idx * self.BC
+        h_akk_col = head_idx * self.BT
+
+        vr0 = cutlass.min(cutlass.max(eos - i_tc0, 0), self.BC)
+        vr1 = cutlass.min(cutlass.max(eos - i_tc1, 0), self.BC)
+        vr2 = cutlass.min(cutlass.max(eos - i_tc2, 0), self.BC)
+        vr3 = cutlass.min(cutlass.max(eos - i_tc3, 0), self.BC)
+
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+        sAi0 = storage.sAi0.get_tensor(sAi_layout)
+        sAi1 = storage.sAi1.get_tensor(sAi_layout)
+        sAi2 = storage.sAi2.get_tensor(sAi_layout)
+        sAi3 = storage.sAi3.get_tensor(sAi_layout)
+        sSchurA0 = storage.sSchurA0.get_tensor(sSchurA_layout)
+        sSchurB0 = storage.sSchurB0.get_tensor(sSchurB_layout)
+        sSchurA1 = storage.sSchurA1.get_tensor(sSchurA_layout)
+        sSchurB1 = storage.sSchurB1.get_tensor(sSchurB_layout)
+        sSchurA2 = storage.sSchurA2.get_tensor(sSchurA_layout)
+        sSchurB2 = storage.sSchurB2.get_tensor(sSchurB_layout)
+
+        thr_mma = tiled_mma.get_slice(lane_idx)
+        thrA = smem_copy_A.get_slice(lane_idx)
+        thrB = smem_copy_B.get_slice(lane_idx)
+
+        tCsA0 = thrA.partition_S(sSchurA0)
+        tCsB0 = thrB.partition_S(sSchurB0)
+        tCsA1 = thrA.partition_S(sSchurA1)
+        tCsB1 = thrB.partition_S(sSchurB1)
+        tCsA2 = thrA.partition_S(sSchurA2)
+        tCsB2 = thrB.partition_S(sSchurB2)
+
+        _tA = thr_mma.partition_A(sSchurA0)
+        _tB = thr_mma.partition_B(sSchurB0)
+        tCrA = thr_mma.make_fragment_A(_tA)
+        tCrB = thr_mma.make_fragment_B(_tB)
+        tCrAc = thrA.retile(tCrA)
+        tCrBc = thrB.retile(tCrB)
+
+        acc_shape = thr_mma.partition_shape_C((self.BC, self.BC))
+        cC = cute.make_identity_tensor((self.BC, self.BC))
+        tCcC = thr_mma.partition_C(cC)
+
+        acc_tmp = cute.make_rmem_tensor(acc_shape, cutlass.Float32)
+        acc_res1 = cute.make_rmem_tensor(acc_shape, cutlass.Float32)
+        acc_res2 = cute.make_rmem_tensor(acc_shape, cutlass.Float32)
+        acc_res3 = cute.make_rmem_tensor(acc_shape, cutlass.Float32)
+        acc_od0 = cute.make_rmem_tensor(acc_shape, cutlass.Float32)
+        acc_od1 = cute.make_rmem_tensor(acc_shape, cutlass.Float32)
+        acc_od2 = cute.make_rmem_tensor(acc_shape, cutlass.Float32)
+        acc_od3 = cute.make_rmem_tensor(acc_shape, cutlass.Float32)
+        acc_od4 = cute.make_rmem_tensor(acc_shape, cutlass.Float32)
+        acc_od5 = cute.make_rmem_tensor(acc_shape, cutlass.Float32)
+
+        # ══════════════════════════════════════════════════════════
+        # PHASE 1: Per-warp OD loading + parallel forward substitution
+        # ══════════════════════════════════════════════════════════
+        od_base_row = chunk_idx * 6
+
+        if warp_idx == 0:
+            for i in cutlass.range_constexpr(cute.size(acc_od0)):
+                row = tCcC[i][0]
+                col = tCcC[i][1]
+                rc = head_idx * self.BC * self.BC + row * self.BC + col
+                acc_od0[i] = mAkkOD[od_base_row + 0, rc]
+                acc_od1[i] = mAkkOD[od_base_row + 1, rc]
+                acc_od2[i] = mAkkOD[od_base_row + 2, rc]
+                acc_od3[i] = mAkkOD[od_base_row + 3, rc]
+                acc_od4[i] = mAkkOD[od_base_row + 4, rc]
+                acc_od5[i] = mAkkOD[od_base_row + 5, rc]
+            self._fwd_sub_block(mAkkd, sAi0, i_tc0, lane_idx, h_akkd_col, vr0)
+
+        if warp_idx == 1:
+            for i in cutlass.range_constexpr(cute.size(acc_od0)):
+                row = tCcC[i][0]
+                col = tCcC[i][1]
+                rc = head_idx * self.BC * self.BC + row * self.BC + col
+                acc_od2[i] = mAkkOD[od_base_row + 2, rc]
+                acc_od4[i] = mAkkOD[od_base_row + 4, rc]
+                acc_od5[i] = mAkkOD[od_base_row + 5, rc]
+            self._fwd_sub_block(mAkkd, sAi1, i_tc1, lane_idx, h_akkd_col, vr1)
+
+        if warp_idx == 2:
+            for i in cutlass.range_constexpr(cute.size(acc_od0)):
+                row = tCcC[i][0]
+                col = tCcC[i][1]
+                rc = head_idx * self.BC * self.BC + row * self.BC + col
+                acc_od5[i] = mAkkOD[od_base_row + 5, rc]
+            self._fwd_sub_block(mAkkd, sAi2, i_tc2, lane_idx, h_akkd_col, vr2)
+
+        if warp_idx == 3:
+            self._fwd_sub_block(mAkkd, sAi3, i_tc3, lane_idx, h_akkd_col, vr3)
+
+        cute.arch.barrier(barrier_id=0, number_of_threads=128)
+
+        # ══════════════════════════════════════════════════════════
+        # PHASE 2: Parallel Schur Complement + Overlapped Stores
+        # ══════════════════════════════════════════════════════════
+
+        # ── WARP 0: 9 GEMMs (reordered for B-fragment reuse) ──
+        if warp_idx == 0:
+            # GEMM 1: tmp = Ai11 @ Akk10
+            for k in cutlass.range_constexpr(cute.size(acc_tmp) // 2):
+                c0 = tCcC[k * 2]
+                c1 = tCcC[k * 2 + 1]
+                sSchurA0[c0[0], c0[1]] = self._dtype(sAi1[c0[0], c0[1]])
+                sSchurA0[c1[0], c1[1]] = self._dtype(sAi1[c1[0], c1[1]])
+                sSchurB0[c0[1], c0[0]] = self._dtype(acc_od0[k * 2])
+                sSchurB0[c1[1], c1[0]] = self._dtype(acc_od0[k * 2 + 1])
+            cute.arch.sync_warp()
+            cute.copy(smem_copy_A, tCsA0[None, None, 0], tCrAc[None, None, 0])
+            cute.copy(smem_copy_B, tCsB0[None, None, 0], tCrBc[None, None, 0])
+            acc_tmp.fill(0.0)
+            cute.gemm(
+                tiled_mma, acc_tmp, tCrA[None, None, 0], tCrB[None, None, 0], acc_tmp
+            )
+
+            # GEMM 2: Ai10 = -(tmp @ Ai00)  [loads B=sAi0_T]
+            for k in cutlass.range_constexpr(cute.size(acc_tmp) // 2):
+                c0 = tCcC[k * 2]
+                c1 = tCcC[k * 2 + 1]
+                sSchurA0[c0[0], c0[1]] = self._dtype(acc_tmp[k * 2])
+                sSchurA0[c1[0], c1[1]] = self._dtype(acc_tmp[k * 2 + 1])
+                sSchurB0[c0[0], c0[1]] = self._dtype(sAi0[c0[1], c0[0]])
+                sSchurB0[c1[0], c1[1]] = self._dtype(sAi0[c1[1], c1[0]])
+            cute.arch.sync_warp()
+            cute.copy(smem_copy_A, tCsA0[None, None, 0], tCrAc[None, None, 0])
+            cute.copy(smem_copy_B, tCsB0[None, None, 0], tCrBc[None, None, 0])
+            acc_res1.fill(0.0)
+            cute.gemm(
+                tiled_mma, acc_res1, tCrA[None, None, 0], tCrB[None, None, 0], acc_res1
+            )
+            for i in cutlass.range_constexpr(cute.size(acc_res1)):
+                acc_res1[i] = -acc_res1[i]
+
+            # GEMM 3: tmp = Akk20 @ Ai00  [REUSE B]
+            for i in cutlass.range_constexpr(cute.size(acc_tmp)):
+                coord = tCcC[i]
+                sSchurA0[coord[0], coord[1]] = self._dtype(acc_od1[i])
+            cute.arch.sync_warp()
+            cute.copy(smem_copy_A, tCsA0[None, None, 0], tCrAc[None, None, 0])
+            acc_tmp.fill(0.0)
+            cute.gemm(
+                tiled_mma, acc_tmp, tCrA[None, None, 0], tCrB[None, None, 0], acc_tmp
+            )
+
+            # GEMM 6': tmp_2c = Akk30 @ Ai00  [REUSE B]
+            for i in cutlass.range_constexpr(cute.size(acc_res3)):
+                coord = tCcC[i]
+                sSchurA0[coord[0], coord[1]] = self._dtype(acc_od3[i])
+            cute.arch.sync_warp()
+            cute.copy(smem_copy_A, tCsA0[None, None, 0], tCrAc[None, None, 0])
+            acc_res3.fill(0.0)
+            cute.gemm(
+                tiled_mma, acc_res3, tCrA[None, None, 0], tCrB[None, None, 0], acc_res3
+            )
+
+            # GEMM 4: tmp += Akk21 @ Ai10  [loads B=Ai10, paired A stores]
+            for k in cutlass.range_constexpr(cute.size(acc_tmp) // 2):
+                c0 = tCcC[k * 2]
+                c1 = tCcC[k * 2 + 1]
+                sSchurA0[c0[0], c0[1]] = self._dtype(acc_od2[k * 2])
+                sSchurA0[c1[0], c1[1]] = self._dtype(acc_od2[k * 2 + 1])
+                sSchurB0[c0[1], c0[0]] = self._dtype(acc_res1[k * 2])
+                sSchurB0[c1[1], c1[0]] = self._dtype(acc_res1[k * 2 + 1])
+            cute.arch.sync_warp()
+            cute.copy(smem_copy_A, tCsA0[None, None, 0], tCrAc[None, None, 0])
+            cute.copy(smem_copy_B, tCsB0[None, None, 0], tCrBc[None, None, 0])
+            cute.gemm(
+                tiled_mma, acc_tmp, tCrA[None, None, 0], tCrB[None, None, 0], acc_tmp
+            )
+
+            # GEMM 7: tmp_2c += Akk31 @ Ai10  [REUSE B]
+            for i in cutlass.range_constexpr(cute.size(acc_res3)):
+                coord = tCcC[i]
+                sSchurA0[coord[0], coord[1]] = self._dtype(acc_od4[i])
+            cute.arch.sync_warp()
+            cute.copy(smem_copy_A, tCsA0[None, None, 0], tCrAc[None, None, 0])
+            cute.gemm(
+                tiled_mma, acc_res3, tCrA[None, None, 0], tCrB[None, None, 0], acc_res3
+            )
+
+            # GEMM 5: Ai20 = -(Ai22 @ tmp)
+            for k in cutlass.range_constexpr(cute.size(acc_tmp) // 2):
+                c0 = tCcC[k * 2]
+                c1 = tCcC[k * 2 + 1]
+                sSchurA0[c0[0], c0[1]] = self._dtype(sAi2[c0[0], c0[1]])
+                sSchurA0[c1[0], c1[1]] = self._dtype(sAi2[c1[0], c1[1]])
+                sSchurB0[c0[1], c0[0]] = self._dtype(acc_tmp[k * 2])
+                sSchurB0[c1[1], c1[0]] = self._dtype(acc_tmp[k * 2 + 1])
+            cute.arch.sync_warp()
+            cute.copy(smem_copy_A, tCsA0[None, None, 0], tCrAc[None, None, 0])
+            cute.copy(smem_copy_B, tCsB0[None, None, 0], tCrBc[None, None, 0])
+            acc_res2.fill(0.0)
+            cute.gemm(
+                tiled_mma, acc_res2, tCrA[None, None, 0], tCrB[None, None, 0], acc_res2
+            )
+            for i in cutlass.range_constexpr(cute.size(acc_res2)):
+                acc_res2[i] = -acc_res2[i]
+
+            # GEMM 8: tmp_2c += Akk32 @ Ai20
+            for k in cutlass.range_constexpr(cute.size(acc_res3) // 2):
+                c0 = tCcC[k * 2]
+                c1 = tCcC[k * 2 + 1]
+                sSchurA0[c0[0], c0[1]] = self._dtype(acc_od5[k * 2])
+                sSchurA0[c1[0], c1[1]] = self._dtype(acc_od5[k * 2 + 1])
+                sSchurB0[c0[1], c0[0]] = self._dtype(acc_res2[k * 2])
+                sSchurB0[c1[1], c1[0]] = self._dtype(acc_res2[k * 2 + 1])
+            cute.arch.sync_warp()
+            cute.copy(smem_copy_A, tCsA0[None, None, 0], tCrAc[None, None, 0])
+            cute.copy(smem_copy_B, tCsB0[None, None, 0], tCrBc[None, None, 0])
+            cute.gemm(
+                tiled_mma, acc_res3, tCrA[None, None, 0], tCrB[None, None, 0], acc_res3
+            )
+
+            # GEMM 9: Ai30 = -(Ai33 @ tmp_2c)
+            for k in cutlass.range_constexpr(cute.size(acc_res3) // 2):
+                c0 = tCcC[k * 2]
+                c1 = tCcC[k * 2 + 1]
+                sSchurA0[c0[0], c0[1]] = self._dtype(sAi3[c0[0], c0[1]])
+                sSchurA0[c1[0], c1[1]] = self._dtype(sAi3[c1[0], c1[1]])
+                sSchurB0[c0[1], c0[0]] = self._dtype(acc_res3[k * 2])
+                sSchurB0[c1[1], c1[0]] = self._dtype(acc_res3[k * 2 + 1])
+            cute.arch.sync_warp()
+            cute.copy(smem_copy_A, tCsA0[None, None, 0], tCrAc[None, None, 0])
+            cute.copy(smem_copy_B, tCsB0[None, None, 0], tCrBc[None, None, 0])
+            acc_tmp.fill(0.0)
+            cute.gemm(
+                tiled_mma, acc_tmp, tCrA[None, None, 0], tCrB[None, None, 0], acc_tmp
+            )
+            for i in cutlass.range_constexpr(cute.size(acc_tmp)):
+                acc_tmp[i] = -acc_tmp[i]
+
+            # Store: Ai10, Ai20, Ai30
+            for i in cutlass.range_constexpr(cute.size(acc_res1)):
+                row = tCcC[i][0]
+                col = tCcC[i][1]
+                if i_tc1 + row < eos:
+                    mAkk[i_tc1 + row, h_akk_col + 0 * self.BC + col] = self._dtype(
+                        acc_res1[i]
+                    )
+                if i_tc2 + row < eos:
+                    mAkk[i_tc2 + row, h_akk_col + 0 * self.BC + col] = self._dtype(
+                        acc_res2[i]
+                    )
+                if i_tc3 + row < eos:
+                    mAkk[i_tc3 + row, h_akk_col + 0 * self.BC + col] = self._dtype(
+                        acc_tmp[i]
+                    )
+
+        # ── WARP 1: 5 GEMMs with B-reuse on sAi1_T ──
+        if warp_idx == 1:
+            # GEMM 1: tmp = Ai22 @ Akk21
+            for k in cutlass.range_constexpr(cute.size(acc_tmp) // 2):
+                c0 = tCcC[k * 2]
+                c1 = tCcC[k * 2 + 1]
+                sSchurA1[c0[0], c0[1]] = self._dtype(sAi2[c0[0], c0[1]])
+                sSchurA1[c1[0], c1[1]] = self._dtype(sAi2[c1[0], c1[1]])
+                sSchurB1[c0[1], c0[0]] = self._dtype(acc_od2[k * 2])
+                sSchurB1[c1[1], c1[0]] = self._dtype(acc_od2[k * 2 + 1])
+            cute.arch.sync_warp()
+            cute.copy(smem_copy_A, tCsA1[None, None, 0], tCrAc[None, None, 0])
+            cute.copy(smem_copy_B, tCsB1[None, None, 0], tCrBc[None, None, 0])
+            acc_tmp.fill(0.0)
+            cute.gemm(
+                tiled_mma, acc_tmp, tCrA[None, None, 0], tCrB[None, None, 0], acc_tmp
+            )
+
+            # GEMM 2: Ai21 = -(tmp @ Ai11)  [loads B=sAi1_T]
+            for k in cutlass.range_constexpr(cute.size(acc_tmp) // 2):
+                c0 = tCcC[k * 2]
+                c1 = tCcC[k * 2 + 1]
+                sSchurA1[c0[0], c0[1]] = self._dtype(acc_tmp[k * 2])
+                sSchurA1[c1[0], c1[1]] = self._dtype(acc_tmp[k * 2 + 1])
+                sSchurB1[c0[0], c0[1]] = self._dtype(sAi1[c0[1], c0[0]])
+                sSchurB1[c1[0], c1[1]] = self._dtype(sAi1[c1[1], c1[0]])
+            cute.arch.sync_warp()
+            cute.copy(smem_copy_A, tCsA1[None, None, 0], tCrAc[None, None, 0])
+            cute.copy(smem_copy_B, tCsB1[None, None, 0], tCrBc[None, None, 0])
+            acc_res1.fill(0.0)
+            cute.gemm(
+                tiled_mma, acc_res1, tCrA[None, None, 0], tCrB[None, None, 0], acc_res1
+            )
+            for i in cutlass.range_constexpr(cute.size(acc_res1)):
+                acc_res1[i] = -acc_res1[i]
+
+            # GEMM 3: tmp = Akk31 @ Ai11  [REUSE B]
+            for i in cutlass.range_constexpr(cute.size(acc_tmp)):
+                coord = tCcC[i]
+                sSchurA1[coord[0], coord[1]] = self._dtype(acc_od4[i])
+            cute.arch.sync_warp()
+            cute.copy(smem_copy_A, tCsA1[None, None, 0], tCrAc[None, None, 0])
+            acc_tmp.fill(0.0)
+            cute.gemm(
+                tiled_mma, acc_tmp, tCrA[None, None, 0], tCrB[None, None, 0], acc_tmp
+            )
+
+            # GEMM 4: tmp += Akk32 @ Ai21
+            for k in cutlass.range_constexpr(cute.size(acc_tmp) // 2):
+                c0 = tCcC[k * 2]
+                c1 = tCcC[k * 2 + 1]
+                sSchurA1[c0[0], c0[1]] = self._dtype(acc_od5[k * 2])
+                sSchurA1[c1[0], c1[1]] = self._dtype(acc_od5[k * 2 + 1])
+                sSchurB1[c0[1], c0[0]] = self._dtype(acc_res1[k * 2])
+                sSchurB1[c1[1], c1[0]] = self._dtype(acc_res1[k * 2 + 1])
+            cute.arch.sync_warp()
+            cute.copy(smem_copy_A, tCsA1[None, None, 0], tCrAc[None, None, 0])
+            cute.copy(smem_copy_B, tCsB1[None, None, 0], tCrBc[None, None, 0])
+            cute.gemm(
+                tiled_mma, acc_tmp, tCrA[None, None, 0], tCrB[None, None, 0], acc_tmp
+            )
+
+            # GEMM 5: Ai31 = -(Ai33 @ tmp)
+            for k in cutlass.range_constexpr(cute.size(acc_tmp) // 2):
+                c0 = tCcC[k * 2]
+                c1 = tCcC[k * 2 + 1]
+                sSchurA1[c0[0], c0[1]] = self._dtype(sAi3[c0[0], c0[1]])
+                sSchurA1[c1[0], c1[1]] = self._dtype(sAi3[c1[0], c1[1]])
+                sSchurB1[c0[1], c0[0]] = self._dtype(acc_tmp[k * 2])
+                sSchurB1[c1[1], c1[0]] = self._dtype(acc_tmp[k * 2 + 1])
+            cute.arch.sync_warp()
+            cute.copy(smem_copy_A, tCsA1[None, None, 0], tCrAc[None, None, 0])
+            cute.copy(smem_copy_B, tCsB1[None, None, 0], tCrBc[None, None, 0])
+            acc_res2.fill(0.0)
+            cute.gemm(
+                tiled_mma, acc_res2, tCrA[None, None, 0], tCrB[None, None, 0], acc_res2
+            )
+            for i in cutlass.range_constexpr(cute.size(acc_res2)):
+                acc_res2[i] = -acc_res2[i]
+
+            # Store: Ai21, Ai31
+            for i in cutlass.range_constexpr(cute.size(acc_res1)):
+                row = tCcC[i][0]
+                col = tCcC[i][1]
+                if i_tc2 + row < eos:
+                    mAkk[i_tc2 + row, h_akk_col + 1 * self.BC + col] = self._dtype(
+                        acc_res1[i]
+                    )
+                if i_tc3 + row < eos:
+                    mAkk[i_tc3 + row, h_akk_col + 1 * self.BC + col] = self._dtype(
+                        acc_res2[i]
+                    )
+
+        # ── WARP 2: 2 GEMMs + store Ai32 ──
+        if warp_idx == 2:
+            # GEMM 1: tmp = Ai33 @ Akk32
+            for k in cutlass.range_constexpr(cute.size(acc_tmp) // 2):
+                c0 = tCcC[k * 2]
+                c1 = tCcC[k * 2 + 1]
+                sSchurA2[c0[0], c0[1]] = self._dtype(sAi3[c0[0], c0[1]])
+                sSchurA2[c1[0], c1[1]] = self._dtype(sAi3[c1[0], c1[1]])
+                sSchurB2[c0[1], c0[0]] = self._dtype(acc_od5[k * 2])
+                sSchurB2[c1[1], c1[0]] = self._dtype(acc_od5[k * 2 + 1])
+            cute.arch.sync_warp()
+            cute.copy(smem_copy_A, tCsA2[None, None, 0], tCrAc[None, None, 0])
+            cute.copy(smem_copy_B, tCsB2[None, None, 0], tCrBc[None, None, 0])
+            acc_tmp.fill(0.0)
+            cute.gemm(
+                tiled_mma, acc_tmp, tCrA[None, None, 0], tCrB[None, None, 0], acc_tmp
+            )
+
+            # GEMM 2: Ai32 = -(tmp @ Ai22)
+            for k in cutlass.range_constexpr(cute.size(acc_tmp) // 2):
+                c0 = tCcC[k * 2]
+                c1 = tCcC[k * 2 + 1]
+                sSchurA2[c0[0], c0[1]] = self._dtype(acc_tmp[k * 2])
+                sSchurA2[c1[0], c1[1]] = self._dtype(acc_tmp[k * 2 + 1])
+                sSchurB2[c0[0], c0[1]] = self._dtype(sAi2[c0[1], c0[0]])
+                sSchurB2[c1[0], c1[1]] = self._dtype(sAi2[c1[1], c1[0]])
+            cute.arch.sync_warp()
+            cute.copy(smem_copy_A, tCsA2[None, None, 0], tCrAc[None, None, 0])
+            cute.copy(smem_copy_B, tCsB2[None, None, 0], tCrBc[None, None, 0])
+            acc_res1.fill(0.0)
+            cute.gemm(
+                tiled_mma, acc_res1, tCrA[None, None, 0], tCrB[None, None, 0], acc_res1
+            )
+            for i in cutlass.range_constexpr(cute.size(acc_res1)):
+                acc_res1[i] = -acc_res1[i]
+
+            # Store Ai32
+            for i in cutlass.range_constexpr(cute.size(acc_res1)):
+                row = tCcC[i][0]
+                col = tCcC[i][1]
+                if i_tc3 + row < eos:
+                    mAkk[i_tc3 + row, h_akk_col + 2 * self.BC + col] = self._dtype(
+                        acc_res1[i]
+                    )
+
+        # ── WARP 3: Store all 4 diagonal blocks ──
+        if warp_idx == 3:
+            for k in cutlass.range_constexpr(self.BC * self.BC // 32):
+                linear_idx = lane_idx + k * 32
+                row = linear_idx // self.BC
+                col_idx = linear_idx % self.BC
+                if i_tc0 + row < eos:
+                    mAkk[i_tc0 + row, h_akk_col + 0 * self.BC + col_idx] = self._dtype(
+                        sAi0[row, col_idx]
+                    )
+                if i_tc1 + row < eos:
+                    mAkk[i_tc1 + row, h_akk_col + 1 * self.BC + col_idx] = self._dtype(
+                        sAi1[row, col_idx]
+                    )
+                if i_tc2 + row < eos:
+                    mAkk[i_tc2 + row, h_akk_col + 2 * self.BC + col_idx] = self._dtype(
+                        sAi2[row, col_idx]
+                    )
+                if i_tc3 + row < eos:
+                    mAkk[i_tc3 + row, h_akk_col + 3 * self.BC + col_idx] = self._dtype(
+                        sAi3[row, col_idx]
+                    )

--- a/attn_gym/linear/kda/fwd/cute/recompute_w_u_fwd.py
+++ b/attn_gym/linear/kda/fwd/cute/recompute_w_u_fwd.py
@@ -1,0 +1,1803 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# CuTe DSL implementation of recompute_w_u_fwd (SM100 / Blackwell).
+#
+# This is the narrow production CuTe path for varlen B=1 full chunks:
+# BT=64 and head_dim K=V=128. It recomputes:
+#   w  = A @ (k * beta * exp2(gk))  or A @ (k * beta) when gk is absent
+#   u  = A @ (v * beta)
+#   qg = q * exp2(gk)               when both q and gk are present
+#   kg = k * exp2(gk_last - gk)     when gk is present
+#
+# The grid is persistent over runtime (chunk, head) work items. num_chunks is a
+# caller-owned CUDA scalar loaded in-kernel, so CUDA graph replay can change the
+# active chunk count without recompiling or reallocating metadata.
+#
+# ----------------------------------------------------------------------------
+# MMA input precision (dot_precision knob)
+# ----------------------------------------------------------------------------
+# The accumulator is always fp32 in TMEM; only the *operand* precision of the
+# W = A @ KB and U = A @ VB tensor-core dots changes:
+#
+#   "bf16"  (default) -- operands cast to bf16; tcgen05.mma.kind::f16, K-inst 16,
+#                        8 mantissa bits. Fastest: fewest MMA issues and 2-byte
+#                        SMEM operands. Matches what Triton actually runs (below).
+#   "tf32"            -- operands cast to tf32; tcgen05.mma.kind::tf32, K-inst 8,
+#                        10 mantissa bits. More accurate than bf16 at a higher
+#                        MMA cost (twice the K-issues).
+#   "tf32x3"          -- tf32 base plus the two first-order residual products
+#                        (A_hi@V_hi + A_hi@V_lo + A_lo@V_hi) on the U dot,
+#                        emulating ~fp32 accuracy. ONLY valid when A is fp32 --
+#                        once A is bf16-rounded the residual is meaningless, so
+#                        the wrapper rejects tf32x3 for non-fp32 A. W stays
+#                        single-pass tf32 even in this mode.
+#
+# What Triton does, by contrast: the shipped Triton kernel casts both dot
+# operands to A.dtype before tl.dot(..., input_precision="tf32x3"). When A is
+# bf16 (the common case) that cast forces a bf16 tensor-core op and the
+# input_precision request is silently ignored -- so Triton effectively runs
+# bf16 regardless of its config. tf32/tf32x3 only take effect for Triton when A
+# is fp32. CuTe can run any of the three precisions independently of the A
+# storage dtype, and feeds the MMA without the intermediate bf16 round-trip
+# Triton applies to k*beta / v*beta (so CuTe tf32 is strictly more accurate
+# than Triton's "tf32x3"-on-bf16-A, which is really bf16).
+#
+# W and U occupy disjoint TMEM column regions: W at cols [0:128], U at
+# cols [128:256].
+
+# pyre-ignore-all-errors
+# NOTE: do NOT use `from __future__ import annotations` — cute.struct
+# requires eager-evaluated annotations.
+
+import enum
+from typing import Optional, Union
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.pipeline as pipeline
+import cutlass.utils as utils
+import cutlass.utils.blackwell_helpers as sm100_utils
+import torch
+from cutlass import Boolean, Float32, Int32
+from cutlass.cute.nvgpu import cpasync, tcgen05
+from cutlass.cute.runtime import from_dlpack
+from cutlass.cutlass_dsl import Constexpr
+from torch._subclasses.fake_tensor import FakeTensor
+
+
+# ============================================================================
+# Constants
+# ============================================================================
+
+DATA_ALIGN_BYTES = 16
+INDEX_ALIGN_BYTES = 4
+
+# I/O dtype: gmem inputs K/V/Q and outputs W/U/qg/kg are bf16.
+IO_DTYPE = cutlass.BFloat16
+# MMA operand dtype is chosen at launch from dot_precision (see _mma_config):
+# tf32 (4 bytes, K-inst 8) for "tf32"/"tf32x3", or bf16 (2 bytes, K-inst 16) for
+# "bf16". Both accumulate in fp32 with CtaGroup.ONE. The values below are the
+# tf32 defaults used to size layouts/comments; the bf16 variant uses K-inst 16.
+MMA_DTYPE = cutlass.TFloat32
+ACC_DTYPE = cutlass.Float32
+
+# MMA instruction shape -- K=8 for tf32 (kind::tf32), K=16 for bf16 (kind::f16).
+# N=128 covers a single operand (W OR U, not both). Two independent MMAs are
+# issued (W = A@KB and U = A@VB) targeting non-overlapping TMEM regions:
+#   W accumulator: TMEM rows [0:64], cols [0:128]
+#   U accumulator: TMEM rows [0:64], cols [128:256]
+# Row bias was tried for U, but UMMA did not honor it; column offsetting keeps
+# the accumulator regions disjoint.
+MMA_INST_SHAPE_MNK = (64, 128, 8)
+MMA_INST_SHAPE_MNK_BF16 = (64, 128, 16)
+# Block tile for the GEMM -- (M=BT=64, N=128, K_red=BT=64). K_red=64 is reduced
+# with (64 / K-inst) MMA K-issues per operand: 8 issues for tf32, 4 for bf16.
+MMA_TILER_MNK = (64, 128, 64)
+MMA_K_INST = MMA_INST_SHAPE_MNK[2]
+MMA_K_INST_BF16 = MMA_INST_SHAPE_MNK_BF16[2]
+
+
+class MmaPrecision(enum.Enum):
+    """MMA operand precision knob (see the module header for the trade-offs)."""
+
+    BF16 = "bf16"  # bf16 operands, kind::f16 MMA, K-inst 16. Fastest.
+    TF32 = "tf32"  # tf32 operands, kind::tf32 MMA, K-inst 8. More accurate.
+    TF32X3 = "tf32x3"  # tf32 + residual products on U; fp32 A only.
+
+    @property
+    def is_bf16(self) -> bool:
+        return self is MmaPrecision.BF16
+
+    @property
+    def is_tf32x3(self) -> bool:
+        return self is MmaPrecision.TF32X3
+
+
+def _normalize_precision(precision: "Union[str, MmaPrecision]") -> MmaPrecision:
+    if isinstance(precision, MmaPrecision):
+        return precision
+    try:
+        return MmaPrecision(precision)
+    except ValueError:
+        valid = ", ".join(repr(p.value) for p in MmaPrecision)
+        raise AssertionError(
+            f"recompute_w_u_fwd dot_precision must be one of {valid}; got {precision!r}."
+        )
+
+
+def _mma_config(precision: MmaPrecision):
+    """Return (op, mma_dtype) for the requested operand precision.
+
+    The kernel derives its compile-time K-inst (MMA_K_INST{,_BF16}) directly
+    from the precision, so this host helper only builds the op + operand dtype.
+    """
+    if precision.is_bf16:
+        op = tcgen05.MmaF16BF16Op(
+            cutlass.BFloat16,
+            ACC_DTYPE,
+            MMA_INST_SHAPE_MNK_BF16,
+            tcgen05.CtaGroup.ONE,
+            tcgen05.OperandSource.SMEM,
+            tcgen05.OperandMajorMode.K,
+            tcgen05.OperandMajorMode.MN,
+        )
+        return op, cutlass.BFloat16
+    op = tcgen05.MmaTF32Op(
+        MMA_INST_SHAPE_MNK,
+        tcgen05.CtaGroup.ONE,
+        tcgen05.OperandSource.SMEM,
+        tcgen05.OperandMajorMode.K,
+        tcgen05.OperandMajorMode.MN,
+    )
+    return op, MMA_DTYPE
+
+
+THREADS_PER_CTA = 256
+BT = 64  # chunk size
+KEY_DIM = 128  # hardcoded head_dim for staging SMEM
+VAL_DIM = 128
+
+AB_STAGES = 1  # no K-tile pipelining (single K-tile per block)
+# ACC_STAGE=2: split W and U as separate pipeline stages at disjoint TMEM
+# regions (W at col 0, U at col 128). In the single-pass U path this lets
+# EPI_W run while MMA_U is in flight; in the tf32x3 U path the same two stages
+# are reused for U_hi, U_v_res, and U_a_res.
+ACC_STAGE = 2
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def _has_default_compact_strides(tensor: torch.Tensor) -> bool:
+    expected_stride = 1
+    for size, stride in zip(reversed(tensor.shape), reversed(tensor.stride())):
+        if size == 1:
+            continue
+        if stride != expected_stride:
+            return False
+        expected_stride *= size
+    return True
+
+
+def _as_cute_tensor(
+    tensor: torch.Tensor,
+    *,
+    assumed_align: int = DATA_ALIGN_BYTES,
+    mark_divisibility: bool = False,
+    enable_tvm_ffi: bool = False,
+) -> cute.Tensor:
+    """Convert a torch tensor into a CuTe tensor with dynamic layout metadata.
+
+    When mark_divisibility=True, marks the innermost mode's shape as divisible
+    by 128 bits / elem_width elements — required for vectorized cp.async gmem
+    loads to verify ptr alignment after tile slicing. The caller is responsible
+    for ensuring this is actually true (e.g., for 4-D [B,T,H,D] bf16 tensors
+    with D a multiple of 8).
+    """
+    leading_dim = tensor.ndim - 1 if tensor.ndim > 1 else 0
+    t = from_dlpack(
+        tensor.detach(),
+        assumed_align=assumed_align,
+        enable_tvm_ffi=enable_tvm_ffi,
+    ).mark_layout_dynamic(leading_dim=leading_dim)
+    # mark_compact_shape_dynamic is an annotation for compact-stride layouts.
+    # Outer-strided views still carry their strides through mark_layout_dynamic.
+    if mark_divisibility and tensor.ndim >= 2 and _has_default_compact_strides(tensor):
+        elem_bits = t.element_type.width
+        div = 128 // elem_bits if 128 % elem_bits == 0 else 1
+        if div > 1 and tensor.shape[leading_dim] % div == 0:
+            stride_order = tuple(range(tensor.ndim))
+            t = t.mark_compact_shape_dynamic(
+                mode=leading_dim, stride_order=stride_order, divisibility=div
+            )
+    return t
+
+
+@cute.jit
+def _predicate_valid(tCoord: cute.Tensor, valid: Int32, check_cols: Constexpr) -> cute.Tensor:
+    # tCoord is the source-partitioned identity tile, shape ((v, 1), rest_m,
+    # rest_n). rest_m is the row-repeat mode: a single thread owns several rows
+    # (e.g. rows m, m+16, m+32, m+48). The predicate MUST be evaluated per
+    # rest_m — broadcasting one row's predicate across all repeats would load
+    # rows >= valid and over-read past the packed-token boundary. check_cols also
+    # masks the column coord (for the square A tile, which is valid x valid).
+    pred = cute.make_fragment(
+        cute.make_layout(
+            (
+                cute.size(tCoord, mode=[0, 1]),
+                cute.size(tCoord, mode=[1]),
+                cute.size(tCoord, mode=[2]),
+            ),
+        ),
+        Boolean,
+    )
+    for rest_v in cutlass.range_constexpr(pred.shape[0]):
+        for rest_m in cutlass.range_constexpr(pred.shape[1]):
+            for rest_k in cutlass.range_constexpr(pred.shape[2]):
+                coord = tCoord[(0, rest_v), rest_m, rest_k]
+                keep = coord[0] < valid
+                if cutlass.const_expr(check_cols):
+                    keep = keep & (coord[1] < valid)
+                pred[rest_v, rest_m, rest_k] = keep
+    return pred
+
+
+@cute.jit
+def _make_input_tiles(
+    mK: cute.Tensor,
+    mV: cute.Tensor,
+    mQ: cute.Tensor,
+    mG: cute.Tensor,
+    mA: cute.Tensor,
+    time_base: Int32,
+    key_head_idx: Int32,
+    value_head_idx: Int32,
+):
+    # Address the exact packed-token row. Document starts are not guaranteed to
+    # be BT-aligned, so using time_base // BT would floor into a previous chunk.
+    k_shifted = cute.domain_offset((0, time_base, key_head_idx, 0), mK)
+    v_shifted = cute.domain_offset((0, time_base, value_head_idx, 0), mV)
+    q_shifted = cute.domain_offset((0, time_base, value_head_idx, 0), mQ)
+    g_shifted = cute.domain_offset((0, time_base, key_head_idx, 0), mG)
+    a_shifted = cute.domain_offset((0, time_base, value_head_idx, 0), mA)
+    gK_tile = cute.make_tensor(
+        k_shifted.iterator,
+        cute.make_layout((BT, KEY_DIM), stride=(mK.layout.stride[1], mK.layout.stride[3])),
+    )
+    gV_tile = cute.make_tensor(
+        v_shifted.iterator,
+        cute.make_layout((BT, VAL_DIM), stride=(mV.layout.stride[1], mV.layout.stride[3])),
+    )
+    gQ_tile = cute.make_tensor(
+        q_shifted.iterator,
+        cute.make_layout((BT, KEY_DIM), stride=(mQ.layout.stride[1], mQ.layout.stride[3])),
+    )
+    gG_tile = cute.make_tensor(
+        g_shifted.iterator,
+        cute.make_layout((BT, KEY_DIM), stride=(mG.layout.stride[1], mG.layout.stride[3])),
+    )
+    gA_tile = cute.make_tensor(
+        a_shifted.iterator,
+        cute.make_layout((BT, BT), stride=(mA.layout.stride[1], mA.layout.stride[3])),
+    )
+    return gK_tile, gV_tile, gQ_tile, gG_tile, gA_tile
+
+
+@cute.jit
+def _copy_input_tiles(
+    tiled_copy_bf16: cute.TiledCopy,
+    tiled_copy_fp32_kv: cute.TiledCopy,
+    tiled_copy_a: cute.TiledCopy,
+    thr_copy_bf16: cute.TiledCopy,
+    thr_copy_fp32_kv: cute.TiledCopy,
+    thr_copy_a: cute.TiledCopy,
+    gK_tile: cute.Tensor,
+    gV_tile: cute.Tensor,
+    gQ_tile: cute.Tensor,
+    gG_tile: cute.Tensor,
+    gA_tile: cute.Tensor,
+    sK_stage: cute.Tensor,
+    sV_stage: cute.Tensor,
+    sQ_stage: cute.Tensor,
+    sG_stage: cute.Tensor,
+    sA_stage: cute.Tensor,
+    valid: Int32,
+    has_q: Constexpr,
+    has_gk: Constexpr,
+):
+    cKV = cute.make_identity_tensor((BT, KEY_DIM))
+    cA = cute.make_identity_tensor((BT, BT))
+
+    if valid >= BT:
+        cute.copy(
+            tiled_copy_bf16,
+            thr_copy_bf16.partition_S(gK_tile),
+            thr_copy_bf16.partition_D(sK_stage),
+        )
+        cute.copy(
+            tiled_copy_bf16,
+            thr_copy_bf16.partition_S(gV_tile),
+            thr_copy_bf16.partition_D(sV_stage),
+        )
+        if cutlass.const_expr(has_q):
+            cute.copy(
+                tiled_copy_bf16,
+                thr_copy_bf16.partition_S(gQ_tile),
+                thr_copy_bf16.partition_D(sQ_stage),
+            )
+        if cutlass.const_expr(has_gk):
+            cute.copy(
+                tiled_copy_fp32_kv,
+                thr_copy_fp32_kv.partition_S(gG_tile),
+                thr_copy_fp32_kv.partition_D(sG_stage),
+            )
+        cute.arch.cp_async_commit_group()
+        cute.copy(
+            tiled_copy_a,
+            thr_copy_a.partition_S(gA_tile),
+            thr_copy_a.partition_D(sA_stage),
+        )
+    else:
+        pred_bf16 = _predicate_valid(thr_copy_bf16.partition_S(cKV), valid, check_cols=False)
+        cute.copy(
+            tiled_copy_bf16,
+            thr_copy_bf16.partition_S(gK_tile),
+            thr_copy_bf16.partition_D(sK_stage),
+            pred=pred_bf16,
+        )
+        cute.copy(
+            tiled_copy_bf16,
+            thr_copy_bf16.partition_S(gV_tile),
+            thr_copy_bf16.partition_D(sV_stage),
+            pred=pred_bf16,
+        )
+        if cutlass.const_expr(has_q):
+            cute.copy(
+                tiled_copy_bf16,
+                thr_copy_bf16.partition_S(gQ_tile),
+                thr_copy_bf16.partition_D(sQ_stage),
+                pred=pred_bf16,
+            )
+        if cutlass.const_expr(has_gk):
+            pred_g = _predicate_valid(thr_copy_fp32_kv.partition_S(cKV), valid, check_cols=False)
+            cute.copy(
+                tiled_copy_fp32_kv,
+                thr_copy_fp32_kv.partition_S(gG_tile),
+                thr_copy_fp32_kv.partition_D(sG_stage),
+                pred=pred_g,
+            )
+        cute.arch.cp_async_commit_group()
+        pred_a = _predicate_valid(thr_copy_a.partition_S(cA), valid, check_cols=True)
+        cute.copy(
+            tiled_copy_a,
+            thr_copy_a.partition_S(gA_tile),
+            thr_copy_a.partition_D(sA_stage),
+            pred=pred_a,
+        )
+    cute.arch.cp_async_commit_group()
+
+
+@cute.jit
+def _store_epilogue_tile(
+    src: cute.Tensor,
+    dst: cute.Tensor,
+    coord: cute.Tensor,
+    valid: Int32,
+):
+    if valid >= BT:
+        cute.autovec_copy(src, dst)
+    else:
+        for i in cutlass.range_constexpr(cute.size(src)):
+            if coord[i][0] < valid:
+                dst[i] = src[i]
+
+
+# ============================================================================
+# Shared storage
+# ============================================================================
+
+
+@cute.struct
+class SharedStorage:
+    """
+    SMEM layout for the kernel.
+
+    Fields:
+    - acc_mbar_ptr: PipelineUmmaAsync mbarriers for W/U accumulator stages.
+    - ab_mbar_ptr: kept for layout stability; CVT->MMA sync uses a named
+        barrier because AB_STAGES=1 has no K-tile overlap.
+    - tmem_holding_buf: holds the TMEM allocation pointer (32-bit).
+    - sK/sV/sQ/sG/sA/sBeta staging: cp.async source tiles and per-row beta.
+        MMA-ready swizzled A/KB/VB buffers are allocated dynamically below with
+        allocate_tensor so their layouts match the tiled MMA descriptors.
+    """
+
+    ab_mbar_ptr: cute.struct.MemRange[cutlass.Int64, AB_STAGES * 2]
+    acc_mbar_ptr: cute.struct.MemRange[cutlass.Int64, ACC_STAGE * 2]
+    tmem_holding_buf: cutlass.Int32
+    # cp.async staging: bf16 inputs K, V, Q and fp32 g/A.
+    sK_staging: cute.struct.Align[cute.struct.MemRange[cutlass.BFloat16, BT * KEY_DIM], 128]
+    sV_staging: cute.struct.Align[cute.struct.MemRange[cutlass.BFloat16, BT * VAL_DIM], 128]
+    sQ_staging: cute.struct.Align[cute.struct.MemRange[cutlass.BFloat16, BT * KEY_DIM], 128]
+    sG_staging: cute.struct.Align[cute.struct.MemRange[cutlass.Float32, BT * KEY_DIM], 128]
+    sA_staging: cute.struct.Align[cute.struct.MemRange[cutlass.Float32, BT * BT], 128]
+    # Per-chunk beta broadcast buffer: one fp32 per row, read by all 32 col-threads.
+    sBeta_staging: cute.struct.Align[cute.struct.MemRange[cutlass.Float32, BT], 128]
+
+
+# ============================================================================
+# Kernel
+# ============================================================================
+
+
+@cute.kernel
+def _kernel_varlen_b1_full_chunk(
+    tiled_mma: cute.TiledMma,
+    mQ: cute.Tensor,
+    mK: cute.Tensor,
+    mV: cute.Tensor,
+    mBeta: cute.Tensor,
+    mA: cute.Tensor,
+    mG: cute.Tensor,
+    mW: cute.Tensor,
+    mU: cute.Tensor,
+    mQG: cute.Tensor,
+    mKG: cute.Tensor,
+    mCuSeqlens: cute.Tensor,
+    mChunkIndices: cute.Tensor,
+    mNumChunks: cute.Tensor,
+    a_smem_layout: cute.ComposedLayout,
+    b_smem_layout: cute.ComposedLayout,
+    num_persistent_ctas: Constexpr,
+    a_is_fp32: Constexpr,
+    has_q: Constexpr,
+    has_gk: Constexpr,
+    u_dot_precision_tf32x3: Constexpr,
+    prefetch_next_tile: Constexpr,
+    mma_is_bf16: Constexpr,
+):
+    """
+    Kernel body for the UMMA path.
+
+    Grid: (num_persistent_ctas, 1, 1). CTAs stride over runtime
+    (chunk, head) work items, bounded by mNumChunks[0] loaded in-kernel.
+    Block: (256, 1, 1).
+
+    Life of a block:
+      1. Resolve varlen chunk (seq_idx, chunk_idx, time_base) from metadata.
+      2. Load source tiles (K, V, Q, beta, g, A) from gmem.
+      3. CVT: build TF32 MMA operands A, kb, and vb in swizzled SMEM; store
+         optional qg and kg directly to gmem.
+      4. UMMA: compute W = A @ kb and U = A @ vb into separate TMEM columns.
+         If requested for fp32 A, U is expanded to Triton-style tf32x3.
+      5. Epilogue: copy TMEM -> rmem, cast to bf16, and store W/U to gmem.
+    """
+    # Operand precision is compile-time: bf16 (kind::f16, K-inst 16) or tf32
+    # (kind::tf32, K-inst 8). The accumulator is fp32 either way.
+    mma_dtype: Constexpr = cutlass.BFloat16 if mma_is_bf16 else MMA_DTYPE
+    mma_k_inst: Constexpr = MMA_K_INST_BF16 if mma_is_bf16 else MMA_K_INST
+
+    # CVT scatter geometry: each thread reads/writes CVT_VEC contiguous elements
+    # per row. CVT_VEC stays 4 for BOTH precisions on purpose. The (8 x 32)
+    # stride-4 layout is tuned to spread SMEM accesses across 8 banks; widening
+    # bf16 to 8 (a (16 x 16) layout) cuts the store *instruction* count but lands
+    # on the higher-bank-conflict pattern the stride-4 layout was chosen to avoid
+    # and measured ~1.5x SLOWER at T=16384 (the kernel is SMEM-bank-conflict
+    # bound, not store-width bound). So bf16 keeps the 4-wide (STS.64) scatter.
+    CVT_VEC: Constexpr = 4
+    CVT_NCOL: Constexpr = KEY_DIM // CVT_VEC
+    CVT_NROW: Constexpr = THREADS_PER_CTA // CVT_NCOL
+    CVT_ROWSTEPS: Constexpr = BT // CVT_NROW
+    # A (BT x BT) scatter over the K=BT dim — same reasoning, kept 4-wide.
+    A_VEC: Constexpr = 4
+    A_NCOL: Constexpr = BT // A_VEC
+    A_NROW: Constexpr = THREADS_PER_CTA // A_NCOL
+    A_ROWSTEPS: Constexpr = BT // A_NROW
+
+    tidx, _, _ = cute.arch.thread_idx()
+    warp_idx = cute.arch.warp_idx()
+    warp_idx = cute.arch.make_warp_uniform(warp_idx)
+    cta_idx, _, _ = cute.arch.block_idx()
+    num_key_heads = cute.size(mK.shape[2])
+    num_value_heads = cute.size(mV.shape[2])
+    head_group_size = num_value_heads // num_key_heads
+    num_chunks_runtime = mNumChunks[0].to(Int32)
+    total_work_runtime = num_chunks_runtime * num_value_heads
+    iters_per_cta_outer = (
+        total_work_runtime + num_persistent_ctas - 1 - cta_idx
+    ) // num_persistent_ctas
+
+    if cta_idx < num_persistent_ctas:
+        key_dim = cute.size(mK.shape[3])
+        value_dim = cute.size(mV.shape[3])
+
+        # ---- 2. SMEM allocation ----
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+
+        # MMA-ready swizzled SMEM for A and B operands.
+        # A is shared by both MMAs; B is split into KB (for W) and VB (for U).
+        sA_mma = smem.allocate_tensor(
+            element_type=mma_dtype,
+            layout=a_smem_layout.outer,
+            byte_alignment=128,
+            swizzle=a_smem_layout.inner,
+        )
+        sKb_mma = smem.allocate_tensor(
+            element_type=mma_dtype,
+            layout=b_smem_layout.outer,
+            byte_alignment=128,
+            swizzle=b_smem_layout.inner,
+        )
+        sVb_mma = smem.allocate_tensor(
+            element_type=mma_dtype,
+            layout=b_smem_layout.outer,
+            byte_alignment=128,
+            swizzle=b_smem_layout.inner,
+        )
+
+        # ---- TMEM allocation ----
+        tmem_alloc_barrier = pipeline.NamedBarrier(
+            barrier_id=1,
+            num_threads=THREADS_PER_CTA,
+        )
+        tmem = utils.TmemAllocator(
+            storage.tmem_holding_buf,
+            barrier_for_retrieve=tmem_alloc_barrier,
+        )
+        # W accumulator uses TMEM cols [0:128], U uses cols [128:256].
+        # (Row-bias was attempted at rows [64:128] but is not honored by UMMA.)
+        num_tmem_cols = 256
+        tmem.allocate(num_tmem_cols)
+
+        # ---- Pipelines ----
+        # Only MMA completion uses a pipeline (PipelineUmmaAsync). CVT->MMA sync
+        # is done via a simple named barrier. AB_STAGES=1 means no overlap, so a
+        # full pipeline is unnecessary.
+        acc_producer, acc_consumer = pipeline.PipelineUmmaAsync.create(
+            num_stages=ACC_STAGE,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, size=THREADS_PER_CTA),
+            barrier_storage=storage.acc_mbar_ptr.data_ptr(),
+        ).make_participants()
+
+        # CVT -> MMA named barrier (all 256 threads arrive).
+        cvt_mma_barrier = pipeline.NamedBarrier(
+            barrier_id=2,
+            num_threads=THREADS_PER_CTA,
+        )
+
+        # ---- 3a. cp.async staging for bf16 inputs ----
+        sK_stage = cute.make_tensor(
+            storage.sK_staging.data_ptr(),
+            cute.make_layout((BT, KEY_DIM), stride=(KEY_DIM, 1)),
+        )
+        sV_stage = cute.make_tensor(
+            storage.sV_staging.data_ptr(),
+            cute.make_layout((BT, VAL_DIM), stride=(VAL_DIM, 1)),
+        )
+        sQ_stage = cute.make_tensor(
+            storage.sQ_staging.data_ptr(),
+            cute.make_layout((BT, KEY_DIM), stride=(KEY_DIM, 1)),
+        )
+        sG_stage = cute.make_tensor(
+            storage.sG_staging.data_ptr(),
+            cute.make_layout((BT, KEY_DIM), stride=(KEY_DIM, 1)),
+        )
+        # sA_staging is allocated as fp32 (max size). For bf16 A, reinterpret
+        # the pointer as bf16 — uses the same memory, half the elements.
+        if cutlass.const_expr(a_is_fp32):
+            sA_stage = cute.make_tensor(
+                storage.sA_staging.data_ptr(),
+                cute.make_layout((BT, BT), stride=(BT, 1)),
+            )
+        else:
+            sA_stage = cute.make_tensor(
+                cute.recast_ptr(storage.sA_staging.data_ptr(), dtype=cutlass.BFloat16),
+                cute.make_layout((BT, BT), stride=(BT, 1)),
+            )
+        sBeta_stage = cute.make_tensor(storage.sBeta_staging.data_ptr(), cute.make_layout(BT))
+
+        atom_bf16 = cute.make_copy_atom(
+            cpasync.CopyG2SOp(cache_mode=cpasync.LoadCacheMode.GLOBAL),
+            cutlass.BFloat16,
+            num_bits_per_copy=128,
+        )
+        atom_fp32 = cute.make_copy_atom(
+            cpasync.CopyG2SOp(cache_mode=cpasync.LoadCacheMode.GLOBAL),
+            cutlass.Float32,
+            num_bits_per_copy=128,
+        )
+        tiled_copy_bf16 = cute.make_tiled_copy_tv(
+            atom_bf16,
+            cute.make_layout((16, 16), stride=(16, 1)),
+            cute.make_layout((1, 8)),
+        )
+        tiled_copy_fp32_kv = cute.make_tiled_copy_tv(
+            atom_fp32,
+            cute.make_layout((8, 32), stride=(32, 1)),
+            cute.make_layout((1, 4)),
+        )
+        # A copy: fp32 uses (16,16) threads × (1,4) vals = 4 fp32/thread/rep, 4 reps.
+        # bf16 uses (32,8) threads × (1,8) vals = 8 bf16/thread/rep, 2 reps.
+        if cutlass.const_expr(a_is_fp32):
+            tiled_copy_a = cute.make_tiled_copy_tv(
+                atom_fp32,
+                cute.make_layout((16, 16), stride=(16, 1)),
+                cute.make_layout((1, 4)),
+            )
+        else:
+            tiled_copy_a = cute.make_tiled_copy_tv(
+                atom_bf16,
+                cute.make_layout((32, 8), stride=(8, 1)),
+                cute.make_layout((1, 8)),
+            )
+        thr_copy_bf16 = tiled_copy_bf16.get_slice(tidx)
+        thr_copy_fp32_kv = tiled_copy_fp32_kv.get_slice(tidx)
+        thr_copy_a = tiled_copy_a.get_slice(tidx)
+
+        # ---- TMEM pointer setup (one-time, hoisted out of chunk loop) ----
+        tmem.wait_for_alloc()
+        tmem_ptr = tmem.retrieve_ptr(ACC_DTYPE)
+        # Col-offset pointer: TMEM addressing is (row << 16) | col; adding 128
+        # to the low bits shifts col by 128 fp32 lanes.
+        tmem_ptr_u = tmem_ptr + 128
+
+        # Partition for MMA. Each MMA handles a single (M=64, N=128) tile; K=64.
+        # These are loop-invariant — same for every chunk.
+        thr_mma = tiled_mma.get_slice(0)
+        acc_shape = tiled_mma.partition_shape_C(MMA_TILER_MNK[:2])
+        tCtAcc_tmpl = tiled_mma.make_fragment_C(acc_shape)
+        acc_w = cute.make_tensor(tmem_ptr, tCtAcc_tmpl.layout)
+        acc_u = cute.make_tensor(tmem_ptr_u, tCtAcc_tmpl.layout)
+        tCrA = tiled_mma.make_fragment_A(sA_mma)
+        tCrB_w = tiled_mma.make_fragment_B(sKb_mma)
+        tCrB_u = tiled_mma.make_fragment_B(sVb_mma)
+
+        # Release TMEM allocation lock so other warps can proceed. Only needed
+        # once since alloc happens once.
+        tmem.relinquish_alloc_permit()
+
+        # ---- Persistent-loop prologue: prefetch the first work item ----
+        # The raw staging buffers are only needed through CVT/A packing. Once
+        # those are complete, later iterations can reuse the same raw buffers
+        # for the next work item while the current tile drains from TMEM.
+        if cutlass.const_expr(prefetch_next_tile):
+            if iters_per_cta_outer > 0:
+                prologue_work_idx = cta_idx
+                prologue_chunk_block = prologue_work_idx % num_chunks_runtime
+                prologue_value_head_idx = prologue_work_idx // num_chunks_runtime
+                prologue_key_head_idx = prologue_value_head_idx // head_group_size
+                prologue_seq_idx = mChunkIndices[prologue_chunk_block, 0].to(Int32)
+                prologue_chunk_idx = mChunkIndices[prologue_chunk_block, 1].to(Int32)
+                prologue_bos = mCuSeqlens[prologue_seq_idx].to(Int32)
+                prologue_eos = mCuSeqlens[prologue_seq_idx + 1].to(Int32)
+                prologue_time_base = prologue_bos + prologue_chunk_idx * BT
+                prologue_valid = cutlass.min(prologue_eos - prologue_time_base, Int32(BT))
+
+                (
+                    prologue_gK_tile,
+                    prologue_gV_tile,
+                    prologue_gQ_tile,
+                    prologue_gG_tile,
+                    prologue_gA_tile,
+                ) = _make_input_tiles(
+                    mK,
+                    mV,
+                    mQ,
+                    mG,
+                    mA,
+                    prologue_time_base,
+                    prologue_key_head_idx,
+                    prologue_value_head_idx,
+                )
+                _copy_input_tiles(
+                    tiled_copy_bf16,
+                    tiled_copy_fp32_kv,
+                    tiled_copy_a,
+                    thr_copy_bf16,
+                    thr_copy_fp32_kv,
+                    thr_copy_a,
+                    prologue_gK_tile,
+                    prologue_gV_tile,
+                    prologue_gQ_tile,
+                    prologue_gG_tile,
+                    prologue_gA_tile,
+                    sK_stage,
+                    sV_stage,
+                    sQ_stage,
+                    sG_stage,
+                    sA_stage,
+                    prologue_valid,
+                    has_q,
+                    has_gk,
+                )
+
+        # ---- Persistent loop over runtime (chunk, head) work items ----
+        for persistent_iter in cutlass.range(iters_per_cta_outer, unroll=1):
+            work_idx = persistent_iter * num_persistent_ctas + cta_idx
+            chunk_block = work_idx % num_chunks_runtime
+            value_head_idx = work_idx // num_chunks_runtime
+            key_head_idx = value_head_idx // head_group_size
+
+            # ---- Varlen chunk coords (for CVT / EPI addressing) ----
+            seq_idx = mChunkIndices[chunk_block, 0].to(Int32)
+            chunk_idx = mChunkIndices[chunk_block, 1].to(Int32)
+            bos = mCuSeqlens[seq_idx].to(Int32)
+            eos = mCuSeqlens[seq_idx + 1].to(Int32)
+            time_base = bos + chunk_idx * BT
+            valid = cutlass.min(eos - time_base, Int32(BT))
+
+            if cutlass.const_expr(not prefetch_next_tile):
+                gK_tile, gV_tile, gQ_tile, gG_tile, gA_tile = _make_input_tiles(
+                    mK, mV, mQ, mG, mA, time_base, key_head_idx, value_head_idx
+                )
+                _copy_input_tiles(
+                    tiled_copy_bf16,
+                    tiled_copy_fp32_kv,
+                    tiled_copy_a,
+                    thr_copy_bf16,
+                    thr_copy_fp32_kv,
+                    thr_copy_a,
+                    gK_tile,
+                    gV_tile,
+                    gQ_tile,
+                    gG_tile,
+                    gA_tile,
+                    sK_stage,
+                    sV_stage,
+                    sQ_stage,
+                    sG_stage,
+                    sA_stage,
+                    valid,
+                    has_q,
+                    has_gk,
+                )
+
+            # Stage beta[time_base:time_base+BT, value_head_idx] into SMEM once per chunk.
+            # beta staging only depends on gmem mBeta (independent of the K/V/Q/G
+            # cp.async), so it is issued BEFORE the cp.async wait and shares the
+            # single post-wait barrier — saving one full-block barrier per tile.
+            # Layout is transposed so each CVT thread's CVT_ROWSTEPS beta values
+            # sit contiguously → 1 vectorized LDS per thread. Mapping:
+            # beta[orig_row] → sBeta[(orig_row % CVT_NROW)*CVT_ROWSTEPS +
+            # orig_row // CVT_NROW] (tr inner, row_step outer).
+            if tidx < BT:
+                safe_tidx = cutlass.min(tidx, valid - 1)
+                sBeta_stage[(tidx % CVT_NROW) * CVT_ROWSTEPS + (tidx // CVT_NROW)] = mBeta[
+                    0, time_base + safe_tidx, value_head_idx
+                ]
+
+            # Wait until only 1 group is in flight — i.e., KVQG done, A may still be loading.
+            cute.arch.cp_async_wait_group(1)
+            cute.arch.barrier()
+
+            # ---- 3b. CVT: 256 threads, (CVT_NROW x CVT_NCOL) layout ----
+            # Thread (tr, tc): tr = tidx//CVT_NCOL, tc = tidx%CVT_NCOL.
+            # Owns rows [tr, tr+CVT_NROW, ...] and cols [tc*CVT_VEC, +CVT_VEC).
+            # CVT_VEC contig cols per thread → one 128-bit LDS/STS per access.
+            tr = tidx // CVT_NCOL
+            tc = tidx % CVT_NCOL
+            col_start = tc * CVT_VEC
+
+            # Hoist g_last[col_start:col_start+CVT_VEC] once via vectorized SMEM
+            # read. Only meaningful when gating is active.
+            g_last_vals = cute.make_fragment(CVT_VEC, Float32)
+            if cutlass.const_expr(has_gk):
+                # gk_last is the gate at the chunk's LAST VALID row. For a partial
+                # (varlen) chunk the valid length is < BT, so the fixed row BT-1
+                # falls past the sequence's valid tokens (into padding or the next
+                # sequence) and corrupts kg = k * exp2(gk_last - gk). Clamp to the
+                # real last row: valid - 1 = min(BT, eos - time_base) - 1.
+                g_last_row = valid - 1
+                sG_last_slice = cute.make_tensor(
+                    sG_stage.iterator + g_last_row * KEY_DIM + col_start,
+                    cute.make_layout(CVT_VEC),
+                )
+                cute.autovec_copy(sG_last_slice, g_last_vals)
+
+            # Hoist beta as fp32. Production GDN beta is fp32, while older
+            # benchmarks may pass bf16; staging in fp32 preserves both paths.
+            # Per-thread beta positions are tr*CVT_ROWSTEPS + row_step.
+            sBeta_tr_slice = cute.make_tensor(
+                sBeta_stage.iterator + tr * CVT_ROWSTEPS,
+                cute.make_layout(CVT_ROWSTEPS),
+            )
+            beta_frag = cute.make_fragment(CVT_ROWSTEPS, Float32)
+            cute.autovec_copy(sBeta_tr_slice, beta_frag)
+
+            # Per-iter register fragments — CVT_VEC elements (one scatter phase).
+            k_frag = cute.make_fragment(CVT_VEC, IO_DTYPE)
+            v_frag = cute.make_fragment(CVT_VEC, IO_DTYPE)
+            q_frag = cute.make_fragment(CVT_VEC, IO_DTYPE)
+            g_frag = cute.make_fragment(CVT_VEC, Float32)
+            qg_frag = cute.make_fragment(CVT_VEC, IO_DTYPE)
+            kg_frag = cute.make_fragment(CVT_VEC, IO_DTYPE)
+            # kb/vb feed the MMA B operand → mma_dtype.
+            kb_frag = cute.make_fragment(CVT_VEC, mma_dtype)
+            vb_frag = cute.make_fragment(CVT_VEC, mma_dtype)
+
+            for row_step in cutlass.range(CVT_ROWSTEPS, unroll_full=True):
+                row = tr + row_step * CVT_NROW
+                safe_row = cutlass.min(row, valid - 1)
+                row_in_range = row < valid
+                time_idx = time_base + row
+                beta_val = beta_frag[row_step]
+                k_inst = row % mma_k_inst
+                k_outer = row // mma_k_inst
+
+                # Vectorized 128-bit SMEM reads of CVT_VEC contig cols.
+                sK_slice = cute.make_tensor(
+                    sK_stage.iterator + safe_row * KEY_DIM + col_start,
+                    cute.make_layout(CVT_VEC),
+                )
+                sV_slice = cute.make_tensor(
+                    sV_stage.iterator + safe_row * VAL_DIM + col_start,
+                    cute.make_layout(CVT_VEC),
+                )
+                cute.autovec_copy(sK_slice, k_frag)
+                cute.autovec_copy(sV_slice, v_frag)
+                if cutlass.const_expr(has_q):
+                    sQ_slice = cute.make_tensor(
+                        sQ_stage.iterator + safe_row * KEY_DIM + col_start,
+                        cute.make_layout(CVT_VEC),
+                    )
+                    cute.autovec_copy(sQ_slice, q_frag)
+                if cutlass.const_expr(has_gk):
+                    sG_slice = cute.make_tensor(
+                        sG_stage.iterator + safe_row * KEY_DIM + col_start,
+                        cute.make_layout(CVT_VEC),
+                    )
+                    cute.autovec_copy(sG_slice, g_frag)
+
+                # Compute.
+                for c_off in cutlass.range_constexpr(CVT_VEC):
+                    k_val = k_frag[c_off].to(Float32)
+                    v_val = v_frag[c_off].to(Float32)
+
+                    if cutlass.const_expr(has_gk):
+                        g_val = g_frag[c_off]
+                        g_last = g_last_vals[c_off]
+                        exp2_g = cute.math.exp2(g_val, fastmath=True)
+                        exp2_last_minus_g = cute.math.exp2(g_last - g_val, fastmath=True)
+                        kb_frag[c_off] = (k_val * beta_val * exp2_g).to(mma_dtype)
+                        kg_frag[c_off] = (k_val * exp2_last_minus_g).to(IO_DTYPE)
+                    else:
+                        kb_frag[c_off] = (k_val * beta_val).to(mma_dtype)
+
+                    vb_frag[c_off] = (v_val * beta_val).to(mma_dtype)
+
+                    if cutlass.const_expr(has_q and has_gk):
+                        q_val = q_frag[c_off].to(Float32)
+                        qg_frag[c_off] = (q_val * exp2_g).to(IO_DTYPE)
+
+                # Scatter kb/vb into swizzled SMEM B operands (separate for W and U).
+                # Build a rank-1 view over the N-mode at fixed (k_inst, k_outer) and
+                # tile-divide into CVT_VEC-wide chunks. Each thread owns tile index =
+                # tc (since col_start = tc*CVT_VEC). autovec_copy over the CVT_VEC
+                # sub-view folds the scalar stores into one 128-bit STS (addresses
+                # are contiguous within one 16B swizzle chunk for the aligned
+                # col_start: 4 tf32 = 8 bf16 = 16 B).
+                sKb_col = sKb_mma[(None, k_inst), 0, k_outer, 0]
+                sVb_col = sVb_mma[(None, k_inst), 0, k_outer, 0]
+                sKb_vec = cute.tiled_divide(sKb_col, (CVT_VEC,))
+                sVb_vec = cute.tiled_divide(sVb_col, (CVT_VEC,))
+                cute.autovec_copy(kb_frag, sKb_vec[None, tc])
+                cute.autovec_copy(vb_frag, sVb_vec[None, tc])
+
+                # Inline QG/KG gmem stores (vectorized 128-bit). QG only when q and gk
+                # are both present; KG only when gk is present (matches triton semantics).
+                if cutlass.const_expr(has_q and has_gk):
+                    if row_in_range:
+                        gQG_slice = cute.make_tensor(
+                            mQG.iterator
+                            + (time_idx * mQG.layout.stride[1])
+                            + (value_head_idx * mQG.layout.stride[2])
+                            + col_start * mQG.layout.stride[3],
+                            cute.make_layout(CVT_VEC),
+                        )
+                        cute.autovec_copy(qg_frag, gQG_slice)
+                if cutlass.const_expr(has_gk):
+                    if row_in_range:
+                        gKG_slice = cute.make_tensor(
+                            mKG.iterator
+                            + (time_idx * mKG.layout.stride[1])
+                            + (value_head_idx * mKG.layout.stride[2])
+                            + col_start * mKG.layout.stride[3],
+                            cute.make_layout(CVT_VEC),
+                        )
+                        cute.autovec_copy(kg_frag, gKG_slice)
+
+            # Wait for A cp.async (group 0) to complete — was allowed to overlap with KVQG CVT.
+            cute.arch.cp_async_wait_group(0)
+            cute.arch.barrier()
+
+            # Process A (BT × BT) with vectorized scatter over the K=BT dim.
+            # Thread remap: (tr_a, tc_a) = (tidx // A_NCOL, tidx % A_NCOL).
+            # Each thread owns A_ROWSTEPS rows × A_VEC cols. col_start_a =
+            # tc_a*A_VEC; the thread's A_VEC K-cols all fall in one a_k_outer group
+            # (= col_start_a // mma_k_inst) and a single A_VEC-wide tile within the
+            # mma_k_inst-wide a_k_inst dimension, so the scalar stores fold into one
+            # 128-bit STS (4 tf32 = 8 bf16 = 16 B).
+            tr_a = tidx // A_NCOL
+            tc_a = tidx % A_NCOL
+            col_start_a = tc_a * A_VEC
+            a_k_outer_t = col_start_a // mma_k_inst
+            a_tile_in_outer = (col_start_a % mma_k_inst) // A_VEC
+            a_mma_frag = cute.make_fragment(A_VEC, mma_dtype)
+            for a_row_step in cutlass.range(A_ROWSTEPS, unroll_full=True):
+                a_row = tr_a + a_row_step * A_NROW
+                a_row_in_range = a_row < valid
+                sA_slice = cute.make_tensor(
+                    sA_stage.iterator + a_row * BT + col_start_a,
+                    cute.make_layout(A_VEC),
+                )
+                if cutlass.const_expr(a_is_fp32):
+                    a_frag = cute.make_fragment(A_VEC, Float32)
+                    cute.autovec_copy(sA_slice, a_frag)
+                    for a_c_off in cutlass.range_constexpr(A_VEC):
+                        a_col = col_start_a + a_c_off
+                        keep_a = a_row_in_range & (a_col < valid)
+                        a_val = a_frag[a_c_off] if keep_a else Float32(0.0)
+                        a_mma_frag[a_c_off] = a_val.to(mma_dtype)
+                else:
+                    a_bf16_frag = cute.make_fragment(A_VEC, IO_DTYPE)
+                    cute.autovec_copy(sA_slice, a_bf16_frag)
+                    for a_c_off in cutlass.range_constexpr(A_VEC):
+                        a_col = col_start_a + a_c_off
+                        keep_a = a_row_in_range & (a_col < valid)
+                        a_val = a_bf16_frag[a_c_off].to(Float32) if keep_a else Float32(0.0)
+                        a_mma_frag[a_c_off] = a_val.to(mma_dtype)
+                # Rank-1 view over a_k_inst at fixed (a_row, a_k_outer); tile into
+                # A_VEC-wide chunks and write via autovec_copy → 128-bit STS.
+                sA_row = sA_mma[(a_row, None), 0, a_k_outer_t, 0]
+                sA_vec = cute.tiled_divide(sA_row, (A_VEC,))
+                cute.autovec_copy(a_mma_frag, sA_vec[None, a_tile_in_outer])
+
+            # Signal AB ready (fills both A and B SMEM tiles).
+            cute.arch.fence_proxy(
+                cute.arch.ProxyKind.async_shared, space=cute.arch.SharedSpace.shared_cta
+            )
+            cvt_mma_barrier.arrive_and_wait()
+
+            # ---- 4. MMA ----
+            # Two independent MMAs into disjoint TMEM regions:
+            #   W = A @ KB  -> acc_w at TMEM rows [0:64], cols [0:128]
+            #   U = A @ VB  -> acc_u at TMEM rows [0:64], cols [128:256]
+            # TMEM ptrs, acc_w/acc_u, tCrA/tCrB_* are all hoisted outside the loop.
+
+            # Issue MMAs — warp 0 drives. W and U use separate pipeline stages
+            # so EPI_W can start as soon as MMA_W completes (while MMA_U is
+            # still in flight) and MMA_{n+1,W} can start while EPI_{n,U} runs.
+            if warp_idx == 0:
+                num_k_blocks = cute.size(tCrA, mode=[2])
+
+                # MMA_W — stage 0, TMEM cols [0:128]
+                acc_empty_w = acc_producer.acquire_and_advance()
+                tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+                for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                    k_block_coord = (None, None, k_block_idx, 0)
+                    cute.gemm(
+                        tiled_mma,
+                        acc_w,
+                        tCrA[k_block_coord],
+                        tCrB_w[k_block_coord],
+                        acc_w,
+                    )
+                    tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                acc_empty_w.commit()
+
+                if cutlass.const_expr(not u_dot_precision_tf32x3):
+                    # MMA_U — stage 1, TMEM cols [128:256]
+                    acc_empty_u = acc_producer.acquire_and_advance()
+                    tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+                    for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                        k_block_coord = (None, None, k_block_idx, 0)
+                        cute.gemm(
+                            tiled_mma,
+                            acc_u,
+                            tCrA[k_block_coord],
+                            tCrB_u[k_block_coord],
+                            acc_u,
+                        )
+                        tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                    acc_empty_u.commit()
+
+            if cutlass.const_expr(prefetch_next_tile and not u_dot_precision_tf32x3):
+                next_persistent_iter = persistent_iter + 1
+                if next_persistent_iter < iters_per_cta_outer:
+                    next_work_idx = next_persistent_iter * num_persistent_ctas + cta_idx
+                    next_chunk_block = next_work_idx % num_chunks_runtime
+                    next_value_head_idx = next_work_idx // num_chunks_runtime
+                    next_key_head_idx = next_value_head_idx // head_group_size
+                    next_seq_idx = mChunkIndices[next_chunk_block, 0].to(Int32)
+                    next_chunk_idx = mChunkIndices[next_chunk_block, 1].to(Int32)
+                    next_bos = mCuSeqlens[next_seq_idx].to(Int32)
+                    next_eos = mCuSeqlens[next_seq_idx + 1].to(Int32)
+                    next_time_base = next_bos + next_chunk_idx * BT
+                    next_valid = cutlass.min(next_eos - next_time_base, Int32(BT))
+
+                    (
+                        next_gK_tile,
+                        next_gV_tile,
+                        next_gQ_tile,
+                        next_gG_tile,
+                        next_gA_tile,
+                    ) = _make_input_tiles(
+                        mK,
+                        mV,
+                        mQ,
+                        mG,
+                        mA,
+                        next_time_base,
+                        next_key_head_idx,
+                        next_value_head_idx,
+                    )
+                    _copy_input_tiles(
+                        tiled_copy_bf16,
+                        tiled_copy_fp32_kv,
+                        tiled_copy_a,
+                        thr_copy_bf16,
+                        thr_copy_fp32_kv,
+                        thr_copy_a,
+                        next_gK_tile,
+                        next_gV_tile,
+                        next_gQ_tile,
+                        next_gG_tile,
+                        next_gA_tile,
+                        sK_stage,
+                        sV_stage,
+                        sQ_stage,
+                        sG_stage,
+                        sA_stage,
+                        next_valid,
+                        has_q,
+                        has_gk,
+                    )
+
+            # ---- 5. Epilogue: TMEM -> rmem -> bf16 -> gmem ----
+            # W and U are waited independently so EPI_W can overlap with MMA_U
+            # (TMEM alloc permit was released once before the chunk loop.)
+
+            # Sub-tile epilogue for ILP.
+            # For M=64 tiles the correct TMEM load atom is Ld16x256b (16 rows × 256b
+            # lanes). With Repetition.x8 each warp reads 16 rows × 64 fp32 cols.
+            # Each accumulator is 64×128 (fp32), so 2 subtiles of 64 cols each.
+            subtile_cnt = 4  # 128 cols / 4 = 32 cols per subtile
+            epi_tiler = (
+                (
+                    cute.size(acc_w, mode=[0, 0]),
+                    cute.size(acc_w, mode=[0, 1]) // subtile_cnt,
+                ),
+            )
+            acc_w_epi = cute.zipped_divide(acc_w, epi_tiler)
+            acc_u_epi = cute.zipped_divide(acc_u, epi_tiler)
+
+            tmem_atom = cute.make_copy_atom(
+                tcgen05.Ld16x256bOp(tcgen05.Repetition.x4),
+                ACC_DTYPE,
+            )
+            tmem_tiled_copy = tcgen05.make_tmem_copy(tmem_atom, acc_w_epi[None, 0])
+            # Only first 128 threads participate in TMEM epilogue (TMEM atom is 128-thread).
+            epi_tidx = tidx % 128
+            tmem_thr_copy = tmem_tiled_copy.get_slice(epi_tidx)
+
+            tDtW = tmem_thr_copy.partition_S(acc_w_epi)
+            tDtU = tmem_thr_copy.partition_S(acc_u_epi)
+
+            # Build MMA-partitioned views of gW and gU. Each is shape (BT, head_dim).
+            w_stride_t = mW.layout.stride[1]
+            w_stride_k = mW.layout.stride[3]
+            u_stride_t = mU.layout.stride[1]
+            u_stride_v = mU.layout.stride[3]
+            mW_shifted = cute.domain_offset((0, time_base, value_head_idx, 0), mW)
+            mU_shifted = cute.domain_offset((0, time_base, value_head_idx, 0), mU)
+            gW = cute.make_tensor(
+                mW_shifted.iterator,
+                cute.make_layout((BT, key_dim), stride=(w_stride_t, w_stride_k)),
+            )
+            gU = cute.make_tensor(
+                mU_shifted.iterator,
+                cute.make_layout((BT, value_dim), stride=(u_stride_t, u_stride_v)),
+            )
+
+            # MMA-partition then epi-subtile so mode=1 (subtile index) matches tDt.
+            tCgW = thr_mma.partition_C(gW)
+            tCgU = thr_mma.partition_C(gU)
+            gW_epi = cute.zipped_divide(tCgW, epi_tiler)
+            gU_epi = cute.zipped_divide(tCgU, epi_tiler)
+            cW = cute.make_identity_tensor((BT, KEY_DIM))
+            cU = cute.make_identity_tensor((BT, VAL_DIM))
+            tCcW = thr_mma.partition_C(cW)
+            tCcU = thr_mma.partition_C(cU)
+            cW_epi = cute.zipped_divide(tCcW, epi_tiler)
+            cU_epi = cute.zipped_divide(tCcU, epi_tiler)
+
+            tDgW = tmem_thr_copy.partition_D(gW_epi)
+            tDgU = tmem_thr_copy.partition_D(gU_epi)
+            tDcW = tmem_thr_copy.partition_D(cW_epi)
+            tDcU = tmem_thr_copy.partition_D(cU_epi)
+
+            tCrAcc = cute.make_rmem_tensor(tDgW[None, None, 0].shape, ACC_DTYPE)
+            tCrC = cute.make_rmem_tensor(tDgW[None, None, 0].shape, IO_DTYPE)
+
+            # Drain W stage first (stage 0): this runs in parallel with MMA_U.
+            acc_full_w = acc_consumer.wait_and_advance()
+            if tidx < 128:
+                for w_i in cutlass.range_constexpr(subtile_cnt):
+                    cute.copy(tmem_tiled_copy, tDtW[None, None, w_i], tCrAcc)
+                    tCrC.store(tCrAcc.load().to(IO_DTYPE))
+                    _store_epilogue_tile(
+                        tCrC,
+                        tDgW[None, None, w_i],
+                        tDcW[None, None, w_i],
+                        valid,
+                    )
+            acc_full_w.release()
+
+            if cutlass.const_expr(u_dot_precision_tf32x3):
+                # Triton tf32x3 expands the U dot into three TF32 products:
+                # A_hi @ V_hi + A_hi @ V_lo + A_lo @ V_hi. Run them
+                # sequentially so the existing A/V SMEM operands can be reused.
+                if warp_idx == 0:
+                    num_k_blocks = cute.size(tCrA, mode=[2])
+                    acc_empty_u_hi = acc_producer.acquire_and_advance()
+                    tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+                    for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                        k_block_coord = (None, None, k_block_idx, 0)
+                        cute.gemm(
+                            tiled_mma,
+                            acc_u,
+                            tCrA[k_block_coord],
+                            tCrB_u[k_block_coord],
+                            acc_u,
+                        )
+                        tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                    acc_empty_u_hi.commit()
+                acc_full_u_hi = acc_consumer.wait_and_advance()
+                acc_full_u_hi.release()
+                cute.arch.barrier()
+
+                vb_res_frag = cute.make_fragment(4, mma_dtype)
+                for row_step_res in cutlass.range(8, unroll_full=True):
+                    row_res = tr + row_step_res * 8
+                    safe_row_res = cutlass.min(row_res, valid - 1)
+                    k_inst_res = row_res % mma_k_inst
+                    k_outer_res = row_res // mma_k_inst
+                    beta_val_res = beta_frag[row_step_res]
+                    sV_slice_res = cute.make_tensor(
+                        sV_stage.iterator + safe_row_res * VAL_DIM + col_start,
+                        cute.make_layout(4),
+                    )
+                    cute.autovec_copy(sV_slice_res, v_frag)
+                    for c_off_res in cutlass.range_constexpr(4):
+                        vb_full = v_frag[c_off_res].to(Float32) * beta_val_res
+                        vb_hi = vb_full.to(mma_dtype)
+                        vb_res_frag[c_off_res] = (vb_full - vb_hi.to(Float32)).to(mma_dtype)
+                    sVb_res_col = sVb_mma[(None, k_inst_res), 0, k_outer_res, 0]
+                    sVb_res_4 = cute.tiled_divide(sVb_res_col, (4,))
+                    cute.autovec_copy(vb_res_frag, sVb_res_4[None, tc])
+
+                cute.arch.fence_proxy(
+                    cute.arch.ProxyKind.async_shared,
+                    space=cute.arch.SharedSpace.shared_cta,
+                )
+                cvt_mma_barrier.arrive_and_wait()
+
+                if warp_idx == 0:
+                    num_k_blocks = cute.size(tCrA, mode=[2])
+                    acc_empty_u_v_res = acc_producer.acquire_and_advance()
+                    tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                    for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                        k_block_coord = (None, None, k_block_idx, 0)
+                        cute.gemm(
+                            tiled_mma,
+                            acc_u,
+                            tCrA[k_block_coord],
+                            tCrB_u[k_block_coord],
+                            acc_u,
+                        )
+                    acc_empty_u_v_res.commit()
+                acc_full_u_v_res = acc_consumer.wait_and_advance()
+                acc_full_u_v_res.release()
+                cute.arch.barrier()
+
+                a_res_pack_frag = cute.make_fragment(4, mma_dtype)
+                for a_res_row_step in cutlass.range(4, unroll_full=True):
+                    a_res_row = tr_a + a_res_row_step * 16
+                    a_res_row_in_range = a_res_row < valid
+                    sA_res_slice = cute.make_tensor(
+                        sA_stage.iterator + a_res_row * BT + col_start_a,
+                        cute.make_layout(4),
+                    )
+                    a_res_load_frag = cute.make_fragment(4, Float32)
+                    cute.autovec_copy(sA_res_slice, a_res_load_frag)
+                    for a_res_c_off in cutlass.range_constexpr(4):
+                        a_res_col = col_start_a + a_res_c_off
+                        keep_a_res = a_res_row_in_range & (a_res_col < valid)
+                        a_res_val = a_res_load_frag[a_res_c_off] if keep_a_res else Float32(0.0)
+                        a_hi = a_res_val.to(mma_dtype)
+                        a_res_pack_frag[a_res_c_off] = (a_res_val - a_hi.to(Float32)).to(mma_dtype)
+                    sA_res_row = sA_mma[(a_res_row, None), 0, a_k_outer_t, 0]
+                    sA_res_4 = cute.tiled_divide(sA_res_row, (4,))
+                    cute.autovec_copy(a_res_pack_frag, sA_res_4[None, a_tile_in_outer])
+
+                vb_hi_frag = cute.make_fragment(4, mma_dtype)
+                for row_step_hi in cutlass.range(8, unroll_full=True):
+                    row_hi = tr + row_step_hi * 8
+                    safe_row_hi = cutlass.min(row_hi, valid - 1)
+                    k_inst_hi = row_hi % mma_k_inst
+                    k_outer_hi = row_hi // mma_k_inst
+                    beta_val_hi = beta_frag[row_step_hi]
+                    sV_slice_hi = cute.make_tensor(
+                        sV_stage.iterator + safe_row_hi * VAL_DIM + col_start,
+                        cute.make_layout(4),
+                    )
+                    cute.autovec_copy(sV_slice_hi, v_frag)
+                    for c_off_hi in cutlass.range_constexpr(4):
+                        vb_hi_frag[c_off_hi] = (v_frag[c_off_hi].to(Float32) * beta_val_hi).to(
+                            mma_dtype
+                        )
+                    sVb_hi_col = sVb_mma[(None, k_inst_hi), 0, k_outer_hi, 0]
+                    sVb_hi_4 = cute.tiled_divide(sVb_hi_col, (4,))
+                    cute.autovec_copy(vb_hi_frag, sVb_hi_4[None, tc])
+
+                cute.arch.fence_proxy(
+                    cute.arch.ProxyKind.async_shared,
+                    space=cute.arch.SharedSpace.shared_cta,
+                )
+                cvt_mma_barrier.arrive_and_wait()
+
+                if warp_idx == 0:
+                    num_k_blocks = cute.size(tCrA, mode=[2])
+                    acc_empty_u_a_res = acc_producer.acquire_and_advance()
+                    tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                    for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                        k_block_coord = (None, None, k_block_idx, 0)
+                        cute.gemm(
+                            tiled_mma,
+                            acc_u,
+                            tCrA[k_block_coord],
+                            tCrB_u[k_block_coord],
+                            acc_u,
+                        )
+                    acc_empty_u_a_res.commit()
+
+                if cutlass.const_expr(prefetch_next_tile):
+                    next_persistent_iter = persistent_iter + 1
+                    if next_persistent_iter < iters_per_cta_outer:
+                        next_work_idx = next_persistent_iter * num_persistent_ctas + cta_idx
+                        next_chunk_block = next_work_idx % num_chunks_runtime
+                        next_value_head_idx = next_work_idx // num_chunks_runtime
+                        next_key_head_idx = next_value_head_idx // head_group_size
+                        next_seq_idx = mChunkIndices[next_chunk_block, 0].to(Int32)
+                        next_chunk_idx = mChunkIndices[next_chunk_block, 1].to(Int32)
+                        next_bos = mCuSeqlens[next_seq_idx].to(Int32)
+                        next_eos = mCuSeqlens[next_seq_idx + 1].to(Int32)
+                        next_time_base = next_bos + next_chunk_idx * BT
+                        next_valid = cutlass.min(next_eos - next_time_base, Int32(BT))
+
+                        (
+                            next_gK_tile,
+                            next_gV_tile,
+                            next_gQ_tile,
+                            next_gG_tile,
+                            next_gA_tile,
+                        ) = _make_input_tiles(
+                            mK,
+                            mV,
+                            mQ,
+                            mG,
+                            mA,
+                            next_time_base,
+                            next_key_head_idx,
+                            next_value_head_idx,
+                        )
+                        _copy_input_tiles(
+                            tiled_copy_bf16,
+                            tiled_copy_fp32_kv,
+                            tiled_copy_a,
+                            thr_copy_bf16,
+                            thr_copy_fp32_kv,
+                            thr_copy_a,
+                            next_gK_tile,
+                            next_gV_tile,
+                            next_gQ_tile,
+                            next_gG_tile,
+                            next_gA_tile,
+                            sK_stage,
+                            sV_stage,
+                            sQ_stage,
+                            sG_stage,
+                            sA_stage,
+                            next_valid,
+                            has_q,
+                            has_gk,
+                        )
+
+            # Drain U stage (stage 1).
+            acc_full_u = acc_consumer.wait_and_advance()
+            if tidx < 128:
+                for u_i in cutlass.range_constexpr(subtile_cnt):
+                    cute.copy(tmem_tiled_copy, tDtU[None, None, u_i], tCrAcc)
+                    tCrC.store(tCrAcc.load().to(IO_DTYPE))
+                    _store_epilogue_tile(
+                        tCrC,
+                        tDgU[None, None, u_i],
+                        tDcU[None, None, u_i],
+                        valid,
+                    )
+            acc_full_u.release()
+
+        # Deallocate TMEM
+        pipeline.sync(barrier_id=1)
+        tmem.free(tmem_ptr)
+
+
+# ============================================================================
+# Host function: build tiled_mma and TMA atoms, then launch
+# ============================================================================
+
+
+class RecomputeWUForwardVarlenB1FullChunk:
+    """
+    Launch wrapper for the varlen B=1 full-chunk UMMA kernel.
+
+    The specialization knobs are compile-time constants: optional q/gk outputs,
+    A dtype, and the MMA operand precision (MmaPrecision). num_chunks remains a
+    runtime device scalar passed through to the kernel.
+    """
+
+    def __init__(
+        self,
+        num_persistent_ctas: int,
+        chunk_size: int = BT,
+        a_is_fp32: bool = True,
+        has_q: bool = True,
+        has_gk: bool = True,
+        precision: MmaPrecision = MmaPrecision.BF16,
+        prefetch_next_tile: bool = False,
+    ):
+        assert chunk_size == BT, (
+            f"RecomputeWUForwardVarlenB1FullChunk requires chunk_size={BT}, "
+            f"got {chunk_size}. chunk_size=32 is not supported yet "
+            f"(tf32 UMMA requires M>=64)."
+        )
+        self.num_persistent_ctas = num_persistent_ctas
+        self.chunk_size = chunk_size
+        self.a_is_fp32 = a_is_fp32
+        self.has_q = has_q
+        self.has_gk = has_gk
+        self.precision = precision
+        self.prefetch_next_tile = prefetch_next_tile
+        self.threads_per_cta = THREADS_PER_CTA
+
+    @cute.jit
+    def __call__(
+        self,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        mBeta: cute.Tensor,
+        mA: cute.Tensor,
+        mG: cute.Tensor,
+        mW: cute.Tensor,
+        mU: cute.Tensor,
+        mQG: cute.Tensor,
+        mKG: cute.Tensor,
+        mCuSeqlens: cute.Tensor,
+        mChunkIndices: cute.Tensor,
+        mNumChunks: cute.Tensor,
+        stream: cuda.CUstream = None,
+    ):
+        a_is_fp32: Constexpr = self.a_is_fp32
+        has_q: Constexpr = self.has_q
+        has_gk: Constexpr = self.has_gk
+        prefetch_next_tile: Constexpr = self.prefetch_next_tile
+        # The single precision enum drives the kernel's compile-time flags; the
+        # two booleans below are mutually exclusive by construction.
+        mma_is_bf16: Constexpr = self.precision.is_bf16
+        u_dot_precision_tf32x3: Constexpr = self.precision.is_tf32x3
+
+        # Build the tiled MMA from the requested operand precision: bf16
+        # (kind::f16, K-inst 16) or tf32 (kind::tf32, K-inst 8); fp32 accumulator.
+        # B is MN-major so the CVT scatter of consecutive N cols at fixed K lands
+        # on a contiguous SMEM stripe — eliminates the bank conflicts that K-major
+        # produced.
+        op, mma_dtype = _mma_config(self.precision)
+        tiled_mma = cute.make_tiled_mma(op)
+
+        # SMEM layouts (swizzled) for A and B operands.
+        a_smem_layout = sm100_utils.make_smem_layout_a(
+            tiled_mma,
+            MMA_TILER_MNK,
+            mma_dtype,
+            AB_STAGES,
+        )
+        b_smem_layout = sm100_utils.make_smem_layout_b(
+            tiled_mma,
+            MMA_TILER_MNK,
+            mma_dtype,
+            AB_STAGES,
+        )
+
+        _kernel_varlen_b1_full_chunk.set_name_prefix("cutlass_dsl_recompute_w_u_fwd")
+        _kernel_varlen_b1_full_chunk(
+            tiled_mma,
+            mQ,
+            mK,
+            mV,
+            mBeta,
+            mA,
+            mG,
+            mW,
+            mU,
+            mQG,
+            mKG,
+            mCuSeqlens,
+            mChunkIndices,
+            mNumChunks,
+            a_smem_layout,
+            b_smem_layout,
+            self.num_persistent_ctas,
+            a_is_fp32,
+            has_q,
+            has_gk,
+            u_dot_precision_tf32x3,
+            prefetch_next_tile,
+            mma_is_bf16,
+        ).launch(
+            grid=(self.num_persistent_ctas, 1, 1),
+            block=(THREADS_PER_CTA, 1, 1),
+            stream=stream,
+        )
+
+
+# ============================================================================
+# Entry point
+# ============================================================================
+
+# Cache of precompiled executables keyed by (chunk_size, shape/dtype signature).
+_COMPILED_CACHE: dict[tuple, object] = {}
+
+
+def _compile_signature(t: torch.Tensor) -> tuple:
+    return (tuple(t.shape), t.dtype, t.device.index)
+
+
+def _assert_tensor_contract(
+    name: str,
+    tensor: torch.Tensor,
+    *,
+    shape: tuple[int, ...],
+    dtype: torch.dtype | tuple[torch.dtype, ...],
+    device: torch.device,
+    assumed_align: int = DATA_ALIGN_BYTES,
+) -> None:
+    assert tuple(tensor.shape) == shape, (
+        f"{name} must have shape {shape}, got {tuple(tensor.shape)}"
+    )
+    allowed_dtypes = dtype if isinstance(dtype, tuple) else (dtype,)
+    assert tensor.dtype in allowed_dtypes, (
+        f"{name} must have dtype "
+        f"{allowed_dtypes[0] if len(allowed_dtypes) == 1 else allowed_dtypes}, "
+        f"got {tensor.dtype}"
+    )
+    assert tensor.device == device, f"{name} must be on {device}, got {tensor.device}"
+    assert tensor.stride(-1) == 1, f"{name} must have innermost stride 1, got {tensor.stride(-1)}"
+    assert tensor.data_ptr() % assumed_align == 0, (
+        f"{name} data pointer must be {assumed_align}-byte aligned"
+    )
+
+
+def recompute_w_u_fwd(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    A: torch.Tensor,
+    q: Optional[torch.Tensor] = None,
+    gk: Optional[torch.Tensor] = None,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    chunk_indices: Optional[torch.Tensor] = None,
+    num_chunks: Optional[torch.Tensor] = None,
+    chunk_size: int = BT,
+    dot_precision: Union[str, MmaPrecision] = "bf16",
+    experimental_prefetch: bool = True,
+    # Back-compat alias: older callers may pass `g=` instead of `gk=`.
+    g: Optional[torch.Tensor] = None,
+) -> tuple[
+    Optional[torch.Tensor],
+    torch.Tensor,
+    Optional[torch.Tensor],
+    Optional[torch.Tensor],
+]:
+    """
+    Recompute KDA W/U intermediates on the native CuTe path.
+
+    Supported scope: varlen B=1, full chunks, chunk_size=64, K=V=128. The
+    caller must provide cu_seqlens, chunk_indices, and num_chunks. num_chunks is
+    a CUDA scalar tensor read by the kernel at runtime, not specialized by
+    value, which keeps padded CUDA graph replay from recompiling when the active
+    chunk count changes.
+
+    Computes per chunk:
+      - w = A @ (k * beta * exp2(gk)), or A @ (k * beta) without gk
+      - u = A @ (v * beta)
+      - qg = q * exp2(gk), returned only when both q and gk are provided
+      - kg = k * exp2(gk_last - gk), returned only when gk is provided
+
+    dot_precision selects the MMA operand precision (see the module header):
+      - "bf16"   (default): bf16 operands, kind::f16 MMA. Fastest.
+      - "tf32"            : tf32 operands, kind::tf32 MMA. More accurate.
+      - "tf32x3"          : tf32 base + first-order residual products on U for
+                            ~fp32 accuracy. Only valid when A is fp32.
+    The accumulator is always fp32; W is single-pass for every mode.
+    """
+    if gk is None and g is not None:
+        gk = g
+    has_gk = gk is not None
+    has_q = q is not None and has_gk
+
+    precision = _normalize_precision(dot_precision)
+    assert chunk_size == BT, (
+        f"recompute_w_u_fwd only supports chunk_size={BT} on the native CuTe "
+        f"path; got {chunk_size}. chunk_size=32 is not supported yet "
+        f"(tf32 UMMA requires M>=64)."
+    )
+
+    assert k.ndim == 4, f"k must be 4D [B, T, H, K], got shape {tuple(k.shape)}"
+    assert v.ndim == 4, f"v must be 4D [B, T, H, V], got shape {tuple(v.shape)}"
+    assert beta.ndim == 3, f"beta must be 3D [B, T, H], got shape {tuple(beta.shape)}"
+    assert A.ndim == 4, f"A must be 4D [B, T, H, BT], got shape {tuple(A.shape)}"
+    if q is not None:
+        assert q.ndim == 4, f"q must be 4D [B, T, H, K], got shape {tuple(q.shape)}"
+    if gk is not None:
+        assert gk.ndim == 4, f"gk must be 4D [B, T, H, K], got shape {tuple(gk.shape)}"
+
+    B, T, H_K, K = k.shape
+    H_V = v.shape[2]
+    V = v.shape[3]
+    device = k.device
+    assert B == 1, f"recompute_w_u_fwd requires B=1, got B={B}"
+    assert cu_seqlens is not None, "recompute_w_u_fwd requires cu_seqlens (varlen path only)"
+    assert T % BT == 0, f"recompute_w_u_fwd requires T % BT == 0 (T={T}, BT={BT})"
+    assert K == KEY_DIM, f"recompute_w_u_fwd requires head_dim K={KEY_DIM}, got {K}"
+    assert V == VAL_DIM, f"recompute_w_u_fwd requires head_dim V={VAL_DIM}, got {V}"
+    assert H_V % H_K == 0, (
+        f"recompute_w_u_fwd requires value heads ({H_V}) to be divisible by key heads ({H_K})"
+    )
+    assert beta.shape[2] == H_V, f"beta heads ({beta.shape[2]}) must match v heads ({H_V})"
+    assert A.shape[2] == H_V, f"A heads ({A.shape[2]}) must match v heads ({H_V})"
+    if q is not None:
+        assert q.shape[2] == H_V, f"q heads ({q.shape[2]}) must match v heads ({H_V})"
+    if gk is not None:
+        assert gk.shape[2] == H_K, f"gk heads ({gk.shape[2]}) must match k heads ({H_K})"
+    assert A.shape[-1] == BT, f"A.shape[-1]={A.shape[-1]} does not match chunk_size={BT}"
+    assert A.dtype in (
+        torch.float32,
+        torch.bfloat16,
+    ), f"A.dtype must be float32 or bfloat16, got {A.dtype}"
+    assert beta.dtype in (
+        torch.float32,
+        torch.bfloat16,
+    ), f"beta.dtype must be float32 or bfloat16, got {beta.dtype}"
+
+    if not isinstance(k, FakeTensor):
+        if not k.is_cuda:
+            raise RuntimeError("recompute_w_u_fwd kernel requires CUDA tensors")
+        _assert_tensor_contract(
+            "k",
+            k,
+            shape=(B, T, H_K, KEY_DIM),
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        _assert_tensor_contract(
+            "v",
+            v,
+            shape=(B, T, H_V, VAL_DIM),
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        _assert_tensor_contract(
+            "beta",
+            beta,
+            shape=(B, T, H_V),
+            dtype=(torch.float32, torch.bfloat16),
+            device=device,
+        )
+        _assert_tensor_contract(
+            "A",
+            A,
+            shape=(B, T, H_V, BT),
+            dtype=(torch.float32, torch.bfloat16),
+            device=device,
+        )
+        if q is not None:
+            _assert_tensor_contract(
+                "q",
+                q,
+                shape=(B, T, H_V, KEY_DIM),
+                dtype=torch.bfloat16,
+                device=device,
+            )
+        if gk is not None:
+            _assert_tensor_contract(
+                "gk",
+                gk,
+                shape=(B, T, H_K, KEY_DIM),
+                dtype=torch.float32,
+                device=device,
+            )
+
+    # Output allocation — only allocate the outputs we will actually produce.
+    w = k.new_empty((B, T, H_V, KEY_DIM))
+    u = torch.empty_like(v)
+    qg_out: Optional[torch.Tensor] = torch.empty_like(q) if has_q else None
+    kg_out: Optional[torch.Tensor] = k.new_empty((B, T, H_V, KEY_DIM)) if has_gk else None
+
+    if isinstance(k, FakeTensor):
+        return w, u, qg_out, kg_out
+
+    # Require caller-owned varlen metadata. num_chunks follows Triton: it is a
+    # runtime device scalar loaded in-kernel, not specialized by value. The
+    # wrapper must not allocate hidden metadata tensors on the hot path.
+    assert chunk_indices is not None, (
+        "recompute_w_u_fwd CuTe path requires caller-provided chunk_indices"
+    )
+    assert num_chunks is not None, (
+        "recompute_w_u_fwd CuTe path requires caller-provided num_chunks"
+    )
+    assert isinstance(num_chunks, torch.Tensor), (
+        "recompute_w_u_fwd CuTe path requires num_chunks as a caller-provided CUDA tensor"
+    )
+    assert cu_seqlens.dtype in (
+        torch.int32,
+        torch.int64,
+    ), f"cu_seqlens must be int32 or int64, got {cu_seqlens.dtype}"
+    assert cu_seqlens.ndim == 1 and cu_seqlens.numel() >= 2, (
+        f"cu_seqlens must be 1D with >=2 entries, got shape {tuple(cu_seqlens.shape)}"
+    )
+    assert cu_seqlens.device == k.device, (
+        f"cu_seqlens must be on {k.device}, got {cu_seqlens.device}"
+    )
+    assert cu_seqlens.is_contiguous(), "cu_seqlens must be contiguous"
+    assert chunk_indices.dtype in (
+        torch.int32,
+        torch.int64,
+    ), f"chunk_indices must be int32 or int64, got {chunk_indices.dtype}"
+    assert chunk_indices.ndim == 2 and chunk_indices.shape[-1] == 2, (
+        f"chunk_indices must have shape (num_chunks, 2), got {tuple(chunk_indices.shape)}"
+    )
+    assert chunk_indices.device == k.device, (
+        f"chunk_indices must be on {k.device}, got {chunk_indices.device}"
+    )
+    assert chunk_indices.is_contiguous(), "chunk_indices must be contiguous"
+    assert num_chunks.dtype in (
+        torch.int32,
+        torch.int64,
+    ), f"num_chunks must be int32 or int64, got {num_chunks.dtype}"
+    assert num_chunks.numel() == 1, (
+        f"num_chunks must contain one scalar value, got shape {tuple(num_chunks.shape)}"
+    )
+    assert num_chunks.device == k.device, (
+        f"num_chunks must be on {k.device}, got {num_chunks.device}"
+    )
+    assert num_chunks.is_contiguous(), "num_chunks must be contiguous"
+
+    num_chunks_i = num_chunks.reshape(1)
+
+    # Stubs for optional inputs/outputs — kernel's constexpr branches fully
+    # remove the corresponding loads/stores, but every mX param still needs a
+    # valid tensor with compatible shape (kernel derives tile shapes from them).
+    q_in = q if has_q else v
+    # gG_full uses mG[*, *, *, K=128]. k has this shape, but its fp32-vs-bf16
+    # dtype mismatch is fine because the cp.async and SMEM reads are dead code
+    # when has_gk=False. Reusing k avoids a hidden CUDA allocation on the hot
+    # optional no-gate path and keeps graph capture allocation-free.
+    gk_in = gk if has_gk else k
+    qg_in = qg_out if qg_out is not None else v
+    kg_in = kg_out if kg_out is not None else v
+
+    stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
+    # Both index tensors are passed through — kernel casts to int32 at load
+    # time, so int64 or int32 works identically.
+    cu_align = INDEX_ALIGN_BYTES if cu_seqlens.dtype == torch.int32 else 8
+    ci_align = INDEX_ALIGN_BYTES if chunk_indices.dtype == torch.int32 else 8
+    nc_align = INDEX_ALIGN_BYTES if num_chunks_i.dtype == torch.int32 else 8
+    mCuSeqlens = _as_cute_tensor(cu_seqlens, assumed_align=cu_align, enable_tvm_ffi=True)
+    mChunkIndices = _as_cute_tensor(chunk_indices, assumed_align=ci_align, enable_tvm_ffi=True)
+    mNumChunks = _as_cute_tensor(num_chunks_i, assumed_align=nc_align, enable_tvm_ffi=True)
+
+    mQ = _as_cute_tensor(q_in, mark_divisibility=True, enable_tvm_ffi=True)
+    mK = _as_cute_tensor(k, mark_divisibility=True, enable_tvm_ffi=True)
+    mV = _as_cute_tensor(v, mark_divisibility=True, enable_tvm_ffi=True)
+    mBeta = _as_cute_tensor(beta, enable_tvm_ffi=True)
+    mA = _as_cute_tensor(A, mark_divisibility=True, enable_tvm_ffi=True)
+    mG = _as_cute_tensor(gk_in, mark_divisibility=True, enable_tvm_ffi=True)
+    mW = _as_cute_tensor(w, mark_divisibility=True, enable_tvm_ffi=True)
+    mU = _as_cute_tensor(u, mark_divisibility=True, enable_tvm_ffi=True)
+    mQG = _as_cute_tensor(qg_in, mark_divisibility=True, enable_tvm_ffi=True)
+    mKG = _as_cute_tensor(kg_in, mark_divisibility=True, enable_tvm_ffi=True)
+
+    a_is_fp32 = A.dtype == torch.float32
+    # tf32x3 emulates fp32 by adding first-order residual products; once A is
+    # bf16-rounded the residual is meaningless, so it is only valid for fp32 A.
+    assert not (precision.is_tf32x3 and not a_is_fp32), (
+        "recompute_w_u_fwd dot_precision='tf32x3' requires fp32 A "
+        f"(got A.dtype={A.dtype}); use 'bf16' or 'tf32' for non-fp32 A."
+    )
+    num_persistent_ctas = torch.cuda.get_device_properties(k.device).multi_processor_count * 2
+    sig = (
+        num_persistent_ctas,
+        BT,
+        _compile_signature(q_in),
+        _compile_signature(k),
+        _compile_signature(v),
+        _compile_signature(beta),
+        _compile_signature(A),
+        _compile_signature(gk_in),
+        _compile_signature(cu_seqlens),
+        _compile_signature(chunk_indices),
+        _compile_signature(num_chunks_i),
+        a_is_fp32,
+        has_q,
+        has_gk,
+        precision,
+        experimental_prefetch,
+    )
+    compiled = _COMPILED_CACHE.get(sig)
+    if compiled is None:
+        kernel = RecomputeWUForwardVarlenB1FullChunk(
+            num_persistent_ctas=num_persistent_ctas,
+            chunk_size=BT,
+            a_is_fp32=a_is_fp32,
+            has_q=has_q,
+            has_gk=has_gk,
+            precision=precision,
+            prefetch_next_tile=experimental_prefetch,
+        )
+        compiled = cute.compile(
+            kernel,
+            mQ,
+            mK,
+            mV,
+            mBeta,
+            mA,
+            mG,
+            mW,
+            mU,
+            mQG,
+            mKG,
+            mCuSeqlens,
+            mChunkIndices,
+            mNumChunks,
+            stream,
+            options="--enable-tvm-ffi",
+        )
+        _COMPILED_CACHE[sig] = compiled
+
+    compiled(
+        q_in.detach(),
+        k.detach(),
+        v.detach(),
+        beta.detach(),
+        A.detach(),
+        gk_in.detach(),
+        w,
+        u,
+        qg_in,
+        kg_in,
+        cu_seqlens,
+        chunk_indices,
+        num_chunks_i,
+    )
+
+    return w, u, qg_out, kg_out

--- a/attn_gym/linear/kda/fwd/triton/__init__.py
+++ b/attn_gym/linear/kda/fwd/triton/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
@@ -1,0 +1,766 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import triton
+import triton.language as tl
+from attn_gym.linear.kda.utils import (
+    exp,
+    exp2,
+)
+
+
+@triton.heuristics(
+    {
+        "USE_G": lambda args: args["g"] is not None,
+        "USE_GK": lambda args: args["gk"] is not None,
+        "USE_INITIAL_STATE": lambda args: args["h0"] is not None,
+        "STORE_FINAL_STATE": lambda args: args["ht"] is not None,
+        "SAVE_NEW_VALUE": lambda args: args["v_new"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+        "HAS_NUM_SEQS": lambda args: args["num_seqs"] is not None,
+    }
+)
+@triton.jit(do_not_specialize=["T", "num_seqs"])
+def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
+    k,
+    v,
+    w,
+    v_new,
+    g,
+    gk,
+    h,
+    h0,
+    ht,
+    cu_seqlens,
+    chunk_offsets,
+    num_seqs,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BV: tl.constexpr,
+    USE_G: tl.constexpr,
+    USE_GK: tl.constexpr,
+    USE_INITIAL_STATE: tl.constexpr,
+    STORE_FINAL_STATE: tl.constexpr,
+    SAVE_NEW_VALUE: tl.constexpr,
+    USE_EXP2: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    HAS_NUM_SEQS: tl.constexpr,
+):
+    i_nh, i_v = tl.program_id(0), tl.program_id(1)
+    i_n, i_h = i_nh // H, i_nh % H
+    if IS_VARLEN:
+        if HAS_NUM_SEQS:
+            if i_n >= tl.load(num_seqs):
+                return
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int32),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+        )
+        T = eos - bos
+        NT = tl.cdiv(T, BT)
+        boh = tl.load(chunk_offsets + i_n).to(tl.int32)
+    else:
+        bos, eos = i_n * T, i_n * T + T
+        NT = tl.cdiv(T, BT)
+        boh = i_n * NT
+
+    # [BK, BV]
+    b_h1 = tl.zeros([64, BV], dtype=tl.float32)
+    if K > 64:
+        b_h2 = tl.zeros([64, BV], dtype=tl.float32)
+    if K > 128:
+        b_h3 = tl.zeros([64, BV], dtype=tl.float32)
+    if K > 192:
+        b_h4 = tl.zeros([64, BV], dtype=tl.float32)
+
+    # calculate offset
+    h += (boh * H + i_h).to(tl.int64) * K * V
+    v += (bos * H + i_h).to(tl.int64) * V
+    k += (bos * H + i_h).to(tl.int64) * K
+    w += (bos * H + i_h).to(tl.int64) * K
+    if SAVE_NEW_VALUE:
+        v_new += (bos * H + i_h).to(tl.int64) * V
+
+    if USE_INITIAL_STATE:
+        h0 = h0 + i_nh * K * V
+    if STORE_FINAL_STATE:
+        ht = ht + i_nh * K * V
+
+    # load initial state
+    if USE_INITIAL_STATE:
+        p_h0_1 = tl.make_block_ptr(h0, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
+        b_h1 += tl.load(p_h0_1, boundary_check=(0, 1)).to(tl.float32)
+        if K > 64:
+            p_h0_2 = tl.make_block_ptr(
+                h0, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0)
+            )
+            b_h2 += tl.load(  # pyrefly: ignore[unbound-name]
+                p_h0_2, boundary_check=(0, 1)
+            ).to(  # pyrefly: ignore[unbound-name]
+                tl.float32
+            )  # pyrefly: ignore[unbound-name]
+        if K > 128:
+            p_h0_3 = tl.make_block_ptr(
+                h0,
+                (K, V),
+                (V, 1),
+                (128, i_v * BV),
+                (64, BV),
+                (1, 0),  # pyrefly: ignore[unbound-name]
+            )
+            b_h3 += tl.load(  # pyrefly: ignore[unbound-name]
+                p_h0_3, boundary_check=(0, 1)
+            ).to(  # pyrefly: ignore[unbound-name]
+                tl.float32
+            )  # pyrefly: ignore[unbound-name]
+        if K > 192:  # pyrefly: ignore[unbound-name]
+            p_h0_4 = tl.make_block_ptr(
+                h0, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0)
+            )
+            b_h4 += tl.load(  # pyrefly: ignore[unbound-name]
+                p_h0_4, boundary_check=(0, 1)
+            ).to(  # pyrefly: ignore[unbound-name]
+                tl.float32
+            )  # pyrefly: ignore[unbound-name]
+
+    # main recurrence
+    for i_t in range(NT):
+        p_h1 = tl.make_block_ptr(
+            h + i_t * H * K * V, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0)
+        )  # pyrefly: ignore[unbound-name]
+        tl.store(p_h1, b_h1.to(p_h1.dtype.element_ty), boundary_check=(0, 1))
+        if K > 64:
+            p_h2 = tl.make_block_ptr(
+                h + i_t * H * K * V, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0)
+            )  # pyrefly: ignore[unbound-name]
+            tl.store(
+                p_h2,
+                b_h2.to(p_h2.dtype.element_ty),  # pyrefly: ignore[unbound-name]
+                boundary_check=(0, 1),  # pyrefly: ignore[unbound-name]
+            )  # pyrefly: ignore[unbound-name]
+        if K > 128:
+            p_h3 = tl.make_block_ptr(  # pyrefly: ignore[unbound-name]
+                h + i_t * H * K * V, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0)
+            )
+            tl.store(
+                p_h3,
+                b_h3.to(p_h3.dtype.element_ty),  # pyrefly: ignore[unbound-name]
+                boundary_check=(0, 1),  # pyrefly: ignore[unbound-name]
+            )  # pyrefly: ignore[unbound-name]
+        if K > 192:
+            p_h4 = tl.make_block_ptr(
+                h + i_t * H * K * V, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0)
+            )
+            tl.store(  # pyrefly: ignore[unbound-name]
+                p_h4,
+                b_h4.to(p_h4.dtype.element_ty),  # pyrefly: ignore[unbound-name]
+                boundary_check=(0, 1),  # pyrefly: ignore[unbound-name]
+            )  # pyrefly: ignore[unbound-name]
+
+        p_w = tl.make_block_ptr(w, (T, K), (H * K, 1), (i_t * BT, 0), (BT, 64), (1, 0))
+        b_w = tl.load(p_w, boundary_check=(0, 1))
+        b_v = tl.dot(b_w, b_h1.to(b_w.dtype))  # pyrefly: ignore[unbound-name]
+        if K > 64:
+            p_w = tl.make_block_ptr(
+                w, (T, K), (H * K, 1), (i_t * BT, 64), (BT, 64), (1, 0)
+            )
+            b_w = tl.load(p_w, boundary_check=(0, 1))
+            b_v += tl.dot(b_w, b_h2.to(b_w.dtype))  # pyrefly: ignore[unbound-name]
+        if K > 128:
+            p_w = tl.make_block_ptr(
+                w, (T, K), (H * K, 1), (i_t * BT, 128), (BT, 64), (1, 0)
+            )
+            b_w = tl.load(p_w, boundary_check=(0, 1))
+            b_v += tl.dot(b_w, b_h3.to(b_w.dtype))  # pyrefly: ignore[unbound-name]
+        if K > 192:
+            p_w = tl.make_block_ptr(
+                w, (T, K), (H * K, 1), (i_t * BT, 192), (BT, 64), (1, 0)
+            )
+            b_w = tl.load(p_w, boundary_check=(0, 1))
+            b_v += tl.dot(b_w, b_h4.to(b_w.dtype))  # pyrefly: ignore[unbound-name]
+        p_v = tl.make_block_ptr(
+            v, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+        )
+        b_v = tl.load(p_v, boundary_check=(0, 1)) - b_v
+
+        if SAVE_NEW_VALUE:
+            p_v = tl.make_block_ptr(
+                v_new, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+            )
+            tl.store(p_v, b_v.to(p_v.dtype.element_ty), boundary_check=(0, 1))
+
+        last_idx = min((i_t + 1) * BT, T) - 1
+        if USE_G:
+            m_t = (i_t * BT + tl.arange(0, BT)) < T
+            b_g_last = tl.load(g + bos * H + last_idx * H + i_h)
+            p_g = tl.make_block_ptr(  # pyrefly: ignore[unbound-name]
+                g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
+            )  # pyrefly: ignore[unbound-name]
+            b_g = tl.load(p_g, boundary_check=(0,))
+            if USE_EXP2:  # pyrefly: ignore[unbound-name]
+                b_v = b_v * tl.where(m_t, exp2(b_g_last - b_g), 0)[:, None]
+                b_g_last = exp2(b_g_last)
+            else:
+                b_v = b_v * tl.where(m_t, exp(b_g_last - b_g), 0)[:, None]
+                b_g_last = exp(b_g_last)
+            b_h1 *= b_g_last
+            if K > 64:
+                b_h2 *= b_g_last  # pyrefly: ignore[unbound-name]
+            if K > 128:
+                b_h3 *= b_g_last  # pyrefly: ignore[unbound-name,unsupported-operation]
+            if K > 192:
+                b_h4 *= b_g_last  # pyrefly: ignore[unbound-name,unsupported-operation]
+
+        if USE_GK:
+            o_k1 = tl.arange(0, 64)
+            b_gk_last1 = tl.load(
+                gk + (bos + last_idx) * H * K + i_h * K + o_k1,
+                mask=(o_k1 < K),
+                other=0.0,
+            )
+            if USE_EXP2:  # pyrefly: ignore[unbound-name,unsupported-operation]
+                b_h1 *= exp2(b_gk_last1)[
+                    :, None  # pyrefly: ignore[unbound-name,unsupported-operation]
+                ]  # pyrefly: ignore[unsupported-operation]
+            else:
+                b_h1 *= exp(b_gk_last1)[
+                    :, None
+                ]  # pyrefly: ignore[unsupported-operation]
+            if K > 64:
+                o_k2 = 64 + o_k1
+                b_gk_last2 = tl.load(
+                    gk
+                    + (bos + last_idx) * H * K
+                    + i_h * K
+                    + o_k2,  # pyrefly: ignore[unbound-name,unsupported-operation]
+                    mask=(o_k2 < K),
+                    other=0.0,  # pyrefly: ignore[unbound-name,unsupported-operation]
+                )
+                if USE_EXP2:
+                    b_h2 *= exp2(b_gk_last2)[  # pyrefly: ignore[unbound-name]
+                        :, None
+                    ]  # pyrefly: ignore[unbound-name,unsupported-operation]
+                else:
+                    b_h2 *= exp(b_gk_last2)[  # pyrefly: ignore[unbound-name]
+                        :, None
+                    ]  # pyrefly: ignore[unbound-name,unsupported-operation]
+            if K > 128:
+                o_k3 = 128 + o_k1  # pyrefly: ignore[unbound-name,unsupported-operation]
+                b_gk_last3 = tl.load(
+                    gk + (bos + last_idx) * H * K + i_h * K + o_k3,
+                    mask=(o_k3 < K),
+                    other=0.0,
+                )
+                if USE_EXP2:
+                    b_h3 *= exp2(b_gk_last3)[  # pyrefly: ignore[unbound-name]
+                        :, None
+                    ]  # pyrefly: ignore[unbound-name,unsupported-operation]
+                else:
+                    b_h3 *= exp(b_gk_last3)[  # pyrefly: ignore[unbound-name]
+                        :, None
+                    ]  # pyrefly: ignore[unbound-name,unsupported-operation]
+            if K > 192:
+                o_k4 = 192 + o_k1
+                b_gk_last4 = tl.load(
+                    gk
+                    + (bos + last_idx) * H * K
+                    + i_h * K
+                    + o_k4,  # pyrefly: ignore[unbound-name]
+                    mask=(o_k4 < K),
+                    other=0.0,
+                )
+                if USE_EXP2:
+                    b_h4 *= exp2(b_gk_last4)[  # pyrefly: ignore[unbound-name]
+                        :, None  # pyrefly: ignore[unbound-name]
+                    ]  # pyrefly: ignore[unbound-name,unsupported-operation]
+                else:
+                    b_h4 *= exp(b_gk_last4)[  # pyrefly: ignore[unbound-name]
+                        :, None
+                    ]  # pyrefly: ignore[unbound-name,unsupported-operation]
+        b_v = b_v.to(k.dtype.element_ty)
+
+        p_k = tl.make_block_ptr(k, (K, T), (1, H * K), (0, i_t * BT), (64, BT), (0, 1))
+        b_k = tl.load(p_k, boundary_check=(0, 1))  # pyrefly: ignore[unbound-name]
+        b_h1 += tl.dot(b_k, b_v)
+        if K > 64:
+            p_k = tl.make_block_ptr(
+                k, (K, T), (1, H * K), (64, i_t * BT), (64, BT), (0, 1)
+            )  # pyrefly: ignore[unbound-name]
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            b_h2 += tl.dot(b_k, b_v)  # pyrefly: ignore[unbound-name]
+        if K > 128:
+            p_k = tl.make_block_ptr(
+                k,
+                (K, T),
+                (1, H * K),
+                (128, i_t * BT),
+                (64, BT),
+                (0, 1),  # pyrefly: ignore[unbound-name]
+            )
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            b_h3 += tl.dot(b_k, b_v)  # pyrefly: ignore[unbound-name]
+        if K > 192:
+            p_k = tl.make_block_ptr(
+                k, (K, T), (1, H * K), (192, i_t * BT), (64, BT), (0, 1)
+            )
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            b_h4 += tl.dot(b_k, b_v)  # pyrefly: ignore[unbound-name]
+
+    if STORE_FINAL_STATE:
+        p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
+        tl.store(p_ht, b_h1.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+        if K > 64:
+            p_ht = tl.make_block_ptr(
+                ht, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0)
+            )
+            tl.store(
+                p_ht,
+                b_h2.to(p_ht.dtype.element_ty),  # pyrefly: ignore[unbound-name]
+                boundary_check=(0, 1),  # pyrefly: ignore[unbound-name]
+            )  # pyrefly: ignore[unbound-name]
+        if K > 128:
+            p_ht = tl.make_block_ptr(
+                ht, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0)
+            )
+            tl.store(
+                p_ht,
+                b_h3.to(p_ht.dtype.element_ty),  # pyrefly: ignore[unbound-name]
+                boundary_check=(0, 1),  # pyrefly: ignore[unbound-name]
+            )  # pyrefly: ignore[unbound-name]
+        if K > 192:
+            p_ht = tl.make_block_ptr(
+                ht, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0)
+            )
+            tl.store(
+                p_ht,
+                b_h4.to(p_ht.dtype.element_ty),  # pyrefly: ignore[unbound-name]
+                boundary_check=(0, 1),  # pyrefly: ignore[unbound-name]
+            )  # pyrefly: ignore[unbound-name]
+
+
+@triton.heuristics(
+    {
+        "USE_G": lambda args: args["g"] is not None,
+        "USE_GK": lambda args: args["gk"] is not None,
+        "USE_INITIAL_STATE": lambda args: args["h0"] is not None,
+        "STORE_FINAL_STATE": lambda args: args["ht"] is not None,
+        "SAVE_NEW_VALUE": lambda args: args["v_new"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+        "HAS_NUM_SEQS": lambda args: args["num_seqs"] is not None,
+    }
+)
+@triton.jit(do_not_specialize=["T", "num_seqs"])
+def chunk_gated_delta_rule_fwd_kernel_h_blockdim64_forloop(
+    k,
+    v,
+    w,
+    v_new,
+    g,
+    gk,
+    h,
+    h0,
+    ht,
+    cu_seqlens,
+    chunk_offsets,
+    num_seqs,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BV: tl.constexpr,
+    USE_G: tl.constexpr,
+    USE_GK: tl.constexpr,
+    USE_INITIAL_STATE: tl.constexpr,
+    STORE_FINAL_STATE: tl.constexpr,
+    SAVE_NEW_VALUE: tl.constexpr,
+    USE_EXP2: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    HAS_NUM_SEQS: tl.constexpr,
+    GRID_N: tl.constexpr,
+    MAX_N: tl.constexpr,
+):
+    i_nh, i_v = tl.program_id(0), tl.program_id(1)
+    i_h = i_nh % H
+    i_n_start = i_nh // H
+
+    if HAS_NUM_SEQS:
+        upper_limit = tl.load(num_seqs)
+
+    for _iter in range((MAX_N + GRID_N - 1) // GRID_N):
+        i_n = i_n_start + _iter * GRID_N
+        _run = i_n < MAX_N
+        if IS_VARLEN:
+            if HAS_NUM_SEQS:
+                if _run:
+                    _run = i_n < upper_limit  # pyrefly: ignore [unbound-name]
+        if _run:
+            if IS_VARLEN:
+                bos, eos = (
+                    tl.load(cu_seqlens + i_n).to(tl.int32),
+                    tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+                )
+                T_local = eos - bos
+                NT = tl.cdiv(T_local, BT)
+                boh = tl.load(chunk_offsets + i_n).to(tl.int32)
+            else:
+                bos, eos = i_n * T, i_n * T + T
+                T_local = T
+                NT = tl.cdiv(T_local, BT)
+                boh = i_n * NT
+
+            # [BK, BV]
+            b_h1 = tl.zeros([64, BV], dtype=tl.float32)
+            if K > 64:
+                b_h2 = tl.zeros([64, BV], dtype=tl.float32)
+            if K > 128:
+                b_h3 = tl.zeros([64, BV], dtype=tl.float32)
+            if K > 192:
+                b_h4 = tl.zeros([64, BV], dtype=tl.float32)
+
+            # calculate offset from base pointers
+            h_off = h + (boh * H + i_h).to(tl.int64) * K * V
+            v_off = v + (bos * H + i_h).to(tl.int64) * V
+            k_off = k + (bos * H + i_h).to(tl.int64) * K
+            w_off = w + (bos * H + i_h).to(tl.int64) * K
+            if SAVE_NEW_VALUE:
+                v_new_off = v_new + (bos * H + i_h).to(tl.int64) * V
+
+            i_nh_abs = i_n * H + i_h
+
+            # load initial state
+            if USE_INITIAL_STATE:
+                h0_off = h0 + i_nh_abs * K * V
+                p_h0_1 = tl.make_block_ptr(
+                    h0_off, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0)
+                )
+                b_h1 += tl.load(p_h0_1, boundary_check=(0, 1)).to(tl.float32)
+                if K > 64:
+                    p_h0_2 = tl.make_block_ptr(
+                        h0_off, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0)
+                    )
+                    # pyrefly: ignore [unbound-name]
+                    b_h2 += tl.load(p_h0_2, boundary_check=(0, 1)).to(tl.float32)
+                if K > 128:
+                    p_h0_3 = tl.make_block_ptr(
+                        h0_off,
+                        (K, V),
+                        (V, 1),
+                        (128, i_v * BV),
+                        (64, BV),
+                        (1, 0),
+                    )
+                    # pyrefly: ignore [unbound-name]
+                    b_h3 += tl.load(p_h0_3, boundary_check=(0, 1)).to(tl.float32)
+                if K > 192:
+                    p_h0_4 = tl.make_block_ptr(
+                        h0_off, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0)
+                    )
+                    # pyrefly: ignore [unbound-name]
+                    b_h4 += tl.load(p_h0_4, boundary_check=(0, 1)).to(tl.float32)
+
+            # main recurrence
+            for i_t in range(NT):
+                p_h1 = tl.make_block_ptr(
+                    h_off + i_t * H * K * V,
+                    (K, V),
+                    (V, 1),
+                    (0, i_v * BV),
+                    (64, BV),
+                    (1, 0),
+                )  # pyrefly: ignore[unbound-name]
+                tl.store(p_h1, b_h1.to(p_h1.dtype.element_ty), boundary_check=(0, 1))
+                if K > 64:
+                    p_h2 = tl.make_block_ptr(
+                        h_off + i_t * H * K * V,
+                        (K, V),
+                        (V, 1),
+                        (64, i_v * BV),
+                        (64, BV),
+                        (1, 0),
+                    )  # pyrefly: ignore[unbound-name]
+                    tl.store(
+                        p_h2,
+                        b_h2.to(p_h2.dtype.element_ty),  # pyrefly: ignore[unbound-name]
+                        boundary_check=(0, 1),  # pyrefly: ignore[unbound-name]
+                    )  # pyrefly: ignore[unbound-name]
+                if K > 128:
+                    p_h3 = tl.make_block_ptr(  # pyrefly: ignore[unbound-name]
+                        h_off + i_t * H * K * V,
+                        (K, V),
+                        (V, 1),
+                        (128, i_v * BV),
+                        (64, BV),
+                        (1, 0),
+                    )
+                    tl.store(
+                        p_h3,
+                        b_h3.to(p_h3.dtype.element_ty),  # pyrefly: ignore[unbound-name]
+                        boundary_check=(0, 1),  # pyrefly: ignore[unbound-name]
+                    )  # pyrefly: ignore[unbound-name]
+                if K > 192:
+                    p_h4 = tl.make_block_ptr(
+                        h_off + i_t * H * K * V,
+                        (K, V),
+                        (V, 1),
+                        (192, i_v * BV),
+                        (64, BV),
+                        (1, 0),
+                    )
+                    tl.store(  # pyrefly: ignore[unbound-name]
+                        p_h4,
+                        b_h4.to(p_h4.dtype.element_ty),  # pyrefly: ignore[unbound-name]
+                        boundary_check=(0, 1),  # pyrefly: ignore[unbound-name]
+                    )  # pyrefly: ignore[unbound-name]
+
+                p_w = tl.make_block_ptr(
+                    w_off, (T_local, K), (H * K, 1), (i_t * BT, 0), (BT, 64), (1, 0)
+                )
+                b_w = tl.load(p_w, boundary_check=(0, 1))
+                b_v = tl.dot(b_w, b_h1.to(b_w.dtype))  # pyrefly: ignore[unbound-name]
+                if K > 64:
+                    p_w = tl.make_block_ptr(
+                        w_off,
+                        (T_local, K),
+                        (H * K, 1),
+                        (i_t * BT, 64),
+                        (BT, 64),
+                        (1, 0),
+                    )
+                    b_w = tl.load(p_w, boundary_check=(0, 1))
+                    b_v += tl.dot(
+                        b_w,
+                        b_h2.to(b_w.dtype),  # pyrefly: ignore [unbound-name]
+                    )  # pyrefly: ignore[unbound-name]
+                if K > 128:
+                    p_w = tl.make_block_ptr(
+                        w_off,
+                        (T_local, K),
+                        (H * K, 1),
+                        (i_t * BT, 128),
+                        (BT, 64),
+                        (1, 0),
+                    )
+                    b_w = tl.load(p_w, boundary_check=(0, 1))
+                    b_v += tl.dot(
+                        b_w,
+                        b_h3.to(b_w.dtype),  # pyrefly: ignore [unbound-name]
+                    )  # pyrefly: ignore[unbound-name]
+                if K > 192:
+                    p_w = tl.make_block_ptr(
+                        w_off,
+                        (T_local, K),
+                        (H * K, 1),
+                        (i_t * BT, 192),
+                        (BT, 64),
+                        (1, 0),
+                    )
+                    b_w = tl.load(p_w, boundary_check=(0, 1))
+                    b_v += tl.dot(
+                        b_w,
+                        b_h4.to(b_w.dtype),  # pyrefly: ignore [unbound-name]
+                    )  # pyrefly: ignore[unbound-name]
+                p_v = tl.make_block_ptr(
+                    v_off,
+                    (T_local, V),
+                    (H * V, 1),
+                    (i_t * BT, i_v * BV),
+                    (BT, BV),
+                    (1, 0),
+                )
+                b_v = tl.load(p_v, boundary_check=(0, 1)) - b_v
+
+                if SAVE_NEW_VALUE:
+                    p_v = tl.make_block_ptr(
+                        # pyrefly: ignore [unbound-name]
+                        v_new_off,
+                        (T_local, V),
+                        (H * V, 1),
+                        (i_t * BT, i_v * BV),
+                        (BT, BV),
+                        (1, 0),
+                    )
+                    tl.store(p_v, b_v.to(p_v.dtype.element_ty), boundary_check=(0, 1))
+
+                last_idx = min((i_t + 1) * BT, T_local) - 1
+                if USE_G:
+                    m_t = (i_t * BT + tl.arange(0, BT)) < T_local
+                    b_g_last = tl.load(g + bos * H + last_idx * H + i_h)
+                    p_g = tl.make_block_ptr(  # pyrefly: ignore[unbound-name]
+                        g + bos * H + i_h, (T_local,), (H,), (i_t * BT,), (BT,), (0,)
+                    )  # pyrefly: ignore[unbound-name]
+                    b_g = tl.load(p_g, boundary_check=(0,))
+                    if USE_EXP2:  # pyrefly: ignore[unbound-name]
+                        b_v = b_v * tl.where(m_t, exp2(b_g_last - b_g), 0)[:, None]
+                        b_g_last = exp2(b_g_last)
+                    else:
+                        b_v = b_v * tl.where(m_t, exp(b_g_last - b_g), 0)[:, None]
+                        b_g_last = exp(b_g_last)
+                    b_h1 *= b_g_last
+                    if K > 64:
+                        b_h2 *= b_g_last  # pyrefly: ignore[unbound-name]
+                    if K > 128:
+                        b_h3 *= b_g_last  # pyrefly: ignore[unbound-name,unsupported-operation]
+                    if K > 192:
+                        b_h4 *= b_g_last  # pyrefly: ignore[unbound-name,unsupported-operation]
+
+                if USE_GK:
+                    o_k1 = tl.arange(0, 64)
+                    b_gk_last1 = tl.load(
+                        gk + (bos + last_idx) * H * K + i_h * K + o_k1,
+                        mask=(o_k1 < K),
+                        other=0.0,
+                    )
+                    if USE_EXP2:  # pyrefly: ignore[unbound-name,unsupported-operation]
+                        b_h1 *= exp2(b_gk_last1)[
+                            :,
+                            None,  # pyrefly: ignore[unbound-name,unsupported-operation]
+                        ]  # pyrefly: ignore[unsupported-operation]
+                    else:
+                        b_h1 *= exp(b_gk_last1)[
+                            :, None
+                        ]  # pyrefly: ignore[unsupported-operation]
+                    if K > 64:
+                        o_k2 = 64 + o_k1
+                        b_gk_last2 = tl.load(
+                            gk
+                            + (bos + last_idx) * H * K
+                            + i_h * K
+                            + o_k2,  # pyrefly: ignore[unbound-name,unsupported-operation]
+                            mask=(o_k2 < K),
+                            other=0.0,  # pyrefly: ignore[unbound-name,unsupported-operation]
+                        )
+                        if USE_EXP2:
+                            b_h2 *= exp2(b_gk_last2)[  # pyrefly: ignore[unbound-name]
+                                :, None
+                            ]  # pyrefly: ignore[unbound-name,unsupported-operation]
+                        else:
+                            b_h2 *= exp(b_gk_last2)[  # pyrefly: ignore[unbound-name]
+                                :, None
+                            ]  # pyrefly: ignore[unbound-name,unsupported-operation]
+                    if K > 128:
+                        o_k3 = (
+                            128 + o_k1
+                        )  # pyrefly: ignore[unbound-name,unsupported-operation]
+                        b_gk_last3 = tl.load(
+                            gk + (bos + last_idx) * H * K + i_h * K + o_k3,
+                            mask=(o_k3 < K),
+                            other=0.0,
+                        )
+                        if USE_EXP2:
+                            b_h3 *= exp2(b_gk_last3)[  # pyrefly: ignore[unbound-name]
+                                :, None
+                            ]  # pyrefly: ignore[unbound-name,unsupported-operation]
+                        else:
+                            b_h3 *= exp(b_gk_last3)[  # pyrefly: ignore[unbound-name]
+                                :, None
+                            ]  # pyrefly: ignore[unbound-name,unsupported-operation]
+                    if K > 192:
+                        o_k4 = 192 + o_k1
+                        b_gk_last4 = tl.load(
+                            gk
+                            + (bos + last_idx) * H * K
+                            + i_h * K
+                            + o_k4,  # pyrefly: ignore[unbound-name]
+                            mask=(o_k4 < K),
+                            other=0.0,
+                        )
+                        if USE_EXP2:
+                            b_h4 *= exp2(b_gk_last4)[  # pyrefly: ignore[unbound-name]
+                                :, None  # pyrefly: ignore[unbound-name]
+                            ]  # pyrefly: ignore[unbound-name,unsupported-operation]
+                        else:
+                            b_h4 *= exp(b_gk_last4)[  # pyrefly: ignore[unbound-name]
+                                :, None
+                            ]  # pyrefly: ignore[unbound-name,unsupported-operation]
+                b_v = b_v.to(k.dtype.element_ty)
+
+                p_k = tl.make_block_ptr(
+                    k_off, (K, T_local), (1, H * K), (0, i_t * BT), (64, BT), (0, 1)
+                )
+                b_k = tl.load(
+                    p_k, boundary_check=(0, 1)
+                )  # pyrefly: ignore[unbound-name]
+                b_h1 += tl.dot(b_k, b_v)
+                if K > 64:
+                    p_k = tl.make_block_ptr(
+                        k_off,
+                        (K, T_local),
+                        (1, H * K),
+                        (64, i_t * BT),
+                        (64, BT),
+                        (0, 1),
+                    )
+                    b_k = tl.load(p_k, boundary_check=(0, 1))
+                    b_h2 += tl.dot(b_k, b_v)  # pyrefly: ignore [unbound-name]
+                if K > 128:
+                    p_k = tl.make_block_ptr(
+                        k_off,
+                        (K, T_local),
+                        (1, H * K),
+                        (128, i_t * BT),
+                        (64, BT),
+                        (0, 1),
+                    )
+                    b_k = tl.load(p_k, boundary_check=(0, 1))
+                    b_h3 += tl.dot(b_k, b_v)  # pyrefly: ignore [unbound-name]
+                if K > 192:
+                    p_k = tl.make_block_ptr(
+                        k_off,
+                        (K, T_local),
+                        (1, H * K),
+                        (192, i_t * BT),
+                        (64, BT),
+                        (0, 1),
+                    )
+                    b_k = tl.load(p_k, boundary_check=(0, 1))
+                    b_h4 += tl.dot(b_k, b_v)  # pyrefly: ignore[unbound-name]
+
+            if STORE_FINAL_STATE:
+                ht_off = ht + i_nh_abs * K * V
+                p_ht = tl.make_block_ptr(
+                    ht_off, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0)
+                )
+                tl.store(p_ht, b_h1.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+                if K > 64:
+                    p_ht = tl.make_block_ptr(
+                        ht_off, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0)
+                    )
+                    tl.store(
+                        # pyrefly: ignore [unbound-name]
+                        p_ht,
+                        # pyrefly: ignore [unbound-name]
+                        b_h2.to(p_ht.dtype.element_ty),
+                        boundary_check=(0, 1),
+                    )
+                if K > 128:
+                    p_ht = tl.make_block_ptr(
+                        ht_off, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0)
+                    )
+                    tl.store(
+                        # pyrefly: ignore [unbound-name]
+                        p_ht,
+                        # pyrefly: ignore [unbound-name]
+                        b_h3.to(p_ht.dtype.element_ty),
+                        boundary_check=(0, 1),
+                    )
+                if K > 192:
+                    p_ht = tl.make_block_ptr(
+                        ht_off, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0)
+                    )
+                    tl.store(
+                        # pyrefly: ignore [unbound-name]
+                        p_ht,
+                        # pyrefly: ignore [unbound-name]
+                        b_h4.to(p_ht.dtype.element_ty),
+                        boundary_check=(0, 1),
+                    )
+

--- a/attn_gym/linear/kda/fwd/triton/chunk_gla_fwd_o.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_gla_fwd_o.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+#
+# Forward-only GLA output-projection, ported verbatim from
+# genai/llama4x/llama4x/ops/fla/ops/gla/chunk.py.
+# Only the imports were rewritten to point at the standalone mslk common utils.
+
+from __future__ import annotations
+
+import triton
+import triton.language as tl
+from attn_gym.linear.kda.utils import (
+    autotune_cache_kwargs,
+    exp,
+    exp2,
+)
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+        "HAS_NUM_CHUNKS": lambda args: args["num_chunks"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({"BK": 32, "BV": 64}, num_warps=2, num_stages=4),
+    ],
+    key=["BT"],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["T", "num_chunks"])
+def chunk_gla_fwd_kernel_o(
+    q,
+    v,
+    g,
+    h,
+    o,
+    A,
+    cu_seqlens,
+    chunk_indices,
+    num_chunks,
+    scale,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    USE_EXP2: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    HAS_NUM_CHUNKS: tl.constexpr,
+):
+    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        if HAS_NUM_CHUNKS:
+            if i_t >= tl.load(num_chunks):
+                return
+        i_tg = i_t
+        i_n, i_t = (
+            tl.load(chunk_indices + i_t * 2).to(tl.int32),
+            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32),
+        )
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int32),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+        )
+        T = eos - bos
+        NT = tl.cdiv(T, BT)
+    else:
+        NT = tl.cdiv(T, BT)
+        i_tg = i_b * NT + i_t
+        bos, eos = i_b * T, i_b * T + T
+
+    m_s = tl.arange(0, BT)[:, None] >= tl.arange(0, BT)[None, :]
+
+    b_o = tl.zeros([BT, BV], dtype=tl.float32)
+    for i_k in range(tl.cdiv(K, BK)):
+        p_q = tl.make_block_ptr(
+            q + (bos * H + i_h) * K,
+            (T, K),
+            (H * K, 1),
+            (i_t * BT, i_k * BK),
+            (BT, BK),
+            (1, 0),
+        )
+        p_g = tl.make_block_ptr(
+            g + (bos * H + i_h) * K,
+            (T, K),
+            (H * K, 1),
+            (i_t * BT, i_k * BK),
+            (BT, BK),
+            (1, 0),
+        )
+        p_h = tl.make_block_ptr(
+            h + (i_tg * H + i_h) * K * V,
+            (K, V),
+            (V, 1),
+            (i_k * BK, i_v * BV),
+            (BK, BV),
+            (1, 0),
+        )
+
+        # [BT, BK]
+        b_q = tl.load(p_q, boundary_check=(0, 1))
+        # [BT, BK]
+        b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
+        # [BT, BK]
+        if USE_EXP2:
+            b_qg = (b_q * exp2(b_g)).to(b_q.dtype)
+        else:
+            b_qg = (b_q * exp(b_g)).to(b_q.dtype)
+        # [BK, BV]
+        b_h = tl.load(p_h, boundary_check=(0, 1))
+        # works but dkw, owing to divine benevolence
+        # [BT, BV]
+        if i_k >= 0:
+            b_o += tl.dot(b_qg, b_h.to(b_qg.dtype))
+    b_o *= scale
+    p_v = tl.make_block_ptr(
+        v + (bos * H + i_h) * V,
+        (T, V),
+        (H * V, 1),
+        (i_t * BT, i_v * BV),
+        (BT, BV),
+        (1, 0),
+    )
+    p_o = tl.make_block_ptr(
+        o + (bos * H + i_h) * V,
+        (T, V),
+        (H * V, 1),
+        (i_t * BT, i_v * BV),
+        (BT, BV),
+        (1, 0),
+    )
+    p_A = tl.make_block_ptr(
+        A + (bos * H + i_h) * BT, (T, BT), (H * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0)
+    )
+    # [BT, BV]
+    b_v = tl.load(p_v, boundary_check=(0, 1))
+    # [BT, BT]
+    b_A = tl.load(p_A, boundary_check=(0, 1))
+    b_A = tl.where(m_s, b_A, 0.0).to(b_v.dtype)
+    b_o += tl.dot(b_A, b_v)
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+

--- a/attn_gym/linear/kda/fwd/triton/chunk_kda_fwd_intra_sub_chunk_forloop.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_kda_fwd_intra_sub_chunk_forloop.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# KDA forward intra-chunk diagonal sub-chunk kernel (safe-gate persistent grid).
+#
+# Computes the diagonal 16x16 Aqk/Akk sub-blocks of each 64-token chunk and
+# inverts each diagonal Akk block by forward substitution. The off-diagonal
+# blocks and the full 64x64 block-triangular inverse are handled by the CuTe
+# K3b/K4b kernels. Only ``chunk_kda_fwd_kernel_intra_sub_chunk_forloop`` is
+# consumed by the CuTe forward path
+# (attn_gym.linear.kda.fwd.cute.chunk_kda_fwd_intra).
+
+import triton
+import triton.language as tl
+from attn_gym.linear.kda.utils import (
+    autotune_cache_kwargs,
+    exp2,
+    gather,
+)
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+        "HAS_NUM_CHUNKS": lambda args: args["num_chunks"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=1, num_stages=3),
+    ],
+    key=["BT", "BC"],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["T", "num_chunks"])
+def chunk_kda_fwd_kernel_intra_sub_chunk_forloop(
+    q,
+    k,
+    g,
+    beta,
+    Aqk,
+    Akk,
+    scale,
+    cu_seqlens,
+    chunk_indices,
+    num_chunks,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    HAS_NUM_CHUNKS: tl.constexpr,
+    USE_GATHER: tl.constexpr,
+    CAUSAL_NORMREF: tl.constexpr = True,
+    GRID_NT: tl.constexpr = 0,
+    MAX_NT: tl.constexpr = 0,
+):
+    i_t_start, i_i, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+
+    for _iter in range((MAX_NT + GRID_NT - 1) // GRID_NT):
+        i_t_orig = i_t_start + _iter * GRID_NT
+        _run = i_t_orig < MAX_NT
+        if IS_VARLEN:
+            if HAS_NUM_CHUNKS:
+                if _run:
+                    _run = i_t_orig < tl.load(num_chunks)
+        if _run:
+            if IS_VARLEN:
+                i_n, i_t = (
+                    tl.load(chunk_indices + i_t_orig * 2).to(tl.int32),
+                    tl.load(chunk_indices + i_t_orig * 2 + 1).to(tl.int32),
+                )
+                bos, eos = (
+                    tl.load(cu_seqlens + i_n).to(tl.int32),
+                    tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+                )
+                T_local = eos - bos
+            else:
+                i_t = i_t_orig
+                bos, eos = i_b * T, i_b * T + T
+                T_local = T
+
+            i_ti = i_t * BT + i_i * BC
+            if i_ti < T_local:
+                o_c = i_ti + tl.arange(0, BC)
+                m_c = o_c < T_local
+
+                q_off = q + (bos * H + i_h) * K
+                k_off = k + (bos * H + i_h) * K
+                g_off = g + (bos * H + i_h) * K
+                beta_off = beta + bos * H + i_h
+                Aqk_off = Aqk + (bos * H + i_h) * BT
+                Akk_off = Akk + (bos * H + i_h) * BC
+
+                p_q = tl.make_block_ptr(
+                    q_off, (T_local, K), (H * K, 1), (i_ti, 0), (BC, BK), (1, 0)
+                )
+                p_k = tl.make_block_ptr(
+                    k_off, (T_local, K), (H * K, 1), (i_ti, 0), (BC, BK), (1, 0)
+                )
+                p_g = tl.make_block_ptr(
+                    g_off, (T_local, K), (H * K, 1), (i_ti, 0), (BC, BK), (1, 0)
+                )
+
+                p_beta = tl.make_block_ptr(
+                    beta_off, (T_local,), (H,), (i_ti,), (BC,), (0,)
+                )
+
+                b_q = tl.load(p_q, boundary_check=(0, 1))
+                b_k = tl.load(p_k, boundary_check=(0, 1))
+                b_g = tl.load(p_g, boundary_check=(0, 1))
+                b_beta = tl.load(p_beta, boundary_check=(0,))
+
+                if CAUSAL_NORMREF:
+                    normref_idx = 0
+                else:
+                    normref_idx = min(BC // 2, T_local - i_ti - 1)
+                if USE_GATHER:
+                    b_gn = gather(
+                        b_g, tl.full([1, BK], normref_idx, dtype=tl.int16), axis=0
+                    )
+                else:
+                    p_gn = g_off + (i_ti + normref_idx) * H * K + tl.arange(0, BK)
+                    b_gn = tl.load(p_gn, mask=tl.arange(0, BK) < K, other=0.0)
+                    b_gn = b_gn[None, :]
+
+                b_gm = (b_g - b_gn).to(tl.float32)
+
+                b_gq = tl.where(m_c[:, None], exp2(b_gm), 0.0)
+                b_gk = tl.where(m_c[:, None], exp2(-b_gm), 0.0)
+
+                b_kgt = tl.trans(b_k * b_gk)
+
+                b_Aqk = tl.dot(b_q * b_gq, b_kgt) * scale
+                b_Akk = tl.dot(b_k * b_gq, b_kgt) * b_beta[:, None]
+
+                o_i = tl.arange(0, BC)
+                m_Aqk = o_i[:, None] >= o_i[None, :]
+                m_Akk = o_i[:, None] > o_i[None, :]
+                m_I = o_i[:, None] == o_i[None, :]
+
+                b_Aqk = tl.where(m_Aqk, b_Aqk, 0.0)
+                b_Akk = tl.where(m_Akk, b_Akk, 0.0)
+
+                p_Aqk = tl.make_block_ptr(
+                    Aqk_off,
+                    (T_local, BT),
+                    (H * BT, 1),
+                    (i_ti, i_i * BC),
+                    (BC, BC),
+                    (1, 0),
+                )
+                p_Akk = tl.make_block_ptr(
+                    Akk_off, (T_local, BC), (H * BC, 1), (i_ti, 0), (BC, BC), (1, 0)
+                )
+                tl.store(p_Aqk, b_Aqk.to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+                tl.store(p_Akk, b_Akk.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+
+                tl.debug_barrier()
+
+                # forward substitution
+                b_Ai = -b_Akk
+                for i in range(2, min(BC, T_local - i_ti)):
+                    b_a = -tl.load(Akk_off + (i_ti + i) * H * BC + o_i)
+                    b_a = tl.where(o_i < i, b_a, 0.0)
+                    b_a += tl.sum(b_a[:, None] * b_Ai, 0)
+                    b_Ai = tl.where((o_i == i)[:, None], b_a, b_Ai)
+                b_Ai += m_I
+                tl.store(p_Akk, b_Ai.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+
+
+__all__ = ["chunk_kda_fwd_kernel_intra_sub_chunk_forloop"]

--- a/attn_gym/linear/kda/fwd/triton/gate_fwd.py
+++ b/attn_gym/linear/kda/fwd/triton/gate_fwd.py
@@ -1,0 +1,389 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# FORWARD-ONLY KDA gate chunk-cumsum.
+# Ported faithfully (functions copied verbatim) from:
+#   genai/llama4x/llama4x/ops/fla/ops/kda/gate.py
+#
+# Only imports were rewritten to ``attn_gym.linear.kda.utils``. The `softplus`
+# helper (originally `fla.ops.utils.softplus`) is inlined verbatim below.
+
+from __future__ import annotations
+
+import triton
+import triton.language as tl
+from attn_gym.linear.kda.utils import (
+    autotune_cache_kwargs,
+    exp,
+    IS_NVIDIA,
+)
+
+
+# ---------------------------------------------------------------------------
+# Inlined verbatim from fla.ops.utils.softplus.
+# REVISED FROM
+# https://github.com/shawntan/stickbreaking-attention/blob/main/stickbreaking_attention/sb_varlen/softplus.py
+# ---------------------------------------------------------------------------
+def _generate_softplus(num_pack):
+    template = """
+        .reg .pred p;
+        setp.gt.f32  p, ${in_reg}, 20.;
+        @p  mov.f32  ${out_reg}, ${in_reg};
+        @!p mul.f32            ${out_reg}, ${in_reg}, 1.4426950408889634;
+        @!p ex2.approx.ftz.f32 ${out_reg}, ${out_reg};
+        @!p add.f32            ${out_reg}, ${out_reg}, 1.0;
+        @!p lg2.approx.ftz.f32 ${out_reg}, ${out_reg};
+        @!p mul.f32            ${out_reg}, ${out_reg}, 0.6931471805599453;
+    """
+    out_str = ""
+
+    for i in range(num_pack):
+        inner_str = template.format(out_reg=i, in_reg=i + num_pack)
+        out_str += "{" + inner_str + "}\n"
+    # flatten out because torch.compile doesn't like newlines
+    out_str = " ".join(out_str.split("\n"))
+    return out_str
+
+
+def _generate_softplus2(num_pack):
+    template = """
+        .reg .pred p;
+        setp.gt.f32  p, ${in_reg}, 15.;
+        @p  mov.f32  ${out_reg}, ${in_reg};
+        @!p ex2.approx.ftz.f32 ${out_reg}, ${in_reg};
+        @!p add.f32            ${out_reg}, ${out_reg}, 1.0;
+        @!p lg2.approx.ftz.f32 ${out_reg}, ${out_reg};
+    """
+    out_str = ""
+
+    for i in range(num_pack):
+        inner_str = template.format(out_reg=i, in_reg=i + num_pack)
+        out_str += "{" + inner_str + "}\n"
+    # flatten out because torch.compile doesn't like newlines
+    out_str = " ".join(out_str.split("\n"))
+    return out_str
+
+
+def _generate_constraints(num_pack):
+    return (
+        ",".join("=r" for i in range(num_pack))
+        + ","
+        + ",".join("r" for i in range(num_pack))
+    )
+
+
+_NUM_REG = 1
+s_softplus: tl.constexpr = tl.constexpr(_generate_softplus(_NUM_REG))
+s_softplus2: tl.constexpr = tl.constexpr(_generate_softplus2(_NUM_REG))
+s_constraints: tl.constexpr = tl.constexpr(_generate_constraints(_NUM_REG))
+NUM_REG: tl.constexpr = tl.constexpr(_NUM_REG)
+
+
+@triton.jit
+def softplus_nv(x):
+    # equivalent to:
+    # return tl.where(x < 20.0, tl.math.log(1 + tl.math.exp(x)), x)
+    return tl.inline_asm_elementwise(
+        asm=s_softplus,
+        constraints=s_constraints,
+        pack=NUM_REG,
+        args=[
+            x,
+        ],
+        dtype=tl.float32,
+        is_pure=True,
+    )
+
+
+@triton.jit
+def softplus_triton(x):
+    return tl.where(x < 20.0, tl.math.log(1 + tl.math.exp(x)), x)
+
+
+@triton.jit
+def softplus2_nv(x):
+    # equivalent to:
+    # return tl.where(x < 15.0, tl.math.log2(1 + tl.math.exp2(x)), x)
+    return tl.inline_asm_elementwise(
+        asm=s_softplus2,
+        constraints=s_constraints,
+        pack=NUM_REG,
+        args=[
+            x,
+        ],
+        dtype=tl.float32,
+        is_pure=True,
+    )
+
+
+@triton.jit
+def softplus2_triton(x):
+    return tl.where(x < 15.0, tl.math.log2(1 + tl.math.exp2(x)), x)
+
+
+if IS_NVIDIA:
+    softplus = softplus_nv
+    softplus2 = softplus2_nv
+else:
+    softplus = softplus_triton
+    softplus2 = softplus2_triton
+
+
+# ---------------------------------------------------------------------------
+# Chunk-cumsum forward path (copied verbatim from the source gate.py).
+# ---------------------------------------------------------------------------
+@triton.heuristics(
+    {
+        "HAS_BIAS": lambda args: args["dt_bias"] is not None,
+        "HAS_SCALE": lambda args: args["scale"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+        "USE_LOWER_BOUND": lambda args: args["lower_bound"] is not None,
+        "USE_REPEAT": lambda args: args["S_in"] != args["S"],
+        "HAS_NUM_CHUNKS": lambda args: args["num_chunks"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        # Best config from autotuning: BS: 32, num_warps: 2, num_ctas: 1, num_stages: 3
+        triton.Config({"BS": 32}, num_warps=2, num_stages=3),
+    ],
+    key=["B", "H", "S", "BT", "IS_VARLEN", "REVERSE"],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["T", "num_chunks"])
+def kda_gate_chunk_cumsum_vector_kernel(
+    s,
+    A_log,
+    dt_bias,
+    o,
+    scale,
+    cu_seqlens,
+    chunk_indices,
+    lower_bound,
+    T,
+    num_chunks,
+    B: tl.constexpr,
+    H: tl.constexpr,
+    S: tl.constexpr,
+    S_in: tl.constexpr,
+    F_REPEAT: tl.constexpr,
+    BT: tl.constexpr,
+    BS: tl.constexpr,
+    REVERSE: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
+    HAS_SCALE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    USE_LOWER_BOUND: tl.constexpr,
+    USE_REPEAT: tl.constexpr,
+    HAS_NUM_CHUNKS: tl.constexpr,
+):
+    i_t, i_bh, i_s = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        if HAS_NUM_CHUNKS:
+            if i_t >= tl.load(num_chunks):
+                return
+        i_n, i_t = (
+            tl.load(chunk_indices + i_t * 2).to(tl.int32),
+            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32),
+        )
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int32),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+        )
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    if USE_REPEAT:
+        # Input g has reduced dimension S_in = S / F_REPEAT
+        # We read from S_in and produce output of dimension S
+        # i_s indexes output blocks of size BS in the full dimension S
+        # Map output column indices to input column indices via integer division
+        b_out_cols = i_s * BS + tl.arange(0, BS)  # [BS] output column indices
+        b_in_cols = b_out_cols // F_REPEAT  # [BS] input column indices
+
+        # Load g from reduced dimension using gather
+        b_t_offs = i_t * BT + tl.arange(0, BT)  # [BT]
+        b_s_ptrs = s + ((bos + b_t_offs[:, None]) * H + i_h) * S_in + b_in_cols[None, :]
+        b_mask = (b_t_offs[:, None] < T) & (b_out_cols[None, :] < S)
+        b_s = tl.load(b_s_ptrs, mask=b_mask, other=0.0).to(tl.float32)
+    else:
+        p_s = tl.make_block_ptr(
+            s + (bos * H + i_h) * S,
+            (T, S),
+            (H * S, 1),
+            (i_t * BT, i_s * BS),
+            (BT, BS),
+            (1, 0),
+        )
+        # [BT, BS]
+        b_s = tl.load(p_s, boundary_check=(0, 1)).to(tl.float32)
+
+    p_o = tl.make_block_ptr(
+        o + (bos * H + i_h) * S,
+        (T, S),
+        (H * S, 1),
+        (i_t * BT, i_s * BS),
+        (BT, BS),
+        (1, 0),
+    )
+
+    # Apply dt_bias if exists (dt_bias is always in full dimension S)
+    if HAS_BIAS:
+        p_b = tl.make_block_ptr(dt_bias + i_h * S, (S,), (1,), (i_s * BS,), (BS,), (0,))
+        b_bias = tl.load(p_b, boundary_check=(0,)).to(tl.float32)
+        b_s = b_s + b_bias[None, :]
+
+    b_A = tl.load(A_log + i_h).to(tl.float32)
+    if not USE_LOWER_BOUND:  # pyrefly: ignore[unsupported-operation]
+        # Apply gate: -exp(A_log) * softplus(g + bias)
+        b_gate = -exp(b_A) * softplus(b_s)  # pyrefly: ignore[unsupported-operation]
+    else:
+        b_gate = lower_bound * tl.sigmoid(exp(b_A) * b_s)
+
+    # Apply chunk local cumsum
+    if REVERSE:
+        b_o = tl.cumsum(b_gate, axis=0, reverse=True)
+    else:
+        b_o = tl.cumsum(b_gate, axis=0)
+
+    if HAS_SCALE:
+        b_o *= scale
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.heuristics(
+    {
+        "HAS_BIAS": lambda args: args["dt_bias"] is not None,
+        "HAS_SCALE": lambda args: args["scale"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+        "USE_LOWER_BOUND": lambda args: args["lower_bound"] is not None,
+        "USE_REPEAT": lambda args: args["S_in"] != args["S"],
+        "HAS_NUM_CHUNKS": lambda args: args["num_chunks"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({"BS": 32}, num_warps=2, num_stages=3),
+    ],
+    key=["B", "H", "S", "BT", "IS_VARLEN", "REVERSE"],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["T", "num_chunks"])
+def kda_gate_chunk_cumsum_vector_kernel_forloop(
+    s,
+    A_log,
+    dt_bias,
+    o,
+    scale,
+    cu_seqlens,
+    chunk_indices,
+    lower_bound,
+    T,
+    num_chunks,
+    B: tl.constexpr,
+    H: tl.constexpr,
+    S: tl.constexpr,
+    S_in: tl.constexpr,
+    F_REPEAT: tl.constexpr,
+    BT: tl.constexpr,
+    BS: tl.constexpr,
+    REVERSE: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
+    HAS_SCALE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    USE_LOWER_BOUND: tl.constexpr,
+    USE_REPEAT: tl.constexpr,
+    HAS_NUM_CHUNKS: tl.constexpr,
+    # pyrefly: ignore [bad-function-definition]
+    GRID_NT: tl.constexpr = 0,
+    # pyrefly: ignore [bad-function-definition]
+    MAX_NT: tl.constexpr = 0,
+):
+    i_t_start, i_bh, i_s = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+
+    for _iter in range((MAX_NT + GRID_NT - 1) // GRID_NT):
+        i_t_orig = i_t_start + _iter * GRID_NT
+        _run = i_t_orig < MAX_NT
+        if IS_VARLEN:
+            if HAS_NUM_CHUNKS:
+                if _run:
+                    _run = i_t_orig < tl.load(num_chunks)
+        if _run:
+            if IS_VARLEN:
+                i_n, i_t = (
+                    tl.load(chunk_indices + i_t_orig * 2).to(tl.int32),
+                    tl.load(chunk_indices + i_t_orig * 2 + 1).to(tl.int32),
+                )
+                bos, eos = (
+                    tl.load(cu_seqlens + i_n).to(tl.int32),
+                    tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+                )
+                T_local = eos - bos
+            else:
+                i_t = i_t_orig
+                bos, eos = i_b * T, i_b * T + T
+                T_local = T
+
+            if USE_REPEAT:
+                b_out_cols = i_s * BS + tl.arange(0, BS)
+                b_in_cols = b_out_cols // F_REPEAT
+
+                b_t_offs = i_t * BT + tl.arange(0, BT)
+                b_s_ptrs = (
+                    s
+                    + ((bos + b_t_offs[:, None]) * H + i_h) * S_in
+                    + b_in_cols[None, :]
+                )
+                b_mask = (b_t_offs[:, None] < T_local) & (b_out_cols[None, :] < S)
+                b_s = tl.load(b_s_ptrs, mask=b_mask, other=0.0).to(tl.float32)
+            else:
+                p_s = tl.make_block_ptr(
+                    s + (bos * H + i_h) * S,
+                    (T_local, S),
+                    (H * S, 1),
+                    (i_t * BT, i_s * BS),
+                    (BT, BS),
+                    (1, 0),
+                )
+                b_s = tl.load(p_s, boundary_check=(0, 1)).to(tl.float32)
+
+            p_o = tl.make_block_ptr(
+                o + (bos * H + i_h) * S,
+                (T_local, S),
+                (H * S, 1),
+                (i_t * BT, i_s * BS),
+                (BT, BS),
+                (1, 0),
+            )
+
+            if HAS_BIAS:
+                p_b = tl.make_block_ptr(
+                    dt_bias + i_h * S, (S,), (1,), (i_s * BS,), (BS,), (0,)
+                )
+                b_bias = tl.load(p_b, boundary_check=(0,)).to(tl.float32)
+                b_s = b_s + b_bias[None, :]
+
+            b_A = tl.load(A_log + i_h).to(tl.float32)
+            if not USE_LOWER_BOUND:  # pyrefly: ignore[unsupported-operation]
+                # pyrefly: ignore [unsupported-operation]
+                b_gate = -exp(b_A) * softplus(
+                    b_s
+                )  # pyrefly: ignore[unsupported-operation]
+            else:
+                b_gate = lower_bound * tl.sigmoid(exp(b_A) * b_s)
+
+            if REVERSE:
+                b_o = tl.cumsum(b_gate, axis=0, reverse=True)
+            else:
+                b_o = tl.cumsum(b_gate, axis=0)
+
+            if HAS_SCALE:
+                b_o *= scale
+            tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+

--- a/attn_gym/linear/kda/fwd/triton/l2norm_fwd.py
+++ b/attn_gym/linear/kda/fwd/triton/l2norm_fwd.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+
+from __future__ import annotations
+
+
+import triton
+import triton.language as tl
+
+
+@triton.autotune(
+    configs=[triton.Config({}, num_warps=4)],
+    key=["D"],
+)
+@triton.jit
+def l2norm_fwd_kernel1(
+    x,
+    y,
+    rstd,
+    eps,
+    D: tl.constexpr,
+    BD: tl.constexpr,
+):
+    i_t = tl.program_id(0).to(tl.int64)
+    x += i_t * D
+    y += i_t * D
+    # Compute mean and variance
+    cols = tl.arange(0, BD)
+    mask = cols < D
+
+    b_x = tl.load(x + cols, mask=mask, other=0.0).to(tl.float32)
+    b_rstd = 1 / tl.sqrt(tl.sum(b_x * b_x) + eps)
+    b_y = b_x * b_rstd
+    tl.store(y + cols, b_y, mask=mask)
+    tl.store(rstd + i_t, b_rstd)
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BT": 16}, num_warps=4, num_stages=3),
+    ],
+    key=["D", "NB"],
+)
+@triton.jit
+def l2norm_fwd_kernel(
+    x,
+    y,
+    rstd,
+    eps,
+    T,
+    D: tl.constexpr,
+    BD: tl.constexpr,
+    NB,
+    BT: tl.constexpr,
+):
+    i_t = tl.program_id(0)
+    p_x = tl.make_block_ptr(x, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
+    p_y = tl.make_block_ptr(y, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
+    p_rstd = tl.make_block_ptr(rstd, (T,), (1,), (i_t * BT,), (BT,), (0,))
+
+    b_x = tl.load(p_x, boundary_check=(0, 1)).to(tl.float32)
+    b_rstd = 1 / tl.sqrt(tl.sum(b_x * b_x, 1) + eps)
+    b_y = b_x * b_rstd[:, None]
+
+    tl.store(p_y, b_y.to(p_y.dtype.element_ty), boundary_check=(0, 1))  # type: ignore
+    tl.store(p_rstd, b_rstd.to(p_rstd.dtype.element_ty), boundary_check=(0,))  # type: ignore
+

--- a/attn_gym/linear/kda/naive.py
+++ b/attn_gym/linear/kda/naive.py
@@ -1,0 +1,127 @@
+"""KDA (Kimi Delta Attention) delta-rule ops."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+
+def naive_recurrent_kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float | None = None,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Reference O(T) KDA delta rule. State S in [K, V], per (batch, head).
+
+    Per step t (per-channel decay a_t = 2^{g_t} in R^K):
+        S <- diag(a_t) S ;  delta = beta_t * (v_t - k^T S) ;  S <- S + outer(k_t, delta) ;  o_t = q^T S
+
+    Shapes: q, k, g (B, T, H, K); v (B, T, H, V); beta (B, T, H); state (B, H, K, V).
+
+    Args:
+        q: query tensor
+        k: key tensor
+        v: value tensor
+        g: per-channel log2-decay, a_t = 2^{g_t} in R^K (the KDA diagonal gate)
+        beta: scalar-per-head delta step size / write gate
+        scale: query scale for q k^T (optional; default 1/sqrt(K))
+        initial_state: initial recurrent state (B, H, K, V) (optional)
+        output_final_state: also return the final state (optional)
+    """
+    b, t, h, k_dim = q.shape
+    q = q * scale if scale else q * k_dim**-0.5
+    state = initial_state if initial_state is not None else q.new_zeros(b, h, k_dim, v.shape[-1])
+    outputs = []
+
+    for i in range(t):
+        state = state * g[:, i].exp2()[..., None]  # per-channel decay: diag(2^{g_t}) over V
+        delta = v[:, i] - torch.einsum("bhk,bhkv->bhv", k[:, i], state)  # vt - k^T S (v_old)
+        delta = delta * beta[:, i][..., None]
+        state = state + torch.einsum("bhk,bhv->bhkv", k[:, i], delta)  # + outer(k, delta)
+        outputs.append(torch.einsum("bhk,bhkv->bhv", q[:, i], state))  # q^T S
+    return torch.stack(outputs, dim=1), (state if output_final_state else None)
+
+
+def naive_chunk_kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float | None = None,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    chunk_size: int = 64,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Naive chunk-parallel KDA delta rule (training / prefill).
+
+    Same delta rule as :func:`naive_recurrent_kda`, computed chunk-at-a-time: the intra-chunk
+    solve builds ``(I + Akk)^-1`` and the inter-chunk scan carries the state S across chunks.
+    Per-channel decay is folded into q/k as ``2^{+/-decay}`` so the intra-chunk sums stay plain
+    matmuls.
+    """
+    b, t, h, k_dim = q.shape
+    v_dim = v.shape[-1]
+    orig_dtype = q.dtype
+    if scale is None:
+        scale = k_dim**-0.5
+
+    # -> (B, H, T, .) in fp32
+    q, k, v, g = (x.transpose(1, 2).float() for x in (q, k, v, g))
+    beta = beta.transpose(1, 2).float()
+    pad = (chunk_size - t % chunk_size) % chunk_size
+    if pad:
+        q, k, v, g = (F.pad(x, (0, 0, 0, pad)) for x in (q, k, v, g))
+        beta = F.pad(beta, (0, pad))
+    length = q.shape[-2]
+    num_chunks = length // chunk_size
+
+    def to_chunks(x):
+        return x.reshape(b, h, num_chunks, chunk_size, x.shape[-1])
+
+    q, k, v, g = (to_chunks(x) for x in (q, k, v, g))
+    beta = beta.reshape(b, h, num_chunks, chunk_size)
+    decay = g.cumsum(-2)  # cumulative per-channel log2-decay within each chunk
+
+    # fold per-channel decay into keys/queries so intra-chunk sums are plain matmuls
+    q_g = q * scale * decay.exp2()  # gated (scaled) queries, 2^{+decay}
+    k_gi = k * (-decay).exp2()  # gated keys, 2^{-decay}
+    kb_g = k * beta[..., None] * decay.exp2()  # k * beta * 2^{+decay}
+
+    diag_incl = torch.triu(
+        torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=q.device), 0
+    )
+    diag_strict = torch.triu(
+        torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=q.device), 1
+    )
+
+    # strictly-lower Akk, then (I + Akk)^-1 via triangular solve
+    raw = (kb_g @ k_gi.transpose(-1, -2)).masked_fill(diag_incl, 0)
+    eye = torch.eye(chunk_size, dtype=torch.float, device=q.device)
+    attn = torch.linalg.solve_triangular(eye + raw, eye.expand_as(raw), upper=False)
+
+    u = attn @ (v * beta[..., None])  # "pseudo-values" per chunk
+    w = attn @ kb_g  # gated key basis for the carried-state correction
+
+    state = q.new_zeros(b, h, k_dim, v_dim) if initial_state is None else initial_state.float()
+    o = torch.zeros_like(u)
+    for i in range(num_chunks):
+        q_i = q_g[:, :, i]
+        attn_i = (q_i @ k_gi[:, :, i].transpose(-1, -2)).masked_fill(diag_strict, 0)
+        u_eff = u[:, :, i] - w[:, :, i] @ state  # correction against carried state
+        o[:, :, i] = q_i @ state + attn_i @ u_eff  # inter-chunk read + intra-chunk read
+        # carry state to next chunk: decayed old state + this chunk's writes
+        d_last = decay[:, :, i, -1]  # total per-channel decay over the chunk
+        kg = k[:, :, i] * (d_last[:, :, None] - decay[:, :, i]).exp2()
+        state = state * d_last[..., None].exp2() + kg.transpose(-1, -2) @ u_eff
+
+    o = o.reshape(b, h, length, v_dim)[:, :, :t].transpose(1, 2).to(orig_dtype)
+    return o, (state.to(orig_dtype) if output_final_state else None)
+
+
+__all__ = ["naive_chunk_kda", "naive_recurrent_kda"]

--- a/attn_gym/linear/kda/utils.py
+++ b/attn_gym/linear/kda/utils.py
@@ -1,0 +1,502 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+#
+# Portions of this file are derived from flash-linear-attention
+# (https://github.com/fla-org/flash-linear-attention) and are licensed under
+# the MIT license; for the full list of FLA contributors, visit
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+# The remaining portions are licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Consolidated utilities for the KDA kernels (forward + backward). Merges the
+# former ``common/utils.py`` (Meta) and ``fla_ops/utils.py`` (FLA) into a single
+# module. Targets NVIDIA GPUs only.
+
+import contextlib
+import functools
+import inspect
+import logging
+import os
+import sys
+import warnings
+from collections import deque
+from collections.abc import Callable
+from enum import Enum
+from functools import cache, lru_cache
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+import triton
+import triton.language as tl
+import triton.language.extra.libdevice as tldevice
+from packaging import version
+from torch._subclasses.fake_tensor import FakeTensor
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+RCP_LN2 = 1.4426950216
+DEFAULT_CHUNK_SIZE = 64
+
+# ---------------------------------------------------------------------------
+# Env flags / autotune caching
+# ---------------------------------------------------------------------------
+FLA_DISABLE_TENSOR_CACHE = os.getenv("FLA_DISABLE_TENSOR_CACHE", "0") == "1"
+FLA_CACHE_RESULTS = os.getenv("FLA_CACHE_RESULTS", "1") == "1"
+
+SUPPORTS_AUTOTUNE_CACHE = "cache_results" in inspect.signature(triton.autotune).parameters
+autotune_cache_kwargs = {"cache_results": FLA_CACHE_RESULTS} if SUPPORTS_AUTOTUNE_CACHE else {}
+
+
+# ---------------------------------------------------------------------------
+# Environment checks (OS / Triton / Python version)
+# ---------------------------------------------------------------------------
+@lru_cache(maxsize=1)
+def check_environments():
+    """Warn if OS, Triton, or Python versions are below recommendations.
+
+    Body only runs once due to lru_cache.
+    """
+    if sys.platform == "win32":
+        try:
+            from importlib.metadata import PackageNotFoundError, metadata
+
+            metadata("triton-windows")
+        except PackageNotFoundError:
+            logger.warning(
+                "Detected Windows operating system. Consider installing triton-windows "
+                "(https://github.com/triton-lang/triton-windows) for better compatibility. "
+                "Without it, some features may not work correctly.",
+            )
+
+    triton_version = version.parse(triton.__version__)
+    required_triton_version = version.parse("3.3.0")
+    if triton_version < required_triton_version:
+        logger.warning(
+            f"Current Triton version {triton_version} is below the recommended 3.3.0 version. "
+            "Errors may occur and these issues will not be fixed. "
+            "Please consider upgrading Triton.",
+        )
+
+    py_version = version.parse(f"{sys.version_info.major}.{sys.version_info.minor}")
+    required_py_version = version.parse("3.11")
+    if py_version < required_py_version:
+        logger.warning(
+            f"Current Python version {py_version} is below the recommended 3.11 version. "
+            "It is recommended to upgrade to Python 3.11 or higher for the best experience.",
+        )
+
+    return None
+
+
+check_environments()
+
+
+# ---------------------------------------------------------------------------
+# Device detection (NVIDIA only)
+# ---------------------------------------------------------------------------
+def _cpu_device_warning():
+    warnings.warn(("Triton is not supported on current platform, roll back to CPU."), stacklevel=2)
+
+
+@cache
+def get_available_device() -> str:
+    try:
+        return triton.runtime.driver.active.get_current_target().backend
+    except Exception:
+        _cpu_device_warning()
+        return "cpu"
+
+
+device = "cuda"
+device_torch_lib = torch.cuda
+device_name = "cuda"
+device_platform = get_available_device()
+
+IS_AMD = device_platform == "hip"
+IS_NVIDIA = device_platform == "cuda"
+IS_NVIDIA_HOPPER = IS_NVIDIA and (
+    "NVIDIA H" in torch.cuda.get_device_name(0) or torch.cuda.get_device_capability()[0] >= 9
+)
+IS_NVIDIA_BLACKWELL = IS_NVIDIA and torch.cuda.get_device_capability()[0] in (10, 12)
+IS_TF32_SUPPORTED = IS_NVIDIA and torch.cuda.get_device_capability(0)[0] >= 8
+IS_TMA_SUPPORTED = (
+    IS_NVIDIA
+    and torch.cuda.get_device_capability(0)[0] >= 9
+    and os.environ.get("FLA_USE_TMA", "0") == "1"
+    and (
+        hasattr(triton.language, "_experimental_make_tensor_descriptor")
+        or hasattr(triton.language, "make_tensor_descriptor")
+    )
+)
+IS_GATHER_SUPPORTED = hasattr(triton.language, "gather")
+USE_CUDA_GRAPH = IS_NVIDIA and os.environ.get("FLA_USE_CUDA_GRAPH", "0") == "1"
+
+# Lowercase aliases
+is_nvidia_hopper = IS_NVIDIA_HOPPER
+is_gather_supported = IS_GATHER_SUPPORTED
+use_cuda_graph = USE_CUDA_GRAPH
+
+if IS_NVIDIA and not IS_TF32_SUPPORTED:
+    # Make old cards happy, since triton will use tf32 by default.
+    os.environ["TRITON_F32_DEFAULT"] = "ieee"
+
+
+def _default_alloc_fn(size: int, alignment: int, stream: int | None):
+    return torch.empty(
+        size, device=torch.device(device_name, device_torch_lib.current_device()), dtype=torch.int8
+    )
+
+
+if IS_TMA_SUPPORTED:
+    logger.info("TMA is supported, using TMA by default.")
+    triton.set_allocator(_default_alloc_fn)
+elif IS_NVIDIA_BLACKWELL:
+    # Blackwell (SM100 datacenter / SM120 consumer): Triton compiler may emit global_scratch for
+    # autotuned kernels even without TMA. Register a default allocator to prevent NullAllocator
+    # crashes. See triton-lang/triton#10002.
+    logger.info("Blackwell detected: registering default global_scratch allocator.")
+    triton.set_allocator(_default_alloc_fn)
+
+
+# ---------------------------------------------------------------------------
+# Triton math ops
+# ---------------------------------------------------------------------------
+if os.environ.get("FLA_USE_FAST_OPS", "0") == "1":
+    exp2 = tldevice.exp2
+    log = tldevice.fast_logf
+    log2 = tldevice.fast_log2f
+else:
+    exp2 = tl.math.exp2
+    log = tl.log
+    log2 = tl.log2
+
+
+@triton.jit
+def exp(x):
+    return tl.exp(x.to(tl.float32))
+
+
+@triton.jit
+def safe_exp(x):
+    return exp(tl.where(x <= 0, x, float("-inf")))
+
+
+if not IS_GATHER_SUPPORTED:
+
+    @triton.jit
+    def gather(src, index, axis, _builder=None):
+        return None
+else:
+    gather = tl.gather  # type: ignore
+
+
+def _generate_softplus(num_pack):
+    template = """
+        .reg .pred p;
+        setp.gt.f32  p, ${in_reg}, 20.;
+        @p  mov.f32  ${out_reg}, ${in_reg};
+        @!p mul.f32            ${out_reg}, ${in_reg}, 1.4426950408889634;
+        @!p ex2.approx.ftz.f32 ${out_reg}, ${out_reg};
+        @!p add.f32            ${out_reg}, ${out_reg}, 1.0;
+        @!p lg2.approx.ftz.f32 ${out_reg}, ${out_reg};
+        @!p mul.f32            ${out_reg}, ${out_reg}, 0.6931471805599453;
+    """
+    out_str = ""
+    for i in range(num_pack):
+        inner_str = template.format(out_reg=i, in_reg=i + num_pack)
+        out_str += "{" + inner_str + "}\n"
+    # flatten out because torch.compile doesn't like newlines
+    out_str = " ".join(out_str.split("\n"))
+    return out_str
+
+
+def _generate_constraints(num_pack):
+    return ",".join("=r" for i in range(num_pack)) + "," + ",".join("r" for i in range(num_pack))
+
+
+_NUM_REG = 1
+s_softplus: tl.constexpr = tl.constexpr(_generate_softplus(_NUM_REG))
+s_constraints: tl.constexpr = tl.constexpr(_generate_constraints(_NUM_REG))
+NUM_REG: tl.constexpr = tl.constexpr(_NUM_REG)
+
+
+@triton.jit
+def softplus(x):
+    # equivalent to:
+    # return tl.where(x < 20.0, tl.math.log(1 + tl.math.exp(x)), x)
+    return tl.inline_asm_elementwise(
+        asm=s_softplus,
+        constraints=s_constraints,
+        pack=NUM_REG,
+        args=[
+            x,
+        ],
+        dtype=tl.float32,
+        is_pure=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shared memory check / device context
+# ---------------------------------------------------------------------------
+class Backend(Enum):
+    ADA = 101376       # RTX 4090
+    AMPERE = 166912    # A100
+    HOPPER = 232448    # H100
+    DEFAULT = 102400   # Default
+
+    @classmethod
+    def get_shared_memory(cls, arch: str) -> int:
+        try:
+            return cls[arch.upper()].value
+        except KeyError:
+            return cls.DEFAULT.value
+
+
+def get_all_max_shared_mem():
+    try:
+        return [
+            triton.runtime.driver.active.utils.get_device_properties(i)["max_shared_mem"]
+            for i in range(device_torch_lib.device_count())
+        ]
+    except Exception:
+        _cpu_device_warning()
+        return [-1]
+
+
+@cache
+def check_shared_mem(arch: str = "none", tensor_idx: int = 0) -> bool:
+    try:
+        device_shared_mem_list = get_all_max_shared_mem()
+        max_shared_memory = device_shared_mem_list[tensor_idx]
+        return max_shared_memory >= Backend.get_shared_memory(arch)
+    except Exception:
+        return False
+
+
+def custom_device_ctx(index: int):
+    if index is None:
+        return contextlib.nullcontext()
+    try:
+        return device_torch_lib.device(index)
+    except (AttributeError, AssertionError, RuntimeError):
+        return contextlib.nullcontext()
+
+
+# ---------------------------------------------------------------------------
+# input_guard decorator
+# ---------------------------------------------------------------------------
+def _skip_contiguous(
+    no_guard_contiguous: bool | list[str] | tuple[str, ...] | set[str],
+    param_name: str,
+    skip_params: set[str],
+) -> bool:
+    return no_guard_contiguous is True or param_name in skip_params
+
+
+def _contiguous_if_needed(arg: Any, skip: bool) -> Any:
+    if isinstance(arg, torch.Tensor) and not skip:
+        return arg.contiguous()
+    return arg
+
+
+def input_guard(
+    fn: Callable[..., torch.Tensor] | None = None,
+    *,
+    no_guard_contiguous: bool | list[str] | tuple[str, ...] | set[str] = False,
+) -> (
+    Callable[[Callable[..., torch.Tensor]], Callable[..., torch.Tensor]]
+    | Callable[..., torch.Tensor]
+):
+    """Ensure all input tensors are contiguous and set the device from input tensors.
+
+    Args:
+        no_guard_contiguous: If True, skip all contiguous checks. If a
+            list/tuple/set of parameter names, skip contiguous checks for those.
+    """
+
+    def decorator(fn: Callable[..., torch.Tensor]) -> Callable[..., torch.Tensor]:
+        sig = inspect.signature(fn)
+        param_names = list(sig.parameters.keys())
+        skip_params = (
+            set(no_guard_contiguous)
+            if isinstance(no_guard_contiguous, (list, tuple, set))
+            else set()
+        )
+
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            processed_args = []
+            for i, arg in enumerate(args):
+                param_name = param_names[i] if i < len(param_names) else f"__arg_{i}"
+                processed_args.append(
+                    _contiguous_if_needed(
+                        arg, _skip_contiguous(no_guard_contiguous, param_name, skip_params)
+                    )
+                )
+
+            processed_kwargs = {}
+            for k, v in kwargs.items():
+                processed_kwargs[k] = _contiguous_if_needed(
+                    v, _skip_contiguous(no_guard_contiguous, k, skip_params)
+                )
+
+            tensor = None
+            for arg in args:
+                if isinstance(arg, torch.Tensor):
+                    tensor = arg
+                    break
+            if tensor is None:
+                for value in kwargs.values():
+                    if isinstance(value, torch.Tensor):
+                        tensor = value
+                        break
+
+            if tensor is not None:
+                ctx = custom_device_ctx(tensor.device.index)
+            else:
+                ctx = contextlib.nullcontext()
+
+            with ctx:
+                return fn(*processed_args, **processed_kwargs)
+
+        return wrapper
+
+    # Handle direct usage without parentheses: @input_guard
+    if fn is not None:
+        return decorator(fn)
+    return decorator
+
+
+# ---------------------------------------------------------------------------
+# tensor_cache decorator
+# ---------------------------------------------------------------------------
+_TENSOR_CACHE_MAXSIZE: int = 2
+
+
+def tensor_cache(
+    fn: Callable[..., torch.Tensor] | None = None,
+    *,
+    maxsize: int | None = None,
+) -> Callable[..., torch.Tensor]:
+    """FIFO cache for functions with tensor inputs."""
+
+    def decorator(fn: Callable[..., torch.Tensor]) -> Callable[..., torch.Tensor]:
+        effective_maxsize = maxsize if maxsize is not None else _TENSOR_CACHE_MAXSIZE
+        cache: deque[tuple[tuple, dict, Any]] = deque(maxlen=effective_maxsize)
+
+        @functools.wraps(fn)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            if FLA_DISABLE_TENSOR_CACHE:
+                return fn(*args, **kwargs)
+            for cached_args, cached_kwargs, cached_result in reversed(cache):
+                if len(args) == len(cached_args) and len(kwargs) == len(cached_kwargs):
+                    if all(a is b for a, b in zip(args, cached_args, strict=False)) and all(
+                        k in cached_kwargs and v is cached_kwargs[k] for k, v in kwargs.items()
+                    ):
+                        return cached_result
+            result = fn(*args, **kwargs)
+            cache.append((args, kwargs, result))
+            return result
+
+        return wrapper
+
+    if fn is not None:
+        return decorator(fn)
+    return decorator
+
+
+def tensor_tree_nbytes(value: Any) -> int:
+    """Count unique tensor storage bytes in a nested structure."""
+    seen_storages: set[tuple[str, int | None, int]] = set()
+
+    def _tensor_nbytes(tensor: torch.Tensor) -> int:
+        if isinstance(tensor, FakeTensor):
+            return tensor.numel() * tensor.element_size()
+        storage = tensor.untyped_storage()
+        storage_key = (tensor.device.type, tensor.device.index, storage.data_ptr())
+        if storage_key in seen_storages:
+            return 0
+        seen_storages.add(storage_key)
+        return storage.nbytes()
+
+    def _walk(obj: Any) -> int:
+        if isinstance(obj, torch.Tensor):
+            return _tensor_nbytes(obj)
+        if isinstance(obj, dict):
+            return sum(_walk(item) for item in obj.values())
+        if isinstance(obj, (list, tuple, set)):
+            return sum(_walk(item) for item in obj)
+        return 0
+
+    return _walk(value)
+
+
+def chunk_local_cumsum_reference(
+    g: torch.Tensor,
+    chunk_size: int,
+    reverse: bool = False,
+    scale: float | None = None,
+    cu_seqlens: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Pure PyTorch chunk-local cumsum used to model the stripped gate wrapper."""
+    out = torch.empty_like(g)
+    g_f = g.float()
+
+    def _fill_range(batch_idx: int, bos: int, eos: int) -> None:
+        for chunk_start in range(bos, eos, chunk_size):
+            chunk_end = min(chunk_start + chunk_size, eos)
+            block = g_f[batch_idx, chunk_start:chunk_end]
+            if reverse:
+                block = block.flip(0).cumsum(0).flip(0)
+            else:
+                block = block.cumsum(0)
+            if scale is not None:
+                block = block * scale
+            out[batch_idx, chunk_start:chunk_end] = block.to(out.dtype)
+
+    if cu_seqlens is None:
+        for batch_idx in range(g.shape[0]):
+            _fill_range(batch_idx, 0, g.shape[1])
+    else:
+        offsets = cu_seqlens.tolist()
+        for bos, eos in zip(offsets[:-1], offsets[1:], strict=False):
+            _fill_range(0, bos, eos)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Varlen chunk indexing
+# ---------------------------------------------------------------------------
+@tensor_cache(maxsize=10)
+def prepare_lens(cu_seqlens: torch.LongTensor) -> torch.LongTensor:
+    return torch.diff(cu_seqlens)
+
+
+@tensor_cache(maxsize=10)
+def prepare_chunk_indices(
+    cu_seqlens: torch.LongTensor,
+    chunk_size: int,
+    cu_seqlens_cpu: torch.LongTensor | None = None,
+) -> torch.LongTensor:
+    if isinstance(cu_seqlens, FakeTensor):
+        num_seqs = cu_seqlens.shape[0] - 1
+        chunk_counts = [1] * num_seqs
+    else:
+        seqlens_for_lens = cu_seqlens_cpu if cu_seqlens_cpu is not None else cu_seqlens
+        lens = prepare_lens(seqlens_for_lens)
+        chunk_counts = ((lens + chunk_size - 1) // chunk_size).tolist()
+    indices = torch.cat([torch.arange(n) for n in chunk_counts])
+    return torch.stack([indices.eq(0).cumsum(0) - 1, indices], 1).to(cu_seqlens)
+
+
+@tensor_cache(maxsize=10)
+def prepare_chunk_offsets(
+    cu_seqlens: torch.LongTensor,
+    chunk_size: int,
+) -> torch.LongTensor:
+    return F.pad(triton.cdiv(prepare_lens(cu_seqlens), chunk_size), (1, 0), value=0).cumsum(-1)

--- a/test/test_kda.py
+++ b/test/test_kda.py
@@ -1,0 +1,57 @@
+import pytest
+import torch
+import torch.nn.functional as F
+
+from attn_gym.linear import (
+    naive_chunk_kda,
+    naive_recurrent_kda,
+)
+
+
+def make_inputs(seq_len: int) -> tuple[torch.Tensor, ...]:
+    """Create stable KDA delta-rule inputs with normalized keys and a per-channel gate."""
+    torch.manual_seed(0)
+    batch, heads, key_dim, value_dim = 2, 3, 4, 5
+    q = torch.randn(batch, seq_len, heads, key_dim)
+    k = F.normalize(torch.randn_like(q), dim=-1)
+    v = torch.randn(batch, seq_len, heads, value_dim)
+    g = F.logsigmoid(torch.randn(batch, seq_len, heads, key_dim))  # per-channel (diagonal) gate
+    beta = torch.sigmoid(torch.randn(batch, seq_len, heads))
+    initial_state = torch.randn(batch, heads, key_dim, value_dim)
+    return q, k, v, g, beta, initial_state
+
+
+@pytest.mark.parametrize("seq_len,chunk_size", [(1, 4), (7, 4), (8, 4), (17, 8)])
+@pytest.mark.parametrize("use_initial_state", [False, True])
+def test_naive_chunk_matches_recurrent(seq_len, chunk_size, use_initial_state):
+    inputs = make_inputs(seq_len)
+    initial_state = inputs[-1] if use_initial_state else None
+    recurrent_output, recurrent_state = naive_recurrent_kda(
+        *inputs[:-1], initial_state=initial_state, output_final_state=True
+    )
+    chunk_output, chunk_state = naive_chunk_kda(
+        *inputs[:-1],
+        initial_state=initial_state,
+        output_final_state=True,
+        chunk_size=chunk_size,
+    )
+
+    torch.testing.assert_close(chunk_output, recurrent_output, atol=1e-5, rtol=1e-4)
+    torch.testing.assert_close(chunk_state, recurrent_state, atol=1e-5, rtol=1e-4)
+
+
+def test_naive_chunk_gradients_match_recurrent():
+    inputs = make_inputs(seq_len=7)[:-1]
+    gradients = []
+    for function in (naive_recurrent_kda, naive_chunk_kda):
+        differentiable_inputs = [value.clone().requires_grad_() for value in inputs]
+        kwargs = {"chunk_size": 4} if function is naive_chunk_kda else {}
+        output, state = function(*differentiable_inputs, output_final_state=True, **kwargs)
+        gradients.append(
+            torch.autograd.grad(
+                output.square().mean() + state.square().mean(), differentiable_inputs
+            )
+        )
+
+    for chunk_gradient, recurrent_gradient in zip(gradients[1], gradients[0]):
+        torch.testing.assert_close(chunk_gradient, recurrent_gradient, atol=1e-5, rtol=1e-4)


### PR DESCRIPTION
as title. i wrote: 
1. attn_gym/linear/kda/bwd/triton/cumsum.py
2. attn_gym/linear/kda/bwd/triton/gate_bwd.py
3. attn_gym/linear/kda/bwd/triton/l2norm_bwd.py

everything else was directly copied over. i didn't bring over any python level apis and bindings between different kernels to remove some complexity, so this should just be all the kernels we need for E2E training run. this includes all chunked kernels for forward and backward, this does not include any recurrent kernels necessary for decode.

i also added naive impl attn_gym/linear/kda/naive.py and very simple tests to compare against the naive impl
