### PR TITLE
Support realistic top-k in shared-KV selected attention

### DIFF
--- a/attn_gym/sparse/selected_attention/api.py
+++ b/attn_gym/sparse/selected_attention/api.py
@@ -37,9 +37,10 @@ def _validate_inputs(
         raise ValueError(
             f"sparse_kv must have the same dtype as query, but got {sparse_kv.dtype} and {query.dtype}."
         )
-    if attention_sink.dtype != query.dtype:
+    if attention_sink.dtype not in (query.dtype, torch.float32):
         raise ValueError(
-            f"attention_sink must have the same dtype as query, but got {attention_sink.dtype} and {query.dtype}."
+            "attention_sink must have the same dtype as query or use torch.float32, "
+            f"but got {attention_sink.dtype} and {query.dtype}."
         )
 
     if local_kv.device != query.device:
@@ -168,8 +169,8 @@ def selected_attention(
             Shape of (batch, sequence_length, num_topk_blocks), integer tensor
             query[i, j] will attend to all sparse_kv[i, kv_indices[k]] for all k < num_topk_blocks
 
-        attention_sink: tensor in shape of (num_heads, ), learnable per head weight that occupies
-            denominator of softmax
+        attention_sink: tensor in shape of (num_heads, ), learnable per-head weight that occupies
+            the denominator of softmax. It may use the query dtype or torch.float32.
 
         doc_ids: Integer tensor in shape of (batch_size, sequence_length) or None.
             Looks something like [0, 0, 0, 1, 1, 2, 2, 2, 2], where tokens with the same id

--- a/attn_gym/sparse/selected_attention/impl/reference.py
+++ b/attn_gym/sparse/selected_attention/impl/reference.py
@@ -120,6 +120,7 @@ def selected_attention(
     """
     device = query.device
     dtype = query.dtype
+    accumulation_dtype = torch.promote_types(dtype, torch.float32)
     b, h, s, head_dim = query.shape
     sparse_seq_len = sparse_kv.shape[2]
     if share_kv:
@@ -134,39 +135,47 @@ def selected_attention(
         valid_mask = kv_indices >= 0
         safe_indices = kv_indices.clamp(min=0)
         # Count how many times each position is selected per query (ignoring sentinels)
-        counts = torch.zeros(b, s, sparse_seq_len, device=device, dtype=dtype)
+        counts = torch.zeros(b, s, sparse_seq_len, device=device, dtype=accumulation_dtype)
         counts.scatter_add_(
             dim=-1,
             index=safe_indices,
-            src=valid_mask.to(dtype),
+            src=valid_mask.to(accumulation_dtype),
         )
         # Convert counts to additive log-mask: 0 selections → -inf, k selections → log(k)
         topk_mask = torch.where(
             counts > 0, torch.log(counts), torch.full_like(counts, float("-inf"))
         )
 
-    SWA_mask = make_sliding_window_mask(s, sliding_window_size, device, dtype).unsqueeze(0)
+    SWA_mask = make_sliding_window_mask(
+        s, sliding_window_size, device, accumulation_dtype
+    ).unsqueeze(0)
     SWA_mask = SWA_mask.expand(b, -1, -1)
 
     if doc_ids is not None:
-        packing_mask = make_packed_mask(doc_ids, dtype=dtype)
+        packing_mask = make_packed_mask(doc_ids, dtype=accumulation_dtype)
         # packing_mask is [B, 1, S, S], SWA_mask is [B, S, S]
         SWA_mask = SWA_mask + packing_mask.squeeze(1)
 
     attention_kv = torch.cat([sparse_kv, local_kv], dim=-2)
     attention_mask = torch.cat([topk_mask, SWA_mask], dim=-1).unsqueeze(1)
+    query_acc = query.to(accumulation_dtype)
+    attention_kv_acc = attention_kv.to(accumulation_dtype)
 
     scale = head_dim**0.5
 
+    # Match the optimized backends' mixed-precision boundaries: accumulate QK and
+    # softmax in FP32 for low-precision inputs, then quantize P for the PV dot.
     logits = (
-        torch.matmul(query, torch.permute(attention_kv, (0, 1, 3, 2))) / scale + attention_mask
+        torch.matmul(query_acc, torch.permute(attention_kv_acc, (0, 1, 3, 2))) / scale
+        + attention_mask
     )
 
-    # Concatenate sink as an extra column, apply standard softmax, then drop it
-    sink_logit = attention_sink[None, :, None, None].expand(b, -1, s, 1)
+    # Concatenate sink as an extra column, apply standard softmax, then drop it.
+    sink_logit = attention_sink.to(accumulation_dtype)[None, :, None, None].expand(b, -1, s, 1)
     logits_with_sink = torch.cat([logits, sink_logit], dim=-1)
     probs_with_sink = torch.softmax(logits_with_sink, dim=-1)
-    probs = probs_with_sink[..., :-1].to(attention_kv.dtype)
+    probs = probs_with_sink[..., :-1].to(dtype)
 
-    attn_output = probs @ attention_kv
-    return attn_output
+    # The low-precision P and KV operands accumulate in FP32 before the output
+    # is stored in the input dtype, as in a tensor-core dot.
+    return torch.matmul(probs.to(accumulation_dtype), attention_kv_acc).to(dtype)

--- a/attn_gym/sparse/selected_attention/impl/reference.py
+++ b/attn_gym/sparse/selected_attention/impl/reference.py
@@ -166,7 +166,7 @@ def selected_attention(
     sink_logit = attention_sink[None, :, None, None].expand(b, -1, s, 1)
     logits_with_sink = torch.cat([logits, sink_logit], dim=-1)
     probs_with_sink = torch.softmax(logits_with_sink, dim=-1)
-    probs = probs_with_sink[..., :-1]
+    probs = probs_with_sink[..., :-1].to(attention_kv.dtype)
 
     attn_output = probs @ attention_kv
     return attn_output

--- a/attn_gym/sparse/selected_attention/impl/triton/__init__.py
+++ b/attn_gym/sparse/selected_attention/impl/triton/__init__.py
@@ -115,9 +115,15 @@ def selected_attention(
     if doc_ids is not None:
         doc_ids = doc_ids.contiguous()
 
-    if torch.is_grad_enabled() and any(
-        t.requires_grad for t in (query, local_kv, sparse_kv, attention_sink)
-    ):
+    requires_grad = torch.is_grad_enabled() and any(
+        tensor.requires_grad for tensor in (query, local_kv, sparse_kv, attention_sink)
+    )
+    if requires_grad and query.shape[-1] == 512:
+        raise NotImplementedError(
+            "The Triton selected-attention backend currently supports head_dim=512 only for "
+            "inference."
+        )
+    if requires_grad:
         return _SelectedAttentionFunction.apply(
             query, sparse_kv, local_kv, kv_indices, attention_sink, doc_ids, sliding_window_size
         )

--- a/attn_gym/sparse/selected_attention/impl/triton/forward.py
+++ b/attn_gym/sparse/selected_attention/impl/triton/forward.py
@@ -144,6 +144,13 @@ def _selected_attention_fwd(
     )
 
 
+def prune_shared_forward_configs(configs, _named_args, D, **_):
+    """Avoid local tiles that exceed shared memory for wide head dimensions."""
+    if D <= 128:
+        return configs
+    return [config for config in configs if config.kwargs["BLOCK_N"] == 64]
+
+
 @triton.autotune(
     configs=[
         triton.Config({"BLOCK_N": block_n}, num_warps=num_warps, num_stages=1)
@@ -151,6 +158,7 @@ def _selected_attention_fwd(
         for num_warps in (4, 8)
     ],
     key=["B", "H", "S", "D", "SPARSE_SEQ_LEN", "TOPK", "WINDOW", "HAS_DOC_IDS"],
+    prune_configs_by={"early_config_prune": prune_shared_forward_configs},
     cache_results=True,
 )
 @triton.jit
@@ -208,37 +216,42 @@ def _selected_attention_fwd_shared(
     accumulator = tl.zeros((BLOCK_H, BLOCK_D), tl.float32)
 
     if TOPK:
+        # Keep on-chip storage bounded when the selected set contains hundreds of entries.
         offsets_k = tl.arange(0, BLOCK_K)
-        selected_idx = tl.load(
-            kv_indices_ptr + ptr_offset((batch, sequence, offsets_k), KV_INDICES_STRIDES),
-            mask=offsets_k < TOPK,
-            other=-1,
-        )
-        selected_valid = (offsets_k < TOPK) & (selected_idx >= 0) & (selected_idx < SPARSE_SEQ_LEN)
-        selected_idx = tl.where(selected_valid, selected_idx, 0)
-        sparse_values = tl.load(
-            sparse_kv_ptr
-            + ptr_offset(
-                (batch, 0, selected_idx[:, None], offsets_d[None, :]),
-                SPARSE_KV_STRIDES,
-            ),
-            mask=selected_valid[:, None] & dimension_mask[None, :],
-            other=0.0,
-        )
-        logits = tl.dot(query, tl.trans(sparse_values), input_precision="tf32x3") * SCALE
-        logits = tl.where(head_mask[:, None] & selected_valid[None, :], logits, -float("inf"))
-        accumulator, running_max, running_sum = online_softmax_update(
-            accumulator, running_max, running_sum, logits, sparse_values
-        )
+        for selected_start in tl.range(0, TOPK, BLOCK_K, num_stages=2):
+            selected_offsets = selected_start + offsets_k
+            selected_idx = tl.load(
+                kv_indices_ptr
+                + ptr_offset((batch, sequence, selected_offsets), KV_INDICES_STRIDES),
+                mask=selected_offsets < TOPK,
+                other=-1,
+            )
+            selected_valid = (
+                (selected_offsets < TOPK) & (selected_idx >= 0) & (selected_idx < SPARSE_SEQ_LEN)
+            )
+            selected_idx = tl.where(selected_valid, selected_idx, 0)
+            sparse_values = tl.load(
+                sparse_kv_ptr
+                + ptr_offset(
+                    (batch, 0, selected_idx[:, None], offsets_d[None, :]),
+                    SPARSE_KV_STRIDES,
+                ),
+                mask=selected_valid[:, None] & dimension_mask[None, :],
+                other=0.0,
+            )
+            logits = tl.dot(query, tl.trans(sparse_values), input_precision="tf32x3") * SCALE
+            logits = tl.where(head_mask[:, None] & selected_valid[None, :], logits, -float("inf"))
+            accumulator, running_max, running_sum = online_softmax_update(
+                accumulator, running_max, running_sum, logits, sparse_values
+            )
 
     if HAS_DOC_IDS:
         query_doc_id = tl.load(doc_ids_ptr + ptr_offset((batch, sequence), DOC_IDS_STRIDES))
 
     offsets_n_base = tl.arange(0, BLOCK_N)
     first_local_position = sequence - WINDOW + 1
-    num_local_tiles: tl.constexpr = tl.cdiv(WINDOW, BLOCK_N)
-    for local_tile in tl.static_range(0, num_local_tiles):
-        offsets_n = first_local_position + local_tile * BLOCK_N + offsets_n_base
+    for local_start in tl.range(0, WINDOW, BLOCK_N, num_stages=2):
+        offsets_n = first_local_position + local_start + offsets_n_base
         local_valid = (offsets_n >= 0) & (offsets_n <= sequence) & (offsets_n < S)
         local_values = tl.load(
             local_kv_ptr
@@ -428,12 +441,16 @@ def _launch_forward(
         and local_kv.stride(-1) == 1
         and 16 <= heads <= 128
         and head_dim % 16 == 0
-        and head_dim <= 128
-        and topk <= 64
+        and (head_dim <= 128 or head_dim == 512)
         and sliding_window_size <= 2048
     ):
-        block_h = max(16, triton.next_power_of_2(heads))
-        block_k = max(16, triton.next_power_of_2(topk)) if topk else 16
+        # A smaller head tile keeps D=512 accumulators within Blackwell's resources.
+        block_h = (
+            triton.next_power_of_2(heads)
+            if head_dim <= 128
+            else min(32, triton.next_power_of_2(heads))
+        )
+        block_k = max(16, min(64, triton.next_power_of_2(topk))) if topk else 16
         _selected_attention_fwd_shared[(seq_len, batch, triton.cdiv(heads, block_h))](
             query,
             sparse_kv,

--- a/test/test_selected_attention_semantics.py
+++ b/test/test_selected_attention_semantics.py
@@ -370,6 +370,78 @@ def test_float32_attention_sink(backend):
     )
 
 
+def test_eager_bfloat16_mixed_precision_schedule():
+    """Eager mirrors FP32 QK/softmax/PV accumulation and BF16 dot operands."""
+    torch.manual_seed(2027)
+    batch, heads, seq_len, head_dim = 1, 2, 5, 16
+    sparse_seq_len, window = 6, 3
+    query = torch.randn(batch, heads, seq_len, head_dim, dtype=torch.bfloat16)
+    local_kv = torch.randn(batch, heads, seq_len, head_dim, dtype=torch.bfloat16)
+    sparse_kv = torch.randn(batch, heads, sparse_seq_len, head_dim, dtype=torch.bfloat16)
+    kv_indices = torch.tensor(
+        [[[0, 0, 2], [1, 3, -1], [2, 4, 5], [0, 3, 5], [1, 1, 4]]],
+        dtype=torch.int64,
+    )
+    attention_sink = torch.randn(heads, dtype=torch.bfloat16)
+
+    valid_indices = kv_indices >= 0
+    counts = torch.zeros(batch, seq_len, sparse_seq_len, dtype=torch.float32)
+    counts.scatter_add_(
+        -1,
+        kv_indices.clamp(min=0),
+        valid_indices.to(torch.float32),
+    )
+    sparse_mask = torch.where(
+        counts > 0,
+        counts.log(),
+        torch.full_like(counts, -float("inf")),
+    )
+    query_positions = torch.arange(seq_len)[:, None]
+    key_positions = torch.arange(seq_len)[None, :]
+    local_valid = (key_positions <= query_positions) & (
+        key_positions >= query_positions - window + 1
+    )
+    local_mask = torch.zeros(seq_len, seq_len, dtype=torch.float32).masked_fill(
+        ~local_valid, -float("inf")
+    )
+    attention_mask = torch.cat([sparse_mask, local_mask.expand(batch, -1, -1)], dim=-1).unsqueeze(
+        1
+    )
+    attention_kv = torch.cat([sparse_kv, local_kv], dim=-2)
+    logits = (query.float() @ attention_kv.float().transpose(-2, -1)) / math.sqrt(
+        head_dim
+    ) + attention_mask
+    sink_logits = attention_sink.float()[None, :, None, None].expand(batch, -1, seq_len, 1)
+    probabilities = torch.softmax(torch.cat([logits, sink_logits], dim=-1), dim=-1)[..., :-1].to(
+        torch.bfloat16
+    )
+    expected = (probabilities.float() @ attention_kv.float()).to(torch.bfloat16)
+
+    actual = selected_attention(
+        query,
+        local_kv,
+        sparse_kv,
+        kv_indices,
+        attention_sink,
+        None,
+        window,
+        backend="eager",
+    )
+    actual_float32_sink = selected_attention(
+        query,
+        local_kv,
+        sparse_kv,
+        kv_indices,
+        attention_sink.float(),
+        None,
+        window,
+        backend="eager",
+    )
+
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+    torch.testing.assert_close(actual_float32_sink, expected, atol=0, rtol=0)
+
+
 # ---------------------------------------------------------------------------
 # 5. Repeated selections (backends must agree)
 # ---------------------------------------------------------------------------

--- a/test/test_selected_attention_semantics.py
+++ b/test/test_selected_attention_semantics.py
@@ -5,6 +5,8 @@ attention sink behavior, and repeated selections.
 Tests both eager (reference) and triton backends.
 """
 
+import math
+
 import pytest
 import torch
 
@@ -22,7 +24,7 @@ def shared_kv_blackwell_inputs():
     """Create a packed shared-KV case that exercises both attention branches."""
     torch.manual_seed(123)
     batch, heads, seq_len, head_dim = 1, 24, 33, 32
-    sparse_seq_len, topk = 37, 7
+    sparse_seq_len, topk = 79, 73
     query = torch.randn(
         batch,
         heads,
@@ -64,6 +66,27 @@ def _device_for_backend(backend):
 
 def _dtype_for_backend(backend):
     return torch.float32
+
+
+def assert_matches_low_precision_eager(
+    actual,
+    low_precision_expected,
+    high_precision_expected,
+    reduction_sizes,
+):
+    """Bound kernel error by low-precision eager error against an FP64 measuring stick."""
+    assert torch.isfinite(actual).all()
+    actual_difference = (actual.double() - high_precision_expected).abs()
+    eager_difference = (low_precision_expected.double() - high_precision_expected).abs()
+    accumulation_eps = (
+        sum(math.sqrt(size) for size in reduction_sizes) * torch.finfo(torch.float32).eps
+    )
+    output_rounding_eps = torch.finfo(actual.dtype).eps
+    rounding_eps = accumulation_eps + output_rounding_eps
+    mean_atol = rounding_eps * high_precision_expected.abs().mean().item()
+    max_atol = rounding_eps * high_precision_expected.abs().max().item()
+    assert actual_difference.mean().item() <= eager_difference.mean().item() + mean_atol
+    assert actual_difference.max().item() <= eager_difference.max().item() + max_atol
 
 
 # ---------------------------------------------------------------------------
@@ -310,6 +333,43 @@ def test_sink_very_negative_has_no_effect(backend):
     torch.testing.assert_close(out, expected, atol=atol, rtol=1e-4)
 
 
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_float32_attention_sink(backend):
+    """A float32 sink is supported with lower-precision query and KV tensors."""
+    device = _device_for_backend(backend)
+    torch.manual_seed(101)
+    query = torch.randn(1, 2, 4, 16, device=device, dtype=torch.bfloat16)
+    local_kv = torch.randn(1, 2, 4, 16, device=device, dtype=torch.bfloat16)
+    sparse_kv = torch.randn(1, 2, 4, 16, device=device, dtype=torch.bfloat16)
+    kv_indices = torch.tensor([[[0, 1], [1, 2], [2, 3], [0, 3]]], device=device, dtype=torch.int32)
+    attention_sink = torch.randn(2, device=device, dtype=torch.float32)
+
+    high_precision_expected = selected_attention(
+        query.double(),
+        local_kv.double(),
+        sparse_kv.double(),
+        kv_indices,
+        attention_sink.double(),
+        None,
+        2,
+        backend="eager",
+    )
+    low_precision_expected = selected_attention(
+        query, local_kv, sparse_kv, kv_indices, attention_sink, None, 2, backend="eager"
+    )
+    actual = selected_attention(
+        query, local_kv, sparse_kv, kv_indices, attention_sink, None, 2, backend=backend
+    )
+
+    assert actual.dtype == torch.bfloat16
+    assert_matches_low_precision_eager(
+        actual,
+        low_precision_expected,
+        high_precision_expected,
+        reduction_sizes=(query.shape[-1], kv_indices.shape[-1] + 2, kv_indices.shape[-1] + 2),
+    )
+
+
 # ---------------------------------------------------------------------------
 # 5. Repeated selections (backends must agree)
 # ---------------------------------------------------------------------------
@@ -475,6 +535,74 @@ def test_shared_kv_blackwell_sparse_only():
         )
 
     torch.testing.assert_close(actual, expected, atol=0.04, rtol=0.02)
+
+
+@pytest.mark.skipif(not BLACKWELL_AVAILABLE, reason="Blackwell GPU required")
+def test_shared_kv_blackwell_dsv4_forward():
+    """The tiled shared-KV forward handles DSV4's head dimension and sparse top-k."""
+    torch.manual_seed(2026)
+    batch, heads, seq_len, head_dim = 1, 64, 16, 512
+    sparse_seq_len, topk, window = 512, 512, 128
+    query = torch.randn(batch, heads, seq_len, head_dim, device="cuda", dtype=torch.bfloat16)
+    local_kv = torch.randn(batch, 1, seq_len, head_dim, device="cuda", dtype=torch.bfloat16)
+    sparse_kv = torch.randn(
+        batch, 1, sparse_seq_len, head_dim, device="cuda", dtype=torch.bfloat16
+    )
+    kv_indices = torch.stack(
+        [torch.randperm(sparse_seq_len, device="cuda")[:topk] for _ in range(seq_len)]
+    ).unsqueeze(0)
+    kv_indices[:, :4, -3:] = -1
+    attention_sink = torch.randn(heads, device="cuda", dtype=torch.float32)
+
+    with torch.inference_mode():
+        high_precision_expected = selected_attention(
+            query.double(),
+            local_kv.double(),
+            sparse_kv.double(),
+            kv_indices,
+            attention_sink.double(),
+            None,
+            window,
+            backend="eager",
+        )
+        low_precision_expected = selected_attention(
+            query,
+            local_kv,
+            sparse_kv,
+            kv_indices,
+            attention_sink,
+            None,
+            window,
+            backend="eager",
+        )
+        actual = selected_attention(
+            query,
+            local_kv,
+            sparse_kv,
+            kv_indices,
+            attention_sink,
+            None,
+            window,
+            backend="triton",
+        )
+
+    assert_matches_low_precision_eager(
+        actual,
+        low_precision_expected,
+        high_precision_expected,
+        reduction_sizes=(head_dim, topk + window, topk + window),
+    )
+    with pytest.raises(NotImplementedError, match="head_dim=512 only for inference"):
+        selected_attention(
+            query.requires_grad_(),
+            local_kv,
+            sparse_kv,
+            kv_indices,
+            attention_sink,
+            None,
+            window,
+            backend="triton",
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- stream selected shared-KV entries through bounded 64-entry tiles instead of materializing the full top-k set on chip
- pipeline both selected and local tiles with `tl.range(..., num_stages=2)`
- add a resource-safe `H=32` schedule for Blackwell `head_dim=512` forward and prune oversized local-tile configs
- accept FP32 attention sinks, matching the DSV4 model definition
- validate low-precision numerics against an FP64 measuring stick, using low-precision eager as the error baseline

The optimized `head_dim=512` Triton route is intentionally inference-only. Gradient-requiring D=512 calls now fail early with a clear error instead of reaching the existing backward shared-memory OOR.

## Performance

NVIDIA GB300 (SM 10.3), torch `2.14.0.dev20260724+cu132`, Triton 3.8.0, BF16, fixed warm/reused tensors, default DVFS, no CUDA graphs. Existing-shape numbers use the same GPU and internal launcher before/after.

| case | main | this PR | speedup |
|---|---:|---:|---:|
| model | 1033.2 us | 669.2 us | 1.54x |
| long context | 824.0 us | 679.5 us | 1.21x |
| wide selection | 1052.7 us | 567.9 us | 1.85x |
| packed docs | 360.4 us | 269.9 us | 1.34x |
| ragged holdout | 445.7 us | 339.5 us | 1.31x |
| non-shared control | 890.9 us | 890.9 us | 1.00x |

Realistic large-top-k public-API measurements:

- DSV4-like `B=1,H=64,S=4096,D=512,K=512,W=128`, ratio-4 causal compressed indices, FP32 sink: **1.185 ms**, **290.0 fixed-work TFLOP/s**, **231.1 useful TFLOP/s**
- uncompressed `K=2048` stress case at `B=1,H=64,S=4096,D=512,W=128`: **3.730 ms**, **313.2 fixed-work TFLOP/s**, **239.2 useful TFLOP/s**

The old DSV4-shaped generic fallback did not finish compiling within 600 seconds even at `S=16`; the tiled specialization compiles/autotunes in about 4.5 seconds there.

A focused NCU run (`--cache-control none`) shows this Triton formulation is not HBM-bound: 313 GB/s / 3.95% DRAM throughput with an 85.9% L2 hit rate. It is primarily on-chip/dependency limited: 76.4% L1/TEX throughput, 49.2% tensor-pipe utilization, 255 registers/thread, 102.7 KiB dynamic shared memory, two CTAs/SM, 12.5% occupancy, and 66.2% cycles with no eligible warp. This leaves a clear follow-up opportunity for a TCGEN/TMEM CuTe specialization rather than a persistent-grid tweak.

## Validation

- `CUDA_VISIBLE_DEVICES=1 PYTHONPATH=. ~/.venvs/nightly/bin/pytest -q` — **242 passed, 1 skipped**
- `prek run --all-files`
- manual `torch.compile(fullgraph=True)` DSV4-shaped forward check
