### PR TITLE
Optimize shared-KV selected-attention backward

### DIFF
--- a/attn_gym/sparse/selected_attention/impl/triton/__init__.py
+++ b/attn_gym/sparse/selected_attention/impl/triton/__init__.py
@@ -19,6 +19,7 @@ class _SelectedAttentionFunction(torch.autograd.Function):
         attention_sink: torch.Tensor,
         doc_ids: torch.Tensor | None,
         sliding_window_size: int,
+        share_kv: bool,
     ) -> torch.Tensor:
         output, lse = _launch_forward(
             query,
@@ -43,6 +44,7 @@ class _SelectedAttentionFunction(torch.autograd.Function):
         )
         ctx.doc_ids = doc_ids
         ctx.sliding_window_size = sliding_window_size
+        ctx.share_kv = share_kv
         return output
 
     @staticmethod
@@ -71,8 +73,9 @@ class _SelectedAttentionFunction(torch.autograd.Function):
             lse,
             grad_output,
             ctx.sliding_window_size,
+            ctx.share_kv,
         )
-        return grad_query, grad_sparse_kv, grad_local_kv, None, grad_sink, None, None
+        return grad_query, grad_sparse_kv, grad_local_kv, None, grad_sink, None, None, None
 
 
 def selected_attention(
@@ -83,7 +86,7 @@ def selected_attention(
     attention_sink: torch.Tensor,
     doc_ids: torch.Tensor | None,
     sliding_window_size: int,
-    share_kv: bool = True,
+    share_kv: bool,
 ) -> torch.Tensor:
     """Triton implementation of selected attention.
 
@@ -95,7 +98,7 @@ def selected_attention(
         attention_sink: (heads,) — learned per-head sink weight.
         doc_ids: (batch, seq_len) or None — document IDs for packing isolation.
         sliding_window_size: size of the causal sliding window.
-        share_kv: if True, expand single-head KV to all heads.
+        share_kv: if True, expand single-head KV and sum its per-head gradients.
 
     Returns:
         Attention output with same shape as query.
@@ -125,7 +128,14 @@ def selected_attention(
         )
     if requires_grad:
         return _SelectedAttentionFunction.apply(
-            query, sparse_kv, local_kv, kv_indices, attention_sink, doc_ids, sliding_window_size
+            query,
+            sparse_kv,
+            local_kv,
+            kv_indices,
+            attention_sink,
+            doc_ids,
+            sliding_window_size,
+            share_kv,
         )
     return _launch_forward(
         query, sparse_kv, local_kv, kv_indices, attention_sink, doc_ids, sliding_window_size

--- a/attn_gym/sparse/selected_attention/impl/triton/backward.py
+++ b/attn_gym/sparse/selected_attention/impl/triton/backward.py
@@ -9,7 +9,17 @@ from triton.tools.tensor_descriptor import TensorDescriptor
 
 from attn_gym._backends.triton.utils import can_use_tma
 
-from .primitives import causal_window_mask, load_bhsd, load_bs, store_bhsd
+from .primitives import (
+    can_use_shared_kv_schedule,
+    causal_window_mask,
+    load_bhsd,
+    load_bs,
+    store_bhsd,
+)
+from .shared_backward import (
+    _selected_attention_bwd_dq_shared,
+    _selected_attention_bwd_dsparse_kv_shared,
+)
 
 
 @triton.jit
@@ -531,6 +541,7 @@ def _launch_backward(
     lse: torch.Tensor,
     grad_output: torch.Tensor,
     sliding_window_size: int,
+    share_kv: bool,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """Launch backward kernels for selected attention."""
     batch, heads, seq_len, head_dim = query.shape
@@ -546,52 +557,98 @@ def _launch_backward(
     # Expanded shared KV has a zero head stride, but its per-head gradients
     # need distinct storage before ExpandBackward sums them.
     grad_local_kv = torch.empty(local_kv.shape, device=local_kv.device, dtype=local_kv.dtype)
-    grad_sink_fp32 = torch.zeros(heads, device=query.device, dtype=torch.float32)
 
     has_doc_ids = doc_ids is not None
     doc_ids = query if doc_ids is None else doc_ids
     use_tma = can_use_tma(query) and can_use_tma(local_kv) and can_use_tma(grad_output)
 
-    num_local_key_tiles = (
-        triton.cdiv(sliding_window_size + block_m - 1, block_n) if sliding_window_size else 0
-    )
     num_local_query_tiles = (
         triton.cdiv(sliding_window_size + block_n - 1, block_m) if sliding_window_size else 0
     )
 
-    _selected_attention_bwd_dq[(triton.cdiv(seq_len, block_m), batch * heads)](
-        query,
-        sparse_kv,
-        local_kv,
-        kv_indices,
-        doc_ids,
-        output,
-        grad_output,
-        lse,
-        attention_sink,
-        grad_query,
-        grad_sink_fp32,
-        QUERY_STRIDES=query.stride(),
-        SPARSE_KV_STRIDES=sparse_kv.stride(),
-        LOCAL_KV_STRIDES=local_kv.stride(),
-        KV_INDICES_STRIDES=kv_indices.stride(),
-        DOC_IDS_STRIDES=doc_ids.stride(),
-        LSE_STRIDES=lse.stride(),
-        H=heads,
-        S=seq_len,
-        D=head_dim,
-        SPARSE_SEQ_LEN=sparse_seq_len,
-        TOPK=topk,
-        WINDOW=sliding_window_size,
-        SCALE=scale,
-        HAS_DOC_IDS=has_doc_ids,
-        NUM_LOCAL_TILES=num_local_key_tiles,
-        BLOCK_M=block_m,
-        BLOCK_N=block_n,
-        BLOCK_D=block_d,
-        num_warps=8,
-        num_stages=3,
+    # Zero head strides share values; share_kv also guarantees autograd will sum dKV heads.
+    use_shared_schedule = (
+        share_kv
+        and can_use_shared_kv_schedule(query, sparse_kv, local_kv, sliding_window_size)
+        and head_dim <= 128
     )
+    if use_shared_schedule:
+        block_h = min(32, triton.next_power_of_2(heads))
+        block_k = max(16, min(64, triton.next_power_of_2(topk)))
+        grad_sink_partials = torch.empty(
+            batch, heads, seq_len, device=query.device, dtype=torch.float32
+        )
+        _selected_attention_bwd_dq_shared[(seq_len, batch, triton.cdiv(heads, block_h))](
+            query,
+            sparse_kv,
+            local_kv,
+            kv_indices,
+            doc_ids,
+            output,
+            grad_output,
+            lse,
+            attention_sink,
+            grad_query,
+            grad_sink_partials,
+            QUERY_STRIDES=query.stride(),
+            SPARSE_KV_STRIDES=sparse_kv.stride(),
+            LOCAL_KV_STRIDES=local_kv.stride(),
+            KV_INDICES_STRIDES=kv_indices.stride(),
+            DOC_IDS_STRIDES=doc_ids.stride(),
+            LSE_STRIDES=lse.stride(),
+            GRAD_SINK_PARTIALS_STRIDES=grad_sink_partials.stride(),
+            B=batch,
+            H=heads,
+            S=seq_len,
+            D=head_dim,
+            SPARSE_SEQ_LEN=sparse_seq_len,
+            TOPK=topk,
+            WINDOW=sliding_window_size,
+            SCALE=scale,
+            HAS_DOC_IDS=has_doc_ids,
+            BLOCK_H=block_h,
+            BLOCK_K=block_k,
+            BLOCK_D=block_d,
+        )
+        grad_sink_fp32 = grad_sink_partials.sum(dim=(0, 2))
+    else:
+        num_local_key_tiles = (
+            triton.cdiv(sliding_window_size + block_m - 1, block_n) if sliding_window_size else 0
+        )
+        grad_sink_fp32 = torch.zeros(heads, device=query.device, dtype=torch.float32)
+        _selected_attention_bwd_dq[(triton.cdiv(seq_len, block_m), batch * heads)](
+            query,
+            sparse_kv,
+            local_kv,
+            kv_indices,
+            doc_ids,
+            output,
+            grad_output,
+            lse,
+            attention_sink,
+            grad_query,
+            grad_sink_fp32,
+            QUERY_STRIDES=query.stride(),
+            SPARSE_KV_STRIDES=sparse_kv.stride(),
+            LOCAL_KV_STRIDES=local_kv.stride(),
+            KV_INDICES_STRIDES=kv_indices.stride(),
+            DOC_IDS_STRIDES=doc_ids.stride(),
+            LSE_STRIDES=lse.stride(),
+            H=heads,
+            S=seq_len,
+            D=head_dim,
+            SPARSE_SEQ_LEN=sparse_seq_len,
+            TOPK=topk,
+            WINDOW=sliding_window_size,
+            SCALE=scale,
+            HAS_DOC_IDS=has_doc_ids,
+            NUM_LOCAL_TILES=num_local_key_tiles,
+            BLOCK_M=block_m,
+            BLOCK_N=block_n,
+            BLOCK_D=block_d,
+            num_warps=8,
+            num_stages=3,
+        )
 
     local_grid = (triton.cdiv(seq_len, block_n), batch * heads)
     if use_tma:
@@ -650,10 +707,25 @@ def _launch_backward(
         )
 
     if topk > 0:
-        grad_sparse_kv = torch.empty(
-            sparse_kv.shape, device=sparse_kv.device, dtype=sparse_kv.dtype
-        )
-        _selected_attention_bwd_dsparse_kv[(sparse_seq_len, batch * heads)](
+        if use_shared_schedule:
+            # ExpandBackward sums every head slot, including slots no tile writes.
+            grad_sparse_kv = torch.zeros(
+                sparse_kv.shape, device=sparse_kv.device, dtype=sparse_kv.dtype
+            )
+            sparse_kernel = _selected_attention_bwd_dsparse_kv_shared
+            sparse_grid = lambda meta: (
+                sparse_seq_len,
+                batch,
+                triton.cdiv(heads, meta["BLOCK_H"]),
+            )
+        else:
+            grad_sparse_kv = torch.empty(
+                sparse_kv.shape, device=sparse_kv.device, dtype=sparse_kv.dtype
+            )
+            sparse_kernel = _selected_attention_bwd_dsparse_kv
+            sparse_grid = (sparse_seq_len, batch * heads)
+
+        sparse_kernel[sparse_grid](
             query,
             sparse_kv,
             selected_queries,

--- a/attn_gym/sparse/selected_attention/impl/triton/forward.py
+++ b/attn_gym/sparse/selected_attention/impl/triton/forward.py
@@ -9,7 +9,14 @@ from triton.tools.tensor_descriptor import TensorDescriptor
 
 from attn_gym._backends.triton.utils import can_use_tma, ptr_offset
 
-from .primitives import causal_window_mask, load_bhsd, load_bs, online_softmax_update, store_bhsd
+from .primitives import (
+    can_use_shared_kv_schedule,
+    causal_window_mask,
+    load_bhsd,
+    load_bs,
+    online_softmax_update,
+    store_bhsd,
+)
 
 
 @triton.jit
@@ -431,18 +438,8 @@ def _launch_forward(
     doc_ids = query if doc_ids is None else doc_ids
 
     # This head-major schedule is tuned for shared KV on Blackwell.
-    if (
-        torch.cuda.get_device_capability(query.device)[0] >= 10
-        and query.dtype == torch.bfloat16
-        and sparse_kv.stride(1) == 0
-        and local_kv.stride(1) == 0
-        and query.stride(-1) == 1
-        and sparse_kv.stride(-1) == 1
-        and local_kv.stride(-1) == 1
-        and 16 <= heads <= 128
-        and head_dim % 16 == 0
-        and (head_dim <= 128 or head_dim == 512)
-        and sliding_window_size <= 2048
+    if can_use_shared_kv_schedule(query, sparse_kv, local_kv, sliding_window_size) and (
+        head_dim <= 128 or head_dim == 512
     ):
         # A smaller head tile keeps D=512 accumulators within Blackwell's resources.
         block_h = (
@@ -450,7 +447,7 @@ def _launch_forward(
             if head_dim <= 128
             else min(32, triton.next_power_of_2(heads))
         )
-        block_k = max(16, min(64, triton.next_power_of_2(topk))) if topk else 16
+        block_k = max(16, min(64, triton.next_power_of_2(topk)))
         _selected_attention_fwd_shared[(seq_len, batch, triton.cdiv(heads, block_h))](
             query,
             sparse_kv,

--- a/attn_gym/sparse/selected_attention/impl/triton/primitives.py
+++ b/attn_gym/sparse/selected_attention/impl/triton/primitives.py
@@ -1,9 +1,35 @@
 """Triton primitives shared by selected-attention kernel schedules."""
 
+import torch
 import triton
 import triton.language as tl
 
 from attn_gym._backends.triton.utils import ptr_offset
+
+
+def can_use_shared_kv_schedule(
+    query: torch.Tensor,
+    sparse_kv: torch.Tensor,
+    local_kv: torch.Tensor,
+    sliding_window_size: int,
+) -> bool:
+    """Check Blackwell shared-KV constraints common to forward and backward.
+
+    Callers enforce the head-dimension limits supported by their kernel.
+    """
+    _, heads, _, head_dim = query.shape
+    return (
+        torch.cuda.get_device_capability(query.device)[0] >= 10
+        and query.dtype == torch.bfloat16
+        and sparse_kv.stride(1) == 0
+        and local_kv.stride(1) == 0
+        and query.stride(-1) == 1
+        and sparse_kv.stride(-1) == 1
+        and local_kv.stride(-1) == 1
+        and 16 <= heads <= 128
+        and head_dim % 16 == 0
+        and sliding_window_size <= 2048
+    )
 
 
 @triton.jit

--- a/attn_gym/sparse/selected_attention/impl/triton/shared_backward.py
+++ b/attn_gym/sparse/selected_attention/impl/triton/shared_backward.py
@@ -1,0 +1,338 @@
+"""Blackwell shared-KV schedules for selected-attention backward.
+
+Each dQ program owns its query and sink-partial outputs. Sparse dKV programs write one
+partial per head tile into the expanded head dimension, which autograd subsequently sums.
+This keeps repeated backward calls from one forward atomic-free and bitwise repeatable.
+"""
+
+import triton
+import triton.language as tl
+
+from attn_gym._backends.triton.utils import ptr_offset
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_N": block_n}, num_warps=num_warps, num_stages=1)
+        for block_n in (64, 128)
+        for num_warps in (4, 8)
+    ],
+    key=["B", "H", "S", "D", "SPARSE_SEQ_LEN", "TOPK", "WINDOW", "HAS_DOC_IDS"],
+    cache_results=True,
+)
+@triton.jit
+def _selected_attention_bwd_dq_shared(
+    query_ptr,
+    sparse_kv_ptr,
+    local_kv_ptr,
+    kv_indices_ptr,
+    doc_ids_ptr,
+    output_ptr,
+    grad_output_ptr,
+    lse_ptr,
+    attention_sink_ptr,
+    grad_query_ptr,
+    grad_sink_partials_ptr,
+    QUERY_STRIDES: tl.constexpr,
+    SPARSE_KV_STRIDES: tl.constexpr,
+    LOCAL_KV_STRIDES: tl.constexpr,
+    KV_INDICES_STRIDES: tl.constexpr,
+    DOC_IDS_STRIDES: tl.constexpr,
+    LSE_STRIDES: tl.constexpr,
+    GRAD_SINK_PARTIALS_STRIDES: tl.constexpr,
+    B: tl.constexpr,
+    H: tl.constexpr,
+    S: tl.constexpr,
+    D: tl.constexpr,
+    SPARSE_SEQ_LEN: tl.constexpr,
+    TOPK: tl.constexpr,
+    WINDOW: tl.constexpr,
+    SCALE: tl.constexpr,
+    HAS_DOC_IDS: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    """Compute query gradients across heads while reusing shared KV tiles."""
+    sequence = tl.program_id(0)
+    batch = tl.program_id(1)
+    head_block = tl.program_id(2)
+
+    offsets_h = head_block * BLOCK_H + tl.arange(0, BLOCK_H)
+    offsets_d = tl.arange(0, BLOCK_D)
+    head_mask = offsets_h < H
+    dimension_mask = offsets_d < D
+    matrix_mask = head_mask[:, None] & dimension_mask[None, :]
+
+    query = tl.load(
+        query_ptr
+        + ptr_offset((batch, offsets_h[:, None], sequence, offsets_d[None, :]), QUERY_STRIDES),
+        mask=matrix_mask,
+        other=0.0,
+    )
+    output = tl.load(
+        output_ptr
+        + ptr_offset((batch, offsets_h[:, None], sequence, offsets_d[None, :]), QUERY_STRIDES),
+        mask=matrix_mask,
+        other=0.0,
+    )
+    grad_output = tl.load(
+        grad_output_ptr
+        + ptr_offset((batch, offsets_h[:, None], sequence, offsets_d[None, :]), QUERY_STRIDES),
+        mask=matrix_mask,
+        other=0.0,
+    )
+    lse = tl.load(
+        lse_ptr + ptr_offset((batch, offsets_h, sequence), LSE_STRIDES),
+        mask=head_mask,
+        other=0.0,
+    )
+    delta = tl.sum(grad_output * output, axis=1)
+    grad_query = tl.zeros((BLOCK_H, BLOCK_D), tl.float32)
+
+    if TOPK:
+        offsets_k = tl.arange(0, BLOCK_K)
+        for selected_start in tl.range(0, TOPK, BLOCK_K, num_stages=2):
+            selected_offsets = selected_start + offsets_k
+            selected_idx = tl.load(
+                kv_indices_ptr
+                + ptr_offset((batch, sequence, selected_offsets), KV_INDICES_STRIDES),
+                mask=selected_offsets < TOPK,
+                other=-1,
+            )
+            selected_valid = (
+                (selected_offsets < TOPK) & (selected_idx >= 0) & (selected_idx < SPARSE_SEQ_LEN)
+            )
+            selected_idx = tl.where(selected_valid, selected_idx, 0)
+            sparse_values = tl.load(
+                sparse_kv_ptr
+                + ptr_offset(
+                    (batch, 0, selected_idx[:, None], offsets_d[None, :]),
+                    SPARSE_KV_STRIDES,
+                ),
+                mask=selected_valid[:, None] & dimension_mask[None, :],
+                other=0.0,
+            )
+            scores = tl.dot(query, tl.trans(sparse_values), input_precision="tf32x3") * SCALE
+            probabilities = tl.where(
+                head_mask[:, None] & selected_valid[None, :],
+                tl.exp(scores - lse[:, None]),
+                0.0,
+            )
+            grad_probabilities = tl.dot(
+                grad_output, tl.trans(sparse_values), input_precision="tf32x3"
+            )
+            grad_scores = probabilities * (grad_probabilities - delta[:, None])
+            grad_query += (
+                tl.dot(
+                    grad_scores.to(sparse_values.dtype),
+                    sparse_values,
+                    input_precision="tf32x3",
+                )
+                * SCALE
+            )
+
+    if HAS_DOC_IDS:
+        query_doc_id = tl.load(doc_ids_ptr + ptr_offset((batch, sequence), DOC_IDS_STRIDES))
+
+    offsets_n_base = tl.arange(0, BLOCK_N)
+    first_local_position = sequence - WINDOW + 1
+    for local_start in tl.range(0, WINDOW, BLOCK_N, num_stages=2):
+        offsets_n = first_local_position + local_start + offsets_n_base
+        local_valid = (offsets_n >= 0) & (offsets_n <= sequence) & (offsets_n < S)
+        local_values = tl.load(
+            local_kv_ptr
+            + ptr_offset(
+                (batch, 0, offsets_n[:, None], offsets_d[None, :]),
+                LOCAL_KV_STRIDES,
+            ),
+            mask=local_valid[:, None] & dimension_mask[None, :],
+            other=0.0,
+        )
+        if HAS_DOC_IDS:
+            key_doc_ids = tl.load(
+                doc_ids_ptr + ptr_offset((batch, offsets_n), DOC_IDS_STRIDES),
+                mask=local_valid,
+                other=-1,
+            )
+            local_valid &= key_doc_ids == query_doc_id
+
+        scores = tl.dot(query, tl.trans(local_values), input_precision="tf32x3") * SCALE
+        probabilities = tl.where(
+            head_mask[:, None] & local_valid[None, :],
+            tl.exp(scores - lse[:, None]),
+            0.0,
+        )
+        grad_probabilities = tl.dot(grad_output, tl.trans(local_values), input_precision="tf32x3")
+        grad_scores = probabilities * (grad_probabilities - delta[:, None])
+        grad_query += (
+            tl.dot(
+                grad_scores.to(local_values.dtype),
+                local_values,
+                input_precision="tf32x3",
+            )
+            * SCALE
+        )
+
+    tl.store(
+        grad_query_ptr
+        + ptr_offset((batch, offsets_h[:, None], sequence, offsets_d[None, :]), QUERY_STRIDES),
+        grad_query,
+        mask=matrix_mask,
+    )
+
+    sink = tl.load(attention_sink_ptr + offsets_h, mask=head_mask, other=0.0)
+    sink_gradient = -tl.exp(sink - lse) * delta
+    tl.store(
+        grad_sink_partials_ptr
+        + ptr_offset((batch, offsets_h, sequence), GRAD_SINK_PARTIALS_STRIDES),
+        sink_gradient,
+        mask=head_mask,
+    )
+
+
+# Different BLOCK_H configs write different partial slots, so clear stale slots between trials.
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {"BLOCK_H": block_h, "BLOCK_M": block_m},
+            num_warps=num_warps,
+            num_stages=1,
+        )
+        for block_h, block_m, num_warps in (
+            (2, 32, 4),
+            (4, 16, 4),
+            (4, 32, 4),
+            (4, 32, 8),
+            (8, 16, 4),
+            (8, 16, 8),
+        )
+    ],
+    key=["H", "S", "D", "SPARSE_SEQ_LEN", "TOPK"],
+    reset_to_zero=["grad_sparse_kv_ptr"],
+    cache_results=True,
+)
+@triton.jit
+def _selected_attention_bwd_dsparse_kv_shared(
+    query_ptr,
+    sparse_kv_ptr,
+    selected_queries_ptr,
+    block_offsets_ptr,
+    output_ptr,
+    grad_output_ptr,
+    lse_ptr,
+    grad_sparse_kv_ptr,
+    QUERY_STRIDES: tl.constexpr,
+    SPARSE_KV_STRIDES: tl.constexpr,
+    SELECTED_QUERIES_STRIDES: tl.constexpr,
+    BLOCK_OFFSETS_STRIDES: tl.constexpr,
+    LSE_STRIDES: tl.constexpr,
+    GRAD_SPARSE_KV_STRIDES: tl.constexpr,
+    H: tl.constexpr,
+    S: tl.constexpr,
+    D: tl.constexpr,
+    SPARSE_SEQ_LEN: tl.constexpr,
+    TOPK: tl.constexpr,
+    SCALE: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    """Accumulate a head tile into one partial shared sparse-KV gradient."""
+    sparse_index = tl.program_id(0)
+    batch = tl.program_id(1)
+    head_block = tl.program_id(2)
+
+    offsets_h = head_block * BLOCK_H + tl.arange(0, BLOCK_H)
+    offsets_m_base = tl.arange(0, BLOCK_M)
+    offsets_d = tl.arange(0, BLOCK_D)
+    dot_rows = tl.arange(0, 16)
+    head_mask = offsets_h < H
+    dimension_mask = offsets_d < D
+    sparse_value = tl.load(
+        sparse_kv_ptr + ptr_offset((batch, 0, sparse_index, offsets_d), SPARSE_KV_STRIDES),
+        mask=dimension_mask,
+        other=0.0,
+    )
+    dot_value = tl.where(dot_rows[None, :] == 0, sparse_value[:, None], 0.0)
+    grad_value = tl.zeros((16, BLOCK_D), tl.float32)
+    entry_start = tl.load(
+        block_offsets_ptr + ptr_offset((batch, sparse_index), BLOCK_OFFSETS_STRIDES)
+    )
+    entry_end = tl.load(
+        block_offsets_ptr + ptr_offset((batch, sparse_index + 1), BLOCK_OFFSETS_STRIDES)
+    )
+
+    for entry_tile in tl.range(entry_start, entry_end, BLOCK_M):
+        entry_offsets = entry_tile + offsets_m_base
+        entry_mask = entry_offsets < entry_end
+        query_positions = tl.load(
+            selected_queries_ptr + ptr_offset((batch, entry_offsets), SELECTED_QUERIES_STRIDES),
+            mask=entry_mask,
+            other=0,
+        )
+        query_mask = entry_mask & (query_positions >= 0) & (query_positions < S)
+        row_mask = head_mask[:, None] & query_mask[None, :]
+        matrix_mask = row_mask[:, :, None] & dimension_mask[None, None, :]
+        tensor_offsets = ptr_offset(
+            (
+                batch,
+                offsets_h[:, None, None],
+                query_positions[None, :, None],
+                offsets_d[None, None, :],
+            ),
+            QUERY_STRIDES,
+        )
+        query = tl.reshape(
+            tl.load(query_ptr + tensor_offsets, mask=matrix_mask, other=0.0),
+            (BLOCK_H * BLOCK_M, BLOCK_D),
+        )
+        output = tl.reshape(
+            tl.load(output_ptr + tensor_offsets, mask=matrix_mask, other=0.0),
+            (BLOCK_H * BLOCK_M, BLOCK_D),
+        )
+        grad_output = tl.reshape(
+            tl.load(grad_output_ptr + tensor_offsets, mask=matrix_mask, other=0.0),
+            (BLOCK_H * BLOCK_M, BLOCK_D),
+        )
+        flat_row_mask = tl.reshape(row_mask, (BLOCK_H * BLOCK_M,))
+        lse = tl.reshape(
+            tl.load(
+                lse_ptr
+                + ptr_offset(
+                    (batch, offsets_h[:, None], query_positions[None, :]),
+                    LSE_STRIDES,
+                ),
+                mask=row_mask,
+                other=0.0,
+            ),
+            (BLOCK_H * BLOCK_M,),
+        )
+        score_tile = tl.dot(query, dot_value, input_precision="tf32x3")
+        scores = tl.sum(score_tile * (dot_rows[None, :] == 0), axis=1) * SCALE
+        grad_probability_tile = tl.dot(grad_output, dot_value, input_precision="tf32x3")
+        grad_probabilities = tl.sum(grad_probability_tile * (dot_rows[None, :] == 0), axis=1)
+        delta = tl.sum(grad_output * output, axis=1)
+        probabilities = tl.where(flat_row_mask, tl.exp(scores - lse), 0.0)
+        grad_scores = probabilities * (grad_probabilities - delta)
+        combined_weights = tl.cat(probabilities, grad_scores * SCALE, dim=0)
+        combined_values = tl.cat(grad_output, query, dim=0)
+        combined_weight_tile = tl.where(
+            dot_rows[:, None] == 0,
+            combined_weights[None, :],
+            0.0,
+        )
+        grad_value = tl.dot(
+            combined_weight_tile.to(query.dtype),
+            combined_values,
+            acc=grad_value,
+            input_precision="tf32x3",
+        )
+
+    tl.store(
+        grad_sparse_kv_ptr
+        + ptr_offset((batch, head_block, sparse_index, offsets_d), GRAD_SPARSE_KV_STRIDES),
+        tl.sum(grad_value * (dot_rows[:, None] == 0), axis=0),
+        mask=dimension_mask,
+    )

--- a/test/test_selected_attention_semantics.py
+++ b/test/test_selected_attention_semantics.py
@@ -21,9 +21,9 @@ BLACKWELL_AVAILABLE = torch.cuda.is_available() and torch.cuda.get_device_capabi
 
 @pytest.fixture
 def shared_kv_blackwell_inputs():
-    """Create a packed shared-KV case that exercises both attention branches."""
+    """Create a batched, partial-head-tile shared-KV case with a float32 sink."""
     torch.manual_seed(123)
-    batch, heads, seq_len, head_dim = 1, 24, 33, 32
+    batch, heads, seq_len, head_dim = 2, 17, 33, 32
     sparse_seq_len, topk = 79, 73
     query = torch.randn(
         batch,
@@ -55,8 +55,10 @@ def shared_kv_blackwell_inputs():
     kv_indices = torch.randint(0, sparse_seq_len, (batch, seq_len, topk), device="cuda")
     kv_indices[:, ::3, -1] = -1
     kv_indices[:, 1::4, 1] = kv_indices[:, 1::4, 0]
-    attention_sink = torch.randn(heads, device="cuda", dtype=torch.bfloat16, requires_grad=True)
-    doc_ids = torch.tensor([[0] * 11 + [1] * 9 + [2] * 13], device="cuda", dtype=torch.int32)
+    attention_sink = torch.randn(heads, device="cuda", dtype=torch.float32, requires_grad=True)
+    doc_ids = torch.tensor(
+        [[0] * 11 + [1] * 9 + [2] * 13], device="cuda", dtype=torch.int32
+    ).expand(batch, -1)
     return query, local_kv, sparse_kv, kv_indices, attention_sink, doc_ids
 
 
@@ -530,13 +532,13 @@ def test_mixed_repeated_and_unique_indices_backends_match():
 
 
 # ---------------------------------------------------------------------------
-# 6. Shared-KV Blackwell forward
+# 6. Shared-KV Blackwell schedules
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.skipif(not BLACKWELL_AVAILABLE, reason="Blackwell GPU required")
 def test_shared_kv_blackwell_matches_eager(shared_kv_blackwell_inputs):
-    """The head-major shared-KV path matches eager forward and gradients."""
+    """The head-major shared-KV path matches eager and has deterministic gradients."""
     query, local_kv, sparse_kv, kv_indices, attention_sink, doc_ids = shared_kv_blackwell_inputs
     differentiable_inputs = query, local_kv, sparse_kv, attention_sink
 
@@ -562,51 +564,170 @@ def test_shared_kv_blackwell_matches_eager(shared_kv_blackwell_inputs):
     )
     grad_output = torch.randn_like(expected)
     expected_grads = torch.autograd.grad(expected, differentiable_inputs, grad_output)
+    actual_grads = torch.autograd.grad(
+        actual, differentiable_inputs, grad_output, retain_graph=True
+    )
+    repeated_grads = torch.autograd.grad(actual, differentiable_inputs, grad_output)
+
+    torch.testing.assert_close(actual, expected, atol=0.04, rtol=0.02)
+    for actual_grad, repeated_grad, expected_grad in zip(
+        actual_grads, repeated_grads, expected_grads, strict=True
+    ):
+        torch.testing.assert_close(actual_grad, expected_grad, atol=0.06, rtol=0.03)
+        torch.testing.assert_close(repeated_grad, actual_grad, atol=0, rtol=0)
+
+
+@pytest.mark.skipif(not BLACKWELL_AVAILABLE, reason="Blackwell GPU required")
+def test_zero_stride_unshared_kv_keeps_per_head_gradients():
+    """Zero-stride shape-H KV inputs retain distinct per-head gradient semantics."""
+    torch.manual_seed(456)
+    batch, heads, seq_len, head_dim = 1, 16, 8, 16
+    sparse_seq_len, topk, window = 6, 2, 3
+    query = torch.randn(
+        batch,
+        heads,
+        seq_len,
+        head_dim,
+        device="cuda",
+        dtype=torch.bfloat16,
+        requires_grad=True,
+    )
+    local_kv = (
+        torch.randn(batch, 1, seq_len, head_dim, device="cuda", dtype=torch.bfloat16)
+        .expand(-1, heads, -1, -1)
+        .detach()
+        .requires_grad_()
+    )
+    sparse_kv = (
+        torch.randn(batch, 1, sparse_seq_len, head_dim, device="cuda", dtype=torch.bfloat16)
+        .expand(-1, heads, -1, -1)
+        .detach()
+        .requires_grad_()
+    )
+    kv_indices = torch.randint(0, sparse_seq_len, (batch, seq_len, topk), device="cuda")
+    attention_sink = torch.randn(heads, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    differentiable_inputs = query, local_kv, sparse_kv, attention_sink
+
+    expected = selected_attention(
+        query,
+        local_kv,
+        sparse_kv,
+        kv_indices,
+        attention_sink,
+        None,
+        window,
+        backend="eager",
+    )
+    actual = selected_attention(
+        query,
+        local_kv,
+        sparse_kv,
+        kv_indices,
+        attention_sink,
+        None,
+        window,
+        backend="triton",
+    )
+    grad_output = torch.randn_like(expected)
+    expected_grads = torch.autograd.grad(expected, differentiable_inputs, grad_output)
     actual_grads = torch.autograd.grad(actual, differentiable_inputs, grad_output)
 
     torch.testing.assert_close(actual, expected, atol=0.04, rtol=0.02)
-    for actual_grad, expected_grad in zip(actual_grads, expected_grads):
+    for actual_grad, expected_grad in zip(actual_grads, expected_grads, strict=True):
         torch.testing.assert_close(actual_grad, expected_grad, atol=0.06, rtol=0.03)
 
 
 @pytest.mark.skipif(not BLACKWELL_AVAILABLE, reason="Blackwell GPU required")
-def test_shared_kv_blackwell_sparse_only():
-    """The full head tile handles the zero-window sparse-only specialization."""
+@pytest.mark.parametrize(
+    "heads,seq_len,head_dim,topk,window",
+    [(128, 17, 128, 16, 0), (16, 160, 64, 0, 136)],
+    ids=["max-head-sparse-only", "min-head-multi-tile-window-only"],
+)
+def test_shared_kv_blackwell_single_branch(heads, seq_len, head_dim, topk, window):
+    """Boundary head tiles handle either attention branch alone."""
     torch.manual_seed(321)
-    batch, heads, seq_len, head_dim = 1, 128, 17, 128
-    sparse_seq_len, topk = 19, 16
-    query = torch.randn(batch, heads, seq_len, head_dim, device="cuda", dtype=torch.bfloat16)
-    local_kv = torch.randn(batch, 1, seq_len, head_dim, device="cuda", dtype=torch.bfloat16)
+    batch = 1
+    sparse_seq_len = 19
+    query = torch.randn(
+        batch,
+        heads,
+        seq_len,
+        head_dim,
+        device="cuda",
+        dtype=torch.bfloat16,
+        requires_grad=True,
+    )
+    local_kv = torch.randn(
+        batch, 1, seq_len, head_dim, device="cuda", dtype=torch.bfloat16, requires_grad=True
+    )
     sparse_kv = torch.randn(
-        batch, 1, sparse_seq_len, head_dim, device="cuda", dtype=torch.bfloat16
+        batch,
+        1,
+        sparse_seq_len,
+        head_dim,
+        device="cuda",
+        dtype=torch.bfloat16,
+        requires_grad=True,
     )
     kv_indices = torch.randint(0, sparse_seq_len, (batch, seq_len, topk), device="cuda")
-    kv_indices[:, ::3, -1] = -1
-    attention_sink = torch.randn(heads, device="cuda", dtype=torch.bfloat16)
+    if topk:
+        kv_indices[:, ::3, -1] = -1
+        kv_indices[:, 1::4, 1] = kv_indices[:, 1::4, 0]
+    attention_sink = torch.randn(heads, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    differentiable_inputs = query, local_kv, sparse_kv, attention_sink
+    high_precision_inputs = tuple(
+        tensor.detach().double().requires_grad_(True) for tensor in differentiable_inputs
+    )
 
-    with torch.inference_mode():
-        expected = selected_attention(
-            query,
-            local_kv,
-            sparse_kv,
-            kv_indices,
-            attention_sink,
-            None,
-            0,
-            backend="eager",
-        )
-        actual = selected_attention(
-            query,
-            local_kv,
-            sparse_kv,
-            kv_indices,
-            attention_sink,
-            None,
-            0,
-            backend="triton",
-        )
+    high_precision_expected = selected_attention(
+        high_precision_inputs[0],
+        high_precision_inputs[1],
+        high_precision_inputs[2],
+        kv_indices,
+        high_precision_inputs[3],
+        None,
+        window,
+        backend="eager",
+    )
+    expected = selected_attention(
+        query,
+        local_kv,
+        sparse_kv,
+        kv_indices,
+        attention_sink,
+        None,
+        window,
+        backend="eager",
+    )
+    actual = selected_attention(
+        query,
+        local_kv,
+        sparse_kv,
+        kv_indices,
+        attention_sink,
+        None,
+        window,
+        backend="triton",
+    )
+    grad_output = torch.randn_like(expected)
+    high_precision_grads = torch.autograd.grad(
+        high_precision_expected, high_precision_inputs, grad_output.double()
+    )
+    expected_grads = torch.autograd.grad(expected, differentiable_inputs, grad_output)
+    actual_grads = torch.autograd.grad(actual, differentiable_inputs, grad_output)
 
     torch.testing.assert_close(actual, expected, atol=0.04, rtol=0.02)
+    for actual_grad, expected_grad, high_precision_grad in zip(
+        actual_grads, expected_grads, high_precision_grads, strict=True
+    ):
+        assert_matches_low_precision_eager(
+            actual_grad,
+            expected_grad,
+            high_precision_grad,
+            reduction_sizes=(head_dim, topk + window, heads * seq_len),
+        )
+    if topk == 0:
+        assert actual_grads[2].count_nonzero().item() == 0
 
 
 @pytest.mark.skipif(not BLACKWELL_AVAILABLE, reason="Blackwell GPU required")
@@ -684,8 +805,9 @@ def test_shared_kv_blackwell_dsv4_forward():
 
 @pytest.mark.skipif(not BLACKWELL_AVAILABLE, reason="Blackwell GPU required")
 def test_shared_kv_blackwell_torch_compile_fullgraph(shared_kv_blackwell_inputs):
-    """The shared-KV Triton path compiles without graph breaks."""
+    """The shared-KV Triton forward and backward compile without graph breaks."""
     query, local_kv, sparse_kv, kv_indices, attention_sink, doc_ids = shared_kv_blackwell_inputs
+    differentiable_inputs = query, local_kv, sparse_kv, attention_sink
 
     def fn(query, local_kv, sparse_kv, kv_indices, attention_sink, doc_ids):
         return selected_attention(
@@ -700,11 +822,27 @@ def test_shared_kv_blackwell_torch_compile_fullgraph(shared_kv_blackwell_inputs)
         )
 
     compiled_fn = torch.compile(fn, fullgraph=True)
-    with torch.inference_mode():
-        expected = fn(query, local_kv, sparse_kv, kv_indices, attention_sink, doc_ids)
-        actual = compiled_fn(query, local_kv, sparse_kv, kv_indices, attention_sink, doc_ids)
+    compiled_inputs = tuple(
+        tensor.detach().clone().requires_grad_(True) for tensor in differentiable_inputs
+    )
+    compiled_query, compiled_local_kv, compiled_sparse_kv, compiled_sink = compiled_inputs
+    expected = fn(query, local_kv, sparse_kv, kv_indices, attention_sink, doc_ids)
+    actual = compiled_fn(
+        compiled_query,
+        compiled_local_kv,
+        compiled_sparse_kv,
+        kv_indices,
+        compiled_sink,
+        doc_ids,
+    )
+    grad_output = torch.randn_like(expected)
+    expected_grads = torch.autograd.grad(expected, differentiable_inputs, grad_output)
+    actual_grads = torch.autograd.grad(actual, compiled_inputs, grad_output)
 
     torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+    for actual_grad, expected_grad in zip(actual_grads[:-1], expected_grads[:-1], strict=True):
+        torch.testing.assert_close(actual_grad, expected_grad, atol=0, rtol=0)
+    torch.testing.assert_close(actual_grads[-1], expected_grads[-1], atol=1e-6, rtol=1e-6)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for compile test")


### PR DESCRIPTION
Optimize shared-KV selected-attention backward

Human Note

Agent note
The Blackwell shared-KV forward schedule amortizes KV loads across query heads, while backward
continued to launch query- and sparse-KV-gradient work independently for every head. That reread
identical KV values and created one sparse-gradient CTA per head.

This adds a head-major query-gradient schedule and a head-tiled sparse-KV-gradient schedule for
explicitly shared BF16 inputs on Blackwell. Query programs own their query-gradient and sink-partial
slots. Sparse programs write unique head-tile partials into the expanded gradient workspace, then
reuse autograd's existing expanded-head reduction. The optimized shared path therefore has no
atomics; its query, local-KV, sparse-KV, and sink gradients were bitwise identical across ten repeated
backward calls with deterministic algorithms enabled. The generic fallback retains its pre-existing
sink atomic and is outside that determinism claim.

The public API remains the owner of whether KV is semantically shared. Carrying that bit through the
private autograd function prevents a shape-H, zero-stride leaf from taking a schedule whose partial
sparse gradients require ExpandBackward. Common tensor and device eligibility checks are shared by
forward and backward, while head-dimension policy remains local to each schedule.

Steady-state GB300 results use BF16 B=8, H=32, S=4096, D=128, sparse length 1024, and window 512:

| Route | Before | This PR | Change |
|---|---:|---:|---:|
| shared backward, top-k 16 | 8.140 ms | 6.745 ms | 17.1% lower |
| shared backward, top-k 128 | 32.384 ms | 24.280 ms | 25.0% lower |
| shared forward, top-k 16 | 1.053 ms | 1.053 ms | unchanged |
| unshared backward, top-k 16 | 8.234 ms | 8.225 ms | unchanged |

The default shared improvement comes from dQ falling from 2.196 to 1.245 ms and sparse dKV from
3.705 to 3.192 ms; local dKV remains on the existing 2.213 ms TMA schedule. Collapsing all heads into
one sparse-dKV CTA and replacing local-dKV TMA with pointer loads were both slower and were removed.

Test Plan:

```bash
env PYTHONPATH="$PWD" gpu-run 0 -- ~/.venvs/dev/bin/pytest \
  test/test_selected_attention_matches_csa_reference.py \
  test/test_selected_attention_reference.py \
  test/test_selected_attention_semantics.py \
  -q --tb=short --durations=15

env PYTHONPATH="$PWD" gpu-run 0 -- ~/.venvs/dev/bin/python \
  benchmarks/sparse/selected_attention_benchmark.py --backend triton --warmup 100 --rep 500

env PYTHONPATH="$PWD" gpu-run 0 -- ~/.venvs/dev/bin/python \
  benchmarks/sparse/selected_attention_benchmark.py --backend triton --topk 128 \
  --warmup 100 --rep 500

env PYTHONPATH="$PWD" gpu-run 0 -- ~/.venvs/dev/bin/python \
  benchmarks/sparse/selected_attention_benchmark.py --backend triton --no-share-kv \
  --warmup 100 --rep 500

prek run --files \
  attn_gym/sparse/selected_attention/impl/triton/__init__.py \
  attn_gym/sparse/selected_attention/impl/triton/backward.py \
  attn_gym/sparse/selected_attention/impl/triton/forward.py \
  attn_gym/sparse/selected_attention/impl/triton/primitives.py \
  attn_gym/sparse/selected_attention/impl/triton/shared_backward.py \
  test/test_selected_attention_semantics.py
```
