### PR TITLE
Accelerate shared-KV selected-attention backward

### DIFF
--- a/attn_gym/sparse/selected_attention/api.py
+++ b/attn_gym/sparse/selected_attention/api.py
@@ -185,7 +185,9 @@ def selected_attention(
 
         sliding_window_size: Integer, size of sliding window
 
-        backend: one of eager, triton, or cute, controls which backend executes this code
+        backend: one of eager, triton, or cute, controls which backend executes this code.
+            Triton shared-KV backward uses nondeterministic atomic accumulation unless deterministic
+            algorithms are enabled with torch.use_deterministic_algorithms.
 
         mode: Currently only chunked is supported; auto defaults to chunked
     Returns:

--- a/attn_gym/sparse/selected_attention/impl/triton/__init__.py
+++ b/attn_gym/sparse/selected_attention/impl/triton/__init__.py
@@ -21,6 +21,10 @@ class _SelectedAttentionFunction(torch.autograd.Function):
         sliding_window_size: int,
         share_kv: bool,
     ) -> torch.Tensor:
+        if share_kv:
+            sparse_kv = sparse_kv.expand(-1, query.shape[1], -1, -1)
+            local_kv = local_kv.expand(-1, query.shape[1], -1, -1)
+
         output, lse = _launch_forward(
             query,
             sparse_kv,
@@ -30,6 +34,7 @@ class _SelectedAttentionFunction(torch.autograd.Function):
             doc_ids,
             sliding_window_size,
         )
+        # Keep the output-owned fallback available if deterministic mode is enabled before backward.
         selected_queries, block_offsets = _build_index_query_map(kv_indices, sparse_kv.shape[2])
         ctx.save_for_backward(
             query,
@@ -98,7 +103,7 @@ def selected_attention(
         attention_sink: (heads,) — learned per-head sink weight.
         doc_ids: (batch, seq_len) or None — document IDs for packing isolation.
         sliding_window_size: size of the causal sliding window.
-        share_kv: if True, expand single-head KV and sum its per-head gradients.
+        share_kv: if True, broadcast single-head KV and return single-head gradients.
 
     Returns:
         Attention output with same shape as query.
@@ -107,11 +112,6 @@ def selected_attention(
 
     if query.device.type != "cuda":
         raise ValueError("The Triton selected attention backend requires CUDA tensors.")
-
-    # Expand shared KV heads (stride-zero broadcast; no memory duplication)
-    if share_kv:
-        local_kv = local_kv.expand(-1, heads, -1, -1)
-        sparse_kv = sparse_kv.expand(-1, heads, -1, -1)
 
     query = query.contiguous()
     kv_indices = kv_indices.contiguous()
@@ -137,6 +137,10 @@ def selected_attention(
             sliding_window_size,
             share_kv,
         )
+
+    if share_kv:
+        local_kv = local_kv.expand(-1, heads, -1, -1)
+        sparse_kv = sparse_kv.expand(-1, heads, -1, -1)
     return _launch_forward(
         query, sparse_kv, local_kv, kv_indices, attention_sink, doc_ids, sliding_window_size
     )[0]

--- a/attn_gym/sparse/selected_attention/impl/triton/backward.py
+++ b/attn_gym/sparse/selected_attention/impl/triton/backward.py
@@ -19,6 +19,7 @@ from .primitives import (
 from .shared_backward import (
     _selected_attention_bwd_dq_shared,
     _selected_attention_bwd_dsparse_kv_shared,
+    _selected_attention_bwd_dsparse_kv_shared_atomic,
 )
 
 
@@ -706,11 +707,59 @@ def _launch_backward(
             num_stages=3,
         )
 
-    if topk > 0:
+    if topk == 0:
+        kv_heads = 1 if share_kv else heads
+        grad_sparse_kv = torch.zeros(
+            batch,
+            kv_heads,
+            sparse_seq_len,
+            head_dim,
+            device=sparse_kv.device,
+            dtype=sparse_kv.dtype,
+        )
+    elif use_shared_schedule and not torch.are_deterministic_algorithms_enabled():
+        grad_sparse_kv_fp32 = torch.zeros(
+            batch,
+            1,
+            sparse_seq_len,
+            head_dim,
+            device=sparse_kv.device,
+            dtype=torch.float32,
+        )
+        sparse_grid = lambda meta: (
+            seq_len,
+            batch,
+            triton.cdiv(heads, meta["BLOCK_H"]) * triton.cdiv(topk, meta["BLOCK_K"]),
+        )
+        _selected_attention_bwd_dsparse_kv_shared_atomic[sparse_grid](
+            query,
+            sparse_kv,
+            kv_indices,
+            output,
+            grad_output,
+            lse,
+            grad_sparse_kv_fp32,
+            QUERY_STRIDES=query.stride(),
+            SPARSE_KV_STRIDES=sparse_kv.stride(),
+            KV_INDICES_STRIDES=kv_indices.stride(),
+            LSE_STRIDES=lse.stride(),
+            GRAD_SPARSE_KV_STRIDES=grad_sparse_kv_fp32.stride(),
+            B=batch,
+            H=heads,
+            S=seq_len,
+            D=head_dim,
+            SPARSE_SEQ_LEN=sparse_seq_len,
+            TOPK=topk,
+            SCALE=scale,
+            BLOCK_D=block_d,
+        )
+        grad_sparse_kv = grad_sparse_kv_fp32.to(sparse_kv.dtype)
+    else:
         if use_shared_schedule:
-            # ExpandBackward sums every head slot, including slots no tile writes.
-            grad_sparse_kv = torch.zeros(
-                sparse_kv.shape, device=sparse_kv.device, dtype=sparse_kv.dtype
+            grad_sparse_kv_partials = torch.zeros(
+                sparse_kv.shape,
+                device=sparse_kv.device,
+                dtype=sparse_kv.dtype,
             )
             sparse_kernel = _selected_attention_bwd_dsparse_kv_shared
             sparse_grid = lambda meta: (
@@ -719,8 +768,10 @@ def _launch_backward(
                 triton.cdiv(heads, meta["BLOCK_H"]),
             )
         else:
-            grad_sparse_kv = torch.empty(
-                sparse_kv.shape, device=sparse_kv.device, dtype=sparse_kv.dtype
+            grad_sparse_kv_partials = torch.empty(
+                sparse_kv.shape,
+                device=sparse_kv.device,
+                dtype=sparse_kv.dtype,
             )
             sparse_kernel = _selected_attention_bwd_dsparse_kv
             sparse_grid = (sparse_seq_len, batch * heads)
@@ -733,13 +784,13 @@ def _launch_backward(
             output,
             grad_output,
             lse,
-            grad_sparse_kv,
+            grad_sparse_kv_partials,
             QUERY_STRIDES=query.stride(),
             SPARSE_KV_STRIDES=sparse_kv.stride(),
             SELECTED_QUERIES_STRIDES=selected_queries.stride(),
             BLOCK_OFFSETS_STRIDES=block_offsets.stride(),
             LSE_STRIDES=lse.stride(),
-            GRAD_SPARSE_KV_STRIDES=grad_sparse_kv.stride(),
+            GRAD_SPARSE_KV_STRIDES=grad_sparse_kv_partials.stride(),
             H=heads,
             S=seq_len,
             D=head_dim,
@@ -748,9 +799,13 @@ def _launch_backward(
             SCALE=scale,
             BLOCK_D=block_d,
         )
-    else:
-        grad_sparse_kv = torch.zeros(
-            sparse_kv.shape, device=sparse_kv.device, dtype=sparse_kv.dtype
+        grad_sparse_kv = (
+            grad_sparse_kv_partials.sum(dim=1, keepdim=True)
+            if share_kv
+            else grad_sparse_kv_partials
         )
+
+    if share_kv:
+        grad_local_kv = grad_local_kv.sum(dim=1, keepdim=True)
 
     return grad_query, grad_sparse_kv, grad_local_kv, grad_sink_fp32.to(attention_sink.dtype)

--- a/attn_gym/sparse/selected_attention/impl/triton/shared_backward.py
+++ b/attn_gym/sparse/selected_attention/impl/triton/shared_backward.py
@@ -1,8 +1,8 @@
 """Blackwell shared-KV schedules for selected-attention backward.
 
-Each dQ program owns its query and sink-partial outputs. Sparse dKV programs write one
-partial per head tile into the expanded head dimension, which autograd subsequently sums.
-This keeps repeated backward calls from one forward atomic-free and bitwise repeatable.
+The default sparse-dKV schedule forms query-owned top-k-by-dimension gradient tiles and
+atomically scatters them into one FP32 shared-KV gradient. Deterministic mode instead uses
+an inverted query map so each sparse-KV program exclusively owns its output.
 """
 
 import triton
@@ -189,6 +189,137 @@ def _selected_attention_bwd_dq_shared(
         + ptr_offset((batch, offsets_h, sequence), GRAD_SINK_PARTIALS_STRIDES),
         sink_gradient,
         mask=head_mask,
+    )
+
+
+# Atomic configs accumulate into the same FP32 output, so clear it between tuning trials.
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {"BLOCK_H": block_h, "BLOCK_K": block_k},
+            num_warps=num_warps,
+            num_stages=1,
+        )
+        for block_h, block_k, num_warps in (
+            (16, 16, 4),
+            (32, 16, 4),
+            (16, 32, 4),
+            (32, 32, 8),
+            (16, 64, 8),
+            (32, 64, 8),
+        )
+    ],
+    key=["B", "H", "S", "D", "SPARSE_SEQ_LEN", "TOPK"],
+    reset_to_zero=["grad_sparse_kv_ptr"],
+    cache_results=True,
+)
+@triton.jit
+def _selected_attention_bwd_dsparse_kv_shared_atomic(
+    query_ptr,
+    sparse_kv_ptr,
+    kv_indices_ptr,
+    output_ptr,
+    grad_output_ptr,
+    lse_ptr,
+    grad_sparse_kv_ptr,
+    QUERY_STRIDES: tl.constexpr,
+    SPARSE_KV_STRIDES: tl.constexpr,
+    KV_INDICES_STRIDES: tl.constexpr,
+    LSE_STRIDES: tl.constexpr,
+    GRAD_SPARSE_KV_STRIDES: tl.constexpr,
+    B: tl.constexpr,
+    H: tl.constexpr,
+    S: tl.constexpr,
+    D: tl.constexpr,
+    SPARSE_SEQ_LEN: tl.constexpr,
+    TOPK: tl.constexpr,
+    SCALE: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    """Atomically scatter one query's sparse-KV gradient tile into shared dKV."""
+    query_position = tl.program_id(0)
+    batch = tl.program_id(1)
+    tile = tl.program_id(2)
+    num_selected_tiles = tl.cdiv(TOPK, BLOCK_K)
+    head_block = tile // num_selected_tiles
+    selected_block = tile % num_selected_tiles
+
+    offsets_h = head_block * BLOCK_H + tl.arange(0, BLOCK_H)
+    offsets_k = selected_block * BLOCK_K + tl.arange(0, BLOCK_K)
+    offsets_d = tl.arange(0, BLOCK_D)
+    head_mask = offsets_h < H
+    selected_mask = offsets_k < TOPK
+    dimension_mask = offsets_d < D
+
+    selected_indices = tl.load(
+        kv_indices_ptr + ptr_offset((batch, query_position, offsets_k), KV_INDICES_STRIDES),
+        mask=selected_mask,
+        other=-1,
+    )
+    selected_valid = selected_mask & (selected_indices >= 0) & (selected_indices < SPARSE_SEQ_LEN)
+    selected_indices = tl.where(selected_valid, selected_indices, 0)
+
+    head_dimension_mask = head_mask[:, None] & dimension_mask[None, :]
+    query_offsets = ptr_offset(
+        (batch, offsets_h[:, None], query_position, offsets_d[None, :]),
+        QUERY_STRIDES,
+    )
+    query = tl.load(query_ptr + query_offsets, mask=head_dimension_mask, other=0.0)
+    output = tl.load(output_ptr + query_offsets, mask=head_dimension_mask, other=0.0)
+    grad_output = tl.load(
+        grad_output_ptr + query_offsets,
+        mask=head_dimension_mask,
+        other=0.0,
+    )
+    lse = tl.load(
+        lse_ptr + ptr_offset((batch, offsets_h, query_position), LSE_STRIDES),
+        mask=head_mask,
+        other=0.0,
+    )
+    sparse_values = tl.load(
+        sparse_kv_ptr
+        + ptr_offset(
+            (batch, 0, selected_indices[:, None], offsets_d[None, :]),
+            SPARSE_KV_STRIDES,
+        ),
+        mask=selected_valid[:, None] & dimension_mask[None, :],
+        other=0.0,
+    )
+
+    scores = tl.dot(query, tl.trans(sparse_values), input_precision="tf32x3") * SCALE
+    probabilities = tl.where(
+        head_mask[:, None] & selected_valid[None, :],
+        tl.exp(scores - lse[:, None]),
+        0.0,
+    )
+    grad_probabilities = tl.dot(
+        grad_output,
+        tl.trans(sparse_values),
+        input_precision="tf32x3",
+    )
+    delta = tl.sum(grad_output * output, axis=1)
+    grad_scores = probabilities * (grad_probabilities - delta[:, None])
+    grad_values = tl.dot(
+        tl.trans(probabilities.to(grad_output.dtype)),
+        grad_output,
+        input_precision="tf32x3",
+    )
+    grad_values += tl.dot(
+        tl.trans((grad_scores * SCALE).to(query.dtype)),
+        query,
+        input_precision="tf32x3",
+    )
+
+    tl.atomic_add(
+        grad_sparse_kv_ptr
+        + ptr_offset(
+            (batch, 0, selected_indices[:, None], offsets_d[None, :]),
+            GRAD_SPARSE_KV_STRIDES,
+        ),
+        grad_values,
+        mask=selected_valid[:, None] & dimension_mask[None, :],
     )
 
 

--- a/test/test_selected_attention_semantics.py
+++ b/test/test_selected_attention_semantics.py
@@ -538,10 +538,24 @@ def test_mixed_repeated_and_unique_indices_backends_match():
 
 @pytest.mark.skipif(not BLACKWELL_AVAILABLE, reason="Blackwell GPU required")
 def test_shared_kv_blackwell_matches_eager(shared_kv_blackwell_inputs):
-    """The head-major shared-KV path matches eager and has deterministic gradients."""
+    """The default atomic shared-KV path matches eager forward and gradients."""
     query, local_kv, sparse_kv, kv_indices, attention_sink, doc_ids = shared_kv_blackwell_inputs
+    kv_indices = kv_indices.to(torch.int32)
     differentiable_inputs = query, local_kv, sparse_kv, attention_sink
+    high_precision_inputs = tuple(
+        tensor.detach().double().requires_grad_(True) for tensor in differentiable_inputs
+    )
 
+    high_precision_expected = selected_attention(
+        high_precision_inputs[0],
+        high_precision_inputs[1],
+        high_precision_inputs[2],
+        kv_indices,
+        high_precision_inputs[3],
+        doc_ids,
+        19,
+        backend="eager",
+    )
     expected = selected_attention(
         query,
         local_kv,
@@ -563,13 +577,72 @@ def test_shared_kv_blackwell_matches_eager(shared_kv_blackwell_inputs):
         backend="triton",
     )
     grad_output = torch.randn_like(expected)
-    expected_grads = torch.autograd.grad(expected, differentiable_inputs, grad_output)
-    actual_grads = torch.autograd.grad(
-        actual, differentiable_inputs, grad_output, retain_graph=True
+    high_precision_grads = torch.autograd.grad(
+        high_precision_expected,
+        high_precision_inputs,
+        grad_output.double(),
     )
-    repeated_grads = torch.autograd.grad(actual, differentiable_inputs, grad_output)
+    expected_grads = torch.autograd.grad(expected, differentiable_inputs, grad_output)
+    actual_grads = torch.autograd.grad(actual, differentiable_inputs, grad_output)
 
-    torch.testing.assert_close(actual, expected, atol=0.04, rtol=0.02)
+    assert_matches_low_precision_eager(
+        actual,
+        expected,
+        high_precision_expected,
+        reduction_sizes=(query.shape[-1], kv_indices.shape[-1] + 19),
+    )
+    for actual_grad, expected_grad in zip(actual_grads, expected_grads, strict=True):
+        torch.testing.assert_close(actual_grad, expected_grad, atol=0.06, rtol=0.03)
+    assert_matches_low_precision_eager(
+        actual_grads[2],
+        expected_grads[2],
+        high_precision_grads[2],
+        reduction_sizes=(
+            query.shape[-1],
+            kv_indices.shape[-1] + 19,
+            query.shape[1] * query.shape[2],
+        ),
+    )
+
+
+@pytest.mark.skipif(not BLACKWELL_AVAILABLE, reason="Blackwell GPU required")
+def test_shared_kv_blackwell_deterministic_backward(shared_kv_blackwell_inputs):
+    """Deterministic mode retains the output-owned shared-KV backward schedule."""
+    query, local_kv, sparse_kv, kv_indices, attention_sink, doc_ids = shared_kv_blackwell_inputs
+    differentiable_inputs = query, local_kv, sparse_kv, attention_sink
+    was_enabled = torch.are_deterministic_algorithms_enabled()
+    was_warn_only = torch.is_deterministic_algorithms_warn_only_enabled()
+    torch.use_deterministic_algorithms(True)
+    try:
+        expected = selected_attention(
+            query,
+            local_kv,
+            sparse_kv,
+            kv_indices,
+            attention_sink,
+            doc_ids,
+            19,
+            backend="eager",
+        )
+        actual = selected_attention(
+            query,
+            local_kv,
+            sparse_kv,
+            kv_indices,
+            attention_sink,
+            doc_ids,
+            19,
+            backend="triton",
+        )
+        grad_output = torch.randn_like(expected)
+        expected_grads = torch.autograd.grad(expected, differentiable_inputs, grad_output)
+        actual_grads = torch.autograd.grad(
+            actual, differentiable_inputs, grad_output, retain_graph=True
+        )
+        repeated_grads = torch.autograd.grad(actual, differentiable_inputs, grad_output)
+    finally:
+        torch.use_deterministic_algorithms(was_enabled, warn_only=was_warn_only)
+
     for actual_grad, repeated_grad, expected_grad in zip(
         actual_grads, repeated_grads, expected_grads, strict=True
     ):
@@ -840,9 +913,11 @@ def test_shared_kv_blackwell_torch_compile_fullgraph(shared_kv_blackwell_inputs)
     actual_grads = torch.autograd.grad(actual, compiled_inputs, grad_output)
 
     torch.testing.assert_close(actual, expected, atol=0, rtol=0)
-    for actual_grad, expected_grad in zip(actual_grads[:-1], expected_grads[:-1], strict=True):
+    for actual_grad, expected_grad in zip(actual_grads[:2], expected_grads[:2], strict=True):
         torch.testing.assert_close(actual_grad, expected_grad, atol=0, rtol=0)
-    torch.testing.assert_close(actual_grads[-1], expected_grads[-1], atol=1e-6, rtol=1e-6)
+    # Atomic sparse-dKV accumulation order may differ across compiled and eager launches.
+    torch.testing.assert_close(actual_grads[2], expected_grads[2], atol=0.06, rtol=0.03)
+    torch.testing.assert_close(actual_grads[3], expected_grads[3], atol=1e-6, rtol=1e-6)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for compile test")


### PR DESCRIPTION
Human Note

Agent note
The output-owned shared sparse-dKV schedule inverts the selection map and then revisits every
selecting query for each sparse value and head tile. That avoids atomics, but its work and temporary
expanded gradient scale poorly with top-k even though all query heads share one KV head.

Use a query-owned Triton schedule for the default Blackwell BF16 path. Each program forms a
head-by-selected-index gradient tile and atomically scatters it into a one-head FP32 sparse gradient,
which is downcast only after accumulation. Keep shared-head broadcasting and gradient reduction
inside the custom autograd boundary so the launcher returns gradients with the original one-head
shape instead of relying on `ExpandBackward` as implementation machinery. Invalid and repeated
indices remain masked or accumulated correctly, and the unshared schedule is unchanged. The sparse
gradient workspace for the benchmark shape falls from 64 MiB of expanded BF16 partials to roughly
6 MiB for the one-head FP32 accumulator and BF16 result.

Atomic accumulation is intentionally nondeterministic. When
`torch.use_deterministic_algorithms(True)` is enabled, dispatch retains the existing inverse-CSR,
output-owned schedule and produces bitwise-repeatable gradients. The inverse map is still built in
forward so deterministic mode may be enabled between forward and backward without adding another
public mode or narrowing that behavior.

Matched GB300 measurements use B=8, H=32, S=4096, D=128, sparse length 1024, BF16, window 512,
100 warmups, and 500 repetitions:

| top-k | `origin/main` backward | PR backward | speedup | latency reduction |
| ---: | ---: | ---: | ---: | ---: |
| 16 | 6.745 ms | 3.794 ms | 1.78x | 43.8% |
| 128 | 24.278 ms | 5.468 ms | 4.44x | 77.5% |

Forward is unchanged at 1.053/1.283 ms for top-k 16/128. The deterministic top-k 16 route remains
6.911 ms in matched baseline and candidate runs, and the unshared top-k 16 route remains 8.225 ms.

Test Plan:

```bash
gpu-run 0 -- env PYTHONPATH="$PWD" ~/.venvs/dev/bin/pytest \
  test/test_selected_attention_matches_csa_reference.py \
  test/test_selected_attention_reference.py \
  test/test_selected_attention_semantics.py \
  -q --tb=short --durations=15

prek run --files \
  attn_gym/sparse/selected_attention/api.py \
  attn_gym/sparse/selected_attention/impl/triton/__init__.py \
  attn_gym/sparse/selected_attention/impl/triton/backward.py \
  attn_gym/sparse/selected_attention/impl/triton/shared_backward.py \
  test/test_selected_attention_semantics.py

~/.venvs/dev/bin/python -m compileall -q \
  attn_gym/sparse/selected_attention test/test_selected_attention_semantics.py

git diff --check

gpu-run 0 -- env PYTHONPATH="$PWD" ~/.venvs/dev/bin/python \
  benchmarks/sparse/selected_attention_benchmark.py \
  --backend triton --warmup 100 --rep 500

gpu-run 0 -- env PYTHONPATH="$PWD" ~/.venvs/dev/bin/python \
  benchmarks/sparse/selected_attention_benchmark.py \
  --backend triton --topk 128 --warmup 100 --rep 500
```
