### PR TITLE
Add persistent CuTeDSL compile cache

### DIFF
--- a/attn_gym/_backends/cute/__init__.py
+++ b/attn_gym/_backends/cute/__init__.py
@@ -1,0 +1,6 @@
+"""Infrastructure shared by CuTeDSL attention backends."""
+
+from .cache import jit_cache
+from .utils import compile_tvm_ffi
+
+__all__ = ["compile_tvm_ffi", "jit_cache"]

--- a/attn_gym/_backends/cute/_key.py
+++ b/attn_gym/_backends/cute/_key.py
@@ -1,0 +1,190 @@
+"""Deterministic source and invocation keys for the CuTeDSL cache."""
+
+from __future__ import annotations
+
+import dataclasses
+import enum
+import functools
+import hashlib
+import os
+import pickle
+import platform
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from .target import CompileTarget
+
+CACHE_FORMAT_VERSION = 4
+
+
+def _hash_file(hasher: Any, label: str, source: Path) -> None:
+    content = source.read_bytes()
+    encoded_label = label.encode()
+    hasher.update(len(encoded_label).to_bytes(8, "little"))
+    hasher.update(encoded_label)
+    hasher.update(len(content).to_bytes(8, "little"))
+    hasher.update(content)
+
+
+def _hash_source_tree(hasher: Any, root: Path) -> None:
+    for source in sorted(root.rglob("*.py")):
+        if source.is_file():
+            _hash_file(hasher, source.relative_to(root).as_posix(), source)
+
+
+@functools.cache
+def source_fingerprint(
+    fn: Callable[..., Any],
+    extra_sources: tuple[str, ...] = (),
+) -> str:
+    """Fingerprint the compile function, CuTe sources, and host/runtime ABI."""
+    import cutlass
+    import torch
+    import tvm_ffi
+
+    hasher = hashlib.sha256()
+    stamps = (
+        CACHE_FORMAT_VERSION,
+        sys.implementation.cache_tag,
+        platform.system(),
+        platform.machine(),
+        cutlass.__version__,
+        tvm_ffi.__version__,
+        torch.__version__,
+        torch.version.cuda,
+    )
+    hasher.update(pickle.dumps(stamps, protocol=pickle.HIGHEST_PROTOCOL))
+
+    module = sys.modules.get(fn.__module__)
+    module_file = getattr(module, "__file__", None)
+    if module_file is not None:
+        source = Path(module_file).resolve()
+        if source.suffix == ".py" and source.is_file():
+            _hash_file(hasher, fn.__module__, source)
+
+    package_root = Path(__file__).resolve().parents[2]
+    for source in sorted(package_root.rglob("*.py")):
+        relative_path = source.relative_to(package_root)
+        if "cute" in relative_path.parts:
+            _hash_file(hasher, relative_path.as_posix(), source)
+
+    for extra_source in extra_sources:
+        path = Path(extra_source).expanduser().resolve()
+        if path.is_dir():
+            _hash_source_tree(hasher, path)
+        elif path.is_file():
+            _hash_file(hasher, str(path), path)
+        else:
+            raise FileNotFoundError(f"extra CuTeDSL cache source does not exist: {path}")
+
+    cutlass_root = Path(cutlass.__file__).resolve().parent
+    for relative_path in (
+        "__init__.py",
+        "base_dsl/compiler.py",
+        "base_dsl/dsl.py",
+        "cutlass_dsl/tvm_ffi_provider.py",
+        "cute/runtime.py",
+    ):
+        source = cutlass_root / relative_path
+        if source.is_file():
+            _hash_file(hasher, f"cutlass/{relative_path}", source)
+
+    codegen_environment = tuple(
+        (name, os.getenv(name))
+        for name in (
+            "CUTE_DSL_ARCH",
+            "CUTE_DSL_COMPILER_OPT",
+            "CUTE_DSL_ENABLE_ASSERTIONS",
+            "CUTE_DSL_ENABLE_TVM_FFI",
+            "CUTE_DSL_LIBS",
+            "CUTE_DSL_LINEINFO",
+        )
+    )
+    hasher.update(pickle.dumps(codegen_environment, protocol=pickle.HIGHEST_PROTOCOL))
+    return hasher.hexdigest()
+
+
+def _is_named_tuple(item: Any) -> bool:
+    fields = getattr(type(item), "_fields", None)
+    return isinstance(item, tuple) and isinstance(fields, tuple)
+
+
+def _pickle_sort_key(item: Any) -> bytes:
+    return pickle.dumps(item, protocol=pickle.HIGHEST_PROTOCOL)
+
+
+def _canonicalize(item: Any) -> Any:
+    custom_key = getattr(item, "__attention_gym_cache_key__", None)
+    if custom_key is not None:
+        value = custom_key() if callable(custom_key) else custom_key
+        return (
+            "custom",
+            type(item).__module__,
+            type(item).__qualname__,
+            _canonicalize(value),
+        )
+    if _is_named_tuple(item):
+        return (
+            "named_tuple",
+            type(item).__module__,
+            type(item).__qualname__,
+            tuple((name, _canonicalize(getattr(item, name))) for name in type(item)._fields),
+        )
+    if dataclasses.is_dataclass(item) and not isinstance(item, type):
+        return (
+            "dataclass",
+            type(item).__module__,
+            type(item).__qualname__,
+            tuple(
+                (field.name, _canonicalize(getattr(item, field.name)))
+                for field in dataclasses.fields(item)
+            ),
+        )
+    if isinstance(item, enum.Enum):
+        return ("enum", type(item).__module__, type(item).__qualname__, item.name)
+    if isinstance(item, type):
+        return ("type", item.__module__, item.__qualname__)
+    if isinstance(item, Path):
+        return ("path", str(item))
+    if isinstance(item, tuple):
+        return ("tuple", tuple(_canonicalize(value) for value in item))
+    if isinstance(item, list):
+        return ("list", tuple(_canonicalize(value) for value in item))
+    if isinstance(item, dict):
+        entries = [(_canonicalize(key), _canonicalize(value)) for key, value in item.items()]
+        return ("dict", tuple(sorted(entries, key=lambda entry: _pickle_sort_key(entry[0]))))
+    if isinstance(item, set):
+        values = [_canonicalize(value) for value in item]
+        return ("set", tuple(sorted(values, key=_pickle_sort_key)))
+    if isinstance(item, frozenset):
+        values = [_canonicalize(value) for value in item]
+        return ("frozenset", tuple(sorted(values, key=_pickle_sort_key)))
+    try:
+        pickle.dumps(item, protocol=pickle.HIGHEST_PROTOCOL)
+    except (pickle.PickleError, TypeError) as error:
+        raise TypeError(
+            f"CuTeDSL cache argument of type {type(item).__qualname__} has no stable key; "
+            "pass static pickleable values or define __attention_gym_cache_key__"
+        ) from error
+    return item
+
+
+def make_key(
+    fn: Callable[..., Any],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    target: CompileTarget,
+) -> str:
+    """Hash one compile invocation and its complete target contract."""
+    key_data = (
+        CACHE_FORMAT_VERSION,
+        fn.__module__,
+        fn.__qualname__,
+        _canonicalize(args),
+        _canonicalize(kwargs),
+        target,
+    )
+    encoded = pickle.dumps(key_data, protocol=pickle.HIGHEST_PROTOCOL)
+    return hashlib.sha256(encoded).hexdigest()

--- a/attn_gym/_backends/cute/cache.py
+++ b/attn_gym/_backends/cute/cache.py
@@ -1,0 +1,394 @@
+"""Persistent cache primitives for TVM-FFI CuTeDSL kernels.
+
+``jit_cache`` decorates a module-level function that calls ``cute.compile``.
+Its static arguments and ``CompileTarget`` determine the cache key. Cold
+entries are compiled under a per-key process lock and atomically exported;
+warm entries are loaded from the shared object file.
+
+``ATTN_GYM_CUTE_CACHE_DIR`` is the only Attention Gym environment override.
+Other behavior is expressed through ``jit_cache`` and tuning options. The
+upstream ``CUTE_DSL_NO_CACHE`` switch is still respected.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import errno
+import functools
+import logging
+import os
+import tempfile
+import threading
+import time
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, ParamSpec, TypeVar
+
+from typing_extensions import Self
+
+from ._key import make_key as _make_key
+from ._key import source_fingerprint as _source_fingerprint
+from .target import get_compile_target
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - CuTeDSL currently targets Linux.
+    fcntl = None  # type: ignore[assignment]
+
+
+logger = logging.getLogger(__name__)
+
+EXPORT_FUNCTION_NAME = "func"
+DEFAULT_LOCK_TIMEOUT_SECONDS = 600.0
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+_compile_lock = threading.Lock()
+_compile_lock_pid = os.getpid()
+_runtime_library_handles: list[Any] = []
+_runtime_library_lock = threading.Lock()
+_runtime_library_lock_pid = os.getpid()
+
+
+@dataclass(frozen=True)
+class CacheInfo:
+    """Process-local cache statistics for one decorated compile function."""
+
+    hits: int
+    misses: int
+    currsize: int
+
+
+@dataclass(frozen=True)
+class _CacheEntry:
+    key: str
+    object_path: Path
+    lock_path: Path
+
+
+class CacheLockError(RuntimeError):
+    """Raised when a persistent cache entry cannot be locked."""
+
+
+class _FileLock:
+    """Hold an exclusive advisory file lock with a bounded wait."""
+
+    def __init__(self, path: Path, timeout: float):
+        self.path = path
+        self.timeout = timeout
+        self.fd = -1
+
+    def __enter__(self) -> Self:
+        if fcntl is None:
+            raise CacheLockError("persistent CuTeDSL caching requires fcntl.flock")
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            self.fd = os.open(self.path, os.O_RDWR | os.O_CREAT, 0o600)
+        except OSError as error:
+            raise CacheLockError(f"could not open cache lock {self.path}") from error
+
+        deadline = time.monotonic() + self.timeout
+        while True:
+            try:
+                fcntl.flock(self.fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                return self
+            except OSError as error:
+                if error.errno not in (errno.EACCES, errno.EAGAIN):
+                    self._close()
+                    raise CacheLockError(f"could not lock cache entry {self.path}") from error
+                if time.monotonic() >= deadline:
+                    self._close()
+                    raise CacheLockError(
+                        f"timed out waiting for cache lock {self.path}"
+                    ) from error
+                time.sleep(0.05)
+
+    def __exit__(self, *exc: object) -> None:
+        if self.fd >= 0:
+            assert fcntl is not None
+            fcntl.flock(self.fd, fcntl.LOCK_UN)
+            self._close()
+
+    def _close(self) -> None:
+        if self.fd >= 0:
+            os.close(self.fd)
+            self.fd = -1
+
+
+def get_cache_path() -> Path:
+    """Return the root directory used for persistent CuTeDSL artifacts."""
+    configured = os.getenv("ATTN_GYM_CUTE_CACHE_DIR")
+    if configured:
+        return Path(configured).expanduser()
+    xdg_cache = os.getenv("XDG_CACHE_HOME")
+    cache_home = Path(xdg_cache).expanduser() if xdg_cache else Path.home() / ".cache"
+    return cache_home / "attention_gym" / "cute"
+
+
+def cache_enabled() -> bool:
+    """Return whether the upstream CuTeDSL no-cache switch is inactive."""
+    value = os.getenv("CUTE_DSL_NO_CACHE")
+    return value is None or value.lower() in {"0", "false", "no", "off"}
+
+
+def _cache_entry(
+    fn: Callable[..., Any],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    extra_sources: tuple[str, ...],
+) -> _CacheEntry:
+    key = _make_key(fn, args, kwargs, get_compile_target())
+    directory = get_cache_path() / _source_fingerprint(fn, extra_sources)
+    return _CacheEntry(key, directory / f"{key}.o", directory / f"{key}.lock")
+
+
+def _compile(fn: Callable[P, T], args: tuple[Any, ...], kwargs: dict[str, Any]) -> T:
+    """Serialize CuTeDSL compilation within one process."""
+    global _compile_lock, _compile_lock_pid
+    current_pid = os.getpid()
+    if current_pid != _compile_lock_pid:
+        _compile_lock = threading.Lock()
+        _compile_lock_pid = current_pid
+    with _compile_lock:
+        return fn(*args, **kwargs)
+
+
+def _ensure_runtime_libraries_global() -> None:
+    """Preload runtime libraries for symbols referenced by cached objects."""
+    global _runtime_library_lock, _runtime_library_lock_pid
+    if _runtime_library_handles or not hasattr(ctypes, "RTLD_GLOBAL"):
+        return
+    current_pid = os.getpid()
+    if current_pid != _runtime_library_lock_pid:
+        _runtime_library_lock = threading.Lock()
+        _runtime_library_lock_pid = current_pid
+    with _runtime_library_lock:
+        if _runtime_library_handles:
+            return
+        from cutlass import cute
+
+        for library_path in cute.runtime.find_runtime_libraries(enable_tvm_ffi=False):
+            path = Path(library_path)
+            if path.exists():
+                _runtime_library_handles.append(ctypes.CDLL(str(path), mode=ctypes.RTLD_GLOBAL))
+
+
+def _load_compiled(path: Path) -> Any:
+    """Load a TVM-FFI callable from an exported object file."""
+    from cutlass import cute
+
+    _ensure_runtime_libraries_global()
+    module = cute.runtime.load_module(str(path), enable_tvm_ffi=True)
+    return module[EXPORT_FUNCTION_NAME]
+
+
+def _publish_compiled(compiled: Any, destination: Path) -> None:
+    """Export a compiled callable and atomically publish its object file."""
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(
+        prefix=f".{destination.stem}.", suffix=".tmp.o", dir=destination.parent
+    )
+    os.close(fd)
+    temporary_path = Path(temporary_name)
+    try:
+        compiled.export_to_c(
+            object_file_path=str(temporary_path),
+            function_name=EXPORT_FUNCTION_NAME,
+        )
+        if temporary_path.stat().st_size == 0:
+            raise RuntimeError("CuTeDSL exported an empty object file")
+        with temporary_path.open("rb") as artifact:
+            os.fsync(artifact.fileno())
+        os.replace(temporary_path, destination)
+        directory_fd = os.open(destination.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+def _artifact_exists(path: Path) -> bool:
+    try:
+        return path.stat().st_size > 0
+    except OSError:
+        return False
+
+
+def jit_cache(
+    fn: Callable[P, T] | None = None,
+    *,
+    persistent: bool = True,
+    lock_timeout: float = DEFAULT_LOCK_TIMEOUT_SECONDS,
+    extra_sources: Iterable[str | os.PathLike[str]] = (),
+) -> Callable[P, T]:
+    """Cache a ``cute.compile`` function in memory and optionally on disk.
+
+    The function's arguments must be static values that completely determine
+    generated code. ``persistent=False`` keeps only the process-local cache.
+    ``extra_sources`` explicitly adds downstream files or trees to source
+    invalidation; neither setting requires an environment variable.
+    """
+    if fn is None:
+        return functools.partial(
+            jit_cache,
+            persistent=persistent,
+            lock_timeout=lock_timeout,
+            extra_sources=extra_sources,
+        )
+    if lock_timeout <= 0:
+        raise ValueError(f"lock_timeout must be positive, got {lock_timeout}")
+    source_paths = tuple(os.fspath(Path(path).expanduser().resolve()) for path in extra_sources)
+    memory_cache: dict[str, T] = {}
+    key_locks: dict[str, threading.Lock] = {}
+    state_lock = threading.RLock()
+    cache_pid = os.getpid()
+    hits = 0
+    misses = 0
+
+    def reset_after_fork() -> None:
+        nonlocal cache_pid, hits, misses, state_lock
+        current_pid = os.getpid()
+        if current_pid == cache_pid:
+            return
+        state_lock = threading.RLock()
+        memory_cache.clear()
+        key_locks.clear()
+        hits = 0
+        misses = 0
+        cache_pid = current_pid
+
+    def remember(key: str, compiled: T, *, hit: bool) -> T:
+        nonlocal hits, misses
+        with state_lock:
+            memory_cache[key] = compiled
+            if hit:
+                hits += 1
+            else:
+                misses += 1
+        return compiled
+
+    def compile_and_publish(
+        entry: _CacheEntry,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+        *,
+        strict: bool,
+    ) -> T:
+        compiled = _compile(fn, args, kwargs)
+        try:
+            _publish_compiled(compiled, entry.object_path)
+        except Exception:
+            if strict:
+                raise
+            logger.warning(
+                "Could not persist CuTeDSL cache artifact %s",
+                entry.object_path,
+                exc_info=True,
+            )
+        return compiled
+
+    def load_from_disk(entry: _CacheEntry) -> T | None:
+        if not _artifact_exists(entry.object_path):
+            return None
+        try:
+            return _load_compiled(entry.object_path)
+        except (AttributeError, KeyError, OSError, RuntimeError, ValueError):
+            return None
+
+    def disk_cache_enabled() -> bool:
+        return persistent and cache_enabled()
+
+    @functools.wraps(fn)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+        nonlocal hits
+        entry = _cache_entry(fn, args, kwargs, source_paths)
+        reset_after_fork()
+        with state_lock:
+            if entry.key in memory_cache:
+                hits += 1
+                return memory_cache[entry.key]
+            key_lock = key_locks.setdefault(entry.key, threading.Lock())
+
+        with key_lock:
+            reset_after_fork()
+            with state_lock:
+                if entry.key in memory_cache:
+                    hits += 1
+                    return memory_cache[entry.key]
+
+            if not disk_cache_enabled():
+                return remember(entry.key, _compile(fn, args, kwargs), hit=False)
+
+            compiled = load_from_disk(entry)
+            if compiled is not None:
+                return remember(entry.key, compiled, hit=True)
+
+            try:
+                with _FileLock(entry.lock_path, lock_timeout):
+                    compiled = load_from_disk(entry)
+                    if compiled is not None:
+                        return remember(entry.key, compiled, hit=True)
+                    if entry.object_path.exists():
+                        logger.warning(
+                            "Replacing corrupt CuTeDSL cache artifact %s",
+                            entry.object_path,
+                        )
+                        entry.object_path.unlink(missing_ok=True)
+                    compiled = compile_and_publish(entry, args, kwargs, strict=False)
+                    return remember(entry.key, compiled, hit=False)
+            except CacheLockError:
+                logger.warning(
+                    "CuTeDSL cache lock unavailable for key %s; compiling without disk cache",
+                    entry.key,
+                    exc_info=True,
+                )
+                return remember(entry.key, _compile(fn, args, kwargs), hit=False)
+
+    def precompile(*args: P.args, **kwargs: P.kwargs) -> None:
+        """Populate one disk entry without loading or returning the artifact."""
+        if not disk_cache_enabled():
+            raise RuntimeError("parallel CuTeDSL precompilation requires the disk cache")
+        entry = _cache_entry(fn, args, kwargs, source_paths)
+        if _artifact_exists(entry.object_path):
+            return
+        with _FileLock(entry.lock_path, lock_timeout):
+            if _artifact_exists(entry.object_path):
+                return
+            entry.object_path.unlink(missing_ok=True)
+            compile_and_publish(entry, args, kwargs, strict=True)
+
+    def is_cached(*args: P.args, **kwargs: P.kwargs) -> bool:
+        """Return whether a nonempty disk artifact exists for this invocation."""
+        return _artifact_exists(_cache_entry(fn, args, kwargs, source_paths).object_path)
+
+    def prepare_cache() -> None:
+        """Warm source fingerprinting before compiler workers are forked."""
+        _source_fingerprint(fn, source_paths)
+
+    def cache_clear() -> None:
+        """Clear this function's process-local entries and statistics."""
+        nonlocal hits, misses
+        reset_after_fork()
+        with state_lock:
+            memory_cache.clear()
+            key_locks.clear()
+            hits = 0
+            misses = 0
+
+    def cache_info() -> CacheInfo:
+        """Return this function's process-local hit and miss counters."""
+        reset_after_fork()
+        with state_lock:
+            return CacheInfo(hits=hits, misses=misses, currsize=len(memory_cache))
+
+    wrapper.precompile = precompile  # type: ignore[attr-defined]
+    wrapper.is_cached = is_cached  # type: ignore[attr-defined]
+    wrapper.disk_cache_enabled = disk_cache_enabled  # type: ignore[attr-defined]
+    wrapper.prepare_cache = prepare_cache  # type: ignore[attr-defined]
+    wrapper.cache_clear = cache_clear  # type: ignore[attr-defined]
+    wrapper.cache_info = cache_info  # type: ignore[attr-defined]
+    return wrapper

--- a/attn_gym/_backends/cute/target.py
+++ b/attn_gym/_backends/cute/target.py
@@ -1,0 +1,74 @@
+"""CUDA target metadata that forked compiler workers can inherit safely."""
+
+from __future__ import annotations
+
+import os
+import threading
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CompileTarget:
+    """Device facts that may affect generated code or launch policy."""
+
+    device_type: str
+    configured_arch: str | None = None
+    capability: tuple[int, int] | None = None
+    name: str | None = None
+    sm_count: int | None = None
+
+
+_target: CompileTarget | None = None
+_target_lock = threading.Lock()
+_target_lock_pid = os.getpid()
+
+
+def _lock() -> threading.Lock:
+    global _target_lock, _target_lock_pid
+    current_pid = os.getpid()
+    if current_pid != _target_lock_pid:
+        _target_lock = threading.Lock()
+        _target_lock_pid = current_pid
+    return _target_lock
+
+
+def set_compile_target(target: CompileTarget | None) -> None:
+    """Set target metadata for this process and subsequently forked workers."""
+    global _target
+    with _lock():
+        _target = target
+
+
+def detect_compile_target(device: int | None = None) -> CompileTarget:
+    """Query target metadata in a process allowed to use the CUDA driver."""
+    import torch
+
+    is_bad_fork = getattr(torch.cuda, "_is_in_bad_fork", lambda: False)
+    if is_bad_fork():
+        raise RuntimeError(
+            "cannot discover a CuTeDSL target in a forked CUDA child; pass a "
+            "CompileTarget or use precompile_many(), which uses a fresh compiler process"
+        )
+
+    configured_arch = os.getenv("CUTE_DSL_ARCH")
+    if not torch.cuda.is_available():
+        return CompileTarget(device_type="none", configured_arch=configured_arch)
+
+    device_index = torch.cuda.current_device() if device is None else device
+    properties = torch.cuda.get_device_properties(device_index)
+    return CompileTarget(
+        device_type="cuda",
+        configured_arch=configured_arch,
+        capability=(properties.major, properties.minor),
+        name=properties.name,
+        sm_count=properties.multi_processor_count,
+    )
+
+
+def get_compile_target() -> CompileTarget:
+    """Return explicitly supplied target metadata, discovering it if necessary."""
+    global _target
+    with _lock():
+        if _target is None:
+            _target = detect_compile_target()
+        return _target

--- a/attn_gym/_backends/cute/utils.py
+++ b/attn_gym/_backends/cute/utils.py
@@ -1,0 +1,65 @@
+"""Opinionated primitives for standalone CuTeDSL kernels."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+_VALID_NAME = re.compile(r"[a-z][a-z0-9_]*\Z")
+
+
+def _contains_torch_tensor(value: Any) -> bool:
+    import torch
+
+    if isinstance(value, torch.Tensor):
+        return True
+    if isinstance(value, (tuple, list)):
+        return any(_contains_torch_tensor(item) for item in value)
+    if isinstance(value, dict):
+        return any(
+            _contains_torch_tensor(key) or _contains_torch_tensor(item)
+            for key, item in value.items()
+        )
+    return False
+
+
+def compile_tvm_ffi(
+    entrypoint: Any,
+    *compile_args: Any,
+    name: str | None = None,
+) -> Any:
+    """Compile a fake-tensor signature with the canonical TVM-FFI stream ABI.
+
+    ``compile_args`` describe the callable's runtime signature and must omit the
+    stream. Tensor arguments should be fake CuTe tensors, never runtime Torch
+    tensors. This helper appends a fake environment stream, enables TVM-FFI with
+    a typed compile option, and gives the outer artifact a stable name.
+
+    Class-based entrypoints should expose ``get_name()``. Free-function
+    entrypoints may instead provide ``name=`` explicitly.
+    """
+    if name is None:
+        get_name = getattr(entrypoint, "get_name", None)
+        if not callable(get_name):
+            raise TypeError("compile_tvm_ffi() requires entrypoint.get_name() or name=")
+        name = get_name()
+    if not isinstance(name, str) or _VALID_NAME.fullmatch(name) is None:
+        raise ValueError(
+            "CuTeDSL compile names must start with a lowercase letter and contain "
+            f"only lowercase letters, digits, and underscores; got {name!r}"
+        )
+    if any(_contains_torch_tensor(arg) for arg in compile_args):
+        raise TypeError("compile_tvm_ffi() accepts fake CuTe tensors, not runtime Torch tensors")
+
+    from cutlass import cute
+
+    stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
+    return cute.compile[cute.EnableTVMFFI](
+        entrypoint,
+        *compile_args,
+        stream,
+        _name_prefix=name,
+    )
+
+
+__all__ = ["compile_tvm_ffi"]

--- a/test/test_cute_cache.py
+++ b/test/test_cute_cache.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+import multiprocessing
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from attn_gym._backends.cute import cache as cute_cache
+from attn_gym._backends.cute import target as cute_target
+from attn_gym._backends.cute.utils import compile_tvm_ffi
+
+
+class FakeCompiled:
+    """Minimal compiled callable that exports a loadable test artifact."""
+
+    def __init__(self, value: str):
+        self.value = value
+
+    def __call__(self) -> str:
+        return self.value
+
+    def export_to_c(self, object_file_path: str, function_name: str) -> None:
+        Path(object_file_path).write_text(f"{function_name}:{self.value}")
+
+
+def load_fake_compiled(path: Path) -> FakeCompiled:
+    """Load the test artifact format written by ``FakeCompiled``."""
+    function_name, separator, value = path.read_text().partition(":")
+    if separator != ":" or function_name != cute_cache.EXPORT_FUNCTION_NAME:
+        raise RuntimeError("corrupt test artifact")
+    return FakeCompiled(value)
+
+
+def wait_for_processes(processes, timeout: float = 15.0) -> None:
+    """Join child processes and fail without leaving a process behind."""
+    deadline = time.monotonic() + timeout
+    try:
+        for process in processes:
+            process.join(timeout=max(0.0, deadline - time.monotonic()))
+        failures = [(process.pid, process.exitcode) for process in processes if process.exitcode]
+        assert failures == []
+    finally:
+        for process in processes:
+            if process.is_alive():
+                process.terminate()
+                process.join(timeout=5)
+
+
+@pytest.fixture(autouse=True)
+def reset_compile_target():
+    cute_target.set_compile_target(None)
+    yield
+    cute_target.set_compile_target(None)
+
+
+@pytest.fixture
+def isolated_cache(tmp_path, monkeypatch):
+    """Use deterministic fingerprints and an isolated persistent cache."""
+    cache_directory = tmp_path / "cache"
+    monkeypatch.setenv("ATTN_GYM_CUTE_CACHE_DIR", str(cache_directory))
+    monkeypatch.delenv("CUTE_DSL_NO_CACHE", raising=False)
+    monkeypatch.setattr(
+        cute_cache,
+        "_source_fingerprint",
+        lambda _fn, _extra_sources=(): "test-source",
+    )
+    monkeypatch.setattr(
+        cute_cache,
+        "get_compile_target",
+        lambda: cute_target.CompileTarget("test"),
+    )
+    monkeypatch.setattr(cute_cache, "_load_compiled", load_fake_compiled)
+    return cache_directory
+
+
+def test_cache_directory_can_be_overridden(tmp_path, monkeypatch):
+    configured_path = tmp_path / "custom-cache"
+    monkeypatch.setenv("ATTN_GYM_CUTE_CACHE_DIR", str(configured_path))
+
+    assert cute_cache.get_cache_path() == configured_path
+
+
+def test_compile_tvm_ffi_enforces_the_compile_contract():
+    import torch
+
+    with pytest.raises(TypeError, match=r"get_name\(\) or name="):
+        compile_tvm_ffi(object())
+    with pytest.raises(ValueError, match="lowercase"):
+        compile_tvm_ffi(object(), name="Bad-Name")
+    with pytest.raises(TypeError, match="fake CuTe tensors"):
+        compile_tvm_ffi(object(), {"nested": torch.empty(0)}, name="valid_name")
+
+
+def test_compile_tvm_ffi_adds_fake_stream_and_typed_option(monkeypatch):
+    cute = pytest.importorskip("cutlass.cute")
+
+    fake_stream = object()
+    fake_tensor = object()
+    observed = {}
+
+    class FakeCompile:
+        def __getitem__(self, option):
+            observed["option"] = option
+            return self
+
+        def __call__(self, entrypoint, *args, **kwargs):
+            observed.update(entrypoint=entrypoint, args=args, kwargs=kwargs)
+            return "compiled"
+
+    class EntryPoint:
+        @staticmethod
+        def get_name() -> str:
+            return "stable_kernel_name"
+
+    monkeypatch.setattr(cute, "compile", FakeCompile())
+    monkeypatch.setattr(
+        cute.runtime,
+        "make_fake_stream",
+        lambda *, use_tvm_ffi_env_stream: fake_stream if use_tvm_ffi_env_stream else None,
+    )
+    entrypoint = EntryPoint()
+
+    assert compile_tvm_ffi(entrypoint, fake_tensor) == "compiled"
+    assert observed == {
+        "option": cute.EnableTVMFFI,
+        "entrypoint": entrypoint,
+        "args": (fake_tensor, fake_stream),
+        "kwargs": {"_name_prefix": "stable_kernel_name"},
+    }
+
+
+def test_same_key_compiles_once_across_threads(isolated_cache):
+    compile_count = 0
+    count_lock = threading.Lock()
+
+    @cute_cache.jit_cache
+    def compile_kernel(key: str) -> FakeCompiled:
+        nonlocal compile_count
+        with count_lock:
+            compile_count += 1
+        time.sleep(0.1)
+        return FakeCompiled(key)
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        results = list(executor.map(compile_kernel, ["shared"] * 8))
+
+    assert compile_count == 1
+    assert [result() for result in results] == ["shared"] * 8
+    assert compile_kernel.cache_info() == cute_cache.CacheInfo(hits=7, misses=1, currsize=1)
+    assert len(list(isolated_cache.rglob("*.o"))) == 1
+
+
+def test_distinct_keys_serialize_compilation_within_process(isolated_cache):
+    active_compiles = 0
+    max_active_compiles = 0
+    count_lock = threading.Lock()
+
+    @cute_cache.jit_cache
+    def compile_kernel(key: str) -> FakeCompiled:
+        nonlocal active_compiles, max_active_compiles
+        with count_lock:
+            active_compiles += 1
+            max_active_compiles = max(max_active_compiles, active_compiles)
+        time.sleep(0.1)
+        with count_lock:
+            active_compiles -= 1
+        return FakeCompiled(key)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(compile_kernel, ["first", "second"]))
+
+    assert {result() for result in results} == {"first", "second"}
+    assert max_active_compiles == 1
+    assert compile_kernel.cache_info().misses == 2
+
+
+def test_corrupt_artifact_is_recompiled(isolated_cache):
+    compile_count = 0
+
+    @cute_cache.jit_cache
+    def compile_kernel(key: str) -> FakeCompiled:
+        nonlocal compile_count
+        compile_count += 1
+        return FakeCompiled(key)
+
+    assert compile_kernel("key")() == "key"
+    compile_kernel.cache_clear()
+    artifact = next(isolated_cache.rglob("*.o"))
+    artifact.write_bytes(b"corrupt")
+
+    assert compile_kernel("key")() == "key"
+    assert compile_count == 2
+    assert artifact.read_text() == f"{cute_cache.EXPORT_FUNCTION_NAME}:key"
+
+
+def test_failed_export_does_not_publish_partial_artifact(isolated_cache):
+    class FailedExport(FakeCompiled):
+        def export_to_c(self, object_file_path: str, function_name: str) -> None:
+            Path(object_file_path).write_bytes(b"partial")
+            raise RuntimeError("export failed")
+
+    @cute_cache.jit_cache
+    def compile_kernel() -> FailedExport:
+        return FailedExport("value")
+
+    assert compile_kernel()() == "value"
+    assert not list(isolated_cache.rglob("*.o"))
+
+
+def test_persistent_cache_can_be_disabled_with_an_option(tmp_path, monkeypatch):
+    cache_directory = tmp_path / "cache"
+    monkeypatch.setenv("ATTN_GYM_CUTE_CACHE_DIR", str(cache_directory))
+    monkeypatch.setattr(
+        cute_cache,
+        "get_compile_target",
+        lambda: cute_target.CompileTarget("test"),
+    )
+    monkeypatch.setattr(
+        cute_cache,
+        "_source_fingerprint",
+        lambda _fn, _extra_sources=(): "test-source",
+    )
+    compile_count = 0
+
+    @cute_cache.jit_cache(persistent=False)
+    def compile_kernel() -> FakeCompiled:
+        nonlocal compile_count
+        compile_count += 1
+        return FakeCompiled("value")
+
+    compile_kernel()
+    compile_kernel.cache_clear()
+    compile_kernel()
+
+    assert compile_count == 2
+    assert not list(cache_directory.rglob("*.o"))
+
+
+def test_explicit_target_avoids_device_discovery(monkeypatch):
+    target = cute_target.CompileTarget(
+        device_type="cuda",
+        capability=(10, 0),
+        name="test-gpu",
+        sm_count=100,
+    )
+
+    def unexpected_discovery():
+        raise AssertionError("CUDA discovery was called")
+
+    monkeypatch.setattr(cute_target, "detect_compile_target", unexpected_discovery)
+    cute_target.set_compile_target(target)
+
+    assert cute_target.get_compile_target() == target
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="fcntl.flock and fork are required")
+@pytest.mark.filterwarnings("ignore:This process .* is multi-threaded.*:DeprecationWarning")
+def test_same_key_compiles_once_across_processes(isolated_cache):
+    context = multiprocessing.get_context("fork")
+    process_count = 6
+    compile_count = context.Value("i", 0)
+    start = context.Event()
+
+    @cute_cache.jit_cache
+    def compile_kernel(key: str) -> FakeCompiled:
+        with compile_count.get_lock():
+            compile_count.value += 1
+        time.sleep(0.2)
+        return FakeCompiled(key)
+
+    def worker() -> None:
+        start.wait()
+        assert compile_kernel("shared")() == "shared"
+
+    processes = [context.Process(target=worker) for _ in range(process_count)]
+    for process in processes:
+        process.start()
+    start.set()
+    wait_for_processes(processes)
+
+    assert compile_count.value == 1
+    assert len(list(isolated_cache.rglob("*.o"))) == 1
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="fcntl.flock and fork are required")
+@pytest.mark.filterwarnings("ignore:This process .* is multi-threaded.*:DeprecationWarning")
+@pytest.mark.parametrize("process_count", [1, 2, 4, 8])
+def test_parallel_population_then_sequential_reload(isolated_cache, process_count):
+    """Workers compile distinct variants before the parent reloads them sequentially."""
+    context = multiprocessing.get_context("fork")
+    compile_count = context.Value("i", 0)
+    compile_barrier = context.Barrier(process_count, timeout=10)
+
+    @cute_cache.jit_cache
+    def compile_kernel(variant: str) -> FakeCompiled:
+        with compile_count.get_lock():
+            compile_count.value += 1
+        compile_barrier.wait()
+        return FakeCompiled(variant)
+
+    def run_wave() -> None:
+        start = context.Event()
+
+        def worker(variant: int) -> None:
+            start.wait()
+            expected = str(variant)
+            assert compile_kernel(expected)() == expected
+
+        processes = [
+            context.Process(target=worker, args=(variant,)) for variant in range(process_count)
+        ]
+        for process in processes:
+            process.start()
+        start.set()
+        wait_for_processes(processes)
+
+    run_wave()
+    assert compile_count.value == process_count
+    assert len(list(isolated_cache.rglob("*.o"))) == process_count
+
+    compile_kernel.cache_clear()
+    for variant in range(process_count):
+        expected = str(variant)
+        assert compile_kernel(expected)() == expected
+
+    assert compile_count.value == process_count
+    assert compile_kernel.cache_info() == cute_cache.CacheInfo(
+        hits=process_count,
+        misses=0,
+        currsize=process_count,
+    )


### PR DESCRIPTION
Stacked PRs:
 * #248
 * #247
 * #246
 * __->__#245


--- --- ---

Add persistent CuTeDSL compile cache

Human Note

Agent note
CuTeDSL call sites currently rely on process-local dictionaries or the compiler's implicit cache,
which cannot safely coordinate concurrent tuning workers. Add a source- and target-aware artifact
cache with per-key file locking, atomic object publication, corrupt-entry recovery, and process-local
loaded-callable reuse. Keep runtime tensors outside the key and centralize the fake-stream, typed
TVM-FFI compile contract in `compile_tvm_ffi`.

The cache directory has one Attention Gym override, while the upstream `CUTE_DSL_NO_CACHE` switch
remains authoritative. Tests use an isolated temporary cache and fake exported objects to cover
thread/process contention, warm reloads, failure cleanup, target inheritance, and the TVM-FFI ABI
without requiring a GPU.

Test Plan:

```bash
~/.venvs/nightly/bin/python -m pytest -q test/test_cute_cache.py
~/.venvs/dev/bin/ruff check attn_gym/_backends/cute/{__init__,_key,cache,target,utils}.py test/test_cute_cache.py
```