### PR TITLE
Add parallel CuTeDSL tuning

### DIFF
--- a/attn_gym/_backends/cute/__init__.py
+++ b/attn_gym/_backends/cute/__init__.py
@@ -1,6 +1,13 @@
 """Infrastructure shared by CuTeDSL attention backends."""
 
 from .cache import jit_cache
+from .tune import TunableKernel, benchmark_gpu, run_tunable
 from .utils import compile_tvm_ffi
 
-__all__ = ["compile_tvm_ffi", "jit_cache"]
+__all__ = [
+    "TunableKernel",
+    "benchmark_gpu",
+    "compile_tvm_ffi",
+    "jit_cache",
+    "run_tunable",
+]

--- a/attn_gym/_backends/cute/_compile_driver.py
+++ b/attn_gym/_backends/cute/_compile_driver.py
@@ -1,0 +1,83 @@
+"""Fresh-process driver for CuTeDSL compilation.
+
+The driver is a fresh interpreter. It installs import paths and target metadata,
+decodes a trusted compile-call payload, then forks workers that receive only
+integer indices into state inherited from the driver.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import pickle
+import sys
+from concurrent.futures import ProcessPoolExecutor
+from multiprocessing import get_context
+from pathlib import Path
+from typing import Any
+
+_compile_fn: Any | None = None
+_compile_calls: list[tuple[Any, ...]] = []
+
+
+def _resolve(module_name: str, qualname: str) -> Any:
+    value: Any = importlib.import_module(module_name)
+    for component in qualname.split("."):
+        value = getattr(value, component)
+    return value
+
+
+def _precompile_call(index: int) -> None:
+    if _compile_fn is None:
+        raise RuntimeError("compiler worker was forked without a compile function")
+    _compile_fn.precompile(*_compile_calls[index])
+
+
+def main(request_path: Path, calls_path: Path) -> int:
+    global _compile_calls, _compile_fn
+    request = json.loads(request_path.read_text(encoding="utf-8"))
+    inherited_paths = request["sys_path"]
+    sys.path[:] = inherited_paths + [path for path in sys.path if path not in inherited_paths]
+
+    try:
+        import torch._thread_safe_fork  # noqa: F401
+    except ImportError:
+        pass
+
+    from attn_gym._backends.cute.target import CompileTarget, set_compile_target
+
+    target_fields = request["target"]
+    capability = target_fields.get("capability")
+    if capability is not None:
+        target_fields["capability"] = tuple(capability)
+    set_compile_target(CompileTarget(**target_fields))
+
+    _compile_fn = _resolve(request["module"], request["qualname"])
+    if not callable(getattr(_compile_fn, "precompile", None)):
+        raise TypeError("compile function is not decorated with jit_cache")
+
+    # The parent creates this payload inside the same private TemporaryDirectory.
+    # It is never accepted from a persistent cache or an external caller.
+    _compile_calls = pickle.loads(calls_path.read_bytes())
+
+    # Amortize imports and source hashing across workers. Target metadata is
+    # already available, so this setup does not need CUDA device discovery.
+    prepare_cache = getattr(_compile_fn, "prepare_cache", None)
+    if callable(prepare_cache):
+        prepare_cache()
+
+    context = get_context("fork")
+    with ProcessPoolExecutor(
+        max_workers=request["workers"],
+        mp_context=context,
+    ) as pool:
+        futures = [pool.submit(_precompile_call, index) for index in range(len(_compile_calls))]
+        for future in futures:
+            future.result()
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        raise SystemExit("usage: _compile_driver.py REQUEST CALLS")
+    raise SystemExit(main(Path(sys.argv[1]), Path(sys.argv[2])))

--- a/attn_gym/_backends/cute/compile.py
+++ b/attn_gym/_backends/cute/compile.py
@@ -1,0 +1,181 @@
+"""Process orchestration for parallel CuTeDSL compilation.
+
+The application discovers its target once, starts a fresh compiler process,
+and asks it to fork compiler workers. Workers populate the disk cache;
+the application then loads artifacts sequentially without sharing CUDA state
+or CuTeDSL compiler singletons across processes.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pickle
+import subprocess
+import sys
+import tempfile
+from collections.abc import Callable, Iterable
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, TypeVar
+
+from .target import CompileTarget, get_compile_target, set_compile_target
+
+T = TypeVar("T")
+DEFAULT_COMPILE_TIMEOUT_SECONDS = 15 * 60
+
+
+def _materialize_calls(calls: Iterable[tuple[Any, ...]]) -> list[tuple[Any, ...]]:
+    """Materialize positional compile calls and reject ambiguous scalar values."""
+    result = list(calls)
+    if not all(isinstance(call, tuple) for call in result):
+        raise TypeError("each compile call must be a tuple of positional static arguments")
+    return result
+
+
+def _worker_count(requested: int | None, call_count: int) -> int:
+    requested = min(4, os.cpu_count() or 1) if requested is None else requested
+    if requested < 1:
+        raise ValueError(f"workers must be positive, got {requested}")
+    return min(requested, call_count)
+
+
+def _function_reference(fn: Callable[..., Any]) -> tuple[str, str]:
+    module = fn.__module__
+    qualname = fn.__qualname__
+    if module == "__main__" or "<locals>" in qualname:
+        raise ValueError(
+            "parallel CuTeDSL compile functions must be decorated at module scope "
+            "in an importable module"
+        )
+    if not callable(getattr(fn, "precompile", None)):
+        raise TypeError("precompile_many() requires a function decorated with jit_cache")
+    return module, qualname
+
+
+def _module_root(fn: Callable[..., Any]) -> str | None:
+    module = sys.modules.get(fn.__module__)
+    module_file = getattr(module, "__file__", None)
+    if module_file is None:
+        return None
+    root = Path(module_file).resolve().parent
+    levels = len(fn.__module__.split("."))
+    if Path(module_file).name != "__init__.py":
+        levels -= 1
+    for _ in range(levels):
+        root = root.parent
+    return str(root)
+
+
+def _import_paths(fn: Callable[..., Any]) -> list[str]:
+    paths = []
+    module_root = _module_root(fn)
+    candidates = ([module_root] if module_root else []) + list(sys.path)
+    for path in candidates:
+        resolved = os.getcwd() if path == "" else os.fspath(path)
+        if resolved not in paths:
+            paths.append(resolved)
+    return paths
+
+
+def _driver_error(completed: subprocess.CompletedProcess[str]) -> str:
+    details = []
+    if completed.stdout:
+        details.append("compiler process stdout:\n" + completed.stdout)
+    if completed.stderr:
+        details.append("compiler process stderr:\n" + completed.stderr)
+    return "\n".join(details) or f"compiler process exited with status {completed.returncode}"
+
+
+def precompile_many(
+    fn: Callable[..., Any],
+    calls: Iterable[tuple[Any, ...]],
+    *,
+    workers: int | None = None,
+    target: CompileTarget | None = None,
+    timeout: float | None = DEFAULT_COMPILE_TIMEOUT_SECONDS,
+) -> None:
+    """Populate many variants through a fresh compiler process and forked workers.
+
+    Each item in ``calls`` is a tuple of positional static arguments; use
+    ``(config,)`` for a one-argument compile function. Values must be pickleable,
+    and custom config classes must live at module scope so the fresh compiler
+    process can import them.
+    """
+    call_args = _materialize_calls(calls)
+    if not call_args:
+        return
+    if sys.platform == "win32":  # pragma: no cover - CuTeDSL currently targets Linux.
+        raise RuntimeError("parallel CuTeDSL precompilation requires fork support")
+
+    module, qualname = _function_reference(fn)
+    disk_cache_enabled = getattr(fn, "disk_cache_enabled", None)
+    if callable(disk_cache_enabled) and not disk_cache_enabled():
+        raise RuntimeError("parallel CuTeDSL precompilation requires the disk cache")
+
+    target = target or get_compile_target()
+    set_compile_target(target)
+    is_cached = getattr(fn, "is_cached", None)
+    pending_calls = (
+        [args for args in call_args if not is_cached(*args)] if callable(is_cached) else call_args
+    )
+    if not pending_calls:
+        return
+
+    request = {
+        "module": module,
+        "qualname": qualname,
+        "workers": _worker_count(workers, len(pending_calls)),
+        "target": asdict(target),
+        "sys_path": _import_paths(fn),
+    }
+
+    driver = Path(__file__).with_name("_compile_driver.py")
+    with tempfile.TemporaryDirectory(prefix="attention-gym-cute-compile-") as directory:
+        request_path = Path(directory) / "request.json"
+        calls_path = Path(directory) / "calls.pkl"
+        request_path.write_text(
+            json.dumps(request, ensure_ascii=False, separators=(",", ":")),
+            encoding="utf-8",
+        )
+        # This trusted, one-shot payload is created and consumed inside the
+        # private TemporaryDirectory; persistent cache entries are never pickled.
+        calls_path.write_bytes(pickle.dumps(pending_calls, protocol=pickle.HIGHEST_PROTOCOL))
+        try:
+            completed = subprocess.run(
+                [sys.executable, str(driver), str(request_path), str(calls_path)],
+                check=False,
+                capture_output=True,
+                text=True,
+                env={**os.environ, "TORCH_WARM_POOL": "0"},
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired as error:
+            raise RuntimeError(
+                f"parallel CuTeDSL precompilation timed out after {timeout} seconds"
+            ) from error
+
+        if completed.returncode != 0:
+            raise RuntimeError(
+                "parallel CuTeDSL precompilation failed:\n" + _driver_error(completed)
+            )
+
+
+def compile_many(
+    fn: Callable[..., T],
+    calls: Iterable[tuple[Any, ...]],
+    *,
+    workers: int | None = None,
+    target: CompileTarget | None = None,
+    timeout: float | None = DEFAULT_COMPILE_TIMEOUT_SECONDS,
+) -> list[T]:
+    """Compile variants in parallel, then load them sequentially in the caller."""
+    call_args = _materialize_calls(calls)
+    precompile_many(
+        fn,
+        call_args,
+        workers=workers,
+        target=target,
+        timeout=timeout,
+    )
+    return [fn(*args) for args in call_args]

--- a/attn_gym/_backends/cute/tune.py
+++ b/attn_gym/_backends/cute/tune.py
@@ -1,0 +1,218 @@
+"""Explicit compile-and-benchmark tuning for cached CuTeDSL variants."""
+
+from __future__ import annotations
+
+import functools
+import inspect
+import math
+import statistics
+from collections.abc import Callable, Iterable
+from typing import Any, Protocol, TypeVar
+
+from .compile import (
+    DEFAULT_COMPILE_TIMEOUT_SECONDS,
+    _materialize_calls,
+    compile_many,
+)
+from .target import CompileTarget, set_compile_target
+
+ConfigT = TypeVar("ConfigT")
+CompiledT = TypeVar("CompiledT")
+
+
+class TunableKernel(Protocol[ConfigT, CompiledT]):
+    """Convention consumed by :func:`run_tunable`."""
+
+    default_config: ConfigT
+
+    def configs(self, *runtime_args: Any) -> Iterable[ConfigT]: ...
+
+    def compile(self, *args: Any) -> CompiledT: ...
+
+    def compile_call(
+        self,
+        config: ConfigT,
+        *runtime_args: Any,
+    ) -> tuple[Any, ...]: ...
+
+    def launch(
+        self,
+        compiled: CompiledT,
+        config: ConfigT,
+        *runtime_args: Any,
+    ) -> Any: ...
+
+
+def benchmark_gpu(
+    fn: Callable[[], Any],
+    *,
+    estimation_iters: int = 5,
+    memory_warmup_iters: int = 100,
+    benchmark_iters: int = 100,
+    max_benchmark_duration: int = 25,
+) -> float:
+    """Return median GPU latency in milliseconds using Inductor's benchmarker.
+
+    Inductor performs CUDA-event timing and L2-cache warmup/flush work. Keyword
+    support is detected at runtime so this helper remains usable across the
+    Torch versions supported by Attention Gym.
+    """
+    from torch._inductor.runtime.benchmarking import benchmarker
+
+    supported = inspect.signature(benchmarker.benchmark_gpu).parameters
+    options = {
+        "estimation_iters": estimation_iters,
+        "memory_warmup_iters": memory_warmup_iters,
+        "benchmark_iters": benchmark_iters,
+        "max_benchmark_duration": max_benchmark_duration,
+        "return_mode": "all",
+        "is_vetted_benchmarking": True,
+    }
+    timings = benchmarker.benchmark_gpu(
+        fn,
+        **{name: value for name, value in options.items() if name in supported},
+    )
+    if isinstance(timings, list):
+        if not timings:
+            raise RuntimeError("Inductor benchmarker returned no GPU timings")
+        return float(statistics.median(timings))
+    return float(timings)
+
+
+def tune(
+    configs: Iterable[ConfigT],
+    compile_fn: Callable[..., CompiledT],
+    launch: Callable[[CompiledT, ConfigT], Any],
+    *,
+    benchmark: Callable[[Callable[[], Any]], float] | None = None,
+    compile_call: Callable[[ConfigT], tuple[Any, ...]] | None = None,
+    parallel_compile: bool = True,
+    workers: int | None = None,
+    target: CompileTarget | None = None,
+    timeout: float | None = DEFAULT_COMPILE_TIMEOUT_SECONDS,
+) -> ConfigT:
+    """Compile candidates, benchmark GPU launches sequentially, and return the fastest.
+
+    The common case passes each config as the compile function's sole argument
+    and uses the default Inductor GPU benchmarker::
+
+        best = tune(
+            configs,
+            compile_kernel,
+            lambda kernel, config: kernel(*runtime_arguments),
+        )
+
+    Cold variants can be populated concurrently. Module-scope ``NamedTuple``
+    and dataclass configs work directly. A warm invocation skips the compiler
+    process, loads every requested artifact, and benchmarks again.
+    ``benchmark`` may replace the default timing policy; it receives a zero-arg
+    callable for one candidate launch. Kernels with destructive or stateful
+    inputs should use that hook to restore state between measurements.
+
+    Use ``compile_call`` when the compile function needs additional static
+    arguments::
+
+        best = tune(
+            configs,
+            compile_kernel,
+            launch,
+            compile_call=lambda config: (head_dim, config),
+        )
+    """
+    candidates = list(configs)
+    if not candidates:
+        raise ValueError("tune() requires at least one config")
+    if workers is not None and workers < 1:
+        raise ValueError(f"workers must be positive, got {workers}")
+    if not callable(getattr(compile_fn, "precompile", None)):
+        raise TypeError("tune() requires a compile function decorated with jit_cache")
+
+    if compile_call is None:
+        calls = [(config,) for config in candidates]
+    else:
+        calls = _materialize_calls(compile_call(config) for config in candidates)
+
+    if parallel_compile and len(calls) > 1:
+        compiled_candidates = compile_many(
+            compile_fn,
+            calls,
+            workers=workers,
+            target=target,
+            timeout=timeout,
+        )
+    else:
+        if target is not None:
+            set_compile_target(target)
+        compiled_candidates = [compile_fn(*args) for args in calls]
+
+    measure = benchmark_gpu if benchmark is None else benchmark
+    timings = []
+    for compiled, config in zip(compiled_candidates, candidates):
+        timing = float(measure(functools.partial(launch, compiled, config)))
+        if math.isnan(timing):
+            raise ValueError(f"benchmark returned NaN for config {config!r}")
+        timings.append(timing)
+    return candidates[min(range(len(candidates)), key=timings.__getitem__)]
+
+
+def run_tunable(
+    kernel: TunableKernel[ConfigT, CompiledT],
+    *runtime_args: Any,
+    config: ConfigT | None = None,
+    autotune: bool = False,
+    configs: Iterable[ConfigT] | None = None,
+    benchmark: Callable[[Callable[[], Any]], float] | None = None,
+    parallel_compile: bool = True,
+    workers: int | None = None,
+    target: CompileTarget | None = None,
+    timeout: float | None = DEFAULT_COMPILE_TIMEOUT_SECONDS,
+) -> tuple[Any, ConfigT]:
+    """Select, compile, and launch an op following the tunable-kernel convention.
+
+    ``kernel`` supplies ``default_config``, an input-aware
+    ``configs(*runtime_args)`` method, a cached ``compile`` function, and
+    ``compile_call``/``launch`` adapters. This keeps candidate generation and
+    fake-tensor ABI construction in the kernel implementation while public
+    PyTorch entrypoints only choose between a default, explicit config, or
+    autotuning. Passing ``configs=`` overrides the kernel's candidate method.
+
+    The return value is ``(launch_result, selected_config)``. Autotuning still
+    compiles candidates in parallel and benchmarks launches sequentially, then
+    performs one final launch with the winner.
+    """
+    if autotune and config is not None:
+        raise ValueError("pass either config= or autotune=True, not both")
+    if not autotune and configs is not None:
+        raise ValueError("configs= requires autotune=True")
+
+    compile_fn = kernel.compile
+    if not callable(getattr(compile_fn, "precompile", None)):
+        raise TypeError("run_tunable() requires kernel.compile decorated with jit_cache")
+    if autotune:
+        candidates = kernel.configs(*runtime_args) if configs is None else configs
+
+        def launch(compiled: CompiledT, candidate: ConfigT) -> Any:
+            return kernel.launch(compiled, candidate, *runtime_args)
+
+        selected = tune(
+            candidates,
+            compile_fn,
+            launch,
+            benchmark=benchmark,
+            compile_call=lambda candidate: kernel.compile_call(candidate, *runtime_args),
+            parallel_compile=parallel_compile,
+            workers=workers,
+            target=target,
+            timeout=timeout,
+        )
+    else:
+        selected = kernel.default_config if config is None else config
+        if target is not None:
+            set_compile_target(target)
+
+    call_args = _materialize_calls((kernel.compile_call(selected, *runtime_args),))[0]
+    compiled = compile_fn(*call_args)
+    return kernel.launch(compiled, selected, *runtime_args), selected
+
+
+__all__ = ["TunableKernel", "benchmark_gpu", "run_tunable", "tune"]

--- a/test/test_cute_cache.py
+++ b/test/test_cute_cache.py
@@ -1,17 +1,32 @@
 from __future__ import annotations
 
 import multiprocessing
+import os
 import sys
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from typing import NamedTuple
 
 import pytest
 
 from attn_gym._backends.cute import cache as cute_cache
+from attn_gym._backends.cute import compile as cute_compile
 from attn_gym._backends.cute import target as cute_target
+from attn_gym._backends.cute.tune import benchmark_gpu, run_tunable, tune
 from attn_gym._backends.cute.utils import compile_tvm_ffi
+
+_DRIVER_LOG_ENV = "ATTN_GYM_TEST_CUTE_DRIVER_LOG"
+_DRIVER_READY_ENV = "ATTN_GYM_TEST_CUTE_DRIVER_READY"
+_DRIVER_EXPECTED_ENV = "ATTN_GYM_TEST_CUTE_DRIVER_EXPECTED"
+
+
+class CompileConfig(NamedTuple):
+    """Typed static config used across the JSON exec boundary."""
+
+    variant: str
+    timing: float
 
 
 class FakeCompiled:
@@ -33,6 +48,33 @@ def load_fake_compiled(path: Path) -> FakeCompiled:
     if separator != ":" or function_name != cute_cache.EXPORT_FUNCTION_NAME:
         raise RuntimeError("corrupt test artifact")
     return FakeCompiled(value)
+
+
+def measure_return_value(fn) -> float:
+    """Use a launch's return value as a deterministic unit-test timing."""
+    return float(fn())
+
+
+@cute_cache.jit_cache
+def compile_test_variant(config: CompileConfig) -> FakeCompiled:
+    """Importable fake compiler used to exercise the fresh compiler process."""
+    ready_directory = os.getenv(_DRIVER_READY_ENV)
+    expected = int(os.getenv(_DRIVER_EXPECTED_ENV, "0"))
+    if ready_directory and expected:
+        ready_path = Path(ready_directory)
+        ready_path.mkdir(parents=True, exist_ok=True)
+        (ready_path / f"{config.variant}-{os.getpid()}.ready").touch()
+        deadline = time.monotonic() + 10
+        while len(list(ready_path.glob("*.ready"))) < expected:
+            if time.monotonic() >= deadline:
+                raise RuntimeError("compiler workers did not run concurrently")
+            time.sleep(0.01)
+
+    log_path = os.getenv(_DRIVER_LOG_ENV)
+    if log_path:
+        with Path(log_path).open("a") as log:
+            log.write(f"{os.getpid()},{os.getppid()},{config.variant}\n")
+    return FakeCompiled(config.variant)
 
 
 def wait_for_processes(processes, timeout: float = 15.0) -> None:
@@ -131,6 +173,211 @@ def test_compile_tvm_ffi_adds_fake_stream_and_typed_option(monkeypatch):
         "args": (fake_tensor, fake_stream),
         "kwargs": {"_name_prefix": "stable_kernel_name"},
     }
+
+
+def test_benchmark_gpu_uses_inductor_benchmarker(monkeypatch):
+    import torch._inductor.runtime.benchmarking as inductor_benchmarking
+
+    launches = []
+    observed = {}
+
+    class FakeBenchmarker:
+        def benchmark_gpu(
+            self,
+            fn,
+            estimation_iters,
+            memory_warmup_iters,
+            benchmark_iters,
+            max_benchmark_duration,
+            return_mode,
+            is_vetted_benchmarking,
+        ):
+            fn()
+            observed.update(
+                estimation_iters=estimation_iters,
+                memory_warmup_iters=memory_warmup_iters,
+                benchmark_iters=benchmark_iters,
+                max_benchmark_duration=max_benchmark_duration,
+                return_mode=return_mode,
+                is_vetted_benchmarking=is_vetted_benchmarking,
+            )
+            return [0.003, 0.001, 0.002]
+
+    monkeypatch.setattr(inductor_benchmarking, "benchmarker", FakeBenchmarker())
+
+    timing = benchmark_gpu(
+        lambda: launches.append("launch"),
+        estimation_iters=2,
+        memory_warmup_iters=3,
+        benchmark_iters=4,
+        max_benchmark_duration=5,
+    )
+
+    assert timing == pytest.approx(0.002)
+    assert launches == ["launch"]
+    assert observed == {
+        "estimation_iters": 2,
+        "memory_warmup_iters": 3,
+        "benchmark_iters": 4,
+        "max_benchmark_duration": 5,
+        "return_mode": "all",
+        "is_vetted_benchmarking": True,
+    }
+
+
+def test_tune_sequential_option_caches_every_named_tuple_config(isolated_cache):
+    compile_count = 0
+    configs = (
+        CompileConfig("slow", 3.0),
+        CompileConfig("fast", 1.0),
+        CompileConfig("medium", 2.0),
+    )
+
+    @cute_cache.jit_cache
+    def compile_kernel(config: CompileConfig) -> FakeCompiled:
+        nonlocal compile_count
+        compile_count += 1
+        return FakeCompiled(config.variant)
+
+    benchmark_order = []
+
+    def launch(compiled: FakeCompiled, config: CompileConfig) -> float:
+        assert compiled() == config.variant
+        benchmark_order.append(config.variant)
+        return config.timing
+
+    best = tune(
+        configs,
+        compile_kernel,
+        launch,
+        benchmark=measure_return_value,
+        parallel_compile=False,
+    )
+
+    assert best is configs[1]
+    assert benchmark_order == ["slow", "fast", "medium"]
+    assert compile_count == len(configs)
+    assert len(list(isolated_cache.rglob("*.o"))) == len(configs)
+
+    compile_kernel.cache_clear()
+    benchmark_order.clear()
+    assert (
+        tune(
+            configs,
+            compile_kernel,
+            launch,
+            benchmark=measure_return_value,
+            parallel_compile=False,
+        )
+        is configs[1]
+    )
+    assert benchmark_order == ["slow", "fast", "medium"]
+    assert compile_count == len(configs)
+    assert compile_kernel.cache_info() == cute_cache.CacheInfo(
+        hits=len(configs),
+        misses=0,
+        currsize=len(configs),
+    )
+
+
+def test_run_tunable_uses_kernel_convention(isolated_cache):
+    candidates = (
+        CompileConfig("default", 3.0),
+        CompileConfig("fast", 1.0),
+        CompileConfig("medium", 2.0),
+    )
+    compile_count = 0
+    config_requests = []
+    launches = []
+
+    class ToyKernel:
+        default_config = candidates[0]
+
+        @staticmethod
+        def configs(prefix: str, _launch_log):
+            config_requests.append(prefix)
+            return candidates
+
+        @staticmethod
+        @cute_cache.jit_cache
+        def compile(prefix: str, config: CompileConfig) -> FakeCompiled:
+            nonlocal compile_count
+            compile_count += 1
+            return FakeCompiled(f"{prefix}:{config.variant}")
+
+        @staticmethod
+        def compile_call(config: CompileConfig, prefix: str, _launches):
+            return prefix, config
+
+        @staticmethod
+        def launch(
+            compiled: FakeCompiled,
+            config: CompileConfig,
+            prefix: str,
+            launch_log,
+        ) -> float:
+            assert compiled() == f"{prefix}:{config.variant}"
+            launch_log.append(config.variant)
+            return config.timing
+
+    result, best = run_tunable(
+        ToyKernel,
+        "toy",
+        launches,
+        autotune=True,
+        benchmark=measure_return_value,
+        parallel_compile=False,
+    )
+
+    assert best is candidates[1]
+    assert result == best.timing
+    assert launches == [config.variant for config in candidates] + [best.variant]
+    assert config_requests == ["toy"]
+    assert compile_count == len(candidates)
+    assert len(list(isolated_cache.rglob("*.o"))) == len(candidates)
+
+    launches.clear()
+    result, selected = run_tunable(ToyKernel, "toy", launches)
+    assert selected is ToyKernel.default_config
+    assert result == selected.timing
+    assert launches == [selected.variant]
+    assert config_requests == ["toy"]
+    assert compile_count == len(candidates)
+
+    launches.clear()
+    override = (candidates[2],)
+    result, selected = run_tunable(
+        ToyKernel,
+        "toy",
+        launches,
+        autotune=True,
+        configs=override,
+        benchmark=measure_return_value,
+        parallel_compile=False,
+    )
+    assert selected is override[0]
+    assert result == selected.timing
+    assert launches == [selected.variant, selected.variant]
+    assert config_requests == ["toy"]
+
+    with pytest.raises(ValueError, match="either config= or autotune=True"):
+        run_tunable(
+            ToyKernel,
+            "toy",
+            launches,
+            config=candidates[0],
+            autotune=True,
+        )
+    with pytest.raises(ValueError, match="configs= requires autotune=True"):
+        run_tunable(ToyKernel, "toy", launches, configs=candidates)
+
+    class InvalidCompileCall(ToyKernel):
+        @staticmethod
+        def compile_call(_config, prefix, _launch_log):
+            return prefix
+
+    with pytest.raises(TypeError, match="tuple of positional static arguments"):
+        run_tunable(InvalidCompileCall, "toy", launches)
 
 
 def test_same_key_compiles_once_across_threads(isolated_cache):
@@ -255,6 +502,77 @@ def test_explicit_target_avoids_device_discovery(monkeypatch):
     cute_target.set_compile_target(target)
 
     assert cute_target.get_compile_target() == target
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="fork is required")
+def test_fresh_compile_driver_forks_parallel_workers(tmp_path, monkeypatch):
+    pytest.importorskip("cutlass")
+    pytest.importorskip("tvm_ffi")
+    cache_directory = tmp_path / "cache"
+    log_path = tmp_path / "compiles.log"
+    ready_directory = tmp_path / "ready"
+    configs = tuple(CompileConfig(str(index), float(index + 1)) for index in range(4))
+    shared = CompileConfig("shared", 0.5)
+    monkeypatch.setenv("ATTN_GYM_CUTE_CACHE_DIR", str(cache_directory))
+    monkeypatch.delenv("CUTE_DSL_NO_CACHE", raising=False)
+    monkeypatch.setenv(_DRIVER_LOG_ENV, str(log_path))
+    monkeypatch.setenv(_DRIVER_READY_ENV, str(ready_directory))
+    monkeypatch.setenv(_DRIVER_EXPECTED_ENV, str(len(configs)))
+    monkeypatch.setattr(cute_cache, "_load_compiled", load_fake_compiled)
+    compile_test_variant.cache_clear()
+    target = cute_target.CompileTarget(
+        device_type="cuda",
+        capability=(10, 0),
+        name="test-gpu",
+        sm_count=100,
+    )
+    benchmark_order = []
+
+    def launch(compiled: FakeCompiled, config: CompileConfig) -> float:
+        assert compiled() == config.variant
+        benchmark_order.append(config.variant)
+        return config.timing
+
+    best = tune(
+        configs + (shared,) * 4,
+        compile_test_variant,
+        launch,
+        benchmark=measure_return_value,
+        workers=len(configs),
+        target=target,
+    )
+
+    assert best is shared
+    assert benchmark_order == [config.variant for config in configs] + ["shared"] * 4
+    records = [line.split(",") for line in log_path.read_text().splitlines()]
+    variant_records = [record for record in records if record[2] != "shared"]
+    worker_pids = {int(record[0]) for record in variant_records}
+    driver_pids = {int(record[1]) for record in records}
+    assert {record[2] for record in variant_records} == {config.variant for config in configs}
+    assert sum(record[2] == "shared" for record in records) == 1
+    assert len(worker_pids) == len(configs)
+    assert len(driver_pids) == 1
+    assert os.getpid() not in driver_pids
+    assert len(list(cache_directory.rglob("*.o"))) == len(configs) + 1
+
+    def unexpected_driver(*args, **kwargs):
+        raise AssertionError("a fully warm tune started a compiler process")
+
+    compile_test_variant.cache_clear()
+    benchmark_order.clear()
+    monkeypatch.setattr(cute_compile.subprocess, "run", unexpected_driver)
+    assert (
+        tune(
+            configs + (shared,),
+            compile_test_variant,
+            launch,
+            benchmark=measure_return_value,
+            workers=len(configs),
+            target=target,
+        )
+        is shared
+    )
+    assert benchmark_order == [config.variant for config in configs] + ["shared"]
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="fcntl.flock and fork are required")

--- a/test/test_cute_cache_gpu.py
+++ b/test/test_cute_cache_gpu.py
@@ -1,0 +1,113 @@
+import os
+from pathlib import Path
+
+import pytest
+import torch
+
+from attn_gym._backends.cute.cache import CacheInfo, jit_cache
+from attn_gym._backends.cute.target import detect_compile_target
+from attn_gym._backends.cute.tune import tune
+from attn_gym._backends.cute.utils import compile_tvm_ffi
+
+cutlass = pytest.importorskip("cutlass")
+cute = pytest.importorskip("cutlass.cute")
+
+
+_THREADS = 64
+_TOY_VARIANTS = (16, 32)
+
+
+@cute.kernel
+def copy_kernel(source: cute.Tensor, destination: cute.Tensor):
+    """Copy one tiny vector for cache export/load validation."""
+    thread_idx, _, _ = cute.arch.thread_idx()
+    if thread_idx < cute.size(source):
+        destination[thread_idx] = source[thread_idx]
+
+
+@cute.jit
+def launch_copy(source: cute.Tensor, destination: cute.Tensor, stream):
+    """Launch the toy cache validation kernel."""
+    copy_kernel(source, destination, _name_prefix="attention_gym_cache_copy").launch(
+        grid=(1, 1, 1),
+        block=(_THREADS, 1, 1),
+        stream=stream,
+    )
+
+
+@jit_cache
+def compile_copy(vector_size: int):
+    """Compile one static vector-size variant with a TVM-FFI signature."""
+    compile_log = os.getenv("ATTN_GYM_TEST_CUTE_GPU_COMPILE_LOG")
+    if compile_log:
+        is_bad_fork = getattr(torch.cuda, "_is_in_bad_fork", lambda: False)()
+        with Path(compile_log).open("a") as log:
+            log.write(f"{os.getpid()},{vector_size},{int(is_bad_fork)}\n")
+    source = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (vector_size,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    destination = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (vector_size,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    return compile_tvm_ffi(
+        launch_copy,
+        source,
+        destination,
+        name=f"attention_gym_cache_copy_n{vector_size}",
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_parallel_compile_then_inductor_benchmark(tmp_path, monkeypatch):
+    """A CUDA-owning parent benchmarks variants compiled by offline workers."""
+    cache_directory = tmp_path / "cache"
+    compile_log = tmp_path / "compiles.log"
+    monkeypatch.setenv("ATTN_GYM_CUTE_CACHE_DIR", str(cache_directory))
+    monkeypatch.setenv("ATTN_GYM_TEST_CUTE_GPU_COMPILE_LOG", str(compile_log))
+    monkeypatch.delenv("CUTE_DSL_NO_CACHE", raising=False)
+    compile_copy.cache_clear()
+
+    # Initialize CUDA before creating the fresh compiler process. A direct fork would be poisoned.
+    tensors = {
+        vector_size: (
+            torch.randn(vector_size, device="cuda"),
+            torch.empty(vector_size, device="cuda"),
+        )
+        for vector_size in _TOY_VARIANTS
+    }
+    target = detect_compile_target()
+
+    def launch(compiled, vector_size):
+        source, destination = tensors[vector_size]
+        compiled(source, destination)
+
+    best = tune(
+        _TOY_VARIANTS,
+        compile_copy,
+        launch,
+        workers=len(_TOY_VARIANTS),
+        target=target,
+    )
+
+    assert best in _TOY_VARIANTS
+
+    compile_records = [line.split(",") for line in compile_log.read_text().splitlines()]
+    assert len(compile_records) == len(_TOY_VARIANTS)
+    assert all(record[2] == "1" for record in compile_records)
+    assert len(list(cache_directory.rglob("*.o"))) == len(_TOY_VARIANTS)
+    assert compile_copy.cache_info() == CacheInfo(
+        hits=len(_TOY_VARIANTS),
+        misses=0,
+        currsize=len(_TOY_VARIANTS),
+    )
+
+    for vector_size in _TOY_VARIANTS:
+        source, destination = tensors[vector_size]
+        compile_copy(vector_size)(source, destination)
+        torch.testing.assert_close(destination, source)


### PR DESCRIPTION
Stacked PRs:
 * #248
 * #247
 * __->__#246
 * #245


--- --- ---

Add parallel CuTeDSL tuning

Human Note

Agent note
A CUDA-owning process cannot safely fork workers that rediscover the device or inherit CuTeDSL
compiler state. Add a fresh interpreter driver that receives only static, pickleable compile calls
and parent-discovered target metadata, imports the cached compile function once, then forks bounded
workers to populate distinct disk artifacts. The parent loads those artifacts and benchmarks each
candidate sequentially with Inductor's CUDA benchmarker.

Expose `run_tunable` as the author-facing boundary. An op owns a conservative default, an
input-aware typed config generator, a projection from runtime tensors to positional static compile
arguments, and a launch adapter. Runtime tensors never cross the compiler-process boundary, and a
fully warm tune starts no compiler process.

Test Plan:

```bash
~/.venvs/nightly/bin/python -m pytest -q test/test_cute_cache.py
gpu-run 0 -- ~/.venvs/nightly/bin/python -m pytest -q test/test_cute_cache_gpu.py
~/.venvs/dev/bin/ruff check attn_gym/_backends/cute test/test_cute_cache.py test/test_cute_cache_gpu.py
```