### PR TITLE
Add tunable CuTeDSL kernel skill

### DIFF
--- a/.agents/skills/cutedsl-tunable-kernel-template/SKILL.md
+++ b/.agents/skills/cutedsl-tunable-kernel-template/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: cutedsl-tunable-kernel-template
+description: Adds an Attention Gym tuning adapter to a CuTeDSL op using typed input-aware configs, cached fake-tensor TVM-FFI compilation, parallel candidate compilation, and sequential GPU benchmarking. Use after the core kernel exists and needs a public default, explicit-config, or autotune path.
+---
+
+# Tunable CuTeDSL Kernel Template
+
+Use this after `cutedsl-kernel-template` establishes the core kernel. This skill owns the Attention Gym adapter and parent/compiler-process boundary. Load `cutedsl-performance` separately to design the search space, measure candidates, and accept a selector.
+
+The canonical Attention Gym helpers are:
+
+```python
+from attn_gym._backends.cute import compile_tvm_ffi, jit_cache, run_tunable
+```
+
+If another repo has equivalent helpers, reuse them. Do not rebuild cache/process orchestration inside each op.
+
+## Ownership Boundary
+
+Keep each value in one domain:
+
+| Value | Owner |
+|---|---|
+| Real `torch.Tensor` inputs and outputs | Parent process and public wrapper |
+| Candidate generation from shapes/dtypes/device facts | `configs(*runtime_args)` in the parent |
+| Static, pickleable specialization values | Config record and `compile_call(...)` result |
+| Fake CuTe tensors matching the runtime ABI | Cached `compile(...)` method |
+| Fake environment stream and typed TVM-FFI option | `compile_tvm_ffi(...)` |
+| Compiled callable launch and benchmarking | Parent process through `launch(...)` |
+
+Never pass real tensors to `compile(...)` or compiler workers. `compile_call(...)` is the explicit projection from runtime inputs to static compile arguments.
+
+## Minimal Kernel Convention
+
+Use a module-scope `NamedTuple` or frozen dataclass for codegen choices. Module scope makes the config importable and pickleable by fresh compiler processes.
+
+```python
+from typing import NamedTuple
+
+
+class MyConfig(NamedTuple):
+    threads: int
+    tile_size: int
+```
+
+The internal op supplies five distinct pieces:
+
+```python
+class _MyOp:
+    default_config = MyConfig(threads=128, tile_size=256)
+
+    @staticmethod
+    def configs(*runtime_args) -> tuple[MyConfig, ...]:
+        """Return valid candidates derived from actual runtime inputs."""
+        ...
+
+    @staticmethod
+    @jit_cache
+    def compile(*static_args):
+        """Construct the fake ABI and compile one specialization."""
+        ...
+
+    @staticmethod
+    def compile_call(config: MyConfig, *runtime_args) -> tuple:
+        """Project runtime inputs to static arguments for compile(...)."""
+        ...
+
+    @staticmethod
+    def launch(compiled, config: MyConfig, *runtime_args):
+        """Launch in the parent with real tensors and return the public result."""
+        ...
+```
+
+These members should not be merged:
+
+- `default_config` provides a no-tuning path.
+- `configs(...)` may inspect runtime shape, stride, dtype, alignment, or device facts.
+- `compile(...)` owns fake tensors and the cached artifact boundary.
+- `compile_call(...)` prevents runtime tensors from leaking into cache keys or subprocess payloads.
+- `launch(...)` binds the compiled callable to real tensors for correctness checks and timing.
+
+## Public Wrapper
+
+Users call one ordinary PyTorch function; they do not construct op objects or compiled callables.
+
+```python
+def my_op(
+    x: torch.Tensor,
+    *,
+    config: MyConfig | None = None,
+    tune: bool = False,
+    configs: Iterable[MyConfig] | None = None,
+) -> torch.Tensor:
+    y = torch.empty_like(x)
+    result, _selected = run_tunable(
+        _MyOp,
+        x,
+        y,
+        config=config,
+        autotune=tune,
+        configs=configs,
+    )
+    return result
+```
+
+This gives three intentional modes:
+
+```python
+my_op(x)                                      # conservative default
+my_op(x, config=MyConfig(64, 128))            # force one specialization
+my_op(x, tune=True)                           # input-aware candidate method
+my_op(x, tune=True, configs=(cfg_a, cfg_b))   # explicit candidate override
+```
+
+Reject `config=` with tuning and reject `configs=` without tuning rather than silently ignoring either argument.
+
+## Compile Contract
+
+Inside `compile(...)`:
+
+1. Accept only static values that completely determine generated code and the fake ABI.
+2. Build fake compact tensors with runtime-compatible shapes, strides, dtype, and assumed alignment.
+3. Instantiate any internal CuTeDSL op object there; never require public callers to construct it.
+4. Call `compile_tvm_ffi(...)` with a stable lowercase config-derived name.
+5. Return the compiled TVM-FFI callable directly.
+
+```python
+@staticmethod
+@jit_cache
+def compile(num_elements: int, config: MyConfig):
+    source = cute.runtime.make_fake_compact_tensor(...)
+    destination = cute.runtime.make_fake_compact_tensor(...)
+    op = _MyOp()
+    return compile_tvm_ffi(
+        op._jit_entrypoint,
+        source,
+        destination,
+        num_elements,
+        config.threads,
+        config.tile_size,
+        name=op.get_name(num_elements, config),
+    )
+```
+
+`compile_tvm_ffi` owns the typed TVM-FFI option and fake environment stream. Do not append another stream or pass string compiler options at call sites. `compile_call(...)` returns exactly one tuple of positional static arguments; use `(config,)` when `compile(...)` accepts only a config.
+
+## Tune Flow
+
+For `tune=True`, `run_tunable` should:
+
+1. Use the explicit `configs=` iterable, otherwise call `kernel.configs(*runtime_args)` once.
+2. Map each candidate through `compile_call(...)`.
+3. Populate cold disk-cache entries in parallel compiler workers.
+4. Load and benchmark candidates sequentially in the CUDA-owning parent.
+5. Compile/load the winner through the same cache boundary and perform one final launch.
+
+Before enabling tuning, force every generated candidate through `config=` in correctness tests and compare it with an independent reference; a benchmark cannot detect a wrong fast candidate. Direct benchmarking also assumes repeatable launches. Destructive or stateful ops must provide a `benchmark=` hook that restores inputs between measurements.
+
+A fully warm run must not start the compiler process. It still benchmarks requested candidates unless a separate baked selector chooses one without tuning.
+
+## Example
+
+Read or run [copy_reads_example.py](copy_reads_example.py) for a complete toy kernel using an input-aware `ReadConfig` search space and a single public `copy_reads(...)` entrypoint.
+
+## Validation
+
+- Put the cache under a temporary directory in tests.
+- Test default, explicit config, generated candidates, and explicit candidate override.
+- Correctness-check every candidate against an independent reference before benchmarking.
+- Verify all cold candidates produce distinct artifacts and a warm run launches no compiler process.
+- Keep real GPU coverage tiny: compile a toy kernel, benchmark with Inductor's GPU benchmarker, launch the winner, and compare output with an independent reference.
+- Measure cold and warm wall time locally, but do not make noisy scaling timing a correctness assertion.

--- a/.agents/skills/cutedsl-tunable-kernel-template/copy_reads_example.py
+++ b/.agents/skills/cutedsl-tunable-kernel-template/copy_reads_example.py
@@ -1,0 +1,217 @@
+"""Runnable input-aware CuTeDSL compile/cache/tune example.
+
+Run this from an environment containing Attention Gym and CuTeDSL. Reuse the
+same cache directory to compare cold and warm behavior::
+
+    ATTN_GYM_CUTE_CACHE_DIR=/tmp/cute-playground \
+        python .agents/skills/cutedsl-tunable-kernel-template/copy_reads_example.py
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable, Iterable
+from typing import Any, NamedTuple
+
+import cutlass
+import torch
+from cutlass import cute
+
+from attn_gym._backends.cute import benchmark_gpu, compile_tvm_ffi, jit_cache, run_tunable
+from attn_gym._backends.cute.cache import get_cache_path
+
+NUM_ELEMENTS = 1 << 24
+
+
+class ReadConfig(NamedTuple):
+    threads: int
+    reads: int
+
+
+class _CopyReadsOp:
+    """Internal tunable CuTeDSL op; users call :func:`copy_reads`."""
+
+    default_config = ReadConfig(128, 2)
+
+    @staticmethod
+    def configs(
+        source: torch.Tensor,
+        *_runtime_args: Any,
+    ) -> tuple[ReadConfig, ...]:
+        """Generate candidates that are sensible for this input shape."""
+        max_threads = max(64, min(256, source.numel()))
+        reads_per_thread = (1,) if source.numel() < 4 else (1, 2, 4)
+        return tuple(
+            ReadConfig(threads, reads)
+            for threads in (64, 128, 256)
+            if threads <= max_threads
+            for reads in reads_per_thread
+        )
+
+    @staticmethod
+    def _name(num_elements: int, threads: int, reads: int) -> str:
+        return f"cute_playground_n{num_elements}_t{threads}_r{reads}"
+
+    @cute.kernel
+    def _kernel(
+        self,
+        source: cute.Tensor,
+        destination: cute.Tensor,
+        threads: cutlass.Constexpr,
+        reads: cutlass.Constexpr,
+    ):
+        """Have each thread copy several values; every iteration is coalesced."""
+        tid = cute.arch.thread_idx()[0]
+        block = cute.arch.block_idx()[0]
+        block_start = block * threads * reads
+
+        # ``reads`` is static, so CuTeDSL unrolls this loop for each config.
+        for read in cutlass.range_constexpr(reads):
+            index = block_start + read * threads + tid
+            if index < cute.size(source):
+                destination[index] = source[index]
+
+    @cute.jit
+    def _launch(
+        self,
+        source: cute.Tensor,
+        destination: cute.Tensor,
+        num_elements: cutlass.Constexpr,
+        threads: cutlass.Constexpr,
+        reads: cutlass.Constexpr,
+        stream,
+    ):
+        blocks = (num_elements + threads * reads - 1) // (threads * reads)
+        self._kernel(
+            source,
+            destination,
+            threads,
+            reads,
+            _name_prefix=self._name(num_elements, threads, reads),
+        ).launch(
+            grid=(blocks, 1, 1),
+            block=(threads, 1, 1),
+            stream=stream,
+        )
+
+    @staticmethod
+    @jit_cache
+    def compile(num_elements: int, config: ReadConfig):
+        """Build the fake ABI internally when this specialization misses cache."""
+        source = cute.runtime.make_fake_compact_tensor(
+            cutlass.Float32,
+            (num_elements,),
+            stride_order=(0,),
+            assumed_align=16,
+        )
+        destination = cute.runtime.make_fake_compact_tensor(
+            cutlass.Float32,
+            (num_elements,),
+            stride_order=(0,),
+            assumed_align=16,
+        )
+        op = _CopyReadsOp()
+        return compile_tvm_ffi(
+            op._launch,
+            source,
+            destination,
+            num_elements,
+            config.threads,
+            config.reads,
+            name=op._name(num_elements, config.threads, config.reads),
+        )
+
+    @staticmethod
+    def compile_call(
+        config: ReadConfig,
+        source: torch.Tensor,
+        _destination: torch.Tensor,
+    ) -> tuple[int, ReadConfig]:
+        return source.numel(), config
+
+    @staticmethod
+    def launch(
+        compiled,
+        _config: ReadConfig,
+        source: torch.Tensor,
+        destination: torch.Tensor,
+    ) -> torch.Tensor:
+        compiled(source, destination)
+        return destination
+
+
+def copy_reads(
+    source: torch.Tensor,
+    *,
+    config: ReadConfig | None = None,
+    tune: bool = False,
+    configs: Iterable[ReadConfig] | None = None,
+    workers: int = 4,
+    benchmark: Callable[[Callable[[], Any]], float] | None = None,
+) -> torch.Tensor:
+    """Copy a real PyTorch tensor using a selected or freshly tuned kernel.
+
+    ``copy_reads(source)`` uses the op's ``default_config``. Pass ``config=...`` to
+    force one specialization. ``tune=True`` asks the op to generate candidates
+    from the runtime inputs; passing ``configs=...`` overrides those candidates.
+    """
+    if source.ndim != 1 or source.dtype != torch.float32 or not source.is_cuda:
+        raise ValueError("copy_reads expects a 1D CUDA float32 tensor")
+    if source.numel() == 0 or not source.is_contiguous() or source.data_ptr() % 16:
+        raise ValueError("copy_reads expects nonempty, contiguous, 16-byte-aligned storage")
+
+    destination = torch.empty_like(source)
+    output, _selected = run_tunable(
+        _CopyReadsOp,
+        source,
+        destination,
+        config=config,
+        autotune=tune,
+        configs=configs,
+        workers=workers,
+        benchmark=benchmark,
+    )
+    return output
+
+
+def main() -> None:
+    if not torch.cuda.is_available():
+        raise RuntimeError("this playground requires a CUDA GPU")
+
+    source = torch.randn(NUM_ELEMENTS, device="cuda", dtype=torch.float32)
+
+    # This wrapper is optional: without benchmark=report, tune() uses the same
+    # Inductor benchmark_gpu helper but only returns the winning configuration.
+    candidates = _CopyReadsOp.configs(source)
+    remaining = iter(candidates)
+    timings = {}
+
+    def report(fn):
+        config = next(remaining)  # tune benchmarks sequentially in config order
+        timings[config] = benchmark_gpu(fn)
+        print(f"{config}: {timings[config]:.4f} ms")
+        return timings[config]
+
+    started = time.perf_counter()
+    destination = copy_reads(
+        source,
+        tune=True,
+        configs=candidates,
+        benchmark=report,
+        workers=4,
+    )
+    elapsed = time.perf_counter() - started
+    torch.testing.assert_close(destination, source)
+    best = min(timings, key=timings.__getitem__)
+
+    print(f"\nbest: {best} ({timings[best]:.4f} ms)")
+    print(f"compile + benchmark wall time: {elapsed:.3f} s")
+    print(f"cache: {get_cache_path()}")
+    print("correctness: output matches input")
+
+
+if __name__ == "__main__":
+    # Give the compiler process an importable module instead of ``__main__``.
+    from copy_reads_example import main as importable_main
+
+    importable_main()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,16 @@ mkdocs build                    # static site in site/
 
 Line length: 99 chars. Python target: 3.10+. Formatter/linter: ruff.
 
+## Project-local Agent Skills
+
+Repository-specific workflows live under `.agents/skills/`. Load the matching `SKILL.md`
+before changing the covered subsystem:
+
+- [`validating-pytorch-custom-ops`](.agents/skills/validating-pytorch-custom-ops/SKILL.md) —
+  registration, fake implementations, autograd, `opcheck`, and `torch.compile` validation.
+- [`cutedsl-tunable-kernel-template`](.agents/skills/cutedsl-tunable-kernel-template/SKILL.md) —
+  typed config generation, cached TVM-FFI compilation, parallel compile, and sequential tuning.
+
 ## Agent Scratch Space
 
 If you need scratch space for intermediate files, drafts, or temporary artifacts, use the `agent_space/` directory. This directory is gitignored and will not be checked in.


### PR DESCRIPTION
Stacked PRs:
 * __->__#248
 * #247
 * #246
 * #245


--- --- ---

Add tunable CuTeDSL kernel skill

Human Note

Agent note
Document the project-local authoring convention for tunable CuTeDSL kernels. The skill makes the
parent/compiler ownership boundary explicit: runtime tensors remain in the parent, typed configs
project to positional static compile arguments, fake tensors define the cached ABI, cold variants
compile in parallel, and GPU benchmarking remains sequential.

Include a runnable `ReadConfig` copy kernel that exercises the default, explicit-config, generated
candidate, and override flows. Register both project-local skills in `AGENTS.md` so agents can find
the workflow without adding Attention Gym-specific guidance to the global dotfiles registry.

Test Plan:

```bash
~/.venvs/dev/bin/ruff check .agents/skills/cutedsl-tunable-kernel-template/copy_reads_example.py
ATTN_GYM_CUTE_CACHE_DIR=$(mktemp -d) gpu-run 0 -- ~/.venvs/nightly/bin/python \
  .agents/skills/cutedsl-tunable-kernel-template/copy_reads_example.py
```