### PR TITLE
Support strided layouts in KDA Triton helpers

### DIFF
--- a/attn_gym/_backends/triton/utils.py
+++ b/attn_gym/_backends/triton/utils.py
@@ -1,5 +1,7 @@
 """Small utilities shared by hand-written Triton kernels."""
 
+from collections.abc import Sequence
+
 import torch
 import triton
 import triton.language as tl
@@ -13,6 +15,29 @@ def ptr_offset(indices, strides: tl.constexpr):
     for axis in tl.static_range(len(strides)):
         offset += indices[axis] * strides[axis]
     return offset
+
+
+def storage_cosize(shape: Sequence[int], strides: Sequence[int]) -> int:
+    """Return the storage extent of a nonnegative-strided logical layout.
+
+    Analogous to CuTe's ``cosize``: a layout with a zero-sized dimension has
+    extent zero; otherwise the result is one plus the largest offset from the
+    logical origin.
+    """
+    if len(shape) != len(strides):
+        raise ValueError("shape and strides must have equal length")
+
+    cosize = 1
+    is_empty = False
+    for size, stride in zip(shape, strides):
+        if size < 0:
+            raise ValueError("shape dimensions must be nonnegative")
+        if stride < 0:
+            raise ValueError("strides must be nonnegative")
+        is_empty |= size == 0
+        if size > 0:
+            cosize += (size - 1) * stride
+    return 0 if is_empty else cosize
 
 
 def can_use_tma(tensor: torch.Tensor) -> bool:

--- a/attn_gym/linear/kda/bwd/triton/cumsum.py
+++ b/attn_gym/linear/kda/bwd/triton/cumsum.py
@@ -9,15 +9,16 @@
 # adjoint of a forward prefix-sum is a reverse prefix-sum), so both directions
 # are supported.
 #
-# Two layouts are handled:
-#   * scalar gates  (B, T, H)      -> chunk_local_cumsum_scalar_kernel
-#   * vector gates  (B, T, H, S)   -> chunk_local_cumsum_vector_kernel
-# with optional variable-length packing via (cu_seqlens, chunk_indices) and an
-# optional output scale.
+# The kernels use logical (B, T, H[, S]) strides, including for physical
+# head-first layouts. The leading batch stride is passed separately so Triton can
+# specialize on its alignment without treating its T-dependent value as constexpr;
+# inner strides remain constexpr for codegen. Variable-length packing and an
+# optional output scale are also supported.
 
 import triton
 import triton.language as tl
 
+from attn_gym._backends.triton.utils import ptr_offset
 from attn_gym.linear.kda.utils import autotune_cache_kwargs, check_shared_mem
 
 BS_LIST = [32, 64] if check_shared_mem() else [16, 32]
@@ -42,14 +43,18 @@ def chunk_local_cumsum_scalar_kernel(
     cu_seqlens,
     chunk_indices,
     T,
+    s_batch_stride,
+    o_batch_stride,
+    S_STRIDES: tl.constexpr,
+    O_STRIDES: tl.constexpr,
     B: tl.constexpr,
     H: tl.constexpr,
     BT: tl.constexpr,
     REVERSE: tl.constexpr,
     HAS_SCALE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
-    HEAD_FIRST: tl.constexpr,
 ):
+    tl.static_assert(not IS_VARLEN or B == 1, "packed varlen requires B == 1")
     i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1).to(tl.int64)
     i_b, i_h = i_bh // H, i_bh % H
 
@@ -62,20 +67,27 @@ def chunk_local_cumsum_scalar_kernel(
         eos = tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = eos - bos
     else:
-        bos = i_b * T
+        bos = 0
 
     o_t = i_t * BT + tl.arange(0, BT)
     m_t = o_t < T
-    if HEAD_FIRST:
-        off = bos * H + i_h * T + o_t
-    else:
-        off = bos * H + i_h + o_t * H
+    token = bos + o_t if IS_VARLEN else o_t
 
-    b_s = tl.load(s + off, mask=m_t, other=0.0).to(tl.float32)
+    s_batch_offset = i_b * s_batch_stride if B > 1 else 0
+    b_s = tl.load(
+        s + s_batch_offset + ptr_offset((token, i_h), S_STRIDES),
+        mask=m_t,
+        other=0.0,
+    ).to(tl.float32)
     b_o = tl.cumsum(b_s, axis=0, reverse=REVERSE)
     if HAS_SCALE:
         b_o = b_o * scale
-    tl.store(o + off, b_o.to(o.dtype.element_ty), mask=m_t)
+    o_batch_offset = i_b * o_batch_stride if B > 1 else 0
+    tl.store(
+        o + o_batch_offset + ptr_offset((token, i_h), O_STRIDES),
+        b_o.to(o.dtype.element_ty),
+        mask=m_t,
+    )
 
 
 @triton.heuristics(
@@ -97,6 +109,10 @@ def chunk_local_cumsum_vector_kernel(
     cu_seqlens,
     chunk_indices,
     T,
+    s_batch_stride,
+    o_batch_stride,
+    S_STRIDES: tl.constexpr,
+    O_STRIDES: tl.constexpr,
     B: tl.constexpr,
     H: tl.constexpr,
     S: tl.constexpr,
@@ -105,9 +121,9 @@ def chunk_local_cumsum_vector_kernel(
     REVERSE: tl.constexpr,
     HAS_SCALE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
-    HEAD_FIRST: tl.constexpr,
 ):
-    i_s = tl.program_id(0)
+    tl.static_assert(not IS_VARLEN or B == 1, "packed varlen requires B == 1")
+    i_s = tl.program_id(0).to(tl.int64)
     i_t = tl.program_id(1).to(tl.int64)
     i_bh = tl.program_id(2).to(tl.int64)
     i_b, i_h = i_bh // H, i_bh % H
@@ -119,20 +135,35 @@ def chunk_local_cumsum_vector_kernel(
         eos = tl.load(cu_seqlens + i_n + 1).to(tl.int64)
         T = eos - bos
     else:
-        bos = i_b * T
+        bos = 0
 
     o_t = i_t * BT + tl.arange(0, BT)
     o_s = i_s * BS + tl.arange(0, BS)
     m = (o_t[:, None] < T) & (o_s[None, :] < S)
-    # (B, T, H, S) row-major: token stride H*S, head offset i_h*S (or i_h*T*S
-    # when the head axis precedes time in a head-first packing).
-    if HEAD_FIRST:
-        off = (bos * H + i_h * T) * S + o_t[:, None] * S + o_s[None, :]
-    else:
-        off = (bos * H + i_h) * S + o_t[:, None] * (H * S) + o_s[None, :]
+    token = bos + o_t if IS_VARLEN else o_t
 
-    b_s = tl.load(s + off, mask=m, other=0.0).to(tl.float32)
+    s_batch_offset = i_b * s_batch_stride if B > 1 else 0
+    b_s = tl.load(
+        s
+        + s_batch_offset
+        + ptr_offset(
+            (token[:, None], i_h, o_s[None, :]),
+            S_STRIDES,
+        ),
+        mask=m,
+        other=0.0,
+    ).to(tl.float32)
     b_o = tl.cumsum(b_s, axis=0, reverse=REVERSE)
     if HAS_SCALE:
         b_o = b_o * scale
-    tl.store(o + off, b_o.to(o.dtype.element_ty), mask=m)
+    o_batch_offset = i_b * o_batch_stride if B > 1 else 0
+    tl.store(
+        o
+        + o_batch_offset
+        + ptr_offset(
+            (token[:, None], i_h, o_s[None, :]),
+            O_STRIDES,
+        ),
+        b_o.to(o.dtype.element_ty),
+        mask=m,
+    )

--- a/attn_gym/linear/kda/bwd/triton/gate_bwd.py
+++ b/attn_gym/linear/kda/bwd/triton/gate_bwd.py
@@ -26,6 +26,7 @@
 import triton
 import triton.language as tl
 
+from attn_gym._backends.triton.utils import ptr_offset
 from attn_gym.linear.kda.utils import autotune_cache_kwargs
 
 NUM_WARPS_AUTOTUNE = [4, 8, 16, 32]
@@ -60,6 +61,12 @@ def kda_gate_bwd_kernel(
     dA,
     lower_bound,
     T,
+    G_STRIDES: tl.constexpr,
+    A_LOG_STRIDES: tl.constexpr,
+    DT_BIAS_STRIDES: tl.constexpr,
+    DYG_STRIDES: tl.constexpr,
+    DG_STRIDES: tl.constexpr,
+    DA_STRIDES: tl.constexpr,
     H: tl.constexpr,
     D: tl.constexpr,
     BT: tl.constexpr,
@@ -67,22 +74,31 @@ def kda_gate_bwd_kernel(
     HAS_BIAS: tl.constexpr,
     USE_LOWER_BOUND: tl.constexpr,
 ):
-    i_t, i_h = tl.program_id(0).to(tl.int64), tl.program_id(1)
+    i_t, i_h = tl.program_id(0).to(tl.int64), tl.program_id(1).to(tl.int64)
 
     o_t = i_t * BT + tl.arange(0, BT)
     o_d = tl.arange(0, BD)
     m_t = o_t < T
     m = m_t[:, None] & (o_d[None, :] < D)
-    # (B*T, H, D) row-major: token stride H*D, head offset i_h*D.
-    off = i_h * D + o_t[:, None] * (H * D) + o_d[None, :]
 
-    b_g = tl.load(g + off, mask=m, other=0.0).to(tl.float32)
-    b_dy = tl.load(dyg + off, mask=m, other=0.0).to(tl.float32)
+    b_g = tl.load(
+        g + ptr_offset((o_t[:, None], i_h, o_d[None, :]), G_STRIDES),
+        mask=m,
+        other=0.0,
+    ).to(tl.float32)
+    b_dy = tl.load(
+        dyg + ptr_offset((o_t[:, None], i_h, o_d[None, :]), DYG_STRIDES),
+        mask=m,
+        other=0.0,
+    ).to(tl.float32)
     if HAS_BIAS:
-        o_b = i_h * D + o_d
-        b_g = b_g + tl.load(dt_bias + o_b, mask=o_b < H * D, other=0.0).to(tl.float32)
+        b_g += tl.load(
+            dt_bias + ptr_offset((i_h, o_d), DT_BIAS_STRIDES),
+            mask=o_d < D,
+            other=0.0,
+        ).to(tl.float32)
 
-    b_alog = tl.load(A_log + i_h).to(tl.float32)
+    b_alog = tl.load(A_log + ptr_offset((i_h,), A_LOG_STRIDES)).to(tl.float32)
     if USE_LOWER_BOUND:
         b_a = tl.exp(b_alog)
         b_s = tl.sigmoid(b_a * b_g)
@@ -96,5 +112,9 @@ def kda_gate_bwd_kernel(
         # dyg/dA_log = yg; masked lanes carry b_dy == 0 and drop out of the sum.
         b_dalog = tl.sum(tl.sum(b_dy * b_yg, 1), 0)
 
-    tl.store(dg + off, b_dg.to(dg.dtype.element_ty), mask=m)
-    tl.store(dA + i_t * H + i_h, b_dalog)
+    tl.store(
+        dg + ptr_offset((o_t[:, None], i_h, o_d[None, :]), DG_STRIDES),
+        b_dg.to(dg.dtype.element_ty),
+        mask=m,
+    )
+    tl.store(dA + ptr_offset((i_t, i_h), DA_STRIDES), b_dalog)

--- a/attn_gym/linear/kda/bwd/triton/l2norm_bwd.py
+++ b/attn_gym/linear/kda/bwd/triton/l2norm_bwd.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import triton
 import triton.language as tl
 
+from attn_gym._backends.triton.utils import ptr_offset
 from attn_gym.linear.kda.utils import autotune_cache_kwargs
 
 _WARPS = [1, 2, 4, 8, 16, 32]
@@ -41,21 +42,28 @@ def l2norm_bwd_kernel1(
     dx,
     eps,
     D,
+    Y_STRIDES: tl.constexpr,
+    RSTD_STRIDES: tl.constexpr,
+    DY_STRIDES: tl.constexpr,
+    DX_STRIDES: tl.constexpr,
     BD: tl.constexpr,
 ):
     # One program per row; the entire feature vector fits in a single [BD] tile.
     i_t = tl.program_id(0).to(tl.int64)
-    base = i_t * D
-    cols = tl.arange(0, BD)
-    mask = cols < D
+    o_d = tl.arange(0, BD)
+    mask = o_d < D
 
-    b_y = tl.load(y + base + cols, mask=mask, other=0.0).to(tl.float32)
-    b_dy = tl.load(dy + base + cols, mask=mask, other=0.0).to(tl.float32)
-    b_rstd = tl.load(rstd + i_t).to(tl.float32)
+    b_y = tl.load(y + ptr_offset((i_t, o_d), Y_STRIDES), mask=mask, other=0.0).to(tl.float32)
+    b_dy = tl.load(dy + ptr_offset((i_t, o_d), DY_STRIDES), mask=mask, other=0.0).to(tl.float32)
+    b_rstd = tl.load(rstd + ptr_offset((i_t,), RSTD_STRIDES)).to(tl.float32)
 
     b_dot = tl.sum(b_dy * b_y)
     b_dx = b_rstd * (b_dy - b_y * b_dot)
-    tl.store(dx + base + cols, b_dx, mask=mask)
+    tl.store(
+        dx + ptr_offset((i_t, o_d), DX_STRIDES),
+        b_dx.to(dx.dtype.element_ty),
+        mask=mask,
+    )
 
 
 @triton.autotune(
@@ -71,6 +79,10 @@ def l2norm_bwd_kernel(
     dx,
     eps,
     T,
+    Y_STRIDES: tl.constexpr,
+    RSTD_STRIDES: tl.constexpr,
+    DY_STRIDES: tl.constexpr,
+    DX_STRIDES: tl.constexpr,
     D: tl.constexpr,
     BD: tl.constexpr,
     NB: tl.constexpr,
@@ -82,12 +94,23 @@ def l2norm_bwd_kernel(
     o_d = tl.arange(0, BD)
     m_t = o_t < T
     m_x = m_t[:, None] & (o_d[None, :] < D)
-    off = o_t[:, None] * D + o_d[None, :]
 
-    b_y = tl.load(y + off, mask=m_x, other=0.0).to(tl.float32)
-    b_dy = tl.load(dy + off, mask=m_x, other=0.0).to(tl.float32)
-    b_rstd = tl.load(rstd + o_t, mask=m_t, other=0.0).to(tl.float32)
+    b_y = tl.load(
+        y + ptr_offset((o_t[:, None], o_d[None, :]), Y_STRIDES),
+        mask=m_x,
+        other=0.0,
+    ).to(tl.float32)
+    b_dy = tl.load(
+        dy + ptr_offset((o_t[:, None], o_d[None, :]), DY_STRIDES),
+        mask=m_x,
+        other=0.0,
+    ).to(tl.float32)
+    b_rstd = tl.load(rstd + ptr_offset((o_t,), RSTD_STRIDES), mask=m_t, other=0.0).to(tl.float32)
 
     b_dot = tl.sum(b_dy * b_y, 1)
     b_dx = b_rstd[:, None] * (b_dy - b_y * b_dot[:, None])
-    tl.store(dx + off, b_dx.to(dx.dtype.element_ty), mask=m_x)
+    tl.store(
+        dx + ptr_offset((o_t[:, None], o_d[None, :]), DX_STRIDES),
+        b_dx.to(dx.dtype.element_ty),
+        mask=m_x,
+    )

--- a/attn_gym/linear/kda/fwd/triton/gate_fwd.py
+++ b/attn_gym/linear/kda/fwd/triton/gate_fwd.py
@@ -4,18 +4,19 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 #
-# FORWARD-ONLY KDA gate chunk-cumsum.
-# Ported faithfully (functions copied verbatim) from:
+# FORWARD-ONLY KDA gate chunk-cumsum, derived from:
 #   genai/llama4x/llama4x/ops/fla/ops/kda/gate.py
 #
-# Only imports were rewritten to ``attn_gym.linear.kda.utils``. The `softplus`
-# helper (originally `fla.ops.utils.softplus`) is inlined verbatim below.
+# The gate math and launch configuration follow the source implementation. The
+# indexing uses logical stride tuples so inputs and outputs need not be contiguous.
+# The `softplus` helper (originally `fla.ops.utils.softplus`) remains inlined below.
 
 from __future__ import annotations
 
 import triton
 import triton.language as tl
 
+from attn_gym._backends.triton.utils import ptr_offset, storage_cosize
 from attn_gym.linear.kda.utils import (
     IS_NVIDIA,
     autotune_cache_kwargs,
@@ -130,8 +131,26 @@ else:
 
 
 # ---------------------------------------------------------------------------
-# Chunk-cumsum forward path (copied verbatim from the source gate.py).
+# Chunk-cumsum forward kernels.
+# s_batch_stride + S_STRIDES describe s as logical (B, T, H, S_in), while
+# o_batch_stride + O_STRIDES describe o as logical (B, T, H, S). In varlen mode,
+# T is the total number of packed tokens.
 # ---------------------------------------------------------------------------
+def _requires_int64_offsets(args):
+    """Select 64-bit indexing when any tensor offset can exceed int32."""
+    input_cosize = storage_cosize(
+        (args["B"], args["T"], args["H"], args["S_in"]),
+        (args["s_batch_stride"], *args["S_STRIDES"]),
+    )
+    output_cosize = storage_cosize(
+        (args["B"], args["T"], args["H"], args["S"]),
+        (args["o_batch_stride"], *args["O_STRIDES"]),
+    )
+    bias_cosize = storage_cosize((args["H"], args["S"]), args["DT_BIAS_STRIDES"])
+    a_log_cosize = storage_cosize((args["H"],), args["A_LOG_STRIDES"])
+    return max(input_cosize, output_cosize, bias_cosize, a_log_cosize) > 1 << 31
+
+
 @triton.heuristics(
     {
         "HAS_BIAS": lambda args: args["dt_bias"] is not None,
@@ -140,6 +159,7 @@ else:
         "USE_LOWER_BOUND": lambda args: args["lower_bound"] is not None,
         "USE_REPEAT": lambda args: args["S_in"] != args["S"],
         "HAS_NUM_CHUNKS": lambda args: args["num_chunks"] is not None,
+        "USE_INT64_OFFSETS": _requires_int64_offsets,
     }
 )
 @triton.autotune(
@@ -162,6 +182,12 @@ def kda_gate_chunk_cumsum_vector_kernel(
     lower_bound,
     T,
     num_chunks,
+    s_batch_stride,
+    o_batch_stride,
+    S_STRIDES: tl.constexpr,
+    A_LOG_STRIDES: tl.constexpr,
+    DT_BIAS_STRIDES: tl.constexpr,
+    O_STRIDES: tl.constexpr,
     B: tl.constexpr,
     H: tl.constexpr,
     S: tl.constexpr,
@@ -176,8 +202,16 @@ def kda_gate_chunk_cumsum_vector_kernel(
     USE_LOWER_BOUND: tl.constexpr,
     USE_REPEAT: tl.constexpr,
     HAS_NUM_CHUNKS: tl.constexpr,
+    USE_INT64_OFFSETS: tl.constexpr,
 ):
-    i_t, i_bh, i_s = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    tl.static_assert(not IS_VARLEN or B == 1, "packed varlen requires B == 1")
+    i_t = tl.program_id(0)
+    i_bh = tl.program_id(1)
+    i_s = tl.program_id(2)
+    if USE_INT64_OFFSETS:
+        i_t = i_t.to(tl.int64)
+        i_bh = i_bh.to(tl.int64)
+        i_s = i_s.to(tl.int64)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
         if HAS_NUM_CHUNKS and i_t >= tl.load(num_chunks):
@@ -191,68 +225,64 @@ def kda_gate_chunk_cumsum_vector_kernel(
             tl.load(cu_seqlens + i_n + 1).to(tl.int32),
         )
         T = eos - bos
+        if USE_INT64_OFFSETS:
+            i_t = i_t.to(tl.int64)
+            bos = bos.to(tl.int64)
     else:
-        bos, eos = i_b * T, i_b * T + T
+        bos = 0
 
-    if USE_REPEAT:
-        # Input g has reduced dimension S_in = S / F_REPEAT
-        # We read from S_in and produce output of dimension S
-        # i_s indexes output blocks of size BS in the full dimension S
-        # Map output column indices to input column indices via integer division
-        b_out_cols = i_s * BS + tl.arange(0, BS)  # [BS] output column indices
-        b_in_cols = b_out_cols // F_REPEAT  # [BS] input column indices
-
-        # Load g from reduced dimension using gather
-        b_t_offs = i_t * BT + tl.arange(0, BT)  # [BT]
-        b_s_ptrs = s + ((bos + b_t_offs[:, None]) * H + i_h) * S_in + b_in_cols[None, :]
-        b_mask = (b_t_offs[:, None] < T) & (b_out_cols[None, :] < S)
-        b_s = tl.load(b_s_ptrs, mask=b_mask, other=0.0).to(tl.float32)
-    else:
-        p_s = tl.make_block_ptr(
-            s + (bos * H + i_h) * S,
-            (T, S),
-            (H * S, 1),
-            (i_t * BT, i_s * BS),
-            (BT, BS),
-            (1, 0),
-        )
-        # [BT, BS]
-        b_s = tl.load(p_s, boundary_check=(0, 1)).to(tl.float32)
-
-    p_o = tl.make_block_ptr(
-        o + (bos * H + i_h) * S,
-        (T, S),
-        (H * S, 1),
-        (i_t * BT, i_s * BS),
-        (BT, BS),
-        (1, 0),
-    )
+    b_out_cols = i_s * BS + tl.arange(0, BS)
+    b_in_cols = b_out_cols // F_REPEAT if USE_REPEAT else b_out_cols
+    b_t_offs = i_t * BT + tl.arange(0, BT)
+    token = bos + b_t_offs if IS_VARLEN else b_t_offs
+    m_t = b_t_offs < T
+    b_mask = m_t[:, None] & (b_out_cols[None, :] < S)
+    s_batch_offset = i_b * s_batch_stride if B > 1 else 0
+    b_s = tl.load(
+        s
+        + s_batch_offset
+        + ptr_offset(
+            (token[:, None], i_h, b_in_cols[None, :]),
+            S_STRIDES,
+        ),
+        mask=b_mask,
+        other=0.0,
+    ).to(tl.float32)
 
     # Apply dt_bias if exists (dt_bias is always in full dimension S)
     if HAS_BIAS:
-        p_b = tl.make_block_ptr(dt_bias + i_h * S, (S,), (1,), (i_s * BS,), (BS,), (0,))
-        b_bias = tl.load(p_b, boundary_check=(0,)).to(tl.float32)
+        b_bias = tl.load(
+            dt_bias + ptr_offset((i_h, b_out_cols), DT_BIAS_STRIDES),
+            mask=b_out_cols < S,
+            other=0.0,
+        ).to(tl.float32)
         b_s = b_s + b_bias[None, :]
 
-    b_A = tl.load(A_log + i_h).to(tl.float32)
+    b_A = tl.load(A_log + ptr_offset((i_h,), A_LOG_STRIDES)).to(tl.float32)
     if not USE_LOWER_BOUND:  # pyrefly: ignore[unsupported-operation]
         # Apply gate: -exp(A_log) * softplus(g + bias)
         b_gate = -exp(b_A) * softplus(b_s)  # pyrefly: ignore[unsupported-operation]
     else:
         b_gate = lower_bound * tl.sigmoid(exp(b_A) * b_s)
 
-    m_t = (i_t * BT + tl.arange(0, BT)) < T
     b_gate = tl.where(m_t[:, None], b_gate, 0.0)
 
     # Apply chunk local cumsum
-    if REVERSE:
-        b_o = tl.cumsum(b_gate, axis=0, reverse=True)
-    else:
-        b_o = tl.cumsum(b_gate, axis=0)
+    b_o = tl.cumsum(b_gate, axis=0, reverse=REVERSE)
 
     if HAS_SCALE:
         b_o *= scale
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    o_batch_offset = i_b * o_batch_stride if B > 1 else 0
+    tl.store(
+        o
+        + o_batch_offset
+        + ptr_offset(
+            (token[:, None], i_h, b_out_cols[None, :]),
+            O_STRIDES,
+        ),
+        b_o.to(o.dtype.element_ty),
+        mask=b_mask,
+    )
 
 
 @triton.heuristics(
@@ -263,6 +293,7 @@ def kda_gate_chunk_cumsum_vector_kernel(
         "USE_LOWER_BOUND": lambda args: args["lower_bound"] is not None,
         "USE_REPEAT": lambda args: args["S_in"] != args["S"],
         "HAS_NUM_CHUNKS": lambda args: args["num_chunks"] is not None,
+        "USE_INT64_OFFSETS": _requires_int64_offsets,
     }
 )
 @triton.autotune(
@@ -284,6 +315,12 @@ def kda_gate_chunk_cumsum_vector_kernel_forloop(
     lower_bound,
     T,
     num_chunks,
+    s_batch_stride,
+    o_batch_stride,
+    S_STRIDES: tl.constexpr,
+    A_LOG_STRIDES: tl.constexpr,
+    DT_BIAS_STRIDES: tl.constexpr,
+    O_STRIDES: tl.constexpr,
     B: tl.constexpr,
     H: tl.constexpr,
     S: tl.constexpr,
@@ -298,13 +335,34 @@ def kda_gate_chunk_cumsum_vector_kernel_forloop(
     USE_LOWER_BOUND: tl.constexpr,
     USE_REPEAT: tl.constexpr,
     HAS_NUM_CHUNKS: tl.constexpr,
+    USE_INT64_OFFSETS: tl.constexpr,
     # pyrefly: ignore [bad-function-definition]
     GRID_NT: tl.constexpr = 0,
     # pyrefly: ignore [bad-function-definition]
     MAX_NT: tl.constexpr = 0,
 ):
-    i_t_start, i_bh, i_s = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    tl.static_assert(not IS_VARLEN or B == 1, "packed varlen requires B == 1")
+    i_t_start = tl.program_id(0)
+    i_bh = tl.program_id(1)
+    i_s = tl.program_id(2)
+    if USE_INT64_OFFSETS:
+        i_t_start = i_t_start.to(tl.int64)
+        i_bh = i_bh.to(tl.int64)
+        i_s = i_s.to(tl.int64)
     i_b, i_h = i_bh // H, i_bh % H
+    b_out_cols = i_s * BS + tl.arange(0, BS)
+    b_in_cols = b_out_cols // F_REPEAT if USE_REPEAT else b_out_cols
+    s_batch_offset = i_b * s_batch_stride if B > 1 else 0
+    o_batch_offset = i_b * o_batch_stride if B > 1 else 0
+    p_s = s + s_batch_offset + ptr_offset((0, i_h, b_in_cols), S_STRIDES)
+    p_o = o + o_batch_offset + ptr_offset((0, i_h, b_out_cols), O_STRIDES)
+    if HAS_BIAS:
+        b_bias = tl.load(
+            dt_bias + ptr_offset((i_h, b_out_cols), DT_BIAS_STRIDES),
+            mask=b_out_cols < S,
+            other=0.0,
+        ).to(tl.float32)
+    b_A = tl.load(A_log + ptr_offset((i_h,), A_LOG_STRIDES)).to(tl.float32)
 
     for _iter in range((MAX_NT + GRID_NT - 1) // GRID_NT):
         i_t_orig = i_t_start + _iter * GRID_NT
@@ -322,59 +380,39 @@ def kda_gate_chunk_cumsum_vector_kernel_forloop(
                     tl.load(cu_seqlens + i_n + 1).to(tl.int32),
                 )
                 T_local = eos - bos
+                if USE_INT64_OFFSETS:
+                    i_t = i_t.to(tl.int64)
+                    bos = bos.to(tl.int64)
             else:
                 i_t = i_t_orig
-                bos, eos = i_b * T, i_b * T + T
+                bos = 0
                 T_local = T
 
-            if USE_REPEAT:
-                b_out_cols = i_s * BS + tl.arange(0, BS)
-                b_in_cols = b_out_cols // F_REPEAT
-
-                b_t_offs = i_t * BT + tl.arange(0, BT)
-                b_s_ptrs = s + ((bos + b_t_offs[:, None]) * H + i_h) * S_in + b_in_cols[None, :]
-                b_mask = (b_t_offs[:, None] < T_local) & (b_out_cols[None, :] < S)
-                b_s = tl.load(b_s_ptrs, mask=b_mask, other=0.0).to(tl.float32)
-            else:
-                p_s = tl.make_block_ptr(
-                    s + (bos * H + i_h) * S,
-                    (T_local, S),
-                    (H * S, 1),
-                    (i_t * BT, i_s * BS),
-                    (BT, BS),
-                    (1, 0),
-                )
-                b_s = tl.load(p_s, boundary_check=(0, 1)).to(tl.float32)
-
-            p_o = tl.make_block_ptr(
-                o + (bos * H + i_h) * S,
-                (T_local, S),
-                (H * S, 1),
-                (i_t * BT, i_s * BS),
-                (BT, BS),
-                (1, 0),
-            )
+            b_t_offs = i_t * BT + tl.arange(0, BT)
+            token = bos + b_t_offs if IS_VARLEN else b_t_offs
+            m_t = b_t_offs < T_local
+            b_mask = m_t[:, None] & (b_out_cols[None, :] < S)
+            b_s = tl.load(
+                p_s[None, :] + token[:, None] * S_STRIDES[0],
+                mask=b_mask,
+                other=0.0,
+            ).to(tl.float32)
 
             if HAS_BIAS:
-                p_b = tl.make_block_ptr(dt_bias + i_h * S, (S,), (1,), (i_s * BS,), (BS,), (0,))
-                b_bias = tl.load(p_b, boundary_check=(0,)).to(tl.float32)
                 b_s = b_s + b_bias[None, :]
-
-            b_A = tl.load(A_log + i_h).to(tl.float32)
             if not USE_LOWER_BOUND:  # pyrefly: ignore[unsupported-operation]
                 # pyrefly: ignore [unsupported-operation]
                 b_gate = -exp(b_A) * softplus(b_s)  # pyrefly: ignore[unsupported-operation]
             else:
                 b_gate = lower_bound * tl.sigmoid(exp(b_A) * b_s)
 
-            m_t = (i_t * BT + tl.arange(0, BT)) < T_local
             b_gate = tl.where(m_t[:, None], b_gate, 0.0)
-
-            if REVERSE:
-                b_o = tl.cumsum(b_gate, axis=0, reverse=True)
-            else:
-                b_o = tl.cumsum(b_gate, axis=0)
+            b_o = tl.cumsum(b_gate, axis=0, reverse=REVERSE)
 
             if HAS_SCALE:
                 b_o *= scale
-            tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+            tl.store(
+                p_o[None, :] + token[:, None] * O_STRIDES[0],
+                b_o.to(o.dtype.element_ty),
+                mask=b_mask,
+            )

--- a/attn_gym/linear/kda/fwd/triton/l2norm_fwd.py
+++ b/attn_gym/linear/kda/fwd/triton/l2norm_fwd.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import triton
 import triton.language as tl
 
+from attn_gym._backends.triton.utils import ptr_offset
+
 
 @triton.autotune(
     configs=[triton.Config({}, num_warps=4)],
@@ -16,21 +18,21 @@ def l2norm_fwd_kernel1(
     y,
     rstd,
     eps,
+    X_STRIDES: tl.constexpr,
+    Y_STRIDES: tl.constexpr,
+    RSTD_STRIDES: tl.constexpr,
     D: tl.constexpr,
     BD: tl.constexpr,
 ):
     i_t = tl.program_id(0).to(tl.int64)
-    x += i_t * D
-    y += i_t * D
-    # Compute mean and variance
-    cols = tl.arange(0, BD)
-    mask = cols < D
+    o_d = tl.arange(0, BD)
+    mask = o_d < D
 
-    b_x = tl.load(x + cols, mask=mask, other=0.0).to(tl.float32)
+    b_x = tl.load(x + ptr_offset((i_t, o_d), X_STRIDES), mask=mask, other=0.0).to(tl.float32)
     b_rstd = 1 / tl.sqrt(tl.sum(b_x * b_x) + eps)
     b_y = b_x * b_rstd
-    tl.store(y + cols, b_y, mask=mask)
-    tl.store(rstd + i_t, b_rstd)
+    tl.store(y + ptr_offset((i_t, o_d), Y_STRIDES), b_y, mask=mask)
+    tl.store(rstd + ptr_offset((i_t,), RSTD_STRIDES), b_rstd)
 
 
 @triton.autotune(
@@ -46,19 +48,35 @@ def l2norm_fwd_kernel(
     rstd,
     eps,
     T,
+    X_STRIDES: tl.constexpr,
+    Y_STRIDES: tl.constexpr,
+    RSTD_STRIDES: tl.constexpr,
     D: tl.constexpr,
     BD: tl.constexpr,
     NB,
     BT: tl.constexpr,
 ):
-    i_t = tl.program_id(0)
-    p_x = tl.make_block_ptr(x, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
-    p_y = tl.make_block_ptr(y, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
-    p_rstd = tl.make_block_ptr(rstd, (T,), (1,), (i_t * BT,), (BT,), (0,))
+    i_t = tl.program_id(0).to(tl.int64)
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_d = tl.arange(0, BD)
+    m_t = o_t < T
+    mask = m_t[:, None] & (o_d[None, :] < D)
 
-    b_x = tl.load(p_x, boundary_check=(0, 1)).to(tl.float32)
+    b_x = tl.load(
+        x + ptr_offset((o_t[:, None], o_d[None, :]), X_STRIDES),
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
     b_rstd = 1 / tl.sqrt(tl.sum(b_x * b_x, 1) + eps)
     b_y = b_x * b_rstd[:, None]
 
-    tl.store(p_y, b_y.to(p_y.dtype.element_ty), boundary_check=(0, 1))  # type: ignore
-    tl.store(p_rstd, b_rstd.to(p_rstd.dtype.element_ty), boundary_check=(0,))  # type: ignore
+    tl.store(
+        y + ptr_offset((o_t[:, None], o_d[None, :]), Y_STRIDES),
+        b_y.to(y.dtype.element_ty),
+        mask=mask,
+    )
+    tl.store(
+        rstd + ptr_offset((o_t,), RSTD_STRIDES),
+        b_rstd.to(rstd.dtype.element_ty),
+        mask=m_t,
+    )

--- a/test/test_kda_kernels.py
+++ b/test/test_kda_kernels.py
@@ -26,7 +26,9 @@ from attn_gym.linear.kda.bwd.triton.l2norm_bwd import (
     l2norm_bwd_kernel1,
 )
 from attn_gym.linear.kda.fwd.triton.gate_fwd import (
+    _requires_int64_offsets,
     kda_gate_chunk_cumsum_vector_kernel,
+    kda_gate_chunk_cumsum_vector_kernel_forloop,
 )
 from attn_gym.linear.kda.fwd.triton.l2norm_fwd import (
     l2norm_fwd_kernel,
@@ -130,26 +132,53 @@ def _cu_seqlens(doc_lens: tuple[int, ...]) -> torch.Tensor:
     return cu
 
 
+def _optional_matrix_strides(tensor: torch.Tensor | None) -> tuple[int, ...]:
+    """Return matrix strides or inert strides for a disabled optional input."""
+    return (0, 0) if tensor is None else tensor.stride()
+
+
+def _empty_strided_like(tensor: torch.Tensor) -> torch.Tensor:
+    """Allocate an output view with the same shape and a non-unit innermost stride."""
+    storage_shape = (*tensor.shape[:-1], tensor.shape[-1] * 2)
+    return torch.empty(storage_shape, dtype=tensor.dtype, device=tensor.device)[..., ::2]
+
+
+def _strided_copy(tensor: torch.Tensor) -> torch.Tensor:
+    """Copy a tensor into a view with a non-unit innermost stride."""
+    view = _empty_strided_like(tensor)
+    view.copy_(tensor)
+    return view
+
+
 # Shapes chosen to straddle chunk boundaries: single token, one-below / exact /
-# one-above the internal block, and multi-block. Runtime-shape coverage is
-# independent from element-type coverage, so only one representative shape is
-# crossed with every dtype.
-L2NORM_SHAPES = ((1, 128), (7, 64), (16, 128), (17, 64), (64, 128), (130, 32))
+# one-above the internal block, and multi-block. One existing fp32 case combines
+# a non-power-of-two feature dimension with strided inputs and outputs, avoiding
+# an additional parameterized case and its compilation cost.
+L2NORM_SHAPES = (
+    (1, 128, False),
+    (7, 96, True),
+    (16, 128, False),
+    (17, 64, False),
+    (64, 128, False),
+    (130, 32, False),
+)
 GATE_TS = (1, 15, 16, 17, 33, 64)
 VARLEN_DOCS = ((16,), (16, 32, 16), (7, 16, 24, 1), (64, 3))
 
-_L2NORM_CASES = [(torch.float32, T, D) for T, D in L2NORM_SHAPES] + [
-    (dtype, 17, 64) for dtype in DTYPES[1:]
+_L2NORM_CASES = [(torch.float32, T, D, strided) for T, D, strided in L2NORM_SHAPES] + [
+    (dtype, 17, 64, False) for dtype in DTYPES[1:]
 ]
 
 
 # l2norm forward
-@pytest.mark.parametrize("dtype,T,D", _L2NORM_CASES, ids=_case_id)
-def test_l2norm_fwd(dtype, T, D):
+@pytest.mark.parametrize("dtype,T,D,strided", _L2NORM_CASES, ids=_case_id)
+def test_l2norm_fwd(dtype, T, D, strided):
     torch.manual_seed(0)
     eps = 1e-6
     x64 = torch.randn(T, D, device=DEV, dtype=torch.float64)
     x = x64.to(dtype)
+    if strided:
+        x = _strided_copy(x)
 
     golden = l2norm_fwd_ref(x64, eps)
     ref = l2norm_fwd_ref(x, eps)
@@ -160,24 +189,47 @@ def test_l2norm_fwd(dtype, T, D):
     BD = triton.next_power_of_2(D)
 
     # block kernel
-    y = torch.empty_like(x)
-    rstd = torch.empty(T, device=DEV, dtype=torch.float32)
+    y = _empty_strided_like(x) if strided else torch.empty_like(x)
+    rstd_template = torch.empty(T, device=DEV, dtype=torch.float32)
+    rstd = _empty_strided_like(rstd_template) if strided else rstd_template
     grid = lambda meta: (triton.cdiv(T, meta["BT"]),)
-    l2norm_fwd_kernel[grid](x, y, rstd, eps, T, D=D, BD=BD, NB=triton.cdiv(T, 16))
+    l2norm_fwd_kernel[grid](
+        x,
+        y,
+        rstd,
+        eps,
+        T,
+        X_STRIDES=x.stride(),
+        Y_STRIDES=y.stride(),
+        RSTD_STRIDES=rstd.stride(),
+        D=D,
+        BD=BD,
+        NB=triton.cdiv(T, 16),
+    )
     assert_golden(y, golden, ref, dtype, f"l2norm_fwd_kernel T={T} D={D}")
     assert_golden(rstd, rstd_golden, rstd_ref, dtype, f"l2norm_fwd_kernel rstd T={T} D={D}")
 
     # single-row kernel
-    y1 = torch.empty_like(x)
-    rstd1 = torch.empty(T, device=DEV, dtype=torch.float32)
-    l2norm_fwd_kernel1[(T,)](x, y1, rstd1, eps, D=D, BD=BD)
+    y1 = _empty_strided_like(x) if strided else torch.empty_like(x)
+    rstd1 = _empty_strided_like(rstd_template) if strided else torch.empty_like(rstd_template)
+    l2norm_fwd_kernel1[(T,)](
+        x,
+        y1,
+        rstd1,
+        eps,
+        X_STRIDES=x.stride(),
+        Y_STRIDES=y1.stride(),
+        RSTD_STRIDES=rstd1.stride(),
+        D=D,
+        BD=BD,
+    )
     assert_golden(y1, golden, ref, dtype, f"l2norm_fwd_kernel1 T={T} D={D}")
     assert_golden(rstd1, rstd_golden, rstd_ref, dtype, f"l2norm_fwd_kernel1 rstd T={T} D={D}")
 
 
 # l2norm backward   dx = rstd * (dy - y * <dy, y>)
-@pytest.mark.parametrize("dtype,T,D", _L2NORM_CASES, ids=_case_id)
-def test_l2norm_bwd(dtype, T, D):
+@pytest.mark.parametrize("dtype,T,D,strided", _L2NORM_CASES, ids=_case_id)
+def test_l2norm_bwd(dtype, T, D, strided):
     torch.manual_seed(1)
     eps = 1e-6
     x64 = torch.randn(T, D, device=DEV, dtype=torch.float64)
@@ -191,23 +243,64 @@ def test_l2norm_bwd(dtype, T, D):
     y = y64.to(dtype)
     dy = dy64.to(dtype)
     rstd = rstd64.squeeze(-1).to(torch.float32)
+    if strided:
+        y, dy, rstd = map(_strided_copy, (y, dy, rstd))
 
     ref = l2norm_bwd_ref(y, rstd.unsqueeze(-1), dy)
 
     BD = triton.next_power_of_2(D)
 
-    dx = torch.empty_like(y)
+    dx = _empty_strided_like(y) if strided else torch.empty_like(y)
     grid = lambda meta: (triton.cdiv(T, meta["BT"]),)
-    l2norm_bwd_kernel[grid](y, rstd, dy, dx, eps, T, D=D, BD=BD, NB=triton.cdiv(T, 16))
+    l2norm_bwd_kernel[grid](
+        y,
+        rstd,
+        dy,
+        dx,
+        eps,
+        T,
+        Y_STRIDES=y.stride(),
+        RSTD_STRIDES=rstd.stride(),
+        DY_STRIDES=dy.stride(),
+        DX_STRIDES=dx.stride(),
+        D=D,
+        BD=BD,
+        NB=triton.cdiv(T, 16),
+    )
     assert_golden(dx, golden, ref, dtype, f"l2norm_bwd_kernel T={T} D={D}")
 
-    dx1 = torch.empty_like(y)
-    l2norm_bwd_kernel1[(T,)](y, rstd, dy, dx1, eps, D, BD=BD)
+    dx1 = _empty_strided_like(y) if strided else torch.empty_like(y)
+    l2norm_bwd_kernel1[(T,)](
+        y,
+        rstd,
+        dy,
+        dx1,
+        eps,
+        D,
+        Y_STRIDES=y.stride(),
+        RSTD_STRIDES=rstd.stride(),
+        DY_STRIDES=dy.stride(),
+        DX_STRIDES=dx1.stride(),
+        BD=BD,
+    )
     assert_golden(dx1, golden, ref, dtype, f"l2norm_bwd_kernel1 T={T} D={D}")
 
 
 # gate forward (gate map + chunk-local cumsum)
-def _run_gate_fwd(g, A_log, dt_bias, o, scale, lower_bound, chunk_size, cu_seqlens, reverse=False):
+def _run_gate_fwd(
+    g,
+    A_log,
+    dt_bias,
+    o,
+    scale,
+    lower_bound,
+    chunk_size,
+    cu_seqlens,
+    reverse=False,
+    *,
+    grid_nt=None,
+):
+    """Launch the direct or persistent gate kernel with logical tensor strides."""
     # o carries the full output dim S; g may carry a reduced dim S_in = S / F_REPEAT.
     B, T, H, S = o.shape
     S_in = g.shape[-1]
@@ -218,9 +311,15 @@ def _run_gate_fwd(g, A_log, dt_bias, o, scale, lower_bound, chunk_size, cu_seqle
     else:
         chunk_indices = None
         NT = triton.cdiv(T, chunk_size)
+
+    kernel = kda_gate_chunk_cumsum_vector_kernel
+    kernel_kwargs = {}
+    if grid_nt is not None:
+        kernel = kda_gate_chunk_cumsum_vector_kernel_forloop
+        kernel_kwargs = {"GRID_NT": grid_nt, "MAX_NT": NT}
     # BS is autotuned; the HAS_*/USE_*/IS_VARLEN/USE_REPEAT flags come from @triton.heuristics.
-    grid = lambda meta: (NT, B * H, triton.cdiv(S, meta["BS"]))
-    kda_gate_chunk_cumsum_vector_kernel[grid](
+    grid = lambda meta: (grid_nt or NT, B * H, triton.cdiv(S, meta["BS"]))
+    kernel[grid](
         g,
         A_log,
         dt_bias,
@@ -231,6 +330,12 @@ def _run_gate_fwd(g, A_log, dt_bias, o, scale, lower_bound, chunk_size, cu_seqle
         lower_bound,
         T,
         None,
+        g.stride(0),
+        o.stride(0),
+        S_STRIDES=g.stride()[1:],
+        A_LOG_STRIDES=A_log.stride(),
+        DT_BIAS_STRIDES=_optional_matrix_strides(dt_bias),
+        O_STRIDES=o.stride()[1:],
         B=B,
         H=H,
         S=S,
@@ -238,6 +343,7 @@ def _run_gate_fwd(g, A_log, dt_bias, o, scale, lower_bound, chunk_size, cu_seqle
         F_REPEAT=F_REPEAT,
         BT=chunk_size,
         REVERSE=reverse,
+        **kernel_kwargs,
     )
 
 
@@ -260,7 +366,7 @@ _GATE_FWD_CASES = (
 )
 def test_gate_fwd(dtype, T, lower_bound, has_bias, scale, reverse):
     torch.manual_seed(2)
-    B, H, S, chunk = 1, 2, 16, 16
+    B, H, S, chunk = 2, 2, 16, 16
     g64 = torch.randn(B, T, H, S, device=DEV, dtype=torch.float64)
     A_log64 = torch.randn(H, device=DEV, dtype=torch.float64)
     bias64 = torch.randn(H, S, device=DEV, dtype=torch.float64) if has_bias else None
@@ -338,33 +444,155 @@ def test_gate_fwd_repeat(dtype, f_repeat, reverse):
     assert_golden(o, golden, ref, dtype, f"gate_fwd_repeat f_repeat={f_repeat} rev={reverse}")
 
 
+def test_gate_fwd_varlen_repeat():
+    """Cover packed varlen, repeated channels, and non-contiguous strides together."""
+    torch.manual_seed(9)
+    dtype = torch.float32
+    docs = (7, 17)
+    total, H, S_in, f_repeat, chunk = sum(docs), 2, 8, 2, 16
+    S = S_in * f_repeat
+    cu = _cu_seqlens(docs)
+    g64 = torch.randn(1, total, H, S_in, device=DEV, dtype=torch.float64)
+    A_log64 = torch.randn(H, device=DEV, dtype=torch.float64)
+    bias64 = torch.randn(H, S, device=DEV, dtype=torch.float64)
+
+    g64_full = g64.repeat_interleave(f_repeat, dim=-1)
+    golden = gate_fwd_ref(g64_full, A_log64, bias64, 0.5, None, True, chunk, cu)
+
+    g = _strided_copy(g64.to(dtype))
+    A_log = _strided_copy(A_log64.to(torch.float32))
+    bias = _strided_copy(bias64.to(dtype))
+    ref = gate_fwd_ref(
+        g.repeat_interleave(f_repeat, dim=-1), A_log, bias, 0.5, None, True, chunk, cu
+    )
+    output_template = torch.empty(1, total, H, S, device=DEV, dtype=dtype)
+    o = _empty_strided_like(output_template)
+
+    _run_gate_fwd(g, A_log, bias, o, None, 0.5, chunk, cu, reverse=True)
+    assert_golden(o, golden, ref, dtype, "gate_fwd_varlen_repeat")
+
+    o_forloop = _empty_strided_like(output_template)
+    _run_gate_fwd(
+        g,
+        A_log,
+        bias,
+        o_forloop,
+        None,
+        0.5,
+        chunk,
+        cu,
+        reverse=True,
+        grid_nt=2,
+    )
+    assert_golden(o_forloop, golden, ref, dtype, "gate_fwd_varlen_repeat_forloop")
+
+
+def test_gate_fwd_forloop_fixed_batch():
+    """Cover the persistent kernel's fixed-length and nonzero-batch offsets."""
+    torch.manual_seed(11)
+    dtype = torch.float32
+    B, T, H, S, chunk = 2, 33, 2, 16, 16
+    g64 = torch.randn(B, T, H, S, device=DEV, dtype=torch.float64)
+    A_log64 = torch.randn(H, device=DEV, dtype=torch.float64)
+    golden = gate_fwd_ref(g64, A_log64, None, None, None, False, chunk, None)
+
+    g = g64.to(dtype)
+    A_log = A_log64.to(torch.float32)
+    ref = gate_fwd_ref(g, A_log, None, None, None, False, chunk, None)
+    o = torch.empty_like(g)
+
+    _run_gate_fwd(g, A_log, None, o, None, None, chunk, None, grid_nt=2)
+    assert_golden(o, golden, ref, dtype, "gate_fwd_forloop_fixed_batch")
+
+
+def test_gate_fwd_int64_offsets():
+    """Force the 64-bit offset specialization without allocating a huge tensor."""
+    torch.manual_seed(12)
+    g = torch.randn(1, 1, 1, 1, device=DEV)
+    A_log = torch.randn(1, device=DEV)
+    o = torch.empty_like(g)
+    grid = lambda meta: (1, 1, triton.cdiv(1, meta["BS"]))
+
+    # B=2 makes the synthetic batch span exceed int32, while the one-program
+    # grid accesses only batch zero and therefore remains within the tiny allocation.
+    assert _requires_int64_offsets(
+        {
+            "B": 2,
+            "T": 1,
+            "H": 1,
+            "S": 1,
+            "S_in": 1,
+            "s_batch_stride": 1 << 31,
+            "o_batch_stride": 1 << 31,
+            "S_STRIDES": g.stride()[1:],
+            "A_LOG_STRIDES": A_log.stride(),
+            "DT_BIAS_STRIDES": (0, 0),
+            "O_STRIDES": o.stride()[1:],
+        }
+    )
+    kda_gate_chunk_cumsum_vector_kernel[grid](
+        g,
+        A_log,
+        None,
+        o,
+        None,
+        None,
+        None,
+        None,
+        1,
+        None,
+        1 << 31,
+        1 << 31,
+        S_STRIDES=g.stride()[1:],
+        A_LOG_STRIDES=A_log.stride(),
+        DT_BIAS_STRIDES=(0, 0),
+        O_STRIDES=o.stride()[1:],
+        B=2,
+        H=1,
+        S=1,
+        S_in=1,
+        F_REPEAT=1,
+        BT=1,
+        REVERSE=False,
+    )
+    ref = gate_fwd_ref(g, A_log, None, None, None, False, 1, None)
+    torch.testing.assert_close(o, ref)
+
+
 # gate backward (pointwise gate map only -- no cumsum)
 _GATE_BWD_CASES = (
     [
-        (torch.float32, 17, lower_bound, has_bias)
+        (
+            torch.float32,
+            17,
+            lower_bound,
+            has_bias,
+            12 if lower_bound is None and has_bias else 16,
+            lower_bound is None and has_bias,
+        )
         for lower_bound, has_bias in product((None, 0.5), (False, True))
     ]
-    + [(torch.float32, T, None, False) for T in GATE_TS if T != 17]
-    + [(dtype, 17, None, False) for dtype in DTYPES[1:]]
+    + [(torch.float32, T, None, False, 16, False) for T in GATE_TS if T != 17]
+    + [(dtype, 17, None, False, 16, False) for dtype in DTYPES[1:]]
 )
 
 
 @pytest.mark.parametrize(
-    "dtype,T,lower_bound,has_bias",
+    "dtype,T,lower_bound,has_bias,D,strided",
     _GATE_BWD_CASES,
     ids=_case_id,
 )
-def test_gate_bwd(dtype, T, lower_bound, has_bias):
+def test_gate_bwd(dtype, T, lower_bound, has_bias, D, strided):
     torch.manual_seed(4)
-    H, D, BT = 2, 16, 16
+    H, BT = 2, 16
     g64 = torch.randn(T, H, D, device=DEV, dtype=torch.float64)
     A_log64 = torch.randn(H, device=DEV, dtype=torch.float64)
     bias64 = torch.randn(H, D, device=DEV, dtype=torch.float64) if has_bias else None
     dyg64 = torch.randn(T, H, D, device=DEV, dtype=torch.float64)
 
-    # gate_bwd math is applied per (T, H, D) row; reshape to (B=1, T, H, D) for the ref helper
+    # gate_bwd math is applied per (T, H, D) row; add B=1 for the ref helper.
     def as_bthd(x):
-        return None if x is None else x.view(1, T, H, D)
+        return None if x is None else x.unsqueeze(0)
 
     gold_dg, gold_dA, gold_db = gate_bwd_ref(
         as_bthd(g64), A_log64, bias64, as_bthd(dyg64), lower_bound
@@ -374,21 +602,45 @@ def test_gate_bwd(dtype, T, lower_bound, has_bias):
     A_log = A_log64.to(torch.float32)
     bias = bias64.to(dtype) if has_bias else None
     dyg = dyg64.to(dtype)
+    if strided:
+        assert bias is not None
+        g, A_log, dyg = map(_strided_copy, (g, A_log, dyg))
+        bias = _strided_copy(bias)
     ref_dg, ref_dA, ref_db = gate_bwd_ref(as_bthd(g), A_log, bias, as_bthd(dyg), lower_bound)
 
     NT = triton.cdiv(T, BT)
     BD = triton.next_power_of_2(D)
-    dg = torch.empty_like(g)
-    dA = torch.zeros(NT, H, device=DEV, dtype=torch.float32)
+    dg = _empty_strided_like(g) if strided else torch.empty_like(g)
+    dA_template = torch.zeros(NT, H, device=DEV, dtype=torch.float32)
+    dA = _strided_copy(dA_template) if strided else dA_template
     kda_gate_bwd_kernel[(NT, H)](
-        g, A_log, bias, dyg, dg, dA, lower_bound, T, H=H, D=D, BT=BT, BD=BD
+        g,
+        A_log,
+        bias,
+        dyg,
+        dg,
+        dA,
+        lower_bound,
+        T,
+        G_STRIDES=g.stride(),
+        A_LOG_STRIDES=A_log.stride(),
+        DT_BIAS_STRIDES=_optional_matrix_strides(bias),
+        DYG_STRIDES=dyg.stride(),
+        DG_STRIDES=dg.stride(),
+        DA_STRIDES=dA.stride(),
+        H=H,
+        D=D,
+        BT=BT,
+        BD=BD,
     )
 
-    tag = f"T={T} lb={lower_bound} bias={has_bias}"
-    assert_golden(dg, gold_dg.view(T, H, D), ref_dg.view(T, H, D), dtype, f"gate_bwd dg {tag}")
+    tag = f"T={T} D={D} lb={lower_bound} bias={has_bias} strided={strided}"
+    assert_golden(
+        dg, gold_dg.reshape(T, H, D), ref_dg.reshape(T, H, D), dtype, f"gate_bwd dg {tag}"
+    )
     assert_golden(dA.sum(0), gold_dA, ref_dA, dtype, f"gate_bwd dA_log {tag}")
     if has_bias:
-        assert_golden(dg.sum(0), gold_db, ref_db.view(H, D), dtype, f"gate_bwd dt_bias {tag}")
+        assert_golden(dg.sum(0), gold_db, ref_db.reshape(H, D), dtype, f"gate_bwd dt_bias {tag}")
 
 
 # Plain chunk-local cumsum (scalar + vector), used by the reverse-cumsum adjoint.
@@ -404,7 +656,7 @@ _CUMSUM_CASES = (
 @pytest.mark.parametrize("dtype,T,reverse,scale", _CUMSUM_CASES, ids=_case_id)
 def test_cumsum_scalar(dtype, T, reverse, scale):
     torch.manual_seed(5)
-    B, H, BT = 1, 2, 16
+    B, H, BT = 2, 2, 16
     s64 = torch.randn(B, T, H, device=DEV, dtype=torch.float64)
     golden = chunk_cumsum_ref(s64, BT, reverse, scale, None)
     s = s64.to(dtype)
@@ -413,7 +665,20 @@ def test_cumsum_scalar(dtype, T, reverse, scale):
     o = torch.empty_like(s)
     NT = triton.cdiv(T, BT)
     chunk_local_cumsum_scalar_kernel[(NT, B * H)](
-        s, o, scale, None, None, T, B=B, H=H, BT=BT, REVERSE=reverse, HEAD_FIRST=False
+        s,
+        o,
+        scale,
+        None,
+        None,
+        T,
+        s.stride(0),
+        o.stride(0),
+        S_STRIDES=s.stride()[1:],
+        O_STRIDES=o.stride()[1:],
+        B=B,
+        H=H,
+        BT=BT,
+        REVERSE=reverse,
     )
     assert_golden(o, golden, ref, dtype, f"cumsum_scalar T={T} rev={reverse} scale={scale}")
 
@@ -421,7 +686,7 @@ def test_cumsum_scalar(dtype, T, reverse, scale):
 @pytest.mark.parametrize("dtype,T,reverse,scale", _CUMSUM_CASES, ids=_case_id)
 def test_cumsum_vector(dtype, T, reverse, scale):
     torch.manual_seed(6)
-    B, H, S, BT = 1, 2, 16, 16
+    B, H, S, BT = 2, 2, 16, 16
     s64 = torch.randn(B, T, H, S, device=DEV, dtype=torch.float64)
     golden = chunk_cumsum_ref(s64, BT, reverse, scale, None)
     s = s64.to(dtype)
@@ -431,7 +696,21 @@ def test_cumsum_vector(dtype, T, reverse, scale):
     NT = triton.cdiv(T, BT)
     grid = lambda meta: (triton.cdiv(S, meta["BS"]), NT, B * H)
     chunk_local_cumsum_vector_kernel[grid](
-        s, o, scale, None, None, T, B=B, H=H, S=S, BT=BT, REVERSE=reverse, HEAD_FIRST=False
+        s,
+        o,
+        scale,
+        None,
+        None,
+        T,
+        s.stride(0),
+        o.stride(0),
+        S_STRIDES=s.stride()[1:],
+        O_STRIDES=o.stride()[1:],
+        B=B,
+        H=H,
+        S=S,
+        BT=BT,
+        REVERSE=reverse,
     )
     assert_golden(o, golden, ref, dtype, f"cumsum_vector T={T} rev={reverse} scale={scale}")
 
@@ -467,11 +746,85 @@ def test_cumsum_vector_varlen(dtype, docs, reverse):
         cu,
         chunk_indices,
         total,
+        s.stride(0),
+        o.stride(0),
+        S_STRIDES=s.stride()[1:],
+        O_STRIDES=o.stride()[1:],
         B=1,
         H=H,
         S=S,
         BT=BT,
         REVERSE=reverse,
-        HEAD_FIRST=False,
     )
     assert_golden(o, golden, ref, dtype, f"cumsum_vector_varlen docs={docs} rev={reverse}")
+
+
+def test_cumsum_varlen_head_first():
+    """Exercise packed documents stored physically as (B, H, T[, S])."""
+    torch.manual_seed(10)
+    dtype = torch.float32
+    docs = (7, 17)
+    total, H, S, BT = sum(docs), 2, 16, 16
+    cu = _cu_seqlens(docs)
+    chunk_indices = prepare_chunk_indices(cu, BT)
+    NT = chunk_indices.shape[0]
+
+    scalar64 = torch.randn(1, total, H, device=DEV, dtype=torch.float64)
+    scalar = scalar64.to(dtype).permute(0, 2, 1).contiguous().permute(0, 2, 1)
+    scalar_out = torch.empty(1, H, total, device=DEV, dtype=dtype).permute(0, 2, 1)
+    chunk_local_cumsum_scalar_kernel[(NT, H)](
+        scalar,
+        scalar_out,
+        None,
+        cu,
+        chunk_indices,
+        total,
+        scalar.stride(0),
+        scalar_out.stride(0),
+        S_STRIDES=scalar.stride()[1:],
+        O_STRIDES=scalar_out.stride()[1:],
+        B=1,
+        H=H,
+        BT=BT,
+        REVERSE=True,
+    )
+    scalar_golden = chunk_cumsum_ref(scalar64, BT, True, None, cu)
+    scalar_ref = chunk_cumsum_ref(scalar, BT, True, None, cu)
+    assert_golden(
+        scalar_out,
+        scalar_golden,
+        scalar_ref,
+        dtype,
+        "cumsum_scalar_varlen_head_first",
+    )
+
+    vector64 = torch.randn(1, total, H, S, device=DEV, dtype=torch.float64)
+    vector = vector64.to(dtype).permute(0, 2, 1, 3).contiguous().permute(0, 2, 1, 3)
+    vector_out = torch.empty(1, H, total, S, device=DEV, dtype=dtype).permute(0, 2, 1, 3)
+    grid = lambda meta: (triton.cdiv(S, meta["BS"]), NT, H)
+    chunk_local_cumsum_vector_kernel[grid](
+        vector,
+        vector_out,
+        None,
+        cu,
+        chunk_indices,
+        total,
+        vector.stride(0),
+        vector_out.stride(0),
+        S_STRIDES=vector.stride()[1:],
+        O_STRIDES=vector_out.stride()[1:],
+        B=1,
+        H=H,
+        S=S,
+        BT=BT,
+        REVERSE=True,
+    )
+    vector_golden = chunk_cumsum_ref(vector64, BT, True, None, cu)
+    vector_ref = chunk_cumsum_ref(vector, BT, True, None, cu)
+    assert_golden(
+        vector_out,
+        vector_golden,
+        vector_ref,
+        dtype,
+        "cumsum_vector_varlen_head_first",
+    )

--- a/test/test_triton_utils.py
+++ b/test/test_triton_utils.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for utilities shared by hand-written Triton kernels."""
+
+import pytest
+
+triton_utils = pytest.importorskip("attn_gym._backends.triton.utils")
+storage_cosize = triton_utils.storage_cosize
+
+
+def test_storage_cosize():
+    """Match CuTe co-size semantics for common nonnegative-strided layouts."""
+    assert storage_cosize((), ()) == 1
+    assert storage_cosize((0, 3), (3, 1)) == 0
+    assert storage_cosize((2, 3), (3, 1)) == 6
+    assert storage_cosize((2, 3), (8, 2)) == 13
+    assert storage_cosize((4, 5), (0, 1)) == 5
+
+    with pytest.raises(ValueError, match="equal length"):
+        storage_cosize((2, 3), (1,))
+    with pytest.raises(ValueError, match="nonnegative"):
+        storage_cosize((-1,), (1,))
+    with pytest.raises(ValueError, match="nonnegative"):
+        storage_cosize((1,), (-1,))


### PR DESCRIPTION
Human Note

Agent note
The small KDA Triton helpers encoded contiguous pointer arithmetic, and cumsum selected physical
layouts through `HEAD_FIRST`. In packed-varlen head-first mode, that branch used each document's
local length as the physical head stride, so later documents could overlap or be written to the
wrong location.

Thread actual tensor strides through the L2 norm, gate, and cumsum kernels and centralize their
offset generation through `ptr_offset`. Cumsum now consumes logical strides instead of a layout
flag. Leading batch strides are separate scalar arguments, allowing Triton to specialize on their
alignment without baking T-dependent values into the cache key; constexpr inner strides preserve
vectorization. Add a CuTe-like `storage_cosize` host helper for selecting 64-bit offsets, establish
that packed-varlen launches use `B == 1`, and remove deprecated block pointers from these leaf
helpers. A descriptor-only implementation was not used because the supported arbitrary strided
views, including non-unit innermost strides, are not descriptor compatible.

Focused coverage includes non-power-of-two dimensions, independent strided inputs and outputs,
packed-varlen head-first cumsum, repeated and persistent gate paths, and synthetic 64-bit offset
selection. Matched fixed-pointer CUDA Graph replay on GB300 measured candidate/baseline ratios from
0.984 to 1.008 across all nine B=1 helper variants. Matched B=4 benchmarks measured gate forward at
43.87 versus 45.05 us and vector cumsum at 62.95 versus 63.38 us; PTX retained vectorized global
loads and stores.

Test Plan:

```bash
gpu-run 2 -- env PYTHONPATH=$PWD ~/.venvs/nightly/bin/python -m pytest -q test/test_kda_kernels.py test/test_triton_utils.py
prek run --files attn_gym/_backends/triton/utils.py attn_gym/linear/kda/bwd/triton/cumsum.py attn_gym/linear/kda/bwd/triton/gate_bwd.py attn_gym/linear/kda/bwd/triton/l2norm_bwd.py attn_gym/linear/kda/fwd/triton/gate_fwd.py attn_gym/linear/kda/fwd/triton/l2norm_fwd.py test/test_kda_kernels.py test/test_triton_utils.py
```
