### PR TITLE
Route scalar KDA cumsum through vector kernel

### DIFF
--- a/attn_gym/linear/kda/bwd/triton/cumsum.py
+++ b/attn_gym/linear/kda/bwd/triton/cumsum.py
@@ -13,15 +13,24 @@
 # head-first layouts. The leading batch stride is passed separately so Triton can
 # specialize on its alignment without treating its T-dependent value as constexpr;
 # inner strides remain constexpr for codegen. Variable-length packing and an
-# optional output scale are also supported.
+# optional output scale are also supported. Larger token-major scalar gates reuse
+# the vector kernel through a zero-copy (B, T, 1, H) view.
 
+import torch
 import triton
 import triton.language as tl
 
 from attn_gym._backends.triton.utils import ptr_offset
-from attn_gym.linear.kda.utils import autotune_cache_kwargs, check_shared_mem
+from attn_gym.linear.kda.utils import (
+    autotune_cache_kwargs,
+    check_shared_mem,
+    input_guard,
+    prepare_chunk_indices,
+)
 
 BS_LIST = [32, 64] if check_shared_mem() else [16, 32]
+# H=8 is near the scalar/vector crossover on GB300; K3's supported shapes start at H=16.
+_MIN_VECTOR_HEADS = 16
 
 
 @triton.heuristics(
@@ -98,7 +107,8 @@ def chunk_local_cumsum_scalar_kernel(
 )
 @triton.autotune(
     configs=[triton.Config({"BS": bs}, num_warps=w) for bs in BS_LIST for w in [2, 4, 8]],
-    key=["B", "H", "S", "BT", "IS_VARLEN", "REVERSE"],
+    # BS changes the scan order; exclude grid-only B so batch changes reuse one tile.
+    key=["H", "S", "BT", "IS_VARLEN", "REVERSE"],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=["T"])
@@ -167,3 +177,83 @@ def chunk_local_cumsum_vector_kernel(
         b_o.to(o.dtype.element_ty),
         mask=m,
     )
+
+
+@input_guard(no_guard_contiguous=("g",))
+def chunk_local_cumsum_scalar(
+    g: torch.Tensor,
+    chunk_size: int,
+    reverse: bool = False,
+    scale: float | None = None,
+    cu_seqlens: torch.Tensor | None = None,
+    head_first: bool = False,
+    output_dtype: torch.dtype | None = torch.float32,
+    chunk_indices: torch.LongTensor | None = None,
+) -> torch.Tensor:
+    """Compute chunk-local cumsums for scalar gates.
+
+    Token-major inputs with at least 16 heads use a zero-copy ``(B, T, 1, H)``
+    view of the vector kernel, including for strided tensors. Smaller and
+    head-first inputs retain the scalar kernel. Packed inputs require batch size one.
+    """
+    if g.ndim != 3:
+        raise ValueError(f"Expected a 3D scalar gate, got shape {tuple(g.shape)}")
+    if chunk_size <= 0 or chunk_size & (chunk_size - 1):
+        raise ValueError(f"chunk_size must be a positive power of two, got {chunk_size}")
+    if cu_seqlens is not None and g.shape[0] != 1:
+        raise ValueError("Packed variable-length inputs must have batch size one")
+
+    output = torch.empty_like(
+        g,
+        dtype=output_dtype if output_dtype is not None else g.dtype,
+    )
+    source = g.transpose(1, 2) if head_first else g
+    destination = output.transpose(1, 2) if head_first else output
+    batch, tokens, heads = source.shape
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+    chunks = triton.cdiv(tokens, chunk_size) if cu_seqlens is None else len(chunk_indices)
+
+    if not head_first and heads >= _MIN_VECTOR_HEADS:
+        source = source.unsqueeze(2)
+        destination = destination.unsqueeze(2)
+
+        def grid(meta):
+            return (triton.cdiv(heads, meta["BS"]), chunks, batch)
+
+        chunk_local_cumsum_vector_kernel[grid](
+            source,
+            destination,
+            scale,
+            cu_seqlens,
+            chunk_indices,
+            tokens,
+            source.stride(0),
+            destination.stride(0),
+            S_STRIDES=source.stride()[1:],
+            O_STRIDES=destination.stride()[1:],
+            B=batch,
+            H=1,
+            S=heads,
+            BT=chunk_size,
+            REVERSE=reverse,
+        )
+    else:
+        chunk_local_cumsum_scalar_kernel[(chunks, batch * heads)](
+            source,
+            destination,
+            scale,
+            cu_seqlens,
+            chunk_indices,
+            tokens,
+            source.stride(0),
+            destination.stride(0),
+            S_STRIDES=source.stride()[1:],
+            O_STRIDES=destination.stride()[1:],
+            B=batch,
+            H=heads,
+            BT=chunk_size,
+            REVERSE=reverse,
+        )
+    return output

--- a/test/test_kda_kernels.py
+++ b/test/test_kda_kernels.py
@@ -16,7 +16,9 @@ import torch
 triton = pytest.importorskip("triton")
 
 # These imports intentionally follow the optional-dependency check above.
+import attn_gym.linear.kda.bwd.triton.cumsum as cumsum_module
 from attn_gym.linear.kda.bwd.triton.cumsum import (
+    chunk_local_cumsum_scalar,
     chunk_local_cumsum_scalar_kernel,
     chunk_local_cumsum_vector_kernel,
 )
@@ -683,6 +685,91 @@ def test_cumsum_scalar(dtype, T, reverse, scale):
     assert_golden(o, golden, ref, dtype, f"cumsum_scalar T={T} rev={reverse} scale={scale}")
 
 
+class _KernelRecorder:
+    def __init__(self, name, calls):
+        self.name = name
+        self.calls = calls
+
+    def __getitem__(self, grid):
+        def launch(*args, **kwargs):
+            self.calls.append((self.name, args, kwargs))
+
+        return launch
+
+
+def test_cumsum_vector_autotune_is_batch_invariant():
+    assert "B" not in _autotuner(chunk_local_cumsum_vector_kernel).keys
+
+
+def test_cumsum_scalar_dispatches_by_layout(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        cumsum_module,
+        "chunk_local_cumsum_scalar_kernel",
+        _KernelRecorder("scalar", calls),
+    )
+    monkeypatch.setattr(
+        cumsum_module,
+        "chunk_local_cumsum_vector_kernel",
+        _KernelRecorder("vector", calls),
+    )
+
+    token_major = torch.randn(2, 65, 96, device=DEV)
+    output = chunk_local_cumsum_scalar(token_major, chunk_size=64)
+    name, args, kwargs = calls.pop()
+    assert name == "vector"
+    assert args[0].shape == (2, 65, 1, 96)
+    assert args[0].data_ptr() == token_major.data_ptr()
+    assert args[1].data_ptr() == output.data_ptr()
+    assert kwargs["S_STRIDES"] == args[0].stride()[1:]
+    assert kwargs["H"] == 1
+    assert kwargs["S"] == 96
+
+    strided = _strided_copy(token_major)
+    chunk_local_cumsum_scalar(strided, chunk_size=64)
+    name, args, kwargs = calls.pop()
+    assert name == "vector"
+    assert args[0].data_ptr() == strided.data_ptr()
+    assert args[0].stride(-1) == 2
+    assert kwargs["S_STRIDES"] == args[0].stride()[1:]
+
+    head_first = token_major.transpose(1, 2).contiguous()
+    chunk_local_cumsum_scalar(head_first, chunk_size=64, head_first=True)
+    assert calls.pop()[0] == "scalar"
+
+    small = torch.randn(2, 65, 15, device=DEV)
+    chunk_local_cumsum_scalar(small, chunk_size=64)
+    assert calls.pop()[0] == "scalar"
+
+
+@pytest.mark.parametrize(("reverse", "scale"), ((False, None), (True, 1.25)))
+def test_cumsum_scalar_vector_view_fixed(reverse, scale):
+    torch.manual_seed(51)
+    B, T, H, BT = 3, 129, 96, 64
+    source = torch.randn(B, T, H, device=DEV)
+    expected = chunk_cumsum_ref(source, BT, reverse=reverse, scale=scale)
+
+    actual = chunk_local_cumsum_scalar(source, BT, reverse=reverse, scale=scale)
+    torch.testing.assert_close(actual, expected)
+
+    strided = _strided_copy(source)
+    strided_actual = chunk_local_cumsum_scalar(strided, BT, reverse=reverse, scale=scale)
+    torch.testing.assert_close(strided_actual, expected)
+
+    single = chunk_local_cumsum_scalar(source[1:2], BT, reverse=reverse, scale=scale)
+    torch.testing.assert_close(actual[1], single[0], rtol=0, atol=0)
+
+    head_first = source.transpose(1, 2).contiguous()
+    head_first_actual = chunk_local_cumsum_scalar(
+        head_first,
+        BT,
+        reverse=reverse,
+        scale=scale,
+        head_first=True,
+    )
+    torch.testing.assert_close(head_first_actual, expected.transpose(1, 2))
+
+
 @pytest.mark.parametrize("dtype,T,reverse,scale", _CUMSUM_CASES, ids=_case_id)
 def test_cumsum_vector(dtype, T, reverse, scale):
     torch.manual_seed(6)
@@ -828,3 +915,42 @@ def test_cumsum_varlen_head_first():
         dtype,
         "cumsum_vector_varlen_head_first",
     )
+
+
+def test_cumsum_scalar_vector_view_varlen():
+    torch.manual_seed(52)
+    docs = (31, 65, 79)
+    H, BT = 96, 64
+    cu = _cu_seqlens(docs)
+    source = torch.randn(1, sum(docs), H, device=DEV)
+    expected = chunk_cumsum_ref(source, BT, reverse=True, scale=0.75, cu_seqlens=cu)
+
+    actual = chunk_local_cumsum_scalar(
+        source,
+        BT,
+        reverse=True,
+        scale=0.75,
+        cu_seqlens=cu,
+    )
+    torch.testing.assert_close(actual, expected)
+
+    head_first = source.transpose(1, 2).contiguous()
+    head_first_actual = chunk_local_cumsum_scalar(
+        head_first,
+        BT,
+        reverse=True,
+        scale=0.75,
+        cu_seqlens=cu,
+        head_first=True,
+    )
+    torch.testing.assert_close(head_first_actual, expected.transpose(1, 2))
+
+    start, end = docs[0], docs[0] + docs[1]
+    single = chunk_local_cumsum_scalar(
+        source[:, start:end],
+        BT,
+        reverse=True,
+        scale=0.75,
+        cu_seqlens=_cu_seqlens((docs[1],)),
+    )
+    torch.testing.assert_close(actual[:, start:end], single, rtol=0, atol=0)


### PR DESCRIPTION
## Summary

- add a scalar chunk-cumsum launcher that reuses the existing vector kernel through a zero-copy `[B, T, 1, H]` view for token-major gates with `H >= 16`
- retain the scalar kernel for smaller and head-first layouts, while forwarding the logical strides added by #250 without copying strided inputs
- remove `B` from the vector autotune key because its `BS` tile changes scan order; batch changes now reuse one tile and remain bitwise invariant
- cover Kimi K3's `H=96` shape, zero-copy and strided dispatch, head-first fallback, fixed and packed-varlen paths, forward/reverse scaling, and exact batch invariance

## Performance

On a GB300 at the K3 global-head shape (`B=1, T=300K, H=96, BT=64`, FP32 reverse scan, 2x-L2 flush), the vector view reduced median kernel time from **385.7 us to 60.1 us (6.42x)**. This reaches 48.3% of the analytical pin-bandwidth roofline.

The H=16 cutoff avoids regressions below the measured crossover: H=8 is approximately parity, while K3's supported local/global head counts begin at H=16.

## Rebase onto #250

This branch is rebased directly onto #250's merge commit, `a1e1078`. The launcher passes runtime batch strides and constexpr logical inner strides into the landed kernels, preserving arbitrary strided layouts and the vectorized B>1 load/store path.

## Test plan

```bash
gpu-run 1 -- env PYTHONPATH="$PWD" ~/.venvs/nightly/bin/python -m pytest -q test/test_kda_kernels.py test/test_triton_utils.py
env PYTHONPATH="$PWD" ~/.venvs/nightly/bin/python -m pytest -q test/test_kda.py
prek run --files attn_gym/linear/kda/bwd/triton/cumsum.py test/test_kda_kernels.py
```

Results: 114 focused GPU tests and 9 KDA integration tests passed. A production-autotune spot check also produced bitwise-identical fixed-batch, packed-varlen, and strided-vs-contiguous outputs.
