### PR TITLE
Persist CuTeDSL KDA inter-solve kernels

### DIFF
--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_inter_solve.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_inter_solve.py
@@ -16,10 +16,12 @@ from __future__ import annotations
 import cutlass
 import torch
 import triton
-from cuda.bindings import driver as cuda_drv
-from cutlass.cute.runtime import from_dlpack
+from cutlass import cute
+from cutlass.cute.runtime import make_fake_compact_tensor
 from torch._subclasses.fake_tensor import FakeTensor
 
+from attn_gym._backends.cute import compile_tvm_ffi, jit_cache
+from attn_gym._backends.cute.target import get_compile_target
 from attn_gym.linear.kda.fwd.cute.chunk_kda_k3b_offdiag_cutedsl import (
     ChunkKDAFwdK3bOffdiagCuteDSL,
 )
@@ -31,9 +33,180 @@ from attn_gym.linear.kda.utils import (
     prepare_chunk_indices,
 )
 
+_SUPPORTED_HEAD_DIM = 128
+_SUPPORTED_CHUNK_SIZE = 64
+_SUPPORTED_SUBCHUNK_SIZE = 16
+_SUPPORTED_NUM_SUBCHUNKS = 4
 
-def _to_cute_tensor(tensor: torch.Tensor, assumed_align: int = 16):
-    return from_dlpack(tensor.detach(), assumed_align=assumed_align)
+
+def _check_compile_target() -> None:
+    target = get_compile_target()
+    if target.device_type != "cuda" or target.capability is None or target.capability < (10, 0):
+        raise ValueError(f"KDA inter-solve requires CUDA capability >= 10.0; got target={target}")
+
+
+def _validate_specialization(head_dim: int, chunk_size: int, subchunk_size: int) -> int:
+    assert head_dim == _SUPPORTED_HEAD_DIM, (
+        f"KDA inter-solve requires head_dim={_SUPPORTED_HEAD_DIM}, got {head_dim}"
+    )
+    assert chunk_size == _SUPPORTED_CHUNK_SIZE, (
+        f"KDA inter-solve requires chunk_size={_SUPPORTED_CHUNK_SIZE}, got {chunk_size}"
+    )
+    assert subchunk_size == _SUPPORTED_SUBCHUNK_SIZE, (
+        f"KDA inter-solve requires subchunk_size={_SUPPORTED_SUBCHUNK_SIZE}, got {subchunk_size}"
+    )
+    assert chunk_size % subchunk_size == 0
+    num_subchunks = chunk_size // subchunk_size
+    assert num_subchunks == _SUPPORTED_NUM_SUBCHUNKS
+    return num_subchunks * (num_subchunks - 1) // 2
+
+
+@jit_cache
+def _compile_k3b(
+    heads: int,
+    head_dim: int,
+    chunk_size: int,
+    subchunk_size: int,
+    varlen: bool,
+):
+    """Compile one persistent K3b TVM-FFI specialization."""
+    _check_compile_target()
+    offdiag_blocks = _validate_specialization(head_dim, chunk_size, subchunk_size)
+    num_subchunks = chunk_size // subchunk_size
+    op = ChunkKDAFwdK3bOffdiagCuteDSL(
+        BC=subchunk_size,
+        D=head_dim,
+        chunk_size=chunk_size,
+        num_subchunks=num_subchunks,
+        varlen=varlen,
+    )
+    tokens, chunks, sequences = (cute.sym_int() for _ in range(3))
+    q = make_fake_compact_tensor(
+        cutlass.BFloat16,
+        (tokens, heads * head_dim),
+        stride_order=(1, 0),
+        assumed_align=16,
+    )
+    k = make_fake_compact_tensor(
+        cutlass.BFloat16,
+        (tokens, heads * head_dim),
+        stride_order=(1, 0),
+        assumed_align=16,
+    )
+    g = make_fake_compact_tensor(
+        cutlass.Float32,
+        (tokens, heads * head_dim),
+        stride_order=(1, 0),
+        assumed_align=16,
+    )
+    beta = make_fake_compact_tensor(
+        cutlass.Float32,
+        (tokens, heads),
+        stride_order=(1, 0),
+        assumed_align=16,
+    )
+    Aqk = make_fake_compact_tensor(
+        cutlass.BFloat16,
+        (tokens, heads * chunk_size),
+        stride_order=(1, 0),
+        assumed_align=16,
+    )
+    AkkOD = make_fake_compact_tensor(
+        cutlass.Float32,
+        (chunks * offdiag_blocks, heads * subchunk_size * subchunk_size),
+        stride_order=(1, 0),
+        assumed_align=16,
+    )
+    cu_seqlens = make_fake_compact_tensor(
+        cutlass.Int32,
+        (sequences,),
+        stride_order=(0,),
+        assumed_align=4,
+    )
+    chunk_indices = make_fake_compact_tensor(
+        cutlass.Int32,
+        (chunks * 2,),
+        stride_order=(0,),
+        assumed_align=4,
+    )
+    return compile_tvm_ffi(
+        op,
+        q,
+        k,
+        g,
+        beta,
+        Aqk,
+        AkkOD,
+        cutlass.Float32(1.0),
+        heads,
+        1,
+        cu_seqlens,
+        chunk_indices,
+        name=(f"kda_fwd_k3b_h{heads}_d{head_dim}_c{chunk_size}_sc{subchunk_size}_vl{int(varlen)}"),
+    )
+
+
+@jit_cache
+def _compile_k4b(
+    heads: int,
+    head_dim: int,
+    chunk_size: int,
+    subchunk_size: int,
+    varlen: bool,
+):
+    """Compile one persistent K4b TVM-FFI specialization."""
+    _check_compile_target()
+    offdiag_blocks = _validate_specialization(head_dim, chunk_size, subchunk_size)
+    num_subchunks = chunk_size // subchunk_size
+    op = ChunkKDAFwdK4bInverseCuteDSL(
+        BC=subchunk_size,
+        chunk_size=chunk_size,
+        num_subchunks=num_subchunks,
+        fwd_sub_mode="preinverted",
+        varlen=varlen,
+    )
+    tokens, chunks, sequences = (cute.sym_int() for _ in range(3))
+    AkkOD = make_fake_compact_tensor(
+        cutlass.Float32,
+        (chunks * offdiag_blocks, heads * subchunk_size * subchunk_size),
+        stride_order=(1, 0),
+        assumed_align=16,
+    )
+    Akkd = make_fake_compact_tensor(
+        cutlass.Float32,
+        (tokens, heads * subchunk_size),
+        stride_order=(1, 0),
+        assumed_align=16,
+    )
+    Akk = make_fake_compact_tensor(
+        cutlass.BFloat16,
+        (tokens, heads * chunk_size),
+        stride_order=(1, 0),
+        assumed_align=16,
+    )
+    cu_seqlens = make_fake_compact_tensor(
+        cutlass.Int32,
+        (sequences,),
+        stride_order=(0,),
+        assumed_align=4,
+    )
+    chunk_indices = make_fake_compact_tensor(
+        cutlass.Int32,
+        (chunks * 2,),
+        stride_order=(0,),
+        assumed_align=4,
+    )
+    return compile_tvm_ffi(
+        op,
+        AkkOD,
+        Akkd,
+        Akk,
+        heads,
+        1,
+        cu_seqlens,
+        chunk_indices,
+        name=(f"kda_fwd_k4b_h{heads}_d{head_dim}_c{chunk_size}_sc{subchunk_size}_vl{int(varlen)}"),
+    )
 
 
 def chunk_kda_fwd_inter_solve_cute(
@@ -53,15 +226,20 @@ def chunk_kda_fwd_inter_solve_cute(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     del num_chunks
 
-    assert chunk_size == 64, "chunk_kda_fwd_inter_solve_cute requires chunk_size=64"
+    assert Akkd.ndim == 4, f"Akkd must be 4D, got shape {tuple(Akkd.shape)}"
     B, T, H, K = k.shape
     BT = chunk_size
-    BC = 16
+    BC = Akkd.shape[-1]
+    offdiag_blocks = _validate_specialization(K, BT, BC)
     assert B == 1, f"chunk_kda_fwd_inter_solve_cute requires B=1, got B={B}"
-    assert K == 128, f"chunk_kda_fwd_inter_solve_cute requires K=128, got K={K}"
     assert Akkd.shape == (B, T, H, BC), (
         f"Akkd must have shape {(B, T, H, BC)}, got {tuple(Akkd.shape)}"
     )
+    if cu_seqlens is None:
+        assert T % BT == 0, (
+            "fixed-length KDA inter-solve requires complete chunks, "
+            f"got tokens={T}, chunk_size={BT}"
+        )
 
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
@@ -93,62 +271,47 @@ def chunk_kda_fwd_inter_solve_cute(
     g_flat = gk.reshape(B * T, H * K).contiguous()
     beta_flat = beta.reshape(B * T, H).contiguous()
     akkd_flat = Akkd.reshape(B * T, H * BC).contiguous()
+    akk_od_shape = (NT * offdiag_blocks, H * BC * BC)
     if AkkOD is None:
-        akk_od = torch.empty(NT * 6, H * BC * BC, device=k.device, dtype=torch.float32)
+        akk_od = torch.empty(akk_od_shape, device=k.device, dtype=torch.float32)
     else:
-        assert AkkOD.shape == (NT * 6, H * BC * BC), (
-            f"AkkOD must have shape {(NT * 6, H * BC * BC)}, got {tuple(AkkOD.shape)}"
+        assert AkkOD.shape == akk_od_shape, (
+            f"AkkOD must have shape {akk_od_shape}, got {tuple(AkkOD.shape)}"
         )
         akk_od = AkkOD
 
-    m_q = _to_cute_tensor(q_flat)
-    m_k = _to_cute_tensor(k_flat)
-    m_g = _to_cute_tensor(g_flat)
-    m_beta = _to_cute_tensor(beta_flat)
-    m_aqk = _to_cute_tensor(Aqk_flat)
-    m_akk_od = _to_cute_tensor(akk_od)
-    m_akkd = _to_cute_tensor(akkd_flat)
-    m_akk = _to_cute_tensor(Akk_flat)
-
-    m_cu_seqlens = None
-    m_chunk_indices = None
-    if cu_seqlens is not None:
+    varlen = cu_seqlens is not None
+    if varlen:
         assert chunk_indices is not None
         cu_seqlens_i32 = cu_seqlens.to(torch.int32).contiguous()
         chunk_indices_i32 = chunk_indices.to(torch.int32).flatten().contiguous()
-        m_cu_seqlens = _to_cute_tensor(cu_seqlens_i32, assumed_align=4)
-        m_chunk_indices = _to_cute_tensor(chunk_indices_i32, assumed_align=4)
+    else:
+        cu_seqlens_i32 = torch.empty(1, dtype=torch.int32, device=k.device)
+        chunk_indices_i32 = torch.empty(1, dtype=torch.int32, device=k.device)
 
-    stream = cuda_drv.CUstream(torch.cuda.current_stream().cuda_stream)
-    k3b = ChunkKDAFwdK3bOffdiagCuteDSL(BC=BC, D=K)
-    # The repo's diagonal sub-chunk stage already stores (I - Akkd)^-1. The
-    # standalone prototype passed raw diagonal blocks, so K4b's default mode
-    # performs that diagonal forward substitution internally. Use the
-    # pre-inverted mode here to avoid inverting/sign-flipping Akkd twice.
-    k4b = ChunkKDAFwdK4bInverseCuteDSL(BC=BC, BK=64, fwd_sub_mode="preinverted")
+    k3b = _compile_k3b(H, K, BT, BC, varlen)
     k3b(
-        m_q,
-        m_k,
-        m_g,
-        m_beta,
-        m_aqk,
-        m_akk_od,
+        q_flat,
+        k_flat,
+        g_flat,
+        beta_flat,
+        Aqk_flat,
+        akk_od,
         cutlass.Float32(scale),
-        int(H),
-        int(NT),
-        stream,
-        cu_seqlens=m_cu_seqlens,
-        chunk_indices=m_chunk_indices,
+        H,
+        NT,
+        cu_seqlens_i32,
+        chunk_indices_i32,
     )
+    k4b = _compile_k4b(H, K, BT, BC, varlen)
     k4b(
-        m_akk_od,
-        m_akkd,
-        m_akk,
-        int(H),
-        int(NT),
-        stream,
-        cu_seqlens=m_cu_seqlens,
-        chunk_indices=m_chunk_indices,
+        akk_od,
+        akkd_flat,
+        Akk_flat,
+        H,
+        NT,
+        cu_seqlens_i32,
+        chunk_indices_i32,
     )
     return Aqk, Akk
 

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_k3b_offdiag_cutedsl.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_k3b_offdiag_cutedsl.py
@@ -31,13 +31,28 @@ from cutlass.cute.nvgpu import warp
 
 
 class ChunkKDAFwdK3bOffdiagCuteDSL:
-    NC = 4
     WARP_SIZE = 32
 
-    def __init__(self, BC: int = 16, D: int = 128):
+    def __init__(
+        self,
+        BC: int = 16,
+        D: int = 128,
+        chunk_size: int = 64,
+        num_subchunks: int = 4,
+        varlen: bool = False,
+    ):
+        assert num_subchunks == 4, (
+            f"ChunkKDAFwdK3bOffdiagCuteDSL only supports four subchunks, got {num_subchunks}"
+        )
+        assert chunk_size == num_subchunks * BC, (
+            f"chunk_size must equal num_subchunks * BC, got {chunk_size} and "
+            f"{num_subchunks} * {BC}"
+        )
         self.BC = BC
         self.D = D
-        self.BT = self.NC * BC
+        self.varlen = varlen
+        self.BT = chunk_size
+        self.num_offdiag_blocks = num_subchunks * (num_subchunks - 1) // 2
         self.num_threads = 128
         self.mma_inst_shape = (16, 8, 16)
         self.atom_layout_mnk = (1, 1, 1)
@@ -54,17 +69,17 @@ class ChunkKDAFwdK3bOffdiagCuteDSL:
         scale: cutlass.Float32,
         H: int,
         total_chunks: int,
+        cu_seqlens: cute.Tensor,
+        chunk_indices: cute.Tensor,
         stream,
-        cu_seqlens: cute.Tensor | None = None,
-        chunk_indices: cute.Tensor | None = None,
     ):
         self._dtype: type[cutlass.Numeric] = mQ.element_type
 
-        if cutlass.const_expr(cu_seqlens is not None):
+        if cutlass.const_expr(self.varlen):
             NT = cute.size(chunk_indices, mode=[0]) // 2
-            num_pairs = NT * 6
+            num_pairs = NT * self.num_offdiag_blocks
         else:
-            num_pairs = total_chunks * 6
+            num_pairs = total_chunks * self.num_offdiag_blocks
         grid = (num_pairs, H, 1)
 
         smem_k_block_size = 64
@@ -160,8 +175,8 @@ class ChunkKDAFwdK3bOffdiagCuteDSL:
         lane_idx = tidx % self.WARP_SIZE
 
         # ── Decompose block_idx into chunk and pair ──
-        chunk_idx = block_idx // 6
-        pair_idx = block_idx % 6
+        chunk_idx = block_idx // self.num_offdiag_blocks
+        pair_idx = block_idx % self.num_offdiag_blocks
 
         ri = 1
         if pair_idx >= 1:
@@ -171,7 +186,7 @@ class ChunkKDAFwdK3bOffdiagCuteDSL:
         ci = pair_idx - (ri * (ri - 1)) // 2
 
         # ── Varlen resolution ──
-        if cutlass.const_expr(cu_seqlens is not None):
+        if cutlass.const_expr(self.varlen):
             i_n = chunk_indices[chunk_idx * 2]
             i_t = chunk_indices[chunk_idx * 2 + 1]
             bos = cu_seqlens[i_n]
@@ -197,7 +212,7 @@ class ChunkKDAFwdK3bOffdiagCuteDSL:
         # ══════════════════════════════════════════════════════════
         # Phase 1: Gating into SMEM
         # ══════════════════════════════════════════════════════════
-        if cutlass.const_expr(cu_seqlens is not None):
+        if cutlass.const_expr(self.varlen):
             col = tidx
             h_col = h_offset + col
             if chunk_base + self.BT <= eos:
@@ -334,14 +349,14 @@ class ChunkKDAFwdK3bOffdiagCuteDSL:
         cC = cute.make_identity_tensor((self.BC, self.BC))
         tCcC = thr_mma.partition_C(cC)
 
-        od_row = chunk_idx * 6 + pair_idx
+        od_row = chunk_idx * self.num_offdiag_blocks + pair_idx
 
         if warp_idx == 0:
             out_dtype = mAqk.element_type
             for i in cutlass.range_constexpr(cute.size(acc_Aqk)):
                 row = tCcC[i][0]
                 col = tCcC[i][1]
-                if cutlass.const_expr(cu_seqlens is not None):
+                if cutlass.const_expr(self.varlen):
                     if chunk_base + self.BT <= eos or ti_row + row < eos:
                         mAqk[ti_row + row, head_idx * self.BT + ci * self.BC + col] = out_dtype(
                             acc_Aqk[i] * scale

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_k4b_inverse_cutedsl.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_k4b_inverse_cutedsl.py
@@ -32,23 +32,32 @@ from cutlass.cute.nvgpu import warp
 
 
 class ChunkKDAFwdK4bInverseCuteDSL:
-    NC = 4
     WARP_SIZE = 32
 
     def __init__(
         self,
         BC: int = 16,
-        BK: int = 64,
+        chunk_size: int = 64,
+        num_subchunks: int = 4,
         fwd_sub_mode: str = "cute_recurrence",
         skip_fwd_sub: bool = False,
+        varlen: bool = False,
     ):
+        assert num_subchunks == 4, (
+            f"ChunkKDAFwdK4bInverseCuteDSL only supports four subchunks, got {num_subchunks}"
+        )
+        assert chunk_size == num_subchunks * BC, (
+            f"chunk_size must equal num_subchunks * BC, got {chunk_size} and "
+            f"{num_subchunks} * {BC}"
+        )
         self.BC = BC
-        self.BK = BK
-        self.BT = self.NC * BC
+        self.BT = chunk_size
+        self.num_offdiag_blocks = num_subchunks * (num_subchunks - 1) // 2
         self.num_threads = 128
         self.mma_inst_shape = (16, 8, 16)
         self.atom_layout_mnk = (1, 1, 1)
         self.fwd_sub_mode = "skip" if skip_fwd_sub else fwd_sub_mode
+        self.varlen = varlen
 
     @cute.jit
     def _fwd_sub_block(self, mAkkd, sAi, block_start, tidx, akkd_col_off, valid_rows):
@@ -101,9 +110,9 @@ class ChunkKDAFwdK4bInverseCuteDSL:
         mAkk: cute.Tensor,
         H: int,
         total_chunks: int,
+        cu_seqlens: cute.Tensor,
+        chunk_indices: cute.Tensor,
         stream,
-        cu_seqlens: cute.Tensor | None = None,
-        chunk_indices: cute.Tensor | None = None,
     ):
         self._dtype: type[cutlass.Numeric] = mAkk.element_type
         self._sai_dtype: type[cutlass.Numeric] = cutlass.Float32
@@ -112,7 +121,7 @@ class ChunkKDAFwdK4bInverseCuteDSL:
             self._sai_dtype = self._dtype
             self._sai_stride = self.BC
 
-        if cutlass.const_expr(cu_seqlens is not None):
+        if cutlass.const_expr(self.varlen):
             NT = cute.size(chunk_indices, mode=[0]) // 2
             grid = (NT, H, 1)
         else:
@@ -214,7 +223,7 @@ class ChunkKDAFwdK4bInverseCuteDSL:
         warp_idx = tidx // self.WARP_SIZE
         lane_idx = tidx % self.WARP_SIZE
 
-        if cutlass.const_expr(cu_seqlens is not None):
+        if cutlass.const_expr(self.varlen):
             i_n = chunk_indices[chunk_idx * 2]
             i_t = chunk_indices[chunk_idx * 2 + 1]
             bos = cu_seqlens[i_n]
@@ -286,7 +295,7 @@ class ChunkKDAFwdK4bInverseCuteDSL:
         # ══════════════════════════════════════════════════════════
         # PHASE 1: Per-warp OD loading + parallel forward substitution
         # ══════════════════════════════════════════════════════════
-        od_base_row = chunk_idx * 6
+        od_base_row = chunk_idx * self.num_offdiag_blocks
 
         if warp_idx == 0:
             for i in cutlass.range_constexpr(cute.size(acc_od0)):

--- a/test/test_kda_cute_inter_solve.py
+++ b/test/test_kda_cute_inter_solve.py
@@ -1,0 +1,81 @@
+"""Tests for the cached CuTeDSL KDA inter-solve kernels."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+
+@pytest.mark.parametrize(
+    ("head_dim", "chunk_size", "subchunk_size", "message"),
+    (
+        (64, 64, 16, "head_dim=128"),
+        (128, 32, 16, "chunk_size=64"),
+        (128, 64, 8, "subchunk_size=16"),
+    ),
+)
+def test_inter_solve_rejects_unsupported_specializations(
+    head_dim,
+    chunk_size,
+    subchunk_size,
+    message,
+):
+    pytest.importorskip("cutlass")
+    from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd_inter_solve import (
+        _validate_specialization,
+    )
+
+    with pytest.raises(AssertionError, match=message):
+        _validate_specialization(head_dim, chunk_size, subchunk_size)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (10, 0),
+    reason="the CuTeDSL KDA inter-solve requires CUDA capability 10.0 or newer",
+)
+def test_inter_solve_reuses_compiled_specializations(tmp_path, monkeypatch):
+    pytest.importorskip("cutlass")
+    from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd_inter_solve import (
+        _compile_k3b,
+        _compile_k4b,
+        chunk_kda_fwd_inter_solve_cute,
+    )
+
+    monkeypatch.setenv("ATTN_GYM_CUTE_CACHE_DIR", str(tmp_path / "cache"))
+    _compile_k3b.cache_clear()
+    _compile_k4b.cache_clear()
+
+    torch.manual_seed(0)
+    shape = (1, 128, 1, 128)
+    q = torch.randn(shape, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn_like(q)
+    cumulative_gate = (torch.randn(shape, device="cuda") * 0.01).cumsum(1)
+    beta = torch.rand(1, 128, 1, device="cuda")
+    diagonal_inverse = torch.randn(1, 128, 1, 16, device="cuda") * 0.01
+    cu_seqlens = torch.tensor([0, 128], device="cuda", dtype=torch.int64)
+    chunk_indices = torch.tensor([[0, 0], [0, 1]], device="cuda", dtype=torch.int64)
+
+    def run_inter_solve():
+        return chunk_kda_fwd_inter_solve_cute(
+            q,
+            k,
+            cumulative_gate,
+            beta,
+            diagonal_inverse,
+            128**-0.5,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+        )
+
+    run_inter_solve()
+    torch.cuda.synchronize()
+    first_info = (_compile_k3b.cache_info(), _compile_k4b.cache_info())
+    outputs = run_inter_solve()
+    torch.cuda.synchronize()
+    second_info = (_compile_k3b.cache_info(), _compile_k4b.cache_info())
+
+    assert tuple(output.shape for output in outputs) == ((1, 128, 1, 64),) * 2
+    assert all(
+        second.hits == first.hits + 1 and second.currsize == first.currsize
+        for first, second in zip(first_info, second_info, strict=True)
+    )


### PR DESCRIPTION
Stacked PRs:
 * #253
 * #257
 * __->__#256


--- --- ---

Persist CuTeDSL KDA inter-solve kernels

Human Note
use all the cache utils
Agent note
K3b and K4b were invoked through raw @cute.jit objects, causing CuTeDSL tracing and compilation to
run again in every model forward. Compile each static head-count and varlen specialization through the
shared jit_cache and TVM-FFI path instead, while keeping runtime Torch tensors out of cache keys.

The generated objects are now reusable in-process and from the persistent cross-process cache. Dummy
metadata tensors keep fixed-length and variable-length call signatures uniform without static global
kernel instances.

Test Plan:

```bash
gpu-run 2 -- ~/.venvs/nightly/bin/python -m pytest -q test/test_kda_kernels.py
gpu-run 2 -- ~/.venvs/nightly/bin/python -m pytest -q test/test_kda_cute_inter_solve.py
```