### PR TITLE
Reduce Modal test runtime

### DIFF
--- a/modal_tests.py
+++ b/modal_tests.py
@@ -68,7 +68,18 @@ def run_pytest() -> tuple[int, str]:
     """Run the repository test suite and return its exit code and summary."""
     report_path = Path("/tmp/pytest-report.xml")
     result = subprocess.run(
-        ["python", "-m", "pytest", "test", "-ra", "--tb=short", f"--junitxml={report_path}"],
+        [
+            "python",
+            "-m",
+            "pytest",
+            "test",
+            "-n",
+            "4",
+            "--dist=worksteal",
+            "-ra",
+            "--tb=short",
+            f"--junitxml={report_path}",
+        ],
         cwd="/root",
         check=False,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
 [project.optional-dependencies]
 tests = [
     "pytest",
+    "pytest-xdist",
     "jsonargparse",
     "docstring-parser",
     "numpy",

--- a/test/test_cute_cache.py
+++ b/test/test_cute_cache.py
@@ -558,7 +558,7 @@ def test_fresh_compile_driver_forks_parallel_workers(tmp_path, monkeypatch):
     cache_directory = tmp_path / "cache"
     log_path = tmp_path / "compiles.log"
     ready_directory = tmp_path / "ready"
-    configs = tuple(CompileConfig(str(index), float(index + 1)) for index in range(4))
+    configs = tuple(CompileConfig(str(index), float(index + 1)) for index in range(2))
     shared = CompileConfig("shared", 0.5)
     monkeypatch.setenv("ATTN_GYM_CUTE_CACHE_DIR", str(cache_directory))
     monkeypatch.delenv("CUTE_DSL_NO_CACHE", raising=False)
@@ -581,7 +581,7 @@ def test_fresh_compile_driver_forks_parallel_workers(tmp_path, monkeypatch):
         return config.timing
 
     best = tune(
-        configs + (shared,) * 4,
+        configs + (shared,) * 2,
         compile_test_variant,
         launch,
         benchmark=measure_return_value,
@@ -590,7 +590,7 @@ def test_fresh_compile_driver_forks_parallel_workers(tmp_path, monkeypatch):
     )
 
     assert best is shared
-    assert benchmark_order == [config.variant for config in configs] + ["shared"] * 4
+    assert benchmark_order == [config.variant for config in configs] + ["shared"] * 2
     records = [line.split(",") for line in log_path.read_text().splitlines()]
     variant_records = [record for record in records if record[2] != "shared"]
     worker_pids = {int(record[0]) for record in variant_records}
@@ -626,7 +626,7 @@ def test_fresh_compile_driver_forks_parallel_workers(tmp_path, monkeypatch):
 @pytest.mark.filterwarnings("ignore:This process .* is multi-threaded.*:DeprecationWarning")
 def test_same_key_compiles_once_across_processes(isolated_cache):
     context = multiprocessing.get_context("fork")
-    process_count = 6
+    process_count = 2
     compile_count = context.Value("i", 0)
     start = context.Event()
 
@@ -653,7 +653,7 @@ def test_same_key_compiles_once_across_processes(isolated_cache):
 
 @pytest.mark.skipif(sys.platform == "win32", reason="fcntl.flock and fork are required")
 @pytest.mark.filterwarnings("ignore:This process .* is multi-threaded.*:DeprecationWarning")
-@pytest.mark.parametrize("process_count", [1, 2, 4, 8])
+@pytest.mark.parametrize("process_count", [1, 2])
 def test_parallel_population_then_sequential_reload(isolated_cache, process_count):
     """Workers compile distinct variants before the parent reloads them sequentially."""
     context = multiprocessing.get_context("fork")

--- a/test/test_kda_fused_gate_bwd.py
+++ b/test/test_kda_fused_gate_bwd.py
@@ -188,13 +188,12 @@ def test_fused_gate_bwd_matches_reference(tokens, head_dim, lower_bound, chunk_s
     torch.testing.assert_close(actual.dg.sum((0, 1)), expected_dt_bias, rtol=5e-5, atol=7e-4)
 
 
-@pytest.mark.parametrize("fastmath", (False, True))
-def test_fused_gate_bwd_fastmath_specializations_are_correct(fastmath):
-    """Keep both explicit exponential modes numerically valid."""
+def test_fused_gate_bwd_fastmath_specialization_is_correct():
+    """Keep the non-default exponential mode numerically valid."""
     inputs = _inputs(65, heads=17)
     expected, expected_dA, _expected_dt_bias = _expected_output(inputs, -4.75)
 
-    actual = fused_gate_bwd(*inputs, lower_bound=-4.75, fastmath=fastmath)
+    actual = fused_gate_bwd(*inputs, lower_bound=-4.75, fastmath=True)
 
     _assert_output_close(actual, expected)
     torch.testing.assert_close(actual.dA_partial.sum((0, 1)), expected_dA, rtol=5e-5, atol=7e-4)


### PR DESCRIPTION
Stacked PRs:
 * #253
 * __->__#258


--- --- ---

Reduce Modal test runtime

Human Note

Agent note
The Modal suite spent most of its wall time compiling independent Flex FLASH and CuTeDSL
specializations serially. Install pytest-xdist and run four work-stealing workers so those independent
compiles overlap on the B200.

Avoid repeated work inside the tests without removing behavioral branches. The dedicated KDA
fastmath test now covers only the non-default mode because the default mode is exercised throughout
the reference matrix. Cache concurrency tests use the minimum two workers needed to prove overlap,
locking, duplicate suppression, fresh-driver isolation, reloads, and warm-cache behavior instead of
repeating those paths at larger process counts.

Test Plan:

```bash
gpu-run 2 -- env PYTHONPATH="$PWD" ~/.venvs/nightly/bin/pytest test/test_kda_fused_gate_bwd.py test/test_cute_cache.py test/test_cute_cache_gpu.py -q --tb=short --durations=20
gpu-run 3 -- env PYTHONPATH="$PWD" ~/.venvs/nightly/bin/pytest test -q -n 4 --dist=worksteal --tb=short --durations=20
gpu-run 2 -- env PYTHONPATH="$PWD" ~/.venvs/nightly/bin/pytest test/test_kda_fused_gate_bwd.py -q --tb=short --durations=10
```