### PR TITLE
Migrate KDA Triton block pointers

### DIFF
--- a/attn_gym/_backends/triton/utils.py
+++ b/attn_gym/_backends/triton/utils.py
@@ -9,11 +9,11 @@ import triton.language as tl
 
 @triton.jit
 def ptr_offset(indices, strides: tl.constexpr):
-    """Compute a broadcasted linear offset from index and stride tuples."""
+    """Compute a broadcasted signed 64-bit offset from index and stride tuples."""
     tl.static_assert(len(indices) == len(strides), "indices and strides must have equal length")
     offset = 0
     for axis in tl.static_range(len(strides)):
-        offset += indices[axis] * strides[axis]
+        offset += tl.cast(indices[axis], tl.int64) * strides[axis]
     return offset
 
 

--- a/attn_gym/_backends/triton/utils.py
+++ b/attn_gym/_backends/triton/utils.py
@@ -9,11 +9,11 @@ import triton.language as tl
 
 @triton.jit
 def ptr_offset(indices, strides: tl.constexpr):
-    """Compute a broadcasted signed 64-bit offset from index and stride tuples."""
+    """Compute a broadcasted linear offset from index and stride tuples."""
     tl.static_assert(len(indices) == len(strides), "indices and strides must have equal length")
     offset = 0
     for axis in tl.static_range(len(strides)):
-        offset += tl.cast(indices[axis], tl.int64) * strides[axis]
+        offset += indices[axis] * strides[axis]
     return offset
 
 
@@ -38,6 +38,14 @@ def storage_cosize(shape: Sequence[int], strides: Sequence[int]) -> int:
         if size > 0:
             cosize += (size - 1) * stride
     return 0 if is_empty else cosize
+
+
+def requires_int64_offsets(*tensors: torch.Tensor | None) -> bool:
+    """Return whether any tensor's relative storage extent exceeds signed int32."""
+    return any(
+        tensor is not None and storage_cosize(tensor.shape, tensor.stride()) > 2**31
+        for tensor in tensors
+    )
 
 
 def can_use_tma(tensor: torch.Tensor) -> bool:

--- a/attn_gym/linear/kda/bwd/triton/chunk_kda_bwd_dav.py
+++ b/attn_gym/linear/kda/bwd/triton/chunk_kda_bwd_dav.py
@@ -6,7 +6,7 @@
 #
 # Triton dAv backward for KDA (the intra-chunk ``Aqk @ v_new`` path). This is
 # the one KDA backward compute stage with no CuTe implementation, so it ships as
-# Triton. Ported verbatim; only the header and utility imports were rewritten.
+# Triton. Ported from the original source with local utility-based pointer access.
 #
 # Original source: genai/llama4x/llama4x/ops/fla/ops/kda/chunk_bwd.py
 
@@ -15,6 +15,7 @@ from __future__ import annotations
 import triton
 import triton.language as tl
 
+from attn_gym._backends.triton.utils import ptr_offset
 from attn_gym.linear.kda.utils import (
     autotune_cache_kwargs,
 )
@@ -56,56 +57,74 @@ def chunk_kda_bwd_kernel_dAv(
     IS_VARLEN: tl.constexpr,
     HAS_NUM_CHUNKS: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1).to(tl.int64)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
         if HAS_NUM_CHUNKS and i_t >= tl.load(num_chunks):
             return
         i_n, i_t = (
-            tl.load(chunk_indices + i_t * 2).to(tl.int32),
-            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32),
+            tl.load(chunk_indices + ptr_offset((i_t, 0), (2, 1))).to(tl.int64),
+            tl.load(chunk_indices + ptr_offset((i_t, 1), (2, 1))).to(tl.int64),
         )
         bos, eos = (
-            tl.load(cu_seqlens + i_n).to(tl.int32),
-            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+            tl.load(cu_seqlens + ptr_offset((i_n,), (1,))).to(tl.int64),
+            tl.load(cu_seqlens + ptr_offset((i_n + 1,), (1,))).to(tl.int64),
         )
         T = eos - bos
     else:
-        bos, eos = i_b * T, i_b * T + T
+        bos = i_b * T
 
-    # offset calculation
-    q += (bos * H + i_h) * K
-    k += (bos * H + i_h) * K
-    v += (bos * H + i_h) * V
-    do += (bos * H + i_h) * V
-    dv += (bos * H + i_h) * V
-    dA += (bos * H + i_h) * BT
+    q += ptr_offset((bos, i_h), (H * K, K))
+    k += ptr_offset((bos, i_h), (H * K, K))
+    v += ptr_offset((bos, i_h), (H * V, V))
+    A += ptr_offset((bos, i_h), (H * BT, BT))
+    do += ptr_offset((bos, i_h), (H * V, V))
+    dv += ptr_offset((bos, i_h), (H * V, V))
+    dA += ptr_offset((bos, i_h), (H * BT, BT))
 
-    p_A = tl.make_block_ptr(
-        A + (bos * H + i_h) * BT, (BT, T), (1, H * BT), (0, i_t * BT), (BT, BT), (0, 1)
-    )
-    b_A = tl.load(p_A, boundary_check=(0, 1))
-
-    o_t = i_t * BT + tl.arange(0, BT)
+    o_i = tl.arange(0, BT)
+    o_t = i_t * BT + o_i
     m_t = o_t < T
-    m_A = (o_t[:, None] <= o_t[None, :]) & (m_t[:, None] & m_t)
+    m_tt = m_t[:, None] & m_t[None, :]
+    # The leading BT feature axis is always in bounds; only token columns can be ragged.
+    b_A = tl.load(
+        A + ptr_offset((o_i[:, None], o_t[None, :]), (1, H * BT)),
+        mask=m_t[None, :],
+        other=0.0,
+    )
+    m_A = (o_t[:, None] <= o_t[None, :]) & m_tt
     b_A = tl.where(m_A, b_A, 0).to(do.dtype.element_ty)
 
     b_dA = tl.zeros([BT, BT], dtype=tl.float32)
     for i_v in range(tl.cdiv(V, BV)):
-        p_v = tl.make_block_ptr(v, (V, T), (1, H * V), (i_v * BV, i_t * BT), (BV, BT), (0, 1))
-        p_do = tl.make_block_ptr(do, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        p_dv = tl.make_block_ptr(dv, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        o_v = i_v * BV + tl.arange(0, BV)
+        m_v = (o_v[:, None] < V) & m_t[None, :]
+        m_do = m_t[:, None] & (o_v[None, :] < V)
         # [BV, BT]
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = tl.load(
+            v + ptr_offset((o_v[:, None], o_t[None, :]), (1, H * V)),
+            mask=m_v,
+            other=0.0,
+        )
         # [BT, BV]
-        b_do = tl.load(p_do, boundary_check=(0, 1))
+        b_do = tl.load(
+            do + ptr_offset((o_t[:, None], o_v[None, :]), (H * V, 1)),
+            mask=m_do,
+            other=0.0,
+        )
         # [BT, BT]
         b_dA += tl.dot(b_do, b_v)
         # [BT, BV]
         b_dv = tl.dot(b_A.to(b_do.dtype), b_do)
-        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(
+            dv + ptr_offset((o_t[:, None], o_v[None, :]), (H * V, 1)),
+            b_dv.to(dv.dtype.element_ty),
+            mask=m_do,
+        )
 
-    p_dA = tl.make_block_ptr(dA, (T, BT), (H * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
-    b_dA = tl.where(o_t[:, None] >= o_t, b_dA * scale, 0.0)
-    tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
+    b_dA = tl.where(o_t[:, None] >= o_t[None, :], b_dA * scale, 0.0)
+    tl.store(
+        dA + ptr_offset((o_t[:, None], o_i[None, :]), (H * BT, 1)),
+        b_dA.to(dA.dtype.element_ty),
+        mask=m_t[:, None],
+    )

--- a/attn_gym/linear/kda/bwd/triton/chunk_kda_bwd_dav.py
+++ b/attn_gym/linear/kda/bwd/triton/chunk_kda_bwd_dav.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import triton
 import triton.language as tl
 
-from attn_gym._backends.triton.utils import ptr_offset
+from attn_gym._backends.triton.utils import ptr_offset, requires_int64_offsets
 from attn_gym.linear.kda.utils import (
     autotune_cache_kwargs,
 )
@@ -25,6 +25,18 @@ from attn_gym.linear.kda.utils import (
     {
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
         "HAS_NUM_CHUNKS": lambda args: args["num_chunks"] is not None,
+        "USE_INT64_OFFSETS": lambda args: requires_int64_offsets(
+            args["q"],
+            args["k"],
+            args["v"],
+            args["A"],
+            args["do"],
+            args["dv"],
+            args["dA"],
+            args["cu_seqlens"],
+            args["chunk_indices"],
+            args["num_chunks"],
+        ),
     }
 )
 @triton.autotune(
@@ -56,20 +68,30 @@ def chunk_kda_bwd_kernel_dAv(
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     HAS_NUM_CHUNKS: tl.constexpr,
+    USE_INT64_OFFSETS: tl.constexpr,
 ):
-    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1).to(tl.int64)
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    if USE_INT64_OFFSETS:
+        i_t = i_t.to(tl.int64)
+        i_bh = i_bh.to(tl.int64)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
         if HAS_NUM_CHUNKS and i_t >= tl.load(num_chunks):
             return
         i_n, i_t = (
-            tl.load(chunk_indices + ptr_offset((i_t, 0), (2, 1))).to(tl.int64),
-            tl.load(chunk_indices + ptr_offset((i_t, 1), (2, 1))).to(tl.int64),
+            tl.load(chunk_indices + ptr_offset((i_t, 0), (2, 1))).to(tl.int32),
+            tl.load(chunk_indices + ptr_offset((i_t, 1), (2, 1))).to(tl.int32),
         )
+        if USE_INT64_OFFSETS:
+            i_n = i_n.to(tl.int64)
+            i_t = i_t.to(tl.int64)
         bos, eos = (
-            tl.load(cu_seqlens + ptr_offset((i_n,), (1,))).to(tl.int64),
-            tl.load(cu_seqlens + ptr_offset((i_n + 1,), (1,))).to(tl.int64),
+            tl.load(cu_seqlens + ptr_offset((i_n,), (1,))).to(tl.int32),
+            tl.load(cu_seqlens + ptr_offset((i_n + 1,), (1,))).to(tl.int32),
         )
+        if USE_INT64_OFFSETS:
+            bos = bos.to(tl.int64)
+            eos = eos.to(tl.int64)
         T = eos - bos
     else:
         bos = i_b * T

--- a/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
@@ -10,11 +10,28 @@ import torch
 import triton
 import triton.language as tl
 
-from attn_gym._backends.triton.utils import ptr_offset
+from attn_gym._backends.triton.utils import ptr_offset, requires_int64_offsets
 from attn_gym.linear.kda.utils import (
     exp,
     exp2,
 )
+
+
+def _requires_int64_offsets(args):
+    return requires_int64_offsets(
+        args["k"],
+        args["v"],
+        args["w"],
+        args["v_new"],
+        args["g"],
+        args["gk"],
+        args["h"],
+        args["h0"],
+        args["ht"],
+        args["cu_seqlens"],
+        args["chunk_offsets"],
+        args["num_seqs"],
+    )
 
 
 @triton.heuristics(
@@ -26,6 +43,7 @@ from attn_gym.linear.kda.utils import (
         "SAVE_NEW_VALUE": lambda args: args["v_new"] is not None,
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
         "HAS_NUM_SEQS": lambda args: args["num_seqs"] is not None,
+        "USE_INT64_OFFSETS": _requires_int64_offsets,
     }
 )
 @triton.jit(do_not_specialize=["T", "num_seqs"])
@@ -56,8 +74,12 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
     USE_EXP2: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     HAS_NUM_SEQS: tl.constexpr,
+    USE_INT64_OFFSETS: tl.constexpr,
 ):
     i_nh, i_v = tl.program_id(0), tl.program_id(1)
+    if USE_INT64_OFFSETS:
+        i_nh = i_nh.to(tl.int64)
+        i_v = i_v.to(tl.int64)
     i_n, i_h = i_nh // H, i_nh % H
     if IS_VARLEN:
         if HAS_NUM_SEQS and i_n >= tl.load(num_seqs):
@@ -66,14 +88,18 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
             tl.load(cu_seqlens + ptr_offset((i_n,), (1,))).to(tl.int32),
             tl.load(cu_seqlens + ptr_offset((i_n,), (1,)) + 1).to(tl.int32),
         )
+        boh = tl.load(chunk_offsets + ptr_offset((i_n,), (1,))).to(tl.int32)
+        if USE_INT64_OFFSETS:
+            bos = bos.to(tl.int64)
+            eos = eos.to(tl.int64)
+            boh = boh.to(tl.int64)
         T = eos - bos
         NT = tl.cdiv(T, BT)
-        boh = tl.load(chunk_offsets + ptr_offset((i_n,), (1,))).to(tl.int32)
     else:
-        bos = tl.cast(i_n, tl.int64) * T
+        bos = i_n * T
         eos = bos + T
         NT = tl.cdiv(T, BT)
-        boh = tl.cast(i_n, tl.int64) * NT
+        boh = i_n * NT
 
     # [BK, BV]
     b_h1 = tl.zeros([64, BV], dtype=tl.float32)
@@ -139,7 +165,10 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
 
     # main recurrence
     for i_t in range(NT):
-        h_t = h + ptr_offset((i_t,), (H * K * V,))
+        i_t_offset = i_t
+        if USE_INT64_OFFSETS:
+            i_t_offset = i_t_offset.to(tl.int64)
+        h_t = h + ptr_offset((i_t_offset,), (H * K * V,))
         m_h = (o_k1[:, None] < K) & m_v[None, :]
         tl.store(
             h_t + ptr_offset((o_k1[:, None], o_v[None, :]), (V, 1)),
@@ -168,7 +197,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
                 mask=m_h,
             )
 
-        o_t = ptr_offset((i_t,), (BT,)) + tl.arange(0, BT)
+        o_t = ptr_offset((i_t_offset,), (BT,)) + tl.arange(0, BT)
         m_t = o_t < T
         m_w = m_t[:, None] & (o_k1[None, :] < K)
         b_w = tl.load(
@@ -213,7 +242,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
                 mask=m_v_block,
             )
 
-        last_idx = min(ptr_offset((i_t,), (BT,)) + BT, T) - 1
+        last_idx = min(ptr_offset((i_t_offset,), (BT,)) + BT, T) - 1
         if USE_G:
             b_g_last = tl.load(g + ptr_offset((bos, last_idx, i_h), (H, H, 1)))
             b_g = tl.load(
@@ -374,6 +403,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
         "SAVE_NEW_VALUE": lambda args: args["v_new"] is not None,
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
         "HAS_NUM_SEQS": lambda args: args["num_seqs"] is not None,
+        "USE_INT64_OFFSETS": _requires_int64_offsets,
     }
 )
 @triton.jit(do_not_specialize=["T", "num_seqs"])
@@ -404,10 +434,14 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64_forloop(
     USE_EXP2: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     HAS_NUM_SEQS: tl.constexpr,
+    USE_INT64_OFFSETS: tl.constexpr,
     GRID_N: tl.constexpr,
     MAX_N: tl.constexpr,
 ):
     i_nh, i_v = tl.program_id(0), tl.program_id(1)
+    if USE_INT64_OFFSETS:
+        i_nh = i_nh.to(tl.int64)
+        i_v = i_v.to(tl.int64)
     i_h = i_nh % H
     i_n_start = i_nh // H
 
@@ -425,7 +459,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64_forloop(
         o_k4 = 192 + o_k1
 
     for _iter in range((MAX_N + GRID_N - 1) // GRID_N):
-        i_n = tl.cast(i_n_start, tl.int64) + _iter * GRID_N
+        i_n = i_n_start + _iter * GRID_N
         _run = i_n < MAX_N
         if IS_VARLEN and HAS_NUM_SEQS and _run:
             _run = i_n < upper_limit  # pyrefly: ignore [unbound-name]
@@ -435,15 +469,19 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64_forloop(
                     tl.load(cu_seqlens + ptr_offset((i_n,), (1,))).to(tl.int32),
                     tl.load(cu_seqlens + ptr_offset((i_n,), (1,)) + 1).to(tl.int32),
                 )
+                boh = tl.load(chunk_offsets + ptr_offset((i_n,), (1,))).to(tl.int32)
+                if USE_INT64_OFFSETS:
+                    bos = bos.to(tl.int64)
+                    eos = eos.to(tl.int64)
+                    boh = boh.to(tl.int64)
                 T_local = eos - bos
                 NT = tl.cdiv(T_local, BT)
-                boh = tl.load(chunk_offsets + ptr_offset((i_n,), (1,))).to(tl.int32)
             else:
-                bos = tl.cast(i_n, tl.int64) * T
+                bos = i_n * T
                 eos = bos + T
                 T_local = T
                 NT = tl.cdiv(T_local, BT)
-                boh = tl.cast(i_n, tl.int64) * NT
+                boh = i_n * NT
 
             # [BK, BV]
             b_h1 = tl.zeros([64, BV], dtype=tl.float32)
@@ -495,7 +533,10 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64_forloop(
 
             # main recurrence
             for i_t in range(NT):
-                h_t = h_off + ptr_offset((i_t,), (H * K * V,))
+                i_t_offset = i_t
+                if USE_INT64_OFFSETS:
+                    i_t_offset = i_t_offset.to(tl.int64)
+                h_t = h_off + ptr_offset((i_t_offset,), (H * K * V,))
                 m_h = (o_k1[:, None] < K) & m_v[None, :]
                 tl.store(
                     h_t + ptr_offset((o_k1[:, None], o_v[None, :]), (V, 1)),
@@ -524,7 +565,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64_forloop(
                         mask=m_h,
                     )
 
-                o_t = ptr_offset((i_t,), (BT,)) + tl.arange(0, BT)
+                o_t = ptr_offset((i_t_offset,), (BT,)) + tl.arange(0, BT)
                 m_t = o_t < T_local
                 m_w = m_t[:, None] & (o_k1[None, :] < K)
                 b_w = tl.load(
@@ -578,7 +619,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64_forloop(
                         mask=m_v_block,
                     )
 
-                last_idx = min(ptr_offset((i_t,), (BT,)) + BT, T_local) - 1
+                last_idx = min(ptr_offset((i_t_offset,), (BT,)) + BT, T_local) - 1
                 if USE_G:
                     b_g_last = tl.load(g + ptr_offset((bos, last_idx, i_h), (H, H, 1)))
                     b_g = tl.load(

--- a/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
@@ -10,6 +10,7 @@ import torch
 import triton
 import triton.language as tl
 
+from attn_gym._backends.triton.utils import ptr_offset
 from attn_gym.linear.kda.utils import (
     exp,
     exp2,
@@ -62,16 +63,17 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
         if HAS_NUM_SEQS and i_n >= tl.load(num_seqs):
             return
         bos, eos = (
-            tl.load(cu_seqlens + i_n).to(tl.int32),
-            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+            tl.load(cu_seqlens + ptr_offset((i_n,), (1,))).to(tl.int32),
+            tl.load(cu_seqlens + ptr_offset((i_n,), (1,)) + 1).to(tl.int32),
         )
         T = eos - bos
         NT = tl.cdiv(T, BT)
-        boh = tl.load(chunk_offsets + i_n).to(tl.int32)
+        boh = tl.load(chunk_offsets + ptr_offset((i_n,), (1,))).to(tl.int32)
     else:
-        bos, eos = i_n * T, i_n * T + T
+        bos = tl.cast(i_n, tl.int64) * T
+        eos = bos + T
         NT = tl.cdiv(T, BT)
-        boh = i_n * NT
+        boh = tl.cast(i_n, tl.int64) * NT
 
     # [BK, BV]
     b_h1 = tl.zeros([64, BV], dtype=tl.float32)
@@ -83,117 +85,142 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
         b_h4 = tl.zeros([64, BV], dtype=tl.float32)
 
     # calculate offset
-    h += (boh * H + i_h).to(tl.int64) * K * V
-    v += (bos * H + i_h).to(tl.int64) * V
-    k += (bos * H + i_h).to(tl.int64) * K
-    w += (bos * H + i_h).to(tl.int64) * K
+    h += ptr_offset((boh, i_h), (H * K * V, K * V))
+    v += ptr_offset((bos, i_h), (H * V, V))
+    k += ptr_offset((bos, i_h), (H * K, K))
+    w += ptr_offset((bos, i_h), (H * K, K))
     if SAVE_NEW_VALUE:
-        v_new += (bos * H + i_h).to(tl.int64) * V
+        v_new += ptr_offset((bos, i_h), (H * V, V))
 
     if USE_INITIAL_STATE:
-        h0 = h0 + i_nh * K * V
+        h0 = h0 + ptr_offset((i_nh,), (K * V,))
     if STORE_FINAL_STATE:
-        ht = ht + i_nh * K * V
+        ht = ht + ptr_offset((i_nh,), (K * V,))
+
+    o_k1 = tl.arange(0, 64)
+    o_v = ptr_offset((i_v,), (BV,)) + tl.arange(0, BV)
+    m_v = o_v < V
+    if K > 64:
+        o_k2 = 64 + o_k1
+    if K > 128:
+        o_k3 = 128 + o_k1
+    if K > 192:
+        o_k4 = 192 + o_k1
 
     # load initial state
     if USE_INITIAL_STATE:
-        p_h0_1 = tl.make_block_ptr(h0, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
-        b_h1 += tl.load(p_h0_1, boundary_check=(0, 1)).to(tl.float32)
+        m_h0 = (o_k1[:, None] < K) & m_v[None, :]
+        b_h1 += tl.load(
+            h0 + ptr_offset((o_k1[:, None], o_v[None, :]), (V, 1)),
+            mask=m_h0,
+            other=0.0,
+        ).to(tl.float32)
         if K > 64:
-            p_h0_2 = tl.make_block_ptr(h0, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0))
+            m_h0 = (o_k2[:, None] < K) & m_v[None, :]
             b_h2 += tl.load(  # pyrefly: ignore[unbound-name]
-                p_h0_2, boundary_check=(0, 1)
-            ).to(  # pyrefly: ignore[unbound-name]
-                tl.float32
-            )  # pyrefly: ignore[unbound-name]
+                h0 + ptr_offset((o_k2[:, None], o_v[None, :]), (V, 1)),
+                mask=m_h0,
+                other=0.0,
+            ).to(tl.float32)
         if K > 128:
-            p_h0_3 = tl.make_block_ptr(
-                h0,
-                (K, V),
-                (V, 1),
-                (128, i_v * BV),
-                (64, BV),
-                (1, 0),  # pyrefly: ignore[unbound-name]
-            )
+            m_h0 = (o_k3[:, None] < K) & m_v[None, :]
             b_h3 += tl.load(  # pyrefly: ignore[unbound-name]
-                p_h0_3, boundary_check=(0, 1)
-            ).to(  # pyrefly: ignore[unbound-name]
-                tl.float32
-            )  # pyrefly: ignore[unbound-name]
-        if K > 192:  # pyrefly: ignore[unbound-name]
-            p_h0_4 = tl.make_block_ptr(h0, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0))
+                h0 + ptr_offset((o_k3[:, None], o_v[None, :]), (V, 1)),
+                mask=m_h0,
+                other=0.0,
+            ).to(tl.float32)
+        if K > 192:
+            m_h0 = (o_k4[:, None] < K) & m_v[None, :]
             b_h4 += tl.load(  # pyrefly: ignore[unbound-name]
-                p_h0_4, boundary_check=(0, 1)
-            ).to(  # pyrefly: ignore[unbound-name]
-                tl.float32
-            )  # pyrefly: ignore[unbound-name]
+                h0 + ptr_offset((o_k4[:, None], o_v[None, :]), (V, 1)),
+                mask=m_h0,
+                other=0.0,
+            ).to(tl.float32)
 
     # main recurrence
     for i_t in range(NT):
-        p_h1 = tl.make_block_ptr(
-            h + i_t * H * K * V, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0)
-        )  # pyrefly: ignore[unbound-name]
-        tl.store(p_h1, b_h1.to(p_h1.dtype.element_ty), boundary_check=(0, 1))
+        h_t = h + ptr_offset((i_t,), (H * K * V,))
+        m_h = (o_k1[:, None] < K) & m_v[None, :]
+        tl.store(
+            h_t + ptr_offset((o_k1[:, None], o_v[None, :]), (V, 1)),
+            b_h1.to(h.dtype.element_ty),
+            mask=m_h,
+        )
         if K > 64:
-            p_h2 = tl.make_block_ptr(
-                h + i_t * H * K * V, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0)
-            )  # pyrefly: ignore[unbound-name]
+            m_h = (o_k2[:, None] < K) & m_v[None, :]
             tl.store(
-                p_h2,
-                b_h2.to(p_h2.dtype.element_ty),  # pyrefly: ignore[unbound-name]
-                boundary_check=(0, 1),  # pyrefly: ignore[unbound-name]
-            )  # pyrefly: ignore[unbound-name]
+                h_t + ptr_offset((o_k2[:, None], o_v[None, :]), (V, 1)),
+                b_h2.to(h.dtype.element_ty),  # pyrefly: ignore[unbound-name]
+                mask=m_h,
+            )
         if K > 128:
-            p_h3 = tl.make_block_ptr(  # pyrefly: ignore[unbound-name]
-                h + i_t * H * K * V, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0)
-            )
+            m_h = (o_k3[:, None] < K) & m_v[None, :]
             tl.store(
-                p_h3,
-                b_h3.to(p_h3.dtype.element_ty),  # pyrefly: ignore[unbound-name]
-                boundary_check=(0, 1),  # pyrefly: ignore[unbound-name]
-            )  # pyrefly: ignore[unbound-name]
-        if K > 192:
-            p_h4 = tl.make_block_ptr(
-                h + i_t * H * K * V, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0)
+                h_t + ptr_offset((o_k3[:, None], o_v[None, :]), (V, 1)),
+                b_h3.to(h.dtype.element_ty),  # pyrefly: ignore[unbound-name]
+                mask=m_h,
             )
-            tl.store(  # pyrefly: ignore[unbound-name]
-                p_h4,
-                b_h4.to(p_h4.dtype.element_ty),  # pyrefly: ignore[unbound-name]
-                boundary_check=(0, 1),  # pyrefly: ignore[unbound-name]
-            )  # pyrefly: ignore[unbound-name]
+        if K > 192:
+            m_h = (o_k4[:, None] < K) & m_v[None, :]
+            tl.store(
+                h_t + ptr_offset((o_k4[:, None], o_v[None, :]), (V, 1)),
+                b_h4.to(h.dtype.element_ty),  # pyrefly: ignore[unbound-name]
+                mask=m_h,
+            )
 
-        p_w = tl.make_block_ptr(w, (T, K), (H * K, 1), (i_t * BT, 0), (BT, 64), (1, 0))
-        b_w = tl.load(p_w, boundary_check=(0, 1))
+        o_t = ptr_offset((i_t,), (BT,)) + tl.arange(0, BT)
+        m_t = o_t < T
+        m_w = m_t[:, None] & (o_k1[None, :] < K)
+        b_w = tl.load(
+            w + ptr_offset((o_t[:, None], o_k1[None, :]), (H * K, 1)),
+            mask=m_w,
+            other=0.0,
+        )
         b_v = tl.dot(b_w, b_h1.to(b_w.dtype))  # pyrefly: ignore[unbound-name]
         if K > 64:
-            p_w = tl.make_block_ptr(w, (T, K), (H * K, 1), (i_t * BT, 64), (BT, 64), (1, 0))
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            m_w = m_t[:, None] & (o_k2[None, :] < K)
+            b_w = tl.load(
+                w + ptr_offset((o_t[:, None], o_k2[None, :]), (H * K, 1)),
+                mask=m_w,
+                other=0.0,
+            )
             b_v += tl.dot(b_w, b_h2.to(b_w.dtype))  # pyrefly: ignore[unbound-name]
         if K > 128:
-            p_w = tl.make_block_ptr(w, (T, K), (H * K, 1), (i_t * BT, 128), (BT, 64), (1, 0))
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            m_w = m_t[:, None] & (o_k3[None, :] < K)
+            b_w = tl.load(
+                w + ptr_offset((o_t[:, None], o_k3[None, :]), (H * K, 1)),
+                mask=m_w,
+                other=0.0,
+            )
             b_v += tl.dot(b_w, b_h3.to(b_w.dtype))  # pyrefly: ignore[unbound-name]
         if K > 192:
-            p_w = tl.make_block_ptr(w, (T, K), (H * K, 1), (i_t * BT, 192), (BT, 64), (1, 0))
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            m_w = m_t[:, None] & (o_k4[None, :] < K)
+            b_w = tl.load(
+                w + ptr_offset((o_t[:, None], o_k4[None, :]), (H * K, 1)),
+                mask=m_w,
+                other=0.0,
+            )
             b_v += tl.dot(b_w, b_h4.to(b_w.dtype))  # pyrefly: ignore[unbound-name]
-        p_v = tl.make_block_ptr(v, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
-        b_v = tl.load(p_v, boundary_check=(0, 1)) - b_v
+
+        m_v_block = m_t[:, None] & m_v[None, :]
+        v_offset = ptr_offset((o_t[:, None], o_v[None, :]), (H * V, 1))
+        b_v = tl.load(v + v_offset, mask=m_v_block, other=0.0) - b_v
 
         if SAVE_NEW_VALUE:
-            p_v = tl.make_block_ptr(
-                v_new, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+            tl.store(
+                v_new + v_offset,
+                b_v.to(v_new.dtype.element_ty),
+                mask=m_v_block,
             )
-            tl.store(p_v, b_v.to(p_v.dtype.element_ty), boundary_check=(0, 1))
 
-        last_idx = min((i_t + 1) * BT, T) - 1
+        last_idx = min(ptr_offset((i_t,), (BT,)) + BT, T) - 1
         if USE_G:
-            m_t = (i_t * BT + tl.arange(0, BT)) < T
-            b_g_last = tl.load(g + bos * H + last_idx * H + i_h)
-            p_g = tl.make_block_ptr(  # pyrefly: ignore[unbound-name]
-                g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
-            )  # pyrefly: ignore[unbound-name]
-            b_g = tl.load(p_g, boundary_check=(0,))
+            b_g_last = tl.load(g + ptr_offset((bos, last_idx, i_h), (H, H, 1)))
+            b_g = tl.load(
+                g + ptr_offset((bos, o_t, i_h), (H, H, 1)),
+                mask=m_t,
+                other=0.0,
+            )
             if USE_EXP2:  # pyrefly: ignore[unbound-name]
                 b_v = b_v * tl.where(m_t, exp2(b_g_last - b_g), 0)[:, None]
                 b_g_last = exp2(b_g_last)
@@ -209,9 +236,8 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
                 b_h4 *= b_g_last  # pyrefly: ignore[unbound-name,unsupported-operation]
 
         if USE_GK:
-            o_k1 = tl.arange(0, 64)
             b_gk_last1 = tl.load(
-                gk + (bos + last_idx) * H * K + i_h * K + o_k1,
+                gk + ptr_offset((bos, last_idx, i_h, o_k1), (H * K, H * K, K, 1)),
                 mask=(o_k1 < K),
                 other=0.0,
             )
@@ -222,9 +248,12 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
             else:
                 b_h1 *= exp(b_gk_last1)[:, None]  # pyrefly: ignore[unsupported-operation]
             if K > 64:
-                o_k2 = 64 + o_k1
                 b_gk_last2 = tl.load(
-                    gk + (bos + last_idx) * H * K + i_h * K + o_k2,  # pyrefly: ignore[unbound-name,unsupported-operation]
+                    gk
+                    + ptr_offset(
+                        (bos, last_idx, i_h, o_k2),
+                        (H * K, H * K, K, 1),
+                    ),  # pyrefly: ignore[unbound-name,unsupported-operation]
                     mask=(o_k2 < K),
                     other=0.0,  # pyrefly: ignore[unbound-name,unsupported-operation]
                 )
@@ -237,9 +266,12 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
                         :, None
                     ]  # pyrefly: ignore[unbound-name,unsupported-operation]
             if K > 128:
-                o_k3 = 128 + o_k1  # pyrefly: ignore[unbound-name,unsupported-operation]
                 b_gk_last3 = tl.load(
-                    gk + (bos + last_idx) * H * K + i_h * K + o_k3,
+                    gk
+                    + ptr_offset(
+                        (bos, last_idx, i_h, o_k3),
+                        (H * K, H * K, K, 1),
+                    ),
                     mask=(o_k3 < K),
                     other=0.0,
                 )
@@ -252,9 +284,12 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
                         :, None
                     ]  # pyrefly: ignore[unbound-name,unsupported-operation]
             if K > 192:
-                o_k4 = 192 + o_k1
                 b_gk_last4 = tl.load(
-                    gk + (bos + last_idx) * H * K + i_h * K + o_k4,  # pyrefly: ignore[unbound-name]
+                    gk
+                    + ptr_offset(
+                        (bos, last_idx, i_h, o_k4),
+                        (H * K, H * K, K, 1),
+                    ),  # pyrefly: ignore[unbound-name]
                     mask=(o_k4 < K),
                     other=0.0,
                 )
@@ -268,53 +303,66 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
                     ]  # pyrefly: ignore[unbound-name,unsupported-operation]
         b_v = b_v.to(k.dtype.element_ty)
 
-        p_k = tl.make_block_ptr(k, (K, T), (1, H * K), (0, i_t * BT), (64, BT), (0, 1))
-        b_k = tl.load(p_k, boundary_check=(0, 1))  # pyrefly: ignore[unbound-name]
+        m_k = (o_k1[:, None] < K) & m_t[None, :]
+        b_k = tl.load(
+            k + ptr_offset((o_k1[:, None], o_t[None, :]), (1, H * K)),
+            mask=m_k,
+            other=0.0,
+        )
         b_h1 += tl.dot(b_k, b_v)
         if K > 64:
-            p_k = tl.make_block_ptr(k, (K, T), (1, H * K), (64, i_t * BT), (64, BT), (0, 1))  # pyrefly: ignore[unbound-name]
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            m_k = (o_k2[:, None] < K) & m_t[None, :]
+            b_k = tl.load(
+                k + ptr_offset((o_k2[:, None], o_t[None, :]), (1, H * K)),
+                mask=m_k,
+                other=0.0,
+            )
             b_h2 += tl.dot(b_k, b_v)  # pyrefly: ignore[unbound-name]
         if K > 128:
-            p_k = tl.make_block_ptr(
-                k,
-                (K, T),
-                (1, H * K),
-                (128, i_t * BT),
-                (64, BT),
-                (0, 1),  # pyrefly: ignore[unbound-name]
+            m_k = (o_k3[:, None] < K) & m_t[None, :]
+            b_k = tl.load(
+                k + ptr_offset((o_k3[:, None], o_t[None, :]), (1, H * K)),
+                mask=m_k,
+                other=0.0,
             )
-            b_k = tl.load(p_k, boundary_check=(0, 1))
             b_h3 += tl.dot(b_k, b_v)  # pyrefly: ignore[unbound-name]
         if K > 192:
-            p_k = tl.make_block_ptr(k, (K, T), (1, H * K), (192, i_t * BT), (64, BT), (0, 1))
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            m_k = (o_k4[:, None] < K) & m_t[None, :]
+            b_k = tl.load(
+                k + ptr_offset((o_k4[:, None], o_t[None, :]), (1, H * K)),
+                mask=m_k,
+                other=0.0,
+            )
             b_h4 += tl.dot(b_k, b_v)  # pyrefly: ignore[unbound-name]
 
     if STORE_FINAL_STATE:
-        p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
-        tl.store(p_ht, b_h1.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+        m_ht = (o_k1[:, None] < K) & m_v[None, :]
+        tl.store(
+            ht + ptr_offset((o_k1[:, None], o_v[None, :]), (V, 1)),
+            b_h1.to(ht.dtype.element_ty),
+            mask=m_ht,
+        )
         if K > 64:
-            p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0))
+            m_ht = (o_k2[:, None] < K) & m_v[None, :]
             tl.store(
-                p_ht,
-                b_h2.to(p_ht.dtype.element_ty),  # pyrefly: ignore[unbound-name]
-                boundary_check=(0, 1),  # pyrefly: ignore[unbound-name]
-            )  # pyrefly: ignore[unbound-name]
+                ht + ptr_offset((o_k2[:, None], o_v[None, :]), (V, 1)),
+                b_h2.to(ht.dtype.element_ty),  # pyrefly: ignore[unbound-name]
+                mask=m_ht,
+            )
         if K > 128:
-            p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0))
+            m_ht = (o_k3[:, None] < K) & m_v[None, :]
             tl.store(
-                p_ht,
-                b_h3.to(p_ht.dtype.element_ty),  # pyrefly: ignore[unbound-name]
-                boundary_check=(0, 1),  # pyrefly: ignore[unbound-name]
-            )  # pyrefly: ignore[unbound-name]
+                ht + ptr_offset((o_k3[:, None], o_v[None, :]), (V, 1)),
+                b_h3.to(ht.dtype.element_ty),  # pyrefly: ignore[unbound-name]
+                mask=m_ht,
+            )
         if K > 192:
-            p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0))
+            m_ht = (o_k4[:, None] < K) & m_v[None, :]
             tl.store(
-                p_ht,
-                b_h4.to(p_ht.dtype.element_ty),  # pyrefly: ignore[unbound-name]
-                boundary_check=(0, 1),  # pyrefly: ignore[unbound-name]
-            )  # pyrefly: ignore[unbound-name]
+                ht + ptr_offset((o_k4[:, None], o_v[None, :]), (V, 1)),
+                b_h4.to(ht.dtype.element_ty),  # pyrefly: ignore[unbound-name]
+                mask=m_ht,
+            )
 
 
 @triton.heuristics(
@@ -366,25 +414,36 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64_forloop(
     if HAS_NUM_SEQS:
         upper_limit = tl.load(num_seqs)
 
+    o_k1 = tl.arange(0, 64)
+    o_v = ptr_offset((i_v,), (BV,)) + tl.arange(0, BV)
+    m_v = o_v < V
+    if K > 64:
+        o_k2 = 64 + o_k1
+    if K > 128:
+        o_k3 = 128 + o_k1
+    if K > 192:
+        o_k4 = 192 + o_k1
+
     for _iter in range((MAX_N + GRID_N - 1) // GRID_N):
-        i_n = i_n_start + _iter * GRID_N
+        i_n = tl.cast(i_n_start, tl.int64) + _iter * GRID_N
         _run = i_n < MAX_N
         if IS_VARLEN and HAS_NUM_SEQS and _run:
             _run = i_n < upper_limit  # pyrefly: ignore [unbound-name]
         if _run:
             if IS_VARLEN:
                 bos, eos = (
-                    tl.load(cu_seqlens + i_n).to(tl.int32),
-                    tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+                    tl.load(cu_seqlens + ptr_offset((i_n,), (1,))).to(tl.int32),
+                    tl.load(cu_seqlens + ptr_offset((i_n,), (1,)) + 1).to(tl.int32),
                 )
                 T_local = eos - bos
                 NT = tl.cdiv(T_local, BT)
-                boh = tl.load(chunk_offsets + i_n).to(tl.int32)
+                boh = tl.load(chunk_offsets + ptr_offset((i_n,), (1,))).to(tl.int32)
             else:
-                bos, eos = i_n * T, i_n * T + T
+                bos = tl.cast(i_n, tl.int64) * T
+                eos = bos + T
                 T_local = T
                 NT = tl.cdiv(T_local, BT)
-                boh = i_n * NT
+                boh = tl.cast(i_n, tl.int64) * NT
 
             # [BK, BV]
             b_h1 = tl.zeros([64, BV], dtype=tl.float32)
@@ -396,175 +455,137 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64_forloop(
                 b_h4 = tl.zeros([64, BV], dtype=tl.float32)
 
             # calculate offset from base pointers
-            h_off = h + (boh * H + i_h).to(tl.int64) * K * V
-            v_off = v + (bos * H + i_h).to(tl.int64) * V
-            k_off = k + (bos * H + i_h).to(tl.int64) * K
-            w_off = w + (bos * H + i_h).to(tl.int64) * K
+            h_off = h + ptr_offset((boh, i_h), (H * K * V, K * V))
+            v_off = v + ptr_offset((bos, i_h), (H * V, V))
+            k_off = k + ptr_offset((bos, i_h), (H * K, K))
+            w_off = w + ptr_offset((bos, i_h), (H * K, K))
             if SAVE_NEW_VALUE:
-                v_new_off = v_new + (bos * H + i_h).to(tl.int64) * V
-
-            i_nh_abs = i_n * H + i_h
+                v_new_off = v_new + ptr_offset((bos, i_h), (H * V, V))
 
             # load initial state
             if USE_INITIAL_STATE:
-                h0_off = h0 + i_nh_abs * K * V
-                p_h0_1 = tl.make_block_ptr(h0_off, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
-                b_h1 += tl.load(p_h0_1, boundary_check=(0, 1)).to(tl.float32)
+                h0_off = h0 + ptr_offset((i_n, i_h), (H * K * V, K * V))
+                m_h0 = (o_k1[:, None] < K) & m_v[None, :]
+                b_h1 += tl.load(
+                    h0_off + ptr_offset((o_k1[:, None], o_v[None, :]), (V, 1)),
+                    mask=m_h0,
+                    other=0.0,
+                ).to(tl.float32)
                 if K > 64:
-                    p_h0_2 = tl.make_block_ptr(
-                        h0_off, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0)
-                    )
-                    # pyrefly: ignore [unbound-name]
-                    b_h2 += tl.load(p_h0_2, boundary_check=(0, 1)).to(tl.float32)
+                    m_h0 = (o_k2[:, None] < K) & m_v[None, :]
+                    b_h2 += tl.load(  # pyrefly: ignore[unbound-name]
+                        h0_off + ptr_offset((o_k2[:, None], o_v[None, :]), (V, 1)),
+                        mask=m_h0,
+                        other=0.0,
+                    ).to(tl.float32)
                 if K > 128:
-                    p_h0_3 = tl.make_block_ptr(
-                        h0_off,
-                        (K, V),
-                        (V, 1),
-                        (128, i_v * BV),
-                        (64, BV),
-                        (1, 0),
-                    )
-                    # pyrefly: ignore [unbound-name]
-                    b_h3 += tl.load(p_h0_3, boundary_check=(0, 1)).to(tl.float32)
+                    m_h0 = (o_k3[:, None] < K) & m_v[None, :]
+                    b_h3 += tl.load(  # pyrefly: ignore[unbound-name]
+                        h0_off + ptr_offset((o_k3[:, None], o_v[None, :]), (V, 1)),
+                        mask=m_h0,
+                        other=0.0,
+                    ).to(tl.float32)
                 if K > 192:
-                    p_h0_4 = tl.make_block_ptr(
-                        h0_off, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0)
-                    )
-                    # pyrefly: ignore [unbound-name]
-                    b_h4 += tl.load(p_h0_4, boundary_check=(0, 1)).to(tl.float32)
+                    m_h0 = (o_k4[:, None] < K) & m_v[None, :]
+                    b_h4 += tl.load(  # pyrefly: ignore[unbound-name]
+                        h0_off + ptr_offset((o_k4[:, None], o_v[None, :]), (V, 1)),
+                        mask=m_h0,
+                        other=0.0,
+                    ).to(tl.float32)
 
             # main recurrence
             for i_t in range(NT):
-                p_h1 = tl.make_block_ptr(
-                    h_off + i_t * H * K * V,
-                    (K, V),
-                    (V, 1),
-                    (0, i_v * BV),
-                    (64, BV),
-                    (1, 0),
-                )  # pyrefly: ignore[unbound-name]
-                tl.store(p_h1, b_h1.to(p_h1.dtype.element_ty), boundary_check=(0, 1))
-                if K > 64:
-                    p_h2 = tl.make_block_ptr(
-                        h_off + i_t * H * K * V,
-                        (K, V),
-                        (V, 1),
-                        (64, i_v * BV),
-                        (64, BV),
-                        (1, 0),
-                    )  # pyrefly: ignore[unbound-name]
-                    tl.store(
-                        p_h2,
-                        b_h2.to(p_h2.dtype.element_ty),  # pyrefly: ignore[unbound-name]
-                        boundary_check=(0, 1),  # pyrefly: ignore[unbound-name]
-                    )  # pyrefly: ignore[unbound-name]
-                if K > 128:
-                    p_h3 = tl.make_block_ptr(  # pyrefly: ignore[unbound-name]
-                        h_off + i_t * H * K * V,
-                        (K, V),
-                        (V, 1),
-                        (128, i_v * BV),
-                        (64, BV),
-                        (1, 0),
-                    )
-                    tl.store(
-                        p_h3,
-                        b_h3.to(p_h3.dtype.element_ty),  # pyrefly: ignore[unbound-name]
-                        boundary_check=(0, 1),  # pyrefly: ignore[unbound-name]
-                    )  # pyrefly: ignore[unbound-name]
-                if K > 192:
-                    p_h4 = tl.make_block_ptr(
-                        h_off + i_t * H * K * V,
-                        (K, V),
-                        (V, 1),
-                        (192, i_v * BV),
-                        (64, BV),
-                        (1, 0),
-                    )
-                    tl.store(  # pyrefly: ignore[unbound-name]
-                        p_h4,
-                        b_h4.to(p_h4.dtype.element_ty),  # pyrefly: ignore[unbound-name]
-                        boundary_check=(0, 1),  # pyrefly: ignore[unbound-name]
-                    )  # pyrefly: ignore[unbound-name]
-
-                p_w = tl.make_block_ptr(
-                    w_off, (T_local, K), (H * K, 1), (i_t * BT, 0), (BT, 64), (1, 0)
+                h_t = h_off + ptr_offset((i_t,), (H * K * V,))
+                m_h = (o_k1[:, None] < K) & m_v[None, :]
+                tl.store(
+                    h_t + ptr_offset((o_k1[:, None], o_v[None, :]), (V, 1)),
+                    b_h1.to(h.dtype.element_ty),
+                    mask=m_h,
                 )
-                b_w = tl.load(p_w, boundary_check=(0, 1))
+                if K > 64:
+                    m_h = (o_k2[:, None] < K) & m_v[None, :]
+                    tl.store(
+                        h_t + ptr_offset((o_k2[:, None], o_v[None, :]), (V, 1)),
+                        b_h2.to(h.dtype.element_ty),  # pyrefly: ignore[unbound-name]
+                        mask=m_h,
+                    )
+                if K > 128:
+                    m_h = (o_k3[:, None] < K) & m_v[None, :]
+                    tl.store(
+                        h_t + ptr_offset((o_k3[:, None], o_v[None, :]), (V, 1)),
+                        b_h3.to(h.dtype.element_ty),  # pyrefly: ignore[unbound-name]
+                        mask=m_h,
+                    )
+                if K > 192:
+                    m_h = (o_k4[:, None] < K) & m_v[None, :]
+                    tl.store(
+                        h_t + ptr_offset((o_k4[:, None], o_v[None, :]), (V, 1)),
+                        b_h4.to(h.dtype.element_ty),  # pyrefly: ignore[unbound-name]
+                        mask=m_h,
+                    )
+
+                o_t = ptr_offset((i_t,), (BT,)) + tl.arange(0, BT)
+                m_t = o_t < T_local
+                m_w = m_t[:, None] & (o_k1[None, :] < K)
+                b_w = tl.load(
+                    w_off + ptr_offset((o_t[:, None], o_k1[None, :]), (H * K, 1)),
+                    mask=m_w,
+                    other=0.0,
+                )
                 b_v = tl.dot(b_w, b_h1.to(b_w.dtype))  # pyrefly: ignore[unbound-name]
                 if K > 64:
-                    p_w = tl.make_block_ptr(
-                        w_off,
-                        (T_local, K),
-                        (H * K, 1),
-                        (i_t * BT, 64),
-                        (BT, 64),
-                        (1, 0),
+                    m_w = m_t[:, None] & (o_k2[None, :] < K)
+                    b_w = tl.load(
+                        w_off + ptr_offset((o_t[:, None], o_k2[None, :]), (H * K, 1)),
+                        mask=m_w,
+                        other=0.0,
                     )
-                    b_w = tl.load(p_w, boundary_check=(0, 1))
                     b_v += tl.dot(
                         b_w,
                         b_h2.to(b_w.dtype),  # pyrefly: ignore [unbound-name]
                     )  # pyrefly: ignore[unbound-name]
                 if K > 128:
-                    p_w = tl.make_block_ptr(
-                        w_off,
-                        (T_local, K),
-                        (H * K, 1),
-                        (i_t * BT, 128),
-                        (BT, 64),
-                        (1, 0),
+                    m_w = m_t[:, None] & (o_k3[None, :] < K)
+                    b_w = tl.load(
+                        w_off + ptr_offset((o_t[:, None], o_k3[None, :]), (H * K, 1)),
+                        mask=m_w,
+                        other=0.0,
                     )
-                    b_w = tl.load(p_w, boundary_check=(0, 1))
                     b_v += tl.dot(
                         b_w,
                         b_h3.to(b_w.dtype),  # pyrefly: ignore [unbound-name]
                     )  # pyrefly: ignore[unbound-name]
                 if K > 192:
-                    p_w = tl.make_block_ptr(
-                        w_off,
-                        (T_local, K),
-                        (H * K, 1),
-                        (i_t * BT, 192),
-                        (BT, 64),
-                        (1, 0),
+                    m_w = m_t[:, None] & (o_k4[None, :] < K)
+                    b_w = tl.load(
+                        w_off + ptr_offset((o_t[:, None], o_k4[None, :]), (H * K, 1)),
+                        mask=m_w,
+                        other=0.0,
                     )
-                    b_w = tl.load(p_w, boundary_check=(0, 1))
                     b_v += tl.dot(
                         b_w,
                         b_h4.to(b_w.dtype),  # pyrefly: ignore [unbound-name]
                     )  # pyrefly: ignore[unbound-name]
-                p_v = tl.make_block_ptr(
-                    v_off,
-                    (T_local, V),
-                    (H * V, 1),
-                    (i_t * BT, i_v * BV),
-                    (BT, BV),
-                    (1, 0),
-                )
-                b_v = tl.load(p_v, boundary_check=(0, 1)) - b_v
+
+                m_v_block = m_t[:, None] & m_v[None, :]
+                v_offset = ptr_offset((o_t[:, None], o_v[None, :]), (H * V, 1))
+                b_v = tl.load(v_off + v_offset, mask=m_v_block, other=0.0) - b_v
 
                 if SAVE_NEW_VALUE:
-                    p_v = tl.make_block_ptr(
-                        # pyrefly: ignore [unbound-name]
-                        v_new_off,
-                        (T_local, V),
-                        (H * V, 1),
-                        (i_t * BT, i_v * BV),
-                        (BT, BV),
-                        (1, 0),
+                    tl.store(
+                        v_new_off + v_offset,  # pyrefly: ignore[unbound-name]
+                        b_v.to(v_new.dtype.element_ty),
+                        mask=m_v_block,
                     )
-                    tl.store(p_v, b_v.to(p_v.dtype.element_ty), boundary_check=(0, 1))
 
-                last_idx = min((i_t + 1) * BT, T_local) - 1
+                last_idx = min(ptr_offset((i_t,), (BT,)) + BT, T_local) - 1
                 if USE_G:
-                    m_t = (i_t * BT + tl.arange(0, BT)) < T_local
-                    b_g_last = tl.load(g + bos * H + last_idx * H + i_h)
-                    p_g = tl.make_block_ptr(  # pyrefly: ignore[unbound-name]
-                        g + bos * H + i_h, (T_local,), (H,), (i_t * BT,), (BT,), (0,)
-                    )  # pyrefly: ignore[unbound-name]
-                    b_g = tl.load(p_g, boundary_check=(0,))
+                    b_g_last = tl.load(g + ptr_offset((bos, last_idx, i_h), (H, H, 1)))
+                    b_g = tl.load(
+                        g + ptr_offset((bos, o_t, i_h), (H, H, 1)),
+                        mask=m_t,
+                        other=0.0,
+                    )
                     if USE_EXP2:  # pyrefly: ignore[unbound-name]
                         b_v = b_v * tl.where(m_t, exp2(b_g_last - b_g), 0)[:, None]
                         b_g_last = exp2(b_g_last)
@@ -580,9 +601,12 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64_forloop(
                         b_h4 *= b_g_last  # pyrefly: ignore[unbound-name,unsupported-operation]
 
                 if USE_GK:
-                    o_k1 = tl.arange(0, 64)
                     b_gk_last1 = tl.load(
-                        gk + (bos + last_idx) * H * K + i_h * K + o_k1,
+                        gk
+                        + ptr_offset(
+                            (bos, last_idx, i_h, o_k1),
+                            (H * K, H * K, K, 1),
+                        ),
                         mask=(o_k1 < K),
                         other=0.0,
                     )
@@ -594,9 +618,12 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64_forloop(
                     else:
                         b_h1 *= exp(b_gk_last1)[:, None]  # pyrefly: ignore[unsupported-operation]
                     if K > 64:
-                        o_k2 = 64 + o_k1
                         b_gk_last2 = tl.load(
-                            gk + (bos + last_idx) * H * K + i_h * K + o_k2,  # pyrefly: ignore[unbound-name,unsupported-operation]
+                            gk
+                            + ptr_offset(
+                                (bos, last_idx, i_h, o_k2),
+                                (H * K, H * K, K, 1),
+                            ),  # pyrefly: ignore[unbound-name,unsupported-operation]
                             mask=(o_k2 < K),
                             other=0.0,  # pyrefly: ignore[unbound-name,unsupported-operation]
                         )
@@ -609,9 +636,12 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64_forloop(
                                 :, None
                             ]  # pyrefly: ignore[unbound-name,unsupported-operation]
                     if K > 128:
-                        o_k3 = 128 + o_k1  # pyrefly: ignore[unbound-name,unsupported-operation]
                         b_gk_last3 = tl.load(
-                            gk + (bos + last_idx) * H * K + i_h * K + o_k3,
+                            gk
+                            + ptr_offset(
+                                (bos, last_idx, i_h, o_k3),
+                                (H * K, H * K, K, 1),
+                            ),
                             mask=(o_k3 < K),
                             other=0.0,
                         )
@@ -624,9 +654,12 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64_forloop(
                                 :, None
                             ]  # pyrefly: ignore[unbound-name,unsupported-operation]
                     if K > 192:
-                        o_k4 = 192 + o_k1
                         b_gk_last4 = tl.load(
-                            gk + (bos + last_idx) * H * K + i_h * K + o_k4,  # pyrefly: ignore[unbound-name]
+                            gk
+                            + ptr_offset(
+                                (bos, last_idx, i_h, o_k4),
+                                (H * K, H * K, K, 1),
+                            ),  # pyrefly: ignore[unbound-name]
                             mask=(o_k4 < K),
                             other=0.0,
                         )
@@ -640,81 +673,66 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64_forloop(
                             ]  # pyrefly: ignore[unbound-name,unsupported-operation]
                 b_v = b_v.to(k.dtype.element_ty)
 
-                p_k = tl.make_block_ptr(
-                    k_off, (K, T_local), (1, H * K), (0, i_t * BT), (64, BT), (0, 1)
+                m_k = (o_k1[:, None] < K) & m_t[None, :]
+                b_k = tl.load(
+                    k_off + ptr_offset((o_k1[:, None], o_t[None, :]), (1, H * K)),
+                    mask=m_k,
+                    other=0.0,
                 )
-                b_k = tl.load(p_k, boundary_check=(0, 1))  # pyrefly: ignore[unbound-name]
                 b_h1 += tl.dot(b_k, b_v)
                 if K > 64:
-                    p_k = tl.make_block_ptr(
-                        k_off,
-                        (K, T_local),
-                        (1, H * K),
-                        (64, i_t * BT),
-                        (64, BT),
-                        (0, 1),
+                    m_k = (o_k2[:, None] < K) & m_t[None, :]
+                    b_k = tl.load(
+                        k_off + ptr_offset((o_k2[:, None], o_t[None, :]), (1, H * K)),
+                        mask=m_k,
+                        other=0.0,
                     )
-                    b_k = tl.load(p_k, boundary_check=(0, 1))
                     b_h2 += tl.dot(b_k, b_v)  # pyrefly: ignore [unbound-name]
                 if K > 128:
-                    p_k = tl.make_block_ptr(
-                        k_off,
-                        (K, T_local),
-                        (1, H * K),
-                        (128, i_t * BT),
-                        (64, BT),
-                        (0, 1),
+                    m_k = (o_k3[:, None] < K) & m_t[None, :]
+                    b_k = tl.load(
+                        k_off + ptr_offset((o_k3[:, None], o_t[None, :]), (1, H * K)),
+                        mask=m_k,
+                        other=0.0,
                     )
-                    b_k = tl.load(p_k, boundary_check=(0, 1))
                     b_h3 += tl.dot(b_k, b_v)  # pyrefly: ignore [unbound-name]
                 if K > 192:
-                    p_k = tl.make_block_ptr(
-                        k_off,
-                        (K, T_local),
-                        (1, H * K),
-                        (192, i_t * BT),
-                        (64, BT),
-                        (0, 1),
+                    m_k = (o_k4[:, None] < K) & m_t[None, :]
+                    b_k = tl.load(
+                        k_off + ptr_offset((o_k4[:, None], o_t[None, :]), (1, H * K)),
+                        mask=m_k,
+                        other=0.0,
                     )
-                    b_k = tl.load(p_k, boundary_check=(0, 1))
                     b_h4 += tl.dot(b_k, b_v)  # pyrefly: ignore[unbound-name]
 
             if STORE_FINAL_STATE:
-                ht_off = ht + i_nh_abs * K * V
-                p_ht = tl.make_block_ptr(ht_off, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
-                tl.store(p_ht, b_h1.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+                ht_off = ht + ptr_offset((i_n, i_h), (H * K * V, K * V))
+                m_ht = (o_k1[:, None] < K) & m_v[None, :]
+                tl.store(
+                    ht_off + ptr_offset((o_k1[:, None], o_v[None, :]), (V, 1)),
+                    b_h1.to(ht.dtype.element_ty),
+                    mask=m_ht,
+                )
                 if K > 64:
-                    p_ht = tl.make_block_ptr(
-                        ht_off, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0)
-                    )
+                    m_ht = (o_k2[:, None] < K) & m_v[None, :]
                     tl.store(
-                        # pyrefly: ignore [unbound-name]
-                        p_ht,
-                        # pyrefly: ignore [unbound-name]
-                        b_h2.to(p_ht.dtype.element_ty),
-                        boundary_check=(0, 1),
+                        ht_off + ptr_offset((o_k2[:, None], o_v[None, :]), (V, 1)),
+                        b_h2.to(ht.dtype.element_ty),  # pyrefly: ignore[unbound-name]
+                        mask=m_ht,
                     )
                 if K > 128:
-                    p_ht = tl.make_block_ptr(
-                        ht_off, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0)
-                    )
+                    m_ht = (o_k3[:, None] < K) & m_v[None, :]
                     tl.store(
-                        # pyrefly: ignore [unbound-name]
-                        p_ht,
-                        # pyrefly: ignore [unbound-name]
-                        b_h3.to(p_ht.dtype.element_ty),
-                        boundary_check=(0, 1),
+                        ht_off + ptr_offset((o_k3[:, None], o_v[None, :]), (V, 1)),
+                        b_h3.to(ht.dtype.element_ty),  # pyrefly: ignore[unbound-name]
+                        mask=m_ht,
                     )
                 if K > 192:
-                    p_ht = tl.make_block_ptr(
-                        ht_off, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0)
-                    )
+                    m_ht = (o_k4[:, None] < K) & m_v[None, :]
                     tl.store(
-                        # pyrefly: ignore [unbound-name]
-                        p_ht,
-                        # pyrefly: ignore [unbound-name]
-                        b_h4.to(p_ht.dtype.element_ty),
-                        boundary_check=(0, 1),
+                        ht_off + ptr_offset((o_k4[:, None], o_v[None, :]), (V, 1)),
+                        b_h4.to(ht.dtype.element_ty),  # pyrefly: ignore[unbound-name]
+                        mask=m_ht,
                     )
 
 

--- a/attn_gym/linear/kda/fwd/triton/chunk_gla_fwd_o.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_gla_fwd_o.py
@@ -15,7 +15,7 @@ import torch
 import triton
 import triton.language as tl
 
-from attn_gym._backends.triton.utils import ptr_offset
+from attn_gym._backends.triton.utils import ptr_offset, requires_int64_offsets
 from attn_gym.linear.kda.utils import (
     autotune_cache_kwargs,
     exp,
@@ -27,6 +27,17 @@ from attn_gym.linear.kda.utils import (
     {
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
         "HAS_NUM_CHUNKS": lambda args: args["num_chunks"] is not None,
+        "USE_INT64_OFFSETS": lambda args: requires_int64_offsets(
+            args["q"],
+            args["v"],
+            args["g"],
+            args["h"],
+            args["o"],
+            args["A"],
+            args["cu_seqlens"],
+            args["chunk_indices"],
+            args["num_chunks"],
+        ),
     }
 )
 @triton.autotune(
@@ -58,31 +69,42 @@ def chunk_gla_fwd_kernel_o(
     USE_EXP2: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     HAS_NUM_CHUNKS: tl.constexpr,
+    USE_INT64_OFFSETS: tl.constexpr,
 ):
     i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    if USE_INT64_OFFSETS:
+        i_v = i_v.to(tl.int64)
+        i_t = i_t.to(tl.int64)
+        i_bh = i_bh.to(tl.int64)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
         if HAS_NUM_CHUNKS and i_t >= tl.load(num_chunks):
             return
-        i_tg = i_t.to(tl.int64)
+        i_tg = i_t
         i_n, i_t = (
             tl.load(chunk_indices + ptr_offset((i_t, 0), (2, 1))).to(tl.int32),
             tl.load(chunk_indices + ptr_offset((i_t, 1), (2, 1))).to(tl.int32),
         )
+        if USE_INT64_OFFSETS:
+            i_n = i_n.to(tl.int64)
+            i_t = i_t.to(tl.int64)
         bos, eos = (
             tl.load(cu_seqlens + ptr_offset((i_n, 0), (1, 1))).to(tl.int32),
             tl.load(cu_seqlens + ptr_offset((i_n, 1), (1, 1))).to(tl.int32),
         )
+        if USE_INT64_OFFSETS:
+            bos = bos.to(tl.int64)
+            eos = eos.to(tl.int64)
         T = eos - bos
         NT = tl.cdiv(T, BT)
     else:
         NT = tl.cdiv(T, BT)
-        i_tg = i_b.to(tl.int64) * NT + i_t
-        bos = i_b.to(tl.int64) * T
+        i_tg = i_b * NT + i_t
+        bos = i_b * T
 
     o_i = tl.arange(0, BT)
-    o_t = i_t.to(tl.int64) * BT + o_i
-    o_v = i_v.to(tl.int64) * BV + tl.arange(0, BV)
+    o_t = i_t * BT + o_i
+    o_v = i_v * BV + tl.arange(0, BV)
     m_t = o_t < T
     m_v = o_v < V
     m_tv = m_t[:, None] & m_v[None, :]

--- a/attn_gym/linear/kda/fwd/triton/chunk_gla_fwd_o.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_gla_fwd_o.py
@@ -6,9 +6,8 @@
 #
 # Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
 #
-# Forward-only GLA output-projection, ported verbatim from
+# Forward-only GLA output projection, based on
 # genai/llama4x/llama4x/ops/fla/ops/gla/chunk.py.
-# Only the imports were rewritten to point at the standalone mslk common utils.
 
 from __future__ import annotations
 
@@ -16,6 +15,7 @@ import torch
 import triton
 import triton.language as tl
 
+from attn_gym._backends.triton.utils import ptr_offset
 from attn_gym.linear.kda.utils import (
     autotune_cache_kwargs,
     exp,
@@ -64,93 +64,72 @@ def chunk_gla_fwd_kernel_o(
     if IS_VARLEN:
         if HAS_NUM_CHUNKS and i_t >= tl.load(num_chunks):
             return
-        i_tg = i_t
+        i_tg = i_t.to(tl.int64)
         i_n, i_t = (
-            tl.load(chunk_indices + i_t * 2).to(tl.int32),
-            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32),
+            tl.load(chunk_indices + ptr_offset((i_t, 0), (2, 1))).to(tl.int32),
+            tl.load(chunk_indices + ptr_offset((i_t, 1), (2, 1))).to(tl.int32),
         )
         bos, eos = (
-            tl.load(cu_seqlens + i_n).to(tl.int32),
-            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+            tl.load(cu_seqlens + ptr_offset((i_n, 0), (1, 1))).to(tl.int32),
+            tl.load(cu_seqlens + ptr_offset((i_n, 1), (1, 1))).to(tl.int32),
         )
         T = eos - bos
         NT = tl.cdiv(T, BT)
     else:
         NT = tl.cdiv(T, BT)
-        i_tg = i_b * NT + i_t
-        bos, eos = i_b * T, i_b * T + T
+        i_tg = i_b.to(tl.int64) * NT + i_t
+        bos = i_b.to(tl.int64) * T
 
-    m_s = tl.arange(0, BT)[:, None] >= tl.arange(0, BT)[None, :]
+    o_i = tl.arange(0, BT)
+    o_t = i_t.to(tl.int64) * BT + o_i
+    o_v = i_v.to(tl.int64) * BV + tl.arange(0, BV)
+    m_t = o_t < T
+    m_v = o_v < V
+    m_tv = m_t[:, None] & m_v[None, :]
+    m_s = o_i[:, None] >= o_i[None, :]
+
+    q += ptr_offset((bos, i_h), (H * K, K))
+    g += ptr_offset((bos, i_h), (H * K, K))
+    h += ptr_offset((i_tg, i_h), (H * K * V, K * V))
+    v += ptr_offset((bos, i_h), (H * V, V))
+    o += ptr_offset((bos, i_h), (H * V, V))
+    A += ptr_offset((bos, i_h), (H * BT, BT))
 
     b_o = tl.zeros([BT, BV], dtype=tl.float32)
     for i_k in range(tl.cdiv(K, BK)):
-        p_q = tl.make_block_ptr(
-            q + (bos * H + i_h) * K,
-            (T, K),
-            (H * K, 1),
-            (i_t * BT, i_k * BK),
-            (BT, BK),
-            (1, 0),
-        )
-        p_g = tl.make_block_ptr(
-            g + (bos * H + i_h) * K,
-            (T, K),
-            (H * K, 1),
-            (i_t * BT, i_k * BK),
-            (BT, BK),
-            (1, 0),
-        )
-        p_h = tl.make_block_ptr(
-            h + (i_tg * H + i_h) * K * V,
-            (K, V),
-            (V, 1),
-            (i_k * BK, i_v * BV),
-            (BK, BV),
-            (1, 0),
-        )
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = o_k < K
+        m_qg = m_t[:, None] & m_k[None, :]
+        p_q = q + ptr_offset((o_t[:, None], o_k[None, :]), (H * K, 1))
+        p_g = g + ptr_offset((o_t[:, None], o_k[None, :]), (H * K, 1))
+        p_h = h + ptr_offset((o_k[:, None], o_v[None, :]), (V, 1))
 
         # [BT, BK]
-        b_q = tl.load(p_q, boundary_check=(0, 1))
+        b_q = tl.load(p_q, mask=m_qg, other=0.0)
         # [BT, BK]
-        b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
+        b_g = tl.load(p_g, mask=m_qg, other=0.0).to(tl.float32)
         # [BT, BK]
         if USE_EXP2:
             b_qg = (b_q * exp2(b_g)).to(b_q.dtype)
         else:
             b_qg = (b_q * exp(b_g)).to(b_q.dtype)
         # [BK, BV]
-        b_h = tl.load(p_h, boundary_check=(0, 1))
+        b_h = tl.load(p_h, mask=m_k[:, None] & m_v[None, :], other=0.0)
         # works but dkw, owing to divine benevolence
         # [BT, BV]
         if i_k >= 0:
             b_o += tl.dot(b_qg, b_h.to(b_qg.dtype))
     b_o *= scale
-    p_v = tl.make_block_ptr(
-        v + (bos * H + i_h) * V,
-        (T, V),
-        (H * V, 1),
-        (i_t * BT, i_v * BV),
-        (BT, BV),
-        (1, 0),
-    )
-    p_o = tl.make_block_ptr(
-        o + (bos * H + i_h) * V,
-        (T, V),
-        (H * V, 1),
-        (i_t * BT, i_v * BV),
-        (BT, BV),
-        (1, 0),
-    )
-    p_A = tl.make_block_ptr(
-        A + (bos * H + i_h) * BT, (T, BT), (H * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0)
-    )
+    p_v = v + ptr_offset((o_t[:, None], o_v[None, :]), (H * V, 1))
+    p_o = o + ptr_offset((o_t[:, None], o_v[None, :]), (H * V, 1))
+    p_A = A + ptr_offset((o_t[:, None], o_i[None, :]), (H * BT, 1))
     # [BT, BV]
-    b_v = tl.load(p_v, boundary_check=(0, 1))
+    b_v = tl.load(p_v, mask=m_tv, other=0.0)
     # [BT, BT]
-    b_A = tl.load(p_A, boundary_check=(0, 1))
+    b_A = tl.load(p_A, mask=m_t[:, None], other=0.0)
     b_A = tl.where(m_s, b_A, 0.0).to(b_v.dtype)
     b_o += tl.dot(b_A, b_v)
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_o, b_o.to(o.dtype.element_ty), mask=m_tv)
 
 
 def chunk_gla_fwd_o_gk(

--- a/attn_gym/linear/kda/fwd/triton/chunk_kda_fwd_intra_sub_chunk_forloop.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_kda_fwd_intra_sub_chunk_forloop.py
@@ -16,6 +16,7 @@
 import triton
 import triton.language as tl
 
+from attn_gym._backends.triton.utils import ptr_offset
 from attn_gym.linear.kda.utils import (
     autotune_cache_kwargs,
     exp2,
@@ -71,48 +72,49 @@ def chunk_kda_fwd_kernel_intra_sub_chunk_forloop(
             _run = i_t_orig < tl.load(num_chunks)
         if _run:
             if IS_VARLEN:
+                chunk_offset = ptr_offset((i_t_orig,), (2,))
                 i_n, i_t = (
-                    tl.load(chunk_indices + i_t_orig * 2).to(tl.int32),
-                    tl.load(chunk_indices + i_t_orig * 2 + 1).to(tl.int32),
+                    tl.load(chunk_indices + chunk_offset).to(tl.int32),
+                    tl.load(chunk_indices + chunk_offset + 1).to(tl.int32),
                 )
+                cu_seqlens_offset = ptr_offset((i_n,), (1,))
                 bos, eos = (
-                    tl.load(cu_seqlens + i_n).to(tl.int32),
-                    tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+                    tl.load(cu_seqlens + cu_seqlens_offset).to(tl.int32),
+                    tl.load(cu_seqlens + cu_seqlens_offset + 1).to(tl.int32),
                 )
                 T_local = eos - bos
             else:
                 i_t = i_t_orig
-                bos, eos = i_b * T, i_b * T + T
+                bos = tl.cast(i_b, tl.int64) * T
                 T_local = T
 
-            i_ti = i_t * BT + i_i * BC
+            i_ti = ptr_offset((i_t, i_i), (BT, BC))
             if i_ti < T_local:
                 o_c = i_ti + tl.arange(0, BC)
                 m_c = o_c < T_local
 
-                q_off = q + (bos * H + i_h) * K
-                k_off = k + (bos * H + i_h) * K
-                g_off = g + (bos * H + i_h) * K
-                beta_off = beta + bos * H + i_h
-                Aqk_off = Aqk + (bos * H + i_h) * BT
-                Akk_off = Akk + (bos * H + i_h) * BC
+                qkg_base_offset = ptr_offset((bos, i_h), (H * K, K))
+                q_off = q + qkg_base_offset
+                k_off = k + qkg_base_offset
+                g_off = g + qkg_base_offset
+                beta_off = beta + ptr_offset((bos, i_h), (H, 1))
+                Aqk_off = Aqk + ptr_offset((bos, i_h), (H * BT, BT))
+                Akk_off = Akk + ptr_offset((bos, i_h), (H * BC, BC))
 
-                p_q = tl.make_block_ptr(
-                    q_off, (T_local, K), (H * K, 1), (i_ti, 0), (BC, BK), (1, 0)
+                o_k = tl.arange(0, BK)
+                m_qkg = m_c[:, None] & (o_k[None, :] < K)
+                qkg_offsets = ptr_offset(
+                    (o_c[:, None], o_k[None, :]),
+                    (H * K, 1),
                 )
-                p_k = tl.make_block_ptr(
-                    k_off, (T_local, K), (H * K, 1), (i_ti, 0), (BC, BK), (1, 0)
+                b_q = tl.load(q_off + qkg_offsets, mask=m_qkg, other=0.0)
+                b_k = tl.load(k_off + qkg_offsets, mask=m_qkg, other=0.0)
+                b_g = tl.load(g_off + qkg_offsets, mask=m_qkg, other=0.0)
+                b_beta = tl.load(
+                    beta_off + ptr_offset((o_c,), (H,)),
+                    mask=m_c,
+                    other=0.0,
                 )
-                p_g = tl.make_block_ptr(
-                    g_off, (T_local, K), (H * K, 1), (i_ti, 0), (BC, BK), (1, 0)
-                )
-
-                p_beta = tl.make_block_ptr(beta_off, (T_local,), (H,), (i_ti,), (BC,), (0,))
-
-                b_q = tl.load(p_q, boundary_check=(0, 1))
-                b_k = tl.load(p_k, boundary_check=(0, 1))
-                b_g = tl.load(p_g, boundary_check=(0, 1))
-                b_beta = tl.load(p_beta, boundary_check=(0,))
 
                 if CAUSAL_NORMREF:
                     normref_idx = 0
@@ -121,8 +123,11 @@ def chunk_kda_fwd_kernel_intra_sub_chunk_forloop(
                 if USE_GATHER:
                     b_gn = gather(b_g, tl.full([1, BK], normref_idx, dtype=tl.int16), axis=0)
                 else:
-                    p_gn = g_off + (i_ti + normref_idx) * H * K + tl.arange(0, BK)
-                    b_gn = tl.load(p_gn, mask=tl.arange(0, BK) < K, other=0.0)
+                    p_gn = g_off + ptr_offset(
+                        (i_ti + normref_idx, o_k),
+                        (H * K, 1),
+                    )
+                    b_gn = tl.load(p_gn, mask=o_k < K, other=0.0)
                     b_gn = b_gn[None, :]
 
                 b_gm = (b_g - b_gn).to(tl.float32)
@@ -143,31 +148,31 @@ def chunk_kda_fwd_kernel_intra_sub_chunk_forloop(
                 b_Aqk = tl.where(m_Aqk, b_Aqk, 0.0)
                 b_Akk = tl.where(m_Akk, b_Akk, 0.0)
 
-                p_Aqk = tl.make_block_ptr(
-                    Aqk_off,
-                    (T_local, BT),
+                o_Aqk = ptr_offset((i_i, o_i), (BC, 1))
+                p_Aqk = Aqk_off + ptr_offset(
+                    (o_c[:, None], o_Aqk[None, :]),
                     (H * BT, 1),
-                    (i_ti, i_i * BC),
-                    (BC, BC),
-                    (1, 0),
                 )
-                p_Akk = tl.make_block_ptr(
-                    Akk_off, (T_local, BC), (H * BC, 1), (i_ti, 0), (BC, BC), (1, 0)
+                p_Akk = Akk_off + ptr_offset(
+                    (o_c[:, None], o_i[None, :]),
+                    (H * BC, 1),
                 )
-                tl.store(p_Aqk, b_Aqk.to(Aqk.dtype.element_ty), boundary_check=(0, 1))
-                tl.store(p_Akk, b_Akk.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+                m_Aqk_store = m_c[:, None] & (o_Aqk[None, :] < BT)
+                m_Akk_store = m_c[:, None] & (o_i[None, :] < BC)
+                tl.store(p_Aqk, b_Aqk.to(Aqk.dtype.element_ty), mask=m_Aqk_store)
+                tl.store(p_Akk, b_Akk.to(Akk.dtype.element_ty), mask=m_Akk_store)
 
                 tl.debug_barrier()
 
                 # forward substitution
                 b_Ai = -b_Akk
                 for i in range(2, min(BC, T_local - i_ti)):
-                    b_a = -tl.load(Akk_off + (i_ti + i) * H * BC + o_i)
+                    b_a = -tl.load(Akk_off + ptr_offset((i_ti + i, o_i), (H * BC, 1)))
                     b_a = tl.where(o_i < i, b_a, 0.0)
                     b_a += tl.sum(b_a[:, None] * b_Ai, 0)
                     b_Ai = tl.where((o_i == i)[:, None], b_a, b_Ai)
                 b_Ai += m_I
-                tl.store(p_Akk, b_Ai.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+                tl.store(p_Akk, b_Ai.to(Akk.dtype.element_ty), mask=m_Akk_store)
 
 
 __all__ = ["chunk_kda_fwd_kernel_intra_sub_chunk_forloop"]

--- a/attn_gym/linear/kda/fwd/triton/chunk_kda_fwd_intra_sub_chunk_forloop.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_kda_fwd_intra_sub_chunk_forloop.py
@@ -16,7 +16,7 @@
 import triton
 import triton.language as tl
 
-from attn_gym._backends.triton.utils import ptr_offset
+from attn_gym._backends.triton.utils import ptr_offset, requires_int64_offsets
 from attn_gym.linear.kda.utils import (
     autotune_cache_kwargs,
     exp2,
@@ -28,6 +28,17 @@ from attn_gym.linear.kda.utils import (
     {
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
         "HAS_NUM_CHUNKS": lambda args: args["num_chunks"] is not None,
+        "USE_INT64_OFFSETS": lambda args: requires_int64_offsets(
+            args["q"],
+            args["k"],
+            args["g"],
+            args["beta"],
+            args["Aqk"],
+            args["Akk"],
+            args["cu_seqlens"],
+            args["chunk_indices"],
+            args["num_chunks"],
+        ),
     }
 )
 @triton.autotune(
@@ -57,12 +68,16 @@ def chunk_kda_fwd_kernel_intra_sub_chunk_forloop(
     BK: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     HAS_NUM_CHUNKS: tl.constexpr,
+    USE_INT64_OFFSETS: tl.constexpr,
     USE_GATHER: tl.constexpr,
     CAUSAL_NORMREF: tl.constexpr = True,
     GRID_NT: tl.constexpr = 0,
     MAX_NT: tl.constexpr = 0,
 ):
     i_t_start, i_i, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    if USE_INT64_OFFSETS:
+        i_t_start = i_t_start.to(tl.int64)
+        i_bh = i_bh.to(tl.int64)
     i_b, i_h = i_bh // H, i_bh % H
 
     for _iter in range((MAX_NT + GRID_NT - 1) // GRID_NT):
@@ -77,15 +92,21 @@ def chunk_kda_fwd_kernel_intra_sub_chunk_forloop(
                     tl.load(chunk_indices + chunk_offset).to(tl.int32),
                     tl.load(chunk_indices + chunk_offset + 1).to(tl.int32),
                 )
+                if USE_INT64_OFFSETS:
+                    i_n = i_n.to(tl.int64)
+                    i_t = i_t.to(tl.int64)
                 cu_seqlens_offset = ptr_offset((i_n,), (1,))
                 bos, eos = (
                     tl.load(cu_seqlens + cu_seqlens_offset).to(tl.int32),
                     tl.load(cu_seqlens + cu_seqlens_offset + 1).to(tl.int32),
                 )
+                if USE_INT64_OFFSETS:
+                    bos = bos.to(tl.int64)
+                    eos = eos.to(tl.int64)
                 T_local = eos - bos
             else:
                 i_t = i_t_orig
-                bos = tl.cast(i_b, tl.int64) * T
+                bos = i_b * T
                 T_local = T
 
             i_ti = ptr_offset((i_t, i_i), (BT, BC))

--- a/test/test_kda_cute_forward.py
+++ b/test/test_kda_cute_forward.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import gc
+import importlib
 
 import pytest
 import torch
@@ -108,6 +109,35 @@ def test_optimized_chunk_kda_autograd_without_initial_state():
         error = (actual_gradient.float() - expected_gradient).abs().max()
         tolerance = 5e-3 + 5e-3 * expected_gradient.abs().max()
         assert error <= tolerance
+
+
+def test_kda_offset_width_specializations_match(monkeypatch):
+    """Keep the normal int32 and large-storage int64 specializations equivalent."""
+    torch.manual_seed(40)
+    inputs = _inputs(heads=2)
+    d_output = torch.randn_like(inputs[0])
+
+    output32, state = chunk_kda(*inputs)
+    assert state is None
+    gradients32 = torch.autograd.grad(output32, inputs, d_output)
+
+    for module_name in (
+        "attn_gym.linear.kda.fwd.triton.chunk_kda_fwd_intra_sub_chunk_forloop",
+        "attn_gym.linear.kda.fwd.triton.chunk_delta_h",
+        "attn_gym.linear.kda.fwd.triton.chunk_gla_fwd_o",
+        "attn_gym.linear.kda.bwd.triton.chunk_kda_bwd_dav",
+    ):
+        module = importlib.import_module(module_name)
+        monkeypatch.setattr(module, "requires_int64_offsets", lambda *_tensors: True)
+
+    inputs64 = _clone_inputs(inputs)
+    output64, state = chunk_kda(*inputs64)
+    assert state is None
+    gradients64 = torch.autograd.grad(output64, inputs64, d_output)
+
+    torch.testing.assert_close(output64, output32, rtol=0, atol=0)
+    for gradient64, gradient32 in zip(gradients64, gradients32, strict=True):
+        torch.testing.assert_close(gradient64, gradient32, rtol=0, atol=0)
 
 
 def test_chunk_kda_custom_op_registration():

--- a/test/test_triton_utils.py
+++ b/test/test_triton_utils.py
@@ -13,11 +13,14 @@ triton = pytest.importorskip("triton")
 tl = pytest.importorskip("triton.language")
 triton_utils = pytest.importorskip("attn_gym._backends.triton.utils")
 ptr_offset = triton_utils.ptr_offset
+requires_int64_offsets = triton_utils.requires_int64_offsets
 storage_cosize = triton_utils.storage_cosize
 
 
 @triton.jit
-def _store_ptr_offset(output, index, stride: tl.constexpr):
+def _store_ptr_offset(output, index, stride: tl.constexpr, use_int64_offsets: tl.constexpr):
+    if use_int64_offsets:
+        index = tl.cast(index, tl.int64)
     tl.store(output, ptr_offset((index,), (stride,)))
 
 
@@ -37,20 +40,30 @@ def test_storage_cosize():
         storage_cosize((1,), (-1,))
 
 
-def test_ptr_offset_uses_signed_64_bit_arithmetic():
+def test_requires_int64_offsets_uses_relative_storage_cosize():
+    """Use the strict int32 threshold from tensor shape and stride metadata."""
+    at_limit = torch.empty_strided((2,), (2**31 - 1,), device="meta")
+    over_limit = torch.empty_strided((2,), (2**31,), device="meta")
+
+    assert storage_cosize(at_limit.shape, at_limit.stride()) == 2**31
+    assert storage_cosize(over_limit.shape, over_limit.stride()) == 2**31 + 1
+    assert not requires_int64_offsets()
+    assert not requires_int64_offsets(None, at_limit)
+    assert requires_int64_offsets(at_limit, None, over_limit)
+
+
+@pytest.mark.parametrize("index", [700_001, -700_001])
+def test_ptr_offset_preserves_caller_selected_integer_width(index):
+    """Let callers retain int32 offsets or conditionally promote them to int64."""
     if not torch.cuda.is_available():
         pytest.skip("CUDA is required for Triton kernels")
 
-    index = 700_001
     stride = 4096
     output = torch.empty((), device="cuda", dtype=torch.int64)
-    _store_ptr_offset[(1,)](output, index, stride=stride)
 
+    _store_ptr_offset[(1,)](output, index, stride=stride, use_int64_offsets=False)
+    wrapped_int32 = ((index * stride + 2**31) % 2**32) - 2**31
+    assert output.item() == wrapped_int32
+
+    _store_ptr_offset[(1,)](output, index, stride=stride, use_int64_offsets=True)
     assert output.item() == index * stride
-    assert output.item() > 2**31
-
-    negative_index = -index
-    _store_ptr_offset[(1,)](output, negative_index, stride=stride)
-
-    assert output.item() == negative_index * stride
-    assert output.item() < -(2**31)

--- a/test/test_triton_utils.py
+++ b/test/test_triton_utils.py
@@ -7,9 +7,18 @@
 """Tests for utilities shared by hand-written Triton kernels."""
 
 import pytest
+import torch
 
+triton = pytest.importorskip("triton")
+tl = pytest.importorskip("triton.language")
 triton_utils = pytest.importorskip("attn_gym._backends.triton.utils")
+ptr_offset = triton_utils.ptr_offset
 storage_cosize = triton_utils.storage_cosize
+
+
+@triton.jit
+def _store_ptr_offset(output, index, stride: tl.constexpr):
+    tl.store(output, ptr_offset((index,), (stride,)))
 
 
 def test_storage_cosize():
@@ -26,3 +35,22 @@ def test_storage_cosize():
         storage_cosize((-1,), (1,))
     with pytest.raises(ValueError, match="nonnegative"):
         storage_cosize((1,), (-1,))
+
+
+def test_ptr_offset_uses_signed_64_bit_arithmetic():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for Triton kernels")
+
+    index = 700_001
+    stride = 4096
+    output = torch.empty((), device="cuda", dtype=torch.int64)
+    _store_ptr_offset[(1,)](output, index, stride=stride)
+
+    assert output.item() == index * stride
+    assert output.item() > 2**31
+
+    negative_index = -index
+    _store_ptr_offset[(1,)](output, negative_index, stride=stride)
+
+    assert output.item() == negative_index * stride
+    assert output.item() < -(2**31)


### PR DESCRIPTION
## Summary

- replace all 63 deprecated `tl.make_block_ptr` uses in the KDA Triton kernels with explicit masked loads/stores built on the shared `ptr_offset` helper
- preserve packed-variable-length tails, transposed tile layouts, dtype conversions, and the existing pre-Hopper fallback behavior
- keep `ptr_offset` type-preserving for existing users instead of globally forcing signed 64-bit arithmetic
- specialize each migrated KDA kernel with `USE_INT64_OFFSETS`: normal storage extents retain 32-bit coordinate arithmetic, while extents above `2**31` elements widen global coordinates before multiplication
- preserve vectorized dAv loads and add offset-width threshold and specialization-equivalence coverage

Tensor descriptors are not used here because the generic kernels support device-computed packed sequence boundaries and hardware without TMA. Explicit offsets allow the required per-element local-tail masks without introducing a separate descriptor/fallback kernel family.

The width selector reads only host-side shape/stride metadata. It does not inspect tensor data or synchronize CUDA, and the result is a Triton compile-time specialization.

## Validation

- zero `tl.make_block_ptr` occurrences remain under `attn_gym/linear/kda`
- focused GPU suites:
  - `test/test_triton_utils.py`
  - `test/test_kda_cute_forward.py`, including bitwise equality between normal int32 and forced int64 KDA specializations
  - `test/test_kda_kernels.py`
  - combined result: 140 passed
- `test/test_selected_attention_triton.py`: 111 passed
- direct fixed-length, packed-varlen, non-aligned K/V, and offsets beyond signed 32-bit range matched the previous kernels bit-for-bit
- fullgraph compilation, CUDA Graph replay, custom-op checks, and forward/backward autograd passed
- Ruff, formatting, `py_compile`, `prek`, and `git diff --check` passed

## Performance

Representative GB300 workload: `B=1, T=16384, C=2304, H=32, D=128`, BF16 KDA core, CUDA-event timing after warmup.

- the optimized direct-pointer dAv kernel remains approximately 20% faster than the former block-pointer kernel
- normal-size KDA uses the 32-bit specialization; forced-int64 and int32 variants remain within low-single-digit component differences
- existing non-KDA `ptr_offset` users retain their original arithmetic and code generation

No broad end-to-end speedup is claimed; the migration is performance-neutral at the complete-layer level while removing the deprecated API and retaining a safe large-storage specialization.
