### PR TITLE
Use TMA for regular KDA tiles

### DIFF
--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd.py
@@ -14,7 +14,7 @@ from attn_gym.linear.kda.bwd.cute.chunk_kda_bwd_intra import chunk_kda_bwd_intra
 from attn_gym.linear.kda.bwd.cute.chunk_kda_bwd_wy_dqkg_fused import (
     chunk_kda_bwd_wy_dqkg,
 )
-from attn_gym.linear.kda.bwd.triton.chunk_kda_bwd_dav import chunk_kda_bwd_kernel_dAv
+from attn_gym.linear.kda.bwd.triton.chunk_kda_bwd_dav import chunk_kda_bwd_dav
 from attn_gym.linear.kda.fwd.cute.recompute_w_u_fwd import recompute_w_u_fwd
 from attn_gym.linear.kda.fwd.triton.chunk_delta_h import chunk_gated_delta_rule_fwd_h
 
@@ -46,7 +46,7 @@ def chunk_kda_bwd(
     torch.Tensor | None,
 ]:
     """Differentiate the optimized fixed-length KDA core pipeline."""
-    batch, tokens, heads, head_dim = q.shape
+    batch, tokens, _heads, head_dim = q.shape
     value_dim = v.shape[-1]
     if batch != 1 or head_dim != 128 or value_dim != 128:
         raise ValueError("the composed KDA backward requires B=1 and K=V=128")
@@ -54,7 +54,6 @@ def chunk_kda_bwd(
         raise ValueError(f"the composed KDA backward requires chunk_size=64, got {chunk_size}")
     if tokens % chunk_size:
         raise ValueError("the composed KDA backward requires complete chunks")
-    chunks = tokens // chunk_size
     if initial_state is not None:
         initial_state = initial_state.contiguous()
 
@@ -90,28 +89,13 @@ def chunk_kda_bwd(
         )
     del u
 
-    dv_intra = torch.empty_like(v_new)
-    dAqk = torch.empty_like(Aqk, dtype=torch.float32)
     with record("kda/triton/backward_dav"):
-        chunk_kda_bwd_kernel_dAv[(chunks, batch * heads)](
-            q=q,
-            k=k,
-            v=v_new,
-            A=Aqk,
-            do=do,
-            dv=dv_intra,
-            dA=dAqk,
-            cu_seqlens=None,
-            chunk_indices=None,
-            num_chunks=None,
-            scale=head_dim**-0.5,
-            T=tokens,
-            H=heads,
-            K=head_dim,
-            V=value_dim,
-            BT=chunk_size,
-            BK=head_dim,
-            BV=64,
+        dv_intra, dAqk = chunk_kda_bwd_dav(
+            v_new,
+            Aqk,
+            do,
+            head_dim**-0.5,
+            chunk_size=chunk_size,
         )
     with record("kda/cute/backward_delta_h"):
         dh, d_initial_state, dv = blackwell_delta_h_bwd_dhu_dispatch(

--- a/attn_gym/linear/kda/bwd/triton/chunk_kda_bwd_dav.py
+++ b/attn_gym/linear/kda/bwd/triton/chunk_kda_bwd_dav.py
@@ -12,44 +12,54 @@
 
 from __future__ import annotations
 
+import torch
 import triton
 import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
 
-from attn_gym._backends.triton.utils import ptr_offset, requires_int64_offsets
+from attn_gym._backends.triton.utils import can_use_tma, ptr_offset, requires_int64_offsets
 from attn_gym.linear.kda.utils import (
     autotune_cache_kwargs,
 )
+
+
+def _uses_tensor_descriptors(args) -> bool:
+    return isinstance(args["v"], TensorDescriptor)
+
+
+def _requires_int64_offsets(args) -> bool:
+    if _uses_tensor_descriptors(args):
+        return False
+    return requires_int64_offsets(
+        args["v"],
+        args["A"],
+        args["do"],
+        args["dv"],
+        args["dA"],
+        args["cu_seqlens"],
+        args["chunk_indices"],
+        args["num_chunks"],
+    )
 
 
 @triton.heuristics(
     {
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
         "HAS_NUM_CHUNKS": lambda args: args["num_chunks"] is not None,
-        "USE_INT64_OFFSETS": lambda args: requires_int64_offsets(
-            args["q"],
-            args["k"],
-            args["v"],
-            args["A"],
-            args["do"],
-            args["dv"],
-            args["dA"],
-            args["cu_seqlens"],
-            args["chunk_indices"],
-            args["num_chunks"],
-        ),
+        "USE_TMA": _uses_tensor_descriptors,
+        "USE_INT64_OFFSETS": _requires_int64_offsets,
     }
 )
 @triton.autotune(
     configs=[
         triton.Config({}, num_warps=2, num_stages=2),
+        triton.Config({}, num_warps=2, num_stages=3),
     ],
-    key=["H", "K", "V", "BT", "BK", "BV"],
+    key=["H", "V", "BT", "BV", "USE_TMA"],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=["T", "num_chunks"])
 def chunk_kda_bwd_kernel_dAv(
-    q,
-    k,
     v,
     A,
     do,
@@ -61,92 +71,182 @@ def chunk_kda_bwd_kernel_dAv(
     scale,
     T,
     H: tl.constexpr,
-    K: tl.constexpr,
     V: tl.constexpr,
     BT: tl.constexpr,
-    BK: tl.constexpr,
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     HAS_NUM_CHUNKS: tl.constexpr,
+    USE_TMA: tl.constexpr,
     USE_INT64_OFFSETS: tl.constexpr,
 ):
+    """Differentiate KDA value tiles with pointer or TMA specialization."""
     i_t, i_bh = tl.program_id(0), tl.program_id(1)
-    if USE_INT64_OFFSETS:
+    if not USE_TMA and USE_INT64_OFFSETS:
         i_t = i_t.to(tl.int64)
         i_bh = i_bh.to(tl.int64)
     i_b, i_h = i_bh // H, i_bh % H
-    if IS_VARLEN:
-        if HAS_NUM_CHUNKS and i_t >= tl.load(num_chunks):
-            return
-        i_n, i_t = (
-            tl.load(chunk_indices + ptr_offset((i_t, 0), (2, 1))).to(tl.int32),
-            tl.load(chunk_indices + ptr_offset((i_t, 1), (2, 1))).to(tl.int32),
-        )
-        if USE_INT64_OFFSETS:
-            i_n = i_n.to(tl.int64)
-            i_t = i_t.to(tl.int64)
-        bos, eos = (
-            tl.load(cu_seqlens + ptr_offset((i_n,), (1,))).to(tl.int32),
-            tl.load(cu_seqlens + ptr_offset((i_n + 1,), (1,))).to(tl.int32),
-        )
-        if USE_INT64_OFFSETS:
-            bos = bos.to(tl.int64)
-            eos = eos.to(tl.int64)
-        T = eos - bos
-    else:
-        bos = i_b * T
 
-    q += ptr_offset((bos, i_h), (H * K, K))
-    k += ptr_offset((bos, i_h), (H * K, K))
-    v += ptr_offset((bos, i_h), (H * V, V))
-    A += ptr_offset((bos, i_h), (H * BT, BT))
-    do += ptr_offset((bos, i_h), (H * V, V))
-    dv += ptr_offset((bos, i_h), (H * V, V))
-    dA += ptr_offset((bos, i_h), (H * BT, BT))
+    if not USE_TMA:
+        if IS_VARLEN:
+            if HAS_NUM_CHUNKS and i_t >= tl.load(num_chunks):
+                return
+            i_n, i_t = (
+                tl.load(chunk_indices + ptr_offset((i_t, 0), (2, 1))).to(tl.int32),
+                tl.load(chunk_indices + ptr_offset((i_t, 1), (2, 1))).to(tl.int32),
+            )
+            if USE_INT64_OFFSETS:
+                i_n = i_n.to(tl.int64)
+                i_t = i_t.to(tl.int64)
+            bos, eos = (
+                tl.load(cu_seqlens + ptr_offset((i_n,), (1,))).to(tl.int32),
+                tl.load(cu_seqlens + ptr_offset((i_n + 1,), (1,))).to(tl.int32),
+            )
+            if USE_INT64_OFFSETS:
+                bos = bos.to(tl.int64)
+                eos = eos.to(tl.int64)
+            T = eos - bos
+        else:
+            bos = i_b * T
+
+        v += ptr_offset((bos, i_h), (H * V, V))
+        A += ptr_offset((bos, i_h), (H * BT, BT))
+        do += ptr_offset((bos, i_h), (H * V, V))
+        dv += ptr_offset((bos, i_h), (H * V, V))
+        dA += ptr_offset((bos, i_h), (H * BT, BT))
 
     o_i = tl.arange(0, BT)
     o_t = i_t * BT + o_i
-    m_t = o_t < T
-    m_tt = m_t[:, None] & m_t[None, :]
-    # The leading BT feature axis is always in bounds; only token columns can be ragged.
-    b_A = tl.load(
-        A + ptr_offset((o_i[:, None], o_t[None, :]), (1, H * BT)),
-        mask=m_t[None, :],
-        other=0.0,
-    )
-    m_A = (o_t[:, None] <= o_t[None, :]) & m_tt
-    b_A = tl.where(m_A, b_A, 0).to(do.dtype.element_ty)
+    if USE_TMA:
+        b_A = A.load([i_b, i_t * BT, i_h, 0])
+        b_A = tl.trans(tl.reshape(b_A, [BT, BT]))
+        b_A = tl.where(o_i[:, None] <= o_i[None, :], b_A, 0.0)
+    else:
+        m_t = o_t < T
+        m_tt = m_t[:, None] & m_t[None, :]
+        # The leading BT feature axis is always in bounds; only token columns can be ragged.
+        b_A = tl.load(
+            A + ptr_offset((o_i[:, None], o_t[None, :]), (1, H * BT)),
+            mask=m_t[None, :],
+            other=0.0,
+        )
+        m_A = (o_t[:, None] <= o_t[None, :]) & m_tt
+        b_A = tl.where(m_A, b_A, 0).to(do.dtype.element_ty)
 
     b_dA = tl.zeros([BT, BT], dtype=tl.float32)
     for i_v in range(tl.cdiv(V, BV)):
-        o_v = i_v * BV + tl.arange(0, BV)
-        m_v = (o_v[:, None] < V) & m_t[None, :]
-        m_do = m_t[:, None] & (o_v[None, :] < V)
-        # [BV, BT]
-        b_v = tl.load(
-            v + ptr_offset((o_v[:, None], o_t[None, :]), (1, H * V)),
-            mask=m_v,
-            other=0.0,
-        )
-        # [BT, BV]
-        b_do = tl.load(
-            do + ptr_offset((o_t[:, None], o_v[None, :]), (H * V, 1)),
-            mask=m_do,
-            other=0.0,
-        )
+        if USE_TMA:
+            b_v = v.load([i_b, i_t * BT, i_h, i_v * BV])
+            b_v = tl.trans(tl.reshape(b_v, [BT, BV]))
+            b_do = do.load([i_b, i_t * BT, i_h, i_v * BV])
+            b_do = tl.reshape(b_do, [BT, BV])
+        else:
+            o_v = i_v * BV + tl.arange(0, BV)
+            m_v = (o_v[:, None] < V) & m_t[None, :]
+            m_do = m_t[:, None] & (o_v[None, :] < V)
+            # [BV, BT]
+            b_v = tl.load(
+                v + ptr_offset((o_v[:, None], o_t[None, :]), (1, H * V)),
+                mask=m_v,
+                other=0.0,
+            )
+            # [BT, BV]
+            b_do = tl.load(
+                do + ptr_offset((o_t[:, None], o_v[None, :]), (H * V, 1)),
+                mask=m_do,
+                other=0.0,
+            )
+
         # [BT, BT]
         b_dA += tl.dot(b_do, b_v)
         # [BT, BV]
         b_dv = tl.dot(b_A.to(b_do.dtype), b_do)
+        if USE_TMA:
+            dv.store(
+                [i_b, i_t * BT, i_h, i_v * BV],
+                tl.reshape(b_dv.to(b_do.dtype), [1, BT, 1, BV]),
+            )
+        else:
+            tl.store(
+                dv + ptr_offset((o_t[:, None], o_v[None, :]), (H * V, 1)),
+                b_dv.to(dv.dtype.element_ty),
+                mask=m_do,
+            )
+
+    b_dA = tl.where(o_i[:, None] >= o_i[None, :], b_dA * scale, 0.0)
+    if USE_TMA:
+        dA.store(
+            [i_b, i_t * BT, i_h, 0],
+            tl.reshape(b_dA, [1, BT, 1, BT]),
+        )
+    else:
         tl.store(
-            dv + ptr_offset((o_t[:, None], o_v[None, :]), (H * V, 1)),
-            b_dv.to(dv.dtype.element_ty),
-            mask=m_do,
+            dA + ptr_offset((o_t[:, None], o_i[None, :]), (H * BT, 1)),
+            b_dA.to(dA.dtype.element_ty),
+            mask=m_t[:, None],
         )
 
-    b_dA = tl.where(o_t[:, None] >= o_t[None, :], b_dA * scale, 0.0)
-    tl.store(
-        dA + ptr_offset((o_t[:, None], o_i[None, :]), (H * BT, 1)),
-        b_dA.to(dA.dtype.element_ty),
-        mask=m_t[:, None],
-    )
+
+def _can_use_tensor_descriptors(*tensors: torch.Tensor) -> bool:
+    """Return whether all fixed KDA tensors satisfy host TMA requirements."""
+    return all(can_use_tma(tensor) for tensor in tensors)
+
+
+def chunk_kda_bwd_dav(
+    v: torch.Tensor,
+    A: torch.Tensor,
+    do: torch.Tensor,
+    scale: float,
+    *,
+    chunk_size: int = 64,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Differentiate the fixed-length KDA intra-chunk value term."""
+    batch, tokens, heads, value_dim = v.shape
+    if tokens % chunk_size:
+        raise ValueError(f"the KDA dAv kernel requires complete chunks, got T={tokens}")
+    if A.shape != (batch, tokens, heads, chunk_size):
+        raise ValueError("A must have shape [B, T, H, chunk_size]")
+    if do.shape != v.shape:
+        raise ValueError("do must have the same shape as v")
+
+    dv = torch.empty_like(v)
+    dA = torch.empty_like(A, dtype=torch.float32)
+    chunks = tokens // chunk_size
+    block_value_dim = 64
+    if (value_dim, chunk_size) == (128, 64) and _can_use_tensor_descriptors(v, A, do, dv, dA):
+        chunk_kda_bwd_kernel_dAv[(chunks, batch * heads)](
+            v=TensorDescriptor.from_tensor(v, [1, chunk_size, 1, block_value_dim]),
+            A=TensorDescriptor.from_tensor(A, [1, chunk_size, 1, chunk_size]),
+            do=TensorDescriptor.from_tensor(do, [1, chunk_size, 1, block_value_dim]),
+            dv=TensorDescriptor.from_tensor(dv, [1, chunk_size, 1, block_value_dim]),
+            dA=TensorDescriptor.from_tensor(dA, [1, chunk_size, 1, chunk_size]),
+            cu_seqlens=None,
+            chunk_indices=None,
+            num_chunks=None,
+            scale=scale,
+            T=tokens,
+            H=heads,
+            V=value_dim,
+            BT=chunk_size,
+            BV=block_value_dim,
+        )
+    else:
+        chunk_kda_bwd_kernel_dAv[(chunks, batch * heads)](
+            v=v,
+            A=A,
+            do=do,
+            dv=dv,
+            dA=dA,
+            cu_seqlens=None,
+            chunk_indices=None,
+            num_chunks=None,
+            scale=scale,
+            T=tokens,
+            H=heads,
+            V=value_dim,
+            BT=chunk_size,
+            BV=block_value_dim,
+        )
+    return dv, dA
+
+
+__all__ = ["chunk_kda_bwd_dav"]

--- a/attn_gym/linear/kda/fwd/triton/chunk_gla_fwd_o.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_gla_fwd_o.py
@@ -14,8 +14,9 @@ from __future__ import annotations
 import torch
 import triton
 import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
 
-from attn_gym._backends.triton.utils import ptr_offset, requires_int64_offsets
+from attn_gym._backends.triton.utils import can_use_tma, ptr_offset, requires_int64_offsets
 from attn_gym.linear.kda.utils import (
     autotune_cache_kwargs,
     exp,
@@ -154,6 +155,57 @@ def chunk_gla_fwd_kernel_o(
     tl.store(p_o, b_o.to(o.dtype.element_ty), mask=m_tv)
 
 
+@triton.jit
+def chunk_gla_fwd_kernel_o_tma(
+    q_desc,
+    v_desc,
+    g_desc,
+    h_desc,
+    o_desc,
+    A_desc,
+    scale,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+):
+    """Compose fixed KDA output tiles with TMA-backed tensor descriptors."""
+    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+
+    b_o = tl.zeros([BT, BV], dtype=tl.float32)
+    for i_k in range(tl.cdiv(K, BK)):
+        b_q = q_desc.load([i_b, i_t * BT, i_h, i_k * BK])
+        b_q = tl.reshape(b_q, [BT, BK])
+        b_g = g_desc.load([i_b, i_t * BT, i_h, i_k * BK])
+        b_g = tl.reshape(b_g, [BT, BK]).to(tl.float32)
+        b_qg = (b_q * exp2(b_g)).to(b_q.dtype)
+
+        b_h = h_desc.load([i_b, i_t, i_h, i_k * BK, i_v * BV])
+        b_h = tl.reshape(b_h, [BK, BV]).to(b_qg.dtype)
+        b_o += tl.dot(b_qg, b_h)
+
+    b_o *= scale
+    b_A = A_desc.load([i_b, i_t * BT, i_h, 0])
+    b_A = tl.reshape(b_A, [BT, BT])
+    o_i = tl.arange(0, BT)
+    b_A = tl.where(o_i[:, None] >= o_i[None, :], b_A, 0.0)
+    b_v = v_desc.load([i_b, i_t * BT, i_h, i_v * BV])
+    b_v = tl.reshape(b_v, [BT, BV])
+    b_o += tl.dot(b_A.to(b_v.dtype), b_v)
+    o_desc.store(
+        [i_b, i_t * BT, i_h, i_v * BV],
+        tl.reshape(b_o.to(b_v.dtype), [1, BT, 1, BV]),
+    )
+
+
+def _can_use_tensor_descriptors(*tensors: torch.Tensor) -> bool:
+    """Return whether all fixed KDA tensors satisfy host TMA requirements."""
+    return all(can_use_tma(tensor) for tensor in tensors)
+
+
 def chunk_gla_fwd_o_gk(
     q: torch.Tensor,
     v: torch.Tensor,
@@ -183,28 +235,57 @@ def chunk_gla_fwd_o_gk(
         raise ValueError(f"h must have shape {expected_h_shape}, got {tuple(h.shape)}")
 
     output = torch.empty_like(v)
+    if (key_dim, value_dim, chunk_size) == (128, 128, 64) and _can_use_tensor_descriptors(
+        q, v, g, h, output, A
+    ):
+        block_key_dim = 32
+        block_value_dim = 64
+        chunk_gla_fwd_kernel_o_tma[
+            (
+                triton.cdiv(value_dim, block_value_dim),
+                chunks,
+                batch * heads,
+            )
+        ](
+            TensorDescriptor.from_tensor(q, [1, chunk_size, 1, block_key_dim]),
+            TensorDescriptor.from_tensor(v, [1, chunk_size, 1, block_value_dim]),
+            TensorDescriptor.from_tensor(g, [1, chunk_size, 1, block_key_dim]),
+            TensorDescriptor.from_tensor(h, [1, 1, 1, block_key_dim, block_value_dim]),
+            TensorDescriptor.from_tensor(output, [1, chunk_size, 1, block_value_dim]),
+            TensorDescriptor.from_tensor(A, [1, chunk_size, 1, chunk_size]),
+            scale,
+            H=heads,
+            K=key_dim,
+            V=value_dim,
+            BT=chunk_size,
+            BK=block_key_dim,
+            BV=block_value_dim,
+            num_warps=2,
+            num_stages=3,
+        )
+    else:
 
-    def grid(meta):
-        return (triton.cdiv(value_dim, meta["BV"]), chunks, batch * heads)
+        def grid(meta):
+            return (triton.cdiv(value_dim, meta["BV"]), chunks, batch * heads)
 
-    chunk_gla_fwd_kernel_o[grid](
-        q=q,
-        v=v,
-        g=g,
-        h=h,
-        o=output,
-        A=A,
-        cu_seqlens=None,
-        chunk_indices=None,
-        num_chunks=None,
-        scale=scale,
-        T=tokens,
-        H=heads,
-        K=key_dim,
-        V=value_dim,
-        BT=chunk_size,
-        USE_EXP2=True,
-    )
+        chunk_gla_fwd_kernel_o[grid](
+            q=q,
+            v=v,
+            g=g,
+            h=h,
+            o=output,
+            A=A,
+            cu_seqlens=None,
+            chunk_indices=None,
+            num_chunks=None,
+            scale=scale,
+            T=tokens,
+            H=heads,
+            K=key_dim,
+            V=value_dim,
+            BT=chunk_size,
+            USE_EXP2=True,
+        )
     return output
 
 

--- a/test/test_kda_cute_forward.py
+++ b/test/test_kda_cute_forward.py
@@ -111,11 +111,49 @@ def test_optimized_chunk_kda_autograd_without_initial_state():
         assert error <= tolerance
 
 
+def test_kda_tensor_descriptor_and_pointer_paths_match(monkeypatch):
+    """Keep the Blackwell TMA path bitwise equivalent to its pointer fallback."""
+    torch.manual_seed(41)
+    descriptor_inputs = _inputs(heads=2)
+    d_output = torch.randn_like(descriptor_inputs[0])
+
+    descriptor_output, state = chunk_kda(*descriptor_inputs)
+    assert state is None
+    descriptor_gradients = torch.autograd.grad(descriptor_output, descriptor_inputs, d_output)
+
+    for module_name in (
+        "attn_gym.linear.kda.fwd.triton.chunk_gla_fwd_o",
+        "attn_gym.linear.kda.bwd.triton.chunk_kda_bwd_dav",
+    ):
+        module = importlib.import_module(module_name)
+        monkeypatch.setattr(module, "_can_use_tensor_descriptors", lambda *_tensors: False)
+
+    pointer_inputs = _clone_inputs(descriptor_inputs)
+    pointer_output, state = chunk_kda(*pointer_inputs)
+    assert state is None
+    pointer_gradients = torch.autograd.grad(pointer_output, pointer_inputs, d_output)
+
+    torch.testing.assert_close(pointer_output, descriptor_output, rtol=0, atol=0)
+    for pointer_gradient, descriptor_gradient in zip(
+        pointer_gradients,
+        descriptor_gradients,
+        strict=True,
+    ):
+        torch.testing.assert_close(pointer_gradient, descriptor_gradient, rtol=0, atol=0)
+
+
 def test_kda_offset_width_specializations_match(monkeypatch):
     """Keep the normal int32 and large-storage int64 specializations equivalent."""
     torch.manual_seed(40)
     inputs = _inputs(heads=2)
     d_output = torch.randn_like(inputs[0])
+
+    for module_name in (
+        "attn_gym.linear.kda.fwd.triton.chunk_gla_fwd_o",
+        "attn_gym.linear.kda.bwd.triton.chunk_kda_bwd_dav",
+    ):
+        module = importlib.import_module(module_name)
+        monkeypatch.setattr(module, "_can_use_tensor_descriptors", lambda *_tensors: False)
 
     output32, state = chunk_kda(*inputs)
     assert state is None


### PR DESCRIPTION
## Summary

- add host `TensorDescriptor`/TMA implementations for the regular fixed-shape KDA output-composition and dAv tiles
- select TMA only for the production `K=V=128`, `chunk_size=64` specialization when the tensors satisfy the existing capability, alignment, and stride checks
- retain the pointer-and-mask kernels as fallbacks for unsupported hardware, shapes, or layouts
- keep the pointer implementations for the inter-chunk recurrence and intra-subchunk solve because descriptor prototypes were slower
- add bitwise forward/backward parity coverage between the descriptor and pointer paths

The generated production PTX contains `cp.async.bulk.tensor` loads/stores and uses no global scratch allocation.

## Performance

NVIDIA GB300, `B=1, T=16384, C=2304, H=32, D=128`, `chunk_size=64`; warmed CUDA-event medians:

| Scope | Pointer | TMA | Change |
| --- | ---: | ---: | ---: |
| Output composition | 0.322 ms | 0.231 ms | 28.2% faster |
| dAv | 0.182 ms | 0.153 ms | 15.9% faster |
| Complete KDA core | 5.111 ms | 4.978 ms | 2.6% faster |
| Eager complete layer | 27.187 ms | 27.073 ms | 0.4% faster |
| Fullgraph-compiled complete layer | 25.794 ms | 25.641 ms | 0.6% faster |

Rejected descriptor prototypes:

- inter-chunk `delta_h`: 0.618 ms pointer vs. 0.637 ms TMA
- intra-subchunk solve: 0.291 ms pointer vs. 0.303 ms TMA

Peak allocated memory was unchanged at 4.5023 GiB eager and 4.5025 GiB compiled.

## Validation

- complete descriptor and pointer outputs and gradients are bitwise identical
- strict `torch.compile(fullgraph=True)` and CUDA Graph replay coverage passes
- `141 passed` across:
  - `test/test_triton_utils.py`
  - `test/test_kda_kernels.py`
  - `test/test_kda_cute_forward.py`
- `prek run --all-files`
- `py_compile`
- `git diff --check`
