### PR TITLE
Tune KDA production kernel launches

### DIFF
--- a/.agents/skills/cutedsl-tunable-kernel-template/SKILL.md
+++ b/.agents/skills/cutedsl-tunable-kernel-template/SKILL.md
@@ -62,14 +62,21 @@ class MyConfig(NamedTuple):
     tile_size: int
 ```
 
-A tunable adapter supplies five distinct responsibilities:
+A tunable adapter supplies five distinct responsibilities. When its launch ABI has several values,
+make that ABI an `Args` type owned by the adapter rather than a separate module-level private type:
 
 ```python
-class _MyOp:
+class MyOp:
+    class Args(NamedTuple):
+        q: torch.Tensor
+        k: torch.Tensor
+        output: torch.Tensor
+        workspace: torch.Tensor
+
     default_config = MyConfig(threads=128, tile_size=256)
 
     @staticmethod
-    def configs(*runtime_args) -> tuple[MyConfig, ...]:
+    def configs(args: Args) -> tuple[MyConfig, ...]:
         """Return valid candidates derived from actual runtime inputs."""
         ...
 
@@ -80,12 +87,12 @@ class _MyOp:
         ...
 
     @staticmethod
-    def compile_call(config: MyConfig, *runtime_args) -> tuple:
-        """Project runtime inputs to static arguments for compile(...)."""
+    def compile_call(config: MyConfig, args: Args) -> tuple:
+        """Project launch arguments to static arguments for compile(...)."""
         ...
 
     @staticmethod
-    def launch(compiled, config: MyConfig, *runtime_args):
+    def launch(compiled, config: MyConfig, args: Args):
         """Launch in the parent with real tensors and return the public result."""
         ...
 ```
@@ -95,17 +102,30 @@ constructor-heavy DSL op may stay focused on layouts and device code while a sma
 five static/class methods above.
 
 - `default_config` is a conservative fallback and must be valid for every runtime input accepted by
-  the adapter. If the normal choice depends on inputs or target metadata, resolve it in the parent
-  wrapper and pass it as `config=`. Name canonical mode configs after the mode rather than calling an
-  architecture-specific config the default.
+  the adapter. If the normal choice depends on inputs or target metadata, keep that selection method
+  on the adapter (for example, `default_for(...)`), call it from the parent wrapper, and pass its
+  result as `config=`. Do not leave an adapter-specific default heuristic as an unrelated module-level
+  helper. Name canonical mode configs after the mode rather than calling an architecture-specific
+  config the default.
 - `configs(...)` may inspect runtime shape, stride, dtype, alignment, or device facts.
 - `compile(...)` owns fake tensors and the cached artifact boundary.
 - `compile_call(...)` prevents runtime tensors from leaking into cache keys or subprocess payloads.
 - `launch(...)` binds the compiled callable to real tensors for correctness checks and timing.
 
-The protocol accepts `*runtime_args`, but do not grow a positional list of inputs, outputs, and static
-semantics indefinitely. Pass one parent-only runtime bundle once the arguments form one launch ABI;
-`compile_call(...)` then projects that bundle to static values, while `launch(...)` unwraps it.
+The protocol accepts positional runtime arguments for small ABIs. Keep one or two naturally named
+values positional; wrapping them in `Args` would add ceremony without clarifying ownership. Do not,
+however, grow a positional list of inputs, outputs, and static semantics indefinitely. Once several
+values form one launch ABI, pass one parent-only `Args` value. Nest `Args` in its adapter when no
+other component owns that ABI; use a descriptive top-level type when multiple components genuinely
+share it. Do not create a module-level `_Runtime` or `_Args` type merely to signal privacy. Reserve
+“runtime” for an execution environment or lifecycle-bearing object, not a passive argument tuple.
+`compile_call(...)` projects `Args` to static values, while `launch(...)` binds its real tensors to
+the compiled callable.
+
+Nesting communicates ownership, not public API status. If an adapter has a normal class name but is
+an implementation detail, define the module's `__all__` explicitly and list only the supported
+wrapper and configuration types. Do not use leading underscores as a substitute for deciding and
+documenting the module's actual public surface.
 
 ## Public Wrapper
 
@@ -113,31 +133,35 @@ Users call one ordinary PyTorch function; they do not construct op objects or co
 
 ```python
 def my_op(
-    x: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
     *,
     config: MyConfig | None = None,
     tune: bool = False,
     configs: Iterable[MyConfig] | None = None,
 ) -> torch.Tensor:
-    y = torch.empty_like(x)
-    result, _selected = run_tunable(
-        _MyOp,
-        x,
-        y,
+    args = MyOp.Args(
+        q,
+        k,
+        torch.empty_like(q),
+        torch.empty_like(q, dtype=torch.float32),
+    )
+    return run_tunable(
+        MyOp,
+        args,
         config=config,
         autotune=tune,
         configs=configs,
-    )
-    return result
+    )[0]
 ```
 
 This gives three intentional modes:
 
 ```python
-my_op(x)                                      # conservative default
-my_op(x, config=MyConfig(64, 128))            # force one specialization
-my_op(x, tune=True)                           # input-aware candidate method
-my_op(x, tune=True, configs=(cfg_a, cfg_b))   # explicit candidate override
+my_op(q, k)                                      # conservative default
+my_op(q, k, config=MyConfig(64, 128))            # force one specialization
+my_op(q, k, tune=True)                           # input-aware candidate method
+my_op(q, k, tune=True, configs=(cfg_a, cfg_b))   # explicit candidate override
 ```
 
 Reject `config=` with tuning and reject `configs=` without tuning rather than silently ignoring either argument.

--- a/.agents/skills/cutedsl-tunable-kernel-template/copy_reads_example.py
+++ b/.agents/skills/cutedsl-tunable-kernel-template/copy_reads_example.py
@@ -29,17 +29,15 @@ class ReadConfig(NamedTuple):
     reads: int
 
 
-class _CopyReadsOp:
-    """Internal tunable CuTeDSL op; users call :func:`copy_reads`."""
+class CopyReadsTunable:
+    """Compile, tune, and launch the copy kernel."""
 
     default_config = ReadConfig(128, 4)
 
     @staticmethod
-    def configs(
-        source: torch.Tensor,
-        *_runtime_args: Any,
-    ) -> tuple[ReadConfig, ...]:
+    def configs(source: torch.Tensor, destination: torch.Tensor) -> tuple[ReadConfig, ...]:
         """Generate candidates that are sensible for this input shape."""
+        del destination
         max_threads = min(256, max(64, source.numel()))
         reads_per_thread = (4,) if source.numel() < 16 else (4, 8, 16)
         return tuple(
@@ -50,11 +48,11 @@ class _CopyReadsOp:
         )
 
     @staticmethod
-    def _name(threads: int, reads: int) -> str:
+    def kernel_name(threads: int, reads: int) -> str:
         return f"cute_playground_t{threads}_r{reads}"
 
     @cute.kernel
-    def _kernel(
+    def kernel(
         self,
         source: cute.Tensor,
         destination: cute.Tensor,
@@ -85,7 +83,7 @@ class _CopyReadsOp:
                     destination[index] = source[index]
 
     @cute.jit
-    def _launch(
+    def execute(
         self,
         source: cute.Tensor,
         destination: cute.Tensor,
@@ -94,12 +92,12 @@ class _CopyReadsOp:
         stream,
     ):
         blocks = cute.ceil_div(cute.size(source), threads * reads)
-        self._kernel(
+        self.kernel(
             source,
             destination,
             threads,
             reads,
-            _name_prefix=self._name(threads, reads),
+            _name_prefix=self.kernel_name(threads, reads),
         ).launch(
             grid=(blocks, 1, 1),
             block=(threads, 1, 1),
@@ -123,31 +121,33 @@ class _CopyReadsOp:
             stride_order=(0,),
             assumed_align=16,
         )
-        op = _CopyReadsOp()
+        op = CopyReadsTunable()
         return compile_tvm_ffi(
-            op._launch,
+            op.execute,
             source,
             destination,
             config.threads,
             config.reads,
-            name=op._name(config.threads, config.reads),
+            name=op.kernel_name(config.threads, config.reads),
         )
 
     @staticmethod
     def compile_call(
         config: ReadConfig,
-        _source: torch.Tensor,
-        _destination: torch.Tensor,
+        source: torch.Tensor,
+        destination: torch.Tensor,
     ) -> tuple[ReadConfig]:
+        del source, destination
         return (config,)
 
     @staticmethod
     def launch(
         compiled,
-        _config: ReadConfig,
+        config: ReadConfig,
         source: torch.Tensor,
         destination: torch.Tensor,
     ) -> torch.Tensor:
+        del config
         compiled(source, destination)
         return destination
 
@@ -173,8 +173,8 @@ def copy_reads(
         raise ValueError("copy_reads expects nonempty, contiguous, 16-byte-aligned storage")
 
     destination = torch.empty_like(source)
-    output, _selected = run_tunable(
-        _CopyReadsOp,
+    return run_tunable(
+        CopyReadsTunable,
         source,
         destination,
         config=config,
@@ -182,8 +182,7 @@ def copy_reads(
         configs=configs,
         workers=workers,
         benchmark=benchmark,
-    )
-    return output
+    )[0]
 
 
 def main() -> None:
@@ -194,7 +193,7 @@ def main() -> None:
 
     # This wrapper is optional: without benchmark=report, tune() uses the same
     # Inductor benchmark_gpu helper but only returns the winning configuration.
-    candidates = _CopyReadsOp.configs(source)
+    candidates = CopyReadsTunable.configs(source, torch.empty_like(source))
     remaining = iter(candidates)
     timings = {}
 

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_intra.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_intra.py
@@ -9,6 +9,9 @@
 # requires eager-evaluated annotations.
 
 
+from collections.abc import Iterable
+from typing import NamedTuple
+
 import cuda.bindings.driver as cuda
 import cutlass
 import torch
@@ -18,8 +21,8 @@ from cutlass._mlir.dialects import llvm
 from cutlass.cute.runtime import make_fake_compact_tensor
 from cutlass.cutlass_dsl import Constexpr, T, dsl_user_op
 
-from attn_gym._backends.cute import compile_tvm_ffi, jit_cache
-from attn_gym._backends.cute.target import get_compile_target
+from attn_gym._backends.cute import compile_tvm_ffi, jit_cache, run_tunable
+from attn_gym._backends.cute.target import detect_compile_target, get_compile_target
 
 BT = 64  # chunk_size
 SUBCHUNKS = 4
@@ -1933,7 +1936,6 @@ class ChunkKdaBwdIntraHmmaGrid:
         mNumChunks: cute.Tensor,
         stream: cuda.CUstream = None,
     ):
-        _chunk_kda_bwd_intra_hmma_grid_kernel.set_name_prefix("cutlass_dsl_chunk_kda_bwd_intra")
         _chunk_kda_bwd_intra_hmma_grid_kernel(
             mQ,
             mK,
@@ -1953,6 +1955,7 @@ class ChunkKdaBwdIntraHmmaGrid:
             mNumChunks,
             self.use_i32_metadata,
             self.grid_chunks,
+            _name_prefix="cutlass_dsl_chunk_kda_bwd_intra",
         ).launch(
             grid=(KC_TOTAL, self.grid_chunks, cute.size(mQ.shape[2])),
             block=(32, 1, 1),
@@ -1960,15 +1963,20 @@ class ChunkKdaBwdIntraHmmaGrid:
         )
 
 
+class ChunkKdaBwdIntraConfig(NamedTuple):
+    """Compile-time persistent-grid choice for intra-chunk backward."""
+
+    grid_chunks: int
+
+
 @jit_cache
-def _compile_chunk_kda_bwd_intra(heads: int, chunks: int):
+def _compile_chunk_kda_bwd_intra(heads: int, chunks: int, grid_chunks: int):
     """Compile one persistent fixed-length intra-chunk backward specialization."""
-    sm_count = get_compile_target().sm_count
-    if sm_count is None:
-        raise RuntimeError("KDA compilation requires a CUDA target with an SM count")
+    if not 1 <= grid_chunks <= chunks:
+        raise ValueError(f"grid_chunks must be in [1, {chunks}], got {grid_chunks}")
     op = ChunkKdaBwdIntraHmmaGrid(
         use_i32_metadata=True,
-        grid_chunks=min(chunks, sm_count),
+        grid_chunks=grid_chunks,
     )
     tokens = cute.sym_int()
 
@@ -2022,8 +2030,97 @@ def _compile_chunk_kda_bwd_intra(heads: int, chunks: int):
         cu_seqlens,
         chunk_indices,
         num_chunks,
-        name=f"kda_bwd_intra_h{heads}_c{chunks}",
+        name=f"kda_bwd_intra_h{heads}_c{chunks}_gc{grid_chunks}",
     )
+
+
+def _column_token_head(tensor: torch.Tensor) -> torch.Tensor:
+    return tensor[0].permute(2, 0, 1)
+
+
+class ChunkKdaBwdIntraTunable:
+    class Args(NamedTuple):
+        q: torch.Tensor
+        k: torch.Tensor
+        g: torch.Tensor
+        beta: torch.Tensor
+        dAqk: torch.Tensor
+        dAkk: torch.Tensor
+        dq: torch.Tensor
+        dk: torch.Tensor
+        db: torch.Tensor
+        dg: torch.Tensor
+        dq2: torch.Tensor
+        dk2: torch.Tensor
+        dg2: torch.Tensor
+        db_partial: torch.Tensor
+        cu_seqlens: torch.Tensor
+        chunk_indices: torch.Tensor
+        num_chunks: torch.Tensor
+
+    # The public wrapper replaces this universal fallback with a target-aware default.
+    default_config = ChunkKdaBwdIntraConfig(1)
+
+    @staticmethod
+    def default_for(chunks: int, sm_count: int) -> ChunkKdaBwdIntraConfig:
+        """Prefer a smaller power-of-two grid when it evenly partitions the chunks."""
+        grid_limit = min(chunks, 1 << (sm_count.bit_length() - 1))
+        amortized_grid = max(1, grid_limit // 2)
+        grid_chunks = amortized_grid if chunks % amortized_grid == 0 else min(chunks, sm_count)
+        return ChunkKdaBwdIntraConfig(grid_chunks)
+
+    @classmethod
+    def configs(cls, args: Args) -> tuple[ChunkKdaBwdIntraConfig, ...]:
+        """Generate persistent-grid candidates from sequence length and target size."""
+        chunks = args.q.shape[1] // BT
+        sm_count = get_compile_target().sm_count
+        if sm_count is None:
+            raise RuntimeError("KDA tuning requires a CUDA target with an SM count")
+        grid_limit = min(chunks, 1 << (sm_count.bit_length() - 1))
+        values = (
+            cls.default_for(chunks, sm_count).grid_chunks,
+            max(1, grid_limit // 4),
+            grid_limit,
+            min(chunks, sm_count),
+            min(chunks, grid_limit * 2),
+        )
+        return tuple(ChunkKdaBwdIntraConfig(value) for value in dict.fromkeys(values))
+
+    @staticmethod
+    def compile_call(config: ChunkKdaBwdIntraConfig, args: Args) -> tuple[int, int, int]:
+        return args.q.shape[2], args.q.shape[1] // BT, config.grid_chunks
+
+    compile = staticmethod(_compile_chunk_kda_bwd_intra)
+
+    @staticmethod
+    def launch(
+        compiled, config: ChunkKdaBwdIntraConfig, args: Args
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        del config
+        compiled(
+            _column_token_head(args.q),
+            _column_token_head(args.k),
+            _column_token_head(args.g),
+            args.beta,
+            _column_token_head(args.dAqk),
+            _column_token_head(args.dAkk),
+            _column_token_head(args.dq),
+            _column_token_head(args.dk),
+            args.db_partial,
+            _column_token_head(args.dg),
+            _column_token_head(args.dq2),
+            _column_token_head(args.dk2),
+            _column_token_head(args.dg2),
+            args.cu_seqlens,
+            args.chunk_indices,
+            args.num_chunks.reshape(1),
+        )
+        return (
+            args.dq2,
+            args.dk2,
+            args.dg2,
+            args.db + args.db_partial.sum(0).unsqueeze(0),
+        )
 
 
 def chunk_kda_bwd_intra(
@@ -2040,14 +2137,21 @@ def chunk_kda_bwd_intra(
     cu_seqlens: torch.Tensor,
     chunk_indices: torch.Tensor,
     num_chunks: torch.Tensor,
+    *,
+    config: ChunkKdaBwdIntraConfig | None = None,
+    tune: bool = False,
+    configs: Iterable[ChunkKdaBwdIntraConfig] | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Run the fixed-length intra-chunk Q/K/gate/beta backward stage."""
+    """Run or tune the fixed-length intra-chunk Q/K/gate/beta backward stage."""
     batch, tokens, heads, head_dim = q.shape
     if batch != 1 or head_dim != KEY_DIM:
         raise ValueError("the intra-chunk backward requires B=1 and K=128")
     if tokens % BT:
         raise ValueError("the intra-chunk backward requires complete 64-token chunks")
-    chunks = tokens // BT
+
+    # The kernel combines the incoming gradients with its intra-chunk contribution into
+    # new output buffers. Beta is different: four K-phase CTAs contribute to every token,
+    # so they write FP32 partials to global workspace for a race-free post-launch reduction.
     dq2 = torch.empty_like(q)
     dk2 = torch.empty_like(k)
     dg2 = torch.empty_like(g)
@@ -2058,27 +2162,40 @@ def chunk_kda_bwd_intra(
         dtype=torch.float32,
         device=q.device,
     )
-    compiled = _compile_chunk_kda_bwd_intra(heads, chunks)
-
-    def column_token_head(tensor: torch.Tensor) -> torch.Tensor:
-        return tensor[0].permute(2, 0, 1)
-
-    compiled(
-        column_token_head(q),
-        column_token_head(k),
-        column_token_head(g),
-        beta,
-        column_token_head(dAqk),
-        column_token_head(dAkk),
-        column_token_head(dq),
-        column_token_head(dk),
-        db_partial,
-        column_token_head(dg),
-        column_token_head(dq2),
-        column_token_head(dk2),
-        column_token_head(dg2),
-        cu_seqlens,
-        chunk_indices,
-        num_chunks.reshape(1),
+    args = ChunkKdaBwdIntraTunable.Args(
+        q=q,
+        k=k,
+        g=g,
+        beta=beta,
+        dAqk=dAqk,
+        dAkk=dAkk,
+        dq=dq,
+        dk=dk,
+        db=db,
+        dg=dg,
+        dq2=dq2,
+        dk2=dk2,
+        dg2=dg2,
+        db_partial=db_partial,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        num_chunks=num_chunks,
     )
-    return dq2, dk2, dg2, db + db_partial.sum(0).unsqueeze(0)
+    target = detect_compile_target(q.device.index)
+    if not tune and config is None:
+        if target.sm_count is None:
+            raise RuntimeError("KDA launch requires a CUDA target with an SM count")
+        config = ChunkKdaBwdIntraTunable.default_for(tokens // BT, target.sm_count)
+    result, _ = run_tunable(
+        ChunkKdaBwdIntraTunable,
+        args,
+        config=config,
+        autotune=tune,
+        configs=configs,
+        parallel_compile=_compile_chunk_kda_bwd_intra.disk_cache_enabled(),
+        target=target,
+    )
+    return result
+
+
+__all__ = ["ChunkKdaBwdIntraConfig", "chunk_kda_bwd_intra"]

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_wy_dqkg_fused.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_wy_dqkg_fused.py
@@ -10,6 +10,8 @@
 # pyre-ignore-all-errors
 
 import os
+from collections.abc import Iterable
+from typing import NamedTuple
 
 import cutlass
 import cutlass.utils.blackwell_helpers as sm100_utils
@@ -29,8 +31,8 @@ from cutlass.cute.runtime import make_fake_compact_tensor
 from cutlass.cute.tensor import TensorSSA
 from cutlass.cute.typing import BFloat16, Float32, Int32, Int64
 
-from attn_gym._backends.cute import compile_tvm_ffi, jit_cache
-from attn_gym._backends.cute.target import get_compile_target
+from attn_gym._backends.cute import compile_tvm_ffi, jit_cache, run_tunable
+from attn_gym._backends.cute.target import detect_compile_target, get_compile_target
 
 # ============================================================================
 # Inlined SM100 tcgen05 helper wrappers
@@ -1584,14 +1586,12 @@ _torch_to_cutlass_dtype = {
 }
 
 
-def assert_blackwell(device: torch.device | str | int | None = None) -> None:
-    if device is None:
-        device = torch.cuda.current_device()
-    props = torch.cuda.get_device_properties(device)
-    if not (props.major == 10 and props.minor in (0, 3)):
+def require_blackwell_target() -> None:
+    """Reject compilation targets that cannot execute this SM100/SM103 kernel."""
+    target = get_compile_target()
+    if target.device_type != "cuda" or target.capability not in ((10, 0), (10, 3)):
         raise RuntimeError(
-            "chunk_kda_bwd_wy_dqkg_fused requires Blackwell "
-            f"(SM100/SM103), got sm_{props.major}{props.minor}"
+            f"chunk_kda_bwd_wy_dqkg_fused requires Blackwell (SM100/SM103), got target={target}"
         )
 
 
@@ -1911,14 +1911,14 @@ class ChunkKdaBwdWyDqkgFused:
         g_dtype: type[cutlass.Numeric] = cutlass.Float32,
         beta_dtype: type[cutlass.Numeric] = cutlass.Float32,
         scale: float = 1.0,
-        min_occupancy: int = 1,
+        grid_waves: int = 1,
         use_fast_math: bool = True,
     ):
         assert chunk_size == 64, "chunk_size must be 64"
         assert head_dim_k == 128 and head_dim_v == 128, (
             f"head_dim_k and head_dim_v must both be 128, got head_dim_k={head_dim_k}, head_dim_v={head_dim_v}"
         )
-        assert_blackwell()
+        require_blackwell_target()
 
         self.use_fast_math = use_fast_math
         self.chunk_size = chunk_size
@@ -1946,7 +1946,9 @@ class ChunkKdaBwdWyDqkgFused:
 
         self.num_regs_cuda = 208
         self.num_regs_others = 88
-        self.min_occupancy = min_occupancy
+        if grid_waves < 1:
+            raise ValueError(f"grid_waves must be positive, got {grid_waves}")
+        self.grid_waves = grid_waves
 
         self.cluster_shape_mnk = (1, 1, 1)
         self.cta_group = tcgen05.CtaGroup.ONE
@@ -2008,12 +2010,12 @@ class ChunkKdaBwdWyDqkgFused:
     def _compute_grid(self, B, T, HV, total_nt=None):
         """Compute grid dimensions for persistent kernel launch.
 
-        Grid: (min(num_sm * min_occupancy, total_tiles), 1, 1)
+        Grid: (min(num_sm * grid_waves, total_tiles), 1, 1)
         Each CTA handles multiple tiles via stride-by-gridDim.x loop.
         """
         assert total_nt is not None
         total_tiles = total_nt * HV
-        grid_x = cutlass.min(Int32(self.num_sm * self.min_occupancy), total_tiles)
+        grid_x = cutlass.min(Int32(self.num_sm * self.grid_waves), total_tiles)
         return (grid_x, Int32(1), Int32(1))
 
     @cute.jit
@@ -2654,7 +2656,7 @@ class ChunkKdaBwdWyDqkgFused:
             block=[self.threads_per_cta, 1, 1],
             cluster=self.cluster_shape_mnk,
             stream=stream,
-            min_blocks_per_mp=self.min_occupancy,
+            min_blocks_per_mp=1,
         )
 
     @cute.kernel
@@ -2725,7 +2727,7 @@ class ChunkKdaBwdWyDqkgFused:
         BT = self.BT
 
         # ===================== Persistent work decode =====================
-        # Grid: (min(num_sm * occ, total_tiles), 1, 1) — persistent
+        # Grid: (min(num_sm * grid_waves, total_tiles), 1, 1) — persistent
         block_idx_x = cute.arch.block_idx()[0]
         grid_dim_x = cute.arch.grid_dim()[0]
         thread_idx = cute.arch.thread_idx()[0]
@@ -4710,12 +4712,19 @@ class ChunkKdaBwdWyDqkgFused:
         return bSG_sC, bSG_gC
 
 
+class ChunkKdaBwdWyDqkgConfig(NamedTuple):
+    """Persistent-grid schedule for fused WY/dQKG backward."""
+
+    grid_waves: int
+
+
 @jit_cache
 def _compile_chunk_kda_bwd_wy_dqkg(
     heads: int,
     head_dim: int,
     chunk_size: int,
     fastmath: bool,
+    grid_waves: int,
 ):
     """Compile one persistent fixed-length WY/dQKG backward specialization."""
     op = ChunkKdaBwdWyDqkgFused(
@@ -4723,6 +4732,7 @@ def _compile_chunk_kda_bwd_wy_dqkg(
         head_dim_k=head_dim,
         head_dim_v=head_dim,
         scale=head_dim**-0.5,
+        grid_waves=grid_waves,
         use_fast_math=fastmath,
     )
     tokens, chunks = cute.sym_int(), cute.sym_int()
@@ -4777,8 +4787,106 @@ def _compile_chunk_kda_bwd_wy_dqkg(
         chunk_indices,
         (Int32(1), Int32(1), Int32(heads), Int32(heads), Int32(head_dim), Int32(head_dim)),
         Int32(1),
-        name=(f"kda_bwd_wy_dqkg_h{heads}_d{head_dim}_c{chunk_size}_fm{int(fastmath)}"),
+        name=(
+            f"kda_bwd_wy_dqkg_h{heads}_d{head_dim}_c{chunk_size}_fm{int(fastmath)}_gw{grid_waves}"
+        ),
     )
+
+
+class ChunkKdaBwdWyDqkgTunable:
+    class Args(NamedTuple):
+        q: torch.Tensor
+        k: torch.Tensor
+        v: torch.Tensor
+        v_new: torch.Tensor
+        g: torch.Tensor
+        beta: torch.Tensor
+        A: torch.Tensor
+        h: torch.Tensor
+        do: torch.Tensor
+        dh: torch.Tensor
+        dv: torch.Tensor
+        dq: torch.Tensor
+        dk: torch.Tensor
+        dv2: torch.Tensor
+        dg: torch.Tensor
+        db: torch.Tensor
+        dA: torch.Tensor
+        cu_seqlens: torch.Tensor
+        chunk_indices: torch.Tensor
+        chunk_size: int
+        fastmath: bool
+
+    default_config = ChunkKdaBwdWyDqkgConfig(grid_waves=1)
+
+    @staticmethod
+    def configs(
+        args: Args,
+    ) -> tuple[ChunkKdaBwdWyDqkgConfig, ...]:
+        del args
+        return tuple(ChunkKdaBwdWyDqkgConfig(waves) for waves in (1, 2))
+
+    @staticmethod
+    def compile_call(
+        config: ChunkKdaBwdWyDqkgConfig,
+        args: Args,
+    ) -> tuple[int, int, int, bool, int]:
+        return (
+            args.q.shape[2],
+            args.q.shape[3],
+            args.chunk_size,
+            args.fastmath,
+            config.grid_waves,
+        )
+
+    compile = staticmethod(_compile_chunk_kda_bwd_wy_dqkg)
+
+    @staticmethod
+    def launch(
+        compiled,
+        config: ChunkKdaBwdWyDqkgConfig,
+        args: Args,
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+    ]:
+        del config
+        batch, tokens, heads, head_dim = args.q.shape
+        compiled(
+            args.q,
+            args.k,
+            args.v,
+            args.v_new,
+            args.g,
+            args.beta,
+            args.A,
+            args.h,
+            args.do,
+            args.dh,
+            args.dv,
+            args.dq,
+            args.dk,
+            args.dv2,
+            args.dg,
+            args.db,
+            args.dA,
+            args.cu_seqlens,
+            args.chunk_indices,
+            (
+                Int32(batch),
+                Int32(tokens),
+                Int32(heads),
+                Int32(heads),
+                Int32(head_dim),
+                Int32(head_dim),
+            ),
+            Int32(tokens // args.chunk_size),
+        )
+        return args.dq, args.dk, args.dv2, args.dg, args.db, args.dA
 
 
 def chunk_kda_bwd_wy_dqkg(
@@ -4798,6 +4906,9 @@ def chunk_kda_bwd_wy_dqkg(
     *,
     chunk_size: int = 64,
     fastmath: bool = False,
+    config: ChunkKdaBwdWyDqkgConfig | None = None,
+    tune: bool = False,
+    configs: Iterable[ChunkKdaBwdWyDqkgConfig] | None = None,
 ) -> tuple[
     torch.Tensor,
     torch.Tensor,
@@ -4806,7 +4917,7 @@ def chunk_kda_bwd_wy_dqkg(
     torch.Tensor,
     torch.Tensor,
 ]:
-    """Run the fixed-length fused WY and dQ/K/V/gate/beta backward stage."""
+    """Run or tune the fixed-length fused WY/dQKG backward stage."""
     batch, tokens, heads, head_dim = q.shape
     if batch != 1 or head_dim != 128 or v.shape[-1] != 128:
         raise ValueError("the fused WY backward requires B=1 and K=V=128")
@@ -4819,41 +4930,39 @@ def chunk_kda_bwd_wy_dqkg(
     if h.shape != expected_h or dh.shape != expected_h:
         raise ValueError(f"h and dh must have shape {expected_h}")
 
-    dq = torch.empty_like(g)
-    dk = torch.empty_like(g)
-    dv2 = torch.empty_like(v)
-    dg = torch.empty_like(g)
-    db = torch.empty_like(beta)
-    dA = torch.empty_like(A, dtype=torch.float32)
-    compiled = _compile_chunk_kda_bwd_wy_dqkg(heads, head_dim, chunk_size, fastmath)
-    compiled(
-        q,
-        k,
-        v,
-        v_new,
-        g,
-        beta,
-        A,
-        h,
-        do,
-        dh,
-        dv,
-        dq,
-        dk,
-        dv2,
-        dg,
-        db,
-        dA,
-        cu_seqlens,
-        chunk_indices,
-        (
-            Int32(batch),
-            Int32(tokens),
-            Int32(heads),
-            Int32(heads),
-            Int32(head_dim),
-            Int32(head_dim),
-        ),
-        Int32(chunks),
+    args = ChunkKdaBwdWyDqkgTunable.Args(
+        q=q,
+        k=k,
+        v=v,
+        v_new=v_new,
+        g=g,
+        beta=beta,
+        A=A,
+        h=h,
+        do=do,
+        dh=dh,
+        dv=dv,
+        dq=torch.empty_like(g),
+        dk=torch.empty_like(g),
+        dv2=torch.empty_like(v),
+        dg=torch.empty_like(g),
+        db=torch.empty_like(beta),
+        dA=torch.empty_like(A, dtype=torch.float32),
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        chunk_size=chunk_size,
+        fastmath=fastmath,
     )
-    return dq, dk, dv2, dg, db, dA
+    result, _ = run_tunable(
+        ChunkKdaBwdWyDqkgTunable,
+        args,
+        config=config,
+        autotune=tune,
+        configs=configs,
+        parallel_compile=_compile_chunk_kda_bwd_wy_dqkg.disk_cache_enabled(),
+        target=detect_compile_target(q.device.index),
+    )
+    return result
+
+
+__all__ = ["ChunkKdaBwdWyDqkgConfig", "chunk_kda_bwd_wy_dqkg"]

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py
@@ -11,6 +11,8 @@ from attn_gym.linear.kda.fwd.triton.chunk_delta_h import chunk_gated_delta_rule_
 from attn_gym.linear.kda.fwd.triton.chunk_gla_fwd_o import chunk_gla_fwd_o_gk
 
 _SUPPORTED_INPUT_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
+# TODO: Revisit model-approved chunk sizes: this is a major performance lever,
+# but it changes the KDA decomposition and rounding order, so it can affect numerics.
 _CHUNK_SIZE = 64
 _HEAD_DIM = 128
 

--- a/attn_gym/linear/kda/fwd/cute/recompute_w_u_fwd.py
+++ b/attn_gym/linear/kda/fwd/cute/recompute_w_u_fwd.py
@@ -1372,7 +1372,6 @@ class RecomputeWUForwardVarlenB1FullChunk:
             AB_STAGES,
         )
 
-        _kernel_varlen_b1_full_chunk.set_name_prefix("cutlass_dsl_recompute_w_u_fwd")
         _kernel_varlen_b1_full_chunk(
             tiled_mma,
             mQ,
@@ -1397,6 +1396,7 @@ class RecomputeWUForwardVarlenB1FullChunk:
             u_dot_precision_tf32x3,
             prefetch_next_tile,
             mma_is_bf16,
+            _name_prefix="cutlass_dsl_recompute_w_u_fwd",
         ).launch(
             grid=(self.num_persistent_ctas, 1, 1),
             block=(THREADS_PER_CTA, 1, 1),

--- a/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
@@ -12,6 +12,7 @@ import triton.language as tl
 
 from attn_gym._backends.triton.utils import ptr_offset, requires_int64_offsets
 from attn_gym.linear.kda.utils import (
+    autotune_cache_kwargs,
     exp,
     exp2,
 )
@@ -45,6 +46,15 @@ def _requires_int64_offsets(args):
         "HAS_NUM_SEQS": lambda args: args["num_seqs"] is not None,
         "USE_INT64_OFFSETS": _requires_int64_offsets,
     }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({"BV": 32}, num_warps=4, num_stages=3),
+        triton.Config({"BV": 16}, num_warps=4, num_stages=3),
+        triton.Config({"BV": 64}, num_warps=4, num_stages=3),
+    ],
+    key=["H", "K", "V", "BT"],
+    **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=["T", "num_seqs"])
 def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
@@ -817,8 +827,10 @@ def chunk_gated_delta_rule_fwd_h(
         if output_final_state
         else None
     )
-    block_value_dim = 64
-    grid = (batch * heads, triton.cdiv(value_dim, block_value_dim))
+
+    def grid(meta):
+        return (batch * heads, triton.cdiv(value_dim, meta["BV"]))
+
     chunk_gated_delta_rule_fwd_kernel_h_blockdim64[grid](
         k=k,
         v=u,
@@ -837,7 +849,6 @@ def chunk_gated_delta_rule_fwd_h(
         K=key_dim,
         V=value_dim,
         BT=chunk_size,
-        BV=block_value_dim,
         USE_EXP2=True,
     )
     return h, v_new, final_state

--- a/attn_gym/linear/kda/fwd/triton/chunk_gla_fwd_o.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_gla_fwd_o.py
@@ -42,9 +42,14 @@ from attn_gym.linear.kda.utils import (
 )
 @triton.autotune(
     configs=[
+        triton.Config({"BK": 64, "BV": 64}, num_warps=4, num_stages=4),
         triton.Config({"BK": 32, "BV": 64}, num_warps=2, num_stages=4),
+        triton.Config({"BK": 32, "BV": 64}, num_warps=4, num_stages=4),
+        triton.Config({"BK": 64, "BV": 32}, num_warps=4, num_stages=4),
+        triton.Config({"BK": 64, "BV": 64}, num_warps=2, num_stages=4),
+        triton.Config({"BK": 64, "BV": 64}, num_warps=8, num_stages=4),
     ],
-    key=["BT"],
+    key=["H", "K", "V", "T", "BT"],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=["T", "num_chunks"])

--- a/test/test_kda_cute_forward.py
+++ b/test/test_kda_cute_forward.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import gc
 import importlib
 
@@ -14,6 +15,15 @@ from attn_gym.linear.kda.naive import chunk_cumsum_ref
 
 pytest.importorskip("cutlass")
 
+from attn_gym.linear.kda.bwd.cute import chunk_kda_bwd as _chunk_kda_bwd_module
+from attn_gym.linear.kda.bwd.cute.chunk_kda_bwd_intra import (
+    ChunkKdaBwdIntraConfig,
+    chunk_kda_bwd_intra,
+)
+from attn_gym.linear.kda.bwd.cute.chunk_kda_bwd_wy_dqkg_fused import (
+    ChunkKdaBwdWyDqkgConfig,
+    chunk_kda_bwd_wy_dqkg,
+)
 from attn_gym.linear.kda.fwd.cute import chunk_kda
 from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd import (
     _chunk_kda_bwd_custom_op,
@@ -26,8 +36,14 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def _inputs(*, heads: int = 1, initial_state: bool = False, dtype: torch.dtype = torch.bfloat16):
-    batch, tokens, head_dim = 1, 128, 128
+def _inputs(
+    *,
+    tokens: int = 128,
+    heads: int = 1,
+    initial_state: bool = False,
+    dtype: torch.dtype = torch.bfloat16,
+):
+    batch, head_dim = 1, 128
     shape = (batch, tokens, heads, head_dim)
     q = F.normalize(torch.randn(shape, device="cuda"), dim=-1).to(dtype)
     k = F.normalize(torch.randn(shape, device="cuda"), dim=-1).to(dtype)
@@ -138,6 +154,38 @@ def test_kda_offset_width_specializations_match(monkeypatch):
     torch.testing.assert_close(output64, output32, rtol=0, atol=0)
     for gradient64, gradient32 in zip(gradients64, gradients32, strict=True):
         torch.testing.assert_close(gradient64, gradient32, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize(
+    ("attribute", "kernel", "config_type"),
+    (
+        ("chunk_kda_bwd_intra", chunk_kda_bwd_intra, ChunkKdaBwdIntraConfig),
+        ("chunk_kda_bwd_wy_dqkg", chunk_kda_bwd_wy_dqkg, ChunkKdaBwdWyDqkgConfig),
+    ),
+)
+def test_backward_tuning_configs(monkeypatch, attribute, kernel, config_type):
+    """Keep each explicit and tuned schedule equivalent to its default."""
+    torch.manual_seed(5)
+    inputs = _inputs(tokens=320, heads=2)
+    d_output = torch.randn_like(inputs[0])
+    candidates = tuple(config_type(value) for value in (1, 2))
+    launches = (
+        kernel,
+        *(functools.partial(kernel, config=config) for config in candidates),
+        functools.partial(kernel, tune=True),
+        functools.partial(kernel, tune=True, configs=candidates),
+    )
+
+    gradients = []
+    for launch in launches:
+        monkeypatch.setattr(_chunk_kda_bwd_module, attribute, launch)
+        cloned_inputs = _clone_inputs(inputs)
+        output, _ = chunk_kda(*cloned_inputs)
+        gradients.append(torch.autograd.grad(output, cloned_inputs, d_output))
+
+    for result in gradients[1:]:
+        for candidate, expected in zip(result, gradients[0], strict=True):
+            torch.testing.assert_close(candidate, expected, rtol=0, atol=0)
 
 
 def test_chunk_kda_custom_op_registration():


### PR DESCRIPTION
## Summary

- autotune the Triton inter-chunk recurrence over `BV={16,32,64}` and the output-composition kernel over six validated launch configurations
- expose typed `config=` / `tune=True` adapters for the CuTe backward-intra and WY/dQKG persistent-grid schedules, retaining the measured production defaults
- keep each tuning launch ABI in a nested `Args` type and update the CuTeDSL tuning skill/example to use the same ownership pattern
- make CuTe compilation use inherited target metadata and invocation-local kernel names
- keep `chunk_size=64` outside automatic tuning because it changes KDA decomposition and numerical behavior

## Expected performance

Measured on one NVIDIA GB300 (152 SMs) using the default fused workload from `examples/kda_training.py`:

- `B=1, T=16384, hidden_size=2304, H=32, D=128, chunk_size=64`
- BF16 fused backend
- 5 warmup steps and 20 CUDA-event-timed steps per process
- two alternating clean-main/candidate runs; values below average each run's median

| Range | main | this change | Reduction |
|---|---:|---:|---:|
| Forward + loss | 6.696 ms | 6.464 ms | **3.45%** |
| Backward | 15.476 ms | 15.248 ms | **1.47%** |
| Full train step, including optimizer | 22.701 ms | 22.244 ms | **2.01%** |

The dominant isolated wins are the inter-chunk recurrence (`BV=64` to the tuned `BV=32` path) and output composition (`BK=32/BV=64/2 warps` to `BK=64/BV=64/4 warps`). The one-wave WY schedule remains the default because the two-wave candidate was slightly slower; it remains available through the standard tuning API for other shapes.

## Correctness

- all exposed explicit and generated tuning candidates are checked against the default path, including a non-divisible persistent-grid tail
- existing reference-gradient, custom-op, fullgraph, and CUDA-graph coverage remains enabled
- `CUTE_DSL_NO_CACHE=1 pytest -q test/test_kda_cute_forward.py test/test_kda_cute_recompute.py` — **15 passed**
- Ruff format/check and `git diff --check` pass
