### PR TITLE
Select compatible short convolution defaults

### DIFF
--- a/attn_gym/linear/kda/short_conv/cute.py
+++ b/attn_gym/linear/kda/short_conv/cute.py
@@ -612,9 +612,20 @@ def _launch_backward(
     return grad_x, partials.sum(dim=(0, 1)).to(torch.bfloat16)
 
 
+def _compatible_config(config: ShortConvConfig, channels: int) -> ShortConvConfig:
+    """Adapt the packed channel width while preserving the tuned schedule."""
+    channels_per_thread = 1
+    for divisor in range(config.channels_per_thread, 1, -1):
+        if config.channels_per_thread % divisor == 0 and channels % divisor == 0:
+            channels_per_thread = divisor
+            break
+    return ShortConvConfig(config.threads, channels_per_thread, config.times_per_block)
+
+
 def _candidate_configs(kind: str, channels: int) -> tuple[ShortConvConfig, ...]:
     """Return the focused schedule space used by the explicit tuning flow."""
     if kind == "forward":
+        default = CausalConv1dSiluForward.default_config
         candidates = (
             ShortConvConfig(64, 4, 8),
             ShortConvConfig(128, 2, 8),
@@ -624,6 +635,7 @@ def _candidate_configs(kind: str, channels: int) -> tuple[ShortConvConfig, ...]:
             ShortConvConfig(256, 4, 8),
         )
     elif kind == "input_gradient":
+        default = CausalConv1dSiluInputGradient.default_config
         candidates = (
             ShortConvConfig(64, 4, 8),
             ShortConvConfig(128, 2, 8),
@@ -633,6 +645,7 @@ def _candidate_configs(kind: str, channels: int) -> tuple[ShortConvConfig, ...]:
             ShortConvConfig(256, 4, 8),
         )
     elif kind == "weight_gradient":
+        default = CausalConv1dSiluWeightGradientPartials.default_config
         candidates = (
             ShortConvConfig(64, 4, 128),
             ShortConvConfig(128, 2, 64),
@@ -643,7 +656,12 @@ def _candidate_configs(kind: str, channels: int) -> tuple[ShortConvConfig, ...]:
         )
     else:  # pragma: no cover - internal callers use the literals above.
         raise ValueError(f"unknown short-convolution kernel kind {kind!r}")
-    return tuple(config for config in candidates if channels % config.channels_per_thread == 0)
+    candidates = (*candidates, _compatible_config(default, channels))
+    return tuple(
+        dict.fromkeys(
+            config for config in candidates if channels % config.channels_per_thread == 0
+        )
+    )
 
 
 def tune_causal_conv1d_silu(
@@ -974,24 +992,28 @@ def cute_causal_conv1d_silu(
         A contiguous CUDA BF16 tensor with the same shape as ``x``.
     """
     _validate_inputs(x, weight)
-    if forward_config is None and input_grad_config is None and weight_grad_config is None:
-        for name, config in (
-            ("forward_config", CausalConv1dSiluForward.default_config),
-            ("input_grad_config", CausalConv1dSiluInputGradient.default_config),
-            ("weight_grad_config", CausalConv1dSiluWeightGradientPartials.default_config),
-        ):
-            _validate_config(config, x.shape[2], name)
-        return _forward_custom_op(x, weight)
-
-    forward = forward_config or CausalConv1dSiluForward.default_config
-    input_grad = input_grad_config or CausalConv1dSiluInputGradient.default_config
-    weight_grad = weight_grad_config or CausalConv1dSiluWeightGradientPartials.default_config
+    channels = x.shape[2]
+    default_forward = CausalConv1dSiluForward.default_config
+    default_input_grad = CausalConv1dSiluInputGradient.default_config
+    default_weight_grad = CausalConv1dSiluWeightGradientPartials.default_config
+    forward = forward_config or _compatible_config(default_forward, channels)
+    input_grad = input_grad_config or _compatible_config(default_input_grad, channels)
+    weight_grad = weight_grad_config or _compatible_config(default_weight_grad, channels)
     for name, config in (
         ("forward_config", forward),
         ("input_grad_config", input_grad),
         ("weight_grad_config", weight_grad),
     ):
-        _validate_config(config, x.shape[2], name)
+        _validate_config(config, channels, name)
+    if (
+        forward_config is None
+        and input_grad_config is None
+        and weight_grad_config is None
+        and forward == default_forward
+        and input_grad == default_input_grad
+        and weight_grad == default_weight_grad
+    ):
+        return _forward_custom_op(x, weight)
     return _configured_forward_custom_op(
         x,
         weight,

--- a/test/test_kda_short_conv_cute.py
+++ b/test/test_kda_short_conv_cute.py
@@ -9,6 +9,7 @@ pytest.importorskip("cutlass")
 from attn_gym.linear.kda.short_conv.cute import (
     ShortConvConfig,
     _backward_custom_op,
+    _candidate_configs,
     _forward_custom_op,
     cute_causal_conv1d_silu,
     tune_causal_conv1d_silu,
@@ -46,6 +47,31 @@ def test_short_conv_forward_and_backward_match_pytorch(width: int):
     expected_gradients = torch.autograd.grad(expected, (x, weight), grad_output)
     torch.testing.assert_close(actual_gradients[0], expected_gradients[0], rtol=3e-2, atol=3e-2)
     torch.testing.assert_close(actual_gradients[1], expected_gradients[1], rtol=3e-2, atol=2e-1)
+
+
+@pytest.mark.parametrize("channels", [5, 6])
+def test_short_conv_defaults_support_any_positive_channel_count(channels: int):
+    """Select a compatible packed channel width without requiring an explicit config."""
+    torch.manual_seed(1)
+    x, weight = _inputs(tokens=19, channels=channels)
+    grad_output = torch.randn_like(x)
+
+    actual = cute_causal_conv1d_silu(x, weight)
+    expected = _reference(x, weight)
+    torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
+
+    actual_gradients = torch.autograd.grad(actual, (x, weight), grad_output)
+    expected_gradients = torch.autograd.grad(expected, (x, weight), grad_output)
+    torch.testing.assert_close(actual_gradients[0], expected_gradients[0], rtol=3e-2, atol=3e-2)
+    torch.testing.assert_close(actual_gradients[1], expected_gradients[1], rtol=3e-2, atol=3e-1)
+
+    compiled = torch.compile(cute_causal_conv1d_silu, fullgraph=True)
+    torch.testing.assert_close(compiled(x, weight), expected, rtol=2e-2, atol=2e-2)
+
+    for kind in ("forward", "input_gradient", "weight_gradient"):
+        candidates = _candidate_configs(kind, channels)
+        assert candidates
+        assert all(channels % config.channels_per_thread == 0 for config in candidates)
 
 
 @pytest.mark.parametrize("width", [3, 4])


### PR DESCRIPTION
## Summary

- choose the largest channel packing width shared by the tuned default and the input channel count
- preserve the lean production custom-op path when the width-4 defaults are valid
- add the compatible default to autotuning candidates so every positive channel count has a valid schedule
- cover odd and even non-width-4 channel counts in eager forward/backward and fullgraph compilation

This follows up on https://github.com/meta-pytorch/attention-gym/pull/266#discussion_r3760768971.

The compatibility calculation is gcd-equivalent. It uses a short divisor scan instead of `math.gcd` because `math.gcd` on the symbolic channel extent breaks `torch.compile(fullgraph=True)`.

## Test plan

- `prek run --files attn_gym/linear/kda/short_conv/cute.py test/test_kda_short_conv_cute.py`
- `/home/drisspg/.venvs/nightly/bin/pytest -q test/test_kda_short_conv_cute.py` (`13 passed` on GB300)
