### PR TITLE
Reduce selected attention test autotuning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ source = "vcs"
 # ---------- PYTEST ------------
 [tool.pytest.ini_options]
 testpaths = ["test"]
+markers = ["full_autotune: exercise every production Triton autotuning candidate"]
 
 # ---------- RUFF ------------
 [tool.ruff]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,51 @@
+"""Shared pytest fixtures."""
+
+from collections.abc import Iterator
+
+import pytest
+import torch
+
+
+@pytest.fixture
+def selected_attention_single_config(
+    request: pytest.FixtureRequest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[None]:
+    """Use one valid Triton schedule unless a test explicitly covers autotuning."""
+    if (
+        not torch.cuda.is_available()
+        or request.node.get_closest_marker("full_autotune") is not None
+    ):
+        yield
+        return
+
+    from triton.runtime.autotuner import Autotuner
+
+    from attn_gym.sparse.selected_attention.impl.triton import backward, forward, shared_backward
+
+    tuners = tuple(
+        {
+            id(value): value
+            for module in (forward, backward, shared_backward)
+            for value in vars(module).values()
+            if isinstance(value, Autotuner)
+        }.values()
+    )
+    original_caches = {id(tuner): tuner.cache.copy() for tuner in tuners}
+    for tuner in tuners:
+        original_pruner = tuner.early_config_prune
+
+        def first_valid_config(configs, named_args, _pruner=original_pruner, **kwargs):
+            valid_configs = _pruner(configs, named_args, **kwargs) if _pruner else configs
+            return valid_configs[:1]
+
+        monkeypatch.setattr(tuner, "early_config_prune", first_valid_config)
+
+    try:
+        yield
+    finally:
+        # A single pruned config is inserted into Autotuner.cache without disk caching.
+        # Restore genuine entries so reduced test choices cannot affect later callers.
+        for tuner in tuners:
+            tuner.cache.clear()
+            tuner.cache.update(original_caches[id(tuner)])

--- a/test/test_selected_attention_matches_csa_reference.py
+++ b/test/test_selected_attention_matches_csa_reference.py
@@ -16,6 +16,8 @@ import torch.nn.functional as F
 ATOL = 1e-8
 RTOL = 1e-5
 
+pytestmark = pytest.mark.usefixtures("selected_attention_single_config")
+
 
 # ---------------------------------------------------------------------------
 # Load the CSA example module (composition path via selected_attention).

--- a/test/test_selected_attention_semantics.py
+++ b/test/test_selected_attention_semantics.py
@@ -18,6 +18,8 @@ if torch.cuda.is_available():
 
 BLACKWELL_AVAILABLE = torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 10
 
+pytestmark = pytest.mark.usefixtures("selected_attention_single_config")
+
 
 @pytest.fixture
 def shared_kv_blackwell_inputs():
@@ -452,8 +454,10 @@ def test_eager_bfloat16_mixed_precision_schedule():
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for triton")
 @pytest.mark.parametrize(
     "num_repeats,sliding_window_size",
-    [(2, 0), (3, 4)],
-    ids=["sparse-only", "joint"],
+    [
+        pytest.param(2, 0, id="sparse-only"),
+        pytest.param(3, 4, id="joint", marks=pytest.mark.full_autotune),
+    ],
 )
 def test_repeated_indices_backends_match(num_repeats, sliding_window_size):
     """Repeated indices should produce identical results in eager and triton."""
@@ -537,6 +541,7 @@ def test_mixed_repeated_and_unique_indices_backends_match():
 
 
 @pytest.mark.skipif(not BLACKWELL_AVAILABLE, reason="Blackwell GPU required")
+@pytest.mark.full_autotune
 def test_shared_kv_blackwell_matches_eager(shared_kv_blackwell_inputs):
     """The default atomic shared-KV path matches eager forward and gradients."""
     query, local_kv, sparse_kv, kv_indices, attention_sink, doc_ids = shared_kv_blackwell_inputs
@@ -606,6 +611,7 @@ def test_shared_kv_blackwell_matches_eager(shared_kv_blackwell_inputs):
 
 
 @pytest.mark.skipif(not BLACKWELL_AVAILABLE, reason="Blackwell GPU required")
+@pytest.mark.full_autotune
 def test_shared_kv_blackwell_deterministic_backward(shared_kv_blackwell_inputs):
     """Deterministic mode retains the output-owned shared-KV backward schedule."""
     query, local_kv, sparse_kv, kv_indices, attention_sink, doc_ids = shared_kv_blackwell_inputs

--- a/test/test_selected_attention_triton.py
+++ b/test/test_selected_attention_triton.py
@@ -21,6 +21,8 @@ RTOL_FWD = 1e-2
 ATOL_BWD = 1e-2
 RTOL_BWD = 1e-2
 
+pytestmark = pytest.mark.usefixtures("selected_attention_single_config")
+
 
 def _skip_no_cuda():
     if not torch.cuda.is_available():
@@ -146,9 +148,8 @@ def test_triton_forward_with_doc_ids(share_kv, num_topk):
 
 @pytest.mark.parametrize("share_kv", [False, True])
 @pytest.mark.parametrize("num_topk", [0, 1, 2, 3])
-@pytest.mark.parametrize("grad_target", ["query", "local_kv", "sparse_kv", "attention_sink"])
 @pytest.mark.parametrize("sliding_window_size", [0, 8])
-def test_triton_backward(share_kv, num_topk, grad_target, sliding_window_size):
+def test_triton_backward(share_kv, num_topk, sliding_window_size):
     """Triton backward produces correct gradients for all differentiable inputs."""
     _skip_no_cuda()
 
@@ -175,12 +176,13 @@ def test_triton_backward(share_kv, num_topk, grad_target, sliding_window_size):
     out_ref.backward(grad_output)
     out_tri.backward(grad_output)
 
-    torch.testing.assert_close(
-        inputs_tri[grad_target].grad,
-        inputs_ref[grad_target].grad,
-        atol=ATOL_BWD,
-        rtol=RTOL_BWD,
-    )
+    for name in ("query", "local_kv", "sparse_kv", "attention_sink"):
+        torch.testing.assert_close(
+            inputs_tri[name].grad,
+            inputs_ref[name].grad,
+            atol=ATOL_BWD,
+            rtol=RTOL_BWD,
+        )
 
 
 @pytest.mark.parametrize("num_topk", [0, 2])


### PR DESCRIPTION
Human Note

Test go burr

Agent note
Selected-attention correctness tests currently invoke production Triton autotuning for every shape, causing each
cold test run to compile and benchmark every candidate even though the tests only validate the selected result.
The backward matrix also repeats the same complete backward computation four times to check one gradient at a
time.

This change runs ordinary correctness cases with one valid schedule while retaining full production autotuning
for representative unshared, shared-KV atomic, and deterministic shared-KV paths. It also checks all four
backward gradients in one invocation, reducing that matrix from 64 cases to 16 without removing any gradient
assertions. Warnings and the existing Flash backend tests remain unchanged.

On a GB300 using isolated cold Triton and Inductor caches, the selected-attention suite decreased from 551.18
seconds for 157 tests to 218.77 seconds for 109 tests. The 48 removed cases were duplicate gradient-target runs.

Test Plan:

```bash
prek run --files pyproject.toml test/conftest.py test/test_selected_attention_matches_csa_reference.py test/test_selected_attention_semantics.py test/test_selected_attention_triton.py
PYTHONPATH=$PWD TRITON_CACHE_DIR=$PWD/agent_space/test-speed-cache-gpu2/triton TORCHINDUCTOR_CACHE_DIR=$PWD/agent_space/test-speed-cache-gpu2/inductor gpu-run 2 -- /home/drisspg/.venvs/nightly/bin/pytest -q test/test_selected_attention_matches_csa_reference.py test/test_selected_attention_reference.py test/test_selected_attention_semantics.py test/test_selected_attention_triton.py --durations=10
PYTHONPATH=$PWD TORCHINDUCTOR_CACHE_DIR=$PWD/agent_space/full-validation-inductor gpu-run 2 -- /home/drisspg/.venvs/nightly/bin/pytest -q --durations=20
```
