### PR TITLE
Support packed KDA short convolution

### DIFF
--- a/attn_gym/_backends/cute/device.py
+++ b/attn_gym/_backends/cute/device.py
@@ -8,7 +8,26 @@
 
 from __future__ import annotations
 
-from cutlass import Float32, cute
+from cutlass import Float32, Int32, cute
+
+
+@cute.jit
+def upper_bound(
+    values: cute.Tensor,
+    query: Int32,
+    begin: Int32,
+    end: Int32,
+) -> Int32:
+    """Return the first index in ``[begin, end)`` whose value exceeds ``query``."""
+    low = begin
+    high = end
+    while low < high:
+        middle = (low + high) // 2
+        if Int32(values[middle]) <= query:
+            low = middle + 1
+        else:
+            high = middle
+    return low
 
 
 @cute.jit
@@ -38,4 +57,4 @@ def cta_reduce_sum(value: Float32, warp_partials: cute.Tensor) -> Float32:
     return cta_sum
 
 
-__all__ = ["cta_reduce_sum"]
+__all__ = ["cta_reduce_sum", "upper_bound"]

--- a/attn_gym/linear/kda/short_conv/cute.py
+++ b/attn_gym/linear/kda/short_conv/cute.py
@@ -7,7 +7,9 @@
 """CuTeDSL causal depthwise convolution with a first-order backward.
 
 The implementation accepts contiguous BF16 ``[B, T, C]`` tensors and treats every
-batch row as an independent sequence. Each thread owns a compile-time number of
+batch row as an independent sequence. An optional CUDA ``cu_seqlens`` tensor instead
+delimits independent sequences packed into ``[1, T, C]`` without requiring a maximum
+sequence length or auxiliary schedule. Each thread owns a compile-time number of
 adjacent channels. Forward stages its input window in packed BF16 registers, while
 backward computes BF16 input gradients and FP32 weight-gradient partials followed
 by a Torch reduction.
@@ -18,9 +20,10 @@ from dataclasses import dataclass
 
 import cutlass
 import torch
-from cutlass import BFloat16, Float32, cute
+from cutlass import BFloat16, Float32, Int32, cute
 
 from attn_gym._backends.cute import ceildiv, compile_tvm_ffi, jit_cache, tune
+from attn_gym._backends.cute.device import upper_bound
 
 
 @dataclass(frozen=True)
@@ -54,6 +57,46 @@ def _silu_derivative(value):
     half = value * 0.5
     tanh_half = cute.math.tanh(half, fastmath=True)
     return (tanh_half + 1.0) * 0.5 + half * (1.0 - tanh_half * tanh_half) * 0.5
+
+
+@cute.jit
+def sequence_bounds(cu_seqlens: cute.Tensor, time: Int32):
+    """Find the packed sequence containing a physical token position."""
+    if cutlass.const_expr(cute.size(cu_seqlens) == 2):
+        sequence_start = Int32(cu_seqlens[0])
+        sequence_end = Int32(cu_seqlens[1])
+    else:
+        num_offsets = Int32(cute.size(cu_seqlens))
+        sequence = upper_bound(cu_seqlens, time, Int32(1), num_offsets) - 1
+        if sequence >= num_offsets - 1:
+            sequence = num_offsets - 2
+        sequence_start = Int32(cu_seqlens[sequence])
+        sequence_end = Int32(cu_seqlens[sequence + 1])
+    if sequence_start < 0:
+        sequence_start = Int32(0)
+    return sequence_start, sequence_end
+
+
+@cute.jit
+def unrolled_dot(
+    inputs: cute.Tensor,
+    weights: cute.Tensor,
+    input_offset: cutlass.Constexpr,
+    width: cutlass.Constexpr,
+):
+    """Build a descending compile-time convolution dot product."""
+    last_tap = width - 1
+    value = (
+        inputs[(None, input_offset + last_tap)].load().to(Float32)
+        * weights[(None, last_tap)].load()
+    )
+    for step in cutlass.range_constexpr(width - 1):
+        tap = width - 2 - step
+        value = (
+            value
+            + inputs[(None, input_offset + tap)].load().to(Float32) * weights[(None, tap)].load()
+        )
+    return value
 
 
 class CausalConv1dSiluForward:
@@ -90,7 +133,13 @@ class CausalConv1dSiluForward:
         )
 
     @cute.kernel
-    def kernel(self, x: cute.Tensor, weight: cute.Tensor, output: cute.Tensor):
+    def kernel(
+        self,
+        x: cute.Tensor,
+        weight: cute.Tensor,
+        output: cute.Tensor,
+        cu_seqlens: cute.Tensor | None,
+    ):
         """Compute one packed channel group and eight output tokens."""
         thread_idx, _, _ = cute.arch.thread_idx()
         channel_block, time_block, batch = cute.arch.block_idx()
@@ -120,37 +169,44 @@ class CausalConv1dSiluForward:
                         ].load()
                     )
 
+            if cutlass.const_expr(cu_seqlens is not None):
+                tile_sequence_start, tile_sequence_end = sequence_bounds(
+                    cu_seqlens, Int32(time_start)
+                )
+            else:
+                tile_sequence_start, tile_sequence_end = Int32(0), Int32(self.tokens)
+
             for time_offset in cutlass.range_constexpr(self.times_per_block):
                 time = time_start + time_offset
+                sequence_start = tile_sequence_start
                 if time < self.tokens:
-                    if cutlass.const_expr(self.width == 4):
-                        # Keep the hot K3 specialization as one expression tree.
-                        # CuTeDSL currently emits extra register moves for the
-                        # generic TensorSSA reduction below at this width.
-                        value = (
-                            inputs[(None, time_offset + 3)].load().to(Float32)
-                            * weights[(None, 3)].load()
-                            + inputs[(None, time_offset + 2)].load().to(Float32)
-                            * weights[(None, 2)].load()
-                            + inputs[(None, time_offset + 1)].load().to(Float32)
-                            * weights[(None, 1)].load()
-                            + inputs[(None, time_offset)].load().to(Float32)
-                            * weights[(None, 0)].load()
-                        )
+                    if cutlass.const_expr(cu_seqlens is not None):
+                        if time < tile_sequence_end:
+                            sequence_start = tile_sequence_start
+                        else:
+                            sequence_start, _ = sequence_bounds(cu_seqlens, Int32(time))
                     else:
-                        products = cute.make_rmem_tensor(
-                            (self.channels_per_thread, self.width), Float32
+                        sequence_start = Int32(0)
+
+                    if cutlass.const_expr(cu_seqlens is None):
+                        value = unrolled_dot(inputs, weights, time_offset, self.width)
+                    else:
+                        last_tap = self.width - 1
+                        value = (
+                            inputs[(None, time_offset + last_tap)].load().to(Float32)
+                            * weights[(None, last_tap)].load()
                         )
-                        for tap in cutlass.range_constexpr(self.width):
-                            products[(None, tap)].store(
-                                inputs[(None, time_offset + tap)].load().to(Float32)
-                                * weights[(None, tap)].load()
-                            )
-                        value = products.load().reduce(
-                            cute.ReductionOp.ADD,
-                            Float32(0.0),
-                            reduction_profile=(None, 1),
-                        )
+                        if time - last_tap >= sequence_start:
+                            value = unrolled_dot(inputs, weights, time_offset, self.width)
+                        else:
+                            for step in cutlass.range_constexpr(self.width - 1):
+                                tap = self.width - 2 - step
+                                if time + tap - last_tap >= sequence_start:
+                                    value = (
+                                        value
+                                        + inputs[(None, time_offset + tap)].load().to(Float32)
+                                        * weights[(None, tap)].load()
+                                    )
                     output_groups[((0, None), (batch * self.tokens + time, channel_group))].store(
                         self.activation(value).to(BFloat16)
                     )
@@ -161,10 +217,11 @@ class CausalConv1dSiluForward:
         x: cute.Tensor,
         weight: cute.Tensor,
         output: cute.Tensor,
+        cu_seqlens: cute.Tensor | None,
         stream,
     ):
         """Launch the configured forward specialization."""
-        self.kernel(x, weight, output, _name_prefix=self.get_name()).launch(
+        self.kernel(x, weight, output, cu_seqlens, _name_prefix=self.get_name()).launch(
             grid=(
                 cute.ceil_div(self.channels, self.threads * self.channels_per_thread),
                 cute.ceil_div(self.tokens, self.times_per_block),
@@ -212,6 +269,7 @@ class CausalConv1dSiluInputGradient:
         weight: cute.Tensor,
         grad_output: cute.Tensor,
         grad_x: cute.Tensor,
+        cu_seqlens: cute.Tensor | None,
     ):
         """Compute one packed channel group and ten input-gradient tokens."""
         thread_idx, _, _ = cute.arch.thread_idx()
@@ -250,17 +308,37 @@ class CausalConv1dSiluInputGradient:
                 Float32,
             )
             grad_z.fill(Float32(0.0))
+            if cutlass.const_expr(cu_seqlens is not None):
+                output_sequence_start, output_sequence_end = sequence_bounds(
+                    cu_seqlens, Int32(time_start)
+                )
+            else:
+                output_sequence_start, output_sequence_end = Int32(0), Int32(self.tokens)
             for output_offset in cutlass.range_constexpr(self.times_per_block + self.width - 1):
                 output_time = time_start + output_offset
                 if output_time < self.tokens:
+                    if cutlass.const_expr(cu_seqlens is not None):  # noqa: SIM102
+                        if output_time >= output_sequence_end:
+                            output_sequence_start, output_sequence_end = sequence_bounds(
+                                cu_seqlens, Int32(output_time)
+                            )
                     products = cute.make_rmem_tensor(
                         (self.channels_per_thread, self.width), Float32
                     )
+                    products.fill(Float32(0.0))
                     for tap in cutlass.range_constexpr(self.width):
-                        products[(None, tap)].store(
-                            inputs[(None, output_offset + tap)].load().to(Float32)
-                            * weights[(None, tap)].load()
-                        )
+                        if cutlass.const_expr(cu_seqlens is None):
+                            products[(None, tap)].store(
+                                inputs[(None, output_offset + tap)].load().to(Float32)
+                                * weights[(None, tap)].load()
+                            )
+                        else:
+                            input_time = output_time + tap - (self.width - 1)
+                            if input_time >= output_sequence_start:
+                                products[(None, tap)].store(
+                                    inputs[(None, output_offset + tap)].load().to(Float32)
+                                    * weights[(None, tap)].load()
+                                )
                     value = products.load().reduce(
                         cute.ReductionOp.ADD,
                         Float32(0.0),
@@ -274,17 +352,36 @@ class CausalConv1dSiluInputGradient:
                     )
                     grad_z[(None, output_offset)].store(incoming * derivative)
 
+            if cutlass.const_expr(cu_seqlens is not None):
+                _input_sequence_start, input_sequence_end = sequence_bounds(
+                    cu_seqlens, Int32(time_start)
+                )
+            else:
+                _input_sequence_start, input_sequence_end = Int32(0), Int32(self.tokens)
             for time_offset in cutlass.range_constexpr(self.times_per_block):
                 time = time_start + time_offset
                 if time < self.tokens:
+                    if cutlass.const_expr(cu_seqlens is not None):  # noqa: SIM102
+                        if time >= input_sequence_end:
+                            _input_sequence_start, input_sequence_end = sequence_bounds(
+                                cu_seqlens, Int32(time)
+                            )
                     products = cute.make_rmem_tensor(
                         (self.channels_per_thread, self.width), Float32
                     )
+                    products.fill(Float32(0.0))
                     for future_offset in cutlass.range_constexpr(self.width):
-                        products[(None, future_offset)].store(
-                            grad_z[(None, time_offset + future_offset)].load()
-                            * weights[(None, self.width - 1 - future_offset)].load()
-                        )
+                        if cutlass.const_expr(cu_seqlens is None):
+                            products[(None, future_offset)].store(
+                                grad_z[(None, time_offset + future_offset)].load()
+                                * weights[(None, self.width - 1 - future_offset)].load()
+                            )
+                        else:
+                            if time + future_offset < input_sequence_end:
+                                products[(None, future_offset)].store(
+                                    grad_z[(None, time_offset + future_offset)].load()
+                                    * weights[(None, self.width - 1 - future_offset)].load()
+                                )
                     value = products.load().reduce(
                         cute.ReductionOp.ADD,
                         Float32(0.0),
@@ -301,6 +398,7 @@ class CausalConv1dSiluInputGradient:
         weight: cute.Tensor,
         grad_output: cute.Tensor,
         grad_x: cute.Tensor,
+        cu_seqlens: cute.Tensor | None,
         stream,
     ):
         """Launch the configured input-gradient specialization."""
@@ -309,6 +407,7 @@ class CausalConv1dSiluInputGradient:
             weight,
             grad_output,
             grad_x,
+            cu_seqlens,
             _name_prefix=self.get_name(),
         ).launch(
             grid=(
@@ -358,6 +457,7 @@ class CausalConv1dSiluWeightGradientPartials:
         weight: cute.Tensor,
         grad_output: cute.Tensor,
         partials: cute.Tensor,
+        cu_seqlens: cute.Tensor | None,
     ):
         """Compute one FP32 weight-gradient partial per tap and owned channel."""
         thread_idx, _, _ = cute.arch.thread_idx()
@@ -376,16 +476,23 @@ class CausalConv1dSiluWeightGradientPartials:
                 for tap in cutlass.range_constexpr(self.width):
                     weights[channel_offset, tap] = Float32(weight[channel + channel_offset, tap])
 
+            if cutlass.const_expr(cu_seqlens is not None):
+                sequence_start, sequence_end = sequence_bounds(cu_seqlens, Int32(time_start))
+            else:
+                sequence_start, sequence_end = Int32(0), Int32(self.tokens)
             for time_offset in cutlass.range(self.times_per_block, unroll_full=True):
                 time = time_start + time_offset
                 if time < self.tokens:
+                    if cutlass.const_expr(cu_seqlens is not None):  # noqa: SIM102
+                        if time >= sequence_end:
+                            sequence_start, sequence_end = sequence_bounds(cu_seqlens, Int32(time))
                     input_taps = cute.make_rmem_tensor(
                         (self.channels_per_thread, self.width), Float32
                     )
                     input_taps.fill(Float32(0.0))
                     for tap in cutlass.range_constexpr(self.width):
                         input_time = time + tap - (self.width - 1)
-                        if input_time >= 0:
+                        if input_time >= sequence_start:
                             input_taps[(None, tap)].store(
                                 x_groups[
                                     (
@@ -428,6 +535,7 @@ class CausalConv1dSiluWeightGradientPartials:
         weight: cute.Tensor,
         grad_output: cute.Tensor,
         partials: cute.Tensor,
+        cu_seqlens: cute.Tensor | None,
         stream,
     ):
         """Launch the configured weight-gradient specialization."""
@@ -436,6 +544,7 @@ class CausalConv1dSiluWeightGradientPartials:
             weight,
             grad_output,
             partials,
+            cu_seqlens,
             _name_prefix=self.get_name(),
         ).launch(
             grid=(
@@ -462,6 +571,18 @@ def _fake_bf16_matrix(rows: int, columns: int):
     )
 
 
+def _fake_cu_seqlens(num_sequences: int | None):
+    """Create packed offsets for compilation or preserve the dense specialization."""
+    if num_sequences is None:
+        return None
+    return cute.runtime.make_fake_compact_tensor(
+        Int32,
+        (num_sequences + 1,),
+        stride_order=(0,),
+        assumed_align=4,
+    )
+
+
 @jit_cache
 def _compile_forward(
     batches: int,
@@ -469,6 +590,7 @@ def _compile_forward(
     channels: int,
     width: int,
     config: ShortConvConfig,
+    num_sequences: int | None = None,
 ):
     """Compile one static forward specialization."""
     operation = CausalConv1dSiluForward(batches, tokens, channels, width, config, _silu)
@@ -477,6 +599,7 @@ def _compile_forward(
         _fake_bf16_matrix(batches * tokens, channels),
         _fake_bf16_matrix(channels, width),
         _fake_bf16_matrix(batches * tokens, channels),
+        _fake_cu_seqlens(num_sequences),
     )
 
 
@@ -487,6 +610,7 @@ def _compile_input_gradient(
     channels: int,
     width: int,
     config: ShortConvConfig,
+    num_sequences: int | None = None,
 ):
     """Compile one static input-gradient specialization."""
     operation = CausalConv1dSiluInputGradient(
@@ -498,6 +622,7 @@ def _compile_input_gradient(
         _fake_bf16_matrix(channels, width),
         _fake_bf16_matrix(batches * tokens, channels),
         _fake_bf16_matrix(batches * tokens, channels),
+        _fake_cu_seqlens(num_sequences),
     )
 
 
@@ -508,6 +633,7 @@ def _compile_weight_gradient(
     channels: int,
     width: int,
     config: ShortConvConfig,
+    num_sequences: int | None = None,
 ):
     """Compile one static weight-gradient specialization."""
     num_time_blocks = ceildiv(tokens, config.times_per_block)
@@ -526,10 +652,15 @@ def _compile_weight_gradient(
         _fake_bf16_matrix(channels, width),
         _fake_bf16_matrix(batches * tokens, channels),
         partials,
+        _fake_cu_seqlens(num_sequences),
     )
 
 
-def _validate_inputs(x: torch.Tensor, weight: torch.Tensor) -> None:
+def _validate_inputs(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    cu_seqlens: torch.Tensor | None = None,
+) -> None:
     """Validate the public compile-time-width CuTeDSL tensor contract."""
     if x.ndim != 3:
         raise ValueError(f"x must have shape [B, T, C], got {tuple(x.shape)}")
@@ -543,6 +674,17 @@ def _validate_inputs(x: torch.Tensor, weight: torch.Tensor) -> None:
         )
     if weight.dtype != torch.bfloat16 or weight.device != x.device or not weight.is_contiguous():
         raise ValueError("weight must be contiguous CUDA BF16 on x.device")
+    if cu_seqlens is not None:
+        if x.shape[0] != 1:
+            raise ValueError("packed cu_seqlens require x to have batch size 1")
+        if cu_seqlens.ndim != 1 or cu_seqlens.shape[0] < 2:
+            raise ValueError("cu_seqlens must have shape [num_sequences + 1]")
+        if (
+            cu_seqlens.dtype != torch.int32
+            or cu_seqlens.device != x.device
+            or not cu_seqlens.is_contiguous()
+        ):
+            raise ValueError("cu_seqlens must be contiguous CUDA int32 on x.device")
 
 
 def _aligned(tensor: torch.Tensor) -> torch.Tensor:
@@ -554,6 +696,7 @@ def _launch_forward(
     x: torch.Tensor,
     weight: torch.Tensor,
     config: ShortConvConfig,
+    cu_seqlens: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Allocate and launch the compiled forward specialization."""
     x, weight = _aligned(x), _aligned(weight)
@@ -566,8 +709,14 @@ def _launch_forward(
         channels,
         width,
         config,
+        None if cu_seqlens is None else cu_seqlens.shape[0] - 1,
     )
-    compiled(x.view(batches * tokens, channels), weight, output.view(batches * tokens, channels))
+    compiled(
+        x.view(batches * tokens, channels),
+        weight,
+        output.view(batches * tokens, channels),
+        cu_seqlens,
+    )
     return output
 
 
@@ -577,6 +726,7 @@ def _launch_backward(
     grad_output: torch.Tensor,
     input_config: ShortConvConfig,
     weight_config: ShortConvConfig,
+    cu_seqlens: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Launch configured gradient kernels and reduce FP32 partials."""
     x, weight = _aligned(x), _aligned(weight)
@@ -590,11 +740,13 @@ def _launch_backward(
         channels,
         width,
         input_config,
+        None if cu_seqlens is None else cu_seqlens.shape[0] - 1,
     )(
         x.view(batches * tokens, channels),
         weight,
         grad_output.view(batches * tokens, channels),
         grad_x.view(batches * tokens, channels),
+        cu_seqlens,
     )
 
     num_time_blocks = ceildiv(tokens, weight_config.times_per_block)
@@ -603,11 +755,19 @@ def _launch_backward(
         dtype=torch.float32,
         device=x.device,
     )
-    _compile_weight_gradient(batches, tokens, channels, width, weight_config)(
+    _compile_weight_gradient(
+        batches,
+        tokens,
+        channels,
+        width,
+        weight_config,
+        None if cu_seqlens is None else cu_seqlens.shape[0] - 1,
+    )(
         x.view(batches * tokens, channels),
         weight,
         grad_output.view(batches * tokens, channels),
         partials,
+        cu_seqlens,
     )
     return grad_x, partials.sum(dim=(0, 1)).to(torch.bfloat16)
 
@@ -669,6 +829,7 @@ def tune_causal_conv1d_silu(
     weight: torch.Tensor,
     grad_output: torch.Tensor,
     *,
+    cu_seqlens: torch.Tensor | None = None,
     forward_configs: Iterable[ShortConvConfig] | None = None,
     input_grad_configs: Iterable[ShortConvConfig] | None = None,
     weight_grad_configs: Iterable[ShortConvConfig] | None = None,
@@ -676,12 +837,13 @@ def tune_causal_conv1d_silu(
 ) -> ShortConvTunedConfig:
     """Compile and benchmark forward, input-gradient, and weight-gradient schedules.
 
-    Width is an operation parameter and is specialized but not autotuned. The
-    returned configs can be passed directly to :func:`cute_causal_conv1d_silu`.
+    Width is an operation parameter and is specialized but not autotuned. Packed
+    inputs use the same caller-owned ``cu_seqlens`` accepted by the public operation.
+    The returned configs can be passed directly to :func:`cute_causal_conv1d_silu`.
     Tuning uses the shared CuTeDSL ``tune`` flow: cached variants compile in
     parallel and execute sequentially under the vetted Inductor GPU benchmarker.
     """
-    _validate_inputs(x, weight)
+    _validate_inputs(x, weight, cu_seqlens)
     if grad_output.shape != x.shape or grad_output.dtype != x.dtype:
         raise ValueError("grad_output must match x shape and dtype")
     if grad_output.device != x.device or not grad_output.is_contiguous():
@@ -690,6 +852,7 @@ def tune_causal_conv1d_silu(
     x, weight, grad_output = _aligned(x), _aligned(weight), _aligned(grad_output)
     batches, tokens, channels = x.shape
     width = weight.shape[1]
+    num_sequences = None if cu_seqlens is None else cu_seqlens.shape[0] - 1
     x_matrix = x.view(batches * tokens, channels)
     grad_matrix = grad_output.view(batches * tokens, channels)
 
@@ -702,8 +865,15 @@ def tune_causal_conv1d_silu(
     forward = tune(
         forward_candidates,
         _compile_forward,
-        lambda compiled, _config: compiled(x_matrix, weight, forward_output),
-        compile_call=lambda config: (batches, tokens, channels, width, config),
+        lambda compiled, _config: compiled(x_matrix, weight, forward_output, cu_seqlens),
+        compile_call=lambda config: (
+            batches,
+            tokens,
+            channels,
+            width,
+            config,
+            num_sequences,
+        ),
         parallel_compile=parallel_compile,
     )
 
@@ -718,8 +888,15 @@ def tune_causal_conv1d_silu(
     input_gradient = tune(
         input_candidates,
         _compile_input_gradient,
-        lambda compiled, _config: compiled(x_matrix, weight, grad_matrix, grad_x),
-        compile_call=lambda config: (batches, tokens, channels, width, config),
+        lambda compiled, _config: compiled(x_matrix, weight, grad_matrix, grad_x, cu_seqlens),
+        compile_call=lambda config: (
+            batches,
+            tokens,
+            channels,
+            width,
+            config,
+            num_sequences,
+        ),
         parallel_compile=parallel_compile,
     )
 
@@ -749,8 +926,16 @@ def tune_causal_conv1d_silu(
             weight,
             grad_matrix,
             partials[config],
+            cu_seqlens,
         ),
-        compile_call=lambda config: (batches, tokens, channels, width, config),
+        compile_call=lambda config: (
+            batches,
+            tokens,
+            channels,
+            width,
+            config,
+            num_sequences,
+        ),
         parallel_compile=parallel_compile,
     )
     return ShortConvTunedConfig(forward, input_gradient, weight_gradient)
@@ -762,14 +947,22 @@ def _config(threads: int, channels_per_thread: int, times_per_block: int) -> Sho
 
 
 @torch.library.custom_op("attn_gym::_cute_short_conv_fwd", mutates_args=())
-def _forward_custom_op(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+def _forward_custom_op(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    cu_seqlens: torch.Tensor | None = None,
+) -> torch.Tensor:
     """Launch the tuned K3 defaults through the lean production schema."""
-    return _launch_forward(x, weight, CausalConv1dSiluForward.default_config)
+    return _launch_forward(x, weight, CausalConv1dSiluForward.default_config, cu_seqlens)
 
 
 @_forward_custom_op.register_fake
-def _default_forward_fake(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
-    del weight
+def _default_forward_fake(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    cu_seqlens: torch.Tensor | None = None,
+) -> torch.Tensor:
+    del weight, cu_seqlens
     return torch.empty_like(x)
 
 
@@ -778,6 +971,7 @@ def _backward_custom_op(
     x: torch.Tensor,
     weight: torch.Tensor,
     grad_output: torch.Tensor,
+    cu_seqlens: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Launch the tuned K3 backward defaults through the lean schema."""
     return _launch_backward(
@@ -786,6 +980,7 @@ def _backward_custom_op(
         grad_output,
         CausalConv1dSiluInputGradient.default_config,
         CausalConv1dSiluWeightGradientPartials.default_config,
+        cu_seqlens,
     )
 
 
@@ -794,20 +989,31 @@ def _default_backward_fake(
     x: torch.Tensor,
     weight: torch.Tensor,
     grad_output: torch.Tensor,
+    cu_seqlens: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    del grad_output
+    del grad_output, cu_seqlens
     return torch.empty_like(x), torch.empty_like(weight)
 
 
 def _setup_default_context(ctx, inputs, output) -> None:
     del output
-    ctx.save_for_backward(*inputs)
+    x, weight, cu_seqlens = inputs
+    ctx.has_cu_seqlens = cu_seqlens is not None
+    if cu_seqlens is None:
+        ctx.save_for_backward(x, weight)
+    else:
+        ctx.save_for_backward(x, weight, cu_seqlens)
 
 
 @torch.autograd.function.once_differentiable
-def _default_backward(ctx, grad_output: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-    x, weight = ctx.saved_tensors
-    return _backward_custom_op(x, weight, grad_output)
+def _default_backward(ctx, grad_output: torch.Tensor):
+    if ctx.has_cu_seqlens:
+        x, weight, cu_seqlens = ctx.saved_tensors
+    else:
+        x, weight = ctx.saved_tensors
+        cu_seqlens = None
+    grad_x, grad_weight = _backward_custom_op(x, weight, grad_output, cu_seqlens)
+    return grad_x, grad_weight, None
 
 
 _forward_custom_op.register_autograd(
@@ -820,6 +1026,7 @@ _forward_custom_op.register_autograd(
 def _configured_forward_custom_op(
     x: torch.Tensor,
     weight: torch.Tensor,
+    cu_seqlens: torch.Tensor | None,
     forward_threads: int,
     forward_channels: int,
     forward_times: int,
@@ -836,6 +1043,7 @@ def _configured_forward_custom_op(
         x,
         weight,
         _config(forward_threads, forward_channels, forward_times),
+        cu_seqlens,
     )
 
 
@@ -843,6 +1051,7 @@ def _configured_forward_custom_op(
 def _forward_fake(
     x: torch.Tensor,
     weight: torch.Tensor,
+    cu_seqlens: torch.Tensor | None,
     forward_threads: int,
     forward_channels: int,
     forward_times: int,
@@ -856,6 +1065,7 @@ def _forward_fake(
     """Describe forward output metadata without invoking the compiler."""
     del (
         weight,
+        cu_seqlens,
         forward_threads,
         forward_channels,
         forward_times,
@@ -874,6 +1084,7 @@ def _configured_backward_custom_op(
     x: torch.Tensor,
     weight: torch.Tensor,
     grad_output: torch.Tensor,
+    cu_seqlens: torch.Tensor | None,
     input_threads: int,
     input_channels: int,
     input_times: int,
@@ -888,6 +1099,7 @@ def _configured_backward_custom_op(
         grad_output,
         _config(input_threads, input_channels, input_times),
         _config(weight_threads, weight_channels, weight_times),
+        cu_seqlens,
     )
 
 
@@ -896,6 +1108,7 @@ def _backward_fake(
     x: torch.Tensor,
     weight: torch.Tensor,
     grad_output: torch.Tensor,
+    cu_seqlens: torch.Tensor | None,
     input_threads: int,
     input_channels: int,
     input_times: int,
@@ -906,6 +1119,7 @@ def _backward_fake(
     """Describe backward output metadata without invoking the compiler."""
     del (
         grad_output,
+        cu_seqlens,
         input_threads,
         input_channels,
         input_times,
@@ -922,6 +1136,7 @@ def _setup_context(ctx, inputs, output) -> None:
     (
         x,
         weight,
+        cu_seqlens,
         _forward_threads,
         _forward_channels,
         _forward_times,
@@ -932,17 +1147,26 @@ def _setup_context(ctx, inputs, output) -> None:
         ctx.weight_channels,
         ctx.weight_times,
     ) = inputs
-    ctx.save_for_backward(x, weight)
+    ctx.has_cu_seqlens = cu_seqlens is not None
+    if cu_seqlens is None:
+        ctx.save_for_backward(x, weight)
+    else:
+        ctx.save_for_backward(x, weight, cu_seqlens)
 
 
 @torch.autograd.function.once_differentiable
 def _backward(ctx, grad_output: torch.Tensor):
     """Dispatch the registered first-order backward custom operator."""
-    x, weight = ctx.saved_tensors
+    if ctx.has_cu_seqlens:
+        x, weight, cu_seqlens = ctx.saved_tensors
+    else:
+        x, weight = ctx.saved_tensors
+        cu_seqlens = None
     grad_x, grad_weight = _configured_backward_custom_op(
         x,
         weight,
         grad_output,
+        cu_seqlens,
         ctx.input_threads,
         ctx.input_channels,
         ctx.input_times,
@@ -950,7 +1174,7 @@ def _backward(ctx, grad_output: torch.Tensor):
         ctx.weight_channels,
         ctx.weight_times,
     )
-    return grad_x, grad_weight, None, None, None, None, None, None, None, None, None
+    return grad_x, grad_weight, None, None, None, None, None, None, None, None, None, None
 
 
 _configured_forward_custom_op.register_autograd(_backward, setup_context=_setup_context)
@@ -970,6 +1194,7 @@ def cute_causal_conv1d_silu(
     x: torch.Tensor,
     weight: torch.Tensor,
     *,
+    cu_seqlens: torch.Tensor | None = None,
     forward_config: ShortConvConfig | None = None,
     input_grad_config: ShortConvConfig | None = None,
     weight_grad_config: ShortConvConfig | None = None,
@@ -984,6 +1209,10 @@ def cute_causal_conv1d_silu(
         x: Contiguous CUDA BF16 input with shape ``[B, T, C]``. Each batch row
             is convolved as an independent sequence.
         weight: Contiguous CUDA BF16 depthwise weights with shape ``[C, W]``.
+        cu_seqlens: Optional contiguous CUDA int32 offsets delimiting independent
+            sequences in a packed ``[1, T, C]`` input. Offsets must be nondecreasing,
+            begin at zero, and end at ``T``; repeated offsets represent empty padding
+            slots for static-shape CUDA Graph replay.
         forward_config: Optional forward schedule specialization.
         input_grad_config: Optional input-gradient schedule specialization.
         weight_grad_config: Optional weight-gradient schedule specialization.
@@ -991,7 +1220,7 @@ def cute_causal_conv1d_silu(
     Returns:
         A contiguous CUDA BF16 tensor with the same shape as ``x``.
     """
-    _validate_inputs(x, weight)
+    _validate_inputs(x, weight, cu_seqlens)
     channels = x.shape[2]
     default_forward = CausalConv1dSiluForward.default_config
     default_input_grad = CausalConv1dSiluInputGradient.default_config
@@ -1013,10 +1242,11 @@ def cute_causal_conv1d_silu(
         and input_grad == default_input_grad
         and weight_grad == default_weight_grad
     ):
-        return _forward_custom_op(x, weight)
+        return _forward_custom_op(x, weight, cu_seqlens)
     return _configured_forward_custom_op(
         x,
         weight,
+        cu_seqlens,
         forward.threads,
         forward.channels_per_thread,
         forward.times_per_block,

--- a/test/test_kda_short_conv_cute.py
+++ b/test/test_kda_short_conv_cute.py
@@ -1,5 +1,7 @@
 """Correctness and integration tests for the CuTeDSL KDA short convolution."""
 
+from itertools import pairwise
+
 import pytest
 import torch
 import torch.nn.functional as F
@@ -10,6 +12,8 @@ from attn_gym.linear.kda.short_conv.cute import (
     ShortConvConfig,
     _backward_custom_op,
     _candidate_configs,
+    _configured_backward_custom_op,
+    _configured_forward_custom_op,
     _forward_custom_op,
     cute_causal_conv1d_silu,
     tune_causal_conv1d_silu,
@@ -30,6 +34,19 @@ def _inputs(tokens: int = 17, channels: int = 12, width: int = 4, batch: int = 1
 def _reference(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
     padded = F.pad(x.transpose(1, 2), (weight.shape[1] - 1, 0))
     return F.silu(F.conv1d(padded, weight[:, None], groups=x.shape[-1])).transpose(1, 2)
+
+
+def _packed_reference(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+) -> torch.Tensor:
+    """Concatenate independent convolutions for every nonempty packed sequence."""
+    offsets = cu_seqlens.cpu().tolist()
+    return torch.cat(
+        [_reference(x[:, start:end], weight) for start, end in pairwise(offsets) if start != end],
+        dim=1,
+    )
 
 
 @pytest.mark.parametrize("width", [1, 3, 4, 5])
@@ -84,6 +101,28 @@ def test_short_conv_batched_forward_and_backward_match_pytorch(width: int):
 
     actual = cute_causal_conv1d_silu(x, weight, weight_grad_config=weight_config)
     expected = _reference(x, weight)
+    torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
+
+    actual_gradients = torch.autograd.grad(actual, (x, weight), grad_output)
+    expected_gradients = torch.autograd.grad(expected, (x, weight), grad_output)
+    torch.testing.assert_close(actual_gradients[0], expected_gradients[0], rtol=3e-2, atol=3e-2)
+    torch.testing.assert_close(actual_gradients[1], expected_gradients[1], rtol=3e-2, atol=3e-1)
+
+
+@pytest.mark.parametrize("width", [1, 3, 4, 5])
+def test_short_conv_packed_forward_and_backward_match_independent_sequences(width: int):
+    """Reset convolution and gradient dependencies at every packed boundary."""
+    torch.manual_seed(2)
+    x, weight = _inputs(tokens=67, channels=12, width=width)
+    cu_seqlens = torch.tensor(
+        [0, 1, 3, 8, 8, 17, 31, 67],
+        device="cuda",
+        dtype=torch.int32,
+    )
+    grad_output = torch.randn_like(x)
+
+    actual = cute_causal_conv1d_silu(x, weight, cu_seqlens=cu_seqlens)
+    expected = _packed_reference(x, weight, cu_seqlens)
     torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
 
     actual_gradients = torch.autograd.grad(actual, (x, weight), grad_output)
@@ -149,16 +188,29 @@ def test_short_conv_explicit_config_and_tuning_flow():
     torch.testing.assert_close(compiled(x, weight), expected, rtol=2e-2, atol=2e-2)
 
 
-def test_short_conv_custom_op_registration():
-    """Exercise schemas, fake implementations, and registered autograd."""
-    x, weight = _inputs(batch=2)
+@pytest.mark.parametrize("packed", [False, True])
+def test_short_conv_custom_op_registration(packed: bool):
+    """Exercise dense and packed schemas, fake implementations, and autograd."""
+    x, weight = _inputs(batch=1 if packed else 2)
     grad_output = torch.randn_like(x)
-    torch.library.opcheck(_forward_custom_op, (x, weight))
+    cu_seqlens = torch.tensor([0, 2, 7, 17], device="cuda", dtype=torch.int32) if packed else None
+    torch.library.opcheck(_forward_custom_op, (x, weight, cu_seqlens))
     torch.library.opcheck(
         _backward_custom_op,
-        (x, weight, grad_output),
+        (x, weight, grad_output, cu_seqlens),
         test_utils=("test_schema", "test_faketensor"),
     )
+    if packed:
+        configs = (128, 4, 8, 128, 4, 10, 128, 4, 128)
+        torch.library.opcheck(
+            _configured_forward_custom_op,
+            (x, weight, cu_seqlens, *configs),
+        )
+        torch.library.opcheck(
+            _configured_backward_custom_op,
+            (x, weight, grad_output, cu_seqlens, *configs[3:]),
+            test_utils=("test_schema", "test_faketensor"),
+        )
 
 
 def test_short_conv_fullgraph_forward_and_backward():
@@ -173,6 +225,38 @@ def test_short_conv_fullgraph_forward_and_backward():
     actual = torch.autograd.grad(actual_output, (x, weight), grad_output)
     torch.testing.assert_close(actual[0], expected[0], rtol=3e-2, atol=3e-2)
     torch.testing.assert_close(actual[1], expected[1], rtol=3e-2, atol=2e-1)
+
+
+def test_short_conv_packed_fullgraph_forward_and_backward():
+    """Keep the configured packed operation inside a strict compiled graph."""
+    x, weight = _inputs(tokens=31)
+    cu_seqlens = torch.tensor([0, 2, 9, 17, 31], device="cuda", dtype=torch.int32)
+    grad_output = torch.randn_like(x)
+    configs = {
+        "forward_config": ShortConvConfig(128, 4, 8),
+        "input_grad_config": ShortConvConfig(128, 4, 10),
+        "weight_grad_config": ShortConvConfig(128, 4, 128),
+    }
+
+    expected_output = cute_causal_conv1d_silu(x, weight, cu_seqlens=cu_seqlens, **configs)
+    expected = torch.autograd.grad(expected_output, (x, weight), grad_output)
+    compiled = torch.compile(cute_causal_conv1d_silu, fullgraph=True)
+    actual_output = compiled(x, weight, cu_seqlens=cu_seqlens, **configs)
+    actual = torch.autograd.grad(actual_output, (x, weight), grad_output)
+    torch.testing.assert_close(actual[0], expected[0], rtol=3e-2, atol=3e-2)
+    torch.testing.assert_close(actual[1], expected[1], rtol=3e-2, atol=2e-1)
+
+
+def test_short_conv_packed_offsets_obey_autograd_versioning():
+    """Reject sequence-boundary mutation between forward and backward."""
+    x, weight = _inputs(tokens=31)
+    cu_seqlens = torch.tensor([0, 3, 11, 31], device="cuda", dtype=torch.int32)
+    output = cute_causal_conv1d_silu(x, weight, cu_seqlens=cu_seqlens)
+
+    with torch.no_grad():
+        cu_seqlens[1] = 4
+    with pytest.raises(RuntimeError, match="modified by an inplace operation"):
+        torch.autograd.grad(output, (x, weight), torch.randn_like(output))
 
 
 def test_short_conv_cuda_graph_replay():
@@ -200,6 +284,35 @@ def test_short_conv_cuda_graph_replay():
     assert not torch.equal(captured_gradients[0], first_gradients[0])
     expected_output = _forward_custom_op(x, weight)
     expected_gradients = _backward_custom_op(x, weight, grad_output)
+    torch.testing.assert_close(captured_output, expected_output)
+    torch.testing.assert_close(captured_gradients[0], expected_gradients[0])
+    torch.testing.assert_close(captured_gradients[1], expected_gradients[1])
+
+
+def test_short_conv_packed_cuda_graph_replays_changed_boundaries():
+    """Read packed boundaries from device memory again on every graph replay."""
+    x, weight = _inputs(tokens=31)
+    grad_output = torch.randn_like(x)
+    cu_seqlens = torch.tensor([0, 0, 11, 31, 31], device="cuda", dtype=torch.int32)
+    _forward_custom_op(x, weight, cu_seqlens)
+    _backward_custom_op(x, weight, grad_output, cu_seqlens)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_output = _forward_custom_op(x, weight, cu_seqlens)
+        captured_gradients = _backward_custom_op(x, weight, grad_output, cu_seqlens)
+
+    graph.replay()
+    first_output = captured_output.clone()
+    with torch.no_grad():
+        cu_seqlens.copy_(torch.tensor([0, 0, 8, 31, 31], device="cuda", dtype=torch.int32))
+    graph.replay()
+    torch.cuda.synchronize()
+
+    assert not torch.equal(captured_output, first_output)
+    expected_output = _forward_custom_op(x, weight, cu_seqlens)
+    expected_gradients = _backward_custom_op(x, weight, grad_output, cu_seqlens)
     torch.testing.assert_close(captured_output, expected_output)
     torch.testing.assert_close(captured_gradients[0], expected_gradients[0])
     torch.testing.assert_close(captured_gradients[1], expected_gradients[1])


### PR DESCRIPTION
## Summary

- extend the existing CuTeDSL causal depthwise convolution + SiLU op with an optional caller-owned `cu_seqlens`
- preserve the dense specialization when offsets are absent and use device-side boundary lookup for packed `[1, T, C]` inputs
- keep packed execution CUDA Graph replayable without `max_seqlen`, host synchronization, or caller-provided chunk maps
- enforce sequence boundaries in forward, input gradient, and weight gradient
- add reusable `upper_bound`, `sequence_bounds`, and constexpr-unrolled convolution helpers
- keep convolution width generic while generating the optimized unrolled expression for each compile-time width

`cu_seqlens` is a contiguous CUDA int32 tensor. It must be nondecreasing, start at zero, and end at `T`. Repeated offsets represent empty sequence slots, allowing the same captured graph to replay with changed boundaries while offset tensor shape and total token capacity remain fixed.

## Scheduling

The launch grid remains a static function of physical `T` and `C`. The kernel specializes at compile time on whether `cu_seqlens` is present; packed CTAs locate sequence boundaries directly from device memory. This avoids a public `max_seqlen`, auxiliary `chunk_indices`, and data-dependent host launch dimensions.

## Performance

NVIDIA GB300, BF16, `B=1, T=16384, C=12288, W=4`, fixed-pointer warm-buffer CUDA Graph replay. FLA 0.5.2 used precomputed `chunk_indices`; metadata construction was excluded from timing.

| Distribution | CuTe fwd | FLA fwd | CuTe bwd | FLA bwd |
|---|---:|---:|---:|---:|
| dense | 131.5 us | 213.6 us | 649.0 us | 1367.0 us |
| packed 1 | 133.2 us | 246.4 us | 843.7 us | 1190.3 us |
| packed 8 | 136.3 us | 245.9 us | 853.7 us | 1187.2 us |
| packed 64 | 144.0 us | 250.6 us | 869.7 us | 1186.4 us |
| packed 256 | 151.9 us | 249.5 us | 893.5 us | 1138.6 us |
| skewed 64 | 144.7 us | 286.7 us | 870.4 us | 1363.2 us |

The packed CuTe path is 1.64-1.98x faster than FLA forward and 1.27-1.57x faster backward across these distributions.

## Testing

- packed forward and both gradients against concatenated independent PyTorch references
- widths 1, 3, 4, and 5, including sequences shorter than the convolution width
- boundaries within and exactly on kernel tiles
- repeated offsets / empty sequence slots
- default and configured custom-op schemas and fake implementations
- `torch.compile(fullgraph=True)`
- autograd saved-tensor versioning for offsets
- CUDA Graph capture and replay after changing offsets in place
- 65 related KDA/CuTeDSL tests pass
- `prek`, Ruff, format, `py_compile`, and `git diff --check` pass
