### PR TITLE
Support packed CuTe KDA core

### DIFF
--- a/attn_gym/linear/kda/bwd/cute/chunk_delta_h_bwd_v1_dispatch.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_delta_h_bwd_v1_dispatch.py
@@ -23,6 +23,7 @@ Crossover point: w_tiles_bv16 = SM_count ≈ 132 on GH200.
 
 import torch
 
+from attn_gym._backends.cute import ceildiv
 from attn_gym.linear.kda.bwd.cute.chunk_delta_h_bwd_v1 import (
     blackwell_delta_h_bwd_dhu_v1,
 )
@@ -43,16 +44,18 @@ def blackwell_delta_h_bwd_dhu_dispatch(
     dv2_out: torch.Tensor | None = None,
     chunk_offsets: torch.Tensor | None = None,
     num_seqs: torch.Tensor | int | None = None,
+    num_chunks: int | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     BlackwellDeltaHBwd backward dhu — auto-dispatches BV=16 or BV=32.
 
     Returns (dh, dh0, dv2).
     """
-    B, _T, H, _K = q.shape
-    V = do.shape[-1]
+    batch, _tokens, heads, _head_dim = q.shape
+    value_dim = do.shape[-1]
+    logical_batch = batch if cu_seqlens is None else cu_seqlens.shape[0] - 1
 
-    w_tiles_bv16 = ((V + 15) // 16) * H * B
+    w_tiles_bv16 = ceildiv(value_dim, 16) * heads * logical_batch
     sm_count = torch.cuda.get_device_properties(q.device).multi_processor_count
 
     bv = 32 if w_tiles_bv16 > sm_count else 16
@@ -73,4 +76,5 @@ def blackwell_delta_h_bwd_dhu_dispatch(
         chunk_offsets=chunk_offsets,
         num_seqs=num_seqs,
         bv=bv,
+        NT=num_chunks,
     )

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd.py
@@ -1,4 +1,4 @@
-"""Composed fixed-length Blackwell KDA core backward."""
+"""Composed fixed-length and packed Blackwell KDA core backward."""
 
 from __future__ import annotations
 
@@ -17,6 +17,7 @@ from attn_gym.linear.kda.bwd.cute.chunk_kda_bwd_wy_dqkg_fused import (
 from attn_gym.linear.kda.bwd.triton.chunk_kda_bwd_dav import chunk_kda_bwd_dav
 from attn_gym.linear.kda.fwd.cute.recompute_w_u_fwd import recompute_w_u_fwd
 from attn_gym.linear.kda.fwd.triton.chunk_delta_h import chunk_gated_delta_rule_fwd_h
+from attn_gym.linear.kda.utils import ChunkMetadata
 
 
 def chunk_kda_bwd(
@@ -30,9 +31,7 @@ def chunk_kda_bwd(
     do: torch.Tensor,
     d_final_state: torch.Tensor | None,
     initial_state: torch.Tensor | None,
-    cu_seqlens: torch.Tensor,
-    chunk_indices: torch.Tensor,
-    num_chunks: torch.Tensor,
+    metadata: ChunkMetadata,
     *,
     chunk_size: int = 64,
     fastmath: bool = False,
@@ -45,7 +44,7 @@ def chunk_kda_bwd(
     torch.Tensor,
     torch.Tensor | None,
 ]:
-    """Differentiate the optimized fixed-length KDA core pipeline."""
+    """Differentiate the optimized fixed-length or packed KDA core pipeline."""
     batch, tokens, _heads, head_dim = q.shape
     value_dim = v.shape[-1]
     if batch != 1 or head_dim != 128 or value_dim != 128:
@@ -71,9 +70,7 @@ def chunk_kda_bwd(
             beta=beta,
             A=Akk,
             gk=g,
-            cu_seqlens=cu_seqlens,
-            chunk_indices=chunk_indices,
-            num_chunks=num_chunks,
+            metadata=metadata,
             chunk_size=chunk_size,
         )
     assert w is not None and qg is not None and kg is not None
@@ -86,6 +83,7 @@ def chunk_kda_bwd(
             initial_state,
             chunk_size=chunk_size,
             output_final_state=False,
+            cu_seqlens=metadata.cu_seqlens if metadata.has_multiple_sequences else None,
         )
     del u
 
@@ -96,6 +94,7 @@ def chunk_kda_bwd(
             do,
             head_dim**-0.5,
             chunk_size=chunk_size,
+            metadata=metadata if metadata.has_multiple_sequences else None,
         )
     with record("kda/cute/backward_delta_h"):
         dh, d_initial_state, dv = blackwell_delta_h_bwd_dhu_dispatch(
@@ -108,7 +107,19 @@ def chunk_kda_bwd(
             h0=initial_state,
             dht=d_final_state,
             scale=head_dim**-0.5,
+            cu_seqlens=metadata.cu_seqlens if metadata.has_multiple_sequences else None,
             chunk_size=chunk_size,
+            chunk_offsets=(
+                metadata.cu_seqlens // chunk_size if metadata.has_multiple_sequences else None
+            ),
+            num_seqs=(
+                metadata.cu_seqlens.new_full((1,), metadata.cu_seqlens.shape[0] - 1)
+                if metadata.has_multiple_sequences
+                else None
+            ),
+            num_chunks=metadata.chunk_indices.shape[0]
+            if metadata.has_multiple_sequences
+            else None,
         )
     del w, qg, kg, dv_intra
     with record("kda/cute/backward_wy_dqkg"):
@@ -124,8 +135,7 @@ def chunk_kda_bwd(
             do,
             dh,
             dv,
-            cu_seqlens,
-            chunk_indices,
+            metadata,
             chunk_size=chunk_size,
             fastmath=fastmath,
         )
@@ -142,9 +152,7 @@ def chunk_kda_bwd(
             dk,
             db,
             dg,
-            cu_seqlens,
-            chunk_indices,
-            num_chunks,
+            metadata,
         )
     # The imported kernels accumulate derivatives with respect to their exp2
     # exponent as though it were a natural exponent. Convert to d/d(log2 gate).

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_intra.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_intra.py
@@ -23,6 +23,7 @@ from cutlass.cutlass_dsl import Constexpr, T, dsl_user_op
 
 from attn_gym._backends.cute import compile_tvm_ffi, jit_cache, run_tunable
 from attn_gym._backends.cute.target import detect_compile_target, get_compile_target
+from attn_gym.linear.kda.utils import ChunkMetadata
 
 BT = 64  # chunk_size
 SUBCHUNKS = 4
@@ -1978,7 +1979,7 @@ def _compile_chunk_kda_bwd_intra(heads: int, chunks: int, grid_chunks: int):
         use_i32_metadata=True,
         grid_chunks=grid_chunks,
     )
-    tokens = cute.sym_int()
+    tokens, sequences = cute.sym_int(), cute.sym_int()
 
     def normal(dtype, shape):
         return make_fake_compact_tensor(
@@ -2009,7 +2010,7 @@ def _compile_chunk_kda_bwd_intra(heads: int, chunks: int, grid_chunks: int):
     dq2 = column_token_head(cutlass.BFloat16, KEY_DIM)
     dk2 = column_token_head(cutlass.BFloat16, KEY_DIM)
     dg2 = column_token_head(cutlass.Float32, KEY_DIM)
-    cu_seqlens = normal(cutlass.Int32, (2,))
+    cu_seqlens = normal(cutlass.Int32, (sequences,))
     chunk_indices = normal(cutlass.Int32, (chunks, 2))
     num_chunks = normal(cutlass.Int32, (1,))
     return compile_tvm_ffi(
@@ -2134,15 +2135,13 @@ def chunk_kda_bwd_intra(
     dk: torch.Tensor,
     db: torch.Tensor,
     dg: torch.Tensor,
-    cu_seqlens: torch.Tensor,
-    chunk_indices: torch.Tensor,
-    num_chunks: torch.Tensor,
+    metadata: ChunkMetadata,
     *,
     config: ChunkKdaBwdIntraConfig | None = None,
     tune: bool = False,
     configs: Iterable[ChunkKdaBwdIntraConfig] | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Run or tune the fixed-length intra-chunk Q/K/gate/beta backward stage."""
+    """Run or tune the metadata-driven intra-chunk Q/K/gate/beta backward stage."""
     batch, tokens, heads, head_dim = q.shape
     if batch != 1 or head_dim != KEY_DIM:
         raise ValueError("the intra-chunk backward requires B=1 and K=128")
@@ -2177,9 +2176,9 @@ def chunk_kda_bwd_intra(
         dk2=dk2,
         dg2=dg2,
         db_partial=db_partial,
-        cu_seqlens=cu_seqlens,
-        chunk_indices=chunk_indices,
-        num_chunks=num_chunks,
+        cu_seqlens=metadata.cu_seqlens,
+        chunk_indices=metadata.chunk_indices,
+        num_chunks=metadata.num_chunks,
     )
     target = detect_compile_target(q.device.index)
     if not tune and config is None:

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_wy_dqkg_fused.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_wy_dqkg_fused.py
@@ -33,6 +33,7 @@ from cutlass.cute.typing import BFloat16, Float32, Int32, Int64
 
 from attn_gym._backends.cute import compile_tvm_ffi, jit_cache, run_tunable
 from attn_gym._backends.cute.target import detect_compile_target, get_compile_target
+from attn_gym.linear.kda.utils import ChunkMetadata
 
 # ============================================================================
 # Inlined SM100 tcgen05 helper wrappers
@@ -4735,7 +4736,7 @@ def _compile_chunk_kda_bwd_wy_dqkg(
         grid_waves=grid_waves,
         use_fast_math=fastmath,
     )
-    tokens, chunks = cute.sym_int(), cute.sym_int()
+    tokens, chunks, sequences = (cute.sym_int() for _ in range(3))
 
     def tensor(dtype, shape):
         return make_fake_compact_tensor(
@@ -4762,7 +4763,7 @@ def _compile_chunk_kda_bwd_wy_dqkg(
     dg = tensor(cutlass.Float32, (1, tokens, heads, head_dim))
     db = tensor(cutlass.Float32, (1, tokens, heads))
     dA = tensor(cutlass.Float32, (1, tokens, heads, chunk_size))
-    cu_seqlens = tensor(cutlass.Int32, (2,))
+    cu_seqlens = tensor(cutlass.Int32, (sequences,))
     chunk_indices = tensor(cutlass.Int32, (chunks, 2))
     return compile_tvm_ffi(
         op,
@@ -4855,7 +4856,8 @@ class ChunkKdaBwdWyDqkgTunable:
         torch.Tensor,
     ]:
         del config
-        batch, tokens, heads, head_dim = args.q.shape
+        _batch, tokens, heads, head_dim = args.q.shape
+        sequences = args.cu_seqlens.shape[0] - 1
         compiled(
             args.q,
             args.k,
@@ -4877,7 +4879,7 @@ class ChunkKdaBwdWyDqkgTunable:
             args.cu_seqlens,
             args.chunk_indices,
             (
-                Int32(batch),
+                Int32(sequences),
                 Int32(tokens),
                 Int32(heads),
                 Int32(heads),
@@ -4901,8 +4903,7 @@ def chunk_kda_bwd_wy_dqkg(
     do: torch.Tensor,
     dh: torch.Tensor,
     dv: torch.Tensor,
-    cu_seqlens: torch.Tensor,
-    chunk_indices: torch.Tensor,
+    metadata: ChunkMetadata,
     *,
     chunk_size: int = 64,
     fastmath: bool = False,
@@ -4917,7 +4918,7 @@ def chunk_kda_bwd_wy_dqkg(
     torch.Tensor,
     torch.Tensor,
 ]:
-    """Run or tune the fixed-length fused WY/dQKG backward stage."""
+    """Run or tune the metadata-driven fused WY/dQKG backward stage."""
     batch, tokens, heads, head_dim = q.shape
     if batch != 1 or head_dim != 128 or v.shape[-1] != 128:
         raise ValueError("the fused WY backward requires B=1 and K=V=128")
@@ -4948,8 +4949,8 @@ def chunk_kda_bwd_wy_dqkg(
         dg=torch.empty_like(g),
         db=torch.empty_like(beta),
         dA=torch.empty_like(A, dtype=torch.float32),
-        cu_seqlens=cu_seqlens,
-        chunk_indices=chunk_indices,
+        cu_seqlens=metadata.cu_seqlens,
+        chunk_indices=metadata.chunk_indices,
         chunk_size=chunk_size,
         fastmath=fastmath,
     )

--- a/attn_gym/linear/kda/bwd/triton/chunk_kda_bwd_dav.py
+++ b/attn_gym/linear/kda/bwd/triton/chunk_kda_bwd_dav.py
@@ -19,6 +19,7 @@ from triton.tools.tensor_descriptor import TensorDescriptor
 
 from attn_gym._backends.triton.utils import can_use_tma, ptr_offset, requires_int64_offsets
 from attn_gym.linear.kda.utils import (
+    ChunkMetadata,
     autotune_cache_kwargs,
 )
 
@@ -198,8 +199,9 @@ def chunk_kda_bwd_dav(
     scale: float,
     *,
     chunk_size: int = 64,
+    metadata: ChunkMetadata | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Differentiate the fixed-length KDA intra-chunk value term."""
+    """Differentiate the fixed-length or packed KDA intra-chunk value term."""
     batch, tokens, heads, value_dim = v.shape
     if tokens % chunk_size:
         raise ValueError(f"the KDA dAv kernel requires complete chunks, got T={tokens}")
@@ -212,7 +214,11 @@ def chunk_kda_bwd_dav(
     dA = torch.empty_like(A, dtype=torch.float32)
     chunks = tokens // chunk_size
     block_value_dim = 64
-    if (value_dim, chunk_size) == (128, 64) and _can_use_tensor_descriptors(v, A, do, dv, dA):
+    if (
+        metadata is None
+        and (value_dim, chunk_size) == (128, 64)
+        and _can_use_tensor_descriptors(v, A, do, dv, dA)
+    ):
         chunk_kda_bwd_kernel_dAv[(chunks, batch * heads)](
             v=TensorDescriptor.from_tensor(v, [1, chunk_size, 1, block_value_dim]),
             A=TensorDescriptor.from_tensor(A, [1, chunk_size, 1, chunk_size]),
@@ -236,9 +242,9 @@ def chunk_kda_bwd_dav(
             do=do,
             dv=dv,
             dA=dA,
-            cu_seqlens=None,
-            chunk_indices=None,
-            num_chunks=None,
+            cu_seqlens=None if metadata is None else metadata.cu_seqlens,
+            chunk_indices=None if metadata is None else metadata.chunk_indices,
+            num_chunks=None if metadata is None else metadata.num_chunks,
             scale=scale,
             T=tokens,
             H=heads,

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py
@@ -1,4 +1,4 @@
-"""Composed fixed-length Blackwell KDA core forward."""
+"""Composed fixed-length and packed Blackwell KDA core forward."""
 
 from __future__ import annotations
 
@@ -9,6 +9,7 @@ import torch
 from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd_intra import chunk_kda_fwd_intra
 from attn_gym.linear.kda.fwd.triton.chunk_delta_h import chunk_gated_delta_rule_fwd_h
 from attn_gym.linear.kda.fwd.triton.chunk_gla_fwd_o import chunk_gla_fwd_o_gk
+from attn_gym.linear.kda.utils import ChunkMetadata, prepare_complete_chunk_indices
 
 _SUPPORTED_INPUT_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
 # TODO: Revisit model-approved chunk sizes: this is a major performance lever,
@@ -24,6 +25,7 @@ def _validate_chunk_kda_inputs(
     cumulative_gate: torch.Tensor,
     beta: torch.Tensor,
     initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
 ) -> None:
     """Validate the exported operation's contract before normalizing inputs."""
     if q.ndim != 4:
@@ -43,17 +45,26 @@ def _validate_chunk_kda_inputs(
         )
     if beta.shape != (batch, tokens, heads):
         raise ValueError(f"beta must have shape {(batch, tokens, heads)}, got {tuple(beta.shape)}")
-    expected_state = (batch, heads, head_dim, v.shape[-1])
+    if cu_seqlens is not None:
+        if batch != 1:
+            raise ValueError("packed cu_seqlens require q to have batch size one")
+        if cu_seqlens.ndim != 1 or cu_seqlens.shape[0] < 2:
+            raise ValueError("cu_seqlens must have shape [num_sequences + 1]")
+        if cu_seqlens.dtype != torch.int32 or not cu_seqlens.is_contiguous():
+            raise ValueError("cu_seqlens must be contiguous CUDA int32")
+    state_batch = batch if cu_seqlens is None else cu_seqlens.shape[0] - 1
+    expected_state = (state_batch, heads, head_dim, v.shape[-1])
     if initial_state is not None and initial_state.shape != expected_state:
         raise ValueError(
             f"initial_state must have shape {expected_state}, got {tuple(initial_state.shape)}"
         )
-    tensors = (q, k, v, cumulative_gate, beta)
+    data_tensors = (q, k, v, cumulative_gate, beta)
     if initial_state is not None:
-        tensors += (initial_state,)
+        data_tensors += (initial_state,)
+    tensors = data_tensors if cu_seqlens is None else (*data_tensors, cu_seqlens)
     if not all(tensor.is_cuda and tensor.device == q.device for tensor in tensors):
         raise ValueError("all chunk_kda inputs must be CUDA tensors on the same device")
-    if any(tensor.dtype not in _SUPPORTED_INPUT_DTYPES for tensor in tensors):
+    if any(tensor.dtype not in _SUPPORTED_INPUT_DTYPES for tensor in data_tensors):
         supported = ", ".join(str(dtype) for dtype in _SUPPORTED_INPUT_DTYPES)
         raise TypeError(f"chunk_kda inputs must use one of {supported}")
     if batch != 1 or head_dim != _HEAD_DIM:
@@ -87,11 +98,22 @@ def _validate_private_abi(
         raise ValueError("the CuTe KDA core requires CUDA capability 10.0 or newer")
 
 
-def _fixed_chunk_metadata(q: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Construct the fixed-length metadata required by legacy recompute kernels."""
+def _chunk_metadata(
+    q: torch.Tensor,
+    cu_seqlens: torch.Tensor | None,
+) -> ChunkMetadata:
+    """Construct the internal work map while preserving the caller's layout mode."""
     tokens = q.shape[1]
     chunks = tokens // _CHUNK_SIZE
-    cu_seqlens = torch.arange(2, dtype=torch.int32, device=q.device) * tokens
+    num_chunks = torch.full((), chunks, dtype=torch.int32, device=q.device)
+    if cu_seqlens is not None:
+        return ChunkMetadata(
+            cu_seqlens,
+            prepare_complete_chunk_indices(cu_seqlens, tokens, _CHUNK_SIZE),
+            num_chunks,
+        )
+
+    fixed_cu_seqlens = torch.arange(2, dtype=torch.int32, device=q.device) * tokens
     chunk_indices = torch.stack(
         (
             torch.zeros(chunks, dtype=torch.int32, device=q.device),
@@ -99,7 +121,7 @@ def _fixed_chunk_metadata(q: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, 
         ),
         dim=1,
     )
-    return cu_seqlens, chunk_indices, torch.full((), chunks, dtype=torch.int32, device=q.device)
+    return ChunkMetadata(fixed_cu_seqlens, chunk_indices, num_chunks)
 
 
 def _chunk_kda_fwd(
@@ -109,6 +131,7 @@ def _chunk_kda_fwd(
     cumulative_gate: torch.Tensor,
     beta: torch.Tensor,
     initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
     *,
     output_final_state: bool,
     profile_ranges: bool,
@@ -121,8 +144,8 @@ def _chunk_kda_fwd(
     torch.Tensor,
     torch.Tensor,
 ]:
-    """Run the optimized fixed-length KDA core and return its minimal backward tape."""
-    cu_seqlens, chunk_indices, num_chunks = _fixed_chunk_metadata(q)
+    """Run the optimized KDA core and return its minimal backward tape."""
+    metadata = _chunk_metadata(q, cu_seqlens)
     scale = _HEAD_DIM**-0.5
 
     def record(name: str):
@@ -136,9 +159,7 @@ def _chunk_kda_fwd(
             cumulative_gate,
             beta,
             scale,
-            cu_seqlens,
-            chunk_indices,
-            num_chunks,
+            metadata,
             chunk_size=_CHUNK_SIZE,
             profile_ranges=profile_ranges,
         )
@@ -151,6 +172,7 @@ def _chunk_kda_fwd(
             initial_state,
             chunk_size=_CHUNK_SIZE,
             output_final_state=output_final_state,
+            cu_seqlens=metadata.cu_seqlens if metadata.has_multiple_sequences else None,
         )
     with record("kda/triton/output_composition"):
         output = chunk_gla_fwd_o_gk(
@@ -161,8 +183,20 @@ def _chunk_kda_fwd(
             h,
             scale,
             chunk_size=_CHUNK_SIZE,
+            metadata=metadata if metadata.has_multiple_sequences else None,
         )
-    return output, final_state, Aqk, Akk, cu_seqlens, chunk_indices, num_chunks
+    backward_cu_seqlens = (
+        metadata.cu_seqlens.new_empty(0) if cu_seqlens is not None else metadata.cu_seqlens
+    )
+    return (
+        output,
+        final_state,
+        Aqk,
+        Akk,
+        backward_cu_seqlens,
+        metadata.chunk_indices,
+        metadata.num_chunks,
+    )
 
 
 @torch.library.custom_op("attn_gym::kda_chunk_fwd", mutates_args=())
@@ -173,6 +207,7 @@ def _chunk_kda_fwd_custom_op(
     cumulative_gate: torch.Tensor,
     beta: torch.Tensor,
     initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
     output_final_state: bool,
     fastmath: bool,
     profile_ranges: bool,
@@ -187,7 +222,6 @@ def _chunk_kda_fwd_custom_op(
 ]:
     """Keep the complete composed forward behind one compiler-opaque boundary."""
     del fastmath  # This static option configures the registered backward.
-    _validate_chunk_kda_inputs(q, k, v, cumulative_gate, beta, initial_state)
     _validate_private_abi(q, k, v, cumulative_gate, beta, initial_state)
     output, final_state, Aqk, Akk, cu_seqlens, chunk_indices, num_chunks = _chunk_kda_fwd(
         q,
@@ -196,6 +230,7 @@ def _chunk_kda_fwd_custom_op(
         cumulative_gate,
         beta,
         initial_state,
+        cu_seqlens,
         output_final_state=output_final_state,
         profile_ranges=profile_ranges,
     )
@@ -211,6 +246,7 @@ def _chunk_kda_fwd_fake(
     cumulative_gate: torch.Tensor,
     beta: torch.Tensor,
     initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
     output_final_state: bool,
     fastmath: bool,
     profile_ranges: bool,
@@ -226,8 +262,9 @@ def _chunk_kda_fwd_fake(
     """Describe the composed forward outputs without invoking a launcher."""
     del k, cumulative_gate, beta, initial_state, fastmath, profile_ranges
     batch, tokens, heads, head_dim = q.shape
+    state_batch = batch if cu_seqlens is None else cu_seqlens.shape[0] - 1
     state = (
-        q.new_empty((batch, heads, head_dim, v.shape[-1]), dtype=torch.float32)
+        q.new_empty((state_batch, heads, head_dim, v.shape[-1]), dtype=torch.float32)
         if output_final_state
         else q.new_empty((0,), dtype=torch.float32)
     )
@@ -238,7 +275,7 @@ def _chunk_kda_fwd_fake(
         state,
         q.new_empty(tape_shape),
         q.new_empty(tape_shape),
-        q.new_empty((2,), dtype=torch.int32),
+        q.new_empty((0 if cu_seqlens is not None else 2,), dtype=torch.int32),
         q.new_empty((chunks, 2), dtype=torch.int32),
         q.new_empty((), dtype=torch.int32),
     )
@@ -278,9 +315,7 @@ def _chunk_kda_bwd_custom_op(
         d_output.contiguous(),
         None if d_final_state is None else d_final_state.float().contiguous(),
         initial_state,
-        cu_seqlens,
-        chunk_indices,
-        num_chunks,
+        ChunkMetadata(cu_seqlens, chunk_indices, num_chunks),
         fastmath=fastmath,
         profile_ranges=profile_ranges,
     )
@@ -343,11 +378,13 @@ def _setup_chunk_kda_context(ctx, inputs, output) -> None:
         cumulative_gate,
         beta,
         initial_state,
+        _input_cu_seqlens,
         output_final_state,
         fastmath,
         profile_ranges,
     ) = inputs
     _output, state, Aqk, Akk, cu_seqlens, chunk_indices, num_chunks = output
+    backward_cu_seqlens = cu_seqlens if _input_cu_seqlens is None else _input_cu_seqlens
     ctx.save_for_backward(
         q,
         k,
@@ -357,7 +394,7 @@ def _setup_chunk_kda_context(ctx, inputs, output) -> None:
         Aqk,
         Akk,
         initial_state,
-        cu_seqlens,
+        backward_cu_seqlens,
         chunk_indices,
         num_chunks,
     )
@@ -421,6 +458,7 @@ def _chunk_kda_backward(
         None,
         None,
         None,
+        None,
     )
 
 
@@ -438,16 +476,18 @@ def chunk_kda(
     beta: torch.Tensor,
     initial_state: torch.Tensor | None = None,
     *,
+    cu_seqlens: torch.Tensor | None = None,
     output_final_state: bool = False,
     fastmath: bool = False,
     profile_ranges: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
-    """Apply the graph-capturable, first-order, fixed-length Blackwell KDA core.
+    """Apply the graph-capturable, first-order Blackwell KDA core.
 
-    The output uses ``q.dtype``. The recurrent state remains FP32 so streamed
-    execution does not repeatedly quantize the accumulated state.
+    ``cu_seqlens`` selects packed ``[1, T, H, D]`` execution. Every packed
+    sequence must contain complete 64-token chunks. The output uses ``q.dtype``;
+    recurrent states remain FP32 and have one leading entry per logical sequence.
     """
-    _validate_chunk_kda_inputs(q, k, v, cumulative_gate, beta, initial_state)
+    _validate_chunk_kda_inputs(q, k, v, cumulative_gate, beta, initial_state, cu_seqlens)
     output_dtype = q.dtype
     q, k, v = (tensor.to(torch.bfloat16).contiguous() for tensor in (q, k, v))
     cumulative_gate = cumulative_gate.float().contiguous()
@@ -461,6 +501,7 @@ def chunk_kda(
         cumulative_gate,
         beta,
         initial_state,
+        cu_seqlens,
         output_final_state,
         fastmath,
         profile_ranges,

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_intra.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_intra.py
@@ -24,7 +24,7 @@ from attn_gym.linear.kda.fwd.cute.recompute_w_u_fwd import recompute_w_u_fwd
 from attn_gym.linear.kda.fwd.triton.chunk_kda_fwd_intra_sub_chunk_forloop import (
     chunk_kda_fwd_kernel_intra_sub_chunk_forloop,
 )
-from attn_gym.linear.kda.utils import DEFAULT_CHUNK_SIZE, IS_GATHER_SUPPORTED
+from attn_gym.linear.kda.utils import DEFAULT_CHUNK_SIZE, IS_GATHER_SUPPORTED, ChunkMetadata
 
 
 def chunk_kda_fwd_intra(
@@ -34,9 +34,7 @@ def chunk_kda_fwd_intra(
     gk: torch.Tensor,
     beta: torch.Tensor,
     scale: float,
-    recompute_cu_seqlens: torch.LongTensor,
-    recompute_chunk_indices: torch.LongTensor,
-    recompute_num_chunks: torch.Tensor,
+    metadata: ChunkMetadata,
     chunk_size: int = DEFAULT_CHUNK_SIZE,
     profile_ranges: bool = False,
 ) -> tuple[
@@ -82,9 +80,9 @@ def chunk_kda_fwd_intra(
                 Aqk=Aqk,
                 Akk=Akkd,
                 scale=scale,
-                cu_seqlens=None,
-                chunk_indices=None,
-                num_chunks=None,
+                cu_seqlens=metadata.cu_seqlens if metadata.has_multiple_sequences else None,
+                chunk_indices=metadata.chunk_indices if metadata.has_multiple_sequences else None,
+                num_chunks=metadata.num_chunks if metadata.has_multiple_sequences else None,
                 T=T,
                 H=H,
                 K=K,
@@ -107,9 +105,9 @@ def chunk_kda_fwd_intra(
             beta=beta,
             Akkd=Akkd,
             scale=scale,
-            cu_seqlens=None,
+            cu_seqlens=metadata.cu_seqlens if metadata.has_multiple_sequences else None,
             chunk_size=BT,
-            chunk_indices=None,
+            chunk_indices=metadata.chunk_indices if metadata.has_multiple_sequences else None,
             Aqk=Aqk,
             profile_ranges=profile_ranges,
         )
@@ -125,9 +123,7 @@ def chunk_kda_fwd_intra(
             beta=beta,
             A=Akk,
             gk=gk,
-            cu_seqlens=recompute_cu_seqlens,
-            chunk_indices=recompute_chunk_indices,
-            num_chunks=recompute_num_chunks,
+            metadata=metadata,
         )
     assert w is not None and kg is not None
     return w, u, kg, Aqk, Akk

--- a/attn_gym/linear/kda/fwd/cute/recompute_w_u_fwd.py
+++ b/attn_gym/linear/kda/fwd/cute/recompute_w_u_fwd.py
@@ -67,6 +67,7 @@ from torch._subclasses.fake_tensor import FakeTensor
 
 from attn_gym._backends.cute import compile_tvm_ffi, jit_cache
 from attn_gym._backends.cute.target import get_compile_target
+from attn_gym.linear.kda.utils import ChunkMetadata
 
 # ============================================================================
 # Constants
@@ -1586,11 +1587,9 @@ def recompute_w_u_fwd(
     v: torch.Tensor,
     beta: torch.Tensor,
     A: torch.Tensor,
+    metadata: ChunkMetadata,
     q: torch.Tensor | None = None,
     gk: torch.Tensor | None = None,
-    cu_seqlens: torch.Tensor | None = None,
-    chunk_indices: torch.Tensor | None = None,
-    num_chunks: torch.Tensor | None = None,
     chunk_size: int = BT,
     dot_precision: str | MmaPrecision = "bf16",
     experimental_prefetch: bool = True,
@@ -1606,8 +1605,8 @@ def recompute_w_u_fwd(
     Recompute KDA W/U intermediates on the native CuTe path.
 
     Supported scope: varlen B=1, full chunks, chunk_size=64, K=V=128. The
-    caller must provide cu_seqlens, chunk_indices, and num_chunks. num_chunks is
-    a CUDA scalar tensor read by the kernel at runtime, not specialized by
+    caller must provide chunk metadata. Its num_chunks field is a CUDA scalar
+    tensor read by the kernel at runtime, not specialized by
     value, which keeps padded CUDA graph replay from recompiling when the active
     chunk count changes.
 
@@ -1650,7 +1649,9 @@ def recompute_w_u_fwd(
     V = v.shape[3]
     device = k.device
     assert B == 1, f"recompute_w_u_fwd requires B=1, got B={B}"
-    assert cu_seqlens is not None, "recompute_w_u_fwd requires cu_seqlens (varlen path only)"
+    cu_seqlens = metadata.cu_seqlens
+    chunk_indices = metadata.chunk_indices
+    num_chunks = metadata.num_chunks
     assert T % BT == 0, f"recompute_w_u_fwd requires T % BT == 0 (T={T}, BT={BT})"
     assert K == KEY_DIM, f"recompute_w_u_fwd requires head_dim K={KEY_DIM}, got {K}"
     assert V == VAL_DIM, f"recompute_w_u_fwd requires head_dim V={VAL_DIM}, got {V}"

--- a/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
@@ -796,8 +796,9 @@ def chunk_gated_delta_rule_fwd_h(
     *,
     chunk_size: int = 64,
     output_final_state: bool = True,
+    cu_seqlens: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
-    """Run the fixed-length inter-chunk KDA state recurrence."""
+    """Run the fixed-length or packed inter-chunk KDA state recurrence."""
     batch, tokens, heads, key_dim = k.shape
     value_dim = u.shape[-1]
     if tokens % chunk_size:
@@ -810,7 +811,10 @@ def chunk_gated_delta_rule_fwd_h(
         raise ValueError("k, w, and gk must have the same shape")
     if u.shape != (batch, tokens, heads, value_dim):
         raise ValueError("u must have shape [B, T, H, V]")
-    expected_state_shape = (batch, heads, key_dim, value_dim)
+    if cu_seqlens is not None and batch != 1:
+        raise ValueError("packed cu_seqlens require batch size one")
+    state_batch = batch if cu_seqlens is None else cu_seqlens.shape[0] - 1
+    expected_state_shape = (state_batch, heads, key_dim, value_dim)
     if initial_state is not None:
         if initial_state.shape != expected_state_shape:
             raise ValueError(
@@ -829,7 +833,7 @@ def chunk_gated_delta_rule_fwd_h(
     )
 
     def grid(meta):
-        return (batch * heads, triton.cdiv(value_dim, meta["BV"]))
+        return (state_batch * heads, triton.cdiv(value_dim, meta["BV"]))
 
     chunk_gated_delta_rule_fwd_kernel_h_blockdim64[grid](
         k=k,
@@ -841,8 +845,8 @@ def chunk_gated_delta_rule_fwd_h(
         h=h,
         h0=initial_state,
         ht=final_state,
-        cu_seqlens=None,
-        chunk_offsets=None,
+        cu_seqlens=cu_seqlens,
+        chunk_offsets=None if cu_seqlens is None else cu_seqlens // chunk_size,
         num_seqs=None,
         T=tokens,
         H=heads,

--- a/attn_gym/linear/kda/fwd/triton/chunk_gla_fwd_o.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_gla_fwd_o.py
@@ -18,6 +18,7 @@ from triton.tools.tensor_descriptor import TensorDescriptor
 
 from attn_gym._backends.triton.utils import can_use_tma, ptr_offset, requires_int64_offsets
 from attn_gym.linear.kda.utils import (
+    ChunkMetadata,
     autotune_cache_kwargs,
     exp,
     exp2,
@@ -220,8 +221,9 @@ def chunk_gla_fwd_o_gk(
     scale: float,
     *,
     chunk_size: int = 64,
+    metadata: ChunkMetadata | None = None,
 ) -> torch.Tensor:
-    """Compose fixed-length KDA intra- and inter-chunk output terms."""
+    """Compose fixed-length or packed KDA intra- and inter-chunk output terms."""
     batch, tokens, heads, key_dim = q.shape
     value_dim = v.shape[-1]
     if tokens % chunk_size:
@@ -240,8 +242,10 @@ def chunk_gla_fwd_o_gk(
         raise ValueError(f"h must have shape {expected_h_shape}, got {tuple(h.shape)}")
 
     output = torch.empty_like(v)
-    if (key_dim, value_dim, chunk_size) == (128, 128, 64) and _can_use_tensor_descriptors(
-        q, v, g, h, output, A
+    if (
+        metadata is None
+        and (key_dim, value_dim, chunk_size) == (128, 128, 64)
+        and _can_use_tensor_descriptors(q, v, g, h, output, A)
     ):
         block_key_dim = 32
         block_value_dim = 64
@@ -280,9 +284,9 @@ def chunk_gla_fwd_o_gk(
             h=h,
             o=output,
             A=A,
-            cu_seqlens=None,
-            chunk_indices=None,
-            num_chunks=None,
+            cu_seqlens=None if metadata is None else metadata.cu_seqlens,
+            chunk_indices=None if metadata is None else metadata.chunk_indices,
+            num_chunks=None if metadata is None else metadata.num_chunks,
             scale=scale,
             T=tokens,
             H=heads,

--- a/attn_gym/linear/kda/naive.py
+++ b/attn_gym/linear/kda/naive.py
@@ -109,7 +109,8 @@ def naive_chunk_kda_from_cumulative(
     ``beta: [B,T,H]``. ``cumulative_g`` must reset at each ``chunk_size``
     boundary and use the same chunk size passed here. Unlike
     :func:`naive_chunk_kda`, this function does not apply another cumulative
-    sum. Internal math runs in FP32 and outputs use ``q.dtype``. Gradient-enabled
+    sum. Internal math runs in FP32, or FP64 when ``q`` is FP64, and outputs use
+    ``q.dtype``. Gradient-enabled
     execution checkpoints each chunk so the stable pairwise decay does not retain
     ``[B, H, chunks, chunk_size, chunk_size, K]`` intermediates.
     """
@@ -135,9 +136,12 @@ def naive_chunk_kda_from_cumulative(
         raise ValueError(f"chunk_size must be a positive int, got {chunk_size!r}")
 
     output_dtype = q.dtype
+    compute_dtype = torch.promote_types(q.dtype, torch.float32)
     scale = key_dim**-0.5 if scale is None else scale
-    q, k, v, cumulative_g = (tensor.transpose(1, 2).float() for tensor in (q, k, v, cumulative_g))
-    beta = beta.transpose(1, 2).float()
+    q, k, v, cumulative_g = (
+        tensor.transpose(1, 2).to(compute_dtype) for tensor in (q, k, v, cumulative_g)
+    )
+    beta = beta.transpose(1, 2).to(compute_dtype)
     pad = (-tokens) % chunk_size
     if pad:
         q, k, v = (F.pad(tensor, (0, 0, 0, pad)) for tensor in (q, k, v))
@@ -156,12 +160,12 @@ def naive_chunk_kda_from_cumulative(
     strict_upper = torch.triu(
         torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=q.device), 1
     )
-    eye = torch.eye(chunk_size, dtype=torch.float, device=q.device)
+    eye = torch.eye(chunk_size, dtype=compute_dtype, device=q.device)
     value_dim = v.shape[-1]
     state = (
         q.new_zeros(batch, heads, key_dim, value_dim)
         if initial_state is None
-        else initial_state.float()
+        else initial_state.to(compute_dtype)
     )
     outputs = []
     for index in range(chunks):

--- a/attn_gym/linear/kda/utils.py
+++ b/attn_gym/linear/kda/utils.py
@@ -24,7 +24,7 @@ from collections import deque
 from collections.abc import Callable
 from enum import Enum
 from functools import cache, lru_cache
-from typing import Any
+from typing import Any, NamedTuple
 
 import torch
 import torch.nn.functional as F
@@ -475,6 +475,57 @@ def chunk_local_cumsum_reference(
 # ---------------------------------------------------------------------------
 # Varlen chunk indexing
 # ---------------------------------------------------------------------------
+class ChunkMetadata(NamedTuple):
+    """Internal launch metadata; public callers provide only ``cu_seqlens``.
+
+    ``chunk_indices`` maps global work IDs to sequence-local chunks, while the device
+    ``num_chunks`` scalar lets persistent kernels replay without a host transfer.
+    """
+
+    cu_seqlens: torch.Tensor
+    chunk_indices: torch.Tensor
+    num_chunks: torch.Tensor
+
+    @property
+    def has_multiple_sequences(self) -> bool:
+        """Return whether kernels must honor an internal sequence boundary."""
+        return self.cu_seqlens.shape[0] > 2
+
+
+def prepare_complete_chunk_indices(
+    cu_seqlens: torch.Tensor,
+    tokens: int,
+    chunk_size: int,
+) -> torch.Tensor:
+    """Validate and map complete physical chunks to packed sequence-local indices."""
+    torch._assert_async(cu_seqlens[0] == 0, "cu_seqlens must start at zero")
+    torch._assert_async(cu_seqlens[-1] == tokens, "cu_seqlens must end at T")
+    torch._assert_async(
+        torch.all(cu_seqlens[1:] >= cu_seqlens[:-1]),
+        "cu_seqlens must be nondecreasing",
+    )
+    torch._assert_async(
+        torch.all(torch.remainder(cu_seqlens, chunk_size) == 0),
+        "each packed sequence must contain complete chunks",
+    )
+    chunk_starts = (
+        torch.arange(
+            tokens // chunk_size,
+            dtype=torch.int32,
+            device=cu_seqlens.device,
+        )
+        * chunk_size
+    )
+    sequence_indices = torch.searchsorted(cu_seqlens[1:], chunk_starts, right=True).to(torch.int32)
+    return torch.stack(
+        (
+            sequence_indices,
+            (chunk_starts - cu_seqlens[sequence_indices]) // chunk_size,
+        ),
+        dim=1,
+    )
+
+
 @tensor_cache(maxsize=10)
 def prepare_lens(cu_seqlens: torch.LongTensor) -> torch.LongTensor:
     return torch.diff(cu_seqlens)

--- a/test/test_kda_cute_forward.py
+++ b/test/test_kda_cute_forward.py
@@ -60,6 +60,50 @@ def _clone_inputs(inputs):
     return tuple(tensor.detach().clone().requires_grad_(tensor.requires_grad) for tensor in inputs)
 
 
+def _assert_golden(
+    actual: torch.Tensor,
+    golden: torch.Tensor,
+    reference: torch.Tensor,
+    dtype: torch.dtype,
+    name: str,
+) -> None:
+    """Bound kernel error by the reference error and operand precision."""
+    golden64 = golden.to(torch.float64)
+    band = torch.finfo(dtype).eps * golden64.abs().max().item()
+    actual_error = (actual.to(torch.float64) - golden64).abs().max().item()
+    reference_error = (reference.to(torch.float64) - golden64).abs().max().item()
+    budget = 2.0 * reference_error + 2.0 * band
+    assert actual_error <= budget, (
+        f"{name}: kernel error {actual_error:.3e} exceeds budget {budget:.3e} "
+        f"(reference error {reference_error:.3e}, band {band:.3e}, dtype {dtype})"
+    )
+
+
+def _packed_reference(
+    inputs: tuple[torch.Tensor, ...],
+    spans: tuple[tuple[int, int], ...],
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Evaluate packed sequences independently with the naive implementation."""
+    q, k, v, cumulative_gate, beta, initial_state = inputs
+    outputs = []
+    states = []
+    for sequence, (start, end) in enumerate(spans):
+        output, state = naive_chunk_kda_from_cumulative(
+            q[:, start:end],
+            k[:, start:end],
+            v[:, start:end],
+            cumulative_gate[:, start:end],
+            beta[:, start:end],
+            initial_state=initial_state[sequence : sequence + 1],
+            output_final_state=True,
+            chunk_size=64,
+        )
+        outputs.append(output)
+        assert state is not None
+        states.append(state)
+    return torch.cat(outputs, dim=1), torch.cat(states)
+
+
 def test_optimized_chunk_kda_matches_reference():
     """Check forward values and the isolated final-state cotangent path."""
     torch.manual_seed(3)
@@ -96,6 +140,83 @@ def test_optimized_chunk_kda_matches_reference():
         error = (actual_gradient.float() - expected_gradient).abs().max()
         tolerance = 5e-3 + 5e-3 * expected_gradient.abs().max()
         assert error <= tolerance
+
+
+def test_optimized_chunk_kda_packed_matches_independent_sequences():
+    """Keep packed sequence boundaries first-class through forward and backward."""
+    torch.manual_seed(13)
+    inputs = _inputs(tokens=192, heads=2, initial_state=True)
+    q, k, v, cumulative_gate, beta, _initial_state = inputs
+    initial_state = torch.randn(2, 2, 128, 128, device="cuda", requires_grad=True) * 0.01
+    inputs = (q, k, v, cumulative_gate, beta, initial_state)
+    cu_seqlens = torch.tensor([0, 64, 192], device="cuda", dtype=torch.int32)
+
+    output, state = chunk_kda(
+        *inputs,
+        cu_seqlens=cu_seqlens,
+        output_final_state=True,
+    )
+    assert state is not None and state.shape == (2, 2, 128, 128)
+
+    spans = ((0, 64), (64, 192))
+    reference_inputs = (q.float(), k.float(), v.float(), cumulative_gate, beta, initial_state)
+    expected_output, expected_state = _packed_reference(reference_inputs, spans)
+    golden_inputs = tuple(tensor.detach().double().requires_grad_() for tensor in inputs)
+    golden_output, golden_state = _packed_reference(golden_inputs, spans)
+
+    _assert_golden(output, golden_output, expected_output, torch.bfloat16, "packed output")
+    _assert_golden(state, golden_state, expected_state, torch.bfloat16, "packed state")
+    d_output = torch.randn_like(output)
+    d_state = torch.randn_like(state)
+    actual_gradients = torch.autograd.grad((output, state), inputs, (d_output, d_state))
+    expected_gradients = torch.autograd.grad(
+        (expected_output, expected_state),
+        inputs,
+        (d_output.float(), d_state),
+    )
+    golden_gradients = torch.autograd.grad(
+        (golden_output, golden_state),
+        golden_inputs,
+        (d_output.double(), d_state.double()),
+    )
+    for index, (actual_gradient, golden_gradient, expected_gradient) in enumerate(
+        zip(actual_gradients, golden_gradients, expected_gradients, strict=True)
+    ):
+        _assert_golden(
+            actual_gradient,
+            golden_gradient,
+            expected_gradient,
+            torch.bfloat16,
+            f"packed input gradient {index}",
+        )
+
+
+def test_chunk_kda_single_sequence_metadata_matches_dense_path():
+    """Treat caller-provided ``[0, T]`` metadata as the dense degenerate case."""
+    torch.manual_seed(17)
+    dense_inputs = _inputs(tokens=128, heads=2, initial_state=True)
+    explicit_inputs = _clone_inputs(dense_inputs)
+
+    dense_output, dense_state = chunk_kda(*dense_inputs, output_final_state=True)
+    explicit_output, explicit_state = chunk_kda(
+        *explicit_inputs,
+        cu_seqlens=torch.tensor([0, 128], device="cuda", dtype=torch.int32),
+        output_final_state=True,
+    )
+    assert dense_state is not None and explicit_state is not None
+    torch.testing.assert_close(explicit_output, dense_output, rtol=0, atol=0)
+    torch.testing.assert_close(explicit_state, dense_state, rtol=0, atol=0)
+
+    d_output = torch.randn_like(dense_output)
+    d_state = torch.randn_like(dense_state)
+    dense_gradients = torch.autograd.grad(
+        (dense_output, dense_state), dense_inputs, (d_output, d_state)
+    )
+    explicit_gradients = torch.autograd.grad(
+        (explicit_output, explicit_state), explicit_inputs, (d_output, d_state)
+    )
+    for explicit_gradient, dense_gradient in zip(explicit_gradients, dense_gradients, strict=True):
+        torch.testing.assert_close(explicit_gradient, dense_gradient, rtol=0, atol=0)
 
 
 def test_optimized_chunk_kda_autograd_without_initial_state():
@@ -226,6 +347,38 @@ def test_backward_tuning_configs(monkeypatch, attribute, kernel, config_type):
             torch.testing.assert_close(candidate, expected, rtol=0, atol=0)
 
 
+def test_delta_h_dispatch_counts_packed_sequences(monkeypatch):
+    """Choose BV from logical rather than physical packed batch size."""
+    dispatch = importlib.import_module(
+        "attn_gym.linear.kda.bwd.cute.chunk_delta_h_bwd_v1_dispatch"
+    )
+    captured = {}
+    result = tuple(torch.empty(0, device="cuda") for _ in range(3))
+
+    def fake_delta_h(**kwargs):
+        captured["bv"] = kwargs["bv"]
+        return result
+
+    class DeviceProperties:
+        multi_processor_count = 100
+
+    monkeypatch.setattr(dispatch, "blackwell_delta_h_bwd_dhu_v1", fake_delta_h)
+    monkeypatch.setattr(torch.cuda, "get_device_properties", lambda _device: DeviceProperties())
+    tensor = torch.empty(1, 1, 2, 128, device="cuda")
+    cu_seqlens = torch.arange(8, dtype=torch.int32, device="cuda")
+    actual = dispatch.blackwell_delta_h_bwd_dhu_dispatch(
+        tensor,
+        tensor,
+        tensor,
+        tensor,
+        tensor,
+        cu_seqlens=cu_seqlens,
+    )
+
+    assert actual is result
+    assert captured["bv"] == 32
+
+
 def test_chunk_kda_custom_op_registration():
     """Validate schema, fake tensors, autograd registration, and AOT dispatch."""
     torch.manual_seed(5)
@@ -239,6 +392,7 @@ def test_chunk_kda_custom_op_registration():
             cumulative_gate,
             beta,
             initial_state,
+            None,
             True,
             False,
             False,
@@ -260,6 +414,7 @@ def test_chunk_kda_backward_custom_op_registration():
             cumulative_gate,
             beta,
             initial_state,
+            None,
             True,
             False,
             False,
@@ -335,6 +490,30 @@ def test_chunk_kda_fullgraph_forward_and_backward(dtype, initial_state, output_f
         torch.testing.assert_close(actual_gradient, expected_gradient)
 
 
+def test_chunk_kda_packed_fullgraph_forward_and_backward():
+    """Keep packed metadata inside the strict compiled forward and backward graph."""
+    torch.manual_seed(17)
+    eager_inputs = _inputs(tokens=128, heads=2)
+    compiled_inputs = _clone_inputs(eager_inputs)
+    cu_seqlens = torch.tensor([0, 64, 128], device="cuda", dtype=torch.int32)
+
+    def operation(*args):
+        return chunk_kda(*args, cu_seqlens=cu_seqlens)[0]
+
+    expected = operation(*eager_inputs)
+    actual = torch.compile(operation, fullgraph=True)(*compiled_inputs)
+    torch.testing.assert_close(actual, expected)
+    d_output = torch.randn_like(expected)
+    expected_gradients = torch.autograd.grad(expected, eager_inputs, d_output)
+    actual_gradients = torch.autograd.grad(actual, compiled_inputs, d_output)
+    for actual_gradient, expected_gradient in zip(
+        actual_gradients,
+        expected_gradients,
+        strict=True,
+    ):
+        torch.testing.assert_close(actual_gradient, expected_gradient)
+
+
 def test_chunk_kda_reduce_overhead_backward():
     """Keep CUDA Graph warmup allocations local to the compiled invocation."""
     inputs = _inputs(heads=2)
@@ -389,6 +568,36 @@ def test_chunk_kda_cuda_graph_replay():
     assert not torch.equal(state, captured_state)
     torch.testing.assert_close(output, expected_output)
     torch.testing.assert_close(state, expected_state)
+    for actual_gradient, expected_gradient in zip(gradients, expected_gradients, strict=True):
+        torch.testing.assert_close(actual_gradient, expected_gradient)
+
+
+def test_chunk_kda_packed_cuda_graph_replays_boundaries_and_backward():
+    """Replay packed metadata and gradients without capture-time host transfers."""
+    torch.manual_seed(23)
+    inputs = _inputs(tokens=192, heads=2)
+    cu_seqlens = torch.tensor([0, 64, 192], device="cuda", dtype=torch.int32)
+    warm_output, _ = chunk_kda(*inputs, cu_seqlens=cu_seqlens)
+    warm_gradients = torch.autograd.grad(warm_output.float().sum(), inputs)
+    del warm_output, warm_gradients
+    gc.collect()
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        output, _ = chunk_kda(*inputs, cu_seqlens=cu_seqlens)
+        gradients = torch.autograd.grad(output.float().sum(), inputs)
+
+    with torch.no_grad():
+        inputs[2].mul_(0.5)
+        cu_seqlens.copy_(torch.tensor([0, 128, 192], device="cuda", dtype=torch.int32))
+    expected_inputs = _clone_inputs(inputs)
+    expected_output, _ = chunk_kda(*expected_inputs, cu_seqlens=cu_seqlens)
+    expected_gradients = torch.autograd.grad(expected_output.float().sum(), expected_inputs)
+    graph.replay()
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(output, expected_output)
     for actual_gradient, expected_gradient in zip(gradients, expected_gradients, strict=True):
         torch.testing.assert_close(actual_gradient, expected_gradient)
 

--- a/test/test_kda_cute_recompute.py
+++ b/test/test_kda_cute_recompute.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 import torch
 
-from attn_gym.linear.kda.utils import prepare_chunk_indices
+from attn_gym.linear.kda.utils import ChunkMetadata, prepare_chunk_indices
 
 pytest.importorskip("cutlass")
 
@@ -32,7 +32,11 @@ def test_recompute_ignores_upper_triangle_and_reuses_compilation(tmp_path, monke
     A = A.tril().masked_fill(torch.ones_like(A, dtype=torch.bool).triu(1), torch.nan).unsqueeze(2)
     cu_seqlens = torch.tensor([0, 64], device="cuda", dtype=torch.int32)
     chunk_indices = prepare_chunk_indices(cu_seqlens, 64)
-    num_chunks = torch.tensor(1, device="cuda", dtype=torch.int32)
+    metadata = ChunkMetadata(
+        cu_seqlens,
+        chunk_indices,
+        torch.tensor(1, device="cuda", dtype=torch.int32),
+    )
 
     def run_recompute():
         return recompute_w_u_fwd(
@@ -40,9 +44,7 @@ def test_recompute_ignores_upper_triangle_and_reuses_compilation(tmp_path, monke
             v,
             beta,
             A,
-            cu_seqlens=cu_seqlens,
-            chunk_indices=chunk_indices,
-            num_chunks=num_chunks,
+            metadata=metadata,
         )
 
     w, u, _, _ = run_recompute()


### PR DESCRIPTION
## Human Note

## Agent note

Make caller-owned `cu_seqlens` a first-class input to the composed Blackwell KDA operator. Build
complete-chunk work metadata on the device, carry logical sequence boundaries through every forward
and backward stage, and size recurrent states by logical sequence while retaining the existing dense
fast paths. The initial contract deliberately requires each sequence length to be a multiple of 64;
ragged final chunks remain a follow-up.

## Test Plan

```bash
gpu-run --timeout 120 auto -- env PYTHONPATH=$PWD TORCH_CUSTOM_PYTHONPATH=$PWD TORCHINDUCTOR_CACHE_DIR=/tmp/kda-cu-seqlen-simplified /home/drisspg/.venvs/nightly/bin/pytest -q test/test_kda_cute_forward.py
prek run --files attn_gym/linear/kda/utils.py attn_gym/linear/kda/bwd/cute/chunk_delta_h_bwd_v1_dispatch.py attn_gym/linear/kda/bwd/cute/chunk_kda_bwd.py attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_intra.py attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_wy_dqkg_fused.py attn_gym/linear/kda/bwd/triton/chunk_kda_bwd_dav.py attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_intra.py attn_gym/linear/kda/fwd/triton/chunk_delta_h.py attn_gym/linear/kda/fwd/triton/chunk_gla_fwd_o.py test/test_kda_cute_forward.py
git diff --check
```

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>