### PR TITLE
Generalize packed TMA short-convolution backward

### DIFF
--- a/attn_gym/linear/kda/short_conv/cute.py
+++ b/attn_gym/linear/kda/short_conv/cute.py
@@ -77,30 +77,23 @@ class ShortConvTunedConfig:
                 forward = ShortConvConfig(128, 4, 16)
                 match packed, stateful:
                     case True, _:
-                        gradients = ShortConvConfig(128, 4, 6), ShortConvConfig(128, 4, 128)
-                    case False, True:
-                        gradients = ShortConvConfig(128, 1, 28), ShortConvConfig(128, 4, 128)
-                    case False, False:
+                        gradients = ShortConvConfig(128, 4, 16), ShortConvConfig(128, 2, 32)
+                    case False, _:
                         gradients = ShortConvConfig(128, 2, 32), ShortConvConfig(128, 2, 64)
             case torch.bfloat16:
                 forward = ShortConvConfig(128, 4, 16)
                 match packed, stateful:
-                    case True, False:
+                    case True, _:
                         gradients = ShortConvConfig(128, 4, 16), ShortConvConfig(128, 2, 32)
-                    case True, True:
-                        gradients = ShortConvConfig(128, 4, 10), ShortConvConfig(128, 4, 128)
-                    case False, True:
-                        gradients = ShortConvConfig(128, 1, 28), ShortConvConfig(128, 4, 128)
-                    case False, False:
+                    case False, _:
                         gradients = ShortConvConfig(128, 2, 32), ShortConvConfig(128, 2, 64)
             case torch.float32:
                 forward = ShortConvConfig(128, 4, 4)
-                gradients = (
-                    ShortConvConfig(128, 2, 12),
-                    ShortConvConfig(128, 4, 32)
-                    if packed or stateful
-                    else ShortConvConfig(128, 2, 160),
-                )
+                match packed, stateful:
+                    case True, _:
+                        gradients = ShortConvConfig(128, 2, 16), ShortConvConfig(128, 4, 32)
+                    case False, _:
+                        gradients = ShortConvConfig(128, 2, 12), ShortConvConfig(128, 2, 160)
             case _:
                 raise ValueError(f"unsupported short-convolution dtype {dtype}")
         return cls(forward, *gradients)
@@ -846,6 +839,44 @@ class ShortConvTmaKernel:
             history[(None, self.width - 2)].store(current.load())
 
     @cute.jit
+    def initialize_history(
+        self,
+        history: cute.Tensor,
+        x: cute.Tensor,
+        initial_state: cute.Tensor | None,
+        sequence: Int32,
+        sequence_start: Int32,
+        output_time: Int32,
+        batch: Int32,
+        channel_group: Int32,
+    ):
+        """Initialize a convolution window from physical input, state, or zeros."""
+        history.fill(self.dtype.cute_type(0.0))
+        x_groups = cute.zipped_divide(x, (1, self.channels_per_thread))
+        initial_groups = initial_state
+        if cutlass.const_expr(initial_state is not None):
+            initial_groups = cute.zipped_divide(initial_state, (1, self.channels_per_thread))
+        for history_offset in cutlass.range_constexpr(self.width - 1):
+            history_time = output_time + history_offset - (self.width - 1)
+            if history_time >= sequence_start:
+                history[(None, history_offset)].store(
+                    x_groups[
+                        ((0, None), (batch * self.tokens + history_time, channel_group))
+                    ].load()
+                )
+            elif cutlass.const_expr(initial_state is not None):
+                history[(None, history_offset)].store(
+                    load_history(
+                        initial_groups,
+                        sequence,
+                        history_time,
+                        sequence_start,
+                        channel_group,
+                        self.width,
+                    ).to(self.dtype.cute_type)
+                )
+
+    @cute.jit
     def make_pipeline(
         self,
         tidx: Int32,
@@ -1098,6 +1129,7 @@ class CausalConv1dSiluInputGradientTma(
         grad_output: cute.Tensor,
         grad_x: cute.Tensor,
         cu_seqlens: cute.Tensor | None,
+        initial_state: cute.Tensor | None,
         tma_atom_x: cute.CopyAtom,
         tma_tensor_x: cute.Tensor,
         tma_atom_dy: cute.CopyAtom,
@@ -1176,14 +1208,26 @@ class CausalConv1dSiluInputGradientTma(
             for channel_offset in cutlass.range_constexpr(self.channels_per_thread):
                 for tap in cutlass.range_constexpr(self.width):
                     weights[channel_offset, tap] = Float32(weight[channel + channel_offset, tap])
-            for history_offset in cutlass.range_constexpr(self.width - 1):
-                history_time = time_start + history_offset - (self.width - 1)
-                if history_time >= sequence_start:
-                    history[(None, history_offset)].store(
-                        x_groups[
-                            ((0, None), (batch * self.tokens + history_time, channel_group))
-                        ].load()
-                    )
+            if cutlass.const_expr(initial_state is None):
+                for history_offset in cutlass.range_constexpr(self.width - 1):
+                    history_time = time_start + history_offset - (self.width - 1)
+                    if history_time >= sequence_start:
+                        history[(None, history_offset)].store(
+                            x_groups[
+                                ((0, None), (batch * self.tokens + history_time, channel_group))
+                            ].load()
+                        )
+            else:
+                self.initialize_history(
+                    history,
+                    x,
+                    initial_state,
+                    sequence,
+                    sequence_start,
+                    Int32(time_start),
+                    Int32(batch),
+                    Int32(channel_group),
+                )
 
         for subtile in cutlass.range_constexpr(subtiles):
             tile_pipeline.consumer_wait(consumer_state)
@@ -1224,7 +1268,19 @@ class CausalConv1dSiluInputGradientTma(
                                     Int32(time_start),
                                     previous_sequence_start,
                                 )
-                                history.fill(self.dtype.cute_type(0.0))
+                                if cutlass.const_expr(initial_state is None):
+                                    history.fill(self.dtype.cute_type(0.0))
+                                else:
+                                    self.initialize_history(
+                                        history,
+                                        x,
+                                        initial_state,
+                                        sequence,
+                                        sequence_start,
+                                        Int32(output_time),
+                                        Int32(batch),
+                                        Int32(channel_group),
+                                    )
                                 grad_z.fill(Float32(0.0))
                         current.store(sX_groups[((0, None, 0), (slot, tidx, stage))].load())
                         incoming.store(
@@ -1338,7 +1394,6 @@ class CausalConv1dSiluInputGradientTma(
         stream,
     ):
         """Build TMA descriptors and launch the boundary-aware streaming specialization."""
-        assert cutlass.const_expr(initial_state is None)
         tma_atom_x, tma_tensor_x, tma_atom_dy, tma_tensor_dy = self.make_tma_atoms(
             x,
             grad_output,
@@ -1349,6 +1404,7 @@ class CausalConv1dSiluInputGradientTma(
             grad_output,
             grad_x,
             cu_seqlens,
+            initial_state,
             tma_atom_x,
             tma_tensor_x,
             tma_atom_dy,
@@ -1379,6 +1435,7 @@ class CausalConv1dSiluWeightGradientPartialsTma(
         grad_output: cute.Tensor,
         partials: cute.Tensor,
         cu_seqlens: cute.Tensor | None,
+        initial_state: cute.Tensor | None,
         tma_atom_x: cute.CopyAtom,
         tma_tensor_x: cute.Tensor,
         tma_atom_dy: cute.CopyAtom,
@@ -1453,21 +1510,38 @@ class CausalConv1dSiluWeightGradientPartialsTma(
             for channel_offset in cutlass.range_constexpr(self.channels_per_thread):
                 for tap in cutlass.range_constexpr(self.width):
                     weights[channel_offset, tap] = Float32(weight[channel + channel_offset, tap])
-            for history_offset in cutlass.range_constexpr(self.width - 1):
-                history_time = time_start + history_offset - (self.width - 1)
-                if history_time >= sequence_start:
-                    if cutlass.const_expr(self.dtype.name == "fp32"):
-                        for channel_offset in cutlass.range_constexpr(self.channels_per_thread):
-                            history[channel_offset, history_offset] = x[
-                                batch * self.tokens + history_time,
-                                channel + channel_offset,
-                            ]
-                    else:
-                        history[(None, history_offset)].store(
-                            x_groups[
-                                ((0, None), (batch * self.tokens + history_time, channel_group))
-                            ].load()
-                        )
+            if cutlass.const_expr(initial_state is None):
+                for history_offset in cutlass.range_constexpr(self.width - 1):
+                    history_time = time_start + history_offset - (self.width - 1)
+                    if history_time >= sequence_start:
+                        if cutlass.const_expr(self.dtype.name == "fp32"):
+                            for channel_offset in cutlass.range_constexpr(
+                                self.channels_per_thread
+                            ):
+                                history[channel_offset, history_offset] = x[
+                                    batch * self.tokens + history_time,
+                                    channel + channel_offset,
+                                ]
+                        else:
+                            history[(None, history_offset)].store(
+                                x_groups[
+                                    (
+                                        (0, None),
+                                        (batch * self.tokens + history_time, channel_group),
+                                    )
+                                ].load()
+                            )
+            else:
+                self.initialize_history(
+                    history,
+                    x,
+                    initial_state,
+                    sequence,
+                    sequence_start,
+                    Int32(time_start),
+                    Int32(batch),
+                    Int32(channel_group),
+                )
 
         for subtile in cutlass.range_constexpr(subtiles):
             tile_pipeline.consumer_wait(consumer_state)
@@ -1486,7 +1560,19 @@ class CausalConv1dSiluWeightGradientPartialsTma(
                                 Int32(time),
                             )
                             if sequence != previous_sequence:
-                                history.fill(self.dtype.cute_type(0.0))
+                                if cutlass.const_expr(initial_state is None):
+                                    history.fill(self.dtype.cute_type(0.0))
+                                else:
+                                    self.initialize_history(
+                                        history,
+                                        x,
+                                        initial_state,
+                                        sequence,
+                                        sequence_start,
+                                        Int32(time),
+                                        Int32(batch),
+                                        Int32(channel_group),
+                                    )
                         current = cute.make_rmem_tensor(
                             (self.channels_per_thread,),
                             self.dtype.cute_type,
@@ -1571,7 +1657,6 @@ class CausalConv1dSiluWeightGradientPartialsTma(
         stream,
     ):
         """Build TMA descriptors and launch the boundary-aware staged specialization."""
-        assert cutlass.const_expr(initial_state is None)
         tma_atom_x, tma_tensor_x, tma_atom_dy, tma_tensor_dy = self.make_tma_atoms(
             x,
             grad_output,
@@ -1582,6 +1667,7 @@ class CausalConv1dSiluWeightGradientPartialsTma(
             grad_output,
             partials,
             cu_seqlens,
+            initial_state,
             tma_atom_x,
             tma_tensor_x,
             tma_atom_dy,
@@ -1842,7 +1928,6 @@ def supports_tma(
     channels: int,
     width: int,
     num_sequences: int | None,
-    has_initial_state: bool,
     *,
     packed_supported: bool = False,
 ) -> bool:
@@ -1854,7 +1939,6 @@ def supports_tma(
         and config.times_per_block % operation_type.tma_stage_tokens == 0
         and tokens % operation_type.tma_stage_tokens == 0
         and (num_sequences is None or packed_supported)
-        and not has_initial_state
     )
 
 
@@ -1874,14 +1958,13 @@ def _compile_input_gradient(
         CausalConv1dSiluInputGradientTma,
         config,
         None
-        if dtype.name == "fp32"
+        if dtype.name == "fp32" and num_sequences is None
         else tuned_config(dtype, packed=num_sequences is not None).input_gradient,
         tokens,
         channels,
         width,
         num_sequences,
-        has_initial_state,
-        packed_supported=dtype.name == "bf16",
+        packed_supported=True,
     )
     operation_type = CausalConv1dSiluInputGradientTma if use_tma else CausalConv1dSiluInputGradient
     operation = operation_type(batches, tokens, channels, width, config, dtype, _silu_derivative)
@@ -1929,8 +2012,7 @@ def _compile_weight_gradient(
         channels,
         width,
         num_sequences,
-        has_initial_state,
-        packed_supported=dtype.name == "bf16",
+        packed_supported=True,
     )
     operation_type = (
         CausalConv1dSiluWeightGradientPartialsTma
@@ -2170,9 +2252,12 @@ def _candidate_configs(
     kind: str,
     channels: int,
     dtype: torch.dtype = torch.bfloat16,
+    *,
+    packed: bool = False,
+    stateful: bool = False,
 ) -> tuple[ShortConvConfig, ...]:
     """Return the focused schedule space used by the explicit tuning flow."""
-    defaults = ShortConvTunedConfig.default(dtype)
+    defaults = ShortConvTunedConfig.default(dtype, packed=packed, stateful=stateful)
     if kind == "forward":
         default = defaults.forward
         candidates = (
@@ -2252,8 +2337,12 @@ def tune_causal_conv1d_silu(
     kernel_initial_state = None if width == 1 else initial_state
     state_matrix = None if kernel_initial_state is None else kernel_initial_state.flatten(0, 1)
 
+    candidate_kwargs = {
+        "packed": cu_seqlens is not None,
+        "stateful": kernel_initial_state is not None,
+    }
     forward_candidates = tuple(
-        _candidate_configs("forward", channels, x.dtype)
+        _candidate_configs("forward", channels, x.dtype, **candidate_kwargs)
         if forward_configs is None
         else forward_configs
     )
@@ -2284,7 +2373,7 @@ def tune_causal_conv1d_silu(
     )
 
     input_candidates = tuple(
-        _candidate_configs("input_gradient", channels, x.dtype)
+        _candidate_configs("input_gradient", channels, x.dtype, **candidate_kwargs)
         if input_grad_configs is None
         else input_grad_configs
     )
@@ -2311,7 +2400,7 @@ def tune_causal_conv1d_silu(
     )
 
     weight_candidates = tuple(
-        _candidate_configs("weight_gradient", channels, x.dtype)
+        _candidate_configs("weight_gradient", channels, x.dtype, **candidate_kwargs)
         if weight_grad_configs is None
         else weight_grad_configs
     )

--- a/test/test_kda_short_conv_cute.py
+++ b/test/test_kda_short_conv_cute.py
@@ -109,26 +109,66 @@ def test_short_conv_dtype_defaults_follow_measured_storage_traffic():
     assert fp16.weight_gradient == ShortConvConfig(128, 2, 64)
     assert bf16.input_gradient == ShortConvConfig(128, 2, 32)
     assert bf16.weight_gradient == ShortConvConfig(128, 2, 64)
-    assert ShortConvTunedConfig.default(stateful=True).input_gradient == ShortConvConfig(
-        128, 1, 28
-    )
-    assert ShortConvTunedConfig.default(
-        torch.float16,
-        stateful=True,
-    ).input_gradient == ShortConvConfig(128, 1, 28)
+    assert ShortConvTunedConfig.default(stateful=True) == bf16
+    assert ShortConvTunedConfig.default(torch.float16, stateful=True) == fp16
+    packed_fp16 = ShortConvTunedConfig.default(torch.float16, packed=True)
     packed = ShortConvTunedConfig.default(packed=True)
+    packed_fp32 = ShortConvTunedConfig.default(torch.float32, packed=True)
+    assert packed_fp16.input_gradient == ShortConvConfig(128, 4, 16)
+    assert packed_fp16.weight_gradient == ShortConvConfig(128, 2, 32)
     assert packed.input_gradient == ShortConvConfig(128, 4, 16)
     assert packed.weight_gradient == ShortConvConfig(128, 2, 32)
+    assert packed_fp32.input_gradient == ShortConvConfig(128, 2, 16)
+    assert packed_fp32.weight_gradient == ShortConvConfig(128, 4, 32)
+    packed_stateful = ShortConvTunedConfig.default(packed=True, stateful=True)
+    assert packed_stateful.input_gradient == packed.input_gradient
+    assert packed_stateful.weight_gradient == packed.weight_gradient
     assert ShortConvTunedConfig.default(
-        packed=True, stateful=True
-    ).input_gradient == ShortConvConfig(128, 4, 10)
+        torch.float16, packed=True, stateful=True
+    ) == ShortConvTunedConfig.default(torch.float16, packed=True)
+    assert ShortConvTunedConfig.default(
+        torch.float32, packed=True, stateful=True
+    ) == ShortConvTunedConfig.default(torch.float32, packed=True)
     assert fp32.forward == ShortConvConfig(128, 4, 4)
     assert fp32.input_gradient == ShortConvConfig(128, 2, 12)
     assert fp32.weight_gradient == ShortConvConfig(128, 2, 160)
-    assert ShortConvTunedConfig.default(
-        torch.float32,
-        stateful=True,
-    ).weight_gradient == ShortConvConfig(128, 4, 32)
+    assert ShortConvTunedConfig.default(torch.float32, stateful=True) == fp32
+
+    for dtype in (torch.float16, torch.bfloat16, torch.float32):
+        defaults = ShortConvTunedConfig.default(dtype, packed=True, stateful=True)
+        assert defaults.input_gradient in _candidate_configs(
+            "input_gradient", 512, dtype, packed=True, stateful=True
+        )
+        assert defaults.weight_gradient in _candidate_configs(
+            "weight_gradient", 512, dtype, packed=True, stateful=True
+        )
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_short_conv_packed_defaults_select_tma(dtype: torch.dtype):
+    """Keep the production packed defaults on the staged implementation."""
+    defaults = ShortConvTunedConfig.default(dtype, packed=True, stateful=True)
+    descriptor = cute_backend.SHORT_CONV_DTYPES[dtype]
+    assert cute_backend.supports_tma(
+        cute_backend.CausalConv1dSiluInputGradientTma,
+        defaults.input_gradient,
+        cute_backend.tuned_config(descriptor, packed=True).input_gradient,
+        384,
+        512,
+        4,
+        7,
+        packed_supported=True,
+    )
+    assert cute_backend.supports_tma(
+        cute_backend.CausalConv1dSiluWeightGradientPartialsTma,
+        defaults.weight_gradient,
+        cute_backend.tuned_config(descriptor, packed=True).weight_gradient,
+        384,
+        512,
+        4,
+        7,
+        packed_supported=True,
+    )
 
 
 @pytest.mark.parametrize(
@@ -290,10 +330,31 @@ def test_short_conv_tma_backward_matches_batched_reference(
     )
 
 
-def test_short_conv_packed_tma_backward_matches_fallback():
+def test_short_conv_tma_input_gradient_wider_than_time_tile():
+    """Keep each CTA's tail writes inside its owned tile when width exceeds that tile."""
+    torch.manual_seed(11)
+    x, weight = _inputs(tokens=64, channels=256, width=40, batch=2)
+    grad_output = torch.randn_like(x)
+    expected = _reference(x, weight)
+    (expected_dx,) = torch.autograd.grad(expected, (x,), grad_output)
+
+    defaults = ShortConvTunedConfig.default()
+    actual_dx = cute_backend._launch_backward(
+        x,
+        weight,
+        grad_output,
+        defaults.input_gradient,
+        ShortConvConfig(128, 4, 128),
+    )[0]
+
+    torch.testing.assert_close(actual_dx, expected_dx, rtol=3e-2, atol=3e-2)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_short_conv_packed_tma_backward_matches_fallback(dtype: torch.dtype):
     """Stage physical tiles while resetting both gradients at arbitrary boundaries."""
     torch.manual_seed(8)
-    x, weight = _inputs(tokens=384, channels=512, width=4)
+    x, weight = _inputs(tokens=384, channels=512, width=4, dtype=dtype)
     grad_output = torch.randn_like(x)
     cu_seqlens = torch.tensor(
         [0, 0, 3, 17, 18, 129, 257, 384],
@@ -314,12 +375,123 @@ def test_short_conv_packed_tma_backward_matches_fallback():
         cu_seqlens,
     )
 
-    torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
-    torch.testing.assert_close(actual_gradients[0], expected_gradients[0], rtol=3e-2, atol=3e-2)
-    torch.testing.assert_close(actual_gradients[1], expected_gradients[1], rtol=3e-2, atol=2e-1)
-    # The staged and generic kernels differ only in their FP32 addition order.
-    torch.testing.assert_close(actual_gradients[0], fallback_gradients[0], rtol=1e-4, atol=1e-4)
-    torch.testing.assert_close(actual_gradients[1], fallback_gradients[1], rtol=1e-4, atol=1e-4)
+    tolerance = 1e-4 if dtype == torch.float32 else 3e-2
+    weight_atol = 2e-4 if dtype == torch.float32 else 2e-1
+    torch.testing.assert_close(actual, expected, rtol=tolerance, atol=tolerance)
+    torch.testing.assert_close(
+        actual_gradients[0], expected_gradients[0], rtol=tolerance, atol=tolerance
+    )
+    torch.testing.assert_close(
+        actual_gradients[1], expected_gradients[1], rtol=tolerance, atol=weight_atol
+    )
+    torch.testing.assert_close(
+        actual_gradients[0], fallback_gradients[0], rtol=tolerance, atol=tolerance
+    )
+    torch.testing.assert_close(
+        actual_gradients[1], fallback_gradients[1], rtol=tolerance, atol=weight_atol
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_short_conv_dense_stateful_tma_backward_matches_reference(dtype: torch.dtype):
+    """Use caller history in aligned dense TMA input- and weight-gradient tiles."""
+    torch.manual_seed(12)
+    x, weight = _inputs(tokens=384, channels=256, width=4, batch=2, dtype=dtype)
+    initial_state = torch.randn(2, 3, 256, device="cuda", dtype=dtype, requires_grad=True)
+    reference_state = initial_state.detach().clone().requires_grad_()
+    grad_output = torch.randn_like(x)
+
+    actual = cute_causal_conv1d_silu(x, weight, initial_state=initial_state)
+    expected_input = torch.cat((reference_state, x), dim=1)
+    expected = F.silu(
+        F.conv1d(expected_input.transpose(1, 2), weight[:, None], groups=256)
+    ).transpose(1, 2)
+    actual_gradients = torch.autograd.grad(actual, (x, weight, initial_state), grad_output)
+    expected_gradients = torch.autograd.grad(expected, (x, weight, reference_state), grad_output)
+
+    tolerance = 1e-4 if dtype == torch.float32 else 3e-2
+    weight_atol = 2e-4 if dtype == torch.float32 else 2e-1
+    torch.testing.assert_close(actual, expected, rtol=tolerance, atol=tolerance)
+    for index, (actual_gradient, expected_gradient) in enumerate(
+        zip(actual_gradients, expected_gradients, strict=True)
+    ):
+        torch.testing.assert_close(
+            actual_gradient,
+            expected_gradient,
+            rtol=tolerance,
+            atol=weight_atol if index == 1 else tolerance,
+        )
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_short_conv_packed_stateful_tma_backward_matches_reference_and_fallback(
+    dtype: torch.dtype,
+):
+    """Seed every packed TMA convolution window from caller-owned sequence history."""
+    torch.manual_seed(9)
+    x, weight = _inputs(tokens=384, channels=512, width=4, dtype=dtype)
+    grad_output = torch.randn_like(x)
+    cu_seqlens = torch.tensor(
+        [0, 0, 3, 17, 18, 129, 257, 384],
+        device="cuda",
+        dtype=torch.int32,
+    )
+    initial_state = torch.randn(
+        cu_seqlens.shape[0] - 1,
+        weight.shape[1] - 1,
+        x.shape[2],
+        device="cuda",
+        dtype=dtype,
+        requires_grad=True,
+    )
+    reference_state = initial_state.detach().clone().requires_grad_()
+
+    actual = cute_causal_conv1d_silu(
+        x,
+        weight,
+        cu_seqlens=cu_seqlens,
+        initial_state=initial_state,
+    )
+    expected, _ = _packed_state_reference(x, weight, cu_seqlens, reference_state)
+    actual_gradients = torch.autograd.grad(
+        actual,
+        (x, weight, initial_state),
+        grad_output,
+    )
+    expected_gradients = torch.autograd.grad(
+        expected,
+        (x, weight, reference_state),
+        grad_output,
+    )
+    fallback_gradients = cute_backend._launch_backward(
+        x,
+        weight,
+        grad_output,
+        ShortConvConfig(128, 4, 10),
+        ShortConvConfig(64, 4, 128),
+        cu_seqlens,
+        initial_state,
+    )
+
+    tolerance = 1e-4 if dtype == torch.float32 else 3e-2
+    weight_atol = 2e-4 if dtype == torch.float32 else 2e-1
+    torch.testing.assert_close(actual, expected, rtol=tolerance, atol=tolerance)
+    for index, (actual_gradient, expected_gradient, fallback_gradient) in enumerate(
+        zip(actual_gradients, expected_gradients, fallback_gradients, strict=True)
+    ):
+        atol = weight_atol if index == 1 else tolerance
+        torch.testing.assert_close(
+            actual_gradient,
+            expected_gradient,
+            rtol=tolerance,
+            atol=atol,
+        )
+        torch.testing.assert_close(
+            actual_gradient,
+            fallback_gradient,
+            rtol=tolerance,
+            atol=atol,
+        )
 
 
 @pytest.mark.parametrize("width", [3, 4])
@@ -1089,3 +1261,61 @@ def test_short_conv_packed_tma_cuda_graph_replays_changed_boundaries():
     expected_gradients = _backward_custom_op(x, weight, grad_output, cu_seqlens)
     torch.testing.assert_close(captured_gradients[0], expected_gradients[0])
     torch.testing.assert_close(captured_gradients[1], expected_gradients[1])
+
+
+def test_short_conv_packed_stateful_tma_cuda_graph_replays_boundaries_and_history():
+    """Reread arbitrary boundaries and caller history in packed TMA backward replay."""
+    x, weight = _inputs(tokens=384, channels=512)
+    grad_output = torch.randn_like(x)
+    cu_seqlens = torch.tensor(
+        [0, 0, 3, 17, 129, 257, 384],
+        device="cuda",
+        dtype=torch.int32,
+    )
+    initial_state = torch.randn(
+        cu_seqlens.shape[0] - 1,
+        weight.shape[1] - 1,
+        x.shape[2],
+        device="cuda",
+        dtype=x.dtype,
+    )
+    defaults = ShortConvTunedConfig.default(x.dtype, packed=True, stateful=True)
+    config = (
+        defaults.input_gradient.threads,
+        defaults.input_gradient.channels_per_thread,
+        defaults.input_gradient.times_per_block,
+        defaults.weight_gradient.threads,
+        defaults.weight_gradient.channels_per_thread,
+        defaults.weight_gradient.times_per_block,
+    )
+    _configured_backward_custom_op(
+        x, weight, grad_output, cu_seqlens, initial_state, True, *config
+    )
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_gradients = _configured_backward_custom_op(
+            x, weight, grad_output, cu_seqlens, initial_state, True, *config
+        )
+
+    first_gradients = tuple(gradient.clone() for gradient in captured_gradients)
+    with torch.no_grad():
+        initial_state.add_(0.25)
+        cu_seqlens.copy_(
+            torch.tensor([0, 1, 8, 31, 130, 300, 384], device="cuda", dtype=torch.int32)
+        )
+    graph.replay()
+    torch.cuda.synchronize()
+
+    assert not torch.equal(captured_gradients[0], first_gradients[0])
+    assert not torch.equal(captured_gradients[1], first_gradients[1])
+    expected_gradients = _configured_backward_custom_op(
+        x, weight, grad_output, cu_seqlens, initial_state, True, *config
+    )
+    for actual_gradient, expected_gradient in zip(
+        captured_gradients,
+        expected_gradients,
+        strict=True,
+    ):
+        torch.testing.assert_close(actual_gradient, expected_gradient)

--- a/test/test_kda_short_conv_cute.py
+++ b/test/test_kda_short_conv_cute.py
@@ -384,11 +384,22 @@ def test_short_conv_packed_tma_backward_matches_fallback(dtype: torch.dtype):
     torch.testing.assert_close(
         actual_gradients[1], expected_gradients[1], rtol=tolerance, atol=weight_atol
     )
+
+    # TMA changes only the FP32 addition order relative to the generic kernels.
+    match dtype:
+        case torch.float16:
+            fallback_rtol, input_atol, weight_atol = 1e-4, 2e-3, 8e-3
+        case torch.bfloat16:
+            fallback_rtol, input_atol, weight_atol = 1e-4, 1e-4, 1e-4
+        case torch.float32:
+            fallback_rtol, input_atol, weight_atol = 1e-6, 5e-6, 2e-5
+        case _:
+            raise AssertionError(f"unexpected dtype {dtype}")
     torch.testing.assert_close(
-        actual_gradients[0], fallback_gradients[0], rtol=tolerance, atol=tolerance
+        actual_gradients[0], fallback_gradients[0], rtol=fallback_rtol, atol=input_atol
     )
     torch.testing.assert_close(
-        actual_gradients[1], fallback_gradients[1], rtol=tolerance, atol=weight_atol
+        actual_gradients[1], fallback_gradients[1], rtol=fallback_rtol, atol=weight_atol
     )
 
 


### PR DESCRIPTION
## Human Note

aplly to the rest

## Agent note

Generalize the arbitrary-boundary packed TMA backward path from BF16 stateless execution to FP16,
FP32, and caller-owned convolution state. Both TMA gradients now initialize their raw-input history
from physical input or per-sequence state at CTA starts and packed boundaries; the existing dedicated
state-gradient kernel remains responsible for `dinitial_state`.

Make TMA selection depend on physical transfer legality and the measured schedule rather than dtype
or state mode. The generic kernels remain available for width 1, partial channel tiles, total token
counts not divisible by eight, and incompatible explicit schedules. Preserve the stateless dense BF16
specializations byte-for-byte and include packed/stateful defaults in the explicit tuning candidates.

## Performance

On GB300 at B1/T16384/C12288/W4 with fixed-pointer CUDA Graph replay:

| Mode | Fallback backward | TMA backward |
| --- | ---: | ---: |
| Packed FP16 | 999.81 us | 512.45 us |
| Packed BF16 | 875.02 us | 556.38 us |
| Packed FP32 | 1152.42 us | 678.19 us |
| Packed stateful FP16 | 940.74 us | 555.89 us |
| Packed stateful BF16 | 941.30 us | 560.42 us |
| Packed stateful FP32 | 1190.26 us | 710.85 us |

Under the matched differentiable-state contract, including returned final state and gradients through
both outputs, CuTeDSL is 2.00x faster than FLA 0.5.2 forward and 2.11x faster backward for packed
uniform-64. FLA's chunk-map construction is excluded.

## Test Plan

```bash
gpu-run --timeout 600 2 -- env PYTHONPATH=$PWD \
  TORCHINDUCTOR_CACHE_DIR=/tmp/kda-varlen-final2-full-i \
  CUTE_DSL_CACHE_DIR=/tmp/kda-varlen-final2-full-c \
  /home/drisspg/.venvs/nightly/bin/pytest -q test/test_kda_short_conv_cute.py
# 71 passed

compute-sanitizer --tool memcheck  --report-api-errors no --error-exitcode 99 \
  /home/drisspg/.venvs/nightly/bin/python agent_space/check_packed_tma_sanitizer.py
compute-sanitizer --tool racecheck --report-api-errors no --error-exitcode 99 \
  /home/drisspg/.venvs/nightly/bin/python agent_space/check_packed_tma_sanitizer.py
compute-sanitizer --tool initcheck --report-api-errors no --error-exitcode 99 \
  /home/drisspg/.venvs/nightly/bin/python agent_space/check_packed_tma_sanitizer.py
compute-sanitizer --tool synccheck --report-api-errors no --error-exitcode 99 \
  /home/drisspg/.venvs/nightly/bin/python agent_space/check_packed_tma_sanitizer.py

prek run --all-files
git diff --check
```

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
