### PR TITLE
Simplify TMA short-convolution predicates

### DIFF
--- a/attn_gym/linear/kda/short_conv/cute.py
+++ b/attn_gym/linear/kda/short_conv/cute.py
@@ -1040,11 +1040,10 @@ class CausalConv1dSiluInputGradientTma(
             reduction_profile=(None, 1),
         )
         input_time = output_time - (self.width - 1)
-        if (
-            input_time >= time_start
-            and input_time < self.tokens
-            and (cutlass.const_expr(not packed) or input_time >= sequence_start)
-        ):
+        owns_input = input_time >= time_start and input_time < self.tokens
+        if cutlass.const_expr(packed):
+            owns_input = owns_input and input_time >= sequence_start
+        if owns_input:
             grad_x_groups[((0, None), (batch * self.tokens + input_time, channel_group))].store(
                 dx_value.to(self.dtype.cute_type)
             )

--- a/attn_gym/linear/kda/short_conv/cute.py
+++ b/attn_gym/linear/kda/short_conv/cute.py
@@ -1246,17 +1246,13 @@ class CausalConv1dSiluInputGradientTma(
                     current.fill(self.dtype.cute_type(0.0))
                     incoming.fill(Float32(0.0))
                     if output_time < self.tokens:
-                        if cutlass.const_expr(cu_seqlens is not None):
-                            previous_sequence = sequence
-                            previous_sequence_start = sequence_start
-                            sequence, sequence_start, sequence_end = advance_sequence_bounds(
-                                cu_seqlens,
-                                sequence,
-                                sequence_start,
-                                sequence_end,
-                                Int32(output_time),
-                            )
-                            if sequence != previous_sequence:
+                        if cutlass.const_expr(cu_seqlens is not None):  # noqa: SIM102
+                            if output_time >= sequence_end:
+                                previous_sequence_start = sequence_start
+                                sequence, sequence_start, sequence_end = sequence_bounds(
+                                    cu_seqlens,
+                                    Int32(output_time),
+                                )
                                 self.flush_mainloop_sequence(
                                     grad_z,
                                     weights,
@@ -1321,7 +1317,6 @@ class CausalConv1dSiluInputGradientTma(
 
         if channel < self.channels:
             # A boundary in the lookahead belongs to the next CTA; zero-fill this CTA's tail.
-            tail_finished = Int32(0)
             for tail in cutlass.range_constexpr(self.width - 1):
                 output_offset = self.times_per_block + tail
                 output_time = time_start + output_offset
@@ -1335,36 +1330,20 @@ class CausalConv1dSiluInputGradientTma(
                 )
                 current.fill(self.dtype.cute_type(0.0))
                 incoming.fill(Float32(0.0))
-                if output_time < self.tokens and tail_finished == 0:
-                    if cutlass.const_expr(cu_seqlens is not None):
-                        next_sequence, next_start, next_end = advance_sequence_bounds(
-                            cu_seqlens,
-                            sequence,
-                            sequence_start,
-                            sequence_end,
-                            Int32(output_time),
-                        )
-                        if next_sequence != sequence:
-                            tail_finished = Int32(1)
-                        else:
-                            sequence, sequence_start, sequence_end = (
-                                next_sequence,
-                                next_start,
-                                next_end,
-                            )
-                    if tail_finished == 0:
-                        current.store(
-                            x_groups[
-                                ((0, None), (batch * self.tokens + output_time, channel_group))
-                            ].load()
-                        )
-                        incoming.store(
-                            dy_groups[
-                                ((0, None), (batch * self.tokens + output_time, channel_group))
-                            ]
-                            .load()
-                            .to(Float32)
-                        )
+                has_input = output_time < self.tokens
+                if cutlass.const_expr(cu_seqlens is not None):
+                    has_input = has_input and output_time < sequence_end
+                if has_input:
+                    current.store(
+                        x_groups[
+                            ((0, None), (batch * self.tokens + output_time, channel_group))
+                        ].load()
+                    )
+                    incoming.store(
+                        dy_groups[((0, None), (batch * self.tokens + output_time, channel_group))]
+                        .load()
+                        .to(Float32)
+                    )
                 self.advance_token(
                     current,
                     incoming,
@@ -1549,16 +1528,12 @@ class CausalConv1dSiluWeightGradientPartialsTma(
                 for slot in cutlass.range_constexpr(stage_tokens):
                     time = time_start + subtile * stage_tokens + slot
                     if time < self.tokens:
-                        if cutlass.const_expr(cu_seqlens is not None):
-                            previous_sequence = sequence
-                            sequence, sequence_start, sequence_end = advance_sequence_bounds(
-                                cu_seqlens,
-                                sequence,
-                                sequence_start,
-                                sequence_end,
-                                Int32(time),
-                            )
-                            if sequence != previous_sequence:
+                        if cutlass.const_expr(cu_seqlens is not None):  # noqa: SIM102
+                            if time >= sequence_end:
+                                sequence, sequence_start, sequence_end = sequence_bounds(
+                                    cu_seqlens,
+                                    Int32(time),
+                                )
                                 if cutlass.const_expr(initial_state is None):
                                     history.fill(self.dtype.cute_type(0.0))
                                 else:

--- a/attn_gym/linear/kda/short_conv/cute.py
+++ b/attn_gym/linear/kda/short_conv/cute.py
@@ -796,6 +796,22 @@ class ShortConvTmaKernel:
     stages = 2
     tma_stage_tokens = 8
 
+    def __init__(
+        self,
+        batches: int,
+        tokens: int,
+        channels: int,
+        width: int,
+        config: ShortConvConfig,
+        dtype: ShortConvDType,
+        d_activation,
+    ):
+        channel_tile = config.threads * config.channels_per_thread
+        assert channels % channel_tile == 0, (
+            f"TMA channels ({channels}) must be divisible by the channel tile ({channel_tile})"
+        )
+        super().__init__(batches, tokens, channels, width, config, dtype, d_activation)
+
     def staged_layout(self):
         channels_per_block = self.threads * self.channels_per_thread
         return cute.make_layout(
@@ -1203,99 +1219,97 @@ class CausalConv1dSiluInputGradientTma(
             Int32(batch),
             self.tokens,
         )
-        if channel < self.channels:
-            for channel_offset in cutlass.range_constexpr(self.channels_per_thread):
-                for tap in cutlass.range_constexpr(self.width):
-                    weights[channel_offset, tap] = Float32(weight[channel + channel_offset, tap])
-            if cutlass.const_expr(initial_state is None):
-                for history_offset in cutlass.range_constexpr(self.width - 1):
-                    history_time = time_start + history_offset - (self.width - 1)
-                    if history_time >= sequence_start:
-                        history[(None, history_offset)].store(
-                            x_groups[
-                                ((0, None), (batch * self.tokens + history_time, channel_group))
-                            ].load()
-                        )
-            else:
-                self.initialize_history(
-                    history,
-                    x,
-                    initial_state,
-                    sequence,
-                    sequence_start,
-                    Int32(time_start),
-                    Int32(batch),
-                    Int32(channel_group),
-                )
+        for channel_offset in cutlass.range_constexpr(self.channels_per_thread):
+            for tap in cutlass.range_constexpr(self.width):
+                weights[channel_offset, tap] = Float32(weight[channel + channel_offset, tap])
+        if cutlass.const_expr(initial_state is None):
+            for history_offset in cutlass.range_constexpr(self.width - 1):
+                history_time = time_start + history_offset - (self.width - 1)
+                if history_time >= sequence_start:
+                    history[(None, history_offset)].store(
+                        x_groups[
+                            ((0, None), (batch * self.tokens + history_time, channel_group))
+                        ].load()
+                    )
+        else:
+            self.initialize_history(
+                history,
+                x,
+                initial_state,
+                sequence,
+                sequence_start,
+                Int32(time_start),
+                Int32(batch),
+                Int32(channel_group),
+            )
 
         for subtile in cutlass.range_constexpr(subtiles):
             tile_pipeline.consumer_wait(consumer_state)
             stage = consumer_state.index
-            if channel < self.channels:
-                for slot in cutlass.range_constexpr(stage_tokens):
-                    output_offset = subtile * stage_tokens + slot
-                    output_time = time_start + output_offset
-                    current = cute.make_rmem_tensor(
-                        (self.channels_per_thread,),
-                        self.dtype.cute_type,
-                    )
-                    incoming = cute.make_rmem_tensor(
-                        (self.channels_per_thread,),
-                        Float32,
-                    )
-                    current.fill(self.dtype.cute_type(0.0))
-                    incoming.fill(Float32(0.0))
-                    if output_time < self.tokens:
-                        if cutlass.const_expr(cu_seqlens is not None):  # noqa: SIM102
-                            if output_time >= sequence_end:
-                                previous_sequence_start = sequence_start
-                                sequence, sequence_start, sequence_end = sequence_bounds(
-                                    cu_seqlens,
+            for slot in cutlass.range_constexpr(stage_tokens):
+                output_offset = subtile * stage_tokens + slot
+                output_time = time_start + output_offset
+                current = cute.make_rmem_tensor(
+                    (self.channels_per_thread,),
+                    self.dtype.cute_type,
+                )
+                incoming = cute.make_rmem_tensor(
+                    (self.channels_per_thread,),
+                    Float32,
+                )
+                current.fill(self.dtype.cute_type(0.0))
+                incoming.fill(Float32(0.0))
+                if output_time < self.tokens:
+                    if cutlass.const_expr(cu_seqlens is not None):  # noqa: SIM102
+                        if output_time >= sequence_end:
+                            previous_sequence_start = sequence_start
+                            sequence, sequence_start, sequence_end = sequence_bounds(
+                                cu_seqlens,
+                                Int32(output_time),
+                            )
+                            self.flush_mainloop_sequence(
+                                grad_z,
+                                weights,
+                                dx_groups,
+                                batch,
+                                channel_group,
+                                Int32(output_time),
+                                Int32(time_start),
+                                previous_sequence_start,
+                            )
+                            if cutlass.const_expr(initial_state is None):
+                                history.fill(self.dtype.cute_type(0.0))
+                            else:
+                                self.initialize_history(
+                                    history,
+                                    x,
+                                    initial_state,
+                                    sequence,
+                                    sequence_start,
                                     Int32(output_time),
+                                    Int32(batch),
+                                    Int32(channel_group),
                                 )
-                                self.flush_mainloop_sequence(
-                                    grad_z,
-                                    weights,
-                                    dx_groups,
-                                    batch,
-                                    channel_group,
-                                    Int32(output_time),
-                                    Int32(time_start),
-                                    previous_sequence_start,
-                                )
-                                if cutlass.const_expr(initial_state is None):
-                                    history.fill(self.dtype.cute_type(0.0))
-                                else:
-                                    self.initialize_history(
-                                        history,
-                                        x,
-                                        initial_state,
-                                        sequence,
-                                        sequence_start,
-                                        Int32(output_time),
-                                        Int32(batch),
-                                        Int32(channel_group),
-                                    )
-                                grad_z.fill(Float32(0.0))
-                        current.store(sX_groups[((0, None, 0), (slot, tidx, stage))].load())
-                        incoming.store(
-                            sD_groups[((0, None, 0), (slot, tidx, stage))].load().to(Float32)
-                        )
-                    self.advance_token(
-                        current,
-                        incoming,
-                        weights,
-                        history,
-                        grad_z,
-                        dx_groups,
-                        batch,
-                        channel_group,
-                        output_time,
-                        Int32(time_start),
-                        sequence_start,
-                        cu_seqlens is not None,
-                        output_offset >= self.width - 1,
+                            grad_z.fill(Float32(0.0))
+                    current.store(sX_groups[((0, None, 0), (slot, tidx, stage))].load())
+                    incoming.store(
+                        sD_groups[((0, None, 0), (slot, tidx, stage))].load().to(Float32)
                     )
+                self.advance_token(
+                    current,
+                    incoming,
+                    weights,
+                    history,
+                    grad_z,
+                    dx_groups,
+                    batch,
+                    channel_group,
+                    output_time,
+                    Int32(time_start),
+                    sequence_start,
+                    cu_seqlens is not None,
+                    output_offset >= self.width - 1,
+                )
             cute.arch.fence_view_async_shared()
             cute.arch.sync_warp()
             tile_pipeline.consumer_release(consumer_state)
@@ -1315,50 +1329,49 @@ class CausalConv1dSiluInputGradientTma(
                 )
                 producer_state.advance()
 
-        if channel < self.channels:
-            # A boundary in the lookahead belongs to the next CTA; zero-fill this CTA's tail.
-            for tail in cutlass.range_constexpr(self.width - 1):
-                output_offset = self.times_per_block + tail
-                output_time = time_start + output_offset
-                current = cute.make_rmem_tensor(
-                    (self.channels_per_thread,),
-                    self.dtype.cute_type,
+        # A boundary in the lookahead belongs to the next CTA; zero-fill this CTA's tail.
+        for tail in cutlass.range_constexpr(self.width - 1):
+            output_offset = self.times_per_block + tail
+            output_time = time_start + output_offset
+            current = cute.make_rmem_tensor(
+                (self.channels_per_thread,),
+                self.dtype.cute_type,
+            )
+            incoming = cute.make_rmem_tensor(
+                (self.channels_per_thread,),
+                Float32,
+            )
+            current.fill(self.dtype.cute_type(0.0))
+            incoming.fill(Float32(0.0))
+            has_input = output_time < self.tokens
+            if cutlass.const_expr(cu_seqlens is not None):
+                has_input = has_input and output_time < sequence_end
+            if has_input:
+                current.store(
+                    x_groups[
+                        ((0, None), (batch * self.tokens + output_time, channel_group))
+                    ].load()
                 )
-                incoming = cute.make_rmem_tensor(
-                    (self.channels_per_thread,),
-                    Float32,
+                incoming.store(
+                    dy_groups[((0, None), (batch * self.tokens + output_time, channel_group))]
+                    .load()
+                    .to(Float32)
                 )
-                current.fill(self.dtype.cute_type(0.0))
-                incoming.fill(Float32(0.0))
-                has_input = output_time < self.tokens
-                if cutlass.const_expr(cu_seqlens is not None):
-                    has_input = has_input and output_time < sequence_end
-                if has_input:
-                    current.store(
-                        x_groups[
-                            ((0, None), (batch * self.tokens + output_time, channel_group))
-                        ].load()
-                    )
-                    incoming.store(
-                        dy_groups[((0, None), (batch * self.tokens + output_time, channel_group))]
-                        .load()
-                        .to(Float32)
-                    )
-                self.advance_token(
-                    current,
-                    incoming,
-                    weights,
-                    history,
-                    grad_z,
-                    dx_groups,
-                    batch,
-                    channel_group,
-                    output_time,
-                    Int32(time_start),
-                    sequence_start,
-                    cu_seqlens is not None,
-                    True,
-                )
+            self.advance_token(
+                current,
+                incoming,
+                weights,
+                history,
+                grad_z,
+                dx_groups,
+                batch,
+                channel_group,
+                output_time,
+                Int32(time_start),
+                sequence_start,
+                cu_seqlens is not None,
+                True,
+            )
 
     @cute.jit
     def __call__(
@@ -1390,7 +1403,7 @@ class CausalConv1dSiluInputGradientTma(
             _name_prefix=self.get_name(),
         ).launch(
             grid=(
-                cute.ceil_div(self.channels, self.threads * self.channels_per_thread),
+                self.channels // (self.threads * self.channels_per_thread),
                 cute.ceil_div(self.tokens, self.times_per_block),
                 self.batches,
             ),
@@ -1484,114 +1497,106 @@ class CausalConv1dSiluWeightGradientPartialsTma(
             Int32(batch),
             self.tokens,
         )
-        if channel < self.channels:
-            for channel_offset in cutlass.range_constexpr(self.channels_per_thread):
-                for tap in cutlass.range_constexpr(self.width):
-                    weights[channel_offset, tap] = Float32(weight[channel + channel_offset, tap])
-            if cutlass.const_expr(initial_state is None):
-                for history_offset in cutlass.range_constexpr(self.width - 1):
-                    history_time = time_start + history_offset - (self.width - 1)
-                    if history_time >= sequence_start:
-                        if cutlass.const_expr(self.dtype.name == "fp32"):
-                            for channel_offset in cutlass.range_constexpr(
-                                self.channels_per_thread
-                            ):
-                                history[channel_offset, history_offset] = x[
-                                    batch * self.tokens + history_time,
-                                    channel + channel_offset,
-                                ]
-                        else:
-                            history[(None, history_offset)].store(
-                                x_groups[
-                                    (
-                                        (0, None),
-                                        (batch * self.tokens + history_time, channel_group),
-                                    )
-                                ].load()
-                            )
-            else:
-                self.initialize_history(
-                    history,
-                    x,
-                    initial_state,
-                    sequence,
-                    sequence_start,
-                    Int32(time_start),
-                    Int32(batch),
-                    Int32(channel_group),
-                )
+        for channel_offset in cutlass.range_constexpr(self.channels_per_thread):
+            for tap in cutlass.range_constexpr(self.width):
+                weights[channel_offset, tap] = Float32(weight[channel + channel_offset, tap])
+        if cutlass.const_expr(initial_state is None):
+            for history_offset in cutlass.range_constexpr(self.width - 1):
+                history_time = time_start + history_offset - (self.width - 1)
+                if history_time >= sequence_start:
+                    if cutlass.const_expr(self.dtype.name == "fp32"):
+                        for channel_offset in cutlass.range_constexpr(self.channels_per_thread):
+                            history[channel_offset, history_offset] = x[
+                                batch * self.tokens + history_time,
+                                channel + channel_offset,
+                            ]
+                    else:
+                        history[(None, history_offset)].store(
+                            x_groups[
+                                (
+                                    (0, None),
+                                    (batch * self.tokens + history_time, channel_group),
+                                )
+                            ].load()
+                        )
+        else:
+            self.initialize_history(
+                history,
+                x,
+                initial_state,
+                sequence,
+                sequence_start,
+                Int32(time_start),
+                Int32(batch),
+                Int32(channel_group),
+            )
 
         for subtile in cutlass.range_constexpr(subtiles):
             tile_pipeline.consumer_wait(consumer_state)
             stage = consumer_state.index
-            if channel < self.channels:
-                for slot in cutlass.range_constexpr(stage_tokens):
-                    time = time_start + subtile * stage_tokens + slot
-                    if time < self.tokens:
-                        if cutlass.const_expr(cu_seqlens is not None):  # noqa: SIM102
-                            if time >= sequence_end:
-                                sequence, sequence_start, sequence_end = sequence_bounds(
-                                    cu_seqlens,
+            for slot in cutlass.range_constexpr(stage_tokens):
+                time = time_start + subtile * stage_tokens + slot
+                if time < self.tokens:
+                    if cutlass.const_expr(cu_seqlens is not None):  # noqa: SIM102
+                        if time >= sequence_end:
+                            sequence, sequence_start, sequence_end = sequence_bounds(
+                                cu_seqlens,
+                                Int32(time),
+                            )
+                            if cutlass.const_expr(initial_state is None):
+                                history.fill(self.dtype.cute_type(0.0))
+                            else:
+                                self.initialize_history(
+                                    history,
+                                    x,
+                                    initial_state,
+                                    sequence,
+                                    sequence_start,
                                     Int32(time),
+                                    Int32(batch),
+                                    Int32(channel_group),
                                 )
-                                if cutlass.const_expr(initial_state is None):
-                                    history.fill(self.dtype.cute_type(0.0))
-                                else:
-                                    self.initialize_history(
-                                        history,
-                                        x,
-                                        initial_state,
-                                        sequence,
-                                        sequence_start,
-                                        Int32(time),
-                                        Int32(batch),
-                                        Int32(channel_group),
-                                    )
-                        current = cute.make_rmem_tensor(
-                            (self.channels_per_thread,),
-                            self.dtype.cute_type,
+                    current = cute.make_rmem_tensor(
+                        (self.channels_per_thread,),
+                        self.dtype.cute_type,
+                    )
+                    if cutlass.const_expr(self.dtype.name == "fp32"):
+                        for channel_offset in cutlass.range_constexpr(self.channels_per_thread):
+                            current[channel_offset] = sX[
+                                slot,
+                                tidx * self.channels_per_thread + channel_offset,
+                                stage,
+                            ]
+                    else:
+                        current.store(sX_groups[((0, None, 0), (slot, tidx, stage))].load())
+                    input_taps = self.load_input_taps(history, current)
+                    value = (input_taps.load() * weights.load()).reduce(
+                        cute.ReductionOp.ADD,
+                        Float32(0.0),
+                        reduction_profile=(None, 1),
+                    )
+                    incoming = cute.make_rmem_tensor(
+                        (self.channels_per_thread,),
+                        Float32,
+                    )
+                    if cutlass.const_expr(self.dtype.name == "fp32"):
+                        for channel_offset in cutlass.range_constexpr(self.channels_per_thread):
+                            incoming[channel_offset] = sD[
+                                slot,
+                                tidx * self.channels_per_thread + channel_offset,
+                                stage,
+                            ].to(Float32)
+                    else:
+                        incoming.store(
+                            sD_groups[((0, None, 0), (slot, tidx, stage))].load().to(Float32)
                         )
-                        if cutlass.const_expr(self.dtype.name == "fp32"):
-                            for channel_offset in cutlass.range_constexpr(
-                                self.channels_per_thread
-                            ):
-                                current[channel_offset] = sX[
-                                    slot,
-                                    tidx * self.channels_per_thread + channel_offset,
-                                    stage,
-                                ]
-                        else:
-                            current.store(sX_groups[((0, None, 0), (slot, tidx, stage))].load())
-                        input_taps = self.load_input_taps(history, current)
-                        value = (input_taps.load() * weights.load()).reduce(
-                            cute.ReductionOp.ADD,
-                            Float32(0.0),
-                            reduction_profile=(None, 1),
+                    grad_z = incoming.load() * self.d_activation(value)
+                    for tap in cutlass.range_constexpr(self.width):
+                        accumulators[(None, tap)].store(
+                            accumulators[(None, tap)].load()
+                            + grad_z * input_taps[(None, tap)].load()
                         )
-                        incoming = cute.make_rmem_tensor(
-                            (self.channels_per_thread,),
-                            Float32,
-                        )
-                        if cutlass.const_expr(self.dtype.name == "fp32"):
-                            for channel_offset in cutlass.range_constexpr(
-                                self.channels_per_thread
-                            ):
-                                incoming[channel_offset] = sD[
-                                    slot,
-                                    tidx * self.channels_per_thread + channel_offset,
-                                    stage,
-                                ].to(Float32)
-                        else:
-                            incoming.store(
-                                sD_groups[((0, None, 0), (slot, tidx, stage))].load().to(Float32)
-                            )
-                        grad_z = incoming.load() * self.d_activation(value)
-                        for tap in cutlass.range_constexpr(self.width):
-                            accumulators[(None, tap)].store(
-                                accumulators[(None, tap)].load()
-                                + grad_z * input_taps[(None, tap)].load()
-                            )
-                        self.advance_history(history, current)
+                    self.advance_history(history, current)
             cute.arch.fence_view_async_shared()
             cute.arch.sync_warp()
             tile_pipeline.consumer_release(consumer_state)
@@ -1612,12 +1617,11 @@ class CausalConv1dSiluWeightGradientPartialsTma(
                 )
                 producer_state.advance()
 
-        if channel < self.channels:
-            for channel_offset in cutlass.range_constexpr(self.channels_per_thread):
-                for tap in cutlass.range_constexpr(self.width):
-                    partials[batch, time_block, channel + channel_offset, tap] = accumulators[
-                        channel_offset, tap
-                    ]
+        for channel_offset in cutlass.range_constexpr(self.channels_per_thread):
+            for tap in cutlass.range_constexpr(self.width):
+                partials[batch, time_block, channel + channel_offset, tap] = accumulators[
+                    channel_offset, tap
+                ]
 
     @cute.jit
     def __call__(
@@ -1649,7 +1653,7 @@ class CausalConv1dSiluWeightGradientPartialsTma(
             _name_prefix=self.get_name(),
         ).launch(
             grid=(
-                cute.ceil_div(self.channels, self.threads * self.channels_per_thread),
+                self.channels // (self.threads * self.channels_per_thread),
                 cute.ceil_div(self.tokens, self.times_per_block),
                 self.batches,
             ),

--- a/test/test_kda_short_conv_cute.py
+++ b/test/test_kda_short_conv_cute.py
@@ -171,6 +171,21 @@ def test_short_conv_packed_defaults_select_tma(dtype: torch.dtype):
     )
 
 
+def test_short_conv_tma_rejects_partial_channel_tiles():
+    """Make full channel tiles an explicit invariant of direct TMA construction."""
+    config = ShortConvTunedConfig.default(torch.bfloat16, packed=True).input_gradient
+    with pytest.raises(AssertionError, match="must be divisible by the channel tile"):
+        cute_backend.CausalConv1dSiluInputGradientTma(
+            1,
+            384,
+            513,
+            4,
+            config,
+            cute_backend.SHORT_CONV_DTYPES[torch.bfloat16],
+            cute_backend._silu_derivative,
+        )
+
+
 @pytest.mark.parametrize(
     ("dtype", "rounding_allowance", "rtol", "atol"),
     [


### PR DESCRIPTION
## Human Note

## Agent note

The packed TMA backward kernels carried sequence IDs, starts, ends, and a tail-finished flag through
runtime control flow even though a token crosses a boundary exactly when it reaches the current
`sequence_end`. Compare directly against that boundary and resolve new bounds only after crossing it.
The input-gradient lookahead similarly needs only a physical-token bound and, for packed execution,
the current sequence end.

TMA dispatch already requires channels to be divisible by the complete CTA channel tile. Make that
an assertion on direct TMA construction, launch an exact channel grid, and remove the six per-thread
channel bounds checks. The generic kernels remain the fallback for partial channel tiles. The input
store ownership predicate is named separately so its time-tile and packed-sequence responsibilities
are visible without changing its vectorized predicated store.

An explicit TensorSSA store mask was evaluated but rejected: it was 2.05% slower over nine alternating
rounds. The retained scalar predicate already lowers to a predicated vector `STG.E.64` for the BF16
four-channel fragment.

## Performance

Measured on GB300 for packed BF16 `B=1, T=16384, C=12288, W=4` with 64 equal sequences. Each result
is the median of seven alternating rounds with 1,000 fixed-pointer CUDA Graph samples per variant.

| Change | Kernel | Before (us) | After (us) | Change |
|---|---|---:|---:|---:|
| Simplify sequence boundaries | `dx` | 276.19 | 234.32 | -15.16% |
| Simplify sequence boundaries | `dw` | 249.82 | 215.30 | -13.82% |
| Remove redundant channel guards | `dx` | 234.43 | 224.64 | -4.18% |
| Remove redundant channel guards | `dw` | 215.46 | 216.48 | +0.48% |

The channel-guard `dw` difference had mixed signs across paired rounds and is effectively neutral;
`dx` improved in every pair. Dense BF16 code generation remained byte-identical after the sequence
boundary cleanup.

## Test Plan

```bash
pytest -q test/test_kda_short_conv_cute.py
prek run --all-files
for tool in memcheck racecheck initcheck synccheck; do compute-sanitizer --tool "$tool" --report-api-errors no --error-exitcode 99 python agent_space/check_packed_tma_sanitizer.py; done
```

Results: 72 tests passed; memcheck, initcheck, and synccheck reported zero errors; racecheck reported
zero hazards.
