### PR TITLE
Support dense batches in CuTe KDA core

### DIFF
--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py
@@ -69,8 +69,8 @@ def _validate_chunk_kda_inputs(
     if any(tensor.dtype not in _SUPPORTED_INPUT_DTYPES for tensor in data_tensors):
         supported = ", ".join(str(dtype) for dtype in _SUPPORTED_INPUT_DTYPES)
         raise TypeError(f"chunk_kda inputs must use one of {supported}")
-    if batch != 1 or head_dim != _HEAD_DIM:
-        raise ValueError("the CuTe KDA core requires B=1 and K=V=128")
+    if head_dim != _HEAD_DIM:
+        raise ValueError("the CuTe KDA core requires K=V=128")
     if tokens % _CHUNK_SIZE:
         raise ValueError("the CuTe KDA core requires complete 64-token chunks")
     if not torch.compiler.is_compiling() and torch.cuda.get_device_capability(q.device) < (10, 0):
@@ -510,17 +510,26 @@ def chunk_kda(
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Apply the graph-capturable, first-order Blackwell KDA core.
 
-    ``cu_seqlens`` selects packed ``[1, T, H, D]`` execution. Every packed
+    ``cu_seqlens`` selects packed ``[1, T, H, D]`` execution. Dense batches are
+    lowered to the same packed representation with equal-length sequences. Every
     sequence must contain complete 64-token chunks. The output uses ``q.dtype``;
     recurrent states remain FP32 and have one leading entry per logical sequence.
     """
     _validate_chunk_kda_inputs(q, k, v, cumulative_gate, beta, initial_state, cu_seqlens)
     output_dtype = q.dtype
+    batch, tokens, heads, head_dim = q.shape
     q, k, v = (tensor.to(torch.bfloat16) for tensor in (q, k, v))
     cumulative_gate = cumulative_gate.float().contiguous()
     beta = beta.float().contiguous()
     if initial_state is not None:
         initial_state = initial_state.float().contiguous()
+    if batch > 1:
+        packed_shape = (1, batch * tokens, heads, head_dim)
+        q, k, v, cumulative_gate = (
+            tensor.reshape(packed_shape) for tensor in (q, k, v, cumulative_gate)
+        )
+        beta = beta.reshape(1, batch * tokens, heads)
+        cu_seqlens = torch.arange(batch + 1, dtype=torch.int32, device=q.device) * tokens
     output, state, _Aqk, _Akk, _cu_seqlens, _chunk_indices, _num_chunks = _chunk_kda_fwd_custom_op(
         q,
         k,
@@ -533,7 +542,9 @@ def chunk_kda(
         fastmath,
         profile_ranges,
     )
-    return output.to(output_dtype), state if output_final_state else None
+    return output.reshape(batch, tokens, heads, head_dim).to(output_dtype), (
+        state if output_final_state else None
+    )
 
 
 __all__ = ["chunk_kda"]

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -75,11 +75,12 @@ partials for the shared parameter reduction. The example explicitly runs
 projections in BF16 while retaining FP32 parameters and gate reductions; no
 ambient autocast context is required.
 The CuTe gate path requires a head dimension divisible by 32 in `[32, 1024]`.
-The optimized core requires Blackwell, physical batch size one, BF16 kernel inputs,
-`head_dim=128`, and complete 64-token chunks. `chunk_kda(..., cu_seqlens=offsets)` treats
-`[1, T, H, D]` inputs as packed logical sequences and carries those boundaries through the
-forward, backward, and recurrent states; each logical sequence must currently contain an integer
-number of 64-token chunks. `KDAAttention.forward` threads the same offsets through its short
+The optimized core requires Blackwell, BF16 kernel inputs, `head_dim=128`, and complete
+64-token chunks. Dense `[B, T, H, D]` inputs are lowered internally to equal-length packed
+sequences, while `chunk_kda(..., cu_seqlens=offsets)` accepts explicitly packed
+`[1, T, H, D]` inputs. Both forms carry sequence boundaries through the forward, backward, and
+recurrent states; each logical sequence must currently contain an integer number of 64-token
+chunks. `KDAAttention.forward` threads explicit offsets through its short
 convolution and KDA core; the gate prefix sum already resets at every aligned chunk boundary. The
 optimized boundaries are first-order and do not support higher-order autograd. Run
 `python examples/kda_training.py --backend=fused --packed --batch-size=4 --tokens=256`

--- a/test/test_kda_cute_forward.py
+++ b/test/test_kda_cute_forward.py
@@ -39,12 +39,13 @@ pytestmark = pytest.mark.skipif(
 
 def _inputs(
     *,
+    batch: int = 1,
     tokens: int = 128,
     heads: int = 1,
     initial_state: bool = False,
     dtype: torch.dtype = torch.bfloat16,
 ):
-    batch, head_dim = 1, 128
+    head_dim = 128
     shape = (batch, tokens, heads, head_dim)
     q = F.normalize(torch.randn(shape, device="cuda"), dim=-1).to(dtype)
     k = F.normalize(torch.randn(shape, device="cuda"), dim=-1).to(dtype)
@@ -318,6 +319,51 @@ def test_optimized_chunk_kda_packed_matches_independent_sequences():
             expected_gradient,
             torch.bfloat16,
             f"packed input gradient {index}",
+        )
+
+
+def test_optimized_chunk_kda_dense_batch_matches_equal_length_packing():
+    """Lower a dense batch to independent equal-length packed sequences."""
+    torch.manual_seed(43)
+    dense_inputs = _inputs(batch=2, tokens=128, heads=2, initial_state=True)
+    packed_inputs = _clone_inputs(dense_inputs)
+    q, k, v, cumulative_gate, beta, initial_state = packed_inputs
+    packed_shape = (1, 256, 2, 128)
+    packed_inputs = (
+        q.reshape(packed_shape),
+        k.reshape(packed_shape),
+        v.reshape(packed_shape),
+        cumulative_gate.reshape(packed_shape),
+        beta.reshape(1, 256, 2),
+        initial_state,
+    )
+    cu_seqlens = torch.tensor([0, 128, 256], device="cuda", dtype=torch.int32)
+
+    dense_output, dense_state = chunk_kda(*dense_inputs, output_final_state=True)
+    packed_output, packed_state = chunk_kda(
+        *packed_inputs,
+        cu_seqlens=cu_seqlens,
+        output_final_state=True,
+    )
+    assert dense_state is not None and packed_state is not None
+    torch.testing.assert_close(
+        dense_output.reshape_as(packed_output), packed_output, rtol=0, atol=0
+    )
+    torch.testing.assert_close(dense_state, packed_state, rtol=0, atol=0)
+
+    d_output = torch.randn_like(dense_output)
+    d_state = torch.randn_like(dense_state)
+    dense_gradients = torch.autograd.grad(
+        (dense_output, dense_state), dense_inputs, (d_output, d_state)
+    )
+    packed_gradients = torch.autograd.grad(
+        (packed_output, packed_state),
+        packed_inputs,
+        (d_output.reshape_as(packed_output), d_state),
+    )
+    for dense_gradient, packed_gradient in zip(dense_gradients, packed_gradients, strict=True):
+        torch.testing.assert_close(
+            dense_gradient.reshape_as(packed_gradient), packed_gradient, rtol=0, atol=0
         )
 
 


### PR DESCRIPTION
Support dense batches in CuTe KDA core

## Human Note

## Agent note

Lower fixed-length dense batches to the existing packed physical-B1 representation by flattening
batch and token dimensions and synthesizing equal-length sequence offsets. This keeps the specialized
kernels unchanged while preserving independent recurrent states and sequence boundaries. Restore the
original dense output shape at the public boundary and document the resulting contract.

Add forward, final-state, and backward coverage showing that automatic dense lowering is bitwise
identical to explicit equal-length packing.

## Test Plan

```bash
gpu-run auto -- env PYTHONPATH=$PWD TORCH_CUSTOM_PYTHONPATH=$PWD ~/.venvs/nightly/bin/pytest -q test/test_kda_cute_forward.py::test_optimized_chunk_kda_dense_batch_matches_equal_length_packing test/test_kda_cute_forward.py::test_optimized_chunk_kda_packed_matches_independent_sequences
gpu-run auto -- env PYTHONPATH=$PWD TORCH_CUSTOM_PYTHONPATH=$PWD ~/.venvs/nightly/bin/pytest -q test/test_kda_short_conv_cute.py::test_kda_example_packed_matches_sequence_for_loop
gpu-run auto -- env PYTHONPATH=$PWD TORCH_CUSTOM_PYTHONPATH=$PWD TORCHINDUCTOR_CACHE_DIR=/tmp/kda-dense-b2-compile ~/.venvs/nightly/bin/python examples/kda_training.py --backend fused --compile --steps 2 --batch-size 2 --tokens 64 --hidden-size 32 --num-heads 1 --head-dim 128
prek run --files attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py test/test_kda_cute_forward.py docs/linear.md examples/kda_training.py
```