### PR TITLE
Optimize KDA training primitives

### DIFF
--- a/attn_gym/_backends/cute/__init__.py
+++ b/attn_gym/_backends/cute/__init__.py
@@ -2,14 +2,23 @@
 
 from .cache import jit_cache
 from .tune import TunableKernel, benchmark_gpu, run_tunable, tune
-from .utils import ceildiv, compile_tvm_ffi
+from .utils import (
+    TMA_ALIGNMENT_BYTES,
+    ceildiv,
+    compile_tvm_ffi,
+    get_device_properties,
+    tensor_supports_tma,
+)
 
 __all__ = [
+    "TMA_ALIGNMENT_BYTES",
     "TunableKernel",
     "benchmark_gpu",
     "ceildiv",
     "compile_tvm_ffi",
+    "get_device_properties",
     "jit_cache",
     "run_tunable",
+    "tensor_supports_tma",
     "tune",
 ]

--- a/attn_gym/_backends/cute/utils.py
+++ b/attn_gym/_backends/cute/utils.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 import re
+from functools import lru_cache
 from typing import Any
 
+import torch
+
 _VALID_NAME = re.compile(r"[a-z][a-z0-9_]*\Z")
+TMA_ALIGNMENT_BYTES = 16
 
 
 def ceildiv(number: int, divisor: int) -> int:
@@ -14,8 +18,6 @@ def ceildiv(number: int, divisor: int) -> int:
 
 
 def _contains_torch_tensor(value: Any) -> bool:
-    import torch
-
     if isinstance(value, torch.Tensor):
         return True
     if isinstance(value, (tuple, list)):
@@ -26,6 +28,31 @@ def _contains_torch_tensor(value: Any) -> bool:
             for key, item in value.items()
         )
     return False
+
+
+@lru_cache(maxsize=8)
+def get_device_properties(device: torch.device) -> Any:
+    """Return cached CUDA properties for a device."""
+    return torch.cuda.get_device_properties(device)
+
+
+def tensor_supports_tma(tensor: torch.Tensor) -> bool:
+    """Return whether a CUDA tensor has a TMA-compatible aligned strided layout.
+
+    The innermost dimension must be contiguous. The base pointer and every outer stride,
+    measured in bytes, must satisfy ``TMA_ALIGNMENT_BYTES``.
+    """
+    if not tensor.is_cuda:
+        return False
+    element_size = tensor.element_size()
+    return (
+        tensor.ndim > 0
+        and tensor.stride(-1) == 1
+        and tensor.data_ptr() % TMA_ALIGNMENT_BYTES == 0
+        and all(
+            stride * element_size % TMA_ALIGNMENT_BYTES == 0 for stride in tensor.stride()[:-1]
+        )
+    )
 
 
 def compile_tvm_ffi(
@@ -67,4 +94,10 @@ def compile_tvm_ffi(
     )
 
 
-__all__ = ["ceildiv", "compile_tvm_ffi"]
+__all__ = [
+    "TMA_ALIGNMENT_BYTES",
+    "ceildiv",
+    "compile_tvm_ffi",
+    "get_device_properties",
+    "tensor_supports_tma",
+]

--- a/attn_gym/linear/kda/bwd/cute/chunk_delta_h_bwd_v1_dispatch.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_delta_h_bwd_v1_dispatch.py
@@ -23,7 +23,7 @@ Crossover point: w_tiles_bv16 = SM_count ≈ 132 on GH200.
 
 import torch
 
-from attn_gym._backends.cute import ceildiv
+from attn_gym._backends.cute import ceildiv, get_device_properties
 from attn_gym.linear.kda.bwd.cute.chunk_delta_h_bwd_v1 import (
     blackwell_delta_h_bwd_dhu_v1,
 )
@@ -56,7 +56,7 @@ def blackwell_delta_h_bwd_dhu_dispatch(
     logical_batch = batch if cu_seqlens is None else cu_seqlens.shape[0] - 1
 
     w_tiles_bv16 = ceildiv(value_dim, 16) * heads * logical_batch
-    sm_count = torch.cuda.get_device_properties(q.device).multi_processor_count
+    sm_count = get_device_properties(q.device).multi_processor_count
 
     bv = 32 if w_tiles_bv16 > sm_count else 16
 

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import math
 from contextlib import nullcontext
 
 import torch
@@ -53,8 +52,6 @@ def chunk_kda_bwd(
         raise ValueError(f"the composed KDA backward requires chunk_size=64, got {chunk_size}")
     if tokens % chunk_size:
         raise ValueError("the composed KDA backward requires complete chunks")
-    if initial_state is not None:
-        initial_state = initial_state.contiguous()
 
     def record(name: str):
         return torch.profiler.record_function(name) if profile_ranges else nullcontext()
@@ -154,9 +151,6 @@ def chunk_kda_bwd(
             dg,
             metadata,
         )
-    # The imported kernels accumulate derivatives with respect to their exp2
-    # exponent as though it were a natural exponent. Convert to d/d(log2 gate).
-    dg.mul_(math.log(2.0))
     return dq, dk, dv, dg, db, d_initial_state
 
 

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_intra.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_intra.py
@@ -32,6 +32,9 @@ KEY_DIM = 128  # full head_dim
 KEY_DIM_PER_CTA = 32  # head_dim per K phase
 K_PHASES = KEY_DIM // KEY_DIM_PER_CTA  # four 32-wide head-dim phases
 KC_TOTAL = K_PHASES * SUBCHUNKS  # work items per (chunk, head): 16
+# The gate algebra accumulates d/d(natural exponent); this kernel owns the last dg
+# write, so it converts the complete gradient to d/d(log2 gate).
+LN2 = 0.6931471805599453
 # q and k may arrive as unbound QKV views: only their innermost dimension is
 # contiguous, and the 16-byte cp.async stages need every outer stride and the
 # base pointer to be 16-byte (8 bf16 element) aligned.
@@ -1752,8 +1755,8 @@ def _chunk_kda_bwd_intra_hmma_grid_kernel(
                     dk_word0 = _cvt_bf16x2_f32(dk_out0, dk_out1)
                 else:
                     dk_word1 = _cvt_bf16x2_f32(dk_out0, dk_out1)
-                dg_out0 = dg_in0 + dq_add0 * qval0 + (dk_beta0 - dkt0) * kval0
-                dg_out1 = dg_in1 + dq_add1 * qval1 + (dk_beta1 - dkt1) * kval1
+                dg_out0 = (dg_in0 + dq_add0 * qval0 + (dk_beta0 - dkt0) * kval0) * Float32(LN2)
+                dg_out1 = (dg_in1 + dq_add1 * qval1 + (dk_beta1 - dkt1) * kval1) * Float32(LN2)
                 if lane_row == 0:
                     dg_top0 = dg_out0
                     dg_top1 = dg_out1
@@ -2159,7 +2162,11 @@ def chunk_kda_bwd_intra(
     tune: bool = False,
     configs: Iterable[ChunkKdaBwdIntraConfig] | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Run or tune the metadata-driven intra-chunk Q/K/gate/beta backward stage."""
+    """Run the final intra-chunk backward stage.
+
+    The returned gate gradient includes the ``ln(2)`` factor for differentiating ``2**g``;
+    the incoming ``dg`` and this stage's contribution are both scaled at the final writer.
+    """
     batch, tokens, heads, head_dim = q.shape
     if batch != 1 or head_dim != KEY_DIM:
         raise ValueError("the intra-chunk backward requires B=1 and K=128")

--- a/attn_gym/linear/kda/bwd/cute/gate_bwd_fused.py
+++ b/attn_gym/linear/kda/bwd/cute/gate_bwd_fused.py
@@ -30,7 +30,13 @@ from cuda.bindings import driver as cuda
 from cutlass import Float32, Int32, Int64, cute, pipeline
 from cutlass.cute.nvgpu import cpasync
 
-from attn_gym._backends.cute import ceildiv, compile_tvm_ffi, jit_cache
+from attn_gym._backends.cute import (
+    TMA_ALIGNMENT_BYTES,
+    ceildiv,
+    compile_tvm_ffi,
+    jit_cache,
+    tensor_supports_tma,
+)
 from attn_gym._backends.cute.device import cta_reduce_sum
 from attn_gym._backends.cute.target import get_compile_target
 
@@ -42,14 +48,14 @@ class WarpRole(IntEnum):
 
 
 class FusedGateBwdOutput(NamedTuple):
-    """Partial-producing backward output matching the Triton composition.
+    """BF16 raw-gate gradient plus the FP32 parameter gradients.
 
-    Final gradients are ``dA_log = dA_partial.sum((0, 1))`` and
-    ``d_dt_bias = dg.sum((0, 1))``.
+    ``d_dt_bias`` is final; the A-log gradient is ``dA_partial.sum((0, 1))``.
     """
 
     dg: torch.Tensor
     dA_partial: torch.Tensor
+    d_dt_bias: torch.Tensor
 
 
 class FusedGateBwdOp:
@@ -148,6 +154,7 @@ class FusedGateBwdOp:
         mDtBias: cute.Tensor,
         mDg: cute.Tensor,
         mDA_partial: cute.Tensor,
+        mDDtBias_partial: cute.Tensor,
         tma_atom_g: cute.CopyAtom,
         tma_tensor_g: cute.Tensor,
         tma_atom_d: cute.CopyAtom,
@@ -247,6 +254,7 @@ class FusedGateBwdOp:
 
         reverse_sum = Float32(0.0)
         dA_log = Float32(0.0)
+        d_dt_bias = Float32(0.0)
         dg = Float32(0.0)
         gate_scale = cute.math.exp(
             mA_log[head].to(Float32),
@@ -271,7 +279,10 @@ class FusedGateBwdOp:
                     sigmoid_derivative = sigmoid + (-sigmoid) * sigmoid
                     dg = reverse_sum * (gradient_scale * sigmoid_derivative)
                     dA_log = dA_log + dg * z
-                    mDg[batch, tile_start + Int64(local_token), head, tidx] = dg
+                    d_dt_bias = d_dt_bias + dg
+                    mDg[batch, tile_start + Int64(local_token), head, tidx] = dg.to(
+                        cutlass.BFloat16
+                    )
             cute.arch.fence_view_async_shared()
             cute.arch.sync_warp()
             tile_pipeline.consumer_release(consumer_state)
@@ -294,6 +305,7 @@ class FusedGateBwdOp:
         cta_sum = cta_reduce_sum(dA_log, warp_partials)
         if tidx == 0:
             mDA_partial[batch, chunk, head] = cta_sum
+        mDDtBias_partial[batch, chunk, head, tidx] = d_dt_bias
 
     @cute.jit
     def __call__(
@@ -304,6 +316,7 @@ class FusedGateBwdOp:
         mD_cumulative: cute.Tensor,
         mDg: cute.Tensor,
         mDA_partial: cute.Tensor,
+        mDDtBias_partial: cute.Tensor,
         stream: cuda.CUstream,
     ):
         """Build TMA descriptors and launch one CTA per batch, chunk, and head."""
@@ -334,6 +347,7 @@ class FusedGateBwdOp:
             mDtBias,
             mDg,
             mDA_partial,
+            mDDtBias_partial,
             tma_atom_g,
             tma_tensor_g,
             tma_atom_d,
@@ -365,31 +379,50 @@ def _compile_fused_gate_bwd(
     batch = cute.sym_int()
     tokens = cute.sym_int()
     chunks = cute.sym_int()
-    g, d_cumulative, dg = (
-        cute.runtime.make_fake_compact_tensor(
+
+    def strided_rows(dtype, alignment_elements: int):
+        return cute.runtime.make_fake_tensor(
             dtype,
             (batch, tokens, heads, head_dim),
-            stride_order=(3, 2, 1, 0),
-            assumed_align=16,
+            stride=(
+                cute.sym_int(divisibility=alignment_elements),
+                cute.sym_int(divisibility=alignment_elements),
+                cute.sym_int(divisibility=alignment_elements),
+                1,
+            ),
+            assumed_align=TMA_ALIGNMENT_BYTES,
         )
-        for dtype in (cutlass.BFloat16, cutlass.Float32, cutlass.Float32)
+
+    g = strided_rows(cutlass.BFloat16, TMA_ALIGNMENT_BYTES // 2)
+    d_cumulative = strided_rows(cutlass.Float32, TMA_ALIGNMENT_BYTES // 4)
+    dg = cute.runtime.make_fake_compact_tensor(
+        cutlass.BFloat16,
+        (batch, tokens, heads, head_dim),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=TMA_ALIGNMENT_BYTES,
     )
-    A_log = cute.runtime.make_fake_compact_tensor(
+    A_log = cute.runtime.make_fake_tensor(
         cutlass.Float32,
         (heads,),
-        stride_order=(0,),
-        assumed_align=16,
+        stride=(cute.sym_int(),),
+        assumed_align=4,
     )
-    dt_bias = cute.runtime.make_fake_compact_tensor(
+    dt_bias = cute.runtime.make_fake_tensor(
         cutlass.Float32,
         (heads, head_dim),
-        stride_order=(1, 0),
-        assumed_align=16,
+        stride=(cute.sym_int(), cute.sym_int()),
+        assumed_align=4,
     )
     dA_partial = cute.runtime.make_fake_compact_tensor(
         cutlass.Float32,
         (batch, chunks, heads),
         stride_order=(2, 1, 0),
+        assumed_align=16,
+    )
+    d_dt_bias_partial = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (batch, chunks, heads, head_dim),
+        stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )
     return compile_tvm_ffi(
@@ -400,6 +433,7 @@ def _compile_fused_gate_bwd(
         d_cumulative,
         dg,
         dA_partial,
+        d_dt_bias_partial,
     )
 
 
@@ -442,12 +476,10 @@ def _validate_inputs(
     tensors = (g, A_log, dt_bias, d_cumulative)
     if not all(tensor.is_cuda and tensor.device == g.device for tensor in tensors):
         raise ValueError("all inputs must be CUDA tensors on the same device")
-    if not all(tensor.is_contiguous() for tensor in tensors):
-        raise ValueError("fused_gate_bwd requires contiguous tensors")
-    if not all(tensor.data_ptr() % 16 == 0 for tensor in tensors):
-        raise ValueError("fused_gate_bwd requires 16-byte-aligned tensors")
-    if torch.cuda.get_device_capability(g.device) < (9, 0):
-        raise ValueError("fused_gate_bwd requires TMA on CUDA capability >= 9.0")
+    if not all(tensor_supports_tma(tensor) for tensor in (g, d_cumulative)):
+        raise ValueError(
+            "fused_gate_bwd requires contiguous trailing dimensions and aligned outer strides"
+        )
     return FusedGateBwdOp(heads, head_dim, chunk_size, lower_bound, fastmath)
 
 
@@ -460,8 +492,14 @@ def _fused_gate_bwd_custom_op(
     chunk_size: int,
     lower_bound: float,
     fastmath: bool,
-) -> tuple[torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Keep compilation and the CuTeDSL launcher behind an opaque operator."""
+    g, d_cumulative = (
+        tensor
+        if tensor_supports_tma(tensor)
+        else tensor.clone(memory_format=torch.contiguous_format)
+        for tensor in (g, d_cumulative)
+    )
     op = _validate_inputs(
         g,
         A_log,
@@ -471,11 +509,11 @@ def _fused_gate_bwd_custom_op(
         lower_bound,
         fastmath,
     )
-    dg = torch.empty_like(d_cumulative)
-    dA_partial = torch.empty(
-        (g.shape[0], ceildiv(g.shape[1], op.chunk_size), g.shape[2]),
-        device=g.device,
-        dtype=torch.float32,
+    dg = torch.empty(g.shape, dtype=g.dtype, device=g.device)
+    partial_shape = (g.shape[0], ceildiv(g.shape[1], op.chunk_size), g.shape[2])
+    dA_partial = torch.empty(partial_shape, device=g.device, dtype=torch.float32)
+    d_dt_bias_partial = torch.empty(
+        (*partial_shape, g.shape[3]), device=g.device, dtype=torch.float32
     )
     compiled = _compile_fused_gate_bwd(
         g.shape[2],
@@ -484,8 +522,9 @@ def _fused_gate_bwd_custom_op(
         op.lower_bound,
         op.fastmath,
     )
-    compiled(g, A_log, dt_bias, d_cumulative, dg, dA_partial)
-    return dg, dA_partial
+    compiled(g, A_log, dt_bias, d_cumulative, dg, dA_partial, d_dt_bias_partial)
+    # Reducing the per-chunk partials keeps the post-pass off the full [B, T, H, D] tensors.
+    return dg, dA_partial, d_dt_bias_partial.sum((0, 1))
 
 
 @_fused_gate_bwd_custom_op.register_fake
@@ -497,11 +536,14 @@ def _fused_gate_bwd_fake(
     chunk_size: int,
     lower_bound: float,
     fastmath: bool,
-) -> tuple[torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Describe symbolic output metadata without invoking the compiler."""
-    del A_log, dt_bias, lower_bound, fastmath
-    return torch.empty_like(d_cumulative), d_cumulative.new_empty(
-        (g.shape[0], ceildiv(g.shape[1], chunk_size), g.shape[2])
+    del A_log, lower_bound, fastmath
+    partial_shape = (g.shape[0], ceildiv(g.shape[1], chunk_size), g.shape[2])
+    return (
+        g.new_empty(g.shape),
+        d_cumulative.new_empty(partial_shape),
+        dt_bias.new_empty(dt_bias.shape),
     )
 
 
@@ -517,12 +559,12 @@ def fused_gate_bwd(
 ) -> FusedGateBwdOutput:
     """Run fused reverse-cumsum and bounded gate backward with TMA staging.
 
-    ``g`` is the contiguous BF16 raw gate with shape ``[B, T, H, D]`` and
-    ``d_cumulative`` is the matching contiguous FP32 gradient of the forward
-    chunk-local cumulative gate. The result contains FP32 ``dg`` and one
-    ``dA_log`` partial per batch, static chunk, and head. Callers obtain final
-    gradients with ``dA_log = dA_partial.sum((0, 1))`` and
-    ``d_dt_bias = dg.sum((0, 1))``.
+    ``g`` is the BF16 raw gate with shape ``[B, T, H, D]`` and ``d_cumulative`` is
+    the matching FP32 gradient. Their aligned contiguous trailing dimensions are consumed
+    directly; unsupported layouts use a compact fallback. Parameter tensors may have arbitrary
+    strides. The result contains
+    BF16 ``dg``, the final FP32 ``d_dt_bias``, and one FP32 ``dA_log`` partial per batch,
+    static chunk, and head.
 
     ``chunk_size``, ``lower_bound``, and ``fastmath`` are compile-time
     specializations. ``fastmath`` defaults to ``False``. The operation requires
@@ -537,7 +579,7 @@ def fused_gate_bwd(
     ):
         raise RuntimeError("fused_gate_bwd does not support higher-order autograd")
 
-    dg, dA_partial = _fused_gate_bwd_custom_op(
+    dg, dA_partial, d_dt_bias = _fused_gate_bwd_custom_op(
         g,
         A_log,
         dt_bias,
@@ -546,7 +588,7 @@ def fused_gate_bwd(
         lower_bound,
         fastmath,
     )
-    return FusedGateBwdOutput(dg, dA_partial)
+    return FusedGateBwdOutput(dg, dA_partial, d_dt_bias)
 
 
 __all__ = [

--- a/attn_gym/linear/kda/bwd/triton/l2norm_bwd.py
+++ b/attn_gym/linear/kda/bwd/triton/l2norm_bwd.py
@@ -40,27 +40,37 @@ def l2norm_bwd_kernel1(
     rstd,
     dy,
     dx,
-    eps,
     D,
     Y_STRIDES: tl.constexpr,
     RSTD_STRIDES: tl.constexpr,
     DY_STRIDES: tl.constexpr,
     DX_STRIDES: tl.constexpr,
+    TOKENS: tl.constexpr,
+    HEADS: tl.constexpr,
     BD: tl.constexpr,
 ):
     # One program per row; the entire feature vector fits in a single [BD] tile.
-    i_t = tl.program_id(0).to(tl.int64)
-    o_d = tl.arange(0, BD)
+    i_row = tl.program_id(0).to(tl.int64)
+    i_bt = i_row // HEADS
+    o_d = tl.arange(0, BD).to(tl.int64)
     mask = o_d < D
 
-    b_y = tl.load(y + ptr_offset((i_t, o_d), Y_STRIDES), mask=mask, other=0.0).to(tl.float32)
-    b_dy = tl.load(dy + ptr_offset((i_t, o_d), DY_STRIDES), mask=mask, other=0.0).to(tl.float32)
-    b_rstd = tl.load(rstd + ptr_offset((i_t,), RSTD_STRIDES)).to(tl.float32)
+    b_y = tl.load(y + ptr_offset((i_row, o_d), Y_STRIDES), mask=mask, other=0.0).to(tl.float32)
+    b_dy = tl.load(
+        dy
+        + ptr_offset(
+            (i_bt // TOKENS, i_bt % TOKENS, i_row % HEADS, o_d),
+            DY_STRIDES,
+        ),
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+    b_rstd = tl.load(rstd + ptr_offset((i_row,), RSTD_STRIDES)).to(tl.float32)
 
     b_dot = tl.sum(b_dy * b_y)
     b_dx = b_rstd * (b_dy - b_y * b_dot)
     tl.store(
-        dx + ptr_offset((i_t, o_d), DX_STRIDES),
+        dx + ptr_offset((i_row, o_d), DX_STRIDES),
         b_dx.to(dx.dtype.element_ty),
         mask=mask,
     )
@@ -71,46 +81,59 @@ def l2norm_bwd_kernel1(
     key=["D", "NB"],
     **autotune_cache_kwargs,
 )
-@triton.jit(do_not_specialize=["T"])
+@triton.jit(do_not_specialize=["N_ROWS"])
 def l2norm_bwd_kernel(
     y,
     rstd,
     dy,
     dx,
-    eps,
-    T,
+    N_ROWS,
     Y_STRIDES: tl.constexpr,
     RSTD_STRIDES: tl.constexpr,
     DY_STRIDES: tl.constexpr,
     DX_STRIDES: tl.constexpr,
+    TOKENS: tl.constexpr,
+    HEADS: tl.constexpr,
     D: tl.constexpr,
     BD: tl.constexpr,
     NB: tl.constexpr,
     BT: tl.constexpr,
 ):
     # One program per [BT] block of rows; each row is normalized over [BD].
-    i_t = tl.program_id(0).to(tl.int64)
-    o_t = i_t * BT + tl.arange(0, BT)
-    o_d = tl.arange(0, BD)
-    m_t = o_t < T
-    m_x = m_t[:, None] & (o_d[None, :] < D)
+    i_row = tl.program_id(0).to(tl.int64)
+    o_row = i_row * BT + tl.arange(0, BT)
+    o_bt = o_row // HEADS
+    o_d = tl.arange(0, BD).to(tl.int64)
+    m_row = o_row < N_ROWS
+    mask = m_row[:, None] & (o_d[None, :] < D)
 
     b_y = tl.load(
-        y + ptr_offset((o_t[:, None], o_d[None, :]), Y_STRIDES),
-        mask=m_x,
+        y + ptr_offset((o_row[:, None], o_d[None, :]), Y_STRIDES),
+        mask=mask,
         other=0.0,
     ).to(tl.float32)
     b_dy = tl.load(
-        dy + ptr_offset((o_t[:, None], o_d[None, :]), DY_STRIDES),
-        mask=m_x,
+        dy
+        + ptr_offset(
+            (
+                (o_bt // TOKENS)[:, None],
+                (o_bt % TOKENS)[:, None],
+                (o_row % HEADS)[:, None],
+                o_d[None, :],
+            ),
+            DY_STRIDES,
+        ),
+        mask=mask,
         other=0.0,
     ).to(tl.float32)
-    b_rstd = tl.load(rstd + ptr_offset((o_t,), RSTD_STRIDES), mask=m_t, other=0.0).to(tl.float32)
+    b_rstd = tl.load(rstd + ptr_offset((o_row,), RSTD_STRIDES), mask=m_row, other=0.0).to(
+        tl.float32
+    )
 
     b_dot = tl.sum(b_dy * b_y, 1)
     b_dx = b_rstd[:, None] * (b_dy - b_y * b_dot[:, None])
     tl.store(
-        dx + ptr_offset((o_t[:, None], o_d[None, :]), DX_STRIDES),
+        dx + ptr_offset((o_row[:, None], o_d[None, :]), DX_STRIDES),
         b_dx.to(dx.dtype.element_ty),
-        mask=m_x,
+        mask=mask,
     )

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py
@@ -6,6 +6,7 @@ from contextlib import nullcontext
 
 import torch
 
+from attn_gym._backends.cute import get_device_properties, tensor_supports_tma
 from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd_intra import chunk_kda_fwd_intra
 from attn_gym.linear.kda.fwd.triton.chunk_delta_h import chunk_gated_delta_rule_fwd_h
 from attn_gym.linear.kda.fwd.triton.chunk_gla_fwd_o import chunk_gla_fwd_o_gk
@@ -16,8 +17,6 @@ _SUPPORTED_INPUT_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
 # but it changes the KDA decomposition and rounding order, so it can affect numerics.
 _CHUNK_SIZE = 64
 _HEAD_DIM = 128
-_QKV_ALIGNMENT_BYTES = 16
-_QKV_ALIGNMENT_ELEMENTS = _QKV_ALIGNMENT_BYTES // 2
 
 
 def _validate_chunk_kda_inputs(
@@ -73,26 +72,19 @@ def _validate_chunk_kda_inputs(
         raise ValueError("the CuTe KDA core requires K=V=128")
     if tokens % _CHUNK_SIZE:
         raise ValueError("the CuTe KDA core requires complete 64-token chunks")
-    if not torch.compiler.is_compiling() and torch.cuda.get_device_capability(q.device) < (10, 0):
+    if not torch.compiler.is_compiling() and get_device_properties(q.device).major < 10:
         raise ValueError("the CuTe KDA core requires CUDA capability 10.0 or newer")
 
 
 def _has_supported_qkv_layout(tensor: torch.Tensor) -> bool:
     """Return whether QKV rows satisfy the vectorized kernel input contract."""
-    return (
-        tensor.storage_offset() == 0
-        and tensor.stride(-1) == 1
-        and tensor.stride(-2) == tensor.shape[-1]
-        and all(stride % _QKV_ALIGNMENT_ELEMENTS == 0 for stride in tensor.stride()[:-1])
-        and tensor.data_ptr() % _QKV_ALIGNMENT_BYTES == 0
-    )
+    return tensor.stride(-2) == tensor.shape[-1] and tensor_supports_tma(tensor)
 
 
 def _normalize_qkv_layout(tensor: torch.Tensor) -> torch.Tensor:
     """Copy only layouts unsupported by one or more composed KDA stages."""
     if _has_supported_qkv_layout(tensor):
         return tensor
-    # contiguous() may return an unaligned, nonzero-offset tensor unchanged.
     return tensor.clone(memory_format=torch.contiguous_format)
 
 
@@ -120,7 +112,7 @@ def _validate_private_abi(
             "the private chunk_kda ABI requires QKV to have contiguous heads and "
             "16-byte-aligned token rows"
         )
-    if torch.cuda.get_device_capability(q.device) < (10, 0):
+    if get_device_properties(q.device).major < 10:
         raise ValueError("the CuTe KDA core requires CUDA capability 10.0 or newer")
 
 
@@ -513,8 +505,10 @@ def chunk_kda(
 
     ``cu_seqlens`` selects packed ``[1, T, H, D]`` execution. Dense batches are
     lowered to the same packed representation with equal-length sequences. Every
-    sequence must contain complete 64-token chunks. The output uses ``q.dtype``;
-    recurrent states remain FP32 and have one leading entry per logical sequence.
+    sequence must contain complete 64-token chunks. The optimized core computes Q/K/V in
+    BF16 and gates, beta, and recurrent states in FP32. FP16 or FP32 Q/K/V inputs are cast
+    to BF16 for the core, and the output is cast back to ``q.dtype``. Recurrent states remain
+    FP32 and have one leading entry per logical sequence.
     """
     _validate_chunk_kda_inputs(q, k, v, cumulative_gate, beta, initial_state, cu_seqlens)
     output_dtype = q.dtype

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_intra.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_intra.py
@@ -17,6 +17,7 @@ import torch
 import triton
 from torch._subclasses.fake_tensor import FakeTensor
 
+from attn_gym._backends.cute import get_device_properties
 from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd_inter_solve import (
     chunk_kda_fwd_inter_solve_cute,
 )
@@ -46,7 +47,7 @@ def chunk_kda_fwd_intra(
 ]:
     assert chunk_size == 64, "chunk_kda_fwd_intra CuTe path requires chunk_size=64"
 
-    max_num_grid = torch.cuda.get_device_properties(k.device).multi_processor_count
+    max_num_grid = get_device_properties(k.device).multi_processor_count
 
     B, T, H, K = k.shape
     _, _, _, V = v.shape

--- a/attn_gym/linear/kda/fwd/triton/gate_fwd.py
+++ b/attn_gym/linear/kda/fwd/triton/gate_fwd.py
@@ -269,7 +269,8 @@ def kda_gate_chunk_cumsum_vector_kernel(
         # Apply gate: -exp(A_log) * softplus(g + bias)
         b_gate = -exp(b_A) * softplus(b_s)  # pyrefly: ignore[unsupported-operation]
     else:
-        b_gate = lower_bound * tl.sigmoid(exp(b_A) * b_s)
+        # Inductor passes Python floats as fp64; keep the gate math in fp32.
+        b_gate = lower_bound.to(tl.float32) * tl.sigmoid(exp(b_A) * b_s)
 
     b_gate = tl.where(m_t[:, None], b_gate, 0.0)
 
@@ -277,7 +278,7 @@ def kda_gate_chunk_cumsum_vector_kernel(
     b_o = tl.cumsum(b_gate, axis=0, reverse=REVERSE)
 
     if HAS_SCALE:
-        b_o *= scale
+        b_o *= scale.to(tl.float32)
     o_batch_offset = i_b * o_batch_stride if B > 1 else 0
     tl.store(
         o
@@ -410,13 +411,14 @@ def kda_gate_chunk_cumsum_vector_kernel_forloop(
                 # pyrefly: ignore [unsupported-operation]
                 b_gate = -exp(b_A) * softplus(b_s)  # pyrefly: ignore[unsupported-operation]
             else:
-                b_gate = lower_bound * tl.sigmoid(exp(b_A) * b_s)
+                # Inductor passes Python floats as fp64; keep the gate math in fp32.
+                b_gate = lower_bound.to(tl.float32) * tl.sigmoid(exp(b_A) * b_s)
 
             b_gate = tl.where(m_t[:, None], b_gate, 0.0)
             b_o = tl.cumsum(b_gate, axis=0, reverse=REVERSE)
 
             if HAS_SCALE:
-                b_o *= scale
+                b_o *= scale.to(tl.float32)
             tl.store(
                 p_o[None, :] + token[:, None] * O_STRIDES[0],
                 b_o.to(o.dtype.element_ty),
@@ -455,6 +457,12 @@ def kda_gate_chunk_cumsum(
         )
     if cu_seqlens is not None and batch != 1:
         raise ValueError("packed variable-length inputs must have batch size one")
+    for name, metadata in (
+        ("cu_seqlens", cu_seqlens),
+        ("chunk_indices", chunk_indices),
+    ):
+        if metadata is not None and not metadata.is_contiguous():
+            raise ValueError(f"{name} must be contiguous")
     if chunk_indices is None and cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
     chunks = triton.cdiv(tokens, chunk_size) if cu_seqlens is None else len(chunk_indices)
@@ -532,15 +540,15 @@ class _BoundedGateCumsum(torch.autograd.Function):
                 raw_gate,
                 A_log,
                 dt_bias,
-                d_cumulative.float().contiguous(),
+                d_cumulative.float(),
                 chunk_size=ctx.chunk_size,
                 lower_bound=ctx.lower_bound,
                 fastmath=ctx.fastmath,
             )
         return (
-            result.dg.to(raw_gate.dtype),
+            result.dg,
             result.dA_partial.sum((0, 1)),
-            result.dg.sum((0, 1)),
+            result.d_dt_bias,
             None,
             None,
             None,
@@ -582,12 +590,10 @@ def bounded_gate_cumsum(
         )
     if not all(tensor.device == raw_gate.device for tensor in (A_log, dt_bias)):
         raise ValueError("bounded_gate_cumsum inputs must be on the same device")
-    if torch.cuda.get_device_capability(raw_gate.device) < (9, 0):
-        raise ValueError("bounded_gate_cumsum requires CUDA capability 9.0 or newer")
     return _BoundedGateCumsum.apply(
-        raw_gate.contiguous(),
-        A_log.contiguous(),
-        dt_bias.contiguous(),
+        raw_gate,
+        A_log,
+        dt_bias,
         chunk_size,
         lower_bound,
         fastmath,

--- a/attn_gym/linear/kda/fwd/triton/l2norm_fwd.py
+++ b/attn_gym/linear/kda/fwd/triton/l2norm_fwd.py
@@ -8,6 +8,9 @@ import triton.language as tl
 
 from attn_gym._backends.triton.utils import ptr_offset
 
+# A Triton pointer does not carry tensor shape or stride metadata. The custom-op boundary
+# keeps runtime stride tuples opaque to Dynamo while preserving ptr_offset indexing.
+
 
 @triton.autotune(
     configs=[triton.Config({}, num_warps=4)],
@@ -22,18 +25,31 @@ def l2norm_fwd_kernel1(
     X_STRIDES: tl.constexpr,
     Y_STRIDES: tl.constexpr,
     RSTD_STRIDES: tl.constexpr,
+    T: tl.constexpr,
+    H: tl.constexpr,
     D: tl.constexpr,
     BD: tl.constexpr,
 ):
-    i_t = tl.program_id(0).to(tl.int64)
-    o_d = tl.arange(0, BD)
+    i_row = tl.program_id(0).to(tl.int64)
+    i_bt = i_row // H
+    o_d = tl.arange(0, BD).to(tl.int64)
     mask = o_d < D
+    # Inductor passes Python floats as fp64; keep the reduction in fp32.
+    eps = eps.to(tl.float32)
 
-    b_x = tl.load(x + ptr_offset((i_t, o_d), X_STRIDES), mask=mask, other=0.0).to(tl.float32)
+    b_x = tl.load(
+        x
+        + ptr_offset(
+            (i_bt // T, i_bt % T, i_row % H, o_d),
+            X_STRIDES,
+        ),
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
     b_rstd = 1 / tl.sqrt(tl.sum(b_x * b_x) + eps)
     b_y = b_x * b_rstd
-    tl.store(y + ptr_offset((i_t, o_d), Y_STRIDES), b_y, mask=mask)
-    tl.store(rstd + ptr_offset((i_t,), RSTD_STRIDES), b_rstd)
+    tl.store(y + ptr_offset((i_row, o_d), Y_STRIDES), b_y, mask=mask)
+    tl.store(rstd + ptr_offset((i_row,), RSTD_STRIDES), b_rstd)
 
 
 @triton.autotune(
@@ -48,23 +64,37 @@ def l2norm_fwd_kernel(
     y,
     rstd,
     eps,
-    T,
+    N_ROWS,
     X_STRIDES: tl.constexpr,
     Y_STRIDES: tl.constexpr,
     RSTD_STRIDES: tl.constexpr,
+    T: tl.constexpr,
+    H: tl.constexpr,
     D: tl.constexpr,
     BD: tl.constexpr,
     NB,
     BT: tl.constexpr,
 ):
-    i_t = tl.program_id(0).to(tl.int64)
-    o_t = i_t * BT + tl.arange(0, BT)
-    o_d = tl.arange(0, BD)
-    m_t = o_t < T
-    mask = m_t[:, None] & (o_d[None, :] < D)
+    i_row = tl.program_id(0).to(tl.int64)
+    o_row = i_row * BT + tl.arange(0, BT)
+    o_bt = o_row // H
+    o_d = tl.arange(0, BD).to(tl.int64)
+    m_row = o_row < N_ROWS
+    mask = m_row[:, None] & (o_d[None, :] < D)
+    # Inductor passes Python floats as fp64; keep the reduction in fp32.
+    eps = eps.to(tl.float32)
 
     b_x = tl.load(
-        x + ptr_offset((o_t[:, None], o_d[None, :]), X_STRIDES),
+        x
+        + ptr_offset(
+            (
+                (o_bt // T)[:, None],
+                (o_bt % T)[:, None],
+                (o_row % H)[:, None],
+                o_d[None, :],
+            ),
+            X_STRIDES,
+        ),
         mask=mask,
         other=0.0,
     ).to(tl.float32)
@@ -72,80 +102,126 @@ def l2norm_fwd_kernel(
     b_y = b_x * b_rstd[:, None]
 
     tl.store(
-        y + ptr_offset((o_t[:, None], o_d[None, :]), Y_STRIDES),
+        y + ptr_offset((o_row[:, None], o_d[None, :]), Y_STRIDES),
         b_y.to(y.dtype.element_ty),
         mask=mask,
     )
     tl.store(
-        rstd + ptr_offset((o_t,), RSTD_STRIDES),
+        rstd + ptr_offset((o_row,), RSTD_STRIDES),
         b_rstd.to(rstd.dtype.element_ty),
-        mask=m_t,
+        mask=m_row,
     )
+
+
+@torch.library.custom_op("attn_gym::kda_l2norm_fwd", mutates_args=())
+def _l2norm_fwd_custom_op(x: torch.Tensor, eps: float) -> tuple[torch.Tensor, torch.Tensor]:
+    """Launch L2Norm using runtime shape and stride metadata."""
+    _, tokens, heads, head_dim = x.shape
+    # Compact outputs enumerate rows in the same batch-token-head order reconstructed by
+    # the kernel, regardless of the input's physical strides.
+    rows = x.numel() // head_dim
+    output = torch.empty(rows, head_dim, dtype=x.dtype, device=x.device)
+    rstd = torch.empty(rows, dtype=torch.float32, device=x.device)
+    block_dim = triton.next_power_of_2(head_dim)
+    grid = lambda meta: (triton.cdiv(rows, meta["BT"]),)
+    l2norm_fwd_kernel[grid](
+        x,
+        output,
+        rstd,
+        eps,
+        rows,
+        X_STRIDES=x.stride(),
+        Y_STRIDES=output.stride(),
+        RSTD_STRIDES=rstd.stride(),
+        T=tokens,
+        H=heads,
+        D=head_dim,
+        BD=block_dim,
+        NB=triton.cdiv(rows, 16),
+    )
+    return output.view_as(x), rstd
+
+
+@_l2norm_fwd_custom_op.register_fake
+def _l2norm_fwd_fake(x: torch.Tensor, eps: float) -> tuple[torch.Tensor, torch.Tensor]:
+    """Describe compact output metadata without launching Triton."""
+    del eps
+    rows = x.numel() // x.shape[-1]
+    return (
+        torch.empty_like(x, memory_format=torch.contiguous_format),
+        torch.empty(rows, dtype=torch.float32, device=x.device),
+    )
+
+
+@torch.library.custom_op("attn_gym::kda_l2norm_bwd", mutates_args=())
+def _l2norm_bwd_custom_op(
+    output: torch.Tensor,
+    rstd: torch.Tensor,
+    d_output: torch.Tensor,
+) -> torch.Tensor:
+    """Launch L2Norm backward behind the same opaque stride boundary."""
+    from attn_gym.linear.kda.bwd.triton.l2norm_bwd import l2norm_bwd_kernel
+
+    rows, head_dim = output.shape
+    _, tokens, heads, _ = d_output.shape
+    d_input = torch.empty_like(output)
+    block_dim = triton.next_power_of_2(head_dim)
+    grid = lambda meta: (triton.cdiv(rows, meta["BT"]),)
+    l2norm_bwd_kernel[grid](
+        output,
+        rstd,
+        d_output,
+        d_input,
+        rows,
+        Y_STRIDES=output.stride(),
+        RSTD_STRIDES=rstd.stride(),
+        DY_STRIDES=d_output.stride(),
+        DX_STRIDES=d_input.stride(),
+        TOKENS=tokens,
+        HEADS=heads,
+        D=head_dim,
+        BD=block_dim,
+        NB=triton.cdiv(rows, 16),
+    )
+    return d_input
+
+
+@_l2norm_bwd_custom_op.register_fake
+def _l2norm_bwd_fake(
+    output: torch.Tensor,
+    rstd: torch.Tensor,
+    d_output: torch.Tensor,
+) -> torch.Tensor:
+    """Describe the compact input-gradient metadata."""
+    del rstd, d_output
+    return torch.empty_like(output)
 
 
 class _L2Norm(torch.autograd.Function):
     @staticmethod
     def forward(ctx, x: torch.Tensor, eps: float) -> torch.Tensor:
-        rows = x.numel() // x.shape[-1]
-        matrix = x.contiguous().view(rows, x.shape[-1])
-        output = torch.empty_like(matrix)
-        rstd = torch.empty(rows, dtype=torch.float32, device=x.device)
-        block_dim = triton.next_power_of_2(x.shape[-1])
-        grid = lambda meta: (triton.cdiv(rows, meta["BT"]),)
-        l2norm_fwd_kernel[grid](
-            matrix,
-            output,
-            rstd,
-            eps,
-            rows,
-            X_STRIDES=matrix.stride(),
-            Y_STRIDES=output.stride(),
-            RSTD_STRIDES=rstd.stride(),
-            D=x.shape[-1],
-            BD=block_dim,
-            NB=triton.cdiv(rows, 16),
-        )
-        ctx.save_for_backward(output, rstd)
+        output, rstd = _l2norm_fwd_custom_op(x, eps)
+        ctx.save_for_backward(output.view(-1, x.shape[-1]), rstd)
         ctx.input_shape = x.shape
-        ctx.eps = eps
-        return output.view_as(x)
+        return output
 
     @staticmethod
     @torch.autograd.function.once_differentiable
     def backward(ctx, d_output: torch.Tensor):
-        from attn_gym.linear.kda.bwd.triton.l2norm_bwd import l2norm_bwd_kernel
-
         output, rstd = ctx.saved_tensors
-        rows, head_dim = output.shape
-        d_output = d_output.contiguous().view_as(output)
-        d_input = torch.empty_like(output)
-        block_dim = triton.next_power_of_2(head_dim)
-        grid = lambda meta: (triton.cdiv(rows, meta["BT"]),)
-        l2norm_bwd_kernel[grid](
-            output,
-            rstd,
-            d_output,
-            d_input,
-            ctx.eps,
-            rows,
-            Y_STRIDES=output.stride(),
-            RSTD_STRIDES=rstd.stride(),
-            DY_STRIDES=d_output.stride(),
-            DX_STRIDES=d_input.stride(),
-            D=head_dim,
-            BD=block_dim,
-            NB=triton.cdiv(rows, 16),
-        )
+        d_input = _l2norm_bwd_custom_op(output, rstd, d_output)
         return d_input.view(ctx.input_shape), None
 
 
 def l2norm(x: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
-    """Apply row-wise L2 normalization with a first-order Triton backward."""
+    """Normalize each final-dimension row of a KDA ``[B, T, H, D]`` tensor."""
     if not x.is_cuda:
         raise ValueError("l2norm requires a CUDA tensor")
     if x.dtype not in (torch.float16, torch.bfloat16, torch.float32):
         raise TypeError("l2norm requires float16, bfloat16, or float32 input")
-    if x.ndim < 1 or x.shape[-1] < 1:
+    if x.ndim != 4:
+        raise ValueError(f"x must have shape [B, T, H, D], got {tuple(x.shape)}")
+    if x.shape[-1] < 1:
         raise ValueError(f"x must have a nonempty final dimension, got {tuple(x.shape)}")
     if x.numel() == 0:
         raise ValueError(f"x must contain at least one row, got {tuple(x.shape)}")

--- a/examples/kda_training.py
+++ b/examples/kda_training.py
@@ -476,7 +476,7 @@ def main(
     )
     if compile_model:
         model = torch.compile(model, fullgraph=True, mode="reduce-overhead")
-    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3, fused=True)
     cu_seqlens = None
     input_shape = (batch_size, tokens, hidden_size)
     layout_name = ""

--- a/test/test_kda_cute_forward.py
+++ b/test/test_kda_cute_forward.py
@@ -539,7 +539,7 @@ def test_delta_h_dispatch_counts_packed_sequences(monkeypatch):
         multi_processor_count = 100
 
     monkeypatch.setattr(dispatch, "blackwell_delta_h_bwd_dhu_v1", fake_delta_h)
-    monkeypatch.setattr(torch.cuda, "get_device_properties", lambda _device: DeviceProperties())
+    monkeypatch.setattr(dispatch, "get_device_properties", lambda _device: DeviceProperties())
     tensor = torch.empty(1, 1, 2, 128, device="cuda")
     cu_seqlens = torch.arange(8, dtype=torch.int32, device="cuda")
     actual = dispatch.blackwell_delta_h_bwd_dhu_dispatch(

--- a/test/test_kda_fused_gate_bwd.py
+++ b/test/test_kda_fused_gate_bwd.py
@@ -16,6 +16,7 @@ import torch
 pytest.importorskip("cutlass")
 triton = pytest.importorskip("triton")
 
+from attn_gym._backends.cute import tensor_supports_tma
 from attn_gym.linear.kda.bwd.cute.gate_bwd_fused import (
     FusedGateBwdOp,
     FusedGateBwdOutput,
@@ -88,10 +89,10 @@ def _fused_reference(inputs, lower_bound=-5.0, chunk_size=64):
 
 
 def _expected_output(inputs, lower_bound=-5.0, chunk_size=64):
-    """Build the partial-output ABI from the canonical backward reference."""
+    """Build the kernel output ABI and the final dA_log from the canonical reference."""
     dg, dA_log, d_dt_bias = _fused_reference(inputs, lower_bound, chunk_size)
     z = inputs[0].float() + inputs[2]
-    partials = torch.stack(
+    dA_partial = torch.stack(
         [
             (dg_chunk * z_chunk).sum((1, 3))
             for dg_chunk, z_chunk in zip(
@@ -102,18 +103,29 @@ def _expected_output(inputs, lower_bound=-5.0, chunk_size=64):
         ],
         dim=1,
     )
-    return FusedGateBwdOutput(dg, partials), dA_log, d_dt_bias
+    return FusedGateBwdOutput(dg, dA_partial, d_dt_bias), dA_log
+
+
+def _assert_bf16_within_one_ulp(actual, expected):
+    """Require BF16 ``actual`` to be the rounded FP32 reference or an adjacent BF16 value."""
+    assert actual.dtype == torch.bfloat16
+    rounded = expected.to(torch.bfloat16)
+    assert actual.isfinite().all() and rounded.isfinite().all()
+    lower = torch.nextafter(rounded, torch.full_like(rounded, -torch.inf))
+    upper = torch.nextafter(rounded, torch.full_like(rounded, torch.inf))
+    assert ((actual >= lower) & (actual <= upper)).all()
 
 
 def _assert_output_close(actual, expected):
-    """Compare the two tensors produced by the partial-output ABI."""
-    torch.testing.assert_close(actual.dg, expected.dg, rtol=3e-5, atol=4e-5)
+    """Compare the gate gradient and both parameter gradients."""
+    _assert_bf16_within_one_ulp(actual.dg, expected.dg)
     torch.testing.assert_close(
         actual.dA_partial,
         expected.dA_partial,
         rtol=5e-5,
         atol=5e-4,
     )
+    torch.testing.assert_close(actual.d_dt_bias, expected.d_dt_bias, rtol=5e-5, atol=7e-4)
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -201,9 +213,33 @@ def test_bounded_gate_cumsum_autograd_boundary():
         chunk_size=64,
     )
 
-    torch.testing.assert_close(actual[0].float(), expected[0], rtol=2e-2, atol=2e-3)
+    _assert_bf16_within_one_ulp(actual[0], expected[0])
     torch.testing.assert_close(actual[1], expected[1], rtol=5e-5, atol=5e-4)
     torch.testing.assert_close(actual[2], expected[2], rtol=5e-5, atol=7e-4)
+
+
+def test_bounded_gate_cumsum_compile_matches_eager():
+    """Keep compiled gate forward and backward equivalent to eager execution."""
+    g, A_log, dt_bias, d_cumulative = _inputs(1024, heads=2, batch=1)
+    expected_inputs = tuple(tensor.detach().requires_grad_() for tensor in (g, A_log, dt_bias))
+    actual_inputs = tuple(tensor.detach().clone().requires_grad_() for tensor in expected_inputs)
+
+    def operation(g, A_log, dt_bias):
+        return bounded_gate_cumsum(g, A_log, dt_bias, lower_bound=-3.25)
+
+    expected = operation(*expected_inputs)
+    actual = torch.compile(operation, fullgraph=True)(*actual_inputs)
+    expected_gradients = torch.autograd.grad(expected, expected_inputs, d_cumulative)
+    actual_gradients = torch.autograd.grad(actual, actual_inputs, d_cumulative)
+
+    # The gate gradient leaves the kernel unchanged, while Inductor may reduce the
+    # parameter gradients in a different order than eager.
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    torch.testing.assert_close(actual_gradients[0], expected_gradients[0], rtol=0, atol=0)
+    for actual_gradient, expected_gradient in zip(
+        actual_gradients[1:], expected_gradients[1:], strict=True
+    ):
+        torch.testing.assert_close(actual_gradient, expected_gradient, rtol=5e-5, atol=7e-4)
 
 
 @pytest.mark.parametrize(
@@ -222,23 +258,18 @@ def test_bounded_gate_cumsum_autograd_boundary():
 def test_fused_gate_bwd_matches_reference(tokens, head_dim, lower_bound, chunk_size):
     """Cover TMA tails and independent static semantic specializations."""
     inputs = _inputs(tokens, head_dim=head_dim)
-    expected, expected_dA, expected_dt_bias = _expected_output(
-        inputs,
-        lower_bound,
-        chunk_size,
-    )
+    expected, expected_dA = _expected_output(inputs, lower_bound, chunk_size)
 
     actual = fused_gate_bwd(*inputs, lower_bound=lower_bound, chunk_size=chunk_size)
 
     _assert_output_close(actual, expected)
     torch.testing.assert_close(actual.dA_partial.sum((0, 1)), expected_dA, rtol=5e-5, atol=7e-4)
-    torch.testing.assert_close(actual.dg.sum((0, 1)), expected_dt_bias, rtol=5e-5, atol=7e-4)
 
 
 def test_fused_gate_bwd_fastmath_specialization_is_correct():
     """Keep the non-default exponential mode numerically valid."""
     inputs = _inputs(65, heads=17)
-    expected, expected_dA, _expected_dt_bias = _expected_output(inputs, -4.75)
+    expected, expected_dA = _expected_output(inputs, -4.75)
 
     actual = fused_gate_bwd(*inputs, lower_bound=-4.75, fastmath=True)
 
@@ -308,10 +339,21 @@ def test_fused_gate_bwd_matches_triton_composition():
     )
 
     actual = fused_gate_bwd(*inputs)
-    torch.testing.assert_close(actual.dg[0], triton_dg, rtol=1e-4, atol=1e-3)
+    torch.testing.assert_close(
+        actual.dg[0].float(),
+        triton_dg,
+        rtol=torch.finfo(torch.bfloat16).eps,
+        atol=1e-3,
+    )
     torch.testing.assert_close(
         actual.dA_partial.sum((0, 1)),
         triton_dA_partial.sum(0),
+        rtol=2e-4,
+        atol=2e-2,
+    )
+    torch.testing.assert_close(
+        actual.d_dt_bias,
+        triton_dg.sum(0),
         rtol=2e-4,
         atol=2e-2,
     )
@@ -333,20 +375,44 @@ def test_fused_gate_bwd_requires_batch_dimension():
         fused_gate_bwd(g[0], A_log, dt_bias, d_cumulative[0])
 
 
-def test_fused_gate_bwd_custom_op_rejects_noncontiguous_input():
-    """Enforce the compact fake ABI at the private operator boundary."""
+def test_fused_gate_bwd_reads_aligned_strided_rows_directly():
+    """Avoid compacting packed projections whose trailing rows satisfy TMA alignment."""
+    batch, tokens, heads, head_dim = 2, 17, 16, 64
+    torch.manual_seed(10)
+    g = torch.randn(batch, tokens, 3, heads, head_dim, device="cuda", dtype=torch.bfloat16)[
+        :, :, 0
+    ]
+    d_cumulative = torch.randn(
+        batch, tokens, 2, heads, head_dim, device="cuda", dtype=torch.float32
+    )[:, :, 0]
+    A_log = torch.randn(2 * heads, device="cuda", dtype=torch.float32)[::2]
+    dt_bias = torch.randn(heads, 2 * head_dim, device="cuda", dtype=torch.float32)[:, ::2]
+    inputs = (g, A_log, dt_bias, d_cumulative)
+    assert tensor_supports_tma(g)
+    assert tensor_supports_tma(d_cumulative)
+    assert not A_log.is_contiguous()
+    assert not dt_bias.is_contiguous()
+
+    expected_dg, expected_dA, expected_dt_bias = _fused_reference(inputs, -3.25, 7)
+    compiled = torch.compile(fused_gate_bwd, fullgraph=True, dynamic=True)
+    actual = compiled(*inputs, lower_bound=-3.25, chunk_size=7)
+    _assert_bf16_within_one_ulp(actual.dg, expected_dg)
+    torch.testing.assert_close(actual.dA_partial.sum((0, 1)), expected_dA, rtol=5e-5, atol=7e-4)
+    torch.testing.assert_close(actual.d_dt_bias, expected_dt_bias, rtol=5e-5, atol=7e-4)
+
+
+def test_fused_gate_bwd_compacts_unsupported_inner_stride():
+    """Retain a safe fallback when the feature dimension is not contiguous."""
     _g, A_log, dt_bias, d_cumulative = _inputs(17, head_dim=64)
-    strided_g = torch.empty(2, 17, 16, 128, device="cuda", dtype=torch.bfloat16)[..., ::2]
-    with pytest.raises(ValueError, match="requires contiguous"):
-        _fused_gate_bwd_custom_op(
-            strided_g,
-            A_log,
-            dt_bias,
-            d_cumulative,
-            32,
-            -3.25,
-            False,
-        )
+    g = torch.randn(2, 17, 16, 128, device="cuda", dtype=torch.bfloat16)[..., ::2]
+    assert not tensor_supports_tma(g)
+
+    inputs = (g, A_log, dt_bias, d_cumulative)
+    expected_dg, expected_dA, expected_dt_bias = _fused_reference(inputs, -3.25, 7)
+    actual = fused_gate_bwd(*inputs, lower_bound=-3.25, chunk_size=7)
+    _assert_bf16_within_one_ulp(actual.dg, expected_dg)
+    torch.testing.assert_close(actual.dA_partial.sum((0, 1)), expected_dA, rtol=5e-5, atol=7e-4)
+    torch.testing.assert_close(actual.d_dt_bias, expected_dt_bias, rtol=5e-5, atol=7e-4)
 
 
 def test_fused_gate_bwd_fullgraph_dynamic():
@@ -354,17 +420,18 @@ def test_fused_gate_bwd_fullgraph_dynamic():
     compiled = torch.compile(fused_gate_bwd, fullgraph=True, dynamic=True)
     for batch, tokens in ((1, 63), (3, 65)):
         inputs = _inputs(tokens, head_dim=64, batch=batch)
-        expected_dg, expected_dA, _expected_dt_bias = _fused_reference(inputs, -3.25, 7)
+        expected_dg, expected_dA, expected_dt_bias = _fused_reference(inputs, -3.25, 7)
         actual = compiled(
             *inputs,
             lower_bound=-3.25,
             chunk_size=7,
             fastmath=False,
         )
-        torch.testing.assert_close(actual.dg, expected_dg, rtol=3e-5, atol=4e-5)
+        _assert_bf16_within_one_ulp(actual.dg, expected_dg)
         torch.testing.assert_close(
             actual.dA_partial.sum((0, 1)), expected_dA, rtol=5e-5, atol=7e-4
         )
+        torch.testing.assert_close(actual.d_dt_bias, expected_dt_bias, rtol=5e-5, atol=7e-4)
 
 
 def test_fused_gate_bwd_cuda_graph_replay():
@@ -379,13 +446,14 @@ def test_fused_gate_bwd_cuda_graph_replay():
     captured_dg = actual.dg.clone()
 
     inputs[-1].mul_(-0.5).add_(0.25)
-    expected_dg, expected_dA, _expected_dt_bias = _fused_reference(inputs, -3.25, 7)
+    expected_dg, expected_dA, expected_dt_bias = _fused_reference(inputs, -3.25, 7)
     graph.replay()
     torch.cuda.synchronize()
 
     assert not torch.equal(actual.dg, captured_dg)
-    torch.testing.assert_close(actual.dg, expected_dg, rtol=3e-5, atol=4e-5)
+    _assert_bf16_within_one_ulp(actual.dg, expected_dg)
     torch.testing.assert_close(actual.dA_partial.sum((0, 1)), expected_dA, rtol=5e-5, atol=7e-4)
+    torch.testing.assert_close(actual.d_dt_bias, expected_dt_bias, rtol=5e-5, atol=7e-4)
 
 
 def test_fused_gate_bwd_rejects_invalid_static_scalars():

--- a/test/test_kda_kernels.py
+++ b/test/test_kda_kernels.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+import math
 from itertools import product
 
 import pytest
@@ -47,6 +48,8 @@ from attn_gym.linear.kda.fwd.triton.gate_fwd import (
     kda_gate_chunk_cumsum_vector_kernel_forloop,
 )
 from attn_gym.linear.kda.fwd.triton.l2norm_fwd import (
+    _l2norm_bwd_custom_op,
+    _l2norm_fwd_custom_op,
     l2norm,
     l2norm_fwd_kernel,
     l2norm_fwd_kernel1,
@@ -253,9 +256,11 @@ def test_l2norm_fwd(dtype, T, D, strided):
         rstd,
         eps,
         T,
-        X_STRIDES=x.stride(),
+        X_STRIDES=(0, x.stride(0), 0, x.stride(1)),
         Y_STRIDES=y.stride(),
         RSTD_STRIDES=rstd.stride(),
+        T=T,
+        H=1,
         D=D,
         BD=BD,
         NB=triton.cdiv(T, 16),
@@ -271,9 +276,11 @@ def test_l2norm_fwd(dtype, T, D, strided):
         y1,
         rstd1,
         eps,
-        X_STRIDES=x.stride(),
+        X_STRIDES=(0, x.stride(0), 0, x.stride(1)),
         Y_STRIDES=y1.stride(),
         RSTD_STRIDES=rstd1.stride(),
+        T=T,
+        H=1,
         D=D,
         BD=BD,
     )
@@ -301,6 +308,55 @@ def test_l2norm_autograd_wrapper(dtype):
     )
 
 
+def test_l2norm_custom_op_registration():
+    x = torch.randn(1, 17, 3, 128, device=DEV, dtype=torch.bfloat16)
+    torch.library.opcheck(_l2norm_fwd_custom_op, (x, 1e-6))
+
+    output, rstd = _l2norm_fwd_custom_op(x, 1e-6)
+    d_output = torch.randn_like(output)
+    torch.library.opcheck(
+        _l2norm_bwd_custom_op,
+        (output.view(-1, output.shape[-1]), rstd, d_output),
+    )
+
+
+@pytest.mark.parametrize(
+    "layout",
+    (
+        "compact",
+        "packed-qkv-view",
+        "arbitrary-head-inner-strides",
+        "arbitrary-batch-token-strides",
+    ),
+)
+def test_l2norm_compile_matches_eager(layout):
+    """Keep compiled normalization equivalent across direct and fallback layouts."""
+    torch.manual_seed(2)
+    if layout == "packed-qkv-view":
+        x = torch.randn(1, 1024, 3, 2, 128, device=DEV, dtype=torch.bfloat16)[:, :, 0]
+        assert x.stride() == (1024 * 3 * 2 * 128, 3 * 2 * 128, 128, 1)
+    elif layout == "arbitrary-head-inner-strides":
+        x = torch.randn(1, 1024, 128, 2, device=DEV, dtype=torch.bfloat16).transpose(-1, -2)
+        assert x.stride() == (1024 * 2 * 128, 2 * 128, 1, 2)
+    elif layout == "arbitrary-batch-token-strides":
+        x = torch.randn(128, 2, 2, 128, device=DEV, dtype=torch.bfloat16).transpose(0, 1)
+        assert x.stride() == (2 * 128, 2 * 2 * 128, 128, 1)
+    else:
+        x = torch.randn(1, 1024, 2, 128, device=DEV, dtype=torch.bfloat16)
+
+    x.requires_grad_()
+    d_output = torch.randn_like(x)
+    expected = l2norm(x)
+    actual = torch.compile(l2norm, fullgraph=True, dynamic=True)(x)
+    expected_gradient = torch.autograd.grad(expected, x, d_output)[0]
+    actual_gradient = torch.autograd.grad(actual, x, d_output)[0]
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    lower = torch.nextafter(expected_gradient, torch.full_like(expected_gradient, -torch.inf))
+    upper = torch.nextafter(expected_gradient, torch.full_like(expected_gradient, torch.inf))
+    assert ((actual_gradient >= lower) & (actual_gradient <= upper)).all()
+
+
 @pytest.mark.parametrize("dtype", [torch.float64, torch.int32], ids=["fp64", "int32"])
 def test_l2norm_rejects_unsupported_dtype(dtype):
     x = torch.ones(2, 8, device=DEV, dtype=dtype)
@@ -308,9 +364,14 @@ def test_l2norm_rejects_unsupported_dtype(dtype):
         l2norm(x)
 
 
+def test_l2norm_rejects_non_kda_shape():
+    with pytest.raises(ValueError, match=r"shape \[B, T, H, D\]"):
+        l2norm(torch.empty(2, 128, device=DEV))
+
+
 def test_l2norm_rejects_empty_outer_dimension():
     with pytest.raises(ValueError, match="at least one row"):
-        l2norm(torch.empty(0, 128, device=DEV))
+        l2norm(torch.empty(1, 0, 2, 128, device=DEV))
 
 
 # l2norm backward   dx = rstd * (dy - y * <dy, y>)
@@ -338,17 +399,20 @@ def test_l2norm_bwd(dtype, T, D, strided):
 
     dx = _empty_strided_like(y) if strided else torch.empty_like(y)
     grid = lambda meta: (triton.cdiv(T, meta["BT"]),)
+    # Present physical [T, D] storage to the kernel as logical [1, T, 1, D].
+    dy_strides = (0, dy.stride(0), 0, dy.stride(1))
     l2norm_bwd_kernel[grid](
         y,
         rstd,
         dy,
         dx,
-        eps,
         T,
         Y_STRIDES=y.stride(),
         RSTD_STRIDES=rstd.stride(),
-        DY_STRIDES=dy.stride(),
+        DY_STRIDES=dy_strides,
         DX_STRIDES=dx.stride(),
+        TOKENS=T,
+        HEADS=1,
         D=D,
         BD=BD,
         NB=triton.cdiv(T, 16),
@@ -361,12 +425,13 @@ def test_l2norm_bwd(dtype, T, D, strided):
         rstd,
         dy,
         dx1,
-        eps,
         D,
         Y_STRIDES=y.stride(),
         RSTD_STRIDES=rstd.stride(),
-        DY_STRIDES=dy.stride(),
+        DY_STRIDES=dy_strides,
         DX_STRIDES=dx1.stride(),
+        TOKENS=T,
+        HEADS=1,
         BD=BD,
     )
     assert_golden(dx1, golden, ref, dtype, f"l2norm_bwd_kernel1 T={T} D={D}")
@@ -1696,7 +1761,7 @@ def test_delta_h_bwd_dhu_dispatch_selects_bv(monkeypatch, sm_count, expected_bv)
     class _Props:
         multi_processor_count = sm_count
 
-    monkeypatch.setattr(dispatch_mod.torch.cuda, "get_device_properties", lambda device: _Props())
+    monkeypatch.setattr(dispatch_mod, "get_device_properties", lambda device: _Props())
     monkeypatch.setattr(dispatch_mod, "blackwell_delta_h_bwd_dhu_v1", fake_v1)
 
     dispatch_mod.blackwell_delta_h_bwd_dhu_dispatch(q, q, q, zeros, zeros)
@@ -1858,8 +1923,8 @@ def _bwd_intra_ref(q, k, g, beta, dAqk, dAkk, chunk_size=64, cu_seqlens=None, ch
                    dg += sum_j dAkk*exp2*beta_i*k_i*k_j - sum_i (same)
 
     Both dAqk and dAkk are masked with a NON-strict causal mask (i>=j, incl. diagonal) to
-    match fla upstream. No ``scale`` (folded upstream into dAqk) and no ``ln2`` in dg (the
-    kernel differentiates 2^g directly without the chain-rule factor, by convention).
+    match fla upstream. There is no ``scale`` because it is folded upstream into dAqk.
+    The final ``dg`` writer applies ``ln(2)`` for the derivative of ``2**g``.
     """
     B, T, H, Kd = q.shape
     device = q.device
@@ -1899,7 +1964,7 @@ def _bwd_intra_ref(q, k, g, beta, dAqk, dAkk, chunk_size=64, cu_seqlens=None, ch
             dk[b, s] += (akk * k_j).sum(1) + (akk * k_i).sum(0)
             db[b, s] = (ak * (exp2 * k_i * k_j).sum(-1)).sum(1)
             dg[b, s] += t_akk.sum(1) - t_akk.sum(0)
-    return dq, dk, db, dg
+    return dq, dk, db, dg * math.log(2.0)
 
 
 @requires_cute


### PR DESCRIPTION
## Human Note

## Agent note

Avoid materializing packed row-strided Q and K inputs in L2Norm by indexing the complete runtime
`[B, T, H, D]` stride tuple through `ptr_offset`. L2Norm backward also reads arbitrary-stride
upstream gradients directly. Both Triton launchers sit behind private custom operators because
Dynamo cannot currently pass symbolic stride tuples directly to Triton, preserving the natural
kernel ABI under dynamic full-graph compilation.

Explicitly cast Python scalar arguments to FP32 to prevent compiled FP64 promotion. Fold the final
`ln(2)` scaling into the sole KDA backward-intra `dg` writer. Have fused gate backward emit BF16
`dg` directly while accumulating deterministic FP32 dt-bias partials before conversion, removing
both full-gradient post-passes without reducing parameter-gradient precision. The fused TMA backward
now consumes aligned strided gate and upstream-gradient rows directly, accepts arbitrary parameter
strides, and compacts only unsupported staged layouts. Shared CuTe utilities expose the common
`TMA_ALIGNMENT_BYTES` and `tensor_supports_tma` contract. The BF16 tests compare against the rounded
FP32 reference and permit at most one adjacent representable value.

The composed KDA core remains an explicitly mixed-precision implementation: Q/K/V compute is BF16,
while cumulative gates, beta, and recurrent state compute is FP32. FP16 or FP32 Q/K/V inputs are
converted to BF16 for the optimized core and the output is converted back to the original Q dtype.

## Performance

GB300, B=1, T=16384, H=32, D=128:

| Measurement | Before | After |
| --- | ---: | ---: |
| Packed Q/K L2Norm including copies | 180.7 us | 42.0 us |
| Eager training aggregate kernel time | 9.199 ms | 8.766 ms |
| Compiled training aggregate kernel time | 8.097 ms | 7.816 ms |

The folded `ln(2)`, BF16 conversion, and full-`dg` dt-bias passes removed approximately 188 us of
standalone work; the fused producer kernels absorbed the extra arithmetic with a small local cost.

## Test Plan

```bash
PYTHONPATH=$PWD gpu-run auto -- ~/.venvs/nightly/bin/pytest -q test/test_kda_kernels.py  # 152 passed
PYTHONPATH=$PWD gpu-run auto -- ~/.venvs/nightly/bin/pytest -q test/test_kda_fused_gate_bwd.py  # 30 passed
PYTHONPATH=$PWD gpu-run auto -- ~/.venvs/nightly/bin/pytest -q test/test_kda_cute_forward.py
PYTHONPATH=$PWD gpu-run auto -- ~/.venvs/nightly/bin/pytest -q test/test_kda.py test/linear/test_gdn.py test/test_kda_cute_recompute.py
prek run --files attn_gym/linear/kda/bwd/cute/chunk_kda_bwd.py attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_intra.py attn_gym/linear/kda/bwd/cute/gate_bwd_fused.py attn_gym/linear/kda/bwd/triton/l2norm_bwd.py attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py attn_gym/linear/kda/fwd/triton/gate_fwd.py attn_gym/linear/kda/fwd/triton/l2norm_fwd.py test/test_kda_fused_gate_bwd.py test/test_kda_kernels.py
```

Related compiler issue: https://github.com/pytorch/pytorch/issues/193257


