### PR TITLE
Cache Modal test images by nightly date

### DIFF
--- a/modal_tests.py
+++ b/modal_tests.py
@@ -1,16 +1,20 @@
 import os
 import subprocess
 import xml.etree.ElementTree as ET
+from datetime import UTC, datetime
 from pathlib import Path
 
 import modal
 
 ROOT_PATH = Path(__file__).parent
 PYTORCH_NIGHTLY_INDEX = "https://download.pytorch.org/whl/nightly/cu132"
+# Rebuild once per UTC day without disabling Modal's cache for every commit.
+NIGHTLY_CACHE_DATE = datetime.now(UTC).date().isoformat()
 
 image = (
     modal.Image.debian_slim(python_version="3.12")
-    .pip_install("torch", pre=True, index_url=PYTORCH_NIGHTLY_INDEX, force_build=True)
+    .env({"PYTORCH_NIGHTLY_CACHE_DATE": NIGHTLY_CACHE_DATE})
+    .pip_install("torch", pre=True, index_url=PYTORCH_NIGHTLY_INDEX)
     .pip_install_from_pyproject(
         str(ROOT_PATH / "pyproject.toml"), optional_dependencies=["tests"], pre=True
     )


### PR DESCRIPTION
## Human Note

## Agent note

Stop forcing the Modal test image to rebuild on every commit. Instead, add the UTC date as an image
layer cache key so PyTorch nightly and its dependent test packages rebuild once per day, while
same-day commits reuse those layers. Source and test directories remain runtime mounts and therefore
do not invalidate the dependency image.

This preserves daily nightly coverage without pinning an indefinitely stale PyTorch build.

## Performance

The latest main run spent 114.77s rebuilding the PyTorch/CUDA layer and 17.72s rebuilding test
dependencies, or 132.49s total. Same-day cache hits can now avoid those rebuilds; the first run of
each UTC day still refreshes the nightly.

## Test Plan

```bash
uv tool run ruff check modal_tests.py
~/.venvs/nightly/bin/python -m py_compile modal_tests.py
uv tool run --from modal python -c 'import modal_tests; print(modal_tests.NIGHTLY_CACHE_DATE)'
```

Manual Modal validation: https://github.com/meta-pytorch/attention-gym/actions/runs/31662312566
