### PR TITLE
Optimize CuTeDSL warm cache lookups

### DIFF
--- a/.agents/skills/cutedsl-tunable-kernel-template/SKILL.md
+++ b/.agents/skills/cutedsl-tunable-kernel-template/SKILL.md
@@ -174,7 +174,12 @@ process-global and sticky; callers that temporarily override it must restore the
 
 Inside `compile(...)`:
 
-1. Accept only static values that completely determine generated code and the fake ABI.
+1. Accept only static values that completely determine generated code and the fake ABI. Keep them
+   structurally stable so `jit_cache` can encode them for warm process-local lookups before
+   constructing a persistent hash or cache path. When the call tuple is not the right specialization
+   identity, pass `cache_key=` a pure function returning a complete hashable tuple or frozen config.
+   Return the structural key itself, never `hash(key)`; `jit_cache` adds function, target, and source
+   identity and uses the same structural key for memory and disk caching.
 2. Keep batch-, token-, and head-count-like extents symbolic with `cute.sym_int()`/`cute.sym_int64()`
    when their dependent strides also remain dynamic. Bake a dimension into `compile_call(...)` only
    when it changes layout/stride address arithmetic, tiling, vectorization, block shape, shared-memory

--- a/attn_gym/_backends/cute/_key.py
+++ b/attn_gym/_backends/cute/_key.py
@@ -171,6 +171,16 @@ def _canonicalize(item: Any) -> Any:
     return item
 
 
+def make_runtime_key(
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    target: CompileTarget,
+) -> bytes:
+    """Encode the persistent invocation identity for process-local lookup."""
+    key_data = (_canonicalize(args), _canonicalize(kwargs), target)
+    return pickle.dumps(key_data, protocol=pickle.HIGHEST_PROTOCOL)
+
+
 def make_key(
     fn: Callable[..., Any],
     args: tuple[Any, ...],

--- a/attn_gym/_backends/cute/cache.py
+++ b/attn_gym/_backends/cute/cache.py
@@ -20,7 +20,7 @@ import os
 import tempfile
 import threading
 import time
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Hashable, Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, ParamSpec, TypeVar
@@ -28,8 +28,9 @@ from typing import Any, ParamSpec, TypeVar
 from typing_extensions import Self
 
 from ._key import make_key as _make_key
+from ._key import make_runtime_key as _make_runtime_key
 from ._key import source_fingerprint as _source_fingerprint
-from .target import get_compile_target
+from .target import CompileTarget, get_compile_target
 
 try:
     import fcntl
@@ -138,8 +139,9 @@ def _cache_entry(
     args: tuple[Any, ...],
     kwargs: dict[str, Any],
     extra_sources: tuple[str, ...],
+    target: CompileTarget,
 ) -> _CacheEntry:
-    key = _make_key(fn, args, kwargs, get_compile_target())
+    key = _make_key(fn, args, kwargs, target)
     directory = get_cache_path() / _source_fingerprint(fn, extra_sources)
     return _CacheEntry(key, directory / f"{key}.o", directory / f"{key}.lock")
 
@@ -224,13 +226,16 @@ def jit_cache(
     persistent: bool = True,
     lock_timeout: float = DEFAULT_LOCK_TIMEOUT_SECONDS,
     extra_sources: Iterable[str | os.PathLike[str]] = (),
+    cache_key: Callable[P, Hashable] | None = None,
 ) -> Callable[P, T]:
     """Cache a ``cute.compile`` function in memory and optionally on disk.
 
     The function's arguments must be static values that completely determine
-    generated code. ``persistent=False`` keeps only the process-local cache.
-    ``extra_sources`` explicitly adds downstream files or trees to source
-    invalidation; neither setting requires an environment variable.
+    generated code. Their canonical encoding provides the process-local key;
+    ``cache_key`` may define an explicit structural key instead. Persistent
+    hashing and path construction occur only after a process-local miss.
+    ``persistent=False`` keeps only the process-local cache. ``extra_sources``
+    explicitly adds downstream files or trees to source invalidation.
     """
     if fn is None:
         return functools.partial(
@@ -238,11 +243,13 @@ def jit_cache(
             persistent=persistent,
             lock_timeout=lock_timeout,
             extra_sources=extra_sources,
+            cache_key=cache_key,
         )
     if lock_timeout <= 0:
         raise ValueError(f"lock_timeout must be positive, got {lock_timeout}")
     source_paths = tuple(os.fspath(Path(path).expanduser().resolve()) for path in extra_sources)
     memory_cache: dict[str, T] = {}
+    runtime_cache: dict[bytes, T] = {}
     key_locks: dict[str, threading.Lock] = {}
     state_lock = threading.RLock()
     cache_pid = os.getpid()
@@ -256,15 +263,23 @@ def jit_cache(
             return
         state_lock = threading.RLock()
         memory_cache.clear()
+        runtime_cache.clear()
         key_locks.clear()
         hits = 0
         misses = 0
         cache_pid = current_pid
 
-    def remember(key: str, compiled: T, *, hit: bool) -> T:
+    def remember(
+        key: str,
+        compiled: T,
+        *,
+        runtime_key: bytes,
+        hit: bool,
+    ) -> T:
         nonlocal hits, misses
         with state_lock:
             memory_cache[key] = compiled
+            runtime_cache[runtime_key] = compiled
             if hit:
                 hits += 1
             else:
@@ -302,36 +317,69 @@ def jit_cache(
     def disk_cache_enabled() -> bool:
         return persistent and cache_enabled()
 
+    def key_arguments(
+        args: tuple[Any, ...], kwargs: dict[str, Any]
+    ) -> tuple[tuple[Any, ...], dict[str, Any]]:
+        if cache_key is None:
+            return args, kwargs
+        static_key = cache_key(*args, **kwargs)
+        try:
+            hash(static_key)
+        except TypeError as error:
+            raise TypeError("jit_cache cache_key must return a hashable value") from error
+        return (static_key,), {}
+
     @functools.wraps(fn)
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
         nonlocal hits
-        entry = _cache_entry(fn, args, kwargs, source_paths)
         reset_after_fork()
+        target = get_compile_target()
+        key_args, key_kwargs = key_arguments(args, kwargs)
+        runtime_key = _make_runtime_key(key_args, key_kwargs, target)
+        with state_lock:
+            if runtime_key in runtime_cache:
+                hits += 1
+                return runtime_cache[runtime_key]
+
+        entry = _cache_entry(fn, key_args, key_kwargs, source_paths, target)
         with state_lock:
             if entry.key in memory_cache:
-                hits += 1
-                return memory_cache[entry.key]
+                return remember(
+                    entry.key,
+                    memory_cache[entry.key],
+                    runtime_key=runtime_key,
+                    hit=True,
+                )
             key_lock = key_locks.setdefault(entry.key, threading.Lock())
 
         with key_lock:
             reset_after_fork()
             with state_lock:
                 if entry.key in memory_cache:
-                    hits += 1
-                    return memory_cache[entry.key]
+                    return remember(
+                        entry.key,
+                        memory_cache[entry.key],
+                        runtime_key=runtime_key,
+                        hit=True,
+                    )
 
             if not disk_cache_enabled():
-                return remember(entry.key, _compile(fn, args, kwargs), hit=False)
+                return remember(
+                    entry.key,
+                    _compile(fn, args, kwargs),
+                    runtime_key=runtime_key,
+                    hit=False,
+                )
 
             compiled = load_from_disk(entry)
             if compiled is not None:
-                return remember(entry.key, compiled, hit=True)
+                return remember(entry.key, compiled, runtime_key=runtime_key, hit=True)
 
             try:
                 with _FileLock(entry.lock_path, lock_timeout):
                     compiled = load_from_disk(entry)
                     if compiled is not None:
-                        return remember(entry.key, compiled, hit=True)
+                        return remember(entry.key, compiled, runtime_key=runtime_key, hit=True)
                     if entry.object_path.exists():
                         logger.warning(
                             "Replacing corrupt CuTeDSL cache artifact %s",
@@ -339,20 +387,26 @@ def jit_cache(
                         )
                         entry.object_path.unlink(missing_ok=True)
                     compiled = compile_and_publish(entry, args, kwargs, strict=False)
-                    return remember(entry.key, compiled, hit=False)
+                    return remember(entry.key, compiled, runtime_key=runtime_key, hit=False)
             except CacheLockError:
                 logger.warning(
                     "CuTeDSL cache lock unavailable for key %s; compiling without disk cache",
                     entry.key,
                     exc_info=True,
                 )
-                return remember(entry.key, _compile(fn, args, kwargs), hit=False)
+                return remember(
+                    entry.key,
+                    _compile(fn, args, kwargs),
+                    runtime_key=runtime_key,
+                    hit=False,
+                )
 
     def precompile(*args: P.args, **kwargs: P.kwargs) -> None:
         """Populate one disk entry without loading or returning the artifact."""
         if not disk_cache_enabled():
             raise RuntimeError("parallel CuTeDSL precompilation requires the disk cache")
-        entry = _cache_entry(fn, args, kwargs, source_paths)
+        key_args, key_kwargs = key_arguments(args, kwargs)
+        entry = _cache_entry(fn, key_args, key_kwargs, source_paths, get_compile_target())
         if _artifact_exists(entry.object_path):
             return
         with _FileLock(entry.lock_path, lock_timeout):
@@ -363,7 +417,9 @@ def jit_cache(
 
     def is_cached(*args: P.args, **kwargs: P.kwargs) -> bool:
         """Return whether a nonempty disk artifact exists for this invocation."""
-        return _artifact_exists(_cache_entry(fn, args, kwargs, source_paths).object_path)
+        key_args, key_kwargs = key_arguments(args, kwargs)
+        entry = _cache_entry(fn, key_args, key_kwargs, source_paths, get_compile_target())
+        return _artifact_exists(entry.object_path)
 
     def prepare_cache() -> None:
         """Warm source fingerprinting before compiler workers are forked."""
@@ -375,6 +431,7 @@ def jit_cache(
         reset_after_fork()
         with state_lock:
             memory_cache.clear()
+            runtime_cache.clear()
             key_locks.clear()
             hits = 0
             misses = 0

--- a/test/test_cute_cache.py
+++ b/test/test_cute_cache.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import multiprocessing
 import os
+import struct
 import sys
 import threading
 import time
@@ -425,6 +426,175 @@ def test_run_tunable_sets_target_before_candidate_generation(isolated_cache):
     assert selected is config
     assert result == config.timing
     assert observed_targets == [target]
+
+
+def test_runtime_cache_skips_persistent_key_for_immutable_arguments(isolated_cache, monkeypatch):
+    make_key_calls = 0
+    original_make_key = cute_cache._make_key
+
+    def counting_make_key(*args, **kwargs):
+        nonlocal make_key_calls
+        make_key_calls += 1
+        return original_make_key(*args, **kwargs)
+
+    monkeypatch.setattr(cute_cache, "_make_key", counting_make_key)
+
+    @cute_cache.jit_cache
+    def compile_kernel(config: CompileConfig) -> FakeCompiled:
+        return FakeCompiled(config.variant)
+
+    assert compile_kernel(CompileConfig("shared", 1.0))() == "shared"
+    assert compile_kernel(CompileConfig("shared", 1.0))() == "shared"
+    assert make_key_calls == 1
+    assert compile_kernel.cache_info() == cute_cache.CacheInfo(hits=1, misses=1, currsize=1)
+
+
+@pytest.mark.parametrize(
+    ("first", "second"),
+    [(True, 1), (1, 1.0), (0.0, -0.0)],
+)
+def test_runtime_cache_preserves_scalar_representation(isolated_cache, first, second):
+    def describe(value) -> str:
+        if isinstance(value, float):
+            return f"float:{value.hex()}"
+        return f"{type(value).__name__}:{value}"
+
+    @cute_cache.jit_cache
+    def compile_kernel(value) -> FakeCompiled:
+        return FakeCompiled(describe(value))
+
+    assert compile_kernel(first)() == describe(first)
+    assert compile_kernel(second)() == describe(second)
+    assert compile_kernel(first)() == describe(first)
+    assert compile_kernel(second)() == describe(second)
+    assert compile_kernel.cache_info() == cute_cache.CacheInfo(hits=2, misses=2, currsize=2)
+
+
+def test_explicit_cache_key_is_shared_by_memory_and_disk(isolated_cache):
+    compile_count = 0
+
+    @cute_cache.jit_cache(cache_key=lambda _value: "shared")
+    def compile_kernel(value: str) -> FakeCompiled:
+        nonlocal compile_count
+        compile_count += 1
+        return FakeCompiled(value)
+
+    assert compile_kernel("first")() == "first"
+    assert compile_kernel("second")() == "first"
+    compile_kernel.cache_clear()
+    assert compile_kernel("third")() == "first"
+    assert compile_count == 1
+    assert len(list(isolated_cache.rglob("*.o"))) == 1
+
+
+def test_explicit_cache_key_is_shared_by_precompile_and_lookup(isolated_cache):
+    compile_count = 0
+
+    @cute_cache.jit_cache(cache_key=lambda _value: "shared")
+    def compile_kernel(value: str) -> FakeCompiled:
+        nonlocal compile_count
+        compile_count += 1
+        return FakeCompiled(value)
+
+    assert not compile_kernel.is_cached("first")
+    compile_kernel.precompile("first")
+    assert compile_kernel.is_cached("second")
+    assert compile_kernel("second")() == "first"
+    assert compile_count == 1
+    assert compile_kernel.cache_info() == cute_cache.CacheInfo(hits=1, misses=0, currsize=1)
+
+
+def test_explicit_cache_key_must_be_hashable():
+    @cute_cache.jit_cache(cache_key=lambda _value: [])
+    def compile_kernel(value: str) -> FakeCompiled:
+        return FakeCompiled(value)
+
+    with pytest.raises(TypeError, match="cache_key must return a hashable value"):
+        compile_kernel("value")
+
+
+def test_runtime_cache_includes_compile_target(isolated_cache, monkeypatch):
+    compile_count = 0
+    target = cute_target.CompileTarget("first")
+    monkeypatch.setattr(cute_cache, "get_compile_target", lambda: target)
+
+    @cute_cache.jit_cache
+    def compile_kernel(value: str) -> FakeCompiled:
+        nonlocal compile_count
+        compile_count += 1
+        return FakeCompiled(cute_cache.get_compile_target().device_type)
+
+    assert compile_kernel("shared")() == "first"
+    target = cute_target.CompileTarget("second")
+    assert compile_kernel("shared")() == "second"
+    target = cute_target.CompileTarget("first")
+    assert compile_kernel("shared")() == "first"
+    assert compile_count == 2
+    assert compile_kernel.cache_info() == cute_cache.CacheInfo(hits=1, misses=2, currsize=2)
+
+
+def test_runtime_key_fuzz_matches_persistent_key_equivalence(isolated_cache):
+    same_nan = struct.unpack("!d", bytes.fromhex("7ff8000000000001"))[0]
+    same_nan_copy = struct.unpack("!d", bytes.fromhex("7ff8000000000001"))[0]
+    other_nan = struct.unpack("!d", bytes.fromhex("7ff8000000000002"))[0]
+    calls = [
+        ((True,), {}),
+        ((1,), {}),
+        ((1.0,), {}),
+        ((0.0,), {}),
+        ((-0.0,), {}),
+        ((same_nan,), {}),
+        ((same_nan_copy,), {}),
+        ((other_nan,), {}),
+        ((CompileConfig("shared", 1.0),), {}),
+        ((["nested", {"value": True}],), {}),
+        ((["nested", {"value": 1}],), {}),
+        (({same_nan: "value"},), {}),
+        (({same_nan: "value", same_nan_copy: "value"},), {}),
+        ((), {"first": 1, "second": 2}),
+        ((), {"second": 2, "first": 1}),
+    ]
+    target = cute_target.CompileTarget("test")
+
+    def compile_kernel(value=None, **kwargs):
+        return value, kwargs
+
+    runtime_keys = [cute_cache._make_runtime_key(*call, target) for call in calls]
+    persistent_keys = [cute_cache._make_key(compile_kernel, *call, target) for call in calls]
+    for left in range(len(calls)):
+        for right in range(len(calls)):
+            if runtime_keys[left] == runtime_keys[right]:
+                assert persistent_keys[left] == persistent_keys[right]
+
+    assert runtime_keys[5] == runtime_keys[6]
+    assert runtime_keys[5] != runtime_keys[7]
+    assert runtime_keys[-2] == runtime_keys[-1]
+
+    bool_target = cute_target.CompileTarget("test", sm_count=True)
+    int_target = cute_target.CompileTarget("test", sm_count=1)
+    assert cute_cache._make_runtime_key((), {}, bool_target) != cute_cache._make_runtime_key(
+        (), {}, int_target
+    )
+
+
+def test_runtime_cache_snapshots_mutable_arguments(isolated_cache):
+    compile_count = 0
+
+    @cute_cache.jit_cache
+    def compile_kernel(values: list[str]) -> FakeCompiled:
+        nonlocal compile_count
+        compile_count += 1
+        return FakeCompiled(values[0])
+
+    values = ["first"]
+    assert compile_kernel(values)() == "first"
+    assert compile_kernel(["first"])() == "first"
+    values[0] = "second"
+    assert compile_kernel(values)() == "second"
+    assert compile_kernel(["second"])() == "second"
+    compile_kernel.cache_clear()
+    assert compile_kernel(["first"])() == "first"
+    assert compile_count == 2
 
 
 def test_same_key_compiles_once_across_threads(isolated_cache):


### PR DESCRIPTION
## Summary

- add a process-local CuTeDSL runtime cache checked before persistent SHA/path construction
- derive the runtime identity from the same canonical argument representation used by the disk cache
- support explicit structural `cache_key=` values consistently across memory lookup, disk lookup, precompile, and `is_cached`
- document the cache-key contract for CuTeDSL kernels

## Correctness

The runtime key serializes `(canonical(args), canonical(kwargs), target)`, while the persistent key hashes the same canonical invocation identity plus function/cache metadata. This preserves distinctions such as scalar types, signed zero, NaN payloads, structured configs, mutable-container snapshots, and compile targets.

Added coverage for runtime/persistent equivalence, scalar collisions, mutable arguments, target partitioning, explicit keys, precompile, disk reload, and cache clearing.

## Performance

Representative uninstrumented warm hits now take roughly 7–10 us for most KDA compile signatures and 18 us for the largest recompute signature, versus about 27.5 us for the previous persistent-key-first lookup. Warm hits no longer construct a persistent SHA, source fingerprint, or disk-cache path.

## Test plan

- `prek run --all-files`
- `PYTHONPATH=$PWD ~/.venvs/nightly/bin/pytest -q test/test_cute_cache.py test/test_kda_cute_inter_solve.py::test_inter_solve_rejects_unsupported_specializations` (31 passed)
- nightly GPU validation through `gpu-run auto` covering the real cache round trip and every production KDA CuTeDSL `@jit_cache` wrapper (12 passed)
