### PR TITLE
Add ragged KDA chunk scheduler

### DIFF
--- a/attn_gym/linear/kda/chunk_scheduler.py
+++ b/attn_gym/linear/kda/chunk_scheduler.py
@@ -1,0 +1,275 @@
+"""Graph-safe logical chunk scheduling for packed variable-length KDA inputs."""
+
+from __future__ import annotations
+
+import itertools
+from typing import NamedTuple
+
+import torch
+import triton
+import triton.language as tl
+
+
+class RaggedChunkMetadata(NamedTuple):
+    """Graph-safe routing for sequence-relative chunks in a packed token buffer.
+
+    Attributes:
+        cu_seqlens: Device tensor of shape ``[N + 1]`` containing packed token
+            boundaries. Sequence ``i`` occupies
+            ``[cu_seqlens[i], cu_seqlens[i + 1])``; repeated boundaries represent
+            empty sequences.
+        chunk_offsets: Device tensor of shape ``[N + 1]`` containing the exclusive
+            prefix sum of per-sequence chunk counts. It is a sequence-boundary
+            tensor, not a per-chunk map::
+
+                count[i] = ceil_div(
+                    cu_seqlens[i + 1] - cu_seqlens[i], chunk_size
+                )
+                chunk_offsets[i + 1] = chunk_offsets[i] + count[i]
+
+            Thus ``chunk_offsets[-1]`` is the runtime active chunk count and
+            sequence ``i`` owns global chunks in
+            ``[chunk_offsets[i], chunk_offsets[i + 1])``. Given a
+            ``global_chunk``, kernels find its sequence with
+            ``upper_bound(chunk_offsets, global_chunk) - 1``. Upper-bound search
+            handles the repeated offsets produced by empty sequences.
+        capacity: Static host-side upper bound on the active chunk count for every
+            boundary distribution with the same token and sequence tensor shapes.
+            CUDA Graph capture fixes launch and allocation shapes, so kernels use
+            this capacity while reading the actual active count from
+            ``chunk_offsets[-1]`` on the device. Capacity-only CTAs return before
+            accessing token data.
+        chunk_size: Logical chunk size used to construct ``chunk_offsets``. Keeping
+            it with the offsets prevents consumers from decoding them under a
+            different chunking scheme.
+
+    On CUDA Graph replay, values in ``cu_seqlens`` may change from aligned to ragged
+    without host synchronization or recapture, provided the total token and
+    sequence tensor shapes remain fixed. Changing either shape requires a separate
+    compiled or captured graph, as it does for the input tensors themselves.
+    """
+
+    cu_seqlens: torch.Tensor
+    chunk_offsets: torch.Tensor
+    capacity: int
+    chunk_size: int
+
+
+class ChunkWork(NamedTuple):
+    """One sequence-local chunk decoded from a global logical work index."""
+
+    global_chunk: int
+    sequence: int
+    local_chunk: int
+    token_start: int
+    valid_tokens: int
+
+
+MAX_NUM_SEQUENCES = 4096
+
+
+def chunk_capacity(tokens: int, num_sequences: int, chunk_size: int) -> int:
+    """Return the exact shape-derived launch bound over all valid boundaries.
+
+    At most ``min(tokens, num_sequences)`` sequences can be nonempty. Giving each
+    such sequence one token creates one chunk per sequence; concentrating all
+    remaining tokens in one sequence maximizes the number of additional chunks.
+    """
+    if tokens < 0:
+        raise ValueError(f"tokens must be nonnegative, got {tokens}")
+    if num_sequences < 1:
+        raise ValueError(f"num_sequences must be positive, got {num_sequences}")
+    if chunk_size < 1:
+        raise ValueError(f"chunk_size must be positive, got {chunk_size}")
+
+    nonempty = min(tokens, num_sequences)
+    if nonempty == 0:
+        return 0
+    return nonempty + (tokens - nonempty) // chunk_size
+
+
+def chunk_work_oracle(cu_seqlens: list[int], chunk_size: int) -> list[ChunkWork]:
+    """Decode all logical chunks on the CPU for tests and scheduler validation."""
+    if len(cu_seqlens) < 2:
+        raise ValueError("cu_seqlens must contain at least one sequence")
+    if chunk_size < 1:
+        raise ValueError(f"chunk_size must be positive, got {chunk_size}")
+    if cu_seqlens[0] != 0:
+        raise ValueError("cu_seqlens must start at zero")
+    if any(begin > end for begin, end in itertools.pairwise(cu_seqlens)):
+        raise ValueError("cu_seqlens must be monotonic")
+
+    work: list[ChunkWork] = []
+    for sequence, (begin, end) in enumerate(itertools.pairwise(cu_seqlens)):
+        for token_start in range(begin, end, chunk_size):
+            work.append(
+                ChunkWork(
+                    global_chunk=len(work),
+                    sequence=sequence,
+                    local_chunk=(token_start - begin) // chunk_size,
+                    token_start=token_start,
+                    valid_tokens=min(chunk_size, end - token_start),
+                )
+            )
+    return work
+
+
+@triton.jit(debug=True)
+def _prepare_ragged_chunk_offsets_kernel(
+    cu_seqlens,
+    chunk_offsets,
+    num_sequences: tl.constexpr,
+    tokens: tl.constexpr,
+    chunk_size: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    """Validate boundaries and build the chunk-count prefix in one CTA."""
+    sequence = tl.arange(0, BLOCK)
+    sequence_mask = sequence < num_sequences
+    begin = tl.load(cu_seqlens + sequence, mask=sequence_mask, other=0)
+    end = tl.load(cu_seqlens + sequence + 1, mask=sequence_mask, other=0)
+    valid = (
+        (begin >= 0)
+        & (begin <= end)
+        & (end <= tokens)
+        & ((sequence != 0) | (begin == 0))
+        & ((sequence != num_sequences - 1) | (end == tokens))
+    )
+    tl.device_assert(valid, "invalid packed cu_seqlens", mask=sequence_mask)
+
+    count = tl.where(sequence_mask & valid, (end - begin + chunk_size - 1) // chunk_size, 0)
+    inclusive_offset = tl.cumsum(count, axis=0)
+    tl.store(chunk_offsets, 0)
+    tl.store(chunk_offsets + sequence + 1, inclusive_offset, mask=sequence_mask)
+
+
+@triton.jit
+def load_ragged_chunk_work(
+    cu_seqlens,
+    chunk_offsets,
+    global_chunk,
+    num_sequences: tl.constexpr,
+    chunk_size: tl.constexpr,
+):
+    """Binary-search one known-active global chunk's sequence boundaries.
+
+    Returns its sequence index, sequence-relative chunk index, packed token start,
+    and valid token count. Callers must reject ``global_chunk >= chunk_offsets[-1]``
+    before invoking this helper.
+    """
+    low = 0
+    high = num_sequences + 1
+    while low < high:
+        middle = (low + high) // 2
+        offset = tl.load(chunk_offsets + middle)
+        if offset <= global_chunk:
+            low = middle + 1
+        else:
+            high = middle
+
+    sequence = low - 1
+    sequence_offset = tl.load(chunk_offsets + sequence)
+    local_chunk = global_chunk - sequence_offset
+    begin = tl.load(cu_seqlens + sequence)
+    end = tl.load(cu_seqlens + sequence + 1)
+    token_start = begin + local_chunk * chunk_size
+    valid_tokens = tl.minimum(chunk_size, end - token_start)
+    return sequence, local_chunk, token_start, valid_tokens
+
+
+@triton.jit
+def _decode_ragged_chunk_work_kernel(
+    cu_seqlens,
+    chunk_offsets,
+    work,
+    num_sequences: tl.constexpr,
+    capacity: tl.constexpr,
+    chunk_size: tl.constexpr,
+):
+    global_chunk = tl.program_id(0)
+    active_chunks = tl.load(chunk_offsets + num_sequences)
+    output = work + global_chunk * 5
+
+    if global_chunk < active_chunks:
+        sequence, local_chunk, token_start, valid_tokens = load_ragged_chunk_work(
+            cu_seqlens,
+            chunk_offsets,
+            global_chunk,
+            num_sequences,
+            chunk_size,
+        )
+
+        tl.store(output, global_chunk)
+        tl.store(output + 1, sequence)
+        tl.store(output + 2, local_chunk)
+        tl.store(output + 3, token_start)
+        tl.store(output + 4, valid_tokens)
+    else:
+        for field in tl.static_range(5):
+            tl.store(output + field, -1)
+
+
+def prepare_ragged_chunk_metadata(
+    cu_seqlens: torch.Tensor,
+    tokens: int,
+    chunk_size: int,
+) -> RaggedChunkMetadata:
+    """Build fixed-shape, graph-replayable packed chunk offsets on the GPU."""
+    if cu_seqlens.ndim != 1 or cu_seqlens.shape[0] < 2:
+        raise ValueError("cu_seqlens must have shape [num_sequences + 1]")
+    if cu_seqlens.dtype != torch.int32 or not cu_seqlens.is_contiguous():
+        raise ValueError("cu_seqlens must be contiguous int32")
+    if not cu_seqlens.is_cuda:
+        raise ValueError("cu_seqlens must be a CUDA tensor")
+
+    num_sequences = cu_seqlens.shape[0] - 1
+    if num_sequences > MAX_NUM_SEQUENCES:
+        raise ValueError(
+            f"the ragged chunk scheduler supports at most {MAX_NUM_SEQUENCES} sequences, "
+            f"got {num_sequences}"
+        )
+    capacity = chunk_capacity(tokens, num_sequences, chunk_size)
+    chunk_offsets = torch.empty_like(cu_seqlens)
+    block = triton.next_power_of_2(num_sequences)
+    _prepare_ragged_chunk_offsets_kernel[(1,)](
+        cu_seqlens,
+        chunk_offsets,
+        num_sequences=num_sequences,
+        tokens=tokens,
+        chunk_size=chunk_size,
+        BLOCK=block,
+        num_warps=min(8, max(1, block // 32)),
+    )
+    return RaggedChunkMetadata(cu_seqlens, chunk_offsets, capacity, chunk_size)
+
+
+def decode_ragged_chunk_work(metadata: RaggedChunkMetadata) -> torch.Tensor:
+    """Materialize scheduler decisions for diagnostics and mapping tests."""
+    work = torch.empty(
+        (metadata.capacity, 5),
+        dtype=torch.int32,
+        device=metadata.cu_seqlens.device,
+    )
+    if metadata.capacity:
+        _decode_ragged_chunk_work_kernel[(metadata.capacity,)](
+            metadata.cu_seqlens,
+            metadata.chunk_offsets,
+            work,
+            num_sequences=metadata.cu_seqlens.shape[0] - 1,
+            capacity=metadata.capacity,
+            chunk_size=metadata.chunk_size,
+            num_warps=1,
+        )
+    return work
+
+
+__all__ = [
+    "MAX_NUM_SEQUENCES",
+    "ChunkWork",
+    "RaggedChunkMetadata",
+    "chunk_capacity",
+    "chunk_work_oracle",
+    "decode_ragged_chunk_work",
+    "load_ragged_chunk_work",
+    "prepare_ragged_chunk_metadata",
+]

--- a/attn_gym/linear/kda/fwd/cute/chunk_scheduler_cute.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_scheduler_cute.py
@@ -1,0 +1,193 @@
+"""CuTeDSL work decoding for the packed KDA chunk scheduler."""
+
+from __future__ import annotations
+
+import cutlass
+import torch
+from cuda.bindings import driver as cuda
+from cutlass import Int32, cute
+from cutlass.cute.runtime import make_fake_compact_tensor
+
+from attn_gym._backends.cute import compile_tvm_ffi, jit_cache
+from attn_gym._backends.cute.device import upper_bound
+
+
+@cute.jit
+def load_ragged_chunk_work(
+    cu_seqlens: cute.Tensor,
+    chunk_offsets: cute.Tensor,
+    global_chunk: Int32,
+    chunk_size: Int32,
+):
+    """Binary-search one known-active global chunk's sequence boundaries.
+
+    Returns its sequence index, sequence-relative chunk index, packed token start,
+    and valid token count. The invoking kernel owns its launch configuration and
+    must reject inactive chunks before calling this warp-independent helper.
+    """
+    num_sequences = Int32(cute.size(chunk_offsets)) - 1
+    sequence = (
+        upper_bound(
+            chunk_offsets,
+            global_chunk,
+            Int32(0),
+            num_sequences + 1,
+        )
+        - 1
+    )
+    sequence_offset = Int32(chunk_offsets[sequence])
+    local_chunk = global_chunk - sequence_offset
+    begin = Int32(cu_seqlens[sequence])
+    end = Int32(cu_seqlens[sequence + 1])
+    token_start = begin + local_chunk * chunk_size
+    valid_tokens = cutlass.min(chunk_size, end - token_start)
+    return sequence, local_chunk, token_start, valid_tokens
+
+
+class ChunkSchedulerDiagnostic:
+    """Test one scheduler decode broadcast with a diagnostic-local CTA shape."""
+
+    num_threads = 128
+    num_warps = num_threads // cute.arch.WARP_SIZE
+    fields = 5
+
+    @cute.jit
+    def __call__(
+        self,
+        cu_seqlens: cute.Tensor,
+        chunk_offsets: cute.Tensor,
+        output: cute.Tensor,
+        chunk_size: Int32,
+        stream: cuda.CUstream,
+    ):
+        @cute.struct
+        class SharedStorage:
+            work: cute.struct.MemRange[Int32, self.fields]
+
+        self.kernel(
+            cu_seqlens,
+            chunk_offsets,
+            output,
+            chunk_size,
+            SharedStorage,
+        ).launch(
+            grid=(cute.size(output, mode=[0]), 1, 1),
+            block=(self.num_threads, 1, 1),
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        cu_seqlens: cute.Tensor,
+        chunk_offsets: cute.Tensor,
+        output: cute.Tensor,
+        chunk_size: Int32,
+        SharedStorage: cutlass.Constexpr,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        global_chunk, _, _ = cute.arch.block_idx()
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        lane_idx = tidx % cute.arch.WARP_SIZE
+        num_sequences = Int32(cute.size(chunk_offsets)) - 1
+
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+        work = storage.work.get_tensor(cute.make_layout(self.fields))
+
+        if tidx == 0:
+            active_chunks = Int32(chunk_offsets[num_sequences])
+            if global_chunk < active_chunks:
+                sequence, local_chunk, token_start, valid_tokens = load_ragged_chunk_work(
+                    cu_seqlens,
+                    chunk_offsets,
+                    Int32(global_chunk),
+                    chunk_size,
+                )
+
+                work[0] = Int32(global_chunk)
+                work[1] = sequence
+                work[2] = local_chunk
+                work[3] = token_start
+                work[4] = valid_tokens
+            else:
+                # The diagnostic materializes capacity-only CTAs into an uninitialized
+                # output. Production kernels instead return without writing.
+                for field in cutlass.range_constexpr(self.fields):
+                    work[field] = Int32(-1)
+
+        cute.arch.sync_threads()
+        if lane_idx == 0:
+            for field in cutlass.range_constexpr(self.fields):
+                output[global_chunk, warp_idx, field] = work[field]
+
+
+@jit_cache
+def _compile_chunk_scheduler_diagnostic():
+    sequences = cute.sym_int()
+    capacity = cute.sym_int()
+    cu_seqlens = make_fake_compact_tensor(
+        cutlass.Int32,
+        (sequences,),
+        stride_order=(0,),
+        assumed_align=4,
+    )
+    chunk_offsets = make_fake_compact_tensor(
+        cutlass.Int32,
+        (sequences,),
+        stride_order=(0,),
+        assumed_align=4,
+    )
+    output = make_fake_compact_tensor(
+        cutlass.Int32,
+        (
+            capacity,
+            ChunkSchedulerDiagnostic.num_warps,
+            ChunkSchedulerDiagnostic.fields,
+        ),
+        stride_order=(2, 1, 0),
+        assumed_align=4,
+    )
+    return compile_tvm_ffi(
+        ChunkSchedulerDiagnostic(),
+        cu_seqlens,
+        chunk_offsets,
+        output,
+        Int32(64),
+        name="kda_chunk_scheduler_diagnostic",
+    )
+
+
+def decode_ragged_chunk_work_cute(
+    cu_seqlens: torch.Tensor,
+    chunk_offsets: torch.Tensor,
+    capacity: int,
+    chunk_size: int = 64,
+) -> torch.Tensor:
+    """Decode and expose each warp group's scheduler broadcast for validation."""
+    if chunk_size != 64:
+        raise ValueError(f"the diagnostic scheduler requires chunk_size=64, got {chunk_size}")
+    if cu_seqlens.dtype != torch.int32 or chunk_offsets.dtype != torch.int32:
+        raise TypeError("cu_seqlens and chunk_offsets must be int32")
+    if not cu_seqlens.is_cuda or not chunk_offsets.is_cuda:
+        raise ValueError("cu_seqlens and chunk_offsets must be CUDA tensors")
+    if cu_seqlens.shape != chunk_offsets.shape:
+        raise ValueError("cu_seqlens and chunk_offsets must have the same shape")
+    if not cu_seqlens.is_contiguous() or not chunk_offsets.is_contiguous():
+        raise ValueError("cu_seqlens and chunk_offsets must be contiguous")
+
+    output = torch.empty(
+        (
+            capacity,
+            ChunkSchedulerDiagnostic.num_warps,
+            ChunkSchedulerDiagnostic.fields,
+        ),
+        dtype=torch.int32,
+        device=cu_seqlens.device,
+    )
+    if capacity:
+        _compile_chunk_scheduler_diagnostic()(cu_seqlens, chunk_offsets, output, chunk_size)
+    return output
+
+
+__all__ = ["decode_ragged_chunk_work_cute", "load_ragged_chunk_work"]

--- a/test/test_kda_chunk_scheduler.py
+++ b/test/test_kda_chunk_scheduler.py
@@ -1,0 +1,298 @@
+"""Tests for graph-safe packed KDA logical chunk scheduling."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+from attn_gym.linear.kda.chunk_scheduler import (
+    MAX_NUM_SEQUENCES,
+    chunk_capacity,
+    chunk_work_oracle,
+    decode_ragged_chunk_work,
+    prepare_ragged_chunk_metadata,
+)
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="the KDA chunk scheduler requires CUDA",
+)
+
+
+def _expected_tensor(lengths: list[int], chunk_size: int) -> tuple[torch.Tensor, list[int]]:
+    offsets = [0]
+    for length in lengths:
+        offsets.append(offsets[-1] + length)
+    rows = [tuple(work) for work in chunk_work_oracle(offsets, chunk_size)]
+    return torch.tensor(rows, dtype=torch.int32), offsets
+
+
+@pytest.mark.parametrize(
+    "lengths",
+    [
+        [1],
+        [63],
+        [64],
+        [65],
+        [127],
+        [128],
+        [129],
+        [65, 63],
+        [0, 1, 0, 63, 64, 65, 0],
+        [1] * 257,
+        [65] * 1024,
+        [4097, 1, 511, 0, 65],
+    ],
+)
+def test_ragged_chunk_scheduler_matches_cpu_oracle(lengths):
+    expected, offsets = _expected_tensor(lengths, 64)
+    cu_seqlens = torch.tensor(offsets, device="cuda", dtype=torch.int32)
+    metadata = prepare_ragged_chunk_metadata(cu_seqlens, offsets[-1], 64)
+    actual = decode_ragged_chunk_work(metadata).cpu()
+
+    assert metadata.chunk_size == 64
+
+    active_chunks = expected.shape[0]
+    assert metadata.capacity == chunk_capacity(offsets[-1], len(lengths), 64)
+    assert metadata.chunk_offsets[-1].item() == active_chunks
+    torch.testing.assert_close(actual[:active_chunks], expected)
+    torch.testing.assert_close(
+        actual[active_chunks:],
+        torch.full_like(actual[active_chunks:], -1),
+    )
+
+
+@pytest.mark.parametrize("chunk_size", [16, 32, 64])
+def test_ragged_chunk_scheduler_preserves_chunk_size(chunk_size):
+    lengths = [chunk_size + 1, chunk_size - 1]
+    expected, offsets = _expected_tensor(lengths, chunk_size)
+    cu_seqlens = torch.tensor(offsets, device="cuda", dtype=torch.int32)
+    metadata = prepare_ragged_chunk_metadata(cu_seqlens, offsets[-1], chunk_size)
+
+    assert metadata.chunk_size == chunk_size
+    torch.testing.assert_close(decode_ragged_chunk_work(metadata).cpu(), expected)
+
+
+def test_ragged_chunk_scheduler_cuda_graph_replays_boundaries():
+    cu_seqlens = torch.tensor([0, 65, 128], device="cuda", dtype=torch.int32)
+    metadata = prepare_ragged_chunk_metadata(cu_seqlens, 128, 64)
+    warm_work = decode_ragged_chunk_work(metadata)
+    del warm_work
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_metadata = prepare_ragged_chunk_metadata(cu_seqlens, 128, 64)
+        work = decode_ragged_chunk_work(captured_metadata)
+
+    cu_seqlens.copy_(torch.tensor([0, 1, 128], device="cuda", dtype=torch.int32))
+    graph.replay()
+    torch.cuda.synchronize()
+
+    expected, _ = _expected_tensor([1, 127], 64)
+    active_chunks = expected.shape[0]
+    assert captured_metadata.chunk_offsets[-1].item() == active_chunks
+    torch.testing.assert_close(work[:active_chunks].cpu(), expected)
+    torch.testing.assert_close(
+        work[active_chunks:].cpu(),
+        torch.full_like(work[active_chunks:].cpu(), -1),
+    )
+
+
+def test_ragged_chunk_scheduler_fullgraph():
+    cu_seqlens = torch.tensor([0, 65, 128], device="cuda", dtype=torch.int32)
+
+    def operation(offsets):
+        metadata = prepare_ragged_chunk_metadata(offsets, 128, 64)
+        return metadata.chunk_offsets, decode_ragged_chunk_work(metadata)
+
+    expected_offsets, expected_work = operation(cu_seqlens)
+    actual_offsets, actual_work = torch.compile(operation, fullgraph=True)(cu_seqlens)
+    torch.testing.assert_close(actual_offsets, expected_offsets)
+    torch.testing.assert_close(actual_work, expected_work)
+
+
+def test_ragged_chunk_scheduler_replays_aligned_to_ragged():
+    cu_seqlens = torch.tensor([0, 64, 128], device="cuda", dtype=torch.int32)
+    prepare_ragged_chunk_metadata(cu_seqlens, 128, 64)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        metadata = prepare_ragged_chunk_metadata(cu_seqlens, 128, 64)
+        work = decode_ragged_chunk_work(metadata)
+
+    cu_seqlens.copy_(torch.tensor([0, 65, 128], device="cuda", dtype=torch.int32))
+    graph.replay()
+    torch.cuda.synchronize()
+
+    expected, _ = _expected_tensor([65, 63], 64)
+    torch.testing.assert_close(work.cpu(), expected)
+
+
+def test_ragged_chunk_capacity_is_tight_for_empty_sequences():
+    assert chunk_capacity(0, 1024, 64) == 0
+    assert chunk_capacity(1, 1024, 64) == 1
+    assert chunk_capacity(65, 64, 64) == 64
+    assert chunk_capacity(128, 2, 64) == 3
+
+
+def test_ragged_chunk_scheduler_accepts_zero_capacity():
+    cu_seqlens = torch.tensor([0, 0], device="cuda", dtype=torch.int32)
+    metadata = prepare_ragged_chunk_metadata(cu_seqlens, 0, 64)
+    actual = decode_ragged_chunk_work(metadata)
+
+    assert metadata.capacity == 0
+    assert actual.shape == (0, 5)
+
+
+def test_ragged_chunk_scheduler_accepts_max_sequences():
+    cu_seqlens = torch.arange(MAX_NUM_SEQUENCES + 1, device="cuda", dtype=torch.int32)
+    metadata = prepare_ragged_chunk_metadata(cu_seqlens, MAX_NUM_SEQUENCES, 64)
+    actual = decode_ragged_chunk_work(metadata)
+
+    assert metadata.capacity == MAX_NUM_SEQUENCES
+    torch.testing.assert_close(metadata.chunk_offsets, cu_seqlens)
+    torch.testing.assert_close(actual[:, 0], cu_seqlens[:-1])
+    torch.testing.assert_close(actual[:, 1], cu_seqlens[:-1])
+    torch.testing.assert_close(actual[:, 2], torch.zeros_like(cu_seqlens[:-1]))
+    torch.testing.assert_close(actual[:, 3], cu_seqlens[:-1])
+    torch.testing.assert_close(actual[:, 4], torch.ones_like(cu_seqlens[:-1]))
+
+
+def test_ragged_chunk_scheduler_rejects_excess_sequences():
+    cu_seqlens = torch.zeros(MAX_NUM_SEQUENCES + 2, device="cuda", dtype=torch.int32)
+    with pytest.raises(ValueError, match=f"at most {MAX_NUM_SEQUENCES} sequences"):
+        prepare_ragged_chunk_metadata(cu_seqlens, 0, 64)
+
+
+@pytest.mark.parametrize(
+    "boundaries,tokens",
+    [
+        ([1, 64], 64),
+        ([0, 65, 64], 64),
+        ([0, -1, 64], 64),
+        ([0, 63], 64),
+    ],
+)
+def test_ragged_chunk_scheduler_rejects_invalid_boundaries(boundaries, tokens):
+    source = f"""
+import os
+import torch
+from attn_gym.linear.kda.chunk_scheduler import prepare_ragged_chunk_metadata
+
+try:
+    offsets = torch.tensor({boundaries!r}, device="cuda", dtype=torch.int32)
+    prepare_ragged_chunk_metadata(offsets, {tokens}, 64)
+    torch.cuda.synchronize()
+except RuntimeError as error:
+    if "device-side assert" in str(error).lower():
+        os._exit(0)
+    os._exit(2)
+os._exit(1)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", source],
+        cwd=Path(__file__).parents[1],
+        env={**os.environ, "CUDA_LAUNCH_BLOCKING": "1"},
+        capture_output=True,
+        text=True,
+        timeout=180,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def _decode_ragged_chunk_work_cute(*args, **kwargs):
+    pytest.importorskip("cutlass")
+    from attn_gym.linear.kda.fwd.cute.chunk_scheduler_cute import (
+        decode_ragged_chunk_work_cute,
+    )
+
+    return decode_ragged_chunk_work_cute(*args, **kwargs)
+
+
+requires_cute = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (10, 0),
+    reason="the CuTeDSL KDA scheduler test requires CUDA capability 10.0 or newer",
+)
+
+
+@pytest.mark.parametrize(
+    "lengths",
+    [
+        [65, 63],
+        [0, 1, 0, 63, 64, 65, 0],
+        [1] * 257,
+        [4097, 1, 511, 0, 65],
+    ],
+)
+@requires_cute
+def test_cute_chunk_scheduler_broadcast_matches_oracle(lengths):
+    expected, offsets = _expected_tensor(lengths, 64)
+    cu_seqlens = torch.tensor(offsets, device="cuda", dtype=torch.int32)
+    metadata = prepare_ragged_chunk_metadata(cu_seqlens, offsets[-1], 64)
+    actual = _decode_ragged_chunk_work_cute(
+        cu_seqlens,
+        metadata.chunk_offsets,
+        metadata.capacity,
+    ).cpu()
+
+    for warp in range(actual.shape[1]):
+        torch.testing.assert_close(actual[: expected.shape[0], warp], expected)
+        torch.testing.assert_close(
+            actual[expected.shape[0] :, warp],
+            torch.full_like(actual[expected.shape[0] :, warp], -1),
+        )
+
+
+@requires_cute
+def test_cute_chunk_scheduler_accepts_zero_capacity():
+    cu_seqlens = torch.tensor([0, 0], device="cuda", dtype=torch.int32)
+    metadata = prepare_ragged_chunk_metadata(cu_seqlens, 0, 64)
+    actual = _decode_ragged_chunk_work_cute(
+        cu_seqlens,
+        metadata.chunk_offsets,
+        metadata.capacity,
+    )
+
+    assert actual.shape == (0, 4, 5)
+
+
+@requires_cute
+def test_cute_chunk_scheduler_cuda_graph_replays_boundaries():
+    _, offsets = _expected_tensor([65, 63], 64)
+    cu_seqlens = torch.tensor(offsets, device="cuda", dtype=torch.int32)
+    metadata = prepare_ragged_chunk_metadata(cu_seqlens, 128, 64)
+    _decode_ragged_chunk_work_cute(
+        cu_seqlens,
+        metadata.chunk_offsets,
+        metadata.capacity,
+    )
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_metadata = prepare_ragged_chunk_metadata(cu_seqlens, 128, 64)
+        actual = _decode_ragged_chunk_work_cute(
+            cu_seqlens,
+            captured_metadata.chunk_offsets,
+            captured_metadata.capacity,
+        )
+
+    cu_seqlens.copy_(torch.tensor([0, 1, 128], device="cuda", dtype=torch.int32))
+    graph.replay()
+    torch.cuda.synchronize()
+
+    expected, _ = _expected_tensor([1, 127], 64)
+    for warp in range(actual.shape[1]):
+        torch.testing.assert_close(actual[: expected.shape[0], warp].cpu(), expected)
+        torch.testing.assert_close(
+            actual[expected.shape[0] :, warp].cpu(),
+            torch.full_like(actual[expected.shape[0] :, warp].cpu(), -1),
+        )


### PR DESCRIPTION
Stacked PRs:
 * #301
 * #300
 * #299
 * #298
 * #297
 * #296
 * #295
 * #294
 * #293
 * #292
 * #291
 * #290
 * __->__#289


--- --- ---

Add ragged KDA chunk scheduler

## Follow Up

A possible extension is to distinguish the static physical token capacity from the
runtime active token count without adding a new `chunk_kda` argument:

```text
token_capacity = q.shape[1]
active_tokens = cu_seqlens[-1]
```

This would relax the packed invariant from `cu_seqlens[-1] == token_capacity` to
`cu_seqlens[-1] <= token_capacity`. Kernel grids and workspaces would remain sized
from the static capacity, while token CTAs guard on `active_tokens` and chunk CTAs
guard on `chunk_offsets[-1]`. The padded suffix would belong to no sequence.

This should remain a separate follow-up because it needs an explicit end-to-end
contract: active outputs and states must not depend on padded storage, callers must
ignore or mask the inactive output suffix, and autograd must return zero gradients
for padded input rows so they cannot affect upstream parameter gradients. Existing
calls where `cu_seqlens[-1] == q.shape[1]` would remain unchanged.