### PR TITLE
Lower custom-op CPU overhead with define/impl operator boundaries

### DIFF
--- a/.agents/skills/validating-pytorch-custom-ops/SKILL.md
+++ b/.agents/skills/validating-pytorch-custom-ops/SKILL.md
@@ -15,12 +15,51 @@ Use this workflow whenever adding a backend under `attn_gym/linear/<variant>/imp
 2. **Triton implementation:** direct Triton kernels can work under `torch.compile`. Prefer
    `torch.library.triton_op` with `torch.library.wrap_triton` when a stable operator boundary is
    useful and compiler subsystems should remain able to inspect the implementation.
-3. **CuTeDSL or external implementation:** use a private `torch.library.custom_op` when the launcher
-   cannot be traced correctly.
+3. **CuTeDSL or external implementation:** use a private registered operator
+   (`torch.library.define`/`impl`, below) when the launcher cannot be traced correctly.
 
 The documented public function remains an ordinary Python function that owns semantic validation,
 mode selection, and backend dispatch. Compiling only a private launcher does not prove that the
 public operation is compile-friendly.
+
+## Operator boundary CPU overhead
+
+Every registered-operator boundary costs CPU time per call. Microbenchmark (torch 2.14 nightly,
+B200, identical trivial launcher, CPU wall-clock per call, medians over interleaved rounds):
+
+| boundary                        | inference | fwd, requires_grad=True     |
+| ------------------------------- | --------- | --------------------------- |
+| raw Python                      | 1.2 us    | 3.7 us (+autograd.Function) |
+| `define`/`impl`                 | 2.6 us    | 5.3 us (+autograd.Function) |
+| `custom_op`                     | 5.5 us    | 8.2 us (+autograd.Function) |
+| `impl(op, "Autograd")` kernel   | 6.8 us    | 7.4 us                      |
+| `custom_op` + register_autograd | —         | 10.2 us                     |
+
+Nesting one registered op inside another pays the boundary again (nested `custom_op` 7.1 us,
+nested `define`/`impl` 3.7 us). Wrapping the real `kda_l2norm_fwd` launcher in `custom_op` added
+~11 us per forward call over invoking the launcher directly.
+
+Consequences for launch-bound paths (small kernels, high call rate):
+
+- Registration exists for compile and fake-tensor consumers; eager execution gains nothing from
+  it. The eager floor is a plain `autograd.Function` over the launcher with no `torch.library`
+  registration (real `l2norm` op: ~17 us cheaper per gradient-tracking forward and ~58 us per
+  fwd+bwd than the `custom_op` boundary), at the cost of `fullgraph=True` support.
+- Use the define/impl pattern below for repo operators; `torch.library.custom_op` costs ~3 us
+  more per call for schema inference and mutation checking and is only preferable for
+  prototypes.
+- Prefer `autograd.Function` over `register_autograd` for hot training ops; it was the cheapest
+  measured autograd boundary. Registering a Python kernel at the Autograd dispatch key
+  (`torch.library.impl(op, "Autograd")`) makes the raw op differentiable but runs Python on
+  every call, including inference; use it only when direct `torch.ops` calls must be
+  differentiable.
+- Give each hot path at most one registered-operator boundary. Nested custom ops double the
+  dispatch tax; share the Python launcher between entrypoint ops instead of calling one op from
+  another.
+- A `define`/`impl` op has no autograd kernel: backprop through a direct call warns and produces
+  no gradient, so route all differentiable use through the `autograd.Function` wrapper.
+- `torch.library.opcheck` accepts `torch.ops.attn_gym.op.default`, so the validation workflow
+  below is unchanged.
 
 ## Public result contract
 
@@ -47,22 +86,79 @@ A registered operator's output structure and arity must agree with its schema. D
 returning a tensor and a tuple based on an argument. Represent optional outputs explicitly and match
 them in the fake implementation.
 
-## Opaque custom operator pattern
+## Opaque operator pattern (define/impl + autograd.Function)
+
+The repo standard for opaque kernel boundaries. Write the schema string yourself; nothing is
+inferred from annotations:
 
 ```python
 import torch
 from torch import Tensor
 
+torch.library.define(
+    "attn_gym::example_fwd",
+    "(Tensor query, Tensor key, Tensor value, Tensor? initial_state) -> (Tensor, Tensor)",
+)
+torch.library.define("attn_gym::example_bwd", "(Tensor query, Tensor grad_output) -> Tensor")
 
-@torch.library.custom_op("attn_gym::example_forward", mutates_args=())
-def example_forward(query: Tensor, key: Tensor, value: Tensor) -> Tensor:
-    return launch_backend(query, key, value)
+
+def _example_fwd_cuda(
+    query: Tensor, key: Tensor, value: Tensor, initial_state: Tensor | None
+) -> tuple[Tensor, Tensor]:
+    return launch_backend(query, key, value, initial_state)
 
 
-@example_forward.register_fake
-def example_forward_fake(query: Tensor, key: Tensor, value: Tensor) -> Tensor:
-    return torch.empty_like(value)
+# Register with an explicit call, not as a decorator: the decorator form returns None,
+# and keeping the launcher callable lets benchmarks and tests bypass the boundary.
+torch.library.impl("attn_gym::example_fwd", "CUDA", _example_fwd_cuda)
+
+
+@torch.library.register_fake("attn_gym::example_fwd")
+def _example_fwd_fake(
+    query: Tensor, key: Tensor, value: Tensor, initial_state: Tensor | None
+) -> tuple[Tensor, Tensor]:
+    return torch.empty_like(value), query.new_empty(query.shape[:2])
+
+
+_example_fwd = torch.ops.attn_gym.example_fwd.default
+_example_bwd = torch.ops.attn_gym.example_bwd.default  # impl/fake registered the same way
+
+
+class _Example(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, query: Tensor, key: Tensor, value: Tensor) -> Tensor:
+        output, state = _example_fwd(query, key, value, None)
+        ctx.save_for_backward(query)
+        return output
+
+    @staticmethod
+    @torch.autograd.function.once_differentiable
+    def backward(ctx, grad_output: Tensor):
+        (query,) = ctx.saved_tensors
+        return _example_bwd(query, grad_output), None, None
 ```
+
+Schema rules:
+
+- Optional tensors are `Tensor?`; scalars are `int`, `float`, `bool`; defaults may be embedded
+  (`Tensor? cu_seqlens=None`).
+- Encode mutation explicitly with alias annotations: `(Tensor(a!) state, Tensor value) -> ()`.
+- The schema language is a superset of what `custom_op` annotation inference accepts, adding
+  e.g. `ScalarType`, `Layout`, `MemoryFormat`, `Generator`, `SymInt`, and `int[2]`. Neither flow
+  accepts arbitrary Python objects, dataclasses, or callables; flatten configs to scalars or
+  specialize per-config outside the op.
+- Optional *outputs* parse as `Tensor?` but the compile stack handles `None` returns
+  unreliably, and a sentinel empty tensor forces empty-tensor plumbing on every caller. For
+  "N or N+1 returns depending on a flag", define two fixed-arity schemas sharing one launcher
+  (see `kda_chunk_fwd` / `kda_chunk_fwd_with_state`) and let the `autograd.Function` branch on
+  the flag; its output arity is free to vary. A future "flexible custom ops" feature may lift
+  this, but it does not work with `torch.compile` yet.
+- Tensors needed only by the backward (autograd tapes, packing metadata) should be op outputs
+  saved by the `autograd.Function` via `ctx.save_for_backward`, not part of the wrapper's
+  user-facing return. Unlike `register_autograd`, the Function is not limited to saving
+  user-visible outputs.
+- Bind `torch.ops.attn_gym.<op>.default` to a module-level name and call that; resolving the
+  `torch.ops` attribute chain per call adds overhead.
 
 The fake implementation describes output metadata without running the kernel. It must:
 
@@ -80,15 +176,10 @@ optional kernel dependencies lazily.
 
 ### Mutation and aliasing
 
-Declare every mutated argument:
+Declare every mutated argument in the schema string:
 
 ```python
-@torch.library.custom_op(
-    "attn_gym::update_state",
-    mutates_args={"state"},
-)
-def update_state(state: Tensor, value: Tensor) -> None:
-    launch_state_update(state, value)
+torch.library.define("attn_gym::update_state", "(Tensor(a!) state, Tensor value) -> ()")
 ```
 
 Do not declare an operator functional if its launcher writes into an input, including recurrent
@@ -96,25 +187,21 @@ state, cache, workspace, or output buffers. Prefer functional operators when pra
 
 ### Autograd
 
-Training backends must register an autograd formula:
+Training backends attach autograd with a `torch.autograd.Function` outside the registered ops, as
+in the pattern above: `forward` calls the forward op (autograd is already disabled inside
+`Function.forward`, so no redispatch guard is needed), `backward` calls the backward op, and the
+public API routes through `Function.apply`. Notes:
 
-```python
-def setup_context(ctx, inputs, output):
-    query, key, value = inputs
-    ctx.save_for_backward(query, key, value)
-
-
-def backward(ctx, grad_output):
-    query, key, value = ctx.saved_tensors
-    return backward_formula(query, key, value, grad_output)
-
-
-example_forward.register_autograd(backward, setup_context=setup_context)
-```
-
-The backward formula must itself use operations understood by PyTorch. Return one gradient entry per
-forward input and `None` for nondifferentiable inputs. If training is unsupported, reject
-requiring-gradient inputs clearly instead of silently detaching them.
+- Mark first-order-only backwards with `@torch.autograd.function.once_differentiable`.
+- Return one gradient entry per forward input and `None` for nondifferentiable inputs.
+- Use `ctx.mark_non_differentiable(...)` for auxiliary outputs and
+  `ctx.set_materialize_grads(False)` when the backward handles `None` grads.
+- The raw forward op is not differentiable; direct `torch.ops` calls that backprop through it
+  warn and produce no gradient. Route all differentiable use through the wrapper.
+- Do not use `CustomOpDef.register_autograd` (slowest measured path) or an Autograd dispatch-key
+  kernel (taxes every inference call) unless raw op calls must be differentiable.
+- If training is unsupported, reject requiring-gradient inputs clearly instead of silently
+  detaching them.
 
 ## Compiler-visible Triton pattern
 

--- a/attn_gym/linear/kda/bwd/cute/gate_bwd_fused.py
+++ b/attn_gym/linear/kda/bwd/cute/gate_bwd_fused.py
@@ -483,8 +483,14 @@ def _validate_inputs(
     return FusedGateBwdOp(heads, head_dim, chunk_size, lower_bound, fastmath)
 
 
-@torch.library.custom_op("attn_gym::kda_fused_gate_bwd", mutates_args=())
-def _fused_gate_bwd_custom_op(
+torch.library.define(
+    "attn_gym::kda_fused_gate_bwd",
+    "(Tensor g, Tensor A_log, Tensor dt_bias, Tensor d_cumulative, int chunk_size, "
+    "float lower_bound, bool fastmath) -> (Tensor, Tensor, Tensor)",
+)
+
+
+def _fused_gate_bwd_cuda(
     g: torch.Tensor,
     A_log: torch.Tensor,
     dt_bias: torch.Tensor,
@@ -527,7 +533,10 @@ def _fused_gate_bwd_custom_op(
     return dg, dA_partial, d_dt_bias_partial.sum((0, 1))
 
 
-@_fused_gate_bwd_custom_op.register_fake
+torch.library.impl("attn_gym::kda_fused_gate_bwd", "CUDA", _fused_gate_bwd_cuda)
+
+
+@torch.library.register_fake("attn_gym::kda_fused_gate_bwd")
 def _fused_gate_bwd_fake(
     g: torch.Tensor,
     A_log: torch.Tensor,
@@ -545,6 +554,9 @@ def _fused_gate_bwd_fake(
         d_cumulative.new_empty(partial_shape),
         dt_bias.new_empty(dt_bias.shape),
     )
+
+
+_fused_gate_bwd_op = torch.ops.attn_gym.kda_fused_gate_bwd.default
 
 
 def fused_gate_bwd(
@@ -579,7 +591,7 @@ def fused_gate_bwd(
     ):
         raise RuntimeError("fused_gate_bwd does not support higher-order autograd")
 
-    dg, dA_partial, d_dt_bias = _fused_gate_bwd_custom_op(
+    dg, dA_partial, d_dt_bias = _fused_gate_bwd_op(
         g,
         A_log,
         dt_bias,

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py
@@ -216,8 +216,23 @@ def _chunk_kda_fwd(
     )
 
 
-@torch.library.custom_op("attn_gym::kda_chunk_fwd", mutates_args=())
-def _chunk_kda_fwd_custom_op(
+# Fixed-arity schema pair instead of an optional final-state output. Tapes and packing
+# metadata are op outputs only so the autograd.Function can save them.
+_FWD_ARGS = (
+    "(Tensor q, Tensor k, Tensor v, Tensor cumulative_gate, Tensor beta, "
+    "Tensor? initial_state, Tensor? cu_seqlens, bool profile_ranges)"
+)
+torch.library.define(
+    "attn_gym::kda_chunk_fwd",
+    f"{_FWD_ARGS} -> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor)",
+)
+torch.library.define(
+    "attn_gym::kda_chunk_fwd_with_state",
+    f"{_FWD_ARGS} -> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor)",
+)
+
+
+def _chunk_kda_fwd_shared(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
@@ -226,22 +241,12 @@ def _chunk_kda_fwd_custom_op(
     initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor | None,
     output_final_state: bool,
-    fastmath: bool,
     profile_ranges: bool,
-) -> tuple[
-    torch.Tensor,
-    torch.Tensor,
-    torch.Tensor,
-    torch.Tensor,
-    torch.Tensor,
-    torch.Tensor,
-    torch.Tensor,
-]:
+):
     """Keep the complete composed forward behind one compiler-opaque boundary."""
-    del fastmath  # This static option configures the registered backward.
     q, k, v = (_normalize_qkv_layout(tensor) for tensor in (q, k, v))
     _validate_private_abi(q, k, v, cumulative_gate, beta, initial_state)
-    output, final_state, Aqk, Akk, cu_seqlens, chunk_indices, num_chunks = _chunk_kda_fwd(
+    return _chunk_kda_fwd(
         q,
         k,
         v,
@@ -252,12 +257,9 @@ def _chunk_kda_fwd_custom_op(
         output_final_state=output_final_state,
         profile_ranges=profile_ranges,
     )
-    state = final_state if final_state is not None else q.new_empty((0,), dtype=torch.float32)
-    return output, state, Aqk, Akk, cu_seqlens, chunk_indices, num_chunks
 
 
-@_chunk_kda_fwd_custom_op.register_fake
-def _chunk_kda_fwd_fake(
+def _chunk_kda_fwd_cuda(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
@@ -265,8 +267,37 @@ def _chunk_kda_fwd_fake(
     beta: torch.Tensor,
     initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor | None,
-    output_final_state: bool,
-    fastmath: bool,
+    profile_ranges: bool,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    output, _final_state, Aqk, Akk, cu_seqlens, chunk_indices, num_chunks = _chunk_kda_fwd_shared(
+        q,
+        k,
+        v,
+        cumulative_gate,
+        beta,
+        initial_state,
+        cu_seqlens,
+        False,
+        profile_ranges,
+    )
+    return output, Aqk, Akk, cu_seqlens, chunk_indices, num_chunks
+
+
+def _chunk_kda_fwd_with_state_cuda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
     profile_ranges: bool,
 ) -> tuple[
     torch.Tensor,
@@ -277,20 +308,31 @@ def _chunk_kda_fwd_fake(
     torch.Tensor,
     torch.Tensor,
 ]:
-    """Describe the composed forward outputs without invoking a launcher."""
-    del k, cumulative_gate, beta, initial_state, fastmath, profile_ranges
-    batch, tokens, heads, head_dim = q.shape
-    state_batch = batch if cu_seqlens is None else cu_seqlens.shape[0] - 1
-    state = (
-        q.new_empty((state_batch, heads, head_dim, v.shape[-1]), dtype=torch.float32)
-        if output_final_state
-        else q.new_empty((0,), dtype=torch.float32)
+    output, final_state, Aqk, Akk, cu_seqlens, chunk_indices, num_chunks = _chunk_kda_fwd_shared(
+        q,
+        k,
+        v,
+        cumulative_gate,
+        beta,
+        initial_state,
+        cu_seqlens,
+        True,
+        profile_ranges,
     )
+    return output, final_state, Aqk, Akk, cu_seqlens, chunk_indices, num_chunks
+
+
+torch.library.impl("attn_gym::kda_chunk_fwd", "CUDA", _chunk_kda_fwd_cuda)
+torch.library.impl("attn_gym::kda_chunk_fwd_with_state", "CUDA", _chunk_kda_fwd_with_state_cuda)
+
+
+def _fwd_fake_common(q, v, cu_seqlens):
+    """Describe the composed forward outputs shared by both schemas."""
+    batch, tokens, heads, _head_dim = q.shape
     tape_shape = (batch, tokens, heads, _CHUNK_SIZE)
     chunks = tokens // _CHUNK_SIZE
     return (
         v.new_empty(v.shape),
-        state,
         q.new_empty(tape_shape),
         q.new_empty(tape_shape),
         q.new_empty((0 if cu_seqlens is not None else 2,), dtype=torch.int32),
@@ -299,8 +341,60 @@ def _chunk_kda_fwd_fake(
     )
 
 
-@torch.library.custom_op("attn_gym::kda_chunk_bwd", mutates_args=())
-def _chunk_kda_bwd_custom_op(
+@torch.library.register_fake("attn_gym::kda_chunk_fwd")
+def _chunk_kda_fwd_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+    profile_ranges: bool,
+):
+    del k, cumulative_gate, beta, initial_state, profile_ranges
+    return _fwd_fake_common(q, v, cu_seqlens)
+
+
+@torch.library.register_fake("attn_gym::kda_chunk_fwd_with_state")
+def _chunk_kda_fwd_with_state_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+    profile_ranges: bool,
+):
+    del k, cumulative_gate, beta, initial_state, profile_ranges
+    batch, _tokens, heads, head_dim = q.shape
+    state_batch = batch if cu_seqlens is None else cu_seqlens.shape[0] - 1
+    output, Aqk, Akk, cu, chunk_indices, num_chunks = _fwd_fake_common(q, v, cu_seqlens)
+    state = q.new_empty((state_batch, heads, head_dim, v.shape[-1]), dtype=torch.float32)
+    return output, state, Aqk, Akk, cu, chunk_indices, num_chunks
+
+
+# Fixed-arity schema pair instead of an optional initial-state-gradient output.
+_BWD_ARGS = (
+    "(Tensor q, Tensor k, Tensor v, Tensor cumulative_gate, Tensor beta, Tensor Aqk, "
+    "Tensor Akk, Tensor cu_seqlens, Tensor chunk_indices, Tensor num_chunks, "
+    "Tensor? d_output, Tensor? d_final_state, {initial_state}, bool fastmath, "
+    "bool profile_ranges)"
+)
+torch.library.define(
+    "attn_gym::kda_chunk_bwd",
+    _BWD_ARGS.format(initial_state="Tensor? initial_state")
+    + " -> (Tensor, Tensor, Tensor, Tensor, Tensor)",
+)
+torch.library.define(
+    "attn_gym::kda_chunk_bwd_with_state_grad",
+    _BWD_ARGS.format(initial_state="Tensor initial_state")
+    + " -> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor)",
+)
+
+
+def _chunk_kda_bwd_shared(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
@@ -316,7 +410,7 @@ def _chunk_kda_bwd_custom_op(
     initial_state: torch.Tensor | None,
     fastmath: bool,
     profile_ranges: bool,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+):
     """Keep the complete first-order composed backward opaque to AOTAutograd."""
     from attn_gym.linear.kda.bwd.cute.chunk_kda_bwd import chunk_kda_bwd
 
@@ -324,7 +418,7 @@ def _chunk_kda_bwd_custom_op(
     _validate_private_abi(q, k, v, cumulative_gate, beta, initial_state)
     if d_output is None:
         d_output = v.new_zeros(v.shape)
-    dq, dk, dv, dg, db, d_initial_state = chunk_kda_bwd(
+    return chunk_kda_bwd(
         q,
         k,
         v,
@@ -339,14 +433,49 @@ def _chunk_kda_bwd_custom_op(
         fastmath=fastmath,
         profile_ranges=profile_ranges,
     )
-    initial_state_gradient = (
-        d_initial_state if d_initial_state is not None else q.new_empty((0,), dtype=torch.float32)
+
+
+def _chunk_kda_bwd_cuda(*args) -> tuple[torch.Tensor, ...]:
+    dq, dk, dv, dg, db, _d_initial_state = _chunk_kda_bwd_shared(*args)
+    return dq, dk, dv, dg, db
+
+
+def _chunk_kda_bwd_with_state_grad_cuda(*args) -> tuple[torch.Tensor, ...]:
+    return _chunk_kda_bwd_shared(*args)
+
+
+torch.library.impl("attn_gym::kda_chunk_bwd", "CUDA", _chunk_kda_bwd_cuda)
+torch.library.impl(
+    "attn_gym::kda_chunk_bwd_with_state_grad", "CUDA", _chunk_kda_bwd_with_state_grad_cuda
+)
+
+
+def _bwd_fake_common(q, k, v, cumulative_gate, beta):
+    """Describe backward output metadata without invoking a launcher."""
+    return (
+        q.new_empty(q.shape),
+        k.new_empty(k.shape),
+        v.new_empty(v.shape),
+        cumulative_gate.new_empty(cumulative_gate.shape),
+        beta.new_empty(beta.shape),
     )
-    return dq, dk, dv, dg, db, initial_state_gradient
 
 
-@_chunk_kda_bwd_custom_op.register_fake
+@torch.library.register_fake("attn_gym::kda_chunk_bwd")
 def _chunk_kda_bwd_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    *args,
+):
+    del args
+    return _bwd_fake_common(q, k, v, cumulative_gate, beta)
+
+
+@torch.library.register_fake("attn_gym::kda_chunk_bwd_with_state_grad")
+def _chunk_kda_bwd_with_state_grad_fake(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
@@ -359,133 +488,124 @@ def _chunk_kda_bwd_fake(
     num_chunks: torch.Tensor,
     d_output: torch.Tensor | None,
     d_final_state: torch.Tensor | None,
-    initial_state: torch.Tensor | None,
+    initial_state: torch.Tensor,
     fastmath: bool,
     profile_ranges: bool,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Describe backward output metadata without invoking a launcher."""
-    del (
-        Aqk,
-        Akk,
-        cu_seqlens,
-        chunk_indices,
-        num_chunks,
-        d_output,
-        d_final_state,
-        fastmath,
-        profile_ranges,
-    )
-    d_initial_state = (
-        torch.empty_like(initial_state)
-        if initial_state is not None
-        else q.new_empty((0,), dtype=torch.float32)
-    )
-    return (
-        q.new_empty(q.shape),
-        k.new_empty(k.shape),
-        v.new_empty(v.shape),
-        cumulative_gate.new_empty(cumulative_gate.shape),
-        beta.new_empty(beta.shape),
-        d_initial_state,
-    )
+):
+    del Aqk, Akk, cu_seqlens, chunk_indices, num_chunks, d_output, d_final_state
+    del fastmath, profile_ranges
+    return (*_bwd_fake_common(q, k, v, cumulative_gate, beta), torch.empty_like(initial_state))
 
 
-def _setup_chunk_kda_context(ctx, inputs, output) -> None:
-    (
+_chunk_kda_fwd_op = torch.ops.attn_gym.kda_chunk_fwd.default
+_chunk_kda_fwd_with_state_op = torch.ops.attn_gym.kda_chunk_fwd_with_state.default
+_chunk_kda_bwd_op = torch.ops.attn_gym.kda_chunk_bwd.default
+_chunk_kda_bwd_with_state_grad_op = torch.ops.attn_gym.kda_chunk_bwd_with_state_grad.default
+
+
+class _ChunkKDA(torch.autograd.Function):
+    """First-order autograd wrapper around the opaque composed forward and backward ops.
+
+    The forward returns ``output`` alone or ``(output, final_state)``; the autograd tapes
+    and packing metadata are saved as intermediates rather than exposed as outputs.
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
         q,
         k,
         v,
         cumulative_gate,
         beta,
         initial_state,
-        _input_cu_seqlens,
+        cu_seqlens,
         output_final_state,
         fastmath,
         profile_ranges,
-    ) = inputs
-    _output, state, Aqk, Akk, cu_seqlens, chunk_indices, num_chunks = output
-    backward_cu_seqlens = cu_seqlens if _input_cu_seqlens is None else _input_cu_seqlens
-    ctx.save_for_backward(
-        q,
-        k,
-        v,
-        cumulative_gate,
-        beta,
-        Aqk,
-        Akk,
-        initial_state,
-        backward_cu_seqlens,
-        chunk_indices,
-        num_chunks,
-    )
-    ctx.has_initial_state = initial_state is not None
-    ctx.fastmath = fastmath
-    ctx.profile_ranges = profile_ranges
-    ctx.set_materialize_grads(False)
-    ctx.mark_non_differentiable(Aqk, Akk)
-    if not output_final_state:
-        ctx.mark_non_differentiable(state)
+    ):
+        if output_final_state:
+            output, state, Aqk, Akk, fwd_cu_seqlens, chunk_indices, num_chunks = (
+                _chunk_kda_fwd_with_state_op(
+                    q, k, v, cumulative_gate, beta, initial_state, cu_seqlens, profile_ranges
+                )
+            )
+        else:
+            output, Aqk, Akk, fwd_cu_seqlens, chunk_indices, num_chunks = _chunk_kda_fwd_op(
+                q, k, v, cumulative_gate, beta, initial_state, cu_seqlens, profile_ranges
+            )
+        backward_cu_seqlens = fwd_cu_seqlens if cu_seqlens is None else cu_seqlens
+        ctx.save_for_backward(
+            q,
+            k,
+            v,
+            cumulative_gate,
+            beta,
+            Aqk,
+            Akk,
+            initial_state,
+            backward_cu_seqlens,
+            chunk_indices,
+            num_chunks,
+        )
+        ctx.has_initial_state = initial_state is not None
+        ctx.fastmath = fastmath
+        ctx.profile_ranges = profile_ranges
+        ctx.set_materialize_grads(False)
+        if output_final_state:
+            return output, state
+        return output
 
-
-@torch.autograd.function.once_differentiable
-def _chunk_kda_backward(
-    ctx,
-    d_output,
-    d_final_state,
-    _dAqk,
-    _dAkk,
-    _d_cu_seqlens,
-    _d_chunk_indices,
-    _d_num_chunks,
-):
-    (
-        q,
-        k,
-        v,
-        cumulative_gate,
-        beta,
-        Aqk,
-        Akk,
-        initial_state,
-        cu_seqlens,
-        chunk_indices,
-        num_chunks,
-    ) = ctx.saved_tensors
-    dq, dk, dv, dg, db, d_initial_state = _chunk_kda_bwd_custom_op(
-        q,
-        k,
-        v,
-        cumulative_gate,
-        beta,
-        Aqk,
-        Akk,
-        cu_seqlens,
-        chunk_indices,
-        num_chunks,
-        d_output,
-        d_final_state,
-        initial_state,
-        ctx.fastmath,
-        ctx.profile_ranges,
-    )
-    return (
-        dq,
-        dk,
-        dv,
-        dg,
-        db,
-        d_initial_state if ctx.has_initial_state else None,
-        None,
-        None,
-        None,
-        None,
-    )
-
-
-_chunk_kda_fwd_custom_op.register_autograd(
-    _chunk_kda_backward,
-    setup_context=_setup_chunk_kda_context,
-)
+    @staticmethod
+    @torch.autograd.function.once_differentiable
+    def backward(ctx, d_output, d_final_state=None):
+        (
+            q,
+            k,
+            v,
+            cumulative_gate,
+            beta,
+            Aqk,
+            Akk,
+            initial_state,
+            cu_seqlens,
+            chunk_indices,
+            num_chunks,
+        ) = ctx.saved_tensors
+        args = (
+            q,
+            k,
+            v,
+            cumulative_gate,
+            beta,
+            Aqk,
+            Akk,
+            cu_seqlens,
+            chunk_indices,
+            num_chunks,
+            d_output,
+            d_final_state,
+            initial_state,
+            ctx.fastmath,
+            ctx.profile_ranges,
+        )
+        if ctx.has_initial_state:
+            dq, dk, dv, dg, db, d_initial_state = _chunk_kda_bwd_with_state_grad_op(*args)
+        else:
+            dq, dk, dv, dg, db = _chunk_kda_bwd_op(*args)
+            d_initial_state = None
+        return (
+            dq,
+            dk,
+            dv,
+            dg,
+            db,
+            d_initial_state,
+            None,
+            None,
+            None,
+            None,
+        )
 
 
 def chunk_kda(
@@ -525,21 +645,34 @@ def chunk_kda(
         )
         beta = beta.reshape(1, batch * tokens, heads)
         cu_seqlens = torch.arange(batch + 1, dtype=torch.int32, device=q.device) * tokens
-    output, state, _Aqk, _Akk, _cu_seqlens, _chunk_indices, _num_chunks = _chunk_kda_fwd_custom_op(
-        q,
-        k,
-        v,
-        cumulative_gate,
-        beta,
-        initial_state,
-        cu_seqlens,
-        output_final_state,
-        fastmath,
-        profile_ranges,
-    )
-    return output.reshape(batch, tokens, heads, head_dim).to(output_dtype), (
-        state if output_final_state else None
-    )
+    if output_final_state:
+        output, state = _ChunkKDA.apply(
+            q,
+            k,
+            v,
+            cumulative_gate,
+            beta,
+            initial_state,
+            cu_seqlens,
+            True,
+            fastmath,
+            profile_ranges,
+        )
+    else:
+        output = _ChunkKDA.apply(
+            q,
+            k,
+            v,
+            cumulative_gate,
+            beta,
+            initial_state,
+            cu_seqlens,
+            False,
+            fastmath,
+            profile_ranges,
+        )
+        state = None
+    return output.reshape(batch, tokens, heads, head_dim).to(output_dtype), state
 
 
 __all__ = ["chunk_kda"]

--- a/attn_gym/linear/kda/fwd/triton/l2norm_fwd.py
+++ b/attn_gym/linear/kda/fwd/triton/l2norm_fwd.py
@@ -8,8 +8,8 @@ import triton.language as tl
 
 from attn_gym._backends.triton.utils import ptr_offset
 
-# A Triton pointer does not carry tensor shape or stride metadata. The custom-op boundary
-# keeps runtime stride tuples opaque to Dynamo while preserving ptr_offset indexing.
+# A Triton pointer does not carry tensor shape or stride metadata. The registered-operator
+# boundary keeps runtime stride tuples opaque to Dynamo while preserving ptr_offset indexing.
 
 
 @triton.autotune(
@@ -113,8 +113,10 @@ def l2norm_fwd_kernel(
     )
 
 
-@torch.library.custom_op("attn_gym::kda_l2norm_fwd", mutates_args=())
-def _l2norm_fwd_custom_op(x: torch.Tensor, eps: float) -> tuple[torch.Tensor, torch.Tensor]:
+torch.library.define("attn_gym::kda_l2norm_fwd", "(Tensor x, float eps) -> (Tensor, Tensor)")
+
+
+def _l2norm_fwd_cuda(x: torch.Tensor, eps: float) -> tuple[torch.Tensor, torch.Tensor]:
     """Launch L2Norm using runtime shape and stride metadata."""
     _, tokens, heads, head_dim = x.shape
     # Compact outputs enumerate rows in the same batch-token-head order reconstructed by
@@ -142,7 +144,10 @@ def _l2norm_fwd_custom_op(x: torch.Tensor, eps: float) -> tuple[torch.Tensor, to
     return output.view_as(x), rstd
 
 
-@_l2norm_fwd_custom_op.register_fake
+torch.library.impl("attn_gym::kda_l2norm_fwd", "CUDA", _l2norm_fwd_cuda)
+
+
+@torch.library.register_fake("attn_gym::kda_l2norm_fwd")
 def _l2norm_fwd_fake(x: torch.Tensor, eps: float) -> tuple[torch.Tensor, torch.Tensor]:
     """Describe compact output metadata without launching Triton."""
     del eps
@@ -153,8 +158,13 @@ def _l2norm_fwd_fake(x: torch.Tensor, eps: float) -> tuple[torch.Tensor, torch.T
     )
 
 
-@torch.library.custom_op("attn_gym::kda_l2norm_bwd", mutates_args=())
-def _l2norm_bwd_custom_op(
+torch.library.define(
+    "attn_gym::kda_l2norm_bwd",
+    "(Tensor output, Tensor rstd, Tensor d_output) -> Tensor",
+)
+
+
+def _l2norm_bwd_cuda(
     output: torch.Tensor,
     rstd: torch.Tensor,
     d_output: torch.Tensor,
@@ -186,7 +196,10 @@ def _l2norm_bwd_custom_op(
     return d_input
 
 
-@_l2norm_bwd_custom_op.register_fake
+torch.library.impl("attn_gym::kda_l2norm_bwd", "CUDA", _l2norm_bwd_cuda)
+
+
+@torch.library.register_fake("attn_gym::kda_l2norm_bwd")
 def _l2norm_bwd_fake(
     output: torch.Tensor,
     rstd: torch.Tensor,
@@ -197,10 +210,14 @@ def _l2norm_bwd_fake(
     return torch.empty_like(output)
 
 
+_l2norm_fwd_op = torch.ops.attn_gym.kda_l2norm_fwd.default
+_l2norm_bwd_op = torch.ops.attn_gym.kda_l2norm_bwd.default
+
+
 class _L2Norm(torch.autograd.Function):
     @staticmethod
     def forward(ctx, x: torch.Tensor, eps: float) -> torch.Tensor:
-        output, rstd = _l2norm_fwd_custom_op(x, eps)
+        output, rstd = _l2norm_fwd_op(x, eps)
         ctx.save_for_backward(output.view(-1, x.shape[-1]), rstd)
         ctx.input_shape = x.shape
         return output
@@ -209,7 +226,7 @@ class _L2Norm(torch.autograd.Function):
     @torch.autograd.function.once_differentiable
     def backward(ctx, d_output: torch.Tensor):
         output, rstd = ctx.saved_tensors
-        d_input = _l2norm_bwd_custom_op(output, rstd, d_output)
+        d_input = _l2norm_bwd_op(output, rstd, d_output)
         return d_input.view(ctx.input_shape), None
 
 

--- a/attn_gym/linear/kda/short_conv/cute.py
+++ b/attn_gym/linear/kda/short_conv/cute.py
@@ -2422,12 +2422,17 @@ def tune_causal_conv1d_silu(
 
 
 def _config(threads: int, channels_per_thread: int, times_per_block: int) -> ShortConvConfig:
-    """Reconstruct a compile-time config from custom-op scalar arguments."""
+    """Reconstruct a compile-time config from registered-operator scalar arguments."""
     return ShortConvConfig(threads, channels_per_thread, times_per_block)
 
 
-@torch.library.custom_op("attn_gym::_cute_short_conv_fwd", mutates_args=())
-def _forward_custom_op(
+torch.library.define(
+    "attn_gym::_cute_short_conv_fwd",
+    "(Tensor x, Tensor weight, Tensor? cu_seqlens=None, Tensor? initial_state=None) -> Tensor",
+)
+
+
+def _cute_short_conv_fwd_cuda(
     x: torch.Tensor,
     weight: torch.Tensor,
     cu_seqlens: torch.Tensor | None = None,
@@ -2443,7 +2448,10 @@ def _forward_custom_op(
     )
 
 
-@_forward_custom_op.register_fake
+torch.library.impl("attn_gym::_cute_short_conv_fwd", "CUDA", _cute_short_conv_fwd_cuda)
+
+
+@torch.library.register_fake("attn_gym::_cute_short_conv_fwd")
 def _default_forward_fake(
     x: torch.Tensor,
     weight: torch.Tensor,
@@ -2454,8 +2462,13 @@ def _default_forward_fake(
     return torch.empty_like(x)
 
 
-@torch.library.custom_op("attn_gym::_cute_short_conv_bwd", mutates_args=())
-def _backward_custom_op(
+torch.library.define(
+    "attn_gym::_cute_short_conv_bwd",
+    "(Tensor x, Tensor weight, Tensor grad_output, Tensor? cu_seqlens=None) -> (Tensor, Tensor)",
+)
+
+
+def _cute_short_conv_bwd_cuda(
     x: torch.Tensor,
     weight: torch.Tensor,
     grad_output: torch.Tensor,
@@ -2474,7 +2487,10 @@ def _backward_custom_op(
     return grad_x, grad_weight
 
 
-@_backward_custom_op.register_fake
+torch.library.impl("attn_gym::_cute_short_conv_bwd", "CUDA", _cute_short_conv_bwd_cuda)
+
+
+@torch.library.register_fake("attn_gym::_cute_short_conv_bwd")
 def _default_backward_fake(
     x: torch.Tensor,
     weight: torch.Tensor,
@@ -2485,52 +2501,16 @@ def _default_backward_fake(
     return torch.empty_like(x), torch.empty_like(weight)
 
 
-def _setup_default_context(ctx, inputs, output) -> None:
-    del output
-    ctx.save_for_backward(*inputs)
-
-
-@torch.autograd.function.once_differentiable
-def _default_backward(ctx, grad_output: torch.Tensor):
-    x, weight, cu_seqlens, initial_state = ctx.saved_tensors
-    if initial_state is None:
-        grad_x, grad_weight = _backward_custom_op(x, weight, grad_output, cu_seqlens)
-        grad_initial_state = None
-    else:
-        defaults = ShortConvTunedConfig.default(
-            x.dtype,
-            packed=cu_seqlens is not None,
-            stateful=True,
-        )
-        input_config = defaults.input_gradient
-        weight_config = defaults.weight_gradient
-        grad_x, grad_weight, grad_initial_state = _configured_backward_custom_op(
-            x,
-            weight,
-            grad_output,
-            cu_seqlens,
-            initial_state,
-            ctx.needs_input_grad[3],
-            input_config.threads,
-            input_config.channels_per_thread,
-            input_config.times_per_block,
-            weight_config.threads,
-            weight_config.channels_per_thread,
-            weight_config.times_per_block,
-        )
-        if not ctx.needs_input_grad[3]:
-            grad_initial_state = None
-    return grad_x, grad_weight, None, grad_initial_state
-
-
-_forward_custom_op.register_autograd(
-    _default_backward,
-    setup_context=_setup_default_context,
+torch.library.define(
+    "attn_gym::_cute_short_conv_configured_fwd",
+    "(Tensor x, Tensor weight, Tensor? cu_seqlens, Tensor? initial_state,"
+    " int forward_threads, int forward_channels, int forward_times,"
+    " int input_threads, int input_channels, int input_times,"
+    " int weight_threads, int weight_channels, int weight_times) -> Tensor",
 )
 
 
-@torch.library.custom_op("attn_gym::_cute_short_conv_configured_fwd", mutates_args=())
-def _configured_forward_custom_op(
+def _cute_short_conv_configured_fwd_cuda(
     x: torch.Tensor,
     weight: torch.Tensor,
     cu_seqlens: torch.Tensor | None,
@@ -2556,7 +2536,12 @@ def _configured_forward_custom_op(
     )
 
 
-@_configured_forward_custom_op.register_fake
+torch.library.impl(
+    "attn_gym::_cute_short_conv_configured_fwd", "CUDA", _cute_short_conv_configured_fwd_cuda
+)
+
+
+@torch.library.register_fake("attn_gym::_cute_short_conv_configured_fwd")
 def _forward_fake(
     x: torch.Tensor,
     weight: torch.Tensor,
@@ -2590,14 +2575,59 @@ def _forward_fake(
     return torch.empty_like(x)
 
 
-@torch.library.custom_op("attn_gym::_cute_short_conv_configured_bwd", mutates_args=())
-def _configured_backward_custom_op(
+_CONFIGURED_BWD_ARGS = (
+    "(Tensor x, Tensor weight, Tensor grad_output, Tensor? cu_seqlens, {initial_state},"
+    " int input_threads, int input_channels, int input_times,"
+    " int weight_threads, int weight_channels, int weight_times)"
+)
+torch.library.define(
+    "attn_gym::_cute_short_conv_configured_bwd",
+    _CONFIGURED_BWD_ARGS.format(initial_state="Tensor? initial_state") + " -> (Tensor, Tensor)",
+)
+torch.library.define(
+    "attn_gym::_cute_short_conv_configured_bwd_with_state_grad",
+    _CONFIGURED_BWD_ARGS.format(initial_state="Tensor initial_state")
+    + " -> (Tensor, Tensor, Tensor)",
+)
+
+
+def _cute_short_conv_configured_bwd_cuda(
     x: torch.Tensor,
     weight: torch.Tensor,
     grad_output: torch.Tensor,
     cu_seqlens: torch.Tensor | None,
     initial_state: torch.Tensor | None,
-    compute_initial_state_grad: bool,
+    input_threads: int,
+    input_channels: int,
+    input_times: int,
+    weight_threads: int,
+    weight_channels: int,
+    weight_times: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Keep the configured first-order backward launchers opaque.
+
+    ``initial_state`` remains an optional input for preactivation recomputation,
+    but its gradient is never computed; use the ``_with_state_grad`` variant for that.
+    """
+    grad_x, grad_weight, _ = _launch_backward(
+        x,
+        weight,
+        grad_output,
+        _config(input_threads, input_channels, input_times),
+        _config(weight_threads, weight_channels, weight_times),
+        cu_seqlens,
+        initial_state,
+        compute_initial_state_grad=False,
+    )
+    return grad_x, grad_weight
+
+
+def _cute_short_conv_configured_bwd_with_state_grad_cuda(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    grad_output: torch.Tensor,
+    cu_seqlens: torch.Tensor | None,
+    initial_state: torch.Tensor,
     input_threads: int,
     input_channels: int,
     input_times: int,
@@ -2605,7 +2635,7 @@ def _configured_backward_custom_op(
     weight_channels: int,
     weight_times: int,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Keep the configured first-order backward launchers opaque."""
+    """Compute the configured first-order backward including the state gradient."""
     grad_x, grad_weight, grad_initial_state = _launch_backward(
         x,
         weight,
@@ -2614,21 +2644,57 @@ def _configured_backward_custom_op(
         _config(weight_threads, weight_channels, weight_times),
         cu_seqlens,
         initial_state,
-        compute_initial_state_grad,
+        compute_initial_state_grad=True,
     )
-    if grad_initial_state is None:
-        grad_initial_state = x.new_empty(0)
     return grad_x, grad_weight, grad_initial_state
 
 
-@_configured_backward_custom_op.register_fake
+torch.library.impl(
+    "attn_gym::_cute_short_conv_configured_bwd", "CUDA", _cute_short_conv_configured_bwd_cuda
+)
+torch.library.impl(
+    "attn_gym::_cute_short_conv_configured_bwd_with_state_grad",
+    "CUDA",
+    _cute_short_conv_configured_bwd_with_state_grad_cuda,
+)
+
+
+@torch.library.register_fake("attn_gym::_cute_short_conv_configured_bwd")
 def _backward_fake(
     x: torch.Tensor,
     weight: torch.Tensor,
     grad_output: torch.Tensor,
     cu_seqlens: torch.Tensor | None,
     initial_state: torch.Tensor | None,
-    compute_initial_state_grad: bool,
+    input_threads: int,
+    input_channels: int,
+    input_times: int,
+    weight_threads: int,
+    weight_channels: int,
+    weight_times: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Describe backward output metadata without invoking the compiler."""
+    del (
+        grad_output,
+        cu_seqlens,
+        initial_state,
+        input_threads,
+        input_channels,
+        input_times,
+        weight_threads,
+        weight_channels,
+        weight_times,
+    )
+    return torch.empty_like(x), torch.empty_like(weight)
+
+
+@torch.library.register_fake("attn_gym::_cute_short_conv_configured_bwd_with_state_grad")
+def _backward_with_state_grad_fake(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    grad_output: torch.Tensor,
+    cu_seqlens: torch.Tensor | None,
+    initial_state: torch.Tensor,
     input_threads: int,
     input_channels: int,
     input_times: int,
@@ -2636,7 +2702,7 @@ def _backward_fake(
     weight_channels: int,
     weight_times: int,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Describe backward output metadata without invoking the compiler."""
+    """Describe stateful backward output metadata without invoking the compiler."""
     del (
         grad_output,
         cu_seqlens,
@@ -2647,73 +2713,146 @@ def _backward_fake(
         weight_channels,
         weight_times,
     )
-    grad_initial_state = (
-        x.new_empty(0)
-        if initial_state is None or not compute_initial_state_grad
-        else torch.empty_like(initial_state)
-    )
-    return torch.empty_like(x), torch.empty_like(weight), grad_initial_state
+    return torch.empty_like(x), torch.empty_like(weight), torch.empty_like(initial_state)
 
 
-def _setup_context(ctx, inputs, output) -> None:
-    """Save inputs and backward specializations for preactivation recomputation."""
-    del output
-    (
-        x,
-        weight,
-        cu_seqlens,
-        initial_state,
-        _forward_threads,
-        _forward_channels,
-        _forward_times,
-        ctx.input_threads,
-        ctx.input_channels,
-        ctx.input_times,
-        ctx.weight_threads,
-        ctx.weight_channels,
-        ctx.weight_times,
-    ) = inputs
-    ctx.save_for_backward(x, weight, cu_seqlens, initial_state)
+_forward_op = torch.ops.attn_gym._cute_short_conv_fwd.default
+_backward_op = torch.ops.attn_gym._cute_short_conv_bwd.default
+_configured_forward_op = torch.ops.attn_gym._cute_short_conv_configured_fwd.default
+_configured_backward_op = torch.ops.attn_gym._cute_short_conv_configured_bwd.default
+_configured_backward_with_state_grad_op = (
+    torch.ops.attn_gym._cute_short_conv_configured_bwd_with_state_grad.default
+)
 
 
-@torch.autograd.function.once_differentiable
-def _backward(ctx, grad_output: torch.Tensor):
-    """Dispatch the registered first-order backward custom operator."""
-    x, weight, cu_seqlens, initial_state = ctx.saved_tensors
-    grad_x, grad_weight, grad_initial_state = _configured_backward_custom_op(
-        x,
-        weight,
-        grad_output,
-        cu_seqlens,
-        initial_state,
-        ctx.needs_input_grad[3],
-        ctx.input_threads,
-        ctx.input_channels,
-        ctx.input_times,
-        ctx.weight_threads,
-        ctx.weight_channels,
-        ctx.weight_times,
-    )
-    if not ctx.needs_input_grad[3]:
-        grad_initial_state = None
-    return (
-        grad_x,
-        grad_weight,
-        None,
-        grad_initial_state,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-    )
+class _ShortConv(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        cu_seqlens: torch.Tensor | None,
+        initial_state: torch.Tensor | None,
+    ) -> torch.Tensor:
+        output = _forward_op(x, weight, cu_seqlens, initial_state)
+        ctx.save_for_backward(x, weight, cu_seqlens, initial_state)
+        return output
+
+    @staticmethod
+    @torch.autograd.function.once_differentiable
+    def backward(ctx, grad_output: torch.Tensor):
+        x, weight, cu_seqlens, initial_state = ctx.saved_tensors
+        if initial_state is None:
+            grad_x, grad_weight = _backward_op(x, weight, grad_output, cu_seqlens)
+            grad_initial_state = None
+        else:
+            defaults = ShortConvTunedConfig.default(
+                x.dtype,
+                packed=cu_seqlens is not None,
+                stateful=True,
+            )
+            input_config = defaults.input_gradient
+            weight_config = defaults.weight_gradient
+            configs = (
+                input_config.threads,
+                input_config.channels_per_thread,
+                input_config.times_per_block,
+                weight_config.threads,
+                weight_config.channels_per_thread,
+                weight_config.times_per_block,
+            )
+            if ctx.needs_input_grad[3]:
+                grad_x, grad_weight, grad_initial_state = _configured_backward_with_state_grad_op(
+                    x, weight, grad_output, cu_seqlens, initial_state, *configs
+                )
+            else:
+                grad_x, grad_weight = _configured_backward_op(
+                    x, weight, grad_output, cu_seqlens, initial_state, *configs
+                )
+                grad_initial_state = None
+        return grad_x, grad_weight, None, grad_initial_state
 
 
-_configured_forward_custom_op.register_autograd(_backward, setup_context=_setup_context)
+class _ConfiguredShortConv(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        cu_seqlens: torch.Tensor | None,
+        initial_state: torch.Tensor | None,
+        forward_threads: int,
+        forward_channels: int,
+        forward_times: int,
+        input_threads: int,
+        input_channels: int,
+        input_times: int,
+        weight_threads: int,
+        weight_channels: int,
+        weight_times: int,
+    ) -> torch.Tensor:
+        output = _configured_forward_op(
+            x,
+            weight,
+            cu_seqlens,
+            initial_state,
+            forward_threads,
+            forward_channels,
+            forward_times,
+            input_threads,
+            input_channels,
+            input_times,
+            weight_threads,
+            weight_channels,
+            weight_times,
+        )
+        # Save inputs and backward specializations for preactivation recomputation.
+        ctx.save_for_backward(x, weight, cu_seqlens, initial_state)
+        ctx.input_threads = input_threads
+        ctx.input_channels = input_channels
+        ctx.input_times = input_times
+        ctx.weight_threads = weight_threads
+        ctx.weight_channels = weight_channels
+        ctx.weight_times = weight_times
+        return output
+
+    @staticmethod
+    @torch.autograd.function.once_differentiable
+    def backward(ctx, grad_output: torch.Tensor):
+        """Dispatch the registered first-order backward operator."""
+        x, weight, cu_seqlens, initial_state = ctx.saved_tensors
+        configs = (
+            ctx.input_threads,
+            ctx.input_channels,
+            ctx.input_times,
+            ctx.weight_threads,
+            ctx.weight_channels,
+            ctx.weight_times,
+        )
+        if initial_state is not None and ctx.needs_input_grad[3]:
+            grad_x, grad_weight, grad_initial_state = _configured_backward_with_state_grad_op(
+                x, weight, grad_output, cu_seqlens, initial_state, *configs
+            )
+        else:
+            grad_x, grad_weight = _configured_backward_op(
+                x, weight, grad_output, cu_seqlens, initial_state, *configs
+            )
+            grad_initial_state = None
+        return (
+            grad_x,
+            grad_weight,
+            None,
+            grad_initial_state,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
 
 
 def _validate_config(config: ShortConvConfig, channels: int, name: str) -> None:
@@ -2851,9 +2990,9 @@ def cute_causal_conv1d_silu(
         and input_grad == default_input_grad
         and weight_grad == default_weight_grad
     ):
-        output = _forward_custom_op(x, weight, cu_seqlens, kernel_initial_state)
+        output = _ShortConv.apply(x, weight, cu_seqlens, kernel_initial_state)
     else:
-        output = _configured_forward_custom_op(
+        output = _ConfiguredShortConv.apply(
             x,
             weight,
             cu_seqlens,

--- a/attn_gym/mods/softcapping.py
+++ b/attn_gym/mods/softcapping.py
@@ -10,13 +10,18 @@ from torch._inductor.lowering import make_pointwise, register_lowering
 from torch._inductor.virtualized import ops
 from torch.nn.attention.flex_attention import _score_mod_signature
 
+torch.library.define("approx::tanh", "(Tensor inp) -> Tensor")
 
-@torch.library.custom_op("approx::tanh", mutates_args=())
-def _tanh_approx(inp: Tensor) -> Tensor:
+
+def _tanh_approx_impl(inp: Tensor) -> Tensor:
     return torch.tanh(inp)
 
 
-@_tanh_approx.register_fake
+# CompositeExplicitAutograd covers CPU and CUDA.
+torch.library.impl("approx::tanh", "CompositeExplicitAutograd", _tanh_approx_impl)
+
+
+@torch.library.register_fake("approx::tanh")
 def _(inp: torch.Tensor) -> torch.Tensor:
     return torch.tanh(inp)
 

--- a/test/test_kda_cute_forward.py
+++ b/test/test_kda_cute_forward.py
@@ -26,8 +26,10 @@ from attn_gym.linear.kda.bwd.cute.chunk_kda_bwd_wy_dqkg_fused import (
 )
 from attn_gym.linear.kda.fwd.cute import chunk_kda
 from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd import (
-    _chunk_kda_bwd_custom_op,
-    _chunk_kda_fwd_custom_op,
+    _chunk_kda_bwd_op,
+    _chunk_kda_bwd_with_state_grad_op,
+    _chunk_kda_fwd_op,
+    _chunk_kda_fwd_with_state_op,
 )
 from attn_gym.linear.kda.utils import prepare_complete_chunk_metadata
 
@@ -555,49 +557,69 @@ def test_delta_h_dispatch_counts_packed_sequences(monkeypatch):
     assert captured["bv"] == 32
 
 
-def test_chunk_kda_custom_op_registration():
-    """Validate schema, fake tensors, autograd registration, and AOT dispatch."""
+def test_chunk_kda_op_registration():
+    """Validate schema, fake tensors, and AOT dispatch for both raw forward operators."""
     torch.manual_seed(5)
     q, k, v, cumulative_gate, beta, initial_state = _inputs(initial_state=True)
     q, k, v = _strided_qkv_views(q, k, v)
-    torch.library.opcheck(
-        _chunk_kda_fwd_custom_op,
-        (
-            q,
-            k,
-            v,
-            cumulative_gate,
-            beta,
-            initial_state,
-            None,
-            True,
-            False,
-            False,
-        ),
-        rtol=2e-2,
-        atol=2e-3,
+    # The raw operators are intentionally not differentiable; autograd lives in the
+    # _ChunkKDA autograd.Function, covered by the gradient tests above.
+    args = (
+        q.detach(),
+        k.detach(),
+        v.detach(),
+        cumulative_gate.detach(),
+        beta.detach(),
+        initial_state.detach(),
+        None,
+        False,
     )
+    torch.library.opcheck(_chunk_kda_fwd_op, args, rtol=2e-2, atol=2e-3)
+    torch.library.opcheck(_chunk_kda_fwd_with_state_op, args, rtol=2e-2, atol=2e-3)
 
 
-def test_chunk_kda_backward_custom_op_registration():
-    """Validate the intentionally first-order backward operator registration."""
+def test_chunk_kda_backward_op_registration():
+    """Validate the intentionally first-order backward operator registrations."""
     torch.manual_seed(6)
     q, k, v, cumulative_gate, beta, initial_state = _inputs(initial_state=True)
     with torch.no_grad():
-        _output, state, Aqk, Akk, cu_seqlens, chunk_indices, num_chunks = _chunk_kda_fwd_custom_op(
-            q,
-            k,
-            v,
-            cumulative_gate,
-            beta,
-            initial_state,
-            None,
-            True,
-            False,
-            False,
+        _output, state, Aqk, Akk, cu_seqlens, chunk_indices, num_chunks = (
+            _chunk_kda_fwd_with_state_op(
+                q,
+                k,
+                v,
+                cumulative_gate,
+                beta,
+                initial_state,
+                None,
+                False,
+            )
         )
     torch.library.opcheck(
-        _chunk_kda_bwd_custom_op,
+        _chunk_kda_bwd_op,
+        (
+            q.detach(),
+            k.detach(),
+            v.detach(),
+            cumulative_gate.detach(),
+            beta.detach(),
+            Aqk,
+            Akk,
+            cu_seqlens,
+            chunk_indices,
+            num_chunks,
+            None,
+            torch.randn_like(state),
+            None,
+            False,
+            False,
+        ),
+        test_utils=("test_schema", "test_faketensor", "test_aot_dispatch_dynamic"),
+        rtol=2e-2,
+        atol=2e-3,
+    )
+    torch.library.opcheck(
+        _chunk_kda_bwd_with_state_grad_op,
         (
             q.detach(),
             k.detach(),

--- a/test/test_kda_fused_gate_bwd.py
+++ b/test/test_kda_fused_gate_bwd.py
@@ -21,7 +21,7 @@ from attn_gym.linear.kda.bwd.cute.gate_bwd_fused import (
     FusedGateBwdOp,
     FusedGateBwdOutput,
     _compile_fused_gate_bwd,
-    _fused_gate_bwd_custom_op,
+    _fused_gate_bwd_op,
     fused_gate_bwd,
 )
 from attn_gym.linear.kda.bwd.triton.cumsum import (
@@ -359,11 +359,11 @@ def test_fused_gate_bwd_matches_triton_composition():
     )
 
 
-def test_fused_gate_bwd_custom_op_registration():
+def test_fused_gate_bwd_op_registration():
     """Exercise a non-default TMA schedule through the private operator schema."""
     inputs = _inputs(65, head_dim=64)
     torch.library.opcheck(
-        _fused_gate_bwd_custom_op,
+        _fused_gate_bwd_op,
         (*inputs, 7, -3.25, False),
     )
 

--- a/test/test_kda_kernels.py
+++ b/test/test_kda_kernels.py
@@ -48,8 +48,8 @@ from attn_gym.linear.kda.fwd.triton.gate_fwd import (
     kda_gate_chunk_cumsum_vector_kernel_forloop,
 )
 from attn_gym.linear.kda.fwd.triton.l2norm_fwd import (
-    _l2norm_bwd_custom_op,
-    _l2norm_fwd_custom_op,
+    _l2norm_bwd_op,
+    _l2norm_fwd_op,
     l2norm,
     l2norm_fwd_kernel,
     l2norm_fwd_kernel1,
@@ -308,14 +308,14 @@ def test_l2norm_autograd_wrapper(dtype):
     )
 
 
-def test_l2norm_custom_op_registration():
+def test_l2norm_op_registration():
     x = torch.randn(1, 17, 3, 128, device=DEV, dtype=torch.bfloat16)
-    torch.library.opcheck(_l2norm_fwd_custom_op, (x, 1e-6))
+    torch.library.opcheck(_l2norm_fwd_op, (x, 1e-6))
 
-    output, rstd = _l2norm_fwd_custom_op(x, 1e-6)
+    output, rstd = _l2norm_fwd_op(x, 1e-6)
     d_output = torch.randn_like(output)
     torch.library.opcheck(
-        _l2norm_bwd_custom_op,
+        _l2norm_bwd_op,
         (output.view(-1, output.shape[-1]), rstd, d_output),
     )
 

--- a/test/test_kda_short_conv_cute.py
+++ b/test/test_kda_short_conv_cute.py
@@ -12,11 +12,12 @@ import attn_gym.linear.kda.short_conv.cute as cute_backend
 from attn_gym.linear.kda.short_conv.cute import (
     ShortConvConfig,
     ShortConvTunedConfig,
-    _backward_custom_op,
+    _backward_op,
     _candidate_configs,
-    _configured_backward_custom_op,
-    _configured_forward_custom_op,
-    _forward_custom_op,
+    _configured_backward_op,
+    _configured_backward_with_state_grad_op,
+    _configured_forward_op,
+    _forward_op,
     cute_causal_conv1d_silu,
     tune_causal_conv1d_silu,
 )
@@ -840,24 +841,27 @@ def test_short_conv_explicit_config_and_tuning_flow():
 @pytest.mark.parametrize("packed", [False, True])
 def test_short_conv_custom_op_registration(packed: bool):
     """Exercise dense and packed schemas, fake implementations, and autograd."""
+    # The raw ops have no autograd kernel; differentiable use goes through the
+    # autograd.Function wrappers, so opcheck runs on detached inputs.
     x, weight = _inputs(batch=1 if packed else 2)
+    x, weight = x.detach(), weight.detach()
     grad_output = torch.randn_like(x)
     cu_seqlens = torch.tensor([0, 2, 7, 17], device="cuda", dtype=torch.int32) if packed else None
-    torch.library.opcheck(_forward_custom_op, (x, weight, cu_seqlens))
+    torch.library.opcheck(_forward_op, (x, weight, cu_seqlens))
     torch.library.opcheck(
-        _backward_custom_op,
+        _backward_op,
         (x, weight, grad_output, cu_seqlens),
         test_utils=("test_schema", "test_faketensor"),
     )
     if packed:
         configs = (128, 4, 8, 128, 4, 10, 128, 4, 128)
         torch.library.opcheck(
-            _configured_forward_custom_op,
+            _configured_forward_op,
             (x, weight, cu_seqlens, None, *configs),
         )
         torch.library.opcheck(
-            _configured_backward_custom_op,
-            (x, weight, grad_output, cu_seqlens, None, False, *configs[3:]),
+            _configured_backward_op,
+            (x, weight, grad_output, cu_seqlens, None, *configs[3:]),
             test_utils=("test_schema", "test_faketensor"),
         )
 
@@ -865,6 +869,7 @@ def test_short_conv_custom_op_registration(packed: bool):
 def test_short_conv_stateful_custom_op_registration():
     """Exercise packed schemas, fake tensors, and autograd with caller-provided history."""
     x, weight = _inputs()
+    x, weight = x.detach(), weight.detach()
     cu_seqlens = torch.tensor([0, 2, 7, 17], device="cuda", dtype=torch.int32)
     num_sequences = cu_seqlens.shape[0] - 1
     initial_state = torch.randn(
@@ -873,14 +878,18 @@ def test_short_conv_stateful_custom_op_registration():
         x.shape[2],
         device="cuda",
         dtype=torch.bfloat16,
-        requires_grad=True,
     )
     grad_output = torch.randn_like(x)
-    torch.library.opcheck(_forward_custom_op, (x, weight, cu_seqlens, initial_state))
+    torch.library.opcheck(_forward_op, (x, weight, cu_seqlens, initial_state))
     config = (128, 4, 10, 128, 4, 128)
     torch.library.opcheck(
-        _configured_backward_custom_op,
-        (x, weight, grad_output, cu_seqlens, initial_state, True, *config),
+        _configured_backward_op,
+        (x, weight, grad_output, cu_seqlens, initial_state, *config),
+        test_utils=("test_schema", "test_faketensor"),
+    )
+    torch.library.opcheck(
+        _configured_backward_with_state_grad_op,
+        (x, weight, grad_output, cu_seqlens, initial_state, *config),
         test_utils=("test_schema", "test_faketensor"),
     )
 
@@ -1056,14 +1065,14 @@ def test_short_conv_cuda_graph_replay():
     """Capture the compiled launchers and replay with changed input values."""
     x, weight = _inputs()
     grad_output = torch.randn_like(x)
-    _forward_custom_op(x, weight)
-    _backward_custom_op(x, weight, grad_output)
+    _forward_op(x, weight)
+    _backward_op(x, weight, grad_output)
     torch.cuda.synchronize()
 
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
-        captured_output = _forward_custom_op(x, weight)
-        captured_gradients = _backward_custom_op(x, weight, grad_output)
+        captured_output = _forward_op(x, weight)
+        captured_gradients = _backward_op(x, weight, grad_output)
 
     graph.replay()
     first_output = captured_output.clone()
@@ -1075,8 +1084,8 @@ def test_short_conv_cuda_graph_replay():
 
     assert not torch.equal(captured_output, first_output)
     assert not torch.equal(captured_gradients[0], first_gradients[0])
-    expected_output = _forward_custom_op(x, weight)
-    expected_gradients = _backward_custom_op(x, weight, grad_output)
+    expected_output = _forward_op(x, weight)
+    expected_gradients = _backward_op(x, weight, grad_output)
     torch.testing.assert_close(captured_output, expected_output)
     torch.testing.assert_close(captured_gradients[0], expected_gradients[0])
     torch.testing.assert_close(captured_gradients[1], expected_gradients[1])
@@ -1095,17 +1104,17 @@ def test_short_conv_packed_stateful_cuda_graph_replays_boundaries_and_history():
         dtype=torch.bfloat16,
     )
     config = (128, 4, 10, 128, 4, 128)
-    _forward_custom_op(x, weight, cu_seqlens, initial_state)
-    _configured_backward_custom_op(
-        x, weight, grad_output, cu_seqlens, initial_state, True, *config
+    _forward_op(x, weight, cu_seqlens, initial_state)
+    _configured_backward_with_state_grad_op(
+        x, weight, grad_output, cu_seqlens, initial_state, *config
     )
     torch.cuda.synchronize()
 
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
-        captured_output = _forward_custom_op(x, weight, cu_seqlens, initial_state)
-        captured_gradients = _configured_backward_custom_op(
-            x, weight, grad_output, cu_seqlens, initial_state, True, *config
+        captured_output = _forward_op(x, weight, cu_seqlens, initial_state)
+        captured_gradients = _configured_backward_with_state_grad_op(
+            x, weight, grad_output, cu_seqlens, initial_state, *config
         )
 
     with torch.no_grad():
@@ -1114,9 +1123,9 @@ def test_short_conv_packed_stateful_cuda_graph_replays_boundaries_and_history():
     graph.replay()
     torch.cuda.synchronize()
 
-    expected_output = _forward_custom_op(x, weight, cu_seqlens, initial_state)
-    expected_gradients = _configured_backward_custom_op(
-        x, weight, grad_output, cu_seqlens, initial_state, True, *config
+    expected_output = _forward_op(x, weight, cu_seqlens, initial_state)
+    expected_gradients = _configured_backward_with_state_grad_op(
+        x, weight, grad_output, cu_seqlens, initial_state, *config
     )
     torch.testing.assert_close(captured_output, expected_output)
     for actual_gradient, expected_gradient in zip(
@@ -1152,15 +1161,15 @@ def test_short_conv_packed_stateful_tma_cuda_graph_replays_boundaries_and_histor
         defaults.weight_gradient.channels_per_thread,
         defaults.weight_gradient.times_per_block,
     )
-    _configured_backward_custom_op(
-        x, weight, grad_output, cu_seqlens, initial_state, True, *config
+    _configured_backward_with_state_grad_op(
+        x, weight, grad_output, cu_seqlens, initial_state, *config
     )
     torch.cuda.synchronize()
 
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
-        captured_gradients = _configured_backward_custom_op(
-            x, weight, grad_output, cu_seqlens, initial_state, True, *config
+        captured_gradients = _configured_backward_with_state_grad_op(
+            x, weight, grad_output, cu_seqlens, initial_state, *config
         )
 
     first_gradients = tuple(gradient.clone() for gradient in captured_gradients)
@@ -1174,8 +1183,8 @@ def test_short_conv_packed_stateful_tma_cuda_graph_replays_boundaries_and_histor
 
     assert not torch.equal(captured_gradients[0], first_gradients[0])
     assert not torch.equal(captured_gradients[1], first_gradients[1])
-    expected_gradients = _configured_backward_custom_op(
-        x, weight, grad_output, cu_seqlens, initial_state, True, *config
+    expected_gradients = _configured_backward_with_state_grad_op(
+        x, weight, grad_output, cu_seqlens, initial_state, *config
     )
     for actual_gradient, expected_gradient in zip(
         captured_gradients,


### PR DESCRIPTION

## Human Note

Trying to micro optomzie all teh cpu overhead; @zou3519 gave me this tipp and update the skill

## Agent note

`torch.library.custom_op` adds ~4 us of Python wrapper overhead per call over a raw dispatcher
registration, and `CustomOpDef.register_autograd` is the slowest autograd attachment (~25 us per
fwd+bwd boundary). On launch-bound KDA training steps this wrapper tax is a measurable slice of CPU
time. Per zou3519's guidance, every registered operator in the repo now uses `torch.library.define`
plus per-key `torch.library.impl` with `torch.library.register_fake`, and autograd lives in a
`torch.autograd.Function` outside the op (Function-outside was measured cheaper than both
`register_autograd` and an Autograd dispatch-key kernel, which taxes inference calls).

Follow-on cleanups the Function-outside structure enabled: ops with "N or N+1 outputs depending on
a flag" (`kda_chunk_fwd` final state, `kda_chunk_bwd` and `_cute_short_conv_configured_bwd`
initial-state gradients) are split into fixed-arity schema pairs sharing one launcher, removing the
empty-tensor sentinels and their plumbing; `chunk_kda`'s autograd tapes (`Aqk`/`Akk`) and packing
metadata are saved as Function intermediates instead of user-visible outputs; and the dead
`fastmath`/`output_final_state` forward-op arguments are gone. `approx::tanh` registers at
`CompositeExplicitAutograd` to keep CPU support. The raw ops are intentionally not differentiable;
all differentiable use routes through the wrappers. The validating-pytorch-custom-ops skill now
documents the pattern, the measured overhead table, the split-op idiom, and its limitations.

## Performance

Fused eager `KDAAttention` train step, B=1 T=256 (launch-bound regime), B200, torch 2.14 nightly,
interleaved A/B, 3 rounds of 9x20-step medians:

| tree     | round medians (ms)  | best min (ms) |
| -------- | ------------------- | ------------- |
| this PR  | 4.37 / 4.56 / 4.55  | 4.17          |
| main     | 4.81 / 4.92 / 4.78  | 4.49          |

~250-450 us (~7-9%) less CPU per step; parity at T=16384 where the step is GPU-bound. Microbenchmark
of identical trivial launchers: raw Python 1.2 us, define/impl 2.6 us, custom_op 5.5 us per
inference call; fwd+bwd boundary pair 69.5 us (define/impl + Function) vs 86.2 us (custom_op +
Function) vs 93.4 us (custom_op + register_autograd) against a 64.1 us unregistered floor.

## Test Plan

```bash
pytest test/test_kda_kernels.py test/test_kda_fused_gate_bwd.py test/test_kda_cute_forward.py \
  test/test_kda_short_conv_cute.py  # 254 passed
python examples/kda_training.py --backend=fused --steps=2 --tokens=1024
python examples/kda_training.py --backend=fused --packed --batch-size=4 --tokens=256
ruff check && ruff format --check
```
