### PR TITLE
Add [linear] extra and support public CuTeDSL releases 4.5.0+

### DIFF
--- a/attn_gym/_backends/cute/utils.py
+++ b/attn_gym/_backends/cute/utils.py
@@ -85,8 +85,7 @@ def compile_tvm_ffi(
 
     from cutlass import cute
 
-    # CuTeDSL 4.6.2 removed the `_name_prefix=` call kwarg; `set_name_prefix()` on
-    # the jit wrapper is the compatible spelling across 4.5.0 through 4.7.0+.
+    # Requires CuTeDSL >= 4.5.0 for `set_name_prefix` (`_name_prefix=` was removed in 4.6.2).
     # Class-based entrypoints hold the jit wrapper on their `__call__`.
     jit_wrapper = entrypoint if hasattr(entrypoint, "set_name_prefix") else entrypoint.__call__
     jit_wrapper.set_name_prefix(name)

--- a/attn_gym/_backends/cute/utils.py
+++ b/attn_gym/_backends/cute/utils.py
@@ -85,12 +85,16 @@ def compile_tvm_ffi(
 
     from cutlass import cute
 
+    # CuTeDSL 4.6.2 removed the `_name_prefix=` call kwarg; `set_name_prefix()` on
+    # the jit wrapper is the compatible spelling across 4.5.0 through 4.7.0+.
+    # Class-based entrypoints hold the jit wrapper on their `__call__`.
+    jit_wrapper = entrypoint if hasattr(entrypoint, "set_name_prefix") else entrypoint.__call__
+    jit_wrapper.set_name_prefix(name)
     stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
     return cute.compile[cute.EnableTVMFFI](
         entrypoint,
         *compile_args,
         stream,
-        _name_prefix=name,
     )
 
 

--- a/attn_gym/linear/kda/bwd/cute/chunk_delta_h_bwd_v1.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_delta_h_bwd_v1.py
@@ -609,6 +609,7 @@ class BlackwellDeltaHBwdV1:
         self.shared_type = Shared
         self.grid = self._launch_grid(B, H, V)
 
+        self.kernel.set_name_prefix(self.get_name())
         self.kernel(
             mma_dv,
             mma_qdo,
@@ -656,7 +657,6 @@ class BlackwellDeltaHBwdV1:
             use_gk,
             use_dht,
             use_dh0,
-            _name_prefix=self.get_name(),
         ).launch(
             grid=self.grid,
             block=[self.CTA_THREADS, 1, 1],

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_intra.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_intra.py
@@ -1952,6 +1952,7 @@ class ChunkKdaBwdIntraHmmaGrid:
         mNumChunks: cute.Tensor | None,
         stream: cuda.CUstream = None,
     ):
+        _chunk_kda_bwd_intra_hmma_grid_kernel.set_name_prefix("cutlass_dsl_chunk_kda_bwd_intra")
         _chunk_kda_bwd_intra_hmma_grid_kernel(
             mQ,
             mK,
@@ -1971,7 +1972,6 @@ class ChunkKdaBwdIntraHmmaGrid:
             mNumChunks,
             self.grid_chunks,
             self.ragged,
-            _name_prefix="cutlass_dsl_chunk_kda_bwd_intra",
         ).launch(
             grid=(KC_TOTAL, self.grid_chunks, cute.size(mQ.shape[2])),
             block=(32, 1, 1),

--- a/attn_gym/linear/kda/bwd/cute/gate_bwd_fused.py
+++ b/attn_gym/linear/kda/bwd/cute/gate_bwd_fused.py
@@ -341,6 +341,7 @@ class FusedGateBwdOp:
             cta_tiler,
         )
 
+        self.kernel.set_name_prefix(self.get_name())
         self.kernel(
             mG,
             mA_log,
@@ -352,7 +353,6 @@ class FusedGateBwdOp:
             tma_tensor_g,
             tma_atom_d,
             tma_tensor_d,
-            _name_prefix=self.get_name(),
         ).launch(
             grid=(cute.ceil_div(mG.shape[1], self.chunk_size), self.heads, mG.shape[0]),
             block=(self.head_dim, 1, 1),

--- a/attn_gym/linear/kda/fwd/cute/recompute_w_u_fwd.py
+++ b/attn_gym/linear/kda/fwd/cute/recompute_w_u_fwd.py
@@ -1446,6 +1446,7 @@ class RecomputeWUForwardVarlenB1FullChunk:
             AB_STAGES,
         )
 
+        _kernel_varlen_b1_full_chunk.set_name_prefix("cutlass_dsl_recompute_w_u_fwd")
         _kernel_varlen_b1_full_chunk(
             tiled_mma,
             mQ,
@@ -1471,7 +1472,6 @@ class RecomputeWUForwardVarlenB1FullChunk:
             prefetch_next_tile,
             mma_is_bf16,
             ragged,
-            _name_prefix="cutlass_dsl_recompute_w_u_fwd",
         ).launch(
             grid=(self.num_persistent_ctas, 1, 1),
             block=(THREADS_PER_CTA, 1, 1),

--- a/attn_gym/linear/kda/short_conv/cute.py
+++ b/attn_gym/linear/kda/short_conv/cute.py
@@ -415,13 +415,13 @@ class CausalConv1dSiluForward(ShortConvKernel):
         stream,
     ):
         """Launch the configured forward specialization."""
+        self.kernel.set_name_prefix(self.get_name())
         self.kernel(
             x,
             weight,
             output,
             cu_seqlens,
             initial_state,
-            _name_prefix=self.get_name(),
         ).launch(
             grid=(
                 cute.ceil_div(self.channels, self.threads * self.channels_per_thread),
@@ -623,6 +623,7 @@ class CausalConv1dSiluInputGradient(ShortConvKernel):
         stream,
     ):
         """Launch the configured input-gradient specialization."""
+        self.kernel.set_name_prefix(self.get_name())
         self.kernel(
             x,
             weight,
@@ -630,7 +631,6 @@ class CausalConv1dSiluInputGradient(ShortConvKernel):
             grad_x,
             cu_seqlens,
             initial_state,
-            _name_prefix=self.get_name(),
         ).launch(
             grid=(
                 cute.ceil_div(self.channels, self.threads * self.channels_per_thread),
@@ -771,6 +771,7 @@ class CausalConv1dSiluWeightGradientPartials(ShortConvKernel):
         stream,
     ):
         """Launch the configured weight-gradient specialization."""
+        self.kernel.set_name_prefix(self.get_name())
         self.kernel(
             x,
             weight,
@@ -778,7 +779,6 @@ class CausalConv1dSiluWeightGradientPartials(ShortConvKernel):
             partials,
             cu_seqlens,
             initial_state,
-            _name_prefix=self.get_name(),
         ).launch(
             grid=(
                 cute.ceil_div(self.channels, self.threads * self.channels_per_thread),
@@ -1389,6 +1389,7 @@ class CausalConv1dSiluInputGradientTma(
             x,
             grad_output,
         )
+        self.tma_kernel.set_name_prefix(self.get_name())
         self.tma_kernel(
             x,
             weight,
@@ -1400,7 +1401,6 @@ class CausalConv1dSiluInputGradientTma(
             tma_tensor_x,
             tma_atom_dy,
             tma_tensor_dy,
-            _name_prefix=self.get_name(),
         ).launch(
             grid=(
                 self.channels // (self.threads * self.channels_per_thread),
@@ -1639,6 +1639,7 @@ class CausalConv1dSiluWeightGradientPartialsTma(
             x,
             grad_output,
         )
+        self.tma_kernel.set_name_prefix(self.get_name())
         self.tma_kernel(
             x,
             weight,
@@ -1650,7 +1651,6 @@ class CausalConv1dSiluWeightGradientPartialsTma(
             tma_tensor_x,
             tma_atom_dy,
             tma_tensor_dy,
-            _name_prefix=self.get_name(),
         ).launch(
             grid=(
                 self.channels // (self.threads * self.channels_per_thread),
@@ -1798,6 +1798,7 @@ class CausalConv1dSiluInitialStateGradient(ShortConvKernel):
         stream,
     ):
         """Launch the initial-state gradient specialization."""
+        self.kernel.set_name_prefix(self.get_name())
         self.kernel(
             x,
             weight,
@@ -1805,7 +1806,6 @@ class CausalConv1dSiluInitialStateGradient(ShortConvKernel):
             grad_output,
             grad_initial_state,
             cu_seqlens,
-            _name_prefix=self.get_name(),
         ).launch(
             grid=(
                 cute.ceil_div(self.channels, self.threads * self.channels_per_thread),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+linear = [
+    "nvidia-cutlass-dsl[cu13]>=4.5.0; sys_platform == 'linux'",
+    "apache-tvm-ffi>=0.1.12,<0.2",
+]
+
 tests = [
     "pytest",
     "pytest-xdist",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
 [project.optional-dependencies]
 linear = [
     "nvidia-cutlass-dsl[cu13]>=4.5.0; sys_platform == 'linux'",
-    "apache-tvm-ffi>=0.1.12,<0.2",
+    "apache-tvm-ffi>=0.1.12",
 ]
 
 tests = [

--- a/test/test_cute_cache.py
+++ b/test/test_cute_cache.py
@@ -165,6 +165,9 @@ def test_compile_tvm_ffi_adds_fake_stream_and_typed_option(monkeypatch):
         def get_name() -> str:
             return "stable_kernel_name"
 
+        def set_name_prefix(self, name: str) -> None:
+            observed["name_prefix"] = name
+
     monkeypatch.setattr(cute, "compile", FakeCompile())
     monkeypatch.setattr(
         cute.runtime,
@@ -178,7 +181,8 @@ def test_compile_tvm_ffi_adds_fake_stream_and_typed_option(monkeypatch):
         "option": cute.EnableTVMFFI,
         "entrypoint": entrypoint,
         "args": (fake_tensor, fake_stream),
-        "kwargs": {"_name_prefix": "stable_kernel_name"},
+        "kwargs": {},
+        "name_prefix": "stable_kernel_name",
     }
 
 

--- a/test/test_cute_cache_gpu.py
+++ b/test/test_cute_cache_gpu.py
@@ -28,7 +28,8 @@ def copy_kernel(source: cute.Tensor, destination: cute.Tensor):
 @cute.jit
 def launch_copy(source: cute.Tensor, destination: cute.Tensor, stream):
     """Launch the toy cache validation kernel."""
-    copy_kernel(source, destination, _name_prefix="attention_gym_cache_copy").launch(
+    copy_kernel.set_name_prefix("attention_gym_cache_copy")
+    copy_kernel(source, destination).launch(
         grid=(1, 1, 1),
         block=(_THREADS, 1, 1),
         stream=stream,


### PR DESCRIPTION
## Human Note

made some tweaks to support all verisons add extras

## Agent note

The KDA/short-conv CuTeDSL stack only ran against `nvidia-cutlass-dsl==4.6.0.dev0` (a non-public dev
wheel pulled in by the flash-attn cute pin) and there was no way to install its dependencies from this
package. This adds a `[linear]` extra (`nvidia-cutlass-dsl[cu13]>=4.5.0` + `apache-tvm-ffi`) so
`pip install "attn_gym[linear]"` gets everything the linear kernels need on top of a torch nightly.

CuTeDSL 4.6.2 removed the `_name_prefix=` jit-call kwarg, which broke every public release from 4.6.2
onward with `TypeError: got an unexpected keyword argument '_name_prefix'`. The replacement,
`set_name_prefix()` on the jit wrapper, has existed since at least 4.5.0, so switching `compile_tvm_ffi`
and the ten kernel launch sites to it supports 4.5.0 through 4.7.0 (current latest) with one spelling
and no version gate. The generated names are cosmetic for us — the exported TVM-FFI symbol is always
`func` — so the rename carries no cache or ABI impact. 4.4.x predates other APIs the kernels use, hence
the `>=4.5.0` floor; no upper cap since the new API is the documented one going forward.

## Test Plan

Fresh `uv venv` (py3.13) + torch nightly cu132, sweeping public CuTeDSL releases:

```bash
uv pip install -U --pre torch --index-url https://download.pytorch.org/whl/nightly/cu132
uv pip install -e ".[linear]" pytest pytest-xdist numpy typer jsonargparse docstring-parser
# for v in 4.5.0 4.6.1 4.7.0:
uv pip install "nvidia-cutlass-dsl[cu13]==$v"
pytest test -k "kda or cute or gdn" -n 4 -q   # 443 passed on each
```

Also re-ran the same 443-test selection in the primary dev env (`nvidia-cutlass-dsl==4.6.0.dev0`):
443 passed.

