### PR TITLE
Fuse the ragged KDA gate backward and give dAv a ragged TMA kernel

### DIFF
--- a/attn_gym/linear/kda/bwd/triton/chunk_kda_bwd_dav.py
+++ b/attn_gym/linear/kda/bwd/triton/chunk_kda_bwd_dav.py
@@ -18,7 +18,11 @@ import triton.language as tl
 from triton.tools.tensor_descriptor import TensorDescriptor
 
 from attn_gym._backends.triton.utils import can_use_tma, ptr_offset, requires_int64_offsets
-from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata, load_ragged_chunk_work
+from attn_gym.linear.kda.chunk_scheduler import (
+    RaggedChunkMetadata,
+    chunk_capacity,
+    load_ragged_chunk_work,
+)
 from attn_gym.linear.kda.utils import (
     ChunkMetadata,
     autotune_cache_kwargs,
@@ -42,6 +46,45 @@ def _requires_int64_offsets(args) -> bool:
         args["chunk_indices"],
         args["chunk_offsets"],
         args["num_chunks"],
+    )
+
+
+@triton.jit
+def _dav_tile_tma(
+    v_desc,
+    A_desc,
+    do_desc,
+    dv_desc,
+    dA_desc,
+    scale,
+    i_b,
+    row,
+    i_h,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BV: tl.constexpr,
+):
+    """Differentiate one complete chunk starting at ``row`` through TMA descriptors."""
+    o_i = tl.arange(0, BT)
+    b_A = A_desc.load([i_b, row, i_h, 0])
+    b_A = tl.trans(tl.reshape(b_A, [BT, BT]))
+    b_A = tl.where(o_i[:, None] <= o_i[None, :], b_A, 0.0)
+    b_dA = tl.zeros([BT, BT], dtype=tl.float32)
+    for i_v in range(tl.cdiv(V, BV)):
+        b_v = v_desc.load([i_b, row, i_h, i_v * BV])
+        b_v = tl.trans(tl.reshape(b_v, [BT, BV]))
+        b_do = do_desc.load([i_b, row, i_h, i_v * BV])
+        b_do = tl.reshape(b_do, [BT, BV])
+        b_dA += tl.dot(b_do, b_v)
+        b_dv = tl.dot(b_A.to(b_do.dtype), b_do)
+        dv_desc.store(
+            [i_b, row, i_h, i_v * BV],
+            tl.reshape(b_dv.to(b_do.dtype), [1, BT, 1, BV]),
+        )
+    b_dA = tl.where(o_i[:, None] >= o_i[None, :], b_dA * scale, 0.0)
+    dA_desc.store(
+        [i_b, row, i_h, 0],
+        tl.reshape(b_dA, [1, BT, 1, BT]),
     )
 
 
@@ -88,12 +131,15 @@ def chunk_kda_bwd_kernel_dAv(
 ):
     """Differentiate KDA value tiles with pointer or TMA specialization."""
     i_t, i_bh = tl.program_id(0), tl.program_id(1)
-    if not USE_TMA and USE_INT64_OFFSETS:
-        i_t = i_t.to(tl.int64)
-        i_bh = i_bh.to(tl.int64)
-    i_b, i_h = i_bh // H, i_bh % H
+    if USE_TMA:
+        i_b, i_h = i_bh // H, i_bh % H
+        _dav_tile_tma(v, A, do, dv, dA, scale, i_b, i_t * BT, i_h, V, BT, BV)
+    else:
+        if USE_INT64_OFFSETS:
+            i_t = i_t.to(tl.int64)
+            i_bh = i_bh.to(tl.int64)
+        i_b, i_h = i_bh // H, i_bh % H
 
-    if not USE_TMA:
         if IS_VARLEN:
             if IS_RAGGED:
                 if i_t >= tl.load(chunk_offsets + num_sequences):
@@ -132,13 +178,8 @@ def chunk_kda_bwd_kernel_dAv(
         dv += ptr_offset((bos, i_h), (H * V, V))
         dA += ptr_offset((bos, i_h), (H * BT, BT))
 
-    o_i = tl.arange(0, BT)
-    o_t = i_t * BT + o_i
-    if USE_TMA:
-        b_A = A.load([i_b, i_t * BT, i_h, 0])
-        b_A = tl.trans(tl.reshape(b_A, [BT, BT]))
-        b_A = tl.where(o_i[:, None] <= o_i[None, :], b_A, 0.0)
-    else:
+        o_i = tl.arange(0, BT)
+        o_t = i_t * BT + o_i
         m_t = o_t < T
         m_tt = m_t[:, None] & m_t[None, :]
         # The leading BT feature axis is always in bounds; only token columns can be ragged.
@@ -150,14 +191,8 @@ def chunk_kda_bwd_kernel_dAv(
         m_A = (o_t[:, None] <= o_t[None, :]) & m_tt
         b_A = tl.where(m_A, b_A, 0).to(do.dtype.element_ty)
 
-    b_dA = tl.zeros([BT, BT], dtype=tl.float32)
-    for i_v in range(tl.cdiv(V, BV)):
-        if USE_TMA:
-            b_v = v.load([i_b, i_t * BT, i_h, i_v * BV])
-            b_v = tl.trans(tl.reshape(b_v, [BT, BV]))
-            b_do = do.load([i_b, i_t * BT, i_h, i_v * BV])
-            b_do = tl.reshape(b_do, [BT, BV])
-        else:
+        b_dA = tl.zeros([BT, BT], dtype=tl.float32)
+        for i_v in range(tl.cdiv(V, BV)):
             o_v = i_v * BV + tl.arange(0, BV)
             m_v = (o_v[:, None] < V) & m_t[None, :]
             m_do = m_t[:, None] & (o_v[None, :] < V)
@@ -174,29 +209,17 @@ def chunk_kda_bwd_kernel_dAv(
                 other=0.0,
             )
 
-        # [BT, BT]
-        b_dA += tl.dot(b_do, b_v)
-        # [BT, BV]
-        b_dv = tl.dot(b_A.to(b_do.dtype), b_do)
-        if USE_TMA:
-            dv.store(
-                [i_b, i_t * BT, i_h, i_v * BV],
-                tl.reshape(b_dv.to(b_do.dtype), [1, BT, 1, BV]),
-            )
-        else:
+            # [BT, BT]
+            b_dA += tl.dot(b_do, b_v)
+            # [BT, BV]
+            b_dv = tl.dot(b_A.to(b_do.dtype), b_do)
             tl.store(
                 dv + ptr_offset((o_t[:, None], o_v[None, :]), (H * V, 1)),
                 b_dv.to(dv.dtype.element_ty),
                 mask=m_do,
             )
 
-    b_dA = tl.where(o_i[:, None] >= o_i[None, :], b_dA * scale, 0.0)
-    if USE_TMA:
-        dA.store(
-            [i_b, i_t * BT, i_h, 0],
-            tl.reshape(b_dA, [1, BT, 1, BT]),
-        )
-    else:
+        b_dA = tl.where(o_i[:, None] >= o_i[None, :], b_dA * scale, 0.0)
         tl.store(
             dA + ptr_offset((o_t[:, None], o_i[None, :]), (H * BT, 1)),
             b_dA.to(dA.dtype.element_ty),
@@ -207,6 +230,193 @@ def chunk_kda_bwd_kernel_dAv(
 def _can_use_tensor_descriptors(*tensors: torch.Tensor) -> bool:
     """Return whether all fixed KDA tensors satisfy host TMA requirements."""
     return all(can_use_tma(tensor) for tensor in tensors)
+
+
+@triton.jit(do_not_specialize=["num_sequences"])
+def chunk_kda_bwd_kernel_dAv_ragged_tma(
+    v_desc,
+    A_desc,
+    do_desc,
+    dv_desc,
+    dA_desc,
+    v,
+    A,
+    do,
+    dv,
+    dA,
+    cu_seqlens,
+    chunk_offsets,
+    scale,
+    H: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BV: tl.constexpr,
+    num_sequences,
+):
+    """Differentiate full ragged value chunks with TMA and partial tails with masked pointers."""
+    global_chunk, i_h = tl.program_id(0), tl.program_id(1)
+    if global_chunk >= tl.load(chunk_offsets + num_sequences):
+        return
+    _, _, token_start, valid_tokens = load_ragged_chunk_work(
+        cu_seqlens,
+        chunk_offsets,
+        global_chunk,
+        num_sequences,
+        BT,
+    )
+    o_i = tl.arange(0, BT)
+    if valid_tokens == BT:
+        _dav_tile_tma(
+            v_desc, A_desc, do_desc, dv_desc, dA_desc, scale, 0, token_start, i_h, V, BT, BV
+        )
+    else:
+        o_t = token_start + o_i
+        m_t = o_i < valid_tokens
+        # The leading BT feature axis is always in bounds; only token columns can be ragged.
+        b_A = tl.load(
+            A + ptr_offset((o_t[None, :], i_h, o_i[:, None]), (H * BT, BT, 1)),
+            mask=m_t[None, :],
+            other=0.0,
+        )
+        m_A = (o_i[:, None] <= o_i[None, :]) & m_t[:, None] & m_t[None, :]
+        b_A = tl.where(m_A, b_A, 0).to(do.dtype.element_ty)
+        b_dA = tl.zeros([BT, BT], dtype=tl.float32)
+        for i_v in range(tl.cdiv(V, BV)):
+            o_v = i_v * BV + tl.arange(0, BV)
+            m_v = o_v < V
+            # [BV, BT]
+            b_v = tl.load(
+                v + ptr_offset((o_t[None, :], i_h, o_v[:, None]), (H * V, V, 1)),
+                mask=m_v[:, None] & m_t[None, :],
+                other=0.0,
+            )
+            # [BT, BV]
+            b_do = tl.load(
+                do + ptr_offset((o_t[:, None], i_h, o_v[None, :]), (H * V, V, 1)),
+                mask=m_t[:, None] & m_v[None, :],
+                other=0.0,
+            )
+            b_dA += tl.dot(b_do, b_v)
+            b_dv = tl.dot(b_A, b_do)
+            tl.store(
+                dv + ptr_offset((o_t[:, None], i_h, o_v[None, :]), (H * V, V, 1)),
+                b_dv.to(dv.dtype.element_ty),
+                mask=m_t[:, None] & m_v[None, :],
+            )
+        b_dA = tl.where(o_i[:, None] >= o_i[None, :], b_dA * scale, 0.0)
+        tl.store(
+            dA + ptr_offset((o_t[:, None], i_h, o_i[None, :]), (H * BT, BT, 1)),
+            b_dA.to(dA.dtype.element_ty),
+            mask=m_t[:, None],
+        )
+
+
+def _launch_dav_ragged(
+    v: torch.Tensor,
+    A: torch.Tensor,
+    do: torch.Tensor,
+    scale: float,
+    chunk_size: int,
+    metadata: RaggedChunkMetadata,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Launch the packed dAv kernel with TMA descriptors when the layout allows."""
+    _, tokens, heads, value_dim = v.shape
+    dv = torch.empty_like(v)
+    dA = torch.empty_like(A, dtype=torch.float32)
+    if metadata.capacity == 0:
+        return dv, dA
+
+    block_value_dim = 64
+    if (value_dim, chunk_size) == (128, 64) and _can_use_tensor_descriptors(v, A, do, dv, dA):
+        chunk_kda_bwd_kernel_dAv_ragged_tma[(metadata.capacity, heads)](
+            TensorDescriptor.from_tensor(v, [1, chunk_size, 1, block_value_dim]),
+            TensorDescriptor.from_tensor(A, [1, chunk_size, 1, chunk_size]),
+            TensorDescriptor.from_tensor(do, [1, chunk_size, 1, block_value_dim]),
+            TensorDescriptor.from_tensor(dv, [1, chunk_size, 1, block_value_dim]),
+            TensorDescriptor.from_tensor(dA, [1, chunk_size, 1, chunk_size]),
+            v,
+            A,
+            do,
+            dv,
+            dA,
+            metadata.cu_seqlens,
+            metadata.chunk_offsets,
+            scale,
+            H=heads,
+            V=value_dim,
+            BT=chunk_size,
+            BV=block_value_dim,
+            num_sequences=metadata.cu_seqlens.shape[0] - 1,
+            num_warps=2,
+            num_stages=3,
+        )
+    else:
+        chunk_kda_bwd_kernel_dAv[(metadata.capacity, heads)](
+            v=v,
+            A=A,
+            do=do,
+            dv=dv,
+            dA=dA,
+            cu_seqlens=metadata.cu_seqlens,
+            chunk_indices=None,
+            chunk_offsets=metadata.chunk_offsets,
+            num_chunks=None,
+            scale=scale,
+            T=tokens,
+            H=heads,
+            V=value_dim,
+            BT=chunk_size,
+            BV=block_value_dim,
+            num_sequences=metadata.cu_seqlens.shape[0] - 1,
+        )
+    return dv, dA
+
+
+# The ragged launcher mixes TMA descriptors with aliased raw pointers, which the
+# compile stack cannot functionalize correctly, so it lives behind an opaque op.
+torch.library.define(
+    "attn_gym::kda_chunk_bwd_dav_ragged",
+    "(Tensor v, Tensor A, Tensor do, Tensor cu_seqlens, Tensor chunk_offsets, "
+    "float scale, int chunk_size) -> (Tensor, Tensor)",
+)
+
+
+def _chunk_kda_bwd_dav_ragged_cuda(
+    v: torch.Tensor,
+    A: torch.Tensor,
+    do: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    chunk_offsets: torch.Tensor,
+    scale: float,
+    chunk_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    metadata = RaggedChunkMetadata(
+        cu_seqlens,
+        chunk_offsets,
+        chunk_capacity(v.shape[1], cu_seqlens.shape[0] - 1, chunk_size),
+        chunk_size,
+    )
+    return _launch_dav_ragged(v, A, do, scale, chunk_size, metadata)
+
+
+torch.library.impl("attn_gym::kda_chunk_bwd_dav_ragged", "CUDA", _chunk_kda_bwd_dav_ragged_cuda)
+
+
+@torch.library.register_fake("attn_gym::kda_chunk_bwd_dav_ragged")
+def _chunk_kda_bwd_dav_ragged_fake(
+    v: torch.Tensor,
+    A: torch.Tensor,
+    do: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    chunk_offsets: torch.Tensor,
+    scale: float,
+    chunk_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    del do, cu_seqlens, chunk_offsets, scale, chunk_size
+    return torch.empty_like(v), torch.empty_like(A, dtype=torch.float32)
+
+
+_dav_ragged_op = torch.ops.attn_gym.kda_chunk_bwd_dav_ragged.default
 
 
 def chunk_kda_bwd_dav(
@@ -220,22 +430,23 @@ def chunk_kda_bwd_dav(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Differentiate the fixed-length or packed KDA intra-chunk value term."""
     batch, tokens, heads, value_dim = v.shape
-    if isinstance(metadata, RaggedChunkMetadata):
-        metadata.validate_chunk_size(chunk_size)
-        if batch != 1:
-            raise ValueError("ragged KDA dAv metadata requires batch size 1")
-    elif tokens % chunk_size:
-        raise ValueError(f"the KDA dAv kernel requires complete chunks, got T={tokens}")
     if A.shape != (batch, tokens, heads, chunk_size):
         raise ValueError("A must have shape [B, T, H, chunk_size]")
     if do.shape != v.shape:
         raise ValueError("do must have the same shape as v")
+    if isinstance(metadata, RaggedChunkMetadata):
+        metadata.validate_chunk_size(chunk_size)
+        if batch != 1:
+            raise ValueError("ragged KDA dAv metadata requires batch size 1")
+        return _dav_ragged_op(
+            v, A, do, metadata.cu_seqlens, metadata.chunk_offsets, scale, chunk_size
+        )
+    if tokens % chunk_size:
+        raise ValueError(f"the KDA dAv kernel requires complete chunks, got T={tokens}")
 
     dv = torch.empty_like(v)
     dA = torch.empty_like(A, dtype=torch.float32)
-    chunks = (
-        metadata.capacity if isinstance(metadata, RaggedChunkMetadata) else tokens // chunk_size
-    )
+    chunks = tokens // chunk_size
     if chunks == 0:
         return dv, dA
 
@@ -274,9 +485,7 @@ def chunk_kda_bwd_dav(
             chunk_indices=(
                 metadata.chunk_indices if isinstance(metadata, ChunkMetadata) else None
             ),
-            chunk_offsets=(
-                metadata.chunk_offsets if isinstance(metadata, RaggedChunkMetadata) else None
-            ),
+            chunk_offsets=None,
             num_chunks=metadata.num_chunks if isinstance(metadata, ChunkMetadata) else None,
             scale=scale,
             T=tokens,
@@ -284,11 +493,7 @@ def chunk_kda_bwd_dav(
             V=value_dim,
             BT=chunk_size,
             BV=block_value_dim,
-            num_sequences=(
-                metadata.cu_seqlens.shape[0] - 1
-                if isinstance(metadata, RaggedChunkMetadata)
-                else 0
-            ),
+            num_sequences=0,
         )
     return dv, dA
 

--- a/attn_gym/linear/kda/bwd/triton/cumsum.py
+++ b/attn_gym/linear/kda/bwd/triton/cumsum.py
@@ -21,7 +21,6 @@ import triton
 import triton.language as tl
 
 from attn_gym._backends.triton.utils import ptr_offset
-from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata, load_ragged_chunk_work
 from attn_gym.linear.kda.utils import (
     autotune_cache_kwargs,
     check_shared_mem,
@@ -178,88 +177,6 @@ def chunk_local_cumsum_vector_kernel(
         b_o.to(o.dtype.element_ty),
         mask=m,
     )
-
-
-@triton.jit(do_not_specialize=["num_sequences"])
-def ragged_chunk_local_cumsum_vector_kernel(
-    s,
-    o,
-    scale,
-    cu_seqlens,
-    chunk_offsets,
-    num_sequences,
-    S_STRIDES: tl.constexpr,
-    O_STRIDES: tl.constexpr,
-    S: tl.constexpr,
-    BT: tl.constexpr,
-    BS: tl.constexpr,
-    REVERSE: tl.constexpr,
-):
-    """Scan one device-routed sequence-local chunk in FP32."""
-    global_chunk = tl.program_id(0)
-    i_h = tl.program_id(1).to(tl.int64)
-    i_s = tl.program_id(2).to(tl.int64)
-    if global_chunk >= tl.load(chunk_offsets + num_sequences):
-        return
-
-    _sequence, _local_chunk, token_start, valid_tokens = load_ragged_chunk_work(
-        cu_seqlens,
-        chunk_offsets,
-        global_chunk,
-        num_sequences,
-        BT,
-    )
-    token = token_start.to(tl.int64) + tl.arange(0, BT)
-    channel = i_s * BS + tl.arange(0, BS)
-    mask = (tl.arange(0, BT)[:, None] < valid_tokens) & (channel[None, :] < S)
-    values = tl.load(
-        s + ptr_offset((token[:, None], i_h, channel[None, :]), S_STRIDES),
-        mask=mask,
-        other=0.0,
-    ).to(tl.float32)
-    result = tl.cumsum(values, axis=0, reverse=REVERSE) * scale
-    tl.store(
-        o + ptr_offset((token[:, None], i_h, channel[None, :]), O_STRIDES),
-        result,
-        mask=mask,
-    )
-
-
-@input_guard(no_guard_contiguous=True)
-def ragged_chunk_local_cumsum_vector(
-    g: torch.Tensor,
-    metadata: RaggedChunkMetadata,
-    *,
-    reverse: bool,
-    scale: float,
-) -> torch.Tensor:
-    """Compute a graph-safe FP32 cumsum over device-routed ragged chunks."""
-    if g.ndim != 4 or g.shape[0] != 1:
-        raise ValueError(f"ragged vector cumsum expects shape [1, T, H, D], got {tuple(g.shape)}")
-    if metadata.cu_seqlens.device != g.device:
-        raise ValueError("ragged metadata and input must be on the same device")
-
-    output = torch.empty_like(g, dtype=torch.float32)
-    _, _, heads, head_dim = g.shape
-    block_size = 32
-    ragged_chunk_local_cumsum_vector_kernel[
-        (metadata.capacity, heads, triton.cdiv(head_dim, block_size))
-    ](
-        g,
-        output,
-        scale,
-        metadata.cu_seqlens,
-        metadata.chunk_offsets,
-        metadata.cu_seqlens.shape[0] - 1,
-        S_STRIDES=g.stride()[1:],
-        O_STRIDES=output.stride()[1:],
-        S=head_dim,
-        BT=metadata.chunk_size,
-        BS=block_size,
-        REVERSE=reverse,
-        num_warps=4,
-    )
-    return output
 
 
 @input_guard(no_guard_contiguous=("g",))

--- a/attn_gym/linear/kda/bwd/triton/gate_bwd.py
+++ b/attn_gym/linear/kda/bwd/triton/gate_bwd.py
@@ -28,6 +28,7 @@ import triton
 import triton.language as tl
 
 from attn_gym._backends.triton.utils import ptr_offset
+from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata, load_ragged_chunk_work
 from attn_gym.linear.kda.utils import autotune_cache_kwargs, input_guard
 
 NUM_WARPS_AUTOTUNE = [4, 8, 16, 32]
@@ -121,39 +122,63 @@ def kda_gate_bwd_kernel(
     tl.store(dA + ptr_offset((i_t, i_h), DA_STRIDES), b_dalog)
 
 
-@triton.jit(do_not_specialize=["T"])
+@triton.jit(do_not_specialize=["num_sequences"])
 def kda_gate_bwd_ragged_kernel(
-    g,
+    raw_gate,
     A_log,
     dt_bias,
-    dyg,
+    d_cumulative,
     dg,
-    dA,
+    dA_partial,
+    ddt_partial,
     lower_bound,
-    T,
+    scale,
+    cu_seqlens,
+    chunk_offsets,
+    num_sequences,
     G_STRIDES: tl.constexpr,
     A_LOG_STRIDES: tl.constexpr,
     DT_BIAS_STRIDES: tl.constexpr,
-    DYG_STRIDES: tl.constexpr,
+    DY_STRIDES: tl.constexpr,
     DG_STRIDES: tl.constexpr,
     DA_STRIDES: tl.constexpr,
+    DDT_STRIDES: tl.constexpr,
     D: tl.constexpr,
     BT: tl.constexpr,
     BD: tl.constexpr,
 ):
-    """Differentiate the bounded gate with a fixed graph-capture-safe schedule."""
-    i_t, i_h = tl.program_id(0).to(tl.int64), tl.program_id(1).to(tl.int64)
+    """Reverse-scan one ragged chunk and differentiate the bounded gate in place.
 
-    token = i_t * BT + tl.arange(0, BT)
-    channel = tl.arange(0, BD)
-    mask = (token[:, None] < T) & (channel[None, :] < D)
-    gate_input = tl.load(
-        g + ptr_offset((token[:, None], i_h, channel[None, :]), G_STRIDES),
+    Mirror of ``bounded_gate_chunk_cumsum_ragged_kernel``: one launch replaces the
+    former reverse-cumsum kernel, its full FP32 intermediate, the pointwise
+    derivative kernel, the eager ``dg.sum(0)`` reduction, and the output cast.
+    """
+    global_chunk = tl.program_id(0)
+    i_h = tl.program_id(1).to(tl.int64)
+    i_d = tl.program_id(2).to(tl.int64)
+    if global_chunk >= tl.load(chunk_offsets + num_sequences):
+        return
+
+    _sequence, _local_chunk, token_start, valid_tokens = load_ragged_chunk_work(
+        cu_seqlens,
+        chunk_offsets,
+        global_chunk,
+        num_sequences,
+        BT,
+    )
+    token_offset = tl.arange(0, BT)
+    token = token_start.to(tl.int64) + token_offset
+    channel = i_d * BD + tl.arange(0, BD)
+    mask = (token_offset[:, None] < valid_tokens) & (channel[None, :] < D)
+    d_gate = tl.load(
+        d_cumulative + ptr_offset((token[:, None], i_h, channel[None, :]), DY_STRIDES),
         mask=mask,
         other=0.0,
     ).to(tl.float32)
-    d_gate = tl.load(
-        dyg + ptr_offset((token[:, None], i_h, channel[None, :]), DYG_STRIDES),
+    d_gate = tl.cumsum(d_gate, axis=0, reverse=True) * scale.to(tl.float32)
+
+    gate_input = tl.load(
+        raw_gate + ptr_offset((token[:, None], i_h, channel[None, :]), G_STRIDES),
         mask=mask,
         other=0.0,
     ).to(tl.float32)
@@ -161,62 +186,86 @@ def kda_gate_bwd_ragged_kernel(
         dt_bias + ptr_offset((i_h, channel), DT_BIAS_STRIDES),
         mask=channel < D,
         other=0.0,
-    ).to(tl.float32)
-
+    ).to(tl.float32)[None, :]
     decay = tl.exp(tl.load(A_log + ptr_offset((i_h,), A_LOG_STRIDES)).to(tl.float32))
     sigmoid = tl.sigmoid(decay * gate_input)
-    d_raw_gate = d_gate * (lower_bound * decay * sigmoid * (1.0 - sigmoid))
-    dA_log = tl.sum(tl.sum(d_raw_gate * gate_input, 1), 0)
+    d_raw_gate = d_gate * (lower_bound.to(tl.float32) * decay * sigmoid * (1.0 - sigmoid))
+    d_raw_gate = tl.where(mask, d_raw_gate, 0.0)
 
     tl.store(
         dg + ptr_offset((token[:, None], i_h, channel[None, :]), DG_STRIDES),
-        d_raw_gate,
+        d_raw_gate.to(dg.dtype.element_ty),
         mask=mask,
     )
-    tl.store(dA + ptr_offset((i_t, i_h), DA_STRIDES), dA_log)
+    # dyg/dA_log = dg * z; masked lanes carry d_raw_gate == 0 and drop out.
+    tl.store(
+        dA_partial + ptr_offset((global_chunk, i_h, i_d), DA_STRIDES),
+        tl.sum(tl.sum(d_raw_gate * gate_input, 1), 0),
+    )
+    tl.store(
+        ddt_partial + ptr_offset((global_chunk, i_h, channel), DDT_STRIDES),
+        tl.sum(d_raw_gate, 0),
+        mask=channel < D,
+    )
 
 
 @input_guard(no_guard_contiguous=True)
 def kda_gate_bwd_ragged(
-    g: torch.Tensor,
+    raw_gate: torch.Tensor,
     A_log: torch.Tensor,
     dt_bias: torch.Tensor,
-    d_gate: torch.Tensor,
+    d_cumulative: torch.Tensor,
+    metadata: RaggedChunkMetadata,
     *,
     lower_bound: float,
+    scale: float,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Differentiate the pointwise bounded gate with FP32 parameter reductions."""
-    if g.ndim != 3:
-        raise ValueError(f"g must have shape [T, H, D], got {tuple(g.shape)}")
-    if d_gate.shape != g.shape:
-        raise ValueError(f"d_gate must have shape {tuple(g.shape)}, got {tuple(d_gate.shape)}")
-    tokens, heads, head_dim = g.shape
-    if A_log.shape != (heads,) or dt_bias.shape != (heads, head_dim):
-        raise ValueError("A_log or dt_bias shape does not match g")
+    """Differentiate the packed bounded-gate prefix sum with one fused launch.
 
-    block_tokens = 32
-    time_blocks = triton.cdiv(tokens, block_tokens)
-    dg = torch.empty_like(g, dtype=torch.float32)
-    dA_partial = A_log.new_empty((time_blocks, heads), dtype=torch.float32)
-    kda_gate_bwd_ragged_kernel[(time_blocks, heads)](
-        g,
+    Returns ``dg`` in ``raw_gate.dtype`` plus the reduced FP32 ``dA_log`` and
+    ``d_dt_bias`` parameter gradients.
+    """
+    if raw_gate.ndim != 4 or raw_gate.shape[0] != 1:
+        raise ValueError(f"raw_gate must have shape [1, T, H, D], got {tuple(raw_gate.shape)}")
+    if d_cumulative.shape != raw_gate.shape:
+        raise ValueError(
+            f"d_cumulative must have shape {tuple(raw_gate.shape)}, "
+            f"got {tuple(d_cumulative.shape)}"
+        )
+    _, _, heads, head_dim = raw_gate.shape
+    if A_log.shape != (heads,) or dt_bias.shape != (heads, head_dim):
+        raise ValueError("A_log or dt_bias shape does not match raw_gate")
+
+    block_dim = min(128, triton.next_power_of_2(head_dim))
+    dim_blocks = triton.cdiv(head_dim, block_dim)
+    dg = torch.empty_like(raw_gate)
+    # Zero-filled so chunk slots beyond the active count contribute empty partials.
+    dA_partial = A_log.new_zeros((metadata.capacity, heads, dim_blocks))
+    ddt_partial = A_log.new_zeros((metadata.capacity, heads, head_dim))
+    kda_gate_bwd_ragged_kernel[(metadata.capacity, heads, dim_blocks)](
+        raw_gate,
         A_log,
         dt_bias,
-        d_gate,
+        d_cumulative,
         dg,
         dA_partial,
+        ddt_partial,
         lower_bound,
-        tokens,
-        G_STRIDES=g.stride(),
+        scale,
+        metadata.cu_seqlens,
+        metadata.chunk_offsets,
+        metadata.cu_seqlens.shape[0] - 1,
+        G_STRIDES=raw_gate.stride()[1:],
         A_LOG_STRIDES=A_log.stride(),
         DT_BIAS_STRIDES=dt_bias.stride(),
-        DYG_STRIDES=d_gate.stride(),
-        DG_STRIDES=dg.stride(),
+        DY_STRIDES=d_cumulative.stride()[1:],
+        DG_STRIDES=dg.stride()[1:],
         DA_STRIDES=dA_partial.stride(),
+        DDT_STRIDES=ddt_partial.stride(),
         D=head_dim,
-        BT=block_tokens,
-        BD=triton.next_power_of_2(head_dim),
+        BT=metadata.chunk_size,
+        BD=block_dim,
         num_warps=4,
-        num_stages=3,
+        num_stages=2,
     )
-    return dg, dA_partial.sum(0), dg.sum(0)
+    return dg, dA_partial.sum((0, 2)), ddt_partial.sum(0)

--- a/attn_gym/linear/kda/fwd/triton/gate_fwd.py
+++ b/attn_gym/linear/kda/fwd/triton/gate_fwd.py
@@ -20,7 +20,6 @@ import triton
 import triton.language as tl
 
 from attn_gym._backends.triton.utils import ptr_offset, storage_cosize
-from attn_gym.linear.kda.bwd.triton.cumsum import ragged_chunk_local_cumsum_vector
 from attn_gym.linear.kda.bwd.triton.gate_bwd import kda_gate_bwd_ragged
 from attn_gym.linear.kda.chunk_scheduler import (
     RaggedChunkMetadata,
@@ -442,7 +441,7 @@ def _bounded_gate_cumsum_ragged_bwd_cuda(
     lower_bound: float,
     profile_ranges: bool,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Run ragged reverse scan, pointwise derivative, and reductions as one functional op."""
+    """Differentiate the packed gate prefix sum with one fused launch."""
     metadata = RaggedChunkMetadata(
         cu_seqlens,
         chunk_offsets,
@@ -454,20 +453,15 @@ def _bounded_gate_cumsum_ragged_bwd_cuda(
         if profile_ranges
         else nullcontext()
     ):
-        d_gate = ragged_chunk_local_cumsum_vector(
-            d_cumulative.float(),
-            metadata,
-            reverse=True,
-            scale=RCP_LN2,
-        )
-        dg_fp32, dA_log, d_dt_bias = kda_gate_bwd_ragged(
-            raw_gate[0],
+        return kda_gate_bwd_ragged(
+            raw_gate,
             A_log,
             dt_bias,
-            d_gate[0],
+            d_cumulative,
+            metadata,
             lower_bound=lower_bound,
+            scale=RCP_LN2,
         )
-    return dg_fp32.unsqueeze(0).to(raw_gate.dtype), dA_log, d_dt_bias
 
 
 torch.library.impl(

--- a/test/test_kda_ragged_bwd_dav.py
+++ b/test/test_kda_ragged_bwd_dav.py
@@ -150,3 +150,15 @@ def test_ragged_bwd_dav_replays_aligned_to_ragged():
     assert metadata.chunk_offsets.tolist() == [0, 2, 3]
     for replayed, independent in zip(actual, expected, strict=True):
         torch.testing.assert_close(replayed, independent, rtol=0, atol=0)
+
+
+def test_ragged_bwd_dav_op_registration():
+    """Validate the opaque ragged dAv operator against its schema and fake."""
+    inputs = _inputs(128)
+    cu_seqlens = cumulative_sequence_offsets([65, 63])
+    metadata = prepare_ragged_chunk_metadata(cu_seqlens, 128, _CHUNK_SIZE)
+    torch.library.opcheck(
+        torch.ops.attn_gym.kda_chunk_bwd_dav_ragged.default,
+        (*inputs, metadata.cu_seqlens, metadata.chunk_offsets, _SCALE, _CHUNK_SIZE),
+        test_utils=("test_schema", "test_faketensor", "test_aot_dispatch_dynamic"),
+    )


### PR DESCRIPTION
## Human Note

## Agent note

Two packed-path backward stages were losing their fast kernels. First, the packed bounded-gate
backward ran a five-kernel composition — a ragged FP32 reverse-cumsum kernel materializing a full
`[1, T, H, D]` intermediate, a pointwise derivative kernel writing FP32 `dg`, an eager `dg.sum(0)`
for `d_dt_bias`, a partial reduction, and a dtype cast — roughly 28 bytes/element of traffic where
the dense fused CuTe leaf moves ~8. It is now one Triton launch mirroring the ragged forward kernel:
the chunk-local reverse cumsum stays in registers, the derivative is applied in place, `dg` is
stored directly in the input dtype, and per-chunk `dA_log`/`d_dt_bias` partials land in zero-filled
capacity-sized buffers so CUDA-graph replay semantics are unchanged. The standalone ragged
reverse-cumsum kernel had no other consumer and is deleted.

Second, `chunk_kda_bwd_dav` only took its TensorDescriptor (TMA) kernel when `metadata is None`,
but the public API lowers every dense B>1 batch to the ragged schedule, so ordinary batches always
ran the masked-pointer kernel. Rather than threading an alignment flag through the backward schemas,
the ragged path gets its own descriptor kernel following the existing
`chunk_gla_fwd_kernel_o_ragged_tma` pattern: full 64-token chunks load and store through TMA, and
partial tails fall back to masked pointers inside the same launch — so every packed workload
benefits, aligned or not, with no assumptions about caller-provided boundaries. Because that
launcher mixes descriptors with aliased raw pointers (which the compile stack cannot functionalize
correctly), the ragged branch moves behind an opaque `define`/`impl` operator per the repo custom-op
skill, with a fake registration and an `opcheck` test; the pre-existing dAv fullgraph test catches
exactly that failure mode. Outputs are bitwise identical to the masked-pointer kernel on aligned,
mixed-Zipf, and empty-sequence boundary layouts.

## Performance

B200, bf16, H=32, K=V=128, eager, triton `do_bench`. Op-level:

| stage | case | before | after |
|---|---|---|---|
| gate backward | packed 8x4096 | 819 us | 451 us |
| gate backward | packed Zipf 9340 | 236 us | 180 us |
| dAv | packed 32k tokens | 289 us | 237 us (bitwise equal) |

End-to-end composed KDA-core backward: dense b8 t4096 6474 -> ~6290 us, dense b2 t16384
6491 -> ~6180 us, packed Zipf tot9340 2146 -> ~2050 us. The packed gate backward still trails the
dense fused CuTe leaf (451 vs ~310 us at 32k tokens); a ragged port of that CuTe kernel is the
natural follow-up if the varlen gate share ever matters.

## Test Plan

```bash
pytest test/test_kda_ragged_public_backward.py test/test_kda_ragged_public_forward.py \
  test/test_kda_ragged_autograd_ops.py test/test_kda_ragged_gate.py \
  test/test_kda_cute_forward.py test/test_kda_kernels.py \
  test/test_kda_ragged_bwd_dav.py test/test_kda_ragged_bwd_wy.py
```

223 passed, including the dAv fullgraph/CUDA-graph replay tests and a new `opcheck` for the
registered ragged dAv operator.
