### PR TITLE
Tighten ragged KDA guards, naming, and test structure after #309

### DIFF
--- a/attn_gym/linear/kda/bwd/cute/chunk_delta_h_bwd_v1.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_delta_h_bwd_v1.py
@@ -1275,11 +1275,13 @@ class BlackwellDeltaHBwdV1:
             while has_work:
                 w_idx = bx + tile_idx * gdx
                 bi_m = (w_idx // ((V + self.BV - 1) // self.BV)) // H
-                partial_rows = Int32(0)
+                tail_valid_rows = Int32(0)
                 if cutlass.const_expr(self.varlen):
                     seq_len = cu_seqlens[bi_m + 1] - cu_seqlens[bi_m]
                     NT = (seq_len + BT - 1) // BT
-                    partial_rows = seq_len % self.BT
+                    # Chunks iterate in reverse, so ct == 0 is the trailing
+                    # (possibly partial) chunk of this sequence.
+                    tail_valid_rows = seq_len % self.BT
                 else:
                     NT = (T + BT - 1) // BT
 
@@ -1303,12 +1305,12 @@ class BlackwellDeltaHBwdV1:
 
                     # --- MMA2: q^T(SMEM A) × do(SMEM B) → qdo_acc(TMEM) ---
                     # do is the COMPUTE-warp-produced, partial-chunk-masked
-                    # B-operand (1-stage R2S), mirroring dv2/MMA3 -- so the over-
-                    # read mask is off the MMA warp's critical path entirely.
+                    # B-operand (1-stage R2S), mirroring dv2/MMA3, so only the
+                    # A-operand tail neutralization below runs on the MMA warp.
                     qh = pq_C.wait_and_advance()
                     if cutlass.const_expr(self.varlen):  # noqa: SIM102
-                        if ct == 0 and partial_rows != 0:
-                            self._neutralize_reduction_rows(sQ, qh.index, partial_rows, mma_tid)
+                        if ct == 0 and tail_valid_rows != 0:
+                            self._neutralize_reduction_rows(sQ, qh.index, tail_valid_rows, mma_tid)
                     doh = pdob_C.wait_and_advance()
                     qdod = pqdo_P.acquire_and_advance()
                     for kp in cutlass.range(cute.size(t_q_a, mode=[2]), unroll_full=True):
@@ -1328,8 +1330,8 @@ class BlackwellDeltaHBwdV1:
                     dv2bh = pdv2b_C.wait_and_advance()
                     wh = pw_C.wait_and_advance()
                     if cutlass.const_expr(self.varlen):  # noqa: SIM102
-                        if ct == 0 and partial_rows != 0:
-                            self._neutralize_reduction_rows(sW, wh.index, partial_rows, mma_tid)
+                        if ct == 0 and tail_valid_rows != 0:
+                            self._neutralize_reduction_rows(sW, wh.index, tail_valid_rows, mma_tid)
                     wdvd = pwdv_P.acquire_and_advance()
                     for kp in cutlass.range(cute.size(t_w_a, mode=[2]), unroll_full=True):
                         mma_wdv.set(tcgen05.Field.ACCUMULATE, cutlass.Boolean(kp != 0))
@@ -1628,8 +1630,16 @@ class BlackwellDeltaHBwdV1:
     # ------------------------------------------------------------------
 
     @cute.jit
-    def _neutralize_reduction_rows(self, smem, stage, valid, tid):
-        """Zero invalid Q/W rows and publish them to the warp-issued UMMA."""
+    def _neutralize_reduction_rows(self, smem, stage, valid_rows, tid):
+        """Zero token columns ``[valid_rows, BT)`` of a Q/W stage and publish to UMMA.
+
+        MMA2/MMA3 reduce over tokens, so a tail chunk's over-read tokens must be
+        finite on both operands: the masked B-operand contributes zero, but
+        ``0 * NaN`` is NaN and the physical suffix past ``cu_seqlens[-1]`` is
+        undefined. This runs for every ragged tail, not just the terminal one,
+        because any tail's over-read window may cross the terminal offset
+        (e.g. trailing empty sequences).
+        """
         key_atom = cute.size(smem, mode=[0, 0, 0])
         token_atom = cute.size(smem, mode=[0, 1])
         # Trace-time guards for the hard-coded coordinate nesting below; a
@@ -1638,7 +1648,7 @@ class BlackwellDeltaHBwdV1:
         assert cute.size(smem, mode=[1]) == 1, "expected a single rest-M mode"
         assert key_atom * cute.size(smem, mode=[0, 0, 1]) == self.BK, "key modes must tile BK"
         assert token_atom * cute.size(smem, mode=[2]) == self.BT, "token modes must tile BT"
-        for token in cutlass.range(valid, self.BT, unroll=1):
+        for token in cutlass.range(valid_rows, self.BT, unroll=1):
             for key_block in cutlass.range_constexpr(self.BK // self.WARP_SZ):
                 key = tid + key_block * self.WARP_SZ
                 coord = (

--- a/attn_gym/linear/kda/fwd/triton/gate_fwd.py
+++ b/attn_gym/linear/kda/fwd/triton/gate_fwd.py
@@ -829,9 +829,9 @@ def bounded_gate_cumsum(
 
     Packed ``cu_seqlens`` must start at zero, end at or before the physical ``T``, and
     be monotonic; repeated offsets represent empty sequences. Output values and raw-gate
-    gradients are defined only on ``[0, cu_seqlens[-1])``. Values remain device-resident
-    and are validated by the scheduler so fixed-shape CUDA Graphs can replay with
-    different boundaries and active lengths.
+    gradients are defined only on ``[0, cu_seqlens[-1])``. The offsets remain
+    device-resident and are validated by the scheduler so fixed-shape CUDA Graphs can
+    replay with different boundaries and active lengths.
     """
     if raw_gate.ndim != 4:
         raise ValueError(f"raw_gate must have shape [B, T, H, D], got {tuple(raw_gate.shape)}")

--- a/attn_gym/linear/kda/short_conv/cute.py
+++ b/attn_gym/linear/kda/short_conv/cute.py
@@ -154,7 +154,19 @@ def advance_sequence_bounds(
     sequence_end: Int32,
     time: Int32,
 ):
-    """Advance packed sequence metadata when time crosses a boundary."""
+    """Advance packed sequence metadata when time crosses a boundary.
+
+    NOTE [Boundary trigger forms]: offsets are monotone with ``end <= tokens``
+    (device-asserted by the scheduler; ``sequence_bounds`` is a binary search).
+    Kernels resolve bounds at tile entry and walk ``time`` with unit stride, so
+    every boundary is hit by equality: side-effect-free refreshes may use ``>=``
+    (self-healing) or ``==`` (skips the inactive-tail re-lookup); once-only side
+    effects such as the input-gradient terminal flush MUST use ``==``. Any
+    traversal-stride change must revisit every ``== sequence_end`` trigger. The
+    ``skip_sequence_boundaries`` constexpr fast path is perf-load-bearing
+    (GB300, C=12288: 17-19% for full-capacity replays; a runtime bool loses
+    28-33%).
+    """
     if time >= sequence_end:
         sequence, sequence_start, sequence_end = sequence_bounds(cu_seqlens, time)
     return sequence, sequence_start, sequence_end
@@ -1173,7 +1185,6 @@ class CausalConv1dSiluInputGradientTma(
         channel_block, time_block, batch = cute.arch.block_idx()
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
         channel_group = channel_block * self.threads + tidx
-        channel = channel_group * self.channels_per_thread
         time_start = time_block * self.times_per_block
         stage_tokens = self.tma_stage_tokens
         subtiles = self.times_per_block // stage_tokens
@@ -1193,7 +1204,6 @@ class CausalConv1dSiluInputGradientTma(
             (self.channels_per_thread, self.width),
             Float32,
         )
-        weights.fill(Float32(0.0))
         history.fill(self.dtype.cute_type(0.0))
         grad_z.fill(Float32(0.0))
         sequence, sequence_start, sequence_end = tile_sequence_bounds(
@@ -1202,9 +1212,12 @@ class CausalConv1dSiluInputGradientTma(
             Int32(batch),
             self.tokens,
         )
-        for channel_offset in cutlass.range_constexpr(self.channels_per_thread):
-            for tap in cutlass.range_constexpr(self.width):
-                weights[channel_offset, tap] = Float32(weight[channel + channel_offset, tap])
+        weight_tile = cute.local_tile(
+            weight,
+            (self.channels_per_thread, self.width),
+            (channel_group, 0),
+        )
+        weights.store(weight_tile.load().to(Float32))
         if cutlass.const_expr(initial_state is None):
             for history_offset in cutlass.range_constexpr(self.width - 1):
                 history_time = time_start + history_offset - (self.width - 1)
@@ -1245,7 +1258,7 @@ class CausalConv1dSiluInputGradientTma(
                 if output_time < self.tokens:
                     if cutlass.const_expr(cu_seqlens is not None):  # noqa: SIM102
                         if cutlass.const_expr(not skip_sequence_boundaries):  # noqa: SIM102
-                            # Equality flushes the terminal boundary once; later capacity is undefined.
+                            # Once-only flush: must be "=="; see NOTE [Boundary trigger forms].
                             if output_time == sequence_end:
                                 previous_sequence_start = sequence_start
                                 sequence, sequence_start, sequence_end = sequence_bounds(
@@ -1677,7 +1690,9 @@ class CausalConv1dSiluWeightGradientPartialsTma(
                 if time < self.tokens:
                     active_time = True
                     if cutlass.const_expr(cu_seqlens is not None):
-                        if time >= sequence_end:
+                        # "==" skips the inactive-tail re-lookup; legal because the
+                        # walk is unit-stride -- see NOTE [Boundary trigger forms].
+                        if time == sequence_end:
                             sequence, sequence_start, sequence_end = sequence_bounds(
                                 cu_seqlens,
                                 Int32(time),

--- a/test/test_kda_chunk_scheduler.py
+++ b/test/test_kda_chunk_scheduler.py
@@ -53,18 +53,11 @@ def test_ragged_chunk_scheduler_matches_cpu_oracle(lengths):
     expected, offsets = _expected_tensor(lengths, 64)
     cu_seqlens = torch.tensor(offsets, device="cuda", dtype=torch.int32)
     metadata = prepare_ragged_chunk_metadata(cu_seqlens, offsets[-1], 64)
-    actual = decode_ragged_chunk_work(metadata).cpu()
 
     assert metadata.chunk_size == 64
-
-    active_chunks = expected.shape[0]
     assert metadata.capacity == chunk_capacity(offsets[-1], len(lengths), 64)
-    assert metadata.chunk_offsets[-1].item() == active_chunks
-    torch.testing.assert_close(actual[:active_chunks], expected)
-    torch.testing.assert_close(
-        actual[active_chunks:],
-        torch.full_like(actual[active_chunks:], -1),
-    )
+    assert metadata.chunk_offsets[-1].item() == expected.shape[0]
+    _assert_work_matches(decode_ragged_chunk_work(metadata), expected)
 
 
 @pytest.mark.parametrize("chunk_size", [16, 32, 64])
@@ -78,30 +71,40 @@ def test_ragged_chunk_scheduler_preserves_chunk_size(chunk_size):
     torch.testing.assert_close(decode_ragged_chunk_work(metadata).cpu(), expected)
 
 
-def test_ragged_chunk_scheduler_cuda_graph_replays_boundaries():
-    cu_seqlens = torch.tensor([0, 65, 128], device="cuda", dtype=torch.int32)
-    metadata = prepare_ragged_chunk_metadata(cu_seqlens, 128, 64)
-    warm_work = decode_ragged_chunk_work(metadata)
-    del warm_work
+def _assert_work_matches(work: torch.Tensor, expected: torch.Tensor) -> None:
+    """Active rows match the CPU oracle; the capacity filler rows are -1."""
+    active_chunks = expected.shape[0]
+    torch.testing.assert_close(work[:active_chunks].cpu(), expected)
+    filler = work[active_chunks:].cpu()
+    torch.testing.assert_close(filler, torch.full_like(filler, -1))
+
+
+@pytest.mark.parametrize(
+    ("initial_offsets", "replay_offsets", "replay_lengths"),
+    (
+        pytest.param([0, 65, 128], [0, 1, 128], [1, 127], id="boundaries"),
+        pytest.param([0, 64, 128], [0, 32, 65], [32, 33], id="active-token-count"),
+    ),
+)
+def test_ragged_chunk_scheduler_cuda_graph_replay(initial_offsets, replay_offsets, replay_lengths):
+    """Reread boundaries and the active endpoint from device memory on replay."""
+    cu_seqlens = torch.tensor(initial_offsets, device="cuda", dtype=torch.int32)
+    warm_metadata = prepare_ragged_chunk_metadata(cu_seqlens, initial_offsets[-1], 64)
+    decode_ragged_chunk_work(warm_metadata)
     torch.cuda.synchronize()
 
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
-        captured_metadata = prepare_ragged_chunk_metadata(cu_seqlens, 128, 64)
-        work = decode_ragged_chunk_work(captured_metadata)
+        metadata = prepare_ragged_chunk_metadata(cu_seqlens, initial_offsets[-1], 64)
+        work = decode_ragged_chunk_work(metadata)
 
-    cu_seqlens.copy_(torch.tensor([0, 1, 128], device="cuda", dtype=torch.int32))
+    cu_seqlens.copy_(torch.tensor(replay_offsets, device="cuda", dtype=torch.int32))
     graph.replay()
     torch.cuda.synchronize()
 
-    expected, _ = _expected_tensor([1, 127], 64)
-    active_chunks = expected.shape[0]
-    assert captured_metadata.chunk_offsets[-1].item() == active_chunks
-    torch.testing.assert_close(work[:active_chunks].cpu(), expected)
-    torch.testing.assert_close(
-        work[active_chunks:].cpu(),
-        torch.full_like(work[active_chunks:].cpu(), -1),
-    )
+    expected, _ = _expected_tensor(replay_lengths, 64)
+    assert metadata.chunk_offsets[-1].item() == expected.shape[0]
+    _assert_work_matches(work, expected)
 
 
 def test_ragged_chunk_scheduler_fullgraph():
@@ -115,26 +118,6 @@ def test_ragged_chunk_scheduler_fullgraph():
     actual_offsets, actual_work = torch.compile(operation, fullgraph=True)(cu_seqlens)
     torch.testing.assert_close(actual_offsets, expected_offsets)
     torch.testing.assert_close(actual_work, expected_work)
-
-
-def test_ragged_chunk_scheduler_replays_active_token_count():
-    cu_seqlens = torch.tensor([0, 64, 128], device="cuda", dtype=torch.int32)
-    prepare_ragged_chunk_metadata(cu_seqlens, 128, 64)
-    torch.cuda.synchronize()
-
-    graph = torch.cuda.CUDAGraph()
-    with torch.cuda.graph(graph):
-        metadata = prepare_ragged_chunk_metadata(cu_seqlens, 128, 64)
-        work = decode_ragged_chunk_work(metadata)
-
-    cu_seqlens.copy_(torch.tensor([0, 32, 65], device="cuda", dtype=torch.int32))
-    graph.replay()
-    torch.cuda.synchronize()
-
-    expected, _ = _expected_tensor([32, 33], 64)
-    torch.testing.assert_close(work[: expected.shape[0]].cpu(), expected)
-    inactive_work = work[expected.shape[0] :].cpu()
-    torch.testing.assert_close(inactive_work, torch.full_like(inactive_work, -1))
 
 
 def test_ragged_chunk_capacity_is_tight_for_empty_sequences():

--- a/test/test_kda_ragged_delta_h_bwd.py
+++ b/test/test_kda_ragged_delta_h_bwd.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from functools import partial
+
 import pytest
 import torch
 
@@ -43,16 +45,12 @@ def _run_ragged(
     q, k, w, do, dv, gk, h0, dht = inputs
     offsets = cumulative_sequence_offsets(lengths) if cu_seqlens is None else cu_seqlens
     metadata = prepare_ragged_chunk_metadata(offsets, q.shape[1], 64)
-    options = {
-        "gk": gk,
-        "h0": h0,
-        "dht": dht,
-        "scale": 128**-0.5,
-        "metadata": metadata,
-    }
-    if bv is not None:
-        return blackwell_delta_h_bwd_dhu_v1(q, k, w, do, dv, bv=bv, **options)
-    return blackwell_delta_h_bwd_dhu_dispatch(q, k, w, do, dv, **options)
+    operation = (
+        blackwell_delta_h_bwd_dhu_dispatch
+        if bv is None
+        else partial(blackwell_delta_h_bwd_dhu_v1, bv=bv)
+    )
+    return operation(q, k, w, do, dv, gk=gk, h0=h0, dht=dht, scale=128**-0.5, metadata=metadata)
 
 
 def test_ragged_delta_h_handles_all_empty_sequences():
@@ -120,7 +118,9 @@ def test_ragged_delta_h_matches_independent_sequences():
 
 @pytest.mark.parametrize("bv", [16, 32])
 @pytest.mark.parametrize(
-    "lengths", [[130, 0, 0], [63, 130]], ids=["small-partial", "large-partial"]
+    "lengths",
+    [[130, 0, 0], [63, 130]],
+    ids=["trailing-empty-sequences", "tail-then-multichunk"],
 )
 def test_ragged_delta_h_ignores_nan_poisoned_physical_suffix(bv, lengths):
     physical_tokens = 256

--- a/test/test_kda_ragged_gate.py
+++ b/test/test_kda_ragged_gate.py
@@ -19,12 +19,13 @@ from attn_gym.linear.kda.fwd.triton.gate_fwd import (
     _bounded_gate_cumsum_ragged_fwd_op,
     bounded_gate_cumsum,
 )
-from attn_gym.testing.kda import cumulative_sequence_offsets
+from attn_gym.linear.kda.utils import RCP_LN2
+from attn_gym.testing.kda import clone_kda_inputs, cumulative_sequence_offsets
 
 pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
 
 LOWER_BOUND = -3.25
-RCP_LN2 = 1.4426950216
+BF16_EPS = torch.finfo(torch.bfloat16).eps
 
 
 def _inputs(tokens: int, heads: int = 2, head_dim: int = 128, batch: int = 1):
@@ -36,6 +37,11 @@ def _inputs(tokens: int, heads: int = 2, head_dim: int = 128, batch: int = 1):
     dt_bias = 0.25 * torch.randn(heads, head_dim, device="cuda", dtype=torch.float32)
     d_cumulative = torch.randn(shape, device="cuda", dtype=torch.float32)
     return raw_gate, A_log, dt_bias, d_cumulative
+
+
+def _leaves(*tensors: torch.Tensor) -> tuple[torch.Tensor, ...]:
+    """Reuse the given storage as differentiable leaves."""
+    return tuple(tensor.detach().requires_grad_() for tensor in tensors)
 
 
 def _poison_inactive_suffix(
@@ -72,7 +78,74 @@ def _active_reference(
     return torch.cat(chunks, dim=1)
 
 
-@pytest.mark.parametrize("padding", (0, 17), ids=["full", "padded"])
+Run = tuple[torch.Tensor, tuple[torch.Tensor, ...]]
+
+
+def _run(
+    inputs: tuple[torch.Tensor, ...],
+    cu_seqlens: torch.Tensor,
+    d_cumulative: torch.Tensor,
+    chunk_size: int = 64,
+) -> Run:
+    """Run the ragged gate kernel and differentiate every leaf against one cotangent."""
+    output = bounded_gate_cumsum(
+        *inputs,
+        chunk_size=chunk_size,
+        lower_bound=LOWER_BOUND,
+        cu_seqlens=cu_seqlens,
+    )
+    return output, torch.autograd.grad(output, inputs, d_cumulative)
+
+
+def _reference_run(
+    inputs: tuple[torch.Tensor, ...],
+    lengths: list[int],
+    d_cumulative: torch.Tensor,
+    chunk_size: int = 64,
+) -> Run:
+    """Evaluate the Python reference and its gradients on the active prefix."""
+    expected = _active_reference(*inputs, lengths, chunk_size)
+    return expected, torch.autograd.grad(expected, inputs, d_cumulative[:, : sum(lengths)])
+
+
+def _assert_matches_reference(actual: Run, expected: Run, active_tokens: int, *, gate_rtol):
+    """Compare a kernel run against the Python reference over the active prefix."""
+    actual_output, actual_gradients = actual
+    expected_output, expected_gradients = expected
+    torch.testing.assert_close(
+        actual_output[:, :active_tokens], expected_output, rtol=1e-6, atol=8e-5
+    )
+    torch.testing.assert_close(
+        actual_gradients[0][:, :active_tokens],
+        expected_gradients[0][:, :active_tokens],
+        rtol=gate_rtol,
+        atol=1e-6,
+    )
+    for actual_gradient, expected_gradient in zip(
+        actual_gradients[1:], expected_gradients[1:], strict=True
+    ):
+        torch.testing.assert_close(actual_gradient, expected_gradient, rtol=5e-5, atol=7e-4)
+
+
+def _assert_bitwise_match(actual: Run, other: Run, active_tokens: int) -> None:
+    """Require bit-for-bit agreement between two kernel runs over the active prefix."""
+    actual_output, actual_gradients = actual
+    other_output, other_gradients = other
+    torch.testing.assert_close(
+        actual_output[:, :active_tokens], other_output[:, :active_tokens], rtol=0, atol=0
+    )
+    torch.testing.assert_close(
+        actual_gradients[0][:, :active_tokens],
+        other_gradients[0][:, :active_tokens],
+        rtol=0,
+        atol=0,
+    )
+    for actual_gradient, other_gradient in zip(
+        actual_gradients[1:], other_gradients[1:], strict=True
+    ):
+        torch.testing.assert_close(actual_gradient, other_gradient, rtol=0, atol=0)
+
+
 @pytest.mark.parametrize(
     ("head_dim", "chunk_size"),
     (
@@ -81,79 +154,37 @@ def _active_reference(
         (1024, 64),
     ),
 )
-def test_bounded_gate_cumsum_ragged_matches_active_reference(head_dim, chunk_size, padding):
+def test_bounded_gate_cumsum_ragged_matches_active_reference(head_dim, chunk_size):
     """Ignore poisoned storage beyond the dynamic terminal offset in forward and backward."""
     lengths = [chunk_size + 1, 0, chunk_size - 1]
     active_tokens = sum(lengths)
-    raw_gate, A_log, dt_bias, d_cumulative = _inputs(
-        active_tokens + padding,
-        head_dim=head_dim,
-    )
+    raw_gate, A_log, dt_bias, d_cumulative = _inputs(active_tokens + 17, head_dim=head_dim)
     _poison_inactive_suffix(raw_gate, d_cumulative, active_tokens)
-    actual_inputs = tuple(
-        tensor.detach().requires_grad_() for tensor in (raw_gate, A_log, dt_bias)
-    )
-    reference_inputs = tuple(tensor.detach().clone().requires_grad_() for tensor in actual_inputs)
+    inputs = _leaves(raw_gate, A_log, dt_bias)
+    reference_inputs = clone_kda_inputs(inputs)
     cu_seqlens = cumulative_sequence_offsets(lengths)
 
-    actual = bounded_gate_cumsum(
-        *actual_inputs,
-        chunk_size=chunk_size,
-        lower_bound=LOWER_BOUND,
-        cu_seqlens=cu_seqlens,
-    )
-    actual_gradients = torch.autograd.grad(actual, actual_inputs, d_cumulative)
-    expected = _active_reference(*reference_inputs, lengths, chunk_size)
-    expected_gradients = torch.autograd.grad(
-        expected,
-        reference_inputs,
-        d_cumulative[:, :active_tokens],
-    )
+    actual = _run(inputs, cu_seqlens, d_cumulative, chunk_size)
+    expected = _reference_run(reference_inputs, lengths, d_cumulative, chunk_size)
+    _assert_matches_reference(actual, expected, active_tokens, gate_rtol=4 * BF16_EPS)
 
-    torch.testing.assert_close(actual[:, :active_tokens], expected, rtol=1e-6, atol=8e-5)
-    torch.testing.assert_close(
-        actual_gradients[0][:, :active_tokens],
-        expected_gradients[0][:, :active_tokens],
-        rtol=4 * torch.finfo(torch.bfloat16).eps,
-        atol=1e-6,
+    # The padded run must also match an exactly sized kernel run bit-for-bit, which
+    # transitively pins the full-capacity (no padding) numeric path as well.
+    sliced_inputs = (
+        inputs[0][:, :active_tokens].detach().clone().requires_grad_(),
+        *clone_kda_inputs(inputs[1:]),
     )
-    torch.testing.assert_close(actual_gradients[1], expected_gradients[1], rtol=5e-5, atol=7e-4)
-    torch.testing.assert_close(actual_gradients[2], expected_gradients[2], rtol=5e-5, atol=7e-4)
-
-    # The padded run must also match a physically sliced kernel run bit-for-bit.
-    sliced_gate = actual_inputs[0][:, :active_tokens].detach().clone().requires_grad_()
-    sliced_params = tuple(tensor.detach().clone().requires_grad_() for tensor in actual_inputs[1:])
-    sliced = bounded_gate_cumsum(
-        sliced_gate,
-        *sliced_params,
-        chunk_size=chunk_size,
-        lower_bound=LOWER_BOUND,
-        cu_seqlens=cu_seqlens,
-    )
-    sliced_gradients = torch.autograd.grad(
-        sliced,
-        (sliced_gate, *sliced_params),
-        d_cumulative[:, :active_tokens],
-    )
-    torch.testing.assert_close(actual[:, :active_tokens], sliced, rtol=0, atol=0)
-    torch.testing.assert_close(
-        actual_gradients[0][:, :active_tokens], sliced_gradients[0], rtol=0, atol=0
-    )
-    for actual_gradient, sliced_gradient in zip(
-        actual_gradients[1:], sliced_gradients[1:], strict=True
-    ):
-        torch.testing.assert_close(actual_gradient, sliced_gradient, rtol=0, atol=0)
+    sliced = _run(sliced_inputs, cu_seqlens, d_cumulative[:, :active_tokens], chunk_size)
+    _assert_bitwise_match(actual, sliced, active_tokens)
 
 
 def test_bounded_gate_cumsum_ragged_zero_active_tokens():
     """Produce zero parameter gradients when every physical token is inactive."""
     raw_gate, A_log, dt_bias, d_cumulative = _inputs(64)
     _poison_inactive_suffix(raw_gate, d_cumulative, 0)
-    inputs = tuple(tensor.detach().requires_grad_() for tensor in (raw_gate, A_log, dt_bias))
-    cu_seqlens = cumulative_sequence_offsets([0, 0])
+    inputs = _leaves(raw_gate, A_log, dt_bias)
 
-    output = bounded_gate_cumsum(*inputs, lower_bound=LOWER_BOUND, cu_seqlens=cu_seqlens)
-    gradients = torch.autograd.grad(output, inputs, d_cumulative)
+    output, gradients = _run(inputs, cumulative_sequence_offsets([0, 0]), d_cumulative)
 
     assert output.shape == raw_gate.shape
     torch.testing.assert_close(gradients[1], torch.zeros_like(A_log), rtol=0, atol=0)
@@ -205,12 +236,8 @@ def test_bounded_gate_cumsum_ragged_reduce_overhead():
     active_tokens = sum(lengths)
     raw_gate, A_log, dt_bias, d_cumulative = _inputs(active_tokens + 17)
     _poison_inactive_suffix(raw_gate, d_cumulative, active_tokens)
-    reference_inputs = tuple(
-        tensor.detach().requires_grad_() for tensor in (raw_gate, A_log, dt_bias)
-    )
-    compiled_inputs = tuple(
-        tensor.detach().clone().requires_grad_() for tensor in reference_inputs
-    )
+    reference_inputs = _leaves(raw_gate, A_log, dt_bias)
+    compiled_inputs = clone_kda_inputs(reference_inputs)
     cu_seqlens = cumulative_sequence_offsets(lengths)
 
     def operation(raw_gate, A_log, dt_bias, offsets):
@@ -222,29 +249,16 @@ def test_bounded_gate_cumsum_ragged_reduce_overhead():
             cu_seqlens=offsets,
         )
 
-    expected = _active_reference(*reference_inputs, lengths, 64)
-    expected_gradients = torch.autograd.grad(
-        expected,
-        reference_inputs,
-        d_cumulative[:, :active_tokens],
-    )
+    expected = _reference_run(reference_inputs, lengths, d_cumulative)
     with inductor_config.patch("triton.cudagraph_or_error", True):
         actual = torch.compile(operation, fullgraph=True, mode="reduce-overhead")(
             *compiled_inputs, cu_seqlens
         )
         actual_gradients = torch.autograd.grad(actual, compiled_inputs, d_cumulative)
 
-    torch.testing.assert_close(actual[:, :active_tokens], expected, rtol=1e-6, atol=8e-5)
-    torch.testing.assert_close(
-        actual_gradients[0][:, :active_tokens],
-        expected_gradients[0][:, :active_tokens],
-        rtol=torch.finfo(torch.bfloat16).eps,
-        atol=1e-6,
+    _assert_matches_reference(
+        (actual, actual_gradients), expected, active_tokens, gate_rtol=BF16_EPS
     )
-    for actual_gradient, expected_gradient in zip(
-        actual_gradients[1:], expected_gradients[1:], strict=True
-    ):
-        torch.testing.assert_close(actual_gradient, expected_gradient, rtol=5e-5, atol=7e-4)
 
 
 def test_bounded_gate_cumsum_ragged_cuda_graph_replay():
@@ -254,22 +268,14 @@ def test_bounded_gate_cumsum_ragged_cuda_graph_replay():
     fresh_gate = raw_gate.clone()
     fresh_d_cumulative = d_cumulative.clone()
     _poison_inactive_suffix(raw_gate, d_cumulative, sum(initial_lengths))
-    inputs = tuple(tensor.detach().requires_grad_() for tensor in (raw_gate, A_log, dt_bias))
+    inputs = _leaves(raw_gate, A_log, dt_bias)
     cu_seqlens = cumulative_sequence_offsets(initial_lengths)
 
-    def run(current_inputs, offsets):
-        output = bounded_gate_cumsum(
-            *current_inputs,
-            lower_bound=LOWER_BOUND,
-            cu_seqlens=offsets,
-        )
-        return output, torch.autograd.grad(output, current_inputs, d_cumulative)
-
-    run(inputs, cu_seqlens)
+    _run(inputs, cu_seqlens, d_cumulative)
     torch.cuda.synchronize()
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
-        actual, actual_gradients = run(inputs, cu_seqlens)
+        actual = _run(inputs, cu_seqlens, d_cumulative)
 
     for replay_lengths in ([65, 0, 32], [72, 1, 72]):
         active_tokens = sum(replay_lengths)
@@ -282,40 +288,12 @@ def test_bounded_gate_cumsum_ragged_cuda_graph_replay():
         torch.cuda.synchronize()
 
         # Replay must match a fresh eager kernel run on the same storage bit-for-bit.
-        eager_inputs = tuple(tensor.detach().clone().requires_grad_() for tensor in inputs)
-        eager, eager_gradients = run(eager_inputs, cu_seqlens)
-        torch.testing.assert_close(
-            actual[:, :active_tokens], eager[:, :active_tokens], rtol=0, atol=0
-        )
-        torch.testing.assert_close(
-            actual_gradients[0][:, :active_tokens],
-            eager_gradients[0][:, :active_tokens],
-            rtol=0,
-            atol=0,
-        )
-        for actual_gradient, eager_gradient in zip(
-            actual_gradients[1:], eager_gradients[1:], strict=True
-        ):
-            torch.testing.assert_close(actual_gradient, eager_gradient, rtol=0, atol=0)
+        eager = _run(clone_kda_inputs(inputs), cu_seqlens, d_cumulative)
+        _assert_bitwise_match(actual, eager, active_tokens)
 
-        reference_inputs = tuple(tensor.detach().clone().requires_grad_() for tensor in inputs)
-        expected = _active_reference(*reference_inputs, replay_lengths, 64)
-        expected_gradients = torch.autograd.grad(
-            expected,
-            reference_inputs,
-            d_cumulative[:, :active_tokens],
-        )
-        torch.testing.assert_close(actual[:, :active_tokens], expected, rtol=1e-6, atol=8e-5)
-        torch.testing.assert_close(
-            actual_gradients[0][:, :active_tokens],
-            expected_gradients[0][:, :active_tokens],
-            rtol=torch.finfo(torch.bfloat16).eps,
-            atol=1e-6,
-        )
-        for actual_gradient, expected_gradient in zip(
-            actual_gradients[1:], expected_gradients[1:], strict=True
-        ):
-            torch.testing.assert_close(actual_gradient, expected_gradient, rtol=5e-5, atol=7e-4)
+        reference_inputs = clone_kda_inputs(inputs)
+        expected = _reference_run(reference_inputs, replay_lengths, d_cumulative)
+        _assert_matches_reference(actual, expected, active_tokens, gate_rtol=BF16_EPS)
 
 
 @pytest.mark.parametrize(

--- a/test/test_kda_ragged_public_backward.py
+++ b/test/test_kda_ragged_public_backward.py
@@ -78,15 +78,20 @@ def _run_naive_gradients(
     return reference_output, reference_final_state, gradients
 
 
-def _assert_run_close(actual, expected):
+def _assert_run_close(actual, expected, active_tokens=None):
+    """Compare runs exactly on outputs/state; token tensors only over the active prefix."""
+    prefix = slice(None) if active_tokens is None else slice(None, active_tokens)
     actual_output, actual_state, actual_gradients = actual
     expected_output, expected_state, expected_gradients = expected
-    torch.testing.assert_close(actual_output, expected_output, rtol=0, atol=0)
+    torch.testing.assert_close(actual_output[:, prefix], expected_output, rtol=0, atol=0)
     torch.testing.assert_close(actual_state, expected_state, rtol=0, atol=0)
     for actual_gradient, expected_gradient in zip(
-        actual_gradients, expected_gradients, strict=True
+        actual_gradients[:-1], expected_gradients[:-1], strict=True
     ):
-        torch.testing.assert_close(actual_gradient, expected_gradient, rtol=3e-2, atol=3e-2)
+        torch.testing.assert_close(
+            actual_gradient[:, prefix], expected_gradient, rtol=3e-2, atol=3e-2
+        )
+    torch.testing.assert_close(actual_gradients[-1], expected_gradients[-1], rtol=3e-2, atol=3e-2)
 
 
 def test_public_ragged_backward_matches_independent_sequences():
@@ -241,7 +246,9 @@ def test_public_ragged_forward_and_backward_cuda_graph_replay():
     with torch.no_grad():
         for tensor in inputs:
             tensor[:, active_tokens:].fill_(float("nan"))
-        output_grad[:, active_tokens:].fill_(float("nan"))
+        # The loss multiplies the full physical buffer, so the suffix cotangent
+        # must stay finite; the suffix inputs need not.
+        output_grad[:, active_tokens:].zero_()
     graph.replay()
     torch.cuda.synchronize()
 
@@ -252,17 +259,7 @@ def test_public_ragged_forward_and_backward_cuda_graph_replay():
         output_grad[:, :active_tokens],
         state_grad,
     )
-    actual_output, actual_state, actual_gradients = actual
-    expected_output, expected_state, expected_gradients = expected
-    torch.testing.assert_close(actual_output[:, :active_tokens], expected_output, rtol=0, atol=0)
-    torch.testing.assert_close(actual_state, expected_state, rtol=0, atol=0)
-    for actual_gradient, expected_gradient in zip(
-        actual_gradients[:-1], expected_gradients[:-1], strict=True
-    ):
-        torch.testing.assert_close(
-            actual_gradient[:, :active_tokens], expected_gradient, rtol=3e-2, atol=3e-2
-        )
-    torch.testing.assert_close(actual_gradients[-1], expected_gradients[-1], rtol=3e-2, atol=3e-2)
+    _assert_run_close(actual, expected, active_tokens)
 
 
 def test_dense_tail_batch_gradients_match_explicit_packed_lowering():

--- a/test/test_kda_short_conv_cute.py
+++ b/test/test_kda_short_conv_cute.py
@@ -1346,9 +1346,9 @@ def test_short_conv_cuda_graph_replay():
     assert not torch.equal(captured_gradients[0], first_gradients[0])
     expected_output = _forward_op(x, weight)
     expected_gradients = _backward_op(x, weight, grad_output)
-    torch.testing.assert_close(captured_output, expected_output)
-    torch.testing.assert_close(captured_gradients[0], expected_gradients[0])
-    torch.testing.assert_close(captured_gradients[1], expected_gradients[1])
+    torch.testing.assert_close(captured_output, expected_output, rtol=0, atol=0)
+    torch.testing.assert_close(captured_gradients[0], expected_gradients[0], rtol=0, atol=0)
+    torch.testing.assert_close(captured_gradients[1], expected_gradients[1], rtol=0, atol=0)
 
 
 def test_short_conv_packed_stateful_cuda_graph_replays_boundaries_and_history():
@@ -1393,18 +1393,20 @@ def test_short_conv_packed_stateful_cuda_graph_replays_boundaries_and_history():
         x, weight, grad_output, cu_seqlens, initial_state, *config
     )
     torch.testing.assert_close(
-        captured_output[:, :active_tokens], expected_output[:, :active_tokens]
+        captured_output[:, :active_tokens], expected_output[:, :active_tokens], rtol=0, atol=0
     )
     torch.testing.assert_close(
         captured_gradients[0][:, :active_tokens],
         expected_gradients[0][:, :active_tokens],
+        rtol=0,
+        atol=0,
     )
     for actual_gradient, expected_gradient in zip(
         captured_gradients[1:],
         expected_gradients[1:],
         strict=True,
     ):
-        torch.testing.assert_close(actual_gradient, expected_gradient)
+        torch.testing.assert_close(actual_gradient, expected_gradient, rtol=0, atol=0)
 
 
 def test_short_conv_packed_stateful_tma_cuda_graph_replays_boundaries_and_history():
@@ -1469,10 +1471,12 @@ def test_short_conv_packed_stateful_tma_cuda_graph_replays_boundaries_and_histor
     torch.testing.assert_close(
         captured_gradients[0][:, :active_tokens],
         expected_gradients[0][:, :active_tokens],
+        rtol=0,
+        atol=0,
     )
     for actual_gradient, expected_gradient in zip(
         captured_gradients[1:],
         expected_gradients[1:],
         strict=True,
     ):
-        torch.testing.assert_close(actual_gradient, expected_gradient)
+        torch.testing.assert_close(actual_gradient, expected_gradient, rtol=0, atol=0)


### PR DESCRIPTION
Tighten ragged KDA guards, naming, and test structure after #309

Kernels:
- Document the boundary-trigger contract once (NOTE [Boundary trigger
  forms]) with the GB300 fast-path crossover data, and switch the
  weight-gradient TMA refresh to the once-only "==" form it permits
- Load input-gradient weights through the same local_tile idiom as the
  weight-gradient kernel; drop the dead fill and unused channel local
- delta-h: rename partial_rows/valid to tail_valid_rows, note that
  chunks iterate in reverse, and document why A-operand tail
  neutralization is required (0 * NaN) and unconditional

Tests (coverage-preserving consolidation):
- gate: shared _run/_reference_run and reference/bitwise assert
  helpers; import RCP_LN2 from utils; reuse clone_kda_inputs
- scheduler: _assert_work_matches helper and one parameterized
  graph-replay test covering boundary and active-count changes
- public backward: fold the replay asserts into _assert_run_close via
  an active_tokens prefix
- short-conv: replay-vs-eager comparisons tightened to rtol=0, atol=0
- delta-h: partial-based dispatch in _run_ragged, descriptive ids

Docs: clarify the gate_fwd offsets docstring wording.