### PR TITLE
Test and document fixed-capacity KDA graph replay

### DIFF
--- a/docs/linear.md
+++ b/docs/linear.md
@@ -74,7 +74,12 @@ per-batch, per-chunk partials for the shared parameter reduction. Packed gate ba
 instead uses one graph-safe ragged Triton launch that fuses the reverse scan, bounded-gate
 derivative, and FP32 parameter-gradient partials. The example explicitly runs projections
 in BF16 while retaining FP32 parameters and gate reductions; no ambient autocast context
-is required.
+is required. Distributed mixed-precision policies must preserve `A_log` and `dt_bias` as
+FP32 when parameters are materialized, rather than only casting activations inside
+`forward`. A module-wide BF16 FSDP policy violates the fused gate ABI. A correctness-first
+integration can keep the KDA unit under an FP32 policy while its projections explicitly
+compute in BF16; isolating only the strict-FP32 decay state is a future bandwidth
+optimization.
 The CuTe dense gate backward requires a head dimension divisible by 32 in `[32, 1024]`;
 gate forward is Triton for both dense and ragged inputs.
 The optimized core requires Blackwell, BF16 kernel inputs, `head_dim=128`, and 64-token
@@ -88,6 +93,18 @@ fixed-capacity execution, the terminal offset may be smaller than physical `T`; 
 values outside `[0, cu_seqlens[-1])` are unspecified. Primitives deliberately do not mask
 this inactive suffix automatically; caller-owned masking keeps that cost out of each
 primitive hot path.
+
+A captured graph with sequence capacity `N` keeps `cu_seqlens.shape == (N + 1,)`. If a
+replay has `M <= N` nonempty sequences and `L <= T` active tokens, repeat the terminal
+endpoint through the unused tail:
+
+```text
+[0, sequence_start_1, ..., L, L, ..., L]
+```
+
+The repeated ranges are ordinary empty sequences. Stateful APIs therefore retain `N`
+state rows even when only `M` sequences are nonempty. Both `L` and `M` may change on
+replay, but physical token capacity `T` and metadata capacity `N` may not.
 
 Callers that use dynamic active lengths within fixed-capacity tensors must opt in to
 masking. Ragged primitives read only `[0, cu_seqlens[-1])` from token-shaped inputs,
@@ -162,9 +179,15 @@ work. It can be combined with `--profile`; compilation warmups run before the
 trace starts. Like FLA's default training path, its backward recomputes the W/U,
 gated Q/K, recurrent-state, and
 corrected-value intermediates instead of retaining them across the forward/backward
-boundary. Million-token training still requires model-level activation
-checkpointing and context parallelism; this single-device example implements
-neither distributed policy.
+boundary.
+
+Graph-safe active-token replay does not by itself make complete model time proportional
+to `L`. The ragged short convolution, gate scan, and KDA core can skip inactive token
+work, but the example's projections, output normalization, output gate, and output
+projection still process physical capacity `T`. An end-to-end integration needs
+active-prefix-aware surrounding operations to turn smaller `L` into a comparable step-time
+reduction. Million-token training also requires model-level activation checkpointing and
+context parallelism; this single-device example implements neither distributed policy.
 
 The module can sit behind a transformer layer's attention slot while state is
 threaded explicitly:

--- a/test/test_kda_ragged_public_backward.py
+++ b/test/test_kda_ragged_public_backward.py
@@ -325,11 +325,14 @@ def test_public_ragged_forward_and_backward_fullgraph(
 
 
 def test_public_ragged_forward_and_backward_cuda_graph_replay():
+    """Replay changing L and M under fixed token and sequence capacities."""
     inputs = make_kda_test_inputs(128, requires_grad=True)
-    initial_state = (torch.randn(2, 1, 128, 128, device="cuda") / 8).requires_grad_()
+    initial_state = (torch.randn(4, 1, 128, 128, device="cuda") / 8).requires_grad_()
     output_grad = torch.randn(1, 128, 1, 128, device="cuda")
     state_grad = torch.randn_like(initial_state)
-    offsets = cumulative_sequence_offsets([64, 64])
+    # Capture N=4 state slots with M=2 nonempty sequences. Repeating the active
+    # endpoint encodes the unused sequence-capacity tail without changing shape.
+    offsets = cumulative_sequence_offsets([64, 64, 0, 0])
 
     _run_gradients(
         clone_kda_inputs(inputs),
@@ -344,8 +347,9 @@ def test_public_ragged_forward_and_backward_cuda_graph_replay():
     with torch.cuda.graph(graph):
         actual = _run_gradients(inputs, initial_state, offsets, output_grad, state_grad)
 
-    active_tokens = 65
-    offsets.copy_(cumulative_sequence_offsets([32, 33]))
+    active_lengths = [17, 15, 33]
+    active_tokens = sum(active_lengths)
+    offsets.copy_(cumulative_sequence_offsets([*active_lengths, 0]))
     with torch.no_grad():
         for tensor in inputs:
             tensor[:, active_tokens:].fill_(float("nan"))
@@ -358,7 +362,7 @@ def test_public_ragged_forward_and_backward_cuda_graph_replay():
     expected = _run_gradients(
         tuple(tensor[:, :active_tokens].detach().clone().requires_grad_() for tensor in inputs),
         initial_state.detach().clone().requires_grad_(),
-        cumulative_sequence_offsets([32, 33]),
+        cumulative_sequence_offsets([*active_lengths, 0]),
         output_grad[:, :active_tokens],
         state_grad,
     )

--- a/test/test_kda_training_example.py
+++ b/test/test_kda_training_example.py
@@ -124,7 +124,10 @@ def test_kda_example_packed_matches_sequence_for_loop(monkeypatch):
     """Match independent execution while sharing one packed schedule across fused stages."""
     scheduled_metadata = []
     consumed_metadata = []
+    fused_calls = {"short_conv": 0, "l2norm": 0, "gate": 0, "core": 0}
     prepare_metadata = kda_training.prepare_ragged_chunk_metadata
+    short_conv = kda_training.cute_causal_conv1d_silu
+    fused_l2norm = kda_training.l2norm
     gate = kda_training._bounded_gate_cumsum
     core = kda_training._chunk_kda
 
@@ -132,17 +135,29 @@ def test_kda_example_packed_matches_sequence_for_loop(monkeypatch):
         scheduled_metadata.append(prepare_metadata(*args))
         return scheduled_metadata[-1]
 
+    def record_short_conv(*args, **kwargs):
+        fused_calls["short_conv"] += 1
+        return short_conv(*args, **kwargs)
+
+    def record_l2norm(*args, **kwargs):
+        fused_calls["l2norm"] += 1
+        return fused_l2norm(*args, **kwargs)
+
     def record_gate(*args, **kwargs):
+        fused_calls["gate"] += 1
         if kwargs.get("metadata") is not None:
             consumed_metadata.append(kwargs["metadata"])
         return gate(*args, **kwargs)
 
     def record_core(*args, **kwargs):
+        fused_calls["core"] += 1
         if kwargs.get("metadata") is not None:
             consumed_metadata.append(kwargs["metadata"])
         return core(*args, **kwargs)
 
     monkeypatch.setattr(kda_training, "prepare_ragged_chunk_metadata", record_prepare)
+    monkeypatch.setattr(kda_training, "cute_causal_conv1d_silu", record_short_conv)
+    monkeypatch.setattr(kda_training, "l2norm", record_l2norm)
     monkeypatch.setattr(kda_training, "_bounded_gate_cumsum", record_gate)
     monkeypatch.setattr(kda_training, "_chunk_kda", record_core)
     torch.manual_seed(19)
@@ -159,6 +174,8 @@ def test_kda_example_packed_matches_sequence_for_loop(monkeypatch):
     cu_seqlens = torch.tensor(offsets, device="cuda", dtype=torch.int32)
 
     actual = model(packed_hidden, cu_seqlens=cu_seqlens).hidden_states
+    assert fused_calls == {"short_conv": 1, "l2norm": 2, "gate": 1, "core": 1}
+
     loop_outputs = [
         model(loop_hidden[:, start:end]).hidden_states
         for start, end in pairwise(offsets)
@@ -183,17 +200,18 @@ def test_kda_example_packed_matches_sequence_for_loop(monkeypatch):
     [
         pytest.param([0, 64, 128], [0, 33, 96], id="fewer-tokens"),
         pytest.param([0, 48, 96, 128], [0, 33, 96, 96], id="fewer-tokens-and-sequences"),
+        pytest.param(
+            [0, 64, 128, 128, 128],
+            [0, 33, 64, 96, 96],
+            id="more-sequences-within-capacity",
+        ),
     ],
 )
 def test_kda_example_masked_capacity_matches_active_run_under_graph_replay(
     captured_offsets,
     replayed_offsets,
 ):
-    """Replay a shorter active length over a stale suffix and match an exactly sized run.
-
-    The second case drops a whole sequence at replay time by repeating the active endpoint
-    in the cu_seqlens tail (capture N sequences, replay M<N).
-    """
+    """Replay changing L and M over stale capacity and match an exactly sized run."""
     torch.manual_seed(31)
     capacity, hidden_size = captured_offsets[-1], 32
     model = KDAAttention(


### PR DESCRIPTION
## Summary

- document the fixed-capacity CUDA Graph contract for physical token capacity `T`, sequence capacity `N`, active tokens `L`, and active sequences `M`
- extend primitive and complete-module replay coverage to include increasing `M` within a captured `N`, complementing the existing decreasing-`M` cases
- assert that packed training actually routes through the fused short convolution, L2 normalization, gate scan, and KDA core
- document the strict FP32 decay-parameter policy and the remaining physical-`T` cost in surrounding dense operations

## Testing

- `gpu-run auto -- ~/.venvs/nightly/bin/pytest -q test/test_kda_ragged_public_backward.py::test_public_ragged_forward_and_backward_cuda_graph_replay test/test_kda_training_example.py::test_kda_example_packed_matches_sequence_for_loop test/test_kda_training_example.py::test_kda_example_masked_capacity_matches_active_run_under_graph_replay` (5 passed)
- `prek run --files docs/linear.md test/test_kda_training_example.py test/test_kda_ragged_public_backward.py`
