### PR TITLE
Rename the short conv to causal_conv1d with pluggable activations

### DIFF
--- a/attn_gym/_backends/cute/__init__.py
+++ b/attn_gym/_backends/cute/__init__.py
@@ -1,5 +1,6 @@
 """Infrastructure shared by CuTeDSL attention backends."""
 
+from ._key import function_cache_key
 from .cache import jit_cache
 from .tune import TunableKernel, benchmark_gpu, run_tunable, tune
 from .utils import (
@@ -16,6 +17,7 @@ __all__ = [
     "benchmark_gpu",
     "ceildiv",
     "compile_tvm_ffi",
+    "function_cache_key",
     "get_device_properties",
     "jit_cache",
     "run_tunable",

--- a/attn_gym/_backends/cute/_key.py
+++ b/attn_gym/_backends/cute/_key.py
@@ -3,13 +3,17 @@
 from __future__ import annotations
 
 import dataclasses
+import dis
 import enum
 import functools
 import hashlib
+import inspect
 import os
 import pickle
 import platform
 import sys
+import threading
+import types
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -111,6 +115,80 @@ def _is_named_tuple(item: Any) -> bool:
     return isinstance(item, tuple) and isinstance(fields, tuple)
 
 
+@functools.cache
+def _unwrapped(function: types.FunctionType) -> types.FunctionType:
+    """Resolve decorator wrappers once; wrapper chains are fixed at definition."""
+    return inspect.unwrap(function)
+
+
+@functools.cache
+def _function_static_parts(function: types.FunctionType) -> tuple[str, tuple[str, ...]]:
+    """Fetch a function's source and referenced global names once per function."""
+    try:
+        source = inspect.getsource(function)
+    except (OSError, TypeError) as error:
+        raise TypeError(
+            f"function {function.__qualname__!r} has no stable cache key; it must be "
+            "defined in a source file so compiled kernels can key on its code"
+        ) from error
+    global_names = tuple(
+        sorted(
+            {
+                instruction.argval
+                for instruction in dis.get_instructions(function)
+                if instruction.opname == "LOAD_GLOBAL"
+            }
+        )
+    )
+    return source, global_names
+
+
+_FUNCTIONS_IN_PROGRESS = threading.local()
+
+
+def _canonicalize_function(function: types.FunctionType) -> tuple[Any, ...]:
+    """Encode a function by content: source plus current closure and global values.
+
+    Compiled CuTeDSL kernels inline the traced expressions, so the identity must
+    cover everything that shapes the generated code: the source text, captured
+    closure cells, and referenced module-global values (imported modules and
+    builtins are stable references and are skipped). Values are re-read on every
+    key computation, so mutating a captured global recompiles instead of
+    silently reusing a kernel traced with the old value.
+    """
+    unwrapped = _unwrapped(function)
+    in_progress = getattr(_FUNCTIONS_IN_PROGRESS, "stack", None)
+    if in_progress is None:
+        in_progress = _FUNCTIONS_IN_PROGRESS.stack = set()
+    if id(unwrapped) in in_progress:
+        raise TypeError(
+            f"function {unwrapped.__qualname__!r} participates in a reference cycle "
+            "and has no stable cache key"
+        )
+    in_progress.add(id(unwrapped))
+    try:
+        source, global_names = _function_static_parts(unwrapped)
+        cells = tuple(_canonicalize(cell.cell_contents) for cell in unwrapped.__closure__ or ())
+        module_globals = unwrapped.__globals__
+        globals_used = tuple(
+            (name, _canonicalize(module_globals[name]))
+            for name in global_names
+            if name in module_globals and not isinstance(module_globals[name], types.ModuleType)
+        )
+        # Default values appear in the source text, but a *mutable* default
+        # object can change behavior after definition without changing it.
+        defaults = _canonicalize(unwrapped.__defaults__)
+        keyword_defaults = _canonicalize(unwrapped.__kwdefaults__)
+    finally:
+        in_progress.discard(id(unwrapped))
+    return ("function", source, cells, globals_used, defaults, keyword_defaults)
+
+
+def function_cache_key(function: Callable[..., Any]) -> tuple[Any, ...]:
+    """Return the content-addressed cache identity of a traced function."""
+    return _canonicalize_function(function)
+
+
 def _pickle_sort_key(item: Any) -> bytes:
     return pickle.dumps(item, protocol=pickle.HIGHEST_PROTOCOL)
 
@@ -144,6 +222,8 @@ def _canonicalize(item: Any) -> Any:
         )
     if isinstance(item, enum.Enum):
         return ("enum", type(item).__module__, type(item).__qualname__, item.name)
+    if isinstance(item, types.FunctionType):
+        return _canonicalize_function(item)
     if isinstance(item, type):
         return ("type", item.__module__, item.__qualname__)
     if isinstance(item, Path):

--- a/attn_gym/linear/__init__.py
+++ b/attn_gym/linear/__init__.py
@@ -1,16 +1,64 @@
-"""Linear attention operations."""
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Linear attention operations: ``from attn_gym.linear import ...``."""
+
+import importlib
+from typing import TYPE_CHECKING
 
 from attn_gym.linear.gdn import GatedDeltaRuleOutput, gated_delta_rule
 from attn_gym.linear.kda import (
+    active_token_mask,
+    bounded_gate_cumsum,
+    l2norm,
+    mask_inactive_token_gradients,
+    mask_inactive_tokens,
     naive_chunk_kda,
     naive_chunk_kda_from_cumulative,
     naive_recurrent_kda,
 )
 
-__all__ = [
-    "GatedDeltaRuleOutput",
-    "gated_delta_rule",
+# Note: Lazy Imports
+# The CuTeDSL kernels are an optional dependency (`pip install attn-gym[linear]`);
+# torch- and triton-backed names import eagerly. Names backed by CuTeDSL resolve
+# lazily through PEP 562 module `__getattr__` (the standard scientific-python
+# lazy-import mechanism) so the base package imports without the extra, and a
+# missing backend raises an ImportError naming the install command.
+if TYPE_CHECKING:
+    from attn_gym.linear.kda import causal_conv1d, chunk_kda, register_activation
+
+KDA_OPS = [
+    "bounded_gate_cumsum",
+    "chunk_kda",
     "naive_chunk_kda",
     "naive_chunk_kda_from_cumulative",
     "naive_recurrent_kda",
 ]
+
+GDN_OPS = [
+    "GatedDeltaRuleOutput",
+    "gated_delta_rule",
+]
+
+# Model-agnostic building blocks; they currently ship from the KDA module.
+GENERIC_OPS = [
+    "active_token_mask",
+    "causal_conv1d",
+    "l2norm",
+    "mask_inactive_token_gradients",
+    "mask_inactive_tokens",
+    "register_activation",
+]
+
+__all__ = GDN_OPS + GENERIC_OPS + KDA_OPS  # noqa: PLE0605 -- built from the op groups above
+
+
+def __getattr__(name: str):
+    # Names in __all__ that are not bound eagerly above resolve through
+    # attn_gym.linear.kda; see the lazy-imports note.
+    if name in __all__:
+        return getattr(importlib.import_module("attn_gym.linear.kda"), name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/attn_gym/linear/kda/__init__.py
+++ b/attn_gym/linear/kda/__init__.py
@@ -4,8 +4,12 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""KDA (Kimi Delta Attention) references and optional optimized kernels."""
+"""KDA (Kimi Delta Attention) references and optimized kernels."""
 
+import importlib
+
+from attn_gym.linear.kda.fwd.triton.gate_fwd import bounded_gate_cumsum
+from attn_gym.linear.kda.fwd.triton.l2norm_fwd import l2norm
 from attn_gym.linear.kda.masking import (
     active_token_mask,
     mask_inactive_token_gradients,
@@ -17,11 +21,37 @@ from attn_gym.linear.kda.naive import (
     naive_recurrent_kda,
 )
 
-__all__ = [
-    "active_token_mask",
-    "mask_inactive_token_gradients",
-    "mask_inactive_tokens",
-    "naive_chunk_kda",
-    "naive_chunk_kda_from_cumulative",
-    "naive_recurrent_kda",
-]
+# Note: Lazy Imports (see attn_gym/linear/__init__.py)
+_CUTEDSL_EXPORTS = {
+    "causal_conv1d": "attn_gym.linear.kda.short_conv",
+    "chunk_kda": "attn_gym.linear.kda.fwd.cute",
+    "register_activation": "attn_gym.linear.kda.short_conv",
+}
+
+
+def __getattr__(name: str):
+    module_name = _CUTEDSL_EXPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError as error:
+        raise ImportError(
+            f"{name} requires the optional CuTeDSL backend: pip install attn-gym[linear]"
+        ) from error
+    return getattr(module, name)
+
+
+__all__ = sorted(  # noqa: PLE0605 -- the lazy half comes from _CUTEDSL_EXPORTS
+    [
+        "active_token_mask",
+        "bounded_gate_cumsum",
+        "l2norm",
+        "mask_inactive_token_gradients",
+        "mask_inactive_tokens",
+        "naive_chunk_kda",
+        "naive_chunk_kda_from_cumulative",
+        "naive_recurrent_kda",
+        *_CUTEDSL_EXPORTS,
+    ]
+)

--- a/attn_gym/linear/kda/short_conv/__init__.py
+++ b/attn_gym/linear/kda/short_conv/__init__.py
@@ -6,16 +6,18 @@
 
 """Optimized KDA short-convolution operations."""
 
+from attn_gym.linear.kda.short_conv.activations import register_activation
 from attn_gym.linear.kda.short_conv.cute import (
     ShortConvConfig,
     ShortConvTunedConfig,
-    cute_causal_conv1d_silu,
-    tune_causal_conv1d_silu,
+    causal_conv1d,
+    tune_causal_conv1d,
 )
 
 __all__ = [
     "ShortConvConfig",
     "ShortConvTunedConfig",
-    "cute_causal_conv1d_silu",
-    "tune_causal_conv1d_silu",
+    "causal_conv1d",
+    "register_activation",
+    "tune_causal_conv1d",
 ]

--- a/attn_gym/linear/kda/short_conv/activations.py
+++ b/attn_gym/linear/kda/short_conv/activations.py
@@ -1,0 +1,167 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Named activations fused into the causal convolution epilogue.
+
+``causal_conv1d(..., activation=<name>)`` selects an activation by string, so
+compiled graphs specialize on it like any other static scalar. ``"silu"`` is
+built in and ``None`` applies no activation. Register your own, including
+closure factories in the style of FA4 score mods:
+
+    from cutlass import cute
+
+    from attn_gym.linear import register_activation
+
+
+    def make_softcap(softcap):
+        def softcap_activation(value):
+            return softcap * cute.math.tanh(value / softcap, fastmath=True)
+
+        def softcap_derivative(value):
+            activated = cute.math.tanh(value / softcap, fastmath=True)
+            return 1.0 - activated * activated
+
+        return softcap_activation, softcap_derivative
+
+
+    register_activation("softcap-20", *make_softcap(20.0))
+
+Both functions run at kernel trace time on an FP32 register fragment and may
+use only CuTeDSL expressions (arithmetic and ``cute.math``). ``forward``
+returns the activated fragment; ``derivative`` evaluates
+d(activation)/d(preactivation) from the same preactivation fragment and may
+return a Python scalar. Compiled kernels are cached against the functions'
+content — source text plus current closure and module-global values — so
+captured constants participate in the cache identity and mutating one
+recompiles instead of silently reusing a stale kernel. Two boundaries: imported
+modules are treated as stable library references, so route mutable configuration
+through closures or globals rather than module attributes; and mutating captured
+state between an op's forward and backward is outside the contract, as with any
+state consumed by saved autograd graphs. Closure and
+``__main__``-defined activations cannot cross the parallel compiler-process
+boundary; ``tune_causal_conv1d`` compiles those candidates in-process instead.
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from cutlass import cute
+
+from attn_gym._backends.cute import function_cache_key
+
+
+@cute.jit
+def _silu(value):
+    """Apply SiLU to an FP32 register tensor."""
+    half = value * 0.5
+    return half * cute.math.tanh(half, fastmath=True) + half
+
+
+@cute.jit
+def _silu_derivative(value):
+    """Evaluate the SiLU derivative from its preactivation."""
+    half = value * 0.5
+    tanh_half = cute.math.tanh(half, fastmath=True)
+    return (tanh_half + 1.0) * 0.5 + half * (1.0 - tanh_half * tanh_half) * 0.5
+
+
+def _identity(value):
+    """Pass the preactivation through unchanged."""
+    return value
+
+
+def _identity_derivative(value):
+    """Evaluate the identity derivative; the scalar folds at trace time."""
+    return 1.0
+
+
+@dataclass(frozen=True)
+class Activation:
+    """One registered activation.
+
+    Instances flow into the ``jit_cache``-keyed compile functions, whose cache
+    canonicalizer encodes the two callables by content (source text plus
+    current closure and global values), re-read on every key computation.
+    """
+
+    name: str | None
+    """The registered name; ``None`` is the built-in identity (no activation)."""
+
+    forward: Callable
+    """Trace-time expression applied to the FP32 preactivation fragment."""
+
+    derivative: Callable
+    """Trace-time derivative, evaluated from the same preactivation fragment."""
+
+    @property
+    def crosses_process_boundary(self) -> bool:
+        """Whether the callables can be pickled by reference into a fresh worker."""
+        return all(
+            fn.__module__ != "__main__"
+            and inspect.unwrap(fn).__closure__ is None
+            and "<locals>" not in inspect.unwrap(fn).__qualname__
+            for fn in (self.forward, self.derivative)
+        )
+
+
+_ACTIVATIONS: dict[str | None, Activation] = {}
+
+
+def _activation_identity(name: str | None, activation: Activation) -> tuple:
+    """Compute the content identity, translating cache errors for registration.
+
+    Runs at registration time; per-call resolution is a dictionary lookup.
+    """
+    try:
+        return (
+            function_cache_key(activation.forward),
+            function_cache_key(activation.derivative),
+        )
+    except TypeError as error:
+        raise ValueError(
+            f"activation {name!r} functions have no stable cache identity: {error}"
+        ) from error
+
+
+def register_activation(name: str, forward: Callable, derivative: Callable) -> None:
+    """Register a named activation usable as ``causal_conv1d(activation=name)``.
+
+    See the module docstring for the function contract. Re-registering a name
+    with an identical content identity is a no-op that keeps the original
+    callables; changing the implementation under an existing name raises
+    instead of silently serving stale cached kernels.
+    """
+    if not isinstance(name, str) or not name:
+        raise ValueError(f"activation name must be a nonempty string, got {name!r}")
+    activation = Activation(name, forward, derivative)
+    identity = _activation_identity(name, activation)
+    existing = _ACTIVATIONS.get(name)
+    if existing is not None:
+        if _activation_identity(name, existing) != identity:
+            raise ValueError(
+                f"activation {name!r} is already registered with a different implementation; "
+                "register the new implementation under a new name"
+            )
+        return
+    _ACTIVATIONS[name] = activation
+
+
+def resolve_activation(activation: str | None) -> Activation:
+    """Return the registered activation for a public name argument."""
+    registered = _ACTIVATIONS.get(activation)
+    if registered is None:
+        names = ", ".join(repr(name) for name in _ACTIVATIONS if name is not None)
+        raise ValueError(f"unknown activation {activation!r}; expected None or one of {names}")
+    return registered
+
+
+register_activation("silu", _silu, _silu_derivative)
+_ACTIVATIONS[None] = Activation(None, _identity, _identity_derivative)
+
+__all__ = ["Activation", "register_activation", "resolve_activation"]

--- a/attn_gym/linear/kda/short_conv/cute.py
+++ b/attn_gym/linear/kda/short_conv/cute.py
@@ -29,6 +29,7 @@ from cutlass.cute.nvgpu import cpasync
 
 from attn_gym._backends.cute import ceildiv, compile_tvm_ffi, jit_cache, tune
 from attn_gym._backends.cute.device import upper_bound
+from attn_gym.linear.kda.short_conv.activations import Activation, resolve_activation
 
 
 @dataclass(frozen=True)
@@ -89,21 +90,6 @@ class ShortConvTunedConfig:
             case _:
                 raise ValueError(f"unsupported short-convolution dtype {dtype}")
         return cls(forward, *gradients)
-
-
-@cute.jit
-def _silu(value):
-    """Apply SiLU to an FP32 register tensor."""
-    half = value * 0.5
-    return half * cute.math.tanh(half, fastmath=True) + half
-
-
-@cute.jit
-def _silu_derivative(value):
-    """Evaluate the SiLU derivative from its preactivation."""
-    half = value * 0.5
-    tanh_half = cute.math.tanh(half, fastmath=True)
-    return (tanh_half + 1.0) * 0.5 + half * (1.0 - tanh_half * tanh_half) * 0.5
 
 
 @cute.jit
@@ -2017,11 +2003,15 @@ def _compile_forward(
     width: int,
     dtype: ShortConvDType,
     config: ShortConvConfig,
-    num_sequences: int | None = None,
-    has_initial_state: bool = False,
+    num_sequences: int | None,
+    has_initial_state: bool,
+    activation: Activation,
 ):
     """Compile one static forward specialization."""
-    operation = CausalConv1dSiluForward(batches, tokens, channels, width, config, dtype, _silu)
+    activation_fn = activation.forward
+    operation = CausalConv1dSiluForward(
+        batches, tokens, channels, width, config, dtype, activation_fn
+    )
     return compile_tvm_ffi(
         operation,
         _fake_matrix(dtype, batches * tokens, channels),
@@ -2079,10 +2069,12 @@ def _compile_input_gradient(
     width: int,
     dtype: ShortConvDType,
     config: ShortConvConfig,
-    num_sequences: int | None = None,
-    has_initial_state: bool = False,
+    num_sequences: int | None,
+    has_initial_state: bool,
+    activation: Activation,
 ):
     """Compile one static input-gradient specialization."""
+    derivative = activation.derivative
     use_tma = supports_tma(
         CausalConv1dSiluInputGradientTma,
         config,
@@ -2093,7 +2085,7 @@ def _compile_input_gradient(
         width,
     )
     operation_type = CausalConv1dSiluInputGradientTma if use_tma else CausalConv1dSiluInputGradient
-    operation = operation_type(batches, tokens, channels, width, config, dtype, _silu_derivative)
+    operation = operation_type(batches, tokens, channels, width, config, dtype, derivative)
     return compile_tvm_ffi(
         operation,
         _fake_matrix(dtype, batches * tokens, channels),
@@ -2119,10 +2111,12 @@ def _compile_weight_gradient(
     width: int,
     dtype: ShortConvDType,
     config: ShortConvConfig,
-    num_sequences: int | None = None,
-    has_initial_state: bool = False,
+    num_sequences: int | None,
+    has_initial_state: bool,
+    activation: Activation,
 ):
     """Compile one static weight-gradient specialization."""
+    derivative = activation.derivative
     num_time_blocks = ceildiv(tokens, config.times_per_block)
     partials = cute.runtime.make_fake_compact_tensor(
         Float32,
@@ -2142,7 +2136,7 @@ def _compile_weight_gradient(
         if use_tma
         else CausalConv1dSiluWeightGradientPartials
     )
-    operation = operation_type(batches, tokens, channels, width, config, dtype, _silu_derivative)
+    operation = operation_type(batches, tokens, channels, width, config, dtype, derivative)
     return compile_tvm_ffi(
         operation,
         _fake_matrix(dtype, batches * tokens, channels),
@@ -2169,13 +2163,15 @@ def _compile_initial_state_gradient(
     dtype: ShortConvDType,
     threads: int,
     channels_per_thread: int,
-    num_sequences: int | None = None,
+    num_sequences: int | None,
+    activation: Activation,
 ):
     """Compile one initial-state gradient specialization."""
+    derivative = activation.derivative
     state_sequences = batches if num_sequences is None else num_sequences
     config = ShortConvConfig(threads, channels_per_thread, times_per_block=1)
     operation = CausalConv1dSiluInitialStateGradient(
-        state_sequences, tokens, channels, width, config, dtype, _silu_derivative
+        state_sequences, tokens, channels, width, config, dtype, derivative
     )
     return compile_tvm_ffi(
         operation,
@@ -2244,8 +2240,11 @@ def _launch_forward(
     config: ShortConvConfig,
     cu_seqlens: torch.Tensor | None = None,
     initial_state: torch.Tensor | None = None,
+    *,
+    activation: str | None,
 ) -> torch.Tensor:
     """Allocate and launch the compiled forward specialization."""
+    resolved_activation = resolve_activation(activation)
     x, weight = _aligned(x), _aligned(weight)
     if initial_state is not None:
         initial_state = _aligned(initial_state)
@@ -2262,6 +2261,7 @@ def _launch_forward(
         config,
         None if cu_seqlens is None else cu_seqlens.shape[0] - 1,
         initial_state is not None,
+        resolved_activation,
     )
     compiled(
         x.view(batches * tokens, channels),
@@ -2282,8 +2282,11 @@ def _launch_backward(
     cu_seqlens: torch.Tensor | None = None,
     initial_state: torch.Tensor | None = None,
     compute_initial_state_grad: bool = True,
+    *,
+    activation: str | None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
     """Launch configured gradient kernels and reduce FP32 partials."""
+    resolved_activation = resolve_activation(activation)
     x, weight = _aligned(x), _aligned(weight)
     if initial_state is not None:
         initial_state = _aligned(initial_state)
@@ -2302,6 +2305,7 @@ def _launch_backward(
         input_config,
         num_sequences,
         initial_state is not None,
+        resolved_activation,
     )(
         x.view(batches * tokens, channels),
         weight,
@@ -2332,6 +2336,7 @@ def _launch_backward(
         weight_config,
         num_sequences,
         initial_state is not None,
+        resolved_activation,
     )(
         x.view(batches * tokens, channels),
         weight,
@@ -2350,6 +2355,7 @@ def _launch_backward(
             input_config.threads,
             input_config.channels_per_thread,
             num_sequences,
+            resolved_activation,
         )(
             x.view(batches * tokens, channels),
             weight,
@@ -2421,11 +2427,12 @@ def _candidate_configs(
     )
 
 
-def tune_causal_conv1d_silu(
+def tune_causal_conv1d(
     x: torch.Tensor,
     weight: torch.Tensor,
     grad_output: torch.Tensor,
     *,
+    activation: str | None = None,
     cu_seqlens: torch.Tensor | None = None,
     initial_state: torch.Tensor | None = None,
     forward_configs: Iterable[ShortConvConfig] | None = None,
@@ -2436,11 +2443,15 @@ def tune_causal_conv1d_silu(
     """Compile and benchmark forward, input-gradient, and weight-gradient schedules.
 
     Width is an operation parameter and is specialized but not autotuned. Packed
-    offsets and initial state use the same inputs accepted by the public operation.
-    The returned configs can be passed directly to :func:`cute_causal_conv1d_silu`.
+    offsets, activation, and initial state use the same inputs accepted by the public
+    operation. The returned configs can be passed directly to :func:`causal_conv1d`.
     Tuning uses the shared CuTeDSL ``tune`` flow: cached variants compile in
     parallel and execute sequentially under the vetted Inductor GPU benchmarker.
     """
+    resolved_activation = resolve_activation(activation)
+    # Script-defined (__main__) activations cannot be pickled into the fresh
+    # compiler driver; compile those candidates in this process instead.
+    parallel_compile = parallel_compile and resolved_activation.crosses_process_boundary
     _validate_inputs(x, weight, cu_seqlens, initial_state)
     if grad_output.shape != x.shape or grad_output.dtype != x.dtype:
         raise ValueError("grad_output must match x shape and dtype")
@@ -2487,6 +2498,7 @@ def tune_causal_conv1d_silu(
             config,
             num_sequences,
             kernel_initial_state is not None,
+            resolved_activation,
         ),
         parallel_compile=parallel_compile,
     )
@@ -2514,6 +2526,7 @@ def tune_causal_conv1d_silu(
             config,
             num_sequences,
             kernel_initial_state is not None,
+            resolved_activation,
         ),
         parallel_compile=parallel_compile,
     )
@@ -2556,6 +2569,7 @@ def tune_causal_conv1d_silu(
             config,
             num_sequences,
             kernel_initial_state is not None,
+            resolved_activation,
         ),
         parallel_compile=parallel_compile,
     )
@@ -2569,7 +2583,8 @@ def _config(threads: int, channels_per_thread: int, times_per_block: int) -> Sho
 
 torch.library.define(
     "attn_gym::_cute_short_conv_fwd",
-    "(Tensor x, Tensor weight, Tensor? cu_seqlens=None, Tensor? initial_state=None) -> Tensor",
+    "(Tensor x, Tensor weight, Tensor? cu_seqlens=None, Tensor? initial_state=None,"
+    " *, str? activation=None) -> Tensor",
 )
 
 
@@ -2578,6 +2593,8 @@ def _cute_short_conv_fwd_cuda(
     weight: torch.Tensor,
     cu_seqlens: torch.Tensor | None = None,
     initial_state: torch.Tensor | None = None,
+    *,
+    activation: str | None = None,
 ) -> torch.Tensor:
     """Launch the tuned K3 defaults through the lean production schema."""
     return _launch_forward(
@@ -2586,6 +2603,7 @@ def _cute_short_conv_fwd_cuda(
         ShortConvTunedConfig.default(x.dtype).forward,
         cu_seqlens,
         initial_state,
+        activation=activation,
     )
 
 
@@ -2598,14 +2616,17 @@ def _default_forward_fake(
     weight: torch.Tensor,
     cu_seqlens: torch.Tensor | None = None,
     initial_state: torch.Tensor | None = None,
+    *,
+    activation: str | None = None,
 ) -> torch.Tensor:
-    del weight, cu_seqlens, initial_state
+    del weight, cu_seqlens, initial_state, activation
     return torch.empty_like(x)
 
 
 torch.library.define(
     "attn_gym::_cute_short_conv_bwd",
-    "(Tensor x, Tensor weight, Tensor grad_output, Tensor? cu_seqlens=None) -> (Tensor, Tensor)",
+    "(Tensor x, Tensor weight, Tensor grad_output, Tensor? cu_seqlens=None,"
+    " *, str? activation=None) -> (Tensor, Tensor)",
 )
 
 
@@ -2614,6 +2635,8 @@ def _cute_short_conv_bwd_cuda(
     weight: torch.Tensor,
     grad_output: torch.Tensor,
     cu_seqlens: torch.Tensor | None = None,
+    *,
+    activation: str | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Launch the tuned K3 backward defaults through the lean schema."""
     defaults = ShortConvTunedConfig.default(x.dtype, packed=cu_seqlens is not None)
@@ -2624,6 +2647,7 @@ def _cute_short_conv_bwd_cuda(
         defaults.input_gradient,
         defaults.weight_gradient,
         cu_seqlens,
+        activation=activation,
     )
     return grad_x, grad_weight
 
@@ -2637,8 +2661,10 @@ def _default_backward_fake(
     weight: torch.Tensor,
     grad_output: torch.Tensor,
     cu_seqlens: torch.Tensor | None = None,
+    *,
+    activation: str | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    del grad_output, cu_seqlens
+    del grad_output, cu_seqlens, activation
     return torch.empty_like(x), torch.empty_like(weight)
 
 
@@ -2647,7 +2673,8 @@ torch.library.define(
     "(Tensor x, Tensor weight, Tensor? cu_seqlens, Tensor? initial_state,"
     " int forward_threads, int forward_channels, int forward_times,"
     " int input_threads, int input_channels, int input_times,"
-    " int weight_threads, int weight_channels, int weight_times) -> Tensor",
+    " int weight_threads, int weight_channels, int weight_times,"
+    " *, str? activation=None) -> Tensor",
 )
 
 
@@ -2665,6 +2692,8 @@ def _cute_short_conv_configured_fwd_cuda(
     weight_threads: int,
     weight_channels: int,
     weight_times: int,
+    *,
+    activation: str | None = None,
 ) -> torch.Tensor:
     """Keep the configured CuTeDSL forward launcher behind an opaque operator."""
     del input_threads, input_channels, input_times, weight_threads, weight_channels, weight_times
@@ -2674,6 +2703,7 @@ def _cute_short_conv_configured_fwd_cuda(
         _config(forward_threads, forward_channels, forward_times),
         cu_seqlens,
         initial_state,
+        activation=activation,
     )
 
 
@@ -2697,6 +2727,8 @@ def _forward_fake(
     weight_threads: int,
     weight_channels: int,
     weight_times: int,
+    *,
+    activation: str | None = None,
 ) -> torch.Tensor:
     """Describe forward output metadata without invoking the compiler."""
     del (
@@ -2712,6 +2744,7 @@ def _forward_fake(
         weight_threads,
         weight_channels,
         weight_times,
+        activation,
     )
     return torch.empty_like(x)
 
@@ -2719,7 +2752,8 @@ def _forward_fake(
 _CONFIGURED_BWD_ARGS = (
     "(Tensor x, Tensor weight, Tensor grad_output, Tensor? cu_seqlens, {initial_state},"
     " int input_threads, int input_channels, int input_times,"
-    " int weight_threads, int weight_channels, int weight_times)"
+    " int weight_threads, int weight_channels, int weight_times,"
+    " *, str? activation=None)"
 )
 torch.library.define(
     "attn_gym::_cute_short_conv_configured_bwd",
@@ -2744,6 +2778,8 @@ def _cute_short_conv_configured_bwd_cuda(
     weight_threads: int,
     weight_channels: int,
     weight_times: int,
+    *,
+    activation: str | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Keep the configured first-order backward launchers opaque.
 
@@ -2759,6 +2795,7 @@ def _cute_short_conv_configured_bwd_cuda(
         cu_seqlens,
         initial_state,
         compute_initial_state_grad=False,
+        activation=activation,
     )
     return grad_x, grad_weight
 
@@ -2775,6 +2812,8 @@ def _cute_short_conv_configured_bwd_with_state_grad_cuda(
     weight_threads: int,
     weight_channels: int,
     weight_times: int,
+    *,
+    activation: str | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Compute the configured first-order backward including the state gradient."""
     grad_x, grad_weight, grad_initial_state = _launch_backward(
@@ -2786,6 +2825,7 @@ def _cute_short_conv_configured_bwd_with_state_grad_cuda(
         cu_seqlens,
         initial_state,
         compute_initial_state_grad=True,
+        activation=activation,
     )
     return grad_x, grad_weight, grad_initial_state
 
@@ -2813,6 +2853,8 @@ def _backward_fake(
     weight_threads: int,
     weight_channels: int,
     weight_times: int,
+    *,
+    activation: str | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Describe backward output metadata without invoking the compiler."""
     del (
@@ -2825,6 +2867,7 @@ def _backward_fake(
         weight_threads,
         weight_channels,
         weight_times,
+        activation,
     )
     return torch.empty_like(x), torch.empty_like(weight)
 
@@ -2842,6 +2885,8 @@ def _backward_with_state_grad_fake(
     weight_threads: int,
     weight_channels: int,
     weight_times: int,
+    *,
+    activation: str | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Describe stateful backward output metadata without invoking the compiler."""
     del (
@@ -2853,6 +2898,7 @@ def _backward_with_state_grad_fake(
         weight_threads,
         weight_channels,
         weight_times,
+        activation,
     )
     return torch.empty_like(x), torch.empty_like(weight), torch.empty_like(initial_state)
 
@@ -2874,17 +2920,22 @@ class _ShortConv(torch.autograd.Function):
         weight: torch.Tensor,
         cu_seqlens: torch.Tensor | None,
         initial_state: torch.Tensor | None,
+        activation: str | None,
     ) -> torch.Tensor:
-        output = _forward_op(x, weight, cu_seqlens, initial_state)
+        output = _forward_op(x, weight, cu_seqlens, initial_state, activation=activation)
         ctx.save_for_backward(x, weight, cu_seqlens, initial_state)
+        ctx.activation = activation
         return output
 
     @staticmethod
     @torch.autograd.function.once_differentiable
     def backward(ctx, grad_output: torch.Tensor):
         x, weight, cu_seqlens, initial_state = ctx.saved_tensors
+        activation = ctx.activation
         if initial_state is None:
-            grad_x, grad_weight = _backward_op(x, weight, grad_output, cu_seqlens)
+            grad_x, grad_weight = _backward_op(
+                x, weight, grad_output, cu_seqlens, activation=activation
+            )
             grad_initial_state = None
         else:
             defaults = ShortConvTunedConfig.default(
@@ -2903,14 +2954,26 @@ class _ShortConv(torch.autograd.Function):
             )
             if ctx.needs_input_grad[3]:
                 grad_x, grad_weight, grad_initial_state = _configured_backward_with_state_grad_op(
-                    x, weight, grad_output, cu_seqlens, initial_state, *configs
+                    x,
+                    weight,
+                    grad_output,
+                    cu_seqlens,
+                    initial_state,
+                    *configs,
+                    activation=activation,
                 )
             else:
                 grad_x, grad_weight = _configured_backward_op(
-                    x, weight, grad_output, cu_seqlens, initial_state, *configs
+                    x,
+                    weight,
+                    grad_output,
+                    cu_seqlens,
+                    initial_state,
+                    *configs,
+                    activation=activation,
                 )
                 grad_initial_state = None
-        return grad_x, grad_weight, None, grad_initial_state
+        return grad_x, grad_weight, None, grad_initial_state, None
 
 
 class _ConfiguredShortConv(torch.autograd.Function):
@@ -2921,6 +2984,7 @@ class _ConfiguredShortConv(torch.autograd.Function):
         weight: torch.Tensor,
         cu_seqlens: torch.Tensor | None,
         initial_state: torch.Tensor | None,
+        activation: str | None,
         forward_threads: int,
         forward_channels: int,
         forward_times: int,
@@ -2945,9 +3009,11 @@ class _ConfiguredShortConv(torch.autograd.Function):
             weight_threads,
             weight_channels,
             weight_times,
+            activation=activation,
         )
         # Save inputs and backward specializations for preactivation recomputation.
         ctx.save_for_backward(x, weight, cu_seqlens, initial_state)
+        ctx.activation = activation
         ctx.input_threads = input_threads
         ctx.input_channels = input_channels
         ctx.input_times = input_times
@@ -2971,11 +3037,23 @@ class _ConfiguredShortConv(torch.autograd.Function):
         )
         if initial_state is not None and ctx.needs_input_grad[3]:
             grad_x, grad_weight, grad_initial_state = _configured_backward_with_state_grad_op(
-                x, weight, grad_output, cu_seqlens, initial_state, *configs
+                x,
+                weight,
+                grad_output,
+                cu_seqlens,
+                initial_state,
+                *configs,
+                activation=ctx.activation,
             )
         else:
             grad_x, grad_weight = _configured_backward_op(
-                x, weight, grad_output, cu_seqlens, initial_state, *configs
+                x,
+                weight,
+                grad_output,
+                cu_seqlens,
+                initial_state,
+                *configs,
+                activation=ctx.activation,
             )
             grad_initial_state = None
         return (
@@ -2983,6 +3061,7 @@ class _ConfiguredShortConv(torch.autograd.Function):
             grad_weight,
             None,
             grad_initial_state,
+            None,
             None,
             None,
             None,
@@ -3064,10 +3143,11 @@ def final_conv_state(
     return packed_final_conv_state(x, initial_state, state_length, cu_seqlens)
 
 
-def cute_causal_conv1d_silu(
+def causal_conv1d(
     x: torch.Tensor,
     weight: torch.Tensor,
     *,
+    activation: str | None = None,
     cu_seqlens: torch.Tensor | None = None,
     initial_state: torch.Tensor | None = None,
     return_final_state: bool = False,
@@ -3075,7 +3155,7 @@ def cute_causal_conv1d_silu(
     input_grad_config: ShortConvConfig | None = None,
     weight_grad_config: ShortConvConfig | None = None,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-    """Apply causal depthwise convolution and SiLU with CuTeDSL.
+    """Apply causal depthwise convolution with an optional fused activation.
 
     Width is inferred from ``weight.shape[1]`` and compile-time specialized.
     Schedule fields control register shapes, vector partitioning, unrolled loops,
@@ -3086,6 +3166,11 @@ def cute_causal_conv1d_silu(
             Each batch row is convolved as an independent sequence.
         weight: Contiguous depthwise weights with shape ``[C, W]`` matching
             ``x`` dtype and device.
+        activation: Optional activation fused into the convolution epilogue and
+            recomputed by the backward kernels. ``None`` applies no activation;
+            ``"silu"`` is built in and :func:`register_activation` adds custom
+            names. The name is an ordinary string argument, so compiled graphs
+            specialize on it like any other static scalar.
         cu_seqlens: Optional contiguous CUDA int32 offsets delimiting independent
             sequences in a packed ``[1, T, C]`` input. Offsets must be nondecreasing,
             begin at zero, and end at an active endpoint ``L <= T``; repeated offsets
@@ -3105,6 +3190,7 @@ def cute_causal_conv1d_silu(
         parameter, state, and final-state values exclude the inactive suffix. When
         ``return_final_state`` is true, also returns ``[N, W - 1, C]`` history.
     """
+    resolve_activation(activation)
     _validate_inputs(x, weight, cu_seqlens, initial_state)
     channels = x.shape[2]
     kernel_initial_state = None if weight.shape[1] == 1 else initial_state
@@ -3132,13 +3218,14 @@ def cute_causal_conv1d_silu(
         and input_grad == default_input_grad
         and weight_grad == default_weight_grad
     ):
-        output = _ShortConv.apply(x, weight, cu_seqlens, kernel_initial_state)
+        output = _ShortConv.apply(x, weight, cu_seqlens, kernel_initial_state, activation)
     else:
         output = _ConfiguredShortConv.apply(
             x,
             weight,
             cu_seqlens,
             kernel_initial_state,
+            activation,
             forward.threads,
             forward.channels_per_thread,
             forward.times_per_block,
@@ -3164,6 +3251,6 @@ def cute_causal_conv1d_silu(
 __all__ = [
     "ShortConvConfig",
     "ShortConvTunedConfig",
-    "cute_causal_conv1d_silu",
-    "tune_causal_conv1d_silu",
+    "causal_conv1d",
+    "tune_causal_conv1d",
 ]

--- a/examples/kda_training.py
+++ b/examples/kda_training.py
@@ -57,7 +57,7 @@ from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd import _chunk_kda
 from attn_gym.linear.kda.fwd.triton.gate_fwd import _bounded_gate_cumsum
 from attn_gym.linear.kda.fwd.triton.l2norm_fwd import l2norm
 from attn_gym.linear.kda.naive import gate_fwd_ref, l2norm_fwd_ref
-from attn_gym.linear.kda.short_conv import cute_causal_conv1d_silu
+from attn_gym.linear.kda.short_conv import causal_conv1d
 
 Backend = Literal["reference", "fused"]
 
@@ -340,9 +340,10 @@ class KDAAttention(nn.Module):
             initial_state = initial_state.to(device=qkv.device, dtype=qkv.dtype).contiguous()
 
         if self.backend == "fused":
-            result = cute_causal_conv1d_silu(
+            result = causal_conv1d(
                 qkv,
                 self.qkv_conv1d.weight[:, 0].to(self.compute_dtype),
+                activation="silu",
                 initial_state=initial_state,
                 cu_seqlens=cu_seqlens,
                 return_final_state=return_final_state,

--- a/test/test_kda_short_conv_cute.py
+++ b/test/test_kda_short_conv_cute.py
@@ -1,6 +1,8 @@
 """Correctness and integration tests for the CuTeDSL KDA short convolution."""
 
+import sys
 from itertools import pairwise
+from types import FunctionType
 
 import pytest
 import torch
@@ -9,6 +11,7 @@ import torch.nn.functional as F
 pytest.importorskip("cutlass")
 
 import attn_gym.linear.kda.short_conv.cute as cute_backend
+from attn_gym.linear.kda.short_conv import activations
 from attn_gym.linear.kda.short_conv.cute import (
     ShortConvConfig,
     ShortConvTunedConfig,
@@ -18,8 +21,8 @@ from attn_gym.linear.kda.short_conv.cute import (
     _configured_backward_with_state_grad_op,
     _configured_forward_op,
     _forward_op,
-    cute_causal_conv1d_silu,
-    tune_causal_conv1d_silu,
+    causal_conv1d,
+    tune_causal_conv1d,
 )
 
 pytestmark = pytest.mark.skipif(
@@ -40,9 +43,13 @@ def _inputs(
     return x.requires_grad_(), weight.requires_grad_()
 
 
-def _reference(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+def _plain_conv_reference(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
     padded = F.pad(x.transpose(1, 2), (weight.shape[1] - 1, 0))
-    return F.silu(F.conv1d(padded, weight[:, None], groups=x.shape[-1])).transpose(1, 2)
+    return F.conv1d(padded, weight[:, None], groups=x.shape[-1]).transpose(1, 2)
+
+
+def _reference(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    return F.silu(_plain_conv_reference(x, weight))
 
 
 def _packed_reference(
@@ -89,7 +96,7 @@ def test_short_conv_forward_and_backward_match_pytorch(width: int):
     x, weight = _inputs(width=width)
     grad_output = torch.randn_like(x)
 
-    actual = cute_causal_conv1d_silu(x, weight)
+    actual = causal_conv1d(x, weight, activation="silu")
     expected = _reference(x, weight)
     torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
 
@@ -165,7 +172,7 @@ def test_short_conv_tma_rejects_partial_channel_tiles():
             4,
             config,
             cute_backend.SHORT_CONV_DTYPES[torch.bfloat16],
-            cute_backend._silu_derivative,
+            activations._silu_derivative,
         )
 
 
@@ -196,7 +203,7 @@ def test_short_conv_supported_dtypes_match_high_precision_reference(
     )
     grad_output = torch.randn_like(x)
 
-    actual = cute_causal_conv1d_silu(x, weight, initial_state=initial_state)
+    actual = causal_conv1d(x, weight, activation="silu", initial_state=initial_state)
     reference_input = torch.cat((initial_state, x), dim=1)
     expected = F.silu(
         F.conv1d(reference_input.transpose(1, 2), weight[:, None], groups=12)
@@ -252,7 +259,7 @@ def test_short_conv_defaults_support_any_positive_channel_count(channels: int):
     x, weight = _inputs(tokens=19, channels=channels)
     grad_output = torch.randn_like(x)
 
-    actual = cute_causal_conv1d_silu(x, weight)
+    actual = causal_conv1d(x, weight, activation="silu")
     expected = _reference(x, weight)
     torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
 
@@ -261,8 +268,10 @@ def test_short_conv_defaults_support_any_positive_channel_count(channels: int):
     torch.testing.assert_close(actual_gradients[0], expected_gradients[0], rtol=3e-2, atol=3e-2)
     torch.testing.assert_close(actual_gradients[1], expected_gradients[1], rtol=3e-2, atol=3e-1)
 
-    compiled = torch.compile(cute_causal_conv1d_silu, fullgraph=True)
-    torch.testing.assert_close(compiled(x, weight), expected, rtol=2e-2, atol=2e-2)
+    compiled = torch.compile(causal_conv1d, fullgraph=True)
+    torch.testing.assert_close(
+        compiled(x, weight, activation="silu"), expected, rtol=2e-2, atol=2e-2
+    )
 
     for kind in ("forward", "input_gradient", "weight_gradient"):
         candidates = _candidate_configs(kind, channels)
@@ -285,7 +294,7 @@ def test_short_conv_tma_backward_matches_batched_reference(
     x, weight = _inputs(tokens=tokens, channels=256, width=width, batch=2, dtype=dtype)
     grad_output = torch.randn_like(x)
 
-    actual = cute_causal_conv1d_silu(x, weight)
+    actual = causal_conv1d(x, weight, activation="silu")
     expected = _reference(x, weight)
     actual_gradients = torch.autograd.grad(actual, (x, weight), grad_output)
     expected_gradients = torch.autograd.grad(expected, (x, weight), grad_output)
@@ -304,6 +313,7 @@ def test_short_conv_tma_backward_matches_batched_reference(
         grad_output,
         fallback_input,
         fallback_weight,
+        activation="silu",
     )
 
     tolerance = 1e-4 if dtype == torch.float32 else 3e-2
@@ -347,6 +357,7 @@ def test_short_conv_tma_input_gradient_wider_than_time_tile():
         grad_output,
         defaults.input_gradient,
         ShortConvConfig(128, 4, 128),
+        activation="silu",
     )[0]
 
     torch.testing.assert_close(actual_dx, expected_dx, rtol=3e-2, atol=3e-2)
@@ -364,7 +375,7 @@ def test_short_conv_packed_tma_backward_matches_fallback(tokens: int):
         dtype=torch.int32,
     )
 
-    actual = cute_causal_conv1d_silu(x, weight, cu_seqlens=cu_seqlens)
+    actual = causal_conv1d(x, weight, activation="silu", cu_seqlens=cu_seqlens)
     expected = _packed_reference(x, weight, cu_seqlens)
     actual_gradients = torch.autograd.grad(actual, (x, weight), grad_output)
     expected_gradients = torch.autograd.grad(expected, (x, weight), grad_output)
@@ -375,6 +386,7 @@ def test_short_conv_packed_tma_backward_matches_fallback(tokens: int):
         ShortConvConfig(128, 4, 10),
         ShortConvConfig(64, 4, 128),
         cu_seqlens,
+        activation="silu",
     )
 
     torch.testing.assert_close(actual, expected, rtol=3e-2, atol=3e-2)
@@ -395,7 +407,7 @@ def test_short_conv_dense_stateful_tma_backward_matches_reference():
     reference_state = initial_state.detach().clone().requires_grad_()
     grad_output = torch.randn_like(x)
 
-    actual = cute_causal_conv1d_silu(x, weight, initial_state=initial_state)
+    actual = causal_conv1d(x, weight, activation="silu", initial_state=initial_state)
     expected_input = torch.cat((reference_state, x), dim=1)
     expected = F.silu(
         F.conv1d(expected_input.transpose(1, 2), weight[:, None], groups=256)
@@ -435,9 +447,10 @@ def test_short_conv_packed_stateful_tma_backward_matches_reference_and_fallback(
     )
     reference_state = initial_state.detach().clone().requires_grad_()
 
-    actual = cute_causal_conv1d_silu(
+    actual = causal_conv1d(
         x,
         weight,
+        activation="silu",
         cu_seqlens=cu_seqlens,
         initial_state=initial_state,
     )
@@ -460,6 +473,7 @@ def test_short_conv_packed_stateful_tma_backward_matches_reference_and_fallback(
         ShortConvConfig(64, 4, 128),
         cu_seqlens,
         initial_state,
+        activation="silu",
     )
 
     torch.testing.assert_close(actual, expected, rtol=3e-2, atol=3e-2)
@@ -538,9 +552,10 @@ def test_short_conv_dynamic_active_endpoint_ignores_nan_suffix(
         cu_seqlens,
         expected_state,
     )
-    actual_output, actual_final = cute_causal_conv1d_silu(
+    actual_output, actual_final = causal_conv1d(
         x,
         weight,
+        activation="silu",
         cu_seqlens=cu_seqlens,
         initial_state=initial_state,
         return_final_state=True,
@@ -603,7 +618,7 @@ def test_short_conv_batched_forward_and_backward_match_pytorch():
     grad_output = torch.randn_like(x)
     weight_config = ShortConvConfig(128, 4, 8)
 
-    actual = cute_causal_conv1d_silu(x, weight, weight_grad_config=weight_config)
+    actual = causal_conv1d(x, weight, activation="silu", weight_grad_config=weight_config)
     expected = _reference(x, weight)
     torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
 
@@ -625,7 +640,7 @@ def test_short_conv_packed_forward_and_backward_match_independent_sequences(widt
     )
     grad_output = torch.randn_like(x)
 
-    actual = cute_causal_conv1d_silu(x, weight, cu_seqlens=cu_seqlens)
+    actual = causal_conv1d(x, weight, activation="silu", cu_seqlens=cu_seqlens)
     expected = _packed_reference(x, weight, cu_seqlens)
     torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
 
@@ -639,9 +654,10 @@ def test_short_conv_packed_final_state_uses_implicit_zero_history():
     """Return packed history for empty and short sequences without an initial state."""
     x, weight = _inputs(tokens=7, channels=12, width=5)
     cu_seqlens = torch.tensor([0, 0, 1, 3, 7], device="cuda", dtype=torch.int32)
-    actual, actual_final = cute_causal_conv1d_silu(
+    actual, actual_final = causal_conv1d(
         x,
         weight,
+        activation="silu",
         cu_seqlens=cu_seqlens,
         return_final_state=True,
     )
@@ -667,9 +683,10 @@ def test_short_conv_packed_state_forward_and_backward(width: int):
     )
     expected_state = initial_state.detach().clone().requires_grad_()
 
-    actual, actual_final = cute_causal_conv1d_silu(
+    actual, actual_final = causal_conv1d(
         x,
         weight,
+        activation="silu",
         cu_seqlens=cu_seqlens,
         initial_state=initial_state,
         return_final_state=True,
@@ -713,7 +730,7 @@ def test_short_conv_accepts_misaligned_contiguous_storage():
     assert x.is_contiguous() and x.data_ptr() % 16 != 0
     assert weight.is_contiguous() and weight.data_ptr() % 16 != 0
 
-    actual = cute_causal_conv1d_silu(x, weight)
+    actual = causal_conv1d(x, weight, activation="silu")
     expected = _reference(x, weight)
     torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
 
@@ -734,10 +751,11 @@ def test_short_conv_explicit_config_and_tuning_flow():
     forward = ShortConvConfig(128, 2, 8)
     input_gradient = ShortConvConfig(128, 2, 10)
     weight_gradient = ShortConvConfig(128, 2, 128)
-    selected = tune_causal_conv1d_silu(
+    selected = tune_causal_conv1d(
         x,
         weight,
         grad_output,
+        activation="silu",
         initial_state=initial_state,
         forward_configs=(forward,),
         input_grad_configs=(input_gradient,),
@@ -747,9 +765,10 @@ def test_short_conv_explicit_config_and_tuning_flow():
     assert selected.forward == forward
     assert selected.input_gradient == input_gradient
     assert selected.weight_gradient == weight_gradient
-    actual = cute_causal_conv1d_silu(
+    actual = causal_conv1d(
         x,
         weight,
+        activation="silu",
         initial_state=initial_state,
         forward_config=selected.forward,
         input_grad_config=selected.input_gradient,
@@ -762,9 +781,10 @@ def test_short_conv_explicit_config_and_tuning_flow():
     torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
 
     compiled = torch.compile(
-        lambda x, weight, initial_state: cute_causal_conv1d_silu(
+        lambda x, weight, initial_state: causal_conv1d(
             x,
             weight,
+            activation="silu",
             initial_state=initial_state,
             forward_config=selected.forward,
             input_grad_config=selected.input_gradient,
@@ -858,7 +878,7 @@ def test_short_conv_constant_history_skips_its_gradient_kernel(monkeypatch):
         raise AssertionError("initial-state-gradient kernel should not be compiled")
 
     monkeypatch.setattr(cute_backend, "_compile_initial_state_gradient", fail_compile)
-    output = cute_causal_conv1d_silu(x, weight, initial_state=initial_state)
+    output = causal_conv1d(x, weight, activation="silu", initial_state=initial_state)
     torch.autograd.grad(output, (x, weight), torch.randn_like(output))
 
 
@@ -867,10 +887,10 @@ def test_short_conv_fullgraph_forward_and_backward():
     x, weight = _inputs(batch=2)
     grad_output = torch.randn_like(x)
 
-    expected_output = cute_causal_conv1d_silu(x, weight)
+    expected_output = causal_conv1d(x, weight, activation="silu")
     expected = torch.autograd.grad(expected_output, (x, weight), grad_output)
-    compiled = torch.compile(cute_causal_conv1d_silu, fullgraph=True)
-    actual_output = compiled(x, weight)
+    compiled = torch.compile(causal_conv1d, fullgraph=True)
+    actual_output = compiled(x, weight, activation="silu")
     actual = torch.autograd.grad(actual_output, (x, weight), grad_output)
     torch.testing.assert_close(actual[0], expected[0], rtol=3e-2, atol=3e-2)
     torch.testing.assert_close(actual[1], expected[1], rtol=3e-2, atol=2e-1)
@@ -892,9 +912,10 @@ def test_short_conv_packed_stateful_fullgraph_forward_and_backward():
     grad_final = torch.randn_like(initial_state)
 
     def operation(x, weight, initial_state, cu_seqlens):
-        return cute_causal_conv1d_silu(
+        return causal_conv1d(
             x,
             weight,
+            activation="silu",
             cu_seqlens=cu_seqlens,
             initial_state=initial_state,
             return_final_state=True,
@@ -934,15 +955,16 @@ def test_short_conv_width_one_preserves_empty_state_gradients():
         dtype=torch.bfloat16,
         requires_grad=True,
     )
-    output = cute_causal_conv1d_silu(x, weight, initial_state=initial_state)
+    output = causal_conv1d(x, weight, activation="silu", initial_state=initial_state)
     (grad_initial_state,) = torch.autograd.grad(output.sum(), (initial_state,))
     assert grad_initial_state.shape == initial_state.shape
 
     packed_x, packed_weight = _inputs(tokens=7, width=1)
     cu_seqlens = torch.tensor([0, 0, 2, 7], device="cuda", dtype=torch.int32)
-    _, final_state = cute_causal_conv1d_silu(
+    _, final_state = causal_conv1d(
         packed_x,
         packed_weight,
+        activation="silu",
         cu_seqlens=cu_seqlens,
         return_final_state=True,
     )
@@ -961,9 +983,10 @@ def test_short_conv_final_state_preserves_unused_initial_state_gradient():
         dtype=torch.bfloat16,
         requires_grad=True,
     )
-    _, final_state = cute_causal_conv1d_silu(
+    _, final_state = causal_conv1d(
         x,
         weight,
+        activation="silu",
         initial_state=initial_state,
         return_final_state=True,
     )
@@ -990,7 +1013,7 @@ def test_short_conv_initial_state_obeys_autograd_versioning():
         device="cuda",
         dtype=torch.bfloat16,
     )
-    output = cute_causal_conv1d_silu(x, weight, initial_state=initial_state)
+    output = causal_conv1d(x, weight, activation="silu", initial_state=initial_state)
 
     with torch.no_grad():
         initial_state.add_(0.25)
@@ -1002,7 +1025,7 @@ def test_short_conv_packed_offsets_obey_autograd_versioning():
     """Reject sequence-boundary mutation between forward and backward."""
     x, weight = _inputs(tokens=31)
     cu_seqlens = torch.tensor([0, 3, 11, 31], device="cuda", dtype=torch.int32)
-    output = cute_causal_conv1d_silu(x, weight, cu_seqlens=cu_seqlens)
+    output = causal_conv1d(x, weight, activation="silu", cu_seqlens=cu_seqlens)
 
     with torch.no_grad():
         cu_seqlens[1] = 4
@@ -1014,14 +1037,14 @@ def test_short_conv_cuda_graph_replay():
     """Capture the compiled launchers and replay with changed input values."""
     x, weight = _inputs()
     grad_output = torch.randn_like(x)
-    _forward_op(x, weight)
-    _backward_op(x, weight, grad_output)
+    _forward_op(x, weight, activation="silu")
+    _backward_op(x, weight, grad_output, activation="silu")
     torch.cuda.synchronize()
 
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
-        captured_output = _forward_op(x, weight)
-        captured_gradients = _backward_op(x, weight, grad_output)
+        captured_output = _forward_op(x, weight, activation="silu")
+        captured_gradients = _backward_op(x, weight, grad_output, activation="silu")
 
     graph.replay()
     first_output = captured_output.clone()
@@ -1033,8 +1056,8 @@ def test_short_conv_cuda_graph_replay():
 
     assert not torch.equal(captured_output, first_output)
     assert not torch.equal(captured_gradients[0], first_gradients[0])
-    expected_output = _forward_op(x, weight)
-    expected_gradients = _backward_op(x, weight, grad_output)
+    expected_output = _forward_op(x, weight, activation="silu")
+    expected_gradients = _backward_op(x, weight, grad_output, activation="silu")
     torch.testing.assert_close(captured_output, expected_output, rtol=0, atol=0)
     torch.testing.assert_close(captured_gradients[0], expected_gradients[0], rtol=0, atol=0)
     torch.testing.assert_close(captured_gradients[1], expected_gradients[1], rtol=0, atol=0)
@@ -1053,17 +1076,17 @@ def test_short_conv_packed_stateful_cuda_graph_replays_boundaries_and_history():
         dtype=torch.bfloat16,
     )
     config = (128, 4, 10, 128, 4, 128)
-    _forward_op(x, weight, cu_seqlens, initial_state)
+    _forward_op(x, weight, cu_seqlens, initial_state, activation="silu")
     _configured_backward_with_state_grad_op(
-        x, weight, grad_output, cu_seqlens, initial_state, *config
+        x, weight, grad_output, cu_seqlens, initial_state, *config, activation="silu"
     )
     torch.cuda.synchronize()
 
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
-        captured_output = _forward_op(x, weight, cu_seqlens, initial_state)
+        captured_output = _forward_op(x, weight, cu_seqlens, initial_state, activation="silu")
         captured_gradients = _configured_backward_with_state_grad_op(
-            x, weight, grad_output, cu_seqlens, initial_state, *config
+            x, weight, grad_output, cu_seqlens, initial_state, *config, activation="silu"
         )
 
     active_tokens = 23
@@ -1077,9 +1100,9 @@ def test_short_conv_packed_stateful_cuda_graph_replays_boundaries_and_history():
     graph.replay()
     torch.cuda.synchronize()
 
-    expected_output = _forward_op(x, weight, cu_seqlens, initial_state)
+    expected_output = _forward_op(x, weight, cu_seqlens, initial_state, activation="silu")
     expected_gradients = _configured_backward_with_state_grad_op(
-        x, weight, grad_output, cu_seqlens, initial_state, *config
+        x, weight, grad_output, cu_seqlens, initial_state, *config, activation="silu"
     )
     torch.testing.assert_close(
         captured_output[:, :active_tokens], expected_output[:, :active_tokens], rtol=0, atol=0
@@ -1124,14 +1147,14 @@ def test_short_conv_packed_stateful_tma_cuda_graph_replays_boundaries_and_histor
         defaults.weight_gradient.times_per_block,
     )
     _configured_backward_with_state_grad_op(
-        x, weight, grad_output, cu_seqlens, initial_state, *config
+        x, weight, grad_output, cu_seqlens, initial_state, *config, activation="silu"
     )
     torch.cuda.synchronize()
 
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
         captured_gradients = _configured_backward_with_state_grad_op(
-            x, weight, grad_output, cu_seqlens, initial_state, *config
+            x, weight, grad_output, cu_seqlens, initial_state, *config, activation="silu"
         )
 
     first_gradients = tuple(gradient.clone() for gradient in captured_gradients)
@@ -1155,7 +1178,7 @@ def test_short_conv_packed_stateful_tma_cuda_graph_replays_boundaries_and_histor
     )
     assert not torch.equal(captured_gradients[1], first_gradients[1])
     expected_gradients = _configured_backward_with_state_grad_op(
-        x, weight, grad_output, cu_seqlens, initial_state, *config
+        x, weight, grad_output, cu_seqlens, initial_state, *config, activation="silu"
     )
     torch.testing.assert_close(
         captured_gradients[0][:, :active_tokens],
@@ -1169,3 +1192,242 @@ def test_short_conv_packed_stateful_tma_cuda_graph_replays_boundaries_and_histor
         strict=True,
     ):
         torch.testing.assert_close(actual_gradient, expected_gradient, rtol=0, atol=0)
+
+
+def test_short_conv_identity_activation_matches_plain_conv():
+    """Run the None-activation kernels against an activation-free reference."""
+    torch.manual_seed(5)
+    x, weight = _inputs()
+    grad_output = torch.randn_like(x)
+
+    actual = causal_conv1d(x, weight)
+    expected = _plain_conv_reference(x, weight)
+    torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
+
+    actual_gradients = torch.autograd.grad(actual, (x, weight), grad_output)
+    expected_gradients = torch.autograd.grad(expected, (x, weight), grad_output)
+    torch.testing.assert_close(actual_gradients[0], expected_gradients[0], rtol=3e-2, atol=3e-2)
+    torch.testing.assert_close(actual_gradients[1], expected_gradients[1], rtol=3e-2, atol=3e-1)
+
+
+def test_short_conv_identity_activation_packed_stateful():
+    """Check the identity derivative through the packed stateful gradient kernels."""
+    torch.manual_seed(6)
+    x, weight = _inputs(width=4)
+    cu_seqlens = torch.tensor([0, 2, 7, 17], device="cuda", dtype=torch.int32)
+    initial_state = torch.randn(
+        3, weight.shape[1] - 1, x.shape[2], device="cuda", dtype=torch.bfloat16
+    ).requires_grad_()
+    grad_output = torch.randn_like(x)
+
+    actual = causal_conv1d(x, weight, cu_seqlens=cu_seqlens, initial_state=initial_state)
+    outputs = []
+    for sequence, (start, end) in enumerate(pairwise(cu_seqlens.cpu().tolist())):
+        extended = torch.cat((initial_state[sequence : sequence + 1], x[:, start:end]), dim=1)
+        outputs.append(
+            F.conv1d(extended.transpose(1, 2), weight[:, None], groups=x.shape[-1]).transpose(1, 2)
+        )
+    expected = torch.cat(outputs, dim=1)
+    torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
+
+    leaves = (x, weight, initial_state)
+    actual_gradients = torch.autograd.grad(actual, leaves, grad_output)
+    expected_gradients = torch.autograd.grad(expected, leaves, grad_output)
+    for actual_gradient, expected_gradient in zip(
+        actual_gradients, expected_gradients, strict=True
+    ):
+        torch.testing.assert_close(actual_gradient, expected_gradient, rtol=3e-2, atol=3e-1)
+
+
+_ACTIVATION_GLOBAL_SCALE = 2.0
+
+
+def _globally_scaled_activation(value):
+    return value * _ACTIVATION_GLOBAL_SCALE
+
+
+def _globally_scaled_derivative(value):
+    return _ACTIVATION_GLOBAL_SCALE
+
+
+def _tanh_activation(value):
+    from cutlass import cute
+
+    return cute.math.tanh(value, fastmath=True)
+
+
+def _tanh_activation_derivative(value):
+    from cutlass import cute
+
+    tanh_value = cute.math.tanh(value, fastmath=True)
+    return 1.0 - tanh_value * tanh_value
+
+
+def test_short_conv_registered_custom_activation():
+    """Fuse a user-registered CuTeDSL activation and validate both gradients."""
+    activations.register_activation("tanh", _tanh_activation, _tanh_activation_derivative)
+    torch.manual_seed(7)
+    x, weight = _inputs()
+    grad_output = torch.randn_like(x)
+
+    actual = causal_conv1d(x, weight, activation="tanh")
+    expected = torch.tanh(_plain_conv_reference(x, weight))
+    torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
+
+    actual_gradients = torch.autograd.grad(actual, (x, weight), grad_output)
+    expected_gradients = torch.autograd.grad(expected, (x, weight), grad_output)
+    torch.testing.assert_close(actual_gradients[0], expected_gradients[0], rtol=3e-2, atol=3e-2)
+    torch.testing.assert_close(actual_gradients[1], expected_gradients[1], rtol=3e-2, atol=3e-1)
+
+
+def _make_scaled(scale: float):
+    def scaled_activation(value):
+        return value * scale
+
+    def scaled_derivative(value):
+        return scale
+
+    return scaled_activation, scaled_derivative
+
+
+def test_short_conv_activation_registration_contract():
+    """Reject unknown names, invalid names, and silent re-registration."""
+    x, weight = _inputs()
+    with pytest.raises(ValueError, match="unknown activation"):
+        causal_conv1d(x, weight, activation="missing")
+    with pytest.raises(ValueError, match="nonempty string"):
+        activations.register_activation("", _tanh_activation, _tanh_activation_derivative)
+    # Distinct function objects with identical sources may reuse a name; different
+    # sources must not, so a stale cached kernel can never be served silently.
+    equivalent_forward = FunctionType(_tanh_activation.__code__, _tanh_activation.__globals__)
+    equivalent_derivative = FunctionType(
+        _tanh_activation_derivative.__code__, _tanh_activation_derivative.__globals__
+    )
+    activations.register_activation("tanh-contract", _tanh_activation, _tanh_activation_derivative)
+    activations.register_activation("tanh-contract", equivalent_forward, equivalent_derivative)
+    # The no-op keeps the original, importable callables in the registry.
+    assert activations._ACTIVATIONS["tanh-contract"].forward is _tanh_activation
+    # Closure re-registration is a no-op only for equal captured values.
+    activations.register_activation("scaled-contract", *_make_scaled(2.0))
+    activations.register_activation("scaled-contract", *_make_scaled(2.0))
+    with pytest.raises(ValueError, match="different implementation"):
+        activations.register_activation("scaled-contract", *_make_scaled(3.0))
+    # Functions without retrievable source have no stable cache identity.
+    namespace: dict = {}
+    exec("def sourceless(value):\n    return value", namespace)  # noqa: S102 -- sourceless fixture
+    with pytest.raises(ValueError, match="no stable cache identity"):
+        activations.register_activation(
+            "sourceless", namespace["sourceless"], namespace["sourceless"]
+        )
+    with pytest.raises(ValueError, match="different implementation"):
+        activations.register_activation(
+            "tanh-contract", activations._silu, activations._silu_derivative
+        )
+
+
+def test_short_conv_closure_activations_key_on_captured_values():
+    """Two factory instances with different captures compile different kernels."""
+    activations.register_activation("scaled-two", *_make_scaled(2.0))
+    activations.register_activation("scaled-three", *_make_scaled(3.0))
+    torch.manual_seed(9)
+    x, weight = _inputs(channels=6, width=3)
+    grad_output = torch.randn_like(x)
+
+    doubled = causal_conv1d(x, weight, activation="scaled-two")
+    tripled = causal_conv1d(x, weight, activation="scaled-three")
+    expected = _plain_conv_reference(x, weight)
+    torch.testing.assert_close(doubled, expected * 2.0, rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(tripled, expected * 3.0, rtol=2e-2, atol=2e-2)
+
+    doubled_gradients = torch.autograd.grad(doubled, (x, weight), grad_output)
+    expected_gradients = torch.autograd.grad(expected * 2.0, (x, weight), grad_output)
+    torch.testing.assert_close(doubled_gradients[0], expected_gradients[0], rtol=3e-2, atol=3e-2)
+    torch.testing.assert_close(doubled_gradients[1], expected_gradients[1], rtol=3e-2, atol=3e-1)
+
+
+def test_short_conv_global_mutation_recompiles():
+    """Mutating a referenced module global must recompile, not reuse stale kernels."""
+    module = sys.modules[__name__]
+    activations.register_activation(
+        "global-scaled", _globally_scaled_activation, _globally_scaled_derivative
+    )
+    torch.manual_seed(10)
+    x, weight = _inputs(channels=6, width=3)
+    expected = _plain_conv_reference(x, weight)
+
+    original = module._ACTIVATION_GLOBAL_SCALE
+    try:
+        doubled = causal_conv1d(x, weight, activation="global-scaled")
+        torch.testing.assert_close(doubled, expected * original, rtol=2e-2, atol=2e-2)
+        module._ACTIVATION_GLOBAL_SCALE = original + 1.0
+        rescaled = causal_conv1d(x, weight, activation="global-scaled")
+        torch.testing.assert_close(rescaled, expected * (original + 1.0), rtol=2e-2, atol=2e-2)
+    finally:
+        module._ACTIVATION_GLOBAL_SCALE = original
+
+
+def test_tune_compiles_serially_for_script_defined_activations(monkeypatch):
+    """__main__ and closure callables cannot cross the compiler-process boundary."""
+    captured = []
+
+    def fake_tune(configs, compile_fn, launch, *, compile_call=None, parallel_compile=True):
+        captured.append(parallel_compile)
+        return next(iter(configs))
+
+    monkeypatch.setattr(cute_backend, "tune", fake_tune)
+    script_forward = FunctionType(_tanh_activation.__code__, _tanh_activation.__globals__)
+    script_derivative = FunctionType(
+        _tanh_activation_derivative.__code__, _tanh_activation_derivative.__globals__
+    )
+    script_forward.__module__ = script_derivative.__module__ = "__main__"
+    activations.register_activation("script-scoped", script_forward, script_derivative)
+
+    x, weight = _inputs(channels=6, width=3)
+    config = ShortConvConfig(128, 2, 8)
+    selected = tune_causal_conv1d(
+        x,
+        weight,
+        torch.randn_like(x),
+        activation="script-scoped",
+        forward_configs=(config,),
+        input_grad_configs=(config,),
+        weight_grad_configs=(config,),
+    )
+    assert selected == ShortConvTunedConfig(config, config, config)
+    assert captured == [False, False, False]
+
+    captured.clear()
+    activations.register_activation("closure-scoped", *_make_scaled(4.0))
+    tune_causal_conv1d(
+        x,
+        weight,
+        torch.randn_like(x),
+        activation="closure-scoped",
+        forward_configs=(config,),
+        input_grad_configs=(config,),
+        weight_grad_configs=(config,),
+    )
+    assert captured == [False, False, False]
+
+
+def _defaulted_activation(value, options={"scale": 2.0}):  # noqa: B006 -- mutable default fixture
+    return value * options["scale"]
+
+
+def test_function_cache_key_covers_defaults_and_nested_functions():
+    """Pin the key surface: mutable defaults change keys; nested fns stay serial."""
+    from attn_gym._backends.cute import function_cache_key
+
+    before = function_cache_key(_defaulted_activation)
+    _defaulted_activation.__defaults__[0]["scale"] = 3.0
+    try:
+        assert function_cache_key(_defaulted_activation) != before
+    finally:
+        _defaulted_activation.__defaults__[0]["scale"] = 2.0
+
+    def nested_activation(value, scale=2.0):
+        return value * scale
+
+    # No closure, real module, but <locals>: must not claim process crossing.
+    activation = activations.Activation("nested", nested_activation, nested_activation)
+    assert not activation.crosses_process_boundary

--- a/test/test_kda_training_example.py
+++ b/test/test_kda_training_example.py
@@ -126,7 +126,7 @@ def test_kda_example_packed_matches_sequence_for_loop(monkeypatch):
     consumed_metadata = []
     fused_calls = {"short_conv": 0, "l2norm": 0, "gate": 0, "core": 0}
     prepare_metadata = kda_training.prepare_ragged_chunk_metadata
-    short_conv = kda_training.cute_causal_conv1d_silu
+    short_conv = kda_training.causal_conv1d
     fused_l2norm = kda_training.l2norm
     gate = kda_training._bounded_gate_cumsum
     core = kda_training._chunk_kda
@@ -156,7 +156,7 @@ def test_kda_example_packed_matches_sequence_for_loop(monkeypatch):
         return core(*args, **kwargs)
 
     monkeypatch.setattr(kda_training, "prepare_ragged_chunk_metadata", record_prepare)
-    monkeypatch.setattr(kda_training, "cute_causal_conv1d_silu", record_short_conv)
+    monkeypatch.setattr(kda_training, "causal_conv1d", record_short_conv)
     monkeypatch.setattr(kda_training, "l2norm", record_l2norm)
     monkeypatch.setattr(kda_training, "_bounded_gate_cumsum", record_gate)
     monkeypatch.setattr(kda_training, "_chunk_kda", record_core)

--- a/test/test_namespaces.py
+++ b/test/test_namespaces.py
@@ -1,3 +1,6 @@
+import subprocess
+import sys
+
 import attn_gym
 import attn_gym.linear
 import attn_gym.sparse
@@ -29,3 +32,9 @@ def test_documented_mask_and_score_mods_are_exported():
             generate_mla_rope_score_mod,
         )
     )
+
+
+def test_linear_base_import_keeps_cutedsl_lazy():
+    """The optional CuTeDSL backend must never become an eager import."""
+    script = "import sys, attn_gym.linear; assert 'cutlass' not in sys.modules"
+    subprocess.run([sys.executable, "-c", script], check=True)


### PR DESCRIPTION
Stacked PRs:
 * #318
 * #317
 * __->__#316


--- --- ---

Rename the short conv to causal_conv1d with pluggable activations

## Human Note

## Agent note

`cute_causal_conv1d_silu` baked the backend and the activation into the public name. The op is now
`causal_conv1d(x, weight, *, activation=None, ...)` (with `tune_causal_conv1d` alongside), matching
flash-linear-attention's naming so KDA consumers can swap between the libraries without renaming
call sites. The activation is a kwarg-only string through the whole stack, including the
torch.library schemas (`*, str? activation=None`), so compiled graphs specialize on it like any
other static scalar and the raw ops stay opcheck-clean.

`activation=None` is a real kernel variant rather than an error: an identity forward and a
trace-time-folded scalar derivative thread through all the kernels (fwd, dx, dx-TMA, dw, dw-TMA,
dstate). `register_activation(name, forward, derivative)` lets users fuse their own CuTeDSL
activation expressions; compile caches are keyed on the sha256 of both function sources, so editing
an activation body in place cannot hit a stale persistent artifact, and re-registering a name with
different sources raises instead of silently colliding.

`from attn_gym.linear import ...` is now the main public interface: both `attn_gym.linear` and
`attn_gym.linear.kda` re-export the fused surface (`chunk_kda`, `bounded_gate_cumsum`, `l2norm`,
`causal_conv1d`, `register_activation`) lazily via PEP 562 so the base import stays free of the
optional CuTeDSL dependency (the SPEC 1 / lazy_loader pattern). `__all__` is built from grouped
`KDA_OPS` / `GDN_OPS` / `GENERIC_OPS` blocks so ops keep a conceptual home even when they ship from
the KDA module. The old names are gone; this is an intentional BC break while the KDA API
stabilizes.

## Test Plan

```bash
gpu-run auto -- ~/.venvs/ag-linear/bin/python -m pytest test/test_kda_short_conv_cute.py test/test_kda_training_example.py -q
# 65 passed on B200, including fullgraph compile and CUDA-graph replay; new coverage:
# identity-vs-plain-conv fwd+grads (dense, packed+stateful), registered tanh activation
# fwd+grads, and the registration error contract.
```