### PR TITLE
Give chunk_kda and recurrent_kda a string-enum impl selector

### DIFF
--- a/.agents/skills/cutedsl-tunable-kernel-template/SKILL.md
+++ b/.agents/skills/cutedsl-tunable-kernel-template/SKILL.md
@@ -24,6 +24,7 @@ Keep each value in one domain:
 | Real `torch.Tensor` inputs and outputs | Parent process and public wrapper |
 | Cohesive runtime tensor/output bundle | One parent-only `NamedTuple` or dataclass when the flat argument list grows |
 | Candidate generation from shapes/dtypes/device facts | `configs(*runtime_args)` in the parent |
+| Benchmark-winner reuse identity | Host-static `tuning_key(*runtime_args, target=...)` result |
 | Static, pickleable specialization values | Config record and `compile_call(...)` result |
 | Fake CuTe tensors matching the runtime ABI | Cached `compile(...)` method |
 | Fake environment stream and typed TVM-FFI option | `compile_tvm_ffi(...)` |
@@ -56,13 +57,15 @@ integer utilities such as `ceildiv` directly instead of wrapping one arithmetic 
 ```python
 from typing import NamedTuple
 
+from attn_gym._backends.cute.target import CompileTarget
+
 
 class MyConfig(NamedTuple):
     threads: int
     tile_size: int
 ```
 
-A tunable adapter supplies five distinct responsibilities. When its launch ABI has several values,
+A tunable adapter supplies seven distinct responsibilities. When its launch ABI has several values,
 make that ABI an `Args` type owned by the adapter rather than a separate module-level private type:
 
 ```python
@@ -73,7 +76,15 @@ class MyOp:
         output: torch.Tensor
         workspace: torch.Tensor
 
-    default_config = MyConfig(threads=128, tile_size=256)
+    @staticmethod
+    def default_config(args: Args, *, target: CompileTarget) -> MyConfig:
+        """Return a deterministic valid config without benchmarking."""
+        return MyConfig(threads=128, tile_size=256)
+
+    @staticmethod
+    def tuning_key(args: Args, *, target: CompileTarget) -> tuple[int]:
+        """Identify workloads that may safely reuse one benchmark winner."""
+        return (args.q.shape[1],)
 
     @staticmethod
     def configs(args: Args) -> tuple[MyConfig, ...]:
@@ -99,14 +110,19 @@ class MyOp:
 
 Keep these responsibilities distinct, but they need not all live on the CuTeDSL op class. A
 constructor-heavy DSL op may stay focused on layouts and device code while a small adapter owns the
-five static/class methods above.
+seven static/class methods above.
 
-- `default_config` is a conservative fallback and must be valid for every runtime input accepted by
-  the adapter. If the normal choice depends on inputs or target metadata, keep that selection method
-  on the adapter (for example, `default_for(...)`), call it from the parent wrapper, and pass its
-  result as `config=`. Do not leave an adapter-specific default heuristic as an unrelated module-level
-  helper. Name canonical mode configs after the mode rather than calling an architecture-specific
-  config the default.
+- `default_config(*runtime_args, target=...)` owns deterministic no-tune selection. It may inspect
+  tensor metadata, static operation arguments, and target facts, and must return a valid config for
+  every input accepted by the adapter without benchmarking or reading device-resident tensor values.
+  Keep this policy on the adapter rather than selecting a default in the parent wrapper. A constant
+  fallback simply ignores its arguments. Name canonical mode configs after the mode rather than
+  calling an architecture-specific config the default.
+- `tuning_key(*runtime_args, target=...)` defines when an autotuned winner may be reused. Return
+  host-visible tensor metadata and target facts only; never read device values or synchronize, because
+  the key must remain valid during CUDA Graph replay. Use `()` when `compile_call(...)` already
+  distinguishes every relevant workload. Exact keys are the safe starting point; introduce buckets
+  only after measurements establish stable winner regions.
 - `configs(...)` may inspect runtime shape, stride, dtype, alignment, or device facts.
 - `compile(...)` owns fake tensors and the cached artifact boundary.
 - `compile_call(...)` prevents runtime tensors from leaking into cache keys or subprocess payloads.

--- a/.agents/skills/cutedsl-tunable-kernel-template/copy_reads_example.py
+++ b/.agents/skills/cutedsl-tunable-kernel-template/copy_reads_example.py
@@ -19,6 +19,7 @@ from cutlass import cute
 
 from attn_gym._backends.cute import benchmark_gpu, compile_tvm_ffi, jit_cache, run_tunable
 from attn_gym._backends.cute.cache import get_cache_path
+from attn_gym._backends.cute.target import CompileTarget
 
 # A 256 MiB source keeps the fixed-buffer benchmark larger than modern GPU L2 caches.
 NUM_ELEMENTS = 1 << 26
@@ -32,7 +33,30 @@ class ReadConfig(NamedTuple):
 class CopyReadsTunable:
     """Compile, tune, and launch the copy kernel."""
 
-    default_config = ReadConfig(128, 4)
+    @staticmethod
+    def default_config(
+        source: torch.Tensor,
+        destination: torch.Tensor,
+        *,
+        target: CompileTarget,
+    ) -> ReadConfig:
+        """Return the deterministic no-tune schedule for this input."""
+        del source, destination, target
+        return ReadConfig(128, 4)
+
+    @staticmethod
+    def tuning_key(
+        source: torch.Tensor,
+        destination: torch.Tensor,
+        *,
+        target: CompileTarget,
+    ) -> tuple[int]:
+        """Key winners by the runtime extent that changes launch work."""
+        if target.device_type != "cuda":
+            raise RuntimeError("copy_reads tuning requires a CUDA target")
+        if destination.numel() != source.numel():
+            raise ValueError("source and destination must have the same size")
+        return (source.numel(),)
 
     @staticmethod
     def configs(source: torch.Tensor, destination: torch.Tensor) -> tuple[ReadConfig, ...]:
@@ -163,7 +187,7 @@ def copy_reads(
 ) -> torch.Tensor:
     """Copy a real PyTorch tensor using a selected or freshly tuned kernel.
 
-    ``copy_reads(source)`` uses the op's ``default_config``. Pass ``config=...`` to
+    ``copy_reads(source)`` uses the op's input-aware ``default_config``. Pass ``config=...`` to
     force one specialization. ``tune=True`` asks the op to generate candidates
     from the runtime inputs; passing ``configs=...`` overrides those candidates.
     """

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -333,6 +333,43 @@ Use the least opaque integration that provides the required compiler behavior:
    compilation, caching, or validation machinery, but the variant backend owns its operator schema,
    fake implementation, mutation declaration, autograd registration, and output/state metadata.
 
+#### Register contracts without importing optional backends
+
+When a public operation supports both a torch-only reference and an optional fused backend, put its
+private operator contracts in a small torch-only module:
+
+```text
+<variant>/
+  api.py                  # Imports ops.py, validates semantics, lazily selects a backend
+  ops.py                  # Schemas, fake kernels, dispatch registration, torch.ops handles
+  impl/reference.py       # Torch-only eager oracle
+  impl/triton.py          # Optional kernels and launchers
+  impl/cute.py            # Optional kernels and launchers
+```
+
+`ops.py` must not import Triton, CuTeDSL, or another optional implementation at module import time.
+Its device dispatch functions may import the selected launcher locally when the dispatcher executes
+the operator. This establishes schemas and fake implementations before Dynamo starts tracing while
+keeping reference imports usable with only PyTorch installed:
+
+```text
+import public API
+  register schemas, fake kernels, and lazy device dispatch
+
+call reference
+  run ordinary PyTorch without importing an optional backend
+
+call fused
+  trace an already-registered operator
+  import the optional launcher only when its device implementation executes
+```
+
+Do not register schemas, fake kernels, or device implementations as a side effect of a fused
+backend's first public call. A first-ever `torch.compile(..., fullgraph=True)` invocation must not
+depend on tracing-time registration. Test both boundaries in fresh processes: block optional
+backend imports and run the reference path on CPU, then make strict compilation the first fused
+operation in a backend-enabled process.
+
 Every custom operator used by an optimized backend must provide the compiler metadata required by
 its supported contract, including a fake implementation for shape and dtype propagation. Training
 backends must define an autograd formula or clearly reject gradient-requiring inputs. Mutation and

--- a/attn_gym/_backends/cute/cache.py
+++ b/attn_gym/_backends/cute/cache.py
@@ -442,6 +442,11 @@ def jit_cache(
         with state_lock:
             return CacheInfo(hits=hits, misses=misses, currsize=len(memory_cache))
 
+    def cache_namespace() -> str:
+        """Identify the source/target namespace that owns this function's artifacts."""
+        return _source_fingerprint(fn, source_paths)
+
+    wrapper.cache_namespace = cache_namespace  # type: ignore[attr-defined]
     wrapper.precompile = precompile  # type: ignore[attr-defined]
     wrapper.is_cached = is_cached  # type: ignore[attr-defined]
     wrapper.disk_cache_enabled = disk_cache_enabled  # type: ignore[attr-defined]

--- a/attn_gym/_backends/cute/target.py
+++ b/attn_gym/_backends/cute/target.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import os
 import threading
 from dataclasses import dataclass
@@ -39,8 +40,8 @@ def set_compile_target(target: CompileTarget | None) -> None:
         _target = target
 
 
-def detect_compile_target(device: int | None = None) -> CompileTarget:
-    """Query target metadata in a process allowed to use the CUDA driver."""
+def _reject_bad_fork() -> None:
+    """Reject CUDA discovery even when the target query is already cached."""
     import torch
 
     is_bad_fork = getattr(torch.cuda, "_is_in_bad_fork", lambda: False)
@@ -50,11 +51,12 @@ def detect_compile_target(device: int | None = None) -> CompileTarget:
             "CompileTarget or use precompile_many(), which uses a fresh compiler process"
         )
 
-    configured_arch = os.getenv("CUTE_DSL_ARCH")
-    if not torch.cuda.is_available():
-        return CompileTarget(device_type="none", configured_arch=configured_arch)
 
-    device_index = torch.cuda.current_device() if device is None else device
+@functools.lru_cache
+def _query_compile_target(device_index: int, configured_arch: str | None) -> CompileTarget:
+    """Query the driver once per device; hot launchers re-resolve every call."""
+    import torch
+
     properties = torch.cuda.get_device_properties(device_index)
     return CompileTarget(
         device_type="cuda",
@@ -63,6 +65,18 @@ def detect_compile_target(device: int | None = None) -> CompileTarget:
         name=properties.name,
         sm_count=properties.multi_processor_count,
     )
+
+
+def detect_compile_target(device: int | None = None) -> CompileTarget:
+    """Query target metadata in a process allowed to use the CUDA driver."""
+    import torch
+
+    _reject_bad_fork()
+    configured_arch = os.getenv("CUTE_DSL_ARCH")
+    if not torch.cuda.is_available():
+        return CompileTarget(device_type="none", configured_arch=configured_arch)
+    device_index = torch.cuda.current_device() if device is None else device
+    return _query_compile_target(device_index, configured_arch)
 
 
 def get_compile_target() -> CompileTarget:

--- a/attn_gym/_backends/cute/tune.py
+++ b/attn_gym/_backends/cute/tune.py
@@ -3,27 +3,48 @@
 from __future__ import annotations
 
 import functools
+import hashlib
 import inspect
 import math
+import os
+import pickle
 import statistics
+import threading
 from collections.abc import Callable, Iterable
 from typing import Any, Protocol, TypeVar
 
+from .cache import cache_enabled
 from .compile import (
     DEFAULT_COMPILE_TIMEOUT_SECONDS,
     _materialize_calls,
     compile_many,
 )
-from .target import CompileTarget, set_compile_target
+from .target import CompileTarget, get_compile_target, set_compile_target
 
 ConfigT = TypeVar("ConfigT")
+_WINNERS_LOCK = threading.Lock()
+_WINNERS: dict[str, Any] = {}
+# Hot-path memo in front of the hashed disk key: compile calls are small tuples
+# of static scalars, so they key a plain dict directly. Kernel sources cannot
+# change within a process, so the source namespace only guards the disk entry.
+_WINNERS_FAST: dict[Any, Any] = {}
 CompiledT = TypeVar("CompiledT")
 
 
 class TunableKernel(Protocol[ConfigT, CompiledT]):
     """Convention consumed by :func:`run_tunable`."""
 
-    default_config: ConfigT
+    def default_config(
+        self,
+        *runtime_args: Any,
+        target: CompileTarget,
+    ) -> ConfigT: ...
+
+    def tuning_key(
+        self,
+        *runtime_args: Any,
+        target: CompileTarget,
+    ) -> tuple[Any, ...]: ...
 
     def configs(self, *runtime_args: Any) -> Iterable[ConfigT]: ...
 
@@ -158,6 +179,72 @@ def tune(
     return candidates[min(range(len(candidates)), key=timings.__getitem__)]
 
 
+def _winner_key(
+    kernel: Any,
+    candidates: list[Any],
+    runtime_args: tuple[Any, ...],
+    tuning_key: tuple[Any, ...],
+) -> str:
+    """Identify one tuning decision independently from codegen specialization."""
+    from ._key import _canonicalize
+    from .target import get_compile_target
+
+    name = getattr(kernel, "__qualname__", type(kernel).__qualname__)
+    payload = (
+        # Source and target namespace: editing the kernel or moving to another
+        # GPU model must re-tune rather than reuse a stale winner.
+        kernel.compile.cache_namespace(),
+        _canonicalize(get_compile_target()),
+        getattr(kernel, "__module__", type(kernel).__module__),
+        name,
+        tuple(
+            _canonicalize(kernel.compile_call(candidate, *runtime_args))
+            for candidate in candidates
+        ),
+        _canonicalize(tuning_key),
+    )
+    return hashlib.sha256(pickle.dumps(payload, protocol=pickle.HIGHEST_PROTOCOL)).hexdigest()
+
+
+def _winner_path(key: str):
+    from .cache import get_cache_path
+
+    return get_cache_path() / "winners" / f"{key}.pickle"
+
+
+def _load_winner(key: str) -> Any | None:
+    """Return a previously selected config for this tuning decision, if any."""
+    with _WINNERS_LOCK:
+        if key in _WINNERS:
+            return _WINNERS[key]
+    if not cache_enabled():
+        return None
+    path = _winner_path(key)
+    try:
+        winner = pickle.loads(path.read_bytes())
+    except (EOFError, OSError, pickle.PickleError):
+        return None
+    with _WINNERS_LOCK:
+        _WINNERS[key] = winner
+    return winner
+
+
+def _store_winner(key: str, winner: Any) -> None:
+    """Persist a selected config in memory and on disk (best effort)."""
+    with _WINNERS_LOCK:
+        _WINNERS[key] = winner
+    if not cache_enabled():
+        return
+    path = _winner_path(key)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = path.with_suffix(".tmp")
+        temporary.write_bytes(pickle.dumps(winner, protocol=pickle.HIGHEST_PROTOCOL))
+        os.replace(temporary, path)
+    except OSError:
+        pass
+
+
 def run_tunable(
     kernel: TunableKernel[ConfigT, CompiledT],
     *runtime_args: Any,
@@ -172,19 +259,27 @@ def run_tunable(
 ) -> tuple[Any, ConfigT]:
     """Select, compile, and launch an op following the tunable-kernel convention.
 
-    ``kernel`` supplies ``default_config``, an input-aware
-    ``configs(*runtime_args)`` method, a cached ``compile`` function, and
-    ``compile_call``/``launch`` adapters. This keeps candidate generation and
+    ``kernel`` supplies input-aware ``default_config(*runtime_args, target=...)``,
+    ``tuning_key(*runtime_args, target=...)``, and ``configs(*runtime_args)``
+    methods, a cached ``compile`` function, and ``compile_call``/``launch``
+    adapters. This keeps candidate generation and
     fake-tensor ABI construction in the kernel implementation while public
     PyTorch entrypoints only choose between a default, explicit config, or
     autotuning. Passing ``configs=`` overrides the kernel's candidate method.
 
-    The return value is ``(launch_result, selected_config)``. Autotuning still
-    compiles candidates in parallel and benchmarks launches sequentially, then
-    performs one final launch with the winner. Therefore this convenience API
-    requires repeatable, non-destructive launches. An explicit ``target`` is
-    installed process-wide before candidate generation and remains active after
-    this function returns.
+    The return value is ``(launch_result, selected_config)``. Autotuning
+    compiles candidates in parallel, benchmarks launches sequentially, then
+    performs one final launch with the winner. Winners are cached in memory and
+    under ``<cache>/winners`` keyed by the kernel and its compile-relevant
+    arguments, so repeat invocations skip benchmarking; changing the kernel
+    source, candidate set, static dimensions, or ``tuning_key`` re-tunes.
+    ``tuning_key`` may use host-visible tensor metadata and target facts, but
+    must not read device values or synchronize; return ``()`` when compile
+    identities already distinguish every tuning decision. Passing a custom
+    ``benchmark=`` bypasses winner reuse so that timing policy always runs.
+    Therefore this convenience API requires repeatable, non-destructive
+    launches. An explicit ``target`` is installed process-wide before candidate
+    generation and remains active after this function returns.
     """
     if autotune and config is not None:
         raise ValueError("pass either config= or autotune=True, not both")
@@ -196,25 +291,65 @@ def run_tunable(
         raise TypeError("run_tunable() requires kernel.compile decorated with jit_cache")
     if target is not None:
         set_compile_target(target)
+    resolved_target = get_compile_target()
     if autotune:
-        candidates = kernel.configs(*runtime_args) if configs is None else configs
-
-        def launch(compiled: CompiledT, candidate: ConfigT) -> Any:
-            return kernel.launch(compiled, candidate, *runtime_args)
-
-        selected = tune(
-            candidates,
-            compile_fn,
-            launch,
-            benchmark=benchmark,
-            compile_call=lambda candidate: kernel.compile_call(candidate, *runtime_args),
-            parallel_compile=parallel_compile,
-            workers=workers,
-            target=target,
-            timeout=timeout,
+        # Custom timing policies always benchmark rather than inheriting a winner
+        # selected under different criteria.
+        reuse_winner = benchmark is None
+        tuning_key = (
+            kernel.tuning_key(*runtime_args, target=resolved_target) if reuse_winner else None
         )
+        if tuning_key is not None and not isinstance(tuning_key, tuple):
+            raise TypeError("tuning_key() must return a tuple of host-static values")
+        selected = None
+        fast_key = None
+        if reuse_winner and configs is None:
+            default = kernel.default_config(*runtime_args, target=resolved_target)
+            try:
+                fast_key = (
+                    id(kernel),
+                    resolved_target,
+                    tuning_key,
+                    kernel.compile_call(default, *runtime_args),
+                )
+                selected = _WINNERS_FAST.get(fast_key)
+            except TypeError:
+                fast_key = None
+        if selected is None:
+            candidates = list(kernel.configs(*runtime_args) if configs is None else configs)
+            winner_key = (
+                _winner_key(kernel, candidates, runtime_args, tuning_key)
+                if tuning_key is not None
+                else None
+            )
+            selected = None if winner_key is None else _load_winner(winner_key)
+            # A cached winner outside the candidate set is stale (config space changed).
+            if selected is None or selected not in candidates:
+
+                def launch(compiled: CompiledT, candidate: ConfigT) -> Any:
+                    return kernel.launch(compiled, candidate, *runtime_args)
+
+                selected = tune(
+                    candidates,
+                    compile_fn,
+                    launch,
+                    benchmark=benchmark,
+                    compile_call=lambda candidate: kernel.compile_call(candidate, *runtime_args),
+                    parallel_compile=parallel_compile,
+                    workers=workers,
+                    target=target,
+                    timeout=timeout,
+                )
+                if winner_key is not None:
+                    _store_winner(winner_key, selected)
+            if fast_key is not None:
+                _WINNERS_FAST[fast_key] = selected
     else:
-        selected = kernel.default_config if config is None else config
+        selected = (
+            kernel.default_config(*runtime_args, target=resolved_target)
+            if config is None
+            else config
+        )
 
     call_args = _materialize_calls((kernel.compile_call(selected, *runtime_args),))[0]
     compiled = compile_fn(*call_args)

--- a/attn_gym/_backends/triton/utils.py
+++ b/attn_gym/_backends/triton/utils.py
@@ -67,3 +67,34 @@ def can_use_tma(tensor: torch.Tensor) -> bool:
         and storage_is_aligned
         and all(stride * element_size % 16 == 0 for stride in tensor.stride()[:-1])
     )
+
+
+class PinnedConfigKernel:
+    """An autotuned kernel pinned to its first config, the list's heuristic default.
+
+    Bypasses timing-based selection entirely so launches are reproducible
+    across processes, machines, and cache states. Heuristic constexprs
+    (``@triton.heuristics``) still apply.
+    """
+
+    def __init__(self, kernel):
+        from triton.runtime.autotuner import Autotuner, Heuristics
+
+        heuristic_values = None
+        if isinstance(kernel, Heuristics):
+            heuristic_values = kernel.values
+            kernel = kernel.fn
+        if not isinstance(kernel, Autotuner):
+            raise TypeError(f"expected an autotuned kernel, got {type(kernel).__name__}")
+        self._config_kwargs = kernel.configs[0].all_kwargs()
+        self._kernel = (
+            triton.heuristics(heuristic_values)(kernel.fn) if heuristic_values else kernel.fn
+        )
+
+    def __getitem__(self, grid):
+        launch = self._kernel[grid]
+
+        def pinned_launch(*args, **kwargs):
+            return launch(*args, **kwargs, **self._config_kwargs)
+
+        return pinned_launch

--- a/attn_gym/linear/__init__.py
+++ b/attn_gym/linear/__init__.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""Linear attention operations: ``from attn_gym.linear import ...``."""
+"""Linear attention operations."""
 
 import importlib
 from typing import TYPE_CHECKING
@@ -12,31 +12,27 @@ from typing import TYPE_CHECKING
 from attn_gym.linear.gdn import GatedDeltaRuleOutput, gated_delta_rule
 from attn_gym.linear.kda import (
     active_token_mask,
-    bounded_gate_cumsum,
-    l2norm,
+    chunk_kda,
     mask_inactive_token_gradients,
     mask_inactive_tokens,
-    naive_chunk_kda,
-    naive_chunk_kda_from_cumulative,
-    naive_recurrent_kda,
     recurrent_kda,
 )
+from attn_gym.linear.kda.api import Impl
 
 # Note: Lazy Imports
-# The CuTeDSL kernels are an optional dependency (`pip install attn-gym[linear]`);
-# torch- and triton-backed names import eagerly. Names backed by CuTeDSL resolve
-# lazily through PEP 562 module `__getattr__` (the standard scientific-python
-# lazy-import mechanism) so the base package imports without the extra, and a
-# missing backend raises an ImportError naming the install command.
+# Backend-backed names load on first use, keeping reference imports torch-only.
+# Missing backends raise an actionable ImportError.
 if TYPE_CHECKING:
-    from attn_gym.linear.kda import causal_conv1d, chunk_kda, register_activation
+    from attn_gym.linear.kda import (
+        bounded_gate_cumsum,
+        causal_conv1d,
+        l2norm,
+        register_activation,
+    )
 
 KDA_OPS = [
     "bounded_gate_cumsum",
     "chunk_kda",
-    "naive_chunk_kda",
-    "naive_chunk_kda_from_cumulative",
-    "naive_recurrent_kda",
     "recurrent_kda",
 ]
 
@@ -47,6 +43,7 @@ GDN_OPS = [
 
 # Model-agnostic building blocks; they currently ship from the KDA module.
 GENERIC_OPS = [
+    "Impl",
     "active_token_mask",
     "causal_conv1d",
     "l2norm",

--- a/attn_gym/linear/kda/__init__.py
+++ b/attn_gym/linear/kda/__init__.py
@@ -4,56 +4,53 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""KDA (Kimi Delta Attention) references and optimized kernels."""
+"""KDA (Kimi Delta Attention) operations.
+
+``chunk_kda`` and ``recurrent_kda`` dispatch on ``impl``: fused backends load
+lazily on first fused call, and the naive oracles in
+``attn_gym.linear.kda.naive`` serve ``impl="reference"``.
+"""
 
 import importlib
 
-from attn_gym.linear.kda.fwd.triton.gate_fwd import bounded_gate_cumsum
-from attn_gym.linear.kda.fwd.triton.l2norm_fwd import l2norm
-from attn_gym.linear.kda.fwd.triton.recurrent import recurrent_kda
+from attn_gym.linear.kda.api import chunk_kda, recurrent_kda
 from attn_gym.linear.kda.masking import (
     active_token_mask,
     mask_inactive_token_gradients,
     mask_inactive_tokens,
 )
-from attn_gym.linear.kda.naive import (
-    naive_chunk_kda,
-    naive_chunk_kda_from_cumulative,
-    naive_recurrent_kda,
-)
 
 # Note: Lazy Imports (see attn_gym/linear/__init__.py)
-_CUTEDSL_EXPORTS = {
+_BACKEND_EXPORTS = {
+    "bounded_gate_cumsum": "attn_gym.linear.kda.fwd.triton.gate_fwd",
     "causal_conv1d": "attn_gym.linear.kda.short_conv",
-    "chunk_kda": "attn_gym.linear.kda.fwd.cute",
+    "l2norm": "attn_gym.linear.kda.fwd.triton.l2norm_fwd",
     "register_activation": "attn_gym.linear.kda.short_conv",
 }
 
 
 def __getattr__(name: str):
-    module_name = _CUTEDSL_EXPORTS.get(name)
+    module_name = _BACKEND_EXPORTS.get(name)
     if module_name is None:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
     try:
         module = importlib.import_module(module_name)
     except ImportError as error:
-        raise ImportError(
-            f"{name} requires the optional CuTeDSL backend: pip install attn-gym[linear]"
-        ) from error
+        if name in {"causal_conv1d", "register_activation"}:
+            message = f"{name} requires the optional CuTeDSL backend: pip install attn-gym[linear]"
+        else:
+            message = f"{name} requires CUDA with Triton support"
+        raise ImportError(message) from error
     return getattr(module, name)
 
 
-__all__ = sorted(  # noqa: PLE0605 -- the lazy half comes from _CUTEDSL_EXPORTS
+__all__ = sorted(  # noqa: PLE0605 -- backend exports resolve lazily
     [
         "active_token_mask",
-        "bounded_gate_cumsum",
-        "l2norm",
+        "chunk_kda",
         "mask_inactive_token_gradients",
         "mask_inactive_tokens",
-        "naive_chunk_kda",
-        "naive_chunk_kda_from_cumulative",
-        "naive_recurrent_kda",
         "recurrent_kda",
-        *_CUTEDSL_EXPORTS,
+        *_BACKEND_EXPORTS,
     ]
 )

--- a/attn_gym/linear/kda/api.py
+++ b/attn_gym/linear/kda/api.py
@@ -1,0 +1,199 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Public KDA operations.
+
+``chunk_kda`` supports training and prefill; ``recurrent_kda`` supports decode and
+inference prefill. Use ``impl`` to select fused kernels or the eager reference.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from functools import partial
+
+import torch
+
+from attn_gym.linear.kda.impl.fused import chunk_forward as _fused_chunk_forward
+from attn_gym.linear.kda.impl.reference import reference_kda
+from attn_gym.linear.kda.naive import naive_chunk_kda_from_cumulative, naive_recurrent_kda
+from attn_gym.linear.kda.ops import recurrent_forward as _fused_recurrent_forward
+from attn_gym.linear.kda.validation import validate_kda_inputs
+
+_CHUNK_SIZE = 64
+
+
+class Impl(str, Enum):
+    """Select a fused or reference KDA implementation.
+
+    The public operations validate shared inputs; fused backends validate their
+    extra hardware and shape requirements. There is no automatic fallback.
+    """
+
+    FUSED = "fused"
+    REFERENCE = "reference"
+
+
+def _resolve_impl(impl: Impl | str) -> Impl:
+    try:
+        return Impl(impl)
+    except ValueError:
+        valid = ", ".join(repr(member.value) for member in Impl)
+        raise ValueError(f"unknown impl {impl!r}; expected one of {valid}") from None
+
+
+def chunk_kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None = None,
+    *,
+    cu_seqlens: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    fastmath: bool = False,
+    autotune: bool = True,
+    impl: Impl | str = Impl.FUSED,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Apply chunk-parallel KDA for training and prefill.
+
+    Args:
+        q: Queries shaped ``[B, T, H, K]``, scaled by ``1/sqrt(K)`` internally.
+        k: Keys shaped like ``q``.
+        v: Values shaped ``[B, T, H, V]``.
+        cumulative_gate: Inclusive cumulative log2 decay within each 64-token
+            chunk, shaped like ``q`` and produced by
+            ``bounded_gate_cumsum(chunk_size=64)``.
+        beta: Per-token write gate shaped ``[B, T, H]``.
+        initial_state: Starting recurrent state, with one ``[H, K, V]`` entry per
+            logical sequence.
+        cu_seqlens: Packed offsets shaped ``[N + 1]`` for batch-one inputs, as
+            contiguous ``int32`` on ``q.device``; they start at zero, never
+            decrease, may repeat for empty sequences whose states pass through,
+            and may end before ``T``.
+        output_final_state: Return the final recurrent state with the output.
+        fastmath: Allow less precise fused math for speed; rejected with
+            ``"reference"``.
+        autotune: Benchmark candidate kernel configurations when true (winners
+            are cached and reused); use fixed heuristics when false for
+            repeatable selection across machines and cache states.
+        impl: ``"fused"`` uses the Blackwell kernels with first-order autograd;
+            ``"reference"`` uses differentiable eager PyTorch in FP32, with no
+            automatic fallback.
+
+    Returns:
+        The output in ``q.dtype`` and either an FP32 final state with one entry
+        per logical sequence or ``None``.
+    """
+    selected_impl = _resolve_impl(impl)
+    if selected_impl is Impl.REFERENCE and fastmath:
+        raise ValueError("fastmath applies only to impl='fused'")
+    validate_kda_inputs(
+        q,
+        k,
+        v,
+        cumulative_gate,
+        beta,
+        initial_state,
+        cu_seqlens,
+        op_name="chunk_kda",
+        gate_name="cumulative_gate",
+    )
+    if selected_impl is Impl.FUSED:
+        return _fused_chunk_forward(
+            q,
+            k,
+            v,
+            cumulative_gate,
+            beta,
+            initial_state,
+            cu_seqlens=cu_seqlens,
+            output_final_state=output_final_state,
+            fastmath=fastmath,
+            autotune=autotune,
+        )
+    return reference_kda(
+        partial(naive_chunk_kda_from_cumulative, chunk_size=_CHUNK_SIZE),
+        q,
+        k,
+        v,
+        cumulative_gate,
+        beta,
+        initial_state,
+        cu_seqlens,
+        output_final_state,
+    )
+
+
+def recurrent_kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None = None,
+    *,
+    cu_seqlens: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    autotune: bool = True,
+    impl: Impl | str = Impl.FUSED,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Apply recurrent KDA for decoding and inference prefill.
+
+    Args:
+        q: Queries shaped ``[B, T, H, K]``, scaled by ``1/sqrt(K)`` internally.
+        k: Keys shaped like ``q``.
+        v: Values shaped ``[B, T, H, V]``.
+        gate: Per-token log2 decay shaped like ``q``, as produced by
+            ``bounded_gate_cumsum(chunk_size=1)``; do not pass chunk-cumulative
+            gates.
+        beta: Per-token write gate shaped ``[B, T, H]``.
+        initial_state: Starting recurrent state, with one ``[H, K, V]`` entry per
+            logical sequence.
+        cu_seqlens: Packed offsets shaped ``[N + 1]`` for batch-one inputs, as
+            contiguous ``int32`` on ``q.device``; they start at zero, never
+            decrease, may repeat for empty sequences whose states pass through,
+            and may end before ``T``.
+        output_final_state: Return the final recurrent state with the output.
+        autotune: Reserved for implementation parity with ``chunk_kda``. The
+            current recurrent kernel uses the same fixed launch policy for both
+            values.
+        impl: ``"fused"`` uses the inference-only optimized scan; ``"reference"``
+            uses differentiable eager PyTorch in FP32, with no automatic
+            fallback.
+
+    Returns:
+        The output in ``q.dtype`` and either an FP32 final state with one entry
+        per logical sequence or ``None``.
+
+    Serving limitations: state rows map directly to logical sequences (no
+    state-pool indexing), final states are written out of place, decode
+    preprocessing and scan are separate launches, and speculative-decoding
+    rollback is unsupported.
+    """
+    del autotune
+    selected_impl = _resolve_impl(impl)
+    validate_kda_inputs(
+        q, k, v, gate, beta, initial_state, cu_seqlens, op_name="recurrent_kda", gate_name="gate"
+    )
+    if selected_impl is Impl.FUSED:
+        return _fused_recurrent_forward(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            initial_state,
+            cu_seqlens=cu_seqlens,
+            output_final_state=output_final_state,
+        )
+    return reference_kda(
+        naive_recurrent_kda, q, k, v, gate, beta, initial_state, cu_seqlens, output_final_state
+    )
+
+
+__all__ = ["Impl", "chunk_kda", "recurrent_kda"]

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd.py
@@ -15,6 +15,7 @@ from attn_gym.linear.kda.bwd.triton.chunk_kda_bwd_dav import chunk_kda_bwd_dav
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata
 from attn_gym.linear.kda.fwd.cute.recompute_w_u_fwd import recompute_w_u_fwd
 from attn_gym.linear.kda.fwd.triton.chunk_delta_h import chunk_gated_delta_rule_fwd_h
+from attn_gym.linear.kda.utils import profiler_range
 
 
 def chunk_kda_bwd(
@@ -32,6 +33,7 @@ def chunk_kda_bwd(
     *,
     chunk_size: int = 64,
     fastmath: bool = False,
+    autotune: bool = True,
 ) -> tuple[
     torch.Tensor,
     torch.Tensor,
@@ -53,7 +55,7 @@ def chunk_kda_bwd(
     # Forward deliberately saves only the minimal backward tape. Always
     # reconstruct the large W/U, gated Q/K, state, and corrected-value
     # intermediates here instead of retaining them for the lifetime of the graph.
-    with torch.profiler.record_function("kda/cute/backward_recompute_w_u"):
+    with profiler_range("kda/cute/backward_recompute_w_u"):
         w, u, qg, kg = recompute_w_u_fwd(
             q=q,
             k=k,
@@ -63,9 +65,10 @@ def chunk_kda_bwd(
             gk=g,
             metadata=metadata,
             chunk_size=chunk_size,
+            autotune=autotune,
         )
     assert qg is not None and kg is not None
-    with torch.profiler.record_function("kda/triton/backward_recompute_state"):
+    with profiler_range("kda/triton/backward_recompute_state"):
         h, v_new, _ = chunk_gated_delta_rule_fwd_h(
             kg,
             w,
@@ -75,10 +78,11 @@ def chunk_kda_bwd(
             chunk_size=chunk_size,
             output_final_state=False,
             metadata=metadata,
+            autotune=autotune,
         )
     del u
 
-    with torch.profiler.record_function("kda/triton/backward_dav"):
+    with profiler_range("kda/triton/backward_dav"):
         dv_intra, dAqk = chunk_kda_bwd_dav(
             v_new,
             Aqk,
@@ -86,8 +90,9 @@ def chunk_kda_bwd(
             head_dim**-0.5,
             chunk_size=chunk_size,
             metadata=metadata,
+            autotune=autotune,
         )
-    with torch.profiler.record_function("kda/cute/backward_delta_h"):
+    with profiler_range("kda/cute/backward_delta_h"):
         dh, d_initial_state, dv = blackwell_delta_h_bwd_dhu_dispatch(
             qg,
             kg,
@@ -102,7 +107,7 @@ def chunk_kda_bwd(
             metadata=metadata,
         )
     del w, qg, kg, dv_intra
-    with torch.profiler.record_function("kda/cute/backward_wy_dqkg"):
+    with profiler_range("kda/cute/backward_wy_dqkg"):
         dq, dk, dv, dg, db, dAkk = chunk_kda_bwd_wy_dqkg(
             q,
             k,
@@ -118,9 +123,10 @@ def chunk_kda_bwd(
             metadata,
             chunk_size=chunk_size,
             fastmath=fastmath,
+            autotune=autotune,
         )
     del h, v_new, dh
-    with torch.profiler.record_function("kda/cute/backward_intra"):
+    with profiler_range("kda/cute/backward_intra"):
         dq, dk, dg, db = chunk_kda_bwd_intra(
             q,
             k,
@@ -133,6 +139,7 @@ def chunk_kda_bwd(
             db,
             dg,
             metadata,
+            autotune=autotune,
         )
     return dq, dk, dv, dg, db, d_initial_state
 

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_intra.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_intra.py
@@ -22,7 +22,7 @@ from cutlass.cute.runtime import make_fake_compact_tensor, make_fake_tensor
 from cutlass.cutlass_dsl import Constexpr, T, dsl_user_op
 
 from attn_gym._backends.cute import compile_tvm_ffi, jit_cache, run_tunable
-from attn_gym._backends.cute.target import detect_compile_target, get_compile_target
+from attn_gym._backends.cute.target import CompileTarget, detect_compile_target, get_compile_target
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata
 from attn_gym.linear.kda.fwd.cute.chunk_scheduler_cute import load_ragged_chunk_work
 
@@ -2082,16 +2082,25 @@ class ChunkKdaBwdIntraTunable:
         chunk_offsets: torch.Tensor | None
         capacity: int
 
-    # The public wrapper replaces this universal fallback with a target-aware default.
-    default_config = ChunkKdaBwdIntraConfig(1)
+    @staticmethod
+    def default_config(args: Args, *, target: CompileTarget) -> ChunkKdaBwdIntraConfig:
+        """Choose a deterministic target- and capacity-aware persistent grid."""
+        if target.sm_count is None:
+            raise RuntimeError("KDA launch requires a CUDA target with an SM count")
+        chunks = args.capacity
+        grid_limit = min(chunks, 1 << (target.sm_count.bit_length() - 1))
+        amortized_grid = max(1, grid_limit // 2)
+        grid_chunks = (
+            amortized_grid if chunks % amortized_grid == 0 else min(chunks, target.sm_count)
+        )
+        return ChunkKdaBwdIntraConfig(grid_chunks)
 
     @staticmethod
-    def default_for(chunks: int, sm_count: int) -> ChunkKdaBwdIntraConfig:
-        """Prefer a smaller power-of-two grid when it evenly partitions the chunks."""
-        grid_limit = min(chunks, 1 << (sm_count.bit_length() - 1))
-        amortized_grid = max(1, grid_limit // 2)
-        grid_chunks = amortized_grid if chunks % amortized_grid == 0 else min(chunks, sm_count)
-        return ChunkKdaBwdIntraConfig(grid_chunks)
+    def tuning_key(_args: Args, *, target: CompileTarget) -> tuple[()]:
+        """Reuse winners because capacity is already a compile specialization."""
+        if target.sm_count is None:
+            raise RuntimeError("KDA tuning requires a CUDA target with an SM count")
+        return ()
 
     @classmethod
     def configs(cls, args: Args) -> tuple[ChunkKdaBwdIntraConfig, ...]:
@@ -2101,7 +2110,7 @@ class ChunkKdaBwdIntraTunable:
             raise RuntimeError("KDA tuning requires a CUDA target with an SM count")
         grid_limit = min(args.capacity, 1 << (sm_count.bit_length() - 1))
         values = (
-            cls.default_for(args.capacity, sm_count).grid_chunks,
+            cls.default_config(args, target=get_compile_target()).grid_chunks,
             max(1, grid_limit // 4),
             grid_limit,
             min(args.capacity, sm_count),
@@ -2162,7 +2171,7 @@ def chunk_kda_bwd_intra(
     metadata: RaggedChunkMetadata | None,
     *,
     config: ChunkKdaBwdIntraConfig | None = None,
-    tune: bool = False,
+    autotune: bool = False,
     configs: Iterable[ChunkKdaBwdIntraConfig] | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """Run or tune the final dense or fixed-capacity ragged backward stage.
@@ -2222,15 +2231,13 @@ def chunk_kda_bwd_intra(
         capacity=capacity,
     )
     target = detect_compile_target(q.device.index)
-    if not tune and config is None:
-        if target.sm_count is None:
-            raise RuntimeError("KDA launch requires a CUDA target with an SM count")
-        config = ChunkKdaBwdIntraTunable.default_for(capacity, target.sm_count)
+    # An explicit config pins the schedule regardless of the plumbed flag.
+    autotune = autotune and config is None
     result, _ = run_tunable(
         ChunkKdaBwdIntraTunable,
         args,
         config=config,
-        autotune=tune,
+        autotune=autotune,
         configs=configs,
         parallel_compile=_compile_chunk_kda_bwd_intra.disk_cache_enabled(),
         target=target,

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_wy_dqkg_fused.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_wy_dqkg_fused.py
@@ -32,7 +32,7 @@ from cutlass.cute.tensor import TensorSSA
 from cutlass.cute.typing import BFloat16, Float32, Int32, Int64
 
 from attn_gym._backends.cute import compile_tvm_ffi, jit_cache, run_tunable
-from attn_gym._backends.cute.target import detect_compile_target, get_compile_target
+from attn_gym._backends.cute.target import CompileTarget, detect_compile_target, get_compile_target
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata
 from attn_gym.linear.kda.fwd.cute.chunk_scheduler_cute import load_ragged_chunk_work
 
@@ -4793,7 +4793,23 @@ class ChunkKdaBwdWyDqkgTunable:
         chunk_size: int
         fastmath: bool
 
-    default_config = ChunkKdaBwdWyDqkgConfig(grid_waves=1)
+    @staticmethod
+    def default_config(
+        _args: Args,
+        *,
+        target: CompileTarget,
+    ) -> ChunkKdaBwdWyDqkgConfig:
+        """Choose the deterministic single-wave persistent schedule."""
+        if target.sm_count is None:
+            raise RuntimeError("KDA launch requires a CUDA target with an SM count")
+        return ChunkKdaBwdWyDqkgConfig(grid_waves=1)
+
+    @staticmethod
+    def tuning_key(args: Args, *, target: CompileTarget) -> tuple[int]:
+        """Key winners by the static persistent-grid work envelope."""
+        if target.sm_count is None:
+            raise RuntimeError("KDA tuning requires a CUDA target with an SM count")
+        return (args.h.shape[1] * args.q.shape[2],)
 
     @staticmethod
     def configs(
@@ -4884,7 +4900,7 @@ def chunk_kda_bwd_wy_dqkg(
     chunk_size: int = 64,
     fastmath: bool = False,
     config: ChunkKdaBwdWyDqkgConfig | None = None,
-    tune: bool = False,
+    autotune: bool = False,
     configs: Iterable[ChunkKdaBwdWyDqkgConfig] | None = None,
 ) -> tuple[
     torch.Tensor,
@@ -4951,11 +4967,13 @@ def chunk_kda_bwd_wy_dqkg(
         chunk_size=chunk_size,
         fastmath=fastmath,
     )
+    # An explicit config pins the schedule regardless of the plumbed flag.
+    autotune = autotune and config is None
     result, _ = run_tunable(
         ChunkKdaBwdWyDqkgTunable,
         args,
         config=config,
-        autotune=tune,
+        autotune=autotune,
         configs=configs,
         parallel_compile=_compile_chunk_kda_bwd_wy_dqkg.disk_cache_enabled(),
         target=detect_compile_target(q.device.index),

--- a/attn_gym/linear/kda/bwd/triton/chunk_kda_bwd_dav.py
+++ b/attn_gym/linear/kda/bwd/triton/chunk_kda_bwd_dav.py
@@ -17,7 +17,12 @@ import triton
 import triton.language as tl
 from triton.tools.tensor_descriptor import TensorDescriptor
 
-from attn_gym._backends.triton.utils import can_use_tma, ptr_offset, requires_int64_offsets
+from attn_gym._backends.triton.utils import (
+    PinnedConfigKernel,
+    can_use_tma,
+    ptr_offset,
+    requires_int64_offsets,
+)
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata, load_ragged_chunk_work
 from attn_gym.linear.kda.utils import autotune_cache_kwargs
 
@@ -294,6 +299,7 @@ def _launch_dav_ragged(
     scale: float,
     chunk_size: int,
     metadata: RaggedChunkMetadata,
+    autotune: bool,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Launch the packed dAv kernel with TMA descriptors when the layout allows."""
     _, tokens, heads, value_dim = v.shape
@@ -327,7 +333,8 @@ def _launch_dav_ragged(
             num_stages=3,
         )
     else:
-        chunk_kda_bwd_kernel_dAv[(metadata.capacity, heads)](
+        kernel = chunk_kda_bwd_kernel_dAv if autotune else _PINNED_DAV
+        kernel[(metadata.capacity, heads)](
             v=v,
             A=A,
             do=do,
@@ -346,6 +353,9 @@ def _launch_dav_ragged(
     return dv, dA
 
 
+_PINNED_DAV = PinnedConfigKernel(chunk_kda_bwd_kernel_dAv)
+
+
 def chunk_kda_bwd_dav(
     v: torch.Tensor,
     A: torch.Tensor,
@@ -354,6 +364,7 @@ def chunk_kda_bwd_dav(
     *,
     chunk_size: int = 64,
     metadata: RaggedChunkMetadata | None = None,
+    autotune: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Differentiate the fixed-length or packed KDA intra-chunk value term.
 
@@ -370,7 +381,7 @@ def chunk_kda_bwd_dav(
         metadata.validate_chunk_size(chunk_size)
         if batch != 1:
             raise ValueError("ragged KDA dAv metadata requires batch size 1")
-        return _launch_dav_ragged(v, A, do, scale, chunk_size, metadata)
+        return _launch_dav_ragged(v, A, do, scale, chunk_size, metadata, autotune)
     if tokens % chunk_size:
         raise ValueError(f"the KDA dAv kernel requires complete chunks, got T={tokens}")
 
@@ -382,7 +393,8 @@ def chunk_kda_bwd_dav(
 
     block_value_dim = 64
     if (value_dim, chunk_size) == (128, 64) and _can_use_tensor_descriptors(v, A, do, dv, dA):
-        chunk_kda_bwd_kernel_dAv[(chunks, batch * heads)](
+        kernel = chunk_kda_bwd_kernel_dAv if autotune else _PINNED_DAV
+        kernel[(chunks, batch * heads)](
             v=TensorDescriptor.from_tensor(v, [1, chunk_size, 1, block_value_dim]),
             A=TensorDescriptor.from_tensor(A, [1, chunk_size, 1, chunk_size]),
             do=TensorDescriptor.from_tensor(do, [1, chunk_size, 1, block_value_dim]),
@@ -399,7 +411,8 @@ def chunk_kda_bwd_dav(
             num_sequences=0,
         )
     else:
-        chunk_kda_bwd_kernel_dAv[(chunks, batch * heads)](
+        kernel = chunk_kda_bwd_kernel_dAv if autotune else _PINNED_DAV
+        kernel[(chunks, batch * heads)](
             v=v,
             A=A,
             do=do,

--- a/attn_gym/linear/kda/chunk_schedule.py
+++ b/attn_gym/linear/kda/chunk_schedule.py
@@ -1,0 +1,107 @@
+"""Torch-only packed chunk metadata used by the public fused wrapper."""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+import torch
+
+from attn_gym.linear.kda.ops import prepare_chunk_offsets_op
+
+
+class RaggedChunkMetadata(NamedTuple):
+    """Graph-safe routing for sequence-relative chunks in a packed token buffer.
+
+    Attributes:
+        cu_seqlens: Device tensor of shape ``[N + 1]`` containing packed token
+            boundaries. Sequence ``i`` occupies
+            ``[cu_seqlens[i], cu_seqlens[i + 1])``; repeated boundaries represent
+            empty sequences.
+        chunk_offsets: Device tensor of shape ``[N + 1]`` containing the exclusive
+            prefix sum of per-sequence chunk counts. It is a sequence-boundary
+            tensor, not a per-chunk map::
+
+                count[i] = ceil_div(
+                    cu_seqlens[i + 1] - cu_seqlens[i], chunk_size
+                )
+                chunk_offsets[i + 1] = chunk_offsets[i] + count[i]
+
+            Thus ``chunk_offsets[-1]`` is the runtime active chunk count and
+            sequence ``i`` owns global chunks in
+            ``[chunk_offsets[i], chunk_offsets[i + 1])``. Given a
+            ``global_chunk``, kernels find its sequence with
+            ``upper_bound(chunk_offsets, global_chunk) - 1``. Upper-bound search
+            handles the repeated offsets produced by empty sequences.
+        capacity: Static host-side upper bound on the active chunk count for every
+            boundary distribution with the same token and sequence tensor shapes.
+            CUDA Graph capture fixes launch and allocation shapes, so kernels use
+            this capacity while reading the actual active count from
+            ``chunk_offsets[-1]`` on the device. Capacity-only CTAs finish without
+            accessing token data.
+        chunk_size: Logical chunk size used to construct ``chunk_offsets``. Keeping
+            it with the offsets prevents consumers from decoding them under a
+            different chunking scheme.
+
+    On CUDA Graph replay, values in ``cu_seqlens`` may change from aligned to ragged
+    without host synchronization or recapture, provided the physical token capacity
+    and sequence tensor shapes remain fixed. The terminal offset is the dynamic active
+    token count and may be smaller than the physical capacity.
+    """
+
+    cu_seqlens: torch.Tensor
+    chunk_offsets: torch.Tensor
+    capacity: int
+    chunk_size: int
+
+    def validate_chunk_size(self, chunk_size: int) -> None:
+        """Reject consumers configured for a different logical chunk size."""
+        if self.chunk_size != chunk_size:
+            raise ValueError(
+                f"metadata chunk size must match chunk_size={chunk_size}, got {self.chunk_size}"
+            )
+
+
+def chunk_capacity(tokens: int, num_sequences: int, chunk_size: int) -> int:
+    """Return the exact shape-derived launch bound over all valid boundaries.
+
+    At most ``min(tokens, num_sequences)`` sequences can be nonempty. Giving each
+    such sequence one token creates one chunk per sequence; concentrating all
+    remaining tokens in one sequence maximizes the number of additional chunks.
+    """
+    if tokens < 0:
+        raise ValueError(f"tokens must be nonnegative, got {tokens}")
+    if num_sequences < 1:
+        raise ValueError(f"num_sequences must be positive, got {num_sequences}")
+    if chunk_size < 1:
+        raise ValueError(f"chunk_size must be positive, got {chunk_size}")
+
+    nonempty = min(tokens, num_sequences)
+    if nonempty == 0:
+        return 0
+    return nonempty + (tokens - nonempty) // chunk_size
+
+
+def prepare_ragged_chunk_metadata(
+    cu_seqlens: torch.Tensor,
+    tokens: int,
+    chunk_size: int,
+) -> RaggedChunkMetadata:
+    """Build graph-safe packed chunk metadata through the registered scheduler op."""
+    if cu_seqlens.ndim != 1 or cu_seqlens.shape[0] < 2:
+        raise ValueError("cu_seqlens must have shape [num_sequences + 1]")
+    if cu_seqlens.dtype != torch.int32 or not cu_seqlens.is_contiguous():
+        raise ValueError("cu_seqlens must be contiguous int32")
+    if not cu_seqlens.is_cuda:
+        raise ValueError("cu_seqlens must be a CUDA tensor")
+
+    num_sequences = cu_seqlens.shape[0] - 1
+    capacity = chunk_capacity(tokens, num_sequences, chunk_size)
+    chunk_offsets = prepare_chunk_offsets_op(cu_seqlens, tokens, chunk_size)
+    return RaggedChunkMetadata(cu_seqlens, chunk_offsets, capacity, chunk_size)
+
+
+__all__ = [
+    "RaggedChunkMetadata",
+    "chunk_capacity",
+    "prepare_ragged_chunk_metadata",
+]

--- a/attn_gym/linear/kda/chunk_scheduler.py
+++ b/attn_gym/linear/kda/chunk_scheduler.py
@@ -9,57 +9,7 @@ import torch
 import triton
 import triton.language as tl
 
-
-class RaggedChunkMetadata(NamedTuple):
-    """Graph-safe routing for sequence-relative chunks in a packed token buffer.
-
-    Attributes:
-        cu_seqlens: Device tensor of shape ``[N + 1]`` containing packed token
-            boundaries. Sequence ``i`` occupies
-            ``[cu_seqlens[i], cu_seqlens[i + 1])``; repeated boundaries represent
-            empty sequences.
-        chunk_offsets: Device tensor of shape ``[N + 1]`` containing the exclusive
-            prefix sum of per-sequence chunk counts. It is a sequence-boundary
-            tensor, not a per-chunk map::
-
-                count[i] = ceil_div(
-                    cu_seqlens[i + 1] - cu_seqlens[i], chunk_size
-                )
-                chunk_offsets[i + 1] = chunk_offsets[i] + count[i]
-
-            Thus ``chunk_offsets[-1]`` is the runtime active chunk count and
-            sequence ``i`` owns global chunks in
-            ``[chunk_offsets[i], chunk_offsets[i + 1])``. Given a
-            ``global_chunk``, kernels find its sequence with
-            ``upper_bound(chunk_offsets, global_chunk) - 1``. Upper-bound search
-            handles the repeated offsets produced by empty sequences.
-        capacity: Static host-side upper bound on the active chunk count for every
-            boundary distribution with the same token and sequence tensor shapes.
-            CUDA Graph capture fixes launch and allocation shapes, so kernels use
-            this capacity while reading the actual active count from
-            ``chunk_offsets[-1]`` on the device. Capacity-only CTAs finish without
-            accessing token data.
-        chunk_size: Logical chunk size used to construct ``chunk_offsets``. Keeping
-            it with the offsets prevents consumers from decoding them under a
-            different chunking scheme.
-
-    On CUDA Graph replay, values in ``cu_seqlens`` may change from aligned to ragged
-    without host synchronization or recapture, provided the physical token capacity
-    and sequence tensor shapes remain fixed. The terminal offset is the dynamic active
-    token count and may be smaller than the physical capacity.
-    """
-
-    cu_seqlens: torch.Tensor
-    chunk_offsets: torch.Tensor
-    capacity: int
-    chunk_size: int
-
-    def validate_chunk_size(self, chunk_size: int) -> None:
-        """Reject consumers configured for a different logical chunk size."""
-        if self.chunk_size != chunk_size:
-            raise ValueError(
-                f"metadata chunk size must match chunk_size={chunk_size}, got {self.chunk_size}"
-            )
+from attn_gym.linear.kda.chunk_schedule import RaggedChunkMetadata, chunk_capacity
 
 
 class ChunkWork(NamedTuple):
@@ -70,29 +20,6 @@ class ChunkWork(NamedTuple):
     local_chunk: int
     token_start: int
     valid_tokens: int
-
-
-MAX_NUM_SEQUENCES = 4096
-
-
-def chunk_capacity(tokens: int, num_sequences: int, chunk_size: int) -> int:
-    """Return the exact shape-derived launch bound over all valid boundaries.
-
-    At most ``min(tokens, num_sequences)`` sequences can be nonempty. Giving each
-    such sequence one token creates one chunk per sequence; concentrating all
-    remaining tokens in one sequence maximizes the number of additional chunks.
-    """
-    if tokens < 0:
-        raise ValueError(f"tokens must be nonnegative, got {tokens}")
-    if num_sequences < 1:
-        raise ValueError(f"num_sequences must be positive, got {num_sequences}")
-    if chunk_size < 1:
-        raise ValueError(f"chunk_size must be positive, got {chunk_size}")
-
-    nonempty = min(tokens, num_sequences)
-    if nonempty == 0:
-        return 0
-    return nonempty + (tokens - nonempty) // chunk_size
 
 
 def chunk_work_oracle(cu_seqlens: list[int], chunk_size: int) -> list[ChunkWork]:
@@ -209,6 +136,27 @@ def _decode_ragged_chunk_work_kernel(
             tl.store(output + field, -1)
 
 
+def _prepare_ragged_chunk_offsets(
+    cu_seqlens: torch.Tensor,
+    tokens: int,
+    chunk_size: int,
+) -> torch.Tensor:
+    """Build packed chunk offsets for the torch-only registration wrapper."""
+    num_sequences = cu_seqlens.shape[0] - 1
+    chunk_offsets = torch.empty_like(cu_seqlens)
+    block = triton.next_power_of_2(num_sequences)
+    _prepare_ragged_chunk_offsets_kernel[(1,)](
+        cu_seqlens,
+        chunk_offsets,
+        num_sequences=num_sequences,
+        tokens=tokens,
+        chunk_size=chunk_size,
+        BLOCK=block,
+        num_warps=min(8, max(1, block // 32)),
+    )
+    return chunk_offsets
+
+
 def prepare_ragged_chunk_metadata(
     cu_seqlens: torch.Tensor,
     tokens: int,
@@ -223,23 +171,8 @@ def prepare_ragged_chunk_metadata(
         raise ValueError("cu_seqlens must be a CUDA tensor")
 
     num_sequences = cu_seqlens.shape[0] - 1
-    if num_sequences > MAX_NUM_SEQUENCES:
-        raise ValueError(
-            f"the ragged chunk scheduler supports at most {MAX_NUM_SEQUENCES} sequences, "
-            f"got {num_sequences}"
-        )
     capacity = chunk_capacity(tokens, num_sequences, chunk_size)
-    chunk_offsets = torch.empty_like(cu_seqlens)
-    block = triton.next_power_of_2(num_sequences)
-    _prepare_ragged_chunk_offsets_kernel[(1,)](
-        cu_seqlens,
-        chunk_offsets,
-        num_sequences=num_sequences,
-        tokens=tokens,
-        chunk_size=chunk_size,
-        BLOCK=block,
-        num_warps=min(8, max(1, block // 32)),
-    )
+    chunk_offsets = _prepare_ragged_chunk_offsets(cu_seqlens, tokens, chunk_size)
     return RaggedChunkMetadata(cu_seqlens, chunk_offsets, capacity, chunk_size)
 
 
@@ -263,7 +196,6 @@ def decode_ragged_chunk_work(metadata: RaggedChunkMetadata) -> torch.Tensor:
 
 
 __all__ = [
-    "MAX_NUM_SEQUENCES",
     "ChunkWork",
     "RaggedChunkMetadata",
     "chunk_capacity",

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py
@@ -5,75 +5,35 @@ from __future__ import annotations
 import torch
 
 from attn_gym._backends.cute import get_device_properties, tensor_supports_tma
-from attn_gym.linear.kda.chunk_scheduler import (
-    RaggedChunkMetadata,
-    chunk_capacity,
-    prepare_ragged_chunk_metadata,
-)
+from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata, chunk_capacity
 from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd_intra import chunk_kda_fwd_intra
 from attn_gym.linear.kda.fwd.triton.chunk_delta_h import chunk_gated_delta_rule_fwd_h
 from attn_gym.linear.kda.fwd.triton.chunk_gla_fwd_o import chunk_gla_fwd_o_gk
+from attn_gym.linear.kda.impl.fused import chunk_forward as _chunk_kda
+from attn_gym.linear.kda.ops import (
+    chunk_bwd_op as _chunk_kda_bwd_op,
+)
+from attn_gym.linear.kda.ops import (
+    chunk_bwd_with_state_grad_op as _chunk_kda_bwd_with_state_grad_op,
+)
+from attn_gym.linear.kda.ops import (
+    chunk_fwd_op as _chunk_kda_fwd_op,
+)
+from attn_gym.linear.kda.ops import (
+    chunk_fwd_ragged_op as _chunk_kda_fwd_ragged_op,
+)
+from attn_gym.linear.kda.ops import (
+    chunk_fwd_ragged_with_state_op as _chunk_kda_fwd_ragged_with_state_op,
+)
+from attn_gym.linear.kda.ops import (
+    chunk_fwd_with_state_op as _chunk_kda_fwd_with_state_op,
+)
+from attn_gym.linear.kda.utils import profiler_range
 
-_SUPPORTED_INPUT_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
 # TODO: Revisit model-approved chunk sizes: this is a major performance lever,
 # but it changes the KDA decomposition and rounding order, so it can affect numerics.
 _CHUNK_SIZE = 64
 _HEAD_DIM = 128
-
-
-def _validate_chunk_kda_inputs(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    cumulative_gate: torch.Tensor,
-    beta: torch.Tensor,
-    initial_state: torch.Tensor | None,
-    cu_seqlens: torch.Tensor | None,
-) -> None:
-    """Validate the exported operation's contract before normalizing inputs."""
-    if q.ndim != 4:
-        raise ValueError(f"q must have shape [B, T, H, K], got {tuple(q.shape)}")
-    batch, tokens, heads, head_dim = q.shape
-    if tokens == 0 or heads == 0:
-        raise ValueError(f"q must have nonempty token and head dimensions, got {tuple(q.shape)}")
-    if k.shape != q.shape:
-        raise ValueError(f"k must have shape {tuple(q.shape)}, got {tuple(k.shape)}")
-    if v.shape != (batch, tokens, heads, _HEAD_DIM):
-        raise ValueError(
-            f"v must have shape {(batch, tokens, heads, _HEAD_DIM)}, got {tuple(v.shape)}"
-        )
-    if cumulative_gate.shape != q.shape:
-        raise ValueError(
-            f"cumulative_gate must have shape {tuple(q.shape)}, got {tuple(cumulative_gate.shape)}"
-        )
-    if beta.shape != (batch, tokens, heads):
-        raise ValueError(f"beta must have shape {(batch, tokens, heads)}, got {tuple(beta.shape)}")
-    if cu_seqlens is not None:
-        if batch != 1:
-            raise ValueError("packed cu_seqlens require q to have batch size one")
-        if cu_seqlens.ndim != 1 or cu_seqlens.shape[0] < 2:
-            raise ValueError("cu_seqlens must have shape [num_sequences + 1]")
-        if cu_seqlens.dtype != torch.int32 or not cu_seqlens.is_contiguous():
-            raise ValueError("cu_seqlens must be contiguous CUDA int32")
-    state_batch = batch if cu_seqlens is None else cu_seqlens.shape[0] - 1
-    expected_state = (state_batch, heads, head_dim, v.shape[-1])
-    if initial_state is not None and initial_state.shape != expected_state:
-        raise ValueError(
-            f"initial_state must have shape {expected_state}, got {tuple(initial_state.shape)}"
-        )
-    data_tensors = (q, k, v, cumulative_gate, beta)
-    if initial_state is not None:
-        data_tensors += (initial_state,)
-    tensors = data_tensors if cu_seqlens is None else (*data_tensors, cu_seqlens)
-    if not all(tensor.is_cuda and tensor.device == q.device for tensor in tensors):
-        raise ValueError("all chunk_kda inputs must be CUDA tensors on the same device")
-    if any(tensor.dtype not in _SUPPORTED_INPUT_DTYPES for tensor in data_tensors):
-        supported = ", ".join(str(dtype) for dtype in _SUPPORTED_INPUT_DTYPES)
-        raise TypeError(f"chunk_kda inputs must use one of {supported}")
-    if head_dim != _HEAD_DIM:
-        raise ValueError("the CuTe KDA core requires K=V=128")
-    if not torch.compiler.is_compiling() and get_device_properties(q.device).major < 10:
-        raise ValueError("the CuTe KDA core requires CUDA capability 10.0 or newer")
 
 
 def _has_supported_qkv_layout(tensor: torch.Tensor) -> bool:
@@ -126,11 +86,12 @@ def _chunk_kda_fwd(
     metadata: RaggedChunkMetadata | None,
     *,
     output_final_state: bool,
+    autotune: bool,
 ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor, torch.Tensor]:
     """Run the optimized KDA core using an already selected chunk schedule."""
     scale = _HEAD_DIM**-0.5
 
-    with torch.profiler.record_function("kda/fused/chunk_kda_fwd_intra"):
+    with profiler_range("kda/fused/chunk_kda_fwd_intra"):
         w, u, kg, Aqk, Akk = chunk_kda_fwd_intra(
             q,
             k,
@@ -140,9 +101,10 @@ def _chunk_kda_fwd(
             scale,
             metadata,
             chunk_size=_CHUNK_SIZE,
-            profile_ranges=True,
+            profile_ranges=torch.autograd.profiler._is_profiler_enabled,
+            autotune=autotune,
         )
-    with torch.profiler.record_function("kda/triton/inter_chunk_state"):
+    with profiler_range("kda/triton/inter_chunk_state"):
         h, v_new, final_state = chunk_gated_delta_rule_fwd_h(
             kg,
             w,
@@ -152,8 +114,9 @@ def _chunk_kda_fwd(
             chunk_size=_CHUNK_SIZE,
             output_final_state=output_final_state,
             metadata=metadata,
+            autotune=autotune,
         )
-    with torch.profiler.record_function("kda/triton/output_composition"):
+    with profiler_range("kda/triton/output_composition"):
         output = chunk_gla_fwd_o_gk(
             q,
             v_new,
@@ -163,22 +126,9 @@ def _chunk_kda_fwd(
             scale,
             chunk_size=_CHUNK_SIZE,
             metadata=metadata,
+            autotune=autotune,
         )
     return output, final_state, Aqk, Akk
-
-
-# Fixed-arity schema pair instead of an optional final-state output.
-_FWD_ARGS = (
-    "(Tensor q, Tensor k, Tensor v, Tensor cumulative_gate, Tensor beta, Tensor? initial_state)"
-)
-torch.library.define(
-    "attn_gym::kda_chunk_fwd",
-    f"{_FWD_ARGS} -> (Tensor, Tensor, Tensor)",
-)
-torch.library.define(
-    "attn_gym::kda_chunk_fwd_with_state",
-    f"{_FWD_ARGS} -> (Tensor, Tensor, Tensor, Tensor)",
-)
 
 
 def _chunk_kda_fwd_shared(
@@ -188,6 +138,7 @@ def _chunk_kda_fwd_shared(
     cumulative_gate: torch.Tensor,
     beta: torch.Tensor,
     initial_state: torch.Tensor | None,
+    autotune: bool,
     output_final_state: bool,
 ):
     """Keep the complete composed forward behind one compiler-opaque boundary."""
@@ -202,6 +153,7 @@ def _chunk_kda_fwd_shared(
         initial_state,
         None,
         output_final_state=output_final_state,
+        autotune=autotune,
     )
 
 
@@ -212,6 +164,7 @@ def _chunk_kda_fwd_cuda(
     cumulative_gate: torch.Tensor,
     beta: torch.Tensor,
     initial_state: torch.Tensor | None,
+    autotune: bool,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     output, _final_state, Aqk, Akk = _chunk_kda_fwd_shared(
         q,
@@ -220,6 +173,7 @@ def _chunk_kda_fwd_cuda(
         cumulative_gate,
         beta,
         initial_state,
+        autotune,
         False,
     )
     return output, Aqk, Akk
@@ -232,6 +186,7 @@ def _chunk_kda_fwd_with_state_cuda(
     cumulative_gate: torch.Tensor,
     beta: torch.Tensor,
     initial_state: torch.Tensor | None,
+    autotune: bool,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     return _chunk_kda_fwd_shared(
         q,
@@ -240,63 +195,9 @@ def _chunk_kda_fwd_with_state_cuda(
         cumulative_gate,
         beta,
         initial_state,
+        autotune,
         True,
     )
-
-
-torch.library.impl("attn_gym::kda_chunk_fwd", "CUDA", _chunk_kda_fwd_cuda)
-torch.library.impl("attn_gym::kda_chunk_fwd_with_state", "CUDA", _chunk_kda_fwd_with_state_cuda)
-
-
-def _fwd_fake_common(q: torch.Tensor, v: torch.Tensor):
-    """Describe the composed forward outputs shared by both schemas."""
-    tape_shape = (q.shape[0], q.shape[1], q.shape[2], _CHUNK_SIZE)
-    return v.new_empty(v.shape), q.new_empty(tape_shape), q.new_empty(tape_shape)
-
-
-@torch.library.register_fake("attn_gym::kda_chunk_fwd")
-def _chunk_kda_fwd_fake(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    cumulative_gate: torch.Tensor,
-    beta: torch.Tensor,
-    initial_state: torch.Tensor | None,
-):
-    del k, cumulative_gate, beta, initial_state
-    return _fwd_fake_common(q, v)
-
-
-@torch.library.register_fake("attn_gym::kda_chunk_fwd_with_state")
-def _chunk_kda_fwd_with_state_fake(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    cumulative_gate: torch.Tensor,
-    beta: torch.Tensor,
-    initial_state: torch.Tensor | None,
-):
-    del k, cumulative_gate, beta, initial_state
-    output, Aqk, Akk = _fwd_fake_common(q, v)
-    state = q.new_empty(
-        (q.shape[0], q.shape[2], q.shape[3], v.shape[-1]),
-        dtype=torch.float32,
-    )
-    return output, state, Aqk, Akk
-
-
-_RAGGED_FWD_ARGS = (
-    "(Tensor q, Tensor k, Tensor v, Tensor cumulative_gate, Tensor beta, "
-    "Tensor? initial_state, Tensor cu_seqlens, Tensor chunk_offsets)"
-)
-torch.library.define(
-    "attn_gym::kda_chunk_fwd_ragged",
-    f"{_RAGGED_FWD_ARGS} -> (Tensor, Tensor, Tensor)",
-)
-torch.library.define(
-    "attn_gym::kda_chunk_fwd_ragged_with_state",
-    f"{_RAGGED_FWD_ARGS} -> (Tensor, Tensor, Tensor, Tensor)",
-)
 
 
 def _chunk_kda_fwd_ragged_shared(
@@ -308,6 +209,7 @@ def _chunk_kda_fwd_ragged_shared(
     initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor,
     chunk_offsets: torch.Tensor,
+    autotune: bool,
     output_final_state: bool,
 ):
     """Run ragged forward with caller-prepared routing and fixed-schema tape."""
@@ -328,6 +230,7 @@ def _chunk_kda_fwd_ragged_shared(
         initial_state,
         metadata,
         output_final_state=output_final_state,
+        autotune=autotune,
     )
 
 
@@ -340,6 +243,7 @@ def _chunk_kda_fwd_ragged_cuda(
     initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor,
     chunk_offsets: torch.Tensor,
+    autotune: bool,
 ):
     output, _state, Aqk, Akk = _chunk_kda_fwd_ragged_shared(
         q,
@@ -350,6 +254,7 @@ def _chunk_kda_fwd_ragged_cuda(
         initial_state,
         cu_seqlens,
         chunk_offsets,
+        autotune,
         False,
     )
     return output, Aqk, Akk
@@ -364,6 +269,7 @@ def _chunk_kda_fwd_ragged_with_state_cuda(
     initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor,
     chunk_offsets: torch.Tensor,
+    autotune: bool,
 ):
     return _chunk_kda_fwd_ragged_shared(
         q,
@@ -374,71 +280,9 @@ def _chunk_kda_fwd_ragged_with_state_cuda(
         initial_state,
         cu_seqlens,
         chunk_offsets,
+        autotune,
         True,
     )
-
-
-torch.library.impl("attn_gym::kda_chunk_fwd_ragged", "CUDA", _chunk_kda_fwd_ragged_cuda)
-torch.library.impl(
-    "attn_gym::kda_chunk_fwd_ragged_with_state",
-    "CUDA",
-    _chunk_kda_fwd_ragged_with_state_cuda,
-)
-
-
-@torch.library.register_fake("attn_gym::kda_chunk_fwd_ragged")
-def _chunk_kda_fwd_ragged_fake(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    cumulative_gate: torch.Tensor,
-    beta: torch.Tensor,
-    initial_state: torch.Tensor | None,
-    cu_seqlens: torch.Tensor,
-    chunk_offsets: torch.Tensor,
-):
-    """Describe ragged forward and backward-tape outputs."""
-    del k, cumulative_gate, beta, initial_state, cu_seqlens, chunk_offsets
-    return _fwd_fake_common(q, v)
-
-
-@torch.library.register_fake("attn_gym::kda_chunk_fwd_ragged_with_state")
-def _chunk_kda_fwd_ragged_with_state_fake(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    cumulative_gate: torch.Tensor,
-    beta: torch.Tensor,
-    initial_state: torch.Tensor | None,
-    cu_seqlens: torch.Tensor,
-    chunk_offsets: torch.Tensor,
-):
-    """Describe ragged stateful forward and backward-tape outputs."""
-    del k, cumulative_gate, beta, initial_state, chunk_offsets
-    output, Aqk, Akk = _fwd_fake_common(q, v)
-    state = q.new_empty(
-        (cu_seqlens.shape[0] - 1, q.shape[2], q.shape[3], v.shape[-1]),
-        dtype=torch.float32,
-    )
-    return output, state, Aqk, Akk
-
-
-# Fixed-arity schema pair instead of an optional initial-state-gradient output.
-_BWD_ARGS = (
-    "(Tensor q, Tensor k, Tensor v, Tensor cumulative_gate, Tensor beta, Tensor Aqk, "
-    "Tensor Akk, Tensor? cu_seqlens, Tensor? chunk_offsets, Tensor? d_output, "
-    "Tensor? d_final_state, {initial_state}, bool fastmath)"
-)
-torch.library.define(
-    "attn_gym::kda_chunk_bwd",
-    _BWD_ARGS.format(initial_state="Tensor? initial_state")
-    + " -> (Tensor, Tensor, Tensor, Tensor, Tensor)",
-)
-torch.library.define(
-    "attn_gym::kda_chunk_bwd_with_state_grad",
-    _BWD_ARGS.format(initial_state="Tensor initial_state")
-    + " -> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor)",
-)
 
 
 def _chunk_kda_bwd_shared(
@@ -455,6 +299,7 @@ def _chunk_kda_bwd_shared(
     d_final_state: torch.Tensor | None,
     initial_state: torch.Tensor | None,
     fastmath: bool,
+    autotune: bool,
 ):
     """Keep the complete first-order composed backward opaque to AOTAutograd."""
     from attn_gym.linear.kda.bwd.cute.chunk_kda_bwd import chunk_kda_bwd
@@ -490,6 +335,7 @@ def _chunk_kda_bwd_shared(
         initial_state,
         metadata,
         fastmath=fastmath,
+        autotune=autotune,
     )
 
 
@@ -502,280 +348,14 @@ def _chunk_kda_bwd_with_state_grad_cuda(*args) -> tuple[torch.Tensor, ...]:
     return _chunk_kda_bwd_shared(*args)
 
 
-torch.library.impl("attn_gym::kda_chunk_bwd", "CUDA", _chunk_kda_bwd_cuda)
-torch.library.impl(
-    "attn_gym::kda_chunk_bwd_with_state_grad", "CUDA", _chunk_kda_bwd_with_state_grad_cuda
-)
+forward = _chunk_kda
 
-
-def _bwd_fake_common(q, k, v, cumulative_gate, beta):
-    """Describe backward output metadata without invoking a launcher."""
-    return (
-        q.new_empty(q.shape),
-        k.new_empty(k.shape),
-        v.new_empty(v.shape),
-        cumulative_gate.new_empty(cumulative_gate.shape),
-        beta.new_empty(beta.shape),
-    )
-
-
-@torch.library.register_fake("attn_gym::kda_chunk_bwd")
-def _chunk_kda_bwd_fake(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    cumulative_gate: torch.Tensor,
-    beta: torch.Tensor,
-    Aqk: torch.Tensor,
-    Akk: torch.Tensor,
-    cu_seqlens: torch.Tensor | None,
-    chunk_offsets: torch.Tensor | None,
-    d_output: torch.Tensor | None,
-    d_final_state: torch.Tensor | None,
-    initial_state: torch.Tensor | None,
-    fastmath: bool,
-):
-    del Aqk, Akk, cu_seqlens, chunk_offsets, d_output, d_final_state, initial_state, fastmath
-    return _bwd_fake_common(q, k, v, cumulative_gate, beta)
-
-
-@torch.library.register_fake("attn_gym::kda_chunk_bwd_with_state_grad")
-def _chunk_kda_bwd_with_state_grad_fake(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    cumulative_gate: torch.Tensor,
-    beta: torch.Tensor,
-    Aqk: torch.Tensor,
-    Akk: torch.Tensor,
-    cu_seqlens: torch.Tensor | None,
-    chunk_offsets: torch.Tensor | None,
-    d_output: torch.Tensor | None,
-    d_final_state: torch.Tensor | None,
-    initial_state: torch.Tensor,
-    fastmath: bool,
-):
-    del Aqk, Akk, cu_seqlens, chunk_offsets, d_output, d_final_state, fastmath
-    return (*_bwd_fake_common(q, k, v, cumulative_gate, beta), torch.empty_like(initial_state))
-
-
-_chunk_kda_fwd_op = torch.ops.attn_gym.kda_chunk_fwd.default
-_chunk_kda_fwd_with_state_op = torch.ops.attn_gym.kda_chunk_fwd_with_state.default
-_chunk_kda_fwd_ragged_op = torch.ops.attn_gym.kda_chunk_fwd_ragged.default
-_chunk_kda_fwd_ragged_with_state_op = torch.ops.attn_gym.kda_chunk_fwd_ragged_with_state.default
-_chunk_kda_bwd_op = torch.ops.attn_gym.kda_chunk_bwd.default
-_chunk_kda_bwd_with_state_grad_op = torch.ops.attn_gym.kda_chunk_bwd_with_state_grad.default
-
-
-class _ChunkKDA(torch.autograd.Function):
-    """First-order autograd wrapper for dense or device-scheduled ragged execution."""
-
-    @staticmethod
-    def forward(
-        ctx,
-        q,
-        k,
-        v,
-        cumulative_gate,
-        beta,
-        initial_state,
-        cu_seqlens,
-        chunk_offsets,
-        output_final_state,
-        fastmath,
-    ):
-        if cu_seqlens is None:
-            assert chunk_offsets is None
-            if output_final_state:
-                output, state, Aqk, Akk = _chunk_kda_fwd_with_state_op(
-                    q, k, v, cumulative_gate, beta, initial_state
-                )
-            else:
-                output, Aqk, Akk = _chunk_kda_fwd_op(q, k, v, cumulative_gate, beta, initial_state)
-        elif output_final_state:
-            assert chunk_offsets is not None
-            output, state, Aqk, Akk = _chunk_kda_fwd_ragged_with_state_op(
-                q,
-                k,
-                v,
-                cumulative_gate,
-                beta,
-                initial_state,
-                cu_seqlens,
-                chunk_offsets,
-            )
-        else:
-            assert chunk_offsets is not None
-            output, Aqk, Akk = _chunk_kda_fwd_ragged_op(
-                q,
-                k,
-                v,
-                cumulative_gate,
-                beta,
-                initial_state,
-                cu_seqlens,
-                chunk_offsets,
-            )
-        ctx.save_for_backward(
-            q,
-            k,
-            v,
-            cumulative_gate,
-            beta,
-            Aqk,
-            Akk,
-            initial_state,
-            cu_seqlens,
-            chunk_offsets,
-        )
-        ctx.fastmath = fastmath
-        ctx.set_materialize_grads(False)
-        if output_final_state:
-            return output, state
-        return output
-
-    @staticmethod
-    @torch.autograd.function.once_differentiable
-    def backward(ctx, d_output, d_final_state=None):
-        (
-            q,
-            k,
-            v,
-            cumulative_gate,
-            beta,
-            Aqk,
-            Akk,
-            initial_state,
-            cu_seqlens,
-            chunk_offsets,
-        ) = ctx.saved_tensors
-        args = (
-            q,
-            k,
-            v,
-            cumulative_gate,
-            beta,
-            Aqk,
-            Akk,
-            cu_seqlens,
-            chunk_offsets,
-            d_output,
-            d_final_state,
-            initial_state,
-            ctx.fastmath,
-        )
-        if initial_state is not None:
-            dq, dk, dv, dg, db, d_initial_state = _chunk_kda_bwd_with_state_grad_op(*args)
-        else:
-            dq, dk, dv, dg, db = _chunk_kda_bwd_op(*args)
-            d_initial_state = None
-        return dq, dk, dv, dg, db, d_initial_state, None, None, None, None
-
-
-def _chunk_kda(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    cumulative_gate: torch.Tensor,
-    beta: torch.Tensor,
-    initial_state: torch.Tensor | None = None,
-    *,
-    cu_seqlens: torch.Tensor | None = None,
-    metadata: RaggedChunkMetadata | None = None,
-    output_final_state: bool = False,
-    fastmath: bool = False,
-) -> tuple[torch.Tensor, torch.Tensor | None]:
-    """Apply the core after canonicalizing caller- or integration-owned routing."""
-    if metadata is not None:
-        assert cu_seqlens is None
-        metadata.validate_chunk_size(_CHUNK_SIZE)
-        cu_seqlens = metadata.cu_seqlens
-    _validate_chunk_kda_inputs(q, k, v, cumulative_gate, beta, initial_state, cu_seqlens)
-    output_dtype = q.dtype
-    output_shape = q.shape
-    q, k, v = (tensor.to(torch.bfloat16) for tensor in (q, k, v))
-    cumulative_gate = cumulative_gate.float().contiguous()
-    beta = beta.float().contiguous()
-    batch, tokens, heads, head_dim = output_shape
-    if cu_seqlens is not None and metadata is None:
-        metadata = prepare_ragged_chunk_metadata(cu_seqlens, tokens, _CHUNK_SIZE)
-    # Only complete single-sequence chunks use direct dense launchers.
-    if metadata is None and (batch != 1 or tokens % _CHUNK_SIZE != 0):
-        packed_shape = (1, batch * tokens, heads, head_dim)
-        q, k, v, cumulative_gate = (
-            tensor.reshape(packed_shape) for tensor in (q, k, v, cumulative_gate)
-        )
-        beta = beta.reshape(packed_shape[:3])
-        cu_seqlens = torch.arange(batch + 1, dtype=torch.int32, device=q.device) * tokens
-        metadata = prepare_ragged_chunk_metadata(cu_seqlens, batch * tokens, _CHUNK_SIZE)
-    if initial_state is not None:
-        initial_state = initial_state.float().contiguous()
-    cu_seqlens = None if metadata is None else metadata.cu_seqlens
-    chunk_offsets = None if metadata is None else metadata.chunk_offsets
-    if output_final_state:
-        output, state = _ChunkKDA.apply(
-            q,
-            k,
-            v,
-            cumulative_gate,
-            beta,
-            initial_state,
-            cu_seqlens,
-            chunk_offsets,
-            True,
-            fastmath,
-        )
-    else:
-        output = _ChunkKDA.apply(
-            q,
-            k,
-            v,
-            cumulative_gate,
-            beta,
-            initial_state,
-            cu_seqlens,
-            chunk_offsets,
-            False,
-            fastmath,
-        )
-        state = None
-    return output.reshape(output_shape).to(output_dtype), state
-
-
-def chunk_kda(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    cumulative_gate: torch.Tensor,
-    beta: torch.Tensor,
-    initial_state: torch.Tensor | None = None,
-    *,
-    cu_seqlens: torch.Tensor | None = None,
-    output_final_state: bool = False,
-    fastmath: bool = False,
-) -> tuple[torch.Tensor, torch.Tensor | None]:
-    """Apply the graph-capturable, first-order Blackwell KDA core.
-
-    ``cu_seqlens`` selects packed ``[1, T, H, D]`` execution. Dense batches and
-    dense tails are lowered to the same packed representation with equal-length
-    sequences. Logical sequences may end in a partial 64-token chunk, and the terminal
-    offset may be smaller than the physical token capacity. Values after the terminal
-    offset are outside the operation's contract. The optimized core computes Q/K/V in
-    BF16 and gates, beta, and recurrent states in FP32. FP16 or FP32 Q/K/V inputs are
-    cast to BF16 for the core, and the output is cast back to ``q.dtype``. Recurrent
-    states remain FP32 and have one leading entry per logical sequence.
-    """
-    return _chunk_kda(
-        q,
-        k,
-        v,
-        cumulative_gate,
-        beta,
-        initial_state,
-        cu_seqlens=cu_seqlens,
-        output_final_state=output_final_state,
-        fastmath=fastmath,
-    )
-
-
-__all__ = ["chunk_kda"]
+__all__ = [
+    "_chunk_kda_bwd_op",
+    "_chunk_kda_bwd_with_state_grad_op",
+    "_chunk_kda_fwd_op",
+    "_chunk_kda_fwd_ragged_op",
+    "_chunk_kda_fwd_ragged_with_state_op",
+    "_chunk_kda_fwd_with_state_op",
+    "forward",
+]

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_intra.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_intra.py
@@ -38,6 +38,7 @@ def chunk_kda_fwd_intra(
     metadata: RaggedChunkMetadata | None,
     chunk_size: int = DEFAULT_CHUNK_SIZE,
     profile_ranges: bool = False,
+    autotune: bool = True,
 ) -> tuple[
     torch.Tensor,
     torch.Tensor,
@@ -107,6 +108,7 @@ def chunk_kda_fwd_intra(
         else nullcontext()
     ):
         w, u, _qg, kg = recompute_w_u_fwd(
+            autotune=autotune,
             k=k,
             v=v,
             beta=beta,

--- a/attn_gym/linear/kda/fwd/cute/recompute_w_u_fwd.py
+++ b/attn_gym/linear/kda/fwd/cute/recompute_w_u_fwd.py
@@ -1510,6 +1510,7 @@ def recompute_w_u_fwd(
     gk: torch.Tensor | None = None,
     chunk_size: int = BT,
     dot_precision: str | MmaPrecision = "bf16",
+    autotune: bool = True,
 ) -> tuple[
     torch.Tensor,
     torch.Tensor,
@@ -1543,6 +1544,7 @@ def recompute_w_u_fwd(
         gk=gk,
         chunk_size=chunk_size,
         dot_precision=precision.value,
+        autotune=autotune,
     )
 
 

--- a/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
@@ -10,7 +10,7 @@ import torch
 import triton
 import triton.language as tl
 
-from attn_gym._backends.triton.utils import ptr_offset, requires_int64_offsets
+from attn_gym._backends.triton.utils import PinnedConfigKernel, ptr_offset, requires_int64_offsets
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata
 from attn_gym.linear.kda.utils import autotune_cache_kwargs, exp, exp2
 
@@ -395,6 +395,9 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
             )
 
 
+_PINNED_FWD_H = PinnedConfigKernel(chunk_gated_delta_rule_fwd_kernel_h_blockdim64)
+
+
 def chunk_gated_delta_rule_fwd_h(
     k: torch.Tensor,
     w: torch.Tensor,
@@ -405,6 +408,7 @@ def chunk_gated_delta_rule_fwd_h(
     chunk_size: int = 64,
     output_final_state: bool = True,
     metadata: RaggedChunkMetadata | None = None,
+    autotune: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
     """Run the fixed-length or packed inter-chunk KDA state recurrence."""
     batch, tokens, heads, key_dim = k.shape
@@ -451,7 +455,8 @@ def chunk_gated_delta_rule_fwd_h(
     def grid(meta):
         return (state_batch * heads, triton.cdiv(value_dim, meta["BV"]))
 
-    chunk_gated_delta_rule_fwd_kernel_h_blockdim64[grid](
+    kernel = chunk_gated_delta_rule_fwd_kernel_h_blockdim64 if autotune else _PINNED_FWD_H
+    kernel[grid](
         k=k,
         v=u,
         w=w,

--- a/attn_gym/linear/kda/fwd/triton/chunk_gla_fwd_o.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_gla_fwd_o.py
@@ -16,7 +16,12 @@ import triton
 import triton.language as tl
 from triton.tools.tensor_descriptor import TensorDescriptor
 
-from attn_gym._backends.triton.utils import can_use_tma, ptr_offset, requires_int64_offsets
+from attn_gym._backends.triton.utils import (
+    PinnedConfigKernel,
+    can_use_tma,
+    ptr_offset,
+    requires_int64_offsets,
+)
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata, load_ragged_chunk_work
 from attn_gym.linear.kda.utils import autotune_cache_kwargs, exp, exp2
 
@@ -348,6 +353,9 @@ def _can_use_tensor_descriptors(*tensors: torch.Tensor) -> bool:
     return all(can_use_tma(tensor) for tensor in tensors)
 
 
+_PINNED_FWD_O = PinnedConfigKernel(chunk_gla_fwd_kernel_o)
+
+
 def chunk_gla_fwd_o_gk(
     q: torch.Tensor,
     v: torch.Tensor,
@@ -358,6 +366,7 @@ def chunk_gla_fwd_o_gk(
     *,
     chunk_size: int = 64,
     metadata: RaggedChunkMetadata | None = None,
+    autotune: bool = True,
 ) -> torch.Tensor:
     """Compose fixed-length or packed KDA intra- and inter-chunk output terms."""
     if metadata is not None:
@@ -455,7 +464,8 @@ def chunk_gla_fwd_o_gk(
         def grid(meta):
             return (triton.cdiv(value_dim, meta["BV"]), chunks, batch * heads)
 
-        chunk_gla_fwd_kernel_o[grid](
+        kernel = chunk_gla_fwd_kernel_o if autotune else _PINNED_FWD_O
+        kernel[grid](
             q=q,
             v=v,
             g=g,

--- a/attn_gym/linear/kda/fwd/triton/recompute_w_u.py
+++ b/attn_gym/linear/kda/fwd/triton/recompute_w_u.py
@@ -36,7 +36,7 @@ import triton
 import triton.language as tl
 from torch._subclasses.fake_tensor import FakeTensor
 
-from attn_gym._backends.triton.utils import ptr_offset
+from attn_gym._backends.triton.utils import PinnedConfigKernel, ptr_offset
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata, load_ragged_chunk_work
 from attn_gym.linear.kda.utils import autotune_cache_kwargs, exp2
 
@@ -206,6 +206,9 @@ def recompute_w_u_fwd_kernel(
         )
 
 
+_PINNED_W_U = PinnedConfigKernel(recompute_w_u_fwd_kernel)
+
+
 def recompute_w_u_fwd_triton(
     k: torch.Tensor,
     v: torch.Tensor,
@@ -217,6 +220,7 @@ def recompute_w_u_fwd_triton(
     *,
     chunk_size: int = 64,
     dot_precision: str = "bf16",
+    autotune: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
     """Launch the register-operand recompute for packed B=1 inputs."""
     batch, tokens, key_heads, key_dim = k.shape
@@ -285,7 +289,8 @@ def recompute_w_u_fwd_triton(
         return w, u, qg, kg
     chunks = metadata.capacity if metadata is not None else tokens // chunk_size
     if chunks:
-        recompute_w_u_fwd_kernel[(chunks, value_heads)](
+        kernel = recompute_w_u_fwd_kernel if autotune else _PINNED_W_U
+        kernel[(chunks, value_heads)](
             q=q if has_q else None,
             k=k,
             qg=qg,

--- a/attn_gym/linear/kda/fwd/triton/recurrent.py
+++ b/attn_gym/linear/kda/fwd/triton/recurrent.py
@@ -19,9 +19,11 @@ import torch
 import triton
 import triton.language as tl
 
-from attn_gym.linear.kda.validation import validate_kda_inputs
-
-_MAX_KEY_DIM = 256
+from attn_gym.linear.kda.ops import recurrent_forward as forward
+from attn_gym.linear.kda.ops import (
+    recurrent_fwd_no_state_op as _recurrent_fwd_no_state_op,
+)
+from attn_gym.linear.kda.ops import recurrent_fwd_op as _recurrent_fwd_op
 
 
 @triton.jit
@@ -141,14 +143,6 @@ def _launch_recurrent_fwd(
     return output, final_state
 
 
-_RECURRENT_FWD_ARGS = (
-    "(Tensor q, Tensor k, Tensor v, Tensor gate, Tensor beta,"
-    " Tensor? initial_state, Tensor? cu_seqlens)"
-)
-torch.library.define("attn_gym::kda_recurrent_fwd", _RECURRENT_FWD_ARGS + " -> (Tensor, Tensor)")
-torch.library.define("attn_gym::kda_recurrent_fwd_no_state", _RECURRENT_FWD_ARGS + " -> Tensor")
-
-
 def _kda_recurrent_fwd_cuda(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -179,123 +173,4 @@ def _kda_recurrent_fwd_no_state_cuda(
     )[0]
 
 
-torch.library.impl("attn_gym::kda_recurrent_fwd", "CUDA", _kda_recurrent_fwd_cuda)
-torch.library.impl(
-    "attn_gym::kda_recurrent_fwd_no_state", "CUDA", _kda_recurrent_fwd_no_state_cuda
-)
-
-
-@torch.library.register_fake("attn_gym::kda_recurrent_fwd")
-def _kda_recurrent_fwd_fake(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    gate: torch.Tensor,
-    beta: torch.Tensor,
-    initial_state: torch.Tensor | None,
-    cu_seqlens: torch.Tensor | None,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    del gate, beta, initial_state
-    num_sequences = q.shape[0] if cu_seqlens is None else cu_seqlens.shape[0] - 1
-    final_state = q.new_empty(
-        num_sequences, q.shape[2], q.shape[3], v.shape[-1], dtype=torch.float32
-    )
-    return torch.empty_like(v, dtype=q.dtype), final_state
-
-
-@torch.library.register_fake("attn_gym::kda_recurrent_fwd_no_state")
-def _kda_recurrent_fwd_no_state_fake(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    gate: torch.Tensor,
-    beta: torch.Tensor,
-    initial_state: torch.Tensor | None,
-    cu_seqlens: torch.Tensor | None,
-) -> torch.Tensor:
-    del gate, beta, initial_state, cu_seqlens
-    return torch.empty_like(v, dtype=q.dtype)
-
-
-_recurrent_fwd_op = torch.ops.attn_gym.kda_recurrent_fwd.default
-_recurrent_fwd_no_state_op = torch.ops.attn_gym.kda_recurrent_fwd_no_state.default
-
-
-def _validate_recurrent_kda_inputs(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    gate: torch.Tensor,
-    beta: torch.Tensor,
-    initial_state: torch.Tensor | None,
-    cu_seqlens: torch.Tensor | None,
-) -> None:
-    """Validate the shared contract plus the fused scan's own constraints."""
-    validate_kda_inputs(
-        q, k, v, gate, beta, initial_state, cu_seqlens, op_name="recurrent_kda", gate_name="gate"
-    )
-    if q.shape[-1] > _MAX_KEY_DIM:
-        raise ValueError(f"recurrent_kda requires K in [1, {_MAX_KEY_DIM}], got {q.shape[-1]}")
-    if not q.is_cuda:
-        raise ValueError("recurrent_kda requires CUDA tensors")
-    data_tensors = (q, k, v, gate, beta)
-    if initial_state is not None:
-        data_tensors += (initial_state,)
-    if torch.is_grad_enabled() and any(tensor.requires_grad for tensor in data_tensors):
-        raise RuntimeError(
-            "recurrent_kda is inference-only and has no backward; use chunk_kda for "
-            "training or call under torch.no_grad() / torch.inference_mode()"
-        )
-
-
-def recurrent_kda(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    gate: torch.Tensor,
-    beta: torch.Tensor,
-    initial_state: torch.Tensor | None = None,
-    *,
-    cu_seqlens: torch.Tensor | None = None,
-    output_final_state: bool = False,
-) -> tuple[torch.Tensor, torch.Tensor | None]:
-    """Apply the fused O(T) KDA delta rule for decode and inference prefill.
-
-    Args:
-        q: Queries with shape ``[B, T, H, K]``; scaled by ``1/sqrt(K)`` internally.
-        k: Keys with the same shape as ``q``.
-        v: Values with shape ``[B, T, H, V]``.
-        gate: Per-token log2 decay with the same shape as ``q``, as produced by
-            ``bounded_gate_cumsum(chunk_size=1)`` — not the chunk-local
-            cumulative gate that ``chunk_kda`` consumes.
-        beta: Per-token write gate with shape ``[B, T, H]``.
-        initial_state: Optional recurrent state with one ``[H, K, V]`` entry per
-            logical sequence.
-        cu_seqlens: Optional device-resident int32 offsets selecting packed
-            ``[1, T, H, D]`` execution. Repeated offsets are empty padding slots
-            whose state passes through unchanged, and the terminal offset may sit
-            below the physical token capacity; values past it are outside the
-            operation's contract, so fixed-shape CUDA graphs can replay with
-            different boundaries and active lengths.
-        output_final_state: Also return the final recurrent state. When false,
-            the state is neither allocated nor written.
-
-    Returns:
-        The output in ``q.dtype`` and, when requested, the FP32 recurrent state.
-
-    The scan computes in FP32 regardless of input dtype. The fused scan is
-    inference-only: when autograd is enabled, calls whose data inputs require
-    gradients are rejected instead of silently detaching.
-    """
-    _validate_recurrent_kda_inputs(q, k, v, gate, beta, initial_state, cu_seqlens)
-    # The kernel loads every operand through an FP32 register cast, so only the
-    # layout needs normalizing here; recurrent states are always produced in FP32.
-    q, k, v, gate, beta = (tensor.contiguous() for tensor in (q, k, v, gate, beta))
-    if initial_state is not None:
-        initial_state = initial_state.contiguous()
-    if output_final_state:
-        return _recurrent_fwd_op(q, k, v, gate, beta, initial_state, cu_seqlens)
-    return _recurrent_fwd_no_state_op(q, k, v, gate, beta, initial_state, cu_seqlens), None
-
-
-__all__ = ["recurrent_kda"]
+__all__ = ["_recurrent_fwd_no_state_op", "_recurrent_fwd_op", "forward"]

--- a/attn_gym/linear/kda/impl/__init__.py
+++ b/attn_gym/linear/kda/impl/__init__.py
@@ -4,4 +4,4 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""CuTeDSL KDA forward implementation modules; entry points are private."""
+"""Private KDA implementation backends."""

--- a/attn_gym/linear/kda/impl/fused.py
+++ b/attn_gym/linear/kda/impl/fused.py
@@ -1,0 +1,219 @@
+"""Torch-only public wrapper for the lazily dispatched fused chunk KDA core."""
+
+from __future__ import annotations
+
+import torch
+
+from attn_gym._backends.cute.utils import get_device_properties
+from attn_gym.linear.kda.chunk_schedule import (
+    RaggedChunkMetadata,
+    prepare_ragged_chunk_metadata,
+)
+from attn_gym.linear.kda.ops import (
+    chunk_bwd_op,
+    chunk_bwd_with_state_grad_op,
+    chunk_fwd_op,
+    chunk_fwd_ragged_op,
+    chunk_fwd_ragged_with_state_op,
+    chunk_fwd_with_state_op,
+)
+
+_CHUNK_SIZE = 64
+_HEAD_DIM = 128
+
+
+def _validate_fused_constraints(q: torch.Tensor, v: torch.Tensor) -> None:
+    """Validate constraints shared by every fused chunk launcher."""
+    if not q.is_cuda:
+        raise ValueError("the CuTe KDA core requires CUDA tensors")
+    if q.shape[-1] != _HEAD_DIM or v.shape[-1] != _HEAD_DIM:
+        raise ValueError("the CuTe KDA core requires K=V=128")
+    if not torch.compiler.is_compiling() and get_device_properties(q.device).major < 10:
+        raise ValueError("the CuTe KDA core requires CUDA capability 10.0 or newer")
+
+
+class _ChunkKDA(torch.autograd.Function):
+    """Attach first-order autograd to the pre-registered fused operators."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        q,
+        k,
+        v,
+        cumulative_gate,
+        beta,
+        initial_state,
+        cu_seqlens,
+        chunk_offsets,
+        output_final_state,
+        fastmath,
+        autotune,
+    ):
+        if cu_seqlens is None:
+            assert chunk_offsets is None
+            if output_final_state:
+                output, state, aqk, akk = chunk_fwd_with_state_op(
+                    q, k, v, cumulative_gate, beta, initial_state, autotune
+                )
+            else:
+                output, aqk, akk = chunk_fwd_op(
+                    q, k, v, cumulative_gate, beta, initial_state, autotune
+                )
+        elif output_final_state:
+            assert chunk_offsets is not None
+            output, state, aqk, akk = chunk_fwd_ragged_with_state_op(
+                q,
+                k,
+                v,
+                cumulative_gate,
+                beta,
+                initial_state,
+                cu_seqlens,
+                chunk_offsets,
+                autotune,
+            )
+        else:
+            assert chunk_offsets is not None
+            output, aqk, akk = chunk_fwd_ragged_op(
+                q,
+                k,
+                v,
+                cumulative_gate,
+                beta,
+                initial_state,
+                cu_seqlens,
+                chunk_offsets,
+                autotune,
+            )
+        ctx.save_for_backward(
+            q,
+            k,
+            v,
+            cumulative_gate,
+            beta,
+            aqk,
+            akk,
+            initial_state,
+            cu_seqlens,
+            chunk_offsets,
+        )
+        ctx.fastmath = fastmath
+        ctx.autotune = autotune
+        ctx.set_materialize_grads(False)
+        if output_final_state:
+            return output, state
+        return output
+
+    @staticmethod
+    @torch.autograd.function.once_differentiable
+    def backward(ctx, d_output, d_final_state=None):
+        (
+            q,
+            k,
+            v,
+            cumulative_gate,
+            beta,
+            aqk,
+            akk,
+            initial_state,
+            cu_seqlens,
+            chunk_offsets,
+        ) = ctx.saved_tensors
+        args = (
+            q,
+            k,
+            v,
+            cumulative_gate,
+            beta,
+            aqk,
+            akk,
+            cu_seqlens,
+            chunk_offsets,
+            d_output,
+            d_final_state,
+            initial_state,
+            ctx.fastmath,
+            ctx.autotune,
+        )
+        if initial_state is not None:
+            dq, dk, dv, dg, db, d_initial_state = chunk_bwd_with_state_grad_op(*args)
+        else:
+            dq, dk, dv, dg, db = chunk_bwd_op(*args)
+            d_initial_state = None
+        return dq, dk, dv, dg, db, d_initial_state, None, None, None, None, None
+
+
+def chunk_forward(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None = None,
+    *,
+    cu_seqlens: torch.Tensor | None = None,
+    metadata: RaggedChunkMetadata | None = None,
+    output_final_state: bool = False,
+    fastmath: bool = False,
+    autotune: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Normalize inputs and invoke the registered fused chunk operators."""
+    if metadata is not None:
+        assert cu_seqlens is None
+        metadata.validate_chunk_size(_CHUNK_SIZE)
+        cu_seqlens = metadata.cu_seqlens
+    _validate_fused_constraints(q, v)
+    output_dtype = q.dtype
+    output_shape = q.shape
+    q, k, v = (tensor.to(torch.bfloat16) for tensor in (q, k, v))
+    cumulative_gate = cumulative_gate.float().contiguous()
+    beta = beta.float().contiguous()
+    batch, tokens, heads, head_dim = output_shape
+    if cu_seqlens is not None and metadata is None:
+        metadata = prepare_ragged_chunk_metadata(cu_seqlens, tokens, _CHUNK_SIZE)
+    if metadata is None and (batch != 1 or tokens % _CHUNK_SIZE != 0):
+        packed_shape = (1, batch * tokens, heads, head_dim)
+        q, k, v, cumulative_gate = (
+            tensor.reshape(packed_shape) for tensor in (q, k, v, cumulative_gate)
+        )
+        beta = beta.reshape(packed_shape[:3])
+        cu_seqlens = torch.arange(batch + 1, dtype=torch.int32, device=q.device) * tokens
+        metadata = prepare_ragged_chunk_metadata(cu_seqlens, batch * tokens, _CHUNK_SIZE)
+    if initial_state is not None:
+        initial_state = initial_state.float().contiguous()
+    cu_seqlens = None if metadata is None else metadata.cu_seqlens
+    chunk_offsets = None if metadata is None else metadata.chunk_offsets
+    if output_final_state:
+        output, state = _ChunkKDA.apply(
+            q,
+            k,
+            v,
+            cumulative_gate,
+            beta,
+            initial_state,
+            cu_seqlens,
+            chunk_offsets,
+            True,
+            fastmath,
+            autotune,
+        )
+    else:
+        output = _ChunkKDA.apply(
+            q,
+            k,
+            v,
+            cumulative_gate,
+            beta,
+            initial_state,
+            cu_seqlens,
+            chunk_offsets,
+            False,
+            fastmath,
+            autotune,
+        )
+        state = None
+    return output.reshape(output_shape).to(output_dtype), state
+
+
+__all__ = ["chunk_forward"]

--- a/attn_gym/linear/kda/impl/reference.py
+++ b/attn_gym/linear/kda/impl/reference.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Eager FP32 reference execution behind the public KDA contract.
+
+Wraps the naive oracles with the public packed semantics: FP32 compute
+(autocast disabled), empty padding slots pass their state through, and output
+rows past the terminal offset stay zero. Packed execution is eager-only because
+it reads device offsets on the host before iterating over logical sequences.
+"""
+
+from __future__ import annotations
+
+from itertools import pairwise
+
+import torch
+
+
+def _packed_reference(
+    dense_op,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor,
+    output_final_state: bool,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Evaluate packed sequences independently through a dense reference op.
+
+    The offsets are read on the host, so the reference path synchronizes; the
+    fused implementations keep them device-resident.
+    """
+    heads, key_dim, value_dim = q.shape[2], q.shape[3], v.shape[-1]
+    num_sequences = cu_seqlens.shape[0] - 1
+    output = torch.zeros_like(v)
+    final_state = None
+    if output_final_state:
+        final_state = (
+            q.new_zeros(num_sequences, heads, key_dim, value_dim)
+            if initial_state is None
+            else initial_state.clone()
+        )
+    offsets = cu_seqlens.cpu().tolist()
+    if (
+        offsets[0] != 0
+        or any(start > end for start, end in pairwise(offsets))
+        or offsets[-1] > q.shape[1]
+    ):
+        raise ValueError(
+            "cu_seqlens offsets must start at zero, be nondecreasing, and end within "
+            "the physical token capacity"
+        )
+    for sequence, (start, end) in enumerate(pairwise(offsets)):
+        if start == end:
+            continue
+        span = slice(start, end)
+        span_output, span_state = dense_op(
+            q[:, span],
+            k[:, span],
+            v[:, span],
+            gate[:, span],
+            beta[:, span],
+            initial_state=None
+            if initial_state is None
+            else initial_state[sequence : sequence + 1],
+            output_final_state=output_final_state,
+        )
+        output[:, span] = span_output
+        if final_state is not None:
+            final_state[sequence] = span_state[0]
+    return output, final_state
+
+
+def reference_kda(
+    dense_op,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+    output_final_state: bool,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Run a dense reference op in FP32 under the public packed contract."""
+    output_dtype = q.dtype
+    q, k, v = (tensor.float() for tensor in (q, k, v))
+    gate = gate.float()
+    beta = beta.float()
+    if initial_state is not None:
+        initial_state = initial_state.float()
+    # ``.float()`` casts alone do not stop an active autocast region from
+    # re-electing BF16/FP16 for the matmuls inside the oracles.
+    with torch.autocast(device_type=q.device.type, enabled=False):
+        if cu_seqlens is None:
+            output, state = dense_op(
+                q,
+                k,
+                v,
+                gate,
+                beta,
+                initial_state=initial_state,
+                output_final_state=output_final_state,
+            )
+        else:
+            output, state = _packed_reference(
+                dense_op, q, k, v, gate, beta, initial_state, cu_seqlens, output_final_state
+            )
+    return output.to(output_dtype), state
+
+
+__all__ = ["reference_kda"]

--- a/attn_gym/linear/kda/ops.py
+++ b/attn_gym/linear/kda/ops.py
@@ -1,0 +1,384 @@
+"""Torch-only private operator contracts for fused KDA backends.
+
+Schemas, fake implementations, and dispatch registrations live here so they
+exist before graph capture. CUDA implementations import their optional backend
+only when the dispatcher executes the operator.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import torch
+
+_CHUNK_SIZE = 64
+
+
+# Fixed-arity schema pairs avoid optional outputs on hot paths.
+_CHUNK_FWD_ARGS = (
+    "(Tensor q, Tensor k, Tensor v, Tensor cumulative_gate, Tensor beta, Tensor? initial_state,"
+    " bool autotune)"
+)
+torch.library.define(
+    "attn_gym::kda_chunk_fwd",
+    f"{_CHUNK_FWD_ARGS} -> (Tensor, Tensor, Tensor)",
+)
+torch.library.define(
+    "attn_gym::kda_chunk_fwd_with_state",
+    f"{_CHUNK_FWD_ARGS} -> (Tensor, Tensor, Tensor, Tensor)",
+)
+
+_CHUNK_RAGGED_FWD_ARGS = (
+    "(Tensor q, Tensor k, Tensor v, Tensor cumulative_gate, Tensor beta, "
+    "Tensor? initial_state, Tensor cu_seqlens, Tensor chunk_offsets, bool autotune)"
+)
+torch.library.define(
+    "attn_gym::kda_chunk_fwd_ragged",
+    f"{_CHUNK_RAGGED_FWD_ARGS} -> (Tensor, Tensor, Tensor)",
+)
+torch.library.define(
+    "attn_gym::kda_chunk_fwd_ragged_with_state",
+    f"{_CHUNK_RAGGED_FWD_ARGS} -> (Tensor, Tensor, Tensor, Tensor)",
+)
+
+_CHUNK_BWD_ARGS = (
+    "(Tensor q, Tensor k, Tensor v, Tensor cumulative_gate, Tensor beta, Tensor Aqk, "
+    "Tensor Akk, Tensor? cu_seqlens, Tensor? chunk_offsets, Tensor? d_output, "
+    "Tensor? d_final_state, {initial_state}, bool fastmath, bool autotune)"
+)
+torch.library.define(
+    "attn_gym::kda_chunk_bwd",
+    _CHUNK_BWD_ARGS.format(initial_state="Tensor? initial_state")
+    + " -> (Tensor, Tensor, Tensor, Tensor, Tensor)",
+)
+torch.library.define(
+    "attn_gym::kda_chunk_bwd_with_state_grad",
+    _CHUNK_BWD_ARGS.format(initial_state="Tensor initial_state")
+    + " -> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor)",
+)
+
+_RECURRENT_FWD_ARGS = (
+    "(Tensor q, Tensor k, Tensor v, Tensor gate, Tensor beta,"
+    " Tensor? initial_state, Tensor? cu_seqlens)"
+)
+torch.library.define("attn_gym::kda_recurrent_fwd", _RECURRENT_FWD_ARGS + " -> (Tensor, Tensor)")
+torch.library.define("attn_gym::kda_recurrent_fwd_no_state", _RECURRENT_FWD_ARGS + " -> Tensor")
+torch.library.define(
+    "attn_gym::kda_prepare_chunk_offsets",
+    "(Tensor cu_seqlens, SymInt tokens, int chunk_size) -> Tensor",
+)
+
+
+def _chunk_backend():
+    try:
+        return importlib.import_module("attn_gym.linear.kda.fwd.cute.chunk_kda_fwd")
+    except ImportError as error:
+        raise ImportError(
+            "chunk_kda(impl='fused') requires the optional CuTeDSL backend: "
+            "pip install attn-gym[linear]"
+        ) from error
+
+
+def _recurrent_backend():
+    try:
+        return importlib.import_module("attn_gym.linear.kda.fwd.triton.recurrent")
+    except ImportError as error:
+        raise ImportError(
+            "recurrent_kda(impl='fused') requires CUDA with Triton support"
+        ) from error
+
+
+def _chunk_fwd_cuda(*args):
+    return _chunk_backend()._chunk_kda_fwd_cuda(*args)
+
+
+def _chunk_fwd_with_state_cuda(*args):
+    return _chunk_backend()._chunk_kda_fwd_with_state_cuda(*args)
+
+
+def _chunk_fwd_ragged_cuda(*args):
+    return _chunk_backend()._chunk_kda_fwd_ragged_cuda(*args)
+
+
+def _chunk_fwd_ragged_with_state_cuda(*args):
+    return _chunk_backend()._chunk_kda_fwd_ragged_with_state_cuda(*args)
+
+
+def _chunk_bwd_cuda(*args):
+    return _chunk_backend()._chunk_kda_bwd_cuda(*args)
+
+
+def _chunk_bwd_with_state_grad_cuda(*args):
+    return _chunk_backend()._chunk_kda_bwd_with_state_grad_cuda(*args)
+
+
+def _recurrent_fwd_cuda(*args):
+    return _recurrent_backend()._kda_recurrent_fwd_cuda(*args)
+
+
+def _recurrent_fwd_no_state_cuda(*args):
+    return _recurrent_backend()._kda_recurrent_fwd_no_state_cuda(*args)
+
+
+def _prepare_chunk_offsets_cuda(*args):
+    from attn_gym.linear.kda.chunk_scheduler import _prepare_ragged_chunk_offsets
+
+    return _prepare_ragged_chunk_offsets(*args)
+
+
+torch.library.impl("attn_gym::kda_chunk_fwd", "CUDA", _chunk_fwd_cuda)
+torch.library.impl("attn_gym::kda_chunk_fwd_with_state", "CUDA", _chunk_fwd_with_state_cuda)
+torch.library.impl("attn_gym::kda_chunk_fwd_ragged", "CUDA", _chunk_fwd_ragged_cuda)
+torch.library.impl(
+    "attn_gym::kda_chunk_fwd_ragged_with_state",
+    "CUDA",
+    _chunk_fwd_ragged_with_state_cuda,
+)
+torch.library.impl("attn_gym::kda_chunk_bwd", "CUDA", _chunk_bwd_cuda)
+torch.library.impl(
+    "attn_gym::kda_chunk_bwd_with_state_grad",
+    "CUDA",
+    _chunk_bwd_with_state_grad_cuda,
+)
+torch.library.impl("attn_gym::kda_recurrent_fwd", "CUDA", _recurrent_fwd_cuda)
+torch.library.impl(
+    "attn_gym::kda_recurrent_fwd_no_state",
+    "CUDA",
+    _recurrent_fwd_no_state_cuda,
+)
+torch.library.impl(
+    "attn_gym::kda_prepare_chunk_offsets",
+    "CUDA",
+    _prepare_chunk_offsets_cuda,
+)
+
+
+def _chunk_fwd_fake_common(q: torch.Tensor, v: torch.Tensor):
+    tape_shape = (q.shape[0], q.shape[1], q.shape[2], _CHUNK_SIZE)
+    return v.new_empty(v.shape), q.new_empty(tape_shape), q.new_empty(tape_shape)
+
+
+@torch.library.register_fake("attn_gym::kda_chunk_fwd")
+def _chunk_fwd_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    autotune: bool,
+):
+    del k, cumulative_gate, beta, initial_state, autotune
+    return _chunk_fwd_fake_common(q, v)
+
+
+@torch.library.register_fake("attn_gym::kda_chunk_fwd_with_state")
+def _chunk_fwd_with_state_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    autotune: bool,
+):
+    del k, cumulative_gate, beta, initial_state, autotune
+    output, aqk, akk = _chunk_fwd_fake_common(q, v)
+    state = q.new_empty(
+        (q.shape[0], q.shape[2], q.shape[3], v.shape[-1]),
+        dtype=torch.float32,
+    )
+    return output, state, aqk, akk
+
+
+@torch.library.register_fake("attn_gym::kda_chunk_fwd_ragged")
+def _chunk_fwd_ragged_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor,
+    chunk_offsets: torch.Tensor,
+    autotune: bool,
+):
+    del k, cumulative_gate, beta, initial_state, cu_seqlens, chunk_offsets, autotune
+    return _chunk_fwd_fake_common(q, v)
+
+
+@torch.library.register_fake("attn_gym::kda_chunk_fwd_ragged_with_state")
+def _chunk_fwd_ragged_with_state_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor,
+    chunk_offsets: torch.Tensor,
+    autotune: bool,
+):
+    del k, cumulative_gate, beta, initial_state, chunk_offsets, autotune
+    output, aqk, akk = _chunk_fwd_fake_common(q, v)
+    state = q.new_empty(
+        (cu_seqlens.shape[0] - 1, q.shape[2], q.shape[3], v.shape[-1]),
+        dtype=torch.float32,
+    )
+    return output, state, aqk, akk
+
+
+def _chunk_bwd_fake_common(q, k, v, cumulative_gate, beta):
+    return (
+        q.new_empty(q.shape),
+        k.new_empty(k.shape),
+        v.new_empty(v.shape),
+        cumulative_gate.new_empty(cumulative_gate.shape),
+        beta.new_empty(beta.shape),
+    )
+
+
+@torch.library.register_fake("attn_gym::kda_chunk_bwd")
+def _chunk_bwd_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    aqk: torch.Tensor,
+    akk: torch.Tensor,
+    cu_seqlens: torch.Tensor | None,
+    chunk_offsets: torch.Tensor | None,
+    d_output: torch.Tensor | None,
+    d_final_state: torch.Tensor | None,
+    initial_state: torch.Tensor | None,
+    fastmath: bool,
+    autotune: bool,
+):
+    del aqk, akk, cu_seqlens, chunk_offsets, d_output, d_final_state, initial_state
+    del fastmath, autotune
+    return _chunk_bwd_fake_common(q, k, v, cumulative_gate, beta)
+
+
+@torch.library.register_fake("attn_gym::kda_chunk_bwd_with_state_grad")
+def _chunk_bwd_with_state_grad_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    aqk: torch.Tensor,
+    akk: torch.Tensor,
+    cu_seqlens: torch.Tensor | None,
+    chunk_offsets: torch.Tensor | None,
+    d_output: torch.Tensor | None,
+    d_final_state: torch.Tensor | None,
+    initial_state: torch.Tensor,
+    fastmath: bool,
+    autotune: bool,
+):
+    del aqk, akk, cu_seqlens, chunk_offsets, d_output, d_final_state, fastmath, autotune
+    return (
+        *_chunk_bwd_fake_common(q, k, v, cumulative_gate, beta),
+        torch.empty_like(initial_state),
+    )
+
+
+@torch.library.register_fake("attn_gym::kda_recurrent_fwd")
+def _recurrent_fwd_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    del k, gate, beta, initial_state
+    num_sequences = q.shape[0] if cu_seqlens is None else cu_seqlens.shape[0] - 1
+    final_state = q.new_empty(
+        num_sequences, q.shape[2], q.shape[3], v.shape[-1], dtype=torch.float32
+    )
+    return torch.empty_like(v, dtype=q.dtype), final_state
+
+
+@torch.library.register_fake("attn_gym::kda_recurrent_fwd_no_state")
+def _recurrent_fwd_no_state_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+) -> torch.Tensor:
+    del q, k, gate, beta, initial_state, cu_seqlens
+    return torch.empty_like(v)
+
+
+@torch.library.register_fake("attn_gym::kda_prepare_chunk_offsets")
+def _prepare_chunk_offsets_fake(
+    cu_seqlens: torch.Tensor,
+    tokens: int,
+    chunk_size: int,
+) -> torch.Tensor:
+    del tokens, chunk_size
+    return torch.empty_like(cu_seqlens)
+
+
+chunk_fwd_op = torch.ops.attn_gym.kda_chunk_fwd.default
+chunk_fwd_with_state_op = torch.ops.attn_gym.kda_chunk_fwd_with_state.default
+chunk_fwd_ragged_op = torch.ops.attn_gym.kda_chunk_fwd_ragged.default
+chunk_fwd_ragged_with_state_op = torch.ops.attn_gym.kda_chunk_fwd_ragged_with_state.default
+chunk_bwd_op = torch.ops.attn_gym.kda_chunk_bwd.default
+chunk_bwd_with_state_grad_op = torch.ops.attn_gym.kda_chunk_bwd_with_state_grad.default
+recurrent_fwd_op = torch.ops.attn_gym.kda_recurrent_fwd.default
+recurrent_fwd_no_state_op = torch.ops.attn_gym.kda_recurrent_fwd_no_state.default
+prepare_chunk_offsets_op = torch.ops.attn_gym.kda_prepare_chunk_offsets.default
+
+
+def recurrent_forward(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None = None,
+    *,
+    cu_seqlens: torch.Tensor | None = None,
+    output_final_state: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Validate and invoke the lazily loaded fused recurrent implementation."""
+    if q.shape[-1] > 256:
+        raise ValueError(f"recurrent_kda requires K in [1, 256], got {q.shape[-1]}")
+    if not q.is_cuda:
+        raise ValueError("the fused recurrent scan requires CUDA tensors")
+    data_tensors = (q, k, v, gate, beta)
+    if initial_state is not None:
+        data_tensors += (initial_state,)
+    if torch.is_grad_enabled() and any(tensor.requires_grad for tensor in data_tensors):
+        raise RuntimeError(
+            "recurrent_kda is inference-only and has no backward; use chunk_kda for "
+            "training or call under torch.no_grad() / torch.inference_mode()"
+        )
+
+    q, k, v, gate, beta = (tensor.contiguous() for tensor in (q, k, v, gate, beta))
+    if initial_state is not None:
+        initial_state = initial_state.contiguous()
+    if output_final_state:
+        return recurrent_fwd_op(q, k, v, gate, beta, initial_state, cu_seqlens)
+    return recurrent_fwd_no_state_op(q, k, v, gate, beta, initial_state, cu_seqlens), None
+
+
+__all__ = [
+    "chunk_bwd_op",
+    "chunk_bwd_with_state_grad_op",
+    "chunk_fwd_op",
+    "chunk_fwd_ragged_op",
+    "chunk_fwd_ragged_with_state_op",
+    "chunk_fwd_with_state_op",
+    "prepare_chunk_offsets_op",
+    "recurrent_forward",
+    "recurrent_fwd_no_state_op",
+    "recurrent_fwd_op",
+]

--- a/attn_gym/linear/kda/utils.py
+++ b/attn_gym/linear/kda/utils.py
@@ -264,3 +264,10 @@ def input_guard(
     if fn is not None:
         return decorator(fn)
     return decorator
+
+
+def profiler_range(name: str):
+    """A named profiler range, free when no torch profiler is active (~4us each)."""
+    if torch.autograd.profiler._is_profiler_enabled:
+        return torch.profiler.record_function(name)
+    return contextlib.nullcontext()

--- a/docs/determinism.md
+++ b/docs/determinism.md
@@ -107,6 +107,35 @@ python examples/flex_determinism.py
 
 The script resets compiler state and uses fresh Inductor caches between runs so that it tests repeatability across independent compilations rather than repeatedly executing one cached kernel.
 
+## KDA determinism
+
+The KDA operations contain no atomics, so every kernel is bitwise-deterministic
+given a fixed configuration. The guarantees, strongest first:
+
+- **Same selected configurations, run to run: bitwise.** Repeating a call
+  that resolves to the same kernel configurations — across runs and processes —
+  reproduces identical bits for outputs and gradients. Under the default
+  ``autotune=True`` a cold winner cache re-benchmarks and timing noise may
+  select a different configuration; the next bullet removes that variable.
+- **`chunk_kda(..., autotune=False)`: bitwise by construction.** The default
+  (`autotune=True`) benchmarks candidate configurations — Triton and CuTeDSL
+  stages alike — the first time a shape is seen and reuses the cached winner
+  afterwards; `autotune=False` pins every stage to its fixed heuristic
+  configuration instead, so kernel selection is repeatable across machines and
+  cache states. `recurrent_kda` and `causal_conv1d` have single fixed
+  schedules and need no flag.
+- **CUDA-graph replay: bitwise** by construction, and the intended serving mode
+  for decode.
+- **Across lowerings: never bitwise.** Dense versus packed, chunked versus
+  recurrent, and fused versus reference are different kernels with different
+  reduction orders. They agree numerically, not bit-for-bit — for example, the
+  dense and packed chunk lowerings match bitwise everywhere except the FP32
+  cumulative-gate gradient, whose software reduction chains compile with
+  different schedules.
+
+The reference implementations compute in FP32 even inside an autocast region.
+
+
 ## References
 
 - [FlexAttention API reference](https://docs.pytorch.org/docs/stable/nn.attention.flex_attention.html)

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -167,10 +167,12 @@ to sample token-level lengths from a truncated Zipf distribution, pack them exac
 into one physical batch, print their `cu_seqlens`, and pass those offsets through the
 complete training step. Add `--padded` when chunk-aligned samples are needed. The
 complete composed core forward and backward use private custom
-operators with fake-tensor registrations and first-order autograd wrappers, so the public
-`chunk_kda` operation supports strict `torch.compile(fullgraph=True)` and CUDA Graph
-capture for fixed physical token capacity and sequence count. Boundary values and the active
-token count may change on replay; changing the physical token capacity or sequence count
+operators with fake-tensor registrations and first-order autograd wrappers, so fused
+`chunk_kda` supports strict `torch.compile(fullgraph=True)` and CUDA Graph capture for
+fixed physical token capacity and sequence count. Packed reference execution is
+eager-only: it reads `cu_seqlens` on the host to run each logical sequence
+independently. Boundary values and the active token count may change on replay;
+changing the physical token capacity or sequence count
 requires recompilation or recapture. Pass `--compile` to compile the complete example as
 one full graph. This keeps the custom KDA core behind its registered operator boundary
 while allowing
@@ -211,16 +213,24 @@ the model's packed-sequence metadata, cache layout, and distributed execution po
 short convolution, factorized gates, and learned gated RMS normalization match
 the production structure but remain ordinary PyTorch teaching implementations.
 
-For integrations that fuse gate activation with its forward chunk prefix sum,
-`naive_chunk_kda_from_cumulative` exposes the matching reference boundary. Its
-cumulative log2 gate is inclusive and resets at the same `chunk_size` passed to
-KDA; the function does not perform a second cumulative sum. The composed `chunk_kda`
-backend consumes this same representation. That trainable operator remains intentionally
-narrow: explicit packed inputs use physical batch size one, kernel operands are BF16,
-`head_dim=128`, `chunk_size=64`, and execution requires Blackwell.
+The two public KDA cores are `chunk_kda` (training and prefill; consumes the
+chunk-local inclusive cumulative log2 gate from `bounded_gate_cumsum(chunk_size=64)`
+without a second cumulative sum) and `recurrent_kda` (decode and inference prefill;
+consumes the per-token log2 gate from `bounded_gate_cumsum(chunk_size=1)`). Both
+select their implementation with `impl`: `"fused"` runs the optimized kernels and
+enforces their constraints (the chunked core needs BF16 operands, `head_dim=128`,
+`chunk_size=64`, and Blackwell; the fused scan is inference-only), while
+`"reference"` runs the eager FP32 oracle behind the identical packed contract on
+any hardware and head dimension, and stays differentiable. There is no automatic
+fallback between the two, and the chunk-versus-recurrent switch is caller policy
+(on B200 the scan wins below roughly 32 tokens per sequence).
 
-::: attn_gym.linear.naive_chunk_kda
+The serving limitations listed under `recurrent_kda` below are deliberate and
+the contract is otherwise stable to build against; CUDA-graph capture amortizes
+the multi-launch decode step.
 
-::: attn_gym.linear.naive_chunk_kda_from_cumulative
+::: attn_gym.linear.chunk_kda
 
-::: attn_gym.linear.naive_recurrent_kda
+::: attn_gym.linear.recurrent_kda
+
+::: attn_gym.linear.Impl

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,1 @@
+"""Runnable Attention Gym examples."""

--- a/examples/kda_training.py
+++ b/examples/kda_training.py
@@ -46,7 +46,6 @@ import torch.nn.functional as F
 import typer
 from torch import nn
 
-from attn_gym.linear import naive_chunk_kda_from_cumulative
 from attn_gym.linear.kda import (
     active_token_mask,
     mask_inactive_token_gradients,
@@ -56,7 +55,7 @@ from attn_gym.linear.kda.chunk_scheduler import prepare_ragged_chunk_metadata
 from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd import _chunk_kda
 from attn_gym.linear.kda.fwd.triton.gate_fwd import _bounded_gate_cumsum
 from attn_gym.linear.kda.fwd.triton.l2norm_fwd import l2norm
-from attn_gym.linear.kda.naive import gate_fwd_ref, l2norm_fwd_ref
+from attn_gym.linear.kda.naive import gate_fwd_ref, l2norm_fwd_ref, naive_chunk_kda_from_cumulative
 from attn_gym.linear.kda.short_conv import causal_conv1d
 
 Backend = Literal["reference", "fused"]

--- a/test/test_cute_cache.py
+++ b/test/test_cute_cache.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 import multiprocessing
 import os
 import struct
@@ -299,10 +300,19 @@ def test_run_tunable_uses_kernel_convention(isolated_cache):
     )
     compile_count = 0
     config_requests = []
+    default_requests = []
     launches = []
 
     class ToyKernel:
-        default_config = candidates[0]
+        @staticmethod
+        def default_config(prefix: str, _launch_log, *, target):
+            default_requests.append((prefix, target))
+            return candidates[0]
+
+        @staticmethod
+        def tuning_key(prefix: str, _launch_log, *, target):
+            assert prefix == "toy" and isinstance(target, cute_target.CompileTarget)
+            return ()
 
         @staticmethod
         def configs(prefix: str, _launch_log):
@@ -344,15 +354,18 @@ def test_run_tunable_uses_kernel_convention(isolated_cache):
     assert result == best.timing
     assert launches == [config.variant for config in candidates] + [best.variant]
     assert config_requests == ["toy"]
+    assert default_requests == []
     assert compile_count == len(candidates)
     assert len(list(isolated_cache.rglob("*.o"))) == len(candidates)
 
     launches.clear()
     result, selected = run_tunable(ToyKernel, "toy", launches)
-    assert selected is ToyKernel.default_config
+    assert selected is candidates[0]
     assert result == selected.timing
     assert launches == [selected.variant]
     assert config_requests == ["toy"]
+    assert len(default_requests) == 1
+    assert default_requests[0][0] == "toy"
     assert compile_count == len(candidates)
 
     launches.clear()
@@ -391,6 +404,137 @@ def test_run_tunable_uses_kernel_convention(isolated_cache):
         run_tunable(InvalidCompileCall, "toy", launches)
 
 
+def test_run_tunable_custom_benchmark_bypasses_cached_winner(isolated_cache, monkeypatch):
+    """Always execute an explicitly requested timing policy."""
+    tune_module = importlib.import_module("attn_gym._backends.cute.tune")
+    candidates = (CompileConfig("slow", 3.0), CompileConfig("fast", 1.0))
+
+    class ToyKernel:
+        @staticmethod
+        def default_config(*, target):
+            assert target.device_type == "test"
+            return candidates[0]
+
+        @staticmethod
+        def tuning_key(*, target):
+            assert target.device_type == "test"
+            return ()
+
+        @staticmethod
+        def configs():
+            return candidates
+
+        @staticmethod
+        @cute_cache.jit_cache
+        def compile(config: CompileConfig) -> FakeCompiled:
+            return FakeCompiled(config.variant)
+
+        @staticmethod
+        def compile_call(config: CompileConfig):
+            return (config,)
+
+        @staticmethod
+        def launch(compiled: FakeCompiled, config: CompileConfig) -> float:
+            assert compiled() == config.variant
+            return config.timing
+
+    target = cute_target.CompileTarget("test")
+    monkeypatch.setattr(tune_module, "benchmark_gpu", measure_return_value)
+    _, cached = run_tunable(ToyKernel, autotune=True, parallel_compile=False, target=target)
+    assert cached is candidates[1]
+
+    benchmarked = []
+
+    def reverse_policy(fn) -> float:
+        timing = float(fn())
+        benchmarked.append(timing)
+        return -timing
+
+    _, selected = run_tunable(
+        ToyKernel,
+        autotune=True,
+        benchmark=reverse_policy,
+        parallel_compile=False,
+        target=target,
+    )
+    assert selected is candidates[0]
+    assert benchmarked == [config.timing for config in candidates]
+
+
+def test_run_tunable_keys_winners_by_runtime_workload(isolated_cache, monkeypatch):
+    """Separate winner decisions without recompiling shape-polymorphic binaries."""
+    tune_module = importlib.import_module("attn_gym._backends.cute.tune")
+    candidates = (CompileConfig("small", 0.0), CompileConfig("large", 0.0))
+    compile_count = 0
+    measurements = []
+
+    class WorkloadAwareKernel:
+        @staticmethod
+        def default_config(_work_units: int, *, target):
+            assert target.device_type == "test"
+            return candidates[0]
+
+        @staticmethod
+        def tuning_key(work_units: int, *, target):
+            assert target.device_type == "test"
+            return (work_units,)
+
+        @staticmethod
+        def configs(_work_units: int):
+            return candidates
+
+        @staticmethod
+        @cute_cache.jit_cache
+        def compile(config: CompileConfig) -> FakeCompiled:
+            nonlocal compile_count
+            compile_count += 1
+            return FakeCompiled(config.variant)
+
+        @staticmethod
+        def compile_call(config: CompileConfig, _work_units: int):
+            return (config,)
+
+        @staticmethod
+        def launch(compiled: FakeCompiled, config: CompileConfig, work_units: int) -> float:
+            assert compiled() == config.variant
+            expected = "small" if work_units == 1 else "large"
+            return 1.0 if config.variant == expected else 2.0
+
+    def measure(fn) -> float:
+        timing = float(fn())
+        measurements.append(timing)
+        return timing
+
+    target = cute_target.CompileTarget("test")
+    monkeypatch.setattr(tune_module, "benchmark_gpu", measure)
+    monkeypatch.setattr(tune_module, "_WINNERS", {})
+    monkeypatch.setattr(tune_module, "_WINNERS_FAST", {})
+
+    _, small = run_tunable(
+        WorkloadAwareKernel, 1, autotune=True, parallel_compile=False, target=target
+    )
+    _, large = run_tunable(
+        WorkloadAwareKernel, 2, autotune=True, parallel_compile=False, target=target
+    )
+    assert small is candidates[0]
+    assert large is candidates[1]
+    assert measurements == [1.0, 2.0, 2.0, 1.0]
+    assert compile_count == len(candidates)
+    assert len(list(isolated_cache.rglob("*.o"))) == len(candidates)
+
+    run_tunable(WorkloadAwareKernel, 1, autotune=True, parallel_compile=False, target=target)
+    assert measurements == [1.0, 2.0, 2.0, 1.0]
+
+    monkeypatch.setattr(tune_module, "_WINNERS", {})
+    monkeypatch.setattr(tune_module, "_WINNERS_FAST", {})
+    _, persisted = run_tunable(
+        WorkloadAwareKernel, 2, autotune=True, parallel_compile=False, target=target
+    )
+    assert persisted == candidates[1]
+    assert measurements == [1.0, 2.0, 2.0, 1.0]
+    assert compile_count == len(candidates)
+
+
 def test_run_tunable_sets_target_before_candidate_generation(isolated_cache):
     """Generate target-aware candidates from the explicitly requested device."""
     config = CompileConfig("target-aware", 1.0)
@@ -398,7 +542,15 @@ def test_run_tunable_sets_target_before_candidate_generation(isolated_cache):
     observed_targets = []
 
     class TargetAwareKernel:
-        default_config = config
+        @staticmethod
+        def default_config(*, target):
+            observed_targets.append(target)
+            return config
+
+        @staticmethod
+        def tuning_key(*, target):
+            observed_targets.append(target)
+            return ()
 
         @staticmethod
         def configs():
@@ -708,6 +860,36 @@ def test_persistent_cache_can_be_disabled_with_an_option(tmp_path, monkeypatch):
     assert not list(cache_directory.rglob("*.o"))
 
 
+def test_bad_fork_check_precedes_cached_target_lookup(monkeypatch):
+    """Reject a child that inherited a target cached by its parent."""
+    import torch
+
+    class Properties:
+        major = 10
+        minor = 0
+        name = "test-gpu"
+        multi_processor_count = 100
+
+    bad_fork = False
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 0)
+    monkeypatch.setattr(torch.cuda, "get_device_properties", lambda _device: Properties())
+    monkeypatch.setattr(torch.cuda, "_is_in_bad_fork", lambda: bad_fork, raising=False)
+    cute_target._query_compile_target.cache_clear()
+    try:
+        assert cute_target.detect_compile_target() == cute_target.CompileTarget(
+            device_type="cuda",
+            capability=(10, 0),
+            name="test-gpu",
+            sm_count=100,
+        )
+        bad_fork = True
+        with pytest.raises(RuntimeError, match="forked CUDA child"):
+            cute_target.detect_compile_target()
+    finally:
+        cute_target._query_compile_target.cache_clear()
+
+
 def test_explicit_target_avoids_device_discovery(monkeypatch):
     target = cute_target.CompileTarget(
         device_type="cuda",
@@ -872,3 +1054,72 @@ def test_parallel_population_then_sequential_reload(isolated_cache, process_coun
         misses=0,
         currsize=process_count,
     )
+
+
+def test_run_tunable_winner_cache_round_trip(tmp_path, monkeypatch):
+    """Winners persist across processes-worth of state and reject stale candidates."""
+    tune_module = importlib.import_module("attn_gym._backends.cute.tune")
+
+    monkeypatch.setenv("ATTN_GYM_CUTE_CACHE_DIR", str(tmp_path))
+    monkeypatch.setattr(tune_module, "_WINNERS", {})
+
+    key = "0" * 64
+    tune_module._store_winner(key, {"grid": 4})
+    assert tune_module._load_winner(key) == {"grid": 4}
+
+    # A fresh process sees only the disk copy.
+    monkeypatch.setattr(tune_module, "_WINNERS", {})
+    assert tune_module._load_winner(key) == {"grid": 4}
+
+    # Corrupt and truncated payloads degrade to re-tuning rather than failing.
+    for payload in (b"not a pickle", b"", b"\x80\x04"):
+        monkeypatch.setattr(tune_module, "_WINNERS", {})
+        tune_module._winner_path(key).write_bytes(payload)
+        assert tune_module._load_winner(key) is None
+
+
+def test_winner_cache_honors_cutedsl_no_cache(tmp_path, monkeypatch):
+    """Keep local memoization while disabling winner-file reads and writes."""
+    tune_module = importlib.import_module("attn_gym._backends.cute.tune")
+    monkeypatch.setenv("ATTN_GYM_CUTE_CACHE_DIR", str(tmp_path))
+    monkeypatch.delenv("CUTE_DSL_NO_CACHE", raising=False)
+    monkeypatch.setattr(tune_module, "_WINNERS", {})
+
+    key = "1" * 64
+    tune_module._store_winner(key, "disk-winner")
+    path = tune_module._winner_path(key)
+    disk_payload = path.read_bytes()
+
+    monkeypatch.setenv("CUTE_DSL_NO_CACHE", "1")
+    monkeypatch.setattr(tune_module, "_WINNERS", {})
+    assert tune_module._load_winner(key) is None
+
+    tune_module._store_winner(key, "memory-winner")
+    assert tune_module._load_winner(key) == "memory-winner"
+    assert path.read_bytes() == disk_payload
+
+
+def test_winner_key_tracks_candidates_and_namespace():
+    """Changing the candidate set or kernel namespace re-tunes."""
+    tune_module = importlib.import_module("attn_gym._backends.cute.tune")
+
+    class Kernel:
+        @staticmethod
+        def compile_call(config, capacity):
+            return (config, capacity)
+
+    class _FakeCompile:
+        @staticmethod
+        def cache_namespace():
+            return _FakeCompile.namespace
+
+        namespace = "namespace-a"
+
+    Kernel.compile = _FakeCompile
+    base = tune_module._winner_key(Kernel, [1, 2], (64,), ())
+    assert tune_module._winner_key(Kernel, [1, 2], (64,), ()) == base
+    assert tune_module._winner_key(Kernel, [1, 2, 3], (64,), ()) != base
+    assert tune_module._winner_key(Kernel, [1, 2], (128,), ()) != base
+    assert tune_module._winner_key(Kernel, [1, 2], (64,), ("other",)) != base
+    _FakeCompile.namespace = "namespace-b"
+    assert tune_module._winner_key(Kernel, [1, 2], (64,), ()) != base

--- a/test/test_kda.py
+++ b/test/test_kda.py
@@ -4,12 +4,12 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from attn_gym.linear import (
+from attn_gym.linear.kda.naive import (
+    chunk_cumsum_ref,
     naive_chunk_kda,
     naive_chunk_kda_from_cumulative,
     naive_recurrent_kda,
 )
-from attn_gym.linear.kda.naive import chunk_cumsum_ref
 
 
 def make_inputs(seq_len: int) -> tuple[torch.Tensor, ...]:

--- a/test/test_kda_chunk_scheduler.py
+++ b/test/test_kda_chunk_scheduler.py
@@ -11,7 +11,6 @@ import pytest
 import torch
 
 from attn_gym.linear.kda.chunk_scheduler import (
-    MAX_NUM_SEQUENCES,
     chunk_capacity,
     chunk_work_oracle,
     decode_ragged_chunk_work,
@@ -136,24 +135,19 @@ def test_ragged_chunk_scheduler_accepts_zero_capacity():
     assert actual.shape == (0, 5)
 
 
-def test_ragged_chunk_scheduler_accepts_max_sequences():
-    cu_seqlens = torch.arange(MAX_NUM_SEQUENCES + 1, device="cuda", dtype=torch.int32)
-    metadata = prepare_ragged_chunk_metadata(cu_seqlens, MAX_NUM_SEQUENCES, 64)
+def test_ragged_chunk_scheduler_accepts_more_than_4096_sequences():
+    num_sequences = 4097
+    cu_seqlens = torch.arange(num_sequences + 1, device="cuda", dtype=torch.int32)
+    metadata = prepare_ragged_chunk_metadata(cu_seqlens, num_sequences, 64)
     actual = decode_ragged_chunk_work(metadata)
 
-    assert metadata.capacity == MAX_NUM_SEQUENCES
+    assert metadata.capacity == num_sequences
     torch.testing.assert_close(metadata.chunk_offsets, cu_seqlens)
     torch.testing.assert_close(actual[:, 0], cu_seqlens[:-1])
     torch.testing.assert_close(actual[:, 1], cu_seqlens[:-1])
     torch.testing.assert_close(actual[:, 2], torch.zeros_like(cu_seqlens[:-1]))
     torch.testing.assert_close(actual[:, 3], cu_seqlens[:-1])
     torch.testing.assert_close(actual[:, 4], torch.ones_like(cu_seqlens[:-1]))
-
-
-def test_ragged_chunk_scheduler_rejects_excess_sequences():
-    cu_seqlens = torch.zeros(MAX_NUM_SEQUENCES + 2, device="cuda", dtype=torch.int32)
-    with pytest.raises(ValueError, match=f"at most {MAX_NUM_SEQUENCES} sequences"):
-        prepare_ragged_chunk_metadata(cu_seqlens, 0, 64)
 
 
 @pytest.mark.parametrize(

--- a/test/test_kda_cute_forward.py
+++ b/test/test_kda_cute_forward.py
@@ -10,11 +10,11 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from attn_gym.linear import naive_chunk_kda_from_cumulative
-from attn_gym.linear.kda.naive import chunk_cumsum_ref
+from attn_gym.linear.kda.naive import chunk_cumsum_ref, naive_chunk_kda_from_cumulative
 
 pytest.importorskip("cutlass")
 
+from attn_gym.linear import chunk_kda
 from attn_gym.linear.kda.bwd.cute import chunk_kda_bwd as _chunk_kda_bwd_module
 from attn_gym.linear.kda.bwd.cute.chunk_kda_bwd_intra import (
     ChunkKdaBwdIntraConfig,
@@ -25,7 +25,6 @@ from attn_gym.linear.kda.bwd.cute.chunk_kda_bwd_wy_dqkg_fused import (
     chunk_kda_bwd_wy_dqkg,
 )
 from attn_gym.linear.kda.chunk_scheduler import prepare_ragged_chunk_metadata
-from attn_gym.linear.kda.fwd.cute import chunk_kda
 from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd import (
     _chunk_kda_bwd_op,
     _chunk_kda_bwd_with_state_grad_op,
@@ -337,21 +336,21 @@ def test_chunk_kda_selects_direct_dense_or_ragged_route(
     monkeypatch, batch, tokens, explicit_offsets, expected_route
 ):
     """Keep complete single sequences on the direct launcher without a mode object."""
-    module = importlib.import_module("attn_gym.linear.kda.fwd.cute.chunk_kda_fwd")
+    module = importlib.import_module("attn_gym.linear.kda.impl.fused")
     routes = []
 
-    def dense_forward(q, _k, v, _gate, _beta, _state):
+    def dense_forward(q, _k, v, _gate, _beta, _state, _tune):
         routes.append("dense")
         tape = q.new_empty((*q.shape[:3], 64))
         return torch.empty_like(v), tape, tape
 
-    def ragged_forward(q, _k, v, _gate, _beta, _state, _cu_seqlens, _chunk_offsets):
+    def ragged_forward(q, _k, v, _gate, _beta, _state, _cu_seqlens, _chunk_offsets, _tune):
         routes.append("ragged")
         tape = q.new_empty((*q.shape[:3], 64))
         return torch.empty_like(v), tape, tape
 
-    monkeypatch.setattr(module, "_chunk_kda_fwd_op", dense_forward)
-    monkeypatch.setattr(module, "_chunk_kda_fwd_ragged_op", ragged_forward)
+    monkeypatch.setattr(module, "chunk_fwd_op", dense_forward)
+    monkeypatch.setattr(module, "chunk_fwd_ragged_op", ragged_forward)
     inputs = tuple(tensor.detach() for tensor in _inputs(batch=batch, tokens=tokens))
     cu_seqlens = (
         None
@@ -562,8 +561,8 @@ def test_backward_tuning_configs(monkeypatch, attribute, kernel, config_type):
     launches = (
         kernel,
         *(functools.partial(kernel, config=config) for config in candidates),
-        functools.partial(kernel, tune=True),
-        functools.partial(kernel, tune=True, configs=candidates),
+        functools.partial(kernel, autotune=True),
+        functools.partial(kernel, autotune=True, configs=candidates),
     )
 
     gradients = []
@@ -627,6 +626,7 @@ def test_chunk_kda_op_registration():
         cumulative_gate.detach(),
         beta.detach(),
         initial_state.detach(),
+        True,
     )
     torch.library.opcheck(_chunk_kda_fwd_op, args, rtol=2e-2, atol=2e-3)
     torch.library.opcheck(_chunk_kda_fwd_with_state_op, args, rtol=2e-2, atol=2e-3)
@@ -644,6 +644,7 @@ def test_chunk_kda_backward_op_registration():
             cumulative_gate,
             beta,
             initial_state,
+            True,
         )
     torch.library.opcheck(
         _chunk_kda_bwd_op,
@@ -661,6 +662,7 @@ def test_chunk_kda_backward_op_registration():
             torch.randn_like(state),
             None,
             False,
+            True,
         ),
         test_utils=("test_schema", "test_faketensor", "test_aot_dispatch_dynamic"),
         rtol=2e-2,
@@ -682,6 +684,7 @@ def test_chunk_kda_backward_op_registration():
             torch.randn_like(state),
             initial_state.detach(),
             False,
+            True,
         ),
         test_utils=("test_schema", "test_faketensor", "test_aot_dispatch_dynamic"),
         rtol=2e-2,
@@ -906,7 +909,7 @@ def test_chunk_kda_validates_public_contract():
         chunk_kda(q, k, v, cumulative_gate, beta[:, :-1])
     with pytest.raises(ValueError, match="initial_state must have shape"):
         chunk_kda(q, k, v, cumulative_gate, beta, q.new_empty(1, 1, 64, 128))
-    with pytest.raises(ValueError, match="nonempty token"):
+    with pytest.raises(ValueError, match="nonempty"):
         chunk_kda(q[:, :0], k[:, :0], v[:, :0], cumulative_gate[:, :0], beta[:, :0])
     with pytest.raises(ValueError, match="same device"):
         chunk_kda(q, k, v, cumulative_gate, beta.cpu())

--- a/test/test_kda_impl_dispatch.py
+++ b/test/test_kda_impl_dispatch.py
@@ -1,0 +1,247 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Implementation-selection tests for the public KDA operations."""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from attn_gym.linear import Impl, chunk_kda, recurrent_kda
+from attn_gym.linear.kda.naive import chunk_cumsum_ref
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="KDA ops require CUDA")
+
+BLACKWELL = torch.cuda.is_available() and torch.cuda.get_device_capability() >= (10, 0)
+
+
+def _inputs(
+    batch: int = 2,
+    tokens: int = 37,
+    heads: int = 2,
+    head_dim: int = 64,
+    dtype: torch.dtype = torch.float32,
+    seed: int = 0,
+    device: str = "cuda",
+):
+    torch.manual_seed(seed)
+
+    def normalized() -> torch.Tensor:
+        raw = torch.randn(batch, tokens, heads, head_dim, device=device)
+        return F.normalize(raw, dim=-1).to(dtype)
+
+    q, k = normalized(), normalized()
+    v = torch.randn(batch, tokens, heads, head_dim, device=device, dtype=dtype)
+    gate = -torch.rand(batch, tokens, heads, head_dim, device=device) * 3.0
+    beta = torch.rand(batch, tokens, heads, device=device)
+    return q, k, v, gate, beta
+
+
+def test_impl_accepts_enum_and_string():
+    """Coerce both spellings and reject unknown selectors with the valid set."""
+    q, k, v, gate, beta = _inputs(tokens=8)
+
+    from_enum, _ = recurrent_kda(q, k, v, gate, beta, impl=Impl.REFERENCE)
+    from_string, _ = recurrent_kda(q, k, v, gate, beta, impl="reference")
+    torch.testing.assert_close(from_enum, from_string, rtol=0, atol=0)
+
+    with pytest.raises(ValueError, match="'fused', 'reference'"):
+        recurrent_kda(q, k, v, gate, beta, impl="naive")
+
+
+def test_recurrent_accepts_reserved_autotune_flag():
+    """Keep the public selector signatures aligned while recurrent uses a fixed policy."""
+    q, k, v, gate, beta = _inputs(tokens=8)
+
+    tuned, _ = recurrent_kda(q, k, v, gate, beta, autotune=True, impl="reference")
+    fixed, _ = recurrent_kda(q, k, v, gate, beta, autotune=False, impl="reference")
+    torch.testing.assert_close(tuned, fixed, rtol=0, atol=0)
+
+
+def test_recurrent_reference_matches_fused():
+    """Agree across implementations on dense batches."""
+    q, k, v, gate, beta = _inputs()
+    initial_state = torch.randn(2, 2, 64, 64, device="cuda")
+
+    fused, fused_state = recurrent_kda(
+        q, k, v, gate, beta, initial_state, output_final_state=True, impl="fused"
+    )
+    reference, reference_state = recurrent_kda(
+        q, k, v, gate, beta, initial_state, output_final_state=True, impl="reference"
+    )
+    torch.testing.assert_close(fused, reference, rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(fused_state, reference_state, rtol=1e-5, atol=1e-5)
+
+
+def test_recurrent_reference_packed_capacity_and_empty_slots():
+    """Match the fused packed contract, including padding slots and tails."""
+    q, k, v, gate, beta = _inputs(batch=1, tokens=32, seed=1)
+    cu_seqlens = torch.tensor([0, 0, 11, 27, 27], device="cuda", dtype=torch.int32)
+    initial_state = torch.randn(4, 2, 64, 64, device="cuda")
+
+    with torch.no_grad():
+        fused, fused_state = recurrent_kda(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            initial_state,
+            cu_seqlens=cu_seqlens,
+            output_final_state=True,
+            impl="fused",
+        )
+    reference, reference_state = recurrent_kda(
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        initial_state,
+        cu_seqlens=cu_seqlens,
+        output_final_state=True,
+        impl="reference",
+    )
+    active = cu_seqlens[-1].item()
+    torch.testing.assert_close(fused[:, :active], reference[:, :active], rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(fused_state, reference_state, rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(reference_state[0], initial_state[0], rtol=0, atol=0)
+
+
+def test_reference_impls_run_on_cpu():
+    """The reference contract promises any hardware; pin the CPU boundary."""
+    q, k, v, gate, beta = _inputs(tokens=70, device="cpu")
+    cumulative_gate = chunk_cumsum_ref(gate, 64)
+
+    output, state = recurrent_kda(q, k, v, gate, beta, output_final_state=True, impl="reference")
+    chunk_output, chunk_state = chunk_kda(
+        q, k, v, cumulative_gate, beta, output_final_state=True, impl="reference"
+    )
+    for tensor in (output, state, chunk_output, chunk_state):
+        assert tensor.device.type == "cpu"
+    torch.testing.assert_close(chunk_output, output, rtol=1e-4, atol=1e-4)
+    torch.testing.assert_close(chunk_state, state, rtol=1e-4, atol=1e-4)
+
+
+def test_recurrent_reference_is_differentiable():
+    """Keep a training-capable escape hatch where the fused scan has none."""
+    q, k, v, gate, beta = _inputs(tokens=8)
+    q, v = q.requires_grad_(), v.requires_grad_()
+
+    output, _ = recurrent_kda(q, k, v, gate, beta, impl="reference")
+    output.sum().backward()
+    assert q.grad is not None and v.grad is not None
+
+
+@pytest.mark.skipif(not BLACKWELL, reason="fused chunk_kda requires CUDA capability 10.0")
+def test_chunk_reference_matches_fused():
+    """Agree across implementations through the cumulative-gate contract."""
+    q, k, v, gate, beta = _inputs(tokens=100, head_dim=128, dtype=torch.bfloat16, seed=2)
+    cumulative_gate = chunk_cumsum_ref(gate, 64)
+
+    fused, fused_state = chunk_kda(
+        q, k, v, cumulative_gate, beta, output_final_state=True, impl="fused"
+    )
+    reference, reference_state = chunk_kda(
+        q, k, v, cumulative_gate, beta, output_final_state=True, impl="reference"
+    )
+    assert reference.dtype == q.dtype and reference_state.dtype == torch.float32
+    torch.testing.assert_close(fused.float(), reference.float(), rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(fused_state, reference_state, rtol=2e-2, atol=2e-2)
+
+
+@pytest.mark.skipif(not BLACKWELL, reason="fused chunk_kda requires CUDA capability 10.0")
+def test_chunk_reference_packed_matches_fused():
+    """Match the fused ragged path per sequence, including empty slots."""
+    q, k, v, gate, beta = _inputs(batch=1, tokens=150, head_dim=128, dtype=torch.bfloat16, seed=3)
+    cu_seqlens = torch.tensor([0, 0, 70, 150], device="cuda", dtype=torch.int32)
+    cumulative_gate = chunk_cumsum_ref(gate, 64, cu_seqlens=cu_seqlens)
+
+    fused, fused_state = chunk_kda(
+        q,
+        k,
+        v,
+        cumulative_gate,
+        beta,
+        cu_seqlens=cu_seqlens,
+        output_final_state=True,
+        impl="fused",
+    )
+    reference, reference_state = chunk_kda(
+        q,
+        k,
+        v,
+        cumulative_gate,
+        beta,
+        cu_seqlens=cu_seqlens,
+        output_final_state=True,
+        impl="reference",
+    )
+    torch.testing.assert_close(fused.float(), reference.float(), rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(fused_state, reference_state, rtol=2e-2, atol=2e-2)
+
+
+def test_chunk_reference_supports_any_head_dim():
+    """Lift the fused K=V=128 constraint without changing the contract."""
+    q, k, v, gate, beta = _inputs(tokens=70, head_dim=48, seed=4)
+    cumulative_gate = chunk_cumsum_ref(gate, 64)
+
+    output, state = chunk_kda(
+        q, k, v, cumulative_gate, beta, output_final_state=True, impl="reference"
+    )
+    assert output.shape == v.shape and state.shape == (2, 2, 48, 48)
+    with pytest.raises(ValueError, match="128"):
+        chunk_kda(q, k, v, cumulative_gate, beta, impl="fused")
+
+
+def test_chunk_reference_rejects_fastmath():
+    """Keep fused-only knobs from silently changing meaning."""
+    q, k, v, gate, beta = _inputs(tokens=8)
+    with pytest.raises(ValueError, match="fastmath"):
+        chunk_kda(q, k, v, chunk_cumsum_ref(gate, 64), beta, fastmath=True, impl="reference")
+
+
+@pytest.mark.skipif(not BLACKWELL, reason="fused chunk_kda requires CUDA capability 10.0")
+def test_chunk_autotune_flag_is_deterministic_and_accurate():
+    """autotune=False pins fixed heuristic configs without changing the math contract."""
+    q, k, v, gate, beta = _inputs(tokens=128, head_dim=128, dtype=torch.bfloat16, seed=5)
+    cumulative_gate = chunk_cumsum_ref(gate, 64)
+    q, v = q.requires_grad_(), v.requires_grad_()
+
+    def run():
+        output, state = chunk_kda(
+            q, k, v, cumulative_gate, beta, output_final_state=True, autotune=False
+        )
+        grads = torch.autograd.grad(output.float().square().mean() + state.square().mean(), (q, v))
+        return output, state, *grads
+
+    first = run()
+    second = run()
+    for a, b in zip(first, second, strict=True):
+        torch.testing.assert_close(a, b, rtol=0, atol=0)
+
+    tuned_output, tuned_state = chunk_kda(
+        q.detach(), k, v.detach(), cumulative_gate, beta, output_final_state=True
+    )
+    torch.testing.assert_close(first[0], tuned_output, rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(first[1], tuned_state, rtol=2e-2, atol=2e-2)
+
+
+def test_reference_stays_fp32_under_autocast():
+    """The FP32-oracle contract must survive an active AMP region."""
+    q, k, v, gate, beta = _inputs(tokens=64)
+    with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+        output, state = recurrent_kda(
+            q, k, v, gate, beta, output_final_state=True, impl="reference"
+        )
+        chunk_output, _ = chunk_kda(q, k, v, chunk_cumsum_ref(gate, 64), beta, impl="reference")
+    expected, expected_state = recurrent_kda(
+        q, k, v, gate, beta, output_final_state=True, impl="reference"
+    )
+    chunk_expected, _ = chunk_kda(q, k, v, chunk_cumsum_ref(gate, 64), beta, impl="reference")
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+    torch.testing.assert_close(state, expected_state, rtol=0, atol=0)
+    torch.testing.assert_close(chunk_output, chunk_expected, rtol=0, atol=0)

--- a/test/test_kda_imports.py
+++ b/test/test_kda_imports.py
@@ -1,0 +1,78 @@
+"""Cold-import and registration tests for the public KDA boundary."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+import torch
+
+
+def run_fresh_python(source: str) -> None:
+    """Run a repository import scenario without this pytest process's module state."""
+    subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(source)],
+        check=True,
+        text=True,
+    )
+
+
+def test_reference_api_imports_without_optional_kernel_dependencies():
+    """Keep the public reference path usable with torch as its only dependency."""
+    run_fresh_python(
+        """
+        import builtins
+        import torch
+
+        original_import = builtins.__import__
+
+        def reject_optional_backends(name, *args, **kwargs):
+            if name.split('.', 1)[0] in {'cutlass', 'triton'}:
+                raise ModuleNotFoundError(name)
+            return original_import(name, *args, **kwargs)
+
+        builtins.__import__ = reject_optional_backends
+
+        from attn_gym.linear import chunk_kda, recurrent_kda
+
+        shape = (1, 3, 1, 2)
+        q = torch.randn(shape)
+        k = torch.randn(shape)
+        v = torch.randn(shape)
+        gate = -torch.rand(shape)
+        beta = torch.rand(shape[:3])
+        recurrent_kda(q, k, v, gate, beta, impl='reference')
+        chunk_kda(q, k, v, gate, beta, impl='reference')
+        """
+    )
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (10, 0),
+    reason="cold fused chunk compilation requires CUDA capability 10.0 or newer",
+)
+def test_chunk_kda_cold_public_fullgraph_compile():
+    """Register operator contracts before the first fused call enters Dynamo."""
+    pytest.importorskip("cutlass")
+    run_fresh_python(
+        """
+        import torch
+        import torch.nn.functional as F
+
+        from attn_gym.linear import chunk_kda
+        from attn_gym.linear.kda.naive import chunk_cumsum_ref
+
+        shape = (1, 64, 1, 128)
+        q = F.normalize(torch.randn(shape, device='cuda'), dim=-1).to(torch.bfloat16)
+        k = F.normalize(torch.randn(shape, device='cuda'), dim=-1).to(torch.bfloat16)
+        v = torch.randn(shape, device='cuda', dtype=torch.bfloat16)
+        gate = chunk_cumsum_ref(-torch.rand(shape, device='cuda'), 64)
+        beta = torch.rand(shape[:3], device='cuda')
+
+        compiled = torch.compile(chunk_kda, fullgraph=True)
+        compiled(q, k, v, gate, beta, autotune=False)
+        torch.cuda.synchronize()
+        """
+    )

--- a/test/test_kda_ragged_autograd_ops.py
+++ b/test/test_kda_ragged_autograd_ops.py
@@ -32,6 +32,7 @@ def test_ragged_custom_op_registrations():
         initial_state.detach(),
         cu_seqlens,
         metadata.chunk_offsets,
+        True,
     )
     torch.library.opcheck(
         _chunk_kda_fwd_ragged_with_state_op,
@@ -63,6 +64,7 @@ def test_ragged_custom_op_registrations():
             torch.randn_like(state),
             initial_state.detach(),
             False,
+            True,
         ),
         test_utils=("test_schema", "test_faketensor", "test_aot_dispatch_dynamic"),
         rtol=2e-2,
@@ -74,6 +76,7 @@ def test_ragged_custom_op_registrations():
         None,
         cu_seqlens,
         metadata.chunk_offsets,
+        True,
     )
     with torch.no_grad():
         output, Aqk, Akk = _chunk_kda_fwd_ragged_op(*no_state_args)
@@ -89,6 +92,7 @@ def test_ragged_custom_op_registrations():
             None,
             None,
             False,
+            True,
         ),
         test_utils=("test_schema", "test_faketensor", "test_aot_dispatch_dynamic"),
         rtol=2e-2,

--- a/test/test_kda_ragged_public_backward.py
+++ b/test/test_kda_ragged_public_backward.py
@@ -7,8 +7,8 @@ import torch
 
 pytest.importorskip("cutlass")
 
-from attn_gym.linear import naive_chunk_kda_from_cumulative
-from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd import chunk_kda
+from attn_gym.linear import chunk_kda
+from attn_gym.linear.kda.naive import naive_chunk_kda_from_cumulative
 from attn_gym.testing.kda import (
     assert_matches_low_precision_reference,
     clone_kda_inputs,

--- a/test/test_kda_recurrent.py
+++ b/test/test_kda_recurrent.py
@@ -14,11 +14,12 @@ import torch.nn.functional as F
 
 pytest.importorskip("triton")
 
-from attn_gym.linear import naive_recurrent_kda, recurrent_kda
+from attn_gym.linear import recurrent_kda
 from attn_gym.linear.kda.fwd.triton.recurrent import (
     _recurrent_fwd_no_state_op,
     _recurrent_fwd_op,
 )
+from attn_gym.linear.kda.naive import naive_recurrent_kda
 
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available(), reason="recurrent_kda requires CUDA"

--- a/test/test_kda_training_example.py
+++ b/test/test_kda_training_example.py
@@ -231,11 +231,14 @@ def test_kda_example_masked_capacity_matches_active_run_under_graph_replay(
         output = model(states, cu_seqlens=offsets).hidden_states
         return output, torch.autograd.grad(output, (states, *parameters), grad_output)
 
-    run(hidden, cu_seqlens, cotangent)
-    torch.cuda.synchronize()
+    capture_stream = torch.cuda.Stream()
+    capture_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(capture_stream):
+        run(hidden, cu_seqlens, cotangent)
+    capture_stream.synchronize()
 
     graph = torch.cuda.CUDAGraph()
-    with torch.cuda.graph(graph):
+    with torch.cuda.graph(graph, stream=capture_stream):
         captured_output, captured_gradients = run(hidden, cu_seqlens, cotangent)
 
     active_tokens = replayed_offsets[-1]
@@ -251,11 +254,13 @@ def test_kda_example_masked_capacity_matches_active_run_under_graph_replay(
     graph.replay()
     torch.cuda.synchronize()
 
-    expected_output, expected_gradients = run(
-        hidden[:, :active_tokens].detach().clone().requires_grad_(),
-        active_offsets,
-        cotangent[:, :active_tokens],
-    )
+    with torch.cuda.stream(capture_stream):
+        expected_output, expected_gradients = run(
+            hidden[:, :active_tokens].detach().clone().requires_grad_(),
+            active_offsets,
+            cotangent[:, :active_tokens],
+        )
+    capture_stream.synchronize()
     torch.testing.assert_close(
         captured_output[:, :active_tokens], expected_output, rtol=3e-2, atol=3e-2
     )


### PR DESCRIPTION
Give chunk_kda and recurrent_kda a string-enum impl selector

## Human Note

## Agent note

The two algorithmic forms stay separate functions because their gate contracts differ
(chunk-local cumulative vs per-token log2 decay), but naive-versus-fused is now an argument
instead of parallel `naive_*` names, following the shape of gdn's existing mode/backend split and
FLA's ops-layer layout. `Impl` is a `str` enum ("fused" | "reference") shared from
`attn_gym.linear.impl`; both ops accept the enum or its string value, and unknown selectors list
the valid set. There is deliberately no "auto" fallback: a training run should never silently land
on the eager reference.

The public wrappers move to torch-only `attn_gym.linear.kda.api`, which validates the shared
contract and imports the fused backends lazily inside the fused branch, so `chunk_kda` and
`recurrent_kda` are now eager exports and the PEP 562 lazy set shrinks to the standalone kernels.
`impl="reference"` runs the naive oracles in FP32 behind the identical packed contract (empty
padding slots pass state through, capacity tails stay out of contract, states come back FP32 with
one entry per logical sequence); it lifts the fused constraints — any hardware, any head dimension,
and a differentiable recurrent path where the fused scan is inference-only — at the cost of a host
read of the offsets. Fused-only knobs stay fused-only: `fastmath` with the reference raises. The
`naive_*` functions leave the public interface and remain importable as test oracles from
`attn_gym.linear.kda.naive`.

## Test Plan

```bash
gpu-run auto -- ~/.venvs/ag-linear/bin/python -m pytest test/test_kda_impl_dispatch.py \
  test/test_kda_recurrent.py test/test_kda.py test/test_kda_cute_forward.py \
  test/test_kda_ragged_public_backward.py test/test_kda_training_example.py -q
# 86 passed on B200. New coverage: enum/string coercion and rejection, reference-vs-fused
# agreement for both ops (dense and packed with empty slots and capacity tails), reference
# differentiability plus fused gradient rejection, non-128 head dims on the reference, and
# fastmath rejection. The one failure, test_chunk_kda_single_sequence_metadata_matches_dense_path,
# reproduces on pristine origin/main (16c2563) on this machine and is unrelated.
```