### PR TITLE
Clean up old pull request branches

### DIFF
--- a/.github/scripts/delete_old_pr_branches.py
+++ b/.github/scripts/delete_old_pr_branches.py
@@ -1,0 +1,238 @@
+"""Delete old branches that still point at the head of a closed pull request."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from urllib.parse import quote
+
+RETENTION = timedelta(days=30)
+NO_DELETE_LABEL = "no-delete-branch"
+GHSTACK_BRANCH = re.compile(r"^(gh/.+)/(?:head|base|orig)$")
+BranchGroupKey = tuple[str, str]
+
+
+@dataclass(frozen=True)
+class Branch:
+    """A remote branch at the object observed during discovery."""
+
+    name: str
+    oid: str
+    last_commit_at: datetime
+
+
+@dataclass(frozen=True)
+class BranchGroup:
+    """Branches that must be retained or deleted together."""
+
+    key: BranchGroupKey
+    branches: tuple[Branch, ...]
+
+    @property
+    def name(self) -> str:
+        return self.key[1]
+
+    @property
+    def last_commit_at(self) -> datetime:
+        return max(branch.last_commit_at for branch in self.branches)
+
+
+@dataclass(frozen=True)
+class PullRequest:
+    """Pull request state needed to decide whether its branch can be deleted."""
+
+    number: int
+    head_ref: str
+    head_sha: str
+    head_repo: str | None
+    base_ref: str
+    is_open: bool
+    updated_at: datetime
+    labels: frozenset[str]
+
+
+@dataclass(frozen=True)
+class DeletionCandidate:
+    """A branch group and the closed pull request that authorizes its deletion."""
+
+    group: BranchGroup
+    pull_request: PullRequest
+
+
+def branch_group_key(branch: str) -> BranchGroupKey:
+    """Return a collision-free key for a ghstack family or ordinary branch."""
+    match = GHSTACK_BRANCH.match(branch)
+    return ("ghstack", match.group(1)) if match else ("branch", branch)
+
+
+def group_branches(branches: Iterable[Branch]) -> list[BranchGroup]:
+    """Group ghstack refs while leaving ordinary branches independent."""
+    grouped: dict[BranchGroupKey, list[Branch]] = {}
+    for branch in branches:
+        grouped.setdefault(branch_group_key(branch.name), []).append(branch)
+    return [
+        BranchGroup(key, tuple(sorted(members, key=lambda branch: branch.name)))
+        for key, members in sorted(grouped.items())
+    ]
+
+
+def select_deletions(
+    groups: Iterable[BranchGroup],
+    pull_requests: Iterable[PullRequest],
+    repository: str,
+    now: datetime,
+) -> list[DeletionCandidate]:
+    """Select old closed-PR groups without touching active or unrelated refs."""
+    latest_closed: dict[BranchGroupKey, PullRequest] = {}
+    retained: set[BranchGroupKey] = set()
+
+    for pull_request in pull_requests:
+        if pull_request.is_open:
+            # Base refs always belong to this repository; heads may belong to forks.
+            retained.add(branch_group_key(pull_request.base_ref))
+        if pull_request.head_repo != repository:
+            continue
+        key = branch_group_key(pull_request.head_ref)
+        if pull_request.is_open or NO_DELETE_LABEL in pull_request.labels:
+            retained.add(key)
+        elif key not in latest_closed or pull_request.number > latest_closed[key].number:
+            latest_closed[key] = pull_request
+
+    deletions = []
+    for group in groups:
+        pull_request = latest_closed.get(group.key)
+        if pull_request is None or group.key in retained:
+            continue
+        if now - max(group.last_commit_at, pull_request.updated_at) < RETENTION:
+            continue
+        observed = {(branch.name, branch.oid) for branch in group.branches}
+        if (pull_request.head_ref, pull_request.head_sha) not in observed:
+            continue
+        deletions.append(DeletionCandidate(group, pull_request))
+    return deletions
+
+
+def run(*args: str) -> str:
+    """Run a command and return its standard output."""
+    return subprocess.run(args, check=True, text=True, capture_output=True).stdout
+
+
+def load_branches() -> list[Branch]:
+    """Load remote branches, object IDs, and commit timestamps from the checkout."""
+    output = run(
+        "git",
+        "for-each-ref",
+        "--format=%(refname:strip=3)\t%(objectname)\t%(committerdate:unix)",
+        "refs/remotes/origin",
+    )
+    branches = []
+    for line in output.splitlines():
+        name, oid, timestamp = line.split("\t")
+        if name != "HEAD":
+            branches.append(
+                Branch(name, oid, datetime.fromtimestamp(int(timestamp), timezone.utc))
+            )
+    return branches
+
+
+def parse_pull_request(payload: dict) -> PullRequest:
+    """Convert a GitHub pull request response into cleanup policy state."""
+    head, base = payload["head"], payload["base"]
+    return PullRequest(
+        number=payload["number"],
+        head_ref=head["ref"],
+        head_sha=head["sha"],
+        head_repo=head["repo"]["full_name"] if head["repo"] else None,
+        base_ref=base["ref"],
+        is_open=payload["state"] == "open",
+        updated_at=datetime.fromisoformat(payload["updated_at"].replace("Z", "+00:00")),
+        labels=frozenset(label["name"] for label in payload["labels"]),
+    )
+
+
+def load_pull_requests(repository: str) -> list[PullRequest]:
+    """Load every pull request, following each REST API page."""
+    endpoint = f"repos/{repository}/pulls?state=all&per_page=100"
+    pages = json.loads(run("gh", "api", "--paginate", "--slurp", endpoint))
+    return [parse_pull_request(payload) for page in pages for payload in page]
+
+
+def is_protected(repository: str, branch: str) -> bool:
+    """Return whether a branch is protected, failing closed on API errors."""
+    try:
+        response = run("gh", "api", f"repos/{repository}/branches/{quote(branch, safe='')}")
+    except subprocess.CalledProcessError as error:
+        print(f"[{branch}] Could not check branch protection: {error.stderr}")
+        return True
+    return bool(json.loads(response)["protected"])
+
+
+def group_is_protected(repository: str, group: BranchGroup) -> bool:
+    """Return whether any branch in a group is protected."""
+    return any(is_protected(repository, branch.name) for branch in group.branches)
+
+
+def refresh_candidate(
+    candidate: DeletionCandidate, repository: str, now: datetime
+) -> DeletionCandidate | None:
+    """Recheck protection and freshly fetched pull request state before deleting."""
+    if group_is_protected(repository, candidate.group):
+        return None
+    refreshed = select_deletions(
+        [candidate.group], load_pull_requests(repository), repository, now
+    )
+    return refreshed[0] if refreshed else None
+
+
+def delete_group(group: BranchGroup) -> None:
+    """Atomically delete a group only if every remote ref still has its observed OID."""
+    leases = [
+        f"--force-with-lease=refs/heads/{branch.name}:{branch.oid}" for branch in group.branches
+    ]
+    deletions = [f":refs/heads/{branch.name}" for branch in group.branches]
+    subprocess.run(["git", "push", "--atomic", *leases, "origin", *deletions], check=True)
+
+
+def main() -> None:
+    """Delete eligible branch groups or print them when running in dry-run mode."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    repository = os.environ["GITHUB_REPOSITORY"]
+    now = datetime.now(timezone.utc)
+    groups = group_branches(load_branches())
+    candidates = select_deletions(groups, load_pull_requests(repository), repository, now)
+
+    found_deletion = False
+    for candidate in candidates:
+        if args.dry_run:
+            refreshed = None if group_is_protected(repository, candidate.group) else candidate
+        else:
+            refreshed = refresh_candidate(candidate, repository, now)
+        if refreshed is None:
+            print(f"[{candidate.group.name}] State changed; skipping")
+            continue
+
+        found_deletion = True
+        action = "Would delete" if args.dry_run else "Deleting"
+        for branch in refreshed.group.branches:
+            print(
+                f"[{refreshed.group.name}] {action} {branch.name} "
+                f"for closed PR #{refreshed.pull_request.number}"
+            )
+        if not args.dry_run:
+            delete_group(refreshed.group)
+
+    if not found_deletion:
+        print("No old pull request branches to delete")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_delete_old_pr_branches.py
+++ b/.github/scripts/test_delete_old_pr_branches.py
@@ -1,0 +1,237 @@
+"""Test the cleanup policy with only the Python standard library."""
+
+import os
+import subprocess
+import tempfile
+import unittest
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+from delete_old_pr_branches import (
+    NO_DELETE_LABEL,
+    Branch,
+    BranchGroup,
+    DeletionCandidate,
+    PullRequest,
+    branch_group_key,
+    delete_group,
+    group_branches,
+    is_protected,
+    parse_pull_request,
+    refresh_candidate,
+    select_deletions,
+)
+
+NOW = datetime(2026, 8, 17, tzinfo=timezone.utc)
+OLD = NOW - timedelta(days=60)
+RECENT = NOW - timedelta(days=10)
+REPOSITORY = "meta-pytorch/attention-gym"
+
+
+def branch(name: str = "feature", oid: str = "feature-oid", at: datetime = OLD) -> Branch:
+    return Branch(name, oid, at)
+
+
+def group(*branches: Branch) -> BranchGroup:
+    """Build the group that ``group_branches`` produces for these branches."""
+    return BranchGroup(branch_group_key(branches[0].name), branches)
+
+
+def select(groups: list[BranchGroup], pull_requests: list[PullRequest]) -> list[DeletionCandidate]:
+    """Apply the cleanup policy to this repository at NOW."""
+    return select_deletions(groups, pull_requests, REPOSITORY, NOW)
+
+
+CLOSED_PR = PullRequest(
+    number=1,
+    head_ref="feature",
+    head_sha="feature-oid",
+    head_repo=REPOSITORY,
+    base_ref="main",
+    is_open=False,
+    updated_at=OLD,
+    labels=frozenset(),
+)
+FEATURE = group(branch())
+GHSTACK = group(
+    branch("gh/user/1/base", "base-oid"),
+    branch("gh/user/1/head", "head-oid"),
+    branch("gh/user/1/orig", "orig-oid"),
+)
+GHSTACK_HEAD_PR = replace(CLOSED_PR, head_ref="gh/user/1/head", head_sha="head-oid")
+
+
+class TestBranchGrouping(unittest.TestCase):
+    def test_branch_group_keys(self) -> None:
+        """ghstack refs share one key; every other branch keeps its own."""
+        expected = {
+            "gh/user/1/base": ("ghstack", "gh/user/1"),
+            "gh/user/1/head": ("ghstack", "gh/user/1"),
+            "gh/user/1/orig": ("ghstack", "gh/user/1"),
+            # A branch may share a ghstack family prefix without joining the family.
+            "gh/user/1": ("branch", "gh/user/1"),
+            "user/stack/1": ("branch", "user/stack/1"),
+        }
+
+        self.assertEqual({name: branch_group_key(name) for name in expected}, expected)
+
+    def test_groups_ghstack_family_only(self) -> None:
+        groups = group_branches(
+            [
+                branch("gh/user/1/head", "head-oid", RECENT),
+                branch("gh/user/1/base", "base-oid"),
+                branch("gh/user/1"),
+                branch(),
+            ]
+        )
+
+        self.assertEqual(
+            [(item.key, [member.name for member in item.branches]) for item in groups],
+            [
+                (("branch", "feature"), ["feature"]),
+                (("branch", "gh/user/1"), ["gh/user/1"]),
+                (("ghstack", "gh/user/1"), ["gh/user/1/base", "gh/user/1/head"]),
+            ],
+        )
+
+
+class TestSelectDeletions(unittest.TestCase):
+    def test_selects_old_closed_pr_branch_at_its_reviewed_sha(self) -> None:
+        candidate = DeletionCandidate(FEATURE, CLOSED_PR)
+        self.assertEqual(select([FEATURE], [CLOSED_PR]), [candidate])
+
+    def test_selects_closed_ghstack_family_atomically(self) -> None:
+        candidate = DeletionCandidate(GHSTACK, GHSTACK_HEAD_PR)
+        self.assertEqual(select([GHSTACK], [GHSTACK_HEAD_PR]), [candidate])
+
+    def test_pull_request_retention_rules(self) -> None:
+        """Every pull request state that keeps an otherwise deletable branch alive."""
+        cases: dict[str, list[PullRequest]] = {
+            "branch moved off the reviewed sha": [replace(CLOSED_PR, head_sha="other-oid")],
+            "newer pr moved the head despite an older update time": [
+                CLOSED_PR,
+                replace(
+                    CLOSED_PR,
+                    number=2,
+                    head_sha="new-oid",
+                    updated_at=OLD - timedelta(days=10),
+                ),
+            ],
+            "open pr head": [replace(CLOSED_PR, is_open=True)],
+            "open pr base": [
+                CLOSED_PR,
+                replace(CLOSED_PR, head_ref="child", base_ref="feature", is_open=True),
+            ],
+            "recently updated pr": [replace(CLOSED_PR, updated_at=RECENT)],
+            "no-delete label": [replace(CLOSED_PR, labels=frozenset({NO_DELETE_LABEL}))],
+            "no pull request": [],
+            "fork head": [replace(CLOSED_PR, head_repo="contributor/attention-gym")],
+            "deleted fork head": [replace(CLOSED_PR, head_repo=None)],
+        }
+
+        for reason, pull_requests in cases.items():
+            with self.subTest(reason=reason):
+                self.assertEqual(select([FEATURE], pull_requests), [])
+
+    def test_retains_recently_pushed_branch(self) -> None:
+        self.assertEqual(select([group(branch(at=RECENT))], [CLOSED_PR]), [])
+
+    def test_retains_ghstack_family_with_recently_pushed_sibling(self) -> None:
+        family = group(
+            branch("gh/user/1/base", "base-oid"), branch("gh/user/1/head", "head-oid", RECENT)
+        )
+        self.assertEqual(select([family], [GHSTACK_HEAD_PR]), [])
+
+
+class TestPullRequestParsing(unittest.TestCase):
+    def test_parses_api_payload(self) -> None:
+        payload = {
+            "number": 7,
+            "state": "closed",
+            "updated_at": "2026-06-18T02:30:00Z",
+            "labels": [{"name": NO_DELETE_LABEL}],
+            "head": {"ref": "feature", "sha": "feature-oid", "repo": {"full_name": REPOSITORY}},
+            "base": {"ref": "main"},
+        }
+
+        self.assertEqual(
+            parse_pull_request(payload),
+            replace(
+                CLOSED_PR,
+                number=7,
+                updated_at=datetime(2026, 6, 18, 2, 30, tzinfo=timezone.utc),
+                labels=frozenset({NO_DELETE_LABEL}),
+            ),
+        )
+
+        payload["head"]["repo"] = None
+        self.assertIsNone(parse_pull_request(payload).head_repo)
+
+
+class TestDeletionSafety(unittest.TestCase):
+    @patch("delete_old_pr_branches.load_pull_requests")
+    @patch("delete_old_pr_branches.is_protected", return_value=False)
+    def test_refresh_rejects_new_open_base_dependency(
+        self, _is_protected_mock, load_pull_requests_mock
+    ) -> None:
+        candidate = DeletionCandidate(FEATURE, CLOSED_PR)
+        child = replace(
+            CLOSED_PR,
+            number=2,
+            head_ref="child",
+            head_sha="child-oid",
+            base_ref="feature",
+            is_open=True,
+        )
+        load_pull_requests_mock.return_value = [CLOSED_PR, child]
+
+        self.assertIsNone(refresh_candidate(candidate, REPOSITORY, NOW))
+
+    def test_changed_ref_rejects_entire_atomic_deletion(self) -> None:
+        """git must reject the whole push when one lease is stale."""
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        directory = Path(temporary.name)
+        work = directory / "work"
+        self.git("init", "--bare", "remote.git", cwd=directory)
+        self.git("init", "work", cwd=directory)
+        self.git("remote", "add", "origin", str(directory / "remote.git"), cwd=work)
+        self.git("commit", "--allow-empty", "-m", "reviewed", cwd=work)
+        reviewed_oid = self.git("rev-parse", "HEAD", cwd=work).stdout.strip()
+        head = "HEAD:refs/heads/gh/user/1/head"
+        self.git("push", "origin", "HEAD:refs/heads/gh/user/1/base", head, cwd=work)
+        self.git("commit", "--allow-empty", "-m", "pushed after discovery", cwd=work)
+        self.git("push", "origin", head, cwd=work)
+        stale = group(
+            branch("gh/user/1/base", reviewed_oid), branch("gh/user/1/head", reviewed_oid)
+        )
+
+        self.addCleanup(os.chdir, Path.cwd())
+        os.chdir(work)
+        with self.assertRaises(subprocess.CalledProcessError):
+            delete_group(stale)
+
+        refs = self.git("ls-remote", "--heads", "origin", cwd=work).stdout
+        self.assertIn("refs/heads/gh/user/1/base", refs)
+        self.assertIn("refs/heads/gh/user/1/head", refs)
+
+    @staticmethod
+    def git(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+        identity = ("-c", "user.name=cleanup", "-c", "user.email=cleanup@example.com")
+        return subprocess.run(
+            ["git", *identity, *args], cwd=cwd, check=True, capture_output=True, text=True
+        )
+
+    @patch("delete_old_pr_branches.run")
+    def test_protection_lookup_fails_closed(self, run_mock) -> None:
+        run_mock.side_effect = subprocess.CalledProcessError(
+            1, ["gh", "api"], stderr="API failure"
+        )
+
+        self.assertTrue(is_protected(REPOSITORY, "feature"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/delete-old-pr-branches.yml
+++ b/.github/workflows/delete-old-pr-branches.yml
@@ -1,0 +1,61 @@
+name: Delete old pull request branches
+
+on:
+  schedule:
+    - cron: "30 2 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: delete-old-pr-branches
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  dry-run:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Report old pull request branches
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python .github/scripts/delete_old_pr_branches.py --dry-run
+
+  delete:
+    if: github.event_name == 'schedule' && github.repository == 'meta-pytorch/attention-gym'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          fetch-depth: 0
+          # The cleanup script uses git push to delete eligible branches.
+          persist-credentials: true
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Test branch cleanup policy
+        run: python .github/scripts/test_delete_old_pr_branches.py
+
+      - name: Delete old pull request branches
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python .github/scripts/delete_old_pr_branches.py

--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -19,3 +19,5 @@ jobs:
         persist-credentials: false
     - name: Run prek
       uses: j178/prek-action@5337cb91e0fa35a7ff31b9ca345126d8bbbcdf16 # v2.0.6
+    - name: Test branch cleanup policy
+      run: python3 .github/scripts/test_delete_old_pr_branches.py


### PR DESCRIPTION
## Human Note

## Agent note

Add a weekly cleanup workflow modeled on PyTorch's branch reaper while accounting for both ghstack families
and stack-pr base branches. A branch is eligible only when its latest same-repository PR has been closed for
30 days, the branch still points at that PR's reviewed head SHA, no open PR uses it as a head or base, and it
is not protected or labeled `no-delete-branch`.

The workflow refreshes state immediately before each deletion and uses explicit per-ref leases with an atomic
push, so a concurrent update rejects the whole group. Manual dispatch is always read-only and dry-run; only
the weekly scheduled job receives write permission. The current dry run identifies 68 groups containing 78
refs while excluding active and recent stack branches.

## Test Plan

```bash
python3 .github/scripts/test_delete_old_pr_branches.py
prek run --files .github/scripts/delete_old_pr_branches.py .github/scripts/test_delete_old_pr_branches.py .github/workflows/delete-old-pr-branches.yml .github/workflows/prek.yml
actionlint .github/workflows/delete-old-pr-branches.yml .github/workflows/prek.yml
GITHUB_REPOSITORY=meta-pytorch/attention-gym python3 .github/scripts/delete_old_pr_branches.py --dry-run
git diff --check
```
