### PR TITLE
Bound the metadata-vs-dense gate gradient instead of requiring bit equality

### DIFF
--- a/test/test_kda_cute_forward.py
+++ b/test/test_kda_cute_forward.py
@@ -435,8 +435,19 @@ def test_chunk_kda_single_sequence_metadata_matches_dense_path():
     explicit_gradients = torch.autograd.grad(
         (explicit_output, explicit_state), explicit_inputs, (d_output, d_state)
     )
-    for explicit_gradient, dense_gradient in zip(explicit_gradients, dense_gradients, strict=True):
-        torch.testing.assert_close(explicit_gradient, dense_gradient, rtol=0, atol=0)
+    # Forward values and most gradients stay bitwise across the two lowerings.
+    # The exception is the FP32 cumulative-gate gradient: it is the only output
+    # assembled by software FP32 reduction chains (dq/dk/dv come from MMA
+    # accumulators with hardware-fixed order), and the dense versus ragged
+    # constexpr specializations of the fused wy/dqkg kernel schedule those
+    # chains differently, so it accumulates a few rounding steps near zero and
+    # gets an absolute bound instead of bit equality.
+    gate_index = 3
+    for index, (explicit_gradient, dense_gradient) in enumerate(
+        zip(explicit_gradients, dense_gradients, strict=True)
+    ):
+        atol = 1e-8 if index == gate_index else 0.0
+        torch.testing.assert_close(explicit_gradient, dense_gradient, rtol=0, atol=atol)
 
 
 def test_optimized_chunk_kda_autograd_without_initial_state():


### PR DESCRIPTION
## Human Note

## Agent note

`test_chunk_kda_single_sequence_metadata_matches_dense_path` asserted bitwise equality on every
gradient between the dense lowering and the degenerate `[0, T]` packed lowering. Kernel traces show
the two paths execute different backward kernels (`chunk_kda_bwd_kernel_dAv_ragged_tma` versus the
dense `chunk_kda_bwd_kernel_dAv`, plus vl0/vl1 CuTeDSL specializations), so bitwise gradients only
held on machines where `can_use_tma` routed both paths onto the same fallback kernel. On B200 the
divergence is deterministic and tiny: dq/dk/dv, d_beta, and d_initial_state remain bitwise (0 ULP,
verified), while the FP32 cumulative-gate gradient differs by at most 1.9e-9 absolute — a few
rounding steps near zero across differently scheduled reductions. The test now keeps `rtol=0,
atol=0` everywhere except that one gradient, which gets `atol=1e-8` (5x headroom over the observed
maximum) and a comment naming the kernel split.

## Test Plan

```bash
gpu-run auto -- ~/.venvs/ag-linear/bin/python -m pytest test/test_kda_cute_forward.py -q
# 31 passed on B200 (previously failed deterministically on TMA-capable machines)
```

