### PR TITLE
Add CI health dashboard

### DIFF
--- a/.github/scripts/generate_ci_health.py
+++ b/.github/scripts/generate_ci_health.py
@@ -1,0 +1,301 @@
+"""Build the static data consumed by the documentation site's CI health dashboard."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from statistics import median
+
+EXCLUDED_WORKFLOW_PATHS = {".github/workflows/claude-code.yml"}
+FAILURE_CONCLUSIONS = {"failure", "startup_failure", "stale", "timed_out"}
+IGNORED_CONCLUSIONS = {"action_required", "cancelled", "neutral", "skipped"}
+ANSI_ESCAPE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+PYTEST_FAILURE = re.compile(r"(?:FAILED|ERROR)\s+([^\s]+::[^\s]+)")
+
+
+def run(*args: str) -> str:
+    """Run a command and return its standard output."""
+    return subprocess.run(args, check=True, text=True, capture_output=True).stdout
+
+
+def github_api(endpoint: str) -> object:
+    """Load one GitHub REST API response through the authenticated gh CLI."""
+    return json.loads(run("gh", "api", endpoint))
+
+
+def parse_time(value: str | None) -> datetime | None:
+    """Parse a GitHub timestamp, preserving absence for unstarted jobs."""
+    return datetime.fromisoformat(value.replace("Z", "+00:00")) if value else None
+
+
+def duration_seconds(started_at: str | None, completed_at: str | None) -> float | None:
+    """Return elapsed seconds when both GitHub timestamps are present."""
+    start, end = parse_time(started_at), parse_time(completed_at)
+    return (end - start).total_seconds() if start and end else None
+
+
+def percentile(values: list[float], fraction: float) -> float | None:
+    """Return a linearly interpolated percentile for a small metric sample."""
+    if not values:
+        return None
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * fraction
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    weight = position - lower
+    return ordered[lower] * (1 - weight) + ordered[upper] * weight
+
+
+def extract_pytest_failures(log: str) -> list[str]:
+    """Extract unique pytest node IDs from a GitHub Actions job log."""
+    clean_log = ANSI_ESCAPE.sub("", log)
+    return list(dict.fromkeys(PYTEST_FAILURE.findall(clean_log)))[:12]
+
+
+def conclusion_kind(conclusion: str | None) -> str:
+    """Map GitHub conclusions to the dashboard's success/failure/ignored groups."""
+    if conclusion == "success":
+        return "success"
+    if conclusion in FAILURE_CONCLUSIONS:
+        return "failure"
+    return "ignored"
+
+
+def summarize_runs(runs: list[dict]) -> dict:
+    """Summarize completed workflow runs and preserve a compact recent timeline."""
+    completed = [run for run in runs if run.get("status") == "completed"]
+    counted = [run for run in completed if conclusion_kind(run.get("conclusion")) != "ignored"]
+    successes = sum(run.get("conclusion") == "success" for run in counted)
+    failures = len(counted) - successes
+    durations = [
+        duration
+        for item in counted
+        if (duration := duration_seconds(item.get("run_started_at"), item.get("updated_at")))
+        is not None
+    ]
+    latest = counted[0] if counted else None
+    success_rate = successes / len(counted) * 100 if counted else None
+
+    return {
+        "total": len(counted),
+        "successes": successes,
+        "failures": failures,
+        "ignored": len(completed) - len(counted),
+        "success_rate": success_rate,
+        "median_duration_seconds": median(durations) if durations else None,
+        "p95_duration_seconds": percentile(durations, 0.95),
+        "latest": compact_run(latest) if latest else None,
+        "timeline": [compact_run(run) for run in completed[:20]],
+    }
+
+
+def compact_run(run: dict) -> dict:
+    """Keep only fields required by the browser dashboard."""
+    return {
+        "id": run["id"],
+        "title": run.get("display_title") or run.get("name"),
+        "event": run.get("event"),
+        "branch": run.get("head_branch"),
+        "sha": (run.get("head_sha") or "")[:7],
+        "created_at": run.get("created_at"),
+        "conclusion": run.get("conclusion"),
+        "kind": conclusion_kind(run.get("conclusion")),
+        "duration_seconds": duration_seconds(run.get("run_started_at"), run.get("updated_at")),
+        "url": run.get("html_url"),
+    }
+
+
+def summarize_jobs(
+    workflow_name: str, runs: list[dict], jobs_by_run: dict[int, list[dict]]
+) -> list[dict]:
+    """Aggregate duration and success statistics for each job name in a workflow."""
+    grouped: dict[str, list[dict]] = defaultdict(list)
+    for workflow_run in runs:
+        for job in jobs_by_run.get(workflow_run["id"], []):
+            grouped[job["name"]].append(job)
+
+    summaries = []
+    for job_name, jobs in grouped.items():
+        completed = [job for job in jobs if job.get("status") == "completed"]
+        counted = [job for job in completed if conclusion_kind(job.get("conclusion")) != "ignored"]
+        durations = [
+            duration
+            for job in counted
+            if (duration := duration_seconds(job.get("started_at"), job.get("completed_at")))
+            is not None
+        ]
+        successes = sum(job.get("conclusion") == "success" for job in counted)
+        latest = completed[0] if completed else None
+        summaries.append(
+            {
+                "workflow": workflow_name,
+                "name": job_name,
+                "total": len(counted),
+                "success_rate": successes / len(counted) * 100 if counted else None,
+                "median_duration_seconds": median(durations) if durations else None,
+                "p95_duration_seconds": percentile(durations, 0.95),
+                "latest_conclusion": latest.get("conclusion") if latest else None,
+                "latest_url": latest.get("html_url") if latest else None,
+            }
+        )
+    return sorted(summaries, key=lambda item: (item["workflow"], item["name"]))
+
+
+def failed_run_details(repository: str, run: dict, workflow_name: str, jobs: list[dict]) -> dict:
+    """Describe failed jobs, steps, and pytest node IDs for one workflow run."""
+    failed_jobs = []
+    for job in jobs:
+        if conclusion_kind(job.get("conclusion")) != "failure":
+            continue
+        failed_steps = [
+            step["name"]
+            for step in job.get("steps", [])
+            if conclusion_kind(step.get("conclusion")) == "failure"
+        ]
+        try:
+            log = run_command_for_log(repository, job["id"])
+        except subprocess.CalledProcessError:
+            log = ""
+        failed_jobs.append(
+            {
+                "name": job["name"],
+                "url": job.get("html_url"),
+                "duration_seconds": duration_seconds(
+                    job.get("started_at"), job.get("completed_at")
+                ),
+                "failed_steps": failed_steps,
+                "tests": extract_pytest_failures(log),
+            }
+        )
+
+    return {
+        "workflow": workflow_name,
+        "title": run.get("display_title") or run.get("name"),
+        "branch": run.get("head_branch"),
+        "sha": (run.get("head_sha") or "")[:7],
+        "created_at": run.get("created_at"),
+        "url": run.get("html_url"),
+        "jobs": failed_jobs,
+    }
+
+
+def run_command_for_log(repository: str, job_id: int) -> str:
+    """Download a failed job's text log without treating it as JSON."""
+    return run("gh", "api", f"repos/{repository}/actions/jobs/{job_id}/logs")
+
+
+def build_dashboard(
+    repository: str,
+    workflows: list[dict],
+    runs_by_workflow: dict[int, list[dict]],
+    jobs_by_run: dict[int, list[dict]],
+    now: datetime,
+) -> dict:
+    """Build the complete JSON payload from fetched GitHub workflow data."""
+    workflow_summaries = []
+    job_summaries = []
+    failures = []
+    named_runs = []
+
+    for workflow in workflows:
+        workflow_runs = runs_by_workflow.get(workflow["id"], [])
+        named_runs.extend((run, workflow["name"]) for run in workflow_runs)
+        workflow_summaries.append(
+            {
+                "name": workflow["name"],
+                "path": workflow["path"],
+                "state": workflow["state"],
+                **summarize_runs(workflow_runs),
+            }
+        )
+        job_summaries.extend(summarize_jobs(workflow["name"], workflow_runs, jobs_by_run))
+
+    failed_runs = sorted(
+        (
+            (run, workflow_name)
+            for run, workflow_name in named_runs
+            if conclusion_kind(run.get("conclusion")) == "failure"
+        ),
+        key=lambda item: item[0].get("created_at") or "",
+        reverse=True,
+    )[:10]
+    for workflow_run, workflow_name in failed_runs:
+        failures.append(
+            failed_run_details(
+                repository,
+                workflow_run,
+                workflow_name,
+                jobs_by_run.get(workflow_run["id"], []),
+            )
+        )
+
+    overall = summarize_runs(
+        sorted(
+            (run for run, _ in named_runs),
+            key=lambda run: run.get("created_at") or "",
+            reverse=True,
+        )
+    )
+    return {
+        "repository": repository,
+        "generated_at": now.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "runs_per_workflow": max((len(runs) for runs in runs_by_workflow.values()), default=0),
+        "overall": overall,
+        "workflows": workflow_summaries,
+        "jobs": job_summaries,
+        "failures": failures,
+    }
+
+
+def load_dashboard(repository: str, runs_per_workflow: int, now: datetime) -> dict:
+    """Fetch active and disabled workflows plus their recent runs and jobs."""
+    response = github_api(f"repos/{repository}/actions/workflows?per_page=100")
+    workflows = [
+        workflow
+        for workflow in response["workflows"]
+        if workflow["path"] not in EXCLUDED_WORKFLOW_PATHS
+    ]
+    runs_by_workflow = {}
+    jobs_by_run = {}
+
+    for workflow in workflows:
+        response = github_api(
+            f"repos/{repository}/actions/workflows/{workflow['id']}/runs?per_page={runs_per_workflow}"
+        )
+        workflow_runs = response["workflow_runs"]
+        runs_by_workflow[workflow["id"]] = workflow_runs
+        for workflow_run in workflow_runs:
+            if workflow_run.get("status") != "completed":
+                continue
+            response = github_api(
+                f"repos/{repository}/actions/runs/{workflow_run['id']}/jobs?per_page=100"
+            )
+            jobs_by_run[workflow_run["id"]] = response["jobs"]
+
+    return build_dashboard(repository, workflows, runs_by_workflow, jobs_by_run, now)
+
+
+def main() -> None:
+    """Generate the CI health JSON file used by the documentation site."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY"))
+    parser.add_argument("--output", type=Path, default=Path("docs/assets/ci-health.json"))
+    parser.add_argument("--runs-per-workflow", type=int, default=12)
+    args = parser.parse_args()
+    if not args.repository:
+        parser.error("--repository or GITHUB_REPOSITORY is required")
+
+    dashboard = load_dashboard(args.repository, args.runs_per_workflow, datetime.now(timezone.utc))
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(dashboard, indent=2) + "\n")
+    print(f"Wrote CI health data to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_generate_ci_health.py
+++ b/.github/scripts/test_generate_ci_health.py
@@ -1,0 +1,131 @@
+"""Test CI health aggregation with only the Python standard library."""
+
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+from generate_ci_health import (
+    build_dashboard,
+    duration_seconds,
+    extract_pytest_failures,
+    percentile,
+    summarize_jobs,
+    summarize_runs,
+)
+
+NOW = datetime(2026, 8, 17, tzinfo=timezone.utc)
+REPOSITORY = "meta-pytorch/attention-gym"
+
+
+def workflow_run(
+    run_id: int,
+    conclusion: str,
+    started_at: str = "2026-08-17T10:00:00Z",
+    updated_at: str = "2026-08-17T10:02:00Z",
+) -> dict:
+    """Build a representative completed workflow run payload."""
+    return {
+        "id": run_id,
+        "name": "Run Tests",
+        "display_title": f"Run {run_id}",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": conclusion,
+        "created_at": started_at,
+        "run_started_at": started_at,
+        "updated_at": updated_at,
+        "head_branch": "feature",
+        "head_sha": "1234567890",
+        "html_url": f"https://example.com/runs/{run_id}",
+    }
+
+
+def job(job_id: int, name: str, conclusion: str, duration_minutes: int) -> dict:
+    """Build a representative completed job payload."""
+    return {
+        "id": job_id,
+        "name": name,
+        "status": "completed",
+        "conclusion": conclusion,
+        "started_at": "2026-08-17T10:00:00Z",
+        "completed_at": f"2026-08-17T10:{duration_minutes:02d}:00Z",
+        "html_url": f"https://example.com/jobs/{job_id}",
+        "steps": [{"name": "pytest", "conclusion": conclusion}],
+    }
+
+
+class TestMetricHelpers(unittest.TestCase):
+    def test_duration_and_percentile(self) -> None:
+        self.assertEqual(duration_seconds("2026-08-17T10:00:00Z", "2026-08-17T10:02:30Z"), 150)
+        self.assertEqual(percentile([1, 2, 3, 4, 5], 0.95), 4.8)
+        self.assertIsNone(percentile([], 0.95))
+
+    def test_extracts_unique_pytest_node_ids(self) -> None:
+        log = """
+FAILED test/test_masks.py::test_causal - AssertionError
+ERROR test/test_kda.py::test_backward - RuntimeError
+FAILED test/test_masks.py::test_causal - AssertionError
+"""
+        self.assertEqual(
+            extract_pytest_failures(log),
+            ["test/test_masks.py::test_causal", "test/test_kda.py::test_backward"],
+        )
+
+
+class TestAggregation(unittest.TestCase):
+    def test_summarizes_runs_without_counting_cancelled_runs(self) -> None:
+        runs = [
+            workflow_run(3, "success", updated_at="2026-08-17T10:01:00Z"),
+            workflow_run(2, "failure", updated_at="2026-08-17T10:03:00Z"),
+            workflow_run(1, "cancelled", updated_at="2026-08-17T10:09:00Z"),
+        ]
+
+        summary = summarize_runs(runs)
+
+        self.assertEqual(summary["total"], 2)
+        self.assertEqual(summary["successes"], 1)
+        self.assertEqual(summary["failures"], 1)
+        self.assertEqual(summary["ignored"], 1)
+        self.assertEqual(summary["success_rate"], 50)
+        self.assertEqual(summary["median_duration_seconds"], 120)
+
+    def test_summarizes_each_job_name(self) -> None:
+        runs = [workflow_run(2, "success"), workflow_run(1, "failure")]
+        jobs_by_run = {
+            2: [job(20, "pytest", "success", 2)],
+            1: [job(10, "pytest", "failure", 4)],
+        }
+
+        summaries = summarize_jobs("Run Tests", runs, jobs_by_run)
+
+        self.assertEqual(len(summaries), 1)
+        self.assertEqual(summaries[0]["success_rate"], 50)
+        self.assertEqual(summaries[0]["median_duration_seconds"], 180)
+        self.assertEqual(summaries[0]["p95_duration_seconds"], 234)
+
+    @patch("generate_ci_health.run_command_for_log", return_value="FAILED test/test_ci.py::test_x")
+    def test_builds_recent_failure_details(self, _log_mock) -> None:
+        workflow = {
+            "id": 7,
+            "name": "Run Tests",
+            "path": ".github/workflows/test.yml",
+            "state": "active",
+        }
+        failed_run = workflow_run(10, "failure")
+        failed_job = job(100, "pytest", "failure", 2)
+
+        dashboard = build_dashboard(
+            REPOSITORY,
+            [workflow],
+            {7: [failed_run]},
+            {10: [failed_job]},
+            NOW,
+        )
+
+        self.assertEqual(dashboard["overall"]["failures"], 1)
+        self.assertEqual(dashboard["failures"][0]["jobs"][0]["failed_steps"], ["pytest"])
+        self.assertEqual(dashboard["failures"][0]["jobs"][0]["tests"], ["test/test_ci.py::test_x"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,9 +3,12 @@ name: Deploy Docs
 on:
   push:
     branches: [main]
+  schedule:
+    - cron: "17 */6 * * *"
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
   pages: write
   id-token: write
@@ -31,6 +34,11 @@ jobs:
           python-version: "3.12"
 
       - run: pip install -e ".[docs]"
+
+      - name: Generate CI health data
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python .github/scripts/generate_ci_health.py
 
       - run: mkdocs build --strict
 

--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -19,5 +19,5 @@ jobs:
         persist-credentials: false
     - name: Run prek
       uses: j178/prek-action@5337cb91e0fa35a7ff31b9ca345126d8bbbcdf16 # v2.0.6
-    - name: Test branch cleanup policy
-      run: python3 .github/scripts/test_delete_old_pr_branches.py
+    - name: Test repository automation
+      run: python3 -m unittest discover -s .github/scripts -p 'test_*.py'

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,36 @@
+name: zizmor
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/**"
+  pull_request:
+    paths:
+      - ".github/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    name: Audit GitHub Actions
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          advanced-security: false
+          annotations: true
+          version: 1.29.0

--- a/docs/assets/ci-health.json
+++ b/docs/assets/ci-health.json
@@ -1,0 +1,19 @@
+{
+  "repository": "meta-pytorch/attention-gym",
+  "generated_at": null,
+  "runs_per_workflow": 0,
+  "overall": {
+    "total": 0,
+    "successes": 0,
+    "failures": 0,
+    "ignored": 0,
+    "success_rate": null,
+    "median_duration_seconds": null,
+    "p95_duration_seconds": null,
+    "latest": null,
+    "timeline": []
+  },
+  "workflows": [],
+  "jobs": [],
+  "failures": []
+}

--- a/docs/assets/javascripts/ci-health.js
+++ b/docs/assets/javascripts/ci-health.js
@@ -1,0 +1,397 @@
+(() => {
+  const root = document.getElementById("ci-health-dashboard");
+  if (!root) return;
+
+  const dateFormatter = new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  const healthLabels = {
+    success: "Healthy",
+    warning: "Degraded",
+    failure: "Failing",
+    unknown: "No data",
+  };
+
+  const escapeHtml = (value) =>
+    String(value ?? "")
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#039;");
+
+  const formatPercent = (value) => (value == null ? "—" : `${value.toFixed(1)}%`);
+
+  const formatDuration = (seconds) => {
+    if (seconds == null) return "—";
+    const totalSeconds = Math.round(seconds);
+    if (totalSeconds < 60) return `${totalSeconds}s`;
+    const minutes = Math.floor(totalSeconds / 60);
+    const remainder = totalSeconds % 60;
+    return remainder ? `${minutes}m ${remainder}s` : `${minutes}m`;
+  };
+
+  const formatDate = (value) => (value ? dateFormatter.format(new Date(value)) : "Unknown");
+
+  const healthKind = (summary) => {
+    if (!summary || summary.total === 0) return "unknown";
+    if (summary.latest?.kind === "failure" || summary.success_rate < 80) return "failure";
+    if (summary.success_rate < 95) return "warning";
+    return "success";
+  };
+
+  const conclusionKind = (conclusion) => {
+    if (conclusion === "success") return "success";
+    if (["failure", "startup_failure", "stale", "timed_out"].includes(conclusion)) {
+      return "failure";
+    }
+    return "ignored";
+  };
+
+  const summaryCards = (data) => {
+    const overall = data.overall;
+    const status = healthKind(overall);
+    return `
+      <div class="ci-dashboard-meta">
+        <span>${data.runs_per_workflow} recent runs sampled per workflow</span>
+        <span>Updated ${formatDate(data.generated_at)}</span>
+      </div>
+      <section class="ci-summary" aria-label="CI summary">
+        <article class="ci-stat ci-stat--${status}">
+          <span class="ci-stat__label">Overall status</span>
+          <strong>${healthLabels[status]}</strong>
+          <span>${overall.latest ? `Latest: ${escapeHtml(overall.latest.conclusion)}` : "No completed runs"}</span>
+        </article>
+        <article class="ci-stat">
+          <span class="ci-stat__label">Pass rate</span>
+          <strong>${formatPercent(overall.success_rate)}</strong>
+          <span>${overall.successes} passed · ${overall.failures} failed</span>
+        </article>
+        <article class="ci-stat">
+          <span class="ci-stat__label">Run duration</span>
+          <strong>${formatDuration(overall.median_duration_seconds)}</strong>
+          <span>p95 ${formatDuration(overall.p95_duration_seconds)}</span>
+        </article>
+      </section>`;
+  };
+
+  const trendWorkflows = (workflows) =>
+    workflows.filter(
+      (workflow) => workflow.timeline.filter((run) => run.kind !== "ignored").length >= 2
+    );
+
+  const trendView = (workflows) => {
+    const candidates = trendWorkflows(workflows);
+    if (!candidates.length) return '<div class="ci-empty">Not enough completed runs to chart.</div>';
+    const selected = Math.max(
+      candidates.findIndex((workflow) => workflow.failures > 0),
+      0
+    );
+    return `
+      <div class="ci-trend-toolbar">
+        <label>
+          <span>Workflow</span>
+          <select id="ci-trend-workflow">
+            ${candidates
+              .map(
+                (workflow, index) =>
+                  `<option value="${index}" ${index === selected ? "selected" : ""}>${escapeHtml(workflow.name)}</option>`
+              )
+              .join("")}
+          </select>
+        </label>
+        <div class="ci-metric-tabs" role="group" aria-label="Chart metric">
+          <button type="button" data-metric="pass" class="is-selected">Pass rate</button>
+          <button type="button" data-metric="failure">Failure rate</button>
+          <button type="button" data-metric="duration">Duration</button>
+        </div>
+      </div>
+      <article class="ci-chart-card ci-chart-card--large">
+        <div>
+          <div><h2 id="ci-chart-title">Rolling pass rate</h2><span id="ci-chart-note">Latest five counted runs</span></div>
+          <span><i class="ci-failure-point"></i> failed commit · click any point to open its run</span>
+        </div>
+        <div class="ci-chart"><canvas id="ci-trend-chart"></canvas></div>
+        <div id="ci-chart-failures" class="ci-chart-failures"></div>
+      </article>
+      <div id="ci-chart-fallback" class="ci-muted" hidden>Charts could not be loaded.</div>`;
+  };
+
+  const jobView = (jobs) => `
+    <div class="ci-panel-heading">
+      <div><h2>Job timing</h2><span>Median and p95 across the sampled runs</span></div>
+      <label class="ci-job-filter">Filter <input id="ci-job-filter" type="search" placeholder="pytest, docs, build…"></label>
+    </div>
+    <div class="ci-table-wrap">
+      <table class="ci-job-table">
+        <thead><tr><th>Workflow / job</th><th>Latest</th><th>Success</th><th>Median</th><th>p95</th><th>Samples</th></tr></thead>
+        <tbody id="ci-job-rows">
+          ${jobs
+            .slice()
+            .sort((a, b) => (b.p95_duration_seconds || 0) - (a.p95_duration_seconds || 0))
+            .map(
+              (job) => `
+                <tr data-filter="${escapeHtml(`${job.workflow} ${job.name}`.toLowerCase())}">
+                  <td><span>${escapeHtml(job.workflow)}</span><strong>${escapeHtml(job.name)}</strong></td>
+                  <td><a class="ci-result ci-status--${conclusionKind(job.latest_conclusion)}" href="${escapeHtml(job.latest_url)}">${escapeHtml(job.latest_conclusion || "unknown")}</a></td>
+                  <td>${formatPercent(job.success_rate)}</td>
+                  <td>${formatDuration(job.median_duration_seconds)}</td>
+                  <td>${formatDuration(job.p95_duration_seconds)}</td>
+                  <td>${job.total}</td>
+                </tr>`
+            )
+            .join("")}
+        </tbody>
+      </table>
+    </div>`;
+
+  const failureView = (items) => `
+    <div class="ci-panel-heading">
+      <div><h2>Failing commits</h2><span>Failed jobs, steps, and extracted pytest tests</span></div>
+      <span>${items.length ? `${items.length} most recent` : "No recent failures"}</span>
+    </div>
+    <div class="ci-failures">
+      ${
+        items.length
+          ? items
+              .map(
+                (failure, index) => `
+                  <details class="ci-failure" ${index === 0 ? "open" : ""}>
+                    <summary>
+                      <span class="ci-failure__icon">×</span>
+                      <span><strong>${escapeHtml(failure.workflow)}</strong><small>${escapeHtml(failure.title)} · ${escapeHtml(failure.branch || "unknown branch")} · ${formatDate(failure.created_at)}</small></span>
+                      <code>${escapeHtml(failure.sha)}</code>
+                    </summary>
+                    <div class="ci-failure__body">
+                      ${failure.jobs
+                        .map(
+                          (job) => `
+                            <article>
+                              <div class="ci-failure__job"><a href="${escapeHtml(job.url)}">${escapeHtml(job.name)} →</a><span>${formatDuration(job.duration_seconds)}</span></div>
+                              ${job.failed_steps.length ? `<p><b>Failed steps:</b> ${job.failed_steps.map(escapeHtml).join(", ")}</p>` : ""}
+                              ${
+                                job.tests.length
+                                  ? `<div class="ci-tests">${job.tests.map((test) => `<code>${escapeHtml(test)}</code>`).join("")}</div>`
+                                  : '<p class="ci-muted">No pytest node IDs were found in the retained job log.</p>'
+                              }
+                            </article>`
+                        )
+                        .join("")}
+                      <a class="ci-run-link" href="${escapeHtml(failure.url)}">Open complete workflow run →</a>
+                    </div>
+                  </details>`
+              )
+              .join("")
+          : '<div class="ci-empty">All sampled runs passed.</div>'
+      }
+    </div>`;
+
+  const dashboardViews = (data) => `
+    <div class="ci-view-tabs" role="tablist" aria-label="CI health views">
+      <button type="button" role="tab" aria-selected="true" data-view="trends">Trends</button>
+      <button type="button" role="tab" aria-selected="false" data-view="failures">Failures <span>${data.failures.length}</span></button>
+      <button type="button" role="tab" aria-selected="false" data-view="jobs">Jobs <span>${data.jobs.length}</span></button>
+    </div>
+    <section class="ci-view-panel" role="tabpanel" data-panel="trends">${trendView(data.workflows)}</section>
+    <section class="ci-view-panel" role="tabpanel" data-panel="failures" hidden>${failureView(data.failures)}</section>
+    <section class="ci-view-panel" role="tabpanel" data-panel="jobs" hidden>${jobView(data.jobs)}</section>`;
+
+  const setupViewTabs = () => {
+    const buttons = [...document.querySelectorAll("[data-view]")];
+    const panels = [...document.querySelectorAll("[data-panel]")];
+    buttons.forEach((button) => {
+      button.addEventListener("click", () => {
+        buttons.forEach((item) => item.setAttribute("aria-selected", item === button));
+        panels.forEach((panel) => {
+          panel.hidden = panel.dataset.panel !== button.dataset.view;
+        });
+      });
+    });
+  };
+
+  const setupTrendChart = (workflows) => {
+    const candidates = trendWorkflows(workflows);
+    if (!candidates.length) return;
+    if (!window.Chart) {
+      document.getElementById("ci-chart-fallback").hidden = false;
+      return;
+    }
+
+    const workflowSelect = document.getElementById("ci-trend-workflow");
+    const metricButtons = [...document.querySelectorAll("[data-metric]")];
+    let selectedWorkflow = Number(workflowSelect.value);
+    let metric = "pass";
+    let chart;
+
+    const draw = () => {
+      chart?.destroy();
+      const workflow = candidates[selectedWorkflow];
+      const runs = workflow.timeline
+        .filter((run) => run.kind !== "ignored")
+        .slice()
+        .reverse();
+      const rolling = (kind) =>
+        runs.map((_, index) => {
+          const window = runs.slice(Math.max(0, index - 4), index + 1);
+          return (window.filter((run) => run.kind === kind).length / window.length) * 100;
+        });
+      const metrics = {
+        pass: {
+          title: "Rolling pass rate",
+          note: "Latest five counted runs",
+          values: rolling("success"),
+          percent: true,
+          color: "--ci-success",
+        },
+        failure: {
+          title: "Rolling failure rate",
+          note: "Latest five counted runs",
+          values: rolling("failure"),
+          percent: true,
+          color: "--ci-failure",
+        },
+        duration: {
+          title: "Run duration",
+          note: "Lower is better",
+          values: runs.map((run) => run.duration_seconds),
+          percent: false,
+          color: "--ci-success",
+        },
+      };
+      const selectedMetric = metrics[metric];
+      const styles = getComputedStyle(root);
+      const colors = {
+        border: styles.getPropertyValue("--ci-border").trim(),
+        failure: styles.getPropertyValue("--ci-failure").trim(),
+        line: styles.getPropertyValue(selectedMetric.color).trim(),
+        success: styles.getPropertyValue("--ci-success").trim(),
+        text: getComputedStyle(document.documentElement)
+          .getPropertyValue("--md-default-fg-color--light")
+          .trim(),
+      };
+      document.getElementById("ci-chart-title").textContent = selectedMetric.title;
+      document.getElementById("ci-chart-note").textContent = selectedMetric.note;
+      document.getElementById("ci-chart-failures").innerHTML = runs
+        .filter((run) => run.kind === "failure")
+        .map(
+          (run) =>
+            `<a href="${escapeHtml(run.url)}"><i></i>${escapeHtml(run.sha)} · ${formatDate(run.created_at)}</a>`
+        )
+        .join("");
+
+      chart = new window.Chart(document.getElementById("ci-trend-chart"), {
+        type: "line",
+        data: {
+          labels: runs.map((run) => formatDate(run.created_at)),
+          datasets: [
+            {
+              data: selectedMetric.values,
+              borderColor: colors.line,
+              backgroundColor: `${colors.line}18`,
+              borderWidth: 2,
+              fill: true,
+              pointBackgroundColor: runs.map((run) =>
+                run.kind === "failure" ? colors.failure : colors.line
+              ),
+              pointBorderWidth: 0,
+              pointHoverRadius: 8,
+              pointRadius: runs.map((run) => (run.kind === "failure" ? 6 : 3)),
+              pointStyle: runs.map((run) => (run.kind === "failure" ? "rectRot" : "circle")),
+              tension: 0.25,
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          interaction: { intersect: false, mode: "nearest" },
+          onClick: (_event, elements) => {
+            if (elements.length) window.open(runs[elements[0].index].url, "_blank", "noopener");
+          },
+          onHover: (event, elements) => {
+            event.native.target.style.cursor = elements.length ? "pointer" : "default";
+          },
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                label: (context) =>
+                  selectedMetric.percent
+                    ? `${selectedMetric.title}: ${formatPercent(context.parsed.y)}`
+                    : `Duration: ${formatDuration(context.parsed.y)}`,
+                afterLabel: (context) => {
+                  const run = runs[context.dataIndex];
+                  return [`Result: ${run.conclusion}`, `Commit: ${run.sha}`, "Click to open run"];
+                },
+              },
+            },
+          },
+          scales: {
+            x: {
+              grid: { display: false },
+              ticks: { color: colors.text, maxRotation: 0, maxTicksLimit: 6 },
+            },
+            y: {
+              beginAtZero: true,
+              max: selectedMetric.percent ? 100 : undefined,
+              grid: { color: colors.border },
+              ticks: {
+                color: colors.text,
+                callback: (value) =>
+                  selectedMetric.percent ? `${value}%` : formatDuration(value),
+                stepSize: selectedMetric.percent ? 25 : undefined,
+              },
+            },
+          },
+        },
+      });
+    };
+
+    workflowSelect.addEventListener("change", () => {
+      selectedWorkflow = Number(workflowSelect.value);
+      draw();
+    });
+    metricButtons.forEach((button) => {
+      button.addEventListener("click", () => {
+        metric = button.dataset.metric;
+        metricButtons.forEach((item) => item.classList.toggle("is-selected", item === button));
+        draw();
+      });
+    });
+    new MutationObserver(draw).observe(document.documentElement, {
+      attributeFilter: ["data-md-color-scheme"],
+    });
+    draw();
+  };
+
+  const setupJobFilter = () => {
+    const input = document.getElementById("ci-job-filter");
+    input?.addEventListener("input", () => {
+      const query = input.value.trim().toLowerCase();
+      document.querySelectorAll("#ci-job-rows tr").forEach((row) => {
+        row.hidden = !row.dataset.filter.includes(query);
+      });
+    });
+  };
+
+  const render = (data) => {
+    if (!data.overall) throw new Error("CI health data is incomplete");
+    root.innerHTML = summaryCards(data) + dashboardViews(data);
+    setupViewTabs();
+    setupTrendChart(data.workflows);
+    setupJobFilter();
+  };
+
+  fetch(new URL("../../assets/ci-health.json", window.location.href))
+    .then((response) => {
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      return response.json();
+    })
+    .then(render)
+    .catch((error) => {
+      root.innerHTML = `<div class="ci-health-error"><strong>CI health data is temporarily unavailable.</strong><span>${escapeHtml(error.message)}</span></div>`;
+    });
+})();

--- a/docs/developers/ci-health.md
+++ b/docs/developers/ci-health.md
@@ -1,0 +1,20 @@
+# CI Health
+
+<div class="ci-health-intro">
+  <p>
+    A live view of recent GitHub Actions runs, job reliability, execution time, and
+    test failures. Cancelled, skipped, neutral, and approval-waiting runs are excluded
+    from success-rate calculations.
+  </p>
+</div>
+
+<div id="ci-health-dashboard" class="ci-health" aria-live="polite">
+  <div class="ci-health-loading">Loading recent CI activity…</div>
+</div>
+
+<script
+  src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js"
+  integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ"
+  crossorigin="anonymous"
+></script>
+<script src="../../assets/javascripts/ci-health.js"></script>

--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -1,0 +1,31 @@
+# Developers
+
+Resources for contributing to Attention Gym and monitoring project health.
+
+<div class="grid cards" markdown>
+
+-   :material-heart-pulse: **CI Health**
+
+    ---
+
+    Inspect workflow reliability, run-duration trends, failing commits, and job logs.
+
+    [Open CI Health](ci-health.md)
+
+-   :material-source-pull: **Contributing**
+
+    ---
+
+    Set up a development environment and prepare changes for review.
+
+    [Read the contribution guide](https://github.com/meta-pytorch/attention-gym/blob/main/CONTRIBUTING.md)
+
+</div>
+
+## Local checks
+
+```bash
+pytest
+ruff check && ruff format
+prek
+```

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -210,3 +210,697 @@
 [data-md-color-scheme="default"] .md-typeset img[alt="Attention Gym"] {
   border-color: #d0ccc4;
 }
+
+/* ── CI health dashboard ── */
+
+.ci-health {
+  --ci-surface: #151515;
+  --ci-surface-raised: #1a1a1a;
+  --ci-border: #292929;
+  --ci-muted: #929292;
+  --ci-success: #71a982;
+  --ci-warning: #d0a85c;
+  --ci-failure: #d36b62;
+  margin-top: 1.8rem;
+}
+
+[data-md-color-scheme="default"] .ci-health {
+  --ci-surface: #ede9e1;
+  --ci-surface-raised: #f8f5ef;
+  --ci-border: #d7d1c6;
+  --ci-muted: #657068;
+  --ci-success: #4f7f5e;
+  --ci-warning: #9a6a22;
+  --ci-failure: #aa413a;
+}
+
+.ci-health-intro {
+  max-width: 46rem;
+  color: var(--md-default-fg-color--light);
+}
+
+.ci-health-loading,
+.ci-health-error,
+.ci-empty {
+  display: grid;
+  gap: 0.35rem;
+  padding: 1.2rem;
+  border: 1px solid var(--ci-border);
+  background: var(--ci-surface);
+}
+
+.ci-health-error {
+  border-left: 3px solid var(--ci-failure);
+}
+
+.ci-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.7rem;
+}
+
+.ci-stat,
+.ci-workflow {
+  border: 1px solid var(--ci-border);
+  background: var(--ci-surface);
+}
+
+.ci-stat {
+  position: relative;
+  display: flex;
+  min-height: 8.5rem;
+  flex-direction: column;
+  justify-content: flex-end;
+  gap: 0.15rem;
+  padding: 1rem;
+  overflow: hidden;
+}
+
+.ci-stat::before {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: var(--ci-border);
+  content: "";
+}
+
+.ci-stat--success::before {
+  background: var(--ci-success);
+}
+
+.ci-stat--warning::before {
+  background: var(--ci-warning);
+}
+
+.ci-stat--failure::before {
+  background: var(--ci-failure);
+}
+
+.ci-stat strong {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: clamp(1.25rem, 2vw, 1.75rem);
+  line-height: 1.15;
+}
+
+.ci-stat .ci-stat__date {
+  font-size: 1rem;
+}
+
+.ci-stat > span:last-child,
+.ci-stat__label,
+.ci-eyebrow,
+.ci-section-heading > span,
+.ci-workflow__header span,
+.ci-workflow__latest {
+  color: var(--ci-muted);
+  font-size: 0.72rem;
+}
+
+.ci-stat__label,
+.ci-eyebrow {
+  font-family: "IBM Plex Mono", monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.ci-section-heading {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1rem;
+  margin: 3rem 0 1rem;
+}
+
+.md-typeset .ci-section-heading h2 {
+  margin: 0.15rem 0 0;
+  padding: 0;
+  border: 0;
+}
+
+.ci-legend {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  white-space: nowrap;
+}
+
+.ci-legend i {
+  width: 0.55rem;
+  height: 0.55rem;
+  margin-left: 0.4rem;
+  border-radius: 50%;
+}
+
+.ci-workflows {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.7rem;
+}
+
+.ci-workflow {
+  padding: 1rem;
+  border-top: 2px solid var(--ci-border);
+}
+
+.ci-workflow--success {
+  border-top-color: var(--ci-success);
+}
+
+.ci-workflow--warning {
+  border-top-color: var(--ci-warning);
+}
+
+.ci-workflow--failure {
+  border-top-color: var(--ci-failure);
+}
+
+.ci-workflow__header,
+.ci-failure__job {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.md-typeset .ci-workflow h3 {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.ci-workflow__header > strong {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 1.15rem;
+}
+
+.ci-timeline {
+  display: flex;
+  height: 1.5rem;
+  align-items: stretch;
+  gap: 3px;
+  margin: 1rem 0;
+}
+
+.ci-timeline__run {
+  min-width: 3px;
+  flex: 1;
+  border-radius: 1px;
+  background: var(--ci-muted);
+  opacity: 0.85;
+  transition: opacity 120ms ease, transform 120ms ease;
+}
+
+.ci-timeline__run:hover {
+  opacity: 1;
+  transform: scaleY(1.18);
+}
+
+.ci-status--success {
+  background-color: var(--ci-success);
+}
+
+.ci-status--failure {
+  background-color: var(--ci-failure);
+}
+
+.ci-status--ignored {
+  background-color: var(--ci-muted);
+}
+
+.ci-workflow__metrics {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  margin: 0 0 0.8rem;
+}
+
+.ci-workflow__metrics div {
+  padding-right: 0.35rem;
+  border-right: 1px solid var(--ci-border);
+}
+
+.ci-workflow__metrics div:last-child {
+  border: 0;
+}
+
+.ci-workflow__metrics dt {
+  color: var(--ci-muted);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.62rem;
+  text-transform: uppercase;
+}
+
+.ci-workflow__metrics dd {
+  margin: 0.15rem 0 0;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.76rem;
+}
+
+.ci-workflow__latest {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ci-trend-picker {
+  display: flex;
+  gap: 0.4rem;
+  margin-bottom: 0.7rem;
+  padding-bottom: 0.25rem;
+  overflow-x: auto;
+}
+
+.ci-trend-picker button {
+  flex: 0 0 auto;
+  padding: 0.35rem 0.65rem;
+  border: 1px solid var(--ci-border);
+  border-radius: 999px;
+  background: var(--ci-surface);
+  color: var(--ci-muted);
+  cursor: pointer;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.65rem;
+}
+
+.ci-trend-picker button:hover,
+.ci-trend-picker button.is-selected {
+  border-color: var(--ci-success);
+  color: var(--md-default-fg-color);
+}
+
+.ci-trend-picker button.is-selected {
+  background: color-mix(in srgb, var(--ci-success) 16%, var(--ci-surface));
+}
+
+.ci-chart-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.7rem;
+}
+
+.ci-chart-card {
+  padding: 1rem;
+  border: 1px solid var(--ci-border);
+  background: var(--ci-surface);
+}
+
+.ci-chart-card > div:first-child {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.6rem;
+}
+
+.md-typeset .ci-chart-card h3 {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.ci-chart-card span {
+  color: var(--ci-muted);
+  font-size: 0.65rem;
+}
+
+.ci-chart {
+  position: relative;
+  height: 15rem;
+}
+
+.ci-job-filter {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--ci-muted);
+  font-size: 0.72rem;
+}
+
+.ci-job-filter input {
+  width: min(15rem, 40vw);
+  padding: 0.45rem 0.6rem;
+  border: 1px solid var(--ci-border);
+  border-radius: 2px;
+  outline: 0;
+  background: var(--ci-surface);
+  color: var(--md-default-fg-color);
+  font: inherit;
+}
+
+.ci-job-filter input:focus {
+  border-color: var(--ci-success);
+}
+
+.ci-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--ci-border);
+}
+
+.md-typeset .ci-job-table {
+  width: 100%;
+  margin: 0;
+  border: 0;
+  background: var(--ci-surface);
+  font-size: 0.74rem;
+}
+
+.ci-job-table tbody tr:hover {
+  background: var(--ci-surface-raised);
+}
+
+.ci-job-table td:first-child span,
+.ci-job-table td:first-child strong {
+  display: block;
+}
+
+.ci-job-table td:first-child span {
+  color: var(--ci-muted);
+  font-size: 0.65rem;
+}
+
+.ci-result {
+  display: inline-block;
+  padding: 0.15rem 0.4rem;
+  border-radius: 999px;
+  color: #fff !important;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.63rem;
+}
+
+.ci-failures {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.ci-failure {
+  border: 1px solid var(--ci-border);
+  background: var(--ci-surface);
+}
+
+.md-typeset .ci-failure summary {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.8rem 1rem;
+  cursor: pointer;
+  list-style: none;
+}
+
+.ci-failure summary::-webkit-details-marker {
+  display: none;
+}
+
+.ci-failure summary small {
+  display: block;
+  margin-top: 0.1rem;
+  color: var(--ci-muted);
+  font-size: 0.68rem;
+}
+
+.ci-failure__icon {
+  display: grid;
+  width: 1.4rem;
+  height: 1.4rem;
+  place-items: center;
+  border: 1px solid var(--ci-failure);
+  border-radius: 50%;
+  color: var(--ci-failure);
+  font-family: "IBM Plex Mono", monospace;
+}
+
+.ci-failure__body {
+  display: grid;
+  gap: 0.75rem;
+  padding: 0 1rem 1rem 3.15rem;
+}
+
+.ci-failure__body article {
+  padding: 0.75rem;
+  border: 1px solid var(--ci-border);
+  background: var(--ci-surface-raised);
+}
+
+.ci-failure__body p {
+  margin: 0.5rem 0;
+  font-size: 0.73rem;
+}
+
+.ci-tests {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.md-typeset .ci-tests code {
+  border: 1px solid var(--ci-border);
+  background: var(--ci-surface);
+  font-size: 0.68rem;
+}
+
+.ci-muted {
+  color: var(--ci-muted);
+}
+
+.ci-run-link {
+  justify-self: start;
+  font-size: 0.72rem;
+}
+
+.ci-dashboard-meta,
+.ci-panel-heading,
+.ci-trend-toolbar,
+.ci-chart-card--large > div:first-child {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.ci-dashboard-meta {
+  margin-bottom: 0.6rem;
+  color: var(--ci-muted);
+  font-size: 0.68rem;
+}
+
+.ci-view-tabs {
+  display: flex;
+  gap: 0.25rem;
+  margin: 2.5rem 0 1rem;
+  border-bottom: 1px solid var(--ci-border);
+}
+
+.ci-view-tabs button {
+  position: relative;
+  padding: 0.65rem 0.9rem;
+  border: 0;
+  background: transparent;
+  color: var(--ci-muted);
+  cursor: pointer;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.72rem;
+}
+
+.ci-view-tabs button::after {
+  position: absolute;
+  right: 0;
+  bottom: -1px;
+  left: 0;
+  height: 2px;
+  background: transparent;
+  content: "";
+}
+
+.ci-view-tabs button:hover,
+.ci-view-tabs button[aria-selected="true"] {
+  color: var(--md-default-fg-color);
+}
+
+.ci-view-tabs button[aria-selected="true"]::after {
+  background: var(--ci-success);
+}
+
+.ci-view-tabs button span {
+  display: inline-grid;
+  min-width: 1.25rem;
+  height: 1.25rem;
+  margin-left: 0.25rem;
+  place-items: center;
+  border-radius: 999px;
+  background: var(--ci-surface-raised);
+  font-size: 0.6rem;
+}
+
+.ci-view-panel[hidden] {
+  display: none;
+}
+
+.ci-trend-toolbar {
+  align-items: end;
+  margin-bottom: 0.7rem;
+}
+
+.ci-trend-toolbar label,
+.ci-job-filter {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--ci-muted);
+  font-size: 0.68rem;
+}
+
+.ci-trend-toolbar select,
+.ci-job-filter input {
+  padding: 0.45rem 0.6rem;
+  border: 1px solid var(--ci-border);
+  border-radius: 2px;
+  outline: 0;
+  background: var(--ci-surface);
+  color: var(--md-default-fg-color);
+  font: inherit;
+}
+
+.ci-trend-toolbar select:focus,
+.ci-job-filter input:focus {
+  border-color: var(--ci-success);
+}
+
+.ci-metric-tabs {
+  display: flex;
+  gap: 0.25rem;
+  padding: 0.2rem;
+  border: 1px solid var(--ci-border);
+  background: var(--ci-surface);
+}
+
+.ci-metric-tabs button {
+  padding: 0.35rem 0.6rem;
+  border: 0;
+  background: transparent;
+  color: var(--ci-muted);
+  cursor: pointer;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.65rem;
+}
+
+.ci-metric-tabs button:hover,
+.ci-metric-tabs button.is-selected {
+  background: var(--ci-surface-raised);
+  color: var(--md-default-fg-color);
+}
+
+.ci-chart-card--large > div:first-child {
+  align-items: baseline;
+  margin-bottom: 0.8rem;
+}
+
+.ci-chart-card--large > div:first-child > span {
+  white-space: nowrap;
+}
+
+.ci-chart-card--large h2 {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 1rem;
+}
+
+.ci-chart-card--large .ci-chart {
+  height: 22rem;
+}
+
+.ci-failure-point,
+.ci-chart-failures i {
+  display: inline-block;
+  width: 0.5rem;
+  height: 0.5rem;
+  margin-right: 0.25rem;
+  background: var(--ci-failure);
+  transform: rotate(45deg);
+}
+
+.ci-chart-failures {
+  display: flex;
+  min-height: 1.5rem;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 0.6rem;
+}
+
+.ci-chart-failures a {
+  padding: 0.25rem 0.45rem;
+  border: 1px solid var(--ci-border);
+  color: var(--ci-muted);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.62rem;
+}
+
+.ci-chart-failures a:hover {
+  border-color: var(--ci-failure);
+  color: var(--md-default-fg-color);
+}
+
+.ci-panel-heading {
+  align-items: end;
+  margin-bottom: 0.8rem;
+}
+
+.ci-panel-heading h2 {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.ci-panel-heading span {
+  color: var(--ci-muted);
+  font-size: 0.68rem;
+}
+
+@media screen and (max-width: 52rem) {
+  .ci-summary,
+  .ci-workflows {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .ci-chart-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .ci-section-heading,
+  .ci-trend-toolbar,
+  .ci-panel-heading,
+  .ci-chart-card--large > div:first-child {
+    align-items: start;
+    flex-direction: column;
+  }
+
+  .ci-chart-card--large > div:first-child > span {
+    white-space: normal;
+  }
+}
+
+@media screen and (max-width: 35rem) {
+  .ci-summary,
+  .ci-workflows {
+    grid-template-columns: 1fr;
+  }
+
+  .ci-stat {
+    min-height: 7rem;
+  }
+
+  .ci-legend {
+    flex-wrap: wrap;
+    white-space: normal;
+  }
+
+  .ci-failure summary {
+    grid-template-columns: auto 1fr;
+  }
+
+  .ci-failure summary code {
+    display: none;
+  }
+
+  .ci-failure__body {
+    padding-left: 1rem;
+  }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,9 @@ nav:
   - Linear Attention: linear.md
   - Examples: examples.md
   - Utilities: utilities.md
+  - Developers:
+      - Overview: developers/index.md
+      - CI Health: developers/ci-health.md
 
 markdown_extensions:
   - pymdownx.highlight:


### PR DESCRIPTION
## Human Note

## Agent note

Adds a database-free CI health dashboard under **Developers → CI Health**. The docs workflow
refreshes recent GitHub Actions data every six hours and on main-branch pushes, including workflow
reliability, job timing, failed steps, and pytest node IDs extracted from failed logs.

The page uses focused Trends, Failures, and Jobs tabs. Pass rate, failure rate, and duration are
shown as selectable Chart.js views; failed commits are highlighted and link directly to their
GitHub Actions runs. This also adds a pinned zizmor workflow for Actions security checks.

## Test Plan

```bash
python3 -m unittest discover -s .github/scripts -p "test_*.py"
uvx ruff check .github/scripts/generate_ci_health.py .github/scripts/test_generate_ci_health.py
node --check docs/assets/javascripts/ci-health.js
uvx --from mkdocs-material --with "mkdocstrings[python]" --with numpy mkdocs build --strict
GH_TOKEN="$(gh auth token)" uvx zizmor .github
```
