### PR TITLE
Add worktree-env-setup skill for isolated per-worktree envs

### DIFF
--- a/.agents/skills/worktree-env-setup/SKILL.md
+++ b/.agents/skills/worktree-env-setup/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: worktree-env-setup
+description: Sets up an isolated per-worktree Python environment for attention-gym development using nightly PyTorch and the CI-mirroring uv flow. Use when creating a new git worktree or when a worktree lacks a local .venv.
+---
+
+# Worktree Environment Setup
+
+Each attention-gym worktree gets its own `.venv` so editable installs, concurrent
+agents, and test runs never cross-import another checkout. Never reuse a shared
+env's editable install across worktrees.
+
+## Setup
+
+From the worktree root (mirrors `.github/workflows/test.yml`):
+
+```bash
+uv venv --python 3.13
+uv pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu132
+uv pip install --prerelease allow -e '.[tests,linear,dev]'
+source .venv/bin/activate
+```
+
+Notes:
+
+- uv hard-links wheels from its cache, so after the first nightly download this
+  takes seconds and costs almost no extra disk per worktree.
+- `--prerelease allow` is required for the `flash-attn-4` beta in `[tests]`.
+- Do not use `uv sync`/`uv.lock`: nightly torch churns daily and CI uses the
+  imperative `uv pip` flow above, not a lockfile.
+- Drop `[linear]` if CuTeDSL/TVM-FFI kernels are not needed (CPU-only work).
+
+## Running commands
+
+Prefer the worktree's own interpreter — either activate `.venv` first, or use
+`uv run --no-sync pytest test` (matches CI exactly). Never invoke a Python from
+another worktree or a shared `~/.venvs/*` env for attn_gym imports.
+
+## Verifying isolation
+
+```bash
+python -c "import attn_gym; print(attn_gym.__file__)"
+```
+
+The printed path must be inside the current worktree. If it points at another
+checkout, the editable install is wrong — rerun the `-e '.[tests,linear,dev]'`
+install from this worktree root.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,8 @@ Line length: 99 chars. Python target: 3.10+. Formatter/linter: ruff.
 Repository-specific workflows live under `.agents/skills/`. Load the matching `SKILL.md`
 before changing the covered subsystem:
 
+- [`worktree-env-setup`](.agents/skills/worktree-env-setup/SKILL.md) —
+  isolated per-worktree `.venv` with nightly PyTorch via the CI-mirroring uv flow.
 - [`validating-pytorch-custom-ops`](.agents/skills/validating-pytorch-custom-ops/SKILL.md) —
   registration, fake implementations, autograd, `opcheck`, and `torch.compile` validation.
 - [`cutedsl-tunable-kernel-template`](.agents/skills/cutedsl-tunable-kernel-template/SKILL.md) —


### PR DESCRIPTION
## Human Note

## Agent note

Agents working in git worktrees were reusing a shared venv whose single editable install points at one
checkout, so imports could silently resolve to a different worktree. This adds a repo-local skill that
documents the isolated per-worktree setup: `uv venv` plus the same nightly-torch `uv pip` flow CI uses in
`.github/workflows/test.yml` (no `uv sync`/lockfile, since nightly torch churns daily and CI installs
imperatively). Includes an isolation check (`attn_gym.__file__` must resolve inside the worktree) and a
pointer from AGENTS.md so agents discover it.

## Test Plan

```bash
uv venv --python 3.13
uv pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu132
uv pip install --prerelease allow -e '.[tests,linear,dev]'
.venv/bin/python -c "import torch, attn_gym; print(torch.__version__); print(attn_gym.__file__)"
```
