### PR TITLE
Add persistent scheduling for ragged KDA kernels under CUDA Graph over-capture

### DIFF
--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_intra.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_intra.py
@@ -25,7 +25,10 @@ from attn_gym._backends.cute import compile_tvm_ffi, jit_cache, run_tunable
 from attn_gym._backends.cute.target import CompileTarget, detect_compile_target, get_compile_target
 from attn_gym._backends.cute.utils import requires_int64_abi
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata
-from attn_gym.linear.kda.fwd.cute.chunk_scheduler_cute import load_ragged_chunk_work
+from attn_gym.linear.kda.fwd.cute.chunk_scheduler_cute import (
+    load_ragged_chunk_count,
+    load_ragged_chunk_work,
+)
 
 BT = 64  # chunk_size
 SUBCHUNKS = 4
@@ -964,8 +967,7 @@ def _chunk_kda_bwd_intra_hmma_grid_kernel(
     # Ragged graph replays read the active count on-device; dense launches use
     # their shape-derived compile-time capacity.
     if cutlass.const_expr(ragged):
-        num_sequences = Int32(cute.size(mChunkOffsets)) - 1
-        active_chunks = Int32(mChunkOffsets[num_sequences])
+        active_chunks = load_ragged_chunk_count(mChunkOffsets)
     else:
         active_chunks = Int32(capacity)
     iters = (active_chunks - chunk_start + grid_chunks - 1) // grid_chunks

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_wy_dqkg_fused.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_wy_dqkg_fused.py
@@ -35,7 +35,10 @@ from attn_gym._backends.cute import compile_tvm_ffi, jit_cache, run_tunable
 from attn_gym._backends.cute.target import CompileTarget, detect_compile_target, get_compile_target
 from attn_gym._backends.cute.utils import requires_int64_abi
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata
-from attn_gym.linear.kda.fwd.cute.chunk_scheduler_cute import load_ragged_chunk_work
+from attn_gym.linear.kda.fwd.cute.chunk_scheduler_cute import (
+    load_ragged_chunk_count,
+    load_ragged_chunk_work,
+)
 
 # ============================================================================
 # Inlined SM100 tcgen05 helper wrappers
@@ -2692,8 +2695,7 @@ class ChunkKdaBwdWyDqkgFused:
         lane_idx = thread_idx % 32
 
         if cutlass.const_expr(chunk_offsets is not None):
-            num_sequences = Int32(cute.size(chunk_offsets)) - 1
-            active_chunks = Int32(chunk_offsets[num_sequences])
+            active_chunks = load_ragged_chunk_count(chunk_offsets)
         else:
             active_chunks = capacity
         total_work_units = active_chunks * HV

--- a/attn_gym/linear/kda/bwd/triton/chunk_kda_bwd_dav.py
+++ b/attn_gym/linear/kda/bwd/triton/chunk_kda_bwd_dav.py
@@ -23,7 +23,16 @@ from attn_gym._backends.triton.utils import (
     ptr_offset,
     requires_int64_offsets,
 )
-from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata, load_ragged_chunk_work
+from attn_gym.linear.kda.chunk_scheduler import (
+    GridScheduler,
+    RaggedChunkMetadata,
+    ScheduleKind,
+    ScheduleRequest,
+    decode_ragged_task,
+    load_ragged_chunk_count,
+    load_ragged_chunk_work,
+    load_ragged_task_count,
+)
 from attn_gym.linear.kda.utils import autotune_cache_kwargs
 
 
@@ -131,7 +140,7 @@ def chunk_kda_bwd_kernel_dAv(
         i_b, i_h = i_bh // H, i_bh % H
 
         if IS_VARLEN:
-            if i_t >= tl.load(chunk_offsets + num_sequences):
+            if i_t >= load_ragged_chunk_count(chunk_offsets, num_sequences):
                 return
             i_n, i_t, token_start, _ = load_ragged_chunk_work(
                 cu_seqlens,
@@ -213,8 +222,8 @@ def _can_use_tensor_descriptors(*tensors: torch.Tensor) -> bool:
     return all(can_use_tma(tensor) for tensor in tensors)
 
 
-@triton.jit(do_not_specialize=["num_sequences"])
-def chunk_kda_bwd_kernel_dAv_ragged_tma(
+@triton.jit
+def _compose_dav_ragged_task(
     v_desc,
     A_desc,
     do_desc,
@@ -228,16 +237,18 @@ def chunk_kda_bwd_kernel_dAv_ragged_tma(
     cu_seqlens,
     chunk_offsets,
     scale,
+    global_chunk,
+    i_h,
     H: tl.constexpr,
     V: tl.constexpr,
     BT: tl.constexpr,
     BV: tl.constexpr,
     num_sequences,
 ):
-    """Differentiate full ragged value chunks with TMA and partial tails with masked pointers."""
-    global_chunk, i_h = tl.program_id(0), tl.program_id(1)
-    if global_chunk >= tl.load(chunk_offsets + num_sequences):
-        return
+    """Differentiate one active (chunk, head) ragged value tile.
+
+    Full chunks go through TMA; partial tails use masked pointers.
+    """
     _, _, token_start, valid_tokens = load_ragged_chunk_work(
         cu_seqlens,
         chunk_offsets,
@@ -292,6 +303,108 @@ def chunk_kda_bwd_kernel_dAv_ragged_tma(
         )
 
 
+@triton.jit(do_not_specialize=["num_sequences"])
+def chunk_kda_bwd_kernel_dAv_ragged_tma(
+    v_desc,
+    A_desc,
+    do_desc,
+    dv_desc,
+    dA_desc,
+    v,
+    A,
+    do,
+    dv,
+    dA,
+    cu_seqlens,
+    chunk_offsets,
+    scale,
+    H: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BV: tl.constexpr,
+    num_sequences,
+):
+    """Launch one CTA per capacity task; capacity-only CTAs exit immediately."""
+    global_chunk, i_h = tl.program_id(0), tl.program_id(1)
+    if global_chunk >= load_ragged_chunk_count(chunk_offsets, num_sequences):
+        return
+    _compose_dav_ragged_task(
+        v_desc,
+        A_desc,
+        do_desc,
+        dv_desc,
+        dA_desc,
+        v,
+        A,
+        do,
+        dv,
+        dA,
+        cu_seqlens,
+        chunk_offsets,
+        scale,
+        global_chunk,
+        i_h,
+        H,
+        V,
+        BT,
+        BV,
+        num_sequences,
+    )
+
+
+@triton.jit(do_not_specialize=["num_sequences", "num_workers"])
+def chunk_kda_bwd_kernel_dAv_ragged_tma_persistent(
+    v_desc,
+    A_desc,
+    do_desc,
+    dv_desc,
+    dA_desc,
+    v,
+    A,
+    do,
+    dv,
+    dA,
+    cu_seqlens,
+    chunk_offsets,
+    scale,
+    H: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BV: tl.constexpr,
+    num_sequences,
+    num_workers,
+):
+    """Stride a bounded worker grid over active (chunk, head) tasks."""
+    worker = tl.program_id(0)
+    total_tasks = load_ragged_task_count(chunk_offsets, num_sequences, H)
+    # num_stages=1 stops the software pipeliner from double-buffering the
+    # outer task loop; the extra SMEM stage costs a resident CTA per SM.
+    for task in tl.range(worker, total_tasks, num_workers, num_stages=1):
+        global_chunk, head = decode_ragged_task(task, H)
+        _compose_dav_ragged_task(
+            v_desc,
+            A_desc,
+            do_desc,
+            dv_desc,
+            dA_desc,
+            v,
+            A,
+            do,
+            dv,
+            dA,
+            cu_seqlens,
+            chunk_offsets,
+            scale,
+            global_chunk.to(tl.int32),
+            head.to(tl.int32),
+            H,
+            V,
+            BT,
+            BV,
+            num_sequences,
+        )
+
+
 def _launch_dav_ragged(
     v: torch.Tensor,
     A: torch.Tensor,
@@ -300,6 +413,7 @@ def _launch_dav_ragged(
     chunk_size: int,
     metadata: RaggedChunkMetadata,
     autotune: bool,
+    schedule: ScheduleRequest,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Launch the packed dAv kernel with TMA descriptors when the layout allows."""
     _, tokens, heads, value_dim = v.shape
@@ -307,10 +421,20 @@ def _launch_dav_ragged(
     dA = torch.empty_like(A, dtype=torch.float32)
     if metadata.capacity == 0:
         return dv, dA
+    ragged_tma = (value_dim, chunk_size) == (128, 64) and _can_use_tensor_descriptors(
+        v, A, do, dv, dA
+    )
+    resolved = GridScheduler(metadata).resolve_flat(
+        schedule,
+        heads,
+        v.device,
+        eligible=ragged_tma,
+        requirement="the packed TMA path: V=128, chunk_size=64, and TMA-capable tensors",
+    )
 
     block_value_dim = 64
-    if (value_dim, chunk_size) == (128, 64) and _can_use_tensor_descriptors(v, A, do, dv, dA):
-        chunk_kda_bwd_kernel_dAv_ragged_tma[(metadata.capacity, heads)](
+    if ragged_tma:
+        args = (
             TensorDescriptor.from_tensor(v, [1, chunk_size, 1, block_value_dim]),
             TensorDescriptor.from_tensor(A, [1, chunk_size, 1, chunk_size]),
             TensorDescriptor.from_tensor(do, [1, chunk_size, 1, block_value_dim]),
@@ -324,14 +448,22 @@ def _launch_dav_ragged(
             metadata.cu_seqlens,
             metadata.chunk_offsets,
             scale,
-            H=heads,
-            V=value_dim,
-            BT=chunk_size,
-            BV=block_value_dim,
-            num_sequences=metadata.cu_seqlens.shape[0] - 1,
-            num_warps=2,
-            num_stages=3,
         )
+        kwargs = {
+            "H": heads,
+            "V": value_dim,
+            "BT": chunk_size,
+            "BV": block_value_dim,
+            "num_sequences": metadata.cu_seqlens.shape[0] - 1,
+            "num_warps": 2,
+            "num_stages": 3,
+        }
+        if resolved.kind is ScheduleKind.PERSISTENT:
+            chunk_kda_bwd_kernel_dAv_ragged_tma_persistent[(resolved.workers,)](
+                *args, num_workers=resolved.workers, **kwargs
+            )
+        else:
+            chunk_kda_bwd_kernel_dAv_ragged_tma[(metadata.capacity, heads)](*args, **kwargs)
     else:
         kernel = chunk_kda_bwd_kernel_dAv if autotune else _PINNED_DAV
         kernel[(metadata.capacity, heads)](
@@ -365,12 +497,21 @@ def chunk_kda_bwd_dav(
     chunk_size: int = 64,
     metadata: RaggedChunkMetadata | None = None,
     autotune: bool = True,
+    schedule: ScheduleRequest = ScheduleRequest.AUTO,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Differentiate the fixed-length or packed KDA intra-chunk value term.
 
     This is an eager stage: the ragged launcher mixes TMA descriptors with aliased raw
     pointers, so call it standalone only outside ``torch.compile`` regions. The composed
     ``chunk_kda`` custom op is the supported compiler boundary.
+
+    Args:
+        schedule: Internal scheduling request for tests. Automatic selection is
+            the default and dense inputs keep their exact launch grid.
+
+    Raises:
+        ValueError: If persistent scheduling is forced for a packed input outside
+            the TMA path, where no persistent kernel exists to honor it.
     """
     batch, tokens, heads, value_dim = v.shape
     if A.shape != (batch, tokens, heads, chunk_size):
@@ -381,7 +522,7 @@ def chunk_kda_bwd_dav(
         metadata.validate_chunk_size(chunk_size)
         if batch != 1:
             raise ValueError("ragged KDA dAv metadata requires batch size 1")
-        return _launch_dav_ragged(v, A, do, scale, chunk_size, metadata, autotune)
+        return _launch_dav_ragged(v, A, do, scale, chunk_size, metadata, autotune, schedule)
     if tokens % chunk_size:
         raise ValueError(f"the KDA dAv kernel requires complete chunks, got T={tokens}")
 

--- a/attn_gym/linear/kda/bwd/triton/gate_bwd.py
+++ b/attn_gym/linear/kda/bwd/triton/gate_bwd.py
@@ -19,7 +19,16 @@ import triton
 import triton.language as tl
 
 from attn_gym._backends.triton.utils import ptr_offset, requires_int64_offsets
-from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata, load_ragged_chunk_work
+from attn_gym.linear.kda.chunk_scheduler import (
+    GridScheduler,
+    RaggedChunkMetadata,
+    ScheduleKind,
+    ScheduleRequest,
+    decode_ragged_task,
+    load_ragged_chunk_count,
+    load_ragged_chunk_work,
+    load_ragged_task_count,
+)
 from attn_gym.linear.kda.utils import input_guard
 
 _HEURISTICS = {
@@ -37,9 +46,8 @@ _HEURISTICS = {
 }
 
 
-@triton.heuristics(_HEURISTICS)
-@triton.jit(do_not_specialize=["num_sequences"])
-def kda_gate_bwd_ragged_kernel(
+@triton.jit
+def _kda_gate_bwd_ragged_task(
     raw_gate,
     A_log,
     dt_bias,
@@ -52,6 +60,9 @@ def kda_gate_bwd_ragged_kernel(
     cu_seqlens,
     chunk_offsets,
     num_sequences,
+    global_chunk,
+    i_h,
+    i_d,
     G_STRIDES: tl.constexpr,
     A_LOG_STRIDES: tl.constexpr,
     DT_BIAS_STRIDES: tl.constexpr,
@@ -69,17 +80,11 @@ def kda_gate_bwd_ragged_kernel(
     The scan, pointwise derivative, and parameter-gradient partials share one launch,
     without a full FP32 intermediate.
     """
-    global_chunk = tl.program_id(0)
-    i_h = tl.program_id(1)
-    i_d = tl.program_id(2)
-    if global_chunk >= tl.load(chunk_offsets + num_sequences):
-        return
     if USE_INT64_OFFSETS:
         global_chunk = global_chunk.to(tl.int64)
         i_h = i_h.to(tl.int64)
         i_d = i_d.to(tl.int64)
-
-    _sequence, _local_chunk, token_start, valid_tokens = load_ragged_chunk_work(
+    _, _, token_start, valid_tokens = load_ragged_chunk_work(
         cu_seqlens,
         chunk_offsets,
         global_chunk,
@@ -87,7 +92,6 @@ def kda_gate_bwd_ragged_kernel(
         BT,
     )
     if USE_INT64_OFFSETS:
-        global_chunk = global_chunk.to(tl.int64)
         token_start = token_start.to(tl.int64)
     token_offset = tl.arange(0, BT)
     token = token_start + token_offset
@@ -132,6 +136,139 @@ def kda_gate_bwd_ragged_kernel(
     )
 
 
+@triton.heuristics(_HEURISTICS)
+@triton.jit(do_not_specialize=["num_sequences"])
+def kda_gate_bwd_ragged_kernel(
+    raw_gate,
+    A_log,
+    dt_bias,
+    d_cumulative,
+    dg,
+    dA_partial,
+    ddt_partial,
+    lower_bound,
+    scale,
+    cu_seqlens,
+    chunk_offsets,
+    num_sequences,
+    G_STRIDES: tl.constexpr,
+    A_LOG_STRIDES: tl.constexpr,
+    DT_BIAS_STRIDES: tl.constexpr,
+    DY_STRIDES: tl.constexpr,
+    DG_STRIDES: tl.constexpr,
+    DA_STRIDES: tl.constexpr,
+    DDT_STRIDES: tl.constexpr,
+    D: tl.constexpr,
+    BT: tl.constexpr,
+    BD: tl.constexpr,
+    USE_INT64_OFFSETS: tl.constexpr,
+):
+    """Launch one CTA per capacity task; capacity-only CTAs exit immediately."""
+    global_chunk = tl.program_id(0)
+    if global_chunk >= load_ragged_chunk_count(chunk_offsets, num_sequences):
+        return
+    _kda_gate_bwd_ragged_task(
+        raw_gate,
+        A_log,
+        dt_bias,
+        d_cumulative,
+        dg,
+        dA_partial,
+        ddt_partial,
+        lower_bound,
+        scale,
+        cu_seqlens,
+        chunk_offsets,
+        num_sequences,
+        global_chunk,
+        tl.program_id(1),
+        tl.program_id(2),
+        G_STRIDES,
+        A_LOG_STRIDES,
+        DT_BIAS_STRIDES,
+        DY_STRIDES,
+        DG_STRIDES,
+        DA_STRIDES,
+        DDT_STRIDES,
+        D,
+        BT,
+        BD,
+        USE_INT64_OFFSETS,
+    )
+
+
+@triton.heuristics(_HEURISTICS)
+@triton.jit(do_not_specialize=["num_sequences", "num_workers"])
+def kda_gate_bwd_ragged_kernel_persistent(
+    raw_gate,
+    A_log,
+    dt_bias,
+    d_cumulative,
+    dg,
+    dA_partial,
+    ddt_partial,
+    lower_bound,
+    scale,
+    cu_seqlens,
+    chunk_offsets,
+    num_sequences,
+    num_workers,
+    G_STRIDES: tl.constexpr,
+    A_LOG_STRIDES: tl.constexpr,
+    DT_BIAS_STRIDES: tl.constexpr,
+    DY_STRIDES: tl.constexpr,
+    DG_STRIDES: tl.constexpr,
+    DA_STRIDES: tl.constexpr,
+    DDT_STRIDES: tl.constexpr,
+    D: tl.constexpr,
+    BT: tl.constexpr,
+    BD: tl.constexpr,
+    H: tl.constexpr,
+    DIM_BLOCKS: tl.constexpr,
+    USE_INT64_OFFSETS: tl.constexpr,
+):
+    """Stride a bounded worker grid over active (chunk, head, dim-block) tasks.
+
+    Unvisited slots in the capacity-sized partial buffers remain zero for the
+    final reductions.
+    """
+    worker = tl.program_id(0)
+    subtasks: tl.constexpr = H * DIM_BLOCKS
+    total_tasks = load_ragged_task_count(chunk_offsets, num_sequences, subtasks)
+    # num_stages=1 stops the software pipeliner from double-buffering the
+    # outer task loop; the extra SMEM stage costs a resident CTA per SM.
+    for task in tl.range(worker, total_tasks, num_workers, num_stages=1):
+        global_chunk, subtask = decode_ragged_task(task, subtasks)
+        _kda_gate_bwd_ragged_task(
+            raw_gate,
+            A_log,
+            dt_bias,
+            d_cumulative,
+            dg,
+            dA_partial,
+            ddt_partial,
+            lower_bound,
+            scale,
+            cu_seqlens,
+            chunk_offsets,
+            num_sequences,
+            global_chunk,
+            subtask // DIM_BLOCKS,
+            subtask % DIM_BLOCKS,
+            G_STRIDES,
+            A_LOG_STRIDES,
+            DT_BIAS_STRIDES,
+            DY_STRIDES,
+            DG_STRIDES,
+            DA_STRIDES,
+            DDT_STRIDES,
+            D,
+            BT,
+            BD,
+            USE_INT64_OFFSETS,
+        )
+
+
 @input_guard(no_guard_contiguous=True)
 def kda_gate_bwd_ragged(
     raw_gate: torch.Tensor,
@@ -142,11 +279,16 @@ def kda_gate_bwd_ragged(
     *,
     lower_bound: float,
     scale: float,
+    schedule: ScheduleRequest = ScheduleRequest.AUTO,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Differentiate the packed bounded-gate prefix sum with one fused launch.
 
     Returns ``dg`` in ``raw_gate.dtype`` plus the reduced FP32 ``dA_log`` and
     ``d_dt_bias`` parameter gradients.
+
+    Args:
+        schedule: Internal scheduling request for tests; automatic selection is
+            the default.
     """
     if raw_gate.ndim != 4 or raw_gate.shape[0] != 1:
         raise ValueError(f"raw_gate must have shape [1, T, H, D], got {tuple(raw_gate.shape)}")
@@ -162,10 +304,12 @@ def kda_gate_bwd_ragged(
     block_dim = min(128, triton.next_power_of_2(head_dim))
     dim_blocks = triton.cdiv(head_dim, block_dim)
     dg = torch.empty_like(raw_gate)
-    # Zero-filled so chunk slots beyond the active count contribute empty partials.
+    # Zero-filled because unvisited capacity slots participate in the final reductions.
     dA_partial = A_log.new_zeros((metadata.capacity, heads, dim_blocks))
     ddt_partial = A_log.new_zeros((metadata.capacity, heads, head_dim))
-    kda_gate_bwd_ragged_kernel[(metadata.capacity, heads, dim_blocks)](
+    if metadata.capacity == 0:
+        return dg, dA_partial.sum((0, 2)), ddt_partial.sum(0)
+    args = (
         raw_gate,
         A_log,
         dt_bias,
@@ -178,17 +322,30 @@ def kda_gate_bwd_ragged(
         metadata.cu_seqlens,
         metadata.chunk_offsets,
         metadata.cu_seqlens.shape[0] - 1,
-        G_STRIDES=raw_gate.stride()[1:],
-        A_LOG_STRIDES=A_log.stride(),
-        DT_BIAS_STRIDES=dt_bias.stride(),
-        DY_STRIDES=d_cumulative.stride()[1:],
-        DG_STRIDES=dg.stride()[1:],
-        DA_STRIDES=dA_partial.stride(),
-        DDT_STRIDES=ddt_partial.stride(),
-        D=head_dim,
-        BT=metadata.chunk_size,
-        BD=block_dim,
-        num_warps=4,
-        num_stages=2,
     )
+    kwargs = {
+        "G_STRIDES": raw_gate.stride()[1:],
+        "A_LOG_STRIDES": A_log.stride(),
+        "DT_BIAS_STRIDES": dt_bias.stride(),
+        "DY_STRIDES": d_cumulative.stride()[1:],
+        "DG_STRIDES": dg.stride()[1:],
+        "DA_STRIDES": dA_partial.stride(),
+        "DDT_STRIDES": ddt_partial.stride(),
+        "D": head_dim,
+        "BT": metadata.chunk_size,
+        "BD": block_dim,
+        "num_warps": 4,
+        "num_stages": 2,
+    }
+    resolved = GridScheduler(metadata).resolve_flat(schedule, heads * dim_blocks, raw_gate.device)
+    if resolved.kind is ScheduleKind.PERSISTENT:
+        kda_gate_bwd_ragged_kernel_persistent[(resolved.workers,)](
+            *args,
+            num_workers=resolved.workers,
+            H=heads,
+            DIM_BLOCKS=dim_blocks,
+            **kwargs,
+        )
+    else:
+        kda_gate_bwd_ragged_kernel[(metadata.capacity, heads, dim_blocks)](*args, **kwargs)
     return dg, dA_partial.sum((0, 2)), ddt_partial.sum(0)

--- a/attn_gym/linear/kda/chunk_schedule.py
+++ b/attn_gym/linear/kda/chunk_schedule.py
@@ -2,11 +2,48 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from enum import Enum
 from typing import NamedTuple
 
 import torch
 
 from attn_gym.linear.kda.ops import prepare_chunk_offsets_op
+
+
+class ScheduleRequest(Enum):
+    """Internal scheduling policy before eligibility and geometry are known."""
+
+    AUTO = "auto"
+    STATIC = "static"
+    PERSISTENT = "persistent"
+
+
+class ScheduleKind(Enum):
+    """Concrete internal work-distribution strategy for one launch."""
+
+    STATIC = "static"
+    PERSISTENT = "persistent"
+
+
+def validate_schedule_request(request: ScheduleRequest) -> None:
+    """Reject legacy booleans and other non-enum internal schedule requests."""
+    if not isinstance(request, ScheduleRequest):
+        raise TypeError(f"request must be a ScheduleRequest, got {request!r}")
+
+
+@dataclass(frozen=True)
+class ResolvedSchedule:
+    """Resolved execution kind and the geometry used to select it.
+
+    ``workers`` is the bounded persistent-grid candidate; STATIC kernels use
+    their natural capacity grid. ``capacity_tasks`` is the total number of
+    possible ``(chunk, subtask)`` slots used by the automatic policy.
+    """
+
+    kind: ScheduleKind
+    workers: int
+    capacity_tasks: int
 
 
 class RaggedChunkMetadata(NamedTuple):

--- a/attn_gym/linear/kda/chunk_scheduler.py
+++ b/attn_gym/linear/kda/chunk_scheduler.py
@@ -1,8 +1,91 @@
-"""Graph-safe logical chunk scheduling for packed variable-length KDA inputs."""
+"""Graph-safe chunk scheduling for packed variable-length KDA inputs.
+
+Coordinate system
+-----------------
+
+- **Sequence**: packed token range ``[cu_seqlens[i], cu_seqlens[i + 1])``.
+- **Local chunk**: chunk number within one sequence. Local chunk 0 begins at the
+  sequence start, not at a multiple of ``chunk_size`` in the packed buffer.
+- **Global chunk**: a dense index over all active local chunks from every
+  sequence. Kernels use this as their common chunk coordinate.
+- **Chunk capacity**: the fixed CUDA Graph upper bound on global chunks. Global
+  chunk slots beyond the runtime active count contain no work on that replay.
+
+Scheduling views
+----------------
+
+``GridScheduler`` supports two launch geometries; ``subtask`` is terminology for
+only the flattened one:
+
+1. **Flat-task scheduling** (Triton): a kernel supplies only its number of
+   kernel-specific work coordinates per chunk. The scheduler sees that count,
+   not whether the coordinate means a head, channel tile, or
+   ``(head, output-tile)`` pair. The kernel flattens and later decodes::
+
+       task = global_chunk * subtasks_per_chunk + subtask
+       global_chunk, subtask = divmod(task, subtasks_per_chunk)
+
+   A persistent worker CTA processes tasks
+   ``w, w + num_workers, w + 2 * num_workers, ...``. Here a subtask is CTA-level
+   parallel work, not an inner loop.
+
+2. **Chunk-axis scheduling** (CuTeDSL): the scheduler controls only the chunk
+   grid axis. Pair, head, and tile coordinates remain explicit grid axes, and
+   each CTA strides over chunks for one fixed combination of those coordinates.
+   This path neither passes nor decodes a ``subtasks_per_chunk`` value.
+
+The value three in the worked example below is therefore illustrative only for
+flat-task scheduling; it is not derived from ``cu_seqlens`` and does not describe
+the CuTeDSL grid.
+
+Shared routing metadata
+-----------------------
+
+``chunk_offsets`` has the same fixed ``[N + 1]`` shape as ``cu_seqlens``. During
+CUDA Graph capture its storage and shape become fixed, but one device operation
+rebuilds its values from the current ``cu_seqlens`` on every replay::
+
+    chunk_count[i] = ceil_div(cu_seqlens[i + 1] - cu_seqlens[i], chunk_size)
+    chunk_offsets = exclusive_prefix_sum(chunk_count)
+
+``KDAAttention`` prepares this prefix once, passes the same
+``RaggedChunkMetadata`` to the gate and core forward stages, and saves the same
+``cu_seqlens``/``chunk_offsets`` storage for backward. Each consumer still
+binary-searches ``chunk_offsets`` to map a global chunk to its sequence and local
+chunk, but it does not recompute every sequence's chunk count and prefix. This
+avoids duplicate metadata launches and guarantees one global-chunk coordinate
+system across stages. The motivating packed-step A/B moved from 4.650 to
+4.467 ms; that end-to-end result supports the ownership choice but does not
+isolate metadata preparation alone. The training-example tests explicitly
+enforce one preparation with shared consumers.
+
+Worked example
+--------------
+
+For ``cu_seqlens=[0, 5, 5, 12]`` and ``chunk_size=4``:
+
+- sequence 0 has length 5 and therefore 2 chunks;
+- sequence 1 is empty and therefore has 0 chunks;
+- sequence 2 has length 7 and therefore 2 chunks.
+
+The counts are ``[2, 0, 2]``. Their exclusive prefix sum is
+``chunk_offsets=[0, 2, 2, 4]``: sequence 0 owns global chunks ``[0, 2)``, sequence
+1 owns none, and sequence 2 owns ``[2, 4)``. Global chunk 2 is therefore local
+chunk 0 of sequence 2 and begins at packed token 5. If a flat-scheduled example
+kernel has three subtasks per chunk, task 7 maps to
+``(global_chunk, subtask) = divmod(7, 3) = (2, 1)``.
+
+Flat STATIC scheduling launches every capacity task. Chunk-axis STATIC
+scheduling launches the full chunk-capacity axis while retaining the other grid
+axes. Inactive CTAs return after reading the active count. PERSISTENT scheduling
+bounds the worker or chunk axis and strides only over runtime active work.
+"""
 
 from __future__ import annotations
 
+import functools
 import itertools
+from dataclasses import dataclass
 from typing import NamedTuple
 
 import torch
@@ -13,9 +96,125 @@ import triton.language as tl
 # launch through the registered scheduler op instead of tracing it directly.
 from attn_gym.linear.kda.chunk_schedule import (
     RaggedChunkMetadata,
+    ResolvedSchedule,
+    ScheduleKind,
+    ScheduleRequest,
     chunk_capacity,
     prepare_ragged_chunk_metadata,
+    validate_schedule_request,
 )
+
+# Default persistent worker cap; individual kernels can override it where measured.
+PERSISTENT_CTAS_PER_SM = 4
+
+# Auto policy: static launches pay only launch time for padding CTAs, so a
+# few waves of them are cheaper than the persistent stride loop's overhead.
+# Switch only after the capacity grid exceeds this many bounded-worker waves:
+# with 100 persistent workers, capacities through 400 tasks use the static grid.
+PERSISTENT_AUTO_WAVES = 4
+
+
+@functools.cache
+def _multiprocessor_count_for_index(device_index: int) -> int:
+    """Cache the SM count for one concrete CUDA device."""
+    return torch.cuda.get_device_properties(device_index).multi_processor_count
+
+
+def _multiprocessor_count(device: torch.device) -> int:
+    """Resolve unindexed CUDA devices before consulting the SM-count cache."""
+    device_index = torch.cuda.current_device() if device.index is None else device.index
+    return _multiprocessor_count_for_index(device_index)
+
+
+@dataclass(frozen=True)
+class GridScheduler:
+    """Map ragged chunk work onto launch grids for Triton and CuTeDSL kernels.
+
+    The runtime number of chunks depends on sequence lengths, but CUDA Graph
+    capture fixes the launch shape at ``metadata.capacity``. Static kernels
+    launch one CTA per capacity task; inactive CTAs read the active count and
+    return. Persistent kernels launch a bounded machine-derived worker grid and
+    stride over the active flat-task list, so capacity padding adds neither CTAs
+    nor loop iterations. Workers are independent and require no inter-CTA
+    synchronization; their count is an occupancy choice, not a co-residency
+    requirement.
+    """
+
+    metadata: RaggedChunkMetadata
+    ctas_per_sm: int = PERSISTENT_CTAS_PER_SM
+
+    @staticmethod
+    def _resolve(
+        request: ScheduleRequest,
+        eligible: bool,
+        capacity_tasks: int,
+        workers: int,
+        requirement: str,
+    ) -> ResolvedSchedule:
+        """Translate caller policy into one concrete schedule."""
+        validate_schedule_request(request)
+        if request is ScheduleRequest.PERSISTENT and not eligible:
+            raise ValueError(f"persistent scheduling requires {requirement}")
+        if capacity_tasks == 0:
+            return ResolvedSchedule(ScheduleKind.STATIC, workers, capacity_tasks)
+        if request is ScheduleRequest.AUTO:
+            persistent = eligible and capacity_tasks > PERSISTENT_AUTO_WAVES * workers
+        else:
+            persistent = request is ScheduleRequest.PERSISTENT
+        return ResolvedSchedule(
+            ScheduleKind.PERSISTENT if persistent else ScheduleKind.STATIC,
+            workers,
+            capacity_tasks,
+        )
+
+    def num_workers(self, subtasks_per_chunk: int, device: torch.device | str) -> int:
+        """Return the bounded worker count for a flat ``(chunk, subtask)`` list."""
+        sm_count = _multiprocessor_count(torch.device(device))
+        return min(self.metadata.capacity * subtasks_per_chunk, sm_count * self.ctas_per_sm)
+
+    def num_chunk_workers(self, device: torch.device | str) -> int:
+        """Determine the persistent grid size along the chunk axis for this device.
+
+        CuTeDSL kernels retain their natural grid dimensions for the remaining
+        axes (pair, head, ...), while this helper sizes only the chunk axis. These
+        small CTAs are latency bound, so measured performance improves as chunk
+        parallelism increases; cap that axis at one worker per SM, independently
+        of the number of subtasks per chunk.
+        """
+        sm_count = _multiprocessor_count(torch.device(device))
+        if self.metadata.capacity == 0:
+            return 0
+        # Power-of-two quantization keeps the TVM-FFI compile cache small when
+        # eager callers vary the capacity below the SM count.
+        return min(1 << (self.metadata.capacity - 1).bit_length(), sm_count)
+
+    def resolve_flat(
+        self,
+        request: ScheduleRequest,
+        subtasks_per_chunk: int,
+        device: torch.device | str,
+        *,
+        eligible: bool = True,
+        requirement: str = "a persistent kernel for this input layout",
+    ) -> ResolvedSchedule:
+        """Resolve scheduling for a flattened ``(chunk, subtask)`` work list."""
+        workers = self.num_workers(subtasks_per_chunk, device)
+        return self._resolve(
+            request,
+            eligible,
+            self.metadata.capacity * subtasks_per_chunk,
+            workers,
+            requirement,
+        )
+
+    def resolve_chunk(
+        self,
+        request: ScheduleRequest,
+        device: torch.device | str,
+    ) -> ResolvedSchedule:
+        """Resolve scheduling when only the chunk axis is persistent."""
+        workers = self.num_chunk_workers(device)
+        return self._resolve(request, True, self.metadata.capacity, workers, "a ragged kernel")
 
 
 class ChunkWork(NamedTuple):
@@ -78,6 +277,30 @@ def _prepare_ragged_chunk_offsets_kernel(
 
 
 @triton.jit
+def load_ragged_chunk_count(chunk_offsets, num_sequences):
+    """Load the terminal prefix-sum entry containing the active chunk count."""
+    return tl.load(chunk_offsets + num_sequences).to(tl.int64)
+
+
+@triton.jit
+def load_ragged_task_count(chunk_offsets, num_sequences, subtasks_per_chunk):
+    """Return the runtime number of active flattened chunk tasks.
+
+    ``num_sequences`` selects only the terminal prefix-sum entry; scheduling does
+    not stride over sequences. If each chunk has three subtasks, flat tasks 0--2
+    belong to global chunk 0 and tasks 3--5 belong to global chunk 1. Worker ``w``
+    handles ``w, w + num_workers, ...`` up to this returned bound.
+    """
+    return load_ragged_chunk_count(chunk_offsets, num_sequences) * subtasks_per_chunk
+
+
+@triton.jit
+def decode_ragged_task(task, subtasks_per_chunk):
+    """Decode one widened flat task into ``(global_chunk, subtask)``."""
+    return task // subtasks_per_chunk, task % subtasks_per_chunk
+
+
+@triton.jit
 def load_ragged_chunk_work(
     cu_seqlens,
     chunk_offsets,
@@ -120,7 +343,7 @@ def _decode_ragged_chunk_work_kernel(
     chunk_size: tl.constexpr,
 ):
     global_chunk = tl.program_id(0)
-    active_chunks = tl.load(chunk_offsets + num_sequences)
+    active_chunks = load_ragged_chunk_count(chunk_offsets, num_sequences)
     output = work + global_chunk * 5
 
     if global_chunk < active_chunks:
@@ -184,10 +407,14 @@ def decode_ragged_chunk_work(metadata: RaggedChunkMetadata) -> torch.Tensor:
 
 __all__ = [
     "ChunkWork",
+    "GridScheduler",
     "RaggedChunkMetadata",
     "chunk_capacity",
     "chunk_work_oracle",
     "decode_ragged_chunk_work",
+    "decode_ragged_task",
+    "load_ragged_chunk_count",
     "load_ragged_chunk_work",
+    "load_ragged_task_count",
     "prepare_ragged_chunk_metadata",
 ]

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_inter_solve.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_inter_solve.py
@@ -24,7 +24,14 @@ from torch._subclasses.fake_tensor import FakeTensor
 from attn_gym._backends.cute import compile_tvm_ffi, jit_cache
 from attn_gym._backends.cute.target import get_compile_target
 from attn_gym._backends.cute.utils import requires_int64_abi
-from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata
+from attn_gym.linear.kda.chunk_schedule import (
+    RaggedChunkMetadata,
+    ResolvedSchedule,
+    ScheduleKind,
+    ScheduleRequest,
+    validate_schedule_request,
+)
+from attn_gym.linear.kda.chunk_scheduler import GridScheduler
 from attn_gym.linear.kda.fwd.cute.chunk_kda_k3b_offdiag_cutedsl import (
     ChunkKDAFwdK3bOffdiagCuteDSL,
 )
@@ -62,16 +69,45 @@ def _validate_specialization(head_dim: int, chunk_size: int, subchunk_size: int)
     return num_subchunks * (num_subchunks - 1) // 2
 
 
+def _resolve_ragged_execution(
+    tensor: torch.Tensor,
+    metadata: RaggedChunkMetadata,
+    request: ScheduleRequest,
+) -> ResolvedSchedule:
+    """Resolve a real launch or provide the unused fake-tensor placeholder plan."""
+    validate_schedule_request(request)
+    if isinstance(tensor, FakeTensor):
+        return ResolvedSchedule(ScheduleKind.STATIC, 0, metadata.capacity)
+    return GridScheduler(metadata).resolve_chunk(request, tensor.device)
+
+
+def _make_fake_chunk_index(
+    chunk_schedule: ChunkSchedule,
+    sequences: int,
+):
+    """Create one optional fake ``[N+1]`` routing tensor."""
+    if chunk_schedule is ChunkSchedule.DENSE:
+        return None
+    return make_fake_compact_tensor(
+        cutlass.Int32,
+        (sequences,),
+        stride_order=(0,),
+        assumed_align=4,
+    )
+
+
 @jit_cache
 def _compile_k3b(
     heads: int,
     head_dim: int,
     chunk_size: int,
     subchunk_size: int,
-    schedule: ChunkSchedule,
+    chunk_schedule: ChunkSchedule,
+    schedule_kind: ScheduleKind,
+    chunk_workers: int = 0,
     use_int64_offsets: bool = False,
 ):
-    """Compile one persistent K3b TVM-FFI scheduling specialization."""
+    """Compile K3b for independent layout and execution schedules."""
     _check_compile_target()
     offdiag_blocks = _validate_specialization(head_dim, chunk_size, subchunk_size)
     num_subchunks = chunk_size // subchunk_size
@@ -80,7 +116,9 @@ def _compile_k3b(
         D=head_dim,
         chunk_size=chunk_size,
         num_subchunks=num_subchunks,
-        schedule=schedule,
+        chunk_schedule=chunk_schedule,
+        schedule_kind=schedule_kind,
+        chunk_workers=chunk_workers,
         use_int64_offsets=use_int64_offsets,
     )
     tokens, chunks, sequences = (cute.sym_int() for _ in range(3))
@@ -121,26 +159,8 @@ def _compile_k3b(
         stride_order=(1, 0),
         assumed_align=16,
     )
-    cu_seqlens = (
-        make_fake_compact_tensor(
-            cutlass.Int32,
-            (sequences,),
-            stride_order=(0,),
-            assumed_align=4,
-        )
-        if schedule is ChunkSchedule.RAGGED
-        else None
-    )
-    chunk_offsets = (
-        make_fake_compact_tensor(
-            cutlass.Int32,
-            (sequences,),
-            stride_order=(0,),
-            assumed_align=4,
-        )
-        if schedule is ChunkSchedule.RAGGED
-        else None
-    )
+    cu_seqlens = _make_fake_chunk_index(chunk_schedule, sequences)
+    chunk_offsets = _make_fake_chunk_index(chunk_schedule, sequences)
     return compile_tvm_ffi(
         op,
         q,
@@ -156,7 +176,8 @@ def _compile_k3b(
         chunk_offsets,
         name=(
             f"kda_fwd_k3b_h{heads}_d{head_dim}_c{chunk_size}_sc{subchunk_size}"
-            f"_schedule_{schedule.value}_i64{int(use_int64_offsets)}"
+            f"_layout_{chunk_schedule.value}_execution_{schedule_kind.value}"
+            f"_cw{chunk_workers}_i64{int(use_int64_offsets)}"
         ),
     )
 
@@ -167,10 +188,12 @@ def _compile_k4b(
     head_dim: int,
     chunk_size: int,
     subchunk_size: int,
-    schedule: ChunkSchedule,
+    chunk_schedule: ChunkSchedule,
+    schedule_kind: ScheduleKind,
+    chunk_workers: int = 0,
     use_int64_offsets: bool = False,
 ):
-    """Compile one persistent K4b TVM-FFI scheduling specialization."""
+    """Compile K4b for independent layout and execution schedules."""
     _check_compile_target()
     offdiag_blocks = _validate_specialization(head_dim, chunk_size, subchunk_size)
     num_subchunks = chunk_size // subchunk_size
@@ -178,7 +201,9 @@ def _compile_k4b(
         BC=subchunk_size,
         chunk_size=chunk_size,
         num_subchunks=num_subchunks,
-        schedule=schedule,
+        chunk_schedule=chunk_schedule,
+        schedule_kind=schedule_kind,
+        chunk_workers=chunk_workers,
         use_int64_offsets=use_int64_offsets,
     )
     tokens, chunks, sequences = (cute.sym_int() for _ in range(3))
@@ -200,26 +225,8 @@ def _compile_k4b(
         stride_order=(1, 0),
         assumed_align=16,
     )
-    cu_seqlens = (
-        make_fake_compact_tensor(
-            cutlass.Int32,
-            (sequences,),
-            stride_order=(0,),
-            assumed_align=4,
-        )
-        if schedule is ChunkSchedule.RAGGED
-        else None
-    )
-    chunk_offsets = (
-        make_fake_compact_tensor(
-            cutlass.Int32,
-            (sequences,),
-            stride_order=(0,),
-            assumed_align=4,
-        )
-        if schedule is ChunkSchedule.RAGGED
-        else None
-    )
+    cu_seqlens = _make_fake_chunk_index(chunk_schedule, sequences)
+    chunk_offsets = _make_fake_chunk_index(chunk_schedule, sequences)
     return compile_tvm_ffi(
         op,
         AkkOD,
@@ -231,7 +238,8 @@ def _compile_k4b(
         chunk_offsets,
         name=(
             f"kda_fwd_k4b_h{heads}_d{head_dim}_c{chunk_size}_sc{subchunk_size}"
-            f"_schedule_{schedule.value}_i64{int(use_int64_offsets)}"
+            f"_layout_{chunk_schedule.value}_execution_{schedule_kind.value}"
+            f"_cw{chunk_workers}_i64{int(use_int64_offsets)}"
         ),
     )
 
@@ -244,10 +252,14 @@ def _chunk_kda_fwd_k3b_ragged_impl(
     Aqk: torch.Tensor,
     scale: float,
     metadata: RaggedChunkMetadata,
+    resolved: ResolvedSchedule,
     subchunk_size: int = _SUPPORTED_SUBCHUNK_SIZE,
     AkkOD: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Compute scheduler-routed K3 off-diagonal blocks without running K4."""
+    """Compute K3 with an execution plan shared by composed ragged stages.
+
+    Persistent execution defines only the active ``AkkOD`` rows.
+    """
     batch, tokens, heads, head_dim = k.shape
     chunk_size = _SUPPORTED_CHUNK_SIZE
     metadata.validate_chunk_size(chunk_size)
@@ -273,12 +285,15 @@ def _chunk_kda_fwd_k3b_ragged_impl(
     g_flat = gk.reshape(tokens, heads * head_dim).contiguous()
     beta_flat = beta.reshape(tokens, heads).contiguous()
     Aqk_flat = Aqk.reshape(tokens, heads * chunk_size)
+    chunk_workers = resolved.workers if resolved.kind is ScheduleKind.PERSISTENT else 0
     k3b = _compile_k3b(
         heads,
         head_dim,
         chunk_size,
         subchunk_size,
         ChunkSchedule.RAGGED,
+        resolved.kind,
+        chunk_workers,
         use_int64_offsets=requires_int64_abi(q_flat, k_flat, g_flat, beta_flat, Aqk_flat, AkkOD),
     )
     k3b(
@@ -305,18 +320,21 @@ def chunk_kda_fwd_k3b_ragged_cute(
     Aqk: torch.Tensor,
     scale: float,
     metadata: RaggedChunkMetadata,
+    schedule: ScheduleRequest = ScheduleRequest.AUTO,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Run eager ragged K3 with functional input semantics."""
-    return _chunk_kda_fwd_k3b_ragged_impl(q, k, gk, beta, Aqk.clone(), scale, metadata)
+    resolved = _resolve_ragged_execution(k, metadata, schedule)
+    return _chunk_kda_fwd_k3b_ragged_impl(q, k, gk, beta, Aqk.clone(), scale, metadata, resolved)
 
 
 def _chunk_kda_fwd_k4b_ragged_impl(
     AkkOD: torch.Tensor,
     Akkd: torch.Tensor,
     metadata: RaggedChunkMetadata,
+    resolved: ResolvedSchedule,
     subchunk_size: int = _SUPPORTED_SUBCHUNK_SIZE,
 ) -> torch.Tensor:
-    """Compute scheduler-routed K4 inverse blocks into a zero-initialized output."""
+    """Compute K4 with the same execution plan that produced ``AkkOD``."""
     if Akkd.ndim != 4:
         raise ValueError(f"Akkd must be 4D, got shape {tuple(Akkd.shape)}")
     batch, tokens, heads, diagonal_width = Akkd.shape
@@ -345,6 +363,7 @@ def _chunk_kda_fwd_k4b_ragged_impl(
     if isinstance(Akkd, FakeTensor) or metadata.capacity == 0:
         return Akk
 
+    chunk_workers = resolved.workers if resolved.kind is ScheduleKind.PERSISTENT else 0
     akkd_flat = Akkd.reshape(tokens, heads * subchunk_size).contiguous()
     akk_flat = Akk.reshape(tokens, heads * chunk_size)
     k4b = _compile_k4b(
@@ -353,6 +372,8 @@ def _chunk_kda_fwd_k4b_ragged_impl(
         chunk_size,
         subchunk_size,
         ChunkSchedule.RAGGED,
+        resolved.kind,
+        chunk_workers,
         use_int64_offsets=requires_int64_abi(AkkOD, akkd_flat, akk_flat),
     )
     k4b(
@@ -371,9 +392,11 @@ def chunk_kda_fwd_k4b_ragged_cute(
     AkkOD: torch.Tensor,
     Akkd: torch.Tensor,
     metadata: RaggedChunkMetadata,
+    schedule: ScheduleRequest = ScheduleRequest.AUTO,
 ) -> torch.Tensor:
     """Run the eager ragged K4 inverse stage."""
-    return _chunk_kda_fwd_k4b_ragged_impl(AkkOD, Akkd, metadata)
+    resolved = _resolve_ragged_execution(Akkd, metadata, schedule)
+    return _chunk_kda_fwd_k4b_ragged_impl(AkkOD, Akkd, metadata, resolved)
 
 
 def chunk_kda_fwd_inter_solve_ragged_cute(
@@ -386,10 +409,10 @@ def chunk_kda_fwd_inter_solve_ragged_cute(
     scale: float,
     metadata: RaggedChunkMetadata,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Run the production K3+K4 inter-solve stages with ragged scheduling."""
-    metadata.validate_chunk_size(_SUPPORTED_CHUNK_SIZE)
-    Aqk, AkkOD = _chunk_kda_fwd_k3b_ragged_impl(q, k, gk, beta, Aqk, scale, metadata)
-    return Aqk, _chunk_kda_fwd_k4b_ragged_impl(AkkOD, Akkd, metadata)
+    """Run K3 and K4 with one shared automatic scheduling decision."""
+    resolved = _resolve_ragged_execution(k, metadata, ScheduleRequest.AUTO)
+    Aqk, AkkOD = _chunk_kda_fwd_k3b_ragged_impl(q, k, gk, beta, Aqk, scale, metadata, resolved)
+    return Aqk, _chunk_kda_fwd_k4b_ragged_impl(AkkOD, Akkd, metadata, resolved)
 
 
 def chunk_kda_fwd_inter_solve_cute(
@@ -465,6 +488,7 @@ def chunk_kda_fwd_inter_solve_cute(
             BT,
             BC,
             ChunkSchedule.DENSE,
+            ScheduleKind.STATIC,
             use_int64_offsets=requires_int64_abi(
                 q_flat, k_flat, g_flat, beta_flat, Aqk_flat, akk_od
             ),
@@ -491,6 +515,7 @@ def chunk_kda_fwd_inter_solve_cute(
             BT,
             BC,
             ChunkSchedule.DENSE,
+            ScheduleKind.STATIC,
             use_int64_offsets=requires_int64_abi(akk_od, akkd_flat, Akk_flat),
         )
         k4b(

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_k3b_offdiag_cutedsl.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_k3b_offdiag_cutedsl.py
@@ -8,7 +8,8 @@
 CuTe DSL K3b: Off-diagonal gated matmul, one pair per CTA, 4 warps.
 
 Matches NV C++ kernel_3b_offdiag_matmul.cu architecture:
-  Grid: (total_chunks * 6, H, 1) — one CTA per (pair, head)
+  Exact grid: (total_chunks * 6, H, 1) — one CTA per (chunk, pair, head)
+  Persistent grid: (chunk_workers * 6, H, 1) — each CTA strides over chunks
   128 threads (4 warps):
       All warps: Phase 1 — fused gating into SMEM
       Warp 0:    Phase 2 — Aqk = sQg @ sKn^T  (MMA)
@@ -29,8 +30,12 @@ import cutlass
 from cutlass import Int32, cute
 from cutlass.cute.nvgpu import warp
 
+from attn_gym.linear.kda.chunk_schedule import ScheduleKind
 from attn_gym.linear.kda.fwd.cute.chunk_schedule import ChunkSchedule
-from attn_gym.linear.kda.fwd.cute.chunk_scheduler_cute import load_ragged_chunk_work
+from attn_gym.linear.kda.fwd.cute.chunk_scheduler_cute import (
+    load_ragged_chunk_count,
+    load_ragged_chunk_work,
+)
 
 
 class ChunkKDAFwdK3bOffdiagCuteDSL:
@@ -42,7 +47,9 @@ class ChunkKDAFwdK3bOffdiagCuteDSL:
         D: int = 128,
         chunk_size: int = 64,
         num_subchunks: int = 4,
-        schedule: ChunkSchedule = ChunkSchedule.DENSE,
+        chunk_schedule: ChunkSchedule = ChunkSchedule.DENSE,
+        schedule_kind: ScheduleKind = ScheduleKind.STATIC,
+        chunk_workers: int = 0,
         use_int64_offsets: bool = False,
     ):
         assert num_subchunks == 4, (
@@ -52,10 +59,18 @@ class ChunkKDAFwdK3bOffdiagCuteDSL:
             f"chunk_size must equal num_subchunks * BC, got {chunk_size} and "
             f"{num_subchunks} * {BC}"
         )
+        if schedule_kind is ScheduleKind.PERSISTENT:
+            assert chunk_schedule is ChunkSchedule.RAGGED and chunk_workers > 0, (
+                "persistent execution requires a positive ragged chunk-worker grid"
+            )
+        else:
+            assert chunk_workers == 0, "static execution does not use chunk workers"
+        self.schedule_kind = schedule_kind
+        self.chunk_workers = chunk_workers
         self.use_int64_offsets = use_int64_offsets
         self.BC = BC
         self.D = D
-        self.schedule = schedule
+        self.chunk_schedule = chunk_schedule
         self.BT = chunk_size
         self.num_offdiag_blocks = num_subchunks * (num_subchunks - 1) // 2
         self.num_threads = 128
@@ -84,7 +99,12 @@ class ChunkKDAFwdK3bOffdiagCuteDSL:
         stream,
     ):
         self._dtype: type[cutlass.Numeric] = mQ.element_type
-        grid = (total_chunks * self.num_offdiag_blocks, H, 1)
+        chunk_axis = (
+            self.chunk_workers
+            if cutlass.const_expr(self.schedule_kind is ScheduleKind.PERSISTENT)
+            else total_chunks
+        )
+        grid = (chunk_axis * self.num_offdiag_blocks, H, 1)
 
         smem_k_block_size = 64
         swizzle_bits = 3
@@ -175,10 +195,7 @@ class ChunkKDAFwdK3bOffdiagCuteDSL:
     ):
         tidx, _, _ = cute.arch.thread_idx()
         block_idx, head_idx, _ = cute.arch.block_idx()
-        warp_idx = tidx // self.WARP_SIZE
-        lane_idx = tidx % self.WARP_SIZE
 
-        # ── Decompose block_idx into chunk and pair ──
         chunk_idx = block_idx // self.num_offdiag_blocks
         pair_idx = block_idx % self.num_offdiag_blocks
 
@@ -189,7 +206,7 @@ class ChunkKDAFwdK3bOffdiagCuteDSL:
             ri = 3
         ci = pair_idx - (ri * (ri - 1)) // 2
 
-        # ── Shared memory and work resolution ──
+        # ── Shared memory, allocated once and reused across persistent iterations ──
         smem = cutlass.utils.SmemAllocator()
         storage = smem.allocate(SharedStorage)
         sQg = storage.sQg.get_tensor(sGated_layout)
@@ -198,9 +215,102 @@ class ChunkKDAFwdK3bOffdiagCuteDSL:
         sGref = storage.sGref.get_tensor(sGref_layout)
         sBeta = storage.sBeta.get_tensor(sBeta_layout)
 
-        if cutlass.const_expr(self.schedule is ChunkSchedule.RAGGED):
-            num_sequences = Int32(cute.size(chunk_offsets)) - 1
-            active_chunks = Int32(chunk_offsets[num_sequences])
+        if cutlass.const_expr(self.schedule_kind is ScheduleKind.PERSISTENT):
+            active_chunks = load_ragged_chunk_count(chunk_offsets)
+            # unroll=2 interleaves two chunks' gating loads, restoring the
+            # load->use distance the scheduler achieves in the static body
+            # (median 46 vs 14 instructions; long_scoreboard 25 -> ~12 cyc/inst).
+            # unroll=4 crosses a code-size/register cliff and loses it again.
+            for current_chunk in cutlass.range(
+                chunk_idx, active_chunks, self.chunk_workers, unroll=2
+            ):
+                self._process_chunk(
+                    mQ,
+                    mK,
+                    mG,
+                    mBeta,
+                    mAqk,
+                    mAkkOD,
+                    scale,
+                    cu_seqlens,
+                    chunk_offsets,
+                    sQg,
+                    sKp,
+                    sKn,
+                    sGref,
+                    sBeta,
+                    smem_copy_A,
+                    smem_copy_B,
+                    tiled_mma,
+                    current_chunk,
+                    pair_idx,
+                    ri,
+                    ci,
+                    head_idx,
+                    tidx,
+                )
+                # Synchronize all warps before the next chunk's gating reuses SMEM.
+                cute.arch.sync_threads()
+        else:
+            self._process_chunk(
+                mQ,
+                mK,
+                mG,
+                mBeta,
+                mAqk,
+                mAkkOD,
+                scale,
+                cu_seqlens,
+                chunk_offsets,
+                sQg,
+                sKp,
+                sKn,
+                sGref,
+                sBeta,
+                smem_copy_A,
+                smem_copy_B,
+                tiled_mma,
+                chunk_idx,
+                pair_idx,
+                ri,
+                ci,
+                head_idx,
+                tidx,
+            )
+
+    @cute.jit
+    def _process_chunk(
+        self,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mG: cute.Tensor,
+        mBeta: cute.Tensor,
+        mAqk: cute.Tensor,
+        mAkkOD: cute.Tensor,
+        scale: cutlass.Float32,
+        cu_seqlens: cute.Tensor | None,
+        chunk_offsets: cute.Tensor | None,
+        sQg: cute.Tensor,
+        sKp: cute.Tensor,
+        sKn: cute.Tensor,
+        sGref: cute.Tensor,
+        sBeta: cute.Tensor,
+        smem_copy_A: cute.TiledCopy,
+        smem_copy_B: cute.TiledCopy,
+        tiled_mma: cute.TiledMma,
+        chunk_idx: Int32,
+        pair_idx: Int32,
+        ri: Int32,
+        ci: Int32,
+        head_idx: Int32,
+        tidx: Int32,
+    ):
+        """Gate, multiply, and store one (chunk, pair, head) off-diagonal tile."""
+        warp_idx = tidx // self.WARP_SIZE
+        lane_idx = tidx % self.WARP_SIZE
+
+        if cutlass.const_expr(self.chunk_schedule is ChunkSchedule.RAGGED):
+            active_chunks = load_ragged_chunk_count(chunk_offsets)
             chunk_base = Int32(0)
             eos = Int32(0)
             if chunk_idx < active_chunks:
@@ -225,7 +335,7 @@ class ChunkKDAFwdK3bOffdiagCuteDSL:
         # ══════════════════════════════════════════════════════════
         # Phase 1: Gating into SMEM
         # ══════════════════════════════════════════════════════════
-        if cutlass.const_expr(self.schedule is not ChunkSchedule.DENSE):
+        if cutlass.const_expr(self.chunk_schedule is not ChunkSchedule.DENSE):
             col = tidx
             h_col = h_offset + col
             if chunk_base + self.BT <= eos:
@@ -373,7 +483,7 @@ class ChunkKDAFwdK3bOffdiagCuteDSL:
             for i in cutlass.range_constexpr(cute.size(acc_Aqk)):
                 row = tCcC[i][0]
                 col = tCcC[i][1]
-                if cutlass.const_expr(self.schedule is not ChunkSchedule.DENSE):
+                if cutlass.const_expr(self.chunk_schedule is not ChunkSchedule.DENSE):
                     if chunk_base + self.BT <= eos or ti_row + row < eos:
                         mAqk[ti_row + row, aqk_col + ci * self.BC + col] = out_dtype(
                             acc_Aqk[i] * scale
@@ -396,7 +506,7 @@ class ChunkKDAFwdK3bOffdiagCuteDSL:
             for i in cutlass.range_constexpr(cute.size(acc_Aqk)):
                 row = tCcC[i][0]
                 col = tCcC[i][1]
-                if cutlass.const_expr(self.schedule is not ChunkSchedule.DENSE):
+                if cutlass.const_expr(self.chunk_schedule is not ChunkSchedule.DENSE):
                     if ti_col + row < eos:
                         mAqk[ti_col + row, aqk_col + ri * self.BC + col] = out_dtype(0.0)
                 else:

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_k4b_inverse_cutedsl.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_k4b_inverse_cutedsl.py
@@ -7,7 +7,8 @@
 """
 CuTe DSL K4b: 4×4 block lower-triangular matrix inverse.
 
-Grid: (total_chunks, H, 1) — one CTA per (chunk, head).
+Exact grid: (total_chunks, H, 1) — one CTA per (chunk, head).
+Persistent grid: (chunk_workers, H, 1) — each CTA strides over chunks.
 128 threads (4 warps):
     Phase 1: Per-warp OD register load + preinverted diagonal-block load
     Phase 2a: Warps 0-2 parallel Schur L1 (Ai10, Ai21, Ai32), Warp 3 stores diags
@@ -30,8 +31,12 @@ import cutlass
 from cutlass import Int32, cute
 from cutlass.cute.nvgpu import warp
 
+from attn_gym.linear.kda.chunk_schedule import ScheduleKind
 from attn_gym.linear.kda.fwd.cute.chunk_schedule import ChunkSchedule
-from attn_gym.linear.kda.fwd.cute.chunk_scheduler_cute import load_ragged_chunk_work
+from attn_gym.linear.kda.fwd.cute.chunk_scheduler_cute import (
+    load_ragged_chunk_count,
+    load_ragged_chunk_work,
+)
 
 
 class ChunkKDAFwdK4bInverseCuteDSL:
@@ -42,7 +47,9 @@ class ChunkKDAFwdK4bInverseCuteDSL:
         BC: int = 16,
         chunk_size: int = 64,
         num_subchunks: int = 4,
-        schedule: ChunkSchedule = ChunkSchedule.DENSE,
+        chunk_schedule: ChunkSchedule = ChunkSchedule.DENSE,
+        schedule_kind: ScheduleKind = ScheduleKind.STATIC,
+        chunk_workers: int = 0,
         use_int64_offsets: bool = False,
     ):
         assert num_subchunks == 4, (
@@ -52,6 +59,14 @@ class ChunkKDAFwdK4bInverseCuteDSL:
             f"chunk_size must equal num_subchunks * BC, got {chunk_size} and "
             f"{num_subchunks} * {BC}"
         )
+        if schedule_kind is ScheduleKind.PERSISTENT:
+            assert chunk_schedule is ChunkSchedule.RAGGED and chunk_workers > 0, (
+                "persistent execution requires a positive ragged chunk-worker grid"
+            )
+        else:
+            assert chunk_workers == 0, "static execution does not use chunk workers"
+        self.schedule_kind = schedule_kind
+        self.chunk_workers = chunk_workers
         self.use_int64_offsets = use_int64_offsets
         self.BC = BC
         self.BT = chunk_size
@@ -59,7 +74,7 @@ class ChunkKDAFwdK4bInverseCuteDSL:
         self.num_threads = 128
         self.mma_inst_shape = (16, 8, 16)
         self.atom_layout_mnk = (1, 1, 1)
-        self.schedule = schedule
+        self.chunk_schedule = chunk_schedule
 
     @cute.jit
     def upcast(self, value):
@@ -94,7 +109,12 @@ class ChunkKDAFwdK4bInverseCuteDSL:
         stream,
     ):
         self._dtype: type[cutlass.Numeric] = mAkk.element_type
-        grid = (total_chunks, H, 1)
+        chunk_axis = (
+            self.chunk_workers
+            if cutlass.const_expr(self.schedule_kind is ScheduleKind.PERSISTENT)
+            else total_chunks
+        )
+        grid = (chunk_axis, H, 1)
 
         sSchurA_layout = cute.make_layout((self.BC, self.BC), stride=(self.BC + 8, 1))
         sAi_layout = cute.make_layout((self.BC, self.BC), stride=(self.BC, 1))
@@ -182,9 +202,8 @@ class ChunkKDAFwdK4bInverseCuteDSL:
     ):
         tidx, _, _ = cute.arch.thread_idx()
         chunk_idx, head_idx, _ = cute.arch.block_idx()
-        warp_idx = tidx // self.WARP_SIZE
-        lane_idx = tidx % self.WARP_SIZE
 
+        # ── Shared memory, allocated once and reused across persistent iterations ──
         smem = cutlass.utils.SmemAllocator()
         storage = smem.allocate(SharedStorage)
         work = storage.work.get_tensor(cute.make_layout(3))
@@ -198,11 +217,93 @@ class ChunkKDAFwdK4bInverseCuteDSL:
         sSchurB1 = storage.sSchurB1.get_tensor(sSchurB_layout)
         sSchurA2 = storage.sSchurA2.get_tensor(sSchurA_layout)
         sSchurB2 = storage.sSchurB2.get_tensor(sSchurB_layout)
+        smem_tensors = (
+            work,
+            sAi0,
+            sAi1,
+            sAi2,
+            sAi3,
+            sSchurA0,
+            sSchurB0,
+            sSchurA1,
+            sSchurB1,
+            sSchurA2,
+            sSchurB2,
+        )
 
-        if cutlass.const_expr(self.schedule is ChunkSchedule.RAGGED):
+        if cutlass.const_expr(self.schedule_kind is ScheduleKind.PERSISTENT):
+            active_chunks = load_ragged_chunk_count(chunk_offsets)
+            # No unroll: K4b's register-heavy Schur body regresses under
+            # unroll=2 (0.97x -> 0.87x measured vs the static grid).
+            for current_chunk in cutlass.range(chunk_idx, active_chunks, self.chunk_workers):
+                self._process_chunk(
+                    mAkkOD,
+                    mAkkd,
+                    mAkk,
+                    cu_seqlens,
+                    chunk_offsets,
+                    smem_tensors,
+                    smem_copy_A,
+                    smem_copy_B,
+                    tiled_mma,
+                    current_chunk,
+                    head_idx,
+                    tidx,
+                )
+                # Synchronize all warps before the next chunk's loads reuse SMEM.
+                cute.arch.sync_threads()
+        else:
+            self._process_chunk(
+                mAkkOD,
+                mAkkd,
+                mAkk,
+                cu_seqlens,
+                chunk_offsets,
+                smem_tensors,
+                smem_copy_A,
+                smem_copy_B,
+                tiled_mma,
+                chunk_idx,
+                head_idx,
+                tidx,
+            )
+
+    @cute.jit
+    def _process_chunk(
+        self,
+        mAkkOD: cute.Tensor,
+        mAkkd: cute.Tensor,
+        mAkk: cute.Tensor,
+        cu_seqlens: cute.Tensor | None,
+        chunk_offsets: cute.Tensor | None,
+        smem_tensors,
+        smem_copy_A: cute.TiledCopy,
+        smem_copy_B: cute.TiledCopy,
+        tiled_mma: cute.TiledMma,
+        chunk_idx: Int32,
+        head_idx: Int32,
+        tidx: Int32,
+    ):
+        """Invert one chunk's 4x4 block lower-triangular system."""
+        warp_idx = tidx // self.WARP_SIZE
+        lane_idx = tidx % self.WARP_SIZE
+        (
+            work,
+            sAi0,
+            sAi1,
+            sAi2,
+            sAi3,
+            sSchurA0,
+            sSchurB0,
+            sSchurA1,
+            sSchurB1,
+            sSchurA2,
+            sSchurB2,
+        ) = smem_tensors
+
+        if cutlass.const_expr(self.chunk_schedule is ChunkSchedule.RAGGED):
             if tidx == 0:
-                num_sequences = Int32(cute.size(chunk_offsets)) - 1
-                active_chunks = Int32(chunk_offsets[num_sequences])
+                active_chunks = load_ragged_chunk_count(chunk_offsets)
                 work[0] = Int32(0)
                 work[1] = Int32(0)
                 work[2] = Int32(0)
@@ -317,6 +418,9 @@ class ChunkKDAFwdK4bInverseCuteDSL:
         # ══════════════════════════════════════════════════════════
         # PHASE 2: Parallel Schur Complement + Overlapped Stores
         # ══════════════════════════════════════════════════════════
+        # Each compute warp owns one sSchurA/B pair and writes then reads it in
+        # converged warp order. The CTA barriers protect cross-warp diagonal
+        # handoff above and SMEM reuse between persistent iterations.
 
         # ── WARP 0: 9 GEMMs (reordered for B-fragment reuse) ──
         if is_active and warp_idx == 0:

--- a/attn_gym/linear/kda/fwd/cute/chunk_scheduler_cute.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_scheduler_cute.py
@@ -13,6 +13,13 @@ from attn_gym._backends.cute.device import upper_bound
 
 
 @cute.jit
+def load_ragged_chunk_count(chunk_offsets: cute.Tensor):
+    """Load the terminal prefix-sum entry containing the active chunk count."""
+    num_sequences = Int32(cute.size(chunk_offsets)) - 1
+    return Int32(chunk_offsets[num_sequences])
+
+
+@cute.jit
 def load_ragged_chunk_work(
     cu_seqlens: cute.Tensor,
     chunk_offsets: cute.Tensor,
@@ -89,14 +96,13 @@ class ChunkSchedulerDiagnostic:
         global_chunk, _, _ = cute.arch.block_idx()
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
         lane_idx = tidx % cute.arch.WARP_SIZE
-        num_sequences = Int32(cute.size(chunk_offsets)) - 1
 
         smem = cutlass.utils.SmemAllocator()
         storage = smem.allocate(SharedStorage)
         work = storage.work.get_tensor(cute.make_layout(self.fields))
 
         if tidx == 0:
-            active_chunks = Int32(chunk_offsets[num_sequences])
+            active_chunks = load_ragged_chunk_count(chunk_offsets)
             if global_chunk < active_chunks:
                 sequence, local_chunk, token_start, valid_tokens = load_ragged_chunk_work(
                     cu_seqlens,
@@ -190,4 +196,8 @@ def decode_ragged_chunk_work_cute(
     return output
 
 
-__all__ = ["decode_ragged_chunk_work_cute", "load_ragged_chunk_work"]
+__all__ = [
+    "decode_ragged_chunk_work_cute",
+    "load_ragged_chunk_count",
+    "load_ragged_chunk_work",
+]

--- a/attn_gym/linear/kda/fwd/cute/recompute_w_u_fwd.py
+++ b/attn_gym/linear/kda/fwd/cute/recompute_w_u_fwd.py
@@ -79,7 +79,7 @@ from torch._subclasses.fake_tensor import FakeTensor
 
 from attn_gym._backends.cute import compile_tvm_ffi, jit_cache
 from attn_gym._backends.cute.target import get_compile_target
-from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata
+from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata, ScheduleRequest
 from attn_gym.linear.kda.fwd.cute.chunk_scheduler_cute import load_ragged_chunk_work
 from attn_gym.linear.kda.fwd.triton.recompute_w_u import recompute_w_u_fwd_triton
 
@@ -1511,6 +1511,7 @@ def recompute_w_u_fwd(
     chunk_size: int = BT,
     dot_precision: str | MmaPrecision = "bf16",
     autotune: bool = True,
+    schedule: ScheduleRequest = ScheduleRequest.AUTO,
 ) -> tuple[
     torch.Tensor,
     torch.Tensor,
@@ -1545,6 +1546,7 @@ def recompute_w_u_fwd(
         chunk_size=chunk_size,
         dot_precision=precision.value,
         autotune=autotune,
+        schedule=schedule,
     )
 
 

--- a/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
@@ -22,7 +22,11 @@ import triton.language as tl
 from triton.tools.tensor_descriptor import TensorDescriptor
 
 from attn_gym._backends.triton.utils import can_use_tma, ptr_offset, requires_int64_offsets
-from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata, load_ragged_chunk_work
+from attn_gym.linear.kda.chunk_scheduler import (
+    RaggedChunkMetadata,
+    load_ragged_chunk_count,
+    load_ragged_chunk_work,
+)
 from attn_gym.linear.kda.ops import delta_h_op as _delta_h_op
 from attn_gym.linear.kda.ops import delta_h_with_state_op as _delta_h_with_state_op
 from attn_gym.linear.kda.utils import exp2
@@ -173,7 +177,7 @@ def _chunk_decay_last_kernel(
     """Materialize exp2 of each chunk's last-row cumulative gate in one launch."""
     global_chunk, i_h = tl.program_id(0), tl.program_id(1)
     if IS_VARLEN:
-        if global_chunk >= tl.load(chunk_offsets + num_sequences):
+        if global_chunk >= load_ragged_chunk_count(chunk_offsets, num_sequences):
             return
         _, _, token_start, valid_tokens = load_ragged_chunk_work(
             cu_seqlens,

--- a/attn_gym/linear/kda/fwd/triton/chunk_gla_fwd_o.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_gla_fwd_o.py
@@ -22,7 +22,16 @@ from attn_gym._backends.triton.utils import (
     ptr_offset,
     requires_int64_offsets,
 )
-from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata, load_ragged_chunk_work
+from attn_gym.linear.kda.chunk_scheduler import (
+    GridScheduler,
+    RaggedChunkMetadata,
+    ScheduleKind,
+    ScheduleRequest,
+    decode_ragged_task,
+    load_ragged_chunk_count,
+    load_ragged_chunk_work,
+    load_ragged_task_count,
+)
 from attn_gym.linear.kda.utils import autotune_cache_kwargs, exp, exp2
 
 
@@ -92,7 +101,7 @@ def chunk_gla_fwd_kernel_o(
         i_bh = i_bh.to(tl.int64)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
-        if i_t >= tl.load(chunk_offsets + num_sequences):
+        if i_t >= load_ragged_chunk_count(chunk_offsets, num_sequences):
             return
         i_tg = i_t
         i_n, i_t, token_start, _ = load_ragged_chunk_work(
@@ -256,8 +265,8 @@ def chunk_gla_fwd_kernel_o_tma(
     )
 
 
-@triton.jit(do_not_specialize=["num_sequences"])
-def chunk_gla_fwd_kernel_o_ragged_tma(
+@triton.jit
+def _compose_ragged_output_task(
     q_desc,
     v_desc,
     g_desc,
@@ -275,6 +284,9 @@ def chunk_gla_fwd_kernel_o_ragged_tma(
     scale,
     q_stride_t,
     q_stride_h,
+    i_v,
+    global_chunk,
+    i_h,
     H: tl.constexpr,
     K: tl.constexpr,
     V: tl.constexpr,
@@ -283,10 +295,10 @@ def chunk_gla_fwd_kernel_o_ragged_tma(
     BV: tl.constexpr,
     num_sequences,
 ):
-    """Compose full ragged chunks with TMA and partial tails with masked pointers."""
-    i_v, global_chunk, i_h = tl.program_id(0), tl.program_id(1), tl.program_id(2)
-    if global_chunk >= tl.load(chunk_offsets + num_sequences):
-        return
+    """Compose one active (value-tile, chunk, head) ragged output tile.
+
+    Full chunks go through TMA; partial tails use masked pointers.
+    """
     _, _, token_start, valid_tokens = load_ragged_chunk_work(
         cu_seqlens,
         chunk_offsets,
@@ -348,6 +360,140 @@ def chunk_gla_fwd_kernel_o_ragged_tma(
         tl.store(p_o, b_o.to(o.dtype.element_ty), mask=m_tv)
 
 
+@triton.jit(do_not_specialize=["num_sequences"])
+def chunk_gla_fwd_kernel_o_ragged_tma(
+    q_desc,
+    v_desc,
+    g_desc,
+    h_desc,
+    o_desc,
+    A_desc,
+    q,
+    v,
+    g,
+    h,
+    o,
+    A,
+    cu_seqlens,
+    chunk_offsets,
+    scale,
+    q_stride_t,
+    q_stride_h,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    num_sequences,
+):
+    """Launch one CTA per capacity task; capacity-only CTAs exit immediately."""
+    i_v, global_chunk, i_h = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    if global_chunk >= load_ragged_chunk_count(chunk_offsets, num_sequences):
+        return
+    _compose_ragged_output_task(
+        q_desc,
+        v_desc,
+        g_desc,
+        h_desc,
+        o_desc,
+        A_desc,
+        q,
+        v,
+        g,
+        h,
+        o,
+        A,
+        cu_seqlens,
+        chunk_offsets,
+        scale,
+        q_stride_t,
+        q_stride_h,
+        i_v,
+        global_chunk,
+        i_h,
+        H,
+        K,
+        V,
+        BT,
+        BK,
+        BV,
+        num_sequences,
+    )
+
+
+@triton.jit(do_not_specialize=["num_sequences", "num_workers"])
+def chunk_gla_fwd_kernel_o_ragged_tma_persistent(
+    q_desc,
+    v_desc,
+    g_desc,
+    h_desc,
+    o_desc,
+    A_desc,
+    q,
+    v,
+    g,
+    h,
+    o,
+    A,
+    cu_seqlens,
+    chunk_offsets,
+    scale,
+    q_stride_t,
+    q_stride_h,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    num_sequences,
+    num_workers,
+):
+    """Stride a bounded worker grid over active (chunk, head, value-tile) tasks."""
+    worker = tl.program_id(0)
+    num_value_tiles: tl.constexpr = tl.cdiv(V, BV)
+    subtasks: tl.constexpr = H * num_value_tiles
+    total_tasks = load_ragged_task_count(chunk_offsets, num_sequences, subtasks)
+    # num_stages=1 stops the software pipeliner from double-buffering the
+    # outer task loop; the extra SMEM stage costs a resident CTA per SM.
+    for task in tl.range(worker, total_tasks, num_workers, num_stages=1):
+        # TMA descriptor offsets are int32; chunk capacity and subtask indices
+        # each remain in range even when their flattened product needs int64.
+        global_chunk, remainder = decode_ragged_task(task, subtasks)
+        global_chunk = global_chunk.to(tl.int32)
+        remainder = remainder.to(tl.int32)
+        _compose_ragged_output_task(
+            q_desc,
+            v_desc,
+            g_desc,
+            h_desc,
+            o_desc,
+            A_desc,
+            q,
+            v,
+            g,
+            h,
+            o,
+            A,
+            cu_seqlens,
+            chunk_offsets,
+            scale,
+            q_stride_t,
+            q_stride_h,
+            remainder % num_value_tiles,
+            global_chunk,
+            remainder // num_value_tiles,
+            H,
+            K,
+            V,
+            BT,
+            BK,
+            BV,
+            num_sequences,
+        )
+
+
 def _can_use_tensor_descriptors(*tensors: torch.Tensor) -> bool:
     """Return whether all fixed KDA tensors satisfy host TMA requirements."""
     return all(can_use_tma(tensor) for tensor in tensors)
@@ -367,8 +513,18 @@ def chunk_gla_fwd_o_gk(
     chunk_size: int = 64,
     metadata: RaggedChunkMetadata | None = None,
     autotune: bool = True,
+    schedule: ScheduleRequest = ScheduleRequest.AUTO,
 ) -> torch.Tensor:
-    """Compose fixed-length or packed KDA intra- and inter-chunk output terms."""
+    """Compose fixed-length or packed KDA intra- and inter-chunk output terms.
+
+    Args:
+        schedule: Internal scheduling request for tests. Automatic selection is
+            the default and dense inputs keep their exact launch grid.
+
+    Raises:
+        ValueError: If persistent scheduling is forced for a packed input outside
+            the TMA path, where no persistent kernel exists to honor it.
+    """
     if metadata is not None:
         metadata.validate_chunk_size(chunk_size)
     batch, tokens, heads, key_dim = q.shape
@@ -389,12 +545,24 @@ def chunk_gla_fwd_o_gk(
         raise ValueError(f"h must have shape {expected_h_shape}, got {tuple(h.shape)}")
 
     output = torch.empty(v.shape, dtype=v.dtype, device=v.device)
+    if chunks == 0:
+        return output
     ragged_tma = (
         metadata is not None
         and batch == 1
         and (key_dim, value_dim, chunk_size) == (128, 128, 64)
         and _can_use_tensor_descriptors(q, v, g, h, output, A)
     )
+    if metadata is not None:
+        subtasks = heads * triton.cdiv(value_dim, 64)  # 64 = the persistent kernel's BV tile
+        resolved = GridScheduler(metadata).resolve_flat(
+            schedule,
+            subtasks,
+            q.device,
+            eligible=ragged_tma,
+            requirement="the TMA path on packed inputs: batch=1, K=V=128, chunk_size=64, "
+            "and TMA-capable tensors",
+        )
     if (
         metadata is None
         and (key_dim, value_dim, chunk_size) == (128, 128, 64)
@@ -429,9 +597,8 @@ def chunk_gla_fwd_o_gk(
         if ragged_tma:
             block_key_dim = 32
             block_value_dim = 64
-            chunk_gla_fwd_kernel_o_ragged_tma[
-                (triton.cdiv(value_dim, block_value_dim), chunks, heads)
-            ](
+            value_tiles = triton.cdiv(value_dim, block_value_dim)
+            args = (
                 TensorDescriptor.from_tensor(q, [1, chunk_size, 1, block_key_dim]),
                 TensorDescriptor.from_tensor(v, [1, chunk_size, 1, block_value_dim]),
                 TensorDescriptor.from_tensor(g, [1, chunk_size, 1, block_key_dim]),
@@ -449,20 +616,29 @@ def chunk_gla_fwd_o_gk(
                 scale,
                 q.stride(1),
                 q.stride(2),
-                H=heads,
-                K=key_dim,
-                V=value_dim,
-                BT=chunk_size,
-                BK=block_key_dim,
-                BV=block_value_dim,
-                num_sequences=metadata.cu_seqlens.shape[0] - 1,
-                num_warps=2,
-                num_stages=3,
-                # The rarely taken partial-chunk pointer branch pushes this
-                # kernel to 180 registers vs the dense kernel's 134; cap at the
-                # dense budget so only tail CTAs pay with spills.
-                maxnreg=136,
             )
+            kwargs = {
+                "H": heads,
+                "K": key_dim,
+                "V": value_dim,
+                "BT": chunk_size,
+                "BK": block_key_dim,
+                "BV": block_value_dim,
+                "num_sequences": metadata.cu_seqlens.shape[0] - 1,
+                "num_warps": 2,
+                "num_stages": 3,
+                # The partial-tail pointer branch otherwise pushes this kernel
+                # past the dense register budget and loses a resident CTA.
+                "maxnreg": 136,
+            }
+            if resolved.kind is ScheduleKind.PERSISTENT:
+                chunk_gla_fwd_kernel_o_ragged_tma_persistent[(resolved.workers,)](
+                    *args, num_workers=resolved.workers, **kwargs
+                )
+            else:
+                chunk_gla_fwd_kernel_o_ragged_tma[(value_tiles, metadata.capacity, heads)](
+                    *args, **kwargs
+                )
             return output
 
         def grid(meta):

--- a/attn_gym/linear/kda/fwd/triton/chunk_kda_fwd_intra_sub_chunk_forloop.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_kda_fwd_intra_sub_chunk_forloop.py
@@ -20,6 +20,7 @@ import triton.language as tl
 from attn_gym._backends.triton.utils import ptr_offset, requires_int64_offsets
 from attn_gym.linear.kda.chunk_scheduler import (
     RaggedChunkMetadata,
+    load_ragged_chunk_count,
     load_ragged_chunk_work,
 )
 from attn_gym.linear.kda.utils import (
@@ -100,7 +101,7 @@ def chunk_kda_fwd_kernel_intra_sub_chunk_forloop(
         i_t_orig = i_t_start + _iter * GRID_NT
         _run = i_t_orig < MAX_NT
         if IS_VARLEN and _run:
-            _run = i_t_orig < tl.load(chunk_offsets + num_sequences)
+            _run = i_t_orig < load_ragged_chunk_count(chunk_offsets, num_sequences)
         if _run:
             if IS_VARLEN:
                 i_n, i_t, token_start, _ = load_ragged_chunk_work(

--- a/attn_gym/linear/kda/fwd/triton/gate_fwd.py
+++ b/attn_gym/linear/kda/fwd/triton/gate_fwd.py
@@ -22,9 +22,15 @@ import triton.language as tl
 from attn_gym._backends.triton.utils import ptr_offset, storage_cosize
 from attn_gym.linear.kda.bwd.triton.gate_bwd import kda_gate_bwd_ragged
 from attn_gym.linear.kda.chunk_scheduler import (
+    GridScheduler,
     RaggedChunkMetadata,
+    ScheduleKind,
+    ScheduleRequest,
     chunk_capacity,
+    decode_ragged_task,
+    load_ragged_chunk_count,
     load_ragged_chunk_work,
+    load_ragged_task_count,
     prepare_ragged_chunk_metadata,
 )
 from attn_gym.linear.kda.utils import RCP_LN2, exp, input_guard
@@ -154,8 +160,8 @@ def _bounded_gate_cumsum_dense(
     return output
 
 
-@triton.jit(do_not_specialize=["num_sequences"])
-def bounded_gate_chunk_cumsum_ragged_kernel(
+@triton.jit
+def _bounded_gate_cumsum_task(
     raw_gate,
     A_log,
     dt_bias,
@@ -165,6 +171,9 @@ def bounded_gate_chunk_cumsum_ragged_kernel(
     cu_seqlens,
     chunk_offsets,
     num_sequences,
+    global_chunk,
+    i_h,
+    i_d,
     G_STRIDES: tl.constexpr,
     A_LOG_STRIDES: tl.constexpr,
     DT_BIAS_STRIDES: tl.constexpr,
@@ -173,14 +182,8 @@ def bounded_gate_chunk_cumsum_ragged_kernel(
     BT: tl.constexpr,
     BD: tl.constexpr,
 ):
-    """Apply the bounded gate and prefix sum to one device-routed ragged chunk."""
-    global_chunk = tl.program_id(0)
-    i_h = tl.program_id(1).to(tl.int64)
-    i_d = tl.program_id(2).to(tl.int64)
-    if global_chunk >= tl.load(chunk_offsets + num_sequences):
-        return
-
-    _sequence, _local_chunk, token_start, valid_tokens = load_ragged_chunk_work(
+    """Apply the bounded gate and prefix sum to one active (chunk, head, channel tile)."""
+    _, _, token_start, valid_tokens = load_ragged_chunk_work(
         cu_seqlens,
         chunk_offsets,
         global_chunk,
@@ -213,6 +216,107 @@ def bounded_gate_chunk_cumsum_ragged_kernel(
     )
 
 
+@triton.jit(do_not_specialize=["num_sequences"])
+def bounded_gate_chunk_cumsum_ragged_kernel(
+    raw_gate,
+    A_log,
+    dt_bias,
+    output,
+    lower_bound,
+    scale,
+    cu_seqlens,
+    chunk_offsets,
+    num_sequences,
+    G_STRIDES: tl.constexpr,
+    A_LOG_STRIDES: tl.constexpr,
+    DT_BIAS_STRIDES: tl.constexpr,
+    O_STRIDES: tl.constexpr,
+    D: tl.constexpr,
+    BT: tl.constexpr,
+    BD: tl.constexpr,
+):
+    """Launch one CTA per capacity task; capacity-only CTAs exit immediately."""
+    global_chunk = tl.program_id(0)
+    i_h = tl.program_id(1).to(tl.int64)
+    i_d = tl.program_id(2).to(tl.int64)
+    if global_chunk >= load_ragged_chunk_count(chunk_offsets, num_sequences):
+        return
+    _bounded_gate_cumsum_task(
+        raw_gate,
+        A_log,
+        dt_bias,
+        output,
+        lower_bound,
+        scale,
+        cu_seqlens,
+        chunk_offsets,
+        num_sequences,
+        global_chunk,
+        i_h,
+        i_d,
+        G_STRIDES,
+        A_LOG_STRIDES,
+        DT_BIAS_STRIDES,
+        O_STRIDES,
+        D,
+        BT,
+        BD,
+    )
+
+
+@triton.jit(do_not_specialize=["num_sequences", "num_workers"])
+def bounded_gate_chunk_cumsum_ragged_kernel_persistent(
+    raw_gate,
+    A_log,
+    dt_bias,
+    output,
+    lower_bound,
+    scale,
+    cu_seqlens,
+    chunk_offsets,
+    num_sequences,
+    num_workers,
+    G_STRIDES: tl.constexpr,
+    A_LOG_STRIDES: tl.constexpr,
+    DT_BIAS_STRIDES: tl.constexpr,
+    O_STRIDES: tl.constexpr,
+    H: tl.constexpr,
+    D: tl.constexpr,
+    BT: tl.constexpr,
+    BD: tl.constexpr,
+):
+    """Stride a bounded worker grid over active (chunk, head, channel-tile) tasks."""
+    worker = tl.program_id(0)
+    num_channel_tiles: tl.constexpr = (D + BD - 1) // BD
+    subtasks: tl.constexpr = H * num_channel_tiles
+    total_tasks = load_ragged_task_count(chunk_offsets, num_sequences, subtasks)
+    # num_stages=1 stops the software pipeliner from double-buffering the
+    # outer task loop; the extra SMEM stage costs a resident CTA per SM.
+    for task in tl.range(worker, total_tasks, num_workers, num_stages=1):
+        global_chunk, subtask = decode_ragged_task(task, subtasks)
+        _bounded_gate_cumsum_task(
+            raw_gate,
+            A_log,
+            dt_bias,
+            output,
+            lower_bound,
+            scale,
+            cu_seqlens,
+            chunk_offsets,
+            num_sequences,
+            global_chunk,
+            (subtask // num_channel_tiles).to(tl.int64),
+            (subtask % num_channel_tiles).to(tl.int64),
+            G_STRIDES,
+            A_LOG_STRIDES,
+            DT_BIAS_STRIDES,
+            O_STRIDES,
+            D,
+            BT,
+            BD,
+        )
+
+
 @input_guard(no_guard_contiguous=True)
 def bounded_gate_cumsum_ragged(
     raw_gate: torch.Tensor,
@@ -221,14 +325,21 @@ def bounded_gate_cumsum_ragged(
     metadata: RaggedChunkMetadata,
     *,
     lower_bound: float,
+    schedule: ScheduleRequest = ScheduleRequest.AUTO,
 ) -> torch.Tensor:
-    """Run the graph-safe gate with an already prepared packed schedule."""
+    """Run the graph-safe gate with an already prepared packed schedule.
+
+    Args:
+        schedule: Internal scheduling request for tests; automatic selection is
+            the default.
+    """
     output = torch.empty_like(raw_gate, dtype=torch.float32)
+    if metadata.capacity == 0:
+        return output
     _, _, heads, head_dim = raw_gate.shape
     block_dim = 32
-    bounded_gate_chunk_cumsum_ragged_kernel[
-        (metadata.capacity, heads, triton.cdiv(head_dim, block_dim))
-    ](
+    channel_tiles = triton.cdiv(head_dim, block_dim)
+    args = (
         raw_gate,
         A_log,
         dt_bias,
@@ -238,16 +349,30 @@ def bounded_gate_cumsum_ragged(
         metadata.cu_seqlens,
         metadata.chunk_offsets,
         metadata.cu_seqlens.shape[0] - 1,
-        G_STRIDES=raw_gate.stride()[1:],
-        A_LOG_STRIDES=A_log.stride(),
-        DT_BIAS_STRIDES=dt_bias.stride(),
-        O_STRIDES=output.stride()[1:],
-        D=head_dim,
-        BT=metadata.chunk_size,
-        BD=block_dim,
-        num_warps=2,
-        num_stages=3,
     )
+    kwargs = {
+        "G_STRIDES": raw_gate.stride()[1:],
+        "A_LOG_STRIDES": A_log.stride(),
+        "DT_BIAS_STRIDES": dt_bias.stride(),
+        "O_STRIDES": output.stride()[1:],
+        "D": head_dim,
+        "BT": metadata.chunk_size,
+        "BD": block_dim,
+        "num_warps": 2,
+        "num_stages": 3,
+    }
+    # The gate kernel uses its measured 16-CTA/SM cap rather than the 4-CTA default.
+    resolved = GridScheduler(metadata, ctas_per_sm=16).resolve_flat(
+        schedule, heads * channel_tiles, raw_gate.device
+    )
+    if resolved.kind is ScheduleKind.PERSISTENT:
+        bounded_gate_chunk_cumsum_ragged_kernel_persistent[(resolved.workers,)](
+            *args, num_workers=resolved.workers, H=heads, **kwargs
+        )
+    else:
+        bounded_gate_chunk_cumsum_ragged_kernel[(metadata.capacity, heads, channel_tiles)](
+            *args, **kwargs
+        )
     return output
 
 

--- a/attn_gym/linear/kda/fwd/triton/masking.py
+++ b/attn_gym/linear/kda/fwd/triton/masking.py
@@ -1,0 +1,38 @@
+"""Triton row masking for fixed-capacity packed KDA tensors."""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _mask_inactive_rows_kernel(x, active_mask, out, cols, BLOCK: tl.constexpr):
+    row = tl.program_id(0)
+    offsets = tl.program_id(1) * BLOCK + tl.arange(0, BLOCK)
+    in_bounds = offsets < cols
+    base = row.to(tl.int64) * cols
+    if tl.load(active_mask + row):
+        values = tl.load(x + base + offsets, mask=in_bounds)
+        tl.store(out + base + offsets, values, mask=in_bounds)
+    else:
+        zero = tl.zeros((BLOCK,), dtype=out.dtype.element_ty)
+        tl.store(out + base + offsets, zero, mask=in_bounds)
+
+
+@torch.library.triton_op("attn_gym::kda_mask_inactive_rows", mutates_args={})
+def mask_inactive_rows(x: torch.Tensor, active_mask: torch.Tensor) -> torch.Tensor:
+    """Copy active token rows and write-only zero the inactive suffix."""
+    out = torch.empty_like(x)
+    tokens = x.shape[1]
+    if tokens == 0:
+        return out
+    cols = x.numel() // tokens
+    block = 2048
+    grid = (tokens, triton.cdiv(cols, block))
+    torch.library.wrap_triton(_mask_inactive_rows_kernel)[grid](
+        x, active_mask, out, cols, BLOCK=block
+    )
+    return out
+
+
+__all__ = ["mask_inactive_rows"]

--- a/attn_gym/linear/kda/fwd/triton/recompute_w_u.py
+++ b/attn_gym/linear/kda/fwd/triton/recompute_w_u.py
@@ -41,49 +41,59 @@ from attn_gym._backends.triton.utils import (
     ptr_offset,
     requires_int64_offsets,
 )
-from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata, load_ragged_chunk_work
+from attn_gym.linear.kda.chunk_scheduler import (
+    GridScheduler,
+    RaggedChunkMetadata,
+    ScheduleKind,
+    ScheduleRequest,
+    decode_ragged_task,
+    load_ragged_chunk_count,
+    load_ragged_chunk_work,
+    load_ragged_task_count,
+)
 from attn_gym.linear.kda.utils import autotune_cache_kwargs, exp2
 
 # Compile-time dot-precision selector shared with the launch wrapper.
 _PRECISION_MODES = {"bf16": 0, "tf32": 1, "tf32x3": 2}
 
 
-@triton.heuristics(
-    {
-        "STORE_QG": lambda args: args["q"] is not None,
-        "HAS_GK": lambda args: args["gk"] is not None,
-        "IS_RAGGED": lambda args: args["chunk_offsets"] is not None,
-        "USE_INT64_OFFSETS": lambda args: requires_int64_offsets(
-            args["q"],
-            args["k"],
-            args["qg"],
-            args["kg"],
-            args["v"],
-            args["beta"],
-            args["w"],
-            args["u"],
-            args["A"],
-            args["gk"],
-            args["cu_seqlens"],
-            args["chunk_offsets"],
-        ),
-    }
-)
-@triton.autotune(
-    configs=[triton.Config({}, num_warps=w, num_stages=s) for w in [4, 8] for s in [2, 3]],
-    key=["H", "HV", "K", "V", "BT", "BK", "BV", "IS_RAGGED", "HAS_GK", "STORE_QG", "PRECISION"],
-    **autotune_cache_kwargs,
-)
-@triton.jit(
-    do_not_specialize=[
-        "T",
-        "num_sequences",
-        "q_stride_t",
-        "k_stride_t",
-        "v_stride_t",
-    ]
-)
-def recompute_w_u_fwd_kernel(
+_AUTOTUNE_CONFIGS = [triton.Config({}, num_warps=w, num_stages=s) for w in [4, 8] for s in [2, 3]]
+_AUTOTUNE_KEY = [
+    "H",
+    "HV",
+    "K",
+    "V",
+    "BT",
+    "BK",
+    "BV",
+    "IS_RAGGED",
+    "HAS_GK",
+    "STORE_QG",
+    "PRECISION",
+]
+_HEURISTICS = {
+    "STORE_QG": lambda args: args["q"] is not None,
+    "HAS_GK": lambda args: args["gk"] is not None,
+    "IS_RAGGED": lambda args: args["chunk_offsets"] is not None,
+    "USE_INT64_OFFSETS": lambda args: requires_int64_offsets(
+        args["q"],
+        args["k"],
+        args["qg"],
+        args["kg"],
+        args["v"],
+        args["beta"],
+        args["w"],
+        args["u"],
+        args["A"],
+        args["gk"],
+        args["cu_seqlens"],
+        args["chunk_offsets"],
+    ),
+}
+
+
+@triton.jit
+def _recompute_w_u_task(
     q,
     k,
     qg,
@@ -100,6 +110,8 @@ def recompute_w_u_fwd_kernel(
     q_stride_t,
     k_stride_t,
     v_stride_t,
+    i_c,
+    i_hv,
     H: tl.constexpr,
     HV: tl.constexpr,
     K: tl.constexpr,
@@ -115,14 +127,11 @@ def recompute_w_u_fwd_kernel(
     USE_INT64_OFFSETS: tl.constexpr,
 ):
     """Recompute one chunk's W/U (and optional QG/KG) with register-operand dots."""
-    i_c, i_hv = tl.program_id(0), tl.program_id(1)
     if USE_INT64_OFFSETS:
         i_c = i_c.to(tl.int64)
         i_hv = i_hv.to(tl.int64)
     i_h = i_hv // (HV // H)
     if IS_RAGGED:
-        if i_c >= tl.load(chunk_offsets + num_sequences):
-            return
         i_n, i_t, token_start, _ = load_ragged_chunk_work(
             cu_seqlens, chunk_offsets, i_c, num_sequences, BT
         )
@@ -234,7 +243,178 @@ def recompute_w_u_fwd_kernel(
         )
 
 
+@triton.heuristics(_HEURISTICS)
+@triton.autotune(configs=_AUTOTUNE_CONFIGS, key=_AUTOTUNE_KEY, **autotune_cache_kwargs)
+@triton.jit(
+    do_not_specialize=[
+        "T",
+        "num_sequences",
+        "q_stride_t",
+        "k_stride_t",
+        "v_stride_t",
+    ]
+)
+def recompute_w_u_fwd_kernel(
+    q,
+    k,
+    qg,
+    kg,
+    v,
+    beta,
+    w,
+    u,
+    A,
+    gk,
+    cu_seqlens,
+    chunk_offsets,
+    T,
+    q_stride_t,
+    k_stride_t,
+    v_stride_t,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    PRECISION: tl.constexpr,
+    num_sequences,
+    STORE_QG: tl.constexpr,
+    HAS_GK: tl.constexpr,
+    IS_RAGGED: tl.constexpr,
+    USE_INT64_OFFSETS: tl.constexpr,
+):
+    """Launch one CTA per chunk task; ragged capacity-only CTAs exit immediately."""
+    i_c, i_hv = tl.program_id(0), tl.program_id(1)
+    # Not merged with `and`: the constexpr guard must fold away before the
+    # load traces `chunk_offsets`, which is a None pointer on the dense path.
+    if IS_RAGGED:  # noqa: SIM102
+        if i_c >= load_ragged_chunk_count(chunk_offsets, num_sequences):
+            return
+    _recompute_w_u_task(
+        q,
+        k,
+        qg,
+        kg,
+        v,
+        beta,
+        w,
+        u,
+        A,
+        gk,
+        cu_seqlens,
+        chunk_offsets,
+        T,
+        q_stride_t,
+        k_stride_t,
+        v_stride_t,
+        i_c,
+        i_hv,
+        H,
+        HV,
+        K,
+        V,
+        BT,
+        BK,
+        BV,
+        PRECISION,
+        num_sequences,
+        STORE_QG,
+        HAS_GK,
+        IS_RAGGED,
+        USE_INT64_OFFSETS,
+    )
+
+
+@triton.heuristics(_HEURISTICS)
+@triton.autotune(configs=_AUTOTUNE_CONFIGS, key=_AUTOTUNE_KEY, **autotune_cache_kwargs)
+@triton.jit(
+    do_not_specialize=[
+        "T",
+        "num_sequences",
+        "num_workers",
+        "q_stride_t",
+        "k_stride_t",
+        "v_stride_t",
+    ]
+)
+def recompute_w_u_fwd_kernel_persistent(
+    q,
+    k,
+    qg,
+    kg,
+    v,
+    beta,
+    w,
+    u,
+    A,
+    gk,
+    cu_seqlens,
+    chunk_offsets,
+    T,
+    q_stride_t,
+    k_stride_t,
+    v_stride_t,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    PRECISION: tl.constexpr,
+    num_sequences,
+    num_workers,
+    STORE_QG: tl.constexpr,
+    HAS_GK: tl.constexpr,
+    IS_RAGGED: tl.constexpr,
+    USE_INT64_OFFSETS: tl.constexpr,
+):
+    """Stride a bounded worker grid over active (chunk, value-head) tasks."""
+    worker = tl.program_id(0)
+    total_tasks = load_ragged_task_count(chunk_offsets, num_sequences, HV)
+    # num_stages=1 stops the software pipeliner from double-buffering the
+    # outer task loop; the extra SMEM stage costs a resident CTA per SM.
+    for task in tl.range(worker, total_tasks, num_workers, num_stages=1):
+        global_chunk, value_head = decode_ragged_task(task, HV)
+        _recompute_w_u_task(
+            q,
+            k,
+            qg,
+            kg,
+            v,
+            beta,
+            w,
+            u,
+            A,
+            gk,
+            cu_seqlens,
+            chunk_offsets,
+            T,
+            q_stride_t,
+            k_stride_t,
+            v_stride_t,
+            global_chunk,
+            value_head,
+            H,
+            HV,
+            K,
+            V,
+            BT,
+            BK,
+            BV,
+            PRECISION,
+            num_sequences,
+            STORE_QG,
+            HAS_GK,
+            IS_RAGGED,
+            USE_INT64_OFFSETS,
+        )
+
+
 _PINNED_W_U = PinnedConfigKernel(recompute_w_u_fwd_kernel)
+_PINNED_W_U_PERSISTENT = PinnedConfigKernel(recompute_w_u_fwd_kernel_persistent)
 
 
 def recompute_w_u_fwd_triton(
@@ -249,8 +429,14 @@ def recompute_w_u_fwd_triton(
     chunk_size: int = 64,
     dot_precision: str = "bf16",
     autotune: bool = True,
+    schedule: ScheduleRequest = ScheduleRequest.AUTO,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
-    """Launch the register-operand recompute for packed B=1 inputs."""
+    """Launch the register-operand recompute for packed B=1 inputs.
+
+    Args:
+        schedule: Internal scheduling request for tests; automatic selection is
+            the default and dense inputs keep their exact launch grid.
+    """
     batch, tokens, key_heads, key_dim = k.shape
     value_heads, value_dim = v.shape[2], v.shape[3]
     if batch != 1:
@@ -316,35 +502,47 @@ def recompute_w_u_fwd_triton(
     if isinstance(k, FakeTensor):
         return w, u, qg, kg
     chunks = metadata.capacity if metadata is not None else tokens // chunk_size
-    if chunks:
-        kernel = recompute_w_u_fwd_kernel if autotune else _PINNED_W_U
-        kernel[(chunks, value_heads)](
-            q=q if has_q else None,
-            k=k,
-            qg=qg,
-            kg=kg,
-            v=v,
-            beta=beta,
-            w=w,
-            u=u,
-            A=A,
-            gk=gk,
-            cu_seqlens=None if metadata is None else metadata.cu_seqlens,
-            chunk_offsets=None if metadata is None else metadata.chunk_offsets,
-            T=tokens,
-            q_stride_t=q.stride(1) if has_q else 0,
-            k_stride_t=k.stride(1),
-            v_stride_t=v.stride(1),
-            H=key_heads,
-            HV=value_heads,
-            K=key_dim,
-            V=value_dim,
-            BT=chunk_size,
-            BK=64,
-            BV=64,
-            PRECISION=_PRECISION_MODES[dot_precision],
-            num_sequences=0 if metadata is None else metadata.cu_seqlens.shape[0] - 1,
+    kernel_kwargs = {
+        "q": q if has_q else None,
+        "k": k,
+        "qg": qg,
+        "kg": kg,
+        "v": v,
+        "beta": beta,
+        "w": w,
+        "u": u,
+        "A": A,
+        "gk": gk,
+        "cu_seqlens": None if metadata is None else metadata.cu_seqlens,
+        "chunk_offsets": None if metadata is None else metadata.chunk_offsets,
+        "T": tokens,
+        "q_stride_t": q.stride(1) if has_q else 0,
+        "k_stride_t": k.stride(1),
+        "v_stride_t": v.stride(1),
+        "H": key_heads,
+        "HV": value_heads,
+        "K": key_dim,
+        "V": value_dim,
+        "BT": chunk_size,
+        "BK": 64,
+        "BV": 64,
+        "PRECISION": _PRECISION_MODES[dot_precision],
+        "num_sequences": 0 if metadata is None else metadata.cu_seqlens.shape[0] - 1,
+    }
+    kernel = recompute_w_u_fwd_kernel if autotune else _PINNED_W_U
+    if chunks == 0:
+        return w, u, qg, kg
+    if metadata is None:
+        kernel[(chunks, value_heads)](**kernel_kwargs)
+        return w, u, qg, kg
+    resolved = GridScheduler(metadata).resolve_flat(schedule, value_heads, k.device)
+    if resolved.kind is ScheduleKind.PERSISTENT:
+        persistent_kernel = (
+            recompute_w_u_fwd_kernel_persistent if autotune else _PINNED_W_U_PERSISTENT
         )
+        persistent_kernel[(resolved.workers,)](num_workers=resolved.workers, **kernel_kwargs)
+    else:
+        kernel[(chunks, value_heads)](**kernel_kwargs)
     return w, u, qg, kg
 
 

--- a/attn_gym/linear/kda/masking.py
+++ b/attn_gym/linear/kda/masking.py
@@ -1,8 +1,89 @@
-"""Opt-in masking for fixed-capacity packed KDA tensors."""
+"""Opt-in masking for fixed-capacity packed KDA tensors.
+
+Masking is bandwidth-critical under CUDA Graph over-capture: it runs on the
+physical capacity buffer every step. On the eligible eager CUDA path the row
+kernel never reads padding rows (it write-only zeros them) and the gradient
+barrier aliases ``x`` in the forward. Compiled graphs and unsupported layouts
+keep the ``torch.where`` form so Inductor owns fusion.
+"""
 
 from __future__ import annotations
 
 import torch
+
+
+def _mask_inactive_rows(x: torch.Tensor, active_mask: torch.Tensor) -> torch.Tensor:
+    """Use the optional Triton row kernel, falling back to ordinary ATen masking."""
+    try:
+        from attn_gym.linear.kda.fwd.triton.masking import mask_inactive_rows
+    except ModuleNotFoundError as error:
+        if error.name is None or error.name.split(".", 1)[0] != "triton":
+            raise
+        mask = active_mask.reshape(1, -1, *((1,) * (x.ndim - 2)))
+        return torch.where(mask, x, 0)
+
+    return mask_inactive_rows(x, active_mask)
+
+
+class _MaskRows(torch.autograd.Function):
+    """Row masking whose every derivative zeroes inactive tokens.
+
+    ``preserve_values=True`` is the gradient barrier: a zero-copy identity in
+    the forward (the result aliases ``x``) that still masks cotangents and
+    tangents.
+    """
+
+    generate_vmap_rule = True
+
+    @staticmethod
+    def forward(x: torch.Tensor, active_mask: torch.Tensor, preserve_values: bool) -> torch.Tensor:
+        return x if preserve_values else _mask_inactive_rows(x, active_mask)
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        ctx.save_for_backward(inputs[1])
+        ctx.save_for_forward(inputs[1])
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        (active_mask,) = ctx.saved_tensors
+        return _MaskRows.apply(grad_output.contiguous(), active_mask, False), None, None
+
+    @staticmethod
+    def jvp(ctx, tangent: torch.Tensor, _mask_tangent, _preserve_tangent):
+        (active_mask,) = ctx.saved_for_forward
+        return _MaskRows.apply(tangent.contiguous(), active_mask, False)
+
+
+def _use_row_kernel(x: torch.Tensor, active_mask: torch.Tensor) -> bool:
+    """Gate the bandwidth-optimized path to layouts the row kernel supports.
+
+    Compiled graphs keep the where-form so Inductor owns fusion and traced
+    autograd sees ordinary aten semantics; non-contiguous or CPU inputs fall
+    back to the where-form as well.
+    """
+    return (
+        not torch.compiler.is_compiling()
+        and x.is_cuda
+        and x.dtype in {torch.float16, torch.bfloat16, torch.float32}
+        and x.is_contiguous()
+        and active_mask.is_contiguous()
+    )
+
+
+def _validate_packed_mask(x: torch.Tensor, active_mask: torch.Tensor) -> None:
+    """Validate one packed ``[1, T, ...]`` tensor against its token mask."""
+    if x.ndim < 2 or x.shape[0] != 1:
+        raise ValueError(f"x must have packed shape [1, T, ...], got {tuple(x.shape)}")
+    if active_mask.shape != (x.shape[1],):
+        raise ValueError(
+            f"active_mask must have shape [{x.shape[1]}], got {tuple(active_mask.shape)}"
+        )
+    if active_mask.dtype != torch.bool or active_mask.device != x.device:
+        raise ValueError(
+            f"active_mask must be torch.bool on {x.device}, "
+            f"got {active_mask.dtype} on {active_mask.device}"
+        )
 
 
 def active_token_mask(x: torch.Tensor, cu_seqlens: torch.Tensor) -> torch.Tensor:
@@ -39,12 +120,9 @@ def mask_inactive_tokens(
     """
     if active_mask is None:
         return x
-    if x.ndim < 2 or x.shape[0] != 1:
-        raise ValueError(f"x must have packed shape [1, T, ...], got {tuple(x.shape)}")
-    if active_mask.shape != (x.shape[1],):
-        raise ValueError(
-            f"active_mask must have shape [{x.shape[1]}], got {tuple(active_mask.shape)}"
-        )
+    _validate_packed_mask(x, active_mask)
+    if _use_row_kernel(x, active_mask):
+        return _MaskRows.apply(x, active_mask, False)
     mask = active_mask.reshape(1, -1, *((1,) * (x.ndim - 2)))
     return torch.where(mask, x, 0)
 
@@ -56,19 +134,18 @@ def mask_inactive_token_gradients(
     """Preserve values while blocking inactive automatic-differentiation paths.
 
     Place this barrier between a parameterized producer and a primitive that ignores
-    inactive forward rows but leaves their input-gradient suffix undefined. The
-    inactive branch is detached, so automatic-differentiation paths are zero there
-    and subsequent derivatives inherit the same mask. Passing ``None`` returns ``x``
-    unchanged.
+    inactive forward rows but leaves their input-gradient suffix undefined. Forward
+    values pass through unchanged while cotangents and tangents are row-masked, so
+    automatic-differentiation paths are zero on inactive tokens and subsequent
+    derivatives inherit the same mask. On the eligible eager CUDA path the result
+    aliases ``x`` storage; compiled and fallback paths materialize ``torch.where``.
+    Passing ``None`` returns ``x`` unchanged.
     """
     if active_mask is None:
         return x
-    if x.ndim < 2 or x.shape[0] != 1:
-        raise ValueError(f"x must have packed shape [1, T, ...], got {tuple(x.shape)}")
-    if active_mask.shape != (x.shape[1],):
-        raise ValueError(
-            f"active_mask must have shape [{x.shape[1]}], got {tuple(active_mask.shape)}"
-        )
+    _validate_packed_mask(x, active_mask)
+    if _use_row_kernel(x, active_mask):
+        return _MaskRows.apply(x, active_mask, True)
     mask = active_mask.reshape(1, -1, *((1,) * (x.ndim - 2)))
     return torch.where(mask, x, x.detach())
 

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -125,6 +125,15 @@ The repeated ranges are ordinary empty sequences. Stateful APIs therefore retain
 state rows even when only `M` sequences are nonempty. Both `L` and `M` may change on
 replay, but physical token capacity `T` and metadata capacity `N` may not.
 
+Scheduling for this over-capture regime is automatic and selected independently for
+each eligible chunk-parallel ragged kernel: a kernel switches to a bounded persistent
+worker grid only when its capacity task count exceeds a few waves of that grid.
+Persistent workers stride over the active chunk count built on device from
+`cu_seqlens`, so chunk-compute launch overhead tracks active work rather than captured
+capacity. Capacity-sized initialization and reduction work may remain. Exact or mildly
+padded shapes keep capacity-sized STATIC grids whose padding CTAs return immediately; there is no
+user-facing scheduling knob.
+
 Callers that use dynamic active lengths within fixed-capacity tensors must opt in to
 masking. Ragged primitives read only `[0, cu_seqlens[-1])` from token-shaped inputs,
 including output cotangents, and leave the suffix of token-shaped outputs and input
@@ -161,11 +170,13 @@ output = output_projection(output)
 output = mask_inactive_token_gradients(output, active_mask)  # Model boundary.
 ```
 
-`mask_inactive_token_gradients(x, active_mask)` broadcasts the predicate as
-`[1, T, 1, ...]` and evaluates `torch.where(mask, x, x.detach())`. It preserves forward
-values but materializes an elementwise result; its purpose is masked automatic-
-differentiation semantics, not a free forward identity. Automatic-differentiation paths
-are zero on inactive rows, and subsequent derivatives inherit the same mask. Recurrent
+`mask_inactive_token_gradients(x, active_mask)` preserves forward values while zeroing
+inactive automatic-differentiation paths. For contiguous packed CUDA tensors in eager
+mode its autograd path aliases `x` in the forward and row-masks tangents and
+cotangents; compiled graphs and unsupported layouts keep the
+`torch.where(mask, x, x.detach())` form (which materializes an elementwise result) so
+Inductor can own fusion. Automatic-differentiation paths are zero on inactive rows,
+and subsequent derivatives inherit the same mask. Recurrent
 and convolution states have one row per logical sequence rather than one row per physical
 token, so token masks must not be applied to them.
 
@@ -203,9 +214,9 @@ corrected-value intermediates instead of retaining them across the forward/backw
 boundary.
 
 Graph-safe active-token replay does not by itself make complete model time proportional
-to `L`. The ragged short convolution, gate scan, and KDA core can skip inactive token
-work, but the example's projections, output normalization, output gate, and output
-projection still process physical capacity `T`. An end-to-end integration needs
+to `L`. The ragged short convolution, gate scan, and KDA core avoid reading inactive
+token values, but the example's projections, output normalization, output gate, and
+output projection still process physical capacity `T`. An end-to-end integration needs
 active-prefix-aware surrounding operations to turn smaller `L` into a comparable step-time
 reduction. Million-token training also requires model-level activation checkpointing and
 context parallelism; this single-device example implements neither distributed policy.

--- a/test/test_kda_chunk_scheduler.py
+++ b/test/test_kda_chunk_scheduler.py
@@ -9,11 +9,23 @@ from pathlib import Path
 
 import pytest
 import torch
+import triton
+import triton.language as tl
 
 from attn_gym.linear.kda.chunk_scheduler import (
+    PERSISTENT_AUTO_WAVES,
+    PERSISTENT_CTAS_PER_SM,
+    GridScheduler,
+    RaggedChunkMetadata,
+    ResolvedSchedule,
+    ScheduleKind,
+    ScheduleRequest,
     chunk_capacity,
     chunk_work_oracle,
     decode_ragged_chunk_work,
+    decode_ragged_task,
+    load_ragged_chunk_count,
+    load_ragged_task_count,
     prepare_ragged_chunk_metadata,
 )
 
@@ -21,6 +33,23 @@ pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available(),
     reason="the KDA chunk scheduler requires CUDA",
 )
+
+
+@triton.jit
+def _load_ragged_task_count_kernel(chunk_offsets, output, subtasks_per_chunk):
+    tl.store(output, load_ragged_task_count(chunk_offsets, 0, subtasks_per_chunk))
+
+
+@triton.jit
+def _decode_ragged_task_kernel(task, subtasks_per_chunk, output):
+    global_chunk, subtask = decode_ragged_task(task, subtasks_per_chunk)
+    tl.store(output, global_chunk)
+    tl.store(output + 1, subtask)
+
+
+@triton.jit
+def _load_ragged_chunk_count_kernel(chunk_offsets, output):
+    tl.store(output, load_ragged_chunk_count(chunk_offsets, 0))
 
 
 def _expected_tensor(lengths: list[int], chunk_size: int) -> tuple[torch.Tensor, list[int]]:
@@ -275,3 +304,114 @@ def test_cute_chunk_scheduler_cuda_graph_replays_boundaries():
             actual[expected.shape[0] :, warp].cpu(),
             torch.full_like(actual[expected.shape[0] :, warp].cpu(), -1),
         )
+
+
+def test_grid_scheduler_persistent_grid_is_machine_derived():
+    sm_count = torch.cuda.get_device_properties("cuda").multi_processor_count
+    metadata = RaggedChunkMetadata(None, None, capacity=1 << 20, chunk_size=64)
+    scheduler = GridScheduler(metadata)
+    assert scheduler.num_workers(6, "cuda") == sm_count * PERSISTENT_CTAS_PER_SM
+    # Tiny capacity never over-launches workers, and zero capacity launches nothing.
+    assert GridScheduler(metadata._replace(capacity=2)).num_workers(3, "cuda") == 6
+    assert GridScheduler(metadata._replace(capacity=0)).num_workers(3, "cuda") == 0
+
+
+def test_grid_scheduler_chunk_workers_cap_at_sm_count():
+    sm_count = torch.cuda.get_device_properties("cuda").multi_processor_count
+    metadata = RaggedChunkMetadata(None, None, capacity=1 << 20, chunk_size=64)
+    scheduler = GridScheduler(metadata)
+    assert scheduler.num_chunk_workers("cuda") == sm_count
+    # Sub-SM capacities quantize up to the next power of two to bound the
+    # TVM-FFI compile cache; extra workers idle in the stride loop.
+    assert GridScheduler(metadata._replace(capacity=3)).num_chunk_workers("cuda") == 4
+    assert GridScheduler(metadata._replace(capacity=0)).num_chunk_workers("cuda") == 0
+
+
+def test_persistent_task_count_promotes_before_multiplication():
+    chunk_offsets = torch.tensor([1_500_000_000], device="cuda", dtype=torch.int32)
+    output = torch.empty((), device="cuda", dtype=torch.int64)
+    _load_ragged_task_count_kernel[(1,)](chunk_offsets, output, 2)
+    assert output.item() == 3_000_000_000
+
+
+def test_ragged_task_helpers_load_and_decode_flat_work():
+    chunk_offsets = torch.tensor([4], device="cuda", dtype=torch.int32)
+    count = torch.empty((), device="cuda", dtype=torch.int64)
+    decoded = torch.empty(2, device="cuda", dtype=torch.int64)
+
+    _load_ragged_chunk_count_kernel[(1,)](chunk_offsets, count)
+    _decode_ragged_task_kernel[(1,)](3_000_000_001, 3, decoded)
+
+    assert count.item() == 4
+    assert decoded.tolist() == [1_000_000_000, 1]
+
+
+@pytest.mark.parametrize(
+    ("schedule_request", "eligible", "capacity_tasks", "expected_kind", "raises"),
+    (
+        (ScheduleRequest.AUTO, True, 400, ScheduleKind.STATIC, False),
+        (ScheduleRequest.AUTO, True, 401, ScheduleKind.PERSISTENT, False),
+        (ScheduleRequest.AUTO, False, 401, ScheduleKind.STATIC, False),
+        (ScheduleRequest.STATIC, True, 401, ScheduleKind.STATIC, False),
+        (ScheduleRequest.STATIC, False, 401, ScheduleKind.STATIC, False),
+        (ScheduleRequest.PERSISTENT, True, 1, ScheduleKind.PERSISTENT, False),
+        (ScheduleRequest.PERSISTENT, True, 0, ScheduleKind.STATIC, False),
+        (ScheduleRequest.PERSISTENT, False, 401, None, True),
+        (ScheduleRequest.PERSISTENT, False, 0, None, True),
+    ),
+)
+def test_grid_scheduler_resolves_flat_plan_contract(
+    monkeypatch,
+    schedule_request,
+    eligible,
+    capacity_tasks,
+    expected_kind,
+    raises,
+):
+    workers = 100
+    assert PERSISTENT_AUTO_WAVES * workers == 400
+    metadata = RaggedChunkMetadata(None, None, capacity_tasks, 64)
+    scheduler = GridScheduler(metadata)
+    monkeypatch.setattr(GridScheduler, "num_workers", lambda self, subtasks, device: workers)
+
+    if raises:
+        with pytest.raises(ValueError, match="persistent scheduling requires"):
+            scheduler.resolve_flat(schedule_request, 1, "cuda", eligible=eligible)
+        return
+
+    resolved = scheduler.resolve_flat(schedule_request, 1, "cuda", eligible=eligible)
+    assert resolved == ResolvedSchedule(expected_kind, workers, capacity_tasks)
+
+
+def test_grid_scheduler_rejects_legacy_boolean_requests(monkeypatch):
+    metadata = RaggedChunkMetadata(None, None, capacity=1, chunk_size=64)
+    monkeypatch.setattr(GridScheduler, "num_workers", lambda self, subtasks, device: 1)
+
+    with pytest.raises(TypeError, match="ScheduleRequest"):
+        GridScheduler(metadata).resolve_flat(True, 1, "cuda")
+
+
+@pytest.mark.parametrize(
+    ("schedule_request", "capacity", "expected_kind"),
+    (
+        (ScheduleRequest.AUTO, 256, ScheduleKind.STATIC),
+        (ScheduleRequest.AUTO, 257, ScheduleKind.PERSISTENT),
+        (ScheduleRequest.STATIC, 512, ScheduleKind.STATIC),
+        (ScheduleRequest.PERSISTENT, 512, ScheduleKind.PERSISTENT),
+        (ScheduleRequest.PERSISTENT, 0, ScheduleKind.STATIC),
+    ),
+)
+def test_grid_scheduler_chunk_plan_uses_the_same_resolved_type(
+    monkeypatch, schedule_request, capacity, expected_kind
+):
+    metadata = RaggedChunkMetadata(None, None, capacity=capacity, chunk_size=64)
+    monkeypatch.setattr(
+        GridScheduler,
+        "num_chunk_workers",
+        lambda self, device: 0 if self.metadata.capacity == 0 else 64,
+    )
+
+    resolved = GridScheduler(metadata).resolve_chunk(schedule_request, "cuda")
+
+    expected_workers = 0 if capacity == 0 else 64
+    assert resolved == ResolvedSchedule(expected_kind, expected_workers, capacity)

--- a/test/test_kda_cute_inter_solve.py
+++ b/test/test_kda_cute_inter_solve.py
@@ -29,6 +29,47 @@ def test_inter_solve_rejects_unsupported_specializations(
         _validate_specialization(head_dim, chunk_size, subchunk_size)
 
 
+def test_ragged_fake_tensors_reject_legacy_boolean_schedule():
+    pytest.importorskip("cutlass")
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    from attn_gym.linear.kda.chunk_schedule import RaggedChunkMetadata
+    from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd_inter_solve import (
+        chunk_kda_fwd_k3b_ragged_cute,
+        chunk_kda_fwd_k4b_ragged_cute,
+    )
+
+    with FakeTensorMode():
+        q = torch.empty(1, 64, 1, 128, device="cuda", dtype=torch.bfloat16)
+        g = torch.empty(1, 64, 1, 128, device="cuda")
+        beta = torch.empty(1, 64, 1, device="cuda")
+        aqk = torch.empty(1, 64, 1, 64, device="cuda", dtype=torch.bfloat16)
+        offsets = torch.empty(2, device="cuda", dtype=torch.int32)
+        metadata = RaggedChunkMetadata(offsets, offsets, capacity=1, chunk_size=64)
+
+        with pytest.raises(TypeError, match="ScheduleRequest"):
+            chunk_kda_fwd_k3b_ragged_cute(
+                q,
+                q,
+                g,
+                beta,
+                aqk,
+                128**-0.5,
+                metadata,
+                schedule=True,
+            )
+
+        offdiagonal = torch.empty(6, 256, device="cuda")
+        diagonal = torch.empty(1, 64, 1, 16, device="cuda")
+        with pytest.raises(TypeError, match="ScheduleRequest"):
+            chunk_kda_fwd_k4b_ragged_cute(
+                offdiagonal,
+                diagonal,
+                metadata,
+                schedule=False,
+            )
+
+
 @pytest.mark.skipif(
     not torch.cuda.is_available() or torch.cuda.get_device_capability() < (10, 0),
     reason="the CuTeDSL KDA inter-solve requires CUDA capability 10.0 or newer",

--- a/test/test_kda_cute_recompute.py
+++ b/test/test_kda_cute_recompute.py
@@ -9,6 +9,7 @@ import torch
 
 from attn_gym.linear.kda.chunk_scheduler import (
     RaggedChunkMetadata,
+    ScheduleRequest,
     prepare_ragged_chunk_metadata,
 )
 
@@ -242,3 +243,93 @@ def test_recompute_supports_grouped_value_heads():
     torch.testing.assert_close(kg, kg_c, rtol=0, atol=0)
     torch.testing.assert_close(w.float(), w_c.float(), rtol=2e-2, atol=2e-2)
     torch.testing.assert_close(u.float(), u_c.float(), rtol=2e-2, atol=2e-2)
+
+
+def _chunkwise_reference(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    A: torch.Tensor,
+    gk: torch.Tensor,
+    bounds: list[int],
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Evaluate W/U in fp32 over the active sequence-local 64-token chunks."""
+    w = torch.zeros_like(k, dtype=torch.float32)
+    u = torch.zeros_like(v, dtype=torch.float32)
+    for start, end in pairwise(bounds):
+        for chunk_start in range(start, end, 64):
+            chunk_end = min(chunk_start + 64, end)
+            rows = chunk_end - chunk_start
+            a = A[0, chunk_start:chunk_end, :, :rows].float().permute(1, 0, 2).tril()
+            scaled_beta = beta[0, chunk_start:chunk_end, :, None].float()
+            gate = torch.exp2(gk[0, chunk_start:chunk_end].float())
+            kb = (k[0, chunk_start:chunk_end].float() * scaled_beta * gate).permute(1, 0, 2)
+            vb = (v[0, chunk_start:chunk_end].float() * scaled_beta).permute(1, 0, 2)
+            w[0, chunk_start:chunk_end] = (a @ kb).permute(1, 0, 2)
+            u[0, chunk_start:chunk_end] = (a @ vb).permute(1, 0, 2)
+    return w, u
+
+
+def test_recompute_persistent_matches_static_over_capacity():
+    """Persistent scheduling must be bit-identical to static scheduling."""
+    from attn_gym.linear.kda.fwd.triton.recompute_w_u import recompute_w_u_fwd_triton
+
+    torch.manual_seed(9)
+    lengths = [65, 0, 63]
+    active = sum(lengths)
+    capacity_tokens = 16 * active
+    bounds = [0, *torch.tensor(lengths).cumsum(0).tolist()]
+    offsets = torch.tensor(bounds, device="cuda", dtype=torch.int32)
+    metadata = prepare_ragged_chunk_metadata(offsets, capacity_tokens, 64)
+    assert metadata.capacity >= 8 * ((active + 63) // 64)
+
+    heads = 2
+    k = torch.randn(1, capacity_tokens, heads, 128, device="cuda", dtype=torch.bfloat16) / 8
+    v = torch.randn_like(k) / 8
+    q = torch.randn_like(k) / 8
+    gk = -torch.rand(1, capacity_tokens, heads, 128, device="cuda", dtype=torch.float32)
+    beta = torch.rand(1, capacity_tokens, heads, device="cuda")
+    A = torch.randn(1, capacity_tokens, heads, 64, device="cuda", dtype=torch.float32) / 8
+
+    # Pin the config so bit-equality does not depend on two independent
+    # autotune winners choosing the same accumulation shape.
+    static = recompute_w_u_fwd_triton(k, v, beta, A, metadata, q=q, gk=gk, autotune=False)
+    persistent = recompute_w_u_fwd_triton(
+        k,
+        v,
+        beta,
+        A,
+        metadata,
+        q=q,
+        gk=gk,
+        autotune=False,
+        schedule=ScheduleRequest.PERSISTENT,
+    )
+    for static_tensor, persistent_tensor in zip(static, persistent, strict=True):
+        assert torch.equal(persistent_tensor[:, :active], static_tensor[:, :active])
+
+    expected_w, expected_u = _chunkwise_reference(k, v, beta, A, gk, bounds)
+    torch.testing.assert_close(
+        persistent[0][:, :active].float(), expected_w[:, :active], rtol=2e-2, atol=2e-2
+    )
+    torch.testing.assert_close(
+        persistent[1][:, :active].float(), expected_u[:, :active], rtol=2e-2, atol=2e-2
+    )
+
+
+def test_recompute_persistent_is_noop_for_dense():
+    """Dense launch grids are already exact, so the request is trivially satisfied."""
+    from attn_gym.linear.kda.fwd.triton.recompute_w_u import recompute_w_u_fwd_triton
+
+    torch.manual_seed(5)
+    k = torch.randn(1, 64, 1, 128, device="cuda", dtype=torch.bfloat16) / 8
+    v = torch.randn_like(k) / 8
+    beta = torch.rand(1, 64, 1, device="cuda")
+    A = torch.randn(1, 64, 1, 64, device="cuda", dtype=torch.bfloat16).tril() / 8
+
+    dense = recompute_w_u_fwd_triton(k, v, beta, A, None)
+    dense_persistent = recompute_w_u_fwd_triton(
+        k, v, beta, A, None, schedule=ScheduleRequest.PERSISTENT
+    )
+    for actual, other in zip(dense_persistent, dense, strict=True):
+        assert (actual is None and other is None) or torch.equal(actual, other)

--- a/test/test_kda_imports.py
+++ b/test/test_kda_imports.py
@@ -35,7 +35,19 @@ def test_reference_api_imports_without_optional_kernel_dependencies():
 
         builtins.__import__ = reject_optional_backends
 
-        from attn_gym.linear import chunk_kda, recurrent_kda
+        from attn_gym.linear import (
+            active_token_mask,
+            chunk_kda,
+            mask_inactive_token_gradients,
+            mask_inactive_tokens,
+            recurrent_kda,
+        )
+
+        packed = torch.randn(1, 3, 2)
+        offsets = torch.tensor([0, 2], dtype=torch.int32)
+        mask = active_token_mask(packed, offsets)
+        mask_inactive_tokens(packed, mask)
+        mask_inactive_token_gradients(packed, mask)
 
         shape = (1, 3, 1, 2)
         q = torch.randn(shape)
@@ -45,6 +57,33 @@ def test_reference_api_imports_without_optional_kernel_dependencies():
         beta = torch.rand(shape[:3])
         recurrent_kda(q, k, v, gate, beta, impl='reference')
         chunk_kda(q, k, v, gate, beta, impl='reference')
+        """
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA fallback requires a CUDA device")
+def test_masking_cuda_falls_back_without_triton():
+    """Keep CUDA masking functional when the optional Triton package is absent."""
+    run_fresh_python(
+        """
+        import builtins
+        import torch
+
+        values = torch.tensor([[[1.0], [2.0]]], device='cuda')
+        active_mask = torch.tensor([True, False], device='cuda')
+        original_import = builtins.__import__
+
+        def reject_triton(name, *args, **kwargs):
+            if name.split('.', 1)[0] == 'triton':
+                raise ModuleNotFoundError(name=name)
+            return original_import(name, *args, **kwargs)
+
+        builtins.__import__ = reject_triton
+
+        from attn_gym.linear import mask_inactive_tokens
+
+        actual = mask_inactive_tokens(values, active_mask)
+        torch.testing.assert_close(actual, torch.tensor([[[1.0], [0.0]]], device='cuda'))
         """
     )
 

--- a/test/test_kda_kernels.py
+++ b/test/test_kda_kernels.py
@@ -705,7 +705,7 @@ def test_chunk_delta_h_fwd_fp32_path():
     # TF32 mantissa error compounds through the sequential state updates, so
     # this is a path-coverage check at TF32 tolerances, not a precision
     # guarantee (the dots ran in TF32 before this kernel, too).
-    tf32 = dict(atol=1e-1, rtol=5e-2)
+    tf32 = {"atol": 1e-1, "rtol": 5e-2}
     torch.testing.assert_close(
         h[:, :num_chunks].reshape(B * num_chunks, H, K, V).double(), gh, **tf32
     )

--- a/test/test_kda_masking.py
+++ b/test/test_kda_masking.py
@@ -15,6 +15,17 @@ pytestmark = pytest.mark.skipif(
 )
 
 
+def test_unsupported_row_kernel_dtype_uses_torch_fallback():
+    values = torch.tensor([[[1 + 2j], [3 + 4j]]], device="cuda", dtype=torch.complex64)
+    active_mask = torch.tensor([True, False], device="cuda")
+
+    sanitized = mask_inactive_tokens(values, active_mask)
+    protected = mask_inactive_token_gradients(values, active_mask)
+
+    torch.testing.assert_close(sanitized, torch.tensor([[[1 + 2j], [0j]]], device="cuda"))
+    torch.testing.assert_close(protected, values)
+
+
 def test_mask_inactive_tokens_fullgraph_autograd():
     values = torch.arange(8, device="cuda", dtype=torch.float32).reshape(1, 4, 2)
     values[:, 2:] = float("nan")

--- a/test/test_kda_ragged_bwd_dav.py
+++ b/test/test_kda_ragged_bwd_dav.py
@@ -6,7 +6,7 @@ import pytest
 import torch
 
 from attn_gym.linear.kda.bwd.triton.chunk_kda_bwd_dav import chunk_kda_bwd_dav
-from attn_gym.linear.kda.chunk_scheduler import prepare_ragged_chunk_metadata
+from attn_gym.linear.kda.chunk_scheduler import ScheduleRequest, prepare_ragged_chunk_metadata
 from attn_gym.testing import cumulative_sequence_offsets
 
 pytestmark = pytest.mark.skipif(
@@ -18,11 +18,11 @@ _CHUNK_SIZE = 64
 _SCALE = 128**-0.5
 
 
-def _inputs(tokens: int) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+def _inputs(tokens: int, heads: int = 1) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     torch.manual_seed(31)
-    shape = (1, tokens, 1, 128)
+    shape = (1, tokens, heads, 128)
     v = torch.randn(shape, device="cuda", dtype=torch.bfloat16) / 8
-    A = torch.randn(1, tokens, 1, _CHUNK_SIZE, device="cuda", dtype=torch.bfloat16) / 8
+    A = torch.randn(1, tokens, heads, _CHUNK_SIZE, device="cuda", dtype=torch.bfloat16) / 8
     do = torch.randn_like(v) / 8
     return v, A, do
 
@@ -32,11 +32,13 @@ def _run_ragged(
     A: torch.Tensor,
     do: torch.Tensor,
     lengths: list[int],
+    *,
+    schedule: ScheduleRequest = ScheduleRequest.STATIC,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     metadata = prepare_ragged_chunk_metadata(
         cumulative_sequence_offsets(lengths), v.shape[1], _CHUNK_SIZE
     )
-    return chunk_kda_bwd_dav(v, A, do, _SCALE, metadata=metadata)
+    return chunk_kda_bwd_dav(v, A, do, _SCALE, metadata=metadata, schedule=schedule)
 
 
 def _independent_sequences(
@@ -118,3 +120,76 @@ def test_ragged_bwd_dav_replays_aligned_to_ragged():
     assert metadata.chunk_offsets.tolist() == [0, 2, 3]
     for replayed, independent in zip(actual, expected, strict=True):
         torch.testing.assert_close(replayed, independent, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] < 9,
+    reason="persistent scheduling requires the TMA path",
+)
+@pytest.mark.parametrize("lengths", [[65, 63], [1, 64, 0, 65]])
+@pytest.mark.parametrize("heads", [1, 2])
+def test_persistent_ragged_bwd_dav_matches_static_over_capacity(lengths, heads):
+    """Stay bit-identical to static scheduling when capacity dwarfs active work."""
+    tokens = sum(lengths)
+    inputs = _inputs(16 * tokens, heads)
+    metadata = prepare_ragged_chunk_metadata(
+        cumulative_sequence_offsets(lengths), inputs[0].shape[1], _CHUNK_SIZE
+    )
+    assert metadata.capacity >= 8 * metadata.chunk_offsets[-1].item()
+
+    static = _run_ragged(*inputs, lengths)
+    persistent = _run_ragged(*inputs, lengths, schedule=ScheduleRequest.PERSISTENT)
+    expected = _independent_sequences(*inputs, lengths)
+
+    for actual, reference in zip(persistent, expected, strict=True):
+        torch.testing.assert_close(actual[:, :tokens], reference, rtol=0, atol=0)
+    for actual, other in zip(persistent, static, strict=True):
+        assert torch.equal(actual[:, :tokens], other[:, :tokens])
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] < 9,
+    reason="persistent scheduling requires the TMA path",
+)
+def test_persistent_ragged_bwd_dav_handles_zero_capacity():
+    inputs = _inputs(0)
+    actual = _run_ragged(*inputs, [0, 0], schedule=ScheduleRequest.PERSISTENT)
+
+    assert actual[0].shape == inputs[0].shape
+    assert actual[1].shape == inputs[1].shape
+
+    # Zero capacity has nothing to schedule, so even the off-TMA V=64 layout
+    # returns instead of raising the persistent-eligibility error.
+    v, A, do = inputs
+    metadata = prepare_ragged_chunk_metadata(cumulative_sequence_offsets([0, 0]), 0, _CHUNK_SIZE)
+    dv, dA = chunk_kda_bwd_dav(
+        v[..., :64],
+        A,
+        do[..., :64],
+        _SCALE,
+        metadata=metadata,
+        schedule=ScheduleRequest.PERSISTENT,
+    )
+    assert dv.shape == v[..., :64].shape
+    assert dA.shape == A.shape
+
+
+def test_persistent_ragged_bwd_dav_requires_packed_tma_path():
+    v, A, do = _inputs(64)
+    metadata = prepare_ragged_chunk_metadata(cumulative_sequence_offsets([64]), 64, _CHUNK_SIZE)
+
+    with pytest.raises(ValueError, match="persistent scheduling requires the packed TMA path"):
+        chunk_kda_bwd_dav(
+            v[..., :64],
+            A,
+            do[..., :64],
+            _SCALE,
+            metadata=metadata,
+            schedule=ScheduleRequest.PERSISTENT,
+        )
+
+    # Dense launch grids are already exact, so the request is trivially satisfied.
+    dense = chunk_kda_bwd_dav(v, A, do, _SCALE)
+    dense_persistent = chunk_kda_bwd_dav(v, A, do, _SCALE, schedule=ScheduleRequest.PERSISTENT)
+    for actual, other in zip(dense_persistent, dense, strict=True):
+        assert torch.equal(actual, other)

--- a/test/test_kda_ragged_gate.py
+++ b/test/test_kda_ragged_gate.py
@@ -16,11 +16,13 @@ from torch._inductor import config as inductor_config
 
 pytest.importorskip("triton")
 
-from attn_gym.linear.kda.chunk_scheduler import prepare_ragged_chunk_metadata
+from attn_gym.linear.kda.bwd.triton.gate_bwd import kda_gate_bwd_ragged
+from attn_gym.linear.kda.chunk_scheduler import ScheduleRequest, prepare_ragged_chunk_metadata
 from attn_gym.linear.kda.fwd.triton.gate_fwd import (
     _bounded_gate_cumsum_ragged_bwd_op,
     _bounded_gate_cumsum_ragged_fwd_op,
     bounded_gate_cumsum,
+    bounded_gate_cumsum_ragged,
 )
 from attn_gym.linear.kda.utils import RCP_LN2
 from attn_gym.testing.kda import clone_kda_inputs, cumulative_sequence_offsets
@@ -339,6 +341,151 @@ def test_bounded_gate_cumsum_rejects_packed_batch_and_fastmath():
             cu_seqlens=cumulative_sequence_offsets([64]),
             fastmath=True,
         )
+
+
+def _gate_bwd(
+    inputs: tuple[torch.Tensor, ...],
+    d_cumulative: torch.Tensor,
+    metadata,
+    *,
+    schedule: ScheduleRequest,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Differentiate the packed gate directly, bypassing the autograd composition."""
+    return kda_gate_bwd_ragged(
+        *inputs,
+        d_cumulative,
+        metadata,
+        lower_bound=LOWER_BOUND,
+        scale=RCP_LN2,
+        schedule=schedule,
+    )
+
+
+@pytest.mark.parametrize("head_dim", (128, 1024))
+def test_kda_gate_bwd_ragged_persistent_matches_static_over_capacity(head_dim):
+    """Stay bit-identical to static scheduling when capacity dwarfs active work."""
+    lengths = [65, 0, 63]
+    active_tokens = sum(lengths)
+    raw_gate, A_log, dt_bias, d_cumulative = _inputs(16 * active_tokens, head_dim=head_dim)
+    _poison_inactive_suffix(raw_gate, d_cumulative, active_tokens)
+    cu_seqlens = cumulative_sequence_offsets(lengths)
+    metadata = prepare_ragged_chunk_metadata(cu_seqlens, raw_gate.shape[1], 64)
+    assert metadata.capacity >= 8 * metadata.chunk_offsets[-1].item()
+
+    inputs = (raw_gate, A_log, dt_bias)
+    static = _gate_bwd(inputs, d_cumulative, metadata, schedule=ScheduleRequest.STATIC)
+    persistent = _gate_bwd(inputs, d_cumulative, metadata, schedule=ScheduleRequest.PERSISTENT)
+
+    assert torch.equal(persistent[0][:, :active_tokens], static[0][:, :active_tokens])
+    for actual, other in zip(persistent[1:], static[1:], strict=True):
+        assert torch.equal(actual, other)
+
+    leaves = _leaves(*inputs)
+    expected_output = _active_reference(*leaves, lengths, 64)
+    expected = torch.autograd.grad(expected_output, leaves, d_cumulative[:, :active_tokens])
+    torch.testing.assert_close(
+        persistent[0][:, :active_tokens], expected[0][:, :active_tokens], rtol=BF16_EPS, atol=1e-6
+    )
+    for actual, reference in zip(persistent[1:], expected[1:], strict=True):
+        torch.testing.assert_close(actual, reference, rtol=5e-5, atol=7e-4)
+
+
+def test_kda_gate_bwd_ragged_persistent_handles_zero_capacity():
+    """Reduce capacity-sized partials to zero parameter gradients with nothing launched."""
+    raw_gate, A_log, dt_bias, d_cumulative = _inputs(0)
+    metadata = prepare_ragged_chunk_metadata(cumulative_sequence_offsets([0]), 0, 64)
+    assert metadata.capacity == 0
+
+    dg, dA_log, ddt_bias = _gate_bwd(
+        (raw_gate, A_log, dt_bias),
+        d_cumulative,
+        metadata,
+        schedule=ScheduleRequest.PERSISTENT,
+    )
+
+    assert dg.shape == raw_gate.shape
+    torch.testing.assert_close(dA_log, torch.zeros_like(A_log), rtol=0, atol=0)
+    torch.testing.assert_close(ddt_bias, torch.zeros_like(dt_bias), rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("head_dim", (96, 128, 1024))
+def test_bounded_gate_cumsum_persistent_matches_static_over_capacity(head_dim):
+    """Stride a fixed worker grid over the active chunks far below capacity."""
+    lengths = [65, 0, 63]
+    active_tokens = sum(lengths)
+    capacity_tokens = 16 * active_tokens
+    raw_gate, A_log, dt_bias, _ = _inputs(capacity_tokens, head_dim=head_dim)
+    with torch.no_grad():
+        raw_gate[:, active_tokens:].fill_(torch.nan)
+    cu_seqlens = cumulative_sequence_offsets(lengths)
+    metadata = prepare_ragged_chunk_metadata(cu_seqlens, capacity_tokens, 64)
+    assert metadata.capacity >= 8 * ((active_tokens + 63) // 64)
+
+    static = bounded_gate_cumsum_ragged(
+        raw_gate,
+        A_log,
+        dt_bias,
+        metadata,
+        lower_bound=LOWER_BOUND,
+        schedule=ScheduleRequest.STATIC,
+    )
+    persistent = bounded_gate_cumsum_ragged(
+        raw_gate,
+        A_log,
+        dt_bias,
+        metadata,
+        lower_bound=LOWER_BOUND,
+        schedule=ScheduleRequest.PERSISTENT,
+    )
+    expected = _active_reference(raw_gate, A_log, dt_bias, lengths, 64)
+
+    assert torch.equal(persistent[:, :active_tokens], static[:, :active_tokens])
+    torch.testing.assert_close(persistent[:, :active_tokens], expected, rtol=1e-6, atol=8e-5)
+
+
+def test_bounded_gate_cumsum_persistent_handles_zero_capacity():
+    """Skip the launch entirely when the schedule holds no chunks."""
+    raw_gate, A_log, dt_bias, _ = _inputs(0)
+    metadata = prepare_ragged_chunk_metadata(cumulative_sequence_offsets([0]), 0, 64)
+    assert metadata.capacity == 0
+
+    output = bounded_gate_cumsum_ragged(
+        raw_gate,
+        A_log,
+        dt_bias,
+        metadata,
+        lower_bound=LOWER_BOUND,
+        schedule=ScheduleRequest.PERSISTENT,
+    )
+
+    assert output.shape == raw_gate.shape
+
+
+def test_kda_gate_bwd_ragged_persistent_strides_multiple_tasks_per_worker(monkeypatch):
+    """Force fewer workers than tasks so the stride loop iterates repeatedly."""
+    from attn_gym.linear.kda import chunk_scheduler
+
+    monkeypatch.setattr(chunk_scheduler.GridScheduler, "num_workers", lambda self, s, d: 2)
+    lengths = [65, 0, 63, 130]
+    raw_gate, A_log, dt_bias, d_cumulative = _inputs(sum(lengths))
+    metadata = prepare_ragged_chunk_metadata(
+        cumulative_sequence_offsets(lengths), raw_gate.shape[1], 64
+    )
+
+    static = _gate_bwd(
+        (raw_gate, A_log, dt_bias),
+        d_cumulative,
+        metadata,
+        schedule=ScheduleRequest.STATIC,
+    )
+    persistent = _gate_bwd(
+        (raw_gate, A_log, dt_bias),
+        d_cumulative,
+        metadata,
+        schedule=ScheduleRequest.PERSISTENT,
+    )
+    for actual, other in zip(persistent, static, strict=True):
+        assert torch.equal(actual, other)
 
 
 def test_kda_gate_bwd_offset_width_specializations_match(monkeypatch):

--- a/test/test_kda_ragged_k3.py
+++ b/test/test_kda_ragged_k3.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 import torch
 
-from attn_gym.linear.kda.chunk_scheduler import prepare_ragged_chunk_metadata
+from attn_gym.linear.kda.chunk_scheduler import ScheduleRequest, prepare_ragged_chunk_metadata
 from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd_inter_solve import (
     chunk_kda_fwd_k3b_ragged_cute,
 )
@@ -29,7 +29,11 @@ def _inputs(tokens: int):
     return q, k, g, beta, Aqk
 
 
-def _run(inputs, lengths: list[int]):
+def _run(
+    inputs,
+    lengths: list[int],
+    schedule: ScheduleRequest = ScheduleRequest.AUTO,
+):
     tokens = sum(lengths)
     cu_seqlens = cumulative_sequence_offsets(lengths)
     metadata = prepare_ragged_chunk_metadata(cu_seqlens, tokens, 64)
@@ -37,6 +41,7 @@ def _run(inputs, lengths: list[int]):
         *inputs,
         scale=128**-0.5,
         metadata=metadata,
+        schedule=schedule,
     )
     return metadata, Aqk, AkkOD
 
@@ -136,8 +141,9 @@ def test_ragged_k3_matches_pytorch_reference(lengths):
 
 
 @pytest.mark.parametrize("lengths", [[0], [0, 0, 0]])
-def test_ragged_k3_accepts_all_empty_sequences(lengths):
-    metadata, Aqk, AkkOD = _run(_inputs(0), lengths)
+@pytest.mark.parametrize("schedule", [ScheduleRequest.AUTO, ScheduleRequest.PERSISTENT])
+def test_ragged_k3_accepts_all_empty_sequences(lengths, schedule):
+    metadata, Aqk, AkkOD = _run(_inputs(0), lengths, schedule)
 
     assert Aqk.shape == (1, 0, 1, 64)
     assert AkkOD.shape == (metadata.capacity * 6, 256)
@@ -171,7 +177,8 @@ def test_ragged_k3_rejects_mismatched_metadata_chunk_size():
         )
 
 
-def test_ragged_k3_replays_aligned_to_ragged():
+@pytest.mark.parametrize("schedule", [ScheduleRequest.STATIC, ScheduleRequest.PERSISTENT])
+def test_ragged_k3_replays_aligned_to_ragged(schedule):
     inputs = _inputs(128)
     cu_seqlens = torch.tensor([0, 64, 128], device="cuda", dtype=torch.int32)
     warm_metadata = prepare_ragged_chunk_metadata(cu_seqlens, 128, 64)
@@ -179,6 +186,7 @@ def test_ragged_k3_replays_aligned_to_ragged():
         *inputs,
         scale=128**-0.5,
         metadata=warm_metadata,
+        schedule=schedule,
     )
     torch.cuda.synchronize()
 
@@ -189,6 +197,7 @@ def test_ragged_k3_replays_aligned_to_ragged():
             *inputs,
             scale=128**-0.5,
             metadata=metadata,
+            schedule=schedule,
         )
 
     cu_seqlens.copy_(torch.tensor([0, 65, 128], device="cuda", dtype=torch.int32))
@@ -198,3 +207,72 @@ def test_ragged_k3_replays_aligned_to_ragged():
     expected_aqk, expected_akk_od = _k3_reference(inputs, [65, 63])
     assert metadata.chunk_offsets.tolist() == [0, 2, 3]
     _assert_matches_reference(actual_aqk, actual_akk_od, expected_aqk, expected_akk_od)
+
+
+def test_persistent_ragged_k3_matches_static_over_capacity():
+    """Stride a fixed chunk-worker grid over active chunks far below capacity."""
+    lengths = [65, 63]
+    active_tokens = sum(lengths)
+    capacity_tokens = 16 * active_tokens
+    inputs = _inputs(capacity_tokens)
+    cu_seqlens = cumulative_sequence_offsets(lengths)
+    metadata = prepare_ragged_chunk_metadata(cu_seqlens, capacity_tokens, 64)
+    active_rows = metadata.chunk_offsets[-1].item() * 6
+
+    static = chunk_kda_fwd_k3b_ragged_cute(
+        *inputs,
+        scale=128**-0.5,
+        metadata=metadata,
+        schedule=ScheduleRequest.STATIC,
+    )
+    persistent = chunk_kda_fwd_k3b_ragged_cute(
+        *inputs,
+        scale=128**-0.5,
+        metadata=metadata,
+        schedule=ScheduleRequest.PERSISTENT,
+    )
+
+    assert torch.equal(persistent[0][:, :active_tokens], static[0][:, :active_tokens])
+    # Persistent scheduling leaves AkkOD capacity padding undefined; only the
+    # active rows are contractually meaningful (persistent K4 reads only those).
+    assert torch.equal(persistent[1][:active_rows], static[1][:active_rows])
+
+    expected_aqk, expected_akk_od = _k3_reference(inputs, lengths)
+    _assert_matches_reference(
+        persistent[0][:, :active_tokens],
+        persistent[1][:active_rows],
+        expected_aqk[:, :active_tokens],
+        expected_akk_od,
+    )
+
+
+def test_persistent_ragged_k3_strides_multiple_chunks_per_worker(monkeypatch):
+    """Force fewer workers than active chunks so CTAs reuse SMEM across iterations."""
+    from attn_gym.linear.kda import chunk_scheduler
+
+    monkeypatch.setattr(chunk_scheduler.GridScheduler, "num_chunk_workers", lambda self, device: 2)
+    lengths = [65, 63, 130, 70]
+    tokens = sum(lengths)
+    inputs = _inputs(tokens)
+    metadata = prepare_ragged_chunk_metadata(cumulative_sequence_offsets(lengths), tokens, 64)
+    assert metadata.chunk_offsets[-1].item() > 2
+
+    static = chunk_kda_fwd_k3b_ragged_cute(
+        *inputs,
+        scale=128**-0.5,
+        metadata=metadata,
+        schedule=ScheduleRequest.STATIC,
+    )
+    persistent = chunk_kda_fwd_k3b_ragged_cute(
+        *inputs,
+        scale=128**-0.5,
+        metadata=metadata,
+        schedule=ScheduleRequest.PERSISTENT,
+    )
+
+    # Capacity exceeds the active count even for exact inputs (the shape-derived
+    # bound is conservative for multiple sequences), so AkkOD padding rows are
+    # undefined under persistent scheduling; compare the active rows.
+    active_rows = metadata.chunk_offsets[-1].item() * 6
+    assert torch.equal(persistent[0], static[0])
+    assert torch.equal(persistent[1][:active_rows], static[1][:active_rows])

--- a/test/test_kda_ragged_k4.py
+++ b/test/test_kda_ragged_k4.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import pytest
 import torch
 
-from attn_gym.linear.kda.chunk_scheduler import prepare_ragged_chunk_metadata
+from attn_gym.linear.kda.chunk_scheduler import (
+    GridScheduler,
+    ScheduleRequest,
+    prepare_ragged_chunk_metadata,
+)
 from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd_inter_solve import (
     chunk_kda_fwd_inter_solve_ragged_cute,
     chunk_kda_fwd_k4b_ragged_cute,
@@ -95,8 +99,16 @@ def test_ragged_k4_inactive_capacity_is_ignored_and_output_is_zero_extended():
 
 
 @pytest.mark.parametrize("lengths", [[0], [0, 0, 0]])
-def test_ragged_inter_solve_accepts_all_empty_sequences(lengths):
-    metadata, _, diagonal = _inputs(lengths)
+def test_ragged_inter_solve_accepts_all_empty_sequences(lengths, monkeypatch):
+    requests = []
+    resolve_chunk = GridScheduler.resolve_chunk
+
+    def record_resolve(self, request, device):
+        requests.append(request)
+        return resolve_chunk(self, request, device)
+
+    monkeypatch.setattr(GridScheduler, "resolve_chunk", record_resolve)
+    metadata, offdiagonal, diagonal = _inputs(lengths)
     q = torch.empty(1, 0, 1, 128, device="cuda", dtype=torch.bfloat16)
     g = torch.empty(1, 0, 1, 128, device="cuda")
     beta = torch.empty(1, 0, 1, device="cuda")
@@ -113,15 +125,59 @@ def test_ragged_inter_solve_accepts_all_empty_sequences(lengths):
         metadata,
     )
 
+    forced_akk = chunk_kda_fwd_k4b_ragged_cute(
+        offdiagonal,
+        diagonal,
+        metadata,
+        schedule=ScheduleRequest.PERSISTENT,
+    )
+
     assert actual_aqk.shape == Aqk.shape
     assert actual_akk.shape == (1, 0, 1, 64)
+    assert forced_akk.shape == actual_akk.shape
+    assert requests == [ScheduleRequest.AUTO, ScheduleRequest.PERSISTENT]
 
 
-def test_ragged_k4_replays_aligned_to_ragged():
+def test_ragged_inter_solve_nonempty_resolves_once(monkeypatch):
+    requests = []
+    resolve_chunk = GridScheduler.resolve_chunk
+
+    def record_resolve(self, request, device):
+        requests.append(request)
+        return resolve_chunk(self, request, device)
+
+    monkeypatch.setattr(GridScheduler, "resolve_chunk", record_resolve)
+    lengths = [65, 63]
+    metadata, _, diagonal = _inputs(lengths)
+    torch.manual_seed(37)
+    q = torch.randn(1, sum(lengths), 1, 128, device="cuda", dtype=torch.bfloat16) / 8
+    k = torch.randn_like(q) / 8
+    g = -torch.rand(1, sum(lengths), 1, 128, device="cuda")
+    beta = torch.rand(1, sum(lengths), 1, device="cuda")
+    Aqk = torch.zeros(1, sum(lengths), 1, 64, device="cuda", dtype=torch.bfloat16)
+
+    actual_aqk, actual_akk = chunk_kda_fwd_inter_solve_ragged_cute(
+        q,
+        k,
+        g,
+        beta,
+        diagonal,
+        Aqk,
+        128**-0.5,
+        metadata,
+    )
+
+    assert actual_aqk.shape == Aqk.shape
+    assert actual_akk.shape == Aqk.shape
+    assert requests == [ScheduleRequest.AUTO]
+
+
+@pytest.mark.parametrize("schedule", [ScheduleRequest.STATIC, ScheduleRequest.PERSISTENT])
+def test_ragged_k4_replays_aligned_to_ragged(schedule):
     aligned_lengths = [64, 64]
     metadata, offdiagonal, diagonal = _inputs(aligned_lengths)
     cu_seqlens = metadata.cu_seqlens
-    chunk_kda_fwd_k4b_ragged_cute(offdiagonal, diagonal, metadata)
+    chunk_kda_fwd_k4b_ragged_cute(offdiagonal, diagonal, metadata, schedule=schedule)
     torch.cuda.synchronize()
 
     graph = torch.cuda.CUDAGraph()
@@ -131,6 +187,7 @@ def test_ragged_k4_replays_aligned_to_ragged():
             offdiagonal,
             diagonal,
             captured_metadata,
+            schedule=schedule,
         )
 
     ragged_lengths = [65, 63]
@@ -142,3 +199,56 @@ def test_ragged_k4_replays_aligned_to_ragged():
     expected = _reference(offdiagonal, ragged_lengths)
     assert captured_metadata.chunk_offsets.tolist() == [0, 2, 3]
     torch.testing.assert_close(actual, expected, atol=2e-2, rtol=2e-2)
+
+
+def test_persistent_ragged_k4_matches_static_over_capacity():
+    """Stride a fixed chunk-worker grid over active chunks far below capacity."""
+    lengths = [65, 63]
+    offsets = cumulative_sequence_offsets(lengths)
+    capacity_tokens = 16 * sum(lengths)
+    metadata = prepare_ragged_chunk_metadata(offsets, capacity_tokens, 64)
+    torch.manual_seed(29)
+    offdiagonal = torch.randn(metadata.capacity * 6, 16 * 16, device="cuda") / 32
+    diagonal = torch.zeros(1, capacity_tokens, 1, 16, device="cuda")
+    token_start = 0
+    for length in lengths:
+        rows = torch.arange(length, device="cuda")
+        diagonal[0, token_start + rows, 0, rows % 16] = 1
+        token_start += length
+
+    static = chunk_kda_fwd_k4b_ragged_cute(
+        offdiagonal, diagonal, metadata, schedule=ScheduleRequest.STATIC
+    )
+    persistent = chunk_kda_fwd_k4b_ragged_cute(
+        offdiagonal, diagonal, metadata, schedule=ScheduleRequest.PERSISTENT
+    )
+
+    assert torch.equal(persistent, static)
+    active_tokens = sum(lengths)
+    torch.testing.assert_close(
+        persistent[0, :active_tokens].float(),
+        _reference(offdiagonal, lengths)[0].float(),
+        rtol=2e-2,
+        atol=2e-2,
+    )
+    # The zero-initialized output past the active tokens must stay untouched.
+    assert not persistent[0, active_tokens:].any()
+
+
+def test_persistent_ragged_k4_strides_multiple_chunks_per_worker(monkeypatch):
+    """Force fewer workers than active chunks so CTAs reuse SMEM across iterations."""
+    from attn_gym.linear.kda import chunk_scheduler
+
+    monkeypatch.setattr(chunk_scheduler.GridScheduler, "num_chunk_workers", lambda self, device: 2)
+    lengths = [65, 63, 130, 70]
+    metadata, offdiagonal, diagonal = _inputs(lengths)
+    assert metadata.chunk_offsets[-1].item() > 2
+
+    static = chunk_kda_fwd_k4b_ragged_cute(
+        offdiagonal, diagonal, metadata, schedule=ScheduleRequest.STATIC
+    )
+    persistent = chunk_kda_fwd_k4b_ragged_cute(
+        offdiagonal, diagonal, metadata, schedule=ScheduleRequest.PERSISTENT
+    )
+
+    assert torch.equal(persistent, static)

--- a/test/test_kda_ragged_output.py
+++ b/test/test_kda_ragged_output.py
@@ -6,7 +6,7 @@ import pytest
 import torch
 
 import attn_gym.linear.kda.fwd.triton.chunk_gla_fwd_o as output_module
-from attn_gym.linear.kda.chunk_scheduler import prepare_ragged_chunk_metadata
+from attn_gym.linear.kda.chunk_scheduler import ScheduleRequest, prepare_ragged_chunk_metadata
 
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available(),
@@ -116,7 +116,20 @@ def test_ragged_output_routes_full_chunks_through_tma_and_masks_tails(monkeypatc
     torch.testing.assert_close(actual, expected, atol=3e-2, rtol=3e-2)
 
 
-def test_ragged_output_replays_aligned_to_ragged():
+@pytest.mark.parametrize(
+    "schedule",
+    [
+        ScheduleRequest.STATIC,
+        pytest.param(
+            ScheduleRequest.PERSISTENT,
+            marks=pytest.mark.skipif(
+                torch.cuda.is_available() and torch.cuda.get_device_capability()[0] < 9,
+                reason="persistent scheduling requires the TMA path",
+            ),
+        ),
+    ],
+)
+def test_ragged_output_replays_aligned_to_ragged(schedule):
     torch.manual_seed(1)
     tokens = 128
     heads, key_dim, value_dim = 1, 128, 128
@@ -131,13 +144,17 @@ def test_ragged_output_replays_aligned_to_ragged():
     scale = 0.125
 
     warm_metadata = prepare_ragged_chunk_metadata(cu_seqlens, tokens, 64)
-    output_module.chunk_gla_fwd_o_gk(q, v, g, A, h, scale, metadata=warm_metadata)
+    output_module.chunk_gla_fwd_o_gk(
+        q, v, g, A, h, scale, metadata=warm_metadata, schedule=schedule
+    )
     torch.cuda.synchronize()
 
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
         metadata = prepare_ragged_chunk_metadata(cu_seqlens, tokens, 64)
-        actual = output_module.chunk_gla_fwd_o_gk(q, v, g, A, h, scale, metadata=metadata)
+        actual = output_module.chunk_gla_fwd_o_gk(
+            q, v, g, A, h, scale, metadata=metadata, schedule=schedule
+        )
 
     cu_seqlens.copy_(torch.tensor([0, 65, 128], device="cuda", dtype=torch.int32))
     graph.replay()
@@ -146,3 +163,128 @@ def test_ragged_output_replays_aligned_to_ragged():
     expected = _reference(q, v, g, A, h, [65, 63], scale)
     assert metadata.chunk_offsets.tolist() == [0, 2, 3]
     torch.testing.assert_close(actual, expected, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.skipif(
+    torch.cuda.is_available() and torch.cuda.get_device_capability()[0] < 9,
+    reason="persistent scheduling requires the TMA path",
+)
+@pytest.mark.parametrize("lengths", [[65, 63], [1, 64, 0, 65]])
+def test_persistent_ragged_output_matches_static_over_capacity(lengths):
+    torch.manual_seed(3)
+    tokens = sum(lengths)
+    capacity_tokens = tokens * 8
+    heads, key_dim, value_dim = 2, 128, 128
+    dtype = torch.bfloat16
+    offsets = torch.tensor(
+        [0, *torch.tensor(lengths).cumsum(0).tolist()],
+        device="cuda",
+        dtype=torch.int32,
+    )
+    metadata = prepare_ragged_chunk_metadata(offsets, capacity_tokens, 64)
+
+    q = torch.randn(1, capacity_tokens, heads, key_dim, device="cuda", dtype=dtype) / 8
+    v = torch.randn(1, capacity_tokens, heads, value_dim, device="cuda", dtype=dtype) / 8
+    g = -torch.rand(1, capacity_tokens, heads, key_dim, device="cuda")
+    A = torch.randn(1, capacity_tokens, heads, 64, device="cuda", dtype=dtype) / 8
+    h = (
+        torch.randn(1, metadata.capacity, heads, key_dim, value_dim, device="cuda", dtype=dtype)
+        / 8
+    )
+    scale = 0.125
+
+    expected = _reference(q, v, g, A, h, lengths, scale)
+    static = output_module.chunk_gla_fwd_o_gk(
+        q, v, g, A, h, scale, metadata=metadata, schedule=ScheduleRequest.STATIC
+    )
+    persistent = output_module.chunk_gla_fwd_o_gk(
+        q, v, g, A, h, scale, metadata=metadata, schedule=ScheduleRequest.PERSISTENT
+    )
+    torch.testing.assert_close(persistent[:, :tokens], expected[:, :tokens], atol=2e-2, rtol=2e-2)
+    assert torch.equal(persistent[:, :tokens], static[:, :tokens])
+
+
+def test_persistent_is_noop_for_dense_and_raises_off_the_packed_tma_path():
+    torch.manual_seed(4)
+    tokens, heads, dim = 128, 2, 32
+    q = torch.randn(1, tokens, heads, dim, device="cuda", dtype=torch.bfloat16) / 8
+    v = torch.randn_like(q) / 8
+    g = -torch.rand(1, tokens, heads, dim, device="cuda")
+    A = torch.randn(1, tokens, heads, 64, device="cuda", dtype=torch.bfloat16) / 8
+    h = torch.randn(1, 2, heads, dim, dim, device="cuda", dtype=torch.bfloat16) / 8
+
+    # Dense launch grids are already exact, so the request is trivially satisfied.
+    dense = output_module.chunk_gla_fwd_o_gk(q, v, g, A, h, 0.125)
+    dense_persistent = output_module.chunk_gla_fwd_o_gk(
+        q, v, g, A, h, 0.125, schedule=ScheduleRequest.PERSISTENT
+    )
+    assert torch.equal(dense, dense_persistent)
+
+    # Packed inputs off the TMA path have no persistent kernel to honor the request.
+    offsets = torch.tensor([0, tokens], device="cuda", dtype=torch.int32)
+    metadata = prepare_ragged_chunk_metadata(offsets, tokens, 64)
+    with pytest.raises(ValueError, match="persistent scheduling"):
+        output_module.chunk_gla_fwd_o_gk(
+            q,
+            v,
+            g,
+            A,
+            h,
+            0.125,
+            metadata=metadata,
+            schedule=ScheduleRequest.PERSISTENT,
+        )
+
+
+def test_ragged_output_zero_capacity_skips_launch():
+    heads = 1
+    for schedule in (ScheduleRequest.STATIC, ScheduleRequest.PERSISTENT):
+        q = torch.empty(1, 0, heads, 128, device="cuda", dtype=torch.bfloat16)
+        v = torch.empty_like(q)
+        g = torch.empty(1, 0, heads, 128, device="cuda")
+        A = torch.empty(1, 0, heads, 64, device="cuda", dtype=torch.bfloat16)
+        h = torch.empty(1, 0, heads, 128, 128, device="cuda", dtype=torch.bfloat16)
+        metadata = prepare_ragged_chunk_metadata(
+            torch.tensor([0, 0], device="cuda", dtype=torch.int32), 0, 64
+        )
+        assert metadata.capacity == 0
+        output = output_module.chunk_gla_fwd_o_gk(
+            q, v, g, A, h, 0.125, metadata=metadata, schedule=schedule
+        )
+        assert output.shape == v.shape
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] < 9,
+    reason="persistent scheduling requires the TMA path",
+)
+def test_persistent_ragged_output_strides_multiple_tasks_per_worker(monkeypatch):
+    """Force fewer workers than tasks so the stride loop iterates repeatedly."""
+    from attn_gym.linear.kda import chunk_scheduler
+
+    monkeypatch.setattr(chunk_scheduler.GridScheduler, "num_workers", lambda self, s, d: 3)
+    torch.manual_seed(7)
+    tokens, heads = 256, 2
+    q = torch.randn(1, tokens, heads, 128, device="cuda", dtype=torch.bfloat16) / 8
+    v = torch.randn_like(q) / 8
+    g = -torch.rand(1, tokens, heads, 128, device="cuda")
+    A = torch.randn(1, tokens, heads, 64, device="cuda", dtype=torch.bfloat16) / 8
+    metadata = prepare_ragged_chunk_metadata(
+        torch.tensor([0, 129, 256], device="cuda", dtype=torch.int32), tokens, 64
+    )
+    h = torch.randn(1, metadata.capacity, heads, 128, 128, device="cuda", dtype=torch.bfloat16) / 8
+
+    static = output_module.chunk_gla_fwd_o_gk(
+        q, v, g, A, h, 0.125, metadata=metadata, schedule=ScheduleRequest.STATIC
+    )
+    persistent = output_module.chunk_gla_fwd_o_gk(
+        q,
+        v,
+        g,
+        A,
+        h,
+        0.125,
+        metadata=metadata,
+        schedule=ScheduleRequest.PERSISTENT,
+    )
+    assert torch.equal(persistent, static)

--- a/test/test_kda_ragged_public_backward.py
+++ b/test/test_kda_ragged_public_backward.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import inspect
+
 import pytest
 import torch
 
@@ -485,3 +487,76 @@ def test_dense_tail_batch_gradients_match_explicit_packed_lowering():
             atol=3e-2,
         )
     torch.testing.assert_close(dense_gradients[-1], packed_gradients[-1], rtol=3e-2, atol=3e-2)
+
+
+def test_public_auto_persistent_matches_static_composition(monkeypatch):
+    """Route the complete public forward/backward through AUTO persistent plans."""
+    from attn_gym.linear.kda import chunk_scheduler
+    from attn_gym.linear.kda.chunk_schedule import ScheduleKind
+
+    capacity = 4096
+    active_lengths = [321, 0, 63, 128, 488]
+    active_tokens = sum(active_lengths)
+    inputs = make_kda_test_inputs(capacity, requires_grad=True)
+    output_grad = torch.randn_like(inputs[0])
+    with torch.no_grad():
+        for tensor in inputs:
+            tensor[:, active_tokens:].fill_(float("nan"))
+        output_grad[:, active_tokens:].zero_()
+    offsets = cumulative_sequence_offsets(active_lengths)
+
+    kinds = []
+    resolve_flat = chunk_scheduler.GridScheduler.resolve_flat
+    resolve_chunk = chunk_scheduler.GridScheduler.resolve_chunk
+
+    def record_flat(self, *args, **kwargs):
+        resolved = resolve_flat(self, *args, **kwargs)
+        kinds.append(resolved.kind)
+        return resolved
+
+    def record_chunk(self, *args, **kwargs):
+        resolved = resolve_chunk(self, *args, **kwargs)
+        kinds.append(resolved.kind)
+        return resolved
+
+    monkeypatch.setattr(chunk_scheduler.GridScheduler, "resolve_flat", record_flat)
+    monkeypatch.setattr(chunk_scheduler.GridScheduler, "resolve_chunk", record_chunk)
+    monkeypatch.setattr(chunk_scheduler, "PERSISTENT_AUTO_WAVES", 1 << 30)
+    static = _run_gradients(
+        clone_kda_inputs(inputs),
+        None,
+        offsets,
+        output_grad,
+        None,
+        output_final_state=False,
+    )
+    assert set(kinds) == {ScheduleKind.STATIC}
+
+    kinds.clear()
+    monkeypatch.setattr(chunk_scheduler, "PERSISTENT_AUTO_WAVES", 0)
+    persistent = _run_gradients(
+        clone_kda_inputs(inputs),
+        None,
+        offsets,
+        output_grad,
+        None,
+        output_final_state=False,
+    )
+    assert ScheduleKind.PERSISTENT in kinds
+    torch.testing.assert_close(
+        persistent[0][:, :active_tokens], static[0][:, :active_tokens], rtol=0, atol=0
+    )
+    assert persistent[1] is static[1] is None
+    for persistent_gradient, static_gradient in zip(persistent[2], static[2], strict=True):
+        torch.testing.assert_close(
+            persistent_gradient[:, :active_tokens],
+            static_gradient[:, :active_tokens],
+            rtol=3e-2,
+            atol=3e-2,
+        )
+
+
+def test_public_api_has_no_scheduling_knob():
+    parameters = inspect.signature(chunk_kda).parameters
+    assert "persistent" not in parameters
+    assert "schedule" not in parameters


### PR DESCRIPTION
## Human Note

## Agent note

CUDA Graph capture pins launch configs, so packed varlen KDA kernels get captured at a worst-case token
capacity. The existing early-exit pattern (grid = capacity, padding CTAs read `chunk_offsets[-1]` and
return) costs launch time linear in capacity: ~0.46 µs per 1k empty CTAs, up to 9.2x per-kernel slowdown
at a capacity/active ratio of 8192.

This makes ragged scheduling **automatic — there is no user-facing knob**. `GridScheduler`
(`attn_gym/linear/kda/chunk_scheduler.py`) owns the policy: when a kernel's capacity-derived grid exceeds
`PERSISTENT_AUTO_WAVES` (4) waves of its bounded machine-derived worker grid, the launch switches to a
persistent grid whose CTAs stride over the flat active task list, bounded on device by
`load_ragged_task_count`. Exact or mildly padded shapes keep their exact early-exit grids (a few waves of
empty CTAs are cheaper than the stride loop), and layouts without a persistent kernel (TMA-ineligible
fallbacks) stay on early exit silently. Kernel wrappers keep a tri-state `persistent: bool | None`
override purely for A/B tests; `chunk_kda`, the custom-op schemas, and the training example carry nothing.

Converted kernels: Triton `chunk_gla_fwd_o`, `bounded_gate_cumsum`, `recompute_w_u` (fwd and bwd
recompute), `chunk_kda_bwd_dav`, `kda_gate_bwd` (shared per-task jit helpers; early-exit kernels
unchanged), and CuTeDSL K3b/K4b via a `chunk_workers`-capped chunk axis with a device-bounded stride loop
(generalizing the existing `chunk_kda_bwd_intra` pattern; `chunk_workers` is power-of-two quantized and a
jit_cache key). `chunk_delta_h` (sequential recurrence) and the already-persistent CuTeDSL backward
kernels are untouched. The capacity-masking helpers were also the largest model-level over-capture cost:
the row kernel now write-only zeros padding and the gradient barriers are zero-copy identity forwards;
compiled graphs keep the where-form so Inductor and functorch see aten semantics.

Review order: `chunk_scheduler.py` (`GridScheduler`, `resolve_persistent`, `load_ragged_task_count`) →
the five Triton kernel conversions → CuTeDSL K3b/K4b + `chunk_kda_fwd_inter_solve.py` → `masking.py` →
docs. Reviewed by seven independent agent passes; notable catches folded in: pinned persistent recompute
for `autotune=False` capture safety, backward recompute threading, channel-tile ceil-div hardening, vmap
rule and layout-eligibility gating for the masking fast path.

## Performance

GB300, torch 2.14 nightly cu132, CUDA-event medians, active work fixed at 8192 packed tokens.

Per-kernel early-exit → persistent at 64x over-capture: gla_fwd_o 2.6x, gate cumsum 8.4x, bwd_dav 2.5x,
CuTeDSL K3b kernel 1459 → 72 µs; composed `chunk_kda` fwd 2239 → 519 µs (4.3x).

Full `KDAAttention` graph-replay step with the automatic policy (no flags anywhere):

| capacity ratio | before (early-exit) | after (auto) |
|---|---|---|
| 1x (exact) | 4923 µs | 4979 µs (auto keeps exact grids) |
| 8x | 30082 µs | 20367 µs |
| 16x | 57510 µs | 37575 µs |

The remaining 16x slope is dense projections/norms on padded tokens, out of scheduling's reach
(see `docs/linear.md`).

## Test Plan

```bash
pytest test/test_kda_chunk_scheduler.py test/test_kda_masking.py test/test_kda_ragged_output.py \
  test/test_kda_ragged_gate.py test/test_kda_ragged_bwd_dav.py test/test_kda_cute_recompute.py \
  test/test_kda_ragged_autograd_ops.py test/test_kda_ragged_forward_stages.py \
  test/test_kda_ragged_public_backward.py test/test_kda_cute_forward.py test/test_kda_ragged_k3.py \
  test/test_kda_ragged_k4.py test/test_kda_cute_inter_solve.py test/test_kda_training_example.py \
  test/test_kda_impl_dispatch.py
# 183 passed (GB300): forced-mode bit-equality vs early exit, auto-policy kernel-route checks,
# NaN-poisoned padding graph replay, persistent CUDA-graph replay across changed device-side
# boundaries, multi-task/multi-chunk worker stride loops, zero-capacity, and dense no-op contracts.
python examples/kda_training.py --backend=fused --packed --batch-size=4 --tokens=256
