### PR TITLE
Propagate detected GPU architecture to CuTe compile workers

### DIFF
--- a/attn_gym/_backends/cute/_compile_driver.py
+++ b/attn_gym/_backends/cute/_compile_driver.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import importlib
 import json
+import os
 import pickle
 import sys
 from concurrent.futures import ProcessPoolExecutor
@@ -50,7 +51,15 @@ def main(request_path: Path, calls_path: Path) -> int:
     capability = target_fields.get("capability")
     if capability is not None:
         target_fields["capability"] = tuple(capability)
-    set_compile_target(CompileTarget(**target_fields))
+    target = CompileTarget(**target_fields)
+    set_compile_target(target)
+
+    if target.configured_arch is not None:
+        os.environ["CUTE_DSL_ARCH"] = target.configured_arch
+    elif target.capability is not None:
+        major, minor = target.capability
+        suffix = "a" if major >= 9 else ""
+        os.environ["CUTE_DSL_ARCH"] = f"sm_{major}{minor}{suffix}"
 
     _compile_fn = _resolve(request["module"], request["qualname"])
     if not callable(getattr(_compile_fn, "precompile", None)):

--- a/attn_gym/_backends/cute/_key.py
+++ b/attn_gym/_backends/cute/_key.py
@@ -95,10 +95,10 @@ def source_fingerprint(
         if source.is_file():
             _hash_file(hasher, f"cutlass/{relative_path}", source)
 
+    # Architecture is keyed separately through CompileTarget.
     codegen_environment = tuple(
         (name, os.getenv(name))
         for name in (
-            "CUTE_DSL_ARCH",
             "CUTE_DSL_COMPILER_OPT",
             "CUTE_DSL_ENABLE_ASSERTIONS",
             "CUTE_DSL_ENABLE_TVM_FFI",

--- a/test/test_cute_cache.py
+++ b/test/test_cute_cache.py
@@ -75,7 +75,9 @@ def compile_test_variant(config: CompileConfig) -> FakeCompiled:
     log_path = os.getenv(_DRIVER_LOG_ENV)
     if log_path:
         with Path(log_path).open("a") as log:
-            log.write(f"{os.getpid()},{os.getppid()},{config.variant}\n")
+            log.write(
+                f"{os.getpid()},{os.getppid()},{config.variant},{os.getenv('CUTE_DSL_ARCH', '')}\n"
+            )
     return FakeCompiled(config.variant)
 
 
@@ -956,6 +958,7 @@ def test_fresh_compile_driver_forks_parallel_workers(tmp_path, monkeypatch):
     assert len(worker_pids) == len(configs)
     assert len(driver_pids) == 1
     assert os.getpid() not in driver_pids
+    assert {record[3] for record in records} == {"sm_100a"}
     assert len(list(cache_directory.rglob("*.o"))) == len(configs) + 1
 
     def unexpected_driver(*args, **kwargs):


### PR DESCRIPTION
## Summary

- propagate the parent GPU capability into `CUTE_DSL_ARCH` before importing CuTeDSL in fresh compiler workers
- preserve an explicitly configured CuTe architecture
- rely on `CompileTarget` for architecture cache keying instead of also fingerprinting the worker-local environment
- verify forked workers receive the architecture derived from their supplied compile target

Without this, forked CuTeDSL workers cannot query CUDA and fall back to `sm_100a`, producing `cudaErrorNoKernelImageForDevice` when an artifact is compiled for the wrong GPU architecture (observed on GB300, which requires `sm_103a`).

## Test plan

- `pytest test/test_cute_cache.py -q` (34 passed)
- `pytest test/test_cute_cache_gpu.py::test_parallel_compile_then_inductor_benchmark -q` on GB300 with `CUTE_DSL_ARCH` unset (1 passed)
- `ruff check attn_gym/_backends/cute/_compile_driver.py attn_gym/_backends/cute/_key.py test/test_cute_cache.py`
- `ruff format --check attn_gym/_backends/cute/_compile_driver.py attn_gym/_backends/cute/_key.py test/test_cute_cache.py`
