### PR TITLE
Fix strict-compile failures when gate shapes or lower_bound vary

### DIFF
--- a/attn_gym/linear/kda/chunk_scheduler.py
+++ b/attn_gym/linear/kda/chunk_scheduler.py
@@ -9,7 +9,13 @@ import torch
 import triton
 import triton.language as tl
 
-from attn_gym.linear.kda.chunk_schedule import RaggedChunkMetadata, chunk_capacity
+# The op-wrapped metadata builder is re-exported so every caller routes the offsets
+# launch through the registered scheduler op instead of tracing it directly.
+from attn_gym.linear.kda.chunk_schedule import (
+    RaggedChunkMetadata,
+    chunk_capacity,
+    prepare_ragged_chunk_metadata,
+)
 
 
 class ChunkWork(NamedTuple):
@@ -155,25 +161,6 @@ def _prepare_ragged_chunk_offsets(
         num_warps=min(8, max(1, block // 32)),
     )
     return chunk_offsets
-
-
-def prepare_ragged_chunk_metadata(
-    cu_seqlens: torch.Tensor,
-    tokens: int,
-    chunk_size: int,
-) -> RaggedChunkMetadata:
-    """Build fixed-shape, graph-replayable packed chunk offsets on the GPU."""
-    if cu_seqlens.ndim != 1 or cu_seqlens.shape[0] < 2:
-        raise ValueError("cu_seqlens must have shape [num_sequences + 1]")
-    if cu_seqlens.dtype != torch.int32 or not cu_seqlens.is_contiguous():
-        raise ValueError("cu_seqlens must be contiguous int32")
-    if not cu_seqlens.is_cuda:
-        raise ValueError("cu_seqlens must be a CUDA tensor")
-
-    num_sequences = cu_seqlens.shape[0] - 1
-    capacity = chunk_capacity(tokens, num_sequences, chunk_size)
-    chunk_offsets = _prepare_ragged_chunk_offsets(cu_seqlens, tokens, chunk_size)
-    return RaggedChunkMetadata(cu_seqlens, chunk_offsets, capacity, chunk_size)
 
 
 def decode_ragged_chunk_work(metadata: RaggedChunkMetadata) -> torch.Tensor:

--- a/attn_gym/linear/kda/fwd/triton/gate_fwd.py
+++ b/attn_gym/linear/kda/fwd/triton/gate_fwd.py
@@ -119,7 +119,6 @@ def _bounded_gate_cumsum_dense(
     raw_gate: torch.Tensor,
     A_log: torch.Tensor,
     dt_bias: torch.Tensor,
-    *,
     chunk_size: int,
     lower_bound: float,
 ) -> torch.Tensor:
@@ -252,6 +251,10 @@ def bounded_gate_cumsum_ragged(
 
 
 torch.library.define(
+    "attn_gym::kda_bounded_gate_fwd_dense",
+    "(Tensor raw_gate, Tensor A_log, Tensor dt_bias, int chunk_size, float lower_bound) -> Tensor",
+)
+torch.library.define(
     "attn_gym::kda_bounded_gate_fwd_ragged",
     "(Tensor raw_gate, Tensor A_log, Tensor dt_bias, Tensor cu_seqlens, "
     "Tensor chunk_offsets, int chunk_size, float lower_bound) -> Tensor",
@@ -323,12 +326,26 @@ def _bounded_gate_cumsum_ragged_bwd_cuda(
         )
 
 
+torch.library.impl("attn_gym::kda_bounded_gate_fwd_dense", "CUDA", _bounded_gate_cumsum_dense)
 torch.library.impl(
     "attn_gym::kda_bounded_gate_fwd_ragged", "CUDA", _bounded_gate_cumsum_ragged_fwd_cuda
 )
 torch.library.impl(
     "attn_gym::kda_bounded_gate_bwd_ragged", "CUDA", _bounded_gate_cumsum_ragged_bwd_cuda
 )
+
+
+@torch.library.register_fake("attn_gym::kda_bounded_gate_fwd_dense")
+def _bounded_gate_cumsum_dense_fake(
+    raw_gate: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    chunk_size: int,
+    lower_bound: float,
+) -> torch.Tensor:
+    """Describe the dense gate output."""
+    del A_log, dt_bias, chunk_size, lower_bound
+    return torch.empty_like(raw_gate, dtype=torch.float32)
 
 
 @torch.library.register_fake("attn_gym::kda_bounded_gate_fwd_ragged")
@@ -367,6 +384,7 @@ def _bounded_gate_cumsum_ragged_bwd_fake(
     )
 
 
+_bounded_gate_cumsum_dense_op = torch.ops.attn_gym.kda_bounded_gate_fwd_dense.default
 _bounded_gate_cumsum_ragged_fwd_op = torch.ops.attn_gym.kda_bounded_gate_fwd_ragged.default
 _bounded_gate_cumsum_ragged_bwd_op = torch.ops.attn_gym.kda_bounded_gate_bwd_ragged.default
 
@@ -406,12 +424,12 @@ class _BoundedGateCumsum(torch.autograd.Function):
 
         assert chunk_offsets is None
         ctx.save_for_backward(raw_gate, A_log, dt_bias)
-        return _bounded_gate_cumsum_dense(
+        return _bounded_gate_cumsum_dense_op(
             raw_gate,
             A_log,
             dt_bias,
-            chunk_size=chunk_size,
-            lower_bound=lower_bound,
+            chunk_size,
+            lower_bound,
         )
 
     @staticmethod

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -1,0 +1,19 @@
+# Test Suite Conventions
+
+## Shared test helpers live in `attn_gym/testing/`
+
+Before writing input factories, offset builders, reference oracles, or tolerance
+assertions in a test file, check `attn_gym/testing/` (e.g. `attn_gym/testing/kda.py`)
+for an existing helper:
+
+- `cumulative_sequence_offsets(lengths)` — packed `cu_seqlens` boundary tensors
+- `make_kda_test_inputs(tokens, ...)` / `clone_kda_inputs(...)` — public KDA operands
+  with production dtypes and independent autograd leaves
+- `assert_matches_low_precision_reference(...)` — data-derived error budgets instead of
+  hand-tuned rtol/atol
+- fp64 backward oracles (`bwd_intra_reference`, `bwd_wy_dqkg_reference`, ...)
+
+When a helper you are about to write would have a second caller — or duplicates the
+shape/dtype/seed conventions of an existing one — add or extend it in
+`attn_gym/testing/` instead of keeping a private copy in the test file. Local `_inputs`
+style helpers are fine only for operand sets no shared factory covers.

--- a/test/test_kda_compile_dynamic_shapes.py
+++ b/test/test_kda_compile_dynamic_shapes.py
@@ -1,0 +1,99 @@
+"""Strict compilation regressions for dynamic KDA shapes and scalar arguments.
+
+One compiled callable must serve varying packed sequence counts, head geometry, and
+``lower_bound`` values with eager-parity outputs; shape-derived Triton launch arguments
+must stay representable once Dynamo promotes dimensions to dynamic.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+pytest.importorskip("triton")
+
+from attn_gym.linear import bounded_gate_cumsum, chunk_kda
+from attn_gym.testing.kda import cumulative_sequence_offsets, make_kda_test_inputs
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+
+TOKENS = 128
+
+
+def _gate_inputs(batch: int = 1, heads: int = 2, head_dim: int = 128):
+    """Create valid dense bounded-gate operands for one shape."""
+    torch.manual_seed(0)
+    raw = (0.5 * torch.randn(batch, TOKENS, heads, head_dim, device="cuda")).to(torch.bfloat16)
+    a_log = 0.25 * torch.randn(heads, device="cuda", dtype=torch.float32)
+    dt_bias = 0.25 * torch.randn(heads, head_dim, device="cuda", dtype=torch.float32)
+    return raw, a_log, dt_bias
+
+
+def _offsets(sequence_count: int) -> torch.Tensor:
+    """Split the token capacity into near-equal packed sequence boundaries."""
+    step = TOKENS // sequence_count
+    lengths = [step] * (sequence_count - 1) + [TOKENS - step * (sequence_count - 1)]
+    return cumulative_sequence_offsets(lengths)
+
+
+def test_compiled_gate_accepts_varying_packed_sequence_count():
+    """One compiled callable must serve differing packed sequence counts."""
+    raw, a_log, dt_bias = _gate_inputs()
+    compiled = torch.compile(bounded_gate_cumsum, fullgraph=True, dynamic=True)
+    for index, sequence_count in enumerate((3, 4, 5)):
+        cu_seqlens = _offsets(sequence_count)
+        expected = bounded_gate_cumsum(raw, a_log, dt_bias, cu_seqlens=cu_seqlens)
+        # The dynamic graph from earlier calls must be reused, not respecialized.
+        with torch._dynamo.config.patch(error_on_recompile=index > 1):
+            output = compiled(raw, a_log, dt_bias, cu_seqlens=cu_seqlens)
+        torch.testing.assert_close(output, expected)
+
+
+def test_compiled_gate_accepts_varying_head_geometry():
+    """One compiled callable must serve differing batch, head count, and head dim."""
+    compiled = torch.compile(bounded_gate_cumsum, fullgraph=True, dynamic=True)
+    for batch, heads, head_dim in ((1, 2, 128), (2, 3, 96), (1, 5, 64)):
+        raw, a_log, dt_bias = _gate_inputs(batch=batch, heads=heads, head_dim=head_dim)
+        expected = bounded_gate_cumsum(raw, a_log, dt_bias)
+        output = compiled(raw, a_log, dt_bias)
+        torch.testing.assert_close(output, expected)
+
+
+def test_compiled_gate_backward_survives_varying_lower_bound():
+    """Varying the lower_bound float must keep backward compiling with eager parity."""
+    raw, a_log, dt_bias = _gate_inputs()
+    compiled = torch.compile(bounded_gate_cumsum, fullgraph=True, dynamic=True)
+    for lower_bound in (-10.0, -5.0):
+        expected = bounded_gate_cumsum(raw, a_log, dt_bias, lower_bound=lower_bound)
+        output = compiled(raw, a_log, dt_bias, lower_bound=lower_bound)
+        torch.testing.assert_close(output, expected)
+
+    expected_inputs = tuple(tensor.detach().requires_grad_() for tensor in (raw, a_log, dt_bias))
+    actual_inputs = tuple(tensor.detach().clone().requires_grad_() for tensor in expected_inputs)
+    expected = bounded_gate_cumsum(*expected_inputs, lower_bound=-10.0)
+    actual = compiled(*actual_inputs, lower_bound=-10.0)
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+    cotangent = torch.randn_like(expected)
+    expected_gradients = torch.autograd.grad(expected, expected_inputs, cotangent)
+    actual_gradients = torch.autograd.grad(actual, actual_inputs, cotangent)
+    torch.testing.assert_close(actual_gradients[0], expected_gradients[0], rtol=0, atol=0)
+    # A_log and dt_bias gradients reduce over tokens; compiled reduction order differs.
+    for actual_gradient, expected_gradient in zip(
+        actual_gradients[1:], expected_gradients[1:], strict=True
+    ):
+        torch.testing.assert_close(actual_gradient, expected_gradient, rtol=5e-5, atol=7e-4)
+
+
+def test_compiled_chunk_kda_accepts_varying_packed_sequence_count():
+    """Varying sequence counts through the composed core, which shares the scheduler."""
+    if torch.cuda.get_device_capability() < (10, 0):
+        pytest.skip("the CuTe KDA core requires CUDA capability 10.0 or newer")
+    inputs = make_kda_test_inputs(TOKENS)
+    compiled = torch.compile(chunk_kda, fullgraph=True, dynamic=True)
+    for sequence_count in (2, 4):
+        cu_seqlens = _offsets(sequence_count)
+        expected, expected_state = chunk_kda(*inputs, cu_seqlens=cu_seqlens)
+        actual, actual_state = compiled(*inputs, cu_seqlens=cu_seqlens)
+        assert expected_state is actual_state is None
+        torch.testing.assert_close(actual, expected)

--- a/test/test_kda_kernels.py
+++ b/test/test_kda_kernels.py
@@ -29,6 +29,7 @@ from attn_gym.linear.kda.fwd.triton.chunk_kda_fwd_intra_sub_chunk_forloop import
 )
 from attn_gym.linear.kda.fwd.triton.gate_fwd import (
     _bounded_gate_chunk_cumsum_dense_kernel,
+    _bounded_gate_cumsum_dense_op,
     _requires_int64_offsets,
 )
 from attn_gym.linear.kda.fwd.triton.l2norm_fwd import (
@@ -409,6 +410,22 @@ def test_bounded_gate_fwd_int64_offsets():
     )
     expected = -3.25 * torch.sigmoid(A_log.exp().view(1, 1, 1, 1) * (raw_gate + dt_bias))
     torch.testing.assert_close(output, expected * RCP_LN2)
+
+
+def test_bounded_gate_fwd_dense_op_registration():
+    """Validate the dense gate's functional schema, fake tensor, and AOT dispatch."""
+    torch.manual_seed(13)
+    # Strided views cover the stride-preserving real/fake metadata contract.
+    raw_gate = torch.randn(2, 96, 2, 128, device=DEV, dtype=torch.bfloat16)[..., ::2]
+    A_log = (0.25 * torch.randn(4, device=DEV, dtype=torch.float32))[::2]
+    dt_bias = (0.25 * torch.randn(2, 128, device=DEV, dtype=torch.float32))[..., ::2]
+    assert not any(tensor.is_contiguous() for tensor in (raw_gate, A_log, dt_bias))
+    # Autograd is intentionally owned by _BoundedGateCumsum rather than the raw operator.
+    torch.library.opcheck(
+        _bounded_gate_cumsum_dense_op,
+        (raw_gate, A_log, dt_bias, 64, -5.0),
+        test_utils=("test_schema", "test_faketensor", "test_aot_dispatch_dynamic"),
+    )
 
 
 def _bwd_dav_ref(v, A, do, scale, chunk_size=64):


### PR DESCRIPTION
## Human Note

## Agent note

A KDA fuzz campaign found that one compiled `bounded_gate_cumsum`/`chunk_kda` callable failed on the
second distinct input signature, three ways: a dynamic packed sequence count made the offsets
kernel's `num_warps` symbolic (traced via the raw scheduler), varying head geometry exposed the
dense gate's stride-tuple kernel kwargs to Dynamo, and a second distinct `lower_bound` float was
lifted into a scalar tensor whose backward failed Inductor lowering. All three share one root
cause: Triton launches traced directly instead of sitting behind the custom-op boundary the ragged
path already uses.

The fix deletes the raw `chunk_scheduler.prepare_ragged_chunk_metadata` twin in favor of
re-exporting the op-wrapped `chunk_schedule` builder — every existing import site, including the
compiled forward in `examples/kda_training.py`, now routes the offsets launch through the
registered scheduler op — and registers the dense gate launch as
`attn_gym::kda_bounded_gate_fwd_dense` (define/impl/fake; autograd stays owned by
`_BoundedGateCumsum`), which also keeps `lower_bound` a schema float through backward.

## Test Plan

```bash
# new regression coverage (verified failing before the fix): eager parity across varying
# sequence counts (with error_on_recompile reuse guard), batch/head geometry, and
# lower_bound forward+backward, plus a strided-input opcheck for the new dense op
gpu-run auto -- .venv/bin/python -m pytest -q test/test_kda_compile_dynamic_shapes.py \
  "test/test_kda_kernels.py::test_bounded_gate_fwd_dense_op_registration"
# neighboring suites
gpu-run auto -- .venv/bin/python -m pytest -q test/test_kda_ragged_gate.py \
  test/test_kda_chunk_scheduler.py \
  "test/test_kda_kernels.py::test_bounded_gate_fwd_int64_offsets" \
  "test/test_kda_fused_gate_bwd.py::test_bounded_gate_cumsum_compile_matches_eager" \
  "test/test_kda_fused_gate_bwd.py::test_bounded_gate_cumsum_autograd_boundary" \
  "test/test_kda_fused_gate_bwd.py::test_fused_gate_bwd_reference_matches_forward_autograd" \
  "test/test_kda_fused_gate_bwd.py::test_bounded_gate_cumsum_rejects_backward_unsupported_shape"
