### PR TITLE
fuse KDA decode preprocessing into recurrent kernel

### DIFF
--- a/attn_gym/linear/__init__.py
+++ b/attn_gym/linear/__init__.py
@@ -16,6 +16,7 @@ from attn_gym.linear.kda import (
     mask_inactive_token_gradients,
     mask_inactive_tokens,
     recurrent_kda,
+    recurrent_kda_decode,
 )
 from attn_gym.linear.kda.api import Impl
 
@@ -34,6 +35,7 @@ KDA_OPS = [
     "bounded_gate_cumsum",
     "chunk_kda",
     "recurrent_kda",
+    "recurrent_kda_decode",
 ]
 
 GDN_OPS = [

--- a/attn_gym/linear/kda/__init__.py
+++ b/attn_gym/linear/kda/__init__.py
@@ -13,7 +13,7 @@ lazily on first fused call, and the naive oracles in
 
 import importlib
 
-from attn_gym.linear.kda.api import chunk_kda, recurrent_kda
+from attn_gym.linear.kda.api import chunk_kda, recurrent_kda, recurrent_kda_decode
 from attn_gym.linear.kda.masking import (
     active_token_mask,
     mask_inactive_token_gradients,
@@ -51,6 +51,7 @@ __all__ = sorted(  # noqa: PLE0605 -- backend exports resolve lazily
         "mask_inactive_token_gradients",
         "mask_inactive_tokens",
         "recurrent_kda",
+        "recurrent_kda_decode",
         *_BACKEND_EXPORTS,
     ]
 )

--- a/attn_gym/linear/kda/api.py
+++ b/attn_gym/linear/kda/api.py
@@ -12,16 +12,19 @@ inference prefill. Use ``impl`` to select fused kernels or the eager reference.
 
 from __future__ import annotations
 
+import math
 from enum import Enum
 from functools import partial
+from numbers import Real
 
 import torch
 
 from attn_gym.linear.kda.impl.fused import chunk_forward as _fused_chunk_forward
 from attn_gym.linear.kda.impl.reference import reference_kda
 from attn_gym.linear.kda.naive import naive_chunk_kda_from_cumulative, naive_recurrent_kda
+from attn_gym.linear.kda.ops import recurrent_decode_forward as _fused_recurrent_decode_forward
 from attn_gym.linear.kda.ops import recurrent_forward as _fused_recurrent_forward
-from attn_gym.linear.kda.validation import validate_kda_inputs
+from attn_gym.linear.kda.validation import SUPPORTED_INPUT_DTYPES, validate_kda_inputs
 
 _CHUNK_SIZE = 64
 
@@ -270,4 +273,118 @@ def recurrent_kda(
     )
 
 
-__all__ = ["Impl", "chunk_kda", "recurrent_kda"]
+def recurrent_kda_decode(
+    packed_qkv: torch.Tensor,
+    raw_gate: torch.Tensor,
+    raw_beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    state_cache: torch.Tensor,
+    state_indices: torch.Tensor,
+    *,
+    lower_bound: float | None = -5.0,
+    scale: float | None = None,
+) -> torch.Tensor:
+    """Run one-token paged KDA decode with preprocessing fused into the recurrence.
+
+    Args:
+        packed_qkv: Post-convolution QKV shaped ``[B, H * (2 * K + V)]``. Channels
+            are head-interleaved: each head stores its Q row, K row, then V row.
+        raw_gate: Unactivated gate shaped ``[1, B, H, K]``.
+        raw_beta: Unactivated write gate shaped ``[1, B, H]``.
+        A_log: Per-head log decay parameter shaped ``[H]``.
+        dt_bias: Per-head/channel gate bias shaped ``[H, K]``.
+        state_cache: FP32 paged state pool shaped ``[num_slots, H, K, V]``. Slots
+            may have padding between them but each ``[H, K, V]`` row must be dense.
+        state_indices: Contiguous int32 slot indices shaped ``[B]``. Positive slots
+            are updated in place; non-positive entries produce zero output and leave
+            the state cache untouched.
+        lower_bound: Negative bound for ``lower_bound * sigmoid(exp(A_log) * gate)``.
+            When ``None``, use ``-exp(A_log) * softplus(gate)`` instead.
+        scale: Query scale. Defaults to ``1 / sqrt(K)``.
+
+    Returns:
+        Decode output shaped ``[1, B, H, V]`` in ``packed_qkv.dtype``.
+
+    Q/K L2 normalization, gate activation, beta sigmoid, the recurrent update, and
+    the output projection from recurrent state are performed in one Triton kernel.
+    The operation is inference-only and advances ``state_cache`` in place.
+    """
+    if packed_qkv.ndim != 2 or packed_qkv.shape[0] < 1 or packed_qkv.stride(1) != 1:
+        raise ValueError("packed_qkv must have shape [B, C] and be contiguous within each token")
+    if state_cache.ndim != 4:
+        raise ValueError("state_cache must have shape [num_slots, H, K, V]")
+    num_slots, heads, key_dim, value_dim = state_cache.shape
+    batch = packed_qkv.shape[0]
+    if num_slots < 1 or heads < 1 or key_dim < 1 or value_dim < 1:
+        raise ValueError(
+            f"state_cache must have nonempty dimensions, got {tuple(state_cache.shape)}"
+        )
+    expected_channels = heads * (2 * key_dim + value_dim)
+    if packed_qkv.shape[1] != expected_channels:
+        raise ValueError(
+            f"packed_qkv must have shape ({batch}, {expected_channels}), "
+            f"got {tuple(packed_qkv.shape)}"
+        )
+    if raw_gate.shape != (1, batch, heads, key_dim) or raw_gate.stride()[2:] != (key_dim, 1):
+        raise ValueError(
+            f"raw_gate must have shape {(1, batch, heads, key_dim)} and dense [H, K] rows"
+        )
+    if raw_beta.shape != (1, batch, heads) or raw_beta.stride(2) != 1:
+        raise ValueError(f"raw_beta must have shape {(1, batch, heads)} with contiguous heads")
+    if A_log.shape != (heads,) or not A_log.is_contiguous():
+        raise ValueError(f"A_log must be contiguous with shape ({heads},)")
+    if dt_bias.shape != (heads, key_dim) or not dt_bias.is_contiguous():
+        raise ValueError(f"dt_bias must be contiguous with shape ({heads}, {key_dim})")
+    if state_cache.dtype != torch.float32:
+        raise TypeError("state_cache must use float32")
+    expected_state_strides = (key_dim * value_dim, value_dim, 1)
+    if state_cache.stride()[1:] != expected_state_strides:
+        raise TypeError("state_cache must be contiguous within each [H, K, V] slot")
+    if state_cache.stride(0) < heads * key_dim * value_dim:
+        raise ValueError("state_cache slots must not overlap")
+    if (
+        state_indices.shape != (batch,)
+        or state_indices.dtype != torch.int32
+        or not state_indices.is_contiguous()
+    ):
+        raise ValueError(f"state_indices must be contiguous int32 with shape ({batch},)")
+
+    device = packed_qkv.device
+    data_tensors = (packed_qkv, raw_gate, raw_beta, A_log, dt_bias)
+    if any(tensor.device != device for tensor in (*data_tensors, state_cache, state_indices)):
+        raise ValueError("all recurrent_kda_decode inputs must be on the same device")
+    if any(tensor.dtype not in SUPPORTED_INPUT_DTYPES for tensor in data_tensors):
+        supported = ", ".join(str(dtype) for dtype in SUPPORTED_INPUT_DTYPES)
+        raise TypeError(f"decode data inputs must use one of {supported}")
+
+    if lower_bound is not None:
+        if not isinstance(lower_bound, Real) or isinstance(lower_bound, bool):
+            raise TypeError("lower_bound must be a real scalar or None")
+        lower_bound = float(lower_bound)
+        if not math.isfinite(lower_bound) or lower_bound >= 0:
+            raise ValueError(f"lower_bound must be finite and negative, got {lower_bound}")
+    if scale is None:
+        scale = key_dim**-0.5
+    elif not isinstance(scale, Real) or isinstance(scale, bool):
+        raise TypeError("scale must be a real scalar or None")
+    else:
+        scale = float(scale)
+        if not math.isfinite(scale) or scale <= 0:
+            raise ValueError(f"scale must be finite and positive, got {scale}")
+
+    return _fused_recurrent_decode_forward(
+        packed_qkv,
+        raw_gate,
+        raw_beta,
+        A_log,
+        dt_bias,
+        state_cache,
+        state_indices,
+        0.0 if lower_bound is None else lower_bound,
+        lower_bound is not None,
+        scale,
+    )
+
+
+__all__ = ["Impl", "chunk_kda", "recurrent_kda", "recurrent_kda_decode"]

--- a/attn_gym/linear/kda/fwd/triton/recurrent.py
+++ b/attn_gym/linear/kda/fwd/triton/recurrent.py
@@ -19,6 +19,8 @@ import torch
 import triton
 import triton.language as tl
 
+from attn_gym.linear.kda.ops import recurrent_decode_forward as decode_forward
+from attn_gym.linear.kda.ops import recurrent_decode_op as _recurrent_decode_op
 from attn_gym.linear.kda.ops import recurrent_forward as forward
 from attn_gym.linear.kda.ops import (
     recurrent_fwd_no_state_op as _recurrent_fwd_no_state_op,
@@ -41,9 +43,15 @@ def kda_recurrent_fwd_kernel(
     ht,
     cu_seqlens,
     state_indices,
+    A_log,
+    dt_bias,
+    lower_bound,
     scale,
     T,
     state_batch_stride: tl.constexpr,
+    qkv_token_stride: tl.constexpr,
+    gate_token_stride: tl.constexpr,
+    beta_token_stride: tl.constexpr,
     H: tl.constexpr,
     K: tl.constexpr,
     V: tl.constexpr,
@@ -53,6 +61,8 @@ def kda_recurrent_fwd_kernel(
     STORE_FINAL_STATE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     USE_STATE_INDICES: tl.constexpr,
+    FUSE_DECODE_PREPROCESSING: tl.constexpr,
+    USE_LOWER_BOUND: tl.constexpr,
 ):
     pid = tl.program_id(0).to(tl.int64)
     NV = tl.cdiv(V, BV)
@@ -96,13 +106,40 @@ def kda_recurrent_fwd_kernel(
 
     for t in range(bos, eos):
         row = t * H + i_h
-        b_q = tl.load(q + row * K + o_k, mask=m_k, other=0.0).to(tl.float32) * scale
-        b_k = tl.load(k + row * K + o_k, mask=m_k, other=0.0).to(tl.float32)
-        b_g = tl.load(gate + row * K + o_k, mask=m_k, other=0.0).to(tl.float32)
-        b_beta = tl.load(beta + row).to(tl.float32)
-        b_v = tl.load(v + row * V + o_v, mask=m_v, other=0.0).to(tl.float32)
+        if FUSE_DECODE_PREPROCESSING:
+            head_offset = i_h * (2 * K + V)
+            p_qkv = q + t * qkv_token_stride + head_offset
+            b_q = tl.load(p_qkv + o_k, mask=m_k, other=0.0).to(tl.float32)
+            b_k = tl.load(p_qkv + K + o_k, mask=m_k, other=0.0).to(tl.float32)
+            b_v = tl.load(p_qkv + 2 * K + o_v, mask=m_v, other=0.0).to(tl.float32)
+            b_q *= tl.rsqrt(tl.sum(b_q * b_q) + 1e-6)
+            b_k *= tl.rsqrt(tl.sum(b_k * b_k) + 1e-6)
 
-        b_state *= tl.exp2(b_g)[:, None]
+            p_gate = gate + t * gate_token_stride + i_h * K + o_k
+            b_gate_input = tl.load(p_gate, mask=m_k, other=0.0).to(tl.float32)
+            b_gate_input += tl.load(dt_bias + i_h * K + o_k, mask=m_k, other=0.0).to(tl.float32)
+            b_a = tl.exp(tl.load(A_log + i_h).to(tl.float32))
+            if USE_LOWER_BOUND:
+                b_gate = lower_bound * tl.sigmoid(b_a * b_gate_input)
+            else:
+                b_softplus = tl.where(
+                    b_gate_input > 20.0,
+                    b_gate_input,
+                    tl.log(1.0 + tl.exp(b_gate_input)),
+                )
+                b_gate = -b_a * b_softplus
+            b_decay = tl.exp(b_gate)
+            b_beta = tl.sigmoid(tl.load(beta + t * beta_token_stride + i_h).to(tl.float32))
+        else:
+            b_q = tl.load(q + row * K + o_k, mask=m_k, other=0.0).to(tl.float32)
+            b_k = tl.load(k + row * K + o_k, mask=m_k, other=0.0).to(tl.float32)
+            b_g = tl.load(gate + row * K + o_k, mask=m_k, other=0.0).to(tl.float32)
+            b_beta = tl.load(beta + row).to(tl.float32)
+            b_v = tl.load(v + row * V + o_v, mask=m_v, other=0.0).to(tl.float32)
+            b_decay = tl.exp2(b_g)
+
+        b_q *= scale
+        b_state *= b_decay[:, None]
         b_delta = (b_v - tl.sum(b_k[:, None] * b_state, 0)) * b_beta
         b_state += b_k[:, None] * b_delta[None, :]
         b_o = tl.sum(b_q[:, None] * b_state, 0)
@@ -159,9 +196,15 @@ def _launch_recurrent_fwd(
         final_state,
         cu_seqlens,
         state_indices,
+        None,
+        None,
+        0.0,
         scale=key_dim**-0.5,
         T=tokens,
         state_batch_stride=state_batch_stride,
+        qkv_token_stride=0,
+        gate_token_stride=0,
+        beta_token_stride=0,
         H=heads,
         K=key_dim,
         V=value_dim,
@@ -171,6 +214,8 @@ def _launch_recurrent_fwd(
         STORE_FINAL_STATE=final_state is not None,
         IS_VARLEN=cu_seqlens is not None,
         USE_STATE_INDICES=state_indices is not None,
+        FUSE_DECODE_PREPROCESSING=False,
+        USE_LOWER_BOUND=False,
         num_warps=4,
     )
     return output, final_state
@@ -229,9 +274,64 @@ def _kda_recurrent_fwd_paged_cuda(
     )[0]
 
 
+def _kda_recurrent_decode_cuda(
+    packed_qkv: torch.Tensor,
+    raw_gate: torch.Tensor,
+    raw_beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    state_cache: torch.Tensor,
+    state_indices: torch.Tensor,
+    lower_bound: float,
+    use_lower_bound: bool,
+    scale: float,
+) -> torch.Tensor:
+    batch = packed_qkv.shape[0]
+    heads, key_dim, value_dim = state_cache.shape[1:]
+    output = packed_qkv.new_empty(1, batch, heads, value_dim)
+    block_v = min(triton.next_power_of_2(value_dim), 32)
+    grid = (triton.cdiv(value_dim, block_v) * batch * heads,)
+    kda_recurrent_fwd_kernel[grid](
+        packed_qkv,
+        packed_qkv,
+        packed_qkv,
+        raw_gate,
+        raw_beta,
+        output,
+        state_cache,
+        state_cache,
+        None,
+        state_indices,
+        A_log,
+        dt_bias,
+        lower_bound,
+        scale=scale,
+        T=1,
+        state_batch_stride=state_cache.stride(0),
+        qkv_token_stride=packed_qkv.stride(0),
+        gate_token_stride=raw_gate.stride(1),
+        beta_token_stride=raw_beta.stride(1),
+        H=heads,
+        K=key_dim,
+        V=value_dim,
+        BK=triton.next_power_of_2(key_dim),
+        BV=block_v,
+        USE_INITIAL_STATE=True,
+        STORE_FINAL_STATE=True,
+        IS_VARLEN=False,
+        USE_STATE_INDICES=True,
+        FUSE_DECODE_PREPROCESSING=True,
+        USE_LOWER_BOUND=use_lower_bound,
+        num_warps=4,
+    )
+    return output
+
+
 __all__ = [
+    "_recurrent_decode_op",
     "_recurrent_fwd_no_state_op",
     "_recurrent_fwd_op",
     "_recurrent_fwd_paged_op",
+    "decode_forward",
     "forward",
 ]

--- a/attn_gym/linear/kda/ops.py
+++ b/attn_gym/linear/kda/ops.py
@@ -71,6 +71,12 @@ torch.library.define(
     " Tensor state_indices, Tensor? cu_seqlens) -> Tensor",
 )
 torch.library.define(
+    "attn_gym::kda_recurrent_decode",
+    "(Tensor packed_qkv, Tensor raw_gate, Tensor raw_beta, Tensor A_log, Tensor dt_bias,"
+    " Tensor(a!) state_cache, Tensor state_indices, float lower_bound, bool use_lower_bound,"
+    " float scale) -> Tensor",
+)
+torch.library.define(
     "attn_gym::kda_prepare_chunk_offsets",
     "(Tensor cu_seqlens, SymInt tokens, int chunk_size) -> Tensor",
 )
@@ -131,6 +137,10 @@ def _recurrent_fwd_paged_cuda(*args):
     return _recurrent_backend()._kda_recurrent_fwd_paged_cuda(*args)
 
 
+def _recurrent_decode_cuda(*args):
+    return _recurrent_backend()._kda_recurrent_decode_cuda(*args)
+
+
 def _prepare_chunk_offsets_cuda(*args):
     from attn_gym.linear.kda.chunk_scheduler import _prepare_ragged_chunk_offsets
 
@@ -161,6 +171,11 @@ torch.library.impl(
     "attn_gym::kda_recurrent_fwd_paged",
     "CUDA",
     _recurrent_fwd_paged_cuda,
+)
+torch.library.impl(
+    "attn_gym::kda_recurrent_decode",
+    "CUDA",
+    _recurrent_decode_cuda,
 )
 torch.library.impl(
     "attn_gym::kda_prepare_chunk_offsets",
@@ -347,6 +362,23 @@ def _recurrent_fwd_paged_fake(
     return torch.empty_like(v, dtype=q.dtype)
 
 
+@torch.library.register_fake("attn_gym::kda_recurrent_decode")
+def _recurrent_decode_fake(
+    packed_qkv: torch.Tensor,
+    raw_gate: torch.Tensor,
+    raw_beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    state_cache: torch.Tensor,
+    state_indices: torch.Tensor,
+    lower_bound: float,
+    use_lower_bound: bool,
+    scale: float,
+) -> torch.Tensor:
+    del raw_gate, raw_beta, A_log, dt_bias, state_indices, lower_bound, use_lower_bound, scale
+    return packed_qkv.new_empty(1, packed_qkv.shape[0], state_cache.shape[1], state_cache.shape[3])
+
+
 @torch.library.register_fake("attn_gym::kda_prepare_chunk_offsets")
 def _prepare_chunk_offsets_fake(
     cu_seqlens: torch.Tensor,
@@ -366,6 +398,7 @@ chunk_bwd_with_state_grad_op = torch.ops.attn_gym.kda_chunk_bwd_with_state_grad.
 recurrent_fwd_op = torch.ops.attn_gym.kda_recurrent_fwd.default
 recurrent_fwd_no_state_op = torch.ops.attn_gym.kda_recurrent_fwd_no_state.default
 recurrent_fwd_paged_op = torch.ops.attn_gym.kda_recurrent_fwd_paged.default
+recurrent_decode_op = torch.ops.attn_gym.kda_recurrent_decode.default
 prepare_chunk_offsets_op = torch.ops.attn_gym.kda_prepare_chunk_offsets.default
 
 
@@ -409,6 +442,41 @@ def recurrent_forward(
     return recurrent_fwd_no_state_op(q, k, v, gate, beta, initial_state, cu_seqlens), None
 
 
+def recurrent_decode_forward(
+    packed_qkv: torch.Tensor,
+    raw_gate: torch.Tensor,
+    raw_beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    state_cache: torch.Tensor,
+    state_indices: torch.Tensor,
+    lower_bound: float,
+    use_lower_bound: bool,
+    scale: float,
+) -> torch.Tensor:
+    """Invoke the lazily loaded fused decode implementation."""
+    if not packed_qkv.is_cuda:
+        raise ValueError("recurrent_kda_decode requires CUDA tensors")
+    data_tensors = (packed_qkv, raw_gate, raw_beta, A_log, dt_bias, state_cache)
+    if torch.is_grad_enabled() and any(tensor.requires_grad for tensor in data_tensors):
+        raise RuntimeError(
+            "recurrent_kda_decode is inference-only and has no backward; "
+            "call under torch.no_grad() / torch.inference_mode()"
+        )
+    return recurrent_decode_op(
+        packed_qkv,
+        raw_gate,
+        raw_beta,
+        A_log,
+        dt_bias,
+        state_cache,
+        state_indices,
+        lower_bound,
+        use_lower_bound,
+        scale,
+    )
+
+
 __all__ = [
     "chunk_bwd_op",
     "chunk_bwd_with_state_grad_op",
@@ -417,6 +485,8 @@ __all__ = [
     "chunk_fwd_ragged_with_state_op",
     "chunk_fwd_with_state_op",
     "prepare_chunk_offsets_op",
+    "recurrent_decode_forward",
+    "recurrent_decode_op",
     "recurrent_forward",
     "recurrent_fwd_no_state_op",
     "recurrent_fwd_op",

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -213,7 +213,7 @@ the model's packed-sequence metadata, cache layout, and distributed execution po
 short convolution, factorized gates, and learned gated RMS normalization match
 the production structure but remain ordinary PyTorch teaching implementations.
 
-The two public KDA cores are `chunk_kda` (training and prefill; consumes the
+The general public KDA cores are `chunk_kda` (training and prefill; consumes the
 chunk-local inclusive cumulative log2 gate from `bounded_gate_cumsum(chunk_size=64)`
 without a second cumulative sum) and `recurrent_kda` (decode and inference prefill;
 consumes the per-token log2 gate from `bounded_gate_cumsum(chunk_size=1)`). Both
@@ -225,12 +225,15 @@ any hardware and head dimension, and stays differentiable. There is no automatic
 fallback between the two, and the chunk-versus-recurrent switch is caller policy
 (on B200 the scan wins below roughly 32 tokens per sequence).
 
-The serving limitations listed under `recurrent_kda` below are deliberate and
-the contract is otherwise stable to build against; CUDA-graph capture amortizes
-the multi-launch decode step.
+`recurrent_kda_decode` is the serving-specific one-token path. It consumes
+head-interleaved post-convolution QKV, raw gate and beta projections, and a paged
+state cache. Q/K normalization, gate activation, beta sigmoid, recurrence, output,
+and state-cache update run in one Triton kernel.
 
 ::: attn_gym.linear.chunk_kda
 
 ::: attn_gym.linear.recurrent_kda
+
+::: attn_gym.linear.recurrent_kda_decode
 
 ::: attn_gym.linear.Impl

--- a/test/test_kda_imports.py
+++ b/test/test_kda_imports.py
@@ -35,7 +35,7 @@ def test_reference_api_imports_without_optional_kernel_dependencies():
 
         builtins.__import__ = reject_optional_backends
 
-        from attn_gym.linear import chunk_kda, recurrent_kda
+        from attn_gym.linear import chunk_kda, recurrent_kda, recurrent_kda_decode
 
         shape = (1, 3, 1, 2)
         q = torch.randn(shape)
@@ -45,6 +45,7 @@ def test_reference_api_imports_without_optional_kernel_dependencies():
         beta = torch.rand(shape[:3])
         recurrent_kda(q, k, v, gate, beta, impl='reference')
         chunk_kda(q, k, v, gate, beta, impl='reference')
+        assert callable(recurrent_kda_decode)
         """
     )
 

--- a/test/test_kda_recurrent_decode.py
+++ b/test/test_kda_recurrent_decode.py
@@ -1,0 +1,329 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Correctness and integration tests for fused serving-oriented KDA decode."""
+
+import math
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+pytest.importorskip("triton")
+
+from attn_gym.linear import recurrent_kda_decode
+from attn_gym.linear.kda.naive import naive_recurrent_kda
+from attn_gym.linear.kda.ops import recurrent_decode_op
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="recurrent_kda_decode requires CUDA"
+)
+
+
+def _strided_state_pool(
+    num_slots: int,
+    heads: int,
+    key_dim: int,
+    value_dim: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    prefix, suffix = 11, 17
+    state_elements = heads * key_dim * value_dim
+    storage = torch.randn(
+        num_slots, prefix + state_elements + suffix, device="cuda", dtype=torch.float32
+    )
+    state = storage[:, prefix : prefix + state_elements].view(num_slots, heads, key_dim, value_dim)
+    assert not state.is_contiguous()
+    return storage, state
+
+
+def _decode_inputs(
+    *,
+    batch: int = 3,
+    heads: int = 2,
+    key_dim: int = 64,
+    value_dim: int = 64,
+    dtype: torch.dtype = torch.bfloat16,
+    seed: int = 0,
+):
+    torch.manual_seed(seed)
+    packed_qkv = torch.randn(
+        batch,
+        heads,
+        2 * key_dim + value_dim,
+        device="cuda",
+        dtype=dtype,
+    ).flatten(1)
+    raw_gate = torch.randn(1, batch, heads, key_dim, device="cuda", dtype=dtype)
+    raw_beta = torch.randn(1, batch, heads, device="cuda", dtype=dtype)
+    A_log = 0.1 * torch.randn(heads, device="cuda", dtype=torch.float32)
+    dt_bias = 0.1 * torch.randn(heads, key_dim, device="cuda", dtype=torch.float32)
+    storage, state_cache = _strided_state_pool(7, heads, key_dim, value_dim)
+    state_indices = torch.tensor([5, 1, 3], device="cuda", dtype=torch.int32)[:batch]
+    return (
+        packed_qkv,
+        raw_gate,
+        raw_beta,
+        A_log,
+        dt_bias,
+        storage,
+        state_cache,
+        state_indices,
+    )
+
+
+def _reference_decode(
+    packed_qkv: torch.Tensor,
+    raw_gate: torch.Tensor,
+    raw_beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    state_cache: torch.Tensor,
+    state_indices: torch.Tensor,
+    lower_bound: float | None,
+    scale: float | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    batch = packed_qkv.shape[0]
+    heads, key_dim, value_dim = state_cache.shape[1:]
+    per_head = packed_qkv.view(batch, heads, 2 * key_dim + value_dim)
+    q = per_head[..., :key_dim].unsqueeze(1).float()
+    k = per_head[..., key_dim : 2 * key_dim].unsqueeze(1).float()
+    v = per_head[..., 2 * key_dim :].unsqueeze(1)
+    q *= torch.rsqrt(q.square().sum(-1, keepdim=True) + 1e-6)
+    k *= torch.rsqrt(k.square().sum(-1, keepdim=True) + 1e-6)
+
+    gate_input = raw_gate.float() + dt_bias[None, None]
+    decay = A_log.exp()[None, None, :, None]
+    if lower_bound is None:
+        gate = -decay * F.softplus(gate_input)
+    else:
+        gate = lower_bound * torch.sigmoid(decay * gate_input)
+    gate *= math.log2(math.e)
+    beta = raw_beta.float().sigmoid()
+
+    active = state_indices > 0
+    output = packed_qkv.new_zeros(1, batch, heads, value_dim)
+    expected_cache = state_cache.clone()
+    if active.any():
+        active_indices = state_indices[active].long()
+        active_output, active_state = naive_recurrent_kda(
+            q[active],
+            k[active],
+            v[active],
+            gate[:, active].transpose(0, 1),
+            beta[:, active].transpose(0, 1),
+            scale=scale,
+            initial_state=state_cache[active_indices],
+            output_final_state=True,
+        )
+        output[:, active] = active_output.transpose(0, 1).to(output.dtype)
+        expected_cache[active_indices] = active_state
+    return output, expected_cache
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("lower_bound", [-5.0, None])
+@pytest.mark.parametrize(("key_dim", "value_dim"), [(64, 64), (80, 48)])
+def test_recurrent_decode_matches_reference(
+    dtype: torch.dtype,
+    lower_bound: float | None,
+    key_dim: int,
+    value_dim: int,
+):
+    inputs = _decode_inputs(dtype=dtype, key_dim=key_dim, value_dim=value_dim)
+    packed_qkv, raw_gate, raw_beta, A_log, dt_bias, _, state_cache, state_indices = inputs
+    before = state_cache.clone()
+
+    output = recurrent_kda_decode(
+        packed_qkv,
+        raw_gate,
+        raw_beta,
+        A_log,
+        dt_bias,
+        state_cache,
+        state_indices,
+        lower_bound=lower_bound,
+    )
+    expected, expected_cache = _reference_decode(
+        packed_qkv,
+        raw_gate,
+        raw_beta,
+        A_log,
+        dt_bias,
+        before,
+        state_indices,
+        lower_bound,
+    )
+
+    tolerance = 1e-5 if dtype == torch.float32 else 3e-2
+    assert output.shape == expected.shape and output.dtype == dtype
+    torch.testing.assert_close(output.float(), expected.float(), rtol=tolerance, atol=tolerance)
+    torch.testing.assert_close(state_cache, expected_cache, rtol=tolerance, atol=tolerance)
+
+
+@pytest.mark.parametrize("padding_slot", [0, -1])
+def test_recurrent_decode_padding_slot_is_ignored(padding_slot: int):
+    inputs = list(_decode_inputs())
+    inputs[-1] = torch.tensor([5, padding_slot, 3], device="cuda", dtype=torch.int32)
+    packed_qkv, raw_gate, raw_beta, A_log, dt_bias, _, state_cache, state_indices = inputs
+    before = state_cache.clone()
+
+    output = recurrent_kda_decode(
+        packed_qkv, raw_gate, raw_beta, A_log, dt_bias, state_cache, state_indices
+    )
+
+    torch.testing.assert_close(output[:, 1], torch.zeros_like(output[:, 1]), rtol=0, atol=0)
+    torch.testing.assert_close(state_cache[0], before[0], rtol=0, atol=0)
+
+
+def test_recurrent_decode_validates_contract():
+    inputs = list(_decode_inputs(batch=2))
+    packed_qkv, raw_gate, raw_beta, A_log, dt_bias, _, state_cache, state_indices = inputs
+    with pytest.raises(ValueError, match="packed_qkv must have shape"):
+        recurrent_kda_decode(
+            packed_qkv[:, :-1],
+            raw_gate,
+            raw_beta,
+            A_log,
+            dt_bias,
+            state_cache,
+            state_indices,
+        )
+    with pytest.raises(ValueError, match="raw_gate must have shape"):
+        recurrent_kda_decode(
+            packed_qkv,
+            raw_gate[..., :-1],
+            raw_beta,
+            A_log,
+            dt_bias,
+            state_cache,
+            state_indices,
+        )
+    with pytest.raises(TypeError, match="state_cache must use float32"):
+        recurrent_kda_decode(
+            packed_qkv,
+            raw_gate,
+            raw_beta,
+            A_log,
+            dt_bias,
+            state_cache.bfloat16(),
+            state_indices,
+        )
+    with pytest.raises(ValueError, match="finite and negative"):
+        recurrent_kda_decode(
+            packed_qkv,
+            raw_gate,
+            raw_beta,
+            A_log,
+            dt_bias,
+            state_cache,
+            state_indices,
+            lower_bound=1.0,
+        )
+
+
+def test_recurrent_decode_rejects_gradient_tracking():
+    inputs = list(_decode_inputs(batch=2))
+    inputs[0] = inputs[0].requires_grad_()
+    with pytest.raises(RuntimeError, match="inference-only"):
+        recurrent_kda_decode(
+            inputs[0], inputs[1], inputs[2], inputs[3], inputs[4], inputs[6], inputs[7]
+        )
+
+
+@pytest.mark.parametrize("lower_bound", [-5.0, None])
+def test_recurrent_decode_custom_op_registration(lower_bound: float | None):
+    inputs = _decode_inputs(batch=2)
+    packed_qkv, raw_gate, raw_beta, A_log, dt_bias, _, state_cache, state_indices = inputs
+    torch.library.opcheck(
+        recurrent_decode_op,
+        (
+            packed_qkv,
+            raw_gate,
+            raw_beta,
+            A_log,
+            dt_bias,
+            state_cache,
+            state_indices,
+            0.0 if lower_bound is None else lower_bound,
+            lower_bound is not None,
+            state_cache.shape[2] ** -0.5,
+        ),
+    )
+
+
+@pytest.mark.parametrize("lower_bound", [-5.0, None])
+def test_recurrent_decode_fullgraph_compile(lower_bound: float | None):
+    inputs = _decode_inputs(batch=2)
+    packed_qkv, raw_gate, raw_beta, A_log, dt_bias, _, eager_cache, state_indices = inputs
+    _, compiled_cache = _strided_state_pool(
+        eager_cache.shape[0], eager_cache.shape[1], eager_cache.shape[2], eager_cache.shape[3]
+    )
+    compiled_cache.copy_(eager_cache)
+
+    expected = recurrent_kda_decode(
+        packed_qkv,
+        raw_gate,
+        raw_beta,
+        A_log,
+        dt_bias,
+        eager_cache,
+        state_indices,
+        lower_bound=lower_bound,
+    )
+    compiled = torch.compile(recurrent_kda_decode, fullgraph=True)
+    output = compiled(
+        packed_qkv,
+        raw_gate,
+        raw_beta,
+        A_log,
+        dt_bias,
+        compiled_cache,
+        state_indices,
+        lower_bound=lower_bound,
+    )
+
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+    torch.testing.assert_close(compiled_cache, eager_cache, rtol=0, atol=0)
+
+
+def test_recurrent_decode_cuda_graph_replay():
+    inputs = _decode_inputs(batch=3, seed=4)
+    packed_qkv, raw_gate, raw_beta, A_log, dt_bias, storage, state_cache, state_indices = inputs
+    recurrent_kda_decode(
+        packed_qkv, raw_gate, raw_beta, A_log, dt_bias, state_cache, state_indices
+    )
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_output = recurrent_kda_decode(
+            packed_qkv, raw_gate, raw_beta, A_log, dt_bias, state_cache, state_indices
+        )
+
+    with torch.no_grad():
+        state_cache.add_(0.25)
+        state_indices.copy_(torch.tensor([6, 0, 2], device="cuda", dtype=torch.int32))
+        packed_qkv.add_(0.1)
+        raw_gate.mul_(0.9)
+        raw_beta.add_(0.2)
+    expected_storage = storage.clone()
+    state_elements = state_cache[0].numel()
+    expected_cache = expected_storage[:, 11 : 11 + state_elements].view_as(state_cache)
+    expected = recurrent_kda_decode(
+        packed_qkv,
+        raw_gate,
+        raw_beta,
+        A_log,
+        dt_bias,
+        expected_cache,
+        state_indices,
+    )
+
+    graph.replay()
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(captured_output, expected, rtol=0, atol=0)
+    torch.testing.assert_close(storage, expected_storage, rtol=0, atol=0)


### PR DESCRIPTION
do everything after conv in one kernel for perf, matches vllm 
also this is specialized for t = 1

<img width="416" height="204" alt="Screenshot 2026-08-18 at 11 37 16 AM" src="https://github.com/user-attachments/assets/4d975ad3-6e79-4ea4-9477-9ecdd93a7d28" />

Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #334
* #335
* #333

