### PR TITLE
optimize general recurrent kernel

### DIFF
--- a/attn_gym/linear/kda/api.py
+++ b/attn_gym/linear/kda/api.py
@@ -225,7 +225,7 @@ def recurrent_kda(
     separate launches, and speculative-decoding rollback is unsupported.
     """
     selected_impl = _resolve_impl(impl)
-    # a paged pool's leading dimension is the slot count, not the sequence count, so the
+    # A paged pool's leading dimension is the slot count, not the sequence count, so the
     # shared per-sequence state check does not apply; the pool is checked below instead.
     validate_kda_inputs(
         q,

--- a/attn_gym/linear/kda/api.py
+++ b/attn_gym/linear/kda/api.py
@@ -209,9 +209,9 @@ def recurrent_kda(
             active slot must lie in ``[1, num_slots)`` and differ from every other active
             slot. Non-positive indices are padding: they produce zero output and leave the
             pool untouched. Empty packed sequences touch no state. ``"fused"`` only.
-        autotune: Reserved for implementation parity with ``chunk_kda``. The
-            current recurrent kernel uses the same fixed launch policy for both
-            values.
+        autotune: Benchmark candidate value-tile sizes when true; winners are
+            cached and reused. When false, use a deterministic sequence-length
+            heuristic.
         impl: ``"fused"`` uses the inference-only optimized scan; ``"reference"``
             uses differentiable eager PyTorch in FP32, with no automatic
             fallback.
@@ -224,9 +224,8 @@ def recurrent_kda(
     sequences and final states are written out of place, decode preprocessing and scan are
     separate launches, and speculative-decoding rollback is unsupported.
     """
-    del autotune
     selected_impl = _resolve_impl(impl)
-    # A paged pool's leading dimension is the slot count, not the sequence count, so the
+    # a paged pool's leading dimension is the slot count, not the sequence count, so the
     # shared per-sequence state check does not apply; the pool is checked below instead.
     validate_kda_inputs(
         q,
@@ -254,6 +253,7 @@ def recurrent_kda(
             cu_seqlens=cu_seqlens,
             output_final_state=output_final_state,
             state_indices=state_indices,
+            autotune=autotune,
         )
     return reference_kda(
         naive_recurrent_kda, q, k, v, gate, beta, initial_state, cu_seqlens, output_final_state

--- a/attn_gym/linear/kda/fwd/triton/recurrent.py
+++ b/attn_gym/linear/kda/fwd/triton/recurrent.py
@@ -15,12 +15,11 @@ inference-only; use ``chunk_kda`` for training.
 
 from __future__ import annotations
 
-import threading
-
 import torch
 import triton
 import triton.language as tl
 
+from attn_gym._backends.triton.utils import ptr_offset
 from attn_gym.linear.kda.ops import recurrent_forward as forward
 from attn_gym.linear.kda.ops import (
     recurrent_fwd_no_state_op as _recurrent_fwd_no_state_op,
@@ -38,28 +37,8 @@ def _prune_recurrent_configs(configs, _named_args, V, **_):
     return [config for config in configs if config.kwargs["BV"] <= max_block_v]
 
 
-@triton.autotune(
-    configs=[
-        triton.Config({"BV": block_v}, num_warps=num_warps, num_stages=3)
-        for block_v in (32, 16, 8)
-        for num_warps in (2, 4)
-    ],
-    key=[
-        "T",
-        "N",
-        "H",
-        "K",
-        "V",
-        "USE_INITIAL_STATE",
-        "STORE_FINAL_STATE",
-        "IS_VARLEN",
-        "USE_STATE_INDICES",
-    ],
-    prune_configs_by={"early_config_prune": _prune_recurrent_configs},
-    **autotune_cache_kwargs,
-)
 @triton.jit
-def kda_recurrent_fwd_kernel(
+def _kda_recurrent_fwd_kernel(
     q,
     k,
     v,
@@ -83,7 +62,6 @@ def kda_recurrent_fwd_kernel(
     STORE_FINAL_STATE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     USE_STATE_INDICES: tl.constexpr,
-    CONTIGUOUS_FINAL_STATE: tl.constexpr,
 ):
     pid = tl.program_id(0).to(tl.int64)
     NV = tl.cdiv(V, BV)
@@ -118,7 +96,10 @@ def kda_recurrent_fwd_kernel(
             return
     else:
         i_state = i_n
-    p_state = i_state * state_batch_stride + i_h * K * V + o_k[:, None] * V + o_v[None, :]
+    p_state = ptr_offset(
+        (i_state, i_h, o_k[:, None], o_v[None, :]),
+        (state_batch_stride, K * V, V, 1),
+    )
     if USE_INITIAL_STATE:
         b_state = tl.load(h0 + p_state, mask=m_kv, other=0.0).to(tl.float32)
     else:
@@ -139,16 +120,30 @@ def kda_recurrent_fwd_kernel(
         tl.store(output + row * V + o_v, b_o.to(output.dtype.element_ty), mask=m_v)
 
     if STORE_FINAL_STATE:
-        if CONTIGUOUS_FINAL_STATE:
-            p_final_state = i_n * H * K * V + i_h * K * V + o_k[:, None] * V + o_v[None, :]
-        else:
-            p_final_state = p_state
-        tl.store(ht + p_final_state, b_state, mask=m_kv)
+        tl.store(ht + p_state, b_state, mask=m_kv)
 
 
-_fixed_recurrent_fwd_kernel = kda_recurrent_fwd_kernel.fn
-_recurrent_autotune_configs: dict[tuple[object, ...], dict[str, object]] = {}
-_recurrent_autotune_lock = threading.Lock()
+kda_recurrent_fwd_kernel = triton.autotune(
+    configs=[
+        triton.Config({"BV": block_v}, num_warps=num_warps, num_stages=3)
+        for block_v in (32, 16, 8)
+        for num_warps in (2, 4)
+    ],
+    key=[
+        "T",
+        "N",
+        "H",
+        "K",
+        "V",
+        "USE_INITIAL_STATE",
+        "STORE_FINAL_STATE",
+        "IS_VARLEN",
+        "USE_STATE_INDICES",
+    ],
+    prune_configs_by={"early_config_prune": _prune_recurrent_configs},
+    restore_value=["h0"],
+    **autotune_cache_kwargs,
+)(_kda_recurrent_fwd_kernel)
 
 
 def _launch_recurrent_fwd(
@@ -188,7 +183,7 @@ def _launch_recurrent_fwd(
     # grid-Y limit, while grid-X is effectively unbounded.
     grid = lambda meta: (triton.cdiv(value_dim, meta["BV"]) * num_sequences * heads,)
 
-    def launch(kernel, target_final_state, contiguous_final_state, launch_options):
+    def launch(kernel, launch_options):
         kernel[grid](
             q,
             k,
@@ -197,7 +192,7 @@ def _launch_recurrent_fwd(
             beta,
             output,
             initial_state,
-            target_final_state,
+            final_state,
             cu_seqlens,
             state_indices,
             scale=key_dim**-0.5,
@@ -209,68 +204,25 @@ def _launch_recurrent_fwd(
             V=value_dim,
             BK=triton.next_power_of_2(key_dim),
             USE_INITIAL_STATE=initial_state is not None,
-            STORE_FINAL_STATE=target_final_state is not None,
+            STORE_FINAL_STATE=final_state is not None,
             IS_VARLEN=cu_seqlens is not None,
             USE_STATE_INDICES=state_indices is not None,
-            CONTIGUOUS_FINAL_STATE=contiguous_final_state,
             **launch_options,
         )
 
+    kernel = kda_recurrent_fwd_kernel
+    launch_options = {}
     if not autotune:
         average_tokens = tokens if cu_seqlens is None else triton.cdiv(tokens, num_sequences)
         # smaller value tiles schedule scans of 32 or more tokens better on b200
         block_v_limit = 16 if average_tokens >= 32 else 32
-        launch(
-            _fixed_recurrent_fwd_kernel,
-            final_state,
-            False,
-            {
-                "BV": min(triton.next_power_of_2(value_dim), block_v_limit),
-                "num_warps": 4,
-                "num_stages": 3,
-            },
-        )
-        return output, final_state
-
-    tune_key = (
-        q.device.index,
-        tokens,
-        num_sequences,
-        heads,
-        key_dim,
-        value_dim,
-        initial_state is not None,
-        final_state is not None,
-        cu_seqlens is not None,
-        state_indices is not None,
-        q.dtype,
-        k.dtype,
-        v.dtype,
-        gate.dtype,
-        beta.dtype,
-        None if initial_state is None else initial_state.dtype,
-        None if cu_seqlens is None else cu_seqlens.dtype,
-        None if state_indices is None else state_indices.dtype,
-    )
-    launch_options = _recurrent_autotune_configs.get(tune_key)
-    result_is_ready = False
-    if launch_options is None:
-        with _recurrent_autotune_lock:
-            launch_options = _recurrent_autotune_configs.get(tune_key)
-            if launch_options is None:
-                tuning_final_state = final_state
-                contiguous_final_state = state_indices is not None
-                if contiguous_final_state:
-                    tuning_final_state = q.new_empty(
-                        num_sequences, heads, key_dim, value_dim, dtype=torch.float32
-                    )
-                launch(kda_recurrent_fwd_kernel, tuning_final_state, contiguous_final_state, {})
-                launch_options = dict(kda_recurrent_fwd_kernel.best_config.all_kwargs())
-                _recurrent_autotune_configs[tune_key] = launch_options
-                result_is_ready = not contiguous_final_state
-
-    if not result_is_ready:
-        launch(_fixed_recurrent_fwd_kernel, final_state, False, launch_options)
+        kernel = _kda_recurrent_fwd_kernel
+        launch_options = {
+            "BV": min(triton.next_power_of_2(value_dim), block_v_limit),
+            "num_warps": 4,
+            "num_stages": 3,
+        }
+    launch(kernel, launch_options)
     return output, final_state
 
 

--- a/attn_gym/linear/kda/fwd/triton/recurrent.py
+++ b/attn_gym/linear/kda/fwd/triton/recurrent.py
@@ -253,23 +253,24 @@ def _launch_recurrent_fwd(
         None if state_indices is None else state_indices.dtype,
     )
     launch_options = _recurrent_autotune_configs.get(tune_key)
+    result_is_ready = False
     if launch_options is None:
         with _recurrent_autotune_lock:
             launch_options = _recurrent_autotune_configs.get(tune_key)
             if launch_options is None:
-                if state_indices is None:
-                    launch(kda_recurrent_fwd_kernel, final_state, False, {})
-                else:
-                    tuning_state = q.new_empty(
+                tuning_final_state = final_state
+                contiguous_final_state = state_indices is not None
+                if contiguous_final_state:
+                    tuning_final_state = q.new_empty(
                         num_sequences, heads, key_dim, value_dim, dtype=torch.float32
                     )
-                    launch(kda_recurrent_fwd_kernel, tuning_state, True, {})
+                launch(kda_recurrent_fwd_kernel, tuning_final_state, contiguous_final_state, {})
                 launch_options = dict(kda_recurrent_fwd_kernel.best_config.all_kwargs())
                 _recurrent_autotune_configs[tune_key] = launch_options
-                if state_indices is None:
-                    return output, final_state
+                result_is_ready = not contiguous_final_state
 
-    launch(_fixed_recurrent_fwd_kernel, final_state, False, launch_options)
+    if not result_is_ready:
+        launch(_fixed_recurrent_fwd_kernel, final_state, False, launch_options)
     return output, final_state
 
 

--- a/attn_gym/linear/kda/fwd/triton/recurrent.py
+++ b/attn_gym/linear/kda/fwd/triton/recurrent.py
@@ -15,6 +15,8 @@ inference-only; use ``chunk_kda`` for training.
 
 from __future__ import annotations
 
+import threading
+
 import torch
 import triton
 import triton.language as tl
@@ -27,8 +29,35 @@ from attn_gym.linear.kda.ops import recurrent_fwd_op as _recurrent_fwd_op
 from attn_gym.linear.kda.ops import (
     recurrent_fwd_paged_op as _recurrent_fwd_paged_op,
 )
+from attn_gym.linear.kda.utils import autotune_cache_kwargs
 
 
+def _prune_recurrent_configs(configs, _named_args, V, **_):
+    """drop value tiles wider than the padded value dimension"""
+    max_block_v = max(8, triton.next_power_of_2(V))
+    return [config for config in configs if config.kwargs["BV"] <= max_block_v]
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BV": block_v}, num_warps=num_warps, num_stages=3)
+        for block_v in (32, 16, 8)
+        for num_warps in (2, 4)
+    ],
+    key=[
+        "T",
+        "N",
+        "H",
+        "K",
+        "V",
+        "USE_INITIAL_STATE",
+        "STORE_FINAL_STATE",
+        "IS_VARLEN",
+        "USE_STATE_INDICES",
+    ],
+    prune_configs_by={"early_config_prune": _prune_recurrent_configs},
+    **autotune_cache_kwargs,
+)
 @triton.jit
 def kda_recurrent_fwd_kernel(
     q,
@@ -43,6 +72,7 @@ def kda_recurrent_fwd_kernel(
     state_indices,
     scale,
     T,
+    N: tl.constexpr,
     state_batch_stride: tl.constexpr,
     H: tl.constexpr,
     K: tl.constexpr,
@@ -53,6 +83,7 @@ def kda_recurrent_fwd_kernel(
     STORE_FINAL_STATE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     USE_STATE_INDICES: tl.constexpr,
+    CONTIGUOUS_FINAL_STATE: tl.constexpr,
 ):
     pid = tl.program_id(0).to(tl.int64)
     NV = tl.cdiv(V, BV)
@@ -61,7 +92,7 @@ def kda_recurrent_fwd_kernel(
     i_n, i_h = i_nh // H, i_nh % H
 
     if IS_VARLEN:
-        # Assumption: seqlens have been validated prior to call
+        # assumption: seqlens have been validated prior to call
         bos = tl.load(cu_seqlens + i_n).to(tl.int64)
         eos = tl.load(cu_seqlens + i_n + 1).to(tl.int64)
     else:
@@ -108,7 +139,16 @@ def kda_recurrent_fwd_kernel(
         tl.store(output + row * V + o_v, b_o.to(output.dtype.element_ty), mask=m_v)
 
     if STORE_FINAL_STATE:
-        tl.store(ht + p_state, b_state, mask=m_kv)
+        if CONTIGUOUS_FINAL_STATE:
+            p_final_state = i_n * H * K * V + i_h * K * V + o_k[:, None] * V + o_v[None, :]
+        else:
+            p_final_state = p_state
+        tl.store(ht + p_final_state, b_state, mask=m_kv)
+
+
+_fixed_recurrent_fwd_kernel = kda_recurrent_fwd_kernel.fn
+_recurrent_autotune_configs: dict[tuple[object, ...], dict[str, object]] = {}
+_recurrent_autotune_lock = threading.Lock()
 
 
 def _launch_recurrent_fwd(
@@ -121,6 +161,7 @@ def _launch_recurrent_fwd(
     cu_seqlens: torch.Tensor | None,
     store_final_state: bool,
     state_indices: torch.Tensor | None = None,
+    autotune: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Allocate outputs and launch the sequential scan over token spans."""
     batch, tokens, heads, key_dim = q.shape
@@ -128,7 +169,7 @@ def _launch_recurrent_fwd(
     num_sequences = batch if cu_seqlens is None else cu_seqlens.shape[0] - 1
     output = torch.empty_like(v, dtype=q.dtype)
     if state_indices is not None:
-        # Paged mode reads and writes one slot, so `h0` and `ht` alias the pool and
+        # paged mode reads and writes one slot, so `h0` and `ht` alias the pool and
         # the scan needs no gather/scatter around it.
         final_state = initial_state
     elif store_final_state:
@@ -141,38 +182,90 @@ def _launch_recurrent_fwd(
         state_batch_stride = final_state.stride(0)
     else:
         state_batch_stride = heads * key_dim * value_dim
-    average_tokens = tokens if cu_seqlens is None else triton.cdiv(tokens, num_sequences)
-    # smaller value tiles schedule scans of 32 or more tokens better on b200
-    block_v_limit = 16 if average_tokens >= 32 else 32
-    block_v = min(triton.next_power_of_2(value_dim), block_v_limit)
-    # One flat launch dimension: sequence-head counts can exceed the 65,535
-    # grid-Y limit, while grid-X is effectively unbounded.
-    grid = (triton.cdiv(value_dim, block_v) * num_sequences * heads,)
-    kda_recurrent_fwd_kernel[grid](
-        q,
-        k,
-        v,
-        gate,
-        beta,
-        output,
-        initial_state,
-        final_state,
-        cu_seqlens,
-        state_indices,
-        scale=key_dim**-0.5,
-        T=tokens,
-        state_batch_stride=state_batch_stride,
-        H=heads,
-        K=key_dim,
-        V=value_dim,
-        BK=triton.next_power_of_2(key_dim),
-        BV=block_v,
-        USE_INITIAL_STATE=initial_state is not None,
-        STORE_FINAL_STATE=final_state is not None,
-        IS_VARLEN=cu_seqlens is not None,
-        USE_STATE_INDICES=state_indices is not None,
-        num_warps=4,
+    grid = lambda meta: (triton.cdiv(value_dim, meta["BV"]) * num_sequences * heads,)
+
+    def launch(kernel, target_final_state, contiguous_final_state, launch_options):
+        kernel[grid](
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            output,
+            initial_state,
+            target_final_state,
+            cu_seqlens,
+            state_indices,
+            scale=key_dim**-0.5,
+            T=tokens,
+            N=num_sequences,
+            state_batch_stride=state_batch_stride,
+            H=heads,
+            K=key_dim,
+            V=value_dim,
+            BK=triton.next_power_of_2(key_dim),
+            USE_INITIAL_STATE=initial_state is not None,
+            STORE_FINAL_STATE=target_final_state is not None,
+            IS_VARLEN=cu_seqlens is not None,
+            USE_STATE_INDICES=state_indices is not None,
+            CONTIGUOUS_FINAL_STATE=contiguous_final_state,
+            **launch_options,
+        )
+
+    if not autotune:
+        average_tokens = tokens if cu_seqlens is None else triton.cdiv(tokens, num_sequences)
+        # smaller value tiles schedule scans of 32 or more tokens better on b200
+        block_v_limit = 16 if average_tokens >= 32 else 32
+        launch(
+            _fixed_recurrent_fwd_kernel,
+            final_state,
+            False,
+            {
+                "BV": min(triton.next_power_of_2(value_dim), block_v_limit),
+                "num_warps": 4,
+                "num_stages": 3,
+            },
+        )
+        return output, final_state
+
+    tune_key = (
+        q.device.index,
+        tokens,
+        num_sequences,
+        heads,
+        key_dim,
+        value_dim,
+        initial_state is not None,
+        final_state is not None,
+        cu_seqlens is not None,
+        state_indices is not None,
+        q.dtype,
+        k.dtype,
+        v.dtype,
+        gate.dtype,
+        beta.dtype,
+        None if initial_state is None else initial_state.dtype,
+        None if cu_seqlens is None else cu_seqlens.dtype,
+        None if state_indices is None else state_indices.dtype,
     )
+    launch_options = _recurrent_autotune_configs.get(tune_key)
+    if launch_options is None:
+        with _recurrent_autotune_lock:
+            launch_options = _recurrent_autotune_configs.get(tune_key)
+            if launch_options is None:
+                if state_indices is None:
+                    launch(kda_recurrent_fwd_kernel, final_state, False, {})
+                else:
+                    tuning_state = q.new_empty(
+                        num_sequences, heads, key_dim, value_dim, dtype=torch.float32
+                    )
+                    launch(kda_recurrent_fwd_kernel, tuning_state, True, {})
+                launch_options = dict(kda_recurrent_fwd_kernel.best_config.all_kwargs())
+                _recurrent_autotune_configs[tune_key] = launch_options
+                if state_indices is None:
+                    return output, final_state
+
+    launch(_fixed_recurrent_fwd_kernel, final_state, False, launch_options)
     return output, final_state
 
 
@@ -184,9 +277,18 @@ def _kda_recurrent_fwd_cuda(
     beta: torch.Tensor,
     initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor | None,
+    autotune: bool,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     output, final_state = _launch_recurrent_fwd(
-        q, k, v, gate, beta, initial_state, cu_seqlens, store_final_state=True
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        initial_state,
+        cu_seqlens,
+        store_final_state=True,
+        autotune=autotune,
     )
     assert final_state is not None
     return output, final_state
@@ -200,9 +302,18 @@ def _kda_recurrent_fwd_no_state_cuda(
     beta: torch.Tensor,
     initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor | None,
+    autotune: bool,
 ) -> torch.Tensor:
     return _launch_recurrent_fwd(
-        q, k, v, gate, beta, initial_state, cu_seqlens, store_final_state=False
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        initial_state,
+        cu_seqlens,
+        store_final_state=False,
+        autotune=autotune,
     )[0]
 
 
@@ -215,6 +326,7 @@ def _kda_recurrent_fwd_paged_cuda(
     state_cache: torch.Tensor,
     state_indices: torch.Tensor,
     cu_seqlens: torch.Tensor | None,
+    autotune: bool,
 ) -> torch.Tensor:
     return _launch_recurrent_fwd(
         q,
@@ -226,6 +338,7 @@ def _kda_recurrent_fwd_paged_cuda(
         cu_seqlens,
         store_final_state=True,
         state_indices=state_indices,
+        autotune=autotune,
     )[0]
 
 

--- a/attn_gym/linear/kda/fwd/triton/recurrent.py
+++ b/attn_gym/linear/kda/fwd/triton/recurrent.py
@@ -92,7 +92,7 @@ def kda_recurrent_fwd_kernel(
     i_n, i_h = i_nh // H, i_nh % H
 
     if IS_VARLEN:
-        # assumption: seqlens have been validated prior to call
+        # Assumption: seqlens have been validated prior to call
         bos = tl.load(cu_seqlens + i_n).to(tl.int64)
         eos = tl.load(cu_seqlens + i_n + 1).to(tl.int64)
     else:
@@ -169,7 +169,7 @@ def _launch_recurrent_fwd(
     num_sequences = batch if cu_seqlens is None else cu_seqlens.shape[0] - 1
     output = torch.empty_like(v, dtype=q.dtype)
     if state_indices is not None:
-        # paged mode reads and writes one slot, so `h0` and `ht` alias the pool and
+        # Paged mode reads and writes one slot, so `h0` and `ht` alias the pool and
         # the scan needs no gather/scatter around it.
         final_state = initial_state
     elif store_final_state:
@@ -182,6 +182,10 @@ def _launch_recurrent_fwd(
         state_batch_stride = final_state.stride(0)
     else:
         state_batch_stride = heads * key_dim * value_dim
+    # BV=32 measured faster than 64 on B200 for both decode and prefill
+    # (smaller state tiles schedule better; state traffic is identical).
+    # One flat launch dimension: sequence-head counts can exceed the 65,535
+    # grid-Y limit, while grid-X is effectively unbounded.
     grid = lambda meta: (triton.cdiv(value_dim, meta["BV"]) * num_sequences * heads,)
 
     def launch(kernel, target_final_state, contiguous_final_state, launch_options):

--- a/attn_gym/linear/kda/fwd/triton/recurrent.py
+++ b/attn_gym/linear/kda/fwd/triton/recurrent.py
@@ -141,9 +141,10 @@ def _launch_recurrent_fwd(
         state_batch_stride = final_state.stride(0)
     else:
         state_batch_stride = heads * key_dim * value_dim
-    # BV=32 measured faster than 64 on B200 for both decode and prefill
-    # (smaller state tiles schedule better; state traffic is identical).
-    block_v = min(triton.next_power_of_2(value_dim), 32)
+    average_tokens = tokens if cu_seqlens is None else triton.cdiv(tokens, num_sequences)
+    # smaller value tiles schedule scans of 32 or more tokens better on b200
+    block_v_limit = 16 if average_tokens >= 32 else 32
+    block_v = min(triton.next_power_of_2(value_dim), block_v_limit)
     # One flat launch dimension: sequence-head counts can exceed the 65,535
     # grid-Y limit, while grid-X is effectively unbounded.
     grid = (triton.cdiv(value_dim, block_v) * num_sequences * heads,)

--- a/attn_gym/linear/kda/ops.py
+++ b/attn_gym/linear/kda/ops.py
@@ -14,7 +14,7 @@ import torch
 _CHUNK_SIZE = 64
 
 
-# Fixed-arity schema pairs avoid optional outputs on hot paths.
+# fixed-arity schema pairs avoid optional outputs on hot paths.
 _CHUNK_FWD_ARGS = (
     "(Tensor q, Tensor k, Tensor v, Tensor cumulative_gate, Tensor beta, Tensor? initial_state,"
     " bool autotune)"
@@ -59,16 +59,16 @@ torch.library.define(
 
 _RECURRENT_FWD_ARGS = (
     "(Tensor q, Tensor k, Tensor v, Tensor gate, Tensor beta,"
-    " Tensor? initial_state, Tensor? cu_seqlens)"
+    " Tensor? initial_state, Tensor? cu_seqlens, bool autotune)"
 )
 torch.library.define("attn_gym::kda_recurrent_fwd", _RECURRENT_FWD_ARGS + " -> (Tensor, Tensor)")
 torch.library.define("attn_gym::kda_recurrent_fwd_no_state", _RECURRENT_FWD_ARGS + " -> Tensor")
-# Separate schema: the paged variant advances the state pool in place, so the final state
+# separate schema: the paged variant advances the state pool in place, so the final state
 # is not an output and the alias annotation has to declare the mutation.
 torch.library.define(
     "attn_gym::kda_recurrent_fwd_paged",
     "(Tensor q, Tensor k, Tensor v, Tensor gate, Tensor beta, Tensor(a!) state_cache,"
-    " Tensor state_indices, Tensor? cu_seqlens) -> Tensor",
+    " Tensor state_indices, Tensor? cu_seqlens, bool autotune) -> Tensor",
 )
 torch.library.define(
     "attn_gym::kda_prepare_chunk_offsets",
@@ -309,8 +309,9 @@ def _recurrent_fwd_fake(
     beta: torch.Tensor,
     initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor | None,
+    autotune: bool,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    del k, gate, beta, initial_state
+    del k, gate, beta, initial_state, autotune
     num_sequences = q.shape[0] if cu_seqlens is None else cu_seqlens.shape[0] - 1
     final_state = q.new_empty(
         num_sequences, q.shape[2], q.shape[3], v.shape[-1], dtype=torch.float32
@@ -327,8 +328,9 @@ def _recurrent_fwd_no_state_fake(
     beta: torch.Tensor,
     initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor | None,
+    autotune: bool,
 ) -> torch.Tensor:
-    del k, gate, beta, initial_state, cu_seqlens
+    del k, gate, beta, initial_state, cu_seqlens, autotune
     return torch.empty_like(v, dtype=q.dtype)
 
 
@@ -342,8 +344,9 @@ def _recurrent_fwd_paged_fake(
     state_cache: torch.Tensor,
     state_indices: torch.Tensor,
     cu_seqlens: torch.Tensor | None,
+    autotune: bool,
 ) -> torch.Tensor:
-    del k, gate, beta, state_cache, state_indices, cu_seqlens
+    del k, gate, beta, state_cache, state_indices, cu_seqlens, autotune
     return torch.empty_like(v, dtype=q.dtype)
 
 
@@ -380,6 +383,7 @@ def recurrent_forward(
     cu_seqlens: torch.Tensor | None = None,
     output_final_state: bool = False,
     state_indices: torch.Tensor | None = None,
+    autotune: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Validate and invoke the lazily loaded fused recurrent implementation."""
     if q.shape[-1] > 256:
@@ -400,13 +404,15 @@ def recurrent_forward(
         # `.contiguous()` on the pool would copy and silently drop the in-place advance.
         assert initial_state is not None
         return recurrent_fwd_paged_op(
-            q, k, v, gate, beta, initial_state, state_indices, cu_seqlens
+            q, k, v, gate, beta, initial_state, state_indices, cu_seqlens, autotune
         ), None
     if initial_state is not None:
         initial_state = initial_state.contiguous()
     if output_final_state:
-        return recurrent_fwd_op(q, k, v, gate, beta, initial_state, cu_seqlens)
-    return recurrent_fwd_no_state_op(q, k, v, gate, beta, initial_state, cu_seqlens), None
+        return recurrent_fwd_op(q, k, v, gate, beta, initial_state, cu_seqlens, autotune)
+    return recurrent_fwd_no_state_op(
+        q, k, v, gate, beta, initial_state, cu_seqlens, autotune
+    ), None
 
 
 __all__ = [

--- a/attn_gym/linear/kda/ops.py
+++ b/attn_gym/linear/kda/ops.py
@@ -14,7 +14,7 @@ import torch
 _CHUNK_SIZE = 64
 
 
-# fixed-arity schema pairs avoid optional outputs on hot paths.
+# Fixed-arity schema pairs avoid optional outputs on hot paths.
 _CHUNK_FWD_ARGS = (
     "(Tensor q, Tensor k, Tensor v, Tensor cumulative_gate, Tensor beta, Tensor? initial_state,"
     " bool autotune)"
@@ -63,7 +63,7 @@ _RECURRENT_FWD_ARGS = (
 )
 torch.library.define("attn_gym::kda_recurrent_fwd", _RECURRENT_FWD_ARGS + " -> (Tensor, Tensor)")
 torch.library.define("attn_gym::kda_recurrent_fwd_no_state", _RECURRENT_FWD_ARGS + " -> Tensor")
-# separate schema: the paged variant advances the state pool in place, so the final state
+# Separate schema: the paged variant advances the state pool in place, so the final state
 # is not an output and the alias annotation has to declare the mutation.
 torch.library.define(
     "attn_gym::kda_recurrent_fwd_paged",

--- a/test/test_kda_recurrent.py
+++ b/test/test_kda_recurrent.py
@@ -19,6 +19,7 @@ from attn_gym.linear.kda.fwd.triton.recurrent import (
     _recurrent_fwd_no_state_op,
     _recurrent_fwd_op,
     _recurrent_fwd_paged_op,
+    kda_recurrent_fwd_kernel,
 )
 from attn_gym.linear.kda.naive import naive_recurrent_kda
 
@@ -40,12 +41,12 @@ def _inputs(
     seed: int = 0,
 ):
     torch.manual_seed(seed)
-    # KDA L2-normalizes q and k before the core; unnormalized keys make the
+    # kda l2-normalizes q and k before the core; unnormalized keys make the
     # delta-rule recurrence exponentially unstable and useless for comparison.
     q = F.normalize(torch.randn(batch, tokens, heads, key_dim, device="cuda"), dim=-1).to(dtype)
     k = F.normalize(torch.randn(batch, tokens, heads, key_dim, device="cuda"), dim=-1).to(dtype)
     v = torch.randn(batch, tokens, heads, value_dim, device="cuda", dtype=dtype)
-    # Realistic bounded log2 decays keep the recurrence stable over the scan.
+    # realistic bounded log2 decays keep the recurrence stable over the scan.
     gate = -torch.rand(batch, tokens, heads, key_dim, device="cuda") * 3.0
     beta = torch.rand(batch, tokens, heads, device="cuda")
     state = torch.randn(batch, heads, key_dim, value_dim, device="cuda") if initial_state else None
@@ -108,6 +109,18 @@ def test_recurrent_matches_naive_non_power_of_two(key_dim: int, value_dim: int):
     torch.testing.assert_close(final_state, expected_state, rtol=1e-5, atol=1e-5)
 
 
+def test_recurrent_autotunes_value_tile():
+    """Select the only valid candidate for a value dimension below the minimum tile."""
+    q, k, v, gate, beta, _ = _inputs(key_dim=7, value_dim=3, seed=2)
+
+    output, _ = recurrent_kda(q, k, v, gate, beta, autotune=True)
+    expected, _ = recurrent_kda(q, k, v, gate, beta, autotune=False)
+
+    assert kda_recurrent_fwd_kernel.best_config.kwargs["BV"] == 8
+    assert kda_recurrent_fwd_kernel.best_config.num_warps in (2, 4)
+    torch.testing.assert_close(output, expected, rtol=1e-5, atol=1e-5)
+
+
 def test_recurrent_packed_capacity_and_empty_slots():
     """Pass empty-slot state through and ignore rows past the terminal offset."""
     q, k, v, gate, beta, _ = _inputs(batch=1, tokens=32, seed=3)
@@ -125,7 +138,7 @@ def test_recurrent_packed_capacity_and_empty_slots():
         output_final_state=True,
     )
     assert final_state is not None
-    # Empty padding slots preserve their incoming state bitwise.
+    # empty padding slots preserve their incoming state bitwise.
     torch.testing.assert_close(final_state[0], initial_state[0], rtol=0, atol=0)
     torch.testing.assert_close(final_state[3], initial_state[3], rtol=0, atol=0)
     for sequence, (start, end) in enumerate(pairwise(cu_seqlens.cpu().tolist())):
@@ -211,7 +224,7 @@ def test_recurrent_paged_matches_gather_scatter(packed: bool):
     expected_pool[slots.long()] = expected_state
     torch.testing.assert_close(output, expected, rtol=1e-5, atol=1e-5)
     torch.testing.assert_close(pool, expected_pool, rtol=1e-5, atol=1e-5)
-    # Rows the indices never name stay bitwise untouched.
+    # rows the indices never name stay bitwise untouched.
     untouched = [row for row in range(pool.shape[0]) if row not in slots.tolist()]
     torch.testing.assert_close(pool[untouched], before[untouched], rtol=0, atol=0)
     state_elements = pool[0].numel()
@@ -359,12 +372,15 @@ def test_recurrent_custom_op_registration(packed: bool):
     cu_seqlens = torch.tensor([0, 2, 7, 17], device="cuda", dtype=torch.int32) if packed else None
     num_sequences = 3 if packed else batch
     state = torch.randn(num_sequences, q.shape[2], q.shape[3], v.shape[-1], device="cuda")
-    torch.library.opcheck(_recurrent_fwd_op, (q, k, v, gate, beta, state, cu_seqlens))
-    torch.library.opcheck(_recurrent_fwd_no_state_op, (q, k, v, gate, beta, state, cu_seqlens))
+    torch.library.opcheck(_recurrent_fwd_op, (q, k, v, gate, beta, state, cu_seqlens, True))
+    torch.library.opcheck(
+        _recurrent_fwd_no_state_op, (q, k, v, gate, beta, state, cu_seqlens, True)
+    )
     _, state_pool = _strided_state_pool(num_sequences + 1, q.shape[2], q.shape[3], v.shape[-1])
     slots = torch.arange(1, num_sequences + 1, device="cuda", dtype=torch.int32)
     torch.library.opcheck(
-        _recurrent_fwd_paged_op, (q, k, v, gate, beta, state_pool, slots, cu_seqlens)
+        _recurrent_fwd_paged_op,
+        (q, k, v, gate, beta, state_pool, slots, cu_seqlens, True),
     )
 
 
@@ -376,22 +392,39 @@ def test_recurrent_custom_op_registration_mixed_dtype():
     _, state_pool = _strided_state_pool(3, q.shape[2], q.shape[3], v.shape[-1])
     slots = torch.tensor([1, 2], device="cuda", dtype=torch.int32)
 
-    torch.library.opcheck(_recurrent_fwd_op, (q, k, v, gate, beta, state, None))
-    torch.library.opcheck(_recurrent_fwd_no_state_op, (q, k, v, gate, beta, state, None))
-    torch.library.opcheck(_recurrent_fwd_paged_op, (q, k, v, gate, beta, state_pool, slots, None))
+    torch.library.opcheck(_recurrent_fwd_op, (q, k, v, gate, beta, state, None, True))
+    torch.library.opcheck(_recurrent_fwd_no_state_op, (q, k, v, gate, beta, state, None, True))
+    torch.library.opcheck(
+        _recurrent_fwd_paged_op, (q, k, v, gate, beta, state_pool, slots, None, True)
+    )
 
 
 @pytest.mark.parametrize("output_final_state", [False, True])
-def test_recurrent_fullgraph_compile(output_final_state: bool):
+@pytest.mark.parametrize("autotune", [False, True])
+def test_recurrent_fullgraph_compile(output_final_state: bool, autotune: bool):
     """Compile both optional-state branches of the public operation."""
     q, k, v, gate, beta, state = _inputs(initial_state=True)
 
     expected, expected_state = recurrent_kda(
-        q, k, v, gate, beta, state, output_final_state=output_final_state
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        state,
+        output_final_state=output_final_state,
+        autotune=autotune,
     )
     compiled = torch.compile(recurrent_kda, fullgraph=True)
     output, final_state = compiled(
-        q, k, v, gate, beta, state, output_final_state=output_final_state
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        state,
+        output_final_state=output_final_state,
+        autotune=autotune,
     )
     torch.testing.assert_close(output, expected, rtol=0, atol=0)
     if output_final_state:
@@ -426,13 +459,13 @@ def test_recurrent_cuda_graph_replay():
     q, k, v, gate, beta, _ = _inputs(batch=1, tokens=32, seed=5)
     cu_seqlens = torch.tensor([0, 11, 27, 32], device="cuda", dtype=torch.int32)
     initial_state = torch.randn(3, q.shape[2], q.shape[3], v.shape[-1], device="cuda")
-    _recurrent_fwd_op(q, k, v, gate, beta, initial_state, cu_seqlens)
+    _recurrent_fwd_op(q, k, v, gate, beta, initial_state, cu_seqlens, True)
     torch.cuda.synchronize()
 
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
         captured_output, captured_state = _recurrent_fwd_op(
-            q, k, v, gate, beta, initial_state, cu_seqlens
+            q, k, v, gate, beta, initial_state, cu_seqlens, True
         )
 
     active_tokens = 23
@@ -447,7 +480,7 @@ def test_recurrent_cuda_graph_replay():
     torch.cuda.synchronize()
 
     expected_output, expected_state = _recurrent_fwd_op(
-        q, k, v, gate, beta, initial_state, cu_seqlens
+        q, k, v, gate, beta, initial_state, cu_seqlens, True
     )
     torch.testing.assert_close(
         captured_output[:, :active_tokens],
@@ -463,12 +496,12 @@ def test_recurrent_paged_cuda_graph_replay():
     q, k, v, gate, beta, _ = _inputs(batch=3, tokens=1, dtype=torch.bfloat16, seed=31)
     storage, pool = _strided_state_pool(7, q.shape[2], q.shape[3], v.shape[-1])
     slots = torch.tensor([5, 1, 3], device="cuda", dtype=torch.int32)
-    _recurrent_fwd_paged_op(q, k, v, gate, beta, pool, slots, None)
+    _recurrent_fwd_paged_op(q, k, v, gate, beta, pool, slots, None, True)
     torch.cuda.synchronize()
 
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
-        captured_output = _recurrent_fwd_paged_op(q, k, v, gate, beta, pool, slots, None)
+        captured_output = _recurrent_fwd_paged_op(q, k, v, gate, beta, pool, slots, None, True)
 
     with torch.no_grad():
         storage.add_(0.25)

--- a/test/test_kda_recurrent.py
+++ b/test/test_kda_recurrent.py
@@ -19,7 +19,6 @@ from attn_gym.linear.kda.fwd.triton.recurrent import (
     _recurrent_fwd_no_state_op,
     _recurrent_fwd_op,
     _recurrent_fwd_paged_op,
-    kda_recurrent_fwd_kernel,
 )
 from attn_gym.linear.kda.naive import naive_recurrent_kda
 
@@ -116,8 +115,6 @@ def test_recurrent_autotunes_value_tile():
     output, _ = recurrent_kda(q, k, v, gate, beta, autotune=True)
     expected, _ = recurrent_kda(q, k, v, gate, beta, autotune=False)
 
-    assert kda_recurrent_fwd_kernel.best_config.kwargs["BV"] == 8
-    assert kda_recurrent_fwd_kernel.best_config.num_warps in (2, 4)
     torch.testing.assert_close(output, expected, rtol=1e-5, atol=1e-5)
 
 

--- a/test/test_kda_recurrent.py
+++ b/test/test_kda_recurrent.py
@@ -41,12 +41,12 @@ def _inputs(
     seed: int = 0,
 ):
     torch.manual_seed(seed)
-    # kda l2-normalizes q and k before the core; unnormalized keys make the
+    # KDA L2-normalizes q and k before the core; unnormalized keys make the
     # delta-rule recurrence exponentially unstable and useless for comparison.
     q = F.normalize(torch.randn(batch, tokens, heads, key_dim, device="cuda"), dim=-1).to(dtype)
     k = F.normalize(torch.randn(batch, tokens, heads, key_dim, device="cuda"), dim=-1).to(dtype)
     v = torch.randn(batch, tokens, heads, value_dim, device="cuda", dtype=dtype)
-    # realistic bounded log2 decays keep the recurrence stable over the scan.
+    # Realistic bounded log2 decays keep the recurrence stable over the scan.
     gate = -torch.rand(batch, tokens, heads, key_dim, device="cuda") * 3.0
     beta = torch.rand(batch, tokens, heads, device="cuda")
     state = torch.randn(batch, heads, key_dim, value_dim, device="cuda") if initial_state else None
@@ -138,7 +138,7 @@ def test_recurrent_packed_capacity_and_empty_slots():
         output_final_state=True,
     )
     assert final_state is not None
-    # empty padding slots preserve their incoming state bitwise.
+    # Empty padding slots preserve their incoming state bitwise.
     torch.testing.assert_close(final_state[0], initial_state[0], rtol=0, atol=0)
     torch.testing.assert_close(final_state[3], initial_state[3], rtol=0, atol=0)
     for sequence, (start, end) in enumerate(pairwise(cu_seqlens.cpu().tolist())):
@@ -224,7 +224,7 @@ def test_recurrent_paged_matches_gather_scatter(packed: bool):
     expected_pool[slots.long()] = expected_state
     torch.testing.assert_close(output, expected, rtol=1e-5, atol=1e-5)
     torch.testing.assert_close(pool, expected_pool, rtol=1e-5, atol=1e-5)
-    # rows the indices never name stay bitwise untouched.
+    # Rows the indices never name stay bitwise untouched.
     untouched = [row for row in range(pool.shape[0]) if row not in slots.tolist()]
     torch.testing.assert_close(pool[untouched], before[untouched], rtol=0, atol=0)
     state_elements = pool[0].numel()


### PR DESCRIPTION
trying different BV and stages , setting BV and num_warps to be triton autotune params

<img width="1037" height="622" alt="Screenshot 2026-08-18 at 11 53 06 AM" src="https://github.com/user-attachments/assets/05394bf9-73d9-4d92-ba9d-d1bb364332e7" />

<img width="2174" height="1476" alt="general_recurrent_launch_heatmap" src="https://github.com/user-attachments/assets/6748f35e-825f-433b-9804-fda821f2e36f" />



Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #334
* __->__ #335
* #333

