### PR TITLE
Support int64 indexing for large packed KDA layouts

### DIFF
--- a/.agents/skills/cutedsl-tunable-kernel-template/SKILL.md
+++ b/.agents/skills/cutedsl-tunable-kernel-template/SKILL.md
@@ -230,6 +230,28 @@ def compile(config: MyConfig):
 
 `compile_tvm_ffi` owns the typed TVM-FFI option and fake environment stream. Do not append another stream or pass string compiler options at call sites. `compile_call(...)` returns exactly one tuple of positional static arguments; use `(config,)` when `compile(...)` accepts only a config.
 
+### Int64 offset specialization
+
+Keep ordinary layouts on the int32 address path. At the parent wrapper, call
+`attn_gym._backends.cute.requires_int64_abi` on every ABI-visible input, output, and optional tensor,
+then pass the result through `compile_call(...)` as a static `use_int64_offsets` argument. The CuTe
+predicate is intentionally stricter than reachable cosize: TVM-FFI must represent every declared
+stride, including a stride larger than `INT32_MAX` on a size-one mode that cannot reach it.
+
+The width bool must participate in the `jit_cache` key and profiler/artifact name. In the wide
+specialization, use `cute.sym_int64` for each dynamic fake-tensor dimension or stride involved in
+addressing; the fake signature and runtime tensor ABI must agree. Inside the op, widen each dynamic
+index or origin before its first potentially overflowing multiply or addition. Casting the final
+layout stride, iterator offset, or pointer is too late. Audit manually rebuilt layouts, iterator
+addition, chunk/program indices, and stores as well as ordinary tensor loads. Bounded routing arrays
+may remain int32 when their values and their own addressing are independently proven safe.
+
+Do not infer width from `numel()` and do not make int64 unconditional: wider arithmetic can add
+instructions and register pressure. Validate predicate-only oversized singleton strides, force the
+i64 specialization on small inputs and compare it with i32, and, when memory permits, execute an
+active offset beyond `INT32_MAX` against an equivalent compact layout. See
+`test/test_kda_int64_offsets.py` for the project pattern.
+
 Validate reachable inputs and static semantics once at the eager boundary used by each path: the
 public tune path or the private custom-op implementation. Validate again in `compile(...)`, because
 cache/compiler-worker calls can bypass both wrappers; downstream launch helpers may then rely on the
@@ -279,3 +301,4 @@ Read or run [copy_reads_example.py](copy_reads_example.py) for a complete toy ke
 - Verify all cold candidates produce distinct artifacts and a warm run launches no compiler process.
 - Keep real GPU coverage tiny: compile a toy kernel, benchmark with Inductor's GPU benchmarker, launch the winner, and compare output with an independent reference.
 - Measure cold and warm wall time locally, but do not make noisy scaling timing a correctness assertion.
+- For address-width-specialized kernels, verify the compile projection/cache/name distinguish i32 and i64, ordinary inputs retain i32, and every generated config is correct under both widths.

--- a/.agents/skills/validating-pytorch-custom-ops/SKILL.md
+++ b/.agents/skills/validating-pytorch-custom-ops/SKILL.md
@@ -250,6 +250,41 @@ Keep cross-variant Triton infrastructure in `attn_gym._backends.triton` only aft
 callers. Variant-specific kernels, schemas, fake behavior, and autograd remain in the variant
 backend.
 
+## Large-layout address width
+
+Optimized kernels must preserve an int32 default path and select a separate int64 specialization
+when relative element offsets can exceed signed int32. Inventory every input, output, optional
+tensor, manually reconstructed view, and manual load/store offset; checking only the primary input
+or `numel()` is insufficient.
+
+For Triton, use `attn_gym._backends.triton.requires_int64_offsets` in a
+`@triton.heuristics` `USE_INT64_OFFSETS` constexpr. It checks reachable storage cosize for the
+project's nonnegative-strided layouts. In the wide branch, cast program IDs, loaded token/chunk
+origins, and other address indices to `tl.int64` before the first potentially overflowing multiply
+or addition. Casting a completed offset or pointer is too late. Bounded routing arrays may stay
+int32, but widen their loaded values before using them in wide pointer arithmetic.
+
+For CuTeDSL TVM-FFI, use `attn_gym._backends.cute.requires_int64_abi`. In addition to reachable
+cosize, it checks every declared ABI stride because a size-one dimension can carry an unreachable
+stride larger than `INT32_MAX` that the compiled signature must still represent. Carry
+`use_int64_offsets` through the op, compile-cache key, and stable kernel name; use matching
+`cute.sym_int64` fake-signature fields in the wide variant. Widen values before multiplication when
+constructing layouts or adding to iterators.
+
+Required validation has three layers:
+
+1. Predicate tests on meta/fake tensors, including an oversized singleton stride without allocating
+   the unreachable storage.
+2. Forced-int64 equivalence with the normal int32 specialization on small forward and backward
+   inputs.
+3. When hardware memory permits, execution of an active offset beyond `INT32_MAX`, compared with an
+   equivalent compact layout. Singleton-stride tests prove ABI routing but not wide device pointer
+   arithmetic.
+
+Also assert ordinary layouts select int32 and measure both variants before claiming no regression;
+int64 address arithmetic can increase instructions and registers. Use `test/test_kda_int64_offsets.py`
+as the project reference.
+
 ## Validate registration with `opcheck`
 
 `torch.library.opcheck` validates operator registration. Its default utilities are:

--- a/attn_gym/_backends/cute/utils.py
+++ b/attn_gym/_backends/cute/utils.py
@@ -8,6 +8,8 @@ from typing import Any
 
 import torch
 
+from attn_gym._backends.triton.utils import requires_int64_offsets
+
 _VALID_NAME = re.compile(r"[a-z][a-z0-9_]*\Z")
 TMA_ALIGNMENT_BYTES = 16
 
@@ -34,6 +36,21 @@ def _contains_torch_tensor(value: Any) -> bool:
 def get_device_properties(device: torch.device) -> Any:
     """Return cached CUDA properties for a device."""
     return torch.cuda.get_device_properties(device)
+
+
+def requires_int64_abi(*tensors: torch.Tensor | None) -> bool:
+    """Return whether any tensor needs the Int64 fake-signature specialization.
+
+    TVM-FFI must represent every declared runtime stride, including the outer
+    stride of a size-1 batch mode whose coordinate never leaves zero, so this
+    is stricter than the reachable-offset bound alone. Callers may omit the
+    contiguous ``[num_sequences + 1]`` int32 routing arrays: their extents are
+    bounded by ``MAX_NUM_SEQUENCES`` and cannot approach either limit.
+    """
+    return requires_int64_offsets(*tensors) or any(
+        tensor is not None and any(abs(stride) > 2**31 - 1 for stride in tensor.stride())
+        for tensor in tensors
+    )
 
 
 def tensor_supports_tma(tensor: torch.Tensor) -> bool:

--- a/attn_gym/_backends/cute/utils.py
+++ b/attn_gym/_backends/cute/utils.py
@@ -8,8 +8,6 @@ from typing import Any
 
 import torch
 
-from attn_gym._backends.triton.utils import requires_int64_offsets
-
 _VALID_NAME = re.compile(r"[a-z][a-z0-9_]*\Z")
 TMA_ALIGNMENT_BYTES = 16
 
@@ -39,18 +37,23 @@ def get_device_properties(device: torch.device) -> Any:
 
 
 def requires_int64_abi(*tensors: torch.Tensor | None) -> bool:
-    """Return whether any tensor needs the Int64 fake-signature specialization.
+    """Check both reachable cosize and every stride exposed through the CuTe ABI.
 
-    TVM-FFI must represent every declared runtime stride, including the outer
-    stride of a size-1 batch mode whose coordinate never leaves zero, so this
-    is stricter than the reachable-offset bound alone. Callers may omit the
-    contiguous ``[num_sequences + 1]`` int32 routing arrays: their extents are
-    bounded by ``MAX_NUM_SEQUENCES`` and cannot approach either limit.
+    Unlike cosize, TVM-FFI must represent a size-1 mode's unreachable stride.
+    Bounded int32 routing arrays may be omitted by callers.
     """
-    return requires_int64_offsets(*tensors) or any(
-        tensor is not None and any(abs(stride) > 2**31 - 1 for stride in tensor.stride())
-        for tensor in tensors
-    )
+    for tensor in tensors:
+        if tensor is None:
+            continue
+        strides = tensor.stride()
+        if any(abs(stride) > 2**31 - 1 for stride in strides):
+            return True
+        if (
+            tensor.numel()
+            and 1 + sum((size - 1) * stride for size, stride in zip(tensor.shape, strides)) > 2**31
+        ):
+            return True
+    return False
 
 
 def tensor_supports_tma(tensor: torch.Tensor) -> bool:

--- a/attn_gym/linear/kda/bwd/cute/chunk_delta_h_bwd_v1.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_delta_h_bwd_v1.py
@@ -38,7 +38,7 @@ from torch._guards import active_fake_mode
 from attn_gym._backends.cute.cache import jit_cache
 from attn_gym._backends.cute.target import get_compile_target
 from attn_gym._backends.cute.utils import compile_tvm_ffi
-from attn_gym._backends.triton.utils import requires_int64_offsets
+from attn_gym._backends.cute.utils import requires_int64_abi
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata
 
 # ============================================================================
@@ -1948,7 +1948,7 @@ def blackwell_delta_h_bwd_dhu_v1(
         dv2_k = dv2[0]
 
         ps = (Int32(N), Int32(T), Int32(H), Int32(K), Int32(V))
-        use_int64_offsets = requires_int64_offsets(
+        use_int64_offsets = requires_int64_abi(
             q_k,
             k_k,
             w_k,
@@ -1990,7 +1990,7 @@ def blackwell_delta_h_bwd_dhu_v1(
         co_d = _get_dummy((2,), torch.int32, dev)
 
         ps = (Int32(B), Int32(T), Int32(H), Int32(K), Int32(V))
-        use_int64_offsets = requires_int64_offsets(
+        use_int64_offsets = requires_int64_abi(
             q,
             k,
             w,

--- a/attn_gym/linear/kda/bwd/cute/chunk_delta_h_bwd_v1.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_delta_h_bwd_v1.py
@@ -37,8 +37,7 @@ from torch._guards import active_fake_mode
 
 from attn_gym._backends.cute.cache import jit_cache
 from attn_gym._backends.cute.target import get_compile_target
-from attn_gym._backends.cute.utils import compile_tvm_ffi
-from attn_gym._backends.cute.utils import requires_int64_abi
+from attn_gym._backends.cute.utils import compile_tvm_ffi, requires_int64_abi
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata
 
 # ============================================================================
@@ -136,6 +135,11 @@ class BlackwellDeltaHBwdV1:
         )
         self.align = 1024
 
+    @cute.jit
+    def upcast(self, value):
+        """Promote an address operand before its first overflowing multiply."""
+        return cutlass.Int64(value) if cutlass.const_expr(self.use_int64_offsets) else value
+
     def get_name(self) -> str:
         """Return a stable artifact and profiler name for this specialization."""
         head_tag = f"_h{self.num_heads}" if self.num_heads is not None else ""
@@ -194,44 +198,61 @@ class BlackwellDeltaHBwdV1:
             dB = B
             NT = (T + self.BT - 1) // self.BT
 
-        def addr(value):
-            """Widen address strides in the large-offset specialization."""
-            return cutlass.Int64(value) if cutlass.const_expr(self.use_int64_offsets) else value
-
         # --- GMEM tensor construction ---
         # K: (T, K, (H, dB)) — K-contiguous for MMA1 A-operand (k is K-major)
         g_k = cute.make_tensor(
             kp,
-            cute.make_layout((T, K, (H, dB)), stride=(addr(H * K), 1, (K, addr(T) * H * K))),
+            cute.make_layout(
+                (T, K, (H, dB)),
+                stride=(self.upcast(H * K), 1, (K, self.upcast(T) * H * K)),
+            ),
         )
         # Q^T: (K, T, (H, dB)) — K-contiguous, then transposed for MMA2 A-operand
         g_qt = cute.make_tensor(
             qp,
-            cute.make_layout((K, T, (H, dB)), stride=(1, addr(H * K), (K, addr(T) * H * K))),
+            cute.make_layout(
+                (K, T, (H, dB)),
+                stride=(1, self.upcast(H * K), (K, self.upcast(T) * H * K)),
+            ),
         )
         # W: (K, T, (H, dB)) — K-contiguous for MMA3 A-operand (w^T)
         g_wt = cute.make_tensor(
             wp,
-            cute.make_layout((K, T, (H, dB)), stride=(1, addr(H * K), (K, addr(T) * H * K))),
+            cute.make_layout(
+                (K, T, (H, dB)),
+                stride=(1, self.upcast(H * K), (K, self.upcast(T) * H * K)),
+            ),
         )
         # do transposed: (V, T, (H, dB)) — V-contiguous for MMA2 MN-major B-operand TMA
         g_do_vt = cute.make_tensor(
             dop,
-            cute.make_layout((V, T, (H, dB)), stride=(1, addr(H * V), (V, addr(T) * H * V))),
+            cute.make_layout(
+                (V, T, (H, dB)),
+                stride=(1, self.upcast(H * V), (V, self.upcast(T) * H * V)),
+            ),
         )
         # dv_in: (T, V, (H, dB)) — V-contiguous
-        dv_lay = cute.make_layout((T, V, (H, dB)), stride=(addr(H * V), 1, (V, addr(T) * H * V)))
+        dv_lay = cute.make_layout(
+            (T, V, (H, dB)),
+            stride=(self.upcast(H * V), 1, (V, self.upcast(T) * H * V)),
+        )
         # dv_in transposed: (V, T, (H, dB))
         g_dv_in_t = cute.make_tensor(
             dvp,
-            cute.make_layout((V, T, (H, dB)), stride=(1, addr(H * V), (V, addr(T) * H * V))),
+            cute.make_layout(
+                (V, T, (H, dB)),
+                stride=(1, self.upcast(H * V), (V, self.upcast(T) * H * V)),
+            ),
         )
         # dv2_out: (T, V, (H, dB))
         g_dv2 = cute.make_tensor(dv2p, dv_lay)
         # dv2_out transposed: (V, T, (H, dB))
         g_dv2_t = cute.make_tensor(
             dv2p,
-            cute.make_layout((V, T, (H, dB)), stride=(1, addr(H * V), (V, addr(T) * H * V))),
+            cute.make_layout(
+                (V, T, (H, dB)),
+                stride=(1, self.upcast(H * V), (V, self.upcast(T) * H * V)),
+            ),
         )
 
         # dh_out transposed for TMA store: (V, K, (NT, H, dB))
@@ -239,25 +260,32 @@ class BlackwellDeltaHBwdV1:
             dhop,
             cute.make_layout(
                 (V, K, (NT, H, dB)),
-                stride=(1, V, (addr(H * K * V), K * V, addr(NT) * H * K * V)),
+                stride=(
+                    1,
+                    V,
+                    (self.upcast(H * K * V), K * V, self.upcast(NT) * H * K * V),
+                ),
             ),
         )
 
         # dht: (K, V, (H, B)) — final state gradient input
         g_dht = cute.make_tensor(
             dhtp,
-            cute.make_layout((K, V, (H, B)), stride=(V, 1, (K * V, addr(H * K * V)))),
+            cute.make_layout((K, V, (H, B)), stride=(V, 1, (K * V, self.upcast(H * K * V)))),
         )
         # dh0 transposed for store: (V, K, (H, B))
         g_dh0_t = cute.make_tensor(
             dh0p,
-            cute.make_layout((V, K, (H, B)), stride=(1, V, (K * V, addr(H * K * V)))),
+            cute.make_layout((V, K, (H, B)), stride=(1, V, (K * V, self.upcast(H * K * V)))),
         )
 
         # gk K-contiguous: (K, T, (H, dB))
         g_gk_k = cute.make_tensor(
             gkp,
-            cute.make_layout((K, T, (H, dB)), stride=(1, addr(H * K), (K, addr(T) * H * K))),
+            cute.make_layout(
+                (K, T, (H, dB)),
+                stride=(1, self.upcast(H * K), (K, self.upcast(T) * H * K)),
+            ),
         )
 
         # --- MMA configurations (SS-mode: both operands from SMEM) ---
@@ -1412,9 +1440,7 @@ class BlackwellDeltaHBwdV1:
                             tOr = cute.make_fragment_like(tOs, self.io_type)
                             cute.autovec_copy(tOs, tOr)
 
-                            vn_token = bos + rev_ct * BT
-                            if cutlass.const_expr(self.use_int64_offsets):
-                                vn_token = cutlass.Int64(vn_token)
+                            vn_token = self.upcast(bos + rev_ct * BT)
                             vn_raw = (
                                 g_dv2.iterator + vn_token * H * V + h_idx * V + v_tile * self.BV
                             )
@@ -1959,10 +1985,8 @@ def blackwell_delta_h_bwd_dhu_v1(
             dh0_k,
             dho,
             dv2_k,
-            metadata.cu_seqlens,
-            metadata.chunk_offsets,
         )
-        fn = _compile_bwd_dhu(True, H, K, V, chunk_size, bv, use_int64_offsets)
+        fn = _compile_bwd_dhu(True, H, K, V, chunk_size, bv, use_int64_offsets=use_int64_offsets)
         fn(
             q_k,
             k_k,
@@ -2001,10 +2025,8 @@ def blackwell_delta_h_bwd_dhu_v1(
             dh0_k,
             dh_out,
             dv2,
-            cu_d,
-            co_d,
         )
-        fn = _compile_bwd_dhu(False, H, K, V, chunk_size, bv, use_int64_offsets)
+        fn = _compile_bwd_dhu(False, H, K, V, chunk_size, bv, use_int64_offsets=use_int64_offsets)
         fn(
             q,
             k,

--- a/attn_gym/linear/kda/bwd/cute/chunk_delta_h_bwd_v1.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_delta_h_bwd_v1.py
@@ -38,6 +38,7 @@ from torch._guards import active_fake_mode
 from attn_gym._backends.cute.cache import jit_cache
 from attn_gym._backends.cute.target import get_compile_target
 from attn_gym._backends.cute.utils import compile_tvm_ffi
+from attn_gym._backends.triton.utils import requires_int64_offsets
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata
 
 # ============================================================================
@@ -78,6 +79,7 @@ class BlackwellDeltaHBwdV1:
         io_type=cutlass.BFloat16,
         varlen: bool = False,
         num_heads: int | None = None,
+        use_int64_offsets: bool = False,
     ):
         assert head_k == 128 and head_v == 128, (
             f"Only head_k=head_v=128 supported, got {head_k},{head_v}"
@@ -90,6 +92,7 @@ class BlackwellDeltaHBwdV1:
         self.io_type = io_type
         self.varlen = varlen
         self.num_heads = num_heads
+        self.use_int64_offsets = use_int64_offsets
 
         # Tile dimensions
         self.BT = chunk_size  # 64
@@ -139,6 +142,7 @@ class BlackwellDeltaHBwdV1:
         return (
             f"kda_bwd_dhu_v1_vl{int(self.varlen)}{head_tag}"
             f"_k{self.head_k}_v{self.head_v}_bt{self.BT}_bv{self.BV}"
+            f"_i64{int(self.use_int64_offsets)}"
         )
 
     # ------------------------------------------------------------------
@@ -190,40 +194,44 @@ class BlackwellDeltaHBwdV1:
             dB = B
             NT = (T + self.BT - 1) // self.BT
 
+        def addr(value):
+            """Widen address strides in the large-offset specialization."""
+            return cutlass.Int64(value) if cutlass.const_expr(self.use_int64_offsets) else value
+
         # --- GMEM tensor construction ---
         # K: (T, K, (H, dB)) — K-contiguous for MMA1 A-operand (k is K-major)
         g_k = cute.make_tensor(
             kp,
-            cute.make_layout((T, K, (H, dB)), stride=(H * K, 1, (K, T * H * K))),
+            cute.make_layout((T, K, (H, dB)), stride=(addr(H * K), 1, (K, addr(T) * H * K))),
         )
         # Q^T: (K, T, (H, dB)) — K-contiguous, then transposed for MMA2 A-operand
         g_qt = cute.make_tensor(
             qp,
-            cute.make_layout((K, T, (H, dB)), stride=(1, H * K, (K, T * H * K))),
+            cute.make_layout((K, T, (H, dB)), stride=(1, addr(H * K), (K, addr(T) * H * K))),
         )
         # W: (K, T, (H, dB)) — K-contiguous for MMA3 A-operand (w^T)
         g_wt = cute.make_tensor(
             wp,
-            cute.make_layout((K, T, (H, dB)), stride=(1, H * K, (K, T * H * K))),
+            cute.make_layout((K, T, (H, dB)), stride=(1, addr(H * K), (K, addr(T) * H * K))),
         )
         # do transposed: (V, T, (H, dB)) — V-contiguous for MMA2 MN-major B-operand TMA
         g_do_vt = cute.make_tensor(
             dop,
-            cute.make_layout((V, T, (H, dB)), stride=(1, H * V, (V, T * H * V))),
+            cute.make_layout((V, T, (H, dB)), stride=(1, addr(H * V), (V, addr(T) * H * V))),
         )
         # dv_in: (T, V, (H, dB)) — V-contiguous
-        dv_lay = cute.make_layout((T, V, (H, dB)), stride=(H * V, 1, (V, T * H * V)))
+        dv_lay = cute.make_layout((T, V, (H, dB)), stride=(addr(H * V), 1, (V, addr(T) * H * V)))
         # dv_in transposed: (V, T, (H, dB))
         g_dv_in_t = cute.make_tensor(
             dvp,
-            cute.make_layout((V, T, (H, dB)), stride=(1, H * V, (V, T * H * V))),
+            cute.make_layout((V, T, (H, dB)), stride=(1, addr(H * V), (V, addr(T) * H * V))),
         )
         # dv2_out: (T, V, (H, dB))
         g_dv2 = cute.make_tensor(dv2p, dv_lay)
         # dv2_out transposed: (V, T, (H, dB))
         g_dv2_t = cute.make_tensor(
             dv2p,
-            cute.make_layout((V, T, (H, dB)), stride=(1, H * V, (V, T * H * V))),
+            cute.make_layout((V, T, (H, dB)), stride=(1, addr(H * V), (V, addr(T) * H * V))),
         )
 
         # dh_out transposed for TMA store: (V, K, (NT, H, dB))
@@ -231,25 +239,25 @@ class BlackwellDeltaHBwdV1:
             dhop,
             cute.make_layout(
                 (V, K, (NT, H, dB)),
-                stride=(1, V, (H * K * V, K * V, NT * H * K * V)),
+                stride=(1, V, (addr(H * K * V), K * V, addr(NT) * H * K * V)),
             ),
         )
 
         # dht: (K, V, (H, B)) — final state gradient input
         g_dht = cute.make_tensor(
             dhtp,
-            cute.make_layout((K, V, (H, B)), stride=(V, 1, (K * V, H * K * V))),
+            cute.make_layout((K, V, (H, B)), stride=(V, 1, (K * V, addr(H * K * V)))),
         )
         # dh0 transposed for store: (V, K, (H, B))
         g_dh0_t = cute.make_tensor(
             dh0p,
-            cute.make_layout((V, K, (H, B)), stride=(1, V, (K * V, H * K * V))),
+            cute.make_layout((V, K, (H, B)), stride=(1, V, (K * V, addr(H * K * V)))),
         )
 
         # gk K-contiguous: (K, T, (H, dB))
         g_gk_k = cute.make_tensor(
             gkp,
-            cute.make_layout((K, T, (H, dB)), stride=(1, H * K, (K, T * H * K))),
+            cute.make_layout((K, T, (H, dB)), stride=(1, addr(H * K), (K, addr(T) * H * K))),
         )
 
         # --- MMA configurations (SS-mode: both operands from SMEM) ---
@@ -1404,11 +1412,11 @@ class BlackwellDeltaHBwdV1:
                             tOr = cute.make_fragment_like(tOs, self.io_type)
                             cute.autovec_copy(tOs, tOr)
 
+                            vn_token = bos + rev_ct * BT
+                            if cutlass.const_expr(self.use_int64_offsets):
+                                vn_token = cutlass.Int64(vn_token)
                             vn_raw = (
-                                g_dv2.iterator
-                                + (bos + rev_ct * BT) * H * V
-                                + h_idx * V
-                                + v_tile * self.BV
+                                g_dv2.iterator + vn_token * H * V + h_idx * V + v_tile * self.BV
                             )
                             vn_ptr = cute.make_ptr(
                                 self.io_type,
@@ -1726,7 +1734,7 @@ class BlackwellDeltaHBwdV1:
 
 
 @jit_cache
-def _compile_bwd_dhu(varlen, H, K, V, chunk_size, bv=16):
+def _compile_bwd_dhu(varlen, H, K, V, chunk_size, bv=16, use_int64_offsets=False):
     """Compile one BlackwellDeltaHBwdV1 variant."""
     kern = BlackwellDeltaHBwdV1(
         chunk_size=chunk_size,
@@ -1735,8 +1743,10 @@ def _compile_bwd_dhu(varlen, H, K, V, chunk_size, bv=16):
         head_bv=bv,
         varlen=varlen,
         num_heads=H,
+        use_int64_offsets=use_int64_offsets,
     )
-    sa, sb, snt, sn, sns = (cute.sym_int() for _ in range(5))
+    sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
+    sa, sb, snt, sn, sns = (sym_int() for _ in range(5))
 
     if varlen:
         qf = make_fake_compact_tensor(
@@ -1938,7 +1948,21 @@ def blackwell_delta_h_bwd_dhu_v1(
         dv2_k = dv2[0]
 
         ps = (Int32(N), Int32(T), Int32(H), Int32(K), Int32(V))
-        fn = _compile_bwd_dhu(True, H, K, V, chunk_size, bv)
+        use_int64_offsets = requires_int64_offsets(
+            q_k,
+            k_k,
+            w_k,
+            do_k,
+            dv_k,
+            gk_k,
+            dht_k,
+            dh0_k,
+            dho,
+            dv2_k,
+            metadata.cu_seqlens,
+            metadata.chunk_offsets,
+        )
+        fn = _compile_bwd_dhu(True, H, K, V, chunk_size, bv, use_int64_offsets)
         fn(
             q_k,
             k_k,
@@ -1966,7 +1990,21 @@ def blackwell_delta_h_bwd_dhu_v1(
         co_d = _get_dummy((2,), torch.int32, dev)
 
         ps = (Int32(B), Int32(T), Int32(H), Int32(K), Int32(V))
-        fn = _compile_bwd_dhu(False, H, K, V, chunk_size, bv)
+        use_int64_offsets = requires_int64_offsets(
+            q,
+            k,
+            w,
+            do,
+            dv,
+            gk_k,
+            dht_k,
+            dh0_k,
+            dh_out,
+            dv2,
+            cu_d,
+            co_d,
+        )
+        fn = _compile_bwd_dhu(False, H, K, V, chunk_size, bv, use_int64_offsets)
         fn(
             q,
             k,

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_intra.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_intra.py
@@ -23,7 +23,7 @@ from cutlass.cutlass_dsl import Constexpr, T, dsl_user_op
 
 from attn_gym._backends.cute import compile_tvm_ffi, jit_cache, run_tunable
 from attn_gym._backends.cute.target import CompileTarget, detect_compile_target, get_compile_target
-from attn_gym._backends.triton.utils import requires_int64_offsets
+from attn_gym._backends.cute.utils import requires_int64_abi
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata
 from attn_gym.linear.kda.fwd.cute.chunk_scheduler_cute import load_ragged_chunk_work
 
@@ -2146,7 +2146,7 @@ class ChunkKdaBwdIntraTunable:
             args.capacity,
             config.grid_chunks,
             args.chunk_offsets is not None,
-            requires_int64_offsets(
+            requires_int64_abi(
                 _column_token_head(args.q),
                 _column_token_head(args.k),
                 _column_token_head(args.g),

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_intra.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_intra.py
@@ -23,6 +23,7 @@ from cutlass.cutlass_dsl import Constexpr, T, dsl_user_op
 
 from attn_gym._backends.cute import compile_tvm_ffi, jit_cache, run_tunable
 from attn_gym._backends.cute.target import CompileTarget, detect_compile_target, get_compile_target
+from attn_gym._backends.triton.utils import requires_int64_offsets
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata
 from attn_gym.linear.kda.fwd.cute.chunk_scheduler_cute import load_ragged_chunk_work
 
@@ -943,6 +944,7 @@ def _chunk_kda_bwd_intra_hmma_grid_kernel(
     capacity: Constexpr,
     grid_chunks: Constexpr,
     ragged: Constexpr,
+    use_int64_offsets: Constexpr,
 ):
     tidx, _, _ = cute.arch.thread_idx()
     # Grid is (KC_TOTAL, grid_chunks, H), mirroring Triton's for-loop variant.
@@ -1013,6 +1015,8 @@ def _chunk_kda_bwd_intra_hmma_grid_kernel(
         else:
             row_start = chunk_block * BT
             valid = Int32(BT)
+        if cutlass.const_expr(use_int64_offsets):
+            row_start = cutlass.Int64(row_start)
         # Match Triton's default safe-gate normalization reference
         # (causal_gate_normref=False): use the middle row of this BC subchunk,
         # clamped for partial chunks. This keeps local diagonal dA scaling
@@ -1918,10 +1922,17 @@ def _chunk_kda_bwd_intra_hmma_grid_kernel(
 class ChunkKdaBwdIntraHmmaGrid:
     """Launch the persistent dense or ragged-scheduler kernel."""
 
-    def __init__(self, capacity: int, grid_chunks: int, ragged: bool):
+    def __init__(
+        self,
+        capacity: int,
+        grid_chunks: int,
+        ragged: bool,
+        use_int64_offsets: bool = False,
+    ):
         self.capacity = capacity
         self.grid_chunks = grid_chunks
         self.ragged = ragged
+        self.use_int64_offsets = use_int64_offsets
 
     @cute.jit
     def __call__(
@@ -1963,6 +1974,7 @@ class ChunkKdaBwdIntraHmmaGrid:
             self.capacity,
             self.grid_chunks,
             self.ragged,
+            self.use_int64_offsets,
         ).launch(
             grid=(KC_TOTAL, self.grid_chunks, cute.size(mQ.shape[2])),
             block=(32, 1, 1),
@@ -1982,6 +1994,7 @@ def _compile_chunk_kda_bwd_intra(
     capacity: int,
     grid_chunks: int,
     ragged: bool,
+    use_int64_offsets: bool = False,
 ):
     """Compile one persistent intra-chunk backward specialization."""
     if not 1 <= grid_chunks <= capacity:
@@ -1990,8 +2003,10 @@ def _compile_chunk_kda_bwd_intra(
         capacity=capacity,
         grid_chunks=grid_chunks,
         ragged=ragged,
+        use_int64_offsets=use_int64_offsets,
     )
     tokens, sequences = cute.sym_int(), cute.sym_int()
+    sym_stride = cute.sym_int64 if use_int64_offsets else cute.sym_int
 
     def normal(dtype, shape):
         return make_fake_compact_tensor(
@@ -2016,8 +2031,8 @@ def _compile_chunk_kda_bwd_intra(
             (columns, tokens, heads),
             stride=(
                 1,
-                cute.sym_int(divisibility=_MIN_ALIGN_ELEMENTS_BF16),
-                cute.sym_int(divisibility=_MIN_ALIGN_ELEMENTS_BF16),
+                sym_stride(divisibility=_MIN_ALIGN_ELEMENTS_BF16),
+                sym_stride(divisibility=_MIN_ALIGN_ELEMENTS_BF16),
             ),
             assumed_align=_MIN_ALIGN_BYTES,
         )
@@ -2054,7 +2069,10 @@ def _compile_chunk_kda_bwd_intra(
         dg2,
         cu_seqlens,
         chunk_offsets,
-        name=f"kda_bwd_intra_h{heads}_c{capacity}_gc{grid_chunks}_rg{int(ragged)}",
+        name=(
+            f"kda_bwd_intra_h{heads}_c{capacity}_gc{grid_chunks}_rg{int(ragged)}"
+            f"_i64{int(use_int64_offsets)}"
+        ),
     )
 
 
@@ -2122,8 +2140,28 @@ class ChunkKdaBwdIntraTunable:
     def compile_call(
         config: ChunkKdaBwdIntraConfig,
         args: Args,
-    ) -> tuple[int, int, int, bool]:
-        return args.q.shape[2], args.capacity, config.grid_chunks, args.chunk_offsets is not None
+    ) -> tuple[int, int, int, bool, bool]:
+        return (
+            args.q.shape[2],
+            args.capacity,
+            config.grid_chunks,
+            args.chunk_offsets is not None,
+            requires_int64_offsets(
+                _column_token_head(args.q),
+                _column_token_head(args.k),
+                _column_token_head(args.g),
+                args.beta,
+                _column_token_head(args.dAqk),
+                _column_token_head(args.dAkk),
+                _column_token_head(args.dq),
+                _column_token_head(args.dk),
+                args.db_partial,
+                _column_token_head(args.dg),
+                _column_token_head(args.dq2),
+                _column_token_head(args.dk2),
+                _column_token_head(args.dg2),
+            ),
+        )
 
     compile = staticmethod(_compile_chunk_kda_bwd_intra)
 

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_intra.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_intra.py
@@ -2006,7 +2006,7 @@ def _compile_chunk_kda_bwd_intra(
         use_int64_offsets=use_int64_offsets,
     )
     tokens, sequences = cute.sym_int(), cute.sym_int()
-    sym_stride = cute.sym_int64 if use_int64_offsets else cute.sym_int
+    sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
 
     def normal(dtype, shape):
         return make_fake_compact_tensor(
@@ -2031,8 +2031,8 @@ def _compile_chunk_kda_bwd_intra(
             (columns, tokens, heads),
             stride=(
                 1,
-                sym_stride(divisibility=_MIN_ALIGN_ELEMENTS_BF16),
-                sym_stride(divisibility=_MIN_ALIGN_ELEMENTS_BF16),
+                sym_int(divisibility=_MIN_ALIGN_ELEMENTS_BF16),
+                sym_int(divisibility=_MIN_ALIGN_ELEMENTS_BF16),
             ),
             assumed_align=_MIN_ALIGN_BYTES,
         )

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_wy_dqkg_fused.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_wy_dqkg_fused.py
@@ -32,7 +32,7 @@ from cutlass.cute.tensor import TensorSSA
 from cutlass.cute.typing import BFloat16, Float32, Int32, Int64
 
 from attn_gym._backends.cute import compile_tvm_ffi, jit_cache, run_tunable
-from attn_gym._backends.triton.utils import requires_int64_offsets
+from attn_gym._backends.cute.utils import requires_int64_abi
 from attn_gym._backends.cute.target import CompileTarget, detect_compile_target, get_compile_target
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata
 from attn_gym.linear.kda.fwd.cute.chunk_scheduler_cute import load_ragged_chunk_work
@@ -1973,6 +1973,15 @@ class ChunkKdaBwdWyDqkgFused:
         return (grid_x, Int32(1), Int32(1))
 
     @cute.jit
+    def _token_row(self, row: Int32):
+        """Widen one token-row ordinal before it multiplies a row pitch.
+
+        Manual vector-store addresses bypass the typed layouts, so the cast must
+        happen before the first product that can exceed INT32_MAX.
+        """
+        return cutlass.Int64(row) if cutlass.const_expr(self.use_int64_offsets) else row
+
+    @cute.jit
     def __call__(
         self,
         # ── Inputs ──
@@ -3385,7 +3394,7 @@ class ChunkKdaBwdWyDqkgFused:
 
                     base_addr = (
                         dv2_gmem.iterator
-                        + (tok_offset + tile_idx * self.BT + row) * HV * V
+                        + self._token_row(tok_offset + tile_idx * self.BT + row) * HV * V
                         + i_hv * V
                         + v_iter * self.BV
                         + bv_col_base
@@ -3447,7 +3456,7 @@ class ChunkKdaBwdWyDqkgFused:
                 cute.arch.fence_view_async_tmem_store()
                 dq_base_addr = (
                     dq_gmem.iterator
-                    + (tok_offset + tile_idx * self.BT + row) * HV * K
+                    + self._token_row(tok_offset + tile_idx * self.BT + row) * HV * K
                     + i_hv * K
                     + bk_col_base
                 ).toint()
@@ -3615,7 +3624,7 @@ class ChunkKdaBwdWyDqkgFused:
                 # 8 fp32 store each time for store_256b
                 dk_base_addr = (
                     dk_gmem.iterator
-                    + (tok_offset + tile_idx * self.BT + row) * HV * K
+                    + self._token_row(tok_offset + tile_idx * self.BT + row) * HV * K
                     + i_hv * K
                     + bk_col_base
                 ).toint()
@@ -3803,7 +3812,7 @@ class ChunkKdaBwdWyDqkgFused:
                 num_stores_dA = bt_num_cols_per_wg // 8
                 dA_base_addr = (
                     dA_gmem.iterator
-                    + (tok_offset + tile_idx * self.BT + row) * HV * BT
+                    + self._token_row(tok_offset + tile_idx * self.BT + row) * HV * BT
                     + i_hv * BT
                     + bt_col_base
                 ).toint()
@@ -4574,7 +4583,9 @@ class ChunkKdaBwdWyDqkgFused:
                             )
                             dg_base_addr = (
                                 dg_gmem.iterator
-                                + (tok_offset + tile_idx * self.BT + store_row) * HV * K
+                                + self._token_row(tok_offset + tile_idx * self.BT + store_row)
+                                * HV
+                                * K
                                 + i_hv * K
                                 + store_col_base
                             ).toint()
@@ -4847,7 +4858,7 @@ class ChunkKdaBwdWyDqkgTunable:
             args.fastmath,
             config.grid_waves,
             args.chunk_offsets is not None,
-            requires_int64_offsets(
+            requires_int64_abi(
                 args.q,
                 args.k,
                 args.v,

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_wy_dqkg_fused.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_wy_dqkg_fused.py
@@ -32,8 +32,8 @@ from cutlass.cute.tensor import TensorSSA
 from cutlass.cute.typing import BFloat16, Float32, Int32, Int64
 
 from attn_gym._backends.cute import compile_tvm_ffi, jit_cache, run_tunable
-from attn_gym._backends.cute.utils import requires_int64_abi
 from attn_gym._backends.cute.target import CompileTarget, detect_compile_target, get_compile_target
+from attn_gym._backends.cute.utils import requires_int64_abi
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata
 from attn_gym.linear.kda.fwd.cute.chunk_scheduler_cute import load_ragged_chunk_work
 
@@ -1873,8 +1873,6 @@ class ChunkKdaBwdWyDqkgFused:
         require_blackwell_target()
 
         self.use_fast_math = use_fast_math
-        # Widens token/chunk address strides to Int64 so crd2idx products cannot
-        # wrap once a tensor's reachable element offset exceeds INT32_MAX.
         self.use_int64_offsets = use_int64_offsets
         self.chunk_size = chunk_size
         self.head_dim_k = head_dim_k
@@ -1973,13 +1971,9 @@ class ChunkKdaBwdWyDqkgFused:
         return (grid_x, Int32(1), Int32(1))
 
     @cute.jit
-    def _token_row(self, row: Int32):
-        """Widen one token-row ordinal before it multiplies a row pitch.
-
-        Manual vector-store addresses bypass the typed layouts, so the cast must
-        happen before the first product that can exceed INT32_MAX.
-        """
-        return cutlass.Int64(row) if cutlass.const_expr(self.use_int64_offsets) else row
+    def upcast(self, value):
+        """Promote an address operand before its first overflowing multiply."""
+        return cutlass.Int64(value) if cutlass.const_expr(self.use_int64_offsets) else value
 
     @cute.jit
     def __call__(
@@ -2035,10 +2029,6 @@ class ChunkKdaBwdWyDqkgFused:
         data_B = Int32(1)
         NT = total_nt
 
-        def addr(value):
-            """Widen one address stride so coordinate products promote to i64."""
-            return cutlass.Int64(value) if cutlass.const_expr(self.use_int64_offsets) else value
-
         # ===================== GMEM layouts =====================
         # Token-indexed tensors: (T, dim, (H, data_B))
         def strided_token_layout(tensor: cute.Tensor, dim: Int32, head_count: Int32):
@@ -2060,7 +2050,7 @@ class ChunkKdaBwdWyDqkgFused:
 
         tv_layout = cute.make_layout(
             (T, V, (HV, data_B)),
-            stride=(addr(HV * V), 1, (V, addr(T) * HV * V)),
+            stride=(self.upcast(HV * V), 1, (V, self.upcast(T) * HV * V)),
         )
         v_new = cute.make_tensor(v_new_ptr, tv_layout)
         do = cute.make_tensor(do_ptr, tv_layout)
@@ -2070,14 +2060,14 @@ class ChunkKdaBwdWyDqkgFused:
         # g: (T, K, (HV, data_B)) fp32
         g_layout = cute.make_layout(
             (T, K, (HV, data_B)),
-            stride=(addr(HV * K), 1, (K, addr(T) * HV * K)),
+            stride=(self.upcast(HV * K), 1, (K, self.upcast(T) * HV * K)),
         )
         g = cute.make_tensor(g_ptr, g_layout)
 
         # beta: (T, (HV, data_B)) fp32
         beta_layout = cute.make_layout(
             (T, (HV, data_B)),
-            stride=(addr(HV), (1, addr(T) * HV)),
+            stride=(self.upcast(HV), (1, self.upcast(T) * HV)),
         )
         beta = cute.make_tensor(beta_ptr, beta_layout)
 
@@ -2085,14 +2075,14 @@ class ChunkKdaBwdWyDqkgFused:
         # NOTE: for A as operand A, A is loaded as transposed view to do MMA
         a_t_layout = cute.make_layout(
             (BT, T, (HV, data_B)),
-            stride=(1, addr(HV * BT), (BT, addr(T) * HV * BT)),
+            stride=(1, self.upcast(HV * BT), (BT, self.upcast(T) * HV * BT)),
         )
         A_T = cute.make_tensor(A_ptr, a_t_layout)
 
         # dq, dk: (T, K, (HV, data_B)) fp32
         dqk_layout = cute.make_layout(
             (T, K, (HV, data_B)),
-            stride=(addr(HV * K), 1, (K, addr(T) * HV * K)),
+            stride=(self.upcast(HV * K), 1, (K, self.upcast(T) * HV * K)),
         )
         dq = cute.make_tensor(dq_ptr, dqk_layout)
         dk = cute.make_tensor(dk_ptr, dqk_layout)
@@ -2106,7 +2096,7 @@ class ChunkKdaBwdWyDqkgFused:
         # dA: (T, BT, (HV, data_B)) fp32
         dA_layout = cute.make_layout(
             (T, BT, (HV, data_B)),
-            stride=(addr(HV * BT), 1, (BT, addr(T) * HV * BT)),
+            stride=(self.upcast(HV * BT), 1, (BT, self.upcast(T) * HV * BT)),
         )
         dA_out = cute.make_tensor(dA_ptr, dA_layout)
 
@@ -2115,7 +2105,7 @@ class ChunkKdaBwdWyDqkgFused:
         # h row-major: (K, V, (h_nt_total, HV)) as operand B
         h_layout = cute.make_layout(
             (K, V, (h_nt_total, HV)),
-            stride=(V, 1, (addr(HV * K * V), addr(K * V))),
+            stride=(V, 1, (self.upcast(HV * K * V), K * V)),
         )
         h = cute.make_tensor(h_ptr, h_layout)
         dh = cute.make_tensor(dh_ptr, h_layout)
@@ -3394,7 +3384,7 @@ class ChunkKdaBwdWyDqkgFused:
 
                     base_addr = (
                         dv2_gmem.iterator
-                        + self._token_row(tok_offset + tile_idx * self.BT + row) * HV * V
+                        + self.upcast(tok_offset + tile_idx * self.BT + row) * HV * V
                         + i_hv * V
                         + v_iter * self.BV
                         + bv_col_base
@@ -3456,7 +3446,7 @@ class ChunkKdaBwdWyDqkgFused:
                 cute.arch.fence_view_async_tmem_store()
                 dq_base_addr = (
                     dq_gmem.iterator
-                    + self._token_row(tok_offset + tile_idx * self.BT + row) * HV * K
+                    + self.upcast(tok_offset + tile_idx * self.BT + row) * HV * K
                     + i_hv * K
                     + bk_col_base
                 ).toint()
@@ -3624,7 +3614,7 @@ class ChunkKdaBwdWyDqkgFused:
                 # 8 fp32 store each time for store_256b
                 dk_base_addr = (
                     dk_gmem.iterator
-                    + self._token_row(tok_offset + tile_idx * self.BT + row) * HV * K
+                    + self.upcast(tok_offset + tile_idx * self.BT + row) * HV * K
                     + i_hv * K
                     + bk_col_base
                 ).toint()
@@ -3812,7 +3802,7 @@ class ChunkKdaBwdWyDqkgFused:
                 num_stores_dA = bt_num_cols_per_wg // 8
                 dA_base_addr = (
                     dA_gmem.iterator
-                    + self._token_row(tok_offset + tile_idx * self.BT + row) * HV * BT
+                    + self.upcast(tok_offset + tile_idx * self.BT + row) * HV * BT
                     + i_hv * BT
                     + bt_col_base
                 ).toint()
@@ -4583,9 +4573,7 @@ class ChunkKdaBwdWyDqkgFused:
                             )
                             dg_base_addr = (
                                 dg_gmem.iterator
-                                + self._token_row(tok_offset + tile_idx * self.BT + store_row)
-                                * HV
-                                * K
+                                + self.upcast(tok_offset + tile_idx * self.BT + store_row) * HV * K
                                 + i_hv * K
                                 + store_col_base
                             ).toint()
@@ -4713,12 +4701,7 @@ def _compile_chunk_kda_bwd_wy_dqkg(
     ragged: bool,
     use_int64_offsets: bool = False,
 ):
-    """Compile one persistent dense or ragged WY/dQKG specialization.
-
-    ``use_int64_offsets`` widens the symbolic Q/K/V strides and kernel address
-    layouts to Int64 for tensors whose reachable element offsets exceed
-    INT32_MAX; it must key the cache because the offset width is baked in.
-    """
+    """Compile one persistent dense or ragged WY/dQKG specialization."""
     op = ChunkKdaBwdWyDqkgFused(
         chunk_size=chunk_size,
         head_dim_k=head_dim,
@@ -4729,7 +4712,7 @@ def _compile_chunk_kda_bwd_wy_dqkg(
         use_int64_offsets=use_int64_offsets,
     )
     tokens, chunks, sequences = (cute.sym_int() for _ in range(3))
-    sym_stride = cute.sym_int64 if use_int64_offsets else cute.sym_int
+    sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
 
     def tensor(dtype, shape):
         return make_fake_compact_tensor(
@@ -4743,7 +4726,7 @@ def _compile_chunk_kda_bwd_wy_dqkg(
         return make_fake_tensor(
             cutlass.BFloat16,
             shape,
-            stride=tuple(sym_stride(divisibility=_MIN_ALIGN_ELEMENTS_BF16) for _ in shape[:-1])
+            stride=tuple(sym_int(divisibility=_MIN_ALIGN_ELEMENTS_BF16) for _ in shape[:-1])
             + (1,),
             assumed_align=_MIN_ALIGN_BYTES,
         )

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_wy_dqkg_fused.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_wy_dqkg_fused.py
@@ -32,6 +32,7 @@ from cutlass.cute.tensor import TensorSSA
 from cutlass.cute.typing import BFloat16, Float32, Int32, Int64
 
 from attn_gym._backends.cute import compile_tvm_ffi, jit_cache, run_tunable
+from attn_gym._backends.triton.utils import requires_int64_offsets
 from attn_gym._backends.cute.target import CompileTarget, detect_compile_target, get_compile_target
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata
 from attn_gym.linear.kda.fwd.cute.chunk_scheduler_cute import load_ragged_chunk_work
@@ -1863,6 +1864,7 @@ class ChunkKdaBwdWyDqkgFused:
         scale: float = 1.0,
         grid_waves: int = 1,
         use_fast_math: bool = True,
+        use_int64_offsets: bool = False,
     ):
         assert chunk_size == 64, "chunk_size must be 64"
         assert head_dim_k == 128 and head_dim_v == 128, (
@@ -1871,6 +1873,9 @@ class ChunkKdaBwdWyDqkgFused:
         require_blackwell_target()
 
         self.use_fast_math = use_fast_math
+        # Widens token/chunk address strides to Int64 so crd2idx products cannot
+        # wrap once a tensor's reachable element offset exceeds INT32_MAX.
+        self.use_int64_offsets = use_int64_offsets
         self.chunk_size = chunk_size
         self.head_dim_k = head_dim_k
         self.head_dim_v = head_dim_v
@@ -2021,6 +2026,10 @@ class ChunkKdaBwdWyDqkgFused:
         data_B = Int32(1)
         NT = total_nt
 
+        def addr(value):
+            """Widen one address stride so coordinate products promote to i64."""
+            return cutlass.Int64(value) if cutlass.const_expr(self.use_int64_offsets) else value
+
         # ===================== GMEM layouts =====================
         # Token-indexed tensors: (T, dim, (H, data_B))
         def strided_token_layout(tensor: cute.Tensor, dim: Int32, head_count: Int32):
@@ -2042,7 +2051,7 @@ class ChunkKdaBwdWyDqkgFused:
 
         tv_layout = cute.make_layout(
             (T, V, (HV, data_B)),
-            stride=(HV * V, 1, (V, T * HV * V)),
+            stride=(addr(HV * V), 1, (V, addr(T) * HV * V)),
         )
         v_new = cute.make_tensor(v_new_ptr, tv_layout)
         do = cute.make_tensor(do_ptr, tv_layout)
@@ -2052,14 +2061,14 @@ class ChunkKdaBwdWyDqkgFused:
         # g: (T, K, (HV, data_B)) fp32
         g_layout = cute.make_layout(
             (T, K, (HV, data_B)),
-            stride=(HV * K, 1, (K, T * HV * K)),
+            stride=(addr(HV * K), 1, (K, addr(T) * HV * K)),
         )
         g = cute.make_tensor(g_ptr, g_layout)
 
         # beta: (T, (HV, data_B)) fp32
         beta_layout = cute.make_layout(
             (T, (HV, data_B)),
-            stride=(HV, (1, T * HV)),
+            stride=(addr(HV), (1, addr(T) * HV)),
         )
         beta = cute.make_tensor(beta_ptr, beta_layout)
 
@@ -2067,14 +2076,14 @@ class ChunkKdaBwdWyDqkgFused:
         # NOTE: for A as operand A, A is loaded as transposed view to do MMA
         a_t_layout = cute.make_layout(
             (BT, T, (HV, data_B)),
-            stride=(1, HV * BT, (BT, T * HV * BT)),
+            stride=(1, addr(HV * BT), (BT, addr(T) * HV * BT)),
         )
         A_T = cute.make_tensor(A_ptr, a_t_layout)
 
         # dq, dk: (T, K, (HV, data_B)) fp32
         dqk_layout = cute.make_layout(
             (T, K, (HV, data_B)),
-            stride=(HV * K, 1, (K, T * HV * K)),
+            stride=(addr(HV * K), 1, (K, addr(T) * HV * K)),
         )
         dq = cute.make_tensor(dq_ptr, dqk_layout)
         dk = cute.make_tensor(dk_ptr, dqk_layout)
@@ -2088,7 +2097,7 @@ class ChunkKdaBwdWyDqkgFused:
         # dA: (T, BT, (HV, data_B)) fp32
         dA_layout = cute.make_layout(
             (T, BT, (HV, data_B)),
-            stride=(HV * BT, 1, (BT, T * HV * BT)),
+            stride=(addr(HV * BT), 1, (BT, addr(T) * HV * BT)),
         )
         dA_out = cute.make_tensor(dA_ptr, dA_layout)
 
@@ -2097,7 +2106,7 @@ class ChunkKdaBwdWyDqkgFused:
         # h row-major: (K, V, (h_nt_total, HV)) as operand B
         h_layout = cute.make_layout(
             (K, V, (h_nt_total, HV)),
-            stride=(V, 1, (HV * K * V, K * V)),
+            stride=(V, 1, (addr(HV * K * V), addr(K * V))),
         )
         h = cute.make_tensor(h_ptr, h_layout)
         dh = cute.make_tensor(dh_ptr, h_layout)
@@ -4691,8 +4700,14 @@ def _compile_chunk_kda_bwd_wy_dqkg(
     fastmath: bool,
     grid_waves: int,
     ragged: bool,
+    use_int64_offsets: bool = False,
 ):
-    """Compile one persistent dense or ragged WY/dQKG specialization."""
+    """Compile one persistent dense or ragged WY/dQKG specialization.
+
+    ``use_int64_offsets`` widens the symbolic Q/K/V strides and kernel address
+    layouts to Int64 for tensors whose reachable element offsets exceed
+    INT32_MAX; it must key the cache because the offset width is baked in.
+    """
     op = ChunkKdaBwdWyDqkgFused(
         chunk_size=chunk_size,
         head_dim_k=head_dim,
@@ -4700,8 +4715,10 @@ def _compile_chunk_kda_bwd_wy_dqkg(
         scale=head_dim**-0.5,
         grid_waves=grid_waves,
         use_fast_math=fastmath,
+        use_int64_offsets=use_int64_offsets,
     )
     tokens, chunks, sequences = (cute.sym_int() for _ in range(3))
+    sym_stride = cute.sym_int64 if use_int64_offsets else cute.sym_int
 
     def tensor(dtype, shape):
         return make_fake_compact_tensor(
@@ -4715,7 +4732,7 @@ def _compile_chunk_kda_bwd_wy_dqkg(
         return make_fake_tensor(
             cutlass.BFloat16,
             shape,
-            stride=tuple(cute.sym_int(divisibility=_MIN_ALIGN_ELEMENTS_BF16) for _ in shape[:-1])
+            stride=tuple(sym_stride(divisibility=_MIN_ALIGN_ELEMENTS_BF16) for _ in shape[:-1])
             + (1,),
             assumed_align=_MIN_ALIGN_BYTES,
         )
@@ -4764,7 +4781,7 @@ def _compile_chunk_kda_bwd_wy_dqkg(
         Int32(1),
         name=(
             f"kda_bwd_wy_dqkg_h{heads}_d{head_dim}_c{chunk_size}_fm{int(fastmath)}_"
-            f"gw{grid_waves}_rg{int(ragged)}"
+            f"gw{grid_waves}_rg{int(ragged)}_i64{int(use_int64_offsets)}"
         ),
     )
 
@@ -4822,7 +4839,7 @@ class ChunkKdaBwdWyDqkgTunable:
     def compile_call(
         config: ChunkKdaBwdWyDqkgConfig,
         args: Args,
-    ) -> tuple[int, int, int, bool, int, bool]:
+    ) -> tuple[int, int, int, bool, int, bool, bool]:
         return (
             args.q.shape[2],
             args.q.shape[3],
@@ -4830,6 +4847,25 @@ class ChunkKdaBwdWyDqkgTunable:
             args.fastmath,
             config.grid_waves,
             args.chunk_offsets is not None,
+            requires_int64_offsets(
+                args.q,
+                args.k,
+                args.v,
+                args.v_new,
+                args.g,
+                args.beta,
+                args.A,
+                args.h,
+                args.do,
+                args.dh,
+                args.dv,
+                args.dq,
+                args.dk,
+                args.dv2,
+                args.dg,
+                args.db,
+                args.dA,
+            ),
         )
 
     compile = staticmethod(_compile_chunk_kda_bwd_wy_dqkg)

--- a/attn_gym/linear/kda/bwd/cute/gate_bwd_fused.py
+++ b/attn_gym/linear/kda/bwd/cute/gate_bwd_fused.py
@@ -39,6 +39,7 @@ from attn_gym._backends.cute import (
 )
 from attn_gym._backends.cute.device import cta_reduce_sum
 from attn_gym._backends.cute.target import get_compile_target
+from attn_gym._backends.triton.utils import requires_int64_offsets
 
 
 class WarpRole(IntEnum):
@@ -68,6 +69,7 @@ class FusedGateBwdOp:
         chunk_size: int,
         lower_bound: float,
         fastmath: bool,
+        use_int64_offsets: bool = False,
     ):
         if not isinstance(chunk_size, int) or isinstance(chunk_size, bool) or chunk_size < 1:
             raise ValueError(f"chunk_size must be a positive int, got {chunk_size!r}")
@@ -93,6 +95,7 @@ class FusedGateBwdOp:
         self.chunk_size = chunk_size
         self.lower_bound = lower_bound
         self.fastmath = fastmath
+        self.use_int64_offsets = use_int64_offsets
         self.tokens_per_stage = next(tokens for tokens in (4, 2, 1) if chunk_size % tokens == 0)
         subtiles = chunk_size // self.tokens_per_stage
         # Every TMA stage must begin at a 128-byte-aligned shared address.
@@ -105,7 +108,7 @@ class FusedGateBwdOp:
         return (
             f"kda_fused_gate_bwd_h{self.heads}_d{self.head_dim}_bt{self.chunk_size}"
             f"_lb{lower_bound}_tma_tps{self.tokens_per_stage}_s{self.stages}"
-            f"_fm{int(self.fastmath)}"
+            f"_fm{int(self.fastmath)}_i64{int(self.use_int64_offsets)}"
         )
 
     def _staged_layout(self):
@@ -367,9 +370,10 @@ def _compile_fused_gate_bwd(
     chunk_size: int,
     lower_bound: float,
     fastmath: bool,
+    use_int64_offsets: bool = False,
 ):
     """Compile one fake-tensor TVM-FFI specialization."""
-    op = FusedGateBwdOp(heads, head_dim, chunk_size, lower_bound, fastmath)
+    op = FusedGateBwdOp(heads, head_dim, chunk_size, lower_bound, fastmath, use_int64_offsets)
     target = get_compile_target()
     if target.device_type != "cuda" or target.capability is None or target.capability < (9, 0):
         raise ValueError(
@@ -379,15 +383,16 @@ def _compile_fused_gate_bwd(
     batch = cute.sym_int()
     tokens = cute.sym_int()
     chunks = cute.sym_int()
+    sym_stride = cute.sym_int64 if use_int64_offsets else cute.sym_int
 
     def strided_rows(dtype, alignment_elements: int):
         return cute.runtime.make_fake_tensor(
             dtype,
             (batch, tokens, heads, head_dim),
             stride=(
-                cute.sym_int(divisibility=alignment_elements),
-                cute.sym_int(divisibility=alignment_elements),
-                cute.sym_int(divisibility=alignment_elements),
+                sym_stride(divisibility=alignment_elements),
+                sym_stride(divisibility=alignment_elements),
+                sym_stride(divisibility=alignment_elements),
                 1,
             ),
             assumed_align=TMA_ALIGNMENT_BYTES,
@@ -527,6 +532,15 @@ def _fused_gate_bwd_cuda(
         op.chunk_size,
         op.lower_bound,
         op.fastmath,
+        requires_int64_offsets(
+            g,
+            A_log,
+            dt_bias,
+            d_cumulative,
+            dg,
+            dA_partial,
+            d_dt_bias_partial,
+        ),
     )
     compiled(g, A_log, dt_bias, d_cumulative, dg, dA_partial, d_dt_bias_partial)
     # Reducing the per-chunk partials keeps the post-pass off the full [B, T, H, D] tensors.

--- a/attn_gym/linear/kda/bwd/cute/gate_bwd_fused.py
+++ b/attn_gym/linear/kda/bwd/cute/gate_bwd_fused.py
@@ -373,7 +373,14 @@ def _compile_fused_gate_bwd(
     use_int64_offsets: bool = False,
 ):
     """Compile one fake-tensor TVM-FFI specialization."""
-    op = FusedGateBwdOp(heads, head_dim, chunk_size, lower_bound, fastmath, use_int64_offsets)
+    op = FusedGateBwdOp(
+        heads,
+        head_dim,
+        chunk_size,
+        lower_bound,
+        fastmath,
+        use_int64_offsets=use_int64_offsets,
+    )
     target = get_compile_target()
     if target.device_type != "cuda" or target.capability is None or target.capability < (9, 0):
         raise ValueError(
@@ -383,16 +390,16 @@ def _compile_fused_gate_bwd(
     batch = cute.sym_int()
     tokens = cute.sym_int()
     chunks = cute.sym_int()
-    sym_stride = cute.sym_int64 if use_int64_offsets else cute.sym_int
+    sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
 
     def strided_rows(dtype, alignment_elements: int):
         return cute.runtime.make_fake_tensor(
             dtype,
             (batch, tokens, heads, head_dim),
             stride=(
-                sym_stride(divisibility=alignment_elements),
-                sym_stride(divisibility=alignment_elements),
-                sym_stride(divisibility=alignment_elements),
+                sym_int(divisibility=alignment_elements),
+                sym_int(divisibility=alignment_elements),
+                sym_int(divisibility=alignment_elements),
                 1,
             ),
             assumed_align=TMA_ALIGNMENT_BYTES,
@@ -532,7 +539,7 @@ def _fused_gate_bwd_cuda(
         op.chunk_size,
         op.lower_bound,
         op.fastmath,
-        requires_int64_abi(
+        use_int64_offsets=requires_int64_abi(
             g,
             A_log,
             dt_bias,

--- a/attn_gym/linear/kda/bwd/cute/gate_bwd_fused.py
+++ b/attn_gym/linear/kda/bwd/cute/gate_bwd_fused.py
@@ -39,7 +39,7 @@ from attn_gym._backends.cute import (
 )
 from attn_gym._backends.cute.device import cta_reduce_sum
 from attn_gym._backends.cute.target import get_compile_target
-from attn_gym._backends.triton.utils import requires_int64_offsets
+from attn_gym._backends.cute.utils import requires_int64_abi
 
 
 class WarpRole(IntEnum):
@@ -532,7 +532,7 @@ def _fused_gate_bwd_cuda(
         op.chunk_size,
         op.lower_bound,
         op.fastmath,
-        requires_int64_offsets(
+        requires_int64_abi(
             g,
             A_log,
             dt_bias,

--- a/attn_gym/linear/kda/bwd/triton/gate_bwd.py
+++ b/attn_gym/linear/kda/bwd/triton/gate_bwd.py
@@ -18,11 +18,27 @@ import torch
 import triton
 import triton.language as tl
 
-from attn_gym._backends.triton.utils import ptr_offset
+from attn_gym._backends.triton.utils import ptr_offset, requires_int64_offsets
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata, load_ragged_chunk_work
 from attn_gym.linear.kda.utils import input_guard
 
 
+_HEURISTICS = {
+    "USE_INT64_OFFSETS": lambda args: requires_int64_offsets(
+        args["raw_gate"],
+        args["A_log"],
+        args["dt_bias"],
+        args["d_cumulative"],
+        args["dg"],
+        args["dA_partial"],
+        args["ddt_partial"],
+        args["cu_seqlens"],
+        args["chunk_offsets"],
+    )
+}
+
+
+@triton.heuristics(_HEURISTICS)
 @triton.jit(do_not_specialize=["num_sequences"])
 def kda_gate_bwd_ragged_kernel(
     raw_gate,
@@ -47,6 +63,7 @@ def kda_gate_bwd_ragged_kernel(
     D: tl.constexpr,
     BT: tl.constexpr,
     BD: tl.constexpr,
+    USE_INT64_OFFSETS: tl.constexpr,
 ):
     """Reverse-scan one ragged chunk and differentiate the bounded gate in place.
 
@@ -54,10 +71,14 @@ def kda_gate_bwd_ragged_kernel(
     without a full FP32 intermediate.
     """
     global_chunk = tl.program_id(0)
-    i_h = tl.program_id(1).to(tl.int64)
-    i_d = tl.program_id(2).to(tl.int64)
+    i_h = tl.program_id(1)
+    i_d = tl.program_id(2)
     if global_chunk >= tl.load(chunk_offsets + num_sequences):
         return
+    if USE_INT64_OFFSETS:
+        global_chunk = global_chunk.to(tl.int64)
+        i_h = i_h.to(tl.int64)
+        i_d = i_d.to(tl.int64)
 
     _sequence, _local_chunk, token_start, valid_tokens = load_ragged_chunk_work(
         cu_seqlens,
@@ -66,8 +87,10 @@ def kda_gate_bwd_ragged_kernel(
         num_sequences,
         BT,
     )
+    if USE_INT64_OFFSETS:
+        token_start = token_start.to(tl.int64)
     token_offset = tl.arange(0, BT)
-    token = token_start.to(tl.int64) + token_offset
+    token = token_start + token_offset
     channel = i_d * BD + tl.arange(0, BD)
     mask = (token_offset[:, None] < valid_tokens) & (channel[None, :] < D)
     d_gate = tl.load(

--- a/attn_gym/linear/kda/bwd/triton/gate_bwd.py
+++ b/attn_gym/linear/kda/bwd/triton/gate_bwd.py
@@ -22,7 +22,6 @@ from attn_gym._backends.triton.utils import ptr_offset, requires_int64_offsets
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata, load_ragged_chunk_work
 from attn_gym.linear.kda.utils import input_guard
 
-
 _HEURISTICS = {
     "USE_INT64_OFFSETS": lambda args: requires_int64_offsets(
         args["raw_gate"],

--- a/attn_gym/linear/kda/bwd/triton/gate_bwd.py
+++ b/attn_gym/linear/kda/bwd/triton/gate_bwd.py
@@ -88,6 +88,7 @@ def kda_gate_bwd_ragged_kernel(
         BT,
     )
     if USE_INT64_OFFSETS:
+        global_chunk = global_chunk.to(tl.int64)
         token_start = token_start.to(tl.int64)
     token_offset = tl.arange(0, BT)
     token = token_start + token_offset

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_inter_solve.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_inter_solve.py
@@ -84,17 +84,17 @@ def _compile_k3b(
         use_int64_offsets=use_int64_offsets,
     )
     tokens, chunks, sequences = (cute.sym_int() for _ in range(3))
-    sym_stride = cute.sym_int64 if use_int64_offsets else cute.sym_int
+    sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
     q = make_fake_tensor(
         cutlass.BFloat16,
         (tokens, heads * head_dim),
-        stride=(sym_stride(divisibility=8), 1),
+        stride=(sym_int(divisibility=8), 1),
         assumed_align=16,
     )
     k = make_fake_tensor(
         cutlass.BFloat16,
         (tokens, heads * head_dim),
-        stride=(sym_stride(divisibility=8), 1),
+        stride=(sym_int(divisibility=8), 1),
         assumed_align=16,
     )
     g = make_fake_compact_tensor(
@@ -279,7 +279,7 @@ def _chunk_kda_fwd_k3b_ragged_impl(
         chunk_size,
         subchunk_size,
         ChunkSchedule.RAGGED,
-        requires_int64_abi(q_flat, k_flat, g_flat, beta_flat, Aqk_flat, AkkOD),
+        use_int64_offsets=requires_int64_abi(q_flat, k_flat, g_flat, beta_flat, Aqk_flat, AkkOD),
     )
     k3b(
         q_flat,
@@ -353,7 +353,7 @@ def _chunk_kda_fwd_k4b_ragged_impl(
         chunk_size,
         subchunk_size,
         ChunkSchedule.RAGGED,
-        requires_int64_abi(AkkOD, akkd_flat, akk_flat),
+        use_int64_offsets=requires_int64_abi(AkkOD, akkd_flat, akk_flat),
     )
     k4b(
         AkkOD,

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_inter_solve.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_inter_solve.py
@@ -23,6 +23,7 @@ from torch._subclasses.fake_tensor import FakeTensor
 
 from attn_gym._backends.cute import compile_tvm_ffi, jit_cache
 from attn_gym._backends.cute.target import get_compile_target
+from attn_gym._backends.triton.utils import requires_int64_offsets
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata
 from attn_gym.linear.kda.fwd.cute.chunk_kda_k3b_offdiag_cutedsl import (
     ChunkKDAFwdK3bOffdiagCuteDSL,
@@ -68,6 +69,7 @@ def _compile_k3b(
     chunk_size: int,
     subchunk_size: int,
     schedule: ChunkSchedule,
+    use_int64_offsets: bool = False,
 ):
     """Compile one persistent K3b TVM-FFI scheduling specialization."""
     _check_compile_target()
@@ -79,18 +81,20 @@ def _compile_k3b(
         chunk_size=chunk_size,
         num_subchunks=num_subchunks,
         schedule=schedule,
+        use_int64_offsets=use_int64_offsets,
     )
     tokens, chunks, sequences = (cute.sym_int() for _ in range(3))
+    sym_stride = cute.sym_int64 if use_int64_offsets else cute.sym_int
     q = make_fake_tensor(
         cutlass.BFloat16,
         (tokens, heads * head_dim),
-        stride=(cute.sym_int(divisibility=8), 1),
+        stride=(sym_stride(divisibility=8), 1),
         assumed_align=16,
     )
     k = make_fake_tensor(
         cutlass.BFloat16,
         (tokens, heads * head_dim),
-        stride=(cute.sym_int(divisibility=8), 1),
+        stride=(sym_stride(divisibility=8), 1),
         assumed_align=16,
     )
     g = make_fake_compact_tensor(
@@ -151,7 +155,8 @@ def _compile_k3b(
         cu_seqlens,
         chunk_offsets,
         name=(
-            f"kda_fwd_k3b_h{heads}_d{head_dim}_c{chunk_size}_sc{subchunk_size}_schedule_{schedule.value}"
+            f"kda_fwd_k3b_h{heads}_d{head_dim}_c{chunk_size}_sc{subchunk_size}"
+            f"_schedule_{schedule.value}_i64{int(use_int64_offsets)}"
         ),
     )
 
@@ -163,6 +168,7 @@ def _compile_k4b(
     chunk_size: int,
     subchunk_size: int,
     schedule: ChunkSchedule,
+    use_int64_offsets: bool = False,
 ):
     """Compile one persistent K4b TVM-FFI scheduling specialization."""
     _check_compile_target()
@@ -173,6 +179,7 @@ def _compile_k4b(
         chunk_size=chunk_size,
         num_subchunks=num_subchunks,
         schedule=schedule,
+        use_int64_offsets=use_int64_offsets,
     )
     tokens, chunks, sequences = (cute.sym_int() for _ in range(3))
     AkkOD = make_fake_compact_tensor(
@@ -223,7 +230,8 @@ def _compile_k4b(
         cu_seqlens,
         chunk_offsets,
         name=(
-            f"kda_fwd_k4b_h{heads}_d{head_dim}_c{chunk_size}_sc{subchunk_size}_schedule_{schedule.value}"
+            f"kda_fwd_k4b_h{heads}_d{head_dim}_c{chunk_size}_sc{subchunk_size}"
+            f"_schedule_{schedule.value}_i64{int(use_int64_offsets)}"
         ),
     )
 
@@ -271,6 +279,7 @@ def _chunk_kda_fwd_k3b_ragged_impl(
         chunk_size,
         subchunk_size,
         ChunkSchedule.RAGGED,
+        requires_int64_offsets(q_flat, k_flat, g_flat, beta_flat, Aqk_flat, AkkOD),
     )
     k3b(
         q_flat,
@@ -336,17 +345,20 @@ def _chunk_kda_fwd_k4b_ragged_impl(
     if isinstance(Akkd, FakeTensor) or metadata.capacity == 0:
         return Akk
 
+    akkd_flat = Akkd.reshape(tokens, heads * subchunk_size).contiguous()
+    akk_flat = Akk.reshape(tokens, heads * chunk_size)
     k4b = _compile_k4b(
         heads,
         _SUPPORTED_HEAD_DIM,
         chunk_size,
         subchunk_size,
         ChunkSchedule.RAGGED,
+        requires_int64_offsets(AkkOD, akkd_flat, akk_flat),
     )
     k4b(
         AkkOD,
-        Akkd.reshape(tokens, heads * subchunk_size).contiguous(),
-        Akk.reshape(tokens, heads * chunk_size),
+        akkd_flat,
+        akk_flat,
         heads,
         metadata.capacity,
         metadata.cu_seqlens,
@@ -447,7 +459,16 @@ def chunk_kda_fwd_inter_solve_cute(
     with (
         torch.profiler.record_function("kda/cute/k3b_offdiag") if profile_ranges else nullcontext()
     ):
-        k3b = _compile_k3b(H, K, BT, BC, ChunkSchedule.DENSE)
+        k3b = _compile_k3b(
+            H,
+            K,
+            BT,
+            BC,
+            ChunkSchedule.DENSE,
+            use_int64_offsets=requires_int64_offsets(
+                q_flat, k_flat, g_flat, beta_flat, Aqk_flat, akk_od
+            ),
+        )
         k3b(
             q_flat,
             k_flat,
@@ -464,7 +485,14 @@ def chunk_kda_fwd_inter_solve_cute(
     with (
         torch.profiler.record_function("kda/cute/k4b_inverse") if profile_ranges else nullcontext()
     ):
-        k4b = _compile_k4b(H, K, BT, BC, ChunkSchedule.DENSE)
+        k4b = _compile_k4b(
+            H,
+            K,
+            BT,
+            BC,
+            ChunkSchedule.DENSE,
+            use_int64_offsets=requires_int64_offsets(akk_od, akkd_flat, Akk_flat),
+        )
         k4b(
             akk_od,
             akkd_flat,

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_inter_solve.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_inter_solve.py
@@ -23,7 +23,7 @@ from torch._subclasses.fake_tensor import FakeTensor
 
 from attn_gym._backends.cute import compile_tvm_ffi, jit_cache
 from attn_gym._backends.cute.target import get_compile_target
-from attn_gym._backends.triton.utils import requires_int64_offsets
+from attn_gym._backends.cute.utils import requires_int64_abi
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata
 from attn_gym.linear.kda.fwd.cute.chunk_kda_k3b_offdiag_cutedsl import (
     ChunkKDAFwdK3bOffdiagCuteDSL,
@@ -279,7 +279,7 @@ def _chunk_kda_fwd_k3b_ragged_impl(
         chunk_size,
         subchunk_size,
         ChunkSchedule.RAGGED,
-        requires_int64_offsets(q_flat, k_flat, g_flat, beta_flat, Aqk_flat, AkkOD),
+        requires_int64_abi(q_flat, k_flat, g_flat, beta_flat, Aqk_flat, AkkOD),
     )
     k3b(
         q_flat,
@@ -353,7 +353,7 @@ def _chunk_kda_fwd_k4b_ragged_impl(
         chunk_size,
         subchunk_size,
         ChunkSchedule.RAGGED,
-        requires_int64_offsets(AkkOD, akkd_flat, akk_flat),
+        requires_int64_abi(AkkOD, akkd_flat, akk_flat),
     )
     k4b(
         AkkOD,
@@ -465,7 +465,7 @@ def chunk_kda_fwd_inter_solve_cute(
             BT,
             BC,
             ChunkSchedule.DENSE,
-            use_int64_offsets=requires_int64_offsets(
+            use_int64_offsets=requires_int64_abi(
                 q_flat, k_flat, g_flat, beta_flat, Aqk_flat, akk_od
             ),
         )
@@ -491,7 +491,7 @@ def chunk_kda_fwd_inter_solve_cute(
             BT,
             BC,
             ChunkSchedule.DENSE,
-            use_int64_offsets=requires_int64_offsets(akk_od, akkd_flat, Akk_flat),
+            use_int64_offsets=requires_int64_abi(akk_od, akkd_flat, Akk_flat),
         )
         k4b(
             akk_od,

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_k3b_offdiag_cutedsl.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_k3b_offdiag_cutedsl.py
@@ -33,12 +33,6 @@ from attn_gym.linear.kda.fwd.cute.chunk_schedule import ChunkSchedule
 from attn_gym.linear.kda.fwd.cute.chunk_scheduler_cute import load_ragged_chunk_work
 
 
-@cute.jit
-def _addr(value, use_int64_offsets):
-    """Widen a flattened tensor coordinate in the large-offset specialization."""
-    return cutlass.Int64(value) if cutlass.const_expr(use_int64_offsets) else value
-
-
 class ChunkKDAFwdK3bOffdiagCuteDSL:
     WARP_SIZE = 32
 
@@ -67,6 +61,11 @@ class ChunkKDAFwdK3bOffdiagCuteDSL:
         self.num_threads = 128
         self.mma_inst_shape = (16, 8, 16)
         self.atom_layout_mnk = (1, 1, 1)
+
+    @cute.jit
+    def upcast(self, value):
+        """Promote an address operand before its first overflowing multiply."""
+        return cutlass.Int64(value) if cutlass.const_expr(self.use_int64_offsets) else value
 
     @cute.jit
     def __call__(
@@ -216,12 +215,12 @@ class ChunkKDAFwdK3bOffdiagCuteDSL:
             chunk_base = chunk_idx * self.BT
             eos = cute.size(mQ, mode=[0])
 
-        chunk_base = _addr(chunk_base, self.use_int64_offsets)
+        chunk_base = self.upcast(chunk_base)
         ti_row = chunk_base + ri * self.BC
         ti_col = chunk_base + ci * self.BC
-        h_offset = _addr(head_idx, self.use_int64_offsets) * self.D
-        aqk_col = _addr(head_idx, self.use_int64_offsets) * self.BT
-        akkod_col = _addr(head_idx, self.use_int64_offsets) * self.BC * self.BC
+        h_offset = head_idx * self.D
+        aqk_col = head_idx * self.BT
+        akkod_col = head_idx * self.BC * self.BC
 
         # ══════════════════════════════════════════════════════════
         # Phase 1: Gating into SMEM
@@ -367,7 +366,7 @@ class ChunkKDAFwdK3bOffdiagCuteDSL:
         cC = cute.make_identity_tensor((self.BC, self.BC))
         tCcC = thr_mma.partition_C(cC)
 
-        od_row = _addr(chunk_idx, self.use_int64_offsets) * self.num_offdiag_blocks + pair_idx
+        od_row = self.upcast(chunk_idx) * self.num_offdiag_blocks + pair_idx
 
         if warp_idx == 0:
             out_dtype = mAqk.element_type

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_k3b_offdiag_cutedsl.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_k3b_offdiag_cutedsl.py
@@ -33,6 +33,12 @@ from attn_gym.linear.kda.fwd.cute.chunk_schedule import ChunkSchedule
 from attn_gym.linear.kda.fwd.cute.chunk_scheduler_cute import load_ragged_chunk_work
 
 
+@cute.jit
+def _addr(value, use_int64_offsets):
+    """Widen a flattened tensor coordinate in the large-offset specialization."""
+    return cutlass.Int64(value) if cutlass.const_expr(use_int64_offsets) else value
+
+
 class ChunkKDAFwdK3bOffdiagCuteDSL:
     WARP_SIZE = 32
 
@@ -43,6 +49,7 @@ class ChunkKDAFwdK3bOffdiagCuteDSL:
         chunk_size: int = 64,
         num_subchunks: int = 4,
         schedule: ChunkSchedule = ChunkSchedule.DENSE,
+        use_int64_offsets: bool = False,
     ):
         assert num_subchunks == 4, (
             f"ChunkKDAFwdK3bOffdiagCuteDSL only supports four subchunks, got {num_subchunks}"
@@ -51,6 +58,7 @@ class ChunkKDAFwdK3bOffdiagCuteDSL:
             f"chunk_size must equal num_subchunks * BC, got {chunk_size} and "
             f"{num_subchunks} * {BC}"
         )
+        self.use_int64_offsets = use_int64_offsets
         self.BC = BC
         self.D = D
         self.schedule = schedule
@@ -208,9 +216,12 @@ class ChunkKDAFwdK3bOffdiagCuteDSL:
             chunk_base = chunk_idx * self.BT
             eos = cute.size(mQ, mode=[0])
 
+        chunk_base = _addr(chunk_base, self.use_int64_offsets)
         ti_row = chunk_base + ri * self.BC
         ti_col = chunk_base + ci * self.BC
-        h_offset = head_idx * self.D
+        h_offset = _addr(head_idx, self.use_int64_offsets) * self.D
+        aqk_col = _addr(head_idx, self.use_int64_offsets) * self.BT
+        akkod_col = _addr(head_idx, self.use_int64_offsets) * self.BC * self.BC
 
         # ══════════════════════════════════════════════════════════
         # Phase 1: Gating into SMEM
@@ -356,7 +367,7 @@ class ChunkKDAFwdK3bOffdiagCuteDSL:
         cC = cute.make_identity_tensor((self.BC, self.BC))
         tCcC = thr_mma.partition_C(cC)
 
-        od_row = chunk_idx * self.num_offdiag_blocks + pair_idx
+        od_row = _addr(chunk_idx, self.use_int64_offsets) * self.num_offdiag_blocks + pair_idx
 
         if warp_idx == 0:
             out_dtype = mAqk.element_type
@@ -365,11 +376,11 @@ class ChunkKDAFwdK3bOffdiagCuteDSL:
                 col = tCcC[i][1]
                 if cutlass.const_expr(self.schedule is not ChunkSchedule.DENSE):
                     if chunk_base + self.BT <= eos or ti_row + row < eos:
-                        mAqk[ti_row + row, head_idx * self.BT + ci * self.BC + col] = out_dtype(
+                        mAqk[ti_row + row, aqk_col + ci * self.BC + col] = out_dtype(
                             acc_Aqk[i] * scale
                         )
                 else:
-                    mAqk[ti_row + row, head_idx * self.BT + ci * self.BC + col] = out_dtype(
+                    mAqk[ti_row + row, aqk_col + ci * self.BC + col] = out_dtype(
                         acc_Aqk[i] * scale
                     )
         elif warp_idx == 1:
@@ -377,9 +388,7 @@ class ChunkKDAFwdK3bOffdiagCuteDSL:
                 row = tCcC[i][0]
                 col = tCcC[i][1]
                 beta_val = sBeta[row]
-                mAkkOD[od_row, head_idx * self.BC * self.BC + row * self.BC + col] = (
-                    acc_Akk[i] * beta_val
-                )
+                mAkkOD[od_row, akkod_col + row * self.BC + col] = acc_Akk[i] * beta_val
         elif warp_idx == 2:
             # Define the noncausal block while this CTA already owns the
             # corresponding lower block. Aqk is exposed as custom-op tape, so
@@ -390,8 +399,6 @@ class ChunkKDAFwdK3bOffdiagCuteDSL:
                 col = tCcC[i][1]
                 if cutlass.const_expr(self.schedule is not ChunkSchedule.DENSE):
                     if ti_col + row < eos:
-                        mAqk[ti_col + row, head_idx * self.BT + ri * self.BC + col] = out_dtype(
-                            0.0
-                        )
+                        mAqk[ti_col + row, aqk_col + ri * self.BC + col] = out_dtype(0.0)
                 else:
-                    mAqk[ti_col + row, head_idx * self.BT + ri * self.BC + col] = out_dtype(0.0)
+                    mAqk[ti_col + row, aqk_col + ri * self.BC + col] = out_dtype(0.0)

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_k4b_inverse_cutedsl.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_k4b_inverse_cutedsl.py
@@ -34,12 +34,6 @@ from attn_gym.linear.kda.fwd.cute.chunk_schedule import ChunkSchedule
 from attn_gym.linear.kda.fwd.cute.chunk_scheduler_cute import load_ragged_chunk_work
 
 
-@cute.jit
-def _addr(value, use_int64_offsets):
-    """Widen a flattened tensor coordinate in the large-offset specialization."""
-    return cutlass.Int64(value) if cutlass.const_expr(use_int64_offsets) else value
-
-
 class ChunkKDAFwdK4bInverseCuteDSL:
     WARP_SIZE = 32
 
@@ -66,6 +60,11 @@ class ChunkKDAFwdK4bInverseCuteDSL:
         self.mma_inst_shape = (16, 8, 16)
         self.atom_layout_mnk = (1, 1, 1)
         self.schedule = schedule
+
+    @cute.jit
+    def upcast(self, value):
+        """Promote an address operand before its first overflowing multiply."""
+        return cutlass.Int64(value) if cutlass.const_expr(self.use_int64_offsets) else value
 
     @cute.jit
     def _load_diagonal_inverse_block(
@@ -226,15 +225,15 @@ class ChunkKDAFwdK4bInverseCuteDSL:
             eos = cute.size(mAkk, mode=[0])
             is_active = Int32(1)
 
-        chunk_base = _addr(chunk_base, self.use_int64_offsets)
+        chunk_base = self.upcast(chunk_base)
         i_tc0 = chunk_base
         i_tc1 = chunk_base + self.BC
         i_tc2 = chunk_base + 2 * self.BC
         i_tc3 = chunk_base + 3 * self.BC
 
-        h_akkd_col = _addr(head_idx, self.use_int64_offsets) * self.BC
-        h_akk_col = _addr(head_idx, self.use_int64_offsets) * self.BT
-        h_akkod_col = _addr(head_idx, self.use_int64_offsets) * self.BC * self.BC
+        h_akkd_col = head_idx * self.BC
+        h_akk_col = head_idx * self.BT
+        h_akkod_col = head_idx * self.BC * self.BC
 
         vr0 = cutlass.min(cutlass.max(eos - i_tc0, 0), self.BC)
         vr1 = cutlass.min(cutlass.max(eos - i_tc1, 0), self.BC)
@@ -277,7 +276,7 @@ class ChunkKDAFwdK4bInverseCuteDSL:
         # ══════════════════════════════════════════════════════════
         # PHASE 1: Per-warp OD loading + preinverted diagonal-block loading
         # ══════════════════════════════════════════════════════════
-        od_base_row = _addr(chunk_idx, self.use_int64_offsets) * self.num_offdiag_blocks
+        od_base_row = self.upcast(chunk_idx) * self.num_offdiag_blocks
 
         if is_active and warp_idx == 0:
             for i in cutlass.range_constexpr(cute.size(acc_od0)):

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_k4b_inverse_cutedsl.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_k4b_inverse_cutedsl.py
@@ -34,6 +34,12 @@ from attn_gym.linear.kda.fwd.cute.chunk_schedule import ChunkSchedule
 from attn_gym.linear.kda.fwd.cute.chunk_scheduler_cute import load_ragged_chunk_work
 
 
+@cute.jit
+def _addr(value, use_int64_offsets):
+    """Widen a flattened tensor coordinate in the large-offset specialization."""
+    return cutlass.Int64(value) if cutlass.const_expr(use_int64_offsets) else value
+
+
 class ChunkKDAFwdK4bInverseCuteDSL:
     WARP_SIZE = 32
 
@@ -43,6 +49,7 @@ class ChunkKDAFwdK4bInverseCuteDSL:
         chunk_size: int = 64,
         num_subchunks: int = 4,
         schedule: ChunkSchedule = ChunkSchedule.DENSE,
+        use_int64_offsets: bool = False,
     ):
         assert num_subchunks == 4, (
             f"ChunkKDAFwdK4bInverseCuteDSL only supports four subchunks, got {num_subchunks}"
@@ -51,6 +58,7 @@ class ChunkKDAFwdK4bInverseCuteDSL:
             f"chunk_size must equal num_subchunks * BC, got {chunk_size} and "
             f"{num_subchunks} * {BC}"
         )
+        self.use_int64_offsets = use_int64_offsets
         self.BC = BC
         self.BT = chunk_size
         self.num_offdiag_blocks = num_subchunks * (num_subchunks - 1) // 2
@@ -218,13 +226,15 @@ class ChunkKDAFwdK4bInverseCuteDSL:
             eos = cute.size(mAkk, mode=[0])
             is_active = Int32(1)
 
+        chunk_base = _addr(chunk_base, self.use_int64_offsets)
         i_tc0 = chunk_base
         i_tc1 = chunk_base + self.BC
         i_tc2 = chunk_base + 2 * self.BC
         i_tc3 = chunk_base + 3 * self.BC
 
-        h_akkd_col = head_idx * self.BC
-        h_akk_col = head_idx * self.BT
+        h_akkd_col = _addr(head_idx, self.use_int64_offsets) * self.BC
+        h_akk_col = _addr(head_idx, self.use_int64_offsets) * self.BT
+        h_akkod_col = _addr(head_idx, self.use_int64_offsets) * self.BC * self.BC
 
         vr0 = cutlass.min(cutlass.max(eos - i_tc0, 0), self.BC)
         vr1 = cutlass.min(cutlass.max(eos - i_tc1, 0), self.BC)
@@ -267,13 +277,13 @@ class ChunkKDAFwdK4bInverseCuteDSL:
         # ══════════════════════════════════════════════════════════
         # PHASE 1: Per-warp OD loading + preinverted diagonal-block loading
         # ══════════════════════════════════════════════════════════
-        od_base_row = chunk_idx * self.num_offdiag_blocks
+        od_base_row = _addr(chunk_idx, self.use_int64_offsets) * self.num_offdiag_blocks
 
         if is_active and warp_idx == 0:
             for i in cutlass.range_constexpr(cute.size(acc_od0)):
                 row = tCcC[i][0]
                 col = tCcC[i][1]
-                rc = head_idx * self.BC * self.BC + row * self.BC + col
+                rc = h_akkod_col + row * self.BC + col
                 acc_od0[i] = mAkkOD[od_base_row + 0, rc]
                 acc_od1[i] = mAkkOD[od_base_row + 1, rc]
                 acc_od2[i] = mAkkOD[od_base_row + 2, rc]
@@ -286,7 +296,7 @@ class ChunkKDAFwdK4bInverseCuteDSL:
             for i in cutlass.range_constexpr(cute.size(acc_od0)):
                 row = tCcC[i][0]
                 col = tCcC[i][1]
-                rc = head_idx * self.BC * self.BC + row * self.BC + col
+                rc = h_akkod_col + row * self.BC + col
                 acc_od2[i] = mAkkOD[od_base_row + 2, rc]
                 acc_od4[i] = mAkkOD[od_base_row + 4, rc]
                 acc_od5[i] = mAkkOD[od_base_row + 5, rc]
@@ -296,7 +306,7 @@ class ChunkKDAFwdK4bInverseCuteDSL:
             for i in cutlass.range_constexpr(cute.size(acc_od0)):
                 row = tCcC[i][0]
                 col = tCcC[i][1]
-                rc = head_idx * self.BC * self.BC + row * self.BC + col
+                rc = h_akkod_col + row * self.BC + col
                 acc_od5[i] = mAkkOD[od_base_row + 5, rc]
             self._load_diagonal_inverse_block(mAkkd, sAi2, i_tc2, lane_idx, h_akkd_col, vr2)
 

--- a/attn_gym/linear/kda/fwd/triton/recompute_w_u.py
+++ b/attn_gym/linear/kda/fwd/triton/recompute_w_u.py
@@ -126,18 +126,18 @@ def recompute_w_u_fwd_kernel(
         i_n, i_t, token_start, _ = load_ragged_chunk_work(
             cu_seqlens, chunk_offsets, i_c, num_sequences, BT
         )
-        if USE_INT64_OFFSETS:
-            i_n = i_n.to(tl.int64)
-            i_t = i_t.to(tl.int64)
-            token_start = token_start.to(tl.int64)
         # token_start == bos + i_t * BT; only eos still needs a load for masking.
-        bos = token_start - i_t * BT
         eos = tl.load(cu_seqlens + ptr_offset((i_n,), (1,)) + 1).to(tl.int32)
         if USE_INT64_OFFSETS:
+            i_t = i_t.to(tl.int64)
+            token_start = token_start.to(tl.int64)
             eos = eos.to(tl.int64)
+        bos = token_start - i_t * BT
         T_local = eos - bos
     else:
         i_t = i_c
+        if USE_INT64_OFFSETS:
+            i_t = i_t.to(tl.int64)
         bos = 0
         T_local = T
 

--- a/attn_gym/linear/kda/fwd/triton/recompute_w_u.py
+++ b/attn_gym/linear/kda/fwd/triton/recompute_w_u.py
@@ -36,7 +36,11 @@ import triton
 import triton.language as tl
 from torch._subclasses.fake_tensor import FakeTensor
 
-from attn_gym._backends.triton.utils import PinnedConfigKernel, ptr_offset
+from attn_gym._backends.triton.utils import (
+    PinnedConfigKernel,
+    ptr_offset,
+    requires_int64_offsets,
+)
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata, load_ragged_chunk_work
 from attn_gym.linear.kda.utils import autotune_cache_kwargs, exp2
 
@@ -49,6 +53,20 @@ _PRECISION_MODES = {"bf16": 0, "tf32": 1, "tf32x3": 2}
         "STORE_QG": lambda args: args["q"] is not None,
         "HAS_GK": lambda args: args["gk"] is not None,
         "IS_RAGGED": lambda args: args["chunk_offsets"] is not None,
+        "USE_INT64_OFFSETS": lambda args: requires_int64_offsets(
+            args["q"],
+            args["k"],
+            args["qg"],
+            args["kg"],
+            args["v"],
+            args["beta"],
+            args["w"],
+            args["u"],
+            args["A"],
+            args["gk"],
+            args["cu_seqlens"],
+            args["chunk_offsets"],
+        ),
     }
 )
 @triton.autotune(
@@ -94,9 +112,13 @@ def recompute_w_u_fwd_kernel(
     STORE_QG: tl.constexpr,
     HAS_GK: tl.constexpr,
     IS_RAGGED: tl.constexpr,
+    USE_INT64_OFFSETS: tl.constexpr,
 ):
     """Recompute one chunk's W/U (and optional QG/KG) with register-operand dots."""
-    i_c, i_hv = tl.program_id(0), tl.program_id(1).to(tl.int64)
+    i_c, i_hv = tl.program_id(0), tl.program_id(1)
+    if USE_INT64_OFFSETS:
+        i_c = i_c.to(tl.int64)
+        i_hv = i_hv.to(tl.int64)
     i_h = i_hv // (HV // H)
     if IS_RAGGED:
         if i_c >= tl.load(chunk_offsets + num_sequences):
@@ -104,23 +126,29 @@ def recompute_w_u_fwd_kernel(
         i_n, i_t, token_start, _ = load_ragged_chunk_work(
             cu_seqlens, chunk_offsets, i_c, num_sequences, BT
         )
+        if USE_INT64_OFFSETS:
+            i_n = i_n.to(tl.int64)
+            i_t = i_t.to(tl.int64)
+            token_start = token_start.to(tl.int64)
         # token_start == bos + i_t * BT; only eos still needs a load for masking.
-        bos = (token_start - i_t * BT).to(tl.int64)
-        eos = tl.load(cu_seqlens + ptr_offset((i_n,), (1,)) + 1).to(tl.int64)
-        T_local = (eos - bos).to(tl.int32)
+        bos = token_start - i_t * BT
+        eos = tl.load(cu_seqlens + ptr_offset((i_n,), (1,)) + 1).to(tl.int32)
+        if USE_INT64_OFFSETS:
+            eos = eos.to(tl.int64)
+        T_local = eos - bos
     else:
         i_t = i_c
         bos = 0
         T_local = T
 
-    o_t = i_t.to(tl.int64) * BT + tl.arange(0, BT)
+    o_t = i_t * BT + tl.arange(0, BT)
     m_t = o_t < T_local
     token = bos + o_t
 
     b_b = tl.load(beta + ptr_offset((token, i_hv), (HV, 1)), mask=m_t, other=0.0).to(tl.float32)
 
     o_A = tl.arange(0, BT)
-    valid = T_local - i_t.to(tl.int32) * BT
+    valid = T_local - i_t * BT
     # Inclusive tril + row/col validity, matching the CuTe kernel's A masking.
     m_A = m_t[:, None] & (o_A[None, :] <= o_A[:, None]) & (o_A[None, :] < valid)
     b_A_raw = tl.load(

--- a/test/test_kda_cute_forward.py
+++ b/test/test_kda_cute_forward.py
@@ -530,6 +530,7 @@ def test_kda_offset_width_specializations_match(monkeypatch):
         "attn_gym.linear.kda.fwd.triton.chunk_kda_fwd_intra_sub_chunk_forloop",
         "attn_gym.linear.kda.fwd.triton.chunk_delta_h",
         "attn_gym.linear.kda.fwd.triton.chunk_gla_fwd_o",
+        "attn_gym.linear.kda.fwd.triton.recompute_w_u",
         "attn_gym.linear.kda.bwd.triton.chunk_kda_bwd_dav",
     ):
         module = importlib.import_module(module_name)

--- a/test/test_kda_int64_offsets.py
+++ b/test/test_kda_int64_offsets.py
@@ -41,9 +41,8 @@ def test_forced_int64_chunk_kda_matches_default_path(monkeypatch):
     import attn_gym.linear.kda.bwd.cute.chunk_delta_h_bwd_v1 as delta_module
     import attn_gym.linear.kda.bwd.cute.chunk_kda_bwd_intra as intra_module
     import attn_gym.linear.kda.bwd.cute.chunk_kda_bwd_wy_dqkg_fused as wy_module
-    import attn_gym.linear.kda.bwd.cute.gate_bwd_fused as gate_module
     import attn_gym.linear.kda.fwd.cute.chunk_kda_fwd_inter_solve as inter_module
-    from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd import chunk_kda
+    from attn_gym.linear import chunk_kda
 
     def run():
         torch.manual_seed(13)
@@ -62,7 +61,7 @@ def test_forced_int64_chunk_kda_matches_default_path(monkeypatch):
         return (output, *grads)
 
     baseline = run()
-    for module in (delta_module, intra_module, wy_module, gate_module, inter_module):
+    for module in (delta_module, intra_module, wy_module, inter_module):
         monkeypatch.setattr(module, "requires_int64_abi", lambda *tensors: True)
     forced = run()
     for name, expected, actual in zip(
@@ -71,45 +70,85 @@ def test_forced_int64_chunk_kda_matches_default_path(monkeypatch):
         torch.testing.assert_close(actual, expected, rtol=0, atol=0, msg=lambda m, n=name: n)
 
 
+@pytest.mark.skipif(not CUTE_CAPABLE, reason="the CuTe KDA kernels require capability 10.x")
+def test_chunk_kda_oversized_singleton_stride_matches_compact():
+    """Exercise automatic int64 ABI selection without allocating unreachable storage."""
+    from attn_gym.linear import chunk_kda
+
+    def run(oversized_batch_stride: bool):
+        torch.manual_seed(11)
+        tokens, heads = 192, 2
+        qkv = torch.randn(1, tokens, 3, heads, 128, device="cuda", dtype=torch.bfloat16) / 8
+        q, k, v = (qkv[:, :, index] for index in range(3))
+        if oversized_batch_stride:
+            q, k, v = (
+                tensor.as_strided(tensor.shape, (2**31, *tensor.stride()[1:]))
+                for tensor in (q, k, v)
+            )
+            assert requires_int64_abi(q, k, v)
+        q, k, v = (tensor.requires_grad_() for tensor in (q, k, v))
+        gate = (-torch.rand(1, tokens, heads, 128, device="cuda")).requires_grad_()
+        beta = torch.rand(1, tokens, heads, device="cuda").requires_grad_()
+        offsets = torch.tensor([0, 65, tokens], device="cuda", dtype=torch.int32)
+        output, _ = chunk_kda(q, k, v, gate, beta, cu_seqlens=offsets)
+        grads = torch.autograd.grad(output.float().square().sum(), (q, k, v, gate, beta))
+        return (output, *grads)
+
+    compact = run(False)
+    oversized = run(True)
+    for name, expected, actual in zip(
+        ("output", "dq", "dk", "dv", "dgate", "dbeta"), compact, oversized, strict=True
+    ):
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0, msg=lambda m, n=name: n)
+
+
 @pytest.mark.skipif(
     not CUTE_CAPABLE or torch.cuda.get_device_properties(0).total_memory < 100 * 1024**3,
-    reason="the over-capture regression allocates ~60GB of capacity buffers",
+    reason="the executed-overflow regression allocates ~60GB of fully active buffers",
 )
-def test_chunk_kda_262144_token_packed_capacity_matches_exact():
-    """Run the full core at the first int64-requiring capacity with packed pitch."""
-    from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd import chunk_kda
+def test_chunk_kda_full_262144_tokens_executes_offsets_past_int32():
+    """Actually execute element offsets beyond INT32_MAX, not just accept the ABI.
 
-    heads, dim, active = 32, 128, 8192
+    A fully active 262144-token run with packed-projection pitch reaches
+    token offsets near 3.2e9 in Q/K/V; the same tokens through compact clones
+    stay below INT32_MAX and take the i32 specializations. Both must agree.
+    """
+    from attn_gym.linear import chunk_kda
 
-    def run(capacity):
-        torch.manual_seed(11)
-        qkv = torch.full(
-            (1, capacity, 3, heads, dim), float("nan"), device="cuda", dtype=torch.bfloat16
-        )
-        qkv[:, :active] = (
-            torch.randn(1, active, 3, heads, dim, device="cuda", dtype=torch.bfloat16) / 8
-        )
-        q, k, v = (qkv[:, :, i].requires_grad_() for i in range(3))
-        gate = torch.full((1, capacity, heads, dim), float("nan"), device="cuda")
-        gate[:, :active] = -torch.rand(1, active, heads, dim, device="cuda")
-        gate = gate.requires_grad_()
-        beta = torch.full((1, capacity, heads), float("nan"), device="cuda")
-        beta[:, :active] = torch.rand(1, active, heads, device="cuda")
-        beta = beta.requires_grad_()
-        grad = torch.zeros(1, capacity, heads, dim, device="cuda")
-        grad[:, :active] = torch.randn(1, active, heads, dim, device="cuda") / 8
+    heads, dim, tokens = 32, 128, 262144
+    torch.manual_seed(17)
+    qkv = torch.randn(1, tokens, 3, heads, dim, device="cuda", dtype=torch.bfloat16) / 8
+    packed = tuple(qkv[:, :, i] for i in range(3))
+    compact = tuple(view.contiguous() for view in packed)
+    assert requires_int64_abi(*packed) and not requires_int64_abi(*compact)
 
-        offsets = torch.tensor([0, active], device="cuda", dtype=torch.int32)
-        out, _ = chunk_kda(q, k, v, gate, beta, cu_seqlens=offsets, persistent=True)
-        loss = (out[:, :active].float() * grad[:, :active]).sum()
-        grads = torch.autograd.grad(loss, (q, k, v, gate, beta))
-        return (out[:, :active].clone(), *(g[:, :active].clone() for g in grads))
+    gate = -torch.rand(1, tokens, heads, dim, device="cuda")
+    beta = torch.rand(1, tokens, heads, device="cuda")
+    offsets = torch.tensor([0, tokens], device="cuda", dtype=torch.int32)
 
-    small = run(active)
-    torch.cuda.empty_cache()
-    large = run(262144)
-    for name, expected, actual in zip(
-        ("output", "dq", "dk", "dv", "dgate", "dbeta"), small, large, strict=True
-    ):
-        assert not actual.isnan().any(), name
-        torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2, msg=lambda m, n=name: n)
+    with torch.no_grad():
+        wide, _ = chunk_kda(*packed, gate, beta, cu_seqlens=offsets)
+        narrow, _ = chunk_kda(*compact, gate, beta, cu_seqlens=offsets)
+    torch.testing.assert_close(wide, narrow, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not CUTE_CAPABLE, reason="the CuTe KDA kernels require capability 10.x")
+def test_forced_int64_dense_gate_backward_matches_default(monkeypatch):
+    """Cover the dense fused gate backward's i64 specialization on small inputs."""
+    import attn_gym.linear.kda.bwd.cute.gate_bwd_fused as gate_module
+    from attn_gym.linear.kda.bwd.cute.gate_bwd_fused import fused_gate_bwd
+
+    def run():
+        torch.manual_seed(19)
+        raw_gate = torch.randn(1, 128, 2, 128, device="cuda", dtype=torch.bfloat16) / 8
+        A_log = torch.zeros(2, device="cuda")
+        dt_bias = torch.zeros(2, 128, device="cuda")
+        d_cumulative = torch.randn(1, 128, 2, 128, device="cuda") / 8
+        result = fused_gate_bwd(raw_gate, A_log, dt_bias, d_cumulative, lower_bound=-5.0)
+        return result.dg, result.dA_partial, result.d_dt_bias
+
+    baseline = run()
+    monkeypatch.setattr(gate_module, "requires_int64_abi", lambda *tensors: True)
+    forced = run()
+    for expected, actual in zip(baseline, forced, strict=True):
+        assert torch.equal(actual, expected)

--- a/test/test_kda_int64_offsets.py
+++ b/test/test_kda_int64_offsets.py
@@ -103,8 +103,8 @@ def test_chunk_kda_oversized_singleton_stride_matches_compact():
 
 
 @pytest.mark.skipif(
-    not CUTE_CAPABLE or torch.cuda.get_device_properties(0).total_memory < 100 * 1024**3,
-    reason="the executed-overflow regression allocates ~60GB of fully active buffers",
+    not CUTE_CAPABLE or torch.cuda.get_device_properties(0).total_memory < 60 * 1024**3,
+    reason="the executed-overflow regression peaks near 38 GiB of reserved memory",
 )
 def test_chunk_kda_full_262144_tokens_executes_offsets_past_int32():
     """Actually execute element offsets beyond INT32_MAX, not just accept the ABI.

--- a/test/test_kda_int64_offsets.py
+++ b/test/test_kda_int64_offsets.py
@@ -1,0 +1,115 @@
+"""Int64 offset-width selection and equivalence tests for the CuTe KDA kernels."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from attn_gym._backends.cute.utils import requires_int64_abi
+
+CUTE_CAPABLE = torch.cuda.is_available() and torch.cuda.get_device_capability() in (
+    (10, 0),
+    (10, 3),
+)
+
+
+def test_requires_int64_abi_covers_oversized_singleton_strides():
+    """Reject the i32 signature for every inventoried ABI boundary case.
+
+    ``requires_int64_offsets`` bounds reachable offsets only, so a size-1 batch
+    mode with an oversized declared stride must be caught by the ABI predicate.
+    """
+    cases = {
+        # [1, T, H, D] packed-projection slice at the first ABI failure.
+        "packed_q": ((1, 174763, 32, 128), (174763 * 12288, 12288, 128, 1)),
+        # Compact [1, T, H, D] at the compact-pitch boundary.
+        "compact_q": ((1, 524288, 32, 128), (524288 * 4096, 4096, 128, 1)),
+        # Compact chunk state [1, NT, H, K, V] at 4096 chunks.
+        "state": ((1, 4096, 32, 128, 128), (4096 * 524288, 524288, 16384, 128, 1)),
+    }
+    for name, (shape, stride) in cases.items():
+        tensor = torch.empty(shape, device="meta").as_strided(shape, stride)
+        assert requires_int64_abi(tensor), name
+
+    small = torch.empty_strided((1, 128, 32, 128), (128 * 4096, 4096, 128, 1))
+    assert not requires_int64_abi(small, None)
+
+
+@pytest.mark.skipif(not CUTE_CAPABLE, reason="the CuTe KDA kernels require capability 10.x")
+def test_forced_int64_chunk_kda_matches_default_path(monkeypatch):
+    """Force the i64 specializations on small inputs and match the i32 pipeline."""
+    import attn_gym.linear.kda.bwd.cute.chunk_delta_h_bwd_v1 as delta_module
+    import attn_gym.linear.kda.bwd.cute.chunk_kda_bwd_intra as intra_module
+    import attn_gym.linear.kda.bwd.cute.chunk_kda_bwd_wy_dqkg_fused as wy_module
+    import attn_gym.linear.kda.bwd.cute.gate_bwd_fused as gate_module
+    import attn_gym.linear.kda.fwd.cute.chunk_kda_fwd_inter_solve as inter_module
+    from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd import chunk_kda
+
+    def run():
+        torch.manual_seed(13)
+        tokens, heads = 192, 2
+        q, k, v = (
+            (
+                torch.randn(1, tokens, heads, 128, device="cuda", dtype=torch.bfloat16) / 8
+            ).requires_grad_()
+            for _ in range(3)
+        )
+        gate = (-torch.rand(1, tokens, heads, 128, device="cuda")).requires_grad_()
+        beta = torch.rand(1, tokens, heads, device="cuda").requires_grad_()
+        offsets = torch.tensor([0, 65, 192], device="cuda", dtype=torch.int32)
+        output, _ = chunk_kda(q, k, v, gate, beta, cu_seqlens=offsets)
+        grads = torch.autograd.grad(output.float().square().sum(), (q, k, v, gate, beta))
+        return (output, *grads)
+
+    baseline = run()
+    for module in (delta_module, intra_module, wy_module, gate_module, inter_module):
+        monkeypatch.setattr(module, "requires_int64_abi", lambda *tensors: True)
+    forced = run()
+    for name, expected, actual in zip(
+        ("output", "dq", "dk", "dv", "dgate", "dbeta"), baseline, forced, strict=True
+    ):
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0, msg=lambda m, n=name: n)
+
+
+@pytest.mark.skipif(
+    not CUTE_CAPABLE or torch.cuda.get_device_properties(0).total_memory < 100 * 1024**3,
+    reason="the over-capture regression allocates ~60GB of capacity buffers",
+)
+def test_chunk_kda_262144_token_packed_capacity_matches_exact():
+    """Run the full core at the first int64-requiring capacity with packed pitch."""
+    from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd import chunk_kda
+
+    heads, dim, active = 32, 128, 8192
+
+    def run(capacity):
+        torch.manual_seed(11)
+        qkv = torch.full(
+            (1, capacity, 3, heads, dim), float("nan"), device="cuda", dtype=torch.bfloat16
+        )
+        qkv[:, :active] = (
+            torch.randn(1, active, 3, heads, dim, device="cuda", dtype=torch.bfloat16) / 8
+        )
+        q, k, v = (qkv[:, :, i].requires_grad_() for i in range(3))
+        gate = torch.full((1, capacity, heads, dim), float("nan"), device="cuda")
+        gate[:, :active] = -torch.rand(1, active, heads, dim, device="cuda")
+        gate = gate.requires_grad_()
+        beta = torch.full((1, capacity, heads), float("nan"), device="cuda")
+        beta[:, :active] = torch.rand(1, active, heads, device="cuda")
+        beta = beta.requires_grad_()
+        grad = torch.zeros(1, capacity, heads, dim, device="cuda")
+        grad[:, :active] = torch.randn(1, active, heads, dim, device="cuda") / 8
+
+        offsets = torch.tensor([0, active], device="cuda", dtype=torch.int32)
+        out, _ = chunk_kda(q, k, v, gate, beta, cu_seqlens=offsets, persistent=True)
+        loss = (out[:, :active].float() * grad[:, :active]).sum()
+        grads = torch.autograd.grad(loss, (q, k, v, gate, beta))
+        return (out[:, :active].clone(), *(g[:, :active].clone() for g in grads))
+
+    small = run(active)
+    torch.cuda.empty_cache()
+    large = run(262144)
+    for name, expected, actual in zip(
+        ("output", "dq", "dk", "dv", "dgate", "dbeta"), small, large, strict=True
+    ):
+        assert not actual.isnan().any(), name
+        torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2, msg=lambda m, n=name: n)

--- a/test/test_kda_ragged_gate.py
+++ b/test/test_kda_ragged_gate.py
@@ -8,6 +8,8 @@
 
 from __future__ import annotations
 
+import importlib
+
 import pytest
 import torch
 from torch._inductor import config as inductor_config
@@ -337,3 +339,29 @@ def test_bounded_gate_cumsum_rejects_packed_batch_and_fastmath():
             cu_seqlens=cumulative_sequence_offsets([64]),
             fastmath=True,
         )
+
+
+def test_kda_gate_bwd_offset_width_specializations_match(monkeypatch):
+    """Keep the normal int32 and forced int64 gate-backward paths equivalent."""
+    module = importlib.import_module("attn_gym.linear.kda.bwd.triton.gate_bwd")
+    raw_gate, A_log, dt_bias, d_cumulative = _inputs(64, head_dim=96)
+    metadata = prepare_ragged_chunk_metadata(cumulative_sequence_offsets([33, 31]), 64, 64)
+
+    def run():
+        return module.kda_gate_bwd_ragged(
+            raw_gate,
+            A_log,
+            dt_bias,
+            d_cumulative,
+            metadata,
+            lower_bound=LOWER_BOUND,
+            scale=RCP_LN2,
+        )
+
+    monkeypatch.setattr(module, "requires_int64_offsets", lambda *_tensors: False)
+    outputs32 = run()
+    monkeypatch.setattr(module, "requires_int64_offsets", lambda *_tensors: True)
+    outputs64 = run()
+
+    for output64, output32 in zip(outputs64, outputs32, strict=True):
+        torch.testing.assert_close(output64, output32, rtol=0, atol=0)


### PR DESCRIPTION
## Summary

- select keyed int32 or int64 offset variants for CuTeDSL KDA forward and backward kernels based on reachable storage extent and declared ABI strides
- add the missing int64 offset specializations to Triton gate backward and W/U recomputation
- widen manual WY store-offset arithmetic before multiplication so large packed pitches cannot overflow in int32
- preserve the default int32 path for ordinary layouts
- add regressions for forced-int64 equivalence, singleton ABI strides, and a fully active 262,144-token packed layout that executes offsets beyond signed int32

This fixes large packed KDA layouts where a valid tensor ABI or relative storage offset exceeds the signed int32 range. In particular, the CuTe TVM-FFI ABI must still represent an oversized stride on a size-one dimension even when that stride is not reachable through the logical tensor shape.

## Validation

- full suite on GB300 with nightly Torch and CuTeDSL: `728 passed, 68 skipped`
- `git diff --check`
- fully active 262,144-token packed-pitch result matches the compact layout bitwise
- forced int64 forward/backward paths match the default path on small inputs

## Performance

The normal int32 specialization remains the default and showed no measurable regression in the focused benchmark (~950.1 µs before versus ~944–945 µs after). Forcing int64 measured ~985 µs (~4.3% slower); that cost is only selected for layouts that exceed the int32 range.
