### PR TITLE
Make the KDA forward intra-chunk gate reference causal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,10 +49,19 @@ python attn_gym/masks/causal.py
 ## Development
 
 ```bash
-pytest                          # run tests
+pytest -n 6                     # run tests in parallel (strongly preferred)
+pytest -n 6 test/test_kda.py    # one file, same parallelism
+pytest test/test_kda.py::test_x # single test; -n adds only overhead here
 ruff check && ruff format       # lint + format
 prek                            # full pre-commit suite
 ```
+
+Use `pytest -n 6` (pytest-xdist, already in `[tests]`) for anything wider than a single
+test. Much of the suite is CuTeDSL and `torch.compile` work that is CPU-bound during
+compilation, so a serial run leaves the machine idle and takes minutes where a parallel one
+takes tens of seconds. The workers share one GPU, so raise the count only if the GPU has
+headroom, and drop back to `-n 0` when a failure needs a clean serial repro or readable
+output.
 
 ### Docs
 

--- a/attn_gym/linear/kda/fwd/triton/chunk_kda_fwd_intra_sub_chunk_forloop.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_kda_fwd_intra_sub_chunk_forloop.py
@@ -154,26 +154,12 @@ def chunk_kda_fwd_kernel_intra_sub_chunk_forloop(
                     other=0.0,
                 )
 
-                # the kda gate is applied as a decay between 2 positions i, j
-                # and cumulative log gate is  2^{g[i] − g[j]}
-                # but you can do 2^{g[i]−g[j]}  =  2^{g[i]} * 2^{−g[j]} and this
-                # turns it into a matmul
-                # but then now you have g[i] and g[j] so what if they're really big
-                # and overflow?
-                # so the trick is you pick a rebase index and you do g[i] - rebase and
-                # rebase - g[j] so you always are within bounds because the number is
-                # smaller and also mathematically it cancels out
-                # when CAUSAL_NORMREF = True, we pick g[0] and when its False we pick
-                # the midpoint
-                # but the concern w/ the midpoint is that it breaks causality by whatever
-                # the rounding error is and also no BI because the midpoint changes
-                # so we are setting CAUSAL_NORMREF = True as default for now
-                # the only concern with doing topmost is what if the numbers are actually
-                # really big (but does this happen in practice? we will see)
-                if CAUSAL_NORMREF:
-                    normref_idx = 0
-                else:
-                    normref_idx = min(BC // 2, T_local - i_ti - 1)
+                # The gate decay between positions i and j is 2^{g[i] - g[j]}. Splitting it
+                # as 2^{g[i]-ref} * 2^{ref-g[j]} turns the decay into a matmul, and the
+                # reference cancels in exact arithmetic. It does not cancel in floating
+                # point: the two factors round separately, so the reference row is part of
+                # the numerics. See NOTE [Causal gate reference].
+                normref_idx = 0 if CAUSAL_NORMREF else min(BC // 2, T_local - i_ti - 1)
                 if USE_GATHER:
                     b_gn = gather(b_g, tl.full([1, BK], normref_idx, dtype=tl.int16), axis=0)
                 else:
@@ -229,6 +215,29 @@ def chunk_kda_fwd_kernel_intra_sub_chunk_forloop(
                 tl.store(p_Akk, b_Ai.to(Akk.dtype.element_ty), mask=m_Akk_store)
 
 
+# NOTE [Causal gate reference]
+# The intra-chunk rebase splits 2^{g_i - g_j} into two separately rounded factors, so the
+# reference row chosen for a BC-row subchunk changes results at the rounding level. Two
+# choices are available:
+#
+#   causal (row 0)   never in the future for any query in the subchunk, so a change to a
+#                    later token cannot perturb an earlier result. Spans BC-1 = 15 steps.
+#   midpoint         halves the span to BC/2 = 8 steps, buying exponent headroom, but the
+#                    reference itself moves when future tokens change, so causal-prefix
+#                    outputs drift at the rounding level.
+#
+# Measured on GB300 (agent_space/probe_normref_*.py): both choices land at 1.14x the
+# irreducible BF16 output-rounding floor, identical to five significant figures, so the
+# midpoint buys no accuracy. Its only advantage is range. The span sets a hard ceiling on
+# the supported gate, because the operands must stay inside the FP32 exponent range:
+#
+#   |lower_bound|_max = 128 / (span_steps * log2(e))
+#       causal   128 / (15 * log2 e) = 5.915
+#       midpoint 128 / ( 8 * log2 e) = 11.09
+#
+# Predicted and measured boundaries agree to three decimals. The default lower_bound of -5
+# needs 7.213 log2/token against the causal ceiling of 8.533, clearing it by 18%. The
+# public gate validates that ceiling; see GATE_SPAN_STEPS in gate_fwd.py.
 def chunk_kda_fwd_intra_diagonal(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -289,7 +298,7 @@ def chunk_kda_fwd_intra_diagonal(
         BK=triton.next_power_of_2(key_dim),
         num_sequences=0 if metadata is None else metadata.cu_seqlens.shape[0] - 1,
         USE_GATHER=IS_GATHER_SUPPORTED,
-        CAUSAL_NORMREF=False,
+        CAUSAL_NORMREF=True,
         GRID_NT=grid_chunks,
         MAX_NT=capacity,
     )

--- a/attn_gym/linear/kda/fwd/triton/chunk_kda_fwd_intra_sub_chunk_forloop.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_kda_fwd_intra_sub_chunk_forloop.py
@@ -216,28 +216,19 @@ def chunk_kda_fwd_kernel_intra_sub_chunk_forloop(
 
 
 # NOTE [Causal gate reference]
-# The intra-chunk rebase splits 2^{g_i - g_j} into two separately rounded factors, so the
-# reference row chosen for a BC-row subchunk changes results at the rounding level. Two
-# choices are available:
+# The rebase evaluates 2^{g_i - g_j} as 2^{g_i - g_r} * 2^{g_r - g_j}. The factors round
+# separately, so the reference row r affects floating-point results. Choosing row 0 keeps
+# the reference at or before every query; a midpoint reference reduces the exponent span
+# but makes early outputs depend on a future gate through rounding.
 #
-#   causal (row 0)   never in the future for any query in the subchunk, so a change to a
-#                    later token cannot perturb an earlier result. Spans BC-1 = 15 steps.
-#   midpoint         halves the span to BC/2 = 8 steps, buying exponent headroom, but the
-#                    reference itself moves when future tokens change, so causal-prefix
-#                    outputs drift at the rounding level.
+# A gate contributes at most |lower_bound| * log2(e) per token interval, so keeping the
+# factors within the FP32 exponent range requires
 #
-# Measured on GB300 (agent_space/probe_normref_*.py): both choices land at 1.14x the
-# irreducible BF16 output-rounding floor, identical to five significant figures, so the
-# midpoint buys no accuracy. Its only advantage is range. The span sets a hard ceiling on
-# the supported gate, because the operands must stay inside the FP32 exponent range:
+#     |lower_bound| <= 128 / (span_steps * log2(e)).
 #
-#   |lower_bound|_max = 128 / (span_steps * log2(e))
-#       causal   128 / (15 * log2 e) = 5.915
-#       midpoint 128 / ( 8 * log2 e) = 11.09
-#
-# Predicted and measured boundaries agree to three decimals. The default lower_bound of -5
-# needs 7.213 log2/token against the causal ceiling of 8.533, clearing it by 18%. The
-# public gate validates that ceiling; see GATE_SPAN_STEPS in gate_fwd.py.
+# For BC=16, row 0 spans 15 intervals and gives a 5.915 limit; the 8-interval midpoint
+# would give 11.09. The public gate enforces the causal bound; see GATE_SPAN_STEPS in
+# gate_fwd.py.
 def chunk_kda_fwd_intra_diagonal(
     q: torch.Tensor,
     k: torch.Tensor,

--- a/attn_gym/linear/kda/fwd/triton/gate_fwd.py
+++ b/attn_gym/linear/kda/fwd/triton/gate_fwd.py
@@ -12,6 +12,7 @@
 
 from __future__ import annotations
 
+import math
 from contextlib import nullcontext
 
 import torch
@@ -490,6 +491,25 @@ class _BoundedGateCumsum(torch.autograd.Function):
         )
 
 
+# NOTE [Gate range ceiling]
+# The intra-chunk rebase splits 2^{g_i - g_j} into two separately rounded factors whose
+# operands must stay inside the FP32 exponent range. Because the gate map is
+# `lower_bound * sigmoid(...)` and sigmoid is in (0, 1), per-token log2 decay is hard
+# bounded by |lower_bound| * log2(e) independently of the data, so the worst case over a
+# subchunk is a closed form rather than something that must be measured:
+#
+#     |lower_bound|_max = 2^EXPONENT_BITS_LIMIT / (span_steps * log2(e))
+#
+# The causal reference spans BC-1 = 15 steps, giving 5.915. A saturated-gate bisection on
+# GB300 measured the boundary at 5.915, matching to three decimals. Only the *realized*
+# span is data dependent, which is why random gates underestimate the ceiling; the bound
+# above is sound for any input. Without this check the core returns NaNs with no error.
+# See NOTE [Causal gate reference] in the diagonal forward kernel.
+GATE_SPAN_STEPS = 15
+FP32_EXPONENT_BUDGET = 128.0
+MAX_GATE_LOWER_BOUND_MAGNITUDE = FP32_EXPONENT_BUDGET / (GATE_SPAN_STEPS * math.log2(math.e))
+
+
 def _bounded_gate_cumsum(
     raw_gate: torch.Tensor,
     A_log: torch.Tensor,
@@ -530,6 +550,16 @@ def _bounded_gate_cumsum(
         )
     if chunk_size <= 0 or chunk_size & (chunk_size - 1):
         raise ValueError(f"chunk_size must be a positive power of two, got {chunk_size}")
+    if not math.isfinite(lower_bound) or lower_bound > 0:
+        raise ValueError(f"lower_bound must be finite and non-positive, got {lower_bound}")
+    if -lower_bound > MAX_GATE_LOWER_BOUND_MAGNITUDE:
+        raise ValueError(
+            f"lower_bound must be >= {-MAX_GATE_LOWER_BOUND_MAGNITUDE:.3f} for the KDA "
+            f"intra-chunk gate rebase, got {lower_bound}. Beyond that the per-token decay "
+            f"can exceed the FP32 exponent budget over a {GATE_SPAN_STEPS + 1}-row subchunk "
+            "and the core silently produces non-finite values. "
+            "See NOTE [Gate range ceiling]."
+        )
     if not all(tensor.device == raw_gate.device for tensor in (A_log, dt_bias)):
         raise ValueError("bounded_gate_cumsum inputs must be on the same device")
     if cu_seqlens is not None:

--- a/attn_gym/linear/kda/fwd/triton/gate_fwd.py
+++ b/attn_gym/linear/kda/fwd/triton/gate_fwd.py
@@ -557,9 +557,10 @@ def _bounded_gate_cumsum(
         raise ValueError(
             f"lower_bound must lie in "
             f"[{-MAX_GATE_LOWER_BOUND_MAGNITUDE:.3f}, 0] for the KDA intra-chunk gate "
-            f"rebase, got {lower_bound}. Below that bound the per-token decay can exceed "
-            f"the FP32 exponent budget over a {GATE_SPAN_STEPS + 1}-row subchunk and the "
-            "core silently produces non-finite values. See NOTE [Gate range ceiling]."
+            f"rebase, got {lower_bound}. Past the lower end the per-token decay can "
+            f"exceed the FP32 exponent budget over a {GATE_SPAN_STEPS + 1}-row subchunk, "
+            "and the core silently produces non-finite values. "
+            "See NOTE [Gate range ceiling]."
         )
     if not all(tensor.device == raw_gate.device for tensor in (A_log, dt_bias)):
         raise ValueError("bounded_gate_cumsum inputs must be on the same device")

--- a/attn_gym/linear/kda/fwd/triton/gate_fwd.py
+++ b/attn_gym/linear/kda/fwd/triton/gate_fwd.py
@@ -550,15 +550,16 @@ def _bounded_gate_cumsum(
         )
     if chunk_size <= 0 or chunk_size & (chunk_size - 1):
         raise ValueError(f"chunk_size must be a positive power of two, got {chunk_size}")
-    if not math.isfinite(lower_bound) or lower_bound > 0:
-        raise ValueError(f"lower_bound must be finite and non-positive, got {lower_bound}")
-    if -lower_bound > MAX_GATE_LOWER_BOUND_MAGNITUDE:
+    # Plain comparisons only: `math.isfinite` on a traced float lifts it into a graph
+    # operation, which breaks strict dynamic compilation. A chained comparison rejects
+    # NaN and both infinities without calling into `math`.
+    if not -MAX_GATE_LOWER_BOUND_MAGNITUDE <= lower_bound <= 0.0:
         raise ValueError(
-            f"lower_bound must be >= {-MAX_GATE_LOWER_BOUND_MAGNITUDE:.3f} for the KDA "
-            f"intra-chunk gate rebase, got {lower_bound}. Beyond that the per-token decay "
-            f"can exceed the FP32 exponent budget over a {GATE_SPAN_STEPS + 1}-row subchunk "
-            "and the core silently produces non-finite values. "
-            "See NOTE [Gate range ceiling]."
+            f"lower_bound must lie in "
+            f"[{-MAX_GATE_LOWER_BOUND_MAGNITUDE:.3f}, 0] for the KDA intra-chunk gate "
+            f"rebase, got {lower_bound}. Below that bound the per-token decay can exceed "
+            f"the FP32 exponent budget over a {GATE_SPAN_STEPS + 1}-row subchunk and the "
+            "core silently produces non-finite values. See NOTE [Gate range ceiling]."
         )
     if not all(tensor.device == raw_gate.device for tensor in (A_log, dt_bias)):
         raise ValueError("bounded_gate_cumsum inputs must be on the same device")

--- a/attn_gym/linear/kda/fwd/triton/gate_fwd.py
+++ b/attn_gym/linear/kda/fwd/triton/gate_fwd.py
@@ -492,19 +492,15 @@ class _BoundedGateCumsum(torch.autograd.Function):
 
 
 # NOTE [Gate range ceiling]
-# The intra-chunk rebase splits 2^{g_i - g_j} into two separately rounded factors whose
-# operands must stay inside the FP32 exponent range. Because the gate map is
-# `lower_bound * sigmoid(...)` and sigmoid is in (0, 1), per-token log2 decay is hard
-# bounded by |lower_bound| * log2(e) independently of the data, so the worst case over a
-# subchunk is a closed form rather than something that must be measured:
+# The bounded gate lies in [lower_bound, 0], so one token contributes at most
+# |lower_bound| * log2(e) after conversion to log2 units. Across `span_steps`, the rebase
+# therefore needs this exponent budget:
 #
-#     |lower_bound|_max = 2^EXPONENT_BITS_LIMIT / (span_steps * log2(e))
+#     |lower_bound| * span_steps * log2(e) <= 128
 #
-# The causal reference spans BC-1 = 15 steps, giving 5.915. A saturated-gate bisection on
-# GB300 measured the boundary at 5.915, matching to three decimals. Only the *realized*
-# span is data dependent, which is why random gates underestimate the ceiling; the bound
-# above is sound for any input. Without this check the core returns NaNs with no error.
-# See NOTE [Causal gate reference] in the diagonal forward kernel.
+# The causal reference spans BC-1 = 15 steps, giving a data-independent 5.915 limit.
+# Validate it here because an overflowing rebase factor can otherwise produce non-finite
+# core outputs. See NOTE [Causal gate reference] in the diagonal forward kernel.
 GATE_SPAN_STEPS = 15
 FP32_EXPONENT_BUDGET = 128.0
 MAX_GATE_LOWER_BOUND_MAGNITUDE = FP32_EXPONENT_BUDGET / (GATE_SPAN_STEPS * math.log2(math.e))

--- a/test/test_kda_compile_dynamic_shapes.py
+++ b/test/test_kda_compile_dynamic_shapes.py
@@ -60,18 +60,23 @@ def test_compiled_gate_accepts_varying_head_geometry():
 
 
 def test_compiled_gate_backward_survives_varying_lower_bound():
-    """Varying the lower_bound float must keep backward compiling with eager parity."""
+    """Varying the lower_bound float must keep backward compiling with eager parity.
+
+    The values only need to be distinct so Dynamo stops specializing on the float; they
+    were -10.0 and -5.0 until the causal gate reference capped the supported range at
+    about -5.915. See NOTE [Gate range ceiling].
+    """
     raw, a_log, dt_bias = _gate_inputs()
     compiled = torch.compile(bounded_gate_cumsum, fullgraph=True, dynamic=True)
-    for lower_bound in (-10.0, -5.0):
+    for lower_bound in (-5.0, -3.25):
         expected = bounded_gate_cumsum(raw, a_log, dt_bias, lower_bound=lower_bound)
         output = compiled(raw, a_log, dt_bias, lower_bound=lower_bound)
         torch.testing.assert_close(output, expected)
 
     expected_inputs = tuple(tensor.detach().requires_grad_() for tensor in (raw, a_log, dt_bias))
     actual_inputs = tuple(tensor.detach().clone().requires_grad_() for tensor in expected_inputs)
-    expected = bounded_gate_cumsum(*expected_inputs, lower_bound=-10.0)
-    actual = compiled(*actual_inputs, lower_bound=-10.0)
+    expected = bounded_gate_cumsum(*expected_inputs, lower_bound=-5.0)
+    actual = compiled(*actual_inputs, lower_bound=-5.0)
     torch.testing.assert_close(actual, expected, rtol=0, atol=0)
 
     cotangent = torch.randn_like(expected)

--- a/test/test_kda_cute_forward.py
+++ b/test/test_kda_cute_forward.py
@@ -899,6 +899,46 @@ def test_chunk_kda_packed_cuda_graph_replays_boundaries_and_backward():
         torch.testing.assert_close(actual_gradient, expected_gradient)
 
 
+@pytest.mark.parametrize("cut", [5, 8, 37])
+def test_chunk_kda_forward_prefix_ignores_future_tokens(cut):
+    """Perturbing only future tokens must leave causal-prefix output bitwise unchanged.
+
+    The intra-chunk rebase splits ``2^{g_i - g_j}`` into two separately rounded factors,
+    so a reference row drawn from the future lets a later token perturb an earlier
+    result even though the reference cancels in exact arithmetic. The cuts land inside a
+    16-row subchunk, where a midpoint reference moves as the suffix changes. See
+    NOTE [Causal gate reference].
+    """
+    torch.manual_seed(11)
+    tokens, heads = 128, 2
+    shape = (1, tokens, heads, 128)
+    query = F.normalize(torch.randn(shape, device="cuda"), dim=-1).to(torch.bfloat16)
+    key = F.normalize(torch.randn(shape, device="cuda"), dim=-1).to(torch.bfloat16)
+    value = torch.randn(shape, device="cuda", dtype=torch.bfloat16)
+    beta = torch.rand(1, tokens, heads, device="cuda")
+    increments = -torch.rand(shape, device="cuda")
+
+    def forward(tensors, gate_increments):
+        """Run the public core from per-token gate increments."""
+        output, _ = chunk_kda(*tensors, chunk_cumsum_ref(gate_increments, 64), beta)
+        return output
+
+    baseline = forward((query, key, value), increments)
+
+    # Rebuild the suffix of every operand, including the gate the reference is drawn from.
+    variant = [tensor.clone() for tensor in (query, key, value)]
+    for tensor in variant:
+        tensor[:, cut:] = torch.randn_like(tensor[:, cut:])
+    variant_increments = increments.clone()
+    variant_increments[:, cut:] = -torch.rand_like(variant_increments[:, cut:])
+    perturbed = forward(tuple(variant), variant_increments)
+
+    assert not torch.equal(baseline[:, cut:], perturbed[:, cut:]), (
+        "the suffix perturbation did not take effect, so the test proves nothing"
+    )
+    torch.testing.assert_close(perturbed[:, :cut], baseline[:, :cut], rtol=0, atol=0)
+
+
 def test_chunk_kda_validates_public_contract():
     """Reject malformed inputs at the opaque boundary before a kernel launch."""
     q, k, v, cumulative_gate, beta = (tensor.detach() for tensor in _inputs())

--- a/test/test_kda_fused_gate_bwd.py
+++ b/test/test_kda_fused_gate_bwd.py
@@ -198,13 +198,19 @@ def test_bounded_gate_cumsum_rejects_gate_range_beyond_rebase_budget():
     bounded_gate_cumsum(raw_gate, A_log, dt_bias, lower_bound=-5.0)
     bounded_gate_cumsum(raw_gate, A_log, dt_bias, lower_bound=-(ceiling - 1e-3))
 
-    for rejected in (-(ceiling + 1e-3), -16.0, -32.0):
-        with pytest.raises(ValueError, match="intra-chunk gate rebase"):
+    # One chained comparison covers every rejection reason, so they share a message:
+    # past the ceiling, non-finite, and positive.
+    rejected_values = (
+        -(ceiling + 1e-3),
+        -16.0,
+        -32.0,
+        float("nan"),
+        float("-inf"),
+        1.0,
+    )
+    for rejected in rejected_values:
+        with pytest.raises(ValueError, match="lower_bound must lie in"):
             bounded_gate_cumsum(raw_gate, A_log, dt_bias, lower_bound=rejected)
-    with pytest.raises(ValueError, match="finite and non-positive"):
-        bounded_gate_cumsum(raw_gate, A_log, dt_bias, lower_bound=float("nan"))
-    with pytest.raises(ValueError, match="finite and non-positive"):
-        bounded_gate_cumsum(raw_gate, A_log, dt_bias, lower_bound=1.0)
 
 
 @pytest.mark.parametrize(

--- a/test/test_kda_fused_gate_bwd.py
+++ b/test/test_kda_fused_gate_bwd.py
@@ -24,7 +24,10 @@ from attn_gym.linear.kda.bwd.cute.gate_bwd_fused import (
     _fused_gate_bwd_op,
     fused_gate_bwd,
 )
-from attn_gym.linear.kda.fwd.triton.gate_fwd import bounded_gate_cumsum
+from attn_gym.linear.kda.fwd.triton.gate_fwd import (
+    MAX_GATE_LOWER_BOUND_MAGNITUDE,
+    bounded_gate_cumsum,
+)
 from attn_gym.linear.kda.naive import fused_gate_bwd_ref
 
 TMA_AVAILABLE = torch.cuda.is_available() and torch.cuda.get_device_capability() >= (9, 0)
@@ -177,6 +180,31 @@ def test_fused_gate_bwd_reference_matches_forward_autograd(chunk_size):
     torch.testing.assert_close(actual[0], expected[0])
     torch.testing.assert_close(actual[1], expected[1], rtol=2e-5, atol=3e-5)
     torch.testing.assert_close(actual[2], expected[2], rtol=2e-5, atol=3e-5)
+
+
+def test_bounded_gate_cumsum_rejects_gate_range_beyond_rebase_budget():
+    """Reject decay the intra-chunk rebase cannot represent instead of returning NaNs.
+
+    Past the ceiling the core silently produced non-finite output, so the boundary has to
+    fail fast. The ceiling is derived from the subchunk span and the FP32 exponent range;
+    see NOTE [Gate range ceiling].
+    """
+    raw_gate = torch.zeros(1, 64, 2, 128, dtype=torch.bfloat16, device="cuda")
+    A_log = torch.zeros(2, dtype=torch.float32, device="cuda")
+    dt_bias = torch.zeros(2, 128, dtype=torch.float32, device="cuda")
+    ceiling = MAX_GATE_LOWER_BOUND_MAGNITUDE
+
+    # The shipped default must stay comfortably inside the supported range.
+    bounded_gate_cumsum(raw_gate, A_log, dt_bias, lower_bound=-5.0)
+    bounded_gate_cumsum(raw_gate, A_log, dt_bias, lower_bound=-(ceiling - 1e-3))
+
+    for rejected in (-(ceiling + 1e-3), -16.0, -32.0):
+        with pytest.raises(ValueError, match="intra-chunk gate rebase"):
+            bounded_gate_cumsum(raw_gate, A_log, dt_bias, lower_bound=rejected)
+    with pytest.raises(ValueError, match="finite and non-positive"):
+        bounded_gate_cumsum(raw_gate, A_log, dt_bias, lower_bound=float("nan"))
+    with pytest.raises(ValueError, match="finite and non-positive"):
+        bounded_gate_cumsum(raw_gate, A_log, dt_bias, lower_bound=1.0)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Human Note

## Agent note

A fuzz campaign found that `chunk_kda` is not numerically causal: perturbing only future
tokens changes causal-prefix outputs. The intra-chunk rebase splits `2^{g_i - g_j}` into
`2^{g_i-ref} * 2^{ref-g_j}` so the decay becomes a matmul. The reference cancels in exact
arithmetic but not in floating point, and the diagonal stage launched with
`CAUSAL_NORMREF=False`, drawing that reference from the subchunk midpoint -- a row that
moves when the suffix changes. The kernel's own default and comment already said `True`;
only the launch site disagreed.

Measured on GB300 across three seeds, the midpoint buys no accuracy. Both references land
at 1.14x the irreducible BF16 output-rounding floor, identical to five significant
figures. Its only advantage is exponent range, because the span sets a hard ceiling:

```text
|lower_bound|_max = 128 / (span_steps * log2 e)
    causal   (15 steps) = 5.915
    midpoint ( 8 steps) = 11.09
```

A saturated-gate bisection measured both boundaries at 5.915 and 11.090, matching the
closed form to three decimals. The bound is sound rather than empirical: the gate map is
`lower_bound * sigmoid(...)`, so per-token decay is hard bounded by `|lower_bound| * log2 e`
regardless of data; only the realized span is data dependent, which is why random gates
underestimate it and a saturated gate is required to calibrate.

So this trades range for exactness. The default `lower_bound=-5` needs 7.213 log2/token
against the causal ceiling of 8.533, clearing it by 18%.

That ceiling has to be enforced, because past it the core silently returned NaNs with no
error. `bounded_gate_cumsum` accepted any finite non-positive `lower_bound`, the gate itself
stayed finite, and `chunk_kda` then emitted NaNs:

| lower_bound | gate finite | output finite | non-finite output |
| --- | --- | --- | --- |
| -1 / -5 / -8 / -10 | yes | yes | 0% |
| -16 | yes | **no** | 2.34% |
| -32 | yes | **no** | 100% |

The gate now rejects out-of-range values with an actionable message, using a constant
derived from the subchunk span and the FP32 exponent range rather than a magic number, so
it stays correct if `BC` changes.

The midpoint path is not kept as an opt-in mode: accuracy is identical, no in-repo caller
needs range past the ceiling, and a switch whose real effect is to silently give back the
causality this change adds is a bad knob to offer. If a caller does need more range, the
answer is a pairwise diagonal that needs no reference at all, not restoring the midpoint.

### Scope

Forward only. The backward mirrors the forward's reference by design and still uses
midpoint and future rows, so gradients remain non-invariant (`dq` ~1.5e-05, `dk` ~1.5e-05,
`dgate` ~4.8e-07). That change lands separately; it is more delicate because one of its
three references is used where the subchunk supplies keys and the queries are genuinely in
the future.

## Test Plan

```bash
pytest test/test_kda_cute_forward.py test/test_kda_ragged_intra_diagonal.py \
       test/test_kda_kernels.py test/test_kda_ragged_gate.py \
       test/test_kda_fused_gate_bwd.py
```

130 existing tests pass. Two new tests were verified to fail on the unfixed kernel and pass
after:

- `test_chunk_kda_forward_prefix_ignores_future_tokens` (cuts 5, 8, 37 -- all inside a
  16-row subchunk, where the midpoint reference moves); fails on all three cuts before.
- `test_bounded_gate_cumsum_rejects_gate_range_beyond_rebase_budget`.

End-to-end, forward prefix drift on seeds that previously drifted went to exactly 0, and
the full-capacity forward is now bitwise identical to the exact-prefix lowering.

Measured on GB300, torch `2.15.0.dev20260818+cu132`. All figures were re-baselined on 2.15
after first being taken on 2.14; ceiling, accuracy ratio, and drift reproduce identically.
