### PR TITLE
Document gated delta rule semantics

### DIFF
--- a/attn_gym/linear/gdn/api.py
+++ b/attn_gym/linear/gdn/api.py
@@ -37,7 +37,17 @@ def gated_delta_rule(
     """Apply gated delta rule attention.
 
     Inputs use the SDPA layout ``[batch, heads, sequence, dimension]``. The recurrent state has
-    shape ``[batch, heads, key_dimension, value_dimension]``.
+    shape ``[batch, heads, key_dimension, value_dimension]``. For each token, the scalar natural-log
+    gate first decays the previous state, then the beta-scaled delta rule updates it, and the query
+    reads the updated state:
+
+    ``decayed_state = exp(gate) * state``
+
+    ``residual = beta * (value - key @ decayed_state)``
+
+    ``state = decayed_state + outer(key, residual)``
+
+    ``output = scale * query @ state``
 
     Args:
         query: Query tensor with shape ``[B, H, T, K]``.

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -4,7 +4,19 @@ Attention Gym provides functional linear-attention operators with eager referenc
 
 ## Gated Delta Rule
 
-`gated_delta_rule` uses the SDPA layout `[batch, heads, sequence, dimension]` and returns a structured result. Its eager backend supports recurrent execution for decoding and chunked execution for training or prefill.
+`gated_delta_rule` uses the SDPA layout `[batch, heads, sequence, dimension]` and returns a
+structured result. For each token, its scalar natural-log gate decays the previous state before the
+delta update, and the query reads the updated state:
+
+```text
+decayed_state = exp(gate) * state
+residual = beta * (value - key @ decayed_state)
+state = decayed_state + outer(key, residual)
+output = scale * query @ state
+```
+
+The eager reference includes recurrent and chunked formulations of this recurrence for correctness
+and state-carrying tests.
 
 ```python
 from attn_gym.linear import gated_delta_rule
@@ -23,8 +35,6 @@ result = gated_delta_rule(
 output = result.output
 final_state = result.final_state
 ```
-
-`mode="auto"` selects recurrent execution for a one-token sequence and chunked execution otherwise. `backend="auto"` currently selects the eager reference implementation.
 
 ### Supported capabilities
 


### PR DESCRIPTION
Document gated delta rule semantics

## Human Note

## Agent note

State the token recurrence in the public API and linear-attention documentation. Clarify that
execution mode changes the decomposition while backend selection changes only the implementation,
so future fused paths have an explicit backend-independent contract.

## Test Plan

```bash
.venv/bin/prek run --files attn_gym/linear/gdn/api.py docs/linear.md
.venv/bin/pytest test/linear/test_gdn.py -q
```