### PR TITLE
Cap ragged KDA output-kernel registers at the dense budget

### DIFF
--- a/attn_gym/linear/kda/fwd/triton/chunk_gla_fwd_o.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_gla_fwd_o.py
@@ -458,6 +458,10 @@ def chunk_gla_fwd_o_gk(
                 num_sequences=metadata.cu_seqlens.shape[0] - 1,
                 num_warps=2,
                 num_stages=3,
+                # The rarely taken partial-chunk pointer branch pushes this
+                # kernel to 180 registers vs the dense kernel's 134; cap at the
+                # dense budget so only tail CTAs pay with spills.
+                maxnreg=136,
             )
             return output
 


### PR DESCRIPTION
Stacked PRs:
 * #345
 * #344
 * __->__#343


--- --- ---

Cap ragged KDA output-kernel registers at the dense budget

## Human Note

## Agent note

The ragged output kernel carries a masked-pointer fallback branch for partial tail chunks in the
same kernel as the full-chunk TMA path. NCU shows that dead branch inflates the register budget
from the dense kernel's 134 to 180 per thread, cutting occupancy from 6 to 4 CTAs/SM for every CTA,
including the overwhelming majority that never take it. Capping the launch at the dense budget
restores dense-level occupancy; only the rare partial-chunk CTAs pay with local spills.

## Performance

GB300, h64 packed mixed [1300, 547, 2048, 963, 271, 3063], warm CUDA events: ragged o kernel
233.6us -> 197.7us (dense o at the same token count: 186.7us).

## Test Plan

```bash
pytest test/test_kda_ragged_output.py test/test_kda.py test/test_kda_kernels.py test/test_kda_cute_forward.py
```