### PR TITLE
Share linear attention implementation selector

### DIFF
--- a/attn_gym/linear/__init__.py
+++ b/attn_gym/linear/__init__.py
@@ -17,7 +17,7 @@ from attn_gym.linear.kda import (
     mask_inactive_tokens,
     recurrent_kda,
 )
-from attn_gym.linear.kda.api import Impl
+from attn_gym.linear.types import Impl
 
 # Note: Lazy Imports
 # Backend-backed names load on first use, keeping reference imports torch-only.

--- a/attn_gym/linear/kda/api.py
+++ b/attn_gym/linear/kda/api.py
@@ -12,7 +12,6 @@ inference prefill. Use ``impl`` to select fused kernels or the eager reference.
 
 from __future__ import annotations
 
-from enum import Enum
 from functools import partial
 
 import torch
@@ -22,19 +21,9 @@ from attn_gym.linear.kda.impl.reference import reference_kda
 from attn_gym.linear.kda.naive import naive_chunk_kda_from_cumulative, naive_recurrent_kda
 from attn_gym.linear.kda.ops import recurrent_forward as _fused_recurrent_forward
 from attn_gym.linear.kda.validation import validate_kda_inputs
+from attn_gym.linear.types import Impl
 
 _CHUNK_SIZE = 64
-
-
-class Impl(str, Enum):
-    """Select a fused or reference KDA implementation.
-
-    The public operations validate shared inputs; fused backends validate their
-    extra hardware and shape requirements. There is no automatic fallback.
-    """
-
-    FUSED = "fused"
-    REFERENCE = "reference"
 
 
 def _resolve_impl(impl: Impl | str) -> Impl:

--- a/attn_gym/linear/types.py
+++ b/attn_gym/linear/types.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Types shared by public linear-attention operations."""
+
+from enum import Enum
+
+
+class Impl(str, Enum):
+    """Select a fused or reference implementation without automatic fallback."""
+
+    FUSED = "fused"
+    REFERENCE = "reference"
+
+
+__all__ = ["Impl"]

--- a/test/test_namespaces.py
+++ b/test/test_namespaces.py
@@ -4,6 +4,9 @@ import sys
 import attn_gym
 import attn_gym.linear
 import attn_gym.sparse
+from attn_gym.linear import Impl
+from attn_gym.linear.kda.api import Impl as KDAImpl
+from attn_gym.linear.types import Impl as SharedImpl
 from attn_gym.masks import (
     batchify_mask_mod,
     generate_spatial_head_mask_mod,
@@ -19,6 +22,11 @@ def test_attention_namespaces_are_exported():
     assert "linear" in attn_gym.__all__
     assert "sparse" in attn_gym.__all__
     assert "paged_attention" not in attn_gym.__all__
+
+
+def test_linear_impl_uses_shared_owner():
+    assert Impl is SharedImpl
+    assert KDAImpl is SharedImpl
 
 
 def test_documented_mask_and_score_mods_are_exported():


### PR DESCRIPTION
Share linear attention implementation selector

## Human Note

## Agent note

Move the fused/reference implementation enum to the linear-attention namespace so KDA and future
GDN operations share one selector. Re-export the same enum through the existing top-level and KDA
API paths to preserve current imports and dispatch behavior.

## Test Plan

```bash
.venv/bin/prek run --files attn_gym/linear/types.py attn_gym/linear/kda/api.py attn_gym/linear/__init__.py test/test_namespaces.py
.venv/bin/pytest -n 6 test/test_namespaces.py test/test_kda_imports.py -q
gpu-run auto -- .venv/bin/pytest test/test_kda_impl_dispatch.py::test_impl_accepts_enum_and_string -q
```