### PR TITLE
Split gated delta rule execution APIs

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -94,15 +94,15 @@ add in this repo, land in pytorch core and then replace our implementations here
 
 ### Separate semantics from implementation
 
-An operation name identifies mathematical behavior. Execution form and kernel backend are
-orthogonal choices:
+An operation name identifies mathematical behavior and execution form; ``impl`` selects its
+implementation:
 
-- **Operation:** gated delta rule, GLA, NSA, and so on.
-- **Execution form:** chunked, recurrent, or automatic selection.
-- **Backend:** eager/reference, Triton, CuTeDSL, another Python DSL, FLA, or automatic selection.
+- **Operation:** chunked or recurrent gated delta rule, GLA, NSA, and so on.
+- **Implementation:** fused kernels or the eager reference.
 
-A backend must not silently change the operation's documented semantics. Numerically different but
-mathematically equivalent execution forms must have explicit tolerance and invariance contracts.
+An implementation must not silently change the operation's documented semantics. Numerically
+different but mathematically equivalent execution forms must have explicit tolerance and invariance
+contracts.
 I am tempted to require bit exactness once we establish a trusted implementation for tweaks or new
 imps but that is tbd.
 
@@ -114,23 +114,15 @@ normalizations to justify a single public function with a large parameter union.
 Prefer:
 
 ```python
-from attn_gym.linear import gated_delta_rule
+from attn_gym.linear import chunk_gdn
 
-result = gated_delta_rule(
-    query,
-    key,
-    value,
-    gate,
-    beta,
-    mode="chunked",
-    backend="auto",
-)
+result = chunk_gdn(query, key, value, gate, beta, impl="reference")
 ```
 
 Do not begin with:
 
 ```python
-linear_attention(kind="gated_delta_rule", ..., algorithm_options={...})
+linear_attention(kind="chunk_gdn", ..., algorithm_options={...})
 ```
 
 Shared types and dispatch behavior should be extracted only when multiple operators use them.
@@ -386,21 +378,19 @@ works only when its private launcher is invoked directly does not satisfy the co
 Public functions are re-exported from the namespace root:
 
 ```python
-from attn_gym.linear import gated_delta_rule
+from attn_gym.linear import chunk_gdn, recurrent_gdn
 from attn_gym.sparse import compressed_sparse_attention
 ```
 
 Backend entry points are private and use a consistent internal name such as `forward`. A backend
 may additionally provide a small private capability check when dispatch needs one. Users select an
-implementation through the public `backend=` argument rather than importing implementation modules
+implementation through the public `impl=` argument rather than importing implementation modules
 directly.
 
-The initial dispatch should remain explicit and local to `api.py`: map a documented backend name to
-one lazily imported implementation, validate that implementation's capabilities, and call it. Do
-not introduce registration side effects or a repository-wide priority registry until several
-operations demonstrate that the same mechanism would remove meaningful duplication. Automatic
-selection should use an inspectable ordered policy and report why explicitly requested backends are
-unsupported.
+The initial dispatch should remain explicit and local to `api.py`: resolve `impl`, validate the
+selected implementation's capabilities, and call it. Do not introduce registration side effects or
+a repository-wide priority registry until several operations demonstrate that the same mechanism
+would remove meaningful duplication. Explicit implementation requests never fall back silently.
 
 ### Applying the structure to compressed sparse attention
 
@@ -485,41 +475,26 @@ layout.
 
 ### Execution form
 
-The proposed public argument is:
-
-```python
-mode: Literal["auto", "chunked", "recurrent"] = "auto"
-```
-
-Each operation documents the modes it supports. Unsupported modes fail clearly rather than falling
-back to a semantically different path.
-
-The expected policy is:
-
-- `chunked` for training and long prefill;
-- `recurrent` for token-by-token decoding and a correctness-oriented batch-invariant path;
-- `auto` for a documented shape- and autograd-aware choice.
+Chunked and recurrent formulations are separate public operations. The caller chooses `chunk_*` for
+training and long prefill or `recurrent_*` for decoding, inference prefill, and a
+correctness-oriented batch-invariant path. There is no automatic execution-form switch inside one
+public function.
 
 An operation may expose an additional parallel formulation when it has one, but that is
 operation-specific rather than part of the common contract.
 
-Whether `auto` belongs in the first public release is still open. Explicit-only mode selection is
-simpler for reproducibility and compilation; automatic selection is easier for model authors.
+### Implementation selection
 
-### Backend selection
-
-The proposed public argument is:
+Linear operations use the shared selector:
 
 ```python
-backend: Literal["auto", "eager", "triton", "cute"] = "auto"
+impl: Impl | str
 ```
 
-Backend selection rules must be deterministic and inspectable. `auto` may consider device,
-architecture, dtype, shape, execution mode, autograd requirements, and installed dependencies. It
-must not hide an unsupported input by changing mathematical behavior.
-
-The initial implementation should use straightforward dispatch rather than a general capability
-solver. If backend selection grows complex, supported capabilities can later be represented as data.
+`Impl.FUSED` selects optimized kernels and `Impl.REFERENCE` selects the eager correctness oracle.
+Selection is deterministic and explicit. An unsupported implementation fails clearly rather than
+falling back or changing execution form. The initial implementation should use straightforward
+local dispatch rather than a general capability solver.
 
 ### Variable-length inputs
 
@@ -595,8 +570,8 @@ implementations may advertise a weaker numerical contract if the distinction is 
 The exact first contract remains open: bitwise equality versus tolerance-based equality, whether it
 covers gradients and final recurrent state, and which dtypes and hardware are guaranteed. We should
 settle those details using the first operation rather than prematurely adding a public
-`batch_invariant` flag. Batch invariance should not be inferred solely from
-`mode="recurrent"`.
+`batch_invariant` flag. Batch invariance should not be inferred solely from choosing the recurrent
+operation.
 
 ## Backend and dependency policy
 

--- a/attn_gym/linear/__init__.py
+++ b/attn_gym/linear/__init__.py
@@ -9,7 +9,7 @@
 import importlib
 from typing import TYPE_CHECKING
 
-from attn_gym.linear.gdn import GatedDeltaRuleOutput, gated_delta_rule
+from attn_gym.linear.gdn import GatedDeltaRuleOutput, chunk_gdn, recurrent_gdn
 from attn_gym.linear.kda import (
     active_token_mask,
     chunk_kda,
@@ -38,7 +38,8 @@ KDA_OPS = [
 
 GDN_OPS = [
     "GatedDeltaRuleOutput",
-    "gated_delta_rule",
+    "chunk_gdn",
+    "recurrent_gdn",
 ]
 
 # Model-agnostic building blocks; they currently ship from the KDA module.

--- a/attn_gym/linear/gdn/__init__.py
+++ b/attn_gym/linear/gdn/__init__.py
@@ -1,5 +1,5 @@
 """Gated delta rule attention."""
 
-from attn_gym.linear.gdn.api import GatedDeltaRuleOutput, gated_delta_rule
+from attn_gym.linear.gdn.api import GatedDeltaRuleOutput, chunk_gdn, recurrent_gdn
 
-__all__ = ["GatedDeltaRuleOutput", "gated_delta_rule"]
+__all__ = ["GatedDeltaRuleOutput", "chunk_gdn", "recurrent_gdn"]

--- a/attn_gym/linear/gdn/api.py
+++ b/attn_gym/linear/gdn/api.py
@@ -1,26 +1,24 @@
-"""Public API for the gated delta rule attention operation."""
+"""Public gated delta rule operations."""
 
 from __future__ import annotations
 
-from typing import Literal, NamedTuple
+from typing import NamedTuple
 
 import torch
 
-from attn_gym.linear.gdn.impl.reference import forward
-from attn_gym.linear.gdn.validation import validate_gated_delta_rule_inputs
-
-Mode = Literal["auto", "chunked", "recurrent"]
-Backend = Literal["auto", "eager"]
+from attn_gym.linear.gdn.impl.reference import chunk_forward, recurrent_forward
+from attn_gym.linear.gdn.validation import validate_gdn_inputs
+from attn_gym.linear.types import Impl, resolve_impl
 
 
 class GatedDeltaRuleOutput(NamedTuple):
-    """Output and optional recurrent state from :func:`gated_delta_rule`."""
+    """Output and optional recurrent state from a gated delta rule operation."""
 
     output: torch.Tensor
     final_state: torch.Tensor | None = None
 
 
-def gated_delta_rule(
+def chunk_gdn(
     query: torch.Tensor,
     key: torch.Tensor,
     value: torch.Tensor,
@@ -30,56 +28,39 @@ def gated_delta_rule(
     scale: float | None = None,
     initial_state: torch.Tensor | None = None,
     return_final_state: bool = False,
-    mode: Mode = "auto",
-    backend: Backend = "auto",
     chunk_size: int = 64,
+    impl: Impl | str = Impl.REFERENCE,
 ) -> GatedDeltaRuleOutput:
-    """Apply gated delta rule attention.
+    """Apply chunk-parallel gated delta rule attention for training and prefill.
 
-    Inputs use the SDPA layout ``[batch, heads, sequence, dimension]``. The recurrent state has
-    shape ``[batch, heads, key_dimension, value_dimension]``. For each token, the scalar natural-log
-    gate first decays the previous state, then the beta-scaled delta rule updates it, and the query
-    reads the updated state:
-
-    ``decayed_state = exp(gate) * state``
-
-    ``residual = beta * (value - key @ decayed_state)``
-
-    ``state = decayed_state + outer(key, residual)``
-
-    ``output = scale * query @ state``
+    Inputs use the SDPA layout ``[batch, heads, sequence, dimension]``. The scalar natural-log gate
+    decays the previous state before each beta-scaled delta update, and the query reads the updated
+    state. Chunking changes only the decomposition and floating-point order of that recurrence.
 
     Args:
         query: Query tensor with shape ``[B, H, T, K]``.
         key: Key tensor with shape ``[B, H, T, K]``.
         value: Value tensor with shape ``[B, H, T, V]``.
-        gate: Per-token scalar log-decay with shape ``[B, H, T]``.
+        gate: Per-token scalar natural-log decay with shape ``[B, H, T]``.
         beta: Per-token write gate with shape ``[B, H, T]``.
         scale: Query scale. Defaults to ``1 / sqrt(K)``.
         initial_state: Initial recurrent state with shape ``[B, H, K, V]``.
         return_final_state: Include the final recurrent state in the result.
-        mode: Execution form. ``"auto"`` selects recurrent execution for one token and chunked
-            execution otherwise.
-        backend: Implementation backend. ``"auto"`` currently selects the eager reference.
-        chunk_size: Number of tokens per chunk in chunked mode.
+        chunk_size: Number of tokens per chunk.
+        impl: ``"reference"`` uses eager PyTorch. ``"fused"`` is reserved for the optimized
+            backend and currently raises ``NotImplementedError``.
 
     Returns:
         The attention output and, when requested, the final recurrent state.
     """
-    validate_gated_delta_rule_inputs(
-        query,
-        key,
-        value,
-        gate,
-        beta,
-        initial_state,
-        mode=mode,
-        backend=backend,
-        chunk_size=chunk_size,
-    )
-    selected_mode = ("recurrent" if query.shape[2] == 1 else "chunked") if mode == "auto" else mode
+    selected_impl = resolve_impl(impl)
+    validate_gdn_inputs(query, key, value, gate, beta, initial_state)
+    if chunk_size <= 0:
+        raise ValueError(f"chunk_size must be greater than zero, got {chunk_size}")
+    if selected_impl is Impl.FUSED:
+        raise NotImplementedError("chunk_gdn impl='fused' is not implemented yet")
 
-    output, final_state = forward(
+    output, final_state = chunk_forward(
         query,
         key,
         value,
@@ -88,7 +69,59 @@ def gated_delta_rule(
         scale=scale,
         initial_state=initial_state,
         return_final_state=return_final_state,
-        mode=selected_mode,
         chunk_size=chunk_size,
     )
     return GatedDeltaRuleOutput(output=output, final_state=final_state)
+
+
+def recurrent_gdn(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    *,
+    scale: float | None = None,
+    initial_state: torch.Tensor | None = None,
+    return_final_state: bool = False,
+    impl: Impl | str = Impl.REFERENCE,
+) -> GatedDeltaRuleOutput:
+    """Apply recurrent gated delta rule attention for decoding and inference prefill.
+
+    The recurrence consumes tokens in order, carrying an explicit ``[B, H, K, V]`` state. Inputs
+    and outputs use the SDPA layout ``[batch, heads, sequence, dimension]``.
+
+    Args:
+        query: Query tensor with shape ``[B, H, T, K]``.
+        key: Key tensor with shape ``[B, H, T, K]``.
+        value: Value tensor with shape ``[B, H, T, V]``.
+        gate: Per-token scalar natural-log decay with shape ``[B, H, T]``.
+        beta: Per-token write gate with shape ``[B, H, T]``.
+        scale: Query scale. Defaults to ``1 / sqrt(K)``.
+        initial_state: Initial recurrent state with shape ``[B, H, K, V]``.
+        return_final_state: Include the final recurrent state in the result.
+        impl: ``"reference"`` uses eager PyTorch. ``"fused"`` is reserved for the optimized
+            backend and currently raises ``NotImplementedError``.
+
+    Returns:
+        The attention output and, when requested, the final recurrent state.
+    """
+    selected_impl = resolve_impl(impl)
+    validate_gdn_inputs(query, key, value, gate, beta, initial_state)
+    if selected_impl is Impl.FUSED:
+        raise NotImplementedError("recurrent_gdn impl='fused' is not implemented yet")
+
+    output, final_state = recurrent_forward(
+        query,
+        key,
+        value,
+        gate,
+        beta,
+        scale=scale,
+        initial_state=initial_state,
+        return_final_state=return_final_state,
+    )
+    return GatedDeltaRuleOutput(output=output, final_state=final_state)
+
+
+__all__ = ["GatedDeltaRuleOutput", "chunk_gdn", "recurrent_gdn"]

--- a/attn_gym/linear/gdn/impl/reference.py
+++ b/attn_gym/linear/gdn/impl/reference.py
@@ -6,46 +6,6 @@ import torch
 import torch.nn.functional as F
 
 
-def forward(
-    query: torch.Tensor,
-    key: torch.Tensor,
-    value: torch.Tensor,
-    log_decay: torch.Tensor,
-    beta: torch.Tensor,
-    *,
-    scale: float | None,
-    initial_state: torch.Tensor | None,
-    return_final_state: bool,
-    mode: str,
-    chunk_size: int,
-) -> tuple[torch.Tensor, torch.Tensor | None]:
-    """Run the selected eager gated delta rule execution form."""
-    if mode == "recurrent":
-        return recurrent_forward(
-            query,
-            key,
-            value,
-            log_decay,
-            beta,
-            scale=scale,
-            initial_state=initial_state,
-            return_final_state=return_final_state,
-        )
-    if mode == "chunked":
-        return chunked_forward(
-            query,
-            key,
-            value,
-            log_decay,
-            beta,
-            scale=scale,
-            initial_state=initial_state,
-            return_final_state=return_final_state,
-            chunk_size=chunk_size,
-        )
-    raise AssertionError(f"API validation allowed unexpected mode {mode!r}")
-
-
 def recurrent_forward(
     query: torch.Tensor,
     key: torch.Tensor,
@@ -78,7 +38,7 @@ def recurrent_forward(
     return output, state if return_final_state else None
 
 
-def chunked_forward(
+def chunk_forward(
     query: torch.Tensor,
     key: torch.Tensor,
     value: torch.Tensor,
@@ -169,3 +129,6 @@ def chunked_forward(
     output = output.reshape(batch, heads, padded_length, value_dimension)[:, :, :sequence]
     final_state = state.to(output_dtype) if return_final_state else None
     return output.to(output_dtype), final_state
+
+
+__all__ = ["chunk_forward", "recurrent_forward"]

--- a/attn_gym/linear/gdn/validation.py
+++ b/attn_gym/linear/gdn/validation.py
@@ -1,23 +1,19 @@
-"""Validation for the public gated delta rule contract."""
+"""Validation shared by public gated delta rule operations."""
 
 from __future__ import annotations
 
 import torch
 
 
-def validate_gated_delta_rule_inputs(
+def validate_gdn_inputs(
     query: torch.Tensor,
     key: torch.Tensor,
     value: torch.Tensor,
     gate: torch.Tensor,
     beta: torch.Tensor,
     initial_state: torch.Tensor | None,
-    *,
-    mode: str,
-    backend: str,
-    chunk_size: int,
 ) -> None:
-    """Validate shared tensor invariants and public execution options."""
+    """Validate backend-independent gated delta rule tensor invariants."""
     if query.ndim != 4 or key.ndim != 4 or value.ndim != 4:
         raise ValueError(
             "query, key, and value must have shape [batch, heads, sequence, dimension]"
@@ -42,12 +38,6 @@ def validate_gated_delta_rule_inputs(
             raise ValueError(
                 f"initial_state must have shape {expected_state_shape}, got {initial_state.shape}"
             )
-    if chunk_size <= 0:
-        raise ValueError(f"chunk_size must be greater than zero, got {chunk_size}")
-    if mode not in ("auto", "chunked", "recurrent"):
-        raise ValueError(f"Unsupported mode {mode!r}; expected 'auto', 'chunked', or 'recurrent'")
-    if backend not in ("auto", "eager"):
-        raise ValueError(f"Unsupported backend {backend!r}; expected 'auto' or 'eager'")
 
     tensors = (query, key, value, gate, beta)
     if initial_state is not None:
@@ -60,4 +50,4 @@ def validate_gated_delta_rule_inputs(
         raise ValueError("all inputs must have the same dtype")
 
 
-__all__ = ["validate_gated_delta_rule_inputs"]
+__all__ = ["validate_gdn_inputs"]

--- a/attn_gym/linear/kda/api.py
+++ b/attn_gym/linear/kda/api.py
@@ -21,17 +21,9 @@ from attn_gym.linear.kda.impl.reference import reference_kda
 from attn_gym.linear.kda.naive import naive_chunk_kda_from_cumulative, naive_recurrent_kda
 from attn_gym.linear.kda.ops import recurrent_forward as _fused_recurrent_forward
 from attn_gym.linear.kda.validation import validate_kda_inputs
-from attn_gym.linear.types import Impl
+from attn_gym.linear.types import Impl, resolve_impl
 
 _CHUNK_SIZE = 64
-
-
-def _resolve_impl(impl: Impl | str) -> Impl:
-    try:
-        return Impl(impl)
-    except ValueError:
-        valid = ", ".join(repr(member.value) for member in Impl)
-        raise ValueError(f"unknown impl {impl!r}; expected one of {valid}") from None
 
 
 def chunk_kda(
@@ -78,7 +70,7 @@ def chunk_kda(
         The output in ``q.dtype`` and either an FP32 final state with one entry
         per logical sequence or ``None``.
     """
-    selected_impl = _resolve_impl(impl)
+    selected_impl = resolve_impl(impl)
     if selected_impl is Impl.REFERENCE and fastmath:
         raise ValueError("fastmath applies only to impl='fused'")
     validate_kda_inputs(
@@ -210,7 +202,7 @@ def recurrent_kda(
     separate launches, and speculative-decoding rollback is unsupported.
     """
     del autotune
-    selected_impl = _resolve_impl(impl)
+    selected_impl = resolve_impl(impl)
     # A paged pool's leading dimension is the slot count, not the sequence count, so the
     # shared per-sequence state check does not apply; the pool is checked below instead.
     validate_kda_inputs(

--- a/attn_gym/linear/types.py
+++ b/attn_gym/linear/types.py
@@ -16,4 +16,13 @@ class Impl(str, Enum):
     REFERENCE = "reference"
 
 
-__all__ = ["Impl"]
+def resolve_impl(impl: Impl | str) -> Impl:
+    """Normalize an implementation selector and report the valid values."""
+    try:
+        return Impl(impl)
+    except ValueError:
+        valid = ", ".join(repr(member.value) for member in Impl)
+        raise ValueError(f"unknown impl {impl!r}; expected one of {valid}") from None
+
+
+__all__ = ["Impl", "resolve_impl"]

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -4,9 +4,10 @@ Attention Gym provides functional linear-attention operators with eager referenc
 
 ## Gated Delta Rule
 
-`gated_delta_rule` uses the SDPA layout `[batch, heads, sequence, dimension]` and returns a
-structured result. For each token, its scalar natural-log gate decays the previous state before the
-delta update, and the query reads the updated state:
+`chunk_gdn` and `recurrent_gdn` use the SDPA layout
+`[batch, heads, sequence, dimension]` and return a structured result. For each token, the scalar
+natural-log gate decays the previous state before the delta update, and the query reads the updated
+state:
 
 ```text
 decayed_state = exp(gate) * state
@@ -15,20 +16,20 @@ state = decayed_state + outer(key, residual)
 output = scale * query @ state
 ```
 
-The eager reference includes recurrent and chunked formulations of this recurrence for correctness
-and state-carrying tests.
+`chunk_gdn` uses a chunk-parallel decomposition for training and prefill. `recurrent_gdn` consumes
+tokens in order for decoding, inference prefill, and state-carrying correctness checks. The caller
+chooses the execution form explicitly; `impl="reference"` selects the eager PyTorch implementation.
 
 ```python
-from attn_gym.linear import gated_delta_rule
+from attn_gym.linear import chunk_gdn
 
-result = gated_delta_rule(
+result = chunk_gdn(
     query,
     key,
     value,
     gate,
     beta,
-    mode="chunked",
-    backend="eager",
+    impl="reference",
     return_final_state=True,
 )
 
@@ -39,24 +40,27 @@ final_state = result.final_state
 ### Supported capabilities
 
 - Fixed-length inputs in `[batch, heads, sequence, dimension]` layout.
-- Recurrent and chunked execution, including initial and final recurrent state.
+- Separate recurrent and chunked operations with explicit initial and final state.
 - CPU and CUDA execution through eager PyTorch operations.
 - Autograd for inputs and initial state.
 
-Packed variable-length inputs and optimized backends are not implemented yet. Requesting an unsupported backend fails explicitly rather than changing execution semantics.
+Packed variable-length inputs and fused implementations are not implemented yet. Explicit
+`impl="fused"` calls fail rather than falling back to the reference.
 
 ### Migration from the prototype API
 
-The earlier prototype functions were replaced by the variant-level API:
+- `naive_recurrent_gated_delta_rule(...)` and `gated_delta_rule(..., mode="recurrent")` become
+  `recurrent_gdn(...)`.
+- `naive_chunk_gated_delta_rule(...)` and `gated_delta_rule(..., mode="chunked")` become
+  `chunk_gdn(...)`.
+- Inputs use `[batch, heads, sequence, dimension]`, matching SDPA and FlexAttention.
+- `output_final_state` is named `return_final_state`.
+- Both operations return `GatedDeltaRuleOutput`; access tensors through `.output` and
+  `.final_state`.
 
-- `naive_recurrent_gated_delta_rule(...)` becomes `gated_delta_rule(..., mode="recurrent")`.
-- `naive_chunk_gated_delta_rule(...)` becomes `gated_delta_rule(..., mode="chunked")`.
-- Inputs now use `[batch, heads, sequence, dimension]`, matching SDPA and FlexAttention.
-- `output_final_state` was renamed to `return_final_state`.
-- The return value is always `GatedDeltaRuleOutput`; access tensors through `.output` and `.final_state`.
-- The unimplemented fused recurrent stub was removed. Optimized backends will be selected through `backend=` when they are added.
+::: attn_gym.linear.chunk_gdn
 
-::: attn_gym.linear.gated_delta_rule
+::: attn_gym.linear.recurrent_gdn
 
 ::: attn_gym.linear.GatedDeltaRuleOutput
 

--- a/test/linear/test_gdn.py
+++ b/test/linear/test_gdn.py
@@ -2,7 +2,12 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from attn_gym.linear import GatedDeltaRuleOutput, gated_delta_rule
+from attn_gym.linear import (
+    GatedDeltaRuleOutput,
+    Impl,
+    chunk_gdn,
+    recurrent_gdn,
+)
 
 
 def make_inputs(sequence: int) -> tuple[torch.Tensor, ...]:
@@ -20,20 +25,18 @@ def make_inputs(sequence: int) -> tuple[torch.Tensor, ...]:
 
 @pytest.mark.parametrize("sequence,chunk_size", [(1, 4), (7, 4), (8, 4), (17, 8)])
 @pytest.mark.parametrize("use_initial_state", [False, True])
-def test_chunked_matches_recurrent(sequence, chunk_size, use_initial_state):
+def test_chunk_matches_recurrent(sequence, chunk_size, use_initial_state):
     inputs = make_inputs(sequence)
     initial_state = inputs[-1] if use_initial_state else None
-    recurrent = gated_delta_rule(
+    recurrent = recurrent_gdn(
         *inputs[:-1],
         initial_state=initial_state,
         return_final_state=True,
-        mode="recurrent",
     )
-    chunked = gated_delta_rule(
+    chunked = chunk_gdn(
         *inputs[:-1],
         initial_state=initial_state,
         return_final_state=True,
-        mode="chunked",
         chunk_size=chunk_size,
     )
 
@@ -44,17 +47,15 @@ def test_chunked_matches_recurrent(sequence, chunk_size, use_initial_state):
 
 def test_segmented_recurrent_execution_matches_full_sequence():
     inputs = make_inputs(sequence=9)
-    full = gated_delta_rule(*inputs[:-1], return_final_state=True, mode="recurrent")
-    first = gated_delta_rule(
+    full = recurrent_gdn(*inputs[:-1], return_final_state=True)
+    first = recurrent_gdn(
         *(tensor[:, :, :4] for tensor in inputs[:-1]),
         return_final_state=True,
-        mode="recurrent",
     )
-    second = gated_delta_rule(
+    second = recurrent_gdn(
         *(tensor[:, :, 4:] for tensor in inputs[:-1]),
         initial_state=first.final_state,
         return_final_state=True,
-        mode="recurrent",
     )
 
     torch.testing.assert_close(torch.cat((first.output, second.output), dim=2), full.output)
@@ -63,28 +64,26 @@ def test_segmented_recurrent_execution_matches_full_sequence():
 
 def test_recurrent_execution_is_batch_invariant():
     inputs = make_inputs(sequence=5)
-    batched = gated_delta_rule(*inputs[:-1], return_final_state=True, mode="recurrent")
+    batched = recurrent_gdn(*inputs[:-1], return_final_state=True)
 
     for batch_index in range(inputs[0].shape[0]):
-        single = gated_delta_rule(
+        single = recurrent_gdn(
             *(tensor[batch_index : batch_index + 1] for tensor in inputs[:-1]),
             return_final_state=True,
-            mode="recurrent",
         )
         torch.testing.assert_close(single.output[0], batched.output[batch_index])
         torch.testing.assert_close(single.final_state[0], batched.final_state[batch_index])
 
 
-def test_chunked_gradients_match_recurrent():
+def test_chunk_gradients_match_recurrent():
     inputs = make_inputs(sequence=7)[:-1]
     gradients = []
-    for mode in ("recurrent", "chunked"):
+    for function, kwargs in ((recurrent_gdn, {}), (chunk_gdn, {"chunk_size": 4})):
         differentiable_inputs = [value.clone().requires_grad_() for value in inputs]
-        result = gated_delta_rule(
+        result = function(
             *differentiable_inputs,
             return_final_state=True,
-            mode=mode,
-            chunk_size=4,
+            **kwargs,
         )
         gradients.append(
             torch.autograd.grad(
@@ -93,37 +92,34 @@ def test_chunked_gradients_match_recurrent():
             )
         )
 
-    for chunked_gradient, recurrent_gradient in zip(gradients[1], gradients[0]):
-        torch.testing.assert_close(chunked_gradient, recurrent_gradient, atol=1e-6, rtol=1e-5)
+    for chunk_gradient, recurrent_gradient in zip(gradients[1], gradients[0]):
+        torch.testing.assert_close(chunk_gradient, recurrent_gradient, atol=1e-6, rtol=1e-5)
 
 
-@pytest.mark.parametrize("sequence,expected_mode", [(1, "recurrent"), (7, "chunked")])
-def test_auto_mode_matches_documented_policy(sequence, expected_mode):
-    inputs = make_inputs(sequence)
-    automatic = gated_delta_rule(*inputs[:-1])
-    explicit = gated_delta_rule(*inputs[:-1], mode=expected_mode)
-    torch.testing.assert_close(automatic.output, explicit.output)
-    assert automatic.final_state is None
-
-
-@pytest.mark.parametrize(
-    "kwargs,match",
-    [
-        ({"mode": "parallel"}, "Unsupported mode"),
-        ({"backend": "triton"}, "Unsupported backend"),
-        ({"chunk_size": 0}, "chunk_size must be greater than zero"),
-    ],
-)
-def test_invalid_options_fail_clearly(kwargs, match):
+@pytest.mark.parametrize("function", [chunk_gdn, recurrent_gdn])
+def test_impl_accepts_enum_and_string(function):
     inputs = make_inputs(sequence=2)
-    with pytest.raises(ValueError, match=match):
-        gated_delta_rule(*inputs[:-1], **kwargs)
+    from_enum = function(*inputs[:-1], impl=Impl.REFERENCE)
+    from_string = function(*inputs[:-1], impl="reference")
+    torch.testing.assert_close(from_enum.output, from_string.output)
+
+    with pytest.raises(ValueError, match="'fused', 'reference'"):
+        function(*inputs[:-1], impl="eager")
+    with pytest.raises(NotImplementedError, match="impl='fused'"):
+        function(*inputs[:-1], impl=Impl.FUSED)
 
 
-def test_invalid_initial_state_shape_fails_clearly():
+def test_invalid_chunk_size_fails_clearly():
+    inputs = make_inputs(sequence=2)
+    with pytest.raises(ValueError, match="chunk_size must be greater than zero"):
+        chunk_gdn(*inputs[:-1], chunk_size=0)
+
+
+@pytest.mark.parametrize("function", [chunk_gdn, recurrent_gdn])
+def test_invalid_initial_state_shape_fails_clearly(function):
     inputs = make_inputs(sequence=2)
     with pytest.raises(ValueError, match="initial_state must have shape"):
-        gated_delta_rule(*inputs[:-1], initial_state=inputs[-1][..., :-1])
+        function(*inputs[:-1], initial_state=inputs[-1][..., :-1])
 
 
 @pytest.mark.parametrize("mismatch_initial_state", [False, True])
@@ -137,7 +133,7 @@ def test_mismatched_dtypes_fail_clearly(mismatch_initial_state):
         kwargs = {}
 
     with pytest.raises(ValueError, match="all inputs must have the same dtype"):
-        gated_delta_rule(*inputs[:-1], **kwargs)
+        recurrent_gdn(*inputs[:-1], **kwargs)
 
 
 def test_mismatched_devices_fail_clearly():
@@ -145,7 +141,7 @@ def test_mismatched_devices_fail_clearly():
     inputs[2] = inputs[2].to("meta")
 
     with pytest.raises(ValueError, match="all inputs must be on the same device"):
-        gated_delta_rule(*inputs[:-1])
+        recurrent_gdn(*inputs[:-1])
 
 
 def test_nonfloating_inputs_fail_clearly():
@@ -153,4 +149,4 @@ def test_nonfloating_inputs_fail_clearly():
     inputs[4] = inputs[4].long()
 
     with pytest.raises(ValueError, match="all inputs must have floating-point dtypes"):
-        gated_delta_rule(*inputs[:-1])
+        recurrent_gdn(*inputs[:-1])

--- a/test/test_namespaces.py
+++ b/test/test_namespaces.py
@@ -4,7 +4,7 @@ import sys
 import attn_gym
 import attn_gym.linear
 import attn_gym.sparse
-from attn_gym.linear import Impl
+from attn_gym.linear import Impl, chunk_gdn, recurrent_gdn
 from attn_gym.linear.kda.api import Impl as KDAImpl
 from attn_gym.linear.types import Impl as SharedImpl
 from attn_gym.masks import (
@@ -27,6 +27,12 @@ def test_attention_namespaces_are_exported():
 def test_linear_impl_uses_shared_owner():
     assert Impl is SharedImpl
     assert KDAImpl is SharedImpl
+
+
+def test_gdn_operations_are_exported():
+    assert callable(chunk_gdn)
+    assert callable(recurrent_gdn)
+    assert "gated_delta_rule" not in attn_gym.linear.__all__
 
 
 def test_documented_mask_and_score_mods_are_exported():


### PR DESCRIPTION
Split gated delta rule execution APIs

## Human Note

## Agent note

Replace the single automatic GDN dispatcher with explicit `chunk_gdn` and `recurrent_gdn`
operations, matching the public KDA shape. Both operations use the shared `Impl` selector and retain
the existing eager reference mathematics, layouts, state behavior, and structured result; the fused
selector is reserved with a clear error until its backend lands.

## Test Plan

```bash
.venv/bin/prek run --files DESIGN.md docs/linear.md attn_gym/linear/__init__.py attn_gym/linear/gdn/__init__.py attn_gym/linear/gdn/api.py attn_gym/linear/gdn/impl/reference.py attn_gym/linear/gdn/validation.py test/linear/test_gdn.py test/test_namespaces.py
.venv/bin/pytest -n 6 test/linear/test_gdn.py test/test_namespaces.py test/test_kda_imports.py -q
```