### PR TITLE
Define GDN precision and state dtypes

### DIFF
--- a/attn_gym/linear/gdn/api.py
+++ b/attn_gym/linear/gdn/api.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+from functools import partial
 from typing import NamedTuple
 
 import torch
 
-from attn_gym.linear.gdn.impl.reference import chunk_forward, recurrent_forward
+from attn_gym.linear.gdn.impl.reference import (
+    chunk_forward,
+    recurrent_forward,
+    reference_gdn,
+)
 from attn_gym.linear.gdn.validation import validate_gdn_inputs
 from attn_gym.linear.types import Impl, resolve_impl
 
@@ -36,22 +41,25 @@ def chunk_gdn(
     Inputs use the SDPA layout ``[batch, heads, sequence, dimension]``. The scalar natural-log gate
     decays the previous state before each beta-scaled delta update, and the query reads the updated
     state. Chunking changes only the decomposition and floating-point order of that recurrence.
+    FP16 and BF16 inputs use FP32 recurrence math and state.
 
     Args:
         query: Query tensor with shape ``[B, H, T, K]``.
-        key: Key tensor with shape ``[B, H, T, K]``.
-        value: Value tensor with shape ``[B, H, T, V]``.
-        gate: Per-token scalar natural-log decay with shape ``[B, H, T]``.
-        beta: Per-token write gate with shape ``[B, H, T]``.
+        key: Key tensor with shape ``[B, H, T, K]`` and the same dtype as ``query``.
+        value: Value tensor with shape ``[B, H, T, V]`` and the same dtype as ``query``.
+        gate: Floating per-token scalar natural-log decay with shape ``[B, H, T]``.
+        beta: Floating per-token write gate with shape ``[B, H, T]``.
         scale: Query scale. Defaults to ``1 / sqrt(K)``.
-        initial_state: Initial recurrent state with shape ``[B, H, K, V]``.
+        initial_state: Initial recurrent state with shape ``[B, H, K, V]`` and the recurrence
+            compute dtype (FP32 for FP16/BF16 QKV).
         return_final_state: Include the final recurrent state in the result.
         chunk_size: Number of tokens per chunk.
         impl: ``"reference"`` uses eager PyTorch. ``"fused"`` is reserved for the optimized
             backend and currently raises ``NotImplementedError``.
 
     Returns:
-        The attention output and, when requested, the final recurrent state.
+        The attention output in ``query.dtype`` and, when requested, the final recurrent state in
+        the recurrence compute dtype.
     """
     selected_impl = resolve_impl(impl)
     validate_gdn_inputs(query, key, value, gate, beta, initial_state)
@@ -60,7 +68,8 @@ def chunk_gdn(
     if selected_impl is Impl.FUSED:
         raise NotImplementedError("chunk_gdn impl='fused' is not implemented yet")
 
-    output, final_state = chunk_forward(
+    output, final_state = reference_gdn(
+        partial(chunk_forward, chunk_size=chunk_size),
         query,
         key,
         value,
@@ -69,7 +78,6 @@ def chunk_gdn(
         scale=scale,
         initial_state=initial_state,
         return_final_state=return_final_state,
-        chunk_size=chunk_size,
     )
     return GatedDeltaRuleOutput(output=output, final_state=final_state)
 
@@ -89,29 +97,33 @@ def recurrent_gdn(
     """Apply recurrent gated delta rule attention for decoding and inference prefill.
 
     The recurrence consumes tokens in order, carrying an explicit ``[B, H, K, V]`` state. Inputs
-    and outputs use the SDPA layout ``[batch, heads, sequence, dimension]``.
+    and outputs use the SDPA layout ``[batch, heads, sequence, dimension]``. FP16 and BF16 inputs use
+    FP32 recurrence math and state.
 
     Args:
         query: Query tensor with shape ``[B, H, T, K]``.
-        key: Key tensor with shape ``[B, H, T, K]``.
-        value: Value tensor with shape ``[B, H, T, V]``.
-        gate: Per-token scalar natural-log decay with shape ``[B, H, T]``.
-        beta: Per-token write gate with shape ``[B, H, T]``.
+        key: Key tensor with shape ``[B, H, T, K]`` and the same dtype as ``query``.
+        value: Value tensor with shape ``[B, H, T, V]`` and the same dtype as ``query``.
+        gate: Floating per-token scalar natural-log decay with shape ``[B, H, T]``.
+        beta: Floating per-token write gate with shape ``[B, H, T]``.
         scale: Query scale. Defaults to ``1 / sqrt(K)``.
-        initial_state: Initial recurrent state with shape ``[B, H, K, V]``.
+        initial_state: Initial recurrent state with shape ``[B, H, K, V]`` and the recurrence
+            compute dtype (FP32 for FP16/BF16 QKV).
         return_final_state: Include the final recurrent state in the result.
         impl: ``"reference"`` uses eager PyTorch. ``"fused"`` is reserved for the optimized
             backend and currently raises ``NotImplementedError``.
 
     Returns:
-        The attention output and, when requested, the final recurrent state.
+        The attention output in ``query.dtype`` and, when requested, the final recurrent state in
+        the recurrence compute dtype.
     """
     selected_impl = resolve_impl(impl)
     validate_gdn_inputs(query, key, value, gate, beta, initial_state)
     if selected_impl is Impl.FUSED:
         raise NotImplementedError("recurrent_gdn impl='fused' is not implemented yet")
 
-    output, final_state = recurrent_forward(
+    output, final_state = reference_gdn(
+        recurrent_forward,
         query,
         key,
         value,

--- a/attn_gym/linear/gdn/impl/reference.py
+++ b/attn_gym/linear/gdn/impl/reference.py
@@ -6,6 +6,39 @@ import torch
 import torch.nn.functional as F
 
 
+def reference_gdn(
+    dense_op,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    log_decay: torch.Tensor,
+    beta: torch.Tensor,
+    *,
+    scale: float | None,
+    initial_state: torch.Tensor | None,
+    return_final_state: bool,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Run a dense GDN reference operation in the documented compute dtype."""
+    output_dtype = query.dtype
+    compute_dtype = torch.promote_types(query.dtype, torch.float32)
+    query, key, value, log_decay, beta = (
+        tensor.to(compute_dtype) for tensor in (query, key, value, log_decay, beta)
+    )
+    # Explicit casts do not stop autocast from selecting low-precision contractions.
+    with torch.autocast(device_type=query.device.type, enabled=False):
+        output, state = dense_op(
+            query,
+            key,
+            value,
+            log_decay,
+            beta,
+            scale=scale,
+            initial_state=initial_state,
+            return_final_state=return_final_state,
+        )
+    return output.to(output_dtype), state
+
+
 def recurrent_forward(
     query: torch.Tensor,
     key: torch.Tensor,
@@ -34,8 +67,7 @@ def recurrent_forward(
         state = state + torch.einsum("bhk,bhv->bhkv", key[:, :, token], residual)
         outputs.append(torch.einsum("bhk,bhkv->bhv", query[:, :, token], state))
 
-    output = torch.stack(outputs, dim=2)
-    return output, state if return_final_state else None
+    return torch.stack(outputs, dim=2), state if return_final_state else None
 
 
 def chunk_forward(
@@ -53,13 +85,7 @@ def chunk_forward(
     """Evaluate the gated delta rule with a naive chunk-parallel decomposition."""
     batch, heads, sequence, key_dimension = query.shape
     value_dimension = value.shape[-1]
-    output_dtype = query.dtype
     scale = key_dimension**-0.5 if scale is None else scale
-    compute_dtype = torch.float32 if query.dtype != torch.float64 else torch.float64
-
-    query, key, value, beta, log_decay = (
-        tensor.to(compute_dtype) for tensor in (query, key, value, beta, log_decay)
-    )
     padding = (-sequence) % chunk_size
     if padding:
         query, key, value = (F.pad(tensor, (0, 0, 0, padding)) for tensor in (query, key, value))
@@ -92,14 +118,14 @@ def chunk_forward(
             transition[..., row, :row, None].clone() * transition[..., :row, :row].clone()
         ).sum(-2)
 
-    transition = transition + torch.eye(chunk_size, dtype=torch.float, device=query.device)
+    transition = transition + torch.eye(chunk_size, dtype=query.dtype, device=query.device)
     value = transition @ value
     decayed_key = transition @ (beta_key * cumulative_decay.exp()[..., None])
 
     state = (
         query.new_zeros(batch, heads, key_dimension, value_dimension)
         if initial_state is None
-        else initial_state.to(compute_dtype)
+        else initial_state
     )
     output = torch.zeros_like(value)
     strictly_upper = torch.triu(
@@ -127,8 +153,7 @@ def chunk_forward(
         )
 
     output = output.reshape(batch, heads, padded_length, value_dimension)[:, :, :sequence]
-    final_state = state.to(output_dtype) if return_final_state else None
-    return output.to(output_dtype), final_state
+    return output, state if return_final_state else None
 
 
-__all__ = ["chunk_forward", "recurrent_forward"]
+__all__ = ["chunk_forward", "recurrent_forward", "reference_gdn"]

--- a/attn_gym/linear/gdn/validation.py
+++ b/attn_gym/linear/gdn/validation.py
@@ -46,8 +46,15 @@ def validate_gdn_inputs(
         raise ValueError("all inputs must have floating-point dtypes")
     if any(tensor.device != query.device for tensor in tensors[1:]):
         raise ValueError("all inputs must be on the same device")
-    if any(tensor.dtype != query.dtype for tensor in tensors[1:]):
-        raise ValueError("all inputs must have the same dtype")
+    if key.dtype != query.dtype or value.dtype != query.dtype:
+        raise ValueError("query, key, and value must have the same dtype")
+
+    compute_dtype = torch.promote_types(query.dtype, torch.float32)
+    if initial_state is not None and initial_state.dtype != compute_dtype:
+        raise ValueError(
+            f"initial_state must have dtype {compute_dtype} for {query.dtype} query, "
+            f"got {initial_state.dtype}"
+        )
 
 
 __all__ = ["validate_gdn_inputs"]

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -43,6 +43,11 @@ final_state = result.final_state
 - Separate recurrent and chunked operations with explicit initial and final state.
 - CPU and CUDA execution through eager PyTorch operations.
 - Autograd for inputs and initial state.
+- Q/K/V share one dtype. FP16 and BF16 inputs use FP32 recurrence math and state while returning
+  output in the Q dtype.
+- Gate and beta may use independent floating dtypes and are converted to the recurrence compute
+  dtype. A provided initial state uses FP32 for low-precision QKV.
+- FP64 reference inputs retain FP64 recurrence math and state.
 
 Packed variable-length inputs and fused implementations are not implemented yet. Explicit
 `impl="fused"` calls fail rather than falling back to the reference.

--- a/test/linear/test_gdn.py
+++ b/test/linear/test_gdn.py
@@ -9,6 +9,8 @@ from attn_gym.linear import (
     recurrent_gdn,
 )
 
+REFERENCE_CASES = [(recurrent_gdn, {}), (chunk_gdn, {"chunk_size": 4})]
+
 
 def make_inputs(sequence: int) -> tuple[torch.Tensor, ...]:
     """Create stable gated delta rule inputs with normalized keys."""
@@ -21,6 +23,11 @@ def make_inputs(sequence: int) -> tuple[torch.Tensor, ...]:
     beta = torch.sigmoid(torch.randn(batch, heads, sequence))
     initial_state = torch.randn(batch, heads, key_dimension, value_dimension)
     return query, key, value, gate, beta, initial_state
+
+
+def run_with_state(function, inputs, kwargs):
+    """Run one GDN form with its initial and final recurrent state."""
+    return function(*inputs[:5], initial_state=inputs[5], return_final_state=True, **kwargs)
 
 
 @pytest.mark.parametrize("sequence,chunk_size", [(1, 4), (7, 4), (8, 4), (17, 8)])
@@ -78,7 +85,7 @@ def test_recurrent_execution_is_batch_invariant():
 def test_chunk_gradients_match_recurrent():
     inputs = make_inputs(sequence=7)[:-1]
     gradients = []
-    for function, kwargs in ((recurrent_gdn, {}), (chunk_gdn, {"chunk_size": 4})):
+    for function, kwargs in REFERENCE_CASES:
         differentiable_inputs = [value.clone().requires_grad_() for value in inputs]
         result = function(
             *differentiable_inputs,
@@ -94,6 +101,104 @@ def test_chunk_gradients_match_recurrent():
 
     for chunk_gradient, recurrent_gradient in zip(gradients[1], gradients[0]):
         torch.testing.assert_close(chunk_gradient, recurrent_gradient, atol=1e-6, rtol=1e-5)
+
+
+@pytest.mark.parametrize("function,kwargs", REFERENCE_CASES)
+@pytest.mark.parametrize("qkv_dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("fp32_gate", [False, True])
+def test_low_precision_compute_and_gradient_dtypes(function, kwargs, qkv_dtype, fp32_gate):
+    query, key, value, gate, beta, initial_state = make_inputs(sequence=7)
+    gate_dtype = torch.float32 if fp32_gate else qkv_dtype
+    inputs = [
+        query.to(qkv_dtype),
+        key.to(qkv_dtype),
+        value.to(qkv_dtype),
+        gate.to(gate_dtype),
+        beta.to(gate_dtype),
+        initial_state,
+    ]
+    inputs = [tensor.requires_grad_() for tensor in inputs]
+    expected_inputs = [tensor.detach().float() for tensor in inputs]
+
+    result = run_with_state(function, inputs, kwargs)
+    expected = run_with_state(function, expected_inputs, kwargs)
+    assert result.output.dtype == qkv_dtype
+    assert result.final_state.dtype == torch.float32
+    torch.testing.assert_close(
+        result.output.float(),
+        expected.output,
+        rtol=torch.finfo(qkv_dtype).eps,
+        atol=torch.finfo(qkv_dtype).eps,
+    )
+    torch.testing.assert_close(result.final_state, expected.final_state, rtol=0, atol=0)
+
+    gradients = torch.autograd.grad(
+        result.output.float().square().mean() + result.final_state.square().mean(), inputs
+    )
+    assert tuple(gradient.dtype for gradient in gradients) == (
+        qkv_dtype,
+        qkv_dtype,
+        qkv_dtype,
+        gate_dtype,
+        gate_dtype,
+        torch.float32,
+    )
+
+
+@pytest.mark.parametrize(
+    "function,kwargs,device_type,autocast_dtype",
+    [
+        (recurrent_gdn, {}, "cpu", torch.bfloat16),
+        (chunk_gdn, {"chunk_size": 4}, "cpu", torch.bfloat16),
+        (recurrent_gdn, {}, "cuda", torch.float16),
+        (recurrent_gdn, {}, "cuda", torch.bfloat16),
+    ],
+)
+def test_reference_disables_autocast(function, kwargs, device_type, autocast_dtype):
+    if device_type == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA autocast requires CUDA")
+
+    expected_inputs = [
+        tensor.to(device_type).requires_grad_() for tensor in make_inputs(sequence=7)
+    ]
+    actual_inputs = [tensor.detach().clone().requires_grad_() for tensor in expected_inputs]
+    expected = run_with_state(function, expected_inputs, kwargs)
+    with torch.autocast(device_type=device_type, dtype=autocast_dtype):
+        actual = run_with_state(function, actual_inputs, kwargs)
+
+    torch.testing.assert_close(actual.output, expected.output, rtol=0, atol=0)
+    torch.testing.assert_close(actual.final_state, expected.final_state, rtol=0, atol=0)
+    expected_gradients = torch.autograd.grad(
+        expected.output.square().mean() + expected.final_state.square().mean(), expected_inputs
+    )
+    actual_gradients = torch.autograd.grad(
+        actual.output.square().mean() + actual.final_state.square().mean(), actual_inputs
+    )
+    for actual_gradient, expected_gradient in zip(actual_gradients, expected_gradients):
+        torch.testing.assert_close(actual_gradient, expected_gradient, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("function", [chunk_gdn, recurrent_gdn])
+def test_low_precision_default_state_is_fp32(function):
+    query, key, value, gate, beta, _initial_state = make_inputs(sequence=3)
+    result = function(
+        query.bfloat16(),
+        key.bfloat16(),
+        value.bfloat16(),
+        gate,
+        beta,
+        return_final_state=True,
+    )
+    assert result.output.dtype == torch.bfloat16
+    assert result.final_state.dtype == torch.float32
+
+
+@pytest.mark.parametrize("function", [chunk_gdn, recurrent_gdn])
+def test_fp64_preserves_compute_and_state_dtype(function):
+    inputs = [tensor.double() for tensor in make_inputs(sequence=3)]
+    result = function(*inputs[:5], initial_state=inputs[5], return_final_state=True)
+    assert result.output.dtype == torch.float64
+    assert result.final_state.dtype == torch.float64
 
 
 @pytest.mark.parametrize("function", [chunk_gdn, recurrent_gdn])
@@ -122,18 +227,38 @@ def test_invalid_initial_state_shape_fails_clearly(function):
         function(*inputs[:-1], initial_state=inputs[-1][..., :-1])
 
 
-@pytest.mark.parametrize("mismatch_initial_state", [False, True])
-def test_mismatched_dtypes_fail_clearly(mismatch_initial_state):
+def test_mismatched_qkv_dtypes_fail_clearly():
     inputs = list(make_inputs(sequence=2))
-    if mismatch_initial_state:
-        inputs[-1] = inputs[-1].double()
-        kwargs = {"initial_state": inputs[-1]}
-    else:
-        inputs[2] = inputs[2].double()
-        kwargs = {}
+    inputs[2] = inputs[2].double()
+    with pytest.raises(ValueError, match="query, key, and value must have the same dtype"):
+        recurrent_gdn(*inputs[:-1])
 
-    with pytest.raises(ValueError, match="all inputs must have the same dtype"):
-        recurrent_gdn(*inputs[:-1], **kwargs)
+
+def test_gate_and_beta_accept_independent_floating_dtypes():
+    query, key, value, gate, beta, _initial_state = make_inputs(sequence=2)
+    result = recurrent_gdn(
+        query.bfloat16(),
+        key.bfloat16(),
+        value.bfloat16(),
+        gate.half(),
+        beta.double(),
+        return_final_state=True,
+    )
+    assert result.output.dtype == torch.bfloat16
+    assert result.final_state.dtype == torch.float32
+
+
+def test_invalid_initial_state_dtype_fails_clearly():
+    query, key, value, gate, beta, initial_state = make_inputs(sequence=2)
+    with pytest.raises(ValueError, match="initial_state must have dtype torch.float32"):
+        recurrent_gdn(
+            query.bfloat16(),
+            key.bfloat16(),
+            value.bfloat16(),
+            gate,
+            beta,
+            initial_state=initial_state.bfloat16(),
+        )
 
 
 def test_mismatched_devices_fail_clearly():


### PR DESCRIPTION
Define GDN precision and state dtypes

## Human Note

## Agent note

Define one precision contract for future reference and fused GDN implementations. Q/K/V share a
dtype; low-precision gates and beta may remain low precision or use FP32; recurrence math and state
are FP32 for FP16/BF16 inputs; outputs retain the query dtype; and FP64 reference execution remains
FP64. Apply the contract to both eager formulations and cover output, state, numerical, and gradient
dtypes.

## Test Plan

```bash
.venv/bin/prek run --files attn_gym/linear/gdn/api.py attn_gym/linear/gdn/impl/reference.py attn_gym/linear/gdn/validation.py docs/linear.md test/linear/test_gdn.py
.venv/bin/pytest -n 6 test/linear/test_gdn.py test/test_namespaces.py -q
```