### PR TITLE
optimize general recurrent kernel

### DIFF
--- a/attn_gym/linear/kda/api.py
+++ b/attn_gym/linear/kda/api.py
@@ -196,9 +196,9 @@ def recurrent_kda(
                 seq 1 is padding (index is -1) so this is ignored
                 seq 2 reads and updates initial_state[5]
                 seq 3 is padding bc 0
-        autotune: Reserved for implementation parity with ``chunk_kda``. The
-            current recurrent kernel uses the same fixed launch policy for both
-            values.
+        autotune: Benchmark candidate value-tile sizes for non-paged execution
+            when true; winners are cached and reused. Paged execution and false
+            use a deterministic sequence-length heuristic.
         impl: ``"fused"`` uses the inference-only optimized scan; ``"reference"``
             uses differentiable eager PyTorch in FP32, with no automatic
             fallback.
@@ -211,7 +211,6 @@ def recurrent_kda(
     sequences and final states are written out of place, decode preprocessing and scan are
     separate launches, and speculative-decoding rollback is unsupported.
     """
-    del autotune
     selected_impl = resolve_impl(impl)
     # A paged pool's leading dimension is the slot count, not the sequence count, so the
     # shared per-sequence state check does not apply; the pool is checked below instead.
@@ -241,6 +240,7 @@ def recurrent_kda(
             cu_seqlens=cu_seqlens,
             output_final_state=output_final_state,
             state_indices=state_indices,
+            autotune=autotune,
         )
     return reference_kda(
         naive_recurrent_kda, q, k, v, gate, beta, initial_state, cu_seqlens, output_final_state

--- a/attn_gym/linear/kda/fwd/triton/recurrent.py
+++ b/attn_gym/linear/kda/fwd/triton/recurrent.py
@@ -28,10 +28,17 @@ from attn_gym.linear.kda.ops import recurrent_fwd_op as _recurrent_fwd_op
 from attn_gym.linear.kda.ops import (
     recurrent_fwd_paged_op as _recurrent_fwd_paged_op,
 )
+from attn_gym.linear.kda.utils import autotune_cache_kwargs
 
 
-@triton.jit
-def kda_recurrent_fwd_kernel(
+def _prune_recurrent_configs(configs, _named_args, V, **_):
+    """drop value tiles wider than the padded value dimension"""
+    max_block_v = max(8, triton.next_power_of_2(V))
+    return [config for config in configs if config.kwargs["BV"] <= max_block_v]
+
+
+@triton.jit(do_not_specialize=["N"])
+def _kda_recurrent_fwd_kernel(
     q,
     k,
     v,
@@ -44,6 +51,7 @@ def kda_recurrent_fwd_kernel(
     state_indices,
     scale,
     T,
+    N,
     state_batch_stride: tl.constexpr,
     H: tl.constexpr,
     K: tl.constexpr,
@@ -123,6 +131,27 @@ def kda_recurrent_fwd_kernel(
         tl.store(ht + p_state, b_state, mask=m_kv)
 
 
+kda_recurrent_fwd_kernel = triton.autotune(
+    configs=[
+        triton.Config({"BV": block_v}, num_warps=num_warps, num_stages=3)
+        for block_v in (32, 16, 8)
+        for num_warps in (2, 4)
+    ],
+    key=[
+        "T",
+        "N",
+        "H",
+        "K",
+        "V",
+        "USE_INITIAL_STATE",
+        "STORE_FINAL_STATE",
+        "IS_VARLEN",
+    ],
+    prune_configs_by={"early_config_prune": _prune_recurrent_configs},
+    **autotune_cache_kwargs,
+)(_kda_recurrent_fwd_kernel)
+
+
 def _launch_recurrent_fwd(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -133,6 +162,7 @@ def _launch_recurrent_fwd(
     cu_seqlens: torch.Tensor | None,
     store_final_state: bool,
     state_indices: torch.Tensor | None = None,
+    autotune: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Allocate outputs and launch the sequential scan over token spans."""
     batch, tokens, heads, key_dim = q.shape
@@ -152,35 +182,62 @@ def _launch_recurrent_fwd(
     )
     # BV=32 measured faster than 64 on B200 for both decode and prefill
     # (smaller state tiles schedule better; state traffic is identical).
-    block_v = min(triton.next_power_of_2(value_dim), 32)
     # One flat launch dimension: sequence-head counts can exceed the 65,535
     # grid-Y limit, while grid-X is effectively unbounded.
-    grid = (triton.cdiv(value_dim, block_v) * num_sequences * heads,)
-    kda_recurrent_fwd_kernel[grid](
-        q,
-        k,
-        v,
-        gate,
-        beta,
-        output,
-        initial_state,
-        final_state,
-        cu_seqlens,
-        state_indices,
-        scale=key_dim**-0.5,
-        T=tokens,
-        state_batch_stride=state_batch_stride,
-        H=heads,
-        K=key_dim,
-        V=value_dim,
-        BK=triton.next_power_of_2(key_dim),
-        BV=block_v,
-        USE_INITIAL_STATE=initial_state is not None,
-        STORE_FINAL_STATE=final_state is not None,
-        IS_VARLEN=cu_seqlens is not None,
-        USE_STATE_INDICES=state_indices is not None,
-        num_warps=4,
-    )
+    grid = lambda meta: (triton.cdiv(value_dim, meta["BV"]) * num_sequences * heads,)
+
+    def launch(kernel, launch_options):
+        kernel[grid](
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            output,
+            initial_state,
+            final_state,
+            cu_seqlens,
+            state_indices,
+            scale=key_dim**-0.5,
+            T=tokens,
+            N=num_sequences,
+            state_batch_stride=state_batch_stride,
+            H=heads,
+            K=key_dim,
+            V=value_dim,
+            BK=triton.next_power_of_2(key_dim),
+            USE_INITIAL_STATE=initial_state is not None,
+            STORE_FINAL_STATE=final_state is not None,
+            IS_VARLEN=cu_seqlens is not None,
+            USE_STATE_INDICES=state_indices is not None,
+            **launch_options,
+        )
+
+    use_autotune = autotune and state_indices is None
+    kernel = kda_recurrent_fwd_kernel if use_autotune else _kda_recurrent_fwd_kernel
+    launch_options = {}
+    if not use_autotune:
+        average_tokens = tokens if cu_seqlens is None else triton.cdiv(tokens, num_sequences)
+        sequence_heads = num_sequences * heads
+        # offline b200 sweeps favor small tiles for long scans and low-occupancy decode
+        if average_tokens >= 32:
+            block_v_limit, num_warps = 8, 4
+        elif average_tokens > 1:
+            block_v_limit, num_warps = 32, 2
+        elif value_dim >= 128:
+            block_v_limit, num_warps = 16, 4
+        elif sequence_heads <= 8:
+            block_v_limit, num_warps = 8, 4
+        elif sequence_heads < 1024:
+            block_v_limit, num_warps = 16, 2
+        else:
+            block_v_limit, num_warps = 32, 2
+        launch_options = {
+            "BV": min(triton.next_power_of_2(value_dim), block_v_limit),
+            "num_warps": num_warps,
+            "num_stages": 3,
+        }
+    launch(kernel, launch_options)
     return output, final_state
 
 
@@ -192,9 +249,18 @@ def _kda_recurrent_fwd_cuda(
     beta: torch.Tensor,
     initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor | None,
+    autotune: bool,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     output, final_state = _launch_recurrent_fwd(
-        q, k, v, gate, beta, initial_state, cu_seqlens, store_final_state=True
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        initial_state,
+        cu_seqlens,
+        store_final_state=True,
+        autotune=autotune,
     )
     assert final_state is not None
     return output, final_state
@@ -208,9 +274,18 @@ def _kda_recurrent_fwd_no_state_cuda(
     beta: torch.Tensor,
     initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor | None,
+    autotune: bool,
 ) -> torch.Tensor:
     return _launch_recurrent_fwd(
-        q, k, v, gate, beta, initial_state, cu_seqlens, store_final_state=False
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        initial_state,
+        cu_seqlens,
+        store_final_state=False,
+        autotune=autotune,
     )[0]
 
 
@@ -223,6 +298,7 @@ def _kda_recurrent_fwd_paged_cuda(
     state_cache: torch.Tensor,
     state_indices: torch.Tensor,
     cu_seqlens: torch.Tensor | None,
+    autotune: bool,
 ) -> torch.Tensor:
     return _launch_recurrent_fwd(
         q,
@@ -234,6 +310,7 @@ def _kda_recurrent_fwd_paged_cuda(
         cu_seqlens,
         store_final_state=True,
         state_indices=state_indices,
+        autotune=autotune,
     )[0]
 
 

--- a/attn_gym/linear/kda/ops.py
+++ b/attn_gym/linear/kda/ops.py
@@ -59,7 +59,7 @@ torch.library.define(
 
 _RECURRENT_FWD_ARGS = (
     "(Tensor q, Tensor k, Tensor v, Tensor gate, Tensor beta,"
-    " Tensor? initial_state, Tensor? cu_seqlens)"
+    " Tensor? initial_state, Tensor? cu_seqlens, bool autotune)"
 )
 torch.library.define("attn_gym::kda_recurrent_fwd", _RECURRENT_FWD_ARGS + " -> (Tensor, Tensor)")
 torch.library.define("attn_gym::kda_recurrent_fwd_no_state", _RECURRENT_FWD_ARGS + " -> Tensor")
@@ -68,7 +68,7 @@ torch.library.define("attn_gym::kda_recurrent_fwd_no_state", _RECURRENT_FWD_ARGS
 torch.library.define(
     "attn_gym::kda_recurrent_fwd_paged",
     "(Tensor q, Tensor k, Tensor v, Tensor gate, Tensor beta, Tensor(a!) state_cache,"
-    " Tensor state_indices, Tensor? cu_seqlens) -> Tensor",
+    " Tensor state_indices, Tensor? cu_seqlens, bool autotune) -> Tensor",
 )
 torch.library.define(
     "attn_gym::kda_prepare_chunk_offsets",
@@ -339,8 +339,9 @@ def _recurrent_fwd_fake(
     beta: torch.Tensor,
     initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor | None,
+    autotune: bool,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    del k, gate, beta, initial_state
+    del k, gate, beta, initial_state, autotune
     num_sequences = q.shape[0] if cu_seqlens is None else cu_seqlens.shape[0] - 1
     final_state = q.new_empty(
         num_sequences, q.shape[2], q.shape[3], v.shape[-1], dtype=torch.float32
@@ -357,8 +358,9 @@ def _recurrent_fwd_no_state_fake(
     beta: torch.Tensor,
     initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor | None,
+    autotune: bool,
 ) -> torch.Tensor:
-    del k, gate, beta, initial_state, cu_seqlens
+    del k, gate, beta, initial_state, cu_seqlens, autotune
     return torch.empty_like(v, dtype=q.dtype)
 
 
@@ -372,8 +374,9 @@ def _recurrent_fwd_paged_fake(
     state_cache: torch.Tensor,
     state_indices: torch.Tensor,
     cu_seqlens: torch.Tensor | None,
+    autotune: bool,
 ) -> torch.Tensor:
-    del k, gate, beta, state_cache, state_indices, cu_seqlens
+    del k, gate, beta, state_cache, state_indices, cu_seqlens, autotune
     return torch.empty_like(v, dtype=q.dtype)
 
 
@@ -454,6 +457,7 @@ def recurrent_forward(
     cu_seqlens: torch.Tensor | None = None,
     output_final_state: bool = False,
     state_indices: torch.Tensor | None = None,
+    autotune: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Validate and invoke the lazily loaded fused recurrent implementation."""
     if q.shape[-1] > 256:
@@ -474,13 +478,15 @@ def recurrent_forward(
         # `.contiguous()` on the pool would copy and silently drop the in-place advance.
         assert initial_state is not None
         return recurrent_fwd_paged_op(
-            q, k, v, gate, beta, initial_state, state_indices, cu_seqlens
+            q, k, v, gate, beta, initial_state, state_indices, cu_seqlens, autotune
         ), None
     if initial_state is not None:
         initial_state = initial_state.contiguous()
     if output_final_state:
-        return recurrent_fwd_op(q, k, v, gate, beta, initial_state, cu_seqlens)
-    return recurrent_fwd_no_state_op(q, k, v, gate, beta, initial_state, cu_seqlens), None
+        return recurrent_fwd_op(q, k, v, gate, beta, initial_state, cu_seqlens, autotune)
+    return recurrent_fwd_no_state_op(
+        q, k, v, gate, beta, initial_state, cu_seqlens, autotune
+    ), None
 
 
 __all__ = [

--- a/test/test_kda_recurrent.py
+++ b/test/test_kda_recurrent.py
@@ -15,6 +15,7 @@ import torch.nn.functional as F
 pytest.importorskip("triton")
 
 from attn_gym.linear import recurrent_kda
+from attn_gym.linear.kda.fwd.triton import recurrent as recurrent_backend
 from attn_gym.linear.kda.fwd.triton.recurrent import (
     _recurrent_fwd_no_state_op,
     _recurrent_fwd_op,
@@ -106,6 +107,29 @@ def test_recurrent_matches_naive_non_power_of_two(key_dim: int, value_dim: int):
     expected, expected_state = naive_recurrent_kda(q, k, v, gate, beta, output_final_state=True)
     torch.testing.assert_close(output, expected, rtol=1e-5, atol=1e-5)
     torch.testing.assert_close(final_state, expected_state, rtol=1e-5, atol=1e-5)
+
+
+def test_recurrent_autotunes_value_tile():
+    """Select the only valid candidate for a value dimension below the minimum tile."""
+    q, k, v, gate, beta, _ = _inputs(key_dim=7, value_dim=3, seed=2)
+
+    output, _ = recurrent_kda(q, k, v, gate, beta, autotune=True)
+    expected, _ = recurrent_kda(q, k, v, gate, beta, autotune=False)
+
+    torch.testing.assert_close(output, expected, rtol=1e-5, atol=1e-5)
+
+
+def test_recurrent_paged_skips_autotune(monkeypatch):
+    q, k, v, gate, beta, _ = _inputs(batch=2, tokens=1, seed=3)
+    _, pool = _strided_state_pool(3, q.shape[2], q.shape[3], v.shape[-1])
+    slots = torch.tensor([1, 2], device="cuda", dtype=torch.int32)
+
+    class UnexpectedAutotune:
+        def __getitem__(self, _grid):
+            raise AssertionError("paged execution must not invoke the autotuner")
+
+    monkeypatch.setattr(recurrent_backend, "kda_recurrent_fwd_kernel", UnexpectedAutotune())
+    recurrent_kda(q, k, v, gate, beta, pool, state_indices=slots, autotune=True)
 
 
 def test_recurrent_packed_capacity_and_empty_slots():
@@ -359,12 +383,15 @@ def test_recurrent_custom_op_registration(packed: bool):
     cu_seqlens = torch.tensor([0, 2, 7, 17], device="cuda", dtype=torch.int32) if packed else None
     num_sequences = 3 if packed else batch
     state = torch.randn(num_sequences, q.shape[2], q.shape[3], v.shape[-1], device="cuda")
-    torch.library.opcheck(_recurrent_fwd_op, (q, k, v, gate, beta, state, cu_seqlens))
-    torch.library.opcheck(_recurrent_fwd_no_state_op, (q, k, v, gate, beta, state, cu_seqlens))
+    torch.library.opcheck(_recurrent_fwd_op, (q, k, v, gate, beta, state, cu_seqlens, True))
+    torch.library.opcheck(
+        _recurrent_fwd_no_state_op, (q, k, v, gate, beta, state, cu_seqlens, True)
+    )
     _, state_pool = _strided_state_pool(num_sequences + 1, q.shape[2], q.shape[3], v.shape[-1])
     slots = torch.arange(1, num_sequences + 1, device="cuda", dtype=torch.int32)
     torch.library.opcheck(
-        _recurrent_fwd_paged_op, (q, k, v, gate, beta, state_pool, slots, cu_seqlens)
+        _recurrent_fwd_paged_op,
+        (q, k, v, gate, beta, state_pool, slots, cu_seqlens, True),
     )
 
 
@@ -376,22 +403,39 @@ def test_recurrent_custom_op_registration_mixed_dtype():
     _, state_pool = _strided_state_pool(3, q.shape[2], q.shape[3], v.shape[-1])
     slots = torch.tensor([1, 2], device="cuda", dtype=torch.int32)
 
-    torch.library.opcheck(_recurrent_fwd_op, (q, k, v, gate, beta, state, None))
-    torch.library.opcheck(_recurrent_fwd_no_state_op, (q, k, v, gate, beta, state, None))
-    torch.library.opcheck(_recurrent_fwd_paged_op, (q, k, v, gate, beta, state_pool, slots, None))
+    torch.library.opcheck(_recurrent_fwd_op, (q, k, v, gate, beta, state, None, True))
+    torch.library.opcheck(_recurrent_fwd_no_state_op, (q, k, v, gate, beta, state, None, True))
+    torch.library.opcheck(
+        _recurrent_fwd_paged_op, (q, k, v, gate, beta, state_pool, slots, None, True)
+    )
 
 
 @pytest.mark.parametrize("output_final_state", [False, True])
-def test_recurrent_fullgraph_compile(output_final_state: bool):
+@pytest.mark.parametrize("autotune", [False, True])
+def test_recurrent_fullgraph_compile(output_final_state: bool, autotune: bool):
     """Compile both optional-state branches of the public operation."""
     q, k, v, gate, beta, state = _inputs(initial_state=True)
 
     expected, expected_state = recurrent_kda(
-        q, k, v, gate, beta, state, output_final_state=output_final_state
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        state,
+        output_final_state=output_final_state,
+        autotune=autotune,
     )
     compiled = torch.compile(recurrent_kda, fullgraph=True)
     output, final_state = compiled(
-        q, k, v, gate, beta, state, output_final_state=output_final_state
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        state,
+        output_final_state=output_final_state,
+        autotune=autotune,
     )
     torch.testing.assert_close(output, expected, rtol=0, atol=0)
     if output_final_state:
@@ -426,13 +470,13 @@ def test_recurrent_cuda_graph_replay():
     q, k, v, gate, beta, _ = _inputs(batch=1, tokens=32, seed=5)
     cu_seqlens = torch.tensor([0, 11, 27, 32], device="cuda", dtype=torch.int32)
     initial_state = torch.randn(3, q.shape[2], q.shape[3], v.shape[-1], device="cuda")
-    _recurrent_fwd_op(q, k, v, gate, beta, initial_state, cu_seqlens)
+    _recurrent_fwd_op(q, k, v, gate, beta, initial_state, cu_seqlens, True)
     torch.cuda.synchronize()
 
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
         captured_output, captured_state = _recurrent_fwd_op(
-            q, k, v, gate, beta, initial_state, cu_seqlens
+            q, k, v, gate, beta, initial_state, cu_seqlens, True
         )
 
     active_tokens = 23
@@ -447,7 +491,7 @@ def test_recurrent_cuda_graph_replay():
     torch.cuda.synchronize()
 
     expected_output, expected_state = _recurrent_fwd_op(
-        q, k, v, gate, beta, initial_state, cu_seqlens
+        q, k, v, gate, beta, initial_state, cu_seqlens, True
     )
     torch.testing.assert_close(
         captured_output[:, :active_tokens],
@@ -463,12 +507,12 @@ def test_recurrent_paged_cuda_graph_replay():
     q, k, v, gate, beta, _ = _inputs(batch=3, tokens=1, dtype=torch.bfloat16, seed=31)
     storage, pool = _strided_state_pool(7, q.shape[2], q.shape[3], v.shape[-1])
     slots = torch.tensor([5, 1, 3], device="cuda", dtype=torch.int32)
-    _recurrent_fwd_paged_op(q, k, v, gate, beta, pool, slots, None)
+    _recurrent_fwd_paged_op(q, k, v, gate, beta, pool, slots, None, True)
     torch.cuda.synchronize()
 
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
-        captured_output = _recurrent_fwd_paged_op(q, k, v, gate, beta, pool, slots, None)
+        captured_output = _recurrent_fwd_paged_op(q, k, v, gate, beta, pool, slots, None, True)
 
     with torch.no_grad():
         storage.add_(0.25)


### PR DESCRIPTION
trying different BV and stages , setting BV and num_warps to be triton autotune params

<img width="1037" height="622" alt="Screenshot 2026-08-18 at 11 53 06 AM" src="https://github.com/user-attachments/assets/05394bf9-73d9-4d92-ba9d-d1bb364332e7" />

<img width="2174" height="1476" alt="general_recurrent_launch_heatmap" src="https://github.com/user-attachments/assets/6748f35e-825f-433b-9804-fda821f2e36f" />
