### PR TITLE
Fuse KDA decode preprocessing into recurrent kernel

### DIFF
--- a/attn_gym/linear/__init__.py
+++ b/attn_gym/linear/__init__.py
@@ -16,6 +16,7 @@ from attn_gym.linear.kda import (
     mask_inactive_token_gradients,
     mask_inactive_tokens,
     recurrent_kda,
+    recurrent_kda_decode,
 )
 from attn_gym.linear.types import Impl
 
@@ -33,6 +34,7 @@ if TYPE_CHECKING:
 KDA_OPS = [
     "chunk_kda",
     "recurrent_kda",
+    "recurrent_kda_decode",
 ]
 
 GDN_OPS = [

--- a/attn_gym/linear/kda/__init__.py
+++ b/attn_gym/linear/kda/__init__.py
@@ -13,7 +13,7 @@ lazily on first fused call, and the naive oracles in
 
 import importlib
 
-from attn_gym.linear.kda.api import chunk_kda, recurrent_kda
+from attn_gym.linear.kda.api import chunk_kda, recurrent_kda, recurrent_kda_decode
 from attn_gym.linear.kda.constants import MAX_GATE_LOWER_BOUND_MAGNITUDE
 from attn_gym.linear.kda.gate import bound_gate
 from attn_gym.linear.kda.masking import (
@@ -55,6 +55,7 @@ __all__ = sorted(  # noqa: PLE0605 -- backend exports resolve lazily
         "mask_inactive_token_gradients",
         "mask_inactive_tokens",
         "recurrent_kda",
+        "recurrent_kda_decode",
         *_BACKEND_EXPORTS,
     ]
 )

--- a/attn_gym/linear/kda/api.py
+++ b/attn_gym/linear/kda/api.py
@@ -12,9 +12,10 @@ inference prefill. Use ``impl`` to select fused kernels or the eager reference.
 
 from __future__ import annotations
 
-import math
+import sys
 from functools import partial
 from numbers import Real
+from typing import Literal
 
 import torch
 
@@ -28,6 +29,20 @@ from attn_gym.linear.kda.validation import SUPPORTED_INPUT_DTYPES, validate_kda_
 from attn_gym.linear.types import Impl, resolve_impl
 
 _CHUNK_SIZE = 64
+_DECODE_GATE_TRANSFORMS = {
+    "bounded": True,
+    "softplus": False,
+}
+
+
+def _resolve_decode_gate_transform(gate_transform: str) -> bool:
+    try:
+        return _DECODE_GATE_TRANSFORMS[gate_transform]
+    except KeyError:
+        supported = ", ".join(sorted(_DECODE_GATE_TRANSFORMS))
+        raise ValueError(
+            f"gate_transform must be one of {{{supported}}}, got {gate_transform!r}"
+        ) from None
 
 
 def chunk_kda(
@@ -274,29 +289,46 @@ def recurrent_kda_decode(
     state_cache: torch.Tensor,
     state_indices: torch.Tensor,
     *,
-    lower_bound: float | None = -5.0,
+    gate_transform: Literal["bounded", "softplus"] = "bounded",
+    lower_bound: float = -5.0,
     scale: float | None = None,
+    out: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Run one-token paged KDA decode with preprocessing fused into the recurrence.
 
     Args:
-        packed_qkv: Post-convolution QKV shaped ``[B, H * (2 * K + V)]``. Channels
-            are head-interleaved: each head stores its Q row, K row, then V row.
+        packed_qkv: Post-convolution QKV shaped ``[B, H * (2 * K + V)]``. Each
+            token stores ``[Q for all heads | K for all heads | V for all heads]``;
+            within each section, head rows are contiguous.
         raw_gate: Unactivated gate shaped ``[1, B, H, K]``.
         raw_beta: Unactivated write gate shaped ``[1, B, H]``.
-        A_log: Per-head log decay parameter shaped ``[H]``.
-        dt_bias: Per-head/channel gate bias shaped ``[H, K]``.
-        state_cache: FP32 paged state pool shaped ``[num_slots, H, K, V]``. Slots
-            may have padding between them but each ``[H, K, V]`` row must be dense.
-        state_indices: Contiguous int32 slot indices shaped ``[B]``. Positive slots
-            are updated in place; non-positive entries produce zero output and leave
-            the state cache untouched.
-        lower_bound: Negative bound for ``lower_bound * sigmoid(exp(A_log) * gate)``.
-            When ``None``, use ``-exp(A_log) * softplus(gate)`` instead.
+        A_log: FP32 per-head log decay parameter shaped ``[H]``.
+        dt_bias: FP32 per-head/channel gate bias shaped ``[H, K]``.
+        state_cache: FP32 paged state pool shaped ``[num_slots, H, V, K]``. Slots
+            may have padding between them but each ``[H, V, K]`` row must be dense.
+            ``K`` must be at most 256.
+            The prefill kernel uses ``[H, K, V]``, while this decode kernel uses
+            ``[H, V, K]`` because decode benefits significantly from a contiguous
+            ``K`` dimension. A prefill-to-decode transition therefore requires a
+            transpose/layout conversion.
+        state_indices: Contiguous int32 slot indices shaped ``[B]``. Non-positive
+            indices are padding/null entries: they produce zero output and leave the
+            cache untouched. Each positive index must be in ``[1, num_slots)`` and
+            unique among active rows because duplicate in-place updates race. These
+            value constraints are caller responsibilities and are not host-validated.
+        gate_transform: Pointwise gate transform. ``"bounded"`` computes
+            ``lower_bound * sigmoid(exp(A_log) * (raw_gate + dt_bias))``;
+            ``"softplus"`` computes
+            ``-exp(A_log) * softplus(raw_gate + dt_bias)``.
+        lower_bound: Finite nonpositive bound used only by the ``"bounded"`` transform.
         scale: Query scale. Defaults to ``1 / sqrt(K)``.
+        out: Optional caller-owned contiguous output buffer shaped ``[1, B, H, V]``
+            in ``packed_qkv.dtype`` on the same device. When supplied, the kernel
+            writes into and returns this exact tensor. It must not alias any input.
 
     Returns:
-        Decode output shaped ``[1, B, H, V]`` in ``packed_qkv.dtype``.
+        Decode output shaped ``[1, B, H, V]`` in ``packed_qkv.dtype``. This is
+        ``out`` itself when a buffer is supplied.
 
     Q/K L2 normalization, gate activation, beta sigmoid, the recurrent update, and
     the output projection from recurrent state are performed in one Triton kernel.
@@ -305,8 +337,8 @@ def recurrent_kda_decode(
     if packed_qkv.ndim != 2 or packed_qkv.shape[0] < 1 or packed_qkv.stride(1) != 1:
         raise ValueError("packed_qkv must have shape [B, C] and be contiguous within each token")
     if state_cache.ndim != 4:
-        raise ValueError("state_cache must have shape [num_slots, H, K, V]")
-    num_slots, heads, key_dim, value_dim = state_cache.shape
+        raise ValueError("state_cache must have shape [num_slots, H, V, K]")
+    num_slots, heads, value_dim, key_dim = state_cache.shape
     batch = packed_qkv.shape[0]
     if num_slots < 1 or heads < 1 or key_dim < 1 or value_dim < 1:
         raise ValueError(
@@ -324,15 +356,19 @@ def recurrent_kda_decode(
         )
     if raw_beta.shape != (1, batch, heads) or raw_beta.stride(2) != 1:
         raise ValueError(f"raw_beta must have shape {(1, batch, heads)} with contiguous heads")
-    if A_log.shape != (heads,) or not A_log.is_contiguous():
-        raise ValueError(f"A_log must be contiguous with shape ({heads},)")
-    if dt_bias.shape != (heads, key_dim) or not dt_bias.is_contiguous():
-        raise ValueError(f"dt_bias must be contiguous with shape ({heads}, {key_dim})")
+    if A_log.shape != (heads,) or A_log.dtype != torch.float32 or not A_log.is_contiguous():
+        raise ValueError(f"A_log must be contiguous float32 with shape ({heads},)")
+    if (
+        dt_bias.shape != (heads, key_dim)
+        or dt_bias.dtype != torch.float32
+        or not dt_bias.is_contiguous()
+    ):
+        raise ValueError(f"dt_bias must be contiguous float32 with shape ({heads}, {key_dim})")
     if state_cache.dtype != torch.float32:
         raise TypeError("state_cache must use float32")
-    expected_state_strides = (key_dim * value_dim, value_dim, 1)
+    expected_state_strides = (value_dim * key_dim, key_dim, 1)
     if state_cache.stride()[1:] != expected_state_strides:
-        raise TypeError("state_cache must be contiguous within each [H, K, V] slot")
+        raise TypeError("state_cache must be contiguous within each [H, V, K] slot")
     if state_cache.stride(0) < heads * key_dim * value_dim:
         raise ValueError("state_cache slots must not overlap")
     if (
@@ -341,29 +377,58 @@ def recurrent_kda_decode(
         or not state_indices.is_contiguous()
     ):
         raise ValueError(f"state_indices must be contiguous int32 with shape ({batch},)")
+    if key_dim > 256:
+        raise ValueError(f"recurrent_kda_decode requires K in [1, 256], got {key_dim}")
 
     device = packed_qkv.device
     data_tensors = (packed_qkv, raw_gate, raw_beta, A_log, dt_bias)
     if any(tensor.device != device for tensor in (*data_tensors, state_cache, state_indices)):
         raise ValueError("all recurrent_kda_decode inputs must be on the same device")
-    if any(tensor.dtype not in SUPPORTED_INPUT_DTYPES for tensor in data_tensors):
+    activation_tensors = (packed_qkv, raw_gate, raw_beta)
+    if any(tensor.dtype not in SUPPORTED_INPUT_DTYPES for tensor in activation_tensors):
         supported = ", ".join(str(dtype) for dtype in SUPPORTED_INPUT_DTYPES)
-        raise TypeError(f"decode data inputs must use one of {supported}")
+        raise TypeError(f"decode activation inputs must use one of {supported}")
 
-    if lower_bound is not None:
+    use_lower_bound = _resolve_decode_gate_transform(gate_transform)
+    if use_lower_bound:
         if not isinstance(lower_bound, Real) or isinstance(lower_bound, bool):
-            raise TypeError("lower_bound must be a real scalar or None")
+            raise TypeError("lower_bound must be a real scalar")
         lower_bound = float(lower_bound)
-        if not math.isfinite(lower_bound) or lower_bound >= 0:
-            raise ValueError(f"lower_bound must be finite and negative, got {lower_bound}")
+        if (
+            lower_bound != lower_bound  # noqa: PLR0124 - compile-safe NaN check
+            or lower_bound < -sys.float_info.max
+            or lower_bound > 0
+        ):
+            raise ValueError(f"lower_bound must be finite and nonpositive, got {lower_bound}")
+    else:
+        lower_bound = 0.0
     if scale is None:
         scale = key_dim**-0.5
     elif not isinstance(scale, Real) or isinstance(scale, bool):
         raise TypeError("scale must be a real scalar or None")
     else:
         scale = float(scale)
-        if not math.isfinite(scale) or scale <= 0:
+        if (
+            scale != scale  # noqa: PLR0124 - compile-safe NaN check
+            or scale <= 0
+            or scale > sys.float_info.max
+        ):
             raise ValueError(f"scale must be finite and positive, got {scale}")
+
+    expected_output_shape = (1, batch, heads, value_dim)
+    if out is None:
+        out = packed_qkv.new_empty(expected_output_shape)
+    else:
+        if out.shape != expected_output_shape:
+            raise ValueError(
+                f"out must have shape {expected_output_shape}, got {tuple(out.shape)}"
+            )
+        if out.dtype != packed_qkv.dtype:
+            raise TypeError(f"out must use packed_qkv.dtype ({packed_qkv.dtype}), got {out.dtype}")
+        if out.device != device:
+            raise ValueError("out must be on packed_qkv.device")
+        if not out.is_contiguous():
+            raise ValueError("out must be contiguous")
 
     return _fused_recurrent_decode_forward(
         packed_qkv,
@@ -373,8 +438,9 @@ def recurrent_kda_decode(
         dt_bias,
         state_cache,
         state_indices,
-        0.0 if lower_bound is None else lower_bound,
-        lower_bound is not None,
+        out,
+        lower_bound,
+        use_lower_bound,
         scale,
     )
 

--- a/attn_gym/linear/kda/api.py
+++ b/attn_gym/linear/kda/api.py
@@ -12,7 +12,9 @@ inference prefill. Use ``impl`` to select fused kernels or the eager reference.
 
 from __future__ import annotations
 
+import math
 from functools import partial
+from numbers import Real
 
 import torch
 
@@ -20,8 +22,9 @@ from attn_gym.linear.kda.constants import LOG2_E
 from attn_gym.linear.kda.impl.fused import chunk_forward as _fused_chunk_forward
 from attn_gym.linear.kda.impl.reference import reference_kda
 from attn_gym.linear.kda.naive import naive_chunk_kda, naive_recurrent_kda
+from attn_gym.linear.kda.ops import recurrent_decode_forward as _fused_recurrent_decode_forward
 from attn_gym.linear.kda.ops import recurrent_forward as _fused_recurrent_forward
-from attn_gym.linear.kda.validation import validate_kda_inputs
+from attn_gym.linear.kda.validation import SUPPORTED_INPUT_DTYPES, validate_kda_inputs
 from attn_gym.linear.types import Impl, resolve_impl
 
 _CHUNK_SIZE = 64
@@ -262,4 +265,118 @@ def recurrent_kda(
     )
 
 
-__all__ = ["Impl", "chunk_kda", "recurrent_kda"]
+def recurrent_kda_decode(
+    packed_qkv: torch.Tensor,
+    raw_gate: torch.Tensor,
+    raw_beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    state_cache: torch.Tensor,
+    state_indices: torch.Tensor,
+    *,
+    lower_bound: float | None = -5.0,
+    scale: float | None = None,
+) -> torch.Tensor:
+    """Run one-token paged KDA decode with preprocessing fused into the recurrence.
+
+    Args:
+        packed_qkv: Post-convolution QKV shaped ``[B, H * (2 * K + V)]``. Channels
+            are head-interleaved: each head stores its Q row, K row, then V row.
+        raw_gate: Unactivated gate shaped ``[1, B, H, K]``.
+        raw_beta: Unactivated write gate shaped ``[1, B, H]``.
+        A_log: Per-head log decay parameter shaped ``[H]``.
+        dt_bias: Per-head/channel gate bias shaped ``[H, K]``.
+        state_cache: FP32 paged state pool shaped ``[num_slots, H, K, V]``. Slots
+            may have padding between them but each ``[H, K, V]`` row must be dense.
+        state_indices: Contiguous int32 slot indices shaped ``[B]``. Positive slots
+            are updated in place; non-positive entries produce zero output and leave
+            the state cache untouched.
+        lower_bound: Negative bound for ``lower_bound * sigmoid(exp(A_log) * gate)``.
+            When ``None``, use ``-exp(A_log) * softplus(gate)`` instead.
+        scale: Query scale. Defaults to ``1 / sqrt(K)``.
+
+    Returns:
+        Decode output shaped ``[1, B, H, V]`` in ``packed_qkv.dtype``.
+
+    Q/K L2 normalization, gate activation, beta sigmoid, the recurrent update, and
+    the output projection from recurrent state are performed in one Triton kernel.
+    The operation is inference-only and advances ``state_cache`` in place.
+    """
+    if packed_qkv.ndim != 2 or packed_qkv.shape[0] < 1 or packed_qkv.stride(1) != 1:
+        raise ValueError("packed_qkv must have shape [B, C] and be contiguous within each token")
+    if state_cache.ndim != 4:
+        raise ValueError("state_cache must have shape [num_slots, H, K, V]")
+    num_slots, heads, key_dim, value_dim = state_cache.shape
+    batch = packed_qkv.shape[0]
+    if num_slots < 1 or heads < 1 or key_dim < 1 or value_dim < 1:
+        raise ValueError(
+            f"state_cache must have nonempty dimensions, got {tuple(state_cache.shape)}"
+        )
+    expected_channels = heads * (2 * key_dim + value_dim)
+    if packed_qkv.shape[1] != expected_channels:
+        raise ValueError(
+            f"packed_qkv must have shape ({batch}, {expected_channels}), "
+            f"got {tuple(packed_qkv.shape)}"
+        )
+    if raw_gate.shape != (1, batch, heads, key_dim) or raw_gate.stride()[2:] != (key_dim, 1):
+        raise ValueError(
+            f"raw_gate must have shape {(1, batch, heads, key_dim)} and dense [H, K] rows"
+        )
+    if raw_beta.shape != (1, batch, heads) or raw_beta.stride(2) != 1:
+        raise ValueError(f"raw_beta must have shape {(1, batch, heads)} with contiguous heads")
+    if A_log.shape != (heads,) or not A_log.is_contiguous():
+        raise ValueError(f"A_log must be contiguous with shape ({heads},)")
+    if dt_bias.shape != (heads, key_dim) or not dt_bias.is_contiguous():
+        raise ValueError(f"dt_bias must be contiguous with shape ({heads}, {key_dim})")
+    if state_cache.dtype != torch.float32:
+        raise TypeError("state_cache must use float32")
+    expected_state_strides = (key_dim * value_dim, value_dim, 1)
+    if state_cache.stride()[1:] != expected_state_strides:
+        raise TypeError("state_cache must be contiguous within each [H, K, V] slot")
+    if state_cache.stride(0) < heads * key_dim * value_dim:
+        raise ValueError("state_cache slots must not overlap")
+    if (
+        state_indices.shape != (batch,)
+        or state_indices.dtype != torch.int32
+        or not state_indices.is_contiguous()
+    ):
+        raise ValueError(f"state_indices must be contiguous int32 with shape ({batch},)")
+
+    device = packed_qkv.device
+    data_tensors = (packed_qkv, raw_gate, raw_beta, A_log, dt_bias)
+    if any(tensor.device != device for tensor in (*data_tensors, state_cache, state_indices)):
+        raise ValueError("all recurrent_kda_decode inputs must be on the same device")
+    if any(tensor.dtype not in SUPPORTED_INPUT_DTYPES for tensor in data_tensors):
+        supported = ", ".join(str(dtype) for dtype in SUPPORTED_INPUT_DTYPES)
+        raise TypeError(f"decode data inputs must use one of {supported}")
+
+    if lower_bound is not None:
+        if not isinstance(lower_bound, Real) or isinstance(lower_bound, bool):
+            raise TypeError("lower_bound must be a real scalar or None")
+        lower_bound = float(lower_bound)
+        if not math.isfinite(lower_bound) or lower_bound >= 0:
+            raise ValueError(f"lower_bound must be finite and negative, got {lower_bound}")
+    if scale is None:
+        scale = key_dim**-0.5
+    elif not isinstance(scale, Real) or isinstance(scale, bool):
+        raise TypeError("scale must be a real scalar or None")
+    else:
+        scale = float(scale)
+        if not math.isfinite(scale) or scale <= 0:
+            raise ValueError(f"scale must be finite and positive, got {scale}")
+
+    return _fused_recurrent_decode_forward(
+        packed_qkv,
+        raw_gate,
+        raw_beta,
+        A_log,
+        dt_bias,
+        state_cache,
+        state_indices,
+        0.0 if lower_bound is None else lower_bound,
+        lower_bound is not None,
+        scale,
+    )
+
+
+__all__ = ["Impl", "chunk_kda", "recurrent_kda", "recurrent_kda_decode"]

--- a/attn_gym/linear/kda/fwd/triton/recurrent.py
+++ b/attn_gym/linear/kda/fwd/triton/recurrent.py
@@ -20,6 +20,8 @@ import triton
 import triton.language as tl
 
 from attn_gym._backends.triton.utils import ptr_offset
+from attn_gym.linear.kda.ops import recurrent_decode_forward as decode_forward
+from attn_gym.linear.kda.ops import recurrent_decode_op as _recurrent_decode_op
 from attn_gym.linear.kda.ops import recurrent_forward as forward
 from attn_gym.linear.kda.ops import (
     recurrent_fwd_no_state_op as _recurrent_fwd_no_state_op,
@@ -150,6 +152,82 @@ kda_recurrent_fwd_kernel = triton.autotune(
     prune_configs_by={"early_config_prune": _prune_recurrent_configs},
     **autotune_cache_kwargs,
 )(_kda_recurrent_fwd_kernel)
+
+
+@triton.jit
+def kda_recurrent_decode_kernel(
+    packed_qkv,
+    raw_gate,
+    raw_beta,
+    A_log,
+    dt_bias,
+    output,
+    state_cache,
+    state_indices,
+    lower_bound,
+    scale,
+    state_batch_stride: tl.constexpr,
+    qkv_token_stride: tl.constexpr,
+    gate_token_stride: tl.constexpr,
+    beta_token_stride: tl.constexpr,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    USE_LOWER_BOUND: tl.constexpr,
+):
+    pid = tl.program_id(0).to(tl.int64)
+    NV = tl.cdiv(V, BV)
+    i_v = pid % NV
+    i_nh = pid // NV
+    i_n, i_h = i_nh // H, i_nh % H
+
+    o_k = tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_k = o_k < K
+    m_v = o_v < V
+    m_kv = m_k[:, None] & m_v[None, :]
+
+    i_state = tl.load(state_indices + i_n).to(tl.int64)
+    row = i_n * H + i_h
+    if i_state <= 0:
+        tl.store(output + row * V + o_v, 0.0, mask=m_v)
+        return
+
+    p_state = i_state * state_batch_stride + i_h * K * V + o_k[:, None] * V + o_v[None, :]
+    b_state = tl.load(state_cache + p_state, mask=m_kv, other=0.0).to(tl.float32)
+
+    head_offset = i_h * (2 * K + V)
+    p_qkv = packed_qkv + i_n * qkv_token_stride + head_offset
+    b_q = tl.load(p_qkv + o_k, mask=m_k, other=0.0).to(tl.float32)
+    b_k = tl.load(p_qkv + K + o_k, mask=m_k, other=0.0).to(tl.float32)
+    b_v = tl.load(p_qkv + 2 * K + o_v, mask=m_v, other=0.0).to(tl.float32)
+    b_q *= tl.rsqrt(tl.sum(b_q * b_q) + 1e-6) * scale
+    b_k *= tl.rsqrt(tl.sum(b_k * b_k) + 1e-6)
+
+    p_gate = raw_gate + i_n * gate_token_stride + i_h * K + o_k
+    b_gate_input = tl.load(p_gate, mask=m_k, other=0.0).to(tl.float32)
+    b_gate_input += tl.load(dt_bias + i_h * K + o_k, mask=m_k, other=0.0).to(tl.float32)
+    b_a = tl.exp(tl.load(A_log + i_h).to(tl.float32))
+    if USE_LOWER_BOUND:
+        b_gate = lower_bound * tl.sigmoid(b_a * b_gate_input)
+    else:
+        b_softplus = tl.where(
+            b_gate_input > 20.0,
+            b_gate_input,
+            tl.log(1.0 + tl.exp(b_gate_input)),
+        )
+        b_gate = -b_a * b_softplus
+
+    b_state *= tl.exp(b_gate)[:, None]
+    b_delta = b_v - tl.sum(b_k[:, None] * b_state, 0)
+    b_beta = tl.sigmoid(tl.load(raw_beta + i_n * beta_token_stride + i_h).to(tl.float32))
+    b_delta *= b_beta
+    b_state += b_k[:, None] * b_delta[None, :]
+    b_o = tl.sum(b_q[:, None] * b_state, 0)
+    tl.store(output + row * V + o_v, b_o.to(output.dtype.element_ty), mask=m_v)
+    tl.store(state_cache + p_state, b_state, mask=m_kv)
 
 
 def _launch_recurrent_fwd(
@@ -314,9 +392,54 @@ def _kda_recurrent_fwd_paged_cuda(
     )[0]
 
 
+def _kda_recurrent_decode_cuda(
+    packed_qkv: torch.Tensor,
+    raw_gate: torch.Tensor,
+    raw_beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    state_cache: torch.Tensor,
+    state_indices: torch.Tensor,
+    lower_bound: float,
+    use_lower_bound: bool,
+    scale: float,
+) -> torch.Tensor:
+    batch = packed_qkv.shape[0]
+    heads, key_dim, value_dim = state_cache.shape[1:]
+    output = packed_qkv.new_empty(1, batch, heads, value_dim)
+    block_v = min(triton.next_power_of_2(value_dim), 32)
+    grid = (triton.cdiv(value_dim, block_v) * batch * heads,)
+    kda_recurrent_decode_kernel[grid](
+        packed_qkv,
+        raw_gate,
+        raw_beta,
+        A_log,
+        dt_bias,
+        output,
+        state_cache,
+        state_indices,
+        lower_bound,
+        scale=scale,
+        state_batch_stride=state_cache.stride(0),
+        qkv_token_stride=packed_qkv.stride(0),
+        gate_token_stride=raw_gate.stride(1),
+        beta_token_stride=raw_beta.stride(1),
+        H=heads,
+        K=key_dim,
+        V=value_dim,
+        BK=triton.next_power_of_2(key_dim),
+        BV=block_v,
+        USE_LOWER_BOUND=use_lower_bound,
+        num_warps=4,
+    )
+    return output
+
+
 __all__ = [
+    "_recurrent_decode_op",
     "_recurrent_fwd_no_state_op",
     "_recurrent_fwd_op",
     "_recurrent_fwd_paged_op",
+    "decode_forward",
     "forward",
 ]

--- a/attn_gym/linear/kda/fwd/triton/recurrent.py
+++ b/attn_gym/linear/kda/fwd/triton/recurrent.py
@@ -154,6 +154,9 @@ kda_recurrent_fwd_kernel = triton.autotune(
 )(_kda_recurrent_fwd_kernel)
 
 
+# Use a flat 1D grid of B * H * ceil(V / BV) programs. Each program owns one
+# (batch row, head, V tile), processes all K channels for that tile, and gets
+# contiguous K-dimension accesses from the [V, K] state layout.
 @triton.jit
 def kda_recurrent_decode_kernel(
     packed_qkv,
@@ -187,7 +190,7 @@ def kda_recurrent_decode_kernel(
     o_v = i_v * BV + tl.arange(0, BV)
     m_k = o_k < K
     m_v = o_v < V
-    m_kv = m_k[:, None] & m_v[None, :]
+    m_vk = m_v[:, None] & m_k[None, :]
 
     i_state = tl.load(state_indices + i_n).to(tl.int64)
     row = i_n * H + i_h
@@ -195,14 +198,13 @@ def kda_recurrent_decode_kernel(
         tl.store(output + row * V + o_v, 0.0, mask=m_v)
         return
 
-    p_state = i_state * state_batch_stride + i_h * K * V + o_k[:, None] * V + o_v[None, :]
-    b_state = tl.load(state_cache + p_state, mask=m_kv, other=0.0).to(tl.float32)
+    p_state = i_state * state_batch_stride + i_h * V * K + o_v[:, None] * K + o_k[None, :]
+    b_state = tl.load(state_cache + p_state, mask=m_vk, other=0.0).to(tl.float32)
 
-    head_offset = i_h * (2 * K + V)
-    p_qkv = packed_qkv + i_n * qkv_token_stride + head_offset
-    b_q = tl.load(p_qkv + o_k, mask=m_k, other=0.0).to(tl.float32)
-    b_k = tl.load(p_qkv + K + o_k, mask=m_k, other=0.0).to(tl.float32)
-    b_v = tl.load(p_qkv + 2 * K + o_v, mask=m_v, other=0.0).to(tl.float32)
+    p_qkv = packed_qkv + i_n * qkv_token_stride
+    b_q = tl.load(p_qkv + i_h * K + o_k, mask=m_k, other=0.0).to(tl.float32)
+    b_k = tl.load(p_qkv + H * K + i_h * K + o_k, mask=m_k, other=0.0).to(tl.float32)
+    b_v = tl.load(p_qkv + 2 * H * K + i_h * V + o_v, mask=m_v, other=0.0).to(tl.float32)
     b_q *= tl.rsqrt(tl.sum(b_q * b_q) + 1e-6) * scale
     b_k *= tl.rsqrt(tl.sum(b_k * b_k) + 1e-6)
 
@@ -216,18 +218,22 @@ def kda_recurrent_decode_kernel(
         b_softplus = tl.where(
             b_gate_input > 20.0,
             b_gate_input,
-            tl.log(1.0 + tl.exp(b_gate_input)),
+            tl.where(
+                b_gate_input < -10.0,
+                tl.exp(b_gate_input),
+                tl.log(1.0 + tl.exp(b_gate_input)),
+            ),
         )
         b_gate = -b_a * b_softplus
 
-    b_state *= tl.exp(b_gate)[:, None]
-    b_delta = b_v - tl.sum(b_k[:, None] * b_state, 0)
+    b_state *= tl.exp(b_gate)[None, :]
+    b_delta = b_v - tl.sum(b_state * b_k[None, :], axis=1)
     b_beta = tl.sigmoid(tl.load(raw_beta + i_n * beta_token_stride + i_h).to(tl.float32))
     b_delta *= b_beta
-    b_state += b_k[:, None] * b_delta[None, :]
-    b_o = tl.sum(b_q[:, None] * b_state, 0)
+    b_state += b_delta[:, None] * b_k[None, :]
+    b_o = tl.sum(b_state * b_q[None, :], axis=1)
     tl.store(output + row * V + o_v, b_o.to(output.dtype.element_ty), mask=m_v)
-    tl.store(state_cache + p_state, b_state, mask=m_kv)
+    tl.store(state_cache + p_state, b_state, mask=m_vk)
 
 
 def _launch_recurrent_fwd(
@@ -400,14 +406,25 @@ def _kda_recurrent_decode_cuda(
     dt_bias: torch.Tensor,
     state_cache: torch.Tensor,
     state_indices: torch.Tensor,
+    output: torch.Tensor,
     lower_bound: float,
     use_lower_bound: bool,
     scale: float,
-) -> torch.Tensor:
+) -> None:
+    read_only_inputs = (packed_qkv, raw_gate, raw_beta, A_log, dt_bias, state_indices)
+    if any(torch._C._overlaps(output, tensor) for tensor in (*read_only_inputs, state_cache)):
+        raise ValueError("out must not alias any recurrent_kda_decode input")
+    if any(torch._C._overlaps(state_cache, tensor) for tensor in read_only_inputs):
+        raise ValueError("state_cache must not alias recurrent_kda_decode read-only inputs")
+
     batch = packed_qkv.shape[0]
-    heads, key_dim, value_dim = state_cache.shape[1:]
-    output = packed_qkv.new_empty(1, batch, heads, value_dim)
-    block_v = min(triton.next_power_of_2(value_dim), 32)
+    heads, value_dim, key_dim = state_cache.shape[1:]
+    if value_dim <= 32:
+        block_v, num_warps = min(triton.next_power_of_2(value_dim), 8), 4
+    elif batch * heads <= 8:
+        block_v, num_warps = min(triton.next_power_of_2(value_dim), 16), 2
+    else:
+        block_v, num_warps = min(triton.next_power_of_2(value_dim), 16), 1
     grid = (triton.cdiv(value_dim, block_v) * batch * heads,)
     kda_recurrent_decode_kernel[grid](
         packed_qkv,
@@ -430,9 +447,8 @@ def _kda_recurrent_decode_cuda(
         BK=triton.next_power_of_2(key_dim),
         BV=block_v,
         USE_LOWER_BOUND=use_lower_bound,
-        num_warps=4,
+        num_warps=num_warps,
     )
-    return output
 
 
 __all__ = [

--- a/attn_gym/linear/kda/ops.py
+++ b/attn_gym/linear/kda/ops.py
@@ -88,6 +88,12 @@ torch.library.define(
     " Tensor state_indices, Tensor? cu_seqlens, bool autotune) -> Tensor",
 )
 torch.library.define(
+    "attn_gym::kda_recurrent_decode",
+    "(Tensor packed_qkv, Tensor raw_gate, Tensor raw_beta, Tensor A_log, Tensor dt_bias,"
+    " Tensor(a!) state_cache, Tensor state_indices, float lower_bound, bool use_lower_bound,"
+    " float scale) -> Tensor",
+)
+torch.library.define(
     "attn_gym::kda_prepare_chunk_offsets",
     "(Tensor cu_seqlens, SymInt tokens, int chunk_size) -> Tensor",
 )
@@ -262,6 +268,10 @@ def _delta_h_with_state_cuda(*args):
     return _delta_h_backend()._delta_h_with_state_cuda(*args)
 
 
+def _recurrent_decode_cuda(*args):
+    return _recurrent_backend()._kda_recurrent_decode_cuda(*args)
+
+
 def _prepare_chunk_offsets_cuda(*args):
     from attn_gym.linear.kda.chunk_scheduler import _prepare_ragged_chunk_offsets
 
@@ -295,6 +305,11 @@ torch.library.impl(
     "attn_gym::kda_recurrent_fwd_paged",
     "CUDA",
     _recurrent_fwd_paged_cuda,
+)
+torch.library.impl(
+    "attn_gym::kda_recurrent_decode",
+    "CUDA",
+    _recurrent_decode_cuda,
 )
 torch.library.impl(
     "attn_gym::kda_prepare_chunk_offsets",
@@ -534,6 +549,23 @@ def _recurrent_fwd_paged_fake(
     return torch.empty_like(v, dtype=q.dtype)
 
 
+@torch.library.register_fake("attn_gym::kda_recurrent_decode")
+def _recurrent_decode_fake(
+    packed_qkv: torch.Tensor,
+    raw_gate: torch.Tensor,
+    raw_beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    state_cache: torch.Tensor,
+    state_indices: torch.Tensor,
+    lower_bound: float,
+    use_lower_bound: bool,
+    scale: float,
+) -> torch.Tensor:
+    del raw_gate, raw_beta, A_log, dt_bias, state_indices, lower_bound, use_lower_bound, scale
+    return packed_qkv.new_empty(1, packed_qkv.shape[0], state_cache.shape[1], state_cache.shape[3])
+
+
 @torch.library.register_fake("attn_gym::kda_prepare_chunk_offsets")
 def _prepare_chunk_offsets_fake(
     cu_seqlens: torch.Tensor,
@@ -598,6 +630,7 @@ _bound_gate_bwd_op = torch.ops.attn_gym._kda_bound_gate_bwd.default
 recurrent_fwd_op = torch.ops.attn_gym.kda_recurrent_fwd.default
 recurrent_fwd_no_state_op = torch.ops.attn_gym.kda_recurrent_fwd_no_state.default
 recurrent_fwd_paged_op = torch.ops.attn_gym.kda_recurrent_fwd_paged.default
+recurrent_decode_op = torch.ops.attn_gym.kda_recurrent_decode.default
 prepare_chunk_offsets_op = torch.ops.attn_gym.kda_prepare_chunk_offsets.default
 delta_h_op = torch.ops.attn_gym.kda_delta_h.default
 delta_h_with_state_op = torch.ops.attn_gym.kda_delta_h_with_state.default
@@ -655,6 +688,41 @@ def recurrent_forward(
     ), None
 
 
+def recurrent_decode_forward(
+    packed_qkv: torch.Tensor,
+    raw_gate: torch.Tensor,
+    raw_beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    state_cache: torch.Tensor,
+    state_indices: torch.Tensor,
+    lower_bound: float,
+    use_lower_bound: bool,
+    scale: float,
+) -> torch.Tensor:
+    """Invoke the lazily loaded fused decode implementation."""
+    if not packed_qkv.is_cuda:
+        raise ValueError("recurrent_kda_decode requires CUDA tensors")
+    data_tensors = (packed_qkv, raw_gate, raw_beta, A_log, dt_bias, state_cache)
+    if torch.is_grad_enabled() and any(tensor.requires_grad for tensor in data_tensors):
+        raise RuntimeError(
+            "recurrent_kda_decode is inference-only and has no backward; "
+            "call under torch.no_grad() / torch.inference_mode()"
+        )
+    return recurrent_decode_op(
+        packed_qkv,
+        raw_gate,
+        raw_beta,
+        A_log,
+        dt_bias,
+        state_cache,
+        state_indices,
+        lower_bound,
+        use_lower_bound,
+        scale,
+    )
+
+
 __all__ = [
     "chunk_bwd_op",
     "chunk_bwd_with_state_grad_op",
@@ -665,6 +733,8 @@ __all__ = [
     "delta_h_op",
     "delta_h_with_state_op",
     "prepare_chunk_offsets_op",
+    "recurrent_decode_forward",
+    "recurrent_decode_op",
     "recurrent_forward",
     "recurrent_fwd_no_state_op",
     "recurrent_fwd_op",

--- a/attn_gym/linear/kda/ops.py
+++ b/attn_gym/linear/kda/ops.py
@@ -90,8 +90,8 @@ torch.library.define(
 torch.library.define(
     "attn_gym::kda_recurrent_decode",
     "(Tensor packed_qkv, Tensor raw_gate, Tensor raw_beta, Tensor A_log, Tensor dt_bias,"
-    " Tensor(a!) state_cache, Tensor state_indices, float lower_bound, bool use_lower_bound,"
-    " float scale) -> Tensor",
+    " Tensor(a!) state_cache, Tensor state_indices, Tensor(b!) out, float lower_bound,"
+    " bool use_lower_bound, float scale) -> ()",
 )
 torch.library.define(
     "attn_gym::kda_prepare_chunk_offsets",
@@ -558,12 +558,24 @@ def _recurrent_decode_fake(
     dt_bias: torch.Tensor,
     state_cache: torch.Tensor,
     state_indices: torch.Tensor,
+    out: torch.Tensor,
     lower_bound: float,
     use_lower_bound: bool,
     scale: float,
-) -> torch.Tensor:
-    del raw_gate, raw_beta, A_log, dt_bias, state_indices, lower_bound, use_lower_bound, scale
-    return packed_qkv.new_empty(1, packed_qkv.shape[0], state_cache.shape[1], state_cache.shape[3])
+) -> None:
+    del (
+        packed_qkv,
+        raw_gate,
+        raw_beta,
+        A_log,
+        dt_bias,
+        state_cache,
+        state_indices,
+        out,
+        lower_bound,
+        use_lower_bound,
+        scale,
+    )
 
 
 @torch.library.register_fake("attn_gym::kda_prepare_chunk_offsets")
@@ -696,6 +708,7 @@ def recurrent_decode_forward(
     dt_bias: torch.Tensor,
     state_cache: torch.Tensor,
     state_indices: torch.Tensor,
+    out: torch.Tensor,
     lower_bound: float,
     use_lower_bound: bool,
     scale: float,
@@ -703,13 +716,13 @@ def recurrent_decode_forward(
     """Invoke the lazily loaded fused decode implementation."""
     if not packed_qkv.is_cuda:
         raise ValueError("recurrent_kda_decode requires CUDA tensors")
-    data_tensors = (packed_qkv, raw_gate, raw_beta, A_log, dt_bias, state_cache)
+    data_tensors = (packed_qkv, raw_gate, raw_beta, A_log, dt_bias, state_cache, out)
     if torch.is_grad_enabled() and any(tensor.requires_grad for tensor in data_tensors):
         raise RuntimeError(
             "recurrent_kda_decode is inference-only and has no backward; "
             "call under torch.no_grad() / torch.inference_mode()"
         )
-    return recurrent_decode_op(
+    recurrent_decode_op(
         packed_qkv,
         raw_gate,
         raw_beta,
@@ -717,10 +730,12 @@ def recurrent_decode_forward(
         dt_bias,
         state_cache,
         state_indices,
+        out,
         lower_bound,
         use_lower_bound,
         scale,
     )
+    return out
 
 
 __all__ = [

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -258,12 +258,15 @@ dimension, and stays differentiable. There is no automatic fallback between the 
 the chunk-versus-recurrent switch is caller policy (on B200 the scan wins below roughly
 32 tokens per sequence).
 
-The serving limitations listed under `recurrent_kda` below are deliberate and
-the contract is otherwise stable to build against; CUDA-graph capture amortizes
-the multi-launch decode step.
+`recurrent_kda_decode` is the serving-specific one-token path. It consumes
+head-interleaved post-convolution QKV, raw gate and beta projections, and a paged
+state cache. Q/K normalization, gate activation, beta sigmoid, recurrence, output,
+and state-cache update run in one Triton kernel.
 
 ::: attn_gym.linear.chunk_kda
 
 ::: attn_gym.linear.recurrent_kda
+
+::: attn_gym.linear.recurrent_kda_decode
 
 ::: attn_gym.linear.Impl

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -259,9 +259,11 @@ the chunk-versus-recurrent switch is caller policy (on B200 the scan wins below 
 32 tokens per sequence).
 
 `recurrent_kda_decode` is the serving-specific one-token path. It consumes
-head-interleaved post-convolution QKV, raw gate and beta projections, and a paged
-state cache. Q/K normalization, gate activation, beta sigmoid, recurrence, output,
-and state-cache update run in one Triton kernel.
+channel-major post-convolution QKV (`[Q for all heads | K for all heads | V for all
+heads]`), raw gate and beta projections, and a paged state cache. Q/K normalization,
+gate activation, beta sigmoid, recurrence, output, and state-cache update run in one
+Triton kernel. Callers may provide a stable output buffer for allocation-free CUDA
+Graph replay.
 
 ::: attn_gym.linear.chunk_kda
 

--- a/test/test_kda_imports.py
+++ b/test/test_kda_imports.py
@@ -45,6 +45,7 @@ def test_reference_api_imports_without_optional_kernel_dependencies():
             mask_inactive_token_gradients,
             mask_inactive_tokens,
             recurrent_kda,
+            recurrent_kda_decode,
         )
         from attn_gym.linear.kda import bound_gate
 
@@ -75,6 +76,7 @@ def test_reference_api_imports_without_optional_kernel_dependencies():
         assert not hasattr(linear, 'bounded_gate_cumsum')
         recurrent_kda(q, k, v, gate, beta, impl='reference')
         chunk_kda(q, k, v, gate, beta, impl='reference')
+        assert callable(recurrent_kda_decode)
         """
     )
 

--- a/test/test_kda_recurrent_decode.py
+++ b/test/test_kda_recurrent_decode.py
@@ -34,7 +34,7 @@ def _strided_state_pool(
     storage = torch.randn(
         num_slots, prefix + state_elements + suffix, device="cuda", dtype=torch.float32
     )
-    state = storage[:, prefix : prefix + state_elements].view(num_slots, heads, key_dim, value_dim)
+    state = storage[:, prefix : prefix + state_elements].view(num_slots, heads, value_dim, key_dim)
     assert not state.is_contiguous()
     return storage, state
 
@@ -49,13 +49,10 @@ def _decode_inputs(
     seed: int = 0,
 ):
     torch.manual_seed(seed)
-    packed_qkv = torch.randn(
-        batch,
-        heads,
-        2 * key_dim + value_dim,
-        device="cuda",
-        dtype=dtype,
-    ).flatten(1)
+    q = torch.randn(batch, heads, key_dim, device="cuda", dtype=dtype)
+    k = torch.randn_like(q)
+    v = torch.randn(batch, heads, value_dim, device="cuda", dtype=dtype)
+    packed_qkv = torch.cat((q.flatten(1), k.flatten(1), v.flatten(1)), dim=1)
     raw_gate = torch.randn(1, batch, heads, key_dim, device="cuda", dtype=dtype)
     raw_beta = torch.randn(1, batch, heads, device="cuda", dtype=dtype)
     A_log = 0.1 * torch.randn(heads, device="cuda", dtype=torch.float32)
@@ -82,24 +79,28 @@ def _reference_decode(
     dt_bias: torch.Tensor,
     state_cache: torch.Tensor,
     state_indices: torch.Tensor,
-    lower_bound: float | None,
+    gate_transform: str = "bounded",
+    lower_bound: float = -5.0,
     scale: float | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     batch = packed_qkv.shape[0]
-    heads, key_dim, value_dim = state_cache.shape[1:]
-    per_head = packed_qkv.view(batch, heads, 2 * key_dim + value_dim)
-    q = per_head[..., :key_dim].unsqueeze(1).float()
-    k = per_head[..., key_dim : 2 * key_dim].unsqueeze(1).float()
-    v = per_head[..., 2 * key_dim :].unsqueeze(1)
-    q *= torch.rsqrt(q.square().sum(-1, keepdim=True) + 1e-6)
-    k *= torch.rsqrt(k.square().sum(-1, keepdim=True) + 1e-6)
+    heads, value_dim, key_dim = state_cache.shape[1:]
+    q_flat, k_flat, v_flat = packed_qkv.split(
+        (heads * key_dim, heads * key_dim, heads * value_dim), dim=1
+    )
+    q = q_flat.view(batch, heads, key_dim).unsqueeze(1).float()
+    k = k_flat.view(batch, heads, key_dim).unsqueeze(1).float()
+    v = v_flat.view(batch, heads, value_dim).unsqueeze(1)
+    q = q * torch.rsqrt(q.square().sum(-1, keepdim=True) + 1e-6)
+    k = k * torch.rsqrt(k.square().sum(-1, keepdim=True) + 1e-6)
 
     gate_input = raw_gate.float() + dt_bias[None, None]
     decay = A_log.exp()[None, None, :, None]
-    if lower_bound is None:
-        gate = -decay * F.softplus(gate_input)
-    else:
+    if gate_transform == "bounded":
         gate = lower_bound * torch.sigmoid(decay * gate_input)
+    else:
+        assert gate_transform == "softplus"
+        gate = -decay * F.softplus(gate_input)
     gate *= math.log2(math.e)
     beta = raw_beta.float().sigmoid()
 
@@ -115,20 +116,29 @@ def _reference_decode(
             gate[:, active].transpose(0, 1),
             beta[:, active].transpose(0, 1),
             scale=scale,
-            initial_state=state_cache[active_indices],
+            initial_state=state_cache[active_indices].transpose(-1, -2).contiguous(),
             output_final_state=True,
         )
         output[:, active] = active_output.transpose(0, 1).to(output.dtype)
-        expected_cache[active_indices] = active_state
+        expected_cache[active_indices] = active_state.transpose(-1, -2)
     return output, expected_cache
 
 
-@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
-@pytest.mark.parametrize("lower_bound", [-5.0, None])
-@pytest.mark.parametrize(("key_dim", "value_dim"), [(64, 64), (80, 48)])
+@pytest.mark.parametrize(
+    ("dtype", "gate_transform", "lower_bound", "key_dim", "value_dim"),
+    [
+        (torch.float16, "bounded", -5.0, 64, 64),
+        (torch.float16, "softplus", 1.0, 80, 48),
+        (torch.bfloat16, "bounded", -5.0, 80, 48),
+        (torch.bfloat16, "softplus", float("nan"), 64, 64),
+        (torch.float32, "bounded", 0.0, 64, 64),
+        (torch.float32, "softplus", -5.0, 80, 48),
+    ],
+)
 def test_recurrent_decode_matches_reference(
     dtype: torch.dtype,
-    lower_bound: float | None,
+    gate_transform: str,
+    lower_bound: float,
     key_dim: int,
     value_dim: int,
 ):
@@ -144,6 +154,7 @@ def test_recurrent_decode_matches_reference(
         dt_bias,
         state_cache,
         state_indices,
+        gate_transform=gate_transform,
         lower_bound=lower_bound,
     )
     expected, expected_cache = _reference_decode(
@@ -154,6 +165,7 @@ def test_recurrent_decode_matches_reference(
         dt_bias,
         before,
         state_indices,
+        gate_transform,
         lower_bound,
     )
 
@@ -163,10 +175,43 @@ def test_recurrent_decode_matches_reference(
     torch.testing.assert_close(state_cache, expected_cache, rtol=tolerance, atol=tolerance)
 
 
-@pytest.mark.parametrize("padding_slot", [0, -1])
-def test_recurrent_decode_padding_slot_is_ignored(padding_slot: int):
+def test_recurrent_decode_softplus_matches_negative_tail_reference():
+    inputs = _decode_inputs(batch=1, heads=1, key_dim=16, value_dim=8, dtype=torch.float32)
+    packed_qkv, raw_gate, raw_beta, A_log, dt_bias, _, state_cache, state_indices = inputs
+    raw_gate.fill_(-18.0)
+    raw_beta.fill_(-100.0)
+    A_log.fill_(18.0)
+    dt_bias.zero_()
+    before = state_cache.clone()
+    expected, expected_cache = _reference_decode(
+        packed_qkv,
+        raw_gate,
+        raw_beta,
+        A_log,
+        dt_bias,
+        before,
+        state_indices,
+        "softplus",
+    )
+
+    output = recurrent_kda_decode(
+        packed_qkv,
+        raw_gate,
+        raw_beta,
+        A_log,
+        dt_bias,
+        state_cache,
+        state_indices,
+        gate_transform="softplus",
+    )
+
+    torch.testing.assert_close(output, expected, rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(state_cache, expected_cache, rtol=1e-5, atol=1e-5)
+
+
+def test_recurrent_decode_padding_slots_are_ignored():
     inputs = list(_decode_inputs())
-    inputs[-1] = torch.tensor([5, padding_slot, 3], device="cuda", dtype=torch.int32)
+    inputs[-1] = torch.tensor([5, 0, -1], device="cuda", dtype=torch.int32)
     packed_qkv, raw_gate, raw_beta, A_log, dt_bias, _, state_cache, state_indices = inputs
     before = state_cache.clone()
 
@@ -174,12 +219,39 @@ def test_recurrent_decode_padding_slot_is_ignored(padding_slot: int):
         packed_qkv, raw_gate, raw_beta, A_log, dt_bias, state_cache, state_indices
     )
 
-    torch.testing.assert_close(output[:, 1], torch.zeros_like(output[:, 1]), rtol=0, atol=0)
+    torch.testing.assert_close(output[:, 1:], torch.zeros_like(output[:, 1:]), rtol=0, atol=0)
     torch.testing.assert_close(state_cache[0], before[0], rtol=0, atol=0)
 
 
+def test_recurrent_decode_key_dim_boundary():
+    inputs = _decode_inputs(batch=1, heads=1, key_dim=256, value_dim=16, dtype=torch.float32)
+    packed_qkv, raw_gate, raw_beta, A_log, dt_bias, _, state_cache, state_indices = inputs
+    before = state_cache.clone()
+    expected, expected_cache = _reference_decode(
+        packed_qkv, raw_gate, raw_beta, A_log, dt_bias, before, state_indices
+    )
+
+    output = recurrent_kda_decode(
+        packed_qkv, raw_gate, raw_beta, A_log, dt_bias, state_cache, state_indices
+    )
+    torch.testing.assert_close(output, expected, rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(state_cache, expected_cache, rtol=1e-5, atol=1e-5)
+
+    too_large = _decode_inputs(batch=1, heads=1, key_dim=257, value_dim=16)
+    with pytest.raises(ValueError, match=r"K in \[1, 256\]"):
+        recurrent_kda_decode(
+            too_large[0],
+            too_large[1],
+            too_large[2],
+            too_large[3],
+            too_large[4],
+            too_large[6],
+            too_large[7],
+        )
+
+
 def test_recurrent_decode_validates_contract():
-    inputs = list(_decode_inputs(batch=2))
+    inputs = list(_decode_inputs(batch=1, heads=1, key_dim=16, value_dim=8))
     packed_qkv, raw_gate, raw_beta, A_log, dt_bias, _, state_cache, state_indices = inputs
     with pytest.raises(ValueError, match="packed_qkv must have shape"):
         recurrent_kda_decode(
@@ -211,7 +283,7 @@ def test_recurrent_decode_validates_contract():
             state_cache.bfloat16(),
             state_indices,
         )
-    with pytest.raises(ValueError, match="finite and negative"):
+    with pytest.raises(ValueError, match="finite and nonpositive"):
         recurrent_kda_decode(
             packed_qkv,
             raw_gate,
@@ -222,10 +294,64 @@ def test_recurrent_decode_validates_contract():
             state_indices,
             lower_bound=1.0,
         )
+    for name, invalid_A_log, invalid_dt_bias in (
+        ("A_log", A_log.bfloat16(), dt_bias),
+        ("dt_bias", A_log, dt_bias.bfloat16()),
+    ):
+        with pytest.raises(ValueError, match=rf"{name} must be contiguous float32"):
+            recurrent_kda_decode(
+                packed_qkv,
+                raw_gate,
+                raw_beta,
+                invalid_A_log,
+                invalid_dt_bias,
+                state_cache,
+                state_indices,
+            )
+    with pytest.raises(ValueError, match="gate_transform must be one of"):
+        recurrent_kda_decode(
+            packed_qkv,
+            raw_gate,
+            raw_beta,
+            A_log,
+            dt_bias,
+            state_cache,
+            state_indices,
+            gate_transform="unknown",
+        )
+    with pytest.raises(ValueError, match="out must have shape"):
+        recurrent_kda_decode(
+            packed_qkv,
+            raw_gate,
+            raw_beta,
+            A_log,
+            dt_bias,
+            state_cache,
+            state_indices,
+            out=packed_qkv.new_empty(1, 1, state_cache.shape[1], state_cache.shape[2] - 1),
+        )
+    with pytest.raises(TypeError, match="out must use packed_qkv.dtype"):
+        recurrent_kda_decode(
+            packed_qkv,
+            raw_gate,
+            raw_beta,
+            A_log,
+            dt_bias,
+            state_cache,
+            state_indices,
+            out=torch.empty(
+                1,
+                1,
+                state_cache.shape[1],
+                state_cache.shape[2],
+                device="cuda",
+                dtype=torch.float32,
+            ),
+        )
 
 
 def test_recurrent_decode_rejects_gradient_tracking():
-    inputs = list(_decode_inputs(batch=2))
+    inputs = list(_decode_inputs(batch=1, heads=1, key_dim=16, value_dim=8))
     inputs[0] = inputs[0].requires_grad_()
     with pytest.raises(RuntimeError, match="inference-only"):
         recurrent_kda_decode(
@@ -233,10 +359,57 @@ def test_recurrent_decode_rejects_gradient_tracking():
         )
 
 
-@pytest.mark.parametrize("lower_bound", [-5.0, None])
-def test_recurrent_decode_custom_op_registration(lower_bound: float | None):
-    inputs = _decode_inputs(batch=2)
+@pytest.mark.parametrize("compiled", [False, True])
+def test_recurrent_decode_rejects_aliasing_out(compiled: bool):
+    inputs = _decode_inputs(batch=2, heads=2, key_dim=16, value_dim=8, dtype=torch.float32)
     packed_qkv, raw_gate, raw_beta, A_log, dt_bias, _, state_cache, state_indices = inputs
+    out = packed_qkv.flatten()[: 2 * 2 * 8].view(1, 2, 2, 8)
+    function = (
+        torch.compile(recurrent_kda_decode, fullgraph=True) if compiled else recurrent_kda_decode
+    )
+
+    with pytest.raises(ValueError, match="out must not alias"):
+        function(
+            packed_qkv,
+            raw_gate,
+            raw_beta,
+            A_log,
+            dt_bias,
+            state_cache,
+            state_indices,
+            out=out,
+        )
+
+
+def test_recurrent_decode_rejects_state_aliasing_read_only_input():
+    batch, heads, key_dim, value_dim, slots = 1, 1, 16, 8, 7
+    state_elements = heads * value_dim * key_dim
+    storage = torch.randn(slots * state_elements, device="cuda", dtype=torch.float32)
+    state_cache = storage.view(slots, heads, value_dim, key_dim)
+    channels = heads * (2 * key_dim + value_dim)
+    packed_qkv = storage[5 * state_elements : 5 * state_elements + channels].view(batch, channels)
+    raw_gate = torch.randn(1, batch, heads, key_dim, device="cuda")
+    raw_beta = torch.randn(1, batch, heads, device="cuda")
+    A_log = torch.randn(heads, device="cuda")
+    dt_bias = torch.randn(heads, key_dim, device="cuda")
+    state_indices = torch.tensor([5], device="cuda", dtype=torch.int32)
+
+    with pytest.raises(ValueError, match="state_cache must not alias"):
+        recurrent_kda_decode(
+            packed_qkv,
+            raw_gate,
+            raw_beta,
+            A_log,
+            dt_bias,
+            state_cache,
+            state_indices,
+        )
+
+
+def test_recurrent_decode_custom_op_registration():
+    inputs = _decode_inputs(batch=1, heads=1, key_dim=16, value_dim=8)
+    packed_qkv, raw_gate, raw_beta, A_log, dt_bias, _, state_cache, state_indices = inputs
+    out = packed_qkv.new_empty(1, 1, state_cache.shape[1], state_cache.shape[2])
     torch.library.opcheck(
         recurrent_decode_op,
         (
@@ -247,21 +420,26 @@ def test_recurrent_decode_custom_op_registration(lower_bound: float | None):
             dt_bias,
             state_cache,
             state_indices,
-            0.0 if lower_bound is None else lower_bound,
-            lower_bound is not None,
-            state_cache.shape[2] ** -0.5,
+            out,
+            -5.0,
+            True,
+            state_cache.shape[3] ** -0.5,
         ),
     )
 
 
-@pytest.mark.parametrize("lower_bound", [-5.0, None])
-def test_recurrent_decode_fullgraph_compile(lower_bound: float | None):
-    inputs = _decode_inputs(batch=2)
+@pytest.mark.parametrize(("gate_transform", "use_out"), [("bounded", False), ("softplus", True)])
+def test_recurrent_decode_fullgraph_compile(gate_transform: str, use_out: bool):
+    inputs = _decode_inputs(batch=1, heads=1, key_dim=16, value_dim=8)
     packed_qkv, raw_gate, raw_beta, A_log, dt_bias, _, eager_cache, state_indices = inputs
+    lower_bound = 0.0 if gate_transform == "bounded" else float("nan")
     _, compiled_cache = _strided_state_pool(
-        eager_cache.shape[0], eager_cache.shape[1], eager_cache.shape[2], eager_cache.shape[3]
+        eager_cache.shape[0], eager_cache.shape[1], eager_cache.shape[3], eager_cache.shape[2]
     )
     compiled_cache.copy_(eager_cache)
+    output_shape = (1, 1, eager_cache.shape[1], eager_cache.shape[2])
+    eager_out = packed_qkv.new_full(output_shape, torch.nan) if use_out else None
+    compiled_out = torch.full_like(eager_out, torch.nan) if eager_out is not None else None
 
     expected = recurrent_kda_decode(
         packed_qkv,
@@ -271,7 +449,9 @@ def test_recurrent_decode_fullgraph_compile(lower_bound: float | None):
         dt_bias,
         eager_cache,
         state_indices,
+        gate_transform=gate_transform,
         lower_bound=lower_bound,
+        out=eager_out,
     )
     compiled = torch.compile(recurrent_kda_decode, fullgraph=True)
     output = compiled(
@@ -282,26 +462,80 @@ def test_recurrent_decode_fullgraph_compile(lower_bound: float | None):
         dt_bias,
         compiled_cache,
         state_indices,
+        gate_transform=gate_transform,
         lower_bound=lower_bound,
+        out=compiled_out,
     )
 
+    if compiled_out is not None:
+        assert expected is eager_out
+        assert output is compiled_out
+        assert not torch.isnan(output).any()
     torch.testing.assert_close(output, expected, rtol=0, atol=0)
     torch.testing.assert_close(compiled_cache, eager_cache, rtol=0, atol=0)
+
+
+def test_recurrent_decode_fullgraph_dynamic_batch():
+    with torch._dynamo.config.patch(error_on_recompile=True):
+        compiled = torch.compile(recurrent_kda_decode, fullgraph=True, dynamic=True)
+        for batch in (2, 3):
+            inputs = _decode_inputs(
+                batch=batch,
+                heads=4,
+                key_dim=16,
+                value_dim=8,
+                dtype=torch.float32,
+            )
+            packed_qkv, raw_gate, raw_beta, A_log, dt_bias, _, state_cache, state_indices = inputs
+            eager_cache = state_cache.clone()
+            compiled_cache = state_cache.clone()
+            expected = recurrent_kda_decode(
+                packed_qkv,
+                raw_gate,
+                raw_beta,
+                A_log,
+                dt_bias,
+                eager_cache,
+                state_indices,
+                scale=0.25,
+            )
+            actual = compiled(
+                packed_qkv,
+                raw_gate,
+                raw_beta,
+                A_log,
+                dt_bias,
+                compiled_cache,
+                state_indices,
+                scale=0.25,
+            )
+
+            torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+            torch.testing.assert_close(compiled_cache, eager_cache, rtol=0, atol=0)
 
 
 def test_recurrent_decode_cuda_graph_replay():
     inputs = _decode_inputs(batch=3, seed=4)
     packed_qkv, raw_gate, raw_beta, A_log, dt_bias, storage, state_cache, state_indices = inputs
+    out = packed_qkv.new_empty(1, 3, state_cache.shape[1], state_cache.shape[2])
     recurrent_kda_decode(
-        packed_qkv, raw_gate, raw_beta, A_log, dt_bias, state_cache, state_indices
+        packed_qkv, raw_gate, raw_beta, A_log, dt_bias, state_cache, state_indices, out=out
     )
     torch.cuda.synchronize()
 
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
         captured_output = recurrent_kda_decode(
-            packed_qkv, raw_gate, raw_beta, A_log, dt_bias, state_cache, state_indices
+            packed_qkv,
+            raw_gate,
+            raw_beta,
+            A_log,
+            dt_bias,
+            state_cache,
+            state_indices,
+            out=out,
         )
+    assert captured_output is out
 
     with torch.no_grad():
         state_cache.add_(0.25)

--- a/test/test_kda_recurrent_decode.py
+++ b/test/test_kda_recurrent_decode.py
@@ -1,0 +1,329 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Correctness and integration tests for fused serving-oriented KDA decode."""
+
+import math
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+pytest.importorskip("triton")
+
+from attn_gym.linear import recurrent_kda_decode
+from attn_gym.linear.kda.naive import naive_recurrent_kda
+from attn_gym.linear.kda.ops import recurrent_decode_op
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="recurrent_kda_decode requires CUDA"
+)
+
+
+def _strided_state_pool(
+    num_slots: int,
+    heads: int,
+    key_dim: int,
+    value_dim: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    prefix, suffix = 11, 17
+    state_elements = heads * key_dim * value_dim
+    storage = torch.randn(
+        num_slots, prefix + state_elements + suffix, device="cuda", dtype=torch.float32
+    )
+    state = storage[:, prefix : prefix + state_elements].view(num_slots, heads, key_dim, value_dim)
+    assert not state.is_contiguous()
+    return storage, state
+
+
+def _decode_inputs(
+    *,
+    batch: int = 3,
+    heads: int = 2,
+    key_dim: int = 64,
+    value_dim: int = 64,
+    dtype: torch.dtype = torch.bfloat16,
+    seed: int = 0,
+):
+    torch.manual_seed(seed)
+    packed_qkv = torch.randn(
+        batch,
+        heads,
+        2 * key_dim + value_dim,
+        device="cuda",
+        dtype=dtype,
+    ).flatten(1)
+    raw_gate = torch.randn(1, batch, heads, key_dim, device="cuda", dtype=dtype)
+    raw_beta = torch.randn(1, batch, heads, device="cuda", dtype=dtype)
+    A_log = 0.1 * torch.randn(heads, device="cuda", dtype=torch.float32)
+    dt_bias = 0.1 * torch.randn(heads, key_dim, device="cuda", dtype=torch.float32)
+    storage, state_cache = _strided_state_pool(7, heads, key_dim, value_dim)
+    state_indices = torch.tensor([5, 1, 3], device="cuda", dtype=torch.int32)[:batch]
+    return (
+        packed_qkv,
+        raw_gate,
+        raw_beta,
+        A_log,
+        dt_bias,
+        storage,
+        state_cache,
+        state_indices,
+    )
+
+
+def _reference_decode(
+    packed_qkv: torch.Tensor,
+    raw_gate: torch.Tensor,
+    raw_beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    state_cache: torch.Tensor,
+    state_indices: torch.Tensor,
+    lower_bound: float | None,
+    scale: float | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    batch = packed_qkv.shape[0]
+    heads, key_dim, value_dim = state_cache.shape[1:]
+    per_head = packed_qkv.view(batch, heads, 2 * key_dim + value_dim)
+    q = per_head[..., :key_dim].unsqueeze(1).float()
+    k = per_head[..., key_dim : 2 * key_dim].unsqueeze(1).float()
+    v = per_head[..., 2 * key_dim :].unsqueeze(1)
+    q *= torch.rsqrt(q.square().sum(-1, keepdim=True) + 1e-6)
+    k *= torch.rsqrt(k.square().sum(-1, keepdim=True) + 1e-6)
+
+    gate_input = raw_gate.float() + dt_bias[None, None]
+    decay = A_log.exp()[None, None, :, None]
+    if lower_bound is None:
+        gate = -decay * F.softplus(gate_input)
+    else:
+        gate = lower_bound * torch.sigmoid(decay * gate_input)
+    gate *= math.log2(math.e)
+    beta = raw_beta.float().sigmoid()
+
+    active = state_indices > 0
+    output = packed_qkv.new_zeros(1, batch, heads, value_dim)
+    expected_cache = state_cache.clone()
+    if active.any():
+        active_indices = state_indices[active].long()
+        active_output, active_state = naive_recurrent_kda(
+            q[active],
+            k[active],
+            v[active],
+            gate[:, active].transpose(0, 1),
+            beta[:, active].transpose(0, 1),
+            scale=scale,
+            initial_state=state_cache[active_indices],
+            output_final_state=True,
+        )
+        output[:, active] = active_output.transpose(0, 1).to(output.dtype)
+        expected_cache[active_indices] = active_state
+    return output, expected_cache
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("lower_bound", [-5.0, None])
+@pytest.mark.parametrize(("key_dim", "value_dim"), [(64, 64), (80, 48)])
+def test_recurrent_decode_matches_reference(
+    dtype: torch.dtype,
+    lower_bound: float | None,
+    key_dim: int,
+    value_dim: int,
+):
+    inputs = _decode_inputs(dtype=dtype, key_dim=key_dim, value_dim=value_dim)
+    packed_qkv, raw_gate, raw_beta, A_log, dt_bias, _, state_cache, state_indices = inputs
+    before = state_cache.clone()
+
+    output = recurrent_kda_decode(
+        packed_qkv,
+        raw_gate,
+        raw_beta,
+        A_log,
+        dt_bias,
+        state_cache,
+        state_indices,
+        lower_bound=lower_bound,
+    )
+    expected, expected_cache = _reference_decode(
+        packed_qkv,
+        raw_gate,
+        raw_beta,
+        A_log,
+        dt_bias,
+        before,
+        state_indices,
+        lower_bound,
+    )
+
+    tolerance = 1e-5 if dtype == torch.float32 else 3e-2
+    assert output.shape == expected.shape and output.dtype == dtype
+    torch.testing.assert_close(output.float(), expected.float(), rtol=tolerance, atol=tolerance)
+    torch.testing.assert_close(state_cache, expected_cache, rtol=tolerance, atol=tolerance)
+
+
+@pytest.mark.parametrize("padding_slot", [0, -1])
+def test_recurrent_decode_padding_slot_is_ignored(padding_slot: int):
+    inputs = list(_decode_inputs())
+    inputs[-1] = torch.tensor([5, padding_slot, 3], device="cuda", dtype=torch.int32)
+    packed_qkv, raw_gate, raw_beta, A_log, dt_bias, _, state_cache, state_indices = inputs
+    before = state_cache.clone()
+
+    output = recurrent_kda_decode(
+        packed_qkv, raw_gate, raw_beta, A_log, dt_bias, state_cache, state_indices
+    )
+
+    torch.testing.assert_close(output[:, 1], torch.zeros_like(output[:, 1]), rtol=0, atol=0)
+    torch.testing.assert_close(state_cache[0], before[0], rtol=0, atol=0)
+
+
+def test_recurrent_decode_validates_contract():
+    inputs = list(_decode_inputs(batch=2))
+    packed_qkv, raw_gate, raw_beta, A_log, dt_bias, _, state_cache, state_indices = inputs
+    with pytest.raises(ValueError, match="packed_qkv must have shape"):
+        recurrent_kda_decode(
+            packed_qkv[:, :-1],
+            raw_gate,
+            raw_beta,
+            A_log,
+            dt_bias,
+            state_cache,
+            state_indices,
+        )
+    with pytest.raises(ValueError, match="raw_gate must have shape"):
+        recurrent_kda_decode(
+            packed_qkv,
+            raw_gate[..., :-1],
+            raw_beta,
+            A_log,
+            dt_bias,
+            state_cache,
+            state_indices,
+        )
+    with pytest.raises(TypeError, match="state_cache must use float32"):
+        recurrent_kda_decode(
+            packed_qkv,
+            raw_gate,
+            raw_beta,
+            A_log,
+            dt_bias,
+            state_cache.bfloat16(),
+            state_indices,
+        )
+    with pytest.raises(ValueError, match="finite and negative"):
+        recurrent_kda_decode(
+            packed_qkv,
+            raw_gate,
+            raw_beta,
+            A_log,
+            dt_bias,
+            state_cache,
+            state_indices,
+            lower_bound=1.0,
+        )
+
+
+def test_recurrent_decode_rejects_gradient_tracking():
+    inputs = list(_decode_inputs(batch=2))
+    inputs[0] = inputs[0].requires_grad_()
+    with pytest.raises(RuntimeError, match="inference-only"):
+        recurrent_kda_decode(
+            inputs[0], inputs[1], inputs[2], inputs[3], inputs[4], inputs[6], inputs[7]
+        )
+
+
+@pytest.mark.parametrize("lower_bound", [-5.0, None])
+def test_recurrent_decode_custom_op_registration(lower_bound: float | None):
+    inputs = _decode_inputs(batch=2)
+    packed_qkv, raw_gate, raw_beta, A_log, dt_bias, _, state_cache, state_indices = inputs
+    torch.library.opcheck(
+        recurrent_decode_op,
+        (
+            packed_qkv,
+            raw_gate,
+            raw_beta,
+            A_log,
+            dt_bias,
+            state_cache,
+            state_indices,
+            0.0 if lower_bound is None else lower_bound,
+            lower_bound is not None,
+            state_cache.shape[2] ** -0.5,
+        ),
+    )
+
+
+@pytest.mark.parametrize("lower_bound", [-5.0, None])
+def test_recurrent_decode_fullgraph_compile(lower_bound: float | None):
+    inputs = _decode_inputs(batch=2)
+    packed_qkv, raw_gate, raw_beta, A_log, dt_bias, _, eager_cache, state_indices = inputs
+    _, compiled_cache = _strided_state_pool(
+        eager_cache.shape[0], eager_cache.shape[1], eager_cache.shape[2], eager_cache.shape[3]
+    )
+    compiled_cache.copy_(eager_cache)
+
+    expected = recurrent_kda_decode(
+        packed_qkv,
+        raw_gate,
+        raw_beta,
+        A_log,
+        dt_bias,
+        eager_cache,
+        state_indices,
+        lower_bound=lower_bound,
+    )
+    compiled = torch.compile(recurrent_kda_decode, fullgraph=True)
+    output = compiled(
+        packed_qkv,
+        raw_gate,
+        raw_beta,
+        A_log,
+        dt_bias,
+        compiled_cache,
+        state_indices,
+        lower_bound=lower_bound,
+    )
+
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+    torch.testing.assert_close(compiled_cache, eager_cache, rtol=0, atol=0)
+
+
+def test_recurrent_decode_cuda_graph_replay():
+    inputs = _decode_inputs(batch=3, seed=4)
+    packed_qkv, raw_gate, raw_beta, A_log, dt_bias, storage, state_cache, state_indices = inputs
+    recurrent_kda_decode(
+        packed_qkv, raw_gate, raw_beta, A_log, dt_bias, state_cache, state_indices
+    )
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_output = recurrent_kda_decode(
+            packed_qkv, raw_gate, raw_beta, A_log, dt_bias, state_cache, state_indices
+        )
+
+    with torch.no_grad():
+        state_cache.add_(0.25)
+        state_indices.copy_(torch.tensor([6, 0, 2], device="cuda", dtype=torch.int32))
+        packed_qkv.add_(0.1)
+        raw_gate.mul_(0.9)
+        raw_beta.add_(0.2)
+    expected_storage = storage.clone()
+    state_elements = state_cache[0].numel()
+    expected_cache = expected_storage[:, 11 : 11 + state_elements].view_as(state_cache)
+    expected = recurrent_kda_decode(
+        packed_qkv,
+        raw_gate,
+        raw_beta,
+        A_log,
+        dt_bias,
+        expected_cache,
+        state_indices,
+    )
+
+    graph.replay()
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(captured_output, expected, rtol=0, atol=0)
+    torch.testing.assert_close(storage, expected_storage, rtol=0, atol=0)


### PR DESCRIPTION
do everything after conv in one kernel for perf, matches vllm 
also this is specialized for t = 1

<img width="416" height="204" alt="Screenshot 2026-08-18 at 11 37 16 AM" src="https://github.com/user-attachments/assets/4d975ad3-6e79-4ea4-9477-9ecdd93a7d28" />

we should use VK layout for decode because it benefits more and this also matches vLLM layout. VK makes K the contiguous dimension and since K is the reduction dim its more efficient.  this part is most dominant for decode
<img width="2472" height="1494" alt="image" src="https://github.com/user-attachments/assets/bff43f6c-654b-485c-9f49-e3010c779cdc" />

prefill doesn't benefit has much and the difference is marginal as seqlen increases 
<img width="2880" height="1254" alt="image" src="https://github.com/user-attachments/assets/5b277405-531e-4222-827f-6bb53eec8ad4" />
