### PR TITLE
Share the recurrent delta-rule scan

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -291,6 +291,8 @@ Use the narrowest ownership level that fits the behavior:
 
 - mathematical behavior shared by two implementations of one variant belongs in
   `<variant>/impl/common.py`;
+- private mathematical kernels shared by multiple variants belong in a semantic namespace such as
+  `attn_gym/linear/_delta_rule/`, not in a backend-infrastructure package;
 - Triton infrastructure shared by different variants belongs in `attn_gym/_backends/triton/`;
 - CuTeDSL infrastructure shared by different variants belongs in `attn_gym/_backends/cute/`;
 - public types shared by multiple linear or sparse operations belong in a namespace-level module

--- a/attn_gym/_backends/triton/utils.py
+++ b/attn_gym/_backends/triton/utils.py
@@ -1,10 +1,34 @@
 """Small utilities shared by hand-written Triton kernels."""
 
+import inspect
+import math
 from collections.abc import Sequence
 
 import torch
 import triton
 import triton.language as tl
+
+# Kernels fold natural-log inputs into the faster exp2 with ``exp(x) == exp2(x * LOG2_E)``.
+# Wrapped as a constexpr so ``@triton.jit`` functions can reference it as a module global.
+LOG2_E = tl.constexpr(math.log2(math.e))
+
+SUPPORTS_AUTOTUNE_CACHE = "cache_results" in inspect.signature(triton.autotune).parameters
+autotune_cache_kwargs = {"cache_results": True} if SUPPORTS_AUTOTUNE_CACHE else {}
+
+
+def configure_triton_allocator() -> None:
+    """Install a scratch allocator when Triton kernels may require one.
+
+    On Blackwell (SM100 datacenter / SM120 consumer) the Triton compiler may emit
+    global_scratch even without TMA descriptors; a default allocator prevents
+    NullAllocator crashes. See triton-lang/triton#10002.
+    """
+    if torch.cuda.is_available() and torch.cuda.get_device_capability()[0] in (10, 12):
+        triton.set_allocator(
+            lambda size, alignment, stream: torch.empty(
+                size, device=torch.device("cuda", torch.cuda.current_device()), dtype=torch.int8
+            )
+        )
 
 
 @triton.jit

--- a/attn_gym/linear/_delta_rule/__init__.py
+++ b/attn_gym/linear/_delta_rule/__init__.py
@@ -1,0 +1,1 @@
+"""Private kernels shared by delta-rule attention variants."""

--- a/attn_gym/linear/_delta_rule/recurrent.py
+++ b/attn_gym/linear/_delta_rule/recurrent.py
@@ -1,0 +1,275 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Fused recurrent scan shared by scalar- and vector-gated delta rules.
+
+Per token, the ``[K, V]`` state decays, a beta-scaled delta rule writes the new value, and the
+query reads the updated state:
+
+    state  = decay_t * state                    # GateKind.SCALAR: exp(g_t) * state
+                                                # GateKind.VECTOR: diag(exp(g_t)) @ state
+    delta  = beta_t * (v_t - k_t @ state)
+    state += outer(k_t, delta)
+    out_t  = scale * q_t @ state
+
+Gates are natural-log decays end to end; the kernel folds the log2 conversion into the ``exp2``
+argument in registers, so no caller pays a separate conversion pass. The FP32 state stays in
+registers per (sequence, head, value tile). Forward-only; training uses the chunked forms.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+import torch
+import triton
+import triton.language as tl
+
+from attn_gym._backends.triton.utils import (
+    LOG2_E,
+    autotune_cache_kwargs,
+    configure_triton_allocator,
+    ptr_offset,
+)
+
+configure_triton_allocator()
+
+
+class GateKind(Enum):
+    """Gate layout consumed by the scan."""
+
+    SCALAR = "scalar"  # one natural-log decay per token, shaped [B, T, H]
+    VECTOR = "vector"  # one natural-log decay per key channel, shaped [B, T, H, K]
+
+
+def _prune_recurrent_configs(configs, _named_args, V, **_):
+    """Drop value tiles wider than the padded value dimension."""
+    max_block_v = max(8, triton.next_power_of_2(V))
+    return [config for config in configs if config.kwargs["BV"] <= max_block_v]
+
+
+@triton.jit(do_not_specialize=["N"])
+def _recurrent_delta_rule_fwd_kernel(
+    q,
+    k,
+    v,
+    gate,
+    beta,
+    output,
+    h0,
+    ht,
+    cu_seqlens,
+    state_indices,
+    scale,
+    T,
+    N,
+    state_batch_stride: tl.constexpr,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    USE_INITIAL_STATE: tl.constexpr,
+    STORE_FINAL_STATE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    USE_STATE_INDICES: tl.constexpr,
+    SCALAR_GATE: tl.constexpr,
+):
+    """Scan one sequence/head/value tile while retaining the FP32 state in registers."""
+    pid = tl.program_id(0).to(tl.int64)
+    NV = tl.cdiv(V, BV)
+    i_v = pid % NV
+    i_nh = pid // NV
+    i_n, i_h = i_nh // H, i_nh % H
+
+    if IS_VARLEN:
+        # Assumption: seqlens have been validated prior to call
+        bos = tl.load(cu_seqlens + i_n).to(tl.int64)
+        eos = tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+    else:
+        bos = i_n * T
+        eos = bos + T
+
+    if USE_STATE_INDICES and bos == eos:
+        return
+
+    o_k = tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_k = o_k < K
+    m_v = o_v < V
+    m_kv = m_k[:, None] & m_v[None, :]
+
+    # Paged mode addresses the state pool by slot instead of by sequence position. Active
+    # sequences must select distinct, positive, in-bounds slots; nonpositive slots are padding.
+    if USE_STATE_INDICES:
+        i_state = tl.load(state_indices + i_n).to(tl.int64)
+        if i_state <= 0:
+            for t in range(bos, eos):
+                row = t * H + i_h
+                tl.store(output + ptr_offset((row, o_v), (V, 1)), 0.0, mask=m_v)
+            return
+        p_state = ptr_offset(
+            (i_state, i_h, o_v[None, :], o_k[:, None]),
+            (state_batch_stride, V * K, K, 1),
+        )
+    else:
+        p_state = ptr_offset(
+            (i_n, i_h, o_k[:, None], o_v[None, :]),
+            (state_batch_stride, K * V, V, 1),
+        )
+    if USE_INITIAL_STATE:
+        b_state = tl.load(h0 + p_state, mask=m_kv, other=0.0).to(tl.float32)
+    else:
+        b_state = tl.zeros([BK, BV], dtype=tl.float32)
+
+    for t in range(bos, eos):
+        row = t * H + i_h
+        b_q = tl.load(q + row * K + o_k, mask=m_k, other=0.0).to(tl.float32) * scale
+        b_k = tl.load(k + row * K + o_k, mask=m_k, other=0.0).to(tl.float32)
+        if SCALAR_GATE:
+            b_g = tl.load(gate + row).to(tl.float32)
+        else:
+            b_g = tl.load(gate + row * K + o_k, mask=m_k, other=0.0).to(tl.float32)
+        b_beta = tl.load(beta + row).to(tl.float32)
+        b_v = tl.load(v + row * V + o_v, mask=m_v, other=0.0).to(tl.float32)
+
+        # exp(g) computed as exp2(g * log2(e)); the FMA folds into the exp2 argument.
+        if SCALAR_GATE:
+            b_state *= tl.exp2(b_g * LOG2_E)
+        else:
+            b_state *= tl.exp2(b_g * LOG2_E)[:, None]
+
+        b_delta = (b_v - tl.sum(b_k[:, None] * b_state, 0)) * b_beta
+        b_state += b_k[:, None] * b_delta[None, :]
+        b_o = tl.sum(b_q[:, None] * b_state, 0)
+        tl.store(output + row * V + o_v, b_o.to(output.dtype.element_ty), mask=m_v)
+
+    if STORE_FINAL_STATE:
+        tl.store(ht + p_state, b_state, mask=m_kv)
+
+
+recurrent_delta_rule_fwd_kernel = triton.autotune(
+    configs=[
+        triton.Config({"BV": block_v}, num_warps=num_warps, num_stages=3)
+        for block_v in (32, 16, 8)
+        for num_warps in (2, 4)
+    ],
+    key=[
+        "T",
+        "N",
+        "H",
+        "K",
+        "V",
+        "USE_INITIAL_STATE",
+        "STORE_FINAL_STATE",
+        "IS_VARLEN",
+        "SCALAR_GATE",
+    ],
+    prune_configs_by={"early_config_prune": _prune_recurrent_configs},
+    **autotune_cache_kwargs,
+)(_recurrent_delta_rule_fwd_kernel)
+
+
+def launch_recurrent_delta_rule_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+    *,
+    scale: float,
+    gate_kind: GateKind,
+    store_final_state: bool,
+    state_indices: torch.Tensor | None = None,
+    autotune: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Launch a scalar- or vector-gated recurrent delta-rule specialization."""
+    assert k.shape == q.shape
+    assert v.shape[:3] == q.shape[:3]
+    assert gate.shape == (q.shape[:-1] if gate_kind is GateKind.SCALAR else q.shape)
+    assert beta.shape == q.shape[:-1]
+    assert all(tensor.is_contiguous() for tensor in (q, k, v, gate, beta))
+
+    batch, tokens, heads, key_dim = q.shape
+    value_dim = v.shape[-1]
+    if initial_state is not None:
+        if state_indices is None:
+            assert initial_state.is_contiguous()
+        else:
+            assert initial_state.stride()[1:] == (value_dim * key_dim, key_dim, 1)
+    num_sequences = batch if cu_seqlens is None else cu_seqlens.shape[0] - 1
+    output = torch.empty_like(v, dtype=q.dtype)
+    if state_indices is not None:
+        # Paged mode reads and writes one slot, so `h0` and `ht` alias the pool and
+        # the scan needs no gather/scatter around it.
+        assert store_final_state and initial_state is not None
+        final_state = initial_state
+    elif store_final_state:
+        final_state = q.new_empty(num_sequences, heads, key_dim, value_dim, dtype=torch.float32)
+    else:
+        final_state = None
+    state_batch_stride = (
+        initial_state.stride(0) if initial_state is not None else heads * key_dim * value_dim
+    )
+    # One flat launch dimension avoids the 65,535 grid-Y limit for large batches.
+    grid = lambda meta: (triton.cdiv(value_dim, meta["BV"]) * num_sequences * heads,)
+
+    use_autotune = autotune and state_indices is None
+    kernel = recurrent_delta_rule_fwd_kernel if use_autotune else _recurrent_delta_rule_fwd_kernel
+    launch_options = {}
+    if not use_autotune:
+        # Offline B200 sweeps favor small tiles for long scans and low-occupancy decode.
+        average_tokens = tokens if cu_seqlens is None else triton.cdiv(tokens, num_sequences)
+        sequence_heads = num_sequences * heads
+        if average_tokens >= 32:
+            block_v_limit, num_warps = 8, 4
+        elif average_tokens > 1:
+            block_v_limit, num_warps = 32, 2
+        elif value_dim >= 128:
+            block_v_limit, num_warps = 16, 4
+        elif sequence_heads <= 8:
+            block_v_limit, num_warps = 8, 4
+        elif sequence_heads < 1024:
+            block_v_limit, num_warps = 16, 2
+        else:
+            block_v_limit, num_warps = 32, 2
+        launch_options = {
+            "BV": min(triton.next_power_of_2(value_dim), block_v_limit),
+            "num_warps": num_warps,
+            "num_stages": 3,
+        }
+    kernel[grid](
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        output,
+        initial_state,
+        final_state,
+        cu_seqlens,
+        state_indices,
+        scale=scale,
+        T=tokens,
+        N=num_sequences,
+        state_batch_stride=state_batch_stride,
+        H=heads,
+        K=key_dim,
+        V=value_dim,
+        BK=triton.next_power_of_2(key_dim),
+        USE_INITIAL_STATE=initial_state is not None,
+        STORE_FINAL_STATE=final_state is not None,
+        IS_VARLEN=cu_seqlens is not None,
+        USE_STATE_INDICES=state_indices is not None,
+        SCALAR_GATE=gate_kind is GateKind.SCALAR,
+        **launch_options,
+    )
+    return output, final_state
+
+
+__all__ = ["GateKind", "launch_recurrent_delta_rule_fwd"]

--- a/attn_gym/linear/kda/api.py
+++ b/attn_gym/linear/kda/api.py
@@ -342,13 +342,12 @@ def recurrent_kda(
         _validate_paged_state(q, v, initial_state, cu_seqlens, state_indices)
         if selected_impl is not Impl.FUSED:
             raise ValueError("state_indices requires impl='fused'")
-    log2_gate = gate.float() * LOG2_E
     if selected_impl is Impl.FUSED:
         return _fused_recurrent_forward(
             q,
             k,
             v,
-            log2_gate,
+            gate,
             beta,
             initial_state,
             cu_seqlens=cu_seqlens,
@@ -361,7 +360,7 @@ def recurrent_kda(
         q,
         k,
         v,
-        log2_gate,
+        gate.float() * LOG2_E,
         beta,
         initial_state,
         cu_seqlens,

--- a/attn_gym/linear/kda/fwd/triton/recurrent.py
+++ b/attn_gym/linear/kda/fwd/triton/recurrent.py
@@ -4,13 +4,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""Fused O(T) KDA recurrence for decode and inference prefill.
+"""Inference-only KDA wrappers for recurrent prefill and fused decode.
 
-The kernel scans tokens sequentially per (sequence, head, value block), holding the
-FP32 recurrent state in registers. It mirrors :func:`naive_recurrent_kda` exactly:
-per step the state decays by ``exp2(gate)`` per key channel, a beta-scaled delta
-writes the new value, and the query reads the updated state. The operation is
-inference-only; use ``chunk_kda`` for training.
+The vector-gate prefill specialization uses the shared recurrent delta-rule scan;
+use ``chunk_kda`` for training.
 """
 
 from __future__ import annotations
@@ -19,7 +16,7 @@ import torch
 import triton
 import triton.language as tl
 
-from attn_gym._backends.triton.utils import ptr_offset
+from attn_gym.linear._delta_rule.recurrent import GateKind, launch_recurrent_delta_rule_fwd
 from attn_gym.linear.kda.ops import recurrent_decode_forward as decode_forward
 from attn_gym.linear.kda.ops import recurrent_decode_op as _recurrent_decode_op
 from attn_gym.linear.kda.ops import recurrent_forward as forward
@@ -30,128 +27,6 @@ from attn_gym.linear.kda.ops import recurrent_fwd_op as _recurrent_fwd_op
 from attn_gym.linear.kda.ops import (
     recurrent_fwd_paged_op as _recurrent_fwd_paged_op,
 )
-from attn_gym.linear.kda.utils import autotune_cache_kwargs
-
-
-def _prune_recurrent_configs(configs, _named_args, V, **_):
-    """drop value tiles wider than the padded value dimension"""
-    max_block_v = max(8, triton.next_power_of_2(V))
-    return [config for config in configs if config.kwargs["BV"] <= max_block_v]
-
-
-@triton.jit(do_not_specialize=["N"])
-def _kda_recurrent_fwd_kernel(
-    q,
-    k,
-    v,
-    gate,
-    beta,
-    output,
-    h0,
-    ht,
-    cu_seqlens,
-    state_indices,
-    scale,
-    T,
-    N,
-    state_batch_stride: tl.constexpr,
-    H: tl.constexpr,
-    K: tl.constexpr,
-    V: tl.constexpr,
-    BK: tl.constexpr,
-    BV: tl.constexpr,
-    USE_INITIAL_STATE: tl.constexpr,
-    STORE_FINAL_STATE: tl.constexpr,
-    IS_VARLEN: tl.constexpr,
-    USE_STATE_INDICES: tl.constexpr,
-):
-    pid = tl.program_id(0).to(tl.int64)
-    NV = tl.cdiv(V, BV)
-    i_v = pid % NV
-    i_nh = pid // NV
-    i_n, i_h = i_nh // H, i_nh % H
-
-    if IS_VARLEN:
-        # Assumption: seqlens have been validated prior to call
-        bos = tl.load(cu_seqlens + i_n).to(tl.int64)
-        eos = tl.load(cu_seqlens + i_n + 1).to(tl.int64)
-    else:
-        bos = i_n * T
-        eos = bos + T
-
-    if USE_STATE_INDICES and bos == eos:
-        return
-
-    o_k = tl.arange(0, BK)
-    o_v = i_v * BV + tl.arange(0, BV)
-    m_k = o_k < K
-    m_v = o_v < V
-    m_kv = m_k[:, None] & m_v[None, :]
-
-    # Paged mode addresses the state pool by slot instead of by sequence position.
-    # we are assuming that every nonempty sequence's slot must lie in
-    # [1, num_slots) and differ from every other nonempty sequence's slot
-    # we can figure out where to put the right checker kernel later
-    if USE_STATE_INDICES:
-        i_state = tl.load(state_indices + i_n).to(tl.int64)
-        # ignore vllm padded entries
-        if i_state <= 0:
-            for t in range(bos, eos):
-                row = t * H + i_h
-                p_output = ptr_offset((row, o_v), (V, 1))
-                tl.store(output + p_output, 0.0, mask=m_v)
-            return
-        p_state = ptr_offset(
-            (i_state, i_h, o_v[None, :], o_k[:, None]),
-            (state_batch_stride, V * K, K, 1),
-        )
-    else:
-        p_state = ptr_offset(
-            (i_n, i_h, o_k[:, None], o_v[None, :]),
-            (state_batch_stride, K * V, V, 1),
-        )
-    if USE_INITIAL_STATE:
-        b_state = tl.load(h0 + p_state, mask=m_kv, other=0.0).to(tl.float32)
-    else:
-        b_state = tl.zeros([BK, BV], dtype=tl.float32)
-
-    for t in range(bos, eos):
-        row = t * H + i_h
-        b_q = tl.load(q + row * K + o_k, mask=m_k, other=0.0).to(tl.float32) * scale
-        b_k = tl.load(k + row * K + o_k, mask=m_k, other=0.0).to(tl.float32)
-        b_g = tl.load(gate + row * K + o_k, mask=m_k, other=0.0).to(tl.float32)
-        b_beta = tl.load(beta + row).to(tl.float32)
-        b_v = tl.load(v + row * V + o_v, mask=m_v, other=0.0).to(tl.float32)
-
-        b_state *= tl.exp2(b_g)[:, None]
-        b_delta = (b_v - tl.sum(b_k[:, None] * b_state, 0)) * b_beta
-        b_state += b_k[:, None] * b_delta[None, :]
-        b_o = tl.sum(b_q[:, None] * b_state, 0)
-        tl.store(output + row * V + o_v, b_o.to(output.dtype.element_ty), mask=m_v)
-
-    if STORE_FINAL_STATE:
-        tl.store(ht + p_state, b_state, mask=m_kv)
-
-
-kda_recurrent_fwd_kernel = triton.autotune(
-    configs=[
-        triton.Config({"BV": block_v}, num_warps=num_warps, num_stages=3)
-        for block_v in (32, 16, 8)
-        for num_warps in (2, 4)
-    ],
-    key=[
-        "T",
-        "N",
-        "H",
-        "K",
-        "V",
-        "USE_INITIAL_STATE",
-        "STORE_FINAL_STATE",
-        "IS_VARLEN",
-    ],
-    prune_configs_by={"early_config_prune": _prune_recurrent_configs},
-    **autotune_cache_kwargs,
-)(_kda_recurrent_fwd_kernel)
 
 
 # Use a flat 1D grid of B * H * ceil(V / BV) programs. Each program owns one
@@ -236,7 +111,7 @@ def kda_recurrent_decode_kernel(
     tl.store(state_cache + p_state, b_state, mask=m_vk)
 
 
-def _launch_recurrent_fwd(
+def _launch_kda_recurrent_fwd(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
@@ -244,85 +119,26 @@ def _launch_recurrent_fwd(
     beta: torch.Tensor,
     initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor | None,
+    *,
     store_final_state: bool,
     state_indices: torch.Tensor | None = None,
     autotune: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
-    """Allocate outputs and launch the sequential scan over token spans."""
-    batch, tokens, heads, key_dim = q.shape
-    value_dim = v.shape[-1]
-    num_sequences = batch if cu_seqlens is None else cu_seqlens.shape[0] - 1
-    output = torch.empty_like(v, dtype=q.dtype)
-    if state_indices is not None:
-        # Paged mode reads and writes one slot, so `h0` and `ht` alias the pool and
-        # the scan needs no gather/scatter around it.
-        final_state = initial_state
-    elif store_final_state:
-        final_state = q.new_empty(num_sequences, heads, key_dim, value_dim, dtype=torch.float32)
-    else:
-        final_state = None
-    state_batch_stride = (
-        initial_state.stride(0) if initial_state is not None else heads * key_dim * value_dim
+    """Launch the vector-gate specialization used by recurrent KDA."""
+    return launch_recurrent_delta_rule_fwd(
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        initial_state,
+        cu_seqlens,
+        scale=q.shape[-1] ** -0.5,
+        gate_kind=GateKind.VECTOR,
+        store_final_state=store_final_state,
+        state_indices=state_indices,
+        autotune=autotune,
     )
-    # BV=32 measured faster than 64 on B200 for both decode and prefill
-    # (smaller state tiles schedule better; state traffic is identical).
-    # One flat launch dimension: sequence-head counts can exceed the 65,535
-    # grid-Y limit, while grid-X is effectively unbounded.
-    grid = lambda meta: (triton.cdiv(value_dim, meta["BV"]) * num_sequences * heads,)
-
-    def launch(kernel, launch_options):
-        kernel[grid](
-            q,
-            k,
-            v,
-            gate,
-            beta,
-            output,
-            initial_state,
-            final_state,
-            cu_seqlens,
-            state_indices,
-            scale=key_dim**-0.5,
-            T=tokens,
-            N=num_sequences,
-            state_batch_stride=state_batch_stride,
-            H=heads,
-            K=key_dim,
-            V=value_dim,
-            BK=triton.next_power_of_2(key_dim),
-            USE_INITIAL_STATE=initial_state is not None,
-            STORE_FINAL_STATE=final_state is not None,
-            IS_VARLEN=cu_seqlens is not None,
-            USE_STATE_INDICES=state_indices is not None,
-            **launch_options,
-        )
-
-    use_autotune = autotune and state_indices is None
-    kernel = kda_recurrent_fwd_kernel if use_autotune else _kda_recurrent_fwd_kernel
-    launch_options = {}
-    if not use_autotune:
-        average_tokens = tokens if cu_seqlens is None else triton.cdiv(tokens, num_sequences)
-        sequence_heads = num_sequences * heads
-        # offline b200 sweeps favor small tiles for long scans and low-occupancy decode
-        if average_tokens >= 32:
-            block_v_limit, num_warps = 8, 4
-        elif average_tokens > 1:
-            block_v_limit, num_warps = 32, 2
-        elif value_dim >= 128:
-            block_v_limit, num_warps = 16, 4
-        elif sequence_heads <= 8:
-            block_v_limit, num_warps = 8, 4
-        elif sequence_heads < 1024:
-            block_v_limit, num_warps = 16, 2
-        else:
-            block_v_limit, num_warps = 32, 2
-        launch_options = {
-            "BV": min(triton.next_power_of_2(value_dim), block_v_limit),
-            "num_warps": num_warps,
-            "num_stages": 3,
-        }
-    launch(kernel, launch_options)
-    return output, final_state
 
 
 def _kda_recurrent_fwd_cuda(
@@ -335,7 +151,7 @@ def _kda_recurrent_fwd_cuda(
     cu_seqlens: torch.Tensor | None,
     autotune: bool,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    output, final_state = _launch_recurrent_fwd(
+    output, final_state = _launch_kda_recurrent_fwd(
         q,
         k,
         v,
@@ -360,7 +176,7 @@ def _kda_recurrent_fwd_no_state_cuda(
     cu_seqlens: torch.Tensor | None,
     autotune: bool,
 ) -> torch.Tensor:
-    return _launch_recurrent_fwd(
+    return _launch_kda_recurrent_fwd(
         q,
         k,
         v,
@@ -384,7 +200,7 @@ def _kda_recurrent_fwd_paged_cuda(
     cu_seqlens: torch.Tensor | None,
     autotune: bool,
 ) -> torch.Tensor:
-    return _launch_recurrent_fwd(
+    return _launch_kda_recurrent_fwd(
         q,
         k,
         v,

--- a/attn_gym/linear/kda/ops.py
+++ b/attn_gym/linear/kda/ops.py
@@ -838,7 +838,9 @@ def recurrent_forward(
             "training or call under torch.no_grad() / torch.inference_mode()"
         )
 
-    q, k, v, gate, beta = (tensor.contiguous() for tensor in (q, k, v, gate, beta))
+    q, k, v, beta = (tensor.contiguous() for tensor in (q, k, v, beta))
+    # FP32 gate loads measured faster than bf16 in the latency-bound scan loop.
+    gate = gate.float().contiguous()
     if state_indices is not None:
         # `.contiguous()` on the pool would copy and silently drop the in-place advance.
         assert initial_state is not None

--- a/attn_gym/linear/kda/utils.py
+++ b/attn_gym/linear/kda/utils.py
@@ -26,18 +26,14 @@ from typing import Any
 import torch
 import triton
 import triton.language as tl
-import triton.language.extra.libdevice as tldevice
 from packaging import version
 
+from attn_gym._backends.triton import utils as triton_utils
+
+SUPPORTS_AUTOTUNE_CACHE = triton_utils.SUPPORTS_AUTOTUNE_CACHE
+autotune_cache_kwargs = triton_utils.autotune_cache_kwargs
+
 logger = logging.getLogger(__name__)
-
-# ---------------------------------------------------------------------------
-# Env flags / autotune caching
-# ---------------------------------------------------------------------------
-FLA_CACHE_RESULTS = os.getenv("FLA_CACHE_RESULTS", "1") == "1"
-
-SUPPORTS_AUTOTUNE_CACHE = "cache_results" in inspect.signature(triton.autotune).parameters
-autotune_cache_kwargs = {"cache_results": FLA_CACHE_RESULTS} if SUPPORTS_AUTOTUNE_CACHE else {}
 
 
 # ---------------------------------------------------------------------------
@@ -107,15 +103,6 @@ IS_AMD = device_platform == "hip"
 IS_NVIDIA = device_platform == "cuda"
 IS_NVIDIA_BLACKWELL = IS_NVIDIA and torch.cuda.get_device_capability()[0] in (10, 12)
 IS_TF32_SUPPORTED = IS_NVIDIA and torch.cuda.get_device_capability(0)[0] >= 8
-IS_TMA_SUPPORTED = (
-    IS_NVIDIA
-    and torch.cuda.get_device_capability(0)[0] >= 9
-    and os.environ.get("FLA_USE_TMA", "0") == "1"
-    and (
-        hasattr(triton.language, "_experimental_make_tensor_descriptor")
-        or hasattr(triton.language, "make_tensor_descriptor")
-    )
-)
 IS_GATHER_SUPPORTED = hasattr(triton.language, "gather")
 
 if IS_NVIDIA and not IS_TF32_SUPPORTED:
@@ -123,30 +110,15 @@ if IS_NVIDIA and not IS_TF32_SUPPORTED:
     os.environ["TRITON_F32_DEFAULT"] = "ieee"
 
 
-def _default_alloc_fn(size: int, alignment: int, stream: int | None):
-    return torch.empty(
-        size, device=torch.device(device_name, device_torch_lib.current_device()), dtype=torch.int8
-    )
-
-
-if IS_TMA_SUPPORTED:
-    logger.info("TMA is supported, using TMA by default.")
-    triton.set_allocator(_default_alloc_fn)
-elif IS_NVIDIA_BLACKWELL:
-    # Blackwell (SM100 datacenter / SM120 consumer): Triton compiler may emit global_scratch for
-    # autotuned kernels even without TMA. Register a default allocator to prevent NullAllocator
-    # crashes. See triton-lang/triton#10002.
+if IS_NVIDIA_BLACKWELL:
     logger.info("Blackwell detected: registering default global_scratch allocator.")
-    triton.set_allocator(_default_alloc_fn)
+triton_utils.configure_triton_allocator()
 
 
 # ---------------------------------------------------------------------------
 # Triton math ops
 # ---------------------------------------------------------------------------
-if os.environ.get("FLA_USE_FAST_OPS", "0") == "1":
-    exp2 = tldevice.exp2
-else:
-    exp2 = tl.math.exp2
+exp2 = tl.math.exp2
 
 
 @triton.jit

--- a/test/linear/test_recurrent_delta_rule.py
+++ b/test/linear/test_recurrent_delta_rule.py
@@ -1,0 +1,174 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Correctness tests for the shared recurrent delta-rule scan."""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+pytest.importorskip("triton")
+
+from attn_gym.linear import recurrent_gdn
+from attn_gym.linear._delta_rule.recurrent import GateKind, launch_recurrent_delta_rule_fwd
+from attn_gym.testing.kda import assert_matches_low_precision_reference
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="the fused recurrent scan requires CUDA"
+)
+
+
+def _make_inputs(
+    *,
+    tokens: int,
+    dtype: torch.dtype,
+    initial_state: bool,
+    key_dim: int = 64,
+    value_dim: int = 48,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor | None,
+]:
+    """Create stable scalar-gated inputs in the public GDN layout."""
+    torch.manual_seed(0)
+    batch, heads = 2, 2
+    query = F.normalize(torch.randn(batch, heads, tokens, key_dim, device="cuda"), dim=-1)
+    key = F.normalize(torch.randn_like(query), dim=-1)
+    value = torch.randn(batch, heads, tokens, value_dim, device="cuda")
+    gate = F.logsigmoid(torch.randn(batch, heads, tokens, device="cuda"))
+    beta = torch.sigmoid(torch.randn(batch, heads, tokens, device="cuda"))
+    state = torch.randn(batch, heads, key_dim, value_dim, device="cuda") if initial_state else None
+    return query.to(dtype), key.to(dtype), value.to(dtype), gate, beta, state
+
+
+def _launch_scalar_gdn(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    *,
+    scale: float,
+    store_final_state: bool,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Adapt head-major GDN inputs to the private token-major scan."""
+    output, final_state = launch_recurrent_delta_rule_fwd(
+        query.transpose(1, 2).contiguous(),
+        key.transpose(1, 2).contiguous(),
+        value.transpose(1, 2).contiguous(),
+        gate.transpose(1, 2).contiguous(),
+        beta.transpose(1, 2).contiguous(),
+        initial_state,
+        None,
+        scale=scale,
+        gate_kind=GateKind.SCALAR,
+        store_final_state=store_final_state,
+    )
+    return output.transpose(1, 2), final_state
+
+
+@pytest.mark.parametrize(
+    "dtype,tokens,use_initial_state,return_final_state,scale,key_dim,value_dim",
+    [
+        (torch.float32, 37, True, True, 0.37, 64, 48),
+        (torch.float32, 3, True, True, None, 40, 37),
+        (torch.float32, 5, False, False, None, 64, 48),
+        (torch.bfloat16, 37, True, True, None, 64, 48),
+    ],
+)
+def test_scalar_gate_matches_recurrent_gdn(
+    dtype, tokens, use_initial_state, return_final_state, scale, key_dim, value_dim
+):
+    query, key, value, gate, beta, state = _make_inputs(
+        tokens=tokens,
+        dtype=dtype,
+        initial_state=use_initial_state,
+        key_dim=key_dim,
+        value_dim=value_dim,
+    )
+    kernel_scale = query.shape[-1] ** -0.5 if scale is None else scale
+    with torch.no_grad():
+        expected = recurrent_gdn(
+            query,
+            key,
+            value,
+            gate,
+            beta,
+            scale=scale,
+            initial_state=state,
+            return_final_state=return_final_state,
+        )
+        output, final_state = _launch_scalar_gdn(
+            query,
+            key,
+            value,
+            gate,
+            beta,
+            state,
+            scale=kernel_scale,
+            store_final_state=return_final_state,
+        )
+
+    assert output.dtype == dtype
+    if return_final_state:
+        assert final_state is not None and final_state.dtype == torch.float32
+    else:
+        assert final_state is None and expected.final_state is None
+    if dtype == torch.bfloat16:
+        high_precision = recurrent_gdn(
+            query.double(),
+            key.double(),
+            value.double(),
+            gate.double(),
+            beta.double(),
+            scale=scale,
+            initial_state=None if state is None else state.double(),
+            return_final_state=return_final_state,
+        )
+        assert_matches_low_precision_reference(
+            output, high_precision.output, expected.output, "output"
+        )
+        if return_final_state:
+            assert_matches_low_precision_reference(
+                final_state, high_precision.final_state, expected.final_state, "final_state"
+            )
+    else:
+        torch.testing.assert_close(output, expected.output, rtol=1e-5, atol=1e-5)
+        if return_final_state:
+            torch.testing.assert_close(final_state, expected.final_state, rtol=1e-5, atol=1e-5)
+
+
+def test_scalar_and_vector_gate_specializations_agree():
+    query, key, value, gate, beta, state = _make_inputs(
+        tokens=37, dtype=torch.float32, initial_state=True
+    )
+    scale = query.shape[-1] ** -0.5
+    with torch.no_grad():
+        scalar_output, scalar_state = _launch_scalar_gdn(
+            query, key, value, gate, beta, state, scale=scale, store_final_state=True
+        )
+        token_gate = gate.transpose(1, 2).contiguous()
+        vector_gate = token_gate.unsqueeze(-1).expand(*token_gate.shape, query.shape[-1])
+        vector_output, vector_state = launch_recurrent_delta_rule_fwd(
+            query.transpose(1, 2).contiguous(),
+            key.transpose(1, 2).contiguous(),
+            value.transpose(1, 2).contiguous(),
+            vector_gate.contiguous(),
+            beta.transpose(1, 2).contiguous(),
+            state,
+            None,
+            scale=scale,
+            gate_kind=GateKind.VECTOR,
+            store_final_state=True,
+        )
+
+    torch.testing.assert_close(scalar_output, vector_output.transpose(1, 2), rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(scalar_state, vector_state, rtol=1e-5, atol=1e-5)

--- a/test/test_kda_recurrent.py
+++ b/test/test_kda_recurrent.py
@@ -16,7 +16,6 @@ pytest.importorskip("triton")
 
 from attn_gym.linear import recurrent_kda
 from attn_gym.linear.kda.constants import LOG2_E
-from attn_gym.linear.kda.fwd.triton import recurrent as recurrent_backend
 from attn_gym.linear.kda.fwd.triton.recurrent import (
     _recurrent_fwd_no_state_op,
     _recurrent_fwd_op,
@@ -131,7 +130,11 @@ def test_recurrent_paged_skips_autotune(monkeypatch):
         def __getitem__(self, _grid):
             raise AssertionError("paged execution must not invoke the autotuner")
 
-    monkeypatch.setattr(recurrent_backend, "kda_recurrent_fwd_kernel", UnexpectedAutotune())
+    from attn_gym.linear._delta_rule import recurrent as delta_rule_recurrent
+
+    monkeypatch.setattr(
+        delta_rule_recurrent, "recurrent_delta_rule_fwd_kernel", UnexpectedAutotune()
+    )
     recurrent_kda(q, k, v, gate, beta, pool, state_indices=slots, autotune=True)
 
 
@@ -383,17 +386,17 @@ def test_recurrent_custom_op_registration(packed: bool):
     state = torch.randn(num_sequences, q.shape[2], q.shape[3], v.shape[-1], device="cuda")
     torch.library.opcheck(
         _recurrent_fwd_op,
-        (q, k, v, gate * LOG2_E, beta, state, cu_seqlens, True),
+        (q, k, v, gate, beta, state, cu_seqlens, True),
     )
     torch.library.opcheck(
         _recurrent_fwd_no_state_op,
-        (q, k, v, gate * LOG2_E, beta, state, cu_seqlens, True),
+        (q, k, v, gate, beta, state, cu_seqlens, True),
     )
     _, state_pool = _strided_state_pool(num_sequences + 1, q.shape[2], q.shape[3], v.shape[-1])
     slots = torch.arange(1, num_sequences + 1, device="cuda", dtype=torch.int32)
     torch.library.opcheck(
         _recurrent_fwd_paged_op,
-        (q, k, v, gate * LOG2_E, beta, state_pool, slots, cu_seqlens, True),
+        (q, k, v, gate, beta, state_pool, slots, cu_seqlens, True),
     )
 
 
@@ -405,14 +408,14 @@ def test_recurrent_custom_op_registration_mixed_dtype():
     _, state_pool = _strided_state_pool(3, q.shape[2], q.shape[3], v.shape[-1])
     slots = torch.tensor([1, 2], device="cuda", dtype=torch.int32)
 
-    torch.library.opcheck(_recurrent_fwd_op, (q, k, v, gate * LOG2_E, beta, state, None, True))
+    torch.library.opcheck(_recurrent_fwd_op, (q, k, v, gate, beta, state, None, True))
     torch.library.opcheck(
         _recurrent_fwd_no_state_op,
-        (q, k, v, gate * LOG2_E, beta, state, None, True),
+        (q, k, v, gate, beta, state, None, True),
     )
     torch.library.opcheck(
         _recurrent_fwd_paged_op,
-        (q, k, v, gate * LOG2_E, beta, state_pool, slots, None, True),
+        (q, k, v, gate, beta, state_pool, slots, None, True),
     )
 
 
@@ -476,13 +479,13 @@ def test_recurrent_cuda_graph_replay():
     q, k, v, gate, beta, _ = _inputs(batch=1, tokens=32, seed=5)
     cu_seqlens = torch.tensor([0, 11, 27, 32], device="cuda", dtype=torch.int32)
     initial_state = torch.randn(3, q.shape[2], q.shape[3], v.shape[-1], device="cuda")
-    _recurrent_fwd_op(q, k, v, gate * LOG2_E, beta, initial_state, cu_seqlens, True)
+    _recurrent_fwd_op(q, k, v, gate, beta, initial_state, cu_seqlens, True)
     torch.cuda.synchronize()
 
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
         captured_output, captured_state = _recurrent_fwd_op(
-            q, k, v, gate * LOG2_E, beta, initial_state, cu_seqlens, True
+            q, k, v, gate, beta, initial_state, cu_seqlens, True
         )
 
     active_tokens = 23
@@ -497,7 +500,7 @@ def test_recurrent_cuda_graph_replay():
     torch.cuda.synchronize()
 
     expected_output, expected_state = _recurrent_fwd_op(
-        q, k, v, gate * LOG2_E, beta, initial_state, cu_seqlens, True
+        q, k, v, gate, beta, initial_state, cu_seqlens, True
     )
     torch.testing.assert_close(
         captured_output[:, :active_tokens],
@@ -513,14 +516,12 @@ def test_recurrent_paged_cuda_graph_replay():
     q, k, v, gate, beta, _ = _inputs(batch=3, tokens=1, dtype=torch.bfloat16, seed=31)
     storage, pool = _strided_state_pool(7, q.shape[2], q.shape[3], v.shape[-1])
     slots = torch.tensor([5, 1, 3], device="cuda", dtype=torch.int32)
-    _recurrent_fwd_paged_op(q, k, v, gate * LOG2_E, beta, pool, slots, None, True)
+    _recurrent_fwd_paged_op(q, k, v, gate, beta, pool, slots, None, True)
     torch.cuda.synchronize()
 
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
-        captured_output = _recurrent_fwd_paged_op(
-            q, k, v, gate * LOG2_E, beta, pool, slots, None, True
-        )
+        captured_output = _recurrent_fwd_paged_op(q, k, v, gate, beta, pool, slots, None, True)
 
     with torch.no_grad():
         storage.add_(0.25)


### PR DESCRIPTION
Stacked PRs:
 * #381
 * #380
 * #379
 * __->__#353


--- --- ---

Share the recurrent delta-rule scan

## Human Note

## Agent note

Extract KDA's existing recurrent Triton scan behind a private delta-rule launcher and preserve the
vector-log2 specialization used by every current KDA path. Add one compile-time scalar-gate
specialization that consumes natural-log decay and an explicit scale for future GDN integration;
private tests compare it with the GDN reference and the equivalent vector-gate specialization.

## Test Plan

```bash
.venv/bin/prek run --files attn_gym/linear/_delta_rule/__init__.py attn_gym/linear/_delta_rule/recurrent.py attn_gym/linear/kda/fwd/triton/recurrent.py test/linear/test_recurrent_delta_rule.py
gpu-run auto -- .venv/bin/pytest -n 6 test/test_kda_recurrent.py test/linear/test_recurrent_delta_rule.py -q
```