### PR TITLE
Add persistent KDA state recurrence scheduling

### DIFF
--- a/attn_gym/linear/kda/chunk_schedule.py
+++ b/attn_gym/linear/kda/chunk_schedule.py
@@ -38,7 +38,7 @@ class ResolvedSchedule:
 
     ``workers`` is the bounded persistent-grid candidate; STATIC kernels use
     their natural capacity grid. ``capacity_tasks`` is the total number of
-    possible ``(chunk, subtask)`` slots used by the automatic policy.
+    possible logical work slots used by the automatic policy.
     """
 
     kind: ScheduleKind

--- a/attn_gym/linear/kda/chunk_scheduler.py
+++ b/attn_gym/linear/kda/chunk_scheduler.py
@@ -14,8 +14,8 @@ Coordinate system
 Scheduling views
 ----------------
 
-``GridScheduler`` supports two launch geometries; ``subtask`` is terminology for
-only the flattened one:
+``GridScheduler`` supports three launch geometries; ``subtask`` is terminology
+for only the flattened one:
 
 1. **Flat-task scheduling** (Triton): a kernel supplies only its number of
    kernel-specific work coordinates per chunk. The scheduler sees that count,
@@ -33,6 +33,10 @@ only the flattened one:
    grid axis. Pair, head, and tile coordinates remain explicit grid axes, and
    each CTA strides over chunks for one fixed combination of those coordinates.
    This path neither passes nor decodes a ``subtasks_per_chunk`` value.
+
+3. **Sequence-axis scheduling**: recurrence kernels persist the sequence-head
+   axis while retaining the value tile as an explicit grid axis. Kernels derive
+   the active sequence extent from ``cu_seqlens`` during replay.
 
 The value three in the worked example below is therefore illustrative only for
 flat-task scheduling; it is not derived from ``cu_seqlens`` and does not describe
@@ -78,7 +82,7 @@ kernel has three subtasks per chunk, task 7 maps to
 Flat STATIC scheduling launches every capacity task. Chunk-axis STATIC
 scheduling launches the full chunk-capacity axis while retaining the other grid
 axes. Inactive CTAs return after reading the active count. PERSISTENT scheduling
-bounds the worker or chunk axis and strides only over runtime active work.
+bounds the flat, chunk, or sequence axis and strides only over runtime active work.
 """
 
 from __future__ import annotations
@@ -128,9 +132,9 @@ def _multiprocessor_count(device: torch.device) -> int:
 
 @dataclass(frozen=True)
 class GridScheduler:
-    """Map ragged chunk work onto launch grids for Triton and CuTeDSL kernels.
+    """Map ragged work onto launch grids for Triton and CuTeDSL kernels.
 
-    The runtime number of chunks depends on sequence lengths, but CUDA Graph
+    The runtime work count depends on sequence lengths, but CUDA Graph
     capture fixes the launch shape at ``metadata.capacity``. Static kernels
     launch one CTA per capacity task; inactive CTAs read the active count and
     return. Persistent kernels launch a bounded machine-derived worker grid and
@@ -205,6 +209,24 @@ class GridScheduler:
             self.metadata.capacity * subtasks_per_chunk,
             workers,
             requirement,
+        )
+
+    def resolve_sequences(
+        self,
+        request: ScheduleRequest,
+        subtasks_per_sequence: int,
+        device: torch.device | str,
+    ) -> ResolvedSchedule:
+        """Resolve scheduling for flattened sequence-level recurrence work."""
+        num_sequences = self.metadata.cu_seqlens.shape[0] - 1
+        sm_count = _multiprocessor_count(torch.device(device))
+        workers = min(num_sequences * subtasks_per_sequence, sm_count * self.ctas_per_sm)
+        return self._resolve(
+            request,
+            True,
+            num_sequences * subtasks_per_sequence,
+            workers,
+            "a sequence-persistent kernel",
         )
 
     def resolve_chunk(
@@ -292,6 +314,21 @@ def load_ragged_task_count(chunk_offsets, num_sequences, subtasks_per_chunk):
     handles ``w, w + num_workers, ...`` up to this returned bound.
     """
     return load_ragged_chunk_count(chunk_offsets, num_sequences) * subtasks_per_chunk
+
+
+@triton.jit
+def load_ragged_sequence_extent(cu_seqlens, num_sequences: tl.constexpr):
+    """Return one past the last sequence slot that may contain tokens."""
+    active_tokens = tl.load(cu_seqlens + num_sequences)
+    low = 0
+    high = num_sequences
+    while low < high:
+        middle = (low + high) // 2
+        if tl.load(cu_seqlens + middle) < active_tokens:
+            low = middle + 1
+        else:
+            high = middle
+    return low
 
 
 @triton.jit
@@ -415,6 +452,7 @@ __all__ = [
     "decode_ragged_task",
     "load_ragged_chunk_count",
     "load_ragged_chunk_work",
+    "load_ragged_sequence_extent",
     "load_ragged_task_count",
     "prepare_ragged_chunk_metadata",
 ]

--- a/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
@@ -23,17 +23,21 @@ from triton.tools.tensor_descriptor import TensorDescriptor
 
 from attn_gym._backends.triton.utils import can_use_tma, ptr_offset, requires_int64_offsets
 from attn_gym.linear.kda.chunk_scheduler import (
+    GridScheduler,
     RaggedChunkMetadata,
+    ScheduleKind,
+    ScheduleRequest,
     load_ragged_chunk_count,
     load_ragged_chunk_work,
+    load_ragged_sequence_extent,
 )
 from attn_gym.linear.kda.ops import delta_h_op as _delta_h_op
 from attn_gym.linear.kda.ops import delta_h_with_state_op as _delta_h_with_state_op
 from attn_gym.linear.kda.utils import exp2
 
 
-@triton.jit(do_not_specialize=["T"])
-def chunk_delta_h_kernel_k128_wsp(
+@triton.jit
+def _run_chunk_delta_h_sequence(
     k_desc,
     w_desc,
     u_desc,
@@ -49,6 +53,8 @@ def chunk_delta_h_kernel_k128_wsp(
     u,
     v_new,
     T,
+    i_nh,
+    i_v,
     H: tl.constexpr,
     K: tl.constexpr,
     V: tl.constexpr,
@@ -61,19 +67,13 @@ def chunk_delta_h_kernel_k128_wsp(
     IS_VARLEN: tl.constexpr,
     USE_INT64_OFFSETS: tl.constexpr,
 ):
-    """Warp-specialized K=128 inter-chunk recurrence.
+    """Process one sequence, head, and value tile through the state recurrence.
 
-    Holds the full [K, BV] state in one accumulator and walks full chunks with
-    a warp-specialized descriptor loop. A partial tail chunk uses masked
-    pointers because a descriptor load would cross the sequence boundary in
-    the token-major packed layout. ``decay_desc`` holds precomputed ``exp2``
-    of each chunk's last-row cumulative gate. Descriptor coordinates are
-    element indices and stay int32; the raw-pointer tail and state paths
-    promote to int64 when tensor sizes require it. Compute follows the
-    blockdim64 kernel it replaced: dots run in the input dtype with FP32
-    accumulation, and the state stays FP32.
+    The full ``[K, BV]`` state stays in one FP32 accumulator while complete
+    chunks use tensor descriptors and a partial tail uses masked pointers.
+    Descriptor coordinates remain int32; raw-pointer state and tail paths widen
+    when the reachable layout requires int64 offsets.
     """
-    i_nh, i_v = tl.program_id(0), tl.program_id(1)
     i_n, i_h = i_nh // H, i_nh % H
     if USE_INT64_OFFSETS:
         i_state = i_nh.to(tl.int64)
@@ -162,6 +162,137 @@ def chunk_delta_h_kernel_k128_wsp(
         )
 
 
+@triton.jit(do_not_specialize=["T"])
+def chunk_delta_h_kernel_k128_wsp(
+    k_desc,
+    w_desc,
+    u_desc,
+    vnew_desc,
+    h_desc,
+    decay_desc,
+    h0,
+    ht,
+    cu_seqlens,
+    chunk_offsets,
+    k,
+    w,
+    u,
+    v_new,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BV: tl.constexpr,
+    WARP_SPECIALIZE: tl.constexpr,
+    NUM_STAGES: tl.constexpr,
+    USE_INITIAL_STATE: tl.constexpr,
+    STORE_FINAL_STATE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    USE_INT64_OFFSETS: tl.constexpr,
+):
+    """Warp-specialized K=128 inter-chunk recurrence."""
+    _run_chunk_delta_h_sequence(
+        k_desc,
+        w_desc,
+        u_desc,
+        vnew_desc,
+        h_desc,
+        decay_desc,
+        h0,
+        ht,
+        cu_seqlens,
+        chunk_offsets,
+        k,
+        w,
+        u,
+        v_new,
+        T,
+        tl.program_id(0),
+        tl.program_id(1),
+        H,
+        K,
+        V,
+        BT,
+        BV,
+        WARP_SPECIALIZE,
+        NUM_STAGES,
+        USE_INITIAL_STATE,
+        STORE_FINAL_STATE,
+        IS_VARLEN,
+        USE_INT64_OFFSETS,
+    )
+
+
+@triton.jit(do_not_specialize=["T"])
+def chunk_delta_h_kernel_k128_persistent(
+    k_desc,
+    w_desc,
+    u_desc,
+    vnew_desc,
+    h_desc,
+    decay_desc,
+    h0,
+    ht,
+    cu_seqlens,
+    chunk_offsets,
+    k,
+    w,
+    u,
+    v_new,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BV: tl.constexpr,
+    WARP_SPECIALIZE: tl.constexpr,
+    NUM_STAGES: tl.constexpr,
+    USE_INITIAL_STATE: tl.constexpr,
+    STORE_FINAL_STATE: tl.constexpr,
+    USE_INT64_OFFSETS: tl.constexpr,
+    NUM_SEQUENCES: tl.constexpr,
+    NUM_WORKERS: tl.constexpr,
+):
+    """Stride persistent workers over sequence recurrences after the first wave."""
+    worker = tl.program_id(0)
+    i_v = tl.program_id(1)
+    sequence_extent = load_ragged_sequence_extent(cu_seqlens, NUM_SEQUENCES)
+    active_tasks = sequence_extent * H
+    task_end = NUM_SEQUENCES * H if STORE_FINAL_STATE else active_tasks
+    for i_nh in tl.range(NUM_WORKERS + worker, task_end, NUM_WORKERS):
+        _run_chunk_delta_h_sequence(
+            k_desc,
+            w_desc,
+            u_desc,
+            vnew_desc,
+            h_desc,
+            decay_desc,
+            h0,
+            ht,
+            cu_seqlens,
+            chunk_offsets,
+            k,
+            w,
+            u,
+            v_new,
+            T,
+            i_nh,
+            i_v,
+            H,
+            K,
+            V,
+            BT,
+            BV,
+            WARP_SPECIALIZE,
+            NUM_STAGES,
+            USE_INITIAL_STATE,
+            STORE_FINAL_STATE,
+            True,
+            USE_INT64_OFFSETS,
+        )
+
+
 @triton.jit(do_not_specialize=["num_sequences"])
 def _chunk_decay_last_kernel(
     gk,
@@ -227,6 +358,35 @@ def _chunk_decay_last(
 # attn_gym.linear.kda.ops; this module provides the CUDA entry points.
 _CHUNK_SIZE = 64
 _BLOCK_VALUE_DIM = 64
+_MIN_PERSISTENT_SEQUENCES = 32
+_MIN_PERSISTENT_HEADS = 8
+_AUTO_PERSISTENT_MAX_AVERAGE_TOKENS = _CHUNK_SIZE
+
+
+def _persistent_sequence_workers(
+    metadata: RaggedChunkMetadata,
+    tokens: int,
+    heads: int,
+    value_tiles: int,
+    device: torch.device,
+    schedule: ScheduleRequest,
+) -> int:
+    """Return the sequence-head workers for the selected recurrence schedule."""
+    num_sequences = metadata.cu_seqlens.shape[0] - 1
+    resolved = GridScheduler(metadata, ctas_per_sm=1).resolve_sequences(
+        schedule, heads * value_tiles, device
+    )
+    if resolved.kind is ScheduleKind.STATIC:
+        return 0
+    # Longer capacity-average recurrences favor the fully warp-specialized grid;
+    # explicit PERSISTENT remains available for targeted tuning experiments.
+    if schedule is ScheduleRequest.AUTO and (
+        num_sequences < _MIN_PERSISTENT_SEQUENCES
+        or heads < _MIN_PERSISTENT_HEADS
+        or tokens > num_sequences * _AUTO_PERSISTENT_MAX_AVERAGE_TOKENS
+    ):
+        return 0
+    return max(1, resolved.workers // value_tiles)
 
 
 def _delta_h_launch(
@@ -239,6 +399,7 @@ def _delta_h_launch(
     chunk_offsets: torch.Tensor | None,
     capacity: int,
     final_state: torch.Tensor | None,
+    schedule: ScheduleRequest = ScheduleRequest.AUTO,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Allocate outputs and launch the recurrence; runs eagerly inside the op."""
     batch, tokens, heads, key_dim = k.shape
@@ -253,13 +414,16 @@ def _delta_h_launch(
     # pipelined loop instead. 16-bit inputs keep the tuned contract schedule.
     use_16bit_config = k.element_size() == 2
     block_value_dim = _BLOCK_VALUE_DIM if use_16bit_config else _BLOCK_VALUE_DIM // 2
-    chunk_delta_h_kernel_k128_wsp[(state_batch * heads, value_dim // block_value_dim)](
+    descriptors = (
         TensorDescriptor.from_tensor(k, [1, _CHUNK_SIZE, 1, key_dim]),
         TensorDescriptor.from_tensor(w, [1, _CHUNK_SIZE, 1, key_dim]),
         TensorDescriptor.from_tensor(u, [1, _CHUNK_SIZE, 1, block_value_dim]),
         TensorDescriptor.from_tensor(v_new, [1, _CHUNK_SIZE, 1, block_value_dim]),
         TensorDescriptor.from_tensor(h, [1, 1, 1, key_dim, block_value_dim]),
         TensorDescriptor.from_tensor(decay, [1, 1, key_dim]),
+    )
+    kernel_args = (
+        *descriptors,
         initial_state,
         final_state,
         cu_seqlens,
@@ -269,19 +433,57 @@ def _delta_h_launch(
         u,
         v_new,
         tokens,
-        H=heads,
-        K=key_dim,
-        V=value_dim,
-        BT=_CHUNK_SIZE,
-        BV=block_value_dim,
-        WARP_SPECIALIZE=use_16bit_config,
-        NUM_STAGES=3 if use_16bit_config else 2,
-        USE_INITIAL_STATE=initial_state is not None,
-        STORE_FINAL_STATE=final_state is not None,
-        IS_VARLEN=cu_seqlens is not None,
-        USE_INT64_OFFSETS=requires_int64_offsets(k, w, u, v_new, h, initial_state, final_state),
-        num_warps=4,
     )
+    kernel_options = {
+        "H": heads,
+        "K": key_dim,
+        "V": value_dim,
+        "BT": _CHUNK_SIZE,
+        "BV": block_value_dim,
+        "WARP_SPECIALIZE": use_16bit_config,
+        "NUM_STAGES": 3 if use_16bit_config else 2,
+        "USE_INITIAL_STATE": initial_state is not None,
+        "STORE_FINAL_STATE": final_state is not None,
+        "USE_INT64_OFFSETS": requires_int64_offsets(k, w, u, v_new, h, initial_state, final_state),
+        "num_warps": 4,
+    }
+    value_tiles = value_dim // block_value_dim
+    sequence_workers = 0
+    if cu_seqlens is not None:
+        assert chunk_offsets is not None
+        sequence_workers = _persistent_sequence_workers(
+            RaggedChunkMetadata(cu_seqlens, chunk_offsets, capacity, _CHUNK_SIZE),
+            tokens,
+            heads,
+            value_tiles,
+            k.device,
+            schedule,
+        )
+    if sequence_workers:
+        # Keep one machine-sized wave warp-specialized, then stride persistent workers
+        # over the remaining work; Triton cannot warp-specialize the nested loop. This
+        # reduced N=512, M=32 graph replay from 1.22 ms to 0.68 ms on B200.
+        chunk_delta_h_kernel_k128_wsp[(sequence_workers, value_tiles)](
+            *kernel_args,
+            **kernel_options,
+            IS_VARLEN=True,
+        )
+        persistent_options = kernel_options | {
+            "WARP_SPECIALIZE": False,
+            "NUM_STAGES": 2,
+        }
+        chunk_delta_h_kernel_k128_persistent[(sequence_workers, value_tiles)](
+            *kernel_args,
+            **persistent_options,
+            NUM_SEQUENCES=state_batch,
+            NUM_WORKERS=sequence_workers,
+        )
+    else:
+        chunk_delta_h_kernel_k128_wsp[(state_batch * heads, value_tiles)](
+            *kernel_args,
+            **kernel_options,
+            IS_VARLEN=cu_seqlens is not None,
+        )
     return h, v_new
 
 

--- a/test/test_kda_chunk_scheduler.py
+++ b/test/test_kda_chunk_scheduler.py
@@ -316,6 +316,20 @@ def test_grid_scheduler_persistent_grid_is_machine_derived():
     assert GridScheduler(metadata._replace(capacity=0)).num_workers(3, "cuda") == 0
 
 
+def test_grid_scheduler_sequence_workers_use_sequence_capacity():
+    sm_count = torch.cuda.get_device_properties("cuda").multi_processor_count
+    cu_seqlens = torch.empty(513, device="cuda", dtype=torch.int32)
+    metadata = RaggedChunkMetadata(cu_seqlens, None, capacity=1, chunk_size=64)
+    scheduler = GridScheduler(metadata, ctas_per_sm=1)
+
+    resolved = scheduler.resolve_sequences(ScheduleRequest.PERSISTENT, 6, "cuda")
+    assert resolved == ResolvedSchedule(
+        ScheduleKind.PERSISTENT,
+        min(512 * 6, sm_count),
+        512 * 6,
+    )
+
+
 def test_grid_scheduler_chunk_workers_cap_at_sm_count():
     sm_count = torch.cuda.get_device_properties("cuda").multi_processor_count
     metadata = RaggedChunkMetadata(None, None, capacity=1 << 20, chunk_size=64)

--- a/test/test_kda_ragged_recurrence.py
+++ b/test/test_kda_ragged_recurrence.py
@@ -5,8 +5,18 @@ from __future__ import annotations
 import pytest
 import torch
 
-from attn_gym.linear.kda.chunk_scheduler import prepare_ragged_chunk_metadata
-from attn_gym.linear.kda.fwd.triton.chunk_delta_h import chunk_gated_delta_rule_fwd_h
+from attn_gym.linear.kda import chunk_scheduler
+from attn_gym.linear.kda.chunk_scheduler import (
+    RaggedChunkMetadata,
+    ScheduleRequest,
+    prepare_ragged_chunk_metadata,
+)
+from attn_gym.linear.kda.fwd.triton import chunk_delta_h
+from attn_gym.linear.kda.fwd.triton.chunk_delta_h import (
+    _delta_h_launch,
+    _persistent_sequence_workers,
+    chunk_gated_delta_rule_fwd_h,
+)
 from attn_gym.testing import cumulative_sequence_offsets
 
 pytestmark = pytest.mark.skipif(
@@ -72,6 +82,118 @@ def test_ragged_recurrence_matches_independent_sequences():
     torch.testing.assert_close(v_new, expected_v, rtol=0, atol=0)
     torch.testing.assert_close(h[:, :3], torch.cat(expected_h, dim=1), rtol=0, atol=0)
     torch.testing.assert_close(final_state, torch.stack(expected_final), rtol=0, atol=0)
+
+
+def _persistent_overflow_case(
+    dtype: torch.dtype,
+) -> tuple[tuple[torch.Tensor, ...], RaggedChunkMetadata, list[int]]:
+    torch.manual_seed(11)
+    lengths = [2, 0] * 40
+    tokens = sum(lengths)
+    heads = 2
+    shape = (1, tokens, heads, 128)
+    k = torch.randn(shape, device="cuda", dtype=dtype) / 32
+    w = torch.randn_like(k) / 32
+    u = torch.randn_like(k) / 32
+    gk = -torch.rand(shape, device="cuda")
+    initial_state = torch.randn(len(lengths), heads, 128, 128, device="cuda") / 32
+    metadata = prepare_ragged_chunk_metadata(cumulative_sequence_offsets(lengths), tokens, 64)
+    return (k, w, u, gk, initial_state), metadata, lengths
+
+
+def _run_persistent_overflow_case(
+    inputs: tuple[torch.Tensor, ...],
+    metadata: RaggedChunkMetadata,
+    schedule: ScheduleRequest,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Run one explicit schedule with a materialized final state."""
+    final_state = torch.empty_like(inputs[-1])
+    h, v_new = _delta_h_launch(
+        *inputs,
+        metadata.cu_seqlens,
+        metadata.chunk_offsets,
+        metadata.capacity,
+        final_state,
+        schedule,
+    )
+    return h, v_new, final_state
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+def test_ragged_recurrence_persistent_matches_static_with_active_overflow(dtype):
+    inputs, metadata, lengths = _persistent_overflow_case(dtype)
+    heads = inputs[0].shape[2]
+    sequence_workers = _persistent_sequence_workers(
+        metadata,
+        inputs[0].shape[1],
+        heads,
+        value_tiles=2 if dtype != torch.float32 else 4,
+        device=inputs[0].device,
+        schedule=ScheduleRequest.PERSISTENT,
+    )
+    sequence_extent = max(index + 1 for index, length in enumerate(lengths) if length)
+    assert sequence_workers < sequence_extent * heads
+
+    outputs = [
+        _run_persistent_overflow_case(inputs, metadata, schedule)
+        for schedule in (ScheduleRequest.STATIC, ScheduleRequest.PERSISTENT)
+    ]
+
+    active_chunks = metadata.chunk_offsets[-1].item()
+    torch.testing.assert_close(
+        outputs[1][0][:, :active_chunks], outputs[0][0][:, :active_chunks], rtol=0, atol=0
+    )
+    torch.testing.assert_close(outputs[1][1:], outputs[0][1:], rtol=0, atol=0)
+
+
+def test_ragged_recurrence_persistent_int64_matches_default(monkeypatch):
+    inputs, metadata, _ = _persistent_overflow_case(torch.bfloat16)
+
+    expected = _run_persistent_overflow_case(inputs, metadata, ScheduleRequest.PERSISTENT)
+    monkeypatch.setattr(chunk_delta_h, "requires_int64_offsets", lambda *_tensors: True)
+    actual = _run_persistent_overflow_case(inputs, metadata, ScheduleRequest.PERSISTENT)
+    active_chunks = metadata.chunk_offsets[-1].item()
+    torch.testing.assert_close(
+        actual[0][:, :active_chunks], expected[0][:, :active_chunks], rtol=0, atol=0
+    )
+    torch.testing.assert_close(actual[1:], expected[1:], rtol=0, atol=0)
+
+
+@pytest.mark.parametrize(
+    ("num_sequences", "heads", "tokens", "schedule", "expected_workers"),
+    (
+        (31, 16, 31 * 64, ScheduleRequest.AUTO, 0),
+        (32, 16, 32 * 64, ScheduleRequest.AUTO, 74),
+        (32, 16, 32 * 64 + 1, ScheduleRequest.AUTO, 0),
+        (64, 7, 64 * 64, ScheduleRequest.AUTO, 0),
+        (64, 8, 64 * 64, ScheduleRequest.AUTO, 74),
+        (32, 16, 32 * 64 + 1, ScheduleRequest.PERSISTENT, 74),
+        (512, 16, 2048, ScheduleRequest.STATIC, 0),
+    ),
+)
+def test_delta_h_auto_schedule_is_conservative(
+    monkeypatch,
+    num_sequences,
+    heads,
+    tokens,
+    schedule,
+    expected_workers,
+):
+    monkeypatch.setattr(chunk_scheduler, "_multiprocessor_count", lambda device: 148)
+    cu_seqlens = torch.empty(num_sequences + 1, device="cuda", dtype=torch.int32)
+    metadata = RaggedChunkMetadata(cu_seqlens, None, capacity=0, chunk_size=64)
+
+    assert (
+        _persistent_sequence_workers(
+            metadata,
+            tokens,
+            heads=heads,
+            value_tiles=2,
+            device=cu_seqlens.device,
+            schedule=schedule,
+        )
+        == expected_workers
+    )
 
 
 def test_ragged_recurrence_accepts_all_empty_sequences():
@@ -168,6 +290,97 @@ def test_ragged_recurrence_replays_aligned_to_ragged():
     torch.testing.assert_close(v_new, expected_v, rtol=0, atol=0)
     torch.testing.assert_close(h[:, :3], expected_h[:, :3], rtol=0, atol=0)
     torch.testing.assert_close(final_state, expected_final, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("use_initial_state", [False, True])
+@pytest.mark.parametrize("output_final_state", [False, True])
+def test_ragged_recurrence_persistent_cuda_graph_replays_active_sequences(
+    use_initial_state: bool,
+    output_final_state: bool,
+):
+    torch.manual_seed(13)
+    tokens, heads, num_sequences = 128, 16, 32
+    shape = (1, tokens, heads, 128)
+    k = torch.randn(shape, device="cuda", dtype=torch.bfloat16) / 32
+    w = torch.randn_like(k) / 32
+    u = torch.randn_like(k) / 32
+    gk = -torch.rand(shape, device="cuda")
+    initial_state = (
+        torch.randn(num_sequences, heads, 128, 128, device="cuda") / 32
+        if use_initial_state
+        else None
+    )
+    cu_seqlens = cumulative_sequence_offsets([4] * num_sequences)
+
+    warm_metadata = prepare_ragged_chunk_metadata(cu_seqlens, tokens, 64)
+    assert (
+        _persistent_sequence_workers(
+            warm_metadata,
+            tokens,
+            heads,
+            value_tiles=2,
+            device=k.device,
+            schedule=ScheduleRequest.AUTO,
+        )
+        > 0
+    )
+    chunk_gated_delta_rule_fwd_h(k, w, u, gk, initial_state, metadata=warm_metadata)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        metadata = prepare_ragged_chunk_metadata(cu_seqlens, tokens, 64)
+        h, v_new, final_state = chunk_gated_delta_rule_fwd_h(
+            k,
+            w,
+            u,
+            gk,
+            initial_state,
+            metadata=metadata,
+            output_final_state=output_final_state,
+        )
+    assert (final_state is not None) is output_final_state
+
+    replay_lengths = [8] * 16 + [0] * (num_sequences - 16)
+    cu_seqlens.copy_(cumulative_sequence_offsets(replay_lengths))
+    graph.replay()
+    torch.cuda.synchronize()
+
+    expected_metadata = prepare_ragged_chunk_metadata(cu_seqlens, tokens, 64)
+    replay_extent = max(index + 1 for index, length in enumerate(replay_lengths) if length)
+    sequence_workers = _persistent_sequence_workers(
+        expected_metadata,
+        tokens,
+        heads,
+        value_tiles=2,
+        device=k.device,
+        schedule=ScheduleRequest.AUTO,
+    )
+    assert sequence_workers < replay_extent * heads
+    expected_final = (
+        torch.empty(num_sequences, heads, 128, 128, device="cuda", dtype=torch.float32)
+        if output_final_state
+        else None
+    )
+    expected_h, expected_v = _delta_h_launch(
+        k,
+        w,
+        u,
+        gk,
+        initial_state,
+        expected_metadata.cu_seqlens,
+        expected_metadata.chunk_offsets,
+        expected_metadata.capacity,
+        expected_final,
+        ScheduleRequest.STATIC,
+    )
+    active_chunks = expected_metadata.chunk_offsets[-1].item()
+    torch.testing.assert_close(h[:, :active_chunks], expected_h[:, :active_chunks], rtol=0, atol=0)
+    torch.testing.assert_close(v_new, expected_v, rtol=0, atol=0)
+    if output_final_state:
+        torch.testing.assert_close(final_state, expected_final, rtol=0, atol=0)
+    else:
+        assert final_state is None and expected_final is None
 
 
 def test_delta_h_opcheck():


### PR DESCRIPTION
## Human Note

## Agent note

CUDA Graph capture fixes the inter-chunk recurrence grid at the maximum sequence capacity, so
replays with a short active sequence extent still launch every sequence/head/value-tile CTA. Add a
sequence-axis scheduler that derives the active extent from device `cu_seqlens`, preserves one
machine-sized warp-specialized wave, and strides a bounded persistent grid over the remaining work.
Interior empty sequences and trailing final-state slots retain their existing semantics.

Triton currently fails SM100 compilation when this warp-specialized recurrence is nested directly
inside a persistent loop. Keeping the first wave in the original kernel and using an ordinarily
pipelined persistent continuation avoids that compiler limitation. AUTO selection remains
conservative: it requires at least 32 sequence slots, 8 heads, at most one captured chunk per
sequence on average, and the shared scheduler's capacity-wave threshold.

## Performance

B200, BF16 public `chunk_kda` forward plus first-order backward in one fixed-pointer CUDA Graph:

| T | N | M | static | AUTO | result |
|---:|---:|---:|---:|---:|---:|
| 2,048 | 512 | 32 | 1,215.20 us | 677.09 us | 1.79x |
| 2,048 | 512 | 512 | 5,506.37 us | 5,189.09 us | 1.06x |

A rejected long-recurrence holdout (`T=8192`, `N=M=32`) measured 1,226.78 us static, 1,241.54 us
forced persistent, and 1,226.66 us AUTO, confirming that AUTO retained the static path.

## Test Plan

```bash
gpu-run auto -- env PYTHONPATH=$PWD .venv/bin/pytest -n 6 -q test/test_kda_chunk_scheduler.py test/test_kda_ragged_recurrence.py test/test_kda_cute_forward.py test/test_kda_compile_dynamic_shapes.py test/test_kda_int64_offsets.py test/test_kda_kernels.py::test_chunk_delta_h_fwd test/test_kda_kernels.py::test_chunk_delta_h_fwd_fp32_path
git add attn_gym/linear/kda/chunk_schedule.py attn_gym/linear/kda/chunk_scheduler.py attn_gym/linear/kda/fwd/triton/chunk_delta_h.py test/test_kda_chunk_scheduler.py test/test_kda_ragged_recurrence.py && prek && git reset
gpu-run auto -- env PYTHONPATH=$PWD .venv/bin/python agent_space/delta_h_persistent_prototype/run_full_mode.py --mode auto --label ship_auto --output-dir agent_space/delta_h_persistent_prototype/ship_holdout/auto --tokens 2048 --max-sequences 512 --active-tokens 2048 --active-sequences 32 --samples 15 --warmup-replays 8
```
