### PR TITLE
Select persistent KDA inter-solve after three waves

### DIFF
--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_inter_solve.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_inter_solve.py
@@ -45,6 +45,9 @@ _SUPPORTED_HEAD_DIM = 128
 _SUPPORTED_CHUNK_SIZE = 64
 _SUPPORTED_SUBCHUNK_SIZE = 16
 _SUPPORTED_NUM_SUBCHUNKS = 4
+# K3/K4 persistent execution wins beyond three chunk-worker waves; the shared
+# four-wave threshold leaves the N=512, T=2048 graph on the 5.4x slower static path.
+_INTER_SOLVE_AUTO_WAVES = 3
 
 
 def _check_compile_target() -> None:
@@ -78,7 +81,14 @@ def _resolve_ragged_execution(
     validate_schedule_request(request)
     if isinstance(tensor, FakeTensor):
         return ResolvedSchedule(ScheduleKind.STATIC, 0, metadata.capacity)
-    return GridScheduler(metadata).resolve_chunk(request, tensor.device)
+    resolved = GridScheduler(metadata).resolve_chunk(request, tensor.device)
+    if (
+        request is ScheduleRequest.AUTO
+        and resolved.kind is ScheduleKind.STATIC
+        and metadata.capacity > _INTER_SOLVE_AUTO_WAVES * resolved.workers
+    ):
+        return ResolvedSchedule(ScheduleKind.PERSISTENT, resolved.workers, metadata.capacity)
+    return resolved
 
 
 def _make_fake_chunk_index(

--- a/test/test_kda_ragged_k4.py
+++ b/test/test_kda_ragged_k4.py
@@ -7,10 +7,13 @@ import torch
 
 from attn_gym.linear.kda.chunk_scheduler import (
     GridScheduler,
+    RaggedChunkMetadata,
+    ScheduleKind,
     ScheduleRequest,
     prepare_ragged_chunk_metadata,
 )
 from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd_inter_solve import (
+    _resolve_ragged_execution,
     chunk_kda_fwd_inter_solve_ragged_cute,
     chunk_kda_fwd_k4b_ragged_cute,
 )
@@ -136,6 +139,36 @@ def test_ragged_inter_solve_accepts_all_empty_sequences(lengths, monkeypatch):
     assert actual_akk.shape == (1, 0, 1, 64)
     assert forced_akk.shape == actual_akk.shape
     assert requests == [ScheduleRequest.AUTO, ScheduleRequest.PERSISTENT]
+
+
+@pytest.mark.parametrize(
+    ("schedule_request", "capacity", "expected_kind"),
+    (
+        (ScheduleRequest.AUTO, 300, ScheduleKind.STATIC),
+        (ScheduleRequest.AUTO, 301, ScheduleKind.PERSISTENT),
+        (ScheduleRequest.STATIC, 301, ScheduleKind.STATIC),
+        (ScheduleRequest.PERSISTENT, 1, ScheduleKind.PERSISTENT),
+    ),
+)
+def test_ragged_inter_solve_uses_three_wave_auto_threshold(
+    monkeypatch, schedule_request, capacity, expected_kind
+):
+    monkeypatch.setattr(
+        GridScheduler,
+        "num_chunk_workers",
+        lambda self, device: min(self.metadata.capacity, 100),
+    )
+    metadata = RaggedChunkMetadata(
+        torch.empty(2, device="cuda", dtype=torch.int32),
+        torch.empty(2, device="cuda", dtype=torch.int32),
+        capacity,
+        64,
+    )
+    resolved = _resolve_ragged_execution(torch.empty(1, device="cuda"), metadata, schedule_request)
+
+    assert resolved.kind is expected_kind
+    assert resolved.workers == min(capacity, 100)
+    assert resolved.capacity_tasks == capacity
 
 
 def test_ragged_inter_solve_nonempty_resolves_once(monkeypatch):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #359
* __->__ #358

## Human Note

## Agent note

The shared four-wave AUTO threshold keeps ragged K3/K4 on their capacity-sized static grids at the
`T=2048`, `N=512` CUDA Graph shape even though their existing persistent implementations are much
faster for sparse replays. Give the composed inter-solve a local three-wave crossover while leaving
the scheduler default and every other KDA stage unchanged. K3 and K4 continue to share one resolved
schedule.

## Performance

B200, BF16 K3+K4 CUDA Graph replay, `T=2048`, `N=512`, `M=32`, `H=16`:

| schedule | median |
|---|---:|
| static | 223.84 us |
| persistent | 40.88 us |
| AUTO | 40.91 us |

Across `M=1,8,32,64,128,256,384,512`, persistent ranged from 5.44x faster at `M=32` to 1.9%
slower at the fully active `M=512` endpoint.

## Test Plan

```bash
gpu-run auto -- env PYTHONPATH=$PWD .venv/bin/pytest test/test_kda_ragged_k3.py test/test_kda_ragged_k4.py -n 6 -q
gpu-run auto -- env PYTHONPATH=$PWD .venv/bin/python /home/dev/meta/attention-gym/agent_space/cuda_graph_overcapture/benchmark_k3_k4_schedule.py --output agent_space/k3_k4_selector_after.json --samples 30
```