### PR TITLE
Bound ragged KDA dHU work by active sequences

### DIFF
--- a/attn_gym/linear/kda/bwd/cute/chunk_delta_h_bwd_v1.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_delta_h_bwd_v1.py
@@ -39,6 +39,7 @@ from attn_gym._backends.cute.cache import jit_cache
 from attn_gym._backends.cute.target import get_compile_target
 from attn_gym._backends.cute.utils import compile_tvm_ffi, requires_int64_abi
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata
+from attn_gym.linear.kda.fwd.cute.chunk_scheduler_cute import load_ragged_sequence_extent
 
 # ============================================================================
 # BlackwellDeltaHBwdV1 — warp-specialized backward inter-chunk recurrence
@@ -79,6 +80,7 @@ class BlackwellDeltaHBwdV1:
         varlen: bool = False,
         num_heads: int | None = None,
         use_int64_offsets: bool = False,
+        bound_sequence_extent: bool = False,
     ):
         assert head_k == 128 and head_v == 128, (
             f"Only head_k=head_v=128 supported, got {head_k},{head_v}"
@@ -92,6 +94,8 @@ class BlackwellDeltaHBwdV1:
         self.varlen = varlen
         self.num_heads = num_heads
         self.use_int64_offsets = use_int64_offsets
+        self.bound_sequence_extent = bound_sequence_extent
+        assert not bound_sequence_extent or varlen, "sequence extent applies only to varlen inputs"
 
         # Tile dimensions
         self.BT = chunk_size  # 64
@@ -146,7 +150,7 @@ class BlackwellDeltaHBwdV1:
         return (
             f"kda_bwd_dhu_v1_vl{int(self.varlen)}{head_tag}"
             f"_k{self.head_k}_v{self.head_v}_bt{self.BT}_bv{self.BV}"
-            f"_i64{int(self.use_int64_offsets)}"
+            f"_i64{int(self.use_int64_offsets)}_se{int(self.bound_sequence_extent)}"
         )
 
     # ------------------------------------------------------------------
@@ -737,6 +741,7 @@ class BlackwellDeltaHBwdV1:
     ):
         warp_id = cute.arch.make_warp_uniform(cute.arch.warp_idx())
         tid, _, _ = cute.arch.thread_idx()
+        lane = tid % self.WARP_SZ
 
         # Prefetch TMA descriptors (load warp)
         if warp_id == self.LOAD_WARP_ID:
@@ -986,7 +991,13 @@ class BlackwellDeltaHBwdV1:
         gdx = cute.arch.grid_dim()[0]
         n_vtiles = (V + self.BV - 1) // self.BV
 
-        w_tiles = n_vtiles * H * B
+        sequence_extent = B
+        if cutlass.const_expr(self.bound_sequence_extent):
+            if lane == 0:
+                sequence_extent = load_ragged_sequence_extent(cu_seqlens)
+            sequence_extent = Int32(cute.arch.shuffle_sync(sequence_extent, 0))
+
+        w_tiles = n_vtiles * H * sequence_extent
 
         n_iters = (w_tiles - bx + gdx - 1) // gdx
         w_idx = Int32(0)
@@ -1760,7 +1771,16 @@ class BlackwellDeltaHBwdV1:
 
 
 @jit_cache
-def _compile_bwd_dhu(varlen, H, K, V, chunk_size, bv=16, use_int64_offsets=False):
+def _compile_bwd_dhu(
+    varlen,
+    H,
+    K,
+    V,
+    chunk_size,
+    bv=16,
+    use_int64_offsets=False,
+    bound_sequence_extent=False,
+):
     """Compile one BlackwellDeltaHBwdV1 variant."""
     kern = BlackwellDeltaHBwdV1(
         chunk_size=chunk_size,
@@ -1770,6 +1790,7 @@ def _compile_bwd_dhu(varlen, H, K, V, chunk_size, bv=16, use_int64_offsets=False
         varlen=varlen,
         num_heads=H,
         use_int64_offsets=use_int64_offsets,
+        bound_sequence_extent=bound_sequence_extent,
     )
     sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
     sa, sb, snt, sn, sns = (sym_int() for _ in range(5))
@@ -1910,6 +1931,25 @@ def _is_fake_mode() -> bool:
 # Public API wrapper
 # ============================================================================
 
+_MIN_SEQUENCE_EXTENT_SEQUENCES = 32
+_MIN_SEQUENCE_EXTENT_HEADS = 8
+
+
+def _should_bound_sequence_extent(
+    tokens: int,
+    sequences: int,
+    heads: int,
+    chunk_size: int,
+    has_initial_state: bool,
+) -> bool:
+    """Select the measured graph-overcapture region for sequence-bounded dHU."""
+    return (
+        not has_initial_state
+        and sequences >= _MIN_SEQUENCE_EXTENT_SEQUENCES
+        and heads >= _MIN_SEQUENCE_EXTENT_HEADS
+        and tokens <= sequences * chunk_size
+    )
+
 
 def _get_dummy(shape, dtype, device) -> torch.Tensor:
     """Create an invocation-local placeholder for an unused kernel argument."""
@@ -1986,7 +2026,22 @@ def blackwell_delta_h_bwd_dhu_v1(
             dho,
             dv2_k,
         )
-        fn = _compile_bwd_dhu(True, H, K, V, chunk_size, bv, use_int64_offsets=use_int64_offsets)
+        fn = _compile_bwd_dhu(
+            True,
+            H,
+            K,
+            V,
+            chunk_size,
+            bv,
+            use_int64_offsets=use_int64_offsets,
+            bound_sequence_extent=_should_bound_sequence_extent(
+                T,
+                N,
+                H,
+                chunk_size,
+                h0 is not None,
+            ),
+        )
         fn(
             q_k,
             k_k,

--- a/attn_gym/linear/kda/fwd/cute/chunk_scheduler_cute.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_scheduler_cute.py
@@ -20,6 +20,22 @@ def load_ragged_chunk_count(chunk_offsets: cute.Tensor):
 
 
 @cute.jit
+def load_ragged_sequence_extent(cu_seqlens: cute.Tensor):
+    """Return one past the last sequence slot that may contain tokens."""
+    num_sequences = Int32(cute.size(cu_seqlens)) - 1
+    active_tokens = Int32(cu_seqlens[num_sequences])
+    sequence_extent = num_sequences
+    if Int32(cu_seqlens[num_sequences - 1]) >= active_tokens:
+        sequence_extent = upper_bound(
+            cu_seqlens,
+            active_tokens - 1,
+            Int32(0),
+            num_sequences,
+        )
+    return sequence_extent
+
+
+@cute.jit
 def load_ragged_chunk_work(
     cu_seqlens: cute.Tensor,
     chunk_offsets: cute.Tensor,
@@ -200,4 +216,5 @@ __all__ = [
     "decode_ragged_chunk_work_cute",
     "load_ragged_chunk_count",
     "load_ragged_chunk_work",
+    "load_ragged_sequence_extent",
 ]

--- a/test/test_kda_ragged_delta_h_bwd.py
+++ b/test/test_kda_ragged_delta_h_bwd.py
@@ -9,11 +9,15 @@ import torch
 
 pytest.importorskip("cutlass")
 
-from attn_gym.linear.kda.bwd.cute.chunk_delta_h_bwd_v1 import blackwell_delta_h_bwd_dhu_v1
+from attn_gym.linear.kda.bwd.cute import chunk_delta_h_bwd_v1
+from attn_gym.linear.kda.bwd.cute.chunk_delta_h_bwd_v1 import (
+    _should_bound_sequence_extent,
+    blackwell_delta_h_bwd_dhu_v1,
+)
 from attn_gym.linear.kda.bwd.cute.chunk_delta_h_bwd_v1_dispatch import (
     blackwell_delta_h_bwd_dhu_dispatch,
 )
-from attn_gym.linear.kda.chunk_scheduler import prepare_ragged_chunk_metadata
+from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata, prepare_ragged_chunk_metadata
 from attn_gym.testing import cumulative_sequence_offsets
 
 pytestmark = pytest.mark.skipif(
@@ -22,16 +26,16 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def _inputs(tokens: int, sequences: int) -> tuple[torch.Tensor, ...]:
+def _inputs(tokens: int, sequences: int, heads: int = 1) -> tuple[torch.Tensor, ...]:
     torch.manual_seed(37)
-    shape = (1, tokens, 1, 128)
+    shape = (1, tokens, heads, 128)
     q = torch.randn(shape, device="cuda", dtype=torch.bfloat16) / 8
     k = torch.randn_like(q) / 8
     w = torch.randn_like(q) / 8
     do = torch.randn_like(q) / 8
     dv = torch.randn_like(q) / 8
     gk = -torch.rand(shape, device="cuda")
-    h0 = torch.randn(sequences, 1, 128, 128, device="cuda") / 8
+    h0 = torch.randn(sequences, heads, 128, 128, device="cuda") / 8
     dht = torch.randn_like(h0) / 8
     return q, k, w, do, dv, gk, h0, dht
 
@@ -51,6 +55,59 @@ def _run_ragged(
         else partial(blackwell_delta_h_bwd_dhu_v1, bv=bv)
     )
     return operation(q, k, w, do, dv, gk=gk, h0=h0, dht=dht, scale=128**-0.5, metadata=metadata)
+
+
+@pytest.mark.parametrize(
+    ("tokens", "sequences", "heads", "has_initial_state", "expected"),
+    (
+        (2048, 31, 16, False, False),
+        (2048, 32, 7, False, False),
+        (2048, 32, 8, False, True),
+        (2049, 32, 8, False, False),
+        (2048, 512, 16, True, False),
+    ),
+)
+def test_delta_h_sequence_extent_selector(tokens, sequences, heads, has_initial_state, expected):
+    assert (
+        _should_bound_sequence_extent(tokens, sequences, heads, 64, has_initial_state) is expected
+    )
+
+
+def _run_without_initial_state(
+    inputs: tuple[torch.Tensor, ...],
+    metadata: RaggedChunkMetadata,
+    *,
+    bv: int = 32,
+    dht: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, None, torch.Tensor]:
+    """Run dHU without materializing an initial-state gradient."""
+    return blackwell_delta_h_bwd_dhu_v1(
+        *inputs[:5],
+        gk=inputs[5],
+        h0=None,
+        dht=dht,
+        scale=128**-0.5,
+        metadata=metadata,
+        bv=bv,
+    )
+
+
+def test_ragged_delta_h_without_initial_state_handles_zero_sequence_extent():
+    physical_tokens = 128
+    num_sequences = 32
+    inputs = _inputs(physical_tokens, num_sequences, heads=8)
+    metadata = prepare_ragged_chunk_metadata(
+        cumulative_sequence_offsets([0] * num_sequences), physical_tokens, 64
+    )
+    for tensor in inputs[:6]:
+        tensor.fill_(torch.nan)
+
+    dh, dh0, dv = _run_without_initial_state(inputs, metadata)
+    torch.cuda.synchronize()
+
+    assert dh.shape == (1, metadata.capacity, 8, 128, 128)
+    assert dh0 is None
+    assert dv.shape == inputs[4].shape
 
 
 def test_ragged_delta_h_handles_all_empty_sequences():
@@ -187,3 +244,104 @@ def test_ragged_delta_h_replays_aligned_boundaries(replayed_lengths):
     )
     torch.testing.assert_close(captured_dh0, expected_dh0, rtol=0, atol=0)
     torch.testing.assert_close(captured_dv, expected_dv, rtol=0, atol=0)
+
+
+def test_ragged_delta_h_sequence_extent_forced_int64_matches_default(monkeypatch):
+    lengths = [65, 0, 63] + [0] * 77
+    inputs = _inputs(sum(lengths), len(lengths), heads=8)
+    metadata = prepare_ragged_chunk_metadata(
+        cumulative_sequence_offsets(lengths), sum(lengths), 64
+    )
+
+    expected_dh, expected_dh0, expected_dv = _run_without_initial_state(inputs, metadata)
+    monkeypatch.setattr(chunk_delta_h_bwd_v1, "requires_int64_abi", lambda *_tensors: True)
+    actual_dh, actual_dh0, actual_dv = _run_without_initial_state(inputs, metadata)
+    assert actual_dh0 is None and expected_dh0 is None
+    active_chunks = metadata.chunk_offsets[-1].item()
+    torch.testing.assert_close(
+        actual_dh[:, :active_chunks], expected_dh[:, :active_chunks], rtol=0, atol=0
+    )
+    torch.testing.assert_close(actual_dv, expected_dv, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize(
+    "replay_lengths",
+    (
+        pytest.param([65, 0, 63] + [0] * 77, id="sparse-interior-empty"),
+        pytest.param([4] * 16 + [3] * 64, id="fully-active"),
+    ),
+)
+@pytest.mark.parametrize("use_dht", [False, True])
+@pytest.mark.parametrize("bv", [16, 32])
+def test_ragged_delta_h_replay_bounds_sequence_extent_without_initial_state(
+    replay_lengths, use_dht, bv
+):
+    physical_tokens = 256
+    num_sequences = 80
+    inputs = _inputs(physical_tokens, num_sequences, heads=8)
+    q, k, w, do, dv, gk = inputs[:6]
+    cu_seqlens = cumulative_sequence_offsets([4] * 64 + [0] * 16)
+
+    warm_metadata = prepare_ragged_chunk_metadata(cu_seqlens, physical_tokens, 64)
+    blackwell_delta_h_bwd_dhu_v1(
+        q,
+        k,
+        w,
+        do,
+        dv,
+        gk=gk,
+        h0=None,
+        dht=inputs[7] if use_dht else None,
+        scale=128**-0.5,
+        metadata=warm_metadata,
+        bv=bv,
+    )
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        metadata = prepare_ragged_chunk_metadata(cu_seqlens, physical_tokens, 64)
+        actual_dh, actual_dh0, actual_dv = blackwell_delta_h_bwd_dhu_v1(
+            q,
+            k,
+            w,
+            do,
+            dv,
+            gk=gk,
+            h0=None,
+            dht=inputs[7] if use_dht else None,
+            scale=128**-0.5,
+            metadata=metadata,
+            bv=bv,
+        )
+    assert actual_dh0 is None
+
+    active_tokens = sum(replay_lengths)
+    cu_seqlens.copy_(cumulative_sequence_offsets(replay_lengths))
+    for tensor in (q, k, w, do, dv, gk):
+        tensor[:, active_tokens:].fill_(torch.nan)
+    graph.replay()
+    torch.cuda.synchronize()
+
+    sequence_extent = max(index + 1 for index, length in enumerate(replay_lengths) if length)
+    compact_inputs = tuple(tensor[:, :active_tokens].clone() for tensor in inputs[:6])
+    compact_metadata = prepare_ragged_chunk_metadata(
+        cumulative_sequence_offsets(replay_lengths[:sequence_extent]), active_tokens, 64
+    )
+    expected_dh, expected_dh0, expected_dv = blackwell_delta_h_bwd_dhu_v1(
+        *compact_inputs[:5],
+        gk=compact_inputs[5],
+        h0=None,
+        dht=inputs[7][:sequence_extent].clone() if use_dht else None,
+        scale=128**-0.5,
+        metadata=compact_metadata,
+        bv=bv,
+    )
+    assert expected_dh0 is None
+    active_chunks = compact_metadata.chunk_offsets[-1].item()
+    torch.testing.assert_close(
+        actual_dh[:, :active_chunks], expected_dh[:, :active_chunks], rtol=0, atol=0
+    )
+    torch.testing.assert_close(
+        actual_dv[:, :active_tokens], expected_dv[:, :active_tokens], rtol=0, atol=0
+    )


### PR DESCRIPTION
## Human Note

## Agent note

The ragged dHU kernel already launches one fixed SM-sized grid, but every worker strides through the
captured `N × heads × value_tiles` sequence space. Derive the trailing active sequence extent from
device `cu_seqlens` and use it as the persistent loop bound so CUDA Graph replay skips repeated-end
sequence slots without host synchronization.

Compile this path only in the measured graph-overcapture region and only when no initial-state
gradient is requested. Calls with `h0` retain the original `N`-slot specialization so empty-sequence
`dh0 = dht` semantics and the existing code generation remain unchanged. A warp-local lane-zero
lookup and shuffle give every pipeline role the same trip count without adding a CTA barrier.

## Performance

B200, BF16 dHU CUDA Graph replay, `T=2048`, `N=512`, `H=16`, no initial state:

| M | before | after | result |
|---:|---:|---:|---:|
| 1 | 111.94 us | 50.05 us | 2.24x |
| 32 | 92.13 us | 35.23 us | 2.62x |
| 512 | 1,486.21 us | 1,577.38 us | 0.94x |

On top of the K3/K4 selector layer, full public `chunk_kda` forward/backward replay moves from
495.26 to 437.63 us at `M=32` (1.13x) and from 5,205.79 to 5,284.45 us at `M=512` (1.5% slower).

## Test Plan

```bash
gpu-run auto -- env CUTE_DSL_NO_CACHE=1 PYTHONPATH=$PWD .venv/bin/pytest test/test_kda_ragged_delta_h_bwd.py -q
gpu-run auto -- env PYTHONPATH=$PWD .venv/bin/pytest -n 6 -q test/test_kda_ragged_k3.py test/test_kda_ragged_k4.py test/test_kda_ragged_delta_h_bwd.py test/test_kda_ragged_public_backward.py test/test_kda_cute_forward.py test/test_kda_int64_offsets.py test/test_kda_compile_dynamic_shapes.py test/test_kda_chunk_scheduler.py
gpu-run auto -- env CUTE_DSL_NO_CACHE=1 PYTHONPATH=$PWD .venv/bin/python agent_space/dhu_m_sweep.py --label final --output agent_space/dhu_final.json --samples 15
```

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>