### PR TITLE
Select persistent KDA inter-solve for short captures

### DIFF
--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_inter_solve.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_inter_solve.py
@@ -45,9 +45,11 @@ _SUPPORTED_HEAD_DIM = 128
 _SUPPORTED_CHUNK_SIZE = 64
 _SUPPORTED_SUBCHUNK_SIZE = 16
 _SUPPORTED_NUM_SUBCHUNKS = 4
-# K3/K4 persistent execution wins beyond three chunk-worker waves; the shared
-# four-wave threshold leaves the N=512, T=2048 graph on the 5.4x slower static path.
-_INTER_SOLVE_AUTO_WAVES = 3
+# Short average sequences benefit from persistence as soon as the capacity grid
+# exceeds one machine-sized wave. Longer recurrences retain the conservative
+# three-wave crossover because the persistent chunk loop can otherwise lose.
+_INTER_SOLVE_SHORT_AUTO_WAVES = 1
+_INTER_SOLVE_LONG_AUTO_WAVES = 3
 
 
 def _check_compile_target() -> None:
@@ -82,10 +84,13 @@ def _resolve_ragged_execution(
     if isinstance(tensor, FakeTensor):
         return ResolvedSchedule(ScheduleKind.STATIC, 0, metadata.capacity)
     resolved = GridScheduler(metadata).resolve_chunk(request, tensor.device)
+    num_sequences = metadata.cu_seqlens.shape[0] - 1
+    short_average = tensor.shape[1] <= num_sequences * _SUPPORTED_CHUNK_SIZE
+    auto_waves = _INTER_SOLVE_SHORT_AUTO_WAVES if short_average else _INTER_SOLVE_LONG_AUTO_WAVES
     if (
         request is ScheduleRequest.AUTO
         and resolved.kind is ScheduleKind.STATIC
-        and metadata.capacity > _INTER_SOLVE_AUTO_WAVES * resolved.workers
+        and metadata.capacity > auto_waves * resolved.workers
     ):
         return ResolvedSchedule(ScheduleKind.PERSISTENT, resolved.workers, metadata.capacity)
     return resolved

--- a/test/test_kda_ragged_k4.py
+++ b/test/test_kda_ragged_k4.py
@@ -142,16 +142,18 @@ def test_ragged_inter_solve_accepts_all_empty_sequences(lengths, monkeypatch):
 
 
 @pytest.mark.parametrize(
-    ("schedule_request", "capacity", "expected_kind"),
+    ("schedule_request", "tokens", "num_sequences", "capacity", "expected_kind"),
     (
-        (ScheduleRequest.AUTO, 300, ScheduleKind.STATIC),
-        (ScheduleRequest.AUTO, 301, ScheduleKind.PERSISTENT),
-        (ScheduleRequest.STATIC, 301, ScheduleKind.STATIC),
-        (ScheduleRequest.PERSISTENT, 1, ScheduleKind.PERSISTENT),
+        (ScheduleRequest.AUTO, 6400, 100, 100, ScheduleKind.STATIC),
+        (ScheduleRequest.AUTO, 6400, 100, 101, ScheduleKind.PERSISTENT),
+        (ScheduleRequest.AUTO, 6401, 100, 300, ScheduleKind.STATIC),
+        (ScheduleRequest.AUTO, 6401, 100, 301, ScheduleKind.PERSISTENT),
+        (ScheduleRequest.STATIC, 6400, 100, 301, ScheduleKind.STATIC),
+        (ScheduleRequest.PERSISTENT, 6401, 100, 1, ScheduleKind.PERSISTENT),
     ),
 )
-def test_ragged_inter_solve_uses_three_wave_auto_threshold(
-    monkeypatch, schedule_request, capacity, expected_kind
+def test_ragged_inter_solve_uses_average_length_auto_threshold(
+    monkeypatch, schedule_request, tokens, num_sequences, capacity, expected_kind
 ):
     monkeypatch.setattr(
         GridScheduler,
@@ -159,12 +161,13 @@ def test_ragged_inter_solve_uses_three_wave_auto_threshold(
         lambda self, device: min(self.metadata.capacity, 100),
     )
     metadata = RaggedChunkMetadata(
-        torch.empty(2, device="cuda", dtype=torch.int32),
-        torch.empty(2, device="cuda", dtype=torch.int32),
+        torch.empty(num_sequences + 1, device="cuda", dtype=torch.int32),
+        torch.empty(num_sequences + 1, device="cuda", dtype=torch.int32),
         capacity,
         64,
     )
-    resolved = _resolve_ragged_execution(torch.empty(1, device="cuda"), metadata, schedule_request)
+    tensor = torch.empty(1, tokens, device="cuda")
+    resolved = _resolve_ragged_execution(tensor, metadata, schedule_request)
 
     assert resolved.kind is expected_kind
     assert resolved.workers == min(capacity, 100)


### PR DESCRIPTION
## Human Note

## Agent note

The three-wave K3/K4 crossover fixed highly overcaptured N=512 graphs but left smaller short-
sequence capacities on the static path. Select persistent execution after one machine-sized wave
when the captured tensor averages at most one chunk per sequence, while retaining the conservative
three-wave crossover for longer average sequences.

## Performance

B200, BF16 K3+K4 fixed-pointer CUDA Graph replay covered 70 discovery and holdout shapes across
T=2048--16384, H=8/16/32, sparse and fully active sequence layouts. The changed region had a 1.12x
median speedup and a 2.2% worst isolated regression. Full public chunk_kda forward+backward at
T=L=2048, M=32 improved 453.62 to 416.22 us for N=128 and 506.22 to 423.22 us for N=256; N=32,
64, and 512 remained unchanged. Fully active N=128/256/384 public replays were unchanged within
0.6% and slightly faster in the combined runs.

## Test Plan

```bash
gpu-run auto -- env PYTHONPATH=$PWD .venv/bin/pytest -n 6 -q test/test_kda_ragged_k3.py test/test_kda_ragged_k4.py test/test_kda_cute_forward.py test/test_kda_int64_offsets.py test/test_kda_compile_dynamic_shapes.py
prek
```
