### PR TITLE
Add persistent scheduling to packed short convolution

### DIFF
--- a/attn_gym/linear/kda/fwd/cute/chunk_scheduler_cute.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_scheduler_cute.py
@@ -20,10 +20,16 @@ def load_ragged_chunk_count(chunk_offsets: cute.Tensor):
 
 
 @cute.jit
+def load_ragged_token_count(cu_seqlens: cute.Tensor):
+    """Load the terminal packed offset containing the runtime active token count."""
+    return Int32(cu_seqlens[cute.size(cu_seqlens) - 1])
+
+
+@cute.jit
 def load_ragged_sequence_extent(cu_seqlens: cute.Tensor):
     """Return one past the last sequence slot that may contain tokens."""
     num_sequences = Int32(cute.size(cu_seqlens)) - 1
-    active_tokens = Int32(cu_seqlens[num_sequences])
+    active_tokens = load_ragged_token_count(cu_seqlens)
     sequence_extent = num_sequences
     if Int32(cu_seqlens[num_sequences - 1]) >= active_tokens:
         sequence_extent = upper_bound(
@@ -217,4 +223,5 @@ __all__ = [
     "load_ragged_chunk_count",
     "load_ragged_chunk_work",
     "load_ragged_sequence_extent",
+    "load_ragged_token_count",
 ]

--- a/attn_gym/linear/kda/short_conv/cute.py
+++ b/attn_gym/linear/kda/short_conv/cute.py
@@ -27,15 +27,10 @@ import torch
 from cutlass import BFloat16, Float16, Float32, Int32, Int64, cute, pipeline
 from cutlass.cute.nvgpu import cpasync
 
-from attn_gym._backends.cute import (
-    ceildiv,
-    compile_tvm_ffi,
-    get_device_properties,
-    jit_cache,
-    tune,
-)
+from attn_gym._backends.cute import ceildiv, compile_tvm_ffi, jit_cache, tune
 from attn_gym._backends.cute.device import upper_bound
 from attn_gym.linear.kda import ops as kda_ops
+from attn_gym.linear.kda.fwd.cute.chunk_scheduler_cute import load_ragged_token_count
 from attn_gym.linear.kda.short_conv.activations import Activation, resolve_activation
 
 _forward_op = kda_ops.short_conv_forward_op
@@ -60,32 +55,6 @@ SHORT_CONV_DTYPES = {
     torch.bfloat16: ShortConvDType(BFloat16, "bf16"),
     torch.float32: ShortConvDType(Float32, "fp32"),
 }
-
-
-# NOTE [Short-convolution time scheduling]
-# Match the shared scheduler's concrete launch convention: zero time workers means a
-# static capacity grid whose inactive CTAs return from a device check; a positive count
-# means a bounded grid that strides over active tiles. The measured short-convolution
-# policy uses eight CTAs per SM across the complete channel/time grid.
-_SHORT_CONV_CTAS_PER_SM = 8
-
-
-def _persistent_time_workers(
-    tokens: int,
-    channels: int,
-    config: ShortConvConfig,
-    device: torch.device,
-    *,
-    persistent_eligible: bool,
-) -> int:
-    """Return a bounded packed time grid, or zero for static execution."""
-    if not persistent_eligible:
-        return 0
-    capacity = ceildiv(tokens, config.times_per_block)
-    channel_blocks = ceildiv(channels, config.threads * config.channels_per_thread)
-    device_workers = get_device_properties(device).multi_processor_count * _SHORT_CONV_CTAS_PER_SM
-    workers = ceildiv(device_workers, channel_blocks)
-    return workers if workers < capacity else 0
 
 
 @dataclass(frozen=True)
@@ -291,7 +260,6 @@ class ShortConvKernel:
         width: int,
         config: ShortConvConfig,
         dtype: ShortConvDType,
-        time_workers: int = 0,
     ):
         self.sequences = sequences
         self.tokens = tokens
@@ -301,7 +269,6 @@ class ShortConvKernel:
         self.channels_per_thread = config.channels_per_thread
         self.times_per_block = config.times_per_block
         self.dtype = dtype
-        self.time_workers = time_workers
 
     def get_name(self) -> str:
         """Return the stable compiled-artifact name."""
@@ -311,12 +278,19 @@ class ShortConvKernel:
         )
         if self.time_tiled:
             name += f"_bt{self.times_per_block}"
-        if self.time_workers:
-            name += f"_execution_persistent_tw{self.time_workers}"
         name += f"_v{self.channels_per_thread}"
         if self.tma_stage_tokens:
             name += f"_tma{self.tma_stage_tokens}"
         return name
+
+
+# NOTE [Packed forward active endpoint]
+# CUDA Graph capture fixes the physical token capacity T, while cu_seqlens[-1]
+# supplies the runtime active token count L. Keep the natural capacity launch grid
+# for full-length throughput, but let CTAs whose tile begins at or beyond L return
+# before loading weights or allocating tile-local registers. Active CTAs also clamp
+# their input window and stores to L. The inactive output suffix is intentionally
+# undefined and is masked by the KDA wrapper before another operation consumes it.
 
 
 class CausalConv1dSiluForward(ShortConvKernel):
@@ -333,9 +307,8 @@ class CausalConv1dSiluForward(ShortConvKernel):
         config: ShortConvConfig,
         dtype: ShortConvDType,
         activation,
-        time_workers: int = 0,
     ):
-        super().__init__(batches, tokens, channels, width, config, dtype, time_workers)
+        super().__init__(batches, tokens, channels, width, config, dtype)
         self.batches = batches
         self.activation = activation
 
@@ -347,94 +320,103 @@ class CausalConv1dSiluForward(ShortConvKernel):
         output: cute.Tensor,
         cu_seqlens: cute.Tensor | None,
         initial_state: cute.Tensor | None,
-        channel_group: Int32,
-        channel: Int32,
-        time_block: Int32,
-        batch: Int32,
-        active_endpoint: Int32,
+        full_endpoint: cutlass.Constexpr,
     ):
-        """Compute one independent physical time tile for a channel group."""
+        """Compute the physical time tile owned by this CTA."""
+        thread_idx, _, _ = cute.arch.thread_idx()
+        channel_block, time_block, batch = cute.arch.block_idx()
+        channel_group = channel_block * self.threads + thread_idx
+        channel = channel_group * self.channels_per_thread
         time_start = time_block * self.times_per_block
-        weights = cute.make_rmem_tensor((self.channels_per_thread, self.width), Float32)
-        for channel_offset in cutlass.range_constexpr(self.channels_per_thread):
-            for tap in cutlass.range_constexpr(self.width):
-                weights[channel_offset, tap] = Float32(weight[channel + channel_offset, tap])
+        active_endpoint = Int32(self.tokens)
+        if cutlass.const_expr(not full_endpoint):
+            active_endpoint = load_ragged_token_count(cu_seqlens)
 
-        x_groups = cute.zipped_divide(x, (1, self.channels_per_thread))
-        output_groups = cute.zipped_divide(output, (1, self.channels_per_thread))
-        if cutlass.const_expr(initial_state is not None):
-            initial_groups = cute.zipped_divide(initial_state, (1, self.channels_per_thread))
-        inputs = cute.make_rmem_tensor(
-            (self.channels_per_thread, self.times_per_block + self.width - 1),
-            self.dtype.cute_type,
-        )
-        inputs.fill(self.dtype.cute_type(0.0))
-        for input_offset in cutlass.range_constexpr(self.times_per_block + self.width - 1):
-            input_time = time_start + input_offset - (self.width - 1)
-            if input_time >= 0 and input_time < active_endpoint:
-                inputs[(None, input_offset)].store(
-                    x_groups[((0, None), (batch * self.tokens + input_time, channel_group))].load()
-                )
+        # See NOTE [Packed forward active endpoint].
+        if channel < self.channels and time_start < active_endpoint:
+            weights = cute.make_rmem_tensor((self.channels_per_thread, self.width), Float32)
+            for channel_offset in cutlass.range_constexpr(self.channels_per_thread):
+                for tap in cutlass.range_constexpr(self.width):
+                    weights[channel_offset, tap] = Float32(weight[channel + channel_offset, tap])
 
-        tile_sequence, tile_sequence_start, tile_sequence_end = tile_sequence_bounds(
-            cu_seqlens,
-            Int32(time_start),
-            Int32(batch),
-            self.tokens,
-        )
-        for time_offset in cutlass.range_constexpr(self.times_per_block):
-            time = time_start + time_offset
-            sequence = tile_sequence
-            sequence_start = tile_sequence_start
-            if time < active_endpoint:
-                if cutlass.const_expr(cu_seqlens is not None):
-                    sequence, sequence_start, _ = advance_sequence_bounds(
-                        cu_seqlens,
-                        tile_sequence,
-                        tile_sequence_start,
-                        tile_sequence_end,
-                        Int32(time),
+            x_groups = cute.zipped_divide(x, (1, self.channels_per_thread))
+            output_groups = cute.zipped_divide(output, (1, self.channels_per_thread))
+            if cutlass.const_expr(initial_state is not None):
+                initial_groups = cute.zipped_divide(initial_state, (1, self.channels_per_thread))
+            inputs = cute.make_rmem_tensor(
+                (self.channels_per_thread, self.times_per_block + self.width - 1),
+                self.dtype.cute_type,
+            )
+            inputs.fill(self.dtype.cute_type(0.0))
+            for input_offset in cutlass.range_constexpr(self.times_per_block + self.width - 1):
+                input_time = time_start + input_offset - (self.width - 1)
+                if input_time >= 0 and input_time < active_endpoint:
+                    inputs[(None, input_offset)].store(
+                        x_groups[
+                            ((0, None), (batch * self.tokens + input_time, channel_group))
+                        ].load()
                     )
-                else:
-                    sequence_start = Int32(0)
 
-                if cutlass.const_expr(initial_state is not None):
-                    value = unrolled_dot(inputs, weights, time_offset, self.width)
-                    if time - (self.width - 1) < sequence_start:
-                        value = history_dot(
-                            inputs,
-                            weights,
-                            initial_groups,
-                            sequence,
+            tile_sequence, tile_sequence_start, tile_sequence_end = tile_sequence_bounds(
+                cu_seqlens,
+                Int32(time_start),
+                Int32(batch),
+                self.tokens,
+            )
+
+            for time_offset in cutlass.range_constexpr(self.times_per_block):
+                time = time_start + time_offset
+                sequence = tile_sequence
+                sequence_start = tile_sequence_start
+                if time < active_endpoint:
+                    if cutlass.const_expr(cu_seqlens is not None):
+                        sequence, sequence_start, _ = advance_sequence_bounds(
+                            cu_seqlens,
+                            tile_sequence,
+                            tile_sequence_start,
+                            tile_sequence_end,
                             Int32(time),
-                            sequence_start,
-                            time_offset,
-                            channel_group,
-                            self.channels_per_thread,
-                            self.width,
                         )
-                elif cutlass.const_expr(cu_seqlens is None):
-                    value = unrolled_dot(inputs, weights, time_offset, self.width)
-                else:
-                    last_tap = self.width - 1
-                    value = (
-                        inputs[(None, time_offset + last_tap)].load().to(Float32)
-                        * weights[(None, last_tap)].load()
-                    )
-                    if time - last_tap >= sequence_start:
+                    else:
+                        sequence_start = Int32(0)
+
+                    if cutlass.const_expr(initial_state is not None):
+                        value = unrolled_dot(inputs, weights, time_offset, self.width)
+                        if time - (self.width - 1) < sequence_start:
+                            value = history_dot(
+                                inputs,
+                                weights,
+                                initial_groups,
+                                sequence,
+                                Int32(time),
+                                sequence_start,
+                                time_offset,
+                                channel_group,
+                                self.channels_per_thread,
+                                self.width,
+                            )
+                    elif cutlass.const_expr(cu_seqlens is None):
                         value = unrolled_dot(inputs, weights, time_offset, self.width)
                     else:
-                        for step in cutlass.range_constexpr(self.width - 1):
-                            tap = self.width - 2 - step
-                            if time + tap - last_tap >= sequence_start:
-                                value = (
-                                    value
-                                    + inputs[(None, time_offset + tap)].load().to(Float32)
-                                    * weights[(None, tap)].load()
-                                )
-                output_groups[((0, None), (batch * self.tokens + time, channel_group))].store(
-                    self.activation(value).to(self.dtype.cute_type)
-                )
+                        last_tap = self.width - 1
+                        value = (
+                            inputs[(None, time_offset + last_tap)].load().to(Float32)
+                            * weights[(None, last_tap)].load()
+                        )
+                        if time - last_tap >= sequence_start:
+                            value = unrolled_dot(inputs, weights, time_offset, self.width)
+                        else:
+                            for step in cutlass.range_constexpr(self.width - 1):
+                                tap = self.width - 2 - step
+                                if time + tap - last_tap >= sequence_start:
+                                    value = (
+                                        value
+                                        + inputs[(None, time_offset + tap)].load().to(Float32)
+                                        * weights[(None, tap)].load()
+                                    )
+                    output_groups[((0, None), (batch * self.tokens + time, channel_group))].store(
+                        self.activation(value).to(self.dtype.cute_type)
+                    )
 
     @cute.kernel
     def kernel(
@@ -445,71 +427,16 @@ class CausalConv1dSiluForward(ShortConvKernel):
         cu_seqlens: cute.Tensor | None,
         initial_state: cute.Tensor | None,
     ):
-        """Compute one channel group over static or persistent time tiles."""
-        thread_idx, _, _ = cute.arch.thread_idx()
-        channel_block, worker, batch = cute.arch.block_idx()
-        channel_group = channel_block * self.threads + thread_idx
-        channel = channel_group * self.channels_per_thread
-        if channel < self.channels:
-            if cutlass.const_expr(cu_seqlens is not None):
-                active_endpoint = Int32(cu_seqlens[cute.size(cu_seqlens) - 1])
-                active_time_blocks = (
-                    active_endpoint + self.times_per_block - 1
-                ) // self.times_per_block
-                if cutlass.const_expr(self.time_workers == 0):
-                    if active_endpoint == self.tokens:
-                        self.run_tile(
-                            x,
-                            weight,
-                            output,
-                            cu_seqlens,
-                            initial_state,
-                            Int32(channel_group),
-                            Int32(channel),
-                            Int32(worker),
-                            Int32(batch),
-                            Int32(self.tokens),
-                        )
-                    elif worker < active_time_blocks:
-                        self.run_tile(
-                            x,
-                            weight,
-                            output,
-                            cu_seqlens,
-                            initial_state,
-                            Int32(channel_group),
-                            Int32(channel),
-                            Int32(worker),
-                            Int32(batch),
-                            active_endpoint,
-                        )
-                else:
-                    for time_block in cutlass.range(worker, active_time_blocks, self.time_workers):
-                        self.run_tile(
-                            x,
-                            weight,
-                            output,
-                            cu_seqlens,
-                            initial_state,
-                            Int32(channel_group),
-                            Int32(channel),
-                            Int32(time_block),
-                            Int32(batch),
-                            active_endpoint,
-                        )
-            else:
-                self.run_tile(
-                    x,
-                    weight,
-                    output,
-                    cu_seqlens,
-                    initial_state,
-                    Int32(channel_group),
-                    Int32(channel),
-                    Int32(worker),
-                    Int32(batch),
-                    Int32(self.tokens),
-                )
+        """Dispatch one capacity tile using the runtime packed endpoint."""
+        _, time_block, _ = cute.arch.block_idx()
+        if cutlass.const_expr(cu_seqlens is not None):
+            active_endpoint = load_ragged_token_count(cu_seqlens)
+            if active_endpoint == self.tokens:
+                self.run_tile(x, weight, output, cu_seqlens, initial_state, True)
+            elif time_block * self.times_per_block < active_endpoint:
+                self.run_tile(x, weight, output, cu_seqlens, initial_state, False)
+        else:
+            self.run_tile(x, weight, output, cu_seqlens, initial_state, True)
 
     @cute.jit
     def __call__(
@@ -532,11 +459,7 @@ class CausalConv1dSiluForward(ShortConvKernel):
         ).launch(
             grid=(
                 cute.ceil_div(self.channels, self.threads * self.channels_per_thread),
-                (
-                    self.time_workers
-                    if cutlass.const_expr(self.time_workers > 0)
-                    else cute.ceil_div(self.tokens, self.times_per_block)
-                ),
+                cute.ceil_div(self.tokens, self.times_per_block),
                 self.batches,
             ),
             block=(self.threads, 1, 1),
@@ -670,163 +593,10 @@ class CausalConv1dSiluInputGradient(ShortConvKernel):
         config: ShortConvConfig,
         dtype: ShortConvDType,
         d_activation,
-        time_workers: int = 0,
     ):
-        super().__init__(batches, tokens, channels, width, config, dtype, time_workers)
+        super().__init__(batches, tokens, channels, width, config, dtype)
         self.batches = batches
         self.d_activation = d_activation
-
-    @cute.jit
-    def run_tile(
-        self,
-        x: cute.Tensor,
-        weight: cute.Tensor,
-        grad_output: cute.Tensor,
-        grad_x: cute.Tensor,
-        cu_seqlens: cute.Tensor | None,
-        initial_state: cute.Tensor | None,
-        channel_group: Int32,
-        channel: Int32,
-        time_block: Int32,
-        batch: Int32,
-        active_endpoint: Int32,
-    ):
-        """Compute one independent physical time tile for a channel group."""
-        time_start = time_block * self.times_per_block
-        x_groups = cute.zipped_divide(x, (1, self.channels_per_thread))
-        dy_groups = cute.zipped_divide(grad_output, (1, self.channels_per_thread))
-        dx_groups = cute.zipped_divide(grad_x, (1, self.channels_per_thread))
-        if cutlass.const_expr(initial_state is not None):
-            initial_groups = cute.zipped_divide(initial_state, (1, self.channels_per_thread))
-        weights = cute.make_rmem_tensor((self.channels_per_thread, self.width), Float32)
-        for channel_offset in cutlass.range_constexpr(self.channels_per_thread):
-            for tap in cutlass.range_constexpr(self.width):
-                weights[channel_offset, tap] = Float32(weight[channel + channel_offset, tap])
-
-        inputs = cute.make_rmem_tensor(
-            (self.channels_per_thread, self.times_per_block + 2 * (self.width - 1)),
-            self.dtype.cute_type,
-        )
-        inputs.fill(self.dtype.cute_type(0.0))
-        for input_offset in cutlass.range_constexpr(self.times_per_block + 2 * (self.width - 1)):
-            input_time = time_start + input_offset - (self.width - 1)
-            if input_time >= 0 and input_time < active_endpoint:
-                inputs[(None, input_offset)].store(
-                    x_groups[((0, None), (batch * self.tokens + input_time, channel_group))].load()
-                )
-
-        grad_z = cute.make_rmem_tensor(
-            (self.channels_per_thread, self.times_per_block + self.width - 1),
-            Float32,
-        )
-        grad_z.fill(Float32(0.0))
-        output_sequence, output_sequence_start, output_sequence_end = tile_sequence_bounds(
-            cu_seqlens,
-            Int32(time_start),
-            Int32(batch),
-            self.tokens,
-        )
-        for output_offset in cutlass.range_constexpr(self.times_per_block + self.width - 1):
-            output_time = time_start + output_offset
-            if output_time < active_endpoint:
-                if cutlass.const_expr(cu_seqlens is not None):
-                    (
-                        output_sequence,
-                        output_sequence_start,
-                        output_sequence_end,
-                    ) = advance_sequence_bounds(
-                        cu_seqlens,
-                        output_sequence,
-                        output_sequence_start,
-                        output_sequence_end,
-                        Int32(output_time),
-                    )
-                if cutlass.const_expr(initial_state is not None):
-                    value = unrolled_dot(inputs, weights, output_offset, self.width)
-                    if output_time - (self.width - 1) < output_sequence_start:
-                        value = history_dot(
-                            inputs,
-                            weights,
-                            initial_groups,
-                            output_sequence,
-                            Int32(output_time),
-                            output_sequence_start,
-                            output_offset,
-                            channel_group,
-                            self.channels_per_thread,
-                            self.width,
-                        )
-                else:
-                    products = cute.make_rmem_tensor(
-                        (self.channels_per_thread, self.width), Float32
-                    )
-                    products.fill(Float32(0.0))
-                    for tap in cutlass.range_constexpr(self.width):
-                        input_time = output_time + tap - (self.width - 1)
-                        if (
-                            cutlass.const_expr(cu_seqlens is None)
-                            or input_time >= output_sequence_start
-                        ):
-                            products[(None, tap)].store(
-                                inputs[(None, output_offset + tap)].load().to(Float32)
-                                * weights[(None, tap)].load()
-                            )
-                    value = products.load().reduce(
-                        cute.ReductionOp.ADD,
-                        Float32(0.0),
-                        reduction_profile=(None, 1),
-                    )
-                derivative = self.d_activation(value)
-                incoming = (
-                    dy_groups[((0, None), (batch * self.tokens + output_time, channel_group))]
-                    .load()
-                    .to(Float32)
-                )
-                grad_z[(None, output_offset)].store(incoming * derivative)
-
-        input_sequence, input_sequence_start, input_sequence_end = tile_sequence_bounds(
-            cu_seqlens,
-            Int32(time_start),
-            Int32(batch),
-            self.tokens,
-        )
-        for time_offset in cutlass.range_constexpr(self.times_per_block):
-            time = time_start + time_offset
-            if time < active_endpoint:
-                if cutlass.const_expr(cu_seqlens is not None):
-                    (
-                        input_sequence,
-                        input_sequence_start,
-                        input_sequence_end,
-                    ) = advance_sequence_bounds(
-                        cu_seqlens,
-                        input_sequence,
-                        input_sequence_start,
-                        input_sequence_end,
-                        Int32(time),
-                    )
-                products = cute.make_rmem_tensor((self.channels_per_thread, self.width), Float32)
-                products.fill(Float32(0.0))
-                for future_offset in cutlass.range_constexpr(self.width):
-                    if cutlass.const_expr(cu_seqlens is None):
-                        products[(None, future_offset)].store(
-                            grad_z[(None, time_offset + future_offset)].load()
-                            * weights[(None, self.width - 1 - future_offset)].load()
-                        )
-                    else:
-                        if time + future_offset < input_sequence_end:
-                            products[(None, future_offset)].store(
-                                grad_z[(None, time_offset + future_offset)].load()
-                                * weights[(None, self.width - 1 - future_offset)].load()
-                            )
-                value = products.load().reduce(
-                    cute.ReductionOp.ADD,
-                    Float32(0.0),
-                    reduction_profile=(None, 1),
-                )
-                dx_groups[((0, None), (batch * self.tokens + time, channel_group))].store(
-                    value.to(self.dtype.cute_type)
-                )
 
     @cute.kernel
     def kernel(
@@ -838,75 +608,154 @@ class CausalConv1dSiluInputGradient(ShortConvKernel):
         cu_seqlens: cute.Tensor | None,
         initial_state: cute.Tensor | None,
     ):
-        """Compute one channel group over static or persistent time tiles."""
+        """Compute one packed channel group and ten input-gradient tokens."""
         thread_idx, _, _ = cute.arch.thread_idx()
-        channel_block, worker, batch = cute.arch.block_idx()
+        channel_block, time_block, batch = cute.arch.block_idx()
         channel_group = channel_block * self.threads + thread_idx
         channel = channel_group * self.channels_per_thread
+        time_start = time_block * self.times_per_block
+
         if channel < self.channels:
-            if cutlass.const_expr(cu_seqlens is not None):
-                active_endpoint = Int32(cu_seqlens[cute.size(cu_seqlens) - 1])
-                active_time_blocks = (
-                    active_endpoint + self.times_per_block - 1
-                ) // self.times_per_block
-                if cutlass.const_expr(self.time_workers == 0):
-                    if active_endpoint == self.tokens:
-                        self.run_tile(
-                            x,
-                            weight,
-                            grad_output,
-                            grad_x,
+            x_groups = cute.zipped_divide(x, (1, self.channels_per_thread))
+            dy_groups = cute.zipped_divide(grad_output, (1, self.channels_per_thread))
+            dx_groups = cute.zipped_divide(grad_x, (1, self.channels_per_thread))
+            if cutlass.const_expr(initial_state is not None):
+                initial_groups = cute.zipped_divide(initial_state, (1, self.channels_per_thread))
+            weights = cute.make_rmem_tensor((self.channels_per_thread, self.width), Float32)
+            for channel_offset in cutlass.range_constexpr(self.channels_per_thread):
+                for tap in cutlass.range_constexpr(self.width):
+                    weights[channel_offset, tap] = Float32(weight[channel + channel_offset, tap])
+
+            inputs = cute.make_rmem_tensor(
+                (self.channels_per_thread, self.times_per_block + 2 * (self.width - 1)),
+                self.dtype.cute_type,
+            )
+            inputs.fill(self.dtype.cute_type(0.0))
+            for input_offset in cutlass.range_constexpr(
+                self.times_per_block + 2 * (self.width - 1)
+            ):
+                input_time = time_start + input_offset - (self.width - 1)
+                if input_time >= 0 and input_time < self.tokens:
+                    inputs[(None, input_offset)].store(
+                        x_groups[
+                            ((0, None), (batch * self.tokens + input_time, channel_group))
+                        ].load()
+                    )
+
+            grad_z = cute.make_rmem_tensor(
+                (self.channels_per_thread, self.times_per_block + self.width - 1),
+                Float32,
+            )
+            grad_z.fill(Float32(0.0))
+            output_sequence, output_sequence_start, output_sequence_end = tile_sequence_bounds(
+                cu_seqlens,
+                Int32(time_start),
+                Int32(batch),
+                self.tokens,
+            )
+            for output_offset in cutlass.range_constexpr(self.times_per_block + self.width - 1):
+                output_time = time_start + output_offset
+                if output_time < self.tokens:
+                    if cutlass.const_expr(cu_seqlens is not None):
+                        (
+                            output_sequence,
+                            output_sequence_start,
+                            output_sequence_end,
+                        ) = advance_sequence_bounds(
                             cu_seqlens,
-                            initial_state,
-                            Int32(channel_group),
-                            Int32(channel),
-                            Int32(worker),
-                            Int32(batch),
-                            Int32(self.tokens),
+                            output_sequence,
+                            output_sequence_start,
+                            output_sequence_end,
+                            Int32(output_time),
                         )
-                    elif worker < active_time_blocks:
-                        self.run_tile(
-                            x,
-                            weight,
-                            grad_output,
-                            grad_x,
+                    if cutlass.const_expr(initial_state is not None):
+                        value = unrolled_dot(inputs, weights, output_offset, self.width)
+                        if output_time - (self.width - 1) < output_sequence_start:
+                            value = history_dot(
+                                inputs,
+                                weights,
+                                initial_groups,
+                                output_sequence,
+                                Int32(output_time),
+                                output_sequence_start,
+                                output_offset,
+                                channel_group,
+                                self.channels_per_thread,
+                                self.width,
+                            )
+                    else:
+                        products = cute.make_rmem_tensor(
+                            (self.channels_per_thread, self.width), Float32
+                        )
+                        products.fill(Float32(0.0))
+                        for tap in cutlass.range_constexpr(self.width):
+                            input_time = output_time + tap - (self.width - 1)
+                            if (
+                                cutlass.const_expr(cu_seqlens is None)
+                                or input_time >= output_sequence_start
+                            ):
+                                products[(None, tap)].store(
+                                    inputs[(None, output_offset + tap)].load().to(Float32)
+                                    * weights[(None, tap)].load()
+                                )
+                        value = products.load().reduce(
+                            cute.ReductionOp.ADD,
+                            Float32(0.0),
+                            reduction_profile=(None, 1),
+                        )
+                    derivative = self.d_activation(value)
+                    incoming = (
+                        dy_groups[((0, None), (batch * self.tokens + output_time, channel_group))]
+                        .load()
+                        .to(Float32)
+                    )
+                    grad_z[(None, output_offset)].store(incoming * derivative)
+
+            input_sequence, input_sequence_start, input_sequence_end = tile_sequence_bounds(
+                cu_seqlens,
+                Int32(time_start),
+                Int32(batch),
+                self.tokens,
+            )
+            for time_offset in cutlass.range_constexpr(self.times_per_block):
+                time = time_start + time_offset
+                if time < self.tokens:
+                    if cutlass.const_expr(cu_seqlens is not None):
+                        (
+                            input_sequence,
+                            input_sequence_start,
+                            input_sequence_end,
+                        ) = advance_sequence_bounds(
                             cu_seqlens,
-                            initial_state,
-                            Int32(channel_group),
-                            Int32(channel),
-                            Int32(worker),
-                            Int32(batch),
-                            active_endpoint,
+                            input_sequence,
+                            input_sequence_start,
+                            input_sequence_end,
+                            Int32(time),
                         )
-                else:
-                    for time_block in cutlass.range(worker, active_time_blocks, self.time_workers):
-                        self.run_tile(
-                            x,
-                            weight,
-                            grad_output,
-                            grad_x,
-                            cu_seqlens,
-                            initial_state,
-                            Int32(channel_group),
-                            Int32(channel),
-                            Int32(time_block),
-                            Int32(batch),
-                            active_endpoint,
-                        )
-            else:
-                self.run_tile(
-                    x,
-                    weight,
-                    grad_output,
-                    grad_x,
-                    cu_seqlens,
-                    initial_state,
-                    Int32(channel_group),
-                    Int32(channel),
-                    Int32(worker),
-                    Int32(batch),
-                    Int32(self.tokens),
-                )
+                    products = cute.make_rmem_tensor(
+                        (self.channels_per_thread, self.width), Float32
+                    )
+                    products.fill(Float32(0.0))
+                    for future_offset in cutlass.range_constexpr(self.width):
+                        if cutlass.const_expr(cu_seqlens is None):
+                            products[(None, future_offset)].store(
+                                grad_z[(None, time_offset + future_offset)].load()
+                                * weights[(None, self.width - 1 - future_offset)].load()
+                            )
+                        else:
+                            if time + future_offset < input_sequence_end:
+                                products[(None, future_offset)].store(
+                                    grad_z[(None, time_offset + future_offset)].load()
+                                    * weights[(None, self.width - 1 - future_offset)].load()
+                                )
+                    value = products.load().reduce(
+                        cute.ReductionOp.ADD,
+                        Float32(0.0),
+                        reduction_profile=(None, 1),
+                    )
+                    dx_groups[((0, None), (batch * self.tokens + time, channel_group))].store(
+                        value.to(self.dtype.cute_type)
+                    )
 
     @cute.jit
     def __call__(
@@ -931,11 +780,7 @@ class CausalConv1dSiluInputGradient(ShortConvKernel):
         ).launch(
             grid=(
                 cute.ceil_div(self.channels, self.threads * self.channels_per_thread),
-                (
-                    self.time_workers
-                    if cutlass.const_expr(self.time_workers > 0)
-                    else cute.ceil_div(self.tokens, self.times_per_block)
-                ),
+                cute.ceil_div(self.tokens, self.times_per_block),
                 self.batches,
             ),
             block=(self.threads, 1, 1),
@@ -944,7 +789,7 @@ class CausalConv1dSiluInputGradient(ShortConvKernel):
 
 
 class CausalConv1dSiluWeightGradientPartials(ShortConvKernel):
-    """Compute FP32 worker partial sums for the weight gradient."""
+    """Compute FP32 batch/time-tile partial sums for the weight gradient."""
 
     kernel_kind = "dw"
 
@@ -957,96 +802,10 @@ class CausalConv1dSiluWeightGradientPartials(ShortConvKernel):
         config: ShortConvConfig,
         dtype: ShortConvDType,
         d_activation,
-        time_workers: int = 0,
     ):
-        super().__init__(batches, tokens, channels, width, config, dtype, time_workers)
+        super().__init__(batches, tokens, channels, width, config, dtype)
         self.batches = batches
         self.d_activation = d_activation
-
-    @cute.jit
-    def accumulate_tile(
-        self,
-        x: cute.Tensor,
-        grad_output: cute.Tensor,
-        cu_seqlens: cute.Tensor | None,
-        initial_state: cute.Tensor | None,
-        weights: cute.Tensor,
-        accumulators: cute.Tensor,
-        channel_group: Int32,
-        time_block: Int32,
-        batch: Int32,
-        active_endpoint: Int32,
-    ):
-        """Accumulate one logical time tile into a worker-local FP32 partial."""
-        time_start = time_block * self.times_per_block
-        x_groups = cute.zipped_divide(x, (1, self.channels_per_thread))
-        dy_groups = cute.zipped_divide(grad_output, (1, self.channels_per_thread))
-        if cutlass.const_expr(initial_state is not None):
-            initial_groups = cute.zipped_divide(initial_state, (1, self.channels_per_thread))
-        sequence, sequence_start, sequence_end = tile_sequence_bounds(
-            cu_seqlens,
-            Int32(time_start),
-            Int32(batch),
-            self.tokens,
-        )
-        for time_offset in cutlass.range(self.times_per_block, unroll_full=True):
-            time = time_start + time_offset
-            if time < active_endpoint:
-                active_time = True
-                if cutlass.const_expr(cu_seqlens is not None):
-                    sequence, sequence_start, sequence_end = advance_sequence_bounds(
-                        cu_seqlens,
-                        sequence,
-                        sequence_start,
-                        sequence_end,
-                        Int32(time),
-                    )
-                    active_time = time < sequence_end
-                if active_time:
-                    input_taps = cute.make_rmem_tensor(
-                        (self.channels_per_thread, self.width), Float32
-                    )
-                    input_taps.fill(Float32(0.0))
-                    for tap in cutlass.range_constexpr(self.width):
-                        input_time = time + tap - (self.width - 1)
-                        if input_time >= sequence_start:
-                            input_taps[(None, tap)].store(
-                                x_groups[
-                                    (
-                                        (0, None),
-                                        (batch * self.tokens + input_time, channel_group),
-                                    )
-                                ]
-                                .load()
-                                .to(Float32)
-                            )
-                        elif cutlass.const_expr(initial_state is not None):
-                            input_taps[(None, tap)].store(
-                                load_history(
-                                    initial_groups,
-                                    sequence,
-                                    input_time,
-                                    sequence_start,
-                                    channel_group,
-                                    self.width,
-                                )
-                            )
-                    value = (input_taps.load() * weights.load()).reduce(
-                        cute.ReductionOp.ADD,
-                        Float32(0.0),
-                        reduction_profile=(None, 1),
-                    )
-                    incoming = (
-                        dy_groups[((0, None), (batch * self.tokens + time, channel_group))]
-                        .load()
-                        .to(Float32)
-                    )
-                    grad_z = incoming * self.d_activation(value)
-                    for tap in cutlass.range_constexpr(self.width):
-                        accumulators[(None, tap)].store(
-                            accumulators[(None, tap)].load()
-                            + grad_z * input_taps[(None, tap)].load()
-                        )
 
     @cute.kernel
     def kernel(
@@ -1058,13 +817,18 @@ class CausalConv1dSiluWeightGradientPartials(ShortConvKernel):
         cu_seqlens: cute.Tensor | None,
         initial_state: cute.Tensor | None,
     ):
-        """Accumulate static tiles or a strided active-tile list into one worker partial."""
+        """Compute one FP32 weight-gradient partial per tap and owned channel."""
         thread_idx, _, _ = cute.arch.thread_idx()
-        channel_block, worker, batch = cute.arch.block_idx()
+        channel_block, time_block, batch = cute.arch.block_idx()
         channel_group = channel_block * self.threads + thread_idx
         channel = channel_group * self.channels_per_thread
+        time_start = time_block * self.times_per_block
 
         if channel < self.channels:
+            x_groups = cute.zipped_divide(x, (1, self.channels_per_thread))
+            dy_groups = cute.zipped_divide(grad_output, (1, self.channels_per_thread))
+            if cutlass.const_expr(initial_state is not None):
+                initial_groups = cute.zipped_divide(initial_state, (1, self.channels_per_thread))
             weights = cute.make_rmem_tensor((self.channels_per_thread, self.width), Float32)
             accumulators = cute.make_rmem_tensor((self.channels_per_thread, self.width), Float32)
             accumulators.fill(Float32(0.0))
@@ -1072,69 +836,75 @@ class CausalConv1dSiluWeightGradientPartials(ShortConvKernel):
                 for tap in cutlass.range_constexpr(self.width):
                     weights[channel_offset, tap] = Float32(weight[channel + channel_offset, tap])
 
-            if cutlass.const_expr(cu_seqlens is not None):
-                active_endpoint = Int32(cu_seqlens[cute.size(cu_seqlens) - 1])
-                active_time_blocks = (
-                    active_endpoint + self.times_per_block - 1
-                ) // self.times_per_block
-                if cutlass.const_expr(self.time_workers == 0):
-                    if active_endpoint == self.tokens:
-                        self.accumulate_tile(
-                            x,
-                            grad_output,
+            sequence, sequence_start, sequence_end = tile_sequence_bounds(
+                cu_seqlens,
+                Int32(time_start),
+                Int32(batch),
+                self.tokens,
+            )
+            for time_offset in cutlass.range(self.times_per_block, unroll_full=True):
+                time = time_start + time_offset
+                if time < self.tokens:
+                    active_time = True
+                    if cutlass.const_expr(cu_seqlens is not None):
+                        sequence, sequence_start, sequence_end = advance_sequence_bounds(
                             cu_seqlens,
-                            initial_state,
-                            weights,
-                            accumulators,
-                            Int32(channel_group),
-                            Int32(worker),
-                            Int32(batch),
-                            Int32(self.tokens),
+                            sequence,
+                            sequence_start,
+                            sequence_end,
+                            Int32(time),
                         )
-                    elif worker < active_time_blocks:
-                        self.accumulate_tile(
-                            x,
-                            grad_output,
-                            cu_seqlens,
-                            initial_state,
-                            weights,
-                            accumulators,
-                            Int32(channel_group),
-                            Int32(worker),
-                            Int32(batch),
-                            active_endpoint,
+                        active_time = time < sequence_end
+                    if active_time:
+                        input_taps = cute.make_rmem_tensor(
+                            (self.channels_per_thread, self.width), Float32
                         )
-                else:
-                    for time_block in cutlass.range(worker, active_time_blocks, self.time_workers):
-                        self.accumulate_tile(
-                            x,
-                            grad_output,
-                            cu_seqlens,
-                            initial_state,
-                            weights,
-                            accumulators,
-                            Int32(channel_group),
-                            Int32(time_block),
-                            Int32(batch),
-                            active_endpoint,
+                        input_taps.fill(Float32(0.0))
+                        for tap in cutlass.range_constexpr(self.width):
+                            input_time = time + tap - (self.width - 1)
+                            if input_time >= sequence_start:
+                                input_taps[(None, tap)].store(
+                                    x_groups[
+                                        (
+                                            (0, None),
+                                            (batch * self.tokens + input_time, channel_group),
+                                        )
+                                    ]
+                                    .load()
+                                    .to(Float32)
+                                )
+                            elif cutlass.const_expr(initial_state is not None):
+                                input_taps[(None, tap)].store(
+                                    load_history(
+                                        initial_groups,
+                                        sequence,
+                                        input_time,
+                                        sequence_start,
+                                        channel_group,
+                                        self.width,
+                                    )
+                                )
+                        value = (input_taps.load() * weights.load()).reduce(
+                            cute.ReductionOp.ADD,
+                            Float32(0.0),
+                            reduction_profile=(None, 1),
                         )
-            else:
-                self.accumulate_tile(
-                    x,
-                    grad_output,
-                    cu_seqlens,
-                    initial_state,
-                    weights,
-                    accumulators,
-                    Int32(channel_group),
-                    Int32(worker),
-                    Int32(batch),
-                    Int32(self.tokens),
-                )
+                        derivative = self.d_activation(value)
+                        incoming = (
+                            dy_groups[((0, None), (batch * self.tokens + time, channel_group))]
+                            .load()
+                            .to(Float32)
+                        )
+                        grad_z = incoming * derivative
+                        for tap in cutlass.range_constexpr(self.width):
+                            accumulators[(None, tap)].store(
+                                accumulators[(None, tap)].load()
+                                + grad_z * input_taps[(None, tap)].load()
+                            )
 
             for channel_offset in cutlass.range_constexpr(self.channels_per_thread):
                 for tap in cutlass.range_constexpr(self.width):
-                    partials[batch, worker, channel + channel_offset, tap] = accumulators[
+                    partials[batch, time_block, channel + channel_offset, tap] = accumulators[
                         channel_offset, tap
                     ]
 
@@ -1161,11 +931,7 @@ class CausalConv1dSiluWeightGradientPartials(ShortConvKernel):
         ).launch(
             grid=(
                 cute.ceil_div(self.channels, self.threads * self.channels_per_thread),
-                (
-                    self.time_workers
-                    if cutlass.const_expr(self.time_workers > 0)
-                    else cute.ceil_div(self.tokens, self.times_per_block)
-                ),
+                cute.ceil_div(self.tokens, self.times_per_block),
                 self.batches,
             ),
             block=(self.threads, 1, 1),
@@ -2396,19 +2162,11 @@ def _compile_forward(
     num_sequences: int | None,
     has_initial_state: bool,
     activation: Activation,
-    time_workers: int,
 ):
-    """Compile one dense, packed-static, or packed-persistent forward specialization."""
+    """Compile one static forward specialization."""
     activation_fn = activation.forward
     operation = CausalConv1dSiluForward(
-        batches,
-        tokens,
-        channels,
-        width,
-        config,
-        dtype,
-        activation_fn,
-        time_workers,
+        batches, tokens, channels, width, config, dtype, activation_fn
     )
     return compile_tvm_ffi(
         operation,
@@ -2459,42 +2217,6 @@ def supports_tma(
     )
 
 
-def _input_gradient_uses_tma(
-    dtype: ShortConvDType,
-    config: ShortConvConfig,
-    num_sequences: int | None,
-    channels: int,
-    width: int,
-) -> bool:
-    """Select the unchanged staged input-gradient path when its schedule supports it."""
-    return supports_tma(
-        CausalConv1dSiluInputGradientTma,
-        config,
-        None
-        if dtype.name == "fp32" and num_sequences is None
-        else tuned_config(dtype, packed=num_sequences is not None).input_gradient,
-        channels,
-        width,
-    )
-
-
-def _weight_gradient_uses_tma(
-    dtype: ShortConvDType,
-    config: ShortConvConfig,
-    num_sequences: int | None,
-    channels: int,
-    width: int,
-) -> bool:
-    """Select the unchanged staged weight-gradient path when its schedule supports it."""
-    return supports_tma(
-        CausalConv1dSiluWeightGradientPartialsTma,
-        config,
-        tuned_config(dtype, packed=num_sequences is not None).weight_gradient,
-        channels,
-        width,
-    )
-
-
 @jit_cache
 def _compile_input_gradient(
     batches: int,
@@ -2506,27 +2228,20 @@ def _compile_input_gradient(
     num_sequences: int | None,
     has_initial_state: bool,
     activation: Activation,
-    time_workers: int,
 ):
-    """Compile one static, TMA, or packed-persistent input-gradient specialization."""
+    """Compile one static input-gradient specialization."""
     derivative = activation.derivative
-    use_tma = _input_gradient_uses_tma(dtype, config, num_sequences, channels, width)
-    if use_tma:
-        assert time_workers == 0
-        operation = CausalConv1dSiluInputGradientTma(
-            batches, tokens, channels, width, config, dtype, derivative
-        )
-    else:
-        operation = CausalConv1dSiluInputGradient(
-            batches,
-            tokens,
-            channels,
-            width,
-            config,
-            dtype,
-            derivative,
-            time_workers,
-        )
+    use_tma = supports_tma(
+        CausalConv1dSiluInputGradientTma,
+        config,
+        None
+        if dtype.name == "fp32" and num_sequences is None
+        else tuned_config(dtype, packed=num_sequences is not None).input_gradient,
+        channels,
+        width,
+    )
+    operation_type = CausalConv1dSiluInputGradientTma if use_tma else CausalConv1dSiluInputGradient
+    operation = operation_type(batches, tokens, channels, width, config, dtype, derivative)
     return compile_tvm_ffi(
         operation,
         _fake_matrix(dtype, batches * tokens, channels),
@@ -2555,34 +2270,29 @@ def _compile_weight_gradient(
     num_sequences: int | None,
     has_initial_state: bool,
     activation: Activation,
-    time_workers: int,
 ):
-    """Compile one static, TMA, or packed-persistent weight-gradient specialization."""
+    """Compile one static weight-gradient specialization."""
     derivative = activation.derivative
-    use_tma = _weight_gradient_uses_tma(dtype, config, num_sequences, channels, width)
-    num_partials = time_workers or ceildiv(tokens, config.times_per_block)
+    num_time_blocks = ceildiv(tokens, config.times_per_block)
     partials = cute.runtime.make_fake_compact_tensor(
         Float32,
-        (batches, num_partials, channels, width),
+        (batches, num_time_blocks, channels, width),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )
-    if use_tma:
-        assert time_workers == 0
-        operation = CausalConv1dSiluWeightGradientPartialsTma(
-            batches, tokens, channels, width, config, dtype, derivative
-        )
-    else:
-        operation = CausalConv1dSiluWeightGradientPartials(
-            batches,
-            tokens,
-            channels,
-            width,
-            config,
-            dtype,
-            derivative,
-            time_workers,
-        )
+    use_tma = supports_tma(
+        CausalConv1dSiluWeightGradientPartialsTma,
+        config,
+        tuned_config(dtype, packed=num_sequences is not None).weight_gradient,
+        channels,
+        width,
+    )
+    operation_type = (
+        CausalConv1dSiluWeightGradientPartialsTma
+        if use_tma
+        else CausalConv1dSiluWeightGradientPartials
+    )
+    operation = operation_type(batches, tokens, channels, width, config, dtype, derivative)
     return compile_tvm_ffi(
         operation,
         _fake_matrix(dtype, batches * tokens, channels),
@@ -2739,7 +2449,6 @@ def _launch_forward(
     width = weight.shape[1]
     dtype = SHORT_CONV_DTYPES[x.dtype]
     output = torch.empty_like(x)
-    num_sequences = None if cu_seqlens is None else cu_seqlens.shape[0] - 1
     compiled = _compile_forward(
         batches,
         tokens,
@@ -2747,16 +2456,9 @@ def _launch_forward(
         width,
         dtype,
         config,
-        num_sequences,
+        None if cu_seqlens is None else cu_seqlens.shape[0] - 1,
         initial_state is not None,
         resolved_activation,
-        _persistent_time_workers(
-            tokens,
-            channels,
-            config,
-            x.device,
-            persistent_eligible=num_sequences is not None,
-        ),
     )
     compiled(
         x.view(batches * tokens, channels),
@@ -2801,14 +2503,6 @@ def _launch_backward(
         num_sequences,
         initial_state is not None,
         resolved_activation,
-        _persistent_time_workers(
-            tokens,
-            channels,
-            input_config,
-            x.device,
-            persistent_eligible=num_sequences is not None
-            and not _input_gradient_uses_tma(dtype, input_config, num_sequences, channels, width),
-        ),
     )(
         x.view(batches * tokens, channels),
         weight,
@@ -2818,15 +2512,7 @@ def _launch_backward(
         None if initial_state is None else initial_state.flatten(0, 1),
     )
 
-    weight_workers = _persistent_time_workers(
-        tokens,
-        channels,
-        weight_config,
-        x.device,
-        persistent_eligible=num_sequences is not None
-        and not _weight_gradient_uses_tma(dtype, weight_config, num_sequences, channels, width),
-    )
-    num_partials = weight_workers or ceildiv(tokens, weight_config.times_per_block)
+    num_time_blocks = ceildiv(tokens, weight_config.times_per_block)
     if initial_state is None or not compute_initial_state_grad:
         grad_initial_state = None
     elif width == 1:
@@ -2834,7 +2520,7 @@ def _launch_backward(
     else:
         grad_initial_state = torch.empty_like(initial_state)
     partials = torch.empty(
-        (batches, num_partials, channels, width),
+        (batches, num_time_blocks, channels, width),
         dtype=torch.float32,
         device=x.device,
     )
@@ -2848,7 +2534,6 @@ def _launch_backward(
         num_sequences,
         initial_state is not None,
         resolved_activation,
-        weight_workers,
     )(
         x.view(batches * tokens, channels),
         weight,
@@ -3011,13 +2696,6 @@ def tune_causal_conv1d(
             num_sequences,
             kernel_initial_state is not None,
             resolved_activation,
-            _persistent_time_workers(
-                tokens,
-                channels,
-                config,
-                x.device,
-                persistent_eligible=num_sequences is not None,
-            ),
         ),
         parallel_compile=parallel_compile,
     )
@@ -3046,14 +2724,6 @@ def tune_causal_conv1d(
             num_sequences,
             kernel_initial_state is not None,
             resolved_activation,
-            _persistent_time_workers(
-                tokens,
-                channels,
-                config,
-                x.device,
-                persistent_eligible=num_sequences is not None
-                and not _input_gradient_uses_tma(dtype, config, num_sequences, channels, width),
-            ),
         ),
         parallel_compile=parallel_compile,
     )
@@ -3065,27 +2735,16 @@ def tune_causal_conv1d(
     )
     for config in weight_candidates:
         _validate_config(config, channels, "weight_grad_configs")
-    weight_workers = {
-        config: _persistent_time_workers(
-            tokens,
-            channels,
-            config,
-            x.device,
-            persistent_eligible=num_sequences is not None
-            and not _weight_gradient_uses_tma(dtype, config, num_sequences, channels, width),
-        )
-        for config in weight_candidates
-    }
     partials = {
         config: torch.empty(
             batches,
-            workers or ceildiv(tokens, config.times_per_block),
+            ceildiv(tokens, config.times_per_block),
             channels,
             width,
             dtype=torch.float32,
             device=x.device,
         )
-        for config, workers in weight_workers.items()
+        for config in weight_candidates
     }
     weight_gradient = tune(
         weight_candidates,
@@ -3108,7 +2767,6 @@ def tune_causal_conv1d(
             num_sequences,
             kernel_initial_state is not None,
             resolved_activation,
-            weight_workers[config],
         ),
         parallel_compile=parallel_compile,
     )

--- a/attn_gym/linear/kda/short_conv/cute.py
+++ b/attn_gym/linear/kda/short_conv/cute.py
@@ -36,6 +36,7 @@ from attn_gym._backends.cute import (
 )
 from attn_gym._backends.cute.device import upper_bound
 from attn_gym.linear.kda import ops as kda_ops
+from attn_gym.linear.kda.chunk_schedule import ResolvedSchedule, ScheduleKind
 from attn_gym.linear.kda.short_conv.activations import Activation, resolve_activation
 
 _forward_op = kda_ops.short_conv_forward_op
@@ -62,26 +63,34 @@ SHORT_CONV_DTYPES = {
 }
 
 
-# Measured packed worker budget: preserve full-capacity parallelism through 16K tokens
-# while bounding larger 2D grids and skipping inactive replay tiles before tile setup.
-_PERSISTENT_TIME_CTAS_PER_SM = 8
+# NOTE [Short-convolution time scheduling]
+# Match the shared GridScheduler contract: STATIC launches the capacity time axis and
+# lets inactive CTAs return from a device active-count check; PERSISTENT launches a
+# bounded worker axis and strides over active tiles. Short convolution needs no chunk
+# metadata because its active tile count is ceil_div(cu_seqlens[-1], times_per_block).
+# The measured eight-CTA/SM override preserves full-capacity throughput through 16K.
+_SHORT_CONV_CTAS_PER_SM = 8
 
 
-def _persistent_time_workers(
+def _resolve_time_schedule(
     tokens: int,
     channels: int,
     config: ShortConvConfig,
     device: torch.device,
-) -> int:
-    """Bound the packed time axis so the complete 2D grid stays machine-sized."""
+    *,
+    persistent_eligible: bool,
+    ctas_per_sm: int = _SHORT_CONV_CTAS_PER_SM,
+) -> ResolvedSchedule:
+    """Resolve static or machine-bounded execution for one time-tiled kernel."""
+    capacity = ceildiv(tokens, config.times_per_block)
+    if not persistent_eligible:
+        return ResolvedSchedule(ScheduleKind.STATIC, 0, capacity)
     channel_blocks = ceildiv(channels, config.threads * config.channels_per_thread)
-    device_workers = (
-        get_device_properties(device).multi_processor_count * _PERSISTENT_TIME_CTAS_PER_SM
-    )
-    return min(
-        ceildiv(tokens, config.times_per_block),
-        max(1, ceildiv(device_workers, channel_blocks)),
-    )
+    device_workers = get_device_properties(device).multi_processor_count * ctas_per_sm
+    workers = min(capacity, max(1, ceildiv(device_workers, channel_blocks)))
+    if workers < capacity:
+        return ResolvedSchedule(ScheduleKind.PERSISTENT, workers, capacity)
+    return ResolvedSchedule(ScheduleKind.STATIC, 0, capacity)
 
 
 @dataclass(frozen=True)
@@ -287,8 +296,13 @@ class ShortConvKernel:
         width: int,
         config: ShortConvConfig,
         dtype: ShortConvDType,
-        persistent_time_workers: int = 0,
+        schedule_kind: ScheduleKind = ScheduleKind.STATIC,
+        time_workers: int = 0,
     ):
+        if schedule_kind is ScheduleKind.PERSISTENT:
+            assert time_workers > 0, "persistent execution requires a positive time-worker grid"
+        else:
+            assert time_workers == 0, "static execution does not use time workers"
         self.sequences = sequences
         self.tokens = tokens
         self.channels = channels
@@ -297,7 +311,8 @@ class ShortConvKernel:
         self.channels_per_thread = config.channels_per_thread
         self.times_per_block = config.times_per_block
         self.dtype = dtype
-        self.persistent_time_workers = persistent_time_workers
+        self.schedule_kind = schedule_kind
+        self.time_workers = time_workers
 
     def get_name(self) -> str:
         """Return the stable compiled-artifact name."""
@@ -307,8 +322,8 @@ class ShortConvKernel:
         )
         if self.time_tiled:
             name += f"_bt{self.times_per_block}"
-        if self.persistent_time_workers:
-            name += f"_ptw{self.persistent_time_workers}"
+        if self.schedule_kind is ScheduleKind.PERSISTENT:
+            name += f"_execution_persistent_tw{self.time_workers}"
         name += f"_v{self.channels_per_thread}"
         if self.tma_stage_tokens:
             name += f"_tma{self.tma_stage_tokens}"
@@ -329,7 +344,8 @@ class CausalConv1dSiluForward(ShortConvKernel):
         config: ShortConvConfig,
         dtype: ShortConvDType,
         activation,
-        persistent_time_workers: int = 0,
+        schedule_kind: ScheduleKind = ScheduleKind.STATIC,
+        time_workers: int = 0,
     ):
         super().__init__(
             batches,
@@ -338,7 +354,8 @@ class CausalConv1dSiluForward(ShortConvKernel):
             width,
             config,
             dtype,
-            persistent_time_workers,
+            schedule_kind,
+            time_workers,
         )
         self.batches = batches
         self.activation = activation
@@ -455,14 +472,12 @@ class CausalConv1dSiluForward(ShortConvKernel):
         channel_group = channel_block * self.threads + thread_idx
         channel = channel_group * self.channels_per_thread
         if channel < self.channels:
-            if cutlass.const_expr(self.persistent_time_workers > 0):
+            if cutlass.const_expr(cu_seqlens is not None):
                 active_endpoint = Int32(cu_seqlens[cute.size(cu_seqlens) - 1])
                 active_time_blocks = (
                     active_endpoint + self.times_per_block - 1
                 ) // self.times_per_block
-                if cutlass.const_expr(
-                    self.persistent_time_workers == ceildiv(self.tokens, self.times_per_block)
-                ):
+                if cutlass.const_expr(self.schedule_kind is ScheduleKind.STATIC):
                     if active_endpoint == self.tokens:
                         self.run_tile(
                             x,
@@ -490,9 +505,7 @@ class CausalConv1dSiluForward(ShortConvKernel):
                             active_endpoint,
                         )
                 else:
-                    for time_block in cutlass.range(
-                        worker, active_time_blocks, self.persistent_time_workers
-                    ):
+                    for time_block in cutlass.range(worker, active_time_blocks, self.time_workers):
                         self.run_tile(
                             x,
                             weight,
@@ -541,8 +554,8 @@ class CausalConv1dSiluForward(ShortConvKernel):
             grid=(
                 cute.ceil_div(self.channels, self.threads * self.channels_per_thread),
                 (
-                    self.persistent_time_workers
-                    if cutlass.const_expr(self.persistent_time_workers > 0)
+                    self.time_workers
+                    if cutlass.const_expr(self.schedule_kind is ScheduleKind.PERSISTENT)
                     else cute.ceil_div(self.tokens, self.times_per_block)
                 ),
                 self.batches,
@@ -678,7 +691,8 @@ class CausalConv1dSiluInputGradient(ShortConvKernel):
         config: ShortConvConfig,
         dtype: ShortConvDType,
         d_activation,
-        persistent_time_workers: int = 0,
+        schedule_kind: ScheduleKind = ScheduleKind.STATIC,
+        time_workers: int = 0,
     ):
         super().__init__(
             batches,
@@ -687,7 +701,8 @@ class CausalConv1dSiluInputGradient(ShortConvKernel):
             width,
             config,
             dtype,
-            persistent_time_workers,
+            schedule_kind,
+            time_workers,
         )
         self.batches = batches
         self.d_activation = d_activation
@@ -860,14 +875,12 @@ class CausalConv1dSiluInputGradient(ShortConvKernel):
         channel_group = channel_block * self.threads + thread_idx
         channel = channel_group * self.channels_per_thread
         if channel < self.channels:
-            if cutlass.const_expr(self.persistent_time_workers > 0):
+            if cutlass.const_expr(cu_seqlens is not None):
                 active_endpoint = Int32(cu_seqlens[cute.size(cu_seqlens) - 1])
                 active_time_blocks = (
                     active_endpoint + self.times_per_block - 1
                 ) // self.times_per_block
-                if cutlass.const_expr(
-                    self.persistent_time_workers == ceildiv(self.tokens, self.times_per_block)
-                ):
+                if cutlass.const_expr(self.schedule_kind is ScheduleKind.STATIC):
                     if active_endpoint == self.tokens:
                         self.run_tile(
                             x,
@@ -897,9 +910,7 @@ class CausalConv1dSiluInputGradient(ShortConvKernel):
                             active_endpoint,
                         )
                 else:
-                    for time_block in cutlass.range(
-                        worker, active_time_blocks, self.persistent_time_workers
-                    ):
+                    for time_block in cutlass.range(worker, active_time_blocks, self.time_workers):
                         self.run_tile(
                             x,
                             weight,
@@ -952,8 +963,8 @@ class CausalConv1dSiluInputGradient(ShortConvKernel):
             grid=(
                 cute.ceil_div(self.channels, self.threads * self.channels_per_thread),
                 (
-                    self.persistent_time_workers
-                    if cutlass.const_expr(self.persistent_time_workers > 0)
+                    self.time_workers
+                    if cutlass.const_expr(self.schedule_kind is ScheduleKind.PERSISTENT)
                     else cute.ceil_div(self.tokens, self.times_per_block)
                 ),
                 self.batches,
@@ -964,7 +975,7 @@ class CausalConv1dSiluInputGradient(ShortConvKernel):
 
 
 class CausalConv1dSiluWeightGradientPartials(ShortConvKernel):
-    """Compute FP32 batch/time-tile partial sums for the weight gradient."""
+    """Compute FP32 worker partial sums for the weight gradient."""
 
     kernel_kind = "dw"
 
@@ -977,10 +988,106 @@ class CausalConv1dSiluWeightGradientPartials(ShortConvKernel):
         config: ShortConvConfig,
         dtype: ShortConvDType,
         d_activation,
+        schedule_kind: ScheduleKind = ScheduleKind.STATIC,
+        time_workers: int = 0,
     ):
-        super().__init__(batches, tokens, channels, width, config, dtype)
+        super().__init__(
+            batches,
+            tokens,
+            channels,
+            width,
+            config,
+            dtype,
+            schedule_kind,
+            time_workers,
+        )
         self.batches = batches
         self.d_activation = d_activation
+
+    @cute.jit
+    def accumulate_tile(
+        self,
+        x: cute.Tensor,
+        grad_output: cute.Tensor,
+        cu_seqlens: cute.Tensor | None,
+        initial_state: cute.Tensor | None,
+        weights: cute.Tensor,
+        accumulators: cute.Tensor,
+        channel_group: Int32,
+        time_block: Int32,
+        batch: Int32,
+        active_endpoint: Int32,
+    ):
+        """Accumulate one logical time tile into a worker-local FP32 partial."""
+        time_start = time_block * self.times_per_block
+        x_groups = cute.zipped_divide(x, (1, self.channels_per_thread))
+        dy_groups = cute.zipped_divide(grad_output, (1, self.channels_per_thread))
+        if cutlass.const_expr(initial_state is not None):
+            initial_groups = cute.zipped_divide(initial_state, (1, self.channels_per_thread))
+        sequence, sequence_start, sequence_end = tile_sequence_bounds(
+            cu_seqlens,
+            Int32(time_start),
+            Int32(batch),
+            self.tokens,
+        )
+        for time_offset in cutlass.range(self.times_per_block, unroll_full=True):
+            time = time_start + time_offset
+            if time < active_endpoint:
+                active_time = True
+                if cutlass.const_expr(cu_seqlens is not None):
+                    sequence, sequence_start, sequence_end = advance_sequence_bounds(
+                        cu_seqlens,
+                        sequence,
+                        sequence_start,
+                        sequence_end,
+                        Int32(time),
+                    )
+                    active_time = time < sequence_end
+                if active_time:
+                    input_taps = cute.make_rmem_tensor(
+                        (self.channels_per_thread, self.width), Float32
+                    )
+                    input_taps.fill(Float32(0.0))
+                    for tap in cutlass.range_constexpr(self.width):
+                        input_time = time + tap - (self.width - 1)
+                        if input_time >= sequence_start:
+                            input_taps[(None, tap)].store(
+                                x_groups[
+                                    (
+                                        (0, None),
+                                        (batch * self.tokens + input_time, channel_group),
+                                    )
+                                ]
+                                .load()
+                                .to(Float32)
+                            )
+                        elif cutlass.const_expr(initial_state is not None):
+                            input_taps[(None, tap)].store(
+                                load_history(
+                                    initial_groups,
+                                    sequence,
+                                    input_time,
+                                    sequence_start,
+                                    channel_group,
+                                    self.width,
+                                )
+                            )
+                    value = (input_taps.load() * weights.load()).reduce(
+                        cute.ReductionOp.ADD,
+                        Float32(0.0),
+                        reduction_profile=(None, 1),
+                    )
+                    incoming = (
+                        dy_groups[((0, None), (batch * self.tokens + time, channel_group))]
+                        .load()
+                        .to(Float32)
+                    )
+                    grad_z = incoming * self.d_activation(value)
+                    for tap in cutlass.range_constexpr(self.width):
+                        accumulators[(None, tap)].store(
+                            accumulators[(None, tap)].load()
+                            + grad_z * input_taps[(None, tap)].load()
+                        )
 
     @cute.kernel
     def kernel(
@@ -992,18 +1099,13 @@ class CausalConv1dSiluWeightGradientPartials(ShortConvKernel):
         cu_seqlens: cute.Tensor | None,
         initial_state: cute.Tensor | None,
     ):
-        """Compute one FP32 weight-gradient partial per tap and owned channel."""
+        """Accumulate static tiles or a strided active-tile list into one worker partial."""
         thread_idx, _, _ = cute.arch.thread_idx()
-        channel_block, time_block, batch = cute.arch.block_idx()
+        channel_block, worker, batch = cute.arch.block_idx()
         channel_group = channel_block * self.threads + thread_idx
         channel = channel_group * self.channels_per_thread
-        time_start = time_block * self.times_per_block
 
         if channel < self.channels:
-            x_groups = cute.zipped_divide(x, (1, self.channels_per_thread))
-            dy_groups = cute.zipped_divide(grad_output, (1, self.channels_per_thread))
-            if cutlass.const_expr(initial_state is not None):
-                initial_groups = cute.zipped_divide(initial_state, (1, self.channels_per_thread))
             weights = cute.make_rmem_tensor((self.channels_per_thread, self.width), Float32)
             accumulators = cute.make_rmem_tensor((self.channels_per_thread, self.width), Float32)
             accumulators.fill(Float32(0.0))
@@ -1011,75 +1113,69 @@ class CausalConv1dSiluWeightGradientPartials(ShortConvKernel):
                 for tap in cutlass.range_constexpr(self.width):
                     weights[channel_offset, tap] = Float32(weight[channel + channel_offset, tap])
 
-            sequence, sequence_start, sequence_end = tile_sequence_bounds(
-                cu_seqlens,
-                Int32(time_start),
-                Int32(batch),
-                self.tokens,
-            )
-            for time_offset in cutlass.range(self.times_per_block, unroll_full=True):
-                time = time_start + time_offset
-                if time < self.tokens:
-                    active_time = True
-                    if cutlass.const_expr(cu_seqlens is not None):
-                        sequence, sequence_start, sequence_end = advance_sequence_bounds(
+            if cutlass.const_expr(cu_seqlens is not None):
+                active_endpoint = Int32(cu_seqlens[cute.size(cu_seqlens) - 1])
+                active_time_blocks = (
+                    active_endpoint + self.times_per_block - 1
+                ) // self.times_per_block
+                if cutlass.const_expr(self.schedule_kind is ScheduleKind.STATIC):
+                    if active_endpoint == self.tokens:
+                        self.accumulate_tile(
+                            x,
+                            grad_output,
                             cu_seqlens,
-                            sequence,
-                            sequence_start,
-                            sequence_end,
-                            Int32(time),
+                            initial_state,
+                            weights,
+                            accumulators,
+                            Int32(channel_group),
+                            Int32(worker),
+                            Int32(batch),
+                            Int32(self.tokens),
                         )
-                        active_time = time < sequence_end
-                    if active_time:
-                        input_taps = cute.make_rmem_tensor(
-                            (self.channels_per_thread, self.width), Float32
+                    elif worker < active_time_blocks:
+                        self.accumulate_tile(
+                            x,
+                            grad_output,
+                            cu_seqlens,
+                            initial_state,
+                            weights,
+                            accumulators,
+                            Int32(channel_group),
+                            Int32(worker),
+                            Int32(batch),
+                            active_endpoint,
                         )
-                        input_taps.fill(Float32(0.0))
-                        for tap in cutlass.range_constexpr(self.width):
-                            input_time = time + tap - (self.width - 1)
-                            if input_time >= sequence_start:
-                                input_taps[(None, tap)].store(
-                                    x_groups[
-                                        (
-                                            (0, None),
-                                            (batch * self.tokens + input_time, channel_group),
-                                        )
-                                    ]
-                                    .load()
-                                    .to(Float32)
-                                )
-                            elif cutlass.const_expr(initial_state is not None):
-                                input_taps[(None, tap)].store(
-                                    load_history(
-                                        initial_groups,
-                                        sequence,
-                                        input_time,
-                                        sequence_start,
-                                        channel_group,
-                                        self.width,
-                                    )
-                                )
-                        value = (input_taps.load() * weights.load()).reduce(
-                            cute.ReductionOp.ADD,
-                            Float32(0.0),
-                            reduction_profile=(None, 1),
+                else:
+                    for time_block in cutlass.range(worker, active_time_blocks, self.time_workers):
+                        self.accumulate_tile(
+                            x,
+                            grad_output,
+                            cu_seqlens,
+                            initial_state,
+                            weights,
+                            accumulators,
+                            Int32(channel_group),
+                            Int32(time_block),
+                            Int32(batch),
+                            active_endpoint,
                         )
-                        derivative = self.d_activation(value)
-                        incoming = (
-                            dy_groups[((0, None), (batch * self.tokens + time, channel_group))]
-                            .load()
-                            .to(Float32)
-                        )
-                        grad_z = incoming * derivative
-                        for tap in cutlass.range_constexpr(self.width):
-                            accumulators[(None, tap)].store(
-                                accumulators[(None, tap)].load()
-                                + grad_z * input_taps[(None, tap)].load()
-                            )
+            else:
+                self.accumulate_tile(
+                    x,
+                    grad_output,
+                    cu_seqlens,
+                    initial_state,
+                    weights,
+                    accumulators,
+                    Int32(channel_group),
+                    Int32(worker),
+                    Int32(batch),
+                    Int32(self.tokens),
+                )
 
             for channel_offset in cutlass.range_constexpr(self.channels_per_thread):
                 for tap in cutlass.range_constexpr(self.width):
-                    partials[batch, time_block, channel + channel_offset, tap] = accumulators[
+                    partials[batch, worker, channel + channel_offset, tap] = accumulators[
                         channel_offset, tap
                     ]
 
@@ -1106,7 +1202,11 @@ class CausalConv1dSiluWeightGradientPartials(ShortConvKernel):
         ).launch(
             grid=(
                 cute.ceil_div(self.channels, self.threads * self.channels_per_thread),
-                cute.ceil_div(self.tokens, self.times_per_block),
+                (
+                    self.time_workers
+                    if cutlass.const_expr(self.schedule_kind is ScheduleKind.PERSISTENT)
+                    else cute.ceil_div(self.tokens, self.times_per_block)
+                ),
                 self.batches,
             ),
             block=(self.threads, 1, 1),
@@ -2337,9 +2437,10 @@ def _compile_forward(
     num_sequences: int | None,
     has_initial_state: bool,
     activation: Activation,
-    persistent_time_workers: int = 0,
+    schedule_kind: ScheduleKind = ScheduleKind.STATIC,
+    time_workers: int = 0,
 ):
-    """Compile one static or packed-persistent forward specialization."""
+    """Compile one dense, packed-static, or packed-persistent forward specialization."""
     activation_fn = activation.forward
     operation = CausalConv1dSiluForward(
         batches,
@@ -2349,7 +2450,8 @@ def _compile_forward(
         config,
         dtype,
         activation_fn,
-        persistent_time_workers,
+        schedule_kind,
+        time_workers,
     )
     return compile_tvm_ffi(
         operation,
@@ -2419,6 +2521,23 @@ def _input_gradient_uses_tma(
     )
 
 
+def _weight_gradient_uses_tma(
+    dtype: ShortConvDType,
+    config: ShortConvConfig,
+    num_sequences: int | None,
+    channels: int,
+    width: int,
+) -> bool:
+    """Select the unchanged staged weight-gradient path when its schedule supports it."""
+    return supports_tma(
+        CausalConv1dSiluWeightGradientPartialsTma,
+        config,
+        tuned_config(dtype, packed=num_sequences is not None).weight_gradient,
+        channels,
+        width,
+    )
+
+
 @jit_cache
 def _compile_input_gradient(
     batches: int,
@@ -2430,13 +2549,14 @@ def _compile_input_gradient(
     num_sequences: int | None,
     has_initial_state: bool,
     activation: Activation,
-    persistent_time_workers: int = 0,
+    schedule_kind: ScheduleKind = ScheduleKind.STATIC,
+    time_workers: int = 0,
 ):
     """Compile one static, TMA, or packed-persistent input-gradient specialization."""
     derivative = activation.derivative
     use_tma = _input_gradient_uses_tma(dtype, config, num_sequences, channels, width)
     if use_tma:
-        assert persistent_time_workers == 0
+        assert schedule_kind is ScheduleKind.STATIC and time_workers == 0
         operation = CausalConv1dSiluInputGradientTma(
             batches, tokens, channels, width, config, dtype, derivative
         )
@@ -2449,7 +2569,8 @@ def _compile_input_gradient(
             config,
             dtype,
             derivative,
-            persistent_time_workers,
+            schedule_kind,
+            time_workers,
         )
     return compile_tvm_ffi(
         operation,
@@ -2479,29 +2600,40 @@ def _compile_weight_gradient(
     num_sequences: int | None,
     has_initial_state: bool,
     activation: Activation,
+    schedule_kind: ScheduleKind = ScheduleKind.STATIC,
+    time_workers: int = 0,
 ):
-    """Compile one static weight-gradient specialization."""
+    """Compile one static, TMA, or packed-persistent weight-gradient specialization."""
     derivative = activation.derivative
-    num_time_blocks = ceildiv(tokens, config.times_per_block)
+    use_tma = _weight_gradient_uses_tma(dtype, config, num_sequences, channels, width)
+    num_partials = (
+        time_workers
+        if schedule_kind is ScheduleKind.PERSISTENT
+        else ceildiv(tokens, config.times_per_block)
+    )
     partials = cute.runtime.make_fake_compact_tensor(
         Float32,
-        (batches, num_time_blocks, channels, width),
+        (batches, num_partials, channels, width),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )
-    use_tma = supports_tma(
-        CausalConv1dSiluWeightGradientPartialsTma,
-        config,
-        tuned_config(dtype, packed=num_sequences is not None).weight_gradient,
-        channels,
-        width,
-    )
-    operation_type = (
-        CausalConv1dSiluWeightGradientPartialsTma
-        if use_tma
-        else CausalConv1dSiluWeightGradientPartials
-    )
-    operation = operation_type(batches, tokens, channels, width, config, dtype, derivative)
+    if use_tma:
+        assert schedule_kind is ScheduleKind.STATIC and time_workers == 0
+        operation = CausalConv1dSiluWeightGradientPartialsTma(
+            batches, tokens, channels, width, config, dtype, derivative
+        )
+    else:
+        operation = CausalConv1dSiluWeightGradientPartials(
+            batches,
+            tokens,
+            channels,
+            width,
+            config,
+            dtype,
+            derivative,
+            schedule_kind,
+            time_workers,
+        )
     return compile_tvm_ffi(
         operation,
         _fake_matrix(dtype, batches * tokens, channels),
@@ -2659,6 +2791,13 @@ def _launch_forward(
     dtype = SHORT_CONV_DTYPES[x.dtype]
     output = torch.empty_like(x)
     num_sequences = None if cu_seqlens is None else cu_seqlens.shape[0] - 1
+    schedule = _resolve_time_schedule(
+        tokens,
+        channels,
+        config,
+        x.device,
+        persistent_eligible=num_sequences is not None,
+    )
     compiled = _compile_forward(
         batches,
         tokens,
@@ -2669,11 +2808,8 @@ def _launch_forward(
         num_sequences,
         initial_state is not None,
         resolved_activation,
-        (
-            0
-            if num_sequences is None
-            else _persistent_time_workers(tokens, channels, config, x.device)
-        ),
+        schedule.kind,
+        schedule.workers,
     )
     compiled(
         x.view(batches * tokens, channels),
@@ -2708,13 +2844,14 @@ def _launch_backward(
     num_sequences = None if cu_seqlens is None else cu_seqlens.shape[0] - 1
     grad_output = _aligned(grad_output.contiguous())
     grad_x = torch.empty_like(x)
-    input_persistent_time_workers = 0
-    if num_sequences is not None and not _input_gradient_uses_tma(
-        dtype, input_config, num_sequences, channels, width
-    ):
-        input_persistent_time_workers = _persistent_time_workers(
-            tokens, channels, input_config, x.device
-        )
+    input_schedule = _resolve_time_schedule(
+        tokens,
+        channels,
+        input_config,
+        x.device,
+        persistent_eligible=num_sequences is not None
+        and not _input_gradient_uses_tma(dtype, input_config, num_sequences, channels, width),
+    )
     _compile_input_gradient(
         batches,
         tokens,
@@ -2725,7 +2862,8 @@ def _launch_backward(
         num_sequences,
         initial_state is not None,
         resolved_activation,
-        input_persistent_time_workers,
+        input_schedule.kind,
+        input_schedule.workers,
     )(
         x.view(batches * tokens, channels),
         weight,
@@ -2735,7 +2873,19 @@ def _launch_backward(
         None if initial_state is None else initial_state.flatten(0, 1),
     )
 
-    num_time_blocks = ceildiv(tokens, weight_config.times_per_block)
+    weight_schedule = _resolve_time_schedule(
+        tokens,
+        channels,
+        weight_config,
+        x.device,
+        persistent_eligible=num_sequences is not None
+        and not _weight_gradient_uses_tma(dtype, weight_config, num_sequences, channels, width),
+    )
+    num_partials = (
+        weight_schedule.workers
+        if weight_schedule.kind is ScheduleKind.PERSISTENT
+        else weight_schedule.capacity_tasks
+    )
     if initial_state is None or not compute_initial_state_grad:
         grad_initial_state = None
     elif width == 1:
@@ -2743,7 +2893,7 @@ def _launch_backward(
     else:
         grad_initial_state = torch.empty_like(initial_state)
     partials = torch.empty(
-        (batches, num_time_blocks, channels, width),
+        (batches, num_partials, channels, width),
         dtype=torch.float32,
         device=x.device,
     )
@@ -2757,6 +2907,8 @@ def _launch_backward(
         num_sequences,
         initial_state is not None,
         resolved_activation,
+        weight_schedule.kind,
+        weight_schedule.workers,
     )(
         x.view(batches * tokens, channels),
         weight,
@@ -2898,6 +3050,16 @@ def tune_causal_conv1d(
     )
     for config in forward_candidates:
         _validate_config(config, channels, "forward_configs")
+    forward_schedules = {
+        config: _resolve_time_schedule(
+            tokens,
+            channels,
+            config,
+            x.device,
+            persistent_eligible=num_sequences is not None,
+        )
+        for config in forward_candidates
+    }
     forward_output = torch.empty_like(x).view(batches * tokens, channels)
     forward = tune(
         forward_candidates,
@@ -2919,11 +3081,8 @@ def tune_causal_conv1d(
             num_sequences,
             kernel_initial_state is not None,
             resolved_activation,
-            (
-                0
-                if num_sequences is None
-                else _persistent_time_workers(tokens, channels, config, x.device)
-            ),
+            forward_schedules[config].kind,
+            forward_schedules[config].workers,
         ),
         parallel_compile=parallel_compile,
     )
@@ -2935,6 +3094,17 @@ def tune_causal_conv1d(
     )
     for config in input_candidates:
         _validate_config(config, channels, "input_grad_configs")
+    input_schedules = {
+        config: _resolve_time_schedule(
+            tokens,
+            channels,
+            config,
+            x.device,
+            persistent_eligible=num_sequences is not None
+            and not _input_gradient_uses_tma(dtype, config, num_sequences, channels, width),
+        )
+        for config in input_candidates
+    }
     grad_x = torch.empty_like(x).view(batches * tokens, channels)
     input_gradient = tune(
         input_candidates,
@@ -2952,12 +3122,8 @@ def tune_causal_conv1d(
             num_sequences,
             kernel_initial_state is not None,
             resolved_activation,
-            (
-                0
-                if num_sequences is None
-                or _input_gradient_uses_tma(dtype, config, num_sequences, channels, width)
-                else _persistent_time_workers(tokens, channels, config, x.device)
-            ),
+            input_schedules[config].kind,
+            input_schedules[config].workers,
         ),
         parallel_compile=parallel_compile,
     )
@@ -2969,16 +3135,31 @@ def tune_causal_conv1d(
     )
     for config in weight_candidates:
         _validate_config(config, channels, "weight_grad_configs")
+    weight_schedules = {
+        config: _resolve_time_schedule(
+            tokens,
+            channels,
+            config,
+            x.device,
+            persistent_eligible=num_sequences is not None
+            and not _weight_gradient_uses_tma(dtype, config, num_sequences, channels, width),
+        )
+        for config in weight_candidates
+    }
     partials = {
         config: torch.empty(
             batches,
-            ceildiv(tokens, config.times_per_block),
+            (
+                schedule.workers
+                if schedule.kind is ScheduleKind.PERSISTENT
+                else schedule.capacity_tasks
+            ),
             channels,
             width,
             dtype=torch.float32,
             device=x.device,
         )
-        for config in weight_candidates
+        for config, schedule in weight_schedules.items()
     }
     weight_gradient = tune(
         weight_candidates,
@@ -3001,6 +3182,8 @@ def tune_causal_conv1d(
             num_sequences,
             kernel_initial_state is not None,
             resolved_activation,
+            weight_schedules[config].kind,
+            weight_schedules[config].workers,
         ),
         parallel_compile=parallel_compile,
     )

--- a/attn_gym/linear/kda/short_conv/cute.py
+++ b/attn_gym/linear/kda/short_conv/cute.py
@@ -36,7 +36,6 @@ from attn_gym._backends.cute import (
 )
 from attn_gym._backends.cute.device import upper_bound
 from attn_gym.linear.kda import ops as kda_ops
-from attn_gym.linear.kda.chunk_schedule import ResolvedSchedule, ScheduleKind
 from attn_gym.linear.kda.short_conv.activations import Activation, resolve_activation
 
 _forward_op = kda_ops.short_conv_forward_op
@@ -64,33 +63,29 @@ SHORT_CONV_DTYPES = {
 
 
 # NOTE [Short-convolution time scheduling]
-# Match the shared GridScheduler contract: STATIC launches the capacity time axis and
-# lets inactive CTAs return from a device active-count check; PERSISTENT launches a
-# bounded worker axis and strides over active tiles. Short convolution needs no chunk
-# metadata because its active tile count is ceil_div(cu_seqlens[-1], times_per_block).
-# The measured eight-CTA/SM override preserves full-capacity throughput through 16K.
+# Match the shared scheduler's concrete launch convention: zero time workers means a
+# static capacity grid whose inactive CTAs return from a device check; a positive count
+# means a bounded grid that strides over active tiles. The measured short-convolution
+# policy uses eight CTAs per SM across the complete channel/time grid.
 _SHORT_CONV_CTAS_PER_SM = 8
 
 
-def _resolve_time_schedule(
+def _persistent_time_workers(
     tokens: int,
     channels: int,
     config: ShortConvConfig,
     device: torch.device,
     *,
     persistent_eligible: bool,
-    ctas_per_sm: int = _SHORT_CONV_CTAS_PER_SM,
-) -> ResolvedSchedule:
-    """Resolve static or machine-bounded execution for one time-tiled kernel."""
-    capacity = ceildiv(tokens, config.times_per_block)
+) -> int:
+    """Return a bounded packed time grid, or zero for static execution."""
     if not persistent_eligible:
-        return ResolvedSchedule(ScheduleKind.STATIC, 0, capacity)
+        return 0
+    capacity = ceildiv(tokens, config.times_per_block)
     channel_blocks = ceildiv(channels, config.threads * config.channels_per_thread)
-    device_workers = get_device_properties(device).multi_processor_count * ctas_per_sm
-    workers = min(capacity, max(1, ceildiv(device_workers, channel_blocks)))
-    if workers < capacity:
-        return ResolvedSchedule(ScheduleKind.PERSISTENT, workers, capacity)
-    return ResolvedSchedule(ScheduleKind.STATIC, 0, capacity)
+    device_workers = get_device_properties(device).multi_processor_count * _SHORT_CONV_CTAS_PER_SM
+    workers = ceildiv(device_workers, channel_blocks)
+    return workers if workers < capacity else 0
 
 
 @dataclass(frozen=True)
@@ -296,13 +291,8 @@ class ShortConvKernel:
         width: int,
         config: ShortConvConfig,
         dtype: ShortConvDType,
-        schedule_kind: ScheduleKind = ScheduleKind.STATIC,
         time_workers: int = 0,
     ):
-        if schedule_kind is ScheduleKind.PERSISTENT:
-            assert time_workers > 0, "persistent execution requires a positive time-worker grid"
-        else:
-            assert time_workers == 0, "static execution does not use time workers"
         self.sequences = sequences
         self.tokens = tokens
         self.channels = channels
@@ -311,7 +301,6 @@ class ShortConvKernel:
         self.channels_per_thread = config.channels_per_thread
         self.times_per_block = config.times_per_block
         self.dtype = dtype
-        self.schedule_kind = schedule_kind
         self.time_workers = time_workers
 
     def get_name(self) -> str:
@@ -322,7 +311,7 @@ class ShortConvKernel:
         )
         if self.time_tiled:
             name += f"_bt{self.times_per_block}"
-        if self.schedule_kind is ScheduleKind.PERSISTENT:
+        if self.time_workers:
             name += f"_execution_persistent_tw{self.time_workers}"
         name += f"_v{self.channels_per_thread}"
         if self.tma_stage_tokens:
@@ -344,19 +333,9 @@ class CausalConv1dSiluForward(ShortConvKernel):
         config: ShortConvConfig,
         dtype: ShortConvDType,
         activation,
-        schedule_kind: ScheduleKind = ScheduleKind.STATIC,
         time_workers: int = 0,
     ):
-        super().__init__(
-            batches,
-            tokens,
-            channels,
-            width,
-            config,
-            dtype,
-            schedule_kind,
-            time_workers,
-        )
+        super().__init__(batches, tokens, channels, width, config, dtype, time_workers)
         self.batches = batches
         self.activation = activation
 
@@ -477,7 +456,7 @@ class CausalConv1dSiluForward(ShortConvKernel):
                 active_time_blocks = (
                     active_endpoint + self.times_per_block - 1
                 ) // self.times_per_block
-                if cutlass.const_expr(self.schedule_kind is ScheduleKind.STATIC):
+                if cutlass.const_expr(self.time_workers == 0):
                     if active_endpoint == self.tokens:
                         self.run_tile(
                             x,
@@ -555,7 +534,7 @@ class CausalConv1dSiluForward(ShortConvKernel):
                 cute.ceil_div(self.channels, self.threads * self.channels_per_thread),
                 (
                     self.time_workers
-                    if cutlass.const_expr(self.schedule_kind is ScheduleKind.PERSISTENT)
+                    if cutlass.const_expr(self.time_workers > 0)
                     else cute.ceil_div(self.tokens, self.times_per_block)
                 ),
                 self.batches,
@@ -691,19 +670,9 @@ class CausalConv1dSiluInputGradient(ShortConvKernel):
         config: ShortConvConfig,
         dtype: ShortConvDType,
         d_activation,
-        schedule_kind: ScheduleKind = ScheduleKind.STATIC,
         time_workers: int = 0,
     ):
-        super().__init__(
-            batches,
-            tokens,
-            channels,
-            width,
-            config,
-            dtype,
-            schedule_kind,
-            time_workers,
-        )
+        super().__init__(batches, tokens, channels, width, config, dtype, time_workers)
         self.batches = batches
         self.d_activation = d_activation
 
@@ -880,7 +849,7 @@ class CausalConv1dSiluInputGradient(ShortConvKernel):
                 active_time_blocks = (
                     active_endpoint + self.times_per_block - 1
                 ) // self.times_per_block
-                if cutlass.const_expr(self.schedule_kind is ScheduleKind.STATIC):
+                if cutlass.const_expr(self.time_workers == 0):
                     if active_endpoint == self.tokens:
                         self.run_tile(
                             x,
@@ -964,7 +933,7 @@ class CausalConv1dSiluInputGradient(ShortConvKernel):
                 cute.ceil_div(self.channels, self.threads * self.channels_per_thread),
                 (
                     self.time_workers
-                    if cutlass.const_expr(self.schedule_kind is ScheduleKind.PERSISTENT)
+                    if cutlass.const_expr(self.time_workers > 0)
                     else cute.ceil_div(self.tokens, self.times_per_block)
                 ),
                 self.batches,
@@ -988,19 +957,9 @@ class CausalConv1dSiluWeightGradientPartials(ShortConvKernel):
         config: ShortConvConfig,
         dtype: ShortConvDType,
         d_activation,
-        schedule_kind: ScheduleKind = ScheduleKind.STATIC,
         time_workers: int = 0,
     ):
-        super().__init__(
-            batches,
-            tokens,
-            channels,
-            width,
-            config,
-            dtype,
-            schedule_kind,
-            time_workers,
-        )
+        super().__init__(batches, tokens, channels, width, config, dtype, time_workers)
         self.batches = batches
         self.d_activation = d_activation
 
@@ -1118,7 +1077,7 @@ class CausalConv1dSiluWeightGradientPartials(ShortConvKernel):
                 active_time_blocks = (
                     active_endpoint + self.times_per_block - 1
                 ) // self.times_per_block
-                if cutlass.const_expr(self.schedule_kind is ScheduleKind.STATIC):
+                if cutlass.const_expr(self.time_workers == 0):
                     if active_endpoint == self.tokens:
                         self.accumulate_tile(
                             x,
@@ -1204,7 +1163,7 @@ class CausalConv1dSiluWeightGradientPartials(ShortConvKernel):
                 cute.ceil_div(self.channels, self.threads * self.channels_per_thread),
                 (
                     self.time_workers
-                    if cutlass.const_expr(self.schedule_kind is ScheduleKind.PERSISTENT)
+                    if cutlass.const_expr(self.time_workers > 0)
                     else cute.ceil_div(self.tokens, self.times_per_block)
                 ),
                 self.batches,
@@ -2437,8 +2396,7 @@ def _compile_forward(
     num_sequences: int | None,
     has_initial_state: bool,
     activation: Activation,
-    schedule_kind: ScheduleKind = ScheduleKind.STATIC,
-    time_workers: int = 0,
+    time_workers: int,
 ):
     """Compile one dense, packed-static, or packed-persistent forward specialization."""
     activation_fn = activation.forward
@@ -2450,7 +2408,6 @@ def _compile_forward(
         config,
         dtype,
         activation_fn,
-        schedule_kind,
         time_workers,
     )
     return compile_tvm_ffi(
@@ -2549,14 +2506,13 @@ def _compile_input_gradient(
     num_sequences: int | None,
     has_initial_state: bool,
     activation: Activation,
-    schedule_kind: ScheduleKind = ScheduleKind.STATIC,
-    time_workers: int = 0,
+    time_workers: int,
 ):
     """Compile one static, TMA, or packed-persistent input-gradient specialization."""
     derivative = activation.derivative
     use_tma = _input_gradient_uses_tma(dtype, config, num_sequences, channels, width)
     if use_tma:
-        assert schedule_kind is ScheduleKind.STATIC and time_workers == 0
+        assert time_workers == 0
         operation = CausalConv1dSiluInputGradientTma(
             batches, tokens, channels, width, config, dtype, derivative
         )
@@ -2569,7 +2525,6 @@ def _compile_input_gradient(
             config,
             dtype,
             derivative,
-            schedule_kind,
             time_workers,
         )
     return compile_tvm_ffi(
@@ -2600,17 +2555,12 @@ def _compile_weight_gradient(
     num_sequences: int | None,
     has_initial_state: bool,
     activation: Activation,
-    schedule_kind: ScheduleKind = ScheduleKind.STATIC,
-    time_workers: int = 0,
+    time_workers: int,
 ):
     """Compile one static, TMA, or packed-persistent weight-gradient specialization."""
     derivative = activation.derivative
     use_tma = _weight_gradient_uses_tma(dtype, config, num_sequences, channels, width)
-    num_partials = (
-        time_workers
-        if schedule_kind is ScheduleKind.PERSISTENT
-        else ceildiv(tokens, config.times_per_block)
-    )
+    num_partials = time_workers or ceildiv(tokens, config.times_per_block)
     partials = cute.runtime.make_fake_compact_tensor(
         Float32,
         (batches, num_partials, channels, width),
@@ -2618,7 +2568,7 @@ def _compile_weight_gradient(
         assumed_align=16,
     )
     if use_tma:
-        assert schedule_kind is ScheduleKind.STATIC and time_workers == 0
+        assert time_workers == 0
         operation = CausalConv1dSiluWeightGradientPartialsTma(
             batches, tokens, channels, width, config, dtype, derivative
         )
@@ -2631,7 +2581,6 @@ def _compile_weight_gradient(
             config,
             dtype,
             derivative,
-            schedule_kind,
             time_workers,
         )
     return compile_tvm_ffi(
@@ -2791,13 +2740,6 @@ def _launch_forward(
     dtype = SHORT_CONV_DTYPES[x.dtype]
     output = torch.empty_like(x)
     num_sequences = None if cu_seqlens is None else cu_seqlens.shape[0] - 1
-    schedule = _resolve_time_schedule(
-        tokens,
-        channels,
-        config,
-        x.device,
-        persistent_eligible=num_sequences is not None,
-    )
     compiled = _compile_forward(
         batches,
         tokens,
@@ -2808,8 +2750,13 @@ def _launch_forward(
         num_sequences,
         initial_state is not None,
         resolved_activation,
-        schedule.kind,
-        schedule.workers,
+        _persistent_time_workers(
+            tokens,
+            channels,
+            config,
+            x.device,
+            persistent_eligible=num_sequences is not None,
+        ),
     )
     compiled(
         x.view(batches * tokens, channels),
@@ -2844,14 +2791,6 @@ def _launch_backward(
     num_sequences = None if cu_seqlens is None else cu_seqlens.shape[0] - 1
     grad_output = _aligned(grad_output.contiguous())
     grad_x = torch.empty_like(x)
-    input_schedule = _resolve_time_schedule(
-        tokens,
-        channels,
-        input_config,
-        x.device,
-        persistent_eligible=num_sequences is not None
-        and not _input_gradient_uses_tma(dtype, input_config, num_sequences, channels, width),
-    )
     _compile_input_gradient(
         batches,
         tokens,
@@ -2862,8 +2801,14 @@ def _launch_backward(
         num_sequences,
         initial_state is not None,
         resolved_activation,
-        input_schedule.kind,
-        input_schedule.workers,
+        _persistent_time_workers(
+            tokens,
+            channels,
+            input_config,
+            x.device,
+            persistent_eligible=num_sequences is not None
+            and not _input_gradient_uses_tma(dtype, input_config, num_sequences, channels, width),
+        ),
     )(
         x.view(batches * tokens, channels),
         weight,
@@ -2873,7 +2818,7 @@ def _launch_backward(
         None if initial_state is None else initial_state.flatten(0, 1),
     )
 
-    weight_schedule = _resolve_time_schedule(
+    weight_workers = _persistent_time_workers(
         tokens,
         channels,
         weight_config,
@@ -2881,11 +2826,7 @@ def _launch_backward(
         persistent_eligible=num_sequences is not None
         and not _weight_gradient_uses_tma(dtype, weight_config, num_sequences, channels, width),
     )
-    num_partials = (
-        weight_schedule.workers
-        if weight_schedule.kind is ScheduleKind.PERSISTENT
-        else weight_schedule.capacity_tasks
-    )
+    num_partials = weight_workers or ceildiv(tokens, weight_config.times_per_block)
     if initial_state is None or not compute_initial_state_grad:
         grad_initial_state = None
     elif width == 1:
@@ -2907,8 +2848,7 @@ def _launch_backward(
         num_sequences,
         initial_state is not None,
         resolved_activation,
-        weight_schedule.kind,
-        weight_schedule.workers,
+        weight_workers,
     )(
         x.view(batches * tokens, channels),
         weight,
@@ -3050,16 +2990,6 @@ def tune_causal_conv1d(
     )
     for config in forward_candidates:
         _validate_config(config, channels, "forward_configs")
-    forward_schedules = {
-        config: _resolve_time_schedule(
-            tokens,
-            channels,
-            config,
-            x.device,
-            persistent_eligible=num_sequences is not None,
-        )
-        for config in forward_candidates
-    }
     forward_output = torch.empty_like(x).view(batches * tokens, channels)
     forward = tune(
         forward_candidates,
@@ -3081,8 +3011,13 @@ def tune_causal_conv1d(
             num_sequences,
             kernel_initial_state is not None,
             resolved_activation,
-            forward_schedules[config].kind,
-            forward_schedules[config].workers,
+            _persistent_time_workers(
+                tokens,
+                channels,
+                config,
+                x.device,
+                persistent_eligible=num_sequences is not None,
+            ),
         ),
         parallel_compile=parallel_compile,
     )
@@ -3094,17 +3029,6 @@ def tune_causal_conv1d(
     )
     for config in input_candidates:
         _validate_config(config, channels, "input_grad_configs")
-    input_schedules = {
-        config: _resolve_time_schedule(
-            tokens,
-            channels,
-            config,
-            x.device,
-            persistent_eligible=num_sequences is not None
-            and not _input_gradient_uses_tma(dtype, config, num_sequences, channels, width),
-        )
-        for config in input_candidates
-    }
     grad_x = torch.empty_like(x).view(batches * tokens, channels)
     input_gradient = tune(
         input_candidates,
@@ -3122,8 +3046,14 @@ def tune_causal_conv1d(
             num_sequences,
             kernel_initial_state is not None,
             resolved_activation,
-            input_schedules[config].kind,
-            input_schedules[config].workers,
+            _persistent_time_workers(
+                tokens,
+                channels,
+                config,
+                x.device,
+                persistent_eligible=num_sequences is not None
+                and not _input_gradient_uses_tma(dtype, config, num_sequences, channels, width),
+            ),
         ),
         parallel_compile=parallel_compile,
     )
@@ -3135,8 +3065,8 @@ def tune_causal_conv1d(
     )
     for config in weight_candidates:
         _validate_config(config, channels, "weight_grad_configs")
-    weight_schedules = {
-        config: _resolve_time_schedule(
+    weight_workers = {
+        config: _persistent_time_workers(
             tokens,
             channels,
             config,
@@ -3149,17 +3079,13 @@ def tune_causal_conv1d(
     partials = {
         config: torch.empty(
             batches,
-            (
-                schedule.workers
-                if schedule.kind is ScheduleKind.PERSISTENT
-                else schedule.capacity_tasks
-            ),
+            workers or ceildiv(tokens, config.times_per_block),
             channels,
             width,
             dtype=torch.float32,
             device=x.device,
         )
-        for config, schedule in weight_schedules.items()
+        for config, workers in weight_workers.items()
     }
     weight_gradient = tune(
         weight_candidates,
@@ -3182,8 +3108,7 @@ def tune_causal_conv1d(
             num_sequences,
             kernel_initial_state is not None,
             resolved_activation,
-            weight_schedules[config].kind,
-            weight_schedules[config].workers,
+            weight_workers[config],
         ),
         parallel_compile=parallel_compile,
     )

--- a/attn_gym/linear/kda/short_conv/cute.py
+++ b/attn_gym/linear/kda/short_conv/cute.py
@@ -27,7 +27,13 @@ import torch
 from cutlass import BFloat16, Float16, Float32, Int32, Int64, cute, pipeline
 from cutlass.cute.nvgpu import cpasync
 
-from attn_gym._backends.cute import ceildiv, compile_tvm_ffi, jit_cache, tune
+from attn_gym._backends.cute import (
+    ceildiv,
+    compile_tvm_ffi,
+    get_device_properties,
+    jit_cache,
+    tune,
+)
 from attn_gym._backends.cute.device import upper_bound
 from attn_gym.linear.kda import ops as kda_ops
 from attn_gym.linear.kda.short_conv.activations import Activation, resolve_activation
@@ -54,6 +60,28 @@ SHORT_CONV_DTYPES = {
     torch.bfloat16: ShortConvDType(BFloat16, "bf16"),
     torch.float32: ShortConvDType(Float32, "fp32"),
 }
+
+
+# Measured packed worker budget: preserve full-capacity parallelism through 16K tokens
+# while bounding larger 2D grids and skipping inactive replay tiles before tile setup.
+_PERSISTENT_TIME_CTAS_PER_SM = 8
+
+
+def _persistent_time_workers(
+    tokens: int,
+    channels: int,
+    config: ShortConvConfig,
+    device: torch.device,
+) -> int:
+    """Bound the packed time axis so the complete 2D grid stays machine-sized."""
+    channel_blocks = ceildiv(channels, config.threads * config.channels_per_thread)
+    device_workers = (
+        get_device_properties(device).multi_processor_count * _PERSISTENT_TIME_CTAS_PER_SM
+    )
+    return min(
+        ceildiv(tokens, config.times_per_block),
+        max(1, ceildiv(device_workers, channel_blocks)),
+    )
 
 
 @dataclass(frozen=True)
@@ -259,6 +287,7 @@ class ShortConvKernel:
         width: int,
         config: ShortConvConfig,
         dtype: ShortConvDType,
+        persistent_time_workers: int = 0,
     ):
         self.sequences = sequences
         self.tokens = tokens
@@ -268,6 +297,7 @@ class ShortConvKernel:
         self.channels_per_thread = config.channels_per_thread
         self.times_per_block = config.times_per_block
         self.dtype = dtype
+        self.persistent_time_workers = persistent_time_workers
 
     def get_name(self) -> str:
         """Return the stable compiled-artifact name."""
@@ -277,6 +307,8 @@ class ShortConvKernel:
         )
         if self.time_tiled:
             name += f"_bt{self.times_per_block}"
+        if self.persistent_time_workers:
+            name += f"_ptw{self.persistent_time_workers}"
         name += f"_v{self.channels_per_thread}"
         if self.tma_stage_tokens:
             name += f"_tma{self.tma_stage_tokens}"
@@ -297,10 +329,116 @@ class CausalConv1dSiluForward(ShortConvKernel):
         config: ShortConvConfig,
         dtype: ShortConvDType,
         activation,
+        persistent_time_workers: int = 0,
     ):
-        super().__init__(batches, tokens, channels, width, config, dtype)
+        super().__init__(
+            batches,
+            tokens,
+            channels,
+            width,
+            config,
+            dtype,
+            persistent_time_workers,
+        )
         self.batches = batches
         self.activation = activation
+
+    @cute.jit
+    def run_tile(
+        self,
+        x: cute.Tensor,
+        weight: cute.Tensor,
+        output: cute.Tensor,
+        cu_seqlens: cute.Tensor | None,
+        initial_state: cute.Tensor | None,
+        channel_group: Int32,
+        channel: Int32,
+        time_block: Int32,
+        batch: Int32,
+        active_endpoint: Int32,
+    ):
+        """Compute one independent physical time tile for a channel group."""
+        time_start = time_block * self.times_per_block
+        weights = cute.make_rmem_tensor((self.channels_per_thread, self.width), Float32)
+        for channel_offset in cutlass.range_constexpr(self.channels_per_thread):
+            for tap in cutlass.range_constexpr(self.width):
+                weights[channel_offset, tap] = Float32(weight[channel + channel_offset, tap])
+
+        x_groups = cute.zipped_divide(x, (1, self.channels_per_thread))
+        output_groups = cute.zipped_divide(output, (1, self.channels_per_thread))
+        if cutlass.const_expr(initial_state is not None):
+            initial_groups = cute.zipped_divide(initial_state, (1, self.channels_per_thread))
+        inputs = cute.make_rmem_tensor(
+            (self.channels_per_thread, self.times_per_block + self.width - 1),
+            self.dtype.cute_type,
+        )
+        inputs.fill(self.dtype.cute_type(0.0))
+        for input_offset in cutlass.range_constexpr(self.times_per_block + self.width - 1):
+            input_time = time_start + input_offset - (self.width - 1)
+            if input_time >= 0 and input_time < active_endpoint:
+                inputs[(None, input_offset)].store(
+                    x_groups[((0, None), (batch * self.tokens + input_time, channel_group))].load()
+                )
+
+        tile_sequence, tile_sequence_start, tile_sequence_end = tile_sequence_bounds(
+            cu_seqlens,
+            Int32(time_start),
+            Int32(batch),
+            self.tokens,
+        )
+        for time_offset in cutlass.range_constexpr(self.times_per_block):
+            time = time_start + time_offset
+            sequence = tile_sequence
+            sequence_start = tile_sequence_start
+            if time < active_endpoint:
+                if cutlass.const_expr(cu_seqlens is not None):
+                    sequence, sequence_start, _ = advance_sequence_bounds(
+                        cu_seqlens,
+                        tile_sequence,
+                        tile_sequence_start,
+                        tile_sequence_end,
+                        Int32(time),
+                    )
+                else:
+                    sequence_start = Int32(0)
+
+                if cutlass.const_expr(initial_state is not None):
+                    value = unrolled_dot(inputs, weights, time_offset, self.width)
+                    if time - (self.width - 1) < sequence_start:
+                        value = history_dot(
+                            inputs,
+                            weights,
+                            initial_groups,
+                            sequence,
+                            Int32(time),
+                            sequence_start,
+                            time_offset,
+                            channel_group,
+                            self.channels_per_thread,
+                            self.width,
+                        )
+                elif cutlass.const_expr(cu_seqlens is None):
+                    value = unrolled_dot(inputs, weights, time_offset, self.width)
+                else:
+                    last_tap = self.width - 1
+                    value = (
+                        inputs[(None, time_offset + last_tap)].load().to(Float32)
+                        * weights[(None, last_tap)].load()
+                    )
+                    if time - last_tap >= sequence_start:
+                        value = unrolled_dot(inputs, weights, time_offset, self.width)
+                    else:
+                        for step in cutlass.range_constexpr(self.width - 1):
+                            tap = self.width - 2 - step
+                            if time + tap - last_tap >= sequence_start:
+                                value = (
+                                    value
+                                    + inputs[(None, time_offset + tap)].load().to(Float32)
+                                    * weights[(None, tap)].load()
+                                )
+                output_groups[((0, None), (batch * self.tokens + time, channel_group))].store(
+                    self.activation(value).to(self.dtype.cute_type)
+                )
 
     @cute.kernel
     def kernel(
@@ -311,97 +449,75 @@ class CausalConv1dSiluForward(ShortConvKernel):
         cu_seqlens: cute.Tensor | None,
         initial_state: cute.Tensor | None,
     ):
-        """Compute one packed channel group and eight output tokens."""
+        """Compute one channel group over static or persistent time tiles."""
         thread_idx, _, _ = cute.arch.thread_idx()
-        channel_block, time_block, batch = cute.arch.block_idx()
+        channel_block, worker, batch = cute.arch.block_idx()
         channel_group = channel_block * self.threads + thread_idx
         channel = channel_group * self.channels_per_thread
-        time_start = time_block * self.times_per_block
-
         if channel < self.channels:
-            weights = cute.make_rmem_tensor((self.channels_per_thread, self.width), Float32)
-            for channel_offset in cutlass.range_constexpr(self.channels_per_thread):
-                for tap in cutlass.range_constexpr(self.width):
-                    weights[channel_offset, tap] = Float32(weight[channel + channel_offset, tap])
-
-            x_groups = cute.zipped_divide(x, (1, self.channels_per_thread))
-            output_groups = cute.zipped_divide(output, (1, self.channels_per_thread))
-            if cutlass.const_expr(initial_state is not None):
-                initial_groups = cute.zipped_divide(initial_state, (1, self.channels_per_thread))
-            inputs = cute.make_rmem_tensor(
-                (self.channels_per_thread, self.times_per_block + self.width - 1),
-                self.dtype.cute_type,
-            )
-            inputs.fill(self.dtype.cute_type(0.0))
-            for input_offset in cutlass.range_constexpr(self.times_per_block + self.width - 1):
-                input_time = time_start + input_offset - (self.width - 1)
-                if input_time >= 0 and input_time < self.tokens:
-                    inputs[(None, input_offset)].store(
-                        x_groups[
-                            ((0, None), (batch * self.tokens + input_time, channel_group))
-                        ].load()
-                    )
-
-            tile_sequence, tile_sequence_start, tile_sequence_end = tile_sequence_bounds(
-                cu_seqlens,
-                Int32(time_start),
-                Int32(batch),
-                self.tokens,
-            )
-
-            for time_offset in cutlass.range_constexpr(self.times_per_block):
-                time = time_start + time_offset
-                sequence = tile_sequence
-                sequence_start = tile_sequence_start
-                if time < self.tokens:
-                    if cutlass.const_expr(cu_seqlens is not None):
-                        sequence, sequence_start, _ = advance_sequence_bounds(
+            if cutlass.const_expr(self.persistent_time_workers > 0):
+                active_endpoint = Int32(cu_seqlens[cute.size(cu_seqlens) - 1])
+                active_time_blocks = (
+                    active_endpoint + self.times_per_block - 1
+                ) // self.times_per_block
+                if cutlass.const_expr(
+                    self.persistent_time_workers == ceildiv(self.tokens, self.times_per_block)
+                ):
+                    if active_endpoint == self.tokens:
+                        self.run_tile(
+                            x,
+                            weight,
+                            output,
                             cu_seqlens,
-                            tile_sequence,
-                            tile_sequence_start,
-                            tile_sequence_end,
-                            Int32(time),
+                            initial_state,
+                            Int32(channel_group),
+                            Int32(channel),
+                            Int32(worker),
+                            Int32(batch),
+                            Int32(self.tokens),
                         )
-                    else:
-                        sequence_start = Int32(0)
-
-                    if cutlass.const_expr(initial_state is not None):
-                        value = unrolled_dot(inputs, weights, time_offset, self.width)
-                        if time - (self.width - 1) < sequence_start:
-                            value = history_dot(
-                                inputs,
-                                weights,
-                                initial_groups,
-                                sequence,
-                                Int32(time),
-                                sequence_start,
-                                time_offset,
-                                channel_group,
-                                self.channels_per_thread,
-                                self.width,
-                            )
-                    elif cutlass.const_expr(cu_seqlens is None):
-                        value = unrolled_dot(inputs, weights, time_offset, self.width)
-                    else:
-                        last_tap = self.width - 1
-                        value = (
-                            inputs[(None, time_offset + last_tap)].load().to(Float32)
-                            * weights[(None, last_tap)].load()
+                    elif worker < active_time_blocks:
+                        self.run_tile(
+                            x,
+                            weight,
+                            output,
+                            cu_seqlens,
+                            initial_state,
+                            Int32(channel_group),
+                            Int32(channel),
+                            Int32(worker),
+                            Int32(batch),
+                            active_endpoint,
                         )
-                        if time - last_tap >= sequence_start:
-                            value = unrolled_dot(inputs, weights, time_offset, self.width)
-                        else:
-                            for step in cutlass.range_constexpr(self.width - 1):
-                                tap = self.width - 2 - step
-                                if time + tap - last_tap >= sequence_start:
-                                    value = (
-                                        value
-                                        + inputs[(None, time_offset + tap)].load().to(Float32)
-                                        * weights[(None, tap)].load()
-                                    )
-                    output_groups[((0, None), (batch * self.tokens + time, channel_group))].store(
-                        self.activation(value).to(self.dtype.cute_type)
-                    )
+                else:
+                    for time_block in cutlass.range(
+                        worker, active_time_blocks, self.persistent_time_workers
+                    ):
+                        self.run_tile(
+                            x,
+                            weight,
+                            output,
+                            cu_seqlens,
+                            initial_state,
+                            Int32(channel_group),
+                            Int32(channel),
+                            Int32(time_block),
+                            Int32(batch),
+                            active_endpoint,
+                        )
+            else:
+                self.run_tile(
+                    x,
+                    weight,
+                    output,
+                    cu_seqlens,
+                    initial_state,
+                    Int32(channel_group),
+                    Int32(channel),
+                    Int32(worker),
+                    Int32(batch),
+                    Int32(self.tokens),
+                )
 
     @cute.jit
     def __call__(
@@ -424,7 +540,11 @@ class CausalConv1dSiluForward(ShortConvKernel):
         ).launch(
             grid=(
                 cute.ceil_div(self.channels, self.threads * self.channels_per_thread),
-                cute.ceil_div(self.tokens, self.times_per_block),
+                (
+                    self.persistent_time_workers
+                    if cutlass.const_expr(self.persistent_time_workers > 0)
+                    else cute.ceil_div(self.tokens, self.times_per_block)
+                ),
                 self.batches,
             ),
             block=(self.threads, 1, 1),
@@ -558,10 +678,171 @@ class CausalConv1dSiluInputGradient(ShortConvKernel):
         config: ShortConvConfig,
         dtype: ShortConvDType,
         d_activation,
+        persistent_time_workers: int = 0,
     ):
-        super().__init__(batches, tokens, channels, width, config, dtype)
+        super().__init__(
+            batches,
+            tokens,
+            channels,
+            width,
+            config,
+            dtype,
+            persistent_time_workers,
+        )
         self.batches = batches
         self.d_activation = d_activation
+
+    @cute.jit
+    def run_tile(
+        self,
+        x: cute.Tensor,
+        weight: cute.Tensor,
+        grad_output: cute.Tensor,
+        grad_x: cute.Tensor,
+        cu_seqlens: cute.Tensor | None,
+        initial_state: cute.Tensor | None,
+        channel_group: Int32,
+        channel: Int32,
+        time_block: Int32,
+        batch: Int32,
+        active_endpoint: Int32,
+    ):
+        """Compute one independent physical time tile for a channel group."""
+        time_start = time_block * self.times_per_block
+        x_groups = cute.zipped_divide(x, (1, self.channels_per_thread))
+        dy_groups = cute.zipped_divide(grad_output, (1, self.channels_per_thread))
+        dx_groups = cute.zipped_divide(grad_x, (1, self.channels_per_thread))
+        if cutlass.const_expr(initial_state is not None):
+            initial_groups = cute.zipped_divide(initial_state, (1, self.channels_per_thread))
+        weights = cute.make_rmem_tensor((self.channels_per_thread, self.width), Float32)
+        for channel_offset in cutlass.range_constexpr(self.channels_per_thread):
+            for tap in cutlass.range_constexpr(self.width):
+                weights[channel_offset, tap] = Float32(weight[channel + channel_offset, tap])
+
+        inputs = cute.make_rmem_tensor(
+            (self.channels_per_thread, self.times_per_block + 2 * (self.width - 1)),
+            self.dtype.cute_type,
+        )
+        inputs.fill(self.dtype.cute_type(0.0))
+        for input_offset in cutlass.range_constexpr(self.times_per_block + 2 * (self.width - 1)):
+            input_time = time_start + input_offset - (self.width - 1)
+            if input_time >= 0 and input_time < active_endpoint:
+                inputs[(None, input_offset)].store(
+                    x_groups[((0, None), (batch * self.tokens + input_time, channel_group))].load()
+                )
+
+        grad_z = cute.make_rmem_tensor(
+            (self.channels_per_thread, self.times_per_block + self.width - 1),
+            Float32,
+        )
+        grad_z.fill(Float32(0.0))
+        output_sequence, output_sequence_start, output_sequence_end = tile_sequence_bounds(
+            cu_seqlens,
+            Int32(time_start),
+            Int32(batch),
+            self.tokens,
+        )
+        for output_offset in cutlass.range_constexpr(self.times_per_block + self.width - 1):
+            output_time = time_start + output_offset
+            if output_time < active_endpoint:
+                if cutlass.const_expr(cu_seqlens is not None):
+                    (
+                        output_sequence,
+                        output_sequence_start,
+                        output_sequence_end,
+                    ) = advance_sequence_bounds(
+                        cu_seqlens,
+                        output_sequence,
+                        output_sequence_start,
+                        output_sequence_end,
+                        Int32(output_time),
+                    )
+                if cutlass.const_expr(initial_state is not None):
+                    value = unrolled_dot(inputs, weights, output_offset, self.width)
+                    if output_time - (self.width - 1) < output_sequence_start:
+                        value = history_dot(
+                            inputs,
+                            weights,
+                            initial_groups,
+                            output_sequence,
+                            Int32(output_time),
+                            output_sequence_start,
+                            output_offset,
+                            channel_group,
+                            self.channels_per_thread,
+                            self.width,
+                        )
+                else:
+                    products = cute.make_rmem_tensor(
+                        (self.channels_per_thread, self.width), Float32
+                    )
+                    products.fill(Float32(0.0))
+                    for tap in cutlass.range_constexpr(self.width):
+                        input_time = output_time + tap - (self.width - 1)
+                        if (
+                            cutlass.const_expr(cu_seqlens is None)
+                            or input_time >= output_sequence_start
+                        ):
+                            products[(None, tap)].store(
+                                inputs[(None, output_offset + tap)].load().to(Float32)
+                                * weights[(None, tap)].load()
+                            )
+                    value = products.load().reduce(
+                        cute.ReductionOp.ADD,
+                        Float32(0.0),
+                        reduction_profile=(None, 1),
+                    )
+                derivative = self.d_activation(value)
+                incoming = (
+                    dy_groups[((0, None), (batch * self.tokens + output_time, channel_group))]
+                    .load()
+                    .to(Float32)
+                )
+                grad_z[(None, output_offset)].store(incoming * derivative)
+
+        input_sequence, input_sequence_start, input_sequence_end = tile_sequence_bounds(
+            cu_seqlens,
+            Int32(time_start),
+            Int32(batch),
+            self.tokens,
+        )
+        for time_offset in cutlass.range_constexpr(self.times_per_block):
+            time = time_start + time_offset
+            if time < active_endpoint:
+                if cutlass.const_expr(cu_seqlens is not None):
+                    (
+                        input_sequence,
+                        input_sequence_start,
+                        input_sequence_end,
+                    ) = advance_sequence_bounds(
+                        cu_seqlens,
+                        input_sequence,
+                        input_sequence_start,
+                        input_sequence_end,
+                        Int32(time),
+                    )
+                products = cute.make_rmem_tensor((self.channels_per_thread, self.width), Float32)
+                products.fill(Float32(0.0))
+                for future_offset in cutlass.range_constexpr(self.width):
+                    if cutlass.const_expr(cu_seqlens is None):
+                        products[(None, future_offset)].store(
+                            grad_z[(None, time_offset + future_offset)].load()
+                            * weights[(None, self.width - 1 - future_offset)].load()
+                        )
+                    else:
+                        if time + future_offset < input_sequence_end:
+                            products[(None, future_offset)].store(
+                                grad_z[(None, time_offset + future_offset)].load()
+                                * weights[(None, self.width - 1 - future_offset)].load()
+                            )
+                value = products.load().reduce(
+                    cute.ReductionOp.ADD,
+                    Float32(0.0),
+                    reduction_profile=(None, 1),
+                )
+                dx_groups[((0, None), (batch * self.tokens + time, channel_group))].store(
+                    value.to(self.dtype.cute_type)
+                )
 
     @cute.kernel
     def kernel(
@@ -573,154 +854,79 @@ class CausalConv1dSiluInputGradient(ShortConvKernel):
         cu_seqlens: cute.Tensor | None,
         initial_state: cute.Tensor | None,
     ):
-        """Compute one packed channel group and ten input-gradient tokens."""
+        """Compute one channel group over static or persistent time tiles."""
         thread_idx, _, _ = cute.arch.thread_idx()
-        channel_block, time_block, batch = cute.arch.block_idx()
+        channel_block, worker, batch = cute.arch.block_idx()
         channel_group = channel_block * self.threads + thread_idx
         channel = channel_group * self.channels_per_thread
-        time_start = time_block * self.times_per_block
-
         if channel < self.channels:
-            x_groups = cute.zipped_divide(x, (1, self.channels_per_thread))
-            dy_groups = cute.zipped_divide(grad_output, (1, self.channels_per_thread))
-            dx_groups = cute.zipped_divide(grad_x, (1, self.channels_per_thread))
-            if cutlass.const_expr(initial_state is not None):
-                initial_groups = cute.zipped_divide(initial_state, (1, self.channels_per_thread))
-            weights = cute.make_rmem_tensor((self.channels_per_thread, self.width), Float32)
-            for channel_offset in cutlass.range_constexpr(self.channels_per_thread):
-                for tap in cutlass.range_constexpr(self.width):
-                    weights[channel_offset, tap] = Float32(weight[channel + channel_offset, tap])
-
-            inputs = cute.make_rmem_tensor(
-                (self.channels_per_thread, self.times_per_block + 2 * (self.width - 1)),
-                self.dtype.cute_type,
-            )
-            inputs.fill(self.dtype.cute_type(0.0))
-            for input_offset in cutlass.range_constexpr(
-                self.times_per_block + 2 * (self.width - 1)
-            ):
-                input_time = time_start + input_offset - (self.width - 1)
-                if input_time >= 0 and input_time < self.tokens:
-                    inputs[(None, input_offset)].store(
-                        x_groups[
-                            ((0, None), (batch * self.tokens + input_time, channel_group))
-                        ].load()
-                    )
-
-            grad_z = cute.make_rmem_tensor(
-                (self.channels_per_thread, self.times_per_block + self.width - 1),
-                Float32,
-            )
-            grad_z.fill(Float32(0.0))
-            output_sequence, output_sequence_start, output_sequence_end = tile_sequence_bounds(
-                cu_seqlens,
-                Int32(time_start),
-                Int32(batch),
-                self.tokens,
-            )
-            for output_offset in cutlass.range_constexpr(self.times_per_block + self.width - 1):
-                output_time = time_start + output_offset
-                if output_time < self.tokens:
-                    if cutlass.const_expr(cu_seqlens is not None):
-                        (
-                            output_sequence,
-                            output_sequence_start,
-                            output_sequence_end,
-                        ) = advance_sequence_bounds(
+            if cutlass.const_expr(self.persistent_time_workers > 0):
+                active_endpoint = Int32(cu_seqlens[cute.size(cu_seqlens) - 1])
+                active_time_blocks = (
+                    active_endpoint + self.times_per_block - 1
+                ) // self.times_per_block
+                if cutlass.const_expr(
+                    self.persistent_time_workers == ceildiv(self.tokens, self.times_per_block)
+                ):
+                    if active_endpoint == self.tokens:
+                        self.run_tile(
+                            x,
+                            weight,
+                            grad_output,
+                            grad_x,
                             cu_seqlens,
-                            output_sequence,
-                            output_sequence_start,
-                            output_sequence_end,
-                            Int32(output_time),
+                            initial_state,
+                            Int32(channel_group),
+                            Int32(channel),
+                            Int32(worker),
+                            Int32(batch),
+                            Int32(self.tokens),
                         )
-                    if cutlass.const_expr(initial_state is not None):
-                        value = unrolled_dot(inputs, weights, output_offset, self.width)
-                        if output_time - (self.width - 1) < output_sequence_start:
-                            value = history_dot(
-                                inputs,
-                                weights,
-                                initial_groups,
-                                output_sequence,
-                                Int32(output_time),
-                                output_sequence_start,
-                                output_offset,
-                                channel_group,
-                                self.channels_per_thread,
-                                self.width,
-                            )
-                    else:
-                        products = cute.make_rmem_tensor(
-                            (self.channels_per_thread, self.width), Float32
-                        )
-                        products.fill(Float32(0.0))
-                        for tap in cutlass.range_constexpr(self.width):
-                            input_time = output_time + tap - (self.width - 1)
-                            if (
-                                cutlass.const_expr(cu_seqlens is None)
-                                or input_time >= output_sequence_start
-                            ):
-                                products[(None, tap)].store(
-                                    inputs[(None, output_offset + tap)].load().to(Float32)
-                                    * weights[(None, tap)].load()
-                                )
-                        value = products.load().reduce(
-                            cute.ReductionOp.ADD,
-                            Float32(0.0),
-                            reduction_profile=(None, 1),
-                        )
-                    derivative = self.d_activation(value)
-                    incoming = (
-                        dy_groups[((0, None), (batch * self.tokens + output_time, channel_group))]
-                        .load()
-                        .to(Float32)
-                    )
-                    grad_z[(None, output_offset)].store(incoming * derivative)
-
-            input_sequence, input_sequence_start, input_sequence_end = tile_sequence_bounds(
-                cu_seqlens,
-                Int32(time_start),
-                Int32(batch),
-                self.tokens,
-            )
-            for time_offset in cutlass.range_constexpr(self.times_per_block):
-                time = time_start + time_offset
-                if time < self.tokens:
-                    if cutlass.const_expr(cu_seqlens is not None):
-                        (
-                            input_sequence,
-                            input_sequence_start,
-                            input_sequence_end,
-                        ) = advance_sequence_bounds(
+                    elif worker < active_time_blocks:
+                        self.run_tile(
+                            x,
+                            weight,
+                            grad_output,
+                            grad_x,
                             cu_seqlens,
-                            input_sequence,
-                            input_sequence_start,
-                            input_sequence_end,
-                            Int32(time),
+                            initial_state,
+                            Int32(channel_group),
+                            Int32(channel),
+                            Int32(worker),
+                            Int32(batch),
+                            active_endpoint,
                         )
-                    products = cute.make_rmem_tensor(
-                        (self.channels_per_thread, self.width), Float32
-                    )
-                    products.fill(Float32(0.0))
-                    for future_offset in cutlass.range_constexpr(self.width):
-                        if cutlass.const_expr(cu_seqlens is None):
-                            products[(None, future_offset)].store(
-                                grad_z[(None, time_offset + future_offset)].load()
-                                * weights[(None, self.width - 1 - future_offset)].load()
-                            )
-                        else:
-                            if time + future_offset < input_sequence_end:
-                                products[(None, future_offset)].store(
-                                    grad_z[(None, time_offset + future_offset)].load()
-                                    * weights[(None, self.width - 1 - future_offset)].load()
-                                )
-                    value = products.load().reduce(
-                        cute.ReductionOp.ADD,
-                        Float32(0.0),
-                        reduction_profile=(None, 1),
-                    )
-                    dx_groups[((0, None), (batch * self.tokens + time, channel_group))].store(
-                        value.to(self.dtype.cute_type)
-                    )
+                else:
+                    for time_block in cutlass.range(
+                        worker, active_time_blocks, self.persistent_time_workers
+                    ):
+                        self.run_tile(
+                            x,
+                            weight,
+                            grad_output,
+                            grad_x,
+                            cu_seqlens,
+                            initial_state,
+                            Int32(channel_group),
+                            Int32(channel),
+                            Int32(time_block),
+                            Int32(batch),
+                            active_endpoint,
+                        )
+            else:
+                self.run_tile(
+                    x,
+                    weight,
+                    grad_output,
+                    grad_x,
+                    cu_seqlens,
+                    initial_state,
+                    Int32(channel_group),
+                    Int32(channel),
+                    Int32(worker),
+                    Int32(batch),
+                    Int32(self.tokens),
+                )
 
     @cute.jit
     def __call__(
@@ -745,7 +951,11 @@ class CausalConv1dSiluInputGradient(ShortConvKernel):
         ).launch(
             grid=(
                 cute.ceil_div(self.channels, self.threads * self.channels_per_thread),
-                cute.ceil_div(self.tokens, self.times_per_block),
+                (
+                    self.persistent_time_workers
+                    if cutlass.const_expr(self.persistent_time_workers > 0)
+                    else cute.ceil_div(self.tokens, self.times_per_block)
+                ),
                 self.batches,
             ),
             block=(self.threads, 1, 1),
@@ -2127,11 +2337,19 @@ def _compile_forward(
     num_sequences: int | None,
     has_initial_state: bool,
     activation: Activation,
+    persistent_time_workers: int = 0,
 ):
-    """Compile one static forward specialization."""
+    """Compile one static or packed-persistent forward specialization."""
     activation_fn = activation.forward
     operation = CausalConv1dSiluForward(
-        batches, tokens, channels, width, config, dtype, activation_fn
+        batches,
+        tokens,
+        channels,
+        width,
+        config,
+        dtype,
+        activation_fn,
+        persistent_time_workers,
     )
     return compile_tvm_ffi(
         operation,
@@ -2182,6 +2400,25 @@ def supports_tma(
     )
 
 
+def _input_gradient_uses_tma(
+    dtype: ShortConvDType,
+    config: ShortConvConfig,
+    num_sequences: int | None,
+    channels: int,
+    width: int,
+) -> bool:
+    """Select the unchanged staged input-gradient path when its schedule supports it."""
+    return supports_tma(
+        CausalConv1dSiluInputGradientTma,
+        config,
+        None
+        if dtype.name == "fp32" and num_sequences is None
+        else tuned_config(dtype, packed=num_sequences is not None).input_gradient,
+        channels,
+        width,
+    )
+
+
 @jit_cache
 def _compile_input_gradient(
     batches: int,
@@ -2193,20 +2430,27 @@ def _compile_input_gradient(
     num_sequences: int | None,
     has_initial_state: bool,
     activation: Activation,
+    persistent_time_workers: int = 0,
 ):
-    """Compile one static input-gradient specialization."""
+    """Compile one static, TMA, or packed-persistent input-gradient specialization."""
     derivative = activation.derivative
-    use_tma = supports_tma(
-        CausalConv1dSiluInputGradientTma,
-        config,
-        None
-        if dtype.name == "fp32" and num_sequences is None
-        else tuned_config(dtype, packed=num_sequences is not None).input_gradient,
-        channels,
-        width,
-    )
-    operation_type = CausalConv1dSiluInputGradientTma if use_tma else CausalConv1dSiluInputGradient
-    operation = operation_type(batches, tokens, channels, width, config, dtype, derivative)
+    use_tma = _input_gradient_uses_tma(dtype, config, num_sequences, channels, width)
+    if use_tma:
+        assert persistent_time_workers == 0
+        operation = CausalConv1dSiluInputGradientTma(
+            batches, tokens, channels, width, config, dtype, derivative
+        )
+    else:
+        operation = CausalConv1dSiluInputGradient(
+            batches,
+            tokens,
+            channels,
+            width,
+            config,
+            dtype,
+            derivative,
+            persistent_time_workers,
+        )
     return compile_tvm_ffi(
         operation,
         _fake_matrix(dtype, batches * tokens, channels),
@@ -2414,6 +2658,7 @@ def _launch_forward(
     width = weight.shape[1]
     dtype = SHORT_CONV_DTYPES[x.dtype]
     output = torch.empty_like(x)
+    num_sequences = None if cu_seqlens is None else cu_seqlens.shape[0] - 1
     compiled = _compile_forward(
         batches,
         tokens,
@@ -2421,9 +2666,14 @@ def _launch_forward(
         width,
         dtype,
         config,
-        None if cu_seqlens is None else cu_seqlens.shape[0] - 1,
+        num_sequences,
         initial_state is not None,
         resolved_activation,
+        (
+            0
+            if num_sequences is None
+            else _persistent_time_workers(tokens, channels, config, x.device)
+        ),
     )
     compiled(
         x.view(batches * tokens, channels),
@@ -2458,6 +2708,13 @@ def _launch_backward(
     num_sequences = None if cu_seqlens is None else cu_seqlens.shape[0] - 1
     grad_output = _aligned(grad_output.contiguous())
     grad_x = torch.empty_like(x)
+    input_persistent_time_workers = 0
+    if num_sequences is not None and not _input_gradient_uses_tma(
+        dtype, input_config, num_sequences, channels, width
+    ):
+        input_persistent_time_workers = _persistent_time_workers(
+            tokens, channels, input_config, x.device
+        )
     _compile_input_gradient(
         batches,
         tokens,
@@ -2468,6 +2725,7 @@ def _launch_backward(
         num_sequences,
         initial_state is not None,
         resolved_activation,
+        input_persistent_time_workers,
     )(
         x.view(batches * tokens, channels),
         weight,
@@ -2661,6 +2919,11 @@ def tune_causal_conv1d(
             num_sequences,
             kernel_initial_state is not None,
             resolved_activation,
+            (
+                0
+                if num_sequences is None
+                else _persistent_time_workers(tokens, channels, config, x.device)
+            ),
         ),
         parallel_compile=parallel_compile,
     )
@@ -2689,6 +2952,12 @@ def tune_causal_conv1d(
             num_sequences,
             kernel_initial_state is not None,
             resolved_activation,
+            (
+                0
+                if num_sequences is None
+                or _input_gradient_uses_tma(dtype, config, num_sequences, channels, width)
+                else _persistent_time_workers(tokens, channels, config, x.device)
+            ),
         ),
         parallel_compile=parallel_compile,
     )

--- a/test/test_kda_short_conv_cute.py
+++ b/test/test_kda_short_conv_cute.py
@@ -179,8 +179,8 @@ def test_short_conv_dtype_defaults_follow_measured_storage_traffic():
         )
 
 
-def test_short_conv_time_schedule_bounds_the_complete_2d_grid(monkeypatch):
-    """Resolve static capacity grids or persistent grids across channel blocks."""
+def test_short_conv_persistent_workers_bound_the_complete_2d_grid(monkeypatch):
+    """Return zero for static execution or a bounded persistent time grid."""
     monkeypatch.setattr(
         cute_backend,
         "get_device_properties",
@@ -189,21 +189,21 @@ def test_short_conv_time_schedule_bounds_the_complete_2d_grid(monkeypatch):
     config = ShortConvConfig(128, 4, 16)
     device = torch.device("cuda", 0)
 
-    static = cute_backend._resolve_time_schedule(
-        4096, 384, config, device, persistent_eligible=True
+    assert (
+        cute_backend._persistent_time_workers(4096, 384, config, device, persistent_eligible=True)
+        == 0
     )
-    assert static == cute_backend.ResolvedSchedule(
-        cute_backend.ScheduleKind.STATIC,
-        workers=0,
-        capacity_tasks=256,
+    assert (
+        cute_backend._persistent_time_workers(
+            4096, 12_288, config, device, persistent_eligible=True
+        )
+        == 50
     )
-    persistent = cute_backend._resolve_time_schedule(
-        4096, 12_288, config, device, persistent_eligible=True
-    )
-    assert persistent == cute_backend.ResolvedSchedule(
-        cute_backend.ScheduleKind.PERSISTENT,
-        workers=50,
-        capacity_tasks=256,
+    assert (
+        cute_backend._persistent_time_workers(
+            4096, 12_288, config, device, persistent_eligible=False
+        )
+        == 0
     )
 
 
@@ -1121,17 +1121,15 @@ def test_short_conv_cuda_graph_replay():
 
 
 def test_short_conv_packed_persistent_cuda_graph_skips_nan_capacity_and_strides_workers():
-    """Replay non-TMA forward/dx workers across several active packed time tiles."""
-    forward_config = ShortConvConfig(128, 4, 8)
-    input_config = ShortConvConfig(128, 4, 8)
-    weight_config = ShortConvConfig(128, 4, 8)
+    """Replay non-TMA forward and backward workers across several active tiles."""
+    config = ShortConvConfig(128, 4, 8)
     device = torch.device("cuda", torch.cuda.current_device())
     workers = (
         cute_backend.get_device_properties(device).multi_processor_count
         * cute_backend._SHORT_CONV_CTAS_PER_SM
     )
-    tokens = (workers + 3) * forward_config.times_per_block
-    active_tokens = (workers + 1) * forward_config.times_per_block - 3
+    tokens = (workers + 3) * config.times_per_block
+    active_tokens = (workers + 1) * config.times_per_block - 3
     x, weight = _inputs(tokens=tokens, channels=4, width=4)
     grad_output = torch.randn_like(x)
     cu_seqlens = torch.tensor(
@@ -1139,50 +1137,37 @@ def test_short_conv_packed_persistent_cuda_graph_skips_nan_capacity_and_strides_
         device="cuda",
         dtype=torch.int32,
     )
-    forward_args = (
-        forward_config.threads,
-        forward_config.channels_per_thread,
-        forward_config.times_per_block,
-        input_config.threads,
-        input_config.channels_per_thread,
-        input_config.times_per_block,
-        weight_config.threads,
-        weight_config.channels_per_thread,
-        weight_config.times_per_block,
-    )
-    backward_args = forward_args[3:]
+    config_args = (config.threads, config.channels_per_thread, config.times_per_block)
+    forward_args = config_args * 3
+    backward_args = config_args * 2
 
-    forward_schedule = cute_backend._resolve_time_schedule(
-        tokens,
-        x.shape[2],
-        forward_config,
-        x.device,
-        persistent_eligible=True,
+    assert (
+        cute_backend._persistent_time_workers(
+            tokens,
+            x.shape[2],
+            config,
+            x.device,
+            persistent_eligible=True,
+        )
+        == workers
     )
-    assert forward_schedule.kind is cute_backend.ScheduleKind.PERSISTENT
-    assert forward_schedule.workers == workers
+    descriptor = cute_backend.SHORT_CONV_DTYPES[x.dtype]
+    num_sequences = cu_seqlens.shape[0] - 1
     assert not cute_backend._input_gradient_uses_tma(
-        cute_backend.SHORT_CONV_DTYPES[x.dtype],
-        input_config,
-        cu_seqlens.shape[0] - 1,
+        descriptor,
+        config,
+        num_sequences,
         x.shape[2],
         weight.shape[1],
     )
-    assert (
-        active_tokens + forward_config.times_per_block - 1
-    ) // forward_config.times_per_block > workers
-    weight_schedule = cute_backend._resolve_time_schedule(
-        tokens,
+    assert not cute_backend._weight_gradient_uses_tma(
+        descriptor,
+        config,
+        num_sequences,
         x.shape[2],
-        weight_config,
-        x.device,
-        persistent_eligible=True,
+        weight.shape[1],
     )
-    assert weight_schedule.kind is cute_backend.ScheduleKind.PERSISTENT
-    weight_workers = weight_schedule.workers
-    assert (
-        active_tokens + weight_config.times_per_block - 1
-    ) // weight_config.times_per_block > weight_workers
+    assert (active_tokens + config.times_per_block - 1) // config.times_per_block > workers
     _configured_forward_op(x, weight, cu_seqlens, None, *forward_args, activation="silu")
     _configured_backward_op(
         x, weight, grad_output, cu_seqlens, None, *backward_args, activation="silu"

--- a/test/test_kda_short_conv_cute.py
+++ b/test/test_kda_short_conv_cute.py
@@ -179,8 +179,8 @@ def test_short_conv_dtype_defaults_follow_measured_storage_traffic():
         )
 
 
-def test_short_conv_persistent_time_workers_bound_the_complete_2d_grid(monkeypatch):
-    """Divide the machine worker budget across independent channel blocks."""
+def test_short_conv_time_schedule_bounds_the_complete_2d_grid(monkeypatch):
+    """Resolve static capacity grids or persistent grids across channel blocks."""
     monkeypatch.setattr(
         cute_backend,
         "get_device_properties",
@@ -189,8 +189,22 @@ def test_short_conv_persistent_time_workers_bound_the_complete_2d_grid(monkeypat
     config = ShortConvConfig(128, 4, 16)
     device = torch.device("cuda", 0)
 
-    assert cute_backend._persistent_time_workers(4096, 384, config, device) == 256
-    assert cute_backend._persistent_time_workers(4096, 12_288, config, device) == 50
+    static = cute_backend._resolve_time_schedule(
+        4096, 384, config, device, persistent_eligible=True
+    )
+    assert static == cute_backend.ResolvedSchedule(
+        cute_backend.ScheduleKind.STATIC,
+        workers=0,
+        capacity_tasks=256,
+    )
+    persistent = cute_backend._resolve_time_schedule(
+        4096, 12_288, config, device, persistent_eligible=True
+    )
+    assert persistent == cute_backend.ResolvedSchedule(
+        cute_backend.ScheduleKind.PERSISTENT,
+        workers=50,
+        capacity_tasks=256,
+    )
 
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
@@ -1110,11 +1124,11 @@ def test_short_conv_packed_persistent_cuda_graph_skips_nan_capacity_and_strides_
     """Replay non-TMA forward/dx workers across several active packed time tiles."""
     forward_config = ShortConvConfig(128, 4, 8)
     input_config = ShortConvConfig(128, 4, 8)
-    weight_config = ShortConvConfig(128, 4, 128)
+    weight_config = ShortConvConfig(128, 4, 8)
     device = torch.device("cuda", torch.cuda.current_device())
     workers = (
         cute_backend.get_device_properties(device).multi_processor_count
-        * cute_backend._PERSISTENT_TIME_CTAS_PER_SM
+        * cute_backend._SHORT_CONV_CTAS_PER_SM
     )
     tokens = (workers + 3) * forward_config.times_per_block
     active_tokens = (workers + 1) * forward_config.times_per_block - 3
@@ -1138,10 +1152,15 @@ def test_short_conv_packed_persistent_cuda_graph_skips_nan_capacity_and_strides_
     )
     backward_args = forward_args[3:]
 
-    assert (
-        cute_backend._persistent_time_workers(tokens, x.shape[2], forward_config, x.device)
-        == workers
+    forward_schedule = cute_backend._resolve_time_schedule(
+        tokens,
+        x.shape[2],
+        forward_config,
+        x.device,
+        persistent_eligible=True,
     )
+    assert forward_schedule.kind is cute_backend.ScheduleKind.PERSISTENT
+    assert forward_schedule.workers == workers
     assert not cute_backend._input_gradient_uses_tma(
         cute_backend.SHORT_CONV_DTYPES[x.dtype],
         input_config,
@@ -1152,6 +1171,18 @@ def test_short_conv_packed_persistent_cuda_graph_skips_nan_capacity_and_strides_
     assert (
         active_tokens + forward_config.times_per_block - 1
     ) // forward_config.times_per_block > workers
+    weight_schedule = cute_backend._resolve_time_schedule(
+        tokens,
+        x.shape[2],
+        weight_config,
+        x.device,
+        persistent_eligible=True,
+    )
+    assert weight_schedule.kind is cute_backend.ScheduleKind.PERSISTENT
+    weight_workers = weight_schedule.workers
+    assert (
+        active_tokens + weight_config.times_per_block - 1
+    ) // weight_config.times_per_block > weight_workers
     _configured_forward_op(x, weight, cu_seqlens, None, *forward_args, activation="silu")
     _configured_backward_op(
         x, weight, grad_output, cu_seqlens, None, *backward_args, activation="silu"
@@ -1163,7 +1194,7 @@ def test_short_conv_packed_persistent_cuda_graph_skips_nan_capacity_and_strides_
         captured_output = _configured_forward_op(
             x, weight, cu_seqlens, None, *forward_args, activation="silu"
         )
-        captured_dx, _ = _configured_backward_op(
+        captured_dx, captured_dw = _configured_backward_op(
             x, weight, grad_output, cu_seqlens, None, *backward_args, activation="silu"
         )
 
@@ -1182,15 +1213,16 @@ def test_short_conv_packed_persistent_cuda_graph_skips_nan_capacity_and_strides_
     reference_x = x[:, :active_tokens].detach().clone().requires_grad_()
     reference_weight = weight.detach().clone().requires_grad_()
     expected_output = _packed_reference(reference_x, reference_weight, replay_seqlens)
-    (expected_dx,) = torch.autograd.grad(
+    expected_dx, expected_dw = torch.autograd.grad(
         expected_output,
-        (reference_x,),
+        (reference_x, reference_weight),
         grad_output[:, :active_tokens],
     )
     torch.testing.assert_close(
         captured_output[:, :active_tokens], expected_output, rtol=2e-2, atol=2e-2
     )
     torch.testing.assert_close(captured_dx[:, :active_tokens], expected_dx, rtol=3e-2, atol=3e-2)
+    torch.testing.assert_close(captured_dw, expected_dw, rtol=3e-2, atol=2e-1)
 
 
 def test_short_conv_packed_stateful_cuda_graph_replays_boundaries_and_history():

--- a/test/test_kda_short_conv_cute.py
+++ b/test/test_kda_short_conv_cute.py
@@ -2,7 +2,7 @@
 
 import sys
 from itertools import pairwise
-from types import FunctionType, SimpleNamespace
+from types import FunctionType
 
 import pytest
 import torch
@@ -177,34 +177,6 @@ def test_short_conv_dtype_defaults_follow_measured_storage_traffic():
         assert defaults.weight_gradient in _candidate_configs(
             "weight_gradient", 512, dtype, packed=True
         )
-
-
-def test_short_conv_persistent_workers_bound_the_complete_2d_grid(monkeypatch):
-    """Return zero for static execution or a bounded persistent time grid."""
-    monkeypatch.setattr(
-        cute_backend,
-        "get_device_properties",
-        lambda _device: SimpleNamespace(multi_processor_count=148),
-    )
-    config = ShortConvConfig(128, 4, 16)
-    device = torch.device("cuda", 0)
-
-    assert (
-        cute_backend._persistent_time_workers(4096, 384, config, device, persistent_eligible=True)
-        == 0
-    )
-    assert (
-        cute_backend._persistent_time_workers(
-            4096, 12_288, config, device, persistent_eligible=True
-        )
-        == 50
-    )
-    assert (
-        cute_backend._persistent_time_workers(
-            4096, 12_288, config, device, persistent_eligible=False
-        )
-        == 0
-    )
 
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
@@ -548,6 +520,27 @@ def test_short_conv_packed_stateful_tma_backward_matches_reference_and_fallback(
         atol = 2e-1 if index == 1 else 3e-2
         torch.testing.assert_close(actual_gradient, expected_gradient, rtol=3e-2, atol=atol)
         torch.testing.assert_close(actual_gradient, fallback_gradient, rtol=3e-2, atol=atol)
+
+
+def test_short_conv_packed_forward_active_endpoint_is_bitwise_exact():
+    """Skip inactive capacity without changing any active forward value."""
+    tokens, active_tokens = 257, 63
+    x, weight = _inputs(tokens=tokens, channels=512, width=4)
+    cu_seqlens = torch.tensor(
+        [0, 7, active_tokens, active_tokens],
+        device="cuda",
+        dtype=torch.int32,
+    )
+    expected = causal_conv1d(
+        x[:, :active_tokens].detach().clone(),
+        weight,
+        activation="silu",
+        cu_seqlens=cu_seqlens,
+    )
+    with torch.no_grad():
+        x[:, active_tokens:].fill_(float("nan"))
+    actual = causal_conv1d(x, weight, activation="silu", cu_seqlens=cu_seqlens)
+    torch.testing.assert_close(actual[:, :active_tokens], expected, rtol=0, atol=0)
 
 
 @pytest.mark.parametrize(
@@ -1118,96 +1111,6 @@ def test_short_conv_cuda_graph_replay():
     torch.testing.assert_close(captured_output, expected_output, rtol=0, atol=0)
     torch.testing.assert_close(captured_gradients[0], expected_gradients[0], rtol=0, atol=0)
     torch.testing.assert_close(captured_gradients[1], expected_gradients[1], rtol=0, atol=0)
-
-
-def test_short_conv_packed_persistent_cuda_graph_skips_nan_capacity_and_strides_workers():
-    """Replay non-TMA forward and backward workers across several active tiles."""
-    config = ShortConvConfig(128, 4, 8)
-    device = torch.device("cuda", torch.cuda.current_device())
-    workers = (
-        cute_backend.get_device_properties(device).multi_processor_count
-        * cute_backend._SHORT_CONV_CTAS_PER_SM
-    )
-    tokens = (workers + 3) * config.times_per_block
-    active_tokens = (workers + 1) * config.times_per_block - 3
-    x, weight = _inputs(tokens=tokens, channels=4, width=4)
-    grad_output = torch.randn_like(x)
-    cu_seqlens = torch.tensor(
-        [0, 0, tokens // 3, tokens // 2, tokens, tokens],
-        device="cuda",
-        dtype=torch.int32,
-    )
-    config_args = (config.threads, config.channels_per_thread, config.times_per_block)
-    forward_args = config_args * 3
-    backward_args = config_args * 2
-
-    assert (
-        cute_backend._persistent_time_workers(
-            tokens,
-            x.shape[2],
-            config,
-            x.device,
-            persistent_eligible=True,
-        )
-        == workers
-    )
-    descriptor = cute_backend.SHORT_CONV_DTYPES[x.dtype]
-    num_sequences = cu_seqlens.shape[0] - 1
-    assert not cute_backend._input_gradient_uses_tma(
-        descriptor,
-        config,
-        num_sequences,
-        x.shape[2],
-        weight.shape[1],
-    )
-    assert not cute_backend._weight_gradient_uses_tma(
-        descriptor,
-        config,
-        num_sequences,
-        x.shape[2],
-        weight.shape[1],
-    )
-    assert (active_tokens + config.times_per_block - 1) // config.times_per_block > workers
-    _configured_forward_op(x, weight, cu_seqlens, None, *forward_args, activation="silu")
-    _configured_backward_op(
-        x, weight, grad_output, cu_seqlens, None, *backward_args, activation="silu"
-    )
-    torch.cuda.synchronize()
-
-    graph = torch.cuda.CUDAGraph()
-    with torch.cuda.graph(graph):
-        captured_output = _configured_forward_op(
-            x, weight, cu_seqlens, None, *forward_args, activation="silu"
-        )
-        captured_dx, captured_dw = _configured_backward_op(
-            x, weight, grad_output, cu_seqlens, None, *backward_args, activation="silu"
-        )
-
-    replay_seqlens = torch.tensor(
-        [0, 0, 7, active_tokens // 2, active_tokens, active_tokens],
-        device="cuda",
-        dtype=torch.int32,
-    )
-    with torch.no_grad():
-        cu_seqlens.copy_(replay_seqlens)
-        x[:, active_tokens:].fill_(float("nan"))
-        grad_output[:, active_tokens:].fill_(float("nan"))
-    graph.replay()
-    torch.cuda.synchronize()
-
-    reference_x = x[:, :active_tokens].detach().clone().requires_grad_()
-    reference_weight = weight.detach().clone().requires_grad_()
-    expected_output = _packed_reference(reference_x, reference_weight, replay_seqlens)
-    expected_dx, expected_dw = torch.autograd.grad(
-        expected_output,
-        (reference_x, reference_weight),
-        grad_output[:, :active_tokens],
-    )
-    torch.testing.assert_close(
-        captured_output[:, :active_tokens], expected_output, rtol=2e-2, atol=2e-2
-    )
-    torch.testing.assert_close(captured_dx[:, :active_tokens], expected_dx, rtol=3e-2, atol=3e-2)
-    torch.testing.assert_close(captured_dw, expected_dw, rtol=3e-2, atol=2e-1)
 
 
 def test_short_conv_packed_stateful_cuda_graph_replays_boundaries_and_history():

--- a/test/test_kda_short_conv_cute.py
+++ b/test/test_kda_short_conv_cute.py
@@ -2,7 +2,7 @@
 
 import sys
 from itertools import pairwise
-from types import FunctionType
+from types import FunctionType, SimpleNamespace
 
 import pytest
 import torch
@@ -177,6 +177,20 @@ def test_short_conv_dtype_defaults_follow_measured_storage_traffic():
         assert defaults.weight_gradient in _candidate_configs(
             "weight_gradient", 512, dtype, packed=True
         )
+
+
+def test_short_conv_persistent_time_workers_bound_the_complete_2d_grid(monkeypatch):
+    """Divide the machine worker budget across independent channel blocks."""
+    monkeypatch.setattr(
+        cute_backend,
+        "get_device_properties",
+        lambda _device: SimpleNamespace(multi_processor_count=148),
+    )
+    config = ShortConvConfig(128, 4, 16)
+    device = torch.device("cuda", 0)
+
+    assert cute_backend._persistent_time_workers(4096, 384, config, device) == 256
+    assert cute_backend._persistent_time_workers(4096, 12_288, config, device) == 50
 
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
@@ -1090,6 +1104,93 @@ def test_short_conv_cuda_graph_replay():
     torch.testing.assert_close(captured_output, expected_output, rtol=0, atol=0)
     torch.testing.assert_close(captured_gradients[0], expected_gradients[0], rtol=0, atol=0)
     torch.testing.assert_close(captured_gradients[1], expected_gradients[1], rtol=0, atol=0)
+
+
+def test_short_conv_packed_persistent_cuda_graph_skips_nan_capacity_and_strides_workers():
+    """Replay non-TMA forward/dx workers across several active packed time tiles."""
+    forward_config = ShortConvConfig(128, 4, 8)
+    input_config = ShortConvConfig(128, 4, 8)
+    weight_config = ShortConvConfig(128, 4, 128)
+    device = torch.device("cuda", torch.cuda.current_device())
+    workers = (
+        cute_backend.get_device_properties(device).multi_processor_count
+        * cute_backend._PERSISTENT_TIME_CTAS_PER_SM
+    )
+    tokens = (workers + 3) * forward_config.times_per_block
+    active_tokens = (workers + 1) * forward_config.times_per_block - 3
+    x, weight = _inputs(tokens=tokens, channels=4, width=4)
+    grad_output = torch.randn_like(x)
+    cu_seqlens = torch.tensor(
+        [0, 0, tokens // 3, tokens // 2, tokens, tokens],
+        device="cuda",
+        dtype=torch.int32,
+    )
+    forward_args = (
+        forward_config.threads,
+        forward_config.channels_per_thread,
+        forward_config.times_per_block,
+        input_config.threads,
+        input_config.channels_per_thread,
+        input_config.times_per_block,
+        weight_config.threads,
+        weight_config.channels_per_thread,
+        weight_config.times_per_block,
+    )
+    backward_args = forward_args[3:]
+
+    assert (
+        cute_backend._persistent_time_workers(tokens, x.shape[2], forward_config, x.device)
+        == workers
+    )
+    assert not cute_backend._input_gradient_uses_tma(
+        cute_backend.SHORT_CONV_DTYPES[x.dtype],
+        input_config,
+        cu_seqlens.shape[0] - 1,
+        x.shape[2],
+        weight.shape[1],
+    )
+    assert (
+        active_tokens + forward_config.times_per_block - 1
+    ) // forward_config.times_per_block > workers
+    _configured_forward_op(x, weight, cu_seqlens, None, *forward_args, activation="silu")
+    _configured_backward_op(
+        x, weight, grad_output, cu_seqlens, None, *backward_args, activation="silu"
+    )
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_output = _configured_forward_op(
+            x, weight, cu_seqlens, None, *forward_args, activation="silu"
+        )
+        captured_dx, _ = _configured_backward_op(
+            x, weight, grad_output, cu_seqlens, None, *backward_args, activation="silu"
+        )
+
+    replay_seqlens = torch.tensor(
+        [0, 0, 7, active_tokens // 2, active_tokens, active_tokens],
+        device="cuda",
+        dtype=torch.int32,
+    )
+    with torch.no_grad():
+        cu_seqlens.copy_(replay_seqlens)
+        x[:, active_tokens:].fill_(float("nan"))
+        grad_output[:, active_tokens:].fill_(float("nan"))
+    graph.replay()
+    torch.cuda.synchronize()
+
+    reference_x = x[:, :active_tokens].detach().clone().requires_grad_()
+    reference_weight = weight.detach().clone().requires_grad_()
+    expected_output = _packed_reference(reference_x, reference_weight, replay_seqlens)
+    (expected_dx,) = torch.autograd.grad(
+        expected_output,
+        (reference_x,),
+        grad_output[:, :active_tokens],
+    )
+    torch.testing.assert_close(
+        captured_output[:, :active_tokens], expected_output, rtol=2e-2, atol=2e-2
+    )
+    torch.testing.assert_close(captured_dx[:, :active_tokens], expected_dx, rtol=3e-2, atol=3e-2)
 
 
 def test_short_conv_packed_stateful_cuda_graph_replays_boundaries_and_history():


### PR DESCRIPTION
## Human Note

## Agent note

Packed CUDA Graph replay fixes the physical short-convolution input at `T_max`, while the runtime
active endpoint in `cu_seqlens[-1]` may be much smaller. The existing non-TMA kernels launched and
processed the capacity time grid, so sparse replays paid for inactive forward, input-gradient, and
weight-gradient tiles.

Add the repository's static/persistent launch pattern to packed short convolution. Static capacity
grids read the device endpoint and skip inactive CTAs; larger grids use a measured machine-bounded
worker count and stride over active time tiles. Weight-gradient workers accumulate their assigned
tiles into FP32 worker partials before the existing Torch reduction. Dense and staged TMA paths are
unchanged. Short convolution derives its active tile count directly from `cu_seqlens[-1]`, so it
does not need KDA chunk-prefix metadata.

The commits are ordered as forward/input-gradient scheduling, weight-gradient scheduling, then a
behavior-preserving simplification pass. Persistent weight accumulation changes the FP32 reduction
grouping, so the CUDA Graph regression compares `dw` with an exactly sized reference while also
poisoning inactive capacity with NaNs.

## Performance

B200, BF16, `C=384`, width 4, fixed-pointer CUDA Graph replay. The replicated forward/input-gradient
stage produced these total replay speedups at `L = T_max / 16`:

| `T_max` | before | forward + `dx` persistent | result |
|---:|---:|---:|---:|
| 4,096 | 56.70 us | 44.08 us | 1.29x |
| 8,192 | 87.44 us | 50.55 us | 1.73x |
| 16,384 | 167.57 us | 67.18 us | 2.49x |

The weight-gradient follow-up reduced the 16K sparse replay further to 51.39 us in the discovery
sweep. A matched full-capacity A/B for that follow-up was neutral at 4K (+0.1%), +2.7% at 8K, and
+0.9% at 16K. The final simplification preserved the 16K sparse and full timings within noise.

## Test Plan

```bash
gpu-run auto -- env PYTHONPATH=$PWD .venv/bin/pytest -n 6 -q test/test_kda_short_conv_cute.py
gpu-run auto -- env PYTHONPATH=$PWD .venv/bin/pytest -q test/test_kda_training_example.py
prek --files attn_gym/linear/kda/short_conv/cute.py test/test_kda_short_conv_cute.py
gpu-run auto -- env PYTHONPATH=$PWD .venv/bin/python agent_space/short_conv_persistent/short_conv_cuda_graph_scaling_split.py --label final --output-dir agent_space/short_conv_persistent/final --capacity 16384 --sequences 128 --samples 30 --replays-per-sample 3 --warmup-replays 15
```
