### PR TITLE
Skip inactive rows in packed KDA L2Norm

### DIFF
--- a/attn_gym/linear/kda/bwd/triton/l2norm_bwd.py
+++ b/attn_gym/linear/kda/bwd/triton/l2norm_bwd.py
@@ -40,6 +40,7 @@ def l2norm_bwd_kernel(
     dy,
     dx,
     N_ROWS,
+    cu_seqlens,
     Y_STRIDES: tl.constexpr,
     RSTD_STRIDES: tl.constexpr,
     DY_STRIDES: tl.constexpr,
@@ -49,10 +50,17 @@ def l2norm_bwd_kernel(
     D: tl.constexpr,
     BD: tl.constexpr,
     NB: tl.constexpr,
+    NUM_SEQUENCES: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
     BT: tl.constexpr,
 ):
     # One program per [BT] block of rows; each row is normalized over [BD].
     i_row = tl.program_id(0).to(tl.int64)
+    if IS_VARLEN:
+        active_rows = tl.load(cu_seqlens + NUM_SEQUENCES).to(tl.int64) * HEADS
+        if i_row * BT >= active_rows:
+            return
+        N_ROWS = active_rows
     o_row = i_row * BT + tl.arange(0, BT)
     o_bt = o_row // HEADS
     o_d = tl.arange(0, BD).to(tl.int64)

--- a/attn_gym/linear/kda/fwd/triton/l2norm_fwd.py
+++ b/attn_gym/linear/kda/fwd/triton/l2norm_fwd.py
@@ -25,6 +25,7 @@ def l2norm_fwd_kernel(
     rstd,
     eps,
     N_ROWS,
+    cu_seqlens,
     X_STRIDES: tl.constexpr,
     Y_STRIDES: tl.constexpr,
     RSTD_STRIDES: tl.constexpr,
@@ -33,9 +34,16 @@ def l2norm_fwd_kernel(
     D: tl.constexpr,
     BD: tl.constexpr,
     NB,
+    NUM_SEQUENCES: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
     BT: tl.constexpr,
 ):
     i_row = tl.program_id(0).to(tl.int64)
+    if IS_VARLEN:
+        active_rows = tl.load(cu_seqlens + NUM_SEQUENCES).to(tl.int64) * H
+        if i_row * BT >= active_rows:
+            return
+        N_ROWS = active_rows
     o_row = i_row * BT + tl.arange(0, BT)
     o_bt = o_row // H
     o_d = tl.arange(0, BD).to(tl.int64)
@@ -73,11 +81,18 @@ def l2norm_fwd_kernel(
     )
 
 
-torch.library.define("attn_gym::kda_l2norm_fwd", "(Tensor x, float eps) -> (Tensor, Tensor)")
+torch.library.define(
+    "attn_gym::kda_l2norm_fwd",
+    "(Tensor x, float eps, Tensor? cu_seqlens=None) -> (Tensor, Tensor)",
+)
 
 
-def _l2norm_fwd_cuda(x: torch.Tensor, eps: float) -> tuple[torch.Tensor, torch.Tensor]:
-    """Launch L2Norm using runtime shape and stride metadata."""
+def _l2norm_fwd_cuda(
+    x: torch.Tensor,
+    eps: float,
+    cu_seqlens: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Launch L2Norm using runtime shape, strides, and optional packed metadata."""
     _, tokens, heads, head_dim = x.shape
     # Compact outputs enumerate rows in the same batch-token-head order reconstructed by
     # the kernel, regardless of the input's physical strides.
@@ -92,6 +107,7 @@ def _l2norm_fwd_cuda(x: torch.Tensor, eps: float) -> tuple[torch.Tensor, torch.T
         rstd,
         eps,
         rows,
+        cu_seqlens,
         X_STRIDES=x.stride(),
         Y_STRIDES=output.stride(),
         RSTD_STRIDES=rstd.stride(),
@@ -100,6 +116,8 @@ def _l2norm_fwd_cuda(x: torch.Tensor, eps: float) -> tuple[torch.Tensor, torch.T
         D=head_dim,
         BD=block_dim,
         NB=triton.cdiv(rows, 16),
+        NUM_SEQUENCES=0 if cu_seqlens is None else cu_seqlens.shape[0] - 1,
+        IS_VARLEN=cu_seqlens is not None,
     )
     return output.view_as(x), rstd
 
@@ -108,9 +126,13 @@ torch.library.impl("attn_gym::kda_l2norm_fwd", "CUDA", _l2norm_fwd_cuda)
 
 
 @torch.library.register_fake("attn_gym::kda_l2norm_fwd")
-def _l2norm_fwd_fake(x: torch.Tensor, eps: float) -> tuple[torch.Tensor, torch.Tensor]:
-    """Describe compact output metadata without launching Triton."""
-    del eps
+def _l2norm_fwd_fake(
+    x: torch.Tensor,
+    eps: float,
+    cu_seqlens: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Describe compact output metadata without reading the packed endpoint."""
+    del eps, cu_seqlens
     rows = x.numel() // x.shape[-1]
     return (
         torch.empty_like(x, memory_format=torch.contiguous_format),
@@ -120,7 +142,7 @@ def _l2norm_fwd_fake(x: torch.Tensor, eps: float) -> tuple[torch.Tensor, torch.T
 
 torch.library.define(
     "attn_gym::kda_l2norm_bwd",
-    "(Tensor output, Tensor rstd, Tensor d_output) -> Tensor",
+    "(Tensor output, Tensor rstd, Tensor d_output, Tensor? cu_seqlens=None) -> Tensor",
 )
 
 
@@ -128,6 +150,7 @@ def _l2norm_bwd_cuda(
     output: torch.Tensor,
     rstd: torch.Tensor,
     d_output: torch.Tensor,
+    cu_seqlens: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Launch L2Norm backward behind the same opaque stride boundary."""
     from attn_gym.linear.kda.bwd.triton.l2norm_bwd import l2norm_bwd_kernel
@@ -143,6 +166,7 @@ def _l2norm_bwd_cuda(
         d_output,
         d_input,
         rows,
+        cu_seqlens,
         Y_STRIDES=output.stride(),
         RSTD_STRIDES=rstd.stride(),
         DY_STRIDES=d_output.stride(),
@@ -152,6 +176,8 @@ def _l2norm_bwd_cuda(
         D=head_dim,
         BD=block_dim,
         NB=triton.cdiv(rows, 16),
+        NUM_SEQUENCES=0 if cu_seqlens is None else cu_seqlens.shape[0] - 1,
+        IS_VARLEN=cu_seqlens is not None,
     )
     return d_input
 
@@ -164,9 +190,10 @@ def _l2norm_bwd_fake(
     output: torch.Tensor,
     rstd: torch.Tensor,
     d_output: torch.Tensor,
+    cu_seqlens: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    """Describe the compact input-gradient metadata."""
-    del rstd, d_output
+    """Describe input-gradient metadata without reading the packed endpoint."""
+    del rstd, d_output, cu_seqlens
     return torch.empty_like(output)
 
 
@@ -176,22 +203,43 @@ _l2norm_bwd_op = torch.ops.attn_gym.kda_l2norm_bwd.default
 
 class _L2Norm(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, x: torch.Tensor, eps: float) -> torch.Tensor:
-        output, rstd = _l2norm_fwd_op(x, eps)
-        ctx.save_for_backward(output.view(-1, x.shape[-1]), rstd)
+    def forward(
+        ctx,
+        x: torch.Tensor,
+        eps: float,
+        cu_seqlens: torch.Tensor | None,
+    ) -> torch.Tensor:
+        output, rstd = _l2norm_fwd_op(x, eps, cu_seqlens)
+        output_2d = output.view(-1, x.shape[-1])
+        if cu_seqlens is None:
+            ctx.save_for_backward(output_2d, rstd)
+        else:
+            ctx.save_for_backward(output_2d, rstd, cu_seqlens)
         ctx.input_shape = x.shape
+        ctx.is_ragged = cu_seqlens is not None
         return output
 
     @staticmethod
     @torch.autograd.function.once_differentiable
     def backward(ctx, d_output: torch.Tensor):
-        output, rstd = ctx.saved_tensors
-        d_input = _l2norm_bwd_op(output, rstd, d_output)
-        return d_input.view(ctx.input_shape), None
+        output, rstd, *metadata = ctx.saved_tensors
+        cu_seqlens = metadata[0] if ctx.is_ragged else None
+        d_input = _l2norm_bwd_op(output, rstd, d_output, cu_seqlens)
+        return d_input.view(ctx.input_shape), None, None
 
 
-def l2norm(x: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
-    """Normalize each final-dimension row of a KDA ``[B, T, H, D]`` tensor."""
+def l2norm(
+    x: torch.Tensor,
+    eps: float = 1e-6,
+    *,
+    cu_seqlens: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Normalize rows, optionally stopping at a packed device endpoint.
+
+    With ``cu_seqlens``, only rows before ``cu_seqlens[-1]`` are defined in the
+    output and input gradient. Packed callers must hide the inactive suffix from
+    later consumers and parameter reductions.
+    """
     if not x.is_cuda:
         raise ValueError("l2norm requires a CUDA tensor")
     if x.dtype not in (torch.float16, torch.bfloat16, torch.float32):
@@ -202,7 +250,16 @@ def l2norm(x: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
         raise ValueError(f"x must have a nonempty final dimension, got {tuple(x.shape)}")
     if x.numel() == 0:
         raise ValueError(f"x must contain at least one row, got {tuple(x.shape)}")
-    return _L2Norm.apply(x, eps)
+    if cu_seqlens is not None:
+        if x.shape[0] != 1:
+            raise ValueError("cu_seqlens require packed x with batch size one")
+        if cu_seqlens.ndim != 1 or cu_seqlens.shape[0] < 2:
+            raise ValueError("cu_seqlens must have shape [num_sequences + 1]")
+        if cu_seqlens.dtype != torch.int32 or not cu_seqlens.is_contiguous():
+            raise ValueError("cu_seqlens must be contiguous int32")
+        if cu_seqlens.device != x.device:
+            raise ValueError("cu_seqlens must be on the same device as x")
+    return _L2Norm.apply(x, eps, cu_seqlens)
 
 
 __all__ = ["l2norm"]

--- a/examples/kda_training.py
+++ b/examples/kda_training.py
@@ -287,7 +287,8 @@ class KDAAttention(nn.Module):
         # Ordinary Q/K normalization reads and saves every physical row.
         qkv = mask_inactive_tokens(qkv, active_mask)
         q, k, v = qkv.view(batch, tokens, 3, self.num_heads, self.head_dim).unbind(2)
-        q, k = self.qk_normalization(q, k)
+        norm_cu_seqlens = cu_seqlens if active_mask is not None else None
+        q, k = self.qk_normalization(q, k, norm_cu_seqlens)
         raw_gate, beta = self.gate_projections(hidden_states_compute)
         # These barriers exclude undefined primitive dInputs from projection dW.
         raw_gate = mask_inactive_token_gradients(raw_gate, active_mask)
@@ -405,12 +406,15 @@ class KDAAttention(nn.Module):
 
     @annotate_kernels("kda/qk_normalization")
     def qk_normalization(
-        self, q: torch.Tensor, k: torch.Tensor
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        cu_seqlens: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         if self.backend == "reference":
             return l2norm_fwd_ref(q.float()), l2norm_fwd_ref(k.float())
 
-        return l2norm(q), l2norm(k)
+        return l2norm(q, cu_seqlens=cu_seqlens), l2norm(k, cu_seqlens=cu_seqlens)
 
     @annotate_kernels("kda/gate_projections")
     def gate_projections(self, hidden_states: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:

--- a/test/test_kda_kernels.py
+++ b/test/test_kda_kernels.py
@@ -215,6 +215,7 @@ def test_l2norm_fwd(dtype, T, D, strided):
         rstd,
         eps,
         T,
+        None,
         X_STRIDES=(0, x.stride(0), 0, x.stride(1)),
         Y_STRIDES=y.stride(),
         RSTD_STRIDES=rstd.stride(),
@@ -223,6 +224,8 @@ def test_l2norm_fwd(dtype, T, D, strided):
         D=D,
         BD=BD,
         NB=triton.cdiv(T, 16),
+        NUM_SEQUENCES=0,
+        IS_VARLEN=False,
     )
     assert_golden(y, golden, ref, dtype, f"l2norm_fwd_kernel T={T} D={D}")
     assert_golden(rstd, rstd_golden, rstd_ref, dtype, f"l2norm_fwd_kernel rstd T={T} D={D}")
@@ -250,7 +253,9 @@ def test_l2norm_autograd_wrapper(dtype):
 
 def test_l2norm_op_registration():
     x = torch.randn(1, 17, 3, 128, device=DEV, dtype=torch.bfloat16)
+    cu_seqlens = torch.tensor([0, 9, 17, 17], device=DEV, dtype=torch.int32)
     torch.library.opcheck(_l2norm_fwd_op, (x, 1e-6))
+    torch.library.opcheck(_l2norm_fwd_op, (x, 1e-6, cu_seqlens))
 
     output, rstd = _l2norm_fwd_op(x, 1e-6)
     d_output = torch.randn_like(output)
@@ -258,6 +263,46 @@ def test_l2norm_op_registration():
         _l2norm_bwd_op,
         (output.view(-1, output.shape[-1]), rstd, d_output),
     )
+    ragged_output, ragged_rstd = _l2norm_fwd_op(x, 1e-6, cu_seqlens)
+    torch.library.opcheck(
+        _l2norm_bwd_op,
+        (
+            ragged_output.view(-1, ragged_output.shape[-1]),
+            ragged_rstd,
+            d_output,
+            cu_seqlens,
+        ),
+    )
+
+
+def test_l2norm_ragged_matches_exact_active_prefix():
+    """Packed normalization ignores NaN-poisoned physical capacity in both passes."""
+    torch.manual_seed(2)
+    tokens, active_tokens, heads, head_dim = 128, 65, 3, 128
+    x = torch.randn(
+        1,
+        tokens,
+        heads,
+        head_dim,
+        device=DEV,
+        dtype=torch.bfloat16,
+        requires_grad=True,
+    )
+    d_output = torch.randn_like(x)
+    cu_seqlens = torch.tensor([0, 33, 65, 65], device=DEV, dtype=torch.int32)
+    with torch.no_grad():
+        x[:, active_tokens:].fill_(float("nan"))
+        d_output[:, active_tokens:].fill_(float("nan"))
+
+    output = l2norm(x, cu_seqlens=cu_seqlens)
+    gradient = torch.autograd.grad(output, x, d_output)[0]
+    exact_x = x[:, :active_tokens].detach().clone().requires_grad_()
+    exact_d_output = d_output[:, :active_tokens].detach().clone()
+    exact_output = l2norm(exact_x)
+    exact_gradient = torch.autograd.grad(exact_output, exact_x, exact_d_output)[0]
+
+    torch.testing.assert_close(output[:, :active_tokens], exact_output, rtol=2e-2, atol=2e-3)
+    torch.testing.assert_close(gradient[:, :active_tokens], exact_gradient, rtol=2e-2, atol=2e-3)
 
 
 @pytest.mark.parametrize(
@@ -295,6 +340,73 @@ def test_l2norm_compile_matches_eager(layout):
     lower = torch.nextafter(expected_gradient, torch.full_like(expected_gradient, -torch.inf))
     upper = torch.nextafter(expected_gradient, torch.full_like(expected_gradient, torch.inf))
     assert ((actual_gradient >= lower) & (actual_gradient <= upper)).all()
+
+
+def test_l2norm_ragged_compile_matches_eager():
+    """Compile the public packed forward and backward without reading its endpoint."""
+    torch.manual_seed(3)
+    tokens, active_tokens = 128, 65
+    x = torch.randn(1, tokens, 2, 128, device=DEV, dtype=torch.bfloat16, requires_grad=True)
+    d_output = torch.randn_like(x)
+    cu_seqlens = torch.tensor([0, 33, 65, 65], device=DEV, dtype=torch.int32)
+    with torch.no_grad():
+        x[:, active_tokens:].fill_(float("nan"))
+        d_output[:, active_tokens:].fill_(float("nan"))
+
+    def operation(x, cu_seqlens):
+        return l2norm(x, cu_seqlens=cu_seqlens)
+
+    expected = operation(x, cu_seqlens)
+    actual = torch.compile(operation, fullgraph=True, dynamic=True)(x, cu_seqlens)
+    expected_gradient = torch.autograd.grad(expected, x, d_output)[0]
+    actual_gradient = torch.autograd.grad(actual, x, d_output)[0]
+
+    torch.testing.assert_close(
+        actual[:, :active_tokens], expected[:, :active_tokens], rtol=0, atol=0
+    )
+    torch.testing.assert_close(
+        actual_gradient[:, :active_tokens],
+        expected_gradient[:, :active_tokens],
+        rtol=0,
+        atol=0,
+    )
+
+
+def test_l2norm_ragged_cuda_graph_replays_smaller_endpoint():
+    """Replay updates the active row bound from static metadata."""
+    torch.manual_seed(4)
+    tokens, active_tokens = 1024, 65
+    x = torch.randn(1, tokens, 3, 128, device=DEV, dtype=torch.bfloat16, requires_grad=True)
+    d_output = torch.randn_like(x)
+    cu_seqlens = torch.tensor([0, 512, 1024], device=DEV, dtype=torch.int32)
+
+    def operation():
+        output = l2norm(x, cu_seqlens=cu_seqlens)
+        return output, torch.autograd.grad(output, x, d_output)[0]
+
+    capture_stream = torch.cuda.Stream()
+    capture_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(capture_stream):
+        operation()
+    capture_stream.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=capture_stream):
+        output, gradient = operation()
+
+    with torch.no_grad():
+        x[:, active_tokens:].fill_(float("nan"))
+        d_output[:, active_tokens:].fill_(float("nan"))
+        cu_seqlens.copy_(torch.tensor([0, 33, 65], device=DEV, dtype=torch.int32))
+    graph.replay()
+    torch.cuda.synchronize()
+
+    exact_x = x[:, :active_tokens].detach().clone().requires_grad_()
+    exact_d_output = d_output[:, :active_tokens].detach().clone()
+    exact_output = l2norm(exact_x)
+    exact_gradient = torch.autograd.grad(exact_output, exact_x, exact_d_output)[0]
+    torch.testing.assert_close(output[:, :active_tokens], exact_output, rtol=2e-2, atol=2e-3)
+    torch.testing.assert_close(gradient[:, :active_tokens], exact_gradient, rtol=2e-2, atol=2e-3)
 
 
 @pytest.mark.parametrize("dtype", [torch.float64, torch.int32], ids=["fp64", "int32"])
@@ -347,6 +459,7 @@ def test_l2norm_bwd(dtype, T, D, strided):
         dy,
         dx,
         T,
+        None,
         Y_STRIDES=y.stride(),
         RSTD_STRIDES=rstd.stride(),
         DY_STRIDES=dy_strides,
@@ -356,6 +469,8 @@ def test_l2norm_bwd(dtype, T, D, strided):
         D=D,
         BD=BD,
         NB=triton.cdiv(T, 16),
+        NUM_SEQUENCES=0,
+        IS_VARLEN=False,
     )
     assert_golden(dx, golden, ref, dtype, f"l2norm_bwd_kernel T={T} D={D}")
 


### PR DESCRIPTION
## Human Note

## Agent note

KDA's Q/K L2Norm still normalized every physical capacity row during a smaller ragged CUDA Graph
replay. Thread `cu_seqlens` through the existing registered forward and backward operators, then stop
whole Triton row tiles beyond the device-resident logical endpoint. Dense calls retain their original
specialization, while packed calls define only their active prefix.

The tests cover optional-metadata op registration, active-prefix forward and backward correctness,
full-graph compilation, and replaying a captured graph with a smaller endpoint.

## Performance

On one B200, a matched CUDA Graph forward-and-backward benchmark used `T=4096`, `N=32`, 32
heads, head dimension 128, and hidden size 2304. Values are medians from three interleaved rounds of
30 samples.

| Replay | Baseline | Active endpoint | Change |
| --- | ---: | ---: | ---: |
| `L=512`, `M=8` | 1757.81 us | 1720.61 us | 2.16% faster |
| `L=4096`, `M=32` | 2888.54 us | 2898.93 us | 0.36% slower |

## Test Plan

```bash
gpu-run --timeout 300 auto -- .venv/bin/pytest -n 6 -q test/test_kda_kernels.py test/test_kda_training_example.py test/test_kda_compile_dynamic_shapes.py
.venv/bin/prek run --files attn_gym/linear/kda/fwd/triton/l2norm_fwd.py attn_gym/linear/kda/bwd/triton/l2norm_bwd.py examples/kda_training.py test/test_kda_kernels.py
git diff --check
```
