### PR TITLE
Vendor Mega CuTeDSL kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,4 +103,5 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for more details.
 
 ## ⚖️ License
 
-attention-gym is released under the BSD 3-Clause License.
+Attention Gym-authored code is released under the BSD 3-Clause License. Vendored third-party
+components retain the licenses and notices included alongside their source.

--- a/attn_gym/linear/_delta_rule/mega/__init__.py
+++ b/attn_gym/linear/_delta_rule/mega/__init__.py
@@ -1,0 +1,5 @@
+"""Optional Mega implementation shared by delta-rule attention variants.
+
+Importing this package does not load CuTeDSL. Variant adapters lazily load the shared
+launchers and vendored Frost kernels only after explicit Mega dispatch.
+"""

--- a/attn_gym/linear/_delta_rule/mega/kernels/LICENSE.Apache-2.0
+++ b/attn_gym/linear/_delta_rule/mega/kernels/LICENSE.Apache-2.0
@@ -1,0 +1,204 @@
+Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/attn_gym/linear/_delta_rule/mega/kernels/LICENSE.MIT
+++ b/attn_gym/linear/_delta_rule/mega/kernels/LICENSE.MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/attn_gym/linear/_delta_rule/mega/kernels/NOTICE.md
+++ b/attn_gym/linear/_delta_rule/mega/kernels/NOTICE.md
@@ -1,0 +1,50 @@
+# Third-party notice
+
+## Upstream notice
+
+cudnn-frontend
+
+Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+This product includes software developed at NVIDIA CORPORATION
+(https://www.nvidia.com/).
+
+The upstream project is distributed primarily under the Apache License, Version 2.0, with a subset
+of files under the MIT License as declared by each file's SPDX identifier.
+
+## Attention Gym adaptation
+
+The low-level KDA prefill, checkpoint-recompute, bprop kernels, and supporting helpers are adapted
+from NVIDIA's `cudnn-frontend` repository at commit
+`085d50b33691f06e2309f8e6724741a021985649`.
+
+Source mapping:
+
+- `linear_attention/frost/kernel/kda_prefill_f16.py` ->
+  `_delta_rule/mega/kernels/kda_prefill_f16.py`;
+- `linear_attention/frost/kernel/kda_recompute_f16.py` ->
+  `_delta_rule/mega/kernels/kda_recompute_f16.py`;
+- `linear_attention/frost/kernel/kda_bprop_f16.py` ->
+  `_delta_rule/mega/kernels/kda_bprop_f16.py`;
+- required `linear_attention/frost/common/` and `frost/tile_dsl/` files retain their package names.
+
+Changes made for Attention Gym:
+
+- imports were moved from `cudnn.frost.*` into this package;
+- cuDNN host/device utilities were replaced by the Torch shim in `compat.py`;
+- host dtype validation, device-aware compilation caching, role invariants, and stale documentation
+  were tightened for the Attention Gym integration;
+- unused upstream forward, recompute, and bprop replay wrappers were removed; the public adapters
+  call the cached launch paths directly;
+- FP8 conversion and MMA helpers used only by upstream SDPA kernels were omitted from this
+  linear-attention subset;
+- split backward scheduling omits empty-sequence work items, preventing invalid persistent-kernel
+  TMEM lifecycle transitions;
+- package-marker descriptions identify the vendored subset;
+- Attention Gym adapters map tensors, scheduling metadata, gradients, and state layouts to the
+  kernel ABIs.
+
+Original copyright and license notices are retained where present. Modified upstream files carry an
+explicit modification notice. Kernel and linear-attention common helpers are Apache-2.0 licensed;
+low-level tile helpers are MIT licensed. Copies are provided in `LICENSE.Apache-2.0` and
+`LICENSE.MIT`.

--- a/attn_gym/linear/_delta_rule/mega/kernels/README.md
+++ b/attn_gym/linear/_delta_rule/mega/kernels/README.md
@@ -1,0 +1,45 @@
+# Mega delta-rule CuTeDSL kernels
+
+This package vendors the SM100/SM103 prefill, checkpoint-recompute, and bprop kernels adapted from
+NVIDIA's Frost KDA implementation. It is the shared donor-derived kernel unit for delta-rule
+variants. The current KDA adapter owns public API selection, validation, gate preparation, and
+autograd; a future GDN adapter can reuse the same implementation boundary.
+
+## Raw specialization
+
+- CuTeDSL 4.7 or newer on NVIDIA SM100 or SM103.
+- Native FP16 or BF16 Q/K/V with K=V=128.
+- FP32 per-token natural-log gate increments and post-sigmoid beta.
+- Packed THD execution with contiguous int32 `cu_seqlens`, including tails and empty sequences.
+- Internal recurrent state and checkpoints use `[sequence, head, V, K]`.
+
+The `[V, K]` state layout is schedule-native rather than an inherited naming choice. State GEMMs use
+value dimension as the MMA M mode and contiguous key vectors as the K mode; forward, recompute, and
+bprop share that orientation. A maintained adapter must preserve the public `[K, V]` contract with
+explicit conversion unless the MMA descriptors, direct state loads/stores, and checkpoint TMA layout
+are redesigned together.
+
+## Checkpoint contract
+
+For a nonempty sequence of length `L`, checkpoint recompute stores `ceil(L / N)` entering states at
+interval `N`. Row zero is the provided initial state or zeros. Empty sequences allocate no row and
+emit no token work. Bprop consumes the same entering-state convention.
+
+## Scheduling
+
+The persistent kernels use one work item per `(sequence, head)` for exact execution. The optional
+forgetting-horizon split table is an approximate scheduling primitive for contracting-update
+experiments; it is not part of the raw kernel's exactness guarantee.
+
+Pipeline indices and phases are CTA-lifetime state and advance across persistent work items. The
+prologue constructs runtime tensor maps and the work table before the role-partitioned main kernel
+runs.
+
+## Source and licensing
+
+The kernels and required `common/` and `tile_dsl/` helpers are adapted from NVIDIA
+`cudnn-frontend` commit `085d50b33691f06e2309f8e6724741a021985649`. Runtime imports were moved
+into the Attention Gym namespace, and `compat.py` replaces cuDNN host utilities. There is no
+`cudnn.frost` runtime dependency.
+
+See `NOTICE.md`, `LICENSE.Apache-2.0`, and `LICENSE.MIT`.

--- a/attn_gym/linear/_delta_rule/mega/kernels/__init__.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/__init__.py
@@ -1,0 +1,1 @@
+"""Vendored SM100/SM103 Frost kernels for shared Mega delta-rule backends."""

--- a/attn_gym/linear/_delta_rule/mega/kernels/common/__init__.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/common/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Modified by Attention Gym in 2026: the package description names the vendored KDA subset.
+
+"""Sequence scheduling, host, and tensor-map helpers for the vendored KDA kernels."""

--- a/attn_gym/linear/_delta_rule/mega/kernels/common/elementwise.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/common/elementwise.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Element-wise device helpers shared by the FROST LA kernels: a lane-group
+butterfly reduction, the inverse L2 norm with its epsilon floor, and the
+sigmoid / softplus activations behind the safe gate and beta."""
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.experimental.primitives as nvvm
+
+L2_NORM_EPS = 1.0e-12
+
+
+@cute.jit
+def lane_group_sum(value: cutlass.Float32, lanes: cutlass.Constexpr[int]) -> cutlass.Float32:
+    """Sum ``value`` across a power-of-two group of consecutive lanes via
+    butterfly shuffles (every lane ends up holding the group total)."""
+    offset = lanes // 2
+    while offset >= 1:
+        value = value + cutlass.Float32(nvvm.shfl_sync(0xFFFFFFFF, value, offset, 31, kind=nvvm.Shfl.BFLY))
+        offset = offset // 2
+    return value
+
+
+@cute.jit
+def l2norm_inv(sum_sq: cutlass.Float32) -> cutlass.Float32:
+    """Inverse L2 norm with the shared epsilon floor: rows at or below the
+    floor normalize by ``1 / L2_NORM_EPS`` instead of dividing by zero."""
+    norm_floor_sq = cutlass.Float32(L2_NORM_EPS * L2_NORM_EPS)
+    return cute.math.rsqrt(cute.math.max(sum_sq, norm_floor_sq), fastmath=True)
+
+
+@cute.jit
+def sigmoid(x: cutlass.Float32) -> cutlass.Float32:
+    """sigmoid(x) via the tanh identity (single MUFU on Blackwell)."""
+    half = cutlass.Float32(0.5)
+    return cute.math.tanh(x * half, approx=True) * half + half
+
+
+@cute.jit
+def softplus(x: cutlass.Float32) -> cutlass.Float32:
+    """log(1 + exp(x)) with the linear tail (x > 20 returns x: exp saturates
+    fp32 there and log1p(exp(x)) == x to fp32 precision)."""
+    result = x
+    if x < cutlass.Float32(20.0):
+        result = cute.math.log(cutlass.Float32(1.0) + cute.math.exp(x, fastmath=True), fastmath=True)
+    return result

--- a/attn_gym/linear/_delta_rule/mega/kernels/common/host.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/common/host.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# Modified by Attention Gym in 2026: dtype validation now uses exact supported names.
+
+"""Host-side helpers shared by the FROST LA kernel modules (engine-invoked)."""
+
+import cutlass
+
+from .thd import TENSOR_MAP_QWORDS
+
+
+_DTYPES = {
+    "bfloat16": cutlass.BFloat16,
+    "float16": cutlass.Float16,
+    "half": cutlass.Float16,
+    "float32": cutlass.Float32,
+}
+
+
+def get_dtype(dtype):
+    """Map an exact Torch dtype name or supported alias to its CuTeDSL type."""
+    name = str(dtype).removeprefix("torch.")
+    try:
+        return _DTYPES[name]
+    except KeyError:
+        raise ValueError(
+            f"Unsupported dtype {dtype}, expected bfloat16, float16, half, or float32"
+        ) from None
+
+
+def tensormap_workspace_bytes(mod, B: int) -> int:
+    """Runtime TMA-descriptor block for a kernel module: per-batch arrays +
+    static slots + 128 alignment slack."""
+    return TENSOR_MAP_QWORDS * 8 * (mod.TENSORMAP_DESC_ARRAYS * B + mod.TENSORMAP_STATIC_SLOTS) + 128

--- a/attn_gym/linear/_delta_rule/mega/kernels/common/split_k.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/common/split_k.py
@@ -1,0 +1,1104 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Modified by Attention Gym in 2026: imports were relocated and empty sequences were changed to
+# emit no work item, preventing invalid persistent-kernel TMEM lifecycle transitions.
+
+"""Split-K sequence partitioning for ALL chunked linear-attention kernels:
+GDN (scalar ``gate (T, HO)``, b_t=64) and KDA / GDN-2 (per-key-channel
+``gate (T, HO, DK)``, b_t=16) share this one three-kernel pipeline.
+
+The chunked kernels are persistent one-CTA-per-(batch, head) kernels; when
+``B * HO`` does not fill the SMs, long sequences serialize on a few CTAs.
+This module cuts each (batch, head) sequence into independent work items at
+"forgetting horizon" boundaries: a cut is placed only where the running
+log2 of the forget gates saturates below a threshold on both sides, so the
+recurrent state (forward) and the state gradient (backward) entering an
+item can be reconstructed from a short warmup window recomputed by the item
+itself — no state is exchanged between items.
+
+Work-item table row (``WORK_ITEM_FIELDS`` x int32, chunk units)::
+
+    [batch_idx, head_idx, wstart, wend, cstart, cend, batch_start, batch_end]
+
+``batch_start``/``batch_end`` are the token bounds ``cu_seqlens[b]`` /
+``cu_seqlens[b+1]`` denormalized into the row: decode reads one 32-byte
+vectorizable row instead of chasing a dependent ``cu_seqlens`` load pair.
+
+The item OWNS (writes outputs for) chunks ``[wstart, wend)``.  The forward
+kernel COMPUTES chunks ``[cstart, wend)`` — ``[cstart, wstart)`` is the
+left warmup that rebuilds the incoming state from zero (accurate to
+``2^log2_threshold`` because the gate decay over the window saturates).
+The backward kernel computes ``[wstart, cend)`` — ``[wend, cend)`` is the
+right warmup for the reverse dstate recurrence (the forward states come exactly
+from the per-chunk state checkpoints).  ``cstart == 0`` items seed the true
+initial state; ``cend == num_chunks`` items seed the true ``d_final_state``
+— so the un-cut degenerate item ``(0, nc, 0, nc)`` reproduces the serial
+kernel exactly.
+
+Piece choice per (batch, head): spans never exceed ``ideal_chunks`` (total
+work / SM count), so outlier-long sequences are always cut down to the
+batch-wide grain.  When the grid is small (``n_tiles < 2 * num_sms``) a
+wave-quantized search widens the cut further to fill the machine; in the
+many-tile regime cutting only adds per-item overhead, so the cap alone
+decides.
+
+The pipeline (one fixed shape regardless of gate kind):
+
+1. scan: a flat data-parallel grid — CTA ``(x, h)`` covers chunk-scratch
+   rows ``[x * WARPS, (x + 1) * WARPS)`` of head ``h``, one warp per chunk
+   — reduces the gate to per-chunk values in the caller's GMEM scratch
+   (channel gates: max over the per-channel clamped-log2 sums, a cut is
+   valid only when EVERY channel saturated; scalar gates: the plain sum).
+   Only chunks within ``WARMUP_CAP_CHUNKS`` of a candidate boundary are
+   read: skipping chunks can only RAISE the (negative) horizon sums, so the
+   windowed scan never accepts an unsaturated cut, it can only skip one.
+   Uncut tiles never touch the gate.
+2. walk: one CTA per (batch, head) probes every candidate boundary in
+   parallel (one warp per boundary, one lane per window chunk), then
+   thread 0 walks the probe results and emits work items into the caller's
+   ``item_scratch``.
+3. order (:func:`order_body`, hosted by each kernel module's
+   prologue kernel alongside its TMA-descriptor build — one launch for
+   both): bitonic-sort the items into ``work_items``, longest ``[cstart,
+   cend)`` first, so the ticket scheduler consumes them in LPT order —
+   the makespan tail is set by whatever starts last, so the big items
+   must go first.  This is what keeps ragged varlen batches balanced
+   without cutting them.
+
+The order body also zeroes the main kernels' scheduler ticket rings
+(dirty on exit), and with ``split=False`` it replaces the whole pipeline:
+scan and walk never launch, and the prologue kernel synthesizes the uncut
+whole-sequence item per (batch, head) from ``cu_seqlens`` alone, then
+LPT-sorts those.  That no-cuts table serves batch-invariant mode and
+coarse checkpoint cadences (cuts may not cross a checkpoint period).
+"""
+
+import math
+from typing import NamedTuple
+
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.experimental.primitives as nvvm
+from cutlass.cute.arch.nvvm_wrappers import inline_ptx
+from cutlass.cute.runtime import from_dlpack
+
+from ..compat import current_device, data_ptr, get_device_properties, tensor_device_index
+
+from .elementwise import softplus
+
+WORK_ITEM_FIELDS = 8
+WARMUP_CAP_CHUNKS = 32  # hard warmup cap: a cut must saturate within one warp of chunks per side
+MAX_BLOCKS = 2048  # piece-count ceiling; host clamps ideal_chunks so the per-tile block count fits
+WARP_SIZE = 32
+WARPS = 8
+THREADS_PER_BLOCK = WARPS * WARP_SIZE
+SCAN_WARPS = 4
+SCAN_THREADS = SCAN_WARPS * WARP_SIZE
+SCAN_ROWS_PER_WARP = 4  # consecutive chunk rows per scan warp
+SCAN_TOKEN_STRIDE = 4  # sample every Nth token of a chunk: skipped tokens only RAISE the negative horizon sums
+OVERHEAD_TOKENS = 256  # per-item fixed cost for the piece model: state reseed + pipeline refill + typical warmup
+P_WINDOW = 16  # fill-regime piece-count search width
+P_BELOW = 8  # how far below the ideal-cap floor the fill-regime search may go
+
+ORDER_THREADS = 1024
+ORDER_ELEMS = 4
+ORDER_CAPACITY = ORDER_THREADS * ORDER_ELEMS  # sort capacity (32 KB SMEM); past this the device-side branch copies through unsorted
+
+DEFAULT_LOG2_THRESHOLD = -10.0 / math.log(2.0)  # e^-10, in log2 units
+RCP_LN2 = 1.4426950408889634  # 1/ln(2): natural-log gates -> the scan's log2 domain
+
+
+def compute_ideal_chunks(total_tokens: int, n_heads_out: int, num_sms: int, b_t: int) -> int:
+    """Ideal per-work-item span in chunks: total work across all (b,h)
+    tiles divided by the SM count, floored at one chunk and clamped so the
+    per-tile block count fits ``MAX_BLOCKS``."""
+    total_chunks = -(-total_tokens // b_t)
+    ideal_tokens = -(-(total_tokens * n_heads_out) // num_sms)
+    ideal_chunks = max(1, -(-ideal_tokens // b_t))
+    return max(ideal_chunks, -(-total_chunks // MAX_BLOCKS))
+
+
+def chunk_scratch_rows(total_tokens: int, batch_size: int, b_t: int) -> int:
+    """Rows of the ``(rows, HO)`` fp32 chunk-value scratch: per-batch chunk
+    ranges are based at ``cu[b] // b_t + b``, so one extra row per sequence
+    covers the ceil rounding."""
+    return total_tokens // b_t + batch_size
+
+
+def max_work_items(total_tokens: int, batch_size: int, n_heads_out: int, ideal_chunks: int, b_t: int, num_sms: int) -> int:
+    """Provable upper bound on the emitted item count: spans are capped at
+    ``ideal_chunks`` (at most ``ceil(nc / ideal) + 1`` pieces per (b, h)),
+    zero-length sequences emit no work item, and the fill-regime search
+    can widen any tile by up to ``P_WINDOW - 1`` extra pieces."""
+    total_chunks = -(-total_tokens // b_t)
+    window = P_WINDOW - 1 if batch_size * n_heads_out < 2 * num_sms else 0
+    return n_heads_out * (-(-total_chunks // ideal_chunks) + (2 + window) * batch_size)
+
+
+@cute.jit
+def decode_work_item(cfg, tile_idx, mWorkItems):
+    """Tile decode shared by every warp body of the main kernels: read the
+    work-item row (an uncut table row IS the whole sequence).  Returns
+    ``(batch_idx, head_idx, batch_start, batch_end, seqlen_b, num_chunks_b,
+    wstart, wend, cstart, cend)`` with chunk-unit bounds."""
+    batch_idx = mWorkItems[tile_idx, 0]
+    head_idx = mWorkItems[tile_idx, 1]
+    wstart = mWorkItems[tile_idx, 2]
+    wend = mWorkItems[tile_idx, 3]
+    cstart = mWorkItems[tile_idx, 4]
+    cend = mWorkItems[tile_idx, 5]
+    batch_start = mWorkItems[tile_idx, 6]
+    batch_end = mWorkItems[tile_idx, 7]
+    seqlen_b = batch_end - batch_start
+    num_chunks_b = cute.ceil_div(seqlen_b, cfg.b_t)
+    return batch_idx, head_idx, batch_start, batch_end, seqlen_b, num_chunks_b, wstart, wend, cstart, cend
+
+
+@cute.jit
+def emit_item(mWorkItems, mCount, batch_idx, head_idx, wstart, wend, cstart, cend, batch_start, batch_end):
+    count_addr = mCount.iterator.toint()
+    wi = inline_ptx(
+        "atom.global.add.s32 {$w0}, [{$r0}], 1;",
+        write_only_types=[cutlass.Int32],
+        read_only_args=[count_addr],
+    )
+    mWorkItems[wi, 0] = batch_idx
+    mWorkItems[wi, 1] = head_idx
+    mWorkItems[wi, 2] = wstart
+    mWorkItems[wi, 3] = wend
+    mWorkItems[wi, 4] = cstart
+    mWorkItems[wi, 5] = cend
+    mWorkItems[wi, 6] = batch_start
+    mWorkItems[wi, 7] = batch_end
+
+
+@cute.jit
+def clamped_log2(log_gate: cutlass.Constexpr[bool], gate_val: cutlass.Float32) -> cutlass.Float32:
+    """Log2-domain decay increment, clamped to <= 0 (a gate > 1 must not
+    relax the horizon)."""
+    if cutlass.const_expr(log_gate):
+        lg = gate_val * cutlass.Float32(RCP_LN2)
+    else:
+        lg = cute.math.log2(gate_val + cutlass.Float32(1e-10), fastmath=True)
+    return lg if lg < cutlass.Float32(0.0) else cutlass.Float32(0.0)
+
+
+@cute.jit
+def piece_choice(overhead_chunks: cutlass.Constexpr[int], num_chunks_b, n_tiles, num_sms, ideal_chunks):
+    """Per-tile piece choice.  Returns ``(span, num_blocks)``."""
+    # even spread: spans never exceed ideal_chunks (total work / SM count)
+    p_hi = num_chunks_b if num_chunks_b < cutlass.Int32(MAX_BLOCKS) else cutlass.Int32(MAX_BLOCKS)
+    p_hi = p_hi if p_hi > 0 else cutlass.Int32(1)
+    p = (num_chunks_b + ideal_chunks - cutlass.Int32(1)) // ideal_chunks
+    p = p if p > 0 else cutlass.Int32(1)
+    p = p if p < p_hi else p_hi
+    if n_tiles < cutlass.Int32(2) * num_sms:
+        # fill regime: SMs to spare — search piece counts around the cap on
+        # the wave-quantized makespan estimate
+        p_start = p - cutlass.Int32(P_BELOW)
+        p_start = p_start if p_start > 0 else cutlass.Int32(1)
+        best = cutlass.Int32(2147483647)
+        for dp in cutlass.range_constexpr(P_WINDOW):
+            cand = p_start + cutlass.Int32(dp)
+            cand = cand if cand < p_hi else p_hi
+            span_c = (num_chunks_b + cand - cutlass.Int32(1)) // cand
+            waves = (n_tiles * cand + num_sms - cutlass.Int32(1)) // num_sms
+            est = waves * (span_c + cutlass.Int32(overhead_chunks))
+            hit = est < best
+            best = est if hit else best
+            p = cand if hit else p
+        # the estimate flatters marginal cuts; cut only on a clear margin over uncut
+        est1 = ((n_tiles + num_sms - cutlass.Int32(1)) // num_sms) * (num_chunks_b + cutlass.Int32(overhead_chunks))
+        if cutlass.Int32(4) * best > cutlass.Int32(3) * est1:
+            p = cutlass.Int32(1)
+    span = cutlass.Int32(0)
+    num_blocks = cutlass.Int32(0)
+    if num_chunks_b > 0:
+        span = (num_chunks_b + p - cutlass.Int32(1)) // p
+        num_blocks = (num_chunks_b + span - cutlass.Int32(1)) // span
+    return span, num_blocks
+
+
+@cute.jit
+def tile_spans(b_t: cutlass.Constexpr[int], overhead_chunks: cutlass.Constexpr[int], n_heads_out, n_tiles, num_sms, ideal_chunks, mCuSeqlens, tile):
+    """Per-tile decode + piece choice.  Returns ``(batch_idx, head_idx,
+    batch_start, batch_end, num_chunks_b, cv_base, span, num_blocks)``;
+    ``cv_base`` is the tile's row base in the GMEM chunk scratch."""
+    batch_idx = tile // n_heads_out
+    head_idx = tile % n_heads_out
+    batch_start = cutlass.Int32(mCuSeqlens[batch_idx])
+    batch_end = cutlass.Int32(mCuSeqlens[batch_idx + 1])
+    seqlen_b = batch_end - batch_start
+    num_chunks_b = cute.ceil_div(seqlen_b, b_t)
+    cv_base = batch_start // cutlass.Int32(b_t) + batch_idx
+    span, num_blocks = piece_choice(overhead_chunks, num_chunks_b, n_tiles, num_sms, ideal_chunks)
+    return batch_idx, head_idx, batch_start, batch_end, num_chunks_b, cv_base, span, num_blocks
+
+
+@cute.jit
+def near_boundary(c, span, num_blocks):
+    """True iff chunk ``c`` lies in the walk's read window of a candidate
+    boundary: suffix ``[j*span - W, j*span)`` or prefix ``[j*span, j*span
+    + W)`` for some ``j`` in ``[1, num_blocks)``."""
+    j0 = c // span
+    cm = c - j0 * span
+    w = cutlass.Int32(WARMUP_CAP_CHUNKS)
+    pre = (cm < w) and (j0 >= cutlass.Int32(1))
+    suf = (span - cm <= w) and (j0 < num_blocks - cutlass.Int32(1))
+    return pre or suf
+
+
+@cute.kernel
+def scan_kernel(
+    b_t: cutlass.Constexpr[int],
+    log_gate: cutlass.Constexpr[bool],
+    safe_gate: cutlass.Constexpr[bool],
+    gate_channels: cutlass.Constexpr[int],
+    overhead_chunks: cutlass.Constexpr[int],
+    n_heads_out: cutlass.Int32,
+    n_tiles: cutlass.Int32,
+    num_sms: cutlass.Int32,
+    ideal_chunks: cutlass.Int32,
+    batch_size: cutlass.Int32,
+    gate_scale_log2: cutlass.Float32,
+    mGate: cute.Tensor,
+    mALog: cute.Tensor | None,
+    mDtBias: cute.Tensor | None,
+    mCuSeqlens: cute.Tensor,
+    mChunkVals: cute.Tensor,
+    mCount: cute.Tensor,
+):
+    """Flat windowed chunk scan, per-channel gate (KDA / GDN-2): CTA
+    ``(x, h)`` covers 16 chunk-scratch rows of head ``h``, one warp per
+    chunk, lane ``l`` owning channels ``[l*cpl, (l+1)*cpl)``.  Chunks
+    outside every cut window — and whole tiles the piece choice leaves
+    uncut — never touch the gate.  CTA (0, 0) also zeroes the item count
+    for the walk (the scheduler rings are the order kernel's job)."""
+    tidx, _, _ = cute.arch.thread_idx()
+    bidx = cute.arch.block_idx()
+    tidx = cutlass.Int32(tidx)
+    head_idx = cutlass.Int32(bidx[1])
+    if cutlass.Int32(bidx[0]) == 0 and head_idx == 0 and tidx == 0:
+        mCount[0] = cutlass.Int32(0)
+    lidx = tidx % cutlass.Int32(WARP_SIZE)
+    widx = tidx // cutlass.Int32(WARP_SIZE)
+    row0 = (cutlass.Int32(bidx[0]) * cutlass.Int32(SCAN_WARPS) + widx) * cutlass.Int32(SCAN_ROWS_PER_WARP)
+
+    # batch of the warp's first row: largest b with cu[b] // b_t + b <= row0
+    lo = cutlass.Int32(0)
+    hi = batch_size - cutlass.Int32(1)
+    while lo < hi:
+        mid = (lo + hi + cutlass.Int32(1)) // cutlass.Int32(2)
+        take = cutlass.Int32(mCuSeqlens[mid]) // cutlass.Int32(b_t) + mid <= row0
+        lo = mid if take else lo
+        hi = hi if take else mid - cutlass.Int32(1)
+    batch_idx = lo
+    batch_start = cutlass.Int32(mCuSeqlens[batch_idx])
+    batch_end = cutlass.Int32(mCuSeqlens[batch_idx + 1])
+    num_chunks_b = cute.ceil_div(batch_end - batch_start, b_t)
+    cv_base = batch_start // cutlass.Int32(b_t) + batch_idx
+    # the piece choice is computed per batch, NOT per row
+    span, num_blocks = piece_choice(overhead_chunks, num_chunks_b, n_tiles, num_sms, ideal_chunks)
+    for rr in cutlass.range_constexpr(SCAN_ROWS_PER_WARP):
+        row = row0 + cutlass.Int32(rr)
+        while (batch_idx + cutlass.Int32(1) < batch_size) and (
+            cutlass.Int32(mCuSeqlens[batch_idx + 1]) // cutlass.Int32(b_t) + batch_idx + cutlass.Int32(1) <= row
+        ):
+            batch_idx = batch_idx + cutlass.Int32(1)
+            batch_start = cutlass.Int32(mCuSeqlens[batch_idx])
+            batch_end = cutlass.Int32(mCuSeqlens[batch_idx + 1])
+            num_chunks_b = cute.ceil_div(batch_end - batch_start, b_t)
+            cv_base = batch_start // cutlass.Int32(b_t) + batch_idx
+            span, num_blocks = piece_choice(overhead_chunks, num_chunks_b, n_tiles, num_sms, ideal_chunks)
+        c = row - cv_base
+        if (c >= 0) and (c < num_chunks_b) and (num_blocks > 1):
+            if near_boundary(c, span if span > 0 else cutlass.Int32(1), num_blocks):
+                # chunk value = max over channels of the per-channel
+                # clamped-log2 sums (each lane owns a contiguous channel run)
+                cpl = gate_channels // WARP_SIZE
+                row_elems = cutlass.Int32(mGate.stride[0])
+                lane_base = cutlass.Int64(head_idx * cutlass.Int32(mGate.stride[1]) + lidx * cutlass.Int32(cpl))
+                gate_addr = mGate.iterator.toint() + lane_base * cutlass.Int64(4)
+                gate_ptr = mGate.iterator + lane_base
+                a_exp = cutlass.Float32(1.0)
+                dt_vals = cutlass.Array(cutlass.Float32, cpl)
+                if cutlass.const_expr(safe_gate):
+                    # per-head rate + per-lane channel biases, fixed for the whole chunk
+                    a_exp = cute.math.exp2(mALog[head_idx].to(cutlass.Float32) * cutlass.Float32(RCP_LN2), fastmath=True)
+                    for q in cutlass.range_constexpr(cpl):
+                        dt_vals[q] = mDtBias[head_idx, lidx * cutlass.Int32(cpl) + cutlass.Int32(q)].to(cutlass.Float32)
+                ch_acc = cutlass.Array(cutlass.Float32, cpl, alignment=16)
+                for q in cutlass.range_constexpr(cpl):
+                    ch_acc[q] = cutlass.Float32(0.0)
+                oob = cutlass.Float32(0.0) if cutlass.const_expr(log_gate) else cutlass.Float32(1.0)
+                for tt in cutlass.range(0, b_t, SCAN_TOKEN_STRIDE, unroll_full=True):
+                    pos = batch_start + c * cutlass.Int32(b_t) + cutlass.Int32(tt)
+                    inb = pos < batch_end
+                    pos_r = pos if inb else batch_start
+                    grow = cutlass.Int64(pos_r) * cutlass.Int64(row_elems)
+                    if cutlass.const_expr(cpl % 4 == 0):
+                        for q4 in cutlass.range_constexpr(cpl // 4):
+                            addr = gate_addr + (grow + cutlass.Int64(4 * q4)) * cutlass.Int64(4)
+                            g0, g1, g2, g3 = inline_ptx(
+                                "ld.global.v4.f32 {$0, $1, $2, $3}, [$4];",
+                                write_only_types=[cutlass.Float32, cutlass.Float32, cutlass.Float32, cutlass.Float32],
+                                read_only_args=[addr],
+                            )
+                            for qq, gvq in enumerate((g0, g1, g2, g3)):
+                                q = 4 * q4 + qq
+                                if cutlass.const_expr(safe_gate):
+                                    # the main kernel's transform, in log2 domain: scale * sigmoid(exp(a_log) * (g + dt_bias))
+                                    half = cutlass.Float32(0.5)
+                                    sig = cute.math.tanh(a_exp * (gvq + dt_vals[q]) * half, approx=True) * half + half
+                                    contrib = gate_scale_log2 * sig
+                                    contrib = contrib if inb else cutlass.Float32(0.0)
+                                else:
+                                    gvq = gvq if inb else oob
+                                    contrib = clamped_log2(log_gate, gvq)
+                                ch_acc[q] = ch_acc[q] + contrib
+                    else:
+                        for q in cutlass.range_constexpr(cpl):
+                            gv = (gate_ptr + grow + cutlass.Int32(q)).load()
+                            if cutlass.const_expr(safe_gate):
+                                half = cutlass.Float32(0.5)
+                                sig = cute.math.tanh(a_exp * (gv + dt_vals[q]) * half, approx=True) * half + half
+                                contrib = gate_scale_log2 * sig
+                                contrib = contrib if inb else cutlass.Float32(0.0)
+                            else:
+                                gv = gv if inb else oob
+                                contrib = clamped_log2(log_gate, gv)
+                            ch_acc[q] = ch_acc[q] + contrib
+                m = ch_acc[0]
+                for q in cutlass.range_constexpr(1, cpl):
+                    m = m if m > ch_acc[q] else ch_acc[q]
+                for off in [1, 2, 4, 8, 16]:
+                    other = cutlass.Float32(nvvm.shfl_sync(0xFFFFFFFF, m, off, 31, kind=nvvm.Shfl.BFLY))
+                    m = m if m > other else other
+                if lidx == 0:
+                    mChunkVals[cv_base + c, head_idx] = m
+
+
+@cute.kernel
+def scan_scalar_kernel(
+    b_t: cutlass.Constexpr[int],
+    log_gate: cutlass.Constexpr[bool],
+    safe_gate: cutlass.Constexpr[bool],
+    overhead_chunks: cutlass.Constexpr[int],
+    n_heads_out: cutlass.Int32,
+    n_tiles: cutlass.Int32,
+    num_sms: cutlass.Int32,
+    ideal_chunks: cutlass.Int32,
+    batch_size: cutlass.Int32,
+    mGate: cute.Tensor,
+    mALog: cute.Tensor | None,
+    mDtBias: cute.Tensor | None,
+    mCuSeqlens: cute.Tensor,
+    mChunkVals: cute.Tensor,
+    mCount: cute.Tensor,
+):
+    """Scalar-gate scan (GDN): CTA ``(x, hg)`` covers 16 chunk-scratch rows
+    for heads ``[hg*32, (hg+1)*32)``; lane ``l`` owns head ``hg*32 + l``, so
+    gate reads and chunk-value writes are coalesced across lanes and every
+    lane accumulates its own head — no reduction.  With ``safe_gate`` the
+    gate holds raw logits and each token contributes the GDN transform in
+    log2 domain: ``-exp(A_log[h]) * softplus(g + dt_bias[h]) * RCP_LN2``.
+    CTA (0, 0) zeroes the item count (the scheduler rings are the order
+    kernel's job)."""
+    tidx, _, _ = cute.arch.thread_idx()
+    bidx = cute.arch.block_idx()
+    tidx = cutlass.Int32(tidx)
+    if cutlass.Int32(bidx[0]) == 0 and cutlass.Int32(bidx[1]) == 0 and tidx == 0:
+        mCount[0] = cutlass.Int32(0)
+    lidx = tidx % cutlass.Int32(WARP_SIZE)
+    widx = tidx // cutlass.Int32(WARP_SIZE)
+    h = cutlass.Int32(bidx[1]) * cutlass.Int32(WARP_SIZE) + lidx
+    h_ok = h < n_heads_out
+    h_r = h if h_ok else n_heads_out - cutlass.Int32(1)
+    a_l2 = cutlass.Float32(0.0)
+    bias = cutlass.Float32(0.0)
+    if cutlass.const_expr(safe_gate):
+        # per-head transform constants, fixed for the lane's whole sweep
+        a_l2 = -cute.math.exp2(mALog[h_r].to(cutlass.Float32) * cutlass.Float32(RCP_LN2), fastmath=True) * cutlass.Float32(RCP_LN2)
+        bias = mDtBias[h_r].to(cutlass.Float32)
+    row0 = (cutlass.Int32(bidx[0]) * cutlass.Int32(SCAN_WARPS) + widx) * cutlass.Int32(SCAN_ROWS_PER_WARP)
+
+    # batch of the warp's first row: largest b with cu[b] // b_t + b <= row0
+    lo = cutlass.Int32(0)
+    hi = batch_size - cutlass.Int32(1)
+    while lo < hi:
+        mid = (lo + hi + cutlass.Int32(1)) // cutlass.Int32(2)
+        take = cutlass.Int32(mCuSeqlens[mid]) // cutlass.Int32(b_t) + mid <= row0
+        lo = mid if take else lo
+        hi = hi if take else mid - cutlass.Int32(1)
+    batch_idx = lo
+    batch_start = cutlass.Int32(mCuSeqlens[batch_idx])
+    batch_end = cutlass.Int32(mCuSeqlens[batch_idx + 1])
+    num_chunks_b = cute.ceil_div(batch_end - batch_start, b_t)
+    cv_base = batch_start // cutlass.Int32(b_t) + batch_idx
+    span, num_blocks = piece_choice(overhead_chunks, num_chunks_b, n_tiles, num_sms, ideal_chunks)
+    for rr in cutlass.range_constexpr(SCAN_ROWS_PER_WARP):
+        row = row0 + cutlass.Int32(rr)
+        while (batch_idx + cutlass.Int32(1) < batch_size) and (
+            cutlass.Int32(mCuSeqlens[batch_idx + 1]) // cutlass.Int32(b_t) + batch_idx + cutlass.Int32(1) <= row
+        ):
+            batch_idx = batch_idx + cutlass.Int32(1)
+            batch_start = cutlass.Int32(mCuSeqlens[batch_idx])
+            batch_end = cutlass.Int32(mCuSeqlens[batch_idx + 1])
+            num_chunks_b = cute.ceil_div(batch_end - batch_start, b_t)
+            cv_base = batch_start // cutlass.Int32(b_t) + batch_idx
+            span, num_blocks = piece_choice(overhead_chunks, num_chunks_b, n_tiles, num_sms, ideal_chunks)
+        c = row - cv_base
+        if (c >= 0) and (c < num_chunks_b) and (num_blocks > 1):
+            if near_boundary(c, span if span > 0 else cutlass.Int32(1), num_blocks):
+                oob = cutlass.Float32(0.0) if cutlass.const_expr(log_gate) else cutlass.Float32(1.0)
+                acc = cutlass.Float32(0.0)
+                for tt in cutlass.range(0, b_t, SCAN_TOKEN_STRIDE, unroll_full=True):
+                    pos = batch_start + c * cutlass.Int32(b_t) + cutlass.Int32(tt)
+                    inb = pos < batch_end
+                    pos_r = pos if inb else batch_start
+                    gate_offset = (
+                        cutlass.Int64(pos_r) * cutlass.Int64(mGate.stride[0])
+                        + cutlass.Int64(h_r) * cutlass.Int64(mGate.stride[1])
+                    )
+                    gv = (mGate.iterator + gate_offset).load()
+                    if cutlass.const_expr(safe_gate):
+                        contrib = a_l2 * softplus(gv + bias)
+                        acc = acc + (contrib if inb else cutlass.Float32(0.0))
+                    else:
+                        gv = gv if inb else oob
+                        acc = acc + clamped_log2(log_gate, gv)
+                if h_ok:
+                    mChunkVals[cv_base + c, h] = acc
+
+
+@cute.kernel
+def walk_kernel(
+    b_t: cutlass.Constexpr[int],
+    overhead_chunks: cutlass.Constexpr[int],
+    n_heads_out: cutlass.Int32,
+    n_tiles: cutlass.Int32,
+    num_sms: cutlass.Int32,
+    ideal_chunks: cutlass.Int32,
+    log2_thresh: cutlass.Float32,
+    mCuSeqlens: cute.Tensor,
+    mChunkVals: cute.Tensor,
+    mStaging: cute.Tensor,
+    mCount: cute.Tensor,
+):
+    """One CTA per (batch, head): every candidate boundary is probed by its
+    own warp (one lane per window chunk, warp-scan for the smallest
+    saturating warmup), then thread 0 walks the probe results and emits the
+    items."""
+    tidx, _, _ = cute.arch.thread_idx()
+    bidx = cute.arch.block_idx()[0]
+    tidx = cutlass.Int32(tidx)
+
+    batch_idx, head_idx, batch_start, batch_end, num_chunks_b, cv_base, span, num_blocks = tile_spans(
+        b_t, overhead_chunks, n_heads_out, n_tiles, num_sms, ideal_chunks, mCuSeqlens, cutlass.Int32(bidx)
+    )
+    if num_blocks <= 1:
+        # Single nonempty piece: no cuts, nothing scanned. Empty sequences
+        # preserve state through preinitialized outputs and require no kernel work.
+        if (tidx == 0) and (num_chunks_b > 0):
+            emit_item(mStaging, mCount, batch_idx, head_idx, cutlass.Int32(0), num_chunks_b, cutlass.Int32(0), num_chunks_b, batch_start, batch_end)
+
+    else:
+        # packed per-boundary probe results: warm_b | warm_f << 8, 0 = no cut
+        sWarm = cutlass.Array(cutlass.Int32, MAX_BLOCKS, space=cutlass.AddressSpace.smem, alignment=16)
+        lidx = tidx % cutlass.Int32(WARP_SIZE)
+        widx = tidx // cutlass.Int32(WARP_SIZE)
+        big = cutlass.Int32(2 * WARMUP_CAP_CHUNKS)
+        j = widx + cutlass.Int32(1)
+        while j < num_blocks:
+            wend = j * span
+            # fwd warmup: smallest chunk suffix of [0, wend) that saturates
+            idx = wend - cutlass.Int32(1) - lidx
+            ok_b = idx >= 0
+            v = mChunkVals[cv_base + (idx if ok_b else cutlass.Int32(0)), head_idx]
+            acc = v if ok_b else cutlass.Float32(0.0)
+            for off in [1, 2, 4, 8, 16]:
+                o = cutlass.Float32(nvvm.shfl_sync(0xFFFFFFFF, acc, off, 0, kind=nvvm.Shfl.UP))
+                acc = acc + (o if lidx >= cutlass.Int32(off) else cutlass.Float32(0.0))
+            cand = lidx + cutlass.Int32(1) if (ok_b and acc <= log2_thresh) else big
+            for off in [1, 2, 4, 8, 16]:
+                other = cutlass.Int32(nvvm.shfl_sync(0xFFFFFFFF, cand, off, 31, kind=nvvm.Shfl.BFLY))
+                cand = cand if cand < other else other
+            warm_b = cand if cand < big else cutlass.Int32(0)
+            # bwd warmup: smallest chunk prefix of [wend, nc) that saturates
+            idx = wend + lidx
+            ok_f = idx < num_chunks_b
+            v = mChunkVals[cv_base + (idx if ok_f else cutlass.Int32(0)), head_idx]
+            acc = v if ok_f else cutlass.Float32(0.0)
+            for off in [1, 2, 4, 8, 16]:
+                o = cutlass.Float32(nvvm.shfl_sync(0xFFFFFFFF, acc, off, 0, kind=nvvm.Shfl.UP))
+                acc = acc + (o if lidx >= cutlass.Int32(off) else cutlass.Float32(0.0))
+            cand = lidx + cutlass.Int32(1) if (ok_f and acc <= log2_thresh) else big
+            for off in [1, 2, 4, 8, 16]:
+                other = cutlass.Int32(nvvm.shfl_sync(0xFFFFFFFF, cand, off, 31, kind=nvvm.Shfl.BFLY))
+                cand = cand if cand < other else other
+            warm_f = cand if cand < big else cutlass.Int32(0)
+            if lidx == 0:
+                packed = warm_b + warm_f * cutlass.Int32(256)
+                packed = packed if (warm_b > 0 and warm_f > 0) else cutlass.Int32(0)
+                sWarm[j] = packed
+            j = j + cutlass.Int32(WARPS)
+        nvvm.barrier_cta_sync()
+
+        if tidx == 0:
+            prev_cut = cutlass.Int32(0)  # wstart of the open item, chunk units
+            cur_cstart = cutlass.Int32(0)  # cstart of the open item, chunk units
+            jj = cutlass.Int32(1)
+            while jj < num_blocks:
+                r = sWarm[jj]
+                if r != 0:
+                    wend = jj * span
+                    warm_b = r % cutlass.Int32(256)
+                    warm_f = r // cutlass.Int32(256)
+                    cend = wend + warm_f
+                    cend = cend if cend < num_chunks_b else num_chunks_b
+                    emit_item(mStaging, mCount, batch_idx, head_idx, prev_cut, wend, cur_cstart, cend, batch_start, batch_end)
+                    cur_cstart = wend - warm_b
+                    prev_cut = wend
+                jj = jj + cutlass.Int32(1)
+            emit_item(mStaging, mCount, batch_idx, head_idx, prev_cut, num_chunks_b, cur_cstart, num_chunks_b, batch_start, batch_end)
+
+
+@cute.jit
+def gen_item_bounds(b_t: cutlass.Constexpr[int], n_heads_out, mCuSeqlens, item):
+    """(batch, head, batch_start, batch_end, num_chunks) of the uncut
+    whole-sequence item ``item`` — a no-cuts table row is pure geometry."""
+    batch_idx = item // n_heads_out
+    head_idx = item % n_heads_out
+    batch_start = cutlass.Int32(mCuSeqlens[batch_idx])
+    batch_end = cutlass.Int32(mCuSeqlens[batch_idx + 1])
+    num_chunks_b = cute.ceil_div(batch_end - batch_start, b_t)
+    return batch_idx, head_idx, batch_start, batch_end, num_chunks_b
+
+
+@cute.jit
+def write_item(
+    gen: cutlass.Constexpr[bool],
+    b_t: cutlass.Constexpr[int],
+    n_heads_out,
+    mCuSeqlens,
+    mStaging,
+    mWorkItems,
+    dst,
+    src,
+):
+    """Final-table row ``dst`` from source item ``src``: the walk's staged
+    row, or (``gen``) the synthesized uncut item ``(0, nc, 0, nc)``."""
+    if cutlass.const_expr(gen):
+        batch_idx, head_idx, batch_start, batch_end, num_chunks_b = gen_item_bounds(b_t, n_heads_out, mCuSeqlens, src)
+        mWorkItems[dst, 0] = batch_idx
+        mWorkItems[dst, 1] = head_idx
+        mWorkItems[dst, 2] = cutlass.Int32(0)
+        mWorkItems[dst, 3] = num_chunks_b
+        mWorkItems[dst, 4] = cutlass.Int32(0)
+        mWorkItems[dst, 5] = num_chunks_b
+        mWorkItems[dst, 6] = batch_start
+        mWorkItems[dst, 7] = batch_end
+    else:
+        for f in cutlass.range_constexpr(WORK_ITEM_FIELDS):
+            mWorkItems[dst, cutlass.Int32(f)] = mStaging[src, cutlass.Int32(f)]
+
+
+@cute.jit
+def order_body(
+    gen: cutlass.Constexpr[bool],
+    has_sched: cutlass.Constexpr[bool],
+    b_t: cutlass.Constexpr[int],
+    n_threads: cutlass.Constexpr[int],
+    order_elems: cutlass.Constexpr[int],
+    tidx,
+    n_heads_out: cutlass.Int32,
+    n_tiles: cutlass.Int32,
+    mCuSeqlens: cute.Tensor,
+    mStaging: cute.Tensor | None,
+    mCount: cute.Tensor,
+    mWorkItems: cute.Tensor,
+    mSched: cute.Tensor | None,
+    sKey,
+    sIdx,
+    sSpread,
+):
+    """LPT ordering body over ``n_threads`` CTA threads and caller-owned SMEM
+    staging (``sKey``/``sIdx`` of ``n_threads * order_elems`` Int32 cells +
+    a 2-cell ``sSpread``): bitonic-sort the items by span ``cend - cstart``,
+    longest first, into the final table.  Sorts the walk's staged items, or
+    with ``gen`` synthesizes the uncut whole-sequence item per (batch, head)
+    from ``cu_seqlens`` directly — the no-cuts table.  Thread 0 also zeroes
+    every ``sched_ctr`` cell (the main kernels' ticket rings, dirty on exit).
+    Runs on the standalone :func:`order_kernel` CTA, or fused into a main
+    kernel's CTA 0 prologue.  Internally CTA-wide-barriers; every thread of
+    the calling CTA must reach it."""
+    capacity = cutlass.const_expr(n_threads * order_elems)
+    if cutlass.const_expr(has_sched):
+        if tidx == 0:
+            si = cutlass.Int32(0)
+            while si < mSched.shape[0]:
+                mSched[si] = cutlass.Int32(0)
+                si = si + cutlass.Int32(1)
+    if cutlass.const_expr(gen):
+        n = n_tiles
+        if tidx == 0:
+            mCount[0] = n_tiles
+    else:
+        n = mCount[0]
+    if n > cutlass.Int32(capacity):
+        i = tidx
+        while i < n:
+            write_item(gen, b_t, n_heads_out, mCuSeqlens, mStaging, mWorkItems, i, i)
+            i = i + cutlass.Int32(n_threads)
+    else:
+        if tidx == 0:
+            sSpread[0] = cutlass.Int32(2147483647)
+            sSpread[1] = cutlass.Int32(-2147483648)
+        b_pad = cutlass.Int32(1)
+        while b_pad < n:
+            b_pad = b_pad * cutlass.Int32(2)
+        nvvm.barrier_cta_sync()
+        kmin = cutlass.Int32(2147483647)
+        kmax = cutlass.Int32(-2147483648)
+        for e in cutlass.range_constexpr(order_elems):
+            i = tidx + cutlass.Int32(e * n_threads)
+            if i < n:
+                if cutlass.const_expr(gen):
+                    batch_idx, head_idx, batch_start, batch_end, num_chunks_b = gen_item_bounds(b_t, n_heads_out, mCuSeqlens, i)
+                    key = num_chunks_b
+                else:
+                    key = mStaging[i, 5] - mStaging[i, 4]
+                sKey[i] = key
+                sIdx[i] = i
+                kmin = kmin if kmin < key else key
+                kmax = kmax if kmax > key else key
+            elif i < b_pad:
+                # pads sort to the end of the descending order
+                sKey[i] = cutlass.Int32(-2147483648)
+                sIdx[i] = i
+        nvvm.atomicrmw("min", sSpread.data_ptr(0), kmin, space=nvvm.SharedSpace.shared_cta)
+        nvvm.atomicrmw("max", sSpread.data_ptr(1), kmax, space=nvvm.SharedSpace.shared_cta)
+        nvvm.barrier_cta_sync()
+        if sSpread[0] == sSpread[1]:
+            # every key equal (uniform batches): copy through
+            i2 = tidx
+            while i2 < n:
+                write_item(gen, b_t, n_heads_out, mCuSeqlens, mStaging, mWorkItems, i2, i2)
+                i2 = i2 + cutlass.Int32(n_threads)
+        else:
+            k = cutlass.Int32(2)
+            while k <= b_pad:
+                j = k // cutlass.Int32(2)
+                while j > 0:
+                    for e in cutlass.range_constexpr(order_elems):
+                        i = tidx + cutlass.Int32(e * n_threads)
+                        if i < b_pad:
+                            l = i ^ j
+                            if l > i:
+                                ki = sKey[i]
+                                kl = sKey[l]
+                                up = (i // k) % cutlass.Int32(2) == 0
+                                dn = (i // k) % cutlass.Int32(2) == 1
+                                swap = (up and ki < kl) or (dn and ki > kl)
+                                if swap:
+                                    sKey[i] = kl
+                                    sKey[l] = ki
+                                    si = sIdx[i]
+                                    sIdx[i] = sIdx[l]
+                                    sIdx[l] = si
+                    nvvm.barrier_cta_sync()
+                    j = j // cutlass.Int32(2)
+                k = k * cutlass.Int32(2)
+            for e in cutlass.range_constexpr(order_elems):
+                i = tidx + cutlass.Int32(e * n_threads)
+                if i < n:
+                    src = sIdx[i]
+                    write_item(gen, b_t, n_heads_out, mCuSeqlens, mStaging, mWorkItems, i, src)
+
+
+@cute.jit
+def launch(
+    split: cutlass.Constexpr[bool],
+    b_t: cutlass.Constexpr[int],
+    log_gate: cutlass.Constexpr[bool],
+    safe_gate: cutlass.Constexpr[bool],
+    gate_channels: cutlass.Constexpr[int],
+    overhead_chunks: cutlass.Constexpr[int],
+    has_sched: cutlass.Constexpr[bool],
+    n_heads_out: cutlass.Int32,
+    n_tiles: cutlass.Int32,
+    num_sms: cutlass.Int32,
+    ideal_chunks: cutlass.Int32,
+    batch_size: cutlass.Int32,
+    log2_thresh: cutlass.Float32,
+    gate_scale_log2: cutlass.Float32,
+    mGate: cute.Tensor | None,
+    mALog: cute.Tensor | None,
+    mDtBias: cute.Tensor | None,
+    mCuSeqlens: cute.Tensor,
+    mChunkVals: cute.Tensor | None,
+    mStaging: cute.Tensor | None,
+    mWorkItems: cute.Tensor,
+    mCount: cute.Tensor,
+    mSched: cute.Tensor | None,
+    n_scan_ctas: cutlass.Int32,
+    n_walk_ctas: cutlass.Int32,
+    stream: cuda.CUstream,
+) -> None:
+    if cutlass.const_expr(split):
+        if cutlass.const_expr(gate_channels > 0):
+            scan_kernel(
+                b_t,
+                log_gate,
+                safe_gate,
+                gate_channels,
+                overhead_chunks,
+                n_heads_out,
+                n_tiles,
+                num_sms,
+                ideal_chunks,
+                batch_size,
+                gate_scale_log2,
+                mGate,
+                mALog,
+                mDtBias,
+                mCuSeqlens,
+                mChunkVals,
+                mCount,
+            ).launch(
+                grid=(n_scan_ctas, n_heads_out, 1),
+                block=(SCAN_THREADS, 1, 1),
+                stream=stream,
+            )
+        else:
+            scan_scalar_kernel(
+                b_t,
+                log_gate,
+                safe_gate,
+                overhead_chunks,
+                n_heads_out,
+                n_tiles,
+                num_sms,
+                ideal_chunks,
+                batch_size,
+                mGate,
+                mALog,
+                mDtBias,
+                mCuSeqlens,
+                mChunkVals,
+                mCount,
+            ).launch(
+                grid=(n_scan_ctas, (n_heads_out + cutlass.Int32(WARP_SIZE - 1)) // cutlass.Int32(WARP_SIZE), 1),
+                block=(SCAN_THREADS, 1, 1),
+                stream=stream,
+            )
+        walk_kernel(
+            b_t,
+            overhead_chunks,
+            n_heads_out,
+            n_tiles,
+            num_sms,
+            ideal_chunks,
+            log2_thresh,
+            mCuSeqlens,
+            mChunkVals,
+            mStaging,
+            mCount,
+        ).launch(
+            grid=(n_walk_ctas, 1, 1),
+            block=(THREADS_PER_BLOCK, 1, 1),
+            stream=stream,
+        )
+
+
+compiled_cache = {}
+
+
+class TableRecipe(NamedTuple):
+    """Build-time facts of one split-table launch: everything static is
+    settled once so :func:`run_table` can replay the call as a straight
+    line.  Produced by :func:`build_split_table`."""
+
+    compiled: object
+    split: bool
+    safe_gate: bool
+    n_heads_out: int
+    n_tiles: int
+    num_sms: int
+    ideal_chunks: int
+    batch_size: int
+    log2_threshold: float
+    gate_scale_log2: float
+    n_scan_ctas: int
+    n_walk_ctas: int
+    has_sched: bool
+
+
+def run_table(r, gate, a_log, dt_bias, cu_seqlens, chunk_scratch, item_scratch, work_items, work_count, sched_ctr, stream) -> None:
+    """The lowered split-table launch: no validation, no key build.  Only
+    buffers move between calls; every scalar comes from the recipe."""
+    r.compiled(
+        r.n_heads_out,
+        r.n_tiles,
+        r.num_sms,
+        r.ideal_chunks,
+        r.batch_size,
+        r.log2_threshold,
+        r.gate_scale_log2,
+        gate if r.split else None,
+        a_log if r.safe_gate else None,
+        dt_bias if r.safe_gate else None,
+        cu_seqlens,
+        chunk_scratch if r.split else None,
+        item_scratch if r.split else None,
+        work_items,
+        work_count,
+        sched_ctr if r.has_sched else None,
+        r.n_scan_ctas,
+        r.n_walk_ctas,
+        cuda.CUstream(int(stream)),
+    )
+
+
+def build_split_table(
+    gate,
+    cu_seqlens,
+    work_items,
+    work_count,
+    *,
+    ideal_chunks=None,
+    n_tiles,
+    num_sms,
+    b_t,
+    chunk_scratch=None,
+    item_scratch=None,
+    log2_threshold=None,
+    log_gate=False,
+    safe_gate=False,
+    a_log=None,
+    dt_bias=None,
+    gate_lower_bound=None,
+    sched_ctr=None,
+    split=True,
+    stream,
+) -> "TableRecipe":
+    """Fill ``work_items``/``work_count`` with the split-K partition of
+    ``gate`` / ``cu_seqlens (B+1,) int32``, LPT-ordered (longest item
+    first).  A 2-D ``(total_tokens, HO)`` gate is the scalar GDN kind; a
+    3-D ``(total_tokens, HO, DK)`` gate is the per-key-channel KDA / GDN-2
+    kind.  With ``log_gate`` the gate values are natural-log decay instead
+    of raw linear alpha.  With ``safe_gate`` the gate holds RAW logits and
+    the scan applies the matching transform so cuts land on true decay
+    values: per-channel (KDA / GDN-2, ``gate_lower_bound`` required)
+    ``gate_lower_bound * sigmoid(exp(a_log) * (g + dt_bias))`` per element;
+    scalar (GDN) ``-exp(a_log[h]) * softplus(g + dt_bias[h])`` per head.
+
+    With ``split=False`` the scan and walk never launch: the order kernel
+    alone synthesizes the no-cuts table — the uncut whole-sequence item per
+    (batch, head), LPT-sorted by sequence length — and ``ideal_chunks`` /
+    ``chunk_scratch`` / ``item_scratch`` / the gate contents are unused.
+    Batch-invariant mode and coarse checkpoint cadences (cuts may not cross
+    a checkpoint period) take this path.
+
+    ``work_items`` and ``item_scratch`` are ``(max_items,
+    WORK_ITEM_FIELDS)`` int32 with ``max_items >= max_work_items(...)``
+    (``>= n_tiles`` rows and no ``item_scratch`` with ``split=False``);
+    ``work_count`` is ``(1,)`` int32.  Every cell of ``sched_ctr`` when
+    passed — the main kernels' int32 ticket rings, ``(2,)`` per kernel
+    launch that consumes this table, dirty on exit — is zeroed by the
+    order kernel, which runs in both modes; the count is zeroed by the
+    scan (split) or written by the order kernel (non-split).
+    ``chunk_scratch`` is ``(>= chunk_scratch_rows(total_tokens,
+    B, b_t), HO)`` fp32 (contents managed here).  Runs entirely on device
+    — no host synchronization."""
+    if log2_threshold is None:
+        log2_threshold = DEFAULT_LOG2_THRESHOLD
+    if len(gate.shape) not in (2, 3):
+        raise ValueError(f"gate must be (total_tokens, HO) or (total_tokens, HO, DK), got {tuple(gate.shape)}")
+    gate_channels = gate.shape[2] if len(gate.shape) == 3 else 0
+    if gate_channels and gate.stride(2) != 1:
+        raise ValueError("per-channel gate channels must be contiguous")
+    if gate_channels and gate_channels % 128 == 0 and (
+        data_ptr(gate) % 16 != 0 or gate.stride(0) % 4 != 0 or gate.stride(1) % 4 != 0
+    ):
+        raise ValueError(
+            "per-channel gate rows and head slices must be 16-byte aligned "
+            "for vectorized scan loads"
+        )
+    if safe_gate and (a_log is None or dt_bias is None):
+        raise ValueError("safe_gate requires a_log and dt_bias")
+    if safe_gate and gate_channels > 0 and gate_lower_bound is None:
+        raise ValueError("per-channel safe_gate requires gate_lower_bound")
+    if not safe_gate:
+        a_log = None
+        dt_bias = None
+    gate_scale_log2 = float(gate_lower_bound) * RCP_LN2 if safe_gate and gate_channels > 0 else 0.0
+    n_heads_out = gate.shape[1]
+    batch_size = cu_seqlens.shape[0] - 1
+    expected_tiles = batch_size * n_heads_out
+    if n_tiles != expected_tiles:
+        raise ValueError(f"n_tiles must equal batch_size * n_heads_out ({expected_tiles}), got {n_tiles}")
+    if (
+        len(work_items.shape) != 2
+        or work_items.shape[1] != WORK_ITEM_FIELDS
+        or str(work_items.dtype) != "torch.int32"
+        or not work_items.is_contiguous()
+    ):
+        raise ValueError(
+            f"work_items must be contiguous int32 (rows, {WORK_ITEM_FIELDS}), "
+            f"got {tuple(work_items.shape)} {work_items.dtype}"
+        )
+    if (
+        tuple(work_count.shape) != (1,)
+        or str(work_count.dtype) != "torch.int32"
+        or not work_count.is_contiguous()
+    ):
+        raise ValueError("work_count must be contiguous int32 with shape (1,)")
+    device_index = tensor_device_index(cu_seqlens)
+    if current_device() != device_index:
+        raise ValueError("the active CUDA device must match cu_seqlens.device")
+    device_properties = get_device_properties(device_index)
+    if split:
+        if ideal_chunks is None or chunk_scratch is None or item_scratch is None:
+            raise ValueError("split=True requires ideal_chunks, chunk_scratch, and item_scratch")
+        if gate_channels and gate_channels % WARP_SIZE != 0:
+            raise ValueError(f"per-channel gate dim must be a multiple of {WARP_SIZE}, got {gate_channels}")
+        n_walk_ctas = batch_size * n_heads_out
+        need_rows = chunk_scratch_rows(gate.shape[0], batch_size, b_t)
+        n_scan_ctas = -(-need_rows // (SCAN_WARPS * SCAN_ROWS_PER_WARP))
+        if len(chunk_scratch.shape) != 2 or chunk_scratch.shape[0] < need_rows or chunk_scratch.shape[1] != n_heads_out:
+            raise ValueError(f"chunk_scratch must be (>= {need_rows}, {n_heads_out}) fp32, got {tuple(chunk_scratch.shape)}")
+        required_rows = max_work_items(
+            gate.shape[0], batch_size, n_heads_out, ideal_chunks, b_t, num_sms
+        )
+        if work_items.shape[0] < required_rows:
+            raise ValueError(
+                f"work_items requires at least {required_rows} rows for split=True, "
+                f"got {work_items.shape[0]}"
+            )
+        if (
+            tuple(item_scratch.shape) != tuple(work_items.shape)
+            or str(item_scratch.dtype) != "torch.int32"
+            or not item_scratch.is_contiguous()
+        ):
+            raise ValueError(
+                f"item_scratch must match work_items as contiguous int32, "
+                f"got {tuple(item_scratch.shape)} {item_scratch.dtype}"
+            )
+    else:
+        if work_items.shape[0] < n_tiles or work_items.shape[1] != WORK_ITEM_FIELDS:
+            raise ValueError(f"work_items must be (>= {n_tiles}, {WORK_ITEM_FIELDS}) int32, got {tuple(work_items.shape)}")
+        log_gate = False
+        safe_gate = False
+        gate_channels = 0
+        a_log = None
+        dt_bias = None
+        gate_scale_log2 = 0.0
+        gate = None
+        chunk_scratch = None
+        item_scratch = None
+        ideal_chunks = 0
+        n_scan_ctas = 0
+        n_walk_ctas = 0
+    overhead_chunks = max(1, OVERHEAD_TOKENS // b_t)
+    cu_stream = cuda.CUstream(int(stream))
+
+    key = (
+        device_index,
+        device_properties.major,
+        device_properties.minor,
+        bool(split),
+        b_t,
+        n_heads_out,
+        bool(log_gate),
+        bool(safe_gate),
+        gate_channels,
+        sched_ctr is not None,
+        str(cu_seqlens.dtype),
+    )
+    if key not in compiled_cache:
+
+        dt_bias_c = None
+        if safe_gate:
+            dt_bias_c = from_dlpack(dt_bias, assumed_align=4)
+            dt_bias_c.mark_compact_shape_dynamic(mode=0, stride_order=tuple(range(len(dt_bias.shape))), divisibility=1)
+        chunk_scratch_c = None
+        item_scratch_c = None
+        if split:
+            chunk_scratch_c = from_dlpack(chunk_scratch, assumed_align=4)
+            chunk_scratch_c.mark_compact_shape_dynamic(mode=0, stride_order=(0, 1), divisibility=1)
+            item_scratch_c = from_dlpack(item_scratch, assumed_align=4)
+            item_scratch_c.mark_compact_shape_dynamic(mode=0, stride_order=(0, 1), divisibility=1)
+        work_items_c = from_dlpack(work_items, assumed_align=4)
+        work_items_c.mark_compact_shape_dynamic(mode=0, stride_order=(0, 1), divisibility=1)
+        work_count_c = from_dlpack(work_count, assumed_align=4)
+        work_count_c.mark_compact_shape_dynamic(mode=0, stride_order=(0,), divisibility=1)
+        compiled_cache[key] = cute.compile(
+            launch,
+            bool(split),
+            b_t,
+            bool(log_gate),
+            bool(safe_gate),
+            gate_channels,
+            overhead_chunks,
+            sched_ctr is not None,
+            cutlass.Int32(n_heads_out),
+            cutlass.Int32(n_tiles),
+            cutlass.Int32(num_sms),
+            cutlass.Int32(ideal_chunks),
+            cutlass.Int32(batch_size),
+            cutlass.Float32(log2_threshold),
+            cutlass.Float32(gate_scale_log2),
+            from_dlpack(gate, assumed_align=4).mark_layout_dynamic(leading_dim=len(gate.shape) - 1) if split else None,
+            from_dlpack(a_log, assumed_align=4).mark_layout_dynamic() if safe_gate else None,
+            dt_bias_c,
+            from_dlpack(cu_seqlens, assumed_align=4).mark_layout_dynamic(),
+            chunk_scratch_c,
+            item_scratch_c,
+            work_items_c,
+            work_count_c,
+            from_dlpack(sched_ctr, assumed_align=4).mark_layout_dynamic() if sched_ctr is not None else None,
+            cutlass.Int32(n_scan_ctas),
+            cutlass.Int32(n_walk_ctas),
+            cu_stream,
+            options="--enable-tvm-ffi",
+        )
+    compiled_cache[key](
+        n_heads_out,
+        n_tiles,
+        num_sms,
+        ideal_chunks,
+        batch_size,
+        float(log2_threshold),
+        float(gate_scale_log2),
+        gate,
+        a_log,
+        dt_bias,
+        cu_seqlens,
+        chunk_scratch,
+        item_scratch,
+        work_items,
+        work_count,
+        sched_ctr,
+        n_scan_ctas,
+        n_walk_ctas,
+        cu_stream,
+    )
+    return TableRecipe(
+        compiled_cache[key],
+        bool(split),
+        bool(safe_gate),
+        n_heads_out,
+        n_tiles,
+        num_sms,
+        int(ideal_chunks),
+        batch_size,
+        float(log2_threshold),
+        float(gate_scale_log2),
+        n_scan_ctas,
+        n_walk_ctas,
+        sched_ctr is not None,
+    )

--- a/attn_gym/linear/_delta_rule/mega/kernels/common/thd.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/common/thd.py
@@ -1,0 +1,166 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared THD / varlen (packed ``[T,H,D]`` + ``cu_seqlens``) device helpers.
+
+* :data:`TENSOR_MAP_QWORDS` — int64 words per 128-byte TMA descriptor.
+* :func:`emit_seq_load_descs` — per-sequence input descriptors that keep the
+  original packed allocation map at the physical token endpoint.
+* :func:`emit_seq_descs` — device helper (one electing thread) that builds
+  a per-BATCH TMA-descriptor array in GMEM for varlen loads/stores over a
+  packed ``[T,H,D]`` tensor whose head axis is a load coordinate.  Each op
+  calls it from a single ``prologue_kernel`` launch (one
+  warp per array).
+* :func:`emit_checkpoint_seq_descs` — its per-chunk-checkpoint sibling; derives the
+  per-sequence checkpoint offsets from the token ``cu_seqlens`` in place of a
+  caller-computed prefix array.
+"""
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.experimental.primitives as nvvm
+from cutlass.base_dsl.typing import Pointer
+
+TENSOR_MAP_QWORDS = 128 // 8
+
+
+@cute.jit
+def emit_seq_load_descs(
+    base_desc,
+    desc_words,
+    cu_seqlens,
+    base_ptr,
+    n_batch: cutlass.Int32,
+    row_stride: cutlass.Int32,
+    seq_ord: cutlass.Constexpr[int],
+) -> None:
+    """Build sequence-relative input maps except at the physical token endpoint.
+
+    Interior maps retain per-sequence bounds so partial tail tiles zero-fill rather
+    than reading the next sequence. Maps ending at the packed-token endpoint keep the
+    original allocation base and use that endpoint as their bound, avoiding a
+    relocated short map whose last TMA tile can overfetch beyond the allocation.
+    """
+    desc_base = desc_words.iterator.raw_ptr()
+    src_words = Pointer(base_desc.get_ptr(), dtype=cutlass.Int64)
+    cu = cutlass.make_array_view(cu_seqlens)
+    base = base_ptr.iterator.raw_ptr()
+    packed_tokens = cutlass.Int32(cu[n_batch])
+    for b in cutlass.range(0, n_batch, 1, unroll=1):
+        cu_b = cutlass.Int32(cu[b])
+        cu_next = cutlass.Int32(cu[b + cutlass.Int32(1)])
+        s_b = cu_next - cu_b
+        dptr = desc_base + b * cutlass.Int32(TENSOR_MAP_QWORDS)
+        for i in cutlass.range_constexpr(TENSOR_MAP_QWORDS):
+            (dptr + i).store((src_words + i).load())
+        if cu_next == packed_tokens:
+            nvvm.tensormap_replace(
+                nvvm.TensormapField.GLOBAL_DIM,
+                dptr,
+                new_value=packed_tokens,
+                ord=seq_ord,
+            )
+        else:
+            addr = base + cutlass.Int64(cu_b) * cutlass.Int64(row_stride)
+            nvvm.tensormap_replace(
+                nvvm.TensormapField.GLOBAL_ADDRESS,
+                dptr,
+                new_value=addr.toint(cutlass.Int64),
+            )
+            nvvm.tensormap_replace(
+                nvvm.TensormapField.GLOBAL_DIM,
+                dptr,
+                new_value=s_b,
+                ord=seq_ord,
+            )
+
+
+@cute.jit
+def emit_seq_descs(
+    base_desc,
+    desc_words,
+    cu_seqlens,
+    base_ptr,
+    n_batch: cutlass.Int32,
+    row_stride: cutlass.Int32,
+    seq_ord: cutlass.Constexpr[int],
+) -> None:
+    """Per-BATCH TMA-descriptor array for a VARLEN (THD) tensor whose base
+    descriptor carries the head axis as a real dimension (``(d, head,
+    token)``); the head index is a load COORDINATE, so only the sequence
+    base and length are patched per slot.  GLOBAL_ADDRESS folds
+    ``cu_seqlens[b] * row_stride`` (Int64); GLOBAL_DIM[``seq_ord``] is
+    capped to the per-sequence token count so tail loads zero-fill and tail
+    stores clip in hardware.  GQA/GVA head grouping happens at the issue
+    site (``head_idx // group`` with a static group), not here.  Runs on
+    one electing thread; the calling warp elects and release-fences
+    (GENERIC->TENSORMAP)."""
+    desc_base = desc_words.iterator.raw_ptr()
+    src_words = Pointer(base_desc.get_ptr(), dtype=cutlass.Int64)
+    cu = cutlass.make_array_view(cu_seqlens)
+    base = base_ptr.iterator.raw_ptr()
+    for b in cutlass.range(0, n_batch, 1, unroll=1):
+        cu_b = cutlass.Int32(cu[b])
+        s_b = cutlass.Int32(cu[b + cutlass.Int32(1)]) - cu_b
+        dptr = desc_base + b * cutlass.Int32(TENSOR_MAP_QWORDS)
+        for i in cutlass.range_constexpr(TENSOR_MAP_QWORDS):
+            (dptr + i).store((src_words + i).load())
+        addr = base + cutlass.Int64(cu_b) * cutlass.Int64(row_stride)
+        nvvm.tensormap_replace(
+            nvvm.TensormapField.GLOBAL_ADDRESS,
+            dptr,
+            new_value=addr.toint(cutlass.Int64),
+        )
+        nvvm.tensormap_replace(
+            nvvm.TensormapField.GLOBAL_DIM,
+            dptr,
+            new_value=s_b,
+            ord=seq_ord,
+        )
+
+
+@cute.jit
+def emit_checkpoint_seq_descs(
+    base_desc,
+    desc_words,
+    cu_seqlens,
+    base_ptr,
+    n_batch: cutlass.Int32,
+    row_stride: cutlass.Int32,
+    every_n: cutlass.Int32,
+    seq_ord: cutlass.Constexpr[int],
+) -> None:
+    """Per-BATCH descriptor array for the per-chunk checkpoint tensor with the head
+    axis as a descriptor dimension (``(dv, dk, chunk, head)``).  Derives the
+    per-sequence checkpoint offsets from the TOKEN ``cu_seqlens`` on the fly
+    (``count_b = (seqlen_b - 1) // every_n + 1``, running-prefix-summed) — an
+    address fold no coordinate transform can express — and caps
+    GLOBAL_DIM[``seq_ord``] to ``count_b``.  The head index is a load
+    coordinate.  Runs on one electing thread; the calling warp elects and
+    fences."""
+    desc_base = desc_words.iterator.raw_ptr()
+    src_words = Pointer(base_desc.get_ptr(), dtype=cutlass.Int64)
+    cu = cutlass.make_array_view(cu_seqlens)
+    base = base_ptr.iterator.raw_ptr()
+    run = cutlass.Int32(0)
+    for b in cutlass.range(0, n_batch, 1, unroll=1):
+        s_tok = cutlass.Int32(cu[b + cutlass.Int32(1)]) - cutlass.Int32(cu[b])
+        cnt = (s_tok - cutlass.Int32(1)) // every_n + cutlass.Int32(1)
+        cnt = cnt if s_tok > 0 else cutlass.Int32(0)
+        checkpoint_base = run
+        run = run + cnt
+        dptr = desc_base + b * cutlass.Int32(TENSOR_MAP_QWORDS)
+        for i in cutlass.range_constexpr(TENSOR_MAP_QWORDS):
+            (dptr + i).store((src_words + i).load())
+        addr = base + cutlass.Int64(checkpoint_base) * cutlass.Int64(row_stride)
+        nvvm.tensormap_replace(
+            nvvm.TensormapField.GLOBAL_ADDRESS,
+            dptr,
+            new_value=addr.toint(cutlass.Int64),
+        )
+        nvvm.tensormap_replace(
+            nvvm.TensormapField.GLOBAL_DIM,
+            dptr,
+            new_value=cnt,
+            ord=seq_ord,
+        )

--- a/attn_gym/linear/_delta_rule/mega/kernels/compat.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/compat.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Torch host utilities for the experimental CuTeDSL 4.7 KDA backend."""
+
+from __future__ import annotations
+
+from functools import cache
+
+import torch
+
+
+def data_ptr(buffer: torch.Tensor) -> int:
+    """Return a Torch tensor's CUDA address."""
+    return buffer.data_ptr()
+
+
+def current_device() -> int:
+    """Return the active CUDA device ordinal."""
+    return torch.cuda.current_device()
+
+
+def tensor_device_index(tensor: torch.Tensor) -> int:
+    """Return a CUDA tensor's explicit device ordinal."""
+    return current_device() if tensor.device.index is None else tensor.device.index
+
+
+@cache
+def get_device_properties(device: int):
+    """Return cached CUDA properties for a device ordinal."""
+    return torch.cuda.get_device_properties(device)
+
+
+def multiprocessor_count(device: int) -> int:
+    """Return the cached number of SMs on a CUDA device."""
+    return get_device_properties(device).multi_processor_count
+
+
+def checkpoint_capacity_bound(tokens: int, num_sequences: int, interval: int) -> int:
+    """Return the graph-safe checkpoint-row bound for packed sequences."""
+    nonempty = min(tokens, num_sequences)
+    return 0 if nonempty == 0 else nonempty + (tokens - nonempty) // interval
+
+
+def validate_tma_tensor(name: str, tensor: torch.Tensor, *, alignment: int = 16) -> None:
+    """Reject layouts that cannot be represented by the current int32 TMA ABI."""
+    if tensor.data_ptr() % alignment:
+        raise ValueError(f"{name} data pointer must be {alignment}-byte aligned")
+    if tensor.stride(-1) != 1:
+        raise ValueError(f"{name} innermost stride must be one")
+    element_bytes = tensor.element_size()
+    for stride in tensor.stride()[:-1]:
+        if stride < 0 or stride > 2**31 - 1:
+            raise ValueError(f"{name} outer strides must fit nonnegative int32")
+        if stride * element_bytes % 16:
+            raise ValueError(f"{name} outer byte strides must be multiples of 16")

--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_bprop_config.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_bprop_config.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# This kernel is derived from cuDNN, NVIDIA Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Kimi Delta Attention (KDA) Cutlass DSL backward kernel config (fixed
+compile-time constants).  The BT=16 backward mirrors the prefill's 16-warp
+(512-thread) specialization; the derived SMEM/TMEM sizes and offsets are
+stamped by ``build_cfg`` in ``kda_bprop_f16.py``.
+
+Target arch: Blackwell SM100 (GB200) / SM103 (GB300).
+"""
+
+from dataclasses import dataclass
+from typing import Tuple
+
+
+@dataclass(frozen=True)
+class Cfg:
+    # --- tile shape ---
+    B_T: int = 16  # chunk-inner token tile (BT=16 KDA schedule)
+    D_K: int = 128  # query/key head dim
+    D_V: int = 128  # value head dim
+
+    # --- warp assignments (16 warps = 512 threads) ---
+    COMPUTE_GROUP_0_WARP_IDS: Tuple[int, ...] = (0, 1, 2, 3)  # forward gate cumsum + decay-operand materialize
+    COMPUTE_GROUP_1_WARP_IDS: Tuple[int, ...] = (4, 5, 6, 7)  # value-side TMEM staging / restages / dH capture
+    COMPUTE_GROUP_2_WARP_IDS: Tuple[int, ...] = (8, 9, 10, 11)  # dq/dk-bank drain, dG assembly + reverse cumsum
+    SUPER_MMA_WARP_ID: int = 12  # register-MMA KK/A/dA/dM + Neumann T_inv
+    TCGEN05_MMA_WARP_ID: int = 13  # tcgen05 GEMM schedule
+    TMA_WARP_ID: int = 14  # q/k/v/gate/do/S(H) TMA loads
+    EPILOGUE_WARP_ID: int = 15  # dQ/dK/dV/dGate TMA stores
+
+    # --- register split ---
+    NUM_REGS_COMPUTE_GROUP_0: int = 144
+    NUM_REGS_COMPUTE_GROUP_1: int = 168
+    NUM_REGS_COMPUTE_GROUP_2: int = 144
+    NUM_REGS_OTHER: int = 56
+
+    THREADS_PER_WARP: int = 32
+
+    BUFFER_ALIGN_BYTES: int = 1024
+
+    # --- SMEM / TMEM ring stage counts ---
+    SMEM_RAW_STAGES: int = 2
+    SMEM_S_STAGES: int = 1
+    SMEM_DECAY_STAGES: int = 2
+    SMEM_INTERMEDIATE_STAGES: int = 2
+    SMEM_STATE_SCALE_DIAG_STAGES: int = 2
+    SMEM_DQ_STAGES: int = 1
+    SMEM_DK_STAGES: int = 1
+    SMEM_DGATE_STAGES: int = 1
+    SMEM_DV_STAGES: int = 2
+
+    CLUSTER_SHAPE_MNK: Tuple[int, int, int] = (1, 1, 1)
+
+
+CFG = Cfg()

--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_bprop_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_bprop_f16.py
@@ -1,0 +1,4307 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# This kernel is derived from cuDNN, NVIDIA Corporation.
+# Modified by Attention Gym in 2026: imports were relocated into this package.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Chunked Kimi Delta Attention (KDA) BPROP kernel for Blackwell SM100/SM103
+(Cutlass DSL), BT=16 tiling with a per-key-channel decay.  Framework-neutral
+entry ``chunk_kda_bwd_sm100``.
+
+Algorithm overview (per chunk c, iterated c = NT-1 .. 0; within-chunk
+log2-domain gate cumsum G[t,d], eG = 2^G, eGl = 2^G[BT-1]):
+  Inputs : Q/K[BT,DK], V/dO[BT,DV], S = state_checkpoints[c] (state ENTERING chunk c, KV),
+           Gate[BT,DK], Beta[BT]
+  State  : dH[DV,DK] (state gradient, fp32 TMEM, accumulated backward)
+
+  Operands (WG0, prefill recompute): K_decay = eG.K, K_inv = K/eG,
+  K_restore = (eGl/eG).K, Q_decay = eG.Q, diag(eGl).
+
+  Forward recompute: A_kk = K_decay@K_inv^T; T_inv = (I + Beta.tril(A_kk,-1))^-1
+  (register Neumann); A = tril_incl(Q_decay@K_inv^T); Y = Beta.(V - S^T K_decay);
+  U = T_inv@Y.
+
+  Backward math:
+  dU  = K_restore@dH + A^T@dO (Q_decay carries scale, so A does too)
+  dY  = T_inv^T@dU                    dV = Beta.dY
+  dA  = tril_incl(dO@U^T) (unscaled)  dM = dY@U^T        dM_strict = Beta_row.strict(dM)
+  dQ  = eG.scale.(dO@S^T + dA@K_inv)
+  dK  = eG.dK_decay + dK_inv/eG + (eGl/eG).dK_restore  where (sign-flipped parts)
+        dK_decay part = (Beta.dY)@S^T + dM_strict@K_inv   (= -dK_decay)
+        dK_inv part = dA^T@(scale.Q_decay) - dM_strict^T@K_decay   (= dK_inv; one TMEM
+                acc, the minus rides the staged -dM_strict tile)
+        dK_restore part = U@dH^T                     (= +dK_restore)
+  dBeta = sum_v dY.Y / Beta - sum_{j<i} dM.tril(A_kk,-1)
+  dGate[t,d] = Q_n.dQ_pre + K_n.(-eG.dK_decay_part + dK_inv_part/eG
+            - (eGl/eG).dK_restore_part)
+  dGate_last[d] = eGl.sum_v(dH.S) + sum_t K_n.(eGl/eG).dK_restore_part
+  dGate = suffix-sum(dGate + dGate_last at row BT-1) (WG2 in-register reverse cumsum)
+  dH <- diag-GEMM(eGl).dH + (scale.Q_decay)^T@dO - K_decay^T@(Beta.dY)
+
+ABI: state_checkpoints `[total_checkpoints, HO, DV, DK]` (VK, k contiguous) io
+dtype, the plain per-chunk checkpoint series (entry `c` = state entering chunk
+c, so row 0 is the initial state or zeros); dq/dk/dv io at HO heads; dgate `[T, HO, DK]` fp32
+(natural-log gate domain; with SAFE_GATE the gradient stays wrt the
+transformed log-decay); dbeta `[T, HO]` fp32, io dtype with BETA_SIGMOID
+(post-sigmoid space, or wrt the raw logits under BETA_SIGMOID).  Gate
+arrives natural-log fp32 unless SAFE_GATE (safe-gate transform from raw gate
++ a_log/dt_bias); beta arrives post-sigmoid fp32, or io-dtype logits with
+BETA_SIGMOID; d_initial_state / d_final_state fp32 `[N, HO, DV, DK]`
+(V-major).
+
+Warp assignments (16 warps = 512 threads):
+  warps 0-3  : WG0 - Gate prefix scan + decay/restore operands (all chunks) + Beta scalar gather
+  warps 4-7  : WG1 - value-side TMEM staging, dstate capture, dBeta
+  warps 8-11 : WG2 - dQ/dK part drain, dGate assembly, reverse cumsum, dGate
+  warp  12   : super-MMA - register KK/A/dA/dM + Neumann inverse
+  warp  13   : tcgen05-MMA - the 15-GEMM backward schedule
+  warp  14   : TMA load - Q/K/V/Gate/dO/entering-state loads
+  warp  15   : epilogue - dQ/dK/dV/dGate TMA stores
+"""
+
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import NamedTuple, Type
+
+import cuda.bindings.driver as cuda_driver
+import cutlass
+import cutlass.experimental.cuda as cuda
+import cutlass.experimental.primitives as nvvm
+import cutlass.cute as cute
+from cutlass.cute.runtime import from_dlpack
+
+from attn_gym.linear._delta_rule.mega.kernels.common.split_k import ORDER_CAPACITY, ORDER_ELEMS, ORDER_THREADS, decode_work_item, order_body
+from attn_gym.linear._delta_rule.mega.kernels.common.host import get_dtype
+from attn_gym.linear._delta_rule.mega.kernels.compat import (
+    checkpoint_capacity_bound,
+    current_device,
+    get_device_properties,
+    tensor_device_index,
+    validate_tma_tensor,
+)
+from attn_gym.linear._delta_rule.mega.kernels.common.thd import (
+    TENSOR_MAP_QWORDS,
+    emit_checkpoint_seq_descs,
+    emit_seq_descs,
+    emit_seq_load_descs,
+)
+from .kda_bprop_config import CFG
+
+from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.barrier import (
+    advance,
+    MBarrier,
+    PipelineState,
+    Producer,
+)
+from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.handles import MmaDesc, SmemTile, tma_slice_runtime_desc
+from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.mma import mma_ss, mma_step, mma_ts_step
+from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.swizzle import swizzle_lin_S, swizzle_xor_128b
+from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.tma import tma_load_tile, tma_store_commit, tma_store_tile, tma_store_wait, tma_tensormap_acquire
+from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.pointwise import (
+    f16x2_to_f32,
+    fadd2,
+    ffma2,
+    fmul2,
+    fp32_to_fp16,
+    movmatrix_16b,
+    mul_f16x2,
+    opaque_f32_zero,
+    sub_f16x2,
+)
+
+LOG2_E: float = 1.4426950408889634
+
+
+DEFAULT_GATE_LOWER_BOUND: float = -5.0
+
+
+L2_NORM_EPS: float = 1.0e-12
+
+
+class KdaBwdBars(NamedTuple):
+    """Every inter-warp handoff as an ``MBarrier`` over its ring.  Consumers
+    track ``(idx, phase)`` inline; the producer tag selects the arrive
+    lowering (``TMA_LOAD``/``MMA_COMMIT``/``THREAD``).
+
+    Buffers read by both the MMA warp and a compute/warp group carry mixed
+    arrive counts (one MMA commit + N thread arrivers) so the producer only
+    reuses the slot once every reader is done."""
+
+    mb_q_ready: MBarrier
+    mb_q_done: MBarrier
+    mb_k_ready: MBarrier
+    mb_k_done: MBarrier
+    mb_gate_ready: MBarrier
+    mb_gate_done: MBarrier
+    mb_do_ready: MBarrier
+    mb_do_done: MBarrier
+    mb_v_ready: MBarrier
+    mb_v_done: MBarrier
+    mb_state_ready: MBarrier
+    mb_state_done: MBarrier
+    mb_state_cg0_done: MBarrier
+
+    mb_beta_ready: MBarrier
+    mb_beta_done: MBarrier
+
+    mb_state_k_acc_ready: MBarrier
+    mb_du_acc_ready: MBarrier
+    mb_u_acc_ready: MBarrier
+    mb_dy_acc_ready: MBarrier
+    mb_dq_acc_ready: MBarrier
+    mb_dk_decay_part_acc_ready: MBarrier
+    mb_dk_inv_part_acc_ready: MBarrier
+    mb_dk_restore_part_acc_ready: MBarrier
+    mb_dqk_acc_done: MBarrier
+
+    mb_qk_raw_ready: MBarrier
+    mb_qk_raw_done: MBarrier
+    mb_state_inp_ready: MBarrier
+    mb_state_inp_done: MBarrier
+    mb_state_inp_cg2_done: MBarrier
+    mb_y_inp_ready: MBarrier
+    mb_du_inp_ready: MBarrier
+    mb_neg_beta_dy_inp_ready: MBarrier
+
+    mb_k_decay_inv_ready: MBarrier
+    mb_q_decay_k_restore_ready: MBarrier
+    mb_decay_done: MBarrier
+    mb_t_inv_ready: MBarrier
+    mb_t_inv_done: MBarrier
+    mb_a_ready: MBarrier
+    mb_a_done: MBarrier
+    mb_da_ready: MBarrier
+    mb_da_done: MBarrier
+    mb_dm_ready: MBarrier
+    mb_dm_done: MBarrier
+    mb_u_smem_ready: MBarrier
+    mb_dy_smem_ready: MBarrier
+    mb_dbeta_m_ready: MBarrier
+
+    mb_dstate_acc_ready: MBarrier
+    mb_dstate_inp_ready: MBarrier
+    mb_dstate_smem_ready: MBarrier
+    mb_dstate_smem_done: MBarrier
+    mb_dstate_smem_cg2_done: MBarrier
+
+    mb_dq_tmastg_ready: MBarrier
+    mb_dq_tmastg_done: MBarrier
+    mb_dk_tmastg_ready: MBarrier
+    mb_dk_tmastg_done: MBarrier
+    mb_dv_tmastg_ready: MBarrier
+    mb_dv_tmastg_done: MBarrier
+    mb_dgate_tmastg_ready: MBarrier
+    mb_dgate_tmastg_done: MBarrier
+
+    mb_dstate0_acc_stored: MBarrier
+    mb_tmem_done: MBarrier
+
+    mb_sched_ready: MBarrier
+    mb_sched_done: MBarrier
+
+
+def make_kda_bwd_bars(cfg) -> KdaBwdBars:
+    """Bars factory.  MUST be called from inside ``kernel`` (allocates the
+    mbarrier rings in SMEM ahead of the data buffers)."""
+
+    def alloc(n):
+        return cutlass.Array(cutlass.Int64, n, space=cutlass.AddressSpace.smem, alignment=8)
+
+    WARP = cfg.threads_per_warp
+    CG0 = len(cfg.compute_group_0_warp_ids) * WARP
+    CG2 = len(cfg.compute_group_2_warp_ids) * WARP
+    CG1 = len(cfg.compute_group_1_warp_ids) * WARP
+    SCHED_CONSUMER_WARPS = cfg.threads_per_cta // WARP - 1
+    MMA = 1
+
+    return KdaBwdBars(
+        mb_q_ready=MBarrier(alloc(cfg.smem_raw_stages), stages=cfg.smem_raw_stages, init_count=1, producer=Producer.TMA_LOAD),
+        mb_q_done=MBarrier(alloc(cfg.smem_raw_stages), stages=cfg.smem_raw_stages, init_count=CG0, producer=Producer.THREAD),
+        mb_k_ready=MBarrier(alloc(cfg.smem_raw_stages), stages=cfg.smem_raw_stages, init_count=1, producer=Producer.TMA_LOAD),
+        mb_k_done=MBarrier(alloc(cfg.smem_raw_stages), stages=cfg.smem_raw_stages, init_count=CG0, producer=Producer.THREAD),
+        mb_gate_ready=MBarrier(alloc(cfg.smem_raw_stages), stages=cfg.smem_raw_stages, init_count=1, producer=Producer.TMA_LOAD),
+        mb_gate_done=MBarrier(alloc(cfg.smem_raw_stages), stages=cfg.smem_raw_stages, init_count=CG0 + CG2, producer=Producer.THREAD),
+        mb_do_ready=MBarrier(alloc(cfg.smem_raw_stages), stages=cfg.smem_raw_stages, init_count=1, producer=Producer.TMA_LOAD),
+        mb_do_done=MBarrier(alloc(cfg.smem_raw_stages), stages=cfg.smem_raw_stages, init_count=WARP, producer=Producer.THREAD),
+        mb_v_ready=MBarrier(alloc(cfg.smem_raw_stages), stages=cfg.smem_raw_stages, init_count=1, producer=Producer.TMA_LOAD),
+        mb_v_done=MBarrier(alloc(cfg.smem_raw_stages), stages=cfg.smem_raw_stages, init_count=CG1, producer=Producer.THREAD),
+        mb_state_ready=MBarrier(alloc(cfg.smem_state_stages), stages=cfg.smem_state_stages, init_count=1, producer=Producer.TMA_LOAD),
+        mb_state_done=MBarrier(alloc(cfg.smem_state_stages), stages=cfg.smem_state_stages, init_count=MMA, producer=Producer.MMA_COMMIT),
+        mb_state_cg0_done=MBarrier(alloc(cfg.smem_state_stages), stages=cfg.smem_state_stages, init_count=CG0, producer=Producer.THREAD),
+        mb_beta_ready=MBarrier(alloc(cfg.smem_beta_stages), stages=cfg.smem_beta_stages, init_count=WARP, producer=Producer.THREAD),
+        mb_beta_done=MBarrier(alloc(cfg.smem_beta_stages), stages=cfg.smem_beta_stages, init_count=WARP + CG1, producer=Producer.THREAD),
+        mb_state_k_acc_ready=MBarrier(alloc(1), stages=1, init_count=MMA, producer=Producer.MMA_COMMIT),
+        mb_du_acc_ready=MBarrier(alloc(1), stages=1, init_count=MMA, producer=Producer.MMA_COMMIT),
+        mb_u_acc_ready=MBarrier(alloc(1), stages=1, init_count=MMA, producer=Producer.MMA_COMMIT),
+        mb_dy_acc_ready=MBarrier(alloc(1), stages=1, init_count=MMA, producer=Producer.MMA_COMMIT),
+        mb_dq_acc_ready=MBarrier(alloc(1), stages=1, init_count=MMA, producer=Producer.MMA_COMMIT),
+        mb_dk_decay_part_acc_ready=MBarrier(alloc(1), stages=1, init_count=MMA, producer=Producer.MMA_COMMIT),
+        mb_dk_inv_part_acc_ready=MBarrier(alloc(1), stages=1, init_count=MMA, producer=Producer.MMA_COMMIT),
+        mb_dk_restore_part_acc_ready=MBarrier(alloc(1), stages=1, init_count=MMA, producer=Producer.MMA_COMMIT),
+        mb_dqk_acc_done=MBarrier(alloc(1), stages=1, init_count=CG2, producer=Producer.THREAD),
+        mb_qk_raw_ready=MBarrier(alloc(cfg.tmem_qk_raw_stages), stages=cfg.tmem_qk_raw_stages, init_count=CG0, producer=Producer.THREAD),
+        mb_qk_raw_done=MBarrier(alloc(cfg.tmem_qk_raw_stages), stages=cfg.tmem_qk_raw_stages, init_count=CG2, producer=Producer.THREAD),
+        mb_state_inp_ready=MBarrier(alloc(2), stages=2, init_count=CG0, producer=Producer.THREAD),
+        mb_state_inp_done=MBarrier(alloc(2), stages=2, init_count=MMA, producer=Producer.MMA_COMMIT),
+        mb_state_inp_cg2_done=MBarrier(alloc(2), stages=2, init_count=CG2, producer=Producer.THREAD),
+        mb_y_inp_ready=MBarrier(alloc(1), stages=1, init_count=CG1, producer=Producer.THREAD),
+        mb_du_inp_ready=MBarrier(alloc(1), stages=1, init_count=CG1, producer=Producer.THREAD),
+        mb_neg_beta_dy_inp_ready=MBarrier(alloc(1), stages=1, init_count=CG1, producer=Producer.THREAD),
+        mb_k_decay_inv_ready=MBarrier(alloc(cfg.smem_decay_stages), stages=cfg.smem_decay_stages, init_count=CG0, producer=Producer.THREAD),
+        mb_q_decay_k_restore_ready=MBarrier(alloc(cfg.smem_decay_stages), stages=cfg.smem_decay_stages, init_count=CG0, producer=Producer.THREAD),
+        mb_decay_done=MBarrier(alloc(cfg.smem_decay_stages), stages=cfg.smem_decay_stages, init_count=MMA, producer=Producer.MMA_COMMIT),
+        mb_t_inv_ready=MBarrier(alloc(cfg.smem_intermediate_stages), stages=cfg.smem_intermediate_stages, init_count=WARP, producer=Producer.THREAD),
+        mb_t_inv_done=MBarrier(alloc(cfg.smem_intermediate_stages), stages=cfg.smem_intermediate_stages, init_count=MMA, producer=Producer.MMA_COMMIT),
+        mb_a_ready=MBarrier(alloc(cfg.smem_intermediate_stages), stages=cfg.smem_intermediate_stages, init_count=WARP, producer=Producer.THREAD),
+        mb_a_done=MBarrier(alloc(cfg.smem_intermediate_stages), stages=cfg.smem_intermediate_stages, init_count=MMA, producer=Producer.MMA_COMMIT),
+        mb_da_ready=MBarrier(alloc(cfg.smem_intermediate_stages), stages=cfg.smem_intermediate_stages, init_count=WARP, producer=Producer.THREAD),
+        mb_da_done=MBarrier(alloc(cfg.smem_intermediate_stages), stages=cfg.smem_intermediate_stages, init_count=MMA, producer=Producer.MMA_COMMIT),
+        mb_dm_ready=MBarrier(alloc(cfg.smem_intermediate_stages), stages=cfg.smem_intermediate_stages, init_count=WARP, producer=Producer.THREAD),
+        mb_dm_done=MBarrier(alloc(cfg.smem_intermediate_stages), stages=cfg.smem_intermediate_stages, init_count=MMA, producer=Producer.MMA_COMMIT),
+        mb_u_smem_ready=MBarrier(alloc(1), stages=1, init_count=CG1, producer=Producer.THREAD),
+        mb_dy_smem_ready=MBarrier(alloc(1), stages=1, init_count=CG1, producer=Producer.THREAD),
+        mb_dbeta_m_ready=MBarrier(alloc(1), stages=1, init_count=WARP, producer=Producer.THREAD),
+        mb_dstate_acc_ready=MBarrier(alloc(1), stages=1, init_count=MMA, producer=Producer.MMA_COMMIT),
+        mb_dstate_inp_ready=MBarrier(alloc(1), stages=1, init_count=CG1, producer=Producer.THREAD),
+        mb_dstate_smem_ready=MBarrier(alloc(1), stages=1, init_count=CG1, producer=Producer.THREAD),
+        mb_dstate_smem_done=MBarrier(alloc(1), stages=1, init_count=MMA, producer=Producer.MMA_COMMIT),
+        mb_dstate_smem_cg2_done=MBarrier(alloc(1), stages=1, init_count=CG2, producer=Producer.THREAD),
+        mb_dq_tmastg_ready=MBarrier(alloc(cfg.smem_dq_stages), stages=cfg.smem_dq_stages, init_count=CG2, producer=Producer.THREAD),
+        mb_dq_tmastg_done=MBarrier(alloc(cfg.smem_dq_stages), stages=cfg.smem_dq_stages, init_count=WARP, producer=Producer.THREAD),
+        mb_dk_tmastg_ready=MBarrier(alloc(cfg.smem_dk_stages), stages=cfg.smem_dk_stages, init_count=CG2, producer=Producer.THREAD),
+        mb_dk_tmastg_done=MBarrier(alloc(cfg.smem_dk_stages), stages=cfg.smem_dk_stages, init_count=WARP, producer=Producer.THREAD),
+        mb_dv_tmastg_ready=MBarrier(alloc(cfg.smem_dv_stages), stages=cfg.smem_dv_stages, init_count=CG1, producer=Producer.THREAD),
+        mb_dv_tmastg_done=MBarrier(alloc(cfg.smem_dv_stages), stages=cfg.smem_dv_stages, init_count=WARP, producer=Producer.THREAD),
+        mb_dgate_tmastg_ready=MBarrier(alloc(cfg.smem_dgate_stages), stages=cfg.smem_dgate_stages, init_count=CG2, producer=Producer.THREAD),
+        mb_dgate_tmastg_done=MBarrier(alloc(cfg.smem_dgate_stages), stages=cfg.smem_dgate_stages, init_count=WARP, producer=Producer.THREAD),
+        mb_dstate0_acc_stored=MBarrier(alloc(1), stages=1, init_count=CG1, producer=Producer.THREAD),
+        mb_tmem_done=MBarrier(alloc(1), stages=1, init_count=CG1 + CG2, producer=Producer.THREAD),
+        mb_sched_ready=MBarrier(alloc(cfg.sched_stages), stages=cfg.sched_stages, init_count=1, producer=Producer.THREAD),
+        mb_sched_done=MBarrier(
+            alloc(cfg.sched_stages),
+            stages=cfg.sched_stages,
+            init_count=SCHED_CONSUMER_WARPS,
+            producer=Producer.THREAD,
+        ),
+    )
+
+
+# ---- Dynamic tile scheduler ------------------------------------------------------
+
+
+@cute.jit
+def sched_publish_next(cfg, bars, sSched, mSched, sched_state, tile_idx, num_ctas):
+    """TMA-warp side: pull the next tile off the global ticket, publish it."""
+    if cutlass.const_expr(cfg.dyn_sched):
+        bars.mb_sched_done[sched_state.idx].wait(sched_state.phase)
+        if nvvm.elect_sync():
+            fetched = cutlass.Int32(nvvm.atomicrmw("add", mSched.iterator, cutlass.Int32(1), mem_order="relaxed", syncscope="gpu"))
+            sSched[sched_state.idx] = num_ctas + fetched
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+        next_tile = sSched[sched_state.idx]
+        if nvvm.elect_sync():
+            bars.mb_sched_ready[sched_state.idx].arrive()
+        return next_tile, advance(sched_state, cfg.sched_stages)
+    return tile_idx + num_ctas, sched_state
+
+
+@cute.jit
+def sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas):
+    """Consumer side: read the TMA warp's published next tile."""
+    if cutlass.const_expr(cfg.dyn_sched):
+        bars.mb_sched_ready[sched_state.idx].wait(sched_state.phase)
+        next_tile = sSched[sched_state.idx]
+        if nvvm.elect_sync():
+            bars.mb_sched_done[sched_state.idx].arrive()
+        return next_tile, advance(sched_state, cfg.sched_stages)
+    return tile_idx + num_ctas, sched_state
+
+
+# ---- Warp bodies -----------------------------------------------------------------
+
+
+@cute.jit
+def epilogue_warp(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    cu_seqlens,
+    mWorkItems,
+    sSched,
+    lane,
+    sK_inv_raw,
+    sQ_decay_raw,
+    sDo_raw,
+    sU_raw,
+    sIntermediate_raw,
+    sDq_raw,
+    sDk_raw,
+    sDv_raw,
+    sDgate_raw,
+    desc_dq_base,
+    desc_dk_base,
+    desc_dv_base,
+    desc_dgate_base,
+    bars,
+) -> None:
+    """Epilogue warp role (warp 15): the register-MMA A/dA tiles and the
+    dQ/dK/dV/dGate TMA stores, in chunk order with a one-behind store
+    ladder."""
+    elect_one = nvvm.elect_sync()
+
+    nvvm.setmaxregister(cfg.num_regs_other, nvvm.SetMaxRegisterAction.DECREASE)
+
+    # ---- ldmatrix/stmatrix lane decode -------------------------------------------
+    rhs_row_coord = lane % 8 + (cutlass.Int32(8) if (lane // 16) else cutlass.Int32(0))
+    rhs_col_offset = cutlass.Int32(8) if ((lane // 8) % 2) else cutlass.Int32(0)
+    lhs_row_coord = lane % 8 + (cutlass.Int32(8) if ((lane // 8) % 2) else cutlass.Int32(0))
+    lhs_col_offset = cutlass.Int32(8) if ((lane // 8) // 2) else cutlass.Int32(0)
+    stsm_row_coord = lane & 7
+    stsm_col_coord = cutlass.Int32(0)
+    if (lane // 8) & 1:
+        stsm_row_coord = stsm_row_coord + cutlass.Int32(8)
+    if lane // 8 >= 2:
+        stsm_col_coord = cutlass.Int32(8)
+    stsm_idx = swizzle_lin_S(stsm_row_coord * cfg.b_t + stsm_col_coord, bbits=1, mbase=3, sshift=3)
+    row_lo = lane // 4
+    row_hi = row_lo + cutlass.Int32(8)
+
+    tril_incl_mask = cutlass.Int32(0)
+    for accum_idx in cutlass.range_constexpr(8):
+        row_coord = row_hi if cutlass.const_expr(accum_idx % 4 >= 2) else row_lo
+        col_coord = (accum_idx // 4) * 8 + 2 * (lane % 4)
+        if cutlass.const_expr(accum_idx % 2 == 1):
+            col_coord = col_coord + cutlass.Int32(1)
+        tril_incl_mask = tril_incl_mask | (cutlass.Int32(1 << accum_idx) if row_coord >= col_coord else cutlass.Int32(0))
+    raw_index = PipelineState.start(phase=0)
+    u_index = PipelineState.start(phase=0)
+    chunk_serial_base = cutlass.Int32(0)
+
+    sDq_tma = SmemTile(
+        base=sDq_raw,
+        elems_per_stage=(cfg.b_t * cfg.d_k),
+        stages=cfg.smem_dq_stages,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=0,
+        tma_loads_per_tile=(cfg.d_k // 64),
+        tma_granu_elems=64,
+        tma_subtile_stride_elems=cfg.b_t * 64,
+    )
+    sDk_tma = SmemTile(
+        base=sDk_raw,
+        elems_per_stage=(cfg.b_t * cfg.d_k),
+        stages=cfg.smem_dk_stages,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=0,
+        tma_loads_per_tile=(cfg.d_k // 64),
+        tma_granu_elems=64,
+        tma_subtile_stride_elems=cfg.b_t * 64,
+    )
+    sDv_tma = SmemTile(
+        base=sDv_raw,
+        elems_per_stage=(cfg.b_t * cfg.d_v),
+        stages=cfg.smem_dv_stages,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=0,
+        tma_loads_per_tile=(cfg.d_v // 64),
+        tma_granu_elems=64,
+        tma_subtile_stride_elems=cfg.b_t * 64,
+    )
+    sDgate_tma = SmemTile(
+        base=sDgate_raw,
+        elems_per_stage=(cfg.b_t * cfg.d_k),
+        stages=cfg.smem_dgate_stages,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=0,
+        tma_loads_per_tile=(cfg.d_k // 32),
+        tma_granu_elems=32,
+        tma_subtile_stride_elems=cfg.b_t * 32,
+    )
+    dq_index = PipelineState.start(phase=0)
+    dk_index = PipelineState.start(phase=0)
+    dv_index = PipelineState.start(phase=0)
+    dgate_index = PipelineState.start(phase=0)
+    sched_state = PipelineState.start(phase=0)
+    tile_idx = cutlass.Int32(bidx)
+    FIRST_STATE_CHUNK = 0 if cfg.use_initial_state else 1
+    while tile_idx < total_tiles:
+        batch_idx, head_idx, batch_start, batch_end, seqlen_b, num_chunks_b, wstart, wend, cstart, cend = decode_work_item(cfg, tile_idx, mWorkItems)
+        head_o = head_idx
+        slot = batch_idx * cutlass.Int32(TENSOR_MAP_QWORDS)
+        if elect_one:
+            desc_dq_slot = (desc_dq_base + slot).tospace(cutlass.AddressSpace.generic)
+            desc_dk_slot = (desc_dk_base + slot).tospace(cutlass.AddressSpace.generic)
+            desc_dv_slot = (desc_dv_base + slot).tospace(cutlass.AddressSpace.generic)
+            desc_dgate_slot = (desc_dgate_base + slot).tospace(cutlass.AddressSpace.generic)
+            tma_tensormap_acquire(desc_dq_slot)
+            tma_tensormap_acquire(desc_dk_slot)
+            tma_tensormap_acquire(desc_dv_slot)
+            tma_tensormap_acquire(desc_dgate_slot)
+        num_compute_chunks = cend - wstart
+        pend_start = cutlass.Int32(0)
+        pend_writes = cutlass.Boolean(False)
+        for rev_idx in cutlass.range(num_compute_chunks, unroll=1):
+            chunk_idx = cend - cutlass.Int32(1) - rev_idx
+            chunk_start = chunk_idx * cfg.b_t
+            writes = chunk_idx < wend
+            chunk_serial = chunk_serial_base + rev_idx
+            decay_stage = chunk_serial % cfg.smem_decay_stages
+            intermediate_stage = chunk_serial % cfg.smem_intermediate_stages
+            raw_stage = raw_index.idx
+            sK_inv_ptr = sK_inv_raw.data_ptr() + decay_stage * (cfg.b_t * cfg.d_k)
+            sQ_decay_ptr = sQ_decay_raw.data_ptr() + decay_stage * (cfg.b_t * cfg.d_k)
+            sDo_ptr = sDo_raw.data_ptr() + raw_stage * (cfg.d_v * cfg.b_t)
+            sIntermediate_ptr = sIntermediate_raw.data_ptr() + intermediate_stage * (cfg.intermediate_tiles * cfg.b_t * cfg.b_t)
+
+            # ---- A = tril_incl(Q_decay @ K_inv^T) --------------------------------
+            bars.mb_a_done[intermediate_stage].wait(((chunk_serial // cfg.smem_intermediate_stages) + 1) % 2)
+            bars.mb_q_decay_k_restore_ready[decay_stage].wait((chunk_serial // cfg.smem_decay_stages) % 2)
+            a_acc = cutlass.Array(cutlass.Float32, 8, alignment=16)
+            for accum_idx in cutlass.range_constexpr(8):
+                a_acc[accum_idx] = cutlass.Float32(0.0)
+            for k_block in cutlass.range_constexpr(cfg.d_k // 16):
+                a_col = k_block * 16 + lhs_col_offset
+                a_seg = a_col // 64
+                a_frag = nvvm.ldmatrix(
+                    sQ_decay_ptr + a_seg * (cfg.b_t * 64) + lhs_row_coord * 64 + swizzle_xor_128b(lhs_row_coord, a_col - a_seg * 64, elem_bytes=2),
+                    4,
+                    nvvm.MMALayout.ROW,
+                )
+                b_col = k_block * 16 + rhs_col_offset
+                b_seg = b_col // 64
+                b_frag = nvvm.ldmatrix(
+                    sK_inv_ptr + b_seg * (cfg.b_t * 64) + rhs_row_coord * 64 + swizzle_xor_128b(rhs_row_coord, b_col - b_seg * 64, elem_bytes=2),
+                    4,
+                    nvvm.MMALayout.ROW,
+                )
+                mma_step(
+                    a_acc,
+                    (a_frag[0], a_frag[1], a_frag[2], a_frag[3]),
+                    (b_frag[0], b_frag[1], b_frag[2], b_frag[3]),
+                    k_step=0,
+                    M=16,
+                    N=16,
+                    ab_dtype=cfg.io_dtype,
+                )
+            for accum_idx in cutlass.range_constexpr(8):
+                a_acc[accum_idx] = a_acc[accum_idx] if (tril_incl_mask >> accum_idx) & 1 else cutlass.Float32(0.0)
+            nvvm.stmatrix(
+                sIntermediate_ptr + stsm_idx,
+                [
+                    fp32_to_fp16(a_acc[0], a_acc[1], dtype=cfg.io_dtype),
+                    fp32_to_fp16(a_acc[2], a_acc[3], dtype=cfg.io_dtype),
+                    fp32_to_fp16(a_acc[4], a_acc[5], dtype=cfg.io_dtype),
+                    fp32_to_fp16(a_acc[6], a_acc[7], dtype=cfg.io_dtype),
+                ],
+                nvvm.MMALayout.ROW,
+                shape=nvvm.StoreShape.M8N8,
+            )
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_a_ready[intermediate_stage].arrive()
+
+            # ---- dA = tril_incl(dO @ U^T) ----------------------------------------
+            bars.mb_u_smem_ready.wait(u_index.phase)
+            u_index = advance(u_index, 1)
+            da_acc = cutlass.Array(cutlass.Float32, 8, alignment=16)
+            for accum_idx in cutlass.range_constexpr(8):
+                da_acc[accum_idx] = cutlass.Float32(0.0)
+            for k_block in cutlass.range_constexpr(cfg.d_v // 16):
+                a_col = k_block * 16 + lhs_col_offset
+                a_seg = a_col // 64
+                a_frag = nvvm.ldmatrix(
+                    sDo_ptr + a_seg * (cfg.b_t * 64) + lhs_row_coord * 64 + swizzle_xor_128b(lhs_row_coord, a_col - a_seg * 64, elem_bytes=2),
+                    4,
+                    nvvm.MMALayout.ROW,
+                )
+                b_col = k_block * 16 + rhs_col_offset
+                b_seg = b_col // 64
+                b_frag = nvvm.ldmatrix(
+                    sU_raw.data_ptr() + b_seg * (cfg.b_t * 64) + rhs_row_coord * 64 + swizzle_xor_128b(rhs_row_coord, b_col - b_seg * 64, elem_bytes=2),
+                    4,
+                    nvvm.MMALayout.ROW,
+                )
+                mma_step(
+                    da_acc,
+                    (a_frag[0], a_frag[1], a_frag[2], a_frag[3]),
+                    (b_frag[0], b_frag[1], b_frag[2], b_frag[3]),
+                    k_step=0,
+                    M=16,
+                    N=16,
+                    ab_dtype=cfg.io_dtype,
+                )
+            # fence: the dO/U ldmatrix reads must complete before this release
+            # licenses the TMA reload (sDo)
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_do_done[raw_stage].arrive()
+            for accum_idx in cutlass.range_constexpr(8):
+                da_acc[accum_idx] = da_acc[accum_idx] if (tril_incl_mask >> accum_idx) & 1 else cutlass.Float32(0.0)
+            bars.mb_da_done[intermediate_stage].wait(((chunk_serial // cfg.smem_intermediate_stages) + 1) % 2)
+            nvvm.stmatrix(
+                sIntermediate_ptr + 2 * (cfg.b_t * cfg.b_t) + stsm_idx,
+                [
+                    fp32_to_fp16(da_acc[0], da_acc[1], dtype=cfg.io_dtype),
+                    fp32_to_fp16(da_acc[2], da_acc[3], dtype=cfg.io_dtype),
+                    fp32_to_fp16(da_acc[4], da_acc[5], dtype=cfg.io_dtype),
+                    fp32_to_fp16(da_acc[6], da_acc[7], dtype=cfg.io_dtype),
+                ],
+                nvvm.MMALayout.ROW,
+                shape=nvvm.StoreShape.M8N8,
+            )
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_da_ready[intermediate_stage].arrive()
+            raw_index = advance(raw_index, cfg.smem_raw_stages)
+
+            # ---- dQ/dK/dGate/dV: previous chunk, one-behind store ladder ---------
+            if rev_idx > 0:
+                bars.mb_dq_tmastg_ready[dq_index.idx].wait(dq_index.phase)
+                if pend_writes:
+                    desc_dq_slot = (desc_dq_base + slot).tospace(cutlass.AddressSpace.generic)
+                    dq_slice = tma_slice_runtime_desc(desc_dq_slot, cutlass.Int32(0), head_o, pend_start)
+                    tma_store_tile(sDq_tma[dq_index.idx], dq_slice, acquire=False)
+                    tma_store_commit()
+                bars.mb_dk_tmastg_ready[dk_index.idx].wait(dk_index.phase)
+                if pend_writes:
+                    desc_dk_slot = (desc_dk_base + slot).tospace(cutlass.AddressSpace.generic)
+                    dk_slice = tma_slice_runtime_desc(desc_dk_slot, cutlass.Int32(0), head_o, pend_start)
+                    tma_store_tile(sDk_tma[dk_index.idx], dk_slice, acquire=False)
+                    tma_store_commit()
+                bars.mb_dgate_tmastg_ready[dgate_index.idx].wait(dgate_index.phase)
+                if pend_writes:
+                    desc_dgate_slot = (desc_dgate_base + slot).tospace(cutlass.AddressSpace.generic)
+                    dgate_slice = tma_slice_runtime_desc(desc_dgate_slot, cutlass.Int32(0), head_o, pend_start)
+                    tma_store_tile(sDgate_tma[dgate_index.idx], dgate_slice, acquire=False)
+                    tma_store_commit()
+                bars.mb_dv_tmastg_ready[dv_index.idx].wait(dv_index.phase)
+                if pend_writes:
+                    desc_dv_slot = (desc_dv_base + slot).tospace(cutlass.AddressSpace.generic)
+                    dv_slice = tma_slice_runtime_desc(desc_dv_slot, cutlass.Int32(0), head_o, pend_start)
+                    tma_store_tile(sDv_tma[dv_index.idx], dv_slice, acquire=False)
+                    tma_store_commit()
+                tma_store_wait(3)
+                bars.mb_dq_tmastg_done[dq_index.idx].arrive()
+                tma_store_wait(2)
+                bars.mb_dk_tmastg_done[dk_index.idx].arrive()
+                tma_store_wait(1)
+                bars.mb_dgate_tmastg_done[dgate_index.idx].arrive()
+                tma_store_wait(0)
+                bars.mb_dv_tmastg_done[dv_index.idx].arrive()
+                dq_index = advance(dq_index, cfg.smem_dq_stages)
+                dk_index = advance(dk_index, cfg.smem_dk_stages)
+                dgate_index = advance(dgate_index, cfg.smem_dgate_stages)
+                dv_index = advance(dv_index, cfg.smem_dv_stages)
+            pend_start = chunk_start
+            pend_writes = writes
+
+        # ---- tile tail: drain the last chunk's dQ/dK/dGate/dV --------------------
+        if num_compute_chunks > 0:
+            bars.mb_dq_tmastg_ready[dq_index.idx].wait(dq_index.phase)
+            if pend_writes:
+                desc_dq_slot = (desc_dq_base + slot).tospace(cutlass.AddressSpace.generic)
+                dq_slice = tma_slice_runtime_desc(desc_dq_slot, cutlass.Int32(0), head_o, pend_start)
+                tma_store_tile(sDq_tma[dq_index.idx], dq_slice, acquire=False)
+                tma_store_commit()
+            bars.mb_dk_tmastg_ready[dk_index.idx].wait(dk_index.phase)
+            if pend_writes:
+                desc_dk_slot = (desc_dk_base + slot).tospace(cutlass.AddressSpace.generic)
+                dk_slice = tma_slice_runtime_desc(desc_dk_slot, cutlass.Int32(0), head_o, pend_start)
+                tma_store_tile(sDk_tma[dk_index.idx], dk_slice, acquire=False)
+                tma_store_commit()
+            bars.mb_dgate_tmastg_ready[dgate_index.idx].wait(dgate_index.phase)
+            if pend_writes:
+                desc_dgate_slot = (desc_dgate_base + slot).tospace(cutlass.AddressSpace.generic)
+                dgate_slice = tma_slice_runtime_desc(desc_dgate_slot, cutlass.Int32(0), head_o, pend_start)
+                tma_store_tile(sDgate_tma[dgate_index.idx], dgate_slice, acquire=False)
+                tma_store_commit()
+            bars.mb_dv_tmastg_ready[dv_index.idx].wait(dv_index.phase)
+            if pend_writes:
+                desc_dv_slot = (desc_dv_base + slot).tospace(cutlass.AddressSpace.generic)
+                dv_slice = tma_slice_runtime_desc(desc_dv_slot, cutlass.Int32(0), head_o, pend_start)
+                tma_store_tile(sDv_tma[dv_index.idx], dv_slice, acquire=False)
+                tma_store_commit()
+            tma_store_wait(3)
+            bars.mb_dq_tmastg_done[dq_index.idx].arrive()
+            tma_store_wait(2)
+            bars.mb_dk_tmastg_done[dk_index.idx].arrive()
+            tma_store_wait(1)
+            bars.mb_dgate_tmastg_done[dgate_index.idx].arrive()
+            tma_store_wait(0)
+            bars.mb_dv_tmastg_done[dv_index.idx].arrive()
+            dq_index = advance(dq_index, cfg.smem_dq_stages)
+            dk_index = advance(dk_index, cfg.smem_dk_stages)
+            dgate_index = advance(dgate_index, cfg.smem_dgate_stages)
+            dv_index = advance(dv_index, cfg.smem_dv_stages)
+
+        chunk_serial_base += num_compute_chunks
+        tile_idx, sched_state = sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas)
+
+
+@cute.jit
+def super_mma_warp(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    cu_seqlens,
+    mWorkItems,
+    sSched,
+    lane,
+    sK_decay_raw,
+    sK_inv_raw,
+    sU_raw,
+    sDy_raw,
+    sIntermediate_raw,
+    sBeta_raw,
+    sBetaM_raw,
+    bars,
+) -> None:
+    """Super-MMA warp role (warp 12): the Neumann T_inv and dM register MMAs
+    plus the dBeta M-term row sums, in chunk order."""
+    nvvm.setmaxregister(cfg.num_regs_other, nvvm.SetMaxRegisterAction.DECREASE)
+    sdy_index = PipelineState.start(phase=0)
+
+    # ---- ldmatrix lane decode ----------------------------------------------------
+    rhs_row_coord = lane % 8 + (cutlass.Int32(8) if (lane // 16) else cutlass.Int32(0))
+    rhs_col_offset = cutlass.Int32(8) if ((lane // 8) % 2) else cutlass.Int32(0)
+    lhs_row_coord = lane % 8 + (cutlass.Int32(8) if ((lane // 8) % 2) else cutlass.Int32(0))
+    lhs_col_offset = cutlass.Int32(8) if ((lane // 8) // 2) else cutlass.Int32(0)
+    stsm_row_coord = lane & 7
+    stsm_col_coord = cutlass.Int32(0)
+    if (lane // 8) & 1:
+        stsm_row_coord = stsm_row_coord + cutlass.Int32(8)
+    if lane // 8 >= 2:
+        stsm_col_coord = cutlass.Int32(8)
+    stsm_idx = swizzle_lin_S(stsm_row_coord * cfg.b_t + stsm_col_coord, bbits=1, mbase=3, sshift=3)
+    row_lo = lane // 4
+    row_hi = row_lo + cutlass.Int32(8)
+
+    # hoisted tril bitmasks: bit i = row > col / row == col for accum index i
+    tril_strict_mask = cutlass.Int32(0)
+    eye_mask = cutlass.Int32(0)
+    for accum_idx in cutlass.range_constexpr(8):
+        row_coord = row_hi if cutlass.const_expr(accum_idx % 4 >= 2) else row_lo
+        col_coord = (accum_idx // 4) * 8 + 2 * (lane % 4)
+        if cutlass.const_expr(accum_idx % 2 == 1):
+            col_coord = col_coord + cutlass.Int32(1)
+        tril_strict_mask = tril_strict_mask | (cutlass.Int32(1 << accum_idx) if row_coord > col_coord else cutlass.Int32(0))
+        eye_mask = eye_mask | (cutlass.Int32(1 << accum_idx) if row_coord == col_coord else cutlass.Int32(0))
+
+    chunk_serial_base = cutlass.Int32(0)
+    sched_state = PipelineState.start(phase=0)
+    tile_idx = cutlass.Int32(bidx)
+    FIRST_STATE_CHUNK = 0 if cfg.use_initial_state else 1
+    while tile_idx < total_tiles:
+        batch_idx, head_idx, batch_start, batch_end, seqlen_b, num_chunks_b, wstart, wend, cstart, cend = decode_work_item(cfg, tile_idx, mWorkItems)
+        num_compute_chunks = cend - wstart
+        for rev_idx in cutlass.range(num_compute_chunks, unroll=1):
+            chunk_serial = chunk_serial_base + rev_idx
+            decay_stage = chunk_serial % cfg.smem_decay_stages
+            intermediate_stage = chunk_serial % cfg.smem_intermediate_stages
+            sBeta_ptr = sBeta_raw.data_ptr() + (chunk_serial % cfg.smem_beta_stages) * cfg.b_t
+            sK_inv_ptr = sK_inv_raw.data_ptr() + decay_stage * (cfg.b_t * cfg.d_k)
+            sK_decay_ptr = sK_decay_raw.data_ptr() + decay_stage * (cfg.b_t * cfg.d_k)
+            sIntermediate_ptr = sIntermediate_raw.data_ptr() + intermediate_stage * (cfg.intermediate_tiles * cfg.b_t * cfg.b_t)
+
+            bars.mb_t_inv_done[intermediate_stage].wait(((chunk_serial // cfg.smem_intermediate_stages) + 1) % 2)
+
+            # ---- KK = K_decay @ K_inv^T ------------------------------------------
+            bars.mb_k_decay_inv_ready[decay_stage].wait((chunk_serial // cfg.smem_decay_stages) % 2)
+            kk_lhs_row = lhs_row_coord
+            kk_acc = cutlass.Array(cutlass.Float32, 8, alignment=16)
+            for accum_idx in cutlass.range_constexpr(8):
+                kk_acc[accum_idx] = cutlass.Float32(0.0)
+            for k_block in cutlass.range_constexpr(cfg.d_k // 16):
+                a_col = k_block * 16 + lhs_col_offset
+                a_seg = a_col // 64
+                a_frag = nvvm.ldmatrix(
+                    sK_decay_ptr + a_seg * (cfg.b_t * 64) + kk_lhs_row * 64 + swizzle_xor_128b(kk_lhs_row, a_col - a_seg * 64, elem_bytes=2),
+                    4,
+                    nvvm.MMALayout.ROW,
+                )
+                b_col = k_block * 16 + rhs_col_offset
+                b_seg = b_col // 64
+                b_frag = nvvm.ldmatrix(
+                    sK_inv_ptr + b_seg * (cfg.b_t * 64) + rhs_row_coord * 64 + swizzle_xor_128b(rhs_row_coord, b_col - b_seg * 64, elem_bytes=2),
+                    4,
+                    nvvm.MMALayout.ROW,
+                )
+                mma_step(
+                    kk_acc,
+                    (a_frag[0], a_frag[1], a_frag[2], a_frag[3]),
+                    (b_frag[0], b_frag[1], b_frag[2], b_frag[3]),
+                    k_step=0,
+                    M=16,
+                    N=16,
+                    ab_dtype=cfg.io_dtype,
+                )
+
+            # ---- L = Beta * tril(KK, -1) -----------------------------------------
+            bars.mb_beta_ready[chunk_serial % cfg.smem_beta_stages].wait((chunk_serial // cfg.smem_beta_stages) % 2)
+            beta_lo = (sBeta_ptr + row_lo).load().to(cutlass.Float32)
+            beta_hi = (sBeta_ptr + row_hi).load().to(cutlass.Float32)
+            bars.mb_beta_done[chunk_serial % cfg.smem_beta_stages].arrive()
+            l_regs = cutlass.Array(cutlass.Float32, 8, alignment=16)
+            for accum_idx in cutlass.range_constexpr(8):
+                beta_scale = beta_lo if accum_idx % 4 < 2 else beta_hi
+                lower = kk_acc[accum_idx] if (tril_strict_mask >> accum_idx) & 1 else cutlass.Float32(0.0)
+                l_regs[accum_idx] = lower * beta_scale
+            l_a0 = fp32_to_fp16(l_regs[0], l_regs[1], dtype=cfg.io_dtype)
+            l_a1 = fp32_to_fp16(l_regs[2], l_regs[3], dtype=cfg.io_dtype)
+            l_a2 = fp32_to_fp16(l_regs[4], l_regs[5], dtype=cfg.io_dtype)
+            l_a3 = fp32_to_fp16(l_regs[6], l_regs[7], dtype=cfg.io_dtype)
+            l_values = cutlass.Vector.from_elements((l_a0, l_a1, l_a2, l_a3), cutlass.Int32).bitcast(cfg.io_dtype).to(cutlass.Float32)
+
+            tinv_acc = cutlass.Array(cutlass.Float32, 8, alignment=16)
+            for accum_idx in cutlass.range_constexpr(8):
+                eye = cutlass.Float32(1.0) if (eye_mask >> accum_idx) & 1 else cutlass.Float32(0.0)
+                tinv_acc[accum_idx] = eye - l_values[accum_idx]
+
+            lpow_a0, lpow_a1, lpow_a2, lpow_a3 = l_a0, l_a1, l_a2, l_a3
+            mov_lpow0, mov_lpow1, mov_lpow2, mov_lpow3 = movmatrix_16b(l_a0), movmatrix_16b(l_a1), movmatrix_16b(l_a2), movmatrix_16b(l_a3)
+            for _round in cutlass.range_constexpr(3):
+                sq_acc = cutlass.Array(cutlass.Float32, 8, alignment=16)
+                for accum_idx in cutlass.range_constexpr(8):
+                    sq_acc[accum_idx] = cutlass.Float32(0.0)
+                mma_step(
+                    sq_acc,
+                    (lpow_a0, lpow_a1, lpow_a2, lpow_a3),
+                    (mov_lpow0, mov_lpow1, mov_lpow2, mov_lpow3),
+                    k_step=0,
+                    M=16,
+                    N=16,
+                    ab_dtype=cfg.io_dtype,
+                )
+                lpow_a0 = fp32_to_fp16(sq_acc[0], sq_acc[1], dtype=cfg.io_dtype)
+                lpow_a1 = fp32_to_fp16(sq_acc[2], sq_acc[3], dtype=cfg.io_dtype)
+                lpow_a2 = fp32_to_fp16(sq_acc[4], sq_acc[5], dtype=cfg.io_dtype)
+                lpow_a3 = fp32_to_fp16(sq_acc[6], sq_acc[7], dtype=cfg.io_dtype)
+                mov_lpow0, mov_lpow1, mov_lpow2, mov_lpow3 = movmatrix_16b(lpow_a0), movmatrix_16b(lpow_a1), movmatrix_16b(lpow_a2), movmatrix_16b(lpow_a3)
+                upd_acc = cutlass.Array(cutlass.Float32, 8, alignment=16)
+                for accum_idx in cutlass.range_constexpr(8):
+                    upd_acc[accum_idx] = cutlass.Float32(0.0)
+                tinv_p0 = fp32_to_fp16(tinv_acc[0], tinv_acc[1], dtype=cfg.io_dtype)
+                tinv_p1 = fp32_to_fp16(tinv_acc[2], tinv_acc[3], dtype=cfg.io_dtype)
+                tinv_p2 = fp32_to_fp16(tinv_acc[4], tinv_acc[5], dtype=cfg.io_dtype)
+                tinv_p3 = fp32_to_fp16(tinv_acc[6], tinv_acc[7], dtype=cfg.io_dtype)
+                mma_step(
+                    upd_acc,
+                    (tinv_p0, tinv_p1, tinv_p2, tinv_p3),
+                    (mov_lpow0, mov_lpow1, mov_lpow2, mov_lpow3),
+                    k_step=0,
+                    M=16,
+                    N=16,
+                    ab_dtype=cfg.io_dtype,
+                )
+                tinv_lo0, tinv_hi0 = f16x2_to_f32(tinv_p0, dtype=cfg.io_dtype)
+                tinv_lo1, tinv_hi1 = f16x2_to_f32(tinv_p1, dtype=cfg.io_dtype)
+                tinv_lo2, tinv_hi2 = f16x2_to_f32(tinv_p2, dtype=cfg.io_dtype)
+                tinv_lo3, tinv_hi3 = f16x2_to_f32(tinv_p3, dtype=cfg.io_dtype)
+                tinv_acc[0], tinv_acc[1] = fadd2(tinv_lo0, tinv_hi0, upd_acc[0], upd_acc[1])
+                tinv_acc[2], tinv_acc[3] = fadd2(tinv_lo1, tinv_hi1, upd_acc[2], upd_acc[3])
+                tinv_acc[4], tinv_acc[5] = fadd2(tinv_lo2, tinv_hi2, upd_acc[4], upd_acc[5])
+                tinv_acc[6], tinv_acc[7] = fadd2(tinv_lo3, tinv_hi3, upd_acc[6], upd_acc[7])
+
+            nvvm.stmatrix(
+                sIntermediate_ptr + 1 * (cfg.b_t * cfg.b_t) + stsm_idx,
+                [
+                    fp32_to_fp16(tinv_acc[0], tinv_acc[1], dtype=cfg.io_dtype),
+                    fp32_to_fp16(tinv_acc[2], tinv_acc[3], dtype=cfg.io_dtype),
+                    fp32_to_fp16(tinv_acc[4], tinv_acc[5], dtype=cfg.io_dtype),
+                    fp32_to_fp16(tinv_acc[6], tinv_acc[7], dtype=cfg.io_dtype),
+                ],
+                nvvm.MMALayout.ROW,
+                shape=nvvm.StoreShape.M8N8,
+            )
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_t_inv_ready[intermediate_stage].arrive()
+
+            # ---- dM = dY @ U^T ---------------------------------------------------
+            bars.mb_dm_done[intermediate_stage].wait(((chunk_serial // cfg.smem_intermediate_stages) + 1) % 2)
+            bars.mb_dy_smem_ready.wait(sdy_index.phase)
+            sdy_index = advance(sdy_index, 1)
+            dm_acc = cutlass.Array(cutlass.Float32, 8, alignment=16)
+            for accum_idx in cutlass.range_constexpr(8):
+                dm_acc[accum_idx] = cutlass.Float32(0.0)
+            for k_block in cutlass.range_constexpr(cfg.d_v // 16):
+                a_col = k_block * 16 + lhs_col_offset
+                a_seg = a_col // 64
+                a_frag = nvvm.ldmatrix(
+                    sDy_raw.data_ptr() + a_seg * (cfg.b_t * 64) + lhs_row_coord * 64 + swizzle_xor_128b(lhs_row_coord, a_col - a_seg * 64, elem_bytes=2),
+                    4,
+                    nvvm.MMALayout.ROW,
+                )
+                b_col = k_block * 16 + rhs_col_offset
+                b_seg = b_col // 64
+                b_frag = nvvm.ldmatrix(
+                    sU_raw.data_ptr() + b_seg * (cfg.b_t * 64) + rhs_row_coord * 64 + swizzle_xor_128b(rhs_row_coord, b_col - b_seg * 64, elem_bytes=2),
+                    4,
+                    nvvm.MMALayout.ROW,
+                )
+                mma_step(
+                    dm_acc,
+                    (a_frag[0], a_frag[1], a_frag[2], a_frag[3]),
+                    (b_frag[0], b_frag[1], b_frag[2], b_frag[3]),
+                    k_step=0,
+                    M=16,
+                    N=16,
+                    ab_dtype=cfg.io_dtype,
+                )
+            # ---- dM_strict = Beta_row . strict(dM) -------------------------------
+            dm_strict_regs = cutlass.Array(cutlass.Float32, 8, alignment=16)
+            for accum_idx in cutlass.range_constexpr(8):
+                beta_scale = beta_lo if accum_idx % 4 < 2 else beta_hi
+                val = dm_acc[accum_idx] * beta_scale if (tril_strict_mask >> accum_idx) & 1 else cutlass.Float32(0.0)
+                dm_strict_regs[accum_idx] = val
+            w0 = fp32_to_fp16(dm_strict_regs[0], dm_strict_regs[1], dtype=cfg.io_dtype)
+            w1 = fp32_to_fp16(dm_strict_regs[2], dm_strict_regs[3], dtype=cfg.io_dtype)
+            w2 = fp32_to_fp16(dm_strict_regs[4], dm_strict_regs[5], dtype=cfg.io_dtype)
+            w3 = fp32_to_fp16(dm_strict_regs[6], dm_strict_regs[7], dtype=cfg.io_dtype)
+            nvvm.stmatrix(sIntermediate_ptr + 3 * (cfg.b_t * cfg.b_t) + stsm_idx, [w0, w1, w2, w3], nvvm.MMALayout.ROW, shape=nvvm.StoreShape.M8N8)
+            nw0 = fp32_to_fp16(-dm_strict_regs[0], -dm_strict_regs[1], dtype=cfg.io_dtype)
+            nw1 = fp32_to_fp16(-dm_strict_regs[2], -dm_strict_regs[3], dtype=cfg.io_dtype)
+            nw2 = fp32_to_fp16(-dm_strict_regs[4], -dm_strict_regs[5], dtype=cfg.io_dtype)
+            nw3 = fp32_to_fp16(-dm_strict_regs[6], -dm_strict_regs[7], dtype=cfg.io_dtype)
+            nvvm.stmatrix(sIntermediate_ptr + 4 * (cfg.b_t * cfg.b_t) + stsm_idx, [nw0, nw1, nw2, nw3], nvvm.MMALayout.ROW, shape=nvvm.StoreShape.M8N8)
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_dm_ready[intermediate_stage].arrive()
+
+            # ---- M-term: bsum = sum strict(dM . KK) ------------------------------
+            bsum_lo = cutlass.Float32(0.0)
+            bsum_hi = cutlass.Float32(0.0)
+            for accum_idx in cutlass.range_constexpr(8):
+                e = dm_acc[accum_idx] * kk_acc[accum_idx] if (tril_strict_mask >> accum_idx) & 1 else cutlass.Float32(0.0)
+                if cutlass.const_expr(accum_idx % 4 < 2):
+                    bsum_lo = bsum_lo + e
+                else:
+                    bsum_hi = bsum_hi + e
+            bsum_lo = bsum_lo + cutlass.Float32(nvvm.shfl_sync(0xFFFFFFFF, bsum_lo, 1, 31, kind=nvvm.Shfl.BFLY))
+            bsum_lo = bsum_lo + cutlass.Float32(nvvm.shfl_sync(0xFFFFFFFF, bsum_lo, 2, 31, kind=nvvm.Shfl.BFLY))
+            bsum_hi = bsum_hi + cutlass.Float32(nvvm.shfl_sync(0xFFFFFFFF, bsum_hi, 1, 31, kind=nvvm.Shfl.BFLY))
+            bsum_hi = bsum_hi + cutlass.Float32(nvvm.shfl_sync(0xFFFFFFFF, bsum_hi, 2, 31, kind=nvvm.Shfl.BFLY))
+            if lane % 4 == 0:
+                sBetaM_raw[row_lo] = -bsum_lo
+                sBetaM_raw[row_hi] = -bsum_hi
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_dbeta_m_ready.arrive()
+        chunk_serial_base += num_compute_chunks
+        tile_idx, sched_state = sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas)
+
+
+@cute.jit
+def tcgen05_mma_warp(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    cu_seqlens,
+    mWorkItems,
+    sSched,
+    tmem_base_holder,
+    sState_alt,
+    sState_direct,
+    sK_decay_lead16,
+    sK_inv_lead16,
+    sK_inv_amaj,
+    sK_restore_lead16,
+    sDo_lead16,
+    sDo_amaj,
+    sQ_decay_trans,
+    sK_decay_trans,
+    sU_lead16,
+    sDv_lead16,
+    sDstate_alt,
+    sIntermediate,
+    sState_scale_diag,
+    bars,
+) -> None:
+    """tcgen05-MMA warp role (warp 13): issues every tcgen05 GEMM and owns
+    the TMEM lifecycle."""
+    elect_one = nvvm.elect_sync()
+
+    nvvm.setmaxregister(cfg.num_regs_other, nvvm.SetMaxRegisterAction.DECREASE)
+    nvvm.tcgen05_alloc(tmem_base_holder, cutlass.Int32(512), group=nvvm.CTAGroup.CTA_1)
+    nvvm.barrier_cta_sync(cfg.tmem_lifecycle_barrier_id, thread_count=cfg.tmem_user_threads)
+    tmem_base = tmem_base_holder.load()
+    bpe = cfg.io_dtype.width // 8
+
+    # ---- chunk-invariant GEMM descriptors ----------------------------------------
+    idesc_mv_nt = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.b_t,
+        m_dim=cfg.d_v,
+    )
+    idesc_state_k_at = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.b_t,
+        m_dim=cfg.d_v,
+        a_major=1,
+    )
+    bmm_state_k_desc = MmaDesc(
+        M=cfg.d_v,
+        N=cfg.b_t,
+        K=cfg.d_k,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=False,
+        atranspose=True,
+        cta_group=1,
+        idesc=idesc_state_k_at,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    idesc_state_k_kmaj = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.b_t,
+        m_dim=cfg.d_v,
+    )
+    bmm_state_k_kmaj_desc = MmaDesc(
+        M=cfg.d_v,
+        N=cfg.b_t,
+        K=cfg.d_k,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=False,
+        atranspose=False,
+        cta_group=1,
+        idesc=idesc_state_k_kmaj,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    bmm_dvinter_desc = MmaDesc(
+        M=cfg.d_v,
+        N=cfg.b_t,
+        K=cfg.d_k,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=False,
+        cta_group=1,
+        idesc=idesc_mv_nt,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    idesc_du_at = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.b_t,
+        m_dim=cfg.d_v,
+        a_major=1,
+        b_major=1,
+    )
+    bmm_du_at_desc = MmaDesc(
+        M=cfg.d_v,
+        N=cfg.b_t,
+        K=cfg.b_t,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=True,
+        atranspose=True,
+        cta_group=1,
+        idesc=idesc_du_at,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    idesc_dstate_q_at = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.d_k,
+        m_dim=cfg.d_v,
+        a_major=1,
+        b_major=1,
+    )
+    bmm_dstate_q_at_desc = MmaDesc(
+        M=cfg.d_v,
+        N=cfg.d_k,
+        K=cfg.b_t,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=True,
+        atranspose=True,
+        cta_group=1,
+        idesc=idesc_dstate_q_at,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    bmm_qk_ts_desc = MmaDesc(
+        M=cfg.d_v,
+        N=cfg.b_t,
+        K=cfg.b_t,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=False,
+        cta_group=1,
+        idesc=idesc_mv_nt,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    idesc_mv_nt_t = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.b_t,
+        m_dim=cfg.d_v,
+        b_major=1,
+    )
+    bmm_qk_ts_t_desc = MmaDesc(
+        M=cfg.d_v,
+        N=cfg.b_t,
+        K=cfg.b_t,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=True,
+        cta_group=1,
+        idesc=idesc_mv_nt_t,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    idesc_diag = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=16,
+        m_dim=cfg.d_v,
+    )
+    bmm_diag_desc = MmaDesc(
+        M=cfg.d_v,
+        N=16,
+        K=16,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=False,
+        cta_group=1,
+        idesc=idesc_diag,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    idesc_dstate_k = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.d_k,
+        m_dim=cfg.d_v,
+        b_major=1,
+    )
+    bmm_dstate_k_desc = MmaDesc(
+        M=cfg.d_v,
+        N=cfg.d_k,
+        K=cfg.b_t,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=True,
+        cta_group=1,
+        idesc=idesc_dstate_k,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    idesc_dstate = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.b_t,
+        m_dim=cfg.d_k,
+    )
+    bmm_dstate_ts_desc = MmaDesc(
+        M=cfg.d_k,
+        N=cfg.b_t,
+        K=cfg.d_v,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=False,
+        cta_group=1,
+        idesc=idesc_dstate,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    idesc_dstate_at = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.b_t,
+        m_dim=cfg.d_k,
+        a_major=1,
+    )
+    bmm_dstate_at_desc = MmaDesc(
+        M=cfg.d_k,
+        N=cfg.b_t,
+        K=cfg.d_v,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=False,
+        atranspose=True,
+        cta_group=1,
+        idesc=idesc_dstate_at,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    idesc_dgp = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.b_t,
+        m_dim=cfg.d_k,
+    )
+    bmm_dgrad_ts_desc = MmaDesc(
+        M=cfg.d_k,
+        N=cfg.b_t,
+        K=cfg.b_t,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=False,
+        cta_group=1,
+        idesc=idesc_dgp,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    idesc_dgp_at = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.b_t,
+        m_dim=cfg.d_k,
+        a_major=1,
+    )
+    bmm_dgrad_at_desc = MmaDesc(
+        M=cfg.d_k,
+        N=cfg.b_t,
+        K=cfg.b_t,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=False,
+        atranspose=True,
+        cta_group=1,
+        idesc=idesc_dgp_at,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    idesc_dgp_at_t = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.b_t,
+        m_dim=cfg.d_k,
+        a_major=1,
+        b_major=1,
+    )
+    bmm_dgrad_at_t_desc = MmaDesc(
+        M=cfg.d_k,
+        N=cfg.b_t,
+        K=cfg.b_t,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=True,
+        atranspose=True,
+        cta_group=1,
+        idesc=idesc_dgp_at_t,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+
+    state_index = PipelineState.start(phase=0)
+    y_inp_index = PipelineState.start(phase=0)
+    dstate_inp_index = PipelineState.start(phase=0)
+    du_inp_index = PipelineState.start(phase=0)
+    neg_beta_dy_index = PipelineState.start(phase=0)
+    u_smem_index = PipelineState.start(phase=0)
+    dstate_smem_index = PipelineState.start(phase=0)
+    parts_done_index = PipelineState.start(phase=1)
+
+    do_seg = (cfg.b_t * cfg.d_v * (cfg.io_dtype.width // 8)) >> 4
+    op_seg = (cfg.b_t * cfg.d_k * (cfg.io_dtype.width // 8)) >> 4
+    intermediate_seg = (cfg.intermediate_tiles * cfg.b_t * cfg.b_t * (cfg.io_dtype.width // 8)) >> 4
+    intermediate_slot = (cfg.b_t * cfg.b_t * (cfg.io_dtype.width // 8)) >> 4
+    diag_seg = ((cfg.d_k // 16) * 256 * (cfg.io_dtype.width // 8)) >> 4
+    dv_seg = (cfg.b_t * cfg.d_v * (cfg.io_dtype.width // 8)) >> 4
+    d_do_amaj0 = sDo_amaj[0].desc()
+    d_qd_trans0 = sQ_decay_trans[0].desc()
+    d_kd_trans0 = sK_decay_trans[0].desc()
+    d_ki_amaj0 = sK_inv_amaj[0].desc()
+    d_int0 = sIntermediate[0].desc()
+    d_kd_lead0 = sK_decay_lead16[0].desc()
+    d_do_lead0 = sDo_lead16[0].desc()
+    d_kr_lead0 = sK_restore_lead16[0].desc()
+    d_diag0 = sState_scale_diag[0].desc()
+    d_dv_lead0 = sDv_lead16[0].desc()
+    d_dstate_alt0 = sDstate_alt[0].desc()
+    d_u_lead0 = sU_lead16[0].desc()
+    assert cfg.smem_state_stages == 1
+    d_state_alt0 = sState_alt[0].desc()
+    d_state_direct0 = sState_direct[0].desc()
+    dstate0_index = PipelineState.start(phase=0)
+
+    chunk_serial_base = cutlass.Int32(0)
+    sched_state = PipelineState.start(phase=0)
+    tile_idx = cutlass.Int32(bidx)
+    FIRST_STATE_CHUNK = 0 if cfg.use_initial_state else 1
+    while tile_idx < total_tiles:
+        batch_idx, head_idx, batch_start, batch_end, seqlen_b, num_chunks_b, wstart, wend, cstart, cend = decode_work_item(cfg, tile_idx, mWorkItems)
+        num_compute_chunks = cend - wstart
+        for rev_idx in cutlass.range(num_compute_chunks, unroll=1):
+            chunk_serial = chunk_serial_base + rev_idx
+            decay_stage = chunk_serial % cfg.smem_decay_stages
+            intermediate_stage = chunk_serial % cfg.smem_intermediate_stages
+            decay_phase = (chunk_serial // cfg.smem_decay_stages) % 2
+            intermediate_phase = (chunk_serial // cfg.smem_intermediate_stages) % 2
+            has_dstate = cutlass.Boolean(rev_idx > 0)
+            if cutlass.const_expr(cfg.use_dstate_in):
+                has_dstate = cutlass.Boolean(True)
+            raw_stage_idx = chunk_serial % cfg.smem_raw_stages
+
+            # ---- stage-derived operand descriptors -------------------------------
+            decay_op_off = decay_stage * op_seg
+            d_do_amaj = d_do_amaj0 + raw_stage_idx * do_seg
+            d_qd_trans = d_qd_trans0 + decay_op_off
+            d_kd_trans = d_kd_trans0 + decay_op_off
+            d_ki_amaj = d_ki_amaj0 + decay_op_off
+            d_int = d_int0 + intermediate_stage * intermediate_seg
+            d_int_tinv = d_int + intermediate_slot
+            d_int_da = d_int + 2 * intermediate_slot
+            d_int_dm = d_int + 3 * intermediate_slot
+            d_int_ndm = d_int + 4 * intermediate_slot
+            chunk_idx = cend - cutlass.Int32(1) - rev_idx
+
+            # ---- state_k = state(S) @ K_decay^T --------------------------------------
+            bars.mb_k_decay_inv_ready[decay_stage].wait(decay_phase)
+            if chunk_idx >= FIRST_STATE_CHUNK:
+                bars.mb_state_ready[state_index.idx].wait(state_index.phase)
+                mma_ss(
+                    bmm_state_k_kmaj_desc,
+                    d_state_direct0,
+                    d_kd_lead0 + decay_op_off,
+                    nvvm.make_tmem_ptr((tmem_base + cfg.tmem_state_k_acc_offset), cutlass.Float32),
+                    accumulate=False,
+                )
+                if elect_one:
+                    bars.mb_state_k_acc_ready.arrive(cta_group=1)
+                    bars.mb_state_done[state_index.idx].arrive(cta_group=1)
+                state_index = advance(state_index, cfg.smem_state_stages)
+
+            # ---- dQ inter = state(T) @ dO^T ------------------------------------------
+            bars.mb_dqk_acc_done.wait(parts_done_index.phase)
+            parts_done_index = advance(parts_done_index, 1)
+            bars.mb_state_inp_ready[chunk_serial % 2].wait((chunk_serial // 2) % 2)
+            bars.mb_do_ready[raw_stage_idx].wait((chunk_serial // cfg.smem_raw_stages) % 2)
+            if chunk_idx >= FIRST_STATE_CHUNK:
+                a_ptr = nvvm.make_tmem_ptr((tmem_base + cfg.tmem_state_inp_offset + (chunk_serial % 2) * (cfg.d_v // 2)), cutlass.Int8)
+                b_desc = d_do_lead0 + raw_stage_idx * do_seg
+                c_ptr = nvvm.make_tmem_ptr((tmem_base + cfg.tmem_dq_acc_offset), cutlass.Float32)
+                for sub in cutlass.range_constexpr(bmm_dstate_ts_desc.num_subtiles_B):
+                    for k in cutlass.range_constexpr(bmm_dstate_ts_desc.sps_B):
+                        mma_ts_step(
+                            bmm_dstate_ts_desc,
+                            a_ptr.subview(sub * bmm_dstate_ts_desc.sps_B * bmm_dstate_ts_desc.tmem_advance_A),
+                            b_desc + sub * (bmm_dstate_ts_desc.smem_subtile_B >> 4),
+                            c_ptr,
+                            k,
+                            cutlass.Boolean(sub + k > 0),
+                        )
+
+            # ---- dU inter = dstate(T) @ K_restore ------------------------------------
+            bars.mb_q_decay_k_restore_ready[decay_stage].wait(decay_phase)
+            if has_dstate:
+                bars.mb_dstate_inp_ready.wait(dstate_inp_index.phase)
+                a_ptr = nvvm.make_tmem_ptr((tmem_base + cfg.tmem_dstate_inp_offset), cutlass.Int8)
+                b_desc = d_kr_lead0 + decay_op_off
+                c_ptr = nvvm.make_tmem_ptr((tmem_base + cfg.tmem_du_acc_offset), cutlass.Float32)
+                for sub in cutlass.range_constexpr(bmm_dvinter_desc.num_subtiles_B):
+                    for k in cutlass.range_constexpr(bmm_dvinter_desc.sps_B):
+                        mma_ts_step(
+                            bmm_dvinter_desc,
+                            a_ptr.subview(sub * bmm_dvinter_desc.sps_B * bmm_dvinter_desc.tmem_advance_A),
+                            b_desc + sub * (bmm_dvinter_desc.smem_subtile_B >> 4),
+                            c_ptr,
+                            k,
+                            cutlass.Boolean(sub + k > 0),
+                        )
+
+            # ---- dstate decay = dstate(T) @ diag(eGl) ------------------------------------
+            if has_dstate:
+                desc_diag = d_diag0 + decay_stage * diag_seg
+                for k_block in cutlass.range_constexpr(cfg.d_k // 16):
+                    a_ptr = nvvm.make_tmem_ptr((tmem_base + cfg.tmem_dstate_inp_offset) + k_block * 8, cutlass.Int8)
+                    b_desc = desc_diag.advance_start_address(k_block * 256 * 2)
+                    c_ptr = nvvm.make_tmem_ptr((tmem_base + cfg.tmem_dstate_acc_offset) + k_block * 16, cutlass.Float32)
+                    for sub in cutlass.range_constexpr(bmm_diag_desc.num_subtiles_B):
+                        for k in cutlass.range_constexpr(bmm_diag_desc.sps_B):
+                            mma_ts_step(
+                                bmm_diag_desc,
+                                a_ptr.subview(sub * bmm_diag_desc.sps_B * bmm_diag_desc.tmem_advance_A),
+                                b_desc + sub * (bmm_diag_desc.smem_subtile_B >> 4),
+                                c_ptr,
+                                k,
+                                cutlass.Boolean(sub + k > 0),
+                            )
+                dstate_inp_index = advance(dstate_inp_index, 1)
+
+            # ---- dU intra += dO^T(S) @ A -----------------------------------------
+            bars.mb_a_ready[intermediate_stage].wait(intermediate_phase)
+            mma_ss(
+                bmm_du_at_desc,
+                d_do_amaj,
+                d_int,
+                nvvm.make_tmem_ptr((tmem_base + cfg.tmem_du_acc_offset), cutlass.Float32),
+                accumulate=has_dstate,
+            )
+            if elect_one:
+                bars.mb_du_acc_ready.arrive(cta_group=1)
+                bars.mb_a_done[intermediate_stage].arrive(cta_group=1)
+
+            # ---- dstate q-term += dO^T(S) @ Q_decay ----------------------------------
+            mma_ss(
+                bmm_dstate_q_at_desc,
+                d_do_amaj,
+                d_qd_trans,
+                nvvm.make_tmem_ptr((tmem_base + cfg.tmem_dstate_acc_offset), cutlass.Float32),
+                accumulate=has_dstate,
+            )
+
+            # ---- U = Y(T) @ T_inv ------------------------------------------------
+            bars.mb_t_inv_ready[intermediate_stage].wait(intermediate_phase)
+            bars.mb_y_inp_ready.wait(y_inp_index.phase)
+            y_inp_index = advance(y_inp_index, 1)
+            a_ptr = nvvm.make_tmem_ptr((tmem_base + cfg.tmem_y_inp_offset), cutlass.Int8)
+            b_desc = d_int_tinv
+            c_ptr = nvvm.make_tmem_ptr((tmem_base + cfg.tmem_u_acc_offset), cutlass.Float32)
+            for sub in cutlass.range_constexpr(bmm_qk_ts_desc.num_subtiles_B):
+                for k in cutlass.range_constexpr(bmm_qk_ts_desc.sps_B):
+                    mma_ts_step(
+                        bmm_qk_ts_desc,
+                        a_ptr.subview(sub * bmm_qk_ts_desc.sps_B * bmm_qk_ts_desc.tmem_advance_A),
+                        b_desc + sub * (bmm_qk_ts_desc.smem_subtile_B >> 4),
+                        c_ptr,
+                        k,
+                        cutlass.Boolean(sub + k > 0),
+                    )
+            if elect_one:
+                bars.mb_u_acc_ready.arrive(cta_group=1)
+
+            # ---- dY = dU(T) @ T_inv ----------------------------------------------
+            bars.mb_du_inp_ready.wait(du_inp_index.phase)
+            du_inp_index = advance(du_inp_index, 1)
+            a_ptr = nvvm.make_tmem_ptr((tmem_base + cfg.tmem_du_inp_offset), cutlass.Int8)
+            dy_b_desc = d_int_tinv
+            c_ptr = nvvm.make_tmem_ptr((tmem_base + cfg.tmem_dy_acc_offset), cutlass.Float32)
+            for sub in cutlass.range_constexpr(bmm_qk_ts_t_desc.num_subtiles_B):
+                for k in cutlass.range_constexpr(bmm_qk_ts_t_desc.sps_B):
+                    mma_ts_step(
+                        bmm_qk_ts_t_desc,
+                        a_ptr.subview(sub * bmm_qk_ts_t_desc.sps_B * bmm_qk_ts_t_desc.tmem_advance_A),
+                        dy_b_desc + sub * (bmm_qk_ts_t_desc.smem_subtile_B >> 4),
+                        c_ptr,
+                        k,
+                        cutlass.Boolean(sub + k > 0),
+                    )
+            if elect_one:
+                bars.mb_dy_acc_ready.arrive(cta_group=1)
+                bars.mb_t_inv_done[intermediate_stage].arrive(cta_group=1)
+
+            # ---- dK_restore part = dstate(S) @ U^T -----------------------------------
+            bars.mb_u_smem_ready.wait(u_smem_index.phase)
+            u_smem_index = advance(u_smem_index, 1)
+            if has_dstate:
+                bars.mb_dstate_smem_ready.wait(dstate_smem_index.phase)
+                dstate_smem_index = advance(dstate_smem_index, 1)
+                mma_ss(
+                    bmm_dstate_at_desc,
+                    d_dstate_alt0,
+                    d_u_lead0,
+                    nvvm.make_tmem_ptr((tmem_base + cfg.tmem_dk_restore_acc_offset), cutlass.Float32),
+                    accumulate=False,
+                )
+                if elect_one:
+                    bars.mb_dk_restore_part_acc_ready.arrive(cta_group=1)
+                    bars.mb_dstate_smem_done.arrive(cta_group=1)
+
+            # ---- dstate dY-term += -Beta.dY(T) @ K_decay -----------------------------
+            bars.mb_neg_beta_dy_inp_ready.wait(neg_beta_dy_index.phase)
+            neg_beta_dy_index = advance(neg_beta_dy_index, 1)
+            a_ptr = nvvm.make_tmem_ptr((tmem_base + cfg.tmem_neg_beta_dy_inp_offset), cutlass.Int8)
+            b_desc = d_kd_trans
+            c_ptr = nvvm.make_tmem_ptr((tmem_base + cfg.tmem_dstate_acc_offset), cutlass.Float32)
+            for sub in cutlass.range_constexpr(bmm_dstate_k_desc.num_subtiles_B):
+                for k in cutlass.range_constexpr(bmm_dstate_k_desc.sps_B):
+                    mma_ts_step(
+                        bmm_dstate_k_desc,
+                        a_ptr.subview(sub * bmm_dstate_k_desc.sps_B * bmm_dstate_k_desc.tmem_advance_A),
+                        b_desc + sub * (bmm_dstate_k_desc.smem_subtile_B >> 4),
+                        c_ptr,
+                        k,
+                        cutlass.Boolean(True),
+                    )
+            if elect_one:
+                bars.mb_dstate_acc_ready.arrive(cta_group=1)
+
+            # ---- dK_inv part = scale.Q_decay^T(S) @ dA ---------------------------
+            bars.mb_da_ready[intermediate_stage].wait(intermediate_phase)
+            mma_ss(
+                bmm_dgrad_at_t_desc,
+                d_qd_trans,
+                d_int_da,
+                nvvm.make_tmem_ptr((tmem_base + cfg.tmem_dk_inv_acc_offset), cutlass.Float32),
+                accumulate=False,
+            )
+
+            # ---- dQ attn += K_inv^T(S) @ dA^T ------------------------------------
+            if chunk_idx >= FIRST_STATE_CHUNK:
+                mma_ss(
+                    bmm_dgrad_at_desc,
+                    d_ki_amaj,
+                    d_int_da,
+                    nvvm.make_tmem_ptr((tmem_base + cfg.tmem_dq_acc_offset), cutlass.Float32),
+                    accumulate=True,
+                )
+            if chunk_idx < FIRST_STATE_CHUNK:
+                mma_ss(
+                    bmm_dgrad_at_desc,
+                    d_ki_amaj,
+                    d_int_da,
+                    nvvm.make_tmem_ptr((tmem_base + cfg.tmem_dq_acc_offset), cutlass.Float32),
+                    accumulate=False,
+                )
+            if elect_one:
+                bars.mb_dq_acc_ready.arrive(cta_group=1)
+                bars.mb_da_done[intermediate_stage].arrive(cta_group=1)
+
+            # ---- dK_decay part = state(T) @ (Beta.dY)^T ------------------------------
+            bars.mb_dv_tmastg_ready[chunk_serial % cfg.smem_dv_stages].wait((chunk_serial // cfg.smem_dv_stages) % 2)
+            if chunk_idx >= FIRST_STATE_CHUNK:
+                a_ptr = nvvm.make_tmem_ptr((tmem_base + cfg.tmem_state_inp_offset + (chunk_serial % 2) * (cfg.d_v // 2)), cutlass.Int8)
+                b_desc = d_dv_lead0 + (chunk_serial % cfg.smem_dv_stages) * dv_seg
+                c_ptr = nvvm.make_tmem_ptr((tmem_base + cfg.tmem_dk_decay_acc_offset), cutlass.Float32)
+                for sub in cutlass.range_constexpr(bmm_dstate_ts_desc.num_subtiles_B):
+                    for k in cutlass.range_constexpr(bmm_dstate_ts_desc.sps_B):
+                        mma_ts_step(
+                            bmm_dstate_ts_desc,
+                            a_ptr.subview(sub * bmm_dstate_ts_desc.sps_B * bmm_dstate_ts_desc.tmem_advance_A),
+                            b_desc + sub * (bmm_dstate_ts_desc.smem_subtile_B >> 4),
+                            c_ptr,
+                            k,
+                            cutlass.Boolean(sub + k > 0),
+                        )
+            if elect_one:
+                bars.mb_state_inp_done[chunk_serial % 2].arrive(cta_group=1)
+
+            # ---- dK_inv part += K_decay^T(S) @ -dM_strict ------------------------
+            bars.mb_dm_ready[intermediate_stage].wait(intermediate_phase)
+            mma_ss(
+                bmm_dgrad_at_t_desc,
+                d_kd_trans,
+                d_int_ndm,
+                nvvm.make_tmem_ptr((tmem_base + cfg.tmem_dk_inv_acc_offset), cutlass.Float32),
+                accumulate=True,
+            )
+            if elect_one:
+                bars.mb_dk_inv_part_acc_ready.arrive(cta_group=1)
+
+            # ---- dK_decay part += K_inv^T(S) @ dM_strict^T -----------------------
+            if chunk_idx >= FIRST_STATE_CHUNK:
+                mma_ss(
+                    bmm_dgrad_at_desc,
+                    d_ki_amaj,
+                    d_int_dm,
+                    nvvm.make_tmem_ptr((tmem_base + cfg.tmem_dk_decay_acc_offset), cutlass.Float32),
+                    accumulate=True,
+                )
+            if chunk_idx < FIRST_STATE_CHUNK:
+                mma_ss(
+                    bmm_dgrad_at_desc,
+                    d_ki_amaj,
+                    d_int_dm,
+                    nvvm.make_tmem_ptr((tmem_base + cfg.tmem_dk_decay_acc_offset), cutlass.Float32),
+                    accumulate=False,
+                )
+            if elect_one:
+                bars.mb_dk_decay_part_acc_ready.arrive(cta_group=1)
+                bars.mb_dm_done[intermediate_stage].arrive(cta_group=1)
+                bars.mb_decay_done[decay_stage].arrive(cta_group=1)
+
+        # ---- tile end: WG1's dstate0 drain gates the next tile's dstate reuse ------------
+        bars.mb_dstate0_acc_stored.wait(dstate0_index.phase)
+        dstate0_index = advance(dstate0_index, 1)
+        chunk_serial_base += num_compute_chunks
+        tile_idx, sched_state = sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas)
+    bars.mb_tmem_done[0].wait(0)
+    nvvm.tcgen05_relinquish_alloc_permit(group=nvvm.CTAGroup.CTA_1)
+    nvvm.tcgen05_dealloc(
+        nvvm.make_tmem_ptr(tmem_base, cutlass.Int8),
+        cutlass.Int32(512),
+        group=nvvm.CTAGroup.CTA_1,
+    )
+
+
+@cute.jit
+def tmaldg_warp(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    n_desc,
+    cu_seqlens,
+    mWorkItems,
+    mSched,
+    sSched,
+    lane,
+    sQ_raw,
+    sK_raw,
+    sV_raw,
+    sGate_raw,
+    sDo_raw,
+    sState_raw,
+    desc_q_base,
+    desc_k_base,
+    desc_v_base,
+    desc_gate_base,
+    desc_do_base,
+    desc_checkpoint_base,
+    bars,
+) -> None:
+    """TMA-LDG warp role (warp 14): persistent tile-scheduler loop issuing
+    every G->S TMA load."""
+    elect_one = nvvm.elect_sync()
+
+    nvvm.setmaxregister(cfg.num_regs_other, nvvm.SetMaxRegisterAction.DECREASE)
+
+    sQ_tma = SmemTile(
+        base=sQ_raw,
+        elems_per_stage=(cfg.d_k * cfg.b_t),
+        stages=cfg.smem_raw_stages,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=0,
+        tma_loads_per_tile=(cfg.d_k // 64),
+        tma_granu_elems=64,
+        tma_subtile_stride_elems=(cfg.b_t * 64),
+    )
+    sK_tma = SmemTile(
+        base=sK_raw,
+        elems_per_stage=(cfg.d_k * cfg.b_t),
+        stages=cfg.smem_raw_stages,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=0,
+        tma_loads_per_tile=(cfg.d_k // 64),
+        tma_granu_elems=64,
+        tma_subtile_stride_elems=(cfg.b_t * 64),
+    )
+    sV_tma = SmemTile(
+        base=sV_raw,
+        elems_per_stage=(cfg.d_v * cfg.b_t),
+        stages=cfg.smem_raw_stages,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=0,
+        tma_loads_per_tile=(cfg.d_v // 64),
+        tma_granu_elems=64,
+        tma_subtile_stride_elems=(cfg.b_t * 64),
+    )
+    sGate_tma = SmemTile(
+        base=sGate_raw,
+        elems_per_stage=(cfg.d_k * cfg.b_t),
+        stages=cfg.smem_raw_stages,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=0,
+        tma_loads_per_tile=(cfg.d_k // 32),
+        tma_granu_elems=32,
+        tma_subtile_stride_elems=(cfg.b_t * 32),
+    )
+    sDo_tma = SmemTile(
+        base=sDo_raw,
+        elems_per_stage=(cfg.d_v * cfg.b_t),
+        stages=cfg.smem_raw_stages,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=0,
+        tma_loads_per_tile=(cfg.d_v // 64),
+        tma_granu_elems=64,
+        tma_subtile_stride_elems=(cfg.b_t * 64),
+    )
+    sState_tma = SmemTile(
+        base=sState_raw,
+        elems_per_stage=(cfg.d_k * cfg.d_v),
+        stages=cfg.smem_state_stages,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=0,
+        tma_loads_per_tile=(cfg.d_v // 64),
+        tma_granu_elems=64,
+        tma_subtile_stride_elems=cfg.d_k * 64,
+    )
+    raw_index = PipelineState.start(phase=1)
+    state_index = PipelineState.start(phase=1)
+    sched_state = PipelineState.start(phase=1)
+    packed_tokens = cutlass.Int32(cu_seqlens[n_desc])
+    tile_idx = cutlass.Int32(bidx)
+    FIRST_STATE_CHUNK = 0 if cfg.use_initial_state else 1
+    while tile_idx < total_tiles:
+        batch_idx, head_idx, batch_start, batch_end, seqlen_b, num_chunks_b, wstart, wend, cstart, cend = decode_work_item(cfg, tile_idx, mWorkItems)
+        next_tile, sched_state = sched_publish_next(cfg, bars, sSched, mSched, sched_state, tile_idx, num_ctas)
+        head_o = head_idx
+        head_q = head_idx if cfg.q_ratio == 1 else head_idx // cutlass.Int32(cfg.q_ratio)
+        head_k = head_idx if cfg.k_ratio == 1 else head_idx // cutlass.Int32(cfg.k_ratio)
+        head_v = head_idx if cfg.v_ratio == 1 else head_idx // cutlass.Int32(cfg.v_ratio)
+        slot = batch_idx * cutlass.Int32(TENSOR_MAP_QWORDS)
+        desc_q_slot = (desc_q_base + slot).tospace(cutlass.AddressSpace.generic)
+        desc_k_slot = (desc_k_base + slot).tospace(cutlass.AddressSpace.generic)
+        desc_v_slot = (desc_v_base + slot).tospace(cutlass.AddressSpace.generic)
+        desc_gate_slot = (desc_gate_base + slot).tospace(cutlass.AddressSpace.generic)
+        desc_do_slot = (desc_do_base + slot).tospace(cutlass.AddressSpace.generic)
+        desc_checkpoint_slot = (desc_checkpoint_base + slot).tospace(cutlass.AddressSpace.generic)
+        if elect_one:
+            tma_tensormap_acquire(desc_q_slot)
+            tma_tensormap_acquire(desc_k_slot)
+            tma_tensormap_acquire(desc_v_slot)
+            tma_tensormap_acquire(desc_gate_slot)
+            tma_tensormap_acquire(desc_do_slot)
+            tma_tensormap_acquire(desc_checkpoint_slot)
+        use_packed_coords = batch_end == packed_tokens
+        num_compute_chunks = cend - wstart
+        for rev_idx in cutlass.range(num_compute_chunks, unroll=1):
+            chunk_idx = cend - cutlass.Int32(1) - rev_idx
+            chunk_start = chunk_idx * cfg.b_t
+            input_chunk_start = (
+                batch_start + chunk_start if use_packed_coords else chunk_start
+            )
+
+            # ---- Q load ----------------------------------------------------------
+            bars.mb_q_done[raw_index.idx].wait(raw_index.phase)
+            if elect_one:
+                bars.mb_q_ready[raw_index.idx].arrive(n_bytes=cfg.tma_q_bytes)
+            q_slice = tma_slice_runtime_desc(
+                desc_q_slot, cutlass.Int32(0), head_q, input_chunk_start
+            )
+            tma_load_tile(sQ_tma[raw_index.idx], q_slice, bars.mb_q_ready[raw_index.idx].smem_ptr, acquire=False)
+
+            # ---- K load ----------------------------------------------------------
+            bars.mb_k_done[raw_index.idx].wait(raw_index.phase)
+            if elect_one:
+                bars.mb_k_ready[raw_index.idx].arrive(n_bytes=cfg.tma_k_bytes)
+            k_slice = tma_slice_runtime_desc(
+                desc_k_slot, cutlass.Int32(0), head_k, input_chunk_start
+            )
+            tma_load_tile(sK_tma[raw_index.idx], k_slice, bars.mb_k_ready[raw_index.idx].smem_ptr, acquire=False)
+
+            # ---- Gate load -------------------------------------------------------
+            bars.mb_gate_done[raw_index.idx].wait(raw_index.phase)
+            if elect_one:
+                bars.mb_gate_ready[raw_index.idx].arrive(n_bytes=cfg.tma_gate_bytes)
+            gate_slice = tma_slice_runtime_desc(
+                desc_gate_slot, cutlass.Int32(0), head_o, input_chunk_start
+            )
+            tma_load_tile(sGate_tma[raw_index.idx], gate_slice, bars.mb_gate_ready[raw_index.idx].smem_ptr, acquire=False)
+
+            # ---- dO load ---------------------------------------------------------
+            bars.mb_do_done[raw_index.idx].wait(raw_index.phase)
+            if elect_one:
+                bars.mb_do_ready[raw_index.idx].arrive(n_bytes=cfg.tma_do_bytes)
+            do_slice = tma_slice_runtime_desc(
+                desc_do_slot, cutlass.Int32(0), head_o, input_chunk_start
+            )
+            tma_load_tile(sDo_tma[raw_index.idx], do_slice, bars.mb_do_ready[raw_index.idx].smem_ptr, acquire=False)
+
+            # ---- V load ----------------------------------------------------------
+            bars.mb_v_done[raw_index.idx].wait(raw_index.phase)
+            if elect_one:
+                bars.mb_v_ready[raw_index.idx].arrive(n_bytes=cfg.tma_v_bytes)
+            v_slice = tma_slice_runtime_desc(
+                desc_v_slot, cutlass.Int32(0), head_v, input_chunk_start
+            )
+            tma_load_tile(sV_tma[raw_index.idx], v_slice, bars.mb_v_ready[raw_index.idx].smem_ptr, acquire=False)
+
+            # ---- entering state ----
+            if chunk_idx >= FIRST_STATE_CHUNK:
+                state_idx = state_index.idx
+                bars.mb_state_cg0_done[state_idx].wait(state_index.phase)
+                bars.mb_state_done[state_idx].wait(state_index.phase)
+                state_index = advance(state_index, cfg.smem_state_stages)
+                if elect_one:
+                    bars.mb_state_ready[state_idx].arrive(n_bytes=cfg.tma_state_bytes)
+                state_slice = tma_slice_runtime_desc(desc_checkpoint_slot, cutlass.Int32(0), cutlass.Int32(0), chunk_idx, head_o)
+                tma_load_tile(sState_tma[state_idx], state_slice, bars.mb_state_ready[state_idx].smem_ptr, acquire=False)
+            raw_index = advance(raw_index, cfg.smem_raw_stages)
+        tile_idx = next_tile
+
+
+@cute.jit
+def gate_scale(cfg, raw_gate: cutlass.Float32) -> cutlass.Float32:
+    """Map raw gate to the log2-domain decay increment used by KDA."""
+
+    if cutlass.const_expr(cfg.safe_gate):
+        half = cutlass.Float32(0.5)
+        sigmoid = cute.math.tanh(raw_gate * half, approx=True) * half + half
+        return cfg.gate_scale_log2 * sigmoid
+    # Default ABI: Gate arrives in natural-log space
+    return raw_gate * cutlass.Float32(LOG2_E)
+
+
+@cute.jit
+def compute0_warp_group(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    cu_seqlens,
+    mWorkItems,
+    sSched,
+    lane,
+    tmem_base_holder,
+    warp_idx,
+    scale,
+    mA_log,
+    mDt_bias,
+    mBeta,
+    sBeta_raw,
+    sK_inv_raw,
+    sGate_raw,
+    sK_raw,
+    sQ_raw,
+    sState_raw,
+    sNorm_raw,
+    sK_decay_raw,
+    sK_restore_raw,
+    sQ_decay_raw,
+    sState_scale_diag_raw,
+    bars,
+) -> None:
+    """WG0 warp role (warps 0-3): persistent tile-scheduler loop + gate prefix
+    scan and the decay/restore operand materialization into tcgen05 SMEM for
+    EVERY chunk (no ping-pong: the backward pipeline is drain-bound).  Also
+    stashes the per-row Q/K inverse norms for WG2's dGate assembly and copies
+    H -> TMEM f16 at the chunk tail."""
+    nvvm.setmaxregister(cfg.num_regs_compute_group_0, nvvm.SetMaxRegisterAction.INCREASE)
+    cg0_warp = warp_idx - cfg.compute_group_0_warp_ids[0]
+    prefix_dim = cg0_warp * cfg.threads_per_warp + lane
+    cg0_a_log_exp = cutlass.Float32(1.0)
+    cg0_dt_bias_value = cutlass.Float32(0.0)
+    nvvm.barrier_cta_sync(cfg.tmem_lifecycle_barrier_id, thread_count=cfg.tmem_user_threads)
+    tmem_base = tmem_base_holder.load()
+    tmem_col = tmem_base & 0xFFFF
+    tmem_row = tmem_base >> 16
+    tmem_subpartition = warp_idx % (cfg.d_v // cfg.threads_per_warp)
+    value_dim = tmem_subpartition * cfg.threads_per_warp + lane
+    row_addr = (tmem_row + tmem_subpartition * cfg.threads_per_warp) << 16
+    state_index = PipelineState.start(phase=0)
+    chunk_serial_base = cutlass.Int32(0)
+    sched_state = PipelineState.start(phase=0)
+    tile_idx = cutlass.Int32(bidx)
+    FIRST_STATE_CHUNK = 0 if cfg.use_initial_state else 1
+    while tile_idx < total_tiles:
+        batch_idx, head_idx, batch_start, batch_end, seqlen_b, num_chunks_b, wstart, wend, cstart, cend = decode_work_item(cfg, tile_idx, mWorkItems)
+        num_compute_chunks = cend - wstart
+        if cutlass.const_expr(cfg.safe_gate):
+            if num_compute_chunks > 0:
+                cg0_a_log_exp = cute.math.exp2(mA_log[head_idx].to(cutlass.Float32) * LOG2_E, fastmath=True)
+                cg0_dt_bias_value = mDt_bias[head_idx, prefix_dim].to(cutlass.Float32)
+        for rev_idx in cutlass.range(num_compute_chunks, unroll=1):
+            chunk_idx = cend - cutlass.Int32(1) - rev_idx
+            chunk_serial = chunk_serial_base + rev_idx
+            chunk_start = chunk_idx * cfg.b_t
+            decay_stage = chunk_serial % cfg.smem_decay_stages
+            raw_stage = chunk_serial % cfg.smem_raw_stages
+            sQ_ptr = sQ_raw.data_ptr() + raw_stage * (cfg.d_k * cfg.b_t)
+            sK_ptr = sK_raw.data_ptr() + raw_stage * (cfg.d_k * cfg.b_t)
+            sGate_ptr = sGate_raw.data_ptr() + raw_stage * (cfg.d_k * cfg.b_t)
+            sK_inv_ptr = sK_inv_raw.data_ptr() + decay_stage * (cfg.b_t * cfg.d_k)
+            sK_decay_ptr = sK_decay_raw.data_ptr() + decay_stage * (cfg.d_k * cfg.b_t)
+            sQ_decay_ptr = sQ_decay_raw.data_ptr() + decay_stage * (cfg.d_k * cfg.b_t)
+            sK_restore_ptr = sK_restore_raw.data_ptr() + decay_stage * (cfg.d_k * cfg.b_t)
+            sState_scale_diag_ptr = sState_scale_diag_raw.data_ptr() + decay_stage * ((cfg.d_k // 16) * 256)
+
+            # ---- beta scalars: gathered in the inputs-wait shadow ----------------
+            if cg0_warp == 0:
+                beta_stage = chunk_serial % cfg.smem_beta_stages
+                bars.mb_beta_done[beta_stage].wait(((chunk_serial // cfg.smem_beta_stages) + 1) % 2)
+                if lane < cfg.b_t:
+                    token_idx = chunk_start + lane
+                    beta_value = cutlass.Float32(0.0)
+                    if token_idx < seqlen_b:
+                        beta_value = mBeta[batch_start + token_idx, head_idx].to(cutlass.Float32)
+                        if cutlass.const_expr(cfg.beta_sigmoid):
+                            half = cutlass.Float32(0.5)
+                            beta_value = (cute.math.tanh(beta_value * half, approx=True) * half + half).to(mBeta.element_type).to(cutlass.Float32)
+                    sBeta_raw[beta_stage * cfg.b_t + lane] = beta_value
+                bars.mb_beta_ready[beta_stage].arrive()
+
+            bars.mb_gate_ready[raw_stage].wait((chunk_serial // cfg.smem_raw_stages) % 2)
+            bars.mb_q_ready[raw_stage].wait((chunk_serial // cfg.smem_raw_stages) % 2)
+            bars.mb_k_ready[raw_stage].wait((chunk_serial // cfg.smem_raw_stages) % 2)
+
+            row_group_start = cg0_warp * (cfg.b_t // len(cfg.compute_group_0_warp_ids))
+            lane_row_group = lane // 8
+            lane_in_row_group = lane - lane_row_group * 8
+            decay_row = row_group_start + lane_row_group
+
+            g_prefix_ptr = sGate_ptr
+            prefix_dim = cg0_warp * cfg.threads_per_warp + lane
+            # ---- gate prefix scan: cumulative log-gate per key channel -----------
+            gate_raw = cutlass.Array(cutlass.Float32, cfg.b_t, alignment=16)
+            for row in cutlass.range_constexpr(cfg.b_t):
+                f32_segment = prefix_dim // 32
+                f32_segment_dim = prefix_dim - f32_segment * 32
+                prefix_idx = f32_segment * (cfg.b_t * 32) + row * 32 + swizzle_xor_128b(row, f32_segment_dim, elem_bytes=4)
+                gate_raw[row] = (sGate_ptr + prefix_idx).load()
+            g_prefix_regs = cutlass.Array(cutlass.Float32, cfg.b_t, alignment=16)
+            if cutlass.const_expr(cfg.safe_gate):
+                valid_rows = seqlen_b - chunk_idx * cutlass.Int32(cfg.b_t)
+                valid_mask = cutlass.vector.create_mask([cfg.b_t], [valid_rows])
+                for row_pair in cutlass.range_constexpr(cfg.b_t // 2):
+                    row0 = row_pair * 2
+                    row1 = row0 + 1
+                    gate0 = cg0_a_log_exp * (gate_raw[row0] + cg0_dt_bias_value)
+                    gate1 = cg0_a_log_exp * (gate_raw[row1] + cg0_dt_bias_value)
+                    gate0 = gate_scale(
+                        cfg,
+                        gate0,
+                    )
+                    gate1 = gate_scale(
+                        cfg,
+                        gate1,
+                    )
+                    gate_pair = cutlass.Vector.from_elements((gate0, gate1), cutlass.Float32)
+                    gate_pair = cutlass.vector.where(valid_mask[row0 : row1 + 1], gate_pair, 0.0)
+                    g_prefix_regs[row0] = gate_pair[0]
+                    g_prefix_regs[row1] = gate_pair[1]
+            else:
+                for row in cutlass.range_constexpr(cfg.b_t):
+                    gate = gate_raw[row]
+                    token_idx = chunk_idx * cutlass.Int32(cfg.b_t) + cutlass.Int32(row)
+                    if token_idx < seqlen_b:
+                        gate = gate_scale(
+                            cfg,
+                            gate,
+                        )
+                    else:
+                        gate = cutlass.Float32(0.0)
+                    g_prefix_regs[row] = gate
+
+            prefix_acc = cutlass.Float32(0.0)
+            for row_pair in cutlass.range_constexpr(cfg.b_t // 2):
+                row0 = row_pair * 2
+                row1 = row0 + 1
+                gate0 = g_prefix_regs[row0]
+                gate1 = g_prefix_regs[row1]
+                pair_vec = nvvm.add_packed_f32x2(
+                    cutlass.Vector.from_elements((prefix_acc, gate0), cutlass.Float32),
+                    cutlass.Vector.from_elements((gate0, gate1), cutlass.Float32),
+                    ftz=False,
+                    rnd="rn",
+                )
+                prefix0, row_pair_sum = cutlass.Float32(pair_vec[0]), cutlass.Float32(pair_vec[1])
+                prefix1 = prefix_acc + row_pair_sum
+                g_prefix_regs[row0] = prefix0
+                g_prefix_regs[row1] = prefix1
+                prefix_acc = prefix1
+
+            for row in cutlass.range_constexpr(cfg.b_t):
+                g_prefix_regs[row] = cute.math.exp2(g_prefix_regs[row], fastmath=True)
+
+            exp_g_last = g_prefix_regs[cfg.b_t - 1]
+            # ---- decay-slot guard: previous use fully consumed -------------------
+            operand_done_phase = ((chunk_serial // cfg.smem_decay_stages) + 1) % 2
+            bars.mb_decay_done[decay_stage].wait(operand_done_phase)
+
+            for row in cutlass.range_constexpr(cfg.b_t):
+                f32_segment = prefix_dim // 32
+                f32_segment_dim = prefix_dim - f32_segment * 32
+                prefix_idx = f32_segment * (cfg.b_t * 32) + row * 32 + swizzle_xor_128b(row, f32_segment_dim, elem_bytes=4)
+                (sGate_ptr + prefix_idx).store(g_prefix_regs[row])
+
+            # ---- state-scale diag: stage exp2(g_last) decay blocks ---------------
+            block = prefix_dim // cutlass.Int32(16)
+            coord = prefix_dim - block * cutlass.Int32(16)
+            linear_idx = block * cutlass.Int32(256) + coord * cutlass.Int32(16) + coord
+            diag_idx = swizzle_lin_S(linear_idx, bbits=1, mbase=3, sshift=3)
+            sState_scale_diag_ptr[diag_idx] = exp_g_last.to(cfg.io_dtype)
+
+            # ---- raw Q/K: SMEM -> TMEM ring (channel-major, for WG2) -------------
+            qk_raw_stage = chunk_serial % cfg.tmem_qk_raw_stages
+            bars.mb_qk_raw_done[qk_raw_stage].wait(((chunk_serial // cfg.tmem_qk_raw_stages) + 1) % 2)
+            raw_seg = prefix_dim // 64
+            raw_dim = prefix_dim - raw_seg * 64
+            q_raw_words = cutlass.Array(cutlass.Int32, cfg.b_t // 2, alignment=16)
+            k_raw_words = cutlass.Array(cutlass.Int32, cfg.b_t // 2, alignment=16)
+            for t2 in cutlass.range_constexpr(cfg.b_t // 2):
+                t0 = 2 * t2
+                ridx0 = raw_seg * (cfg.b_t * 64) + t0 * 64 + swizzle_xor_128b(t0, raw_dim, elem_bytes=2)
+                ridx1 = raw_seg * (cfg.b_t * 64) + (t0 + 1) * 64 + swizzle_xor_128b(t0 + 1, raw_dim, elem_bytes=2)
+                q0 = (sQ_ptr + ridx0).load().to(cutlass.Float32)
+                q1 = (sQ_ptr + ridx1).load().to(cutlass.Float32)
+                k0 = (sK_ptr + ridx0).load().to(cutlass.Float32)
+                k1 = (sK_ptr + ridx1).load().to(cutlass.Float32)
+                q_raw_words[t2] = fp32_to_fp16(q0, q1, dtype=cfg.io_dtype)
+                k_raw_words[t2] = fp32_to_fp16(k0, k1, dtype=cfg.io_dtype)
+            nvvm.tcgen05_st(
+                "32x32b",
+                nvvm.make_tmem_ptr(row_addr + (tmem_col + cfg.tmem_qraw_inp_offset + qk_raw_stage * (cfg.b_t // 2)), cutlass.Int8),
+                q_raw_words[0 : (cfg.b_t // 2)],
+            )
+            nvvm.tcgen05_st(
+                "32x32b",
+                nvvm.make_tmem_ptr(row_addr + (tmem_col + cfg.tmem_kraw_inp_offset + qk_raw_stage * (cfg.b_t // 2)), cutlass.Int8),
+                k_raw_words[0 : (cfg.b_t // 2)],
+            )
+            nvvm.tcgen05_wait("store")
+            bars.mb_qk_raw_ready[qk_raw_stage].arrive()
+
+            nvvm.barrier_cta_sync(cfg.cg0_sync_barrier_id, thread_count=cfg.cg0_threads)
+
+            k_inv_pack = cutlass.Array(cutlass.Int32, 2 * 4, alignment=16)
+            raw_q_regs = cutlass.Array(cutlass.Float32, 2 * 8, alignment=16)
+            raw_k_regs = cutlass.Array(cutlass.Float32, 2 * 8, alignment=16)
+            # ---- optional Q/K L2-norm --------------------------------------------
+            if cutlass.const_expr(cfg.l2norm):
+                qk0_lo = opaque_f32_zero()
+                qk0_hi = opaque_f32_zero()
+                qk1_lo = opaque_f32_zero()
+                qk1_hi = opaque_f32_zero()
+            for dim_half in cutlass.range_constexpr(2):
+                dim_base = dim_half * (cfg.d_k // 2) + lane_in_row_group * 8
+                reg_base = dim_half * 8
+                f16_segment = dim_base // 64
+                f16_segment_dim = dim_base - f16_segment * 64
+                raw_f16_idx = f16_segment * (cfg.b_t * 64) + decay_row * 64 + swizzle_xor_128b(decay_row, f16_segment_dim, elem_bytes=2)
+                raw_q_frag = (sQ_ptr + raw_f16_idx).load(count=8, alignment=16)
+                raw_k_frag = (sK_ptr + raw_f16_idx).load(count=8, alignment=16)
+                raw_q_frag_f32 = raw_q_frag.to(cutlass.Float32)
+                raw_k_frag_f32 = raw_k_frag.to(cutlass.Float32)
+                for dim_offset in cutlass.range_constexpr(8):
+                    q_val = raw_q_frag_f32[dim_offset]
+                    k_val = raw_k_frag_f32[dim_offset]
+                    raw_q_regs[reg_base + dim_offset] = q_val
+                    raw_k_regs[reg_base + dim_offset] = k_val
+                    if cutlass.const_expr(cfg.l2norm):
+                        if cutlass.const_expr(dim_offset % 2 == 0):
+                            qk0_lo, qk0_hi = ffma2(q_val, k_val, q_val, k_val, qk0_lo, qk0_hi)
+                        else:
+                            qk1_lo, qk1_hi = ffma2(q_val, k_val, q_val, k_val, qk1_lo, qk1_hi)
+
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_q_done[raw_stage].arrive()
+            bars.mb_k_done[raw_stage].arrive()
+
+            q_inv_norm = opaque_f32_zero() + cutlass.Float32(1.0)
+            k_inv_norm = opaque_f32_zero() + cutlass.Float32(1.0)
+            if cutlass.const_expr(cfg.l2norm):
+                q_sum_sq = qk0_lo + qk1_lo
+                k_sum_sq = qk0_hi + qk1_hi
+                q_sum_sq = q_sum_sq + cutlass.Float32(nvvm.shfl_sync(0xFFFFFFFF, q_sum_sq, 4, 31, kind=nvvm.Shfl.BFLY))
+                q_sum_sq = q_sum_sq + cutlass.Float32(nvvm.shfl_sync(0xFFFFFFFF, q_sum_sq, 2, 31, kind=nvvm.Shfl.BFLY))
+                q_sum_sq = q_sum_sq + cutlass.Float32(nvvm.shfl_sync(0xFFFFFFFF, q_sum_sq, 1, 31, kind=nvvm.Shfl.BFLY))
+                k_sum_sq = k_sum_sq + cutlass.Float32(nvvm.shfl_sync(0xFFFFFFFF, k_sum_sq, 4, 31, kind=nvvm.Shfl.BFLY))
+                k_sum_sq = k_sum_sq + cutlass.Float32(nvvm.shfl_sync(0xFFFFFFFF, k_sum_sq, 2, 31, kind=nvvm.Shfl.BFLY))
+                k_sum_sq = k_sum_sq + cutlass.Float32(nvvm.shfl_sync(0xFFFFFFFF, k_sum_sq, 1, 31, kind=nvvm.Shfl.BFLY))
+                norm_floor_sq = cutlass.Float32(L2_NORM_EPS * L2_NORM_EPS)
+                q_inv_norm = cute.math.rsqrt(cute.math.max(q_sum_sq, norm_floor_sq), fastmath=True)
+                k_inv_norm = cute.math.rsqrt(cute.math.max(k_sum_sq, norm_floor_sq), fastmath=True)
+                if lane_in_row_group == 0:
+                    sNorm_raw[(chunk_serial % cfg.tmem_qk_raw_stages) * (2 * cfg.b_t) + decay_row] = q_inv_norm
+                    sNorm_raw[(chunk_serial % cfg.tmem_qk_raw_stages) * (2 * cfg.b_t) + cfg.b_t + decay_row] = k_inv_norm
+            q_stage_norm = q_inv_norm * scale
+
+            # ---- decay/restore operands: exp2(+-g) applied per key channel -------
+            exp_g_regs = cutlass.Array(cutlass.Float32, 2 * 8, alignment=16)
+            exp_g_last_regs = cutlass.Array(cutlass.Float32, 2 * 8, alignment=16)
+            for dim_half in cutlass.range_constexpr(2):
+                dim_base = dim_half * (cfg.d_k // 2) + lane_in_row_group * 8
+                reg_base = dim_half * 8
+                for f32_group in cutlass.range_constexpr(2):
+                    f32_dim_base = dim_base + f32_group * 4
+                    f32_segment = f32_dim_base // 32
+                    f32_segment_dim = f32_dim_base - f32_segment * 32
+                    g_prefix_idx = f32_segment * (cfg.b_t * 32) + decay_row * 32 + swizzle_xor_128b(decay_row, f32_segment_dim, elem_bytes=4)
+                    exp_g_frag = (g_prefix_ptr + g_prefix_idx).load(count=4, alignment=16)
+                    exp_g_last_idx = f32_segment * (cfg.b_t * 32) + (cfg.b_t - 1) * 32 + swizzle_xor_128b((cfg.b_t - 1), f32_segment_dim, elem_bytes=4)
+                    exp_g_last_frag = (g_prefix_ptr + exp_g_last_idx).load(count=4, alignment=16)
+                    f32_reg_base = reg_base + f32_group * 4
+                    exp_g_regs[f32_reg_base] = exp_g_frag[0]
+                    exp_g_regs[f32_reg_base + 1] = exp_g_frag[1]
+                    exp_g_regs[f32_reg_base + 2] = exp_g_frag[2]
+                    exp_g_regs[f32_reg_base + 3] = exp_g_frag[3]
+                    exp_g_last_regs[f32_reg_base] = exp_g_last_frag[0]
+                    exp_g_last_regs[f32_reg_base + 1] = exp_g_last_frag[1]
+                    exp_g_last_regs[f32_reg_base + 2] = exp_g_last_frag[2]
+                    exp_g_last_regs[f32_reg_base + 3] = exp_g_last_frag[3]
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_gate_done[raw_stage].arrive()
+
+            for dim_half in cutlass.range_constexpr(2):
+                dim_base = dim_half * (cfg.d_k // 2) + lane_in_row_group * 8
+                reg_base = dim_half * 8
+                # ---- K decay + K inv operands: exp2(+g) * K / exp2(-g) * K -------
+                k_decay_pack = cutlass.Array(cutlass.Int32, 4, alignment=16)
+                for pair_idx in cutlass.range_constexpr(4):
+                    dim0 = pair_idx * 2
+                    dim1 = dim0 + 1
+                    raw_reg_idx0 = reg_base + dim0
+                    raw_reg_idx1 = reg_base + dim1
+                    k_value0, k_value1 = fmul2(raw_k_regs[raw_reg_idx0], raw_k_regs[raw_reg_idx1], k_inv_norm, k_inv_norm)
+                    k_pair = fp32_to_fp16(k_value0, k_value1, dtype=cfg.io_dtype)
+                    exp_g_pair = fp32_to_fp16(exp_g_regs[raw_reg_idx0], exp_g_regs[raw_reg_idx1], dtype=cfg.io_dtype)
+                    k_decay_pack[pair_idx] = mul_f16x2(k_pair, exp_g_pair, cfg.io_dtype)
+                    exp_neg_g0 = cute.math.rcp(exp_g_regs[raw_reg_idx0], approx=True, ftz=True)
+                    exp_neg_g1 = cute.math.rcp(exp_g_regs[raw_reg_idx1], approx=True, ftz=True)
+                    exp_neg_pair = fp32_to_fp16(exp_neg_g0, exp_neg_g1, dtype=cfg.io_dtype)
+                    k_inv_pack[dim_half * 4 + pair_idx] = mul_f16x2(k_pair, exp_neg_pair, cfg.io_dtype)
+
+                k_inv_vec = cutlass.Vector.from_elements(
+                    (
+                        k_inv_pack[dim_half * 4],
+                        k_inv_pack[dim_half * 4 + 1],
+                        k_inv_pack[dim_half * 4 + 2],
+                        k_inv_pack[dim_half * 4 + 3],
+                    ),
+                    cutlass.Int32,
+                ).bitcast(cfg.io_dtype)
+                k_decay_vec = cutlass.Vector.from_elements(
+                    (k_decay_pack[0], k_decay_pack[1], k_decay_pack[2], k_decay_pack[3]),
+                    cutlass.Int32,
+                ).bitcast(cfg.io_dtype)
+                f16_segment = dim_base // 64
+                f16_segment_dim = dim_base - f16_segment * 64
+                op_idx = f16_segment * (cfg.b_t * 64) + decay_row * 64 + swizzle_xor_128b(decay_row, f16_segment_dim, elem_bytes=2)
+                (sK_inv_ptr + op_idx).store(k_inv_vec, alignment=16)
+                (sK_decay_ptr + op_idx).store(k_decay_vec, alignment=16)
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_k_decay_inv_ready[decay_stage].arrive()
+
+            # ---- Q decay + K_restore operands ------------------------------------
+            for dim_half in cutlass.range_constexpr(2):
+                dim_base = dim_half * (cfg.d_k // 2) + lane_in_row_group * 8
+                reg_base = dim_half * 8
+                q_decay_pack = cutlass.Array(cutlass.Int32, 4, alignment=16)
+                k_restore_pack = cutlass.Array(cutlass.Int32, 4, alignment=16)
+                for pair_idx in cutlass.range_constexpr(4):
+                    dim0 = pair_idx * 2
+                    dim1 = dim0 + 1
+                    raw_reg_idx0 = reg_base + dim0
+                    raw_reg_idx1 = reg_base + dim1
+                    q_value0, q_value1 = fmul2(raw_q_regs[raw_reg_idx0], raw_q_regs[raw_reg_idx1], q_stage_norm, q_stage_norm)
+                    q_pair = fp32_to_fp16(q_value0, q_value1, dtype=cfg.io_dtype)
+                    exp_g_pair = fp32_to_fp16(exp_g_regs[raw_reg_idx0], exp_g_regs[raw_reg_idx1], dtype=cfg.io_dtype)
+                    q_decay_pack[pair_idx] = mul_f16x2(q_pair, exp_g_pair, cfg.io_dtype)
+                    exp_g_last_pair = fp32_to_fp16(exp_g_last_regs[raw_reg_idx0], exp_g_last_regs[raw_reg_idx1], dtype=cfg.io_dtype)
+                    k_restore_pack[pair_idx] = mul_f16x2(k_inv_pack[dim_half * 4 + pair_idx], exp_g_last_pair, cfg.io_dtype)
+
+                q_decay_vec = cutlass.Vector.from_elements(
+                    (q_decay_pack[0], q_decay_pack[1], q_decay_pack[2], q_decay_pack[3]),
+                    cutlass.Int32,
+                ).bitcast(cfg.io_dtype)
+                k_restore_vec = cutlass.Vector.from_elements(
+                    (k_restore_pack[0], k_restore_pack[1], k_restore_pack[2], k_restore_pack[3]),
+                    cutlass.Int32,
+                ).bitcast(cfg.io_dtype)
+                f16_segment = dim_base // 64
+                f16_segment_dim = dim_base - f16_segment * 64
+                op_idx = f16_segment * (cfg.b_t * 64) + decay_row * 64 + swizzle_xor_128b(decay_row, f16_segment_dim, elem_bytes=2)
+                (sQ_decay_ptr + op_idx).store(q_decay_vec, alignment=16)
+                (sK_restore_ptr + op_idx).store(k_restore_vec, alignment=16)
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_q_decay_k_restore_ready[decay_stage].arrive()
+
+            # ---- state copy: SMEM -> TMEM f16 ----------------------------------------
+            bars.mb_state_inp_done[chunk_serial % 2].wait(((chunk_serial // 2) + 1) % 2)
+            bars.mb_state_inp_cg2_done[chunk_serial % 2].wait(((chunk_serial // 2) + 1) % 2)
+            if chunk_idx >= FIRST_STATE_CHUNK:
+                bars.mb_state_ready[state_index.idx].wait(state_index.phase)
+                state_src = sState_raw.data_ptr() + state_index.idx * (cfg.d_k * cfg.d_v)
+                for v_seg in cutlass.range_constexpr(2):
+                    for v_col8 in cutlass.range_constexpr(8):
+                        state_frag = cutlass.Vector.from_elements(
+                            tuple(
+                                (
+                                    state_src
+                                    + (value_dim // 64) * (cfg.d_v * 64)
+                                    + (v_seg * 64 + v_col8 * 8 + e) * 64
+                                    + swizzle_xor_128b(v_seg * 64 + v_col8 * 8 + e, value_dim % 64, elem_bytes=2)
+                                ).load()
+                                for e in range(8)
+                            ),
+                            cfg.io_dtype,
+                        )
+                        nvvm.tcgen05_st(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(
+                                row_addr + (tmem_col + cfg.tmem_state_inp_offset + (chunk_serial % 2) * (cfg.d_v // 2) + v_seg * 32 + v_col8 * 4), cutlass.Int8
+                            ),
+                            state_frag.bitcast(cutlass.Int32),
+                        )
+                nvvm.tcgen05_wait("store")
+                bars.mb_state_cg0_done[state_index.idx].arrive()
+                state_index = advance(state_index, cfg.smem_state_stages)
+            bars.mb_state_inp_ready[chunk_serial % 2].arrive()
+        chunk_serial_base += num_compute_chunks
+        tile_idx, sched_state = sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas)
+
+
+@cute.jit
+def compute1_warp_group(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    cu_seqlens,
+    mWorkItems,
+    sSched,
+    lane,
+    tmem_base_holder,
+    warp_idx,
+    mDbeta,
+    mDstate0,
+    mDstate_in,
+    sV_raw,
+    sDo_raw,
+    sBeta_raw,
+    sU_raw,
+    sDy_raw,
+    sDv_raw,
+    sDstate_raw,
+    sRed_raw,
+    sBetaM_raw,
+    bars,
+) -> None:
+    """WG1 warp role (warps 4-7): the value-side TMEM staging."""
+    nvvm.setmaxregister(cfg.num_regs_compute_group_1, nvvm.SetMaxRegisterAction.INCREASE)
+    nvvm.barrier_cta_sync(cfg.tmem_lifecycle_barrier_id, thread_count=cfg.tmem_user_threads)
+    tmem_base = tmem_base_holder.load()
+    tmem_col = tmem_base & 0xFFFF
+    tmem_row = tmem_base >> 16
+    tmem_subpartition = warp_idx % (cfg.d_v // cfg.threads_per_warp)
+    token_row_coord = (lane // 16) * 8 + (lane & 7)
+    value_col_offset = ((lane // 8) & 1) * 8
+    value_dim = tmem_subpartition * cfg.threads_per_warp + lane
+    value_dim_base = tmem_subpartition * cfg.threads_per_warp
+    cg1_tidx = warp_idx % 4 * cfg.threads_per_warp + lane
+
+    raw_index = PipelineState.start(phase=0)
+    state_k_index = PipelineState.start(phase=0)
+    u_acc_index = PipelineState.start(phase=0)
+    du_acc_index = PipelineState.start(phase=0)
+    dy_acc_index = PipelineState.start(phase=0)
+    dstate_ready_index = PipelineState.start(phase=0)
+    dstate_smem_done_index = PipelineState.start(phase=1)
+    dbeta_m_index = PipelineState.start(phase=0)
+    dv_done_index = PipelineState.start(phase=1)
+
+    chunk_serial_base = cutlass.Int32(0)
+    sched_state = PipelineState.start(phase=0)
+    tile_idx = cutlass.Int32(bidx)
+    FIRST_STATE_CHUNK = 0 if cfg.use_initial_state else 1
+    while tile_idx < total_tiles:
+        batch_idx, head_idx, batch_start, batch_end, seqlen_b, num_chunks_b, wstart, wend, cstart, cend = decode_work_item(cfg, tile_idx, mWorkItems)
+        num_compute_chunks = cend - wstart
+
+        # ---- dht seeding: dh acc + dh_inp f16 + sdH ------------------------------
+        if cutlass.const_expr(cfg.use_dstate_in):
+            if num_compute_chunks > 0:
+                seed_true = cend == num_chunks_b
+                bars.mb_dstate_smem_done.wait(dstate_smem_done_index.phase)
+                bars.mb_dstate_smem_cg2_done.wait(dstate_smem_done_index.phase)
+                dstate_smem_done_index = advance(dstate_smem_done_index, 1)
+                row_addr = (tmem_row + tmem_subpartition * cfg.threads_per_warp) << 16
+                dstate_src = (mDstate_in.iterator + mDstate_in.layout((batch_idx, head_idx, value_dim, 0))).raw_ptr()
+                for sub in cutlass.range_constexpr(cfg.d_k // 16):
+                    seed_block = cutlass.Array(cutlass.Float32, 16, alignment=16)
+                    for g in cutlass.range_constexpr(4):
+                        seed_chunk = (dstate_src + sub * 16 + g * 4).load(count=4, alignment=16)
+                        for t in cutlass.range_constexpr(4):
+                            dval = seed_chunk[t].to(cutlass.Float32)
+                            seed_block[g * 4 + t] = dval if seed_true else cutlass.Float32(0.0)
+                    nvvm.tcgen05_st(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(row_addr + (tmem_col + cfg.tmem_dstate_acc_offset + sub * 16), cutlass.Float32),
+                        seed_block[0:16],
+                    )
+                    seed_pack = cutlass.Array(cutlass.Int32, 8, alignment=16)
+                    for pc in cutlass.range_constexpr(8):
+                        seed_pack[pc] = fp32_to_fp16(seed_block[2 * pc], seed_block[2 * pc + 1], dtype=cfg.io_dtype)
+                    nvvm.tcgen05_st(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(row_addr + (tmem_col + cfg.tmem_dstate_inp_offset + sub * 8), cutlass.Int8),
+                        seed_pack[0:8],
+                    )
+                nvvm.tcgen05_wait("store")
+                bars.mb_dstate_inp_ready.arrive()
+
+                # ---- dht seed -> sdH: re-read dh_inp after the TMEM publish ------
+                for sub in cutlass.range_constexpr(cfg.d_k // 16):
+                    dstate_words = nvvm.tcgen05_ld(
+                        "32x32b", nvvm.make_tmem_ptr(row_addr + (tmem_col + cfg.tmem_dstate_inp_offset + sub * 8), cutlass.Float32), num=8
+                    )
+                    for half in cutlass.range_constexpr(2):
+                        d_base = sub * 16 + half * 8
+                        h_vec = cutlass.Vector.from_elements(
+                            (dstate_words[half * 4], dstate_words[half * 4 + 1], dstate_words[half * 4 + 2], dstate_words[half * 4 + 3]),
+                            cutlass.Float32,
+                        ).bitcast(cfg.io_dtype)
+                        h_addr = (d_base // 64) * (cfg.d_v * 64) + value_dim * 64 + swizzle_xor_128b(value_dim, d_base % 64, elem_bytes=2)
+                        (sDstate_raw.data_ptr() + h_addr).store(h_vec, alignment=16)
+                nvvm.fence_proxy("async.shared", space="cta")
+                bars.mb_dstate_smem_ready.arrive()
+
+        for rev_idx in cutlass.range(num_compute_chunks, unroll=1):
+            chunk_idx = cend - cutlass.Int32(1) - rev_idx
+            chunk_serial = chunk_serial_base + rev_idx
+            sV_ptr = sV_raw.data_ptr() + raw_index.idx * (cfg.d_v * cfg.b_t)
+            sDo_ptr = sDo_raw.data_ptr() + raw_index.idx * (cfg.d_v * cfg.b_t)
+            sBeta_ptr = sBeta_raw.data_ptr() + (chunk_serial % cfg.smem_beta_stages) * cfg.b_t
+            row_addr_lo = tmem_row << 16
+            row_addr_hi = (tmem_row + 16) << 16
+            row_id0 = tmem_row + value_dim_base
+            row_id1 = row_id0 + 16
+            has_dstate = cutlass.Boolean(rev_idx > 0)
+            if cutlass.const_expr(cfg.use_dstate_in):
+                has_dstate = cutlass.Boolean(True)
+
+            # ---- Y staging: Y = Beta * (V - state_k) -----------------------------
+            bars.mb_v_ready[raw_index.idx].wait((chunk_serial // cfg.smem_raw_stages) % 2)
+            projection_col_id = tmem_col + cfg.tmem_state_k_acc_offset
+            input_col_id = tmem_col + cfg.tmem_y_inp_offset
+            raw_v_frag0 = nvvm.ldmatrix(
+                sV_ptr
+                + (value_dim_base + value_col_offset) // 64 * (cfg.b_t * 64)
+                + token_row_coord * 64
+                + swizzle_xor_128b(token_row_coord, (value_dim_base + value_col_offset) % 64, elem_bytes=2),
+                4,
+                nvvm.MMALayout.COL,
+            )
+            raw_v_frag1 = nvvm.ldmatrix(
+                sV_ptr
+                + (value_dim_base + 16 + value_col_offset) // 64 * (cfg.b_t * 64)
+                + token_row_coord * 64
+                + swizzle_xor_128b(token_row_coord, (value_dim_base + 16 + value_col_offset) % 64, elem_bytes=2),
+                4,
+                nvvm.MMALayout.COL,
+            )
+            # fence: the V ldmatrix reads must complete before this release
+            # licenses the TMA reload (sV)
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_v_done[raw_index.idx].arrive()
+
+            bars.mb_beta_ready[chunk_serial % cfg.smem_beta_stages].wait((chunk_serial // cfg.smem_beta_stages) % 2)
+            beta_pairs = cutlass.Array(cutlass.Int32, 2, space=cutlass.AddressSpace.rmem)
+            for half in cutlass.range_constexpr(2):
+                token0 = ((half * 4 + (lane & 3)) ^ 4) * 2
+                beta0 = (sBeta_ptr + token0).load().to(cutlass.Float32)
+                beta1 = (sBeta_ptr + token0 + 1).load().to(cutlass.Float32)
+                beta_pairs[half] = fp32_to_fp16(beta0, beta1, dtype=cfg.io_dtype)
+            diff_w0 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            diff_w1 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            y_inp_pack0 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            y_inp_pack1 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            if chunk_idx >= FIRST_STATE_CHUNK:
+                bars.mb_state_k_acc_ready.wait(state_k_index.phase)
+                state_k_index = advance(state_k_index, 1)
+                state_k_vec0 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr((row_id0 << 16) + projection_col_id, cutlass.Float32), num=2)
+                state_k_vec1 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr((row_id1 << 16) + projection_col_id, cutlass.Float32), num=2)
+                for reg_idx in cutlass.range_constexpr(4):
+                    raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
+                    frag_pair = (reg_idx ^ 2) * 2
+                    state_k_pair = fp32_to_fp16(state_k_vec0[frag_pair], state_k_vec0[frag_pair + 1], dtype=cfg.io_dtype)
+                    diff_pair = sub_f16x2(raw_v_frag0[raw_matrix], state_k_pair, cfg.io_dtype)
+                    diff_w0[reg_idx ^ 2] = diff_pair
+                    y_inp_pack0[reg_idx ^ 2] = mul_f16x2(beta_pairs[reg_idx // 2], diff_pair, cfg.io_dtype)
+                for reg_idx in cutlass.range_constexpr(4):
+                    raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
+                    frag_pair = (reg_idx ^ 2) * 2
+                    state_k_pair = fp32_to_fp16(state_k_vec1[frag_pair], state_k_vec1[frag_pair + 1], dtype=cfg.io_dtype)
+                    diff_pair = sub_f16x2(raw_v_frag1[raw_matrix], state_k_pair, cfg.io_dtype)
+                    diff_w1[reg_idx ^ 2] = diff_pair
+                    y_inp_pack1[reg_idx ^ 2] = mul_f16x2(beta_pairs[reg_idx // 2], diff_pair, cfg.io_dtype)
+            if chunk_idx < FIRST_STATE_CHUNK:
+                for reg_idx in cutlass.range_constexpr(4):
+                    raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
+                    diff_w0[reg_idx ^ 2] = raw_v_frag0[raw_matrix]
+                    y_inp_pack0[reg_idx ^ 2] = mul_f16x2(beta_pairs[reg_idx // 2], raw_v_frag0[raw_matrix], cfg.io_dtype)
+                for reg_idx in cutlass.range_constexpr(4):
+                    raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
+                    diff_w1[reg_idx ^ 2] = raw_v_frag1[raw_matrix]
+                    y_inp_pack1[reg_idx ^ 2] = mul_f16x2(beta_pairs[reg_idx // 2], raw_v_frag1[raw_matrix], cfg.io_dtype)
+            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(row_addr_lo + input_col_id, cutlass.Int8), y_inp_pack0[0:4])
+            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(row_addr_hi + input_col_id, cutlass.Int8), y_inp_pack1[0:4])
+            nvvm.tcgen05_wait("store")
+            bars.mb_y_inp_ready.arrive()
+
+            # ---- dU restage: dU acc -> TMEM f16 A operand ------------------------
+            bars.mb_du_acc_ready.wait(du_acc_index.phase)
+            du_acc_index = advance(du_acc_index, 1)
+            du_col_id = tmem_col + cfg.tmem_du_acc_offset
+            du_vec0 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr((row_id0 << 16) + du_col_id, cutlass.Float32), num=2)
+            du_vec1 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr((row_id1 << 16) + du_col_id, cutlass.Float32), num=2)
+
+            du_pack0 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            du_pack1 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            for reg_idx in cutlass.range_constexpr(4):
+                frag_pair = reg_idx * 2
+                du_pack0[reg_idx] = fp32_to_fp16(du_vec0[frag_pair], du_vec0[frag_pair + 1], dtype=cfg.io_dtype)
+                du_pack1[reg_idx] = fp32_to_fp16(du_vec1[frag_pair], du_vec1[frag_pair + 1], dtype=cfg.io_dtype)
+            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(row_addr_lo + (tmem_col + cfg.tmem_du_inp_offset), cutlass.Int8), du_pack0[0:4])
+            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(row_addr_hi + (tmem_col + cfg.tmem_du_inp_offset), cutlass.Int8), du_pack1[0:4])
+            nvvm.tcgen05_wait("store")
+            bars.mb_du_inp_ready.arrive()
+
+            # ---- U readback -> sU ------------------------------------------------
+            bars.mb_u_acc_ready.wait(u_acc_index.phase)
+            u_acc_index = advance(u_acc_index, 1)
+            u_col_id = tmem_col + cfg.tmem_u_acc_offset
+            u_vec0 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr((row_id0 << 16) + u_col_id, cutlass.Float32), num=2)
+            u_vec1 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr((row_id1 << 16) + u_col_id, cutlass.Float32), num=2)
+
+            u_pack0 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            u_pack1 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            for reg_idx in cutlass.range_constexpr(4):
+                u_pack0[reg_idx] = fp32_to_fp16(u_vec0[2 * reg_idx], u_vec0[2 * reg_idx + 1], dtype=cfg.io_dtype)
+                u_pack1[reg_idx] = fp32_to_fp16(u_vec1[2 * reg_idx], u_vec1[2 * reg_idx + 1], dtype=cfg.io_dtype)
+            nvvm.stmatrix(
+                sU_raw.data_ptr()
+                + (value_dim_base + value_col_offset) // 64 * (cfg.b_t * 64)
+                + token_row_coord * 64
+                + swizzle_xor_128b(token_row_coord, (value_dim_base + value_col_offset) % 64, elem_bytes=2),
+                u_pack0.data_ptr().load(count=4, alignment=4),
+                nvvm.MMALayout.COL,
+                shape=nvvm.StoreShape.M8N8,
+            )
+            nvvm.stmatrix(
+                sU_raw.data_ptr()
+                + (value_dim_base + 16 + value_col_offset) // 64 * (cfg.b_t * 64)
+                + token_row_coord * 64
+                + swizzle_xor_128b(token_row_coord, (value_dim_base + 16 + value_col_offset) % 64, elem_bytes=2),
+                u_pack1.data_ptr().load(count=4, alignment=4),
+                nvvm.MMALayout.COL,
+                shape=nvvm.StoreShape.M8N8,
+            )
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_u_smem_ready.arrive()
+
+            # ---- dY readback -------------------------------------------------------
+            bars.mb_dy_acc_ready.wait(dy_acc_index.phase)
+            dy_acc_index = advance(dy_acc_index, 1)
+            dy_col_id = tmem_col + cfg.tmem_dy_acc_offset
+            dy_vec0 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr((row_id0 << 16) + dy_col_id, cutlass.Float32), num=2)
+            dy_vec1 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr((row_id1 << 16) + dy_col_id, cutlass.Float32), num=2)
+
+            # ---- dY -> sdY: pack + store + publish (super warp's dM operand) -------
+            addr_lo0 = (
+                (value_dim_base + value_col_offset) // 64 * (cfg.b_t * 64)
+                + token_row_coord * 64
+                + swizzle_xor_128b(token_row_coord, (value_dim_base + value_col_offset) % 64, elem_bytes=2)
+            )
+            addr_lo1 = (
+                (value_dim_base + 16 + value_col_offset) // 64 * (cfg.b_t * 64)
+                + token_row_coord * 64
+                + swizzle_xor_128b(token_row_coord, (value_dim_base + 16 + value_col_offset) % 64, elem_bytes=2)
+            )
+            dy_pack0 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            dy_pack1 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            for reg_idx in cutlass.range_constexpr(4):
+                dy_pack0[reg_idx] = fp32_to_fp16(dy_vec0[2 * reg_idx], dy_vec0[2 * reg_idx + 1], dtype=cfg.io_dtype)
+                dy_pack1[reg_idx] = fp32_to_fp16(dy_vec1[2 * reg_idx], dy_vec1[2 * reg_idx + 1], dtype=cfg.io_dtype)
+            nvvm.stmatrix(sDy_raw.data_ptr() + addr_lo0, dy_pack0.data_ptr().load(count=4, alignment=4), nvvm.MMALayout.COL, shape=nvvm.StoreShape.M8N8)
+            nvvm.stmatrix(sDy_raw.data_ptr() + addr_lo1, dy_pack1.data_ptr().load(count=4, alignment=4), nvvm.MMALayout.COL, shape=nvvm.StoreShape.M8N8)
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_dy_smem_ready.arrive()
+
+            # ---- beta scalars -> beta.dY -> sdV (epilogue TMA + dK_decay MMA operand) ---
+            beta_c0 = (sBeta_ptr + (lane % 4) * 2).load().to(cutlass.Float32)
+            beta_c1 = (sBeta_ptr + (lane % 4) * 2 + 1).load().to(cutlass.Float32)
+            beta_c8 = (sBeta_ptr + (lane % 4) * 2 + 8).load().to(cutlass.Float32)
+            beta_c9 = (sBeta_ptr + (lane % 4) * 2 + 9).load().to(cutlass.Float32)
+            # latched before the stage is released; the dbeta store runs after the refill
+            beta_self = cutlass.Float32(0.0)
+            if cutlass.const_expr(cfg.beta_sigmoid):
+                if cg1_tidx < cfg.b_t:
+                    beta_self = (sBeta_ptr + cg1_tidx).load().to(cutlass.Float32)
+            bars.mb_beta_done[chunk_serial % cfg.smem_beta_stages].arrive()
+            beta_dy_regs0 = cutlass.Array(cutlass.Float32, 8, alignment=16)
+            beta_dy_regs1 = cutlass.Array(cutlass.Float32, 8, alignment=16)
+            for e2 in cutlass.range_constexpr(4):
+                e = 2 * e2
+                b_lo = beta_c8 if cutlass.const_expr(e >= 4) else beta_c0
+                b_hi = beta_c9 if cutlass.const_expr(e >= 4) else beta_c1
+                beta_dy_regs0[e], beta_dy_regs0[e + 1] = fmul2(dy_vec0[e], dy_vec0[e + 1], b_lo, b_hi)
+                beta_dy_regs1[e], beta_dy_regs1[e + 1] = fmul2(dy_vec1[e], dy_vec1[e + 1], b_lo, b_hi)
+
+            # ---- -beta.dY -> TMEM: A operand of the dH ds-term ---------------------
+            neg_beta_dy_regs0 = cutlass.Array(cutlass.Float32, 8, alignment=16)
+            neg_beta_dy_regs1 = cutlass.Array(cutlass.Float32, 8, alignment=16)
+            for e in cutlass.range_constexpr(8):
+                neg_beta_dy_regs0[e] = -beta_dy_regs0[e]
+                neg_beta_dy_regs1[e] = -beta_dy_regs1[e]
+            neg_beta_dy_pack0 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            neg_beta_dy_pack1 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            for reg_idx in cutlass.range_constexpr(4):
+                frag_pair = reg_idx * 2
+                neg_beta_dy_pack0[reg_idx] = fp32_to_fp16(neg_beta_dy_regs0[frag_pair], neg_beta_dy_regs0[frag_pair + 1], dtype=cfg.io_dtype)
+                neg_beta_dy_pack1[reg_idx] = fp32_to_fp16(neg_beta_dy_regs1[frag_pair], neg_beta_dy_regs1[frag_pair + 1], dtype=cfg.io_dtype)
+            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(row_addr_lo + (tmem_col + cfg.tmem_neg_beta_dy_inp_offset), cutlass.Int8), neg_beta_dy_pack0[0:4])
+            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(row_addr_hi + (tmem_col + cfg.tmem_neg_beta_dy_inp_offset), cutlass.Int8), neg_beta_dy_pack1[0:4])
+            nvvm.tcgen05_wait("store")
+            bars.mb_neg_beta_dy_inp_ready.arrive()
+
+            # ---- dBeta v-term parts: dY.(V - state_k), diff_w from Y staging -------
+            tok4 = cutlass.Array(cutlass.Float32, 4, alignment=16)
+            for s in cutlass.range_constexpr(4):
+                tok4[s] = cutlass.Float32(0.0)
+            for j in cutlass.range_constexpr(4):
+                d0_lo, d0_hi = f16x2_to_f32(diff_w0[j], dtype=cfg.io_dtype)
+                d1_lo, d1_hi = f16x2_to_f32(diff_w1[j], dtype=cfg.io_dtype)
+                s_lo = cutlass.const_expr(2 * (j // 2))
+                s_hi = cutlass.const_expr(2 * (j // 2) + 1)
+                t_lo, t_hi = ffma2(dy_vec0[2 * j], dy_vec0[2 * j + 1], d0_lo, d0_hi, tok4[s_lo], tok4[s_hi])
+                t_lo, t_hi = ffma2(dy_vec1[2 * j], dy_vec1[2 * j + 1], d1_lo, d1_hi, t_lo, t_hi)
+                tok4[s_lo] = t_lo
+                tok4[s_hi] = t_hi
+
+            # ---- beta.dY -> sdV (epilogue TMA + dK_decay MMA operand) ------------
+            beta_dy_pack0 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            beta_dy_pack1 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            for reg_idx in cutlass.range_constexpr(4):
+                beta_dy_pack0[reg_idx] = fp32_to_fp16(beta_dy_regs0[2 * reg_idx], beta_dy_regs0[2 * reg_idx + 1], dtype=cfg.io_dtype)
+                beta_dy_pack1[reg_idx] = fp32_to_fp16(beta_dy_regs1[2 * reg_idx], beta_dy_regs1[2 * reg_idx + 1], dtype=cfg.io_dtype)
+            dv_stage = chunk_serial % cfg.smem_dv_stages
+            sdv_stage_base = dv_stage * (cfg.b_t * cfg.d_v)
+            bars.mb_dv_tmastg_done[dv_stage].wait(dv_done_index.phase)
+            dv_done_index = advance(dv_done_index, cfg.smem_dv_stages)
+            nvvm.stmatrix(
+                sDv_raw.data_ptr() + sdv_stage_base + addr_lo0,
+                beta_dy_pack0.data_ptr().load(count=4, alignment=4),
+                nvvm.MMALayout.COL,
+                shape=nvvm.StoreShape.M8N8,
+            )
+            nvvm.stmatrix(
+                sDv_raw.data_ptr() + sdv_stage_base + addr_lo1,
+                beta_dy_pack1.data_ptr().load(count=4, alignment=4),
+                nvvm.MMALayout.COL,
+                shape=nvvm.StoreShape.M8N8,
+            )
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_dv_tmastg_ready[dv_stage].arrive()
+
+            # ---- dBeta = sum_v dY.(V - state_k) + M-term -------------------------
+            nvvm.barrier_cta_sync(cfg.cg1_sync_barrier_id, thread_count=cfg.cg1_threads)
+            bars.mb_dbeta_m_ready.wait(dbeta_m_index.phase)
+            dbeta_m_index = advance(dbeta_m_index, 1)
+            for off in cutlass.range_constexpr(3):
+                step = cutlass.const_expr(4 << off)
+                for s in cutlass.range_constexpr(4):
+                    tok4[s] = tok4[s] + cutlass.Float32(nvvm.shfl_sync(0xFFFFFFFF, tok4[s], step, 31, kind=nvvm.Shfl.BFLY))
+            if lane < 4:
+                for s in cutlass.range_constexpr(4):
+                    sRed_raw[(warp_idx % 4) * cfg.b_t + (lane % 4) * 2 + (s % 2) + 8 * (s // 2)] = tok4[s]
+            nvvm.barrier_cta_sync(cfg.cg1_sync_barrier_id, thread_count=cfg.cg1_threads)
+            if cg1_tidx < cfg.b_t:
+                acc = cutlass.Float32(0.0)
+                for w in cutlass.range_constexpr(4):
+                    acc = acc + sRed_raw[w * cfg.b_t + cg1_tidx]
+                db_val = acc + sBetaM_raw[cg1_tidx]
+                if cutlass.const_expr(cfg.beta_sigmoid):
+                    db_val = db_val * (beta_self - beta_self * beta_self)
+                token_idx = chunk_idx * cutlass.Int32(cfg.b_t) + cg1_tidx
+                if token_idx < seqlen_b and chunk_idx < wend:
+                    mDbeta[batch_start + token_idx, head_idx] = db_val.to(mDbeta.element_type)
+            nvvm.barrier_cta_sync(cfg.cg1_sync_barrier_id, thread_count=cfg.cg1_threads)
+
+            # ---- dH capture for the next -----------------------------------------
+            bars.mb_dstate_acc_ready.wait(dstate_ready_index.phase)
+            dstate_ready_index = advance(dstate_ready_index, 1)
+            if rev_idx + cutlass.Int32(1) < num_compute_chunks:
+                bars.mb_dstate_smem_done.wait(dstate_smem_done_index.phase)
+                bars.mb_dstate_smem_cg2_done.wait(dstate_smem_done_index.phase)
+                dstate_smem_done_index = advance(dstate_smem_done_index, 1)
+                row_addr = (tmem_row + tmem_subpartition * cfg.threads_per_warp) << 16
+                for sub in cutlass.range_constexpr(cfg.d_k // 32):
+                    dstate_vec = nvvm.tcgen05_ld(
+                        "32x32b", nvvm.make_tmem_ptr(row_addr + (tmem_col + cfg.tmem_dstate_acc_offset + sub * 32), cutlass.Float32), num=32
+                    )
+                    dstate_pack = cutlass.Array(cutlass.Int32, 16, alignment=16)
+                    for pc in cutlass.range_constexpr(16):
+                        dstate_pack[pc] = fp32_to_fp16(dstate_vec[2 * pc], dstate_vec[2 * pc + 1], dtype=cfg.io_dtype)
+                    nvvm.tcgen05_st(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(row_addr + (tmem_col + cfg.tmem_dstate_inp_offset + sub * 16), cutlass.Int8),
+                        dstate_pack[0:16],
+                    )
+                nvvm.tcgen05_wait("store")
+                bars.mb_dstate_inp_ready.arrive()
+
+                # ---- dh_inp -> sdH: re-read after the TMEM publish ---------------
+                for sub in cutlass.range_constexpr(cfg.d_k // 32):
+                    dstate_words = nvvm.tcgen05_ld(
+                        "32x32b", nvvm.make_tmem_ptr(row_addr + (tmem_col + cfg.tmem_dstate_inp_offset + sub * 16), cutlass.Float32), num=16
+                    )
+                    for half in cutlass.range_constexpr(4):
+                        d_base = sub * 32 + half * 8
+                        h_vec = cutlass.Vector.from_elements(
+                            (dstate_words[half * 4], dstate_words[half * 4 + 1], dstate_words[half * 4 + 2], dstate_words[half * 4 + 3]),
+                            cutlass.Float32,
+                        ).bitcast(cfg.io_dtype)
+                        h_addr = (d_base // 64) * (cfg.d_v * 64) + value_dim * 64 + swizzle_xor_128b(value_dim, d_base % 64, elem_bytes=2)
+                        (sDstate_raw.data_ptr() + h_addr).store(h_vec, alignment=16)
+                nvvm.fence_proxy("async.shared", space="cta")
+                bars.mb_dstate_smem_ready.arrive()
+            raw_index = advance(raw_index, cfg.smem_raw_stages)
+
+        # ---- tile end: dS0 drain / zero-length pass-through ----------------------
+        if cutlass.const_expr(mDstate0 is not None):
+            if num_compute_chunks > 0:
+                if wstart == 0:
+                    row_addr = (tmem_row + tmem_subpartition * cfg.threads_per_warp) << 16
+                    dstate0_dst = (mDstate0.iterator + mDstate0.layout((batch_idx, head_idx, value_dim, 0))).raw_ptr()
+                    for sub in cutlass.range_constexpr(cfg.d_k // 32):
+                        dstate0_vec = nvvm.tcgen05_ld(
+                            "32x32b", nvvm.make_tmem_ptr(row_addr + (tmem_col + cfg.tmem_dstate_acc_offset + sub * 32), cutlass.Float32), num=32
+                        )
+                        for g in cutlass.range_constexpr(8):
+                            (dstate0_dst + sub * 32 + g * 4).store(
+                                cutlass.Vector.from_elements(tuple(dstate0_vec[g * 4 + t] for t in range(4)), cutlass.Float32),
+                                alignment=16,
+                            )
+            else:
+                for key_dim_base in cutlass.range_constexpr(0, cfg.d_k, 32):
+                    for kk_i in cutlass.range_constexpr(32):
+                        kd = key_dim_base + kk_i
+                        if cutlass.const_expr(cfg.use_dstate_in):
+                            mDstate0[batch_idx, head_idx, value_dim, kd] = mDstate_in[batch_idx, head_idx, value_dim, kd]
+                        else:
+                            mDstate0[batch_idx, head_idx, value_dim, kd] = cutlass.Float32(0.0)
+        bars.mb_dstate0_acc_stored.arrive()
+        chunk_serial_base += num_compute_chunks
+        tile_idx, sched_state = sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas)
+
+    bars.mb_tmem_done[0].arrive()
+
+
+@cute.jit
+def compute2_warp_group(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    cu_seqlens,
+    mWorkItems,
+    sSched,
+    lane,
+    tmem_base_holder,
+    warp_idx,
+    sGate_raw,
+    sNorm_raw,
+    sDq_raw,
+    sDk_raw,
+    sRed1_raw,
+    sDstate_raw,
+    sDgate_raw,
+    scale,
+    bars,
+) -> None:
+    """WG2 warp role (warps 8-11): the gradient drain.  Each thread owns one
+    key channel d for all 16 tokens: reads the dQ accumulator and the four dK
+    parts from TMEM, assembles dQ/dK with the per-channel gate factors (raw
+    Q/K arrive through WG0's TMEM ring), applies the in-kernel L2-norm
+    backward row projection, assembles the per-channel dGate including the
+    g_last terms, reverse-cumsums it in registers, stages dGate for the
+    epilogue's TMA store, and stages dQ/dK for the epilogue's TMA stores."""
+    nvvm.setmaxregister(cfg.num_regs_compute_group_2, nvvm.SetMaxRegisterAction.INCREASE)
+    nvvm.barrier_cta_sync(cfg.tmem_lifecycle_barrier_id, thread_count=cfg.tmem_user_threads)
+    tmem_base = tmem_base_holder.load()
+    tmem_col = tmem_base & 0xFFFF
+    tmem_row = tmem_base >> 16
+    tmem_subpartition = warp_idx % 4
+    channel = tmem_subpartition * cfg.threads_per_warp + lane
+    row_addr = (tmem_row + tmem_subpartition * cfg.threads_per_warp) << 16
+    cg2_tidx = channel
+
+    raw_index = PipelineState.start(phase=0)
+    dq_acc_index = PipelineState.start(phase=0)
+    dk_decay_part_index = PipelineState.start(phase=0)
+    dk_inv_part_index = PipelineState.start(phase=0)
+    dk_restore_part_index = PipelineState.start(phase=0)
+    dgate_last_dstate_smem_index = PipelineState.start(phase=0)
+    chunk_serial_base = cutlass.Int32(0)
+    sched_state = PipelineState.start(phase=0)
+    tile_idx = cutlass.Int32(bidx)
+    FIRST_STATE_CHUNK = 0 if cfg.use_initial_state else 1
+    while tile_idx < total_tiles:
+        batch_idx, head_idx, batch_start, batch_end, seqlen_b, num_chunks_b, wstart, wend, cstart, cend = decode_work_item(cfg, tile_idx, mWorkItems)
+        num_compute_chunks = cend - wstart
+        for rev_idx in cutlass.range(num_compute_chunks, unroll=1):
+            chunk_idx = cend - cutlass.Int32(1) - rev_idx
+            chunk_serial = chunk_serial_base + rev_idx
+            chunk_start = chunk_idx * cfg.b_t
+            raw_stage = chunk_serial % cfg.smem_raw_stages
+            decay_stage = chunk_serial % cfg.smem_decay_stages
+            has_dstate = cutlass.Boolean(rev_idx > 0)
+            if cutlass.const_expr(cfg.use_dstate_in):
+                has_dstate = cutlass.Boolean(True)
+            sGate_ptr = sGate_raw.data_ptr() + raw_stage * (cfg.d_k * cfg.b_t)
+            writes = chunk_idx < wend
+
+            # ---- gate landed: CG0 publishes the decay ring only after consuming
+            # the gate TMA, so this wait is CG2's visibility guard for sGate ------
+            bars.mb_k_decay_inv_ready[decay_stage].wait((chunk_serial // cfg.smem_decay_stages) % 2)
+
+            # ---- per-channel gate factors ----------------------------------------
+            f32_seg = channel // 32
+            f32_dim = channel - f32_seg * 32
+            f16_seg = channel // 64
+            f16_dim = channel - f16_seg * 64
+            eg = cutlass.Array(cutlass.Float32, cfg.b_t, alignment=16)
+            for t in cutlass.range_constexpr(cfg.b_t):
+                eg[t] = (sGate_ptr + f32_seg * (cfg.b_t * 32) + t * 32 + swizzle_xor_128b(t, f32_dim, elem_bytes=4)).load()
+            egl = eg[cfg.b_t - 1]
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_gate_done[raw_stage].arrive()
+
+            # ---- staged raw Q/K: TMEM ring cols for this chunk -------------------
+            qk_raw_stage = chunk_serial % cfg.tmem_qk_raw_stages
+            qraw_col = tmem_col + cfg.tmem_qraw_inp_offset + qk_raw_stage * (cfg.b_t // 2)
+            kraw_col = tmem_col + cfg.tmem_kraw_inp_offset + qk_raw_stage * (cfg.b_t // 2)
+            norm_base = qk_raw_stage * (2 * cfg.b_t)
+            bars.mb_qk_raw_ready[qk_raw_stage].wait((chunk_serial // cfg.tmem_qk_raw_stages) % 2)
+
+            # ---- dGate_last hdot: sum_v sdH[v, c] * S0[c, v] ---------------------
+            dgate_last_val = cutlass.Float32(0.0)
+            bars.mb_state_inp_ready[chunk_serial % 2].wait((chunk_serial // 2) % 2)
+            if has_dstate:
+                bars.mb_dstate_smem_ready.wait(dgate_last_dstate_smem_index.phase)
+                dgate_last_dstate_smem_index = advance(dgate_last_dstate_smem_index, 1)
+                for pl in cutlass.range_constexpr(2):
+                    for row_half in cutlass.range_constexpr(2):
+                        state_vec = nvvm.tcgen05_ld(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(
+                                row_addr + (tmem_col + cfg.tmem_state_inp_offset + (chunk_serial % 2) * (cfg.d_v // 2) + pl * 32 + row_half * 16),
+                                cutlass.Float32,
+                            ),
+                            num=16,
+                        )
+                        hacc = cutlass.Array(cutlass.Float32, 8, alignment=16)
+                        for i in cutlass.range_constexpr(8):
+                            hacc[i] = opaque_f32_zero()
+                        for j in cutlass.range_constexpr(16):
+                            v0 = pl * 64 + row_half * 32 + 2 * j
+                            state_pair = cutlass.Vector.from_elements((state_vec[j],), cutlass.Float32).bitcast(cfg.io_dtype)
+                            dstate_addr0 = (channel // 64) * (cfg.d_v * 64) + v0 * 64 + swizzle_xor_128b(v0, channel % 64, elem_bytes=2)
+                            dstate_addr1 = (channel // 64) * (cfg.d_v * 64) + (v0 + 1) * 64 + swizzle_xor_128b(v0 + 1, channel % 64, elem_bytes=2)
+                            hval0 = (sDstate_raw.data_ptr() + dstate_addr0).load().to(cutlass.Float32)
+                            hval1 = (sDstate_raw.data_ptr() + dstate_addr1).load().to(cutlass.Float32)
+                            hacc[(2 * j) % 8] = hacc[(2 * j) % 8] + hval0 * state_pair[0].to(cutlass.Float32)
+                            hacc[(2 * j + 1) % 8] = hacc[(2 * j + 1) % 8] + hval1 * state_pair[1].to(cutlass.Float32)
+                        pa0, pb0 = fadd2(hacc[0], hacc[2], hacc[4], hacc[6])
+                        pa1, pb1 = fadd2(hacc[1], hacc[3], hacc[5], hacc[7])
+                        part_a, part_b = fadd2(pa0, pb0, pa1, pb1)
+                        dgate_last_val = dgate_last_val + (part_a + part_b)
+                bars.mb_dstate_smem_cg2_done.arrive()
+            bars.mb_state_inp_cg2_done[chunk_serial % 2].arrive()
+
+            # ---- part-drain accumulators -------------------------------------------
+            dq_n = cutlass.Array(cutlass.Float32, cfg.b_t, alignment=16)
+            dk_n = cutlass.Array(cutlass.Float32, cfg.b_t, alignment=16)
+            dgate_regs = cutlass.Array(cutlass.Float32, cfg.b_t, alignment=16)
+            dgate_last_acc = cutlass.Array(cutlass.Float32, 4, alignment=16)
+            for i in cutlass.range_constexpr(4):
+                dgate_last_acc[i] = opaque_f32_zero()
+            for t in cutlass.range_constexpr(cfg.b_t):
+                dk_n[t] = cutlass.Float32(0.0)
+
+            # ---- dK_restore part drain: (eGl/eG) scale + dGate_last K-dot ----------
+            if has_dstate:
+                bars.mb_dk_restore_part_acc_ready.wait(dk_restore_part_index.phase)
+                dk_restore_part_index = advance(dk_restore_part_index, 1)
+                dk_restore_part_vec = nvvm.tcgen05_ld(
+                    "32x32b", nvvm.make_tmem_ptr(row_addr + (tmem_col + cfg.tmem_dk_restore_acc_offset), cutlass.Float32), num=cfg.b_t
+                )
+                kr_words = nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(row_addr + kraw_col, cutlass.Float32), num=cfg.b_t // 2)
+                for t in cutlass.range_constexpr(cfg.b_t):
+                    dk_hat = egl * cute.math.rcp(eg[t], approx=True, ftz=True) * dk_restore_part_vec[t]
+                    dk_n[t] = dk_hat
+                    k_pair = cutlass.Vector.from_elements((kr_words[t // 2],), cutlass.Float32).bitcast(cfg.io_dtype)
+                    k_v = k_pair[t % 2].to(cutlass.Float32)
+                    if cutlass.const_expr(cfg.l2norm):
+                        k_v = k_v * sNorm_raw[norm_base + cfg.b_t + t]
+                    dgate_last_acc[t % 4] = dgate_last_acc[t % 4] + k_v * dk_hat
+
+            # ---- dQ acc drain: eG.scale ---------------------------------------------
+            bars.mb_dq_acc_ready.wait(dq_acc_index.phase)
+            dq_acc_index = advance(dq_acc_index, 1)
+            dq_vec = nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(row_addr + (tmem_col + cfg.tmem_dq_acc_offset), cutlass.Float32), num=cfg.b_t)
+            for t2 in cutlass.range_constexpr(cfg.b_t // 2):
+                t = 2 * t2
+                es_lo, es_hi = fmul2(eg[t], eg[t + 1], scale, scale)
+                dq_n[t], dq_n[t + 1] = fmul2(es_lo, es_hi, dq_vec[t], dq_vec[t + 1])
+
+            # ---- dK_inv part drain: (dA - dM) term, 1/eG scale ----------------------
+            bars.mb_dk_inv_part_acc_ready.wait(dk_inv_part_index.phase)
+            dk_inv_part_index = advance(dk_inv_part_index, 1)
+            dk_inv_part_vec = nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(row_addr + (tmem_col + cfg.tmem_dk_inv_acc_offset), cutlass.Float32), num=cfg.b_t)
+            for t in cutlass.range_constexpr(cfg.b_t):
+                dk_n[t] = dk_n[t] + dk_inv_part_vec[t] * cute.math.rcp(eg[t], approx=True, ftz=True)
+
+            # ---- dK_decay part drain: -eG scale, seeds dGate ------------------------
+            bars.mb_dk_decay_part_acc_ready.wait(dk_decay_part_index.phase)
+            dk_decay_part_index = advance(dk_decay_part_index, 1)
+            dk_decay_part_vec = nvvm.tcgen05_ld(
+                "32x32b", nvvm.make_tmem_ptr(row_addr + (tmem_col + cfg.tmem_dk_decay_acc_offset), cutlass.Float32), num=cfg.b_t
+            )
+            for t in cutlass.range_constexpr(cfg.b_t):
+                dgate_regs[t] = -eg[t] * dk_decay_part_vec[t]
+                dk_n[t] = dk_n[t] + dgate_regs[t]
+
+            nvvm.tcgen05_wait("load")
+            bars.mb_dqk_acc_done.arrive()
+
+            # ---- dGate finalize --------------------------------------------------
+            qf_words = nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(row_addr + qraw_col, cutlass.Float32), num=cfg.b_t // 2)
+            kf_words = nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(row_addr + kraw_col, cutlass.Float32), num=cfg.b_t // 2)
+            for t in cutlass.range_constexpr(cfg.b_t):
+                q_pair = cutlass.Vector.from_elements((qf_words[t // 2],), cutlass.Float32).bitcast(cfg.io_dtype)
+                k_pair = cutlass.Vector.from_elements((kf_words[t // 2],), cutlass.Float32).bitcast(cfg.io_dtype)
+                q_v = q_pair[t % 2].to(cutlass.Float32)
+                k_v = k_pair[t % 2].to(cutlass.Float32)
+                if cutlass.const_expr(cfg.l2norm):
+                    q_v = q_v * sNorm_raw[norm_base + t]
+                    k_v = k_v * sNorm_raw[norm_base + cfg.b_t + t]
+                dgate_regs[t] = q_v * dq_n[t] + k_v * (cutlass.Float32(2.0) * dgate_regs[t] - dk_n[t])
+            dgate_regs[cfg.b_t - 1] = dgate_regs[cfg.b_t - 1] + ((dgate_last_acc[0] + dgate_last_acc[1]) + (dgate_last_acc[2] + dgate_last_acc[3]))
+
+            # ---- L2-norm backward row projection ---------------------------------
+            if cutlass.const_expr(cfg.l2norm):
+                for grad, qk_col, inv_off in ((dq_n, qraw_col, 0), (dk_n, kraw_col, cfg.b_t)):
+                    dots = cutlass.Array(cutlass.Float32, cfg.b_t, alignment=16)
+                    for half in cutlass.range_constexpr(2):
+                        p_words = nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(row_addr + qk_col + half * (cfg.b_t // 4), cutlass.Float32), num=cfg.b_t // 4)
+                        for tt2 in cutlass.range_constexpr(cfg.b_t // 4):
+                            t = half * (cfg.b_t // 2) + 2 * tt2
+                            p_pair = cutlass.Vector.from_elements((p_words[tt2],), cutlass.Float32).bitcast(cfg.io_dtype)
+                            gp_lo, gp_hi = fmul2(grad[t], grad[t + 1], p_pair[0].to(cutlass.Float32), p_pair[1].to(cutlass.Float32))
+                            dots[t], dots[t + 1] = fmul2(gp_lo, gp_hi, sNorm_raw[norm_base + inv_off + t], sNorm_raw[norm_base + inv_off + t + 1])
+                    for off in cutlass.range_constexpr(5):
+                        step = cutlass.const_expr(1 << off)
+                        for t2 in cutlass.range_constexpr(cfg.b_t // 2):
+                            t = 2 * t2
+                            sh_lo = cutlass.Float32(nvvm.shfl_sync(0xFFFFFFFF, dots[t], step, 31, kind=nvvm.Shfl.BFLY))
+                            sh_hi = cutlass.Float32(nvvm.shfl_sync(0xFFFFFFFF, dots[t + 1], step, 31, kind=nvvm.Shfl.BFLY))
+                            dots[t], dots[t + 1] = fadd2(dots[t], dots[t + 1], sh_lo, sh_hi)
+                    if lane == 0:
+                        for t in cutlass.range_constexpr(cfg.b_t):
+                            sRed1_raw[tmem_subpartition * cfg.b_t + t] = dots[t]
+                    nvvm.barrier_cta_sync(cfg.cg2_sync_barrier_id, thread_count=cfg.cg2_threads)
+                    for half in cutlass.range_constexpr(2):
+                        a_words = nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(row_addr + qk_col + half * (cfg.b_t // 4), cutlass.Float32), num=cfg.b_t // 4)
+                        for tt2 in cutlass.range_constexpr(cfg.b_t // 4):
+                            t = half * (cfg.b_t // 2) + 2 * tt2
+                            a_pair = cutlass.Vector.from_elements((a_words[tt2],), cutlass.Float32).bitcast(cfg.io_dtype)
+                            dot_lo, dot_hi = fadd2(sRed1_raw[t], sRed1_raw[t + 1], sRed1_raw[cfg.b_t + t], sRed1_raw[cfg.b_t + t + 1])
+                            dot_lo, dot_hi = fadd2(dot_lo, dot_hi, sRed1_raw[2 * cfg.b_t + t], sRed1_raw[2 * cfg.b_t + t + 1])
+                            dot_lo, dot_hi = fadd2(dot_lo, dot_hi, sRed1_raw[3 * cfg.b_t + t], sRed1_raw[3 * cfg.b_t + t + 1])
+                            norm_lo = sNorm_raw[norm_base + inv_off + t]
+                            norm_hi = sNorm_raw[norm_base + inv_off + t + 1]
+                            an_lo, an_hi = fmul2(a_pair[0].to(cutlass.Float32), a_pair[1].to(cutlass.Float32), norm_lo, norm_hi)
+                            sub_lo = grad[t] - an_lo * dot_lo
+                            sub_hi = grad[t + 1] - an_hi * dot_hi
+                            grad[t], grad[t + 1] = fmul2(sub_lo, sub_hi, norm_lo, norm_hi)
+                    nvvm.barrier_cta_sync(cfg.cg2_sync_barrier_id, thread_count=cfg.cg2_threads)
+
+            bars.mb_qk_raw_done[qk_raw_stage].arrive()
+
+            # ---- stage dQ/dK for the epilogue TMA stores -------------------------
+            dq_stage = chunk_serial % cfg.smem_dq_stages
+            dk_stage = chunk_serial % cfg.smem_dk_stages
+            bars.mb_dq_tmastg_done[dq_stage].wait(((chunk_serial // cfg.smem_dq_stages) + 1) % 2)
+            bars.mb_dk_tmastg_done[dk_stage].wait(((chunk_serial // cfg.smem_dk_stages) + 1) % 2)
+            dq_base = dq_stage * (cfg.b_t * cfg.d_k)
+            dk_base = dk_stage * (cfg.b_t * cfg.d_k)
+            for t in cutlass.range_constexpr(cfg.b_t):
+                out_idx = f16_seg * (cfg.b_t * 64) + t * 64 + swizzle_xor_128b(t, f16_dim, elem_bytes=2)
+                (sDq_raw.data_ptr() + dq_base + out_idx).store(dq_n[t].to(cfg.io_dtype))
+                (sDk_raw.data_ptr() + dk_base + out_idx).store(dk_n[t].to(cfg.io_dtype))
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_dq_tmastg_ready[dq_stage].arrive()
+            bars.mb_dk_tmastg_ready[dk_stage].arrive()
+
+            # ---- dGate_last add --------------------------------------------------
+            if has_dstate:
+                if chunk_idx >= FIRST_STATE_CHUNK:
+                    dgate_regs[cfg.b_t - 1] = dgate_regs[cfg.b_t - 1] + egl * dgate_last_val
+
+            # ---- dGate reverse cumsum --------------------------------------------
+            suffix = cutlass.Float32(0.0)
+            for rt in cutlass.range_constexpr(cfg.b_t):
+                t = cfg.b_t - 1 - rt
+                suffix = suffix + dgate_regs[t]
+                dgate_regs[t] = suffix
+
+            # ---- stage dGate for the epilogue TMA store --------------------------
+            dgate_stage = chunk_serial % cfg.smem_dgate_stages
+            bars.mb_dgate_tmastg_done[dgate_stage].wait(((chunk_serial // cfg.smem_dgate_stages) + 1) % 2)
+            for t in cutlass.range_constexpr(cfg.b_t):
+                dgate_idx = f32_seg * (cfg.b_t * 32) + t * 32 + swizzle_xor_128b(t, f32_dim, elem_bytes=4)
+                (sDgate_raw.data_ptr() + dgate_idx).store(dgate_regs[t])
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_dgate_tmastg_ready[dgate_stage].arrive()
+            raw_index = advance(raw_index, cfg.smem_raw_stages)
+        chunk_serial_base += num_compute_chunks
+        tile_idx, sched_state = sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas)
+
+    bars.mb_tmem_done[0].arrive()
+
+
+# ---------------------------------------------------------------------------
+# Host-side assembly
+# ---------------------------------------------------------------------------
+
+
+@cute.jit
+def build_descs_body(
+    widx,
+    base_q,
+    base_k,
+    base_v,
+    base_gate,
+    base_do,
+    base_dq,
+    base_dk,
+    base_dv,
+    base_dgate,
+    base_checkpoint,
+    desc_ws: cute.Tensor,
+    cu_seqlens: cute.Tensor,
+    q: cute.Tensor,
+    k: cute.Tensor,
+    v: cute.Tensor,
+    gate: cute.Tensor,
+    do: cute.Tensor,
+    dq: cute.Tensor,
+    dk: cute.Tensor,
+    dv: cute.Tensor,
+    dgate: cute.Tensor,
+    state_checkpoints: cute.Tensor,
+    n_batch: cutlass.Int32,
+    q_row_stride: cutlass.Int32,
+    k_row_stride: cutlass.Int32,
+    v_row_stride: cutlass.Int32,
+    gate_row_stride: cutlass.Int32,
+    do_row_stride: cutlass.Int32,
+    dq_row_stride: cutlass.Int32,
+    dk_row_stride: cutlass.Int32,
+    dv_row_stride: cutlass.Int32,
+    dgate_row_stride: cutlass.Int32,
+    checkpoint_row_stride: cutlass.Int32,
+    checkpoint_every_n: cutlass.Int32,
+) -> None:
+    """Per-batch descriptor-array build, one warp per array. Runs inside the
+    prologue kernel after its order pass; warps past the array count fall
+    through the widx guards."""
+    arr_words = n_batch * cutlass.Int32(TENSOR_MAP_QWORDS)
+    sub0 = cute.make_tensor(desc_ws.iterator, cute.make_layout((arr_words,), stride=(1,)))
+    sub1 = cute.make_tensor(desc_ws.iterator + arr_words, cute.make_layout((arr_words,), stride=(1,)))
+    sub2 = cute.make_tensor(desc_ws.iterator + 2 * arr_words, cute.make_layout((arr_words,), stride=(1,)))
+    sub3 = cute.make_tensor(desc_ws.iterator + 3 * arr_words, cute.make_layout((arr_words,), stride=(1,)))
+    sub4 = cute.make_tensor(desc_ws.iterator + 4 * arr_words, cute.make_layout((arr_words,), stride=(1,)))
+    sub5 = cute.make_tensor(desc_ws.iterator + 5 * arr_words, cute.make_layout((arr_words,), stride=(1,)))
+    sub6 = cute.make_tensor(desc_ws.iterator + 6 * arr_words, cute.make_layout((arr_words,), stride=(1,)))
+    sub7 = cute.make_tensor(desc_ws.iterator + 7 * arr_words, cute.make_layout((arr_words,), stride=(1,)))
+    sub8 = cute.make_tensor(desc_ws.iterator + 8 * arr_words, cute.make_layout((arr_words,), stride=(1,)))
+    sub9 = cute.make_tensor(desc_ws.iterator + 9 * arr_words, cute.make_layout((arr_words,), stride=(1,)))
+
+    if widx == 0:
+        if nvvm.elect_sync():
+            emit_seq_load_descs(base_q, sub0, cu_seqlens, q, n_batch, q_row_stride, 2)
+            nvvm.fence_proxy_release(nvvm.MemScope.GPU, from_proxy=nvvm.Proxy.GENERIC, to_proxy=nvvm.Proxy.TENSORMAP)
+    if widx == 1:
+        if nvvm.elect_sync():
+            emit_seq_load_descs(base_k, sub1, cu_seqlens, k, n_batch, k_row_stride, 2)
+            nvvm.fence_proxy_release(nvvm.MemScope.GPU, from_proxy=nvvm.Proxy.GENERIC, to_proxy=nvvm.Proxy.TENSORMAP)
+    if widx == 2:
+        if nvvm.elect_sync():
+            emit_seq_load_descs(base_v, sub2, cu_seqlens, v, n_batch, v_row_stride, 2)
+            nvvm.fence_proxy_release(nvvm.MemScope.GPU, from_proxy=nvvm.Proxy.GENERIC, to_proxy=nvvm.Proxy.TENSORMAP)
+    if widx == 3:
+        if nvvm.elect_sync():
+            emit_seq_load_descs(
+                base_gate, sub3, cu_seqlens, gate, n_batch, gate_row_stride, 2
+            )
+            nvvm.fence_proxy_release(nvvm.MemScope.GPU, from_proxy=nvvm.Proxy.GENERIC, to_proxy=nvvm.Proxy.TENSORMAP)
+    if widx == 4:
+        if nvvm.elect_sync():
+            emit_seq_load_descs(base_do, sub4, cu_seqlens, do, n_batch, do_row_stride, 2)
+            nvvm.fence_proxy_release(nvvm.MemScope.GPU, from_proxy=nvvm.Proxy.GENERIC, to_proxy=nvvm.Proxy.TENSORMAP)
+    if widx == 5:
+        if nvvm.elect_sync():
+            emit_seq_descs(base_dq, sub5, cu_seqlens, dq, n_batch, dq_row_stride, 2)
+            nvvm.fence_proxy_release(nvvm.MemScope.GPU, from_proxy=nvvm.Proxy.GENERIC, to_proxy=nvvm.Proxy.TENSORMAP)
+    if widx == 6:
+        if nvvm.elect_sync():
+            emit_seq_descs(base_dk, sub6, cu_seqlens, dk, n_batch, dk_row_stride, 2)
+            nvvm.fence_proxy_release(nvvm.MemScope.GPU, from_proxy=nvvm.Proxy.GENERIC, to_proxy=nvvm.Proxy.TENSORMAP)
+    if widx == 7:
+        if nvvm.elect_sync():
+            emit_seq_descs(base_dv, sub7, cu_seqlens, dv, n_batch, dv_row_stride, 2)
+            nvvm.fence_proxy_release(nvvm.MemScope.GPU, from_proxy=nvvm.Proxy.GENERIC, to_proxy=nvvm.Proxy.TENSORMAP)
+    if widx == 8:
+        if nvvm.elect_sync():
+            emit_seq_descs(base_dgate, sub8, cu_seqlens, dgate, n_batch, dgate_row_stride, 2)
+            nvvm.fence_proxy_release(nvvm.MemScope.GPU, from_proxy=nvvm.Proxy.GENERIC, to_proxy=nvvm.Proxy.TENSORMAP)
+    if widx == 9:
+        if nvvm.elect_sync():
+            emit_checkpoint_seq_descs(base_checkpoint, sub9, cu_seqlens, state_checkpoints, n_batch, checkpoint_row_stride, checkpoint_every_n, 2)
+            nvvm.fence_proxy_release(nvvm.MemScope.GPU, from_proxy=nvvm.Proxy.GENERIC, to_proxy=nvvm.Proxy.TENSORMAP)
+
+
+@cute.kernel
+def prologue_kernel(
+    run_order: cutlass.Constexpr[bool],
+    order_gen: cutlass.Constexpr[bool],
+    has_sched: cutlass.Constexpr[bool],
+    b_t: cutlass.Constexpr[int],
+    base_q: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    base_k: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    base_v: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    base_gate: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    base_do: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    base_dq: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    base_dk: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    base_dv: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    base_dgate: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    base_checkpoint: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    desc_ws: cute.Tensor,
+    cu_seqlens: cute.Tensor,
+    q: cute.Tensor,
+    k: cute.Tensor,
+    v: cute.Tensor,
+    gate: cute.Tensor,
+    do: cute.Tensor,
+    dq: cute.Tensor,
+    dk: cute.Tensor,
+    dv: cute.Tensor,
+    dgate: cute.Tensor,
+    state_checkpoints: cute.Tensor,
+    mStaging: cute.Tensor | None,
+    mCount: cute.Tensor,
+    mWorkItems: cute.Tensor | None,
+    mSched: cute.Tensor | None,
+    n_batch: cutlass.Int32,
+    q_row_stride: cutlass.Int32,
+    k_row_stride: cutlass.Int32,
+    v_row_stride: cutlass.Int32,
+    gate_row_stride: cutlass.Int32,
+    do_row_stride: cutlass.Int32,
+    dq_row_stride: cutlass.Int32,
+    dk_row_stride: cutlass.Int32,
+    dv_row_stride: cutlass.Int32,
+    dgate_row_stride: cutlass.Int32,
+    checkpoint_row_stride: cutlass.Int32,
+    checkpoint_every_n: cutlass.Int32,
+) -> None:
+    """Single-CTA prologue. Under ``run_order`` this kernel is the first
+    work-item-table consumer, so it LPT-orders the table and zeroes both
+    consumers' sched rings via :func:`order_body`; it then builds the
+    per-batch TMA-descriptor arrays via :func:`build_descs_body`, one warp
+    per array (the extra warps only take part in the order phase)."""
+    tidx, _, _ = cute.arch.thread_idx()
+    tidx = cutlass.Int32(tidx)
+    widx = tidx // cutlass.Int32(32)
+    if cutlass.const_expr(run_order):
+        sKey = cutlass.Array(cutlass.Int32, ORDER_CAPACITY, space=cutlass.AddressSpace.smem, alignment=16)
+        sIdx = cutlass.Array(cutlass.Int32, ORDER_CAPACITY, space=cutlass.AddressSpace.smem, alignment=16)
+        sSpread = cutlass.Array(cutlass.Int32, 2, space=cutlass.AddressSpace.smem, alignment=8)
+        n_heads_out = cutlass.Int32(gate.shape[1])
+        order_body(
+            order_gen,
+            has_sched,
+            b_t,
+            ORDER_THREADS,
+            ORDER_ELEMS,
+            tidx,
+            n_heads_out,
+            n_heads_out * n_batch,
+            cu_seqlens,
+            mStaging,
+            mCount,
+            mWorkItems,
+            mSched,
+            sKey,
+            sIdx,
+            sSpread,
+        )
+    build_descs_body(
+        widx,
+        base_q,
+        base_k,
+        base_v,
+        base_gate,
+        base_do,
+        base_dq,
+        base_dk,
+        base_dv,
+        base_dgate,
+        base_checkpoint,
+        desc_ws,
+        cu_seqlens,
+        q,
+        k,
+        v,
+        gate,
+        do,
+        dq,
+        dk,
+        dv,
+        dgate,
+        state_checkpoints,
+        n_batch,
+        q_row_stride,
+        k_row_stride,
+        v_row_stride,
+        gate_row_stride,
+        do_row_stride,
+        dq_row_stride,
+        dk_row_stride,
+        dv_row_stride,
+        dgate_row_stride,
+        checkpoint_row_stride,
+        checkpoint_every_n,
+    )
+
+
+@cute.jit
+def prologue(
+    io_dtype: cutlass.Constexpr,
+    b_t: cutlass.Constexpr[int],
+    run_order: cutlass.Constexpr[bool],
+    order_gen: cutlass.Constexpr[bool],
+    has_sched: cutlass.Constexpr[bool],
+    q: cute.Tensor,
+    k: cute.Tensor,
+    v: cute.Tensor,
+    gate: cute.Tensor,
+    do: cute.Tensor,
+    dq: cute.Tensor,
+    dk: cute.Tensor,
+    dv: cute.Tensor,
+    dgate: cute.Tensor,
+    state_checkpoints: cute.Tensor,
+    cu_seqlens: cute.Tensor,
+    work_item_staging: cute.Tensor | None,
+    work_count: cute.Tensor,
+    work_items: cute.Tensor | None,
+    sched_all: cute.Tensor | None,
+    tensormap_workspace: cute.Tensor,
+    stream: cuda_driver.CUstream,
+):
+    """One-launch prologue: LPT-order the work items (when ``run_order``) and
+    build the 11 per-(batch, head) capped TMA-descriptor arrays into
+    ``tensormap_workspace`` (sequence-relative coordinates; tail loads
+    zero-fill and tail stores clip in hardware)."""
+    h_q = q.shape[1]
+    h_k = k.shape[1]
+    h_v = v.shape[1]
+    ho = gate.shape[1]
+    batch_size = cu_seqlens.shape[0] - 1
+    d_k = q.shape[2]
+    d_v = v.shape[2]
+    bpe = io_dtype.width // 8
+    tma_granu_elems = 128 // bpe
+    seqlen = q.shape[0]
+
+    q_headed = cute.make_tensor(q.iterator, cute.make_layout((d_k, h_q, seqlen), stride=(1, q.stride[1], q.stride[0])))
+    k_headed = cute.make_tensor(k.iterator, cute.make_layout((d_k, h_k, seqlen), stride=(1, k.stride[1], k.stride[0])))
+    v_headed = cute.make_tensor(v.iterator, cute.make_layout((d_v, h_v, seqlen), stride=(1, v.stride[1], v.stride[0])))
+    gate_headed = cute.make_tensor(gate.iterator, cute.make_layout((d_k, ho, seqlen), stride=(1, gate.stride[1], gate.stride[0])))
+    do_headed = cute.make_tensor(do.iterator, cute.make_layout((d_v, ho, seqlen), stride=(1, do.stride[1], do.stride[0])))
+    dq_headed = cute.make_tensor(dq.iterator, cute.make_layout((d_k, ho, seqlen), stride=(1, dq.stride[1], dq.stride[0])))
+    dk_headed = cute.make_tensor(dk.iterator, cute.make_layout((d_k, ho, seqlen), stride=(1, dk.stride[1], dk.stride[0])))
+    dv_headed = cute.make_tensor(dv.iterator, cute.make_layout((d_v, ho, seqlen), stride=(1, dv.stride[1], dv.stride[0])))
+    dgate_headed = cute.make_tensor(dgate.iterator, cute.make_layout((d_k, ho, seqlen), stride=(1, dgate.stride[1], dgate.stride[0])))
+
+    swz = cuda.TensorMapSwizzle.s128b
+    base_q = cuda.create_tensor_map_tiled_from_view(q_headed, box_dims=(tma_granu_elems, 1, b_t), stride_order=(0, 1, 2), swizzle=swz)
+    base_k = cuda.create_tensor_map_tiled_from_view(k_headed, box_dims=(tma_granu_elems, 1, b_t), stride_order=(0, 1, 2), swizzle=swz)
+    base_v = cuda.create_tensor_map_tiled_from_view(v_headed, box_dims=(tma_granu_elems, 1, b_t), stride_order=(0, 1, 2), swizzle=swz)
+    base_gate = cuda.create_tensor_map_tiled_from_view(gate_headed, box_dims=(32, 1, b_t), stride_order=(0, 1, 2), swizzle=swz)
+    base_do = cuda.create_tensor_map_tiled_from_view(do_headed, box_dims=(tma_granu_elems, 1, b_t), stride_order=(0, 1, 2), swizzle=swz)
+    base_dq = cuda.create_tensor_map_tiled_from_view(dq_headed, box_dims=(tma_granu_elems, 1, b_t), stride_order=(0, 1, 2), swizzle=swz)
+    base_dk = cuda.create_tensor_map_tiled_from_view(dk_headed, box_dims=(tma_granu_elems, 1, b_t), stride_order=(0, 1, 2), swizzle=swz)
+    base_dv = cuda.create_tensor_map_tiled_from_view(dv_headed, box_dims=(tma_granu_elems, 1, b_t), stride_order=(0, 1, 2), swizzle=swz)
+    base_dgate = cuda.create_tensor_map_tiled_from_view(dgate_headed, box_dims=(32, 1, b_t), stride_order=(0, 1, 2), swizzle=swz)
+
+    checkpoint_view = cute.make_tensor(
+        state_checkpoints.iterator,
+        cute.make_layout(
+            (d_v, d_k, state_checkpoints.shape[0], ho),
+            stride=(state_checkpoints.stride[3], state_checkpoints.stride[2], state_checkpoints.stride[0], state_checkpoints.stride[1]),
+        ),
+    )
+    base_checkpoint = cuda.create_tensor_map_tiled_from_view(checkpoint_view, box_dims=(64, d_k, 1, 1), stride_order=(0, 1, 2, 3), swizzle=swz)
+
+    prologue_kernel(
+        run_order,
+        order_gen,
+        has_sched,
+        b_t,
+        base_q,
+        base_k,
+        base_v,
+        base_gate,
+        base_do,
+        base_dq,
+        base_dk,
+        base_dv,
+        base_dgate,
+        base_checkpoint,
+        tensormap_workspace,
+        cu_seqlens,
+        q,
+        k,
+        v,
+        gate,
+        do,
+        dq,
+        dk,
+        dv,
+        dgate,
+        state_checkpoints,
+        work_item_staging,
+        work_count,
+        work_items,
+        sched_all,
+        cutlass.Int32(batch_size),
+        cutlass.Int32(q.stride[0]),
+        cutlass.Int32(k.stride[0]),
+        cutlass.Int32(v.stride[0]),
+        cutlass.Int32(gate.stride[0]),
+        cutlass.Int32(do.stride[0]),
+        cutlass.Int32(dq.stride[0]),
+        cutlass.Int32(dk.stride[0]),
+        cutlass.Int32(dv.stride[0]),
+        cutlass.Int32(dgate.stride[0]),
+        cutlass.Int32(state_checkpoints.stride[0]),
+        cutlass.Int32(b_t),
+    ).launch(grid=(1, 1, 1), block=(ORDER_THREADS, 1, 1), stream=stream)
+
+
+class KdaBpropOp:
+    """Compile and launch one static mega KDA backward configuration."""
+
+    def __init__(self, cfg: "KdaBwdCfg"):
+        self.cfg = cfg
+
+    def get_name(self) -> str:
+        cfg = self.cfg
+        gate_scale = (
+            f"_gs{float(cfg.gate_scale_log2).hex()}"
+            .replace("-", "m")
+            .replace(".", "p")
+            .replace("+", "")
+            if cfg.safe_gate
+            else ""
+        )
+        return (
+            f"kda_mega_bprop_{cfg.io_dtype.__name__.lower()}_h{cfg.n_heads_out}"
+            f"_q{cfg.q_ratio}_k{cfg.k_ratio}_v{cfg.v_ratio}"
+            f"_s{int(cfg.use_dstate_in)}z{int(cfg.use_dstate0)}"
+            f"l{int(cfg.l2norm)}g{int(cfg.safe_gate)}b{int(cfg.beta_sigmoid)}"
+            f"i{int(cfg.use_initial_state)}d{int(cfg.dyn_sched)}"
+            f"_sm{cfg.max_active_clusters}{gate_scale}"
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        a_log: cute.Tensor | None,
+        dt_bias: cute.Tensor | None,
+        beta: cute.Tensor,
+        state_checkpoints: cute.Tensor,
+        dgate: cute.Tensor,
+        dbeta: cute.Tensor,
+        cu_seqlens: cute.Tensor,
+        d_initial_state: cute.Tensor | None,
+        d_final_state: cute.Tensor | None,
+        work_items: cute.Tensor | None,
+        work_count: cute.Tensor | None,
+        sched_ctr: cute.Tensor | None,
+        tensormap_workspace: cute.Tensor,
+        scale: cutlass.Float32,
+        stream,
+    ) -> None:
+        cfg = self.cfg
+        num_sequences = cu_seqlens.shape[0] - 1
+
+        kernel.set_name_prefix(self.get_name())
+        kernel(
+            cfg,
+            tensormap_workspace,
+            num_sequences,
+            a_log,
+            dt_bias,
+            beta,
+            cu_seqlens,
+            dgate,
+            dbeta,
+            d_initial_state,
+            d_final_state,
+            work_items,
+            work_count,
+            sched_ctr,
+            scale,
+        ).launch(
+            grid=(cfg.max_active_clusters, 1, 1),
+            block=(cfg.threads_per_cta, 1, 1),
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
+
+
+@cute.kernel
+def kernel(
+    cfg: cutlass.Constexpr,
+    tensormap_workspace: cute.Tensor,
+    n_desc: cutlass.Int32,
+    mA_log: cute.Tensor | None,
+    mDt_bias: cute.Tensor | None,
+    mBeta: cute.Tensor,
+    cu_seqlens: cute.Tensor,
+    mDgate: cute.Tensor,
+    mDbeta: cute.Tensor,
+    mDstate0: cute.Tensor | None,
+    mDstate_in: cute.Tensor | None,
+    mWorkItems: cute.Tensor,
+    mCount: cute.Tensor,
+    mSched: cute.Tensor | None,
+    scale: cutlass.Float32,
+) -> None:
+    """BT=16 KDA backward kernel (persistent, 16 warps)."""
+    tidx, _, _ = cute.arch.thread_idx()
+    bidx = cute.arch.block_idx()[0]
+    num_ctas = cute.arch.grid_dim()[0]
+    warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+    lane = tidx % cfg.threads_per_warp
+
+    total_tiles = mCount[0]
+    beta_expected = cfg.io_dtype if cutlass.const_expr(cfg.beta_sigmoid) else cutlass.Float32
+    assert mBeta.element_type == beta_expected
+    assert cu_seqlens.element_type in (cutlass.Int32, cutlass.Int64)
+    assert mDgate.element_type == cutlass.Float32 and mDbeta.element_type == beta_expected
+
+    desc_base_words = tensormap_workspace.iterator.raw_ptr()
+    arr_words = n_desc * cutlass.Int32(TENSOR_MAP_QWORDS)
+    desc_q_base = desc_base_words
+    desc_k_base = desc_base_words + arr_words
+    desc_v_base = desc_base_words + cutlass.Int32(2) * arr_words
+    desc_gate_base = desc_base_words + cutlass.Int32(3) * arr_words
+    desc_do_base = desc_base_words + cutlass.Int32(4) * arr_words
+    desc_dq_base = desc_base_words + cutlass.Int32(5) * arr_words
+    desc_dk_base = desc_base_words + cutlass.Int32(6) * arr_words
+    desc_dv_base = desc_base_words + cutlass.Int32(7) * arr_words
+    desc_dgate_base = desc_base_words + cutlass.Int32(8) * arr_words
+    desc_checkpoint_base = desc_base_words + cutlass.Int32(9) * arr_words
+
+    SMEM = cutlass.AddressSpace.smem
+    bars = make_kda_bwd_bars(cfg)
+    tmem_base_holder = cutlass.Array(cutlass.Int32, 1, space=SMEM, alignment=4)
+    sSched = cutlass.Array(cutlass.Int32, cfg.sched_stages, space=SMEM, alignment=16)
+    bpe = cfg.io_dtype.width // 8
+    SWZ = 2
+    LEAD = 16
+    STRIDE = 8 * 128
+    STATE_ALT_LEAD = cfg.d_v * 128
+
+    # sub-bank split: tcgen05-descriptor operands low, generic-client buffers high
+    sBeta_raw = cutlass.Array(cutlass.Float32, cfg.smem_beta_stages * cfg.b_t, space=SMEM, alignment=64)
+    sNorm_raw = cutlass.Array(cutlass.Float32, cfg.tmem_qk_raw_stages * 2 * cfg.b_t, space=SMEM, alignment=64)
+    sRed_raw = cutlass.Array(cutlass.Float32, 4 * cfg.b_t, space=SMEM, alignment=64)
+    sRed1_raw = cutlass.Array(cutlass.Float32, 4 * cfg.b_t, space=SMEM, alignment=64)
+    sBetaM_raw = cutlass.Array(cutlass.Float32, cfg.b_t, space=SMEM, alignment=64)
+    sState_raw = cutlass.Array(cfg.io_dtype, cfg.state_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
+    sDstate_raw = cutlass.Array(cfg.io_dtype, cfg.d_k * cfg.d_v, space=SMEM, alignment=cfg.buffer_align_bytes)
+    sK_decay_raw = cutlass.Array(cfg.io_dtype, cfg.operand_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
+    sK_inv_raw = cutlass.Array(cfg.io_dtype, cfg.operand_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
+    sK_restore_raw = cutlass.Array(cfg.io_dtype, cfg.operand_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
+    sQ_decay_raw = cutlass.Array(cfg.io_dtype, cfg.operand_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
+    sState_scale_diag_raw = cutlass.Array(cfg.io_dtype, cfg.diag_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
+    sIntermediate_raw = cutlass.Array(cfg.io_dtype, cfg.intermediate_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
+    sDo_raw = cutlass.Array(cfg.io_dtype, cfg.raw_v_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
+    sDv_raw = cutlass.Array(cfg.io_dtype, cfg.dv_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
+    sQ_raw = cutlass.Array(cfg.io_dtype, cfg.raw_qk_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
+    sK_raw = cutlass.Array(cfg.io_dtype, cfg.raw_qk_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
+    sV_raw = cutlass.Array(cfg.io_dtype, cfg.raw_v_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
+    sGate_raw = cutlass.Array(cutlass.Float32, cfg.raw_gate_cosize, space=SMEM, alignment=1024)
+    sDy_raw = cutlass.Array(cfg.io_dtype, cfg.b_t * cfg.d_v, space=SMEM, alignment=cfg.buffer_align_bytes)
+    sU_raw = cutlass.Array(cfg.io_dtype, cfg.b_t * cfg.d_v, space=SMEM, alignment=cfg.buffer_align_bytes)
+    sDq_raw = cutlass.Array(cfg.io_dtype, cfg.dq_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
+    sDk_raw = cutlass.Array(cfg.io_dtype, cfg.dk_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
+    sDgate_raw = cutlass.Array(cutlass.Float32, cfg.dgate_cosize, space=SMEM, alignment=1024)
+
+    sState_alt = SmemTile(
+        base=sState_raw.data_ptr().toint(),
+        elems_per_stage=((cfg.state_cosize) // (cfg.smem_state_stages)) * bpe,
+        stages=cfg.smem_state_stages,
+        leading_byte_offset=STATE_ALT_LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sState_direct = SmemTile(
+        base=sState_raw.data_ptr().toint(),
+        elems_per_stage=((cfg.state_cosize) // (cfg.smem_state_stages)) * bpe,
+        stages=cfg.smem_state_stages,
+        leading_byte_offset=LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sK_decay_lead16 = SmemTile(
+        base=sK_decay_raw.data_ptr().toint(),
+        elems_per_stage=((cfg.operand_cosize) // (cfg.smem_decay_stages)) * bpe,
+        stages=cfg.smem_decay_stages,
+        leading_byte_offset=LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sK_inv_lead16 = SmemTile(
+        base=sK_inv_raw.data_ptr().toint(),
+        elems_per_stage=((cfg.operand_cosize) // (cfg.smem_decay_stages)) * bpe,
+        stages=cfg.smem_decay_stages,
+        leading_byte_offset=LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sK_restore_lead16 = SmemTile(
+        base=sK_restore_raw.data_ptr().toint(),
+        elems_per_stage=((cfg.operand_cosize) // (cfg.smem_decay_stages)) * bpe,
+        stages=cfg.smem_decay_stages,
+        leading_byte_offset=LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sDo_lead16 = SmemTile(
+        base=sDo_raw.data_ptr().toint(),
+        elems_per_stage=((cfg.raw_v_cosize) // (cfg.smem_raw_stages)) * bpe,
+        stages=cfg.smem_raw_stages,
+        leading_byte_offset=LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sDo_amaj = SmemTile(
+        base=sDo_raw.data_ptr().toint(),
+        elems_per_stage=((cfg.raw_v_cosize) // (cfg.smem_raw_stages)) * bpe,
+        stages=cfg.smem_raw_stages,
+        leading_byte_offset=cfg.b_t * 128,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sU_lead16 = SmemTile(
+        base=sU_raw.data_ptr().toint(),
+        elems_per_stage=((cfg.b_t * cfg.d_v) // (1)) * bpe,
+        stages=1,
+        leading_byte_offset=LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sDv_lead16 = SmemTile(
+        base=sDv_raw.data_ptr().toint(),
+        elems_per_stage=((cfg.dv_cosize) // (cfg.smem_dv_stages)) * bpe,
+        stages=cfg.smem_dv_stages,
+        leading_byte_offset=LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sDstate_alt = SmemTile(
+        base=sDstate_raw.data_ptr().toint(),
+        elems_per_stage=((cfg.d_k * cfg.d_v) // (1)) * bpe,
+        stages=1,
+        leading_byte_offset=STATE_ALT_LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+
+    sQ_decay_trans = SmemTile(
+        base=sQ_decay_raw.data_ptr().toint(),
+        elems_per_stage=((cfg.operand_cosize) // (cfg.smem_decay_stages)) * bpe,
+        stages=cfg.smem_decay_stages,
+        leading_byte_offset=cfg.b_t * 128,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sK_inv_amaj = SmemTile(
+        base=sK_inv_raw.data_ptr().toint(),
+        elems_per_stage=((cfg.operand_cosize) // (cfg.smem_decay_stages)) * bpe,
+        stages=cfg.smem_decay_stages,
+        leading_byte_offset=cfg.b_t * 128,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sK_decay_trans = SmemTile(
+        base=sK_decay_raw.data_ptr().toint(),
+        elems_per_stage=((cfg.operand_cosize) // (cfg.smem_decay_stages)) * bpe,
+        stages=cfg.smem_decay_stages,
+        leading_byte_offset=cfg.b_t * 128,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sState_scale_diag = SmemTile(
+        base=sState_scale_diag_raw,
+        elems_per_stage=((cfg.d_k // 16) * 256),
+        stages=cfg.smem_decay_stages,
+        leading_byte_offset=16,
+        stride_byte_offset=(8 * 16 * 2),
+        layout=nvvm.Tcgen05SmemSwizzle.SWIZZLE_32B,
+    )
+    sIntermediate = SmemTile(
+        base=sIntermediate_raw,
+        elems_per_stage=(cfg.intermediate_tiles * cfg.b_t * cfg.b_t),
+        stages=cfg.smem_intermediate_stages,
+        leading_byte_offset=16,
+        stride_byte_offset=(8 * cfg.b_t * 2),
+        layout=nvvm.Tcgen05SmemSwizzle.SWIZZLE_32B,
+    )
+
+    elect_one = nvvm.elect_sync()
+    if warp_idx == cfg.tma_warp_id:
+        if elect_one:
+            for stage in cutlass.range_constexpr(cfg.smem_raw_stages):
+                bars.mb_q_ready[stage].init()
+                bars.mb_q_done[stage].init()
+                bars.mb_k_ready[stage].init()
+                bars.mb_k_done[stage].init()
+                bars.mb_gate_ready[stage].init()
+                bars.mb_gate_done[stage].init()
+                bars.mb_do_ready[stage].init()
+                bars.mb_do_done[stage].init()
+                bars.mb_v_ready[stage].init()
+                bars.mb_v_done[stage].init()
+            for stage in cutlass.range_constexpr(cfg.smem_beta_stages):
+                bars.mb_beta_ready[stage].init()
+                bars.mb_beta_done[stage].init()
+            for stage in cutlass.range_constexpr(cfg.smem_state_stages):
+                bars.mb_state_ready[stage].init()
+                bars.mb_state_done[stage].init()
+                bars.mb_state_cg0_done[stage].init()
+            for stage in cutlass.range_constexpr(2):
+                bars.mb_state_inp_ready[stage].init()
+                bars.mb_state_inp_done[stage].init()
+                bars.mb_state_inp_cg2_done[stage].init()
+    elif warp_idx == cfg.tcgen05_mma_warp_id:
+        if elect_one:
+            bars.mb_state_k_acc_ready.init()
+            bars.mb_y_inp_ready.init()
+            bars.mb_u_acc_ready.init()
+            bars.mb_u_smem_ready.init()
+            bars.mb_du_acc_ready.init()
+            bars.mb_du_inp_ready.init()
+            bars.mb_dy_acc_ready.init()
+            bars.mb_neg_beta_dy_inp_ready.init()
+            bars.mb_dy_smem_ready.init()
+            bars.mb_dstate_acc_ready.init()
+            bars.mb_dstate_inp_ready.init()
+            bars.mb_dstate_smem_ready.init()
+            bars.mb_dstate_smem_done.init()
+            bars.mb_dstate_smem_cg2_done.init()
+            bars.mb_dq_acc_ready.init()
+            bars.mb_dk_decay_part_acc_ready.init()
+            bars.mb_dk_inv_part_acc_ready.init()
+            bars.mb_dk_restore_part_acc_ready.init()
+            bars.mb_dqk_acc_done.init()
+            bars.mb_dbeta_m_ready.init()
+            bars.mb_dstate0_acc_stored.init()
+            bars.mb_tmem_done[0].init()
+    elif warp_idx == cfg.super_mma_warp_id:
+        if elect_one:
+            for stage in cutlass.range_constexpr(cfg.smem_decay_stages):
+                bars.mb_k_decay_inv_ready[stage].init()
+                bars.mb_q_decay_k_restore_ready[stage].init()
+                bars.mb_decay_done[stage].init()
+            for stage in cutlass.range_constexpr(cfg.tmem_qk_raw_stages):
+                bars.mb_qk_raw_ready[stage].init()
+                bars.mb_qk_raw_done[stage].init()
+            for stage in cutlass.range_constexpr(cfg.smem_intermediate_stages):
+                bars.mb_t_inv_ready[stage].init()
+                bars.mb_a_ready[stage].init()
+                bars.mb_da_ready[stage].init()
+                bars.mb_dm_ready[stage].init()
+                bars.mb_a_done[stage].init()
+                bars.mb_t_inv_done[stage].init()
+                bars.mb_da_done[stage].init()
+                bars.mb_dm_done[stage].init()
+    elif warp_idx == cfg.epilogue_warp_id:
+        if elect_one:
+            for stage in cutlass.range_constexpr(cfg.smem_dq_stages):
+                bars.mb_dq_tmastg_ready[stage].init()
+                bars.mb_dq_tmastg_done[stage].init()
+            for stage in cutlass.range_constexpr(cfg.smem_dk_stages):
+                bars.mb_dk_tmastg_ready[stage].init()
+                bars.mb_dk_tmastg_done[stage].init()
+            for stage in cutlass.range_constexpr(cfg.smem_dgate_stages):
+                bars.mb_dgate_tmastg_ready[stage].init()
+                bars.mb_dgate_tmastg_done[stage].init()
+            for stage in cutlass.range_constexpr(cfg.smem_dv_stages):
+                bars.mb_dv_tmastg_ready[stage].init()
+                bars.mb_dv_tmastg_done[stage].init()
+            for stage in cutlass.range_constexpr(cfg.sched_stages):
+                bars.mb_sched_ready[stage].init()
+                bars.mb_sched_done[stage].init()
+    diag_zero = cfg.io_dtype(0.0)
+    for diag_idx in cutlass.range(tidx, cfg.diag_cosize, cfg.threads_per_cta, unroll=1):
+        sState_scale_diag_raw[diag_idx] = diag_zero
+    nvvm.fence_mbarrier_init()
+    nvvm.barrier_cta_sync(0, thread_count=cfg.threads_per_cta)
+    if warp_idx == cfg.tma_warp_id:
+        tmaldg_warp(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            n_desc,
+            cu_seqlens,
+            mWorkItems,
+            mSched,
+            sSched,
+            lane,
+            sQ_raw,
+            sK_raw,
+            sV_raw,
+            sGate_raw,
+            sDo_raw,
+            sState_raw,
+            desc_q_base,
+            desc_k_base,
+            desc_v_base,
+            desc_gate_base,
+            desc_do_base,
+            desc_checkpoint_base,
+            bars,
+        )
+    elif warp_idx == cfg.super_mma_warp_id:
+        super_mma_warp(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            cu_seqlens,
+            mWorkItems,
+            sSched,
+            lane,
+            sK_decay_raw,
+            sK_inv_raw,
+            sU_raw,
+            sDy_raw,
+            sIntermediate_raw,
+            sBeta_raw,
+            sBetaM_raw,
+            bars,
+        )
+    elif warp_idx == cfg.tcgen05_mma_warp_id:
+        tcgen05_mma_warp(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            cu_seqlens,
+            mWorkItems,
+            sSched,
+            tmem_base_holder,
+            sState_alt,
+            sState_direct,
+            sK_decay_lead16,
+            sK_inv_lead16,
+            sK_inv_amaj,
+            sK_restore_lead16,
+            sDo_lead16,
+            sDo_amaj,
+            sQ_decay_trans,
+            sK_decay_trans,
+            sU_lead16,
+            sDv_lead16,
+            sDstate_alt,
+            sIntermediate,
+            sState_scale_diag,
+            bars,
+        )
+    elif warp_idx == cfg.epilogue_warp_id:
+        epilogue_warp(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            cu_seqlens,
+            mWorkItems,
+            sSched,
+            lane,
+            sK_inv_raw,
+            sQ_decay_raw,
+            sDo_raw,
+            sU_raw,
+            sIntermediate_raw,
+            sDq_raw,
+            sDk_raw,
+            sDv_raw,
+            sDgate_raw,
+            desc_dq_base,
+            desc_dk_base,
+            desc_dv_base,
+            desc_dgate_base,
+            bars,
+        )
+    elif warp_idx >= cfg.compute_group_0_warp_ids[0] and warp_idx <= cfg.compute_group_0_warp_ids[-1]:
+        compute0_warp_group(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            cu_seqlens,
+            mWorkItems,
+            sSched,
+            lane,
+            tmem_base_holder,
+            warp_idx,
+            scale,
+            mA_log,
+            mDt_bias,
+            mBeta,
+            sBeta_raw,
+            sK_inv_raw,
+            sGate_raw,
+            sK_raw,
+            sQ_raw,
+            sState_raw,
+            sNorm_raw,
+            sK_decay_raw,
+            sK_restore_raw,
+            sQ_decay_raw,
+            sState_scale_diag_raw,
+            bars,
+        )
+    elif warp_idx >= cfg.compute_group_2_warp_ids[0] and warp_idx <= cfg.compute_group_2_warp_ids[-1]:
+        compute2_warp_group(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            cu_seqlens,
+            mWorkItems,
+            sSched,
+            lane,
+            tmem_base_holder,
+            warp_idx,
+            sGate_raw,
+            sNorm_raw,
+            sDq_raw,
+            sDk_raw,
+            sRed1_raw,
+            sDstate_raw,
+            sDgate_raw,
+            scale,
+            bars,
+        )
+    elif warp_idx >= cfg.compute_group_1_warp_ids[0] and warp_idx <= cfg.compute_group_1_warp_ids[-1]:
+        compute1_warp_group(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            cu_seqlens,
+            mWorkItems,
+            sSched,
+            lane,
+            tmem_base_holder,
+            warp_idx,
+            mDbeta,
+            mDstate0,
+            mDstate_in,
+            sV_raw,
+            sDo_raw,
+            sBeta_raw,
+            sU_raw,
+            sDy_raw,
+            sDv_raw,
+            sDstate_raw,
+            sRed_raw,
+            sBetaM_raw,
+            bars,
+        )
+
+
+@dataclass
+class KdaBwdCfg:
+    """Kernel cfg (fixed BT=16 schedule constants; derived TMEM column offsets
+    and SMEM buffer cosizes are stamped by ``build_cfg``)."""
+
+    io_dtype: Type[cutlass.Numeric]
+    use_dstate_in: bool
+    use_dstate0: bool
+    l2norm: bool
+    safe_gate: bool
+    gate_scale_log2: float
+    beta_sigmoid: bool
+    use_initial_state: bool
+    q_ratio: int
+    k_ratio: int
+    v_ratio: int
+    n_heads_out: int
+    max_active_clusters: int
+    dyn_sched: bool = False
+    sched_stages: int = 8
+
+    # ---- fixed constants stamped from CFG by build_cfg ---------------------------
+    compute_group_0_warp_ids: tuple = CFG.COMPUTE_GROUP_0_WARP_IDS
+    compute_group_2_warp_ids: tuple = CFG.COMPUTE_GROUP_2_WARP_IDS
+    compute_group_1_warp_ids: tuple = CFG.COMPUTE_GROUP_1_WARP_IDS
+    super_mma_warp_id: int = CFG.SUPER_MMA_WARP_ID
+    tcgen05_mma_warp_id: int = CFG.TCGEN05_MMA_WARP_ID
+    tma_warp_id: int = CFG.TMA_WARP_ID
+    epilogue_warp_id: int = CFG.EPILOGUE_WARP_ID
+    b_t: int = CFG.B_T
+    d_k: int = CFG.D_K
+    d_v: int = CFG.D_V
+    threads_per_warp: int = CFG.THREADS_PER_WARP
+    threads_per_cta: int = 0
+    num_regs_compute_group_0: int = CFG.NUM_REGS_COMPUTE_GROUP_0
+    num_regs_compute_group_1: int = CFG.NUM_REGS_COMPUTE_GROUP_1
+    num_regs_compute_group_2: int = CFG.NUM_REGS_COMPUTE_GROUP_2
+    num_regs_other: int = CFG.NUM_REGS_OTHER
+
+    # ---- named barrier slots (ids 1-4; 0 is the CTA-wide sync) -------------------
+    cg0_sync_barrier_id: int = 1
+    cg0_threads: int = 0
+    cg2_sync_barrier_id: int = 2
+    cg2_threads: int = 0
+    tmem_lifecycle_barrier_id: int = 3
+    tmem_user_threads: int = 0
+    cg1_sync_barrier_id: int = 4
+    cg1_threads: int = 0
+
+    # ---- SMEM / TMEM stage counts + TMEM column offsets --------------------------
+    smem_raw_stages: int = CFG.SMEM_RAW_STAGES
+    smem_state_stages: int = CFG.SMEM_S_STAGES
+    smem_decay_stages: int = CFG.SMEM_DECAY_STAGES
+    smem_intermediate_stages: int = CFG.SMEM_INTERMEDIATE_STAGES
+    smem_dq_stages: int = CFG.SMEM_DQ_STAGES
+    smem_dk_stages: int = CFG.SMEM_DK_STAGES
+    smem_dgate_stages: int = CFG.SMEM_DGATE_STAGES
+    smem_dv_stages: int = CFG.SMEM_DV_STAGES
+    smem_beta_stages: int = 4
+    intermediate_tiles: int = 5
+    tmem_dstate_acc_offset: int = 0
+    tmem_dstate_inp_offset: int = 0
+    tmem_state_k_acc_offset: int = 0
+    tmem_u_acc_offset: int = 0
+    tmem_du_acc_offset: int = 0
+    tmem_dy_acc_offset: int = 0
+    tmem_dq_acc_offset: int = 0
+    tmem_dk_decay_acc_offset: int = 0
+    tmem_dk_inv_acc_offset: int = 0
+    tmem_dk_restore_acc_offset: int = 0
+    tmem_qk_raw_stages: int = 4
+    tmem_qraw_inp_offset: int = 0
+    tmem_kraw_inp_offset: int = 0
+    tmem_y_inp_offset: int = 0
+    tmem_du_inp_offset: int = 0
+    tmem_neg_beta_dy_inp_offset: int = 0
+    tmem_state_inp_offset: int = 0
+    buffer_align_bytes: int = CFG.BUFFER_ALIGN_BYTES
+
+    # ---- buffer cosizes / TMA bytes stamped by build_cfg -------------------------
+    raw_qk_cosize: int = 0
+    raw_v_cosize: int = 0
+    raw_gate_cosize: int = 0
+    operand_cosize: int = 0
+    diag_cosize: int = 0
+    intermediate_cosize: int = 0
+    state_cosize: int = 0
+    dq_cosize: int = 0
+    dk_cosize: int = 0
+    dgate_cosize: int = 0
+    dv_cosize: int = 0
+
+    # TMA transaction bytes per stage
+    tma_q_bytes: int = 0
+    tma_k_bytes: int = 0
+    tma_gate_bytes: int = 0
+    tma_do_bytes: int = 0
+    tma_v_bytes: int = 0
+    tma_state_bytes: int = 0
+
+
+def build_cfg(
+    io_dtype: Type[cutlass.Numeric],
+    *,
+    use_dstate_in: bool,
+    use_dstate0: bool,
+    l2norm: bool,
+    safe_gate: bool,
+    gate_scale_log2: float,
+    beta_sigmoid: bool,
+    use_initial_state: bool,
+    q_ratio: int,
+    k_ratio: int,
+    v_ratio: int,
+    n_heads_out: int,
+    max_active_clusters: int,
+    dyn_sched: bool = False,
+) -> KdaBwdCfg:
+    if io_dtype not in (cutlass.Float16, cutlass.BFloat16):
+        raise ValueError(f"io_dtype={io_dtype} not supported; only Float16 and BFloat16 are supported")
+    cfg = KdaBwdCfg(
+        io_dtype=io_dtype,
+        use_dstate_in=use_dstate_in,
+        use_dstate0=use_dstate0,
+        l2norm=l2norm,
+        safe_gate=safe_gate,
+        gate_scale_log2=gate_scale_log2,
+        beta_sigmoid=beta_sigmoid,
+        use_initial_state=use_initial_state,
+        q_ratio=q_ratio,
+        k_ratio=k_ratio,
+        v_ratio=v_ratio,
+        n_heads_out=n_heads_out,
+        max_active_clusters=max_active_clusters,
+        dyn_sched=dyn_sched,
+    )
+    role_ids = (
+        *cfg.compute_group_0_warp_ids,
+        *cfg.compute_group_1_warp_ids,
+        *cfg.compute_group_2_warp_ids,
+        cfg.super_mma_warp_id,
+        cfg.tcgen05_mma_warp_id,
+        cfg.tma_warp_id,
+        cfg.epilogue_warp_id,
+    )
+    if tuple(sorted(role_ids)) != tuple(range(len(role_ids))):
+        raise ValueError("warp roles must be disjoint and cover contiguous IDs from zero")
+    for group in (
+        cfg.compute_group_0_warp_ids,
+        cfg.compute_group_1_warp_ids,
+        cfg.compute_group_2_warp_ids,
+    ):
+        if len(group) != 4 or group != tuple(range(group[0], group[-1] + 1)):
+            raise ValueError("the fixed schedule requires contiguous four-warp compute groups")
+    cfg.threads_per_cta = len(role_ids) * cfg.threads_per_warp
+    cfg.cg0_threads = len(cfg.compute_group_0_warp_ids) * cfg.threads_per_warp
+    cfg.cg2_threads = len(cfg.compute_group_2_warp_ids) * cfg.threads_per_warp
+    cfg.cg1_threads = len(cfg.compute_group_1_warp_ids) * cfg.threads_per_warp
+    cfg.tmem_user_threads = (
+        1 + len(cfg.compute_group_2_warp_ids) + len(cfg.compute_group_1_warp_ids) + len(cfg.compute_group_0_warp_ids)
+    ) * cfg.threads_per_warp
+    named_barrier_ids = (
+        cfg.cg0_sync_barrier_id,
+        cfg.cg2_sync_barrier_id,
+        cfg.tmem_lifecycle_barrier_id,
+        cfg.cg1_sync_barrier_id,
+    )
+    if (
+        any(not 1 <= barrier_id <= 15 for barrier_id in named_barrier_ids)
+        or len(set(named_barrier_ids)) != len(named_barrier_ids)
+    ):
+        raise ValueError("named barrier IDs must be disjoint values in [1, 15]")
+
+    cfg.tmem_dstate_acc_offset = 0
+    cfg.tmem_dstate_inp_offset = cfg.d_k
+    cfg.tmem_state_inp_offset = cfg.tmem_dstate_inp_offset + cfg.d_k // 2
+    cfg.tmem_state_k_acc_offset = cfg.tmem_state_inp_offset + cfg.d_v
+    cfg.tmem_u_acc_offset = cfg.tmem_state_k_acc_offset + cfg.b_t
+    cfg.tmem_du_acc_offset = cfg.tmem_u_acc_offset + cfg.b_t
+    cfg.tmem_dy_acc_offset = cfg.tmem_state_k_acc_offset
+    cfg.tmem_dq_acc_offset = cfg.tmem_du_acc_offset + cfg.b_t
+    cfg.tmem_dk_decay_acc_offset = cfg.tmem_dq_acc_offset + cfg.b_t
+    cfg.tmem_dk_inv_acc_offset = cfg.tmem_dk_decay_acc_offset + cfg.b_t
+    cfg.tmem_dk_restore_acc_offset = cfg.tmem_dk_inv_acc_offset + cfg.b_t
+    cfg.tmem_y_inp_offset = cfg.tmem_dk_restore_acc_offset + cfg.b_t
+    cfg.tmem_neg_beta_dy_inp_offset = cfg.tmem_y_inp_offset
+    cfg.tmem_du_inp_offset = cfg.tmem_y_inp_offset + cfg.b_t // 2
+    cfg.tmem_qraw_inp_offset = cfg.tmem_du_inp_offset + cfg.b_t // 2
+    cfg.tmem_kraw_inp_offset = cfg.tmem_qraw_inp_offset + cfg.tmem_qk_raw_stages * (cfg.b_t // 2)
+    assert cfg.tmem_kraw_inp_offset + cfg.tmem_qk_raw_stages * (cfg.b_t // 2) <= 512
+
+    cfg.raw_qk_cosize = cfg.smem_raw_stages * cfg.d_k * cfg.b_t
+    cfg.raw_v_cosize = cfg.smem_raw_stages * cfg.d_v * cfg.b_t
+    cfg.raw_gate_cosize = cfg.smem_raw_stages * cfg.d_k * cfg.b_t
+    cfg.operand_cosize = cfg.smem_decay_stages * cfg.b_t * cfg.d_k
+    cfg.diag_cosize = cfg.smem_decay_stages * (cfg.d_k // 16) * 256
+    cfg.intermediate_cosize = cfg.smem_intermediate_stages * cfg.intermediate_tiles * cfg.b_t * cfg.b_t
+    cfg.state_cosize = cfg.smem_state_stages * cfg.d_k * cfg.d_v
+    cfg.dq_cosize = cfg.smem_dq_stages * cfg.b_t * cfg.d_k
+    cfg.dk_cosize = cfg.smem_dk_stages * cfg.b_t * cfg.d_k
+    cfg.dgate_cosize = cfg.smem_dgate_stages * cfg.b_t * cfg.d_k
+    cfg.dv_cosize = cfg.smem_dv_stages * cfg.b_t * cfg.d_v
+    cfg.tma_state_bytes = cfg.d_k * cfg.d_v * (io_dtype.width // 8)
+    cfg.tma_q_bytes = cfg.d_k * cfg.b_t * (cfg.io_dtype.width // 8)
+    cfg.tma_k_bytes = cfg.d_k * cfg.b_t * (cfg.io_dtype.width // 8)
+    cfg.tma_gate_bytes = cfg.d_k * cfg.b_t * 4
+    cfg.tma_do_bytes = cfg.d_v * cfg.b_t * (cfg.io_dtype.width // 8)
+    cfg.tma_v_bytes = cfg.d_v * cfg.b_t * (cfg.io_dtype.width // 8)
+    return cfg
+
+
+TENSORMAP_DESC_ARRAYS = 10  # per-batch runtime TMA descriptors: Q, K, V, Gate, dO, state_checkpoints, dQ, dK, dV, dGate
+TENSORMAP_STATIC_SLOTS = 0
+
+
+# ---- Torch adapter / host-side compilation ---------------------------------------
+
+
+@lru_cache(maxsize=None)
+def get_compiled_cache(
+    io_dtype_str: str,
+    cu_dtype_str: str,
+    HQ: int,
+    HK: int,
+    HV: int,
+    use_dstate_in: bool,
+    use_dstate0: bool,
+    l2norm: bool,
+    safe_gate: bool,
+    gate_lower_bound: float,
+    beta_sigmoid: bool,
+    use_initial_state: bool,
+    dyn_sched: bool,
+    run_order: bool,
+    order_gen: bool,
+    device_index: int,
+    device_major: int,
+    device_minor: int,
+    num_sm: int,
+):
+    return {}
+
+
+def chunk_kda_bwd_sm100(
+    q,
+    k,
+    v,
+    gate,
+    beta,
+    do,
+    state_checkpoints,
+    dq,
+    dk,
+    dv,
+    dgate,
+    dbeta,
+    cu_seqlens,
+    scale: float,
+    *,
+    use_initial_state: bool = False,
+    d_initial_state=None,
+    d_final_state=None,
+    use_qk_l2norm_in_kernel: bool = False,
+    safe_gate: bool = False,
+    gate_lower_bound: float = DEFAULT_GATE_LOWER_BOUND,
+    a_log=None,
+    dt_bias=None,
+    use_beta_sigmoid: bool = False,
+    work_items=None,
+    work_count=None,
+    sched_ctr=None,
+    sched_all=None,
+    work_item_scratch=None,
+    order_in_prologue: bool = False,
+    tensormap_workspace,
+    stream,
+) -> None:
+    """Execute the Blackwell BT=16 chunked KDA backward kernel.
+
+    All tensors must be contiguous and on the same CUDA device.
+
+    Args:
+        q: ``(total_tokens, HQ, DK)`` float16/bfloat16
+        k: ``(total_tokens, HK, DK)`` float16/bfloat16
+        v: ``(total_tokens, HV, DV)`` float16/bfloat16
+        gate: ``(total_tokens, HO, DK)`` fp32.  Natural-log per-channel decay
+              unless ``safe_gate``, which applies the safe-gate transform
+              ``lower_bound * sigmoid(exp(a_log) * (gate + dt_bias))``.
+        beta: ``(total_tokens, HO)``.  Post-sigmoid float32, or io-dtype
+              logits when ``use_beta_sigmoid``
+        do: ``(total_tokens, HO, DV)`` io dtype
+        state_checkpoints: ``(total_checkpoints, HO, DV, DK)`` io dtype (VK, k
+            contiguous), the PLAIN per-chunk checkpoint series: sequence-local
+            entry ``c`` is the state ENTERING chunk c of sequence b, so row 0
+            is the initial state (or zeros when the forward had none)
+        dq/dk/dv: io dtype at ``HO = max(HQ, HV)`` heads, pre-allocated
+        dgate: ``(total_tokens, HO, DK)`` fp32 (dL/d ln alpha), pre-allocated.
+            With ``safe_gate`` this stays the gradient wrt the TRANSFORMED
+            log-decay; a host-side helper converts to d(raw gate) afterward
+        dbeta: ``(total_tokens, HO)`` fp32, or io dtype with
+            ``use_beta_sigmoid``, pre-allocated.  Gradient wrt the post-sigmoid
+            beta, or wrt the raw logits under ``use_beta_sigmoid`` (the kernel
+            folds the sigmoid derivative into its own dbeta write)
+        cu_seqlens: ``(num_seqs + 1,)`` int32
+        scale: attention scale factor
+        use_initial_state: the forward ran with an initial state, so chunk 0
+            has an entering state to load from ``state_checkpoints`` row 0
+        d_initial_state: fp32 ``(num_seqs, HO, DV, DK)`` OUT (dL/d initial state), or None
+        d_final_state: fp32 ``(num_seqs, HO, DV, DK)`` IN (dL/d final state)
+        use_qk_l2norm_in_kernel: q/k arrive raw; the kernel normalizes for the
+            recompute math and chains the L2-norm backward into dq/dk
+        safe_gate: interpret ``gate`` through the safe-gate transform
+        a_log: ``(HO,)`` float32, safe-gate per-head log-amplitude (None = 0)
+        dt_bias: ``(HO, DK)`` float32, safe-gate channel bias (None = 0)
+        use_beta_sigmoid: ``beta`` holds logits; sigmoid in-kernel
+        work_items/work_count: split-K table (``common/split_k.py``, REQUIRED;
+            an uncut table row is the whole (b, h) sequence); each item
+            computes chunks ``[wstart, cend)`` backward and writes
+            gradients only for ``[wstart, wend)``
+        sched_ctr: ``(2,)`` int32 zeroed scratch enabling the dynamic
+            (work-stealing) tile scheduler
+        tensormap_workspace: ``tensormap_workspace_bytes(module, B)`` bytes,
+            128-byte aligned, for the per-(batch, head) TMA-descriptor
+            arrays (tail chunks clip/zero-fill in hardware)
+    """
+    for name, tensor in (
+        ("q", q),
+        ("k", k),
+        ("v", v),
+        ("gate", gate),
+        ("do", do),
+        ("state_checkpoints", state_checkpoints),
+        ("dq", dq),
+        ("dk", dk),
+        ("dv", dv),
+        ("dgate", dgate),
+    ):
+        validate_tma_tensor(name, tensor)
+    for name, tensor in (("d_initial_state", d_initial_state), ("d_final_state", d_final_state)):
+        if tensor is not None:
+            validate_tma_tensor(name, tensor)
+    if cu_seqlens.data_ptr() % 8:
+        raise ValueError("cu_seqlens data pointer must be 8-byte aligned")
+
+    tokens, HQ, d_k = q.shape
+    HK, HV = k.shape[1], v.shape[1]
+    HO = max(HQ, HV)
+    if d_k != 128 or k.shape != (tokens, HK, 128) or v.shape != (tokens, HV, 128):
+        raise ValueError("q, k, and v must have shape (T, H, 128)")
+    if gate.shape != (tokens, HO, 128) or beta.shape != (tokens, HO):
+        raise ValueError("gate and beta must match the output head count and token extent")
+    if do.shape != (tokens, HO, 128):
+        raise ValueError("do must have shape (T, HO, 128)")
+    expected_grad_shapes = ((dq, q.shape), (dk, k.shape), (dv, v.shape), (dgate, gate.shape))
+    if any(tensor.shape != expected for tensor, expected in expected_grad_shapes):
+        raise ValueError("dq, dk, dv, and dgate must match their corresponding inputs")
+    if dbeta.shape != beta.shape:
+        raise ValueError("dbeta must match beta")
+    use_dstate_in = d_final_state is not None
+    use_dstate0 = d_initial_state is not None
+    if work_items is None or work_count is None:
+        raise ValueError("work_items/work_count are required (the split-table stage builds them for every launch)")
+    dyn_sched = sched_ctr is not None
+    run_order = order_in_prologue
+    order_gen = order_in_prologue and work_item_scratch is None
+    if run_order and sched_all is None:
+        raise ValueError("order in the prologue requires sched_all (the prologue zeroes both consumers' sched rings)")
+    required_checkpoint_rows = checkpoint_capacity_bound(
+        q.shape[0], cu_seqlens.shape[0] - 1, CFG.B_T
+    )
+    if state_checkpoints.shape[0] < required_checkpoint_rows:
+        raise ValueError(
+            f"state_checkpoints requires at least {required_checkpoint_rows} rows, "
+            f"got {state_checkpoints.shape[0]}"
+        )
+    if str(state_checkpoints.dtype).split(".")[-1] != str(q.dtype).split(".")[-1]:
+        raise ValueError(f"state_checkpoints dtype must match the io dtype: got {state_checkpoints.dtype} with io {q.dtype}")
+    for name, hh in (("HQ", HQ), ("HK", HK), ("HV", HV)):
+        if HO % hh != 0:
+            raise ValueError(f"{name}={hh} must divide {HO}")
+    B = cu_seqlens.shape[0] - 1
+    gate_scale_log2 = gate_lower_bound * LOG2_E
+
+    if safe_gate and (a_log is None or dt_bias is None):
+        raise ValueError("safe_gate requires a_log and dt_bias")
+    if dt_bias is not None:
+        validate_tma_tensor("dt_bias", dt_bias)
+    if not safe_gate:
+        a_log = None
+        dt_bias = None
+
+    cu_stream = cuda_driver.CUstream(int(stream))
+    device_index = tensor_device_index(q)
+    if current_device() != device_index:
+        raise ValueError("the active CUDA device must match q.device")
+    device_properties = get_device_properties(device_index)
+    num_sm = device_properties.multi_processor_count
+    cache = get_compiled_cache(
+        str(q.dtype),
+        str(cu_seqlens.dtype),
+        HQ,
+        HK,
+        HV,
+        use_dstate_in,
+        use_dstate0,
+        use_qk_l2norm_in_kernel,
+        safe_gate,
+        gate_lower_bound,
+        use_beta_sigmoid,
+        use_initial_state,
+        dyn_sched,
+        run_order,
+        order_gen,
+        device_index,
+        device_properties.major,
+        device_properties.minor,
+        num_sm,
+    )
+
+    if "compiled" not in cache:
+        io_dtype = get_dtype(q.dtype)
+        cfg = build_cfg(
+            io_dtype,
+            use_dstate_in=use_dstate_in,
+            use_dstate0=use_dstate0,
+            l2norm=use_qk_l2norm_in_kernel,
+            safe_gate=safe_gate,
+            gate_scale_log2=gate_scale_log2,
+            beta_sigmoid=use_beta_sigmoid,
+            use_initial_state=use_initial_state,
+            q_ratio=HO // HQ,
+            k_ratio=HO // HK,
+            v_ratio=HO // HV,
+            n_heads_out=HO,
+            max_active_clusters=num_sm,
+            dyn_sched=dyn_sched,
+        )
+
+        dstate0_cute = None
+        if use_dstate0:
+            dstate0_cute = from_dlpack(d_initial_state, assumed_align=16).mark_layout_dynamic(leading_dim=3)
+        dstate_in_cute = None
+        if use_dstate_in:
+            dstate_in_cute = from_dlpack(d_final_state, assumed_align=16).mark_layout_dynamic(leading_dim=3)
+        wi_cute = from_dlpack(work_items, assumed_align=16)
+        wi_cute.mark_compact_shape_dynamic(mode=0, stride_order=(0, 1), divisibility=1)
+        wc_cute = from_dlpack(work_count, assumed_align=4).mark_layout_dynamic()
+        sc_cute = None
+        if dyn_sched:
+            sc_cute = from_dlpack(sched_ctr, assumed_align=4).mark_layout_dynamic()
+
+        tensormap_ws_cute = from_dlpack(tensormap_workspace, assumed_align=128).mark_layout_dynamic()
+
+        a_log_cute = from_dlpack(a_log, assumed_align=4) if a_log is not None else None
+        dt_bias_cute = from_dlpack(dt_bias, assumed_align=16) if dt_bias is not None else None
+        beta_cute = from_dlpack(beta, assumed_align=4).mark_layout_dynamic(leading_dim=len(beta.shape) - 1)
+        state_checkpoints_cute = from_dlpack(state_checkpoints, assumed_align=16).mark_layout_dynamic(leading_dim=len(state_checkpoints.shape) - 1)
+        dgate_cute = from_dlpack(dgate, assumed_align=16).mark_layout_dynamic(leading_dim=len(dgate.shape) - 1)
+        dbeta_cute = from_dlpack(dbeta, assumed_align=4).mark_layout_dynamic(leading_dim=len(dbeta.shape) - 1)
+        op = KdaBpropOp(cfg)
+        op.__call__.set_name_prefix(op.get_name())
+        cache["compiled"] = cute.compile(
+            op,
+            a_log_cute,
+            dt_bias_cute,
+            beta_cute,
+            state_checkpoints_cute,
+            dgate_cute,
+            dbeta_cute,
+            from_dlpack(cu_seqlens, assumed_align=8).mark_layout_dynamic(),
+            dstate0_cute,
+            dstate_in_cute,
+            wi_cute,
+            wc_cute,
+            sc_cute,
+            tensormap_ws_cute,
+            scale,
+            cu_stream,
+            options="--enable-tvm-ffi --opt-level 2",
+        )
+
+    if "prologue" not in cache:
+        io_dtype = get_dtype(q.dtype)
+        q_pl = from_dlpack(q, assumed_align=16).mark_layout_dynamic(leading_dim=2)
+        k_pl = from_dlpack(k, assumed_align=16).mark_layout_dynamic(leading_dim=2)
+        v_pl = from_dlpack(v, assumed_align=16).mark_layout_dynamic(leading_dim=2)
+        gate_pl = from_dlpack(gate, assumed_align=16).mark_layout_dynamic(leading_dim=2)
+        do_pl = from_dlpack(do, assumed_align=16).mark_layout_dynamic(leading_dim=2)
+        dq_pl = from_dlpack(dq, assumed_align=16).mark_layout_dynamic(leading_dim=2)
+        dk_pl = from_dlpack(dk, assumed_align=16).mark_layout_dynamic(leading_dim=2)
+        dv_pl = from_dlpack(dv, assumed_align=16).mark_layout_dynamic(leading_dim=2)
+        dgate_pl = from_dlpack(dgate, assumed_align=16).mark_layout_dynamic(leading_dim=2)
+        state_checkpoints_pl = from_dlpack(state_checkpoints, assumed_align=16).mark_layout_dynamic(leading_dim=3)
+        cu_pl = from_dlpack(cu_seqlens, assumed_align=8).mark_layout_dynamic()
+        ws_pl = from_dlpack(tensormap_workspace, assumed_align=128).mark_layout_dynamic()
+        staging_pl = None
+        if run_order and not order_gen:
+            staging_pl = from_dlpack(work_item_scratch, assumed_align=16)
+            staging_pl.mark_compact_shape_dynamic(mode=0, stride_order=(0, 1), divisibility=1)
+        work_items_pl = from_dlpack(work_items, assumed_align=16)
+        work_items_pl.mark_compact_shape_dynamic(mode=0, stride_order=(0, 1), divisibility=1)
+        work_count_pl = from_dlpack(work_count, assumed_align=4).mark_layout_dynamic()
+        sched_pl = None
+        if run_order:
+            sched_pl = from_dlpack(sched_all, assumed_align=4).mark_layout_dynamic()
+        cache["prologue"] = cute.compile(
+            prologue,
+            io_dtype,
+            CFG.B_T,
+            run_order,
+            order_gen,
+            run_order,
+            q_pl,
+            k_pl,
+            v_pl,
+            gate_pl,
+            do_pl,
+            dq_pl,
+            dk_pl,
+            dv_pl,
+            dgate_pl,
+            state_checkpoints_pl,
+            cu_pl,
+            staging_pl,
+            work_count_pl,
+            work_items_pl,
+            sched_pl,
+            ws_pl,
+            cu_stream,
+            options="--enable-tvm-ffi",
+        )
+    cache["prologue"](
+        q,
+        k,
+        v,
+        gate,
+        do,
+        dq,
+        dk,
+        dv,
+        dgate,
+        state_checkpoints,
+        cu_seqlens,
+        work_item_scratch if run_order else None,
+        work_count,
+        work_items,
+        sched_all if run_order else None,
+        tensormap_workspace,
+        cu_stream,
+    )
+    cache["compiled"](
+        a_log,
+        dt_bias,
+        beta,
+        state_checkpoints,
+        dgate,
+        dbeta,
+        cu_seqlens,
+        d_initial_state,
+        d_final_state,
+        work_items,
+        work_count,
+        sched_ctr,
+        tensormap_workspace,
+        scale,
+        cu_stream,
+    )

--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_prefill_config.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_prefill_config.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# This kernel is derived from cuDNN, NVIDIA Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Kimi Delta Attention (KDA) Cutlass DSL prefill kernel config (fixed
+compile-time constants).  The BT=16 KDA schedule uses a 16-warp (512-thread)
+specialization with a per-key-channel decay; the derived SMEM/TMEM sizes and
+offsets are stamped by ``build_cfg`` in ``kda_prefill_f16.py``.
+
+Target arch: Blackwell SM100 (GB200) / SM103 (GB300).
+"""
+
+from dataclasses import dataclass
+from typing import Tuple
+
+
+@dataclass(frozen=True)
+class Cfg:
+    # --- tile shape ---
+    B_T: int = 16  # chunk-inner token tile (BT=16 KDA schedule)
+    D_K: int = 128  # query/key head dim
+    D_V: int = 128  # value head dim
+
+    # --- warp assignments (16 warps = 512 threads) ---
+    COMPUTE_GROUP_0_WARP_IDS: Tuple[int, ...] = (0, 1, 2, 3, 4, 5, 6, 7)  # decay-operand materialize (2-group ping-pong)
+    COMPUTE_GROUP_1_WARP_IDS: Tuple[int, ...] = (8, 9, 10, 11)  # value-side TMEM / epilogue staging
+    SUPER_MMA_WARP_ID: int = 12  # register-MMA KK^T + Neumann T_inv
+    TCGEN05_MMA_WARP_ID: int = 13  # tcgen05 state GEMMs
+    TMA_WARP_ID: int = 14  # q/k/v/gate TMA loads
+    EPILOGUE_WARP_ID: int = 15  # A register-MMA + O store
+
+    # --- register split ---
+    NUM_REGS_COMPUTE_GROUP_0: int = 160
+    NUM_REGS_COMPUTE_GROUP_1: int = 136
+    NUM_REGS_OTHER: int = 56
+
+    THREADS_PER_WARP: int = 32
+
+    BUFFER_ALIGN_BYTES: int = 1024
+
+    # --- SMEM / TMEM ring stage counts ---
+    SMEM_RAW_STAGES: int = 8
+    SMEM_SCHED_STAGES: int = 8
+    SMEM_O_STAGES: int = 2
+    SMEM_DECAY_STAGES: int = 2
+    SMEM_INTERMEDIATE_STAGES: int = 2
+    SMEM_STATE_SCALE_DIAG_STAGES: int = 4
+    QK_SCALE_READY_STAGES: int = 4
+    TMEM_Q_STATE_ACC_STAGES: int = 2
+
+    CLUSTER_SHAPE_MNK: Tuple[int, int, int] = (1, 1, 1)
+
+
+CFG = Cfg()

--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_prefill_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_prefill_f16.py
@@ -1,0 +1,3360 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# This kernel is derived from cuDNN, NVIDIA Corporation.
+# Modified by Attention Gym in 2026: imports were relocated into this package.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Chunked Kimi Delta Attention (KDA) prefill kernel for Blackwell SM100/SM103
+(Cutlass DSL), BT=16 tiling with a per-key-channel decay.  Framework-neutral
+entry ``chunk_kda_sm100``.
+
+Persistent kernel: the grid is the SM count and every warp role
+runs a tile-scheduler loop (``decode_work_item``); a tile is one (batch,
+head) sequence, or one split-K work item computing chunks ``[cstart, wend)``
+and writing O / checkpoints only for the owned ``[wstart, wend)`` (see
+``common/split_k.py``; warmup chunks rebuild the incoming state from
+zero).  All ring stage/phase bookkeeping runs on cumulative per-CTA chunk
+counters so pipelines flow seamlessly across tiles.
+
+Pipeline (direct CUTLASS primitives, chunk_idx-size 16 KDA schedule):
+
+  load Q/K/V/Gate/Beta
+  optional in-kernel L2-norm of Q/K (L2NORM specialization)
+  exp2(G), exp2(-G), stage final-token exp2(G) as exp2(G_last)
+  super-MMA: KK/A/Neumann inverse (T_inv) + apply Beta
+  tcgen05-MMA: state*K/state*Q/U solve/state update/O
+  store O, periodic state checkpoints, final state
+
+ABI: q `[T, HQ, DK]`, k `[T, HK, DK]`, v `[T, HV, DV]`, gate
+`[T, HO, DK]` fp32 (natural-log decay unless SAFE_GATE, which applies the
+safe-gate transform from raw gate + a_log/dt_bias), beta `[T, HO]` fp32
+post-sigmoid, cu_seqlens int32, states/checkpoints `[N, HO, DV, DK]` (VK, k
+contiguous).
+GQA/GVA head broadcast follows repeat_interleave: source head =
+head_idx // (HO // H_x).  State presence, L2NORM, SAFE_GATE, checkpoints, and the
+head ratios are compile-time specializations.
+
+Warp assignments (16 warps = 512 threads):
+  warps 0-7  : compute group 0 - Gate prefix scan + decay/restore operands
+  warps 8-11 : compute group 1 - TMEM value side, O drain, state stores
+  warp  12   : super-MMA       - register-MMA KK^T + Neumann inverse
+  warp  13   : tcgen05-MMA     - the six state GEMMs + the TMEM lifecycle
+  warp  14   : TMA load        - per-chunk input G->S loads
+  warp  15   : epilogue        - register-MMA A + the O TMA store
+
+SMEM layout (~221 KB total):
+  Buffer                    Bytes  Stages
+  Q / K / V raw             32768  8       <-- SW128 TMA ring (io dtype)
+  gate raw                  65536  8       <-- fp32 prefix-scan source
+  beta                        512  8       <-- fp32 per-token scalars
+  K_inv                      8192  2       <-- token-major ldmatrix/tcgen05 B operand
+  K decay / Q decay       2x 8192  2       <-- tcgen05 SW128 K-box-major A/B operands
+  K restore                  8192  2       <-- tcgen05 B operand for the state update
+  state-scale diag          16384  4       <-- per-K-atom decay diagonal blocks
+  intermediate (A / T_inv)    2048  2       <-- SW32 16x16 register-MMA tiles
+  O staging                  8192  2       <-- W128 output drain
+
+TMEM layout (272 of 512 columns):
+  Buffer          Cols     Purpose
+  state           0-127    state[DK,DV] fp32 recurrent state
+  state inp       128-191  packed b16 A operand view of the state
+  q_state_acc      192-223  2-stage state*Q -> O accumulator
+  state_k_acc     224-239  state*K fp32 accumulator
+  u_acc           240-255  U fp32 accumulator
+  y_inp           256-263  packed b16 Y staging: Beta * (V - state*K)
+  u_inp           264-271  packed b16 U input (b16 U repack)
+
+GEMM schedule (tcgen05-MMA warp, in issue order per chunk):
+  state*K -> state_k_acc
+  state*Q -> q_state_acc (the O acc)
+  state decay (diag blocks)
+  U = Y(T) @ T_inv -> u_acc
+  final_state += U @ K_restore
+  O += A @ U -> q_state_acc
+
+Requires the public CuTeDSL 4.7 API, including `cutlass.experimental.*`.
+"""
+
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import NamedTuple, Type
+
+import cuda.bindings.driver as cuda_driver
+import cutlass
+import cutlass.experimental.cuda as cuda
+import cutlass.experimental.primitives as nvvm
+import cutlass.cute as cute
+from cutlass.cute.runtime import from_dlpack
+
+from .common.split_k import ORDER_CAPACITY, ORDER_ELEMS, ORDER_THREADS, decode_work_item, order_body
+from .common.host import get_dtype
+from .compat import (
+    checkpoint_capacity_bound,
+    current_device,
+    get_device_properties,
+    tensor_device_index,
+    validate_tma_tensor,
+)
+from .common.thd import (
+    TENSOR_MAP_QWORDS,
+    emit_checkpoint_seq_descs,
+    emit_seq_descs,
+    emit_seq_load_descs,
+)
+from .kda_prefill_config import CFG
+
+from .tile_dsl.barrier import (
+    advance,
+    MBarrier,
+    PipelineState,
+    Producer,
+)
+from .tile_dsl.handles import MmaDesc, SmemTile, tma_slice_runtime_desc
+from .tile_dsl.mma import mma_step, mma_ts_step
+from .tile_dsl.swizzle import swizzle_lin_S, swizzle_xor_128b
+from .tile_dsl.tma import tma_load_tile, tma_store_commit, tma_store_tile, tma_store_wait, tma_tensormap_acquire
+from .tile_dsl.pointwise import (
+    opaque_f32_zero,
+    f16x2_to_f32,
+    fadd2,
+    fmul2,
+    ffma2,
+    movmatrix_16b,
+    mul_f16x2,
+    fp32_to_fp16,
+    sub_f16x2,
+)
+
+LOG2_E: float = 1.4426950408889634
+
+
+DEFAULT_GATE_LOWER_BOUND: float = -5.0
+
+
+# Host-side API defaults.
+
+
+L2_NORM_EPS: float = 1.0e-12
+
+
+class KdaBars(NamedTuple):
+    """Every inter-warp handoff as an ``MBarrier`` over its ring.  Consumers
+    track ``(idx, phase)`` inline; the producer tag selects
+    the arrive lowering (``TMA_LOAD``/``MMA_COMMIT``/``THREAD``)."""
+
+    mb_q_ready: MBarrier
+    mb_q_done: MBarrier
+    mb_k_ready: MBarrier
+    mb_k_done: MBarrier
+    mb_v_ready: MBarrier
+    mb_v_done: MBarrier
+    mb_gate_ready: MBarrier
+    mb_gate_done: MBarrier
+
+    mb_beta_ready: MBarrier
+    mb_beta_done: MBarrier
+
+    mb_o_acc_ready: MBarrier
+    mb_o_acc_done: MBarrier
+    mb_state_k_acc_ready: MBarrier
+    mb_u_acc_ready: MBarrier
+
+    mb_state_inp_ready: MBarrier
+    mb_y_inp_ready: MBarrier
+    mb_u_inp_ready: MBarrier
+
+    mb_t_inv_ready: MBarrier
+    mb_t_inv_done: MBarrier
+    mb_a_ready: MBarrier
+    mb_a_done: MBarrier
+    mb_qk_scale_ready: MBarrier
+    mb_state_scale_diag_done: MBarrier
+    mb_k_decay_inv_cg0_ready: MBarrier
+    mb_decay_tcgen05_done: MBarrier
+    mb_decay_super_done: MBarrier
+    mb_k_restore_done: MBarrier
+
+    mb_state_acc_read_done: MBarrier
+    mb_state_acc_done: MBarrier
+    mb_tmem_done: MBarrier
+
+    mb_o_tmastg_ready: MBarrier
+    mb_o_tmastg_done: MBarrier
+
+    mb_checkpoint_tmastg_ready: MBarrier
+    mb_checkpoint_tmastg_done: MBarrier
+
+    mb_sched_ready: MBarrier
+    mb_sched_done: MBarrier
+
+
+def make_kda_bars(cfg) -> KdaBars:
+    """Bars factory.  MUST be called from inside ``kernel`` (allocates the
+    mbarrier rings in SMEM ahead of the data buffers)."""
+
+    def alloc(n):
+        return cutlass.Array(cutlass.Int64, n, space=cutlass.AddressSpace.smem, alignment=8)
+
+    WARP = cfg.threads_per_warp
+    CG0_GROUP_THREADS = cfg.cg0_warps_per_group * WARP
+    CG1_THREADS = len(cfg.compute_group_1_warp_ids) * WARP
+    SCHED_CONSUMER_WARPS = cfg.threads_per_cta // WARP - 1
+
+    return KdaBars(
+        mb_q_ready=MBarrier(alloc(cfg.smem_raw_bar_stages), stages=cfg.smem_raw_bar_stages, init_count=1, producer=Producer.TMA_LOAD),
+        mb_q_done=MBarrier(alloc(cfg.smem_raw_stages), stages=cfg.smem_raw_stages, init_count=CG0_GROUP_THREADS, producer=Producer.THREAD),
+        mb_k_ready=MBarrier(alloc(cfg.smem_raw_bar_stages), stages=cfg.smem_raw_bar_stages, init_count=1, producer=Producer.TMA_LOAD),
+        mb_k_done=MBarrier(alloc(cfg.smem_raw_stages), stages=cfg.smem_raw_stages, init_count=CG0_GROUP_THREADS, producer=Producer.THREAD),
+        mb_v_ready=MBarrier(alloc(cfg.smem_raw_bar_stages), stages=cfg.smem_raw_bar_stages, init_count=1, producer=Producer.TMA_LOAD),
+        mb_v_done=MBarrier(alloc(cfg.smem_raw_stages), stages=cfg.smem_raw_stages, init_count=CG1_THREADS, producer=Producer.THREAD),
+        mb_gate_ready=MBarrier(alloc(cfg.smem_raw_bar_stages), stages=cfg.smem_raw_bar_stages, init_count=1, producer=Producer.TMA_LOAD),
+        mb_gate_done=MBarrier(alloc(cfg.smem_raw_stages), stages=cfg.smem_raw_stages, init_count=CG0_GROUP_THREADS, producer=Producer.THREAD),
+        mb_beta_ready=MBarrier(alloc(cfg.smem_raw_bar_stages), stages=cfg.smem_raw_bar_stages, init_count=WARP, producer=Producer.THREAD),
+        mb_beta_done=MBarrier(alloc(cfg.smem_raw_bar_stages), stages=cfg.smem_raw_bar_stages, init_count=WARP + CG1_THREADS, producer=Producer.THREAD),
+        mb_o_acc_ready=MBarrier(alloc(1), stages=1, init_count=1, producer=Producer.MMA_COMMIT),
+        mb_o_acc_done=MBarrier(alloc(cfg.tmem_q_state_acc_stages), stages=cfg.tmem_q_state_acc_stages, init_count=CG1_THREADS, producer=Producer.THREAD),
+        mb_state_k_acc_ready=MBarrier(alloc(1), stages=1, init_count=1, producer=Producer.MMA_COMMIT),
+        mb_u_acc_ready=MBarrier(alloc(1), stages=1, init_count=1, producer=Producer.MMA_COMMIT),
+        mb_state_inp_ready=MBarrier(alloc(1), stages=1, init_count=CG1_THREADS, producer=Producer.THREAD),
+        mb_y_inp_ready=MBarrier(alloc(1), stages=1, init_count=CG1_THREADS, producer=Producer.THREAD),
+        mb_u_inp_ready=MBarrier(alloc(1), stages=1, init_count=CG1_THREADS, producer=Producer.THREAD),
+        mb_t_inv_ready=MBarrier(alloc(cfg.smem_intermediate_stages), stages=cfg.smem_intermediate_stages, init_count=WARP, producer=Producer.THREAD),
+        mb_t_inv_done=MBarrier(alloc(cfg.smem_intermediate_stages), stages=cfg.smem_intermediate_stages, init_count=1, producer=Producer.MMA_COMMIT),
+        mb_a_ready=MBarrier(alloc(cfg.smem_intermediate_stages), stages=cfg.smem_intermediate_stages, init_count=WARP, producer=Producer.THREAD),
+        mb_a_done=MBarrier(alloc(cfg.smem_intermediate_stages), stages=cfg.smem_intermediate_stages, init_count=1, producer=Producer.MMA_COMMIT),
+        mb_qk_scale_ready=MBarrier(
+            alloc(cfg.qk_scale_ready_stages),
+            stages=cfg.qk_scale_ready_stages,
+            init_count=CG0_GROUP_THREADS,
+            producer=Producer.THREAD,
+        ),
+        mb_state_scale_diag_done=MBarrier(
+            alloc(cfg.smem_state_scale_diag_stages),
+            stages=cfg.smem_state_scale_diag_stages,
+            init_count=1,
+            producer=Producer.MMA_COMMIT,
+        ),
+        mb_k_decay_inv_cg0_ready=MBarrier(alloc(cfg.smem_decay_stages), stages=cfg.smem_decay_stages, init_count=CG0_GROUP_THREADS, producer=Producer.THREAD),
+        mb_decay_tcgen05_done=MBarrier(alloc(cfg.smem_decay_stages), stages=cfg.smem_decay_stages, init_count=1, producer=Producer.MMA_COMMIT),
+        mb_decay_super_done=MBarrier(alloc(cfg.smem_decay_stages), stages=cfg.smem_decay_stages, init_count=2 * WARP, producer=Producer.THREAD),
+        mb_k_restore_done=MBarrier(alloc(cfg.smem_decay_stages), stages=cfg.smem_decay_stages, init_count=1, producer=Producer.MMA_COMMIT),
+        mb_state_acc_read_done=MBarrier(alloc(1), stages=1, init_count=CG1_THREADS, producer=Producer.THREAD),
+        mb_state_acc_done=MBarrier(alloc(1), stages=1, init_count=1, producer=Producer.MMA_COMMIT),
+        mb_tmem_done=MBarrier(alloc(1), stages=1, init_count=CG1_THREADS, producer=Producer.THREAD),
+        mb_o_tmastg_ready=MBarrier(alloc(cfg.smem_o_stages), stages=cfg.smem_o_stages, init_count=CG1_THREADS, producer=Producer.THREAD),
+        mb_o_tmastg_done=MBarrier(alloc(cfg.smem_o_stages), stages=cfg.smem_o_stages, init_count=WARP, producer=Producer.THREAD),
+        mb_checkpoint_tmastg_ready=MBarrier(
+            alloc(cfg.smem_checkpoint_stages), stages=cfg.smem_checkpoint_stages, init_count=CG1_THREADS, producer=Producer.THREAD
+        ),
+        mb_checkpoint_tmastg_done=MBarrier(alloc(cfg.smem_checkpoint_stages), stages=cfg.smem_checkpoint_stages, init_count=WARP, producer=Producer.THREAD),
+        # The TMA warp publishes each scheduler slot. Every other warp elects one done arrival.
+        mb_sched_ready=MBarrier(alloc(cfg.sched_stages), stages=cfg.sched_stages, init_count=1, producer=Producer.THREAD),
+        mb_sched_done=MBarrier(
+            alloc(cfg.sched_stages),
+            stages=cfg.sched_stages,
+            init_count=SCHED_CONSUMER_WARPS,
+            producer=Producer.THREAD,
+        ),
+    )
+
+
+# ---- Dynamic tile scheduler ------------------------------------------------------
+
+
+@cute.jit
+def sched_publish_next(cfg, bars, sSched, mSched, sched_state, tile_idx, num_ctas):
+    """TMA-warp side: pull the next tile off the global ticket, publish it."""
+    if cutlass.const_expr(cfg.dyn_sched):
+        bars.mb_sched_done[sched_state.idx].wait(sched_state.phase)
+        if nvvm.elect_sync():
+            fetched = cutlass.Int32(nvvm.atomicrmw("add", mSched.iterator, cutlass.Int32(1), mem_order="relaxed", syncscope="gpu"))
+            sSched[sched_state.idx] = num_ctas + fetched
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+        next_tile = sSched[sched_state.idx]
+        if nvvm.elect_sync():
+            bars.mb_sched_ready[sched_state.idx].arrive()
+        return next_tile, advance(sched_state, cfg.sched_stages)
+    return tile_idx + num_ctas, sched_state
+
+
+@cute.jit
+def sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas):
+    """Consumer side: read the TMA warp's published next tile."""
+    if cutlass.const_expr(cfg.dyn_sched):
+        bars.mb_sched_ready[sched_state.idx].wait(sched_state.phase)
+        next_tile = sSched[sched_state.idx]
+        if nvvm.elect_sync():
+            bars.mb_sched_done[sched_state.idx].arrive()
+        return next_tile, advance(sched_state, cfg.sched_stages)
+    return tile_idx + num_ctas, sched_state
+
+
+@cute.jit
+def tmaldg_warp(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    n_desc,
+    cu_seqlens,
+    mWorkItems,
+    mSched,
+    sSched,
+    lane,
+    sQ_raw,
+    sK_raw,
+    sV_raw,
+    sGate_raw,
+    desc_q_base,
+    desc_k_base,
+    desc_v_base,
+    desc_gate_base,
+    bars,
+) -> None:
+    """TMA-LDG warp role (warp 14): persistent scheduler loop issuing the
+    per-chunk Q/K/V/Gate G->S loads."""
+    elect_one = nvvm.elect_sync()
+    nvvm.setmaxregister(cfg.num_regs_other, nvvm.SetMaxRegisterAction.DECREASE)
+    sQ_tma = SmemTile(
+        base=sQ_raw,
+        elems_per_stage=(cfg.d_k * cfg.b_t),
+        stages=cfg.smem_raw_stages,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=0,
+        tma_loads_per_tile=(cfg.d_k // 64),
+        tma_granu_elems=64,
+        tma_subtile_stride_elems=(cfg.b_t * 64),
+    )
+    sK_tma = SmemTile(
+        base=sK_raw,
+        elems_per_stage=(cfg.d_k * cfg.b_t),
+        stages=cfg.smem_raw_stages,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=0,
+        tma_loads_per_tile=(cfg.d_k // 64),
+        tma_granu_elems=64,
+        tma_subtile_stride_elems=(cfg.b_t * 64),
+    )
+    sV_tma = SmemTile(
+        base=sV_raw,
+        elems_per_stage=(cfg.d_v * cfg.b_t),
+        stages=cfg.smem_raw_stages,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=0,
+        tma_loads_per_tile=(cfg.d_k // 64),
+        tma_granu_elems=64,
+        tma_subtile_stride_elems=(cfg.b_t * 64),
+    )
+    sGate_tma = SmemTile(
+        base=sGate_raw,
+        elems_per_stage=(cfg.d_k * cfg.b_t),
+        stages=cfg.smem_raw_stages,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=0,
+        tma_loads_per_tile=(cfg.d_k // 32),
+        tma_granu_elems=32,
+        tma_subtile_stride_elems=(cfg.b_t * 32),
+    )
+    raw_index = PipelineState.start(phase=1)
+    raw_bar_index = PipelineState.start(phase=0)
+    sched_state = PipelineState.start(phase=1)
+    packed_tokens = cutlass.Int32(cu_seqlens[n_desc])
+    tile_idx = cutlass.Int32(bidx)
+    while tile_idx < total_tiles:
+        batch_idx, head_idx, batch_start, batch_end, seqlen_b, num_chunks_b, wstart, wend, cstart, cend = decode_work_item(cfg, tile_idx, mWorkItems)
+        head_o = head_idx
+        head_q = head_idx if cfg.q_ratio == 1 else head_idx // cutlass.Int32(cfg.q_ratio)
+        head_k = head_idx if cfg.k_ratio == 1 else head_idx // cutlass.Int32(cfg.k_ratio)
+        head_v = head_idx if cfg.v_ratio == 1 else head_idx // cutlass.Int32(cfg.v_ratio)
+        slot = batch_idx * cutlass.Int32(TENSOR_MAP_QWORDS)
+        desc_q_slot = (desc_q_base + slot).tospace(cutlass.AddressSpace.generic)
+        desc_k_slot = (desc_k_base + slot).tospace(cutlass.AddressSpace.generic)
+        desc_v_slot = (desc_v_base + slot).tospace(cutlass.AddressSpace.generic)
+        desc_gate_slot = (desc_gate_base + slot).tospace(cutlass.AddressSpace.generic)
+        if elect_one:
+            tma_tensormap_acquire(desc_q_slot)
+            tma_tensormap_acquire(desc_k_slot)
+            tma_tensormap_acquire(desc_v_slot)
+            tma_tensormap_acquire(desc_gate_slot)
+        use_packed_coords = batch_end == packed_tokens
+        for chunk_idx in cutlass.range(cstart, wend, 1, unroll=1):
+            chunk_start = chunk_idx * cfg.b_t
+            input_chunk_start = (
+                batch_start + chunk_start if use_packed_coords else chunk_start
+            )
+
+            # ---- Q load ----------------------------------------------------------
+            bars.mb_q_done[raw_index.idx].wait(raw_index.phase)
+            if elect_one:
+                bars.mb_q_ready[raw_bar_index.idx].arrive(n_bytes=cfg.tma_q_bytes)
+            q_slice = tma_slice_runtime_desc(
+                desc_q_slot, cutlass.Int32(0), head_q, input_chunk_start
+            )
+            tma_load_tile(
+                sQ_tma[raw_index.idx],
+                q_slice,
+                bars.mb_q_ready[raw_bar_index.idx].smem_ptr,
+                acquire=False,
+            )
+
+            # ---- K load ----------------------------------------------------------
+            bars.mb_k_done[raw_index.idx].wait(raw_index.phase)
+            if elect_one:
+                bars.mb_k_ready[raw_bar_index.idx].arrive(n_bytes=cfg.tma_k_bytes)
+            k_slice = tma_slice_runtime_desc(
+                desc_k_slot, cutlass.Int32(0), head_k, input_chunk_start
+            )
+            tma_load_tile(
+                sK_tma[raw_index.idx],
+                k_slice,
+                bars.mb_k_ready[raw_bar_index.idx].smem_ptr,
+                acquire=False,
+            )
+
+            # ---- Gate load -------------------------------------------------------
+            bars.mb_gate_done[raw_index.idx].wait(raw_index.phase)
+            if elect_one:
+                bars.mb_gate_ready[raw_bar_index.idx].arrive(n_bytes=cfg.tma_gate_bytes)
+            gate_slice = tma_slice_runtime_desc(
+                desc_gate_slot, cutlass.Int32(0), head_o, input_chunk_start
+            )
+            tma_load_tile(
+                sGate_tma[raw_index.idx],
+                gate_slice,
+                bars.mb_gate_ready[raw_bar_index.idx].smem_ptr,
+                acquire=False,
+            )
+
+            # ---- V load ----------------------------------------------------------
+            bars.mb_v_done[raw_index.idx].wait(raw_index.phase)
+            if elect_one:
+                bars.mb_v_ready[raw_bar_index.idx].arrive(n_bytes=cfg.tma_v_bytes)
+            v_slice = tma_slice_runtime_desc(
+                desc_v_slot, cutlass.Int32(0), head_v, input_chunk_start
+            )
+            tma_load_tile(
+                sV_tma[raw_index.idx],
+                v_slice,
+                bars.mb_v_ready[raw_bar_index.idx].smem_ptr,
+                acquire=False,
+            )
+
+            raw_index = advance(raw_index, cfg.smem_raw_stages)
+            raw_bar_index = advance(raw_bar_index, cfg.smem_raw_bar_stages)
+        tile_idx, sched_state = sched_publish_next(cfg, bars, sSched, mSched, sched_state, tile_idx, num_ctas)
+
+
+@cute.jit
+def super_mma_warp(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    cu_seqlens,
+    mWorkItems,
+    sSched,
+    lane,
+    sK_inv_raw,
+    sIntermediate_raw,
+    sBeta_raw,
+    sK_decay_raw,
+    bars,
+) -> None:
+    """Super-MMA warp role (warp 12): persistent scheduler loop computing the
+    Neumann-series T_inv via register MMA."""
+    nvvm.setmaxregister(cfg.num_regs_other, nvvm.SetMaxRegisterAction.DECREASE)
+    raw_index = PipelineState.start(phase=0)
+    t_inv_free = PipelineState.start(phase=1)
+    k_decay_ready = PipelineState.start(phase=0)
+
+    # ---- ldmatrix/stmatrix lane decode -------------------------------------------
+    rhs_row_coord = lane % 8 + (cutlass.Int32(8) if (lane // 16) else cutlass.Int32(0))
+    rhs_col_offset = cutlass.Int32(8) if ((lane // 8) % 2) else cutlass.Int32(0)
+    lhs_row_coord = lane % 8 + (cutlass.Int32(8) if ((lane // 8) % 2) else cutlass.Int32(0))
+    lhs_col_offset = cutlass.Int32(8) if ((lane // 8) // 2) else cutlass.Int32(0)
+    decay_key_mask = cutlass.Int32(8)
+    stsm_row_coord = lane & 7
+    stsm_col_coord = cutlass.Int32(0)
+    if (lane // 8) & 1:
+        stsm_row_coord = stsm_row_coord + cutlass.Int32(8)
+    if lane // 8 >= 2:
+        stsm_col_coord = cutlass.Int32(8)
+    stsm_idx = swizzle_lin_S(stsm_row_coord * cfg.b_t + (stsm_col_coord ^ (cfg.b_t // 2)), bbits=1, mbase=3, sshift=3)
+    cum_chunk_base = cutlass.Int32(0)
+    sched_state = PipelineState.start(phase=0)
+    tile_idx = cutlass.Int32(bidx)
+    while tile_idx < total_tiles:
+        batch_idx, head_idx, batch_start, batch_end, seqlen_b, num_chunks_b, wstart, wend, cstart, cend = decode_work_item(cfg, tile_idx, mWorkItems)
+        num_chunks_tile = wend - cstart  # processed chunks; ring bookkeeping runs on cum_chunk_base + local_chunk_idx
+        for local_chunk_idx in cutlass.range(num_chunks_tile, unroll=1):
+            cum_chunk = cum_chunk_base + local_chunk_idx
+            decay_stage = k_decay_ready.idx
+            intermediate_stage = t_inv_free.idx
+            sBeta_ptr = sBeta_raw.data_ptr() + raw_index.idx * cfg.b_t
+            sK_inv_ptr = sK_inv_raw.data_ptr() + decay_stage * (cfg.b_t * cfg.d_k)
+            sK_decay_ptr = sK_decay_raw.data_ptr() + decay_stage * (cfg.d_k * cfg.b_t)
+            sIntermediate_ptr = sIntermediate_raw.data_ptr() + intermediate_stage * (2 * cfg.b_t * cfg.b_t)
+
+            bars.mb_k_decay_inv_cg0_ready[decay_stage].wait(k_decay_ready.phase)
+            k_decay_ready = advance(k_decay_ready, cfg.smem_decay_stages)
+
+            # ---- KK = K_decay @ K_inv^T ------------------------------------------
+            kk_acc = cutlass.Array(cutlass.Float32, 8, alignment=16)
+            for accum_idx in cutlass.range_constexpr(8):
+                kk_acc[accum_idx] = cutlass.Float32(0.0)
+
+            for k_block in cutlass.range_constexpr((cfg.d_k // 16)):
+                # Load B operand
+                k_inv_col = k_block * 16 + rhs_col_offset
+                k_inv_segment = k_inv_col // 64
+                rhs_frag = nvvm.ldmatrix(
+                    sK_inv_ptr
+                    + k_inv_segment * (cfg.b_t * 64)
+                    + rhs_row_coord * 64
+                    + swizzle_xor_128b(rhs_row_coord, k_inv_col - k_inv_segment * 64, elem_bytes=2),
+                    4,
+                    nvvm.MMALayout.ROW,
+                )
+                # Load A operand
+                storage_key = (k_block * 16 + lhs_col_offset) ^ decay_key_mask
+                storage_slice = storage_key // 64
+                kk_lhs_frag = nvvm.ldmatrix(
+                    sK_decay_ptr
+                    + storage_slice * (cfg.b_t * 64)
+                    + swizzle_xor_128b(lhs_row_coord, lhs_row_coord * 64 + storage_key - storage_slice * 64, elem_bytes=2),
+                    4,
+                    nvvm.MMALayout.ROW,
+                )
+
+                mma_step(
+                    kk_acc,
+                    (kk_lhs_frag[0], kk_lhs_frag[1], kk_lhs_frag[2], kk_lhs_frag[3]),
+                    (rhs_frag[0], rhs_frag[1], rhs_frag[2], rhs_frag[3]),
+                    k_step=0,
+                    M=16,
+                    N=16,
+                    ab_dtype=cfg.io_dtype,
+                )
+
+            # ---- L = Beta * tril(KK, -1) fragment --------------------------------
+            bars.mb_beta_ready[raw_index.idx].wait(raw_index.phase)
+            row_lo = lane // 4
+            row_hi = row_lo + cutlass.Int32(8)
+            beta_lo = (sBeta_ptr + row_lo).load().to(cutlass.Float32)
+            beta_hi = (sBeta_ptr + row_hi).load().to(cutlass.Float32)
+            l_regs = cutlass.Array(cutlass.Float32, 8, alignment=16)
+            for accum_idx in cutlass.range_constexpr(8):
+                row_coord = row_hi if cutlass.const_expr(accum_idx % 4 >= 2) else row_lo
+                col_coord = (accum_idx // 4) * 8 + 2 * (lane % 4)
+                if cutlass.const_expr(accum_idx % 2 == 1):
+                    col_coord = col_coord + cutlass.Int32(1)
+                l_regs[accum_idx] = kk_acc[accum_idx] if row_coord > col_coord else cutlass.Float32(0.0)
+            for pair in cutlass.range_constexpr(4):
+                beta_scale = beta_hi if cutlass.const_expr(pair % 2 == 1) else beta_lo
+                l_regs[2 * pair], l_regs[2 * pair + 1] = fmul2(l_regs[2 * pair], l_regs[2 * pair + 1], beta_scale, beta_scale)
+            bars.mb_beta_done[raw_index.idx].arrive()
+            l_a0 = fp32_to_fp16(l_regs[0], l_regs[1], dtype=cfg.io_dtype)
+            l_a1 = fp32_to_fp16(l_regs[2], l_regs[3], dtype=cfg.io_dtype)
+            l_a2 = fp32_to_fp16(l_regs[4], l_regs[5], dtype=cfg.io_dtype)
+            l_a3 = fp32_to_fp16(l_regs[6], l_regs[7], dtype=cfg.io_dtype)
+            l_values = cutlass.Vector.from_elements((l_a0, l_a1, l_a2, l_a3), cutlass.Int32).bitcast(cfg.io_dtype).to(cutlass.Float32)
+
+            # ---- T_inv = I - L, then three Neumann doubling rounds ---------------
+            tinv_acc = cutlass.Array(cutlass.Float32, 8, alignment=16)
+            for accum_idx in cutlass.range_constexpr(8):
+                row_coord = row_lo
+                if cutlass.const_expr(accum_idx % 4 >= 2):
+                    row_coord = row_hi
+                col_coord = (accum_idx // 4) * 8 + 2 * (lane % 4)
+                if cutlass.const_expr(accum_idx % 2 == 1):
+                    col_coord = col_coord + cutlass.Int32(1)
+                eye = cutlass.Float32(1.0) if row_coord == col_coord else cutlass.Float32(0.0)
+                tinv_acc[accum_idx] = eye - l_values[accum_idx]
+
+            lpow_a0, lpow_a1, lpow_a2, lpow_a3 = l_a0, l_a1, l_a2, l_a3
+            mov_lpow0, mov_lpow1, mov_lpow2, mov_lpow3 = movmatrix_16b(l_a0), movmatrix_16b(l_a1), movmatrix_16b(l_a2), movmatrix_16b(l_a3)
+            for _round in cutlass.range_constexpr(3):
+                # ---- Lpow = Lpow @ Lpow ------------------------------------------
+                sq_acc = cutlass.Array(cutlass.Float32, 8, alignment=16)
+                for accum_idx in cutlass.range_constexpr(8):
+                    sq_acc[accum_idx] = cutlass.Float32(0.0)
+                mma_step(
+                    sq_acc,
+                    (lpow_a0, lpow_a1, lpow_a2, lpow_a3),
+                    (mov_lpow0, mov_lpow1, mov_lpow2, mov_lpow3),
+                    k_step=0,
+                    M=16,
+                    N=16,
+                    ab_dtype=cfg.io_dtype,
+                )
+                lpow_a0 = fp32_to_fp16(sq_acc[0], sq_acc[1], dtype=cfg.io_dtype)
+                lpow_a1 = fp32_to_fp16(sq_acc[2], sq_acc[3], dtype=cfg.io_dtype)
+                lpow_a2 = fp32_to_fp16(sq_acc[4], sq_acc[5], dtype=cfg.io_dtype)
+                lpow_a3 = fp32_to_fp16(sq_acc[6], sq_acc[7], dtype=cfg.io_dtype)
+                mov_lpow0, mov_lpow1, mov_lpow2, mov_lpow3 = movmatrix_16b(lpow_a0), movmatrix_16b(lpow_a1), movmatrix_16b(lpow_a2), movmatrix_16b(lpow_a3)
+                # ---- T_inv += T_inv @ Lpow ---------------------------------------
+                upd_acc = cutlass.Array(cutlass.Float32, 8, alignment=16)
+                for accum_idx in cutlass.range_constexpr(8):
+                    upd_acc[accum_idx] = cutlass.Float32(0.0)
+                tinv_p0 = fp32_to_fp16(tinv_acc[0], tinv_acc[1], dtype=cfg.io_dtype)
+                tinv_p1 = fp32_to_fp16(tinv_acc[2], tinv_acc[3], dtype=cfg.io_dtype)
+                tinv_p2 = fp32_to_fp16(tinv_acc[4], tinv_acc[5], dtype=cfg.io_dtype)
+                tinv_p3 = fp32_to_fp16(tinv_acc[6], tinv_acc[7], dtype=cfg.io_dtype)
+                mma_step(
+                    upd_acc,
+                    (tinv_p0, tinv_p1, tinv_p2, tinv_p3),
+                    (mov_lpow0, mov_lpow1, mov_lpow2, mov_lpow3),
+                    k_step=0,
+                    M=16,
+                    N=16,
+                    ab_dtype=cfg.io_dtype,
+                )
+                tinv_lo0, tinv_hi0 = f16x2_to_f32(tinv_p0, dtype=cfg.io_dtype)
+                tinv_lo1, tinv_hi1 = f16x2_to_f32(tinv_p1, dtype=cfg.io_dtype)
+                tinv_lo2, tinv_hi2 = f16x2_to_f32(tinv_p2, dtype=cfg.io_dtype)
+                tinv_lo3, tinv_hi3 = f16x2_to_f32(tinv_p3, dtype=cfg.io_dtype)
+                tinv_acc[0], tinv_acc[1] = fadd2(tinv_lo0, tinv_hi0, upd_acc[0], upd_acc[1])
+                tinv_acc[2], tinv_acc[3] = fadd2(tinv_lo1, tinv_hi1, upd_acc[2], upd_acc[3])
+                tinv_acc[4], tinv_acc[5] = fadd2(tinv_lo2, tinv_hi2, upd_acc[4], upd_acc[5])
+                tinv_acc[6], tinv_acc[7] = fadd2(tinv_lo3, tinv_hi3, upd_acc[6], upd_acc[7])
+
+            bars.mb_t_inv_done[intermediate_stage].wait(t_inv_free.phase)
+            t_inv_free = advance(t_inv_free, cfg.smem_intermediate_stages)
+            nvvm.stmatrix(
+                sIntermediate_ptr + (cfg.b_t * cfg.b_t) + stsm_idx,
+                [
+                    fp32_to_fp16(tinv_acc[0], tinv_acc[1], dtype=cfg.io_dtype),
+                    fp32_to_fp16(tinv_acc[2], tinv_acc[3], dtype=cfg.io_dtype),
+                    fp32_to_fp16(tinv_acc[4], tinv_acc[5], dtype=cfg.io_dtype),
+                    fp32_to_fp16(tinv_acc[6], tinv_acc[7], dtype=cfg.io_dtype),
+                ],
+                nvvm.MMALayout.ROW,
+                shape=nvvm.StoreShape.M8N8,
+            )
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_t_inv_ready[intermediate_stage].arrive()
+            bars.mb_decay_super_done[decay_stage].arrive()
+            raw_index = advance(raw_index, cfg.smem_raw_bar_stages)
+        cum_chunk_base += num_chunks_tile
+        tile_idx, sched_state = sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas)
+
+
+@cute.jit
+def tcgen05_mma_warp(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    cu_seqlens,
+    mWorkItems,
+    sSched,
+    tmem_base_slot,
+    sIntermediate,
+    sK_decay,
+    sK_restore,
+    sQ_decay,
+    sState_scale_diag,
+    bars,
+) -> None:
+    """tcgen05-MMA warp role (warp 13): persistent scheduler loop issuing
+    every tcgen05 GEMM and owning the TMEM lifecycle."""
+    elect_one = nvvm.elect_sync()
+    nvvm.setmaxregister(cfg.num_regs_other, nvvm.SetMaxRegisterAction.DECREASE)
+    nvvm.tcgen05_alloc(tmem_base_slot, cutlass.Int32(512), group=nvvm.CTAGroup.CTA_1)
+    nvvm.barrier_cta_sync(cfg.tmem_lifecycle_barrier_id, thread_count=cfg.tmem_user_threads)
+    tmem_base = tmem_base_slot.load()
+    state_inp_ptr = nvvm.make_tmem_ptr(tmem_base + cfg.tmem_state_inp_offset, cutlass.Int8)
+    state_dsts = tuple(nvvm.make_tmem_ptr(tmem_base + cfg.tmem_state_acc_offset + k * 16, cutlass.Float32) for k in range(cfg.d_k // 16))
+    state_k_acc_ptr = nvvm.make_tmem_ptr(tmem_base + cfg.tmem_state_k_acc_offset, cutlass.Float32)
+    u_acc_ptr = nvvm.make_tmem_ptr(tmem_base + cfg.tmem_u_acc_offset, cutlass.Float32)
+    y_inp_ptr = nvvm.make_tmem_ptr(tmem_base + cfg.tmem_y_inp_offset, cutlass.Int8)
+    u_inp_ptr = nvvm.make_tmem_ptr(tmem_base + cfg.tmem_u_inp_offset, cutlass.Int8)
+    state_dst_ptr = nvvm.make_tmem_ptr(tmem_base + cfg.tmem_state_acc_offset, cutlass.Float32)
+    state_inp_index = PipelineState.start(phase=0)
+    state_read_index = PipelineState.start(phase=0)
+    y_inp_index = PipelineState.start(phase=0)
+    u_inp_index = PipelineState.start(phase=0)
+    qk_scale_index = PipelineState.start(phase=0)
+    k_decay_ready = PipelineState.start(phase=0)
+    intermediate_ready = PipelineState.start(phase=0)
+    o_acc_free = PipelineState.start(phase=1)
+
+    # ---- chunk-invariant GEMM descriptors ----------------------------------------
+    bpe = cfg.io_dtype.width // 8
+    idesc_acc = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.b_t,
+        m_dim=cfg.d_v,
+        b_major=0,
+    )
+    idesc_diag = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=16,
+        m_dim=cfg.d_v,
+        b_major=0,
+    )
+    idesc_final_state = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.d_k,
+        m_dim=cfg.d_v,
+        b_major=1,
+    )
+    bmm_state_desc = MmaDesc(
+        M=cfg.d_v,
+        N=cfg.b_t,
+        K=cfg.d_k,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=False,
+        cta_group=1,
+        idesc=idesc_acc,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    bmm_diag_desc = MmaDesc(
+        M=cfg.d_v,
+        N=16,
+        K=16,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=False,
+        cta_group=1,
+        idesc=idesc_diag,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    bmm_intermediate_desc = MmaDesc(
+        M=cfg.d_v,
+        N=cfg.b_t,
+        K=cfg.b_t,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=False,
+        cta_group=1,
+        idesc=idesc_acc,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    bmm_final_state_desc = MmaDesc(
+        M=cfg.d_v,
+        N=cfg.d_k,
+        K=cfg.b_t,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=True,
+        cta_group=1,
+        idesc=idesc_final_state,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    STATE_A_SEG = bmm_state_desc.sps_B * bmm_state_desc.tmem_advance_A
+    STATE_B_SEG = bmm_state_desc.smem_subtile_B >> 4
+    cum_chunk_base = cutlass.Int32(0)
+    sched_state = PipelineState.start(phase=0)
+    tile_idx = cutlass.Int32(bidx)
+    while tile_idx < total_tiles:
+        batch_idx, head_idx, batch_start, batch_end, seqlen_b, num_chunks_b, wstart, wend, cstart, cend = decode_work_item(cfg, tile_idx, mWorkItems)
+        num_chunks_tile = wend - cstart
+        for local_chunk_idx in cutlass.range(num_chunks_tile, unroll=1):
+            cum_chunk = cum_chunk_base + local_chunk_idx
+            have_state = cutlass.Boolean(True) if cutlass.const_expr(cfg.use_initial_state) else local_chunk_idx > 0
+            q_state_acc_stage = o_acc_free.idx
+            decay_stage = k_decay_ready.idx
+            state_scale_diag_stage = qk_scale_index.idx
+            intermediate_stage = intermediate_ready.idx
+            sK_decay_stage = sK_decay[decay_stage]
+            sQ_decay_stage = sQ_decay[decay_stage]
+            sK_restore_stage = sK_restore[decay_stage]
+            sState_scale_diag_stage = sState_scale_diag[state_scale_diag_stage]
+            sIntermediate_stage = sIntermediate[intermediate_stage]
+
+            # ---- state_k = S(T) @ K_decay^T --------------------------------------
+            bars.mb_k_decay_inv_cg0_ready[decay_stage].wait(k_decay_ready.phase)
+            k_decay_ready = advance(k_decay_ready, cfg.smem_decay_stages)
+            if have_state:
+                bars.mb_state_inp_ready.wait(state_inp_index.phase)
+                state_inp_index = advance(state_inp_index, 1)
+                desc_k_decay = sK_decay_stage.desc()
+
+                for s in cutlass.range_constexpr(bmm_state_desc.num_subtiles_B):
+                    for k in cutlass.range_constexpr(bmm_state_desc.sps_B):
+                        mma_ts_step(
+                            bmm_state_desc,
+                            state_inp_ptr.subview(s * STATE_A_SEG),
+                            desc_k_decay + s * STATE_B_SEG,
+                            state_k_acc_ptr,
+                            k,
+                            cutlass.Boolean(s + k > 0),
+                        )
+
+                if elect_one:
+                    bars.mb_state_k_acc_ready.arrive(cta_group=1)
+
+            # ---- q_state = state(T) @ Q_decay^T ---------------------------------
+            bars.mb_qk_scale_ready[qk_scale_index.idx].wait(qk_scale_index.phase)
+            bars.mb_o_acc_done[q_state_acc_stage].wait(o_acc_free.phase)
+            o_acc_free = advance(o_acc_free, cfg.tmem_q_state_acc_stages)
+            q_state_acc_ptr = nvvm.make_tmem_ptr(tmem_base + cfg.tmem_q_state_acc_offset + q_state_acc_stage * cfg.b_t, cutlass.Float32)
+            if have_state:
+                desc_q_decay = sQ_decay_stage.desc()
+                for s in cutlass.range_constexpr(bmm_state_desc.num_subtiles_B):
+                    for k in cutlass.range_constexpr(bmm_state_desc.sps_B):
+                        mma_ts_step(
+                            bmm_state_desc,
+                            state_inp_ptr.subview(s * STATE_A_SEG),
+                            desc_q_decay + s * STATE_B_SEG,
+                            q_state_acc_ptr,
+                            k,
+                            cutlass.Boolean(s + k > 0),
+                        )
+
+            if elect_one:
+                bars.mb_decay_tcgen05_done[decay_stage].arrive(cta_group=1)
+
+            # ---- S decay = S(T) @ diag(exp2(G_last)) ---------
+            if cutlass.const_expr(cfg.enable_checkpoints):
+                if have_state:
+                    bars.mb_state_acc_read_done.wait(state_read_index.phase)
+                    state_read_index = advance(state_read_index, 1)
+            if have_state:
+                desc_diag = sState_scale_diag_stage.desc()
+                for k_block in cutlass.range_constexpr(cfg.d_k // 16):
+                    mma_ts_step(
+                        bmm_diag_desc,
+                        state_inp_ptr.subview(k_block * bmm_diag_desc.tmem_advance_A),
+                        desc_diag.advance_start_address(k_block * 256 * 2),
+                        state_dsts[k_block],
+                        0,
+                        cutlass.Boolean(False),
+                    )
+
+            if elect_one:
+                bars.mb_state_scale_diag_done[state_scale_diag_stage].arrive(cta_group=1)
+
+            # ---- U = Y(T) @ T_inv ------------------------------------------------
+            bars.mb_t_inv_ready[intermediate_stage].wait(intermediate_ready.phase)
+            bars.mb_y_inp_ready.wait(y_inp_index.phase)
+            y_inp_index = advance(y_inp_index, 1)
+            d_int = sIntermediate_stage.shifted((cfg.b_t * cfg.b_t)).desc()
+            mma_ts_step(bmm_intermediate_desc, y_inp_ptr, d_int, u_acc_ptr, 0, cutlass.Boolean(False))
+            if elect_one:
+                bars.mb_t_inv_done[intermediate_stage].arrive(cta_group=1)
+                bars.mb_u_acc_ready.arrive(cta_group=1)
+
+            # ---- final_state += U(T) @ K_restore ---------------------------------
+            bars.mb_u_inp_ready.wait(u_inp_index.phase)
+            u_inp_index = advance(u_inp_index, 1)
+            desc_k_restore = sK_restore_stage.desc()
+
+            mma_ts_step(bmm_final_state_desc, u_inp_ptr, desc_k_restore, state_dst_ptr, 0, have_state)
+            if elect_one:
+                bars.mb_k_restore_done[decay_stage].arrive(cta_group=1)
+                bars.mb_state_acc_done.arrive(cta_group=1)
+
+            # ---- O += U(T) @ A ---------------------------------------------------
+            bars.mb_a_ready[intermediate_stage].wait(intermediate_ready.phase)
+            intermediate_ready = advance(intermediate_ready, cfg.smem_intermediate_stages)
+            d_int = sIntermediate_stage.desc()
+            mma_ts_step(
+                bmm_intermediate_desc,
+                u_inp_ptr,
+                d_int,
+                nvvm.make_tmem_ptr(tmem_base + cfg.tmem_q_state_acc_offset + q_state_acc_stage * cfg.b_t, cutlass.Float32),
+                0,
+                have_state,
+            )
+            if elect_one:
+                bars.mb_o_acc_ready.arrive(cta_group=1)
+                bars.mb_a_done[intermediate_stage].arrive(cta_group=1)
+            qk_scale_index = advance(qk_scale_index, cfg.smem_state_scale_diag_stages)
+
+        cum_chunk_base += num_chunks_tile
+        tile_idx, sched_state = sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas)
+    bars.mb_tmem_done[0].wait(0)
+    nvvm.tcgen05_relinquish_alloc_permit(group=nvvm.CTAGroup.CTA_1)
+    nvvm.tcgen05_dealloc(
+        nvvm.make_tmem_ptr(tmem_base, cutlass.Int8),
+        cutlass.Int32(512),
+        group=nvvm.CTAGroup.CTA_1,
+    )
+
+
+@cute.jit
+def epilogue_warp(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    cu_seqlens,
+    mWorkItems,
+    sSched,
+    lane,
+    mO,
+    sK_inv_raw,
+    sO_raw,
+    sIntermediate_raw,
+    sQ_decay_raw,
+    sCheckpoint_raw,
+    desc_o_base,
+    desc_checkpoint_base,
+    checkpoint_every_n_tokens,
+    bars,
+) -> None:
+    """Epilogue warp role (warp 15): persistent scheduler loop computing the
+    causal A tile via register MMA and draining the O/checkpoint TMA stores."""
+    elect_one = nvvm.elect_sync()
+    nvvm.setmaxregister(cfg.num_regs_other, nvvm.SetMaxRegisterAction.DECREASE)
+    if cutlass.const_expr(cfg.enable_checkpoints):
+        sCheckpoint_tma = SmemTile(
+            base=sCheckpoint_raw,
+            elems_per_stage=(cfg.d_k * cfg.d_v),
+            stages=cfg.smem_checkpoint_stages,
+            leading_byte_offset=0,
+            stride_byte_offset=0,
+            layout=0,
+            tma_loads_per_tile=(cfg.d_v // 64),
+            tma_granu_elems=64,
+            tma_subtile_stride_elems=cfg.d_k * 64,
+        )
+    checkpoint_ready_index = PipelineState.start(phase=0)
+    sO_tma = SmemTile(
+        base=sO_raw,
+        elems_per_stage=(cfg.b_t * cfg.d_v),
+        stages=cfg.smem_o_stages,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=0,
+        tma_loads_per_tile=(cfg.d_v // 64),
+        tma_granu_elems=64,
+        tma_subtile_stride_elems=cfg.b_t * 64,
+    )
+    qk_scale_index = PipelineState.start(phase=0)
+    a_free = PipelineState.start(phase=1)
+
+    # ---- ldmatrix/stmatrix lane decode -------------------------------------------
+    rhs_row_coord = lane % 8 + (cutlass.Int32(8) if (lane // 16) else cutlass.Int32(0))
+    rhs_col_offset = cutlass.Int32(8) if ((lane // 8) % 2) else cutlass.Int32(0)
+    lhs_row_coord = lane % 8 + (cutlass.Int32(8) if ((lane // 8) % 2) else cutlass.Int32(0))
+    lhs_col_offset = cutlass.Int32(8) if ((lane // 8) // 2) else cutlass.Int32(0)
+    decay_key_mask = cutlass.Int32(8)
+    stsm_row_coord = lane & 7
+    stsm_col_coord = cutlass.Int32(0)
+    if (lane // 8) & 1:
+        stsm_row_coord = stsm_row_coord + cutlass.Int32(8)
+    if lane // 8 >= 2:
+        stsm_col_coord = cutlass.Int32(8)
+    stsm_idx = swizzle_lin_S(stsm_row_coord * cfg.b_t + (stsm_col_coord ^ (cfg.b_t // 2)), bbits=1, mbase=3, sshift=3)
+    cum_chunk_base = cutlass.Int32(0)
+    sched_state = PipelineState.start(phase=0)
+    tile_idx = cutlass.Int32(bidx)
+    while tile_idx < total_tiles:
+        batch_idx, head_idx, batch_start, batch_end, seqlen_b, num_chunks_b, wstart, wend, cstart, cend = decode_work_item(cfg, tile_idx, mWorkItems)
+        head_o = head_idx
+        o_slot = batch_idx * cutlass.Int32(TENSOR_MAP_QWORDS)
+        desc_o_slot = (desc_o_base + o_slot).tospace(cutlass.AddressSpace.generic)
+        if cutlass.const_expr(cfg.enable_checkpoints):
+            desc_checkpoint_slot = (desc_checkpoint_base + o_slot).tospace(cutlass.AddressSpace.generic)
+            checkpoint_chunks = checkpoint_every_n_tokens // cutlass.Int32(cfg.b_t)
+            checkpoint_quot = (cstart + cutlass.Int32(1)) // checkpoint_chunks
+            checkpoint_mod = (cstart + cutlass.Int32(1)) % checkpoint_chunks
+            if elect_one:
+                tma_tensormap_acquire(desc_checkpoint_slot)
+        if elect_one:
+            tma_tensormap_acquire(desc_o_slot)
+        num_chunks_tile = wend - cstart
+        if cutlass.const_expr(cfg.enable_checkpoints):
+            if num_chunks_tile > 0 and wstart == 0:
+                checkpoint_stage = checkpoint_ready_index.idx
+                bars.mb_checkpoint_tmastg_ready[checkpoint_stage].wait(checkpoint_ready_index.phase)
+                checkpoint_ready_index = advance(checkpoint_ready_index, cfg.smem_checkpoint_stages)
+                checkpoint_slice = tma_slice_runtime_desc(desc_checkpoint_slot, cutlass.Int32(0), cutlass.Int32(0), cutlass.Int32(0), head_o)
+                tma_store_tile(sCheckpoint_tma[checkpoint_stage], checkpoint_slice, acquire=False)
+                tma_store_commit()
+                tma_store_wait(0)
+                bars.mb_checkpoint_tmastg_done[checkpoint_stage].arrive()
+        for local_chunk_idx in cutlass.range(num_chunks_tile, unroll=1):
+            chunk_idx = cstart + local_chunk_idx
+            cum_chunk = cum_chunk_base + local_chunk_idx
+            decay_stage = cum_chunk % cfg.smem_decay_stages
+            intermediate_stage = a_free.idx
+
+            sK_inv_ptr = sK_inv_raw.data_ptr() + decay_stage * (cfg.b_t * cfg.d_k)
+            sQ_decay_ptr = sQ_decay_raw.data_ptr() + decay_stage * (cfg.d_k * cfg.b_t)
+            sIntermediate_ptr = sIntermediate_raw.data_ptr() + intermediate_stage * (2 * cfg.b_t * cfg.b_t)
+
+            bars.mb_qk_scale_ready[qk_scale_index.idx].wait(qk_scale_index.phase)
+
+            # ---- A = Q_decay @ K_inv^T ------------------------------------------
+            a_acc = cutlass.Array(cutlass.Float32, 8, alignment=16)
+            for accum_idx in cutlass.range_constexpr(8):
+                a_acc[accum_idx] = cutlass.Float32(0.0)
+
+            for k_block in cutlass.range_constexpr((cfg.d_k // 16)):
+                # Load B operand
+                k_inv_col = k_block * 16 + rhs_col_offset
+                k_inv_segment = k_inv_col // 64
+                rhs_frag = nvvm.ldmatrix(
+                    sK_inv_ptr
+                    + k_inv_segment * (cfg.b_t * 64)
+                    + rhs_row_coord * 64
+                    + swizzle_xor_128b(rhs_row_coord, k_inv_col - k_inv_segment * 64, elem_bytes=2),
+                    4,
+                    nvvm.MMALayout.ROW,
+                )
+                # Load A operand
+                storage_key = (k_block * 16 + lhs_col_offset) ^ decay_key_mask
+                storage_slice = storage_key // 64
+                a_lhs_frag = nvvm.ldmatrix(
+                    sQ_decay_ptr
+                    + storage_slice * (cfg.b_t * 64)
+                    + swizzle_xor_128b(lhs_row_coord, lhs_row_coord * 64 + storage_key - storage_slice * 64, elem_bytes=2),
+                    4,
+                    nvvm.MMALayout.ROW,
+                )
+
+                mma_step(
+                    a_acc,
+                    (a_lhs_frag[0], a_lhs_frag[1], a_lhs_frag[2], a_lhs_frag[3]),
+                    (rhs_frag[0], rhs_frag[1], rhs_frag[2], rhs_frag[3]),
+                    k_step=0,
+                    M=16,
+                    N=16,
+                    ab_dtype=cfg.io_dtype,
+                )
+
+            for accum_idx in cutlass.range_constexpr(8):
+                row_coord = lane // 4
+                if cutlass.const_expr(accum_idx % 4 >= 2):
+                    row_coord = row_coord + cutlass.Int32(8)
+                col_coord = (accum_idx // 4) * 8 + 2 * (lane % 4)
+                if cutlass.const_expr(accum_idx % 2 == 1):
+                    col_coord = col_coord + cutlass.Int32(1)
+                a_acc[accum_idx] = a_acc[accum_idx] if row_coord >= col_coord else cutlass.Float32(0.0)
+
+            bars.mb_a_done[intermediate_stage].wait(a_free.phase)
+            a_free = advance(a_free, cfg.smem_intermediate_stages)
+            nvvm.stmatrix(
+                sIntermediate_ptr + stsm_idx,
+                [
+                    fp32_to_fp16(a_acc[0], a_acc[1], dtype=cfg.io_dtype),
+                    fp32_to_fp16(a_acc[2], a_acc[3], dtype=cfg.io_dtype),
+                    fp32_to_fp16(a_acc[4], a_acc[5], dtype=cfg.io_dtype),
+                    fp32_to_fp16(a_acc[6], a_acc[7], dtype=cfg.io_dtype),
+                ],
+                nvvm.MMALayout.ROW,
+                shape=nvvm.StoreShape.M8N8,
+            )
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_a_ready[intermediate_stage].arrive()
+            bars.mb_decay_super_done[decay_stage].arrive()
+            qk_scale_index = advance(qk_scale_index, cfg.qk_scale_ready_stages)
+
+            # ---- checkpoint + O drain: checkpoint stores first (CG1 stages the checkpoint before O) -------------
+            if local_chunk_idx > 0:
+                output_chunk = chunk_idx - cutlass.Int32(1)
+                output_chunk_start = output_chunk * cfg.b_t
+                o_stage = (cum_chunk - cutlass.Int32(1)) % cfg.smem_o_stages
+                did_checkpoint = cutlass.Int32(0)
+                checkpoint_stage = cutlass.Int32(0)
+                if cutlass.const_expr(cfg.enable_checkpoints):
+                    # ---- checkpoint store ----------------------------------------
+                    do_checkpoint = checkpoint_mod == 0
+                    do_checkpoint = do_checkpoint and chunk_idx >= wstart
+                    checkpoint_stage = checkpoint_ready_index.idx
+                    if do_checkpoint:
+                        bars.mb_checkpoint_tmastg_ready[checkpoint_ready_index.idx].wait(checkpoint_ready_index.phase)
+                        checkpoint_ready_index = advance(checkpoint_ready_index, cfg.smem_checkpoint_stages)
+                        checkpoint_entry = checkpoint_quot
+                        checkpoint_slice = tma_slice_runtime_desc(desc_checkpoint_slot, cutlass.Int32(0), cutlass.Int32(0), checkpoint_entry, head_o)
+                        tma_store_tile(sCheckpoint_tma[checkpoint_stage], checkpoint_slice, acquire=False)
+                        tma_store_commit()
+                        did_checkpoint = cutlass.Int32(1)
+                    checkpoint_mod = checkpoint_mod + cutlass.Int32(1)
+                    if checkpoint_mod == checkpoint_chunks:
+                        checkpoint_mod = cutlass.Int32(0)
+                        checkpoint_quot = checkpoint_quot + cutlass.Int32(1)
+                bars.mb_o_tmastg_ready[o_stage].wait(((cum_chunk - cutlass.Int32(1)) // cfg.smem_o_stages) % 2)
+                o_slice = tma_slice_runtime_desc(desc_o_slot, cutlass.Int32(0), head_o, output_chunk_start)
+                did_o = cutlass.Int32(0)
+                if output_chunk >= wstart:
+                    tma_store_tile(sO_tma[o_stage], o_slice, acquire=False)
+                    tma_store_commit()
+                    did_o = cutlass.Int32(1)
+                if cutlass.const_expr(cfg.enable_checkpoints):
+                    if did_checkpoint == 1 and did_o == 1:
+                        tma_store_wait(1)
+                        bars.mb_checkpoint_tmastg_done[checkpoint_stage].arrive()
+                        tma_store_wait(0)
+                        bars.mb_o_tmastg_done[o_stage].arrive()
+                    if did_checkpoint == 1 and did_o == 0:
+                        tma_store_wait(0)
+                        bars.mb_checkpoint_tmastg_done[checkpoint_stage].arrive()
+                        bars.mb_o_tmastg_done[o_stage].arrive()
+                    if did_checkpoint == 0:
+                        if did_o == 1:
+                            tma_store_wait(0)
+                        bars.mb_o_tmastg_done[o_stage].arrive()
+                else:
+                    tma_store_wait(0)
+                    bars.mb_o_tmastg_done[o_stage].arrive()
+
+        # ---- last computed chunk drain (always owned: it is wend - 1) ------------
+        if num_chunks_tile > 0:
+            output_chunk = wend - cutlass.Int32(1)
+            last_cum_chunk = cum_chunk_base + num_chunks_tile - cutlass.Int32(1)
+            output_chunk_start = output_chunk * cfg.b_t
+            o_stage = last_cum_chunk % cfg.smem_o_stages
+            bars.mb_o_tmastg_ready[o_stage].wait((last_cum_chunk // cfg.smem_o_stages) % 2)
+            o_slice = tma_slice_runtime_desc(desc_o_slot, cutlass.Int32(0), head_o, output_chunk_start)
+            tma_store_tile(sO_tma[o_stage], o_slice, acquire=False)
+            tma_store_commit()
+            tma_store_wait(0)
+            bars.mb_o_tmastg_done[o_stage].arrive()
+        cum_chunk_base += num_chunks_tile
+        tile_idx, sched_state = sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas)
+
+
+@cute.jit
+def gate_scale(cfg, raw_gate: cutlass.Float32) -> cutlass.Float32:
+    """Map raw gate to the log2-domain decay increment used by KDA."""
+
+    if cutlass.const_expr(cfg.safe_gate):
+        half = cutlass.Float32(0.5)
+        sigmoid = cute.math.tanh(raw_gate * half, approx=True) * half + half
+        return cfg.gate_scale_log2 * sigmoid
+    return raw_gate * cutlass.Float32(LOG2_E)
+
+
+@cute.jit
+def compute0_warp_group(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    cu_seqlens,
+    mWorkItems,
+    sSched,
+    lane,
+    warp_idx,
+    mQ,
+    mA_log,
+    mDt_bias,
+    sK_inv_raw,
+    sGate_raw,
+    mBeta,
+    sBeta_raw,
+    sK_raw,
+    sQ_raw,
+    sK_decay_raw,
+    sK_restore_raw,
+    sQ_decay_raw,
+    sState_scale_diag_raw,
+    bars,
+) -> None:
+    """CG0 warp role (warps 0-7, two ping-pong groups): persistent scheduler
+    loop for the Gate prefix scan and decay/restore operand materialization."""
+    nvvm.setmaxregister(cfg.num_regs_compute_group_0, nvvm.SetMaxRegisterAction.INCREASE)
+    cg0_warp = warp_idx - cfg.compute_group_0_warp_ids[0]
+    cg0_group_id = cg0_warp // cfg.cg0_warps_per_group
+    cg0_local_warp = cg0_warp % cfg.cg0_warps_per_group
+    prefix_dim = cg0_local_warp * cfg.threads_per_warp + lane
+    cg0_a_log_exp = cutlass.Float32(1.0)
+    cg0_dt_bias_value = cutlass.Float32(0.0)
+    cum_chunk_base = cutlass.Int32(0)
+    sched_state = PipelineState.start(phase=0)
+    tile_idx = cutlass.Int32(bidx)
+    opaque_one = opaque_f32_zero() + cutlass.Float32(1.0)
+    while tile_idx < total_tiles:
+        batch_idx, head_idx, batch_start, batch_end, seqlen_b, num_chunks_b, wstart, wend, cstart, cend = decode_work_item(cfg, tile_idx, mWorkItems)
+        head_o = head_idx
+        num_chunks_tile = wend - cstart
+        if cutlass.const_expr(cfg.safe_gate):
+            if num_chunks_tile > 0:
+                cg0_a_log_exp = cute.math.exp2(mA_log[head_o].to(cutlass.Float32) * LOG2_E, fastmath=True)
+                cg0_dt_bias_value = mDt_bias[head_o, prefix_dim].to(cutlass.Float32)
+        # tile entry: both ping-pong groups inherit each other's delivery proofs (parity-swap guard)
+        nvvm.barrier_cta_sync(cfg.cg0_tile_entry_barrier_id, thread_count=cfg.cg0_group_count * cfg.cg0_threads_per_group)
+        group_cum_chunk_start = cum_chunk_base + cutlass.Int32(cg0_group_id)
+        diag_ring_idx = group_cum_chunk_start % cutlass.Int32(cfg.smem_state_scale_diag_stages)
+        diag_ring_phase = (group_cum_chunk_start // cutlass.Int32(cfg.smem_state_scale_diag_stages)) % cutlass.Int32(2)
+        for local_chunk_idx in cutlass.range(cg0_group_id, num_chunks_tile, cfg.cg0_group_count, unroll=1):
+            chunk_idx = cstart + local_chunk_idx
+            cum_chunk = cum_chunk_base + local_chunk_idx
+            chunk_start = chunk_idx * cfg.b_t
+            decay_stage = cum_chunk % cfg.smem_decay_stages
+            raw_stage = cum_chunk % cfg.smem_raw_stages
+            raw_bar_stage = cum_chunk % cfg.smem_raw_bar_stages
+            state_scale_diag_stage = diag_ring_idx
+            qk_scale_ready_stage = state_scale_diag_stage
+            sQ_ptr = sQ_raw.data_ptr() + raw_stage * (cfg.d_k * cfg.b_t)
+            sK_ptr = sK_raw.data_ptr() + raw_stage * (cfg.d_k * cfg.b_t)
+            sGate_ptr = sGate_raw.data_ptr() + raw_stage * (cfg.d_k * cfg.b_t)
+            sK_inv_ptr = sK_inv_raw.data_ptr() + decay_stage * (cfg.b_t * cfg.d_k)
+            sK_decay_ptr = sK_decay_raw.data_ptr() + decay_stage * (cfg.d_k * cfg.b_t)
+            sQ_decay_ptr = sQ_decay_raw.data_ptr() + decay_stage * (cfg.d_k * cfg.b_t)
+            sK_restore_ptr = sK_restore_raw.data_ptr() + decay_stage * (cfg.d_k * cfg.b_t)
+            sState_scale_diag_ptr = sState_scale_diag_raw.data_ptr() + state_scale_diag_stage * ((cfg.d_k // 16) * 256)
+
+            # ---- Beta scalars ---------------------------------------------------
+            if cg0_local_warp == 0:
+                bars.mb_beta_done[raw_bar_stage].wait(((cum_chunk // cfg.smem_raw_bar_stages) + 1) % 2)
+                if lane < cfg.b_t:
+                    token_idx = chunk_idx * cfg.b_t + lane
+                    beta_value = cutlass.Float32(0.0)
+                    if token_idx < seqlen_b:
+                        beta_value = mBeta[batch_start + token_idx, head_o].to(cutlass.Float32)
+                        if cutlass.const_expr(cfg.beta_sigmoid):
+                            half = cutlass.Float32(0.5)
+                            beta_value = (cute.math.tanh(beta_value * half, approx=True) * half + half).to(mBeta.element_type).to(cutlass.Float32)
+                    sBeta_raw[raw_bar_stage * cfg.b_t + lane] = beta_value
+                bars.mb_beta_ready[raw_bar_stage].arrive()
+            bars.mb_gate_ready[raw_bar_stage].wait((cum_chunk // cfg.smem_raw_bar_stages) % 2)
+
+            row_group_start = cg0_local_warp * (cfg.b_t // cfg.cg0_warps_per_group)
+            lane_row_group = lane // 8
+            lane_in_row_group = lane - lane_row_group * 8
+            decay_row = row_group_start + lane_row_group
+            decay_key_mask = cutlass.Int32(8)
+
+            prefix_dim = cg0_local_warp * cfg.threads_per_warp + lane
+
+            # ---- Gate prefix scan -----------------------------------------------
+            f32_segment = prefix_dim // 32
+            prefix_seg_base = f32_segment * (cfg.b_t * 32)
+            prefix_col = prefix_dim - f32_segment * 32
+            gate_raw = cutlass.Array(cutlass.Float32, cfg.b_t, alignment=16)
+            for row in cutlass.range_constexpr(cfg.b_t):
+                prefix_idx = prefix_seg_base + swizzle_xor_128b(row, row * 32 + prefix_col, elem_bytes=4)
+                gate_raw[row] = (sGate_ptr + prefix_idx).load()
+            g_prefix_regs = cutlass.Array(cutlass.Float32, cfg.b_t, alignment=16)
+            if cutlass.const_expr(cfg.safe_gate):
+                valid_rows = seqlen_b - chunk_idx * cutlass.Int32(cfg.b_t)
+                valid_mask = cutlass.vector.create_mask([cfg.b_t], [valid_rows])
+                for row_pair in cutlass.range_constexpr(cfg.b_t // 2):
+                    row0 = row_pair * 2
+                    row1 = row0 + 1
+                    gate0 = cg0_a_log_exp * (gate_raw[row0] + cg0_dt_bias_value)
+                    gate1 = cg0_a_log_exp * (gate_raw[row1] + cg0_dt_bias_value)
+                    gate0 = gate_scale(
+                        cfg,
+                        gate0,
+                    )
+                    gate1 = gate_scale(
+                        cfg,
+                        gate1,
+                    )
+                    gate_pair = cutlass.Vector.from_elements((gate0, gate1), cutlass.Float32)
+                    gate_pair = cutlass.vector.where(valid_mask[row0 : row1 + 1], gate_pair, 0.0)
+                    g_prefix_regs[row0] = gate_pair[0]
+                    g_prefix_regs[row1] = gate_pair[1]
+            else:
+                for row in cutlass.range_constexpr(cfg.b_t):
+                    gate = gate_raw[row]
+                    token_idx = chunk_idx * cutlass.Int32(cfg.b_t) + cutlass.Int32(row)
+                    if token_idx < seqlen_b:
+                        gate = gate_scale(
+                            cfg,
+                            gate,
+                        )
+                    else:
+                        gate = cutlass.Float32(0.0)
+                    g_prefix_regs[row] = gate
+
+            prefix_acc = cutlass.Float32(0.0)
+            for row_pair in cutlass.range_constexpr(cfg.b_t // 2):
+                row0 = row_pair * 2
+                row1 = row0 + 1
+                gate0 = g_prefix_regs[row0]
+                gate1 = g_prefix_regs[row1]
+                prefix0, row_pair_sum = fadd2(prefix_acc, gate0, gate0, gate1)
+                prefix1 = prefix_acc + row_pair_sum
+                g_prefix_regs[row0] = prefix0
+                g_prefix_regs[row1] = prefix1
+                prefix_acc = prefix1
+
+            # ---- exp2(G): stage prefixes + final-token decay ---------------------
+            for row in cutlass.range_constexpr(cfg.b_t):
+                g_prefix_regs[row] = cute.math.exp2(g_prefix_regs[row], fastmath=True)
+
+            exp_g_last = g_prefix_regs[cfg.b_t - 1]
+            for row in cutlass.range_constexpr(cfg.b_t):
+                prefix_idx = prefix_seg_base + swizzle_xor_128b(row, row * 32 + prefix_col, elem_bytes=4)
+                (sGate_ptr + prefix_idx).store(g_prefix_regs[row])
+
+            # ---- state-scale diag: stage exp2(G_last) decay blocks ---------------
+            bars.mb_state_scale_diag_done[state_scale_diag_stage].wait(diag_ring_phase ^ cutlass.Int32(1))
+            block = prefix_dim // cutlass.Int32(16)
+            coord = prefix_dim - block * cutlass.Int32(16)
+            storage_col = coord ^ cutlass.Int32((cfg.b_t // 2))
+            linear_idx = block * cutlass.Int32(256) + coord * cutlass.Int32(16) + storage_col
+            diag_idx = swizzle_lin_S(linear_idx, bbits=1, mbase=3, sshift=3)
+            sState_scale_diag_ptr[diag_idx] = exp_g_last.to(cfg.io_dtype)
+
+            nvvm.barrier_cta_sync(cfg.cg0_group_sync_barrier_base_id + cg0_group_id, thread_count=cfg.cg0_threads_per_group)
+
+            bars.mb_q_ready[raw_bar_stage].wait((cum_chunk // cfg.smem_raw_bar_stages) % 2)
+            bars.mb_k_ready[raw_bar_stage].wait((cum_chunk // cfg.smem_raw_bar_stages) % 2)
+            k_inv_pack = cutlass.Array(cutlass.Int32, 2 * 4, alignment=16)
+            raw_q_regs = cutlass.Array(cutlass.Float32, 2 * 8, alignment=16)
+            raw_k_regs = cutlass.Array(cutlass.Float32, 2 * 8, alignment=16)
+
+            # ---- optional Q/K L2-norm -------------------------------------------
+            if cutlass.const_expr(cfg.l2norm):
+                q_sq_even = opaque_f32_zero()
+                k_sq_even = opaque_f32_zero()
+                q_sq_odd = opaque_f32_zero()
+                k_sq_odd = opaque_f32_zero()
+            for dim_half in cutlass.range_constexpr(2):
+                dim_base = dim_half * (cfg.d_k // 2) + lane_in_row_group * 8
+                reg_base = dim_half * 8
+                f16_segment = dim_base // 64
+                f16_segment_dim = dim_base - f16_segment * 64
+                raw_f16_idx = f16_segment * (cfg.b_t * 64) + decay_row * 64 + swizzle_xor_128b(decay_row, f16_segment_dim, elem_bytes=2)
+                raw_q_frag = (sQ_ptr + raw_f16_idx).load(count=8, alignment=16)
+                raw_k_frag = (sK_ptr + raw_f16_idx).load(count=8, alignment=16)
+                raw_q_vec_f32 = raw_q_frag.to(cutlass.Float32)
+                raw_k_vec_f32 = raw_k_frag.to(cutlass.Float32)
+                for dim_offset in cutlass.range_constexpr(8):
+                    q_val = raw_q_vec_f32[dim_offset]
+                    k_val = raw_k_vec_f32[dim_offset]
+                    raw_q_regs[reg_base + dim_offset] = q_val
+                    raw_k_regs[reg_base + dim_offset] = k_val
+                    if cutlass.const_expr(cfg.l2norm):
+                        if cutlass.const_expr(dim_offset % 2 == 0):
+                            q_sq_even, k_sq_even = ffma2(q_val, k_val, q_val, k_val, q_sq_even, k_sq_even)
+                        else:
+                            q_sq_odd, k_sq_odd = ffma2(q_val, k_val, q_val, k_val, q_sq_odd, k_sq_odd)
+
+            q_inv_norm = opaque_one
+            k_inv_norm = opaque_one
+            if cutlass.const_expr(cfg.l2norm):
+                q_sum_sq = q_sq_even + q_sq_odd
+                k_sum_sq = k_sq_even + k_sq_odd
+                q_sum_sq = q_sum_sq + cutlass.Float32(nvvm.shfl_sync(0xFFFFFFFF, q_sum_sq, 4, 31, kind=nvvm.Shfl.BFLY))
+                q_sum_sq = q_sum_sq + cutlass.Float32(nvvm.shfl_sync(0xFFFFFFFF, q_sum_sq, 2, 31, kind=nvvm.Shfl.BFLY))
+                q_sum_sq = q_sum_sq + cutlass.Float32(nvvm.shfl_sync(0xFFFFFFFF, q_sum_sq, 1, 31, kind=nvvm.Shfl.BFLY))
+                k_sum_sq = k_sum_sq + cutlass.Float32(nvvm.shfl_sync(0xFFFFFFFF, k_sum_sq, 4, 31, kind=nvvm.Shfl.BFLY))
+                k_sum_sq = k_sum_sq + cutlass.Float32(nvvm.shfl_sync(0xFFFFFFFF, k_sum_sq, 2, 31, kind=nvvm.Shfl.BFLY))
+                k_sum_sq = k_sum_sq + cutlass.Float32(nvvm.shfl_sync(0xFFFFFFFF, k_sum_sq, 1, 31, kind=nvvm.Shfl.BFLY))
+                norm_floor_sq = cutlass.Float32(L2_NORM_EPS * L2_NORM_EPS)
+                q_inv_norm = cute.math.rsqrt(cute.math.max(q_sum_sq, norm_floor_sq), fastmath=True)
+                k_inv_norm = cute.math.rsqrt(cute.math.max(k_sum_sq, norm_floor_sq), fastmath=True)
+
+            # ---- decay/restore operands: exp2(+-G) ------------------------------
+            exp_g_regs = cutlass.Array(cutlass.Float32, 2 * 8, alignment=16)
+            exp_g_last_regs = cutlass.Array(cutlass.Float32, 2 * 8, alignment=16)
+            for dim_half in cutlass.range_constexpr(2):
+                dim_base = dim_half * (cfg.d_k // 2) + lane_in_row_group * 8
+                reg_base = dim_half * 8
+                for f32_group in cutlass.range_constexpr(2):
+                    f32_dim_base = dim_base + f32_group * 4
+                    f32_segment = f32_dim_base // 32
+                    f32_segment_dim = f32_dim_base - f32_segment * 32
+                    g_prefix_idx = f32_segment * (cfg.b_t * 32) + decay_row * 32 + swizzle_xor_128b(decay_row, f32_segment_dim, elem_bytes=4)
+                    exp_g_frag = (sGate_ptr + g_prefix_idx).load(count=4, alignment=16)
+                    exp_g_last_idx = f32_segment * (cfg.b_t * 32) + (cfg.b_t - 1) * 32 + swizzle_xor_128b((cfg.b_t - 1), f32_segment_dim, elem_bytes=4)
+                    exp_g_last_frag = (sGate_ptr + exp_g_last_idx).load(count=4, alignment=16)
+                    f32_reg_base = reg_base + f32_group * 4
+                    for j in cutlass.range_constexpr(4):
+                        exp_g_regs[f32_reg_base + j] = exp_g_frag[j]
+                        exp_g_last_regs[f32_reg_base + j] = exp_g_last_frag[j]
+
+            for dim_half in cutlass.range_constexpr(2):
+                dim_base = dim_half * (cfg.d_k // 2) + lane_in_row_group * 8
+                reg_base = dim_half * 8
+
+                # ---- K decay + K_inv operands: K * exp2(+G) and K * exp2(-G) -----
+                k_decay_pack = cutlass.Array(cutlass.Int32, 4, alignment=16)
+                for pair_idx in cutlass.range_constexpr(4):
+                    dim0 = pair_idx * 2
+                    dim1 = dim0 + 1
+                    raw_reg_idx0 = reg_base + dim0
+                    raw_reg_idx1 = reg_base + dim1
+                    k_value0, k_value1 = fmul2(raw_k_regs[raw_reg_idx0], raw_k_regs[raw_reg_idx1], k_inv_norm, k_inv_norm)
+                    k_pair = fp32_to_fp16(k_value0, k_value1, dtype=cfg.io_dtype)
+                    exp_g_pair = fp32_to_fp16(exp_g_regs[raw_reg_idx0], exp_g_regs[raw_reg_idx1], dtype=cfg.io_dtype)
+                    k_decay_pack[pair_idx] = mul_f16x2(k_pair, exp_g_pair, cfg.io_dtype)
+                    exp_neg_g0 = cute.math.rcp(exp_g_regs[raw_reg_idx0], approx=True, ftz=True)
+                    exp_neg_g1 = cute.math.rcp(exp_g_regs[raw_reg_idx1], approx=True, ftz=True)
+                    exp_neg_pair = fp32_to_fp16(exp_neg_g0, exp_neg_g1, dtype=cfg.io_dtype)
+                    k_inv_pack[dim_half * 4 + pair_idx] = mul_f16x2(k_pair, exp_neg_pair, cfg.io_dtype)
+
+                k_inv_vec = cutlass.Vector.from_elements(
+                    (
+                        k_inv_pack[dim_half * 4],
+                        k_inv_pack[dim_half * 4 + 1],
+                        k_inv_pack[dim_half * 4 + 2],
+                        k_inv_pack[dim_half * 4 + 3],
+                    ),
+                    cutlass.Int32,
+                ).bitcast(cfg.io_dtype)
+                k_decay_vec = cutlass.Vector.from_elements(
+                    (
+                        k_decay_pack[0],
+                        k_decay_pack[1],
+                        k_decay_pack[2],
+                        k_decay_pack[3],
+                    ),
+                    cutlass.Int32,
+                ).bitcast(cfg.io_dtype)
+                if cutlass.const_expr(dim_half == 0):
+                    operand_done_phase = ((cum_chunk // cfg.smem_decay_stages) + 1) % 2
+                    bars.mb_decay_super_done[decay_stage].wait(operand_done_phase)
+                    bars.mb_decay_tcgen05_done[decay_stage].wait(operand_done_phase)
+                f16_segment = dim_base // 64
+                f16_segment_dim = dim_base - f16_segment * 64
+                k_inv_swizzled_idx = f16_segment * (cfg.b_t * 64) + decay_row * 64 + swizzle_xor_128b(decay_row, f16_segment_dim, elem_bytes=2)
+                (sK_inv_ptr + k_inv_swizzled_idx).store(k_inv_vec, alignment=16)
+                storage_key = dim_base ^ decay_key_mask
+                storage_slice = storage_key // 64
+                decay_swizzled_idx = storage_slice * (cfg.b_t * 64) + swizzle_xor_128b(
+                    decay_row, decay_row * 64 + storage_key - storage_slice * 64, elem_bytes=2
+                )
+                (sK_decay_ptr + decay_swizzled_idx).store(k_decay_vec, alignment=16)
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_k_decay_inv_cg0_ready[decay_stage].arrive()
+            bars.mb_q_done[raw_stage].arrive()
+            bars.mb_k_done[raw_stage].arrive()
+            bars.mb_gate_done[raw_stage].arrive()
+
+            # ---- Q_decay operand: Q * q_inv_norm --------------------------------
+            for dim_half in cutlass.range_constexpr(2):
+                dim_base = dim_half * (cfg.d_k // 2) + lane_in_row_group * 8
+                reg_base = dim_half * 8
+                q_decay_pack = cutlass.Array(cutlass.Int32, 4, alignment=16)
+                for pair_idx in cutlass.range_constexpr(4):
+                    dim0 = pair_idx * 2
+                    dim1 = dim0 + 1
+                    raw_reg_idx0 = reg_base + dim0
+                    raw_reg_idx1 = reg_base + dim1
+                    q_value0, q_value1 = fmul2(raw_q_regs[raw_reg_idx0], raw_q_regs[raw_reg_idx1], q_inv_norm, q_inv_norm)
+                    q_pair = fp32_to_fp16(q_value0, q_value1, dtype=cfg.io_dtype)
+                    exp_g_pair = fp32_to_fp16(exp_g_regs[raw_reg_idx0], exp_g_regs[raw_reg_idx1], dtype=cfg.io_dtype)
+                    q_decay_pack[pair_idx] = mul_f16x2(q_pair, exp_g_pair, cfg.io_dtype)
+
+                q_decay_vec = cutlass.Vector.from_elements(
+                    (
+                        q_decay_pack[0],
+                        q_decay_pack[1],
+                        q_decay_pack[2],
+                        q_decay_pack[3],
+                    ),
+                    cutlass.Int32,
+                ).bitcast(cfg.io_dtype)
+                storage_key = dim_base ^ decay_key_mask
+                storage_slice = storage_key // 64
+                decay_swizzled_idx = storage_slice * (cfg.b_t * 64) + swizzle_xor_128b(
+                    decay_row, decay_row * 64 + storage_key - storage_slice * 64, elem_bytes=2
+                )
+                (sQ_decay_ptr + decay_swizzled_idx).store(q_decay_vec, alignment=16)
+
+            # ---- K_restore operand: K_inv * exp_g_last --------------------------
+            bars.mb_k_restore_done[decay_stage].wait(((cum_chunk // cfg.smem_decay_stages + 1) % 2))
+            for dim_half in cutlass.range_constexpr(2):
+                dim_base = dim_half * (cfg.d_k // 2) + lane_in_row_group * 8
+                reg_base = dim_half * 8
+                k_restore_pack = cutlass.Array(cutlass.Int32, 4, alignment=16)
+                for pair_idx in cutlass.range_constexpr(4):
+                    dim0 = pair_idx * 2
+                    dim1 = dim0 + 1
+                    exp_g_last_pair = fp32_to_fp16(exp_g_last_regs[reg_base + dim0], exp_g_last_regs[reg_base + dim1], dtype=cfg.io_dtype)
+                    k_restore_pack[pair_idx] = mul_f16x2(k_inv_pack[dim_half * 4 + pair_idx], exp_g_last_pair, cfg.io_dtype)
+                storage_row = decay_row ^ (cfg.b_t // 2)
+                f16_segment = dim_base // 64
+                f16_segment_dim = dim_base - f16_segment * 64
+                k_restore_idx = f16_segment * (cfg.b_t * 64) + storage_row * 64 + swizzle_xor_128b(storage_row, f16_segment_dim, elem_bytes=2)
+                k_restore_vec = cutlass.Vector.from_elements(
+                    (
+                        k_restore_pack[0],
+                        k_restore_pack[1],
+                        k_restore_pack[2],
+                        k_restore_pack[3],
+                    ),
+                    cutlass.Int32,
+                ).bitcast(cfg.io_dtype)
+                (sK_restore_ptr + k_restore_idx).store(k_restore_vec, alignment=16)
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_qk_scale_ready[qk_scale_ready_stage].arrive()
+            diag_ring_idx = diag_ring_idx + cutlass.Int32(cfg.cg0_group_count)
+            wrapped = diag_ring_idx >= cutlass.Int32(cfg.smem_state_scale_diag_stages)
+            diag_ring_idx = diag_ring_idx - cutlass.Int32(cfg.smem_state_scale_diag_stages) if wrapped else diag_ring_idx
+            diag_ring_phase = diag_ring_phase ^ (cutlass.Int32(1) if wrapped else cutlass.Int32(0))
+        cum_chunk_base += num_chunks_tile
+        tile_idx, sched_state = sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas)
+
+
+@cute.jit
+def compute1_warp_group(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    cu_seqlens,
+    mWorkItems,
+    sSched,
+    lane,
+    tmem_base_slot,
+    warp_idx,
+    mState_out,
+    mState_init,
+    mO,
+    sO_raw,
+    sBeta_raw,
+    sV_raw,
+    sCheckpoint_raw,
+    checkpoint_every_n_tokens,
+    scale,
+    bars,
+) -> None:
+    """CG1 warp role (warps 8-11): persistent scheduler loop for the
+    value-side TMEM staging, output drain, and state stores."""
+    nvvm.setmaxregister(cfg.num_regs_compute_group_1, nvvm.SetMaxRegisterAction.INCREASE)
+    sO_ptr = sO_raw.data_ptr()
+    sCheckpoint_ptr = sCheckpoint_raw.data_ptr() if cutlass.const_expr(cfg.enable_checkpoints) else sO_raw.data_ptr()
+    checkpoint_done_index = PipelineState.start(phase=1)
+    nvvm.barrier_cta_sync(cfg.tmem_lifecycle_barrier_id, thread_count=cfg.tmem_user_threads)
+    tmem_base = tmem_base_slot.load()
+    tmem_col = tmem_base & 0xFFFF
+    tmem_row = tmem_base >> 16
+    tmem_subpartition = warp_idx % (cfg.d_v // cfg.threads_per_warp)
+    ov_token_coord = (lane // 16) * 8 + (lane & 7)
+    ov_col_coord = ((lane // 8) & 1) * 8
+    row_id = tmem_row + tmem_subpartition * cfg.threads_per_warp
+    value_dim = tmem_subpartition * cfg.threads_per_warp + lane
+    value_dim_base = tmem_subpartition * cfg.threads_per_warp
+    row_addr = row_id << 16
+    row16_addr = (row_id + 16) << 16
+    st_row_addr = tmem_row << 16
+    st_row16_addr = (tmem_row + 16) << 16
+    state_col_id = tmem_col + cfg.tmem_state_acc_offset
+    packed_col_id = tmem_col + cfg.tmem_state_inp_offset
+    state_k_col_id = tmem_col + cfg.tmem_state_k_acc_offset
+    y_inp_col_id = tmem_col + cfg.tmem_y_inp_offset
+    u_acc_addr = row_addr + tmem_col + cfg.tmem_u_acc_offset
+    u_inp_addr = st_row_addr + tmem_col + cfg.tmem_u_inp_offset
+    q_state_col_base = tmem_col + cfg.tmem_q_state_acc_offset
+    ov_swz_off0 = (
+        (value_dim_base + ov_col_coord) // 64 * (cfg.b_t * 64)
+        + ov_token_coord * 64
+        + swizzle_xor_128b(ov_token_coord, (value_dim_base + ov_col_coord) % 64, elem_bytes=2)
+    )
+    ov_swz_off = (
+        (value_dim_base + 16 + ov_col_coord) // 64 * (cfg.b_t * 64)
+        + ov_token_coord * 64
+        + swizzle_xor_128b(ov_token_coord, (value_dim_base + 16 + ov_col_coord) % 64, elem_bytes=2)
+    )
+    checkpoint_swz_off0 = (value_dim_base + ov_col_coord) // 64 * (cfg.d_k * 64)
+    checkpoint_swz_col0 = (value_dim_base + ov_col_coord) % 64
+    checkpoint_swz_off = (value_dim_base + 16 + ov_col_coord) // 64 * (cfg.d_k * 64)
+    checkpoint_swz_col = (value_dim_base + 16 + ov_col_coord) % 64
+    state_k_acc_index = PipelineState.start(phase=0)
+    u_acc_index = PipelineState.start(phase=0)
+    o_acc_index = PipelineState.start(phase=0)
+    state_upd_index = PipelineState.start(phase=0)
+    raw_index = PipelineState.start(phase=0)
+    raw_bar_index = PipelineState.start(phase=0)  # even-depth ready/beta-ring slot (decoupled from the data ring)
+    cum_chunk_base = cutlass.Int32(0)
+    sched_state = PipelineState.start(phase=0)
+    tile_idx = cutlass.Int32(bidx)
+    while tile_idx < total_tiles:
+        batch_idx, head_idx, batch_start, batch_end, seqlen_b, num_chunks_b, wstart, wend, cstart, cend = decode_work_item(cfg, tile_idx, mWorkItems)
+        head_o = head_idx
+        num_chunks_tile = wend - cstart
+
+        if num_chunks_tile > 0:
+            # ---- first chunk: seed state TMEM from mState_init ----------
+            seed_from_initial_state = cstart == 0
+            if cutlass.const_expr(mState_init is not None):
+                if seed_from_initial_state:
+                    seed_vw = 16 // (mState_init.element_type.width // 8)
+                    seed_src = (mState_init.iterator + mState_init.layout((batch_idx, head_o, value_dim, 0))).raw_ptr()
+                    for key_block_start in cutlass.range_constexpr(0, cfg.d_k, 32):
+                        state_block = cutlass.Array(cutlass.Float32, 32, alignment=16)
+                        for g in cutlass.range_constexpr(32 // seed_vw):
+                            seed_chunk = (seed_src + key_block_start + g * seed_vw).load(count=seed_vw, alignment=16)
+                            for t in cutlass.range_constexpr(seed_vw):
+                                state_block[g * seed_vw + t] = seed_chunk[t].to(cutlass.Float32)
+
+                        nvvm.tcgen05_st(
+                            "32x32b",
+                            nvvm.make_tmem_ptr((row_id << 16) + (tmem_col + cfg.tmem_state_acc_offset + key_block_start), cutlass.Float32),
+                            state_block[0:32],
+                        )
+                else:
+                    for key_block_start in cutlass.range_constexpr(0, cfg.d_k, 32):
+                        state_block = cutlass.Array(cutlass.Float32, 32, alignment=16)
+                        for col in cutlass.range_constexpr(32):
+                            state_block[col] = cutlass.Float32(0.0)
+
+                        nvvm.tcgen05_st(
+                            "32x32b",
+                            nvvm.make_tmem_ptr((row_id << 16) + (tmem_col + cfg.tmem_state_acc_offset + key_block_start), cutlass.Float32),
+                            state_block[0:32],
+                        )
+            if cutlass.const_expr(mState_init is not None):
+                nvvm.tcgen05_wait("store")
+            sV_ptr = sV_raw.data_ptr() + raw_index.idx * (cfg.d_v * cfg.b_t)
+            sBeta_ptr = sBeta_raw.data_ptr() + raw_bar_index.idx * cfg.b_t
+
+            # ---- state repack: acc TMEM -> packed b16 TMEM ----------------------
+            if cutlass.const_expr(mState_init is not None):
+                state_vecs = []
+                for sub in cutlass.range_constexpr(cfg.d_k // 16):
+                    state_vecs.append(nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(row_addr + state_col_id + sub * 16, cutlass.Float32), num=16))
+
+                for sub in cutlass.range_constexpr(cfg.d_k // 16):
+                    packed_state = cutlass.Array(cutlass.Int32, 8, alignment=16)
+                    for packed_col in cutlass.range_constexpr(8):
+                        source_pair = packed_col ^ 4
+                        packed_state[packed_col] = fp32_to_fp16(state_vecs[sub][2 * source_pair], state_vecs[sub][2 * source_pair + 1], dtype=cfg.io_dtype)
+                    nvvm.tcgen05_st(
+                        "32x32b",
+                        nvvm.make_tmem_ptr((tmem_row << 16) + packed_col_id + sub * 8, cutlass.Int8),
+                        packed_state[0:8],
+                    )
+                nvvm.tcgen05_wait("store")
+                bars.mb_state_inp_ready.arrive()
+                if cutlass.const_expr(cfg.enable_checkpoints):
+                    if wstart == 0:
+                        checkpoint_stage = checkpoint_done_index.idx
+                        bars.mb_checkpoint_tmastg_done[checkpoint_stage].wait(checkpoint_done_index.phase)
+                        checkpoint_done_index = advance(checkpoint_done_index, cfg.smem_checkpoint_stages)
+                        checkpoint_stage_base = checkpoint_stage * (cfg.d_k * cfg.d_v)
+                        for sub in cutlass.range_constexpr(cfg.d_k // 16):
+                            for g in cutlass.range_constexpr(2):
+                                packs = tuple(
+                                    fp32_to_fp16(state_vecs[sub][g * 8 + 2 * t], state_vecs[sub][g * 8 + 2 * t + 1], dtype=cfg.io_dtype) for t in range(4)
+                                )
+                                dk = sub * 16 + g * 8
+                                checkpoint_addr = (
+                                    checkpoint_stage_base + (dk // 64) * (cfg.d_v * 64) + value_dim * 64 + swizzle_xor_128b(value_dim, dk % 64, elem_bytes=2)
+                                )
+                                (sCheckpoint_ptr + checkpoint_addr).store(
+                                    cutlass.Vector.from_elements(packs, cutlass.Int32).bitcast(cfg.io_dtype), alignment=16
+                                )
+                        nvvm.tcgen05_wait("load")
+                        nvvm.fence_proxy("async.shared", space="cta")
+                        bars.mb_checkpoint_tmastg_ready[checkpoint_stage].arrive()
+                    bars.mb_state_acc_read_done.arrive()
+
+            if cutlass.const_expr(cfg.enable_checkpoints and mState_init is None):
+                if wstart == 0:
+                    checkpoint_stage = checkpoint_done_index.idx
+                    bars.mb_checkpoint_tmastg_done[checkpoint_stage].wait(checkpoint_done_index.phase)
+                    checkpoint_done_index = advance(checkpoint_done_index, cfg.smem_checkpoint_stages)
+                    checkpoint_stage_base = checkpoint_stage * (cfg.d_k * cfg.d_v)
+                    zero_packs = tuple(cutlass.Int32(0) for _ in range(4))
+                    for sub in cutlass.range_constexpr(cfg.d_k // 16):
+                        for g in cutlass.range_constexpr(2):
+                            dk = sub * 16 + g * 8
+                            checkpoint_addr = (
+                                checkpoint_stage_base + (dk // 64) * (cfg.d_v * 64) + value_dim * 64 + swizzle_xor_128b(value_dim, dk % 64, elem_bytes=2)
+                            )
+                            (sCheckpoint_ptr + checkpoint_addr).store(
+                                cutlass.Vector.from_elements(zero_packs, cutlass.Int32).bitcast(cfg.io_dtype), alignment=16
+                            )
+                    nvvm.fence_proxy("async.shared", space="cta")
+                    bars.mb_checkpoint_tmastg_ready[checkpoint_stage].arrive()
+
+            # ---- Y staging: Y = Beta * (V - state*K) -----------------------------
+            bars.mb_v_ready[raw_bar_index.idx].wait(raw_bar_index.phase)
+            raw_v_frag0 = nvvm.ldmatrix(
+                sV_ptr + ov_swz_off0,
+                4,
+                nvvm.MMALayout.COL,
+            )
+            raw_v_frag1 = nvvm.ldmatrix(
+                sV_ptr + ov_swz_off,
+                4,
+                nvvm.MMALayout.COL,
+            )
+            bars.mb_beta_ready[raw_bar_index.idx].wait(raw_bar_index.phase)
+            if cutlass.const_expr(mState_init is not None):
+                bars.mb_state_k_acc_ready.wait(state_k_acc_index.phase)
+
+                state_k_vec0 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr(row_addr + state_k_col_id, cutlass.Float32), num=2)
+                state_k_vec1 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr(row16_addr + state_k_col_id, cutlass.Float32), num=2)
+
+            beta_pack = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            for reg_idx in cutlass.range_constexpr(4):
+                token0 = (((reg_idx // 2) * 4 + (lane & 3)) ^ 4) * 2
+                beta0 = (sBeta_ptr + token0).load().to(cutlass.Float32)
+                beta1 = (sBeta_ptr + token0 + 1).load().to(cutlass.Float32)
+                beta_pack[reg_idx] = fp32_to_fp16(beta0, beta1, dtype=cfg.io_dtype)
+            y_inp_pack0 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            for reg_idx in cutlass.range_constexpr(4):
+                raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
+                frag_pair = (reg_idx ^ 2) * 2
+                if cutlass.const_expr(mState_init is not None):
+                    state_k_val0, state_k_val1 = state_k_vec0[frag_pair], state_k_vec0[frag_pair + 1]
+                    state_k_pair = fp32_to_fp16(state_k_val0, state_k_val1, dtype=cfg.io_dtype)
+                    diff_pair = sub_f16x2(
+                        raw_v_frag0[raw_matrix],
+                        state_k_pair,
+                        cfg.io_dtype,
+                    )
+                else:
+                    diff_pair = raw_v_frag0[raw_matrix]
+                y_inp_pack0[reg_idx] = mul_f16x2(
+                    beta_pack[reg_idx],
+                    diff_pair,
+                    cfg.io_dtype,
+                )
+
+            y_inp_pack1 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            for reg_idx in cutlass.range_constexpr(4):
+                raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
+                frag_pair = (reg_idx ^ 2) * 2
+                if cutlass.const_expr(mState_init is not None):
+                    state_k_val0, state_k_val1 = state_k_vec1[frag_pair], state_k_vec1[frag_pair + 1]
+                    state_k_pair = fp32_to_fp16(state_k_val0, state_k_val1, dtype=cfg.io_dtype)
+                    diff_pair = sub_f16x2(
+                        raw_v_frag1[raw_matrix],
+                        state_k_pair,
+                        cfg.io_dtype,
+                    )
+                else:
+                    diff_pair = raw_v_frag1[raw_matrix]
+                y_inp_pack1[reg_idx] = mul_f16x2(
+                    beta_pack[reg_idx],
+                    diff_pair,
+                    cfg.io_dtype,
+                )
+
+            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row_addr + y_inp_col_id, cutlass.Int8), y_inp_pack0[0:4])
+            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row16_addr + y_inp_col_id, cutlass.Int8), y_inp_pack1[0:4])
+            nvvm.tcgen05_wait("store")
+            if cutlass.const_expr(mState_init is not None):
+                state_k_acc_index = advance(state_k_acc_index, 1)
+            bars.mb_v_done[raw_index.idx].arrive()
+            bars.mb_beta_done[raw_bar_index.idx].arrive()
+            bars.mb_y_inp_ready.arrive()
+
+            # ---- U repack: u_acc TMEM -> packed b16 U input TMEM ----------------
+            bars.mb_u_acc_ready.wait(u_acc_index.phase)
+            u_vals = nvvm.tcgen05_ld(
+                "32x32b",
+                nvvm.make_tmem_ptr(u_acc_addr, cutlass.Float32),
+                num=cfg.b_t,
+            )
+
+            u_inp_pack = cutlass.Array(cutlass.Int32, (cfg.b_t // 2), alignment=16)
+            for packed_col in cutlass.range_constexpr((cfg.b_t // 2)):
+                source_pair = packed_col ^ 4
+                token0 = source_pair * 2
+                token1 = token0 + 1
+                u_inp_pack[packed_col] = fp32_to_fp16(u_vals[token0], u_vals[token1], dtype=cfg.io_dtype)
+
+            nvvm.tcgen05_st(
+                "32x32b",
+                nvvm.make_tmem_ptr(u_inp_addr, cutlass.Int8),
+                u_inp_pack[0 : (cfg.b_t // 2)],
+            )
+            nvvm.tcgen05_wait("store")
+            u_acc_index = advance(u_acc_index, 1)
+            bars.mb_u_inp_ready.arrive()
+            if cutlass.const_expr(cfg.enable_checkpoints):
+                bars.mb_state_acc_done.wait(state_upd_index.phase)
+                state_upd_index = advance(state_upd_index, 1)
+
+            raw_index = advance(raw_index, cfg.smem_raw_stages)
+            raw_bar_index = advance(raw_bar_index, cfg.smem_raw_bar_stages)
+
+        if cutlass.const_expr(cfg.enable_checkpoints):
+            cg1_checkpoint_chunks = checkpoint_every_n_tokens // cutlass.Int32(cfg.b_t)
+            cg1_checkpoint_mod = (cstart + cutlass.Int32(1)) % cg1_checkpoint_chunks
+        for local_chunk_idx in cutlass.range(1, num_chunks_tile, 1, unroll=1):
+            chunk_idx = cstart + local_chunk_idx
+            cum_chunk = cum_chunk_base + local_chunk_idx
+            sV_ptr = sV_raw.data_ptr() + raw_index.idx * (cfg.d_v * cfg.b_t)
+            sBeta_ptr = sBeta_raw.data_ptr() + raw_bar_index.idx * cfg.b_t
+
+            prev_output_chunk = chunk_idx - cutlass.Int32(1)
+            prev_cum_chunk = cum_chunk - cutlass.Int32(1)
+            prev_o_stage = prev_cum_chunk % cfg.smem_o_stages
+            prev_q_state_acc_stage = prev_cum_chunk % cfg.tmem_q_state_acc_stages
+            prev_o_stage_base = prev_o_stage * (cfg.b_t * cfg.d_v)
+            do_checkpoint = False
+            if cutlass.const_expr(cfg.enable_checkpoints):
+                do_checkpoint = cg1_checkpoint_mod == 0
+                cg1_checkpoint_mod = cg1_checkpoint_mod + cutlass.Int32(1)
+                cg1_checkpoint_mod = cutlass.Int32(0) if cg1_checkpoint_mod == cg1_checkpoint_chunks else cg1_checkpoint_mod
+                do_checkpoint = do_checkpoint and chunk_idx >= wstart
+
+            # ---- state repack: acc TMEM -> packed b16 TMEM ----------------------
+            if cutlass.const_expr(not cfg.enable_checkpoints):
+                bars.mb_state_acc_done.wait(state_upd_index.phase)
+                state_upd_index = advance(state_upd_index, 1)
+            state_vecs = []
+            for sub in cutlass.range_constexpr(cfg.d_k // 16):
+                state_vecs.append(nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(row_addr + state_col_id + sub * 16, cutlass.Float32), num=16))
+
+            for sub in cutlass.range_constexpr(cfg.d_k // 16):
+                packed_state = cutlass.Array(cutlass.Int32, 8, alignment=16)
+                for packed_col in cutlass.range_constexpr(8):
+                    source_pair = packed_col ^ 4
+                    packed_state[packed_col] = fp32_to_fp16(state_vecs[sub][2 * source_pair], state_vecs[sub][2 * source_pair + 1], dtype=cfg.io_dtype)
+                nvvm.tcgen05_st(
+                    "32x32b",
+                    nvvm.make_tmem_ptr((tmem_row << 16) + packed_col_id + sub * 8, cutlass.Int8),
+                    packed_state[0:8],
+                )
+            nvvm.tcgen05_wait("store")
+            bars.mb_state_inp_ready.arrive()
+
+            # ---- checkpoint store -----------------------------------------------
+            if cutlass.const_expr(cfg.enable_checkpoints):
+                if do_checkpoint:
+                    checkpoint_stage = checkpoint_done_index.idx
+                    bars.mb_checkpoint_tmastg_done[checkpoint_stage].wait(checkpoint_done_index.phase)
+                    checkpoint_done_index = advance(checkpoint_done_index, cfg.smem_checkpoint_stages)
+                    checkpoint_stage_base = checkpoint_stage * (cfg.d_k * cfg.d_v)
+                    for sub in cutlass.range_constexpr(cfg.d_k // 16):
+                        for g in cutlass.range_constexpr(2):
+                            packs = tuple(
+                                fp32_to_fp16(state_vecs[sub][g * 8 + 2 * t], state_vecs[sub][g * 8 + 2 * t + 1], dtype=cfg.io_dtype) for t in range(4)
+                            )
+                            dk = sub * 16 + g * 8
+                            checkpoint_addr = (
+                                checkpoint_stage_base + (dk // 64) * (cfg.d_v * 64) + value_dim * 64 + swizzle_xor_128b(value_dim, dk % 64, elem_bytes=2)
+                            )
+                            (sCheckpoint_ptr + checkpoint_addr).store(cutlass.Vector.from_elements(packs, cutlass.Int32).bitcast(cfg.io_dtype), alignment=16)
+                    nvvm.tcgen05_wait("load")
+                    bars.mb_state_acc_read_done.arrive()
+                    nvvm.fence_proxy("async.shared", space="cta")
+                    bars.mb_checkpoint_tmastg_ready[checkpoint_stage].arrive()
+                else:
+                    bars.mb_state_acc_read_done.arrive()
+
+            bars.mb_o_acc_ready.wait(o_acc_index.phase)
+            o_acc_index = advance(o_acc_index, 1)
+            projection_col_id = q_state_col_base + prev_q_state_acc_stage * cfg.b_t
+            loaded_vec0 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr(row_addr + projection_col_id, cutlass.Float32), num=2)
+            loaded_vec1 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr(row16_addr + projection_col_id, cutlass.Float32), num=2)
+
+            # ---- output drain: O acc TMEM -> scaled b16 SMEM --------------------
+            stsm_pack0 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            stsm_pack1 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            for reg_idx in cutlass.range_constexpr(4):
+                scaled0_0, scaled0_1 = fmul2(loaded_vec0[2 * reg_idx], loaded_vec0[2 * reg_idx + 1], scale, scale)
+                scaled1_0, scaled1_1 = fmul2(loaded_vec1[2 * reg_idx], loaded_vec1[2 * reg_idx + 1], scale, scale)
+                stsm_pack0[reg_idx] = fp32_to_fp16(scaled0_0, scaled0_1, dtype=mO.element_type)
+                stsm_pack1[reg_idx] = fp32_to_fp16(scaled1_0, scaled1_1, dtype=mO.element_type)
+
+            bars.mb_o_tmastg_done[prev_o_stage].wait(((prev_cum_chunk // cfg.smem_o_stages) + 1) % 2)
+            nvvm.stmatrix(
+                sO_ptr + prev_o_stage_base + ov_swz_off0,
+                stsm_pack0.data_ptr().load(count=4, alignment=4),
+                nvvm.MMALayout.COL,
+                shape=nvvm.StoreShape.M8N8,
+            )
+            nvvm.stmatrix(
+                sO_ptr + prev_o_stage_base + ov_swz_off,
+                stsm_pack1.data_ptr().load(count=4, alignment=4),
+                nvvm.MMALayout.COL,
+                shape=nvvm.StoreShape.M8N8,
+            )
+            bars.mb_o_acc_done[prev_q_state_acc_stage].arrive()
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_o_tmastg_ready[prev_o_stage].arrive()
+
+            # ---- Y staging: Y = Beta * (V - state*K) -----------------------------
+            bars.mb_v_ready[raw_bar_index.idx].wait(raw_bar_index.phase)
+            raw_v_frag0 = nvvm.ldmatrix(
+                sV_ptr + ov_swz_off0,
+                4,
+                nvvm.MMALayout.COL,
+            )
+            raw_v_frag1 = nvvm.ldmatrix(
+                sV_ptr + ov_swz_off,
+                4,
+                nvvm.MMALayout.COL,
+            )
+            bars.mb_beta_ready[raw_bar_index.idx].wait(raw_bar_index.phase)
+            bars.mb_state_k_acc_ready.wait(state_k_acc_index.phase)
+
+            state_k_vec0 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr(row_addr + state_k_col_id, cutlass.Float32), num=2)
+            state_k_vec1 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr(row16_addr + state_k_col_id, cutlass.Float32), num=2)
+
+            beta_pack = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            for reg_idx in cutlass.range_constexpr(4):
+                token0 = (((reg_idx // 2) * 4 + (lane & 3)) ^ 4) * 2
+                beta0 = (sBeta_ptr + token0).load().to(cutlass.Float32)
+                beta1 = (sBeta_ptr + token0 + 1).load().to(cutlass.Float32)
+                beta_pack[reg_idx] = fp32_to_fp16(beta0, beta1, dtype=cfg.io_dtype)
+            y_inp_pack0 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            for reg_idx in cutlass.range_constexpr(4):
+                raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
+                frag_pair = (reg_idx ^ 2) * 2
+                state_k_val0, state_k_val1 = state_k_vec0[frag_pair], state_k_vec0[frag_pair + 1]
+                state_k_pair = fp32_to_fp16(state_k_val0, state_k_val1, dtype=cfg.io_dtype)
+                diff_pair = sub_f16x2(
+                    raw_v_frag0[raw_matrix],
+                    state_k_pair,
+                    cfg.io_dtype,
+                )
+                y_inp_pack0[reg_idx] = mul_f16x2(
+                    beta_pack[reg_idx],
+                    diff_pair,
+                    cfg.io_dtype,
+                )
+
+            y_inp_pack1 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            for reg_idx in cutlass.range_constexpr(4):
+                raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
+                frag_pair = (reg_idx ^ 2) * 2
+                state_k_val0, state_k_val1 = state_k_vec1[frag_pair], state_k_vec1[frag_pair + 1]
+                state_k_pair = fp32_to_fp16(state_k_val0, state_k_val1, dtype=cfg.io_dtype)
+                diff_pair = sub_f16x2(
+                    raw_v_frag1[raw_matrix],
+                    state_k_pair,
+                    cfg.io_dtype,
+                )
+                y_inp_pack1[reg_idx] = mul_f16x2(
+                    beta_pack[reg_idx],
+                    diff_pair,
+                    cfg.io_dtype,
+                )
+
+            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row_addr + y_inp_col_id, cutlass.Int8), y_inp_pack0[0:4])
+            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row16_addr + y_inp_col_id, cutlass.Int8), y_inp_pack1[0:4])
+            nvvm.tcgen05_wait("store")
+            state_k_acc_index = advance(state_k_acc_index, 1)
+            bars.mb_v_done[raw_index.idx].arrive()
+            bars.mb_beta_done[raw_bar_index.idx].arrive()
+            bars.mb_y_inp_ready.arrive()
+
+            # ---- U repack: u_acc TMEM -> packed b16 U input TMEM ----------------
+            bars.mb_u_acc_ready.wait(u_acc_index.phase)
+            u_vals = nvvm.tcgen05_ld(
+                "32x32b",
+                nvvm.make_tmem_ptr(u_acc_addr, cutlass.Float32),
+                num=cfg.b_t,
+            )
+
+            u_inp_pack = cutlass.Array(cutlass.Int32, (cfg.b_t // 2), alignment=16)
+            for packed_col in cutlass.range_constexpr((cfg.b_t // 2)):
+                source_pair = packed_col ^ 4
+                token0 = source_pair * 2
+                token1 = token0 + 1
+                u_inp_pack[packed_col] = fp32_to_fp16(u_vals[token0], u_vals[token1], dtype=cfg.io_dtype)
+
+            nvvm.tcgen05_st(
+                "32x32b",
+                nvvm.make_tmem_ptr(u_inp_addr, cutlass.Int8),
+                u_inp_pack[0 : (cfg.b_t // 2)],
+            )
+            nvvm.tcgen05_wait("store")
+            u_acc_index = advance(u_acc_index, 1)
+            bars.mb_u_inp_ready.arrive()
+
+            if cutlass.const_expr(cfg.enable_checkpoints):
+                bars.mb_state_acc_done.wait(state_upd_index.phase)
+                state_upd_index = advance(state_upd_index, 1)
+            raw_index = advance(raw_index, cfg.smem_raw_stages)
+            raw_bar_index = advance(raw_bar_index, cfg.smem_raw_bar_stages)
+
+        if num_chunks_tile > 0:
+            if cutlass.const_expr(not cfg.enable_checkpoints):
+                bars.mb_state_acc_done.wait(state_upd_index.phase)
+                state_upd_index = advance(state_upd_index, 1)
+            last_cum_chunk = cum_chunk_base + num_chunks_tile - cutlass.Int32(1)
+            final_o_stage = last_cum_chunk % cfg.smem_o_stages
+            final_q_state_acc_stage = last_cum_chunk % cfg.tmem_q_state_acc_stages
+            final_o_stage_base = final_o_stage * (cfg.b_t * cfg.d_v)
+
+            bars.mb_o_acc_ready.wait(o_acc_index.phase)
+            o_acc_index = advance(o_acc_index, 1)
+            projection_col_id = q_state_col_base + final_q_state_acc_stage * cfg.b_t
+
+            loaded_vec0 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr(row_addr + projection_col_id, cutlass.Float32), num=2)
+            loaded_vec1 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr(row16_addr + projection_col_id, cutlass.Float32), num=2)
+
+            # ---- output drain: O acc TMEM -> scaled b16 SMEM --------------------
+            stsm_pack0 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            stsm_pack1 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            for reg_idx in cutlass.range_constexpr(4):
+                scaled0_0, scaled0_1 = fmul2(loaded_vec0[2 * reg_idx], loaded_vec0[2 * reg_idx + 1], scale, scale)
+                scaled1_0, scaled1_1 = fmul2(loaded_vec1[2 * reg_idx], loaded_vec1[2 * reg_idx + 1], scale, scale)
+                stsm_pack0[reg_idx] = fp32_to_fp16(scaled0_0, scaled0_1, dtype=mO.element_type)
+                stsm_pack1[reg_idx] = fp32_to_fp16(scaled1_0, scaled1_1, dtype=mO.element_type)
+
+            bars.mb_o_tmastg_done[final_o_stage].wait(((last_cum_chunk // cfg.smem_o_stages) + 1) % 2)
+            nvvm.stmatrix(
+                sO_ptr + final_o_stage_base + ov_swz_off0,
+                stsm_pack0.data_ptr().load(count=4, alignment=4),
+                nvvm.MMALayout.COL,
+                shape=nvvm.StoreShape.M8N8,
+            )
+            nvvm.stmatrix(
+                sO_ptr + final_o_stage_base + ov_swz_off,
+                stsm_pack1.data_ptr().load(count=4, alignment=4),
+                nvvm.MMALayout.COL,
+                shape=nvvm.StoreShape.M8N8,
+            )
+            bars.mb_o_acc_done[final_q_state_acc_stage].arrive()
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_o_tmastg_ready[final_o_stage].arrive()
+
+        owns_final = wend == num_chunks_b
+
+        # ---- final-state drain: state acc TMEM -> GMEM ---------------------------
+        if cutlass.const_expr(mState_out is not None):
+            if seqlen_b > 0:
+                if owns_final:
+                    state_vw = 16 // (mState_out.element_type.width // 8)
+                    state_dst = (mState_out.iterator + mState_out.layout((batch_idx, head_o, value_dim, 0))).raw_ptr()
+                    for key_block_start in cutlass.range_constexpr(0, cfg.d_k, 32):
+                        loaded = nvvm.tcgen05_ld(
+                            "32x32b",
+                            nvvm.make_tmem_ptr((row_id << 16) + (tmem_col + cfg.tmem_state_acc_offset + key_block_start), cutlass.Float32),
+                            num=32,
+                        )
+
+                        for g in cutlass.range_constexpr(32 // state_vw):
+                            (state_dst + key_block_start + g * state_vw).store(
+                                cutlass.Vector.from_elements(
+                                    tuple(loaded[g * state_vw + t].to(mState_out.element_type) for t in range(state_vw)),
+                                    mState_out.element_type,
+                                ),
+                                alignment=16,
+                            )
+            else:
+                for key_block_start in cutlass.range_constexpr(0, cfg.d_k, 32):
+                    for col in cutlass.range_constexpr(32):
+                        key_dim = key_block_start + col
+                        if cutlass.const_expr(mState_init is not None):
+                            mState_out[batch_idx, head_o, value_dim, key_dim] = mState_init[batch_idx, head_o, value_dim, key_dim]
+                        else:
+                            mState_out[batch_idx, head_o, value_dim, key_dim] = cutlass.Float32(0.0).to(mState_out.element_type)
+        cum_chunk_base += num_chunks_tile
+        tile_idx, sched_state = sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas)
+
+    bars.mb_tmem_done[0].arrive()
+
+
+class KdaPrefillOp:
+    """Compile and launch one static mega KDA prefill configuration."""
+
+    def __init__(self, cfg: "KdaCfg"):
+        self.cfg = cfg
+
+    def get_name(self) -> str:
+        cfg = self.cfg
+        gate_scale = (
+            f"_gs{float(cfg.gate_scale_log2).hex()}"
+            .replace("-", "m")
+            .replace(".", "p")
+            .replace("+", "")
+            if cfg.safe_gate
+            else ""
+        )
+        return (
+            f"kda_mega_prefill_{cfg.io_dtype.__name__.lower()}"
+            f"_{cfg.state_dtype.__name__.lower()}_h{cfg.n_heads_out}"
+            f"_q{cfg.q_ratio}_k{cfg.k_ratio}_v{cfg.v_ratio}"
+            f"_i{int(cfg.use_initial_state)}f{int(cfg.store_final_state)}"
+            f"c{int(cfg.enable_checkpoints)}l{int(cfg.l2norm)}"
+            f"g{int(cfg.safe_gate)}b{int(cfg.beta_sigmoid)}d{int(cfg.dyn_sched)}"
+            f"_sm{cfg.max_active_clusters}{gate_scale}"
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        q: cute.Tensor,
+        k: cute.Tensor,
+        v: cute.Tensor,
+        raw_gate: cute.Tensor,
+        a_log: cute.Tensor | None,
+        dt_bias: cute.Tensor | None,
+        beta: cute.Tensor,
+        cu_seqlens: cute.Tensor,
+        initial_state: cute.Tensor | None,
+        out: cute.Tensor,
+        final_state: cute.Tensor | None,
+        work_items: cute.Tensor | None,
+        work_count: cute.Tensor | None,
+        sched_ctr: cute.Tensor | None,
+        tensormap_workspace: cute.Tensor,
+        checkpoint_every_n_tokens: cutlass.Int32,
+        scale: cutlass.Float32,
+        stream,
+    ) -> None:
+        cfg = self.cfg
+        num_sequences = cu_seqlens.shape[0] - 1
+
+        kernel.set_name_prefix(self.get_name())
+        kernel(
+            cfg,
+            tensormap_workspace,
+            cutlass.Int32(num_sequences),
+            q,
+            k,
+            v,
+            raw_gate,
+            a_log,
+            dt_bias,
+            beta,
+            cu_seqlens,
+            initial_state,
+            out,
+            final_state,
+            work_items,
+            work_count,
+            sched_ctr,
+            scale,
+            checkpoint_every_n_tokens,
+        ).launch(
+            grid=(cfg.max_active_clusters, 1, 1),
+            block=(cfg.threads_per_cta, 1, 1),
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
+
+
+@cute.kernel
+def kernel(
+    cfg: cutlass.Constexpr,
+    tensormap_workspace: cute.Tensor,
+    n_desc: cutlass.Int32,
+    mQ: cute.Tensor,
+    mK: cute.Tensor,
+    mV: cute.Tensor,
+    mGate: cute.Tensor,
+    mA_log: cute.Tensor | None,
+    mDt_bias: cute.Tensor | None,
+    mBeta: cute.Tensor,
+    cu_seqlens: cute.Tensor,
+    mState_init: cute.Tensor | None,
+    mO: cute.Tensor,
+    mState_out: cute.Tensor | None,
+    mWorkItems: cute.Tensor,
+    mCount: cute.Tensor,
+    mSched: cute.Tensor | None,
+    scale: cutlass.Float32,
+    checkpoint_every_n_tokens: cutlass.Int32,
+) -> None:
+    """BT=16 KDA forward kernel (persistent, tile-scheduled)."""
+
+    tidx, _, _ = cute.arch.thread_idx()
+    bidx = cute.arch.block_idx()[0]
+    num_ctas = cute.arch.grid_dim()[0]
+    warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+    lane = tidx % cfg.threads_per_warp
+
+    total_tiles = mCount[0]
+    if cutlass.const_expr(cfg.dyn_sched):
+        assert mSched is not None and mSched.element_type == cutlass.Int32
+    assert mQ.element_type == cfg.io_dtype and mK.element_type == cfg.io_dtype and mV.element_type == cfg.io_dtype
+    assert mGate.element_type == cutlass.Float32
+    beta_expected = cfg.io_dtype if cutlass.const_expr(cfg.beta_sigmoid) else cutlass.Float32
+    assert mBeta.element_type == beta_expected
+    assert cu_seqlens.element_type in (cutlass.Int32, cutlass.Int64)
+    if cutlass.const_expr(cfg.use_initial_state):
+        assert mState_init is not None and mState_init.element_type in (cutlass.BFloat16, cutlass.Float32)
+    else:
+        assert mState_init is None, "mState_init must be None if use_initial_state is False"
+    if cutlass.const_expr(cfg.store_final_state):
+        assert mState_out is not None and mState_out.element_type in (cutlass.BFloat16, cutlass.Float32)
+    else:
+        assert mState_out is None, "mState_out must be None if store_final_state is False"
+    if cutlass.const_expr(mState_init is not None and mState_out is not None):
+        assert mState_init.element_type == mState_out.element_type
+    desc_base_words = tensormap_workspace.iterator.raw_ptr()
+    arr_words = n_desc * cutlass.Int32(TENSOR_MAP_QWORDS)
+    desc_q_base = desc_base_words
+    desc_k_base = desc_base_words + arr_words
+    desc_v_base = desc_base_words + cutlass.Int32(2) * arr_words
+    desc_gate_base = desc_base_words + cutlass.Int32(3) * arr_words
+    desc_o_base = desc_base_words + cutlass.Int32(4) * arr_words
+    desc_checkpoint_base = desc_base_words + cutlass.Int32(5) * arr_words
+
+    # Buffers are declaration-ordered and intentionally non-aliased.
+    SMEM = cutlass.AddressSpace.smem
+    bars = make_kda_bars(cfg)
+    tmem_base_slot = cutlass.Array(cutlass.Int32, 1, space=SMEM, alignment=4)
+    sSched = cutlass.Array(cutlass.Int32, cfg.sched_stages, space=SMEM, alignment=16)
+    sK_decay_raw = cutlass.Array(cfg.io_dtype, cfg.k_decay_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
+    sQ_decay_raw = cutlass.Array(cfg.io_dtype, cfg.q_decay_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
+    sK_restore_raw = cutlass.Array(cfg.io_dtype, cfg.k_restore_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
+    sIntermediate_raw = cutlass.Array(cfg.io_dtype, cfg.intermediate_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
+    sQ_raw = cutlass.Array(mQ.element_type, cfg.q_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
+    sK_raw = cutlass.Array(mK.element_type, cfg.k_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
+    sV_raw = cutlass.Array(mV.element_type, cfg.v_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
+    sGate_raw = cutlass.Array(cutlass.Float32, cfg.gate_cosize, space=SMEM, alignment=1024)
+    sState_scale_diag_raw = cutlass.Array(cfg.io_dtype, cfg.state_scale_diag_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
+    sK_inv_raw = cutlass.Array(cfg.io_dtype, cfg.k_inv_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
+    sO_raw = cutlass.Array(
+        mO.element_type,
+        cfg.o_cosize,
+        space=SMEM,
+        alignment=cfg.buffer_align_bytes,
+    )
+    sBeta_raw = cutlass.Array(cutlass.Float32, cfg.beta_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
+    sCheckpoint_raw = (
+        cutlass.Array(cfg.io_dtype, cfg.smem_checkpoint_stages * cfg.d_k * cfg.d_v, space=SMEM, alignment=cfg.buffer_align_bytes)
+        if cutlass.const_expr(cfg.enable_checkpoints)
+        else sO_raw
+    )
+    sK_decay = SmemTile(
+        base=sK_decay_raw,
+        elems_per_stage=(cfg.d_k * cfg.b_t),
+        stages=cfg.smem_decay_stages,
+        leading_byte_offset=16,
+        stride_byte_offset=1024,
+        layout=nvvm.Tcgen05SmemSwizzle.SWIZZLE_128B,
+    )
+    sQ_decay = SmemTile(
+        base=sQ_decay_raw,
+        elems_per_stage=(cfg.d_k * cfg.b_t),
+        stages=cfg.smem_decay_stages,
+        leading_byte_offset=16,
+        stride_byte_offset=1024,
+        layout=nvvm.Tcgen05SmemSwizzle.SWIZZLE_128B,
+    )
+    sK_restore = SmemTile(
+        base=sK_restore_raw,
+        elems_per_stage=(cfg.d_k * cfg.b_t),
+        stages=cfg.smem_decay_stages,
+        leading_byte_offset=(cfg.b_t * (cfg.d_v // 2) * 2),
+        stride_byte_offset=(8 * (cfg.d_v // 2) * 2),
+        layout=nvvm.Tcgen05SmemSwizzle.SWIZZLE_128B,
+    )
+    sState_scale_diag = SmemTile(
+        base=sState_scale_diag_raw,
+        elems_per_stage=((cfg.d_k // 16) * 256),
+        stages=cfg.smem_state_scale_diag_stages,
+        leading_byte_offset=16,
+        stride_byte_offset=(8 * 16 * 2),
+        layout=nvvm.Tcgen05SmemSwizzle.SWIZZLE_32B,
+    )
+    sIntermediate = SmemTile(
+        base=sIntermediate_raw,
+        elems_per_stage=(2 * cfg.b_t * cfg.b_t),
+        stages=cfg.smem_intermediate_stages,
+        leading_byte_offset=16,
+        stride_byte_offset=(8 * cfg.b_t * 2),
+        layout=nvvm.Tcgen05SmemSwizzle.SWIZZLE_32B,
+    )
+
+    elect_one = nvvm.elect_sync()
+    if warp_idx == cfg.tma_warp_id:
+        if elect_one:
+            for stage in cutlass.range_constexpr(cfg.smem_raw_bar_stages):
+                bars.mb_q_ready[stage].init()
+                bars.mb_k_ready[stage].init()
+                bars.mb_v_ready[stage].init()
+                bars.mb_gate_ready[stage].init()
+                bars.mb_beta_ready[stage].init()
+                bars.mb_beta_done[stage].init()
+            for stage in cutlass.range_constexpr(cfg.smem_raw_stages):
+                bars.mb_q_done[stage].init()
+                bars.mb_k_done[stage].init()
+                bars.mb_v_done[stage].init()
+                bars.mb_gate_done[stage].init()
+    elif warp_idx == cfg.tcgen05_mma_warp_id:
+        if elect_one:
+            bars.mb_o_acc_ready.init()
+            for stage in cutlass.range_constexpr(cfg.tmem_q_state_acc_stages):
+                bars.mb_o_acc_done[stage].init()
+            bars.mb_state_k_acc_ready.init()
+            bars.mb_u_acc_ready.init()
+            bars.mb_state_acc_done.init()
+            bars.mb_state_inp_ready.init()
+            for stage in cutlass.range_constexpr(cfg.smem_state_scale_diag_stages):
+                bars.mb_state_scale_diag_done[stage].init()
+            for stage in cutlass.range_constexpr(cfg.smem_decay_stages):
+                bars.mb_decay_tcgen05_done[stage].init()
+                bars.mb_decay_super_done[stage].init()
+                bars.mb_k_restore_done[stage].init()
+            bars.mb_y_inp_ready.init()
+            bars.mb_u_inp_ready.init()
+            bars.mb_tmem_done[0].init()
+    elif warp_idx == cfg.super_mma_warp_id:
+        if elect_one:
+            for stage in cutlass.range_constexpr(cfg.smem_intermediate_stages):
+                bars.mb_t_inv_ready[stage].init()
+                bars.mb_a_ready[stage].init()
+                bars.mb_t_inv_done[stage].init()
+                bars.mb_a_done[stage].init()
+            for stage in cutlass.range_constexpr(cfg.qk_scale_ready_stages):
+                bars.mb_qk_scale_ready[stage].init()
+            for stage in cutlass.range_constexpr(cfg.smem_decay_stages):
+                bars.mb_k_decay_inv_cg0_ready[stage].init()
+    elif warp_idx == cfg.epilogue_warp_id:
+        if elect_one:
+            for stage in cutlass.range_constexpr(cfg.smem_o_stages):
+                bars.mb_o_tmastg_ready[stage].init()
+                bars.mb_o_tmastg_done[stage].init()
+            for stage in cutlass.range_constexpr(cfg.sched_stages):
+                bars.mb_sched_ready[stage].init()
+                bars.mb_sched_done[stage].init()
+            if cutlass.const_expr(cfg.enable_checkpoints):
+                for stage in cutlass.range_constexpr(cfg.smem_checkpoint_stages):
+                    bars.mb_checkpoint_tmastg_ready[stage].init()
+                    bars.mb_checkpoint_tmastg_done[stage].init()
+                bars.mb_state_acc_read_done.init()
+    diag_zero = cfg.io_dtype(0.0)
+    for diag_idx in cutlass.range(tidx, cfg.state_scale_diag_cosize, cfg.threads_per_cta, unroll=1):
+        sState_scale_diag_raw[diag_idx] = diag_zero
+    nvvm.fence_mbarrier_init()
+    nvvm.barrier_cta_sync(0, thread_count=cfg.threads_per_cta)
+    if warp_idx == cfg.tma_warp_id:
+        tmaldg_warp(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            n_desc,
+            cu_seqlens,
+            mWorkItems,
+            mSched,
+            sSched,
+            lane,
+            sQ_raw,
+            sK_raw,
+            sV_raw,
+            sGate_raw,
+            desc_q_base,
+            desc_k_base,
+            desc_v_base,
+            desc_gate_base,
+            bars,
+        )
+    elif warp_idx == cfg.super_mma_warp_id:
+        super_mma_warp(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            cu_seqlens,
+            mWorkItems,
+            sSched,
+            lane,
+            sK_inv_raw,
+            sIntermediate_raw,
+            sBeta_raw,
+            sK_decay_raw,
+            bars,
+        )
+    elif warp_idx == cfg.tcgen05_mma_warp_id:
+        tcgen05_mma_warp(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            cu_seqlens,
+            mWorkItems,
+            sSched,
+            tmem_base_slot,
+            sIntermediate,
+            sK_decay,
+            sK_restore,
+            sQ_decay,
+            sState_scale_diag,
+            bars,
+        )
+    elif warp_idx == cfg.epilogue_warp_id:
+        epilogue_warp(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            cu_seqlens,
+            mWorkItems,
+            sSched,
+            lane,
+            mO,
+            sK_inv_raw,
+            sO_raw,
+            sIntermediate_raw,
+            sQ_decay_raw,
+            sCheckpoint_raw,
+            desc_o_base,
+            desc_checkpoint_base,
+            checkpoint_every_n_tokens,
+            bars,
+        )
+    elif warp_idx >= cfg.compute_group_0_warp_ids[0] and warp_idx <= cfg.compute_group_0_warp_ids[-1]:
+        compute0_warp_group(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            cu_seqlens,
+            mWorkItems,
+            sSched,
+            lane,
+            warp_idx,
+            mQ,
+            mA_log,
+            mDt_bias,
+            sK_inv_raw,
+            sGate_raw,
+            mBeta,
+            sBeta_raw,
+            sK_raw,
+            sQ_raw,
+            sK_decay_raw,
+            sK_restore_raw,
+            sQ_decay_raw,
+            sState_scale_diag_raw,
+            bars,
+        )
+    elif warp_idx >= cfg.compute_group_1_warp_ids[0] and warp_idx <= cfg.compute_group_1_warp_ids[-1]:
+        compute1_warp_group(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            cu_seqlens,
+            mWorkItems,
+            sSched,
+            lane,
+            tmem_base_slot,
+            warp_idx,
+            mState_out,
+            mState_init,
+            mO,
+            sO_raw,
+            sBeta_raw,
+            sV_raw,
+            sCheckpoint_raw,
+            checkpoint_every_n_tokens,
+            scale,
+            bars,
+        )
+
+
+@dataclass
+class KdaCfg:
+    """Kernel cfg (fixed BT=16 schedule constants; derived TMEM column offsets
+    and SMEM buffer cosizes are stamped by ``build_cfg``; per-stage sizes are
+    inlined at the use sites).  Owned by ``KdaPrefillOp`` and passed into
+    ``kernel`` and every warp body."""
+
+    io_dtype: Type[cutlass.Numeric]
+    state_dtype: Type[cutlass.Numeric]
+    use_initial_state: bool
+    store_final_state: bool
+    enable_checkpoints: bool
+    l2norm: bool
+    safe_gate: bool
+    gate_scale_log2: float
+    beta_sigmoid: bool
+    q_ratio: int
+    k_ratio: int
+    v_ratio: int
+    n_heads_out: int
+    max_active_clusters: int
+    dyn_sched: bool = False
+    sched_stages: int = CFG.SMEM_SCHED_STAGES
+
+    compute_group_0_warp_ids: tuple[int, ...] = CFG.COMPUTE_GROUP_0_WARP_IDS
+    compute_group_1_warp_ids: tuple[int, ...] = CFG.COMPUTE_GROUP_1_WARP_IDS
+    super_mma_warp_id: int = CFG.SUPER_MMA_WARP_ID
+    tcgen05_mma_warp_id: int = CFG.TCGEN05_MMA_WARP_ID
+    tma_warp_id: int = CFG.TMA_WARP_ID
+    epilogue_warp_id: int = CFG.EPILOGUE_WARP_ID
+    b_t: int = CFG.B_T
+    d_k: int = CFG.D_K
+    d_v: int = CFG.D_V
+    threads_per_warp: int = CFG.THREADS_PER_WARP
+    buffer_align_bytes: int = CFG.BUFFER_ALIGN_BYTES
+    threads_per_cta: int = 0
+    cg0_group_count: int = 0  # derived by build_cfg
+    cg0_warps_per_group: int = 4
+    cg0_threads_per_group: int = 0
+    cg0_group_sync_barrier_base_id: int = 1  # CG0 group g syncs on nbar id 1 + g
+    cg0_tile_entry_barrier_id: int = 5  # CG0-wide (both groups) work-item entry sync
+    tmem_user_threads: int = 0
+    tmem_lifecycle_barrier_id: int = 3
+    num_regs_compute_group_0: int = CFG.NUM_REGS_COMPUTE_GROUP_0
+    num_regs_compute_group_1: int = CFG.NUM_REGS_COMPUTE_GROUP_1
+    num_regs_other: int = CFG.NUM_REGS_OTHER
+
+    # ---- SMEM / TMEM ring stage counts -------------------------------------------
+    smem_raw_stages: int = CFG.SMEM_RAW_STAGES
+    smem_raw_bar_stages: int = 0  # ready/beta-ring mbar depth: raw rounded up to even (CG0 ping-pong parity)
+    smem_o_stages: int = CFG.SMEM_O_STAGES
+    smem_checkpoint_stages: int = 1
+    smem_decay_stages: int = CFG.SMEM_DECAY_STAGES
+    smem_intermediate_stages: int = CFG.SMEM_INTERMEDIATE_STAGES
+    smem_state_scale_diag_stages: int = CFG.SMEM_STATE_SCALE_DIAG_STAGES
+    qk_scale_ready_stages: int = CFG.QK_SCALE_READY_STAGES
+    tmem_q_state_acc_stages: int = CFG.TMEM_Q_STATE_ACC_STAGES
+
+    # ---- TMEM column offsets (state doubles as the final_state acc) --------------
+    tmem_state_acc_offset: int = 0
+    tmem_state_inp_offset: int = 0
+    tmem_q_state_acc_offset: int = 0
+    tmem_state_k_acc_offset: int = 0
+    tmem_u_acc_offset: int = 0
+    tmem_y_inp_offset: int = 0
+    tmem_u_inp_offset: int = 0
+
+    # ---- SMEM buffer cosizes -----------------------------------------------------
+    q_cosize: int = 0
+    k_cosize: int = 0
+    v_cosize: int = 0
+    gate_cosize: int = 0
+    beta_cosize: int = 0
+    k_inv_cosize: int = 0
+    k_decay_cosize: int = 0
+    q_decay_cosize: int = 0
+    k_restore_cosize: int = 0
+    state_scale_diag_cosize: int = 0
+    o_cosize: int = 0
+
+    # TMA transaction bytes per stage
+    tma_q_bytes: int = 0
+    tma_k_bytes: int = 0
+    tma_v_bytes: int = 0
+    tma_gate_bytes: int = 0
+    intermediate_cosize: int = 0
+
+
+def build_cfg(
+    io_dtype: Type[cutlass.Numeric],
+    state_dtype: Type[cutlass.Numeric],
+    *,
+    use_initial_state: bool,
+    store_final_state: bool,
+    enable_checkpoints: bool,
+    l2norm: bool,
+    safe_gate: bool,
+    gate_scale_log2: float,
+    beta_sigmoid: bool,
+    q_ratio: int,
+    k_ratio: int,
+    v_ratio: int,
+    n_heads_out: int,
+    max_active_clusters: int,
+    dyn_sched: bool = False,
+) -> KdaCfg:
+    """Build the per-compile ``KdaCfg`` (io_dtype in {Float16, BFloat16});
+    fills the derived TMEM column offsets and SMEM buffer cosizes."""
+    if io_dtype not in (cutlass.Float16, cutlass.BFloat16):
+        raise ValueError(f"io_dtype={io_dtype} not supported; only Float16 and BFloat16 are supported")
+    cfg = KdaCfg(
+        io_dtype=io_dtype,
+        state_dtype=state_dtype,
+        use_initial_state=use_initial_state,
+        store_final_state=store_final_state,
+        enable_checkpoints=enable_checkpoints,
+        l2norm=l2norm,
+        safe_gate=safe_gate,
+        gate_scale_log2=gate_scale_log2,
+        beta_sigmoid=beta_sigmoid,
+        q_ratio=q_ratio,
+        k_ratio=k_ratio,
+        v_ratio=v_ratio,
+        n_heads_out=n_heads_out,
+        max_active_clusters=max_active_clusters,
+        dyn_sched=dyn_sched,
+    )
+    if enable_checkpoints:
+        cfg.smem_raw_stages = 5
+        cfg.smem_checkpoint_stages = 2
+    cfg.smem_raw_bar_stages = cfg.smem_raw_stages + (cfg.smem_raw_stages % 2)
+    role_ids = (
+        *cfg.compute_group_0_warp_ids,
+        *cfg.compute_group_1_warp_ids,
+        cfg.super_mma_warp_id,
+        cfg.tcgen05_mma_warp_id,
+        cfg.tma_warp_id,
+        cfg.epilogue_warp_id,
+    )
+    if tuple(sorted(role_ids)) != tuple(range(len(role_ids))):
+        raise ValueError("warp roles must be disjoint and cover contiguous IDs from zero")
+    for group in (cfg.compute_group_0_warp_ids, cfg.compute_group_1_warp_ids):
+        if not group or group != tuple(range(group[0], group[-1] + 1)):
+            raise ValueError("compute warp groups must be nonempty and use contiguous IDs")
+    cfg.threads_per_cta = len(role_ids) * cfg.threads_per_warp
+    if cfg.cg0_warps_per_group != 4:
+        raise ValueError("the fixed schedule requires four warps per compute group 0 subgroup")
+    if len(cfg.compute_group_0_warp_ids) % cfg.cg0_warps_per_group:
+        raise ValueError("compute group 0 must divide evenly into ping-pong warp groups")
+    cfg.cg0_group_count = len(cfg.compute_group_0_warp_ids) // cfg.cg0_warps_per_group
+    if cfg.cg0_group_count != 2:
+        raise ValueError("the fixed schedule requires two compute group 0 ping-pong subgroups")
+    cfg.cg0_threads_per_group = cfg.cg0_warps_per_group * cfg.threads_per_warp
+    cfg.tmem_user_threads = (1 + len(cfg.compute_group_1_warp_ids)) * cfg.threads_per_warp
+    named_barrier_ids = (
+        *range(
+            cfg.cg0_group_sync_barrier_base_id,
+            cfg.cg0_group_sync_barrier_base_id + cfg.cg0_group_count,
+        ),
+        cfg.tmem_lifecycle_barrier_id,
+        cfg.cg0_tile_entry_barrier_id,
+    )
+    if (
+        any(not 1 <= barrier_id <= 15 for barrier_id in named_barrier_ids)
+        or len(set(named_barrier_ids)) != len(named_barrier_ids)
+    ):
+        raise ValueError("named barrier IDs must be disjoint values in [1, 15]")
+    if cfg.smem_state_scale_diag_stages != cfg.qk_scale_ready_stages:
+        raise ValueError("diag and qk-scale ready rings must share their rolling stage")
+
+    cfg.tmem_state_inp_offset = cfg.tmem_state_acc_offset + cfg.d_k
+    cfg.tmem_q_state_acc_offset = cfg.tmem_state_inp_offset + (cfg.d_k // 2)
+    cfg.tmem_state_k_acc_offset = cfg.tmem_q_state_acc_offset + cfg.tmem_q_state_acc_stages * cfg.b_t
+    cfg.tmem_u_acc_offset = cfg.tmem_state_k_acc_offset + cfg.b_t
+    cfg.tmem_y_inp_offset = cfg.tmem_u_acc_offset + cfg.b_t
+    cfg.tmem_u_inp_offset = cfg.tmem_y_inp_offset + (cfg.b_t // 2)
+    assert (cfg.tmem_u_inp_offset + (cfg.b_t // 2)) <= 512
+
+    cfg.q_cosize = cfg.smem_raw_stages * cfg.d_k * cfg.b_t
+    cfg.k_cosize = cfg.smem_raw_stages * cfg.d_k * cfg.b_t
+    cfg.v_cosize = cfg.smem_raw_stages * cfg.d_v * cfg.b_t
+    cfg.gate_cosize = cfg.smem_raw_stages * cfg.d_k * cfg.b_t
+    cfg.beta_cosize = cfg.smem_raw_bar_stages * cfg.b_t
+    cfg.k_inv_cosize = cfg.smem_decay_stages * cfg.b_t * cfg.d_k
+    cfg.k_decay_cosize = cfg.smem_decay_stages * cfg.d_k * cfg.b_t
+    cfg.q_decay_cosize = cfg.smem_decay_stages * cfg.d_k * cfg.b_t
+    cfg.k_restore_cosize = cfg.smem_decay_stages * cfg.d_k * cfg.b_t
+    cfg.state_scale_diag_cosize = cfg.smem_state_scale_diag_stages * (cfg.d_k // 16) * 256
+    cfg.o_cosize = cfg.smem_o_stages * cfg.b_t * cfg.d_v
+    cfg.intermediate_cosize = cfg.smem_intermediate_stages * 2 * cfg.b_t * cfg.b_t
+    cfg.tma_q_bytes = cfg.d_k * cfg.b_t * (cfg.io_dtype.width // 8)
+    cfg.tma_k_bytes = cfg.d_k * cfg.b_t * (cfg.io_dtype.width // 8)
+    cfg.tma_v_bytes = cfg.d_v * cfg.b_t * (cfg.io_dtype.width // 8)
+    cfg.tma_gate_bytes = cfg.d_k * cfg.b_t * 4
+    return cfg
+
+
+TENSORMAP_DESC_ARRAYS = 6  # per-batch runtime TMA descriptors: Q, K, V, Gate, O, state_checkpoints
+TENSORMAP_STATIC_SLOTS = 0
+
+
+@cute.jit
+def build_descs_body(
+    widx,
+    base_q,
+    base_k,
+    base_v,
+    base_gate,
+    base_o,
+    base_checkpoint,
+    desc_ws: cute.Tensor,
+    cu_seqlens: cute.Tensor,
+    q: cute.Tensor,
+    k: cute.Tensor,
+    v: cute.Tensor,
+    gate: cute.Tensor,
+    o: cute.Tensor,
+    state_checkpoints: cute.Tensor | None,
+    n_batch: cutlass.Int32,
+    q_token_stride: cutlass.Int32,
+    k_token_stride: cutlass.Int32,
+    v_token_stride: cutlass.Int32,
+    gate_token_stride: cutlass.Int32,
+    o_token_stride: cutlass.Int32,
+    checkpoint_entry_stride: cutlass.Int32,
+    checkpoint_every_n: cutlass.Int32,
+) -> None:
+    """Per-batch descriptor-array build, one warp per array. Runs inside the
+    prologue kernel after its order pass; warps past the array count fall
+    through the widx guards."""
+    arr_words = n_batch * cutlass.Int32(TENSOR_MAP_QWORDS)
+    desc_q_arr = cute.make_tensor(desc_ws.iterator, cute.make_layout((arr_words,), stride=(1,)))
+    desc_k_arr = cute.make_tensor(desc_ws.iterator + arr_words, cute.make_layout((arr_words,), stride=(1,)))
+    desc_v_arr = cute.make_tensor(desc_ws.iterator + 2 * arr_words, cute.make_layout((arr_words,), stride=(1,)))
+    desc_gate_arr = cute.make_tensor(desc_ws.iterator + 3 * arr_words, cute.make_layout((arr_words,), stride=(1,)))
+    desc_o_arr = cute.make_tensor(desc_ws.iterator + 4 * arr_words, cute.make_layout((arr_words,), stride=(1,)))
+    desc_checkpoint_arr = cute.make_tensor(desc_ws.iterator + 5 * arr_words, cute.make_layout((arr_words,), stride=(1,)))
+
+    if widx == 0:
+        if nvvm.elect_sync():
+            emit_seq_load_descs(
+                base_q, desc_q_arr, cu_seqlens, q, n_batch, q_token_stride, 2
+            )
+            nvvm.fence_proxy_release(
+                nvvm.MemScope.GPU,
+                from_proxy=nvvm.Proxy.GENERIC,
+                to_proxy=nvvm.Proxy.TENSORMAP,
+            )
+    if widx == 1:
+        if nvvm.elect_sync():
+            emit_seq_load_descs(
+                base_k, desc_k_arr, cu_seqlens, k, n_batch, k_token_stride, 2
+            )
+            nvvm.fence_proxy_release(
+                nvvm.MemScope.GPU,
+                from_proxy=nvvm.Proxy.GENERIC,
+                to_proxy=nvvm.Proxy.TENSORMAP,
+            )
+    if widx == 2:
+        if nvvm.elect_sync():
+            emit_seq_load_descs(
+                base_v, desc_v_arr, cu_seqlens, v, n_batch, v_token_stride, 2
+            )
+            nvvm.fence_proxy_release(
+                nvvm.MemScope.GPU,
+                from_proxy=nvvm.Proxy.GENERIC,
+                to_proxy=nvvm.Proxy.TENSORMAP,
+            )
+    if widx == 3:
+        if nvvm.elect_sync():
+            emit_seq_load_descs(
+                base_gate,
+                desc_gate_arr,
+                cu_seqlens,
+                gate,
+                n_batch,
+                gate_token_stride,
+                2,
+            )
+            nvvm.fence_proxy_release(
+                nvvm.MemScope.GPU,
+                from_proxy=nvvm.Proxy.GENERIC,
+                to_proxy=nvvm.Proxy.TENSORMAP,
+            )
+    if widx == 4:
+        if nvvm.elect_sync():
+            emit_seq_descs(base_o, desc_o_arr, cu_seqlens, o, n_batch, o_token_stride, 2)
+            nvvm.fence_proxy_release(nvvm.MemScope.GPU, from_proxy=nvvm.Proxy.GENERIC, to_proxy=nvvm.Proxy.TENSORMAP)
+    if cutlass.const_expr(state_checkpoints is not None):
+        if widx == 5:
+            if nvvm.elect_sync():
+                emit_checkpoint_seq_descs(
+                    base_checkpoint, desc_checkpoint_arr, cu_seqlens, state_checkpoints, n_batch, checkpoint_entry_stride, checkpoint_every_n, 2
+                )
+                nvvm.fence_proxy_release(nvvm.MemScope.GPU, from_proxy=nvvm.Proxy.GENERIC, to_proxy=nvvm.Proxy.TENSORMAP)
+
+
+@cute.kernel
+def prologue_kernel(
+    order_gen: cutlass.Constexpr[bool],
+    has_sched: cutlass.Constexpr[bool],
+    b_t: cutlass.Constexpr[int],
+    base_q: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    base_k: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    base_v: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    base_gate: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    base_o: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    base_checkpoint: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    desc_ws: cute.Tensor,
+    cu_seqlens: cute.Tensor,
+    q: cute.Tensor,
+    k: cute.Tensor,
+    v: cute.Tensor,
+    gate: cute.Tensor,
+    o: cute.Tensor,
+    state_checkpoints: cute.Tensor | None,
+    mStaging: cute.Tensor | None,
+    mCount: cute.Tensor,
+    mWorkItems: cute.Tensor,
+    mSched: cute.Tensor | None,
+    n_batch: cutlass.Int32,
+    q_token_stride: cutlass.Int32,
+    k_token_stride: cutlass.Int32,
+    v_token_stride: cutlass.Int32,
+    gate_token_stride: cutlass.Int32,
+    o_token_stride: cutlass.Int32,
+    checkpoint_entry_stride: cutlass.Int32,
+    checkpoint_every_n: cutlass.Int32,
+) -> None:
+    """Single-CTA prologue: LPT-order the work-item table and zero the sched
+    rings via :func:`order_body`, then build the per-batch TMA-descriptor
+    arrays via :func:`build_descs_body`, one warp per array (the extra warps
+    only take part in the order phase)."""
+    tidx, _, _ = cute.arch.thread_idx()
+    tidx = cutlass.Int32(tidx)
+    widx = tidx // cutlass.Int32(32)
+    sKey = cutlass.Array(cutlass.Int32, ORDER_CAPACITY, space=cutlass.AddressSpace.smem, alignment=16)
+    sIdx = cutlass.Array(cutlass.Int32, ORDER_CAPACITY, space=cutlass.AddressSpace.smem, alignment=16)
+    sSpread = cutlass.Array(cutlass.Int32, 2, space=cutlass.AddressSpace.smem, alignment=8)
+    n_heads_out = cutlass.Int32(gate.shape[1])
+    order_body(
+        order_gen,
+        has_sched,
+        b_t,
+        ORDER_THREADS,
+        ORDER_ELEMS,
+        tidx,
+        n_heads_out,
+        n_heads_out * n_batch,
+        cu_seqlens,
+        mStaging,
+        mCount,
+        mWorkItems,
+        mSched,
+        sKey,
+        sIdx,
+        sSpread,
+    )
+    build_descs_body(
+        widx,
+        base_q,
+        base_k,
+        base_v,
+        base_gate,
+        base_o,
+        base_checkpoint,
+        desc_ws,
+        cu_seqlens,
+        q,
+        k,
+        v,
+        gate,
+        o,
+        state_checkpoints,
+        n_batch,
+        q_token_stride,
+        k_token_stride,
+        v_token_stride,
+        gate_token_stride,
+        o_token_stride,
+        checkpoint_entry_stride,
+        checkpoint_every_n,
+    )
+
+
+@cute.jit
+def prologue(
+    io_dtype: cutlass.Constexpr,
+    b_t: cutlass.Constexpr[int],
+    order_gen: cutlass.Constexpr[bool],
+    has_sched: cutlass.Constexpr[bool],
+    q: cute.Tensor,
+    k: cute.Tensor,
+    v: cute.Tensor,
+    gate: cute.Tensor,
+    o: cute.Tensor,
+    state_checkpoints: cute.Tensor | None,
+    cu_seqlens: cute.Tensor,
+    work_item_staging: cute.Tensor | None,
+    work_count: cute.Tensor,
+    work_items: cute.Tensor,
+    sched_ctr: cute.Tensor | None,
+    tensormap_workspace: cute.Tensor,
+    checkpoint_every_n: cutlass.Int32,
+    stream: cuda_driver.CUstream,
+):
+    """One-launch prologue: LPT-order the work items and build the 6
+    per-(batch, head) TMA-descriptor arrays (q, k, v, gate, o,
+    state_checkpoints) into ``tensormap_workspace``."""
+    h_q = q.shape[1]
+    h_k = k.shape[1]
+    h_v = v.shape[1]
+    n_heads_out = gate.shape[1]
+    batch_size = cu_seqlens.shape[0] - 1
+    d_k = q.shape[2]
+    d_v = v.shape[2]
+    bpe = io_dtype.width // 8
+    tma_granu_elems = 128 // bpe
+    seqlen = q.shape[0]
+
+    q_headed = cute.make_tensor(q.iterator, cute.make_layout((d_k, h_q, seqlen), stride=(1, q.stride[1], q.stride[0])))
+    k_headed = cute.make_tensor(k.iterator, cute.make_layout((d_k, h_k, seqlen), stride=(1, k.stride[1], k.stride[0])))
+    v_headed = cute.make_tensor(v.iterator, cute.make_layout((d_v, h_v, seqlen), stride=(1, v.stride[1], v.stride[0])))
+    gate_headed = cute.make_tensor(gate.iterator, cute.make_layout((d_k, n_heads_out, seqlen), stride=(1, gate.stride[1], gate.stride[0])))
+    o_headed = cute.make_tensor(o.iterator, cute.make_layout((d_v, n_heads_out, seqlen), stride=(1, o.stride[1], o.stride[0])))
+
+    swz = cuda.TensorMapSwizzle.s128b
+    base_q = cuda.create_tensor_map_tiled_from_view(q_headed, box_dims=(tma_granu_elems, 1, b_t), stride_order=(0, 1, 2), swizzle=swz)
+    base_k = cuda.create_tensor_map_tiled_from_view(k_headed, box_dims=(tma_granu_elems, 1, b_t), stride_order=(0, 1, 2), swizzle=swz)
+    base_v = cuda.create_tensor_map_tiled_from_view(v_headed, box_dims=(tma_granu_elems, 1, b_t), stride_order=(0, 1, 2), swizzle=swz)
+    base_gate = cuda.create_tensor_map_tiled_from_view(gate_headed, box_dims=(32, 1, b_t), stride_order=(0, 1, 2), swizzle=swz)
+    base_o = cuda.create_tensor_map_tiled_from_view(o_headed, box_dims=(tma_granu_elems, 1, b_t), stride_order=(0, 1, 2), swizzle=swz)
+
+    base_checkpoint = base_o
+    if cutlass.const_expr(state_checkpoints is not None):
+        checkpoint_view = cute.make_tensor(
+            state_checkpoints.iterator,
+            cute.make_layout(
+                (state_checkpoints.shape[3], state_checkpoints.shape[2], state_checkpoints.shape[0], n_heads_out),
+                stride=(state_checkpoints.stride[3], state_checkpoints.stride[2], state_checkpoints.stride[0], state_checkpoints.stride[1]),
+            ),
+        )
+        base_checkpoint = cuda.create_tensor_map_tiled_from_view(checkpoint_view, box_dims=(tma_granu_elems, d_k, 1, 1), stride_order=(0, 1, 2, 3), swizzle=swz)
+    prologue_kernel(
+        order_gen,
+        has_sched,
+        b_t,
+        base_q,
+        base_k,
+        base_v,
+        base_gate,
+        base_o,
+        base_checkpoint,
+        tensormap_workspace,
+        cu_seqlens,
+        q,
+        k,
+        v,
+        gate,
+        o,
+        state_checkpoints,
+        work_item_staging,
+        work_count,
+        work_items,
+        sched_ctr,
+        cutlass.Int32(batch_size),
+        cutlass.Int32(q.stride[0]),
+        cutlass.Int32(k.stride[0]),
+        cutlass.Int32(v.stride[0]),
+        cutlass.Int32(gate.stride[0]),
+        cutlass.Int32(o.stride[0]),
+        cutlass.Int32(state_checkpoints.stride[0] if state_checkpoints is not None else 0),
+        checkpoint_every_n,
+    ).launch(grid=(1, 1, 1), block=(ORDER_THREADS, 1, 1), stream=stream)
+
+
+# ---- Torch adapter / host-side compilation ---------------------------------------
+
+
+@lru_cache(maxsize=None)
+def get_compiled_cache(
+    io_dtype_str: str,
+    state_dtype_str: str,
+    cu_dtype_str: str,
+    HQ: int,
+    HK: int,
+    HV: int,
+    use_initial_state: bool,
+    store_final_state: bool,
+    enable_checkpoints: bool,
+    l2norm: bool,
+    safe_gate: bool,
+    gate_lower_bound: float,
+    beta_sigmoid: bool,
+    dyn_sched: bool,
+    order_gen: bool,
+    device_index: int,
+    device_major: int,
+    device_minor: int,
+    num_sm: int,
+):
+    """Return a mutable dict that lazily stores the compiled kernel."""
+    return {}
+
+
+def compile(
+    io_dtype,
+    state_dtype,
+    use_initial_state: bool,
+    store_final_state: bool,
+    enable_checkpoints: bool,
+    l2norm: bool,
+    safe_gate: bool,
+    gate_scale_log2: float,
+    beta_sigmoid: bool,
+    q_ratio: int,
+    k_ratio: int,
+    v_ratio: int,
+    n_heads_out: int,
+    dyn_sched: bool = False,
+    *,
+    num_sm: int,
+    q_cute,
+    k_cute,
+    v_cute,
+    gate_cute,
+    a_log_cute,
+    dt_bias_cute,
+    beta_cute,
+    cu_seqlens_cute,
+    state_in_cute,
+    o_cute,
+    state_out_cute,
+    work_items_cute=None,
+    work_count_cute=None,
+    sched_ctr_cute=None,
+    tensormap_ws_cute,
+    checkpoint_every_n_tokens,
+    scale,
+    stream,
+):
+    """JIT-compile the chunked KDA prefill kernel for one static config."""
+    cfg = build_cfg(
+        io_dtype,
+        state_dtype,
+        use_initial_state=use_initial_state,
+        store_final_state=store_final_state,
+        enable_checkpoints=enable_checkpoints,
+        l2norm=l2norm,
+        safe_gate=safe_gate,
+        gate_scale_log2=gate_scale_log2,
+        beta_sigmoid=beta_sigmoid,
+        q_ratio=q_ratio,
+        k_ratio=k_ratio,
+        v_ratio=v_ratio,
+        n_heads_out=n_heads_out,
+        max_active_clusters=num_sm,
+        dyn_sched=dyn_sched,
+    )
+
+    op = KdaPrefillOp(cfg)
+    op.__call__.set_name_prefix(op.get_name())
+    return cute.compile(
+        op,
+        q_cute,
+        k_cute,
+        v_cute,
+        gate_cute,
+        a_log_cute,
+        dt_bias_cute,
+        beta_cute,
+        cu_seqlens_cute,
+        state_in_cute,
+        o_cute,
+        state_out_cute,
+        work_items_cute,
+        work_count_cute,
+        sched_ctr_cute,
+        tensormap_ws_cute,
+        checkpoint_every_n_tokens,
+        scale,
+        stream,
+        options="--enable-tvm-ffi --opt-level 2",
+    )
+
+
+def chunk_kda_sm100(
+    q,
+    k,
+    v,
+    gate,
+    beta,
+    output,
+    cu_seqlens,
+    initial_state,
+    output_state,
+    scale: float,
+    checkpoint_every_n_tokens: int = 0,
+    output_state_checkpoints=None,
+    use_qk_l2norm_in_kernel: bool = False,
+    safe_gate: bool = False,
+    gate_lower_bound: float = DEFAULT_GATE_LOWER_BOUND,
+    a_log=None,
+    dt_bias=None,
+    use_beta_sigmoid_in_kernel: bool = False,
+    work_items=None,
+    work_count=None,
+    sched_ctr=None,
+    work_item_scratch=None,
+    *,
+    tensormap_workspace,
+    stream,
+) -> None:
+    """Execute the Blackwell BT=16 chunked KDA prefill kernel.
+
+    All tensors must be on the same CUDA device with a stride-1 innermost
+    dim; outer strides are free (padded / permuted views are read through
+    the TMA descriptors and dynamic layouts).
+
+    Args:
+        q: ``(total_tokens, HQ, DK)`` float16/bfloat16
+        k: ``(total_tokens, HK, DK)`` float16/bfloat16
+        v: ``(total_tokens, HV, DV)`` float16/bfloat16
+        gate: ``(total_tokens, HO, DK)`` float32.  Natural-log decay unless
+              ``safe_gate``, which applies the safe-gate transform
+              ``lower_bound * sigmoid(exp(a_log) * (gate + dt_bias))``.
+        beta: ``(total_tokens, HO)``.  Post-sigmoid float32, or io-dtype
+              logits when ``use_beta_sigmoid_in_kernel``
+        output: ``(total_tokens, HO, DV)`` float16/bfloat16, pre-allocated
+        cu_seqlens: ``(num_seqs + 1,)`` int32
+        initial_state: ``(num_seqs, HO, DV, DK)`` float32/bfloat16, or None
+        output_state: ``(num_seqs, HO, DV, DK)`` float32/bfloat16, or None
+        scale: attention scale factor (must not be 0)
+        checkpoint_every_n_tokens: emit entering-state checkpoints every N tokens (0 = off),
+            where N is a positive multiple of the 16-token kernel tile. Sequence-local row
+            ``j`` is the state before token ``j * N``; row zero is the provided initial state
+            or zeros. A nonempty sequence contributes ``ceil(L / N)`` rows.
+        output_state_checkpoints: ``(total_checkpoints, HO, DV, DK)`` io-dtype (VK, K
+            contiguous); per-sequence entry offsets are derived on device from
+            ``cu_seqlens``, so there is no separate checkpoint-offset tensor.
+        use_qk_l2norm_in_kernel: L2-normalize q/k rows inside the kernel
+        safe_gate: interpret ``gate`` through the safe-gate transform
+        a_log: ``(HO,)`` float32, safe-gate per-head log-amplitude (None = 0)
+        dt_bias: ``(HO, DK)`` float32, safe-gate channel bias (None = 0)
+        use_beta_sigmoid_in_kernel: ``beta`` holds logits; sigmoid in-kernel
+        work_items: ``(max_items, 8)`` int32 work-item table from
+            ``common/split_k.py`` (REQUIRED; an uncut table row is the whole
+            (b, h) sequence).  Each item computes chunks ``[cstart, wend)``
+            and writes O/checkpoints only for ``[wstart, wend)``.
+        work_count: ``(1,)`` int32 device-side item count (REQUIRED)
+        sched_ctr: ``(2,)`` int32 device scratch ``[ticket, done]`` enabling
+            the dynamic (work-stealing) tile scheduler; must be zeroed before
+            every launch (``build_split_table`` does this when it is passed as
+            ``sched_ctr``).  None keeps the static CTA stride.
+    """
+    for name, tensor in (
+        ("q", q),
+        ("k", k),
+        ("v", v),
+        ("gate", gate),
+        ("output", output),
+    ):
+        validate_tma_tensor(name, tensor)
+    for name, tensor in (
+        ("initial_state", initial_state),
+        ("output_state", output_state),
+        ("output_state_checkpoints", output_state_checkpoints),
+    ):
+        if tensor is not None:
+            validate_tma_tensor(name, tensor)
+    if cu_seqlens.data_ptr() % 8:
+        raise ValueError("cu_seqlens data pointer must be 8-byte aligned")
+
+    tokens, HQ, d_k = q.shape
+    HK, HV = k.shape[1], v.shape[1]
+    HO = max(HQ, HV)
+    if d_k != 128 or k.shape != (tokens, HK, 128) or v.shape != (tokens, HV, 128):
+        raise ValueError("q, k, and v must have shape (T, H, 128)")
+    if gate.shape != (tokens, HO, 128) or beta.shape != (tokens, HO):
+        raise ValueError("gate and beta must match the output head count and token extent")
+    if output.shape != (tokens, HO, 128):
+        raise ValueError("output must have shape (T, HO, 128)")
+    use_initial_state = initial_state is not None
+    store_final_state = output_state is not None
+    if checkpoint_every_n_tokens < 0:
+        raise ValueError("checkpoint interval must be zero or a positive tile multiple")
+    enable_checkpoints = checkpoint_every_n_tokens > 0
+    if enable_checkpoints and checkpoint_every_n_tokens % CFG.B_T:
+        raise ValueError(f"checkpoint interval must be a positive multiple of {CFG.B_T}")
+    if enable_checkpoints:
+        if output_state_checkpoints is None:
+            raise ValueError("checkpoint_every_n_tokens > 0 requires output_state_checkpoints")
+        required_checkpoint_rows = checkpoint_capacity_bound(
+            q.shape[0], cu_seqlens.shape[0] - 1, checkpoint_every_n_tokens
+        )
+        if output_state_checkpoints.shape[0] < required_checkpoint_rows:
+            raise ValueError(
+                f"output_state_checkpoints requires at least {required_checkpoint_rows} rows, "
+                f"got {output_state_checkpoints.shape[0]}"
+            )
+        if str(output_state_checkpoints.dtype).split(".")[-1] != str(q.dtype).split(".")[-1]:
+            raise ValueError(
+                f"output_state_checkpoints dtype must match the io dtype (fp32 state belongs to output_state): got {output_state_checkpoints.dtype} with io {q.dtype}"
+            )
+    if work_items is None or work_count is None:
+        raise ValueError("work_items/work_count are required (the split-table stage builds them for every launch)")
+    dyn_sched = sched_ctr is not None
+    order_gen = work_item_scratch is None
+
+    if initial_state is not None:
+        state_dtype_src = initial_state.dtype
+    elif output_state is not None:
+        state_dtype_src = output_state.dtype
+    else:
+        state_dtype_src = "float32"
+
+    for name, h in (("HQ", HQ), ("HK", HK), ("HV", HV)):
+        if HO % h != 0:
+            raise ValueError(f"{name}={h} must divide sab heads {HO}")
+    q_ratio = HO // HQ
+    k_ratio = HO // HK
+    v_ratio = HO // HV
+    gate_scale_log2 = gate_lower_bound * LOG2_E
+
+    if safe_gate and (a_log is None or dt_bias is None):
+        raise ValueError("safe_gate requires a_log and dt_bias")
+    if dt_bias is not None:
+        validate_tma_tensor("dt_bias", dt_bias)
+    if not safe_gate:
+        a_log = None
+        dt_bias = None
+    cu_stream = cuda_driver.CUstream(int(stream))
+
+    device_index = tensor_device_index(q)
+    if current_device() != device_index:
+        raise ValueError("the active CUDA device must match q.device")
+    device_properties = get_device_properties(device_index)
+    num_sm = device_properties.multi_processor_count
+    cache = get_compiled_cache(
+        str(q.dtype),
+        str(state_dtype_src),
+        str(cu_seqlens.dtype),
+        HQ,
+        HK,
+        HV,
+        use_initial_state,
+        store_final_state,
+        enable_checkpoints,
+        use_qk_l2norm_in_kernel,
+        safe_gate,
+        gate_lower_bound,
+        use_beta_sigmoid_in_kernel,
+        dyn_sched,
+        order_gen,
+        device_index,
+        device_properties.major,
+        device_properties.minor,
+        num_sm,
+    )
+
+    if "compiled" not in cache:
+        io_dtype = get_dtype(q.dtype)
+        state_dtype = get_dtype(state_dtype_src)
+        q_cute = from_dlpack(q, assumed_align=16).mark_layout_dynamic(leading_dim=2)
+        k_cute = from_dlpack(k, assumed_align=16).mark_layout_dynamic(leading_dim=2)
+        v_cute = from_dlpack(v, assumed_align=16).mark_layout_dynamic(leading_dim=2)
+        gate_cute = from_dlpack(gate, assumed_align=16).mark_layout_dynamic(leading_dim=2)
+        a_log_cute = from_dlpack(a_log, assumed_align=4) if a_log is not None else None
+        dt_bias_cute = from_dlpack(dt_bias, assumed_align=16) if dt_bias is not None else None
+        beta_cute = from_dlpack(beta, assumed_align=4).mark_layout_dynamic(leading_dim=1)
+        o_cute = from_dlpack(output, assumed_align=16).mark_layout_dynamic(leading_dim=2)
+        cu_seqlens_cute = from_dlpack(cu_seqlens, assumed_align=8).mark_layout_dynamic()
+
+        state_in_cute = None
+        if use_initial_state:
+            state_in_cute = from_dlpack(initial_state, assumed_align=16).mark_layout_dynamic(leading_dim=3)
+
+        state_out_cute = None
+        if store_final_state:
+            state_out_cute = from_dlpack(output_state, assumed_align=16).mark_layout_dynamic(leading_dim=3)
+
+        work_items_cute = from_dlpack(work_items, assumed_align=16)
+        work_items_cute.mark_compact_shape_dynamic(mode=0, stride_order=(0, 1), divisibility=1)
+        work_count_cute = from_dlpack(work_count, assumed_align=4).mark_layout_dynamic()
+
+        sched_ctr_cute = None
+        if dyn_sched:
+            sched_ctr_cute = from_dlpack(sched_ctr, assumed_align=4).mark_layout_dynamic()
+
+        tensormap_ws_cute = from_dlpack(tensormap_workspace, assumed_align=128).mark_layout_dynamic()
+
+        cache["compiled"] = compile(
+            io_dtype,
+            state_dtype,
+            use_initial_state,
+            store_final_state,
+            enable_checkpoints,
+            use_qk_l2norm_in_kernel,
+            safe_gate,
+            gate_scale_log2,
+            use_beta_sigmoid_in_kernel,
+            q_ratio,
+            k_ratio,
+            v_ratio,
+            HO,
+            dyn_sched,
+            num_sm=num_sm,
+            q_cute=q_cute,
+            k_cute=k_cute,
+            v_cute=v_cute,
+            gate_cute=gate_cute,
+            a_log_cute=a_log_cute,
+            dt_bias_cute=dt_bias_cute,
+            beta_cute=beta_cute,
+            cu_seqlens_cute=cu_seqlens_cute,
+            state_in_cute=state_in_cute,
+            o_cute=o_cute,
+            state_out_cute=state_out_cute,
+            work_items_cute=work_items_cute,
+            work_count_cute=work_count_cute,
+            sched_ctr_cute=sched_ctr_cute,
+            tensormap_ws_cute=tensormap_ws_cute,
+            checkpoint_every_n_tokens=checkpoint_every_n_tokens,
+            scale=scale,
+            stream=cu_stream,
+        )
+
+    compiled = cache["compiled"]
+    state_checkpoints_for_descs = output_state_checkpoints if enable_checkpoints else None
+    if "prologue" not in cache:
+        io_dtype = get_dtype(q.dtype)
+        q_pl = from_dlpack(q, assumed_align=16).mark_layout_dynamic(leading_dim=2)
+        k_pl = from_dlpack(k, assumed_align=16).mark_layout_dynamic(leading_dim=2)
+        v_pl = from_dlpack(v, assumed_align=16).mark_layout_dynamic(leading_dim=2)
+        gate_pl = from_dlpack(gate, assumed_align=16).mark_layout_dynamic(leading_dim=2)
+        o_pl = from_dlpack(output, assumed_align=16).mark_layout_dynamic(leading_dim=2)
+        cu_pl = from_dlpack(cu_seqlens, assumed_align=8).mark_layout_dynamic()
+        ws_pl = from_dlpack(tensormap_workspace, assumed_align=128).mark_layout_dynamic()
+        state_checkpoints_pl = None
+        if state_checkpoints_for_descs is not None:
+            state_checkpoints_pl = from_dlpack(state_checkpoints_for_descs, assumed_align=16).mark_layout_dynamic(leading_dim=3)
+        staging_pl = None
+        if not order_gen:
+            staging_pl = from_dlpack(work_item_scratch, assumed_align=16)
+            staging_pl.mark_compact_shape_dynamic(mode=0, stride_order=(0, 1), divisibility=1)
+        work_items_pl = from_dlpack(work_items, assumed_align=16)
+        work_items_pl.mark_compact_shape_dynamic(mode=0, stride_order=(0, 1), divisibility=1)
+        work_count_pl = from_dlpack(work_count, assumed_align=4).mark_layout_dynamic()
+        sched_pl = None
+        if dyn_sched:
+            sched_pl = from_dlpack(sched_ctr, assumed_align=4).mark_layout_dynamic()
+        cache["prologue"] = cute.compile(
+            prologue,
+            io_dtype,
+            CFG.B_T,
+            order_gen,
+            dyn_sched,
+            q_pl,
+            k_pl,
+            v_pl,
+            gate_pl,
+            o_pl,
+            state_checkpoints_pl,
+            cu_pl,
+            staging_pl,
+            work_count_pl,
+            work_items_pl,
+            sched_pl,
+            ws_pl,
+            cutlass.Int32(checkpoint_every_n_tokens),
+            cu_stream,
+            options="--enable-tvm-ffi",
+        )
+    cache["prologue"](
+        q,
+        k,
+        v,
+        gate,
+        output,
+        state_checkpoints_for_descs,
+        cu_seqlens,
+        work_item_scratch if not order_gen else None,
+        work_count,
+        work_items,
+        sched_ctr,
+        tensormap_workspace,
+        checkpoint_every_n_tokens,
+        cu_stream,
+    )
+    compiled(
+        q,
+        k,
+        v,
+        gate,
+        a_log,
+        dt_bias,
+        beta,
+        cu_seqlens,
+        initial_state if use_initial_state else None,
+        output,
+        output_state if store_final_state else None,
+        work_items,
+        work_count,
+        sched_ctr,
+        tensormap_workspace,
+        checkpoint_every_n_tokens,
+        scale,
+        cu_stream,
+    )

--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_recompute_config.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_recompute_config.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# This kernel is derived from cuDNN, NVIDIA Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Kimi Delta Attention (KDA) Cutlass DSL recompute (state/H-only) kernel
+config (fixed compile-time constants).  The BT=16 KDA schedule uses a 16-warp
+(512-thread) specialization with a per-key-channel decay; the derived
+SMEM/TMEM sizes and offsets are stamped by ``build_cfg`` in
+``kda_recompute_f16.py``.
+
+Target arch: Blackwell SM100 (GB200) / SM103 (GB300).
+"""
+
+from dataclasses import dataclass
+from typing import Tuple
+
+
+@dataclass(frozen=True)
+class Cfg:
+    # --- tile shape ---
+    B_T: int = 16  # chunk-inner token tile (BT=16 KDA schedule)
+    D_K: int = 128  # query/key head dim
+    D_V: int = 128  # value head dim
+
+    # --- warp assignments (16 warps = 512 threads) ---
+    COMPUTE_GROUP_0_WARP_IDS: Tuple[int, ...] = (0, 1, 2, 3, 4, 5, 6, 7)  # decay-operand materialize (2-group ping-pong)
+    COMPUTE_GROUP_1_WARP_IDS: Tuple[int, ...] = (8, 9, 10, 11)  # value-side TMEM / state staging
+    SUPER_MMA_WARP_ID: int = 12  # register-MMA KK + Neumann T_inv
+    TCGEN05_MMA_WARP_ID: int = 13  # tcgen05 state GEMMs
+    TMA_WARP_ID: int = 14  # k/v/gate TMA loads
+    EPILOGUE_WARP_ID: int = 15  # checkpoint TMA store
+
+    # --- register split ---
+    NUM_REGS_COMPUTE_GROUP_0: int = 160
+    NUM_REGS_COMPUTE_GROUP_1: int = 136
+    NUM_REGS_OTHER: int = 56
+
+    THREADS_PER_WARP: int = 32
+
+    BUFFER_ALIGN_BYTES: int = 1024
+
+    # --- SMEM / TMEM ring stage counts ---
+    SMEM_RAW_STAGES: int = 8
+    SMEM_SCHED_STAGES: int = 8
+    SMEM_DECAY_STAGES: int = 2
+    SMEM_INTERMEDIATE_STAGES: int = 2
+    SMEM_STATE_SCALE_DIAG_STAGES: int = 4
+    QK_SCALE_READY_STAGES: int = 4
+
+    CLUSTER_SHAPE_MNK: Tuple[int, int, int] = (1, 1, 1)
+
+
+CFG = Cfg()

--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_recompute_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_recompute_f16.py
@@ -1,0 +1,2811 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# This kernel is derived from cuDNN, NVIDIA Corporation.
+# Modified by Attention Gym in 2026: imports were relocated into this package.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Chunked Kimi Delta Attention (KDA) recompute (state/checkpoints-only) kernel for
+Blackwell SM100/SM103 (Cutlass DSL), BT=16 tiling with a per-key-channel decay.
+Framework-neutral entry ``chunk_kda_recompute_sm100``.
+
+Persistent kernel: the grid is the SM count and every warp role
+runs a tile-scheduler loop (``decode_work_item``); a tile is one (batch,
+head) sequence, or one split-K work item computing chunks ``[cstart, wend)``
+and writing checkpoints only for the owned ``[wstart, wend)`` (see
+``common/split_k.py``; warmup chunks rebuild the incoming state from
+zero).  All ring stage/phase bookkeeping runs on cumulative per-CTA chunk
+counters so pipelines flow seamlessly across tiles.
+
+Pipeline (direct CUTLASS primitives, chunk_idx-size 16 KDA schedule):
+
+  load K/V/Gate/Beta
+  optional in-kernel L2-norm of K (L2NORM specialization)
+  exp2(g), exp2(-g), stage final-token exp2(g) as exp2(g_last)
+  super-MMA: KK/Neumann inverse + apply Beta
+  tcgen05-MMA: State*K / U / state update
+  store periodic state checkpoints, final state
+
+ABI: k `[T, HK, DK]`, v `[T, HV, DV]`, gate
+`[T, HO, DK]` fp32 (natural-log decay unless SAFE_GATE, which applies the
+safe-gate transform from raw gate + a_log/dt_bias), beta `[T, HO]` fp32
+post-sigmoid, cu_seqlens int32, states/checkpoints `[N, HO, DV, DK]` (VK, k
+contiguous).
+GQA/GVA head broadcast follows repeat_interleave: source head =
+head_idx // (HO // H_x).  State presence, L2NORM, SAFE_GATE, checkpoints, and the
+head ratios are compile-time specializations.
+
+Warp assignments (16 warps = 512 threads):
+  warps 0-7  : compute group 0 - Gate prefix scan + decay/restore operands
+  warps 8-11 : compute group 1 - TMEM value side, state stores
+  warp  12   : super-MMA       - register-MMA KK^T + Neumann inverse
+  warp  13   : tcgen05-MMA     - the four state GEMMs + the TMEM lifecycle
+  warp  14   : TMA load        - per-chunk input G->S loads
+  warp  15   : epilogue        - the checkpoint TMA store
+
+SMEM layout:
+  Buffer                    Bytes  Stages
+  K / V raw                 32768  8       <-- SW128 TMA ring (io dtype)
+  Gate raw                  65536  8       <-- fp32 prefix-scan source
+  Beta                        512  8       <-- fp32 per-token scalars
+  K_inv                      8192  2       <-- token-major ldmatrix/tcgen05 B operand
+  K decay                    8192  2       <-- tcgen05 SW128 K-box-major A/B operands
+  K restore                  8192  2       <-- tcgen05 B operand for the state update
+  state-scale diag          16384  4       <-- per-k-atom decay diagonal blocks
+  T_inv                      2048  2       <-- SW32 16x16 register-MMA tiles
+
+TMEM layout (240 of 512 columns):
+  Buffer          Cols     Purpose
+  state           0-127    state[DK,DV] fp32 recurrent state
+  state inp       128-191  packed b16 A operand view of the state
+  state_k_acc     192-207  State*K fp32 accumulator
+  u_acc           208-223  U fp32 accumulator
+  Y               224-231  packed b16 A operand: Beta * (V - State*K)
+  U input         232-239  packed b16 A operand: the b16 U repack
+
+GEMM schedule (tcgen05-MMA warp, in issue order per chunk):
+  State*K -> state_k_acc
+  State decay (diag blocks)
+  U = Y(T) @ T_inv -> u_acc
+  final_state += U @ K_restore
+
+Requires the public CuTeDSL 4.7 API, including `cutlass.experimental.*`.
+"""
+
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import NamedTuple, Type
+
+import cuda.bindings.driver as cuda_driver
+import cutlass
+import cutlass.experimental.cuda as cuda
+import cutlass.experimental.primitives as nvvm
+import cutlass.cute as cute
+from cutlass.cute.runtime import from_dlpack
+
+from attn_gym.linear._delta_rule.mega.kernels.common.split_k import ORDER_CAPACITY, ORDER_ELEMS, ORDER_THREADS, decode_work_item, order_body
+from attn_gym.linear._delta_rule.mega.kernels.common.host import get_dtype
+from attn_gym.linear._delta_rule.mega.kernels.compat import (
+    checkpoint_capacity_bound,
+    current_device,
+    get_device_properties,
+    tensor_device_index,
+    validate_tma_tensor,
+)
+from attn_gym.linear._delta_rule.mega.kernels.common.thd import (
+    TENSOR_MAP_QWORDS,
+    emit_checkpoint_seq_descs,
+    emit_seq_load_descs,
+)
+from .kda_recompute_config import CFG
+
+from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.barrier import (
+    advance,
+    MBarrier,
+    PipelineState,
+    Producer,
+)
+from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.handles import MmaDesc, SmemTile, tma_slice_runtime_desc
+from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.mma import mma_step, mma_ts_step
+from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.swizzle import swizzle_lin_S, swizzle_xor_128b
+from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.tma import tma_load_tile, tma_store_commit, tma_store_tile, tma_store_wait, tma_tensormap_acquire
+from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.pointwise import (
+    opaque_f32_zero,
+    f16x2_to_f32,
+    fadd2,
+    fmul2,
+    ffma2,
+    movmatrix_16b,
+    mul_f16x2,
+    fp32_to_fp16,
+    sub_f16x2,
+)
+
+LOG2_E: float = 1.4426950408889634
+
+
+DEFAULT_GATE_LOWER_BOUND: float = -5.0
+
+
+# Host-side API defaults.
+
+
+L2_NORM_EPS: float = 1.0e-12
+
+
+class KdaBars(NamedTuple):
+    """Every inter-warp handoff as an ``MBarrier`` over its ring.  Consumers track ``(idx, phase)`` inline; the producer tag selects
+    the arrive lowering (``TMA_LOAD``/``MMA_COMMIT``/``THREAD``)."""
+
+    mb_k_ready: MBarrier
+    mb_k_done: MBarrier
+    mb_v_ready: MBarrier
+    mb_v_done: MBarrier
+    mb_gate_ready: MBarrier
+    mb_gate_done: MBarrier
+
+    mb_beta_ready: MBarrier
+    mb_beta_done: MBarrier
+
+    mb_state_k_acc_ready: MBarrier
+    mb_u_acc_ready: MBarrier
+
+    mb_state_inp_ready: MBarrier
+    mb_y_inp_ready: MBarrier
+    mb_u_inp_ready: MBarrier
+
+    mb_t_inv_ready: MBarrier
+    mb_t_inv_done: MBarrier
+    mb_qk_scale_ready: MBarrier
+    mb_state_scale_diag_done: MBarrier
+    mb_k_decay_inv_cg0_ready: MBarrier
+    mb_decay_tcgen05_done: MBarrier
+    mb_decay_super_done: MBarrier
+    mb_k_restore_done: MBarrier
+
+    mb_state_acc_done: MBarrier
+    mb_state_acc_read_done: MBarrier
+    mb_tmem_done: MBarrier
+
+    mb_checkpoint_tmastg_ready: MBarrier
+    mb_checkpoint_tmastg_done: MBarrier
+
+    mb_sched_ready: MBarrier
+    mb_sched_done: MBarrier
+
+
+def make_kda_bars(cfg) -> KdaBars:
+    """Bars factory.  MUST be called from inside ``kernel`` (allocates the
+    mbarrier rings in SMEM ahead of the data buffers)."""
+
+    def alloc(n):
+        return cutlass.Array(cutlass.Int64, n, space=cutlass.AddressSpace.smem, alignment=8)
+
+    WARP = cfg.threads_per_warp
+    CG0_GROUP_THREADS = cfg.cg0_warps_per_group * WARP
+    CG1_THREADS = len(cfg.compute_group_1_warp_ids) * WARP
+    SCHED_CONSUMER_WARPS = cfg.threads_per_cta // WARP - 1
+
+    return KdaBars(
+        mb_k_ready=MBarrier(alloc(cfg.smem_raw_stages), stages=cfg.smem_raw_stages, init_count=1, producer=Producer.TMA_LOAD),
+        mb_k_done=MBarrier(alloc(cfg.smem_raw_stages), stages=cfg.smem_raw_stages, init_count=CG0_GROUP_THREADS, producer=Producer.THREAD),
+        mb_v_ready=MBarrier(alloc(cfg.smem_raw_stages), stages=cfg.smem_raw_stages, init_count=1, producer=Producer.TMA_LOAD),
+        mb_v_done=MBarrier(alloc(cfg.smem_raw_stages), stages=cfg.smem_raw_stages, init_count=CG1_THREADS, producer=Producer.THREAD),
+        mb_gate_ready=MBarrier(alloc(cfg.smem_raw_stages), stages=cfg.smem_raw_stages, init_count=1, producer=Producer.TMA_LOAD),
+        mb_gate_done=MBarrier(alloc(cfg.smem_raw_stages), stages=cfg.smem_raw_stages, init_count=CG0_GROUP_THREADS, producer=Producer.THREAD),
+        mb_beta_ready=MBarrier(alloc(cfg.smem_raw_stages), stages=cfg.smem_raw_stages, init_count=WARP, producer=Producer.THREAD),
+        mb_beta_done=MBarrier(alloc(cfg.smem_raw_stages), stages=cfg.smem_raw_stages, init_count=WARP + CG1_THREADS, producer=Producer.THREAD),
+        mb_state_k_acc_ready=MBarrier(alloc(1), stages=1, init_count=1, producer=Producer.MMA_COMMIT),
+        mb_u_acc_ready=MBarrier(alloc(1), stages=1, init_count=1, producer=Producer.MMA_COMMIT),
+        mb_state_inp_ready=MBarrier(alloc(1), stages=1, init_count=CG1_THREADS, producer=Producer.THREAD),
+        mb_y_inp_ready=MBarrier(alloc(1), stages=1, init_count=CG1_THREADS, producer=Producer.THREAD),
+        mb_u_inp_ready=MBarrier(alloc(1), stages=1, init_count=CG1_THREADS, producer=Producer.THREAD),
+        mb_t_inv_ready=MBarrier(alloc(cfg.smem_intermediate_stages), stages=cfg.smem_intermediate_stages, init_count=WARP, producer=Producer.THREAD),
+        mb_t_inv_done=MBarrier(alloc(cfg.smem_intermediate_stages), stages=cfg.smem_intermediate_stages, init_count=1, producer=Producer.MMA_COMMIT),
+        mb_qk_scale_ready=MBarrier(
+            alloc(cfg.qk_scale_ready_stages),
+            stages=cfg.qk_scale_ready_stages,
+            init_count=CG0_GROUP_THREADS,
+            producer=Producer.THREAD,
+        ),
+        mb_state_scale_diag_done=MBarrier(
+            alloc(cfg.smem_state_scale_diag_stages),
+            stages=cfg.smem_state_scale_diag_stages,
+            init_count=1,
+            producer=Producer.MMA_COMMIT,
+        ),
+        mb_k_decay_inv_cg0_ready=MBarrier(alloc(cfg.smem_decay_stages), stages=cfg.smem_decay_stages, init_count=CG0_GROUP_THREADS, producer=Producer.THREAD),
+        mb_decay_tcgen05_done=MBarrier(alloc(cfg.smem_decay_stages), stages=cfg.smem_decay_stages, init_count=1, producer=Producer.MMA_COMMIT),
+        mb_decay_super_done=MBarrier(alloc(cfg.smem_decay_stages), stages=cfg.smem_decay_stages, init_count=WARP, producer=Producer.THREAD),
+        mb_k_restore_done=MBarrier(alloc(cfg.smem_decay_stages), stages=cfg.smem_decay_stages, init_count=1, producer=Producer.MMA_COMMIT),
+        mb_state_acc_done=MBarrier(alloc(1), stages=1, init_count=1, producer=Producer.MMA_COMMIT),
+        mb_state_acc_read_done=MBarrier(alloc(1), stages=1, init_count=CG1_THREADS, producer=Producer.THREAD),
+        mb_tmem_done=MBarrier(alloc(1), stages=1, init_count=CG1_THREADS, producer=Producer.THREAD),
+        mb_checkpoint_tmastg_ready=MBarrier(
+            alloc(cfg.smem_checkpoint_stages), stages=cfg.smem_checkpoint_stages, init_count=CG1_THREADS, producer=Producer.THREAD
+        ),
+        mb_checkpoint_tmastg_done=MBarrier(alloc(cfg.smem_checkpoint_stages), stages=cfg.smem_checkpoint_stages, init_count=WARP, producer=Producer.THREAD),
+        mb_sched_ready=MBarrier(alloc(cfg.sched_stages), stages=cfg.sched_stages, init_count=1, producer=Producer.THREAD),
+        mb_sched_done=MBarrier(
+            alloc(cfg.sched_stages),
+            stages=cfg.sched_stages,
+            init_count=SCHED_CONSUMER_WARPS,
+            producer=Producer.THREAD,
+        ),
+    )
+
+
+# ---- Dynamic tile scheduler ------------------------------------------------------
+
+
+@cute.jit
+def sched_publish_next(cfg, bars, sSched, mSched, sched_state, tile_idx, num_ctas):
+    """TMA-warp side: pull the next tile off the global ticket, publish it."""
+    if cutlass.const_expr(cfg.dyn_sched):
+        bars.mb_sched_done[sched_state.idx].wait(sched_state.phase)
+        if nvvm.elect_sync():
+            fetched = cutlass.Int32(nvvm.atomicrmw("add", mSched.iterator, cutlass.Int32(1), mem_order="relaxed", syncscope="gpu"))
+            sSched[sched_state.idx] = num_ctas + fetched
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+        next_tile = sSched[sched_state.idx]
+        if nvvm.elect_sync():
+            bars.mb_sched_ready[sched_state.idx].arrive()
+        return next_tile, advance(sched_state, cfg.sched_stages)
+    return tile_idx + num_ctas, sched_state
+
+
+@cute.jit
+def sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas):
+    """Consumer side: read the TMA warp's published next tile."""
+    if cutlass.const_expr(cfg.dyn_sched):
+        bars.mb_sched_ready[sched_state.idx].wait(sched_state.phase)
+        next_tile = sSched[sched_state.idx]
+        if nvvm.elect_sync():
+            bars.mb_sched_done[sched_state.idx].arrive()
+        return next_tile, advance(sched_state, cfg.sched_stages)
+    return tile_idx + num_ctas, sched_state
+
+
+@cute.jit
+def tmaldg_warp(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    n_desc,
+    cu_seqlens,
+    mWorkItems,
+    mSched,
+    sSched,
+    lane,
+    sK_raw,
+    sV_raw,
+    sGate_raw,
+    desc_k_base,
+    desc_v_base,
+    desc_gate_base,
+    bars,
+) -> None:
+    """TMA-LDG warp role (warp 14): persistent scheduler loop issuing the
+    per-chunk K/V/Gate G->S loads."""
+    elect_one = nvvm.elect_sync()
+    nvvm.setmaxregister(cfg.num_regs_other, nvvm.SetMaxRegisterAction.DECREASE)
+    sK_tma = SmemTile(
+        base=sK_raw,
+        elems_per_stage=(cfg.d_k * cfg.b_t),
+        stages=cfg.smem_raw_stages,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=0,
+        tma_loads_per_tile=(cfg.d_k // 64),
+        tma_granu_elems=64,
+        tma_subtile_stride_elems=(cfg.b_t * 64),
+    )
+    sV_tma = SmemTile(
+        base=sV_raw,
+        elems_per_stage=(cfg.d_v * cfg.b_t),
+        stages=cfg.smem_raw_stages,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=0,
+        tma_loads_per_tile=(cfg.d_k // 64),
+        tma_granu_elems=64,
+        tma_subtile_stride_elems=(cfg.b_t * 64),
+    )
+    sGate_tma = SmemTile(
+        base=sGate_raw,
+        elems_per_stage=(cfg.d_k * cfg.b_t),
+        stages=cfg.smem_raw_stages,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=0,
+        tma_loads_per_tile=(cfg.d_k // 32),
+        tma_granu_elems=32,
+        tma_subtile_stride_elems=(cfg.b_t * 32),
+    )
+    raw_index = PipelineState.start(phase=1)
+    sched_state = PipelineState.start(phase=1)
+    packed_tokens = cutlass.Int32(cu_seqlens[n_desc])
+    tile_idx = cutlass.Int32(bidx)
+    while tile_idx < total_tiles:
+        batch_idx, head_idx, batch_start, batch_end, seqlen_b, num_chunks_b, wstart, wend, cstart, cend = decode_work_item(cfg, tile_idx, mWorkItems)
+        head_o = head_idx
+        head_k = head_idx if cfg.k_ratio == 1 else head_idx // cutlass.Int32(cfg.k_ratio)
+        head_v = head_idx if cfg.v_ratio == 1 else head_idx // cutlass.Int32(cfg.v_ratio)
+        slot = batch_idx * cutlass.Int32(TENSOR_MAP_QWORDS)
+        desc_k_slot = (desc_k_base + slot).tospace(cutlass.AddressSpace.generic)
+        desc_v_slot = (desc_v_base + slot).tospace(cutlass.AddressSpace.generic)
+        desc_gate_slot = (desc_gate_base + slot).tospace(cutlass.AddressSpace.generic)
+        if elect_one:
+            tma_tensormap_acquire(desc_k_slot)
+            tma_tensormap_acquire(desc_v_slot)
+            tma_tensormap_acquire(desc_gate_slot)
+        use_packed_coords = batch_end == packed_tokens
+        for chunk_idx in cutlass.range(cstart, wend, 1, unroll=1):
+            chunk_start = chunk_idx * cfg.b_t
+            input_chunk_start = (
+                batch_start + chunk_start if use_packed_coords else chunk_start
+            )
+
+            # ---- K load ----------------------------------------------------------
+            bars.mb_k_done[raw_index.idx].wait(raw_index.phase)
+            if elect_one:
+                bars.mb_k_ready[raw_index.idx].arrive(n_bytes=cfg.tma_k_bytes)
+            k_slice = tma_slice_runtime_desc(
+                desc_k_slot, cutlass.Int32(0), head_k, input_chunk_start
+            )
+            tma_load_tile(sK_tma[raw_index.idx], k_slice, bars.mb_k_ready[raw_index.idx].smem_ptr, acquire=False)
+
+            # ---- Gate load -------------------------------------------------------
+            bars.mb_gate_done[raw_index.idx].wait(raw_index.phase)
+            if elect_one:
+                bars.mb_gate_ready[raw_index.idx].arrive(n_bytes=cfg.tma_gate_bytes)
+            gate_slice = tma_slice_runtime_desc(
+                desc_gate_slot, cutlass.Int32(0), head_o, input_chunk_start
+            )
+            tma_load_tile(sGate_tma[raw_index.idx], gate_slice, bars.mb_gate_ready[raw_index.idx].smem_ptr, acquire=False)
+
+            # ---- V load ----------------------------------------------------------
+            bars.mb_v_done[raw_index.idx].wait(raw_index.phase)
+            if elect_one:
+                bars.mb_v_ready[raw_index.idx].arrive(n_bytes=cfg.tma_v_bytes)
+            v_slice = tma_slice_runtime_desc(
+                desc_v_slot, cutlass.Int32(0), head_v, input_chunk_start
+            )
+            tma_load_tile(sV_tma[raw_index.idx], v_slice, bars.mb_v_ready[raw_index.idx].smem_ptr, acquire=False)
+
+            raw_index = advance(raw_index, cfg.smem_raw_stages)
+        tile_idx, sched_state = sched_publish_next(cfg, bars, sSched, mSched, sched_state, tile_idx, num_ctas)
+
+
+@cute.jit
+def super_mma_warp(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    cu_seqlens,
+    mWorkItems,
+    sSched,
+    lane,
+    sK_inv_raw,
+    sIntermediate_raw,
+    sBeta_raw,
+    sK_decay_raw,
+    bars,
+) -> None:
+    """Super-MMA warp role (warp 12): persistent scheduler loop computing the
+    register-MMA Neumann-series T_inv."""
+    nvvm.setmaxregister(cfg.num_regs_other, nvvm.SetMaxRegisterAction.DECREASE)
+    raw_index = PipelineState.start(phase=0)
+    t_inv_free = PipelineState.start(phase=1)
+    k_decay_ready = PipelineState.start(phase=0)
+
+    # ---- ldmatrix/stmatrix lane decode -------------------------------------------
+    rhs_row_coord = lane % 8 + (cutlass.Int32(8) if (lane // 16) else cutlass.Int32(0))
+    rhs_col_offset = cutlass.Int32(8) if ((lane // 8) % 2) else cutlass.Int32(0)
+    lhs_row_coord = lane % 8 + (cutlass.Int32(8) if ((lane // 8) % 2) else cutlass.Int32(0))
+    lhs_col_offset = cutlass.Int32(8) if ((lane // 8) // 2) else cutlass.Int32(0)
+    decay_key_mask = cutlass.Int32(8)
+    stsm_row_coord = lane & 7
+    stsm_col_coord = cutlass.Int32(0)
+    if (lane // 8) & 1:
+        stsm_row_coord = stsm_row_coord + cutlass.Int32(8)
+    if lane // 8 >= 2:
+        stsm_col_coord = cutlass.Int32(8)
+    stsm_idx = swizzle_lin_S(stsm_row_coord * cfg.b_t + (stsm_col_coord ^ (cfg.b_t // 2)), bbits=1, mbase=3, sshift=3)
+    cum_chunk_base = cutlass.Int32(0)
+    sched_state = PipelineState.start(phase=0)
+    tile_idx = cutlass.Int32(bidx)
+    while tile_idx < total_tiles:
+        batch_idx, head_idx, batch_start, batch_end, seqlen_b, num_chunks_b, wstart, wend, cstart, cend = decode_work_item(cfg, tile_idx, mWorkItems)
+        num_chunks_tile = wend - cstart  # processed chunks; ring bookkeeping runs on cum_chunk_base + local_chunk_idx
+        for local_chunk_idx in cutlass.range(num_chunks_tile, unroll=1):
+            cum_chunk = cum_chunk_base + local_chunk_idx
+            decay_stage = k_decay_ready.idx
+            intermediate_stage = t_inv_free.idx
+            sBeta_ptr = sBeta_raw.data_ptr() + raw_index.idx * cfg.b_t
+            sK_inv_ptr = sK_inv_raw.data_ptr() + decay_stage * (cfg.b_t * cfg.d_k)
+            sK_decay_ptr = sK_decay_raw.data_ptr() + decay_stage * (cfg.d_k * cfg.b_t)
+            sIntermediate_ptr = sIntermediate_raw.data_ptr() + intermediate_stage * (2 * cfg.b_t * cfg.b_t)
+
+            bars.mb_k_decay_inv_cg0_ready[decay_stage].wait(k_decay_ready.phase)
+            k_decay_ready = advance(k_decay_ready, cfg.smem_decay_stages)
+
+            # ---- KK = K_decay @ K_inv^T ------------------------------------------
+            kk_acc = cutlass.Array(cutlass.Float32, 8, alignment=16)
+            for accum_idx in cutlass.range_constexpr(8):
+                kk_acc[accum_idx] = cutlass.Float32(0.0)
+
+            for k_block in cutlass.range_constexpr((cfg.d_k // 16)):
+                # Load B operand
+                k_inv_col = k_block * 16 + rhs_col_offset
+                k_inv_segment = k_inv_col // 64
+                rhs_frag = nvvm.ldmatrix(
+                    sK_inv_ptr
+                    + k_inv_segment * (cfg.b_t * 64)
+                    + rhs_row_coord * 64
+                    + swizzle_xor_128b(rhs_row_coord, k_inv_col - k_inv_segment * 64, elem_bytes=2),
+                    4,
+                    nvvm.MMALayout.ROW,
+                )
+                # Load A operand
+                storage_key = (k_block * 16 + lhs_col_offset) ^ decay_key_mask
+                storage_slice = storage_key // 64
+                kk_lhs_frag = nvvm.ldmatrix(
+                    sK_decay_ptr
+                    + storage_slice * (cfg.b_t * 64)
+                    + swizzle_xor_128b(lhs_row_coord, lhs_row_coord * 64 + storage_key - storage_slice * 64, elem_bytes=2),
+                    4,
+                    nvvm.MMALayout.ROW,
+                )
+
+                mma_step(
+                    kk_acc,
+                    (kk_lhs_frag[0], kk_lhs_frag[1], kk_lhs_frag[2], kk_lhs_frag[3]),
+                    (rhs_frag[0], rhs_frag[1], rhs_frag[2], rhs_frag[3]),
+                    k_step=0,
+                    M=16,
+                    N=16,
+                    ab_dtype=cfg.io_dtype,
+                )
+
+            # ---- L = Beta * tril(KK, -1) fragment --------------------------------
+            bars.mb_beta_ready[raw_index.idx].wait(raw_index.phase)
+            row_lo = lane // 4
+            row_hi = row_lo + cutlass.Int32(8)
+            beta_lo = (sBeta_ptr + row_lo).load().to(cutlass.Float32)
+            beta_hi = (sBeta_ptr + row_hi).load().to(cutlass.Float32)
+            l_regs = cutlass.Array(cutlass.Float32, 8, alignment=16)
+            for accum_idx in cutlass.range_constexpr(8):
+                row_coord = row_hi if cutlass.const_expr(accum_idx % 4 >= 2) else row_lo
+                col_coord = (accum_idx // 4) * 8 + 2 * (lane % 4)
+                if cutlass.const_expr(accum_idx % 2 == 1):
+                    col_coord = col_coord + cutlass.Int32(1)
+                l_regs[accum_idx] = kk_acc[accum_idx] if row_coord > col_coord else cutlass.Float32(0.0)
+            for pair in cutlass.range_constexpr(4):
+                beta_scale = beta_hi if cutlass.const_expr(pair % 2 == 1) else beta_lo
+                l_regs[2 * pair], l_regs[2 * pair + 1] = fmul2(l_regs[2 * pair], l_regs[2 * pair + 1], beta_scale, beta_scale)
+            bars.mb_beta_done[raw_index.idx].arrive()
+            l_a0 = fp32_to_fp16(l_regs[0], l_regs[1], dtype=cfg.io_dtype)
+            l_a1 = fp32_to_fp16(l_regs[2], l_regs[3], dtype=cfg.io_dtype)
+            l_a2 = fp32_to_fp16(l_regs[4], l_regs[5], dtype=cfg.io_dtype)
+            l_a3 = fp32_to_fp16(l_regs[6], l_regs[7], dtype=cfg.io_dtype)
+            l_values = cutlass.Vector.from_elements((l_a0, l_a1, l_a2, l_a3), cutlass.Int32).bitcast(cfg.io_dtype).to(cutlass.Float32)
+
+            # ---- T_inv = I - L, then three Neumann doubling rounds ---------------
+            tinv_acc = cutlass.Array(cutlass.Float32, 8, alignment=16)
+            for accum_idx in cutlass.range_constexpr(8):
+                row_coord = row_lo
+                if cutlass.const_expr(accum_idx % 4 >= 2):
+                    row_coord = row_hi
+                col_coord = (accum_idx // 4) * 8 + 2 * (lane % 4)
+                if cutlass.const_expr(accum_idx % 2 == 1):
+                    col_coord = col_coord + cutlass.Int32(1)
+                eye = cutlass.Float32(1.0) if row_coord == col_coord else cutlass.Float32(0.0)
+                tinv_acc[accum_idx] = eye - l_values[accum_idx]
+
+            lpow_a0, lpow_a1, lpow_a2, lpow_a3 = l_a0, l_a1, l_a2, l_a3
+            mov_lpow0, mov_lpow1, mov_lpow2, mov_lpow3 = movmatrix_16b(l_a0), movmatrix_16b(l_a1), movmatrix_16b(l_a2), movmatrix_16b(l_a3)
+            for _round in cutlass.range_constexpr(3):
+                # ---- Lpow = Lpow @ Lpow ------------------------------------------
+                sq_acc = cutlass.Array(cutlass.Float32, 8, alignment=16)
+                for accum_idx in cutlass.range_constexpr(8):
+                    sq_acc[accum_idx] = cutlass.Float32(0.0)
+                mma_step(
+                    sq_acc,
+                    (lpow_a0, lpow_a1, lpow_a2, lpow_a3),
+                    (mov_lpow0, mov_lpow1, mov_lpow2, mov_lpow3),
+                    k_step=0,
+                    M=16,
+                    N=16,
+                    ab_dtype=cfg.io_dtype,
+                )
+                lpow_a0 = fp32_to_fp16(sq_acc[0], sq_acc[1], dtype=cfg.io_dtype)
+                lpow_a1 = fp32_to_fp16(sq_acc[2], sq_acc[3], dtype=cfg.io_dtype)
+                lpow_a2 = fp32_to_fp16(sq_acc[4], sq_acc[5], dtype=cfg.io_dtype)
+                lpow_a3 = fp32_to_fp16(sq_acc[6], sq_acc[7], dtype=cfg.io_dtype)
+                mov_lpow0, mov_lpow1, mov_lpow2, mov_lpow3 = movmatrix_16b(lpow_a0), movmatrix_16b(lpow_a1), movmatrix_16b(lpow_a2), movmatrix_16b(lpow_a3)
+                # ---- T_inv += T_inv @ Lpow ---------------------------------------
+                upd_acc = cutlass.Array(cutlass.Float32, 8, alignment=16)
+                for accum_idx in cutlass.range_constexpr(8):
+                    upd_acc[accum_idx] = cutlass.Float32(0.0)
+                tinv_p0 = fp32_to_fp16(tinv_acc[0], tinv_acc[1], dtype=cfg.io_dtype)
+                tinv_p1 = fp32_to_fp16(tinv_acc[2], tinv_acc[3], dtype=cfg.io_dtype)
+                tinv_p2 = fp32_to_fp16(tinv_acc[4], tinv_acc[5], dtype=cfg.io_dtype)
+                tinv_p3 = fp32_to_fp16(tinv_acc[6], tinv_acc[7], dtype=cfg.io_dtype)
+                mma_step(
+                    upd_acc,
+                    (tinv_p0, tinv_p1, tinv_p2, tinv_p3),
+                    (mov_lpow0, mov_lpow1, mov_lpow2, mov_lpow3),
+                    k_step=0,
+                    M=16,
+                    N=16,
+                    ab_dtype=cfg.io_dtype,
+                )
+                tinv_lo0, tinv_hi0 = f16x2_to_f32(tinv_p0, dtype=cfg.io_dtype)
+                tinv_lo1, tinv_hi1 = f16x2_to_f32(tinv_p1, dtype=cfg.io_dtype)
+                tinv_lo2, tinv_hi2 = f16x2_to_f32(tinv_p2, dtype=cfg.io_dtype)
+                tinv_lo3, tinv_hi3 = f16x2_to_f32(tinv_p3, dtype=cfg.io_dtype)
+                tinv_acc[0], tinv_acc[1] = fadd2(tinv_lo0, tinv_hi0, upd_acc[0], upd_acc[1])
+                tinv_acc[2], tinv_acc[3] = fadd2(tinv_lo1, tinv_hi1, upd_acc[2], upd_acc[3])
+                tinv_acc[4], tinv_acc[5] = fadd2(tinv_lo2, tinv_hi2, upd_acc[4], upd_acc[5])
+                tinv_acc[6], tinv_acc[7] = fadd2(tinv_lo3, tinv_hi3, upd_acc[6], upd_acc[7])
+
+            bars.mb_t_inv_done[intermediate_stage].wait(t_inv_free.phase)
+            t_inv_free = advance(t_inv_free, cfg.smem_intermediate_stages)
+            nvvm.stmatrix(
+                sIntermediate_ptr + (cfg.b_t * cfg.b_t) + stsm_idx,
+                [
+                    fp32_to_fp16(tinv_acc[0], tinv_acc[1], dtype=cfg.io_dtype),
+                    fp32_to_fp16(tinv_acc[2], tinv_acc[3], dtype=cfg.io_dtype),
+                    fp32_to_fp16(tinv_acc[4], tinv_acc[5], dtype=cfg.io_dtype),
+                    fp32_to_fp16(tinv_acc[6], tinv_acc[7], dtype=cfg.io_dtype),
+                ],
+                nvvm.MMALayout.ROW,
+                shape=nvvm.StoreShape.M8N8,
+            )
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_t_inv_ready[intermediate_stage].arrive()
+            bars.mb_decay_super_done[decay_stage].arrive()
+            raw_index = advance(raw_index, cfg.smem_raw_stages)
+        cum_chunk_base += num_chunks_tile
+        tile_idx, sched_state = sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas)
+
+
+@cute.jit
+def tcgen05_mma_warp(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    cu_seqlens,
+    mWorkItems,
+    sSched,
+    sTmem_base,
+    sIntermediate,
+    sK_decay,
+    sK_restore,
+    sState_scale_diag,
+    bars,
+) -> None:
+    """tcgen05-MMA warp role (warp 13): persistent scheduler loop issuing
+    every state GEMM and owning the TMEM lifecycle."""
+    elect_one = nvvm.elect_sync()
+    nvvm.setmaxregister(cfg.num_regs_other, nvvm.SetMaxRegisterAction.DECREASE)
+    nvvm.tcgen05_alloc(sTmem_base, cutlass.Int32(512), group=nvvm.CTAGroup.CTA_1)
+    nvvm.barrier_cta_sync(cfg.tmem_lifecycle_barrier_id, thread_count=cfg.tmem_user_threads)
+    tmem_base = sTmem_base.load()
+    state_inp_ptr = nvvm.make_tmem_ptr(tmem_base + cfg.tmem_state_inp_offset, cutlass.Int8)
+    state_dsts = tuple(nvvm.make_tmem_ptr(tmem_base + cfg.tmem_state_acc_offset + k * 16, cutlass.Float32) for k in range(cfg.d_k // 16))
+    state_k_acc_ptr = nvvm.make_tmem_ptr(tmem_base + cfg.tmem_state_k_acc_offset, cutlass.Float32)
+    u_acc_ptr = nvvm.make_tmem_ptr(tmem_base + cfg.tmem_u_acc_offset, cutlass.Float32)
+    y_inp_ptr = nvvm.make_tmem_ptr(tmem_base + cfg.tmem_y_inp_offset, cutlass.Int8)
+    u_inp_ptr = nvvm.make_tmem_ptr(tmem_base + cfg.tmem_u_inp_offset, cutlass.Int8)
+    state_dst_ptr = nvvm.make_tmem_ptr(tmem_base + cfg.tmem_state_acc_offset, cutlass.Float32)
+    state_inp_index = PipelineState.start(phase=0)
+    state_read_index = PipelineState.start(phase=0)
+    y_inp_index = PipelineState.start(phase=0)
+    u_inp_index = PipelineState.start(phase=0)
+    qk_scale_index = PipelineState.start(phase=0)
+    k_decay_ready = PipelineState.start(phase=0)
+    t_inv_ready = PipelineState.start(phase=0)
+
+    # ---- chunk-invariant GEMM descriptors ----------------------------------------
+    bpe = cfg.io_dtype.width // 8
+    idesc_acc = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.b_t,
+        m_dim=cfg.d_v,
+        b_major=0,
+    )
+    idesc_diag = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=16,
+        m_dim=cfg.d_v,
+        b_major=0,
+    )
+    idesc_final_state = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.d_k,
+        m_dim=cfg.d_v,
+        b_major=1,
+    )
+    bmm_state_desc = MmaDesc(
+        M=cfg.d_v,
+        N=cfg.b_t,
+        K=cfg.d_k,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=False,
+        cta_group=1,
+        idesc=idesc_acc,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    bmm_diag_desc = MmaDesc(
+        M=cfg.d_v,
+        N=16,
+        K=16,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=False,
+        cta_group=1,
+        idesc=idesc_diag,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    bmm_qk_desc = MmaDesc(
+        M=cfg.d_v,
+        N=cfg.b_t,
+        K=cfg.b_t,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=False,
+        cta_group=1,
+        idesc=idesc_acc,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    bmm_final_state_desc = MmaDesc(
+        M=cfg.d_v,
+        N=cfg.d_k,
+        K=cfg.b_t,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=True,
+        cta_group=1,
+        idesc=idesc_final_state,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    STATE_A_SEG = bmm_state_desc.sps_B * bmm_state_desc.tmem_advance_A
+    STATE_B_SEG = bmm_state_desc.smem_subtile_B >> 4
+    cum_chunk_base = cutlass.Int32(0)
+    sched_state = PipelineState.start(phase=0)
+    tile_idx = cutlass.Int32(bidx)
+    while tile_idx < total_tiles:
+        batch_idx, head_idx, batch_start, batch_end, seqlen_b, num_chunks_b, wstart, wend, cstart, cend = decode_work_item(cfg, tile_idx, mWorkItems)
+        num_chunks_tile = wend - cstart
+        for local_chunk_idx in cutlass.range(num_chunks_tile, unroll=1):
+            cum_chunk = cum_chunk_base + local_chunk_idx
+            have_state = cutlass.Boolean(True) if cutlass.const_expr(cfg.use_initial_state) else local_chunk_idx > 0
+            decay_stage = k_decay_ready.idx
+            state_scale_diag_stage = qk_scale_index.idx
+            intermediate_stage = t_inv_ready.idx
+            sK_decay_stage = sK_decay[decay_stage]
+            sK_restore_stage = sK_restore[decay_stage]
+            sState_scale_diag_stage = sState_scale_diag[state_scale_diag_stage]
+            sIntermediate_stage = sIntermediate[intermediate_stage]
+
+            # ---- State*K = State(T) @ K_decay^T ----------------------------------
+            bars.mb_k_decay_inv_cg0_ready[decay_stage].wait(k_decay_ready.phase)
+            k_decay_ready = advance(k_decay_ready, cfg.smem_decay_stages)
+            if have_state:
+                bars.mb_state_inp_ready.wait(state_inp_index.phase)
+                state_inp_index = advance(state_inp_index, 1)
+                desc_k_decay = sK_decay_stage.desc()
+
+                for s in cutlass.range_constexpr(bmm_state_desc.num_subtiles_B):
+                    for k in cutlass.range_constexpr(bmm_state_desc.sps_B):
+                        mma_ts_step(
+                            bmm_state_desc,
+                            state_inp_ptr.subview(s * STATE_A_SEG),
+                            desc_k_decay + s * STATE_B_SEG,
+                            state_k_acc_ptr,
+                            k,
+                            cutlass.Boolean(s + k > 0),
+                        )
+
+                if elect_one:
+                    bars.mb_state_k_acc_ready.arrive(cta_group=1)
+
+            if elect_one:
+                bars.mb_decay_tcgen05_done[decay_stage].arrive(cta_group=1)
+
+            bars.mb_qk_scale_ready[qk_scale_index.idx].wait(qk_scale_index.phase)
+            if cutlass.const_expr(cfg.enable_checkpoints):
+                if have_state:
+                    bars.mb_state_acc_read_done.wait(state_read_index.phase)
+                    state_read_index = advance(state_read_index, 1)
+
+            # ---- State decay = State(T) @ exp2(g_last) diag (per-k-atom blocks) ----
+            if have_state:
+                desc_diag = sState_scale_diag_stage.desc()
+                for k_block in cutlass.range_constexpr(cfg.d_k // 16):
+                    mma_ts_step(
+                        bmm_diag_desc,
+                        state_inp_ptr.subview(k_block * bmm_diag_desc.tmem_advance_A),
+                        desc_diag.advance_start_address(k_block * 256 * 2),
+                        state_dsts[k_block],
+                        0,
+                        cutlass.Boolean(False),
+                    )
+
+            if elect_one:
+                bars.mb_state_scale_diag_done[state_scale_diag_stage].arrive(cta_group=1)
+
+            # ---- U = Y(T) @ T_inv ------------------------------------------------
+            bars.mb_t_inv_ready[intermediate_stage].wait(t_inv_ready.phase)
+            bars.mb_y_inp_ready.wait(y_inp_index.phase)
+            y_inp_index = advance(y_inp_index, 1)
+            desc_t_inv = sIntermediate_stage.shifted((cfg.b_t * cfg.b_t)).desc()
+            mma_ts_step(bmm_qk_desc, y_inp_ptr, desc_t_inv, u_acc_ptr, 0, cutlass.Boolean(False))
+            if elect_one:
+                bars.mb_t_inv_done[intermediate_stage].arrive(cta_group=1)
+                bars.mb_u_acc_ready.arrive(cta_group=1)
+
+            # ---- final_state += U(T) @ K_restore ---------------------------------
+            bars.mb_u_inp_ready.wait(u_inp_index.phase)
+            u_inp_index = advance(u_inp_index, 1)
+            desc_k_restore = sK_restore_stage.desc()
+
+            mma_ts_step(bmm_final_state_desc, u_inp_ptr, desc_k_restore, state_dst_ptr, 0, have_state)
+            if elect_one:
+                bars.mb_k_restore_done[decay_stage].arrive(cta_group=1)
+                bars.mb_state_acc_done.arrive(cta_group=1)
+
+            t_inv_ready = advance(t_inv_ready, cfg.smem_intermediate_stages)
+            qk_scale_index = advance(qk_scale_index, cfg.smem_state_scale_diag_stages)
+
+        cum_chunk_base += num_chunks_tile
+        tile_idx, sched_state = sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas)
+    bars.mb_tmem_done[0].wait(0)
+    nvvm.tcgen05_relinquish_alloc_permit(group=nvvm.CTAGroup.CTA_1)
+    nvvm.tcgen05_dealloc(
+        nvvm.make_tmem_ptr(tmem_base, cutlass.Int8),
+        cutlass.Int32(512),
+        group=nvvm.CTAGroup.CTA_1,
+    )
+
+
+@cute.jit
+def epilogue_warp(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    cu_seqlens,
+    mWorkItems,
+    sSched,
+    sCheckpoint_raw,
+    desc_checkpoint_base,
+    checkpoint_every_n_tokens,
+    bars,
+) -> None:
+    """Epilogue warp role (warp 15): persistent scheduler loop issuing the
+    per-chunk checkpoint TMA stores."""
+    elect_one = nvvm.elect_sync()
+    nvvm.setmaxregister(cfg.num_regs_other, nvvm.SetMaxRegisterAction.DECREASE)
+    if cutlass.const_expr(cfg.enable_checkpoints):
+        sCheckpoint_tma = SmemTile(
+            base=sCheckpoint_raw,
+            elems_per_stage=(cfg.d_k * cfg.d_v),
+            stages=cfg.smem_checkpoint_stages,
+            leading_byte_offset=0,
+            stride_byte_offset=0,
+            layout=0,
+            tma_loads_per_tile=(cfg.d_v // 64),
+            tma_granu_elems=64,
+            tma_subtile_stride_elems=cfg.d_k * 64,
+        )
+    checkpoint_ready_index = PipelineState.start(phase=0)
+    sched_state = PipelineState.start(phase=0)
+    tile_idx = cutlass.Int32(bidx)
+    while tile_idx < total_tiles:
+        batch_idx, head_idx, batch_start, batch_end, seqlen_b, num_chunks_b, wstart, wend, cstart, cend = decode_work_item(cfg, tile_idx, mWorkItems)
+        if cutlass.const_expr(cfg.enable_checkpoints):
+            head_o = head_idx
+            checkpoint_slot = batch_idx * cutlass.Int32(TENSOR_MAP_QWORDS)
+            desc_checkpoint_slot = (desc_checkpoint_base + checkpoint_slot).tospace(cutlass.AddressSpace.generic)
+            checkpoint_chunks = checkpoint_every_n_tokens // cutlass.Int32(cfg.b_t)
+            checkpoint_quot = (cstart + cutlass.Int32(1)) // checkpoint_chunks
+            checkpoint_mod = (cstart + cutlass.Int32(1)) % checkpoint_chunks
+            if elect_one:
+                tma_tensormap_acquire(desc_checkpoint_slot)
+            num_chunks_tile = wend - cstart
+            if num_chunks_tile > 0 and wstart == 0:
+                checkpoint_stage = checkpoint_ready_index.idx
+                bars.mb_checkpoint_tmastg_ready[checkpoint_stage].wait(checkpoint_ready_index.phase)
+                checkpoint_ready_index = advance(checkpoint_ready_index, cfg.smem_checkpoint_stages)
+                checkpoint_slice = tma_slice_runtime_desc(desc_checkpoint_slot, cutlass.Int32(0), cutlass.Int32(0), cutlass.Int32(0), head_o)
+                tma_store_tile(sCheckpoint_tma[checkpoint_stage], checkpoint_slice, acquire=False)
+                tma_store_commit()
+                tma_store_wait(0)
+                bars.mb_checkpoint_tmastg_done[checkpoint_stage].arrive()
+            for local_chunk_idx in cutlass.range(num_chunks_tile, unroll=1):
+                chunk_idx = cstart + local_chunk_idx
+                if local_chunk_idx > 0:
+                    # ---- checkpoint store ----------------------------------------
+                    do_checkpoint = checkpoint_mod == 0
+                    do_checkpoint = do_checkpoint and chunk_idx >= wstart
+                    if do_checkpoint:
+                        checkpoint_stage = checkpoint_ready_index.idx
+                        bars.mb_checkpoint_tmastg_ready[checkpoint_stage].wait(checkpoint_ready_index.phase)
+                        checkpoint_ready_index = advance(checkpoint_ready_index, cfg.smem_checkpoint_stages)
+                        checkpoint_entry = checkpoint_quot
+                        checkpoint_slice = tma_slice_runtime_desc(desc_checkpoint_slot, cutlass.Int32(0), cutlass.Int32(0), checkpoint_entry, head_o)
+                        tma_store_tile(sCheckpoint_tma[checkpoint_stage], checkpoint_slice, acquire=False)
+                        tma_store_commit()
+                        tma_store_wait(0)
+                        bars.mb_checkpoint_tmastg_done[checkpoint_stage].arrive()
+                    checkpoint_mod = checkpoint_mod + cutlass.Int32(1)
+                    if checkpoint_mod == checkpoint_chunks:
+                        checkpoint_mod = cutlass.Int32(0)
+                        checkpoint_quot = checkpoint_quot + cutlass.Int32(1)
+        tile_idx, sched_state = sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas)
+
+
+@cute.jit
+def gate_scale(cfg, raw_gate: cutlass.Float32) -> cutlass.Float32:
+    """Map raw gate to the log2-domain decay increment used by KDA."""
+
+    if cutlass.const_expr(cfg.safe_gate):
+        half = cutlass.Float32(0.5)
+        sigmoid = cute.math.tanh(raw_gate * half, approx=True) * half + half
+        return cfg.gate_scale_log2 * sigmoid
+    # Default ABI: Gate arrives in natural-log space
+    return raw_gate * cutlass.Float32(LOG2_E)
+
+
+@cute.jit
+def compute0_warp_group(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    cu_seqlens,
+    mWorkItems,
+    sSched,
+    lane,
+    warp_idx,
+    mA_log,
+    mDt_bias,
+    sK_inv_raw,
+    sGate_raw,
+    mBeta,
+    sBeta_raw,
+    sK_raw,
+    sK_decay_raw,
+    sK_restore_raw,
+    sState_scale_diag_raw,
+    bars,
+) -> None:
+    """CG0 warp-group role (warps 0-7): persistent scheduler loop running the
+    Gate prefix scan and staging the decay/restore operands."""
+    nvvm.setmaxregister(cfg.num_regs_compute_group_0, nvvm.SetMaxRegisterAction.INCREASE)
+    cg0_warp = warp_idx - cfg.compute_group_0_warp_ids[0]
+    cg0_group_id = cg0_warp // cfg.cg0_warps_per_group
+    cg0_local_warp = cg0_warp % cfg.cg0_warps_per_group
+    prefix_dim = cg0_local_warp * cfg.threads_per_warp + lane
+    cg0_a_log_exp = cutlass.Float32(1.0)
+    cg0_dt_bias_value = cutlass.Float32(0.0)
+    cum_chunk_base = cutlass.Int32(0)
+    sched_state = PipelineState.start(phase=0)
+    tile_idx = cutlass.Int32(bidx)
+    opaque_one = opaque_f32_zero() + cutlass.Float32(1.0)
+    while tile_idx < total_tiles:
+        batch_idx, head_idx, batch_start, batch_end, seqlen_b, num_chunks_b, wstart, wend, cstart, cend = decode_work_item(cfg, tile_idx, mWorkItems)
+        head_o = head_idx
+        num_chunks_tile = wend - cstart
+        if cutlass.const_expr(cfg.safe_gate):
+            if num_chunks_tile > 0:
+                cg0_a_log_exp = cute.math.exp2(mA_log[head_o].to(cutlass.Float32) * LOG2_E, fastmath=True)
+                cg0_dt_bias_value = mDt_bias[head_o, prefix_dim].to(cutlass.Float32)
+        # tile entry: both ping-pong groups inherit each other's delivery proofs (parity-swap guard)
+        nvvm.barrier_cta_sync(cfg.cg0_tile_entry_barrier_id, thread_count=cfg.cg0_group_count * cfg.cg0_threads_per_group)
+        group_cum_chunk_start = cum_chunk_base + cutlass.Int32(cg0_group_id)
+        diag_ring_stage = group_cum_chunk_start % cutlass.Int32(cfg.smem_state_scale_diag_stages)
+        diag_ring_phase = (group_cum_chunk_start // cutlass.Int32(cfg.smem_state_scale_diag_stages)) % cutlass.Int32(2)
+        for local_chunk_idx in cutlass.range(cg0_group_id, num_chunks_tile, cfg.cg0_group_count, unroll=1):
+            chunk_idx = cstart + local_chunk_idx
+            cum_chunk = cum_chunk_base + local_chunk_idx
+            chunk_start = chunk_idx * cfg.b_t
+            decay_stage = cum_chunk % cfg.smem_decay_stages
+            raw_stage = cum_chunk % cfg.smem_raw_stages
+            state_scale_diag_stage = diag_ring_stage
+            qk_scale_ready_stage = state_scale_diag_stage
+            sK_ptr = sK_raw.data_ptr() + raw_stage * (cfg.d_k * cfg.b_t)
+            sGate_ptr = sGate_raw.data_ptr() + raw_stage * (cfg.d_k * cfg.b_t)
+            sK_inv_ptr = sK_inv_raw.data_ptr() + decay_stage * (cfg.b_t * cfg.d_k)
+            sK_decay_ptr = sK_decay_raw.data_ptr() + decay_stage * (cfg.d_k * cfg.b_t)
+            sK_restore_ptr = sK_restore_raw.data_ptr() + decay_stage * (cfg.d_k * cfg.b_t)
+            sState_scale_diag_ptr = sState_scale_diag_raw.data_ptr() + state_scale_diag_stage * ((cfg.d_k // 16) * 256)
+
+            # ---- Beta scalars ---------------------------------------------------
+            if cg0_local_warp == 0:
+                bars.mb_beta_done[raw_stage].wait(((cum_chunk // cfg.smem_raw_stages) + 1) % 2)
+                if lane < cfg.b_t:
+                    token_idx = chunk_idx * cfg.b_t + lane
+                    beta_value = cutlass.Float32(0.0)
+                    if token_idx < seqlen_b:
+                        beta_value = mBeta[batch_start + token_idx, head_o].to(cutlass.Float32)
+                        if cutlass.const_expr(cfg.beta_sigmoid):
+                            half = cutlass.Float32(0.5)
+                            beta_value = (cute.math.tanh(beta_value * half, approx=True) * half + half).to(mBeta.element_type).to(cutlass.Float32)
+                    sBeta_raw[raw_stage * cfg.b_t + lane] = beta_value
+                bars.mb_beta_ready[raw_stage].arrive()
+            bars.mb_gate_ready[raw_stage].wait((cum_chunk // cfg.smem_raw_stages) % 2)
+
+            row_group_start = cg0_local_warp * (cfg.b_t // cfg.cg0_warps_per_group)
+            lane_row_group = lane // 8
+            lane_in_row_group = lane - lane_row_group * 8
+            decay_row = row_group_start + lane_row_group
+            decay_key_mask = cutlass.Int32(8)
+
+            prefix_dim = cg0_local_warp * cfg.threads_per_warp + lane
+
+            # ---- Gate prefix scan -----------------------------------------------
+            f32_segment = prefix_dim // 32
+            prefix_seg_base = f32_segment * (cfg.b_t * 32)
+            prefix_col = prefix_dim - f32_segment * 32
+            gate_raw = cutlass.Array(cutlass.Float32, cfg.b_t, alignment=16)
+            for row in cutlass.range_constexpr(cfg.b_t):
+                prefix_idx = prefix_seg_base + swizzle_xor_128b(row, row * 32 + prefix_col, elem_bytes=4)
+                gate_raw[row] = (sGate_ptr + prefix_idx).load()
+            g_prefix_regs = cutlass.Array(cutlass.Float32, cfg.b_t, alignment=16)
+            if cutlass.const_expr(cfg.safe_gate):
+                valid_rows = seqlen_b - chunk_idx * cutlass.Int32(cfg.b_t)
+                valid_mask = cutlass.vector.create_mask([cfg.b_t], [valid_rows])
+                for row_pair in cutlass.range_constexpr(cfg.b_t // 2):
+                    row0 = row_pair * 2
+                    row1 = row0 + 1
+                    gate0 = cg0_a_log_exp * (gate_raw[row0] + cg0_dt_bias_value)
+                    gate1 = cg0_a_log_exp * (gate_raw[row1] + cg0_dt_bias_value)
+                    gate0 = gate_scale(
+                        cfg,
+                        gate0,
+                    )
+                    gate1 = gate_scale(
+                        cfg,
+                        gate1,
+                    )
+                    gate_pair = cutlass.Vector.from_elements((gate0, gate1), cutlass.Float32)
+                    gate_pair = cutlass.vector.where(valid_mask[row0 : row1 + 1], gate_pair, 0.0)
+                    g_prefix_regs[row0] = gate_pair[0]
+                    g_prefix_regs[row1] = gate_pair[1]
+            else:
+                for row in cutlass.range_constexpr(cfg.b_t):
+                    gate = gate_raw[row]
+                    token_idx = chunk_idx * cutlass.Int32(cfg.b_t) + cutlass.Int32(row)
+                    if token_idx < seqlen_b:
+                        gate = gate_scale(
+                            cfg,
+                            gate,
+                        )
+                    else:
+                        gate = cutlass.Float32(0.0)
+                    g_prefix_regs[row] = gate
+
+            prefix_acc = cutlass.Float32(0.0)
+            for row_pair in cutlass.range_constexpr(cfg.b_t // 2):
+                row0 = row_pair * 2
+                row1 = row0 + 1
+                gate0 = g_prefix_regs[row0]
+                gate1 = g_prefix_regs[row1]
+                prefix0, row_pair_sum = fadd2(prefix_acc, gate0, gate0, gate1)
+                prefix1 = prefix_acc + row_pair_sum
+                g_prefix_regs[row0] = prefix0
+                g_prefix_regs[row1] = prefix1
+                prefix_acc = prefix1
+
+            # ---- exp2(g): stage prefixes + final-token decay ---------------------
+            for row in cutlass.range_constexpr(cfg.b_t):
+                g_prefix_regs[row] = cute.math.exp2(g_prefix_regs[row], fastmath=True)
+
+            exp_g_last = g_prefix_regs[cfg.b_t - 1]
+            for row in cutlass.range_constexpr(cfg.b_t):
+                prefix_idx = prefix_seg_base + swizzle_xor_128b(row, row * 32 + prefix_col, elem_bytes=4)
+                (sGate_ptr + prefix_idx).store(g_prefix_regs[row])
+
+            # ---- state-scale diag: stage exp2(g_last) decay blocks ---------------
+            bars.mb_state_scale_diag_done[state_scale_diag_stage].wait(diag_ring_phase ^ cutlass.Int32(1))
+            block = prefix_dim // cutlass.Int32(16)
+            coord = prefix_dim - block * cutlass.Int32(16)
+            storage_col = coord ^ cutlass.Int32((cfg.b_t // 2))
+            linear_idx = block * cutlass.Int32(256) + coord * cutlass.Int32(16) + storage_col
+            diag_idx = swizzle_lin_S(linear_idx, bbits=1, mbase=3, sshift=3)
+            sState_scale_diag_ptr[diag_idx] = exp_g_last.to(cfg.io_dtype)
+
+            nvvm.barrier_cta_sync(cfg.cg0_group_sync_barrier_base_id + cg0_group_id, thread_count=cfg.cg0_threads_per_group)
+
+            bars.mb_k_ready[raw_stage].wait((cum_chunk // cfg.smem_raw_stages) % 2)
+            k_inv_pack = cutlass.Array(cutlass.Int32, 2 * 4, alignment=16)
+            raw_k_regs = cutlass.Array(cutlass.Float32, 2 * 8, alignment=16)
+
+            # ---- optional K L2-norm + K_inv staging ------------------------------
+            if cutlass.const_expr(cfg.l2norm):
+                kk_lo = opaque_f32_zero()
+                kk_hi = opaque_f32_zero()
+            for dim_half in cutlass.range_constexpr(2):
+                dim_base = dim_half * (cfg.d_k // 2) + lane_in_row_group * 8
+                reg_base = dim_half * 8
+                f16_segment = dim_base // 64
+                f16_segment_dim = dim_base - f16_segment * 64
+                raw_f16_idx = f16_segment * (cfg.b_t * 64) + decay_row * 64 + swizzle_xor_128b(decay_row, f16_segment_dim, elem_bytes=2)
+                raw_k_frag = (sK_ptr + raw_f16_idx).load(count=8, alignment=16)
+                raw_k_vec_f32 = raw_k_frag.to(cutlass.Float32)
+                for dim_offset in cutlass.range_constexpr(8):
+                    k_val = raw_k_vec_f32[dim_offset]
+                    raw_k_regs[reg_base + dim_offset] = k_val
+                if cutlass.const_expr(cfg.l2norm):
+                    for dim_pair in cutlass.range_constexpr(4):
+                        k_even = raw_k_vec_f32[2 * dim_pair]
+                        k_odd = raw_k_vec_f32[2 * dim_pair + 1]
+                        kk_lo, kk_hi = ffma2(k_even, k_odd, k_even, k_odd, kk_lo, kk_hi)
+
+            k_inv_norm = opaque_one
+            if cutlass.const_expr(cfg.l2norm):
+                k_sum_sq = kk_lo + kk_hi
+                k_sum_sq = k_sum_sq + cutlass.Float32(nvvm.shfl_sync(0xFFFFFFFF, k_sum_sq, 4, 31, kind=nvvm.Shfl.BFLY))
+                k_sum_sq = k_sum_sq + cutlass.Float32(nvvm.shfl_sync(0xFFFFFFFF, k_sum_sq, 2, 31, kind=nvvm.Shfl.BFLY))
+                k_sum_sq = k_sum_sq + cutlass.Float32(nvvm.shfl_sync(0xFFFFFFFF, k_sum_sq, 1, 31, kind=nvvm.Shfl.BFLY))
+                norm_floor_sq = cutlass.Float32(L2_NORM_EPS * L2_NORM_EPS)
+                k_inv_norm = cute.math.rsqrt(cute.math.max(k_sum_sq, norm_floor_sq), fastmath=True)
+
+            # ---- decay/restore operands: exp2(+-g) applied per key channel -------
+            exp_g_regs = cutlass.Array(cutlass.Float32, 2 * 8, alignment=16)
+            exp_g_last_regs = cutlass.Array(cutlass.Float32, 2 * 8, alignment=16)
+            for dim_half in cutlass.range_constexpr(2):
+                dim_base = dim_half * (cfg.d_k // 2) + lane_in_row_group * 8
+                reg_base = dim_half * 8
+                for f32_group in cutlass.range_constexpr(2):
+                    f32_dim_base = dim_base + f32_group * 4
+                    f32_segment = f32_dim_base // 32
+                    f32_segment_dim = f32_dim_base - f32_segment * 32
+                    g_prefix_idx = f32_segment * (cfg.b_t * 32) + decay_row * 32 + swizzle_xor_128b(decay_row, f32_segment_dim, elem_bytes=4)
+                    exp_g_frag = (sGate_ptr + g_prefix_idx).load(count=4, alignment=16)
+                    exp_g_last_idx = f32_segment * (cfg.b_t * 32) + (cfg.b_t - 1) * 32 + swizzle_xor_128b((cfg.b_t - 1), f32_segment_dim, elem_bytes=4)
+                    exp_g_last_frag = (sGate_ptr + exp_g_last_idx).load(count=4, alignment=16)
+                    f32_reg_base = reg_base + f32_group * 4
+                    for j in cutlass.range_constexpr(4):
+                        exp_g_regs[f32_reg_base + j] = exp_g_frag[j]
+                        exp_g_last_regs[f32_reg_base + j] = exp_g_last_frag[j]
+
+            for dim_half in cutlass.range_constexpr(2):
+                dim_base = dim_half * (cfg.d_k // 2) + lane_in_row_group * 8
+                reg_base = dim_half * 8
+
+                # ---- K decay + K_inv operands: K * exp2(+g) and K * exp2(-g) -----
+                k_decay_pack = cutlass.Array(cutlass.Int32, 4, alignment=16)
+                for pair_idx in cutlass.range_constexpr(4):
+                    dim0 = pair_idx * 2
+                    dim1 = dim0 + 1
+                    raw_reg_idx0 = reg_base + dim0
+                    raw_reg_idx1 = reg_base + dim1
+                    k_value0, k_value1 = fmul2(raw_k_regs[raw_reg_idx0], raw_k_regs[raw_reg_idx1], k_inv_norm, k_inv_norm)
+                    k_pair = fp32_to_fp16(k_value0, k_value1, dtype=cfg.io_dtype)
+                    exp_g_pair = fp32_to_fp16(exp_g_regs[raw_reg_idx0], exp_g_regs[raw_reg_idx1], dtype=cfg.io_dtype)
+                    k_decay_pack[pair_idx] = mul_f16x2(k_pair, exp_g_pair, cfg.io_dtype)
+                    exp_neg_g0 = cute.math.rcp(exp_g_regs[raw_reg_idx0], approx=True, ftz=True)
+                    exp_neg_g1 = cute.math.rcp(exp_g_regs[raw_reg_idx1], approx=True, ftz=True)
+                    exp_neg_pair = fp32_to_fp16(exp_neg_g0, exp_neg_g1, dtype=cfg.io_dtype)
+                    k_inv_pack[dim_half * 4 + pair_idx] = mul_f16x2(k_pair, exp_neg_pair, cfg.io_dtype)
+
+                k_inv_vec = cutlass.Vector.from_elements(
+                    (
+                        k_inv_pack[dim_half * 4],
+                        k_inv_pack[dim_half * 4 + 1],
+                        k_inv_pack[dim_half * 4 + 2],
+                        k_inv_pack[dim_half * 4 + 3],
+                    ),
+                    cutlass.Int32,
+                ).bitcast(cfg.io_dtype)
+                k_decay_vec = cutlass.Vector.from_elements(
+                    (
+                        k_decay_pack[0],
+                        k_decay_pack[1],
+                        k_decay_pack[2],
+                        k_decay_pack[3],
+                    ),
+                    cutlass.Int32,
+                ).bitcast(cfg.io_dtype)
+                if cutlass.const_expr(dim_half == 0):
+                    operand_done_phase = ((cum_chunk // cfg.smem_decay_stages) + 1) % 2
+                    bars.mb_decay_super_done[decay_stage].wait(operand_done_phase)
+                    bars.mb_decay_tcgen05_done[decay_stage].wait(operand_done_phase)
+                f16_segment = dim_base // 64
+                f16_segment_dim = dim_base - f16_segment * 64
+                k_inv_swizzled_idx = f16_segment * (cfg.b_t * 64) + decay_row * 64 + swizzle_xor_128b(decay_row, f16_segment_dim, elem_bytes=2)
+                (sK_inv_ptr + k_inv_swizzled_idx).store(k_inv_vec, alignment=16)
+                storage_key = dim_base ^ decay_key_mask
+                storage_slice = storage_key // 64
+                decay_swizzled_idx = storage_slice * (cfg.b_t * 64) + swizzle_xor_128b(
+                    decay_row, decay_row * 64 + storage_key - storage_slice * 64, elem_bytes=2
+                )
+                (sK_decay_ptr + decay_swizzled_idx).store(k_decay_vec, alignment=16)
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_k_decay_inv_cg0_ready[decay_stage].arrive()
+
+            # ---- K_restore operand: K_inv * exp_g_last --------------------------
+            bars.mb_k_restore_done[decay_stage].wait(((cum_chunk // cfg.smem_decay_stages + 1) % 2))
+            for dim_half in cutlass.range_constexpr(2):
+                dim_base = dim_half * (cfg.d_k // 2) + lane_in_row_group * 8
+                reg_base = dim_half * 8
+                k_restore_pack = cutlass.Array(cutlass.Int32, 4, alignment=16)
+                for pair_idx in cutlass.range_constexpr(4):
+                    dim0 = pair_idx * 2
+                    dim1 = dim0 + 1
+                    exp_g_last_pair = fp32_to_fp16(exp_g_last_regs[reg_base + dim0], exp_g_last_regs[reg_base + dim1], dtype=cfg.io_dtype)
+                    k_restore_pack[pair_idx] = mul_f16x2(k_inv_pack[dim_half * 4 + pair_idx], exp_g_last_pair, cfg.io_dtype)
+                storage_row = decay_row ^ (cfg.b_t // 2)
+                f16_segment = dim_base // 64
+                f16_segment_dim = dim_base - f16_segment * 64
+                k_restore_idx = f16_segment * (cfg.b_t * 64) + storage_row * 64 + swizzle_xor_128b(storage_row, f16_segment_dim, elem_bytes=2)
+                k_restore_vec = cutlass.Vector.from_elements(
+                    (
+                        k_restore_pack[0],
+                        k_restore_pack[1],
+                        k_restore_pack[2],
+                        k_restore_pack[3],
+                    ),
+                    cutlass.Int32,
+                ).bitcast(cfg.io_dtype)
+                (sK_restore_ptr + k_restore_idx).store(k_restore_vec, alignment=16)
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_qk_scale_ready[qk_scale_ready_stage].arrive()
+            bars.mb_k_done[raw_stage].arrive()
+            bars.mb_gate_done[raw_stage].arrive()
+            diag_ring_stage = diag_ring_stage + cutlass.Int32(cfg.cg0_group_count)
+            wrapped = diag_ring_stage >= cutlass.Int32(cfg.smem_state_scale_diag_stages)
+            diag_ring_stage = diag_ring_stage - cutlass.Int32(cfg.smem_state_scale_diag_stages) if wrapped else diag_ring_stage
+            diag_ring_phase = diag_ring_phase ^ (cutlass.Int32(1) if wrapped else cutlass.Int32(0))
+        cum_chunk_base += num_chunks_tile
+        tile_idx, sched_state = sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas)
+
+
+@cute.jit
+def compute1_warp_group(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    cu_seqlens,
+    mWorkItems,
+    sSched,
+    lane,
+    sTmem_base,
+    warp_idx,
+    mState_out,
+    mState_init,
+    sBeta_raw,
+    sV_raw,
+    sCheckpoint_raw,
+    checkpoint_every_n_tokens,
+    bars,
+) -> None:
+    """CG1 warp-group role (warps 8-11): persistent scheduler loop staging the
+    value-side TMEM operands and storing the checkpoint/final states."""
+    nvvm.setmaxregister(cfg.num_regs_compute_group_1, nvvm.SetMaxRegisterAction.INCREASE)
+    sCheckpoint_ptr = sCheckpoint_raw.data_ptr() if cutlass.const_expr(cfg.enable_checkpoints) else sV_raw.data_ptr()
+    checkpoint_done_index = PipelineState.start(phase=1)
+    nvvm.barrier_cta_sync(cfg.tmem_lifecycle_barrier_id, thread_count=cfg.tmem_user_threads)
+    tmem_base = sTmem_base.load()
+    tmem_col = tmem_base & 0xFFFF
+    tmem_row = tmem_base >> 16
+    tmem_subpartition = warp_idx % (cfg.d_v // cfg.threads_per_warp)
+    # ldmatrix.x4 COL lane decode for the V loads
+    frag_row_coord = (lane // 16) * 8 + (lane & 7)
+    frag_col_offset = ((lane // 8) & 1) * 8
+    row_id = tmem_row + tmem_subpartition * cfg.threads_per_warp
+    value_dim = tmem_subpartition * cfg.threads_per_warp + lane
+    value_dim_base = tmem_subpartition * cfg.threads_per_warp
+    row_addr = row_id << 16
+    row16_addr = (row_id + 16) << 16
+    st_row_addr = tmem_row << 16
+    st_row16_addr = (tmem_row + 16) << 16
+    state_col_id = tmem_col + cfg.tmem_state_acc_offset
+    packed_col_id = tmem_col + cfg.tmem_state_inp_offset
+    statek_col_id = tmem_col + cfg.tmem_state_k_acc_offset
+    y_inp_col_id = tmem_col + cfg.tmem_y_inp_offset
+    u_acc_addr = row_addr + tmem_col + cfg.tmem_u_acc_offset
+    u_inp_addr = st_row_addr + tmem_col + cfg.tmem_u_inp_offset
+    v_swz_off0 = (
+        (value_dim_base + frag_col_offset) // 64 * (cfg.b_t * 64)
+        + frag_row_coord * 64
+        + swizzle_xor_128b(frag_row_coord, (value_dim_base + frag_col_offset) % 64, elem_bytes=2)
+    )
+    v_swz_off = (
+        (value_dim_base + 16 + frag_col_offset) // 64 * (cfg.b_t * 64)
+        + frag_row_coord * 64
+        + swizzle_xor_128b(frag_row_coord, (value_dim_base + 16 + frag_col_offset) % 64, elem_bytes=2)
+    )
+    checkpoint_swz_off0 = (value_dim_base + frag_col_offset) // 64 * (cfg.d_k * 64)
+    checkpoint_swz_col0 = (value_dim_base + frag_col_offset) % 64
+    checkpoint_swz_off = (value_dim_base + 16 + frag_col_offset) // 64 * (cfg.d_k * 64)
+    checkpoint_swz_col = (value_dim_base + 16 + frag_col_offset) % 64
+    state_k_acc_index = PipelineState.start(phase=0)
+    u_acc_index = PipelineState.start(phase=0)
+    state_upd_index = PipelineState.start(phase=0)
+    raw_index = PipelineState.start(phase=0)
+    sched_state = PipelineState.start(phase=0)
+    tile_idx = cutlass.Int32(bidx)
+    while tile_idx < total_tiles:
+        batch_idx, head_idx, batch_start, batch_end, seqlen_b, num_chunks_b, wstart, wend, cstart, cend = decode_work_item(cfg, tile_idx, mWorkItems)
+        head_o = head_idx
+        num_chunks_tile = wend - cstart
+
+        if num_chunks_tile > 0:
+            # ---- first chunk: seed state TMEM from mState_init ----------
+            seed_from_initial_state = cstart == 0
+            if cutlass.const_expr(mState_init is not None):
+                if seed_from_initial_state:
+                    seed_vw = 16 // (mState_init.element_type.width // 8)
+                    seed_src = (mState_init.iterator + mState_init.layout((batch_idx, head_o, value_dim, 0))).raw_ptr()
+                    for key_block_start in cutlass.range_constexpr(0, cfg.d_k, 32):
+                        state_block = cutlass.Array(cutlass.Float32, 32, alignment=16)
+                        for g in cutlass.range_constexpr(32 // seed_vw):
+                            seed_chunk = (seed_src + key_block_start + g * seed_vw).load(count=seed_vw, alignment=16)
+                            for t in cutlass.range_constexpr(seed_vw):
+                                state_block[g * seed_vw + t] = seed_chunk[t].to(cutlass.Float32)
+
+                        nvvm.tcgen05_st(
+                            "32x32b",
+                            nvvm.make_tmem_ptr((row_id << 16) + (tmem_col + cfg.tmem_state_acc_offset + key_block_start), cutlass.Float32),
+                            state_block[0:32],
+                        )
+                else:
+                    for key_block_start in cutlass.range_constexpr(0, cfg.d_k, 32):
+                        state_block = cutlass.Array(cutlass.Float32, 32, alignment=16)
+                        for col in cutlass.range_constexpr(32):
+                            state_block[col] = cutlass.Float32(0.0)
+
+                        nvvm.tcgen05_st(
+                            "32x32b",
+                            nvvm.make_tmem_ptr((row_id << 16) + (tmem_col + cfg.tmem_state_acc_offset + key_block_start), cutlass.Float32),
+                            state_block[0:32],
+                        )
+            if cutlass.const_expr(mState_init is not None):
+                nvvm.tcgen05_wait("store")
+            sV_ptr = sV_raw.data_ptr() + raw_index.idx * (cfg.d_v * cfg.b_t)
+            sBeta_ptr = sBeta_raw.data_ptr() + raw_index.idx * cfg.b_t
+
+            # ---- state repack: acc TMEM -> packed b16 TMEM ----------------------
+            if cutlass.const_expr(mState_init is not None):
+                state_vecs = []
+                for sub in cutlass.range_constexpr(cfg.d_k // 16):
+                    state_vecs.append(nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(row_addr + state_col_id + sub * 16, cutlass.Float32), num=16))
+
+                for sub in cutlass.range_constexpr(cfg.d_k // 16):
+                    state_pack = cutlass.Array(cutlass.Int32, 8, alignment=16)
+                    for packed_col in cutlass.range_constexpr(8):
+                        source_pair = packed_col ^ 4
+                        state_pack[packed_col] = fp32_to_fp16(state_vecs[sub][2 * source_pair], state_vecs[sub][2 * source_pair + 1], dtype=cfg.io_dtype)
+                    nvvm.tcgen05_st(
+                        "32x32b",
+                        nvvm.make_tmem_ptr((tmem_row << 16) + packed_col_id + sub * 8, cutlass.Int8),
+                        state_pack[0:8],
+                    )
+
+                nvvm.tcgen05_wait("store")
+                bars.mb_state_inp_ready.arrive()
+                if cutlass.const_expr(cfg.enable_checkpoints):
+                    if wstart == 0:
+                        checkpoint_stage = checkpoint_done_index.idx
+                        bars.mb_checkpoint_tmastg_done[checkpoint_stage].wait(checkpoint_done_index.phase)
+                        checkpoint_done_index = advance(checkpoint_done_index, cfg.smem_checkpoint_stages)
+                        checkpoint_stage_base = checkpoint_stage * (cfg.d_k * cfg.d_v)
+                        for sub in cutlass.range_constexpr(cfg.d_k // 16):
+                            for g in cutlass.range_constexpr(2):
+                                packs = tuple(
+                                    fp32_to_fp16(state_vecs[sub][g * 8 + 2 * t], state_vecs[sub][g * 8 + 2 * t + 1], dtype=cfg.io_dtype) for t in range(4)
+                                )
+                                dk = sub * 16 + g * 8
+                                checkpoint_addr = (
+                                    checkpoint_stage_base + (dk // 64) * (cfg.d_v * 64) + value_dim * 64 + swizzle_xor_128b(value_dim, dk % 64, elem_bytes=2)
+                                )
+                                (sCheckpoint_ptr + checkpoint_addr).store(
+                                    cutlass.Vector.from_elements(packs, cutlass.Int32).bitcast(cfg.io_dtype), alignment=16
+                                )
+                        nvvm.tcgen05_wait("load")
+                        nvvm.fence_proxy("async.shared", space="cta")
+                        bars.mb_checkpoint_tmastg_ready[checkpoint_stage].arrive()
+                    bars.mb_state_acc_read_done.arrive()
+
+            if cutlass.const_expr(cfg.enable_checkpoints and mState_init is None):
+                if wstart == 0:
+                    checkpoint_stage = checkpoint_done_index.idx
+                    bars.mb_checkpoint_tmastg_done[checkpoint_stage].wait(checkpoint_done_index.phase)
+                    checkpoint_done_index = advance(checkpoint_done_index, cfg.smem_checkpoint_stages)
+                    checkpoint_stage_base = checkpoint_stage * (cfg.d_k * cfg.d_v)
+                    zero_packs = tuple(cutlass.Int32(0) for _ in range(4))
+                    for sub in cutlass.range_constexpr(cfg.d_k // 16):
+                        for g in cutlass.range_constexpr(2):
+                            dk = sub * 16 + g * 8
+                            checkpoint_addr = (
+                                checkpoint_stage_base + (dk // 64) * (cfg.d_v * 64) + value_dim * 64 + swizzle_xor_128b(value_dim, dk % 64, elem_bytes=2)
+                            )
+                            (sCheckpoint_ptr + checkpoint_addr).store(
+                                cutlass.Vector.from_elements(zero_packs, cutlass.Int32).bitcast(cfg.io_dtype), alignment=16
+                            )
+                    nvvm.fence_proxy("async.shared", space="cta")
+                    bars.mb_checkpoint_tmastg_ready[checkpoint_stage].arrive()
+
+            # ---- Y staging: Y = Beta * (V - State*K) -----------------------------
+            bars.mb_v_ready[raw_index.idx].wait(raw_index.phase)
+            raw_v_frag0 = nvvm.ldmatrix(
+                sV_ptr + v_swz_off0,
+                4,
+                nvvm.MMALayout.COL,
+            )
+            raw_v_frag1 = nvvm.ldmatrix(
+                sV_ptr + v_swz_off,
+                4,
+                nvvm.MMALayout.COL,
+            )
+            bars.mb_beta_ready[raw_index.idx].wait(raw_index.phase)
+            if cutlass.const_expr(mState_init is not None):
+                bars.mb_state_k_acc_ready.wait(state_k_acc_index.phase)
+
+                state_k_vec0 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr(row_addr + statek_col_id, cutlass.Float32), num=2)
+                state_k_vec1 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr(row16_addr + statek_col_id, cutlass.Float32), num=2)
+
+            beta_pack = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            for reg_idx in cutlass.range_constexpr(4):
+                token0 = (((reg_idx // 2) * 4 + (lane & 3)) ^ 4) * 2
+                beta0 = (sBeta_ptr + token0).load().to(cutlass.Float32)
+                beta1 = (sBeta_ptr + token0 + 1).load().to(cutlass.Float32)
+                beta_pack[reg_idx] = fp32_to_fp16(beta0, beta1, dtype=cfg.io_dtype)
+            y_inp_pack0 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            for reg_idx in cutlass.range_constexpr(4):
+                raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
+                frag_pair = (reg_idx ^ 2) * 2
+                if cutlass.const_expr(mState_init is not None):
+                    state_k_val0, state_k_val1 = state_k_vec0[frag_pair], state_k_vec0[frag_pair + 1]
+                    state_k_pair = fp32_to_fp16(state_k_val0, state_k_val1, dtype=cfg.io_dtype)
+                    diff_pair = sub_f16x2(
+                        raw_v_frag0[raw_matrix],
+                        state_k_pair,
+                        cfg.io_dtype,
+                    )
+                else:
+                    diff_pair = raw_v_frag0[raw_matrix]
+                y_inp_pack0[reg_idx] = mul_f16x2(
+                    beta_pack[reg_idx],
+                    diff_pair,
+                    cfg.io_dtype,
+                )
+
+            y_inp_pack1 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            for reg_idx in cutlass.range_constexpr(4):
+                raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
+                frag_pair = (reg_idx ^ 2) * 2
+                if cutlass.const_expr(mState_init is not None):
+                    state_k_val0, state_k_val1 = state_k_vec1[frag_pair], state_k_vec1[frag_pair + 1]
+                    state_k_pair = fp32_to_fp16(state_k_val0, state_k_val1, dtype=cfg.io_dtype)
+                    diff_pair = sub_f16x2(
+                        raw_v_frag1[raw_matrix],
+                        state_k_pair,
+                        cfg.io_dtype,
+                    )
+                else:
+                    diff_pair = raw_v_frag1[raw_matrix]
+                y_inp_pack1[reg_idx] = mul_f16x2(
+                    beta_pack[reg_idx],
+                    diff_pair,
+                    cfg.io_dtype,
+                )
+
+            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row_addr + y_inp_col_id, cutlass.Int8), y_inp_pack0[0:4])
+            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row16_addr + y_inp_col_id, cutlass.Int8), y_inp_pack1[0:4])
+            nvvm.tcgen05_wait("store")
+            if cutlass.const_expr(mState_init is not None):
+                state_k_acc_index = advance(state_k_acc_index, 1)
+            bars.mb_v_done[raw_index.idx].arrive()
+            bars.mb_beta_done[raw_index.idx].arrive()
+            bars.mb_y_inp_ready.arrive()
+
+            # ---- U repack: u_acc TMEM -> packed b16 (U input) TMEM --------------
+            bars.mb_u_acc_ready.wait(u_acc_index.phase)
+            u_acc_vals = nvvm.tcgen05_ld(
+                "32x32b",
+                nvvm.make_tmem_ptr(u_acc_addr, cutlass.Float32),
+                num=cfg.b_t,
+            )
+
+            u_inp_pack = cutlass.Array(cutlass.Int32, (cfg.b_t // 2), alignment=16)
+            for packed_col in cutlass.range_constexpr((cfg.b_t // 2)):
+                source_pair = packed_col ^ 4
+                token0 = source_pair * 2
+                token1 = token0 + 1
+                u_inp_pack[packed_col] = fp32_to_fp16(u_acc_vals[token0], u_acc_vals[token1], dtype=cfg.io_dtype)
+
+            nvvm.tcgen05_st(
+                "32x32b",
+                nvvm.make_tmem_ptr(u_inp_addr, cutlass.Int8),
+                u_inp_pack[0 : (cfg.b_t // 2)],
+            )
+            nvvm.tcgen05_wait("store")
+            u_acc_index = advance(u_acc_index, 1)
+            bars.mb_u_inp_ready.arrive()
+            if cutlass.const_expr(cfg.enable_checkpoints):
+                bars.mb_state_acc_done.wait(state_upd_index.phase)
+                state_upd_index = advance(state_upd_index, 1)
+
+            raw_index = advance(raw_index, cfg.smem_raw_stages)
+
+        if cutlass.const_expr(cfg.enable_checkpoints):
+            cg1_checkpoint_chunks = checkpoint_every_n_tokens // cutlass.Int32(cfg.b_t)
+            cg1_checkpoint_mod = (cstart + cutlass.Int32(1)) % cg1_checkpoint_chunks
+        for local_chunk_idx in cutlass.range(1, num_chunks_tile, 1, unroll=1):
+            chunk_idx = cstart + local_chunk_idx
+            sV_ptr = sV_raw.data_ptr() + raw_index.idx * (cfg.d_v * cfg.b_t)
+            sBeta_ptr = sBeta_raw.data_ptr() + raw_index.idx * cfg.b_t
+
+            do_checkpoint = False
+            if cutlass.const_expr(cfg.enable_checkpoints):
+                do_checkpoint = cg1_checkpoint_mod == 0
+                cg1_checkpoint_mod = cg1_checkpoint_mod + cutlass.Int32(1)
+                cg1_checkpoint_mod = cutlass.Int32(0) if cg1_checkpoint_mod == cg1_checkpoint_chunks else cg1_checkpoint_mod
+                do_checkpoint = do_checkpoint and chunk_idx >= wstart
+
+            # ---- state repack: acc TMEM -> packed b16 TMEM ----------------------
+            if cutlass.const_expr(not cfg.enable_checkpoints):
+                bars.mb_state_acc_done.wait(state_upd_index.phase)
+                state_upd_index = advance(state_upd_index, 1)
+            state_vecs = []
+            for sub in cutlass.range_constexpr(cfg.d_k // 16):
+                state_vecs.append(nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(row_addr + state_col_id + sub * 16, cutlass.Float32), num=16))
+
+            for sub in cutlass.range_constexpr(cfg.d_k // 16):
+                state_pack = cutlass.Array(cutlass.Int32, 8, alignment=16)
+                for packed_col in cutlass.range_constexpr(8):
+                    source_pair = packed_col ^ 4
+                    state_pack[packed_col] = fp32_to_fp16(state_vecs[sub][2 * source_pair], state_vecs[sub][2 * source_pair + 1], dtype=cfg.io_dtype)
+                nvvm.tcgen05_st(
+                    "32x32b",
+                    nvvm.make_tmem_ptr((tmem_row << 16) + packed_col_id + sub * 8, cutlass.Int8),
+                    state_pack[0:8],
+                )
+            nvvm.tcgen05_wait("store")
+            bars.mb_state_inp_ready.arrive()
+
+            # ---- checkpoint store -----------------------------------------------
+            if cutlass.const_expr(cfg.enable_checkpoints):
+                if do_checkpoint:
+                    checkpoint_stage = checkpoint_done_index.idx
+                    bars.mb_checkpoint_tmastg_done[checkpoint_stage].wait(checkpoint_done_index.phase)
+                    checkpoint_done_index = advance(checkpoint_done_index, cfg.smem_checkpoint_stages)
+                    checkpoint_stage_base = checkpoint_stage * (cfg.d_k * cfg.d_v)
+                    for k_base in cutlass.range_constexpr(0, cfg.d_k, 32):
+                        checkpoint_vec = nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(row_addr + state_col_id + k_base, cutlass.Float32), num=32)
+                        for g in cutlass.range_constexpr(4):
+                            packs = tuple(fp32_to_fp16(checkpoint_vec[g * 8 + 2 * t], checkpoint_vec[g * 8 + 2 * t + 1], dtype=cfg.io_dtype) for t in range(4))
+                            dk = k_base + g * 8
+                            checkpoint_addr = (
+                                checkpoint_stage_base + (dk // 64) * (cfg.d_v * 64) + value_dim * 64 + swizzle_xor_128b(value_dim, dk % 64, elem_bytes=2)
+                            )
+                            (sCheckpoint_ptr + checkpoint_addr).store(cutlass.Vector.from_elements(packs, cutlass.Int32).bitcast(cfg.io_dtype), alignment=16)
+                    nvvm.fence_proxy("async.shared", space="cta")
+                    bars.mb_checkpoint_tmastg_ready[checkpoint_stage].arrive()
+                    nvvm.tcgen05_wait("load")
+                    bars.mb_state_acc_read_done.arrive()
+                else:
+                    bars.mb_state_acc_read_done.arrive()
+
+            # ---- Y staging: Y = Beta * (V - State*K) -----------------------------
+            bars.mb_v_ready[raw_index.idx].wait(raw_index.phase)
+            raw_v_frag0 = nvvm.ldmatrix(
+                sV_ptr + v_swz_off0,
+                4,
+                nvvm.MMALayout.COL,
+            )
+            raw_v_frag1 = nvvm.ldmatrix(
+                sV_ptr + v_swz_off,
+                4,
+                nvvm.MMALayout.COL,
+            )
+            bars.mb_beta_ready[raw_index.idx].wait(raw_index.phase)
+
+            # ---- read back State*K acc -------------------------------------------
+            bars.mb_state_k_acc_ready.wait(state_k_acc_index.phase)
+            state_k_vec0 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr(row_addr + statek_col_id, cutlass.Float32), num=2)
+            state_k_vec1 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr(row16_addr + statek_col_id, cutlass.Float32), num=2)
+
+            beta_pack = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            for reg_idx in cutlass.range_constexpr(4):
+                token0 = (((reg_idx // 2) * 4 + (lane & 3)) ^ 4) * 2
+                beta0 = (sBeta_ptr + token0).load().to(cutlass.Float32)
+                beta1 = (sBeta_ptr + token0 + 1).load().to(cutlass.Float32)
+                beta_pack[reg_idx] = fp32_to_fp16(beta0, beta1, dtype=cfg.io_dtype)
+            y_inp_pack0 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            for reg_idx in cutlass.range_constexpr(4):
+                raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
+                frag_pair = (reg_idx ^ 2) * 2
+                state_k_val0, state_k_val1 = state_k_vec0[frag_pair], state_k_vec0[frag_pair + 1]
+                state_k_pair = fp32_to_fp16(state_k_val0, state_k_val1, dtype=cfg.io_dtype)
+                diff_pair = sub_f16x2(
+                    raw_v_frag0[raw_matrix],
+                    state_k_pair,
+                    cfg.io_dtype,
+                )
+                y_inp_pack0[reg_idx] = mul_f16x2(
+                    beta_pack[reg_idx],
+                    diff_pair,
+                    cfg.io_dtype,
+                )
+
+            y_inp_pack1 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            for reg_idx in cutlass.range_constexpr(4):
+                raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
+                frag_pair = (reg_idx ^ 2) * 2
+                state_k_val0, state_k_val1 = state_k_vec1[frag_pair], state_k_vec1[frag_pair + 1]
+                state_k_pair = fp32_to_fp16(state_k_val0, state_k_val1, dtype=cfg.io_dtype)
+                diff_pair = sub_f16x2(
+                    raw_v_frag1[raw_matrix],
+                    state_k_pair,
+                    cfg.io_dtype,
+                )
+                y_inp_pack1[reg_idx] = mul_f16x2(
+                    beta_pack[reg_idx],
+                    diff_pair,
+                    cfg.io_dtype,
+                )
+
+            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row_addr + y_inp_col_id, cutlass.Int8), y_inp_pack0[0:4])
+            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row16_addr + y_inp_col_id, cutlass.Int8), y_inp_pack1[0:4])
+            nvvm.tcgen05_wait("store")
+            state_k_acc_index = advance(state_k_acc_index, 1)
+            bars.mb_v_done[raw_index.idx].arrive()
+            bars.mb_beta_done[raw_index.idx].arrive()
+            bars.mb_y_inp_ready.arrive()
+
+            # ---- U repack: u_acc TMEM -> packed b16 (U input) TMEM --------------
+            bars.mb_u_acc_ready.wait(u_acc_index.phase)
+            u_acc_vals = nvvm.tcgen05_ld(
+                "32x32b",
+                nvvm.make_tmem_ptr(u_acc_addr, cutlass.Float32),
+                num=cfg.b_t,
+            )
+
+            u_inp_pack = cutlass.Array(cutlass.Int32, (cfg.b_t // 2), alignment=16)
+            for packed_col in cutlass.range_constexpr((cfg.b_t // 2)):
+                source_pair = packed_col ^ 4
+                token0 = source_pair * 2
+                token1 = token0 + 1
+                u_inp_pack[packed_col] = fp32_to_fp16(u_acc_vals[token0], u_acc_vals[token1], dtype=cfg.io_dtype)
+
+            nvvm.tcgen05_st(
+                "32x32b",
+                nvvm.make_tmem_ptr(u_inp_addr, cutlass.Int8),
+                u_inp_pack[0 : (cfg.b_t // 2)],
+            )
+            nvvm.tcgen05_wait("store")
+            u_acc_index = advance(u_acc_index, 1)
+            bars.mb_u_inp_ready.arrive()
+
+            if cutlass.const_expr(cfg.enable_checkpoints):
+                bars.mb_state_acc_done.wait(state_upd_index.phase)
+                state_upd_index = advance(state_upd_index, 1)
+            raw_index = advance(raw_index, cfg.smem_raw_stages)
+
+        if num_chunks_tile > 0:
+            if cutlass.const_expr(not cfg.enable_checkpoints):
+                bars.mb_state_acc_done.wait(state_upd_index.phase)
+                state_upd_index = advance(state_upd_index, 1)
+
+        owns_final = wend == num_chunks_b
+
+        # ---- final-state drain: state acc TMEM -> GMEM ---------------------------
+        if cutlass.const_expr(mState_out is not None):
+            if seqlen_b > 0:
+                if owns_final:
+                    state_vw = 16 // (mState_out.element_type.width // 8)
+                    state_dst = (mState_out.iterator + mState_out.layout((batch_idx, head_o, value_dim, 0))).raw_ptr()
+                    for key_block_start in cutlass.range_constexpr(0, cfg.d_k, 32):
+                        loaded = nvvm.tcgen05_ld(
+                            "32x32b",
+                            nvvm.make_tmem_ptr((row_id << 16) + (tmem_col + cfg.tmem_state_acc_offset + key_block_start), cutlass.Float32),
+                            num=32,
+                        )
+
+                        for g in cutlass.range_constexpr(32 // state_vw):
+                            (state_dst + key_block_start + g * state_vw).store(
+                                cutlass.Vector.from_elements(
+                                    tuple(loaded[g * state_vw + t].to(mState_out.element_type) for t in range(state_vw)),
+                                    mState_out.element_type,
+                                ),
+                                alignment=16,
+                            )
+            else:
+                for key_block_start in cutlass.range_constexpr(0, cfg.d_k, 32):
+                    for col in cutlass.range_constexpr(32):
+                        key_dim = key_block_start + col
+                        if cutlass.const_expr(mState_init is not None):
+                            mState_out[batch_idx, head_o, value_dim, key_dim] = mState_init[batch_idx, head_o, value_dim, key_dim]
+                        else:
+                            mState_out[batch_idx, head_o, value_dim, key_dim] = cutlass.Float32(0.0).to(mState_out.element_type)
+        tile_idx, sched_state = sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas)
+
+    bars.mb_tmem_done[0].arrive()
+
+
+class KdaRecomputeOp:
+    """Compile and launch one static mega KDA recompute configuration."""
+
+    def __init__(self, cfg: "KdaRecomputeCfg"):
+        self.cfg = cfg
+
+    def get_name(self) -> str:
+        cfg = self.cfg
+        gate_scale = (
+            f"_gs{float(cfg.gate_scale_log2).hex()}"
+            .replace("-", "m")
+            .replace(".", "p")
+            .replace("+", "")
+            if cfg.safe_gate
+            else ""
+        )
+        return (
+            f"kda_mega_recompute_{cfg.io_dtype.__name__.lower()}"
+            f"_{cfg.state_dtype.__name__.lower()}_h{cfg.n_heads_out}"
+            f"_k{cfg.k_ratio}_v{cfg.v_ratio}"
+            f"_i{int(cfg.use_initial_state)}f{int(cfg.store_final_state)}"
+            f"c{int(cfg.enable_checkpoints)}l{int(cfg.l2norm)}"
+            f"g{int(cfg.safe_gate)}b{int(cfg.beta_sigmoid)}d{int(cfg.dyn_sched)}"
+            f"_sm{cfg.max_active_clusters}{gate_scale}"
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        k: cute.Tensor,
+        v: cute.Tensor,
+        raw_gate: cute.Tensor,
+        a_log: cute.Tensor | None,
+        dt_bias: cute.Tensor | None,
+        beta: cute.Tensor,
+        cu_seqlens: cute.Tensor,
+        initial_state: cute.Tensor | None,
+        final_state: cute.Tensor | None,
+        work_items: cute.Tensor | None,
+        work_count: cute.Tensor | None,
+        sched_ctr: cute.Tensor | None,
+        tensormap_workspace: cute.Tensor,
+        checkpoint_every_n_tokens: cutlass.Int32,
+        stream,
+    ) -> None:
+        cfg = self.cfg
+        num_sequences = cu_seqlens.shape[0] - 1
+
+        kernel.set_name_prefix(self.get_name())
+        kernel(
+            cfg,
+            tensormap_workspace,
+            cutlass.Int32(num_sequences),
+            k,
+            v,
+            raw_gate,
+            a_log,
+            dt_bias,
+            beta,
+            cu_seqlens,
+            initial_state,
+            final_state,
+            work_items,
+            work_count,
+            sched_ctr,
+            checkpoint_every_n_tokens,
+        ).launch(
+            grid=(cfg.max_active_clusters, 1, 1),
+            block=(cfg.threads_per_cta, 1, 1),
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
+
+
+@cute.kernel
+def kernel(
+    cfg: cutlass.Constexpr,
+    tensormap_workspace: cute.Tensor,
+    n_desc: cutlass.Int32,
+    mK: cute.Tensor,
+    mV: cute.Tensor,
+    mGate: cute.Tensor,
+    mA_log: cute.Tensor | None,
+    mDt_bias: cute.Tensor | None,
+    mBeta: cute.Tensor,
+    cu_seqlens: cute.Tensor,
+    mState_init: cute.Tensor | None,
+    mState_out: cute.Tensor | None,
+    mWorkItems: cute.Tensor,
+    mCount: cute.Tensor,
+    mSched: cute.Tensor | None,
+    checkpoint_every_n_tokens: cutlass.Int32,
+) -> None:
+    """BT=16 KDA recompute (state/checkpoints-only) persistent kernel body: every warp
+    role runs a tile-scheduler loop over the tiles."""
+
+    tidx, _, _ = cute.arch.thread_idx()
+    bidx = cute.arch.block_idx()[0]
+    num_ctas = cute.arch.grid_dim()[0]
+    warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+    lane = tidx % cfg.threads_per_warp
+
+    total_tiles = mCount[0]
+    if cutlass.const_expr(cfg.dyn_sched):
+        assert mSched is not None and mSched.element_type == cutlass.Int32
+    assert mK.element_type == cfg.io_dtype and mV.element_type == cfg.io_dtype
+    assert mGate.element_type == cutlass.Float32
+    beta_expected = cfg.io_dtype if cutlass.const_expr(cfg.beta_sigmoid) else cutlass.Float32
+    assert mBeta.element_type == beta_expected
+    assert cu_seqlens.element_type in (cutlass.Int32, cutlass.Int64)
+    if cutlass.const_expr(cfg.use_initial_state):
+        assert mState_init is not None and mState_init.element_type in (cutlass.BFloat16, cutlass.Float32)
+    else:
+        assert mState_init is None, "mState_init must be None if use_initial_state is False"
+    if cutlass.const_expr(cfg.store_final_state):
+        assert mState_out is not None and mState_out.element_type in (cutlass.BFloat16, cutlass.Float32)
+    else:
+        assert mState_out is None, "mState_out must be None if store_final_state is False"
+    if cutlass.const_expr(mState_init is not None and mState_out is not None):
+        assert mState_init.element_type == mState_out.element_type
+    desc_base_words = tensormap_workspace.iterator.raw_ptr()
+    arr_words = n_desc * cutlass.Int32(TENSOR_MAP_QWORDS)
+    desc_k_base = desc_base_words
+    desc_v_base = desc_base_words + arr_words
+    desc_gate_base = desc_base_words + cutlass.Int32(2) * arr_words
+    desc_checkpoint_base = desc_base_words + cutlass.Int32(3) * arr_words
+
+    # Buffers are declaration-ordered and intentionally non-aliased.
+    SMEM = cutlass.AddressSpace.smem
+    bars = make_kda_bars(cfg)
+    sTmem_base = cutlass.Array(cutlass.Int32, 1, space=SMEM, alignment=4)
+    sSched = cutlass.Array(cutlass.Int32, cfg.sched_stages, space=SMEM, alignment=16)
+    sK_decay_raw = cutlass.Array(cfg.io_dtype, cfg.k_decay_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
+    sK_restore_raw = cutlass.Array(cfg.io_dtype, cfg.k_restore_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
+    sIntermediate_raw = cutlass.Array(cfg.io_dtype, cfg.intermediate_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
+    sK_raw = cutlass.Array(mK.element_type, cfg.k_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
+    sV_raw = cutlass.Array(mV.element_type, cfg.v_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
+    sGate_raw = cutlass.Array(cutlass.Float32, cfg.gate_cosize, space=SMEM, alignment=1024)
+    sState_scale_diag_raw = cutlass.Array(cfg.io_dtype, cfg.state_scale_diag_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
+    sK_inv_raw = cutlass.Array(cfg.io_dtype, cfg.k_inv_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
+    sBeta_raw = cutlass.Array(cutlass.Float32, cfg.beta_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
+    sCheckpoint_raw = (
+        cutlass.Array(cfg.io_dtype, cfg.smem_checkpoint_stages * cfg.d_k * cfg.d_v, space=SMEM, alignment=cfg.buffer_align_bytes)
+        if cutlass.const_expr(cfg.enable_checkpoints)
+        else sV_raw
+    )
+    sK_decay = SmemTile(
+        base=sK_decay_raw,
+        elems_per_stage=(cfg.d_k * cfg.b_t),
+        stages=cfg.smem_decay_stages,
+        leading_byte_offset=16,
+        stride_byte_offset=1024,
+        layout=nvvm.Tcgen05SmemSwizzle.SWIZZLE_128B,
+    )
+    sK_restore = SmemTile(
+        base=sK_restore_raw,
+        elems_per_stage=(cfg.d_k * cfg.b_t),
+        stages=cfg.smem_decay_stages,
+        leading_byte_offset=(cfg.b_t * (cfg.d_v // 2) * 2),
+        stride_byte_offset=(8 * (cfg.d_v // 2) * 2),
+        layout=nvvm.Tcgen05SmemSwizzle.SWIZZLE_128B,
+    )
+    sState_scale_diag = SmemTile(
+        base=sState_scale_diag_raw,
+        elems_per_stage=((cfg.d_k // 16) * 256),
+        stages=cfg.smem_state_scale_diag_stages,
+        leading_byte_offset=16,
+        stride_byte_offset=(8 * 16 * 2),
+        layout=nvvm.Tcgen05SmemSwizzle.SWIZZLE_32B,
+    )
+    sIntermediate = SmemTile(
+        base=sIntermediate_raw,
+        elems_per_stage=(2 * cfg.b_t * cfg.b_t),
+        stages=cfg.smem_intermediate_stages,
+        leading_byte_offset=16,
+        stride_byte_offset=(8 * cfg.b_t * 2),
+        layout=nvvm.Tcgen05SmemSwizzle.SWIZZLE_32B,
+    )
+
+    elect_one = nvvm.elect_sync()
+    if warp_idx == cfg.tma_warp_id:
+        if elect_one:
+            for stage in cutlass.range_constexpr(cfg.smem_raw_stages):
+                bars.mb_k_ready[stage].init()
+                bars.mb_v_ready[stage].init()
+                bars.mb_gate_ready[stage].init()
+                bars.mb_beta_ready[stage].init()
+                bars.mb_beta_done[stage].init()
+                bars.mb_k_done[stage].init()
+                bars.mb_v_done[stage].init()
+                bars.mb_gate_done[stage].init()
+    elif warp_idx == cfg.tcgen05_mma_warp_id:
+        if elect_one:
+            bars.mb_state_k_acc_ready.init()
+            bars.mb_u_acc_ready.init()
+            bars.mb_state_acc_done.init()
+            bars.mb_state_inp_ready.init()
+            for stage in cutlass.range_constexpr(cfg.smem_state_scale_diag_stages):
+                bars.mb_state_scale_diag_done[stage].init()
+            for stage in cutlass.range_constexpr(cfg.smem_decay_stages):
+                bars.mb_decay_tcgen05_done[stage].init()
+                bars.mb_decay_super_done[stage].init()
+                bars.mb_k_restore_done[stage].init()
+            bars.mb_y_inp_ready.init()
+            bars.mb_u_inp_ready.init()
+            bars.mb_tmem_done[0].init()
+    elif warp_idx == cfg.super_mma_warp_id:
+        if elect_one:
+            for stage in cutlass.range_constexpr(cfg.smem_intermediate_stages):
+                bars.mb_t_inv_ready[stage].init()
+                bars.mb_t_inv_done[stage].init()
+            for stage in cutlass.range_constexpr(cfg.qk_scale_ready_stages):
+                bars.mb_qk_scale_ready[stage].init()
+            for stage in cutlass.range_constexpr(cfg.smem_decay_stages):
+                bars.mb_k_decay_inv_cg0_ready[stage].init()
+    elif warp_idx == cfg.epilogue_warp_id:
+        if elect_one:
+            for stage in cutlass.range_constexpr(cfg.sched_stages):
+                bars.mb_sched_ready[stage].init()
+                bars.mb_sched_done[stage].init()
+            if cutlass.const_expr(cfg.enable_checkpoints):
+                for stage in cutlass.range_constexpr(cfg.smem_checkpoint_stages):
+                    bars.mb_checkpoint_tmastg_ready[stage].init()
+                    bars.mb_checkpoint_tmastg_done[stage].init()
+                bars.mb_state_acc_read_done.init()
+    diag_zero = cfg.io_dtype(0.0)
+    for diag_idx in cutlass.range(tidx, cfg.state_scale_diag_cosize, cfg.threads_per_cta, unroll=1):
+        sState_scale_diag_raw[diag_idx] = diag_zero
+    nvvm.fence_mbarrier_init()
+    nvvm.barrier_cta_sync(0, thread_count=cfg.threads_per_cta)
+    if warp_idx == cfg.tma_warp_id:
+        tmaldg_warp(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            n_desc,
+            cu_seqlens,
+            mWorkItems,
+            mSched,
+            sSched,
+            lane,
+            sK_raw,
+            sV_raw,
+            sGate_raw,
+            desc_k_base,
+            desc_v_base,
+            desc_gate_base,
+            bars,
+        )
+    elif warp_idx == cfg.super_mma_warp_id:
+        super_mma_warp(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            cu_seqlens,
+            mWorkItems,
+            sSched,
+            lane,
+            sK_inv_raw,
+            sIntermediate_raw,
+            sBeta_raw,
+            sK_decay_raw,
+            bars,
+        )
+    elif warp_idx == cfg.tcgen05_mma_warp_id:
+        tcgen05_mma_warp(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            cu_seqlens,
+            mWorkItems,
+            sSched,
+            sTmem_base,
+            sIntermediate,
+            sK_decay,
+            sK_restore,
+            sState_scale_diag,
+            bars,
+        )
+    elif warp_idx == cfg.epilogue_warp_id:
+        epilogue_warp(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            cu_seqlens,
+            mWorkItems,
+            sSched,
+            sCheckpoint_raw,
+            desc_checkpoint_base,
+            checkpoint_every_n_tokens,
+            bars,
+        )
+    elif warp_idx >= cfg.compute_group_0_warp_ids[0] and warp_idx <= cfg.compute_group_0_warp_ids[-1]:
+        compute0_warp_group(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            cu_seqlens,
+            mWorkItems,
+            sSched,
+            lane,
+            warp_idx,
+            mA_log,
+            mDt_bias,
+            sK_inv_raw,
+            sGate_raw,
+            mBeta,
+            sBeta_raw,
+            sK_raw,
+            sK_decay_raw,
+            sK_restore_raw,
+            sState_scale_diag_raw,
+            bars,
+        )
+    elif warp_idx >= cfg.compute_group_1_warp_ids[0] and warp_idx <= cfg.compute_group_1_warp_ids[-1]:
+        compute1_warp_group(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            cu_seqlens,
+            mWorkItems,
+            sSched,
+            lane,
+            sTmem_base,
+            warp_idx,
+            mState_out,
+            mState_init,
+            sBeta_raw,
+            sV_raw,
+            sCheckpoint_raw,
+            checkpoint_every_n_tokens,
+            bars,
+        )
+
+
+@dataclass
+class KdaRecomputeCfg:
+    """Kernel cfg (fixed BT=16 schedule constants; derived TMEM column offsets
+    and SMEM buffer cosizes are stamped by ``build_cfg``; per-stage sizes are
+    inlined at the use sites).  Owned by ``KdaRecomputeOp`` and passed into
+    ``kernel`` and every warp body."""
+
+    io_dtype: Type[cutlass.Numeric]
+    state_dtype: Type[cutlass.Numeric]
+    use_initial_state: bool
+    store_final_state: bool
+    enable_checkpoints: bool
+    l2norm: bool
+    safe_gate: bool
+    gate_scale_log2: float
+    beta_sigmoid: bool
+    k_ratio: int
+    v_ratio: int
+    n_heads_out: int
+    max_active_clusters: int
+    dyn_sched: bool = False
+    sched_stages: int = CFG.SMEM_SCHED_STAGES
+
+    compute_group_0_warp_ids: tuple[int, ...] = CFG.COMPUTE_GROUP_0_WARP_IDS
+    compute_group_1_warp_ids: tuple[int, ...] = CFG.COMPUTE_GROUP_1_WARP_IDS
+    super_mma_warp_id: int = CFG.SUPER_MMA_WARP_ID
+    tcgen05_mma_warp_id: int = CFG.TCGEN05_MMA_WARP_ID
+    tma_warp_id: int = CFG.TMA_WARP_ID
+    epilogue_warp_id: int = CFG.EPILOGUE_WARP_ID
+    b_t: int = CFG.B_T
+    d_k: int = CFG.D_K
+    d_v: int = CFG.D_V
+    threads_per_warp: int = CFG.THREADS_PER_WARP
+    buffer_align_bytes: int = CFG.BUFFER_ALIGN_BYTES
+    threads_per_cta: int = 0
+    cg0_group_count: int = 0  # derived by build_cfg
+    cg0_warps_per_group: int = 4
+    cg0_threads_per_group: int = 0
+    cg0_group_sync_barrier_base_id: int = 1  # CG0 group g syncs on nbar id 1 + g
+    cg0_tile_entry_barrier_id: int = 5  # CG0-wide (both groups) work-item entry sync
+    tmem_user_threads: int = 0
+    tmem_lifecycle_barrier_id: int = 3
+    num_regs_compute_group_0: int = CFG.NUM_REGS_COMPUTE_GROUP_0
+    num_regs_compute_group_1: int = CFG.NUM_REGS_COMPUTE_GROUP_1
+    num_regs_other: int = CFG.NUM_REGS_OTHER
+
+    # ---- SMEM / TMEM ring stage counts -------------------------------------------
+    smem_raw_stages: int = CFG.SMEM_RAW_STAGES
+    smem_checkpoint_stages: int = 1
+    smem_decay_stages: int = CFG.SMEM_DECAY_STAGES
+    smem_intermediate_stages: int = CFG.SMEM_INTERMEDIATE_STAGES
+    smem_state_scale_diag_stages: int = CFG.SMEM_STATE_SCALE_DIAG_STAGES
+    qk_scale_ready_stages: int = CFG.QK_SCALE_READY_STAGES
+
+    # ---- TMEM column offsets (state doubles as the final_state acc) --------------
+    tmem_state_acc_offset: int = 0
+    tmem_state_inp_offset: int = 0
+    tmem_state_k_acc_offset: int = 0
+    tmem_u_acc_offset: int = 0
+    tmem_y_inp_offset: int = 0
+    tmem_u_inp_offset: int = 0
+
+    # ---- SMEM buffer cosizes -----------------------------------------------------
+    k_cosize: int = 0
+    v_cosize: int = 0
+    gate_cosize: int = 0
+    beta_cosize: int = 0
+    k_inv_cosize: int = 0
+    k_decay_cosize: int = 0
+    k_restore_cosize: int = 0
+    state_scale_diag_cosize: int = 0
+
+    # TMA transaction bytes per stage
+    tma_k_bytes: int = 0
+    tma_v_bytes: int = 0
+    tma_gate_bytes: int = 0
+    intermediate_cosize: int = 0
+
+
+def build_cfg(
+    io_dtype: Type[cutlass.Numeric],
+    state_dtype: Type[cutlass.Numeric],
+    *,
+    use_initial_state: bool,
+    store_final_state: bool,
+    enable_checkpoints: bool,
+    l2norm: bool,
+    safe_gate: bool,
+    gate_scale_log2: float,
+    beta_sigmoid: bool,
+    k_ratio: int,
+    v_ratio: int,
+    n_heads_out: int,
+    max_active_clusters: int,
+    dyn_sched: bool = False,
+) -> KdaRecomputeCfg:
+    """Build the per-compile ``KdaRecomputeCfg`` (io_dtype in {Float16, BFloat16});
+    fills the derived TMEM column offsets and SMEM buffer cosizes."""
+    if io_dtype not in (cutlass.Float16, cutlass.BFloat16):
+        raise ValueError(f"io_dtype={io_dtype} not supported; only Float16 and BFloat16 are supported")
+    cfg = KdaRecomputeCfg(
+        io_dtype=io_dtype,
+        state_dtype=state_dtype,
+        use_initial_state=use_initial_state,
+        store_final_state=store_final_state,
+        enable_checkpoints=enable_checkpoints,
+        l2norm=l2norm,
+        safe_gate=safe_gate,
+        gate_scale_log2=gate_scale_log2,
+        beta_sigmoid=beta_sigmoid,
+        k_ratio=k_ratio,
+        v_ratio=v_ratio,
+        n_heads_out=n_heads_out,
+        max_active_clusters=max_active_clusters,
+        dyn_sched=dyn_sched,
+    )
+    if enable_checkpoints:
+        cfg.smem_raw_stages = 6
+        cfg.smem_checkpoint_stages = 2
+    if cfg.smem_raw_stages % 2 != 0:
+        raise ValueError("smem_raw_stages must be even: the CG0 ping-pong groups alias parity waits on odd rings")
+    role_ids = (
+        *cfg.compute_group_0_warp_ids,
+        *cfg.compute_group_1_warp_ids,
+        cfg.super_mma_warp_id,
+        cfg.tcgen05_mma_warp_id,
+        cfg.tma_warp_id,
+        cfg.epilogue_warp_id,
+    )
+    if tuple(sorted(role_ids)) != tuple(range(len(role_ids))):
+        raise ValueError("warp roles must be disjoint and cover contiguous IDs from zero")
+    for group in (cfg.compute_group_0_warp_ids, cfg.compute_group_1_warp_ids):
+        if not group or group != tuple(range(group[0], group[-1] + 1)):
+            raise ValueError("compute warp groups must be nonempty and use contiguous IDs")
+    if cfg.cg0_warps_per_group != 4:
+        raise ValueError("the fixed schedule requires four warps per compute group 0 subgroup")
+    if len(cfg.compute_group_0_warp_ids) % cfg.cg0_warps_per_group:
+        raise ValueError("compute group 0 must divide evenly into ping-pong warp groups")
+    cfg.cg0_group_count = len(cfg.compute_group_0_warp_ids) // cfg.cg0_warps_per_group
+    if cfg.cg0_group_count != 2:
+        raise ValueError("the fixed schedule requires two compute group 0 ping-pong subgroups")
+    cfg.threads_per_cta = len(role_ids) * cfg.threads_per_warp
+    cfg.cg0_threads_per_group = cfg.cg0_warps_per_group * cfg.threads_per_warp
+    cfg.tmem_user_threads = (1 + len(cfg.compute_group_1_warp_ids)) * cfg.threads_per_warp
+    named_barrier_ids = (
+        *range(
+            cfg.cg0_group_sync_barrier_base_id,
+            cfg.cg0_group_sync_barrier_base_id + cfg.cg0_group_count,
+        ),
+        cfg.tmem_lifecycle_barrier_id,
+        cfg.cg0_tile_entry_barrier_id,
+    )
+    if (
+        any(not 1 <= barrier_id <= 15 for barrier_id in named_barrier_ids)
+        or len(set(named_barrier_ids)) != len(named_barrier_ids)
+    ):
+        raise ValueError("named barrier IDs must be disjoint values in [1, 15]")
+    if cfg.smem_state_scale_diag_stages != cfg.qk_scale_ready_stages:
+        raise ValueError("diag and qk-scale ready rings must share their rolling stage")
+
+    cfg.tmem_state_inp_offset = cfg.tmem_state_acc_offset + cfg.d_k
+    cfg.tmem_state_k_acc_offset = cfg.tmem_state_inp_offset + (cfg.d_k // 2)
+    cfg.tmem_u_acc_offset = cfg.tmem_state_k_acc_offset + cfg.b_t
+    cfg.tmem_y_inp_offset = cfg.tmem_u_acc_offset + cfg.b_t
+    cfg.tmem_u_inp_offset = cfg.tmem_y_inp_offset + (cfg.b_t // 2)
+    assert (cfg.tmem_u_inp_offset + (cfg.b_t // 2)) <= 512
+
+    cfg.k_cosize = cfg.smem_raw_stages * cfg.d_k * cfg.b_t
+    cfg.v_cosize = cfg.smem_raw_stages * cfg.d_v * cfg.b_t
+    cfg.gate_cosize = cfg.smem_raw_stages * cfg.d_k * cfg.b_t
+    cfg.beta_cosize = cfg.smem_raw_stages * cfg.b_t
+    cfg.k_inv_cosize = cfg.smem_decay_stages * cfg.b_t * cfg.d_k
+    cfg.k_decay_cosize = cfg.smem_decay_stages * cfg.d_k * cfg.b_t
+    cfg.k_restore_cosize = cfg.smem_decay_stages * cfg.d_k * cfg.b_t
+    cfg.state_scale_diag_cosize = cfg.smem_state_scale_diag_stages * (cfg.d_k // 16) * 256
+    cfg.intermediate_cosize = cfg.smem_intermediate_stages * 2 * cfg.b_t * cfg.b_t
+    cfg.tma_k_bytes = cfg.d_k * cfg.b_t * (cfg.io_dtype.width // 8)
+    cfg.tma_v_bytes = cfg.d_v * cfg.b_t * (cfg.io_dtype.width // 8)
+    cfg.tma_gate_bytes = cfg.d_k * cfg.b_t * 4
+    return cfg
+
+
+TENSORMAP_DESC_ARRAYS = 4  # per-batch runtime TMA descriptors: K, V, Gate, state_checkpoints
+TENSORMAP_STATIC_SLOTS = 0
+
+
+@cute.jit
+def build_descs_body(
+    widx,
+    base_k,
+    base_v,
+    base_gate,
+    base_checkpoint,
+    desc_ws: cute.Tensor,
+    cu_seqlens: cute.Tensor,
+    k: cute.Tensor,
+    v: cute.Tensor,
+    gate: cute.Tensor,
+    state_checkpoints: cute.Tensor | None,
+    n_batch: cutlass.Int32,
+    k_row_stride: cutlass.Int32,
+    v_row_stride: cutlass.Int32,
+    gate_row_stride: cutlass.Int32,
+    checkpoint_row_stride: cutlass.Int32,
+    checkpoint_every_n: cutlass.Int32,
+) -> None:
+    """Per-batch descriptor-array build, one warp per array. Runs inside the
+    prologue kernel after its order pass; warps past the array count fall
+    through the widx guards."""
+    arr_words = n_batch * cutlass.Int32(TENSOR_MAP_QWORDS)
+    desc_words_k = cute.make_tensor(desc_ws.iterator, cute.make_layout((arr_words,), stride=(1,)))
+    desc_words_v = cute.make_tensor(desc_ws.iterator + arr_words, cute.make_layout((arr_words,), stride=(1,)))
+    desc_words_gate = cute.make_tensor(desc_ws.iterator + 2 * arr_words, cute.make_layout((arr_words,), stride=(1,)))
+    desc_words_checkpoint = cute.make_tensor(desc_ws.iterator + 3 * arr_words, cute.make_layout((arr_words,), stride=(1,)))
+
+    if widx == 0:
+        if nvvm.elect_sync():
+            emit_seq_load_descs(
+                base_k, desc_words_k, cu_seqlens, k, n_batch, k_row_stride, 2
+            )
+            nvvm.fence_proxy_release(nvvm.MemScope.GPU, from_proxy=nvvm.Proxy.GENERIC, to_proxy=nvvm.Proxy.TENSORMAP)
+    if widx == 1:
+        if nvvm.elect_sync():
+            emit_seq_load_descs(
+                base_v, desc_words_v, cu_seqlens, v, n_batch, v_row_stride, 2
+            )
+            nvvm.fence_proxy_release(nvvm.MemScope.GPU, from_proxy=nvvm.Proxy.GENERIC, to_proxy=nvvm.Proxy.TENSORMAP)
+    if widx == 2:
+        if nvvm.elect_sync():
+            emit_seq_load_descs(
+                base_gate,
+                desc_words_gate,
+                cu_seqlens,
+                gate,
+                n_batch,
+                gate_row_stride,
+                2,
+            )
+            nvvm.fence_proxy_release(nvvm.MemScope.GPU, from_proxy=nvvm.Proxy.GENERIC, to_proxy=nvvm.Proxy.TENSORMAP)
+    if cutlass.const_expr(state_checkpoints is not None):
+        if widx == 3:
+            if nvvm.elect_sync():
+                emit_checkpoint_seq_descs(
+                    base_checkpoint, desc_words_checkpoint, cu_seqlens, state_checkpoints, n_batch, checkpoint_row_stride, checkpoint_every_n, 2
+                )
+                nvvm.fence_proxy_release(nvvm.MemScope.GPU, from_proxy=nvvm.Proxy.GENERIC, to_proxy=nvvm.Proxy.TENSORMAP)
+
+
+@cute.kernel
+def prologue_kernel(
+    run_order: cutlass.Constexpr[bool],
+    order_gen: cutlass.Constexpr[bool],
+    has_sched: cutlass.Constexpr[bool],
+    b_t: cutlass.Constexpr[int],
+    base_k: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    base_v: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    base_gate: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    base_checkpoint: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    desc_ws: cute.Tensor,
+    cu_seqlens: cute.Tensor,
+    k: cute.Tensor,
+    v: cute.Tensor,
+    gate: cute.Tensor,
+    state_checkpoints: cute.Tensor | None,
+    mStaging: cute.Tensor | None,
+    mCount: cute.Tensor,
+    mWorkItems: cute.Tensor | None,
+    mSched: cute.Tensor | None,
+    n_batch: cutlass.Int32,
+    k_row_stride: cutlass.Int32,
+    v_row_stride: cutlass.Int32,
+    gate_row_stride: cutlass.Int32,
+    checkpoint_row_stride: cutlass.Int32,
+    checkpoint_every_n: cutlass.Int32,
+) -> None:
+    """Single-CTA prologue. Under ``run_order`` this kernel is the first
+    work-item-table consumer, so it LPT-orders the table and zeroes both
+    consumers' sched rings via :func:`order_body`; it then builds the
+    per-batch TMA-descriptor arrays via :func:`build_descs_body`, one warp
+    per array (the extra warps only take part in the order phase)."""
+    tidx, _, _ = cute.arch.thread_idx()
+    tidx = cutlass.Int32(tidx)
+    widx = tidx // cutlass.Int32(32)
+    if cutlass.const_expr(run_order):
+        sKey = cutlass.Array(cutlass.Int32, ORDER_CAPACITY, space=cutlass.AddressSpace.smem, alignment=16)
+        sIdx = cutlass.Array(cutlass.Int32, ORDER_CAPACITY, space=cutlass.AddressSpace.smem, alignment=16)
+        sSpread = cutlass.Array(cutlass.Int32, 2, space=cutlass.AddressSpace.smem, alignment=8)
+        n_heads_out = cutlass.Int32(gate.shape[1])
+        order_body(
+            order_gen,
+            has_sched,
+            b_t,
+            ORDER_THREADS,
+            ORDER_ELEMS,
+            tidx,
+            n_heads_out,
+            n_heads_out * n_batch,
+            cu_seqlens,
+            mStaging,
+            mCount,
+            mWorkItems,
+            mSched,
+            sKey,
+            sIdx,
+            sSpread,
+        )
+    build_descs_body(
+        widx,
+        base_k,
+        base_v,
+        base_gate,
+        base_checkpoint,
+        desc_ws,
+        cu_seqlens,
+        k,
+        v,
+        gate,
+        state_checkpoints,
+        n_batch,
+        k_row_stride,
+        v_row_stride,
+        gate_row_stride,
+        checkpoint_row_stride,
+        checkpoint_every_n,
+    )
+
+
+@cute.jit
+def prologue(
+    io_dtype: cutlass.Constexpr,
+    b_t: cutlass.Constexpr[int],
+    run_order: cutlass.Constexpr[bool],
+    order_gen: cutlass.Constexpr[bool],
+    has_sched: cutlass.Constexpr[bool],
+    k: cute.Tensor,
+    v: cute.Tensor,
+    gate: cute.Tensor,
+    state_checkpoints: cute.Tensor | None,
+    cu_seqlens: cute.Tensor,
+    work_item_staging: cute.Tensor | None,
+    work_count: cute.Tensor,
+    work_items: cute.Tensor | None,
+    sched_all: cute.Tensor | None,
+    tensormap_workspace: cute.Tensor,
+    checkpoint_every_n: cutlass.Int32,
+    stream: cuda_driver.CUstream,
+):
+    """One-launch prologue: LPT-order the work items (when ``run_order``) and
+    build the per-batch K/V/Gate/checkpoint TMA-descriptor arrays into
+    ``tensormap_workspace``."""
+    h_k = k.shape[1]
+    h_v = v.shape[1]
+    ho = gate.shape[1]
+    batch_size = cu_seqlens.shape[0] - 1
+    d_k = k.shape[2]
+    d_v = v.shape[2]
+    bpe = io_dtype.width // 8
+    tma_granu_elems = 128 // bpe
+    seqlen = k.shape[0]
+
+    k_headed = cute.make_tensor(k.iterator, cute.make_layout((d_k, h_k, seqlen), stride=(1, k.stride[1], k.stride[0])))
+    v_headed = cute.make_tensor(v.iterator, cute.make_layout((d_v, h_v, seqlen), stride=(1, v.stride[1], v.stride[0])))
+    gate_headed = cute.make_tensor(gate.iterator, cute.make_layout((d_k, ho, seqlen), stride=(1, gate.stride[1], gate.stride[0])))
+
+    swz = cuda.TensorMapSwizzle.s128b
+    base_k = cuda.create_tensor_map_tiled_from_view(k_headed, box_dims=(tma_granu_elems, 1, b_t), stride_order=(0, 1, 2), swizzle=swz)
+    base_v = cuda.create_tensor_map_tiled_from_view(v_headed, box_dims=(tma_granu_elems, 1, b_t), stride_order=(0, 1, 2), swizzle=swz)
+    base_gate = cuda.create_tensor_map_tiled_from_view(gate_headed, box_dims=(32, 1, b_t), stride_order=(0, 1, 2), swizzle=swz)
+
+    base_checkpoint = base_gate
+    if cutlass.const_expr(state_checkpoints is not None):
+        checkpoint_view = cute.make_tensor(
+            state_checkpoints.iterator,
+            cute.make_layout(
+                (state_checkpoints.shape[3], state_checkpoints.shape[2], state_checkpoints.shape[0], ho),
+                stride=(state_checkpoints.stride[3], state_checkpoints.stride[2], state_checkpoints.stride[0], state_checkpoints.stride[1]),
+            ),
+        )
+        base_checkpoint = cuda.create_tensor_map_tiled_from_view(checkpoint_view, box_dims=(tma_granu_elems, d_k, 1, 1), stride_order=(0, 1, 2, 3), swizzle=swz)
+    prologue_kernel(
+        run_order,
+        order_gen,
+        has_sched,
+        b_t,
+        base_k,
+        base_v,
+        base_gate,
+        base_checkpoint,
+        tensormap_workspace,
+        cu_seqlens,
+        k,
+        v,
+        gate,
+        state_checkpoints,
+        work_item_staging,
+        work_count,
+        work_items,
+        sched_all,
+        cutlass.Int32(batch_size),
+        cutlass.Int32(k.stride[0]),
+        cutlass.Int32(v.stride[0]),
+        cutlass.Int32(gate.stride[0]),
+        cutlass.Int32(state_checkpoints.stride[0] if state_checkpoints is not None else 0),
+        checkpoint_every_n,
+    ).launch(grid=(1, 1, 1), block=(ORDER_THREADS, 1, 1), stream=stream)
+
+
+# ---- Torch adapter / host-side compilation ---------------------------------------
+
+
+@lru_cache(maxsize=None)
+def get_compiled_cache(
+    io_dtype_str: str,
+    state_dtype_str: str,
+    cu_dtype_str: str,
+    HO: int,
+    HK: int,
+    HV: int,
+    use_initial_state: bool,
+    store_final_state: bool,
+    enable_checkpoints: bool,
+    l2norm: bool,
+    safe_gate: bool,
+    gate_lower_bound: float,
+    beta_sigmoid: bool,
+    dyn_sched: bool,
+    run_order: bool,
+    order_gen: bool,
+    device_index: int,
+    device_major: int,
+    device_minor: int,
+    num_sm: int,
+):
+    """Return a mutable dict that lazily stores the compiled kernel."""
+    return {}
+
+
+def compile(
+    io_dtype,
+    state_dtype,
+    use_initial_state: bool,
+    store_final_state: bool,
+    enable_checkpoints: bool,
+    l2norm: bool,
+    safe_gate: bool,
+    gate_scale_log2: float,
+    beta_sigmoid: bool,
+    k_ratio: int,
+    v_ratio: int,
+    n_heads_out: int,
+    dyn_sched: bool = False,
+    *,
+    num_sm: int,
+    k_cute,
+    v_cute,
+    gate_cute,
+    a_log_cute,
+    dt_bias_cute,
+    beta_cute,
+    cu_seqlens_cute,
+    state_in_cute,
+    state_out_cute,
+    work_items_cute=None,
+    work_count_cute=None,
+    sched_ctr_cute=None,
+    tensormap_ws_cute,
+    checkpoint_every_n_tokens,
+    stream,
+):
+    """JIT-compile the chunked KDA recompute kernel for one static config."""
+    cfg = build_cfg(
+        io_dtype,
+        state_dtype,
+        use_initial_state=use_initial_state,
+        store_final_state=store_final_state,
+        enable_checkpoints=enable_checkpoints,
+        l2norm=l2norm,
+        safe_gate=safe_gate,
+        gate_scale_log2=gate_scale_log2,
+        beta_sigmoid=beta_sigmoid,
+        k_ratio=k_ratio,
+        v_ratio=v_ratio,
+        n_heads_out=n_heads_out,
+        max_active_clusters=num_sm,
+        dyn_sched=dyn_sched,
+    )
+
+    op = KdaRecomputeOp(cfg)
+    op.__call__.set_name_prefix(op.get_name())
+    return cute.compile(
+        op,
+        k_cute,
+        v_cute,
+        gate_cute,
+        a_log_cute,
+        dt_bias_cute,
+        beta_cute,
+        cu_seqlens_cute,
+        state_in_cute,
+        state_out_cute,
+        work_items_cute,
+        work_count_cute,
+        sched_ctr_cute,
+        tensormap_ws_cute,
+        checkpoint_every_n_tokens,
+        stream,
+        options="--enable-tvm-ffi --opt-level 2",
+    )
+
+
+def chunk_kda_recompute_sm100(
+    k,
+    v,
+    gate,
+    beta,
+    cu_seqlens,
+    initial_state,
+    output_state,
+    checkpoint_every_n_tokens: int = 0,
+    output_state_checkpoints=None,
+    use_qk_l2norm_in_kernel: bool = False,
+    safe_gate: bool = False,
+    gate_lower_bound: float = DEFAULT_GATE_LOWER_BOUND,
+    a_log=None,
+    dt_bias=None,
+    use_beta_sigmoid: bool = False,
+    work_items=None,
+    work_count=None,
+    sched_ctr=None,
+    sched_all=None,
+    work_item_scratch=None,
+    order_in_prologue: bool = False,
+    *,
+    tensormap_workspace,
+    stream,
+) -> None:
+    """Execute the Blackwell BT=16 chunked KDA recompute (state/checkpoints-only)
+    kernel.
+
+    All tensors must be on the same CUDA device with a stride-1 innermost
+    dim; outer strides are free (padded / permuted views are read through
+    the TMA descriptors and dynamic layouts).
+
+    Args:
+        k: ``(total_tokens, HK, DK)`` float16/bfloat16
+        v: ``(total_tokens, HV, DV)`` float16/bfloat16
+        gate: ``(total_tokens, HO, DK)`` float32.  Natural-log decay unless
+              ``safe_gate``, which applies the safe-gate transform
+              ``lower_bound * sigmoid(exp(a_log) * (gate + dt_bias))``.
+        beta: ``(total_tokens, HO)``.  Post-sigmoid float32, or io-dtype
+              logits when ``use_beta_sigmoid``
+        cu_seqlens: ``(num_seqs + 1,)`` int32
+        initial_state: ``(num_seqs, HO, DV, DK)`` float32/bfloat16, or None
+        output_state: ``(num_seqs, HO, DV, DK)`` float32/bfloat16, or None
+        checkpoint_every_n_tokens: emit entering-state checkpoints every N tokens (0 = off),
+            where N is a positive multiple of the 16-token kernel tile.
+            Sequence-local row ``j`` is the state before token ``j * N``; row zero is the
+            provided initial state or zeros. A nonempty sequence contributes ``ceil(L / N)``
+            rows. With ``N == B_T`` this is the per-chunk series consumed by bprop.
+        output_state_checkpoints: ``(total_checkpoints, HO, DV, DK)`` io-dtype (VK, K
+            contiguous); per-sequence entry offsets are derived on device from
+            ``cu_seqlens``, so there is no separate checkpoint-offset tensor.
+        use_qk_l2norm_in_kernel: L2-normalize k rows inside the kernel
+        safe_gate: interpret ``gate`` through the safe-gate transform
+        a_log: ``(HO,)`` float32, safe-gate per-head log-amplitude (None = 0)
+        dt_bias: ``(HO, DK)`` float32, safe-gate channel bias (None = 0)
+        use_beta_sigmoid: ``beta`` holds logits; sigmoid in-kernel
+        work_items: ``(max_items, 8)`` int32 work-item table from
+            ``common/split_k.py`` (REQUIRED; an uncut table row is the whole
+            (b, h) sequence).  Each item computes chunks ``[cstart, wend)``
+            and writes checkpoints only for ``[wstart, wend)``.
+        work_count: ``(1,)`` int32 device-side item count (REQUIRED)
+        sched_ctr: ``(2,)`` int32 device scratch ``[ticket, done]`` enabling
+            the dynamic (work-stealing) tile scheduler; must be zeroed before
+            every launch (``build_split_table`` does this when it is passed as
+            ``sched_ctr``).  None keeps the static CTA stride.
+    """
+    for name, tensor in (("k", k), ("v", v), ("gate", gate)):
+        validate_tma_tensor(name, tensor)
+    for name, tensor in (
+        ("initial_state", initial_state),
+        ("output_state", output_state),
+        ("output_state_checkpoints", output_state_checkpoints),
+    ):
+        if tensor is not None:
+            validate_tma_tensor(name, tensor)
+    if cu_seqlens.data_ptr() % 8:
+        raise ValueError("cu_seqlens data pointer must be 8-byte aligned")
+
+    tokens, HK, d_k = k.shape
+    HV, HO = v.shape[1], gate.shape[1]
+    if d_k != 128 or v.shape != (tokens, HV, 128):
+        raise ValueError("k and v must have shape (T, H, 128)")
+    if gate.shape != (tokens, HO, 128) or beta.shape != (tokens, HO):
+        raise ValueError("gate and beta must share the output head count and token extent")
+    use_initial_state = initial_state is not None
+    store_final_state = output_state is not None
+    if checkpoint_every_n_tokens < 0:
+        raise ValueError("checkpoint interval must be zero or a positive tile multiple")
+    enable_checkpoints = checkpoint_every_n_tokens > 0
+    if enable_checkpoints and checkpoint_every_n_tokens % CFG.B_T:
+        raise ValueError(f"checkpoint interval must be a positive multiple of {CFG.B_T}")
+    if enable_checkpoints:
+        if output_state_checkpoints is None:
+            raise ValueError("checkpoint_every_n_tokens > 0 requires output_state_checkpoints")
+        required_checkpoint_rows = checkpoint_capacity_bound(
+            k.shape[0], cu_seqlens.shape[0] - 1, checkpoint_every_n_tokens
+        )
+        if output_state_checkpoints.shape[0] < required_checkpoint_rows:
+            raise ValueError(
+                f"output_state_checkpoints requires at least {required_checkpoint_rows} rows, "
+                f"got {output_state_checkpoints.shape[0]}"
+            )
+        if str(output_state_checkpoints.dtype).split(".")[-1] != str(k.dtype).split(".")[-1]:
+            raise ValueError(
+                f"output_state_checkpoints dtype must match the io dtype (fp32 state belongs to output_state): got {output_state_checkpoints.dtype} with io {k.dtype}"
+            )
+    if work_items is None or work_count is None:
+        raise ValueError("work_items/work_count are required (the split-table stage builds them for every launch)")
+    dyn_sched = sched_ctr is not None
+    run_order = order_in_prologue
+    order_gen = order_in_prologue and work_item_scratch is None
+    if run_order and sched_all is None:
+        raise ValueError("order in the prologue requires sched_all (the prologue zeroes both consumers' sched rings)")
+
+    if initial_state is not None:
+        state_dtype_src = initial_state.dtype
+    elif output_state is not None:
+        state_dtype_src = output_state.dtype
+    else:
+        state_dtype_src = "float32"
+
+    for name, h in (("HK", HK), ("HV", HV)):
+        if HO % h != 0:
+            raise ValueError(f"{name}={h} must divide sab heads {HO}")
+    k_ratio = HO // HK
+    v_ratio = HO // HV
+    gate_scale_log2 = gate_lower_bound * LOG2_E
+
+    if safe_gate and (a_log is None or dt_bias is None):
+        raise ValueError("safe_gate requires a_log and dt_bias")
+    if dt_bias is not None:
+        validate_tma_tensor("dt_bias", dt_bias)
+    if not safe_gate:
+        a_log = None
+        dt_bias = None
+    cu_stream = cuda_driver.CUstream(int(stream))
+    device_index = tensor_device_index(k)
+    if current_device() != device_index:
+        raise ValueError("the active CUDA device must match k.device")
+    device_properties = get_device_properties(device_index)
+    num_sm = device_properties.multi_processor_count
+
+    cache = get_compiled_cache(
+        str(k.dtype),
+        str(state_dtype_src),
+        str(cu_seqlens.dtype),
+        HO,
+        HK,
+        HV,
+        use_initial_state,
+        store_final_state,
+        enable_checkpoints,
+        use_qk_l2norm_in_kernel,
+        safe_gate,
+        gate_lower_bound,
+        use_beta_sigmoid,
+        dyn_sched,
+        run_order,
+        order_gen,
+        device_index,
+        device_properties.major,
+        device_properties.minor,
+        num_sm,
+    )
+
+    if "compiled" not in cache:
+        io_dtype = get_dtype(k.dtype)
+        state_dtype = get_dtype(state_dtype_src)
+        k_cute = from_dlpack(k, assumed_align=16).mark_layout_dynamic(leading_dim=2)
+        v_cute = from_dlpack(v, assumed_align=16).mark_layout_dynamic(leading_dim=2)
+        gate_cute = from_dlpack(gate, assumed_align=16).mark_layout_dynamic(leading_dim=2)
+        a_log_cute = from_dlpack(a_log, assumed_align=4) if a_log is not None else None
+        dt_bias_cute = from_dlpack(dt_bias, assumed_align=16) if dt_bias is not None else None
+        beta_cute = from_dlpack(beta, assumed_align=4).mark_layout_dynamic(leading_dim=1)
+        cu_seqlens_cute = from_dlpack(cu_seqlens, assumed_align=8).mark_layout_dynamic()
+
+        state_in_cute = None
+        if use_initial_state:
+            state_in_cute = from_dlpack(initial_state, assumed_align=16).mark_layout_dynamic(leading_dim=3)
+
+        state_out_cute = None
+        if store_final_state:
+            state_out_cute = from_dlpack(output_state, assumed_align=16).mark_layout_dynamic(leading_dim=3)
+
+        work_items_cute = from_dlpack(work_items, assumed_align=16)
+        work_items_cute.mark_compact_shape_dynamic(mode=0, stride_order=(0, 1), divisibility=1)
+        work_count_cute = from_dlpack(work_count, assumed_align=4).mark_layout_dynamic()
+
+        sched_ctr_cute = None
+        if dyn_sched:
+            sched_ctr_cute = from_dlpack(sched_ctr, assumed_align=4).mark_layout_dynamic()
+
+        tensormap_ws_cute = from_dlpack(tensormap_workspace, assumed_align=128).mark_layout_dynamic()
+
+        cache["compiled"] = compile(
+            io_dtype,
+            state_dtype,
+            use_initial_state,
+            store_final_state,
+            enable_checkpoints,
+            use_qk_l2norm_in_kernel,
+            safe_gate,
+            gate_scale_log2,
+            use_beta_sigmoid,
+            k_ratio,
+            v_ratio,
+            HO,
+            dyn_sched,
+            num_sm=num_sm,
+            k_cute=k_cute,
+            v_cute=v_cute,
+            gate_cute=gate_cute,
+            a_log_cute=a_log_cute,
+            dt_bias_cute=dt_bias_cute,
+            beta_cute=beta_cute,
+            cu_seqlens_cute=cu_seqlens_cute,
+            state_in_cute=state_in_cute,
+            state_out_cute=state_out_cute,
+            work_items_cute=work_items_cute,
+            work_count_cute=work_count_cute,
+            sched_ctr_cute=sched_ctr_cute,
+            tensormap_ws_cute=tensormap_ws_cute,
+            checkpoint_every_n_tokens=checkpoint_every_n_tokens,
+            stream=cu_stream,
+        )
+
+    compiled = cache["compiled"]
+    state_checkpoints_for_descs = output_state_checkpoints if enable_checkpoints else None
+    if "prologue" not in cache:
+        io_dtype = get_dtype(k.dtype)
+        k_pl = from_dlpack(k, assumed_align=16).mark_layout_dynamic(leading_dim=2)
+        v_pl = from_dlpack(v, assumed_align=16).mark_layout_dynamic(leading_dim=2)
+        gate_pl = from_dlpack(gate, assumed_align=16).mark_layout_dynamic(leading_dim=2)
+        cu_pl = from_dlpack(cu_seqlens, assumed_align=8).mark_layout_dynamic()
+        ws_pl = from_dlpack(tensormap_workspace, assumed_align=128).mark_layout_dynamic()
+        state_checkpoints_pl = None
+        if state_checkpoints_for_descs is not None:
+            state_checkpoints_pl = from_dlpack(state_checkpoints_for_descs, assumed_align=16).mark_layout_dynamic(leading_dim=3)
+        staging_pl = None
+        if run_order and not order_gen:
+            staging_pl = from_dlpack(work_item_scratch, assumed_align=16)
+            staging_pl.mark_compact_shape_dynamic(mode=0, stride_order=(0, 1), divisibility=1)
+        work_items_pl = from_dlpack(work_items, assumed_align=16)
+        work_items_pl.mark_compact_shape_dynamic(mode=0, stride_order=(0, 1), divisibility=1)
+        work_count_pl = from_dlpack(work_count, assumed_align=4).mark_layout_dynamic()
+        sched_pl = None
+        if run_order:
+            sched_pl = from_dlpack(sched_all, assumed_align=4).mark_layout_dynamic()
+        cache["prologue"] = cute.compile(
+            prologue,
+            io_dtype,
+            CFG.B_T,
+            run_order,
+            order_gen,
+            run_order,
+            k_pl,
+            v_pl,
+            gate_pl,
+            state_checkpoints_pl,
+            cu_pl,
+            staging_pl,
+            work_count_pl,
+            work_items_pl,
+            sched_pl,
+            ws_pl,
+            cutlass.Int32(checkpoint_every_n_tokens),
+            cu_stream,
+            options="--enable-tvm-ffi",
+        )
+    cache["prologue"](
+        k,
+        v,
+        gate,
+        state_checkpoints_for_descs,
+        cu_seqlens,
+        work_item_scratch if run_order else None,
+        work_count,
+        work_items,
+        sched_all if run_order else None,
+        tensormap_workspace,
+        checkpoint_every_n_tokens,
+        cu_stream,
+    )
+    compiled(
+        k,
+        v,
+        gate,
+        a_log,
+        dt_bias,
+        beta,
+        cu_seqlens,
+        initial_state if use_initial_state else None,
+        output_state if store_final_state else None,
+        work_items,
+        work_count,
+        sched_ctr,
+        tensormap_workspace,
+        checkpoint_every_n_tokens,
+        cu_stream,
+    )

--- a/attn_gym/linear/_delta_rule/mega/kernels/tile_dsl/__init__.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/tile_dsl/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""CuTeDSL tile primitives shared by the vendored KDA kernels."""

--- a/attn_gym/linear/_delta_rule/mega/kernels/tile_dsl/barrier.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/tile_dsl/barrier.py
@@ -1,0 +1,226 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+
+import enum
+from dataclasses import dataclass, replace
+from typing import NamedTuple
+
+from cutlass.cute.arch.nvvm_wrappers import inline_ptx
+from cutlass.experimental import primitives as nvvm
+import cutlass
+import cutlass.cute as cute
+
+WAIT_TIMEOUT = 1
+
+
+class PipelineState(NamedTuple):
+    idx: object
+    phase: object
+
+    @classmethod
+    def start(cls, phase: int = 0):
+        return cls(idx=cutlass.Int32(0), phase=cutlass.Int32(phase))
+
+
+def advance(state, stages):
+    if stages < 1:
+        raise ValueError(f"PipelineState.advance requires stages >= 1, got {stages}")
+    incr = state.idx + cutlass.Int32(1)
+    stages_i = cutlass.Int32(stages)
+    new_idx = incr % stages_i
+    flip = incr // stages_i
+    new_phase = state.phase ^ flip
+    return PipelineState(idx=new_idx, phase=new_phase)
+
+
+@cute.jit
+def wait(mb, phase):
+    while not nvvm.mbarrier_try_wait_parity(mb, phase, time_limit=WAIT_TIMEOUT):
+        pass
+
+
+@cute.jit
+def arrive(mb):
+    nvvm.mbarrier_arrive(mb)
+
+
+@cute.jit
+def arrive_expect_tx(mb, n_bytes, pred=None):
+    if cutlass.const_expr(pred is None):
+        nvvm.mbarrier_arrive_expect_tx(mb, n_bytes)
+    else:
+        # A branch round the native op, NOT nvvm.inline_ptx(predicate=...): the
+        # DSL can lower that predicate to the last operand's *value* rather than
+        # a predicate register, emitting PTX like
+        #     @512 mbarrier.arrive.expect_tx.release.cta.shared.b64 %rd271, [%r202], 512;
+        # which ptxas rejects as a syntax error, surfaced only as the generic
+        # "NVVM backend compilation failed".  The two forms are equivalent here --
+        # a thread whose predicate is false does not arrive either way.
+        if pred:
+            nvvm.mbarrier_arrive_expect_tx(mb, n_bytes)
+
+
+@cute.jit
+def cga_arrive():
+    nvvm.barrier_cluster_arrive_relaxed_aligned()
+
+
+@cute.jit
+def cga_wait():
+    nvvm.barrier_cluster_wait_aligned()
+
+
+@cute.jit
+def wait_on_dependent_grids():
+    inline_ptx(
+        "griddepcontrol.wait;",
+        write_only_types=[],
+        read_only_args=[],
+    )
+
+
+@cute.jit
+def launch_dependent_grids():
+    inline_ptx(
+        "griddepcontrol.launch_dependents;",
+        write_only_types=[],
+        read_only_args=[],
+    )
+
+
+@cute.jit
+def mbar_arrive_on_peer(mb, peer_cta_id, pred=None):
+    peer_mb = nvvm.mapa(mb, peer_cta_id)
+    if cutlass.const_expr(pred is None):
+        nvvm.mbarrier_arrive(peer_mb, scope=nvvm.MemScope.CLUSTER, relaxed=True)
+    else:
+        nvvm.inline_ptx(
+            "mbarrier.arrive.relaxed.cluster.shared::cluster.b64 _, [{$r0}];",
+            read_only_args=[peer_mb.ir_value()],
+            predicate=pred,
+        )
+
+
+@cute.jit
+def arrive_on_leader(mb, leader_cta_id, cta_group: int):
+    if cutlass.const_expr(cta_group == 1):
+        nvvm.mbarrier_arrive(mb)
+    else:
+        peer_mb = nvvm.mapa(mb, leader_cta_id)
+        nvvm.mbarrier_arrive(peer_mb, scope=nvvm.MemScope.CLUSTER, relaxed=True)
+
+
+@cute.jit
+def commit_mma(mb, mcast_mask, cta_group: int, pred=None):
+    if cutlass.const_expr(pred is None):
+        if cutlass.const_expr(cta_group == 1):
+            nvvm.tcgen05_commit(mb, group=nvvm.CTAGroup.CTA_1)
+        else:
+            nvvm.tcgen05_commit(
+                mb,
+                multicast_mask=mcast_mask,
+                group=nvvm.CTAGroup.CTA_2,
+            )
+    else:
+        # Branch round the native ops rather than nvvm.inline_ptx(predicate=...);
+        # see arrive_expect_tx above.  The multicast form has a second reason: a
+        # constant-folded mask reaches the asm operand as an immediate, and the
+        # emitted "tcgen05.commit...multicast::cluster.b64 [%r661], 3;" is
+        # rejected by ptxas ("Arguments mismatch") because ctaMask must be a
+        # register.  That is the integer twin of the float hazard opaque_f32_zero
+        # documents.  The native op takes the mask as a value and keeps it in a
+        # register, so both problems go away.
+        if pred:
+            if cutlass.const_expr(cta_group == 1):
+                nvvm.tcgen05_commit(mb, group=nvvm.CTAGroup.CTA_1)
+            else:
+                nvvm.tcgen05_commit(mb, multicast_mask=mcast_mask, group=nvvm.CTAGroup.CTA_2)
+
+
+class Producer(enum.IntEnum):
+    THREAD = 0
+    TMA_LOAD = 1
+    MMA_COMMIT = 2
+    LEADER = 3
+
+
+class Scope(enum.IntEnum):
+    LOCAL = 0
+    LEADER = 1
+
+
+@dataclass(frozen=True)
+class MBarrier:
+    base_ptr: object
+    stages: cutlass.Constexpr[int]
+    init_count: cutlass.Constexpr[object]
+    producer: cutlass.Constexpr[int] = int(Producer.THREAD)
+    scope: cutlass.Constexpr[int] = int(Scope.LOCAL)
+    stage_idx: object = 0
+
+    def __getitem__(self, i):
+        return replace(self, stage_idx=i)
+
+    @property
+    def smem_ptr(self):
+        if isinstance(self.stage_idx, int) and self.stage_idx == 0:
+            return self.base_ptr
+        return self.base_ptr.subview(self.stage_idx)
+
+    def init(self, override_count=None):
+        if override_count is not None:
+            count = override_count
+        elif isinstance(self.init_count, (tuple, list)):
+            if not isinstance(self.stage_idx, int):
+                raise TypeError("MBarrier with tuple init_count requires a Python-int " f"stage_idx (via [py_int]); got " f"{type(self.stage_idx).__name__}.")
+            count = int(self.init_count[self.stage_idx])
+        else:
+            count = int(self.init_count)
+        nvvm.mbarrier_init(self.smem_ptr, count)
+
+    def wait(self, phase):
+        wait(self.smem_ptr, phase)
+
+    def arrive(
+        self,
+        *,
+        n_bytes=None,
+        mcast_mask=None,
+        cta_group=None,
+        leader_cta_id=None,
+        pred=None,
+    ):
+        if cutlass.const_expr(self.producer == int(Producer.THREAD)):
+            if cutlass.const_expr(pred is not None):
+                raise TypeError(
+                    "MBarrier(producer=THREAD).arrive() does NOT support pred= "
+                    "(silently over-arrives). Keep the `if nvvm.elect_sync():` "
+                    "branch around the plain arrive; only TMA_LOAD (expect_tx) "
+                    "and MMA_COMMIT (commit) arrives have a predicated path."
+                )
+            arrive(self.smem_ptr)
+
+        elif cutlass.const_expr(self.producer == int(Producer.TMA_LOAD)):
+            if n_bytes is None:
+                raise TypeError("MBarrier(producer=TMA_LOAD).arrive() requires n_bytes=")
+            arrive_expect_tx(self.smem_ptr, n_bytes, pred=pred)
+
+        elif cutlass.const_expr(self.producer == int(Producer.MMA_COMMIT)):
+            if cta_group is None:
+                raise TypeError("MBarrier(producer=MMA_COMMIT).arrive() requires " "cta_group= (Python compile-time int).")
+            commit_mma(self.smem_ptr, mcast_mask, cta_group, pred=pred)
+
+        else:
+            if cta_group is None or leader_cta_id is None:
+                raise TypeError("MBarrier(producer=LEADER).arrive() requires " "cta_group= AND leader_cta_id=.")
+            if cutlass.const_expr(pred is not None):
+                raise TypeError(
+                    "MBarrier(producer=LEADER).arrive() does NOT support pred=. "
+                    "Use arrive_on_peer(pred=) for a predicated cross-CTA arrive, "
+                    "or keep the `if elect_sync():` branch."
+                )
+            arrive_on_leader(self.smem_ptr, leader_cta_id, cta_group)
+
+    def arrive_on_peer(self, peer_cta_id, pred=None):
+        mbar_arrive_on_peer(self.smem_ptr, peer_cta_id, pred=pred)

--- a/attn_gym/linear/_delta_rule/mega/kernels/tile_dsl/handles.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/tile_dsl/handles.py
@@ -1,0 +1,207 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+
+from dataclasses import dataclass, replace
+
+
+@dataclass(frozen=True)
+class MmaDesc:
+    M: int
+    N: int
+    K: int
+    bpe_a: int
+    bpe_b: int
+    tile_k_hw: int = 64
+    btranspose: bool = False
+    atranspose: bool = False
+    k_subtile: int = -1
+    cta_group: int = 1
+    idesc: object = None
+    kind: object = None
+    is_block_scale: bool = False
+    sf_blocks_per_step: int = 0
+    sf_cycle: int = 0
+    scale_vec_size: object = None
+
+    def __post_init__(self):
+        if self.k_subtile < 0:
+            ks = self.K if self.btranspose else (128 // self.bpe_a if (self.K * self.bpe_a) % 128 == 0 else 64 // self.bpe_a)
+            object.__setattr__(self, "k_subtile", ks)
+
+    @property
+    def m_per_cta(self):
+        return self.M // self.cta_group
+
+    @property
+    def n_per_cta(self):
+        return self.N // self.cta_group
+
+    @property
+    def num_k_steps(self):
+        return self.K // self.tile_k_hw
+
+    @property
+    def steps_per_subtile(self):
+        return self.k_subtile // self.tile_k_hw
+
+    @property
+    def num_subtiles(self):
+        return self.num_k_steps // self.steps_per_subtile
+
+    @staticmethod
+    def _swz_from_inner(inner_bytes: int) -> int:
+        if inner_bytes % 128 == 0:
+            return 128
+        if inner_bytes % 64 == 0:
+            return 64
+        return 32
+
+    @property
+    def swz_a_bytes(self):
+        inner = self.m_per_cta if self.atranspose else self.K
+        return MmaDesc._swz_from_inner(inner * self.bpe_a)
+
+    @property
+    def swz_b_bytes(self):
+        inner = self.n_per_cta if self.btranspose else self.K
+        return MmaDesc._swz_from_inner(inner * self.bpe_b)
+
+    @property
+    def smem_advance_A_intra(self):
+        if self.atranspose:
+            return self.tile_k_hw * self.swz_a_bytes
+        return self.tile_k_hw * self.bpe_a
+
+    @property
+    def smem_advance_B_intra(self):
+        if self.btranspose:
+            return self.tile_k_hw * self.swz_b_bytes
+        return self.tile_k_hw * self.bpe_b
+
+    @property
+    def smem_subtile_A(self):
+        if self.atranspose:
+            return self.K * self.swz_a_bytes
+        return self.swz_a_bytes * self.m_per_cta
+
+    @property
+    def smem_subtile_B(self):
+        if self.btranspose:
+            return self.K * self.swz_b_bytes
+        return self.swz_b_bytes * self.n_per_cta
+
+    @property
+    def sps_A(self):
+        if self.atranspose:
+            return self.K // self.tile_k_hw
+        return (self.swz_a_bytes // self.bpe_a) // self.tile_k_hw
+
+    @property
+    def sps_B(self):
+        if self.btranspose:
+            return self.K // self.tile_k_hw
+        return (self.swz_b_bytes // self.bpe_b) // self.tile_k_hw
+
+    @property
+    def num_subtiles_A(self):
+        return self.num_k_steps // self.sps_A
+
+    @property
+    def num_subtiles_B(self):
+        return self.num_k_steps // self.sps_B
+
+    @property
+    def tmem_advance_A(self):
+        return self.tile_k_hw * self.bpe_a // 4
+
+
+@dataclass(frozen=True)
+class SmemTile:
+    base: object
+    elems_per_stage: int
+    leading_byte_offset: int
+    stride_byte_offset: int
+    layout: int
+    tma_loads_per_tile: int = 1
+    tma_granu_elems: int = 0
+    tma_subtile_stride_elems: int = 0
+    stages: int = 1
+
+    def __getitem__(self, stage):
+        off = stage * self.elems_per_stage
+        base = self.base.subview(off) if hasattr(self.base, "subview") else self.base + off
+        return replace(self, base=base, stages=1)
+
+    def shifted(self, off_elems):
+        base = self.base.subview(off_elems) if hasattr(self.base, "subview") else self.base + off_elems
+        return replace(self, base=base)
+
+    def desc(self):
+        from cutlass.experimental import primitives as prims
+
+        return prims.Tcgen05SmemDesc.build(
+            self.base,
+            leading_byte_offset=self.leading_byte_offset,
+            stride_byte_offset=self.stride_byte_offset,
+            layout=self.layout,
+        )
+
+
+@dataclass(frozen=True)
+class GmemTileTma:
+    tma_desc: object
+
+    def __call__(self, *coords, coord_0=None):
+        if not coords:
+            raise ValueError("GmemTileTma needs at least the innermost coord")
+        if coord_0 is not None:
+            if len(coords) != 4:
+                raise ValueError(f"GmemTileTma 5-D form (coord_0=…) expects 4 positional " f"coords; got {len(coords)}")
+            return GmemTileTmaSlice(
+                tma_desc=self.tma_desc,
+                coords=(coord_0,) + tuple(coords),
+            )
+        if not 2 <= len(coords) <= 5:
+            raise ValueError(f"GmemTileTma supports rank 2..5; got {len(coords)} coords")
+        return GmemTileTmaSlice(
+            tma_desc=self.tma_desc,
+            coords=tuple(coords),
+        )
+
+
+@dataclass(frozen=True)
+class GmemTileTmaSlice:
+    tma_desc: object
+    coords: tuple
+    desc_ptr: object = None
+
+    @property
+    def rank(self):
+        return len(self.coords)
+
+    @property
+    def coord_d(self):
+        return self.coords[0]
+
+    def with_coord_d(self, new_d):
+        return GmemTileTmaSlice(
+            tma_desc=self.tma_desc,
+            coords=(new_d,) + tuple(self.coords[1:]),
+            desc_ptr=self.desc_ptr,
+        )
+
+
+def tma_slice_runtime_desc(desc_ptr, *coords):
+    return GmemTileTmaSlice(tma_desc=None, coords=tuple(coords), desc_ptr=desc_ptr)
+
+
+@dataclass(frozen=True)
+class GmemTileLinear:
+    base: object
+    stride_b: int
+    stride_h: int
+    stride_tile: int
+
+    def addr(self, batch, head, tile_idx):
+        return self.base + batch * self.stride_b + head * self.stride_h + tile_idx * self.stride_tile

--- a/attn_gym/linear/_delta_rule/mega/kernels/tile_dsl/mma.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/tile_dsl/mma.py
@@ -1,0 +1,474 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+
+from typing import Type
+
+from cutlass.cute.arch.nvvm_wrappers import inline_ptx
+from cutlass.experimental import primitives as nvvm
+import cutlass
+import cutlass.cute as cute
+
+from .swizzle import swizzle_xor_128b, swizzle_lin_128b
+
+
+@cute.jit
+def mma_m16n8k16_f32(
+    a0: cutlass.Int32,
+    a1: cutlass.Int32,
+    a2: cutlass.Int32,
+    a3: cutlass.Int32,
+    b0: cutlass.Int32,
+    b1: cutlass.Int32,
+    c0: cutlass.Float32,
+    c1: cutlass.Float32,
+    c2: cutlass.Float32,
+    c3: cutlass.Float32,
+    ab_dtype: cutlass.Constexpr[Type[cutlass.Numeric]],
+) -> tuple[cutlass.Float32, cutlass.Float32, cutlass.Float32, cutlass.Float32]:
+    """``mma.sync.aligned.m16n8k16.row.col.f32.{f16|bf16}.{f16|bf16}.f32``."""
+    if cutlass.const_expr(ab_dtype != cutlass.Float16 and ab_dtype != cutlass.BFloat16):
+        raise TypeError(f"Invalid A/B dtype: {ab_dtype}")
+    ab_tag = "f16" if cutlass.const_expr(ab_dtype == cutlass.Float16) else "bf16"
+    return cute.arch.inline_ptx(
+        f"mma.sync.aligned.m16n8k16.row.col.f32.{ab_tag}.{ab_tag}.f32 {{$0,$1,$2,$3}}, {{$4,$5,$6,$7}}, {{$8,$9}}, {{$10,$11,$12,$13}};",
+        write_only_types=[
+            cutlass.Float32,
+            cutlass.Float32,
+            cutlass.Float32,
+            cutlass.Float32,
+        ],
+        read_only_args=[a0, a1, a2, a3, b0, b1, c0, c1, c2, c3],
+    )
+
+
+@cute.jit
+def mma_ss(desc, desc_a_base, desc_b_base, tmem_c, tmem_sf_a=None, tmem_sf_b=None, accumulate: bool = False, k_start: int = 0, k_count=None):
+    if cutlass.const_expr(desc.cta_group == 1):
+        cta_group_kind = nvvm.CTAGroup.CTA_1
+    else:
+        cta_group_kind = nvvm.CTAGroup.CTA_2
+    intra_a = desc.smem_advance_A_intra
+    intra_b = desc.smem_advance_B_intra
+    subtile_a = desc.smem_subtile_A
+    subtile_b = desc.smem_subtile_B
+    sps_a = desc.sps_A
+    sps_b = desc.sps_B
+    num_k_steps = desc.num_k_steps
+    k_count = num_k_steps if cutlass.const_expr(k_count is None) else k_count
+    enable_input_d = accumulate
+    SF_CYCLE = 4
+    SF_REGISTERS_PER_BLOCK = 4
+    for kk in cutlass.range_constexpr(k_count):
+        k = k_start + kk
+        ki_a = k % sps_a
+        s_a = k // sps_a
+        ki_b = k % sps_b
+        s_b = k // sps_b
+        inc_a = (intra_a * ki_a + subtile_a * s_a) >> 4
+        inc_b = (intra_b * ki_b + subtile_b * s_b) >> 4
+        da = desc_a_base + inc_a
+        db = desc_b_base + inc_b
+        if nvvm.elect_sync():
+            if cutlass.const_expr(desc.is_block_scale):
+                sf_id = (k * desc.sf_blocks_per_step) % SF_CYCLE
+                sf_group = (k * desc.sf_blocks_per_step) // SF_CYCLE
+                step_idesc = desc.idesc.set_sf_ids(a_sf_id=sf_id, b_sf_id=sf_id)
+                sf_off = sf_group * SF_REGISTERS_PER_BLOCK
+                sf_a = tmem_sf_a if sf_off == 0 else tmem_sf_a.subview(sf_off)
+                sf_b = tmem_sf_b if sf_off == 0 else tmem_sf_b.subview(sf_off)
+                nvvm.tcgen05_mma_block_scale(
+                    desc.kind,
+                    cta_group_kind,
+                    tmem_c,
+                    da,
+                    db,
+                    step_idesc,
+                    enable_input_d,
+                    scale_a=sf_a,
+                    scale_b=sf_b,
+                    scale_vec_size=desc.scale_vec_size,
+                )
+            else:
+                nvvm.tcgen05_mma(desc.kind, cta_group_kind, tmem_c, da, db, desc.idesc, enable_input_d)
+        enable_input_d = True
+
+
+@cute.jit
+def mma_ts(desc, tmem_a_base, desc_b_base, tmem_c, tmem_sf_a=None, tmem_sf_b=None, accumulate: bool = False):
+    if cutlass.const_expr(desc.cta_group == 1):
+        cta_group_kind = nvvm.CTAGroup.CTA_1
+    else:
+        cta_group_kind = nvvm.CTAGroup.CTA_2
+    num_k_steps = desc.num_k_steps
+    intra_b = desc.smem_advance_B_intra
+    subtile_b = desc.smem_subtile_B
+    sps_b = desc.sps_B
+    enable_input_d = accumulate
+    SF_CYCLE = 4
+    SF_REGISTERS_PER_BLOCK = 4
+    for k in cutlass.range_constexpr(num_k_steps):
+        dp = tmem_a_base.subview(k * desc.tmem_advance_A)
+        ki_b = k % sps_b
+        s_b = k // sps_b
+        inc_b = (intra_b * ki_b + subtile_b * s_b) >> 4
+        db = desc_b_base + inc_b
+        if nvvm.elect_sync():
+            if cutlass.const_expr(desc.is_block_scale):
+                sf_id = (k * desc.sf_blocks_per_step) % SF_CYCLE
+                sf_group = (k * desc.sf_blocks_per_step) // SF_CYCLE
+                step_idesc = desc.idesc.set_sf_ids(a_sf_id=sf_id, b_sf_id=sf_id)
+                sf_off = sf_group * SF_REGISTERS_PER_BLOCK
+                sf_a = tmem_sf_a if sf_off == 0 else tmem_sf_a.subview(sf_off)
+                sf_b = tmem_sf_b if sf_off == 0 else tmem_sf_b.subview(sf_off)
+                nvvm.tcgen05_mma_block_scale(
+                    desc.kind,
+                    cta_group_kind,
+                    tmem_c,
+                    dp,
+                    db,
+                    step_idesc,
+                    enable_input_d,
+                    scale_a=sf_a,
+                    scale_b=sf_b,
+                    scale_vec_size=desc.scale_vec_size,
+                )
+            else:
+                nvvm.tcgen05_mma(desc.kind, cta_group_kind, tmem_c, dp, db, desc.idesc, enable_input_d)
+        enable_input_d = True
+
+
+@cute.jit
+def mma_ts_step(desc, tmem_a_base, desc_b_base, tmem_c, k_idx: int, accumulate, tmem_sf_a=None, tmem_sf_b=None):
+    if cutlass.const_expr(desc.cta_group == 1):
+        cta_group_kind = nvvm.CTAGroup.CTA_1
+    else:
+        cta_group_kind = nvvm.CTAGroup.CTA_2
+    dp = tmem_a_base.subview(k_idx * desc.tmem_advance_A)
+    increment = (desc.smem_advance_B_intra * k_idx) >> 4
+    db = desc_b_base + increment
+    SF_CYCLE = 4
+    SF_REGISTERS_PER_BLOCK = 4
+    if nvvm.elect_sync():
+        if cutlass.const_expr(desc.is_block_scale):
+            sf_id = (k_idx * desc.sf_blocks_per_step) % SF_CYCLE
+            sf_group = (k_idx * desc.sf_blocks_per_step) // SF_CYCLE
+            step_idesc = desc.idesc.set_sf_ids(a_sf_id=sf_id, b_sf_id=sf_id)
+            sf_off = sf_group * SF_REGISTERS_PER_BLOCK
+            sf_a = tmem_sf_a if sf_off == 0 else tmem_sf_a.subview(sf_off)
+            sf_b = tmem_sf_b if sf_off == 0 else tmem_sf_b.subview(sf_off)
+            nvvm.tcgen05_mma_block_scale(
+                desc.kind,
+                cta_group_kind,
+                tmem_c,
+                dp,
+                db,
+                step_idesc,
+                accumulate,
+                scale_a=sf_a,
+                scale_b=sf_b,
+                scale_vec_size=desc.scale_vec_size,
+            )
+        else:
+            nvvm.tcgen05_mma(desc.kind, cta_group_kind, tmem_c, dp, db, desc.idesc, accumulate)
+
+
+@cute.jit
+def load_b_smem(
+    sB_base,
+    *,
+    k_step: cutlass.Constexpr[int],
+    N: cutlass.Constexpr[int],
+    sB_elems_per_row,
+    b_trans: cutlass.Constexpr[bool],
+    lane,
+    swizzle: cutlass.Constexpr[bool] = False,
+    elem_bytes: cutlass.Constexpr[int] = 2,
+):
+    N_FRAGS = N // 8
+    if cutlass.const_expr(b_trans):
+        b_row = lane % 16
+        layout_flag = nvvm.MMALayout.COL
+    else:
+        b_row = lane % 8
+        b_col_subchunk = (lane % 16) // 8
+        layout_flag = nvvm.MMALayout.ROW
+
+    b_frag = [None] * (N_FRAGS * 2)
+    for n_frag in cutlass.range_constexpr(N_FRAGS):
+        if cutlass.const_expr(b_trans):
+            row = k_step * 16 + b_row
+            col = n_frag * 8
+        else:
+            row = n_frag * 8 + b_row
+            col = k_step * 16 + b_col_subchunk * 8
+        if cutlass.const_expr(swizzle):
+            smem_col = swizzle_xor_128b(row, col, elem_bytes=elem_bytes)
+        else:
+            smem_col = col
+        b_ptr = sB_base.subview(row * sB_elems_per_row + smem_col)
+        b_v = nvvm.ldmatrix(b_ptr.data_ptr(), 2, layout_flag)
+        b_frag[n_frag * 2 + 0] = b_v[0]
+        b_frag[n_frag * 2 + 1] = b_v[1]
+    return b_frag
+
+
+@cute.jit
+def load_b_smem_x4(
+    sB_base,
+    *,
+    k_step: cutlass.Constexpr[int],
+    N: cutlass.Constexpr[int],
+    sB_elems_per_row,
+    b_trans: cutlass.Constexpr[bool],
+    lane,
+    swizzle: cutlass.Constexpr[bool] = False,
+    elem_bytes: cutlass.Constexpr[int] = 2,
+    col_base=0,
+    row_stride_log2: cutlass.Constexpr = None,
+):
+    N_FRAGS = N // 8
+    if cutlass.const_expr(N_FRAGS % 2 != 0):
+        raise ValueError(f"load_b_smem_x4: N//8 must be even (got N={N}, N//8={N_FRAGS})")
+    PAIRS = N_FRAGS // 2
+
+    if cutlass.const_expr(b_trans):
+        b_row = lane % 16
+        n_offset = lane // 16
+        layout_flag = nvvm.MMALayout.COL
+    else:
+        b_row = lane % 8
+        b_col_subchunk = (lane // 8) % 2
+        n_offset = lane // 16
+        layout_flag = nvvm.MMALayout.ROW
+
+    b_frag = [None] * (N_FRAGS * 2)
+    for pair in cutlass.range_constexpr(PAIRS):
+        n_frag = pair * 2
+        if cutlass.const_expr(b_trans):
+            row = k_step * 16 + b_row
+            col = (n_frag + n_offset) * 8
+        else:
+            row = (n_frag + n_offset) * 8 + b_row
+            col = k_step * 16 + b_col_subchunk * 8
+        col = col + col_base
+        if cutlass.const_expr(swizzle and row_stride_log2 is not None):
+            lin = row * (1 << row_stride_log2) + col
+            b_ptr = sB_base.subview(swizzle_lin_128b(lin, row_stride_log2=row_stride_log2, elem_bytes=elem_bytes))
+        elif cutlass.const_expr(swizzle):
+            smem_col = swizzle_xor_128b(row, col, elem_bytes=elem_bytes)
+            b_ptr = sB_base.subview(row * sB_elems_per_row + smem_col)
+        else:
+            b_ptr = sB_base.subview(row * sB_elems_per_row + col)
+        b_v = nvvm.ldmatrix(b_ptr.data_ptr(), 4, layout_flag)
+        b_frag[n_frag * 2 + 0] = b_v[0]
+        b_frag[n_frag * 2 + 1] = b_v[1]
+        b_frag[(n_frag + 1) * 2 + 0] = b_v[2]
+        b_frag[(n_frag + 1) * 2 + 1] = b_v[3]
+    return b_frag
+
+
+@cute.jit
+def b_smem_x4_prepare(
+    sB_base,
+    *,
+    N: cutlass.Constexpr[int],
+    sB_elems_per_row,
+    b_trans: cutlass.Constexpr[bool],
+    lane,
+    swizzle: cutlass.Constexpr[bool] = False,
+    elem_bytes: cutlass.Constexpr[int] = 2,
+    col_base=0,
+):
+    N_FRAGS = N // 8
+    if cutlass.const_expr(N_FRAGS % 2 != 0):
+        raise ValueError(f"b_smem_x4_prepare: N//8 must be even (got N={N}, N//8={N_FRAGS})")
+    PAIRS = N_FRAGS // 2
+
+    if cutlass.const_expr(b_trans):
+        b_row = lane % 16
+        n_offset = lane // 16
+    else:
+        b_row = lane % 8
+        b_col_subchunk = (lane // 8) % 2
+        n_offset = lane // 16
+
+    prep = [None] * PAIRS
+    for pair in cutlass.range_constexpr(PAIRS):
+        n_frag = pair * 2
+        if cutlass.const_expr(b_trans):
+            col = (n_frag + n_offset) * 8 + col_base
+            if cutlass.const_expr(swizzle):
+                swz_col = swizzle_xor_128b(b_row, col, elem_bytes=elem_bytes)
+            else:
+                swz_col = col
+            base_ptr = sB_base.subview(b_row * sB_elems_per_row + swz_col)
+            stride16 = 16 * sB_elems_per_row
+            prep[pair] = (base_ptr, stride16, cutlass.Int32(0))
+        else:
+            row = (n_frag + n_offset) * 8 + b_row
+            base_ptr = sB_base.subview(row * sB_elems_per_row)
+            prep[pair] = (base_ptr, row & 7, b_col_subchunk)
+    return prep
+
+
+@cute.jit
+def load_b_smem_x4_step(
+    prep,
+    *,
+    k_step: cutlass.Constexpr[int],
+    b_trans: cutlass.Constexpr[bool],
+    swizzle: cutlass.Constexpr[bool] = False,
+    elem_bytes: cutlass.Constexpr[int] = 2,
+    col_base=0,
+):
+    PAIRS = len(prep)
+    N_FRAGS = PAIRS * 2
+    chunk_elems = cutlass.const_expr(16 // elem_bytes)
+    layout_flag = nvvm.MMALayout.COL if cutlass.const_expr(b_trans) else nvvm.MMALayout.ROW
+
+    b_frag = [None] * (N_FRAGS * 2)
+    for pair in cutlass.range_constexpr(PAIRS):
+        n_frag = pair * 2
+        base_ptr, key2, key3 = prep[pair]
+        if cutlass.const_expr(b_trans):
+            b_ptr = base_ptr.subview(k_step * key2)
+        else:
+            r7 = key2
+            sub = key3
+            col = k_step * 16 + sub * 8 + col_base
+            if cutlass.const_expr(swizzle):
+                swz_chunk = (col // chunk_elems) ^ r7
+                b_ptr = base_ptr.subview(swz_chunk * chunk_elems + (col % chunk_elems))
+            else:
+                b_ptr = base_ptr.subview(col)
+        b_v = nvvm.ldmatrix(b_ptr.data_ptr(), 4, layout_flag)
+        b_frag[n_frag * 2 + 0] = b_v[0]
+        b_frag[n_frag * 2 + 1] = b_v[1]
+        b_frag[(n_frag + 1) * 2 + 0] = b_v[2]
+        b_frag[(n_frag + 1) * 2 + 1] = b_v[3]
+    return b_frag
+
+
+@cute.jit
+def mma_step(
+    acc,
+    a_frag,
+    b_frag,
+    *,
+    k_step: cutlass.Constexpr[int],
+    M: cutlass.Constexpr[int],
+    N: cutlass.Constexpr[int],
+    ab_dtype: cutlass.Constexpr[Type[cutlass.Numeric]] = cutlass.Float16,
+):
+    if cutlass.const_expr(M % 16 != 0):
+        raise ValueError(f"mma_step: M must be a multiple of 16, got M={M}")
+    if cutlass.const_expr(ab_dtype != cutlass.Float16 and ab_dtype != cutlass.BFloat16):
+        raise TypeError(f"mma_step: ab_dtype must be Float16 or BFloat16, got {ab_dtype}")
+    M_BLOCKS = M // 16
+    N_FRAGS = N // 8
+    a_stride = len(a_frag) // M_BLOCKS
+
+    ab_tag = "f16" if cutlass.const_expr(ab_dtype == cutlass.Float16) else "bf16"
+    mma_ptx = f"mma.sync.aligned.m16n8k16.row.col.f32.{ab_tag}.{ab_tag}.f32" " {$0,$1,$2,$3}, {$4,$5,$6,$7}, {$8,$9}, {$10,$11,$12,$13};"
+
+    for m_block in cutlass.range_constexpr(M_BLOCKS):
+        a_off = m_block * a_stride + k_step * 4
+        a0 = a_frag[a_off + 0]
+        a1 = a_frag[a_off + 1]
+        a2 = a_frag[a_off + 2]
+        a3 = a_frag[a_off + 3]
+        acc_base = m_block * N_FRAGS * 4
+        for n_frag in cutlass.range_constexpr(N_FRAGS):
+            b0 = b_frag[n_frag * 2 + 0]
+            b1 = b_frag[n_frag * 2 + 1]
+            s_off = acc_base + n_frag * 4
+            c0, c1, c2, c3 = inline_ptx(
+                mma_ptx,
+                write_only_types=[cutlass.Float32, cutlass.Float32, cutlass.Float32, cutlass.Float32],
+                read_only_args=[
+                    a0,
+                    a1,
+                    a2,
+                    a3,
+                    b0,
+                    b1,
+                    acc[s_off + 0],
+                    acc[s_off + 1],
+                    acc[s_off + 2],
+                    acc[s_off + 3],
+                ],
+            )
+            acc[s_off + 0] = c0
+            acc[s_off + 1] = c1
+            acc[s_off + 2] = c2
+            acc[s_off + 3] = c3
+
+
+@cute.jit
+def mma_step_k8(
+    acc,
+    a_frag,
+    b_frag,
+    *,
+    k_step: cutlass.Constexpr[int],
+    M: cutlass.Constexpr[int],
+    N: cutlass.Constexpr[int],
+    ab_dtype: cutlass.Constexpr[Type[cutlass.Numeric]] = cutlass.Float16,
+):
+    if cutlass.const_expr(M % 16 != 0):
+        raise ValueError(f"mma_step_k8: M must be a multiple of 16, got M={M}")
+    if cutlass.const_expr(ab_dtype != cutlass.Float16 and ab_dtype != cutlass.BFloat16):
+        raise TypeError(f"mma_step_k8: ab_dtype must be Float16 or BFloat16, got {ab_dtype}")
+    M_BLOCKS = M // 16
+    N_FRAGS = N // 8
+    a_stride = len(a_frag) // M_BLOCKS
+
+    ab_tag = "f16" if cutlass.const_expr(ab_dtype == cutlass.Float16) else "bf16"
+    mma_ptx = f"mma.sync.aligned.m16n8k8.row.col.f32.{ab_tag}.{ab_tag}.f32" " {$0,$1,$2,$3}, {$4,$5}, {$6}, {$7,$8,$9,$10};"
+
+    for m_block in cutlass.range_constexpr(M_BLOCKS):
+        a_off = m_block * a_stride + k_step * 2
+        a0 = a_frag[a_off + 0]
+        a1 = a_frag[a_off + 1]
+        acc_base = m_block * N_FRAGS * 4
+        for n_frag in cutlass.range_constexpr(N_FRAGS):
+            b0 = b_frag[n_frag]
+            s_off = acc_base + n_frag * 4
+            c0, c1, c2, c3 = inline_ptx(
+                mma_ptx,
+                write_only_types=[cutlass.Float32, cutlass.Float32, cutlass.Float32, cutlass.Float32],
+                read_only_args=[
+                    a0,
+                    a1,
+                    b0,
+                    acc[s_off + 0],
+                    acc[s_off + 1],
+                    acc[s_off + 2],
+                    acc[s_off + 3],
+                ],
+            )
+            acc[s_off + 0] = c0
+            acc[s_off + 1] = c1
+            acc[s_off + 2] = c2
+            acc[s_off + 3] = c3
+
+
+@cute.jit
+def mma(
+    acc,
+    a_frag,
+    sB_base,
+    *,
+    M: cutlass.Constexpr[int],
+    N: cutlass.Constexpr[int],
+    K: cutlass.Constexpr[int],
+    sB_elems_per_row,
+    b_trans: cutlass.Constexpr[bool],
+    lane,
+    ab_dtype: cutlass.Constexpr[Type[cutlass.Numeric]] = cutlass.Float16,
+):
+    K_STEPS = K // 16
+    for k in cutlass.range_constexpr(K_STEPS):
+        b_frag = load_b_smem(sB_base, k_step=k, N=N, sB_elems_per_row=sB_elems_per_row, b_trans=b_trans, lane=lane)
+        mma_step(acc, a_frag, b_frag, k_step=k, M=M, N=N, ab_dtype=ab_dtype)

--- a/attn_gym/linear/_delta_rule/mega/kernels/tile_dsl/pointwise.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/tile_dsl/pointwise.py
@@ -1,0 +1,288 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+
+import inspect
+
+import cutlass
+from cutlass.cute.arch.nvvm_wrappers import inline_ptx
+from cutlass.experimental import primitives as nvvm
+import cutlass.cute as cute
+from cutlass._mlir.dialects import arith, vector
+from cutlass._mlir.dialects import nvvm as nvvm_ops
+from cutlass._mlir.extras import types as T_
+from cutlass._mlir import ir as _ir
+
+from .regtile import RegTile, vec_concat
+
+# nvidia-cutlass-dsl 4.7.0a0 nightlies from 2026-07-27 (6986e65) on regenerated
+# the nvvm bindings to take an explicit result type -- *_packed_f32x2(res,
+# src_a, src_b) -- but the cutlass.experimental.primitives wrappers still call
+# the two-positional form, so going through them raises "missing 1 required
+# positional argument: 'src_b'".  Call the dialect ops directly and adapt to
+# whichever binding generation is installed; older ones infer the result type.
+_PACKED_RES_FIRST = "res" in inspect.signature(nvvm_ops.mul_packed_f32x2).parameters
+
+
+def _packed_f32x2(op, vec_a, vec_b):
+    """``op(vec_a, vec_b)`` for nvvm.{mul,add}_packed_f32x2 on f32x2 IR values."""
+    if _PACKED_RES_FIRST:
+        return op(vec_a.type, vec_a, vec_b, rnd=nvvm_ops.FPRoundingMode.RN)
+    return op(vec_a, vec_b, rnd=nvvm_ops.FPRoundingMode.RN)
+
+
+def tmem_load_max_reduction(tmem_addr, num: cutlass.Constexpr = 64):
+    """tcgen05.ld.red.sync.aligned.32x32b.x{num}.f32.max — fused TMEM
+    load + HW row-max reduction (LDTM.STAT).  ``num`` is the elements-per-
+    thread count (= TILE_N/2 for the current dual-MMA softmax path).
+    """
+    _data_ops = ", ".join("{$w%d}" % i for i in range(num))
+    _ptx = ("tcgen05.ld.red.sync.aligned.32x32b.x%d.f32.max " "{" + _data_ops + "}, {$w%d}, [{$r0}];") % (num, num)
+    outs = inline_ptx(
+        _ptx,
+        write_only_types=[cutlass.Int32] * (num + 1),
+        read_only_args=[tmem_addr],
+    )
+    return cutlass.Vector.from_elements(tuple(outs), cutlass.Int32)
+
+
+def row_max_reduction(vec):
+    n = int(vec.shape[0])
+    elems = [vec[i] for i in range(n)]
+    while len(elems) > 1:
+        nxt = []
+        for i in range(0, len(elems), 3):
+            grp = elems[i : i + 3]
+            acc = grp[0]
+            for g in grp[1:]:
+                acc = cute.math.max(acc, g, ftz=True)
+            nxt.append(acc)
+        elems = nxt
+    return elems[0]
+
+
+def row_reduction_pair(vec):
+    n = int(vec.shape[0])
+    assert n % 2 == 0, f"row_reduction_pair: N={n} must be even"
+    half = n // 2
+    paired_ty = _ir.VectorType.get([half, 2], T_.f32())
+    paired = vector.shape_cast(paired_ty, vec.ir_value())
+
+    acc = vector.extract(paired, dynamic_position=[], static_position=[0])
+    for i in range(1, half):
+        pair = vector.extract(paired, dynamic_position=[], static_position=[i])
+        acc = arith.addf(acc, pair)
+    return cutlass.Vector(acc, dtype=cutlass.Float32)
+
+
+def tmem_load_max_reduction_x64(tmem_addr):
+    return tmem_load_max_reduction(tmem_addr, num=64)
+
+
+def row_max_reduction_64(vec64):
+    return row_max_reduction(vec64)
+
+
+def row_reduction_pair_64(vec64):
+    return row_reduction_pair(vec64)
+
+
+def tmem_load_tile(tmem_addr, num_elems: int, ld_num: int = 64) -> RegTile:
+    assert num_elems % ld_num == 0, f"tmem_load_tile: num_elems={num_elems} must be a multiple of " f"ld_num={ld_num}"
+    chunks = [
+        nvvm.tcgen05_ld(
+            "32x32b",
+            nvvm.make_tmem_ptr(tmem_addr + cutlass.Int32(i * ld_num), cutlass.Float32),
+            num=ld_num,
+        )
+        for i in range(num_elems // ld_num)
+    ]
+    return RegTile(vec_concat(chunks))
+
+
+def tmem_load_max_reduction_tile(tmem_addr, num_elems: int):
+    assert num_elems % 64 == 0, f"tmem_load_max_reduction_tile: num_elems={num_elems} must be a multiple of 64"
+    raw_results = [tmem_load_max_reduction(tmem_addr + cutlass.Int32(i * 64), num=64) for i in range(num_elems // 64)]
+    data_chunks = [cutlass.Vector.from_elements(tuple(res[:64]), cutlass.Int32).bitcast(cutlass.Float32) for res in raw_results]
+    max_scalars = [cutlass.Vector.from_elements((res[64],), cutlass.Int32).bitcast(cutlass.Float32)[0] for res in raw_results]
+    final_max = max_scalars[0]
+    for m in max_scalars[1:]:
+        final_max = cute.math.max(final_max, m)
+    return RegTile(vec_concat(data_chunks)), final_max
+
+
+@cute.jit
+def fp32_to_fp16(lo, hi, *, dtype=cutlass.Float16):
+    if cutlass.const_expr(dtype != cutlass.Float16 and dtype != cutlass.BFloat16):
+        raise TypeError(f"fp32_to_fp16: dtype must be Float16 or BFloat16, got {dtype}")
+    tag = "f16" if cutlass.const_expr(dtype == cutlass.Float16) else "bf16"
+    return inline_ptx(
+        f"cvt.rn.{tag}x2.f32 $0, $2, $1;",
+        write_only_types=[cutlass.Int32],
+        read_only_args=[lo, hi],
+    )
+
+
+def vec_scale_pair(vec, scalar, N):
+    assert N % 2 == 0, f"vec_scale_pair: N={N} must be even"
+    pair_ty = _ir.VectorType.get([2], T_.f32())
+    paired_ty = _ir.VectorType.get([N // 2, 2], T_.f32())
+    flat_ty = _ir.VectorType.get([N], T_.f32())
+
+    scalar_pair = vector.broadcast(pair_ty, scalar.ir_value())
+
+    paired_in = vector.shape_cast(paired_ty, vec.ir_value())
+    result = paired_in
+    for i in range(N // 2):
+        pair = vector.extract(paired_in, dynamic_position=[], static_position=[i])
+        scaled = _packed_f32x2(nvvm_ops.mul_packed_f32x2, pair, scalar_pair)
+        result = vector.insert(
+            scaled,
+            result,
+            dynamic_position=[],
+            static_position=[i],
+        )
+    return cutlass.Vector(vector.shape_cast(flat_ty, result), dtype=cutlass.Float32)
+
+
+@cutlass.cute.jit
+def f16x2_to_f32(word, *, dtype=cutlass.Float16):
+    """Unpack one Int32 (= 2 packed halves) into ``(lo_f32, hi_f32)`` Float32.
+
+    The inverse of :func:`fp32_to_fp16`.  bf16 IS the top 16 bits of an fp32,
+    so f32 = bf16 << 16 (bit move, no PRMT storm); masks stay 32-bit (a Python
+    ``0xFFFF0000`` promotes to i64 -> mov.b32 mismatch).  fp16 needs the real
+    ``cvt.f32.f16`` converts.
+    """
+    if cutlass.const_expr(dtype != cutlass.Float16 and dtype != cutlass.BFloat16):
+        raise TypeError(f"f16x2_to_f32: dtype must be Float16 or BFloat16, got {dtype}")
+    if cutlass.const_expr(dtype == cutlass.BFloat16):
+        lo, hi = inline_ptx(
+            "{ .reg .b16 l, h; mov.b32 {l, h}, $2; mov.b32 $0, {0, l}; mov.b32 $1, {0, h}; }",
+            write_only_types=[cutlass.Float32, cutlass.Float32],
+            read_only_args=[word],
+        )
+    else:
+        lo, hi = inline_ptx(
+            "{ .reg .b16 h0, h1; mov.b32 {h0, h1}, $2; " "cvt.f32.f16 $0, h0; cvt.f32.f16 $1, h1; }",
+            write_only_types=[cutlass.Float32, cutlass.Float32],
+            read_only_args=[word],
+        )
+    return lo, hi
+
+
+@cutlass.cute.jit
+def opaque_f32_zero():
+    """A 0.0f the optimizer cannot prove constant.
+
+    Use for values that feed packed-asm operands (:func:`fmul2` /
+    :func:`ffma2`) and could otherwise fold to a literal: the
+    ``nvvm.inline_ptx`` lowering gives constant float operands the ``n``
+    immediate constraint, which ICEs libNVVM."""
+    return inline_ptx("mov.b32 $0, 0;", write_only_types=[cutlass.Float32])
+
+
+@cutlass.cute.jit
+def fmul2(a_lo, a_hi, b_lo, b_hi):
+    """Packed fp32 multiply (SM100 FMUL2): ``(a_lo * b_lo, a_hi * b_hi)``.
+
+    ``mul.f32x2`` operates on register pairs; the ``mov.b64`` packs map to
+    register-pair allocation and usually fold away in SASS."""
+    return inline_ptx(
+        "{ .reg .b64 pa, pb, pc; mov.b64 pa, {$2, $3}; mov.b64 pb, {$4, $5}; mul.f32x2 pc, pa, pb; mov.b64 {$0, $1}, pc; }",
+        write_only_types=[cutlass.Float32, cutlass.Float32],
+        read_only_args=[a_lo, a_hi, b_lo, b_hi],
+    )
+
+
+@cutlass.cute.jit
+def fadd2(a_lo, a_hi, b_lo, b_hi):
+    """Packed fp32 add (SM100 FADD2): ``(a_lo + b_lo, a_hi + b_hi)``.
+
+    Native NVVM op, not inline asm: libNVVM rejects ``add.f32x2`` in asm
+    blocks (mul/fma made it in, add did not)."""
+    vec_a = cutlass.Vector.from_elements((a_lo, a_hi), cutlass.Float32)
+    vec_b = cutlass.Vector.from_elements((b_lo, b_hi), cutlass.Float32)
+    res = cutlass.Vector(_packed_f32x2(nvvm_ops.add_packed_f32x2, vec_a.ir_value(), vec_b.ir_value()), dtype=cutlass.Float32)
+    return cutlass.Float32(res[0]), cutlass.Float32(res[1])
+
+
+@cutlass.cute.jit
+def ffma2(a_lo, a_hi, b_lo, b_hi, c_lo, c_hi):
+    """Packed fp32 fma (SM100 FFMA2): ``(a_lo*b_lo + c_lo, a_hi*b_hi + c_hi)``."""
+    return inline_ptx(
+        "{ .reg .b64 pa, pb, pc, pd; mov.b64 pa, {$2, $3}; mov.b64 pb, {$4, $5}; mov.b64 pc, {$6, $7}; " "fma.rn.f32x2 pd, pa, pb, pc; mov.b64 {$0, $1}, pd; }",
+        write_only_types=[cutlass.Float32, cutlass.Float32],
+        read_only_args=[a_lo, a_hi, b_lo, b_hi, c_lo, c_hi],
+    )
+
+
+@cutlass.cute.jit
+def movmatrix_16b(value: cutlass.Int32) -> cutlass.Int32:
+    """Transpose one packed m8n8 b16 register fragment."""
+    return inline_ptx(
+        "movmatrix.sync.aligned.m8n8.trans.b16 $0, $1;",
+        write_only_types=[cutlass.Int32],
+        read_only_args=[value],
+    )
+
+
+@cutlass.cute.jit
+def mul_fp16x2(value: cutlass.Int32, scale: cutlass.Int32) -> cutlass.Int32:
+    """Multiply two packed FP16 pairs."""
+    return inline_ptx(
+        "mul.f16x2 $0, $1, $2;",
+        write_only_types=[cutlass.Int32],
+        read_only_args=[value, scale],
+    )
+
+
+@cutlass.cute.jit
+def sub_f16x2(lhs: cutlass.Int32, rhs: cutlass.Int32, input_dtype: cutlass.Constexpr) -> cutlass.Int32:
+    """Subtract two packed pairs using the compile-time input dtype."""
+    if cutlass.const_expr(input_dtype is cutlass.BFloat16):
+        return inline_ptx("sub.bf16x2 $0, $1, $2;", write_only_types=[cutlass.Int32], read_only_args=[lhs, rhs])
+    return inline_ptx("sub.f16x2 $0, $1, $2;", write_only_types=[cutlass.Int32], read_only_args=[lhs, rhs])
+
+
+@cutlass.cute.jit
+def mul_f16x2(lhs: cutlass.Int32, rhs: cutlass.Int32, input_dtype: cutlass.Constexpr) -> cutlass.Int32:
+    """Multiply two packed pairs using the compile-time input dtype."""
+    if cutlass.const_expr(input_dtype is cutlass.BFloat16):
+        return nvvm.mul_bf16x2(lhs, rhs)
+    return mul_fp16x2(lhs, rhs)
+
+
+@cute.jit
+def sigmoid_f16x2(logit_pair: cutlass.Int32, input_dtype: cutlass.Constexpr):
+    """Sigmoid of a packed 16-bit logit pair, returned as two fp32 values."""
+
+    logit_vec_f32 = cutlass.Vector.from_elements((logit_pair,), cutlass.Int32).bitcast(input_dtype).to(cutlass.Float32)
+    half = cutlass.Float32(0.5)
+    value0 = cute.math.tanh(logit_vec_f32[0] * half, approx=True) * half + half
+    value1 = cute.math.tanh(logit_vec_f32[1] * half, approx=True) * half + half
+    return value0, value1
+
+
+@cute.jit
+def ex2_f16x2(pair: cutlass.Int32, *, dtype=cutlass.Float16) -> cutlass.Int32:
+    """Packed-pair ``exp2`` in ONE MUFU op: ``ex2.approx.f16x2`` (fp16) or
+    ``ex2.approx.ftz.bf16x2`` (bf16).
+
+    PTX/target contract (ISA 9.4, 9.7.4.10):
+
+    - ``.f16x2``: PTX ISA 7.0, sm_75+. Max relative error 2^-9.9; subnormal
+      inputs are supported.
+    - ``.ftz.bf16x2``: PTX ISA 7.8, sm_90+. Max relative error 2^-7; ``ftz``
+      is mandatory for bf16 — subnormal inputs and results flush to
+      sign-preserving zero (so +/-subnormal -> +1.0; -Inf -> +0.0;
+      NaN -> NaN).
+    """
+    if cutlass.const_expr(dtype != cutlass.Float16 and dtype != cutlass.BFloat16):
+        raise TypeError(f"ex2_f16x2: dtype must be Float16 or BFloat16, got {dtype}")
+    op = "ex2.approx.f16x2" if cutlass.const_expr(dtype == cutlass.Float16) else "ex2.approx.ftz.bf16x2"
+    return inline_ptx(
+        f"{op} $0, $1;",
+        write_only_types=[cutlass.Int32],
+        read_only_args=[pair],
+    )

--- a/attn_gym/linear/_delta_rule/mega/kernels/tile_dsl/regtile.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/tile_dsl/regtile.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+
+import cutlass
+from cutlass._mlir.dialects import vector
+from cutlass._mlir.extras import types as T_
+from cutlass._mlir import ir as _ir
+
+
+def _ir_elem_ty(dtype):
+    if dtype is cutlass.Float32:
+        return T_.f32()
+    if dtype is cutlass.Int32:
+        return T_.i32()
+    if dtype is cutlass.Float16:
+        return T_.f16()
+    if dtype is cutlass.BFloat16:
+        return T_.bf16()
+    raise TypeError(f"RegTile: unsupported dtype {dtype!r}")
+
+
+def vec_slice(vec, start: int, length: int):
+    n = int(vec.shape[0])
+    assert 0 <= start and start + length <= n, f"vec_slice: [{start}:{start + length}) out of range [0:{n})"
+    elem_ty = _ir_elem_ty(vec.dtype)
+    out_ty = _ir.VectorType.get([length], elem_ty)
+    sliced = vector.extract_strided_slice(
+        out_ty,
+        vec.ir_value(),
+        offsets=[start],
+        sizes=[length],
+        strides=[1],
+    )
+    return cutlass.Vector(sliced, dtype=vec.dtype)
+
+
+def _vec_width(vec):
+    return int(_ir.VectorType(vec.ir_value().type).shape[0])
+
+
+def vec_concat(parts):
+    assert len(parts) >= 1, "vec_concat: need at least one part"
+    dtype = parts[0].dtype
+    widths = [_vec_width(p) for p in parts]
+    total = sum(widths)
+    elem_ty = _ir_elem_ty(dtype)
+    out_ty = _ir.VectorType.get([total], elem_ty)
+
+    acc = vector.broadcast(out_ty, _zero_scalar(dtype))
+    offset = 0
+    for p, w in zip(parts, widths):
+        acc = vector.insert_strided_slice(
+            p.ir_value(),
+            acc,
+            offsets=[offset],
+            strides=[1],
+        )
+        offset += w
+    return cutlass.Vector(acc, dtype=dtype)
+
+
+def _zero_scalar(dtype):
+    if dtype is cutlass.Float32:
+        return cutlass.Float32(0.0).ir_value()
+    if dtype is cutlass.Int32:
+        return cutlass.Int32(0).ir_value()
+    if dtype is cutlass.Float16:
+        return cutlass.Float16(0.0).ir_value()
+    if dtype is cutlass.BFloat16:
+        return cutlass.BFloat16(0.0).ir_value()
+    raise TypeError(f"_zero_scalar: unsupported dtype {dtype!r}")
+
+
+class RegTile:
+
+    __slots__ = ("_vec", "_size")
+
+    def __init__(self, vec_or_n, dtype=None, *, size: int = None):
+        if isinstance(vec_or_n, int):
+            assert dtype is not None, "RegTile(int, ...) requires explicit dtype"
+            self._vec = cutlass.Vector.from_elements(
+                tuple(_zero_py(dtype) for _ in range(vec_or_n)),
+                dtype,
+            )
+            self._size = vec_or_n
+        else:
+            self._vec = vec_or_n
+            if size is not None:
+                self._size = int(size)
+            else:
+                self._size = _vec_width(vec_or_n)
+
+    @classmethod
+    def empty(cls, num_elems: int, dtype):
+        return cls(num_elems, dtype=dtype)
+
+    @property
+    def vec(self):
+        return self._vec
+
+    @property
+    def dtype(self):
+        return self._vec.dtype
+
+    def __len__(self):
+        return self._size
+
+    def __getitem__(self, key):
+        if isinstance(key, slice):
+            start, stop, step = key.indices(self._size)
+            assert step == 1, f"RegTile slice step must be 1, got {step}"
+            return RegTile(vec_slice(self._vec, start, stop - start), size=stop - start)
+        return self._vec[key]
+
+    def to(self, dtype):
+        return RegTile(self._vec.to(dtype), size=self._size)
+
+    def __mul__(self, other):
+        rhs = other.vec if isinstance(other, RegTile) else other
+        return RegTile(self._vec * rhs, size=self._size)
+
+    def __rmul__(self, other):
+        rhs = other.vec if isinstance(other, RegTile) else other
+        return RegTile(rhs * self._vec, size=self._size)
+
+    def __sub__(self, other):
+        rhs = other.vec if isinstance(other, RegTile) else other
+        return RegTile(self._vec - rhs, size=self._size)
+
+    def __rsub__(self, other):
+        rhs = other.vec if isinstance(other, RegTile) else other
+        return RegTile(rhs - self._vec, size=self._size)
+
+    def __add__(self, other):
+        rhs = other.vec if isinstance(other, RegTile) else other
+        return RegTile(self._vec + rhs, size=self._size)
+
+    def __radd__(self, other):
+        rhs = other.vec if isinstance(other, RegTile) else other
+        return RegTile(rhs + self._vec, size=self._size)
+
+
+def _zero_py(dtype):
+    if dtype is cutlass.Float32:
+        return cutlass.Float32(0.0)
+    if dtype is cutlass.Int32:
+        return cutlass.Int32(0)
+    if dtype is cutlass.Float16:
+        return cutlass.Float16(0.0)
+    if dtype is cutlass.BFloat16:
+        return cutlass.BFloat16(0.0)
+    raise TypeError(f"_zero_py: unsupported dtype {dtype!r}")

--- a/attn_gym/linear/_delta_rule/mega/kernels/tile_dsl/swizzle.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/tile_dsl/swizzle.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+
+import cutlass
+import cutlass.cute as cute
+
+
+@cute.jit
+def swizzle_xor_128b(row, col_elem, *, elem_bytes: cutlass.Constexpr[int] = 2):
+    return col_elem ^ ((row & 7) * cutlass.const_expr(16 // elem_bytes))
+
+
+@cute.jit
+def swizzle_xor_64b(row, col_elem, *, elem_bytes: cutlass.Constexpr[int] = 2):
+    chunk_elems = 16 // elem_bytes
+    chunk_idx = col_elem // chunk_elems
+    in_chunk = col_elem % chunk_elems
+    swz_chunk = chunk_idx ^ ((row >> 1) & 3)
+    return swz_chunk * chunk_elems + in_chunk
+
+
+@cute.jit
+def swizzle_xor_32b(row, col_elem, *, elem_bytes: cutlass.Constexpr[int] = 2):
+    chunk_elems = 16 // elem_bytes
+    chunk_idx = col_elem // chunk_elems
+    in_chunk = col_elem % chunk_elems
+    swz_chunk = chunk_idx ^ ((row >> 2) & 1)
+    return swz_chunk * chunk_elems + in_chunk
+
+
+@cute.jit
+def swizzle_xor(
+    row: cutlass.Int32,
+    col: cutlass.Int32,
+    row_stride: cutlass.Constexpr[int],
+    elem_bytes: cutlass.Constexpr[int],
+) -> cutlass.Int32:
+    """Return the physical SMEM column for an XOR-swizzled row-major tile.
+
+    The XOR is applied at the 16-byte boundary for all element widths.
+    ``elem_bytes`` selects the element-domain shift and swizzle chunk size.
+    """
+    row_stride_bytes = cutlass.const_expr(row_stride * elem_bytes)
+    if cutlass.const_expr(row_stride_bytes % 128 == 0):
+        chunk_elems = 128 // elem_bytes
+        swizzled = swizzle_xor_128b(row, col % chunk_elems, elem_bytes=elem_bytes)
+    elif cutlass.const_expr(row_stride_bytes % 64 == 0):
+        chunk_elems = 64 // elem_bytes
+        swizzled = swizzle_xor_64b(row, col % chunk_elems, elem_bytes=elem_bytes)
+    else:
+        chunk_elems = 32 // elem_bytes
+        swizzled = swizzle_xor_32b(row, col % chunk_elems, elem_bytes=elem_bytes)
+    return (col // chunk_elems) * chunk_elems + swizzled
+
+
+@cute.jit
+def swizzle_lin_128b(lin, *, row_stride_log2: cutlass.Constexpr[int], elem_bytes: cutlass.Constexpr[int] = 2):
+    chunk_log2 = cutlass.const_expr((16 // elem_bytes).bit_length() - 1)
+    shift = cutlass.const_expr(row_stride_log2 - chunk_log2)
+    mask = cutlass.const_expr(0x7 << chunk_log2)
+    return lin ^ ((lin >> shift) & mask)
+
+
+@cute.jit
+def swizzle_lin_S(lin, *, bbits: cutlass.Constexpr[int], mbase: cutlass.Constexpr[int], sshift: cutlass.Constexpr[int]):
+    yyy = (lin >> cutlass.const_expr(mbase + sshift)) & cutlass.const_expr((1 << bbits) - 1)
+    return lin ^ (yyy << cutlass.const_expr(mbase))

--- a/attn_gym/linear/_delta_rule/mega/kernels/tile_dsl/tma.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/tile_dsl/tma.py
@@ -1,0 +1,278 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+
+from cutlass.experimental import primitives as nvvm
+import cutlass
+import cutlass.cute as cute
+
+from .swizzle import swizzle_xor_128b
+
+
+def _advance(x, n):
+    if hasattr(x, "subview"):
+        return x.subview(n)
+    return x + n
+
+
+def _bulk_copy_ptr(x):
+    if hasattr(x, "llvm_ptr"):
+        return x.llvm_ptr
+    if hasattr(x, "ir_value") and callable(x.ir_value):
+        return x.ir_value()
+    return x
+
+
+@cute.jit
+def cp_async_bulk_shared_cluster_shared_cta(dst_mem, src_mem, mbar, size, *, pred=None):
+    if cutlass.const_expr(pred is None):
+        nvvm.cp_async_bulk_shared_cluster_shared_cta(dst_mem, src_mem, mbar, size)
+    else:
+        nvvm.inline_ptx(
+            "cp.async.bulk.shared::cluster.shared::cta" ".mbarrier::complete_tx::bytes " "[{$r0}], [{$r1}], {$r2}, [{$r3}];",
+            read_only_args=[
+                _bulk_copy_ptr(dst_mem),
+                _bulk_copy_ptr(src_mem),
+                cutlass.Int32(size),
+                _bulk_copy_ptr(mbar),
+            ],
+            predicate=pred,
+        )
+
+
+@cute.jit
+def tma_load_tile(
+    smem_tile,
+    gmem_slice,
+    mbar,
+    *,
+    cta_group: int = 1,
+    mcast_mask=None,
+    acquire: cutlass.Constexpr[bool] = True,
+    l2_cache_hint=None,
+):
+    num_iters = smem_tile.tma_loads_per_tile
+    granu_elems = smem_tile.tma_granu_elems
+    sub_stride = smem_tile.tma_subtile_stride_elems
+    if cutlass.const_expr(gmem_slice.desc_ptr is not None):
+        tma_desc_ptr = gmem_slice.desc_ptr
+        if cutlass.const_expr(acquire):
+            nvvm.fence_proxy_acquire(
+                nvvm.MemScope.GPU,
+                tma_desc_ptr,
+                128,
+                from_proxy=nvvm.Proxy.GENERIC,
+                to_proxy=nvvm.Proxy.TENSORMAP,
+            )
+    else:
+        tma_desc_ptr = gmem_slice.tma_desc.get_ptr()
+    coord_d = gmem_slice.coord_d
+    outer_coords = tuple(gmem_slice.coords[1:])
+    for i in cutlass.range_constexpr(num_iters):
+        d = coord_d + cutlass.Int32(i * granu_elems)
+        smem_chunk = smem_tile.base.subview(i * sub_stride)
+        if nvvm.elect_sync():
+            coords = [d] + list(outer_coords)
+            if cutlass.const_expr(cta_group == 1):
+                nvvm.cp_async_bulk_tensor_shared_cta_global(
+                    smem_chunk,
+                    tma_desc_ptr,
+                    coords,
+                    mbar,
+                    l2_cache_hint=l2_cache_hint,
+                )
+            else:
+                nvvm.cp_async_bulk_tensor_shared_cluster_global(
+                    smem_chunk,
+                    tma_desc_ptr,
+                    coords,
+                    mbar,
+                    [],
+                    multicast_mask=mcast_mask,
+                    group=nvvm.CTAGroup.CTA_2,
+                    l2_cache_hint=l2_cache_hint,
+                )
+
+
+@cute.jit
+def tma_store_tile(smem_tile, gmem_slice, *, acquire: cutlass.Constexpr[bool] = True):
+    num_iters = smem_tile.tma_loads_per_tile
+    granu_elems = smem_tile.tma_granu_elems
+    sub_stride = smem_tile.tma_subtile_stride_elems
+    coord_d = gmem_slice.coord_d
+    outer_coords = tuple(gmem_slice.coords[1:])
+    if cutlass.const_expr(gmem_slice.desc_ptr is not None):
+        tma_desc_ptr = gmem_slice.desc_ptr
+        if cutlass.const_expr(acquire):
+            nvvm.fence_proxy_acquire(
+                nvvm.MemScope.GPU,
+                tma_desc_ptr,
+                128,
+                from_proxy=nvvm.Proxy.GENERIC,
+                to_proxy=nvvm.Proxy.TENSORMAP,
+            )
+    else:
+        tma_desc_ptr = gmem_slice.tma_desc.get_ptr()
+    for i in cutlass.range_constexpr(num_iters):
+        d = coord_d + cutlass.Int32(i * granu_elems)
+        smem_chunk = smem_tile.base.subview(i * sub_stride)
+        nvvm.cp_async_bulk_tensor_global_shared_cta(
+            tma_desc_ptr,
+            smem_chunk,
+            tuple([d] + list(outer_coords)),
+        )
+
+
+@cute.jit
+def bulk_copy(smem_dst, gmem_src, n_bytes, mbar):
+    if nvvm.elect_sync():
+        nvvm.cp_async_bulk_shared_cluster_global(
+            smem_dst,
+            gmem_src,
+            mbar,
+            n_bytes,
+        )
+
+
+@cute.jit
+def bulk_copy_multicast(smem_dst, gmem_src, n_bytes, mbar, mcast_mask):
+    if nvvm.elect_sync():
+        cluster_dst = nvvm.mapa(smem_dst, cutlass.Int32(0), addrspace=7)
+        nvvm.cp_async_bulk_shared_cluster_global(
+            cluster_dst,
+            gmem_src,
+            mbar,
+            n_bytes,
+            multicast_mask=mcast_mask,
+        )
+
+
+@cute.jit
+def tma_store_commit():
+    nvvm.cp_async_bulk_commit_group()
+
+
+@cute.jit
+def tma_store_wait(num_remaining: int = 0):
+    nvvm.cp_async_bulk_wait_group(num_remaining, read=True)
+
+
+@cute.jit
+def cp_async_commit():
+    nvvm.cp_async_commit_group()
+
+
+@cute.jit
+def cp_async_wait(num_remaining: cutlass.Constexpr[int] = 0):
+    nvvm.cp_async_wait_group(num_remaining)
+
+
+@cute.jit
+def load_tile(
+    smem_dst,
+    gmem_src,
+    total_elems: cutlass.Constexpr[int],
+    tidx,
+    *,
+    num_threads: cutlass.Constexpr[int],
+    elems_per_copy: cutlass.Constexpr[int],
+    elem_bytes: cutlass.Constexpr[int],
+    cache: nvvm.LoadCacheModifier = nvvm.LoadCacheModifier.CG,
+):
+    bytes_per_copy = elems_per_copy * elem_bytes
+    if cutlass.const_expr(bytes_per_copy not in (4, 8, 16)):
+        raise ValueError(f"load_tile: elems_per_copy*elem_bytes must be 4/8/16, got " f"{elems_per_copy}*{elem_bytes}={bytes_per_copy}")
+    chunk_elems = num_threads * elems_per_copy
+    if cutlass.const_expr(total_elems % chunk_elems != 0):
+        raise ValueError(
+            f"load_tile: total_elems ({total_elems}) must be a multiple of " f"num_threads*elems_per_copy ({num_threads}*{elems_per_copy}=" f"{chunk_elems})"
+        )
+    n_iters = total_elems // chunk_elems
+    base_off = tidx * elems_per_copy
+    for i in cutlass.range_constexpr(n_iters):
+        off = base_off + i * chunk_elems
+        nvvm.cp_async_shared_global(
+            _advance(smem_dst, off),
+            _advance(gmem_src, off),
+            bytes_per_copy,
+            cache,
+        )
+
+
+@cute.jit
+def load_tile_2d(
+    smem_dst,
+    gmem_src,
+    rows: cutlass.Constexpr[int],
+    elems_per_row: cutlass.Constexpr[int],
+    gmem_row_stride_elems,
+    tidx,
+    *,
+    num_threads: cutlass.Constexpr[int],
+    elems_per_copy: cutlass.Constexpr[int],
+    elem_bytes: cutlass.Constexpr[int],
+    cache: nvvm.LoadCacheModifier = nvvm.LoadCacheModifier.CG,
+    swizzle: cutlass.Constexpr[bool] = False,
+    cp_size_bytes=None,
+    valid_rows=None,
+    valid_cols=None,
+    row_base=None,
+    col_base=None,
+):
+    bytes_per_copy = elems_per_copy * elem_bytes
+    if cutlass.const_expr(bytes_per_copy not in (4, 8, 16)):
+        raise ValueError(f"load_tile_2d: elems_per_copy*elem_bytes must be 4/8/16, got " f"{elems_per_copy}*{elem_bytes}={bytes_per_copy}")
+    if cutlass.const_expr(elems_per_row % elems_per_copy != 0):
+        raise ValueError(f"load_tile_2d: elems_per_row ({elems_per_row}) must be a multiple " f"of elems_per_copy ({elems_per_copy})")
+    chunks_per_row = elems_per_row // elems_per_copy
+    total_chunks = rows * chunks_per_row
+    if cutlass.const_expr(total_chunks % num_threads != 0):
+        raise ValueError(f"load_tile_2d: total_chunks ({rows}*{chunks_per_row}={total_chunks}) " f"must be a multiple of num_threads ({num_threads})")
+    if cutlass.const_expr(cp_size_bytes is None):
+        cp_size_bytes = bytes_per_copy
+    predicate_active = cutlass.const_expr((valid_rows is not None) or (valid_cols is not None))
+    n_iters = total_chunks // num_threads
+    for i in cutlass.range_constexpr(n_iters):
+        chunk_idx = i * num_threads + tidx
+        row = chunk_idx // chunks_per_row
+        col_elem = (chunk_idx % chunks_per_row) * elems_per_copy
+        src = _advance(gmem_src, row * gmem_row_stride_elems + col_elem)
+        if cutlass.const_expr(swizzle):
+            smem_col = swizzle_xor_128b(row, col_elem, elem_bytes=elem_bytes)
+        else:
+            smem_col = col_elem
+        dst = smem_dst.subview(row * elems_per_row + smem_col)
+        if cutlass.const_expr(predicate_active):
+            pred = cutlass.Int32(1)
+            if cutlass.const_expr(valid_rows is not None):
+                row_abs = row if row_base is None else row + row_base
+                pred = pred * cutlass.Int32(row_abs < valid_rows)
+            if cutlass.const_expr(valid_cols is not None):
+                col_abs_end = col_elem + cutlass.Int32(elems_per_copy) if col_base is None else col_elem + col_base + cutlass.Int32(elems_per_copy)
+                pred = pred * cutlass.Int32(col_abs_end <= valid_cols)
+            cp_size_final = cp_size_bytes * pred
+        else:
+            cp_size_final = cp_size_bytes
+        nvvm.cp_async_shared_global(dst, src, bytes_per_copy, cache, cp_size=cp_size_final)
+
+
+@cute.jit
+def tma_tensormap_acquire(desc_ptr):
+    """Issue a single ``fence.proxy.tensormap::generic.acquire.gpu`` over a
+    runtime TMA descriptor.
+
+    A runtime descriptor written on the host by a descriptor-builder kernel
+    (via ``tensormap_replace``) is visible to the TMA proxy only after this
+    GENERIC->TENSORMAP acquire.  Such descriptors are built once (not rewritten
+    per work-tile), so a single acquire per consumer CTA (or once per
+    persistent-loop tile) suffices; call this once and pass ``acquire=False`` to
+    the per-tile ``tma_load_tile`` / ``tma_store_tile`` wrappers to skip the
+    redundant per-call fences.
+    """
+    nvvm.fence_proxy_acquire(
+        nvvm.MemScope.GPU,
+        desc_ptr,
+        128,
+        from_proxy=nvvm.Proxy.GENERIC,
+        to_proxy=nvvm.Proxy.TENSORMAP,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,12 @@ linear = [
     "apache-tvm-ffi>=0.1.12",
 ]
 
+mega = [
+    "nvidia-cutlass-dsl[cu13]>=4.7.0; sys_platform == 'linux'",
+    "cuda-python>=13.0; sys_platform == 'linux'",
+    "apache-tvm-ffi>=0.1.12",
+]
+
 tests = [
     "pytest",
     "pytest-xdist",
@@ -65,6 +71,14 @@ docs = [
 ]
 
 # ---------- TOOL CONFIGURATIONS ------------
+[tool.uv]
+conflicts = [
+    [
+        { extra = "mega" },
+        { extra = "tests" },
+    ],
+]
+
 [tool.hatch.version]
 source = "vcs"
 
@@ -106,6 +120,15 @@ exclude = [
     "site-packages",
     "venv",
     "*.ipynb",
+    # Vendored NVIDIA Apache-2.0/MIT source; lint the maintained Mega adapters instead.
+    "attn_gym/linear/_delta_rule/mega/kernels/common",
+    "attn_gym/linear/_delta_rule/mega/kernels/kda_bprop_config.py",
+    "attn_gym/linear/_delta_rule/mega/kernels/kda_bprop_f16.py",
+    "attn_gym/linear/_delta_rule/mega/kernels/kda_prefill_config.py",
+    "attn_gym/linear/_delta_rule/mega/kernels/kda_prefill_f16.py",
+    "attn_gym/linear/_delta_rule/mega/kernels/kda_recompute_config.py",
+    "attn_gym/linear/_delta_rule/mega/kernels/kda_recompute_f16.py",
+    "attn_gym/linear/_delta_rule/mega/kernels/tile_dsl",
 ]
 
 [tool.ruff.lint]

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,10 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
+conflicts = [[
+    { package = "attn-gym", extra = "mega" },
+    { package = "attn-gym", extra = "tests" },
+]]
 
 [[package]]
 name = "annotated-doc"
@@ -21,9 +25,9 @@ name = "anyio"
 version = "4.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
     { name = "idna" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
 wheels = [
@@ -89,11 +93,17 @@ docs = [
 ]
 linear = [
     { name = "apache-tvm-ffi" },
-    { name = "nvidia-cutlass-dsl", extra = ["cu13"], marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cutlass-dsl", version = "4.6.3", source = { registry = "https://pypi.org/simple" }, extra = ["cu13"], marker = "(sys_platform == 'linux' and extra == 'extra-8-attn-gym-tests') or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "nvidia-cutlass-dsl", version = "4.7.1", source = { registry = "https://pypi.org/simple" }, extra = ["cu13"], marker = "(sys_platform == 'linux' and extra == 'extra-8-attn-gym-mega') or (sys_platform == 'linux' and extra != 'extra-8-attn-gym-tests') or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+]
+mega = [
+    { name = "apache-tvm-ffi" },
+    { name = "cuda-python", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cutlass-dsl", version = "4.7.1", source = { registry = "https://pypi.org/simple" }, extra = ["cu13"], marker = "(sys_platform == 'linux' and extra == 'extra-8-attn-gym-mega') or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
 ]
 tests = [
     { name = "docstring-parser" },
-    { name = "flash-attn-4", extra = ["cu13"], marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "flash-attn-4", extra = ["cu13"], marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-8-attn-gym-tests') or (platform_machine != 'x86_64' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform != 'linux' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
     { name = "jsonargparse" },
     { name = "pytest" },
     { name = "pytest-xdist" },
@@ -103,8 +113,8 @@ viz = [
     { name = "docstring-parser" },
     { name = "jsonargparse" },
     { name = "marimo" },
-    { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "matplotlib", version = "3.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "matplotlib", version = "3.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
     { name = "pyyaml" },
     { name = "tabulate" },
 ]
@@ -112,6 +122,8 @@ viz = [
 [package.metadata]
 requires-dist = [
     { name = "apache-tvm-ffi", marker = "extra == 'linear'", specifier = ">=0.1.12" },
+    { name = "apache-tvm-ffi", marker = "extra == 'mega'", specifier = ">=0.1.12" },
+    { name = "cuda-python", marker = "sys_platform == 'linux' and extra == 'mega'", specifier = ">=13.0" },
     { name = "docstring-parser", marker = "extra == 'dev'" },
     { name = "docstring-parser", marker = "extra == 'tests'" },
     { name = "docstring-parser", marker = "extra == 'viz'" },
@@ -126,6 +138,7 @@ requires-dist = [
     { name = "mkdocs-redirects", marker = "extra == 'docs'" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'" },
     { name = "nvidia-cutlass-dsl", extras = ["cu13"], marker = "sys_platform == 'linux' and extra == 'linear'", specifier = ">=4.5.0" },
+    { name = "nvidia-cutlass-dsl", extras = ["cu13"], marker = "sys_platform == 'linux' and extra == 'mega'", specifier = ">=4.7.0" },
     { name = "prek", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'tests'" },
@@ -137,7 +150,7 @@ requires-dist = [
     { name = "typer", marker = "extra == 'dev'" },
     { name = "typer", marker = "extra == 'tests'" },
 ]
-provides-extras = ["dev", "docs", "linear", "tests", "viz"]
+provides-extras = ["dev", "docs", "linear", "mega", "tests", "viz"]
 
 [[package]]
 name = "babel"
@@ -184,7 +197,7 @@ name = "cffi"
 version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9e/ef/008a1939e372c06329a3fce4279c02f328488f3526744906eeec3da7ad5f/cffi-2.1.1.tar.gz", hash = "sha256:dd31f52ea1086513bb9df30f8fcee9b8918323ae067a3d5b78bc826a000712be", size = 530807, upload-time = "2026-08-03T21:21:18.939Z" }
 wheels = [
@@ -478,7 +491,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -549,8 +562,8 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -637,16 +650,22 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/21/8464d133752951c154feafb3b65c297e7d80f301183d220bec4c830f1441/cuda_bindings-13.3.1-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:120fcc53d57903df529c3486962c56528cba5b7d6c57c99537320ed9922c8b86", size = 6073403, upload-time = "2026-05-29T23:11:36.22Z" },
     { url = "https://files.pythonhosted.org/packages/a8/1f/5ef51f5fbaa5d4d3201bb3d7555af028ec1aa4416275ccbf73c9e34e3d2d/cuda_bindings-13.3.1-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9851b0caa8bfd3bc6fa054eaf57bea7c8e9c3a62db2d2621224677f49f3c53d0", size = 6675244, upload-time = "2026-05-29T23:11:38.664Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/64/bb17e4d168569ef7be05c44474fe3dc19278d60a69ba228e45a431c86444/cuda_bindings-13.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:c0c4b1a995098c46695c24257a342dc97d6e6d3f3050b944c9f43bd26d734051", size = 5625597, upload-time = "2026-05-29T23:11:40.808Z" },
     { url = "https://files.pythonhosted.org/packages/51/6b/457ca12dad3ee9bfcc9a545cfd6b64b359ba49de40f776f6e028e678f262/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5879712accf6e14bb01aa5e67440eb84998b8d104b509cc7a6dc0b8f656a474", size = 6053539, upload-time = "2026-05-29T23:11:43.19Z" },
     { url = "https://files.pythonhosted.org/packages/95/7a/c5e3c34a409b148f5c0f5a4ea374158f95d488862c1dffedf9aa5c639df9/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04436a9364059c84b8f9636f359eccda1cf814341f5b670c71d80d2f79dbc708", size = 6674166, upload-time = "2026-05-29T23:11:45.478Z" },
+    { url = "https://files.pythonhosted.org/packages/93/f7/0e35987a21914f84068061dcf4b61466ccbce1c62ddc9727596d5ed0c26f/cuda_bindings-13.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:507b0e19e7f934c5e30f30f0244ad70a75812619a7d3a0d742543caae1bd50f1", size = 5664286, upload-time = "2026-05-29T23:11:47.719Z" },
     { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
     { url = "https://files.pythonhosted.org/packages/39/2a/6d2e9047d1fb243dbaa364b01e0297534b9ed7fd27dba1c9f361519cf69b/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e32d08f71ebcdf00f0f41eab2eb37e8da94c8ed411cc9f7f7a019ce6b34abe3a", size = 6657965, upload-time = "2026-05-29T23:11:52.227Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/95/872a0392122f1fb43fcb06869790ef3171f37beee9f7db8f441739113570/cuda_bindings-13.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:b134dd8c5c66ae4c4ad814f7aee88fd215353c077010cbc47e3b55ed35ec9eff", size = 5875099, upload-time = "2026-05-29T23:11:54.635Z" },
     { url = "https://files.pythonhosted.org/packages/cc/6e/2394f8163360f8391f8f1b7e72d300a82724edb81a7b7084c799fbd4c91f/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9efb21c1ee64981e184b9e0ba5eb3179e5ba3d4b51665a6cb52b8ef3d01a7cbf", size = 5920504, upload-time = "2026-05-29T23:11:56.883Z" },
     { url = "https://files.pythonhosted.org/packages/34/c2/ef9b6a63f7dc432712a462c816662e662e00d38caa9b861c8c2588195d03/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2732904099e0a4d4db774a5fc6d91ee95fae065b4d2ecabb4968c5fe2406c9d7", size = 6476660, upload-time = "2026-05-29T23:11:59.188Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/2f/6a0dd496550c6fafbf6aeb1bf40242eeabb2fd138a43892aabb4be8224c2/cuda_bindings-13.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:18c8c167c8907b8f02531ca810534315c458dabef31f7965095619bf647b9202", size = 5830027, upload-time = "2026-05-29T23:12:01.205Z" },
     { url = "https://files.pythonhosted.org/packages/b1/81/bff68ce829999c1e4209c761bbf903b1c06ec570416ddb25020864ad5907/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ab2f74ed65bfef4163ba07a8db16f1085e0729291db12a2423aff84ee8278b8", size = 6013639, upload-time = "2026-05-29T23:12:03.509Z" },
     { url = "https://files.pythonhosted.org/packages/d4/e0/c8a1f0c8f9ffdea4f5fe6dbab89b326cef4d85caf489dad39e209da89416/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd4c814d311ec08c981f6dded1dbe7d4b371067ee4f6c14cccec4bde9590f80", size = 6534419, upload-time = "2026-05-29T23:12:05.633Z" },
+    { url = "https://files.pythonhosted.org/packages/48/45/2734be44dbc80ac082ec23a86b41c8294992dcb90033645ed1bc50aafe4c/cuda_bindings-13.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:8de12ef60bf40756852cb62bbb40460609269f6ece522903d1cc93d73a3ececb", size = 5961055, upload-time = "2026-05-29T23:12:07.971Z" },
     { url = "https://files.pythonhosted.org/packages/52/b8/83b1f563925b290f2d11a01a77a84013ba56052fe3653a5bef3ccfbb43d6/cuda_bindings-13.3.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c3c772dfff49681541d59630c90f858e173ac926b9c593a2b7123f2a1043cc76", size = 5809771, upload-time = "2026-05-29T23:12:10.422Z" },
     { url = "https://files.pythonhosted.org/packages/12/20/e79b4bfe98f075195afb6343d41c498f9dbd2d161d7021d4d28bceb83581/cuda_bindings-13.3.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:36febb7c1079d68a981dbbd8d5a67235b399802b82075c9388624719607e52b9", size = 6358584, upload-time = "2026-05-29T23:12:12.767Z" },
+    { url = "https://files.pythonhosted.org/packages/27/2a/b59bcac016ab9985d6b48a5d05b0d698461a159ca03ee11c4abd54da2ac4/cuda_bindings-13.3.1-cp314-cp314t-win_amd64.whl", hash = "sha256:61120b5e4f4a63f67efd7e7396914cb9ef871bb1f0021e990fb70277be240a4d", size = 6740329, upload-time = "2026-05-29T23:12:15.153Z" },
 ]
 
 [[package]]
@@ -654,25 +673,31 @@ name = "cuda-core"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "backports-strenum", marker = "python_full_version < '3.11'" },
+    { name = "backports-strenum", marker = "python_full_version < '3.11' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
     { name = "cuda-pathfinder" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/90/21/ef85f3e15d394c9ca41fe116d78cd9e28533b9d7ead842f9241b332acf01/cuda_core-1.0.1-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9632db74eceb1cd72a7c95b61a5e4cfb9cc2291de0503e170334d936cab3316", size = 4788165, upload-time = "2026-05-12T20:11:17.116Z" },
     { url = "https://files.pythonhosted.org/packages/e0/41/c2c07b313c6cbb5d93010200c62b01ddb9f6c6f43a096a75c7b902c42ad6/cuda_core-1.0.1-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46690b0864417a5f2f9a7d10408e2570cbacae195c890a41286701eefb01ba79", size = 5061723, upload-time = "2026-05-12T20:11:19.767Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/2d/b16b0af698a1bf4db337345daa7a44cd372fef107a3b692ffe1e0e6c5cc5/cuda_core-1.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:1693fae113604cf9c114bfe3da15a15981f9d44ae78ecceb0b23e24c628ad19b", size = 4742003, upload-time = "2026-05-12T20:11:21.943Z" },
     { url = "https://files.pythonhosted.org/packages/41/4b/4ac1d0639241da756c634add606f93a7f3a39bef12f70e1fb4b40cc53c21/cuda_core-1.0.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3effd11283bc46fd06348c2fd18a0941ba7718a6f447343858c944c1a93a6dab", size = 4784340, upload-time = "2026-05-12T20:11:23.961Z" },
     { url = "https://files.pythonhosted.org/packages/01/55/bb3e701f4af504e5e39e837135dc80022ec4c84858b2886ad577fe696a77/cuda_core-1.0.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1934517ff8a9dcd21b3f4a28e15e12643164b7d3ec187a4ee7560e22fd2dfc17", size = 5059041, upload-time = "2026-05-12T20:11:26.045Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/e3/3ffaca2eabc71d0f9d29368fabc8ffb309353f05f418ea4c7eb5f223cf09/cuda_core-1.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:95c91d434a9baca066646cefa577227385104670a02fbe8e3defaadda84becf5", size = 4746198, upload-time = "2026-05-12T20:11:28.405Z" },
     { url = "https://files.pythonhosted.org/packages/0d/a0/1daeae599cadd612689dbbf70d7da1c01883964fc2fbc7386f3c630a68cf/cuda_core-1.0.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6816dc020aee6103d8071bc02d8e4e1d91f2b49596f666896d608d92224d79d1", size = 4789856, upload-time = "2026-05-12T20:11:30.862Z" },
     { url = "https://files.pythonhosted.org/packages/a1/4d/603557ab3cb171cc2a61d3678a39cb4dae3fd21275078bfbd1c0b0b5230b/cuda_core-1.0.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be7b65311bf78964b7905adbf3c0f8f717d432f2854dc45169277729bf60f1e2", size = 5106023, upload-time = "2026-05-12T20:11:33.509Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/1a/ae079963c9df7f4274227eb63cf8f6083a532a6443adb340d951fd21c626/cuda_core-1.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:1a5c1aa3b738a7599ea289498d038fe625d259fd7ab795394541eee58a8e29bc", size = 4663076, upload-time = "2026-05-12T20:11:35.784Z" },
     { url = "https://files.pythonhosted.org/packages/57/f9/a6676b1fa555fad5748a945f4b530b51b898b4771a1e5d9f3520d3f415ea/cuda_core-1.0.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c427e5025096d96fcd5092fdc85d5d5e4ac3dea007914e90472ed52f27220446", size = 4749800, upload-time = "2026-05-12T20:11:38.012Z" },
     { url = "https://files.pythonhosted.org/packages/9c/9d/4534a9564a812ee95b43db7324f9b25cbffda001bb348bb5b3f90dad50b9/cuda_core-1.0.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b392178202c652368883dbe3773cee14f3e1ed6b8bf45d1a1bcdd37c73604e06", size = 5078597, upload-time = "2026-05-12T20:11:40.836Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/7c/2f68b0bdeb7dd36204f752468254d6b4487c6d82e9e442cfbe815a656eac/cuda_core-1.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:b99e3ca9bf3bd2c7d3028e5dc541b00e432e21373816889cdf2722b675bd9be8", size = 4647545, upload-time = "2026-05-12T20:11:43.494Z" },
     { url = "https://files.pythonhosted.org/packages/c2/45/55b07d643c87f1234b3cbc9d8383c0962b368ba1d6686a1919d6f6001af4/cuda_core-1.0.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e9b0f115a68f2f84c0f6d9b7e863a29517f6dfe5f7b7d07d1d9da8904754e9a2", size = 4816184, upload-time = "2026-05-12T20:11:46.114Z" },
     { url = "https://files.pythonhosted.org/packages/51/08/1aeffc9a529a7f94c9cee9bfd3a991743398b5f90aab30f06f2a4bc8205e/cuda_core-1.0.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:af2db9e50e81d73e4f0b72ad279d0a9c789372393938fe75c17236b9ed974d7d", size = 5104496, upload-time = "2026-05-12T20:11:48.518Z" },
+    { url = "https://files.pythonhosted.org/packages/66/66/965330a44bcfa548793cf13244083528a597da2a18ff42d00fe8ef91ba03/cuda_core-1.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:29783ba03d36960b6612b15ff97123e88cfadfb7b1884f3581839f6bfba4b29f", size = 4765708, upload-time = "2026-05-12T20:11:51.107Z" },
     { url = "https://files.pythonhosted.org/packages/e3/ab/db09228d5a8c124a93514726d2e18f31824f66d3a6769ee4e51721dd64cf/cuda_core-1.0.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4410bf1ef15c2ec23dccc302da76893c9354b530dee422e3277b116231bf5fe1", size = 4996094, upload-time = "2026-05-12T20:11:53.575Z" },
     { url = "https://files.pythonhosted.org/packages/29/e7/8ced56d6c6fa32b7385a8dccefd1424e3c1201bfee3385d9710609a43d16/cuda_core-1.0.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e0f1324486bb90be6bde28bd0afbaf78a38827948d37f93f90318a01da8a3f8c", size = 5212461, upload-time = "2026-05-12T20:11:56.238Z" },
+    { url = "https://files.pythonhosted.org/packages/da/06/36236c44ed4025a6cbf5b6450364fc29e0f3d35ef4becb13b168fcd271f4/cuda_core-1.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:180bc808166483b0d6658a7c0d3f1312083b220f301de49476c1bc459cc46cf8", size = 5551965, upload-time = "2026-05-12T20:11:58.84Z" },
 ]
 
 [[package]]
@@ -706,43 +731,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'linux' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'win32' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'linux' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'win32' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'linux' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'win32' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'linux' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'win32' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'linux' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'win32' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cufile", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'linux' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'win32' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'linux' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'win32' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'linux' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'win32' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'linux' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'win32' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'linux' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'win32' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'linux' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'win32' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'linux' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'win32' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'linux' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'win32' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'linux' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'win32' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'linux' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'win32' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'linux' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'win32' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
 ]
 
 [[package]]
@@ -786,7 +811,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -818,7 +843,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apache-tvm-ffi" },
     { name = "einops" },
-    { name = "nvidia-cutlass-dsl" },
+    { name = "nvidia-cutlass-dsl", version = "4.6.3", source = { registry = "https://pypi.org/simple" } },
     { name = "quack-kernels" },
     { name = "torch" },
     { name = "torch-c-dlpack-ext" },
@@ -831,7 +856,7 @@ wheels = [
 
 [package.optional-dependencies]
 cu13 = [
-    { name = "nvidia-cutlass-dsl", extra = ["cu13"] },
+    { name = "nvidia-cutlass-dsl", version = "4.6.3", source = { registry = "https://pypi.org/simple" }, extra = ["cu13"], marker = "extra == 'extra-8-attn-gym-tests'" },
 ]
 
 [[package]]
@@ -1237,27 +1262,27 @@ name = "marimo"
 version = "0.24.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "sys_platform != 'emscripten'" },
+    { name = "click", marker = "sys_platform != 'emscripten' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
     { name = "docutils" },
     { name = "itsdangerous" },
     { name = "jedi" },
-    { name = "loro", marker = "sys_platform != 'android' and sys_platform != 'emscripten'" },
+    { name = "loro", marker = "(sys_platform != 'android' and sys_platform != 'emscripten') or (sys_platform == 'android' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'emscripten' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
     { name = "markdown" },
     { name = "msgspec" },
     { name = "narwhals" },
     { name = "packaging" },
-    { name = "psutil", marker = "sys_platform != 'android' and sys_platform != 'emscripten'" },
+    { name = "psutil", marker = "(sys_platform != 'android' and sys_platform != 'emscripten') or (sys_platform == 'android' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'emscripten' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
     { name = "pygments" },
     { name = "pymdown-extensions" },
     { name = "python-multipart" },
     { name = "pyyaml" },
-    { name = "pyzmq", marker = "python_full_version < '3.15' and sys_platform != 'emscripten'" },
-    { name = "starlette", marker = "sys_platform != 'emscripten'" },
+    { name = "pyzmq", marker = "(python_full_version < '3.15' and sys_platform != 'emscripten') or (python_full_version >= '3.15' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'emscripten' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "starlette", marker = "sys_platform != 'emscripten' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
     { name = "tomlkit" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
-    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
-    { name = "websockets", version = "16.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform != 'emscripten'" },
-    { name = "websockets", version = "17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "websockets", version = "16.1.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and sys_platform != 'emscripten') or (python_full_version >= '3.11' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'emscripten' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "websockets", version = "17.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform != 'emscripten') or (python_full_version < '3.11' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform == 'emscripten' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/36/e0/70c18b2862d9a439c811cf2e5bf0aef2b9d0cc7ac72beb2ba6eea9a9a055/marimo-0.24.0.tar.gz", hash = "sha256:30aaeae5a5936df524814fddd98f4b260d3068f97df2611d252fe4b253f3fb80", size = 39054161, upload-time = "2026-08-17T21:30:18.072Z" }
 wheels = [
@@ -1378,15 +1403,15 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "cycler", marker = "python_full_version < '3.11'" },
-    { name = "fonttools", marker = "python_full_version < '3.11'" },
-    { name = "kiwisolver", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "pillow", marker = "python_full_version < '3.11'" },
-    { name = "pyparsing", marker = "python_full_version < '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
+    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "cycler", marker = "python_full_version < '3.11' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "fonttools", marker = "python_full_version < '3.11' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "kiwisolver", marker = "python_full_version < '3.11' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "packaging", marker = "python_full_version < '3.11' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "pillow", marker = "python_full_version < '3.11' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "pyparsing", marker = "python_full_version < '3.11' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "python-dateutil", marker = "python_full_version < '3.11' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/1b/4be5be87d43d327a0cf4de1a56e86f7f84c89312452406cf122efe2839e6/matplotlib-3.10.9.tar.gz", hash = "sha256:fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358", size = 34811233, upload-time = "2026-04-24T00:14:13.539Z" }
 wheels = [
@@ -1455,16 +1480,16 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "cycler", marker = "python_full_version >= '3.11'" },
-    { name = "fonttools", marker = "python_full_version >= '3.11'" },
-    { name = "kiwisolver", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.11'" },
-    { name = "pillow", marker = "python_full_version >= '3.11'" },
-    { name = "pyparsing", marker = "python_full_version >= '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
+    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "cycler", marker = "python_full_version >= '3.11' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "fonttools", marker = "python_full_version >= '3.11' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "kiwisolver", marker = "python_full_version >= '3.11' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "packaging", marker = "python_full_version >= '3.11' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "pillow", marker = "python_full_version >= '3.11' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "pyparsing", marker = "python_full_version >= '3.11' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.11' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/49/64/f9a391af28f518b11ad45a8a712353c94a0aefce09d3703200e5c54b610a/matplotlib-3.11.1.tar.gz", hash = "sha256:69647db5746941c793d6e445a4cd349323ffb87d9cc958c2ad84a659b4832d30", size = 32612045, upload-time = "2026-07-18T03:39:46.63Z" }
 wheels = [
@@ -1539,7 +1564,7 @@ version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
     { name = "ghp-import" },
     { name = "jinja2" },
     { name = "markdown" },
@@ -1680,7 +1705,7 @@ dependencies = [
     { name = "griffelib" },
     { name = "mkdocs-autorefs" },
     { name = "mkdocstrings" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/90/5d/1be1c7a49d8fa13dc80f66a85f53333d52cf5206911412006ffdff8fb9a0/mkdocstrings_python-2.0.7.tar.gz", hash = "sha256:8c49faf66d243072d7590a1b5dea028d9d7425fac191f54f096123a4a9c1a783", size = 201598, upload-time = "2026-08-17T16:56:18.239Z" }
 wheels = [
@@ -2019,6 +2044,7 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
     { url = "https://files.pythonhosted.org/packages/3b/cd/154ca20c38269e05eff77c1464e6c1da89f50a6390b565e9d82e06bc11e1/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:37936a16db8fe4ac1f065c2139360608a543a09275cb1a1af612e08cfa065436", size = 423138758, upload-time = "2026-04-08T18:46:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/45/9e/2f562daf80eb8f7a685fb7bea4fda71f6048e4f359d6fdd1b6e70206cb2f/nvidia_cublas-13.1.1.3-py3-none-win_amd64.whl", hash = "sha256:b6cdce694e47ff6aadf0a69df1cab6628d696f5ff56e8d16af50309d855fa20f", size = 404358158, upload-time = "2026-04-08T18:47:26.987Z" },
 ]
 
 [[package]]
@@ -2028,6 +2054,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/2a/80353b103fc20ce05ef51e928daed4b6015db4aaa9162ed0997090fe2250/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151", size = 10310827, upload-time = "2025-09-04T08:26:42.012Z" },
     { url = "https://files.pythonhosted.org/packages/33/6d/737d164b4837a9bbd202f5ae3078975f0525a55730fe871d8ed4e3b952b0/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8", size = 10715597, upload-time = "2025-09-04T08:26:51.312Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/df/b74b10025c1205695c5676373f2edd3e87a7202cc62ead0dfbc373b0f6ea/nvidia_cuda_cupti-13.0.85-py3-none-win_amd64.whl", hash = "sha256:683f58d301548deeefcb8f6fac1b8d907691b9d8b18eccab417f51e362102f00", size = 7736776, upload-time = "2025-09-04T08:38:08.38Z" },
 ]
 
 [[package]]
@@ -2037,6 +2064,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/92/be/e9de501cb71b10f7654381a485fa4ebf470ea25c3dce018cccaecf8a8f9a/nvidia_cuda_nvdisasm-13.3.73-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:dd4751884f9016b9b6dbf007abdeb5681d0a2edc731dd3d2fda9d6d878e88f73", size = 4744517, upload-time = "2026-06-29T16:48:33.527Z" },
     { url = "https://files.pythonhosted.org/packages/86/3e/88460ebd737e559e8e9843db7a63f8ced9ec7be1882344438819dd13aebc/nvidia_cuda_nvdisasm-13.3.73-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fa17084b07c0dca68a42892f771b4b1b40fbe9b91660209623e61cea611cae8c", size = 4782824, upload-time = "2026-06-29T16:49:05.109Z" },
+    { url = "https://files.pythonhosted.org/packages/32/63/00d687730b124f94345f83023363251310ccc08eeac269ec2eeff6b097f3/nvidia_cuda_nvdisasm-13.3.73-py3-none-win_amd64.whl", hash = "sha256:da2fab133c3d095d83f13587eb87149beabd199b34a3cc270d0aa99449a628c3", size = 5015368, upload-time = "2026-06-29T17:22:50.207Z" },
 ]
 
 [[package]]
@@ -2046,6 +2074,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/68/483a78f5e8f31b08fb1bb671559968c0ca3a065ac7acabfc7cee55214fd6/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575", size = 90215200, upload-time = "2025-09-04T08:28:44.204Z" },
     { url = "https://files.pythonhosted.org/packages/b7/dc/6bb80850e0b7edd6588d560758f17e0550893a1feaf436807d64d2da040f/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d27f20a0ca67a4bb34268a5e951033496c5b74870b868bacd046b1b8e0c3267b", size = 43015449, upload-time = "2025-09-04T08:28:20.239Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/af/345fedb9f4c76c84ab4fa445b36bd4048a4d9db60e6bc76b4f913ff4b852/nvidia_cuda_nvrtc-13.0.88-py3-none-win_amd64.whl", hash = "sha256:6bcd4e7f8e205cbe644f5a98f2f799bef9556fefc89dd786e79a16312ce49872", size = 76807835, upload-time = "2025-09-04T08:39:15.274Z" },
 ]
 
 [[package]]
@@ -2055,6 +2084,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/4f/17d7b9b8e285199c58ce28e31b5c5bbaa4d8271af06a89b6405258245de2/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55", size = 2261060, upload-time = "2025-10-09T08:55:15.78Z" },
     { url = "https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548", size = 2243632, upload-time = "2025-10-09T08:55:36.117Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/94/6b867483bec07da24ffa32736c79fabb94ef3a7af4d787a9d4a974868576/nvidia_cuda_runtime-13.0.96-py3-none-win_amd64.whl", hash = "sha256:f79298c8a098cec150a597c8eba58ecdab96e3bdc4b9bc4f9983635031740492", size = 2927037, upload-time = "2025-10-09T09:04:23.782Z" },
 ]
 
 [[package]]
@@ -2067,6 +2097,7 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
     { url = "https://files.pythonhosted.org/packages/6e/5e/edb9c0ae051602c3ccaffe424256463636d639e27d7f302dde9975ef9e7a/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0c45dd8eeb50b603f07995b1b300c62ffe6a1980482b82b3bcf94a4ca9d49304", size = 366173588, upload-time = "2026-03-09T19:29:34.474Z" },
+    { url = "https://files.pythonhosted.org/packages/78/39/21507455b1bca8b5702a9e9fc6ce73735f216f558dac2c9ede58e4d456b8/nvidia_cudnn_cu13-9.20.0.48-py3-none-win_amd64.whl", hash = "sha256:af8139732b99c0118be65ea5aac97f0d46018f8c552889e49d2fb0c6261a4a24", size = 350712614, upload-time = "2026-03-09T19:31:11.398Z" },
 ]
 
 [[package]]
@@ -2079,6 +2110,7 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
     { url = "https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3", size = 214085489, upload-time = "2025-09-04T08:31:56.044Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b2/f8af21a2ed1beed337a6a02c5a28aeb85441f4d578ec3d529543c775ea4b/nvidia_cufft-12.0.0.61-py3-none-win_amd64.whl", hash = "sha256:2abce5b39d2f5ae12730fb7e5db6696533e36c26e2d3e8fd1750bdd2853364eb", size = 213342123, upload-time = "2025-09-04T08:40:51.145Z" },
 ]
 
 [[package]]
@@ -2097,6 +2129,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/72/7c2ae24fb6b63a32e6ae5d241cc65263ea18d08802aaae087d9f013335a2/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:133df5a7509c3e292aaa2b477afd0194f06ce4ea24d714d616ff36439cee349a", size = 61962106, upload-time = "2025-08-04T10:21:41.128Z" },
     { url = "https://files.pythonhosted.org/packages/a5/9f/be0a41ca4a4917abf5cb9ae0daff1a6060cc5de950aec0396de9f3b52bc5/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:1aee33a5da6e1db083fe2b90082def8915f30f3248d5896bcec36a579d941bfc", size = 59544258, upload-time = "2025-08-04T10:22:03.992Z" },
+    { url = "https://files.pythonhosted.org/packages/99/27/72103153b1ffc00e09fdc40ac970235343dcd1ea8bd762e84d2d73219ffa/nvidia_curand-10.4.0.35-py3-none-win_amd64.whl", hash = "sha256:65b1710aa6961d326b411e314b374290904c5ddf41dc3f766ebc3f1d7d4ca69f", size = 55242481, upload-time = "2025-08-04T10:30:41.831Z" },
 ]
 
 [[package]]
@@ -2111,6 +2144,7 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
     { url = "https://files.pythonhosted.org/packages/5f/67/cba3777620cdacb99102da4042883709c41c709f4b6323c10781a9c3aa34/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0a759da5dea5c0ea10fd307de75cdeb59e7ea4fcb8add0924859b944babf1112", size = 200941980, upload-time = "2025-09-04T08:33:22.767Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ef/332a0101260ca78a1daef046bf0b06199e8ed4dac1d2aa698289c358169c/nvidia_cusolver-12.0.4.66-py3-none-win_amd64.whl", hash = "sha256:16515bd33a8e76bb54d024cfa068fa68d30e80fc34b9e1090813ea9362e0cb65", size = 193551444, upload-time = "2025-09-04T08:41:46.813Z" },
 ]
 
 [[package]]
@@ -2123,6 +2157,7 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
     { url = "https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b3c89c88d01ee0e477cb7f82ef60a11a4bcd57b6b87c33f789350b59759360b", size = 145942937, upload-time = "2025-09-04T08:33:58.029Z" },
+    { url = "https://files.pythonhosted.org/packages/02/b0/b043d6f3480f102f885cf87fc3ffd3edcb5e23b855025a50e2ef4d059185/nvidia_cusparse-12.6.3.3-py3-none-win_amd64.whl", hash = "sha256:cbcf42feb737bd7ec15b4c0a63e62351886bd3f975027b8815d7f720a2b5ea79", size = 143783033, upload-time = "2025-09-04T08:42:12.391Z" },
 ]
 
 [[package]]
@@ -2132,15 +2167,21 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/e1/cdc1797eadf82d3a9a575a19b33fdc871a97edbec42c00b5b5e914f4aff4/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4dca476c50bf4780d46cd0bfbd82e2bc10a08e4fef7950917ce8d7578d22a23f", size = 221051344, upload-time = "2025-09-05T18:49:51.289Z" },
     { url = "https://files.pythonhosted.org/packages/34/7d/2661f2fb3ac4302f3a246f5fc030213ac60c1fe0bce84f9783dbd831dbb7/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:786ce87568c303fadb5afcc7102d454cd3040d75f6f8626f5db460d1871f4dd0", size = 170148586, upload-time = "2025-09-05T18:50:50.248Z" },
+    { url = "https://files.pythonhosted.org/packages/31/83/f3647ce26916c94a6ca4ff1810623e2c405cff2dea6e78d29516b2514df9/nvidia_cusparselt_cu13-0.8.1-py3-none-win_amd64.whl", hash = "sha256:dccbd362f91a7b9024d1f55ee9f548ac065027ff15d8c8b0db889ab3a8f31215", size = 156885108, upload-time = "2025-09-05T18:51:35.958Z" },
 ]
 
 [[package]]
 name = "nvidia-cutlass-dsl"
 version = "4.6.3"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
+]
 dependencies = [
-    { name = "nvidia-cutlass-dsl-libs-base" },
-    { name = "nvidia-cutlass-dsl-libs-cu12" },
+    { name = "nvidia-cutlass-dsl-libs-base", version = "4.6.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-attn-gym-tests'" },
+    { name = "nvidia-cutlass-dsl-libs-cu12", version = "4.6.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-attn-gym-tests'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/de/b5917cdd95eba8c43d42b08fe0bc22bb600534e4e0c4e56cda6f56fbb4fd/nvidia_cutlass_dsl-4.6.3-py3-none-any.whl", hash = "sha256:8d0ce96f9891723657ea26b5d64f57a0ff8eb86ea6a18380308fadf056d86cc7", size = 10459, upload-time = "2026-08-26T03:10:30.674Z" },
@@ -2148,22 +2189,49 @@ wheels = [
 
 [package.optional-dependencies]
 cu13 = [
-    { name = "nvidia-cutlass-dsl-libs-cu13" },
+    { name = "nvidia-cutlass-dsl-libs-cu13", version = "4.6.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-attn-gym-tests'" },
+]
+
+[[package]]
+name = "nvidia-cutlass-dsl"
+version = "4.7.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "nvidia-cutlass-dsl-libs-base", version = "4.7.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-attn-gym-mega' or extra != 'extra-8-attn-gym-tests'" },
+    { name = "nvidia-cutlass-dsl-libs-cu12", version = "4.7.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-attn-gym-mega' or extra != 'extra-8-attn-gym-tests'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/ef/903dab832a19e0f1d798c9acc96edbda5dfb29f2e030b46e163946555817/nvidia_cutlass_dsl-4.7.1-py3-none-any.whl", hash = "sha256:765850c74868a0b5a02fefbfc1b380842b64e5f7a1c8b1655e322a3b14c01726", size = 10460, upload-time = "2026-08-26T03:11:56.593Z" },
+]
+
+[package.optional-dependencies]
+cu13 = [
+    { name = "nvidia-cutlass-dsl-libs-cu13", version = "4.7.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-attn-gym-mega' or extra != 'extra-8-attn-gym-tests'" },
 ]
 
 [[package]]
 name = "nvidia-cutlass-dsl-libs-base"
 version = "4.6.3"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
+]
 dependencies = [
-    { name = "cuda-python" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "nvidia-cuda-nvdisasm" },
-    { name = "nvidia-cutlass-dsl-libs-core" },
-    { name = "protobuf" },
-    { name = "typing-extensions" },
+    { name = "cuda-python", marker = "extra == 'extra-8-attn-gym-tests'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-8-attn-gym-tests') or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-8-attn-gym-tests') or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-8-attn-gym-tests') or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "nvidia-cuda-nvdisasm", marker = "extra == 'extra-8-attn-gym-tests'" },
+    { name = "nvidia-cutlass-dsl-libs-core", version = "4.6.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-attn-gym-tests'" },
+    { name = "protobuf", marker = "extra == 'extra-8-attn-gym-tests'" },
+    { name = "typing-extensions", marker = "extra == 'extra-8-attn-gym-tests'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/3f/3b58d553556e662b8c613263ede19caa1f613b04f963f30d8812f665b0cf/nvidia_cutlass_dsl_libs_base-4.6.3-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:fee1f74e19b64d6b3c20ead5c1198a4e4f08642f691685378299539e91ccdad2", size = 3321203, upload-time = "2026-08-26T02:50:07.548Z" },
@@ -2181,35 +2249,103 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-cutlass-dsl-libs-base"
+version = "4.7.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "backports-strenum", marker = "(python_full_version < '3.11' and extra == 'extra-8-attn-gym-mega') or (python_full_version < '3.11' and extra != 'extra-8-attn-gym-tests') or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "cuda-python", marker = "extra == 'extra-8-attn-gym-mega' or extra != 'extra-8-attn-gym-tests'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-8-attn-gym-mega') or (python_full_version < '3.11' and extra != 'extra-8-attn-gym-tests') or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-8-attn-gym-mega') or (python_full_version == '3.11.*' and extra != 'extra-8-attn-gym-tests') or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-8-attn-gym-mega') or (python_full_version >= '3.12' and extra != 'extra-8-attn-gym-tests') or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "nvidia-cuda-nvdisasm", marker = "extra == 'extra-8-attn-gym-mega' or extra != 'extra-8-attn-gym-tests'" },
+    { name = "nvidia-cutlass-dsl-libs-core", version = "4.7.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-attn-gym-mega' or extra != 'extra-8-attn-gym-tests'" },
+    { name = "protobuf", marker = "extra == 'extra-8-attn-gym-mega' or extra != 'extra-8-attn-gym-tests'" },
+    { name = "typing-extensions", marker = "extra == 'extra-8-attn-gym-mega' or extra != 'extra-8-attn-gym-tests'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/c0/4108f126cdfc25831291d19aba121f9fd3ff61693fbfd9869c1ea276480e/nvidia_cutlass_dsl_libs_base-4.7.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:d01420777ac1ff22ee0c7842b6779fa58271b37c9a57cbd0bfff3eea932d35c7", size = 3327942, upload-time = "2026-08-26T02:51:32.742Z" },
+    { url = "https://files.pythonhosted.org/packages/83/0b/c725327eb2849efcf3de75e9f9c8cf643c43b1058c6e74dea6795a855b5b/nvidia_cutlass_dsl_libs_base-4.7.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:094579fb7700336a8d7e532c154777e99f1bbd5f54ec82cb9537a3584add9fe8", size = 2832694, upload-time = "2026-08-26T02:52:01.739Z" },
+    { url = "https://files.pythonhosted.org/packages/09/34/5a5436f21cf59e156b32da0d8021740ef9c87700ef6c10af317647edd5b1/nvidia_cutlass_dsl_libs_base-4.7.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:298e73ad0f1b0484e4b8438e9daae38732a6cadc9f4023475e5b0c2868985aba", size = 3329790, upload-time = "2026-08-26T02:52:26.184Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4e/633b96c28c31550ff64ca47287614bd9355f7e0d154eb3eecf069ffabac3/nvidia_cutlass_dsl_libs_base-4.7.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:431e3648b84ad4a81a8d3b1fa7e445326cb5a524e64f6c22b4d191a76455bdf9", size = 2834334, upload-time = "2026-08-26T02:52:51.079Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/6e/5d3f67caba70fe9a5cc21b845d2be35d88049da536185196a2644b0d461c/nvidia_cutlass_dsl_libs_base-4.7.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:e86c55a5010a7edfc067648a75cb29d0c5bd67d75210168cf507b0d0e4d15ba7", size = 3329548, upload-time = "2026-08-26T02:53:14.176Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b5/af332a4dbb0dba45828994d9789d1969dfecca006a6221cd8b92e4825d3f/nvidia_cutlass_dsl_libs_base-4.7.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:c2b67dacabfc905e4d132784fe4848647f40b0b97b1cdde3ce4a482642536b84", size = 2832971, upload-time = "2026-08-26T02:53:52.164Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/cb/7b9b9383404e0b0d7d42640f99f50b0c4032ac105509360263a816775a44/nvidia_cutlass_dsl_libs_base-4.7.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:06658e691eb1047c83be48ba501bf73f2ea7ecdd8c1ee5f9f26db587908e43ed", size = 3329437, upload-time = "2026-08-26T02:54:17.895Z" },
+    { url = "https://files.pythonhosted.org/packages/da/cd/14545cf33b22a0ddeaa7486d49fdfe278d1fd95e0c9ab3e3e5c8202044ab/nvidia_cutlass_dsl_libs_base-4.7.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:61097c5c355e1e42f8531efd4e8ead0ba61ae1ab6b0b9acfcbf2ca665b3dae5a", size = 2832969, upload-time = "2026-08-26T02:54:45.33Z" },
+    { url = "https://files.pythonhosted.org/packages/86/3f/862ce2fe87938167e9c603a484f0310cfa023cfce670c363730c2aca0c03/nvidia_cutlass_dsl_libs_base-4.7.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:36192b4d0f72c4f47b39def20f4fda71058005617b7204395570768827524982", size = 3330052, upload-time = "2026-08-26T02:55:09.058Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/95/e1a150a9c212ed59e3b4726171cbda746b4f6bfc1a7a9e0b2ec7c1d4749f/nvidia_cutlass_dsl_libs_base-4.7.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:0776506f666e1c6834a8a9195ef20299733ae013d234726829565be5d8509942", size = 2833044, upload-time = "2026-08-26T02:55:26.348Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/07/e56e96b31cbbca7c31aba09862c778baac684255a076c0bb0ee679563930/nvidia_cutlass_dsl_libs_base-4.7.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:93880e666f17513d5878f3b2ee76e9177a0acd59673dd27cb2c34dbdf5fe89f0", size = 3338184, upload-time = "2026-08-26T02:55:46.183Z" },
+    { url = "https://files.pythonhosted.org/packages/88/0a/58c94945aaf722f7cccecfab239248784ad9be841a04894dc103fd65645e/nvidia_cutlass_dsl_libs_base-4.7.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:115608a7a514309e5a8448c6421a8597217c58760a3cadf2b781b37dd7c4d821", size = 2845972, upload-time = "2026-08-26T02:56:08.788Z" },
+]
+
+[[package]]
 name = "nvidia-cutlass-dsl-libs-core"
 version = "4.6.3"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
+]
 dependencies = [
-    { name = "cuda-python" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "nvidia-cuda-nvdisasm" },
-    { name = "protobuf" },
-    { name = "typing-extensions" },
+    { name = "cuda-python", marker = "extra == 'extra-8-attn-gym-tests'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-8-attn-gym-tests') or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-8-attn-gym-tests') or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-8-attn-gym-tests') or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "nvidia-cuda-nvdisasm", marker = "extra == 'extra-8-attn-gym-tests'" },
+    { name = "protobuf", marker = "extra == 'extra-8-attn-gym-tests'" },
+    { name = "typing-extensions", marker = "extra == 'extra-8-attn-gym-tests'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/72/b4/6132e72c2da8e8cdc65fab819d8ccf868e4520fa604dc1f610566b295f10/nvidia_cutlass_dsl_libs_core-4.6.3-py3-none-any.whl", hash = "sha256:b7a460dc0ace8be5449593ea793bb6083b0b4e5a8ffc7e857b906ecd67817cc3", size = 778988, upload-time = "2026-08-26T02:49:29.758Z" },
 ]
 
 [[package]]
+name = "nvidia-cutlass-dsl-libs-core"
+version = "4.7.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "backports-strenum", marker = "(python_full_version < '3.11' and extra == 'extra-8-attn-gym-mega') or (python_full_version < '3.11' and extra != 'extra-8-attn-gym-tests') or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "cuda-python", marker = "extra == 'extra-8-attn-gym-mega' or extra != 'extra-8-attn-gym-tests'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-8-attn-gym-mega') or (python_full_version < '3.11' and extra != 'extra-8-attn-gym-tests') or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-8-attn-gym-mega') or (python_full_version == '3.11.*' and extra != 'extra-8-attn-gym-tests') or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-8-attn-gym-mega') or (python_full_version >= '3.12' and extra != 'extra-8-attn-gym-tests') or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "nvidia-cuda-nvdisasm", marker = "extra == 'extra-8-attn-gym-mega' or extra != 'extra-8-attn-gym-tests'" },
+    { name = "protobuf", marker = "extra == 'extra-8-attn-gym-mega' or extra != 'extra-8-attn-gym-tests'" },
+    { name = "typing-extensions", marker = "extra == 'extra-8-attn-gym-mega' or extra != 'extra-8-attn-gym-tests'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/14/b669cc890f7fd74008d7bc52f493d0a7ff256de10f3941c6676249419c07/nvidia_cutlass_dsl_libs_core-4.7.1-py3-none-any.whl", hash = "sha256:c65662abc9ab18fd997c57547895736928e559f4624bbe2aa1aa91418ea014ca", size = 1235214, upload-time = "2026-08-26T02:50:56.241Z" },
+]
+
+[[package]]
 name = "nvidia-cutlass-dsl-libs-cu12"
 version = "4.6.3"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
+]
 dependencies = [
-    { name = "cuda-python" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "nvidia-cuda-nvdisasm" },
-    { name = "nvidia-cutlass-dsl-libs-base" },
-    { name = "protobuf" },
-    { name = "typing-extensions" },
+    { name = "cuda-python", marker = "extra == 'extra-8-attn-gym-tests'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-8-attn-gym-tests') or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-8-attn-gym-tests') or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-8-attn-gym-tests') or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "nvidia-cuda-nvdisasm", marker = "extra == 'extra-8-attn-gym-tests'" },
+    { name = "nvidia-cutlass-dsl-libs-base", version = "4.6.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-attn-gym-tests'" },
+    { name = "protobuf", marker = "extra == 'extra-8-attn-gym-tests'" },
+    { name = "typing-extensions", marker = "extra == 'extra-8-attn-gym-tests'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/5e/3de9354ab49163771c338e9a31cbb1edadc5316eaa5b0459e0d632bb1fe0/nvidia_cutlass_dsl_libs_cu12-4.6.3-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:a4217c85d9fcf6574acf791d02e4a6a0fcba8706f9a53f8bd3d3af8ab7d9c088", size = 87000483, upload-time = "2026-08-26T02:55:31.645Z" },
@@ -2227,18 +2363,58 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-cutlass-dsl-libs-cu12"
+version = "4.7.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "backports-strenum", marker = "(python_full_version < '3.11' and extra == 'extra-8-attn-gym-mega') or (python_full_version < '3.11' and extra != 'extra-8-attn-gym-tests') or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "cuda-python", marker = "extra == 'extra-8-attn-gym-mega' or extra != 'extra-8-attn-gym-tests'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-8-attn-gym-mega') or (python_full_version < '3.11' and extra != 'extra-8-attn-gym-tests') or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-8-attn-gym-mega') or (python_full_version == '3.11.*' and extra != 'extra-8-attn-gym-tests') or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-8-attn-gym-mega') or (python_full_version >= '3.12' and extra != 'extra-8-attn-gym-tests') or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "nvidia-cuda-nvdisasm", marker = "extra == 'extra-8-attn-gym-mega' or extra != 'extra-8-attn-gym-tests'" },
+    { name = "nvidia-cutlass-dsl-libs-base", version = "4.7.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-attn-gym-mega' or extra != 'extra-8-attn-gym-tests'" },
+    { name = "protobuf", marker = "extra == 'extra-8-attn-gym-mega' or extra != 'extra-8-attn-gym-tests'" },
+    { name = "typing-extensions", marker = "extra == 'extra-8-attn-gym-mega' or extra != 'extra-8-attn-gym-tests'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/0f/2cfeb5661ade4986ce659b07c4b7a03a90a77383453e66e2e9f398aef138/nvidia_cutlass_dsl_libs_cu12-4.7.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:f5ab528aeb4548261fab7f393f2d119909f792c7165c986e98479ce2345a125d", size = 87254699, upload-time = "2026-08-26T02:57:25.71Z" },
+    { url = "https://files.pythonhosted.org/packages/14/a1/e19e715930ab7383c2203a5ad08b044b283617615ca6c2c58c853dc019c6/nvidia_cutlass_dsl_libs_cu12-4.7.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:94e6da2629a3182f5b5810af22021d0e36d1ccf323bb8c93e71f1267ca7f82a4", size = 88679870, upload-time = "2026-08-26T02:58:06.794Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/7b/f168a9b5732a0b645d014f4b6c0ac38d5f9f5aa19e2b657d7abe6928159e/nvidia_cutlass_dsl_libs_cu12-4.7.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:49d556f2be188d75810fa8c547ad15dba40685138ac27d5441844182ac4955a9", size = 87258628, upload-time = "2026-08-26T02:58:41.596Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/03/8c63f43a919de0d071c905c9a1fa2e7f8863e3fa1ad0e3f93281d7cd7a0d/nvidia_cutlass_dsl_libs_cu12-4.7.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:f37fcbd94aad66b016dcea483db50ddb0fcaab7130c538df20ef29ddeeb8ba85", size = 88680153, upload-time = "2026-08-26T02:59:17.268Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c1/e1202a7d8e3ce5fbb430f1123fd8109e92785a5d18a8749ca8f199318fde/nvidia_cutlass_dsl_libs_cu12-4.7.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:f57a3955c17b7dcd5472aa47c46513e5f3914e1325fc308afca1b9063a8f897b", size = 87255991, upload-time = "2026-08-26T02:59:54.308Z" },
+    { url = "https://files.pythonhosted.org/packages/94/39/d847abeeb9a4ced8e11b30b401564c74c692ac9609f5bd921ed9d0a32f43/nvidia_cutlass_dsl_libs_cu12-4.7.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:c8a0f93a1cde41404696b3194dd1f589c6f3a7b426bcabe97845f8fe96f949f5", size = 88679788, upload-time = "2026-08-26T03:00:32.28Z" },
+    { url = "https://files.pythonhosted.org/packages/75/f4/65da00f890b107cfe000a74ed0517f4541ced654c452bc9a09f18173c110/nvidia_cutlass_dsl_libs_cu12-4.7.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:77684a86191195b2d6eb5f7088bb9bf25e45db58ceb44a9c02ffb0787bb95fb9", size = 87257016, upload-time = "2026-08-26T03:01:05.727Z" },
+    { url = "https://files.pythonhosted.org/packages/71/af/3a0c2d252c883d87037c9c5ff52a394d178c26e3037be056b6d5b4a83367/nvidia_cutlass_dsl_libs_cu12-4.7.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:b34a933cde1e5cf2df1f3cfd78efbd5484ea33dd0c97be201c057e168af79c10", size = 88679588, upload-time = "2026-08-26T03:01:43.689Z" },
+    { url = "https://files.pythonhosted.org/packages/19/15/bf6bd6661d67b794f05cf70e45f752ce65b68227c33f45005d6fc90e8e59/nvidia_cutlass_dsl_libs_cu12-4.7.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:d3708b78b9b70dc1b29c9a48a7030d14a1a8c17b52f3f2d088db3d73c603bec8", size = 87256152, upload-time = "2026-08-26T03:02:20.069Z" },
+    { url = "https://files.pythonhosted.org/packages/19/35/c895f12d08bf79a7f70f8f1ef743e0b31bcbe0e71a05a1bbced151217fa4/nvidia_cutlass_dsl_libs_cu12-4.7.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:06f53df4ada14043b459993a6dc469d0505ad9a144d101b5f40461a58a8e80e3", size = 88680782, upload-time = "2026-08-26T03:02:48.472Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/c5/9663b43a06dac878b909ff1a46e6d4b7570d5b446d8c4205d329054f4923/nvidia_cutlass_dsl_libs_cu12-4.7.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:5c1087e1d514b4afcaea9296e5f19c8e678aba93ee485e56f681fa7169e7a861", size = 87272635, upload-time = "2026-08-26T03:03:12.583Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a8/15e55b0428d538b517748426ff785057068d36538f5864a3ac98cee9e456/nvidia_cutlass_dsl_libs_cu12-4.7.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:10f98e415188e582a0159ed1bb375f4f18e5652bac286621e4362c0ad51ee845", size = 88687733, upload-time = "2026-08-26T03:03:43.539Z" },
+]
+
+[[package]]
 name = "nvidia-cutlass-dsl-libs-cu13"
 version = "4.6.3"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
+]
 dependencies = [
-    { name = "cuda-python" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "nvidia-cuda-nvdisasm" },
-    { name = "nvidia-cutlass-dsl-libs-base" },
-    { name = "protobuf" },
-    { name = "typing-extensions" },
+    { name = "cuda-python", marker = "extra == 'extra-8-attn-gym-tests'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-8-attn-gym-tests') or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-8-attn-gym-tests') or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-8-attn-gym-tests') or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "nvidia-cuda-nvdisasm", marker = "extra == 'extra-8-attn-gym-tests'" },
+    { name = "nvidia-cutlass-dsl-libs-base", version = "4.6.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-attn-gym-tests'" },
+    { name = "protobuf", marker = "extra == 'extra-8-attn-gym-tests'" },
+    { name = "typing-extensions", marker = "extra == 'extra-8-attn-gym-tests'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/23/82309b08eea68d147ec4c922d044037d1c2d1dbe5687a2235f49f5bbdb29/nvidia_cutlass_dsl_libs_cu13-4.6.3-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:81166c8aed627e4bd16d378734f42c7a3c10b8229d42e1618392122e74f7b655", size = 86708322, upload-time = "2026-08-26T03:03:00.283Z" },
@@ -2253,6 +2429,41 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/5f/26d563a5998df448dcfcdcf2118b13fa0269ee59300055a6e543e2aecba5/nvidia_cutlass_dsl_libs_cu13-4.6.3-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:37cb75fe3fe454e326ace4df1617e695b612cabea0a7849a69e5fc92f21abbde", size = 88029849, upload-time = "2026-08-26T03:08:15.686Z" },
     { url = "https://files.pythonhosted.org/packages/85/0a/e42f77d789facbec6c1b1fa5d148db4bebb470e2e51e528ae1209657deb4/nvidia_cutlass_dsl_libs_cu13-4.6.3-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:53245e566da9bde42bc8d6ead8bc0dade035f506ab57e31515e402547040ad53", size = 86713065, upload-time = "2026-08-26T03:08:54.622Z" },
     { url = "https://files.pythonhosted.org/packages/83/14/09e967a5c8c9d37e87cc33c3c9b2ea531b2fd0c04f12d68ce68f5bdeef31/nvidia_cutlass_dsl_libs_cu13-4.6.3-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:689316111f7012223b4173206de1b21f8e4a95f19f7433e49364ce86a5435595", size = 88033629, upload-time = "2026-08-26T03:09:29.347Z" },
+]
+
+[[package]]
+name = "nvidia-cutlass-dsl-libs-cu13"
+version = "4.7.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "backports-strenum", marker = "(python_full_version < '3.11' and extra == 'extra-8-attn-gym-mega') or (python_full_version < '3.11' and extra != 'extra-8-attn-gym-tests') or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "cuda-python", marker = "extra == 'extra-8-attn-gym-mega' or extra != 'extra-8-attn-gym-tests'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-8-attn-gym-mega') or (python_full_version < '3.11' and extra != 'extra-8-attn-gym-tests') or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-8-attn-gym-mega') or (python_full_version == '3.11.*' and extra != 'extra-8-attn-gym-tests') or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-8-attn-gym-mega') or (python_full_version >= '3.12' and extra != 'extra-8-attn-gym-tests') or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "nvidia-cuda-nvdisasm", marker = "extra == 'extra-8-attn-gym-mega' or extra != 'extra-8-attn-gym-tests'" },
+    { name = "nvidia-cutlass-dsl-libs-base", version = "4.7.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-attn-gym-mega' or extra != 'extra-8-attn-gym-tests'" },
+    { name = "protobuf", marker = "extra == 'extra-8-attn-gym-mega' or extra != 'extra-8-attn-gym-tests'" },
+    { name = "typing-extensions", marker = "extra == 'extra-8-attn-gym-mega' or extra != 'extra-8-attn-gym-tests'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/52/28b1abbd36850e78f24efb0c6690c7078a4ebb1f4f445e18c99ae2ddbecc/nvidia_cutlass_dsl_libs_cu13-4.7.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:4474ca7a9ea274f2977ee6fca7618c7611fcbad25bcdf756770458c8ad6a84a2", size = 86957358, upload-time = "2026-08-26T03:04:31.708Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/54/1d5e4bdb1e660172f21ce09109ce147110746dc6b7e9be449d44991980b8/nvidia_cutlass_dsl_libs_cu13-4.7.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:575e9558dfeca44402f53fe3d07e8cdfdc8cc4e847706213a5cc1bd7953cbdf1", size = 88259275, upload-time = "2026-08-26T03:05:16.867Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/82/07ad8d1745a5216fa3e8321da0c35a07fb83aaa6b13f33144f63c85461bf/nvidia_cutlass_dsl_libs_cu13-4.7.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:7aaf4380a338ae36c53512f66b89470de6ee1f04f38163a89cd25e6dee92fe87", size = 86958328, upload-time = "2026-08-26T03:05:59.309Z" },
+    { url = "https://files.pythonhosted.org/packages/27/b1/94697e4d5d917720f17c827a30e563a62a37eda49825a31fc300ffa68b93/nvidia_cutlass_dsl_libs_cu13-4.7.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:813ee19f8c8b6d39284a24ae99dd9a9b496b33c99270b2cf9548e79f49178405", size = 88259952, upload-time = "2026-08-26T03:06:41.701Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ea/c7c2b4da3d6c9818e152e20cd5f797fb6d9ef75c3a5c80d2d6a9cb211489/nvidia_cutlass_dsl_libs_cu13-4.7.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:e675bf04dc6c91f7c4d5540699b7a031f2b8b44cd2687b32c20892f112f7e0d9", size = 86957786, upload-time = "2026-08-26T03:07:23.015Z" },
+    { url = "https://files.pythonhosted.org/packages/10/71/e178bb0858fd7b96857e98e3acec70b23f13b88540a2fcc53569f8e8ea34/nvidia_cutlass_dsl_libs_cu13-4.7.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:20c14e16125cb8e36bc9947a9f0a57a660f44651365337b911c84abde4967f5f", size = 88260436, upload-time = "2026-08-26T03:07:59.639Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/10/f11dda3394201ad789b69268681c4f03614cddf2c842df2cd7681b7632d2/nvidia_cutlass_dsl_libs_cu13-4.7.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a1d23cef44675e63825c3f5d773e7b4228802ca155eab61c0bc5e551caf35ad2", size = 86958039, upload-time = "2026-08-26T03:08:35.65Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/fa/46e2e4db696c35923dff02c5135f0a0f9e00ab7be6456aaeb80dfb7e9769/nvidia_cutlass_dsl_libs_cu13-4.7.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:2f86fe8d1a7ef510b853a3800cbf324401a12fdc770cccf4ac5e20a9d0c7d1bd", size = 88260292, upload-time = "2026-08-26T03:09:11.02Z" },
+    { url = "https://files.pythonhosted.org/packages/87/32/385117c0af4ab6c3baefe58dc725d870a426e703521c09d6ca13d571fb70/nvidia_cutlass_dsl_libs_cu13-4.7.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:425676733c1a1751e5fd4fc4ddd4ec6fbe6760d631ce12ed287dd63cf8c3646e", size = 86958338, upload-time = "2026-08-26T03:09:44.861Z" },
+    { url = "https://files.pythonhosted.org/packages/69/54/56778af4587e2a3cb972e59aaa8f6eaeaa3a518a13dfddaa7e95bf7e8df7/nvidia_cutlass_dsl_libs_cu13-4.7.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:67d363a9603cebdb847698bc6fc18bc14ba94f5c0f45c20b1138a316e068c7be", size = 88260728, upload-time = "2026-08-26T03:10:12.831Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ba/9e45ee560d9c5826e2d8af53014c99a8f4ea42cd6ccd831b8ac953a6e5ca/nvidia_cutlass_dsl_libs_cu13-4.7.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:990baa4dc8b6b0c7710afc89411e8eb05099a4c9bd01162bcbd365bd876edf59", size = 86974347, upload-time = "2026-08-26T03:10:43.595Z" },
+    { url = "https://files.pythonhosted.org/packages/51/79/9ac4d35b7b53aa74c434508631e54cbb19c3eba8ce2fc57aea18d5420fc7/nvidia_cutlass_dsl_libs_cu13-4.7.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:3aa56ee073da8584c84a3eac71dee32e6cc5ae6be958f8b589ca6dae276f299f", size = 88276182, upload-time = "2026-08-26T03:11:04.425Z" },
 ]
 
 [[package]]
@@ -2271,6 +2482,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f0/ee/580ca6f29dcab0221db8706badca1bbbb084f1975c4d4e83329c3a7e31f0/nvidia_nvjitlink-13.3.33-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:26a6de7fb4c8fdaa7703d3dad720d6d427ddfea5c48a528fd97c11733ad830e5", size = 40742423, upload-time = "2026-05-26T16:54:51.613Z" },
     { url = "https://files.pythonhosted.org/packages/69/30/45414e35ff2eee7db3da037e5707037ccf9d2b5218ffbdb055ea4d5aa98a/nvidia_nvjitlink-13.3.33-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ce48b37dfeb3cb1eae4cf85adacb47d7a6539ea2272870c9a3628ce275c2037e", size = 39168635, upload-time = "2026-05-26T16:54:13.906Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f2/ec9c05a108095828dfc58840978c627b3c313fdf2a567c6de9ffbbb46901/nvidia_nvjitlink-13.3.33-py3-none-win_amd64.whl", hash = "sha256:4297ee49639b4f2e07255a1d69b3acc7ab2d011bb892b403e91ac98368962e3b", size = 37766359, upload-time = "2026-05-26T17:11:28.96Z" },
 ]
 
 [[package]]
@@ -2289,6 +2501,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
     { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/50/0e2220f8620a177de994211186ffc5bfa9f2ce1e1282797f8f90096f9f88/nvidia_nvtx-13.0.85-py3-none-win_amd64.whl", hash = "sha256:d66ea44254dd3c6eacc300047af6e1288d2269dd072b417e0adffbf479e18519", size = 137066, upload-time = "2025-09-04T08:39:25.649Z" },
 ]
 
 [[package]]
@@ -2469,7 +2682,7 @@ version = "1.6.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
     { name = "ghp-import" },
     { name = "jinja2" },
     { name = "markdown" },
@@ -2492,9 +2705,12 @@ version = "7.36.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a7/e7/0553e21d25ca4d9f573135775348a372c3ec34a93a71d5f297c3bac38341/protobuf-7.36.0.tar.gz", hash = "sha256:e8e09cb0d794c6687926fa558a8a6e72aa10edb997d5ca61da0765f12a3e00ea", size = 510034, upload-time = "2026-08-20T16:34:01.071Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/ae/58e3ca96cb2e118cc546b677359b3c6659f79a140935c08dec94c7998585/protobuf-7.36.0-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:9103532dffd80c6fab7e50c65a31007680a06eb57537d437bb1b35812c138a37", size = 453256, upload-time = "2026-08-20T16:33:53.945Z" },
     { url = "https://files.pythonhosted.org/packages/f0/15/5162230af4912697f0fe406f6800f80760945babcff0e2c2fe6c84ef2d5d/protobuf-7.36.0-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:bf94a5917c71058262de683669bc0a797a7669d3de71f0b36d058e3194f47b44", size = 341436, upload-time = "2026-08-20T16:33:55.134Z" },
     { url = "https://files.pythonhosted.org/packages/d7/09/1670b2bfc9a45e807e520c3e9be36524db9ccc7dc05ea17af7681cabdc61/protobuf-7.36.0-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:3297e60abdff301e5f74393d87f6cc59dacab5f024a89548a6e8de1d26576b16", size = 354440, upload-time = "2026-08-20T16:33:56.077Z" },
     { url = "https://files.pythonhosted.org/packages/c7/f8/bd5804695ba400e423c33fd4d9f58c28d86633d5ba1945c36ff3967d98cb/protobuf-7.36.0-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:70f5ec8eb0da81a44360c0dc0beac99a0d78071d21956a7076bae8bd2051841b", size = 340439, upload-time = "2026-08-20T16:33:56.992Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/9f/acd02338235a3e7d03168c4303478347b7624fc8189ff4e7f0d2654bbe86/protobuf-7.36.0-cp310-abi3-win32.whl", hash = "sha256:7326fd717bdc419162a735938d89d4032332bcc3408804012b24ff3a37086071", size = 440216, upload-time = "2026-08-20T16:33:57.99Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4e/12cb93270967a2affff5b3f720694700d4d87712a67afd05c8cb3f6fa52c/protobuf-7.36.0-cp310-abi3-win_amd64.whl", hash = "sha256:1781cc1de61249b750848029bca452c0a8b7e990080316b9bbc2518b2117b488", size = 453731, upload-time = "2026-08-20T16:33:58.951Z" },
     { url = "https://files.pythonhosted.org/packages/01/c3/629999e78d46c1115c11886d51c6bd68c17ce4a944f1ea3e153a91316a33/protobuf-7.36.0-py3-none-any.whl", hash = "sha256:53374d53fc29a67f7dbbf0ade47d7526a0f0137bf0f9c90e48d8a60790ef748c", size = 177024, upload-time = "2026-08-20T16:34:00.053Z" },
 ]
 
@@ -2571,13 +2787,13 @@ name = "pytest"
 version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
     { name = "pygments" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
@@ -2699,7 +2915,7 @@ name = "pyzmq"
 version = "27.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "implementation_name == 'pypy'" },
+    { name = "cffi", marker = "implementation_name == 'pypy' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e7/8d/5b3d5631c2f4b4b8862f64cd0c9eb777b5710eeb5125b4be8dd0a200a4c0/pyzmq-27.2.0.tar.gz", hash = "sha256:54d4259d1bfae24ecdb5ca79f7acc2eac6c286a02d6a0ae617797cb45f0726d3", size = 292316, upload-time = "2026-08-20T19:08:21.19Z" }
 wheels = [
@@ -2781,7 +2997,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apache-tvm-ffi" },
     { name = "einops" },
-    { name = "nvidia-cutlass-dsl" },
+    { name = "nvidia-cutlass-dsl", version = "4.6.3", source = { registry = "https://pypi.org/simple" } },
     { name = "torch" },
     { name = "torch-c-dlpack-ext" },
 ]
@@ -2876,7 +3092,7 @@ version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
 wheels = [
@@ -2993,20 +3209,20 @@ name = "torch"
 version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-bindings", marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
-    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
+    { name = "cuda-bindings", marker = "(python_full_version < '3.15' and sys_platform == 'linux') or (python_full_version >= '3.15' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform != 'linux' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
     { name = "filelock" },
     { name = "fsspec" },
     { name = "jinja2" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
     { name = "setuptools" },
     { name = "sympy" },
-    { name = "triton", marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
+    { name = "triton", marker = "(python_full_version < '3.15' and sys_platform == 'linux') or (python_full_version >= '3.15' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests') or (sys_platform != 'linux' and extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
     { name = "typing-extensions" },
 ]
 wheels = [
@@ -3045,11 +3261,26 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/37/de/921b6491efce5c389a5ef9bbed3d2d6660005840dae488124173180859ab/torch_c_dlpack_ext-0.1.5.tar.gz", hash = "sha256:d06f0357d575d22a168cc77acb9020fc4bae30968ceb6718a055dcbe92bacabe", size = 12913, upload-time = "2026-01-12T11:25:08.484Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/49/67a66932ab2fcdda3c5a4dcf606e713d86883a4a9a99a3bb832815b52b8e/torch_c_dlpack_ext-0.1.5-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:e0f6c197d5293884898b9ebf13d07501de39cb94799b374ed43f91731087d557", size = 7056755, upload-time = "2026-01-12T11:24:31.817Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/28/d2d6bf90e01a1f4da3277c9a56d9ecac648b6d6adaa8e20c17f802deb7fb/torch_c_dlpack_ext-0.1.5-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba3d88f0f7d5e1d9c3d4a3179037fc8e261c3b77ac1fad23edc0d3a9214ef193", size = 432066, upload-time = "2026-01-12T11:24:33.619Z" },
     { url = "https://files.pythonhosted.org/packages/a1/e9/a1f9584a3af4ac6ae5ad5cf86927d8c3a9b6bb50d54e54d19313411216a0/torch_c_dlpack_ext-0.1.5-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c7468df84ec152d930fbc3acf460c44a60b3462b95af3d3a676d133629c7e176", size = 879488, upload-time = "2026-01-12T11:24:34.837Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/08/478cfcb5814e29f9b720111bdef315fc2fbc8b276e4b1183c8b9c9414a4f/torch_c_dlpack_ext-0.1.5-cp310-cp310-win_amd64.whl", hash = "sha256:78dd4904bd26170a2dd7c0eab56367756ee0a15672ce9b84146169e68f0c6ddc", size = 1461437, upload-time = "2026-01-12T11:24:36.385Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/c12a9bb3a5ddc0962c00467891bf1ffdda39a4d4780bf0fbbf54523ff34e/torch_c_dlpack_ext-0.1.5-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:56bd25a2af19280bf8a06aa62cff5510106f43235b9327d8561b3e9a659c4d84", size = 5076782, upload-time = "2026-01-12T11:24:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e1/64e1e579d107064785549e70758e38a42376ab7e73d86897ed4beab10e74/torch_c_dlpack_ext-0.1.5-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fba674110e1fab0b176bb5a28223e157db65c90767d4ba74abdbee9f537b0e9d", size = 440949, upload-time = "2026-01-12T11:24:39.716Z" },
     { url = "https://files.pythonhosted.org/packages/64/5c/3e1382a620824f92920ab3fae132d8fb4e85898284c99e0c6a7764e452ce/torch_c_dlpack_ext-0.1.5-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3448c4f0d64104d0b2e58080a7efa72304a04960c18f338024b80b13cd3eca26", size = 897768, upload-time = "2026-01-12T11:24:41.209Z" },
+    { url = "https://files.pythonhosted.org/packages/54/4f/76ea1006b9038b496d01e916c91efd17cb782abde2491a261cf203f57e30/torch_c_dlpack_ext-0.1.5-cp311-cp311-win_amd64.whl", hash = "sha256:74676474e0afa9a4216c4755ea7cf05e8158be1d168f6bda669ba91097c263f2", size = 1479088, upload-time = "2026-01-12T11:24:42.436Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/67/10d236698525d7b7db4d74ec0a4b01f5b2db33968995fdd9ac6b4635e327/torch_c_dlpack_ext-0.1.5-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:c0f2bd51fcd99c0e5b50314e1985f2728c4941bfa821f065e6c30951d1f995ca", size = 5291237, upload-time = "2026-01-12T11:24:44.011Z" },
+    { url = "https://files.pythonhosted.org/packages/87/06/8d760997307a5c3be4384424667bf31aae0a42060838c532c7d846516175/torch_c_dlpack_ext-0.1.5-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3562ee411258676f9c38b8ad39306d1c8d027b6a86f6a87c920d2d009a9d1510", size = 443069, upload-time = "2026-01-12T11:24:45.451Z" },
     { url = "https://files.pythonhosted.org/packages/e2/79/a914539b4785f3e44f891aa012a886edb8bc10fe081c440981c57543ce21/torch_c_dlpack_ext-0.1.5-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e6f9da4bb9af70e27facc777458be62e10dbbbddda7672d16138db0553c5a524", size = 897846, upload-time = "2026-01-12T11:24:48.168Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/e6/7d7a97a3953208d6d6ce749180c34d1dab48464ded9a76cecabe9d021ce6/torch_c_dlpack_ext-0.1.5-cp312-cp312-win_amd64.whl", hash = "sha256:670fbbab70123cc228bed41693a3720757af57a0ad22669063c9db25321e8f55", size = 1482855, upload-time = "2026-01-12T11:24:49.581Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/c6/65346a201d921b616731311fc9941f15137672b444cebdad702cb52ccee0/torch_c_dlpack_ext-0.1.5-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:74acea2ed395cadda63342845b9e9ee7cd4537846223dacfb4431b4610109265", size = 1993243, upload-time = "2026-01-12T11:24:51.079Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/ec/faf10be09a5812b1c5ec9922b53fb5def5fc4080b81a653b9347bb169ebb/torch_c_dlpack_ext-0.1.5-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49f1e99d13c64e22dac0a34a1560e9e5a398a49a9fa81df83053e04fde6ec5bd", size = 443798, upload-time = "2026-01-12T11:24:52.754Z" },
     { url = "https://files.pythonhosted.org/packages/2d/68/f434b48700f3e04f33882f54d8d3910327b935f55e14ec49da7d607bf470/torch_c_dlpack_ext-0.1.5-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:debe62e5ef93e631065d6b9f6e60d3d39bae6b89fa1b25d9523f40b3efbf8aba", size = 755004, upload-time = "2026-01-12T11:24:54.004Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a8/cc64e563f05ea99bd79bdb43f71f0f46452d3acd734da4843ede5fc73a35/torch_c_dlpack_ext-0.1.5-cp313-cp313-win_amd64.whl", hash = "sha256:30e3eab616dbc81dfdb7492aca557be551a9163ba9b585f97394a42b336b113a", size = 999126, upload-time = "2026-01-12T11:24:55.44Z" },
+    { url = "https://files.pythonhosted.org/packages/96/5e/449324ca8e81573e650b6851fc31c1038f750d1de85d0b185d788e1c7a3a/torch_c_dlpack_ext-0.1.5-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:cac94a4905d391889e679a8da31e46dc325af5d55d13b7c70c0ce3d71d1ced6d", size = 1982154, upload-time = "2026-01-12T11:24:58.038Z" },
+    { url = "https://files.pythonhosted.org/packages/20/62/11c05b99f69aa5152bca0313e0dfa6d125a020cf890dc888ef009aa7891c/torch_c_dlpack_ext-0.1.5-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a58fdf45fb0bda7bc459632cec891570f31c11636d5851c825cf308ec8b73c2", size = 163825, upload-time = "2026-01-12T11:24:59.474Z" },
     { url = "https://files.pythonhosted.org/packages/15/b5/be613cd8e71c9982bd07af530f86c5a7f30df7831d14cec5414857af7149/torch_c_dlpack_ext-0.1.5-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b985a324c68241cf83a9474b28015524b66775b12a91930dd4c0760aa628d01", size = 171740, upload-time = "2026-01-12T11:25:00.776Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/11/52e291f1659e2ec70a09f5ca4ad27e015eb4f0a1371ae68d23a9fbd1c704/torch_c_dlpack_ext-0.1.5-cp314-cp314-win_amd64.whl", hash = "sha256:d794e19fa3f330ab7a29987c07e031fc08e4953aec516d35701d0827863e356b", size = 277086, upload-time = "2026-01-12T11:25:01.901Z" },
 ]
 
 [[package]]
@@ -3077,7 +3308,7 @@ version = "0.27.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
     { name = "rich" },
     { name = "shellingham" },
 ]
@@ -3111,7 +3342,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f2/0f/3f86e61397dd33bf2ccf28188c40db6a740658aeebbbf6e7dbc101a1f487/uvicorn-0.52.4.tar.gz", hash = "sha256:73acfee47a0b133c5de13d219492d62d8a31e935f4fe6e41a232451a15379f86", size = 100627, upload-time = "2026-08-19T06:27:41.821Z" }
 wheels = [


### PR DESCRIPTION
Stacked PRs:
 * #400
 * #399
 * #397
 * #369
 * __->__#368


--- --- ---

Vendor CuTeDSL 4.7 KDA kernels

## Human Note

## Agent note

Vendor the attributed SM100/SM103 KDA forward, checkpoint-recompute, bprop, and shared low-level
CuTeDSL helpers. Runtime imports are rewritten into Attention Gym without a cuDNN dependency.

## Test Plan

```bash
python -c "import attn_gym.linear.kda.fwd.cute47.chunk_kda_fwd_frost47"
uv build
prek
```