### PR TITLE
Integrate the Mega KDA training backend

### DIFF
--- a/attn_gym/linear/_delta_rule/mega/backward.py
+++ b/attn_gym/linear/_delta_rule/mega/backward.py
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Torch launcher for the CuTeDSL 4.7 Mega no-state long-context backward."""
+
+from __future__ import annotations
+
+import torch
+
+from attn_gym._backends.cute import tensor_supports_contiguous_dim, tensor_supports_tma
+from attn_gym.linear._delta_rule.mega.kernels.common.host import tensormap_workspace_bytes
+from attn_gym.linear._delta_rule.validation import resolve_scale
+from attn_gym.utils import ceildiv
+
+from .kernels import kda_bprop_f16, kda_recompute_f16
+from .schedule import prepare_mega_schedule
+
+_SUPPORTED_IO_DTYPES = (torch.float16, torch.bfloat16)
+_KERNEL_CHUNK_SIZE = 16
+_SCHEDULER_COUNTERS = 4
+_WORKSPACE_WORD_BYTES = 8
+
+
+def chunk_delta_rule_bwd_mega_packed(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    value: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    d_output: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    *,
+    scale: float | None = None,
+    split: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Run checkpoint recompute followed by exact or forgetting-horizon backward."""
+    scale = resolve_scale(scale, q.shape[-1])
+    if not q.is_cuda:
+        raise ValueError("q must be a CUDA tensor")
+    with torch.cuda.device(q.device):
+        if q.ndim != 4 or q.shape[0] != 1 or q.shape[-1] != 128:
+            raise ValueError("q must have shape [1, T, H, 128]")
+        if any(tensor.shape != q.shape for tensor in (k, value, gate, d_output)):
+            raise ValueError("k, value, gate, and d_output must match q")
+        if beta.shape != q.shape[:3]:
+            raise ValueError("beta must have shape [1, T, H]")
+        inputs = (q, k, value, gate, beta, d_output)
+        if any(tensor.device != q.device for tensor in inputs):
+            raise ValueError("all inputs must be on q.device")
+        if any(not tensor_supports_tma(tensor) for tensor in (q, k, value, gate, d_output)):
+            raise TypeError("q, k, value, gate, and d_output require a TMA-compatible inner mode")
+        if not tensor_supports_contiguous_dim(beta, alignment_bytes=4):
+            raise TypeError("beta requires a contiguous, element-aligned inner mode")
+        if q.dtype not in _SUPPORTED_IO_DTYPES or any(
+            tensor.dtype != q.dtype for tensor in (k, value, d_output)
+        ):
+            raise TypeError("q, k, value, and d_output must share dtype float16 or bfloat16")
+        if gate.dtype != torch.float32 or beta.dtype != torch.float32:
+            raise TypeError("gate and beta must be float32")
+
+        _, tokens, heads, dim = q.shape
+        if (
+            cu_seqlens.ndim != 1
+            or cu_seqlens.shape[0] < 2
+            or cu_seqlens.dtype != torch.int32
+            or not cu_seqlens.is_contiguous()
+            or cu_seqlens.device != q.device
+            or cu_seqlens.data_ptr() % 8
+        ):
+            raise TypeError("cu_seqlens must be aligned contiguous int32 on q.device")
+        num_sequences = cu_seqlens.shape[0] - 1
+        stream = torch.cuda.current_stream(q.device).cuda_stream
+        schedule = prepare_mega_schedule(
+            gate,
+            cu_seqlens,
+            tile_tokens=_KERNEL_CHUNK_SIZE,
+            counter_count=_SCHEDULER_COUNTERS,
+            split=split,
+            stream=stream,
+        )
+        checkpoints = torch.empty(
+            tokens // _KERNEL_CHUNK_SIZE + num_sequences,
+            heads,
+            dim,
+            dim,
+            dtype=q.dtype,
+            device=q.device,
+        )
+        recompute_workspace = torch.empty(
+            ceildiv(
+                tensormap_workspace_bytes(kda_recompute_f16, num_sequences),
+                _WORKSPACE_WORD_BYTES,
+            ),
+            dtype=torch.int64,
+            device=q.device,
+        )
+        backward_workspace = torch.empty(
+            ceildiv(
+                tensormap_workspace_bytes(kda_bprop_f16, num_sequences),
+                _WORKSPACE_WORD_BYTES,
+            ),
+            dtype=torch.int64,
+            device=q.device,
+        )
+        dq = torch.empty_like(q[0])
+        dk = torch.empty_like(k[0])
+        dv = torch.empty_like(value[0])
+        dgate = torch.empty_like(gate[0])
+        dbeta = torch.empty_like(beta[0])
+
+        kda_recompute_f16.chunk_kda_recompute_sm100(
+            k[0],
+            value[0],
+            gate[0],
+            beta[0],
+            cu_seqlens,
+            None,
+            None,
+            checkpoint_every_n_tokens=16,
+            output_state_checkpoints=checkpoints,
+            work_items=schedule.work_items,
+            work_count=schedule.work_count,
+            sched_ctr=schedule.counters[:2],
+            sched_all=schedule.counters,
+            work_item_scratch=schedule.item_scratch,
+            order_in_prologue=True,
+            tensormap_workspace=recompute_workspace,
+        )
+        bwd_scheduler = (
+            schedule.counters[2:] if num_sequences * heads <= schedule.num_sms else None
+        )
+        kda_bprop_f16.chunk_kda_bwd_sm100(
+            q[0],
+            k[0],
+            value[0],
+            gate[0],
+            beta[0],
+            d_output[0],
+            checkpoints,
+            dq,
+            dk,
+            dv,
+            dgate,
+            dbeta,
+            cu_seqlens,
+            scale,
+            use_initial_state=False,
+            d_initial_state=None,
+            d_final_state=None,
+            work_items=schedule.work_items,
+            work_count=schedule.work_count,
+            sched_ctr=bwd_scheduler,
+            order_in_prologue=False,
+            tensormap_workspace=backward_workspace,
+        )
+        return (
+            dq.unsqueeze(0),
+            dk.unsqueeze(0),
+            dv.unsqueeze(0),
+            dgate.unsqueeze(0),
+            dbeta.unsqueeze(0),
+        )
+
+
+__all__ = ["chunk_delta_rule_bwd_mega_packed"]

--- a/attn_gym/linear/_delta_rule/mega/forward.py
+++ b/attn_gym/linear/_delta_rule/mega/forward.py
@@ -1,0 +1,235 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Shared Torch launcher for the CuTeDSL 4.7 Mega forward kernel."""
+
+from __future__ import annotations
+
+import torch
+
+from attn_gym._backends.cute import tensor_supports_contiguous_dim, tensor_supports_tma
+from attn_gym.linear._delta_rule.validation import resolve_scale
+from attn_gym.utils import ceildiv
+
+from .kernels import kda_prefill_f16 as kernel
+from .kernels.common.host import tensormap_workspace_bytes
+from .kernels.compat import get_device_properties, tensor_device_index
+from .schedule import prepare_mega_schedule
+
+_SUPPORTED_IO_DTYPES = (torch.float16, torch.bfloat16)
+_WORKSPACE_WORD_BYTES = 8
+
+
+def validate_available(q: torch.Tensor) -> None:
+    """Validate the device contract without launching asynchronous work."""
+    if not q.is_cuda:
+        raise ValueError("the Mega KDA backend requires CUDA tensors")
+    properties = get_device_properties(tensor_device_index(q))
+    if (properties.major, properties.minor) not in ((10, 0), (10, 3)):
+        raise ValueError("the CuTeDSL 4.7 KDA backend requires SM100 or SM103")
+
+
+def run_forward_on_current_device(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    value: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    *,
+    scale: float | None,
+    output_final_state: bool,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Validate and launch one unsplit packed forward invocation."""
+    scale = resolve_scale(scale, q.shape[-1])
+    validate_available(q)
+    if q.ndim != 4 or q.shape[0] != 1 or q.shape[-1] != 128:
+        raise ValueError("q must have shape [1, T, H, 128]")
+    if k.shape != q.shape or gate.shape != q.shape:
+        raise ValueError("k and gate must match q")
+    heads = q.shape[2]
+    if value.shape != q.shape:
+        raise ValueError("value must match q")
+    if beta.shape != q.shape[:3]:
+        raise ValueError("beta must have shape [1, T, H]")
+    if q.dtype not in _SUPPORTED_IO_DTYPES or k.dtype != q.dtype or value.dtype != q.dtype:
+        raise TypeError("q, k, and value must share dtype float16 or bfloat16")
+    if gate.dtype != torch.float32 or beta.dtype != torch.float32:
+        raise TypeError("gate and beta must be float32")
+    inputs = (q, k, value, gate, beta)
+    if any(not tensor.is_cuda for tensor in inputs):
+        raise ValueError("all inputs must be CUDA tensors")
+    if any(tensor.device != q.device for tensor in inputs[1:]):
+        raise ValueError("all inputs must be on q.device")
+    if any(not tensor_supports_tma(tensor) for tensor in (q, k, value, gate)):
+        raise TypeError("q, k, value, and gate require a TMA-compatible inner mode")
+    if not tensor_supports_contiguous_dim(beta, alignment_bytes=4):
+        raise TypeError("beta requires a contiguous, element-aligned inner mode")
+    if (
+        cu_seqlens.ndim != 1
+        or cu_seqlens.shape[0] < 2
+        or cu_seqlens.dtype != torch.int32
+        or not cu_seqlens.is_contiguous()
+    ):
+        raise TypeError("cu_seqlens must be a contiguous int32 vector")
+    if not cu_seqlens.is_cuda or cu_seqlens.device != q.device:
+        raise ValueError("cu_seqlens must be on the input CUDA device")
+
+    num_sequences = cu_seqlens.shape[0] - 1
+    if initial_state is not None:
+        expected_state = (num_sequences, heads, 128, 128)
+        if initial_state.shape != expected_state or initial_state.dtype != torch.float32:
+            raise TypeError(f"initial_state must be float32 with shape {expected_state}")
+        if not initial_state.is_cuda or initial_state.device != q.device:
+            raise ValueError("initial_state must be on the input CUDA device")
+        if not tensor_supports_tma(initial_state):
+            raise TypeError("initial_state requires a TMA-compatible inner mode")
+    if output_final_state and initial_state is None:
+        raise ValueError("output_final_state requires an initial_state buffer")
+
+    # Empty sequences emit no token work. Cloning only when requested preserves their state.
+    final_state = initial_state.clone() if output_final_state else None
+    output = torch.empty_like(value)
+    stream = torch.cuda.current_stream(q.device).cuda_stream
+    schedule = prepare_mega_schedule(
+        gate,
+        cu_seqlens,
+        tile_tokens=kernel.CFG.B_T,
+        counter_count=2,
+        split=False,
+        stream=stream,
+    )
+    tensormap_workspace = torch.empty(
+        ceildiv(tensormap_workspace_bytes(kernel, num_sequences), _WORKSPACE_WORD_BYTES),
+        dtype=torch.int64,
+        device=q.device,
+    )
+    kernel.chunk_kda_sm100(
+        q[0],
+        k[0],
+        value[0],
+        gate[0],
+        beta[0],
+        output[0],
+        cu_seqlens,
+        initial_state,
+        final_state,
+        scale,
+        work_items=schedule.work_items,
+        work_count=schedule.work_count,
+        sched_ctr=schedule.counters,
+        work_item_scratch=schedule.item_scratch,
+        tensormap_workspace=tensormap_workspace,
+    )
+    return output, final_state
+
+
+def run_forward(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    value: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    *,
+    scale: float | None,
+    output_final_state: bool,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Launch under the input tensor's CUDA device guard."""
+    if not q.is_cuda:
+        raise ValueError("q must be a CUDA tensor")
+    with torch.cuda.device(q.device):
+        return run_forward_on_current_device(
+            q,
+            k,
+            value,
+            gate,
+            beta,
+            cu_seqlens,
+            initial_state,
+            scale=scale,
+            output_final_state=output_final_state,
+        )
+
+
+def chunk_delta_rule_fwd_mega_unsplit(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    value: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    scale: float | None = None,
+) -> torch.Tensor:
+    """Run an unsplit packed forward without recurrent state."""
+    output, _ = run_forward(
+        q,
+        k,
+        value,
+        gate,
+        beta,
+        cu_seqlens,
+        None,
+        scale=scale,
+        output_final_state=False,
+    )
+    return output
+
+
+def chunk_delta_rule_fwd_mega_unsplit_with_initial_state(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    value: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    scale: float | None = None,
+) -> torch.Tensor:
+    """Run an unsplit packed forward from an initial state without storing the final state."""
+    output, _ = run_forward(
+        q,
+        k,
+        value,
+        gate,
+        beta,
+        cu_seqlens,
+        initial_state,
+        scale=scale,
+        output_final_state=False,
+    )
+    return output
+
+
+def chunk_delta_rule_fwd_mega_unsplit_with_state(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    value: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    scale: float | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run an unsplit packed forward and return the final `[V, K]` state."""
+    output, final_state = run_forward(
+        q,
+        k,
+        value,
+        gate,
+        beta,
+        cu_seqlens,
+        initial_state,
+        scale=scale,
+        output_final_state=True,
+    )
+    assert final_state is not None
+    return output, final_state
+
+
+__all__ = [
+    "chunk_delta_rule_fwd_mega_unsplit",
+    "chunk_delta_rule_fwd_mega_unsplit_with_initial_state",
+    "chunk_delta_rule_fwd_mega_unsplit_with_state",
+]

--- a/attn_gym/linear/_delta_rule/mega/kernels/README.md
+++ b/attn_gym/linear/_delta_rule/mega/kernels/README.md
@@ -1,9 +1,10 @@
 # Mega delta-rule CuTeDSL kernels
 
-This package vendors the SM100/SM103 prefill, checkpoint-recompute, and bprop kernels adapted from
-NVIDIA's Frost KDA implementation. It is the shared donor-derived kernel unit for delta-rule
-variants. The current KDA adapter owns public API selection, validation, gate preparation, and
-autograd; a future GDN adapter can reuse the same implementation boundary.
+This package contains the shared SM100/SM103 Mega kernels for delta-rule variants. The prefill,
+checkpoint-recompute, and bprop core is adapted from NVIDIA's Frost KDA implementation;
+`kda_plain_gate_bwd.py` is an Attention Gym-authored dense gate-gradient helper. The current KDA
+adapter owns public API selection, validation, and autograd, while a future GDN adapter can reuse
+the same implementation boundary.
 
 ## Raw specialization
 
@@ -36,9 +37,9 @@ runs.
 
 ## Source and licensing
 
-The kernels and required `common/` and `tile_dsl/` helpers are adapted from NVIDIA
+The Frost-derived kernels and required `common/` and `tile_dsl/` helpers are adapted from NVIDIA
 `cudnn-frontend` commit `085d50b33691f06e2309f8e6724741a021985649`. Runtime imports were moved
 into the Attention Gym namespace, and `compat.py` replaces cuDNN host utilities. There is no
-`cudnn.frost` runtime dependency.
+`cudnn.frost` runtime dependency. `kda_plain_gate_bwd.py` remains BSD-3-Clause Attention Gym code.
 
 See `NOTICE.md`, `LICENSE.Apache-2.0`, and `LICENSE.MIT`.

--- a/attn_gym/linear/_delta_rule/mega/kernels/__init__.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/__init__.py
@@ -1,1 +1,1 @@
-"""Vendored SM100/SM103 Frost kernels for shared Mega delta-rule backends."""
+"""SM100/SM103 Mega kernels, including the vendored Frost core."""

--- a/attn_gym/linear/_delta_rule/mega/kernels/common/split_k.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/common/split_k.py
@@ -83,13 +83,21 @@ import cutlass
 import cutlass.cute as cute
 import cutlass.experimental.primitives as nvvm
 from cutlass.cute.arch.nvvm_wrappers import inline_ptx
-from cutlass.cute.runtime import from_dlpack
+from cutlass.cute.runtime import make_fake_compact_tensor
+
+from attn_gym._backends.cute import make_fake_strided_tensor
 
 from ..compat import current_device, data_ptr, get_device_properties, tensor_device_index
 
 from .elementwise import softplus
-
-WORK_ITEM_FIELDS = 8
+from .host import get_dtype
+from .tvm_ffi import (
+    WORK_ITEM_FIELDS,
+    make_counter_signature,
+    make_cu_seqlens_signature,
+    make_work_items_signature,
+    validate_cu_seqlens,
+)
 WARMUP_CAP_CHUNKS = 32  # hard warmup cap: a cut must saturate within one warp of chunks per side
 MAX_BLOCKS = 2048  # piece-count ceiling; host clamps ideal_chunks so the per-tile block count fits
 WARP_SIZE = 32
@@ -916,6 +924,7 @@ def build_split_table(
     — no host synchronization."""
     if log2_threshold is None:
         log2_threshold = DEFAULT_LOG2_THRESHOLD
+    validate_cu_seqlens(cu_seqlens, assumed_align=4)
     if len(gate.shape) not in (2, 3):
         raise ValueError(f"gate must be (total_tokens, HO) or (total_tokens, HO, DK), got {tuple(gate.shape)}")
     gate_channels = gate.shape[2] if len(gate.shape) == 3 else 0
@@ -1006,6 +1015,8 @@ def build_split_table(
     overhead_chunks = max(1, OVERHEAD_TOKENS // b_t)
     cu_stream = cuda.CUstream(int(stream))
 
+    has_sched = sched_ctr is not None
+
     key = (
         device_index,
         device_properties.major,
@@ -1016,27 +1027,59 @@ def build_split_table(
         bool(log_gate),
         bool(safe_gate),
         gate_channels,
-        sched_ctr is not None,
-        str(cu_seqlens.dtype),
+        has_sched,
+        str(gate.dtype) if split else None,
+        str(a_log.dtype) if safe_gate else None,
+        str(dt_bias.dtype) if safe_gate else None,
     )
     if key not in compiled_cache:
-
-        dt_bias_c = None
-        if safe_gate:
-            dt_bias_c = from_dlpack(dt_bias, assumed_align=4)
-            dt_bias_c.mark_compact_shape_dynamic(mode=0, stride_order=tuple(range(len(dt_bias.shape))), divisibility=1)
-        chunk_scratch_c = None
-        item_scratch_c = None
-        if split:
-            chunk_scratch_c = from_dlpack(chunk_scratch, assumed_align=4)
-            chunk_scratch_c.mark_compact_shape_dynamic(mode=0, stride_order=(0, 1), divisibility=1)
-            item_scratch_c = from_dlpack(item_scratch, assumed_align=4)
-            item_scratch_c.mark_compact_shape_dynamic(mode=0, stride_order=(0, 1), divisibility=1)
-        work_items_c = from_dlpack(work_items, assumed_align=4)
-        work_items_c.mark_compact_shape_dynamic(mode=0, stride_order=(0, 1), divisibility=1)
-        work_count_c = from_dlpack(work_count, assumed_align=4)
-        work_count_c.mark_compact_shape_dynamic(mode=0, stride_order=(0,), divisibility=1)
-        compiled_cache[key] = cute.compile(
+        tokens = cute.sym_int()
+        sequence_entries = cute.sym_int()
+        item_rows = cute.sym_int()
+        gate_c = (
+            make_fake_strided_tensor(
+                get_dtype(gate.dtype),
+                (tokens, n_heads_out, gate_channels) if gate_channels else (tokens, n_heads_out),
+                assumed_align=4,
+            )
+            if split
+            else None
+        )
+        a_log_c = (
+            make_fake_compact_tensor(
+                get_dtype(a_log.dtype),
+                (n_heads_out,),
+                stride_order=(0,),
+                assumed_align=4,
+            )
+            if safe_gate
+            else None
+        )
+        dt_bias_c = (
+            make_fake_compact_tensor(
+                get_dtype(dt_bias.dtype),
+                (n_heads_out, gate_channels) if gate_channels else (n_heads_out,),
+                stride_order=(1, 0) if gate_channels else (0,),
+                assumed_align=4,
+            )
+            if safe_gate
+            else None
+        )
+        chunk_scratch_c = (
+            make_fake_compact_tensor(
+                cutlass.Float32,
+                (cute.sym_int(), n_heads_out),
+                stride_order=(1, 0),
+                assumed_align=4,
+            )
+            if split
+            else None
+        )
+        work_items_c = make_work_items_signature(item_rows)
+        item_scratch_c = work_items_c if split else None
+        work_count_c = make_counter_signature()
+        sched_c = make_counter_signature(cute.sym_int()) if has_sched else None
+        compiled_cache[key] = cute.compile[cute.EnableTVMFFI](
             launch,
             bool(split),
             b_t,
@@ -1044,7 +1087,7 @@ def build_split_table(
             bool(safe_gate),
             gate_channels,
             overhead_chunks,
-            sched_ctr is not None,
+            has_sched,
             cutlass.Int32(n_heads_out),
             cutlass.Int32(n_tiles),
             cutlass.Int32(num_sms),
@@ -1052,19 +1095,18 @@ def build_split_table(
             cutlass.Int32(batch_size),
             cutlass.Float32(log2_threshold),
             cutlass.Float32(gate_scale_log2),
-            from_dlpack(gate, assumed_align=4).mark_layout_dynamic(leading_dim=len(gate.shape) - 1) if split else None,
-            from_dlpack(a_log, assumed_align=4).mark_layout_dynamic() if safe_gate else None,
+            gate_c,
+            a_log_c,
             dt_bias_c,
-            from_dlpack(cu_seqlens, assumed_align=4).mark_layout_dynamic(),
+            make_cu_seqlens_signature(sequence_entries, assumed_align=4),
             chunk_scratch_c,
             item_scratch_c,
             work_items_c,
             work_count_c,
-            from_dlpack(sched_ctr, assumed_align=4).mark_layout_dynamic() if sched_ctr is not None else None,
+            sched_c,
             cutlass.Int32(n_scan_ctas),
             cutlass.Int32(n_walk_ctas),
-            cu_stream,
-            options="--enable-tvm-ffi",
+            cute.runtime.make_fake_stream(),
         )
     compiled_cache[key](
         n_heads_out,
@@ -1100,5 +1142,5 @@ def build_split_table(
         float(gate_scale_log2),
         n_scan_ctas,
         n_walk_ctas,
-        sched_ctr is not None,
+        has_sched,
     )

--- a/attn_gym/linear/_delta_rule/mega/kernels/common/tvm_ffi.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/common/tvm_ffi.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Fake-tensor signature builders for the Mega TVM-FFI launchers."""
+
+from typing import Any
+
+import cutlass
+from cutlass.cute.runtime import make_fake_compact_tensor
+
+from attn_gym._backends.cute import make_fake_strided_tensor
+
+WORK_ITEM_FIELDS = 8
+
+
+def make_compact_signature_tensor(
+    dtype: Any,
+    shape: tuple[Any, ...],
+    *,
+    assumed_align: int,
+):
+    """Create a row-major compact signature tensor."""
+    return make_fake_compact_tensor(
+        dtype,
+        shape,
+        stride_order=tuple(reversed(range(len(shape)))),
+        assumed_align=assumed_align,
+    )
+
+
+def make_strided_signature_tensor(
+    dtype: Any,
+    shape: tuple[Any, ...],
+    *,
+    assumed_align: int,
+    use_int64_offsets: bool,
+):
+    """Create a last-dimension-contiguous tensor with aligned dynamic outer strides."""
+    element_bytes = dtype.width // 8
+    if assumed_align % element_bytes:
+        raise ValueError("assumed alignment must be a multiple of the element width")
+    return make_fake_strided_tensor(
+        dtype,
+        shape,
+        stride_divisibility=assumed_align // element_bytes,
+        assumed_align=assumed_align,
+        use_int64_strides=use_int64_offsets,
+    )
+
+
+def make_cu_seqlens_signature(entries: Any, *, assumed_align: int = 8):
+    """Create the compact int32 cumulative-sequence-length signature."""
+    return make_compact_signature_tensor(
+        cutlass.Int32,
+        (entries,),
+        assumed_align=assumed_align,
+    )
+
+
+def make_work_items_signature(rows: Any):
+    """Create a compact work-item table signature."""
+    return make_compact_signature_tensor(
+        cutlass.Int32,
+        (rows, WORK_ITEM_FIELDS),
+        assumed_align=4,
+    )
+
+
+def make_counter_signature(entries: Any = 1):
+    """Create a compact int32 work-count or scheduler-counter signature."""
+    return make_compact_signature_tensor(
+        cutlass.Int32,
+        (entries,),
+        assumed_align=4,
+    )
+
+
+def make_workspace_signature(words: Any):
+    """Create the aligned int64 tensor-map workspace signature."""
+    return make_compact_signature_tensor(
+        cutlass.Int64,
+        (words,),
+        assumed_align=128,
+    )
+
+
+def validate_cu_seqlens(cu_seqlens: Any, *, assumed_align: int) -> None:
+    """Validate the cumulative-sequence-length ABI before cache selection."""
+    if str(cu_seqlens.dtype) != "torch.int32":
+        raise ValueError(f"cu_seqlens must have dtype torch.int32, got {cu_seqlens.dtype}")
+    if cu_seqlens.data_ptr() % assumed_align:
+        raise ValueError(f"cu_seqlens data pointer must be {assumed_align}-byte aligned")

--- a/attn_gym/linear/_delta_rule/mega/kernels/compat.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/compat.py
@@ -42,14 +42,14 @@ def checkpoint_capacity_bound(tokens: int, num_sequences: int, interval: int) ->
 
 
 def validate_tma_tensor(name: str, tensor: torch.Tensor, *, alignment: int = 16) -> None:
-    """Reject layouts that cannot be represented by the current int32 TMA ABI."""
+    """Reject layouts that cannot satisfy the aligned TMA tensor contract."""
     if tensor.data_ptr() % alignment:
         raise ValueError(f"{name} data pointer must be {alignment}-byte aligned")
     if tensor.stride(-1) != 1:
         raise ValueError(f"{name} innermost stride must be one")
     element_bytes = tensor.element_size()
     for stride in tensor.stride()[:-1]:
-        if stride < 0 or stride > 2**31 - 1:
-            raise ValueError(f"{name} outer strides must fit nonnegative int32")
+        if stride < 0:
+            raise ValueError(f"{name} outer strides must be nonnegative")
         if stride * element_bytes % 16:
             raise ValueError(f"{name} outer byte strides must be multiples of 16")

--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_bprop_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_bprop_f16.py
@@ -72,7 +72,7 @@ Warp assignments (16 warps = 512 threads):
 """
 
 from dataclasses import dataclass
-from functools import lru_cache
+from functools import lru_cache, partial
 from typing import NamedTuple, Type
 
 import cuda.bindings.driver as cuda_driver
@@ -80,8 +80,9 @@ import cutlass
 import cutlass.experimental.cuda as cuda
 import cutlass.experimental.primitives as nvvm
 import cutlass.cute as cute
-from cutlass.cute.runtime import from_dlpack
 
+from attn_gym._backends.cute import compile_tvm_ffi
+from attn_gym._backends.cute.utils import requires_int64_abi
 from attn_gym.linear._delta_rule.mega.kernels.common.split_k import ORDER_CAPACITY, ORDER_ELEMS, ORDER_THREADS, decode_work_item, order_body
 from attn_gym.linear._delta_rule.mega.kernels.common.host import get_dtype
 from attn_gym.linear._delta_rule.mega.kernels.compat import (
@@ -96,6 +97,15 @@ from attn_gym.linear._delta_rule.mega.kernels.common.thd import (
     emit_checkpoint_seq_descs,
     emit_seq_descs,
     emit_seq_load_descs,
+)
+from attn_gym.linear._delta_rule.mega.kernels.common.tvm_ffi import (
+    make_compact_signature_tensor,
+    make_counter_signature,
+    make_cu_seqlens_signature,
+    make_strided_signature_tensor,
+    make_work_items_signature,
+    make_workspace_signature,
+    validate_cu_seqlens,
 )
 from .kda_bprop_config import CFG
 
@@ -2897,16 +2907,16 @@ def build_descs_body(
     dgate: cute.Tensor,
     state_checkpoints: cute.Tensor,
     n_batch: cutlass.Int32,
-    q_row_stride: cutlass.Int32,
-    k_row_stride: cutlass.Int32,
-    v_row_stride: cutlass.Int32,
-    gate_row_stride: cutlass.Int32,
-    do_row_stride: cutlass.Int32,
-    dq_row_stride: cutlass.Int32,
-    dk_row_stride: cutlass.Int32,
-    dv_row_stride: cutlass.Int32,
-    dgate_row_stride: cutlass.Int32,
-    checkpoint_row_stride: cutlass.Int32,
+    q_row_stride: cutlass.Int64,
+    k_row_stride: cutlass.Int64,
+    v_row_stride: cutlass.Int64,
+    gate_row_stride: cutlass.Int64,
+    do_row_stride: cutlass.Int64,
+    dq_row_stride: cutlass.Int64,
+    dk_row_stride: cutlass.Int64,
+    dv_row_stride: cutlass.Int64,
+    dgate_row_stride: cutlass.Int64,
+    checkpoint_row_stride: cutlass.Int64,
     checkpoint_every_n: cutlass.Int32,
 ) -> None:
     """Per-batch descriptor-array build, one warp per array. Runs inside the
@@ -3001,16 +3011,16 @@ def prologue_kernel(
     mWorkItems: cute.Tensor | None,
     mSched: cute.Tensor | None,
     n_batch: cutlass.Int32,
-    q_row_stride: cutlass.Int32,
-    k_row_stride: cutlass.Int32,
-    v_row_stride: cutlass.Int32,
-    gate_row_stride: cutlass.Int32,
-    do_row_stride: cutlass.Int32,
-    dq_row_stride: cutlass.Int32,
-    dk_row_stride: cutlass.Int32,
-    dv_row_stride: cutlass.Int32,
-    dgate_row_stride: cutlass.Int32,
-    checkpoint_row_stride: cutlass.Int32,
+    q_row_stride: cutlass.Int64,
+    k_row_stride: cutlass.Int64,
+    v_row_stride: cutlass.Int64,
+    gate_row_stride: cutlass.Int64,
+    do_row_stride: cutlass.Int64,
+    dq_row_stride: cutlass.Int64,
+    dk_row_stride: cutlass.Int64,
+    dv_row_stride: cutlass.Int64,
+    dgate_row_stride: cutlass.Int64,
+    checkpoint_row_stride: cutlass.Int64,
     checkpoint_every_n: cutlass.Int32,
 ) -> None:
     """Single-CTA prologue. Under ``run_order`` this kernel is the first
@@ -3185,16 +3195,16 @@ def prologue(
         work_items,
         sched_all,
         cutlass.Int32(batch_size),
-        cutlass.Int32(q.stride[0]),
-        cutlass.Int32(k.stride[0]),
-        cutlass.Int32(v.stride[0]),
-        cutlass.Int32(gate.stride[0]),
-        cutlass.Int32(do.stride[0]),
-        cutlass.Int32(dq.stride[0]),
-        cutlass.Int32(dk.stride[0]),
-        cutlass.Int32(dv.stride[0]),
-        cutlass.Int32(dgate.stride[0]),
-        cutlass.Int32(state_checkpoints.stride[0]),
+        cutlass.Int64(q.stride[0]),
+        cutlass.Int64(k.stride[0]),
+        cutlass.Int64(v.stride[0]),
+        cutlass.Int64(gate.stride[0]),
+        cutlass.Int64(do.stride[0]),
+        cutlass.Int64(dq.stride[0]),
+        cutlass.Int64(dk.stride[0]),
+        cutlass.Int64(dv.stride[0]),
+        cutlass.Int64(dgate.stride[0]),
+        cutlass.Int64(state_checkpoints.stride[0]),
         cutlass.Int32(b_t),
     ).launch(grid=(1, 1, 1), block=(ORDER_THREADS, 1, 1), stream=stream)
 
@@ -3202,8 +3212,9 @@ def prologue(
 class KdaBpropOp:
     """Compile and launch one static mega KDA backward configuration."""
 
-    def __init__(self, cfg: "KdaBwdCfg"):
+    def __init__(self, cfg: "KdaBwdCfg", use_int64_offsets: bool = False):
         self.cfg = cfg
+        self.use_int64_offsets = use_int64_offsets
 
     def get_name(self) -> str:
         cfg = self.cfg
@@ -3221,7 +3232,7 @@ class KdaBpropOp:
             f"_s{int(cfg.use_dstate_in)}z{int(cfg.use_dstate0)}"
             f"l{int(cfg.l2norm)}g{int(cfg.safe_gate)}b{int(cfg.beta_sigmoid)}"
             f"i{int(cfg.use_initial_state)}d{int(cfg.dyn_sched)}"
-            f"_sm{cfg.max_active_clusters}{gate_scale}"
+            f"_sm{cfg.max_active_clusters}_i64{int(self.use_int64_offsets)}{gate_scale}"
         )
 
     @cute.jit
@@ -3959,7 +3970,6 @@ TENSORMAP_STATIC_SLOTS = 0
 @lru_cache(maxsize=None)
 def get_compiled_cache(
     io_dtype_str: str,
-    cu_dtype_str: str,
     HQ: int,
     HK: int,
     HV: int,
@@ -3973,6 +3983,7 @@ def get_compiled_cache(
     dyn_sched: bool,
     run_order: bool,
     order_gen: bool,
+    use_int64_offsets: bool,
     device_index: int,
     device_major: int,
     device_minor: int,
@@ -4013,11 +4024,10 @@ def chunk_kda_bwd_sm100(
     work_item_scratch=None,
     order_in_prologue: bool = False,
     tensormap_workspace,
-    stream,
 ) -> None:
     """Execute the Blackwell BT=16 chunked KDA backward kernel.
 
-    All tensors must be contiguous and on the same CUDA device.
+    TMA operands require an aligned contiguous innermost mode; outer strides may vary.
 
     Args:
         q: ``(total_tokens, HQ, DK)`` float16/bfloat16
@@ -4079,8 +4089,9 @@ def chunk_kda_bwd_sm100(
     for name, tensor in (("d_initial_state", d_initial_state), ("d_final_state", d_final_state)):
         if tensor is not None:
             validate_tma_tensor(name, tensor)
-    if cu_seqlens.data_ptr() % 8:
-        raise ValueError("cu_seqlens data pointer must be 8-byte aligned")
+    validate_cu_seqlens(cu_seqlens, assumed_align=8)
+    if tensormap_workspace.data_ptr() % 128:
+        raise ValueError("tensormap_workspace data pointer must be 128-byte aligned")
 
     tokens, HQ, d_k = q.shape
     HK, HV = k.shape[1], v.shape[1]
@@ -4103,6 +4114,7 @@ def chunk_kda_bwd_sm100(
     dyn_sched = sched_ctr is not None
     run_order = order_in_prologue
     order_gen = order_in_prologue and work_item_scratch is None
+    has_sched = run_order
     if run_order and sched_all is None:
         raise ValueError("order in the prologue requires sched_all (the prologue zeroes both consumers' sched rings)")
     required_checkpoint_rows = checkpoint_capacity_bound(
@@ -4129,7 +4141,31 @@ def chunk_kda_bwd_sm100(
         a_log = None
         dt_bias = None
 
-    cu_stream = cuda_driver.CUstream(int(stream))
+    use_int64_offsets = requires_int64_abi(
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        do,
+        state_checkpoints,
+        dq,
+        dk,
+        dv,
+        dgate,
+        dbeta,
+        cu_seqlens,
+        a_log,
+        dt_bias,
+        d_initial_state,
+        d_final_state,
+        work_item_scratch,
+        work_items,
+        work_count,
+        sched_ctr,
+        sched_all,
+        tensormap_workspace,
+    )
     device_index = tensor_device_index(q)
     if current_device() != device_index:
         raise ValueError("the active CUDA device must match q.device")
@@ -4137,7 +4173,6 @@ def chunk_kda_bwd_sm100(
     num_sm = device_properties.multi_processor_count
     cache = get_compiled_cache(
         str(q.dtype),
-        str(cu_seqlens.dtype),
         HQ,
         HK,
         HV,
@@ -4151,14 +4186,16 @@ def chunk_kda_bwd_sm100(
         dyn_sched,
         run_order,
         order_gen,
+        use_int64_offsets,
         device_index,
         device_properties.major,
         device_properties.minor,
         num_sm,
     )
 
+    io_dtype = get_dtype(q.dtype)
+    sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
     if "compiled" not in cache:
-        io_dtype = get_dtype(q.dtype)
         cfg = build_cfg(
             io_dtype,
             use_dstate_in=use_dstate_in,
@@ -4175,99 +4212,96 @@ def chunk_kda_bwd_sm100(
             max_active_clusters=num_sm,
             dyn_sched=dyn_sched,
         )
+        op = KdaBpropOp(cfg, use_int64_offsets)
+        (
+            tokens,
+            checkpoint_rows,
+            sequence_entries,
+            sequences,
+            work_rows,
+            sched_entries,
+            workspace_words,
+        ) = (sym_int() for _ in range(7))
 
-        dstate0_cute = None
-        if use_dstate0:
-            dstate0_cute = from_dlpack(d_initial_state, assumed_align=16).mark_layout_dynamic(leading_dim=3)
-        dstate_in_cute = None
-        if use_dstate_in:
-            dstate_in_cute = from_dlpack(d_final_state, assumed_align=16).mark_layout_dynamic(leading_dim=3)
-        wi_cute = from_dlpack(work_items, assumed_align=16)
-        wi_cute.mark_compact_shape_dynamic(mode=0, stride_order=(0, 1), divisibility=1)
-        wc_cute = from_dlpack(work_count, assumed_align=4).mark_layout_dynamic()
-        sc_cute = None
-        if dyn_sched:
-            sc_cute = from_dlpack(sched_ctr, assumed_align=4).mark_layout_dynamic()
-
-        tensormap_ws_cute = from_dlpack(tensormap_workspace, assumed_align=128).mark_layout_dynamic()
-
-        a_log_cute = from_dlpack(a_log, assumed_align=4) if a_log is not None else None
-        dt_bias_cute = from_dlpack(dt_bias, assumed_align=16) if dt_bias is not None else None
-        beta_cute = from_dlpack(beta, assumed_align=4).mark_layout_dynamic(leading_dim=len(beta.shape) - 1)
-        state_checkpoints_cute = from_dlpack(state_checkpoints, assumed_align=16).mark_layout_dynamic(leading_dim=len(state_checkpoints.shape) - 1)
-        dgate_cute = from_dlpack(dgate, assumed_align=16).mark_layout_dynamic(leading_dim=len(dgate.shape) - 1)
-        dbeta_cute = from_dlpack(dbeta, assumed_align=4).mark_layout_dynamic(leading_dim=len(dbeta.shape) - 1)
-        op = KdaBpropOp(cfg)
-        op.__call__.set_name_prefix(op.get_name())
-        cache["compiled"] = cute.compile(
+        tma_tensor = partial(
+            make_strided_signature_tensor,
+            assumed_align=16,
+            use_int64_offsets=use_int64_offsets,
+        )
+        beta_dtype = io_dtype if use_beta_sigmoid else cutlass.Float32
+        cache["compiled"] = compile_tvm_ffi(
             op,
-            a_log_cute,
-            dt_bias_cute,
-            beta_cute,
-            state_checkpoints_cute,
-            dgate_cute,
-            dbeta_cute,
-            from_dlpack(cu_seqlens, assumed_align=8).mark_layout_dynamic(),
-            dstate0_cute,
-            dstate_in_cute,
-            wi_cute,
-            wc_cute,
-            sc_cute,
-            tensormap_ws_cute,
-            scale,
-            cu_stream,
-            options="--enable-tvm-ffi --opt-level 2",
+            make_compact_signature_tensor(
+                cutlass.Float32,
+                (HO,),
+                assumed_align=4,
+            )
+            if safe_gate
+            else None,
+            tma_tensor(cutlass.Float32, (HO, 128)) if safe_gate else None,
+            make_strided_signature_tensor(
+                beta_dtype,
+                (tokens, HO),
+                assumed_align=beta_dtype.width // 8,
+                use_int64_offsets=use_int64_offsets,
+            ),
+            tma_tensor(io_dtype, (checkpoint_rows, HO, 128, 128)),
+            tma_tensor(cutlass.Float32, (tokens, HO, 128)),
+            make_strided_signature_tensor(
+                beta_dtype,
+                (tokens, HO),
+                assumed_align=beta_dtype.width // 8,
+                use_int64_offsets=use_int64_offsets,
+            ),
+            make_cu_seqlens_signature(sequence_entries),
+            tma_tensor(cutlass.Float32, (sequences, HO, 128, 128)) if use_dstate0 else None,
+            tma_tensor(cutlass.Float32, (sequences, HO, 128, 128)) if use_dstate_in else None,
+            make_work_items_signature(work_rows),
+            make_counter_signature(),
+            make_counter_signature(sched_entries) if dyn_sched else None,
+            make_workspace_signature(workspace_words),
+            cutlass.Float32(scale),
         )
 
     if "prologue" not in cache:
-        io_dtype = get_dtype(q.dtype)
-        q_pl = from_dlpack(q, assumed_align=16).mark_layout_dynamic(leading_dim=2)
-        k_pl = from_dlpack(k, assumed_align=16).mark_layout_dynamic(leading_dim=2)
-        v_pl = from_dlpack(v, assumed_align=16).mark_layout_dynamic(leading_dim=2)
-        gate_pl = from_dlpack(gate, assumed_align=16).mark_layout_dynamic(leading_dim=2)
-        do_pl = from_dlpack(do, assumed_align=16).mark_layout_dynamic(leading_dim=2)
-        dq_pl = from_dlpack(dq, assumed_align=16).mark_layout_dynamic(leading_dim=2)
-        dk_pl = from_dlpack(dk, assumed_align=16).mark_layout_dynamic(leading_dim=2)
-        dv_pl = from_dlpack(dv, assumed_align=16).mark_layout_dynamic(leading_dim=2)
-        dgate_pl = from_dlpack(dgate, assumed_align=16).mark_layout_dynamic(leading_dim=2)
-        state_checkpoints_pl = from_dlpack(state_checkpoints, assumed_align=16).mark_layout_dynamic(leading_dim=3)
-        cu_pl = from_dlpack(cu_seqlens, assumed_align=8).mark_layout_dynamic()
-        ws_pl = from_dlpack(tensormap_workspace, assumed_align=128).mark_layout_dynamic()
-        staging_pl = None
-        if run_order and not order_gen:
-            staging_pl = from_dlpack(work_item_scratch, assumed_align=16)
-            staging_pl.mark_compact_shape_dynamic(mode=0, stride_order=(0, 1), divisibility=1)
-        work_items_pl = from_dlpack(work_items, assumed_align=16)
-        work_items_pl.mark_compact_shape_dynamic(mode=0, stride_order=(0, 1), divisibility=1)
-        work_count_pl = from_dlpack(work_count, assumed_align=4).mark_layout_dynamic()
-        sched_pl = None
-        if run_order:
-            sched_pl = from_dlpack(sched_all, assumed_align=4).mark_layout_dynamic()
-        cache["prologue"] = cute.compile(
+        tokens, checkpoint_rows, sequence_entries, work_rows, sched_entries, workspace_words = (
+            sym_int() for _ in range(6)
+        )
+
+        tma_tensor = partial(
+            make_strided_signature_tensor,
+            assumed_align=16,
+            use_int64_offsets=use_int64_offsets,
+        )
+        work_items_signature = make_work_items_signature(work_rows)
+        cache["prologue"] = compile_tvm_ffi(
             prologue,
             io_dtype,
             CFG.B_T,
             run_order,
             order_gen,
-            run_order,
-            q_pl,
-            k_pl,
-            v_pl,
-            gate_pl,
-            do_pl,
-            dq_pl,
-            dk_pl,
-            dv_pl,
-            dgate_pl,
-            state_checkpoints_pl,
-            cu_pl,
-            staging_pl,
-            work_count_pl,
-            work_items_pl,
-            sched_pl,
-            ws_pl,
-            cu_stream,
-            options="--enable-tvm-ffi",
+            has_sched,
+            tma_tensor(io_dtype, (tokens, HQ, 128)),
+            tma_tensor(io_dtype, (tokens, HK, 128)),
+            tma_tensor(io_dtype, (tokens, HV, 128)),
+            tma_tensor(cutlass.Float32, (tokens, HO, 128)),
+            tma_tensor(io_dtype, (tokens, HO, 128)),
+            tma_tensor(io_dtype, (tokens, HQ, 128)),
+            tma_tensor(io_dtype, (tokens, HK, 128)),
+            tma_tensor(io_dtype, (tokens, HV, 128)),
+            tma_tensor(cutlass.Float32, (tokens, HO, 128)),
+            tma_tensor(io_dtype, (checkpoint_rows, HO, 128, 128)),
+            make_cu_seqlens_signature(sequence_entries),
+            work_items_signature if run_order and not order_gen else None,
+            make_counter_signature(),
+            work_items_signature,
+            make_counter_signature(sched_entries) if has_sched else None,
+            make_workspace_signature(workspace_words),
+            name=(
+                f"kda_mega_bprop_prologue_{io_dtype.__name__.lower()}"
+                f"_hq{HQ}_hk{HK}_hv{HV}_ho{HO}_r{int(run_order)}"
+                f"o{int(order_gen)}d{int(dyn_sched)}_i64{int(use_int64_offsets)}"
+            ),
         )
     cache["prologue"](
         q,
@@ -4286,7 +4320,6 @@ def chunk_kda_bwd_sm100(
         work_items,
         sched_all if run_order else None,
         tensormap_workspace,
-        cu_stream,
     )
     cache["compiled"](
         a_log,
@@ -4303,5 +4336,4 @@ def chunk_kda_bwd_sm100(
         sched_ctr,
         tensormap_workspace,
         scale,
-        cu_stream,
     )

--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_plain_gate_bwd.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_plain_gate_bwd.py
@@ -1,0 +1,264 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""TMA-staged dense reverse cumsum for plain KDA gate gradients.
+
+For each BT64 chunk, the forward scan computes
+``c[t] = log2(e) * sum(g[j], j <= t)``. Its backward is therefore the channelwise suffix scan
+``dg[t] = log2(e) * sum(dc[j], j >= t)`` over the same chunk. Each CTA owns one
+``(batch, chunk, head)`` tile: a producer warp streams four FP32 token rows per TMA stage, while
+128 channel threads consume the stages in reverse and carry one suffix value across the chunk.
+This is the dense counterpart of the Triton packed reverse scan and keeps the composed Mega
+backward on CuTeDSL without materializing a transpose or per-channel work table.
+"""
+
+from __future__ import annotations
+
+import math
+from enum import IntEnum
+
+import cutlass
+import torch
+from cuda.bindings import driver as cuda
+from cutlass import Float32, Int32, Int64, cute, pipeline
+from cutlass.cute.nvgpu import cpasync
+from cutlass.cute.runtime import make_fake_compact_tensor
+
+from attn_gym._backends.cute import (
+    TMA_ALIGNMENT_BYTES,
+    compile_tvm_ffi,
+    jit_cache,
+    make_fake_strided_tensor,
+)
+from attn_gym._backends.cute.target import get_compile_target
+from attn_gym._backends.cute.utils import requires_int64_abi
+
+
+class WarpRole(IntEnum):
+    """Fixed warp assignments for the dense gate scan."""
+
+    TMA_PRODUCER = 0
+
+
+class PlainGateBwdOp:
+    """Scan one dense BT64 gate-gradient tile per CTA."""
+
+    chunk_size = 64
+    tokens_per_stage = 4
+    stages = 2
+
+    def __init__(self, heads: int, head_dim: int, use_int64_offsets: bool):
+        if head_dim != 128:
+            raise ValueError(f"plain gate backward requires D=128, got {head_dim}")
+        self.heads = heads
+        self.head_dim = head_dim
+        self.use_int64_offsets = use_int64_offsets
+
+    def get_name(self) -> str:
+        return (
+            f"kda_plain_gate_bwd_tma_h{self.heads}_d{self.head_dim}"
+            f"_i64{int(self.use_int64_offsets)}"
+        )
+
+    def _staged_layout(self):
+        return cute.make_layout(
+            (self.tokens_per_stage, self.head_dim, self.stages),
+            stride=(
+                self.head_dim,
+                1,
+                self.tokens_per_stage * self.head_dim,
+            ),
+        )
+
+    @cute.jit
+    def _issue_subtile(
+        self,
+        tile_pipeline: pipeline.PipelineTmaAsync,
+        producer_state: pipeline.PipelineState,
+        tma_atom: cute.CopyAtom,
+        tGgD: cute.Tensor,
+        tGsD: cute.Tensor,
+        tile_index: Int32,
+    ):
+        tile_pipeline.producer_acquire(producer_state)
+        cute.copy(
+            tma_atom,
+            tGgD[(None, tile_index, 0)],
+            tGsD[(None, producer_state.index)],
+            tma_bar_ptr=tile_pipeline.producer_get_barrier(producer_state),
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        mD_cumulative: cute.Tensor,
+        mD_gate: cute.Tensor,
+        tma_atom: cute.CopyAtom,
+        tma_tensor: cute.Tensor,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        chunk, head, batch = cute.arch.block_idx()
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        subtiles = self.chunk_size // self.tokens_per_stage
+        tile_start = chunk.to(Int64) * Int64(self.chunk_size)
+
+        smem = cutlass.utils.SmemAllocator()
+        barriers = smem.allocate_array(Int64, self.stages * 2)
+        sD = smem.allocate_tensor(Float32, self._staged_layout(), byte_alignment=128)
+        tile_pipeline = pipeline.PipelineTmaAsync.create(
+            num_stages=self.stages,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                self.head_dim // 32,
+            ),
+            tx_count=cute.size_in_bytes(
+                Float32,
+                cute.make_layout(
+                    (self.tokens_per_stage, self.head_dim),
+                    stride=(self.head_dim, 1),
+                ),
+            ),
+            barrier_storage=barriers,
+            tidx=tidx,
+        )
+
+        cta_tiler = (self.tokens_per_stage, self.head_dim)
+        gD_tiles = cute.local_tile(
+            tma_tensor[None, None, head, batch],
+            cta_tiler,
+            (None, None),
+        )
+        tGsD, tGgD = cpasync.tma_partition(
+            tma_atom,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(sD, 0, 2),
+            cute.group_modes(gD_tiles, 0, 2),
+        )
+        producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer,
+            self.stages,
+        )
+        consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer,
+            self.stages,
+        )
+        tile_base = chunk * Int32(subtiles)
+        if warp_idx == WarpRole.TMA_PRODUCER:
+            cpasync.prefetch_descriptor(tma_atom)
+            for issued in cutlass.range_constexpr(self.stages):
+                self._issue_subtile(
+                    tile_pipeline,
+                    producer_state,
+                    tma_atom,
+                    tGgD,
+                    tGsD,
+                    tile_base + Int32(subtiles - 1 - issued),
+                )
+                producer_state.advance()
+
+        suffix = Float32(0.0)
+        scale = Float32(math.log2(math.e))
+        for step in cutlass.range_constexpr(subtiles):
+            subtile = subtiles - 1 - step
+            tile_pipeline.consumer_wait(consumer_state)
+            stage = consumer_state.index
+            for offset in cutlass.range_constexpr(self.tokens_per_stage):
+                slot = self.tokens_per_stage - 1 - offset
+                local_token = subtile * self.tokens_per_stage + slot
+                suffix = suffix + sD[slot, tidx, stage]
+                mD_gate[batch, tile_start + Int64(local_token), head, tidx] = suffix * scale
+            cute.arch.fence_view_async_shared()
+            cute.arch.sync_warp()
+            tile_pipeline.consumer_release(consumer_state)
+            consumer_state.advance()
+            if cutlass.const_expr(subtile >= self.stages) and warp_idx == WarpRole.TMA_PRODUCER:
+                self._issue_subtile(
+                    tile_pipeline,
+                    producer_state,
+                    tma_atom,
+                    tGgD,
+                    tGsD,
+                    tile_base + Int32(subtile - self.stages),
+                )
+                producer_state.advance()
+
+    @cute.jit
+    def __call__(
+        self,
+        mD_cumulative: cute.Tensor,
+        mD_gate: cute.Tensor,
+        stream: cuda.CUstream,
+    ):
+        d_view = cute.make_tensor(
+            mD_cumulative.iterator,
+            cute.select(mD_cumulative.layout, mode=[1, 3, 2, 0]),
+        )
+        load_op = cpasync.CopyBulkTensorTileG2SOp()
+        tma_atom, tma_tensor = cpasync.make_tiled_tma_atom(
+            load_op,
+            d_view,
+            self._staged_layout(),
+            (self.tokens_per_stage, self.head_dim),
+        )
+        self.kernel.set_name_prefix(self.get_name())
+        self.kernel(mD_cumulative, mD_gate, tma_atom, tma_tensor).launch(
+            grid=(
+                cute.ceil_div(mD_cumulative.shape[1], self.chunk_size),
+                self.heads,
+                mD_cumulative.shape[0],
+            ),
+            block=(self.head_dim, 1, 1),
+            stream=stream,
+        )
+
+
+@jit_cache
+def _compile_plain_gate_bwd(heads: int, head_dim: int, use_int64_offsets: bool):
+    target = get_compile_target()
+    if target.device_type != "cuda" or target.capability is None or target.capability < (9, 0):
+        raise ValueError(f"plain gate backward requires SM90+, got target={target}")
+    op = PlainGateBwdOp(heads, head_dim, use_int64_offsets)
+    sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
+    batch = sym_int()
+    tokens = sym_int()
+    source = make_fake_strided_tensor(
+        Float32,
+        (batch, tokens, heads, head_dim),
+        stride_divisibility=TMA_ALIGNMENT_BYTES // 4,
+        assumed_align=TMA_ALIGNMENT_BYTES,
+        use_int64_strides=use_int64_offsets,
+    )
+    output = make_fake_compact_tensor(
+        Float32,
+        (batch, tokens, heads, head_dim),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=TMA_ALIGNMENT_BYTES,
+    )
+    return compile_tvm_ffi(op, source, output)
+
+
+def plain_gate_cumsum_dense_bwd_cute(d_cumulative: torch.Tensor) -> torch.Tensor:
+    """Apply the dense BT64 reverse cumsum with a TMA-staged CuTeDSL kernel."""
+    if d_cumulative.ndim != 4 or d_cumulative.shape[-1] != 128:
+        raise ValueError("d_cumulative must have shape [B, T, H, 128]")
+    if d_cumulative.dtype != torch.float32 or not d_cumulative.is_contiguous():
+        raise TypeError("d_cumulative must be contiguous float32")
+    if d_cumulative.shape[1] % 64:
+        raise ValueError("dense plain gate backward requires T divisible by 64")
+    with torch.cuda.device(d_cumulative.device):
+        output = torch.empty_like(d_cumulative)
+        compiled = _compile_plain_gate_bwd(
+            d_cumulative.shape[2],
+            d_cumulative.shape[3],
+            requires_int64_abi(d_cumulative, output),
+        )
+        compiled(d_cumulative, output)
+        return output
+
+
+__all__ = ["plain_gate_cumsum_dense_bwd_cute"]

--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_prefill_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_prefill_f16.py
@@ -23,7 +23,7 @@ entry ``chunk_kda_sm100``.
 Persistent kernel: the grid is the SM count and every warp role
 runs a tile-scheduler loop (``decode_work_item``); a tile is one (batch,
 head) sequence, or one split-K work item computing chunks ``[cstart, wend)``
-and writing O / checkpoints only for the owned ``[wstart, wend)`` (see
+and writing O only for the owned ``[wstart, wend)`` (see
 ``common/split_k.py``; warmup chunks rebuild the incoming state from
 zero).  All ring stage/phase bookkeeping runs on cumulative per-CTA chunk
 counters so pipelines flow seamlessly across tiles.
@@ -35,16 +35,15 @@ Pipeline (direct CUTLASS primitives, chunk_idx-size 16 KDA schedule):
   exp2(G), exp2(-G), stage final-token exp2(G) as exp2(G_last)
   super-MMA: KK/A/Neumann inverse (T_inv) + apply Beta
   tcgen05-MMA: state*K/state*Q/U solve/state update/O
-  store O, periodic state checkpoints, final state
+  store O and final state
 
 ABI: q `[T, HQ, DK]`, k `[T, HK, DK]`, v `[T, HV, DV]`, gate
 `[T, HO, DK]` fp32 (natural-log decay unless SAFE_GATE, which applies the
 safe-gate transform from raw gate + a_log/dt_bias), beta `[T, HO]` fp32
-post-sigmoid, cu_seqlens int32, states/checkpoints `[N, HO, DV, DK]` (VK, k
-contiguous).
+post-sigmoid, cu_seqlens int32, states `[N, HO, DV, DK]` (VK, k contiguous).
 GQA/GVA head broadcast follows repeat_interleave: source head =
-head_idx // (HO // H_x).  State presence, L2NORM, SAFE_GATE, checkpoints, and the
-head ratios are compile-time specializations.
+head_idx // (HO // H_x).  State presence, L2NORM, SAFE_GATE, and the head ratios
+are compile-time specializations.
 
 Warp assignments (16 warps = 512 threads):
   warps 0-7  : compute group 0 - Gate prefix scan + decay/restore operands
@@ -88,7 +87,7 @@ Requires the public CuTeDSL 4.7 API, including `cutlass.experimental.*`.
 """
 
 from dataclasses import dataclass
-from functools import lru_cache
+from functools import lru_cache, partial
 from typing import NamedTuple, Type
 
 import cuda.bindings.driver as cuda_driver
@@ -96,12 +95,13 @@ import cutlass
 import cutlass.experimental.cuda as cuda
 import cutlass.experimental.primitives as nvvm
 import cutlass.cute as cute
-from cutlass.cute.runtime import from_dlpack
+
+from attn_gym._backends.cute import compile_tvm_ffi
+from attn_gym._backends.cute.utils import requires_int64_abi
 
 from .common.split_k import ORDER_CAPACITY, ORDER_ELEMS, ORDER_THREADS, decode_work_item, order_body
 from .common.host import get_dtype
 from .compat import (
-    checkpoint_capacity_bound,
     current_device,
     get_device_properties,
     tensor_device_index,
@@ -109,9 +109,17 @@ from .compat import (
 )
 from .common.thd import (
     TENSOR_MAP_QWORDS,
-    emit_checkpoint_seq_descs,
     emit_seq_descs,
     emit_seq_load_descs,
+)
+from .common.tvm_ffi import (
+    make_compact_signature_tensor,
+    make_counter_signature,
+    make_cu_seqlens_signature,
+    make_strided_signature_tensor,
+    make_work_items_signature,
+    make_workspace_signature,
+    validate_cu_seqlens,
 )
 from .kda_prefill_config import CFG
 
@@ -186,15 +194,11 @@ class KdaBars(NamedTuple):
     mb_decay_super_done: MBarrier
     mb_k_restore_done: MBarrier
 
-    mb_state_acc_read_done: MBarrier
     mb_state_acc_done: MBarrier
     mb_tmem_done: MBarrier
 
     mb_o_tmastg_ready: MBarrier
     mb_o_tmastg_done: MBarrier
-
-    mb_checkpoint_tmastg_ready: MBarrier
-    mb_checkpoint_tmastg_done: MBarrier
 
     mb_sched_ready: MBarrier
     mb_sched_done: MBarrier
@@ -250,15 +254,10 @@ def make_kda_bars(cfg) -> KdaBars:
         mb_decay_tcgen05_done=MBarrier(alloc(cfg.smem_decay_stages), stages=cfg.smem_decay_stages, init_count=1, producer=Producer.MMA_COMMIT),
         mb_decay_super_done=MBarrier(alloc(cfg.smem_decay_stages), stages=cfg.smem_decay_stages, init_count=2 * WARP, producer=Producer.THREAD),
         mb_k_restore_done=MBarrier(alloc(cfg.smem_decay_stages), stages=cfg.smem_decay_stages, init_count=1, producer=Producer.MMA_COMMIT),
-        mb_state_acc_read_done=MBarrier(alloc(1), stages=1, init_count=CG1_THREADS, producer=Producer.THREAD),
         mb_state_acc_done=MBarrier(alloc(1), stages=1, init_count=1, producer=Producer.MMA_COMMIT),
         mb_tmem_done=MBarrier(alloc(1), stages=1, init_count=CG1_THREADS, producer=Producer.THREAD),
         mb_o_tmastg_ready=MBarrier(alloc(cfg.smem_o_stages), stages=cfg.smem_o_stages, init_count=CG1_THREADS, producer=Producer.THREAD),
         mb_o_tmastg_done=MBarrier(alloc(cfg.smem_o_stages), stages=cfg.smem_o_stages, init_count=WARP, producer=Producer.THREAD),
-        mb_checkpoint_tmastg_ready=MBarrier(
-            alloc(cfg.smem_checkpoint_stages), stages=cfg.smem_checkpoint_stages, init_count=CG1_THREADS, producer=Producer.THREAD
-        ),
-        mb_checkpoint_tmastg_done=MBarrier(alloc(cfg.smem_checkpoint_stages), stages=cfg.smem_checkpoint_stages, init_count=WARP, producer=Producer.THREAD),
         # The TMA warp publishes each scheduler slot. Every other warp elects one done arrival.
         mb_sched_ready=MBarrier(alloc(cfg.sched_stages), stages=cfg.sched_stages, init_count=1, producer=Producer.THREAD),
         mb_sched_done=MBarrier(
@@ -687,7 +686,6 @@ def tcgen05_mma_warp(
     u_inp_ptr = nvvm.make_tmem_ptr(tmem_base + cfg.tmem_u_inp_offset, cutlass.Int8)
     state_dst_ptr = nvvm.make_tmem_ptr(tmem_base + cfg.tmem_state_acc_offset, cutlass.Float32)
     state_inp_index = PipelineState.start(phase=0)
-    state_read_index = PipelineState.start(phase=0)
     y_inp_index = PipelineState.start(phase=0)
     u_inp_index = PipelineState.start(phase=0)
     qk_scale_index = PipelineState.start(phase=0)
@@ -834,10 +832,6 @@ def tcgen05_mma_warp(
                 bars.mb_decay_tcgen05_done[decay_stage].arrive(cta_group=1)
 
             # ---- S decay = S(T) @ diag(exp2(G_last)) ---------
-            if cutlass.const_expr(cfg.enable_checkpoints):
-                if have_state:
-                    bars.mb_state_acc_read_done.wait(state_read_index.phase)
-                    state_read_index = advance(state_read_index, 1)
             if have_state:
                 desc_diag = sState_scale_diag_stage.desc()
                 for k_block in cutlass.range_constexpr(cfg.d_k // 16):
@@ -916,29 +910,12 @@ def epilogue_warp(
     sO_raw,
     sIntermediate_raw,
     sQ_decay_raw,
-    sCheckpoint_raw,
     desc_o_base,
-    desc_checkpoint_base,
-    checkpoint_every_n_tokens,
     bars,
 ) -> None:
-    """Epilogue warp role (warp 15): persistent scheduler loop computing the
-    causal A tile via register MMA and draining the O/checkpoint TMA stores."""
+    """Epilogue warp role (warp 15): compute causal A and drain O stores."""
     elect_one = nvvm.elect_sync()
     nvvm.setmaxregister(cfg.num_regs_other, nvvm.SetMaxRegisterAction.DECREASE)
-    if cutlass.const_expr(cfg.enable_checkpoints):
-        sCheckpoint_tma = SmemTile(
-            base=sCheckpoint_raw,
-            elems_per_stage=(cfg.d_k * cfg.d_v),
-            stages=cfg.smem_checkpoint_stages,
-            leading_byte_offset=0,
-            stride_byte_offset=0,
-            layout=0,
-            tma_loads_per_tile=(cfg.d_v // 64),
-            tma_granu_elems=64,
-            tma_subtile_stride_elems=cfg.d_k * 64,
-        )
-    checkpoint_ready_index = PipelineState.start(phase=0)
     sO_tma = SmemTile(
         base=sO_raw,
         elems_per_stage=(cfg.b_t * cfg.d_v),
@@ -974,26 +951,9 @@ def epilogue_warp(
         head_o = head_idx
         o_slot = batch_idx * cutlass.Int32(TENSOR_MAP_QWORDS)
         desc_o_slot = (desc_o_base + o_slot).tospace(cutlass.AddressSpace.generic)
-        if cutlass.const_expr(cfg.enable_checkpoints):
-            desc_checkpoint_slot = (desc_checkpoint_base + o_slot).tospace(cutlass.AddressSpace.generic)
-            checkpoint_chunks = checkpoint_every_n_tokens // cutlass.Int32(cfg.b_t)
-            checkpoint_quot = (cstart + cutlass.Int32(1)) // checkpoint_chunks
-            checkpoint_mod = (cstart + cutlass.Int32(1)) % checkpoint_chunks
-            if elect_one:
-                tma_tensormap_acquire(desc_checkpoint_slot)
         if elect_one:
             tma_tensormap_acquire(desc_o_slot)
         num_chunks_tile = wend - cstart
-        if cutlass.const_expr(cfg.enable_checkpoints):
-            if num_chunks_tile > 0 and wstart == 0:
-                checkpoint_stage = checkpoint_ready_index.idx
-                bars.mb_checkpoint_tmastg_ready[checkpoint_stage].wait(checkpoint_ready_index.phase)
-                checkpoint_ready_index = advance(checkpoint_ready_index, cfg.smem_checkpoint_stages)
-                checkpoint_slice = tma_slice_runtime_desc(desc_checkpoint_slot, cutlass.Int32(0), cutlass.Int32(0), cutlass.Int32(0), head_o)
-                tma_store_tile(sCheckpoint_tma[checkpoint_stage], checkpoint_slice, acquire=False)
-                tma_store_commit()
-                tma_store_wait(0)
-                bars.mb_checkpoint_tmastg_done[checkpoint_stage].arrive()
         for local_chunk_idx in cutlass.range(num_chunks_tile, unroll=1):
             chunk_idx = cstart + local_chunk_idx
             cum_chunk = cum_chunk_base + local_chunk_idx
@@ -1071,54 +1031,18 @@ def epilogue_warp(
             bars.mb_decay_super_done[decay_stage].arrive()
             qk_scale_index = advance(qk_scale_index, cfg.qk_scale_ready_stages)
 
-            # ---- checkpoint + O drain: checkpoint stores first (CG1 stages the checkpoint before O) -------------
+            # ---- O drain ---------------------------------------------------------
             if local_chunk_idx > 0:
                 output_chunk = chunk_idx - cutlass.Int32(1)
                 output_chunk_start = output_chunk * cfg.b_t
                 o_stage = (cum_chunk - cutlass.Int32(1)) % cfg.smem_o_stages
-                did_checkpoint = cutlass.Int32(0)
-                checkpoint_stage = cutlass.Int32(0)
-                if cutlass.const_expr(cfg.enable_checkpoints):
-                    # ---- checkpoint store ----------------------------------------
-                    do_checkpoint = checkpoint_mod == 0
-                    do_checkpoint = do_checkpoint and chunk_idx >= wstart
-                    checkpoint_stage = checkpoint_ready_index.idx
-                    if do_checkpoint:
-                        bars.mb_checkpoint_tmastg_ready[checkpoint_ready_index.idx].wait(checkpoint_ready_index.phase)
-                        checkpoint_ready_index = advance(checkpoint_ready_index, cfg.smem_checkpoint_stages)
-                        checkpoint_entry = checkpoint_quot
-                        checkpoint_slice = tma_slice_runtime_desc(desc_checkpoint_slot, cutlass.Int32(0), cutlass.Int32(0), checkpoint_entry, head_o)
-                        tma_store_tile(sCheckpoint_tma[checkpoint_stage], checkpoint_slice, acquire=False)
-                        tma_store_commit()
-                        did_checkpoint = cutlass.Int32(1)
-                    checkpoint_mod = checkpoint_mod + cutlass.Int32(1)
-                    if checkpoint_mod == checkpoint_chunks:
-                        checkpoint_mod = cutlass.Int32(0)
-                        checkpoint_quot = checkpoint_quot + cutlass.Int32(1)
                 bars.mb_o_tmastg_ready[o_stage].wait(((cum_chunk - cutlass.Int32(1)) // cfg.smem_o_stages) % 2)
                 o_slice = tma_slice_runtime_desc(desc_o_slot, cutlass.Int32(0), head_o, output_chunk_start)
-                did_o = cutlass.Int32(0)
                 if output_chunk >= wstart:
                     tma_store_tile(sO_tma[o_stage], o_slice, acquire=False)
                     tma_store_commit()
-                    did_o = cutlass.Int32(1)
-                if cutlass.const_expr(cfg.enable_checkpoints):
-                    if did_checkpoint == 1 and did_o == 1:
-                        tma_store_wait(1)
-                        bars.mb_checkpoint_tmastg_done[checkpoint_stage].arrive()
-                        tma_store_wait(0)
-                        bars.mb_o_tmastg_done[o_stage].arrive()
-                    if did_checkpoint == 1 and did_o == 0:
-                        tma_store_wait(0)
-                        bars.mb_checkpoint_tmastg_done[checkpoint_stage].arrive()
-                        bars.mb_o_tmastg_done[o_stage].arrive()
-                    if did_checkpoint == 0:
-                        if did_o == 1:
-                            tma_store_wait(0)
-                        bars.mb_o_tmastg_done[o_stage].arrive()
-                else:
-                    tma_store_wait(0)
-                    bars.mb_o_tmastg_done[o_stage].arrive()
+                tma_store_wait(0)
+                bars.mb_o_tmastg_done[o_stage].arrive()
 
         # ---- last computed chunk drain (always owned: it is wend - 1) ------------
         if num_chunks_tile > 0:
@@ -1523,8 +1447,6 @@ def compute1_warp_group(
     sO_raw,
     sBeta_raw,
     sV_raw,
-    sCheckpoint_raw,
-    checkpoint_every_n_tokens,
     scale,
     bars,
 ) -> None:
@@ -1532,8 +1454,6 @@ def compute1_warp_group(
     value-side TMEM staging, output drain, and state stores."""
     nvvm.setmaxregister(cfg.num_regs_compute_group_1, nvvm.SetMaxRegisterAction.INCREASE)
     sO_ptr = sO_raw.data_ptr()
-    sCheckpoint_ptr = sCheckpoint_raw.data_ptr() if cutlass.const_expr(cfg.enable_checkpoints) else sO_raw.data_ptr()
-    checkpoint_done_index = PipelineState.start(phase=1)
     nvvm.barrier_cta_sync(cfg.tmem_lifecycle_barrier_id, thread_count=cfg.tmem_user_threads)
     tmem_base = tmem_base_slot.load()
     tmem_col = tmem_base & 0xFFFF
@@ -1565,10 +1485,6 @@ def compute1_warp_group(
         + ov_token_coord * 64
         + swizzle_xor_128b(ov_token_coord, (value_dim_base + 16 + ov_col_coord) % 64, elem_bytes=2)
     )
-    checkpoint_swz_off0 = (value_dim_base + ov_col_coord) // 64 * (cfg.d_k * 64)
-    checkpoint_swz_col0 = (value_dim_base + ov_col_coord) % 64
-    checkpoint_swz_off = (value_dim_base + 16 + ov_col_coord) // 64 * (cfg.d_k * 64)
-    checkpoint_swz_col = (value_dim_base + 16 + ov_col_coord) % 64
     state_k_acc_index = PipelineState.start(phase=0)
     u_acc_index = PipelineState.start(phase=0)
     o_acc_index = PipelineState.start(phase=0)
@@ -1579,7 +1495,7 @@ def compute1_warp_group(
     sched_state = PipelineState.start(phase=0)
     tile_idx = cutlass.Int32(bidx)
     while tile_idx < total_tiles:
-        batch_idx, head_idx, batch_start, batch_end, seqlen_b, num_chunks_b, wstart, wend, cstart, cend = decode_work_item(cfg, tile_idx, mWorkItems)
+        batch_idx, head_idx, batch_start, batch_end, seqlen_b, num_chunks_b, _wstart, wend, cstart, cend = decode_work_item(cfg, tile_idx, mWorkItems)
         head_o = head_idx
         num_chunks_tile = wend - cstart
 
@@ -1636,47 +1552,6 @@ def compute1_warp_group(
                     )
                 nvvm.tcgen05_wait("store")
                 bars.mb_state_inp_ready.arrive()
-                if cutlass.const_expr(cfg.enable_checkpoints):
-                    if wstart == 0:
-                        checkpoint_stage = checkpoint_done_index.idx
-                        bars.mb_checkpoint_tmastg_done[checkpoint_stage].wait(checkpoint_done_index.phase)
-                        checkpoint_done_index = advance(checkpoint_done_index, cfg.smem_checkpoint_stages)
-                        checkpoint_stage_base = checkpoint_stage * (cfg.d_k * cfg.d_v)
-                        for sub in cutlass.range_constexpr(cfg.d_k // 16):
-                            for g in cutlass.range_constexpr(2):
-                                packs = tuple(
-                                    fp32_to_fp16(state_vecs[sub][g * 8 + 2 * t], state_vecs[sub][g * 8 + 2 * t + 1], dtype=cfg.io_dtype) for t in range(4)
-                                )
-                                dk = sub * 16 + g * 8
-                                checkpoint_addr = (
-                                    checkpoint_stage_base + (dk // 64) * (cfg.d_v * 64) + value_dim * 64 + swizzle_xor_128b(value_dim, dk % 64, elem_bytes=2)
-                                )
-                                (sCheckpoint_ptr + checkpoint_addr).store(
-                                    cutlass.Vector.from_elements(packs, cutlass.Int32).bitcast(cfg.io_dtype), alignment=16
-                                )
-                        nvvm.tcgen05_wait("load")
-                        nvvm.fence_proxy("async.shared", space="cta")
-                        bars.mb_checkpoint_tmastg_ready[checkpoint_stage].arrive()
-                    bars.mb_state_acc_read_done.arrive()
-
-            if cutlass.const_expr(cfg.enable_checkpoints and mState_init is None):
-                if wstart == 0:
-                    checkpoint_stage = checkpoint_done_index.idx
-                    bars.mb_checkpoint_tmastg_done[checkpoint_stage].wait(checkpoint_done_index.phase)
-                    checkpoint_done_index = advance(checkpoint_done_index, cfg.smem_checkpoint_stages)
-                    checkpoint_stage_base = checkpoint_stage * (cfg.d_k * cfg.d_v)
-                    zero_packs = tuple(cutlass.Int32(0) for _ in range(4))
-                    for sub in cutlass.range_constexpr(cfg.d_k // 16):
-                        for g in cutlass.range_constexpr(2):
-                            dk = sub * 16 + g * 8
-                            checkpoint_addr = (
-                                checkpoint_stage_base + (dk // 64) * (cfg.d_v * 64) + value_dim * 64 + swizzle_xor_128b(value_dim, dk % 64, elem_bytes=2)
-                            )
-                            (sCheckpoint_ptr + checkpoint_addr).store(
-                                cutlass.Vector.from_elements(zero_packs, cutlass.Int32).bitcast(cfg.io_dtype), alignment=16
-                            )
-                    nvvm.fence_proxy("async.shared", space="cta")
-                    bars.mb_checkpoint_tmastg_ready[checkpoint_stage].arrive()
 
             # ---- Y staging: Y = Beta * (V - state*K) -----------------------------
             bars.mb_v_ready[raw_bar_index.idx].wait(raw_bar_index.phase)
@@ -1775,38 +1650,23 @@ def compute1_warp_group(
             nvvm.tcgen05_wait("store")
             u_acc_index = advance(u_acc_index, 1)
             bars.mb_u_inp_ready.arrive()
-            if cutlass.const_expr(cfg.enable_checkpoints):
-                bars.mb_state_acc_done.wait(state_upd_index.phase)
-                state_upd_index = advance(state_upd_index, 1)
 
             raw_index = advance(raw_index, cfg.smem_raw_stages)
             raw_bar_index = advance(raw_bar_index, cfg.smem_raw_bar_stages)
 
-        if cutlass.const_expr(cfg.enable_checkpoints):
-            cg1_checkpoint_chunks = checkpoint_every_n_tokens // cutlass.Int32(cfg.b_t)
-            cg1_checkpoint_mod = (cstart + cutlass.Int32(1)) % cg1_checkpoint_chunks
         for local_chunk_idx in cutlass.range(1, num_chunks_tile, 1, unroll=1):
-            chunk_idx = cstart + local_chunk_idx
             cum_chunk = cum_chunk_base + local_chunk_idx
             sV_ptr = sV_raw.data_ptr() + raw_index.idx * (cfg.d_v * cfg.b_t)
             sBeta_ptr = sBeta_raw.data_ptr() + raw_bar_index.idx * cfg.b_t
 
-            prev_output_chunk = chunk_idx - cutlass.Int32(1)
             prev_cum_chunk = cum_chunk - cutlass.Int32(1)
             prev_o_stage = prev_cum_chunk % cfg.smem_o_stages
             prev_q_state_acc_stage = prev_cum_chunk % cfg.tmem_q_state_acc_stages
             prev_o_stage_base = prev_o_stage * (cfg.b_t * cfg.d_v)
-            do_checkpoint = False
-            if cutlass.const_expr(cfg.enable_checkpoints):
-                do_checkpoint = cg1_checkpoint_mod == 0
-                cg1_checkpoint_mod = cg1_checkpoint_mod + cutlass.Int32(1)
-                cg1_checkpoint_mod = cutlass.Int32(0) if cg1_checkpoint_mod == cg1_checkpoint_chunks else cg1_checkpoint_mod
-                do_checkpoint = do_checkpoint and chunk_idx >= wstart
 
             # ---- state repack: acc TMEM -> packed b16 TMEM ----------------------
-            if cutlass.const_expr(not cfg.enable_checkpoints):
-                bars.mb_state_acc_done.wait(state_upd_index.phase)
-                state_upd_index = advance(state_upd_index, 1)
+            bars.mb_state_acc_done.wait(state_upd_index.phase)
+            state_upd_index = advance(state_upd_index, 1)
             state_vecs = []
             for sub in cutlass.range_constexpr(cfg.d_k // 16):
                 state_vecs.append(nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(row_addr + state_col_id + sub * 16, cutlass.Float32), num=16))
@@ -1823,30 +1683,6 @@ def compute1_warp_group(
                 )
             nvvm.tcgen05_wait("store")
             bars.mb_state_inp_ready.arrive()
-
-            # ---- checkpoint store -----------------------------------------------
-            if cutlass.const_expr(cfg.enable_checkpoints):
-                if do_checkpoint:
-                    checkpoint_stage = checkpoint_done_index.idx
-                    bars.mb_checkpoint_tmastg_done[checkpoint_stage].wait(checkpoint_done_index.phase)
-                    checkpoint_done_index = advance(checkpoint_done_index, cfg.smem_checkpoint_stages)
-                    checkpoint_stage_base = checkpoint_stage * (cfg.d_k * cfg.d_v)
-                    for sub in cutlass.range_constexpr(cfg.d_k // 16):
-                        for g in cutlass.range_constexpr(2):
-                            packs = tuple(
-                                fp32_to_fp16(state_vecs[sub][g * 8 + 2 * t], state_vecs[sub][g * 8 + 2 * t + 1], dtype=cfg.io_dtype) for t in range(4)
-                            )
-                            dk = sub * 16 + g * 8
-                            checkpoint_addr = (
-                                checkpoint_stage_base + (dk // 64) * (cfg.d_v * 64) + value_dim * 64 + swizzle_xor_128b(value_dim, dk % 64, elem_bytes=2)
-                            )
-                            (sCheckpoint_ptr + checkpoint_addr).store(cutlass.Vector.from_elements(packs, cutlass.Int32).bitcast(cfg.io_dtype), alignment=16)
-                    nvvm.tcgen05_wait("load")
-                    bars.mb_state_acc_read_done.arrive()
-                    nvvm.fence_proxy("async.shared", space="cta")
-                    bars.mb_checkpoint_tmastg_ready[checkpoint_stage].arrive()
-                else:
-                    bars.mb_state_acc_read_done.arrive()
 
             bars.mb_o_acc_ready.wait(o_acc_index.phase)
             o_acc_index = advance(o_acc_index, 1)
@@ -1970,16 +1806,12 @@ def compute1_warp_group(
             u_acc_index = advance(u_acc_index, 1)
             bars.mb_u_inp_ready.arrive()
 
-            if cutlass.const_expr(cfg.enable_checkpoints):
-                bars.mb_state_acc_done.wait(state_upd_index.phase)
-                state_upd_index = advance(state_upd_index, 1)
             raw_index = advance(raw_index, cfg.smem_raw_stages)
             raw_bar_index = advance(raw_bar_index, cfg.smem_raw_bar_stages)
 
         if num_chunks_tile > 0:
-            if cutlass.const_expr(not cfg.enable_checkpoints):
-                bars.mb_state_acc_done.wait(state_upd_index.phase)
-                state_upd_index = advance(state_upd_index, 1)
+            bars.mb_state_acc_done.wait(state_upd_index.phase)
+            state_upd_index = advance(state_upd_index, 1)
             last_cum_chunk = cum_chunk_base + num_chunks_tile - cutlass.Int32(1)
             final_o_stage = last_cum_chunk % cfg.smem_o_stages
             final_q_state_acc_stage = last_cum_chunk % cfg.tmem_q_state_acc_stages
@@ -2058,8 +1890,9 @@ def compute1_warp_group(
 class KdaPrefillOp:
     """Compile and launch one static mega KDA prefill configuration."""
 
-    def __init__(self, cfg: "KdaCfg"):
+    def __init__(self, cfg: "KdaCfg", use_int64_offsets: bool = False):
         self.cfg = cfg
+        self.use_int64_offsets = use_int64_offsets
 
     def get_name(self) -> str:
         cfg = self.cfg
@@ -2076,9 +1909,9 @@ class KdaPrefillOp:
             f"_{cfg.state_dtype.__name__.lower()}_h{cfg.n_heads_out}"
             f"_q{cfg.q_ratio}_k{cfg.k_ratio}_v{cfg.v_ratio}"
             f"_i{int(cfg.use_initial_state)}f{int(cfg.store_final_state)}"
-            f"c{int(cfg.enable_checkpoints)}l{int(cfg.l2norm)}"
+            f"l{int(cfg.l2norm)}"
             f"g{int(cfg.safe_gate)}b{int(cfg.beta_sigmoid)}d{int(cfg.dyn_sched)}"
-            f"_sm{cfg.max_active_clusters}{gate_scale}"
+            f"_sm{cfg.max_active_clusters}_i64{int(self.use_int64_offsets)}{gate_scale}"
         )
 
     @cute.jit
@@ -2099,7 +1932,6 @@ class KdaPrefillOp:
         work_count: cute.Tensor | None,
         sched_ctr: cute.Tensor | None,
         tensormap_workspace: cute.Tensor,
-        checkpoint_every_n_tokens: cutlass.Int32,
         scale: cutlass.Float32,
         stream,
     ) -> None:
@@ -2126,7 +1958,6 @@ class KdaPrefillOp:
             work_count,
             sched_ctr,
             scale,
-            checkpoint_every_n_tokens,
         ).launch(
             grid=(cfg.max_active_clusters, 1, 1),
             block=(cfg.threads_per_cta, 1, 1),
@@ -2155,7 +1986,6 @@ def kernel(
     mCount: cute.Tensor,
     mSched: cute.Tensor | None,
     scale: cutlass.Float32,
-    checkpoint_every_n_tokens: cutlass.Int32,
 ) -> None:
     """BT=16 KDA forward kernel (persistent, tile-scheduled)."""
 
@@ -2190,7 +2020,6 @@ def kernel(
     desc_v_base = desc_base_words + cutlass.Int32(2) * arr_words
     desc_gate_base = desc_base_words + cutlass.Int32(3) * arr_words
     desc_o_base = desc_base_words + cutlass.Int32(4) * arr_words
-    desc_checkpoint_base = desc_base_words + cutlass.Int32(5) * arr_words
 
     # Buffers are declaration-ordered and intentionally non-aliased.
     SMEM = cutlass.AddressSpace.smem
@@ -2214,11 +2043,6 @@ def kernel(
         alignment=cfg.buffer_align_bytes,
     )
     sBeta_raw = cutlass.Array(cutlass.Float32, cfg.beta_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
-    sCheckpoint_raw = (
-        cutlass.Array(cfg.io_dtype, cfg.smem_checkpoint_stages * cfg.d_k * cfg.d_v, space=SMEM, alignment=cfg.buffer_align_bytes)
-        if cutlass.const_expr(cfg.enable_checkpoints)
-        else sO_raw
-    )
     sK_decay = SmemTile(
         base=sK_decay_raw,
         elems_per_stage=(cfg.d_k * cfg.b_t),
@@ -2312,11 +2136,6 @@ def kernel(
             for stage in cutlass.range_constexpr(cfg.sched_stages):
                 bars.mb_sched_ready[stage].init()
                 bars.mb_sched_done[stage].init()
-            if cutlass.const_expr(cfg.enable_checkpoints):
-                for stage in cutlass.range_constexpr(cfg.smem_checkpoint_stages):
-                    bars.mb_checkpoint_tmastg_ready[stage].init()
-                    bars.mb_checkpoint_tmastg_done[stage].init()
-                bars.mb_state_acc_read_done.init()
     diag_zero = cfg.io_dtype(0.0)
     for diag_idx in cutlass.range(tidx, cfg.state_scale_diag_cosize, cfg.threads_per_cta, unroll=1):
         sState_scale_diag_raw[diag_idx] = diag_zero
@@ -2392,10 +2211,7 @@ def kernel(
             sO_raw,
             sIntermediate_raw,
             sQ_decay_raw,
-            sCheckpoint_raw,
             desc_o_base,
-            desc_checkpoint_base,
-            checkpoint_every_n_tokens,
             bars,
         )
     elif warp_idx >= cfg.compute_group_0_warp_ids[0] and warp_idx <= cfg.compute_group_0_warp_ids[-1]:
@@ -2442,8 +2258,6 @@ def kernel(
             sO_raw,
             sBeta_raw,
             sV_raw,
-            sCheckpoint_raw,
-            checkpoint_every_n_tokens,
             scale,
             bars,
         )
@@ -2460,7 +2274,6 @@ class KdaCfg:
     state_dtype: Type[cutlass.Numeric]
     use_initial_state: bool
     store_final_state: bool
-    enable_checkpoints: bool
     l2norm: bool
     safe_gate: bool
     gate_scale_log2: float
@@ -2500,7 +2313,6 @@ class KdaCfg:
     smem_raw_stages: int = CFG.SMEM_RAW_STAGES
     smem_raw_bar_stages: int = 0  # ready/beta-ring mbar depth: raw rounded up to even (CG0 ping-pong parity)
     smem_o_stages: int = CFG.SMEM_O_STAGES
-    smem_checkpoint_stages: int = 1
     smem_decay_stages: int = CFG.SMEM_DECAY_STAGES
     smem_intermediate_stages: int = CFG.SMEM_INTERMEDIATE_STAGES
     smem_state_scale_diag_stages: int = CFG.SMEM_STATE_SCALE_DIAG_STAGES
@@ -2543,7 +2355,6 @@ def build_cfg(
     *,
     use_initial_state: bool,
     store_final_state: bool,
-    enable_checkpoints: bool,
     l2norm: bool,
     safe_gate: bool,
     gate_scale_log2: float,
@@ -2564,7 +2375,6 @@ def build_cfg(
         state_dtype=state_dtype,
         use_initial_state=use_initial_state,
         store_final_state=store_final_state,
-        enable_checkpoints=enable_checkpoints,
         l2norm=l2norm,
         safe_gate=safe_gate,
         gate_scale_log2=gate_scale_log2,
@@ -2576,9 +2386,6 @@ def build_cfg(
         max_active_clusters=max_active_clusters,
         dyn_sched=dyn_sched,
     )
-    if enable_checkpoints:
-        cfg.smem_raw_stages = 5
-        cfg.smem_checkpoint_stages = 2
     cfg.smem_raw_bar_stages = cfg.smem_raw_stages + (cfg.smem_raw_stages % 2)
     role_ids = (
         *cfg.compute_group_0_warp_ids,
@@ -2646,7 +2453,7 @@ def build_cfg(
     return cfg
 
 
-TENSORMAP_DESC_ARRAYS = 6  # per-batch runtime TMA descriptors: Q, K, V, Gate, O, state_checkpoints
+TENSORMAP_DESC_ARRAYS = 5  # per-batch runtime TMA descriptors: Q, K, V, Gate, O
 TENSORMAP_STATIC_SLOTS = 0
 
 
@@ -2658,7 +2465,6 @@ def build_descs_body(
     base_v,
     base_gate,
     base_o,
-    base_checkpoint,
     desc_ws: cute.Tensor,
     cu_seqlens: cute.Tensor,
     q: cute.Tensor,
@@ -2666,15 +2472,12 @@ def build_descs_body(
     v: cute.Tensor,
     gate: cute.Tensor,
     o: cute.Tensor,
-    state_checkpoints: cute.Tensor | None,
     n_batch: cutlass.Int32,
-    q_token_stride: cutlass.Int32,
-    k_token_stride: cutlass.Int32,
-    v_token_stride: cutlass.Int32,
-    gate_token_stride: cutlass.Int32,
-    o_token_stride: cutlass.Int32,
-    checkpoint_entry_stride: cutlass.Int32,
-    checkpoint_every_n: cutlass.Int32,
+    q_token_stride: cutlass.Int64,
+    k_token_stride: cutlass.Int64,
+    v_token_stride: cutlass.Int64,
+    gate_token_stride: cutlass.Int64,
+    o_token_stride: cutlass.Int64,
 ) -> None:
     """Per-batch descriptor-array build, one warp per array. Runs inside the
     prologue kernel after its order pass; warps past the array count fall
@@ -2685,7 +2488,6 @@ def build_descs_body(
     desc_v_arr = cute.make_tensor(desc_ws.iterator + 2 * arr_words, cute.make_layout((arr_words,), stride=(1,)))
     desc_gate_arr = cute.make_tensor(desc_ws.iterator + 3 * arr_words, cute.make_layout((arr_words,), stride=(1,)))
     desc_o_arr = cute.make_tensor(desc_ws.iterator + 4 * arr_words, cute.make_layout((arr_words,), stride=(1,)))
-    desc_checkpoint_arr = cute.make_tensor(desc_ws.iterator + 5 * arr_words, cute.make_layout((arr_words,), stride=(1,)))
 
     if widx == 0:
         if nvvm.elect_sync():
@@ -2737,13 +2539,6 @@ def build_descs_body(
         if nvvm.elect_sync():
             emit_seq_descs(base_o, desc_o_arr, cu_seqlens, o, n_batch, o_token_stride, 2)
             nvvm.fence_proxy_release(nvvm.MemScope.GPU, from_proxy=nvvm.Proxy.GENERIC, to_proxy=nvvm.Proxy.TENSORMAP)
-    if cutlass.const_expr(state_checkpoints is not None):
-        if widx == 5:
-            if nvvm.elect_sync():
-                emit_checkpoint_seq_descs(
-                    base_checkpoint, desc_checkpoint_arr, cu_seqlens, state_checkpoints, n_batch, checkpoint_entry_stride, checkpoint_every_n, 2
-                )
-                nvvm.fence_proxy_release(nvvm.MemScope.GPU, from_proxy=nvvm.Proxy.GENERIC, to_proxy=nvvm.Proxy.TENSORMAP)
 
 
 @cute.kernel
@@ -2756,7 +2551,6 @@ def prologue_kernel(
     base_v: cutlass.GridConstant[cuda.tensor_map.TensorMap],
     base_gate: cutlass.GridConstant[cuda.tensor_map.TensorMap],
     base_o: cutlass.GridConstant[cuda.tensor_map.TensorMap],
-    base_checkpoint: cutlass.GridConstant[cuda.tensor_map.TensorMap],
     desc_ws: cute.Tensor,
     cu_seqlens: cute.Tensor,
     q: cute.Tensor,
@@ -2764,19 +2558,16 @@ def prologue_kernel(
     v: cute.Tensor,
     gate: cute.Tensor,
     o: cute.Tensor,
-    state_checkpoints: cute.Tensor | None,
     mStaging: cute.Tensor | None,
     mCount: cute.Tensor,
     mWorkItems: cute.Tensor,
     mSched: cute.Tensor | None,
     n_batch: cutlass.Int32,
-    q_token_stride: cutlass.Int32,
-    k_token_stride: cutlass.Int32,
-    v_token_stride: cutlass.Int32,
-    gate_token_stride: cutlass.Int32,
-    o_token_stride: cutlass.Int32,
-    checkpoint_entry_stride: cutlass.Int32,
-    checkpoint_every_n: cutlass.Int32,
+    q_token_stride: cutlass.Int64,
+    k_token_stride: cutlass.Int64,
+    v_token_stride: cutlass.Int64,
+    gate_token_stride: cutlass.Int64,
+    o_token_stride: cutlass.Int64,
 ) -> None:
     """Single-CTA prologue: LPT-order the work-item table and zero the sched
     rings via :func:`order_body`, then build the per-batch TMA-descriptor
@@ -2814,7 +2605,6 @@ def prologue_kernel(
         base_v,
         base_gate,
         base_o,
-        base_checkpoint,
         desc_ws,
         cu_seqlens,
         q,
@@ -2822,15 +2612,12 @@ def prologue_kernel(
         v,
         gate,
         o,
-        state_checkpoints,
         n_batch,
         q_token_stride,
         k_token_stride,
         v_token_stride,
         gate_token_stride,
         o_token_stride,
-        checkpoint_entry_stride,
-        checkpoint_every_n,
     )
 
 
@@ -2845,19 +2632,15 @@ def prologue(
     v: cute.Tensor,
     gate: cute.Tensor,
     o: cute.Tensor,
-    state_checkpoints: cute.Tensor | None,
     cu_seqlens: cute.Tensor,
     work_item_staging: cute.Tensor | None,
     work_count: cute.Tensor,
     work_items: cute.Tensor,
     sched_ctr: cute.Tensor | None,
     tensormap_workspace: cute.Tensor,
-    checkpoint_every_n: cutlass.Int32,
     stream: cuda_driver.CUstream,
 ):
-    """One-launch prologue: LPT-order the work items and build the 6
-    per-(batch, head) TMA-descriptor arrays (q, k, v, gate, o,
-    state_checkpoints) into ``tensormap_workspace``."""
+    """Order work items and build per-sequence Q/K/V/gate/O descriptors."""
     h_q = q.shape[1]
     h_k = k.shape[1]
     h_v = v.shape[1]
@@ -2882,16 +2665,6 @@ def prologue(
     base_gate = cuda.create_tensor_map_tiled_from_view(gate_headed, box_dims=(32, 1, b_t), stride_order=(0, 1, 2), swizzle=swz)
     base_o = cuda.create_tensor_map_tiled_from_view(o_headed, box_dims=(tma_granu_elems, 1, b_t), stride_order=(0, 1, 2), swizzle=swz)
 
-    base_checkpoint = base_o
-    if cutlass.const_expr(state_checkpoints is not None):
-        checkpoint_view = cute.make_tensor(
-            state_checkpoints.iterator,
-            cute.make_layout(
-                (state_checkpoints.shape[3], state_checkpoints.shape[2], state_checkpoints.shape[0], n_heads_out),
-                stride=(state_checkpoints.stride[3], state_checkpoints.stride[2], state_checkpoints.stride[0], state_checkpoints.stride[1]),
-            ),
-        )
-        base_checkpoint = cuda.create_tensor_map_tiled_from_view(checkpoint_view, box_dims=(tma_granu_elems, d_k, 1, 1), stride_order=(0, 1, 2, 3), swizzle=swz)
     prologue_kernel(
         order_gen,
         has_sched,
@@ -2901,7 +2674,6 @@ def prologue(
         base_v,
         base_gate,
         base_o,
-        base_checkpoint,
         tensormap_workspace,
         cu_seqlens,
         q,
@@ -2909,19 +2681,16 @@ def prologue(
         v,
         gate,
         o,
-        state_checkpoints,
         work_item_staging,
         work_count,
         work_items,
         sched_ctr,
         cutlass.Int32(batch_size),
-        cutlass.Int32(q.stride[0]),
-        cutlass.Int32(k.stride[0]),
-        cutlass.Int32(v.stride[0]),
-        cutlass.Int32(gate.stride[0]),
-        cutlass.Int32(o.stride[0]),
-        cutlass.Int32(state_checkpoints.stride[0] if state_checkpoints is not None else 0),
-        checkpoint_every_n,
+        cutlass.Int64(q.stride[0]),
+        cutlass.Int64(k.stride[0]),
+        cutlass.Int64(v.stride[0]),
+        cutlass.Int64(gate.stride[0]),
+        cutlass.Int64(o.stride[0]),
     ).launch(grid=(1, 1, 1), block=(ORDER_THREADS, 1, 1), stream=stream)
 
 
@@ -2932,19 +2701,18 @@ def prologue(
 def get_compiled_cache(
     io_dtype_str: str,
     state_dtype_str: str,
-    cu_dtype_str: str,
     HQ: int,
     HK: int,
     HV: int,
     use_initial_state: bool,
     store_final_state: bool,
-    enable_checkpoints: bool,
     l2norm: bool,
     safe_gate: bool,
     gate_lower_bound: float,
     beta_sigmoid: bool,
     dyn_sched: bool,
     order_gen: bool,
+    use_int64_offsets: bool,
     device_index: int,
     device_major: int,
     device_minor: int,
@@ -2959,7 +2727,6 @@ def compile(
     state_dtype,
     use_initial_state: bool,
     store_final_state: bool,
-    enable_checkpoints: bool,
     l2norm: bool,
     safe_gate: bool,
     gate_scale_log2: float,
@@ -2969,34 +2736,17 @@ def compile(
     v_ratio: int,
     n_heads_out: int,
     dyn_sched: bool = False,
+    use_int64_offsets: bool = False,
     *,
     num_sm: int,
-    q_cute,
-    k_cute,
-    v_cute,
-    gate_cute,
-    a_log_cute,
-    dt_bias_cute,
-    beta_cute,
-    cu_seqlens_cute,
-    state_in_cute,
-    o_cute,
-    state_out_cute,
-    work_items_cute=None,
-    work_count_cute=None,
-    sched_ctr_cute=None,
-    tensormap_ws_cute,
-    checkpoint_every_n_tokens,
-    scale,
-    stream,
+    scale: float,
 ):
-    """JIT-compile the chunked KDA prefill kernel for one static config."""
+    """JIT-compile one fake-tensor TVM-FFI prefill signature."""
     cfg = build_cfg(
         io_dtype,
         state_dtype,
         use_initial_state=use_initial_state,
         store_final_state=store_final_state,
-        enable_checkpoints=enable_checkpoints,
         l2norm=l2norm,
         safe_gate=safe_gate,
         gate_scale_log2=gate_scale_log2,
@@ -3008,30 +2758,47 @@ def compile(
         max_active_clusters=num_sm,
         dyn_sched=dyn_sched,
     )
+    op = KdaPrefillOp(cfg, use_int64_offsets)
+    sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
+    tokens, sequence_entries, sequences, work_rows, sched_entries, workspace_words = (
+        sym_int() for _ in range(6)
+    )
 
-    op = KdaPrefillOp(cfg)
-    op.__call__.set_name_prefix(op.get_name())
-    return cute.compile(
+    tma_tensor = partial(
+        make_strided_signature_tensor,
+        assumed_align=16,
+        use_int64_offsets=use_int64_offsets,
+    )
+    beta_dtype = io_dtype if beta_sigmoid else cutlass.Float32
+    return compile_tvm_ffi(
         op,
-        q_cute,
-        k_cute,
-        v_cute,
-        gate_cute,
-        a_log_cute,
-        dt_bias_cute,
-        beta_cute,
-        cu_seqlens_cute,
-        state_in_cute,
-        o_cute,
-        state_out_cute,
-        work_items_cute,
-        work_count_cute,
-        sched_ctr_cute,
-        tensormap_ws_cute,
-        checkpoint_every_n_tokens,
-        scale,
-        stream,
-        options="--enable-tvm-ffi --opt-level 2",
+        tma_tensor(io_dtype, (tokens, n_heads_out // q_ratio, 128)),
+        tma_tensor(io_dtype, (tokens, n_heads_out // k_ratio, 128)),
+        tma_tensor(io_dtype, (tokens, n_heads_out // v_ratio, 128)),
+        tma_tensor(cutlass.Float32, (tokens, n_heads_out, 128)),
+        make_compact_signature_tensor(
+            cutlass.Float32,
+            (n_heads_out,),
+            assumed_align=4,
+        )
+        if safe_gate
+        else None,
+        tma_tensor(cutlass.Float32, (n_heads_out, 128)) if safe_gate else None,
+        make_strided_signature_tensor(
+            beta_dtype,
+            (tokens, n_heads_out),
+            assumed_align=beta_dtype.width // 8,
+            use_int64_offsets=use_int64_offsets,
+        ),
+        make_cu_seqlens_signature(sequence_entries),
+        tma_tensor(state_dtype, (sequences, n_heads_out, 128, 128)) if use_initial_state else None,
+        tma_tensor(io_dtype, (tokens, n_heads_out, 128)),
+        tma_tensor(state_dtype, (sequences, n_heads_out, 128, 128)) if store_final_state else None,
+        make_work_items_signature(work_rows),
+        make_counter_signature(),
+        make_counter_signature(sched_entries) if dyn_sched else None,
+        make_workspace_signature(workspace_words),
+        cutlass.Float32(scale),
     )
 
 
@@ -3046,8 +2813,6 @@ def chunk_kda_sm100(
     initial_state,
     output_state,
     scale: float,
-    checkpoint_every_n_tokens: int = 0,
-    output_state_checkpoints=None,
     use_qk_l2norm_in_kernel: bool = False,
     safe_gate: bool = False,
     gate_lower_bound: float = DEFAULT_GATE_LOWER_BOUND,
@@ -3060,7 +2825,6 @@ def chunk_kda_sm100(
     work_item_scratch=None,
     *,
     tensormap_workspace,
-    stream,
 ) -> None:
     """Execute the Blackwell BT=16 chunked KDA prefill kernel.
 
@@ -3082,13 +2846,6 @@ def chunk_kda_sm100(
         initial_state: ``(num_seqs, HO, DV, DK)`` float32/bfloat16, or None
         output_state: ``(num_seqs, HO, DV, DK)`` float32/bfloat16, or None
         scale: attention scale factor (must not be 0)
-        checkpoint_every_n_tokens: emit entering-state checkpoints every N tokens (0 = off),
-            where N is a positive multiple of the 16-token kernel tile. Sequence-local row
-            ``j`` is the state before token ``j * N``; row zero is the provided initial state
-            or zeros. A nonempty sequence contributes ``ceil(L / N)`` rows.
-        output_state_checkpoints: ``(total_checkpoints, HO, DV, DK)`` io-dtype (VK, K
-            contiguous); per-sequence entry offsets are derived on device from
-            ``cu_seqlens``, so there is no separate checkpoint-offset tensor.
         use_qk_l2norm_in_kernel: L2-normalize q/k rows inside the kernel
         safe_gate: interpret ``gate`` through the safe-gate transform
         a_log: ``(HO,)`` float32, safe-gate per-head log-amplitude (None = 0)
@@ -3096,8 +2853,8 @@ def chunk_kda_sm100(
         use_beta_sigmoid_in_kernel: ``beta`` holds logits; sigmoid in-kernel
         work_items: ``(max_items, 8)`` int32 work-item table from
             ``common/split_k.py`` (REQUIRED; an uncut table row is the whole
-            (b, h) sequence).  Each item computes chunks ``[cstart, wend)``
-            and writes O/checkpoints only for ``[wstart, wend)``.
+            (b, h) sequence). Each item computes chunks ``[cstart, wend)``
+            and writes O only for ``[wstart, wend)``.
         work_count: ``(1,)`` int32 device-side item count (REQUIRED)
         sched_ctr: ``(2,)`` int32 device scratch ``[ticket, done]`` enabling
             the dynamic (work-stealing) tile scheduler; must be zeroed before
@@ -3115,12 +2872,12 @@ def chunk_kda_sm100(
     for name, tensor in (
         ("initial_state", initial_state),
         ("output_state", output_state),
-        ("output_state_checkpoints", output_state_checkpoints),
     ):
         if tensor is not None:
             validate_tma_tensor(name, tensor)
-    if cu_seqlens.data_ptr() % 8:
-        raise ValueError("cu_seqlens data pointer must be 8-byte aligned")
+    validate_cu_seqlens(cu_seqlens, assumed_align=8)
+    if tensormap_workspace.data_ptr() % 128:
+        raise ValueError("tensormap_workspace data pointer must be 128-byte aligned")
 
     tokens, HQ, d_k = q.shape
     HK, HV = k.shape[1], v.shape[1]
@@ -3133,31 +2890,12 @@ def chunk_kda_sm100(
         raise ValueError("output must have shape (T, HO, 128)")
     use_initial_state = initial_state is not None
     store_final_state = output_state is not None
-    if checkpoint_every_n_tokens < 0:
-        raise ValueError("checkpoint interval must be zero or a positive tile multiple")
-    enable_checkpoints = checkpoint_every_n_tokens > 0
-    if enable_checkpoints and checkpoint_every_n_tokens % CFG.B_T:
-        raise ValueError(f"checkpoint interval must be a positive multiple of {CFG.B_T}")
-    if enable_checkpoints:
-        if output_state_checkpoints is None:
-            raise ValueError("checkpoint_every_n_tokens > 0 requires output_state_checkpoints")
-        required_checkpoint_rows = checkpoint_capacity_bound(
-            q.shape[0], cu_seqlens.shape[0] - 1, checkpoint_every_n_tokens
-        )
-        if output_state_checkpoints.shape[0] < required_checkpoint_rows:
-            raise ValueError(
-                f"output_state_checkpoints requires at least {required_checkpoint_rows} rows, "
-                f"got {output_state_checkpoints.shape[0]}"
-            )
-        if str(output_state_checkpoints.dtype).split(".")[-1] != str(q.dtype).split(".")[-1]:
-            raise ValueError(
-                f"output_state_checkpoints dtype must match the io dtype (fp32 state belongs to output_state): got {output_state_checkpoints.dtype} with io {q.dtype}"
-            )
     if work_items is None or work_count is None:
         raise ValueError("work_items/work_count are required (the split-table stage builds them for every launch)")
     dyn_sched = sched_ctr is not None
     order_gen = work_item_scratch is None
 
+    has_sched = dyn_sched
     if initial_state is not None:
         state_dtype_src = initial_state.dtype
     elif output_state is not None:
@@ -3180,7 +2918,24 @@ def chunk_kda_sm100(
     if not safe_gate:
         a_log = None
         dt_bias = None
-    cu_stream = cuda_driver.CUstream(int(stream))
+    use_int64_offsets = requires_int64_abi(
+        q,
+        k,
+        v,
+        gate,
+        a_log,
+        dt_bias,
+        beta,
+        output,
+        cu_seqlens,
+        initial_state,
+        output_state,
+        work_item_scratch,
+        work_items,
+        work_count,
+        sched_ctr,
+        tensormap_workspace,
+    )
 
     device_index = tensor_device_index(q)
     if current_device() != device_index:
@@ -3190,62 +2945,31 @@ def chunk_kda_sm100(
     cache = get_compiled_cache(
         str(q.dtype),
         str(state_dtype_src),
-        str(cu_seqlens.dtype),
         HQ,
         HK,
         HV,
         use_initial_state,
         store_final_state,
-        enable_checkpoints,
         use_qk_l2norm_in_kernel,
         safe_gate,
         gate_lower_bound,
         use_beta_sigmoid_in_kernel,
         dyn_sched,
         order_gen,
+        use_int64_offsets,
         device_index,
         device_properties.major,
         device_properties.minor,
         num_sm,
     )
 
+    io_dtype = get_dtype(q.dtype)
     if "compiled" not in cache:
-        io_dtype = get_dtype(q.dtype)
-        state_dtype = get_dtype(state_dtype_src)
-        q_cute = from_dlpack(q, assumed_align=16).mark_layout_dynamic(leading_dim=2)
-        k_cute = from_dlpack(k, assumed_align=16).mark_layout_dynamic(leading_dim=2)
-        v_cute = from_dlpack(v, assumed_align=16).mark_layout_dynamic(leading_dim=2)
-        gate_cute = from_dlpack(gate, assumed_align=16).mark_layout_dynamic(leading_dim=2)
-        a_log_cute = from_dlpack(a_log, assumed_align=4) if a_log is not None else None
-        dt_bias_cute = from_dlpack(dt_bias, assumed_align=16) if dt_bias is not None else None
-        beta_cute = from_dlpack(beta, assumed_align=4).mark_layout_dynamic(leading_dim=1)
-        o_cute = from_dlpack(output, assumed_align=16).mark_layout_dynamic(leading_dim=2)
-        cu_seqlens_cute = from_dlpack(cu_seqlens, assumed_align=8).mark_layout_dynamic()
-
-        state_in_cute = None
-        if use_initial_state:
-            state_in_cute = from_dlpack(initial_state, assumed_align=16).mark_layout_dynamic(leading_dim=3)
-
-        state_out_cute = None
-        if store_final_state:
-            state_out_cute = from_dlpack(output_state, assumed_align=16).mark_layout_dynamic(leading_dim=3)
-
-        work_items_cute = from_dlpack(work_items, assumed_align=16)
-        work_items_cute.mark_compact_shape_dynamic(mode=0, stride_order=(0, 1), divisibility=1)
-        work_count_cute = from_dlpack(work_count, assumed_align=4).mark_layout_dynamic()
-
-        sched_ctr_cute = None
-        if dyn_sched:
-            sched_ctr_cute = from_dlpack(sched_ctr, assumed_align=4).mark_layout_dynamic()
-
-        tensormap_ws_cute = from_dlpack(tensormap_workspace, assumed_align=128).mark_layout_dynamic()
-
         cache["compiled"] = compile(
             io_dtype,
-            state_dtype,
+            get_dtype(state_dtype_src),
             use_initial_state,
             store_final_state,
-            enable_checkpoints,
             use_qk_l2norm_in_kernel,
             safe_gate,
             gate_scale_log2,
@@ -3255,72 +2979,45 @@ def chunk_kda_sm100(
             v_ratio,
             HO,
             dyn_sched,
+            use_int64_offsets,
             num_sm=num_sm,
-            q_cute=q_cute,
-            k_cute=k_cute,
-            v_cute=v_cute,
-            gate_cute=gate_cute,
-            a_log_cute=a_log_cute,
-            dt_bias_cute=dt_bias_cute,
-            beta_cute=beta_cute,
-            cu_seqlens_cute=cu_seqlens_cute,
-            state_in_cute=state_in_cute,
-            o_cute=o_cute,
-            state_out_cute=state_out_cute,
-            work_items_cute=work_items_cute,
-            work_count_cute=work_count_cute,
-            sched_ctr_cute=sched_ctr_cute,
-            tensormap_ws_cute=tensormap_ws_cute,
-            checkpoint_every_n_tokens=checkpoint_every_n_tokens,
             scale=scale,
-            stream=cu_stream,
         )
 
-    compiled = cache["compiled"]
-    state_checkpoints_for_descs = output_state_checkpoints if enable_checkpoints else None
     if "prologue" not in cache:
-        io_dtype = get_dtype(q.dtype)
-        q_pl = from_dlpack(q, assumed_align=16).mark_layout_dynamic(leading_dim=2)
-        k_pl = from_dlpack(k, assumed_align=16).mark_layout_dynamic(leading_dim=2)
-        v_pl = from_dlpack(v, assumed_align=16).mark_layout_dynamic(leading_dim=2)
-        gate_pl = from_dlpack(gate, assumed_align=16).mark_layout_dynamic(leading_dim=2)
-        o_pl = from_dlpack(output, assumed_align=16).mark_layout_dynamic(leading_dim=2)
-        cu_pl = from_dlpack(cu_seqlens, assumed_align=8).mark_layout_dynamic()
-        ws_pl = from_dlpack(tensormap_workspace, assumed_align=128).mark_layout_dynamic()
-        state_checkpoints_pl = None
-        if state_checkpoints_for_descs is not None:
-            state_checkpoints_pl = from_dlpack(state_checkpoints_for_descs, assumed_align=16).mark_layout_dynamic(leading_dim=3)
-        staging_pl = None
-        if not order_gen:
-            staging_pl = from_dlpack(work_item_scratch, assumed_align=16)
-            staging_pl.mark_compact_shape_dynamic(mode=0, stride_order=(0, 1), divisibility=1)
-        work_items_pl = from_dlpack(work_items, assumed_align=16)
-        work_items_pl.mark_compact_shape_dynamic(mode=0, stride_order=(0, 1), divisibility=1)
-        work_count_pl = from_dlpack(work_count, assumed_align=4).mark_layout_dynamic()
-        sched_pl = None
-        if dyn_sched:
-            sched_pl = from_dlpack(sched_ctr, assumed_align=4).mark_layout_dynamic()
-        cache["prologue"] = cute.compile(
+        sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
+        tokens, sequence_entries, work_rows, sched_entries, workspace_words = (
+            sym_int() for _ in range(5)
+        )
+
+        tma_tensor = partial(
+            make_strided_signature_tensor,
+            assumed_align=16,
+            use_int64_offsets=use_int64_offsets,
+        )
+        work_items_signature = make_work_items_signature(work_rows)
+        cache["prologue"] = compile_tvm_ffi(
             prologue,
             io_dtype,
             CFG.B_T,
             order_gen,
-            dyn_sched,
-            q_pl,
-            k_pl,
-            v_pl,
-            gate_pl,
-            o_pl,
-            state_checkpoints_pl,
-            cu_pl,
-            staging_pl,
-            work_count_pl,
-            work_items_pl,
-            sched_pl,
-            ws_pl,
-            cutlass.Int32(checkpoint_every_n_tokens),
-            cu_stream,
-            options="--enable-tvm-ffi",
+            has_sched,
+            tma_tensor(io_dtype, (tokens, HQ, 128)),
+            tma_tensor(io_dtype, (tokens, HK, 128)),
+            tma_tensor(io_dtype, (tokens, HV, 128)),
+            tma_tensor(cutlass.Float32, (tokens, HO, 128)),
+            tma_tensor(io_dtype, (tokens, HO, 128)),
+            make_cu_seqlens_signature(sequence_entries),
+            work_items_signature if not order_gen else None,
+            make_counter_signature(),
+            work_items_signature,
+            make_counter_signature(sched_entries) if has_sched else None,
+            make_workspace_signature(workspace_words),
+            name=(
+                f"kda_mega_prefill_prologue_{io_dtype.__name__.lower()}"
+                f"_hq{HQ}_hk{HK}_hv{HV}_ho{HO}"
+                f"_o{int(order_gen)}d{int(dyn_sched)}_i64{int(use_int64_offsets)}"
+            ),
         )
     cache["prologue"](
         q,
@@ -3328,17 +3025,14 @@ def chunk_kda_sm100(
         v,
         gate,
         output,
-        state_checkpoints_for_descs,
         cu_seqlens,
         work_item_scratch if not order_gen else None,
         work_count,
         work_items,
         sched_ctr,
         tensormap_workspace,
-        checkpoint_every_n_tokens,
-        cu_stream,
     )
-    compiled(
+    cache["compiled"](
         q,
         k,
         v,
@@ -3354,7 +3048,5 @@ def chunk_kda_sm100(
         work_count,
         sched_ctr,
         tensormap_workspace,
-        checkpoint_every_n_tokens,
         scale,
-        cu_stream,
     )

--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_recompute_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_recompute_f16.py
@@ -84,7 +84,7 @@ Requires the public CuTeDSL 4.7 API, including `cutlass.experimental.*`.
 """
 
 from dataclasses import dataclass
-from functools import lru_cache
+from functools import lru_cache, partial
 from typing import NamedTuple, Type
 
 import cuda.bindings.driver as cuda_driver
@@ -92,8 +92,9 @@ import cutlass
 import cutlass.experimental.cuda as cuda
 import cutlass.experimental.primitives as nvvm
 import cutlass.cute as cute
-from cutlass.cute.runtime import from_dlpack
 
+from attn_gym._backends.cute import compile_tvm_ffi
+from attn_gym._backends.cute.utils import requires_int64_abi
 from attn_gym.linear._delta_rule.mega.kernels.common.split_k import ORDER_CAPACITY, ORDER_ELEMS, ORDER_THREADS, decode_work_item, order_body
 from attn_gym.linear._delta_rule.mega.kernels.common.host import get_dtype
 from attn_gym.linear._delta_rule.mega.kernels.compat import (
@@ -107,6 +108,15 @@ from attn_gym.linear._delta_rule.mega.kernels.common.thd import (
     TENSOR_MAP_QWORDS,
     emit_checkpoint_seq_descs,
     emit_seq_load_descs,
+)
+from attn_gym.linear._delta_rule.mega.kernels.common.tvm_ffi import (
+    make_compact_signature_tensor,
+    make_counter_signature,
+    make_cu_seqlens_signature,
+    make_strided_signature_tensor,
+    make_work_items_signature,
+    make_workspace_signature,
+    validate_cu_seqlens,
 )
 from .kda_recompute_config import CFG
 
@@ -1660,8 +1670,9 @@ def compute1_warp_group(
 class KdaRecomputeOp:
     """Compile and launch one static mega KDA recompute configuration."""
 
-    def __init__(self, cfg: "KdaRecomputeCfg"):
+    def __init__(self, cfg: "KdaRecomputeCfg", use_int64_offsets: bool = False):
         self.cfg = cfg
+        self.use_int64_offsets = use_int64_offsets
 
     def get_name(self) -> str:
         cfg = self.cfg
@@ -1680,7 +1691,7 @@ class KdaRecomputeOp:
             f"_i{int(cfg.use_initial_state)}f{int(cfg.store_final_state)}"
             f"c{int(cfg.enable_checkpoints)}l{int(cfg.l2norm)}"
             f"g{int(cfg.safe_gate)}b{int(cfg.beta_sigmoid)}d{int(cfg.dyn_sched)}"
-            f"_sm{cfg.max_active_clusters}{gate_scale}"
+            f"_sm{cfg.max_active_clusters}_i64{int(self.use_int64_offsets)}{gate_scale}"
         )
 
     @cute.jit
@@ -2198,10 +2209,10 @@ def build_descs_body(
     gate: cute.Tensor,
     state_checkpoints: cute.Tensor | None,
     n_batch: cutlass.Int32,
-    k_row_stride: cutlass.Int32,
-    v_row_stride: cutlass.Int32,
-    gate_row_stride: cutlass.Int32,
-    checkpoint_row_stride: cutlass.Int32,
+    k_row_stride: cutlass.Int64,
+    v_row_stride: cutlass.Int64,
+    gate_row_stride: cutlass.Int64,
+    checkpoint_row_stride: cutlass.Int64,
     checkpoint_every_n: cutlass.Int32,
 ) -> None:
     """Per-batch descriptor-array build, one warp per array. Runs inside the
@@ -2267,10 +2278,10 @@ def prologue_kernel(
     mWorkItems: cute.Tensor | None,
     mSched: cute.Tensor | None,
     n_batch: cutlass.Int32,
-    k_row_stride: cutlass.Int32,
-    v_row_stride: cutlass.Int32,
-    gate_row_stride: cutlass.Int32,
-    checkpoint_row_stride: cutlass.Int32,
+    k_row_stride: cutlass.Int64,
+    v_row_stride: cutlass.Int64,
+    gate_row_stride: cutlass.Int64,
+    checkpoint_row_stride: cutlass.Int64,
     checkpoint_every_n: cutlass.Int32,
 ) -> None:
     """Single-CTA prologue. Under ``run_order`` this kernel is the first
@@ -2397,10 +2408,10 @@ def prologue(
         work_items,
         sched_all,
         cutlass.Int32(batch_size),
-        cutlass.Int32(k.stride[0]),
-        cutlass.Int32(v.stride[0]),
-        cutlass.Int32(gate.stride[0]),
-        cutlass.Int32(state_checkpoints.stride[0] if state_checkpoints is not None else 0),
+        cutlass.Int64(k.stride[0]),
+        cutlass.Int64(v.stride[0]),
+        cutlass.Int64(gate.stride[0]),
+        cutlass.Int64(state_checkpoints.stride[0] if state_checkpoints is not None else 0),
         checkpoint_every_n,
     ).launch(grid=(1, 1, 1), block=(ORDER_THREADS, 1, 1), stream=stream)
 
@@ -2412,7 +2423,6 @@ def prologue(
 def get_compiled_cache(
     io_dtype_str: str,
     state_dtype_str: str,
-    cu_dtype_str: str,
     HO: int,
     HK: int,
     HV: int,
@@ -2426,6 +2436,7 @@ def get_compiled_cache(
     dyn_sched: bool,
     run_order: bool,
     order_gen: bool,
+    use_int64_offsets: bool,
     device_index: int,
     device_major: int,
     device_minor: int,
@@ -2449,25 +2460,12 @@ def compile(
     v_ratio: int,
     n_heads_out: int,
     dyn_sched: bool = False,
+    use_int64_offsets: bool = False,
     *,
     num_sm: int,
-    k_cute,
-    v_cute,
-    gate_cute,
-    a_log_cute,
-    dt_bias_cute,
-    beta_cute,
-    cu_seqlens_cute,
-    state_in_cute,
-    state_out_cute,
-    work_items_cute=None,
-    work_count_cute=None,
-    sched_ctr_cute=None,
-    tensormap_ws_cute,
-    checkpoint_every_n_tokens,
-    stream,
+    checkpoint_every_n_tokens: int,
 ):
-    """JIT-compile the chunked KDA recompute kernel for one static config."""
+    """JIT-compile one fake-tensor TVM-FFI recompute signature."""
     cfg = build_cfg(
         io_dtype,
         state_dtype,
@@ -2484,27 +2482,45 @@ def compile(
         max_active_clusters=num_sm,
         dyn_sched=dyn_sched,
     )
+    op = KdaRecomputeOp(cfg, use_int64_offsets)
+    sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
+    tokens, sequence_entries, sequences, work_rows, sched_entries, workspace_words = (
+        sym_int() for _ in range(6)
+    )
 
-    op = KdaRecomputeOp(cfg)
-    op.__call__.set_name_prefix(op.get_name())
-    return cute.compile(
+    tma_tensor = partial(
+        make_strided_signature_tensor,
+        assumed_align=16,
+        use_int64_offsets=use_int64_offsets,
+    )
+    beta_dtype = io_dtype if beta_sigmoid else cutlass.Float32
+    return compile_tvm_ffi(
         op,
-        k_cute,
-        v_cute,
-        gate_cute,
-        a_log_cute,
-        dt_bias_cute,
-        beta_cute,
-        cu_seqlens_cute,
-        state_in_cute,
-        state_out_cute,
-        work_items_cute,
-        work_count_cute,
-        sched_ctr_cute,
-        tensormap_ws_cute,
-        checkpoint_every_n_tokens,
-        stream,
-        options="--enable-tvm-ffi --opt-level 2",
+        tma_tensor(io_dtype, (tokens, n_heads_out // k_ratio, 128)),
+        tma_tensor(io_dtype, (tokens, n_heads_out // v_ratio, 128)),
+        tma_tensor(cutlass.Float32, (tokens, n_heads_out, 128)),
+        make_compact_signature_tensor(
+            cutlass.Float32,
+            (n_heads_out,),
+            assumed_align=4,
+        )
+        if safe_gate
+        else None,
+        tma_tensor(cutlass.Float32, (n_heads_out, 128)) if safe_gate else None,
+        make_strided_signature_tensor(
+            beta_dtype,
+            (tokens, n_heads_out),
+            assumed_align=beta_dtype.width // 8,
+            use_int64_offsets=use_int64_offsets,
+        ),
+        make_cu_seqlens_signature(sequence_entries),
+        tma_tensor(state_dtype, (sequences, n_heads_out, 128, 128)) if use_initial_state else None,
+        tma_tensor(state_dtype, (sequences, n_heads_out, 128, 128)) if store_final_state else None,
+        make_work_items_signature(work_rows),
+        make_counter_signature(),
+        make_counter_signature(sched_entries) if dyn_sched else None,
+        make_workspace_signature(workspace_words),
+        cutlass.Int32(checkpoint_every_n_tokens),
     )
 
 
@@ -2532,7 +2548,6 @@ def chunk_kda_recompute_sm100(
     order_in_prologue: bool = False,
     *,
     tensormap_workspace,
-    stream,
 ) -> None:
     """Execute the Blackwell BT=16 chunked KDA recompute (state/checkpoints-only)
     kernel.
@@ -2584,8 +2599,9 @@ def chunk_kda_recompute_sm100(
     ):
         if tensor is not None:
             validate_tma_tensor(name, tensor)
-    if cu_seqlens.data_ptr() % 8:
-        raise ValueError("cu_seqlens data pointer must be 8-byte aligned")
+    validate_cu_seqlens(cu_seqlens, assumed_align=8)
+    if tensormap_workspace.data_ptr() % 128:
+        raise ValueError("tensormap_workspace data pointer must be 128-byte aligned")
 
     tokens, HK, d_k = k.shape
     HV, HO = v.shape[1], gate.shape[1]
@@ -2620,6 +2636,7 @@ def chunk_kda_recompute_sm100(
     dyn_sched = sched_ctr is not None
     run_order = order_in_prologue
     order_gen = order_in_prologue and work_item_scratch is None
+    has_sched = run_order
     if run_order and sched_all is None:
         raise ValueError("order in the prologue requires sched_all (the prologue zeroes both consumers' sched rings)")
 
@@ -2644,7 +2661,25 @@ def chunk_kda_recompute_sm100(
     if not safe_gate:
         a_log = None
         dt_bias = None
-    cu_stream = cuda_driver.CUstream(int(stream))
+    state_checkpoints_for_descs = output_state_checkpoints if enable_checkpoints else None
+    use_int64_offsets = requires_int64_abi(
+        k,
+        v,
+        gate,
+        a_log,
+        dt_bias,
+        beta,
+        cu_seqlens,
+        initial_state,
+        output_state,
+        state_checkpoints_for_descs,
+        work_item_scratch,
+        work_items,
+        work_count,
+        sched_ctr,
+        sched_all,
+        tensormap_workspace,
+    )
     device_index = tensor_device_index(k)
     if current_device() != device_index:
         raise ValueError("the active CUDA device must match k.device")
@@ -2654,7 +2689,6 @@ def chunk_kda_recompute_sm100(
     cache = get_compiled_cache(
         str(k.dtype),
         str(state_dtype_src),
-        str(cu_seqlens.dtype),
         HO,
         HK,
         HV,
@@ -2668,44 +2702,18 @@ def chunk_kda_recompute_sm100(
         dyn_sched,
         run_order,
         order_gen,
+        use_int64_offsets,
         device_index,
         device_properties.major,
         device_properties.minor,
         num_sm,
     )
 
+    io_dtype = get_dtype(k.dtype)
     if "compiled" not in cache:
-        io_dtype = get_dtype(k.dtype)
-        state_dtype = get_dtype(state_dtype_src)
-        k_cute = from_dlpack(k, assumed_align=16).mark_layout_dynamic(leading_dim=2)
-        v_cute = from_dlpack(v, assumed_align=16).mark_layout_dynamic(leading_dim=2)
-        gate_cute = from_dlpack(gate, assumed_align=16).mark_layout_dynamic(leading_dim=2)
-        a_log_cute = from_dlpack(a_log, assumed_align=4) if a_log is not None else None
-        dt_bias_cute = from_dlpack(dt_bias, assumed_align=16) if dt_bias is not None else None
-        beta_cute = from_dlpack(beta, assumed_align=4).mark_layout_dynamic(leading_dim=1)
-        cu_seqlens_cute = from_dlpack(cu_seqlens, assumed_align=8).mark_layout_dynamic()
-
-        state_in_cute = None
-        if use_initial_state:
-            state_in_cute = from_dlpack(initial_state, assumed_align=16).mark_layout_dynamic(leading_dim=3)
-
-        state_out_cute = None
-        if store_final_state:
-            state_out_cute = from_dlpack(output_state, assumed_align=16).mark_layout_dynamic(leading_dim=3)
-
-        work_items_cute = from_dlpack(work_items, assumed_align=16)
-        work_items_cute.mark_compact_shape_dynamic(mode=0, stride_order=(0, 1), divisibility=1)
-        work_count_cute = from_dlpack(work_count, assumed_align=4).mark_layout_dynamic()
-
-        sched_ctr_cute = None
-        if dyn_sched:
-            sched_ctr_cute = from_dlpack(sched_ctr, assumed_align=4).mark_layout_dynamic()
-
-        tensormap_ws_cute = from_dlpack(tensormap_workspace, assumed_align=128).mark_layout_dynamic()
-
         cache["compiled"] = compile(
             io_dtype,
-            state_dtype,
+            get_dtype(state_dtype_src),
             use_initial_state,
             store_final_state,
             enable_checkpoints,
@@ -2717,66 +2725,49 @@ def chunk_kda_recompute_sm100(
             v_ratio,
             HO,
             dyn_sched,
+            use_int64_offsets,
             num_sm=num_sm,
-            k_cute=k_cute,
-            v_cute=v_cute,
-            gate_cute=gate_cute,
-            a_log_cute=a_log_cute,
-            dt_bias_cute=dt_bias_cute,
-            beta_cute=beta_cute,
-            cu_seqlens_cute=cu_seqlens_cute,
-            state_in_cute=state_in_cute,
-            state_out_cute=state_out_cute,
-            work_items_cute=work_items_cute,
-            work_count_cute=work_count_cute,
-            sched_ctr_cute=sched_ctr_cute,
-            tensormap_ws_cute=tensormap_ws_cute,
             checkpoint_every_n_tokens=checkpoint_every_n_tokens,
-            stream=cu_stream,
         )
 
-    compiled = cache["compiled"]
-    state_checkpoints_for_descs = output_state_checkpoints if enable_checkpoints else None
     if "prologue" not in cache:
-        io_dtype = get_dtype(k.dtype)
-        k_pl = from_dlpack(k, assumed_align=16).mark_layout_dynamic(leading_dim=2)
-        v_pl = from_dlpack(v, assumed_align=16).mark_layout_dynamic(leading_dim=2)
-        gate_pl = from_dlpack(gate, assumed_align=16).mark_layout_dynamic(leading_dim=2)
-        cu_pl = from_dlpack(cu_seqlens, assumed_align=8).mark_layout_dynamic()
-        ws_pl = from_dlpack(tensormap_workspace, assumed_align=128).mark_layout_dynamic()
-        state_checkpoints_pl = None
-        if state_checkpoints_for_descs is not None:
-            state_checkpoints_pl = from_dlpack(state_checkpoints_for_descs, assumed_align=16).mark_layout_dynamic(leading_dim=3)
-        staging_pl = None
-        if run_order and not order_gen:
-            staging_pl = from_dlpack(work_item_scratch, assumed_align=16)
-            staging_pl.mark_compact_shape_dynamic(mode=0, stride_order=(0, 1), divisibility=1)
-        work_items_pl = from_dlpack(work_items, assumed_align=16)
-        work_items_pl.mark_compact_shape_dynamic(mode=0, stride_order=(0, 1), divisibility=1)
-        work_count_pl = from_dlpack(work_count, assumed_align=4).mark_layout_dynamic()
-        sched_pl = None
-        if run_order:
-            sched_pl = from_dlpack(sched_all, assumed_align=4).mark_layout_dynamic()
-        cache["prologue"] = cute.compile(
+        sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
+        tokens, sequence_entries, checkpoint_rows, work_rows, sched_entries, workspace_words = (
+            sym_int() for _ in range(6)
+        )
+
+        tma_tensor = partial(
+            make_strided_signature_tensor,
+            assumed_align=16,
+            use_int64_offsets=use_int64_offsets,
+        )
+        work_items_signature = make_work_items_signature(work_rows)
+        cache["prologue"] = compile_tvm_ffi(
             prologue,
             io_dtype,
             CFG.B_T,
             run_order,
             order_gen,
-            run_order,
-            k_pl,
-            v_pl,
-            gate_pl,
-            state_checkpoints_pl,
-            cu_pl,
-            staging_pl,
-            work_count_pl,
-            work_items_pl,
-            sched_pl,
-            ws_pl,
+            has_sched,
+            tma_tensor(io_dtype, (tokens, HK, 128)),
+            tma_tensor(io_dtype, (tokens, HV, 128)),
+            tma_tensor(cutlass.Float32, (tokens, HO, 128)),
+            tma_tensor(io_dtype, (checkpoint_rows, HO, 128, 128))
+            if state_checkpoints_for_descs is not None
+            else None,
+            make_cu_seqlens_signature(sequence_entries),
+            work_items_signature if run_order and not order_gen else None,
+            make_counter_signature(),
+            work_items_signature,
+            make_counter_signature(sched_entries) if has_sched else None,
+            make_workspace_signature(workspace_words),
             cutlass.Int32(checkpoint_every_n_tokens),
-            cu_stream,
-            options="--enable-tvm-ffi",
+            name=(
+                f"kda_mega_recompute_prologue_{io_dtype.__name__.lower()}"
+                f"_hk{HK}_hv{HV}_ho{HO}_c{int(enable_checkpoints)}"
+                f"_r{int(run_order)}o{int(order_gen)}d{int(dyn_sched)}"
+                f"_i64{int(use_int64_offsets)}"
+            ),
         )
     cache["prologue"](
         k,
@@ -2790,9 +2781,8 @@ def chunk_kda_recompute_sm100(
         sched_all if run_order else None,
         tensormap_workspace,
         checkpoint_every_n_tokens,
-        cu_stream,
     )
-    compiled(
+    cache["compiled"](
         k,
         v,
         gate,
@@ -2807,5 +2797,4 @@ def chunk_kda_recompute_sm100(
         sched_ctr,
         tensormap_workspace,
         checkpoint_every_n_tokens,
-        cu_stream,
     )

--- a/attn_gym/linear/_delta_rule/mega/schedule.py
+++ b/attn_gym/linear/_delta_rule/mega/schedule.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Shared work-table and scratch allocation for Mega forward and backward."""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+import torch
+
+from .kernels.common.split_k import (
+    WORK_ITEM_FIELDS,
+    build_split_table,
+    chunk_scratch_rows,
+    compute_ideal_chunks,
+    max_work_items,
+)
+from .kernels.compat import multiprocessor_count, tensor_device_index
+
+
+class MegaSchedule(NamedTuple):
+    """Allocated work table, counters, and optional split scratch for one launch."""
+
+    work_items: torch.Tensor
+    work_count: torch.Tensor
+    counters: torch.Tensor
+    item_scratch: torch.Tensor | None
+    chunk_scratch: torch.Tensor | None
+    num_sms: int
+
+
+def prepare_mega_schedule(
+    gate: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    *,
+    tile_tokens: int,
+    counter_count: int,
+    split: bool,
+    stream: int,
+) -> MegaSchedule:
+    """Select geometry and allocate every host-owned Mega scheduling buffer."""
+    if counter_count < 1:
+        raise ValueError("counter_count must be positive")
+    tokens, heads = gate.shape[1:3]
+    num_sequences = cu_seqlens.shape[0] - 1
+    num_sms = multiprocessor_count(tensor_device_index(gate))
+    work_count = torch.empty(1, dtype=torch.int32, device=gate.device)
+    counters = torch.empty(counter_count, dtype=torch.int32, device=gate.device)
+
+    if not split:
+        return MegaSchedule(
+            torch.empty(
+                num_sequences * heads,
+                WORK_ITEM_FIELDS,
+                dtype=torch.int32,
+                device=gate.device,
+            ),
+            work_count,
+            counters,
+            None,
+            None,
+            num_sms,
+        )
+
+    ideal_chunks = compute_ideal_chunks(tokens, heads, num_sms, tile_tokens)
+    work_item_rows = max_work_items(
+        tokens,
+        num_sequences,
+        heads,
+        ideal_chunks,
+        tile_tokens,
+        num_sms,
+    )
+    item_scratch = torch.empty(
+        work_item_rows,
+        WORK_ITEM_FIELDS,
+        dtype=torch.int32,
+        device=gate.device,
+    )
+    chunk_scratch = torch.empty(
+        chunk_scratch_rows(tokens, num_sequences, tile_tokens),
+        heads,
+        dtype=torch.float32,
+        device=gate.device,
+    )
+    work_items = torch.empty_like(item_scratch)
+    build_split_table(
+        gate[0],
+        cu_seqlens,
+        work_items,
+        work_count,
+        ideal_chunks=ideal_chunks,
+        n_tiles=num_sequences * heads,
+        num_sms=num_sms,
+        b_t=tile_tokens,
+        chunk_scratch=chunk_scratch,
+        item_scratch=item_scratch,
+        log_gate=True,
+        sched_ctr=counters,
+        split=True,
+        stream=stream,
+    )
+    return MegaSchedule(
+        work_items,
+        work_count,
+        counters,
+        item_scratch,
+        chunk_scratch,
+        num_sms,
+    )
+
+
+__all__ = ["MegaSchedule", "prepare_mega_schedule"]

--- a/attn_gym/linear/kda/api.py
+++ b/attn_gym/linear/kda/api.py
@@ -29,11 +29,12 @@ from attn_gym.linear._delta_rule.validation import (
 from attn_gym.linear.kda.constants import LOG2_E
 from attn_gym.linear.kda.impl.fused import chunk_forward as _fused_chunk_forward
 from attn_gym.linear.kda.impl.fused import paged_chunk_forward as _fused_paged_chunk_forward
+from attn_gym.linear.kda.impl.mega import chunk_forward as _mega_chunk_forward
 from attn_gym.linear.kda.impl.reference import reference_kda
 from attn_gym.linear.kda.naive import naive_chunk_kda, naive_recurrent_kda
 from attn_gym.linear.kda.ops import recurrent_decode_forward as _fused_recurrent_decode_forward
 from attn_gym.linear.kda.ops import recurrent_forward as _fused_recurrent_forward
-from attn_gym.linear.kda.validation import validate_kda_inputs
+from attn_gym.linear.kda.validation import resolve_kernel_options, validate_kda_inputs
 from attn_gym.linear.types import Impl, resolve_impl
 
 _CHUNK_SIZE = 64
@@ -44,7 +45,13 @@ _DECODE_GATE_TRANSFORMS = {
 
 
 class KernelOptions(TypedDict, total=False):
-    """Backend-specific controls for :func:`chunk_kda`."""
+    """Backend and experimental scheduling controls for :func:`chunk_kda`."""
+
+    backend: Literal["fused", "mega"]
+    """Select the default fused backend or the optional Mega CuTeDSL backend."""
+
+    split_backward: bool
+    """Approximate only Mega backward with schedule-selected forgetting-horizon splits."""
 
 
 def _resolve_decode_gate_transform(gate_transform: str) -> bool:
@@ -98,14 +105,12 @@ def chunk_kda(
         scale: Query scale, applied inside the kernels in FP32. Defaults to
             ``1 / sqrt(K)``.
         output_final_state: Return the final recurrent state with the output.
-        fastmath: Allow less precise fused math for speed; rejected with
-            ``"reference"``.
-        autotune: Benchmark candidate kernel configurations when true (winners
-            are cached and reused); use fixed heuristics when false for
-            repeatable selection across machines and cache states.
-        impl: ``"fused"`` uses the Blackwell kernels with first-order autograd;
-            ``"reference"`` uses differentiable eager PyTorch in FP32, with no
-            automatic fallback.
+        fastmath: Allow less precise fused math for speed; rejected by the Mega
+            backend and ``"reference"``.
+        autotune: Benchmark candidate fused-kernel configurations when true. Mega
+            accepts this argument for API compatibility but uses its fixed schedule.
+        impl: ``"fused"`` uses optimized kernels and ``"reference"`` uses
+            differentiable eager PyTorch in FP32. There is no automatic fallback.
         kernel_options: Backend-specific options. This is a sneaky BC trick.
             It is annoying to have a bunch of kwargs that its hard to know when they apply
             but, this trick allows us to add new options without breaking the API. I will
@@ -117,10 +122,12 @@ def chunk_kda(
         per logical sequence or ``None``.
     """
     selected_impl = resolve_impl(impl)
-    if kernel_options:
-        raise ValueError("no chunk_kda kernel options are currently supported")
-    if selected_impl is Impl.REFERENCE and fastmath:
-        raise ValueError("fastmath applies only to impl='fused'")
+    backend, split_backward = resolve_kernel_options(kernel_options)
+    if selected_impl is Impl.REFERENCE:
+        if fastmath:
+            raise ValueError("fastmath applies only to impl='fused'")
+        if kernel_options:
+            raise ValueError("kernel_options are not supported with impl='reference'")
     validate_kda_inputs(
         q,
         k,
@@ -134,6 +141,21 @@ def chunk_kda(
     )
     scale = resolve_scale(scale, q.shape[-1])
     if selected_impl is Impl.FUSED:
+        if backend == "mega":
+            return _mega_chunk_forward(
+                q,
+                k,
+                v,
+                gate,
+                beta,
+                initial_state,
+                cu_seqlens=cu_seqlens,
+                scale=scale,
+                output_final_state=output_final_state,
+                fastmath=fastmath,
+                autotune=autotune,
+                split_backward=split_backward,
+            )
         return _fused_chunk_forward(
             q,
             k,

--- a/attn_gym/linear/kda/bwd/cute/chunk_delta_h_bwd.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_delta_h_bwd.py
@@ -43,7 +43,11 @@ from cutlass.cute.runtime import make_fake_compact_tensor
 from cutlass.cute.typing import Float32, Int32, Int64
 from torch._guards import active_fake_mode
 
-from attn_gym._backends.cute import get_device_properties
+from attn_gym._backends.cute import (
+    get_device_properties,
+    make_fake_strided_tensor,
+    tensor_supports_contiguous_dim,
+)
 from attn_gym._backends.cute.cache import jit_cache
 from attn_gym._backends.cute.target import get_compile_target
 from attn_gym._backends.cute.utils import compile_tvm_ffi, requires_int64_abi
@@ -198,6 +202,7 @@ class BlackwellDeltaHBwd:
         varlen: bool = False,
         use_int64_offsets: bool = False,
         bound_sequence_extent: bool = False,
+        dynamic_state_layout: bool = False,
     ):
         assert head_bv in (16, 32), f"BV must be 16 or 32, got {head_bv}"
         self.head_k = 128
@@ -208,6 +213,7 @@ class BlackwellDeltaHBwd:
         self.varlen = varlen
         self.use_int64_offsets = use_int64_offsets
         self.bound_sequence_extent = bound_sequence_extent
+        self.dynamic_state_layout = dynamic_state_layout
         assert not bound_sequence_extent or varlen, "sequence extent applies only to varlen inputs"
 
         # Tile dimensions
@@ -261,6 +267,7 @@ class BlackwellDeltaHBwd:
             f"kda_bwd_dhu_dv_fused_vl{int(self.varlen)}_h{self.num_heads}"
             f"_k{self.head_k}_v{self.head_v}_bt{self.BT}_bv{self.BV}_{_IO_TYPE_NAMES[self.io_type]}"
             f"_i64{int(self.use_int64_offsets)}_se{int(self.bound_sequence_extent)}"
+            f"_ds{int(self.dynamic_state_layout)}"
         )
 
     # ------------------------------------------------------------------
@@ -282,7 +289,7 @@ class BlackwellDeltaHBwd:
         dv2_out_in,
         problem_shape,
     ):
-        """Re-rank packed compact storage into the logical TMA/state views."""
+        """Re-rank packed storage into the logical TMA/state views."""
         B, T, H, K, V = problem_shape
         dB = Int32(1)
         NT = Int32(cute.size(dh_out_in.shape[0]))
@@ -339,20 +346,30 @@ class BlackwellDeltaHBwd:
                 ),
             ),
         )
-        g_dht = cute.make_tensor(
-            dht_in.iterator,
-            cute.make_layout(
-                (K, V, (H, B)),
-                stride=(1, K, (K * V, self.upcast(H * K * V))),
-            ),
-        )
-        g_dh0_t = cute.make_tensor(
-            dh0_in.iterator,
-            cute.make_layout(
-                (V, K, (H, B)),
-                stride=(K, 1, (K * V, self.upcast(H * K * V))),
-            ),
-        )
+        if cutlass.const_expr(self.dynamic_state_layout):
+            g_dht = cute.make_tensor(
+                dht_in.iterator,
+                cute.group_modes(cute.select(dht_in.layout, mode=[3, 2, 1, 0]), 2, 4),
+            )
+            g_dh0_t = cute.make_tensor(
+                dh0_in.iterator,
+                cute.group_modes(cute.select(dh0_in.layout, mode=[2, 3, 1, 0]), 2, 4),
+            )
+        else:
+            g_dht = cute.make_tensor(
+                dht_in.iterator,
+                cute.make_layout(
+                    (K, V, (H, B)),
+                    stride=(1, K, (K * V, self.upcast(H * K * V))),
+                ),
+            )
+            g_dh0_t = cute.make_tensor(
+                dh0_in.iterator,
+                cute.make_layout(
+                    (V, K, (H, B)),
+                    stride=(K, 1, (K * V, self.upcast(H * K * V))),
+                ),
+            )
         return GmemViews(
             g_k,
             g_qt,
@@ -2175,8 +2192,36 @@ def make_fake_tensor(dtype, shape):
     )
 
 
+def make_state_signature_tensor(dtype, shape, use_int64_offsets, dynamic_strides):
+    """Create the compact fast-path or dynamic-stride state signature."""
+    if not dynamic_strides:
+        return make_fake_tensor(dtype, shape)
+    return make_fake_strided_tensor(
+        dtype,
+        shape,
+        assumed_align=dtype.width // 8,
+        use_int64_strides=use_int64_offsets,
+    )
+
+
+def supports_state_layout(state: torch.Tensor) -> bool:
+    """Return whether raw state loads can address this nonnegative-strided layout."""
+    return all(stride >= 0 for stride in state.stride()) and tensor_supports_contiguous_dim(
+        state,
+        alignment_bytes=state.element_size(),
+    )
+
+
+def requires_dynamic_state_layout(*states: torch.Tensor) -> bool:
+    """Keep the 128-byte-aligned compact signature only for its original fast path."""
+    return any(
+        not state.is_contiguous() or not tensor_supports_contiguous_dim(state, alignment_bytes=128)
+        for state in states
+    )
+
+
 @jit_cache
-def _compile_delta_h_bwd(H, bv, io_type, use_int64_offsets):
+def _compile_delta_h_bwd(H, bv, io_type, use_int64_offsets, dynamic_state_layout):
     """Compile one dense BlackwellDeltaHBwd variant."""
     K = V = 128
     chunk_size = 64
@@ -2185,6 +2230,7 @@ def _compile_delta_h_bwd(H, bv, io_type, use_int64_offsets):
         num_heads=H,
         io_type=io_type,
         use_int64_offsets=use_int64_offsets,
+        dynamic_state_layout=dynamic_state_layout,
     )
     sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
     sa, sb, snt, sns, sn = (sym_int() for _ in range(5))
@@ -2193,8 +2239,18 @@ def _compile_delta_h_bwd(H, bv, io_type, use_int64_offsets):
     dof = make_fake_tensor(io_type, (sa, sb, H, V))
     aqkf = make_fake_tensor(io_type, (sa, sb, H, chunk_size))
     gkf = make_fake_tensor(cutlass.Float32, (sa, sb, H, K))
-    dhtf = make_fake_tensor(cutlass.Float32, (sns, H, V, K))
-    dh0f = make_fake_tensor(cutlass.Float32, (sns, H, V, K))
+    dhtf = make_state_signature_tensor(
+        cutlass.Float32,
+        (sns, H, V, K),
+        use_int64_offsets,
+        dynamic_state_layout,
+    )
+    dh0f = make_state_signature_tensor(
+        cutlass.Float32,
+        (sns, H, V, K),
+        use_int64_offsets,
+        dynamic_state_layout,
+    )
     dhof = make_fake_tensor(io_type, (sa, snt, H, K, V))
     dv2f = make_fake_tensor(io_type, (sa, sb, H, V))
     cuf = make_fake_tensor(cutlass.Int32, (sn,))
@@ -2229,6 +2285,7 @@ def _compile_delta_h_bwd_packed(
     io_type: type[cutlass.Numeric],
     use_int64_offsets: bool,
     bound_sequence_extent: bool,
+    dynamic_state_layout: bool,
 ):
     """Compile one packed fused specialization with a width-matched TVM ABI."""
     key_dim = value_dim = 128
@@ -2240,6 +2297,7 @@ def _compile_delta_h_bwd_packed(
         varlen=True,
         use_int64_offsets=use_int64_offsets,
         bound_sequence_extent=bound_sequence_extent,
+        dynamic_state_layout=dynamic_state_layout,
     )
     sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
     tokens, chunks, sequences, metadata_entries = (sym_int() for _ in range(4))
@@ -2247,7 +2305,19 @@ def _compile_delta_h_bwd_packed(
     def token_tensor(dtype, width):
         return make_fake_tensor(dtype, (tokens, heads, width))
 
-    state = make_fake_tensor(cutlass.Float32, (sequences, heads, value_dim, key_dim))
+    state_shape = (sequences, heads, value_dim, key_dim)
+    dht_state = make_state_signature_tensor(
+        cutlass.Float32,
+        state_shape,
+        use_int64_offsets,
+        dynamic_state_layout,
+    )
+    dh0_state = make_state_signature_tensor(
+        cutlass.Float32,
+        state_shape,
+        use_int64_offsets,
+        dynamic_state_layout,
+    )
     chunk_state = make_fake_tensor(io_type, (chunks, heads, key_dim, value_dim))
     metadata = make_fake_tensor(cutlass.Int32, (metadata_entries,))
     return compile_tvm_ffi(
@@ -2258,8 +2328,8 @@ def _compile_delta_h_bwd_packed(
         token_tensor(io_type, value_dim),
         token_tensor(io_type, chunk_size),
         token_tensor(cutlass.Float32, key_dim),
-        state,
-        state,
+        dht_state,
+        dh0_state,
         chunk_state,
         token_tensor(io_type, value_dim),
         metadata,
@@ -2327,9 +2397,11 @@ def _blackwell_delta_h_bwd_dhu_dv_fused_packed(
         if state is not None and state.shape != expected_state:
             raise ValueError(f"{name} must have shape {expected_state}")
         if state is not None and (
-            state.dtype != torch.float32 or state.device != q.device or not state.is_contiguous()
+            state.dtype != torch.float32
+            or state.device != q.device
+            or not supports_state_layout(state)
         ):
-            raise TypeError(f"{name} must be contiguous float32 on q.device")
+            raise TypeError(f"{name} must be float32 with a contiguous key mode on q.device")
     if bv not in (16, 32):
         raise ValueError(f"bv must be 16 or 32, got {bv}")
 
@@ -2382,6 +2454,7 @@ def _blackwell_delta_h_bwd_dhu_dv_fused_packed(
             chunk_size,
             h0 is not None,
         ),
+        requires_dynamic_state_layout(final_state_kernel, initial_state_gradient_kernel),
     )
     compiled(
         *kernel_tensors,
@@ -2433,9 +2506,11 @@ def blackwell_delta_h_bwd_dhu_dv_fused(
         if state is not None and state.shape != expected_state:
             raise ValueError(f"{name} must have shape {expected_state}")
         if state is not None and (
-            state.dtype != torch.float32 or state.device != q.device or not state.is_contiguous()
+            state.dtype != torch.float32
+            or state.device != q.device
+            or not supports_state_layout(state)
         ):
-            raise TypeError(f"{name} must be contiguous float32 on q.device")
+            raise TypeError(f"{name} must be float32 with a contiguous key mode on q.device")
 
     dh_out = q.new_empty(B, T // BT, H, K, V)
     dh0_out = torch.empty_like(h0, dtype=torch.float32) if h0 is not None else None
@@ -2468,7 +2543,13 @@ def blackwell_delta_h_bwd_dhu_dv_fused(
         dh_out,
         dv2,
     )
-    fn = _compile_delta_h_bwd(H, bv, io_type, use_int64_offsets)
+    fn = _compile_delta_h_bwd(
+        H,
+        bv,
+        io_type,
+        use_int64_offsets,
+        requires_dynamic_state_layout(dht_k, dh0_k),
+    )
     dummy_metadata = torch.empty(2, dtype=torch.int32, device=dev)
     fn(
         q,

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py
@@ -57,8 +57,15 @@ def _normalize_qkv_layout(tensor: torch.Tensor) -> torch.Tensor:
 
 
 def _normalize_packed_cotangent(tensor: torch.Tensor) -> torch.Tensor:
-    """Provide the compact 128-byte-aligned ABI required by packed delta-H."""
+    """Provide the compact 128-byte-aligned ABI required by packed token gradients."""
     if tensor.is_contiguous() and tensor_supports_contiguous_dim(tensor, alignment_bytes=128):
+        return tensor
+    return tensor.clone(memory_format=torch.contiguous_format)
+
+
+def _normalize_state_cotangent(tensor: torch.Tensor) -> torch.Tensor:
+    """Preserve supported state strides and materialize broadcast cotangents."""
+    if tensor.stride(-1) == 1 and all(stride >= 0 for stride in tensor.stride()):
         return tensor
     return tensor.clone(memory_format=torch.contiguous_format)
 
@@ -72,8 +79,6 @@ def _validate_private_abi(
     initial_state: torch.Tensor | None,
 ) -> None:
     contiguous_tensors = (cumulative_gate, beta)
-    if initial_state is not None:
-        contiguous_tensors += (initial_state,)
     if q.dtype not in (torch.float16, torch.bfloat16) or (k.dtype, v.dtype) != (
         q.dtype,
         q.dtype,
@@ -83,8 +88,12 @@ def _validate_private_abi(
         raise TypeError("the private chunk_kda ABI requires float32 cumulative_gate and beta")
     if initial_state is not None and initial_state.dtype != torch.float32:
         raise TypeError("the private chunk_kda ABI requires a float32 initial_state")
+    if initial_state is not None and (
+        initial_state.stride(-1) != 1 or any(stride < 0 for stride in initial_state.stride())
+    ):
+        raise ValueError("the private chunk_kda ABI requires a contiguous state key mode")
     if not all(tensor.is_contiguous() for tensor in contiguous_tensors):
-        raise ValueError("the private chunk_kda ABI requires contiguous gate, beta, and state")
+        raise ValueError("the private chunk_kda ABI requires contiguous gate and beta")
     if not all(_has_supported_qkv_layout(tensor) for tensor in (q, k, v)):
         raise ValueError(
             "the private chunk_kda ABI requires QKV to have contiguous heads and "
@@ -509,12 +518,7 @@ def _prepare_chunk_kda_backward(
     else:
         d_output = _normalize_qkv_layout(d_output)
     if d_final_state is not None:
-        d_final_state = d_final_state.float()
-        d_final_state = (
-            _normalize_packed_cotangent(d_final_state)
-            if metadata is not None
-            else _normalize_qkv_layout(d_final_state)
-        )
+        d_final_state = _normalize_state_cotangent(d_final_state.float())
     return q, k, v, metadata, d_output, d_final_state
 
 

--- a/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
@@ -56,7 +56,9 @@ def _run_chunk_delta_h_sequence(
     T,
     i_nh,
     i_v,
-    state_batch_stride: tl.constexpr,
+    H0_STRIDES,
+    HT_STRIDES,
+    DYNAMIC_STATE_LAYOUT: tl.constexpr,
     H: tl.constexpr,
     K: tl.constexpr,
     V: tl.constexpr,
@@ -119,8 +121,14 @@ def _run_chunk_delta_h_sequence(
         i_state = i_n.to(tl.int64)
     else:
         i_state = i_n
-    p_state = i_state * state_batch_stride + i_h * V * K
-    p_state += ptr_offset((o_v[None, :], o_k[:, None]), (K, 1))
+    if DYNAMIC_STATE_LAYOUT:
+        state_indices_4d = (i_state, i_h, o_v[None, :], o_k[:, None])
+        p_h0 = ptr_offset(state_indices_4d, H0_STRIDES)
+        p_ht = ptr_offset(state_indices_4d, HT_STRIDES)
+    else:
+        p_h0 = i_state * H * V * K + i_h * V * K
+        p_h0 += ptr_offset((o_v[None, :], o_k[:, None]), (K, 1))
+        p_ht = p_h0
 
     b_h = tl.zeros([K, BV], dtype=tl.float32)
     if USE_INITIAL_STATE:
@@ -128,7 +136,7 @@ def _run_chunk_delta_h_sequence(
         if USE_HAS_INITIAL_STATE:
             m_state &= tl.load(has_initial_state + i_n)
         b_h += tl.load(
-            h0 + p_state,
+            h0 + p_h0,
             mask=m_state,
             other=0.0,
         ).to(
@@ -193,7 +201,7 @@ def _run_chunk_delta_h_sequence(
 
     if STORE_FINAL_STATE:
         tl.store(
-            ht + p_state,
+            ht + p_ht,
             b_h,
         )
 
@@ -217,7 +225,15 @@ def chunk_delta_h_kernel_k128_wsp(
     u,
     v_new,
     T,
-    state_batch_stride: tl.constexpr,
+    h0_stride_0,
+    h0_stride_1,
+    h0_stride_2,
+    h0_stride_3,
+    ht_stride_0,
+    ht_stride_1,
+    ht_stride_2,
+    ht_stride_3,
+    DYNAMIC_STATE_LAYOUT: tl.constexpr,
     H: tl.constexpr,
     K: tl.constexpr,
     V: tl.constexpr,
@@ -253,7 +269,9 @@ def chunk_delta_h_kernel_k128_wsp(
         T,
         tl.program_id(0),
         tl.program_id(1),
-        state_batch_stride,
+        (h0_stride_0, h0_stride_1, h0_stride_2, h0_stride_3),
+        (ht_stride_0, ht_stride_1, ht_stride_2, ht_stride_3),
+        DYNAMIC_STATE_LAYOUT,
         H,
         K,
         V,
@@ -289,7 +307,15 @@ def chunk_delta_h_kernel_k128_persistent(
     u,
     v_new,
     T,
-    state_batch_stride: tl.constexpr,
+    h0_stride_0,
+    h0_stride_1,
+    h0_stride_2,
+    h0_stride_3,
+    ht_stride_0,
+    ht_stride_1,
+    ht_stride_2,
+    ht_stride_3,
+    DYNAMIC_STATE_LAYOUT: tl.constexpr,
     H: tl.constexpr,
     K: tl.constexpr,
     V: tl.constexpr,
@@ -332,7 +358,9 @@ def chunk_delta_h_kernel_k128_persistent(
             T,
             i_nh,
             i_v,
-            state_batch_stride,
+            (h0_stride_0, h0_stride_1, h0_stride_2, h0_stride_3),
+            (ht_stride_0, ht_stride_1, ht_stride_2, ht_stride_3),
+            DYNAMIC_STATE_LAYOUT,
             H,
             K,
             V,
@@ -406,9 +434,9 @@ def _delta_h_launch(
     if not can_use_tma(gk):
         gk = gk.clone(memory_format=torch.contiguous_format)
     state_batch = batch if cu_seqlens is None else cu_seqlens.shape[0] - 1
-    state_batch_stride = (
-        initial_state.stride(0) if initial_state is not None else heads * key_dim * value_dim
-    )
+    compact_state_strides = (heads * value_dim * key_dim, value_dim * key_dim, key_dim, 1)
+    h0_strides = initial_state.stride() if initial_state is not None else compact_state_strides
+    ht_strides = final_state.stride() if final_state is not None else compact_state_strides
     # FP32 tiles double the descriptor staging past the shared-memory limit
     # at the 16-bit tile shape, and warp specialization pins its own stage
     # count; for 4-byte inputs halve the value tile and use an ordinarily
@@ -436,9 +464,12 @@ def _delta_h_launch(
         u,
         v_new,
         tokens,
+        *h0_strides,
+        *ht_strides,
     )
     kernel_options = {
-        "state_batch_stride": state_batch_stride,
+        "DYNAMIC_STATE_LAYOUT": (initial_state is not None and not initial_state.is_contiguous())
+        or (final_state is not None and not final_state.is_contiguous()),
         "H": heads,
         "K": key_dim,
         "V": value_dim,
@@ -667,8 +698,8 @@ def chunk_gated_delta_rule_fwd_h(
                 f"initial_state must have shape {expected_state_shape}, "
                 f"got {tuple(initial_state.shape)}"
             )
-        if initial_state.stride()[1:] != (value_dim * key_dim, key_dim, 1):
-            raise TypeError("initial_state must be contiguous within each [H, V, K] row")
+        if initial_state.stride(-1) != 1 or any(stride < 0 for stride in initial_state.stride()):
+            raise TypeError("initial_state requires a contiguous key mode")
 
     if tokens == 0:
         # Zero-size tensors cannot back descriptors; the recurrence is empty

--- a/attn_gym/linear/kda/fwd/triton/plain_gate.py
+++ b/attn_gym/linear/kda/fwd/triton/plain_gate.py
@@ -101,56 +101,57 @@ def _plain_gate_scan_cuda(
     reverse: bool,
 ) -> torch.Tensor:
     """Launch the internal dense or packed gate scan."""
-    _, tokens, heads, head_dim = values.shape
-    is_ragged = cu_seqlens is not None
-    # Packed reverse scans do not visit inactive capacity; its gradient must be zero
-    # before upstream parameter reductions consume it.
-    factory = torch.zeros_like if is_ragged and reverse else torch.empty_like
-    output = factory(values, memory_format=torch.contiguous_format)
-    block_dim = 32
-    if is_ragged:
-        assert chunk_offsets is not None
-        num_sequences = cu_seqlens.shape[0] - 1
-        chunks = chunk_capacity(tokens, num_sequences, DEFAULT_CHUNK_SIZE)
-        _plain_gate_scan_ragged_kernel[(chunks, heads, triton.cdiv(head_dim, block_dim))](
-            values,
-            output,
-            cu_seqlens,
-            chunk_offsets,
-            num_sequences,
-            LOG2_E,
-            X_STRIDES=(0, *values.stride()[1:]),
-            Y_STRIDES=(0, *output.stride()[1:]),
-            D=head_dim,
-            BT=DEFAULT_CHUNK_SIZE,
-            BD=block_dim,
-            REVERSE=reverse,
-            num_warps=2,
-            num_stages=3,
-        )
-    else:
-        assert chunk_offsets is None and values.shape[0] == 1
-        _plain_gate_scan_dense_kernel[
-            (
-                triton.cdiv(tokens, DEFAULT_CHUNK_SIZE),
-                heads,
-                triton.cdiv(head_dim, block_dim),
+    with torch.cuda.device(values.device):
+        _, tokens, heads, head_dim = values.shape
+        is_ragged = cu_seqlens is not None
+        # Packed reverse scans do not visit inactive capacity; its gradient must be zero
+        # before upstream parameter reductions consume it.
+        factory = torch.zeros_like if is_ragged and reverse else torch.empty_like
+        output = factory(values, memory_format=torch.contiguous_format)
+        block_dim = 32
+        if is_ragged:
+            assert chunk_offsets is not None
+            num_sequences = cu_seqlens.shape[0] - 1
+            chunks = chunk_capacity(tokens, num_sequences, DEFAULT_CHUNK_SIZE)
+            _plain_gate_scan_ragged_kernel[(chunks, heads, triton.cdiv(head_dim, block_dim))](
+                values,
+                output,
+                cu_seqlens,
+                chunk_offsets,
+                num_sequences,
+                LOG2_E,
+                X_STRIDES=(0, *values.stride()[1:]),
+                Y_STRIDES=(0, *output.stride()[1:]),
+                D=head_dim,
+                BT=DEFAULT_CHUNK_SIZE,
+                BD=block_dim,
+                REVERSE=reverse,
+                num_warps=2,
+                num_stages=3,
             )
-        ](
-            values,
-            output,
-            tokens,
-            LOG2_E,
-            X_STRIDES=(0, *values.stride()[1:]),
-            Y_STRIDES=(0, *output.stride()[1:]),
-            D=head_dim,
-            BT=DEFAULT_CHUNK_SIZE,
-            BD=block_dim,
-            REVERSE=reverse,
-            num_warps=2,
-            num_stages=3,
-        )
-    return output
+        else:
+            assert chunk_offsets is None and values.shape[0] == 1
+            _plain_gate_scan_dense_kernel[
+                (
+                    triton.cdiv(tokens, DEFAULT_CHUNK_SIZE),
+                    heads,
+                    triton.cdiv(head_dim, block_dim),
+                )
+            ](
+                values,
+                output,
+                tokens,
+                LOG2_E,
+                X_STRIDES=(0, *values.stride()[1:]),
+                Y_STRIDES=(0, *output.stride()[1:]),
+                D=head_dim,
+                BT=DEFAULT_CHUNK_SIZE,
+                BD=block_dim,
+                REVERSE=reverse,
+                num_warps=2,
+                num_stages=3,
+            )
+        return output
 
 
 __all__ = ["_plain_gate_scan_cuda"]

--- a/attn_gym/linear/kda/impl/mega.py
+++ b/attn_gym/linear/kda/impl/mega.py
@@ -1,0 +1,393 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Autograd integration for the experimental CuTeDSL 4.7 KDA forward."""
+
+from __future__ import annotations
+
+import torch
+
+from attn_gym._backends.cute import tensor_supports_contiguous_dim, tensor_supports_tma
+from attn_gym.linear._delta_rule.validation import resolve_scale
+from attn_gym.linear.kda.chunk_schedule import prepare_ragged_chunk_metadata
+from attn_gym.linear.kda.impl.mega_ops import (
+    chunk_mega_dense_training_fwd_op,
+    chunk_mega_packed_fwd_op,
+    chunk_mega_packed_fwd_with_initial_state_op,
+    chunk_mega_packed_fwd_with_state_op,
+    chunk_mega_packed_local_bwd_op,
+    chunk_mega_packed_training_fwd_op,
+    plain_gate_bwd_dense_cute_op,
+    validate_mega_available,
+)
+from attn_gym.linear.kda.ops import (
+    _plain_gate_scan_op,
+    chunk_bwd_recompute_factors_op,
+    chunk_bwd_recompute_factors_with_state_grad_op,
+)
+
+_CHUNK_SIZE = 64
+_SUPPORTED_IO_DTYPES = (torch.float16, torch.bfloat16)
+
+# NOTE [Mega backward crossover]
+# These thresholds correspond to the dense and packed crossover cases in benchmarks/kda.py.
+# Re-run those boundary cases before changing the policy; the public approximation policy remains
+# independent and is controlled only by split_backward.
+_DENSE_LOCAL_BACKWARD_MIN_TOKENS = 32768
+_PACKED_LOCAL_BACKWARD_MIN_TOKENS = 4096
+_LOCAL_BACKWARD_MIN_HEADS = 64
+
+
+def use_local_backward(q: torch.Tensor, min_tokens: int) -> bool:
+    """Select the Mega backward where its launch savings amortize setup."""
+    return q.shape[1] >= min_tokens and q.shape[2] >= _LOCAL_BACKWARD_MIN_HEADS
+
+
+def normalize_output_grad(d_output: torch.Tensor | None, value: torch.Tensor) -> torch.Tensor:
+    """Materialize the contiguous output cotangent required by the Mega operator ABI."""
+    return torch.zeros_like(value) if d_output is None else d_output.contiguous()
+
+
+class ChunkKdaMegaDense(torch.autograd.Function):
+    """Attach autograd to the dense no-state Mega path."""
+
+    @staticmethod
+    def forward(ctx, q, k, value, gate, beta, cu_seqlens, scale, split_backward):
+        ctx.use_local_backward = split_backward and use_local_backward(
+            q, _DENSE_LOCAL_BACKWARD_MIN_TOKENS
+        )
+        ctx.split_backward = split_backward
+        ctx.scale = scale
+        if ctx.use_local_backward:
+            output = chunk_mega_packed_fwd_op(q, k, value, gate, beta, cu_seqlens, scale)
+            ctx.save_for_backward(q, k, value, gate, beta, cu_seqlens)
+        else:
+            output, cumulative_gate = chunk_mega_dense_training_fwd_op(
+                q,
+                k,
+                value,
+                gate,
+                beta,
+                cu_seqlens,
+                scale,
+            )
+            ctx.save_for_backward(q, k, value, cumulative_gate, beta)
+        ctx.set_materialize_grads(False)
+        return output
+
+    @staticmethod
+    @torch.autograd.function.once_differentiable
+    def backward(ctx, d_output):
+        if ctx.use_local_backward:
+            q, k, value, gate, beta, cu_seqlens = ctx.saved_tensors
+            return (
+                *chunk_mega_packed_local_bwd_op(
+                    q,
+                    k,
+                    value,
+                    gate,
+                    beta,
+                    normalize_output_grad(d_output, value),
+                    cu_seqlens,
+                    ctx.split_backward,
+                    ctx.scale,
+                ),
+                None,
+                None,
+                None,
+            )
+
+        q, k, value, cumulative_gate, beta = ctx.saved_tensors
+        dq, dk, dv, d_cumulative, d_beta = chunk_bwd_recompute_factors_op(
+            q,
+            k,
+            value,
+            cumulative_gate,
+            beta,
+            None,
+            None,
+            normalize_output_grad(d_output, value),
+            None,
+            None,
+            ctx.scale,
+            False,
+            False,
+        )
+        d_gate = plain_gate_bwd_dense_cute_op(d_cumulative.contiguous())
+        return dq, dk, dv, d_gate, d_beta, None, None, None
+
+
+class ChunkKdaMegaPacked(torch.autograd.Function):
+    """Attach autograd to packed Mega calls with optional recurrent state."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        q,
+        k,
+        value,
+        gate,
+        beta,
+        initial_state,
+        cu_seqlens,
+        chunk_offsets,
+        scale,
+        split_backward,
+        output_final_state,
+    ):
+        ctx.has_initial_state = initial_state is not None
+        ctx.use_local_backward = not ctx.has_initial_state and use_local_backward(
+            q, _PACKED_LOCAL_BACKWARD_MIN_TOKENS
+        )
+        ctx.split_backward = split_backward
+        ctx.scale = scale
+        if ctx.use_local_backward:
+            output = chunk_mega_packed_fwd_op(
+                q,
+                k,
+                value,
+                gate,
+                beta,
+                cu_seqlens,
+                scale,
+            )
+            ctx.save_for_backward(q, k, value, gate, beta, cu_seqlens)
+        elif ctx.has_initial_state:
+            if output_final_state:
+                output, final_state = chunk_mega_packed_fwd_with_state_op(
+                    q,
+                    k,
+                    value,
+                    gate,
+                    beta,
+                    initial_state,
+                    cu_seqlens,
+                    scale,
+                )
+            else:
+                output = chunk_mega_packed_fwd_with_initial_state_op(
+                    q,
+                    k,
+                    value,
+                    gate,
+                    beta,
+                    initial_state,
+                    cu_seqlens,
+                    scale,
+                )
+            ctx.save_for_backward(
+                q,
+                k,
+                value,
+                gate,
+                beta,
+                initial_state,
+                cu_seqlens,
+                chunk_offsets,
+            )
+        else:
+            output, cumulative_gate = chunk_mega_packed_training_fwd_op(
+                q,
+                k,
+                value,
+                gate,
+                beta,
+                cu_seqlens,
+                chunk_offsets,
+                scale,
+            )
+            ctx.save_for_backward(q, k, value, cumulative_gate, beta, cu_seqlens, chunk_offsets)
+        ctx.set_materialize_grads(False)
+        if output_final_state:
+            assert ctx.has_initial_state
+            return output, final_state
+        return output
+
+    @staticmethod
+    @torch.autograd.function.once_differentiable
+    def backward(ctx, d_output, d_final_state=None):
+        if ctx.use_local_backward:
+            q, k, value, gate, beta, cu_seqlens = ctx.saved_tensors
+            return (
+                *chunk_mega_packed_local_bwd_op(
+                    q,
+                    k,
+                    value,
+                    gate,
+                    beta,
+                    normalize_output_grad(d_output, value),
+                    cu_seqlens,
+                    ctx.split_backward,
+                    ctx.scale,
+                ),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+
+        if ctx.has_initial_state:
+            q, k, value, gate, beta, initial_state, cu_seqlens, chunk_offsets = ctx.saved_tensors
+            cumulative_gate = _plain_gate_scan_op(gate, cu_seqlens, chunk_offsets, False)
+            dq, dk, dv, d_cumulative, d_beta, d_initial_state = (
+                chunk_bwd_recompute_factors_with_state_grad_op(
+                    q,
+                    k,
+                    value,
+                    cumulative_gate,
+                    beta,
+                    cu_seqlens,
+                    chunk_offsets,
+                    normalize_output_grad(d_output, value),
+                    d_final_state,
+                    initial_state,
+                    ctx.scale,
+                    False,
+                    False,
+                )
+            )
+        else:
+            q, k, value, cumulative_gate, beta, cu_seqlens, chunk_offsets = ctx.saved_tensors
+            dq, dk, dv, d_cumulative, d_beta = chunk_bwd_recompute_factors_op(
+                q,
+                k,
+                value,
+                cumulative_gate,
+                beta,
+                cu_seqlens,
+                chunk_offsets,
+                normalize_output_grad(d_output, value),
+                None,
+                None,
+                ctx.scale,
+                False,
+                False,
+            )
+            d_initial_state = None
+        d_gate = _plain_gate_scan_op(d_cumulative.contiguous(), cu_seqlens, chunk_offsets, True)
+        return (
+            dq,
+            dk,
+            dv,
+            d_gate,
+            d_beta,
+            d_initial_state,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+
+
+def validate_mega_constraints(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    value: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+) -> None:
+    """Validate only the additional layout, dtype, and shape constraints of Mega."""
+    if not q.is_cuda:
+        raise ValueError("the Mega KDA backend requires CUDA tensors")
+    if q.shape[0] != 1 or q.shape[-1] != 128 or value.shape[-1] != 128:
+        raise ValueError("the Mega backend requires B=1 and K=V=128")
+    if q.dtype not in _SUPPORTED_IO_DTYPES or k.dtype != q.dtype or value.dtype != q.dtype:
+        raise TypeError("q, k, and value must share dtype float16 or bfloat16")
+    if gate.dtype != torch.float32 or beta.dtype != torch.float32:
+        raise TypeError("gate and beta must be float32")
+    if initial_state is not None and initial_state.dtype != torch.float32:
+        raise TypeError("initial_state must be float32")
+    if not torch.compiler.is_compiling():
+        tma_tensors = (q, k, value, gate) + (() if initial_state is None else (initial_state,))
+        if any(not tensor_supports_tma(tensor) for tensor in tma_tensors):
+            raise TypeError(
+                "Mega q, k, value, gate, and state require a TMA-compatible inner mode"
+            )
+        if not tensor_supports_contiguous_dim(beta, alignment_bytes=4):
+            raise TypeError("Mega beta requires a contiguous, element-aligned inner mode")
+        if cu_seqlens is not None and cu_seqlens.data_ptr() % 8:
+            raise TypeError("Mega cu_seqlens must be 8-byte aligned")
+    if cu_seqlens is None and q.shape[1] % _CHUNK_SIZE:
+        raise ValueError(
+            "dense Mega execution requires T divisible by 64; pass cu_seqlens for tails"
+        )
+
+
+def chunk_forward(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    value: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None = None,
+    *,
+    cu_seqlens: torch.Tensor | None = None,
+    scale: float | None = None,
+    output_final_state: bool = False,
+    fastmath: bool = False,
+    autotune: bool = True,
+    split_backward: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Run the optional Mega implementation behind the shared ``chunk_kda`` contract."""
+    scale = resolve_scale(scale, q.shape[-1])
+    if fastmath:
+        raise ValueError("fastmath is not supported by the Mega backend")
+    if split_backward and (initial_state is not None or output_final_state):
+        raise ValueError("split_backward currently requires a no-state call")
+    del autotune
+    if not torch.compiler.is_compiling():
+        validate_mega_available(q)
+
+    if cu_seqlens is None and initial_state is None and not output_final_state:
+        validate_mega_constraints(q, k, value, gate, beta, None, None)
+        dense_cu_seqlens = torch.arange(2, dtype=torch.int32, device=q.device) * q.shape[1]
+        return (
+            ChunkKdaMegaDense.apply(
+                q,
+                k,
+                value,
+                gate,
+                beta,
+                dense_cu_seqlens,
+                scale,
+                split_backward,
+            ),
+            None,
+        )
+
+    if cu_seqlens is None:
+        cu_seqlens = torch.arange(2, dtype=torch.int32, device=q.device) * q.shape[1]
+    if output_final_state and initial_state is None:
+        initial_state = torch.zeros(
+            cu_seqlens.shape[0] - 1,
+            q.shape[2],
+            value.shape[-1],
+            q.shape[3],
+            dtype=torch.float32,
+            device=q.device,
+        )
+    validate_mega_constraints(q, k, value, gate, beta, initial_state, cu_seqlens)
+    metadata = prepare_ragged_chunk_metadata(cu_seqlens, q.shape[1], _CHUNK_SIZE)
+    result = ChunkKdaMegaPacked.apply(
+        q,
+        k,
+        value,
+        gate,
+        beta,
+        initial_state,
+        metadata.cu_seqlens,
+        metadata.chunk_offsets,
+        scale,
+        split_backward,
+        output_final_state,
+    )
+    if output_final_state:
+        return result
+    return result, None
+
+
+__all__ = ["chunk_forward"]

--- a/attn_gym/linear/kda/impl/mega_ops.py
+++ b/attn_gym/linear/kda/impl/mega_ops.py
@@ -1,0 +1,267 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Private KDA operators around the shared CuTeDSL 4.7 Mega launchers."""
+
+from __future__ import annotations
+
+import importlib
+
+import torch
+
+from attn_gym.utils import fork_join_streams
+
+torch.library.define(
+    "attn_gym::kda_chunk_mega_packed_fwd",
+    "(Tensor q, Tensor k, Tensor v, Tensor gate, Tensor beta, Tensor cu_seqlens, "
+    "float scale) -> Tensor",
+)
+torch.library.define(
+    "attn_gym::kda_chunk_mega_dense_training_fwd",
+    "(Tensor q, Tensor k, Tensor v, Tensor gate, Tensor beta, Tensor cu_seqlens, "
+    "float scale) -> (Tensor, Tensor)",
+)
+torch.library.define(
+    "attn_gym::kda_chunk_mega_packed_training_fwd",
+    "(Tensor q, Tensor k, Tensor v, Tensor gate, Tensor beta, "
+    "Tensor cu_seqlens, Tensor chunk_offsets, float scale) -> (Tensor, Tensor)",
+)
+torch.library.define(
+    "attn_gym::kda_chunk_mega_packed_fwd_with_initial_state",
+    "(Tensor q, Tensor k, Tensor v, Tensor gate, Tensor beta, "
+    "Tensor initial_state, Tensor cu_seqlens, float scale) -> Tensor",
+)
+torch.library.define(
+    "attn_gym::kda_chunk_mega_packed_fwd_with_state",
+    "(Tensor q, Tensor k, Tensor v, Tensor gate, Tensor beta, "
+    "Tensor initial_state, Tensor cu_seqlens, float scale) -> (Tensor, Tensor)",
+)
+torch.library.define(
+    "attn_gym::kda_chunk_mega_packed_local_bwd",
+    "(Tensor q, Tensor k, Tensor v, Tensor gate, Tensor beta, Tensor d_output, "
+    "Tensor cu_seqlens, bool split, float scale) "
+    "-> (Tensor, Tensor, Tensor, Tensor, Tensor)",
+)
+torch.library.define(
+    "attn_gym::kda_plain_gate_bwd_dense_cute",
+    "(Tensor d_cumulative) -> Tensor",
+)
+
+_GATE_STREAMS: dict[int, torch.cuda.Stream] = {}
+_MAIN_STREAMS: dict[int, torch.cuda.Stream] = {}
+
+
+def _backend(q: torch.Tensor):
+    """Import and preflight the optional backend before launching asynchronous work."""
+    try:
+        backend = importlib.import_module("attn_gym.linear._delta_rule.mega.forward")
+    except ImportError as error:
+        raise ImportError("the Mega KDA backend requires CUDA and attn-gym[mega]") from error
+    backend.validate_available(q)
+    return backend
+
+
+def validate_mega_available(q: torch.Tensor) -> None:
+    """Fail before caller-side setup when the optional backend cannot run."""
+    _backend(q)
+
+
+def _stream(cache: dict[int, torch.cuda.Stream], device: torch.device, priority: int = 0):
+    index = torch.cuda.current_device() if device.index is None else device.index
+    stream = cache.get(index)
+    if stream is None:
+        stream = torch.cuda.Stream(device=index, priority=priority)
+        cache[index] = stream
+    return stream
+
+
+def _packed_fwd_cuda(q, k, value, gate, beta, cu_seqlens, scale, *, backend=None):
+    backend = _backend(q) if backend is None else backend
+    return backend.chunk_delta_rule_fwd_mega_unsplit(
+        q,
+        k,
+        value,
+        gate,
+        beta,
+        cu_seqlens,
+        scale,
+    )
+
+
+def _dense_training_fwd_cuda(q, k, value, gate, beta, cu_seqlens, scale):
+    from attn_gym.linear.kda.fwd.triton.plain_gate import _plain_gate_scan_cuda
+
+    backend = _backend(q)
+    # Prioritize the persistent one-CTA-per-SM Mega grid; the scan can fill its drain tail.
+    cumulative_gate, output = fork_join_streams(
+        torch.cuda.current_stream(q.device),
+        _stream(_MAIN_STREAMS, q.device, priority=-1),
+        lambda: _packed_fwd_cuda(
+            q,
+            k,
+            value,
+            gate,
+            beta,
+            cu_seqlens,
+            scale,
+            backend=backend,
+        ),
+        lambda: _plain_gate_scan_cuda(gate, None, None, False),
+    )
+    return output, cumulative_gate
+
+
+def _packed_training_fwd_cuda(q, k, value, gate, beta, cu_seqlens, chunk_offsets, scale):
+    from attn_gym.linear.kda.fwd.triton.plain_gate import _plain_gate_scan_cuda
+
+    backend = _backend(q)
+    output, cumulative_gate = fork_join_streams(
+        torch.cuda.current_stream(q.device),
+        _stream(_GATE_STREAMS, q.device),
+        lambda: _plain_gate_scan_cuda(gate, cu_seqlens, chunk_offsets, False),
+        lambda: _packed_fwd_cuda(
+            q,
+            k,
+            value,
+            gate,
+            beta,
+            cu_seqlens,
+            scale,
+            backend=backend,
+        ),
+    )
+    return output, cumulative_gate
+
+
+def _packed_fwd_with_initial_state_cuda(q, k, value, gate, beta, initial_state, cu_seqlens, scale):
+    backend = _backend(q)
+    return backend.chunk_delta_rule_fwd_mega_unsplit_with_initial_state(
+        q,
+        k,
+        value,
+        gate,
+        beta,
+        initial_state,
+        cu_seqlens,
+        scale,
+    )
+
+
+def _packed_fwd_with_state_cuda(q, k, value, gate, beta, initial_state, cu_seqlens, scale):
+    backend = _backend(q)
+    return backend.chunk_delta_rule_fwd_mega_unsplit_with_state(
+        q,
+        k,
+        value,
+        gate,
+        beta,
+        initial_state,
+        cu_seqlens,
+        scale,
+    )
+
+
+def _packed_local_bwd_cuda(q, k, value, gate, beta, d_output, cu_seqlens, split, scale):
+    from attn_gym.linear._delta_rule.mega.backward import chunk_delta_rule_bwd_mega_packed
+
+    return chunk_delta_rule_bwd_mega_packed(
+        q,
+        k,
+        value,
+        gate,
+        beta,
+        d_output,
+        cu_seqlens,
+        scale=scale,
+        split=split,
+    )
+
+
+def _plain_gate_bwd_cuda(d_cumulative):
+    from attn_gym.linear._delta_rule.mega.kernels.kda_plain_gate_bwd import (
+        plain_gate_cumsum_dense_bwd_cute,
+    )
+
+    return plain_gate_cumsum_dense_bwd_cute(d_cumulative)
+
+
+torch.library.impl("attn_gym::kda_chunk_mega_packed_fwd", "CUDA", _packed_fwd_cuda)
+torch.library.impl("attn_gym::kda_chunk_mega_dense_training_fwd", "CUDA", _dense_training_fwd_cuda)
+torch.library.impl(
+    "attn_gym::kda_chunk_mega_packed_training_fwd", "CUDA", _packed_training_fwd_cuda
+)
+torch.library.impl(
+    "attn_gym::kda_chunk_mega_packed_fwd_with_initial_state",
+    "CUDA",
+    _packed_fwd_with_initial_state_cuda,
+)
+torch.library.impl(
+    "attn_gym::kda_chunk_mega_packed_fwd_with_state", "CUDA", _packed_fwd_with_state_cuda
+)
+torch.library.impl("attn_gym::kda_chunk_mega_packed_local_bwd", "CUDA", _packed_local_bwd_cuda)
+torch.library.impl("attn_gym::kda_plain_gate_bwd_dense_cute", "CUDA", _plain_gate_bwd_cuda)
+
+
+@torch.library.register_fake("attn_gym::kda_chunk_mega_packed_fwd")
+def _packed_fwd_fake(q, k, value, gate, beta, cu_seqlens, scale):
+    del q, k, gate, beta, cu_seqlens, scale
+    return torch.empty_like(value)
+
+
+@torch.library.register_fake("attn_gym::kda_chunk_mega_dense_training_fwd")
+def _dense_training_fwd_fake(q, k, value, gate, beta, cu_seqlens, scale):
+    del q, k, beta, cu_seqlens, scale
+    return torch.empty_like(value), gate.new_empty(gate.shape)
+
+
+@torch.library.register_fake("attn_gym::kda_chunk_mega_packed_training_fwd")
+def _packed_training_fwd_fake(q, k, value, gate, beta, cu_seqlens, chunk_offsets, scale):
+    del q, k, beta, cu_seqlens, chunk_offsets, scale
+    return torch.empty_like(value), gate.new_empty(gate.shape)
+
+
+@torch.library.register_fake("attn_gym::kda_chunk_mega_packed_fwd_with_initial_state")
+def _packed_fwd_with_initial_state_fake(q, k, value, gate, beta, initial_state, cu_seqlens, scale):
+    del q, k, gate, beta, initial_state, cu_seqlens, scale
+    return torch.empty_like(value)
+
+
+@torch.library.register_fake("attn_gym::kda_chunk_mega_packed_fwd_with_state")
+def _packed_fwd_with_state_fake(q, k, value, gate, beta, initial_state, cu_seqlens, scale):
+    del q, k, gate, beta, cu_seqlens, scale
+    return torch.empty_like(value), torch.empty_like(initial_state)
+
+
+@torch.library.register_fake("attn_gym::kda_chunk_mega_packed_local_bwd")
+def _packed_local_bwd_fake(q, k, value, gate, beta, d_output, cu_seqlens, split, scale):
+    del d_output, cu_seqlens, split, scale
+    return tuple(torch.empty_like(tensor[0]).unsqueeze(0) for tensor in (q, k, value, gate, beta))
+
+
+@torch.library.register_fake("attn_gym::kda_plain_gate_bwd_dense_cute")
+def _plain_gate_bwd_fake(d_cumulative):
+    return torch.empty_like(d_cumulative)
+
+
+chunk_mega_packed_fwd_op = torch.ops.attn_gym.kda_chunk_mega_packed_fwd.default
+chunk_mega_dense_training_fwd_op = torch.ops.attn_gym.kda_chunk_mega_dense_training_fwd.default
+chunk_mega_packed_training_fwd_op = torch.ops.attn_gym.kda_chunk_mega_packed_training_fwd.default
+chunk_mega_packed_fwd_with_initial_state_op = (
+    torch.ops.attn_gym.kda_chunk_mega_packed_fwd_with_initial_state.default
+)
+chunk_mega_packed_fwd_with_state_op = (
+    torch.ops.attn_gym.kda_chunk_mega_packed_fwd_with_state.default
+)
+chunk_mega_packed_local_bwd_op = torch.ops.attn_gym.kda_chunk_mega_packed_local_bwd.default
+plain_gate_bwd_dense_cute_op = torch.ops.attn_gym.kda_plain_gate_bwd_dense_cute.default
+
+
+__all__ = [
+    "chunk_mega_dense_training_fwd_op",
+    "chunk_mega_packed_fwd_op",
+    "chunk_mega_packed_fwd_with_initial_state_op",
+    "chunk_mega_packed_fwd_with_state_op",
+    "chunk_mega_packed_local_bwd_op",
+    "chunk_mega_packed_training_fwd_op",
+    "plain_gate_bwd_dense_cute_op",
+    "validate_mega_available",
+]

--- a/attn_gym/linear/kda/validation.py
+++ b/attn_gym/linear/kda/validation.py
@@ -12,11 +12,36 @@ here once; implementation-specific constraints stay with the implementation.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from typing import Literal
+
 import torch
 
 from attn_gym.linear._delta_rule.validation import validate_delta_rule_inputs
 
 SUPPORTED_INPUT_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
+_KERNEL_OPTION_NAMES = frozenset({"backend", "split_backward"})
+
+
+def resolve_kernel_options(
+    kernel_options: Mapping[str, object] | None,
+) -> tuple[Literal["fused", "mega"], bool]:
+    """Validate chunk backend options and resolve their defaults."""
+    if kernel_options is None:
+        return "fused", False
+    unknown = kernel_options.keys() - _KERNEL_OPTION_NAMES
+    if unknown:
+        names = ", ".join(sorted(unknown))
+        raise ValueError(f"unsupported chunk_kda kernel options: {names}")
+    backend = kernel_options.get("backend", "fused")
+    if backend not in ("fused", "mega"):
+        raise ValueError("kernel_options['backend'] must be 'fused' or 'mega'")
+    split_backward = kernel_options.get("split_backward", False)
+    if not isinstance(split_backward, bool):
+        raise TypeError("kernel_options['split_backward'] must be a bool")
+    if split_backward and backend != "mega":
+        raise ValueError("split_backward requires kernel_options['backend']='mega'")
+    return backend, split_backward
 
 
 def validate_kda_inputs(
@@ -60,4 +85,4 @@ def validate_kda_inputs(
         raise TypeError(f"{op_name} inputs must use one of {supported}")
 
 
-__all__ = ["SUPPORTED_INPUT_DTYPES", "validate_kda_inputs"]
+__all__ = ["SUPPORTED_INPUT_DTYPES", "resolve_kernel_options", "validate_kda_inputs"]

--- a/attn_gym/testing/kda.py
+++ b/attn_gym/testing/kda.py
@@ -6,6 +6,10 @@ import math
 from collections.abc import Sequence
 
 import torch
+import torch.nn.functional as F
+
+from attn_gym.linear.kda.constants import LOG2_E
+from attn_gym.linear.kda.naive import naive_recurrent_kda
 
 
 def cumulative_sequence_offsets(
@@ -56,24 +60,78 @@ def make_kda_test_inputs(
     heads: int = 1,
     seed: int = 41,
     gate_scale: float = 1.0,
+    gate_value: float | None = None,
+    log_uniform_gate: bool = False,
+    sigmoid_beta: bool = False,
+    dtype: torch.dtype = torch.bfloat16,
+    normalize_qk: bool = False,
+    value_scale: float = 0.125,
     requires_grad: bool = False,
 ) -> tuple[torch.Tensor, ...]:
     """Create deterministic public KDA inputs with per-token natural-log gates."""
     torch.manual_seed(seed)
     shape = (batch, tokens, heads, 128)
-    values = (
-        torch.randn(shape, device="cuda", dtype=torch.bfloat16) / 8,
-        torch.randn(shape, device="cuda", dtype=torch.bfloat16) / 8,
-        torch.randn(shape, device="cuda", dtype=torch.bfloat16) / 8,
-        -torch.rand(shape, device="cuda") * gate_scale,
-        torch.rand(batch, tokens, heads, device="cuda"),
+    if normalize_qk:
+        q = F.normalize(torch.randn(shape, device="cuda"), dim=-1).to(dtype)
+        k = F.normalize(torch.randn(shape, device="cuda"), dim=-1).to(dtype)
+    else:
+        q = torch.randn(shape, device="cuda", dtype=dtype) / 8
+        k = torch.randn(shape, device="cuda", dtype=dtype) / 8
+    value = torch.randn(shape, device="cuda", dtype=dtype) * value_scale
+    if gate_value is not None:
+        gate = torch.full(shape, gate_value, device="cuda")
+    elif log_uniform_gate:
+        gate = torch.empty(shape, device="cuda").uniform_(math.exp(-gate_scale), 1.0).log_()
+    else:
+        gate = -torch.rand(shape, device="cuda") * gate_scale
+    beta = (
+        torch.randn(batch, tokens, heads, device="cuda").sigmoid_()
+        if sigmoid_beta
+        else torch.rand(batch, tokens, heads, device="cuda")
     )
+    values = (q, k, value, gate, beta)
     return tuple(value.requires_grad_(requires_grad) for value in values)
 
 
-def clone_kda_inputs(inputs: Sequence[torch.Tensor]) -> tuple[torch.Tensor, ...]:
-    """Clone KDA inputs into independent autograd leaves."""
-    return tuple(value.detach().clone().requires_grad_(value.requires_grad) for value in inputs)
+def clone_kda_inputs(
+    inputs: Sequence[torch.Tensor],
+    *,
+    dtype: torch.dtype | None = None,
+) -> tuple[torch.Tensor, ...]:
+    """Clone KDA inputs into independent autograd leaves, optionally changing precision."""
+    return tuple(
+        value.detach()
+        .to(dtype=value.dtype if dtype is None else dtype)
+        .clone()
+        .requires_grad_(value.requires_grad)
+        for value in inputs
+    )
+
+
+def kda_reference(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    value: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None = None,
+    *,
+    cu_seqlens: torch.Tensor | None = None,
+    scale: float | None = None,
+    output_final_state: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Run the eager recurrent KDA oracle using natural-log public gates."""
+    return naive_recurrent_kda(
+        q,
+        k,
+        value,
+        gate * LOG2_E,
+        beta,
+        scale=scale,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        cu_seqlens=cu_seqlens,
+    )
 
 
 def assert_matches_low_precision_reference(
@@ -306,5 +364,6 @@ __all__ = [
     "bwd_wy_dqkg_reference",
     "clone_kda_inputs",
     "cumulative_sequence_offsets",
+    "kda_reference",
     "make_kda_test_inputs",
 ]

--- a/attn_gym/utils.py
+++ b/attn_gym/utils.py
@@ -1,6 +1,8 @@
 import math
+from collections.abc import Callable
 from contextlib import contextmanager, nullcontext
 from pathlib import Path
+from typing import TypeVar
 
 import torch
 from torch.nn.attention.flex_attention import (
@@ -11,17 +13,19 @@ from torch.nn.attention.flex_attention import (
     _vmap_for_bhqkv,
 )
 from torch.profiler import ProfilerActivity, profile
+from torch.utils._pytree import tree_map_only_
 
 # TODO This was moved on nightly, this enables 2.5 and 2.6 | we should remove this once 2.5 is no longer supported
 try:
     from torch._dynamo._trace_wrapped_higher_order_op import TransformGetItemToIndex
 except ImportError:
     from torch._higher_order_ops.flex_attention import TransformGetItemToIndex
-from collections.abc import Callable
 
 from torch._inductor.utils import do_bench_using_profiling
 
 Tensor = torch.Tensor
+CurrentOutputT = TypeVar("CurrentOutputT")
+SideOutputT = TypeVar("SideOutputT")
 
 
 def ceildiv(number: int, divisor: int) -> int:
@@ -34,6 +38,49 @@ def benchmark_cuda_function_in_microseconds(func: Callable, *args, **kwargs) -> 
     no_args = lambda: func(*args, **kwargs)
     time = do_bench_using_profiling(no_args)
     return time * 1e3
+
+
+def fork_join_streams(
+    current_stream: torch.cuda.Stream,
+    side_stream: torch.cuda.Stream,
+    side_work: Callable[[], SideOutputT],
+    current_work: Callable[[], CurrentOutputT],
+) -> tuple[CurrentOutputT, SideOutputT]:
+    """Run independent work on a current CUDA stream and a forked side stream.
+
+    The side stream first waits for work already queued on the current stream. Both
+    callbacks then run on their designated streams, after which the current stream
+    joins the side stream even if either callback raises. Every tensor leaf in the
+    side result is recorded on the current stream so returned allocations remain live
+    while later current-stream consumers use them.
+
+    Args:
+        current_stream: Caller stream that runs ``current_work`` and receives the join.
+        side_stream: Auxiliary stream that runs ``side_work``.
+        side_work: Zero-argument callback launched on ``side_stream``.
+        current_work: Zero-argument callback launched on ``current_stream``.
+
+    Returns:
+        A ``(current_output, side_output)`` pair preserving both callbacks' result
+        types and PyTree structures.
+    """
+    side_stream.wait_stream(current_stream)
+    try:
+        with torch.cuda.stream(side_stream):
+            side_output = side_work()
+        with torch.cuda.stream(current_stream):
+            current_output = current_work()
+    finally:
+        current_stream.wait_stream(side_stream)
+    if isinstance(side_output, torch.Tensor):
+        side_output.record_stream(current_stream)
+    else:
+        tree_map_only_(
+            torch.Tensor,
+            lambda tensor: tensor.record_stream(current_stream),
+            side_output,
+        )
+    return current_output, side_output
 
 
 def merge_attention(

--- a/benchmarks/kda.py
+++ b/benchmarks/kda.py
@@ -1,0 +1,198 @@
+"""Correctness-preserving KDA performance matrix for reference, fused, and Mega."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import torch
+
+
+@dataclass(frozen=True)
+class Case:
+    name: str
+    lengths: tuple[int, ...]
+    heads: int
+    mega_bf16_budget_us: float
+    reference: bool = False
+
+
+CASES = (
+    Case("smoke", (128,), 1, 300.0, True),
+    Case("primary", (8192,), 64, 3450.0),
+    Case("dense_t1024_h16", (1024,), 16, 250.0),
+    Case("dense_t1024_h64", (1024,), 64, 520.0),
+    Case("dense_t4096_h16", (4096,), 16, 780.0),
+    Case("dense_t4096_h64", (4096,), 64, 1850.0),
+    Case("dense_t32768_h16", (32768,), 16, 5500.0),
+    Case("dense_t32768_h64", (32768,), 64, 14000.0),
+    Case("packed_balanced", (4096, 4096), 64, 1950.0),
+    Case("packed_imbalanced", (65, 1024, 4096, 0, 127), 64, 1950.0),
+    Case("packed_many_short", (64,) * 64, 64, 1000.0),
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Benchmark KDA training implementations against fixed correctness-preserving cases."
+    )
+    parser.add_argument(
+        "--impl",
+        nargs="+",
+        choices=("reference", "fused", "mega"),
+        default=("fused", "mega"),
+        help="implementations to benchmark",
+    )
+    parser.add_argument(
+        "--case",
+        action="append",
+        dest="cases",
+        choices=[case.name for case in CASES],
+        help="case to run; may be repeated",
+    )
+    parser.add_argument(
+        "--dtype",
+        choices=("bfloat16", "float16"),
+        default="bfloat16",
+        help="Q/K/V and output-gradient dtype",
+    )
+    parser.add_argument("--rounds", type=int, default=3, help="timing rounds")
+    parser.add_argument("--iterations", type=int, default=20, help="graph replays per round")
+    parser.add_argument("--warmups", type=int, default=3, help="warmup iterations")
+    parser.add_argument("--output", type=Path, help="optional JSON output path")
+    return parser.parse_args()
+
+
+def make_inputs(case: Case, dtype: torch.dtype = torch.bfloat16):
+    torch.manual_seed(0)
+    tokens, dim = sum(case.lengths), 128
+    shape = (1, tokens, case.heads, dim)
+    values = (
+        torch.nn.functional.normalize(torch.randn(shape, device="cuda"), dim=-1).to(dtype),
+        torch.nn.functional.normalize(torch.randn(shape, device="cuda"), dim=-1).to(dtype),
+        torch.randn(shape, device="cuda", dtype=dtype),
+        torch.empty(shape, device="cuda").uniform_(0.5, 1.0).log(),
+        torch.sigmoid(torch.randn(1, tokens, case.heads, device="cuda")),
+    )
+    inputs = tuple(value.requires_grad_() for value in values)
+    offsets = [0]
+    for length in case.lengths:
+        offsets.append(offsets[-1] + length)
+    cu_seqlens = torch.tensor(offsets, dtype=torch.int32, device="cuda")
+    return inputs, cu_seqlens, torch.randn_like(inputs[2])
+
+
+def forward_for(implementation: str, inputs, cu_seqlens):
+    from attn_gym.linear import chunk_kda
+
+    q, k, value, raw_gate, beta = inputs
+    packed = cu_seqlens.shape[0] > 2
+    output, _ = chunk_kda(
+        q,
+        k,
+        value,
+        raw_gate,
+        beta,
+        cu_seqlens=cu_seqlens if packed else None,
+        autotune=False,
+        impl="fused" if implementation == "mega" else implementation,
+        kernel_options={"backend": "mega"} if implementation == "mega" else None,
+    )
+    return output
+
+
+def benchmark(
+    case: Case,
+    implementation: str,
+    dtype: torch.dtype,
+    rounds: int,
+    iterations: int,
+    warmups: int,
+):
+    if implementation == "reference" and not case.reference:
+        return {"status": "skipped", "reason": "reference is restricted to smoke cases"}
+    inputs, cu_seqlens, d_output = make_inputs(case, dtype)
+
+    def step():
+        output = forward_for(implementation, inputs, cu_seqlens)
+        return torch.autograd.grad(output, inputs, d_output)
+
+    for _ in range(warmups):
+        step()
+    torch.cuda.synchronize()
+
+    if implementation == "reference":
+        graph = None
+    else:
+        graph = torch.cuda.CUDAGraph()
+        torch.autograd.graph.set_override_stale_capture_stream(True)
+        try:
+            with torch.cuda.graph(graph):
+                captured = step()
+        finally:
+            torch.autograd.graph.set_override_stale_capture_stream(False)
+        del captured
+        for _ in range(warmups):
+            graph.replay()
+        torch.cuda.synchronize()
+
+    samples = []
+    for _ in range(rounds):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(iterations):
+            step() if graph is None else graph.replay()
+        end.record()
+        end.synchronize()
+        samples.append(start.elapsed_time(end) * 1000 / iterations)
+    median = statistics.median(samples)
+    budget_us = (
+        case.mega_bf16_budget_us if implementation == "mega" and dtype == torch.bfloat16 else None
+    )
+    passed = budget_us is None or median <= budget_us
+    return {
+        "status": "passed" if passed else "failed",
+        "samples_us": samples,
+        "median_us": median,
+        "budget_us": budget_us,
+    }
+
+
+def main() -> None:
+    args = parse_args()
+    selected = [case for case in CASES if args.cases is None or case.name in args.cases]
+    dtype = getattr(torch, args.dtype)
+    results = []
+    failed = False
+    for case in selected:
+        for implementation in args.impl:
+            result = benchmark(
+                case,
+                implementation,
+                dtype,
+                args.rounds,
+                args.iterations,
+                args.warmups,
+            )
+            failed |= result["status"] == "failed"
+            row = {"case": asdict(case), "impl": implementation, **result}
+            results.append(row)
+            print(json.dumps(row), flush=True)
+    payload = {
+        "gpu": torch.cuda.get_device_name(),
+        "torch": torch.__version__,
+        "dtype": str(dtype),
+        "results": results,
+    }
+    if args.output is not None:
+        args.output.write_text(json.dumps(payload, indent=2) + "\n")
+    if failed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -16,8 +16,8 @@ state = decayed_state + outer(residual, key)
 output = scale * state @ query
 ```
 
-Public and persistent state uses V-major storage shaped `[N, H, V, K]`; paged pools replace `N`
-with the slot count. `chunk_gdn` uses a chunk-parallel decomposition for training and prefill.
+Public and persistent state uses axis order `[N, H, V, K]`; paged pools replace `N` with the
+slot count. `chunk_gdn` uses a chunk-parallel decomposition for training and prefill.
 `recurrent_gdn` consumes
 tokens in order for decoding, inference prefill, and state-carrying correctness checks. The caller
 chooses the execution form explicitly. `impl="reference"` selects eager PyTorch;
@@ -89,8 +89,8 @@ The KDA references use token-major tensors: query, key, and per-channel gate are
 `[batch, sequence, heads, key_dimension]`; value is
 `[batch, sequence, heads, value_dimension]`; beta is
 `[batch, sequence, heads]`. Both recurrent and chunked forms support ordinary
-PyTorch autograd and an optional V-major recurrent state shaped `[N, H, V, K]`. Paged prefill and
-decode use the same layout with the leading dimension interpreted as cache slots.
+PyTorch autograd and an optional recurrent state shaped `[N, H, V, K]`. Paged prefill and decode
+use the same axis order with the leading dimension interpreted as cache slots.
 
 `examples/kda_training.py` builds these operations into a small trainable
 `[B, T, hidden_size] -> [B, T, hidden_size]` attention module. To mirror the
@@ -280,9 +280,9 @@ and enforces their constraints (the chunked core requires `head_dim=128` and Bla
 preserves homogeneous FP16/BF16 Q/K/V, normalizes FP32 or mixed inputs to BF16, and chunks at
 64 tokens; the fused recurrent scan is inference-only), while `"reference"`
 runs the eager FP32 oracle behind the identical packed contract on any hardware and head
-dimension, and stays differentiable. There is no automatic fallback between the two, and
-the chunk-versus-recurrent switch is caller policy (on B200 the scan wins below roughly
-32 tokens per sequence).
+dimension, and stays differentiable. There is no automatic fallback between implementations, and
+the chunk-versus-recurrent switch is caller policy (on B200 the scan wins below roughly 32 tokens
+per sequence).
 
 `recurrent_kda_decode` is the serving-specific one-token path. It consumes
 channel-major post-convolution QKV (`[Q for all heads | K for all heads | V for all
@@ -290,6 +290,23 @@ heads]`), raw gate and beta projections, and a paged state cache. Q/K normalizat
 gate activation, beta sigmoid, recurrence, output, and state-cache update run in one
 Triton kernel. Callers may provide a stable output buffer for allocation-free CUDA
 Graph replay.
+
+`chunk_kda(..., kernel_options={"backend": "mega"})` selects an opt-in SM100/SM103
+FP16/BF16 training backend for
+applications that already hold per-token natural-log gate increments. Q/K/V share one dtype. It uses
+public CuTeDSL 4.7 primitives and has no cuDNN Frontend runtime dependency. Like the other
+implementations, it returns `(output, final_state)`; request the latter with
+`output_final_state=True`. Dense no-state calls require T divisible by 64 and omit `cu_seqlens`,
+while packed/stateful calls pass explicit contiguous int32 boundaries and FP32 `[N, H, V, K]`
+states. Q/K/V/gate/state accept TMA-compatible innermost modes with aligned dynamic outer strides;
+beta requires an element-aligned contiguous inner mode. Forward is always exact and unsplit.
+FP16 and BF16 use exact backward execution by default; eligible packed no-state long contexts may
+use the Mega backward with one unsplit work item per sequence and head. Callers that guarantee
+normalized keys, post-sigmoid beta, and nonpositive decay increments may explicitly opt into
+approximate backward-only forgetting-horizon splitting with
+`kernel_options={"backend": "mega", "split_backward": True}`. The implementation chooses the
+split count from the input geometry; no public split-size knob is exposed. Split backward currently
+requires a no-state call. Install the `mega` extra to use this backend.
 
 ::: attn_gym.linear.chunk_kda
 

--- a/test/kda/mega/test_kda_mega_forward.py
+++ b/test/kda/mega/test_kda_mega_forward.py
@@ -1,0 +1,257 @@
+import math
+
+import pytest
+import torch
+
+pytest.importorskip(
+    "cutlass.experimental",
+    reason="the CuTeDSL 4.7 KDA path requires nvidia-cutlass-dsl>=4.7",
+)
+
+from attn_gym.linear._delta_rule.mega import forward as adapter
+from attn_gym.linear._delta_rule.mega.forward import (
+    chunk_delta_rule_fwd_mega_unsplit,
+    chunk_delta_rule_fwd_mega_unsplit_with_state,
+)
+from attn_gym.linear._delta_rule.mega.kernels.common.split_k import (
+    WORK_ITEM_FIELDS,
+    build_split_table,
+    chunk_scratch_rows,
+)
+from attn_gym.testing.kda import (
+    assert_matches_low_precision_reference,
+    cumulative_sequence_offsets,
+    kda_reference,
+    make_kda_test_inputs,
+)
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() not in ((10, 0), (10, 3)),
+    reason="the CuTeDSL 4.7 KDA path requires SM100 or SM103",
+)
+
+
+def _reference_forward(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    value: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    output, final_state = kda_reference(
+        q.to(dtype),
+        k.to(dtype),
+        value.to(dtype),
+        gate.to(dtype),
+        beta.to(dtype),
+        initial_state.to(dtype),
+        cu_seqlens=cu_seqlens,
+    )
+    assert final_state is not None
+    return output, final_state
+
+
+def _inputs(dtype: torch.dtype = torch.bfloat16) -> tuple[torch.Tensor, ...]:
+    lengths = (65, 0, 127)
+    q, k, value, gate, beta = make_kda_test_inputs(
+        sum(lengths),
+        seed=0,
+        gate_scale=math.log(2.0),
+        log_uniform_gate=True,
+        sigmoid_beta=True,
+        dtype=dtype,
+        normalize_qk=True,
+        value_scale=1.0,
+    )
+    initial_state = torch.randn(len(lengths), 1, 128, 128, device="cuda").div_(100)
+    return (
+        q,
+        k,
+        value,
+        gate,
+        beta,
+        cumulative_sequence_offsets(lengths),
+        initial_state,
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_mega_forward_packed_tail_empty_and_deterministic(dtype: torch.dtype) -> None:
+    q, k, value, gate, beta, cu_seqlens, initial_state = _inputs(dtype)
+    zero_state = torch.zeros_like(initial_state)
+    low_precision, _ = _reference_forward(
+        q, k, value, gate, beta, zero_state, cu_seqlens, torch.float32
+    )
+    high_precision, _ = _reference_forward(
+        q, k, value, gate, beta, zero_state, cu_seqlens, torch.float64
+    )
+    actual = chunk_delta_rule_fwd_mega_unsplit(q, k, value, gate, beta, cu_seqlens)
+    assert_matches_low_precision_reference(
+        actual, high_precision, low_precision, "output", source_dtype=dtype
+    )
+    for _ in range(20):
+        torch.testing.assert_close(
+            chunk_delta_rule_fwd_mega_unsplit(q, k, value, gate, beta, cu_seqlens),
+            actual,
+            rtol=0,
+            atol=0,
+        )
+
+    low_output, low_state = _reference_forward(
+        q, k, value, gate, beta, initial_state, cu_seqlens, torch.float32
+    )
+    high_output, high_state = _reference_forward(
+        q, k, value, gate, beta, initial_state, cu_seqlens, torch.float64
+    )
+    actual_output, actual_state = chunk_delta_rule_fwd_mega_unsplit_with_state(
+        q,
+        k,
+        value,
+        gate,
+        beta,
+        initial_state,
+        cu_seqlens,
+    )
+    assert_matches_low_precision_reference(
+        actual_output, high_output, low_output, "stateful output", source_dtype=dtype
+    )
+    assert_matches_low_precision_reference(
+        actual_state, high_state, low_state, "final state", source_dtype=dtype
+    )
+
+
+def test_mega_split_table_rejects_misaligned_vector_gate_rows() -> None:
+    tokens, heads, dim = 16, 2, 128
+    gate = torch.empty(tokens, heads, dim + 1, device="cuda")[..., :dim]
+    assert gate.data_ptr() % 16 == 0
+    assert gate.stride(-1) == 1
+
+    cu_seqlens = torch.tensor([0, tokens], dtype=torch.int32, device="cuda")
+    work_items = torch.empty(16, WORK_ITEM_FIELDS, dtype=torch.int32, device="cuda")
+    item_scratch = torch.empty_like(work_items)
+    work_count = torch.empty(1, dtype=torch.int32, device="cuda")
+    chunk_scratch = torch.empty(
+        chunk_scratch_rows(tokens, 1, 16),
+        heads,
+        dtype=torch.float32,
+        device="cuda",
+    )
+
+    with pytest.raises(ValueError, match="rows and head slices must be 16-byte aligned"):
+        build_split_table(
+            gate,
+            cu_seqlens,
+            work_items,
+            work_count,
+            ideal_chunks=1,
+            n_tiles=heads,
+            num_sms=1,
+            b_t=16,
+            chunk_scratch=chunk_scratch,
+            item_scratch=item_scratch,
+            log_gate=True,
+            split=True,
+            stream=torch.cuda.current_stream().cuda_stream,
+        )
+
+
+def test_mega_split_table_rejects_invalid_geometry_and_capacity() -> None:
+    tokens, heads, dim = 16, 2, 128
+    gate = torch.zeros(tokens, heads, dim, device="cuda")
+    cu_seqlens = torch.tensor([0, tokens], dtype=torch.int32, device="cuda")
+    work_count = torch.empty(1, dtype=torch.int32, device="cuda")
+    stream = torch.cuda.current_stream().cuda_stream
+
+    with pytest.raises(ValueError, match="n_tiles must equal"):
+        build_split_table(
+            gate,
+            cu_seqlens,
+            torch.empty(heads, WORK_ITEM_FIELDS, dtype=torch.int32, device="cuda"),
+            work_count,
+            n_tiles=heads - 1,
+            num_sms=1,
+            b_t=16,
+            split=False,
+            stream=stream,
+        )
+
+    work_items = torch.empty(1, WORK_ITEM_FIELDS, dtype=torch.int32, device="cuda")
+    with pytest.raises(ValueError, match="requires at least"):
+        build_split_table(
+            gate,
+            cu_seqlens,
+            work_items,
+            work_count,
+            ideal_chunks=1,
+            n_tiles=heads,
+            num_sms=1,
+            b_t=16,
+            chunk_scratch=torch.empty(
+                chunk_scratch_rows(tokens, 1, 16), heads, dtype=torch.float32, device="cuda"
+            ),
+            item_scratch=torch.empty_like(work_items),
+            log_gate=True,
+            split=True,
+            stream=stream,
+        )
+
+
+def test_mega_forward_rejects_misaligned_tma() -> None:
+    q, k, value, gate, beta, cu_seqlens, _ = _inputs()
+    storage = torch.empty(q.numel() + 1, dtype=q.dtype, device="cuda")
+    misaligned_q = storage[1:].view_as(q)
+    with pytest.raises(TypeError, match="TMA-compatible inner mode"):
+        adapter.chunk_delta_rule_fwd_mega_unsplit(misaligned_q, k, value, gate, beta, cu_seqlens)
+
+
+def test_mega_public_forward_preserves_large_finite_state() -> None:
+    torch.manual_seed(19)
+    tokens, heads, dim = 1024, 1, 128
+    shape = (1, tokens, heads, dim)
+    q = torch.nn.functional.normalize(torch.randn(shape, device="cuda"), dim=-1).bfloat16()
+    k = torch.nn.functional.normalize(torch.randn(shape, device="cuda"), dim=-1).bfloat16()
+    value = torch.zeros(shape, device="cuda", dtype=torch.bfloat16)
+    gate = torch.zeros(shape, device="cuda")
+    gate[:, ::4] = -2.5
+    beta = torch.zeros(*shape[:3], device="cuda")
+    cu_seqlens = torch.tensor([0, tokens], dtype=torch.int32, device="cuda")
+    initial_state = torch.full((1, heads, dim, dim), 1e30, device="cuda")
+
+    low_precision, _ = _reference_forward(
+        q,
+        k,
+        value,
+        gate,
+        beta,
+        initial_state,
+        cu_seqlens,
+        torch.float32,
+    )
+    high_precision, _ = _reference_forward(
+        q,
+        k,
+        value,
+        gate,
+        beta,
+        initial_state,
+        cu_seqlens,
+        torch.float64,
+    )
+    actual, _ = adapter.chunk_delta_rule_fwd_mega_unsplit_with_state(
+        q,
+        k,
+        value,
+        gate,
+        beta,
+        initial_state,
+        cu_seqlens,
+    )
+    assert_matches_low_precision_reference(
+        actual,
+        high_precision,
+        low_precision,
+        "large-state output",
+    )

--- a/test/kda/mega/test_kda_mega_training.py
+++ b/test/kda/mega/test_kda_mega_training.py
@@ -1,0 +1,1037 @@
+"""Training integration for the CuTeDSL 4.7 KDA forward."""
+
+from __future__ import annotations
+
+import math
+from itertools import accumulate
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from attn_gym.linear.kda.chunk_schedule import prepare_ragged_chunk_metadata
+from attn_gym.testing.kda import (
+    assert_matches_low_precision_reference,
+    clone_kda_inputs,
+    cumulative_sequence_offsets,
+    kda_reference,
+    make_kda_test_inputs,
+)
+
+pytest.importorskip(
+    "cutlass.experimental",
+    reason="the CuTeDSL 4.7 KDA path requires nvidia-cutlass-dsl>=4.7",
+)
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() not in ((10, 0), (10, 3)),
+    reason="the CuTeDSL 4.7 KDA path requires SM100 or SM103",
+)
+
+D = 128
+SCALE = D**-0.5
+
+
+def _swap_token_head_storage(tensor: torch.Tensor) -> torch.Tensor:
+    """Copy `[B,T,H,D]` data into dense TMA-compatible `[B,H,T,D]` storage order."""
+    _, tokens, heads, dim = tensor.shape
+    storage = torch.empty(tensor.numel(), dtype=tensor.dtype, device=tensor.device)
+    return torch.as_strided(
+        storage,
+        tensor.shape,
+        (heads * tokens * dim, dim, tokens * dim, 1),
+    ).copy_(tensor)
+
+
+def _swap_state_head_value_storage(tensor: torch.Tensor) -> torch.Tensor:
+    """Copy `[N,H,V,K]` data into dense TMA-compatible `[N,V,H,K]` storage order."""
+    _, heads, value_dim, key_dim = tensor.shape
+    storage = torch.empty(tensor.numel(), dtype=tensor.dtype, device=tensor.device)
+    return torch.as_strided(
+        storage,
+        tensor.shape,
+        (heads * value_dim * key_dim, key_dim, heads * key_dim, 1),
+    ).copy_(tensor)
+
+
+def _pad_state_sequence_storage(tensor: torch.Tensor) -> torch.Tensor:
+    """Copy `[N,H,V,K]` data into slots with aligned padding between sequences."""
+    sequences, heads, value_dim, key_dim = tensor.shape
+    sequence_stride = heads * value_dim * key_dim + 16
+    storage = torch.empty(
+        sequences * sequence_stride,
+        dtype=tensor.dtype,
+        device=tensor.device,
+    )
+    return torch.as_strided(
+        storage,
+        tensor.shape,
+        (sequence_stride, value_dim * key_dim, key_dim, 1),
+    ).copy_(tensor)
+
+
+def _make_inputs(
+    *,
+    requires_grad: bool,
+    saturated: bool = False,
+    heads: int = 1,
+    dtype: torch.dtype = torch.bfloat16,
+) -> tuple[torch.Tensor, ...]:
+    lengths = [65, 0, 63]
+    q, k, value, gate, beta = make_kda_test_inputs(
+        sum(lengths),
+        heads=heads,
+        seed=97,
+        gate_scale=math.log(2.0),
+        gate_value=-5.0 if saturated else None,
+        log_uniform_gate=True,
+        sigmoid_beta=True,
+        dtype=dtype,
+        normalize_qk=True,
+        value_scale=1.0,
+        requires_grad=requires_grad,
+    )
+    initial_state = (torch.randn(len(lengths), heads, D, D, device="cuda") / 100).requires_grad_(
+        requires_grad
+    )
+    return (
+        q,
+        k,
+        value,
+        gate,
+        beta,
+        initial_state,
+        cumulative_sequence_offsets(lengths),
+    )
+
+
+def _reference(
+    inputs: tuple[torch.Tensor, ...],
+    dtype: torch.dtype,
+    *,
+    scale: float | None = None,
+    initial_state: bool = True,
+    packed: bool = True,
+    output_final_state: bool = True,
+) -> tuple[tuple[torch.Tensor, torch.Tensor | None], tuple[torch.Tensor, ...]]:
+    """Run one precision of the shared oracle and return its autograd leaves."""
+    operands = clone_kda_inputs(inputs[:5], dtype=dtype)
+    state = inputs[5].detach().to(dtype).clone().requires_grad_(inputs[5].requires_grad)
+    targets = (*operands, *((state,) if initial_state else ()))
+    result = kda_reference(
+        *operands,
+        state if initial_state else None,
+        cu_seqlens=inputs[-1] if packed else None,
+        scale=scale,
+        output_final_state=output_final_state,
+    )
+    return result, targets
+
+
+def _references(
+    inputs: tuple[torch.Tensor, ...],
+    **kwargs,
+) -> tuple[
+    tuple[torch.Tensor, torch.Tensor | None],
+    tuple[torch.Tensor, torch.Tensor | None],
+    tuple[torch.Tensor, ...],
+    tuple[torch.Tensor, ...],
+]:
+    """Run matched FP64 and FP32 references from the same quantized inputs."""
+    low_precision, low_targets = _reference(inputs, torch.float32, **kwargs)
+    high_precision, high_targets = _reference(inputs, torch.float64, **kwargs)
+    return high_precision, low_precision, high_targets, low_targets
+
+
+def _reference_gradients(
+    result: tuple[torch.Tensor, torch.Tensor | None],
+    targets: tuple[torch.Tensor, ...],
+    cotangents: tuple[torch.Tensor, ...],
+) -> tuple[torch.Tensor, ...]:
+    """Differentiate an eager reference using cotangents in its compute precision."""
+    outputs = tuple(output for output in result if output is not None)
+    return torch.autograd.grad(
+        outputs,
+        targets,
+        tuple(cotangent.to(output.dtype) for cotangent, output in zip(cotangents, outputs)),
+    )
+
+
+def _assert_reference(
+    actual: torch.Tensor,
+    high_precision: torch.Tensor,
+    low_precision: torch.Tensor,
+    name: str,
+    source_dtype: torch.dtype,
+) -> None:
+    """Apply the shared low-precision error budget with the operand dtype."""
+    assert_matches_low_precision_reference(
+        actual,
+        high_precision,
+        low_precision,
+        name,
+        source_dtype=source_dtype,
+    )
+
+
+def _candidate(*inputs: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    from attn_gym.linear import chunk_kda
+
+    q, k, value, gate, beta, initial_state, cu_seqlens = inputs
+    output, final_state = chunk_kda(
+        q,
+        k,
+        value,
+        gate,
+        beta,
+        initial_state,
+        cu_seqlens=cu_seqlens,
+        output_final_state=True,
+        kernel_options={"backend": "mega"},
+    )
+    assert final_state is not None
+    return output, final_state
+
+
+def _candidate_initial_state_no_final(*inputs: torch.Tensor) -> torch.Tensor:
+    from attn_gym.linear import chunk_kda
+
+    q, k, value, gate, beta, initial_state, cu_seqlens = inputs
+    output, final_state = chunk_kda(
+        q,
+        k,
+        value,
+        gate,
+        beta,
+        initial_state,
+        cu_seqlens=cu_seqlens,
+        output_final_state=False,
+        kernel_options={"backend": "mega"},
+    )
+    assert final_state is None
+    return output
+
+
+def _candidate_no_state(*inputs: torch.Tensor) -> torch.Tensor:
+    from attn_gym.linear import chunk_kda
+
+    q, k, value, gate, beta, _, cu_seqlens = inputs
+    output, _ = chunk_kda(
+        q,
+        k,
+        value,
+        gate,
+        beta,
+        cu_seqlens=cu_seqlens,
+        kernel_options={"backend": "mega"},
+    )
+    return output
+
+
+def _candidate_dense(*inputs: torch.Tensor) -> torch.Tensor:
+    from attn_gym.linear import chunk_kda
+
+    output, _ = chunk_kda(*inputs[:5], kernel_options={"backend": "mega"})
+    return output
+
+
+def _candidate_dense_split(*inputs: torch.Tensor) -> torch.Tensor:
+    from attn_gym.linear import chunk_kda
+
+    output, _ = chunk_kda(
+        *inputs[:5],
+        kernel_options={"backend": "mega", "split_backward": True},
+    )
+    return output
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_mega_training_fullgraph_and_six_gradients(dtype: torch.dtype) -> None:
+    actual_inputs = _make_inputs(requires_grad=True, dtype=dtype)
+    high_precision, low_precision, high_targets, low_targets = _references(actual_inputs)
+    actual = torch.compile(_candidate, fullgraph=True)(*actual_inputs)
+    assert actual[0].dtype == dtype
+    assert actual[1].dtype == torch.float32
+    for name, actual_tensor, high_tensor, low_tensor in zip(
+        ("output", "final_state"), actual, high_precision, low_precision, strict=True
+    ):
+        assert high_tensor is not None and low_tensor is not None
+        _assert_reference(actual_tensor, high_tensor, low_tensor, name, dtype)
+
+    cotangents = (torch.randn_like(actual[0]), torch.randn_like(actual[1]))
+    high_grads = _reference_gradients(high_precision, high_targets, cotangents)
+    low_grads = _reference_gradients(low_precision, low_targets, cotangents)
+    actual_grads = torch.autograd.grad(actual, actual_inputs[:-1], cotangents)
+    for index, (actual_grad, high_grad, low_grad) in enumerate(
+        zip(actual_grads, high_grads, low_grads, strict=True)
+    ):
+        assert actual_grad.dtype == (dtype if index < 3 else torch.float32)
+        _assert_reference(actual_grad, high_grad, low_grad, f"gradient {index}", dtype)
+
+
+@pytest.mark.parametrize(
+    ("state_layout", "cotangent_layout"),
+    [
+        (_swap_state_head_value_storage, _pad_state_sequence_storage),
+        (_pad_state_sequence_storage, _swap_state_head_value_storage),
+    ],
+    ids=["permuted-head-value", "padded-sequence"],
+)
+def test_mega_outer_strided_initial_state_fullgraph_gradients(
+    state_layout,
+    cotangent_layout,
+) -> None:
+    inputs = list(_make_inputs(requires_grad=True, heads=2, dtype=torch.bfloat16))
+    inputs[5] = state_layout(inputs[5].detach()).requires_grad_()
+    actual_inputs = tuple(inputs)
+    assert not actual_inputs[5].is_contiguous()
+
+    high_precision, low_precision, high_targets, low_targets = _references(actual_inputs)
+    actual = torch.compile(_candidate, fullgraph=True)(*actual_inputs)
+    state_cotangent = cotangent_layout(torch.randn_like(actual[1].contiguous()))
+    cotangents = (torch.randn_like(actual[0]), state_cotangent)
+    high_grads = _reference_gradients(high_precision, high_targets, cotangents)
+    low_grads = _reference_gradients(low_precision, low_targets, cotangents)
+    actual_grads = torch.autograd.grad(actual, actual_inputs[:-1], cotangents)
+    for index, (actual_grad, high_grad, low_grad) in enumerate(
+        zip(actual_grads, high_grads, low_grads, strict=True)
+    ):
+        _assert_reference(
+            actual_grad,
+            high_grad,
+            low_grad,
+            f"outer-strided state gradient {index}",
+            torch.bfloat16,
+        )
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_mega_initial_state_without_final_state_fullgraph_gradients(dtype: torch.dtype) -> None:
+    inputs = _make_inputs(requires_grad=True, dtype=dtype)
+    high_precision, low_precision, high_targets, low_targets = _references(
+        inputs, output_final_state=False
+    )
+    actual = torch.compile(_candidate_initial_state_no_final, fullgraph=True)(*inputs)
+    high_output, low_output = high_precision[0], low_precision[0]
+    _assert_reference(actual, high_output, low_output, "output-only stateful output", dtype)
+
+    d_output = torch.randn_like(actual)
+    high_grads = _reference_gradients(high_precision, high_targets, (d_output,))
+    low_grads = _reference_gradients(low_precision, low_targets, (d_output,))
+    actual_grads = torch.autograd.grad(actual, inputs[:-1], d_output)
+    for index, (actual_grad, high_grad, low_grad) in enumerate(
+        zip(actual_grads, high_grads, low_grads, strict=True)
+    ):
+        _assert_reference(
+            actual_grad,
+            high_grad,
+            low_grad,
+            f"output-only stateful gradient {index}",
+            dtype,
+        )
+
+
+def test_mega_initial_state_without_final_state_selects_output_only_op(monkeypatch) -> None:
+    from attn_gym.linear import chunk_kda
+    from attn_gym.linear.kda.impl import mega as backend
+
+    selected = []
+    inputs = _make_inputs(requires_grad=False)
+    initial_state_ptr = inputs[5].data_ptr()
+    output_only_op = backend.chunk_mega_packed_fwd_with_initial_state_op
+    tensor_clone = torch.Tensor.clone
+
+    def reject_state_clone(tensor, *args, **kwargs):
+        if tensor.is_cuda and tensor.data_ptr() == initial_state_ptr:
+            pytest.fail("output-only initial-state execution must not clone the state")
+        return tensor_clone(tensor, *args, **kwargs)
+
+    def record_output_only(*args):
+        selected.append(True)
+        return output_only_op(*args)
+
+    monkeypatch.setattr(torch.Tensor, "clone", reject_state_clone)
+    monkeypatch.setattr(backend, "chunk_mega_packed_fwd_with_initial_state_op", record_output_only)
+    monkeypatch.setattr(
+        backend,
+        "chunk_mega_packed_fwd_with_state_op",
+        lambda *args: pytest.fail("state-returning operator must not run"),
+    )
+    output, final_state = chunk_kda(
+        *inputs[:6],
+        cu_seqlens=inputs[-1],
+        output_final_state=False,
+        kernel_options={"backend": "mega"},
+    )
+    assert output.shape == inputs[2].shape
+    assert final_state is None
+    assert selected == [True]
+
+
+def test_mega_custom_scale_matches_fused_forward_and_gradients() -> None:
+    from attn_gym.linear import chunk_kda
+
+    scale = 0.125
+    actual_inputs = _make_inputs(requires_grad=True)
+    high_precision, low_precision, high_targets, low_targets = _references(
+        actual_inputs, scale=scale
+    )
+    actual = chunk_kda(
+        *actual_inputs[:6],
+        cu_seqlens=actual_inputs[-1],
+        scale=scale,
+        output_final_state=True,
+        kernel_options={"backend": "mega"},
+    )
+    for name, actual_tensor, high_tensor, low_tensor in zip(
+        ("output", "final_state"), actual, high_precision, low_precision, strict=True
+    ):
+        assert actual_tensor is not None and high_tensor is not None and low_tensor is not None
+        _assert_reference(actual_tensor, high_tensor, low_tensor, name, torch.bfloat16)
+
+    cotangents = (torch.randn_like(actual[0]), torch.randn_like(actual[1]))
+    high_grads = _reference_gradients(high_precision, high_targets, cotangents)
+    low_grads = _reference_gradients(low_precision, low_targets, cotangents)
+    actual_grads = torch.autograd.grad(actual, actual_inputs[:-1], cotangents)
+    for index, (actual_grad, high_grad, low_grad) in enumerate(
+        zip(actual_grads, high_grads, low_grads, strict=True)
+    ):
+        _assert_reference(
+            actual_grad, high_grad, low_grad, f"custom-scale gradient {index}", torch.bfloat16
+        )
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_mega_dense_training_fullgraph_and_gradients(dtype: torch.dtype) -> None:
+    expected_inputs = list(_make_inputs(requires_grad=True, dtype=dtype))
+    actual_inputs = list(_make_inputs(requires_grad=True, dtype=dtype))
+    dense_cu = torch.tensor([0, expected_inputs[0].shape[1]], dtype=torch.int32, device="cuda")
+    expected_inputs[-1] = dense_cu
+    actual_inputs[-1] = dense_cu
+    expected_inputs = tuple(expected_inputs)
+    actual_inputs = tuple(actual_inputs)
+    expected = _candidate_no_state(*expected_inputs)
+    actual = torch.compile(_candidate_dense, fullgraph=True)(*actual_inputs)
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+    high_precision, low_precision, high_targets, low_targets = _references(
+        actual_inputs,
+        initial_state=False,
+        packed=False,
+        output_final_state=False,
+    )
+    _assert_reference(actual, high_precision[0], low_precision[0], "dense output", dtype)
+    d_output = torch.randn_like(actual)
+    high_grads = _reference_gradients(high_precision, high_targets, (d_output,))
+    low_grads = _reference_gradients(low_precision, low_targets, (d_output,))
+    actual_grads = torch.autograd.grad(actual, actual_inputs[:5], d_output)
+    for index, (actual_grad, high_grad, low_grad) in enumerate(
+        zip(actual_grads, high_grads, low_grads, strict=True)
+    ):
+        _assert_reference(actual_grad, high_grad, low_grad, f"dense gradient {index}", dtype)
+
+
+def test_mega_saturated_gate_six_gradients_are_finite() -> None:
+    actual_inputs = _make_inputs(requires_grad=True, saturated=True)
+    high_precision, low_precision, high_targets, low_targets = _references(actual_inputs)
+    actual = _candidate(*actual_inputs)
+    for name, actual_tensor, high_tensor, low_tensor in zip(
+        ("output", "final_state"), actual, high_precision, low_precision, strict=True
+    ):
+        assert high_tensor is not None and low_tensor is not None
+        _assert_reference(
+            actual_tensor, high_tensor, low_tensor, f"saturated {name}", torch.bfloat16
+        )
+
+    cotangents = (torch.randn_like(actual[0]), torch.randn_like(actual[1]))
+    high_grads = _reference_gradients(high_precision, high_targets, cotangents)
+    low_grads = _reference_gradients(low_precision, low_targets, cotangents)
+    actual_grads = torch.autograd.grad(actual, actual_inputs[:-1], cotangents)
+    for index, (actual_grad, high_grad, low_grad) in enumerate(
+        zip(actual_grads, high_grads, low_grads, strict=True)
+    ):
+        _assert_reference(
+            actual_grad,
+            high_grad,
+            low_grad,
+            f"saturated gradient {index}",
+            torch.bfloat16,
+        )
+
+
+def test_mega_local_backward_split_matches_exact_gradients() -> None:
+    from attn_gym.linear.kda.impl.mega_ops import chunk_mega_packed_local_bwd_op
+
+    tokens, heads = 2048, 1
+    for mode in ("contracting", "no_forgetting"):
+        torch.manual_seed(107)
+        shape = (1, tokens, heads, D)
+        q = F.normalize(torch.randn(shape, device="cuda"), dim=-1).bfloat16().requires_grad_()
+        k = F.normalize(torch.randn(shape, device="cuda"), dim=-1).bfloat16().requires_grad_()
+        value = torch.randn(shape, device="cuda", dtype=torch.bfloat16).requires_grad_()
+        gate = (
+            torch.empty(shape, device="cuda").uniform_(0.5, 1.0).log()
+            if mode == "contracting"
+            else torch.full(shape, -1e-5, device="cuda")
+        ).requires_grad_()
+        beta = torch.sigmoid(torch.randn(1, tokens, heads, device="cuda")).requires_grad_()
+        d_output = torch.randn_like(value)
+        inputs = (
+            q,
+            k,
+            value,
+            gate,
+            beta,
+            torch.empty(0, device="cuda"),
+            torch.empty(0, dtype=torch.int32, device="cuda"),
+        )
+        high_precision, low_precision, high_targets, low_targets = _references(
+            inputs,
+            initial_state=False,
+            packed=False,
+            output_final_state=False,
+        )
+        high_grads = _reference_gradients(high_precision, high_targets, (d_output,))
+        low_grads = _reference_gradients(low_precision, low_targets, (d_output,))
+        actual = chunk_mega_packed_local_bwd_op(
+            q.detach(),
+            k.detach(),
+            value.detach(),
+            gate.detach(),
+            beta.detach(),
+            d_output,
+            cumulative_sequence_offsets([tokens]),
+            True,
+            SCALE,
+        )
+        for index, (actual_grad, high_grad, low_grad) in enumerate(
+            zip(actual, high_grads, low_grads, strict=True)
+        ):
+            _assert_reference(
+                actual_grad,
+                high_grad,
+                low_grad,
+                f"{mode} local gradient {index}",
+                torch.bfloat16,
+            )
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("heads", [1, 64])
+def test_mega_packed_local_backward_matches_exact_gradients(
+    heads: int, dtype: torch.dtype
+) -> None:
+    from attn_gym.linear.kda.impl.mega_ops import chunk_mega_packed_local_bwd_op
+
+    actual_inputs = _make_inputs(requires_grad=True, heads=heads, dtype=dtype)
+    high_precision, low_precision, high_targets, low_targets = _references(
+        actual_inputs,
+        initial_state=False,
+        output_final_state=False,
+    )
+    d_output = torch.randn_like(actual_inputs[2])
+    high_grads = _reference_gradients(high_precision, high_targets, (d_output,))
+    low_grads = _reference_gradients(low_precision, low_targets, (d_output,))
+    actual = chunk_mega_packed_local_bwd_op(
+        *(tensor.detach() for tensor in actual_inputs[:5]),
+        d_output,
+        actual_inputs[-1],
+        True,
+        SCALE,
+    )
+    for index, (actual_grad, high_grad, low_grad) in enumerate(
+        zip(actual, high_grads, low_grads, strict=True)
+    ):
+        _assert_reference(actual_grad, high_grad, low_grad, f"packed gradient {index}", dtype)
+
+
+def test_mega_public_packed_unsplit_local_backward_matches_exact_gradients(monkeypatch) -> None:
+    from attn_gym.linear.kda.impl import mega as backend
+
+    monkeypatch.setattr(backend, "_PACKED_LOCAL_BACKWARD_MIN_TOKENS", 1)
+    monkeypatch.setattr(backend, "_LOCAL_BACKWARD_MIN_HEADS", 1)
+    selected = []
+    local_backward_op = backend.chunk_mega_packed_local_bwd_op
+
+    def record_local_backward(*args):
+        selected.append(args[-2])
+        return local_backward_op(*args)
+
+    monkeypatch.setattr(backend, "chunk_mega_packed_local_bwd_op", record_local_backward)
+    inputs = _make_inputs(requires_grad=True)
+    high_precision, low_precision, high_targets, low_targets = _references(
+        inputs,
+        initial_state=False,
+        output_final_state=False,
+    )
+    actual = _candidate_no_state(*inputs)
+    d_output = torch.randn_like(actual)
+    high_grads = _reference_gradients(high_precision, high_targets, (d_output,))
+    low_grads = _reference_gradients(low_precision, low_targets, (d_output,))
+    actual_grads = torch.autograd.grad(actual, inputs[:5], d_output)
+    assert selected == [False]
+    for index, (actual_grad, high_grad, low_grad) in enumerate(
+        zip(actual_grads, high_grads, low_grads, strict=True)
+    ):
+        _assert_reference(
+            actual_grad,
+            high_grad,
+            low_grad,
+            f"public packed unsplit gradient {index}",
+            torch.bfloat16,
+        )
+
+
+def test_mega_kernel_options_are_strict() -> None:
+    from attn_gym.linear.kda.validation import resolve_kernel_options
+
+    assert resolve_kernel_options(None) == ("fused", False)
+    assert resolve_kernel_options({}) == ("fused", False)
+    assert resolve_kernel_options({"backend": "mega", "split_backward": True}) == ("mega", True)
+    with pytest.raises(ValueError, match="unsupported chunk_kda kernel options"):
+        resolve_kernel_options({"unknown": True})
+    with pytest.raises(TypeError, match="must be a bool"):
+        resolve_kernel_options({"split_backward": 1})
+    with pytest.raises(ValueError, match="requires.*mega"):
+        resolve_kernel_options({"split_backward": True})
+
+
+def test_mega_split_backward_rejects_stateful_calls() -> None:
+    from attn_gym.linear import chunk_kda
+
+    inputs = _make_inputs(requires_grad=False)
+    with pytest.raises(ValueError, match="split_backward currently requires a no-state call"):
+        chunk_kda(
+            *inputs[:6],
+            cu_seqlens=inputs[-1],
+            output_final_state=True,
+            kernel_options={"backend": "mega", "split_backward": True},
+        )
+
+
+def test_mega_cpu_inputs_fail_before_dispatch() -> None:
+    from attn_gym.linear import chunk_kda
+
+    shape = (1, 64, 1, D)
+    q, k, value = (torch.zeros(shape) for _ in range(3))
+    gate = torch.zeros(shape)
+    beta = torch.zeros(shape[:3])
+    with pytest.raises(ValueError, match="Mega KDA backend requires CUDA tensors"):
+        chunk_kda(q, k, value, gate, beta, kernel_options={"backend": "mega"})
+
+
+def test_mega_dense_and_packed_split_share_auto_scheduler(monkeypatch) -> None:
+    from attn_gym.linear import chunk_kda
+    from attn_gym.linear._delta_rule.mega import schedule
+    from attn_gym.linear.kda.impl import mega as backend
+
+    monkeypatch.setattr(backend, "_DENSE_LOCAL_BACKWARD_MIN_TOKENS", 1)
+    monkeypatch.setattr(backend, "_PACKED_LOCAL_BACKWARD_MIN_TOKENS", 1)
+    monkeypatch.setattr(backend, "_LOCAL_BACKWARD_MIN_HEADS", 1)
+    local_backward = backend.chunk_mega_packed_local_bwd_op
+    compute_ideal_chunks = schedule.compute_ideal_chunks
+    selected = []
+    geometries = []
+
+    def record_split(*args):
+        selected.append(args[-2])
+        return local_backward(*args)
+
+    def record_geometry(*args):
+        geometries.append(args)
+        return compute_ideal_chunks(*args)
+
+    monkeypatch.setattr(backend, "chunk_mega_packed_local_bwd_op", record_split)
+    monkeypatch.setattr(schedule, "compute_ideal_chunks", record_geometry)
+
+    exact_inputs = _make_inputs(requires_grad=True)
+    exact_output = _candidate_dense(*exact_inputs)
+    torch.autograd.grad(exact_output, exact_inputs[:5], torch.randn_like(exact_output))
+
+    dense_inputs = _make_inputs(requires_grad=True)
+    dense_output = _candidate_dense_split(*dense_inputs)
+    torch.autograd.grad(dense_output, dense_inputs[:5], torch.randn_like(dense_output))
+
+    packed_inputs = _make_inputs(requires_grad=True)
+    dense_cu_seqlens = cumulative_sequence_offsets([packed_inputs[0].shape[1]])
+    packed_output, _ = chunk_kda(
+        *packed_inputs[:5],
+        cu_seqlens=dense_cu_seqlens,
+        kernel_options={"backend": "mega", "split_backward": True},
+    )
+    torch.autograd.grad(packed_output, packed_inputs[:5], torch.randn_like(packed_output))
+
+    assert selected == [True, True]
+    assert len(geometries) == 2 and geometries[0] == geometries[1]
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_mega_local_backward_fullgraph(monkeypatch, dtype: torch.dtype) -> None:
+    from attn_gym.linear.kda.impl import mega as backend
+
+    monkeypatch.setattr(backend, "_DENSE_LOCAL_BACKWARD_MIN_TOKENS", 1)
+    monkeypatch.setattr(backend, "_LOCAL_BACKWARD_MIN_HEADS", 1)
+    expected_inputs = list(_make_inputs(requires_grad=True, dtype=dtype))
+    actual_inputs = list(_make_inputs(requires_grad=True, dtype=dtype))
+    dense_cu = torch.tensor([0, expected_inputs[0].shape[1]], dtype=torch.int32, device="cuda")
+    expected_inputs[-1] = dense_cu
+    actual_inputs[-1] = dense_cu
+    expected_inputs = tuple(expected_inputs)
+    actual_inputs = tuple(actual_inputs)
+    expected = _candidate_no_state(*expected_inputs)
+    compiled = torch.compile(_candidate_dense_split, fullgraph=True)
+    actual = compiled(*actual_inputs)
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+    high_precision, low_precision, high_targets, low_targets = _references(
+        actual_inputs,
+        initial_state=False,
+        packed=False,
+        output_final_state=False,
+    )
+    d_output = torch.randn_like(actual)
+    high_grads = _reference_gradients(high_precision, high_targets, (d_output,))
+    low_grads = _reference_gradients(low_precision, low_targets, (d_output,))
+    actual_grads = torch.autograd.grad(actual, actual_inputs[:5], d_output)
+    for index, (actual_grad, high_grad, low_grad) in enumerate(
+        zip(actual_grads, high_grads, low_grads, strict=True)
+    ):
+        _assert_reference(
+            actual_grad, high_grad, low_grad, f"local fullgraph gradient {index}", dtype
+        )
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_mega_composed_state_only_backward(dtype: torch.dtype) -> None:
+    actual_inputs = _make_inputs(requires_grad=True, dtype=dtype)
+    high_precision, low_precision, high_targets, low_targets = _references(actual_inputs)
+    actual = torch.compile(_candidate, fullgraph=True)(*actual_inputs)
+    state_cotangent = torch.ones_like(actual[1])
+    high_grads = _reference_gradients(
+        high_precision, high_targets, (torch.zeros_like(actual[0]), state_cotangent)
+    )
+    low_grads = _reference_gradients(
+        low_precision, low_targets, (torch.zeros_like(actual[0]), state_cotangent)
+    )
+    actual_grads = torch.autograd.grad(actual[1], actual_inputs[:-1], state_cotangent)
+    for index, (actual_grad, high_grad, low_grad) in enumerate(
+        zip(actual_grads, high_grads, low_grads, strict=True)
+    ):
+        _assert_reference(actual_grad, high_grad, low_grad, f"state-only gradient {index}", dtype)
+
+
+def test_mega_dense_tail_rejected_at_public_boundary() -> None:
+    from attn_gym.linear import chunk_kda
+
+    inputs = _make_inputs(requires_grad=False)
+    dense_tail = tuple(tensor[:, :65].contiguous() for tensor in inputs[:5])
+    with pytest.raises(ValueError, match="T divisible by 64"):
+        chunk_kda(*dense_tail, kernel_options={"backend": "mega"})
+
+
+def test_mega_rejects_mismatched_value_and_beta_shapes() -> None:
+    from attn_gym.linear import chunk_kda
+
+    inputs = _make_inputs(requires_grad=False)
+    with pytest.raises(ValueError, match="v must have shape"):
+        chunk_kda(
+            inputs[0],
+            inputs[1],
+            inputs[2].repeat(2, 1, 1, 1),
+            *inputs[3:5],
+            kernel_options={"backend": "mega"},
+        )
+    with pytest.raises(ValueError, match="beta must have shape"):
+        chunk_kda(
+            inputs[0],
+            inputs[1],
+            inputs[2],
+            inputs[3],
+            inputs[4].repeat(2, 1, 1),
+            kernel_options={"backend": "mega"},
+        )
+
+
+def test_mega_packed_h64_exact_tail_with_trailing_empty_is_finite() -> None:
+    from attn_gym.linear import chunk_kda
+    from attn_gym.linear.kda import bound_gate, l2norm
+
+    lengths = (
+        33,
+        159,
+        4,
+        2,
+        431,
+        3,
+        161,
+        1006,
+        2,
+        737,
+        488,
+        3732,
+        72,
+        254,
+        1106,
+        2,
+        0,
+    )
+    tokens, heads = sum(lengths), 64
+    shape = (1, tokens, heads, D)
+    torch.manual_seed(2090)
+
+    def tensor(*dims: int, scale: float = 1.0) -> torch.Tensor:
+        return (torch.randn(*dims, device="cuda") * scale).bfloat16().requires_grad_()
+
+    q = tensor(*shape)
+    k = tensor(*shape)
+    value = tensor(*shape)
+    gate = tensor(*shape, scale=0.5)
+    beta_logits = tensor(*shape[:3])
+    a_log = torch.zeros(heads, device="cuda", requires_grad=True)
+    dt_bias = torch.zeros(heads, D, device="cuda", requires_grad=True)
+    cu_seqlens = torch.tensor(
+        (0, *accumulate(lengths)),
+        device="cuda",
+        dtype=torch.int32,
+    )
+
+    output, _ = chunk_kda(
+        l2norm(q, cu_seqlens=cu_seqlens),
+        l2norm(k, cu_seqlens=cu_seqlens),
+        value,
+        bound_gate(gate, a_log, dt_bias, lower_bound=-5.0, impl="fused"),
+        beta_logits.float().sigmoid(),
+        cu_seqlens=cu_seqlens,
+        kernel_options={"backend": "mega"},
+    )
+    torch.cuda.synchronize()
+    assert torch.isfinite(output).all()
+
+    output.float().sum().backward()
+    for tensor in (q, k, value, gate, beta_logits, a_log, dt_bias):
+        assert tensor.grad is not None
+        assert torch.isfinite(tensor.grad).all()
+
+
+def test_mega_packed_tail_isolated_from_next_sequence() -> None:
+    from attn_gym.linear import chunk_kda
+
+    torch.manual_seed(2111)
+    tokens, heads = 17, 1
+    shape = (1, tokens, heads, D)
+    q = F.normalize(torch.randn(shape, device="cuda"), dim=-1).bfloat16()
+    k = F.normalize(torch.randn(shape, device="cuda"), dim=-1).bfloat16()
+    value = torch.randn(shape, device="cuda", dtype=torch.bfloat16)
+    gate = torch.full(shape, -0.5, device="cuda")
+    beta = torch.full((1, tokens, heads), 0.5, device="cuda")
+    k[:, 1:] = 1e20
+    cu_seqlens = torch.tensor([0, 1, tokens], dtype=torch.int32, device="cuda")
+
+    expected, _ = chunk_kda(
+        q[:, :1],
+        k[:, :1],
+        value[:, :1],
+        gate[:, :1],
+        beta[:, :1],
+        autotune=False,
+    )
+    actual, _ = chunk_kda(
+        q,
+        k,
+        value,
+        gate,
+        beta,
+        cu_seqlens=cu_seqlens,
+        kernel_options={"backend": "mega"},
+    )
+    torch.testing.assert_close(actual[:, :1], expected, rtol=2e-2, atol=2e-2)
+
+    final_sequence_only = torch.tensor([0, 1], dtype=torch.int32, device="cuda")
+    final_actual, _ = chunk_kda(
+        q,
+        k,
+        value,
+        gate,
+        beta,
+        cu_seqlens=final_sequence_only,
+        kernel_options={"backend": "mega"},
+    )
+    torch.testing.assert_close(final_actual[:, :1], expected, rtol=2e-2, atol=2e-2)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("outer_strided", [False, True])
+def test_mega_forward_op_registration(dtype: torch.dtype, outer_strided: bool) -> None:
+    from attn_gym.linear.kda.impl.mega_ops import (
+        chunk_mega_dense_training_fwd_op,
+        chunk_mega_packed_fwd_op,
+        chunk_mega_packed_fwd_with_initial_state_op,
+        chunk_mega_packed_fwd_with_state_op,
+        chunk_mega_packed_local_bwd_op,
+        chunk_mega_packed_training_fwd_op,
+        plain_gate_bwd_dense_cute_op,
+    )
+
+    inputs = _make_inputs(requires_grad=False, heads=2, dtype=dtype)
+    if outer_strided:
+        q, k, value, gate = (_swap_token_head_storage(tensor) for tensor in inputs[:4])
+        initial_state = _swap_state_head_value_storage(inputs[5])
+        inputs = (q, k, value, gate, inputs[4], initial_state, inputs[6])
+    dense_cu_seqlens = cumulative_sequence_offsets([inputs[0].shape[1]])
+    test_utils = ("test_schema", "test_faketensor", "test_aot_dispatch_dynamic")
+    torch.library.opcheck(
+        chunk_mega_packed_fwd_op,
+        (*inputs[:5], inputs[-1], SCALE),
+        test_utils=test_utils,
+        rtol=2e-2,
+        atol=2e-2,
+    )
+    torch.library.opcheck(
+        chunk_mega_dense_training_fwd_op,
+        (*inputs[:5], dense_cu_seqlens, SCALE),
+        test_utils=test_utils,
+        rtol=2e-2,
+        atol=2e-2,
+    )
+    d_output = torch.randn_like(inputs[2])
+    local_gradients = chunk_mega_packed_local_bwd_op(
+        *inputs[:5], d_output, inputs[-1], False, SCALE
+    )
+    expected_strides = tuple(
+        torch.empty_like(tensor[0]).unsqueeze(0).stride() for tensor in inputs[:5]
+    )
+    assert tuple(gradient.stride() for gradient in local_gradients) == expected_strides
+    torch.library.opcheck(
+        chunk_mega_packed_local_bwd_op,
+        (*inputs[:5], d_output, inputs[-1], False, SCALE),
+        test_utils=test_utils,
+        rtol=2e-2,
+        atol=2e-2,
+    )
+    backward_metadata = prepare_ragged_chunk_metadata(inputs[-1], inputs[0].shape[1], 64)
+    torch.library.opcheck(
+        chunk_mega_packed_training_fwd_op,
+        (
+            *inputs[:5],
+            backward_metadata.cu_seqlens,
+            backward_metadata.chunk_offsets,
+            SCALE,
+        ),
+        test_utils=test_utils,
+        rtol=2e-2,
+        atol=2e-2,
+    )
+    torch.library.opcheck(
+        chunk_mega_packed_fwd_with_initial_state_op,
+        (*inputs, SCALE),
+        test_utils=test_utils,
+        rtol=2e-2,
+        atol=2e-2,
+    )
+    torch.library.opcheck(
+        chunk_mega_packed_fwd_with_state_op,
+        (*inputs, SCALE),
+        test_utils=test_utils,
+        rtol=2e-2,
+        atol=2e-2,
+    )
+    torch.library.opcheck(
+        plain_gate_bwd_dense_cute_op,
+        (torch.randn(1, 128, 1, D, device="cuda"),),
+        test_utils=test_utils,
+        rtol=2e-2,
+        atol=2e-2,
+    )
+
+
+def test_mega_initial_state_forward_op_fullgraph() -> None:
+    from attn_gym.linear.kda.impl.mega_ops import chunk_mega_packed_fwd_with_initial_state_op
+
+    inputs = _make_inputs(requires_grad=False)
+    args = (*inputs, SCALE)
+    expected = chunk_mega_packed_fwd_with_initial_state_op(*args)
+    actual = torch.compile(
+        chunk_mega_packed_fwd_with_initial_state_op,
+        fullgraph=True,
+    )(*args)
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("candidate", [_candidate_dense, _candidate_no_state])
+def test_mega_multistream_fullgraph_cuda_graph_replay(candidate) -> None:
+    inputs = _make_inputs(requires_grad=False)
+    compiled = torch.compile(candidate, fullgraph=True)
+    expected = compiled(*inputs)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = compiled(*inputs)
+    graph.replay()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(captured, expected, rtol=0, atol=0)
+
+
+def test_mega_tma_validation_routes_oversized_singleton_stride_to_int64() -> None:
+    from attn_gym._backends.cute.utils import requires_int64_abi
+    from attn_gym.linear._delta_rule.mega.kernels.compat import validate_tma_tensor
+
+    tensor = torch.empty_strided(
+        (1, 1, D),
+        (D, 2**31 + 8, 1),
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    validate_tma_tensor("tensor", tensor)
+    assert requires_int64_abi(tensor)
+
+
+def test_mega_forced_int64_forward_backward_matches_int32(monkeypatch) -> None:
+    from attn_gym.linear._delta_rule.mega.kernels import (
+        kda_bprop_f16,
+        kda_prefill_f16,
+        kda_recompute_f16,
+    )
+    from attn_gym.linear.kda.impl import mega as backend
+
+    monkeypatch.setattr(backend, "_PACKED_LOCAL_BACKWARD_MIN_TOKENS", 1)
+    monkeypatch.setattr(backend, "_LOCAL_BACKWARD_MIN_HEADS", 1)
+    expected_inputs = _make_inputs(requires_grad=True, dtype=torch.float16)
+    actual_inputs = _make_inputs(requires_grad=True, dtype=torch.float16)
+    d_output = torch.randn_like(expected_inputs[2])
+
+    expected = _candidate_no_state(*expected_inputs)
+    expected_grads = torch.autograd.grad(expected, expected_inputs[:5], d_output)
+    for module in (kda_prefill_f16, kda_recompute_f16, kda_bprop_f16):
+        monkeypatch.setattr(module, "requires_int64_abi", lambda *_: True)
+    actual = _candidate_no_state(*actual_inputs)
+    actual_grads = torch.autograd.grad(actual, actual_inputs[:5], d_output)
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    for actual_grad, expected_grad in zip(actual_grads, expected_grads, strict=True):
+        torch.testing.assert_close(actual_grad, expected_grad, rtol=0, atol=0)
+
+
+def test_mega_plain_gate_backward_forced_int64_matches_int32(monkeypatch) -> None:
+    from attn_gym.linear._delta_rule.mega.kernels import kda_plain_gate_bwd
+
+    d_cumulative = torch.randn(1, 64, 1, D, device="cuda")
+    expected = kda_plain_gate_bwd.plain_gate_cumsum_dense_bwd_cute(d_cumulative)
+    monkeypatch.setattr(kda_plain_gate_bwd, "requires_int64_abi", lambda *_: True)
+    actual = kda_plain_gate_bwd.plain_gate_cumsum_dense_bwd_cute(d_cumulative)
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_mega_fullgraph_cuda_graph_replay() -> None:
+    inputs = _make_inputs(requires_grad=False)
+    compiled = torch.compile(_candidate, fullgraph=True)
+    expected = compiled(*inputs)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = compiled(*inputs)
+    graph.replay()
+    torch.cuda.synchronize()
+    for captured_tensor, expected_tensor in zip(captured, expected, strict=True):
+        torch.testing.assert_close(captured_tensor, expected_tensor, rtol=0, atol=0)

--- a/test/test_cuda_stream_utils.py
+++ b/test/test_cuda_stream_utils.py
@@ -1,0 +1,69 @@
+import pytest
+import torch
+
+from attn_gym.utils import fork_join_streams
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+
+
+def test_fork_join_streams_orders_and_returns_both_outputs() -> None:
+    current_stream = torch.cuda.current_stream()
+    side_stream = torch.cuda.Stream()
+
+    def side_work() -> tuple[torch.Tensor, torch.Tensor, str]:
+        output = torch.zeros(1, device="cuda")
+        torch.cuda._sleep(1_000_000)
+        return output.fill_(3), output.new_full((1,), 4), "side"
+
+    current_output, side_output = fork_join_streams(
+        current_stream,
+        side_stream,
+        side_work,
+        lambda: (torch.full((1,), 2, device="cuda"), "current"),
+    )
+
+    torch.testing.assert_close(current_output[0], torch.tensor([2], device="cuda"))
+    assert current_output[1] == "current"
+    torch.testing.assert_close(side_output[0], torch.tensor([3.0], device="cuda"))
+    torch.testing.assert_close(side_output[1], torch.tensor([4.0], device="cuda"))
+    assert side_output[2] == "side"
+    assert torch.cuda.current_stream() == current_stream
+
+
+def test_fork_join_streams_joins_when_side_work_raises() -> None:
+    current_stream = torch.cuda.current_stream()
+    side_stream = torch.cuda.Stream()
+    marker = torch.zeros(1, device="cuda")
+
+    def fail() -> torch.Tensor:
+        torch.cuda._sleep(1_000_000)
+        marker.fill_(1)
+        raise RuntimeError("side work failed")
+
+    with pytest.raises(RuntimeError, match="side work failed"):
+        fork_join_streams(
+            current_stream,
+            side_stream,
+            fail,
+            lambda: torch.zeros(1, device="cuda"),
+        )
+
+    torch.testing.assert_close(marker, torch.ones_like(marker))
+
+
+def test_fork_join_streams_joins_when_current_work_raises() -> None:
+    current_stream = torch.cuda.current_stream()
+    side_stream = torch.cuda.Stream()
+    marker = torch.zeros(1, device="cuda")
+
+    def side_work() -> torch.Tensor:
+        torch.cuda._sleep(1_000_000)
+        return marker.fill_(1)
+
+    def fail() -> torch.Tensor:
+        raise RuntimeError("current work failed")
+
+    with pytest.raises(RuntimeError, match="current work failed"):
+        fork_join_streams(current_stream, side_stream, side_work, fail)
+
+    torch.testing.assert_close(marker, torch.ones_like(marker))

--- a/test/test_kda_impl_dispatch.py
+++ b/test/test_kda_impl_dispatch.py
@@ -210,14 +210,15 @@ def test_chunk_kernel_options_plumbing():
         kernel_options=options,
     )
     torch.testing.assert_close(actual, expected, rtol=0, atol=0)
-    with pytest.raises(ValueError, match="no chunk_kda kernel options"):
+    with pytest.raises(ValueError, match="not supported with impl='reference'"):
         chunk_kda(
             q,
             k,
             v,
             gate,
             beta,
-            kernel_options={"BACKEND": "MEGA"},  # type: ignore[typeddict-unknown-key]
+            impl="reference",
+            kernel_options={"backend": "mega"},
         )
 
 

--- a/test/test_mega_optional_import.py
+++ b/test/test_mega_optional_import.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2026 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Optional-dependency isolation tests for the Mega delta-rule implementation."""
+
+import subprocess
+import sys
+
+
+def test_linear_import_does_not_load_mega_kernel_dependencies() -> None:
+    """Keep CuTeDSL 4.7 modules behind explicit Mega dispatch."""
+    code = """
+import sys
+import attn_gym.linear
+
+assert "attn_gym.linear._delta_rule.mega.forward" not in sys.modules
+assert "attn_gym.linear._delta_rule.mega.backward" not in sys.modules
+assert not any(name.startswith("attn_gym.linear._delta_rule.mega.kernels") for name in sys.modules)
+assert not any(name.startswith("cutlass.experimental") for name in sys.modules)
+"""
+    subprocess.run([sys.executable, "-c", code], check=True)


### PR DESCRIPTION
Stacked PRs:
 * #397
 * __->__#369


--- --- ---

Add fused CuTeDSL 4.7 KDA training backend

## Human Note

## Agent note

Integrate the persistent raw-gate forward, packed and long-context local-recompute backward
selectors, checkpoint/state support, custom operators, and the public `chunk_kda_cute47` API. Add a
generic `benchmarks/kda.py --impl reference fused mega` performance matrix and consolidate Mega
correctness coverage under `test/kda/mega`.

## Performance

On B200 B1/T8192/H64, Mega measures 3.273 ms versus Frost 3.499 ms, a paired 6.47% win.

## Test Plan

```bash
pytest -n 6 -q test/kda/mega
python benchmarks/kda.py --impl fused mega --case smoke --case primary
uv build
mkdocs build --strict
prek
```