### PR TITLE
Organize documentation navigation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,12 +8,11 @@ It provides ready-to-use **mask functions** and **score mods** that you can comp
 
 ## What's Inside
 
-- **[Concepts](concepts.md)** — how `mask_mod`, `score_mod`, and `BlockMask` work together
-- **[Masks](masks.md)** — `mask_mod` functions for causal, sliding window, document-level, neighborhood attention, and more
-- **[Score Mods](mods.md)** — `score_mod` functions like ALiBi, soft-capping, and latent attention
-- **[Linear Attention](linear.md)** — gated-delta-rule reference implementations
-- **[Examples](examples.md)** — benchmarks, MLA, paged attention, determinism testing, and advanced patterns
-- **[Utilities](utilities.md)** — visualization, benchmarking, and profiling helpers
+- **[Getting Started](getting-started.md)** — install Attention Gym and build your first mask
+- **[Core Concepts](concepts.md)** — understand how `mask_mod`, `score_mod`, and `BlockMask` work together
+- **Guides** — learn about [CUDA Graphs for ragged training](tutorials/cuda-graphs.md) and [deterministic FlexAttention](determinism.md)
+- **Reference** — browse [masks](masks.md), [score mods](mods.md), [linear attention](linear.md), and [utilities](utilities.md)
+- **[Examples](examples.md)** — explore benchmarks, MLA, paged attention, distributed attention, and advanced patterns
 
 ## Quick Example
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,17 +56,19 @@ plugins:
 
 nav:
   - Home: index.md
-  - Getting Started: getting-started.md
-  - Concepts: concepts.md
-  - Tutorials:
-      - CUDA Graphs: tutorials/cuda-graphs.md
-  - Determinism: determinism.md
-  - Masks: masks.md
-  - Score Mods: mods.md
-  - Linear Attention: linear.md
+  - Start Here:
+      - Getting Started: getting-started.md
+      - Core Concepts: concepts.md
+  - Guides:
+      - Ragged CUDA Graphs: tutorials/cuda-graphs.md
+      - Determinism: determinism.md
+  - Reference:
+      - Masks: masks.md
+      - Score Mods: mods.md
+      - Linear Attention: linear.md
+      - Utilities: utilities.md
   - Examples: examples.md
-  - Utilities: utilities.md
-  - Developers:
+  - Development:
       - CI Health: developers/ci-health.md
 
 markdown_extensions:


### PR DESCRIPTION
## Human Note

## Agent note

Group related documentation into collapsible Start Here, Guides, Reference, and Development
sections so the left sidebar stays compact. Keep Home and Examples as standalone links, and align
the homepage overview with the new information architecture.

## Test Plan

```bash
.venv/bin/mkdocs build --strict
git diff --check
```
