### PR TITLE
Fix main CI gate validation and optional imports

### DIFF
--- a/attn_gym/linear/kda/gate.py
+++ b/attn_gym/linear/kda/gate.py
@@ -8,8 +8,8 @@
 
 from __future__ import annotations
 
-import math
 from numbers import Real
+from sys import float_info
 
 import torch
 
@@ -46,7 +46,7 @@ def _validate_bound_gate_inputs(
     if isinstance(lower_bound, bool) or not isinstance(lower_bound, Real):
         raise TypeError(f"lower_bound must be a real scalar, got {type(lower_bound).__name__}")
     lower_bound = float(lower_bound)
-    if not math.isfinite(lower_bound) or lower_bound > 0.0:
+    if not -float_info.max <= lower_bound <= 0.0:
         raise ValueError(f"lower_bound must be finite and nonpositive, got {lower_bound}")
     return heads, head_dim, lower_bound
 

--- a/examples/cuda_graph_trace_comparison.py
+++ b/examples/cuda_graph_trace_comparison.py
@@ -4,7 +4,6 @@ import multiprocessing
 from pathlib import Path
 
 import torch
-from transformer_nuggets.utils.merge_traces import merge_traces
 
 from examples.cuda_graphs import hello_world_training_loop
 
@@ -30,6 +29,8 @@ def _capture_trace(
 
 def main() -> None:
     """Capture stock and annotated arms, then write one native Perfetto trace."""
+    from transformer_nuggets.utils.merge_traces import merge_traces
+
     WORK_DIR.mkdir(parents=True, exist_ok=True)
     before_trace = WORK_DIR / "before-raw.json"
     after_trace = WORK_DIR / "after-postprocessed.json.gz"

--- a/examples/cuda_graphs.py
+++ b/examples/cuda_graphs.py
@@ -11,7 +11,6 @@ import typer
 from torch import nn
 from torch.cuda.graph_annotations import mark_kernels
 from torch.nn.attention.varlen import varlen_attn
-from transformer_nuggets.utils.benchmark import profiler
 
 Tensor = torch.Tensor
 GraphOutput = TypeVar("GraphOutput")
@@ -83,6 +82,8 @@ def get_zipf_tokens(
 
 
 def hello_world() -> Tensor:
+    from transformer_nuggets.utils.benchmark import profiler
+
     total_tokens = 4096
     dim = 512
     num_heads = 8
@@ -133,6 +134,8 @@ def capture_graph(
 
 # --8<-- [start:hello-world-graph]
 def hello_world_graph() -> Tensor:
+    from transformer_nuggets.utils.benchmark import profiler
+
     total_tokens = 4096
     dim = 512
     num_heads = 8
@@ -332,6 +335,8 @@ def training_loop_profiler(
     trace_format: TraceFormat = "track_event",
     fix_overlapping_events: bool = True,
 ):
+    from transformer_nuggets.utils.benchmark import profiler
+
     if trace_path is None:
         trace_path = TRACE_PATH / "docs/assets/traces/hello_world_training_loop"
     return profiler(


### PR DESCRIPTION
## Human Note

## Agent note

Keep bound-gate scalar validation traceable under strict full-graph compilation by replacing
`math.isfinite` with an equivalent finite-range comparison. Load the optional
`transformer_nuggets` profiling utilities only when the trace-generation examples execute, so the
test suite can collect those examples without installing the external profiling package.

This fixes both failures from the August 26, 2026 B200 pytest run on `main`.

## Test Plan

```bash
gpu-run --timeout 30 auto -- timeout --signal=TERM --kill-after=5s 180s env PYTHONPATH=$PWD .venv/bin/pytest test/test_kda_gate_semantics.py::test_bound_gate_fused_backward_fullgraph_dynamic_tokens -q
PYTHONPATH=$PWD .venv/bin/pytest test/test_cuda_graphs_example.py -q
PYTHONPATH=$PWD .venv/bin/ruff check attn_gym/linear/kda/gate.py examples/cuda_graphs.py examples/cuda_graph_trace_comparison.py test/test_cuda_graphs_example.py
PYTHONPATH=$PWD .venv/bin/ruff format --check attn_gym/linear/kda/gate.py examples/cuda_graphs.py examples/cuda_graph_trace_comparison.py test/test_cuda_graphs_example.py
```
