### PR TITLE
Add native FP16 KDA training

### DIFF
--- a/attn_gym/linear/kda/api.py
+++ b/attn_gym/linear/kda/api.py
@@ -64,8 +64,10 @@ def chunk_kda(
     """Apply chunk-parallel KDA for training and prefill.
 
     Args:
-        q: Queries shaped ``[B, T, H, K]``, scaled by ``1/sqrt(K)`` internally.
-        k: Keys shaped like ``q``.
+        q: Queries shaped ``[B, T, H, K]``, scaled by ``1/sqrt(K)`` internally. Use
+            L2-normalized Q/K with fused FP16: unnormalized values can overflow the FP16
+            intermediates passed between FP32-accumulating GEMMs.
+        k: Keys shaped like ``q`` and subject to the same fused FP16 range limitation.
         v: Values shaped ``[B, T, H, V]``.
         gate: Finite, nonpositive per-token natural-log decay shaped like ``q``. At
             each token the previous state is multiplied channelwise by ``exp(gate)``.

--- a/attn_gym/linear/kda/bwd/cute/chunk_delta_h_bwd.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_delta_h_bwd.py
@@ -53,6 +53,14 @@ from attn_gym.utils import ceildiv
 
 _MIN_SEQUENCE_EXTENT_SEQUENCES = 32
 _MIN_SEQUENCE_EXTENT_HEADS = 8
+_IO_TYPES = {
+    torch.float16: cutlass.Float16,
+    torch.bfloat16: cutlass.BFloat16,
+}
+_IO_TYPE_NAMES = {
+    cutlass.Float16: "fp16",
+    cutlass.BFloat16: "bf16",
+}
 
 
 def select_delta_h_bv(
@@ -185,6 +193,7 @@ class BlackwellDeltaHBwd:
     def __init__(
         self,
         num_heads: int,
+        io_type: type[cutlass.Numeric] = cutlass.BFloat16,
         head_bv: int = 16,
         varlen: bool = False,
         use_int64_offsets: bool = False,
@@ -194,7 +203,7 @@ class BlackwellDeltaHBwd:
         self.head_k = 128
         self.head_v = 128
         self.acc_type = cutlass.Float32
-        self.io_type = cutlass.BFloat16
+        self.io_type = io_type
         self.num_heads = num_heads
         self.varlen = varlen
         self.use_int64_offsets = use_int64_offsets
@@ -250,7 +259,7 @@ class BlackwellDeltaHBwd:
         """Return a stable artifact and profiler name for this specialization."""
         return (
             f"kda_bwd_dhu_dv_fused_vl{int(self.varlen)}_h{self.num_heads}"
-            f"_k{self.head_k}_v{self.head_v}_bt{self.BT}_bv{self.BV}"
+            f"_k{self.head_k}_v{self.head_v}_bt{self.BT}_bv{self.BV}_{_IO_TYPE_NAMES[self.io_type]}"
             f"_i64{int(self.use_int64_offsets)}_se{int(self.bound_sequence_extent)}"
         )
 
@@ -2167,26 +2176,27 @@ def make_fake_tensor(dtype, shape):
 
 
 @jit_cache
-def _compile_delta_h_bwd(H, bv, use_int64_offsets):
+def _compile_delta_h_bwd(H, bv, io_type, use_int64_offsets):
     """Compile one dense BlackwellDeltaHBwd variant."""
     K = V = 128
     chunk_size = 64
     kern = BlackwellDeltaHBwd(
         head_bv=bv,
         num_heads=H,
+        io_type=io_type,
         use_int64_offsets=use_int64_offsets,
     )
     sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
     sa, sb, snt, sns, sn = (sym_int() for _ in range(5))
 
-    qf, kf, wf = (make_fake_tensor(cutlass.BFloat16, (sa, sb, H, K)) for _ in range(3))
-    dof = make_fake_tensor(cutlass.BFloat16, (sa, sb, H, V))
-    aqkf = make_fake_tensor(cutlass.BFloat16, (sa, sb, H, chunk_size))
+    qf, kf, wf = (make_fake_tensor(io_type, (sa, sb, H, K)) for _ in range(3))
+    dof = make_fake_tensor(io_type, (sa, sb, H, V))
+    aqkf = make_fake_tensor(io_type, (sa, sb, H, chunk_size))
     gkf = make_fake_tensor(cutlass.Float32, (sa, sb, H, K))
     dhtf = make_fake_tensor(cutlass.Float32, (sns, H, K, V))
     dh0f = make_fake_tensor(cutlass.Float32, (sns, H, K, V))
-    dhof = make_fake_tensor(cutlass.BFloat16, (sa, snt, H, K, V))
-    dv2f = make_fake_tensor(cutlass.BFloat16, (sa, sb, H, V))
+    dhof = make_fake_tensor(io_type, (sa, snt, H, K, V))
+    dv2f = make_fake_tensor(io_type, (sa, sb, H, V))
     cuf = make_fake_tensor(cutlass.Int32, (sn,))
     cof = make_fake_tensor(cutlass.Int32, (sn,))
 
@@ -2216,6 +2226,7 @@ def _compile_delta_h_bwd(H, bv, use_int64_offsets):
 def _compile_delta_h_bwd_packed(
     heads: int,
     bv: int,
+    io_type: type[cutlass.Numeric],
     use_int64_offsets: bool,
     bound_sequence_extent: bool,
 ):
@@ -2225,6 +2236,7 @@ def _compile_delta_h_bwd_packed(
     kernel = BlackwellDeltaHBwd(
         num_heads=heads,
         head_bv=bv,
+        io_type=io_type,
         varlen=True,
         use_int64_offsets=use_int64_offsets,
         bound_sequence_extent=bound_sequence_extent,
@@ -2236,20 +2248,20 @@ def _compile_delta_h_bwd_packed(
         return make_fake_tensor(dtype, (tokens, heads, width))
 
     state = make_fake_tensor(cutlass.Float32, (sequences, heads, key_dim, value_dim))
-    chunk_state = make_fake_tensor(cutlass.BFloat16, (chunks, heads, key_dim, value_dim))
+    chunk_state = make_fake_tensor(io_type, (chunks, heads, key_dim, value_dim))
     metadata = make_fake_tensor(cutlass.Int32, (metadata_entries,))
     return compile_tvm_ffi(
         kernel,
-        token_tensor(cutlass.BFloat16, key_dim),
-        token_tensor(cutlass.BFloat16, key_dim),
-        token_tensor(cutlass.BFloat16, key_dim),
-        token_tensor(cutlass.BFloat16, value_dim),
-        token_tensor(cutlass.BFloat16, chunk_size),
+        token_tensor(io_type, key_dim),
+        token_tensor(io_type, key_dim),
+        token_tensor(io_type, key_dim),
+        token_tensor(io_type, value_dim),
+        token_tensor(io_type, chunk_size),
         token_tensor(cutlass.Float32, key_dim),
         state,
         state,
         chunk_state,
-        token_tensor(cutlass.BFloat16, value_dim),
+        token_tensor(io_type, value_dim),
         metadata,
         metadata,
         (Int32(1), Int32(1), Int32(heads), Int32(key_dim), Int32(value_dim)),
@@ -2304,8 +2316,9 @@ def _blackwell_delta_h_bwd_dhu_dv_fused_packed(
         raise ValueError("packed delta-H+dV inputs must share q.device")
     if any(not tensor.is_contiguous() for tensor in tensor_inputs):
         raise ValueError("packed delta-H+dV inputs must be contiguous")
-    if any(tensor.dtype != torch.bfloat16 for tensor in (q, k, w, do, aqk)):
-        raise TypeError("q, k, w, do, and Aqk must be bfloat16")
+    if q.dtype not in _IO_TYPES or any(tensor.dtype != q.dtype for tensor in (k, w, do, aqk)):
+        raise TypeError("q, k, w, do, and Aqk must share dtype float16 or bfloat16")
+    io_type = _IO_TYPES[q.dtype]
     if gk is not None and gk.dtype != torch.float32:
         raise TypeError("gk must be float32")
     sequences = metadata.cu_seqlens.shape[0] - 1
@@ -2360,6 +2373,7 @@ def _blackwell_delta_h_bwd_dhu_dv_fused_packed(
     compiled = _compile_delta_h_bwd_packed(
         heads,
         bv,
+        io_type,
         use_int64_offsets,
         should_bound_sequence_extent(
             tokens,
@@ -2439,6 +2453,9 @@ def blackwell_delta_h_bwd_dhu_dv_fused(
         else torch.empty(state_shape, dtype=torch.float32, device=dev)
     )
 
+    if q.dtype not in _IO_TYPES or any(tensor.dtype != q.dtype for tensor in (k, w, do, aqk)):
+        raise TypeError("q, k, w, do, and Aqk must share dtype float16 or bfloat16")
+    io_type = _IO_TYPES[q.dtype]
     use_int64_offsets = requires_int64_abi(
         q,
         k,
@@ -2451,7 +2468,7 @@ def blackwell_delta_h_bwd_dhu_dv_fused(
         dh_out,
         dv2,
     )
-    fn = _compile_delta_h_bwd(H, bv, use_int64_offsets)
+    fn = _compile_delta_h_bwd(H, bv, io_type, use_int64_offsets)
     dummy_metadata = torch.empty(2, dtype=torch.int32, device=dev)
     fn(
         q,

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_intra.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_intra.py
@@ -47,7 +47,15 @@ KC_TOTAL = K_PHASES * SUBCHUNKS  # work items per (chunk, head): 16
 # contiguous, and the 16-byte cp.async stages need every outer stride and the
 # base pointer to be 16-byte (8 bf16 element) aligned.
 _MIN_ALIGN_BYTES = 16
-_MIN_ALIGN_ELEMENTS_BF16 = _MIN_ALIGN_BYTES // 2
+_MIN_ALIGN_ELEMENTS_16BIT = _MIN_ALIGN_BYTES // 2
+_IO_TYPES = {
+    torch.float16: cutlass.Float16,
+    torch.bfloat16: cutlass.BFloat16,
+}
+_IO_TYPE_NAMES = {
+    cutlass.Float16: "fp16",
+    cutlass.BFloat16: "bf16",
+}
 
 
 @triton.jit(do_not_specialize=["elements"])
@@ -149,16 +157,12 @@ def _cp_async_cg_g2s_16b(
     loc=None,
     ip=None,
 ):
-    """Issue one 16-byte cp.async from global to shared memory."""
+    """Issue one 16-byte cp.async without the register cost of the native wrapper."""
     gmem_addr = gmem_ptr.toint(loc=loc, ip=ip).ir_value()
     smem_addr = smem_ptr.toint(loc=loc, ip=ip).ir_value()
     llvm.inline_asm(
         None,
-        [
-            smem_addr,
-            gmem_addr,
-            src_bytes.ir_value(loc=loc, ip=ip),
-        ],
+        [smem_addr, gmem_addr, src_bytes.ir_value(loc=loc, ip=ip)],
         "cp.async.cg.shared.global [$0], [$1], 0x10, $2;",
         "r,l,r",
         has_side_effects=True,
@@ -288,31 +292,10 @@ def _bitcast_i32_to_f32(x: Int32, *, loc=None, ip=None):
     return cutlass.Float32(llvm.bitcast(T.f32(), x.ir_value(loc=loc, ip=ip), loc=loc, ip=ip))
 
 
-@dsl_user_op
-def _bf16x2_to_f32_pair(x: Int32, *, loc=None, ip=None):
-    result = llvm.inline_asm(
-        ir.Type.parse("!llvm.struct<(f32, f32)>"),
-        [x.ir_value(loc=loc, ip=ip)],
-        "{\n\t"
-        ".reg .u32 lo, hi, lo_f32, hi_f32;\n\t"
-        "and.b32 lo, $2, 0x0000ffff;\n\t"
-        "shr.u32 hi, $2, 16;\n\t"
-        "shl.b32 lo_f32, lo, 16;\n\t"
-        "shl.b32 hi_f32, hi, 16;\n\t"
-        "mov.b32 $0, lo_f32;\n\t"
-        "mov.b32 $1, hi_f32;\n\t"
-        "}\n",
-        "=f,=f,r",
-        has_side_effects=False,
-        is_align_stack=False,
-        asm_dialect=llvm.AsmDialect.AD_ATT,
-        loc=loc,
-        ip=ip,
-    )
-    return (
-        cutlass.Float32(llvm.extractvalue(T.f32(), result, [0], loc=loc, ip=ip)),
-        cutlass.Float32(llvm.extractvalue(T.f32(), result, [1], loc=loc, ip=ip)),
-    )
+@cute.jit
+def _half2_to_f32_pair(x, io_type):
+    values = cutlass.Vector.from_elements((x,), Int32).bitcast(io_type).to(Float32)
+    return Float32(values[0]), Float32(values[1])
 
 
 @dsl_user_op
@@ -422,67 +405,10 @@ def _ld_global_f32x4_lo2_pred(
     )
 
 
-@dsl_user_op
-def _add_f32x2(
-    a0: Float32,
-    a1: Float32,
-    b0: Float32,
-    b1: Float32,
-    *,
-    loc=None,
-    ip=None,
-):
-    result = llvm.inline_asm(
-        ir.Type.parse("!llvm.struct<(f32, f32)>"),
-        [
-            Float32(a0).ir_value(loc=loc, ip=ip),
-            Float32(a1).ir_value(loc=loc, ip=ip),
-            Float32(b0).ir_value(loc=loc, ip=ip),
-            Float32(b1).ir_value(loc=loc, ip=ip),
-        ],
-        "{\n\t"
-        ".reg .b64 lhs, rhs, out;\n\t"
-        "mov.b64 lhs, {$2, $3};\n\t"
-        "mov.b64 rhs, {$4, $5};\n\t"
-        "add.f32x2 out, lhs, rhs;\n\t"
-        "mov.b64 {$0, $1}, out;\n\t"
-        "}\n",
-        "=f,=f,f,f,f,f",
-        has_side_effects=False,
-        is_align_stack=False,
-        asm_dialect=llvm.AsmDialect.AD_ATT,
-        loc=loc,
-        ip=ip,
-    )
-    return (
-        cutlass.Float32(llvm.extractvalue(T.f32(), result, [0], loc=loc, ip=ip)),
-        cutlass.Float32(llvm.extractvalue(T.f32(), result, [1], loc=loc, ip=ip)),
-    )
-
-
-@dsl_user_op
-def _cvt_bf16x2_f32(
-    a: Float32,
-    b: Float32,
-    *,
-    loc=None,
-    ip=None,
-) -> Int32:
-    packed = llvm.inline_asm(
-        T.i32(),
-        [
-            Float32(a).ir_value(loc=loc, ip=ip),
-            Float32(b).ir_value(loc=loc, ip=ip),
-        ],
-        "cvt.rn.bf16x2.f32 $0, $2, $1;",
-        "=r,f,f",
-        has_side_effects=False,
-        is_align_stack=False,
-        asm_dialect=llvm.AsmDialect.AD_ATT,
-        loc=loc,
-        ip=ip,
-    )
-    return Int32(packed)
+@cute.jit
+def _cvt_half2_f32(a, b, io_type):
+    packed = cutlass.Vector.from_elements((a, b), Float32).to(io_type).bitcast(Int32)
+    return Int32(packed[0])
 
 
 @dsl_user_op
@@ -594,23 +520,8 @@ def _st_global_u32x4_pred(
     )
 
 
-@dsl_user_op
-def _bar_warp_sync(*, loc=None, ip=None) -> None:
-    llvm.inline_asm(
-        None,
-        [],
-        "bar.warp.sync -1;",
-        "",
-        has_side_effects=True,
-        is_align_stack=False,
-        asm_dialect=llvm.AsmDialect.AD_ATT,
-        loc=loc,
-        ip=ip,
-    )
-
-
 @cute.jit
-def _st_global_bf16_ldmatrix_epilogue_16x32(
+def _st_global_16b_ldmatrix_epilogue_16x32(
     sEpi_tile,
     gmem_ptr,
     top0: Int32,
@@ -639,11 +550,11 @@ def _st_global_bf16_ldmatrix_epilogue_16x32(
     row_valid0 = (row_base + out_row0) < valid
     row_valid1 = (row_base + out_row0 + 8) < valid
 
-    _bar_warp_sync()
+    cute.arch.sync_warp()
     _st_shared_u32x4(sEpi_tile.iterator + store_bytes // 2, top0, top1, top2, top3)
-    _bar_warp_sync()
+    cute.arch.sync_warp()
     v0, v1, v2, v3 = _ldmatrix_x4_b16(sEpi_tile.iterator + load_bytes // 2)
-    _bar_warp_sync()
+    cute.arch.sync_warp()
     _st_shared_u32x4(
         sEpi_tile.iterator + store_bytes // 2,
         bottom0,
@@ -651,7 +562,7 @@ def _st_global_bf16_ldmatrix_epilogue_16x32(
         bottom2,
         bottom3,
     )
-    _bar_warp_sync()
+    cute.arch.sync_warp()
     v4, v5, v6, v7 = _ldmatrix_x4_b16(sEpi_tile.iterator + load_bytes // 2)
     _st_global_u32x4_pred(
         gmem_ptr + out_row0 * row_stride + out_col,
@@ -669,7 +580,7 @@ def _st_global_bf16_ldmatrix_epilogue_16x32(
         v7,
         Boolean(row_valid1),
     )
-    _bar_warp_sync()
+    cute.arch.sync_warp()
 
 
 @cute.jit
@@ -715,7 +626,7 @@ def _st_global_f32_triton_shared_epilogue_16x32(
     valid,
     row_stride,
 ):
-    _bar_warp_sync()
+    cute.arch.sync_warp()
     lane = tidx & 31
     low3 = lane & 7
     lane_bit3 = lane & 8
@@ -768,7 +679,7 @@ def _st_global_f32_triton_shared_epilogue_16x32(
         v15,
         Boolean(row_valid3),
     )
-    _bar_warp_sync()
+    cute.arch.sync_warp()
 
 
 @dsl_user_op
@@ -801,10 +712,10 @@ def _hmma_load_b_groups_smem_ldmatrix(sB, row_base, k_outer, tidx):
     group8 = tidx // 8
     smem_ptr = sB.iterator + (row_base + k_outer * 8 + lane8) * KEY_DIM_PER_CTA + group8 * 8
     r0, r1, r2, r3 = _ldmatrix_x4_trans_b16(smem_ptr)
-    b00, b01 = _bf16x2_to_f32_pair(r0)
-    b10, b11 = _bf16x2_to_f32_pair(r1)
-    b20, b21 = _bf16x2_to_f32_pair(r2)
-    b30, b31 = _bf16x2_to_f32_pair(r3)
+    b00, b01 = _half2_to_f32_pair(r0, sB.element_type)
+    b10, b11 = _half2_to_f32_pair(r1, sB.element_type)
+    b20, b21 = _half2_to_f32_pair(r2, sB.element_type)
+    b30, b31 = _half2_to_f32_pair(r3, sB.element_type)
     return b00, b01, b10, b11, b20, b21, b30, b31
 
 
@@ -1004,13 +915,13 @@ def _chunk_kda_bwd_intra_hmma_grid_kernel(
     # SMEM is allocated once and reused across the chunk-loop iterations.
     smem = cutlass.utils.SmemAllocator()
     sQ_tile = smem.allocate_tensor(
-        element_type=cutlass.BFloat16,
+        element_type=mQ.element_type,
         layout=cute.make_layout((BT * KEY_DIM_PER_CTA,), stride=(1,)),
         byte_alignment=128,
         swizzle=None,
     )
     sK_tile = smem.allocate_tensor(
-        element_type=cutlass.BFloat16,
+        element_type=mK.element_type,
         layout=cute.make_layout((BT * KEY_DIM_PER_CTA,), stride=(1,)),
         byte_alignment=128,
         swizzle=None,
@@ -1028,7 +939,7 @@ def _chunk_kda_bwd_intra_hmma_grid_kernel(
         swizzle=None,
     )
     sEpi_tile = smem.allocate_tensor(
-        element_type=cutlass.BFloat16,
+        element_type=mDq2.element_type,
         layout=cute.make_layout((2048,), stride=(1,)),
         byte_alignment=128,
         swizzle=None,
@@ -1286,7 +1197,7 @@ def _chunk_kda_bwd_intra_hmma_grid_kernel(
                     b0 = b0 if key0 < valid else z
                     b1 = b1 if key1 < valid else z
                     _hmma_stage_b_group_stmatrix(sEpi_tile, b0, b1, tidx)
-                    _bar_warp_sync()
+                    cute.arch.sync_warp()
                     b0, b1 = _hmma_load_b_group_stmatrix(sEpi_tile, tidx)
                     if group == 0:
                         q00, q01, q02, q03 = _mma_tf32_m16n8k8(
@@ -1405,7 +1316,7 @@ def _chunk_kda_bwd_intra_hmma_grid_kernel(
                 b0 = b0 if key0 < valid else z
                 b1 = b1 if key1 < valid else z
                 _hmma_stage_b_group_stmatrix(sEpi_tile, b0, b1, tidx)
-                _bar_warp_sync()
+                cute.arch.sync_warp()
                 b0, b1 = _hmma_load_b_group_stmatrix(sEpi_tile, tidx)
                 if group == 0:
                     qd00, qd01, qd02, qd03 = _mma_tf32_m16n8k8(
@@ -1768,11 +1679,11 @@ def _chunk_kda_bwd_intra_hmma_grid_kernel(
                 )
                 dq_add0 = q_acc0 * qscale_prev0 + q_diag0 * qscale_diag0
                 dq_add1 = q_acc1 * qscale_prev1 + q_diag1 * qscale_diag1
-                dq_out0, dq_out1 = _add_f32x2(dq_in0, dq_in1, dq_add0, dq_add1)
+                dq_out0, dq_out1 = cute.arch.add_packed_f32x2((dq_in0, dq_in1), (dq_add0, dq_add1))
                 if lane_row == 0:
-                    dq_word0 = _cvt_bf16x2_f32(dq_out0, dq_out1)
+                    dq_word0 = _cvt_half2_f32(dq_out0, dq_out1, mDq2.element_type)
                 else:
-                    dq_word1 = _cvt_bf16x2_f32(dq_out0, dq_out1)
+                    dq_word1 = _cvt_half2_f32(dq_out0, dq_out1, mDq2.element_type)
                 dk_qk0 = k_acc0 * qscale_prev0 + k_diag0 * qscale_diag0
                 dk_qk1 = k_acc1 * qscale_prev1 + k_diag1 * qscale_diag1
                 dkt0 = d_acc0 * dscale0 + t_acc0 * tscale0
@@ -1781,11 +1692,11 @@ def _chunk_kda_bwd_intra_hmma_grid_kernel(
                 dk_beta1 = dk_qk1 * beta_row
                 dk_add0 = dk_beta0 + dkt0
                 dk_add1 = dk_beta1 + dkt1
-                dk_out0, dk_out1 = _add_f32x2(dk_in0, dk_in1, dk_add0, dk_add1)
+                dk_out0, dk_out1 = cute.arch.add_packed_f32x2((dk_in0, dk_in1), (dk_add0, dk_add1))
                 if lane_row == 0:
-                    dk_word0 = _cvt_bf16x2_f32(dk_out0, dk_out1)
+                    dk_word0 = _cvt_half2_f32(dk_out0, dk_out1, mDk2.element_type)
                 else:
-                    dk_word1 = _cvt_bf16x2_f32(dk_out0, dk_out1)
+                    dk_word1 = _cvt_half2_f32(dk_out0, dk_out1, mDk2.element_type)
                 dg_out0 = (dg_in0 + dq_add0 * qval0 + (dk_beta0 - dkt0) * kval0) * Float32(LN2)
                 dg_out1 = (dg_in1 + dq_add1 * qval1 + (dk_beta1 - dkt1) * kval1) * Float32(LN2)
                 if lane_row == 0:
@@ -1885,7 +1796,7 @@ def _chunk_kda_bwd_intra_hmma_grid_kernel(
             valid=valid,
             row_stride=dg2_row_stride,
         )
-        _st_global_bf16_ldmatrix_epilogue_16x32(
+        _st_global_16b_ldmatrix_epilogue_16x32(
             sEpi_tile,
             mDq2.iterator
             + (row_start + row_base) * dq2_row_stride
@@ -1904,7 +1815,7 @@ def _chunk_kda_bwd_intra_hmma_grid_kernel(
             valid=valid,
             row_stride=dq2_row_stride,
         )
-        _st_global_bf16_ldmatrix_epilogue_16x32(
+        _st_global_16b_ldmatrix_epilogue_16x32(
             sEpi_tile,
             mDk2.iterator
             + (row_start + row_base) * dk2_row_stride
@@ -2025,6 +1936,7 @@ def _compile_chunk_kda_bwd_intra(
     capacity: int,
     grid_chunks: int,
     ragged: bool,
+    io_type: type[cutlass.Numeric],
     use_int64_offsets: bool = False,
 ):
     """Compile one persistent intra-chunk backward specialization."""
@@ -2062,14 +1974,14 @@ def _compile_chunk_kda_bwd_intra(
             (columns, tokens, heads),
             stride=(
                 1,
-                sym_int(divisibility=_MIN_ALIGN_ELEMENTS_BF16),
-                sym_int(divisibility=_MIN_ALIGN_ELEMENTS_BF16),
+                sym_int(divisibility=_MIN_ALIGN_ELEMENTS_16BIT),
+                sym_int(divisibility=_MIN_ALIGN_ELEMENTS_16BIT),
             ),
             assumed_align=_MIN_ALIGN_BYTES,
         )
 
-    q = strided_column_token_head(cutlass.BFloat16, KEY_DIM)
-    k = strided_column_token_head(cutlass.BFloat16, KEY_DIM)
+    q = strided_column_token_head(io_type, KEY_DIM)
+    k = strided_column_token_head(io_type, KEY_DIM)
     g = column_token_head(cutlass.Float32, KEY_DIM)
     beta = normal(cutlass.Float32, (1, tokens, heads))
     dAqk = column_token_head(cutlass.Float32, BT)
@@ -2078,8 +1990,8 @@ def _compile_chunk_kda_bwd_intra(
     dk = column_token_head(cutlass.Float32, KEY_DIM)
     db_partial = normal(cutlass.Float32, (K_PHASES, tokens, heads))
     dg = column_token_head(cutlass.Float32, KEY_DIM)
-    dq2 = column_token_head(cutlass.BFloat16, KEY_DIM)
-    dk2 = column_token_head(cutlass.BFloat16, KEY_DIM)
+    dq2 = column_token_head(io_type, KEY_DIM)
+    dk2 = column_token_head(io_type, KEY_DIM)
     dg2 = column_token_head(cutlass.Float32, KEY_DIM)
     cu_seqlens = normal(cutlass.Int32, (sequences,)) if ragged else None
     chunk_offsets = normal(cutlass.Int32, (sequences,)) if ragged else None
@@ -2101,7 +2013,7 @@ def _compile_chunk_kda_bwd_intra(
         cu_seqlens,
         chunk_offsets,
         name=(
-            f"kda_bwd_intra_h{heads}_c{capacity}_gc{grid_chunks}_rg{int(ragged)}"
+            f"kda_bwd_intra_h{heads}_c{capacity}_gc{grid_chunks}_{_IO_TYPE_NAMES[io_type]}_rg{int(ragged)}"
             f"_i64{int(use_int64_offsets)}"
         ),
     )
@@ -2171,12 +2083,14 @@ class ChunkKdaBwdIntraTunable:
     def compile_call(
         config: ChunkKdaBwdIntraConfig,
         args: Args,
-    ) -> tuple[int, int, int, bool, bool]:
+    ) -> tuple[int, int, int, bool, type[cutlass.Numeric], bool]:
+        io_type = _IO_TYPES[args.q.dtype]
         return (
             args.q.shape[2],
             args.capacity,
             config.grid_chunks,
             args.chunk_offsets is not None,
+            io_type,
             requires_int64_abi(
                 _column_token_head(args.q),
                 _column_token_head(args.k),
@@ -2260,6 +2174,8 @@ def chunk_kda_bwd_intra(
     batch, tokens, heads, head_dim = q.shape
     if batch != 1 or head_dim != KEY_DIM:
         raise ValueError("the intra-chunk backward requires B=1 and K=128")
+    if q.dtype not in _IO_TYPES or k.dtype != q.dtype:
+        raise TypeError("q and k must share dtype float16 or bfloat16")
     if metadata is not None:
         metadata.validate_chunk_size(BT)
     elif tokens % BT:

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_wy_dqkg_fused.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_wy_dqkg_fused.py
@@ -9,7 +9,6 @@
 #
 # pyre-ignore-all-errors
 
-import os
 from collections.abc import Iterable
 from typing import NamedTuple
 
@@ -17,6 +16,15 @@ import cutlass
 import cutlass.utils.blackwell_helpers as sm100_utils
 import torch
 from cutlass import cute, pipeline, utils
+
+# ============================================================================
+# SM100 primitives used by this kernel
+# ============================================================================
+from cutlass._mlir import ir
+from cutlass._mlir.dialects import arith as _arith
+from cutlass._mlir.dialects import llvm
+from cutlass._mlir.dialects import nvvm as _nvvm
+from cutlass._mlir.dialects import vector as _vector
 from cutlass.cute.arch import (
     elect_one,
     mbarrier_arrive,
@@ -29,7 +37,8 @@ from cutlass.cute.nvgpu import cpasync, tcgen05
 from cutlass.cute.nvgpu.tcgen05 import make_umma_smem_desc, smem_descriptor_to_int
 from cutlass.cute.runtime import make_fake_compact_tensor, make_fake_tensor
 from cutlass.cute.tensor import TensorSSA
-from cutlass.cute.typing import BFloat16, Float32, Int32, Int64
+from cutlass.cute.typing import BFloat16, Float16, Float32, Int32, Int64
+from cutlass.cutlass_dsl import dsl_user_op
 
 from attn_gym._backends.cute import compile_tvm_ffi, jit_cache, run_tunable
 from attn_gym._backends.cute.target import CompileTarget, detect_compile_target, get_compile_target
@@ -40,625 +49,37 @@ from attn_gym.linear.kda.fwd.cute.chunk_scheduler_cute import (
     load_ragged_chunk_work,
 )
 
-# ============================================================================
-# Inlined SM100 tcgen05 helper wrappers
-# ============================================================================
-
-# ---- ptx_umma_ext.py ----
-# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
-#
-# Adapted from cuLA's SM100 tcgen05 MMA extension wrappers.
-#
+# The retained tcgen05 descriptor and TMEM vector bridges are adapted from cuLA.
 # Copyright (c) 2025 ANTGROUP. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""CuteDSL UMMA extension wrappers for SM100 (Blackwell) ``tcgen05.mma``.
-
-CuteDSL's high-level ``cute.gemm()`` / ``make_tiled_mma()`` API does not
-expose all ``tcgen05.mma`` instruction variants.  This module provides
-low-level wrappers for the two categories currently needed:
-
-1. **Masked MMA** – SS and TS forms with the 128-bit ``disable-output-lane``
-   mask operand (``{m0, m1, m2, m3}``).  Implemented via the native
-   ``nvvm.tcgen05_mma`` MLIR op with its ``write_disable_mask`` parameter
-   (``vector<4xi32>``).
-
-2. **Weight-stationary (WS) MMA** – ``tcgen05.mma.ws`` SS / TS forms for
-   both ``kind::tf32`` and ``kind::f16``.  Implemented via
-   ``llvm.inline_asm``.
-
-----------------------------------------------------------------------
-PTX instruction forms
-----------------------------------------------------------------------
-SS (SMEM A, SMEM B):
-    tcgen05.mma.cta_group::1.kind::tf32  [tmem_c], desc_a, desc_b,
-                                          desc_val, {m0,m1,m2,m3}, p;
-
-TS (TMEM A, SMEM B):
-    tcgen05.mma.cta_group::1.kind::tf32  [tmem_c], [tmem_a], desc_b,
-                                          desc_val, {m0,m1,m2,m3}, p;
-
-WS_SS (weight-stationary, SMEM A, SMEM B):
-    tcgen05.mma.ws.cta_group::1.kind::tf32  [tmem_c], desc_a, desc_b,
-                                             desc_val, p;
-    tcgen05.mma.ws.cta_group::1.kind::f16   [tmem_c], desc_a, desc_b,
-                                             desc_val, p;
-
-WS_TS (weight-stationary, TMEM A, SMEM B):
-    tcgen05.mma.ws.cta_group::1.kind::tf32  [tmem_c], [tmem_a], desc_b,
-                                             desc_val, p;
-    tcgen05.mma.ws.cta_group::1.kind::f16   [tmem_c], [tmem_a], desc_b,
-                                             desc_val, p;
-
-----------------------------------------------------------------------
-Disable-output-lane mask layout (4 × uint32 = 128 bits)
-----------------------------------------------------------------------
-Each uint32 covers 32 M-dimension rows (8 rows × 4 elements per group).
-  0x00000000  → group is ACTIVE    (output written)
-  0xFFFFFFFF  → group is DISABLED  (output suppressed)
-
-Predefined SS mask constants (SMEM A variants):
-  SS_NO_MASK  = (0, 0, 0, 0)                       all rows active
-  SS_MASK0    = (0, 0xFF…, 0, 0xFF…)               odd groups disabled
-  SS_MASK1    = (0xFF…, 0, 0xFF…, 0)               even groups disabled
-  SS_MASK2    = (0xFF…, 0xFF…, 0, 0xFF…)           group 2 only active
-  SS_MASK3    = (0xFF…, 0xFF…, 0xFF…, 0)           group 3 only active
-
-Predefined TS mask constants (TMEM A variants):
-  TS_NO_MASK  = (0, 0, 0, 0)                       all rows active
-  TS_MASK0    = (0, 0xFF…, 0xFF…, 0xFF…)           group 0 only active
-  TS_MASK1    = (0xFF…, 0, 0xFF…, 0xFF…)           group 1 only active
-  TS_MASK2    = (0xFF…, 0xFF…, 0, 0xFF…)           group 2 only active
-  TS_MASK3    = (0xFF…, 0xFF…, 0xFF…, 0)           group 3 only active
-  TS_MASK02   = (0, 0xFF…, 0, 0xFF…)               groups 0,2 only active
-  TS_MASK13   = (0xFF…, 0, 0xFF…, 0)               groups 1,3 only active
-
-Public API (all decorated with @cute.jit)
-----------------------------------------------------------------------
-Descriptor helpers (call inside @cute.jit):
-    Tcgen05SmemDescriptor          — 64-bit SMEM descriptor object
-    initialize_tcgen05_descriptor  — fill descriptor bitfields
-
-Low-level primitives (pass mask words explicitly):
-    tcgen05mma_ss(desc_a, desc_b, tmem_c, desc_val, scale_out,
-                  mask0, mask1, mask2, mask3)
-    tcgen05mma_ts(tmem_a, desc_b, tmem_c, desc_val, scale_out,
-                  mask0, mask1, mask2, mask3)
-    tcgen05mma_ws_ss_tf32(desc_a, desc_b, tmem_c, desc_val, scale_out)
-    tcgen05mma_ws_ts_tf32(tmem_a, desc_b, tmem_c, desc_val, scale_out)
-    tcgen05mma_ws_ss_f16(desc_a, desc_b, tmem_c, desc_val, scale_out)
-    tcgen05mma_ws_ts_f16(tmem_a, desc_b, tmem_c, desc_val, scale_out)
-
-Named convenience wrappers (pre-set masks, pass only MMA operands):
-    tcgen05mma_ss_no_mask / tcgen05mma_ss_mask0 / …mask1 / …mask2 / …mask3
-    tcgen05mma_ts_no_mask / tcgen05mma_ts_mask0 / …mask1 / …mask2 / …mask3
-    tcgen05mma_ts_mask02  / tcgen05mma_ts_mask13
-"""
-
-__all__ = [
-    # collector enums (re-exported for convenience)
-    "CollectorBBuffer",
-    "CollectorOp",
-    # descriptor helpers
-    "Tcgen05SmemDescriptor",
-    "initialize_tcgen05_descriptor",
-    # low-level primitives
-    "tcgen05mma_ss",
-    "tcgen05mma_ss_mask0",
-    "tcgen05mma_ss_mask1",
-    "tcgen05mma_ss_mask2",
-    "tcgen05mma_ss_mask3",
-    # SS named wrappers
-    "tcgen05mma_ss_no_mask",
-    "tcgen05mma_ts",
-    "tcgen05mma_ts_mask0",
-    "tcgen05mma_ts_mask02",
-    "tcgen05mma_ts_mask1",
-    "tcgen05mma_ts_mask2",
-    "tcgen05mma_ts_mask3",
-    "tcgen05mma_ts_mask13",
-    # TS named wrappers
-    "tcgen05mma_ts_no_mask",
-    "tcgen05mma_ws_ss_f16",
-    "tcgen05mma_ws_ss_tf32",
-    "tcgen05mma_ws_ts_f16",
-    "tcgen05mma_ws_ts_tf32",
-]
-
-from cutlass._mlir import ir
-from cutlass._mlir.dialects import arith as _arith
-from cutlass._mlir.dialects import llvm
-from cutlass._mlir.dialects import nvvm as _nvvm
-from cutlass.cutlass_dsl import dsl_user_op
-
-# Re-export collector enums for caller convenience.
-CollectorBBuffer = _nvvm.Tcgen05MMACollectorBBuffer
-CollectorOp = _nvvm.Tcgen05MMACollectorOp
-
-# ---------------------------------------------------------------------------
-# Mask constants (4 × uint32).  0 = ACTIVE, 0xFFFFFFFF = DISABLED.
-# ---------------------------------------------------------------------------
-_ALL_ACTIVE = 0x00000000
-_ALL_OFF = 0xFFFFFFFF
-
-# SS masks (SMEM A, SMEM B)
-SS_NO_MASK = (_ALL_ACTIVE, _ALL_ACTIVE, _ALL_ACTIVE, _ALL_ACTIVE)
-SS_MASK0 = (_ALL_ACTIVE, _ALL_OFF, _ALL_ACTIVE, _ALL_OFF)  # {0,F,0,F}
-SS_MASK1 = (_ALL_OFF, _ALL_ACTIVE, _ALL_OFF, _ALL_ACTIVE)  # {F,0,F,0}
-SS_MASK2 = (_ALL_OFF, _ALL_OFF, _ALL_ACTIVE, _ALL_OFF)  # {F,F,0,F}
-SS_MASK3 = (_ALL_OFF, _ALL_OFF, _ALL_OFF, _ALL_ACTIVE)  # {F,F,F,0}
-
-# TS masks (TMEM A, SMEM B)
-TS_NO_MASK = (_ALL_ACTIVE, _ALL_ACTIVE, _ALL_ACTIVE, _ALL_ACTIVE)
-TS_MASK0 = (_ALL_ACTIVE, _ALL_OFF, _ALL_OFF, _ALL_OFF)  # {0,F,F,F}
-TS_MASK1 = (_ALL_OFF, _ALL_ACTIVE, _ALL_OFF, _ALL_OFF)  # {F,0,F,F}
-TS_MASK2 = (_ALL_OFF, _ALL_OFF, _ALL_ACTIVE, _ALL_OFF)  # {F,F,0,F}
-TS_MASK3 = (_ALL_OFF, _ALL_OFF, _ALL_OFF, _ALL_ACTIVE)  # {F,F,F,0}
-TS_MASK02 = (_ALL_ACTIVE, _ALL_OFF, _ALL_ACTIVE, _ALL_OFF)  # {0,F,0,F}
-TS_MASK13 = (_ALL_OFF, _ALL_ACTIVE, _ALL_OFF, _ALL_ACTIVE)  # {F,0,F,0}
-
-
-# ---------------------------------------------------------------------------
-# Tcgen05SmemDescriptor — 64-bit SMEM descriptor stored as 2×Int32
-# ---------------------------------------------------------------------------
-
 
 class Tcgen05SmemDescriptor:
-    """64-bit shared-memory descriptor for tcgen05 MMA (Blackwell / SM100).
+    """64-bit shared-memory descriptor for tcgen05 MMA."""
 
-    The descriptor encodes SMEM base address, leading/stride byte offsets,
-    swizzle mode, and other fields required by the ``tcgen05.mma`` PTX
-    instruction to locate a matrix tile in shared memory.
-
-    64-bit layout (PTX ISA Table 40)::
-
-      Bit 63                                                      Bit 0
-      ┌──────────┬────────┬─────┬──────────┬────┬──────────┬──────┬──────────────┐
-      │ 63    61 │ 60  53 │  52 │ 51    49 │ 48 │ 45    32 │31 30 │ 29   16│15 14│ 13     0│
-      │layout_typ│ reservd│l_abs│base_offst│ 46 │   SBO    │ rsvd │  LBO   │rsvd │start_adr│
-      │  (3 bit) │ (8 bit)│(1b) │  (3 bit) │=0b001│(14 bit)│(2 b) │(14 bit)│(2b) │(14 bit) │
-      └──────────┴────────┴─────┴──────────┴────┴──────────┴──────┴────────┴─────┴─────────┘
-
-    Field descriptions:
-
-    - **start_address** [bits 0-13]: SMEM base pointer, encoded as
-      ``smem_ptr >> 4`` (16-byte aligned). The hardware reconstructs the
-      full address as ``encoded_value << 4``.
-
-    - **LBO** (Leading Byte Offset) [bits 16-29]: distance in bytes between
-      consecutive elements along the leading dimension, encoded as
-      ``lbo_bytes >> 4``.  When ``lbo_mode=1`` this is an absolute byte
-      address rather than a relative offset.
-
-    - **SBO** (Stride Byte Offset) [bits 32-45]: distance in bytes between
-      consecutive elements along the stride dimension, encoded as
-      ``sbo_bytes >> 4``.
-
-    - **version** [bits 46-48]: fixed constant ``0b001`` (= 1).
-
-    - **base_offset** [bits 49-51]: 3-bit alignment correction when the
-      SMEM tile does not start at a natural swizzle-pattern boundary
-      (1024B for 128B swizzle, 512B for 64B, 256B for 32B).
-      Computed as ``(start_addr >> 7) & 0x7``.  Usually 0.
-
-    - **lbo_mode** (leading_abs) [bit 52]: 0 → LBO is a relative byte
-      offset; 1 → LBO is an absolute byte address.
-
-    - **layout_type** (swizzle_mode) [bits 61-63]:
-        - 0 = SWIZZLE_NONE
-        - 1 = SWIZZLE_128B_BASE32B  (128-byte pattern, 32-byte atom)
-        - 2 = SWIZZLE_128B          (128-byte pattern)
-        - 4 = SWIZZLE_64B           (64-byte pattern)
-        - 6 = SWIZZLE_32B           (32-byte pattern)
-
-    Storage: two Int32 registers (desc[0] = low 32 bits, desc[1] = high 32
-    bits), recast to a single Int64 for the PTX ``l``-constraint operand.
-
-    Usage inside a @cute.jit kernel::
-
-        desc = Tcgen05SmemDescriptor()
-        initialize_tcgen05_descriptor(desc, smem_ptr, lbo, sbo, 0, True, swizzle)
-    """
-
-    def __init__(self, desc_64: cute.Int64 = None):
-        # desc[0]: low  32 bits → start_address[0:14] | LBO[16:30]
-        # desc[1]: high 32 bits → SBO[0:14] | version[14:16] | base_offset[17:20]
-        #                         | lbo_mode[20] | layout_type[29:32]
+    def __init__(self, desc_64: cute.Int64):
         self.desc = cute.make_rmem_tensor((2,), dtype=cutlass.Int32)
-        # Alias the 2×i32 as 1×i64 for PTX "l" constraint (64-bit operand)
         self.desc_i64 = cute.make_tensor(
-            cute.recast_ptr(self.desc.iterator, dtype=cute.Int64), (1,)
+            cute.recast_ptr(self.desc.iterator, dtype=cute.Int64),
+            (1,),
         )
-        if desc_64 is not None:
-            self.desc_i64[0] = desc_64
+        self.desc_i64[0] = desc_64
 
     def __add__(self, byte_offset):
-        """Return a new descriptor offset by ``byte_offset`` bytes.
-
-        Only the start_address field (bits 0-13 of desc[0]) is modified.
-        Since it is stored in 16-byte units, we add ``byte_offset >> 4``.
-        All other fields (LBO, SBO, swizzle, etc.) are copied unchanged.
-        """
-        res = cute.make_rmem_tensor((2,), dtype=cutlass.Int32)
-        res_i64 = cute.make_tensor(cute.recast_ptr(res.iterator, dtype=cute.Int64), (1,))
-        res[0] = self.desc[0] + (byte_offset >> 4)  # adjust start_address
-        res[1] = self.desc[1]  # high word unchanged
-        return Tcgen05SmemDescriptor(res_i64[0])
-
-
-# ---------------------------------------------------------------------------
-# initialize_tcgen05_descriptor
-# ---------------------------------------------------------------------------
-
-
-def initialize_tcgen05_descriptor(
-    desc,
-    start_address,
-    leading_byte_offset,
-    stride_byte_offset,
-    base_offset,
-    leading_abs,
-    swizzle_mode,
-):
-    """Pack SMEM descriptor bitfields into *desc* (a Tcgen05SmemDescriptor).
-
-    Constructs the 64-bit descriptor in two 32-bit halves (desc[0] and desc[1]).
-    All address/offset fields must be pre-divided by 16 (``>> 4``) before
-    passing, because the hardware stores them in 16-byte granularity.
-
-    Low 32 bits — desc[0]::
-
-      ┌────────────────┬──────┬──────────────────┐
-      │ bits 29…16     │15…14 │ bits 13…0        │
-      │ LBO (14 bits)  │ rsvd │ start_addr >> 4   │
-      └────────────────┴──────┴──────────────────┘
-
-      - [0:14)   start_address >> 4  — SMEM tile base pointer in 16B units.
-      - [14:16)  reserved (0).
-      - [16:30)  leading_byte_offset — LBO in 16B units (caller passes >> 4).
-
-    High 32 bits — desc[1]::
-
-      ┌────────┬────────┬─────┬──────────┬────────┬──────────────────┐
-      │ 31…29  │ 28…21  │  20 │ 19…17    │ 16…14  │ bits 13…0        │
-      │ layout │  rsvd  │l_abs│base_off  │version │ SBO (14 bits)    │
-      │ (3 bit)│ (8 bit)│(1b) │  (3 bit) │=0b001  │                  │
-      └────────┴────────┴─────┴──────────┴────────┴──────────────────┘
-
-      - [0:14)   stride_byte_offset — SBO in 16B units (caller passes >> 4).
-      - [14:16)  version = 1 (fixed constant 0b001, only bit 14 set).
-      - [17:20)  base_offset & 0x7 — swizzle alignment correction.
-                 Typically 0.  Non-zero when the tile doesn't start at
-                 the natural swizzle boundary (1024B/512B/256B).
-      - [20:21)  lbo_mode — 0 = LBO is relative offset, 1 = absolute address.
-      - [29:32)  layout_type (swizzle_mode & 0x7):
-                   0 = SWIZZLE_NONE
-                   1 = SWIZZLE_128B_BASE32B  (Swizzle<2,5,2>)
-                   2 = SWIZZLE_128B          (Swizzle<3,4,3>)
-                   4 = SWIZZLE_64B           (Swizzle<2,4,3>)
-                   6 = SWIZZLE_32B           (Swizzle<1,4,3>)
-
-    Args:
-        desc:                 Tcgen05SmemDescriptor to fill.
-        start_address:        CuTeDSL Pointer to the SMEM tile start.
-        leading_byte_offset:  Leading-dimension byte offset, already >> 4.
-        stride_byte_offset:   Stride  byte offset, already >> 4.
-        base_offset:          Swizzle alignment correction (raw int, bits 17-19).
-        leading_abs:          Bool — True → LBO is absolute address.
-        swizzle_mode:         Swizzle layout_type integer (bits 29-31).
-    """
-    # Encode start_address: take SMEM pointer, shift right by 4 to get 16B units
-    ptr_val = start_address.toint() >> 4
-
-    # --- Low 32 bits (desc[0]) ---
-    # bits [0:14)  = start_address >> 4
-    # bits [16:30) = leading_byte_offset (already in 16B units)
-    desc.desc[0] = cutlass.Int32(ptr_val) | cutlass.Int32(cutlass.Int32(leading_byte_offset) << 16)
-
-    # --- High 32 bits (desc[1]) ---
-    # bits [0:14)  = stride_byte_offset (already in 16B units)
-    # bit  [14]    = version = 1  (fixed)
-    # bits [17:20) = base_offset & 0x7  (swizzle alignment correction)
-    # bit  [20]    = lbo_mode  (0=relative, 1=absolute)
-    # bits [29:32) = layout_type  (swizzle mode)
-    desc.desc[1] = (
-        cutlass.Int32(stride_byte_offset)
-        | cutlass.Int32(1 << 14)  # version = 1
-        | cutlass.Int32(cutlass.Int32(base_offset & 0x7) << 17)
-        | cutlass.Int32(cutlass.Int32(int(leading_abs)) << 20)
-        | cutlass.Int32(cutlass.Int32(swizzle_mode & 0x7) << 29)
-    )
-
-
-# ---------------------------------------------------------------------------
-# Internal helper
-# ---------------------------------------------------------------------------
-
-
-def _ir(val, loc=None, ip=None):
-    """Extract raw MLIR IR value from a CuTeDSL wrapper."""
-    return val.ir_value(loc=loc, ip=ip) if hasattr(val, "ir_value") else val
-
-
-# ===========================================================================
-# Low-level primitives
-# ===========================================================================
-
-# ---------------------------------------------------------------------------
-# tcgen05mma_ss  —  SMEM A, SMEM B (non-warp-specialised)
-# ---------------------------------------------------------------------------
-
-
-@cute.jit
-def tcgen05mma_ss(
-    desc_a: Tcgen05SmemDescriptor,
-    desc_b: Tcgen05SmemDescriptor,
-    tmem_c: int,
-    desc_val: int,
-    scale_out: int,
-    mask0: int,
-    mask1: int,
-    mask2: int,
-    mask3: int,
-):
-    """Issue ``tcgen05.mma.cta_group::1.kind::tf32`` with SMEM operands.
-
-    ``mask{0-3}`` are the four uint32 words of the 128-bit
-    ``disable-output-lane`` mask (0=active, 0xFFFFFFFF=disabled).
-
-    Caller must ensure single-thread execution (e.g. via ``elect_one``);
-    no internal ``elect.sync`` is performed.
-
-    Args:
-        desc_a:    64-bit SMEM descriptor for matrix A.
-        desc_b:    64-bit SMEM descriptor for matrix B.
-        tmem_c:    TMEM base address (uint32) for accumulators C/D.
-        desc_val:  High 32 bits of the UMMA instruction descriptor (idescE>>32).
-        scale_out: 1 → accumulate into C, 0 → overwrite C (clear accumulators).
-        mask0-3:   Four uint32 words of the disable-output-lane mask.
-    """
-
-    @dsl_user_op
-    def _do(
-        c_val,
-        da_val,
-        db_val,
-        dv_val,
-        sc_val,
-        m0_val,
-        m1_val,
-        m2_val,
-        m3_val,
-        *,
-        loc=None,
-        ip=None,
-    ):
-        ptr6_ty = llvm.PointerType.get(address_space=6)
-        i32_ty = ir.IntegerType.get_signless(32)
-        i1_ty = ir.IntegerType.get_signless(1)
-        vec4i32_ty = ir.VectorType.get([4], i32_ty)
-
-        c_ir = _ir(c_val, loc, ip)
-        d_ptr = llvm.inttoptr(ptr6_ty, c_ir, loc=loc, ip=ip)
-        da_ir = _ir(da_val, loc, ip)  # i64 SMEM descriptor
-        db_ir = _ir(db_val, loc, ip)  # i64 SMEM descriptor
-        dv_ir = _ir(dv_val, loc, ip)
-        sc_ir = _ir(sc_val, loc, ip)
-        enable_d = _arith.trunci(i1_ty, sc_ir, loc=loc, ip=ip)
-
-        m0_ir = _ir(m0_val, loc, ip)
-        m1_ir = _ir(m1_val, loc, ip)
-        m2_ir = _ir(m2_val, loc, ip)
-        m3_ir = _ir(m3_val, loc, ip)
-
-        undef = llvm.mlir_undef(vec4i32_ty, loc=loc, ip=ip)
-        idx0 = _arith.constant(i32_ty, 0, loc=loc, ip=ip)
-        idx1 = _arith.constant(i32_ty, 1, loc=loc, ip=ip)
-        idx2 = _arith.constant(i32_ty, 2, loc=loc, ip=ip)
-        idx3 = _arith.constant(i32_ty, 3, loc=loc, ip=ip)
-        v = llvm.InsertElementOp(undef, m0_ir, idx0, loc=loc, ip=ip)
-        v = llvm.InsertElementOp(v, m1_ir, idx1, loc=loc, ip=ip)
-        v = llvm.InsertElementOp(v, m2_ir, idx2, loc=loc, ip=ip)
-        mask = llvm.InsertElementOp(v, m3_ir, idx3, loc=loc, ip=ip)
-
-        _nvvm.tcgen05_mma(
-            mma_kind=_nvvm.Tcgen05MMAKind.TF32,
-            cta_group=_nvvm.Tcgen05GroupKind.CTA_1,
-            d=d_ptr,
-            a=da_ir,
-            b=db_ir,
-            idesc=dv_ir,
-            enable_input_d=enable_d,
-            write_disable_mask=mask,
-            loc=loc,
-            ip=ip,
+        """Return a descriptor with its start address advanced by a byte offset."""
+        result = cute.make_rmem_tensor((2,), dtype=cutlass.Int32)
+        result_i64 = cute.make_tensor(
+            cute.recast_ptr(result.iterator, dtype=cute.Int64),
+            (1,),
         )
-
-    _do(
-        cutlass.Int32(tmem_c),
-        desc_a.desc_i64[0],
-        desc_b.desc_i64[0],
-        cutlass.Int32(desc_val),
-        cutlass.Int32(scale_out),
-        cutlass.Int32(mask0),
-        cutlass.Int32(mask1),
-        cutlass.Int32(mask2),
-        cutlass.Int32(mask3),
-    )
+        result[0] = self.desc[0] + (byte_offset >> 4)
+        result[1] = self.desc[1]
+        return Tcgen05SmemDescriptor(result_i64[0])
 
 
-# ---------------------------------------------------------------------------
-# tcgen05mma_ts  —  TMEM A, SMEM B (non-warp-specialised)
-# ---------------------------------------------------------------------------
-
-
-@cute.jit
-def tcgen05mma_ts(
-    tmem_a: int,
-    desc_b: Tcgen05SmemDescriptor,
-    tmem_c: int,
-    desc_val: int,
-    scale_out: int,
-    mask0: int,
-    mask1: int,
-    mask2: int,
-    mask3: int,
-):
-    """Issue ``tcgen05.mma.cta_group::1.kind::tf32`` with TMEM A operand.
-
-    Matrix A is read from TMEM via indirect addressing ``[tmem_a]``.
-    Matrix B is read from SMEM via descriptor.
-    Caller must ensure single-thread execution (e.g. via ``elect_one``).
-
-    Args:
-        tmem_a:    TMEM base address (uint32) for matrix A.
-        desc_b:    64-bit SMEM descriptor for matrix B.
-        tmem_c:    TMEM base address (uint32) for accumulators C/D.
-        desc_val:  High 32 bits of the UMMA instruction descriptor (idescE>>32).
-        scale_out: 1 → accumulate into C, 0 → overwrite C.
-        mask0-3:   Four uint32 words of the disable-output-lane mask.
-    """
-
-    @dsl_user_op
-    def _do(
-        c_val,
-        a_val,
-        db_val,
-        dv_val,
-        sc_val,
-        m0_val,
-        m1_val,
-        m2_val,
-        m3_val,
-        *,
-        loc=None,
-        ip=None,
-    ):
-        ptr6_ty = llvm.PointerType.get(address_space=6)
-        i32_ty = ir.IntegerType.get_signless(32)
-        i1_ty = ir.IntegerType.get_signless(1)
-        vec4i32_ty = ir.VectorType.get([4], i32_ty)
-
-        c_ir = _ir(c_val, loc, ip)
-        a_ir = _ir(a_val, loc, ip)
-        d_ptr = llvm.inttoptr(ptr6_ty, c_ir, loc=loc, ip=ip)
-        a_ptr = llvm.inttoptr(ptr6_ty, a_ir, loc=loc, ip=ip)
-        b_ir = _ir(db_val, loc, ip)
-        dv_ir = _ir(dv_val, loc, ip)
-        sc_ir = _ir(sc_val, loc, ip)
-        enable_d = _arith.trunci(i1_ty, sc_ir, loc=loc, ip=ip)
-
-        m0_ir = _ir(m0_val, loc, ip)
-        m1_ir = _ir(m1_val, loc, ip)
-        m2_ir = _ir(m2_val, loc, ip)
-        m3_ir = _ir(m3_val, loc, ip)
-
-        undef = llvm.mlir_undef(vec4i32_ty, loc=loc, ip=ip)
-        idx0 = _arith.constant(i32_ty, 0, loc=loc, ip=ip)
-        idx1 = _arith.constant(i32_ty, 1, loc=loc, ip=ip)
-        idx2 = _arith.constant(i32_ty, 2, loc=loc, ip=ip)
-        idx3 = _arith.constant(i32_ty, 3, loc=loc, ip=ip)
-        v = llvm.InsertElementOp(undef, m0_ir, idx0, loc=loc, ip=ip)
-        v = llvm.InsertElementOp(v, m1_ir, idx1, loc=loc, ip=ip)
-        v = llvm.InsertElementOp(v, m2_ir, idx2, loc=loc, ip=ip)
-        mask = llvm.InsertElementOp(v, m3_ir, idx3, loc=loc, ip=ip)
-
-        _nvvm.tcgen05_mma(
-            mma_kind=_nvvm.Tcgen05MMAKind.TF32,
-            cta_group=_nvvm.Tcgen05GroupKind.CTA_1,
-            d=d_ptr,
-            a=a_ptr,
-            b=b_ir,
-            idesc=dv_ir,
-            enable_input_d=enable_d,
-            write_disable_mask=mask,
-            loc=loc,
-            ip=ip,
-        )
-
-    _do(
-        cutlass.Int32(tmem_c),
-        cutlass.Int32(tmem_a),
-        desc_b.desc_i64[0],
-        cutlass.Int32(desc_val),
-        cutlass.Int32(scale_out),
-        cutlass.Int32(mask0),
-        cutlass.Int32(mask1),
-        cutlass.Int32(mask2),
-        cutlass.Int32(mask3),
-    )
-
-
-# ---------------------------------------------------------------------------
-# tcgen05mma_ws_ss_tf32  —  weight-stationary, SMEM A, SMEM B, kind::tf32
-# ---------------------------------------------------------------------------
-
-
-@cute.jit
-def tcgen05mma_ws_ss_tf32(
-    desc_a: Tcgen05SmemDescriptor,
-    desc_b: Tcgen05SmemDescriptor,
-    tmem_c: int,
-    desc_val: int,
-    scale_out: int,
-    collector_b_buffer=None,
-    collector_op=None,
-):
-    """Issue ``tcgen05.mma.ws.cta_group::1.kind::tf32`` (weight-stationary form).
-
-    This variant does NOT take a ``disable-output-lane`` mask; the
-    optional ``zero-column-mask-desc`` operand is omitted.
-
-    Args:
-        desc_a:    64-bit SMEM descriptor for matrix A.
-        desc_b:    64-bit SMEM descriptor for matrix B.
-        tmem_c:    TMEM base address (uint32) for accumulators C/D.
-        desc_val:  High 32 bits of the UMMA instruction descriptor (idescE>>32).
-        scale_out: 1 → accumulate, 0 → overwrite.
-        collector_b_buffer: Optional ``CollectorBBuffer`` enum (B0–B3).
-                            Defaults to None (hardware default: ``b0::discard``).
-        collector_op: Optional ``CollectorOp`` enum (FILL/USE/LASTUSE/DISCARD).
-                      Defaults to None (hardware default: discard).
-    """
-
-    @dsl_user_op
-    def _do(c_val, da_val, db_val, dv_val, sc_val, *, loc=None, ip=None):
-        ptr6_ty = llvm.PointerType.get(address_space=6)
-        i1_ty = ir.IntegerType.get_signless(1)
-
-        c_ir = _ir(c_val, loc, ip)
-        d_ptr = llvm.inttoptr(ptr6_ty, c_ir, loc=loc, ip=ip)
-        da_ir = _ir(da_val, loc, ip)
-        db_ir = _ir(db_val, loc, ip)
-        dv_ir = _ir(dv_val, loc, ip)
-        sc_ir = _ir(sc_val, loc, ip)
-        enable_d = _arith.trunci(i1_ty, sc_ir, loc=loc, ip=ip)
-
-        _nvvm.tcgen05_mma_ws(
-            mma_kind=_nvvm.Tcgen05MMAKind.TF32,
-            d=d_ptr,
-            a=da_ir,
-            b=db_ir,
-            idesc=dv_ir,
-            enable_input_d=enable_d,
-            collector_b_buffer=collector_b_buffer,
-            collector_op=collector_op,
-            loc=loc,
-            ip=ip,
-        )
-
-    _do(
-        cutlass.Int32(tmem_c),
-        desc_a.desc_i64[0],
-        desc_b.desc_i64[0],
-        cutlass.Int32(desc_val),
-        cutlass.Int32(scale_out),
-    )
-
-
-# ---------------------------------------------------------------------------
-# tcgen05mma_ws_ss_f16  —  weight-stationary, SMEM A, SMEM B, kind::f16
-# ---------------------------------------------------------------------------
+def _ir(value, loc=None, ip=None):
+    """Extract an MLIR value from a CuTeDSL wrapper."""
+    return value.ir_value(loc=loc, ip=ip) if hasattr(value, "ir_value") else value
 
 
 @cute.jit
@@ -668,51 +89,29 @@ def tcgen05mma_ws_ss_f16(
     tmem_c: int,
     desc_val: int,
     scale_out: int,
-    collector_b_buffer=None,
-    collector_op=None,
 ):
-    """Issue ``tcgen05.mma.ws.cta_group::1.kind::f16`` (weight-stationary form).
-
-    Same as the tf32 variant but uses ``.kind::f16`` for half-precision
-    input types (f16 / bf16).  K dimension is 16 instead of 8.
-
-    This variant does NOT take a ``disable-output-lane`` mask; the
-    optional ``zero-column-mask-desc`` operand is omitted.
-
-    Args:
-        desc_a:    64-bit SMEM descriptor for matrix A.
-        desc_b:    64-bit SMEM descriptor for matrix B.
-        tmem_c:    TMEM base address (uint32) for accumulators C/D.
-        desc_val:  High 32 bits of the UMMA instruction descriptor (idescE>>32).
-        scale_out: 1 → accumulate, 0 → overwrite.
-        collector_b_buffer: Optional ``CollectorBBuffer`` enum (B0–B3).
-                            Defaults to None (hardware default: ``b0::discard``).
-        collector_op: Optional ``CollectorOp`` enum (FILL/USE/LASTUSE/DISCARD).
-                      Defaults to None (hardware default: discard).
-    """
+    """Issue weight-stationary kind::f16 MMA with shared-memory operands."""
 
     @dsl_user_op
-    def _do(c_val, da_val, db_val, dv_val, sc_val, *, loc=None, ip=None):
-        ptr6_ty = llvm.PointerType.get(address_space=6)
-        i1_ty = ir.IntegerType.get_signless(1)
-
-        c_ir = _ir(c_val, loc, ip)
-        d_ptr = llvm.inttoptr(ptr6_ty, c_ir, loc=loc, ip=ip)
-        da_ir = _ir(da_val, loc, ip)
-        db_ir = _ir(db_val, loc, ip)
-        dv_ir = _ir(dv_val, loc, ip)
-        sc_ir = _ir(sc_val, loc, ip)
-        enable_d = _arith.trunci(i1_ty, sc_ir, loc=loc, ip=ip)
-
+    def _do(c_value, a_value, b_value, idesc_value, scale_value, *, loc=None, ip=None):
+        pointer_type = llvm.PointerType.get(address_space=6)
+        predicate_type = ir.IntegerType.get_signless(1)
+        destination = llvm.inttoptr(pointer_type, _ir(c_value, loc, ip), loc=loc, ip=ip)
+        enable_d = _arith.trunci(
+            predicate_type,
+            _ir(scale_value, loc, ip),
+            loc=loc,
+            ip=ip,
+        )
         _nvvm.tcgen05_mma_ws(
             mma_kind=_nvvm.Tcgen05MMAKind.F16,
-            d=d_ptr,
-            a=da_ir,
-            b=db_ir,
-            idesc=dv_ir,
+            d=destination,
+            a=_ir(a_value, loc, ip),
+            b=_ir(b_value, loc, ip),
+            idesc=_ir(idesc_value, loc, ip),
             enable_input_d=enable_d,
-            collector_b_buffer=collector_b_buffer,
-            collector_op=collector_op,
+            collector_b_buffer=None,
+            collector_op=None,
             loc=loc,
             ip=ip,
         )
@@ -726,557 +125,17 @@ def tcgen05mma_ws_ss_f16(
     )
 
 
-# ---------------------------------------------------------------------------
-# tcgen05mma_ws_ts_tf32  —  weight-stationary, TMEM A, SMEM B, kind::tf32
-# ---------------------------------------------------------------------------
-
-
-@cute.jit
-def tcgen05mma_ws_ts_tf32(
-    tmem_a: int,
-    desc_b: Tcgen05SmemDescriptor,
-    tmem_c: int,
-    desc_val: int,
-    scale_out: int,
-    collector_b_buffer=None,
-    collector_op=None,
-):
-    """Issue ``tcgen05.mma.ws.cta_group::1.kind::tf32`` with TMEM A (weight-stationary).
-
-    Matrix A is read from TMEM via indirect addressing ``[tmem_a]``.
-    Matrix B is read from SMEM via descriptor.
-    This variant does NOT take a ``disable-output-lane`` mask; the
-    optional ``zero-column-mask-desc`` operand is omitted.
-
-    Args:
-        tmem_a:    TMEM base address (uint32) for matrix A.
-        desc_b:    64-bit SMEM descriptor for matrix B.
-        tmem_c:    TMEM base address (uint32) for accumulators C/D.
-        desc_val:  High 32 bits of the UMMA instruction descriptor (idescE>>32).
-        scale_out: 1 → accumulate, 0 → overwrite.
-        collector_b_buffer: Optional ``CollectorBBuffer`` enum (B0–B3).
-                            Defaults to None (hardware default: ``b0::discard``).
-        collector_op: Optional ``CollectorOp`` enum (FILL/USE/LASTUSE/DISCARD).
-                      Defaults to None (hardware default: discard).
-    """
-
-    @dsl_user_op
-    def _do(c_val, a_val, db_val, dv_val, sc_val, *, loc=None, ip=None):
-        ptr6_ty = llvm.PointerType.get(address_space=6)
-        i1_ty = ir.IntegerType.get_signless(1)
-
-        c_ir = _ir(c_val, loc, ip)
-        d_ptr = llvm.inttoptr(ptr6_ty, c_ir, loc=loc, ip=ip)
-        a_ir = _ir(a_val, loc, ip)
-        a_ptr = llvm.inttoptr(ptr6_ty, a_ir, loc=loc, ip=ip)
-        db_ir = _ir(db_val, loc, ip)
-        dv_ir = _ir(dv_val, loc, ip)
-        sc_ir = _ir(sc_val, loc, ip)
-        enable_d = _arith.trunci(i1_ty, sc_ir, loc=loc, ip=ip)
-
-        _nvvm.tcgen05_mma_ws(
-            mma_kind=_nvvm.Tcgen05MMAKind.TF32,
-            d=d_ptr,
-            a=a_ptr,
-            b=db_ir,
-            idesc=dv_ir,
-            enable_input_d=enable_d,
-            collector_b_buffer=collector_b_buffer,
-            collector_op=collector_op,
-            loc=loc,
-            ip=ip,
-        )
-
-    _do(
-        cutlass.Int32(tmem_c),
-        cutlass.Int32(tmem_a),
-        desc_b.desc_i64[0],
-        cutlass.Int32(desc_val),
-        cutlass.Int32(scale_out),
-    )
-
-
-# ---------------------------------------------------------------------------
-# tcgen05mma_ws_ts_f16  —  weight-stationary, TMEM A, SMEM B, kind::f16
-# ---------------------------------------------------------------------------
-
-
-@cute.jit
-def tcgen05mma_ws_ts_f16(
-    tmem_a: int,
-    desc_b: Tcgen05SmemDescriptor,
-    tmem_c: int,
-    desc_val: int,
-    scale_out: int,
-    collector_b_buffer=None,
-    collector_op=None,
-):
-    """Issue ``tcgen05.mma.ws.cta_group::1.kind::f16`` with TMEM A (weight-stationary).
-
-    Same as the tf32 variant but uses ``.kind::f16`` for half-precision
-    input types (f16 / bf16).  K dimension is 16 instead of 8.
-
-    Matrix A is read from TMEM via indirect addressing ``[tmem_a]``.
-    Matrix B is read from SMEM via descriptor.
-    This variant does NOT take a ``disable-output-lane`` mask; the
-    optional ``zero-column-mask-desc`` operand is omitted.
-
-    Args:
-        tmem_a:    TMEM base address (uint32) for matrix A.
-        desc_b:    64-bit SMEM descriptor for matrix B.
-        tmem_c:    TMEM base address (uint32) for accumulators C/D.
-        desc_val:  High 32 bits of the UMMA instruction descriptor (idescE>>32).
-        scale_out: 1 → accumulate, 0 → overwrite.
-        collector_b_buffer: Optional ``CollectorBBuffer`` enum (B0–B3).
-                            Defaults to None (hardware default: ``b0::discard``).
-        collector_op: Optional ``CollectorOp`` enum (FILL/USE/LASTUSE/DISCARD).
-                      Defaults to None (hardware default: discard).
-    """
-
-    @dsl_user_op
-    def _do(c_val, a_val, db_val, dv_val, sc_val, *, loc=None, ip=None):
-        ptr6_ty = llvm.PointerType.get(address_space=6)
-        i1_ty = ir.IntegerType.get_signless(1)
-
-        c_ir = _ir(c_val, loc, ip)
-        d_ptr = llvm.inttoptr(ptr6_ty, c_ir, loc=loc, ip=ip)
-        a_ir = _ir(a_val, loc, ip)
-        a_ptr = llvm.inttoptr(ptr6_ty, a_ir, loc=loc, ip=ip)
-        db_ir = _ir(db_val, loc, ip)
-        dv_ir = _ir(dv_val, loc, ip)
-        sc_ir = _ir(sc_val, loc, ip)
-        enable_d = _arith.trunci(i1_ty, sc_ir, loc=loc, ip=ip)
-
-        _nvvm.tcgen05_mma_ws(
-            mma_kind=_nvvm.Tcgen05MMAKind.F16,
-            d=d_ptr,
-            a=a_ptr,
-            b=db_ir,
-            idesc=dv_ir,
-            enable_input_d=enable_d,
-            collector_b_buffer=collector_b_buffer,
-            collector_op=collector_op,
-            loc=loc,
-            ip=ip,
-        )
-
-    _do(
-        cutlass.Int32(tmem_c),
-        cutlass.Int32(tmem_a),
-        desc_b.desc_i64[0],
-        cutlass.Int32(desc_val),
-        cutlass.Int32(scale_out),
-    )
-
-
-# ===========================================================================
-# Named convenience wrappers
-# ===========================================================================
-# These call the low-level primitives with pre-set mask constants so callers
-# do not need to repeat the literal values.  Signature: same as the base
-# function but without the mask0-3 args.
-
-# ---------------------------------------------------------------------------
-# SS named wrappers  (SMEM A)
-# ---------------------------------------------------------------------------
-
-
-@cute.jit
-def tcgen05mma_ss_no_mask(
-    desc_a: Tcgen05SmemDescriptor,
-    desc_b: Tcgen05SmemDescriptor,
-    tmem_c: int,
-    desc_val: int,
-    scale_out: int,
-):
-    """SS MMA with no output-lane disable (all rows active)."""
-    tcgen05mma_ss(
-        desc_a,
-        desc_b,
-        tmem_c,
-        desc_val,
-        scale_out,
-        SS_NO_MASK[0],
-        SS_NO_MASK[1],
-        SS_NO_MASK[2],
-        SS_NO_MASK[3],
-    )
-
-
-@cute.jit
-def tcgen05mma_ss_mask0(
-    desc_a: Tcgen05SmemDescriptor,
-    desc_b: Tcgen05SmemDescriptor,
-    tmem_c: int,
-    desc_val: int,
-    scale_out: int,
-):
-    """SS MMA: mask={0, 0xF…, 0, 0xF…} — groups 0,2 active (1,3 disabled)."""
-    tcgen05mma_ss(
-        desc_a,
-        desc_b,
-        tmem_c,
-        desc_val,
-        scale_out,
-        SS_MASK0[0],
-        SS_MASK0[1],
-        SS_MASK0[2],
-        SS_MASK0[3],
-    )
-
-
-@cute.jit
-def tcgen05mma_ss_mask1(
-    desc_a: Tcgen05SmemDescriptor,
-    desc_b: Tcgen05SmemDescriptor,
-    tmem_c: int,
-    desc_val: int,
-    scale_out: int,
-):
-    """SS MMA: mask={0xF…, 0, 0xF…, 0} — groups 1,3 active (0,2 disabled)."""
-    tcgen05mma_ss(
-        desc_a,
-        desc_b,
-        tmem_c,
-        desc_val,
-        scale_out,
-        SS_MASK1[0],
-        SS_MASK1[1],
-        SS_MASK1[2],
-        SS_MASK1[3],
-    )
-
-
-@cute.jit
-def tcgen05mma_ss_mask2(
-    desc_a: Tcgen05SmemDescriptor,
-    desc_b: Tcgen05SmemDescriptor,
-    tmem_c: int,
-    desc_val: int,
-    scale_out: int,
-):
-    """SS MMA: mask={0xF…, 0xF…, 0, 0xF…} — group 2 only active."""
-    tcgen05mma_ss(
-        desc_a,
-        desc_b,
-        tmem_c,
-        desc_val,
-        scale_out,
-        SS_MASK2[0],
-        SS_MASK2[1],
-        SS_MASK2[2],
-        SS_MASK2[3],
-    )
-
-
-@cute.jit
-def tcgen05mma_ss_mask3(
-    desc_a: Tcgen05SmemDescriptor,
-    desc_b: Tcgen05SmemDescriptor,
-    tmem_c: int,
-    desc_val: int,
-    scale_out: int,
-):
-    """SS MMA: mask={0xF…, 0xF…, 0xF…, 0} — group 3 only active."""
-    tcgen05mma_ss(
-        desc_a,
-        desc_b,
-        tmem_c,
-        desc_val,
-        scale_out,
-        SS_MASK3[0],
-        SS_MASK3[1],
-        SS_MASK3[2],
-        SS_MASK3[3],
-    )
-
-
-# ---------------------------------------------------------------------------
-# TS named wrappers  (TMEM A)
-# ---------------------------------------------------------------------------
-
-
-@cute.jit
-def tcgen05mma_ts_no_mask(
-    tmem_a: int,
-    desc_b: Tcgen05SmemDescriptor,
-    tmem_c: int,
-    desc_val: int,
-    scale_out: int,
-):
-    """TS MMA with no output-lane disable (all rows active)."""
-    tcgen05mma_ts(
-        tmem_a,
-        desc_b,
-        tmem_c,
-        desc_val,
-        scale_out,
-        TS_NO_MASK[0],
-        TS_NO_MASK[1],
-        TS_NO_MASK[2],
-        TS_NO_MASK[3],
-    )
-
-
-@cute.jit
-def tcgen05mma_ts_mask0(
-    tmem_a: int,
-    desc_b: Tcgen05SmemDescriptor,
-    tmem_c: int,
-    desc_val: int,
-    scale_out: int,
-):
-    """TS MMA: mask={0, 0xF…, 0xF…, 0xF…} — group 0 only active."""
-    tcgen05mma_ts(
-        tmem_a,
-        desc_b,
-        tmem_c,
-        desc_val,
-        scale_out,
-        TS_MASK0[0],
-        TS_MASK0[1],
-        TS_MASK0[2],
-        TS_MASK0[3],
-    )
-
-
-@cute.jit
-def tcgen05mma_ts_mask1(
-    tmem_a: int,
-    desc_b: Tcgen05SmemDescriptor,
-    tmem_c: int,
-    desc_val: int,
-    scale_out: int,
-):
-    """TS MMA: mask={0xF…, 0, 0xF…, 0xF…} — group 1 only active."""
-    tcgen05mma_ts(
-        tmem_a,
-        desc_b,
-        tmem_c,
-        desc_val,
-        scale_out,
-        TS_MASK1[0],
-        TS_MASK1[1],
-        TS_MASK1[2],
-        TS_MASK1[3],
-    )
-
-
-@cute.jit
-def tcgen05mma_ts_mask2(
-    tmem_a: int,
-    desc_b: Tcgen05SmemDescriptor,
-    tmem_c: int,
-    desc_val: int,
-    scale_out: int,
-):
-    """TS MMA: mask={0xF…, 0xF…, 0, 0xF…} — group 2 only active."""
-    tcgen05mma_ts(
-        tmem_a,
-        desc_b,
-        tmem_c,
-        desc_val,
-        scale_out,
-        TS_MASK2[0],
-        TS_MASK2[1],
-        TS_MASK2[2],
-        TS_MASK2[3],
-    )
-
-
-@cute.jit
-def tcgen05mma_ts_mask3(
-    tmem_a: int,
-    desc_b: Tcgen05SmemDescriptor,
-    tmem_c: int,
-    desc_val: int,
-    scale_out: int,
-):
-    """TS MMA: mask={0xF…, 0xF…, 0xF…, 0} — group 3 only active."""
-    tcgen05mma_ts(
-        tmem_a,
-        desc_b,
-        tmem_c,
-        desc_val,
-        scale_out,
-        TS_MASK3[0],
-        TS_MASK3[1],
-        TS_MASK3[2],
-        TS_MASK3[3],
-    )
-
-
-@cute.jit
-def tcgen05mma_ts_mask02(
-    tmem_a: int,
-    desc_b: Tcgen05SmemDescriptor,
-    tmem_c: int,
-    desc_val: int,
-    scale_out: int,
-):
-    """TS MMA: mask={0, 0xF…, 0, 0xF…} — groups 0,2 active (1,3 disabled).
-
-    Used in the KDA intra-chunk backward kernel for the QK/KG phase where
-    only even row-groups of the M tile contribute to the triangular region.
-    """
-    tcgen05mma_ts(
-        tmem_a,
-        desc_b,
-        tmem_c,
-        desc_val,
-        scale_out,
-        TS_MASK02[0],
-        TS_MASK02[1],
-        TS_MASK02[2],
-        TS_MASK02[3],
-    )
-
-
-@cute.jit
-def tcgen05mma_ts_mask13(
-    tmem_a: int,
-    desc_b: Tcgen05SmemDescriptor,
-    tmem_c: int,
-    desc_val: int,
-    scale_out: int,
-):
-    """TS MMA: mask={0xF…, 0, 0xF…, 0} — groups 1,3 active (0,2 disabled).
-
-    Used in the KDA intra-chunk backward kernel for the QK/KG phase where
-    only odd row-groups of the M tile contribute to the triangular region.
-    """
-    tcgen05mma_ts(
-        tmem_a,
-        desc_b,
-        tmem_c,
-        desc_val,
-        scale_out,
-        TS_MASK13[0],
-        TS_MASK13[1],
-        TS_MASK13[2],
-        TS_MASK13[3],
-    )
-
-
-# ---- intrinsics_sm100.py ----
-# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
-#
-# Adapted from cuLA's SM100 Tensor Memory intrinsic wrappers.
-#
-# Copyright 2025-2026 Ant Group Co., Ltd.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-"""NVVM wrappers for SM100 (Blackwell) Tensor Memory intrinsics.
-
-Provides low-level, CuteDSL-compatible helpers that move data between
-Tensor Memory (TMEM) and registers / shared memory via the native
-``nvvm.tcgen05.*`` MLIR ops.
-
-**T2R / R2T** – ``tcgen05.ld`` / ``tcgen05.st`` with ``.32x32b`` shape.
-**S2T**       – ``tcgen05.cp`` with ``.128x256b`` shape (SMEM → TMEM)
-PTX reference
--------------
-    tcgen05.ld.sync.aligned.32x32b.xN.b32  {r0, ..., rN-1}, [taddr];
-    tcgen05.st.sync.aligned.32x32b.xN.b32  [taddr], {r0, ..., rN-1};
-
-where ``N ∈ {2, 4, 8, 16, 32, 64, 128}`` and each ``r`` is a 32-bit
-register.  ``taddr`` encodes both the TMEM column index (bits [15:0])
-and the lane index (bits [31:16]).
-
-See https://docs.nvidia.com/cuda/parallel-thread-execution/#tcgen05-instructions-tcgen05-ld
-
-Usage inside a ``@cute.kernel`` or ``@cute.jit`` function::
-
-    from this file's inlined SM100 helper wrappers import (
-        tcgen05_ld_32x32b, tcgen05_st_32x32b,
-        reinterpret_cast, subvec, store_256b,
-    )
-    from cutlass.cute.typing import Float32, Int32
-
-    # Load 32 × 32-bit values from TMEM → opaque vector<32 x i32>
-    vec_i32 = tcgen05_ld_32x32b(32, taddr)
-
-    # Zero-cost reinterpret as f32 (single vector.bitcast, no instructions)
-    vec_f32 = reinterpret_cast(vec_i32, Int32, 32, Float32)
-
-    # Store to global via store_256b (4 × 256-bit stores)
-    # store_256b takes vector<8 x i32>, so reinterpret back and slice
-    vec_i32_back = reinterpret_cast(vec_f32, Float32, 32, Int32)
-    for chunk in range(4):  # 32 / 8 = 4 chunks
-        store_256b(gmem_addr + chunk * 32, subvec(vec_i32_back, chunk * 8, 8))
-
-    # Store back to TMEM
-    tcgen05_st_32x32b(32, taddr, vec_i32_back)
-"""
-
-__all__ = [
-    "reinterpret_cast",
-    "store_256b",
-    "subvec",
-    "tcgen05_cp_128x256b",
-    "tcgen05_ld_32x32b",
-    "tcgen05_st_32x32b",
-    "umma_arrive",
-    "umma_arrive_noelect",
-]
-
-from cutlass import cute
-from cutlass._mlir import ir as _ir_mod
-from cutlass._mlir.dialects import (
-    nvvm as _nvvm,
-)
-from cutlass._mlir.dialects import (
-    vector as _vector,
-)
-
-
-def _to_ir(val, loc=None, ip=None):
-    """Extract raw MLIR IR value from a CuteDSL wrapper."""
-    return val.ir_value(loc=loc, ip=ip) if hasattr(val, "ir_value") else val
-
-
-# ---------------------------------------------------------------------------
-# tcgen05.ld.sync.aligned.32x32b.xN.b32  (via nvvm.tcgen05.ld)
-# ---------------------------------------------------------------------------
-
-
 @cute.jit
 def tcgen05_ld_32x32b(num: int, taddr: int):
-    """Load *num* × 32-bit values from TMEM → an opaque ``vector<N x i32>``.
-
-    ``num`` must be a **compile-time constant** in {2, 4, 8, 16, 32, 64, 128}.
-    Returns a single opaque MLIR vector value (``vector<num x i32>``).
-
-    Use :func:`reinterpret_cast` to reinterpret the element type (zero-cost),
-    and :func:`subvec` to slice a contiguous sub-vector.
-
-    Parameters
-    ----------
-    num : int
-        Number of 32-bit registers to load.  Must be a compile-time constant.
-    taddr : int
-        TMEM address (bits [31:16] = lane, bits [15:0] = column).
-    """
+    """Load an opaque vector of 32-bit values from TMEM."""
 
     @dsl_user_op
-    def _do(addr_val, *, loc=None, ip=None):
-        i32_ty = _ir_mod.IntegerType.get_signless(32)
-        ptr6_ty = llvm.PointerType.get(address_space=6)
-        tmem_ptr = llvm.inttoptr(ptr6_ty, _to_ir(addr_val, loc, ip), loc=loc, ip=ip)
-        vec_i32_ty = _ir_mod.VectorType.get([num], i32_ty)
+    def _do(address, *, loc=None, ip=None):
+        pointer_type = llvm.PointerType.get(address_space=6)
+        tmem_ptr = llvm.inttoptr(pointer_type, _ir(address, loc, ip), loc=loc, ip=ip)
+        vector_type = ir.VectorType.get([num], ir.IntegerType.get_signless(32))
         return _nvvm.tcgen05_ld(
-            res=vec_i32_ty,
+            res=vector_type,
             shape=_nvvm.Tcgen05LdStShape.SHAPE_32X32B,
             tmem_addr=tmem_ptr,
             loc=loc,
@@ -1286,123 +145,54 @@ def tcgen05_ld_32x32b(num: int, taddr: int):
     return _do(Int32(taddr))
 
 
-# ---------------------------------------------------------------------------
-# tcgen05.st.sync.aligned.32x32b.xN.b32  (via nvvm.tcgen05.st)
-# ---------------------------------------------------------------------------
-
-
 @cute.jit
-def tcgen05_st_32x32b(num: int, taddr: int, vec):
-    """Store *num* × 32-bit values from an opaque vector → TMEM.
-
-    ``num`` must be a **compile-time constant** in {2, 4, 8, 16, 32, 64, 128}.
-
-    Parameters
-    ----------
-    num : int
-        Number of 32-bit registers to store.  Must be a compile-time constant.
-    taddr : int
-        TMEM address (bits [31:16] = lane, bits [15:0] = column).
-    vec : opaque vector
-        An opaque ``vector<num x i32>`` value (from :func:`tcgen05_ld_32x32b`
-        or :func:`reinterpret_cast`).
-    """
+def tcgen05_st_32x32b(num: int, taddr: int, values):
+    """Store an opaque vector of 32-bit values to TMEM."""
 
     @dsl_user_op
-    def _do(addr_val, vec_val, *, loc=None, ip=None):
-        ptr6_ty = llvm.PointerType.get(address_space=6)
-        tmem_ptr = llvm.inttoptr(ptr6_ty, _to_ir(addr_val, loc, ip), loc=loc, ip=ip)
+    def _do(address, vector, *, loc=None, ip=None):
+        pointer_type = llvm.PointerType.get(address_space=6)
+        tmem_ptr = llvm.inttoptr(pointer_type, _ir(address, loc, ip), loc=loc, ip=ip)
         _nvvm.tcgen05_st(
             shape=_nvvm.Tcgen05LdStShape.SHAPE_32X32B,
             tmem_addr=tmem_ptr,
-            val=_to_ir(vec_val, loc, ip),
+            val=_ir(vector, loc, ip),
             loc=loc,
             ip=ip,
         )
 
-    _do(Int32(taddr), vec)
-
-
-# ---------------------------------------------------------------------------
-# reinterpret_cast  (zero-cost vector.bitcast)
-# ---------------------------------------------------------------------------
+    _do(Int32(taddr), values)
 
 
 @cute.jit
-def reinterpret_cast(vec, src_type, src_num, tgt_type):
-    """Zero-cost reinterpret of a vector's element type (single ``vector.bitcast``).
-
-    Analogous to C++ ``reinterpret_cast``: no instructions emitted, just
-    re-labels the bits.  The total bit-width is preserved:
-    ``src_num * src_type.width == tgt_num * tgt_type.width``.
-
-    Parameters
-    ----------
-    vec : opaque vector
-        Source vector (e.g. ``vector<N x i32>`` from :func:`tcgen05_ld_32x32b`).
-    src_type : CuTeDSL type
-        Element type of *vec* (e.g. ``Int32``).
-    src_num : int
-        Number of elements in *vec* (compile-time constant).
-    tgt_type : CuTeDSL type
-        Desired element type (e.g. ``Float32``, ``BFloat16``, ``Float16``).
-
-    Returns
-    -------
-    opaque vector
-        ``vector<M x tgt_type>`` where ``M = src_num * src_type.width // tgt_type.width``.
-
-    Examples
-    --------
-    ::
-
-        vec_i32  = tcgen05_ld_32x32b(8, taddr)                     # vector<8 x i32>
-        vec_f32  = reinterpret_cast(vec_i32, Int32, 8, Float32)    # vector<8 x f32>
-        vec_bf16 = reinterpret_cast(vec_i32, Int32, 8, BFloat16)   # vector<16 x bf16>
-        vec_back = reinterpret_cast(vec_bf16, BFloat16, 16, Int32) # vector<8 x i32>
-    """
-    tgt_num = src_num * src_type.width // tgt_type.width
+def reinterpret_cast(values, source_type, source_count, target_type):
+    """Bitcast an opaque vector while preserving its total width."""
+    target_count = source_count * source_type.width // target_type.width
 
     @dsl_user_op
-    def _do(v, *, loc=None, ip=None):
-        tgt_vec_ty = _ir_mod.VectorType.get([tgt_num], tgt_type.mlir_type)
-        return _vector.bitcast(tgt_vec_ty, _to_ir(v, loc, ip), loc=loc, ip=ip)
+    def _do(vector, *, loc=None, ip=None):
+        target_vector_type = ir.VectorType.get([target_count], target_type.mlir_type)
+        return _vector.bitcast(
+            target_vector_type,
+            _ir(vector, loc, ip),
+            loc=loc,
+            ip=ip,
+        )
 
-    return _do(vec)
-
-
-# ---------------------------------------------------------------------------
-# subvec  (extract a contiguous sub-vector)
-# ---------------------------------------------------------------------------
+    return _do(values)
 
 
 @cute.jit
-def subvec(vec, offset, size):
-    """Extract a contiguous sub-vector (``vector.extract_strided_slice``).
-
-    Parameters
-    ----------
-    vec : opaque vector
-        Source vector.
-    offset : int
-        Starting element index (compile-time constant).
-    size : int
-        Number of elements to extract (compile-time constant).
-
-    Returns
-    -------
-    opaque vector
-        ``vector<size x elem_type>``.
-    """
+def subvec(values, offset, size):
+    """Extract a contiguous compile-time slice from an opaque vector."""
 
     @dsl_user_op
-    def _do(v, *, loc=None, ip=None):
-        ir_v = _to_ir(v, loc, ip)
-        elem_ty = _ir_mod.VectorType(ir_v.type).element_type
-        res_ty = _ir_mod.VectorType.get([size], elem_ty)
+    def _do(vector, *, loc=None, ip=None):
+        ir_vector = _ir(vector, loc, ip)
+        result_type = ir.VectorType.get([size], ir.VectorType(ir_vector.type).element_type)
         return _vector.extract_strided_slice(
-            res_ty,
-            ir_v,
+            result_type,
+            ir_vector,
             offsets=[offset],
             sizes=[size],
             strides=[1],
@@ -1410,142 +200,44 @@ def subvec(vec, offset, size):
             ip=ip,
         )
 
-    return _do(vec)
-
-
-# ---------------------------------------------------------------------------
-# st.global.L1::no_allocate.v8.f32  (256-bit direct R2G store)
-# ---------------------------------------------------------------------------
-
-_STORE_256B_ASM = "st.global.L1::no_allocate.v8.f32 [$0], {$1, $2, $3, $4, $5, $6, $7, $8};"
-_STORE_256B_CONSTRAINTS = "l,r,r,r,r,r,r,r,r"
+    return _do(values)
 
 
 @cute.jit
-def store_256b(gmem_ptr, vec):
-    """Store 256 bits (8 × 32-bit) to global memory, bypassing L1 allocation.
-
-    Issues ``st.global.L1::no_allocate.v8.f32`` with ``"r"`` (integer register)
-    constraints — type-agnostic, just like C++ ``reinterpret_cast<uint32_t*>``.
-
-    Parameters
-    ----------
-    gmem_ptr : pointer
-        Global-memory destination address (must be 32-byte aligned).
-    vec : opaque vector
-        A ``vector<8 x i32>`` (use :func:`subvec` to slice from a larger vector).
-    """
-
-    @dsl_user_op
-    def _do(addr, v, *, loc=None, ip=None):
-        i32_ty = _ir_mod.IntegerType.get_signless(32)
-        ir_v = _to_ir(v, loc, ip)
-        elems = [
-            llvm.extractelement(
-                ir_v,
-                position=_arith.constant(i32_ty, i, loc=loc, ip=ip),
-                loc=loc,
-                ip=ip,
-            )
-            for i in range(8)
-        ]
-        operands = [_to_ir(addr, loc, ip)] + elems
-        llvm.inline_asm(
-            _ir_mod.Type.parse("!llvm.void"),
-            operands,
-            _STORE_256B_ASM,
-            _STORE_256B_CONSTRAINTS,
-            has_side_effects=True,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
-            loc=loc,
-            ip=ip,
-        )
-
-    _do(gmem_ptr, vec)
-
-
-# ---------------------------------------------------------------------------
-# tcgen05.cp.cta_group::1.128x256b  (via nvvm.tcgen05.cp)
-# ---------------------------------------------------------------------------
-
-
-@cute.jit
-def tcgen05_cp_128x256b(taddr: int, smem_desc: Tcgen05SmemDescriptor):
-    """Async copy SMEM → TMEM with shape ``128x256b`` (``cta_group::1``).
-
-    Issues ``tcgen05.cp.cta_group::1.128x256b  [taddr], s-desc;``
-    via the native ``nvvm.tcgen05.cp`` MLIR op.
-
-    The instruction copies a 128-row × 256-bit tile from shared memory
-    (described by *smem_desc*) into Tensor Memory at *taddr*.  The copy
-    is **asynchronous** — use ``tcgen05.commit`` + ``mbarrier.wait`` to
-    synchronize.
-
-    PTX reference
-    -------------
-        tcgen05.cp.cta_group::1.128x256b  [taddr], s-desc;
-
-    Parameters
-    ----------
-    taddr : int
-        TMEM destination address (uint32, passed as ``!llvm.ptr<6>``).
-    smem_desc : Tcgen05SmemDescriptor
-        64-bit SMEM matrix descriptor (same format as ``tcgen05.mma``
-        descriptors — see ``Tcgen05SmemDescriptor``).
-    """
-
-    @dsl_user_op
-    def _do(addr_val, desc_val, *, loc=None, ip=None):
-        ptr6_ty = llvm.PointerType.get(address_space=6)
-        tmem_ptr = llvm.inttoptr(ptr6_ty, _to_ir(addr_val, loc, ip), loc=loc, ip=ip)
-        _nvvm.tcgen05_cp(
-            shape=_nvvm.Tcgen05CpShape.SHAPE_128x256b,
-            taddr=tmem_ptr,
-            smem_desc=_to_ir(desc_val, loc, ip),
-            cta_group=_nvvm.Tcgen05GroupKind.CTA_1,
-            loc=loc,
-            ip=ip,
-        )
-
-    _do(Int32(taddr), smem_desc.desc_i64[0])
+def store_256b(gmem_addr, values):
+    """Store ``vector<8 x i32>`` to global memory without allocating in L1."""
+    gmem_ptr = cute.make_ptr(
+        Int32,
+        gmem_addr,
+        cute.AddressSpace.gmem,
+        assumed_align=32,
+    )
+    cute.arch.store(gmem_ptr, values, level1_eviction_priority="evict_no_allocate")
 
 
 @cute.jit
 def tcgen05_fence_before():
-    """tcgen05.fence::before_thread_sync — non-blocking ordering fence."""
+    """Order prior TMEM accesses before thread synchronization."""
     _nvvm.tcgen05_fence(kind=_nvvm.Tcgen05FenceKind.BEFORE_THREAD_SYNC)
 
 
 @cute.jit
 def tcgen05_fence_after():
-    """tcgen05.fence::after_thread_sync — non-blocking ordering fence."""
+    """Order subsequent TMEM accesses after thread synchronization."""
     _nvvm.tcgen05_fence(kind=_nvvm.Tcgen05FenceKind.AFTER_THREAD_SYNC)
 
 
 @cute.jit
 def umma_arrive(mbar_ptr: cute.Pointer):
-    """tcgen05.commit.cta_group::1.mbarrier::arrive::one — signal MMA done."""
+    """Signal completion of one warp-group MMA sequence."""
     with elect_one():
         tcgen05.commit(mbar_ptr, cta_group=tcgen05.CtaGroup.ONE)
 
 
-@cute.jit
-def umma_arrive_noelect(mbar_ptr: cute.Pointer):
-    """tcgen05.commit.cta_group::1.mbarrier::arrive::one — signal MMA done."""
-    tcgen05.commit(mbar_ptr, cta_group=tcgen05.CtaGroup.ONE)
-
-
-PRINT_DEBUG = False
-
-
-COMPILE_OPTIONS = "--enable-tvm-ffi"
-USE_FAST_MATH: bool = os.getenv("MSLK_USE_FAST_MATH", "1") == "1"
-
-# Mapping from torch dtype to cutlass dtype (for beta_dtype conversion)
+# Mapping from torch dtypes to CuTeDSL scalar types.
 _torch_to_cutlass_dtype = {
     torch.bfloat16: cutlass.BFloat16,
-    torch.float32: cutlass.Float32,
+    torch.float16: cutlass.Float16,
 }
 
 
@@ -1582,75 +274,55 @@ def _resolve_chunk_route(
 
 
 # ── TMEM column offset constants (cta_group::1, M=64, .ws Layout E) ──
-TMEM_DA_ACC_OFF = 0  # [0,32)   32 cols  dA fp32 acc; Phase 3: [0,16) overwritten by dA_bf16
-TMEM_DQ_ACC_OFF = 32  # [32,96)  64 cols  dq fp32 acc; Phase 3: step2/step3 result [32,64)
-TMEM_DK_ACC_OFF = 96  # [96,160) 64 cols  dk fp32 acc
+TMEM_DA_ACC_OFF = 0  # [0,32)   32 cols dA fp32 acc; Phase 3 overwrites [0,16)
+TMEM_DQ_ACC_OFF = 32  # [32,96)  64 cols dq fp32 acc; Phase 3 result uses [32,64)
+TMEM_DK_ACC_OFF = 96  # [96,160) 64 cols dk fp32 acc
 TMEM_DW_ACC_OFF = 160  # [160,224] 64 cols dw fp32 acc
-TMEM_FLEX_OFF = 224  # [224,256) 32 cols  dvb time-shared
-TMEM_A_BF16_OFF = 256  # [256,272) 16 cols  A_bf16 TS opA (persistent) (not used currently)
-TMEM_DKGB_ACC_OFF = 272  # [272,336) 64 cols, dkgb fp32 acc
-TMEM_DA2_ACC_OFF = 336  # [336,368) 32 cols  dA fp32 acc, used for dA=dA@A and dA=A@dA
-TMEM_DQ_SCALED_OFF = 368  # [368,432) 64 cols  dq_scaled (stored for dg)
+TMEM_FLEX_OFF = 224  # [224,256) 32 cols dvb time-shared
+TMEM_DKGB_ACC_OFF = 272  # [272,336) 64 cols dkgb fp32 acc
+TMEM_DA2_ACC_OFF = 336  # [336,368) 32 cols dA fp32 acc for dA@A and A@dA
+TMEM_DQ_SCALED_OFF = 368  # [368,432) 64 cols dq_scaled (stored for dg)
 TMEM_TOTAL = 512
 
-# Instruction descriptor for M=64, N=64, BF16, dense, TransposeB=1
-# Bits: M>>4=4 at [24:28], N>>3=8 at [17:22], TransposeB at [16],
-#       btype=bf16(1) at [10:12], atype=bf16(1) at [7:9], dtype=f32(1) at [4:5]
-IDESC_F16_M64_N64_K_MN = (4 << 24) | (8 << 17) | (1 << 16) | (1 << 10) | (1 << 7) | (1 << 4)
+# tcgen05 kind::f16 uses type value 0 for FP16 and 1 for BF16 in both operand fields.
+IDESC_F16_INPUT_TYPE_MASK = (1 << 10) | (1 << 7)
+IDESC_F16_M64_N128_K_K = (4 << 24) | (16 << 17) | (1 << 4)
+IDESC_F16_M64_N128_MN_MN = (4 << 24) | (16 << 17) | (1 << 16) | (1 << 15) | (1 << 4)
+IDESC_F16_M64_N64_MN_MN = (4 << 24) | (8 << 17) | (1 << 16) | (1 << 15) | (1 << 4)
+IDESC_F16_M64_N64_K_K = (4 << 24) | (8 << 17) | (1 << 4)
 
-# Instruction descriptor for M=64, N=128, BF16, dense, TransposeB=1
-# Bits: M>>4=4 at [24:28], N>>3=16 at [17:22], TransposeB at [16],
-#       btype=bf16(1) at [10:12], atype=bf16(1) at [7:9], dtype=f32(1) at [4:5]
-IDESC_F16_M64_N128_K_MN = (4 << 24) | (16 << 17) | (1 << 16) | (1 << 10) | (1 << 7) | (1 << 4)
+ELEM_BYTES_F16 = Float16.width // 8
 
-# Instruction descriptor for M=64, N=128, BF16, dense
-# Bits: M>>4=4 at [24:28], N>>3=16 at [17:22],
-#       btype=bf16(1) at [10:12], atype=bf16(1) at [7:9], dtype=f32(1) at [4:5]
-IDESC_F16_M64_N128_K_K = (4 << 24) | (16 << 17) | (1 << 10) | (1 << 7) | (1 << 4)
 
-# Instruction descriptor for M=64, N=128, BF16, dense, TransposeA=1, TransposeB=1
-# Bits: M>>4=4 at [24:28], N>>3=16 at [17:22],
-#       TransposeB at [16], TransposeA at [15],
-#       btype=bf16(1) at [10:12], atype=bf16(1) at [7:9], dtype=f32(1) at [4:5]
-IDESC_F16_M64_N128_MN_MN = (
-    (4 << 24) | (16 << 17) | (1 << 16) | (1 << 15) | (1 << 10) | (1 << 7) | (1 << 4)
-)
-
-# Instruction descriptor for M=64, N=64, BF16, dense, TransposeA=1, TransposeB=1
-# Bits: M>>4=4 at [24:28], N>>3=8 at [17:22],
-#       TransposeB at [16], TransposeA at [15],
-#       btype=bf16(1) at [10:12], atype=bf16(1) at [7:9], dtype=f32(1) at [4:5]
-IDESC_F16_M64_N64_MN_MN = (
-    (4 << 24) | (8 << 17) | (1 << 16) | (1 << 15) | (1 << 10) | (1 << 7) | (1 << 4)
-)
-
-# Instruction descriptor for M=64, N=64, BF16, dense
-# Bits: M>>4=4 at [24:28], N>>3=8 at [17:22],
-#       TransposeB at [16], TransposeA at [15],
-#       btype=bf16(1) at [10:12], atype=bf16(1) at [7:9], dtype=f32(1) at [4:5]
-IDESC_F16_M64_N64_K_K = (4 << 24) | (8 << 17) | (1 << 10) | (1 << 7) | (1 << 4)
-
-ELEM_BYTES_BF16 = BFloat16.width // 8
+def instruction_descriptor_for_io_dtype(base: int, io_dtype: type[cutlass.Numeric]) -> int:
+    """Set the tcgen05 operand type fields while preserving the descriptor shape bits."""
+    if io_dtype is BFloat16:
+        return base | IDESC_F16_INPUT_TYPE_MASK
+    if io_dtype is Float16:
+        return base
+    raise ValueError(f"unsupported tcgen05 kind::f16 I/O dtype: {io_dtype}")
 
 
 @cute.jit
-def smem_load_bf16x8_sw128(raw_ptr: cute.Pointer, row: Int32, col_base: Int32):
+def smem_load_f16x8_sw128(
+    raw_ptr: cute.Pointer, row: Int32, col_base: Int32, io_dtype: type[cutlass.Numeric]
+):
     """
-    Load 8 consecutive bfloat16 from SMEM with Swizzle<3,4,3> layout.
-    raw_ptr: BFloat16 SMEM base pointer (NOT recast_ptr — raw buffer start)
+    Load 8 consecutive 16-bit values from SMEM with Swizzle<3,4,3> layout.
+    raw_ptr: selected I/O dtype SMEM base pointer (NOT recast_ptr — raw buffer start)
     row: row index in [0, T_TILE=64)
     col_base: 8-aligned column index in [0, K_TILE=128)
     Logical layout: [BT=64, BV=128] K-major, with the BV=128 dim split into
     two halves of 64 elements (high half offset by 4096 elements).
-    Swizzle<3,4,3> on bf16: phys_elem = elem ^ ((row & 7) << 3) within a half.
-    Returns an 8-element rmem fragment (bf16).
+    Swizzle<3,4,3> on 16-bit elements: phys_elem = elem ^ ((row & 7) << 3) within a half.
+    Returns an 8-element rmem fragment in the selected I/O dtype.
     """
     half = col_base >> Int32(6)
     k_inner = col_base & Int32(63)
     swizzled = k_inner ^ ((row & Int32(7)) << Int32(3))
     elem_off = half * Int32(4096) + row * Int32(64) + swizzled
     aligned_ptr = cute.make_ptr(
-        BFloat16,
+        io_dtype,
         (raw_ptr + elem_off).toint(),
         cute.AddressSpace.smem,
         assumed_align=16,
@@ -1662,13 +334,19 @@ def smem_load_bf16x8_sw128(raw_ptr: cute.Pointer, row: Int32, col_base: Int32):
 
 
 @cute.jit
-def smem_store_bf16x8_sw128(raw_ptr: cute.Pointer, row: Int32, col_base: Int32, data: cute.Tensor):
+def smem_store_f16x8_sw128(
+    raw_ptr: cute.Pointer,
+    row: Int32,
+    col_base: Int32,
+    data: cute.Tensor,
+    io_dtype: type[cutlass.Numeric],
+):
     """
-    Store 8 consecutive bfloat16 to SMEM with Swizzle<3,4,3> layout.
-    raw_ptr: BFloat16 SMEM base pointer (NOT recast_ptr — raw buffer start)
+    Store 8 consecutive 16-bit values to SMEM with Swizzle<3,4,3> layout.
+    raw_ptr: selected I/O dtype SMEM base pointer (NOT recast_ptr — raw buffer start)
     row: row index in [0, T_TILE=64)
     col_base: 8-aligned column index in [0, K_TILE=128)
-    data: 8-element rmem fragment (bf16) to store.
+    data: 8-element rmem fragment in the selected I/O dtype to store.
 
     NOTE: For the K-major→MN-major dv re-swizzle, source layout
     `(BT,BV) K-major Swizzle<3,4,3>` and destination layout
@@ -1682,7 +360,7 @@ def smem_store_bf16x8_sw128(raw_ptr: cute.Pointer, row: Int32, col_base: Int32, 
     swizzled = k_inner ^ ((row & Int32(7)) << Int32(3))
     elem_off = half * Int32(4096) + row * Int32(64) + swizzled
     smem_ptr = cute.make_ptr(
-        BFloat16,
+        io_dtype,
         (raw_ptr + elem_off).toint(),
         cute.AddressSpace.smem,
         assumed_align=16,
@@ -1752,94 +430,31 @@ def smem_store_f32x4_sw128(raw_ptr: cute.Pointer, row: Int32, col_base: Int32, d
 
 
 @cute.jit
-def mma_ws_ss_m64n128_k_k_call(
+def mma_ws_ss_call(
     a_smem_layout: cute.Layout,
     desc_a_base: Tcgen05SmemDescriptor,
     b_smem_layout: cute.Layout,
     desc_b_base: Tcgen05SmemDescriptor,
     tmem_c: Int32,
     K: Int32,
+    instruction_descriptor: int,
     is_accum: bool = False,
 ):
+    """Issue one weight-stationary MMA sequence over the descriptor K tiles."""
     with elect_one():
         a_outer = a_smem_layout.outer
         b_outer = b_smem_layout.outer
-        scale = 0 if not is_accum else 1
+        scale = 1 if is_accum else 0
         for ks in cutlass.range_constexpr(K // 16):
-            a_off = cute.crd2idx(((0, 0), 0, ks, 0), a_outer) * ELEM_BYTES_BF16
-            b_off = cute.crd2idx(((0, 0), 0, ks, 0), b_outer) * ELEM_BYTES_BF16
-            desc_a = desc_a_base + a_off
-            desc_b = desc_b_base + b_off
-            tcgen05mma_ws_ss_f16(desc_a, desc_b, tmem_c, IDESC_F16_M64_N128_K_K, scale)
-            scale = 1
-
-
-@cute.jit
-def mma_ws_ss_m64n128_mn_mn_call(
-    a_smem_layout: cute.Layout,
-    desc_a_base: Tcgen05SmemDescriptor,
-    b_smem_layout: cute.Layout,
-    desc_b_base: Tcgen05SmemDescriptor,
-    tmem_c: Int32,
-    K: Int32,
-    is_accum: bool = False,
-):
-    with elect_one():
-        a_outer = a_smem_layout.outer
-        b_outer = b_smem_layout.outer
-        scale = 0 if not is_accum else 1
-        for ks in cutlass.range_constexpr(K // 16):
-            a_off = cute.crd2idx(((0, 0), 0, ks, 0), a_outer) * ELEM_BYTES_BF16
-            b_off = cute.crd2idx(((0, 0), 0, ks, 0), b_outer) * ELEM_BYTES_BF16
-            desc_a = desc_a_base + a_off
-            desc_b = desc_b_base + b_off
-            tcgen05mma_ws_ss_f16(desc_a, desc_b, tmem_c, IDESC_F16_M64_N128_MN_MN, scale)
-            scale = 1
-
-
-@cute.jit
-def mma_ws_ss_m64n64_k_k_call(
-    a_smem_layout: cute.Layout,
-    desc_a_base: Tcgen05SmemDescriptor,
-    b_smem_layout: cute.Layout,
-    desc_b_base: Tcgen05SmemDescriptor,
-    tmem_c: Int32,
-    K: Int32,
-    is_accum: bool = False,
-):
-    with elect_one():
-        a_outer = a_smem_layout.outer
-        b_outer = b_smem_layout.outer
-        scale = 0 if not is_accum else 1
-        for ks in cutlass.range_constexpr(K // 16):
-            a_off = cute.crd2idx(((0, 0), 0, ks, 0), a_outer) * ELEM_BYTES_BF16
-            b_off = cute.crd2idx(((0, 0), 0, ks, 0), b_outer) * ELEM_BYTES_BF16
-            desc_a = desc_a_base + a_off
-            desc_b = desc_b_base + b_off
-            tcgen05mma_ws_ss_f16(desc_a, desc_b, tmem_c, IDESC_F16_M64_N64_K_K, scale)
-            scale = 1
-
-
-@cute.jit
-def mma_ws_ss_m64n64_mn_mn_call(
-    a_smem_layout: cute.Layout,
-    desc_a_base: Tcgen05SmemDescriptor,
-    b_smem_layout: cute.Layout,
-    desc_b_base: Tcgen05SmemDescriptor,
-    tmem_c: Int32,
-    K: Int32,
-    is_accum: bool = False,
-):
-    with elect_one():
-        a_outer = a_smem_layout.outer
-        b_outer = b_smem_layout.outer
-        scale = 0 if not is_accum else 1
-        for ks in cutlass.range_constexpr(K // 16):
-            a_off = cute.crd2idx(((0, 0), 0, ks, 0), a_outer) * ELEM_BYTES_BF16
-            b_off = cute.crd2idx(((0, 0), 0, ks, 0), b_outer) * ELEM_BYTES_BF16
-            desc_a = desc_a_base + a_off
-            desc_b = desc_b_base + b_off
-            tcgen05mma_ws_ss_f16(desc_a, desc_b, tmem_c, IDESC_F16_M64_N64_MN_MN, scale)
+            a_offset = cute.crd2idx(((0, 0), 0, ks, 0), a_outer) * ELEM_BYTES_F16
+            b_offset = cute.crd2idx(((0, 0), 0, ks, 0), b_outer) * ELEM_BYTES_F16
+            tcgen05mma_ws_ss_f16(
+                desc_a_base + a_offset,
+                desc_b_base + b_offset,
+                tmem_c,
+                instruction_descriptor,
+                scale,
+            )
             scale = 1
 
 
@@ -1861,7 +476,6 @@ class ChunkKdaBwdWyDqkgFused:
         acc_dtype: type[cutlass.Numeric] = cutlass.Float32,
         io_dtype: type[cutlass.Numeric] = cutlass.BFloat16,
         g_dtype: type[cutlass.Numeric] = cutlass.Float32,
-        beta_dtype: type[cutlass.Numeric] = cutlass.Float32,
         scale: float = 1.0,
         grid_waves: int = 1,
         use_fast_math: bool = True,
@@ -1881,8 +495,19 @@ class ChunkKdaBwdWyDqkgFused:
         self.acc_dtype = acc_dtype
         self.io_dtype = io_dtype
         self.g_dtype = g_dtype
-        self.beta_dtype = beta_dtype
         self.scale = scale
+        self.idesc_m64n128_k_k = instruction_descriptor_for_io_dtype(
+            IDESC_F16_M64_N128_K_K, io_dtype
+        )
+        self.idesc_m64n128_mn_mn = instruction_descriptor_for_io_dtype(
+            IDESC_F16_M64_N128_MN_MN, io_dtype
+        )
+        self.idesc_m64n64_k_k = instruction_descriptor_for_io_dtype(
+            IDESC_F16_M64_N64_K_K, io_dtype
+        )
+        self.idesc_m64n64_mn_mn = instruction_descriptor_for_io_dtype(
+            IDESC_F16_M64_N64_MN_MN, io_dtype
+        )
 
         # Tile sizes
         self.BT = chunk_size  # 64
@@ -1980,21 +605,21 @@ class ChunkKdaBwdWyDqkgFused:
     def __call__(
         self,
         # ── Inputs ──
-        q_in: cute.Tensor,  # [B, T, H, K] bf16
-        k_in: cute.Tensor,  # [B, T, H, K] bf16
-        v_in: cute.Tensor,  # [B, T, HV, V] bf16
-        v_new_in: cute.Tensor,  # [B, T, HV, V] bf16
+        q_in: cute.Tensor,  # [B, T, H, K] io_dtype
+        k_in: cute.Tensor,  # [B, T, H, K] io_dtype
+        v_in: cute.Tensor,  # [B, T, HV, V] io_dtype
+        v_new_in: cute.Tensor,  # [B, T, HV, V] io_dtype
         g_in: cute.Tensor,  # [B, T, HV, K] fp32
         beta_in: cute.Tensor,  # [B, T, HV]   fp32
-        A_in: cute.Tensor,  # [B, T, HV, BT] bf16
-        h_in: cute.Tensor,  # [B, NT, HV, K, V] bf16
-        do_in: cute.Tensor,  # [B, T, HV, V] bf16
-        dh_in: cute.Tensor,  # [B, NT, HV, K, V] bf16
-        dv_in: cute.Tensor,  # [B, T, HV, V] bf16
+        A_in: cute.Tensor,  # [B, T, HV, BT] io_dtype
+        h_in: cute.Tensor,  # [B, NT, HV, K, V] io_dtype
+        do_in: cute.Tensor,  # [B, T, HV, V] io_dtype
+        dh_in: cute.Tensor,  # [B, NT, HV, K, V] io_dtype
+        dv_in: cute.Tensor,  # [B, T, HV, V] io_dtype
         # ── Outputs ──
         dq_in: cute.Tensor,  # [B, T, HV, K] fp32
         dk_in: cute.Tensor,  # [B, T, HV, K] fp32
-        dv2_in: cute.Tensor,  # [B, T, HV, V] bf16
+        dv2_in: cute.Tensor,  # [B, T, HV, V] io_dtype
         dg_in: cute.Tensor,  # [B, T, HV, K] fp32
         db_in: cute.Tensor,  # [B, T, HV]    fp32
         dA_in: cute.Tensor,  # [B, T, HV, BT] fp32
@@ -2072,7 +697,7 @@ class ChunkKdaBwdWyDqkgFused:
         )
         beta = cute.make_tensor(beta_ptr, beta_layout)
 
-        # A: (T, BT, (HV, data_B)) bf16
+        # A: (T, BT, (HV, data_B)) io_dtype
         # NOTE: for A as operand A, A is loaded as transposed view to do MMA
         a_t_layout = cute.make_layout(
             (BT, T, (HV, data_B)),
@@ -3312,8 +1937,12 @@ class ChunkKdaBwdWyDqkgFused:
                     if wg_idx == 0:
                         for i in cutlass.range_constexpr(self.BV // 8):
                             col = i * 8
-                            h_vals = smem_load_bf16x8_sw128(sH_raw_ptr, local_tidx, col)
-                            dh_vals = smem_load_bf16x8_sw128(sDh_raw_ptr, local_tidx, col)
+                            h_vals = smem_load_f16x8_sw128(
+                                sH_raw_ptr, local_tidx, col, self.io_dtype
+                            )
+                            dh_vals = smem_load_f16x8_sw128(
+                                sDh_raw_ptr, local_tidx, col, self.io_dtype
+                            )
                             h_dh_vals = cute.make_rmem_tensor((8,), Float32)
                             h_dh_vals.store(h_vals.load().to(Float32) * dh_vals.load().to(Float32))
                             for j in cutlass.range_constexpr(8):
@@ -3338,7 +1967,7 @@ class ChunkKdaBwdWyDqkgFused:
 
                     # db += sum(dvb * v, axis=1)
                     mbarrier_wait(bar_tma_v_ptr + vloop_stage_idx, vloop_phase)
-                    rV_bf16 = cute.make_rmem_tensor((bv_num_cols_per_wg,), self.io_dtype)
+                    rV_io = cute.make_rmem_tensor((bv_num_cols_per_wg,), self.io_dtype)
                     sV_raw_ptr_cur = cute.make_ptr(
                         self.io_dtype,
                         sV_ptr_base + vloop_stage_idx * v_opB_bytes_per_stage,
@@ -3347,19 +1976,21 @@ class ChunkKdaBwdWyDqkgFused:
                     if row < sub_seq_len:
                         for i in cutlass.range_constexpr(bv_num_cols_per_wg // 8):
                             col_base = bv_col_base + i * 8
-                            vals = smem_load_bf16x8_sw128(sV_raw_ptr_cur, row, col_base)
-                            rV_bf16[i * 8 + 0] = vals[0]
-                            rV_bf16[i * 8 + 1] = vals[1]
-                            rV_bf16[i * 8 + 2] = vals[2]
-                            rV_bf16[i * 8 + 3] = vals[3]
-                            rV_bf16[i * 8 + 4] = vals[4]
-                            rV_bf16[i * 8 + 5] = vals[5]
-                            rV_bf16[i * 8 + 6] = vals[6]
-                            rV_bf16[i * 8 + 7] = vals[7]
+                            vals = smem_load_f16x8_sw128(
+                                sV_raw_ptr_cur, row, col_base, self.io_dtype
+                            )
+                            rV_io[i * 8 + 0] = vals[0]
+                            rV_io[i * 8 + 1] = vals[1]
+                            rV_io[i * 8 + 2] = vals[2]
+                            rV_io[i * 8 + 3] = vals[3]
+                            rV_io[i * 8 + 4] = vals[4]
+                            rV_io[i * 8 + 5] = vals[5]
+                            rV_io[i * 8 + 6] = vals[6]
+                            rV_io[i * 8 + 7] = vals[7]
                     else:
-                        rV_bf16.fill(BFloat16(0.0))
+                        rV_io.fill(self.io_dtype(0.0))
                     rV_fp32 = cute.make_rmem_tensor((bv_num_cols_per_wg,), Float32)
-                    rV_fp32.store(rV_bf16.load().to(Float32))
+                    rV_fp32.store(rV_io.load().to(Float32))
                     rV_fp32.store(rV_fp32.load() * dvb_f32_val)
                     if row < sub_seq_len:
                         for i in cutlass.range_constexpr(bv_num_cols_per_wg):
@@ -3367,19 +1998,19 @@ class ChunkKdaBwdWyDqkgFused:
 
                     mbarrier_arrive(bar_mma_cuda_v_ptr + vloop_stage_idx)
 
-                    # ── dv2 epilogue: dv2 = dvb * beta, cast to bf16, store to gmem ──
+                    # ── dv2 epilogue: dv2 = dvb * beta, cast to the I/O dtype, store to gmem ──
                     dvb_f32_rmem = cute.make_rmem_tensor((bv_num_cols_per_wg,), Float32)
                     dvb_f32_rmem.store(dvb_f32_val * beta_val)
 
-                    dvb_bf16_rmem = cute.make_rmem_tensor((bv_num_cols_per_wg,), self.io_dtype)
-                    dvb_bf16_rmem.store(dvb_f32_rmem.load().to(self.io_dtype))
+                    dvb_io_rmem = cute.make_rmem_tensor((bv_num_cols_per_wg,), self.io_dtype)
+                    dvb_io_rmem.store(dvb_f32_rmem.load().to(self.io_dtype))
 
-                    # bf16 vector → i32 vector for store_256b (8 i32 = 16 bf16 = 32 bytes per store).
-                    dvb_bf16_val = dvb_bf16_rmem.load()
+                    # 16-bit I/O vector → i32 vector for store_256b (8 i32 = 16 I/O values = 32 bytes per store).
+                    dvb_io_val = dvb_io_rmem.load()
                     dvb_i32_vec = reinterpret_cast(
-                        dvb_bf16_val, self.io_dtype, bv_num_cols_per_wg, Int32
+                        dvb_io_val, self.io_dtype, bv_num_cols_per_wg, Int32
                     )
-                    # bv_num_cols bf16 = bv_num_cols // 16 stores of 256b each.
+                    # bv_num_cols I/O values = bv_num_cols // 16 stores of 256b each.
                     num_stores_per_row = bv_num_cols_per_wg // 16  # = 4 for BV=128
 
                     base_addr = (
@@ -3467,23 +2098,23 @@ class ChunkKdaBwdWyDqkgFused:
                 pipeline_mma_dw.consumer_release(mma_dw_consumer_state)
                 mma_dw_consumer_state.advance()
 
-                # dw = -dw, convert to bf16, write to smem
+                # dw = -dw, convert to the I/O dtype, write to smem
                 dw_f32 = reinterpret_cast(dw_i32, Int32, bk_num_cols_per_wg, Float32)
                 dw_f32_val = TensorSSA(dw_f32, (bk_num_cols_per_wg,), Float32)
 
-                dw_bf16_rmem = cute.make_rmem_tensor((bk_num_cols_per_wg,), BFloat16)
+                dw_io_rmem = cute.make_rmem_tensor((bk_num_cols_per_wg,), self.io_dtype)
                 if row < sub_seq_len:
-                    dw_bf16_rmem.store((-dw_f32_val).to(BFloat16))
+                    dw_io_rmem.store((-dw_f32_val).to(self.io_dtype))
                 else:
-                    dw_bf16_rmem.fill(BFloat16(0.0))
+                    dw_io_rmem.fill(self.io_dtype(0.0))
 
                 pipeline_prologue_dw.producer_acquire(prologue_dw_producer_state)
-                # store bf16x8 each time
+                # store 8 I/O values each time
                 dw_smem_num_stores = bk_num_cols_per_wg // 8
                 for i in cutlass.range_constexpr(dw_smem_num_stores):
                     col_base = bk_col_base + i * 8
-                    chunk = cute.local_tile(dw_bf16_rmem, (8,), (i,))
-                    smem_store_bf16x8_sw128(sDw_raw_ptr, row, col_base, chunk)
+                    chunk = cute.local_tile(dw_io_rmem, (8,), (i,))
+                    smem_store_f16x8_sw128(sDw_raw_ptr, row, col_base, chunk, self.io_dtype)
 
                 cute.arch.fence_proxy("async.shared", space="cta")
                 pipeline_prologue_dw.producer_commit(prologue_dw_producer_state)
@@ -3495,7 +2126,7 @@ class ChunkKdaBwdWyDqkgFused:
                 if row < sub_seq_len:
                     for i in cutlass.range_constexpr(self.BK // 4 // 8):
                         col_base = bk_col_base + i * 8
-                        vals = smem_load_bf16x8_sw128(sK_raw_ptr, row, col_base)
+                        vals = smem_load_f16x8_sw128(sK_raw_ptr, row, col_base, self.io_dtype)
                         rK[i * 8 + 0] = vals[0]
                         rK[i * 8 + 1] = vals[1]
                         rK[i * 8 + 2] = vals[2]
@@ -3505,7 +2136,7 @@ class ChunkKdaBwdWyDqkgFused:
                         rK[i * 8 + 6] = vals[6]
                         rK[i * 8 + 7] = vals[7]
                 else:
-                    rK.fill(BFloat16(0.0))
+                    rK.fill(self.io_dtype(0.0))
                 rK_fp32 = cute.make_rmem_tensor((self.BK // 4,), Float32)
                 rK_fp32.store(rK.load().to(Float32))
                 rK_fp32_val = rK_fp32.load()
@@ -3513,14 +2144,14 @@ class ChunkKdaBwdWyDqkgFused:
 
                 # write kg to K smem,
                 # notify dA += dw @ kg^T
-                rKG_bf16 = cute.make_rmem_tensor((self.BK // 4,), BFloat16)
-                rKG_bf16.store(rKG_val.to(BFloat16))
+                rKG_io = cute.make_rmem_tensor((self.BK // 4,), self.io_dtype)
+                rKG_io.store(rKG_val.to(self.io_dtype))
 
                 pipeline_prologue_kg.producer_acquire(prologue_kg_producer_state)
                 for i in cutlass.range_constexpr(self.BK // 4 // 8):
                     col_base = bk_col_base + i * 8
-                    chunk_kg = cute.local_tile(rKG_bf16, (8,), (i,))
-                    smem_store_bf16x8_sw128(sK_raw_ptr, row, col_base, chunk_kg)
+                    chunk_kg = cute.local_tile(rKG_io, (8,), (i,))
+                    smem_store_f16x8_sw128(sK_raw_ptr, row, col_base, chunk_kg, self.io_dtype)
 
                 cute.arch.fence_proxy("async.shared", space="cta")
                 pipeline_prologue_kg.producer_commit(prologue_kg_producer_state)
@@ -3654,7 +2285,7 @@ class ChunkKdaBwdWyDqkgFused:
                 if row < sub_seq_len:
                     for i in cutlass.range_constexpr(self.BK // 4 // 8):
                         col_base = bk_col_base + i * 8
-                        vals = smem_load_bf16x8_sw128(sQ_raw_ptr, row, col_base)
+                        vals = smem_load_f16x8_sw128(sQ_raw_ptr, row, col_base, self.io_dtype)
                         rQ[i * 8 + 0] = vals[0]
                         rQ[i * 8 + 1] = vals[1]
                         rQ[i * 8 + 2] = vals[2]
@@ -3664,7 +2295,7 @@ class ChunkKdaBwdWyDqkgFused:
                         rQ[i * 8 + 6] = vals[6]
                         rQ[i * 8 + 7] = vals[7]
                 else:
-                    rQ.fill(BFloat16(0.0))
+                    rQ.fill(self.io_dtype(0.0))
                 dq_scaled_i32 = tcgen05_ld_32x32b(
                     bk_num_cols_per_wg, TMEM_DQ_SCALED_OFF + wg_idx * bk_num_cols_per_wg
                 )
@@ -3716,24 +2347,24 @@ class ChunkKdaBwdWyDqkgFused:
                 # and keeps only `row > col`.
                 dA_f32 = reinterpret_cast(dA_i32, Int32, bt_num_cols_per_wg, Float32)
                 dA_f32_val = TensorSSA(dA_f32, (bt_num_cols_per_wg,), Float32)
-                rDA = cute.make_rmem_tensor((bt_num_cols_per_wg,), BFloat16)
+                rDA = cute.make_rmem_tensor((bt_num_cols_per_wg,), self.io_dtype)
                 for i in cutlass.range_constexpr(bt_num_cols_per_wg):
                     col = bt_col_base + i
                     beta_col = sBeta[(col,)]
-                    dA_scaled = (dA_f32_val[i] * beta_col).to(BFloat16)
+                    dA_scaled = (dA_f32_val[i] * beta_col).to(self.io_dtype)
                     if col < row:
                         rDA[i] = dA_scaled
                     else:
-                        rDA[i] = BFloat16(0.0)
+                        rDA[i] = self.io_dtype(0.0)
                 if row >= sub_seq_len:
-                    rDA.fill(BFloat16(0.0))
+                    rDA.fill(self.io_dtype(0.0))
 
                 pipeline_prologue_dA2.producer_acquire(prologue_dA2_producer_state)
 
                 for i in cutlass.range_constexpr(bt_num_cols_per_wg // 8):
                     col_base = bt_col_base + i * 8
                     chunk_dA = cute.local_tile(rDA, (8,), (i,))
-                    smem_store_bf16x8_sw128(sQ_raw_ptr, row, col_base, chunk_dA)
+                    smem_store_f16x8_sw128(sQ_raw_ptr, row, col_base, chunk_dA, self.io_dtype)
                 # notify dA2 = dA @ A
                 cute.arch.fence_proxy("async.shared", space="cta")
                 pipeline_prologue_dA2.producer_commit(prologue_dA2_producer_state)
@@ -3755,15 +2386,15 @@ class ChunkKdaBwdWyDqkgFused:
                 # write dA2 to smem notify dA2 = A @ dA2
                 dA2_f32 = reinterpret_cast(dA2_i32, Int32, bt_num_cols_per_wg, Float32)
                 dA2_f32_val = TensorSSA(dA2_f32, (bt_num_cols_per_wg,), Float32)
-                rDA2 = cute.make_rmem_tensor((bt_num_cols_per_wg,), BFloat16)
+                rDA2 = cute.make_rmem_tensor((bt_num_cols_per_wg,), self.io_dtype)
                 if row < sub_seq_len:
-                    rDA2.store(dA2_f32_val.to(BFloat16))
+                    rDA2.store(dA2_f32_val.to(self.io_dtype))
                 else:
-                    rDA2.fill(BFloat16(0.0))
+                    rDA2.fill(self.io_dtype(0.0))
                 for i in cutlass.range_constexpr(bt_num_cols_per_wg // 8):
                     col_base = bt_col_base + i * 8
                     chunk_dA2 = cute.local_tile(rDA2, (8,), (i,))
-                    smem_store_bf16x8_sw128(sQ_raw_ptr, row, col_base, chunk_dA2)
+                    smem_store_f16x8_sw128(sQ_raw_ptr, row, col_base, chunk_dA2, self.io_dtype)
 
                 cute.arch.fence_proxy("async.shared", space="cta")
                 pipeline_prologue_dA3.producer_commit(prologue_dA3_producer_state)
@@ -3783,7 +2414,7 @@ class ChunkKdaBwdWyDqkgFused:
                 mma_dA2_consumer_state.advance()
                 pipeline_mma_dA3.consumer_release(mma_dA3_consumer_state)
                 mma_dA3_consumer_state.advance()
-                # NOTE: release smem Q because we reuse to store bf16 dA
+                # NOTE: release smem Q because we reuse to store input-dtype dA
                 pipeline_load_q.consumer_release(load_q_consumer_state)
                 load_q_consumer_state.advance()
 
@@ -4132,7 +2763,7 @@ class ChunkKdaBwdWyDqkgFused:
                 )
 
                 zeros8 = cute.make_rmem_tensor((8,), dtype=self.io_dtype)
-                zeros8.fill(BFloat16(0.0))
+                zeros8.fill(self.io_dtype(0.0))
 
                 pipeline_load_A.consumer_wait(load_A_consumer_state)
                 sA_raw_ptr = cute.make_ptr(
@@ -4148,13 +2779,19 @@ class ChunkKdaBwdWyDqkgFused:
                             # A participates in full 64x64 MMAs, so neutralize both
                             # invalid rows and invalid columns of a partial chunk.
                             if row >= sub_seq_len or col_base >= sub_seq_len:
-                                smem_store_bf16x8_sw128(sA_raw_ptr, row, col_base, zeros8)
+                                smem_store_f16x8_sw128(
+                                    sA_raw_ptr, row, col_base, zeros8, self.io_dtype
+                                )
                             elif col_base + 8 > sub_seq_len:
-                                values = smem_load_bf16x8_sw128(sA_raw_ptr, row, col_base)
+                                values = smem_load_f16x8_sw128(
+                                    sA_raw_ptr, row, col_base, self.io_dtype
+                                )
                                 for element in cutlass.range_constexpr(8):
                                     if col_base + element >= sub_seq_len:
-                                        values[element] = BFloat16(0.0)
-                                smem_store_bf16x8_sw128(sA_raw_ptr, row, col_base, values)
+                                        values[element] = self.io_dtype(0.0)
+                                smem_store_f16x8_sw128(
+                                    sA_raw_ptr, row, col_base, values, self.io_dtype
+                                )
                     # Make generic-proxy SMEM stores visible to UMMA async-proxy readers.
                     cute.arch.fence_proxy("async.shared", space="cta")
 
@@ -4173,7 +2810,9 @@ class ChunkKdaBwdWyDqkgFused:
                             if row >= sub_seq_len:
                                 for col in cutlass.range_constexpr(self.BV // 8):
                                     # dv tile uses the same Swizzle<3,4,3> physical mapping.
-                                    smem_store_bf16x8_sw128(sDo_raw_ptr, row, col * 8, zeros8)
+                                    smem_store_f16x8_sw128(
+                                        sDo_raw_ptr, row, col * 8, zeros8, self.io_dtype
+                                    )
                         cute.arch.fence_proxy("async.shared", space="cta")
 
                     if v_iter == 0:
@@ -4190,13 +2829,14 @@ class ChunkKdaBwdWyDqkgFused:
                     )
                     desc_a_base = Tcgen05SmemDescriptor(desc_a_i64)
                     desc_b_base = Tcgen05SmemDescriptor(desc_b_i64)
-                    mma_ws_ss_m64n128_k_k_call(
+                    mma_ws_ss_call(
                         vloop_opA_smem,
                         desc_a_base,
                         vloop_opB_smem,
                         desc_b_base,
                         TMEM_DQ_ACC_OFF,
                         self.BV,
+                        self.idesc_m64n128_k_k,
                         is_accum,
                     )
 
@@ -4219,7 +2859,9 @@ class ChunkKdaBwdWyDqkgFused:
                             if row >= sub_seq_len:
                                 for col in cutlass.range_constexpr(self.BV // 8):
                                     # dv tile uses the same Swizzle<3,4,3> physical mapping.
-                                    smem_store_bf16x8_sw128(sDv_raw, row, col * 8, zeros8)
+                                    smem_store_f16x8_sw128(
+                                        sDv_raw, row, col * 8, zeros8, self.io_dtype
+                                    )
                         cute.arch.fence_proxy("async.shared", space="cta")
 
                     # if lane_idx == 0:
@@ -4236,13 +2878,14 @@ class ChunkKdaBwdWyDqkgFused:
                     )
                     desc_a_base = Tcgen05SmemDescriptor(desc_a_i64)
                     desc_b_base = Tcgen05SmemDescriptor(desc_b_i64)
-                    mma_ws_ss_m64n64_mn_mn_call(
+                    mma_ws_ss_call(
                         A_mn_opA_smem,
                         desc_a_base,
                         dv_mn_opB_smem,
                         desc_b_base,
                         TMEM_FLEX_OFF,
                         self.BT,
+                        self.idesc_m64n64_mn_mn,
                     )
 
                     pipeline_mma_dvb.producer_commit(mma_dvb_producer_state)
@@ -4261,13 +2904,14 @@ class ChunkKdaBwdWyDqkgFused:
                     )
                     desc_a_base = Tcgen05SmemDescriptor(desc_a_i64)
                     desc_b_base = Tcgen05SmemDescriptor(desc_b_i64)
-                    mma_ws_ss_m64n128_k_k_call(
+                    mma_ws_ss_call(
                         vloop_opA_smem,
                         desc_a_base,
                         vloop_opB_smem,
                         desc_b_base,
                         TMEM_DW_ACC_OFF,
                         self.BV,
+                        self.idesc_m64n128_k_k,
                         is_accum,
                     )
 
@@ -4284,7 +2928,9 @@ class ChunkKdaBwdWyDqkgFused:
                             if row >= sub_seq_len:
                                 for col in cutlass.range_constexpr(self.BV // 8):
                                     # dv tile uses the same Swizzle<3,4,3> physical mapping.
-                                    smem_store_bf16x8_sw128(sV_raw, row, col * 8, zeros8)
+                                    smem_store_f16x8_sw128(
+                                        sV_raw, row, col * 8, zeros8, self.io_dtype
+                                    )
                         cute.arch.fence_proxy("async.shared", space="cta")
 
                     if v_iter == 0:
@@ -4299,13 +2945,14 @@ class ChunkKdaBwdWyDqkgFused:
                     )
                     desc_a_base = Tcgen05SmemDescriptor(desc_a_i64)
                     desc_b_base = Tcgen05SmemDescriptor(desc_b_i64)
-                    mma_ws_ss_m64n64_k_k_call(
+                    mma_ws_ss_call(
                         vloop_opA_smem,
                         desc_a_base,
                         v_opB_smem,
                         desc_b_base,
                         TMEM_DA_ACC_OFF,
                         self.BV,
+                        self.idesc_m64n64_k_k,
                         is_accum,
                     )
 
@@ -4333,7 +2980,9 @@ class ChunkKdaBwdWyDqkgFused:
                             if row >= sub_seq_len:
                                 for col in cutlass.range_constexpr(self.BV // 8):
                                     # dv tile uses the same Swizzle<3,4,3> physical mapping.
-                                    smem_store_bf16x8_sw128(sDvnew_raw_ptr, row, col * 8, zeros8)
+                                    smem_store_f16x8_sw128(
+                                        sDvnew_raw_ptr, row, col * 8, zeros8, self.io_dtype
+                                    )
                         cute.arch.fence_proxy("async.shared", space="cta")
 
                     mbarrier_wait(bar_tma_dh_ptr + vloop_stage_idx, vloop_phase)
@@ -4350,13 +2999,14 @@ class ChunkKdaBwdWyDqkgFused:
                     )
                     desc_a_base = Tcgen05SmemDescriptor(desc_a_i64)
                     desc_b_base = Tcgen05SmemDescriptor(desc_b_i64)
-                    mma_ws_ss_m64n128_k_k_call(
+                    mma_ws_ss_call(
                         vloop_opA_smem,
                         desc_a_base,
                         vloop_opB_smem,
                         desc_b_base,
                         TMEM_DK_ACC_OFF,
                         self.BV,
+                        self.idesc_m64n128_k_k,
                         is_accum,
                     )
 
@@ -4392,13 +3042,14 @@ class ChunkKdaBwdWyDqkgFused:
                 )
                 desc_a_base = Tcgen05SmemDescriptor(desc_a_i64)
                 desc_b_base = Tcgen05SmemDescriptor(desc_b_i64)
-                mma_ws_ss_m64n128_mn_mn_call(
+                mma_ws_ss_call(
                     A_mn_opA_smem,
                     desc_a_base,
                     dw_mn_opB_smem,
                     desc_b_base,
                     TMEM_DKGB_ACC_OFF,
                     self.BT,
+                    self.idesc_m64n128_mn_mn,
                 )
 
                 pipeline_mma_dkgb.producer_commit(mma_dgkb_producer_state)
@@ -4417,13 +3068,14 @@ class ChunkKdaBwdWyDqkgFused:
                 )
                 desc_a_base = Tcgen05SmemDescriptor(desc_a_i64)
                 desc_b_base = Tcgen05SmemDescriptor(desc_b_i64)
-                mma_ws_ss_m64n64_k_k_call(
+                mma_ws_ss_call(
                     dw_k_opA_smem,
                     desc_a_base,
                     kg_k_opB_smem,
                     desc_b_base,
                     TMEM_DA_ACC_OFF,
                     self.BK,
+                    self.idesc_m64n64_k_k,
                     True,
                 )
 
@@ -4450,13 +3102,14 @@ class ChunkKdaBwdWyDqkgFused:
                 )
                 desc_a_base = Tcgen05SmemDescriptor(desc_a_i64)
                 desc_b_base = Tcgen05SmemDescriptor(desc_b_i64)
-                mma_ws_ss_m64n64_k_k_call(
+                mma_ws_ss_call(
                     dA_k_opA_smem,
                     desc_a_base,
                     A_k_opB_smem,
                     desc_b_base,
                     TMEM_DA2_ACC_OFF,
                     self.BT,
+                    self.idesc_m64n64_k_k,
                 )
 
                 pipeline_mma_dA2.producer_commit(mma_dA2_producer_state)
@@ -4479,13 +3132,14 @@ class ChunkKdaBwdWyDqkgFused:
                 )
                 desc_a_base = Tcgen05SmemDescriptor(desc_a_i64)
                 desc_b_base = Tcgen05SmemDescriptor(desc_b_i64)
-                mma_ws_ss_m64n64_mn_mn_call(
+                mma_ws_ss_call(
                     A_mn_opA_smem,
                     desc_a_base,
                     dA_mn_opB_smem,
                     desc_b_base,
                     TMEM_DA2_ACC_OFF,
                     self.BT,
+                    self.idesc_m64n64_mn_mn,
                 )
 
                 pipeline_mma_dA3.producer_commit(mma_dA3_producer_state)
@@ -4680,9 +3334,9 @@ class ChunkKdaBwdWyDqkgFused:
 
 # q, k, and v may arrive as unbound QKV views: only their innermost dimension is
 # contiguous, and TMA needs every outer stride and the base pointer to be 16-byte
-# (8 bf16 element) aligned.
+# (8 16-bit elements) aligned.
 _MIN_ALIGN_BYTES = 16
-_MIN_ALIGN_ELEMENTS_BF16 = _MIN_ALIGN_BYTES // 2
+_MIN_ALIGN_ELEMENTS_IO = _MIN_ALIGN_BYTES // 2
 
 
 class ChunkKdaBwdWyDqkgConfig(NamedTuple):
@@ -4696,16 +3350,19 @@ def _compile_chunk_kda_bwd_wy_dqkg(
     heads: int,
     head_dim: int,
     chunk_size: int,
+    io_dtype: torch.dtype,
     fastmath: bool,
     grid_waves: int,
     ragged: bool,
     use_int64_offsets: bool = False,
 ):
     """Compile one persistent dense or ragged WY/dQKG specialization."""
+    cutlass_io_dtype = _torch_to_cutlass_dtype[io_dtype]
     op = ChunkKdaBwdWyDqkgFused(
         chunk_size=chunk_size,
         head_dim_k=head_dim,
         head_dim_v=head_dim,
+        io_dtype=cutlass_io_dtype,
         scale=head_dim**-0.5,
         grid_waves=grid_waves,
         use_fast_math=fastmath,
@@ -4722,29 +3379,28 @@ def _compile_chunk_kda_bwd_wy_dqkg(
             assumed_align=128,
         )
 
-    def strided_bf16_tensor(shape):
+    def strided_io_tensor(shape):
         return make_fake_tensor(
-            cutlass.BFloat16,
+            cutlass_io_dtype,
             shape,
-            stride=tuple(sym_int(divisibility=_MIN_ALIGN_ELEMENTS_BF16) for _ in shape[:-1])
-            + (1,),
+            stride=tuple(sym_int(divisibility=_MIN_ALIGN_ELEMENTS_IO) for _ in shape[:-1]) + (1,),
             assumed_align=_MIN_ALIGN_BYTES,
         )
 
-    q = strided_bf16_tensor((1, tokens, heads, head_dim))
-    k = strided_bf16_tensor((1, tokens, heads, head_dim))
-    v = strided_bf16_tensor((1, tokens, heads, head_dim))
-    v_new = tensor(cutlass.BFloat16, (1, tokens, heads, head_dim))
+    q = strided_io_tensor((1, tokens, heads, head_dim))
+    k = strided_io_tensor((1, tokens, heads, head_dim))
+    v = strided_io_tensor((1, tokens, heads, head_dim))
+    v_new = tensor(cutlass_io_dtype, (1, tokens, heads, head_dim))
     g = tensor(cutlass.Float32, (1, tokens, heads, head_dim))
     beta = tensor(cutlass.Float32, (1, tokens, heads))
-    A = tensor(cutlass.BFloat16, (1, tokens, heads, chunk_size))
-    h = tensor(cutlass.BFloat16, (1, chunks, heads, head_dim, head_dim))
-    do = tensor(cutlass.BFloat16, (1, tokens, heads, head_dim))
-    dh = tensor(cutlass.BFloat16, (1, chunks, heads, head_dim, head_dim))
-    dv = tensor(cutlass.BFloat16, (1, tokens, heads, head_dim))
+    A = tensor(cutlass_io_dtype, (1, tokens, heads, chunk_size))
+    h = tensor(cutlass_io_dtype, (1, chunks, heads, head_dim, head_dim))
+    do = tensor(cutlass_io_dtype, (1, tokens, heads, head_dim))
+    dh = tensor(cutlass_io_dtype, (1, chunks, heads, head_dim, head_dim))
+    dv = tensor(cutlass_io_dtype, (1, tokens, heads, head_dim))
     dq = tensor(cutlass.Float32, (1, tokens, heads, head_dim))
     dk = tensor(cutlass.Float32, (1, tokens, heads, head_dim))
-    dv2 = tensor(cutlass.BFloat16, (1, tokens, heads, head_dim))
+    dv2 = tensor(cutlass_io_dtype, (1, tokens, heads, head_dim))
     dg = tensor(cutlass.Float32, (1, tokens, heads, head_dim))
     db = tensor(cutlass.Float32, (1, tokens, heads))
     dA = tensor(cutlass.Float32, (1, tokens, heads, chunk_size))
@@ -4774,7 +3430,8 @@ def _compile_chunk_kda_bwd_wy_dqkg(
         (Int32(1), Int32(1), Int32(heads), Int32(heads), Int32(head_dim), Int32(head_dim)),
         Int32(1),
         name=(
-            f"kda_bwd_wy_dqkg_h{heads}_d{head_dim}_c{chunk_size}_fm{int(fastmath)}_"
+            f"kda_bwd_wy_dqkg_h{heads}_d{head_dim}_c{chunk_size}_"
+            f"{str(io_dtype).removeprefix('torch.')}_fm{int(fastmath)}_"
             f"gw{grid_waves}_rg{int(ragged)}_i64{int(use_int64_offsets)}"
         ),
     )
@@ -4833,11 +3490,12 @@ class ChunkKdaBwdWyDqkgTunable:
     def compile_call(
         config: ChunkKdaBwdWyDqkgConfig,
         args: Args,
-    ) -> tuple[int, int, int, bool, int, bool, bool]:
+    ) -> tuple[int, int, int, torch.dtype, bool, int, bool, bool]:
         return (
             args.q.shape[2],
             args.q.shape[3],
             args.chunk_size,
+            args.q.dtype,
             args.fastmath,
             config.grid_waves,
             args.chunk_offsets is not None,
@@ -4946,6 +3604,13 @@ def chunk_kda_bwd_wy_dqkg(
         raise ValueError("the fused WY backward requires B=1 and K=V=128")
     if chunk_size != 64:
         raise ValueError(f"the fused WY backward requires chunk_size=64, got {chunk_size}")
+    if q.dtype not in (torch.bfloat16, torch.float16):
+        raise ValueError(f"the fused WY backward requires FP16 or BF16 inputs, got {q.dtype}")
+    io_tensors = (k, v, v_new, A, h, do, dh, dv)
+    if any(tensor.dtype != q.dtype for tensor in io_tensors):
+        raise ValueError("q, k, v, v_new, A, h, do, dh, and dv must have the same dtype")
+    if g.dtype != torch.float32 or beta.dtype != torch.float32:
+        raise ValueError("g and beta must have dtype torch.float32")
     if metadata is None:
         if tokens % chunk_size:
             raise ValueError("the fused WY backward requires complete chunks")

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py
@@ -72,8 +72,11 @@ def _validate_private_abi(
     contiguous_tensors = (cumulative_gate, beta)
     if initial_state is not None:
         contiguous_tensors += (initial_state,)
-    if (q.dtype, k.dtype, v.dtype) != (torch.bfloat16,) * 3:
-        raise TypeError("the private chunk_kda ABI requires bfloat16 q, k, and v")
+    if q.dtype not in (torch.float16, torch.bfloat16) or (k.dtype, v.dtype) != (
+        q.dtype,
+        q.dtype,
+    ):
+        raise TypeError("the private chunk_kda ABI requires matching float16 or bfloat16 q, k, v")
     if cumulative_gate.dtype != torch.float32 or beta.dtype != torch.float32:
         raise TypeError("the private chunk_kda ABI requires float32 cumulative_gate and beta")
     if initial_state is not None and initial_state.dtype != torch.float32:

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_inter_solve.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_inter_solve.py
@@ -50,6 +50,10 @@ _SUPPORTED_NUM_SUBCHUNKS = 4
 # three-wave crossover because the persistent chunk loop can otherwise lose.
 _INTER_SOLVE_SHORT_AUTO_WAVES = 1
 _INTER_SOLVE_LONG_AUTO_WAVES = 3
+_IO_TYPES = {
+    torch.float16: (cutlass.Float16, "fp16"),
+    torch.bfloat16: (cutlass.BFloat16, "bf16"),
+}
 
 
 def _check_compile_target() -> None:
@@ -117,6 +121,8 @@ def _compile_k3b(
     head_dim: int,
     chunk_size: int,
     subchunk_size: int,
+    io_type: type[cutlass.Numeric],
+    io_name: str,
     chunk_schedule: ChunkSchedule,
     schedule_kind: ScheduleKind,
     chunk_workers: int = 0,
@@ -139,13 +145,13 @@ def _compile_k3b(
     tokens, chunks, sequences = (cute.sym_int() for _ in range(3))
     sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
     q = make_fake_tensor(
-        cutlass.BFloat16,
+        io_type,
         (tokens, heads * head_dim),
         stride=(sym_int(divisibility=8), 1),
         assumed_align=16,
     )
     k = make_fake_tensor(
-        cutlass.BFloat16,
+        io_type,
         (tokens, heads * head_dim),
         stride=(sym_int(divisibility=8), 1),
         assumed_align=16,
@@ -163,7 +169,7 @@ def _compile_k3b(
         assumed_align=16,
     )
     Aqk = make_fake_compact_tensor(
-        cutlass.BFloat16,
+        io_type,
         (tokens, heads * chunk_size),
         stride_order=(1, 0),
         assumed_align=16,
@@ -190,7 +196,7 @@ def _compile_k3b(
         cu_seqlens,
         chunk_offsets,
         name=(
-            f"kda_fwd_k3b_h{heads}_d{head_dim}_c{chunk_size}_sc{subchunk_size}"
+            f"kda_fwd_k3b_h{heads}_d{head_dim}_c{chunk_size}_sc{subchunk_size}_{io_name}"
             f"_layout_{chunk_schedule.value}_execution_{schedule_kind.value}"
             f"_cw{chunk_workers}_i64{int(use_int64_offsets)}"
         ),
@@ -203,6 +209,8 @@ def _compile_k4b(
     head_dim: int,
     chunk_size: int,
     subchunk_size: int,
+    io_type: type[cutlass.Numeric],
+    io_name: str,
     chunk_schedule: ChunkSchedule,
     schedule_kind: ScheduleKind,
     chunk_workers: int = 0,
@@ -235,7 +243,7 @@ def _compile_k4b(
         assumed_align=16,
     )
     Akk = make_fake_compact_tensor(
-        cutlass.BFloat16,
+        io_type,
         (tokens, heads * chunk_size),
         stride_order=(1, 0),
         assumed_align=16,
@@ -252,7 +260,7 @@ def _compile_k4b(
         cu_seqlens,
         chunk_offsets,
         name=(
-            f"kda_fwd_k4b_h{heads}_d{head_dim}_c{chunk_size}_sc{subchunk_size}"
+            f"kda_fwd_k4b_h{heads}_d{head_dim}_c{chunk_size}_sc{subchunk_size}_{io_name}"
             f"_layout_{chunk_schedule.value}_execution_{schedule_kind.value}"
             f"_cw{chunk_workers}_i64{int(use_int64_offsets)}"
         ),
@@ -295,6 +303,9 @@ def _chunk_kda_fwd_k3b_ragged_impl(
         AkkOD.zero_()
         return Aqk, AkkOD
 
+    if q.dtype != k.dtype or q.dtype != Aqk.dtype or q.dtype not in _IO_TYPES:
+        raise TypeError("q, k, and Aqk must share dtype float16 or bfloat16")
+    io_type, io_name = _IO_TYPES[q.dtype]
     q_flat = q[0].reshape(tokens, heads * head_dim)
     k_flat = k[0].reshape(tokens, heads * head_dim)
     g_flat = gk.reshape(tokens, heads * head_dim).contiguous()
@@ -306,6 +317,8 @@ def _chunk_kda_fwd_k3b_ragged_impl(
         head_dim,
         chunk_size,
         subchunk_size,
+        io_type,
+        io_name,
         ChunkSchedule.RAGGED,
         resolved.kind,
         chunk_workers,
@@ -348,6 +361,7 @@ def _chunk_kda_fwd_k4b_ragged_impl(
     metadata: RaggedChunkMetadata,
     resolved: ResolvedSchedule,
     subchunk_size: int = _SUPPORTED_SUBCHUNK_SIZE,
+    output_dtype: torch.dtype = torch.bfloat16,
 ) -> torch.Tensor:
     """Compute K4 with the same execution plan that produced ``AkkOD``."""
     if Akkd.ndim != 4:
@@ -372,9 +386,12 @@ def _chunk_kda_fwd_k4b_ragged_impl(
 
     # Only rows owned by active ragged chunks are defined; downstream ragged consumers route from
     # metadata and must not read capacity slack.
+    if output_dtype not in _IO_TYPES:
+        raise TypeError("Akk output dtype must be float16 or bfloat16")
+    io_type, io_name = _IO_TYPES[output_dtype]
     Akk = torch.empty(
         (batch, tokens, heads, chunk_size),
-        dtype=torch.bfloat16,
+        dtype=output_dtype,
         device=Akkd.device,
     )
     if isinstance(Akkd, FakeTensor) or metadata.capacity == 0:
@@ -388,6 +405,8 @@ def _chunk_kda_fwd_k4b_ragged_impl(
         _SUPPORTED_HEAD_DIM,
         chunk_size,
         subchunk_size,
+        io_type,
+        io_name,
         ChunkSchedule.RAGGED,
         resolved.kind,
         chunk_workers,
@@ -410,16 +429,20 @@ def chunk_kda_fwd_k4b_ragged_cute(
     Akkd: torch.Tensor,
     metadata: RaggedChunkMetadata,
     schedule: ScheduleRequest = ScheduleRequest.AUTO,
+    output_dtype: torch.dtype = torch.bfloat16,
 ) -> torch.Tensor:
     """Run the eager ragged K4 inverse stage."""
     resolved = _resolve_ragged_execution(Akkd, metadata, schedule)
-    return _chunk_kda_fwd_k4b_ragged_impl(AkkOD, Akkd, metadata, resolved)
+    return _chunk_kda_fwd_k4b_ragged_impl(
+        AkkOD, Akkd, metadata, resolved, output_dtype=output_dtype
+    )
 
 
 def chunk_kda_fwd_k4b_dense_cute(
     AkkOD: torch.Tensor,
     Akkd: torch.Tensor,
     chunk_size: int = DEFAULT_CHUNK_SIZE,
+    output_dtype: torch.dtype = torch.bfloat16,
 ) -> torch.Tensor:
     """Assemble dense BT=64 inverse blocks from precomputed K3-compatible factors."""
     if Akkd.ndim != 4:
@@ -437,9 +460,12 @@ def chunk_kda_fwd_k4b_dense_cute(
     if AkkOD.shape != expected_od:
         raise ValueError(f"AkkOD must have shape {expected_od}, got {tuple(AkkOD.shape)}")
 
+    if output_dtype not in _IO_TYPES:
+        raise TypeError("Akk output dtype must be float16 or bfloat16")
+    io_type, io_name = _IO_TYPES[output_dtype]
     Akk = torch.empty(
         (batch, tokens, heads, chunk_size),
-        dtype=torch.bfloat16,
+        dtype=output_dtype,
         device=Akkd.device,
     )
     if isinstance(Akkd, FakeTensor) or chunks == 0:
@@ -451,6 +477,8 @@ def chunk_kda_fwd_k4b_dense_cute(
         _SUPPORTED_HEAD_DIM,
         chunk_size,
         subchunk_size,
+        io_type,
+        io_name,
         ChunkSchedule.DENSE,
         ScheduleKind.STATIC,
         use_int64_offsets=requires_int64_abi(AkkOD, akkd_flat, akk_flat),
@@ -472,7 +500,9 @@ def chunk_kda_fwd_inter_solve_ragged_cute(
     """Run K3 and K4 with one shared automatic scheduling decision."""
     resolved = _resolve_ragged_execution(k, metadata, ScheduleRequest.AUTO)
     Aqk, AkkOD = _chunk_kda_fwd_k3b_ragged_impl(q, k, gk, beta, Aqk, scale, metadata, resolved)
-    return Aqk, _chunk_kda_fwd_k4b_ragged_impl(AkkOD, Akkd, metadata, resolved)
+    return Aqk, _chunk_kda_fwd_k4b_ragged_impl(
+        AkkOD, Akkd, metadata, resolved, output_dtype=q.dtype
+    )
 
 
 def chunk_kda_fwd_inter_solve_cute(
@@ -520,6 +550,11 @@ def chunk_kda_fwd_inter_solve_cute(
         )
         Akk_flat = Akk.reshape(B * T, H * BT)
 
+    if q.dtype != k.dtype or q.dtype not in _IO_TYPES:
+        raise TypeError("q and k must share dtype float16 or bfloat16")
+    if Aqk.dtype != q.dtype or Akk.dtype != q.dtype:
+        raise TypeError("Aqk and Akk must match the Q/K dtype")
+    io_type, io_name = _IO_TYPES[q.dtype]
     if isinstance(k, FakeTensor):
         return Aqk, Akk
 
@@ -546,6 +581,8 @@ def chunk_kda_fwd_inter_solve_cute(
             K,
             BT,
             BC,
+            io_type,
+            io_name,
             ChunkSchedule.DENSE,
             ScheduleKind.STATIC,
             use_int64_offsets=requires_int64_abi(
@@ -573,6 +610,8 @@ def chunk_kda_fwd_inter_solve_cute(
             K,
             BT,
             BC,
+            io_type,
+            io_name,
             ChunkSchedule.DENSE,
             ScheduleKind.STATIC,
             use_int64_offsets=requires_int64_abi(akk_od, akkd_flat, Akk_flat),

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_intra.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_intra.py
@@ -4,8 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 #
-# CuTe DSL KDA forward intra-chunk path: the persistent engine produces Aqk and
-# K3-compatible factors, then K4b assembles the dense or ragged Akk inverse.
+# KDA forward factor composition. BF16 uses the persistent intra engine; FP16
+# uses the FP32/TF32 diagonal stage plus CuTe K3b/K4b to preserve gate range.
 
 from __future__ import annotations
 
@@ -17,11 +17,16 @@ from torch._subclasses.fake_tensor import FakeTensor
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata
 from attn_gym.linear.kda.constants import DEFAULT_CHUNK_SIZE
 from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd_inter_solve import (
+    chunk_kda_fwd_inter_solve_cute,
+    chunk_kda_fwd_inter_solve_ragged_cute,
     chunk_kda_fwd_k4b_dense_cute,
     chunk_kda_fwd_k4b_ragged_cute,
 )
 from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd_intra_engine import kda_intra_engine_fwd
 from attn_gym.linear.kda.fwd.cute.recompute_w_u_fwd import recompute_w_u_fwd
+from attn_gym.linear.kda.fwd.triton.chunk_kda_fwd_intra_sub_chunk_forloop import (
+    chunk_kda_fwd_intra_diagonal,
+)
 
 
 def chunk_kda_fwd_factors(
@@ -45,6 +50,34 @@ def chunk_kda_fwd_factors(
         shape = (batch, tokens, heads, chunk_size)
         return k.new_empty(shape), k.new_empty(shape)
 
+    if q.dtype == torch.float16:
+        # The engine stores two-sided diagonal rebase factors in the I/O dtype. Their
+        # public gate-bound exponent fits BF16 but can overflow FP16, so keep the
+        # diagonal products in FP32/TF32 and use FP16 only for the safe solved factors.
+        Aqk, Akkd = chunk_kda_fwd_intra_diagonal(q, k, gk, beta, scale, metadata, chunk_size)
+        if metadata is None:
+            return chunk_kda_fwd_inter_solve_cute(
+                q,
+                k,
+                gk,
+                beta,
+                Akkd,
+                scale,
+                chunk_size,
+                Aqk=Aqk,
+                profile_ranges=profile_ranges,
+            )
+        return chunk_kda_fwd_inter_solve_ragged_cute(
+            q,
+            k,
+            gk,
+            beta,
+            Akkd,
+            Aqk,
+            scale,
+            metadata,
+        )
+
     with (
         torch.profiler.record_function("kda/cute/intra_engine")
         if profile_ranges
@@ -52,9 +85,9 @@ def chunk_kda_fwd_factors(
     ):
         Aqk, AkkOD, Akkd = kda_intra_engine_fwd(q, k, gk, beta, scale, metadata)
         Akk = (
-            chunk_kda_fwd_k4b_dense_cute(AkkOD, Akkd, chunk_size)
+            chunk_kda_fwd_k4b_dense_cute(AkkOD, Akkd, chunk_size, output_dtype=q.dtype)
             if metadata is None
-            else chunk_kda_fwd_k4b_ragged_cute(AkkOD, Akkd, metadata)
+            else chunk_kda_fwd_k4b_ragged_cute(AkkOD, Akkd, metadata, output_dtype=q.dtype)
         )
     return Aqk, Akk
 

--- a/attn_gym/linear/kda/fwd/triton/recompute_w_u.py
+++ b/attn_gym/linear/kda/fwd/triton/recompute_w_u.py
@@ -467,15 +467,19 @@ def recompute_w_u_fwd_triton(
             f"q must have shape {(batch, tokens, value_heads, key_dim)}, got {tuple(q.shape)}"
         )
     for name, tensor, dtypes in (
-        ("k", k, (torch.bfloat16,)),
-        ("v", v, (torch.bfloat16,)),
-        ("q", q, (torch.bfloat16,)),
-        ("beta", beta, (torch.float32, torch.bfloat16)),
+        ("k", k, (torch.float16, torch.bfloat16)),
+        ("v", v, (torch.float16, torch.bfloat16)),
+        ("q", q, (torch.float16, torch.bfloat16)),
+        ("beta", beta, (torch.float32, torch.float16, torch.bfloat16)),
         ("gk", gk, (torch.float32,)),
-        ("A", A, (torch.float32, torch.bfloat16)),
+        ("A", A, (torch.float32, torch.float16, torch.bfloat16)),
     ):
         if tensor is not None and tensor.dtype not in dtypes:
             raise ValueError(f"{name} must be one of {dtypes}, got {tensor.dtype}")
+    if k.dtype != v.dtype or (q is not None and q.dtype != k.dtype):
+        raise ValueError("q, k, and v must share one dtype")
+    if A.dtype != torch.float32 and A.dtype != k.dtype:
+        raise ValueError("half-precision A must match the Q/K/V dtype")
     if dot_precision == "tf32x3" and A.dtype != torch.float32:
         raise ValueError("dot_precision='tf32x3' requires fp32 A")
     # q/k/v may carry a strided token dimension (fused-QKV views); heads must be

--- a/attn_gym/linear/kda/impl/fused.py
+++ b/attn_gym/linear/kda/impl/fused.py
@@ -172,7 +172,12 @@ def chunk_forward(
     _validate_fused_constraints(q, v)
     output_dtype = q.dtype
     output_shape = q.shape
-    q, k, v = (tensor.to(torch.bfloat16) for tensor in (q, k, v))
+    kernel_dtype = (
+        q.dtype
+        if q.dtype in (torch.float16, torch.bfloat16) and k.dtype == v.dtype == q.dtype
+        else torch.bfloat16
+    )
+    q, k, v = (tensor.to(kernel_dtype) for tensor in (q, k, v))
     gate = gate.float()
     beta = beta.float().contiguous()
     batch, tokens, heads, head_dim = output_shape

--- a/attn_gym/testing/kda.py
+++ b/attn_gym/testing/kda.py
@@ -52,10 +52,12 @@ def assert_matches_low_precision_reference(
     high_precision: torch.Tensor,
     low_precision: torch.Tensor,
     name: str,
+    *,
+    source_dtype: torch.dtype = torch.bfloat16,
 ) -> None:
-    """Bound kernel error by an independent low-precision reference's FP64 error."""
+    """Bound kernel error by the reference error and source-operand precision."""
     high_precision = high_precision.double()
-    rounding_band = torch.finfo(torch.bfloat16).eps * high_precision.abs().max().item()
+    rounding_band = torch.finfo(source_dtype).eps * high_precision.abs().max().item()
     actual_error = (actual.double() - high_precision).abs().max().item()
     reference_error = (low_precision.double() - high_precision).abs().max().item()
     budget = 2 * (reference_error + rounding_band)

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -95,8 +95,9 @@ contract. A correctness-first integration can keep the KDA unit under an FP32 po
 its projections explicitly compute in BF16; isolating only the strict-FP32 decay state is
 a future bandwidth optimization.
 The optimized core requires Blackwell and `head_dim=128`; its public boundary accepts
-FP16, BF16, or FP32 inputs and normalizes private Q/K/V kernel operands to BF16. It chunks
-internally at 64 tokens. Complete `B=1` inputs whose length is a multiple of the chunk size run on the
+FP16, BF16, or FP32 inputs. Homogeneous FP16 and BF16 Q/K/V stay in their input dtype, while
+FP32 or mixed-dtype inputs retain the existing BF16 normalization. The core chunks internally at
+64 tokens. Complete `B=1` inputs whose length is a multiple of the chunk size run on the
 direct dense route; other dense `[B, T, H, D]` inputs are lowered internally to
 equal-length packed sequences, while `chunk_kda(..., cu_seqlens=offsets)` accepts
 explicitly packed `[1, T, H, D]` inputs. All forms carry sequence boundaries through the
@@ -107,6 +108,16 @@ forward values outside `[0, cu_seqlens[-1])` are unspecified. The internal rever
 returns zero cotangents for inactive gate rows. This does not sanitize arbitrary
 parameterized gate producers: callers still need the masking rules below because
 ``0 * NaN`` can poison their reductions.
+
+!!! warning "FP16 intermediate range"
+
+    Use L2-normalized Q/K with FP16, as the training example does. Unnormalized Q/K can easily
+    produce attention or solve factors outside the FP16 range. Unusually large V or initial-state
+    carries can likewise overflow the FP16 chunk-state and value intermediates. The GEMMs
+    accumulate in FP32, but their results are converted back to FP16 when used as inputs to the
+    next GEMM; an overflow at that conversion cannot be recovered by the next FP32 accumulator.
+    BF16 uses the same storage size with a much larger exponent range, so it is substantially less
+    likely to hit these issues, although sufficiently large values can overflow any finite dtype.
 
 A captured graph with sequence capacity `N` keeps `cu_seqlens.shape == (N + 1,)`. If a
 replay has `M <= N` nonempty sequences and `L <= T` active tokens, repeat the terminal
@@ -251,8 +262,8 @@ part of the public KDA API.
 
 Both cores select their implementation with `impl`: `"fused"` runs the optimized kernels
 and enforces their constraints (the chunked core requires `head_dim=128` and Blackwell,
-normalizes Q/K/V operands to BF16 internally, and chunks at 64 tokens; the fused recurrent scan
-is inference-only), while `"reference"`
+preserves homogeneous FP16/BF16 Q/K/V, normalizes FP32 or mixed inputs to BF16, and chunks at
+64 tokens; the fused recurrent scan is inference-only), while `"reference"`
 runs the eager FP32 oracle behind the identical packed contract on any hardware and head
 dimension, and stays differentiable. There is no automatic fallback between the two, and
 the chunk-versus-recurrent switch is caller policy (on B200 the scan wins below roughly

--- a/examples/kda_training.py
+++ b/examples/kda_training.py
@@ -17,6 +17,10 @@ On a Blackwell GPU, exercise the fused backend with::
 
     python examples/kda_training.py --backend=fused
 
+Run the fused training loop in FP16 with::
+
+    python examples/kda_training.py --backend=fused --compute-dtype=float16
+
 Pack Zipf-distributed sequence lengths into one physical batch with::
 
     python examples/kda_training.py --backend=fused --packed --batch-size=4 --tokens=256
@@ -68,6 +72,13 @@ class BackendOption(str, Enum):
 
     REFERENCE = "reference"
     FUSED = "fused"
+
+
+class ComputeDTypeOption(str, Enum):
+    """Low-precision compute dtypes exposed by the command line."""
+
+    FLOAT16 = "float16"
+    BFLOAT16 = "bfloat16"
 
 
 def _record_function(enabled: bool, name: str):
@@ -197,8 +208,8 @@ class KDAAttention(nn.Module):
             if compute_dtype is None
             else compute_dtype
         )
-        if backend == "fused" and self.compute_dtype != torch.bfloat16:
-            raise ValueError("the fused backend requires compute_dtype=torch.bfloat16")
+        if backend == "fused" and self.compute_dtype not in (torch.float16, torch.bfloat16):
+            raise ValueError("the fused backend requires compute_dtype float16 or bfloat16")
 
         projection_size = num_heads * head_dim
         factory_kwargs = {"device": device}
@@ -472,6 +483,10 @@ def main(
         BackendOption,
         typer.Option(help="Use the reference or the best integrated fused kernels."),
     ] = BackendOption.REFERENCE,
+    compute_dtype: Annotated[
+        ComputeDTypeOption | None,
+        typer.Option(help="Use float16 or bfloat16 projection and fused-kernel inputs."),
+    ] = None,
     steps: Annotated[int, typer.Option(min=1, help="Number of optimizer steps.")] = 2,
     batch_size: Annotated[
         int,
@@ -519,11 +534,14 @@ def main(
         head_dim,
         short_conv_kernel_size=short_conv_kernel_size,
         backend=backend.value,
+        compute_dtype=(None if compute_dtype is None else getattr(torch, compute_dtype.value)),
         device=device,
     )
+    use_grad_scaler = model.compute_dtype == torch.float16 and torch.device(device).type == "cuda"
     if compile_model:
         model = torch.compile(model, fullgraph=True, mode="reduce-overhead")
     optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3, fused=True)
+    grad_scaler = torch.amp.GradScaler("cuda", enabled=use_grad_scaler)
     cu_seqlens = None
     input_shape = (batch_size, tokens, hidden_size)
     layout_name = ""
@@ -536,8 +554,9 @@ def main(
     hidden_states = torch.randn(input_shape, device=device)
     target = torch.randn_like(hidden_states)
     execution_name = "_compiled" if compile_model else ""
+    dtype_name = "" if compute_dtype is None else f"_{compute_dtype.value}"
     profile_name = (
-        f"kda_training_backend-{backend.value}{layout_name}{execution_name}"
+        f"kda_training_backend-{backend.value}{dtype_name}{layout_name}{execution_name}"
         f"_b{batch_size}_t{tokens}_c{hidden_size}_h{num_heads}_d{head_dim}"
     )
 
@@ -548,9 +567,10 @@ def main(
         with _record_function(profile, f"{profile_name}/loss"):
             loss = F.mse_loss(output.float(), target)
         with _record_function(profile, f"{profile_name}/backward"):
-            loss.backward()
+            grad_scaler.scale(loss).backward()
         with _record_function(profile, f"{profile_name}/optimizer"):
-            optimizer.step()
+            grad_scaler.step(optimizer)
+            grad_scaler.update()
         return loss
 
     if profile or compile_model:

--- a/test/test_kda_cute_forward.py
+++ b/test/test_kda_cute_forward.py
@@ -11,7 +11,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from attn_gym.linear.kda.constants import LOG2_E
+from attn_gym.linear.kda.constants import LOG2_E, MAX_GATE_LOWER_BOUND_MAGNITUDE
 from attn_gym.linear.kda.naive import chunk_cumsum_ref, naive_chunk_kda
 
 pytest.importorskip("cutlass")
@@ -159,6 +159,41 @@ def _packed_reference(
     return torch.cat(outputs, dim=1), torch.cat(states)
 
 
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_private_chunk_kda_forward_matches_reference(dtype: torch.dtype):
+    """Exercise native 16-bit forward factors without the public dtype normalization."""
+    torch.manual_seed(2)
+    q, k, v, gate, beta = _inputs(tokens=64, dtype=dtype)
+    cumulative_gate = chunk_cumsum_ref(gate * LOG2_E, 64)
+    actual, aqk, akk = _chunk_kda_fwd_op(q, k, v, cumulative_gate, beta, None, False)
+    golden, _ = naive_chunk_kda(
+        q.double(),
+        k.double(),
+        v.double(),
+        (gate * LOG2_E).double(),
+        beta.double(),
+        chunk_size=64,
+    )
+    reference, _ = naive_chunk_kda(q, k, v, gate * LOG2_E, beta, chunk_size=64)
+
+    assert actual.dtype == aqk.dtype == akk.dtype == dtype
+    _assert_golden(actual, golden, reference, dtype, f"private forward {dtype}")
+
+
+def test_private_fp16_forward_factors_are_finite_at_gate_limit():
+    """Keep the diagonal gate factorization within FP16 range at the public bound."""
+    torch.manual_seed(37)
+    q, k, v, _gate, beta = _inputs(tokens=64, dtype=torch.float16)
+    gate = torch.full_like(q, -MAX_GATE_LOWER_BOUND_MAGNITUDE, dtype=torch.float32)
+    cumulative_gate = chunk_cumsum_ref(gate * LOG2_E, 64)
+
+    output, aqk, akk = _chunk_kda_fwd_op(q, k, v, cumulative_gate, beta, None, False)
+
+    for tensor in (output, aqk, akk):
+        assert tensor.dtype == torch.float16
+        assert torch.isfinite(tensor).all()
+
+
 def test_optimized_chunk_kda_matches_reference():
     """Check forward values and the isolated final-state cotangent path."""
     torch.manual_seed(3)
@@ -195,6 +230,46 @@ def test_optimized_chunk_kda_matches_reference():
         error = (actual_gradient.float() - expected_gradient).abs().max()
         tolerance = 5e-3 + 5e-3 * expected_gradient.abs().max()
         assert error <= tolerance
+
+
+@pytest.mark.parametrize(("tokens", "packed"), [(128, False), (65, True)])
+def test_optimized_chunk_kda_fp16_training_matches_reference(tokens, packed):
+    """Exercise native FP16 dense and packed training with state gradients."""
+    torch.manual_seed(101)
+    inputs = _inputs(tokens=tokens, initial_state=True, dtype=torch.float16)
+    actual_inputs = _clone_inputs(inputs)
+    expected_inputs = _clone_inputs(inputs)
+    cu_seqlens = torch.tensor([0, tokens], device="cuda", dtype=torch.int32) if packed else None
+
+    actual, actual_state = chunk_kda(
+        *actual_inputs,
+        cu_seqlens=cu_seqlens,
+        output_final_state=True,
+        autotune=False,
+    )
+    expected, expected_state = chunk_kda(
+        *expected_inputs,
+        cu_seqlens=cu_seqlens,
+        output_final_state=True,
+        impl="reference",
+    )
+    assert actual_state is not None and expected_state is not None
+    actual_loss = actual.float().square().mean() + actual_state.square().mean()
+    expected_loss = expected.float().square().mean() + expected_state.square().mean()
+    actual_gradients = torch.autograd.grad(actual_loss, actual_inputs)
+    expected_gradients = torch.autograd.grad(expected_loss, expected_inputs)
+
+    assert actual.dtype == torch.float16
+    assert actual_state.dtype == torch.float32
+    torch.testing.assert_close(actual, expected, rtol=3e-2, atol=1e-3)
+    torch.testing.assert_close(actual_state, expected_state, rtol=3e-2, atol=1e-3)
+    for actual_gradient, expected_gradient in zip(
+        actual_gradients,
+        expected_gradients,
+        strict=True,
+    ):
+        assert torch.isfinite(actual_gradient).all()
+        torch.testing.assert_close(actual_gradient, expected_gradient, rtol=3e-2, atol=1e-3)
 
 
 def test_optimized_chunk_kda_accepts_strided_packed_qkv_views():
@@ -780,10 +855,11 @@ def test_delta_h_dispatch_counts_packed_sequences(monkeypatch):
     assert captured["metadata"] is metadata
 
 
-def test_chunk_kda_op_registration():
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_chunk_kda_op_registration(dtype):
     """Validate schema, fake tensors, and AOT dispatch for both raw forward operators."""
     torch.manual_seed(5)
-    q, k, v, gate, beta, initial_state = _inputs(initial_state=True)
+    q, k, v, gate, beta, initial_state = _inputs(initial_state=True, dtype=dtype)
     cumulative_gate = chunk_cumsum_ref(gate * LOG2_E, 64)
     q, k, v = _strided_qkv_views(q, k, v)
     # The raw operators are intentionally not differentiable; autograd lives in the
@@ -831,10 +907,11 @@ def test_chunk_kda_paged_op_registration():
     )
 
 
-def test_chunk_kda_backward_op_registration():
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_chunk_kda_backward_op_registration(dtype):
     """Validate the intentionally first-order backward operator registrations."""
     torch.manual_seed(6)
-    q, k, v, gate, beta, initial_state = _inputs(initial_state=True)
+    q, k, v, gate, beta, initial_state = _inputs(initial_state=True, dtype=dtype)
     cumulative_gate = chunk_cumsum_ref(gate * LOG2_E, 64)
     with torch.no_grad():
         _output, state, Aqk, Akk = _chunk_kda_fwd_with_state_op(
@@ -899,8 +976,9 @@ def test_chunk_kda_backward_op_registration():
         (torch.bfloat16, False, True),
         (torch.bfloat16, True, False),
         (torch.bfloat16, True, True),
+        (torch.float16, True, True),
     ],
-    ids=["fp32-output", "no-initial", "no-final", "initial-and-final"],
+    ids=["fp32-output", "no-initial", "no-final", "initial-and-final", "fp16"],
 )
 def test_chunk_kda_fullgraph_forward_and_backward(dtype, initial_state, output_final_state):
     """Capture the public operation and its registered backward as one strict graph."""
@@ -1094,10 +1172,11 @@ def test_chunk_kda_cuda_graph_replay():
         torch.testing.assert_close(actual_gradient, expected_gradient)
 
 
-def test_chunk_kda_packed_cuda_graph_replays_boundaries_and_backward():
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_chunk_kda_packed_cuda_graph_replays_boundaries_and_backward(dtype):
     """Replay packed metadata and gradients without capture-time host transfers."""
     torch.manual_seed(23)
-    inputs = _inputs(tokens=192, heads=2)
+    inputs = _inputs(tokens=192, heads=2, dtype=dtype)
     cu_seqlens = torch.tensor([0, 64, 192], device="cuda", dtype=torch.int32)
     warm_output, _ = chunk_kda(*inputs, cu_seqlens=cu_seqlens)
     warm_gradients = torch.autograd.grad(warm_output.float().sum(), inputs)

--- a/test/test_kda_gate_semantics.py
+++ b/test/test_kda_gate_semantics.py
@@ -251,18 +251,24 @@ def test_bound_gate_operator_registration():
     )
 
 
-def test_fused_chunk_gate_range_boundary_is_finite():
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_fused_chunk_gate_range_boundary_is_finite(dtype):
     """Exercise the strongest documented per-token decay accepted by the fused rebase."""
     torch.manual_seed(17)
     shape = (1, 64, 1, 128)
-    q = F.normalize(torch.randn(shape, device="cuda"), dim=-1).to(torch.bfloat16)
-    k = F.normalize(torch.randn(shape, device="cuda"), dim=-1).to(torch.bfloat16)
-    v = torch.randn(shape, device="cuda", dtype=torch.bfloat16)
-    gate = torch.full(shape, -MAX_GATE_LOWER_BOUND_MAGNITUDE, device="cuda")
-    beta = torch.rand(shape[:3], device="cuda")
+    inputs = (
+        F.normalize(torch.randn(shape, device="cuda"), dim=-1).to(dtype),
+        F.normalize(torch.randn(shape, device="cuda"), dim=-1).to(dtype),
+        torch.randn(shape, device="cuda", dtype=dtype),
+        torch.full(shape, -MAX_GATE_LOWER_BOUND_MAGNITUDE, device="cuda"),
+        torch.rand(shape[:3], device="cuda"),
+    )
+    inputs = tuple(tensor.requires_grad_() for tensor in inputs)
 
-    output, _ = chunk_kda(q, k, v, gate, beta, autotune=False)
+    output, _ = chunk_kda(*inputs, autotune=False)
+    gradients = torch.autograd.grad(output.float().square().mean(), inputs)
     assert torch.isfinite(output).all()
+    assert all(torch.isfinite(gradient).all() for gradient in gradients)
 
 
 def test_plain_gate_scan_accepts_strided_dense_input():

--- a/test/test_kda_ragged_bwd_intra.py
+++ b/test/test_kda_ragged_bwd_intra.py
@@ -30,11 +30,11 @@ def _metadata(lengths: list[int]):
     return prepare_ragged_chunk_metadata(offsets, sum(lengths), 64)
 
 
-def _inputs(tokens: int) -> tuple[torch.Tensor, ...]:
+def _inputs(tokens: int, dtype: torch.dtype = torch.bfloat16) -> tuple[torch.Tensor, ...]:
     """Create deterministic standalone inputs for the intra backward stage."""
     torch.manual_seed(29)
     shape = (1, tokens, 1, 128)
-    q = torch.randn(shape, device="cuda", dtype=torch.bfloat16) / 8
+    q = torch.randn(shape, device="cuda", dtype=dtype) / 8
     k = torch.randn_like(q) / 8
     g = -torch.rand(shape, device="cuda")
     beta = torch.rand(1, tokens, 1, device="cuda")
@@ -75,9 +75,10 @@ def _sequence_local_reference(
     return tuple(torch.cat(parts, dim=1) for parts in output_parts)
 
 
-def test_ragged_bwd_intra_matches_independent_numerical_reference():
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_ragged_bwd_intra_matches_independent_numerical_reference(dtype: torch.dtype):
     lengths = [65, 0, 63]
-    inputs = list(_inputs(sum(lengths)))
+    inputs = list(_inputs(sum(lengths), dtype))
     cu_seqlens = cumulative_sequence_offsets(lengths)
     chunk_routes = torch.tensor(
         [
@@ -121,7 +122,7 @@ def test_ragged_bwd_intra_matches_independent_numerical_reference():
             inputs[8].to(db.dtype) + db,
         )
         if reference:
-            return (outputs[0].to(torch.bfloat16), outputs[1].to(torch.bfloat16), *outputs[2:])
+            return (outputs[0].to(dtype), outputs[1].to(dtype), *outputs[2:])
         return outputs
 
     golden = combine(golden_contribution, reference=False)
@@ -130,7 +131,13 @@ def test_ragged_bwd_intra_matches_independent_numerical_reference():
         ("dq", "dk", "dg", "db"), actual, golden, reference, strict=True
     ):
         assert torch.isfinite(output).all()
-        assert_matches_low_precision_reference(output, golden_output, reference_output, name)
+        assert_matches_low_precision_reference(
+            output,
+            golden_output,
+            reference_output,
+            name,
+            source_dtype=dtype,
+        )
 
 
 def test_ragged_bwd_intra_rejects_mismatched_chunk_size():

--- a/test/test_kda_ragged_bwd_wy.py
+++ b/test/test_kda_ragged_bwd_wy.py
@@ -39,25 +39,29 @@ class StageInputs(NamedTuple):
     dv: torch.Tensor
 
 
-def _inputs(tokens: int, capacity: int) -> StageInputs:
+def _inputs(
+    tokens: int,
+    capacity: int,
+    dtype: torch.dtype = torch.bfloat16,
+) -> StageInputs:
     torch.manual_seed(37)
     shape = (1, tokens, 1, 128)
 
-    def bf16(shape: tuple[int, ...]) -> torch.Tensor:
-        return torch.randn(shape, device="cuda", dtype=torch.bfloat16) / 8
+    def rand16(shape: tuple[int, ...]) -> torch.Tensor:
+        return torch.randn(shape, device="cuda", dtype=dtype) / 8
 
     return StageInputs(
-        q=bf16(shape),
-        k=bf16(shape),
-        v=bf16(shape),
-        v_new=bf16(shape),
+        q=rand16(shape),
+        k=rand16(shape),
+        v=rand16(shape),
+        v_new=rand16(shape),
         g=-torch.rand(shape, device="cuda"),
         beta=torch.rand(1, tokens, 1, device="cuda"),
-        A=bf16((1, tokens, 1, 64)),
-        h=bf16((1, capacity, 1, 128, 128)),
-        do=bf16(shape),
-        dh=bf16((1, capacity, 1, 128, 128)),
-        dv=bf16(shape),
+        A=rand16((1, tokens, 1, 64)),
+        h=rand16((1, capacity, 1, 128, 128)),
+        do=rand16(shape),
+        dh=rand16((1, capacity, 1, 128, 128)),
+        dv=rand16(shape),
     )
 
 
@@ -97,7 +101,8 @@ def _sequence_local_reference(inputs: StageInputs, lengths: list[int]):
     return tuple(torch.cat(parts, dim=1) for parts in output_parts)
 
 
-def test_ragged_wy_matches_independent_numerical_reference():
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_ragged_wy_matches_independent_numerical_reference(dtype):
     lengths = [65, 0, 63]
     cu_seqlens = cumulative_sequence_offsets(lengths)
     chunk_routes = torch.tensor(
@@ -110,7 +115,7 @@ def test_ragged_wy_matches_independent_numerical_reference():
         dtype=torch.int64,
     )
     metadata = prepare_ragged_chunk_metadata(cu_seqlens, sum(lengths), 64)
-    inputs = _inputs(sum(lengths), metadata.capacity)
+    inputs = _inputs(sum(lengths), metadata.capacity, dtype)
     actual = _run(inputs, metadata)
     reference_args = inputs[3:]
     scale = 128**-0.5
@@ -138,7 +143,13 @@ def test_ragged_wy_matches_independent_numerical_reference():
     for name, output, golden_output, reference_output in zip(
         names, actual, golden, reference, strict=True
     ):
-        assert_matches_low_precision_reference(output, golden_output, reference_output, name)
+        assert_matches_low_precision_reference(
+            output,
+            golden_output,
+            reference_output,
+            name,
+            source_dtype=dtype,
+        )
 
 
 def test_ragged_wy_rejects_mismatched_chunk_size():

--- a/test/test_kda_ragged_delta_h_bwd.py
+++ b/test/test_kda_ragged_delta_h_bwd.py
@@ -27,14 +27,15 @@ def _inputs(
     sequences: int,
     heads: int = 1,
     lengths: list[int] | None = None,
+    dtype: torch.dtype = torch.bfloat16,
 ) -> tuple[torch.Tensor, ...]:
     torch.manual_seed(37)
     shape = (1, tokens, heads, 128)
-    q = torch.randn(shape, device="cuda", dtype=torch.bfloat16) / 8
+    q = torch.randn(shape, device="cuda", dtype=dtype) / 8
     k = torch.randn_like(q) / 8
     w = torch.randn_like(q) / 8
     do = torch.randn_like(q) / 8
-    aqk = torch.randn(1, tokens, heads, 64, device="cuda", dtype=torch.bfloat16) / 8
+    aqk = torch.randn(1, tokens, heads, 64, device="cuda", dtype=dtype) / 8
     begin = 0
     for sequence_length in lengths or [tokens]:
         for offset in range(0, sequence_length, 64):
@@ -155,9 +156,10 @@ def test_ragged_delta_h_rejects_mismatched_chunk_size():
         )
 
 
-def test_ragged_delta_h_matches_independent_sequences():
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_ragged_delta_h_matches_independent_sequences(dtype: torch.dtype):
     lengths = [65, 0, 63]
-    inputs = _inputs(sum(lengths), len(lengths), lengths=lengths)
+    inputs = _inputs(sum(lengths), len(lengths), lengths=lengths, dtype=dtype)
     dh, dh0, dv = _run_ragged(inputs, lengths)
 
     expected_dh = []

--- a/test/test_kda_ragged_forward_stages.py
+++ b/test/test_kda_ragged_forward_stages.py
@@ -23,12 +23,13 @@ def _metadata(lengths: list[int]):
     return prepare_ragged_chunk_metadata(offsets, sum(lengths), 64)
 
 
-def test_ragged_forward_stages_match_independent_sequences():
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_ragged_forward_stages_match_independent_sequences(dtype: torch.dtype):
     torch.manual_seed(13)
     lengths = [65, 0, 63]
     tokens = sum(lengths)
     shape = (1, tokens, 1, 128)
-    q = torch.randn(shape, device="cuda", dtype=torch.bfloat16) / 8
+    q = torch.randn(shape, device="cuda", dtype=dtype) / 8
     k = torch.randn_like(q) / 8
     v = torch.randn_like(q) / 8
     gk = -torch.rand(shape, device="cuda")
@@ -60,11 +61,12 @@ def test_ragged_forward_stages_match_independent_sequences():
         torch.testing.assert_close(packed, expected, rtol=0, atol=0)
 
 
-def test_ragged_forward_stages_replay_aligned_to_ragged():
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_ragged_forward_stages_replay_aligned_to_ragged(dtype: torch.dtype):
     torch.manual_seed(17)
     tokens = 128
     shape = (1, tokens, 1, 128)
-    q = torch.randn(shape, device="cuda", dtype=torch.bfloat16) / 8
+    q = torch.randn(shape, device="cuda", dtype=dtype) / 8
     k = torch.randn_like(q) / 8
     v = torch.randn_like(q) / 8
     gk = -torch.rand(shape, device="cuda")

--- a/test/test_kda_training_example.py
+++ b/test/test_kda_training_example.py
@@ -190,8 +190,9 @@ def test_kda_example_marks_cuda_graph_kernel_stages(monkeypatch):
     ]
 
 
-def test_kda_example_packed_matches_sequence_for_loop(monkeypatch):
-    """Match one packed execution against independent sequence calls."""
+@pytest.mark.parametrize("compute_dtype", [torch.bfloat16, torch.float16])
+def test_kda_example_packed_matches_sequence_for_loop(monkeypatch, compute_dtype):
+    """Match packed BF16/FP16 training against independent sequence calls."""
     fused_calls = {"short_conv": 0, "l2norm": 0, "gate": 0, "core": 0}
     short_conv = kda_training.causal_conv1d
     fused_l2norm = kda_training.l2norm
@@ -224,6 +225,7 @@ def test_kda_example_packed_matches_sequence_for_loop(monkeypatch):
         num_heads=1,
         head_dim=128,
         backend="fused",
+        compute_dtype=compute_dtype,
         device="cuda",
     )
     offsets = (0, 65, 65, 128)


### PR DESCRIPTION
## Human Note

## Agent note

Keep homogeneous FP16 Q/K/V in FP16 across the composed KDA forward and backward instead of
normalizing the complete private ABI to BF16. The FP16 forward uses the FP32/TF32 diagonal factor
path where strip-rebased FP16 operands can overflow; FP32 and mixed-dtype callers retain the
existing BF16 normalization.

The backward kernels select FP16 tcgen05 descriptors and use native CuTeDSL/TensorSSA for ordinary
conversion and synchronization operations. The WY kernel also drops roughly 1,500 lines of unused
masked/TF32/TS helper-library surface while preserving the source attribution.

FP16 has less exponent range than BF16. The documentation recommends L2-normalized or otherwise
bounded Q/K, as used by the training example: intermediate GEMMs accumulate in FP32, but their
results are converted back to FP16 when consumed by the next GEMM.

## Performance

B200 public `chunk_kda` forward plus autograd, fixed warm tensors, CUDA Graph replay,
`autotune=False`:

| Workload | BF16-bridge baseline | Native FP16 | Change |
| --- | ---: | ---: | ---: |
| T1024/H16 | 248.039 us | 194.274 us | -21.7% |
| packed `[65,1024,4096,0,127]`/H16 | 1128.815 us | 912.489 us | -19.2% |
| T8192/H64 | 4969.449 us | 3729.254 us | -25.0% |

BF16 T8192/H64 remained stable: 3572.415 us before and 3570.097 us after (-0.065%).

## Test Plan

```bash
pytest -n 6 -q  # 974 passed, 1 skipped
prek --all-files
mkdocs build --strict

gpu-run auto -- cutracer trace \
  --cutracer-so ~/.cache/cutracer/current/lib/cutracer.so \
  -a random_delay --delay-ns 20000 --delay-enable-prob 1.0 \
  --delay-dump-path agent_space/cutracer_fp16_wy_stress/delay.json \
  -k ChunkKdaBwdWyDqkgFused -- \
  pytest -q 'test/test_kda_ragged_bwd_wy.py::test_ragged_wy_matches_independent_numerical_reference[dtype1]'
```
