### PR TITLE
Fix KDA CI test regressions

### DIFF
--- a/test/test_kda_ragged_recurrence.py
+++ b/test/test_kda_ragged_recurrence.py
@@ -134,6 +134,8 @@ def _run_persistent_overflow_case(
     final_state = torch.empty_like(inputs[-1])
     h, v_new = _delta_h_launch(
         *inputs,
+        None,
+        None,
         metadata.cu_seqlens,
         metadata.chunk_offsets,
         metadata.capacity,
@@ -392,6 +394,8 @@ def test_ragged_recurrence_persistent_cuda_graph_replays_active_sequences(
         u,
         gk,
         initial_state,
+        None,
+        None,
         expected_metadata.cu_seqlens,
         expected_metadata.chunk_offsets,
         expected_metadata.capacity,

--- a/test/test_kda_recurrent_decode.py
+++ b/test/test_kda_recurrent_decode.py
@@ -476,6 +476,7 @@ def test_recurrent_decode_fullgraph_compile(gate_transform: str, use_out: bool):
 
 
 def test_recurrent_decode_fullgraph_dynamic_batch():
+    torch.compiler.reset()
     with torch._dynamo.config.patch(error_on_recompile=True):
         compiled = torch.compile(recurrent_kda_decode, fullgraph=True, dynamic=True)
         for batch in (2, 3):


### PR DESCRIPTION
## Human Note

## Agent note

Update direct delta-H launcher tests for the paging arguments added to the private launcher. Reset
Dynamo before the dynamic-batch no-recompile assertion so earlier compile tests in the same worker
do not pollute its process-global frame cache.

## Test Plan

```bash
gpu-run --timeout 30 auto -- env PYTHONPATH="$PWD" .venv/bin/python -m pytest -q test/test_kda_ragged_recurrence.py test/test_kda_recurrent_decode.py
.venv/bin/ruff check test/test_kda_ragged_recurrence.py test/test_kda_recurrent_decode.py
.venv/bin/ruff format --check test/test_kda_ragged_recurrence.py test/test_kda_recurrent_decode.py
git diff --check
```
