### PR TITLE
Align GDN with KDA API conventions

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -140,19 +140,8 @@ streaming should accept an initial state and optionally return a final state. Th
 - activation checkpointing policies;
 - serving-framework adapters.
 
-The initial proposal is a generic structured result:
-
-```python
-StateT = TypeVar("StateT")
-
-
-@dataclass
-class LinearAttentionOutput(Generic[StateT]):
-    output: torch.Tensor
-    final_state: StateT | None = None
-```
-
-The concrete state type may be a tensor or a variant-specific dataclass.
+Chunked and recurrent operations return ``(output, final_state)``. The state is ``None`` unless
+``output_final_state=True``; paged operations instead update their explicit cache in place.
 
 ### Reference implementations define correctness
 
@@ -459,20 +448,20 @@ use a custom sparse kernel.
 
 ### Inputs and layout
 
-Fixed-length public APIs use the SDPA/FlexAttention layout:
+Fixed-length public linear-attention APIs use the token-major layout:
 
 ```text
-[batch, heads, sequence, dimension]
+[batch, sequence, heads, dimension]
 ```
 
-Packed variable-length inputs use:
+Packed variable-length inputs use batch-one storage with tokens concatenated along the sequence
+axis:
 
 ```text
-[total_tokens, heads, dimension]
+[1, total_tokens, heads, dimension]
 ```
 
-where `total_tokens` is the sum of all sequence lengths. Backends may transpose internally, but
-public callers should not need backend-specific layouts. Outputs follow the corresponding input
+where `total_tokens` is the sum of all sequence lengths. Outputs follow the corresponding input
 layout.
 
 ### Execution form
@@ -501,7 +490,7 @@ local dispatch rather than a general capability solver.
 ### Variable-length inputs
 
 Variable-length support is part of the intended base contract rather than an optional follow-up.
-Packed inputs use `[total_tokens, heads, dimension]` tensors with cumulative sequence lengths:
+Packed inputs use `[1, total_tokens, heads, dimension]` tensors with cumulative sequence lengths:
 
 ```python
 cu_seqlens: torch.Tensor | None = None
@@ -513,16 +502,9 @@ unless required.
 
 ### Outputs and recurrent state
 
-The public API should always return a structured result rather than switch between a tensor and tuple
-based on `return_final_state`. A stable result shape is easier to compose and extend:
-
-```python
-result.output
-result.final_state
-```
-
-The cost is a small departure from existing operator conventions. This should be validated with the
-first TorchTitan integration before being finalized.
+Chunked and recurrent operations return ``(output, final_state)``. The state is ``None`` unless
+``output_final_state=True``. This matches the KDA operations and keeps state-carrying execution
+explicit without introducing a variant-specific result wrapper.
 
 ### Layers versus functional operators
 

--- a/attn_gym/linear/__init__.py
+++ b/attn_gym/linear/__init__.py
@@ -9,7 +9,7 @@
 import importlib
 from typing import TYPE_CHECKING
 
-from attn_gym.linear.gdn import GatedDeltaRuleOutput, chunk_gdn, recurrent_gdn
+from attn_gym.linear.gdn import chunk_gdn, recurrent_gdn
 from attn_gym.linear.kda import (
     active_token_mask,
     chunk_kda,
@@ -40,7 +40,6 @@ KDA_OPS = [
 ]
 
 GDN_OPS = [
-    "GatedDeltaRuleOutput",
     "chunk_gdn",
     "recurrent_gdn",
 ]

--- a/attn_gym/linear/gdn/__init__.py
+++ b/attn_gym/linear/gdn/__init__.py
@@ -1,5 +1,5 @@
 """Gated delta rule attention."""
 
-from attn_gym.linear.gdn.api import GatedDeltaRuleOutput, chunk_gdn, recurrent_gdn
+from attn_gym.linear.gdn.api import chunk_gdn, recurrent_gdn
 
-__all__ = ["GatedDeltaRuleOutput", "chunk_gdn", "recurrent_gdn"]
+__all__ = ["chunk_gdn", "recurrent_gdn"]

--- a/attn_gym/linear/gdn/api.py
+++ b/attn_gym/linear/gdn/api.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-from functools import partial
-from typing import NamedTuple
-
 import torch
 
 from attn_gym.linear.gdn.impl.reference import (
@@ -16,124 +13,109 @@ from attn_gym.linear.gdn.validation import validate_gdn_inputs
 from attn_gym.linear.types import Impl, resolve_impl
 
 
-class GatedDeltaRuleOutput(NamedTuple):
-    """Output and optional recurrent state from a gated delta rule operation."""
-
-    output: torch.Tensor
-    final_state: torch.Tensor | None = None
-
-
 def chunk_gdn(
-    query: torch.Tensor,
-    key: torch.Tensor,
-    value: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
     gate: torch.Tensor,
     beta: torch.Tensor,
+    initial_state: torch.Tensor | None = None,
     *,
     scale: float | None = None,
-    initial_state: torch.Tensor | None = None,
-    return_final_state: bool = False,
-    chunk_size: int = 64,
+    output_final_state: bool = False,
     impl: Impl | str = Impl.REFERENCE,
-) -> GatedDeltaRuleOutput:
+) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Apply chunk-parallel gated delta rule attention for training and prefill.
 
-    Inputs use the SDPA layout ``[batch, heads, sequence, dimension]``. The scalar natural-log gate
-    decays the previous state before each beta-scaled delta update, and the query reads the updated
-    state. Chunking changes only the decomposition and floating-point order of that recurrence.
-    FP16 and BF16 inputs use FP32 recurrence math and state.
+    Inputs use the token-major layout ``[batch, sequence, heads, dimension]``. The scalar
+    natural-log gate decays the previous state before each beta-scaled delta update, and the query
+    reads the updated state. Chunking changes only the decomposition and floating-point order of
+    that recurrence. FP16 and BF16 inputs use FP32 recurrence math and state.
 
     Args:
-        query: Query tensor with shape ``[B, H, T, K]``.
-        key: Key tensor with shape ``[B, H, T, K]`` and the same dtype as ``query``.
-        value: Value tensor with shape ``[B, H, T, V]`` and the same dtype as ``query``.
-        gate: Floating per-token scalar natural-log decay with shape ``[B, H, T]``.
-        beta: Floating per-token write gate with shape ``[B, H, T]``.
+        q: Queries shaped ``[B, T, H, K]``.
+        k: Keys shaped like ``q`` and using the same dtype.
+        v: Values shaped ``[B, T, H, V]`` and using the same dtype as ``q``.
+        gate: Floating per-token scalar natural-log decay shaped ``[B, T, H]``.
+        beta: Floating per-token write gate shaped ``[B, T, H]``.
+        initial_state: Initial recurrent state shaped ``[B, H, K, V]`` in the recurrence compute
+            dtype (FP32 for FP16/BF16 QKV).
         scale: Query scale. Defaults to ``1 / sqrt(K)``.
-        initial_state: Initial recurrent state with shape ``[B, H, K, V]`` and the recurrence
-            compute dtype (FP32 for FP16/BF16 QKV).
-        return_final_state: Include the final recurrent state in the result.
-        chunk_size: Number of tokens per chunk.
+        output_final_state: Return the final recurrent state with the output.
         impl: ``"reference"`` uses eager PyTorch. ``"fused"`` is reserved for the optimized
             backend and currently raises ``NotImplementedError``.
 
     Returns:
-        The attention output in ``query.dtype`` and, when requested, the final recurrent state in
-        the recurrence compute dtype.
+        The output in ``q.dtype`` and either the final recurrent state or ``None``.
     """
     selected_impl = resolve_impl(impl)
-    validate_gdn_inputs(query, key, value, gate, beta, initial_state)
-    if chunk_size <= 0:
-        raise ValueError(f"chunk_size must be greater than zero, got {chunk_size}")
+    validate_gdn_inputs(q, k, v, gate, beta, initial_state)
     if selected_impl is Impl.FUSED:
         raise NotImplementedError("chunk_gdn impl='fused' is not implemented yet")
 
-    output, final_state = reference_gdn(
-        partial(chunk_forward, chunk_size=chunk_size),
-        query,
-        key,
-        value,
+    return reference_gdn(
+        chunk_forward,
+        q,
+        k,
+        v,
         gate,
         beta,
         scale=scale,
         initial_state=initial_state,
-        return_final_state=return_final_state,
+        output_final_state=output_final_state,
     )
-    return GatedDeltaRuleOutput(output=output, final_state=final_state)
 
 
 def recurrent_gdn(
-    query: torch.Tensor,
-    key: torch.Tensor,
-    value: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
     gate: torch.Tensor,
     beta: torch.Tensor,
+    initial_state: torch.Tensor | None = None,
     *,
     scale: float | None = None,
-    initial_state: torch.Tensor | None = None,
-    return_final_state: bool = False,
+    output_final_state: bool = False,
     impl: Impl | str = Impl.REFERENCE,
-) -> GatedDeltaRuleOutput:
+) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Apply recurrent gated delta rule attention for decoding and inference prefill.
 
     The recurrence consumes tokens in order, carrying an explicit ``[B, H, K, V]`` state. Inputs
-    and outputs use the SDPA layout ``[batch, heads, sequence, dimension]``. FP16 and BF16 inputs use
-    FP32 recurrence math and state.
+    and outputs use the token-major layout ``[batch, sequence, heads, dimension]``. FP16 and BF16
+    inputs use FP32 recurrence math and state.
 
     Args:
-        query: Query tensor with shape ``[B, H, T, K]``.
-        key: Key tensor with shape ``[B, H, T, K]`` and the same dtype as ``query``.
-        value: Value tensor with shape ``[B, H, T, V]`` and the same dtype as ``query``.
-        gate: Floating per-token scalar natural-log decay with shape ``[B, H, T]``.
-        beta: Floating per-token write gate with shape ``[B, H, T]``.
+        q: Queries shaped ``[B, T, H, K]``.
+        k: Keys shaped like ``q`` and using the same dtype.
+        v: Values shaped ``[B, T, H, V]`` and using the same dtype as ``q``.
+        gate: Floating per-token scalar natural-log decay shaped ``[B, T, H]``.
+        beta: Floating per-token write gate shaped ``[B, T, H]``.
+        initial_state: Initial recurrent state shaped ``[B, H, K, V]`` in the recurrence compute
+            dtype (FP32 for FP16/BF16 QKV).
         scale: Query scale. Defaults to ``1 / sqrt(K)``.
-        initial_state: Initial recurrent state with shape ``[B, H, K, V]`` and the recurrence
-            compute dtype (FP32 for FP16/BF16 QKV).
-        return_final_state: Include the final recurrent state in the result.
+        output_final_state: Return the final recurrent state with the output.
         impl: ``"reference"`` uses eager PyTorch. ``"fused"`` is reserved for the optimized
             backend and currently raises ``NotImplementedError``.
 
     Returns:
-        The attention output in ``query.dtype`` and, when requested, the final recurrent state in
-        the recurrence compute dtype.
+        The output in ``q.dtype`` and either the final recurrent state or ``None``.
     """
     selected_impl = resolve_impl(impl)
-    validate_gdn_inputs(query, key, value, gate, beta, initial_state)
+    validate_gdn_inputs(q, k, v, gate, beta, initial_state)
     if selected_impl is Impl.FUSED:
         raise NotImplementedError("recurrent_gdn impl='fused' is not implemented yet")
 
-    output, final_state = reference_gdn(
+    return reference_gdn(
         recurrent_forward,
-        query,
-        key,
-        value,
+        q,
+        k,
+        v,
         gate,
         beta,
         scale=scale,
         initial_state=initial_state,
-        return_final_state=return_final_state,
+        output_final_state=output_final_state,
     )
-    return GatedDeltaRuleOutput(output=output, final_state=final_state)
 
 
-__all__ = ["GatedDeltaRuleOutput", "chunk_gdn", "recurrent_gdn"]
+__all__ = ["chunk_gdn", "recurrent_gdn"]

--- a/attn_gym/linear/gdn/impl/reference.py
+++ b/attn_gym/linear/gdn/impl/reference.py
@@ -5,137 +5,136 @@ from __future__ import annotations
 import torch
 import torch.nn.functional as F
 
+_CHUNK_SIZE = 64
+
 
 def reference_gdn(
     dense_op,
-    query: torch.Tensor,
-    key: torch.Tensor,
-    value: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
     log_decay: torch.Tensor,
     beta: torch.Tensor,
     *,
     scale: float | None,
     initial_state: torch.Tensor | None,
-    return_final_state: bool,
+    output_final_state: bool,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Run a dense GDN reference operation in the documented compute dtype."""
-    output_dtype = query.dtype
-    compute_dtype = torch.promote_types(query.dtype, torch.float32)
-    query, key, value, log_decay, beta = (
-        tensor.to(compute_dtype) for tensor in (query, key, value, log_decay, beta)
-    )
+    output_dtype = q.dtype
+    compute_dtype = torch.promote_types(q.dtype, torch.float32)
+    q, k, v, log_decay, beta = (tensor.to(compute_dtype) for tensor in (q, k, v, log_decay, beta))
     # Explicit casts do not stop autocast from selecting low-precision contractions.
-    with torch.autocast(device_type=query.device.type, enabled=False):
+    with torch.autocast(device_type=q.device.type, enabled=False):
         output, state = dense_op(
-            query,
-            key,
-            value,
+            q,
+            k,
+            v,
             log_decay,
             beta,
             scale=scale,
             initial_state=initial_state,
-            return_final_state=return_final_state,
+            output_final_state=output_final_state,
         )
     return output.to(output_dtype), state
 
 
 def recurrent_forward(
-    query: torch.Tensor,
-    key: torch.Tensor,
-    value: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
     log_decay: torch.Tensor,
     beta: torch.Tensor,
     *,
     scale: float | None,
     initial_state: torch.Tensor | None,
-    return_final_state: bool,
+    output_final_state: bool,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Evaluate the gated delta rule recurrence one token at a time."""
-    batch, heads, sequence, key_dimension = query.shape
-    query = query * (key_dimension**-0.5 if scale is None else scale)
+    batch, sequence, heads, key_dim = q.shape
+    q = q * (key_dim**-0.5 if scale is None else scale)
     state = (
-        query.new_zeros(batch, heads, key_dimension, value.shape[-1])
-        if initial_state is None
-        else initial_state
+        q.new_zeros(batch, heads, key_dim, v.shape[-1]) if initial_state is None else initial_state
     )
     outputs = []
 
     for token in range(sequence):
-        state = state * log_decay[:, :, token].exp()[..., None, None]
-        residual = value[:, :, token] - torch.einsum("bhk,bhkv->bhv", key[:, :, token], state)
-        residual = residual * beta[:, :, token, None]
-        state = state + torch.einsum("bhk,bhv->bhkv", key[:, :, token], residual)
-        outputs.append(torch.einsum("bhk,bhkv->bhv", query[:, :, token], state))
+        state = state * log_decay[:, token].exp()[..., None, None]
+        residual = v[:, token] - torch.einsum("bhk,bhkv->bhv", k[:, token], state)
+        residual = residual * beta[:, token, :, None]
+        state = state + torch.einsum("bhk,bhv->bhkv", k[:, token], residual)
+        outputs.append(torch.einsum("bhk,bhkv->bhv", q[:, token], state))
 
-    return torch.stack(outputs, dim=2), state if return_final_state else None
+    return torch.stack(outputs, dim=1), state if output_final_state else None
 
 
 def chunk_forward(
-    query: torch.Tensor,
-    key: torch.Tensor,
-    value: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
     log_decay: torch.Tensor,
     beta: torch.Tensor,
     *,
     scale: float | None,
     initial_state: torch.Tensor | None,
-    return_final_state: bool,
-    chunk_size: int,
+    output_final_state: bool,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
-    """Evaluate the gated delta rule with a naive chunk-parallel decomposition."""
-    batch, heads, sequence, key_dimension = query.shape
-    value_dimension = value.shape[-1]
-    scale = key_dimension**-0.5 if scale is None else scale
-    padding = (-sequence) % chunk_size
+    """Evaluate the gated delta rule with the fixed chunk-parallel decomposition."""
+    batch, sequence, heads, key_dim = q.shape
+    value_dim = v.shape[-1]
+    scale = key_dim**-0.5 if scale is None else scale
+    padding = (-sequence) % _CHUNK_SIZE
     if padding:
-        query, key, value = (F.pad(tensor, (0, 0, 0, padding)) for tensor in (query, key, value))
-        beta, log_decay = (F.pad(tensor, (0, padding)) for tensor in (beta, log_decay))
+        q, k, v = (F.pad(tensor, (0, 0, 0, 0, 0, padding)) for tensor in (q, k, v))
+        beta, log_decay = (F.pad(tensor, (0, 0, 0, padding)) for tensor in (beta, log_decay))
 
-    padded_length = query.shape[-2]
-    chunk_count = padded_length // chunk_size
-    query = query * scale
-    value = value * beta[..., None]
-    beta_key = key * beta[..., None]
+    padded_length = q.shape[1]
+    chunk_count = padded_length // _CHUNK_SIZE
+    q = q * scale
+    v = v * beta[..., None]
+    beta_key = k * beta[..., None]
 
-    query, key, value, beta_key = (
-        tensor.reshape(batch, heads, chunk_count, chunk_size, tensor.shape[-1])
-        for tensor in (query, key, value, beta_key)
+    q, k, v, beta_key = (
+        tensor.reshape(batch, chunk_count, _CHUNK_SIZE, heads, tensor.shape[-1]).permute(
+            0, 3, 1, 2, 4
+        )
+        for tensor in (q, k, v, beta_key)
     )
-    cumulative_decay = log_decay.reshape(batch, heads, chunk_count, chunk_size).cumsum(-1)
+    cumulative_decay = (
+        log_decay.reshape(batch, chunk_count, _CHUNK_SIZE, heads).permute(0, 3, 1, 2).cumsum(-1)
+    )
 
     decay_matrix = (
         (cumulative_decay.unsqueeze(-1) - cumulative_decay.unsqueeze(-2)).tril().exp().tril()
     )
     diagonal_and_upper = torch.triu(
-        torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=query.device)
+        torch.ones(_CHUNK_SIZE, _CHUNK_SIZE, dtype=torch.bool, device=q.device)
     )
-    transition = -((beta_key @ key.transpose(-1, -2)) * decay_matrix).masked_fill(
+    transition = -((beta_key @ k.transpose(-1, -2)) * decay_matrix).masked_fill(
         diagonal_and_upper, 0
     )
 
-    for row in range(1, chunk_size):
+    for row in range(1, _CHUNK_SIZE):
         transition[..., row, :row] = transition[..., row, :row].clone() + (
             transition[..., row, :row, None].clone() * transition[..., :row, :row].clone()
         ).sum(-2)
 
-    transition = transition + torch.eye(chunk_size, dtype=query.dtype, device=query.device)
-    value = transition @ value
+    transition = transition + torch.eye(_CHUNK_SIZE, dtype=q.dtype, device=q.device)
+    v = transition @ v
     decayed_key = transition @ (beta_key * cumulative_decay.exp()[..., None])
 
     state = (
-        query.new_zeros(batch, heads, key_dimension, value_dimension)
-        if initial_state is None
-        else initial_state
+        q.new_zeros(batch, heads, key_dim, value_dim) if initial_state is None else initial_state
     )
-    output = torch.zeros_like(value)
+    output = torch.zeros_like(v)
     strictly_upper = torch.triu(
-        torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=query.device), diagonal=1
+        torch.ones(_CHUNK_SIZE, _CHUNK_SIZE, dtype=torch.bool, device=q.device), diagonal=1
     )
 
     for chunk in range(chunk_count):
-        chunk_query = query[:, :, chunk]
-        chunk_key = key[:, :, chunk]
-        chunk_value = value[:, :, chunk]
+        chunk_query = q[:, :, chunk]
+        chunk_key = k[:, :, chunk]
+        chunk_value = v[:, :, chunk]
         attention = (
             (chunk_query @ chunk_key.transpose(-1, -2)) * decay_matrix[:, :, chunk]
         ).masked_fill(strictly_upper, 0)
@@ -152,8 +151,8 @@ def chunk_forward(
             @ corrected_value
         )
 
-    output = output.reshape(batch, heads, padded_length, value_dimension)[:, :, :sequence]
-    return output, state if return_final_state else None
+    output = output.permute(0, 2, 3, 1, 4).reshape(batch, padded_length, heads, value_dim)
+    return output[:, :sequence], state if output_final_state else None
 
 
 __all__ = ["chunk_forward", "recurrent_forward", "reference_gdn"]

--- a/attn_gym/linear/gdn/validation.py
+++ b/attn_gym/linear/gdn/validation.py
@@ -6,53 +6,49 @@ import torch
 
 
 def validate_gdn_inputs(
-    query: torch.Tensor,
-    key: torch.Tensor,
-    value: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
     gate: torch.Tensor,
     beta: torch.Tensor,
     initial_state: torch.Tensor | None,
 ) -> None:
     """Validate backend-independent gated delta rule tensor invariants."""
-    if query.ndim != 4 or key.ndim != 4 or value.ndim != 4:
+    if q.ndim != 4:
+        raise ValueError(f"q must have shape [B, T, H, K], got {tuple(q.shape)}")
+    batch, tokens, heads, key_dim = q.shape
+    if batch == 0 or tokens == 0 or heads == 0 or key_dim == 0:
+        raise ValueError(f"q must have nonempty dimensions, got {tuple(q.shape)}")
+    if k.shape != q.shape:
+        raise ValueError(f"k must have shape {tuple(q.shape)}, got {tuple(k.shape)}")
+    if v.ndim != 4 or v.shape[:3] != (batch, tokens, heads) or v.shape[-1] == 0:
         raise ValueError(
-            "query, key, and value must have shape [batch, heads, sequence, dimension]"
+            f"v must have shape [{batch}, {tokens}, {heads}, V], got {tuple(v.shape)}"
         )
-    if gate.ndim != 3 or beta.ndim != 3:
-        raise ValueError("gate and beta must have shape [batch, heads, sequence]")
-    if query.shape != key.shape:
-        raise ValueError(
-            f"query and key must have the same shape, got {query.shape} and {key.shape}"
-        )
+    if gate.shape != (batch, tokens, heads):
+        raise ValueError(f"gate must have shape {(batch, tokens, heads)}, got {tuple(gate.shape)}")
+    if beta.shape != (batch, tokens, heads):
+        raise ValueError(f"beta must have shape {(batch, tokens, heads)}, got {tuple(beta.shape)}")
 
-    batch, heads, sequence, key_dimension = query.shape
-    if sequence == 0:
-        raise ValueError("sequence length must be greater than zero")
-    if value.shape[:3] != (batch, heads, sequence):
-        raise ValueError("value must match query in its batch, head, and sequence dimensions")
-    if gate.shape != (batch, heads, sequence) or beta.shape != (batch, heads, sequence):
-        raise ValueError("gate and beta must match query's batch, head, and sequence dimensions")
     if initial_state is not None:
-        expected_state_shape = (batch, heads, key_dimension, value.shape[-1])
+        expected_state_shape = (batch, heads, key_dim, v.shape[-1])
         if initial_state.shape != expected_state_shape:
             raise ValueError(
                 f"initial_state must have shape {expected_state_shape}, got {initial_state.shape}"
             )
 
-    tensors = (query, key, value, gate, beta)
-    if initial_state is not None:
-        tensors += (initial_state,)
+    tensors = (q, k, v, gate, beta) + (() if initial_state is None else (initial_state,))
     if not all(tensor.is_floating_point() for tensor in tensors):
         raise ValueError("all inputs must have floating-point dtypes")
-    if any(tensor.device != query.device for tensor in tensors[1:]):
+    if any(tensor.device != q.device for tensor in tensors[1:]):
         raise ValueError("all inputs must be on the same device")
-    if key.dtype != query.dtype or value.dtype != query.dtype:
-        raise ValueError("query, key, and value must have the same dtype")
+    if k.dtype != q.dtype or v.dtype != q.dtype:
+        raise ValueError("q, k, and v must have the same dtype")
 
-    compute_dtype = torch.promote_types(query.dtype, torch.float32)
+    compute_dtype = torch.promote_types(q.dtype, torch.float32)
     if initial_state is not None and initial_state.dtype != compute_dtype:
         raise ValueError(
-            f"initial_state must have dtype {compute_dtype} for {query.dtype} query, "
+            f"initial_state must have dtype {compute_dtype} for {q.dtype} q, "
             f"got {initial_state.dtype}"
         )
 

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -4,8 +4,8 @@ Attention Gym provides functional linear-attention operators with eager referenc
 
 ## Gated Delta Rule
 
-`chunk_gdn` and `recurrent_gdn` use the SDPA layout
-`[batch, heads, sequence, dimension]` and return a structured result. For each token, the scalar
+`chunk_gdn` and `recurrent_gdn` use the token-major layout
+`[batch, sequence, heads, dimension]` and return an output/state tuple. For each token, the scalar
 natural-log gate decays the previous state before the delta update, and the query reads the updated
 state:
 
@@ -23,23 +23,20 @@ chooses the execution form explicitly; `impl="reference"` selects the eager PyTo
 ```python
 from attn_gym.linear import chunk_gdn
 
-result = chunk_gdn(
+output, final_state = chunk_gdn(
     query,
     key,
     value,
     gate,
     beta,
     impl="reference",
-    return_final_state=True,
+    output_final_state=True,
 )
-
-output = result.output
-final_state = result.final_state
 ```
 
 ### Supported capabilities
 
-- Fixed-length inputs in `[batch, heads, sequence, dimension]` layout.
+- Fixed-length inputs in `[batch, sequence, heads, dimension]` layout.
 - Separate recurrent and chunked operations with explicit initial and final state.
 - CPU and CUDA execution through eager PyTorch operations.
 - Autograd for inputs and initial state.
@@ -58,16 +55,15 @@ Packed variable-length inputs and fused implementations are not implemented yet.
   `recurrent_gdn(...)`.
 - `naive_chunk_gated_delta_rule(...)` and `gated_delta_rule(..., mode="chunked")` become
   `chunk_gdn(...)`.
-- Inputs use `[batch, heads, sequence, dimension]`, matching SDPA and FlexAttention.
-- `output_final_state` is named `return_final_state`.
-- Both operations return `GatedDeltaRuleOutput`; access tensors through `.output` and
-  `.final_state`.
+- Inputs use `[batch, sequence, heads, dimension]`, matching the KDA operations; keyword callers
+  use `q`, `k`, and `v`.
+- The public chunk size is fixed at 64, matching KDA's fused decomposition.
+- `initial_state` may be positional, and `output_final_state` controls the optional state output.
+- Both operations return `(output, final_state)`, matching the KDA operations.
 
 ::: attn_gym.linear.chunk_gdn
 
 ::: attn_gym.linear.recurrent_gdn
-
-::: attn_gym.linear.GatedDeltaRuleOutput
 
 ## Kimi Delta Attention
 

--- a/test/linear/test_gdn.py
+++ b/test/linear/test_gdn.py
@@ -2,99 +2,92 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from attn_gym.linear import (
-    GatedDeltaRuleOutput,
-    Impl,
-    chunk_gdn,
-    recurrent_gdn,
-)
+from attn_gym.linear import Impl, chunk_gdn, recurrent_gdn
 
-REFERENCE_CASES = [(recurrent_gdn, {}), (chunk_gdn, {"chunk_size": 4})]
+REFERENCE_CASES = [recurrent_gdn, chunk_gdn]
 
 
 def make_inputs(sequence: int) -> tuple[torch.Tensor, ...]:
     """Create stable gated delta rule inputs with normalized keys."""
     torch.manual_seed(0)
     batch, heads, key_dimension, value_dimension = 2, 3, 4, 5
-    query = torch.randn(batch, heads, sequence, key_dimension)
+    query = torch.randn(batch, sequence, heads, key_dimension)
     key = F.normalize(torch.randn_like(query), dim=-1)
-    value = torch.randn(batch, heads, sequence, value_dimension)
-    gate = F.logsigmoid(torch.randn(batch, heads, sequence))
-    beta = torch.sigmoid(torch.randn(batch, heads, sequence))
+    value = torch.randn(batch, sequence, heads, value_dimension)
+    gate = F.logsigmoid(torch.randn(batch, sequence, heads))
+    beta = torch.sigmoid(torch.randn(batch, sequence, heads))
     initial_state = torch.randn(batch, heads, key_dimension, value_dimension)
     return query, key, value, gate, beta, initial_state
 
 
-def run_with_state(function, inputs, kwargs):
+def run_with_state(function, inputs):
     """Run one GDN form with its initial and final recurrent state."""
-    return function(*inputs[:5], initial_state=inputs[5], return_final_state=True, **kwargs)
+    return function(*inputs, output_final_state=True)
 
 
-@pytest.mark.parametrize("sequence,chunk_size", [(1, 4), (7, 4), (8, 4), (17, 8)])
+@pytest.mark.parametrize("sequence", [1, 7, 64, 73])
 @pytest.mark.parametrize("use_initial_state", [False, True])
-def test_chunk_matches_recurrent(sequence, chunk_size, use_initial_state):
+def test_chunk_matches_recurrent(sequence, use_initial_state):
     inputs = make_inputs(sequence)
     initial_state = inputs[-1] if use_initial_state else None
-    recurrent = recurrent_gdn(
+    recurrent_output, recurrent_state = recurrent_gdn(
         *inputs[:-1],
-        initial_state=initial_state,
-        return_final_state=True,
+        initial_state,
+        output_final_state=True,
     )
-    chunked = chunk_gdn(
+    chunked_output, chunked_state = chunk_gdn(
         *inputs[:-1],
-        initial_state=initial_state,
-        return_final_state=True,
-        chunk_size=chunk_size,
+        initial_state,
+        output_final_state=True,
     )
 
-    assert isinstance(chunked, GatedDeltaRuleOutput)
-    torch.testing.assert_close(chunked.output, recurrent.output, atol=1e-6, rtol=1e-5)
-    torch.testing.assert_close(chunked.final_state, recurrent.final_state, atol=1e-6, rtol=1e-5)
+    torch.testing.assert_close(chunked_output, recurrent_output, atol=1e-6, rtol=1e-5)
+    torch.testing.assert_close(chunked_state, recurrent_state, atol=1e-6, rtol=1e-5)
 
 
 def test_segmented_recurrent_execution_matches_full_sequence():
     inputs = make_inputs(sequence=9)
-    full = recurrent_gdn(*inputs[:-1], return_final_state=True)
-    first = recurrent_gdn(
-        *(tensor[:, :, :4] for tensor in inputs[:-1]),
-        return_final_state=True,
+    full_output, full_state = recurrent_gdn(*inputs[:-1], output_final_state=True)
+    first_output, first_state = recurrent_gdn(
+        *(tensor[:, :4] for tensor in inputs[:-1]),
+        output_final_state=True,
     )
-    second = recurrent_gdn(
-        *(tensor[:, :, 4:] for tensor in inputs[:-1]),
-        initial_state=first.final_state,
-        return_final_state=True,
+    second_output, second_state = recurrent_gdn(
+        *(tensor[:, 4:] for tensor in inputs[:-1]),
+        first_state,
+        output_final_state=True,
     )
 
-    torch.testing.assert_close(torch.cat((first.output, second.output), dim=2), full.output)
-    torch.testing.assert_close(second.final_state, full.final_state)
+    torch.testing.assert_close(torch.cat((first_output, second_output), dim=1), full_output)
+    torch.testing.assert_close(second_state, full_state)
 
 
 def test_recurrent_execution_is_batch_invariant():
     inputs = make_inputs(sequence=5)
-    batched = recurrent_gdn(*inputs[:-1], return_final_state=True)
+    batched_output, batched_state = recurrent_gdn(*inputs[:-1], output_final_state=True)
 
     for batch_index in range(inputs[0].shape[0]):
-        single = recurrent_gdn(
+        single_output, single_state = recurrent_gdn(
             *(tensor[batch_index : batch_index + 1] for tensor in inputs[:-1]),
-            return_final_state=True,
+            output_final_state=True,
         )
-        torch.testing.assert_close(single.output[0], batched.output[batch_index])
-        torch.testing.assert_close(single.final_state[0], batched.final_state[batch_index])
+        torch.testing.assert_close(single_output[0], batched_output[batch_index])
+        torch.testing.assert_close(single_state[0], batched_state[batch_index])
 
 
 def test_chunk_gradients_match_recurrent():
-    inputs = make_inputs(sequence=7)[:-1]
+    inputs = make_inputs(sequence=73)[:-1]
     gradients = []
-    for function, kwargs in REFERENCE_CASES:
+    for function in REFERENCE_CASES:
         differentiable_inputs = [value.clone().requires_grad_() for value in inputs]
         result = function(
             *differentiable_inputs,
-            return_final_state=True,
-            **kwargs,
+            output_final_state=True,
         )
+        output, final_state = result
         gradients.append(
             torch.autograd.grad(
-                result.output.square().mean() + result.final_state.square().mean(),
+                output.square().mean() + final_state.square().mean(),
                 differentiable_inputs,
             )
         )
@@ -103,10 +96,10 @@ def test_chunk_gradients_match_recurrent():
         torch.testing.assert_close(chunk_gradient, recurrent_gradient, atol=1e-6, rtol=1e-5)
 
 
-@pytest.mark.parametrize("function,kwargs", REFERENCE_CASES)
+@pytest.mark.parametrize("function", REFERENCE_CASES)
 @pytest.mark.parametrize("qkv_dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("fp32_gate", [False, True])
-def test_low_precision_compute_and_gradient_dtypes(function, kwargs, qkv_dtype, fp32_gate):
+def test_low_precision_compute_and_gradient_dtypes(function, qkv_dtype, fp32_gate):
     query, key, value, gate, beta, initial_state = make_inputs(sequence=7)
     gate_dtype = torch.float32 if fp32_gate else qkv_dtype
     inputs = [
@@ -120,20 +113,20 @@ def test_low_precision_compute_and_gradient_dtypes(function, kwargs, qkv_dtype, 
     inputs = [tensor.requires_grad_() for tensor in inputs]
     expected_inputs = [tensor.detach().float() for tensor in inputs]
 
-    result = run_with_state(function, inputs, kwargs)
-    expected = run_with_state(function, expected_inputs, kwargs)
-    assert result.output.dtype == qkv_dtype
-    assert result.final_state.dtype == torch.float32
+    output, final_state = run_with_state(function, inputs)
+    expected_output, expected_state = run_with_state(function, expected_inputs)
+    assert output.dtype == qkv_dtype
+    assert final_state.dtype == torch.float32
     torch.testing.assert_close(
-        result.output.float(),
-        expected.output,
+        output.float(),
+        expected_output,
         rtol=torch.finfo(qkv_dtype).eps,
         atol=torch.finfo(qkv_dtype).eps,
     )
-    torch.testing.assert_close(result.final_state, expected.final_state, rtol=0, atol=0)
+    torch.testing.assert_close(final_state, expected_state, rtol=0, atol=0)
 
     gradients = torch.autograd.grad(
-        result.output.float().square().mean() + result.final_state.square().mean(), inputs
+        output.float().square().mean() + final_state.square().mean(), inputs
     )
     assert tuple(gradient.dtype for gradient in gradients) == (
         qkv_dtype,
@@ -146,15 +139,15 @@ def test_low_precision_compute_and_gradient_dtypes(function, kwargs, qkv_dtype, 
 
 
 @pytest.mark.parametrize(
-    "function,kwargs,device_type,autocast_dtype",
+    "function,device_type,autocast_dtype",
     [
-        (recurrent_gdn, {}, "cpu", torch.bfloat16),
-        (chunk_gdn, {"chunk_size": 4}, "cpu", torch.bfloat16),
-        (recurrent_gdn, {}, "cuda", torch.float16),
-        (recurrent_gdn, {}, "cuda", torch.bfloat16),
+        (recurrent_gdn, "cpu", torch.bfloat16),
+        (chunk_gdn, "cpu", torch.bfloat16),
+        (recurrent_gdn, "cuda", torch.float16),
+        (recurrent_gdn, "cuda", torch.bfloat16),
     ],
 )
-def test_reference_disables_autocast(function, kwargs, device_type, autocast_dtype):
+def test_reference_disables_autocast(function, device_type, autocast_dtype):
     if device_type == "cuda" and not torch.cuda.is_available():
         pytest.skip("CUDA autocast requires CUDA")
 
@@ -162,17 +155,17 @@ def test_reference_disables_autocast(function, kwargs, device_type, autocast_dty
         tensor.to(device_type).requires_grad_() for tensor in make_inputs(sequence=7)
     ]
     actual_inputs = [tensor.detach().clone().requires_grad_() for tensor in expected_inputs]
-    expected = run_with_state(function, expected_inputs, kwargs)
+    expected_output, expected_state = run_with_state(function, expected_inputs)
     with torch.autocast(device_type=device_type, dtype=autocast_dtype):
-        actual = run_with_state(function, actual_inputs, kwargs)
+        actual_output, actual_state = run_with_state(function, actual_inputs)
 
-    torch.testing.assert_close(actual.output, expected.output, rtol=0, atol=0)
-    torch.testing.assert_close(actual.final_state, expected.final_state, rtol=0, atol=0)
+    torch.testing.assert_close(actual_output, expected_output, rtol=0, atol=0)
+    torch.testing.assert_close(actual_state, expected_state, rtol=0, atol=0)
     expected_gradients = torch.autograd.grad(
-        expected.output.square().mean() + expected.final_state.square().mean(), expected_inputs
+        expected_output.square().mean() + expected_state.square().mean(), expected_inputs
     )
     actual_gradients = torch.autograd.grad(
-        actual.output.square().mean() + actual.final_state.square().mean(), actual_inputs
+        actual_output.square().mean() + actual_state.square().mean(), actual_inputs
     )
     for actual_gradient, expected_gradient in zip(actual_gradients, expected_gradients):
         torch.testing.assert_close(actual_gradient, expected_gradient, rtol=0, atol=0)
@@ -181,24 +174,24 @@ def test_reference_disables_autocast(function, kwargs, device_type, autocast_dty
 @pytest.mark.parametrize("function", [chunk_gdn, recurrent_gdn])
 def test_low_precision_default_state_is_fp32(function):
     query, key, value, gate, beta, _initial_state = make_inputs(sequence=3)
-    result = function(
+    output, final_state = function(
         query.bfloat16(),
         key.bfloat16(),
         value.bfloat16(),
         gate,
         beta,
-        return_final_state=True,
+        output_final_state=True,
     )
-    assert result.output.dtype == torch.bfloat16
-    assert result.final_state.dtype == torch.float32
+    assert output.dtype == torch.bfloat16
+    assert final_state.dtype == torch.float32
 
 
 @pytest.mark.parametrize("function", [chunk_gdn, recurrent_gdn])
 def test_fp64_preserves_compute_and_state_dtype(function):
     inputs = [tensor.double() for tensor in make_inputs(sequence=3)]
-    result = function(*inputs[:5], initial_state=inputs[5], return_final_state=True)
-    assert result.output.dtype == torch.float64
-    assert result.final_state.dtype == torch.float64
+    output, final_state = function(*inputs, output_final_state=True)
+    assert output.dtype == torch.float64
+    assert final_state.dtype == torch.float64
 
 
 @pytest.mark.parametrize("function", [chunk_gdn, recurrent_gdn])
@@ -206,18 +199,13 @@ def test_impl_accepts_enum_and_string(function):
     inputs = make_inputs(sequence=2)
     from_enum = function(*inputs[:-1], impl=Impl.REFERENCE)
     from_string = function(*inputs[:-1], impl="reference")
-    torch.testing.assert_close(from_enum.output, from_string.output)
+    torch.testing.assert_close(from_enum[0], from_string[0])
+    assert type(from_enum) is tuple and from_enum[1] is None
 
     with pytest.raises(ValueError, match="'fused', 'reference'"):
         function(*inputs[:-1], impl="eager")
     with pytest.raises(NotImplementedError, match="impl='fused'"):
         function(*inputs[:-1], impl=Impl.FUSED)
-
-
-def test_invalid_chunk_size_fails_clearly():
-    inputs = make_inputs(sequence=2)
-    with pytest.raises(ValueError, match="chunk_size must be greater than zero"):
-        chunk_gdn(*inputs[:-1], chunk_size=0)
 
 
 @pytest.mark.parametrize("function", [chunk_gdn, recurrent_gdn])
@@ -230,22 +218,22 @@ def test_invalid_initial_state_shape_fails_clearly(function):
 def test_mismatched_qkv_dtypes_fail_clearly():
     inputs = list(make_inputs(sequence=2))
     inputs[2] = inputs[2].double()
-    with pytest.raises(ValueError, match="query, key, and value must have the same dtype"):
+    with pytest.raises(ValueError, match="q, k, and v must have the same dtype"):
         recurrent_gdn(*inputs[:-1])
 
 
 def test_gate_and_beta_accept_independent_floating_dtypes():
     query, key, value, gate, beta, _initial_state = make_inputs(sequence=2)
-    result = recurrent_gdn(
+    output, final_state = recurrent_gdn(
         query.bfloat16(),
         key.bfloat16(),
         value.bfloat16(),
         gate.half(),
         beta.double(),
-        return_final_state=True,
+        output_final_state=True,
     )
-    assert result.output.dtype == torch.bfloat16
-    assert result.final_state.dtype == torch.float32
+    assert output.dtype == torch.bfloat16
+    assert final_state.dtype == torch.float32
 
 
 def test_invalid_initial_state_dtype_fails_clearly():

--- a/test/linear/test_recurrent_delta_rule.py
+++ b/test/linear/test_recurrent_delta_rule.py
@@ -39,11 +39,11 @@ def _make_inputs(
     """Create stable scalar-gated inputs in the public GDN layout."""
     torch.manual_seed(0)
     batch, heads = 2, 2
-    query = F.normalize(torch.randn(batch, heads, tokens, key_dim, device="cuda"), dim=-1)
+    query = F.normalize(torch.randn(batch, tokens, heads, key_dim, device="cuda"), dim=-1)
     key = F.normalize(torch.randn_like(query), dim=-1)
-    value = torch.randn(batch, heads, tokens, value_dim, device="cuda")
-    gate = F.logsigmoid(torch.randn(batch, heads, tokens, device="cuda"))
-    beta = torch.sigmoid(torch.randn(batch, heads, tokens, device="cuda"))
+    value = torch.randn(batch, tokens, heads, value_dim, device="cuda")
+    gate = F.logsigmoid(torch.randn(batch, tokens, heads, device="cuda"))
+    beta = torch.sigmoid(torch.randn(batch, tokens, heads, device="cuda"))
     state = torch.randn(batch, heads, key_dim, value_dim, device="cuda") if initial_state else None
     return query.to(dtype), key.to(dtype), value.to(dtype), gate, beta, state
 
@@ -59,20 +59,19 @@ def _launch_scalar_gdn(
     scale: float,
     store_final_state: bool,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
-    """Adapt head-major GDN inputs to the private token-major scan."""
-    output, final_state = launch_recurrent_delta_rule_fwd(
-        query.transpose(1, 2).contiguous(),
-        key.transpose(1, 2).contiguous(),
-        value.transpose(1, 2).contiguous(),
-        gate.transpose(1, 2).contiguous(),
-        beta.transpose(1, 2).contiguous(),
+    """Launch the scalar-gate specialization with public GDN inputs."""
+    return launch_recurrent_delta_rule_fwd(
+        query,
+        key,
+        value,
+        gate,
+        beta,
         initial_state,
         None,
         scale=scale,
         gate_kind=GateKind.SCALAR,
         store_final_state=store_final_state,
     )
-    return output.transpose(1, 2), final_state
 
 
 @pytest.mark.parametrize(
@@ -102,9 +101,9 @@ def test_scalar_gate_matches_recurrent_gdn(
             value,
             gate,
             beta,
+            state,
             scale=scale,
-            initial_state=state,
-            return_final_state=return_final_state,
+            output_final_state=return_final_state,
         )
         output, final_state = _launch_scalar_gdn(
             query,
@@ -121,7 +120,7 @@ def test_scalar_gate_matches_recurrent_gdn(
     if return_final_state:
         assert final_state is not None and final_state.dtype == torch.float32
     else:
-        assert final_state is None and expected.final_state is None
+        assert final_state is None and expected[1] is None
     if dtype == torch.bfloat16:
         high_precision = recurrent_gdn(
             query.double(),
@@ -131,19 +130,17 @@ def test_scalar_gate_matches_recurrent_gdn(
             beta.double(),
             scale=scale,
             initial_state=None if state is None else state.double(),
-            return_final_state=return_final_state,
+            output_final_state=return_final_state,
         )
-        assert_matches_low_precision_reference(
-            output, high_precision.output, expected.output, "output"
-        )
+        assert_matches_low_precision_reference(output, high_precision[0], expected[0], "output")
         if return_final_state:
             assert_matches_low_precision_reference(
-                final_state, high_precision.final_state, expected.final_state, "final_state"
+                final_state, high_precision[1], expected[1], "final_state"
             )
     else:
-        torch.testing.assert_close(output, expected.output, rtol=1e-5, atol=1e-5)
+        torch.testing.assert_close(output, expected[0], rtol=1e-5, atol=1e-5)
         if return_final_state:
-            torch.testing.assert_close(final_state, expected.final_state, rtol=1e-5, atol=1e-5)
+            torch.testing.assert_close(final_state, expected[1], rtol=1e-5, atol=1e-5)
 
 
 def test_scalar_and_vector_gate_specializations_agree():
@@ -155,14 +152,13 @@ def test_scalar_and_vector_gate_specializations_agree():
         scalar_output, scalar_state = _launch_scalar_gdn(
             query, key, value, gate, beta, state, scale=scale, store_final_state=True
         )
-        token_gate = gate.transpose(1, 2).contiguous()
-        vector_gate = token_gate.unsqueeze(-1).expand(*token_gate.shape, query.shape[-1])
+        vector_gate = gate.unsqueeze(-1).expand(*gate.shape, query.shape[-1])
         vector_output, vector_state = launch_recurrent_delta_rule_fwd(
-            query.transpose(1, 2).contiguous(),
-            key.transpose(1, 2).contiguous(),
-            value.transpose(1, 2).contiguous(),
+            query,
+            key,
+            value,
             vector_gate.contiguous(),
-            beta.transpose(1, 2).contiguous(),
+            beta,
             state,
             None,
             scale=scale,
@@ -170,5 +166,5 @@ def test_scalar_and_vector_gate_specializations_agree():
             store_final_state=True,
         )
 
-    torch.testing.assert_close(scalar_output, vector_output.transpose(1, 2), rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(scalar_output, vector_output, rtol=1e-5, atol=1e-5)
     torch.testing.assert_close(scalar_state, vector_state, rtol=1e-5, atol=1e-5)

--- a/test/test_cuda_graphs_example.py
+++ b/test/test_cuda_graphs_example.py
@@ -1,5 +1,9 @@
 from pathlib import Path
 
+import pytest
+
+pytest.importorskip("torch.cuda.graph_annotations", reason="the example requires a newer torch")
+
 from examples import cuda_graph_trace_comparison
 
 

--- a/test/test_kda_training_example.py
+++ b/test/test_kda_training_example.py
@@ -10,6 +10,7 @@ from torch._inductor import config as inductor_config
 
 pytest.importorskip("cutlass")
 pytest.importorskip("typer")
+pytest.importorskip("torch.cuda.graph_annotations", reason="the example requires a newer torch")
 
 from attn_gym.linear.kda.constants import MAX_GATE_LOWER_BOUND_MAGNITUDE
 from examples import kda_training

--- a/test/test_selected_attention_cute.py
+++ b/test/test_selected_attention_cute.py
@@ -12,6 +12,10 @@ import math
 import pytest
 import torch
 
+pytest.importorskip(
+    "flash_attn.cute.interface", reason="the CuTe backend requires FlashAttention-4"
+)
+
 from attn_gym.sparse.selected_attention import selected_attention
 
 


### PR DESCRIPTION
Stacked PRs:
 * #381
 * #380
 * __->__#379


--- --- ---

Align GDN with KDA API conventions

## Human Note

## Agent note

Switch GDN to KDA-style token-major inputs, positional initial state, output_final_state naming,
and tuple returns while preserving scalar-gate mathematics and reference precision behavior. Fix
the public chunk size at 64 so the eventual fused and reference implementations expose one shape.

## Test Plan

```bash
.venv/bin/prek run --files DESIGN.md docs/linear.md attn_gym/linear/__init__.py attn_gym/linear/gdn/__init__.py attn_gym/linear/gdn/api.py attn_gym/linear/gdn/impl/reference.py attn_gym/linear/gdn/validation.py test/linear/test_gdn.py test/linear/test_recurrent_delta_rule.py test/test_namespaces.py
.venv/bin/pytest -q test/linear/test_gdn.py test/test_namespaces.py
gpu-run auto -- .venv/bin/pytest -q test/linear/test_recurrent_delta_rule.py
```