### PR TITLE
Add fused recurrent GDN

### DIFF
--- a/attn_gym/linear/gdn/api.py
+++ b/attn_gym/linear/gdn/api.py
@@ -4,11 +4,8 @@ from __future__ import annotations
 
 import torch
 
-from attn_gym.linear.gdn.impl.reference import (
-    chunk_forward,
-    recurrent_forward,
-    reference_gdn,
-)
+from attn_gym.linear.gdn.impl.reference import chunk_forward, recurrent_forward, reference_gdn
+from attn_gym.linear.gdn.ops import recurrent_forward as fused_recurrent_forward
 from attn_gym.linear.gdn.validation import validate_gdn_inputs
 from attn_gym.linear.types import Impl, resolve_impl
 
@@ -21,6 +18,7 @@ def chunk_gdn(
     beta: torch.Tensor,
     initial_state: torch.Tensor | None = None,
     *,
+    cu_seqlens: torch.Tensor | None = None,
     scale: float | None = None,
     output_final_state: bool = False,
     impl: Impl | str = Impl.REFERENCE,
@@ -38,8 +36,11 @@ def chunk_gdn(
         v: Values shaped ``[B, T, H, V]`` and using the same dtype as ``q``.
         gate: Floating per-token scalar natural-log decay shaped ``[B, T, H]``.
         beta: Floating per-token write gate shaped ``[B, T, H]``.
-        initial_state: Initial recurrent state shaped ``[B, H, K, V]`` in the recurrence compute
-            dtype (FP32 for FP16/BF16 QKV).
+        initial_state: Initial recurrent state shaped ``[N, H, K, V]`` in the recurrence compute
+            dtype, where ``N`` is the number of logical sequences.
+        cu_seqlens: Optional packed offsets shaped ``[N + 1]`` for batch-one inputs. They start at
+            zero, never decrease, and may end before ``T``; output beyond the terminal offset is
+            unspecified.
         scale: Query scale. Defaults to ``1 / sqrt(K)``.
         output_final_state: Return the final recurrent state with the output.
         impl: ``"reference"`` uses eager PyTorch. ``"fused"`` is reserved for the optimized
@@ -49,7 +50,7 @@ def chunk_gdn(
         The output in ``q.dtype`` and either the final recurrent state or ``None``.
     """
     selected_impl = resolve_impl(impl)
-    validate_gdn_inputs(q, k, v, gate, beta, initial_state)
+    validate_gdn_inputs(q, k, v, gate, beta, initial_state, cu_seqlens)
     if selected_impl is Impl.FUSED:
         raise NotImplementedError("chunk_gdn impl='fused' is not implemented yet")
 
@@ -60,8 +61,9 @@ def chunk_gdn(
         v,
         gate,
         beta,
-        scale=scale,
+        scale=q.shape[-1] ** -0.5 if scale is None else scale,
         initial_state=initial_state,
+        cu_seqlens=cu_seqlens,
         output_final_state=output_final_state,
     )
 
@@ -74,13 +76,15 @@ def recurrent_gdn(
     beta: torch.Tensor,
     initial_state: torch.Tensor | None = None,
     *,
+    cu_seqlens: torch.Tensor | None = None,
     scale: float | None = None,
     output_final_state: bool = False,
+    autotune: bool = True,
     impl: Impl | str = Impl.REFERENCE,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Apply recurrent gated delta rule attention for decoding and inference prefill.
 
-    The recurrence consumes tokens in order, carrying an explicit ``[B, H, K, V]`` state. Inputs
+    The recurrence consumes tokens in order, carrying an explicit ``[N, H, K, V]`` state. Inputs
     and outputs use the token-major layout ``[batch, sequence, heads, dimension]``. FP16 and BF16
     inputs use FP32 recurrence math and state.
 
@@ -90,20 +94,37 @@ def recurrent_gdn(
         v: Values shaped ``[B, T, H, V]`` and using the same dtype as ``q``.
         gate: Floating per-token scalar natural-log decay shaped ``[B, T, H]``.
         beta: Floating per-token write gate shaped ``[B, T, H]``.
-        initial_state: Initial recurrent state shaped ``[B, H, K, V]`` in the recurrence compute
-            dtype (FP32 for FP16/BF16 QKV).
+        initial_state: Initial recurrent state shaped ``[N, H, K, V]`` in the recurrence compute
+            dtype, where ``N`` is the number of logical sequences.
+        cu_seqlens: Optional packed offsets shaped ``[N + 1]`` for batch-one inputs. They start at
+            zero, never decrease, and may end before ``T``; output beyond the terminal offset is
+            unspecified.
         scale: Query scale. Defaults to ``1 / sqrt(K)``.
         output_final_state: Return the final recurrent state with the output.
-        impl: ``"reference"`` uses eager PyTorch. ``"fused"`` is reserved for the optimized
-            backend and currently raises ``NotImplementedError``.
+        autotune: Benchmark candidate value-tile sizes for the fused implementation when true;
+            winners are cached and reused.
+        impl: ``"fused"`` uses the inference-only Triton scan; ``"reference"`` uses eager
+            PyTorch with autograd support.
 
     Returns:
         The output in ``q.dtype`` and either the final recurrent state or ``None``.
     """
     selected_impl = resolve_impl(impl)
-    validate_gdn_inputs(q, k, v, gate, beta, initial_state)
+    validate_gdn_inputs(q, k, v, gate, beta, initial_state, cu_seqlens)
+    scale = q.shape[-1] ** -0.5 if scale is None else scale
     if selected_impl is Impl.FUSED:
-        raise NotImplementedError("recurrent_gdn impl='fused' is not implemented yet")
+        return fused_recurrent_forward(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            initial_state,
+            cu_seqlens=cu_seqlens,
+            scale=scale,
+            output_final_state=output_final_state,
+            autotune=autotune,
+        )
 
     return reference_gdn(
         recurrent_forward,
@@ -114,6 +135,7 @@ def recurrent_gdn(
         beta,
         scale=scale,
         initial_state=initial_state,
+        cu_seqlens=cu_seqlens,
         output_final_state=output_final_state,
     )
 

--- a/attn_gym/linear/gdn/impl/fused.py
+++ b/attn_gym/linear/gdn/impl/fused.py
@@ -1,0 +1,91 @@
+"""Fused gated delta rule implementations."""
+
+from __future__ import annotations
+
+import torch
+
+from attn_gym.linear._delta_rule.recurrent import GateKind, launch_recurrent_delta_rule_fwd
+
+
+def _launch_recurrent(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+    scale: float,
+    autotune: bool,
+    *,
+    output_final_state: bool,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Launch the scalar-gate specialization of the shared log2-space scan."""
+    return launch_recurrent_delta_rule_fwd(
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        initial_state,
+        cu_seqlens,
+        scale=scale,
+        gate_kind=GateKind.SCALAR,
+        store_final_state=output_final_state,
+        autotune=autotune,
+    )
+
+
+def _gdn_recurrent_fwd_cuda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+    scale: float,
+    autotune: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    output, final_state = _launch_recurrent(
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        initial_state,
+        cu_seqlens,
+        scale,
+        autotune,
+        output_final_state=True,
+    )
+    assert final_state is not None
+    return output, final_state
+
+
+def _gdn_recurrent_fwd_no_state_cuda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+    scale: float,
+    autotune: bool,
+) -> torch.Tensor:
+    return _launch_recurrent(
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        initial_state,
+        cu_seqlens,
+        scale,
+        autotune,
+        output_final_state=False,
+    )[0]
+
+
+__all__ = []

--- a/attn_gym/linear/gdn/impl/reference.py
+++ b/attn_gym/linear/gdn/impl/reference.py
@@ -2,10 +2,68 @@
 
 from __future__ import annotations
 
+from itertools import pairwise
+
 import torch
 import torch.nn.functional as F
 
 _CHUNK_SIZE = 64
+
+
+def _packed_reference(
+    dense_op,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    log_decay: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor,
+    scale: float,
+    output_final_state: bool,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Evaluate packed sequences independently through a dense reference operation."""
+    heads, key_dim, value_dim = q.shape[2], q.shape[3], v.shape[-1]
+    num_sequences = cu_seqlens.shape[0] - 1
+    output = torch.zeros_like(v)
+    final_state = None
+    if output_final_state:
+        final_state = (
+            q.new_zeros(num_sequences, heads, key_dim, value_dim)
+            if initial_state is None
+            else initial_state.clone()
+        )
+
+    offsets = cu_seqlens.cpu().tolist()
+    if (
+        offsets[0] != 0
+        or any(begin > end for begin, end in pairwise(offsets))
+        or offsets[-1] > q.shape[1]
+    ):
+        raise ValueError(
+            "cu_seqlens offsets must start at zero, be nondecreasing, and end within "
+            "the physical token capacity"
+        )
+    for sequence, (begin, end) in enumerate(pairwise(offsets)):
+        if begin == end:
+            continue
+        span = slice(begin, end)
+        span_output, span_state = dense_op(
+            q[:, span],
+            k[:, span],
+            v[:, span],
+            log_decay[:, span],
+            beta[:, span],
+            scale=scale,
+            initial_state=None
+            if initial_state is None
+            else initial_state[sequence : sequence + 1],
+            output_final_state=output_final_state,
+        )
+        output[:, span] = span_output
+        if final_state is not None:
+            final_state[sequence] = span_state[0]
+    return output, final_state
 
 
 def reference_gdn(
@@ -16,26 +74,41 @@ def reference_gdn(
     log_decay: torch.Tensor,
     beta: torch.Tensor,
     *,
-    scale: float | None,
+    scale: float,
     initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
     output_final_state: bool,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
-    """Run a dense GDN reference operation in the documented compute dtype."""
+    """Run a GDN reference operation in the documented compute dtype."""
     output_dtype = q.dtype
     compute_dtype = torch.promote_types(q.dtype, torch.float32)
     q, k, v, log_decay, beta = (tensor.to(compute_dtype) for tensor in (q, k, v, log_decay, beta))
     # Explicit casts do not stop autocast from selecting low-precision contractions.
     with torch.autocast(device_type=q.device.type, enabled=False):
-        output, state = dense_op(
-            q,
-            k,
-            v,
-            log_decay,
-            beta,
-            scale=scale,
-            initial_state=initial_state,
-            output_final_state=output_final_state,
-        )
+        if cu_seqlens is None:
+            output, state = dense_op(
+                q,
+                k,
+                v,
+                log_decay,
+                beta,
+                scale=scale,
+                initial_state=initial_state,
+                output_final_state=output_final_state,
+            )
+        else:
+            output, state = _packed_reference(
+                dense_op,
+                q,
+                k,
+                v,
+                log_decay,
+                beta,
+                initial_state,
+                cu_seqlens,
+                scale,
+                output_final_state,
+            )
     return output.to(output_dtype), state
 
 
@@ -46,13 +119,13 @@ def recurrent_forward(
     log_decay: torch.Tensor,
     beta: torch.Tensor,
     *,
-    scale: float | None,
+    scale: float,
     initial_state: torch.Tensor | None,
     output_final_state: bool,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Evaluate the gated delta rule recurrence one token at a time."""
     batch, sequence, heads, key_dim = q.shape
-    q = q * (key_dim**-0.5 if scale is None else scale)
+    q = q * scale
     state = (
         q.new_zeros(batch, heads, key_dim, v.shape[-1]) if initial_state is None else initial_state
     )
@@ -75,14 +148,13 @@ def chunk_forward(
     log_decay: torch.Tensor,
     beta: torch.Tensor,
     *,
-    scale: float | None,
+    scale: float,
     initial_state: torch.Tensor | None,
     output_final_state: bool,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Evaluate the gated delta rule with the fixed chunk-parallel decomposition."""
     batch, sequence, heads, key_dim = q.shape
     value_dim = v.shape[-1]
-    scale = key_dim**-0.5 if scale is None else scale
     padding = (-sequence) % _CHUNK_SIZE
     if padding:
         q, k, v = (F.pad(tensor, (0, 0, 0, 0, 0, padding)) for tensor in (q, k, v))

--- a/attn_gym/linear/gdn/ops.py
+++ b/attn_gym/linear/gdn/ops.py
@@ -1,0 +1,119 @@
+"""Registered operators for fused gated delta rule implementations."""
+
+from __future__ import annotations
+
+import importlib
+
+import torch
+
+_RECURRENT_ARGS = (
+    "(Tensor q, Tensor k, Tensor v, Tensor gate, Tensor beta, Tensor? initial_state, "
+    "Tensor? cu_seqlens, float scale, bool autotune)"
+)
+torch.library.define("attn_gym::gdn_recurrent_fwd", _RECURRENT_ARGS + " -> (Tensor, Tensor)")
+torch.library.define("attn_gym::gdn_recurrent_fwd_no_state", _RECURRENT_ARGS + " -> Tensor")
+
+
+def _recurrent_backend():
+    try:
+        return importlib.import_module("attn_gym.linear.gdn.impl.fused")
+    except ImportError as error:
+        raise ImportError(
+            "recurrent_gdn(impl='fused') requires CUDA with Triton support"
+        ) from error
+
+
+def _recurrent_fwd_cuda(*args):
+    return _recurrent_backend()._gdn_recurrent_fwd_cuda(*args)
+
+
+def _recurrent_fwd_no_state_cuda(*args):
+    return _recurrent_backend()._gdn_recurrent_fwd_no_state_cuda(*args)
+
+
+torch.library.impl("attn_gym::gdn_recurrent_fwd", "CUDA", _recurrent_fwd_cuda)
+torch.library.impl(
+    "attn_gym::gdn_recurrent_fwd_no_state",
+    "CUDA",
+    _recurrent_fwd_no_state_cuda,
+)
+
+
+@torch.library.register_fake("attn_gym::gdn_recurrent_fwd")
+def _recurrent_fwd_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+    scale: float,
+    autotune: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    del k, gate, beta, initial_state, scale, autotune
+    num_sequences = q.shape[0] if cu_seqlens is None else cu_seqlens.shape[0] - 1
+    final_state = q.new_empty(
+        num_sequences, q.shape[2], q.shape[3], v.shape[-1], dtype=torch.float32
+    )
+    return torch.empty_like(v, dtype=q.dtype), final_state
+
+
+@torch.library.register_fake("attn_gym::gdn_recurrent_fwd_no_state")
+def _recurrent_fwd_no_state_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+    scale: float,
+    autotune: bool,
+) -> torch.Tensor:
+    del k, gate, beta, initial_state, cu_seqlens, scale, autotune
+    return torch.empty_like(v, dtype=q.dtype)
+
+
+recurrent_fwd_op = torch.ops.attn_gym.gdn_recurrent_fwd.default
+recurrent_fwd_no_state_op = torch.ops.attn_gym.gdn_recurrent_fwd_no_state.default
+
+
+def recurrent_forward(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    *,
+    cu_seqlens: torch.Tensor | None,
+    scale: float,
+    output_final_state: bool,
+    autotune: bool,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Normalize inputs and invoke the fused recurrent GDN operator."""
+    if q.shape[-1] > 256:
+        raise ValueError(f"recurrent_gdn requires K in [1, 256], got {q.shape[-1]}")
+    if not q.is_cuda:
+        raise ValueError("recurrent_gdn(impl='fused') requires CUDA tensors")
+    if q.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+        raise TypeError("recurrent_gdn(impl='fused') requires float16, bfloat16, or float32 QKV")
+    tensors = (q, k, v, gate, beta) + (() if initial_state is None else (initial_state,))
+    if torch.is_grad_enabled() and any(tensor.requires_grad for tensor in tensors):
+        raise RuntimeError(
+            "recurrent_gdn(impl='fused') is inference-only and has no backward; "
+            "call under torch.no_grad() or torch.inference_mode()"
+        )
+
+    q, k, v = (tensor.contiguous() for tensor in (q, k, v))
+    gate, beta = (tensor.float().contiguous() for tensor in (gate, beta))
+    if initial_state is not None:
+        initial_state = initial_state.contiguous()
+    args = (q, k, v, gate, beta, initial_state, cu_seqlens, scale, autotune)
+    if output_final_state:
+        return recurrent_fwd_op(*args)
+    return recurrent_fwd_no_state_op(*args), None
+
+
+__all__ = ["recurrent_forward", "recurrent_fwd_no_state_op", "recurrent_fwd_op"]

--- a/attn_gym/linear/gdn/validation.py
+++ b/attn_gym/linear/gdn/validation.py
@@ -12,6 +12,7 @@ def validate_gdn_inputs(
     gate: torch.Tensor,
     beta: torch.Tensor,
     initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None = None,
 ) -> None:
     """Validate backend-independent gated delta rule tensor invariants."""
     if q.ndim != 4:
@@ -30,8 +31,21 @@ def validate_gdn_inputs(
     if beta.shape != (batch, tokens, heads):
         raise ValueError(f"beta must have shape {(batch, tokens, heads)}, got {tuple(beta.shape)}")
 
+    if cu_seqlens is not None:
+        if batch != 1:
+            raise ValueError("packed cu_seqlens require q to have batch size one")
+        if cu_seqlens.ndim != 1 or cu_seqlens.shape[0] < 2:
+            raise ValueError("cu_seqlens must have shape [num_sequences + 1]")
+        if (
+            cu_seqlens.dtype != torch.int32
+            or not cu_seqlens.is_contiguous()
+            or cu_seqlens.device != q.device
+        ):
+            raise ValueError("cu_seqlens must be contiguous int32 on q.device")
+
+    state_batch = batch if cu_seqlens is None else cu_seqlens.shape[0] - 1
     if initial_state is not None:
-        expected_state_shape = (batch, heads, key_dim, v.shape[-1])
+        expected_state_shape = (state_batch, heads, key_dim, v.shape[-1])
         if initial_state.shape != expected_state_shape:
             raise ValueError(
                 f"initial_state must have shape {expected_state_shape}, got {initial_state.shape}"

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -18,7 +18,8 @@ output = scale * query @ state
 
 `chunk_gdn` uses a chunk-parallel decomposition for training and prefill. `recurrent_gdn` consumes
 tokens in order for decoding, inference prefill, and state-carrying correctness checks. The caller
-chooses the execution form explicitly; `impl="reference"` selects the eager PyTorch implementation.
+chooses the execution form explicitly. `impl="reference"` selects eager PyTorch;
+`recurrent_gdn(..., impl="fused")` selects the inference-only Triton scan.
 
 ```python
 from attn_gym.linear import chunk_gdn
@@ -36,18 +37,23 @@ output, final_state = chunk_gdn(
 
 ### Supported capabilities
 
-- Fixed-length inputs in `[batch, sequence, heads, dimension]` layout.
+- Fixed-length inputs in `[batch, sequence, heads, dimension]` layout and packed batch-one inputs
+  with `cu_seqlens`.
 - Separate recurrent and chunked operations with explicit initial and final state.
 - CPU and CUDA execution through eager PyTorch operations.
-- Autograd for inputs and initial state.
+- An inference-only fused recurrent implementation on CUDA.
+- Autograd for reference inputs and initial state.
 - Q/K/V share one dtype. FP16 and BF16 inputs use FP32 recurrence math and state while returning
   output in the Q dtype.
 - Gate and beta may use independent floating dtypes and are converted to the recurrence compute
   dtype. A provided initial state uses FP32 for low-precision QKV.
 - FP64 reference inputs retain FP64 recurrence math and state.
 
-Packed variable-length inputs and fused implementations are not implemented yet. Explicit
-`impl="fused"` calls fail rather than falling back to the reference.
+The fused recurrent implementation requires CUDA with Triton, Q/K/V in FP16, BF16, or FP32, and
+`K <= 256`. Packed offsets must begin at zero, be nondecreasing, and end within the physical token
+capacity. Output rows beyond the terminal offset are inactive capacity and unspecified. The fused
+chunk implementation is not implemented yet; unsupported implementation choices fail rather than
+falling back to the reference.
 
 ### Migration from the prototype API
 

--- a/test/linear/test_gdn.py
+++ b/test/linear/test_gdn.py
@@ -62,6 +62,55 @@ def test_segmented_recurrent_execution_matches_full_sequence():
     torch.testing.assert_close(second_state, full_state)
 
 
+@pytest.mark.parametrize("function", REFERENCE_CASES)
+def test_packed_matches_independent_sequences(function):
+    q, k, v, gate, beta, _state = make_inputs(sequence=8)
+    q, k, v, gate, beta = (tensor[:1] for tensor in (q, k, v, gate, beta))
+    cu_seqlens = torch.tensor([0, 3, 3, 7], dtype=torch.int32)
+    initial_state = torch.randn(3, q.shape[2], q.shape[3], v.shape[-1])
+
+    output, final_state = function(
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        initial_state,
+        cu_seqlens=cu_seqlens,
+        output_final_state=True,
+    )
+    expected_output = torch.zeros_like(v)
+    expected_state = initial_state.clone()
+    for sequence, (begin, end) in enumerate(((0, 3), (3, 3), (3, 7))):
+        if begin == end:
+            continue
+        span = slice(begin, end)
+        span_output, span_state = function(
+            q[:, span],
+            k[:, span],
+            v[:, span],
+            gate[:, span],
+            beta[:, span],
+            initial_state[sequence : sequence + 1],
+            output_final_state=True,
+        )
+        expected_output[:, span] = span_output
+        expected_state[sequence] = span_state[0]
+
+    torch.testing.assert_close(output, expected_output)
+    torch.testing.assert_close(final_state, expected_state)
+
+
+@pytest.mark.parametrize("offsets", [[1, 3], [0, 4, 3], [0, 9]])
+def test_packed_rejects_invalid_offset_values(offsets):
+    inputs = make_inputs(sequence=8)
+    with pytest.raises(ValueError, match="start at zero, be nondecreasing"):
+        recurrent_gdn(
+            *(tensor[:1] for tensor in inputs[:-1]),
+            cu_seqlens=torch.tensor(offsets, dtype=torch.int32),
+        )
+
+
 def test_recurrent_execution_is_batch_invariant():
     inputs = make_inputs(sequence=5)
     batched_output, batched_state = recurrent_gdn(*inputs[:-1], output_final_state=True)
@@ -204,7 +253,9 @@ def test_impl_accepts_enum_and_string(function):
 
     with pytest.raises(ValueError, match="'fused', 'reference'"):
         function(*inputs[:-1], impl="eager")
-    with pytest.raises(NotImplementedError, match="impl='fused'"):
+    error = NotImplementedError if function is chunk_gdn else ValueError
+    message = "impl='fused'" if function is chunk_gdn else "requires CUDA tensors"
+    with pytest.raises(error, match=message):
         function(*inputs[:-1], impl=Impl.FUSED)
 
 

--- a/test/linear/test_gdn_fused.py
+++ b/test/linear/test_gdn_fused.py
@@ -1,0 +1,147 @@
+import pytest
+import torch
+import torch.nn.functional as F
+
+pytest.importorskip("triton")
+
+from attn_gym.linear import Impl, recurrent_gdn
+from attn_gym.linear.gdn.ops import recurrent_fwd_no_state_op, recurrent_fwd_op
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="the fused recurrent scan requires CUDA"
+)
+
+
+def make_inputs(
+    *, batch: int = 2, tokens: int = 9, heads: int = 2, key_dim: int = 32, value_dim: int = 24
+) -> tuple[torch.Tensor, ...]:
+    """Create stable token-major scalar-gate inputs."""
+    torch.manual_seed(0)
+    q = torch.randn(batch, tokens, heads, key_dim, device="cuda")
+    k = F.normalize(torch.randn_like(q), dim=-1)
+    v = torch.randn(batch, tokens, heads, value_dim, device="cuda")
+    gate = F.logsigmoid(torch.randn(batch, tokens, heads, device="cuda"))
+    beta = torch.sigmoid(torch.randn(batch, tokens, heads, device="cuda"))
+    state = torch.randn(batch, heads, key_dim, value_dim, device="cuda")
+    return q, k, v, gate, beta, state
+
+
+@pytest.mark.parametrize("use_initial_state", [False, True])
+@pytest.mark.parametrize("output_final_state", [False, True])
+def test_fused_recurrent_matches_reference(use_initial_state: bool, output_final_state: bool):
+    inputs = make_inputs()
+    state = inputs[-1] if use_initial_state else None
+    with torch.no_grad():
+        expected = recurrent_gdn(
+            *inputs[:-1],
+            state,
+            output_final_state=output_final_state,
+            impl=Impl.REFERENCE,
+        )
+        actual = recurrent_gdn(
+            *inputs[:-1],
+            state,
+            output_final_state=output_final_state,
+            autotune=False,
+            impl=Impl.FUSED,
+        )
+
+    torch.testing.assert_close(actual[0], expected[0], rtol=1e-5, atol=1e-5)
+    if output_final_state:
+        torch.testing.assert_close(actual[1], expected[1], rtol=1e-5, atol=1e-5)
+    else:
+        assert actual[1] is expected[1] is None
+
+
+def test_fused_recurrent_matches_packed_reference():
+    q, k, v, gate, beta, _state = make_inputs(batch=1, tokens=8)
+    cu_seqlens = torch.tensor([0, 3, 3, 7], device="cuda", dtype=torch.int32)
+    state = torch.randn(3, q.shape[2], q.shape[3], v.shape[-1], device="cuda")
+    with torch.no_grad():
+        expected = recurrent_gdn(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            state,
+            cu_seqlens=cu_seqlens,
+            output_final_state=True,
+            impl=Impl.REFERENCE,
+        )
+        actual = recurrent_gdn(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            state,
+            cu_seqlens=cu_seqlens,
+            output_final_state=True,
+            autotune=False,
+            impl=Impl.FUSED,
+        )
+
+    # Rows beyond the terminal offset are inactive capacity and have unspecified values.
+    torch.testing.assert_close(actual[0][:, :7], expected[0][:, :7], rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(actual[1], expected[1], rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.parametrize("output_final_state", [False, True])
+def test_fused_recurrent_registration(output_final_state: bool):
+    q, k, v, gate, beta, state = make_inputs(batch=1, tokens=3)
+    op = recurrent_fwd_op if output_final_state else recurrent_fwd_no_state_op
+    torch.library.opcheck(
+        op,
+        (q, k, v, gate, beta, state, None, q.shape[-1] ** -0.5, False),
+    )
+
+
+def test_fused_recurrent_default_autotune():
+    inputs = make_inputs(batch=1, tokens=3)
+    with torch.no_grad():
+        output, _ = recurrent_gdn(*inputs, impl=Impl.FUSED)
+    assert torch.isfinite(output).all()
+
+
+def test_fused_recurrent_low_precision():
+    inputs = make_inputs(batch=1, tokens=7)
+    q, k, v = (tensor.bfloat16() for tensor in inputs[:3])
+    with torch.no_grad():
+        output, final_state = recurrent_gdn(
+            q,
+            k,
+            v,
+            *inputs[3:5],
+            inputs[5],
+            output_final_state=True,
+            autotune=False,
+            impl=Impl.FUSED,
+        )
+    assert output.dtype == torch.bfloat16
+    assert final_state.dtype == torch.float32
+    assert torch.isfinite(output).all() and torch.isfinite(final_state).all()
+
+
+def test_fused_recurrent_fullgraph():
+    inputs = make_inputs(batch=1, tokens=3)
+
+    @torch.compile(fullgraph=True)
+    def compiled(*args):
+        return recurrent_gdn(
+            *args,
+            output_final_state=True,
+            autotune=False,
+            impl=Impl.FUSED,
+        )
+
+    with torch.no_grad():
+        expected = recurrent_gdn(
+            *inputs,
+            output_final_state=True,
+            autotune=False,
+            impl=Impl.FUSED,
+        )
+        actual = compiled(*inputs)
+    torch.testing.assert_close(actual[0], expected[0])
+    torch.testing.assert_close(actual[1], expected[1])


### PR DESCRIPTION
Stacked PRs:
 * #381
 * __->__#380


--- --- ---

Add fused recurrent GDN

## Human Note

## Agent note

Use the shared scalar-gate recurrent scan as GDN\x27s first fused backend and add packed-sequence
support to the reference and fused paths. Keep the registered operators GDN-owned, with separate
fixed-arity schemas for calls that do and do not return final state.

## Test Plan

```bash
.venv/bin/prek run --files attn_gym/linear/gdn/api.py attn_gym/linear/gdn/ops.py attn_gym/linear/gdn/impl/fused.py attn_gym/linear/gdn/impl/reference.py attn_gym/linear/gdn/validation.py docs/linear.md test/linear/test_gdn.py test/linear/test_gdn_fused.py
.venv/bin/pytest -q test/linear/test_gdn.py test/test_namespaces.py
gpu-run auto -- .venv/bin/pytest -q test/linear/test_gdn_fused.py
```