### PR TITLE
Add paged recurrent GDN

### DIFF
--- a/attn_gym/linear/_delta_rule/recurrent.py
+++ b/attn_gym/linear/_delta_rule/recurrent.py
@@ -63,6 +63,7 @@ def _recurrent_delta_rule_fwd_kernel(
     ht,
     cu_seqlens,
     state_indices,
+    has_initial_state,
     scale,
     T,
     N,
@@ -76,6 +77,7 @@ def _recurrent_delta_rule_fwd_kernel(
     STORE_FINAL_STATE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     USE_STATE_INDICES: tl.constexpr,
+    USE_HAS_INITIAL_STATE: tl.constexpr,
     SCALAR_GATE: tl.constexpr,
 ):
     """Scan one sequence/head/value tile while retaining the FP32 state in registers."""
@@ -93,17 +95,15 @@ def _recurrent_delta_rule_fwd_kernel(
         bos = i_n * T
         eos = bos + T
 
-    if USE_STATE_INDICES and bos == eos:
-        return
-
     o_k = tl.arange(0, BK)
     o_v = i_v * BV + tl.arange(0, BV)
     m_k = o_k < K
     m_v = o_v < V
     m_kv = m_k[:, None] & m_v[None, :]
 
-    # Paged mode addresses the state pool by slot instead of by sequence position. Active
-    # sequences must select distinct, positive, in-bounds slots; nonpositive slots are padding.
+    # Paged mode addresses the state pool by slot instead of by sequence position. Empty
+    # sequences still take the load/store path below so that a freshly assigned slot is
+    # initialized before a later decode reads it.
     if USE_STATE_INDICES:
         i_state = tl.load(state_indices + i_n).to(tl.int64)
         if i_state <= 0:
@@ -121,7 +121,10 @@ def _recurrent_delta_rule_fwd_kernel(
             (state_batch_stride, K * V, V, 1),
         )
     if USE_INITIAL_STATE:
-        b_state = tl.load(h0 + p_state, mask=m_kv, other=0.0).to(tl.float32)
+        m_state = m_kv
+        if USE_HAS_INITIAL_STATE:
+            m_state &= tl.load(has_initial_state + i_n)
+        b_state = tl.load(h0 + p_state, mask=m_state, other=0.0).to(tl.float32)
     else:
         b_state = tl.zeros([BK, BV], dtype=tl.float32)
 
@@ -186,14 +189,47 @@ def launch_recurrent_delta_rule_fwd(
     gate_kind: GateKind,
     store_final_state: bool,
     state_indices: torch.Tensor | None = None,
+    has_initial_state: torch.Tensor | None = None,
     autotune: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
-    """Launch a scalar- or vector-gated recurrent delta-rule specialization."""
+    """Launch a scalar- or vector-gated recurrent delta-rule specialization.
+
+    Args:
+        q: Queries shaped ``[B, T, H, K]``; packed callers pass ``B == 1``.
+        k: Keys shaped like ``q``.
+        v: Values shaped ``[B, T, H, V]``.
+        gate: Natural-log decay, shaped ``[B, T, H]`` for ``GateKind.SCALAR`` or like ``q``
+            for ``GateKind.VECTOR``.
+        beta: Per-token write gate shaped ``[B, T, H]``.
+        initial_state: Optional FP32 starting state shaped ``[N, H, K, V]``, or the mutable
+            ``[slots, H, V, K]`` pool that ``state_indices`` addresses in paged mode.
+        cu_seqlens: Optional packed boundaries shaped ``[N + 1]``; offsets are trusted and
+            must be validated by the caller before launch.
+        scale: Multiplier applied to ``q`` before each state read.
+        gate_kind: Gate layout consumed by the scan.
+        store_final_state: Allocate and return the post-scan state; implied and mandatory in
+            paged mode, where the pool itself is advanced in place.
+        state_indices: Optional per-sequence slot indices enabling paged mode. Active
+            sequences must select distinct, positive, in-bounds slots; nonpositive entries
+            are padding that produce zero output and leave the pool untouched.
+        has_initial_state: Optional per-sequence booleans qualifying paged slots. Pool
+            allocators hand out slots without zeroing them, so a False entry marks garbage
+            contents: the scan starts from zero and overwrites the slot, including for empty
+            sequences, so the slot is initialized before a later decode reads it. Without
+            this mask every selected slot is treated as real history.
+        autotune: Benchmark tile configurations when true; paged launches always use fixed
+            heuristics because rerunning candidates would advance the pool repeatedly.
+
+    Returns:
+        The output in ``q.dtype`` plus the final state (``None`` unless requested). In paged
+        mode the returned state aliases ``initial_state``.
+    """
     assert k.shape == q.shape
     assert v.shape[:3] == q.shape[:3]
     assert gate.shape == (q.shape[:-1] if gate_kind is GateKind.SCALAR else q.shape)
     assert beta.shape == q.shape[:-1]
     assert all(tensor.is_contiguous() for tensor in (q, k, v, gate, beta))
+    assert has_initial_state is None or state_indices is not None
 
     batch, tokens, heads, key_dim = q.shape
     value_dim = v.shape[-1]
@@ -254,6 +290,7 @@ def launch_recurrent_delta_rule_fwd(
         final_state,
         cu_seqlens,
         state_indices,
+        has_initial_state,
         scale=scale,
         T=tokens,
         N=num_sequences,
@@ -266,6 +303,7 @@ def launch_recurrent_delta_rule_fwd(
         STORE_FINAL_STATE=final_state is not None,
         IS_VARLEN=cu_seqlens is not None,
         USE_STATE_INDICES=state_indices is not None,
+        USE_HAS_INITIAL_STATE=has_initial_state is not None,
         SCALAR_GATE=gate_kind is GateKind.SCALAR,
         **launch_options,
     )

--- a/attn_gym/linear/_delta_rule/validation.py
+++ b/attn_gym/linear/_delta_rule/validation.py
@@ -1,0 +1,57 @@
+"""Validation shared by paged delta-rule operations."""
+
+from __future__ import annotations
+
+import torch
+
+
+def validate_paged_state(
+    q: torch.Tensor,
+    v: torch.Tensor,
+    state_cache: torch.Tensor,
+    cu_seqlens: torch.Tensor | None,
+    state_indices: torch.Tensor,
+    has_initial_state: torch.Tensor | None = None,
+) -> None:
+    """Validate the shared mutable ``[slots, H, V, K]`` state contract."""
+    expected_shape = (q.shape[2], v.shape[-1], q.shape[3])
+    if state_cache.ndim != 4 or state_cache.shape[1:] != expected_shape:
+        raise ValueError(
+            "the paged state pool must have shape "
+            f"[num_slots, {q.shape[2]}, {v.shape[-1]}, {q.shape[3]}], "
+            f"got {tuple(state_cache.shape)}"
+        )
+    if state_cache.device != q.device:
+        raise ValueError("the paged state pool must be on q.device")
+    if state_cache.dtype != torch.float32:
+        raise TypeError("the paged state pool must use float32")
+    expected_inner_strides = (v.shape[-1] * q.shape[3], q.shape[3], 1)
+    if state_cache.stride()[1:] != expected_inner_strides:
+        raise TypeError("the paged state pool must be contiguous within each [H, V, K] slot")
+    if state_cache.stride(0) < q.shape[2] * q.shape[3] * v.shape[-1]:
+        raise ValueError("paged state pool slots must not overlap")
+
+    num_sequences = q.shape[0] if cu_seqlens is None else cu_seqlens.shape[0] - 1
+    if (
+        tuple(state_indices.shape) != (num_sequences,)
+        or state_indices.dtype != torch.int32
+        or not state_indices.is_contiguous()
+        or state_indices.device != q.device
+    ):
+        raise ValueError(
+            f"state_indices must be a contiguous int32 tensor of shape ({num_sequences},) "
+            f"on q.device, got {tuple(state_indices.shape)} of {state_indices.dtype}"
+        )
+    if has_initial_state is not None and (
+        tuple(has_initial_state.shape) != (num_sequences,)
+        or has_initial_state.dtype != torch.bool
+        or not has_initial_state.is_contiguous()
+        or has_initial_state.device != q.device
+    ):
+        raise ValueError(
+            "has_initial_state must be a contiguous bool tensor with one entry "
+            "per sequence on q.device"
+        )
+
+
+__all__ = ["validate_paged_state"]

--- a/attn_gym/linear/gdn/api.py
+++ b/attn_gym/linear/gdn/api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import torch
 
+from attn_gym.linear._delta_rule.validation import validate_paged_state
 from attn_gym.linear.gdn.impl.reference import chunk_forward, recurrent_forward, reference_gdn
 from attn_gym.linear.gdn.ops import recurrent_forward as fused_recurrent_forward
 from attn_gym.linear.gdn.validation import validate_gdn_inputs
@@ -79,6 +80,8 @@ def recurrent_gdn(
     cu_seqlens: torch.Tensor | None = None,
     scale: float | None = None,
     output_final_state: bool = False,
+    state_indices: torch.Tensor | None = None,
+    has_initial_state: torch.Tensor | None = None,
     autotune: bool = True,
     impl: Impl | str = Impl.REFERENCE,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
@@ -100,9 +103,17 @@ def recurrent_gdn(
             zero, never decrease, and may end before ``T``; output beyond the terminal offset is
             unspecified.
         scale: Query scale. Defaults to ``1 / sqrt(K)``.
-        output_final_state: Return the final recurrent state with the output.
-        autotune: Benchmark candidate value-tile sizes for the fused implementation when true;
-            winners are cached and reused.
+        output_final_state: Return the final recurrent state with the output. Rejected with
+            ``state_indices``, which advances the state pool in place instead.
+        state_indices: Optional contiguous ``int32`` slot indices selecting rows of a mutable
+            ``initial_state`` pool shaped ``[num_slots, H, V, K]``. Positive indices must be unique
+            and in ``[1, num_slots)``; nonpositive indices produce zero output and leave the pool
+            untouched. These value constraints are caller responsibilities.
+        has_initial_state: Optional contiguous boolean mask indicating whether each selected slot
+            should be loaded. False entries mark freshly assigned slots whose contents are
+            garbage: they start from zero and overwrite the slot, even for empty sequences.
+        autotune: Benchmark candidate value-tile sizes for non-paged execution when true; paged
+            execution always uses deterministic heuristics because it mutates the state cache.
         impl: ``"fused"`` uses the inference-only Triton scan; ``"reference"`` uses eager
             PyTorch with autograd support.
 
@@ -110,7 +121,26 @@ def recurrent_gdn(
         The output in ``q.dtype`` and either the final recurrent state or ``None``.
     """
     selected_impl = resolve_impl(impl)
-    validate_gdn_inputs(q, k, v, gate, beta, initial_state, cu_seqlens)
+    validate_gdn_inputs(
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        None if state_indices is not None else initial_state,
+        cu_seqlens,
+    )
+    if state_indices is not None:
+        if initial_state is None:
+            raise ValueError("state_indices requires initial_state as the paged state pool")
+        if output_final_state:
+            raise ValueError("state_indices advances the pool in place; drop output_final_state")
+        validate_paged_state(q, v, initial_state, cu_seqlens, state_indices, has_initial_state)
+        if selected_impl is not Impl.FUSED:
+            raise ValueError("state_indices requires impl='fused'")
+    elif has_initial_state is not None:
+        raise ValueError("has_initial_state requires state_indices")
+
     scale = q.shape[-1] ** -0.5 if scale is None else scale
     if selected_impl is Impl.FUSED:
         return fused_recurrent_forward(
@@ -123,6 +153,8 @@ def recurrent_gdn(
             cu_seqlens=cu_seqlens,
             scale=scale,
             output_final_state=output_final_state,
+            state_indices=state_indices,
+            has_initial_state=has_initial_state,
             autotune=autotune,
         )
 

--- a/attn_gym/linear/gdn/impl/fused.py
+++ b/attn_gym/linear/gdn/impl/fused.py
@@ -19,6 +19,8 @@ def _launch_recurrent(
     autotune: bool,
     *,
     output_final_state: bool,
+    state_indices: torch.Tensor | None = None,
+    has_initial_state: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Launch the scalar-gate specialization of the shared log2-space scan."""
     return launch_recurrent_delta_rule_fwd(
@@ -32,6 +34,8 @@ def _launch_recurrent(
         scale=scale,
         gate_kind=GateKind.SCALAR,
         store_final_state=output_final_state,
+        state_indices=state_indices,
+        has_initial_state=has_initial_state,
         autotune=autotune,
     )
 
@@ -85,6 +89,35 @@ def _gdn_recurrent_fwd_no_state_cuda(
         scale,
         autotune,
         output_final_state=False,
+    )[0]
+
+
+def _gdn_recurrent_fwd_paged_cuda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    state_cache: torch.Tensor,
+    state_indices: torch.Tensor,
+    has_initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+    scale: float,
+) -> torch.Tensor:
+    """Advance selected cache slots with the shared scalar-gate scan."""
+    return _launch_recurrent(
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        state_cache,
+        cu_seqlens,
+        scale,
+        False,
+        output_final_state=True,
+        state_indices=state_indices,
+        has_initial_state=has_initial_state,
     )[0]
 
 

--- a/attn_gym/linear/gdn/ops.py
+++ b/attn_gym/linear/gdn/ops.py
@@ -12,6 +12,11 @@ _RECURRENT_ARGS = (
 )
 torch.library.define("attn_gym::gdn_recurrent_fwd", _RECURRENT_ARGS + " -> (Tensor, Tensor)")
 torch.library.define("attn_gym::gdn_recurrent_fwd_no_state", _RECURRENT_ARGS + " -> Tensor")
+torch.library.define(
+    "attn_gym::gdn_recurrent_fwd_paged",
+    "(Tensor q, Tensor k, Tensor v, Tensor gate, Tensor beta, Tensor(a!) state_cache, "
+    "Tensor state_indices, Tensor? has_initial_state, Tensor? cu_seqlens, float scale) -> Tensor",
+)
 
 
 def _recurrent_backend():
@@ -31,11 +36,20 @@ def _recurrent_fwd_no_state_cuda(*args):
     return _recurrent_backend()._gdn_recurrent_fwd_no_state_cuda(*args)
 
 
+def _recurrent_fwd_paged_cuda(*args):
+    return _recurrent_backend()._gdn_recurrent_fwd_paged_cuda(*args)
+
+
 torch.library.impl("attn_gym::gdn_recurrent_fwd", "CUDA", _recurrent_fwd_cuda)
 torch.library.impl(
     "attn_gym::gdn_recurrent_fwd_no_state",
     "CUDA",
     _recurrent_fwd_no_state_cuda,
+)
+torch.library.impl(
+    "attn_gym::gdn_recurrent_fwd_paged",
+    "CUDA",
+    _recurrent_fwd_paged_cuda,
 )
 
 
@@ -75,8 +89,26 @@ def _recurrent_fwd_no_state_fake(
     return torch.empty_like(v, dtype=q.dtype)
 
 
+@torch.library.register_fake("attn_gym::gdn_recurrent_fwd_paged")
+def _recurrent_fwd_paged_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    state_cache: torch.Tensor,
+    state_indices: torch.Tensor,
+    has_initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+    scale: float,
+) -> torch.Tensor:
+    del k, gate, beta, state_cache, state_indices, has_initial_state, cu_seqlens, scale
+    return torch.empty_like(v, dtype=q.dtype)
+
+
 recurrent_fwd_op = torch.ops.attn_gym.gdn_recurrent_fwd.default
 recurrent_fwd_no_state_op = torch.ops.attn_gym.gdn_recurrent_fwd_no_state.default
+recurrent_fwd_paged_op = torch.ops.attn_gym.gdn_recurrent_fwd_paged.default
 
 
 def recurrent_forward(
@@ -90,6 +122,8 @@ def recurrent_forward(
     cu_seqlens: torch.Tensor | None,
     scale: float,
     output_final_state: bool,
+    state_indices: torch.Tensor | None,
+    has_initial_state: torch.Tensor | None,
     autotune: bool,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Normalize inputs and invoke the fused recurrent GDN operator."""
@@ -108,6 +142,20 @@ def recurrent_forward(
 
     q, k, v = (tensor.contiguous() for tensor in (q, k, v))
     gate, beta = (tensor.float().contiguous() for tensor in (gate, beta))
+    if state_indices is not None:
+        assert initial_state is not None
+        return recurrent_fwd_paged_op(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            initial_state,
+            state_indices,
+            has_initial_state,
+            cu_seqlens,
+            scale,
+        ), None
     if initial_state is not None:
         initial_state = initial_state.contiguous()
     args = (q, k, v, gate, beta, initial_state, cu_seqlens, scale, autotune)
@@ -116,4 +164,9 @@ def recurrent_forward(
     return recurrent_fwd_no_state_op(*args), None
 
 
-__all__ = ["recurrent_forward", "recurrent_fwd_no_state_op", "recurrent_fwd_op"]
+__all__ = [
+    "recurrent_forward",
+    "recurrent_fwd_no_state_op",
+    "recurrent_fwd_op",
+    "recurrent_fwd_paged_op",
+]

--- a/attn_gym/linear/kda/api.py
+++ b/attn_gym/linear/kda/api.py
@@ -20,6 +20,7 @@ from typing import Literal
 
 import torch
 
+from attn_gym.linear._delta_rule.validation import validate_paged_state
 from attn_gym.linear.kda.constants import LOG2_E
 from attn_gym.linear.kda.impl.fused import chunk_forward as _fused_chunk_forward
 from attn_gym.linear.kda.impl.fused import paged_chunk_forward as _fused_paged_chunk_forward
@@ -187,7 +188,7 @@ def paged_chunk_kda(
         op_name="paged_chunk_kda",
         gate_name="gate",
     )
-    _validate_paged_state(
+    validate_paged_state(
         q,
         v,
         state_cache,
@@ -209,54 +210,6 @@ def paged_chunk_kda(
     )
 
 
-def _validate_paged_state(
-    q: torch.Tensor,
-    v: torch.Tensor,
-    state_cache: torch.Tensor,
-    cu_seqlens: torch.Tensor | None,
-    state_indices: torch.Tensor,
-    has_initial_state: torch.Tensor | None = None,
-) -> None:
-    """Validate the paged state pool and its slot indices."""
-    expected_shape = (q.shape[2], v.shape[-1], q.shape[3])
-    if state_cache.ndim != 4 or state_cache.shape[1:] != expected_shape:
-        raise ValueError(
-            "the paged state pool must have shape "
-            f"[num_slots, {q.shape[2]}, {v.shape[-1]}, {q.shape[3]}], "
-            f"got {tuple(state_cache.shape)}"
-        )
-    if state_cache.device != q.device:
-        raise ValueError("the paged state pool must be on q.device")
-    if state_cache.dtype != torch.float32:
-        raise TypeError("the paged state pool must use float32")
-    expected_inner_strides = (v.shape[-1] * q.shape[3], q.shape[3], 1)
-    if state_cache.stride()[1:] != expected_inner_strides:
-        raise TypeError("the paged state pool must be contiguous within each [H, V, K] slot")
-    if state_cache.stride(0) < q.shape[2] * q.shape[3] * v.shape[-1]:
-        raise ValueError("paged state pool slots must not overlap")
-    num_sequences = q.shape[0] if cu_seqlens is None else cu_seqlens.shape[0] - 1
-    if (
-        tuple(state_indices.shape) != (num_sequences,)
-        or state_indices.dtype != torch.int32
-        or not state_indices.is_contiguous()
-        or state_indices.device != q.device
-    ):
-        raise ValueError(
-            f"state_indices must be a contiguous int32 tensor of shape ({num_sequences},) "
-            f"on q.device, got {tuple(state_indices.shape)} of {state_indices.dtype}"
-        )
-    if has_initial_state is not None and (
-        tuple(has_initial_state.shape) != (num_sequences,)
-        or has_initial_state.dtype != torch.bool
-        or not has_initial_state.is_contiguous()
-        or has_initial_state.device != q.device
-    ):
-        raise ValueError(
-            "has_initial_state must be a contiguous bool tensor with one entry "
-            "per sequence on q.device"
-        )
-
-
 def recurrent_kda(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -268,6 +221,7 @@ def recurrent_kda(
     cu_seqlens: torch.Tensor | None = None,
     output_final_state: bool = False,
     state_indices: torch.Tensor | None = None,
+    has_initial_state: torch.Tensor | None = None,
     autotune: bool = True,
     impl: Impl | str = Impl.FUSED,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
@@ -305,6 +259,8 @@ def recurrent_kda(
                 seq 1 is padding (index is -1) so this is ignored
                 seq 2 reads and updates initial_state[5]
                 seq 3 is padding bc 0
+        has_initial_state: Optional contiguous boolean mask, one per logical sequence.
+            False entries ignore stale contents in the selected slot and start from zero.
         autotune: Benchmark candidate value-tile sizes for non-paged execution
             when true; winners are cached and reused. Paged execution and false
             use a deterministic sequence-length heuristic.
@@ -339,9 +295,11 @@ def recurrent_kda(
             raise ValueError("state_indices requires initial_state as the paged state pool")
         if output_final_state:
             raise ValueError("state_indices advances the pool in place; drop output_final_state")
-        _validate_paged_state(q, v, initial_state, cu_seqlens, state_indices)
+        validate_paged_state(q, v, initial_state, cu_seqlens, state_indices, has_initial_state)
         if selected_impl is not Impl.FUSED:
             raise ValueError("state_indices requires impl='fused'")
+    elif has_initial_state is not None:
+        raise ValueError("has_initial_state requires state_indices")
     if selected_impl is Impl.FUSED:
         return _fused_recurrent_forward(
             q,
@@ -353,6 +311,7 @@ def recurrent_kda(
             cu_seqlens=cu_seqlens,
             output_final_state=output_final_state,
             state_indices=state_indices,
+            has_initial_state=has_initial_state,
             autotune=autotune,
         )
     return reference_kda(
@@ -395,10 +354,8 @@ def recurrent_kda_decode(
         state_cache: FP32 paged state pool shaped ``[num_slots, H, V, K]``. Slots
             may have padding between them but each ``[H, V, K]`` row must be dense.
             ``K`` must be at most 256.
-            The prefill kernel uses ``[H, K, V]``, while this decode kernel uses
-            ``[H, V, K]`` because decode benefits significantly from a contiguous
-            ``K`` dimension. A prefill-to-decode transition therefore requires a
-            transpose/layout conversion.
+            Paged chunk and recurrent prefill use the same ``[H, V, K]`` slot layout, so the
+            cache can transition directly from prefill to decode without a layout conversion.
         state_indices: Contiguous int32 slot indices shaped ``[B]``. Non-positive
             indices are padding/null entries: they produce zero output and leave the
             cache untouched. Each positive index must be in ``[1, num_slots)`` and

--- a/attn_gym/linear/kda/fwd/triton/recurrent.py
+++ b/attn_gym/linear/kda/fwd/triton/recurrent.py
@@ -122,6 +122,7 @@ def _launch_kda_recurrent_fwd(
     *,
     store_final_state: bool,
     state_indices: torch.Tensor | None = None,
+    has_initial_state: torch.Tensor | None = None,
     autotune: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Launch the vector-gate specialization used by recurrent KDA."""
@@ -137,6 +138,7 @@ def _launch_kda_recurrent_fwd(
         gate_kind=GateKind.VECTOR,
         store_final_state=store_final_state,
         state_indices=state_indices,
+        has_initial_state=has_initial_state,
         autotune=autotune,
     )
 
@@ -197,8 +199,8 @@ def _kda_recurrent_fwd_paged_cuda(
     beta: torch.Tensor,
     state_cache: torch.Tensor,
     state_indices: torch.Tensor,
+    has_initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor | None,
-    autotune: bool,
 ) -> torch.Tensor:
     return _launch_kda_recurrent_fwd(
         q,
@@ -210,7 +212,8 @@ def _kda_recurrent_fwd_paged_cuda(
         cu_seqlens,
         store_final_state=True,
         state_indices=state_indices,
-        autotune=autotune,
+        has_initial_state=has_initial_state,
+        autotune=False,
     )[0]
 
 

--- a/attn_gym/linear/kda/ops.py
+++ b/attn_gym/linear/kda/ops.py
@@ -108,7 +108,7 @@ torch.library.define("attn_gym::kda_recurrent_fwd_no_state", _RECURRENT_FWD_ARGS
 torch.library.define(
     "attn_gym::kda_recurrent_fwd_paged",
     "(Tensor q, Tensor k, Tensor v, Tensor gate, Tensor beta, Tensor(a!) state_cache,"
-    " Tensor state_indices, Tensor? cu_seqlens, bool autotune) -> Tensor",
+    " Tensor state_indices, Tensor? has_initial_state, Tensor? cu_seqlens) -> Tensor",
 )
 torch.library.define(
     "attn_gym::kda_recurrent_decode",
@@ -673,10 +673,10 @@ def _recurrent_fwd_paged_fake(
     beta: torch.Tensor,
     state_cache: torch.Tensor,
     state_indices: torch.Tensor,
+    has_initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor | None,
-    autotune: bool,
 ) -> torch.Tensor:
-    del k, gate, beta, state_cache, state_indices, cu_seqlens, autotune
+    del k, gate, beta, state_cache, state_indices, has_initial_state, cu_seqlens
     return torch.empty_like(v, dtype=q.dtype)
 
 
@@ -822,6 +822,7 @@ def recurrent_forward(
     cu_seqlens: torch.Tensor | None = None,
     output_final_state: bool = False,
     state_indices: torch.Tensor | None = None,
+    has_initial_state: torch.Tensor | None = None,
     autotune: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Validate and invoke the lazily loaded fused recurrent implementation."""
@@ -845,7 +846,7 @@ def recurrent_forward(
         # `.contiguous()` on the pool would copy and silently drop the in-place advance.
         assert initial_state is not None
         return recurrent_fwd_paged_op(
-            q, k, v, gate, beta, initial_state, state_indices, cu_seqlens, autotune
+            q, k, v, gate, beta, initial_state, state_indices, has_initial_state, cu_seqlens
         ), None
     if initial_state is not None:
         initial_state = initial_state.contiguous()

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -41,7 +41,8 @@ output, final_state = chunk_gdn(
   with `cu_seqlens`.
 - Separate recurrent and chunked operations with explicit initial and final state.
 - CPU and CUDA execution through eager PyTorch operations.
-- An inference-only fused recurrent implementation on CUDA.
+- An inference-only fused recurrent implementation on CUDA, including mutable paged state caches
+  shaped `[num_slots, H, V, K]` selected by `state_indices`.
 - Autograd for reference inputs and initial state.
 - Q/K/V share one dtype. FP16 and BF16 inputs use FP32 recurrence math and state while returning
   output in the Q dtype.

--- a/test/linear/test_gdn.py
+++ b/test/linear/test_gdn.py
@@ -266,6 +266,31 @@ def test_invalid_initial_state_shape_fails_clearly(function):
         function(*inputs[:-1], initial_state=inputs[-1][..., :-1])
 
 
+def test_recurrent_paged_validates_mode_contract():
+    q, k, v, gate, beta, _state = make_inputs(sequence=2)
+    state_cache = torch.randn(4, q.shape[2], v.shape[-1], q.shape[-1])
+    state_indices = torch.tensor([1, 2], dtype=torch.int32)
+    has_initial_state = torch.ones(2, dtype=torch.bool)
+
+    with pytest.raises(ValueError, match="requires initial_state"):
+        recurrent_gdn(q, k, v, gate, beta, state_indices=state_indices)
+    with pytest.raises(ValueError, match="drop output_final_state"):
+        recurrent_gdn(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            state_cache,
+            state_indices=state_indices,
+            output_final_state=True,
+        )
+    with pytest.raises(ValueError, match="requires impl='fused'"):
+        recurrent_gdn(q, k, v, gate, beta, state_cache, state_indices=state_indices)
+    with pytest.raises(ValueError, match="requires state_indices"):
+        recurrent_gdn(q, k, v, gate, beta, has_initial_state=has_initial_state)
+
+
 def test_mismatched_qkv_dtypes_fail_clearly():
     inputs = list(make_inputs(sequence=2))
     inputs[2] = inputs[2].double()

--- a/test/linear/test_gdn_fused.py
+++ b/test/linear/test_gdn_fused.py
@@ -5,7 +5,11 @@ import torch.nn.functional as F
 pytest.importorskip("triton")
 
 from attn_gym.linear import Impl, recurrent_gdn
-from attn_gym.linear.gdn.ops import recurrent_fwd_no_state_op, recurrent_fwd_op
+from attn_gym.linear.gdn.ops import (
+    recurrent_fwd_no_state_op,
+    recurrent_fwd_op,
+    recurrent_fwd_paged_op,
+)
 
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available(), reason="the fused recurrent scan requires CUDA"
@@ -87,6 +91,159 @@ def test_fused_recurrent_matches_packed_reference():
     torch.testing.assert_close(actual[1], expected[1], rtol=1e-5, atol=1e-5)
 
 
+def test_fused_recurrent_paged_state():
+    q, k, v, gate, beta, _state = make_inputs(batch=3, tokens=5)
+    slots = torch.tensor([2, 0, 4], device="cuda", dtype=torch.int32)
+    has_initial_state = torch.tensor([True, False, False], device="cuda")
+    storage = torch.randn(6, q.shape[2] * v.shape[-1] * q.shape[-1] + 17, device="cuda")
+    state_cache = storage[:, : q.shape[2] * v.shape[-1] * q.shape[-1]].view(
+        6, q.shape[2], v.shape[-1], q.shape[-1]
+    )
+    original_cache = state_cache.clone()
+
+    expected_output = torch.zeros_like(v)
+    expected_cache = original_cache.clone()
+    with torch.no_grad():
+        for sequence, slot in ((0, 2), (2, 4)):
+            initial_state = (
+                original_cache[slot].transpose(-1, -2).unsqueeze(0)
+                if has_initial_state[sequence]
+                else None
+            )
+            output, final_state = recurrent_gdn(
+                q[sequence : sequence + 1],
+                k[sequence : sequence + 1],
+                v[sequence : sequence + 1],
+                gate[sequence : sequence + 1],
+                beta[sequence : sequence + 1],
+                initial_state,
+                output_final_state=True,
+                impl=Impl.REFERENCE,
+            )
+            expected_output[sequence] = output[0]
+            expected_cache[slot] = final_state[0].transpose(-1, -2)
+
+        output, final_state = recurrent_gdn(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            state_cache,
+            state_indices=slots,
+            has_initial_state=has_initial_state,
+            impl=Impl.FUSED,
+        )
+
+    assert final_state is None
+    torch.testing.assert_close(output, expected_output, rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(state_cache, expected_cache, rtol=1e-5, atol=1e-5)
+
+
+def test_fused_recurrent_packed_paged_state():
+    q, k, v, gate, beta, _state = make_inputs(batch=1, tokens=8)
+    cu_seqlens = torch.tensor([0, 3, 3, 7], device="cuda", dtype=torch.int32)
+    slots = torch.tensor([2, 0, 4], device="cuda", dtype=torch.int32)
+    has_initial_state = torch.tensor([True, False, False], device="cuda")
+    state_cache = torch.randn(6, q.shape[2], v.shape[-1], q.shape[-1], device="cuda")
+    original_cache = state_cache.clone()
+    expected_output = torch.zeros_like(v)
+    expected_cache = original_cache.clone()
+
+    with torch.no_grad():
+        for begin, end, slot, use_state in (
+            (0, 3, 2, True),
+            (3, 3, 0, False),
+            (3, 7, 4, False),
+        ):
+            if begin == end or slot <= 0:
+                continue
+            span = slice(begin, end)
+            initial_state = (
+                original_cache[slot].transpose(-1, -2).unsqueeze(0) if use_state else None
+            )
+            span_output, span_state = recurrent_gdn(
+                q[:, span],
+                k[:, span],
+                v[:, span],
+                gate[:, span],
+                beta[:, span],
+                initial_state,
+                output_final_state=True,
+                impl=Impl.REFERENCE,
+            )
+            expected_output[:, span] = span_output
+            expected_cache[slot] = span_state[0].transpose(-1, -2)
+
+        output, _ = recurrent_gdn(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            state_cache,
+            cu_seqlens=cu_seqlens,
+            state_indices=slots,
+            has_initial_state=has_initial_state,
+            impl=Impl.FUSED,
+        )
+
+    torch.testing.assert_close(output[:, :7], expected_output[:, :7], rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(state_cache, expected_cache, rtol=1e-5, atol=1e-5)
+
+
+def test_fused_recurrent_packed_paged_empty_sequences():
+    """Empty packed sequences zero freshly assigned slots and preserve resumed ones."""
+    q, k, v, gate, beta, _state = make_inputs(batch=1, tokens=4)
+    cu_seqlens = torch.tensor([0, 0, 4, 4], device="cuda", dtype=torch.int32)
+    slots = torch.tensor([2, 3, 5], device="cuda", dtype=torch.int32)
+    has_initial_state = torch.tensor([False, False, True], device="cuda")
+    state_cache = torch.randn(6, q.shape[2], v.shape[-1], q.shape[-1], device="cuda")
+    original_cache = state_cache.clone()
+
+    with torch.no_grad():
+        recurrent_gdn(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            state_cache,
+            cu_seqlens=cu_seqlens,
+            state_indices=slots,
+            has_initial_state=has_initial_state,
+            impl=Impl.FUSED,
+        )
+
+    # The empty fresh sequence must initialize its slot to the zero state.
+    torch.testing.assert_close(state_cache[2], torch.zeros_like(state_cache[2]))
+    # The empty resumed sequence and unselected slots keep their contents.
+    preserved = [0, 1, 4, 5]
+    torch.testing.assert_close(state_cache[preserved], original_cache[preserved])
+
+
+def test_fused_recurrent_paged_registration():
+    q, k, v, gate, beta, _state = make_inputs(batch=1, tokens=3)
+    state_cache = torch.randn(3, q.shape[2], v.shape[-1], q.shape[-1], device="cuda")
+    state_indices = torch.tensor([2], device="cuda", dtype=torch.int32)
+    has_initial_state = torch.tensor([True], device="cuda")
+    torch.library.opcheck(
+        recurrent_fwd_paged_op,
+        (
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            state_cache,
+            state_indices,
+            has_initial_state,
+            None,
+            q.shape[-1] ** -0.5,
+        ),
+    )
+
+
 @pytest.mark.parametrize("output_final_state", [False, True])
 def test_fused_recurrent_registration(output_final_state: bool):
     q, k, v, gate, beta, state = make_inputs(batch=1, tokens=3)
@@ -121,6 +278,45 @@ def test_fused_recurrent_low_precision():
     assert output.dtype == torch.bfloat16
     assert final_state.dtype == torch.float32
     assert torch.isfinite(output).all() and torch.isfinite(final_state).all()
+
+
+def test_fused_recurrent_paged_fullgraph():
+    q, k, v, gate, beta, _state = make_inputs(batch=1, tokens=3)
+    state_cache = torch.randn(3, q.shape[2], v.shape[-1], q.shape[-1], device="cuda")
+    expected_cache = state_cache.clone()
+    state_indices = torch.tensor([2], device="cuda", dtype=torch.int32)
+    has_initial_state = torch.tensor([True], device="cuda")
+
+    @torch.compile(fullgraph=True)
+    def compiled(q, k, v, gate, beta, state_cache, state_indices, has_initial_state):
+        return recurrent_gdn(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            state_cache,
+            state_indices=state_indices,
+            has_initial_state=has_initial_state,
+            impl=Impl.FUSED,
+        )
+
+    with torch.no_grad():
+        expected = recurrent_gdn(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            expected_cache,
+            state_indices=state_indices,
+            has_initial_state=has_initial_state,
+            impl=Impl.FUSED,
+        )
+        actual = compiled(q, k, v, gate, beta, state_cache, state_indices, has_initial_state)
+    torch.testing.assert_close(actual[0], expected[0])
+    assert actual[1] is expected[1] is None
+    torch.testing.assert_close(state_cache, expected_cache)
 
 
 def test_fused_recurrent_fullgraph():

--- a/test/test_kda_recurrent.py
+++ b/test/test_kda_recurrent.py
@@ -245,6 +245,32 @@ def test_recurrent_paged_matches_gather_scatter(packed: bool):
     )
 
 
+def test_recurrent_paged_fresh_slot_ignores_existing_state():
+    q, k, v, gate, beta, _ = _inputs(batch=2, tokens=3, seed=9)
+    _, pool = _strided_state_pool(5, q.shape[2], q.shape[3], v.shape[-1])
+    slots = torch.tensor([3, 1], device="cuda", dtype=torch.int32)
+    has_initial_state = torch.tensor([False, False], device="cuda")
+
+    output, _ = recurrent_kda(
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        pool,
+        state_indices=slots,
+        has_initial_state=has_initial_state,
+    )
+    expected, expected_state = naive_recurrent_kda(
+        q, k, v, gate * LOG2_E, beta, output_final_state=True
+    )
+
+    torch.testing.assert_close(output, expected, rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(
+        pool[slots.long()], expected_state.transpose(-1, -2), rtol=1e-5, atol=1e-5
+    )
+
+
 def test_recurrent_paged_decode_accumulates_in_place():
     """Successive single-token steps advance each slot without a round trip."""
     _, pool = _strided_state_pool(5, 2, 64, 64)
@@ -317,6 +343,10 @@ def test_recurrent_paged_validates_contract():
         recurrent_kda(q, k, v, gate, beta, pool, state_indices=slots[:1])
     with pytest.raises(ValueError, match="drop output_final_state"):
         recurrent_kda(q, k, v, gate, beta, pool, state_indices=slots, output_final_state=True)
+    with pytest.raises(ValueError, match="requires state_indices"):
+        recurrent_kda(
+            q, k, v, gate, beta, has_initial_state=torch.ones_like(slots, dtype=torch.bool)
+        )
 
 
 def test_recurrent_validates_public_contract():
@@ -396,7 +426,7 @@ def test_recurrent_custom_op_registration(packed: bool):
     slots = torch.arange(1, num_sequences + 1, device="cuda", dtype=torch.int32)
     torch.library.opcheck(
         _recurrent_fwd_paged_op,
-        (q, k, v, gate, beta, state_pool, slots, cu_seqlens, True),
+        (q, k, v, gate, beta, state_pool, slots, None, cu_seqlens),
     )
 
 
@@ -415,7 +445,7 @@ def test_recurrent_custom_op_registration_mixed_dtype():
     )
     torch.library.opcheck(
         _recurrent_fwd_paged_op,
-        (q, k, v, gate, beta, state_pool, slots, None, True),
+        (q, k, v, gate, beta, state_pool, slots, None, None),
     )
 
 
@@ -516,12 +546,12 @@ def test_recurrent_paged_cuda_graph_replay():
     q, k, v, gate, beta, _ = _inputs(batch=3, tokens=1, dtype=torch.bfloat16, seed=31)
     storage, pool = _strided_state_pool(7, q.shape[2], q.shape[3], v.shape[-1])
     slots = torch.tensor([5, 1, 3], device="cuda", dtype=torch.int32)
-    _recurrent_fwd_paged_op(q, k, v, gate, beta, pool, slots, None, True)
+    _recurrent_fwd_paged_op(q, k, v, gate, beta, pool, slots, None, None)
     torch.cuda.synchronize()
 
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
-        captured_output = _recurrent_fwd_paged_op(q, k, v, gate, beta, pool, slots, None, True)
+        captured_output = _recurrent_fwd_paged_op(q, k, v, gate, beta, pool, slots, None, None)
 
     with torch.no_grad():
         storage.add_(0.25)
@@ -550,6 +580,34 @@ def test_recurrent_launches_beyond_grid_y_limit():
     output, _ = recurrent_kda(q, k, v, gate, beta)
     expected, _ = naive_recurrent_kda(q, k, v, gate * LOG2_E, beta)
     torch.testing.assert_close(output, expected, rtol=1e-5, atol=1e-5)
+
+
+def test_recurrent_paged_empty_sequences_initialize_fresh_slots():
+    """Empty packed sequences zero freshly assigned slots and preserve resumed ones."""
+    q, k, v, gate, beta, _ = _inputs(batch=1, tokens=4, seed=9)
+    cu_seqlens = torch.tensor([0, 0, 4, 4], device="cuda", dtype=torch.int32)
+    _, pool = _strided_state_pool(6, q.shape[2], q.shape[3], v.shape[-1])
+    original_pool = pool.clone()
+    slots = torch.tensor([2, 3, 5], device="cuda", dtype=torch.int32)
+    has_initial_state = torch.tensor([False, False, True], device="cuda")
+
+    recurrent_kda(
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        pool,
+        cu_seqlens=cu_seqlens,
+        state_indices=slots,
+        has_initial_state=has_initial_state,
+    )
+
+    # The empty fresh sequence must initialize its slot to the zero state.
+    torch.testing.assert_close(pool[2], torch.zeros_like(pool[2]), rtol=0, atol=0)
+    # The empty resumed sequence and unselected slots keep their contents.
+    preserved = [0, 1, 4, 5]
+    torch.testing.assert_close(pool[preserved], original_pool[preserved], rtol=0, atol=0)
 
 
 def test_naive_recurrent_packed_matches_public_contract():


### PR DESCRIPTION
Stacked PRs:
 * #386
 * __->__#381


--- --- ---

Add paged recurrent GDN

## Human Note

## Agent note

Give fused recurrent GDN the same mutable [slots, H, V, K] cache contract as KDA, including
padding slots, strided pages, and optional fresh-slot initialization. Share the structural paging
validation across variants while keeping separate mutating custom-op schemas.

## Test Plan

```bash
.venv/bin/prek run --files attn_gym/linear/_delta_rule/recurrent.py attn_gym/linear/_delta_rule/validation.py attn_gym/linear/kda/api.py attn_gym/linear/gdn/api.py attn_gym/linear/gdn/ops.py attn_gym/linear/gdn/impl/fused.py docs/linear.md test/linear/test_gdn_fused.py
.venv/bin/pytest -q test/linear/test_gdn.py test/test_namespaces.py
gpu-run auto -- .venv/bin/pytest -q test/linear/test_gdn_fused.py
gpu-run auto -- .venv/bin/pytest -q test/test_kda_recurrent.py -k paged test/test_kda_cute_forward.py -k paged
```