### PR TITLE
Reset Dynamo before bound-gate recompile assertion

### DIFF
--- a/test/test_kda_gate_semantics.py
+++ b/test/test_kda_gate_semantics.py
@@ -107,6 +107,7 @@ def test_bound_gate_fused_backward_matches_pytorch(
 
 def test_bound_gate_fused_backward_fullgraph_dynamic_tokens():
     """Reuse one fullgraph callable across batch and partial-token shapes."""
+    torch.compiler.reset()
     torch.manual_seed(29)
     with torch._dynamo.config.patch(error_on_recompile=True):
         compiled = torch.compile(


### PR DESCRIPTION
## Human Note

## Agent note

Clear process-global Dynamo state before enabling `error_on_recompile` in the dynamic bound-gate
test. Other tests compile `functools.partial` callables through the same Dynamo wrapper code object,
so xdist worker scheduling can otherwise make unrelated cached guards look like a forbidden
recompile.

## Test Plan

```bash
gpu-run --timeout 30 auto -- timeout --signal=TERM --kill-after=5s 180s env PYTHONPATH="$PWD" .venv/bin/python -m pytest -q test/test_vsa.py::test_vsa_flex_attention_backward_cuda_matches_dense_reference test/test_kda_gate_semantics.py::test_bound_gate_fused_backward_fullgraph_dynamic_tokens
.venv/bin/ruff check test/test_kda_gate_semantics.py
.venv/bin/ruff format --check test/test_kda_gate_semantics.py
git diff --check
```
