### PR TITLE
Remove direct NumPy dependency

### DIFF
--- a/attn_gym/utils.py
+++ b/attn_gym/utils.py
@@ -2,7 +2,6 @@ import math
 from contextlib import contextmanager, nullcontext
 from pathlib import Path
 
-import numpy as np
 import torch
 from torch.nn.attention.flex_attention import (
     _DEFAULT_SPARSE_BLOCK_SIZE,
@@ -203,8 +202,8 @@ def visualize_attention_scores(
         ax.set_yticks(range(num_query_tokens))
         ax.set_yticklabels([f"Q{i}" for i in range(num_query_tokens)], fontsize=16)
         # Align grid with pixel boundaries
-        ax.set_xticks(np.arange(-0.5, num_kv_tokens, 1), minor=True)
-        ax.set_yticks(np.arange(-0.5, num_query_tokens, 1), minor=True)
+        ax.set_xticks(torch.arange(-0.5, num_kv_tokens, 1), minor=True)
+        ax.set_yticks(torch.arange(-0.5, num_query_tokens, 1), minor=True)
         ax.grid(which="minor", color="black", linestyle="-", linewidth=2)
 
     plt.tight_layout()
@@ -305,8 +304,8 @@ def plot_attention_scores(
         ax.set_yticks(range(num_query_tokens))
         ax.set_yticklabels([f"Q{i}" for i in range(num_query_tokens)], fontsize=16)
         # Align grid with pixel boundaries
-        ax.set_xticks(np.arange(-0.5, num_kv_tokens, 1), minor=True)
-        ax.set_yticks(np.arange(-0.5, num_query_tokens, 1), minor=True)
+        ax.set_xticks(torch.arange(-0.5, num_kv_tokens, 1), minor=True)
+        ax.set_yticks(torch.arange(-0.5, num_query_tokens, 1), minor=True)
         ax.grid(which="minor", color="black", linestyle="-", linewidth=2)
 
     plt.tight_layout()

--- a/benchmarks/flex_perf.py
+++ b/benchmarks/flex_perf.py
@@ -10,7 +10,6 @@ from dataclasses import asdict, dataclass
 from functools import partial, wraps
 from typing import Literal
 
-import numpy as np
 import torch
 import torch.nn.functional as F
 from jsonargparse import CLI
@@ -699,9 +698,12 @@ def get_average_speedups(
         calculate_speedup(r.results["flex_attn"], r.results[backend], type) for r in results
     ]
 
-    # Find indices of max and min speedups
-    max_speedup_index = np.nanargmax(speedups)
-    min_speedup_index = np.nanargmin(speedups)
+    speedups_tensor = torch.tensor(speedups, dtype=torch.float64)
+    nan_mask = torch.isnan(speedups_tensor)
+    if nan_mask.all():
+        raise ValueError("All speedups are NaN")
+    max_speedup_index = speedups_tensor.masked_fill(nan_mask, -torch.inf).argmax().item()
+    min_speedup_index = speedups_tensor.masked_fill(nan_mask, torch.inf).argmin().item()
 
     # Get the config dictionaries
     max_config_dict = results[max_speedup_index].config.asdict()
@@ -711,7 +713,7 @@ def get_average_speedups(
     table_data = [
         {
             "Type": "Average",
-            "Speedup": np.nanmean(speedups),
+            "Speedup": torch.nanmean(speedups_tensor).item(),
             **dict.fromkeys(max_config_dict),
         },
         {"Type": "Max", "Speedup": speedups[max_speedup_index], **max_config_dict},
@@ -780,7 +782,9 @@ def print_results(
         for backend in results[0].config.backends:
             if (
                 f"fwd_{backend}_speedup" in table_data
-                and not np.isnan(table_data[f"fwd_{backend}_speedup"]).all()
+                and not torch.isnan(torch.tensor(table_data[f"fwd_{backend}_speedup"]))
+                .all()
+                .item()
             ):
                 print("\n")
                 print(f"FWD Speedups vs. {backend}".center(125, "="))
@@ -1384,9 +1388,7 @@ def main(
     # Always calculate throughput
     throughput = True
 
-    seed = 123
-    np.random.seed(seed)
-    torch.manual_seed(seed)
+    torch.manual_seed(123)
     results = []
     for experiment_count, exp_config in enumerate(
         tqdm(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ tests = [
     "typer",
     "jsonargparse",
     "docstring-parser",
-    "numpy",
     "flash-attn-4[cu13]~=4.0.0b23; sys_platform == 'linux' and platform_machine == 'x86_64'",
 ]
 
@@ -47,12 +46,10 @@ dev = [
     "typer",
     "jsonargparse",
     "docstring-parser",
-    "numpy",
 ]
 
 viz = [
     "matplotlib",
-    "numpy",
     "jsonargparse",
     "docstring-parser",
     "tabulate",
@@ -65,7 +62,6 @@ docs = [
     "mkdocs-macros-plugin",
     "mkdocs-redirects",
     "mkdocstrings[python]",
-    "numpy",
 ]
 
 # ---------- TOOL CONFIGURATIONS ------------

--- a/test/test_namespaces.py
+++ b/test/test_namespaces.py
@@ -54,6 +54,21 @@ def test_linear_base_import_keeps_cutedsl_lazy():
     subprocess.run([sys.executable, "-c", script], check=True)
 
 
+def test_base_import_does_not_require_numpy():
+    """The base package declares only torch and must not import NumPy directly."""
+    script = (
+        "import builtins\n"
+        "original_import = builtins.__import__\n"
+        "def without_numpy(name, globals=None, locals=None, fromlist=(), level=0):\n"
+        "    if level == 0 and (name == 'numpy' or name.startswith('numpy.')):\n"
+        "        raise ModuleNotFoundError('blocked NumPy import')\n"
+        "    return original_import(name, globals, locals, fromlist, level)\n"
+        "builtins.__import__ = without_numpy\n"
+        "import attn_gym\n"
+    )
+    subprocess.run([sys.executable, "-c", script], check=True)
+
+
 def test_short_conv_decode_uses_decode_name():
     assert "causal_conv1d_decode" in attn_gym.linear.__all__
     assert "causal_conv1d_update" not in attn_gym.linear.__all__


### PR DESCRIPTION
## Human Note

## Agent note

Attention Gym imported NumPy for two visualization tick ranges and used it for a few benchmark
summary operations. Because `attn_gym.utils` is imported from the package root, this made NumPy an
undeclared requirement for the base package and led to it being copied into every optional extra.
Use Torch for those operations, remove the redundant direct requirements, and add a regression test
that blocks NumPy while importing the package. Matplotlib still supplies NumPy transitively for the
visualization extra.

## Test Plan

```bash
.venv/bin/pytest test/test_namespaces.py test/test_merge_attention.py test/test_shared_prefix_split_attention.py -q
.venv/bin/ruff check attn_gym/utils.py benchmarks/flex_perf.py test/test_namespaces.py
uv build --out-dir agent_space/numpy_dep_dist
```
