### PR TITLE
Test release wheel before PyPI publishing

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -3,7 +3,7 @@ name: Publish Python 🐍 distribution 📦 to PyPI
 on:
   push:
     tags:
-      - '*'
+      - 'v*'
 
 permissions:
   contents: read
@@ -21,39 +21,135 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
-        python-version: "3.x"
-    - name: Install pypa/build
-      run: >-
-        python3 -m
-        pip install
-        build
-        --user
-    - name: Build a binary wheel and a source tarball
-      run: python3 -m build
-    - name: Store the distribution packages
+        python-version: "3.12"
+    - name: Install build tools
+      run: python -m pip install build twine
+    - name: Build wheel and source distribution
+      run: python -m build
+    - name: Validate distributions
+      env:
+        RELEASE_TAG: ${{ github.ref_name }}
+      run: |
+        python -m twine check dist/*
+        python - <<'PY'
+        import os
+        from pathlib import Path
+
+        from packaging.utils import parse_sdist_filename, parse_wheel_filename
+        from packaging.version import Version
+
+        wheels = list(Path("dist").glob("*.whl"))
+        sdists = list(Path("dist").glob("*.tar.gz"))
+        if len(wheels) != 1 or len(sdists) != 1:
+            raise SystemExit(f"expected one wheel and one sdist, found {wheels} and {sdists}")
+
+        wheel_name, wheel_version, *_ = parse_wheel_filename(wheels[0].name)
+        sdist_name, sdist_version = parse_sdist_filename(sdists[0].name)
+        expected_version = Version(os.environ["RELEASE_TAG"].removeprefix("v"))
+        if wheel_name != "attn-gym" or sdist_name != "attn-gym":
+            raise SystemExit(f"unexpected distribution names: {wheel_name}, {sdist_name}")
+        if wheel_version != expected_version or sdist_version != expected_version:
+            raise SystemExit(
+                f"tag {expected_version} does not match artifacts "
+                f"{wheel_version} and {sdist_version}"
+            )
+        PY
+    - name: Store distributions
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: python-package-distributions
         path: dist/
+        if-no-files-found: error
 
-  publish-to-pypi:
-    name: >-
-      Publish Python 🐍 distribution 📦 to PyPI
-    needs:
-    - build
+  test-wheel:
+    name: Test built wheel on Modal B200
+    needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-    environment:
-      name: pypi
-      url: https://pypi.org/p/attn-gym # Replace <package-name> with your PyPI project name
-    permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    timeout-minutes: 60
+    env:
+      MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+      MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
 
     steps:
-    - name: Download all the dists
+    - name: Checkout repository
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      with:
+        persist-credentials: false
+    - name: Set up Python
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      with:
+        python-version: "3.12"
+    - name: Install Modal
+      run: python -m pip install modal
+    - name: Download distributions
       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: python-package-distributions
         path: dist/
-    - name: Publish distribution 📦 to PyPI
+    - name: Run the full test suite against the built wheel
+      run: |
+        shopt -s nullglob
+        wheels=(dist/*.whl)
+        if (( ${#wheels[@]} != 1 )); then
+          echo "Expected exactly one wheel, found ${#wheels[@]}" >&2
+          exit 1
+        fi
+        ATTN_GYM_WHEEL="${wheels[0]}" modal run -m modal_tests
+
+  publish-to-pypi:
+    name: Publish distribution 📦 to PyPI
+    needs: test-wheel
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: pypi
+      url: https://pypi.org/p/attn-gym
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download distributions
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distributions
       uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+
+  verify-pypi-install:
+    name: Verify PyPI installation
+    needs: publish-to-pypi
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+    - name: Set up Python
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      with:
+        python-version: "3.12"
+    - name: Install CPU PyTorch
+      run: python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+    - name: Install and import the PyPI release
+      env:
+        RELEASE_TAG: ${{ github.ref_name }}
+      run: |
+        export RELEASE_VERSION="${RELEASE_TAG#v}"
+        pip_args=(--no-cache-dir --index-url https://pypi.org/simple)
+        for attempt in {1..10}; do
+          if python -m pip install "${pip_args[@]}" "attn-gym==$RELEASE_VERSION"; then
+            python -m pip check
+            python - <<'PY'
+        from importlib.metadata import version
+
+        import attn_gym
+
+        installed_version = version("attn-gym")
+        print(f"Imported attn_gym {installed_version} from {attn_gym.__file__}")
+        PY
+            exit 0
+          fi
+          if (( attempt == 10 )); then
+            exit 1
+          fi
+          sleep 15
+        done

--- a/modal_tests.py
+++ b/modal_tests.py
@@ -1,3 +1,4 @@
+import importlib
 import os
 import subprocess
 import xml.etree.ElementTree as ET
@@ -8,6 +9,8 @@ import modal
 
 ROOT_PATH = Path(__file__).parent
 PYTORCH_NIGHTLY_INDEX = "https://download.pytorch.org/whl/nightly/cu132"
+WHEEL_PATH = Path(os.environ["ATTN_GYM_WHEEL"]).resolve() if os.getenv("ATTN_GYM_WHEEL") else None
+REMOTE_WHEEL_PATH = f"/tmp/{WHEEL_PATH.name}" if WHEEL_PATH else None
 # Rebuild once per UTC day without disabling Modal's cache for every commit.
 NIGHTLY_CACHE_DATE = datetime.now(UTC).date().isoformat()
 
@@ -15,13 +18,28 @@ image = (
     modal.Image.debian_slim(python_version="3.12")
     .env({"PYTORCH_NIGHTLY_CACHE_DATE": NIGHTLY_CACHE_DATE})
     .pip_install("torch", pre=True, index_url=PYTORCH_NIGHTLY_INDEX)
-    .pip_install_from_pyproject(
+)
+
+if modal.is_local():
+    image = image.pip_install_from_pyproject(
         str(ROOT_PATH / "pyproject.toml"), optional_dependencies=["tests"], pre=True
     )
-    .add_local_python_source("attn_gym")
-    .add_local_dir(ROOT_PATH / "test", remote_path="/root/test")
-    .add_local_dir(ROOT_PATH / "examples", remote_path="/root/examples")
-)
+    if WHEEL_PATH:
+        if not WHEEL_PATH.is_file() or WHEEL_PATH.suffix != ".whl":
+            raise ValueError(f"ATTN_GYM_WHEEL must name an existing wheel: {WHEEL_PATH}")
+        image = (
+            image.env({"ATTN_GYM_WHEEL": REMOTE_WHEEL_PATH})
+            .add_local_file(WHEEL_PATH, REMOTE_WHEEL_PATH, copy=True)
+            .run_commands(
+                f"python -m pip install --no-deps {REMOTE_WHEEL_PATH}",
+                "python -m pip check",
+            )
+        )
+    else:
+        image = image.add_local_python_source("attn_gym")
+    image = image.add_local_dir(ROOT_PATH / "test", remote_path="/root/test").add_local_dir(
+        ROOT_PATH / "examples", remote_path="/root/examples"
+    )
 
 app = modal.App("attention-gym-modal-tests", image=image)
 
@@ -67,9 +85,23 @@ def format_pytest_summary(report_path: Path) -> str:
     return "\n".join(lines) + "\n"
 
 
+def verify_wheel_install() -> None:
+    """Require wheel-mode imports to resolve outside the mounted test checkout."""
+    if WHEEL_PATH is None:
+        return
+
+    package_path = Path(importlib.import_module("attn_gym").__file__).resolve()
+    if "site-packages" not in package_path.parts:
+        raise RuntimeError(f"attn_gym did not import from site-packages: {package_path}")
+    if Path("/root/attn_gym").exists():
+        raise RuntimeError("checkout source unexpectedly exists at /root/attn_gym")
+    print(f"attn_gym imported from {package_path}", flush=True)
+
+
 @app.function(gpu="B200", timeout=30 * 60)
 def run_pytest() -> tuple[int, str]:
     """Run the repository test suite and return its exit code and summary."""
+    verify_wheel_install()
     report_path = Path("/tmp/pytest-report.xml")
     result = subprocess.run(
         [


### PR DESCRIPTION
## Human Note

## Agent note

Build the wheel and source distribution once, validate their metadata against the release tag,
and run the full B200 test suite against the exact wheel artifact before allowing PyPI
publication. Keep the existing source-based Modal tests for normal main-branch coverage and add
a lightweight post-publish installation check for index and dependency resolution.

## Test Plan

```zsh
prek run --files modal_tests.py .github/workflows/publish-to-pypi.yml
python -m build --outdir agent_space/release-eval/dist
uvx twine check agent_space/release-eval/dist/*
wheel=(agent_space/release-eval/dist/*.whl); ATTN_GYM_WHEEL="$wheel[1]" uvx modal run -m modal_tests
```

