### PR TITLE
Support grouped q/k heads in the fused recurrent GDN forward

### DIFF
--- a/attn_gym/linear/_delta_rule/recurrent.py
+++ b/attn_gym/linear/_delta_rule/recurrent.py
@@ -69,6 +69,7 @@ def _recurrent_delta_rule_fwd_kernel(
     N,
     state_batch_stride: tl.constexpr,
     H: tl.constexpr,
+    HK: tl.constexpr,
     K: tl.constexpr,
     V: tl.constexpr,
     BK: tl.constexpr,
@@ -80,12 +81,18 @@ def _recurrent_delta_rule_fwd_kernel(
     USE_HAS_INITIAL_STATE: tl.constexpr,
     SCALAR_GATE: tl.constexpr,
 ):
-    """Scan one sequence/head/value tile while retaining the FP32 state in registers."""
+    """Scan one sequence/head/value tile while retaining the FP32 state in registers.
+
+    Programs are indexed by value head. Scalar-gated callers may share one q/k head across
+    each block of ``H // HK`` consecutive value heads; vector-gated KDA passes ``HK == H``,
+    which reduces every ``row_k`` to the ungrouped ``row``.
+    """
     pid = tl.program_id(0).to(tl.int64)
     NV = tl.cdiv(V, BV)
     i_v = pid % NV
     i_nh = pid // NV
     i_n, i_h = i_nh // H, i_nh % H
+    i_hk = i_h // (H // HK)
 
     if IS_VARLEN:
         # Assumption: seqlens have been validated prior to call
@@ -130,14 +137,18 @@ def _recurrent_delta_rule_fwd_kernel(
 
     for t in range(bos, eos):
         row = t * H + i_h
-        b_q = tl.load(q + row * K + o_k, mask=m_k, other=0.0).to(tl.float32) * scale
-        b_k = tl.load(k + row * K + o_k, mask=m_k, other=0.0).to(tl.float32)
+        row_k = t * HK + i_hk
+        b_q = tl.load(q + ptr_offset((row_k, o_k), (K, 1)), mask=m_k, other=0.0).to(tl.float32)
+        b_q *= scale
+        b_k = tl.load(k + ptr_offset((row_k, o_k), (K, 1)), mask=m_k, other=0.0).to(tl.float32)
         if SCALAR_GATE:
             b_g = tl.load(gate + row).to(tl.float32)
         else:
-            b_g = tl.load(gate + row * K + o_k, mask=m_k, other=0.0).to(tl.float32)
+            b_g = tl.load(gate + ptr_offset((row_k, o_k), (K, 1)), mask=m_k, other=0.0).to(
+                tl.float32
+            )
         b_beta = tl.load(beta + row).to(tl.float32)
-        b_v = tl.load(v + row * V + o_v, mask=m_v, other=0.0).to(tl.float32)
+        b_v = tl.load(v + ptr_offset((row, o_v), (V, 1)), mask=m_v, other=0.0).to(tl.float32)
 
         # exp(g) computed as exp2(g * log2(e)); the FMA folds into the exp2 argument.
         if SCALAR_GATE:
@@ -148,7 +159,9 @@ def _recurrent_delta_rule_fwd_kernel(
         b_delta = (b_v - tl.sum(b_k[:, None] * b_state, 0)) * b_beta
         b_state += b_k[:, None] * b_delta[None, :]
         b_o = tl.sum(b_q[:, None] * b_state, 0)
-        tl.store(output + row * V + o_v, b_o.to(output.dtype.element_ty), mask=m_v)
+        tl.store(
+            output + ptr_offset((row, o_v), (V, 1)), b_o.to(output.dtype.element_ty), mask=m_v
+        )
 
     if STORE_FINAL_STATE:
         tl.store(ht + p_state, b_state, mask=m_kv)
@@ -164,6 +177,7 @@ recurrent_delta_rule_fwd_kernel = triton.autotune(
         "T",
         "N",
         "H",
+        "HK",
         "K",
         "V",
         "USE_INITIAL_STATE",
@@ -195,7 +209,10 @@ def launch_recurrent_delta_rule_fwd(
     """Launch a scalar- or vector-gated recurrent delta-rule specialization.
 
     Args:
-        q: Queries shaped ``[B, T, H, K]``; packed callers pass ``B == 1``.
+        q: Queries shaped ``[B, T, HK, K]``; packed callers pass ``B == 1``. Scalar-gated
+            callers may pass ``HK`` as a divisor of the value head count ``H`` (grouped
+            heads): each block of ``H // HK`` consecutive value heads shares one query/key
+            head, so callers never materialize a ``repeat_interleave``.
         k: Keys shaped like ``q``.
         v: Values shaped ``[B, T, H, V]``.
         gate: Natural-log decay, shaped ``[B, T, H]`` for ``GateKind.SCALAR`` or like ``q``
@@ -225,14 +242,17 @@ def launch_recurrent_delta_rule_fwd(
         mode the returned state aliases ``initial_state``.
     """
     assert k.shape == q.shape
-    assert v.shape[:3] == q.shape[:3]
-    assert gate.shape == (q.shape[:-1] if gate_kind is GateKind.SCALAR else q.shape)
-    assert beta.shape == q.shape[:-1]
+    assert v.shape[:2] == q.shape[:2]
+    assert gate.shape == (v.shape[:-1] if gate_kind is GateKind.SCALAR else q.shape)
+    assert beta.shape == v.shape[:-1]
     assert all(tensor.is_contiguous() for tensor in (q, k, v, gate, beta))
     assert has_initial_state is None or state_indices is not None
 
-    batch, tokens, heads, key_dim = q.shape
-    value_dim = v.shape[-1]
+    batch, tokens, key_heads, key_dim = q.shape
+    heads, value_dim = v.shape[2], v.shape[-1]
+    assert heads % key_heads == 0
+    # No caller groups vector gates; keep that unsupported mode out of the shared contract.
+    assert gate_kind is GateKind.SCALAR or key_heads == heads
     if initial_state is not None:
         if state_indices is None:
             assert initial_state.is_contiguous()
@@ -296,6 +316,7 @@ def launch_recurrent_delta_rule_fwd(
         N=num_sequences,
         state_batch_stride=state_batch_stride,
         H=heads,
+        HK=key_heads,
         K=key_dim,
         V=value_dim,
         BK=triton.next_power_of_2(key_dim),

--- a/attn_gym/linear/_delta_rule/validation.py
+++ b/attn_gym/linear/_delta_rule/validation.py
@@ -13,12 +13,15 @@ def validate_paged_state(
     state_indices: torch.Tensor,
     has_initial_state: torch.Tensor | None = None,
 ) -> None:
-    """Validate the shared mutable ``[slots, H, V, K]`` state contract."""
-    expected_shape = (q.shape[2], v.shape[-1], q.shape[3])
+    """Validate the shared mutable ``[slots, H, V, K]`` state contract.
+
+    The pool carries one state per value head, so grouped-head callers size ``H`` from ``v``.
+    """
+    expected_shape = (v.shape[2], v.shape[-1], q.shape[3])
     if state_cache.ndim != 4 or state_cache.shape[1:] != expected_shape:
         raise ValueError(
             "the paged state pool must have shape "
-            f"[num_slots, {q.shape[2]}, {v.shape[-1]}, {q.shape[3]}], "
+            f"[num_slots, {v.shape[2]}, {v.shape[-1]}, {q.shape[3]}], "
             f"got {tuple(state_cache.shape)}"
         )
     if state_cache.device != q.device:
@@ -28,7 +31,7 @@ def validate_paged_state(
     expected_inner_strides = (v.shape[-1] * q.shape[3], q.shape[3], 1)
     if state_cache.stride()[1:] != expected_inner_strides:
         raise TypeError("the paged state pool must be contiguous within each [H, V, K] slot")
-    if state_cache.stride(0) < q.shape[2] * q.shape[3] * v.shape[-1]:
+    if state_cache.stride(0) < v.shape[2] * q.shape[3] * v.shape[-1]:
         raise ValueError("paged state pool slots must not overlap")
 
     num_sequences = q.shape[0] if cu_seqlens is None else cu_seqlens.shape[0] - 1

--- a/attn_gym/linear/gdn/api.py
+++ b/attn_gym/linear/gdn/api.py
@@ -32,7 +32,9 @@ def chunk_gdn(
     that recurrence. FP16 and BF16 inputs use FP32 recurrence math and state.
 
     Args:
-        q: Queries shaped ``[B, T, H, K]``.
+        q: Queries shaped ``[B, T, HK, K]``. ``HK`` may divide the value head count ``H``
+            for grouped-head attention: each block of ``H // HK`` consecutive value heads
+            shares one query/key head.
         k: Keys shaped like ``q`` and using the same dtype.
         v: Values shaped ``[B, T, H, V]`` and using the same dtype as ``q``.
         gate: Floating per-token scalar natural-log decay shaped ``[B, T, H]``.
@@ -92,7 +94,9 @@ def recurrent_gdn(
     inputs use FP32 recurrence math and state.
 
     Args:
-        q: Queries shaped ``[B, T, H, K]``.
+        q: Queries shaped ``[B, T, HK, K]``. ``HK`` may divide the value head count ``H``
+            for grouped-head attention: each block of ``H // HK`` consecutive value heads
+            shares one query/key head.
         k: Keys shaped like ``q`` and using the same dtype.
         v: Values shaped ``[B, T, H, V]`` and using the same dtype as ``q``.
         gate: Floating per-token scalar natural-log decay shaped ``[B, T, H]``.

--- a/attn_gym/linear/gdn/impl/reference.py
+++ b/attn_gym/linear/gdn/impl/reference.py
@@ -83,6 +83,10 @@ def reference_gdn(
     output_dtype = q.dtype
     compute_dtype = torch.promote_types(q.dtype, torch.float32)
     q, k, v, log_decay, beta = (tensor.to(compute_dtype) for tensor in (q, k, v, log_decay, beta))
+    if q.shape[2] != v.shape[2]:
+        # Grouped heads: expand each shared query/key head across its value-head group.
+        groups = v.shape[2] // q.shape[2]
+        q, k = (tensor.repeat_interleave(groups, dim=2) for tensor in (q, k))
     # Explicit casts do not stop autocast from selecting low-precision contractions.
     with torch.autocast(device_type=q.device.type, enabled=False):
         if cu_seqlens is None:

--- a/attn_gym/linear/gdn/ops.py
+++ b/attn_gym/linear/gdn/ops.py
@@ -67,8 +67,9 @@ def _recurrent_fwd_fake(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     del k, gate, beta, initial_state, scale, autotune
     num_sequences = q.shape[0] if cu_seqlens is None else cu_seqlens.shape[0] - 1
+    # The state carries one [K, V] slab per value head; grouped callers have v.shape[2] > HK.
     final_state = q.new_empty(
-        num_sequences, q.shape[2], q.shape[3], v.shape[-1], dtype=torch.float32
+        num_sequences, v.shape[2], q.shape[3], v.shape[-1], dtype=torch.float32
     )
     return torch.empty_like(v, dtype=q.dtype), final_state
 

--- a/attn_gym/linear/gdn/validation.py
+++ b/attn_gym/linear/gdn/validation.py
@@ -16,15 +16,19 @@ def validate_gdn_inputs(
 ) -> None:
     """Validate backend-independent gated delta rule tensor invariants."""
     if q.ndim != 4:
-        raise ValueError(f"q must have shape [B, T, H, K], got {tuple(q.shape)}")
-    batch, tokens, heads, key_dim = q.shape
-    if batch == 0 or tokens == 0 or heads == 0 or key_dim == 0:
+        raise ValueError(f"q must have shape [B, T, HK, K], got {tuple(q.shape)}")
+    batch, tokens, key_heads, key_dim = q.shape
+    if batch == 0 or tokens == 0 or key_heads == 0 or key_dim == 0:
         raise ValueError(f"q must have nonempty dimensions, got {tuple(q.shape)}")
     if k.shape != q.shape:
         raise ValueError(f"k must have shape {tuple(q.shape)}, got {tuple(k.shape)}")
-    if v.ndim != 4 or v.shape[:3] != (batch, tokens, heads) or v.shape[-1] == 0:
+    if v.ndim != 4 or v.shape[:2] != (batch, tokens) or v.shape[-1] == 0:
+        raise ValueError(f"v must have shape [{batch}, {tokens}, H, V], got {tuple(v.shape)}")
+    heads = v.shape[2]
+    if heads == 0 or heads % key_heads != 0:
         raise ValueError(
-            f"v must have shape [{batch}, {tokens}, {heads}, V], got {tuple(v.shape)}"
+            f"v heads must be a positive multiple of q heads for grouped-head attention, "
+            f"got {heads} value heads for {key_heads} query heads"
         )
     if gate.shape != (batch, tokens, heads):
         raise ValueError(f"gate must have shape {(batch, tokens, heads)}, got {tuple(gate.shape)}")

--- a/test/linear/test_gdn.py
+++ b/test/linear/test_gdn.py
@@ -236,6 +236,43 @@ def test_low_precision_default_state_is_fp32(function):
     assert final_state.dtype == torch.float32
 
 
+@pytest.mark.parametrize("function", REFERENCE_CASES)
+def test_grouped_heads_match_expanded_heads(function):
+    """Fewer q/k heads than v heads must equal an explicit repeat_interleave."""
+    q, k, v, gate, beta, state = make_inputs(sequence=7)
+    groups = 2
+    v, gate, beta = (tensor.repeat_interleave(groups, dim=2) for tensor in (v, gate, beta))
+    state = state.repeat_interleave(groups, dim=1)
+
+    grouped_output, grouped_state = function(q, k, v, gate, beta, state, output_final_state=True)
+    expanded_output, expanded_state = function(
+        q.repeat_interleave(groups, dim=2),
+        k.repeat_interleave(groups, dim=2),
+        v,
+        gate,
+        beta,
+        state,
+        output_final_state=True,
+    )
+
+    # The grouped path expands to the identical tensors internally, so equality is exact.
+    torch.testing.assert_close(grouped_output, expanded_output, rtol=0, atol=0)
+    torch.testing.assert_close(grouped_state, expanded_state, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("function", REFERENCE_CASES)
+def test_grouped_heads_require_divisible_counts(function):
+    q, k, v, gate, beta, _state = make_inputs(sequence=3)
+    # Five value heads cannot be grouped over three query heads.
+    v, gate, beta = (
+        tensor.repeat_interleave(2, dim=2)[:, :, :5].contiguous() for tensor in (v, gate, beta)
+    )
+    with pytest.raises(ValueError, match="positive multiple of q heads"):
+        function(q, k, v, gate, beta)
+    with pytest.raises(ValueError, match="positive multiple of q heads"):
+        function(q, k, v[:, :, :0], gate[:, :, :0], beta[:, :, :0])
+
+
 @pytest.mark.parametrize("function", [chunk_gdn, recurrent_gdn])
 def test_fp64_preserves_compute_and_state_dtype(function):
     inputs = [tensor.double() for tensor in make_inputs(sequence=3)]

--- a/test/linear/test_gdn_fused.py
+++ b/test/linear/test_gdn_fused.py
@@ -18,11 +18,18 @@ pytestmark = pytest.mark.skipif(
 
 
 def make_inputs(
-    *, batch: int = 2, tokens: int = 9, heads: int = 2, key_dim: int = 32, value_dim: int = 24
+    *,
+    batch: int = 2,
+    tokens: int = 9,
+    heads: int = 2,
+    key_dim: int = 32,
+    value_dim: int = 24,
+    key_heads: int | None = None,
 ) -> tuple[torch.Tensor, ...]:
-    """Create stable token-major scalar-gate inputs."""
+    """Create stable token-major scalar-gate inputs; ``key_heads`` enables grouped heads."""
     torch.manual_seed(0)
-    q = torch.randn(batch, tokens, heads, key_dim, device="cuda")
+    q_heads = heads if key_heads is None else key_heads
+    q = torch.randn(batch, tokens, q_heads, key_dim, device="cuda")
     k = F.normalize(torch.randn_like(q), dim=-1)
     v = torch.randn(batch, tokens, heads, value_dim, device="cuda")
     gate = F.logsigmoid(torch.randn(batch, tokens, heads, device="cuda"))
@@ -58,10 +65,13 @@ def test_fused_recurrent_matches_reference(use_initial_state: bool, output_final
         assert actual[1] is expected[1] is None
 
 
-def test_fused_recurrent_matches_packed_reference():
-    q, k, v, gate, beta, _state = make_inputs(batch=1, tokens=8)
+@pytest.mark.parametrize("key_heads", [None, 2])
+def test_fused_recurrent_matches_packed_reference(key_heads: int | None):
+    q, k, v, gate, beta, _state = make_inputs(
+        batch=1, tokens=8, heads=6 if key_heads else 2, key_heads=key_heads
+    )
     cu_seqlens = cumulative_sequence_offsets([3, 0, 4])
-    state = torch.randn(3, q.shape[2], q.shape[3], v.shape[-1], device="cuda")
+    state = torch.randn(3, v.shape[2], q.shape[3], v.shape[-1], device="cuda")
     with torch.no_grad():
         expected = recurrent_gdn(
             q,
@@ -190,6 +200,50 @@ def test_fused_recurrent_packed_paged_state():
     torch.testing.assert_close(state_cache, expected_cache, rtol=1e-5, atol=1e-5)
 
 
+@pytest.mark.parametrize("tokens", [1, 9])
+def test_fused_recurrent_grouped_heads_matches_reference(tokens: int):
+    """Fewer q/k heads than v heads must match the expanding reference oracle."""
+    q, k, v, gate, beta, state = make_inputs(tokens=tokens, heads=6, key_heads=2)
+    with torch.no_grad():
+        expected = recurrent_gdn(
+            q, k, v, gate, beta, state, output_final_state=True, impl=Impl.REFERENCE
+        )
+        actual = recurrent_gdn(
+            q, k, v, gate, beta, state, output_final_state=True, impl=Impl.FUSED
+        )
+    torch.testing.assert_close(actual[0], expected[0], rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(actual[1], expected[1], rtol=1e-5, atol=1e-5)
+
+
+def test_fused_recurrent_grouped_heads_paged_matches_dense():
+    """Paged grouped-head decode equals the dense fused path on gathered slots."""
+    q, k, v, gate, beta, _state = make_inputs(batch=3, tokens=1, heads=6, key_heads=2)
+    _storage, pool = strided_state_pool(5, v.shape[2], q.shape[-1], v.shape[-1])
+    slots = torch.tensor([1, 3, 4], device="cuda", dtype=torch.int32)
+    initial_state = pool[slots.long()].transpose(-1, -2).contiguous()
+
+    with torch.no_grad():
+        expected_output, expected_state = recurrent_gdn(
+            q, k, v, gate, beta, initial_state, output_final_state=True, impl=Impl.REFERENCE
+        )
+        output, _ = recurrent_gdn(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            pool,
+            state_indices=slots,
+            has_initial_state=torch.ones(3, device="cuda", dtype=torch.bool),
+            impl=Impl.FUSED,
+        )
+
+    torch.testing.assert_close(output, expected_output, rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(
+        pool[slots.long()], expected_state.transpose(-1, -2), rtol=1e-5, atol=1e-5
+    )
+
+
 def test_fused_recurrent_packed_paged_empty_sequences():
     """Empty packed sequences zero freshly assigned slots and preserve resumed ones."""
     q, k, v, gate, beta, _state = make_inputs(batch=1, tokens=4)
@@ -239,6 +293,15 @@ def test_fused_recurrent_paged_registration():
             None,
             q.shape[-1] ** -0.5,
         ),
+    )
+
+
+def test_fused_recurrent_grouped_heads_registration():
+    """Grouped-head fakes must size the final state from value heads, not query heads."""
+    q, k, v, gate, beta, state = make_inputs(batch=1, tokens=3, heads=6, key_heads=2)
+    torch.library.opcheck(
+        recurrent_fwd_op,
+        (q, k, v, gate, beta, state, None, q.shape[-1] ** -0.5, False),
     )
 
 


### PR DESCRIPTION
Stacked PRs:
 * #390
 * __->__#388


--- --- ---

Support grouped q/k heads in the fused recurrent GDN forward

## Human Note

## Agent note

Let the shared recurrent delta-rule scan read fewer query/key heads than value heads: each block
of H // HK consecutive value heads shares one q/k (and vector-gate) head, addressed in-kernel via
i_h // (H // HK), so decode callers such as GDN with 4 k-heads over 12 v-heads no longer
materialize a repeat_interleave. The state pool, gate, beta, and output stay per-value-head. GDN
validation accepts value-head counts that are positive multiples of the query-head count, the
reference oracle expands q/k explicitly, and KDA callers are unchanged (HK == H). Tiled loads and
stores in the scan loop now share the ptr_offset helper used elsewhere. Inference-only, matching
the existing fused contract; grouped-head backward for the chunk form is future work.

## Test Plan

```bash
.venv/bin/prek run --files attn_gym/linear/_delta_rule/recurrent.py attn_gym/linear/_delta_rule/validation.py attn_gym/linear/gdn/validation.py attn_gym/linear/gdn/impl/reference.py attn_gym/linear/gdn/api.py test/linear/test_gdn.py test/linear/test_gdn_fused.py
.venv/bin/pytest -q test/linear/test_gdn.py
gpu-run auto -- .venv/bin/pytest -q -n 6 test/linear/ test/test_kda_recurrent.py test/test_kda_recurrent_decode.py
```