### PR TITLE
Add recurrent_gdn_decode with fused QK L2 normalization

### DIFF
--- a/attn_gym/linear/__init__.py
+++ b/attn_gym/linear/__init__.py
@@ -9,7 +9,7 @@
 import importlib
 from typing import TYPE_CHECKING
 
-from attn_gym.linear.gdn import chunk_gdn, recurrent_gdn
+from attn_gym.linear.gdn import chunk_gdn, recurrent_gdn, recurrent_gdn_decode
 from attn_gym.linear.kda import (
     active_token_mask,
     chunk_kda,
@@ -42,6 +42,7 @@ KDA_OPS = [
 GDN_OPS = [
     "chunk_gdn",
     "recurrent_gdn",
+    "recurrent_gdn_decode",
 ]
 
 # Model-agnostic building blocks; they currently ship from the KDA module.

--- a/attn_gym/linear/_delta_rule/recurrent.py
+++ b/attn_gym/linear/_delta_rule/recurrent.py
@@ -69,6 +69,7 @@ def _recurrent_delta_rule_fwd_kernel(
     N,
     state_batch_stride: tl.constexpr,
     H: tl.constexpr,
+    HK: tl.constexpr,
     K: tl.constexpr,
     V: tl.constexpr,
     BK: tl.constexpr,
@@ -80,12 +81,19 @@ def _recurrent_delta_rule_fwd_kernel(
     USE_HAS_INITIAL_STATE: tl.constexpr,
     SCALAR_GATE: tl.constexpr,
 ):
-    """Scan one sequence/head/value tile while retaining the FP32 state in registers."""
+    """Scan one sequence/head/value tile while retaining the FP32 state in registers.
+
+    Programs are indexed by value head. With grouped heads (``HK < H``) each block of
+    ``H // HK`` consecutive value heads reads one shared q/k (and vector-gate) head; KDA
+    passes ``HK == H``, which reduces every ``row_k`` to the ungrouped ``row``.
+    """
     pid = tl.program_id(0).to(tl.int64)
     NV = tl.cdiv(V, BV)
     i_v = pid % NV
     i_nh = pid // NV
     i_n, i_h = i_nh // H, i_nh % H
+    # Grouped heads: consecutive value heads share one query/key (and vector-gate) head.
+    i_hk = i_h // (H // HK)
 
     if IS_VARLEN:
         # Assumption: seqlens have been validated prior to call
@@ -130,14 +138,18 @@ def _recurrent_delta_rule_fwd_kernel(
 
     for t in range(bos, eos):
         row = t * H + i_h
-        b_q = tl.load(q + row * K + o_k, mask=m_k, other=0.0).to(tl.float32) * scale
-        b_k = tl.load(k + row * K + o_k, mask=m_k, other=0.0).to(tl.float32)
+        row_k = t * HK + i_hk
+        b_q = tl.load(q + ptr_offset((row_k, o_k), (K, 1)), mask=m_k, other=0.0).to(tl.float32)
+        b_q *= scale
+        b_k = tl.load(k + ptr_offset((row_k, o_k), (K, 1)), mask=m_k, other=0.0).to(tl.float32)
         if SCALAR_GATE:
             b_g = tl.load(gate + row).to(tl.float32)
         else:
-            b_g = tl.load(gate + row * K + o_k, mask=m_k, other=0.0).to(tl.float32)
+            b_g = tl.load(gate + ptr_offset((row_k, o_k), (K, 1)), mask=m_k, other=0.0).to(
+                tl.float32
+            )
         b_beta = tl.load(beta + row).to(tl.float32)
-        b_v = tl.load(v + row * V + o_v, mask=m_v, other=0.0).to(tl.float32)
+        b_v = tl.load(v + ptr_offset((row, o_v), (V, 1)), mask=m_v, other=0.0).to(tl.float32)
 
         # exp(g) computed as exp2(g * log2(e)); the FMA folds into the exp2 argument.
         if SCALAR_GATE:
@@ -148,7 +160,9 @@ def _recurrent_delta_rule_fwd_kernel(
         b_delta = (b_v - tl.sum(b_k[:, None] * b_state, 0)) * b_beta
         b_state += b_k[:, None] * b_delta[None, :]
         b_o = tl.sum(b_q[:, None] * b_state, 0)
-        tl.store(output + row * V + o_v, b_o.to(output.dtype.element_ty), mask=m_v)
+        tl.store(
+            output + ptr_offset((row, o_v), (V, 1)), b_o.to(output.dtype.element_ty), mask=m_v
+        )
 
     if STORE_FINAL_STATE:
         tl.store(ht + p_state, b_state, mask=m_kv)
@@ -164,6 +178,7 @@ recurrent_delta_rule_fwd_kernel = triton.autotune(
         "T",
         "N",
         "H",
+        "HK",
         "K",
         "V",
         "USE_INITIAL_STATE",
@@ -195,11 +210,14 @@ def launch_recurrent_delta_rule_fwd(
     """Launch a scalar- or vector-gated recurrent delta-rule specialization.
 
     Args:
-        q: Queries shaped ``[B, T, H, K]``; packed callers pass ``B == 1``.
+        q: Queries shaped ``[B, T, HK, K]``; packed callers pass ``B == 1``. ``HK`` may be a
+            divisor of the value head count ``H`` (grouped heads): each block of ``H // HK``
+            consecutive value heads shares one query/key head, so callers never materialize a
+            ``repeat_interleave``.
         k: Keys shaped like ``q``.
         v: Values shaped ``[B, T, H, V]``.
         gate: Natural-log decay, shaped ``[B, T, H]`` for ``GateKind.SCALAR`` or like ``q``
-            for ``GateKind.VECTOR``.
+            for ``GateKind.VECTOR`` (vector gates follow the query/key head count).
         beta: Per-token write gate shaped ``[B, T, H]``.
         initial_state: Optional FP32 starting state shaped ``[N, H, K, V]``, or the mutable
             ``[slots, H, V, K]`` pool that ``state_indices`` addresses in paged mode.
@@ -225,14 +243,15 @@ def launch_recurrent_delta_rule_fwd(
         mode the returned state aliases ``initial_state``.
     """
     assert k.shape == q.shape
-    assert v.shape[:3] == q.shape[:3]
-    assert gate.shape == (q.shape[:-1] if gate_kind is GateKind.SCALAR else q.shape)
-    assert beta.shape == q.shape[:-1]
+    assert v.shape[:2] == q.shape[:2]
+    assert gate.shape == (v.shape[:-1] if gate_kind is GateKind.SCALAR else q.shape)
+    assert beta.shape == v.shape[:-1]
     assert all(tensor.is_contiguous() for tensor in (q, k, v, gate, beta))
     assert has_initial_state is None or state_indices is not None
 
-    batch, tokens, heads, key_dim = q.shape
-    value_dim = v.shape[-1]
+    batch, tokens, key_heads, key_dim = q.shape
+    heads, value_dim = v.shape[2], v.shape[-1]
+    assert heads % key_heads == 0
     if initial_state is not None:
         if state_indices is None:
             assert initial_state.is_contiguous()
@@ -296,6 +315,7 @@ def launch_recurrent_delta_rule_fwd(
         N=num_sequences,
         state_batch_stride=state_batch_stride,
         H=heads,
+        HK=key_heads,
         K=key_dim,
         V=value_dim,
         BK=triton.next_power_of_2(key_dim),

--- a/attn_gym/linear/_delta_rule/recurrent.py
+++ b/attn_gym/linear/_delta_rule/recurrent.py
@@ -80,12 +80,17 @@ def _recurrent_delta_rule_fwd_kernel(
     USE_STATE_INDICES: tl.constexpr,
     USE_HAS_INITIAL_STATE: tl.constexpr,
     SCALAR_GATE: tl.constexpr,
+    QK_L2NORM: tl.constexpr,
 ):
     """Scan one sequence/head/value tile while retaining the FP32 state in registers.
 
     Programs are indexed by value head. With grouped heads (``HK < H``) each block of
     ``H // HK`` consecutive value heads reads one shared q/k (and vector-gate) head; KDA
     passes ``HK == H``, which reduces every ``row_k`` to the ungrouped ``row``.
+
+    ``QK_L2NORM`` rescales each loaded q/k slice to unit L2 norm in registers, computed as
+    ``x / sqrt(sum(x^2) + 1e-6)``; the epsilon keeps near-zero heads finite, and masked
+    tail lanes load zero so they drop out of the sum.
     """
     pid = tl.program_id(0).to(tl.int64)
     NV = tl.cdiv(V, BV)
@@ -140,8 +145,11 @@ def _recurrent_delta_rule_fwd_kernel(
         row = t * H + i_h
         row_k = t * HK + i_hk
         b_q = tl.load(q + ptr_offset((row_k, o_k), (K, 1)), mask=m_k, other=0.0).to(tl.float32)
-        b_q *= scale
         b_k = tl.load(k + ptr_offset((row_k, o_k), (K, 1)), mask=m_k, other=0.0).to(tl.float32)
+        if QK_L2NORM:
+            b_q = b_q / tl.sqrt(tl.sum(b_q * b_q) + 1e-6)
+            b_k = b_k / tl.sqrt(tl.sum(b_k * b_k) + 1e-6)
+        b_q *= scale
         if SCALAR_GATE:
             b_g = tl.load(gate + row).to(tl.float32)
         else:
@@ -185,6 +193,7 @@ recurrent_delta_rule_fwd_kernel = triton.autotune(
         "STORE_FINAL_STATE",
         "IS_VARLEN",
         "SCALAR_GATE",
+        "QK_L2NORM",
     ],
     prune_configs_by={"early_config_prune": _prune_recurrent_configs},
     **autotune_cache_kwargs,
@@ -205,6 +214,7 @@ def launch_recurrent_delta_rule_fwd(
     store_final_state: bool,
     state_indices: torch.Tensor | None = None,
     has_initial_state: torch.Tensor | None = None,
+    qk_l2norm: bool = False,
     autotune: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Launch a scalar- or vector-gated recurrent delta-rule specialization.
@@ -235,6 +245,8 @@ def launch_recurrent_delta_rule_fwd(
             contents: the scan starts from zero and overwrites the slot, including for empty
             sequences, so the slot is initialized before a later decode reads it. Without
             this mask every selected slot is treated as real history.
+        qk_l2norm: L2-normalize each ``[K]`` query and key slice in registers before the
+            scan step; see the kernel docstring for the exact formula.
         autotune: Benchmark tile configurations when true; paged launches always use fixed
             heuristics because rerunning candidates would advance the pool repeatedly.
 
@@ -325,6 +337,7 @@ def launch_recurrent_delta_rule_fwd(
         USE_STATE_INDICES=state_indices is not None,
         USE_HAS_INITIAL_STATE=has_initial_state is not None,
         SCALAR_GATE=gate_kind is GateKind.SCALAR,
+        QK_L2NORM=qk_l2norm,
         **launch_options,
     )
     return output, final_state

--- a/attn_gym/linear/_delta_rule/validation.py
+++ b/attn_gym/linear/_delta_rule/validation.py
@@ -13,22 +13,25 @@ def validate_paged_state(
     state_indices: torch.Tensor,
     has_initial_state: torch.Tensor | None = None,
 ) -> None:
-    """Validate the shared mutable ``[slots, H, V, K]`` state contract."""
-    expected_shape = (q.shape[2], v.shape[-1], q.shape[3])
+    """Validate the shared mutable ``[slots, H, V, K]`` state contract.
+
+    The pool carries one state per value head, so grouped-head callers size ``H`` from ``v``.
+    """
+    expected_shape = (v.shape[2], v.shape[-1], q.shape[3])
     if state_cache.ndim != 4 or state_cache.shape[1:] != expected_shape:
         raise ValueError(
             "the paged state pool must have shape "
-            f"[num_slots, {q.shape[2]}, {v.shape[-1]}, {q.shape[3]}], "
+            f"[num_slots, {v.shape[2]}, {v.shape[-1]}, {q.shape[3]}], "
             f"got {tuple(state_cache.shape)}"
         )
+    expected_inner_strides = (v.shape[-1] * q.shape[3], q.shape[3], 1)
     if state_cache.device != q.device:
         raise ValueError("the paged state pool must be on q.device")
     if state_cache.dtype != torch.float32:
         raise TypeError("the paged state pool must use float32")
-    expected_inner_strides = (v.shape[-1] * q.shape[3], q.shape[3], 1)
     if state_cache.stride()[1:] != expected_inner_strides:
         raise TypeError("the paged state pool must be contiguous within each [H, V, K] slot")
-    if state_cache.stride(0) < q.shape[2] * q.shape[3] * v.shape[-1]:
+    if state_cache.stride(0) < v.shape[2] * q.shape[3] * v.shape[-1]:
         raise ValueError("paged state pool slots must not overlap")
 
     num_sequences = q.shape[0] if cu_seqlens is None else cu_seqlens.shape[0] - 1

--- a/attn_gym/linear/gdn/__init__.py
+++ b/attn_gym/linear/gdn/__init__.py
@@ -1,5 +1,5 @@
 """Gated delta rule attention."""
 
-from attn_gym.linear.gdn.api import chunk_gdn, recurrent_gdn
+from attn_gym.linear.gdn.api import chunk_gdn, recurrent_gdn, recurrent_gdn_decode
 
-__all__ = ["chunk_gdn", "recurrent_gdn"]
+__all__ = ["chunk_gdn", "recurrent_gdn", "recurrent_gdn_decode"]

--- a/attn_gym/linear/gdn/api.py
+++ b/attn_gym/linear/gdn/api.py
@@ -176,4 +176,75 @@ def recurrent_gdn(
     )
 
 
-__all__ = ["chunk_gdn", "recurrent_gdn"]
+def recurrent_gdn_decode(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    state_cache: torch.Tensor,
+    state_indices: torch.Tensor,
+    *,
+    has_initial_state: torch.Tensor | None = None,
+    scale: float | None = None,
+    qk_l2norm: bool = True,
+) -> torch.Tensor:
+    """Run one-token paged GDN decode with QK normalization fused into the recurrence.
+
+    The decode counterpart to :func:`recurrent_gdn`: one token per sequence, the paged
+    state pool advanced in place, and the per-token query/key L2 normalization computed
+    in registers so serving callers launch no separate elementwise kernels.
+
+    Args:
+        q: Queries shaped ``[B, HK, K]``, one token per sequence. ``HK`` may divide the
+            value head count for grouped-head attention.
+        k: Keys shaped like ``q`` and using the same dtype.
+        v: Values shaped ``[B, H, V]``.
+        gate: Finite, nonpositive per-token natural-log decay shaped ``[B, H]``.
+        beta: Per-token write gate shaped ``[B, H]``.
+        state_cache: Mutable FP32 state pool shaped ``[num_slots, H, V, K]``, advanced in
+            place. Slots may have padding between them but each ``[H, V, K]`` row must be
+            dense.
+        state_indices: Contiguous int32 slot indices shaped ``[B]``. Positive indices must
+            be unique and in bounds; non-positive indices are padding that produce zero
+            output and leave the pool untouched.
+        has_initial_state: Optional contiguous boolean mask, one per sequence. False
+            entries mark freshly assigned slots whose contents are garbage: they start
+            from zero and overwrite the slot.
+        scale: Query scale. Defaults to ``1 / sqrt(K)``.
+        qk_l2norm: L2-normalize each query and key head in-kernel, computed as
+            ``x / sqrt(sum(x^2) + 1e-6)``. Disable when the caller has already normalized.
+
+    Returns:
+        Decode output shaped ``[B, H, V]`` in ``q.dtype``. ``state_cache`` is advanced in
+        place.
+    """
+    if q.ndim != 3:
+        raise ValueError(f"q must have shape [B, HK, K], got {tuple(q.shape)}")
+    if v.ndim != 3:
+        raise ValueError(f"v must have shape [B, H, V], got {tuple(v.shape)}")
+    token_q, token_k, token_v = (tensor.unsqueeze(1) for tensor in (q, k, v))
+    token_gate, token_beta = (tensor.unsqueeze(1) for tensor in (gate, beta))
+    validate_gdn_inputs(token_q, token_k, token_v, token_gate, token_beta, None)
+    validate_paged_state(token_q, token_v, state_cache, None, state_indices, has_initial_state)
+
+    output, _ = fused_recurrent_forward(
+        token_q,
+        token_k,
+        token_v,
+        token_gate,
+        token_beta,
+        state_cache,
+        cu_seqlens=None,
+        scale=q.shape[-1] ** -0.5 if scale is None else scale,
+        output_final_state=False,
+        state_indices=state_indices,
+        has_initial_state=has_initial_state,
+        autotune=False,
+        qk_l2norm=qk_l2norm,
+        op_name="recurrent_gdn_decode",
+    )
+    return output.squeeze(1)
+
+
+__all__ = ["chunk_gdn", "recurrent_gdn", "recurrent_gdn_decode"]

--- a/attn_gym/linear/gdn/api.py
+++ b/attn_gym/linear/gdn/api.py
@@ -32,7 +32,9 @@ def chunk_gdn(
     that recurrence. FP16 and BF16 inputs use FP32 recurrence math and state.
 
     Args:
-        q: Queries shaped ``[B, T, H, K]``.
+        q: Queries shaped ``[B, T, HK, K]``. ``HK`` may divide the value head count for
+            grouped-head attention: each block of ``H // HK`` consecutive value heads shares
+            one query/key head, with no materialized ``repeat_interleave``.
         k: Keys shaped like ``q`` and using the same dtype.
         v: Values shaped ``[B, T, H, V]`` and using the same dtype as ``q``.
         gate: Floating per-token scalar natural-log decay shaped ``[B, T, H]``.
@@ -92,7 +94,9 @@ def recurrent_gdn(
     inputs use FP32 recurrence math and state.
 
     Args:
-        q: Queries shaped ``[B, T, H, K]``.
+        q: Queries shaped ``[B, T, HK, K]``. ``HK`` may divide the value head count for
+            grouped-head attention: each block of ``H // HK`` consecutive value heads shares
+            one query/key head, with no materialized ``repeat_interleave``.
         k: Keys shaped like ``q`` and using the same dtype.
         v: Values shaped ``[B, T, H, V]`` and using the same dtype as ``q``.
         gate: Floating per-token scalar natural-log decay shaped ``[B, T, H]``.

--- a/attn_gym/linear/gdn/impl/fused.py
+++ b/attn_gym/linear/gdn/impl/fused.py
@@ -21,6 +21,7 @@ def _launch_recurrent(
     output_final_state: bool,
     state_indices: torch.Tensor | None = None,
     has_initial_state: torch.Tensor | None = None,
+    qk_l2norm: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Launch the scalar-gate specialization of the shared log2-space scan."""
     return launch_recurrent_delta_rule_fwd(
@@ -36,6 +37,7 @@ def _launch_recurrent(
         store_final_state=output_final_state,
         state_indices=state_indices,
         has_initial_state=has_initial_state,
+        qk_l2norm=qk_l2norm,
         autotune=autotune,
     )
 
@@ -103,6 +105,7 @@ def _gdn_recurrent_fwd_paged_cuda(
     has_initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor | None,
     scale: float,
+    qk_l2norm: bool,
 ) -> torch.Tensor:
     """Advance selected cache slots with the shared scalar-gate scan."""
     return _launch_recurrent(
@@ -118,6 +121,7 @@ def _gdn_recurrent_fwd_paged_cuda(
         output_final_state=True,
         state_indices=state_indices,
         has_initial_state=has_initial_state,
+        qk_l2norm=qk_l2norm,
     )[0]
 
 

--- a/attn_gym/linear/gdn/impl/reference.py
+++ b/attn_gym/linear/gdn/impl/reference.py
@@ -83,6 +83,10 @@ def reference_gdn(
     output_dtype = q.dtype
     compute_dtype = torch.promote_types(q.dtype, torch.float32)
     q, k, v, log_decay, beta = (tensor.to(compute_dtype) for tensor in (q, k, v, log_decay, beta))
+    if q.shape[2] != v.shape[2]:
+        # Grouped heads: expand each shared query/key head across its value-head group.
+        groups = v.shape[2] // q.shape[2]
+        q, k = (tensor.repeat_interleave(groups, dim=2) for tensor in (q, k))
     # Explicit casts do not stop autocast from selecting low-precision contractions.
     with torch.autocast(device_type=q.device.type, enabled=False):
         if cu_seqlens is None:

--- a/attn_gym/linear/gdn/ops.py
+++ b/attn_gym/linear/gdn/ops.py
@@ -15,7 +15,8 @@ torch.library.define("attn_gym::gdn_recurrent_fwd_no_state", _RECURRENT_ARGS + "
 torch.library.define(
     "attn_gym::gdn_recurrent_fwd_paged",
     "(Tensor q, Tensor k, Tensor v, Tensor gate, Tensor beta, Tensor(a!) state_cache, "
-    "Tensor state_indices, Tensor? has_initial_state, Tensor? cu_seqlens, float scale) -> Tensor",
+    "Tensor state_indices, Tensor? has_initial_state, Tensor? cu_seqlens, float scale, "
+    "bool qk_l2norm) -> Tensor",
 )
 
 
@@ -102,8 +103,9 @@ def _recurrent_fwd_paged_fake(
     has_initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor | None,
     scale: float,
+    qk_l2norm: bool,
 ) -> torch.Tensor:
-    del k, gate, beta, state_cache, state_indices, has_initial_state, cu_seqlens, scale
+    del k, gate, beta, state_cache, state_indices, has_initial_state, cu_seqlens, scale, qk_l2norm
     return torch.empty_like(v, dtype=q.dtype)
 
 
@@ -126,18 +128,20 @@ def recurrent_forward(
     state_indices: torch.Tensor | None,
     has_initial_state: torch.Tensor | None,
     autotune: bool,
+    qk_l2norm: bool = False,
+    op_name: str = "recurrent_gdn(impl='fused')",
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Normalize inputs and invoke the fused recurrent GDN operator."""
     if q.shape[-1] > 256:
-        raise ValueError(f"recurrent_gdn requires K in [1, 256], got {q.shape[-1]}")
+        raise ValueError(f"{op_name} requires K in [1, 256], got {q.shape[-1]}")
     if not q.is_cuda:
-        raise ValueError("recurrent_gdn(impl='fused') requires CUDA tensors")
+        raise ValueError(f"{op_name} requires CUDA tensors")
     if q.dtype not in (torch.float16, torch.bfloat16, torch.float32):
-        raise TypeError("recurrent_gdn(impl='fused') requires float16, bfloat16, or float32 QKV")
+        raise TypeError(f"{op_name} requires float16, bfloat16, or float32 QKV")
     tensors = (q, k, v, gate, beta) + (() if initial_state is None else (initial_state,))
     if torch.is_grad_enabled() and any(tensor.requires_grad for tensor in tensors):
         raise RuntimeError(
-            "recurrent_gdn(impl='fused') is inference-only and has no backward; "
+            f"{op_name} is inference-only and has no backward; "
             "call under torch.no_grad() or torch.inference_mode()"
         )
 
@@ -156,7 +160,9 @@ def recurrent_forward(
             has_initial_state,
             cu_seqlens,
             scale,
+            qk_l2norm,
         ), None
+    assert not qk_l2norm, "qk_l2norm is only plumbed through the paged operator"
     if initial_state is not None:
         initial_state = initial_state.contiguous()
     args = (q, k, v, gate, beta, initial_state, cu_seqlens, scale, autotune)

--- a/attn_gym/linear/gdn/ops.py
+++ b/attn_gym/linear/gdn/ops.py
@@ -67,8 +67,9 @@ def _recurrent_fwd_fake(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     del k, gate, beta, initial_state, scale, autotune
     num_sequences = q.shape[0] if cu_seqlens is None else cu_seqlens.shape[0] - 1
+    # The state carries one [K, V] slab per value head; grouped callers have v.shape[2] > HK.
     final_state = q.new_empty(
-        num_sequences, q.shape[2], q.shape[3], v.shape[-1], dtype=torch.float32
+        num_sequences, v.shape[2], q.shape[3], v.shape[-1], dtype=torch.float32
     )
     return torch.empty_like(v, dtype=q.dtype), final_state
 

--- a/attn_gym/linear/gdn/validation.py
+++ b/attn_gym/linear/gdn/validation.py
@@ -17,14 +17,18 @@ def validate_gdn_inputs(
     """Validate backend-independent gated delta rule tensor invariants."""
     if q.ndim != 4:
         raise ValueError(f"q must have shape [B, T, H, K], got {tuple(q.shape)}")
-    batch, tokens, heads, key_dim = q.shape
-    if batch == 0 or tokens == 0 or heads == 0 or key_dim == 0:
+    batch, tokens, key_heads, key_dim = q.shape
+    if batch == 0 or tokens == 0 or key_heads == 0 or key_dim == 0:
         raise ValueError(f"q must have nonempty dimensions, got {tuple(q.shape)}")
     if k.shape != q.shape:
         raise ValueError(f"k must have shape {tuple(q.shape)}, got {tuple(k.shape)}")
-    if v.ndim != 4 or v.shape[:3] != (batch, tokens, heads) or v.shape[-1] == 0:
+    if v.ndim != 4 or v.shape[:2] != (batch, tokens) or v.shape[-1] == 0:
+        raise ValueError(f"v must have shape [{batch}, {tokens}, H, V], got {tuple(v.shape)}")
+    heads = v.shape[2]
+    if heads == 0 or heads % key_heads != 0:
         raise ValueError(
-            f"v must have shape [{batch}, {tokens}, {heads}, V], got {tuple(v.shape)}"
+            f"v heads must be a positive multiple of q heads for grouped-head attention, "
+            f"got {heads} value heads for {key_heads} query heads"
         )
     if gate.shape != (batch, tokens, heads):
         raise ValueError(f"gate must have shape {(batch, tokens, heads)}, got {tuple(gate.shape)}")

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -68,9 +68,16 @@ falling back to the reference.
 - `initial_state` may be positional, and `output_final_state` controls the optional state output.
 - Both operations return `(output, final_state)`, matching the KDA operations.
 
+`recurrent_gdn_decode` is the serving-specific one-token path: it consumes `[B, H*, D]`
+tensors without a token dimension, advances the paged FP32 state pool in place through
+`state_indices`, supports grouped q/k heads, and fuses the per-token query/key L2
+normalization into the scan so no separate elementwise kernels run per decode step.
+
 ::: attn_gym.linear.chunk_gdn
 
 ::: attn_gym.linear.recurrent_gdn
+
+::: attn_gym.linear.recurrent_gdn_decode
 
 ## Kimi Delta Attention
 

--- a/test/linear/test_gdn.py
+++ b/test/linear/test_gdn.py
@@ -236,6 +236,41 @@ def test_low_precision_default_state_is_fp32(function):
     assert final_state.dtype == torch.float32
 
 
+@pytest.mark.parametrize("function", REFERENCE_CASES)
+def test_grouped_heads_match_expanded_heads(function):
+    """Fewer q/k heads than v heads must equal an explicit repeat_interleave."""
+    q, k, v, gate, beta, state = make_inputs(sequence=7)
+    groups = 2
+    v, gate, beta = (tensor.repeat_interleave(groups, dim=2) for tensor in (v, gate, beta))
+    state = state.repeat_interleave(groups, dim=1)
+
+    grouped_output, grouped_state = function(q, k, v, gate, beta, state, output_final_state=True)
+    expanded_output, expanded_state = function(
+        q.repeat_interleave(groups, dim=2),
+        k.repeat_interleave(groups, dim=2),
+        v,
+        gate,
+        beta,
+        state,
+        output_final_state=True,
+    )
+
+    torch.testing.assert_close(grouped_output, expanded_output)
+    torch.testing.assert_close(grouped_state, expanded_state)
+
+
+def test_grouped_heads_require_divisible_counts():
+    q, k, v, gate, beta, _state = make_inputs(sequence=3)
+    # Five value heads cannot be grouped over three query heads.
+    v, gate, beta = (
+        tensor.repeat_interleave(2, dim=2)[:, :, :5].contiguous() for tensor in (v, gate, beta)
+    )
+    with pytest.raises(ValueError, match="positive multiple of q heads"):
+        recurrent_gdn(q, k, v, gate, beta)
+    with pytest.raises(ValueError, match="positive multiple of q heads"):
+        recurrent_gdn(q, k, v[:, :, :0], gate[:, :, :0], beta[:, :, :0])
+
+
 @pytest.mark.parametrize("function", [chunk_gdn, recurrent_gdn])
 def test_fp64_preserves_compute_and_state_dtype(function):
     inputs = [tensor.double() for tensor in make_inputs(sequence=3)]

--- a/test/linear/test_gdn_decode.py
+++ b/test/linear/test_gdn_decode.py
@@ -1,0 +1,185 @@
+import pytest
+import torch
+import torch.nn.functional as F
+
+pytest.importorskip("triton")
+
+from attn_gym.linear import recurrent_gdn, recurrent_gdn_decode
+from attn_gym.linear.gdn.ops import recurrent_fwd_paged_op
+from attn_gym.testing import strided_state_pool
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="recurrent_gdn_decode requires CUDA"
+)
+
+
+def make_decode_inputs(
+    *,
+    batch: int = 3,
+    heads: int = 4,
+    key_dim: int = 32,
+    value_dim: int = 24,
+    key_heads: int | None = None,
+    dtype: torch.dtype = torch.float32,
+    seed: int = 0,
+) -> tuple[torch.Tensor, ...]:
+    """Create one-token decode inputs; ``key_heads`` enables grouped heads."""
+    torch.manual_seed(seed)
+    q = torch.randn(batch, key_heads or heads, key_dim, device="cuda", dtype=dtype)
+    k = torch.randn_like(q)
+    v = torch.randn(batch, heads, value_dim, device="cuda", dtype=dtype)
+    gate = F.logsigmoid(torch.randn(batch, heads, device="cuda"))
+    beta = torch.sigmoid(torch.randn(batch, heads, device="cuda"))
+    return q, k, v, gate, beta
+
+
+def fla_l2norm(x: torch.Tensor) -> torch.Tensor:
+    """Normalize like the fused kernel: ``x / sqrt(sum(x^2) + 1e-6)``."""
+    return x * torch.rsqrt(x.square().sum(-1, keepdim=True) + 1e-6)
+
+
+@pytest.mark.parametrize("key_heads", [None, 2])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_decode_matches_reference(key_heads: int | None, dtype: torch.dtype):
+    """Fused decode equals the reference recurrence on externally normalized q/k."""
+    q, k, v, gate, beta = make_decode_inputs(key_heads=key_heads, dtype=dtype)
+    _storage, pool = strided_state_pool(6, v.shape[1], q.shape[-1], v.shape[-1])
+    slots = torch.tensor([1, 3, 5], device="cuda", dtype=torch.int32)
+    initial_state = pool[slots.long()].transpose(-1, -2).contiguous()
+
+    with torch.no_grad():
+        expected, expected_state = recurrent_gdn(
+            fla_l2norm(q.float()).to(dtype).unsqueeze(1),
+            fla_l2norm(k.float()).to(dtype).unsqueeze(1),
+            v.unsqueeze(1),
+            gate.unsqueeze(1),
+            beta.unsqueeze(1),
+            initial_state,
+            output_final_state=True,
+            impl="reference",
+        )
+        output = recurrent_gdn_decode(q, k, v, gate, beta, pool, slots)
+
+    if dtype is torch.float32:
+        tolerance = {"rtol": 1e-5, "atol": 1e-5}
+    else:
+        # The kernel normalizes raw bf16 loads in FP32 registers; the external baseline
+        # must round the normalized q/k back to bf16, adding one quantization the fused
+        # path never performs.
+        tolerance = {"rtol": 2e-2, "atol": 2e-3}
+    torch.testing.assert_close(output, expected.squeeze(1), **tolerance)
+    torch.testing.assert_close(pool[slots.long()], expected_state.transpose(-1, -2), **tolerance)
+
+
+def test_decode_padding_and_fresh_slots():
+    """Nonpositive slots produce zero output; fresh slots start from zero and overwrite."""
+    q, k, v, gate, beta = make_decode_inputs()
+    _storage, pool = strided_state_pool(6, v.shape[1], q.shape[-1], v.shape[-1])
+    original_pool = pool.clone()
+    slots = torch.tensor([0, 2, 4], device="cuda", dtype=torch.int32)
+    has_initial_state = torch.tensor([True, False, True], device="cuda")
+
+    with torch.no_grad():
+        output = recurrent_gdn_decode(
+            q, k, v, gate, beta, pool, slots, has_initial_state=has_initial_state
+        )
+        fresh_pool = torch.zeros_like(original_pool[:2])
+        fresh_expected = recurrent_gdn_decode(
+            q[1:2],
+            k[1:2],
+            v[1:2],
+            gate[1:2],
+            beta[1:2],
+            fresh_pool,
+            torch.tensor([1], device="cuda", dtype=torch.int32),
+        )
+
+    torch.testing.assert_close(output[0], torch.zeros_like(output[0]), rtol=0, atol=0)
+    torch.testing.assert_close(output[1:2], fresh_expected)
+    # The fresh sequence must also store its resulting state into the selected slot.
+    torch.testing.assert_close(pool[2], fresh_pool[1], rtol=1e-5, atol=1e-5)
+    preserved = [0, 1, 3, 5]
+    torch.testing.assert_close(pool[preserved], original_pool[preserved], rtol=0, atol=0)
+
+
+def test_decode_qk_l2norm_disabled_matches_recurrent_gdn():
+    """With normalization off, decode is exactly the paged recurrent op on one token."""
+    q, k, v, gate, beta = make_decode_inputs()
+    _storage, pool = strided_state_pool(5, v.shape[1], q.shape[-1], v.shape[-1])
+    # An identically strided pool keeps the kernel specialization (and thus the exact
+    # floating-point schedule) the same across both calls.
+    _reference_storage, reference_pool = strided_state_pool(
+        5, v.shape[1], q.shape[-1], v.shape[-1]
+    )
+    reference_pool.copy_(pool)
+    slots = torch.tensor([1, 2, 4], device="cuda", dtype=torch.int32)
+
+    with torch.no_grad():
+        output = recurrent_gdn_decode(q, k, v, gate, beta, pool, slots, qk_l2norm=False)
+        expected = recurrent_gdn(
+            q.unsqueeze(1),
+            k.unsqueeze(1),
+            v.unsqueeze(1),
+            gate.unsqueeze(1),
+            beta.unsqueeze(1),
+            reference_pool,
+            state_indices=slots,
+            impl="fused",
+        )[0]
+
+    torch.testing.assert_close(output, expected.squeeze(1), rtol=0, atol=0)
+    torch.testing.assert_close(pool, reference_pool, rtol=0, atol=0)
+
+
+def test_decode_rejects_grad_and_bad_shapes():
+    q, k, v, gate, beta = make_decode_inputs()
+    _storage, pool = strided_state_pool(5, v.shape[1], q.shape[-1], v.shape[-1])
+    slots = torch.tensor([1, 2, 4], device="cuda", dtype=torch.int32)
+
+    with pytest.raises(ValueError, match=r"\[B, HK, K\]"):
+        recurrent_gdn_decode(q.unsqueeze(1), k, v, gate, beta, pool, slots)
+    with pytest.raises(RuntimeError, match="inference-only"):
+        recurrent_gdn_decode(q.clone().requires_grad_(), k, v, gate, beta, pool, slots)
+
+
+def test_decode_custom_op_registration():
+    """Decode lowers to the paged operator; opcheck it with the fused normalization on."""
+    q, k, v, gate, beta = make_decode_inputs()
+    _storage, pool = strided_state_pool(5, v.shape[1], q.shape[-1], v.shape[-1])
+    slots = torch.tensor([1, 2, 4], device="cuda", dtype=torch.int32)
+    token_shaped = (tensor.unsqueeze(1) for tensor in (q, k, v, gate.float(), beta.float()))
+    torch.library.opcheck(
+        recurrent_fwd_paged_op,
+        (*token_shaped, pool, slots, None, None, 0.25, True),
+    )
+
+
+def test_decode_fullgraph_and_cuda_graph():
+    """The decode op compiles fullgraph and replays under CUDA graph capture."""
+    q, k, v, gate, beta = make_decode_inputs()
+    _storage, pool = strided_state_pool(5, v.shape[1], q.shape[-1], v.shape[-1])
+    initial_pool = pool.clone()
+    slots = torch.tensor([1, 2, 4], device="cuda", dtype=torch.int32)
+
+    compiled = torch.compile(recurrent_gdn_decode, fullgraph=True)
+    with torch.no_grad():
+        _eager_storage, eager_pool = strided_state_pool(5, v.shape[1], q.shape[-1], v.shape[-1])
+        eager_pool.copy_(initial_pool)
+        expected = recurrent_gdn_decode(q, k, v, gate, beta, eager_pool, slots)
+        actual = compiled(q, k, v, gate, beta, pool, slots)
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    torch.testing.assert_close(pool, eager_pool, rtol=0, atol=0)
+
+    _graph_storage, graph_pool = strided_state_pool(5, v.shape[1], q.shape[-1], v.shape[-1])
+    with torch.no_grad():
+        graph_pool.copy_(initial_pool)
+        recurrent_gdn_decode(q, k, v, gate, beta, graph_pool, slots)
+        torch.cuda.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            captured = recurrent_gdn_decode(q, k, v, gate, beta, graph_pool, slots)
+        # Reset to the pre-decode snapshot so replay reproduces the eager call.
+        graph_pool.copy_(initial_pool)
+        graph.replay()
+        torch.cuda.synchronize()
+    torch.testing.assert_close(captured, expected, rtol=0, atol=0)

--- a/test/linear/test_gdn_fused.py
+++ b/test/linear/test_gdn_fused.py
@@ -288,6 +288,7 @@ def test_fused_recurrent_paged_registration():
             has_initial_state,
             None,
             q.shape[-1] ** -0.5,
+            False,
         ),
     )
 

--- a/test/linear/test_gdn_fused.py
+++ b/test/linear/test_gdn_fused.py
@@ -18,11 +18,17 @@ pytestmark = pytest.mark.skipif(
 
 
 def make_inputs(
-    *, batch: int = 2, tokens: int = 9, heads: int = 2, key_dim: int = 32, value_dim: int = 24
+    *,
+    batch: int = 2,
+    tokens: int = 9,
+    heads: int = 2,
+    key_dim: int = 32,
+    value_dim: int = 24,
+    key_heads: int | None = None,
 ) -> tuple[torch.Tensor, ...]:
-    """Create stable token-major scalar-gate inputs."""
+    """Create stable token-major scalar-gate inputs; ``key_heads`` enables grouped heads."""
     torch.manual_seed(0)
-    q = torch.randn(batch, tokens, heads, key_dim, device="cuda")
+    q = torch.randn(batch, tokens, key_heads or heads, key_dim, device="cuda")
     k = F.normalize(torch.randn_like(q), dim=-1)
     v = torch.randn(batch, tokens, heads, value_dim, device="cuda")
     gate = F.logsigmoid(torch.randn(batch, tokens, heads, device="cuda"))
@@ -190,6 +196,50 @@ def test_fused_recurrent_packed_paged_state():
     torch.testing.assert_close(state_cache, expected_cache, rtol=1e-5, atol=1e-5)
 
 
+@pytest.mark.parametrize("tokens", [1, 9])
+def test_fused_recurrent_grouped_heads_matches_reference(tokens: int):
+    """Fewer q/k heads than v heads must match the expanding reference oracle."""
+    q, k, v, gate, beta, state = make_inputs(tokens=tokens, heads=6, key_heads=2)
+    with torch.no_grad():
+        expected = recurrent_gdn(
+            q, k, v, gate, beta, state, output_final_state=True, impl=Impl.REFERENCE
+        )
+        actual = recurrent_gdn(
+            q, k, v, gate, beta, state, output_final_state=True, impl=Impl.FUSED
+        )
+    torch.testing.assert_close(actual[0], expected[0], rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(actual[1], expected[1], rtol=1e-5, atol=1e-5)
+
+
+def test_fused_recurrent_grouped_heads_paged_matches_dense():
+    """Paged grouped-head decode equals the dense fused path on gathered slots."""
+    q, k, v, gate, beta, _state = make_inputs(batch=3, tokens=1, heads=6, key_heads=2)
+    _storage, pool = strided_state_pool(5, v.shape[2], q.shape[-1], v.shape[-1])
+    slots = torch.tensor([1, 3, 4], device="cuda", dtype=torch.int32)
+    initial_state = pool[slots.long()].transpose(-1, -2).contiguous()
+
+    with torch.no_grad():
+        expected_output, expected_state = recurrent_gdn(
+            q, k, v, gate, beta, initial_state, output_final_state=True, impl=Impl.FUSED
+        )
+        output, _ = recurrent_gdn(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            pool,
+            state_indices=slots,
+            has_initial_state=torch.ones(3, device="cuda", dtype=torch.bool),
+            impl=Impl.FUSED,
+        )
+
+    torch.testing.assert_close(output, expected_output, rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(
+        pool[slots.long()], expected_state.transpose(-1, -2), rtol=1e-5, atol=1e-5
+    )
+
+
 def test_fused_recurrent_packed_paged_empty_sequences():
     """Empty packed sequences zero freshly assigned slots and preserve resumed ones."""
     q, k, v, gate, beta, _state = make_inputs(batch=1, tokens=4)
@@ -239,6 +289,15 @@ def test_fused_recurrent_paged_registration():
             None,
             q.shape[-1] ** -0.5,
         ),
+    )
+
+
+def test_fused_recurrent_grouped_heads_registration():
+    """Grouped-head fakes must size the final state from value heads, not query heads."""
+    q, k, v, gate, beta, state = make_inputs(batch=1, tokens=3, heads=6, key_heads=2)
+    torch.library.opcheck(
+        recurrent_fwd_op,
+        (q, k, v, gate, beta, state, None, q.shape[-1] ** -0.5, False),
     )
 
 


### PR DESCRIPTION
Stacked PRs:
 * #390
 * __->__#389
 * #388


--- --- ---

Add recurrent_gdn_decode with fused QK L2 normalization

## Human Note

## Agent note

Add the serving-specific one-token GDN entrypoint mirroring recurrent_kda_decode: 3-D per-token
inputs, the paged FP32 state pool advanced in place through state_indices with has_initial_state
fresh-slot semantics, grouped q/k heads, and the per-token query/key L2 normalization fused into
the scan registers (x / sqrt(sum(x^2) + 1e-6), bit-matching FLA use_qk_l2norm_in_kernel) so decode
callers launch no separate elementwise kernels. The shared scan gains a QK_L2NORM constexpr; the
op registers as attn_gym::gdn_recurrent_decode with a mutating schema, fake registration, opcheck,
fullgraph, and CUDA-graph coverage. Exact-equality tests build identically strided pools because
state_batch_stride is a kernel constexpr and different pool layouts compile different FP schedules.

## Test Plan

```bash
.venv/bin/prek run --files attn_gym/linear/_delta_rule/recurrent.py attn_gym/linear/gdn/ops.py attn_gym/linear/gdn/api.py attn_gym/linear/gdn/impl/fused.py test/linear/test_gdn_decode.py docs/linear.md
gpu-run auto -- .venv/bin/pytest -q -n 6 test/linear/ test/test_kda_recurrent.py test/test_kda_recurrent_decode.py test/test_namespaces.py
```