### PR TITLE
Share the fused decode kernel across gate kinds

### DIFF
--- a/attn_gym/linear/_delta_rule/decode.py
+++ b/attn_gym/linear/_delta_rule/decode.py
@@ -1,0 +1,247 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Fused one-token paged decode shared by scalar- and vector-gated delta rules.
+
+One kernel advances each sequence by a single token: it slices q/k/v out of the packed
+post-convolution QKV buffer, applies the gate transform to the raw projections, L2-normalizes
+q and k, runs one delta-rule step against the selected cache slot, and writes the slot back —
+so serving callers launch no separate elementwise kernels. The recurrence matches the shared
+scan in :mod:`attn_gym.linear._delta_rule.recurrent`, with the cache storing the transpose
+``[V, K]`` of the scan's logical ``[K, V]`` state:
+
+    state  = exp(gate) * state       # GateKind.SCALAR: one decay per value head
+                                     # GateKind.VECTOR: one decay per key channel
+    delta  = sigmoid(raw_beta) * (v - k @ state)
+    state += outer(k, delta)
+    out    = scale * l2norm(q) @ state
+
+Gate transforms (`USE_LOWER_BOUND` selects the first):
+
+    bounded:  lower_bound * sigmoid(exp(A_log) * (raw_gate + dt_bias))
+    softplus: -exp(A_log) * softplus(raw_gate + dt_bias)
+
+Scalar-gated callers may pass fewer q/k heads than value heads (grouped heads): each block of
+``H // HK`` consecutive value heads shares one q/k head inside the packed buffer.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+import torch
+import triton
+import triton.language as tl
+
+from attn_gym._backends.triton.utils import ptr_offset
+from attn_gym.linear._delta_rule.recurrent import GateKind
+
+
+class GateTransform(Enum):
+    """Pointwise transform applied to the raw gate projection in-kernel."""
+
+    BOUNDED = "bounded"  # lower_bound * sigmoid(exp(A_log) * (raw_gate + dt_bias))
+    SOFTPLUS = "softplus"  # -exp(A_log) * softplus(raw_gate + dt_bias)
+
+
+# Use a flat 1D grid of B * H * ceil(V / BV) programs. Each program owns one
+# (batch row, value head, V tile), processes all K channels for that tile, and gets
+# contiguous K-dimension accesses from the [V, K] state layout.
+@triton.jit
+def _recurrent_delta_rule_decode_kernel(
+    packed_qkv,
+    raw_gate,
+    raw_beta,
+    A_log,
+    dt_bias,
+    output,
+    state_cache,
+    state_indices,
+    has_initial_state,
+    lower_bound,
+    scale,
+    state_batch_stride: tl.constexpr,
+    qkv_token_stride: tl.constexpr,
+    gate_token_stride: tl.constexpr,
+    beta_token_stride: tl.constexpr,
+    H: tl.constexpr,
+    HK: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    USE_LOWER_BOUND: tl.constexpr,
+    SCALAR_GATE: tl.constexpr,
+    USE_HAS_INITIAL_STATE: tl.constexpr,
+):
+    pid = tl.program_id(0).to(tl.int64)
+    NV = tl.cdiv(V, BV)
+    i_v = pid % NV
+    i_nh = pid // NV
+    i_n, i_h = i_nh // H, i_nh % H
+    i_hk = i_h // (H // HK)
+
+    o_k = tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_k = o_k < K
+    m_v = o_v < V
+    m_vk = m_v[:, None] & m_k[None, :]
+
+    i_state = tl.load(state_indices + i_n).to(tl.int64)
+    row = i_n * H + i_h
+    if i_state <= 0:
+        tl.store(output + ptr_offset((row, o_v), (V, 1)), 0.0, mask=m_v)
+        return
+
+    p_state = ptr_offset(
+        (i_state, i_h, o_v[:, None], o_k[None, :]),
+        (state_batch_stride, V * K, K, 1),
+    )
+    m_state = m_vk
+    if USE_HAS_INITIAL_STATE:
+        m_state &= tl.load(has_initial_state + i_n)
+    b_state = tl.load(state_cache + p_state, mask=m_state, other=0.0).to(tl.float32)
+
+    p_qkv = packed_qkv + i_n * qkv_token_stride
+    b_q = tl.load(p_qkv + ptr_offset((i_hk, o_k), (K, 1)), mask=m_k, other=0.0).to(tl.float32)
+    b_k = tl.load(p_qkv + HK * K + ptr_offset((i_hk, o_k), (K, 1)), mask=m_k, other=0.0).to(
+        tl.float32
+    )
+    b_v = tl.load(p_qkv + 2 * HK * K + ptr_offset((i_h, o_v), (V, 1)), mask=m_v, other=0.0).to(
+        tl.float32
+    )
+    b_q *= tl.rsqrt(tl.sum(b_q * b_q) + 1e-6) * scale
+    b_k *= tl.rsqrt(tl.sum(b_k * b_k) + 1e-6)
+
+    if SCALAR_GATE:
+        b_gate_input = tl.load(raw_gate + i_n * gate_token_stride + i_h).to(tl.float32)
+        b_gate_input += tl.load(dt_bias + i_h).to(tl.float32)
+    else:
+        p_gate = raw_gate + i_n * gate_token_stride + ptr_offset((i_h, o_k), (K, 1))
+        b_gate_input = tl.load(p_gate, mask=m_k, other=0.0).to(tl.float32)
+        b_gate_input += tl.load(dt_bias + ptr_offset((i_h, o_k), (K, 1)), mask=m_k, other=0.0).to(
+            tl.float32
+        )
+    b_a = tl.exp(tl.load(A_log + i_h).to(tl.float32))
+    if USE_LOWER_BOUND:
+        b_gate = lower_bound * tl.sigmoid(b_a * b_gate_input)
+    else:
+        b_softplus = tl.where(
+            b_gate_input > 20.0,
+            b_gate_input,
+            tl.where(
+                b_gate_input < -10.0,
+                tl.exp(b_gate_input),
+                tl.log(1.0 + tl.exp(b_gate_input)),
+            ),
+        )
+        b_gate = -b_a * b_softplus
+
+    if SCALAR_GATE:
+        b_state *= tl.exp(b_gate)
+    else:
+        b_state *= tl.exp(b_gate)[None, :]
+    b_delta = b_v - tl.sum(b_state * b_k[None, :], axis=1)
+    b_beta = tl.sigmoid(tl.load(raw_beta + i_n * beta_token_stride + i_h).to(tl.float32))
+    b_delta *= b_beta
+    b_state += b_delta[:, None] * b_k[None, :]
+    b_o = tl.sum(b_state * b_q[None, :], axis=1)
+    tl.store(output + ptr_offset((row, o_v), (V, 1)), b_o.to(output.dtype.element_ty), mask=m_v)
+    tl.store(state_cache + p_state, b_state, mask=m_vk)
+
+
+def launch_recurrent_delta_rule_decode(
+    packed_qkv: torch.Tensor,
+    raw_gate: torch.Tensor,
+    raw_beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    state_cache: torch.Tensor,
+    state_indices: torch.Tensor,
+    output: torch.Tensor,
+    *,
+    gate_kind: GateKind,
+    gate_transform: GateTransform,
+    key_heads: int,
+    lower_bound: float,
+    scale: float,
+    has_initial_state: torch.Tensor | None,
+    op_name: str,
+) -> None:
+    """Launch a scalar- or vector-gated fused decode specialization.
+
+    Args:
+        packed_qkv: ``[B, HK*K | HK*K | H*V]`` per-token buffer; within each section head
+            rows are contiguous. ``HK == key_heads`` may divide ``H`` for scalar gates.
+        raw_gate: Unactivated token-major gate, ``[B, H]`` for ``GateKind.SCALAR`` or
+            ``[B, H, K]`` for ``GateKind.VECTOR``.
+        raw_beta: Unactivated token-major write gate shaped ``[B, H]``, activated in-kernel
+            as ``sigmoid``.
+        A_log: FP32 per-head log decay parameter shaped ``[H]``.
+        dt_bias: FP32 gate bias, ``[H]`` for scalar or ``[H, K]`` for vector gates.
+        state_cache: Mutable FP32 pool shaped ``[num_slots, H, V, K]``; selected slots are
+            advanced in place. Slots may have padding between them but each ``[H, V, K]``
+            row must be dense.
+        state_indices: Contiguous int32 slot indices shaped ``[B]``; nonpositive entries
+            are padding that produce zero output and leave the pool untouched.
+        output: Preallocated output written in place, one row of ``H * V`` per sequence.
+        gate_kind: Gate layout; selects the transform input shapes above.
+        gate_transform: Pointwise transform applied to the raw gate projection.
+        key_heads: Number of q/k heads packed into ``packed_qkv``.
+        lower_bound: Finite nonpositive bound used only by ``GateTransform.BOUNDED``.
+        scale: Query scale folded into the in-kernel L2 normalization.
+        has_initial_state: Optional per-sequence booleans; False marks freshly assigned
+            slots whose bytes are garbage, so the step starts from the zero state and
+            overwrites the slot.
+    """
+    read_only_inputs = (packed_qkv, raw_gate, raw_beta, A_log, dt_bias, state_indices)
+    if has_initial_state is not None:
+        read_only_inputs += (has_initial_state,)
+    if any(torch._C._overlaps(output, tensor) for tensor in (*read_only_inputs, state_cache)):
+        raise ValueError(f"out must not alias any {op_name} input")
+    if any(torch._C._overlaps(state_cache, tensor) for tensor in read_only_inputs):
+        raise ValueError(f"state_cache must not alias {op_name} read-only inputs")
+
+    batch = packed_qkv.shape[0]
+    heads, value_dim, key_dim = state_cache.shape[1:]
+    assert key_heads > 0 and heads % key_heads == 0
+    if value_dim <= 32:
+        block_v, num_warps = min(triton.next_power_of_2(value_dim), 8), 4
+    elif batch * heads <= 8:
+        block_v, num_warps = min(triton.next_power_of_2(value_dim), 16), 2
+    else:
+        block_v, num_warps = min(triton.next_power_of_2(value_dim), 16), 1
+    grid = (triton.cdiv(value_dim, block_v) * batch * heads,)
+    _recurrent_delta_rule_decode_kernel[grid](
+        packed_qkv,
+        raw_gate,
+        raw_beta,
+        A_log,
+        dt_bias,
+        output,
+        state_cache,
+        state_indices,
+        has_initial_state,
+        lower_bound,
+        scale=scale,
+        state_batch_stride=state_cache.stride(0),
+        qkv_token_stride=packed_qkv.stride(0),
+        gate_token_stride=raw_gate.stride(0),
+        beta_token_stride=raw_beta.stride(0),
+        H=heads,
+        HK=key_heads,
+        K=key_dim,
+        V=value_dim,
+        BK=triton.next_power_of_2(key_dim),
+        BV=block_v,
+        USE_LOWER_BOUND=gate_transform is GateTransform.BOUNDED,
+        SCALAR_GATE=gate_kind is GateKind.SCALAR,
+        USE_HAS_INITIAL_STATE=has_initial_state is not None,
+        num_warps=num_warps,
+    )
+
+
+__all__ = ["GateTransform", "launch_recurrent_delta_rule_decode"]

--- a/attn_gym/linear/kda/api.py
+++ b/attn_gym/linear/kda/api.py
@@ -336,6 +336,7 @@ def recurrent_kda_decode(
     state_cache: torch.Tensor,
     state_indices: torch.Tensor,
     *,
+    has_initial_state: torch.Tensor | None = None,
     gate_transform: Literal["bounded", "softplus"] = "bounded",
     lower_bound: float = -5.0,
     scale: float | None = None,
@@ -361,6 +362,9 @@ def recurrent_kda_decode(
             cache untouched. Each positive index must be in ``[1, num_slots)`` and
             unique among active rows because duplicate in-place updates race. These
             value constraints are caller responsibilities and are not host-validated.
+        has_initial_state: Optional contiguous boolean mask, one per sequence. False
+            entries mark freshly assigned slots whose contents are garbage: the step
+            starts from the zero state and overwrites the slot.
         gate_transform: Pointwise gate transform. ``"bounded"`` computes
             ``lower_bound * sigmoid(exp(A_log) * (raw_gate + dt_bias))``;
             ``"softplus"`` computes
@@ -422,6 +426,15 @@ def recurrent_kda_decode(
         or not state_indices.is_contiguous()
     ):
         raise ValueError(f"state_indices must be contiguous int32 with shape ({batch},)")
+    if has_initial_state is not None and (
+        has_initial_state.shape != (batch,)
+        or has_initial_state.dtype != torch.bool
+        or not has_initial_state.is_contiguous()
+        or has_initial_state.device != packed_qkv.device
+    ):
+        raise ValueError(
+            f"has_initial_state must be contiguous bool with shape ({batch},) on packed_qkv.device"
+        )
     if key_dim > 256:
         raise ValueError(f"recurrent_kda_decode requires K in [1, 256], got {key_dim}")
 
@@ -483,6 +496,7 @@ def recurrent_kda_decode(
         dt_bias,
         state_cache,
         state_indices,
+        has_initial_state,
         out,
         lower_bound,
         use_lower_bound,

--- a/attn_gym/linear/kda/fwd/triton/recurrent.py
+++ b/attn_gym/linear/kda/fwd/triton/recurrent.py
@@ -13,9 +13,8 @@ use ``chunk_kda`` for training.
 from __future__ import annotations
 
 import torch
-import triton
-import triton.language as tl
 
+from attn_gym.linear._delta_rule.decode import GateTransform, launch_recurrent_delta_rule_decode
 from attn_gym.linear._delta_rule.recurrent import GateKind, launch_recurrent_delta_rule_fwd
 from attn_gym.linear.kda.ops import recurrent_decode_forward as decode_forward
 from attn_gym.linear.kda.ops import recurrent_decode_op as _recurrent_decode_op
@@ -27,88 +26,6 @@ from attn_gym.linear.kda.ops import recurrent_fwd_op as _recurrent_fwd_op
 from attn_gym.linear.kda.ops import (
     recurrent_fwd_paged_op as _recurrent_fwd_paged_op,
 )
-
-
-# Use a flat 1D grid of B * H * ceil(V / BV) programs. Each program owns one
-# (batch row, head, V tile), processes all K channels for that tile, and gets
-# contiguous K-dimension accesses from the [V, K] state layout.
-@triton.jit
-def kda_recurrent_decode_kernel(
-    packed_qkv,
-    raw_gate,
-    raw_beta,
-    A_log,
-    dt_bias,
-    output,
-    state_cache,
-    state_indices,
-    lower_bound,
-    scale,
-    state_batch_stride: tl.constexpr,
-    qkv_token_stride: tl.constexpr,
-    gate_token_stride: tl.constexpr,
-    beta_token_stride: tl.constexpr,
-    H: tl.constexpr,
-    K: tl.constexpr,
-    V: tl.constexpr,
-    BK: tl.constexpr,
-    BV: tl.constexpr,
-    USE_LOWER_BOUND: tl.constexpr,
-):
-    pid = tl.program_id(0).to(tl.int64)
-    NV = tl.cdiv(V, BV)
-    i_v = pid % NV
-    i_nh = pid // NV
-    i_n, i_h = i_nh // H, i_nh % H
-
-    o_k = tl.arange(0, BK)
-    o_v = i_v * BV + tl.arange(0, BV)
-    m_k = o_k < K
-    m_v = o_v < V
-    m_vk = m_v[:, None] & m_k[None, :]
-
-    i_state = tl.load(state_indices + i_n).to(tl.int64)
-    row = i_n * H + i_h
-    if i_state <= 0:
-        tl.store(output + row * V + o_v, 0.0, mask=m_v)
-        return
-
-    p_state = i_state * state_batch_stride + i_h * V * K + o_v[:, None] * K + o_k[None, :]
-    b_state = tl.load(state_cache + p_state, mask=m_vk, other=0.0).to(tl.float32)
-
-    p_qkv = packed_qkv + i_n * qkv_token_stride
-    b_q = tl.load(p_qkv + i_h * K + o_k, mask=m_k, other=0.0).to(tl.float32)
-    b_k = tl.load(p_qkv + H * K + i_h * K + o_k, mask=m_k, other=0.0).to(tl.float32)
-    b_v = tl.load(p_qkv + 2 * H * K + i_h * V + o_v, mask=m_v, other=0.0).to(tl.float32)
-    b_q *= tl.rsqrt(tl.sum(b_q * b_q) + 1e-6) * scale
-    b_k *= tl.rsqrt(tl.sum(b_k * b_k) + 1e-6)
-
-    p_gate = raw_gate + i_n * gate_token_stride + i_h * K + o_k
-    b_gate_input = tl.load(p_gate, mask=m_k, other=0.0).to(tl.float32)
-    b_gate_input += tl.load(dt_bias + i_h * K + o_k, mask=m_k, other=0.0).to(tl.float32)
-    b_a = tl.exp(tl.load(A_log + i_h).to(tl.float32))
-    if USE_LOWER_BOUND:
-        b_gate = lower_bound * tl.sigmoid(b_a * b_gate_input)
-    else:
-        b_softplus = tl.where(
-            b_gate_input > 20.0,
-            b_gate_input,
-            tl.where(
-                b_gate_input < -10.0,
-                tl.exp(b_gate_input),
-                tl.log(1.0 + tl.exp(b_gate_input)),
-            ),
-        )
-        b_gate = -b_a * b_softplus
-
-    b_state *= tl.exp(b_gate)[None, :]
-    b_delta = b_v - tl.sum(b_state * b_k[None, :], axis=1)
-    b_beta = tl.sigmoid(tl.load(raw_beta + i_n * beta_token_stride + i_h).to(tl.float32))
-    b_delta *= b_beta
-    b_state += b_delta[:, None] * b_k[None, :]
-    b_o = tl.sum(b_state * b_q[None, :], axis=1)
-    tl.store(output + row * V + o_v, b_o.to(output.dtype.element_ty), mask=m_v)
-    tl.store(state_cache + p_state, b_state, mask=m_vk)
 
 
 def _launch_kda_recurrent_fwd(
@@ -225,48 +142,29 @@ def _kda_recurrent_decode_cuda(
     dt_bias: torch.Tensor,
     state_cache: torch.Tensor,
     state_indices: torch.Tensor,
+    has_initial_state: torch.Tensor | None,
     output: torch.Tensor,
     lower_bound: float,
     use_lower_bound: bool,
     scale: float,
 ) -> None:
-    read_only_inputs = (packed_qkv, raw_gate, raw_beta, A_log, dt_bias, state_indices)
-    if any(torch._C._overlaps(output, tensor) for tensor in (*read_only_inputs, state_cache)):
-        raise ValueError("out must not alias any recurrent_kda_decode input")
-    if any(torch._C._overlaps(state_cache, tensor) for tensor in read_only_inputs):
-        raise ValueError("state_cache must not alias recurrent_kda_decode read-only inputs")
-
-    batch = packed_qkv.shape[0]
-    heads, value_dim, key_dim = state_cache.shape[1:]
-    if value_dim <= 32:
-        block_v, num_warps = min(triton.next_power_of_2(value_dim), 8), 4
-    elif batch * heads <= 8:
-        block_v, num_warps = min(triton.next_power_of_2(value_dim), 16), 2
-    else:
-        block_v, num_warps = min(triton.next_power_of_2(value_dim), 16), 1
-    grid = (triton.cdiv(value_dim, block_v) * batch * heads,)
-    kda_recurrent_decode_kernel[grid](
+    launch_recurrent_delta_rule_decode(
         packed_qkv,
-        raw_gate,
-        raw_beta,
+        # The shared boundary takes token-major gates; drop KDA's leading unit token dim.
+        raw_gate[0],
+        raw_beta[0],
         A_log,
         dt_bias,
-        output,
         state_cache,
         state_indices,
-        lower_bound,
+        output,
+        gate_kind=GateKind.VECTOR,
+        gate_transform=GateTransform.BOUNDED if use_lower_bound else GateTransform.SOFTPLUS,
+        key_heads=state_cache.shape[1],
+        lower_bound=lower_bound,
         scale=scale,
-        state_batch_stride=state_cache.stride(0),
-        qkv_token_stride=packed_qkv.stride(0),
-        gate_token_stride=raw_gate.stride(1),
-        beta_token_stride=raw_beta.stride(1),
-        H=heads,
-        K=key_dim,
-        V=value_dim,
-        BK=triton.next_power_of_2(key_dim),
-        BV=block_v,
-        USE_LOWER_BOUND=use_lower_bound,
-        num_warps=num_warps,
+        has_initial_state=has_initial_state,
+        op_name="recurrent_kda_decode",
     )
 
 

--- a/attn_gym/linear/kda/ops.py
+++ b/attn_gym/linear/kda/ops.py
@@ -113,8 +113,8 @@ torch.library.define(
 torch.library.define(
     "attn_gym::kda_recurrent_decode",
     "(Tensor packed_qkv, Tensor raw_gate, Tensor raw_beta, Tensor A_log, Tensor dt_bias,"
-    " Tensor(a!) state_cache, Tensor state_indices, Tensor(b!) out, float lower_bound,"
-    " bool use_lower_bound, float scale) -> ()",
+    " Tensor(a!) state_cache, Tensor state_indices, Tensor? has_initial_state, Tensor(b!) out,"
+    " float lower_bound, bool use_lower_bound, float scale) -> ()",
 )
 torch.library.define(
     "attn_gym::kda_prepare_chunk_offsets",
@@ -642,6 +642,7 @@ def _recurrent_decode_fake(
     dt_bias: torch.Tensor,
     state_cache: torch.Tensor,
     state_indices: torch.Tensor,
+    has_initial_state: torch.Tensor | None,
     out: torch.Tensor,
     lower_bound: float,
     use_lower_bound: bool,
@@ -655,6 +656,7 @@ def _recurrent_decode_fake(
         dt_bias,
         state_cache,
         state_indices,
+        has_initial_state,
         out,
         lower_bound,
         use_lower_bound,
@@ -809,6 +811,7 @@ def recurrent_decode_forward(
     dt_bias: torch.Tensor,
     state_cache: torch.Tensor,
     state_indices: torch.Tensor,
+    has_initial_state: torch.Tensor | None,
     out: torch.Tensor,
     lower_bound: float,
     use_lower_bound: bool,
@@ -831,6 +834,7 @@ def recurrent_decode_forward(
         dt_bias,
         state_cache,
         state_indices,
+        has_initial_state,
         out,
         lower_bound,
         use_lower_bound,

--- a/test/test_kda_recurrent_decode.py
+++ b/test/test_kda_recurrent_decode.py
@@ -160,6 +160,38 @@ def test_recurrent_decode_matches_reference(
     torch.testing.assert_close(state_cache, expected_cache, rtol=tolerance, atol=tolerance)
 
 
+def test_recurrent_decode_fresh_slots_start_from_zero():
+    """has_initial_state=False treats slot contents as garbage and overwrites them."""
+    inputs = _decode_inputs()
+    packed_qkv, raw_gate, raw_beta, A_log, dt_bias, _, state_cache, state_indices = inputs
+    has_initial_state = torch.tensor([True, False, True], device="cuda")
+    zeroed = state_cache.clone()
+    zeroed[state_indices[1].long()] = 0.0
+
+    output = recurrent_kda_decode(
+        packed_qkv,
+        raw_gate,
+        raw_beta,
+        A_log,
+        dt_bias,
+        state_cache,
+        state_indices,
+        has_initial_state=has_initial_state,
+    )
+    expected, expected_cache = _reference_decode(
+        packed_qkv,
+        raw_gate,
+        raw_beta,
+        A_log,
+        dt_bias,
+        zeroed,
+        state_indices,
+    )
+
+    torch.testing.assert_close(output.float(), expected.float(), rtol=3e-2, atol=3e-2)
+    torch.testing.assert_close(state_cache, expected_cache, rtol=1e-5, atol=1e-5)
+
+
 def test_recurrent_decode_softplus_matches_negative_tail_reference():
     inputs = _decode_inputs(batch=1, heads=1, key_dim=16, value_dim=8, dtype=torch.float32)
     packed_qkv, raw_gate, raw_beta, A_log, dt_bias, _, state_cache, state_indices = inputs
@@ -365,6 +397,24 @@ def test_recurrent_decode_rejects_aliasing_out(compiled: bool):
             out=out,
         )
 
+    if compiled:
+        # Inductor rejects dtype-view input mutations before our alias check can run.
+        return
+    fresh_out = packed_qkv.new_empty(1, 2, 2, 8)
+    has_initial_state = fresh_out.view(torch.bool).flatten()[:2]
+    with pytest.raises(ValueError, match="out must not alias"):
+        function(
+            packed_qkv,
+            raw_gate,
+            raw_beta,
+            A_log,
+            dt_bias,
+            state_cache,
+            state_indices,
+            has_initial_state=has_initial_state,
+            out=fresh_out,
+        )
+
 
 def test_recurrent_decode_rejects_state_aliasing_read_only_input():
     batch, heads, key_dim, value_dim, slots = 1, 1, 16, 8, 7
@@ -405,6 +455,7 @@ def test_recurrent_decode_custom_op_registration():
             dt_bias,
             state_cache,
             state_indices,
+            None,
             out,
             -5.0,
             True,
@@ -425,6 +476,8 @@ def test_recurrent_decode_fullgraph_compile(gate_transform: str, use_out: bool):
     output_shape = (1, 1, eager_cache.shape[1], eager_cache.shape[2])
     eager_out = packed_qkv.new_full(output_shape, torch.nan) if use_out else None
     compiled_out = torch.full_like(eager_out, torch.nan) if eager_out is not None else None
+    # Exercises the optional-tensor plumbing and USE_HAS_INITIAL_STATE under compilation.
+    has_initial_state = torch.ones(1, device="cuda", dtype=torch.bool)
 
     expected = recurrent_kda_decode(
         packed_qkv,
@@ -434,6 +487,7 @@ def test_recurrent_decode_fullgraph_compile(gate_transform: str, use_out: bool):
         dt_bias,
         eager_cache,
         state_indices,
+        has_initial_state=has_initial_state,
         gate_transform=gate_transform,
         lower_bound=lower_bound,
         out=eager_out,
@@ -447,6 +501,7 @@ def test_recurrent_decode_fullgraph_compile(gate_transform: str, use_out: bool):
         dt_bias,
         compiled_cache,
         state_indices,
+        has_initial_state=has_initial_state,
         gate_transform=gate_transform,
         lower_bound=lower_bound,
         out=compiled_out,


### PR DESCRIPTION
Stacked PRs:
 * #395
 * #394
 * #393
 * #392
 * __->__#391


--- --- ---

Share the fused decode kernel across gate kinds

## Human Note

## Agent note

Move the KDA fused decode kernel to attn_gym/linear/_delta_rule/decode.py and parameterize it the
same way as the shared recurrent scan: a SCALAR_GATE constexpr selects per-value-head scalar gate
transforms next to KDA's per-channel vector form, grouped q/k heads address the packed QKV buffer
through i_h // (H // HK), and an optional has_initial_state mask lets freshly assigned cache slots
start from the zero state. KDA decode behavior is unchanged for existing calls (specializations
fold HK == H and the absent mask away; benchmarked at parity on GB200 across B8-B256), and
recurrent_kda_decode now exposes has_initial_state for parity with the paged recurrent form.

## Test Plan

```bash
.venv/bin/prek run --files attn_gym/linear/_delta_rule/decode.py attn_gym/linear/kda/fwd/triton/recurrent.py attn_gym/linear/kda/ops.py attn_gym/linear/kda/api.py test/test_kda_recurrent_decode.py
gpu-run auto -- .venv/bin/pytest -q -n 6 test/test_kda_recurrent_decode.py test/test_kda_recurrent.py test/test_kda_compile_dynamic_shapes.py test/linear/
gpu-run auto -- .venv/bin/python agent_space/bench_decode_v2.py {baseline,shared}
```