### PR TITLE
Add raw-ABI recurrent_gdn_decode on the shared decode kernel

### DIFF
--- a/attn_gym/linear/__init__.py
+++ b/attn_gym/linear/__init__.py
@@ -9,7 +9,7 @@
 import importlib
 from typing import TYPE_CHECKING
 
-from attn_gym.linear.gdn import chunk_gdn, recurrent_gdn
+from attn_gym.linear.gdn import chunk_gdn, recurrent_gdn, recurrent_gdn_decode
 from attn_gym.linear.kda import (
     active_token_mask,
     chunk_kda,
@@ -43,6 +43,7 @@ KDA_OPS = [
 GDN_OPS = [
     "chunk_gdn",
     "recurrent_gdn",
+    "recurrent_gdn_decode",
 ]
 
 # Model-agnostic building blocks.

--- a/attn_gym/linear/_delta_rule/validation.py
+++ b/attn_gym/linear/_delta_rule/validation.py
@@ -4,6 +4,103 @@ from __future__ import annotations
 
 import torch
 
+SUPPORTED_ACTIVATION_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
+
+
+def validate_has_initial_state(
+    has_initial_state: torch.Tensor | None,
+    num_sequences: int,
+    device: torch.device,
+) -> None:
+    """Validate the optional per-sequence fresh-slot mask shared by paged delta-rule ops."""
+    if has_initial_state is None:
+        return
+    if (
+        tuple(has_initial_state.shape) != (num_sequences,)
+        or has_initial_state.dtype != torch.bool
+        or not has_initial_state.is_contiguous()
+        or has_initial_state.device != device
+    ):
+        raise ValueError(
+            "has_initial_state must be a contiguous bool tensor with one entry "
+            "per sequence on the inputs' device"
+        )
+
+
+def validate_decode_inputs(
+    packed_qkv: torch.Tensor,
+    raw_gate: torch.Tensor,
+    raw_beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    state_cache: torch.Tensor,
+    state_indices: torch.Tensor,
+    has_initial_state: torch.Tensor | None,
+    *,
+    op_name: str,
+) -> tuple[int, int, int, int]:
+    """Validate the family-independent fused-decode contract.
+
+    Family-specific checks (packed channel layout, gate/beta/dt_bias shapes) stay with the
+    caller. Returns ``(batch, heads, value_dim, key_dim)`` from the pool and buffer.
+    """
+    if packed_qkv.ndim != 2 or packed_qkv.shape[0] < 1 or packed_qkv.stride(1) != 1:
+        raise ValueError("packed_qkv must have shape [B, C] and be contiguous within each token")
+    if state_cache.ndim != 4:
+        raise ValueError("state_cache must have shape [num_slots, H, V, K]")
+    num_slots, heads, value_dim, key_dim = state_cache.shape
+    batch = packed_qkv.shape[0]
+    if num_slots < 1 or heads < 1 or key_dim < 1 or value_dim < 1:
+        raise ValueError(
+            f"state_cache must have nonempty dimensions, got {tuple(state_cache.shape)}"
+        )
+    if A_log.shape != (heads,) or A_log.dtype != torch.float32 or not A_log.is_contiguous():
+        raise ValueError(f"A_log must be contiguous float32 with shape ({heads},)")
+    if state_cache.dtype != torch.float32:
+        raise TypeError("state_cache must use float32")
+    if state_cache.stride()[1:] != (value_dim * key_dim, key_dim, 1):
+        raise TypeError("state_cache must be contiguous within each [H, V, K] slot")
+    if state_cache.stride(0) < heads * key_dim * value_dim:
+        raise ValueError("state_cache slots must not overlap")
+    if (
+        state_indices.shape != (batch,)
+        or state_indices.dtype != torch.int32
+        or not state_indices.is_contiguous()
+    ):
+        raise ValueError(f"state_indices must be contiguous int32 with shape ({batch},)")
+    validate_has_initial_state(has_initial_state, batch, packed_qkv.device)
+    if key_dim > 256:
+        raise ValueError(f"{op_name} requires K in [1, 256], got {key_dim}")
+
+    device = packed_qkv.device
+    all_tensors = (raw_gate, raw_beta, A_log, dt_bias, state_cache, state_indices)
+    if any(tensor.device != device for tensor in all_tensors):
+        raise ValueError(f"all {op_name} inputs must be on the same device")
+    activation_tensors = (packed_qkv, raw_gate, raw_beta)
+    if any(tensor.dtype not in SUPPORTED_ACTIVATION_DTYPES for tensor in activation_tensors):
+        supported = ", ".join(str(dtype) for dtype in SUPPORTED_ACTIVATION_DTYPES)
+        raise TypeError(f"decode activation inputs must use one of {supported}")
+    return batch, heads, value_dim, key_dim
+
+
+def resolve_decode_out(
+    packed_qkv: torch.Tensor,
+    out: torch.Tensor | None,
+    expected_shape: tuple[int, ...],
+) -> torch.Tensor:
+    """Allocate the decode output or validate a caller-owned buffer."""
+    if out is None:
+        return packed_qkv.new_empty(expected_shape)
+    if out.shape != expected_shape:
+        raise ValueError(f"out must have shape {expected_shape}, got {tuple(out.shape)}")
+    if out.dtype != packed_qkv.dtype:
+        raise TypeError(f"out must use packed_qkv.dtype ({packed_qkv.dtype}), got {out.dtype}")
+    if out.device != packed_qkv.device:
+        raise ValueError("out must be on packed_qkv.device")
+    if not out.is_contiguous():
+        raise ValueError("out must be contiguous")
+    return out
+
 
 def validate_paged_state(
     q: torch.Tensor,
@@ -45,16 +142,13 @@ def validate_paged_state(
             f"state_indices must be a contiguous int32 tensor of shape ({num_sequences},) "
             f"on q.device, got {tuple(state_indices.shape)} of {state_indices.dtype}"
         )
-    if has_initial_state is not None and (
-        tuple(has_initial_state.shape) != (num_sequences,)
-        or has_initial_state.dtype != torch.bool
-        or not has_initial_state.is_contiguous()
-        or has_initial_state.device != q.device
-    ):
-        raise ValueError(
-            "has_initial_state must be a contiguous bool tensor with one entry "
-            "per sequence on q.device"
-        )
+    validate_has_initial_state(has_initial_state, num_sequences, q.device)
 
 
-__all__ = ["validate_paged_state"]
+__all__ = [
+    "SUPPORTED_ACTIVATION_DTYPES",
+    "resolve_decode_out",
+    "validate_decode_inputs",
+    "validate_has_initial_state",
+    "validate_paged_state",
+]

--- a/attn_gym/linear/gdn/__init__.py
+++ b/attn_gym/linear/gdn/__init__.py
@@ -1,5 +1,5 @@
 """Gated delta rule attention."""
 
-from attn_gym.linear.gdn.api import chunk_gdn, recurrent_gdn
+from attn_gym.linear.gdn.api import chunk_gdn, recurrent_gdn, recurrent_gdn_decode
 
-__all__ = ["chunk_gdn", "recurrent_gdn"]
+__all__ = ["chunk_gdn", "recurrent_gdn", "recurrent_gdn_decode"]

--- a/attn_gym/linear/gdn/api.py
+++ b/attn_gym/linear/gdn/api.py
@@ -2,10 +2,18 @@
 
 from __future__ import annotations
 
+import sys
+from numbers import Real
+
 import torch
 
-from attn_gym.linear._delta_rule.validation import validate_paged_state
+from attn_gym.linear._delta_rule.validation import (
+    resolve_decode_out,
+    validate_decode_inputs,
+    validate_paged_state,
+)
 from attn_gym.linear.gdn.impl.reference import chunk_forward, recurrent_forward, reference_gdn
+from attn_gym.linear.gdn.ops import recurrent_decode_forward
 from attn_gym.linear.gdn.ops import recurrent_forward as fused_recurrent_forward
 from attn_gym.linear.gdn.validation import validate_gdn_inputs
 from attn_gym.linear.types import Impl, resolve_impl
@@ -176,4 +184,113 @@ def recurrent_gdn(
     )
 
 
-__all__ = ["chunk_gdn", "recurrent_gdn"]
+def recurrent_gdn_decode(
+    packed_qkv: torch.Tensor,
+    raw_gate: torch.Tensor,
+    raw_beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    state_cache: torch.Tensor,
+    state_indices: torch.Tensor,
+    *,
+    has_initial_state: torch.Tensor | None = None,
+    scale: float | None = None,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Run one-token paged GDN decode with preprocessing fused into the recurrence.
+
+    One Triton kernel slices the post-convolution QKV buffer, computes the gate as
+    ``-exp(A_log) * softplus(raw_gate + dt_bias)`` and the write gate as
+    ``sigmoid(raw_beta)``, L2-normalizes q and k, and advances the selected cache
+    slots in place, so serving callers launch no separate elementwise kernels.
+
+    Args:
+        packed_qkv: Post-convolution QKV shaped ``[B, HK*K + HK*K + H*V]``. Each token
+            stores ``[Q for HK heads | K for HK heads | V for H heads]``; within each
+            section head rows are contiguous. ``HK`` may divide ``H`` for grouped-head
+            attention: each block of ``H // HK`` consecutive value heads shares one
+            query/key head.
+        raw_gate: Unactivated per-head gate projection shaped ``[1, B, H]``, matching the
+            vLLM-style single-token decode convention used by ``recurrent_kda_decode``.
+        raw_beta: Unactivated write gate shaped ``[1, B, H]``.
+        A_log: FP32 per-head log decay parameter shaped ``[H]``.
+        dt_bias: FP32 per-head gate bias shaped ``[H]``.
+        state_cache: FP32 paged state pool shaped ``[num_slots, H, V, K]``. Slots may
+            have padding between them but each ``[H, V, K]`` row must be dense. ``K``
+            must be at most 256.
+        state_indices: Contiguous int32 slot indices shaped ``[B]``. Non-positive
+            indices are padding/null entries: they produce zero output and leave the
+            cache untouched. Each positive index must be in ``[1, num_slots)`` and
+            unique among active rows because duplicate in-place updates race. These
+            value constraints are caller responsibilities and are not host-validated.
+        has_initial_state: Optional contiguous boolean mask, one per sequence. False
+            entries mark freshly assigned slots whose contents are garbage: the step
+            starts from the zero state and overwrites the slot.
+        scale: Query scale. Defaults to ``1 / sqrt(K)``.
+        out: Optional caller-owned contiguous output buffer shaped ``[1, B, H, V]`` in
+            ``packed_qkv.dtype`` on the same device. When supplied, the kernel writes
+            into and returns this exact tensor. It must not alias any input.
+
+    Returns:
+        Decode output shaped ``[1, B, H, V]`` in ``packed_qkv.dtype``. This is ``out``
+        itself when a buffer is supplied. The operation is inference-only and advances
+        ``state_cache`` in place.
+    """
+    batch, heads, value_dim, key_dim = validate_decode_inputs(
+        packed_qkv,
+        raw_gate,
+        raw_beta,
+        A_log,
+        dt_bias,
+        state_cache,
+        state_indices,
+        has_initial_state,
+        op_name="recurrent_gdn_decode",
+    )
+    qk_channels = packed_qkv.shape[1] - heads * value_dim
+    key_heads = qk_channels // (2 * key_dim)
+    if (
+        qk_channels <= 0
+        or key_heads < 1
+        or qk_channels != 2 * key_heads * key_dim
+        or heads % key_heads != 0
+    ):
+        raise ValueError(
+            f"packed_qkv must have shape [B, 2*HK*{key_dim} + {heads}*{value_dim}] with HK a "
+            f"positive divisor of {heads} value heads, got {tuple(packed_qkv.shape)}"
+        )
+    for name, tensor in (("raw_gate", raw_gate), ("raw_beta", raw_beta)):
+        if tensor.shape != (1, batch, heads) or tensor.stride(2) != 1:
+            raise ValueError(f"{name} must have shape {(1, batch, heads)} with contiguous heads")
+    if dt_bias.shape != (heads,) or dt_bias.dtype != torch.float32 or not dt_bias.is_contiguous():
+        raise ValueError(f"dt_bias must be contiguous float32 with shape ({heads},)")
+
+    if scale is None:
+        scale = key_dim**-0.5
+    elif not isinstance(scale, Real) or isinstance(scale, bool):
+        raise TypeError("scale must be a real scalar or None")
+    else:
+        scale = float(scale)
+        if (
+            scale != scale  # noqa: PLR0124 - compile-safe NaN check
+            or scale <= 0
+            or scale > sys.float_info.max
+        ):
+            raise ValueError(f"scale must be finite and positive, got {scale}")
+
+    out = resolve_decode_out(packed_qkv, out, (1, batch, heads, value_dim))
+    return recurrent_decode_forward(
+        packed_qkv,
+        raw_gate,
+        raw_beta,
+        A_log,
+        dt_bias,
+        state_cache,
+        state_indices,
+        has_initial_state,
+        out,
+        scale,
+    )
+
+
+__all__ = ["chunk_gdn", "recurrent_gdn", "recurrent_gdn_decode"]

--- a/attn_gym/linear/gdn/impl/fused.py
+++ b/attn_gym/linear/gdn/impl/fused.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import torch
 
+from attn_gym.linear._delta_rule.decode import GateTransform, launch_recurrent_delta_rule_decode
 from attn_gym.linear._delta_rule.recurrent import GateKind, launch_recurrent_delta_rule_fwd
 
 
@@ -119,6 +120,41 @@ def _gdn_recurrent_fwd_paged_cuda(
         state_indices=state_indices,
         has_initial_state=has_initial_state,
     )[0]
+
+
+def _gdn_recurrent_decode_cuda(
+    packed_qkv: torch.Tensor,
+    raw_gate: torch.Tensor,
+    raw_beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    state_cache: torch.Tensor,
+    state_indices: torch.Tensor,
+    has_initial_state: torch.Tensor | None,
+    output: torch.Tensor,
+    scale: float,
+) -> None:
+    """Advance one token per sequence with GDN preprocessing fused into the step."""
+    heads, value_dim, key_dim = state_cache.shape[1:]
+    key_heads = (packed_qkv.shape[1] - heads * value_dim) // (2 * key_dim)
+    launch_recurrent_delta_rule_decode(
+        packed_qkv,
+        # The shared boundary takes token-major gates; drop the vLLM-style unit token dim.
+        raw_gate[0],
+        raw_beta[0],
+        A_log,
+        dt_bias,
+        state_cache,
+        state_indices,
+        output,
+        gate_kind=GateKind.SCALAR,
+        gate_transform=GateTransform.SOFTPLUS,
+        key_heads=key_heads,
+        lower_bound=0.0,
+        scale=scale,
+        has_initial_state=has_initial_state,
+        op_name="recurrent_gdn_decode",
+    )
 
 
 __all__ = []

--- a/attn_gym/linear/gdn/ops.py
+++ b/attn_gym/linear/gdn/ops.py
@@ -17,6 +17,12 @@ torch.library.define(
     "(Tensor q, Tensor k, Tensor v, Tensor gate, Tensor beta, Tensor(a!) state_cache, "
     "Tensor state_indices, Tensor? has_initial_state, Tensor? cu_seqlens, float scale) -> Tensor",
 )
+torch.library.define(
+    "attn_gym::gdn_recurrent_decode",
+    "(Tensor packed_qkv, Tensor raw_gate, Tensor raw_beta, Tensor A_log, Tensor dt_bias,"
+    " Tensor(a!) state_cache, Tensor state_indices, Tensor? has_initial_state, Tensor(b!) out,"
+    " float scale) -> ()",
+)
 
 
 def _recurrent_backend():
@@ -40,6 +46,10 @@ def _recurrent_fwd_paged_cuda(*args):
     return _recurrent_backend()._gdn_recurrent_fwd_paged_cuda(*args)
 
 
+def _recurrent_decode_cuda(*args):
+    return _recurrent_backend()._gdn_recurrent_decode_cuda(*args)
+
+
 torch.library.impl("attn_gym::gdn_recurrent_fwd", "CUDA", _recurrent_fwd_cuda)
 torch.library.impl(
     "attn_gym::gdn_recurrent_fwd_no_state",
@@ -50,6 +60,11 @@ torch.library.impl(
     "attn_gym::gdn_recurrent_fwd_paged",
     "CUDA",
     _recurrent_fwd_paged_cuda,
+)
+torch.library.impl(
+    "attn_gym::gdn_recurrent_decode",
+    "CUDA",
+    _recurrent_decode_cuda,
 )
 
 
@@ -107,9 +122,26 @@ def _recurrent_fwd_paged_fake(
     return torch.empty_like(v, dtype=q.dtype)
 
 
+@torch.library.register_fake("attn_gym::gdn_recurrent_decode")
+def _recurrent_decode_fake(
+    packed_qkv: torch.Tensor,
+    raw_gate: torch.Tensor,
+    raw_beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    state_cache: torch.Tensor,
+    state_indices: torch.Tensor,
+    has_initial_state: torch.Tensor | None,
+    out: torch.Tensor,
+    scale: float,
+) -> None:
+    """The decode op returns nothing and mutates preallocated buffers; no metadata to fake."""
+
+
 recurrent_fwd_op = torch.ops.attn_gym.gdn_recurrent_fwd.default
 recurrent_fwd_no_state_op = torch.ops.attn_gym.gdn_recurrent_fwd_no_state.default
 recurrent_fwd_paged_op = torch.ops.attn_gym.gdn_recurrent_fwd_paged.default
+recurrent_decode_op = torch.ops.attn_gym.gdn_recurrent_decode.default
 
 
 def recurrent_forward(
@@ -165,7 +197,45 @@ def recurrent_forward(
     return recurrent_fwd_no_state_op(*args), None
 
 
+def recurrent_decode_forward(
+    packed_qkv: torch.Tensor,
+    raw_gate: torch.Tensor,
+    raw_beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    state_cache: torch.Tensor,
+    state_indices: torch.Tensor,
+    has_initial_state: torch.Tensor | None,
+    out: torch.Tensor,
+    scale: float,
+) -> torch.Tensor:
+    """Invoke the lazily loaded fused decode implementation."""
+    if not packed_qkv.is_cuda:
+        raise ValueError("recurrent_gdn_decode requires CUDA tensors")
+    data_tensors = (packed_qkv, raw_gate, raw_beta, A_log, dt_bias, state_cache, out)
+    if torch.is_grad_enabled() and any(tensor.requires_grad for tensor in data_tensors):
+        raise RuntimeError(
+            "recurrent_gdn_decode is inference-only and has no backward; "
+            "call under torch.no_grad() / torch.inference_mode()"
+        )
+    recurrent_decode_op(
+        packed_qkv,
+        raw_gate,
+        raw_beta,
+        A_log,
+        dt_bias,
+        state_cache,
+        state_indices,
+        has_initial_state,
+        out,
+        scale,
+    )
+    return out
+
+
 __all__ = [
+    "recurrent_decode_forward",
+    "recurrent_decode_op",
     "recurrent_forward",
     "recurrent_fwd_no_state_op",
     "recurrent_fwd_op",

--- a/attn_gym/linear/kda/api.py
+++ b/attn_gym/linear/kda/api.py
@@ -20,7 +20,11 @@ from typing import Literal
 
 import torch
 
-from attn_gym.linear._delta_rule.validation import validate_paged_state
+from attn_gym.linear._delta_rule.validation import (
+    resolve_decode_out,
+    validate_decode_inputs,
+    validate_paged_state,
+)
 from attn_gym.linear.kda.constants import LOG2_E
 from attn_gym.linear.kda.impl.fused import chunk_forward as _fused_chunk_forward
 from attn_gym.linear.kda.impl.fused import paged_chunk_forward as _fused_paged_chunk_forward
@@ -28,7 +32,7 @@ from attn_gym.linear.kda.impl.reference import reference_kda
 from attn_gym.linear.kda.naive import naive_chunk_kda, naive_recurrent_kda
 from attn_gym.linear.kda.ops import recurrent_decode_forward as _fused_recurrent_decode_forward
 from attn_gym.linear.kda.ops import recurrent_forward as _fused_recurrent_forward
-from attn_gym.linear.kda.validation import SUPPORTED_INPUT_DTYPES, validate_kda_inputs
+from attn_gym.linear.kda.validation import validate_kda_inputs
 from attn_gym.linear.types import Impl, resolve_impl
 
 _CHUNK_SIZE = 64
@@ -383,16 +387,17 @@ def recurrent_kda_decode(
     the output projection from recurrent state are performed in one Triton kernel.
     The operation is inference-only and advances ``state_cache`` in place.
     """
-    if packed_qkv.ndim != 2 or packed_qkv.shape[0] < 1 or packed_qkv.stride(1) != 1:
-        raise ValueError("packed_qkv must have shape [B, C] and be contiguous within each token")
-    if state_cache.ndim != 4:
-        raise ValueError("state_cache must have shape [num_slots, H, V, K]")
-    num_slots, heads, value_dim, key_dim = state_cache.shape
-    batch = packed_qkv.shape[0]
-    if num_slots < 1 or heads < 1 or key_dim < 1 or value_dim < 1:
-        raise ValueError(
-            f"state_cache must have nonempty dimensions, got {tuple(state_cache.shape)}"
-        )
+    batch, heads, value_dim, key_dim = validate_decode_inputs(
+        packed_qkv,
+        raw_gate,
+        raw_beta,
+        A_log,
+        dt_bias,
+        state_cache,
+        state_indices,
+        has_initial_state,
+        op_name="recurrent_kda_decode",
+    )
     expected_channels = heads * (2 * key_dim + value_dim)
     if packed_qkv.shape[1] != expected_channels:
         raise ValueError(
@@ -405,47 +410,12 @@ def recurrent_kda_decode(
         )
     if raw_beta.shape != (1, batch, heads) or raw_beta.stride(2) != 1:
         raise ValueError(f"raw_beta must have shape {(1, batch, heads)} with contiguous heads")
-    if A_log.shape != (heads,) or A_log.dtype != torch.float32 or not A_log.is_contiguous():
-        raise ValueError(f"A_log must be contiguous float32 with shape ({heads},)")
     if (
         dt_bias.shape != (heads, key_dim)
         or dt_bias.dtype != torch.float32
         or not dt_bias.is_contiguous()
     ):
         raise ValueError(f"dt_bias must be contiguous float32 with shape ({heads}, {key_dim})")
-    if state_cache.dtype != torch.float32:
-        raise TypeError("state_cache must use float32")
-    expected_state_strides = (value_dim * key_dim, key_dim, 1)
-    if state_cache.stride()[1:] != expected_state_strides:
-        raise TypeError("state_cache must be contiguous within each [H, V, K] slot")
-    if state_cache.stride(0) < heads * key_dim * value_dim:
-        raise ValueError("state_cache slots must not overlap")
-    if (
-        state_indices.shape != (batch,)
-        or state_indices.dtype != torch.int32
-        or not state_indices.is_contiguous()
-    ):
-        raise ValueError(f"state_indices must be contiguous int32 with shape ({batch},)")
-    if has_initial_state is not None and (
-        has_initial_state.shape != (batch,)
-        or has_initial_state.dtype != torch.bool
-        or not has_initial_state.is_contiguous()
-        or has_initial_state.device != packed_qkv.device
-    ):
-        raise ValueError(
-            f"has_initial_state must be contiguous bool with shape ({batch},) on packed_qkv.device"
-        )
-    if key_dim > 256:
-        raise ValueError(f"recurrent_kda_decode requires K in [1, 256], got {key_dim}")
-
-    device = packed_qkv.device
-    data_tensors = (packed_qkv, raw_gate, raw_beta, A_log, dt_bias)
-    if any(tensor.device != device for tensor in (*data_tensors, state_cache, state_indices)):
-        raise ValueError("all recurrent_kda_decode inputs must be on the same device")
-    activation_tensors = (packed_qkv, raw_gate, raw_beta)
-    if any(tensor.dtype not in SUPPORTED_INPUT_DTYPES for tensor in activation_tensors):
-        supported = ", ".join(str(dtype) for dtype in SUPPORTED_INPUT_DTYPES)
-        raise TypeError(f"decode activation inputs must use one of {supported}")
 
     use_lower_bound = _resolve_decode_gate_transform(gate_transform)
     if use_lower_bound:
@@ -473,20 +443,7 @@ def recurrent_kda_decode(
         ):
             raise ValueError(f"scale must be finite and positive, got {scale}")
 
-    expected_output_shape = (1, batch, heads, value_dim)
-    if out is None:
-        out = packed_qkv.new_empty(expected_output_shape)
-    else:
-        if out.shape != expected_output_shape:
-            raise ValueError(
-                f"out must have shape {expected_output_shape}, got {tuple(out.shape)}"
-            )
-        if out.dtype != packed_qkv.dtype:
-            raise TypeError(f"out must use packed_qkv.dtype ({packed_qkv.dtype}), got {out.dtype}")
-        if out.device != device:
-            raise ValueError("out must be on packed_qkv.device")
-        if not out.is_contiguous():
-            raise ValueError("out must be contiguous")
+    out = resolve_decode_out(packed_qkv, out, (1, batch, heads, value_dim))
 
     return _fused_recurrent_decode_forward(
         packed_qkv,

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -68,9 +68,18 @@ falling back to the reference.
 - `initial_state` may be positional, and `output_final_state` controls the optional state output.
 - Both operations return `(output, final_state)`, matching the KDA operations.
 
+`recurrent_gdn_decode` is the serving-specific one-token path, mirroring
+`recurrent_kda_decode`: it consumes the packed post-convolution QKV buffer plus raw gate and
+beta projections, computes the gate transform (`-exp(A_log) * softplus(raw + dt_bias)`), the
+beta sigmoid, and the query/key L2 normalization in-kernel, supports grouped q/k heads, and
+advances the paged FP32 state pool in place through `state_indices`, so no separate
+elementwise kernels run per decode step.
+
 ::: attn_gym.linear.chunk_gdn
 
 ::: attn_gym.linear.recurrent_gdn
+
+::: attn_gym.linear.recurrent_gdn_decode
 
 ## Kimi Delta Attention
 

--- a/test/linear/test_gdn_decode.py
+++ b/test/linear/test_gdn_decode.py
@@ -1,0 +1,271 @@
+"""Correctness, registration, and capture tests for fused raw-ABI GDN decode."""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+pytest.importorskip("triton")
+
+from attn_gym.linear import recurrent_gdn, recurrent_gdn_decode
+from attn_gym.linear.gdn.ops import recurrent_decode_op
+from attn_gym.testing import strided_state_pool
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="recurrent_gdn_decode requires CUDA"
+)
+
+
+def make_decode_inputs(
+    *,
+    batch: int = 3,
+    heads: int = 4,
+    key_heads: int | None = None,
+    key_dim: int = 32,
+    value_dim: int = 24,
+    num_slots: int = 6,
+    dtype: torch.dtype = torch.float32,
+    seed: int = 0,
+) -> dict[str, torch.Tensor]:
+    """Create raw decode operands; ``key_heads`` enables grouped heads."""
+    torch.manual_seed(seed)
+    key_heads = key_heads or heads
+    q = torch.randn(batch, key_heads, key_dim, device="cuda", dtype=dtype)
+    k = torch.randn_like(q)
+    v = torch.randn(batch, heads, value_dim, device="cuda", dtype=dtype)
+    _storage, pool = strided_state_pool(num_slots, heads, key_dim, value_dim)
+    return {
+        "packed_qkv": torch.cat((q.flatten(1), k.flatten(1), v.flatten(1)), dim=1),
+        "raw_gate": torch.randn(1, batch, heads, device="cuda", dtype=dtype),
+        "raw_beta": torch.randn(1, batch, heads, device="cuda", dtype=dtype),
+        "A_log": 0.1 * torch.randn(heads, device="cuda", dtype=torch.float32),
+        "dt_bias": 0.1 * torch.randn(heads, device="cuda", dtype=torch.float32),
+        "state_cache": pool,
+        "state_indices": torch.tensor([5, 1, 3], device="cuda", dtype=torch.int32)[:batch],
+        "_storage": _storage,
+    }
+
+
+def cooked_operands(inputs: dict[str, torch.Tensor]) -> tuple[torch.Tensor, ...]:
+    """Recover token-major operands with the decode preprocessing applied in FP32."""
+    pool = inputs["state_cache"]
+    heads, value_dim, key_dim = pool.shape[1:]
+    packed = inputs["packed_qkv"].float()
+    qk_channels = packed.shape[1] - heads * value_dim
+    key_heads = qk_channels // (2 * key_dim)
+    q, k, v = packed.split((key_heads * key_dim, key_heads * key_dim, heads * value_dim), dim=1)
+    q = q.view(-1, key_heads, key_dim)
+    k = k.view(-1, key_heads, key_dim)
+    v = v.view(-1, heads, value_dim)
+    q = q * torch.rsqrt(q.square().sum(-1, keepdim=True) + 1e-6)
+    k = k * torch.rsqrt(k.square().sum(-1, keepdim=True) + 1e-6)
+    gate = -inputs["A_log"].exp() * F.softplus(inputs["raw_gate"][0].float() + inputs["dt_bias"])
+    beta = torch.sigmoid(inputs["raw_beta"][0].float())
+    return q, k, v, gate, beta
+
+
+def reference_decode(
+    inputs: dict[str, torch.Tensor], scale: float | None = None
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Advance a cloned pool through the eager reference, gathering active slots."""
+    q, k, v, gate, beta = cooked_operands(inputs)
+    pool = inputs["state_cache"].clone()
+    slots = inputs["state_indices"]
+    heads = pool.shape[1]
+    key_heads = q.shape[1]
+    if key_heads != heads:
+        q, k = (t.repeat_interleave(heads // key_heads, dim=1) for t in (q, k))
+    output = torch.zeros(v.shape, device="cuda", dtype=torch.float32)
+    for row, slot in enumerate(slots.tolist()):
+        if slot <= 0:
+            continue
+        state = pool[slot].transpose(-1, -2).unsqueeze(0).clone()
+        row_output, final_state = recurrent_gdn(
+            q[row : row + 1, None],
+            k[row : row + 1, None],
+            v[row : row + 1, None],
+            gate[row : row + 1, None],
+            beta[row : row + 1, None],
+            state,
+            output_final_state=True,
+            scale=pool.shape[-1] ** -0.5 if scale is None else scale,
+            impl="reference",
+        )
+        output[row] = row_output[0, 0]
+        pool[slot] = final_state[0].transpose(-1, -2)
+    return output, pool
+
+
+@pytest.mark.parametrize("scale", [None, 0.25])
+@pytest.mark.parametrize("key_heads", [None, 2])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16])
+def test_decode_matches_reference(key_heads: int | None, dtype: torch.dtype, scale: float | None):
+    inputs = make_decode_inputs(key_heads=key_heads, dtype=dtype)
+    expected_output, expected_pool = reference_decode(inputs, scale)
+
+    output = recurrent_gdn_decode(
+        inputs["packed_qkv"],
+        inputs["raw_gate"],
+        inputs["raw_beta"],
+        inputs["A_log"],
+        inputs["dt_bias"],
+        inputs["state_cache"],
+        inputs["state_indices"],
+        scale=scale,
+    )
+
+    tolerance = 1e-5 if dtype is torch.float32 else 3e-2
+    assert output.dtype == dtype and output.shape[0] == 1
+    torch.testing.assert_close(output[0].float(), expected_output, rtol=tolerance, atol=tolerance)
+    torch.testing.assert_close(inputs["state_cache"], expected_pool, rtol=1e-5, atol=1e-5)
+
+
+def test_decode_padding_and_fresh_slots():
+    """Nonpositive slots produce zero output; fresh slots start from zero and overwrite."""
+    inputs = make_decode_inputs()
+    inputs["state_indices"] = torch.tensor([0, 2, 4], device="cuda", dtype=torch.int32)
+    has_initial_state = torch.tensor([True, False, True], device="cuda")
+    original_pool = inputs["state_cache"].clone()
+    zeroed = dict(inputs)
+    zeroed["state_cache"] = inputs["state_cache"].clone()
+    zeroed["state_cache"][2] = 0.0
+    expected_output, expected_pool = reference_decode(zeroed)
+
+    output = recurrent_gdn_decode(
+        inputs["packed_qkv"],
+        inputs["raw_gate"],
+        inputs["raw_beta"],
+        inputs["A_log"],
+        inputs["dt_bias"],
+        inputs["state_cache"],
+        inputs["state_indices"],
+        has_initial_state=has_initial_state,
+    )
+
+    torch.testing.assert_close(output[0, 0], torch.zeros_like(output[0, 0]), rtol=0, atol=0)
+    torch.testing.assert_close(output[0].float(), expected_output, rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(inputs["state_cache"][2], expected_pool[2], rtol=1e-5, atol=1e-5)
+    preserved = [0, 1, 3, 5]
+    torch.testing.assert_close(
+        inputs["state_cache"][preserved], original_pool[preserved], rtol=0, atol=0
+    )
+
+
+def test_decode_out_buffer_contract():
+    inputs = make_decode_inputs()
+    heads, value_dim = inputs["state_cache"].shape[1:3]
+    out = torch.empty(1, 3, heads, value_dim, device="cuda")
+    returned = recurrent_gdn_decode(
+        inputs["packed_qkv"],
+        inputs["raw_gate"],
+        inputs["raw_beta"],
+        inputs["A_log"],
+        inputs["dt_bias"],
+        inputs["state_cache"],
+        inputs["state_indices"],
+        out=out,
+    )
+    assert returned is out
+
+    with pytest.raises(ValueError, match="must not alias"):
+        recurrent_gdn_decode(
+            inputs["packed_qkv"],
+            inputs["raw_gate"],
+            inputs["raw_beta"],
+            inputs["A_log"],
+            inputs["dt_bias"],
+            inputs["state_cache"],
+            inputs["state_indices"],
+            # Slice the pool's backing storage; flattening the strided view would copy.
+            out=inputs["_storage"].flatten()[: out.numel()].view_as(out),
+        )
+
+
+def test_decode_rejects_bad_inputs():
+    inputs = make_decode_inputs()
+    with pytest.raises(ValueError, match="positive divisor"):
+        recurrent_gdn_decode(
+            inputs["packed_qkv"][:, :-1],
+            inputs["raw_gate"],
+            inputs["raw_beta"],
+            inputs["A_log"],
+            inputs["dt_bias"],
+            inputs["state_cache"],
+            inputs["state_indices"],
+        )
+    with pytest.raises(RuntimeError, match="inference-only"):
+        recurrent_gdn_decode(
+            inputs["packed_qkv"].clone().requires_grad_(),
+            inputs["raw_gate"],
+            inputs["raw_beta"],
+            inputs["A_log"],
+            inputs["dt_bias"],
+            inputs["state_cache"],
+            inputs["state_indices"],
+        )
+
+
+def test_decode_custom_op_registration():
+    inputs = make_decode_inputs(batch=1, heads=1, key_dim=16, value_dim=8, num_slots=3)
+    inputs["state_indices"] = torch.tensor([1], device="cuda", dtype=torch.int32)
+    out = inputs["packed_qkv"].new_empty(1, 1, 1, 8)
+    torch.library.opcheck(
+        recurrent_decode_op,
+        (
+            inputs["packed_qkv"],
+            inputs["raw_gate"],
+            inputs["raw_beta"],
+            inputs["A_log"],
+            inputs["dt_bias"],
+            inputs["state_cache"],
+            inputs["state_indices"],
+            None,
+            out,
+            0.25,
+        ),
+    )
+
+
+def test_decode_fullgraph_and_cuda_graph():
+    """The decode op compiles fullgraph and replays under CUDA graph capture."""
+    inputs = make_decode_inputs()
+    initial_pool = inputs["state_cache"].clone()
+    args = (
+        inputs["packed_qkv"],
+        inputs["raw_gate"],
+        inputs["raw_beta"],
+        inputs["A_log"],
+        inputs["dt_bias"],
+    )
+    slots = inputs["state_indices"]
+
+    def run(pool: torch.Tensor, out: torch.Tensor | None = None) -> torch.Tensor:
+        return recurrent_gdn_decode(*args, pool, slots, out=out)
+
+    with torch.no_grad():
+        eager_pool = inputs["state_cache"]
+        expected = run(eager_pool)
+
+        heads, value_dim, key_dim = inputs["state_cache"].shape[1:]
+        _compiled_storage, compiled_pool = strided_state_pool(6, heads, key_dim, value_dim)
+        compiled_pool.copy_(initial_pool)
+        compiled = torch.compile(recurrent_gdn_decode, fullgraph=True)
+        compiled_out = torch.empty_like(expected)
+        actual = compiled(*args, compiled_pool, slots, out=compiled_out)
+        assert actual is compiled_out
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+        torch.testing.assert_close(compiled_pool, eager_pool, rtol=0, atol=0)
+
+        _graph_storage, graph_pool = strided_state_pool(6, heads, key_dim, value_dim)
+        graph_pool.copy_(initial_pool)
+        out = torch.empty_like(expected)
+        run(graph_pool, out=out)
+        torch.cuda.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            run(graph_pool, out=out)
+        # Reset to the pre-decode snapshot so replay reproduces the eager call.
+        graph_pool.copy_(initial_pool)
+        graph.replay()
+        torch.cuda.synchronize()
+        torch.testing.assert_close(out, expected, rtol=0, atol=0)
+        torch.testing.assert_close(graph_pool, eager_pool, rtol=0, atol=0)


### PR DESCRIPTION
Stacked PRs:
 * #395
 * #394
 * #393
 * __->__#392


--- --- ---

Add raw-ABI recurrent_gdn_decode on the shared decode kernel

## Human Note

## Agent note

Add the GDN analogue of recurrent_kda_decode on the shared fused decode kernel: one Triton launch
slices the packed post-convolution QKV buffer (grouped q/k heads supported), computes the gate as
-exp(A_log) * softplus(raw_gate + dt_bias) and the write gate as sigmoid(raw_beta), L2-normalizes
q and k, and advances selected FP32 cache slots in place with has_initial_state fresh-slot
semantics and an optional caller-owned out buffer. Tests derive a reference oracle from the
documented formulas through the eager recurrence and cover grouped heads, padding and fresh
slots, the out contract and aliasing, opcheck, fullgraph compile, and CUDA-graph replay.

GB200 (Titan Qwen3.6-27B TP=4 dims, 4 k-heads / 12 v-heads / 128, CUDA-graph replay): 12.9 us at
B32 and 20.9 us at B64, vs 38.9/47.6 us for the previous cooked-operand prototype (external
l2norm + repeat_interleave + gate cook in-graph) and 86.1/162.6 us for the FLA glue path.

## Test Plan

```bash
.venv/bin/prek run --files attn_gym/linear/gdn/ops.py attn_gym/linear/gdn/api.py attn_gym/linear/gdn/impl/fused.py test/linear/test_gdn_decode.py docs/linear.md
gpu-run auto -- .venv/bin/pytest -q -n 6 test/linear/ test/test_kda_recurrent_decode.py test/test_namespaces.py
gpu-run auto -- .venv/bin/python agent_space/bench_decode_v2.py gdn-raw
```