### PR TITLE
Support grouped q/k heads in recurrent KDA

### DIFF
--- a/attn_gym/linear/_delta_rule/decode.py
+++ b/attn_gym/linear/_delta_rule/decode.py
@@ -24,8 +24,8 @@ Gate transforms (`USE_LOWER_BOUND` selects the first):
     bounded:  lower_bound * sigmoid(exp(A_log) * (raw_gate + dt_bias))
     softplus: -exp(A_log) * softplus(raw_gate + dt_bias)
 
-Scalar-gated callers may pass fewer q/k heads than value heads (grouped heads): each block of
-``H // HK`` consecutive value heads shares one q/k head inside the packed buffer.
+Callers may pass fewer q/k heads than value heads (grouped heads): each block of ``H // HK``
+consecutive value heads shares one q/k (and vector-gate) head inside the packed buffer.
 """
 
 from __future__ import annotations
@@ -120,9 +120,10 @@ def _recurrent_delta_rule_decode_kernel(
         b_gate_input = tl.load(raw_gate + i_n * gate_token_stride + i_h).to(tl.float32)
         b_gate_input += tl.load(dt_bias + i_h).to(tl.float32)
     else:
-        p_gate = raw_gate + i_n * gate_token_stride + ptr_offset((i_h, o_k), (K, 1))
+        # Vector gates follow the q/k heads: the per-channel decay acts on the shared key basis.
+        p_gate = raw_gate + i_n * gate_token_stride + ptr_offset((i_hk, o_k), (K, 1))
         b_gate_input = tl.load(p_gate, mask=m_k, other=0.0).to(tl.float32)
-        b_gate_input += tl.load(dt_bias + ptr_offset((i_h, o_k), (K, 1)), mask=m_k, other=0.0).to(
+        b_gate_input += tl.load(dt_bias + ptr_offset((i_hk, o_k), (K, 1)), mask=m_k, other=0.0).to(
             tl.float32
         )
     b_a = tl.exp(tl.load(A_log + i_h).to(tl.float32))
@@ -175,7 +176,7 @@ def launch_recurrent_delta_rule_decode(
 
     Args:
         packed_qkv: ``[B, HK*K | HK*K | H*V]`` per-token buffer; within each section head
-            rows are contiguous. ``HK == key_heads`` may divide ``H`` for scalar gates.
+            rows are contiguous. ``HK == key_heads`` may divide ``H``.
         raw_gate: Unactivated token-major gate, ``[B, H]`` for ``GateKind.SCALAR`` or
             ``[B, H, K]`` for ``GateKind.VECTOR``.
         raw_beta: Unactivated token-major write gate shaped ``[B, H]``, activated in-kernel

--- a/attn_gym/linear/_delta_rule/recurrent.py
+++ b/attn_gym/linear/_delta_rule/recurrent.py
@@ -83,9 +83,9 @@ def _recurrent_delta_rule_fwd_kernel(
 ):
     """Scan one sequence/head/value tile while retaining the FP32 state in registers.
 
-    Programs are indexed by value head. Scalar-gated callers may share one q/k head across
-    each block of ``H // HK`` consecutive value heads; vector-gated KDA passes ``HK == H``,
-    which reduces every ``row_k`` to the ungrouped ``row``.
+    Programs are indexed by value head. With grouped heads (``HK < H``) each block of
+    ``H // HK`` consecutive value heads reads one shared q/k head; vector gates follow the
+    q/k heads because the per-channel decay acts on the key basis those heads define.
     """
     pid = tl.program_id(0).to(tl.int64)
     NV = tl.cdiv(V, BV)
@@ -209,9 +209,9 @@ def launch_recurrent_delta_rule_fwd(
     """Launch a scalar- or vector-gated recurrent delta-rule specialization.
 
     Args:
-        q: Queries shaped ``[B, T, HK, K]``; packed callers pass ``B == 1``. Scalar-gated
-            callers may pass ``HK`` as a divisor of the value head count ``H`` (grouped
-            heads): each block of ``H // HK`` consecutive value heads shares one query/key
+        q: Queries shaped ``[B, T, HK, K]``; packed callers pass ``B == 1``. ``HK`` may be
+            a divisor of the value head count ``H`` (grouped heads): each block of
+            ``H // HK`` consecutive value heads shares one query/key (and vector-gate)
             head, so callers never materialize a ``repeat_interleave``.
         k: Keys shaped like ``q``.
         v: Values shaped ``[B, T, H, V]``.
@@ -251,8 +251,6 @@ def launch_recurrent_delta_rule_fwd(
     batch, tokens, key_heads, key_dim = q.shape
     heads, value_dim = v.shape[2], v.shape[-1]
     assert heads % key_heads == 0
-    # No caller groups vector gates; keep that unsupported mode out of the shared contract.
-    assert gate_kind is GateKind.SCALAR or key_heads == heads
     if initial_state is not None:
         if state_indices is None:
             assert initial_state.is_contiguous()

--- a/attn_gym/linear/kda/api.py
+++ b/attn_gym/linear/kda/api.py
@@ -232,7 +232,9 @@ def recurrent_kda(
     """Apply recurrent KDA for decoding and inference prefill.
 
     Args:
-        q: Queries shaped ``[B, T, H, K]``, scaled by ``1/sqrt(K)`` internally.
+        q: Queries shaped ``[B, T, HK, K]``, scaled by ``1/sqrt(K)`` internally. ``HK``
+            may divide the value head count ``H`` for grouped-head attention: each block
+            of ``H // HK`` consecutive value heads shares one query/key (and gate) head.
         k: Keys shaped like ``q``.
         v: Values shaped ``[B, T, H, V]``.
         gate: Finite, nonpositive per-token natural-log decay shaped like ``q``. At
@@ -293,6 +295,7 @@ def recurrent_kda(
         cu_seqlens,
         op_name="recurrent_kda",
         gate_name="gate",
+        allow_grouped_heads=True,
     )
     if state_indices is not None:
         if initial_state is None:

--- a/attn_gym/linear/kda/impl/reference.py
+++ b/attn_gym/linear/kda/impl/reference.py
@@ -92,6 +92,10 @@ def reference_kda(
     q, k, v = (tensor.float() for tensor in (q, k, v))
     gate = gate.float()
     beta = beta.float()
+    if q.shape[2] != v.shape[2]:
+        # Grouped heads: expand each shared query/key/gate head across its value-head group.
+        groups = v.shape[2] // q.shape[2]
+        q, k, gate = (tensor.repeat_interleave(groups, dim=2) for tensor in (q, k, gate))
     if initial_state is not None:
         initial_state = initial_state.float()
     # ``.float()`` casts alone do not stop an active autocast region from

--- a/attn_gym/linear/kda/ops.py
+++ b/attn_gym/linear/kda/ops.py
@@ -596,8 +596,9 @@ def _recurrent_fwd_fake(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     del k, gate, beta, initial_state, autotune
     num_sequences = q.shape[0] if cu_seqlens is None else cu_seqlens.shape[0] - 1
+    # The state carries one [K, V] slab per value head; grouped callers have v.shape[2] > HK.
     final_state = q.new_empty(
-        num_sequences, q.shape[2], q.shape[3], v.shape[-1], dtype=torch.float32
+        num_sequences, v.shape[2], q.shape[3], v.shape[-1], dtype=torch.float32
     )
     return torch.empty_like(v, dtype=q.dtype), final_state
 

--- a/attn_gym/linear/kda/validation.py
+++ b/attn_gym/linear/kda/validation.py
@@ -28,21 +28,34 @@ def validate_kda_inputs(
     *,
     op_name: str,
     gate_name: str,
+    allow_grouped_heads: bool = False,
 ) -> None:
-    """Validate the shared KDA operation contract before normalizing inputs."""
+    """Validate the shared KDA operation contract before normalizing inputs.
+
+    ``allow_grouped_heads`` admits value-head counts that are positive multiples of the
+    q/k head count (the recurrent forms map heads in-kernel); the chunk pipeline requires
+    equal head counts. Gates always follow the q/k heads because the per-channel decay
+    acts on the key basis those heads define.
+    """
     if q.ndim != 4:
         raise ValueError(f"q must have shape [B, T, H, K], got {tuple(q.shape)}")
-    batch, tokens, heads, key_dim = q.shape
-    if batch == 0 or tokens == 0 or heads == 0 or key_dim == 0:
+    batch, tokens, key_heads, key_dim = q.shape
+    if batch == 0 or tokens == 0 or key_heads == 0 or key_dim == 0:
         raise ValueError(f"q must have nonempty dimensions, got {tuple(q.shape)}")
     if k.shape != q.shape:
         raise ValueError(f"k must have shape {tuple(q.shape)}, got {tuple(k.shape)}")
     if gate.shape != q.shape:
         raise ValueError(f"{gate_name} must have shape {tuple(q.shape)}, got {tuple(gate.shape)}")
-    if v.ndim != 4 or v.shape[:3] != (batch, tokens, heads) or v.shape[-1] < 1:
-        raise ValueError(
-            f"v must have shape [{batch}, {tokens}, {heads}, V], got {tuple(v.shape)}"
+    if v.ndim != 4 or v.shape[:2] != (batch, tokens) or v.shape[-1] < 1:
+        raise ValueError(f"v must have shape [{batch}, {tokens}, H, V], got {tuple(v.shape)}")
+    heads = v.shape[2]
+    if heads != key_heads and not (allow_grouped_heads and heads != 0 and heads % key_heads == 0):
+        message = (
+            f"v heads must be a positive multiple of q heads for {op_name}, "
+            if allow_grouped_heads
+            else f"v heads must match q heads for {op_name}, "
         )
+        raise ValueError(message + f"got {heads} value heads for {key_heads} query heads")
     if beta.shape != (batch, tokens, heads):
         raise ValueError(f"beta must have shape {(batch, tokens, heads)}, got {tuple(beta.shape)}")
     if cu_seqlens is not None:

--- a/test/test_kda_recurrent.py
+++ b/test/test_kda_recurrent.py
@@ -159,6 +159,78 @@ def test_recurrent_packed_capacity_and_empty_slots():
         )
 
 
+def test_recurrent_grouped_heads_match_expanded_heads():
+    """Fewer q/k/gate heads than v heads must equal an explicit repeat_interleave."""
+    q, k, v, gate, beta, _ = _inputs(batch=2, tokens=17, heads=2, seed=11)
+    groups = 3
+    v = v.repeat_interleave(groups, dim=2).contiguous()
+    beta = beta.repeat_interleave(groups, dim=2).contiguous()
+    state = torch.randn(2, v.shape[2], q.shape[3], v.shape[-1], device="cuda")
+
+    # Fixed heuristics keep both calls on one kernel specialization so equality is exact;
+    # HK is an autotune key, so autotuned calls may pick different tiles.
+    grouped_output, grouped_state = recurrent_kda(
+        q, k, v, gate, beta, state, output_final_state=True, autotune=False
+    )
+    expanded_output, expanded_state = recurrent_kda(
+        q.repeat_interleave(groups, dim=2),
+        k.repeat_interleave(groups, dim=2),
+        v,
+        gate.repeat_interleave(groups, dim=2),
+        beta,
+        state,
+        output_final_state=True,
+        autotune=False,
+    )
+
+    torch.testing.assert_close(grouped_output, expanded_output, rtol=0, atol=0)
+    torch.testing.assert_close(grouped_state, expanded_state, rtol=0, atol=0)
+
+
+def test_recurrent_grouped_heads_match_reference():
+    """The grouped fused path agrees with the expanding reference oracle."""
+    q, k, v, gate, beta, _ = _inputs(batch=2, tokens=9, heads=2, seed=12)
+    v = v.repeat_interleave(2, dim=2).contiguous()
+    beta = beta.repeat_interleave(2, dim=2).contiguous()
+    state = torch.randn(2, v.shape[2], q.shape[3], v.shape[-1], device="cuda")
+
+    fused = recurrent_kda(q, k, v, gate, beta, state, output_final_state=True)
+    reference = recurrent_kda(
+        q, k, v, gate, beta, state, output_final_state=True, impl="reference"
+    )
+
+    torch.testing.assert_close(fused[0], reference[0], rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(fused[1], reference[1], rtol=1e-5, atol=1e-5)
+
+
+def test_grouped_heads_require_divisible_counts():
+    q, k, v, gate, beta, _ = _inputs(batch=2, tokens=3, heads=2)
+    bad_v = v.repeat_interleave(2, dim=2)[:, :, :3].contiguous()
+    bad_beta = beta.repeat_interleave(2, dim=2)[:, :, :3].contiguous()
+    with pytest.raises(ValueError, match="positive multiple of q heads"):
+        recurrent_kda(q, k, bad_v, gate, bad_beta)
+
+
+def test_chunk_rejects_grouped_heads():
+    """The chunk pipeline requires equal head counts; only recurrent forms group."""
+    from attn_gym.linear import chunk_kda
+
+    q, k, v, gate, beta, _ = _inputs(batch=2, tokens=64, heads=2)
+    grouped_v = v.repeat_interleave(2, dim=2).contiguous()
+    grouped_beta = beta.repeat_interleave(2, dim=2).contiguous()
+    with pytest.raises(ValueError, match="v heads must match q heads"):
+        chunk_kda(q, k, grouped_v, gate, grouped_beta)
+
+
+def test_recurrent_grouped_heads_registration():
+    """Grouped-head fakes must size the final state from value heads, not query heads."""
+    q, k, v, gate, beta, _ = _inputs(batch=1, tokens=3, heads=2)
+    v = v.repeat_interleave(3, dim=2).contiguous()
+    beta = beta.repeat_interleave(3, dim=2).contiguous()
+    state = torch.randn(1, v.shape[2], q.shape[3], v.shape[-1], device="cuda")
+    torch.library.opcheck(_recurrent_fwd_op, (q, k, v, gate, beta, state, None, True))
+
+
 @pytest.mark.skipif(not BLACKWELL, reason="chunk_kda requires CUDA capability 10.0")
 def test_recurrent_agrees_with_chunked_core():
     """Cross-check the decode scan against the training core on shared inputs."""


### PR DESCRIPTION
Stacked PRs:
 * #395
 * #394
 * __->__#393


--- --- ---

Support grouped q/k heads in recurrent KDA

## Human Note

## Agent note

Extend the grouped-head contract from GDN to the KDA recurrent forms. The shared scan already
addresses grouped heads; this relaxes validate_kda_inputs for recurrent_kda only (the chunk
pipeline keeps requiring equal head counts), expands q/k/gate in the FP32 reference wrapper,
sizes the recurrent fake state from value heads, and removes the launcher assertion that kept
grouped vector gates out of the shared contract. Vector gates follow the q/k heads because the
per-channel decay acts on the key basis those heads define; the shared decode kernel's vector
gate addressing now matches that convention. Grouped tests pin exact equality against explicit
repeat_interleave expansion plus reference parity, divisibility rejection, and chunk strictness.

## Test Plan

```bash
.venv/bin/prek run --files attn_gym/linear/kda/validation.py attn_gym/linear/kda/api.py attn_gym/linear/kda/impl/reference.py attn_gym/linear/kda/ops.py attn_gym/linear/_delta_rule/recurrent.py attn_gym/linear/_delta_rule/decode.py test/test_kda_recurrent.py
gpu-run auto -- .venv/bin/pytest -q -n 6 test/test_kda_recurrent.py test/test_kda_recurrent_decode.py test/linear/ test/test_kda_cute_forward.py test/test_kda_compile_dynamic_shapes.py
```