### PR TITLE
Add fused chunk_gdn over the KDA chunk pipeline

### DIFF
--- a/attn_gym/linear/_delta_rule/validation.py
+++ b/attn_gym/linear/_delta_rule/validation.py
@@ -2,9 +2,20 @@
 
 from __future__ import annotations
 
+from numbers import Real
+
 import torch
 
 SUPPORTED_ACTIVATION_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
+
+
+def resolve_scale(scale: float | None, key_dim: int) -> float:
+    """Resolve a query-scale override to a concrete float, defaulting to ``1/sqrt(K)``."""
+    if scale is None:
+        return key_dim**-0.5
+    if not isinstance(scale, Real) or isinstance(scale, bool):
+        raise TypeError("scale must be a real scalar or None")
+    return float(scale)
 
 
 def validate_has_initial_state(
@@ -148,6 +159,7 @@ def validate_paged_state(
 __all__ = [
     "SUPPORTED_ACTIVATION_DTYPES",
     "resolve_decode_out",
+    "resolve_scale",
     "validate_decode_inputs",
     "validate_has_initial_state",
     "validate_paged_state",

--- a/attn_gym/linear/gdn/api.py
+++ b/attn_gym/linear/gdn/api.py
@@ -3,17 +3,17 @@
 from __future__ import annotations
 
 import sys
-from numbers import Real
 
 import torch
 
 from attn_gym.linear._delta_rule.validation import (
     resolve_decode_out,
+    resolve_scale,
     validate_decode_inputs,
     validate_paged_state,
 )
 from attn_gym.linear.gdn.impl.reference import chunk_forward, recurrent_forward, reference_gdn
-from attn_gym.linear.gdn.ops import recurrent_decode_forward
+from attn_gym.linear.gdn.ops import fused_chunk_forward, recurrent_decode_forward
 from attn_gym.linear.gdn.ops import recurrent_forward as fused_recurrent_forward
 from attn_gym.linear.gdn.validation import validate_gdn_inputs
 from attn_gym.linear.types import Impl, resolve_impl
@@ -30,6 +30,7 @@ def chunk_gdn(
     cu_seqlens: torch.Tensor | None = None,
     scale: float | None = None,
     output_final_state: bool = False,
+    autotune: bool = True,
     impl: Impl | str = Impl.REFERENCE,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Apply chunk-parallel gated delta rule attention for training and prefill.
@@ -54,16 +55,35 @@ def chunk_gdn(
             unspecified.
         scale: Query scale. Defaults to ``1 / sqrt(K)``.
         output_final_state: Return the final recurrent state with the output.
-        impl: ``"reference"`` uses eager PyTorch. ``"fused"`` is reserved for the optimized
-            backend and currently raises ``NotImplementedError``.
+        autotune: Benchmark candidate fused-kernel configurations when true (winners are
+            cached and reused); use fixed heuristics when false for repeatable selection
+            across machines and cache states. Ignored by the reference implementation.
+        impl: ``"reference"`` uses eager PyTorch. ``"fused"`` runs the CuTe KDA chunk
+            pipeline with the scalar gate expanded per key channel; it requires an
+            SM100-class GPU (compute capability 10.0 or 10.3) and ``K = V = 128``,
+            supports training through autograd, and
+            inherits the fused chunk pipeline's gate-range limit of approximately
+            ``[-5.914, 0]`` per token.
 
     Returns:
         The output in ``q.dtype`` and either the final recurrent state or ``None``.
     """
     selected_impl = resolve_impl(impl)
     validate_gdn_inputs(q, k, v, gate, beta, initial_state, cu_seqlens)
+    scale = resolve_scale(scale, q.shape[-1])
     if selected_impl is Impl.FUSED:
-        raise NotImplementedError("chunk_gdn impl='fused' is not implemented yet")
+        return fused_chunk_forward(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            initial_state,
+            cu_seqlens=cu_seqlens,
+            scale=scale,
+            output_final_state=output_final_state,
+            autotune=autotune,
+        )
 
     return reference_gdn(
         chunk_forward,
@@ -72,7 +92,7 @@ def chunk_gdn(
         v,
         gate,
         beta,
-        scale=q.shape[-1] ** -0.5 if scale is None else scale,
+        scale=scale,
         initial_state=initial_state,
         cu_seqlens=cu_seqlens,
         output_final_state=output_final_state,
@@ -265,18 +285,13 @@ def recurrent_gdn_decode(
     if dt_bias.shape != (heads,) or dt_bias.dtype != torch.float32 or not dt_bias.is_contiguous():
         raise ValueError(f"dt_bias must be contiguous float32 with shape ({heads},)")
 
-    if scale is None:
-        scale = key_dim**-0.5
-    elif not isinstance(scale, Real) or isinstance(scale, bool):
-        raise TypeError("scale must be a real scalar or None")
-    else:
-        scale = float(scale)
-        if (
-            scale != scale  # noqa: PLR0124 - compile-safe NaN check
-            or scale <= 0
-            or scale > sys.float_info.max
-        ):
-            raise ValueError(f"scale must be finite and positive, got {scale}")
+    scale = resolve_scale(scale, key_dim)
+    if (
+        scale != scale  # noqa: PLR0124 - compile-safe NaN check
+        or scale <= 0
+        or scale > sys.float_info.max
+    ):
+        raise ValueError(f"scale must be finite and positive, got {scale}")
 
     out = resolve_decode_out(packed_qkv, out, (1, batch, heads, value_dim))
     return recurrent_decode_forward(

--- a/attn_gym/linear/gdn/ops.py
+++ b/attn_gym/linear/gdn/ops.py
@@ -6,6 +6,8 @@ import importlib
 
 import torch
 
+from attn_gym.linear.kda.api import chunk_kda
+
 _RECURRENT_ARGS = (
     "(Tensor q, Tensor k, Tensor v, Tensor gate, Tensor beta, Tensor? initial_state, "
     "Tensor? cu_seqlens, float scale, bool autotune)"
@@ -197,6 +199,54 @@ def recurrent_forward(
     return recurrent_fwd_no_state_op(*args), None
 
 
+def fused_chunk_forward(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    *,
+    cu_seqlens: torch.Tensor | None,
+    scale: float,
+    output_final_state: bool,
+    autotune: bool,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Run chunk GDN on the fused KDA pipeline by expanding the scalar gate per channel.
+
+    GDN's recurrence is KDA's with one decay shared by every key channel, so the fused KDA
+    chunk kernels compute it exactly. The expansions stay inside autograd, whose backward
+    reduces the gate gradient over K and the q/k gradients over each value-head group.
+    The gate expansion is a zero-stride view; the KDA pipeline normalizes any layouts its
+    kernels cannot take directly.
+    """
+    # TODO: easy (slower) adapter until the Mega chunk backend lands; delegating here
+    # means chunk_gdn inherits that backend for free.
+    if not q.is_cuda:
+        raise ValueError("chunk_gdn(impl='fused') requires CUDA tensors")
+    key_dim = q.shape[-1]
+    groups = v.shape[2] // q.shape[2]
+    if groups > 1:
+        q, k = (tensor.repeat_interleave(groups, dim=2) for tensor in (q, k))
+    # GDN admits any floating gate/beta dtype; KDA validation caps them at FP32.
+    gate, beta = (
+        tensor.float() if tensor.dtype == torch.float64 else tensor for tensor in (gate, beta)
+    )
+    vector_gate = gate.unsqueeze(-1).expand(*gate.shape, key_dim)
+    return chunk_kda(
+        q,
+        k,
+        v,
+        vector_gate,
+        beta,
+        initial_state,
+        cu_seqlens=cu_seqlens,
+        scale=scale,
+        output_final_state=output_final_state,
+        autotune=autotune,
+    )
+
+
 def recurrent_decode_forward(
     packed_qkv: torch.Tensor,
     raw_gate: torch.Tensor,
@@ -234,6 +284,7 @@ def recurrent_decode_forward(
 
 
 __all__ = [
+    "fused_chunk_forward",
     "recurrent_decode_forward",
     "recurrent_decode_op",
     "recurrent_forward",

--- a/attn_gym/linear/kda/api.py
+++ b/attn_gym/linear/kda/api.py
@@ -22,6 +22,7 @@ import torch
 
 from attn_gym.linear._delta_rule.validation import (
     resolve_decode_out,
+    resolve_scale,
     validate_decode_inputs,
     validate_paged_state,
 )
@@ -61,6 +62,7 @@ def chunk_kda(
     initial_state: torch.Tensor | None = None,
     *,
     cu_seqlens: torch.Tensor | None = None,
+    scale: float | None = None,
     output_final_state: bool = False,
     fastmath: bool = False,
     autotune: bool = True,
@@ -69,7 +71,7 @@ def chunk_kda(
     """Apply chunk-parallel KDA for training and prefill.
 
     Args:
-        q: Queries shaped ``[B, T, H, K]``, scaled by ``1/sqrt(K)`` internally. Use
+        q: Queries shaped ``[B, T, H, K]``, scaled by ``scale`` internally. Use
             L2-normalized Q/K with fused FP16: unnormalized values can overflow the FP16
             intermediates passed between FP32-accumulating GEMMs.
         k: Keys shaped like ``q`` and subject to the same fused FP16 range limitation.
@@ -88,6 +90,8 @@ def chunk_kda(
             contiguous ``int32`` on ``q.device``; they start at zero, never
             decrease, may repeat for empty sequences whose states pass through,
             and may end before ``T``.
+        scale: Query scale, applied inside the kernels in FP32. Defaults to
+            ``1 / sqrt(K)``.
         output_final_state: Return the final recurrent state with the output.
         fastmath: Allow less precise fused math for speed; rejected with
             ``"reference"``.
@@ -116,6 +120,7 @@ def chunk_kda(
         op_name="chunk_kda",
         gate_name="gate",
     )
+    scale = resolve_scale(scale, q.shape[-1])
     if selected_impl is Impl.FUSED:
         return _fused_chunk_forward(
             q,
@@ -125,12 +130,13 @@ def chunk_kda(
             beta,
             initial_state,
             cu_seqlens=cu_seqlens,
+            scale=scale,
             output_final_state=output_final_state,
             fastmath=fastmath,
             autotune=autotune,
         )
     return reference_kda(
-        partial(naive_chunk_kda, chunk_size=_CHUNK_SIZE),
+        partial(naive_chunk_kda, chunk_size=_CHUNK_SIZE, scale=scale),
         q,
         k,
         v,
@@ -435,18 +441,13 @@ def recurrent_kda_decode(
             raise ValueError(f"lower_bound must be finite and nonpositive, got {lower_bound}")
     else:
         lower_bound = 0.0
-    if scale is None:
-        scale = key_dim**-0.5
-    elif not isinstance(scale, Real) or isinstance(scale, bool):
-        raise TypeError("scale must be a real scalar or None")
-    else:
-        scale = float(scale)
-        if (
-            scale != scale  # noqa: PLR0124 - compile-safe NaN check
-            or scale <= 0
-            or scale > sys.float_info.max
-        ):
-            raise ValueError(f"scale must be finite and positive, got {scale}")
+    scale = resolve_scale(scale, key_dim)
+    if (
+        scale != scale  # noqa: PLR0124 - compile-safe NaN check
+        or scale <= 0
+        or scale > sys.float_info.max
+    ):
+        raise ValueError(f"scale must be finite and positive, got {scale}")
 
     out = resolve_decode_out(packed_qkv, out, (1, batch, heads, value_dim))
 

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd.py
@@ -31,6 +31,7 @@ def chunk_kda_bwd(
     initial_state: torch.Tensor | None,
     metadata: RaggedChunkMetadata | None,
     *,
+    scale: float,
     chunk_size: int = 64,
     fastmath: bool = False,
     autotune: bool = True,
@@ -51,7 +52,6 @@ def chunk_kda_bwd(
         raise ValueError(f"the composed KDA backward requires chunk_size=64, got {chunk_size}")
     if tokens % chunk_size and metadata is None:
         raise ValueError("the composed KDA backward requires complete chunks")
-    scale = head_dim**-0.5
 
     # Forward deliberately saves only the minimal backward factors. Always
     # reconstruct the large W/U, gated Q/K, state, and corrected-value
@@ -120,6 +120,7 @@ def chunk_kda_bwd(
             dh,
             dv,
             metadata,
+            scale=scale,
             chunk_size=chunk_size,
             fastmath=fastmath,
             autotune=autotune,

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_wy_dqkg_fused.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_wy_dqkg_fused.py
@@ -3351,6 +3351,7 @@ def _compile_chunk_kda_bwd_wy_dqkg(
     head_dim: int,
     chunk_size: int,
     io_dtype: torch.dtype,
+    scale: float,
     fastmath: bool,
     grid_waves: int,
     ragged: bool,
@@ -3363,7 +3364,7 @@ def _compile_chunk_kda_bwd_wy_dqkg(
         head_dim_k=head_dim,
         head_dim_v=head_dim,
         io_dtype=cutlass_io_dtype,
-        scale=head_dim**-0.5,
+        scale=scale,
         grid_waves=grid_waves,
         use_fast_math=fastmath,
         use_int64_offsets=use_int64_offsets,
@@ -3459,6 +3460,7 @@ class ChunkKdaBwdWyDqkgTunable:
         cu_seqlens: torch.Tensor | None
         chunk_offsets: torch.Tensor | None
         chunk_size: int
+        scale: float
         fastmath: bool
 
     @staticmethod
@@ -3490,12 +3492,13 @@ class ChunkKdaBwdWyDqkgTunable:
     def compile_call(
         config: ChunkKdaBwdWyDqkgConfig,
         args: Args,
-    ) -> tuple[int, int, int, torch.dtype, bool, int, bool, bool]:
+    ) -> tuple[int, int, int, torch.dtype, float, bool, int, bool, bool]:
         return (
             args.q.shape[2],
             args.q.shape[3],
             args.chunk_size,
             args.q.dtype,
+            args.scale,
             args.fastmath,
             config.grid_waves,
             args.chunk_offsets is not None,
@@ -3585,6 +3588,7 @@ def chunk_kda_bwd_wy_dqkg(
     dv: torch.Tensor,
     metadata: RaggedChunkMetadata | None = None,
     *,
+    scale: float,
     chunk_size: int = 64,
     fastmath: bool = False,
     config: ChunkKdaBwdWyDqkgConfig | None = None,
@@ -3663,6 +3667,7 @@ def chunk_kda_bwd_wy_dqkg(
         cu_seqlens=cu_seqlens,
         chunk_offsets=chunk_offsets,
         chunk_size=chunk_size,
+        scale=scale,
         fastmath=fastmath,
     )
     # An explicit config pins the schedule regardless of the plumbed flag.

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py
@@ -142,12 +142,11 @@ def _chunk_kda_fwd(
     has_initial_state: torch.Tensor | None,
     metadata: RaggedChunkMetadata | None,
     *,
+    scale: float,
     output_final_state: bool,
     autotune: bool,
 ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor, torch.Tensor]:
     """Run the optimized KDA core using an already selected chunk schedule."""
-    scale = _HEAD_DIM**-0.5
-
     with profiler_range("kda/fused/chunk_kda_fwd_intra"):
         w, u, kg, Aqk, Akk = chunk_kda_fwd_intra(
             q,
@@ -197,6 +196,7 @@ def _chunk_kda_fwd_shared(
     cumulative_gate: torch.Tensor,
     beta: torch.Tensor,
     initial_state: torch.Tensor | None,
+    scale: float,
     autotune: bool,
     output_final_state: bool,
 ):
@@ -213,6 +213,7 @@ def _chunk_kda_fwd_shared(
         None,
         None,
         None,
+        scale=scale,
         output_final_state=output_final_state,
         autotune=autotune,
     )
@@ -225,6 +226,7 @@ def _chunk_kda_fwd_cuda(
     cumulative_gate: torch.Tensor,
     beta: torch.Tensor,
     initial_state: torch.Tensor | None,
+    scale: float,
     autotune: bool,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     output, _final_state, Aqk, Akk = _chunk_kda_fwd_shared(
@@ -234,6 +236,7 @@ def _chunk_kda_fwd_cuda(
         cumulative_gate,
         beta,
         initial_state,
+        scale,
         autotune,
         False,
     )
@@ -247,6 +250,7 @@ def _chunk_kda_fwd_with_state_cuda(
     cumulative_gate: torch.Tensor,
     beta: torch.Tensor,
     initial_state: torch.Tensor | None,
+    scale: float,
     autotune: bool,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     return _chunk_kda_fwd_shared(
@@ -256,6 +260,7 @@ def _chunk_kda_fwd_with_state_cuda(
         cumulative_gate,
         beta,
         initial_state,
+        scale,
         autotune,
         True,
     )
@@ -270,6 +275,7 @@ def _chunk_kda_fwd_ragged_shared(
     initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor,
     chunk_offsets: torch.Tensor,
+    scale: float,
     autotune: bool,
     output_final_state: bool,
 ):
@@ -292,6 +298,7 @@ def _chunk_kda_fwd_ragged_shared(
         None,
         None,
         metadata,
+        scale=scale,
         output_final_state=output_final_state,
         autotune=autotune,
     )
@@ -306,6 +313,7 @@ def _chunk_kda_fwd_ragged_cuda(
     initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor,
     chunk_offsets: torch.Tensor,
+    scale: float,
     autotune: bool,
 ):
     output, _state, Aqk, Akk = _chunk_kda_fwd_ragged_shared(
@@ -317,6 +325,7 @@ def _chunk_kda_fwd_ragged_cuda(
         initial_state,
         cu_seqlens,
         chunk_offsets,
+        scale,
         autotune,
         False,
     )
@@ -332,6 +341,7 @@ def _chunk_kda_fwd_ragged_with_state_cuda(
     initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor,
     chunk_offsets: torch.Tensor,
+    scale: float,
     autotune: bool,
 ):
     return _chunk_kda_fwd_ragged_shared(
@@ -343,6 +353,7 @@ def _chunk_kda_fwd_ragged_with_state_cuda(
         initial_state,
         cu_seqlens,
         chunk_offsets,
+        scale,
         autotune,
         True,
     )
@@ -389,6 +400,7 @@ def _chunk_kda_fwd_ragged_paged_cuda(
         state_indices,
         has_initial_state,
         metadata,
+        scale=_HEAD_DIM**-0.5,
         output_final_state=False,
         autotune=autotune,
     )
@@ -452,6 +464,7 @@ def _chunk_kda_bwd_shared(
     d_output: torch.Tensor | None,
     d_final_state: torch.Tensor | None,
     initial_state: torch.Tensor | None,
+    scale: float,
     fastmath: bool,
     autotune: bool,
 ):
@@ -479,7 +492,7 @@ def _chunk_kda_bwd_shared(
             k,
             cumulative_gate,
             beta,
-            _HEAD_DIM**-0.5,
+            scale,
             metadata,
         )
     else:
@@ -496,6 +509,7 @@ def _chunk_kda_bwd_shared(
         d_final_state,
         initial_state,
         metadata,
+        scale=scale,
         fastmath=fastmath,
         autotune=autotune,
     )
@@ -512,6 +526,7 @@ def _chunk_kda_bwd_recompute_factors_shared(
     d_output: torch.Tensor | None,
     d_final_state: torch.Tensor | None,
     initial_state: torch.Tensor | None,
+    scale: float,
     fastmath: bool,
     autotune: bool,
 ):
@@ -529,6 +544,7 @@ def _chunk_kda_bwd_recompute_factors_shared(
         d_output,
         d_final_state,
         initial_state,
+        scale,
         fastmath,
         autotune,
     )

--- a/attn_gym/linear/kda/impl/fused.py
+++ b/attn_gym/linear/kda/impl/fused.py
@@ -45,6 +45,7 @@ class _ChunkKDA(torch.autograd.Function):
         initial_state,
         cu_seqlens,
         chunk_offsets,
+        scale,
         output_final_state,
         fastmath,
         autotune,
@@ -59,11 +60,11 @@ class _ChunkKDA(torch.autograd.Function):
             assert chunk_offsets is None
             if output_final_state:
                 output, state, aqk, akk = chunk_fwd_with_state_op(
-                    q, k, v, cumulative_gate, beta, initial_state, autotune
+                    q, k, v, cumulative_gate, beta, initial_state, scale, autotune
                 )
             else:
                 output, aqk, akk = chunk_fwd_op(
-                    q, k, v, cumulative_gate, beta, initial_state, autotune
+                    q, k, v, cumulative_gate, beta, initial_state, scale, autotune
                 )
         elif output_final_state:
             assert chunk_offsets is not None
@@ -76,6 +77,7 @@ class _ChunkKDA(torch.autograd.Function):
                 initial_state,
                 cu_seqlens,
                 chunk_offsets,
+                scale,
                 autotune,
             )
         else:
@@ -89,6 +91,7 @@ class _ChunkKDA(torch.autograd.Function):
                 initial_state,
                 cu_seqlens,
                 chunk_offsets,
+                scale,
                 autotune,
             )
         ctx.save_for_backward(
@@ -103,6 +106,7 @@ class _ChunkKDA(torch.autograd.Function):
             cu_seqlens,
             chunk_offsets,
         )
+        ctx.scale = scale
         ctx.fastmath = fastmath
         ctx.autotune = autotune
         ctx.set_materialize_grads(False)
@@ -138,6 +142,7 @@ class _ChunkKDA(torch.autograd.Function):
             d_output,
             d_final_state,
             initial_state,
+            ctx.scale,
             ctx.fastmath,
             ctx.autotune,
         )
@@ -152,7 +157,7 @@ class _ChunkKDA(torch.autograd.Function):
             chunk_offsets,
             True,
         )
-        return dq, dk, dv, d_gate, db, d_initial_state, None, None, None, None, None
+        return dq, dk, dv, d_gate, db, d_initial_state, None, None, None, None, None, None
 
 
 def chunk_forward(
@@ -164,6 +169,7 @@ def chunk_forward(
     initial_state: torch.Tensor | None = None,
     *,
     cu_seqlens: torch.Tensor | None = None,
+    scale: float,
     output_final_state: bool = False,
     fastmath: bool = False,
     autotune: bool = True,
@@ -206,6 +212,7 @@ def chunk_forward(
             initial_state,
             cu_seqlens,
             chunk_offsets,
+            scale,
             True,
             fastmath,
             autotune,
@@ -220,6 +227,7 @@ def chunk_forward(
             initial_state,
             cu_seqlens,
             chunk_offsets,
+            scale,
             False,
             fastmath,
             autotune,

--- a/attn_gym/linear/kda/ops.py
+++ b/attn_gym/linear/kda/ops.py
@@ -20,7 +20,7 @@ _CHUNK_SIZE = 64
 # Fixed-arity schema pairs avoid optional outputs on hot paths.
 _CHUNK_FWD_ARGS = (
     "(Tensor q, Tensor k, Tensor v, Tensor cumulative_gate, Tensor beta, Tensor? initial_state,"
-    " bool autotune)"
+    " float scale, bool autotune)"
 )
 torch.library.define(
     "attn_gym::kda_chunk_fwd",
@@ -33,7 +33,8 @@ torch.library.define(
 
 _CHUNK_RAGGED_FWD_ARGS = (
     "(Tensor q, Tensor k, Tensor v, Tensor cumulative_gate, Tensor beta, "
-    "Tensor? initial_state, Tensor cu_seqlens, Tensor chunk_offsets, bool autotune)"
+    "Tensor? initial_state, Tensor cu_seqlens, Tensor chunk_offsets, float scale, "
+    "bool autotune)"
 )
 torch.library.define(
     "attn_gym::kda_chunk_fwd_ragged",
@@ -54,7 +55,7 @@ torch.library.define(
 _CHUNK_BWD_ARGS = (
     "(Tensor q, Tensor k, Tensor v, Tensor cumulative_gate, Tensor beta, Tensor Aqk, "
     "Tensor Akk, Tensor? cu_seqlens, Tensor? chunk_offsets, Tensor? d_output, "
-    "Tensor? d_final_state, {initial_state}, bool fastmath, bool autotune)"
+    "Tensor? d_final_state, {initial_state}, float scale, bool fastmath, bool autotune)"
 )
 torch.library.define(
     "attn_gym::kda_chunk_bwd",
@@ -70,7 +71,7 @@ torch.library.define(
 _CHUNK_BWD_RECOMPUTE_ARGS = (
     "(Tensor q, Tensor k, Tensor v, Tensor cumulative_gate, Tensor beta, "
     "Tensor? cu_seqlens, Tensor? chunk_offsets, Tensor? d_output, "
-    "Tensor? d_final_state, {initial_state}, bool fastmath, bool autotune)"
+    "Tensor? d_final_state, {initial_state}, float scale, bool fastmath, bool autotune)"
 )
 torch.library.define(
     "attn_gym::kda_chunk_bwd_recompute_factors",
@@ -348,9 +349,10 @@ def _chunk_fwd_fake(
     cumulative_gate: torch.Tensor,
     beta: torch.Tensor,
     initial_state: torch.Tensor | None,
+    scale: float,
     autotune: bool,
 ):
-    del k, cumulative_gate, beta, initial_state, autotune
+    del k, cumulative_gate, beta, initial_state, scale, autotune
     return _chunk_fwd_fake_common(q, v)
 
 
@@ -362,9 +364,10 @@ def _chunk_fwd_with_state_fake(
     cumulative_gate: torch.Tensor,
     beta: torch.Tensor,
     initial_state: torch.Tensor | None,
+    scale: float,
     autotune: bool,
 ):
-    del k, cumulative_gate, beta, initial_state, autotune
+    del k, cumulative_gate, beta, initial_state, scale, autotune
     output, aqk, akk = _chunk_fwd_fake_common(q, v)
     state = q.new_empty(
         (q.shape[0], q.shape[2], q.shape[3], v.shape[-1]),
@@ -383,9 +386,10 @@ def _chunk_fwd_ragged_fake(
     initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor,
     chunk_offsets: torch.Tensor,
+    scale: float,
     autotune: bool,
 ):
-    del k, cumulative_gate, beta, initial_state, cu_seqlens, chunk_offsets, autotune
+    del k, cumulative_gate, beta, initial_state, cu_seqlens, chunk_offsets, scale, autotune
     return _chunk_fwd_fake_common(q, v)
 
 
@@ -399,9 +403,10 @@ def _chunk_fwd_ragged_with_state_fake(
     initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor,
     chunk_offsets: torch.Tensor,
+    scale: float,
     autotune: bool,
 ):
-    del k, cumulative_gate, beta, initial_state, chunk_offsets, autotune
+    del k, cumulative_gate, beta, initial_state, chunk_offsets, scale, autotune
     output, aqk, akk = _chunk_fwd_fake_common(q, v)
     state = q.new_empty(
         (cu_seqlens.shape[0] - 1, q.shape[2], q.shape[3], v.shape[-1]),
@@ -462,11 +467,12 @@ def _chunk_bwd_fake(
     d_output: torch.Tensor | None,
     d_final_state: torch.Tensor | None,
     initial_state: torch.Tensor | None,
+    scale: float,
     fastmath: bool,
     autotune: bool,
 ):
     del aqk, akk, cu_seqlens, chunk_offsets, d_output, d_final_state, initial_state
-    del fastmath, autotune
+    del scale, fastmath, autotune
     return _chunk_bwd_fake_common(q, k, v, cumulative_gate, beta)
 
 
@@ -484,10 +490,11 @@ def _chunk_bwd_with_state_grad_fake(
     d_output: torch.Tensor | None,
     d_final_state: torch.Tensor | None,
     initial_state: torch.Tensor,
+    scale: float,
     fastmath: bool,
     autotune: bool,
 ):
-    del aqk, akk, cu_seqlens, chunk_offsets, d_output, d_final_state, fastmath, autotune
+    del aqk, akk, cu_seqlens, chunk_offsets, d_output, d_final_state, scale, fastmath, autotune
     return (
         *_chunk_bwd_fake_common(q, k, v, cumulative_gate, beta),
         torch.empty_like(initial_state),
@@ -506,10 +513,12 @@ def _chunk_bwd_recompute_factors_fake(
     d_output: torch.Tensor | None,
     d_final_state: torch.Tensor | None,
     initial_state: torch.Tensor | None,
+    scale: float,
     fastmath: bool,
     autotune: bool,
 ):
-    del cu_seqlens, chunk_offsets, d_output, d_final_state, initial_state, fastmath, autotune
+    del cu_seqlens, chunk_offsets, d_output, d_final_state, initial_state
+    del scale, fastmath, autotune
     return _chunk_bwd_fake_common(q, k, v, cumulative_gate, beta)
 
 
@@ -525,10 +534,11 @@ def _chunk_bwd_recompute_factors_with_state_grad_fake(
     d_output: torch.Tensor | None,
     d_final_state: torch.Tensor | None,
     initial_state: torch.Tensor,
+    scale: float,
     fastmath: bool,
     autotune: bool,
 ):
-    del cu_seqlens, chunk_offsets, d_output, d_final_state, fastmath, autotune
+    del cu_seqlens, chunk_offsets, d_output, d_final_state, scale, fastmath, autotune
     return (
         *_chunk_bwd_fake_common(q, k, v, cumulative_gate, beta),
         torch.empty_like(initial_state),

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -19,7 +19,9 @@ output = scale * query @ state
 `chunk_gdn` uses a chunk-parallel decomposition for training and prefill. `recurrent_gdn` consumes
 tokens in order for decoding, inference prefill, and state-carrying correctness checks. The caller
 chooses the execution form explicitly. `impl="reference"` selects eager PyTorch;
-`recurrent_gdn(..., impl="fused")` selects the inference-only Triton scan.
+`chunk_gdn(..., impl="fused")` selects the training-capable CuTe KDA chunk pipeline with the
+scalar gate expanded per key channel, while `recurrent_gdn(..., impl="fused")` selects the
+inference-only Triton scan.
 
 ```python
 from attn_gym.linear import chunk_gdn
@@ -43,7 +45,7 @@ output, final_state = chunk_gdn(
 - CPU and CUDA execution through eager PyTorch operations.
 - An inference-only fused recurrent implementation on CUDA, including mutable paged state caches
   shaped `[num_slots, H, V, K]` selected by `state_indices`.
-- Autograd for reference inputs and initial state.
+- Autograd for reference execution and fused chunk execution, including the initial state.
 - Q/K/V share one dtype. FP16 and BF16 inputs use FP32 recurrence math and state while returning
   output in the Q dtype.
 - Gate and beta may use independent floating dtypes and are converted to the recurrence compute
@@ -53,7 +55,9 @@ output, final_state = chunk_gdn(
 The fused recurrent implementation requires CUDA with Triton, Q/K/V in FP16, BF16, or FP32, and
 `K <= 256`. Packed offsets must begin at zero, be nondecreasing, and end within the physical token
 capacity. Output rows beyond the terminal offset are inactive capacity and unspecified. The fused
-chunk implementation is not implemented yet; unsupported implementation choices fail rather than
+chunk implementation requires an SM100-class GPU (CUDA capability 10.0 or 10.3) and
+`K = V = 128`, and inherits `chunk_kda`’s
+fused FP16 Q/K normalization guidance; unsupported implementation choices fail rather than
 falling back to the reference.
 
 ### Migration from the prototype API

--- a/test/kda/mega/test_kda_recompute_factors_backward.py
+++ b/test/kda/mega/test_kda_recompute_factors_backward.py
@@ -58,6 +58,7 @@ def test_recomputed_factors_backward_matches_saved_factors(lengths):
         d_output,
         None,
         None,
+        D**-0.5,
         False,
         False,
     )
@@ -105,6 +106,7 @@ def test_ragged_backward_ignores_akk_capacity_slack():
         torch.randn_like(v),
         None,
         None,
+        D**-0.5,
         False,
         False,
     )
@@ -137,6 +139,7 @@ def test_recomputed_factors_backward_with_state_matches_saved_factors():
         torch.randn_like(v),
         d_final_state,
         initial_state,
+        D**-0.5,
         False,
         False,
     )
@@ -156,7 +159,7 @@ def test_recomputed_factors_backward_op_registration():
     d_output = torch.randn_like(v)
     torch.library.opcheck(
         chunk_bwd_recompute_factors_op,
-        (q, k, v, gate, beta, None, None, d_output, None, None, False, False),
+        (q, k, v, gate, beta, None, None, d_output, None, None, D**-0.5, False, False),
         test_utils=("test_schema", "test_faketensor", "test_aot_dispatch_dynamic"),
         rtol=2e-2,
         atol=2e-3,
@@ -175,6 +178,7 @@ def test_recomputed_factors_backward_op_registration():
             d_output,
             torch.randn_like(initial_state),
             initial_state,
+            D**-0.5,
             False,
             False,
         ),

--- a/test/linear/test_gdn.py
+++ b/test/linear/test_gdn.py
@@ -291,9 +291,7 @@ def test_impl_accepts_enum_and_string(function):
 
     with pytest.raises(ValueError, match="'fused', 'reference'"):
         function(*inputs[:-1], impl="eager")
-    error = NotImplementedError if function is chunk_gdn else ValueError
-    message = "impl='fused'" if function is chunk_gdn else "requires CUDA tensors"
-    with pytest.raises(error, match=message):
+    with pytest.raises(ValueError, match="requires CUDA tensors"):
         function(*inputs[:-1], impl=Impl.FUSED)
 
 

--- a/test/linear/test_gdn_chunk_fused.py
+++ b/test/linear/test_gdn_chunk_fused.py
@@ -1,0 +1,177 @@
+"""Fused chunk_gdn (KDA-pipeline adapter) against the eager reference, forward and backward."""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+pytest.importorskip("cutlass")
+
+from attn_gym.linear import chunk_gdn
+from attn_gym.testing import cumulative_sequence_offsets
+from attn_gym.testing.kda import assert_matches_low_precision_reference, clone_kda_inputs
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() not in ((10, 0), (10, 3)),
+    reason="the fused chunk pipeline requires SM100/SM103",
+)
+
+_KV_DIM = 128
+
+
+def make_inputs(
+    *,
+    batch: int = 2,
+    tokens: int = 96,
+    heads: int = 2,
+    key_heads: int | None = None,
+    dtype: torch.dtype = torch.bfloat16,
+    requires_grad: bool = False,
+    seed: int = 0,
+) -> tuple[torch.Tensor, ...]:
+    """Create stable K=V=128 chunk inputs; ``key_heads`` enables grouped heads."""
+    torch.manual_seed(seed)
+    q_heads = heads if key_heads is None else key_heads
+    q = F.normalize(torch.randn(batch, tokens, q_heads, _KV_DIM, device="cuda"), dim=-1).to(dtype)
+    k = F.normalize(torch.randn(batch, tokens, q_heads, _KV_DIM, device="cuda"), dim=-1).to(dtype)
+    v = torch.randn(batch, tokens, heads, _KV_DIM, device="cuda", dtype=dtype)
+    gate = F.logsigmoid(torch.randn(batch, tokens, heads, device="cuda"))
+    beta = torch.sigmoid(torch.randn(batch, tokens, heads, device="cuda"))
+    state = torch.randn(batch, heads, _KV_DIM, _KV_DIM, device="cuda")
+    tensors = (q, k, v, gate, beta, state)
+    if requires_grad:
+        tensors = tuple(tensor.clone().requires_grad_() for tensor in tensors)
+    return tensors
+
+
+@pytest.mark.parametrize("key_heads", [None, 1])
+@pytest.mark.parametrize("use_initial_state", [False, True])
+def test_fused_chunk_matches_reference(key_heads: int | None, use_initial_state: bool):
+    q, k, v, gate, beta, state = make_inputs(key_heads=key_heads)
+    state = state if use_initial_state else None
+    doubles = [tensor.double() for tensor in (q, k, v, gate, beta)]
+    golden = chunk_gdn(
+        *doubles,
+        None if state is None else state.double(),
+        output_final_state=True,
+        impl="reference",
+    )
+    expected = chunk_gdn(q, k, v, gate, beta, state, output_final_state=True, impl="reference")
+    actual = chunk_gdn(q, k, v, gate, beta, state, output_final_state=True, impl="fused")
+
+    assert actual[0].dtype == q.dtype
+    assert_matches_low_precision_reference(actual[0], golden[0], expected[0], "output")
+    assert_matches_low_precision_reference(actual[1], golden[1], expected[1], "final_state")
+
+
+def test_fused_chunk_packed_matches_reference():
+    q, k, v, gate, beta, _ = make_inputs(batch=1, tokens=160)
+    cu_seqlens = cumulative_sequence_offsets([64, 0, 96])
+    state = torch.randn(3, v.shape[2], _KV_DIM, _KV_DIM, device="cuda")
+
+    golden = chunk_gdn(
+        q.double(),
+        k.double(),
+        v.double(),
+        gate.double(),
+        beta.double(),
+        state.double(),
+        cu_seqlens=cu_seqlens,
+        output_final_state=True,
+        impl="reference",
+    )
+    expected = chunk_gdn(
+        q, k, v, gate, beta, state, cu_seqlens=cu_seqlens, output_final_state=True
+    )
+    actual = chunk_gdn(
+        q, k, v, gate, beta, state, cu_seqlens=cu_seqlens, output_final_state=True, impl="fused"
+    )
+
+    assert_matches_low_precision_reference(actual[0], golden[0], expected[0], "output")
+    assert_matches_low_precision_reference(actual[1], golden[1], expected[1], "final_state")
+
+
+@pytest.mark.parametrize(("key_heads", "scale"), [(None, None), (1, None), (1, 0.25)])
+def test_fused_chunk_backward_matches_reference(key_heads: int | None, scale: float | None):
+    """Autograd reduces dgate over K and dq/dk over value-head groups automatically."""
+    reference_leaves = make_inputs(key_heads=key_heads, tokens=64, requires_grad=True)
+    golden_leaves = clone_kda_inputs(tuple(tensor.double() for tensor in reference_leaves))
+    fused_leaves = clone_kda_inputs(reference_leaves)
+
+    def run(leaves: tuple[torch.Tensor, ...], impl: str) -> None:
+        q, k, v, gate, beta, state = leaves
+        output, final_state = chunk_gdn(
+            q, k, v, gate, beta, state, scale=scale, output_final_state=True, impl=impl
+        )
+        (output.float().square().mean() + final_state.float().square().mean()).backward()
+
+    run(golden_leaves, "reference")
+    run(reference_leaves, "reference")
+    run(fused_leaves, "fused")
+
+    names = ("q", "k", "v", "gate", "beta", "initial_state")
+    for name, golden, reference, fused in zip(
+        names, golden_leaves, reference_leaves, fused_leaves
+    ):
+        assert fused.grad is not None, f"missing {name} gradient"
+        assert fused.grad.shape == reference.grad.shape
+        assert_matches_low_precision_reference(fused.grad, golden.grad, reference.grad, f"d{name}")
+
+
+def test_fused_chunk_large_scale_override_stays_finite_in_fp16():
+    """The kernels apply scale in FP32; folding ``scale * sqrt(K)`` into FP16 q would inf.
+
+    The one-hot query row is the worst case: its unit component times ``6000 * sqrt(128)``
+    exceeds the FP16 maximum, while the true scaled output stays comfortably finite.
+    """
+    q, k, v, gate, beta, _ = make_inputs(tokens=64, dtype=torch.float16)
+    q[0, 0, 0] = 0.0
+    q[0, 0, 0, 0] = 1.0
+    v = v * 1e-2
+    scale = 6000.0
+
+    expected = chunk_gdn(q, k, v, gate, beta, scale=scale, impl="reference")[0]
+    actual = chunk_gdn(q, k, v, gate, beta, scale=scale, impl="fused")[0]
+    golden = chunk_gdn(
+        q.double(), k.double(), v.double(), gate.double(), beta.double(), scale=scale
+    )[0]
+
+    assert torch.isfinite(expected).all()
+    assert torch.isfinite(actual).all()
+    assert_matches_low_precision_reference(
+        actual, golden, expected, "output", source_dtype=torch.float16
+    )
+
+
+def test_fused_chunk_accepts_float64_gate_and_beta():
+    """GDN permits independent floating gate/beta dtypes; the adapter casts for KDA."""
+    q, k, v, gate, beta, _ = make_inputs(tokens=64)
+    expected = chunk_gdn(q, k, v, gate, beta, impl="fused")[0]
+    actual = chunk_gdn(q, k, v, gate.double(), beta.double(), impl="fused")[0]
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_fused_chunk_fullgraph_forward_and_backward():
+    """The adapter is torch-only composition around registered ops; fullgraph must hold."""
+    eager_inputs = make_inputs(key_heads=1, tokens=64, requires_grad=True)
+    compiled_inputs = clone_kda_inputs(eager_inputs)
+
+    def operation(*inputs):
+        return chunk_gdn(*inputs, output_final_state=True, impl="fused")
+
+    expected = operation(*eager_inputs)
+    actual = torch.compile(operation, fullgraph=True)(*compiled_inputs)
+    cotangents = tuple(torch.randn_like(tensor) for tensor in expected)
+
+    torch.testing.assert_close(actual[0], expected[0])
+    torch.testing.assert_close(actual[1], expected[1])
+
+    expected_grads = torch.autograd.grad(expected, eager_inputs, cotangents)
+    actual_grads = torch.autograd.grad(actual, compiled_inputs, cotangents)
+    for actual_grad, expected_grad in zip(actual_grads, expected_grads, strict=True):
+        torch.testing.assert_close(actual_grad, expected_grad)
+
+
+def test_fused_chunk_rejects_unsupported_head_dims():
+    q, k, v, gate, beta, _ = make_inputs(tokens=64)
+    with pytest.raises(ValueError, match="K=V=128"):
+        chunk_gdn(q[..., :64], k[..., :64], v, gate, beta, impl="fused")

--- a/test/test_kda_cute_forward.py
+++ b/test/test_kda_cute_forward.py
@@ -37,9 +37,11 @@ from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd import (
 from attn_gym.testing import strided_state_pool
 
 pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (10, 0),
-    reason="the CuTeDSL KDA forward pipeline requires CUDA capability 10.0 or newer",
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() not in ((10, 0), (10, 3)),
+    reason="the CuTeDSL KDA forward pipeline requires SM100/SM103",
 )
+
+_DEFAULT_SCALE = 128**-0.5
 
 
 def _inputs(
@@ -150,7 +152,9 @@ def test_private_chunk_kda_forward_matches_reference(dtype: torch.dtype):
     torch.manual_seed(2)
     q, k, v, gate, beta = _inputs(tokens=64, dtype=dtype)
     cumulative_gate = chunk_cumsum_ref(gate * LOG2_E, 64)
-    actual, aqk, akk = _chunk_kda_fwd_op(q, k, v, cumulative_gate, beta, None, False)
+    actual, aqk, akk = _chunk_kda_fwd_op(
+        q, k, v, cumulative_gate, beta, None, _DEFAULT_SCALE, False
+    )
     golden, _ = naive_chunk_kda(
         q.double(),
         k.double(),
@@ -172,7 +176,9 @@ def test_private_fp16_forward_factors_are_finite_at_gate_limit():
     gate = torch.full_like(q, -MAX_GATE_LOWER_BOUND_MAGNITUDE, dtype=torch.float32)
     cumulative_gate = chunk_cumsum_ref(gate * LOG2_E, 64)
 
-    output, aqk, akk = _chunk_kda_fwd_op(q, k, v, cumulative_gate, beta, None, False)
+    output, aqk, akk = _chunk_kda_fwd_op(
+        q, k, v, cumulative_gate, beta, None, _DEFAULT_SCALE, False
+    )
 
     for tensor in (output, aqk, akk):
         assert tensor.dtype == torch.float16
@@ -564,12 +570,12 @@ def test_chunk_kda_selects_direct_dense_or_ragged_route(
     module = importlib.import_module("attn_gym.linear.kda.impl.fused")
     routes = []
 
-    def dense_forward(q, _k, v, _gate, _beta, _state, _tune):
+    def dense_forward(q, _k, v, _gate, _beta, _state, _scale, _tune):
         routes.append("dense")
         factors = q.new_empty((*q.shape[:3], 64))
         return torch.empty_like(v), factors, factors
 
-    def ragged_forward(q, _k, v, _gate, _beta, _state, _cu_seqlens, _chunk_offsets, _tune):
+    def ragged_forward(q, _k, v, _gate, _beta, _state, _cu_seqlens, _chunk_offsets, _scale, _tune):
         routes.append("ragged")
         factors = q.new_empty((*q.shape[:3], 64))
         return torch.empty_like(v), factors, factors
@@ -856,6 +862,7 @@ def test_chunk_kda_op_registration(dtype):
         cumulative_gate.detach(),
         beta.detach(),
         initial_state.detach(),
+        _DEFAULT_SCALE,
         True,
     )
     torch.library.opcheck(_chunk_kda_fwd_op, args, rtol=2e-2, atol=2e-3)
@@ -906,6 +913,7 @@ def test_chunk_kda_backward_op_registration(dtype):
             cumulative_gate,
             beta,
             initial_state,
+            _DEFAULT_SCALE,
             True,
         )
     torch.library.opcheck(
@@ -923,6 +931,7 @@ def test_chunk_kda_backward_op_registration(dtype):
             None,
             torch.randn_like(state),
             None,
+            _DEFAULT_SCALE,
             False,
             True,
         ),
@@ -945,6 +954,7 @@ def test_chunk_kda_backward_op_registration(dtype):
             None,
             torch.randn_like(state),
             initial_state.detach(),
+            _DEFAULT_SCALE,
             False,
             True,
         ),

--- a/test/test_kda_kernels.py
+++ b/test/test_kda_kernels.py
@@ -1226,6 +1226,7 @@ def test_chunk_kda_bwd_wy_dqkg_fused_cute():
         dh,
         dv,
         None,
+        scale=scale,
         chunk_size=64,
     )
 

--- a/test/test_kda_ragged_autograd_ops.py
+++ b/test/test_kda_ragged_autograd_ops.py
@@ -24,6 +24,9 @@ pytestmark = pytest.mark.skipif(
 )
 
 
+_DEFAULT_SCALE = 128**-0.5
+
+
 def test_ragged_custom_op_registrations():
     q, k, v, gate, beta = make_kda_test_inputs(128, requires_grad=True)
     initial_state = (torch.randn(2, 1, 128, 128, device="cuda") / 8).requires_grad_()
@@ -36,6 +39,7 @@ def test_ragged_custom_op_registrations():
         initial_state.detach(),
         cu_seqlens,
         metadata.chunk_offsets,
+        _DEFAULT_SCALE,
         True,
     )
     torch.library.opcheck(
@@ -67,6 +71,7 @@ def test_ragged_custom_op_registrations():
             torch.randn_like(output),
             torch.randn_like(state),
             initial_state.detach(),
+            _DEFAULT_SCALE,
             False,
             True,
         ),
@@ -80,6 +85,7 @@ def test_ragged_custom_op_registrations():
         None,
         cu_seqlens,
         metadata.chunk_offsets,
+        _DEFAULT_SCALE,
         True,
     )
     with torch.no_grad():
@@ -95,6 +101,7 @@ def test_ragged_custom_op_registrations():
             torch.randn_like(output),
             None,
             None,
+            _DEFAULT_SCALE,
             False,
             True,
         ),

--- a/test/test_kda_ragged_bwd_wy.py
+++ b/test/test_kda_ragged_bwd_wy.py
@@ -66,7 +66,7 @@ def _inputs(
 
 
 def _run(inputs: StageInputs, metadata):
-    return chunk_kda_bwd_wy_dqkg(*inputs, metadata)
+    return chunk_kda_bwd_wy_dqkg(*inputs, metadata, scale=128**-0.5)
 
 
 def _sequence_local_reference(inputs: StageInputs, lengths: list[int]):
@@ -232,7 +232,7 @@ def test_ragged_wy_cuda_graph_replay():
     def operation(*args):
         *stage_tensors, offsets = args
         metadata = prepare_ragged_chunk_metadata(offsets, tokens, 64)
-        return chunk_kda_bwd_wy_dqkg(*stage_tensors, metadata)
+        return chunk_kda_bwd_wy_dqkg(*stage_tensors, metadata, scale=128**-0.5)
 
     operation(*inputs, cu_seqlens)
     torch.cuda.synchronize()

--- a/test/test_kda_recurrent.py
+++ b/test/test_kda_recurrent.py
@@ -273,6 +273,37 @@ def test_recurrent_agrees_with_chunked_core():
     torch.testing.assert_close(recurrent_state, chunked_state, rtol=5e-2, atol=5e-2)
 
 
+def test_chunk_scale_override_matches_query_prescale():
+    """``scale`` post-multiplies the output, which equals scaling FP32 queries directly."""
+    from attn_gym.linear import chunk_kda
+
+    q, k, v, gate, beta, state = _inputs(tokens=32, initial_state=True, seed=5)
+    scale, key_dim = 0.25, q.shape[-1]
+    scaled = chunk_kda(
+        q, k, v, gate, beta, state, scale=scale, output_final_state=True, impl="reference"
+    )
+    expected = chunk_kda(
+        q * (scale * key_dim**0.5),
+        k,
+        v,
+        gate,
+        beta,
+        state,
+        output_final_state=True,
+        impl="reference",
+    )
+    torch.testing.assert_close(scaled[0], expected[0])
+    torch.testing.assert_close(scaled[1], expected[1], rtol=0, atol=0)
+
+
+def test_chunk_scale_rejects_bool():
+    from attn_gym.linear import chunk_kda
+
+    q, k, v, gate, beta, _ = _inputs(tokens=3)
+    with pytest.raises(TypeError, match="scale must be a real scalar"):
+        chunk_kda(q, k, v, gate, beta, scale=True, impl="reference")
+
+
 @pytest.mark.parametrize("packed", [False, True])
 def test_recurrent_paged_matches_gather_scatter(packed: bool):
     """Slot indexing equals a native gather, dense scan, and scatter round trip."""


### PR DESCRIPTION
Stacked PRs:
 * #395
 * __->__#394


--- --- ---

Add fused chunk_gdn over the KDA chunk pipeline

## Human Note

## Agent note

Implement chunk_gdn(impl="fused") as an adapter over the fused KDA chunk pipeline: GDN's
recurrence is KDA's with one decay shared by every key channel, so expanding the scalar gate per
channel (and repeat_interleave-ing grouped q/k heads) computes it exactly on the existing CuTe
kernels. The expansions stay inside autograd, whose backward reduces the gate gradient over K and
the q/k gradients over each value-head group, so training works end to end with no new kernels.
Scale overrides fold into q since the core fixes 1/sqrt(K). Requires CUDA capability 10.0 and
K = V = 128, enforced by the shared core validation; CPU calls raise before backend import.

Tests pin forward (dense, grouped, initial-state, packed, scale override) and full backward
gradients against the eager reference with FP64 measuring-stick budgets. GB200, B4/Hk4/Hv12/128:
forward 181.7 us at T1024 and 676.2 us at T4096 vs 142.8/536.2 us for the raw equal-heads
chunk_kda core -- the ~26% adapter overhead (gate expansion + K-redundant cumsum) is the headroom
a scalar-gate specialization of the intra stage can later reclaim.

## Test Plan

```bash
.venv/bin/prek run --files attn_gym/linear/gdn/impl/fused.py attn_gym/linear/gdn/ops.py attn_gym/linear/gdn/api.py attn_gym/testing/__init__.py test/linear/test_gdn.py test/linear/test_gdn_chunk_fused.py
gpu-run auto -- .venv/bin/pytest -q test/linear/test_gdn_chunk_fused.py
gpu-run auto -- .venv/bin/pytest -q -n 6 test/linear/ test/test_kda_recurrent.py test/test_kda_cute_forward.py
gpu-run auto -- .venv/bin/python agent_space/bench_chunk_gdn.py adapter
```