### PR TITLE
Support grouped q/k heads in recurrent KDA

### DIFF
--- a/attn_gym/linear/_delta_rule/decode.py
+++ b/attn_gym/linear/_delta_rule/decode.py
@@ -24,8 +24,9 @@ Gate transforms (`USE_LOWER_BOUND` selects the first):
     bounded:  lower_bound * sigmoid(exp(A_log) * (raw_gate + dt_bias))
     softplus: -exp(A_log) * softplus(raw_gate + dt_bias)
 
-Scalar-gated callers may pass fewer q/k heads than value heads (grouped heads): each block of
-``H // HK`` consecutive value heads shares one q/k head inside the packed buffer.
+Callers may pass fewer q/k heads than value heads (multi-value attention): each block of
+``H // HK`` consecutive value heads shares one q/k head inside the packed buffer, while the
+gate stays per value head.
 """
 
 from __future__ import annotations
@@ -120,6 +121,7 @@ def _recurrent_delta_rule_decode_kernel(
         b_gate_input = tl.load(raw_gate + i_n * gate_token_stride + i_h).to(tl.float32)
         b_gate_input += tl.load(dt_bias + i_h).to(tl.float32)
     else:
+        # The gate decays each value head's own state; only q/k are shared across a group.
         p_gate = raw_gate + i_n * gate_token_stride + ptr_offset((i_h, o_k), (K, 1))
         b_gate_input = tl.load(p_gate, mask=m_k, other=0.0).to(tl.float32)
         b_gate_input += tl.load(dt_bias + ptr_offset((i_h, o_k), (K, 1)), mask=m_k, other=0.0).to(
@@ -175,9 +177,9 @@ def launch_recurrent_delta_rule_decode(
 
     Args:
         packed_qkv: ``[B, HK*K | HK*K | H*V]`` per-token buffer; within each section head
-            rows are contiguous. ``HK == key_heads`` may divide ``H`` for scalar gates.
-        raw_gate: Unactivated token-major gate, ``[B, H]`` for ``GateKind.SCALAR`` or
-            ``[B, H, K]`` for ``GateKind.VECTOR``.
+            rows are contiguous. ``HK == key_heads`` may divide ``H``.
+        raw_gate: Unactivated token-major gate per value head, ``[B, H]`` for
+            ``GateKind.SCALAR`` or ``[B, H, K]`` for ``GateKind.VECTOR``.
         raw_beta: Unactivated token-major write gate shaped ``[B, H]``, activated in-kernel
             as ``sigmoid``.
         A_log: FP32 per-head log decay parameter shaped ``[H]``.

--- a/attn_gym/linear/_delta_rule/recurrent.py
+++ b/attn_gym/linear/_delta_rule/recurrent.py
@@ -83,9 +83,10 @@ def _recurrent_delta_rule_fwd_kernel(
 ):
     """Scan one sequence/head/value tile while retaining the FP32 state in registers.
 
-    Programs are indexed by value head. Scalar-gated callers may share one q/k head across
-    each block of ``H // HK`` consecutive value heads; vector-gated KDA passes ``HK == H``,
-    which reduces every ``row_k`` to the ungrouped ``row``.
+    Programs are indexed by value head. With multi-value attention (MVA, ``HK < H``) each
+    block of ``H // HK`` consecutive value heads reads one shared q/k head, while gates,
+    beta, and state stay per value head: grouping shrinks the q/k projections, and each
+    value head's state remains independent only if its decay is.
     """
     pid = tl.program_id(0).to(tl.int64)
     NV = tl.cdiv(V, BV)
@@ -144,7 +145,7 @@ def _recurrent_delta_rule_fwd_kernel(
         if SCALAR_GATE:
             b_g = tl.load(gate + row).to(tl.float32)
         else:
-            b_g = tl.load(gate + ptr_offset((row_k, o_k), (K, 1)), mask=m_k, other=0.0).to(
+            b_g = tl.load(gate + ptr_offset((row, o_k), (K, 1)), mask=m_k, other=0.0).to(
                 tl.float32
             )
         b_beta = tl.load(beta + row).to(tl.float32)
@@ -209,14 +210,14 @@ def launch_recurrent_delta_rule_fwd(
     """Launch a scalar- or vector-gated recurrent delta-rule specialization.
 
     Args:
-        q: Queries shaped ``[B, T, HK, K]``; packed callers pass ``B == 1``. Scalar-gated
-            callers may pass ``HK`` as a divisor of the value head count ``H`` (grouped
-            heads): each block of ``H // HK`` consecutive value heads shares one query/key
-            head, so callers never materialize a ``repeat_interleave``.
+        q: Queries shaped ``[B, T, HK, K]``; packed callers pass ``B == 1``. ``HK`` may be
+            a divisor of the value head count ``H`` (grouped heads): each block of
+            ``H // HK`` consecutive value heads shares one query/key head, so callers
+            never materialize a ``repeat_interleave``. Gates stay per value head.
         k: Keys shaped like ``q``.
         v: Values shaped ``[B, T, H, V]``.
-        gate: Natural-log decay, shaped ``[B, T, H]`` for ``GateKind.SCALAR`` or like ``q``
-            for ``GateKind.VECTOR``.
+        gate: Natural-log decay per value head, shaped ``[B, T, H]`` for
+            ``GateKind.SCALAR`` or ``[B, T, H, K]`` for ``GateKind.VECTOR``.
         beta: Per-token write gate shaped ``[B, T, H]``.
         initial_state: Optional FP32 starting state shaped ``[N, H, K, V]``, or the mutable
             ``[slots, H, V, K]`` pool that ``state_indices`` addresses in paged mode.
@@ -243,7 +244,9 @@ def launch_recurrent_delta_rule_fwd(
     """
     assert k.shape == q.shape
     assert v.shape[:2] == q.shape[:2]
-    assert gate.shape == (v.shape[:-1] if gate_kind is GateKind.SCALAR else q.shape)
+    assert gate.shape == (
+        v.shape[:-1] if gate_kind is GateKind.SCALAR else (*v.shape[:-1], q.shape[-1])
+    )
     assert beta.shape == v.shape[:-1]
     assert all(tensor.is_contiguous() for tensor in (q, k, v, gate, beta))
     assert has_initial_state is None or state_indices is not None
@@ -251,8 +254,6 @@ def launch_recurrent_delta_rule_fwd(
     batch, tokens, key_heads, key_dim = q.shape
     heads, value_dim = v.shape[2], v.shape[-1]
     assert heads % key_heads == 0
-    # No caller groups vector gates; keep that unsupported mode out of the shared contract.
-    assert gate_kind is GateKind.SCALAR or key_heads == heads
     if initial_state is not None:
         if state_indices is None:
             assert initial_state.is_contiguous()

--- a/attn_gym/linear/kda/api.py
+++ b/attn_gym/linear/kda/api.py
@@ -232,13 +232,17 @@ def recurrent_kda(
     """Apply recurrent KDA for decoding and inference prefill.
 
     Args:
-        q: Queries shaped ``[B, T, H, K]``, scaled by ``1/sqrt(K)`` internally.
+        q: Queries shaped ``[B, T, HK, K]``, scaled by ``1/sqrt(K)`` internally. ``HK``
+            may divide the value head count ``H`` for multi-value attention (MVA): each
+            block of ``H // HK`` consecutive value heads shares one query/key head, while
+            the gate, beta, and state stay per value head.
         k: Keys shaped like ``q``.
         v: Values shaped ``[B, T, H, V]``.
-        gate: Finite, nonpositive per-token natural-log decay shaped like ``q``. At
-            each token the previous state is multiplied channelwise by ``exp(gate)``.
-            Use the same non-cumulative representation for chunked and recurrent
-            execution; recurrent execution has no chunk-rebase lower limit.
+        gate: Finite, nonpositive per-token natural-log decay shaped ``[B, T, H, K]``,
+            one decay vector per value head. At each token the previous state is
+            multiplied channelwise by ``exp(gate)``. Use the same non-cumulative
+            representation for chunked and recurrent execution; recurrent execution has
+            no chunk-rebase lower limit.
         beta: Per-token write gate shaped ``[B, T, H]``.
         initial_state: Starting recurrent state, with one ``[H, K, V]`` entry per
             logical sequence.
@@ -293,6 +297,7 @@ def recurrent_kda(
         cu_seqlens,
         op_name="recurrent_kda",
         gate_name="gate",
+        allow_grouped_heads=True,
     )
     if state_indices is not None:
         if initial_state is None:

--- a/attn_gym/linear/kda/impl/reference.py
+++ b/attn_gym/linear/kda/impl/reference.py
@@ -92,6 +92,11 @@ def reference_kda(
     q, k, v = (tensor.float() for tensor in (q, k, v))
     gate = gate.float()
     beta = beta.float()
+    if q.shape[2] != v.shape[2]:
+        # Grouped heads: expand each shared query/key head across its value-head group.
+        # The gate already carries one decay per value head and passes through unexpanded.
+        groups = v.shape[2] // q.shape[2]
+        q, k = (tensor.repeat_interleave(groups, dim=2) for tensor in (q, k))
     if initial_state is not None:
         initial_state = initial_state.float()
     # ``.float()`` casts alone do not stop an active autocast region from

--- a/attn_gym/linear/kda/ops.py
+++ b/attn_gym/linear/kda/ops.py
@@ -596,8 +596,9 @@ def _recurrent_fwd_fake(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     del k, gate, beta, initial_state, autotune
     num_sequences = q.shape[0] if cu_seqlens is None else cu_seqlens.shape[0] - 1
+    # The state carries one [K, V] slab per value head; grouped callers have v.shape[2] > HK.
     final_state = q.new_empty(
-        num_sequences, q.shape[2], q.shape[3], v.shape[-1], dtype=torch.float32
+        num_sequences, v.shape[2], q.shape[3], v.shape[-1], dtype=torch.float32
     )
     return torch.empty_like(v, dtype=q.dtype), final_state
 

--- a/attn_gym/linear/kda/validation.py
+++ b/attn_gym/linear/kda/validation.py
@@ -28,20 +28,38 @@ def validate_kda_inputs(
     *,
     op_name: str,
     gate_name: str,
+    allow_grouped_heads: bool = False,
 ) -> None:
-    """Validate the shared KDA operation contract before normalizing inputs."""
+    """Validate the shared KDA operation contract before normalizing inputs.
+
+    ``allow_grouped_heads`` admits value-head counts that are positive multiples of the
+    q/k head count (the recurrent forms map heads in-kernel); the chunk pipeline requires
+    equal head counts. This is the multi-value attention (MVA) pattern of "Transformers
+    are SSMs" (arXiv:2405.21060, section 7.2): only q/k are shared across a group, while
+    the gate and beta drive each value head's state update and keep one entry per value
+    head.
+    """
     if q.ndim != 4:
         raise ValueError(f"q must have shape [B, T, H, K], got {tuple(q.shape)}")
-    batch, tokens, heads, key_dim = q.shape
-    if batch == 0 or tokens == 0 or heads == 0 or key_dim == 0:
+    batch, tokens, key_heads, key_dim = q.shape
+    if batch == 0 or tokens == 0 or key_heads == 0 or key_dim == 0:
         raise ValueError(f"q must have nonempty dimensions, got {tuple(q.shape)}")
     if k.shape != q.shape:
         raise ValueError(f"k must have shape {tuple(q.shape)}, got {tuple(k.shape)}")
-    if gate.shape != q.shape:
-        raise ValueError(f"{gate_name} must have shape {tuple(q.shape)}, got {tuple(gate.shape)}")
-    if v.ndim != 4 or v.shape[:3] != (batch, tokens, heads) or v.shape[-1] < 1:
+    if v.ndim != 4 or v.shape[:2] != (batch, tokens) or v.shape[-1] < 1:
+        raise ValueError(f"v must have shape [{batch}, {tokens}, H, V], got {tuple(v.shape)}")
+    heads = v.shape[2]
+    if heads != key_heads and not (allow_grouped_heads and heads != 0 and heads % key_heads == 0):
+        message = (
+            f"v heads must be a positive multiple of q heads for {op_name}, "
+            if allow_grouped_heads
+            else f"v heads must match q heads for {op_name}, "
+        )
+        raise ValueError(message + f"got {heads} value heads for {key_heads} query heads")
+    if gate.shape != (batch, tokens, heads, key_dim):
         raise ValueError(
-            f"v must have shape [{batch}, {tokens}, {heads}, V], got {tuple(v.shape)}"
+            f"{gate_name} must have shape {(batch, tokens, heads, key_dim)}, "
+            f"got {tuple(gate.shape)}"
         )
     if beta.shape != (batch, tokens, heads):
         raise ValueError(f"beta must have shape {(batch, tokens, heads)}, got {tuple(beta.shape)}")

--- a/test/test_kda_recurrent.py
+++ b/test/test_kda_recurrent.py
@@ -159,6 +159,95 @@ def test_recurrent_packed_capacity_and_empty_slots():
         )
 
 
+def test_recurrent_grouped_heads_match_expanded_heads():
+    """Sharing q/k across a value-head group must equal an explicit repeat_interleave.
+
+    Only q/k are grouped; the gate carries an independent decay per value head, so it is
+    identical in both calls rather than expanded.
+    """
+    q, k, v, gate, beta, _ = _inputs(batch=2, tokens=17, heads=2, seed=11)
+    groups = 3
+    v = v.repeat_interleave(groups, dim=2).contiguous()
+    beta = beta.repeat_interleave(groups, dim=2).contiguous()
+    # Independent per-value-head decays: grouping must not collapse state capacity.
+    gate = -torch.rand(2, 17, v.shape[2], q.shape[3], device="cuda") * 3.0
+    state = torch.randn(2, v.shape[2], q.shape[3], v.shape[-1], device="cuda")
+
+    # Fixed heuristics keep both calls on one kernel specialization so equality is exact;
+    # HK is an autotune key, so autotuned calls may pick different tiles.
+    grouped_output, grouped_state = recurrent_kda(
+        q, k, v, gate, beta, state, output_final_state=True, autotune=False
+    )
+    expanded_output, expanded_state = recurrent_kda(
+        q.repeat_interleave(groups, dim=2),
+        k.repeat_interleave(groups, dim=2),
+        v,
+        gate,
+        beta,
+        state,
+        output_final_state=True,
+        autotune=False,
+    )
+
+    torch.testing.assert_close(grouped_output, expanded_output, rtol=0, atol=0)
+    torch.testing.assert_close(grouped_state, expanded_state, rtol=0, atol=0)
+
+
+def test_recurrent_grouped_heads_match_reference():
+    """The grouped fused path agrees with the expanding reference oracle."""
+    q, k, v, gate, beta, _ = _inputs(batch=2, tokens=9, heads=2, seed=12)
+    v = v.repeat_interleave(2, dim=2).contiguous()
+    beta = beta.repeat_interleave(2, dim=2).contiguous()
+    gate = -torch.rand(2, 9, v.shape[2], q.shape[3], device="cuda") * 3.0
+    state = torch.randn(2, v.shape[2], q.shape[3], v.shape[-1], device="cuda")
+
+    fused = recurrent_kda(q, k, v, gate, beta, state, output_final_state=True)
+    reference = recurrent_kda(
+        q, k, v, gate, beta, state, output_final_state=True, impl="reference"
+    )
+
+    torch.testing.assert_close(fused[0], reference[0], rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(fused[1], reference[1], rtol=1e-5, atol=1e-5)
+
+
+def test_grouped_heads_require_divisible_counts():
+    q, k, v, gate, beta, _ = _inputs(batch=2, tokens=3, heads=2)
+    bad_v = v.repeat_interleave(2, dim=2)[:, :, :3].contiguous()
+    bad_beta = beta.repeat_interleave(2, dim=2)[:, :, :3].contiguous()
+    with pytest.raises(ValueError, match="positive multiple of q heads"):
+        recurrent_kda(q, k, bad_v, gate, bad_beta)
+
+
+def test_grouped_heads_require_per_value_head_gate():
+    """A gate shaped like grouped q/k is rejected: decays belong to value heads."""
+    q, k, v, gate, beta, _ = _inputs(batch=2, tokens=3, heads=2)
+    grouped_v = v.repeat_interleave(2, dim=2).contiguous()
+    grouped_beta = beta.repeat_interleave(2, dim=2).contiguous()
+    with pytest.raises(ValueError, match="gate must have shape"):
+        recurrent_kda(q, k, grouped_v, gate, grouped_beta)
+
+
+def test_chunk_rejects_grouped_heads():
+    """The chunk pipeline requires equal head counts; only recurrent forms group."""
+    from attn_gym.linear import chunk_kda
+
+    q, k, v, gate, beta, _ = _inputs(batch=2, tokens=64, heads=2)
+    grouped_v = v.repeat_interleave(2, dim=2).contiguous()
+    grouped_beta = beta.repeat_interleave(2, dim=2).contiguous()
+    with pytest.raises(ValueError, match="v heads must match q heads"):
+        chunk_kda(q, k, grouped_v, gate, grouped_beta)
+
+
+def test_recurrent_grouped_heads_registration():
+    """Grouped-head fakes must size the final state from value heads, not query heads."""
+    q, k, v, gate, beta, _ = _inputs(batch=1, tokens=3, heads=2)
+    v = v.repeat_interleave(3, dim=2).contiguous()
+    beta = beta.repeat_interleave(3, dim=2).contiguous()
+    gate = gate.repeat_interleave(3, dim=2).contiguous()
+    state = torch.randn(1, v.shape[2], q.shape[3], v.shape[-1], device="cuda")
+    torch.library.opcheck(_recurrent_fwd_op, (q, k, v, gate, beta, state, None, True))
+
+
 @pytest.mark.skipif(not BLACKWELL, reason="chunk_kda requires CUDA capability 10.0")
 def test_recurrent_agrees_with_chunked_core():
     """Cross-check the decode scan against the training core on shared inputs."""

--- a/test/test_kda_recurrent_decode.py
+++ b/test/test_kda_recurrent_decode.py
@@ -160,6 +160,65 @@ def test_recurrent_decode_matches_reference(
     torch.testing.assert_close(state_cache, expected_cache, rtol=tolerance, atol=tolerance)
 
 
+def test_decode_launcher_grouped_vector_gate_matches_expanded():
+    """Grouped vector-gate decode shares only q/k; the gate stays per value head.
+
+    The public KDA decode pins equal head counts, so this pins the shared launcher's
+    multi-value attention addressing directly against explicit q/k expansion.
+    """
+    from attn_gym.linear._delta_rule.decode import (
+        GateTransform,
+        launch_recurrent_delta_rule_decode,
+    )
+    from attn_gym.linear._delta_rule.recurrent import GateKind
+
+    torch.manual_seed(0)
+    batch, key_heads, heads, dim = 3, 2, 6, 32
+    groups = heads // key_heads
+    q = torch.randn(batch, key_heads, dim, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn_like(q)
+    v = torch.randn(batch, heads, dim, device="cuda", dtype=torch.bfloat16)
+    # Independent per-value-head decays: grouping must not collapse state capacity.
+    raw_gate = torch.randn(1, batch, heads, dim, device="cuda", dtype=torch.bfloat16)
+    raw_beta = torch.randn(1, batch, heads, device="cuda", dtype=torch.bfloat16)
+    A_log = 0.1 * torch.randn(heads, device="cuda")
+    dt_bias = 0.1 * torch.randn(heads, dim, device="cuda")
+    state_indices = torch.tensor([1, 2, 3], device="cuda", dtype=torch.int32)
+
+    def run(query: torch.Tensor, key: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        packed = torch.cat((query.flatten(1), key.flatten(1), v.flatten(1)), dim=1)
+        pool = torch.randn(4, heads, dim, dim, device="cuda", dtype=torch.float32)
+        torch.manual_seed(7)
+        pool.normal_()
+        output = packed.new_empty(batch, heads, dim)
+        launch_recurrent_delta_rule_decode(
+            packed,
+            raw_gate[0],
+            raw_beta[0],
+            A_log,
+            dt_bias,
+            pool,
+            state_indices,
+            output,
+            gate_kind=GateKind.VECTOR,
+            gate_transform=GateTransform.SOFTPLUS,
+            key_heads=query.shape[1],
+            lower_bound=0.0,
+            scale=dim**-0.5,
+            has_initial_state=None,
+            op_name="test",
+        )
+        return output, pool
+
+    grouped_output, grouped_pool = run(q, k)
+    expanded_output, expanded_pool = run(
+        q.repeat_interleave(groups, dim=1), k.repeat_interleave(groups, dim=1)
+    )
+
+    torch.testing.assert_close(grouped_output, expanded_output, rtol=0, atol=0)
+    torch.testing.assert_close(grouped_pool, expanded_pool, rtol=0, atol=0)
+
+
 def test_recurrent_decode_fresh_slots_start_from_zero():
     """has_initial_state=False treats slot contents as garbage and overwrites them."""
     inputs = _decode_inputs()


### PR DESCRIPTION
Stacked PRs:
 * #395
 * #394
 * __->__#396


--- --- ---

Support grouped q/k heads in recurrent KDA

## Human Note

## Agent note

Extend the grouped-head contract from GDN to the KDA recurrent forms, with grouped value
semantics: each block of H // HK consecutive value heads shares one q/k head, while the gate,
beta, and state keep one entry per value head -- grouping shrinks the q/k projections, and each
value head's state stays independent only if its decay does. The vector gate is therefore shaped
[B, T, H, K] over value heads (review caught an earlier draft that shared the gate with q/k,
which would silently collapse the grouped state capacity; the released GVA-style architectures
project their gates per value head). validate_kda_inputs relaxes for recurrent_kda only (the
chunk pipeline keeps requiring equal head counts), the FP32 reference wrapper expands q/k and
passes the per-value-head gate through, and the recurrent fake sizes its state from value heads.
Grouped tests pin exact equality against explicit q/k expansion with independent per-value-head
decays, reference parity, per-value-head gate shape rejection, divisibility rejection, chunk
strictness, and a grouped opcheck.

## Test Plan

```bash
.venv/bin/prek run --files attn_gym/linear/_delta_rule/recurrent.py attn_gym/linear/_delta_rule/decode.py attn_gym/linear/kda/validation.py attn_gym/linear/kda/impl/reference.py attn_gym/linear/kda/api.py test/test_kda_recurrent.py
gpu-run auto -- .venv/bin/pytest -q -n 6 test/test_kda_recurrent.py test/test_kda_recurrent_decode.py test/linear/ test/test_kda_cute_forward.py test/test_kda_compile_dynamic_shapes.py
```