### PR TITLE
Refactor Mega kernel storage with CuTe tensors

### DIFF
--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_bprop_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_bprop_f16.py
@@ -115,7 +115,12 @@ from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.barrier import (
     PipelineState,
     Producer,
 )
-from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.handles import MmaDesc, SmemTile, tma_slice_runtime_desc
+from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.handles import (
+    MmaDesc,
+    SmemTile,
+    smem_data_ptr,
+    tma_slice_runtime_desc,
+)
 from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.mma import mma_ss, mma_step, mma_ts_step
 from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.swizzle import swizzle_lin_S, swizzle_xor_128b
 from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.tma import tma_load_tile, tma_store_commit, tma_store_tile, tma_store_wait, tma_tensormap_acquire
@@ -475,15 +480,15 @@ def epilogue_warp(
             decay_stage = chunk_serial % cfg.smem_decay_stages
             intermediate_stage = chunk_serial % cfg.smem_intermediate_stages
             raw_stage = raw_index.idx
-            sK_inv_ptr = sK_inv_raw.data_ptr() + decay_stage * (cfg.b_t * cfg.d_k)
-            sQ_decay_ptr = sQ_decay_raw.data_ptr() + decay_stage * (cfg.b_t * cfg.d_k)
-            sDo_ptr = sDo_raw.data_ptr() + raw_stage * (cfg.d_v * cfg.b_t)
-            sIntermediate_ptr = sIntermediate_raw.data_ptr() + intermediate_stage * (cfg.intermediate_tiles * cfg.b_t * cfg.b_t)
+            sK_inv_ptr = smem_data_ptr(sK_inv_raw) + decay_stage * (cfg.b_t * cfg.d_k)
+            sQ_decay_ptr = smem_data_ptr(sQ_decay_raw) + decay_stage * (cfg.b_t * cfg.d_k)
+            sDo_ptr = smem_data_ptr(sDo_raw) + raw_stage * (cfg.d_v * cfg.b_t)
+            sIntermediate_ptr = smem_data_ptr(sIntermediate_raw) + intermediate_stage * (cfg.intermediate_tiles * cfg.b_t * cfg.b_t)
 
             # ---- A = tril_incl(Q_decay @ K_inv^T) --------------------------------
             bars.mb_a_done[intermediate_stage].wait(((chunk_serial // cfg.smem_intermediate_stages) + 1) % 2)
             bars.mb_q_decay_k_restore_ready[decay_stage].wait((chunk_serial // cfg.smem_decay_stages) % 2)
-            a_acc = cutlass.Array(cutlass.Float32, 8, alignment=16)
+            a_acc = cute.make_rmem_tensor((8,), cutlass.Float32)
             for accum_idx in cutlass.range_constexpr(8):
                 a_acc[accum_idx] = cutlass.Float32(0.0)
             for k_block in cutlass.range_constexpr(cfg.d_k // 16):
@@ -529,7 +534,7 @@ def epilogue_warp(
             # ---- dA = tril_incl(dO @ U^T) ----------------------------------------
             bars.mb_u_smem_ready.wait(u_index.phase)
             u_index = advance(u_index, 1)
-            da_acc = cutlass.Array(cutlass.Float32, 8, alignment=16)
+            da_acc = cute.make_rmem_tensor((8,), cutlass.Float32)
             for accum_idx in cutlass.range_constexpr(8):
                 da_acc[accum_idx] = cutlass.Float32(0.0)
             for k_block in cutlass.range_constexpr(cfg.d_v // 16):
@@ -543,7 +548,7 @@ def epilogue_warp(
                 b_col = k_block * 16 + rhs_col_offset
                 b_seg = b_col // 64
                 b_frag = nvvm.ldmatrix(
-                    sU_raw.data_ptr() + b_seg * (cfg.b_t * 64) + rhs_row_coord * 64 + swizzle_xor_128b(rhs_row_coord, b_col - b_seg * 64, elem_bytes=2),
+                    smem_data_ptr(sU_raw) + b_seg * (cfg.b_t * 64) + rhs_row_coord * 64 + swizzle_xor_128b(rhs_row_coord, b_col - b_seg * 64, elem_bytes=2),
                     4,
                     nvvm.MMALayout.ROW,
                 )
@@ -723,17 +728,17 @@ def super_mma_warp(
             chunk_serial = chunk_serial_base + rev_idx
             decay_stage = chunk_serial % cfg.smem_decay_stages
             intermediate_stage = chunk_serial % cfg.smem_intermediate_stages
-            sBeta_ptr = sBeta_raw.data_ptr() + (chunk_serial % cfg.smem_beta_stages) * cfg.b_t
-            sK_inv_ptr = sK_inv_raw.data_ptr() + decay_stage * (cfg.b_t * cfg.d_k)
-            sK_decay_ptr = sK_decay_raw.data_ptr() + decay_stage * (cfg.b_t * cfg.d_k)
-            sIntermediate_ptr = sIntermediate_raw.data_ptr() + intermediate_stage * (cfg.intermediate_tiles * cfg.b_t * cfg.b_t)
+            sBeta_ptr = smem_data_ptr(sBeta_raw) + (chunk_serial % cfg.smem_beta_stages) * cfg.b_t
+            sK_inv_ptr = smem_data_ptr(sK_inv_raw) + decay_stage * (cfg.b_t * cfg.d_k)
+            sK_decay_ptr = smem_data_ptr(sK_decay_raw) + decay_stage * (cfg.b_t * cfg.d_k)
+            sIntermediate_ptr = smem_data_ptr(sIntermediate_raw) + intermediate_stage * (cfg.intermediate_tiles * cfg.b_t * cfg.b_t)
 
             bars.mb_t_inv_done[intermediate_stage].wait(((chunk_serial // cfg.smem_intermediate_stages) + 1) % 2)
 
             # ---- KK = K_decay @ K_inv^T ------------------------------------------
             bars.mb_k_decay_inv_ready[decay_stage].wait((chunk_serial // cfg.smem_decay_stages) % 2)
             kk_lhs_row = lhs_row_coord
-            kk_acc = cutlass.Array(cutlass.Float32, 8, alignment=16)
+            kk_acc = cute.make_rmem_tensor((8,), cutlass.Float32)
             for accum_idx in cutlass.range_constexpr(8):
                 kk_acc[accum_idx] = cutlass.Float32(0.0)
             for k_block in cutlass.range_constexpr(cfg.d_k // 16):
@@ -766,7 +771,7 @@ def super_mma_warp(
             beta_lo = (sBeta_ptr + row_lo).load().to(cutlass.Float32)
             beta_hi = (sBeta_ptr + row_hi).load().to(cutlass.Float32)
             bars.mb_beta_done[chunk_serial % cfg.smem_beta_stages].arrive()
-            l_regs = cutlass.Array(cutlass.Float32, 8, alignment=16)
+            l_regs = cute.make_rmem_tensor((8,), cutlass.Float32)
             for accum_idx in cutlass.range_constexpr(8):
                 beta_scale = beta_lo if accum_idx % 4 < 2 else beta_hi
                 lower = kk_acc[accum_idx] if (tril_strict_mask >> accum_idx) & 1 else cutlass.Float32(0.0)
@@ -777,7 +782,7 @@ def super_mma_warp(
             l_a3 = fp32_to_fp16(l_regs[6], l_regs[7], dtype=cfg.io_dtype)
             l_values = cutlass.Vector.from_elements((l_a0, l_a1, l_a2, l_a3), cutlass.Int32).bitcast(cfg.io_dtype).to(cutlass.Float32)
 
-            tinv_acc = cutlass.Array(cutlass.Float32, 8, alignment=16)
+            tinv_acc = cute.make_rmem_tensor((8,), cutlass.Float32)
             for accum_idx in cutlass.range_constexpr(8):
                 eye = cutlass.Float32(1.0) if (eye_mask >> accum_idx) & 1 else cutlass.Float32(0.0)
                 tinv_acc[accum_idx] = eye - l_values[accum_idx]
@@ -785,7 +790,7 @@ def super_mma_warp(
             lpow_a0, lpow_a1, lpow_a2, lpow_a3 = l_a0, l_a1, l_a2, l_a3
             mov_lpow0, mov_lpow1, mov_lpow2, mov_lpow3 = movmatrix_16b(l_a0), movmatrix_16b(l_a1), movmatrix_16b(l_a2), movmatrix_16b(l_a3)
             for _round in cutlass.range_constexpr(3):
-                sq_acc = cutlass.Array(cutlass.Float32, 8, alignment=16)
+                sq_acc = cute.make_rmem_tensor((8,), cutlass.Float32)
                 for accum_idx in cutlass.range_constexpr(8):
                     sq_acc[accum_idx] = cutlass.Float32(0.0)
                 mma_step(
@@ -802,7 +807,7 @@ def super_mma_warp(
                 lpow_a2 = fp32_to_fp16(sq_acc[4], sq_acc[5], dtype=cfg.io_dtype)
                 lpow_a3 = fp32_to_fp16(sq_acc[6], sq_acc[7], dtype=cfg.io_dtype)
                 mov_lpow0, mov_lpow1, mov_lpow2, mov_lpow3 = movmatrix_16b(lpow_a0), movmatrix_16b(lpow_a1), movmatrix_16b(lpow_a2), movmatrix_16b(lpow_a3)
-                upd_acc = cutlass.Array(cutlass.Float32, 8, alignment=16)
+                upd_acc = cute.make_rmem_tensor((8,), cutlass.Float32)
                 for accum_idx in cutlass.range_constexpr(8):
                     upd_acc[accum_idx] = cutlass.Float32(0.0)
                 tinv_p0 = fp32_to_fp16(tinv_acc[0], tinv_acc[1], dtype=cfg.io_dtype)
@@ -845,21 +850,21 @@ def super_mma_warp(
             bars.mb_dm_done[intermediate_stage].wait(((chunk_serial // cfg.smem_intermediate_stages) + 1) % 2)
             bars.mb_dy_smem_ready.wait(sdy_index.phase)
             sdy_index = advance(sdy_index, 1)
-            dm_acc = cutlass.Array(cutlass.Float32, 8, alignment=16)
+            dm_acc = cute.make_rmem_tensor((8,), cutlass.Float32)
             for accum_idx in cutlass.range_constexpr(8):
                 dm_acc[accum_idx] = cutlass.Float32(0.0)
             for k_block in cutlass.range_constexpr(cfg.d_v // 16):
                 a_col = k_block * 16 + lhs_col_offset
                 a_seg = a_col // 64
                 a_frag = nvvm.ldmatrix(
-                    sDy_raw.data_ptr() + a_seg * (cfg.b_t * 64) + lhs_row_coord * 64 + swizzle_xor_128b(lhs_row_coord, a_col - a_seg * 64, elem_bytes=2),
+                    smem_data_ptr(sDy_raw) + a_seg * (cfg.b_t * 64) + lhs_row_coord * 64 + swizzle_xor_128b(lhs_row_coord, a_col - a_seg * 64, elem_bytes=2),
                     4,
                     nvvm.MMALayout.ROW,
                 )
                 b_col = k_block * 16 + rhs_col_offset
                 b_seg = b_col // 64
                 b_frag = nvvm.ldmatrix(
-                    sU_raw.data_ptr() + b_seg * (cfg.b_t * 64) + rhs_row_coord * 64 + swizzle_xor_128b(rhs_row_coord, b_col - b_seg * 64, elem_bytes=2),
+                    smem_data_ptr(sU_raw) + b_seg * (cfg.b_t * 64) + rhs_row_coord * 64 + swizzle_xor_128b(rhs_row_coord, b_col - b_seg * 64, elem_bytes=2),
                     4,
                     nvvm.MMALayout.ROW,
                 )
@@ -873,7 +878,7 @@ def super_mma_warp(
                     ab_dtype=cfg.io_dtype,
                 )
             # ---- dM_strict = Beta_row . strict(dM) -------------------------------
-            dm_strict_regs = cutlass.Array(cutlass.Float32, 8, alignment=16)
+            dm_strict_regs = cute.make_rmem_tensor((8,), cutlass.Float32)
             for accum_idx in cutlass.range_constexpr(8):
                 beta_scale = beta_lo if accum_idx % 4 < 2 else beta_hi
                 val = dm_acc[accum_idx] * beta_scale if (tril_strict_mask >> accum_idx) & 1 else cutlass.Float32(0.0)
@@ -1830,14 +1835,14 @@ def compute0_warp_group(
             chunk_start = chunk_idx * cfg.b_t
             decay_stage = chunk_serial % cfg.smem_decay_stages
             raw_stage = chunk_serial % cfg.smem_raw_stages
-            sQ_ptr = sQ_raw.data_ptr() + raw_stage * (cfg.d_k * cfg.b_t)
-            sK_ptr = sK_raw.data_ptr() + raw_stage * (cfg.d_k * cfg.b_t)
-            sGate_ptr = sGate_raw.data_ptr() + raw_stage * (cfg.d_k * cfg.b_t)
-            sK_inv_ptr = sK_inv_raw.data_ptr() + decay_stage * (cfg.b_t * cfg.d_k)
-            sK_decay_ptr = sK_decay_raw.data_ptr() + decay_stage * (cfg.d_k * cfg.b_t)
-            sQ_decay_ptr = sQ_decay_raw.data_ptr() + decay_stage * (cfg.d_k * cfg.b_t)
-            sK_restore_ptr = sK_restore_raw.data_ptr() + decay_stage * (cfg.d_k * cfg.b_t)
-            sState_scale_diag_ptr = sState_scale_diag_raw.data_ptr() + decay_stage * ((cfg.d_k // 16) * 256)
+            sQ_ptr = smem_data_ptr(sQ_raw) + raw_stage * (cfg.d_k * cfg.b_t)
+            sK_ptr = smem_data_ptr(sK_raw) + raw_stage * (cfg.d_k * cfg.b_t)
+            sGate_ptr = smem_data_ptr(sGate_raw) + raw_stage * (cfg.d_k * cfg.b_t)
+            sK_inv_ptr = smem_data_ptr(sK_inv_raw) + decay_stage * (cfg.b_t * cfg.d_k)
+            sK_decay_ptr = smem_data_ptr(sK_decay_raw) + decay_stage * (cfg.d_k * cfg.b_t)
+            sQ_decay_ptr = smem_data_ptr(sQ_decay_raw) + decay_stage * (cfg.d_k * cfg.b_t)
+            sK_restore_ptr = smem_data_ptr(sK_restore_raw) + decay_stage * (cfg.d_k * cfg.b_t)
+            sState_scale_diag_ptr = smem_data_ptr(sState_scale_diag_raw) + decay_stage * ((cfg.d_k // 16) * 256)
 
             # ---- beta scalars: gathered in the inputs-wait shadow ----------------
             if cg0_warp == 0:
@@ -1866,13 +1871,13 @@ def compute0_warp_group(
             g_prefix_ptr = sGate_ptr
             prefix_dim = cg0_warp * cfg.threads_per_warp + lane
             # ---- gate prefix scan: cumulative log-gate per key channel -----------
-            gate_raw = cutlass.Array(cutlass.Float32, cfg.b_t, alignment=16)
+            gate_raw = cute.make_rmem_tensor((cfg.b_t,), cutlass.Float32)
             for row in cutlass.range_constexpr(cfg.b_t):
                 f32_segment = prefix_dim // 32
                 f32_segment_dim = prefix_dim - f32_segment * 32
                 prefix_idx = f32_segment * (cfg.b_t * 32) + row * 32 + swizzle_xor_128b(row, f32_segment_dim, elem_bytes=4)
                 gate_raw[row] = (sGate_ptr + prefix_idx).load()
-            g_prefix_regs = cutlass.Array(cutlass.Float32, cfg.b_t, alignment=16)
+            g_prefix_regs = cute.make_rmem_tensor((cfg.b_t,), cutlass.Float32)
             if cutlass.const_expr(cfg.safe_gate):
                 valid_rows = seqlen_b - chunk_idx * cutlass.Int32(cfg.b_t)
                 valid_mask = cutlass.vector.create_mask([cfg.b_t], [valid_rows])
@@ -1950,8 +1955,8 @@ def compute0_warp_group(
             bars.mb_qk_raw_done[qk_raw_stage].wait(((chunk_serial // cfg.tmem_qk_raw_stages) + 1) % 2)
             raw_seg = prefix_dim // 64
             raw_dim = prefix_dim - raw_seg * 64
-            q_raw_words = cutlass.Array(cutlass.Int32, cfg.b_t // 2, alignment=16)
-            k_raw_words = cutlass.Array(cutlass.Int32, cfg.b_t // 2, alignment=16)
+            q_raw_words = cute.make_rmem_tensor((cfg.b_t // 2,), cutlass.Int32)
+            k_raw_words = cute.make_rmem_tensor((cfg.b_t // 2,), cutlass.Int32)
             for t2 in cutlass.range_constexpr(cfg.b_t // 2):
                 t0 = 2 * t2
                 ridx0 = raw_seg * (cfg.b_t * 64) + t0 * 64 + swizzle_xor_128b(t0, raw_dim, elem_bytes=2)
@@ -1965,21 +1970,21 @@ def compute0_warp_group(
             nvvm.tcgen05_st(
                 "32x32b",
                 nvvm.make_tmem_ptr(row_addr + (tmem_col + cfg.tmem_qraw_inp_offset + qk_raw_stage * (cfg.b_t // 2)), cutlass.Int8),
-                q_raw_words[0 : (cfg.b_t // 2)],
+                q_raw_words.load(),
             )
             nvvm.tcgen05_st(
                 "32x32b",
                 nvvm.make_tmem_ptr(row_addr + (tmem_col + cfg.tmem_kraw_inp_offset + qk_raw_stage * (cfg.b_t // 2)), cutlass.Int8),
-                k_raw_words[0 : (cfg.b_t // 2)],
+                k_raw_words.load(),
             )
             nvvm.tcgen05_wait("store")
             bars.mb_qk_raw_ready[qk_raw_stage].arrive()
 
             nvvm.barrier_cta_sync(cfg.cg0_sync_barrier_id, thread_count=cfg.cg0_threads)
 
-            k_inv_pack = cutlass.Array(cutlass.Int32, 2 * 4, alignment=16)
-            raw_q_regs = cutlass.Array(cutlass.Float32, 2 * 8, alignment=16)
-            raw_k_regs = cutlass.Array(cutlass.Float32, 2 * 8, alignment=16)
+            k_inv_pack = cute.make_rmem_tensor((2 * 4,), cutlass.Int32)
+            raw_q_regs = cute.make_rmem_tensor((2 * 8,), cutlass.Float32)
+            raw_k_regs = cute.make_rmem_tensor((2 * 8,), cutlass.Float32)
             # ---- optional Q/K L2-norm --------------------------------------------
             if cutlass.const_expr(cfg.l2norm):
                 qk0_lo = opaque_f32_zero()
@@ -2031,8 +2036,8 @@ def compute0_warp_group(
             q_stage_norm = q_inv_norm * scale
 
             # ---- decay/restore operands: exp2(+-g) applied per key channel -------
-            exp_g_regs = cutlass.Array(cutlass.Float32, 2 * 8, alignment=16)
-            exp_g_last_regs = cutlass.Array(cutlass.Float32, 2 * 8, alignment=16)
+            exp_g_regs = cute.make_rmem_tensor((2 * 8,), cutlass.Float32)
+            exp_g_last_regs = cute.make_rmem_tensor((2 * 8,), cutlass.Float32)
             for dim_half in cutlass.range_constexpr(2):
                 dim_base = dim_half * (cfg.d_k // 2) + lane_in_row_group * 8
                 reg_base = dim_half * 8
@@ -2060,7 +2065,7 @@ def compute0_warp_group(
                 dim_base = dim_half * (cfg.d_k // 2) + lane_in_row_group * 8
                 reg_base = dim_half * 8
                 # ---- K decay + K inv operands: exp2(+g) * K / exp2(-g) * K -------
-                k_decay_pack = cutlass.Array(cutlass.Int32, 4, alignment=16)
+                k_decay_pack = cute.make_rmem_tensor((4,), cutlass.Int32)
                 for pair_idx in cutlass.range_constexpr(4):
                     dim0 = pair_idx * 2
                     dim1 = dim0 + 1
@@ -2100,8 +2105,8 @@ def compute0_warp_group(
             for dim_half in cutlass.range_constexpr(2):
                 dim_base = dim_half * (cfg.d_k // 2) + lane_in_row_group * 8
                 reg_base = dim_half * 8
-                q_decay_pack = cutlass.Array(cutlass.Int32, 4, alignment=16)
-                k_restore_pack = cutlass.Array(cutlass.Int32, 4, alignment=16)
+                q_decay_pack = cute.make_rmem_tensor((4,), cutlass.Int32)
+                k_restore_pack = cute.make_rmem_tensor((4,), cutlass.Int32)
                 for pair_idx in cutlass.range_constexpr(4):
                     dim0 = pair_idx * 2
                     dim1 = dim0 + 1
@@ -2135,7 +2140,7 @@ def compute0_warp_group(
             bars.mb_state_inp_cg2_done[chunk_serial % 2].wait(((chunk_serial // 2) + 1) % 2)
             if chunk_idx >= FIRST_STATE_CHUNK:
                 bars.mb_state_ready[state_index.idx].wait(state_index.phase)
-                state_src = sState_raw.data_ptr() + state_index.idx * (cfg.d_k * cfg.d_v)
+                state_src = smem_data_ptr(sState_raw) + state_index.idx * (cfg.d_k * cfg.d_v)
                 for v_seg in cutlass.range_constexpr(2):
                     for v_col8 in cutlass.range_constexpr(8):
                         state_frag = cutlass.Vector.from_elements(
@@ -2232,7 +2237,7 @@ def compute1_warp_group(
                 row_addr = (tmem_row + tmem_subpartition * cfg.threads_per_warp) << 16
                 dstate_src = (mDstate_in.iterator + mDstate_in.layout((batch_idx, head_idx, value_dim, 0))).raw_ptr()
                 for sub in cutlass.range_constexpr(cfg.d_k // 16):
-                    seed_block = cutlass.Array(cutlass.Float32, 16, alignment=16)
+                    seed_block = cute.make_rmem_tensor((16,), cutlass.Float32)
                     for g in cutlass.range_constexpr(4):
                         seed_chunk = (dstate_src + sub * 16 + g * 4).load(count=4, alignment=16)
                         for t in cutlass.range_constexpr(4):
@@ -2241,15 +2246,15 @@ def compute1_warp_group(
                     nvvm.tcgen05_st(
                         "32x32b",
                         nvvm.make_tmem_ptr(row_addr + (tmem_col + cfg.tmem_dstate_acc_offset + sub * 16), cutlass.Float32),
-                        seed_block[0:16],
+                        seed_block.load(),
                     )
-                    seed_pack = cutlass.Array(cutlass.Int32, 8, alignment=16)
+                    seed_pack = cute.make_rmem_tensor((8,), cutlass.Int32)
                     for pc in cutlass.range_constexpr(8):
                         seed_pack[pc] = fp32_to_fp16(seed_block[2 * pc], seed_block[2 * pc + 1], dtype=cfg.io_dtype)
                     nvvm.tcgen05_st(
                         "32x32b",
                         nvvm.make_tmem_ptr(row_addr + (tmem_col + cfg.tmem_dstate_inp_offset + sub * 8), cutlass.Int8),
-                        seed_pack[0:8],
+                        seed_pack.load(),
                     )
                 nvvm.tcgen05_wait("store")
                 bars.mb_dstate_inp_ready.arrive()
@@ -2266,16 +2271,16 @@ def compute1_warp_group(
                             cutlass.Float32,
                         ).bitcast(cfg.io_dtype)
                         h_addr = (d_base // 64) * (cfg.d_v * 64) + value_dim * 64 + swizzle_xor_128b(value_dim, d_base % 64, elem_bytes=2)
-                        (sDstate_raw.data_ptr() + h_addr).store(h_vec, alignment=16)
+                        (smem_data_ptr(sDstate_raw) + h_addr).store(h_vec, alignment=16)
                 nvvm.fence_proxy("async.shared", space="cta")
                 bars.mb_dstate_smem_ready.arrive()
 
         for rev_idx in cutlass.range(num_compute_chunks, unroll=1):
             chunk_idx = cend - cutlass.Int32(1) - rev_idx
             chunk_serial = chunk_serial_base + rev_idx
-            sV_ptr = sV_raw.data_ptr() + raw_index.idx * (cfg.d_v * cfg.b_t)
-            sDo_ptr = sDo_raw.data_ptr() + raw_index.idx * (cfg.d_v * cfg.b_t)
-            sBeta_ptr = sBeta_raw.data_ptr() + (chunk_serial % cfg.smem_beta_stages) * cfg.b_t
+            sV_ptr = smem_data_ptr(sV_raw) + raw_index.idx * (cfg.d_v * cfg.b_t)
+            sDo_ptr = smem_data_ptr(sDo_raw) + raw_index.idx * (cfg.d_v * cfg.b_t)
+            sBeta_ptr = smem_data_ptr(sBeta_raw) + (chunk_serial % cfg.smem_beta_stages) * cfg.b_t
             row_addr_lo = tmem_row << 16
             row_addr_hi = (tmem_row + 16) << 16
             row_id0 = tmem_row + value_dim_base
@@ -2310,16 +2315,16 @@ def compute1_warp_group(
             bars.mb_v_done[raw_index.idx].arrive()
 
             bars.mb_beta_ready[chunk_serial % cfg.smem_beta_stages].wait((chunk_serial // cfg.smem_beta_stages) % 2)
-            beta_pairs = cutlass.Array(cutlass.Int32, 2, space=cutlass.AddressSpace.rmem)
+            beta_pairs = cute.make_rmem_tensor((2,), cutlass.Int32)
             for half in cutlass.range_constexpr(2):
                 token0 = ((half * 4 + (lane & 3)) ^ 4) * 2
                 beta0 = (sBeta_ptr + token0).load().to(cutlass.Float32)
                 beta1 = (sBeta_ptr + token0 + 1).load().to(cutlass.Float32)
                 beta_pairs[half] = fp32_to_fp16(beta0, beta1, dtype=cfg.io_dtype)
-            diff_w0 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
-            diff_w1 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
-            y_inp_pack0 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
-            y_inp_pack1 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            diff_w0 = cute.make_rmem_tensor((4,), cutlass.Int32)
+            diff_w1 = cute.make_rmem_tensor((4,), cutlass.Int32)
+            y_inp_pack0 = cute.make_rmem_tensor((4,), cutlass.Int32)
+            y_inp_pack1 = cute.make_rmem_tensor((4,), cutlass.Int32)
             if chunk_idx >= FIRST_STATE_CHUNK:
                 bars.mb_state_k_acc_ready.wait(state_k_index.phase)
                 state_k_index = advance(state_k_index, 1)
@@ -2348,8 +2353,8 @@ def compute1_warp_group(
                     raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
                     diff_w1[reg_idx ^ 2] = raw_v_frag1[raw_matrix]
                     y_inp_pack1[reg_idx ^ 2] = mul_f16x2(beta_pairs[reg_idx // 2], raw_v_frag1[raw_matrix], cfg.io_dtype)
-            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(row_addr_lo + input_col_id, cutlass.Int8), y_inp_pack0[0:4])
-            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(row_addr_hi + input_col_id, cutlass.Int8), y_inp_pack1[0:4])
+            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(row_addr_lo + input_col_id, cutlass.Int8), y_inp_pack0.load())
+            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(row_addr_hi + input_col_id, cutlass.Int8), y_inp_pack1.load())
             nvvm.tcgen05_wait("store")
             bars.mb_y_inp_ready.arrive()
 
@@ -2360,14 +2365,14 @@ def compute1_warp_group(
             du_vec0 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr((row_id0 << 16) + du_col_id, cutlass.Float32), num=2)
             du_vec1 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr((row_id1 << 16) + du_col_id, cutlass.Float32), num=2)
 
-            du_pack0 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
-            du_pack1 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            du_pack0 = cute.make_rmem_tensor((4,), cutlass.Int32)
+            du_pack1 = cute.make_rmem_tensor((4,), cutlass.Int32)
             for reg_idx in cutlass.range_constexpr(4):
                 frag_pair = reg_idx * 2
                 du_pack0[reg_idx] = fp32_to_fp16(du_vec0[frag_pair], du_vec0[frag_pair + 1], dtype=cfg.io_dtype)
                 du_pack1[reg_idx] = fp32_to_fp16(du_vec1[frag_pair], du_vec1[frag_pair + 1], dtype=cfg.io_dtype)
-            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(row_addr_lo + (tmem_col + cfg.tmem_du_inp_offset), cutlass.Int8), du_pack0[0:4])
-            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(row_addr_hi + (tmem_col + cfg.tmem_du_inp_offset), cutlass.Int8), du_pack1[0:4])
+            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(row_addr_lo + (tmem_col + cfg.tmem_du_inp_offset), cutlass.Int8), du_pack0.load())
+            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(row_addr_hi + (tmem_col + cfg.tmem_du_inp_offset), cutlass.Int8), du_pack1.load())
             nvvm.tcgen05_wait("store")
             bars.mb_du_inp_ready.arrive()
 
@@ -2378,26 +2383,26 @@ def compute1_warp_group(
             u_vec0 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr((row_id0 << 16) + u_col_id, cutlass.Float32), num=2)
             u_vec1 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr((row_id1 << 16) + u_col_id, cutlass.Float32), num=2)
 
-            u_pack0 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
-            u_pack1 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            u_pack0 = cute.make_rmem_tensor((4,), cutlass.Int32)
+            u_pack1 = cute.make_rmem_tensor((4,), cutlass.Int32)
             for reg_idx in cutlass.range_constexpr(4):
                 u_pack0[reg_idx] = fp32_to_fp16(u_vec0[2 * reg_idx], u_vec0[2 * reg_idx + 1], dtype=cfg.io_dtype)
                 u_pack1[reg_idx] = fp32_to_fp16(u_vec1[2 * reg_idx], u_vec1[2 * reg_idx + 1], dtype=cfg.io_dtype)
             nvvm.stmatrix(
-                sU_raw.data_ptr()
+                smem_data_ptr(sU_raw)
                 + (value_dim_base + value_col_offset) // 64 * (cfg.b_t * 64)
                 + token_row_coord * 64
                 + swizzle_xor_128b(token_row_coord, (value_dim_base + value_col_offset) % 64, elem_bytes=2),
-                u_pack0.data_ptr().load(count=4, alignment=4),
+                u_pack0.load(),
                 nvvm.MMALayout.COL,
                 shape=nvvm.StoreShape.M8N8,
             )
             nvvm.stmatrix(
-                sU_raw.data_ptr()
+                smem_data_ptr(sU_raw)
                 + (value_dim_base + 16 + value_col_offset) // 64 * (cfg.b_t * 64)
                 + token_row_coord * 64
                 + swizzle_xor_128b(token_row_coord, (value_dim_base + 16 + value_col_offset) % 64, elem_bytes=2),
-                u_pack1.data_ptr().load(count=4, alignment=4),
+                u_pack1.load(),
                 nvvm.MMALayout.COL,
                 shape=nvvm.StoreShape.M8N8,
             )
@@ -2422,13 +2427,13 @@ def compute1_warp_group(
                 + token_row_coord * 64
                 + swizzle_xor_128b(token_row_coord, (value_dim_base + 16 + value_col_offset) % 64, elem_bytes=2)
             )
-            dy_pack0 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
-            dy_pack1 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            dy_pack0 = cute.make_rmem_tensor((4,), cutlass.Int32)
+            dy_pack1 = cute.make_rmem_tensor((4,), cutlass.Int32)
             for reg_idx in cutlass.range_constexpr(4):
                 dy_pack0[reg_idx] = fp32_to_fp16(dy_vec0[2 * reg_idx], dy_vec0[2 * reg_idx + 1], dtype=cfg.io_dtype)
                 dy_pack1[reg_idx] = fp32_to_fp16(dy_vec1[2 * reg_idx], dy_vec1[2 * reg_idx + 1], dtype=cfg.io_dtype)
-            nvvm.stmatrix(sDy_raw.data_ptr() + addr_lo0, dy_pack0.data_ptr().load(count=4, alignment=4), nvvm.MMALayout.COL, shape=nvvm.StoreShape.M8N8)
-            nvvm.stmatrix(sDy_raw.data_ptr() + addr_lo1, dy_pack1.data_ptr().load(count=4, alignment=4), nvvm.MMALayout.COL, shape=nvvm.StoreShape.M8N8)
+            nvvm.stmatrix(smem_data_ptr(sDy_raw) + addr_lo0, dy_pack0.load(), nvvm.MMALayout.COL, shape=nvvm.StoreShape.M8N8)
+            nvvm.stmatrix(smem_data_ptr(sDy_raw) + addr_lo1, dy_pack1.load(), nvvm.MMALayout.COL, shape=nvvm.StoreShape.M8N8)
             nvvm.fence_proxy("async.shared", space="cta")
             bars.mb_dy_smem_ready.arrive()
 
@@ -2443,8 +2448,8 @@ def compute1_warp_group(
                 if cg1_tidx < cfg.b_t:
                     beta_self = (sBeta_ptr + cg1_tidx).load().to(cutlass.Float32)
             bars.mb_beta_done[chunk_serial % cfg.smem_beta_stages].arrive()
-            beta_dy_regs0 = cutlass.Array(cutlass.Float32, 8, alignment=16)
-            beta_dy_regs1 = cutlass.Array(cutlass.Float32, 8, alignment=16)
+            beta_dy_regs0 = cute.make_rmem_tensor((8,), cutlass.Float32)
+            beta_dy_regs1 = cute.make_rmem_tensor((8,), cutlass.Float32)
             for e2 in cutlass.range_constexpr(4):
                 e = 2 * e2
                 b_lo = beta_c8 if cutlass.const_expr(e >= 4) else beta_c0
@@ -2453,24 +2458,24 @@ def compute1_warp_group(
                 beta_dy_regs1[e], beta_dy_regs1[e + 1] = fmul2(dy_vec1[e], dy_vec1[e + 1], b_lo, b_hi)
 
             # ---- -beta.dY -> TMEM: A operand of the dH ds-term ---------------------
-            neg_beta_dy_regs0 = cutlass.Array(cutlass.Float32, 8, alignment=16)
-            neg_beta_dy_regs1 = cutlass.Array(cutlass.Float32, 8, alignment=16)
+            neg_beta_dy_regs0 = cute.make_rmem_tensor((8,), cutlass.Float32)
+            neg_beta_dy_regs1 = cute.make_rmem_tensor((8,), cutlass.Float32)
             for e in cutlass.range_constexpr(8):
                 neg_beta_dy_regs0[e] = -beta_dy_regs0[e]
                 neg_beta_dy_regs1[e] = -beta_dy_regs1[e]
-            neg_beta_dy_pack0 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
-            neg_beta_dy_pack1 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            neg_beta_dy_pack0 = cute.make_rmem_tensor((4,), cutlass.Int32)
+            neg_beta_dy_pack1 = cute.make_rmem_tensor((4,), cutlass.Int32)
             for reg_idx in cutlass.range_constexpr(4):
                 frag_pair = reg_idx * 2
                 neg_beta_dy_pack0[reg_idx] = fp32_to_fp16(neg_beta_dy_regs0[frag_pair], neg_beta_dy_regs0[frag_pair + 1], dtype=cfg.io_dtype)
                 neg_beta_dy_pack1[reg_idx] = fp32_to_fp16(neg_beta_dy_regs1[frag_pair], neg_beta_dy_regs1[frag_pair + 1], dtype=cfg.io_dtype)
-            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(row_addr_lo + (tmem_col + cfg.tmem_neg_beta_dy_inp_offset), cutlass.Int8), neg_beta_dy_pack0[0:4])
-            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(row_addr_hi + (tmem_col + cfg.tmem_neg_beta_dy_inp_offset), cutlass.Int8), neg_beta_dy_pack1[0:4])
+            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(row_addr_lo + (tmem_col + cfg.tmem_neg_beta_dy_inp_offset), cutlass.Int8), neg_beta_dy_pack0.load())
+            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(row_addr_hi + (tmem_col + cfg.tmem_neg_beta_dy_inp_offset), cutlass.Int8), neg_beta_dy_pack1.load())
             nvvm.tcgen05_wait("store")
             bars.mb_neg_beta_dy_inp_ready.arrive()
 
             # ---- dBeta v-term parts: dY.(V - state_k), diff_w from Y staging -------
-            tok4 = cutlass.Array(cutlass.Float32, 4, alignment=16)
+            tok4 = cute.make_rmem_tensor((4,), cutlass.Float32)
             for s in cutlass.range_constexpr(4):
                 tok4[s] = cutlass.Float32(0.0)
             for j in cutlass.range_constexpr(4):
@@ -2484,8 +2489,8 @@ def compute1_warp_group(
                 tok4[s_hi] = t_hi
 
             # ---- beta.dY -> sdV (epilogue TMA + dK_decay MMA operand) ------------
-            beta_dy_pack0 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
-            beta_dy_pack1 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            beta_dy_pack0 = cute.make_rmem_tensor((4,), cutlass.Int32)
+            beta_dy_pack1 = cute.make_rmem_tensor((4,), cutlass.Int32)
             for reg_idx in cutlass.range_constexpr(4):
                 beta_dy_pack0[reg_idx] = fp32_to_fp16(beta_dy_regs0[2 * reg_idx], beta_dy_regs0[2 * reg_idx + 1], dtype=cfg.io_dtype)
                 beta_dy_pack1[reg_idx] = fp32_to_fp16(beta_dy_regs1[2 * reg_idx], beta_dy_regs1[2 * reg_idx + 1], dtype=cfg.io_dtype)
@@ -2494,14 +2499,14 @@ def compute1_warp_group(
             bars.mb_dv_tmastg_done[dv_stage].wait(dv_done_index.phase)
             dv_done_index = advance(dv_done_index, cfg.smem_dv_stages)
             nvvm.stmatrix(
-                sDv_raw.data_ptr() + sdv_stage_base + addr_lo0,
-                beta_dy_pack0.data_ptr().load(count=4, alignment=4),
+                smem_data_ptr(sDv_raw) + sdv_stage_base + addr_lo0,
+                beta_dy_pack0.load(),
                 nvvm.MMALayout.COL,
                 shape=nvvm.StoreShape.M8N8,
             )
             nvvm.stmatrix(
-                sDv_raw.data_ptr() + sdv_stage_base + addr_lo1,
-                beta_dy_pack1.data_ptr().load(count=4, alignment=4),
+                smem_data_ptr(sDv_raw) + sdv_stage_base + addr_lo1,
+                beta_dy_pack1.load(),
                 nvvm.MMALayout.COL,
                 shape=nvvm.StoreShape.M8N8,
             )
@@ -2544,13 +2549,13 @@ def compute1_warp_group(
                     dstate_vec = nvvm.tcgen05_ld(
                         "32x32b", nvvm.make_tmem_ptr(row_addr + (tmem_col + cfg.tmem_dstate_acc_offset + sub * 32), cutlass.Float32), num=32
                     )
-                    dstate_pack = cutlass.Array(cutlass.Int32, 16, alignment=16)
+                    dstate_pack = cute.make_rmem_tensor((16,), cutlass.Int32)
                     for pc in cutlass.range_constexpr(16):
                         dstate_pack[pc] = fp32_to_fp16(dstate_vec[2 * pc], dstate_vec[2 * pc + 1], dtype=cfg.io_dtype)
                     nvvm.tcgen05_st(
                         "32x32b",
                         nvvm.make_tmem_ptr(row_addr + (tmem_col + cfg.tmem_dstate_inp_offset + sub * 16), cutlass.Int8),
-                        dstate_pack[0:16],
+                        dstate_pack.load(),
                     )
                 nvvm.tcgen05_wait("store")
                 bars.mb_dstate_inp_ready.arrive()
@@ -2567,7 +2572,7 @@ def compute1_warp_group(
                             cutlass.Float32,
                         ).bitcast(cfg.io_dtype)
                         h_addr = (d_base // 64) * (cfg.d_v * 64) + value_dim * 64 + swizzle_xor_128b(value_dim, d_base % 64, elem_bytes=2)
-                        (sDstate_raw.data_ptr() + h_addr).store(h_vec, alignment=16)
+                        (smem_data_ptr(sDstate_raw) + h_addr).store(h_vec, alignment=16)
                 nvvm.fence_proxy("async.shared", space="cta")
                 bars.mb_dstate_smem_ready.arrive()
             raw_index = advance(raw_index, cfg.smem_raw_stages)
@@ -2663,7 +2668,7 @@ def compute2_warp_group(
             has_dstate = cutlass.Boolean(rev_idx > 0)
             if cutlass.const_expr(cfg.use_dstate_in):
                 has_dstate = cutlass.Boolean(True)
-            sGate_ptr = sGate_raw.data_ptr() + raw_stage * (cfg.d_k * cfg.b_t)
+            sGate_ptr = smem_data_ptr(sGate_raw) + raw_stage * (cfg.d_k * cfg.b_t)
             writes = chunk_idx < wend
 
             # ---- gate landed: CG0 publishes the decay ring only after consuming
@@ -2675,7 +2680,7 @@ def compute2_warp_group(
             f32_dim = channel - f32_seg * 32
             f16_seg = channel // 64
             f16_dim = channel - f16_seg * 64
-            eg = cutlass.Array(cutlass.Float32, cfg.b_t, alignment=16)
+            eg = cute.make_rmem_tensor((cfg.b_t,), cutlass.Float32)
             for t in cutlass.range_constexpr(cfg.b_t):
                 eg[t] = (sGate_ptr + f32_seg * (cfg.b_t * 32) + t * 32 + swizzle_xor_128b(t, f32_dim, elem_bytes=4)).load()
             egl = eg[cfg.b_t - 1]
@@ -2705,7 +2710,7 @@ def compute2_warp_group(
                             ),
                             num=16,
                         )
-                        hacc = cutlass.Array(cutlass.Float32, 8, alignment=16)
+                        hacc = cute.make_rmem_tensor((8,), cutlass.Float32)
                         for i in cutlass.range_constexpr(8):
                             hacc[i] = opaque_f32_zero()
                         for j in cutlass.range_constexpr(16):
@@ -2713,8 +2718,8 @@ def compute2_warp_group(
                             state_pair = cutlass.Vector.from_elements((state_vec[j],), cutlass.Float32).bitcast(cfg.io_dtype)
                             dstate_addr0 = (channel // 64) * (cfg.d_v * 64) + v0 * 64 + swizzle_xor_128b(v0, channel % 64, elem_bytes=2)
                             dstate_addr1 = (channel // 64) * (cfg.d_v * 64) + (v0 + 1) * 64 + swizzle_xor_128b(v0 + 1, channel % 64, elem_bytes=2)
-                            hval0 = (sDstate_raw.data_ptr() + dstate_addr0).load().to(cutlass.Float32)
-                            hval1 = (sDstate_raw.data_ptr() + dstate_addr1).load().to(cutlass.Float32)
+                            hval0 = (smem_data_ptr(sDstate_raw) + dstate_addr0).load().to(cutlass.Float32)
+                            hval1 = (smem_data_ptr(sDstate_raw) + dstate_addr1).load().to(cutlass.Float32)
                             hacc[(2 * j) % 8] = hacc[(2 * j) % 8] + hval0 * state_pair[0].to(cutlass.Float32)
                             hacc[(2 * j + 1) % 8] = hacc[(2 * j + 1) % 8] + hval1 * state_pair[1].to(cutlass.Float32)
                         pa0, pb0 = fadd2(hacc[0], hacc[2], hacc[4], hacc[6])
@@ -2725,10 +2730,10 @@ def compute2_warp_group(
             bars.mb_state_inp_cg2_done[chunk_serial % 2].arrive()
 
             # ---- part-drain accumulators -------------------------------------------
-            dq_n = cutlass.Array(cutlass.Float32, cfg.b_t, alignment=16)
-            dk_n = cutlass.Array(cutlass.Float32, cfg.b_t, alignment=16)
-            dgate_regs = cutlass.Array(cutlass.Float32, cfg.b_t, alignment=16)
-            dgate_last_acc = cutlass.Array(cutlass.Float32, 4, alignment=16)
+            dq_n = cute.make_rmem_tensor((cfg.b_t,), cutlass.Float32)
+            dk_n = cute.make_rmem_tensor((cfg.b_t,), cutlass.Float32)
+            dgate_regs = cute.make_rmem_tensor((cfg.b_t,), cutlass.Float32)
+            dgate_last_acc = cute.make_rmem_tensor((4,), cutlass.Float32)
             for i in cutlass.range_constexpr(4):
                 dgate_last_acc[i] = opaque_f32_zero()
             for t in cutlass.range_constexpr(cfg.b_t):
@@ -2797,7 +2802,7 @@ def compute2_warp_group(
             # ---- L2-norm backward row projection ---------------------------------
             if cutlass.const_expr(cfg.l2norm):
                 for grad, qk_col, inv_off in ((dq_n, qraw_col, 0), (dk_n, kraw_col, cfg.b_t)):
-                    dots = cutlass.Array(cutlass.Float32, cfg.b_t, alignment=16)
+                    dots = cute.make_rmem_tensor((cfg.b_t,), cutlass.Float32)
                     for half in cutlass.range_constexpr(2):
                         p_words = nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(row_addr + qk_col + half * (cfg.b_t // 4), cutlass.Float32), num=cfg.b_t // 4)
                         for tt2 in cutlass.range_constexpr(cfg.b_t // 4):
@@ -2843,8 +2848,8 @@ def compute2_warp_group(
             dk_base = dk_stage * (cfg.b_t * cfg.d_k)
             for t in cutlass.range_constexpr(cfg.b_t):
                 out_idx = f16_seg * (cfg.b_t * 64) + t * 64 + swizzle_xor_128b(t, f16_dim, elem_bytes=2)
-                (sDq_raw.data_ptr() + dq_base + out_idx).store(dq_n[t].to(cfg.io_dtype))
-                (sDk_raw.data_ptr() + dk_base + out_idx).store(dk_n[t].to(cfg.io_dtype))
+                (smem_data_ptr(sDq_raw) + dq_base + out_idx).store(dq_n[t].to(cfg.io_dtype))
+                (smem_data_ptr(sDk_raw) + dk_base + out_idx).store(dk_n[t].to(cfg.io_dtype))
             nvvm.fence_proxy("async.shared", space="cta")
             bars.mb_dq_tmastg_ready[dq_stage].arrive()
             bars.mb_dk_tmastg_ready[dk_stage].arrive()
@@ -2866,7 +2871,7 @@ def compute2_warp_group(
             bars.mb_dgate_tmastg_done[dgate_stage].wait(((chunk_serial // cfg.smem_dgate_stages) + 1) % 2)
             for t in cutlass.range_constexpr(cfg.b_t):
                 dgate_idx = f32_seg * (cfg.b_t * 32) + t * 32 + swizzle_xor_128b(t, f32_dim, elem_bytes=4)
-                (sDgate_raw.data_ptr() + dgate_idx).store(dgate_regs[t])
+                (smem_data_ptr(sDgate_raw) + dgate_idx).store(dgate_regs[t])
             nvvm.fence_proxy("async.shared", space="cta")
             bars.mb_dgate_tmastg_ready[dgate_stage].arrive()
             raw_index = advance(raw_index, cfg.smem_raw_stages)
@@ -3257,9 +3262,71 @@ class KdaBpropOp:
         cfg = self.cfg
         num_sequences = cu_seqlens.shape[0] - 1
 
+        @cute.struct
+        class SharedStorage:
+            state: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.state_cosize], cfg.buffer_align_bytes
+            ]
+            dstate: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.d_k * cfg.d_v], cfg.buffer_align_bytes
+            ]
+            k_decay: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.operand_cosize], cfg.buffer_align_bytes
+            ]
+            k_inv: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.operand_cosize], cfg.buffer_align_bytes
+            ]
+            k_restore: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.operand_cosize], cfg.buffer_align_bytes
+            ]
+            q_decay: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.operand_cosize], cfg.buffer_align_bytes
+            ]
+            state_scale_diag: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.diag_cosize], cfg.buffer_align_bytes
+            ]
+            intermediate: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.intermediate_cosize],
+                cfg.buffer_align_bytes,
+            ]
+            do: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.raw_v_cosize], cfg.buffer_align_bytes
+            ]
+            dv: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.dv_cosize], cfg.buffer_align_bytes
+            ]
+            q: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.raw_qk_cosize], cfg.buffer_align_bytes
+            ]
+            k: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.raw_qk_cosize], cfg.buffer_align_bytes
+            ]
+            v: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.raw_v_cosize], cfg.buffer_align_bytes
+            ]
+            gate: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, cfg.raw_gate_cosize], 1024
+            ]
+            dy: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.b_t * cfg.d_v], cfg.buffer_align_bytes
+            ]
+            u: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.b_t * cfg.d_v], cfg.buffer_align_bytes
+            ]
+            dq: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.dq_cosize], cfg.buffer_align_bytes
+            ]
+            dk: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.dk_cosize], cfg.buffer_align_bytes
+            ]
+            dgate: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, cfg.dgate_cosize], 1024
+            ]
+
         kernel.set_name_prefix(self.get_name())
         kernel(
             cfg,
+            SharedStorage,
             tensormap_workspace,
             num_sequences,
             a_log,
@@ -3285,6 +3352,7 @@ class KdaBpropOp:
 @cute.kernel
 def kernel(
     cfg: cutlass.Constexpr,
+    shared_type: cutlass.Constexpr,
     tensormap_workspace: cute.Tensor,
     n_desc: cutlass.Int32,
     mA_log: cute.Tensor | None,
@@ -3342,28 +3410,33 @@ def kernel(
     sRed_raw = cutlass.Array(cutlass.Float32, 4 * cfg.b_t, space=SMEM, alignment=64)
     sRed1_raw = cutlass.Array(cutlass.Float32, 4 * cfg.b_t, space=SMEM, alignment=64)
     sBetaM_raw = cutlass.Array(cutlass.Float32, cfg.b_t, space=SMEM, alignment=64)
-    sState_raw = cutlass.Array(cfg.io_dtype, cfg.state_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
-    sDstate_raw = cutlass.Array(cfg.io_dtype, cfg.d_k * cfg.d_v, space=SMEM, alignment=cfg.buffer_align_bytes)
-    sK_decay_raw = cutlass.Array(cfg.io_dtype, cfg.operand_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
-    sK_inv_raw = cutlass.Array(cfg.io_dtype, cfg.operand_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
-    sK_restore_raw = cutlass.Array(cfg.io_dtype, cfg.operand_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
-    sQ_decay_raw = cutlass.Array(cfg.io_dtype, cfg.operand_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
-    sState_scale_diag_raw = cutlass.Array(cfg.io_dtype, cfg.diag_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
-    sIntermediate_raw = cutlass.Array(cfg.io_dtype, cfg.intermediate_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
-    sDo_raw = cutlass.Array(cfg.io_dtype, cfg.raw_v_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
-    sDv_raw = cutlass.Array(cfg.io_dtype, cfg.dv_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
-    sQ_raw = cutlass.Array(cfg.io_dtype, cfg.raw_qk_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
-    sK_raw = cutlass.Array(cfg.io_dtype, cfg.raw_qk_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
-    sV_raw = cutlass.Array(cfg.io_dtype, cfg.raw_v_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
-    sGate_raw = cutlass.Array(cutlass.Float32, cfg.raw_gate_cosize, space=SMEM, alignment=1024)
-    sDy_raw = cutlass.Array(cfg.io_dtype, cfg.b_t * cfg.d_v, space=SMEM, alignment=cfg.buffer_align_bytes)
-    sU_raw = cutlass.Array(cfg.io_dtype, cfg.b_t * cfg.d_v, space=SMEM, alignment=cfg.buffer_align_bytes)
-    sDq_raw = cutlass.Array(cfg.io_dtype, cfg.dq_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
-    sDk_raw = cutlass.Array(cfg.io_dtype, cfg.dk_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
-    sDgate_raw = cutlass.Array(cutlass.Float32, cfg.dgate_cosize, space=SMEM, alignment=1024)
+    storage = cutlass.utils.SmemAllocator().allocate(shared_type)
+    sState_raw = storage.state.get_tensor(cute.make_layout((cfg.state_cosize,)))
+    sDstate_raw = storage.dstate.get_tensor(cute.make_layout((cfg.d_k * cfg.d_v,)))
+    sK_decay_raw = storage.k_decay.get_tensor(cute.make_layout((cfg.operand_cosize,)))
+    sK_inv_raw = storage.k_inv.get_tensor(cute.make_layout((cfg.operand_cosize,)))
+    sK_restore_raw = storage.k_restore.get_tensor(cute.make_layout((cfg.operand_cosize,)))
+    sQ_decay_raw = storage.q_decay.get_tensor(cute.make_layout((cfg.operand_cosize,)))
+    sState_scale_diag_raw = storage.state_scale_diag.get_tensor(
+        cute.make_layout((cfg.diag_cosize,))
+    )
+    sIntermediate_raw = storage.intermediate.get_tensor(
+        cute.make_layout((cfg.intermediate_cosize,))
+    )
+    sDo_raw = storage.do.get_tensor(cute.make_layout((cfg.raw_v_cosize,)))
+    sDv_raw = storage.dv.get_tensor(cute.make_layout((cfg.dv_cosize,)))
+    sQ_raw = storage.q.get_tensor(cute.make_layout((cfg.raw_qk_cosize,)))
+    sK_raw = storage.k.get_tensor(cute.make_layout((cfg.raw_qk_cosize,)))
+    sV_raw = storage.v.get_tensor(cute.make_layout((cfg.raw_v_cosize,)))
+    sGate_raw = storage.gate.get_tensor(cute.make_layout((cfg.raw_gate_cosize,)))
+    sDy_raw = storage.dy.get_tensor(cute.make_layout((cfg.b_t * cfg.d_v,)))
+    sU_raw = storage.u.get_tensor(cute.make_layout((cfg.b_t * cfg.d_v,)))
+    sDq_raw = storage.dq.get_tensor(cute.make_layout((cfg.dq_cosize,)))
+    sDk_raw = storage.dk.get_tensor(cute.make_layout((cfg.dk_cosize,)))
+    sDgate_raw = storage.dgate.get_tensor(cute.make_layout((cfg.dgate_cosize,)))
 
     sState_alt = SmemTile(
-        base=sState_raw.data_ptr().toint(),
+        base=smem_data_ptr(sState_raw).toint(),
         elems_per_stage=((cfg.state_cosize) // (cfg.smem_state_stages)) * bpe,
         stages=cfg.smem_state_stages,
         leading_byte_offset=STATE_ALT_LEAD,
@@ -3371,7 +3444,7 @@ def kernel(
         layout=SWZ,
     )
     sState_direct = SmemTile(
-        base=sState_raw.data_ptr().toint(),
+        base=smem_data_ptr(sState_raw).toint(),
         elems_per_stage=((cfg.state_cosize) // (cfg.smem_state_stages)) * bpe,
         stages=cfg.smem_state_stages,
         leading_byte_offset=LEAD,
@@ -3379,7 +3452,7 @@ def kernel(
         layout=SWZ,
     )
     sK_decay_lead16 = SmemTile(
-        base=sK_decay_raw.data_ptr().toint(),
+        base=smem_data_ptr(sK_decay_raw).toint(),
         elems_per_stage=((cfg.operand_cosize) // (cfg.smem_decay_stages)) * bpe,
         stages=cfg.smem_decay_stages,
         leading_byte_offset=LEAD,
@@ -3387,7 +3460,7 @@ def kernel(
         layout=SWZ,
     )
     sK_inv_lead16 = SmemTile(
-        base=sK_inv_raw.data_ptr().toint(),
+        base=smem_data_ptr(sK_inv_raw).toint(),
         elems_per_stage=((cfg.operand_cosize) // (cfg.smem_decay_stages)) * bpe,
         stages=cfg.smem_decay_stages,
         leading_byte_offset=LEAD,
@@ -3395,7 +3468,7 @@ def kernel(
         layout=SWZ,
     )
     sK_restore_lead16 = SmemTile(
-        base=sK_restore_raw.data_ptr().toint(),
+        base=smem_data_ptr(sK_restore_raw).toint(),
         elems_per_stage=((cfg.operand_cosize) // (cfg.smem_decay_stages)) * bpe,
         stages=cfg.smem_decay_stages,
         leading_byte_offset=LEAD,
@@ -3403,7 +3476,7 @@ def kernel(
         layout=SWZ,
     )
     sDo_lead16 = SmemTile(
-        base=sDo_raw.data_ptr().toint(),
+        base=smem_data_ptr(sDo_raw).toint(),
         elems_per_stage=((cfg.raw_v_cosize) // (cfg.smem_raw_stages)) * bpe,
         stages=cfg.smem_raw_stages,
         leading_byte_offset=LEAD,
@@ -3411,7 +3484,7 @@ def kernel(
         layout=SWZ,
     )
     sDo_amaj = SmemTile(
-        base=sDo_raw.data_ptr().toint(),
+        base=smem_data_ptr(sDo_raw).toint(),
         elems_per_stage=((cfg.raw_v_cosize) // (cfg.smem_raw_stages)) * bpe,
         stages=cfg.smem_raw_stages,
         leading_byte_offset=cfg.b_t * 128,
@@ -3419,7 +3492,7 @@ def kernel(
         layout=SWZ,
     )
     sU_lead16 = SmemTile(
-        base=sU_raw.data_ptr().toint(),
+        base=smem_data_ptr(sU_raw).toint(),
         elems_per_stage=((cfg.b_t * cfg.d_v) // (1)) * bpe,
         stages=1,
         leading_byte_offset=LEAD,
@@ -3427,7 +3500,7 @@ def kernel(
         layout=SWZ,
     )
     sDv_lead16 = SmemTile(
-        base=sDv_raw.data_ptr().toint(),
+        base=smem_data_ptr(sDv_raw).toint(),
         elems_per_stage=((cfg.dv_cosize) // (cfg.smem_dv_stages)) * bpe,
         stages=cfg.smem_dv_stages,
         leading_byte_offset=LEAD,
@@ -3435,7 +3508,7 @@ def kernel(
         layout=SWZ,
     )
     sDstate_alt = SmemTile(
-        base=sDstate_raw.data_ptr().toint(),
+        base=smem_data_ptr(sDstate_raw).toint(),
         elems_per_stage=((cfg.d_k * cfg.d_v) // (1)) * bpe,
         stages=1,
         leading_byte_offset=STATE_ALT_LEAD,
@@ -3444,7 +3517,7 @@ def kernel(
     )
 
     sQ_decay_trans = SmemTile(
-        base=sQ_decay_raw.data_ptr().toint(),
+        base=smem_data_ptr(sQ_decay_raw).toint(),
         elems_per_stage=((cfg.operand_cosize) // (cfg.smem_decay_stages)) * bpe,
         stages=cfg.smem_decay_stages,
         leading_byte_offset=cfg.b_t * 128,
@@ -3452,7 +3525,7 @@ def kernel(
         layout=SWZ,
     )
     sK_inv_amaj = SmemTile(
-        base=sK_inv_raw.data_ptr().toint(),
+        base=smem_data_ptr(sK_inv_raw).toint(),
         elems_per_stage=((cfg.operand_cosize) // (cfg.smem_decay_stages)) * bpe,
         stages=cfg.smem_decay_stages,
         leading_byte_offset=cfg.b_t * 128,
@@ -3460,7 +3533,7 @@ def kernel(
         layout=SWZ,
     )
     sK_decay_trans = SmemTile(
-        base=sK_decay_raw.data_ptr().toint(),
+        base=smem_data_ptr(sK_decay_raw).toint(),
         elems_per_stage=((cfg.operand_cosize) // (cfg.smem_decay_stages)) * bpe,
         stages=cfg.smem_decay_stages,
         leading_byte_offset=cfg.b_t * 128,

--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_prefill_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_prefill_f16.py
@@ -129,7 +129,7 @@ from .tile_dsl.barrier import (
     PipelineState,
     Producer,
 )
-from .tile_dsl.handles import MmaDesc, SmemTile, tma_slice_runtime_desc
+from .tile_dsl.handles import MmaDesc, SmemTile, smem_data_ptr, tma_slice_runtime_desc
 from .tile_dsl.mma import mma_step, mma_ts_step
 from .tile_dsl.swizzle import swizzle_lin_S, swizzle_xor_128b
 from .tile_dsl.tma import tma_load_tile, tma_store_commit, tma_store_tile, tma_store_wait, tma_tensormap_acquire
@@ -505,16 +505,16 @@ def super_mma_warp(
             cum_chunk = cum_chunk_base + local_chunk_idx
             decay_stage = k_decay_ready.idx
             intermediate_stage = t_inv_free.idx
-            sBeta_ptr = sBeta_raw.data_ptr() + raw_index.idx * cfg.b_t
-            sK_inv_ptr = sK_inv_raw.data_ptr() + decay_stage * (cfg.b_t * cfg.d_k)
-            sK_decay_ptr = sK_decay_raw.data_ptr() + decay_stage * (cfg.d_k * cfg.b_t)
-            sIntermediate_ptr = sIntermediate_raw.data_ptr() + intermediate_stage * (2 * cfg.b_t * cfg.b_t)
+            sBeta_ptr = smem_data_ptr(sBeta_raw) + raw_index.idx * cfg.b_t
+            sK_inv_ptr = smem_data_ptr(sK_inv_raw) + decay_stage * (cfg.b_t * cfg.d_k)
+            sK_decay_ptr = smem_data_ptr(sK_decay_raw) + decay_stage * (cfg.d_k * cfg.b_t)
+            sIntermediate_ptr = smem_data_ptr(sIntermediate_raw) + intermediate_stage * (2 * cfg.b_t * cfg.b_t)
 
             bars.mb_k_decay_inv_cg0_ready[decay_stage].wait(k_decay_ready.phase)
             k_decay_ready = advance(k_decay_ready, cfg.smem_decay_stages)
 
             # ---- KK = K_decay @ K_inv^T ------------------------------------------
-            kk_acc = cutlass.Array(cutlass.Float32, 8, alignment=16)
+            kk_acc = cute.make_rmem_tensor((8,), cutlass.Float32)
             for accum_idx in cutlass.range_constexpr(8):
                 kk_acc[accum_idx] = cutlass.Float32(0.0)
 
@@ -557,7 +557,7 @@ def super_mma_warp(
             row_hi = row_lo + cutlass.Int32(8)
             beta_lo = (sBeta_ptr + row_lo).load().to(cutlass.Float32)
             beta_hi = (sBeta_ptr + row_hi).load().to(cutlass.Float32)
-            l_regs = cutlass.Array(cutlass.Float32, 8, alignment=16)
+            l_regs = cute.make_rmem_tensor((8,), cutlass.Float32)
             for accum_idx in cutlass.range_constexpr(8):
                 row_coord = row_hi if cutlass.const_expr(accum_idx % 4 >= 2) else row_lo
                 col_coord = (accum_idx // 4) * 8 + 2 * (lane % 4)
@@ -575,7 +575,7 @@ def super_mma_warp(
             l_values = cutlass.Vector.from_elements((l_a0, l_a1, l_a2, l_a3), cutlass.Int32).bitcast(cfg.io_dtype).to(cutlass.Float32)
 
             # ---- T_inv = I - L, then three Neumann doubling rounds ---------------
-            tinv_acc = cutlass.Array(cutlass.Float32, 8, alignment=16)
+            tinv_acc = cute.make_rmem_tensor((8,), cutlass.Float32)
             for accum_idx in cutlass.range_constexpr(8):
                 row_coord = row_lo
                 if cutlass.const_expr(accum_idx % 4 >= 2):
@@ -590,7 +590,7 @@ def super_mma_warp(
             mov_lpow0, mov_lpow1, mov_lpow2, mov_lpow3 = movmatrix_16b(l_a0), movmatrix_16b(l_a1), movmatrix_16b(l_a2), movmatrix_16b(l_a3)
             for _round in cutlass.range_constexpr(3):
                 # ---- Lpow = Lpow @ Lpow ------------------------------------------
-                sq_acc = cutlass.Array(cutlass.Float32, 8, alignment=16)
+                sq_acc = cute.make_rmem_tensor((8,), cutlass.Float32)
                 for accum_idx in cutlass.range_constexpr(8):
                     sq_acc[accum_idx] = cutlass.Float32(0.0)
                 mma_step(
@@ -608,7 +608,7 @@ def super_mma_warp(
                 lpow_a3 = fp32_to_fp16(sq_acc[6], sq_acc[7], dtype=cfg.io_dtype)
                 mov_lpow0, mov_lpow1, mov_lpow2, mov_lpow3 = movmatrix_16b(lpow_a0), movmatrix_16b(lpow_a1), movmatrix_16b(lpow_a2), movmatrix_16b(lpow_a3)
                 # ---- T_inv += T_inv @ Lpow ---------------------------------------
-                upd_acc = cutlass.Array(cutlass.Float32, 8, alignment=16)
+                upd_acc = cute.make_rmem_tensor((8,), cutlass.Float32)
                 for accum_idx in cutlass.range_constexpr(8):
                     upd_acc[accum_idx] = cutlass.Float32(0.0)
                 tinv_p0 = fp32_to_fp16(tinv_acc[0], tinv_acc[1], dtype=cfg.io_dtype)
@@ -960,14 +960,14 @@ def epilogue_warp(
             decay_stage = cum_chunk % cfg.smem_decay_stages
             intermediate_stage = a_free.idx
 
-            sK_inv_ptr = sK_inv_raw.data_ptr() + decay_stage * (cfg.b_t * cfg.d_k)
-            sQ_decay_ptr = sQ_decay_raw.data_ptr() + decay_stage * (cfg.d_k * cfg.b_t)
-            sIntermediate_ptr = sIntermediate_raw.data_ptr() + intermediate_stage * (2 * cfg.b_t * cfg.b_t)
+            sK_inv_ptr = smem_data_ptr(sK_inv_raw) + decay_stage * (cfg.b_t * cfg.d_k)
+            sQ_decay_ptr = smem_data_ptr(sQ_decay_raw) + decay_stage * (cfg.d_k * cfg.b_t)
+            sIntermediate_ptr = smem_data_ptr(sIntermediate_raw) + intermediate_stage * (2 * cfg.b_t * cfg.b_t)
 
             bars.mb_qk_scale_ready[qk_scale_index.idx].wait(qk_scale_index.phase)
 
             # ---- A = Q_decay @ K_inv^T ------------------------------------------
-            a_acc = cutlass.Array(cutlass.Float32, 8, alignment=16)
+            a_acc = cute.make_rmem_tensor((8,), cutlass.Float32)
             for accum_idx in cutlass.range_constexpr(8):
                 a_acc[accum_idx] = cutlass.Float32(0.0)
 
@@ -1132,14 +1132,14 @@ def compute0_warp_group(
             raw_bar_stage = cum_chunk % cfg.smem_raw_bar_stages
             state_scale_diag_stage = diag_ring_idx
             qk_scale_ready_stage = state_scale_diag_stage
-            sQ_ptr = sQ_raw.data_ptr() + raw_stage * (cfg.d_k * cfg.b_t)
-            sK_ptr = sK_raw.data_ptr() + raw_stage * (cfg.d_k * cfg.b_t)
-            sGate_ptr = sGate_raw.data_ptr() + raw_stage * (cfg.d_k * cfg.b_t)
-            sK_inv_ptr = sK_inv_raw.data_ptr() + decay_stage * (cfg.b_t * cfg.d_k)
-            sK_decay_ptr = sK_decay_raw.data_ptr() + decay_stage * (cfg.d_k * cfg.b_t)
-            sQ_decay_ptr = sQ_decay_raw.data_ptr() + decay_stage * (cfg.d_k * cfg.b_t)
-            sK_restore_ptr = sK_restore_raw.data_ptr() + decay_stage * (cfg.d_k * cfg.b_t)
-            sState_scale_diag_ptr = sState_scale_diag_raw.data_ptr() + state_scale_diag_stage * ((cfg.d_k // 16) * 256)
+            sQ_ptr = smem_data_ptr(sQ_raw) + raw_stage * (cfg.d_k * cfg.b_t)
+            sK_ptr = smem_data_ptr(sK_raw) + raw_stage * (cfg.d_k * cfg.b_t)
+            sGate_ptr = smem_data_ptr(sGate_raw) + raw_stage * (cfg.d_k * cfg.b_t)
+            sK_inv_ptr = smem_data_ptr(sK_inv_raw) + decay_stage * (cfg.b_t * cfg.d_k)
+            sK_decay_ptr = smem_data_ptr(sK_decay_raw) + decay_stage * (cfg.d_k * cfg.b_t)
+            sQ_decay_ptr = smem_data_ptr(sQ_decay_raw) + decay_stage * (cfg.d_k * cfg.b_t)
+            sK_restore_ptr = smem_data_ptr(sK_restore_raw) + decay_stage * (cfg.d_k * cfg.b_t)
+            sState_scale_diag_ptr = smem_data_ptr(sState_scale_diag_raw) + state_scale_diag_stage * ((cfg.d_k // 16) * 256)
 
             # ---- Beta scalars ---------------------------------------------------
             if cg0_local_warp == 0:
@@ -1168,11 +1168,11 @@ def compute0_warp_group(
             f32_segment = prefix_dim // 32
             prefix_seg_base = f32_segment * (cfg.b_t * 32)
             prefix_col = prefix_dim - f32_segment * 32
-            gate_raw = cutlass.Array(cutlass.Float32, cfg.b_t, alignment=16)
+            gate_raw = cute.make_rmem_tensor((cfg.b_t,), cutlass.Float32)
             for row in cutlass.range_constexpr(cfg.b_t):
                 prefix_idx = prefix_seg_base + swizzle_xor_128b(row, row * 32 + prefix_col, elem_bytes=4)
                 gate_raw[row] = (sGate_ptr + prefix_idx).load()
-            g_prefix_regs = cutlass.Array(cutlass.Float32, cfg.b_t, alignment=16)
+            g_prefix_regs = cute.make_rmem_tensor((cfg.b_t,), cutlass.Float32)
             if cutlass.const_expr(cfg.safe_gate):
                 valid_rows = seqlen_b - chunk_idx * cutlass.Int32(cfg.b_t)
                 valid_mask = cutlass.vector.create_mask([cfg.b_t], [valid_rows])
@@ -1240,9 +1240,9 @@ def compute0_warp_group(
 
             bars.mb_q_ready[raw_bar_stage].wait((cum_chunk // cfg.smem_raw_bar_stages) % 2)
             bars.mb_k_ready[raw_bar_stage].wait((cum_chunk // cfg.smem_raw_bar_stages) % 2)
-            k_inv_pack = cutlass.Array(cutlass.Int32, 2 * 4, alignment=16)
-            raw_q_regs = cutlass.Array(cutlass.Float32, 2 * 8, alignment=16)
-            raw_k_regs = cutlass.Array(cutlass.Float32, 2 * 8, alignment=16)
+            k_inv_pack = cute.make_rmem_tensor((2 * 4,), cutlass.Int32)
+            raw_q_regs = cute.make_rmem_tensor((2 * 8,), cutlass.Float32)
+            raw_k_regs = cute.make_rmem_tensor((2 * 8,), cutlass.Float32)
 
             # ---- optional Q/K L2-norm -------------------------------------------
             if cutlass.const_expr(cfg.l2norm):
@@ -1287,8 +1287,8 @@ def compute0_warp_group(
                 k_inv_norm = cute.math.rsqrt(cute.math.max(k_sum_sq, norm_floor_sq), fastmath=True)
 
             # ---- decay/restore operands: exp2(+-G) ------------------------------
-            exp_g_regs = cutlass.Array(cutlass.Float32, 2 * 8, alignment=16)
-            exp_g_last_regs = cutlass.Array(cutlass.Float32, 2 * 8, alignment=16)
+            exp_g_regs = cute.make_rmem_tensor((2 * 8,), cutlass.Float32)
+            exp_g_last_regs = cute.make_rmem_tensor((2 * 8,), cutlass.Float32)
             for dim_half in cutlass.range_constexpr(2):
                 dim_base = dim_half * (cfg.d_k // 2) + lane_in_row_group * 8
                 reg_base = dim_half * 8
@@ -1310,7 +1310,7 @@ def compute0_warp_group(
                 reg_base = dim_half * 8
 
                 # ---- K decay + K_inv operands: K * exp2(+G) and K * exp2(-G) -----
-                k_decay_pack = cutlass.Array(cutlass.Int32, 4, alignment=16)
+                k_decay_pack = cute.make_rmem_tensor((4,), cutlass.Int32)
                 for pair_idx in cutlass.range_constexpr(4):
                     dim0 = pair_idx * 2
                     dim1 = dim0 + 1
@@ -1367,7 +1367,7 @@ def compute0_warp_group(
             for dim_half in cutlass.range_constexpr(2):
                 dim_base = dim_half * (cfg.d_k // 2) + lane_in_row_group * 8
                 reg_base = dim_half * 8
-                q_decay_pack = cutlass.Array(cutlass.Int32, 4, alignment=16)
+                q_decay_pack = cute.make_rmem_tensor((4,), cutlass.Int32)
                 for pair_idx in cutlass.range_constexpr(4):
                     dim0 = pair_idx * 2
                     dim1 = dim0 + 1
@@ -1399,7 +1399,7 @@ def compute0_warp_group(
             for dim_half in cutlass.range_constexpr(2):
                 dim_base = dim_half * (cfg.d_k // 2) + lane_in_row_group * 8
                 reg_base = dim_half * 8
-                k_restore_pack = cutlass.Array(cutlass.Int32, 4, alignment=16)
+                k_restore_pack = cute.make_rmem_tensor((4,), cutlass.Int32)
                 for pair_idx in cutlass.range_constexpr(4):
                     dim0 = pair_idx * 2
                     dim1 = dim0 + 1
@@ -1453,7 +1453,7 @@ def compute1_warp_group(
     """CG1 warp role (warps 8-11): persistent scheduler loop for the
     value-side TMEM staging, output drain, and state stores."""
     nvvm.setmaxregister(cfg.num_regs_compute_group_1, nvvm.SetMaxRegisterAction.INCREASE)
-    sO_ptr = sO_raw.data_ptr()
+    sO_ptr = smem_data_ptr(sO_raw)
     nvvm.barrier_cta_sync(cfg.tmem_lifecycle_barrier_id, thread_count=cfg.tmem_user_threads)
     tmem_base = tmem_base_slot.load()
     tmem_col = tmem_base & 0xFFFF
@@ -1507,7 +1507,7 @@ def compute1_warp_group(
                     seed_vw = 16 // (mState_init.element_type.width // 8)
                     seed_src = (mState_init.iterator + mState_init.layout((batch_idx, head_o, value_dim, 0))).raw_ptr()
                     for key_block_start in cutlass.range_constexpr(0, cfg.d_k, 32):
-                        state_block = cutlass.Array(cutlass.Float32, 32, alignment=16)
+                        state_block = cute.make_rmem_tensor((32,), cutlass.Float32)
                         for g in cutlass.range_constexpr(32 // seed_vw):
                             seed_chunk = (seed_src + key_block_start + g * seed_vw).load(count=seed_vw, alignment=16)
                             for t in cutlass.range_constexpr(seed_vw):
@@ -1516,23 +1516,23 @@ def compute1_warp_group(
                         nvvm.tcgen05_st(
                             "32x32b",
                             nvvm.make_tmem_ptr((row_id << 16) + (tmem_col + cfg.tmem_state_acc_offset + key_block_start), cutlass.Float32),
-                            state_block[0:32],
+                            state_block.load(),
                         )
                 else:
                     for key_block_start in cutlass.range_constexpr(0, cfg.d_k, 32):
-                        state_block = cutlass.Array(cutlass.Float32, 32, alignment=16)
+                        state_block = cute.make_rmem_tensor((32,), cutlass.Float32)
                         for col in cutlass.range_constexpr(32):
                             state_block[col] = cutlass.Float32(0.0)
 
                         nvvm.tcgen05_st(
                             "32x32b",
                             nvvm.make_tmem_ptr((row_id << 16) + (tmem_col + cfg.tmem_state_acc_offset + key_block_start), cutlass.Float32),
-                            state_block[0:32],
+                            state_block.load(),
                         )
             if cutlass.const_expr(mState_init is not None):
                 nvvm.tcgen05_wait("store")
-            sV_ptr = sV_raw.data_ptr() + raw_index.idx * (cfg.d_v * cfg.b_t)
-            sBeta_ptr = sBeta_raw.data_ptr() + raw_bar_index.idx * cfg.b_t
+            sV_ptr = smem_data_ptr(sV_raw) + raw_index.idx * (cfg.d_v * cfg.b_t)
+            sBeta_ptr = smem_data_ptr(sBeta_raw) + raw_bar_index.idx * cfg.b_t
 
             # ---- state repack: acc TMEM -> packed b16 TMEM ----------------------
             if cutlass.const_expr(mState_init is not None):
@@ -1541,14 +1541,14 @@ def compute1_warp_group(
                     state_vecs.append(nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(row_addr + state_col_id + sub * 16, cutlass.Float32), num=16))
 
                 for sub in cutlass.range_constexpr(cfg.d_k // 16):
-                    packed_state = cutlass.Array(cutlass.Int32, 8, alignment=16)
+                    packed_state = cute.make_rmem_tensor((8,), cutlass.Int32)
                     for packed_col in cutlass.range_constexpr(8):
                         source_pair = packed_col ^ 4
                         packed_state[packed_col] = fp32_to_fp16(state_vecs[sub][2 * source_pair], state_vecs[sub][2 * source_pair + 1], dtype=cfg.io_dtype)
                     nvvm.tcgen05_st(
                         "32x32b",
                         nvvm.make_tmem_ptr((tmem_row << 16) + packed_col_id + sub * 8, cutlass.Int8),
-                        packed_state[0:8],
+                        packed_state.load(),
                     )
                 nvvm.tcgen05_wait("store")
                 bars.mb_state_inp_ready.arrive()
@@ -1572,13 +1572,13 @@ def compute1_warp_group(
                 state_k_vec0 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr(row_addr + state_k_col_id, cutlass.Float32), num=2)
                 state_k_vec1 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr(row16_addr + state_k_col_id, cutlass.Float32), num=2)
 
-            beta_pack = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            beta_pack = cute.make_rmem_tensor((4,), cutlass.Int32)
             for reg_idx in cutlass.range_constexpr(4):
                 token0 = (((reg_idx // 2) * 4 + (lane & 3)) ^ 4) * 2
                 beta0 = (sBeta_ptr + token0).load().to(cutlass.Float32)
                 beta1 = (sBeta_ptr + token0 + 1).load().to(cutlass.Float32)
                 beta_pack[reg_idx] = fp32_to_fp16(beta0, beta1, dtype=cfg.io_dtype)
-            y_inp_pack0 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            y_inp_pack0 = cute.make_rmem_tensor((4,), cutlass.Int32)
             for reg_idx in cutlass.range_constexpr(4):
                 raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
                 frag_pair = (reg_idx ^ 2) * 2
@@ -1598,7 +1598,7 @@ def compute1_warp_group(
                     cfg.io_dtype,
                 )
 
-            y_inp_pack1 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            y_inp_pack1 = cute.make_rmem_tensor((4,), cutlass.Int32)
             for reg_idx in cutlass.range_constexpr(4):
                 raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
                 frag_pair = (reg_idx ^ 2) * 2
@@ -1618,8 +1618,8 @@ def compute1_warp_group(
                     cfg.io_dtype,
                 )
 
-            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row_addr + y_inp_col_id, cutlass.Int8), y_inp_pack0[0:4])
-            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row16_addr + y_inp_col_id, cutlass.Int8), y_inp_pack1[0:4])
+            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row_addr + y_inp_col_id, cutlass.Int8), y_inp_pack0.load())
+            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row16_addr + y_inp_col_id, cutlass.Int8), y_inp_pack1.load())
             nvvm.tcgen05_wait("store")
             if cutlass.const_expr(mState_init is not None):
                 state_k_acc_index = advance(state_k_acc_index, 1)
@@ -1635,7 +1635,7 @@ def compute1_warp_group(
                 num=cfg.b_t,
             )
 
-            u_inp_pack = cutlass.Array(cutlass.Int32, (cfg.b_t // 2), alignment=16)
+            u_inp_pack = cute.make_rmem_tensor((cfg.b_t // 2,), cutlass.Int32)
             for packed_col in cutlass.range_constexpr((cfg.b_t // 2)):
                 source_pair = packed_col ^ 4
                 token0 = source_pair * 2
@@ -1645,7 +1645,7 @@ def compute1_warp_group(
             nvvm.tcgen05_st(
                 "32x32b",
                 nvvm.make_tmem_ptr(u_inp_addr, cutlass.Int8),
-                u_inp_pack[0 : (cfg.b_t // 2)],
+                u_inp_pack.load(),
             )
             nvvm.tcgen05_wait("store")
             u_acc_index = advance(u_acc_index, 1)
@@ -1656,8 +1656,8 @@ def compute1_warp_group(
 
         for local_chunk_idx in cutlass.range(1, num_chunks_tile, 1, unroll=1):
             cum_chunk = cum_chunk_base + local_chunk_idx
-            sV_ptr = sV_raw.data_ptr() + raw_index.idx * (cfg.d_v * cfg.b_t)
-            sBeta_ptr = sBeta_raw.data_ptr() + raw_bar_index.idx * cfg.b_t
+            sV_ptr = smem_data_ptr(sV_raw) + raw_index.idx * (cfg.d_v * cfg.b_t)
+            sBeta_ptr = smem_data_ptr(sBeta_raw) + raw_bar_index.idx * cfg.b_t
 
             prev_cum_chunk = cum_chunk - cutlass.Int32(1)
             prev_o_stage = prev_cum_chunk % cfg.smem_o_stages
@@ -1672,14 +1672,14 @@ def compute1_warp_group(
                 state_vecs.append(nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(row_addr + state_col_id + sub * 16, cutlass.Float32), num=16))
 
             for sub in cutlass.range_constexpr(cfg.d_k // 16):
-                packed_state = cutlass.Array(cutlass.Int32, 8, alignment=16)
+                packed_state = cute.make_rmem_tensor((8,), cutlass.Int32)
                 for packed_col in cutlass.range_constexpr(8):
                     source_pair = packed_col ^ 4
                     packed_state[packed_col] = fp32_to_fp16(state_vecs[sub][2 * source_pair], state_vecs[sub][2 * source_pair + 1], dtype=cfg.io_dtype)
                 nvvm.tcgen05_st(
                     "32x32b",
                     nvvm.make_tmem_ptr((tmem_row << 16) + packed_col_id + sub * 8, cutlass.Int8),
-                    packed_state[0:8],
+                    packed_state.load(),
                 )
             nvvm.tcgen05_wait("store")
             bars.mb_state_inp_ready.arrive()
@@ -1691,8 +1691,8 @@ def compute1_warp_group(
             loaded_vec1 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr(row16_addr + projection_col_id, cutlass.Float32), num=2)
 
             # ---- output drain: O acc TMEM -> scaled b16 SMEM --------------------
-            stsm_pack0 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
-            stsm_pack1 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            stsm_pack0 = cute.make_rmem_tensor((4,), cutlass.Int32)
+            stsm_pack1 = cute.make_rmem_tensor((4,), cutlass.Int32)
             for reg_idx in cutlass.range_constexpr(4):
                 scaled0_0, scaled0_1 = fmul2(loaded_vec0[2 * reg_idx], loaded_vec0[2 * reg_idx + 1], scale, scale)
                 scaled1_0, scaled1_1 = fmul2(loaded_vec1[2 * reg_idx], loaded_vec1[2 * reg_idx + 1], scale, scale)
@@ -1702,13 +1702,13 @@ def compute1_warp_group(
             bars.mb_o_tmastg_done[prev_o_stage].wait(((prev_cum_chunk // cfg.smem_o_stages) + 1) % 2)
             nvvm.stmatrix(
                 sO_ptr + prev_o_stage_base + ov_swz_off0,
-                stsm_pack0.data_ptr().load(count=4, alignment=4),
+                stsm_pack0.load(),
                 nvvm.MMALayout.COL,
                 shape=nvvm.StoreShape.M8N8,
             )
             nvvm.stmatrix(
                 sO_ptr + prev_o_stage_base + ov_swz_off,
-                stsm_pack1.data_ptr().load(count=4, alignment=4),
+                stsm_pack1.load(),
                 nvvm.MMALayout.COL,
                 shape=nvvm.StoreShape.M8N8,
             )
@@ -1734,13 +1734,13 @@ def compute1_warp_group(
             state_k_vec0 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr(row_addr + state_k_col_id, cutlass.Float32), num=2)
             state_k_vec1 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr(row16_addr + state_k_col_id, cutlass.Float32), num=2)
 
-            beta_pack = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            beta_pack = cute.make_rmem_tensor((4,), cutlass.Int32)
             for reg_idx in cutlass.range_constexpr(4):
                 token0 = (((reg_idx // 2) * 4 + (lane & 3)) ^ 4) * 2
                 beta0 = (sBeta_ptr + token0).load().to(cutlass.Float32)
                 beta1 = (sBeta_ptr + token0 + 1).load().to(cutlass.Float32)
                 beta_pack[reg_idx] = fp32_to_fp16(beta0, beta1, dtype=cfg.io_dtype)
-            y_inp_pack0 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            y_inp_pack0 = cute.make_rmem_tensor((4,), cutlass.Int32)
             for reg_idx in cutlass.range_constexpr(4):
                 raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
                 frag_pair = (reg_idx ^ 2) * 2
@@ -1757,7 +1757,7 @@ def compute1_warp_group(
                     cfg.io_dtype,
                 )
 
-            y_inp_pack1 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            y_inp_pack1 = cute.make_rmem_tensor((4,), cutlass.Int32)
             for reg_idx in cutlass.range_constexpr(4):
                 raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
                 frag_pair = (reg_idx ^ 2) * 2
@@ -1774,8 +1774,8 @@ def compute1_warp_group(
                     cfg.io_dtype,
                 )
 
-            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row_addr + y_inp_col_id, cutlass.Int8), y_inp_pack0[0:4])
-            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row16_addr + y_inp_col_id, cutlass.Int8), y_inp_pack1[0:4])
+            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row_addr + y_inp_col_id, cutlass.Int8), y_inp_pack0.load())
+            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row16_addr + y_inp_col_id, cutlass.Int8), y_inp_pack1.load())
             nvvm.tcgen05_wait("store")
             state_k_acc_index = advance(state_k_acc_index, 1)
             bars.mb_v_done[raw_index.idx].arrive()
@@ -1790,7 +1790,7 @@ def compute1_warp_group(
                 num=cfg.b_t,
             )
 
-            u_inp_pack = cutlass.Array(cutlass.Int32, (cfg.b_t // 2), alignment=16)
+            u_inp_pack = cute.make_rmem_tensor((cfg.b_t // 2,), cutlass.Int32)
             for packed_col in cutlass.range_constexpr((cfg.b_t // 2)):
                 source_pair = packed_col ^ 4
                 token0 = source_pair * 2
@@ -1800,7 +1800,7 @@ def compute1_warp_group(
             nvvm.tcgen05_st(
                 "32x32b",
                 nvvm.make_tmem_ptr(u_inp_addr, cutlass.Int8),
-                u_inp_pack[0 : (cfg.b_t // 2)],
+                u_inp_pack.load(),
             )
             nvvm.tcgen05_wait("store")
             u_acc_index = advance(u_acc_index, 1)
@@ -1825,8 +1825,8 @@ def compute1_warp_group(
             loaded_vec1 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr(row16_addr + projection_col_id, cutlass.Float32), num=2)
 
             # ---- output drain: O acc TMEM -> scaled b16 SMEM --------------------
-            stsm_pack0 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
-            stsm_pack1 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            stsm_pack0 = cute.make_rmem_tensor((4,), cutlass.Int32)
+            stsm_pack1 = cute.make_rmem_tensor((4,), cutlass.Int32)
             for reg_idx in cutlass.range_constexpr(4):
                 scaled0_0, scaled0_1 = fmul2(loaded_vec0[2 * reg_idx], loaded_vec0[2 * reg_idx + 1], scale, scale)
                 scaled1_0, scaled1_1 = fmul2(loaded_vec1[2 * reg_idx], loaded_vec1[2 * reg_idx + 1], scale, scale)
@@ -1836,13 +1836,13 @@ def compute1_warp_group(
             bars.mb_o_tmastg_done[final_o_stage].wait(((last_cum_chunk // cfg.smem_o_stages) + 1) % 2)
             nvvm.stmatrix(
                 sO_ptr + final_o_stage_base + ov_swz_off0,
-                stsm_pack0.data_ptr().load(count=4, alignment=4),
+                stsm_pack0.load(),
                 nvvm.MMALayout.COL,
                 shape=nvvm.StoreShape.M8N8,
             )
             nvvm.stmatrix(
                 sO_ptr + final_o_stage_base + ov_swz_off,
-                stsm_pack1.data_ptr().load(count=4, alignment=4),
+                stsm_pack1.load(),
                 nvvm.MMALayout.COL,
                 shape=nvvm.StoreShape.M8N8,
             )
@@ -1938,9 +1938,51 @@ class KdaPrefillOp:
         cfg = self.cfg
         num_sequences = cu_seqlens.shape[0] - 1
 
+        @cute.struct
+        class SharedStorage:
+            k_decay: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.k_decay_cosize],
+                cfg.buffer_align_bytes,
+            ]
+            q_decay: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.q_decay_cosize],
+                cfg.buffer_align_bytes,
+            ]
+            k_restore: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.k_restore_cosize],
+                cfg.buffer_align_bytes,
+            ]
+            intermediate: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.intermediate_cosize],
+                cfg.buffer_align_bytes,
+            ]
+            q: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.q_cosize], cfg.buffer_align_bytes
+            ]
+            k: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.k_cosize], cfg.buffer_align_bytes
+            ]
+            v: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.v_cosize], cfg.buffer_align_bytes
+            ]
+            gate: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, cfg.gate_cosize], 1024
+            ]
+            state_scale_diag: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.state_scale_diag_cosize],
+                cfg.buffer_align_bytes,
+            ]
+            k_inv: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.k_inv_cosize], cfg.buffer_align_bytes
+            ]
+            output: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.o_cosize], cfg.buffer_align_bytes
+            ]
+
         kernel.set_name_prefix(self.get_name())
         kernel(
             cfg,
+            SharedStorage,
             tensormap_workspace,
             cutlass.Int32(num_sequences),
             q,
@@ -1969,6 +2011,7 @@ class KdaPrefillOp:
 @cute.kernel
 def kernel(
     cfg: cutlass.Constexpr,
+    shared_type: cutlass.Constexpr,
     tensormap_workspace: cute.Tensor,
     n_desc: cutlass.Int32,
     mQ: cute.Tensor,
@@ -2021,28 +2064,33 @@ def kernel(
     desc_gate_base = desc_base_words + cutlass.Int32(3) * arr_words
     desc_o_base = desc_base_words + cutlass.Int32(4) * arr_words
 
-    # Buffers are declaration-ordered and intentionally non-aliased.
+    # Barrier/control rings stay declaration-ordered; data buffers share one storage allocation.
     SMEM = cutlass.AddressSpace.smem
     bars = make_kda_bars(cfg)
     tmem_base_slot = cutlass.Array(cutlass.Int32, 1, space=SMEM, alignment=4)
     sSched = cutlass.Array(cutlass.Int32, cfg.sched_stages, space=SMEM, alignment=16)
-    sK_decay_raw = cutlass.Array(cfg.io_dtype, cfg.k_decay_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
-    sQ_decay_raw = cutlass.Array(cfg.io_dtype, cfg.q_decay_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
-    sK_restore_raw = cutlass.Array(cfg.io_dtype, cfg.k_restore_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
-    sIntermediate_raw = cutlass.Array(cfg.io_dtype, cfg.intermediate_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
-    sQ_raw = cutlass.Array(mQ.element_type, cfg.q_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
-    sK_raw = cutlass.Array(mK.element_type, cfg.k_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
-    sV_raw = cutlass.Array(mV.element_type, cfg.v_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
-    sGate_raw = cutlass.Array(cutlass.Float32, cfg.gate_cosize, space=SMEM, alignment=1024)
-    sState_scale_diag_raw = cutlass.Array(cfg.io_dtype, cfg.state_scale_diag_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
-    sK_inv_raw = cutlass.Array(cfg.io_dtype, cfg.k_inv_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
-    sO_raw = cutlass.Array(
-        mO.element_type,
-        cfg.o_cosize,
+    storage = cutlass.utils.SmemAllocator().allocate(shared_type)
+    sK_decay_raw = storage.k_decay.get_tensor(cute.make_layout((cfg.k_decay_cosize,)))
+    sQ_decay_raw = storage.q_decay.get_tensor(cute.make_layout((cfg.q_decay_cosize,)))
+    sK_restore_raw = storage.k_restore.get_tensor(cute.make_layout((cfg.k_restore_cosize,)))
+    sIntermediate_raw = storage.intermediate.get_tensor(
+        cute.make_layout((cfg.intermediate_cosize,))
+    )
+    sQ_raw = storage.q.get_tensor(cute.make_layout((cfg.q_cosize,)))
+    sK_raw = storage.k.get_tensor(cute.make_layout((cfg.k_cosize,)))
+    sV_raw = storage.v.get_tensor(cute.make_layout((cfg.v_cosize,)))
+    sGate_raw = storage.gate.get_tensor(cute.make_layout((cfg.gate_cosize,)))
+    sState_scale_diag_raw = storage.state_scale_diag.get_tensor(
+        cute.make_layout((cfg.state_scale_diag_cosize,))
+    )
+    sK_inv_raw = storage.k_inv.get_tensor(cute.make_layout((cfg.k_inv_cosize,)))
+    sO_raw = storage.output.get_tensor(cute.make_layout((cfg.o_cosize,)))
+    sBeta_raw = cutlass.Array(
+        cutlass.Float32,
+        cfg.beta_cosize,
         space=SMEM,
         alignment=cfg.buffer_align_bytes,
     )
-    sBeta_raw = cutlass.Array(cutlass.Float32, cfg.beta_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
     sK_decay = SmemTile(
         base=sK_decay_raw,
         elems_per_stage=(cfg.d_k * cfg.b_t),

--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_recompute_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_recompute_f16.py
@@ -126,7 +126,12 @@ from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.barrier import (
     PipelineState,
     Producer,
 )
-from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.handles import MmaDesc, SmemTile, tma_slice_runtime_desc
+from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.handles import (
+    MmaDesc,
+    SmemTile,
+    smem_data_ptr,
+    tma_slice_runtime_desc,
+)
 from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.mma import mma_step, mma_ts_step
 from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.swizzle import swizzle_lin_S, swizzle_xor_128b
 from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.tma import tma_load_tile, tma_store_commit, tma_store_tile, tma_store_wait, tma_tensormap_acquire
@@ -445,16 +450,16 @@ def super_mma_warp(
             cum_chunk = cum_chunk_base + local_chunk_idx
             decay_stage = k_decay_ready.idx
             intermediate_stage = t_inv_free.idx
-            sBeta_ptr = sBeta_raw.data_ptr() + raw_index.idx * cfg.b_t
-            sK_inv_ptr = sK_inv_raw.data_ptr() + decay_stage * (cfg.b_t * cfg.d_k)
-            sK_decay_ptr = sK_decay_raw.data_ptr() + decay_stage * (cfg.d_k * cfg.b_t)
-            sIntermediate_ptr = sIntermediate_raw.data_ptr() + intermediate_stage * (2 * cfg.b_t * cfg.b_t)
+            sBeta_ptr = smem_data_ptr(sBeta_raw) + raw_index.idx * cfg.b_t
+            sK_inv_ptr = smem_data_ptr(sK_inv_raw) + decay_stage * (cfg.b_t * cfg.d_k)
+            sK_decay_ptr = smem_data_ptr(sK_decay_raw) + decay_stage * (cfg.d_k * cfg.b_t)
+            sIntermediate_ptr = smem_data_ptr(sIntermediate_raw) + intermediate_stage * (2 * cfg.b_t * cfg.b_t)
 
             bars.mb_k_decay_inv_cg0_ready[decay_stage].wait(k_decay_ready.phase)
             k_decay_ready = advance(k_decay_ready, cfg.smem_decay_stages)
 
             # ---- KK = K_decay @ K_inv^T ------------------------------------------
-            kk_acc = cutlass.Array(cutlass.Float32, 8, alignment=16)
+            kk_acc = cute.make_rmem_tensor((8,), cutlass.Float32)
             for accum_idx in cutlass.range_constexpr(8):
                 kk_acc[accum_idx] = cutlass.Float32(0.0)
 
@@ -497,7 +502,7 @@ def super_mma_warp(
             row_hi = row_lo + cutlass.Int32(8)
             beta_lo = (sBeta_ptr + row_lo).load().to(cutlass.Float32)
             beta_hi = (sBeta_ptr + row_hi).load().to(cutlass.Float32)
-            l_regs = cutlass.Array(cutlass.Float32, 8, alignment=16)
+            l_regs = cute.make_rmem_tensor((8,), cutlass.Float32)
             for accum_idx in cutlass.range_constexpr(8):
                 row_coord = row_hi if cutlass.const_expr(accum_idx % 4 >= 2) else row_lo
                 col_coord = (accum_idx // 4) * 8 + 2 * (lane % 4)
@@ -515,7 +520,7 @@ def super_mma_warp(
             l_values = cutlass.Vector.from_elements((l_a0, l_a1, l_a2, l_a3), cutlass.Int32).bitcast(cfg.io_dtype).to(cutlass.Float32)
 
             # ---- T_inv = I - L, then three Neumann doubling rounds ---------------
-            tinv_acc = cutlass.Array(cutlass.Float32, 8, alignment=16)
+            tinv_acc = cute.make_rmem_tensor((8,), cutlass.Float32)
             for accum_idx in cutlass.range_constexpr(8):
                 row_coord = row_lo
                 if cutlass.const_expr(accum_idx % 4 >= 2):
@@ -530,7 +535,7 @@ def super_mma_warp(
             mov_lpow0, mov_lpow1, mov_lpow2, mov_lpow3 = movmatrix_16b(l_a0), movmatrix_16b(l_a1), movmatrix_16b(l_a2), movmatrix_16b(l_a3)
             for _round in cutlass.range_constexpr(3):
                 # ---- Lpow = Lpow @ Lpow ------------------------------------------
-                sq_acc = cutlass.Array(cutlass.Float32, 8, alignment=16)
+                sq_acc = cute.make_rmem_tensor((8,), cutlass.Float32)
                 for accum_idx in cutlass.range_constexpr(8):
                     sq_acc[accum_idx] = cutlass.Float32(0.0)
                 mma_step(
@@ -548,7 +553,7 @@ def super_mma_warp(
                 lpow_a3 = fp32_to_fp16(sq_acc[6], sq_acc[7], dtype=cfg.io_dtype)
                 mov_lpow0, mov_lpow1, mov_lpow2, mov_lpow3 = movmatrix_16b(lpow_a0), movmatrix_16b(lpow_a1), movmatrix_16b(lpow_a2), movmatrix_16b(lpow_a3)
                 # ---- T_inv += T_inv @ Lpow ---------------------------------------
-                upd_acc = cutlass.Array(cutlass.Float32, 8, alignment=16)
+                upd_acc = cute.make_rmem_tensor((8,), cutlass.Float32)
                 for accum_idx in cutlass.range_constexpr(8):
                     upd_acc[accum_idx] = cutlass.Float32(0.0)
                 tinv_p0 = fp32_to_fp16(tinv_acc[0], tinv_acc[1], dtype=cfg.io_dtype)
@@ -952,12 +957,12 @@ def compute0_warp_group(
             raw_stage = cum_chunk % cfg.smem_raw_stages
             state_scale_diag_stage = diag_ring_stage
             qk_scale_ready_stage = state_scale_diag_stage
-            sK_ptr = sK_raw.data_ptr() + raw_stage * (cfg.d_k * cfg.b_t)
-            sGate_ptr = sGate_raw.data_ptr() + raw_stage * (cfg.d_k * cfg.b_t)
-            sK_inv_ptr = sK_inv_raw.data_ptr() + decay_stage * (cfg.b_t * cfg.d_k)
-            sK_decay_ptr = sK_decay_raw.data_ptr() + decay_stage * (cfg.d_k * cfg.b_t)
-            sK_restore_ptr = sK_restore_raw.data_ptr() + decay_stage * (cfg.d_k * cfg.b_t)
-            sState_scale_diag_ptr = sState_scale_diag_raw.data_ptr() + state_scale_diag_stage * ((cfg.d_k // 16) * 256)
+            sK_ptr = smem_data_ptr(sK_raw) + raw_stage * (cfg.d_k * cfg.b_t)
+            sGate_ptr = smem_data_ptr(sGate_raw) + raw_stage * (cfg.d_k * cfg.b_t)
+            sK_inv_ptr = smem_data_ptr(sK_inv_raw) + decay_stage * (cfg.b_t * cfg.d_k)
+            sK_decay_ptr = smem_data_ptr(sK_decay_raw) + decay_stage * (cfg.d_k * cfg.b_t)
+            sK_restore_ptr = smem_data_ptr(sK_restore_raw) + decay_stage * (cfg.d_k * cfg.b_t)
+            sState_scale_diag_ptr = smem_data_ptr(sState_scale_diag_raw) + state_scale_diag_stage * ((cfg.d_k // 16) * 256)
 
             # ---- Beta scalars ---------------------------------------------------
             if cg0_local_warp == 0:
@@ -986,11 +991,11 @@ def compute0_warp_group(
             f32_segment = prefix_dim // 32
             prefix_seg_base = f32_segment * (cfg.b_t * 32)
             prefix_col = prefix_dim - f32_segment * 32
-            gate_raw = cutlass.Array(cutlass.Float32, cfg.b_t, alignment=16)
+            gate_raw = cute.make_rmem_tensor((cfg.b_t,), cutlass.Float32)
             for row in cutlass.range_constexpr(cfg.b_t):
                 prefix_idx = prefix_seg_base + swizzle_xor_128b(row, row * 32 + prefix_col, elem_bytes=4)
                 gate_raw[row] = (sGate_ptr + prefix_idx).load()
-            g_prefix_regs = cutlass.Array(cutlass.Float32, cfg.b_t, alignment=16)
+            g_prefix_regs = cute.make_rmem_tensor((cfg.b_t,), cutlass.Float32)
             if cutlass.const_expr(cfg.safe_gate):
                 valid_rows = seqlen_b - chunk_idx * cutlass.Int32(cfg.b_t)
                 valid_mask = cutlass.vector.create_mask([cfg.b_t], [valid_rows])
@@ -1057,8 +1062,8 @@ def compute0_warp_group(
             nvvm.barrier_cta_sync(cfg.cg0_group_sync_barrier_base_id + cg0_group_id, thread_count=cfg.cg0_threads_per_group)
 
             bars.mb_k_ready[raw_stage].wait((cum_chunk // cfg.smem_raw_stages) % 2)
-            k_inv_pack = cutlass.Array(cutlass.Int32, 2 * 4, alignment=16)
-            raw_k_regs = cutlass.Array(cutlass.Float32, 2 * 8, alignment=16)
+            k_inv_pack = cute.make_rmem_tensor((2 * 4,), cutlass.Int32)
+            raw_k_regs = cute.make_rmem_tensor((2 * 8,), cutlass.Float32)
 
             # ---- optional K L2-norm + K_inv staging ------------------------------
             if cutlass.const_expr(cfg.l2norm):
@@ -1091,8 +1096,8 @@ def compute0_warp_group(
                 k_inv_norm = cute.math.rsqrt(cute.math.max(k_sum_sq, norm_floor_sq), fastmath=True)
 
             # ---- decay/restore operands: exp2(+-g) applied per key channel -------
-            exp_g_regs = cutlass.Array(cutlass.Float32, 2 * 8, alignment=16)
-            exp_g_last_regs = cutlass.Array(cutlass.Float32, 2 * 8, alignment=16)
+            exp_g_regs = cute.make_rmem_tensor((2 * 8,), cutlass.Float32)
+            exp_g_last_regs = cute.make_rmem_tensor((2 * 8,), cutlass.Float32)
             for dim_half in cutlass.range_constexpr(2):
                 dim_base = dim_half * (cfg.d_k // 2) + lane_in_row_group * 8
                 reg_base = dim_half * 8
@@ -1114,7 +1119,7 @@ def compute0_warp_group(
                 reg_base = dim_half * 8
 
                 # ---- K decay + K_inv operands: K * exp2(+g) and K * exp2(-g) -----
-                k_decay_pack = cutlass.Array(cutlass.Int32, 4, alignment=16)
+                k_decay_pack = cute.make_rmem_tensor((4,), cutlass.Int32)
                 for pair_idx in cutlass.range_constexpr(4):
                     dim0 = pair_idx * 2
                     dim1 = dim0 + 1
@@ -1169,7 +1174,7 @@ def compute0_warp_group(
             for dim_half in cutlass.range_constexpr(2):
                 dim_base = dim_half * (cfg.d_k // 2) + lane_in_row_group * 8
                 reg_base = dim_half * 8
-                k_restore_pack = cutlass.Array(cutlass.Int32, 4, alignment=16)
+                k_restore_pack = cute.make_rmem_tensor((4,), cutlass.Int32)
                 for pair_idx in cutlass.range_constexpr(4):
                     dim0 = pair_idx * 2
                     dim1 = dim0 + 1
@@ -1224,7 +1229,7 @@ def compute1_warp_group(
     """CG1 warp-group role (warps 8-11): persistent scheduler loop staging the
     value-side TMEM operands and storing the checkpoint/final states."""
     nvvm.setmaxregister(cfg.num_regs_compute_group_1, nvvm.SetMaxRegisterAction.INCREASE)
-    sCheckpoint_ptr = sCheckpoint_raw.data_ptr() if cutlass.const_expr(cfg.enable_checkpoints) else sV_raw.data_ptr()
+    sCheckpoint_ptr = smem_data_ptr(sCheckpoint_raw) if cutlass.const_expr(cfg.enable_checkpoints) else smem_data_ptr(sV_raw)
     checkpoint_done_index = PipelineState.start(phase=1)
     nvvm.barrier_cta_sync(cfg.tmem_lifecycle_barrier_id, thread_count=cfg.tmem_user_threads)
     tmem_base = sTmem_base.load()
@@ -1280,7 +1285,7 @@ def compute1_warp_group(
                     seed_vw = 16 // (mState_init.element_type.width // 8)
                     seed_src = (mState_init.iterator + mState_init.layout((batch_idx, head_o, value_dim, 0))).raw_ptr()
                     for key_block_start in cutlass.range_constexpr(0, cfg.d_k, 32):
-                        state_block = cutlass.Array(cutlass.Float32, 32, alignment=16)
+                        state_block = cute.make_rmem_tensor((32,), cutlass.Float32)
                         for g in cutlass.range_constexpr(32 // seed_vw):
                             seed_chunk = (seed_src + key_block_start + g * seed_vw).load(count=seed_vw, alignment=16)
                             for t in cutlass.range_constexpr(seed_vw):
@@ -1289,23 +1294,23 @@ def compute1_warp_group(
                         nvvm.tcgen05_st(
                             "32x32b",
                             nvvm.make_tmem_ptr((row_id << 16) + (tmem_col + cfg.tmem_state_acc_offset + key_block_start), cutlass.Float32),
-                            state_block[0:32],
+                            state_block.load(),
                         )
                 else:
                     for key_block_start in cutlass.range_constexpr(0, cfg.d_k, 32):
-                        state_block = cutlass.Array(cutlass.Float32, 32, alignment=16)
+                        state_block = cute.make_rmem_tensor((32,), cutlass.Float32)
                         for col in cutlass.range_constexpr(32):
                             state_block[col] = cutlass.Float32(0.0)
 
                         nvvm.tcgen05_st(
                             "32x32b",
                             nvvm.make_tmem_ptr((row_id << 16) + (tmem_col + cfg.tmem_state_acc_offset + key_block_start), cutlass.Float32),
-                            state_block[0:32],
+                            state_block.load(),
                         )
             if cutlass.const_expr(mState_init is not None):
                 nvvm.tcgen05_wait("store")
-            sV_ptr = sV_raw.data_ptr() + raw_index.idx * (cfg.d_v * cfg.b_t)
-            sBeta_ptr = sBeta_raw.data_ptr() + raw_index.idx * cfg.b_t
+            sV_ptr = smem_data_ptr(sV_raw) + raw_index.idx * (cfg.d_v * cfg.b_t)
+            sBeta_ptr = smem_data_ptr(sBeta_raw) + raw_index.idx * cfg.b_t
 
             # ---- state repack: acc TMEM -> packed b16 TMEM ----------------------
             if cutlass.const_expr(mState_init is not None):
@@ -1314,14 +1319,14 @@ def compute1_warp_group(
                     state_vecs.append(nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(row_addr + state_col_id + sub * 16, cutlass.Float32), num=16))
 
                 for sub in cutlass.range_constexpr(cfg.d_k // 16):
-                    state_pack = cutlass.Array(cutlass.Int32, 8, alignment=16)
+                    state_pack = cute.make_rmem_tensor((8,), cutlass.Int32)
                     for packed_col in cutlass.range_constexpr(8):
                         source_pair = packed_col ^ 4
                         state_pack[packed_col] = fp32_to_fp16(state_vecs[sub][2 * source_pair], state_vecs[sub][2 * source_pair + 1], dtype=cfg.io_dtype)
                     nvvm.tcgen05_st(
                         "32x32b",
                         nvvm.make_tmem_ptr((tmem_row << 16) + packed_col_id + sub * 8, cutlass.Int8),
-                        state_pack[0:8],
+                        state_pack.load(),
                     )
 
                 nvvm.tcgen05_wait("store")
@@ -1387,13 +1392,13 @@ def compute1_warp_group(
                 state_k_vec0 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr(row_addr + statek_col_id, cutlass.Float32), num=2)
                 state_k_vec1 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr(row16_addr + statek_col_id, cutlass.Float32), num=2)
 
-            beta_pack = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            beta_pack = cute.make_rmem_tensor((4,), cutlass.Int32)
             for reg_idx in cutlass.range_constexpr(4):
                 token0 = (((reg_idx // 2) * 4 + (lane & 3)) ^ 4) * 2
                 beta0 = (sBeta_ptr + token0).load().to(cutlass.Float32)
                 beta1 = (sBeta_ptr + token0 + 1).load().to(cutlass.Float32)
                 beta_pack[reg_idx] = fp32_to_fp16(beta0, beta1, dtype=cfg.io_dtype)
-            y_inp_pack0 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            y_inp_pack0 = cute.make_rmem_tensor((4,), cutlass.Int32)
             for reg_idx in cutlass.range_constexpr(4):
                 raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
                 frag_pair = (reg_idx ^ 2) * 2
@@ -1413,7 +1418,7 @@ def compute1_warp_group(
                     cfg.io_dtype,
                 )
 
-            y_inp_pack1 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            y_inp_pack1 = cute.make_rmem_tensor((4,), cutlass.Int32)
             for reg_idx in cutlass.range_constexpr(4):
                 raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
                 frag_pair = (reg_idx ^ 2) * 2
@@ -1433,8 +1438,8 @@ def compute1_warp_group(
                     cfg.io_dtype,
                 )
 
-            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row_addr + y_inp_col_id, cutlass.Int8), y_inp_pack0[0:4])
-            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row16_addr + y_inp_col_id, cutlass.Int8), y_inp_pack1[0:4])
+            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row_addr + y_inp_col_id, cutlass.Int8), y_inp_pack0.load())
+            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row16_addr + y_inp_col_id, cutlass.Int8), y_inp_pack1.load())
             nvvm.tcgen05_wait("store")
             if cutlass.const_expr(mState_init is not None):
                 state_k_acc_index = advance(state_k_acc_index, 1)
@@ -1450,7 +1455,7 @@ def compute1_warp_group(
                 num=cfg.b_t,
             )
 
-            u_inp_pack = cutlass.Array(cutlass.Int32, (cfg.b_t // 2), alignment=16)
+            u_inp_pack = cute.make_rmem_tensor((cfg.b_t // 2,), cutlass.Int32)
             for packed_col in cutlass.range_constexpr((cfg.b_t // 2)):
                 source_pair = packed_col ^ 4
                 token0 = source_pair * 2
@@ -1460,7 +1465,7 @@ def compute1_warp_group(
             nvvm.tcgen05_st(
                 "32x32b",
                 nvvm.make_tmem_ptr(u_inp_addr, cutlass.Int8),
-                u_inp_pack[0 : (cfg.b_t // 2)],
+                u_inp_pack.load(),
             )
             nvvm.tcgen05_wait("store")
             u_acc_index = advance(u_acc_index, 1)
@@ -1476,8 +1481,8 @@ def compute1_warp_group(
             cg1_checkpoint_mod = (cstart + cutlass.Int32(1)) % cg1_checkpoint_chunks
         for local_chunk_idx in cutlass.range(1, num_chunks_tile, 1, unroll=1):
             chunk_idx = cstart + local_chunk_idx
-            sV_ptr = sV_raw.data_ptr() + raw_index.idx * (cfg.d_v * cfg.b_t)
-            sBeta_ptr = sBeta_raw.data_ptr() + raw_index.idx * cfg.b_t
+            sV_ptr = smem_data_ptr(sV_raw) + raw_index.idx * (cfg.d_v * cfg.b_t)
+            sBeta_ptr = smem_data_ptr(sBeta_raw) + raw_index.idx * cfg.b_t
 
             do_checkpoint = False
             if cutlass.const_expr(cfg.enable_checkpoints):
@@ -1495,14 +1500,14 @@ def compute1_warp_group(
                 state_vecs.append(nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(row_addr + state_col_id + sub * 16, cutlass.Float32), num=16))
 
             for sub in cutlass.range_constexpr(cfg.d_k // 16):
-                state_pack = cutlass.Array(cutlass.Int32, 8, alignment=16)
+                state_pack = cute.make_rmem_tensor((8,), cutlass.Int32)
                 for packed_col in cutlass.range_constexpr(8):
                     source_pair = packed_col ^ 4
                     state_pack[packed_col] = fp32_to_fp16(state_vecs[sub][2 * source_pair], state_vecs[sub][2 * source_pair + 1], dtype=cfg.io_dtype)
                 nvvm.tcgen05_st(
                     "32x32b",
                     nvvm.make_tmem_ptr((tmem_row << 16) + packed_col_id + sub * 8, cutlass.Int8),
-                    state_pack[0:8],
+                    state_pack.load(),
                 )
             nvvm.tcgen05_wait("store")
             bars.mb_state_inp_ready.arrive()
@@ -1549,13 +1554,13 @@ def compute1_warp_group(
             state_k_vec0 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr(row_addr + statek_col_id, cutlass.Float32), num=2)
             state_k_vec1 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr(row16_addr + statek_col_id, cutlass.Float32), num=2)
 
-            beta_pack = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            beta_pack = cute.make_rmem_tensor((4,), cutlass.Int32)
             for reg_idx in cutlass.range_constexpr(4):
                 token0 = (((reg_idx // 2) * 4 + (lane & 3)) ^ 4) * 2
                 beta0 = (sBeta_ptr + token0).load().to(cutlass.Float32)
                 beta1 = (sBeta_ptr + token0 + 1).load().to(cutlass.Float32)
                 beta_pack[reg_idx] = fp32_to_fp16(beta0, beta1, dtype=cfg.io_dtype)
-            y_inp_pack0 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            y_inp_pack0 = cute.make_rmem_tensor((4,), cutlass.Int32)
             for reg_idx in cutlass.range_constexpr(4):
                 raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
                 frag_pair = (reg_idx ^ 2) * 2
@@ -1572,7 +1577,7 @@ def compute1_warp_group(
                     cfg.io_dtype,
                 )
 
-            y_inp_pack1 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+            y_inp_pack1 = cute.make_rmem_tensor((4,), cutlass.Int32)
             for reg_idx in cutlass.range_constexpr(4):
                 raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
                 frag_pair = (reg_idx ^ 2) * 2
@@ -1589,8 +1594,8 @@ def compute1_warp_group(
                     cfg.io_dtype,
                 )
 
-            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row_addr + y_inp_col_id, cutlass.Int8), y_inp_pack0[0:4])
-            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row16_addr + y_inp_col_id, cutlass.Int8), y_inp_pack1[0:4])
+            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row_addr + y_inp_col_id, cutlass.Int8), y_inp_pack0.load())
+            nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row16_addr + y_inp_col_id, cutlass.Int8), y_inp_pack1.load())
             nvvm.tcgen05_wait("store")
             state_k_acc_index = advance(state_k_acc_index, 1)
             bars.mb_v_done[raw_index.idx].arrive()
@@ -1605,7 +1610,7 @@ def compute1_warp_group(
                 num=cfg.b_t,
             )
 
-            u_inp_pack = cutlass.Array(cutlass.Int32, (cfg.b_t // 2), alignment=16)
+            u_inp_pack = cute.make_rmem_tensor((cfg.b_t // 2,), cutlass.Int32)
             for packed_col in cutlass.range_constexpr((cfg.b_t // 2)):
                 source_pair = packed_col ^ 4
                 token0 = source_pair * 2
@@ -1615,7 +1620,7 @@ def compute1_warp_group(
             nvvm.tcgen05_st(
                 "32x32b",
                 nvvm.make_tmem_ptr(u_inp_addr, cutlass.Int8),
-                u_inp_pack[0 : (cfg.b_t // 2)],
+                u_inp_pack.load(),
             )
             nvvm.tcgen05_wait("store")
             u_acc_index = advance(u_acc_index, 1)
@@ -1715,10 +1720,49 @@ class KdaRecomputeOp:
     ) -> None:
         cfg = self.cfg
         num_sequences = cu_seqlens.shape[0] - 1
+        checkpoint_elements = (
+            cfg.smem_checkpoint_stages * cfg.d_k * cfg.d_v if cfg.enable_checkpoints else 0
+        )
+
+        @cute.struct
+        class SharedStorage:
+            k_decay: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.k_decay_cosize],
+                cfg.buffer_align_bytes,
+            ]
+            k_restore: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.k_restore_cosize],
+                cfg.buffer_align_bytes,
+            ]
+            intermediate: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.intermediate_cosize],
+                cfg.buffer_align_bytes,
+            ]
+            k: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.k_cosize], cfg.buffer_align_bytes
+            ]
+            v: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.v_cosize], cfg.buffer_align_bytes
+            ]
+            gate: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, cfg.gate_cosize], 1024
+            ]
+            state_scale_diag: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.state_scale_diag_cosize],
+                cfg.buffer_align_bytes,
+            ]
+            k_inv: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.k_inv_cosize], cfg.buffer_align_bytes
+            ]
+            checkpoint: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, checkpoint_elements],
+                cfg.buffer_align_bytes,
+            ]
 
         kernel.set_name_prefix(self.get_name())
         kernel(
             cfg,
+            SharedStorage,
             tensormap_workspace,
             cutlass.Int32(num_sequences),
             k,
@@ -1745,6 +1789,7 @@ class KdaRecomputeOp:
 @cute.kernel
 def kernel(
     cfg: cutlass.Constexpr,
+    shared_type: cutlass.Constexpr,
     tensormap_workspace: cute.Tensor,
     n_desc: cutlass.Int32,
     mK: cute.Tensor,
@@ -1795,22 +1840,34 @@ def kernel(
     desc_gate_base = desc_base_words + cutlass.Int32(2) * arr_words
     desc_checkpoint_base = desc_base_words + cutlass.Int32(3) * arr_words
 
-    # Buffers are declaration-ordered and intentionally non-aliased.
+    # Barrier/control rings stay declaration-ordered; data buffers share one storage allocation.
     SMEM = cutlass.AddressSpace.smem
     bars = make_kda_bars(cfg)
     sTmem_base = cutlass.Array(cutlass.Int32, 1, space=SMEM, alignment=4)
     sSched = cutlass.Array(cutlass.Int32, cfg.sched_stages, space=SMEM, alignment=16)
-    sK_decay_raw = cutlass.Array(cfg.io_dtype, cfg.k_decay_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
-    sK_restore_raw = cutlass.Array(cfg.io_dtype, cfg.k_restore_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
-    sIntermediate_raw = cutlass.Array(cfg.io_dtype, cfg.intermediate_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
-    sK_raw = cutlass.Array(mK.element_type, cfg.k_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
-    sV_raw = cutlass.Array(mV.element_type, cfg.v_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
-    sGate_raw = cutlass.Array(cutlass.Float32, cfg.gate_cosize, space=SMEM, alignment=1024)
-    sState_scale_diag_raw = cutlass.Array(cfg.io_dtype, cfg.state_scale_diag_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
-    sK_inv_raw = cutlass.Array(cfg.io_dtype, cfg.k_inv_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
-    sBeta_raw = cutlass.Array(cutlass.Float32, cfg.beta_cosize, space=SMEM, alignment=cfg.buffer_align_bytes)
+    storage = cutlass.utils.SmemAllocator().allocate(shared_type)
+    sK_decay_raw = storage.k_decay.get_tensor(cute.make_layout((cfg.k_decay_cosize,)))
+    sK_restore_raw = storage.k_restore.get_tensor(cute.make_layout((cfg.k_restore_cosize,)))
+    sIntermediate_raw = storage.intermediate.get_tensor(
+        cute.make_layout((cfg.intermediate_cosize,))
+    )
+    sK_raw = storage.k.get_tensor(cute.make_layout((cfg.k_cosize,)))
+    sV_raw = storage.v.get_tensor(cute.make_layout((cfg.v_cosize,)))
+    sGate_raw = storage.gate.get_tensor(cute.make_layout((cfg.gate_cosize,)))
+    sState_scale_diag_raw = storage.state_scale_diag.get_tensor(
+        cute.make_layout((cfg.state_scale_diag_cosize,))
+    )
+    sK_inv_raw = storage.k_inv.get_tensor(cute.make_layout((cfg.k_inv_cosize,)))
+    sBeta_raw = cutlass.Array(
+        cutlass.Float32,
+        cfg.beta_cosize,
+        space=SMEM,
+        alignment=cfg.buffer_align_bytes,
+    )
     sCheckpoint_raw = (
-        cutlass.Array(cfg.io_dtype, cfg.smem_checkpoint_stages * cfg.d_k * cfg.d_v, space=SMEM, alignment=cfg.buffer_align_bytes)
+        storage.checkpoint.get_tensor(
+            cute.make_layout((cfg.smem_checkpoint_stages * cfg.d_k * cfg.d_v,))
+        )
         if cutlass.const_expr(cfg.enable_checkpoints)
         else sV_raw
     )

--- a/attn_gym/linear/_delta_rule/mega/kernels/tile_dsl/handles.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/tile_dsl/handles.py
@@ -4,6 +4,19 @@
 
 from dataclasses import dataclass, replace
 
+import cutlass
+from cutlass import cute
+
+
+@cute.jit
+def smem_data_ptr(storage):
+    """Return the raw shared-memory pointer for an Array or Tensor."""
+    if cutlass.const_expr(hasattr(storage, "iterator")):
+        pointer = storage.iterator.raw_ptr()
+    else:
+        pointer = storage.data_ptr()
+    return pointer
+
 
 @dataclass(frozen=True)
 class MmaDesc:
@@ -128,20 +141,36 @@ class SmemTile:
     tma_subtile_stride_elems: int = 0
     stages: int = 1
 
+    def _offset_base(self, offset):
+        if hasattr(self.base, "iterator"):
+            return cute.domain_offset((offset,), self.base)
+        if hasattr(self.base, "subview"):
+            return self.base.subview(offset)
+        if hasattr(self.base, "data_ptr"):
+            return self.base.data_ptr() + offset
+        return self.base + offset
+
     def __getitem__(self, stage):
-        off = stage * self.elems_per_stage
-        base = self.base.subview(off) if hasattr(self.base, "subview") else self.base + off
-        return replace(self, base=base, stages=1)
+        return replace(
+            self,
+            base=self._offset_base(stage * self.elems_per_stage),
+            stages=1,
+        )
 
     def shifted(self, off_elems):
-        base = self.base.subview(off_elems) if hasattr(self.base, "subview") else self.base + off_elems
-        return replace(self, base=base)
+        return replace(self, base=self._offset_base(off_elems))
 
     def desc(self):
         from cutlass.experimental import primitives as prims
 
+        if hasattr(self.base, "data_ptr"):
+            base = self.base.data_ptr()
+        elif hasattr(self.base, "iterator"):
+            base = self.base.iterator.raw_ptr()
+        else:
+            base = self.base
         return prims.Tcgen05SmemDesc.build(
-            self.base,
+            base,
             leading_byte_offset=self.leading_byte_offset,
             stride_byte_offset=self.stride_byte_offset,
             layout=self.layout,

--- a/attn_gym/linear/_delta_rule/mega/kernels/tile_dsl/tma.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/tile_dsl/tma.py
@@ -6,6 +6,7 @@ from cutlass.experimental import primitives as nvvm
 import cutlass
 import cutlass.cute as cute
 
+from .handles import smem_data_ptr
 from .swizzle import swizzle_xor_128b
 
 
@@ -70,7 +71,7 @@ def tma_load_tile(
     outer_coords = tuple(gmem_slice.coords[1:])
     for i in cutlass.range_constexpr(num_iters):
         d = coord_d + cutlass.Int32(i * granu_elems)
-        smem_chunk = smem_tile.base.subview(i * sub_stride)
+        smem_chunk = smem_data_ptr(smem_tile.shifted(i * sub_stride).base)
         if nvvm.elect_sync():
             coords = [d] + list(outer_coords)
             if cutlass.const_expr(cta_group == 1):
@@ -115,7 +116,7 @@ def tma_store_tile(smem_tile, gmem_slice, *, acquire: cutlass.Constexpr[bool] = 
         tma_desc_ptr = gmem_slice.tma_desc.get_ptr()
     for i in cutlass.range_constexpr(num_iters):
         d = coord_d + cutlass.Int32(i * granu_elems)
-        smem_chunk = smem_tile.base.subview(i * sub_stride)
+        smem_chunk = smem_data_ptr(smem_tile.shifted(i * sub_stride).base)
         nvvm.cp_async_bulk_tensor_global_shared_cta(
             tma_desc_ptr,
             smem_chunk,


### PR DESCRIPTION
Refactor Mega kernel storage with CuTe tensors

## Human Note

## Agent note

Replace donor-style mutable register arrays with `cute.make_rmem_tensor`, group aligned data buffers
into explicit `@cute.struct` shared-storage layouts, and derive pipeline stages by slicing staged CuTe
tensors instead of repeating byte-offset arithmetic. Barrier/control storage remains explicitly
addressable because raw mbarrier and scheduler instructions require stable pointers.

The refactor preserves the existing synchronization protocol and tensor-map ABI. Prefill and bprop
retain their exact kernel hashes; recompute retains 128 registers and no spills while using 640 fewer
bytes of dynamic shared memory.

## Performance

Matched B200 CUDA-graph replay is neutral within run-to-run noise.

| workload | baseline | candidate |
|---|---:|---:|
| primary T8192/H64 | 3372.8 us | 3369.0 us |
| packed 2x4096/H64, cooled | 1881.4 us | 1881.3 us |

## Test Plan

```bash
pytest -n 6 -q test/kda/mega
pytest -q test/kda/mega/test_kda_mega_training.py::test_mega_training_fullgraph_and_six_gradients test/kda/mega/test_kda_mega_training.py::test_mega_local_backward_split_matches_exact_gradients test/kda/mega/test_kda_mega_training.py::test_mega_packed_local_backward_matches_exact_gradients
compute-sanitizer --tool memcheck python agent_space/fuzz_mega_kda.py --mode memory --case interior-empty --dtype bfloat16 --seed 53 --force-local
cutracer trace -a random_delay --delay-ns 100000 -k kda_mega_prefill,kda_mega_recompute,kda_mega_bprop -- python agent_space/fuzz_mega_kda.py --mode determinism --case interior-empty --dtype bfloat16 --seed 59 --force-local
python benchmarks/kda.py --impl mega --case smoke --case primary
python benchmarks/kda.py --impl mega --case packed_balanced
```