### PR TITLE
Support a host-driven query scale in chunk_kda

### DIFF
--- a/attn_gym/linear/_delta_rule/validation.py
+++ b/attn_gym/linear/_delta_rule/validation.py
@@ -2,9 +2,28 @@
 
 from __future__ import annotations
 
+import sys
+from numbers import Real
+
 import torch
 
 SUPPORTED_ACTIVATION_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
+
+
+def resolve_scale(scale: float | None, key_dim: int) -> float:
+    """Resolve a query-scale override to a validated float, defaulting to ``1/sqrt(K)``."""
+    if scale is None:
+        return key_dim**-0.5
+    if not isinstance(scale, Real) or isinstance(scale, bool):
+        raise TypeError("scale must be a real scalar or None")
+    scale = float(scale)
+    if (
+        scale != scale  # noqa: PLR0124 - compile-safe NaN check
+        or scale <= 0
+        or scale > sys.float_info.max
+    ):
+        raise ValueError(f"scale must be finite and positive, got {scale}")
+    return scale
 
 
 def validate_has_initial_state(
@@ -148,6 +167,7 @@ def validate_paged_state(
 __all__ = [
     "SUPPORTED_ACTIVATION_DTYPES",
     "resolve_decode_out",
+    "resolve_scale",
     "validate_decode_inputs",
     "validate_has_initial_state",
     "validate_paged_state",

--- a/attn_gym/linear/gdn/api.py
+++ b/attn_gym/linear/gdn/api.py
@@ -2,13 +2,11 @@
 
 from __future__ import annotations
 
-import sys
-from numbers import Real
-
 import torch
 
 from attn_gym.linear._delta_rule.validation import (
     resolve_decode_out,
+    resolve_scale,
     validate_decode_inputs,
     validate_paged_state,
 )
@@ -265,18 +263,7 @@ def recurrent_gdn_decode(
     if dt_bias.shape != (heads,) or dt_bias.dtype != torch.float32 or not dt_bias.is_contiguous():
         raise ValueError(f"dt_bias must be contiguous float32 with shape ({heads},)")
 
-    if scale is None:
-        scale = key_dim**-0.5
-    elif not isinstance(scale, Real) or isinstance(scale, bool):
-        raise TypeError("scale must be a real scalar or None")
-    else:
-        scale = float(scale)
-        if (
-            scale != scale  # noqa: PLR0124 - compile-safe NaN check
-            or scale <= 0
-            or scale > sys.float_info.max
-        ):
-            raise ValueError(f"scale must be finite and positive, got {scale}")
+    scale = resolve_scale(scale, key_dim)
 
     out = resolve_decode_out(packed_qkv, out, (1, batch, heads, value_dim))
     return recurrent_decode_forward(

--- a/attn_gym/linear/kda/api.py
+++ b/attn_gym/linear/kda/api.py
@@ -22,6 +22,7 @@ import torch
 
 from attn_gym.linear._delta_rule.validation import (
     resolve_decode_out,
+    resolve_scale,
     validate_decode_inputs,
     validate_paged_state,
 )
@@ -61,6 +62,7 @@ def chunk_kda(
     initial_state: torch.Tensor | None = None,
     *,
     cu_seqlens: torch.Tensor | None = None,
+    scale: float | None = None,
     output_final_state: bool = False,
     fastmath: bool = False,
     autotune: bool = True,
@@ -69,7 +71,7 @@ def chunk_kda(
     """Apply chunk-parallel KDA for training and prefill.
 
     Args:
-        q: Queries shaped ``[B, T, H, K]``, scaled by ``1/sqrt(K)`` internally. Use
+        q: Queries shaped ``[B, T, H, K]``, scaled by ``scale`` internally. Use
             L2-normalized Q/K with fused FP16: unnormalized values can overflow the FP16
             intermediates passed between FP32-accumulating GEMMs.
         k: Keys shaped like ``q`` and subject to the same fused FP16 range limitation.
@@ -88,6 +90,8 @@ def chunk_kda(
             contiguous ``int32`` on ``q.device``; they start at zero, never
             decrease, may repeat for empty sequences whose states pass through,
             and may end before ``T``.
+        scale: Query scale, applied inside the kernels in FP32. Defaults to
+            ``1 / sqrt(K)``.
         output_final_state: Return the final recurrent state with the output.
         fastmath: Allow less precise fused math for speed; rejected with
             ``"reference"``.
@@ -116,6 +120,7 @@ def chunk_kda(
         op_name="chunk_kda",
         gate_name="gate",
     )
+    scale = resolve_scale(scale, q.shape[-1])
     if selected_impl is Impl.FUSED:
         return _fused_chunk_forward(
             q,
@@ -125,12 +130,13 @@ def chunk_kda(
             beta,
             initial_state,
             cu_seqlens=cu_seqlens,
+            scale=scale,
             output_final_state=output_final_state,
             fastmath=fastmath,
             autotune=autotune,
         )
     return reference_kda(
-        partial(naive_chunk_kda, chunk_size=_CHUNK_SIZE),
+        partial(naive_chunk_kda, chunk_size=_CHUNK_SIZE, scale=scale),
         q,
         k,
         v,
@@ -435,18 +441,7 @@ def recurrent_kda_decode(
             raise ValueError(f"lower_bound must be finite and nonpositive, got {lower_bound}")
     else:
         lower_bound = 0.0
-    if scale is None:
-        scale = key_dim**-0.5
-    elif not isinstance(scale, Real) or isinstance(scale, bool):
-        raise TypeError("scale must be a real scalar or None")
-    else:
-        scale = float(scale)
-        if (
-            scale != scale  # noqa: PLR0124 - compile-safe NaN check
-            or scale <= 0
-            or scale > sys.float_info.max
-        ):
-            raise ValueError(f"scale must be finite and positive, got {scale}")
+    scale = resolve_scale(scale, key_dim)
 
     out = resolve_decode_out(packed_qkv, out, (1, batch, heads, value_dim))
 

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd.py
@@ -31,6 +31,7 @@ def chunk_kda_bwd(
     initial_state: torch.Tensor | None,
     metadata: RaggedChunkMetadata | None,
     *,
+    scale: float,
     chunk_size: int = 64,
     fastmath: bool = False,
     autotune: bool = True,
@@ -51,7 +52,6 @@ def chunk_kda_bwd(
         raise ValueError(f"the composed KDA backward requires chunk_size=64, got {chunk_size}")
     if tokens % chunk_size and metadata is None:
         raise ValueError("the composed KDA backward requires complete chunks")
-    scale = head_dim**-0.5
 
     # Forward deliberately saves only the minimal backward factors. Always
     # reconstruct the large W/U, gated Q/K, state, and corrected-value
@@ -120,6 +120,7 @@ def chunk_kda_bwd(
             dh,
             dv,
             metadata,
+            scale=scale,
             chunk_size=chunk_size,
             fastmath=fastmath,
             autotune=autotune,

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_wy_dqkg_fused.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_wy_dqkg_fused.py
@@ -3351,6 +3351,7 @@ def _compile_chunk_kda_bwd_wy_dqkg(
     head_dim: int,
     chunk_size: int,
     io_dtype: torch.dtype,
+    scale: float,
     fastmath: bool,
     grid_waves: int,
     ragged: bool,
@@ -3363,7 +3364,7 @@ def _compile_chunk_kda_bwd_wy_dqkg(
         head_dim_k=head_dim,
         head_dim_v=head_dim,
         io_dtype=cutlass_io_dtype,
-        scale=head_dim**-0.5,
+        scale=scale,
         grid_waves=grid_waves,
         use_fast_math=fastmath,
         use_int64_offsets=use_int64_offsets,
@@ -3459,6 +3460,7 @@ class ChunkKdaBwdWyDqkgTunable:
         cu_seqlens: torch.Tensor | None
         chunk_offsets: torch.Tensor | None
         chunk_size: int
+        scale: float
         fastmath: bool
 
     @staticmethod
@@ -3490,12 +3492,13 @@ class ChunkKdaBwdWyDqkgTunable:
     def compile_call(
         config: ChunkKdaBwdWyDqkgConfig,
         args: Args,
-    ) -> tuple[int, int, int, torch.dtype, bool, int, bool, bool]:
+    ) -> tuple[int, int, int, torch.dtype, float, bool, int, bool, bool]:
         return (
             args.q.shape[2],
             args.q.shape[3],
             args.chunk_size,
             args.q.dtype,
+            args.scale,
             args.fastmath,
             config.grid_waves,
             args.chunk_offsets is not None,
@@ -3585,6 +3588,7 @@ def chunk_kda_bwd_wy_dqkg(
     dv: torch.Tensor,
     metadata: RaggedChunkMetadata | None = None,
     *,
+    scale: float,
     chunk_size: int = 64,
     fastmath: bool = False,
     config: ChunkKdaBwdWyDqkgConfig | None = None,
@@ -3663,6 +3667,7 @@ def chunk_kda_bwd_wy_dqkg(
         cu_seqlens=cu_seqlens,
         chunk_offsets=chunk_offsets,
         chunk_size=chunk_size,
+        scale=scale,
         fastmath=fastmath,
     )
     # An explicit config pins the schedule regardless of the plumbed flag.

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py
@@ -142,12 +142,11 @@ def _chunk_kda_fwd(
     has_initial_state: torch.Tensor | None,
     metadata: RaggedChunkMetadata | None,
     *,
+    scale: float,
     output_final_state: bool,
     autotune: bool,
 ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor, torch.Tensor]:
     """Run the optimized KDA core using an already selected chunk schedule."""
-    scale = _HEAD_DIM**-0.5
-
     with profiler_range("kda/fused/chunk_kda_fwd_intra"):
         w, u, kg, Aqk, Akk = chunk_kda_fwd_intra(
             q,
@@ -197,6 +196,7 @@ def _chunk_kda_fwd_shared(
     cumulative_gate: torch.Tensor,
     beta: torch.Tensor,
     initial_state: torch.Tensor | None,
+    scale: float,
     autotune: bool,
     output_final_state: bool,
 ):
@@ -213,6 +213,7 @@ def _chunk_kda_fwd_shared(
         None,
         None,
         None,
+        scale=scale,
         output_final_state=output_final_state,
         autotune=autotune,
     )
@@ -225,6 +226,7 @@ def _chunk_kda_fwd_cuda(
     cumulative_gate: torch.Tensor,
     beta: torch.Tensor,
     initial_state: torch.Tensor | None,
+    scale: float,
     autotune: bool,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     output, _final_state, Aqk, Akk = _chunk_kda_fwd_shared(
@@ -234,6 +236,7 @@ def _chunk_kda_fwd_cuda(
         cumulative_gate,
         beta,
         initial_state,
+        scale,
         autotune,
         False,
     )
@@ -247,6 +250,7 @@ def _chunk_kda_fwd_with_state_cuda(
     cumulative_gate: torch.Tensor,
     beta: torch.Tensor,
     initial_state: torch.Tensor | None,
+    scale: float,
     autotune: bool,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     return _chunk_kda_fwd_shared(
@@ -256,6 +260,7 @@ def _chunk_kda_fwd_with_state_cuda(
         cumulative_gate,
         beta,
         initial_state,
+        scale,
         autotune,
         True,
     )
@@ -270,6 +275,7 @@ def _chunk_kda_fwd_ragged_shared(
     initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor,
     chunk_offsets: torch.Tensor,
+    scale: float,
     autotune: bool,
     output_final_state: bool,
 ):
@@ -292,6 +298,7 @@ def _chunk_kda_fwd_ragged_shared(
         None,
         None,
         metadata,
+        scale=scale,
         output_final_state=output_final_state,
         autotune=autotune,
     )
@@ -306,6 +313,7 @@ def _chunk_kda_fwd_ragged_cuda(
     initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor,
     chunk_offsets: torch.Tensor,
+    scale: float,
     autotune: bool,
 ):
     output, _state, Aqk, Akk = _chunk_kda_fwd_ragged_shared(
@@ -317,6 +325,7 @@ def _chunk_kda_fwd_ragged_cuda(
         initial_state,
         cu_seqlens,
         chunk_offsets,
+        scale,
         autotune,
         False,
     )
@@ -332,6 +341,7 @@ def _chunk_kda_fwd_ragged_with_state_cuda(
     initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor,
     chunk_offsets: torch.Tensor,
+    scale: float,
     autotune: bool,
 ):
     return _chunk_kda_fwd_ragged_shared(
@@ -343,6 +353,7 @@ def _chunk_kda_fwd_ragged_with_state_cuda(
         initial_state,
         cu_seqlens,
         chunk_offsets,
+        scale,
         autotune,
         True,
     )
@@ -389,6 +400,7 @@ def _chunk_kda_fwd_ragged_paged_cuda(
         state_indices,
         has_initial_state,
         metadata,
+        scale=_HEAD_DIM**-0.5,
         output_final_state=False,
         autotune=autotune,
     )
@@ -452,6 +464,7 @@ def _chunk_kda_bwd_shared(
     d_output: torch.Tensor | None,
     d_final_state: torch.Tensor | None,
     initial_state: torch.Tensor | None,
+    scale: float,
     fastmath: bool,
     autotune: bool,
 ):
@@ -479,7 +492,7 @@ def _chunk_kda_bwd_shared(
             k,
             cumulative_gate,
             beta,
-            _HEAD_DIM**-0.5,
+            scale,
             metadata,
         )
     else:
@@ -496,6 +509,7 @@ def _chunk_kda_bwd_shared(
         d_final_state,
         initial_state,
         metadata,
+        scale=scale,
         fastmath=fastmath,
         autotune=autotune,
     )
@@ -512,6 +526,7 @@ def _chunk_kda_bwd_recompute_factors_shared(
     d_output: torch.Tensor | None,
     d_final_state: torch.Tensor | None,
     initial_state: torch.Tensor | None,
+    scale: float,
     fastmath: bool,
     autotune: bool,
 ):
@@ -529,6 +544,7 @@ def _chunk_kda_bwd_recompute_factors_shared(
         d_output,
         d_final_state,
         initial_state,
+        scale,
         fastmath,
         autotune,
     )

--- a/attn_gym/linear/kda/impl/fused.py
+++ b/attn_gym/linear/kda/impl/fused.py
@@ -45,6 +45,7 @@ class _ChunkKDA(torch.autograd.Function):
         initial_state,
         cu_seqlens,
         chunk_offsets,
+        scale,
         output_final_state,
         fastmath,
         autotune,
@@ -59,11 +60,11 @@ class _ChunkKDA(torch.autograd.Function):
             assert chunk_offsets is None
             if output_final_state:
                 output, state, aqk, akk = chunk_fwd_with_state_op(
-                    q, k, v, cumulative_gate, beta, initial_state, autotune
+                    q, k, v, cumulative_gate, beta, initial_state, scale, autotune
                 )
             else:
                 output, aqk, akk = chunk_fwd_op(
-                    q, k, v, cumulative_gate, beta, initial_state, autotune
+                    q, k, v, cumulative_gate, beta, initial_state, scale, autotune
                 )
         elif output_final_state:
             assert chunk_offsets is not None
@@ -76,6 +77,7 @@ class _ChunkKDA(torch.autograd.Function):
                 initial_state,
                 cu_seqlens,
                 chunk_offsets,
+                scale,
                 autotune,
             )
         else:
@@ -89,6 +91,7 @@ class _ChunkKDA(torch.autograd.Function):
                 initial_state,
                 cu_seqlens,
                 chunk_offsets,
+                scale,
                 autotune,
             )
         ctx.save_for_backward(
@@ -103,6 +106,7 @@ class _ChunkKDA(torch.autograd.Function):
             cu_seqlens,
             chunk_offsets,
         )
+        ctx.scale = scale
         ctx.fastmath = fastmath
         ctx.autotune = autotune
         ctx.set_materialize_grads(False)
@@ -138,6 +142,7 @@ class _ChunkKDA(torch.autograd.Function):
             d_output,
             d_final_state,
             initial_state,
+            ctx.scale,
             ctx.fastmath,
             ctx.autotune,
         )
@@ -152,7 +157,7 @@ class _ChunkKDA(torch.autograd.Function):
             chunk_offsets,
             True,
         )
-        return dq, dk, dv, d_gate, db, d_initial_state, None, None, None, None, None
+        return dq, dk, dv, d_gate, db, d_initial_state, None, None, None, None, None, None
 
 
 def chunk_forward(
@@ -164,6 +169,7 @@ def chunk_forward(
     initial_state: torch.Tensor | None = None,
     *,
     cu_seqlens: torch.Tensor | None = None,
+    scale: float,
     output_final_state: bool = False,
     fastmath: bool = False,
     autotune: bool = True,
@@ -206,6 +212,7 @@ def chunk_forward(
             initial_state,
             cu_seqlens,
             chunk_offsets,
+            scale,
             True,
             fastmath,
             autotune,
@@ -220,6 +227,7 @@ def chunk_forward(
             initial_state,
             cu_seqlens,
             chunk_offsets,
+            scale,
             False,
             fastmath,
             autotune,

--- a/attn_gym/linear/kda/ops.py
+++ b/attn_gym/linear/kda/ops.py
@@ -20,7 +20,7 @@ _CHUNK_SIZE = 64
 # Fixed-arity schema pairs avoid optional outputs on hot paths.
 _CHUNK_FWD_ARGS = (
     "(Tensor q, Tensor k, Tensor v, Tensor cumulative_gate, Tensor beta, Tensor? initial_state,"
-    " bool autotune)"
+    " float scale, bool autotune)"
 )
 torch.library.define(
     "attn_gym::kda_chunk_fwd",
@@ -33,7 +33,8 @@ torch.library.define(
 
 _CHUNK_RAGGED_FWD_ARGS = (
     "(Tensor q, Tensor k, Tensor v, Tensor cumulative_gate, Tensor beta, "
-    "Tensor? initial_state, Tensor cu_seqlens, Tensor chunk_offsets, bool autotune)"
+    "Tensor? initial_state, Tensor cu_seqlens, Tensor chunk_offsets, float scale, "
+    "bool autotune)"
 )
 torch.library.define(
     "attn_gym::kda_chunk_fwd_ragged",
@@ -54,7 +55,7 @@ torch.library.define(
 _CHUNK_BWD_ARGS = (
     "(Tensor q, Tensor k, Tensor v, Tensor cumulative_gate, Tensor beta, Tensor Aqk, "
     "Tensor Akk, Tensor? cu_seqlens, Tensor? chunk_offsets, Tensor? d_output, "
-    "Tensor? d_final_state, {initial_state}, bool fastmath, bool autotune)"
+    "Tensor? d_final_state, {initial_state}, float scale, bool fastmath, bool autotune)"
 )
 torch.library.define(
     "attn_gym::kda_chunk_bwd",
@@ -70,7 +71,7 @@ torch.library.define(
 _CHUNK_BWD_RECOMPUTE_ARGS = (
     "(Tensor q, Tensor k, Tensor v, Tensor cumulative_gate, Tensor beta, "
     "Tensor? cu_seqlens, Tensor? chunk_offsets, Tensor? d_output, "
-    "Tensor? d_final_state, {initial_state}, bool fastmath, bool autotune)"
+    "Tensor? d_final_state, {initial_state}, float scale, bool fastmath, bool autotune)"
 )
 torch.library.define(
     "attn_gym::kda_chunk_bwd_recompute_factors",
@@ -348,9 +349,10 @@ def _chunk_fwd_fake(
     cumulative_gate: torch.Tensor,
     beta: torch.Tensor,
     initial_state: torch.Tensor | None,
+    scale: float,
     autotune: bool,
 ):
-    del k, cumulative_gate, beta, initial_state, autotune
+    del k, cumulative_gate, beta, initial_state, scale, autotune
     return _chunk_fwd_fake_common(q, v)
 
 
@@ -362,9 +364,10 @@ def _chunk_fwd_with_state_fake(
     cumulative_gate: torch.Tensor,
     beta: torch.Tensor,
     initial_state: torch.Tensor | None,
+    scale: float,
     autotune: bool,
 ):
-    del k, cumulative_gate, beta, initial_state, autotune
+    del k, cumulative_gate, beta, initial_state, scale, autotune
     output, aqk, akk = _chunk_fwd_fake_common(q, v)
     state = q.new_empty(
         (q.shape[0], q.shape[2], q.shape[3], v.shape[-1]),
@@ -383,9 +386,10 @@ def _chunk_fwd_ragged_fake(
     initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor,
     chunk_offsets: torch.Tensor,
+    scale: float,
     autotune: bool,
 ):
-    del k, cumulative_gate, beta, initial_state, cu_seqlens, chunk_offsets, autotune
+    del k, cumulative_gate, beta, initial_state, cu_seqlens, chunk_offsets, scale, autotune
     return _chunk_fwd_fake_common(q, v)
 
 
@@ -399,9 +403,10 @@ def _chunk_fwd_ragged_with_state_fake(
     initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor,
     chunk_offsets: torch.Tensor,
+    scale: float,
     autotune: bool,
 ):
-    del k, cumulative_gate, beta, initial_state, chunk_offsets, autotune
+    del k, cumulative_gate, beta, initial_state, chunk_offsets, scale, autotune
     output, aqk, akk = _chunk_fwd_fake_common(q, v)
     state = q.new_empty(
         (cu_seqlens.shape[0] - 1, q.shape[2], q.shape[3], v.shape[-1]),
@@ -462,11 +467,12 @@ def _chunk_bwd_fake(
     d_output: torch.Tensor | None,
     d_final_state: torch.Tensor | None,
     initial_state: torch.Tensor | None,
+    scale: float,
     fastmath: bool,
     autotune: bool,
 ):
     del aqk, akk, cu_seqlens, chunk_offsets, d_output, d_final_state, initial_state
-    del fastmath, autotune
+    del scale, fastmath, autotune
     return _chunk_bwd_fake_common(q, k, v, cumulative_gate, beta)
 
 
@@ -484,10 +490,11 @@ def _chunk_bwd_with_state_grad_fake(
     d_output: torch.Tensor | None,
     d_final_state: torch.Tensor | None,
     initial_state: torch.Tensor,
+    scale: float,
     fastmath: bool,
     autotune: bool,
 ):
-    del aqk, akk, cu_seqlens, chunk_offsets, d_output, d_final_state, fastmath, autotune
+    del aqk, akk, cu_seqlens, chunk_offsets, d_output, d_final_state, scale, fastmath, autotune
     return (
         *_chunk_bwd_fake_common(q, k, v, cumulative_gate, beta),
         torch.empty_like(initial_state),
@@ -506,10 +513,12 @@ def _chunk_bwd_recompute_factors_fake(
     d_output: torch.Tensor | None,
     d_final_state: torch.Tensor | None,
     initial_state: torch.Tensor | None,
+    scale: float,
     fastmath: bool,
     autotune: bool,
 ):
-    del cu_seqlens, chunk_offsets, d_output, d_final_state, initial_state, fastmath, autotune
+    del cu_seqlens, chunk_offsets, d_output, d_final_state, initial_state
+    del scale, fastmath, autotune
     return _chunk_bwd_fake_common(q, k, v, cumulative_gate, beta)
 
 
@@ -525,10 +534,11 @@ def _chunk_bwd_recompute_factors_with_state_grad_fake(
     d_output: torch.Tensor | None,
     d_final_state: torch.Tensor | None,
     initial_state: torch.Tensor,
+    scale: float,
     fastmath: bool,
     autotune: bool,
 ):
-    del cu_seqlens, chunk_offsets, d_output, d_final_state, fastmath, autotune
+    del cu_seqlens, chunk_offsets, d_output, d_final_state, scale, fastmath, autotune
     return (
         *_chunk_bwd_fake_common(q, k, v, cumulative_gate, beta),
         torch.empty_like(initial_state),

--- a/test/kda/mega/test_kda_recompute_factors_backward.py
+++ b/test/kda/mega/test_kda_recompute_factors_backward.py
@@ -58,6 +58,7 @@ def test_recomputed_factors_backward_matches_saved_factors(lengths):
         d_output,
         None,
         None,
+        D**-0.5,
         False,
         False,
     )
@@ -105,6 +106,7 @@ def test_ragged_backward_ignores_akk_capacity_slack():
         torch.randn_like(v),
         None,
         None,
+        D**-0.5,
         False,
         False,
     )
@@ -137,6 +139,7 @@ def test_recomputed_factors_backward_with_state_matches_saved_factors():
         torch.randn_like(v),
         d_final_state,
         initial_state,
+        D**-0.5,
         False,
         False,
     )
@@ -156,7 +159,7 @@ def test_recomputed_factors_backward_op_registration():
     d_output = torch.randn_like(v)
     torch.library.opcheck(
         chunk_bwd_recompute_factors_op,
-        (q, k, v, gate, beta, None, None, d_output, None, None, False, False),
+        (q, k, v, gate, beta, None, None, d_output, None, None, D**-0.5, False, False),
         test_utils=("test_schema", "test_faketensor", "test_aot_dispatch_dynamic"),
         rtol=2e-2,
         atol=2e-3,
@@ -175,6 +178,7 @@ def test_recomputed_factors_backward_op_registration():
             d_output,
             torch.randn_like(initial_state),
             initial_state,
+            D**-0.5,
             False,
             False,
         ),

--- a/test/test_kda_cute_forward.py
+++ b/test/test_kda_cute_forward.py
@@ -37,9 +37,11 @@ from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd import (
 from attn_gym.testing import strided_state_pool
 
 pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (10, 0),
-    reason="the CuTeDSL KDA forward pipeline requires CUDA capability 10.0 or newer",
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() not in ((10, 0), (10, 3)),
+    reason="the CuTeDSL KDA forward pipeline requires SM100/SM103",
 )
+
+_DEFAULT_SCALE = 128**-0.5
 
 
 def _inputs(
@@ -150,7 +152,9 @@ def test_private_chunk_kda_forward_matches_reference(dtype: torch.dtype):
     torch.manual_seed(2)
     q, k, v, gate, beta = _inputs(tokens=64, dtype=dtype)
     cumulative_gate = chunk_cumsum_ref(gate * LOG2_E, 64)
-    actual, aqk, akk = _chunk_kda_fwd_op(q, k, v, cumulative_gate, beta, None, False)
+    actual, aqk, akk = _chunk_kda_fwd_op(
+        q, k, v, cumulative_gate, beta, None, _DEFAULT_SCALE, False
+    )
     golden, _ = naive_chunk_kda(
         q.double(),
         k.double(),
@@ -172,7 +176,9 @@ def test_private_fp16_forward_factors_are_finite_at_gate_limit():
     gate = torch.full_like(q, -MAX_GATE_LOWER_BOUND_MAGNITUDE, dtype=torch.float32)
     cumulative_gate = chunk_cumsum_ref(gate * LOG2_E, 64)
 
-    output, aqk, akk = _chunk_kda_fwd_op(q, k, v, cumulative_gate, beta, None, False)
+    output, aqk, akk = _chunk_kda_fwd_op(
+        q, k, v, cumulative_gate, beta, None, _DEFAULT_SCALE, False
+    )
 
     for tensor in (output, aqk, akk):
         assert tensor.dtype == torch.float16
@@ -564,12 +570,12 @@ def test_chunk_kda_selects_direct_dense_or_ragged_route(
     module = importlib.import_module("attn_gym.linear.kda.impl.fused")
     routes = []
 
-    def dense_forward(q, _k, v, _gate, _beta, _state, _tune):
+    def dense_forward(q, _k, v, _gate, _beta, _state, _scale, _tune):
         routes.append("dense")
         factors = q.new_empty((*q.shape[:3], 64))
         return torch.empty_like(v), factors, factors
 
-    def ragged_forward(q, _k, v, _gate, _beta, _state, _cu_seqlens, _chunk_offsets, _tune):
+    def ragged_forward(q, _k, v, _gate, _beta, _state, _cu_seqlens, _chunk_offsets, _scale, _tune):
         routes.append("ragged")
         factors = q.new_empty((*q.shape[:3], 64))
         return torch.empty_like(v), factors, factors
@@ -856,6 +862,7 @@ def test_chunk_kda_op_registration(dtype):
         cumulative_gate.detach(),
         beta.detach(),
         initial_state.detach(),
+        _DEFAULT_SCALE,
         True,
     )
     torch.library.opcheck(_chunk_kda_fwd_op, args, rtol=2e-2, atol=2e-3)
@@ -906,6 +913,7 @@ def test_chunk_kda_backward_op_registration(dtype):
             cumulative_gate,
             beta,
             initial_state,
+            _DEFAULT_SCALE,
             True,
         )
     torch.library.opcheck(
@@ -923,6 +931,7 @@ def test_chunk_kda_backward_op_registration(dtype):
             None,
             torch.randn_like(state),
             None,
+            _DEFAULT_SCALE,
             False,
             True,
         ),
@@ -945,6 +954,7 @@ def test_chunk_kda_backward_op_registration(dtype):
             None,
             torch.randn_like(state),
             initial_state.detach(),
+            _DEFAULT_SCALE,
             False,
             True,
         ),

--- a/test/test_kda_kernels.py
+++ b/test/test_kda_kernels.py
@@ -1226,6 +1226,7 @@ def test_chunk_kda_bwd_wy_dqkg_fused_cute():
         dh,
         dv,
         None,
+        scale=scale,
         chunk_size=64,
     )
 

--- a/test/test_kda_ragged_autograd_ops.py
+++ b/test/test_kda_ragged_autograd_ops.py
@@ -24,6 +24,9 @@ pytestmark = pytest.mark.skipif(
 )
 
 
+_DEFAULT_SCALE = 128**-0.5
+
+
 def test_ragged_custom_op_registrations():
     q, k, v, gate, beta = make_kda_test_inputs(128, requires_grad=True)
     initial_state = (torch.randn(2, 1, 128, 128, device="cuda") / 8).requires_grad_()
@@ -36,6 +39,7 @@ def test_ragged_custom_op_registrations():
         initial_state.detach(),
         cu_seqlens,
         metadata.chunk_offsets,
+        _DEFAULT_SCALE,
         True,
     )
     torch.library.opcheck(
@@ -67,6 +71,7 @@ def test_ragged_custom_op_registrations():
             torch.randn_like(output),
             torch.randn_like(state),
             initial_state.detach(),
+            _DEFAULT_SCALE,
             False,
             True,
         ),
@@ -80,6 +85,7 @@ def test_ragged_custom_op_registrations():
         None,
         cu_seqlens,
         metadata.chunk_offsets,
+        _DEFAULT_SCALE,
         True,
     )
     with torch.no_grad():
@@ -95,6 +101,7 @@ def test_ragged_custom_op_registrations():
             torch.randn_like(output),
             None,
             None,
+            _DEFAULT_SCALE,
             False,
             True,
         ),

--- a/test/test_kda_ragged_bwd_wy.py
+++ b/test/test_kda_ragged_bwd_wy.py
@@ -66,7 +66,7 @@ def _inputs(
 
 
 def _run(inputs: StageInputs, metadata):
-    return chunk_kda_bwd_wy_dqkg(*inputs, metadata)
+    return chunk_kda_bwd_wy_dqkg(*inputs, metadata, scale=128**-0.5)
 
 
 def _sequence_local_reference(inputs: StageInputs, lengths: list[int]):
@@ -232,7 +232,7 @@ def test_ragged_wy_cuda_graph_replay():
     def operation(*args):
         *stage_tensors, offsets = args
         metadata = prepare_ragged_chunk_metadata(offsets, tokens, 64)
-        return chunk_kda_bwd_wy_dqkg(*stage_tensors, metadata)
+        return chunk_kda_bwd_wy_dqkg(*stage_tensors, metadata, scale=128**-0.5)
 
     operation(*inputs, cu_seqlens)
     torch.cuda.synchronize()

--- a/test/test_kda_recurrent.py
+++ b/test/test_kda_recurrent.py
@@ -273,6 +273,37 @@ def test_recurrent_agrees_with_chunked_core():
     torch.testing.assert_close(recurrent_state, chunked_state, rtol=5e-2, atol=5e-2)
 
 
+def test_chunk_scale_override_matches_query_prescale():
+    """``scale`` post-multiplies the output, which equals scaling FP32 queries directly."""
+    from attn_gym.linear import chunk_kda
+
+    q, k, v, gate, beta, state = _inputs(tokens=32, initial_state=True, seed=5)
+    scale, key_dim = 0.25, q.shape[-1]
+    scaled = chunk_kda(
+        q, k, v, gate, beta, state, scale=scale, output_final_state=True, impl="reference"
+    )
+    expected = chunk_kda(
+        q * (scale * key_dim**0.5),
+        k,
+        v,
+        gate,
+        beta,
+        state,
+        output_final_state=True,
+        impl="reference",
+    )
+    torch.testing.assert_close(scaled[0], expected[0])
+    torch.testing.assert_close(scaled[1], expected[1], rtol=0, atol=0)
+
+
+def test_chunk_scale_rejects_bool():
+    from attn_gym.linear import chunk_kda
+
+    q, k, v, gate, beta, _ = _inputs(tokens=3)
+    with pytest.raises(TypeError, match="scale must be a real scalar"):
+        chunk_kda(q, k, v, gate, beta, scale=True, impl="reference")
+
+
 @pytest.mark.parametrize("packed", [False, True])
 def test_recurrent_paged_matches_gather_scatter(packed: bool):
     """Slot indexing equals a native gather, dense scan, and scatter round trip."""


### PR DESCRIPTION
Support a host-driven query scale in chunk_kda

## Human Note

## Agent note

Thread a runtime query scale through the fused KDA chunk pipeline instead of pinning
1/sqrt(K): chunk_kda gains scale (defaulting to 1/sqrt(K)), resolved once at the public
boundary by a shared _delta_rule resolver that the KDA and GDN decode paths now reuse, and
every internal layer takes a required float. Each pipeline stage already accepted scale as a
runtime argument, so the plumbing adds it to the chunk op schemas and fakes, the autograd
Function, and the two orchestrators that previously hardcoded the default. The one genuine
kernel-facing change is the fused WY/dQKG backward stage, which bakes scale into its CuTeDSL
specialization: scale joins its compile key, which is correct because scale is a per-model
constant. Applying scale inside the kernels' FP32 math means large overrides cannot overflow
low-precision q (a folded scale * sqrt(K) multiplier exceeds FP16 range near scale 5800 even
for normalized queries). The reference path binds the same resolved scale into the naive
oracle. Paged chunk prefill keeps the fixed default; its public API is unchanged.

Tests pin the scale semantics against explicit FP32 query pre-scaling with bit-exact final
states, reject bool scales, and update every direct chunk-op caller to the new arity;
repeated default-scale literals become named constants and the touched CuTe test modules now
skip precisely on SM100/SM103.

## Test Plan

```bash
.venv/bin/prek
gpu-run auto -- .venv/bin/pytest -q -n 6 test/
```