### PR TITLE
Support query scale in recurrent KDA

### DIFF
--- a/attn_gym/linear/kda/api.py
+++ b/attn_gym/linear/kda/api.py
@@ -241,6 +241,7 @@ def recurrent_kda(
     initial_state: torch.Tensor | None = None,
     *,
     cu_seqlens: torch.Tensor | None = None,
+    scale: float | None = None,
     output_final_state: bool = False,
     state_indices: torch.Tensor | None = None,
     has_initial_state: torch.Tensor | None = None,
@@ -250,7 +251,7 @@ def recurrent_kda(
     """Apply recurrent KDA for decoding and inference prefill.
 
     Args:
-        q: Queries shaped ``[B, T, HK, K]``, scaled by ``1/sqrt(K)`` internally. ``HK``
+        q: Queries shaped ``[B, T, HK, K]``, scaled by ``scale`` internally. ``HK``
             may divide the value head count ``H`` for multi-value attention (MVA): each
             block of ``H // HK`` consecutive value heads shares one query/key head, while
             the gate, beta, and state stay per value head.
@@ -268,6 +269,7 @@ def recurrent_kda(
             contiguous ``int32`` on ``q.device``; they start at zero, never
             decrease, may repeat for empty sequences whose states pass through,
             and may end before ``T``.
+        scale: Query scale. Defaults to ``1 / sqrt(K)``.
         output_final_state: Return the final recurrent state with the output. Rejected
             together with ``state_indices``, which advances the pool in place instead.
         state_indices: Contiguous ``int32`` slot indices, one per logical sequence,
@@ -327,6 +329,7 @@ def recurrent_kda(
             raise ValueError("state_indices requires impl='fused'")
     elif has_initial_state is not None:
         raise ValueError("has_initial_state requires state_indices")
+    scale = resolve_scale(scale, q.shape[-1])
     if selected_impl is Impl.FUSED:
         return _fused_recurrent_forward(
             q,
@@ -336,13 +339,14 @@ def recurrent_kda(
             beta,
             initial_state,
             cu_seqlens=cu_seqlens,
+            scale=scale,
             output_final_state=output_final_state,
             state_indices=state_indices,
             has_initial_state=has_initial_state,
             autotune=autotune,
         )
     return reference_kda(
-        naive_recurrent_kda,
+        partial(naive_recurrent_kda, scale=scale),
         q,
         k,
         v,

--- a/attn_gym/linear/kda/fwd/triton/recurrent.py
+++ b/attn_gym/linear/kda/fwd/triton/recurrent.py
@@ -37,6 +37,7 @@ def _launch_kda_recurrent_fwd(
     initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor | None,
     *,
+    scale: float,
     store_final_state: bool,
     state_indices: torch.Tensor | None = None,
     has_initial_state: torch.Tensor | None = None,
@@ -51,7 +52,7 @@ def _launch_kda_recurrent_fwd(
         beta,
         initial_state,
         cu_seqlens,
-        scale=q.shape[-1] ** -0.5,
+        scale=scale,
         gate_kind=GateKind.VECTOR,
         store_final_state=store_final_state,
         state_indices=state_indices,
@@ -68,6 +69,7 @@ def _kda_recurrent_fwd_cuda(
     beta: torch.Tensor,
     initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor | None,
+    scale: float,
     autotune: bool,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     output, final_state = _launch_kda_recurrent_fwd(
@@ -78,6 +80,7 @@ def _kda_recurrent_fwd_cuda(
         beta,
         initial_state,
         cu_seqlens,
+        scale=scale,
         store_final_state=True,
         autotune=autotune,
     )
@@ -93,6 +96,7 @@ def _kda_recurrent_fwd_no_state_cuda(
     beta: torch.Tensor,
     initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor | None,
+    scale: float,
     autotune: bool,
 ) -> torch.Tensor:
     return _launch_kda_recurrent_fwd(
@@ -103,6 +107,7 @@ def _kda_recurrent_fwd_no_state_cuda(
         beta,
         initial_state,
         cu_seqlens,
+        scale=scale,
         store_final_state=False,
         autotune=autotune,
     )[0]
@@ -118,6 +123,7 @@ def _kda_recurrent_fwd_paged_cuda(
     state_indices: torch.Tensor,
     has_initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor | None,
+    scale: float,
 ) -> torch.Tensor:
     return _launch_kda_recurrent_fwd(
         q,
@@ -127,6 +133,7 @@ def _kda_recurrent_fwd_paged_cuda(
         beta,
         state_cache,
         cu_seqlens,
+        scale=scale,
         store_final_state=True,
         state_indices=state_indices,
         has_initial_state=has_initial_state,

--- a/attn_gym/linear/kda/ops.py
+++ b/attn_gym/linear/kda/ops.py
@@ -100,7 +100,7 @@ torch.library.define(
 
 _RECURRENT_FWD_ARGS = (
     "(Tensor q, Tensor k, Tensor v, Tensor gate, Tensor beta,"
-    " Tensor? initial_state, Tensor? cu_seqlens, bool autotune)"
+    " Tensor? initial_state, Tensor? cu_seqlens, float scale, bool autotune)"
 )
 torch.library.define("attn_gym::kda_recurrent_fwd", _RECURRENT_FWD_ARGS + " -> (Tensor, Tensor)")
 torch.library.define("attn_gym::kda_recurrent_fwd_no_state", _RECURRENT_FWD_ARGS + " -> Tensor")
@@ -109,7 +109,7 @@ torch.library.define("attn_gym::kda_recurrent_fwd_no_state", _RECURRENT_FWD_ARGS
 torch.library.define(
     "attn_gym::kda_recurrent_fwd_paged",
     "(Tensor q, Tensor k, Tensor v, Tensor gate, Tensor beta, Tensor(a!) state_cache,"
-    " Tensor state_indices, Tensor? has_initial_state, Tensor? cu_seqlens) -> Tensor",
+    " Tensor state_indices, Tensor? has_initial_state, Tensor? cu_seqlens, float scale) -> Tensor",
 )
 torch.library.define(
     "attn_gym::kda_recurrent_decode",
@@ -602,9 +602,10 @@ def _recurrent_fwd_fake(
     beta: torch.Tensor,
     initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor | None,
+    scale: float,
     autotune: bool,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    del k, gate, beta, initial_state, autotune
+    del k, gate, beta, initial_state, scale, autotune
     num_sequences = q.shape[0] if cu_seqlens is None else cu_seqlens.shape[0] - 1
     # The state carries one [V, K] slab per value head; grouped callers have v.shape[2] > HK.
     final_state = q.new_empty(
@@ -622,9 +623,10 @@ def _recurrent_fwd_no_state_fake(
     beta: torch.Tensor,
     initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor | None,
+    scale: float,
     autotune: bool,
 ) -> torch.Tensor:
-    del k, gate, beta, initial_state, cu_seqlens, autotune
+    del k, gate, beta, initial_state, cu_seqlens, scale, autotune
     return torch.empty_like(v, dtype=q.dtype)
 
 
@@ -639,8 +641,9 @@ def _recurrent_fwd_paged_fake(
     state_indices: torch.Tensor,
     has_initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor | None,
+    scale: float,
 ) -> torch.Tensor:
-    del k, gate, beta, state_cache, state_indices, has_initial_state, cu_seqlens
+    del k, gate, beta, state_cache, state_indices, has_initial_state, cu_seqlens, scale
     return torch.empty_like(v, dtype=q.dtype)
 
 
@@ -777,6 +780,7 @@ def recurrent_forward(
     initial_state: torch.Tensor | None = None,
     *,
     cu_seqlens: torch.Tensor | None = None,
+    scale: float,
     output_final_state: bool = False,
     state_indices: torch.Tensor | None = None,
     has_initial_state: torch.Tensor | None = None,
@@ -803,15 +807,23 @@ def recurrent_forward(
         # `.contiguous()` on the pool would copy and silently drop the in-place advance.
         assert initial_state is not None
         return recurrent_fwd_paged_op(
-            q, k, v, gate, beta, initial_state, state_indices, has_initial_state, cu_seqlens
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            initial_state,
+            state_indices,
+            has_initial_state,
+            cu_seqlens,
+            scale,
         ), None
     if initial_state is not None:
         initial_state = initial_state.contiguous()
+    args = (q, k, v, gate, beta, initial_state, cu_seqlens, scale, autotune)
     if output_final_state:
-        return recurrent_fwd_op(q, k, v, gate, beta, initial_state, cu_seqlens, autotune)
-    return recurrent_fwd_no_state_op(
-        q, k, v, gate, beta, initial_state, cu_seqlens, autotune
-    ), None
+        return recurrent_fwd_op(*args)
+    return recurrent_fwd_no_state_op(*args), None
 
 
 def recurrent_decode_forward(

--- a/test/test_kda_recurrent.py
+++ b/test/test_kda_recurrent.py
@@ -257,7 +257,10 @@ def test_recurrent_grouped_heads_registration():
     beta = beta.repeat_interleave(3, dim=2).contiguous()
     gate = gate.repeat_interleave(3, dim=2).contiguous()
     state = torch.randn(1, v.shape[2], v.shape[-1], q.shape[3], device="cuda")
-    torch.library.opcheck(_recurrent_fwd_op, (q, k, v, gate, beta, state, None, True))
+    torch.library.opcheck(
+        _recurrent_fwd_op,
+        (q, k, v, gate, beta, state, None, q.shape[-1] ** -0.5, True),
+    )
 
 
 @pytest.mark.skipif(not BLACKWELL, reason="chunk_kda requires CUDA capability 10.0")
@@ -316,6 +319,55 @@ def test_chunk_scale_rejects_bool():
         chunk_kda(q, k, v, gate, beta, scale=True, impl="reference")
 
 
+def test_recurrent_scale_override_matches_reference_and_query_prescale():
+    """Use the same host-provided query scale in reference and fused recurrent paths."""
+    q, k, v, gate, beta, state = _inputs(tokens=32, initial_state=True, seed=6)
+    scale, key_dim = 0.25, q.shape[-1]
+    expected = recurrent_kda(
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        state,
+        scale=scale,
+        output_final_state=True,
+        impl="reference",
+    )
+    prescaled = recurrent_kda(
+        q * (scale * key_dim**0.5),
+        k,
+        v,
+        gate,
+        beta,
+        state,
+        output_final_state=True,
+        impl="reference",
+    )
+    with torch.no_grad():
+        actual = recurrent_kda(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            state,
+            scale=scale,
+            output_final_state=True,
+        )
+
+    torch.testing.assert_close(expected[0], prescaled[0])
+    torch.testing.assert_close(expected[1], prescaled[1], rtol=0, atol=0)
+    torch.testing.assert_close(actual[0], expected[0], rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(actual[1], expected[1], rtol=1e-5, atol=1e-5)
+
+
+def test_recurrent_scale_rejects_bool():
+    q, k, v, gate, beta, _ = _inputs(tokens=3)
+    with pytest.raises(TypeError, match="scale must be a real scalar"):
+        recurrent_kda(q, k, v, gate, beta, scale=True, impl="reference")
+
+
 @pytest.mark.parametrize("packed", [False, True])
 def test_recurrent_paged_matches_gather_scatter(packed: bool):
     """Slot indexing equals a native gather, dense scan, and scatter round trip."""
@@ -326,8 +378,17 @@ def test_recurrent_paged_matches_gather_scatter(packed: bool):
     slots = torch.tensor([5, 1, 3], device="cuda", dtype=torch.int32)
     before = pool.clone()
 
+    scale = 0.25
     output, final_state = recurrent_kda(
-        q, k, v, gate, beta, pool, cu_seqlens=cu_seqlens, state_indices=slots
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        pool,
+        cu_seqlens=cu_seqlens,
+        scale=scale,
+        state_indices=slots,
     )
 
     assert final_state is None
@@ -338,6 +399,7 @@ def test_recurrent_paged_matches_gather_scatter(packed: bool):
         v,
         gate * LOG2_E,
         beta,
+        scale=scale,
         initial_state=before[slots.long()],
         output_final_state=True,
         cu_seqlens=cu_seqlens,
@@ -523,17 +585,17 @@ def test_recurrent_custom_op_registration(packed: bool):
     state = torch.randn(num_sequences, q.shape[2], v.shape[-1], q.shape[3], device="cuda")
     torch.library.opcheck(
         _recurrent_fwd_op,
-        (q, k, v, gate, beta, state, cu_seqlens, True),
+        (q, k, v, gate, beta, state, cu_seqlens, q.shape[-1] ** -0.5, True),
     )
     torch.library.opcheck(
         _recurrent_fwd_no_state_op,
-        (q, k, v, gate, beta, state, cu_seqlens, True),
+        (q, k, v, gate, beta, state, cu_seqlens, q.shape[-1] ** -0.5, True),
     )
     _, state_pool = strided_state_pool(num_sequences + 1, q.shape[2], q.shape[3], v.shape[-1])
     slots = torch.arange(1, num_sequences + 1, device="cuda", dtype=torch.int32)
     torch.library.opcheck(
         _recurrent_fwd_paged_op,
-        (q, k, v, gate, beta, state_pool, slots, None, cu_seqlens),
+        (q, k, v, gate, beta, state_pool, slots, None, cu_seqlens, q.shape[-1] ** -0.5),
     )
 
 
@@ -545,14 +607,17 @@ def test_recurrent_custom_op_registration_mixed_dtype():
     _, state_pool = strided_state_pool(3, q.shape[2], q.shape[3], v.shape[-1])
     slots = torch.tensor([1, 2], device="cuda", dtype=torch.int32)
 
-    torch.library.opcheck(_recurrent_fwd_op, (q, k, v, gate, beta, state, None, True))
+    torch.library.opcheck(
+        _recurrent_fwd_op,
+        (q, k, v, gate, beta, state, None, q.shape[-1] ** -0.5, True),
+    )
     torch.library.opcheck(
         _recurrent_fwd_no_state_op,
-        (q, k, v, gate, beta, state, None, True),
+        (q, k, v, gate, beta, state, None, q.shape[-1] ** -0.5, True),
     )
     torch.library.opcheck(
         _recurrent_fwd_paged_op,
-        (q, k, v, gate, beta, state_pool, slots, None, None),
+        (q, k, v, gate, beta, state_pool, slots, None, None, q.shape[-1] ** -0.5),
     )
 
 
@@ -561,6 +626,7 @@ def test_recurrent_custom_op_registration_mixed_dtype():
 def test_recurrent_fullgraph_compile(output_final_state: bool, autotune: bool):
     """Compile both optional-state branches of the public operation."""
     q, k, v, gate, beta, state = _inputs(initial_state=True)
+    scale = 0.25
 
     expected, expected_state = recurrent_kda(
         q,
@@ -569,6 +635,7 @@ def test_recurrent_fullgraph_compile(output_final_state: bool, autotune: bool):
         gate,
         beta,
         state,
+        scale=scale,
         output_final_state=output_final_state,
         autotune=autotune,
     )
@@ -580,6 +647,7 @@ def test_recurrent_fullgraph_compile(output_final_state: bool, autotune: bool):
         gate,
         beta,
         state,
+        scale=scale,
         output_final_state=output_final_state,
         autotune=autotune,
     )
@@ -598,10 +666,13 @@ def test_recurrent_paged_mixed_dtype_fullgraph_compile():
     compiled_storage, compiled_pool = strided_state_pool(4, q.shape[2], q.shape[3], v.shape[-1])
     compiled_pool.copy_(eager_pool)
     slots = torch.tensor([3, 1], device="cuda", dtype=torch.int32)
+    scale = 0.25
 
-    expected, _ = recurrent_kda(q, k, v, gate, beta, eager_pool, state_indices=slots)
+    expected, _ = recurrent_kda(q, k, v, gate, beta, eager_pool, scale=scale, state_indices=slots)
     compiled = torch.compile(recurrent_kda, fullgraph=True)
-    output, final_state = compiled(q, k, v, gate, beta, compiled_pool, state_indices=slots)
+    output, final_state = compiled(
+        q, k, v, gate, beta, compiled_pool, scale=scale, state_indices=slots
+    )
 
     assert output.dtype == q.dtype and final_state is None
     torch.testing.assert_close(output, expected, rtol=0, atol=0)
@@ -616,13 +687,14 @@ def test_recurrent_cuda_graph_replay():
     q, k, v, gate, beta, _ = _inputs(batch=1, tokens=32, seed=5)
     cu_seqlens = cumulative_sequence_offsets([11, 16, 5])
     initial_state = torch.randn(3, q.shape[2], v.shape[-1], q.shape[3], device="cuda")
-    _recurrent_fwd_op(q, k, v, gate, beta, initial_state, cu_seqlens, True)
+    scale = 0.25
+    _recurrent_fwd_op(q, k, v, gate, beta, initial_state, cu_seqlens, scale, True)
     torch.cuda.synchronize()
 
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
         captured_output, captured_state = _recurrent_fwd_op(
-            q, k, v, gate, beta, initial_state, cu_seqlens, True
+            q, k, v, gate, beta, initial_state, cu_seqlens, scale, True
         )
 
     active_tokens = 23
@@ -635,7 +707,7 @@ def test_recurrent_cuda_graph_replay():
     torch.cuda.synchronize()
 
     expected_output, expected_state = _recurrent_fwd_op(
-        q, k, v, gate, beta, initial_state, cu_seqlens, True
+        q, k, v, gate, beta, initial_state, cu_seqlens, scale, True
     )
     torch.testing.assert_close(
         captured_output[:, :active_tokens],
@@ -651,12 +723,15 @@ def test_recurrent_paged_cuda_graph_replay():
     q, k, v, gate, beta, _ = _inputs(batch=3, tokens=1, dtype=torch.bfloat16, seed=31)
     storage, pool = strided_state_pool(7, q.shape[2], q.shape[3], v.shape[-1])
     slots = torch.tensor([5, 1, 3], device="cuda", dtype=torch.int32)
-    _recurrent_fwd_paged_op(q, k, v, gate, beta, pool, slots, None, None)
+    scale = 0.25
+    _recurrent_fwd_paged_op(q, k, v, gate, beta, pool, slots, None, None, scale)
     torch.cuda.synchronize()
 
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
-        captured_output = _recurrent_fwd_paged_op(q, k, v, gate, beta, pool, slots, None, None)
+        captured_output = _recurrent_fwd_paged_op(
+            q, k, v, gate, beta, pool, slots, None, None, scale
+        )
 
     with torch.no_grad():
         storage.add_(0.25)
@@ -666,7 +741,9 @@ def test_recurrent_paged_cuda_graph_replay():
     expected_storage = storage.clone()
     state_elements = pool[0].numel()
     expected_pool = expected_storage[:, 11 : 11 + state_elements].view_as(pool)
-    expected, _ = recurrent_kda(q, k, v, gate, beta, expected_pool, state_indices=slots)
+    expected, _ = recurrent_kda(
+        q, k, v, gate, beta, expected_pool, scale=scale, state_indices=slots
+    )
 
     graph.replay()
     torch.cuda.synchronize()


### PR DESCRIPTION
Stacked PRs:
 * #397
 * #369
 * #400
 * __->__#399


--- --- ---

Support query scale in recurrent KDA

## Human Note

## Agent note

Thread the public optional query scale through recurrent KDA's reference, fused, packed, paged,
custom-op, fake-tensor, compile, and CUDA Graph paths. Python resolves `None` from the actual key
dimension before invoking private operators, keeping the low-level schemas free of default policy
and making recurrent inference consistent with `chunk_kda` prefill under custom scaling.

## Test Plan

```bash
pytest -n 6 -q test/test_kda_recurrent.py test/linear/test_recurrent_delta_rule.py
ruff check attn_gym/linear/kda/api.py attn_gym/linear/kda/ops.py attn_gym/linear/kda/fwd/triton/recurrent.py test/test_kda_recurrent.py
```