### PR TITLE
Share delta-rule validation and packed references

### DIFF
--- a/attn_gym/linear/_delta_rule/reference.py
+++ b/attn_gym/linear/_delta_rule/reference.py
@@ -1,0 +1,72 @@
+"""Shared packed execution for eager delta-rule reference implementations."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from itertools import pairwise
+
+import torch
+
+DenseReference = Callable[..., tuple[torch.Tensor, torch.Tensor | None]]
+
+
+def packed_delta_rule_reference(
+    dense_op: DenseReference,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor,
+    output_final_state: bool,
+    *,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Evaluate packed logical sequences independently through a dense reference op."""
+    heads, key_dim, value_dim = v.shape[2], q.shape[3], v.shape[-1]
+    num_sequences = cu_seqlens.shape[0] - 1
+    output = torch.zeros_like(v)
+    final_state = None
+    if output_final_state:
+        final_state = (
+            q.new_zeros(num_sequences, heads, value_dim, key_dim)
+            if initial_state is None
+            else initial_state.clone()
+        )
+
+    offsets = cu_seqlens.cpu().tolist()
+    if (
+        offsets[0] != 0
+        or any(begin > end for begin, end in pairwise(offsets))
+        or offsets[-1] > q.shape[1]
+    ):
+        raise ValueError(
+            "cu_seqlens offsets must start at zero, be nondecreasing, and end within "
+            "the physical token capacity"
+        )
+
+    for sequence, (begin, end) in enumerate(pairwise(offsets)):
+        if begin == end:
+            continue
+        span = slice(begin, end)
+        span_output, span_state = dense_op(
+            q[:, span],
+            k[:, span],
+            v[:, span],
+            gate[:, span],
+            beta[:, span],
+            initial_state=None
+            if initial_state is None
+            else initial_state[sequence : sequence + 1],
+            scale=scale,
+            output_final_state=output_final_state,
+        )
+        output[:, span] = span_output
+        if final_state is not None:
+            assert span_state is not None
+            final_state[sequence] = span_state[0]
+    return output, final_state
+
+
+__all__ = ["packed_delta_rule_reference"]

--- a/attn_gym/linear/_delta_rule/validation.py
+++ b/attn_gym/linear/_delta_rule/validation.py
@@ -1,4 +1,4 @@
-"""Validation shared by paged delta-rule operations."""
+"""Structural validation shared by public delta-rule operations."""
 
 from __future__ import annotations
 
@@ -8,6 +8,70 @@ from numbers import Real
 import torch
 
 SUPPORTED_ACTIVATION_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
+
+
+def validate_delta_rule_inputs(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+    *,
+    op_name: str,
+    gate_name: str,
+    vector_gate: bool,
+    allow_grouped_heads: bool,
+) -> None:
+    """Validate structural invariants shared by scalar- and vector-gated delta rules."""
+    if q.ndim != 4:
+        raise ValueError(f"q must have shape [B, T, H, K], got {tuple(q.shape)}")
+    batch, tokens, key_heads, key_dim = q.shape
+    if batch == 0 or tokens == 0 or key_heads == 0 or key_dim == 0:
+        raise ValueError(f"q must have nonempty dimensions, got {tuple(q.shape)}")
+    if k.shape != q.shape:
+        raise ValueError(f"k must have shape {tuple(q.shape)}, got {tuple(k.shape)}")
+    if v.ndim != 4 or v.shape[:2] != (batch, tokens) or v.shape[-1] < 1:
+        raise ValueError(f"v must have shape [{batch}, {tokens}, H, V], got {tuple(v.shape)}")
+
+    heads = v.shape[2]
+    grouped_heads = heads != key_heads
+    if grouped_heads and not (allow_grouped_heads and heads != 0 and heads % key_heads == 0):
+        relation = "be a positive multiple of" if allow_grouped_heads else "match"
+        raise ValueError(
+            f"v heads must {relation} q heads for {op_name}, "
+            f"got {heads} value heads for {key_heads} query heads"
+        )
+
+    gate_shape = (batch, tokens, heads, key_dim) if vector_gate else (batch, tokens, heads)
+    if gate.shape != gate_shape:
+        raise ValueError(f"{gate_name} must have shape {gate_shape}, got {tuple(gate.shape)}")
+    if beta.shape != (batch, tokens, heads):
+        raise ValueError(f"beta must have shape {(batch, tokens, heads)}, got {tuple(beta.shape)}")
+
+    if cu_seqlens is not None:
+        if batch != 1:
+            raise ValueError("packed cu_seqlens require q to have batch size one")
+        if cu_seqlens.ndim != 1 or cu_seqlens.shape[0] < 2:
+            raise ValueError("cu_seqlens must have shape [num_sequences + 1]")
+        if (
+            cu_seqlens.dtype != torch.int32
+            or not cu_seqlens.is_contiguous()
+            or cu_seqlens.device != q.device
+        ):
+            raise ValueError("cu_seqlens must be contiguous int32 on q.device")
+
+    state_batch = batch if cu_seqlens is None else cu_seqlens.shape[0] - 1
+    expected_state = (state_batch, heads, v.shape[-1], key_dim)
+    if initial_state is not None and initial_state.shape != expected_state:
+        raise ValueError(
+            f"initial_state must have shape {expected_state}, got {tuple(initial_state.shape)}"
+        )
+
+    tensors = (q, k, v, gate, beta) + (() if initial_state is None else (initial_state,))
+    if any(tensor.device != q.device for tensor in tensors[1:]):
+        raise ValueError("all inputs must be on the same device")
 
 
 def resolve_scale(scale: float | None, key_dim: int) -> float:
@@ -169,6 +233,7 @@ __all__ = [
     "resolve_decode_out",
     "resolve_scale",
     "validate_decode_inputs",
+    "validate_delta_rule_inputs",
     "validate_has_initial_state",
     "validate_paged_state",
 ]

--- a/attn_gym/linear/gdn/api.py
+++ b/attn_gym/linear/gdn/api.py
@@ -63,6 +63,7 @@ def chunk_gdn(
     if selected_impl is Impl.FUSED:
         raise NotImplementedError("chunk_gdn impl='fused' is not implemented yet")
 
+    scale = q.shape[-1] ** -0.5 if scale is None else scale
     return reference_gdn(
         chunk_forward,
         q,
@@ -70,7 +71,7 @@ def chunk_gdn(
         v,
         gate,
         beta,
-        scale=q.shape[-1] ** -0.5 if scale is None else scale,
+        scale=scale,
         initial_state=initial_state,
         cu_seqlens=cu_seqlens,
         output_final_state=output_final_state,

--- a/attn_gym/linear/gdn/impl/reference.py
+++ b/attn_gym/linear/gdn/impl/reference.py
@@ -2,68 +2,12 @@
 
 from __future__ import annotations
 
-from itertools import pairwise
-
 import torch
 import torch.nn.functional as F
 
+from attn_gym.linear._delta_rule.reference import packed_delta_rule_reference
+
 _CHUNK_SIZE = 64
-
-
-def _packed_reference(
-    dense_op,
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    log_decay: torch.Tensor,
-    beta: torch.Tensor,
-    initial_state: torch.Tensor | None,
-    cu_seqlens: torch.Tensor,
-    scale: float,
-    output_final_state: bool,
-) -> tuple[torch.Tensor, torch.Tensor | None]:
-    """Evaluate packed sequences independently through a dense reference operation."""
-    heads, key_dim, value_dim = q.shape[2], q.shape[3], v.shape[-1]
-    num_sequences = cu_seqlens.shape[0] - 1
-    output = torch.zeros_like(v)
-    final_state = None
-    if output_final_state:
-        final_state = (
-            q.new_zeros(num_sequences, heads, value_dim, key_dim)
-            if initial_state is None
-            else initial_state.clone()
-        )
-
-    offsets = cu_seqlens.cpu().tolist()
-    if (
-        offsets[0] != 0
-        or any(begin > end for begin, end in pairwise(offsets))
-        or offsets[-1] > q.shape[1]
-    ):
-        raise ValueError(
-            "cu_seqlens offsets must start at zero, be nondecreasing, and end within "
-            "the physical token capacity"
-        )
-    for sequence, (begin, end) in enumerate(pairwise(offsets)):
-        if begin == end:
-            continue
-        span = slice(begin, end)
-        span_output, span_state = dense_op(
-            q[:, span],
-            k[:, span],
-            v[:, span],
-            log_decay[:, span],
-            beta[:, span],
-            scale=scale,
-            initial_state=None
-            if initial_state is None
-            else initial_state[sequence : sequence + 1],
-            output_final_state=output_final_state,
-        )
-        output[:, span] = span_output
-        if final_state is not None:
-            final_state[sequence] = span_state[0]
-    return output, final_state
 
 
 def reference_gdn(
@@ -101,7 +45,7 @@ def reference_gdn(
                 output_final_state=output_final_state,
             )
         else:
-            output, state = _packed_reference(
+            output, state = packed_delta_rule_reference(
                 dense_op,
                 q,
                 k,
@@ -110,8 +54,8 @@ def reference_gdn(
                 beta,
                 initial_state,
                 cu_seqlens,
-                scale,
                 output_final_state,
+                scale=scale,
             )
     return output.to(output_dtype), state
 

--- a/attn_gym/linear/gdn/validation.py
+++ b/attn_gym/linear/gdn/validation.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import torch
 
+from attn_gym.linear._delta_rule.validation import validate_delta_rule_inputs
+
 
 def validate_gdn_inputs(
     q: torch.Tensor,
@@ -15,51 +17,22 @@ def validate_gdn_inputs(
     cu_seqlens: torch.Tensor | None = None,
 ) -> None:
     """Validate backend-independent gated delta rule tensor invariants."""
-    if q.ndim != 4:
-        raise ValueError(f"q must have shape [B, T, HK, K], got {tuple(q.shape)}")
-    batch, tokens, key_heads, key_dim = q.shape
-    if batch == 0 or tokens == 0 or key_heads == 0 or key_dim == 0:
-        raise ValueError(f"q must have nonempty dimensions, got {tuple(q.shape)}")
-    if k.shape != q.shape:
-        raise ValueError(f"k must have shape {tuple(q.shape)}, got {tuple(k.shape)}")
-    if v.ndim != 4 or v.shape[:2] != (batch, tokens) or v.shape[-1] == 0:
-        raise ValueError(f"v must have shape [{batch}, {tokens}, H, V], got {tuple(v.shape)}")
-    heads = v.shape[2]
-    if heads == 0 or heads % key_heads != 0:
-        raise ValueError(
-            f"v heads must be a positive multiple of q heads for grouped-head attention, "
-            f"got {heads} value heads for {key_heads} query heads"
-        )
-    if gate.shape != (batch, tokens, heads):
-        raise ValueError(f"gate must have shape {(batch, tokens, heads)}, got {tuple(gate.shape)}")
-    if beta.shape != (batch, tokens, heads):
-        raise ValueError(f"beta must have shape {(batch, tokens, heads)}, got {tuple(beta.shape)}")
-
-    if cu_seqlens is not None:
-        if batch != 1:
-            raise ValueError("packed cu_seqlens require q to have batch size one")
-        if cu_seqlens.ndim != 1 or cu_seqlens.shape[0] < 2:
-            raise ValueError("cu_seqlens must have shape [num_sequences + 1]")
-        if (
-            cu_seqlens.dtype != torch.int32
-            or not cu_seqlens.is_contiguous()
-            or cu_seqlens.device != q.device
-        ):
-            raise ValueError("cu_seqlens must be contiguous int32 on q.device")
-
-    state_batch = batch if cu_seqlens is None else cu_seqlens.shape[0] - 1
-    if initial_state is not None:
-        expected_state_shape = (state_batch, heads, v.shape[-1], key_dim)
-        if initial_state.shape != expected_state_shape:
-            raise ValueError(
-                f"initial_state must have shape {expected_state_shape}, got {initial_state.shape}"
-            )
-
+    validate_delta_rule_inputs(
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        initial_state,
+        cu_seqlens,
+        op_name="gated delta rule",
+        gate_name="gate",
+        vector_gate=False,
+        allow_grouped_heads=True,
+    )
     tensors = (q, k, v, gate, beta) + (() if initial_state is None else (initial_state,))
     if not all(tensor.is_floating_point() for tensor in tensors):
         raise ValueError("all inputs must have floating-point dtypes")
-    if any(tensor.device != q.device for tensor in tensors[1:]):
-        raise ValueError("all inputs must be on the same device")
     if k.dtype != q.dtype or v.dtype != q.dtype:
         raise ValueError("q, k, and v must have the same dtype")
 

--- a/attn_gym/linear/kda/api.py
+++ b/attn_gym/linear/kda/api.py
@@ -148,7 +148,7 @@ def chunk_kda(
             autotune=autotune,
         )
     return reference_kda(
-        partial(naive_chunk_kda, chunk_size=_CHUNK_SIZE, scale=scale),
+        partial(naive_chunk_kda, chunk_size=_CHUNK_SIZE),
         q,
         k,
         v,
@@ -156,6 +156,7 @@ def chunk_kda(
         beta,
         initial_state,
         cu_seqlens,
+        scale,
         output_final_state,
     )
 
@@ -346,7 +347,7 @@ def recurrent_kda(
             autotune=autotune,
         )
     return reference_kda(
-        partial(naive_recurrent_kda, scale=scale),
+        naive_recurrent_kda,
         q,
         k,
         v,
@@ -354,6 +355,7 @@ def recurrent_kda(
         beta,
         initial_state,
         cu_seqlens,
+        scale,
         output_final_state,
     )
 

--- a/attn_gym/linear/kda/impl/reference.py
+++ b/attn_gym/linear/kda/impl/reference.py
@@ -14,66 +14,9 @@ it reads device offsets on the host before iterating over logical sequences.
 
 from __future__ import annotations
 
-from itertools import pairwise
-
 import torch
 
-
-def _packed_reference(
-    dense_op,
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    gate: torch.Tensor,
-    beta: torch.Tensor,
-    initial_state: torch.Tensor | None,
-    cu_seqlens: torch.Tensor,
-    output_final_state: bool,
-) -> tuple[torch.Tensor, torch.Tensor | None]:
-    """Evaluate packed sequences independently through a dense reference op.
-
-    The offsets are read on the host, so the reference path synchronizes; the
-    fused implementations keep them device-resident.
-    """
-    heads, key_dim, value_dim = q.shape[2], q.shape[3], v.shape[-1]
-    num_sequences = cu_seqlens.shape[0] - 1
-    output = torch.zeros_like(v)
-    final_state = None
-    if output_final_state:
-        final_state = (
-            q.new_zeros(num_sequences, heads, value_dim, key_dim)
-            if initial_state is None
-            else initial_state.clone()
-        )
-    offsets = cu_seqlens.cpu().tolist()
-    if (
-        offsets[0] != 0
-        or any(start > end for start, end in pairwise(offsets))
-        or offsets[-1] > q.shape[1]
-    ):
-        raise ValueError(
-            "cu_seqlens offsets must start at zero, be nondecreasing, and end within "
-            "the physical token capacity"
-        )
-    for sequence, (start, end) in enumerate(pairwise(offsets)):
-        if start == end:
-            continue
-        span = slice(start, end)
-        span_output, span_state = dense_op(
-            q[:, span],
-            k[:, span],
-            v[:, span],
-            gate[:, span],
-            beta[:, span],
-            initial_state=None
-            if initial_state is None
-            else initial_state[sequence : sequence + 1],
-            output_final_state=output_final_state,
-        )
-        output[:, span] = span_output
-        if final_state is not None:
-            final_state[sequence] = span_state[0]
-    return output, final_state
+from attn_gym.linear._delta_rule.reference import packed_delta_rule_reference
 
 
 def reference_kda(
@@ -85,6 +28,7 @@ def reference_kda(
     beta: torch.Tensor,
     initial_state: torch.Tensor | None,
     cu_seqlens: torch.Tensor | None,
+    scale: float,
     output_final_state: bool,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Run a dense reference op in FP32 under the public packed contract."""
@@ -109,12 +53,22 @@ def reference_kda(
                 v,
                 gate,
                 beta,
+                scale=scale,
                 initial_state=initial_state,
                 output_final_state=output_final_state,
             )
         else:
-            output, state = _packed_reference(
-                dense_op, q, k, v, gate, beta, initial_state, cu_seqlens, output_final_state
+            output, state = packed_delta_rule_reference(
+                dense_op,
+                q,
+                k,
+                v,
+                gate,
+                beta,
+                initial_state,
+                cu_seqlens,
+                output_final_state,
+                scale=scale,
             )
     return output.to(output_dtype), state
 

--- a/attn_gym/linear/kda/validation.py
+++ b/attn_gym/linear/kda/validation.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 import torch
 
+from attn_gym.linear._delta_rule.validation import validate_delta_rule_inputs
+
 SUPPORTED_INPUT_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
 
 
@@ -39,52 +41,20 @@ def validate_kda_inputs(
     the gate and beta drive each value head's state update and keep one entry per value
     head.
     """
-    if q.ndim != 4:
-        raise ValueError(f"q must have shape [B, T, H, K], got {tuple(q.shape)}")
-    batch, tokens, key_heads, key_dim = q.shape
-    if batch == 0 or tokens == 0 or key_heads == 0 or key_dim == 0:
-        raise ValueError(f"q must have nonempty dimensions, got {tuple(q.shape)}")
-    if k.shape != q.shape:
-        raise ValueError(f"k must have shape {tuple(q.shape)}, got {tuple(k.shape)}")
-    if v.ndim != 4 or v.shape[:2] != (batch, tokens) or v.shape[-1] < 1:
-        raise ValueError(f"v must have shape [{batch}, {tokens}, H, V], got {tuple(v.shape)}")
-    heads = v.shape[2]
-    if heads != key_heads and not (allow_grouped_heads and heads != 0 and heads % key_heads == 0):
-        message = (
-            f"v heads must be a positive multiple of q heads for {op_name}, "
-            if allow_grouped_heads
-            else f"v heads must match q heads for {op_name}, "
-        )
-        raise ValueError(message + f"got {heads} value heads for {key_heads} query heads")
-    if gate.shape != (batch, tokens, heads, key_dim):
-        raise ValueError(
-            f"{gate_name} must have shape {(batch, tokens, heads, key_dim)}, "
-            f"got {tuple(gate.shape)}"
-        )
-    if beta.shape != (batch, tokens, heads):
-        raise ValueError(f"beta must have shape {(batch, tokens, heads)}, got {tuple(beta.shape)}")
-    if cu_seqlens is not None:
-        if batch != 1:
-            raise ValueError("packed cu_seqlens require q to have batch size one")
-        if cu_seqlens.ndim != 1 or cu_seqlens.shape[0] < 2:
-            raise ValueError("cu_seqlens must have shape [num_sequences + 1]")
-        if (
-            cu_seqlens.dtype != torch.int32
-            or not cu_seqlens.is_contiguous()
-            or cu_seqlens.device != q.device
-        ):
-            raise ValueError("cu_seqlens must be contiguous int32 on q.device")
-    state_batch = batch if cu_seqlens is None else cu_seqlens.shape[0] - 1
-    expected_state = (state_batch, heads, v.shape[-1], key_dim)
-    if initial_state is not None and initial_state.shape != expected_state:
-        raise ValueError(
-            f"initial_state must have shape {expected_state}, got {tuple(initial_state.shape)}"
-        )
-    data_tensors = (q, k, v, gate, beta)
-    if initial_state is not None:
-        data_tensors += (initial_state,)
-    if not all(tensor.device == q.device for tensor in data_tensors):
-        raise ValueError(f"all {op_name} inputs must be on the same device")
+    validate_delta_rule_inputs(
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        initial_state,
+        cu_seqlens,
+        op_name=op_name,
+        gate_name=gate_name,
+        vector_gate=True,
+        allow_grouped_heads=allow_grouped_heads,
+    )
+    data_tensors = (q, k, v, gate, beta) + (() if initial_state is None else (initial_state,))
     if any(tensor.dtype not in SUPPORTED_INPUT_DTYPES for tensor in data_tensors):
         supported = ", ".join(str(dtype) for dtype in SUPPORTED_INPUT_DTYPES)
         raise TypeError(f"{op_name} inputs must use one of {supported}")


### PR DESCRIPTION
Stacked PRs:
 * #397
 * #369
 * __->__#400


--- --- ---

Share delta-rule validation and packed references

## Human Note

## Agent note

Extract the structural Q/K/V, gate, beta, packed-offset, state-shape, and device contract shared by
KDA and GDN while leaving each family responsible for its own gate layout and dtype policy. Reuse
one eager packed-reference loop for both families, preserving their different compute dtypes and
dense-operation arguments. Chunk metadata and scheduler ownership remain unchanged.

## Test Plan

```bash
pytest -n 6 -q test/test_kda_recurrent.py test/test_kda.py test/linear/test_gdn.py test/linear/test_gdn_fused.py test/test_kda_impl_dispatch.py
ruff check attn_gym/linear/_delta_rule/validation.py attn_gym/linear/_delta_rule/reference.py attn_gym/linear/kda/validation.py attn_gym/linear/gdn/validation.py attn_gym/linear/kda/impl/reference.py attn_gym/linear/gdn/impl/reference.py attn_gym/linear/gdn/api.py
```