### PR TITLE
Add typed chunk KDA kernel options

### DIFF
--- a/attn_gym/linear/__init__.py
+++ b/attn_gym/linear/__init__.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 from attn_gym.linear.gdn import chunk_gdn, recurrent_gdn, recurrent_gdn_decode
 from attn_gym.linear.kda import (
+    KernelOptions,
     active_token_mask,
     chunk_kda,
     mask_inactive_token_gradients,
@@ -49,6 +50,7 @@ GDN_OPS = [
 # Model-agnostic building blocks.
 GENERIC_OPS = [
     "Impl",
+    "KernelOptions",
     "active_token_mask",
     "causal_conv1d",
     "causal_conv1d_decode",

--- a/attn_gym/linear/kda/__init__.py
+++ b/attn_gym/linear/kda/__init__.py
@@ -15,6 +15,7 @@ and the naive oracles in
 import importlib
 
 from attn_gym.linear.kda.api import (
+    KernelOptions,
     chunk_kda,
     paged_chunk_kda,
     recurrent_kda,
@@ -50,6 +51,7 @@ def __getattr__(name: str):
 
 __all__ = sorted(  # noqa: PLE0605 -- backend exports resolve lazily
     [
+        "KernelOptions",
         "MAX_GATE_LOWER_BOUND_MAGNITUDE",
         "active_token_mask",
         "bound_gate",

--- a/attn_gym/linear/kda/api.py
+++ b/attn_gym/linear/kda/api.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import sys
 from functools import partial
 from numbers import Real
-from typing import Literal
+from typing import Literal, TypedDict
 
 import torch
 
@@ -43,6 +43,10 @@ _DECODE_GATE_TRANSFORMS = {
 }
 
 
+class KernelOptions(TypedDict, total=False):
+    """Backend-specific controls for :func:`chunk_kda`."""
+
+
 def _resolve_decode_gate_transform(gate_transform: str) -> bool:
     try:
         return _DECODE_GATE_TRANSFORMS[gate_transform]
@@ -67,6 +71,7 @@ def chunk_kda(
     fastmath: bool = False,
     autotune: bool = True,
     impl: Impl | str = Impl.FUSED,
+    kernel_options: KernelOptions | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Apply chunk-parallel KDA for training and prefill.
 
@@ -101,12 +106,19 @@ def chunk_kda(
         impl: ``"fused"`` uses the Blackwell kernels with first-order autograd;
             ``"reference"`` uses differentiable eager PyTorch in FP32, with no
             automatic fallback.
+        kernel_options: Backend-specific options. This is a sneaky BC trick.
+            It is annoying to have a bunch of kwargs that its hard to know when they apply
+            but, this trick allows us to add new options without breaking the API. I will
+            do my best to add new options by providing a nice typed dict and hopefully
+            your agent will now how to use this and be able to find the right option to wiggle.
 
     Returns:
         The output in ``q.dtype`` and either an FP32 final state with one entry
         per logical sequence or ``None``.
     """
     selected_impl = resolve_impl(impl)
+    if kernel_options:
+        raise ValueError("no chunk_kda kernel options are currently supported")
     if selected_impl is Impl.REFERENCE and fastmath:
         raise ValueError("fastmath applies only to impl='fused'")
     validate_kda_inputs(
@@ -461,4 +473,11 @@ def recurrent_kda_decode(
     )
 
 
-__all__ = ["Impl", "chunk_kda", "paged_chunk_kda", "recurrent_kda", "recurrent_kda_decode"]
+__all__ = [
+    "Impl",
+    "KernelOptions",
+    "chunk_kda",
+    "paged_chunk_kda",
+    "recurrent_kda",
+    "recurrent_kda_decode",
+]

--- a/test/test_kda_impl_dispatch.py
+++ b/test/test_kda_impl_dispatch.py
@@ -10,7 +10,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from attn_gym.linear import Impl, chunk_kda, recurrent_kda
+from attn_gym.linear import Impl, KernelOptions, chunk_kda, recurrent_kda
 
 pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="KDA ops require CUDA")
 
@@ -182,6 +182,32 @@ def test_chunk_reference_supports_any_head_dim():
     assert output.shape == v.shape and state.shape == (2, 2, 48, 48)
     with pytest.raises(ValueError, match="128"):
         chunk_kda(q, k, v, gate, beta, impl="fused")
+
+
+def test_chunk_kernel_options_plumbing():
+    """Expose a typed extension point without silently accepting unknown options."""
+    q, k, v, gate, beta = _inputs(tokens=8)
+    options: KernelOptions = {}
+    expected, _ = chunk_kda(q, k, v, gate, beta, impl="reference")
+    actual, _ = chunk_kda(
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        impl="reference",
+        kernel_options=options,
+    )
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    with pytest.raises(ValueError, match="no chunk_kda kernel options"):
+        chunk_kda(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            kernel_options={"BACKEND": "MEGA"},  # type: ignore[typeddict-unknown-key]
+        )
 
 
 def test_chunk_reference_rejects_fastmath():


### PR DESCRIPTION
Stacked PRs:
 * #400
 * #399
 * #397
 * #369
 * #402
 * __->__#401


--- --- ---

Add typed chunk KDA kernel options

## Human Note

## Agent note

Add an exported `KernelOptions` TypedDict and thread the optional dictionary through the public
`chunk_kda` signature. The initial plumbing deliberately accepts only `None` or an empty dictionary,
leaving backend-specific fields to the commits that implement them without requiring another public
signature change.

## Test Plan

```bash
pytest test/test_kda_impl_dispatch.py::test_chunk_kernel_options_plumbing -q
ruff check attn_gym/linear/kda/api.py attn_gym/linear/kda/__init__.py attn_gym/linear/__init__.py test/test_kda_impl_dispatch.py
```