### PR TITLE
Standardize delta-rule state on V-major storage

### DIFF
--- a/attn_gym/linear/_delta_rule/mega/kernels/README.md
+++ b/attn_gym/linear/_delta_rule/mega/kernels/README.md
@@ -14,10 +14,9 @@ autograd; a future GDN adapter can reuse the same implementation boundary.
 - Internal recurrent state and checkpoints use `[sequence, head, V, K]`.
 
 The `[V, K]` state layout is schedule-native rather than an inherited naming choice. State GEMMs use
-value dimension as the MMA M mode and contiguous key vectors as the K mode; forward, recompute, and
-bprop share that orientation. A maintained adapter must preserve the public `[K, V]` contract with
-explicit conversion unless the MMA descriptors, direct state loads/stores, and checkpoint TMA layout
-are redesigned together.
+the value dimension as the MMA M mode and contiguous key vectors as the K mode; forward, recompute,
+and bprop share that orientation. It now matches the public and paged delta-rule state contract, so
+stateful calls require no layout conversion at the Mega boundary.
 
 ## Checkpoint contract
 

--- a/attn_gym/linear/_delta_rule/recurrent.py
+++ b/attn_gym/linear/_delta_rule/recurrent.py
@@ -119,15 +119,13 @@ def _recurrent_delta_rule_fwd_kernel(
                 row = t * H + i_h
                 tl.store(output + ptr_offset((row, o_v), (V, 1)), 0.0, mask=m_v)
             return
-        p_state = ptr_offset(
-            (i_state, i_h, o_v[None, :], o_k[:, None]),
-            (state_batch_stride, V * K, K, 1),
-        )
+        state_row = i_state
     else:
-        p_state = ptr_offset(
-            (i_n, i_h, o_k[:, None], o_v[None, :]),
-            (state_batch_stride, K * V, V, 1),
-        )
+        state_row = i_n
+    p_state = ptr_offset(
+        (state_row, i_h, o_v[None, :], o_k[:, None]),
+        (state_batch_stride, V * K, K, 1),
+    )
     if USE_INITIAL_STATE:
         m_state = m_kv
         if USE_HAS_INITIAL_STATE:
@@ -219,7 +217,7 @@ def launch_recurrent_delta_rule_fwd(
         gate: Natural-log decay per value head, shaped ``[B, T, H]`` for
             ``GateKind.SCALAR`` or ``[B, T, H, K]`` for ``GateKind.VECTOR``.
         beta: Per-token write gate shaped ``[B, T, H]``.
-        initial_state: Optional FP32 starting state shaped ``[N, H, K, V]``, or the mutable
+        initial_state: Optional FP32 starting state shaped ``[N, H, V, K]``, or the mutable
             ``[slots, H, V, K]`` pool that ``state_indices`` addresses in paged mode.
         cu_seqlens: Optional packed boundaries shaped ``[N + 1]``; offsets are trusted and
             must be validated by the caller before launch.
@@ -255,10 +253,7 @@ def launch_recurrent_delta_rule_fwd(
     heads, value_dim = v.shape[2], v.shape[-1]
     assert heads % key_heads == 0
     if initial_state is not None:
-        if state_indices is None:
-            assert initial_state.is_contiguous()
-        else:
-            assert initial_state.stride()[1:] == (value_dim * key_dim, key_dim, 1)
+        assert initial_state.stride()[1:] == (value_dim * key_dim, key_dim, 1)
     num_sequences = batch if cu_seqlens is None else cu_seqlens.shape[0] - 1
     output = torch.empty_like(v, dtype=q.dtype)
     if state_indices is not None:
@@ -267,7 +262,7 @@ def launch_recurrent_delta_rule_fwd(
         assert store_final_state and initial_state is not None
         final_state = initial_state
     elif store_final_state:
-        final_state = q.new_empty(num_sequences, heads, key_dim, value_dim, dtype=torch.float32)
+        final_state = q.new_empty(num_sequences, heads, value_dim, key_dim, dtype=torch.float32)
     else:
         final_state = None
     state_batch_stride = (

--- a/attn_gym/linear/gdn/api.py
+++ b/attn_gym/linear/gdn/api.py
@@ -45,7 +45,7 @@ def chunk_gdn(
         v: Values shaped ``[B, T, H, V]`` and using the same dtype as ``q``.
         gate: Floating per-token scalar natural-log decay shaped ``[B, T, H]``.
         beta: Floating per-token write gate shaped ``[B, T, H]``.
-        initial_state: Initial recurrent state shaped ``[N, H, K, V]`` in the recurrence compute
+        initial_state: Initial recurrent state shaped ``[N, H, V, K]`` in the recurrence compute
             dtype, where ``N`` is the number of logical sequences.
         cu_seqlens: Optional packed offsets shaped ``[N + 1]`` for batch-one inputs. They start at
             zero, never decrease, and may end before ``T``; output beyond the terminal offset is
@@ -95,7 +95,7 @@ def recurrent_gdn(
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Apply recurrent gated delta rule attention for decoding and inference prefill.
 
-    The recurrence consumes tokens in order, carrying an explicit ``[N, H, K, V]`` state. Inputs
+    The recurrence consumes tokens in order, carrying an explicit ``[N, H, V, K]`` state. Inputs
     and outputs use the token-major layout ``[batch, sequence, heads, dimension]``. FP16 and BF16
     inputs use FP32 recurrence math and state.
 
@@ -107,7 +107,7 @@ def recurrent_gdn(
         v: Values shaped ``[B, T, H, V]`` and using the same dtype as ``q``.
         gate: Floating per-token scalar natural-log decay shaped ``[B, T, H]``.
         beta: Floating per-token write gate shaped ``[B, T, H]``.
-        initial_state: Initial recurrent state shaped ``[N, H, K, V]`` in the recurrence compute
+        initial_state: Initial recurrent state shaped ``[N, H, V, K]`` in the recurrence compute
             dtype, where ``N`` is the number of logical sequences.
         cu_seqlens: Optional packed offsets shaped ``[N + 1]`` for batch-one inputs. They start at
             zero, never decrease, and may end before ``T``; output beyond the terminal offset is

--- a/attn_gym/linear/gdn/impl/reference.py
+++ b/attn_gym/linear/gdn/impl/reference.py
@@ -29,7 +29,7 @@ def _packed_reference(
     final_state = None
     if output_final_state:
         final_state = (
-            q.new_zeros(num_sequences, heads, key_dim, value_dim)
+            q.new_zeros(num_sequences, heads, value_dim, key_dim)
             if initial_state is None
             else initial_state.clone()
         )
@@ -131,16 +131,16 @@ def recurrent_forward(
     batch, sequence, heads, key_dim = q.shape
     q = q * scale
     state = (
-        q.new_zeros(batch, heads, key_dim, v.shape[-1]) if initial_state is None else initial_state
+        q.new_zeros(batch, heads, v.shape[-1], key_dim) if initial_state is None else initial_state
     )
     outputs = []
 
     for token in range(sequence):
         state = state * log_decay[:, token].exp()[..., None, None]
-        residual = v[:, token] - torch.einsum("bhk,bhkv->bhv", k[:, token], state)
+        residual = v[:, token] - torch.einsum("bhvk,bhk->bhv", state, k[:, token])
         residual = residual * beta[:, token, :, None]
-        state = state + torch.einsum("bhk,bhv->bhkv", k[:, token], residual)
-        outputs.append(torch.einsum("bhk,bhkv->bhv", q[:, token], state))
+        state = state + torch.einsum("bhv,bhk->bhvk", residual, k[:, token])
+        outputs.append(torch.einsum("bhvk,bhk->bhv", state, q[:, token]))
 
     return torch.stack(outputs, dim=1), state if output_final_state else None
 
@@ -200,7 +200,9 @@ def chunk_forward(
     decayed_key = transition @ (beta_key * cumulative_decay.exp()[..., None])
 
     state = (
-        q.new_zeros(batch, heads, key_dim, value_dim) if initial_state is None else initial_state
+        q.new_zeros(batch, heads, key_dim, value_dim)
+        if initial_state is None
+        else initial_state.transpose(-1, -2)
     )
     output = torch.zeros_like(v)
     strictly_upper = torch.triu(
@@ -228,7 +230,8 @@ def chunk_forward(
         )
 
     output = output.permute(0, 2, 3, 1, 4).reshape(batch, padded_length, heads, value_dim)
-    return output[:, :sequence], state if output_final_state else None
+    final_state = state.transpose(-1, -2).contiguous() if output_final_state else None
+    return output[:, :sequence], final_state
 
 
 __all__ = ["chunk_forward", "recurrent_forward", "reference_gdn"]

--- a/attn_gym/linear/gdn/ops.py
+++ b/attn_gym/linear/gdn/ops.py
@@ -82,9 +82,9 @@ def _recurrent_fwd_fake(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     del k, gate, beta, initial_state, scale, autotune
     num_sequences = q.shape[0] if cu_seqlens is None else cu_seqlens.shape[0] - 1
-    # The state carries one [K, V] slab per value head; grouped callers have v.shape[2] > HK.
+    # The state carries one [V, K] slab per value head; grouped callers have v.shape[2] > HK.
     final_state = q.new_empty(
-        num_sequences, v.shape[2], q.shape[3], v.shape[-1], dtype=torch.float32
+        num_sequences, v.shape[2], v.shape[-1], q.shape[3], dtype=torch.float32
     )
     return torch.empty_like(v, dtype=q.dtype), final_state
 

--- a/attn_gym/linear/gdn/validation.py
+++ b/attn_gym/linear/gdn/validation.py
@@ -49,7 +49,7 @@ def validate_gdn_inputs(
 
     state_batch = batch if cu_seqlens is None else cu_seqlens.shape[0] - 1
     if initial_state is not None:
-        expected_state_shape = (state_batch, heads, key_dim, v.shape[-1])
+        expected_state_shape = (state_batch, heads, v.shape[-1], key_dim)
         if initial_state.shape != expected_state_shape:
             raise ValueError(
                 f"initial_state must have shape {expected_state_shape}, got {initial_state.shape}"

--- a/attn_gym/linear/kda/api.py
+++ b/attn_gym/linear/kda/api.py
@@ -89,7 +89,7 @@ def chunk_kda(
             implementation limit is not shared by reference or recurrent execution and
             is documented rather than checked with a runtime tensor reduction.
         beta: Per-token write gate shaped ``[B, T, H]``.
-        initial_state: Starting recurrent state, with one ``[H, K, V]`` entry per
+        initial_state: Starting recurrent state, with one ``[H, V, K]`` entry per
             logical sequence.
         cu_seqlens: Packed offsets shaped ``[N + 1]`` for batch-one inputs, as
             contiguous ``int32`` on ``q.device``; they start at zero, never
@@ -262,7 +262,7 @@ def recurrent_kda(
             representation for chunked and recurrent execution; recurrent execution has
             no chunk-rebase lower limit.
         beta: Per-token write gate shaped ``[B, T, H]``.
-        initial_state: Starting recurrent state, with one ``[H, K, V]`` entry per
+        initial_state: Starting recurrent state, with one ``[H, V, K]`` entry per
             logical sequence.
         cu_seqlens: Packed offsets shaped ``[N + 1]`` for batch-one inputs, as
             contiguous ``int32`` on ``q.device``; they start at zero, never

--- a/attn_gym/linear/kda/bwd/cute/chunk_delta_h_bwd.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_delta_h_bwd.py
@@ -343,14 +343,14 @@ class BlackwellDeltaHBwd:
             dht_in.iterator,
             cute.make_layout(
                 (K, V, (H, B)),
-                stride=(V, 1, (K * V, self.upcast(H * K * V))),
+                stride=(1, K, (K * V, self.upcast(H * K * V))),
             ),
         )
         g_dh0_t = cute.make_tensor(
             dh0_in.iterator,
             cute.make_layout(
                 (V, K, (H, B)),
-                stride=(1, V, (K * V, self.upcast(H * K * V))),
+                stride=(K, 1, (K * V, self.upcast(H * K * V))),
             ),
         )
         return GmemViews(
@@ -421,11 +421,11 @@ class BlackwellDeltaHBwd:
             ),
             cute.make_tensor(
                 dht_in.iterator,
-                cute.group_modes(cute.select(dht_in.layout, mode=[2, 3, 1, 0]), 2, 4),
+                cute.group_modes(cute.select(dht_in.layout, mode=[3, 2, 1, 0]), 2, 4),
             ),
             cute.make_tensor(
                 dh0_in.iterator,
-                cute.group_modes(cute.select(dh0_in.layout, mode=[3, 2, 1, 0]), 2, 4),
+                cute.group_modes(cute.select(dh0_in.layout, mode=[2, 3, 1, 0]), 2, 4),
             ),
         )
 
@@ -2193,8 +2193,8 @@ def _compile_delta_h_bwd(H, bv, io_type, use_int64_offsets):
     dof = make_fake_tensor(io_type, (sa, sb, H, V))
     aqkf = make_fake_tensor(io_type, (sa, sb, H, chunk_size))
     gkf = make_fake_tensor(cutlass.Float32, (sa, sb, H, K))
-    dhtf = make_fake_tensor(cutlass.Float32, (sns, H, K, V))
-    dh0f = make_fake_tensor(cutlass.Float32, (sns, H, K, V))
+    dhtf = make_fake_tensor(cutlass.Float32, (sns, H, V, K))
+    dh0f = make_fake_tensor(cutlass.Float32, (sns, H, V, K))
     dhof = make_fake_tensor(io_type, (sa, snt, H, K, V))
     dv2f = make_fake_tensor(io_type, (sa, sb, H, V))
     cuf = make_fake_tensor(cutlass.Int32, (sn,))
@@ -2247,7 +2247,7 @@ def _compile_delta_h_bwd_packed(
     def token_tensor(dtype, width):
         return make_fake_tensor(dtype, (tokens, heads, width))
 
-    state = make_fake_tensor(cutlass.Float32, (sequences, heads, key_dim, value_dim))
+    state = make_fake_tensor(cutlass.Float32, (sequences, heads, value_dim, key_dim))
     chunk_state = make_fake_tensor(io_type, (chunks, heads, key_dim, value_dim))
     metadata = make_fake_tensor(cutlass.Int32, (metadata_entries,))
     return compile_tvm_ffi(
@@ -2322,7 +2322,7 @@ def _blackwell_delta_h_bwd_dhu_dv_fused_packed(
     if gk is not None and gk.dtype != torch.float32:
         raise TypeError("gk must be float32")
     sequences = metadata.cu_seqlens.shape[0] - 1
-    expected_state = (sequences, heads, key_dim, value_dim)
+    expected_state = (sequences, heads, value_dim, key_dim)
     for name, state in (("h0", h0), ("dht", dht)):
         if state is not None and state.shape != expected_state:
             raise ValueError(f"{name} must have shape {expected_state}")
@@ -2428,7 +2428,7 @@ def blackwell_delta_h_bwd_dhu_dv_fused(
     expected_aqk = (B, T, H, BT)
     if aqk.shape != expected_aqk:
         raise ValueError(f"the dense delta-H kernel requires Aqk with shape {expected_aqk}")
-    expected_state = (B, H, K, V)
+    expected_state = (B, H, V, K)
     for name, state in (("h0", h0), ("dht", dht)):
         if state is not None and state.shape != expected_state:
             raise ValueError(f"{name} must have shape {expected_state}")
@@ -2444,7 +2444,7 @@ def blackwell_delta_h_bwd_dhu_dv_fused(
     if active_fake_mode() is not None:
         return dh_out, dh0_out, dv2
 
-    state_shape = (B, H, K, V)
+    state_shape = (B, H, V, K)
     gk_k = gk if gk is not None else torch.empty((B, T, H, K), dtype=torch.float32, device=dev)
     dht_k = dht if dht is not None else torch.empty(state_shape, dtype=torch.float32, device=dev)
     dh0_k = (

--- a/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
@@ -121,11 +121,8 @@ def _run_chunk_delta_h_sequence(
         i_state = i_n.to(tl.int64)
     else:
         i_state = i_n
-    p_state = i_state * state_batch_stride + i_h * K * V
-    if USE_STATE_INDICES:
-        p_state += ptr_offset((o_v[None, :], o_k[:, None]), (K, 1))
-    else:
-        p_state += ptr_offset((o_k[:, None], o_v[None, :]), (V, 1))
+    p_state = i_state * state_batch_stride + i_h * V * K
+    p_state += ptr_offset((o_v[None, :], o_k[:, None]), (K, 1))
 
     b_h = tl.zeros([K, BV], dtype=tl.float32)
     if USE_INITIAL_STATE:
@@ -527,7 +524,7 @@ def _delta_h_with_state_cuda(
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     state_batch = k.shape[0] if cu_seqlens is None else cu_seqlens.shape[0] - 1
     final_state = torch.empty(
-        state_batch, k.shape[2], k.shape[3], u.shape[-1], dtype=torch.float32, device=k.device
+        state_batch, k.shape[2], u.shape[-1], k.shape[3], dtype=torch.float32, device=k.device
     )
     h, v_new = _delta_h_launch(
         k,
@@ -630,7 +627,7 @@ def chunk_gated_delta_rule_fwd_h(
     if torch.cuda.get_device_capability(k.device)[0] < 10:
         raise ValueError("the inter-chunk state recurrence requires CUDA capability 10.0 or newer")
     state_batch = batch if cu_seqlens is None else cu_seqlens.shape[0] - 1
-    expected_state_shape = (state_batch, heads, key_dim, value_dim)
+    expected_state_shape = (state_batch, heads, value_dim, key_dim)
     if state_indices is not None:
         if initial_state is None:
             raise ValueError("state_indices requires initial_state as the paged state pool")
@@ -672,7 +669,8 @@ def chunk_gated_delta_rule_fwd_h(
                 f"initial_state must have shape {expected_state_shape}, "
                 f"got {tuple(initial_state.shape)}"
             )
-        initial_state = initial_state.contiguous()
+        if initial_state.stride()[1:] != (value_dim * key_dim, key_dim, 1):
+            raise TypeError("initial_state must be contiguous within each [H, V, K] row")
 
     if tokens == 0:
         # Zero-size tensors cannot back descriptors; the recurrence is empty

--- a/attn_gym/linear/kda/impl/reference.py
+++ b/attn_gym/linear/kda/impl/reference.py
@@ -41,7 +41,7 @@ def _packed_reference(
     final_state = None
     if output_final_state:
         final_state = (
-            q.new_zeros(num_sequences, heads, key_dim, value_dim)
+            q.new_zeros(num_sequences, heads, value_dim, key_dim)
             if initial_state is None
             else initial_state.clone()
         )

--- a/attn_gym/linear/kda/naive.py
+++ b/attn_gym/linear/kda/naive.py
@@ -21,13 +21,13 @@ def naive_recurrent_kda(
     output_final_state: bool = False,
     cu_seqlens: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
-    """Reference O(T) KDA delta rule. State S in [K, V], per (batch, head).
+    """Reference O(T) KDA delta rule with V-major state storage.
 
     Per step t (per-channel decay a_t = 2^{g_t} in R^K):
-        S <- diag(a_t) S ;  delta = beta_t * (v_t - k^T S) ;  S <- S + outer(k_t, delta) ;  o_t = q^T S
+        S <- S diag(a_t) ; delta = beta_t * (v_t - S k) ; S <- S + outer(delta, k_t) ; o_t = S q
 
-    Shapes: q, k, g (B, T, H, K); v (B, T, H, V); beta (B, T, H); state (B, H, K, V),
-    or (N, H, K, V) over the N documents of a packed row in varlen mode.
+    Shapes: q, k, g (B, T, H, K); v (B, T, H, V); beta (B, T, H); state (B, H, V, K),
+    or (N, H, V, K) over the N documents of a packed row in varlen mode.
 
     Args:
         q: query tensor
@@ -36,7 +36,7 @@ def naive_recurrent_kda(
         g: per-channel log2-decay, a_t = 2^{g_t} in R^K (the KDA diagonal gate)
         beta: scalar-per-head delta step size / write gate
         scale: query scale for q k^T (optional; default 1/sqrt(K))
-        initial_state: initial recurrent state (B, H, K, V) (optional)
+        initial_state: initial recurrent state (B, H, V, K) (optional)
         output_final_state: also return the final state (optional; in the compute dtype)
         cu_seqlens: optional int32 offsets (varlen mode) with the public packed
             contract: the recurrence restarts at each document boundary, empty
@@ -56,7 +56,7 @@ def naive_recurrent_kda(
             initial_state.to(compute_dtype).clone()
             if initial_state is not None
             else torch.zeros(
-                num_documents, h, k_dim, v.shape[-1], dtype=compute_dtype, device=q.device
+                num_documents, h, v.shape[-1], k_dim, dtype=compute_dtype, device=q.device
             )
         )
         for doc, (bos, eos) in enumerate(pairwise(offsets)):
@@ -84,15 +84,15 @@ def naive_recurrent_kda(
         initial_state = initial_state.to(dtype)
 
     q = q * scale if scale is not None else q * k_dim**-0.5
-    state = initial_state if initial_state is not None else q.new_zeros(b, h, k_dim, v.shape[-1])
+    state = initial_state if initial_state is not None else q.new_zeros(b, h, v.shape[-1], k_dim)
     outputs = []
 
     for i in range(t):
-        state = state * g[:, i].exp2()[..., None]  # per-channel decay: diag(2^{g_t}) over V
-        delta = v[:, i] - torch.einsum("bhk,bhkv->bhv", k[:, i], state)  # vt - k^T S (v_old)
+        state = state * g[:, i].exp2()[..., None, :]
+        delta = v[:, i] - torch.einsum("bhvk,bhk->bhv", state, k[:, i])
         delta = delta * beta[:, i][..., None]
-        state = state + torch.einsum("bhk,bhv->bhkv", k[:, i], delta)  # + outer(k, delta)
-        outputs.append(torch.einsum("bhk,bhkv->bhv", q[:, i], state))  # q^T S
+        state = state + torch.einsum("bhv,bhk->bhvk", delta, k[:, i])
+        outputs.append(torch.einsum("bhvk,bhk->bhv", state, q[:, i]))
     return torch.stack(outputs, dim=1).to(output_dtype), (state if output_final_state else None)
 
 
@@ -173,7 +173,7 @@ def _naive_chunk_kda_from_cumulative(
         raise ValueError(f"v must have shape [B, T, H, V], got {v.shape}")
     if beta.shape != (batch, tokens, heads):
         raise ValueError(f"beta must have shape {(batch, tokens, heads)}, got {beta.shape}")
-    expected_state = (batch, heads, key_dim, v.shape[-1])
+    expected_state = (batch, heads, v.shape[-1], key_dim)
     if initial_state is not None and initial_state.shape != expected_state:
         raise ValueError(
             f"initial_state must have shape {expected_state}, got {initial_state.shape}"
@@ -211,7 +211,7 @@ def _naive_chunk_kda_from_cumulative(
     state = (
         q.new_zeros(batch, heads, key_dim, value_dim)
         if initial_state is None
-        else initial_state.to(compute_dtype)
+        else initial_state.transpose(-1, -2).to(compute_dtype)
     )
     outputs = []
     for index in range(chunks):
@@ -238,7 +238,10 @@ def _naive_chunk_kda_from_cumulative(
 
     output = torch.stack(outputs, dim=2).reshape(batch, heads, length, value_dim)
     output = output[:, :, :tokens].transpose(1, 2).to(output_dtype)
-    return output, (state.to(output_dtype) if output_final_state else None)
+    final_state = (
+        state.transpose(-1, -2).contiguous().to(output_dtype) if output_final_state else None
+    )
+    return output, final_state
 
 
 def naive_chunk_kda(

--- a/attn_gym/linear/kda/ops.py
+++ b/attn_gym/linear/kda/ops.py
@@ -370,7 +370,7 @@ def _chunk_fwd_with_state_fake(
     del k, cumulative_gate, beta, initial_state, scale, autotune
     output, aqk, akk = _chunk_fwd_fake_common(q, v)
     state = q.new_empty(
-        (q.shape[0], q.shape[2], q.shape[3], v.shape[-1]),
+        (q.shape[0], q.shape[2], v.shape[-1], q.shape[3]),
         dtype=torch.float32,
     )
     return output, state, aqk, akk
@@ -409,7 +409,7 @@ def _chunk_fwd_ragged_with_state_fake(
     del k, cumulative_gate, beta, initial_state, chunk_offsets, scale, autotune
     output, aqk, akk = _chunk_fwd_fake_common(q, v)
     state = q.new_empty(
-        (cu_seqlens.shape[0] - 1, q.shape[2], q.shape[3], v.shape[-1]),
+        (cu_seqlens.shape[0] - 1, q.shape[2], v.shape[-1], q.shape[3]),
         dtype=torch.float32,
     )
     return output, state, aqk, akk
@@ -606,9 +606,9 @@ def _recurrent_fwd_fake(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     del k, gate, beta, initial_state, autotune
     num_sequences = q.shape[0] if cu_seqlens is None else cu_seqlens.shape[0] - 1
-    # The state carries one [K, V] slab per value head; grouped callers have v.shape[2] > HK.
+    # The state carries one [V, K] slab per value head; grouped callers have v.shape[2] > HK.
     final_state = q.new_empty(
-        num_sequences, v.shape[2], q.shape[3], v.shape[-1], dtype=torch.float32
+        num_sequences, v.shape[2], v.shape[-1], q.shape[3], dtype=torch.float32
     )
     return torch.empty_like(v, dtype=q.dtype), final_state
 

--- a/attn_gym/linear/kda/validation.py
+++ b/attn_gym/linear/kda/validation.py
@@ -75,7 +75,7 @@ def validate_kda_inputs(
         ):
             raise ValueError("cu_seqlens must be contiguous int32 on q.device")
     state_batch = batch if cu_seqlens is None else cu_seqlens.shape[0] - 1
-    expected_state = (state_batch, heads, key_dim, v.shape[-1])
+    expected_state = (state_batch, heads, v.shape[-1], key_dim)
     if initial_state is not None and initial_state.shape != expected_state:
         raise ValueError(
             f"initial_state must have shape {expected_state}, got {tuple(initial_state.shape)}"

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -11,12 +11,14 @@ state:
 
 ```text
 decayed_state = exp(gate) * state
-residual = beta * (value - key @ decayed_state)
-state = decayed_state + outer(key, residual)
-output = scale * query @ state
+residual = beta * (value - decayed_state @ key)
+state = decayed_state + outer(residual, key)
+output = scale * state @ query
 ```
 
-`chunk_gdn` uses a chunk-parallel decomposition for training and prefill. `recurrent_gdn` consumes
+Public and persistent state uses V-major storage shaped `[N, H, V, K]`; paged pools replace `N`
+with the slot count. `chunk_gdn` uses a chunk-parallel decomposition for training and prefill.
+`recurrent_gdn` consumes
 tokens in order for decoding, inference prefill, and state-carrying correctness checks. The caller
 chooses the execution form explicitly. `impl="reference"` selects eager PyTorch;
 `recurrent_gdn(..., impl="fused")` selects the inference-only Triton scan.
@@ -87,7 +89,8 @@ The KDA references use token-major tensors: query, key, and per-channel gate are
 `[batch, sequence, heads, key_dimension]`; value is
 `[batch, sequence, heads, value_dimension]`; beta is
 `[batch, sequence, heads]`. Both recurrent and chunked forms support ordinary
-PyTorch autograd and an optional recurrent state.
+PyTorch autograd and an optional V-major recurrent state shaped `[N, H, V, K]`. Paged prefill and
+decode use the same layout with the leading dimension interpreted as cache slots.
 
 `examples/kda_training.py` builds these operations into a small trainable
 `[B, T, hidden_size] -> [B, T, hidden_size]` attention module. To mirror the

--- a/test/kda/mega/test_kda_delta_h_bwd.py
+++ b/test/kda/mega/test_kda_delta_h_bwd.py
@@ -74,7 +74,7 @@ def delta_h_reference(
     begin = 0
     for sequence, length in enumerate(lengths):
         state = (
-            d_final_state[sequence].float().clone()
+            d_final_state[sequence].transpose(-1, -2).float().clone()
             if d_final_state is not None
             else torch.zeros(heads, key_dim, value_dim, device=q.device)
         )
@@ -95,7 +95,7 @@ def delta_h_reference(
             )
         chunk_states.extend(state for _, state in sorted(sequence_states))
         if d_initial_state is not None:
-            d_initial_state.append(state)
+            d_initial_state.append(state.transpose(-1, -2))
         begin += length
     chunk_state = (
         torch.stack(chunk_states)[None]

--- a/test/linear/test_gdn.py
+++ b/test/linear/test_gdn.py
@@ -3,6 +3,7 @@ import torch
 import torch.nn.functional as F
 
 from attn_gym.linear import Impl, chunk_gdn, recurrent_gdn
+from attn_gym.linear._delta_rule.validation import validate_paged_state
 from attn_gym.testing import cumulative_sequence_offsets
 
 REFERENCE_CASES = [recurrent_gdn, chunk_gdn]
@@ -17,7 +18,7 @@ def make_inputs(sequence: int) -> tuple[torch.Tensor, ...]:
     value = torch.randn(batch, sequence, heads, value_dimension)
     gate = F.logsigmoid(torch.randn(batch, sequence, heads))
     beta = torch.sigmoid(torch.randn(batch, sequence, heads))
-    initial_state = torch.randn(batch, heads, key_dimension, value_dimension)
+    initial_state = torch.randn(batch, heads, value_dimension, key_dimension)
     return query, key, value, gate, beta, initial_state
 
 
@@ -44,6 +45,14 @@ def test_chunk_matches_recurrent(sequence, use_initial_state):
 
     torch.testing.assert_close(chunked_output, recurrent_output, atol=1e-6, rtol=1e-5)
     torch.testing.assert_close(chunked_state, recurrent_state, atol=1e-6, rtol=1e-5)
+    assert chunked_state.is_contiguous()
+    validate_paged_state(
+        inputs[0],
+        inputs[2],
+        chunked_state,
+        None,
+        torch.arange(inputs[0].shape[0], dtype=torch.int32),
+    )
 
 
 def test_segmented_recurrent_execution_matches_full_sequence():
@@ -68,7 +77,7 @@ def test_packed_matches_independent_sequences(function):
     q, k, v, gate, beta, _state = make_inputs(sequence=8)
     q, k, v, gate, beta = (tensor[:1] for tensor in (q, k, v, gate, beta))
     cu_seqlens = cumulative_sequence_offsets([3, 0, 4], device="cpu")
-    initial_state = torch.randn(3, q.shape[2], q.shape[3], v.shape[-1])
+    initial_state = torch.randn(3, q.shape[2], v.shape[-1], q.shape[3])
 
     output, final_state = function(
         q,

--- a/test/linear/test_gdn_decode.py
+++ b/test/linear/test_gdn_decode.py
@@ -78,7 +78,7 @@ def reference_decode(
     for row, slot in enumerate(slots.tolist()):
         if slot <= 0:
             continue
-        state = pool[slot].transpose(-1, -2).unsqueeze(0).clone()
+        state = pool[slot].unsqueeze(0).clone()
         row_output, final_state = recurrent_gdn(
             q[row : row + 1, None],
             k[row : row + 1, None],
@@ -91,7 +91,7 @@ def reference_decode(
             impl="reference",
         )
         output[row] = row_output[0, 0]
-        pool[slot] = final_state[0].transpose(-1, -2)
+        pool[slot] = final_state[0]
     return output, pool
 
 

--- a/test/linear/test_gdn_fused.py
+++ b/test/linear/test_gdn_fused.py
@@ -34,7 +34,7 @@ def make_inputs(
     v = torch.randn(batch, tokens, heads, value_dim, device="cuda")
     gate = F.logsigmoid(torch.randn(batch, tokens, heads, device="cuda"))
     beta = torch.sigmoid(torch.randn(batch, tokens, heads, device="cuda"))
-    state = torch.randn(batch, heads, key_dim, value_dim, device="cuda")
+    state = torch.randn(batch, heads, value_dim, key_dim, device="cuda")
     return q, k, v, gate, beta, state
 
 
@@ -71,7 +71,7 @@ def test_fused_recurrent_matches_packed_reference(key_heads: int | None):
         batch=1, tokens=8, heads=6 if key_heads else 2, key_heads=key_heads
     )
     cu_seqlens = cumulative_sequence_offsets([3, 0, 4])
-    state = torch.randn(3, v.shape[2], q.shape[3], v.shape[-1], device="cuda")
+    state = torch.randn(3, v.shape[2], v.shape[-1], q.shape[3], device="cuda")
     with torch.no_grad():
         expected = recurrent_gdn(
             q,
@@ -114,9 +114,7 @@ def test_fused_recurrent_paged_state():
     with torch.no_grad():
         for sequence, slot in ((0, 2), (2, 4)):
             initial_state = (
-                original_cache[slot].transpose(-1, -2).unsqueeze(0)
-                if has_initial_state[sequence]
-                else None
+                original_cache[slot].unsqueeze(0) if has_initial_state[sequence] else None
             )
             output, final_state = recurrent_gdn(
                 q[sequence : sequence + 1],
@@ -129,7 +127,7 @@ def test_fused_recurrent_paged_state():
                 impl=Impl.REFERENCE,
             )
             expected_output[sequence] = output[0]
-            expected_cache[slot] = final_state[0].transpose(-1, -2)
+            expected_cache[slot] = final_state[0]
 
         output, final_state = recurrent_gdn(
             q,
@@ -167,9 +165,7 @@ def test_fused_recurrent_packed_paged_state():
             if begin == end or slot <= 0:
                 continue
             span = slice(begin, end)
-            initial_state = (
-                original_cache[slot].transpose(-1, -2).unsqueeze(0) if use_state else None
-            )
+            initial_state = original_cache[slot].unsqueeze(0) if use_state else None
             span_output, span_state = recurrent_gdn(
                 q[:, span],
                 k[:, span],
@@ -181,7 +177,7 @@ def test_fused_recurrent_packed_paged_state():
                 impl=Impl.REFERENCE,
             )
             expected_output[:, span] = span_output
-            expected_cache[slot] = span_state[0].transpose(-1, -2)
+            expected_cache[slot] = span_state[0]
 
         output, _ = recurrent_gdn(
             q,
@@ -220,7 +216,7 @@ def test_fused_recurrent_grouped_heads_paged_matches_dense():
     q, k, v, gate, beta, _state = make_inputs(batch=3, tokens=1, heads=6, key_heads=2)
     _storage, pool = strided_state_pool(5, v.shape[2], q.shape[-1], v.shape[-1])
     slots = torch.tensor([1, 3, 4], device="cuda", dtype=torch.int32)
-    initial_state = pool[slots.long()].transpose(-1, -2).contiguous()
+    initial_state = pool[slots.long()].clone()
 
     with torch.no_grad():
         expected_output, expected_state = recurrent_gdn(
@@ -239,9 +235,7 @@ def test_fused_recurrent_grouped_heads_paged_matches_dense():
         )
 
     torch.testing.assert_close(output, expected_output, rtol=1e-5, atol=1e-5)
-    torch.testing.assert_close(
-        pool[slots.long()], expected_state.transpose(-1, -2), rtol=1e-5, atol=1e-5
-    )
+    torch.testing.assert_close(pool[slots.long()], expected_state, rtol=1e-5, atol=1e-5)
 
 
 def test_fused_recurrent_packed_paged_empty_sequences():
@@ -301,7 +295,17 @@ def test_fused_recurrent_grouped_heads_registration():
     q, k, v, gate, beta, state = make_inputs(batch=1, tokens=3, heads=6, key_heads=2)
     torch.library.opcheck(
         recurrent_fwd_op,
-        (q, k, v, gate, beta, state, None, q.shape[-1] ** -0.5, False),
+        (
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            state,
+            None,
+            q.shape[-1] ** -0.5,
+            False,
+        ),
     )
 
 
@@ -311,7 +315,17 @@ def test_fused_recurrent_registration(output_final_state: bool):
     op = recurrent_fwd_op if output_final_state else recurrent_fwd_no_state_op
     torch.library.opcheck(
         op,
-        (q, k, v, gate, beta, state, None, q.shape[-1] ** -0.5, False),
+        (
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            state,
+            None,
+            q.shape[-1] ** -0.5,
+            False,
+        ),
     )
 
 

--- a/test/linear/test_recurrent_delta_rule.py
+++ b/test/linear/test_recurrent_delta_rule.py
@@ -44,7 +44,7 @@ def _make_inputs(
     value = torch.randn(batch, tokens, heads, value_dim, device="cuda")
     gate = F.logsigmoid(torch.randn(batch, tokens, heads, device="cuda"))
     beta = torch.sigmoid(torch.randn(batch, tokens, heads, device="cuda"))
-    state = torch.randn(batch, heads, key_dim, value_dim, device="cuda") if initial_state else None
+    state = torch.randn(batch, heads, value_dim, key_dim, device="cuda") if initial_state else None
     return query.to(dtype), key.to(dtype), value.to(dtype), gate, beta, state
 
 
@@ -60,7 +60,7 @@ def _launch_scalar_gdn(
     store_final_state: bool,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Launch the scalar-gate specialization with public GDN inputs."""
-    return launch_recurrent_delta_rule_fwd(
+    output, final_state = launch_recurrent_delta_rule_fwd(
         query,
         key,
         value,
@@ -72,6 +72,7 @@ def _launch_scalar_gdn(
         gate_kind=GateKind.SCALAR,
         store_final_state=store_final_state,
     )
+    return output, final_state
 
 
 @pytest.mark.parametrize(

--- a/test/test_kda.py
+++ b/test/test_kda.py
@@ -21,7 +21,7 @@ def make_inputs(seq_len: int) -> tuple[torch.Tensor, ...]:
     v = torch.randn(batch, seq_len, heads, value_dim)
     g = F.logsigmoid(torch.randn(batch, seq_len, heads, key_dim))  # per-channel (diagonal) gate
     beta = torch.sigmoid(torch.randn(batch, seq_len, heads))
-    initial_state = torch.randn(batch, heads, key_dim, value_dim)
+    initial_state = torch.randn(batch, heads, value_dim, key_dim)
     return q, k, v, g, beta, initial_state
 
 

--- a/test/test_kda_cute_forward.py
+++ b/test/test_kda_cute_forward.py
@@ -426,12 +426,12 @@ def test_paged_chunk_kda_updates_strided_pool():
         v,
         cumulative_gate,
         beta,
-        expected_pool[slots.long()].transpose(-1, -2).contiguous(),
+        expected_pool[slots.long()],
         cu_seqlens=cu_seqlens,
         output_final_state=True,
     )
     assert expected_state is not None
-    expected_pool[slots.long()] = expected_state.transpose(-1, -2)
+    expected_pool[slots.long()] = expected_state
 
     output = paged_chunk_kda(
         q,
@@ -454,7 +454,7 @@ def test_paged_chunk_kda_matches_pytorch():
     state_indices = torch.tensor([3, 1], device="cuda", dtype=torch.int32)
     state_cache = torch.randn(4, 1, 128, 128, device="cuda")
     expected_cache = state_cache.clone()
-    initial_state = expected_cache[state_indices.long()].transpose(-1, -2).contiguous()
+    initial_state = expected_cache[state_indices.long()].clone()
 
     expected_output, expected_state = naive_chunk_kda(
         q.float(),
@@ -467,7 +467,7 @@ def test_paged_chunk_kda_matches_pytorch():
     )
     output = paged_chunk_kda(q, k, v, cumulative_gate, beta, state_cache, state_indices)
     assert expected_state is not None
-    expected_cache[state_indices.long()] = expected_state.transpose(-1, -2)
+    expected_cache[state_indices.long()] = expected_state
 
     torch.testing.assert_close(output.float(), expected_output, rtol=2e-2, atol=2e-3)
     torch.testing.assert_close(state_cache, expected_cache, rtol=2e-2, atol=2e-3)
@@ -500,16 +500,13 @@ def test_paged_chunk_kda_ignores_padding_slots():
         v[:, :64],
         cumulative_gate[:, :64],
         beta[:, :64],
-        before[3:4, : pool[0].numel()]
-        .view(1, q.shape[2], 128, 128)
-        .transpose(-1, -2)
-        .contiguous(),
+        before[3:4, : pool[0].numel()].view(1, q.shape[2], 128, 128),
         output_final_state=True,
     )
     assert expected_state is not None
     torch.testing.assert_close(output[:, :64], expected, rtol=0, atol=0)
     torch.testing.assert_close(output[:, 64:], torch.zeros_like(output[:, 64:]), rtol=0, atol=0)
-    torch.testing.assert_close(pool[3], expected_state[0].transpose(-1, -2), rtol=0, atol=0)
+    torch.testing.assert_close(pool[3], expected_state[0], rtol=0, atol=0)
     torch.testing.assert_close(storage[0], before[0], rtol=0, atol=0)
 
 
@@ -536,7 +533,7 @@ def test_paged_chunk_kda_zero_initializes_new_slots():
     )
     state_elements = pool[0].numel()
     original_slot = before[4, :state_elements].view_as(pool[4])
-    expected_initial = torch.stack((original_slot, torch.zeros_like(pool[2]))).transpose(-1, -2)
+    expected_initial = torch.stack((original_slot, torch.zeros_like(pool[2])))
     expected_output, expected_state = chunk_kda(
         q,
         k,
@@ -550,7 +547,7 @@ def test_paged_chunk_kda_zero_initializes_new_slots():
 
     assert expected_state is not None
     torch.testing.assert_close(output, expected_output, rtol=0, atol=0)
-    torch.testing.assert_close(pool[2], expected_state[1].transpose(-1, -2), rtol=0, atol=0)
+    torch.testing.assert_close(pool[2], expected_state[1], rtol=0, atol=0)
     torch.testing.assert_close(storage[0], before[0], rtol=0, atol=0)
 
 

--- a/test/test_kda_impl_dispatch.py
+++ b/test/test_kda_impl_dispatch.py
@@ -11,6 +11,7 @@ import torch
 import torch.nn.functional as F
 
 from attn_gym.linear import Impl, KernelOptions, chunk_kda, recurrent_kda
+from attn_gym.linear._delta_rule.validation import validate_paged_state
 
 pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="KDA ops require CUDA")
 
@@ -22,6 +23,7 @@ def _inputs(
     tokens: int = 37,
     heads: int = 2,
     head_dim: int = 64,
+    value_dim: int | None = None,
     dtype: torch.dtype = torch.float32,
     seed: int = 0,
     device: str = "cuda",
@@ -33,7 +35,8 @@ def _inputs(
         return F.normalize(raw, dim=-1).to(dtype)
 
     q, k = normalized(), normalized()
-    v = torch.randn(batch, tokens, heads, head_dim, device=device, dtype=dtype)
+    value_dim = head_dim if value_dim is None else value_dim
+    v = torch.randn(batch, tokens, heads, value_dim, device=device, dtype=dtype)
     gate = -torch.rand(batch, tokens, heads, head_dim, device=device) * 3.0
     beta = torch.rand(batch, tokens, heads, device=device)
     return q, k, v, gate, beta
@@ -177,9 +180,17 @@ def test_chunk_reference_packed_matches_fused():
 
 def test_chunk_reference_supports_any_head_dim():
     """Lift the fused K=V=128 constraint without changing the contract."""
-    q, k, v, gate, beta = _inputs(tokens=70, head_dim=48, seed=4)
+    q, k, v, gate, beta = _inputs(tokens=70, head_dim=48, value_dim=32, seed=4)
     output, state = chunk_kda(q, k, v, gate, beta, output_final_state=True, impl="reference")
-    assert output.shape == v.shape and state.shape == (2, 2, 48, 48)
+    assert output.shape == v.shape and state.shape == (2, 2, 32, 48)
+    assert state.is_contiguous()
+    validate_paged_state(
+        q,
+        v,
+        state,
+        None,
+        torch.arange(q.shape[0], dtype=torch.int32, device=q.device),
+    )
     with pytest.raises(ValueError, match="128"):
         chunk_kda(q, k, v, gate, beta, impl="fused")
 

--- a/test/test_kda_kernels.py
+++ b/test/test_kda_kernels.py
@@ -614,7 +614,11 @@ def _fwd_h_ref(k, w, v, gk, h0, chunk_size=64):
     h = torch.zeros(B, num_chunks, H, K, V, dtype=acc, device=k.device)
     v_new = torch.zeros(B, T, H, V, dtype=acc, device=k.device)
     # State recurrence is sequential across chunks; batch (B, H) into the matmuls.
-    state = torch.zeros(B, H, K, V, dtype=acc, device=k.device) if h0 is None else h0.to(acc)
+    state = (
+        torch.zeros(B, H, K, V, dtype=acc, device=k.device)
+        if h0 is None
+        else h0.transpose(-1, -2).to(acc)
+    )
     for it in range(num_chunks):
         s = it * chunk_size
         e = min(s + chunk_size, T)
@@ -627,7 +631,7 @@ def _fwd_h_ref(k, w, v, gk, h0, chunk_size=64):
         v_new[:, s:e] = vn
         state = state * gkc[:, e - 1].exp2()[..., None]
         state = state + torch.einsum("blhk,blhv->bhkv", kc[:, s:e], vn.to(acc))
-    return h.reshape(B * num_chunks, H, K, V), v_new, state
+    return h.reshape(B * num_chunks, H, K, V), v_new, state.transpose(-1, -2)
 
 
 @pytest.mark.parametrize(
@@ -651,7 +655,7 @@ def test_chunk_delta_h_fwd(dtype, T, use_h0):
     v = torch.randn(B, T, H, V, device="cuda", dtype=dtype)
     gk = -torch.rand(B, T, H, K, device="cuda", dtype=torch.float32) * 0.5
     # Since prod keeps initial and final state in fp32, do that here to match.
-    h0 = torch.randn(B, H, K, V, device="cuda", dtype=torch.float32) if use_h0 else None
+    h0 = torch.randn(B, H, V, K, device="cuda", dtype=torch.float32) if use_h0 else None
 
     gh, gvn, ght = _fwd_h_ref(
         k.double(), w.double(), v.double(), gk.double(), h0.double() if use_h0 else None
@@ -902,7 +906,7 @@ def _delta_h_bwd_dhu_ref(q, k, w, do, dv, gk, h0, dht, scale, chunk_size=64):
     dv2 = torch.zeros(B, T, H, V, dtype=acc, device=q.device)
     # Reverse recurrence is sequential across chunks; batch (B, H) into the matmuls.
     D = (
-        dht.to(acc).clone()
+        dht.transpose(-1, -2).to(acc).clone()
         if dht is not None
         else torch.zeros(B, H, K, V, dtype=acc, device=q.device)
     )
@@ -917,7 +921,7 @@ def _delta_h_bwd_dhu_ref(q, k, w, do, dv, gk, h0, dht, scale, chunk_size=64):
             + scale * torch.einsum("blhk,blhv->bhkv", qf[:, s:e], dof[:, s:e])
             - torch.einsum("blhk,blhv->bhkv", wf[:, s:e], dv2c)
         )
-    dh0 = D if h0 is not None else None
+    dh0 = D.transpose(-1, -2) if h0 is not None else None
     return dh_out, dh0, dv2
 
 
@@ -944,8 +948,8 @@ def test_delta_h_bwd_dhu_cute(bv, num_chunks, use_h0, use_dht):
     aqk = aqk * _chunk_tril_mask(T, 64, "cuda")[None, :, None, :]
     # gk is the cumulative per-channel log2-decay (<= 0), so 2^{gk_last} <= 1.
     gk = -torch.rand(B, T, H, K, device="cuda", dtype=torch.float32) * 0.5
-    h0 = torch.randn(B, H, K, V, device="cuda", dtype=torch.float32) if use_h0 else None
-    dht = torch.randn(B, H, K, V, device="cuda", dtype=torch.float32) if use_dht else None
+    h0 = torch.randn(B, H, V, K, device="cuda", dtype=torch.float32) if use_h0 else None
+    dht = torch.randn(B, H, V, K, device="cuda", dtype=torch.float32) if use_dht else None
 
     qb, kb, wb, dob, aqkb = (t.to(torch.bfloat16) for t in (q, k, w, do, aqk))
     dh, dh0, dv2 = blackwell_delta_h_bwd_dhu_dv_fused(

--- a/test/test_kda_recurrent.py
+++ b/test/test_kda_recurrent.py
@@ -50,7 +50,7 @@ def _inputs(
     # Realistic bounded natural-log decays keep the recurrence stable over the scan.
     gate = -torch.rand(batch, tokens, heads, key_dim, device="cuda") * 3.0
     beta = torch.rand(batch, tokens, heads, device="cuda")
-    state = torch.randn(batch, heads, key_dim, value_dim, device="cuda") if initial_state else None
+    state = torch.randn(batch, heads, value_dim, key_dim, device="cuda") if initial_state else None
     return q, k, v, gate, beta, state
 
 
@@ -84,12 +84,24 @@ def test_recurrent_matches_naive_dense(dtype: torch.dtype, use_initial_state: bo
 @pytest.mark.parametrize(("key_dim", "value_dim"), [(80, 48), (128, 128)])
 def test_recurrent_matches_naive_non_power_of_two(key_dim: int, value_dim: int):
     """Mask partial key and value blocks correctly."""
-    q, k, v, gate, beta, _ = _inputs(key_dim=key_dim, value_dim=value_dim, seed=1)
-
-    output, final_state = recurrent_kda(q, k, v, gate, beta, output_final_state=True)
-    expected, expected_state = naive_recurrent_kda(
-        q, k, v, gate * LOG2_E, beta, output_final_state=True
+    q, k, v, gate, beta, state = _inputs(
+        key_dim=key_dim,
+        value_dim=value_dim,
+        initial_state=True,
+        seed=1,
     )
+
+    output, final_state = recurrent_kda(q, k, v, gate, beta, state, output_final_state=True)
+    expected, expected_state = naive_recurrent_kda(
+        q,
+        k,
+        v,
+        gate * LOG2_E,
+        beta,
+        initial_state=state,
+        output_final_state=True,
+    )
+    assert final_state.shape == (q.shape[0], v.shape[2], value_dim, key_dim)
     torch.testing.assert_close(output, expected, rtol=1e-5, atol=1e-5)
     torch.testing.assert_close(final_state, expected_state, rtol=1e-5, atol=1e-5)
 
@@ -125,7 +137,7 @@ def test_recurrent_packed_capacity_and_empty_slots():
     """Pass empty-slot state through and ignore rows past the terminal offset."""
     q, k, v, gate, beta, _ = _inputs(batch=1, tokens=32, seed=3)
     cu_seqlens = cumulative_sequence_offsets([0, 11, 16, 0])
-    initial_state = torch.randn(4, q.shape[2], q.shape[3], v.shape[-1], device="cuda")
+    initial_state = torch.randn(4, q.shape[2], v.shape[-1], q.shape[3], device="cuda")
 
     output, final_state = recurrent_kda(
         q,
@@ -171,7 +183,7 @@ def test_recurrent_grouped_heads_match_expanded_heads():
     beta = beta.repeat_interleave(groups, dim=2).contiguous()
     # Independent per-value-head decays: grouping must not collapse state capacity.
     gate = -torch.rand(2, 17, v.shape[2], q.shape[3], device="cuda") * 3.0
-    state = torch.randn(2, v.shape[2], q.shape[3], v.shape[-1], device="cuda")
+    state = torch.randn(2, v.shape[2], v.shape[-1], q.shape[3], device="cuda")
 
     # Fixed heuristics keep both calls on one kernel specialization so equality is exact;
     # HK is an autotune key, so autotuned calls may pick different tiles.
@@ -199,7 +211,7 @@ def test_recurrent_grouped_heads_match_reference():
     v = v.repeat_interleave(2, dim=2).contiguous()
     beta = beta.repeat_interleave(2, dim=2).contiguous()
     gate = -torch.rand(2, 9, v.shape[2], q.shape[3], device="cuda") * 3.0
-    state = torch.randn(2, v.shape[2], q.shape[3], v.shape[-1], device="cuda")
+    state = torch.randn(2, v.shape[2], v.shape[-1], q.shape[3], device="cuda")
 
     fused = recurrent_kda(q, k, v, gate, beta, state, output_final_state=True)
     reference = recurrent_kda(
@@ -244,7 +256,7 @@ def test_recurrent_grouped_heads_registration():
     v = v.repeat_interleave(3, dim=2).contiguous()
     beta = beta.repeat_interleave(3, dim=2).contiguous()
     gate = gate.repeat_interleave(3, dim=2).contiguous()
-    state = torch.randn(1, v.shape[2], q.shape[3], v.shape[-1], device="cuda")
+    state = torch.randn(1, v.shape[2], v.shape[-1], q.shape[3], device="cuda")
     torch.library.opcheck(_recurrent_fwd_op, (q, k, v, gate, beta, state, None, True))
 
 
@@ -326,11 +338,11 @@ def test_recurrent_paged_matches_gather_scatter(packed: bool):
         v,
         gate * LOG2_E,
         beta,
-        initial_state=before[slots.long()].transpose(-1, -2).contiguous(),
+        initial_state=before[slots.long()],
         output_final_state=True,
         cu_seqlens=cu_seqlens,
     )
-    expected_pool[slots.long()] = expected_state.transpose(-1, -2)
+    expected_pool[slots.long()] = expected_state
     torch.testing.assert_close(output, expected, rtol=1e-5, atol=1e-5)
     torch.testing.assert_close(pool, expected_pool, rtol=1e-5, atol=1e-5)
     # Rows the indices never name stay bitwise untouched.
@@ -367,16 +379,14 @@ def test_recurrent_paged_fresh_slot_ignores_existing_state():
     )
 
     torch.testing.assert_close(output, expected, rtol=1e-5, atol=1e-5)
-    torch.testing.assert_close(
-        pool[slots.long()], expected_state.transpose(-1, -2), rtol=1e-5, atol=1e-5
-    )
+    torch.testing.assert_close(pool[slots.long()], expected_state, rtol=1e-5, atol=1e-5)
 
 
 def test_recurrent_paged_decode_accumulates_in_place():
     """Successive single-token steps advance each slot without a round trip."""
     _, pool = strided_state_pool(5, 2, 64, 64)
     slots = torch.tensor([3, 1], device="cuda", dtype=torch.int32)
-    state = pool[slots.long()].transpose(-1, -2).contiguous()
+    state = pool[slots.long()].clone()
 
     for step in range(3):
         q, k, v, gate, beta, _ = _inputs(batch=2, tokens=1, seed=20 + step)
@@ -385,9 +395,7 @@ def test_recurrent_paged_decode_accumulates_in_place():
             q, k, v, gate * LOG2_E, beta, initial_state=state, output_final_state=True
         )
         torch.testing.assert_close(output, expected, rtol=1e-5, atol=1e-5)
-        torch.testing.assert_close(
-            pool[slots.long()], state.transpose(-1, -2), rtol=1e-5, atol=1e-5
-        )
+        torch.testing.assert_close(pool[slots.long()], state, rtol=1e-5, atol=1e-5)
 
 
 @pytest.mark.parametrize("padding_slot", [0, -1])
@@ -407,14 +415,12 @@ def test_recurrent_paged_padding_slot_is_ignored(padding_slot: int):
         v[active],
         gate[active] * LOG2_E,
         beta[active],
-        initial_state=before[slots[active].long()].transpose(-1, -2).contiguous(),
+        initial_state=before[slots[active].long()],
         output_final_state=True,
     )
     torch.testing.assert_close(output[active], expected, rtol=1e-5, atol=1e-5)
     torch.testing.assert_close(output[1], torch.zeros_like(output[1]), rtol=0, atol=0)
-    torch.testing.assert_close(
-        pool[slots[active].long()], expected_state.transpose(-1, -2), rtol=1e-5, atol=1e-5
-    )
+    torch.testing.assert_close(pool[slots[active].long()], expected_state, rtol=1e-5, atol=1e-5)
     torch.testing.assert_close(pool[0], before[0], rtol=0, atol=0)
 
 
@@ -514,7 +520,7 @@ def test_recurrent_custom_op_registration(packed: bool):
     q, k, v, gate, beta, _ = _inputs(batch=batch, tokens=17)
     cu_seqlens = cumulative_sequence_offsets([2, 5, 10]) if packed else None
     num_sequences = 3 if packed else batch
-    state = torch.randn(num_sequences, q.shape[2], q.shape[3], v.shape[-1], device="cuda")
+    state = torch.randn(num_sequences, q.shape[2], v.shape[-1], q.shape[3], device="cuda")
     torch.library.opcheck(
         _recurrent_fwd_op,
         (q, k, v, gate, beta, state, cu_seqlens, True),
@@ -535,7 +541,7 @@ def test_recurrent_custom_op_registration_mixed_dtype():
     """Fake outputs follow Q dtype even when V uses the model activation dtype."""
     q, k, v, gate, beta, _ = _inputs(batch=2, tokens=1, dtype=torch.bfloat16)
     q, k = q.float(), k.float()
-    state = torch.randn(2, q.shape[2], q.shape[3], v.shape[-1], device="cuda")
+    state = torch.randn(2, q.shape[2], v.shape[-1], q.shape[3], device="cuda")
     _, state_pool = strided_state_pool(3, q.shape[2], q.shape[3], v.shape[-1])
     slots = torch.tensor([1, 2], device="cuda", dtype=torch.int32)
 
@@ -609,7 +615,7 @@ def test_recurrent_cuda_graph_replay():
     """Replay fixed shapes with mutated boundaries, values, and history."""
     q, k, v, gate, beta, _ = _inputs(batch=1, tokens=32, seed=5)
     cu_seqlens = cumulative_sequence_offsets([11, 16, 5])
-    initial_state = torch.randn(3, q.shape[2], q.shape[3], v.shape[-1], device="cuda")
+    initial_state = torch.randn(3, q.shape[2], v.shape[-1], q.shape[3], device="cuda")
     _recurrent_fwd_op(q, k, v, gate, beta, initial_state, cu_seqlens, True)
     torch.cuda.synchronize()
 
@@ -713,7 +719,7 @@ def test_naive_recurrent_packed_matches_public_contract():
     """The pure reference honors packed semantics: empty slots and capacity tails."""
     q, k, v, gate, beta, _ = _inputs(batch=1, tokens=32, seed=7)
     cu_seqlens = cumulative_sequence_offsets([0, 11, 16, 0])
-    initial_state = torch.randn(4, q.shape[2], q.shape[3], v.shape[-1], device="cuda")
+    initial_state = torch.randn(4, q.shape[2], v.shape[-1], q.shape[3], device="cuda")
 
     output, final_state = naive_recurrent_kda(
         q,

--- a/test/test_kda_recurrent_decode.py
+++ b/test/test_kda_recurrent_decode.py
@@ -101,11 +101,11 @@ def _reference_decode(
             gate[:, active].transpose(0, 1),
             beta[:, active].transpose(0, 1),
             scale=scale,
-            initial_state=state_cache[active_indices].transpose(-1, -2).contiguous(),
+            initial_state=state_cache[active_indices],
             output_final_state=True,
         )
         output[:, active] = active_output.transpose(0, 1).to(output.dtype)
-        expected_cache[active_indices] = active_state.transpose(-1, -2)
+        expected_cache[active_indices] = active_state
     return output, expected_cache
 
 


### PR DESCRIPTION
Stacked PRs:
 * #400
 * #399
 * #397
 * #369
 * __->__#402


--- --- ---

Standardize delta-rule state on V-major storage

## Human Note

## Agent note

Make `[N, H, V, K]` the public and persistent state contract for KDA and GDN, matching the
existing paged prefill and decode caches. Reference recurrences now express the update directly in
V-major form, while fused kernels that retain K-major register accumulators convert only at their
private boundaries. This is an intentional compatibility break made before state-carrying use is
widely adopted; asymmetric K/V tests prevent the two layouts from being confused when K equals V.

## Test Plan

```bash
pytest -n 6 -q
prek --all-files
uv lock --check
```