### PR TITLE
Tune linear-attention decode kernels for Hopper

### DIFF
--- a/attn_gym/linear/_delta_rule/decode.py
+++ b/attn_gym/linear/_delta_rule/decode.py
@@ -37,6 +37,7 @@ import torch
 import triton
 import triton.language as tl
 
+from attn_gym._backends.cute.utils import get_device_properties
 from attn_gym._backends.triton.utils import ptr_offset
 from attn_gym.linear._delta_rule.recurrent import GateKind
 
@@ -46,6 +47,17 @@ class GateTransform(Enum):
 
     BOUNDED = "bounded"  # lower_bound * sigmoid(exp(A_log) * (raw_gate + dt_bias))
     SOFTPLUS = "softplus"  # -exp(A_log) * softplus(raw_gate + dt_bias)
+
+
+def _decode_launch_config(
+    value_dim: int, sequence_heads: int, use_hopper_gdn_config: bool
+) -> tuple[int, int]:
+    """Select the value tile and warp count for one-token decode."""
+    if value_dim <= 32:
+        return min(triton.next_power_of_2(value_dim), 8), 4
+    # H100 measurements become inconclusive above 96 sequence-heads.
+    block_v = 8 if use_hopper_gdn_config and sequence_heads < 104 else 16
+    return min(triton.next_power_of_2(value_dim), block_v), 2 if sequence_heads <= 8 else 1
 
 
 # Use a flat 1D grid of B * H * ceil(V / BV) programs. Each program owns one
@@ -210,12 +222,17 @@ def launch_recurrent_delta_rule_decode(
     batch = packed_qkv.shape[0]
     heads, value_dim, key_dim = state_cache.shape[1:]
     assert key_heads > 0 and heads % key_heads == 0
-    if value_dim <= 32:
-        block_v, num_warps = min(triton.next_power_of_2(value_dim), 8), 4
-    elif batch * heads <= 8:
-        block_v, num_warps = min(triton.next_power_of_2(value_dim), 16), 2
-    else:
-        block_v, num_warps = min(triton.next_power_of_2(value_dim), 16), 1
+    use_hopper_gdn_config = (
+        get_device_properties(packed_qkv.device).major == 9
+        and packed_qkv.dtype is torch.bfloat16
+        and key_dim == value_dim == 128
+        and gate_kind is GateKind.SCALAR
+    )
+    block_v, num_warps = _decode_launch_config(
+        value_dim,
+        batch * heads,
+        use_hopper_gdn_config,
+    )
     grid = (triton.cdiv(value_dim, block_v) * batch * heads,)
     _recurrent_delta_rule_decode_kernel[grid](
         packed_qkv,

--- a/attn_gym/linear/kda/fwd/triton/l2norm_fwd.py
+++ b/attn_gym/linear/kda/fwd/triton/l2norm_fwd.py
@@ -6,18 +6,13 @@ import torch
 import triton
 import triton.language as tl
 
+from attn_gym._backends.cute.utils import get_device_properties
 from attn_gym._backends.triton.utils import ptr_offset
 
 # A Triton pointer does not carry tensor shape or stride metadata. The registered-operator
 # boundary keeps runtime stride tuples opaque to Dynamo while preserving ptr_offset indexing.
 
 
-@triton.autotune(
-    configs=[
-        triton.Config({"BT": 16}, num_warps=4, num_stages=3),
-    ],
-    key=["D", "NB"],
-)
 @triton.jit
 def l2norm_fwd_kernel(
     x,
@@ -33,7 +28,6 @@ def l2norm_fwd_kernel(
     H: tl.constexpr,
     D: tl.constexpr,
     BD: tl.constexpr,
-    NB,
     NUM_SEQUENCES: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     BT: tl.constexpr,
@@ -81,6 +75,15 @@ def l2norm_fwd_kernel(
     )
 
 
+def _l2norm_launch_config(rows: int, use_hopper_decode_config: bool) -> tuple[int, int]:
+    """Select the rows per program and warp count for L2 normalization."""
+    if not use_hopper_decode_config or rows > 2048:
+        return 16, 4
+    if rows <= 9:
+        return 1, 1
+    return 4, 2
+
+
 torch.library.define(
     "attn_gym::kda_l2norm_fwd",
     "(Tensor x, float eps, Tensor? cu_seqlens=None) -> (Tensor, Tensor)",
@@ -100,8 +103,15 @@ def _l2norm_fwd_cuda(
     output = torch.empty(rows, head_dim, dtype=x.dtype, device=x.device)
     rstd = torch.empty(rows, dtype=torch.float32, device=x.device)
     block_dim = triton.next_power_of_2(head_dim)
-    grid = lambda meta: (triton.cdiv(rows, meta["BT"]),)
-    l2norm_fwd_kernel[grid](
+    use_hopper_decode_config = (
+        get_device_properties(x.device).major == 9
+        and x.dtype is torch.bfloat16
+        and head_dim == 128
+        and cu_seqlens is not None
+        and cu_seqlens.shape[0] == tokens + 1
+    )
+    block_tokens, num_warps = _l2norm_launch_config(rows, use_hopper_decode_config)
+    l2norm_fwd_kernel[(triton.cdiv(rows, block_tokens),)](
         x,
         output,
         rstd,
@@ -115,9 +125,11 @@ def _l2norm_fwd_cuda(
         H=heads,
         D=head_dim,
         BD=block_dim,
-        NB=triton.cdiv(rows, 16),
         NUM_SEQUENCES=0 if cu_seqlens is None else cu_seqlens.shape[0] - 1,
         IS_VARLEN=cu_seqlens is not None,
+        BT=block_tokens,
+        num_warps=num_warps,
+        num_stages=3,
     )
     return output.view_as(x), rstd
 

--- a/attn_gym/linear/short_conv/cute.py
+++ b/attn_gym/linear/short_conv/cute.py
@@ -2895,6 +2895,24 @@ def _compatible_config(config: ShortConvConfig, channels: int) -> ShortConvConfi
     return ShortConvConfig(config.threads, channels_per_thread, config.times_per_block)
 
 
+def _default_decode_config(x: torch.Tensor, width: int, activation: str | None) -> ShortConvConfig:
+    """Select the measured one-token schedule for the active architecture."""
+    default = ShortConvTunedConfig.default(x.dtype).forward
+    if (
+        get_device_properties(x.device).major == 9
+        and x.dtype is torch.bfloat16
+        and width == 4
+        and activation == "silu"
+    ):
+        # Narrower channel ownership gives Qwen's small H100 decode grids more CTAs.
+        default = ShortConvConfig(
+            default.threads,
+            1 if x.shape[0] <= 8 else 2,
+            default.times_per_block,
+        )
+    return _compatible_config(default, x.shape[1])
+
+
 def _candidate_configs(
     kind: str,
     channels: int,
@@ -3232,7 +3250,7 @@ def _cute_short_conv_decode_cuda(
 ) -> torch.Tensor:
     """Launch the tuned forward defaults through the decode schema."""
     _validate_decode_inputs(x, weight, state, state_indices)
-    config = _compatible_config(ShortConvTunedConfig.default(x.dtype).forward, x.shape[1])
+    config = _default_decode_config(x, weight.shape[1], activation)
     return _launch_decode(
         x,
         weight,
@@ -3974,21 +3992,19 @@ def causal_conv1d_decode(
             "causal_conv1d_decode is inference-only and has no backward; use "
             "causal_conv1d for training or call under torch.no_grad()"
         )
-    default = ShortConvTunedConfig.default(x.dtype).forward
-    config = _compatible_config(default, x.shape[1]) if forward_config is None else forward_config
-    _validate_config(config, x.shape[1], "forward_config")
-    if forward_config is None and config == default:
+    if forward_config is None:
         return short_conv_ops.short_conv_decode_op(
             x, weight, state, state_indices, activation=activation
         )
+    _validate_config(forward_config, x.shape[1], "forward_config")
     return short_conv_ops.short_conv_configured_decode_op(
         x,
         weight,
         state,
         state_indices,
-        config.threads,
-        config.channels_per_thread,
-        config.times_per_block,
+        forward_config.threads,
+        forward_config.channels_per_thread,
+        forward_config.times_per_block,
         activation=activation,
     )
 

--- a/test/linear/test_gdn_decode.py
+++ b/test/linear/test_gdn_decode.py
@@ -7,12 +7,32 @@ import torch.nn.functional as F
 pytest.importorskip("triton")
 
 from attn_gym.linear import recurrent_gdn, recurrent_gdn_decode
+from attn_gym.linear._delta_rule.decode import _decode_launch_config
 from attn_gym.linear.gdn.ops import recurrent_decode_op
 from attn_gym.testing import strided_state_pool
 
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available(), reason="recurrent_gdn_decode requires CUDA"
 )
+
+
+@pytest.mark.parametrize(
+    ("value_dim", "sequence_heads", "use_hopper_gdn_config", "expected"),
+    [
+        (32, 128, True, (8, 4)),
+        (128, 8, True, (8, 2)),
+        (128, 96, True, (8, 1)),
+        (128, 104, True, (16, 1)),
+        (128, 96, False, (16, 1)),
+    ],
+)
+def test_decode_launch_config(
+    value_dim: int,
+    sequence_heads: int,
+    use_hopper_gdn_config: bool,
+    expected: tuple[int, int],
+):
+    assert _decode_launch_config(value_dim, sequence_heads, use_hopper_gdn_config) == expected
 
 
 def make_decode_inputs(
@@ -116,6 +136,33 @@ def test_decode_matches_reference(key_heads: int | None, dtype: torch.dtype, sca
     tolerance = 1e-5 if dtype is torch.float32 else 3e-2
     assert output.dtype == dtype and output.shape[0] == 1
     torch.testing.assert_close(output[0].float(), expected_output, rtol=tolerance, atol=tolerance)
+    torch.testing.assert_close(inputs["state_cache"], expected_pool, rtol=1e-5, atol=1e-5)
+
+
+def test_hopper_decode_schedule_matches_reference():
+    if torch.cuda.get_device_capability()[0] != 9:
+        pytest.skip("Hopper-specific decode schedule")
+    inputs = make_decode_inputs(
+        batch=1,
+        heads=8,
+        key_dim=128,
+        value_dim=128,
+        dtype=torch.bfloat16,
+    )
+    inputs["state_indices"] = torch.tensor([1], device="cuda", dtype=torch.int32)
+    expected_output, expected_pool = reference_decode(inputs)
+
+    output = recurrent_gdn_decode(
+        inputs["packed_qkv"],
+        inputs["raw_gate"],
+        inputs["raw_beta"],
+        inputs["A_log"],
+        inputs["dt_bias"],
+        inputs["state_cache"],
+        inputs["state_indices"],
+    )
+
+    torch.testing.assert_close(output[0].float(), expected_output, rtol=3e-2, atol=3e-2)
     torch.testing.assert_close(inputs["state_cache"], expected_pool, rtol=1e-5, atol=1e-5)
 
 

--- a/test/test_kda_kernels.py
+++ b/test/test_kda_kernels.py
@@ -29,6 +29,7 @@ from attn_gym.linear.kda.fwd.triton.chunk_kda_fwd_intra_sub_chunk_forloop import
 from attn_gym.linear.kda.fwd.triton.l2norm_fwd import (
     _l2norm_bwd_op,
     _l2norm_fwd_op,
+    _l2norm_launch_config,
     l2norm,
     l2norm_fwd_kernel,
 )
@@ -187,6 +188,24 @@ _L2NORM_CASES = [(torch.float32, T, D, strided) for T, D, strided in L2NORM_SHAP
 
 
 # l2norm forward
+@pytest.mark.parametrize(
+    ("rows", "use_hopper_decode_config", "expected"),
+    [
+        (1, True, (1, 1)),
+        (2, True, (1, 1)),
+        (9, True, (1, 1)),
+        (10, True, (4, 2)),
+        (2048, True, (4, 2)),
+        (2049, True, (16, 4)),
+        (128, False, (16, 4)),
+    ],
+)
+def test_l2norm_launch_config(
+    rows: int, use_hopper_decode_config: bool, expected: tuple[int, int]
+):
+    assert _l2norm_launch_config(rows, use_hopper_decode_config) == expected
+
+
 @pytest.mark.parametrize("dtype,T,D,strided", _L2NORM_CASES, ids=_case_id)
 def test_l2norm_fwd(dtype, T, D, strided):
     torch.manual_seed(0)
@@ -208,8 +227,7 @@ def test_l2norm_fwd(dtype, T, D, strided):
     y = _empty_strided_like(x) if strided else torch.empty_like(x)
     rstd_template = torch.empty(T, device=DEV, dtype=torch.float32)
     rstd = _empty_strided_like(rstd_template) if strided else rstd_template
-    grid = lambda meta: (triton.cdiv(T, meta["BT"]),)
-    l2norm_fwd_kernel[grid](
+    l2norm_fwd_kernel[(triton.cdiv(T, 16),)](
         x,
         y,
         rstd,
@@ -223,9 +241,11 @@ def test_l2norm_fwd(dtype, T, D, strided):
         H=1,
         D=D,
         BD=BD,
-        NB=triton.cdiv(T, 16),
         NUM_SEQUENCES=0,
         IS_VARLEN=False,
+        BT=16,
+        num_warps=4,
+        num_stages=3,
     )
     assert_golden(y, golden, ref, dtype, f"l2norm_fwd_kernel T={T} D={D}")
     assert_golden(rstd, rstd_golden, rstd_ref, dtype, f"l2norm_fwd_kernel rstd T={T} D={D}")

--- a/test/test_short_conv_cute.py
+++ b/test/test_short_conv_cute.py
@@ -54,8 +54,8 @@ def test_kda_backward_compatibility_exports():
 
 
 pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (10, 0),
-    reason="the CuTeDSL short convolution requires CUDA capability 10.0 or newer",
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (9, 0),
+    reason="the CuTeDSL short convolution requires CUDA capability 9.0 or newer",
 )
 
 
@@ -198,6 +198,28 @@ def test_short_conv_forward_and_backward_match_pytorch(width: int):
     expected_gradients = torch.autograd.grad(expected, (x, weight), grad_output)
     torch.testing.assert_close(actual_gradients[0], expected_gradients[0], rtol=3e-2, atol=3e-2)
     torch.testing.assert_close(actual_gradients[1], expected_gradients[1], rtol=3e-2, atol=2e-1)
+
+
+@pytest.mark.parametrize(
+    ("sequences", "width", "activation", "channels_per_thread"),
+    [
+        (8, 4, "silu", 1),
+        (9, 4, "silu", 2),
+        (8, 5, "silu", 4),
+        (8, 4, None, 4),
+    ],
+)
+def test_short_conv_hopper_decode_defaults(
+    sequences: int,
+    width: int,
+    activation: str | None,
+    channels_per_thread: int,
+):
+    if torch.cuda.get_device_capability()[0] != 9:
+        pytest.skip("Hopper-specific decode schedule")
+    x = torch.empty(sequences, 6144, device="cuda", dtype=torch.bfloat16)
+    config = cute_backend._default_decode_config(x, width, activation)
+    assert config == ShortConvConfig(128, channels_per_thread, 16)
 
 
 def test_short_conv_dtype_defaults_follow_measured_storage_traffic():
@@ -1798,6 +1820,18 @@ def test_short_conv_decode_configured_dynamic_shapes(paged_short_conv_inputs):
         )
         torch.testing.assert_close(actual, expected, rtol=0, atol=0)
         torch.testing.assert_close(actual_state, expected_state, rtol=0, atol=0)
+
+
+def test_short_conv_hopper_default_schedule_matches_reference(paged_short_conv_inputs):
+    if torch.cuda.get_device_capability()[0] != 9:
+        pytest.skip("Hopper-specific decode schedule")
+    x, weight, state, slots = paged_short_conv_inputs(sequences=64, channels=3072, slots=65)
+    initial_state = state.clone()
+    history = torch.cat([initial_state[slots.long()], x.unsqueeze(1)], dim=1)
+
+    actual = causal_conv1d_decode(x, weight, state, activation="silu", state_indices=slots)
+
+    torch.testing.assert_close(actual, _reference(history, weight)[:, -1], rtol=2e-2, atol=2e-2)
 
 
 def test_short_conv_decode_advances_only_the_named_slots(paged_short_conv_inputs):


### PR DESCRIPTION
## Human Note

## Agent note

The linear-attention decode defaults were selected on Blackwell even though the underlying GDN,
L2-normalization, and short-convolution kernels also run on Hopper. This adds narrowly scoped H100
launch policies for the measured Qwen3.5 decode domain while leaving Blackwell, KDA vector-gate,
other dtype/shape, and prefill behavior unchanged.

The L2-normalization selector directly owns launch configuration rather than bypassing a retained
single-config autotuner. The short-convolution test suite is enabled on SM90 after validating the
complete suite there.

A full repository test run on H100 also exposed three unrelated failures: two Blackwell-only fused
chunk-KDA tests lack SM100 skips, and `test_natten_masks` has a tiled-vs-naive mismatch. All three
reproduce unchanged at base commit `f7c2170` and are not modified here.

## Performance

Fixed-pointer, warm-buffer H100 measurements used
`benchmark_cuda_function_in_microseconds`, with candidate order alternated between rounds.

| Qwen decode shape | Short-conv + GDN baseline | Tuned | Speedup |
|---|---:|---:|---:|
| B1, H2, C768 | 4.687 us | 4.433 us | 1.057x |
| B4, H2, C768 | 4.997 us | 4.703 us | 1.062x |
| B16, H2, C768 | 7.059 us | 6.398 us | 1.103x |
| B1, H16, C6144 | 6.175 us | 5.439 us | 1.135x |
| B4, H16, C6144 | 8.758 us | 8.127 us | 1.078x |

Packed BF16 D=128 L2 normalization improved by 1.035x-1.096x across representative 2-1024-row
decode shapes.

## Test Plan

```bash
~/.venvs/nightly/bin/python -m pytest -q test/test_short_conv_cute.py
~/.venvs/nightly/bin/python -m pytest -q test/linear/test_gdn_decode.py test/linear/test_gdn_fused.py
~/.venvs/nightly/bin/python -m pytest -q test/test_kda_kernels.py -k l2norm
~/.venvs/nightly/bin/ruff format --check attn_gym/linear/_delta_rule/decode.py attn_gym/linear/kda/fwd/triton/l2norm_fwd.py attn_gym/linear/short_conv/cute.py test/linear/test_gdn_decode.py test/test_kda_kernels.py test/test_short_conv_cute.py
~/.venvs/nightly/bin/ruff check attn_gym/linear/_delta_rule/decode.py attn_gym/linear/kda/fwd/triton/l2norm_fwd.py attn_gym/linear/short_conv/cute.py test/linear/test_gdn_decode.py test/test_kda_kernels.py test/test_short_conv_cute.py
```
