### PR TITLE
Tune vector-gated decode for Hopper

### DIFF
--- a/attn_gym/linear/_delta_rule/decode.py
+++ b/attn_gym/linear/_delta_rule/decode.py
@@ -50,14 +50,25 @@ class GateTransform(Enum):
 
 
 def _decode_launch_config(
-    value_dim: int, sequence_heads: int, use_hopper_gdn_config: bool
+    value_dim: int,
+    sequence_heads: int,
+    hopper_gate_kind: GateKind | None,
 ) -> tuple[int, int]:
     """Select the value tile and warp count for one-token decode."""
     if value_dim <= 32:
         return min(triton.next_power_of_2(value_dim), 8), 4
-    # H100 measurements become inconclusive above 96 sequence-heads.
-    block_v = 8 if use_hopper_gdn_config and sequence_heads < 104 else 16
-    return min(triton.next_power_of_2(value_dim), block_v), 2 if sequence_heads <= 8 else 1
+    if hopper_gate_kind is GateKind.SCALAR:
+        # The H100 scalar-gate crossover is between 96 and 104 sequence-heads.
+        block_v = 8 if sequence_heads < 104 else 16
+        num_warps = 2 if sequence_heads <= 8 else 1
+    elif hopper_gate_kind is GateKind.VECTOR:
+        # Vector gates move the H100 crossover between 224 and 232 sequence-heads.
+        block_v = 8 if sequence_heads < 232 else 16
+        num_warps = 1
+    else:
+        block_v = 16
+        num_warps = 2 if sequence_heads <= 8 else 1
+    return min(triton.next_power_of_2(value_dim), block_v), num_warps
 
 
 # Use a flat 1D grid of B * H * ceil(V / BV) programs. Each program owns one
@@ -222,16 +233,17 @@ def launch_recurrent_delta_rule_decode(
     batch = packed_qkv.shape[0]
     heads, value_dim, key_dim = state_cache.shape[1:]
     assert key_heads > 0 and heads % key_heads == 0
-    use_hopper_gdn_config = (
-        get_device_properties(packed_qkv.device).major == 9
+    hopper_gate_kind = (
+        gate_kind
+        if get_device_properties(packed_qkv.device).major == 9
         and packed_qkv.dtype is torch.bfloat16
         and key_dim == value_dim == 128
-        and gate_kind is GateKind.SCALAR
+        else None
     )
     block_v, num_warps = _decode_launch_config(
         value_dim,
         batch * heads,
-        use_hopper_gdn_config,
+        hopper_gate_kind,
     )
     grid = (triton.cdiv(value_dim, block_v) * batch * heads,)
     _recurrent_delta_rule_decode_kernel[grid](

--- a/test/linear/test_gdn_decode.py
+++ b/test/linear/test_gdn_decode.py
@@ -8,6 +8,7 @@ pytest.importorskip("triton")
 
 from attn_gym.linear import recurrent_gdn, recurrent_gdn_decode
 from attn_gym.linear._delta_rule.decode import _decode_launch_config
+from attn_gym.linear._delta_rule.recurrent import GateKind
 from attn_gym.linear.gdn.ops import recurrent_decode_op
 from attn_gym.testing import strided_state_pool
 
@@ -17,22 +18,24 @@ pytestmark = pytest.mark.skipif(
 
 
 @pytest.mark.parametrize(
-    ("value_dim", "sequence_heads", "use_hopper_gdn_config", "expected"),
+    ("value_dim", "sequence_heads", "hopper_gate_kind", "expected"),
     [
-        (32, 128, True, (8, 4)),
-        (128, 8, True, (8, 2)),
-        (128, 96, True, (8, 1)),
-        (128, 104, True, (16, 1)),
-        (128, 96, False, (16, 1)),
+        (32, 128, GateKind.SCALAR, (8, 4)),
+        (128, 8, GateKind.SCALAR, (8, 2)),
+        (128, 96, GateKind.SCALAR, (8, 1)),
+        (128, 104, GateKind.SCALAR, (16, 1)),
+        (128, 224, GateKind.VECTOR, (8, 1)),
+        (128, 232, GateKind.VECTOR, (16, 1)),
+        (128, 96, None, (16, 1)),
     ],
 )
 def test_decode_launch_config(
     value_dim: int,
     sequence_heads: int,
-    use_hopper_gdn_config: bool,
+    hopper_gate_kind: GateKind | None,
     expected: tuple[int, int],
 ):
-    assert _decode_launch_config(value_dim, sequence_heads, use_hopper_gdn_config) == expected
+    assert _decode_launch_config(value_dim, sequence_heads, hopper_gate_kind) == expected
 
 
 def make_decode_inputs(

--- a/test/test_kda_recurrent_decode.py
+++ b/test/test_kda_recurrent_decode.py
@@ -160,6 +160,36 @@ def test_recurrent_decode_matches_reference(
     torch.testing.assert_close(state_cache, expected_cache, rtol=tolerance, atol=tolerance)
 
 
+def test_hopper_vector_gate_schedule_matches_reference():
+    if torch.cuda.get_device_capability()[0] != 9:
+        pytest.skip("Hopper-specific decode schedule")
+    inputs = _decode_inputs(batch=1, heads=16, key_dim=128, value_dim=128)
+    packed_qkv, raw_gate, raw_beta, A_log, dt_bias, _, state_cache, state_indices = inputs
+    before = state_cache.clone()
+
+    output = recurrent_kda_decode(
+        packed_qkv,
+        raw_gate,
+        raw_beta,
+        A_log,
+        dt_bias,
+        state_cache,
+        state_indices,
+    )
+    expected, expected_cache = _reference_decode(
+        packed_qkv,
+        raw_gate,
+        raw_beta,
+        A_log,
+        dt_bias,
+        before,
+        state_indices,
+    )
+
+    torch.testing.assert_close(output.float(), expected.float(), rtol=3e-2, atol=3e-2)
+    torch.testing.assert_close(state_cache, expected_cache, rtol=3e-2, atol=3e-2)
+
+
 def test_decode_launcher_grouped_vector_gate_matches_expanded():
     """Grouped vector-gate decode shares only q/k; the gate stays per value head.
 


### PR DESCRIPTION
## Human Note

## Agent note

Extend the H100 recurrent decode selector from scalar GDN to the measured BF16 vector-gated KDA
domain at K=V=128. The narrower BV=8, one-warp schedule is used below 232 sequence-heads; larger
grids and all unmeasured dtype, dimension, gate, and architecture combinations retain their
existing choices.

The shared selector represents the gate kind directly, so GDN and KDA continue to use one launch
policy boundary without duplicating dispatch logic. A Hopper-specific numerical test exercises the
selected vector-gate schedule against the reference implementation.

## Performance

Fixed-pointer warm-buffer H100 measurements used
`benchmark_cuda_function_in_microseconds`, with five alternating-order rounds and 50 iterations
for final boundary confirmation.

| Sequence-heads | Previous | Tuned | Speedup |
|---:|---:|---:|---:|
| 8 | 3.556 us | 3.327 us | 1.069x |
| 16 | 4.282 us | 3.752 us | 1.141x |
| 64 | 6.898 us | 6.151 us | 1.121x |
| 224 | 14.661 us | 14.321 us | 1.024x |
| 232 | 14.982 us | 15.026 us | fallback retained |

## Test Plan

```bash
PYTHONPATH=$PWD ~/.venvs/nightly/bin/python -m pytest -q test/test_kda_recurrent_decode.py test/linear/test_gdn_decode.py
~/.venvs/nightly/bin/ruff format --check attn_gym/linear/_delta_rule/decode.py test/linear/test_gdn_decode.py test/test_kda_recurrent_decode.py
~/.venvs/nightly/bin/ruff check attn_gym/linear/_delta_rule/decode.py test/linear/test_gdn_decode.py test/test_kda_recurrent_decode.py
```
