### PR TITLE
Avoid Hopper ptxas miscompile in NATTEN masks

### DIFF
--- a/attn_gym/masks/natten.py
+++ b/attn_gym/masks/natten.py
@@ -4,6 +4,10 @@ import torch
 from torch import BoolTensor, IntTensor
 from torch.nn.attention.flex_attention import _mask_mod_signature
 
+# NOTE [Avoid integer abs in Hopper FlexAttention]
+# CUDA 13 ptxas can miscompile the integer abs predicate in FlexAttention's dQ kernel. Keep
+# neighborhood bounds as direct comparisons, which are equivalent for valid token indices.
+
 
 def generate_natten(
     canvas_w: int,
@@ -34,8 +38,12 @@ def generate_natten(
         # is clamped to a fixed distance (kernel half-length) from the canvas edge
         kernel_center_x = q_x.clamp(kernel_w // 2, (canvas_w - 1) - kernel_w // 2)
         kernel_center_y = q_y.clamp(kernel_h // 2, (canvas_h - 1) - kernel_h // 2)
-        hori_mask = (kernel_center_x - kv_x).abs() <= kernel_w // 2
-        vert_mask = (kernel_center_y - kv_y).abs() <= kernel_h // 2
+        hori_mask = (kernel_center_x - kernel_w // 2 <= kv_x) & (
+            kv_x <= kernel_center_x + kernel_w // 2
+        )
+        vert_mask = (kernel_center_y - kernel_h // 2 <= kv_y) & (
+            kv_y <= kernel_center_y + kernel_h // 2
+        )
         return hori_mask & vert_mask
 
     natten_mask_mod.__name__ = f"natten_c{canvas_w}x{canvas_h}_k{kernel_w}x{kernel_h}"
@@ -80,8 +88,8 @@ def generate_tiled_natten(
         kv_x, kv_y = get_x_y_tiled(kv_idx)
         kernel_x = q_x.clamp(K_W // 2, (W - 1) - K_W // 2)
         kernel_y = q_y.clamp(K_H // 2, (H - 1) - K_H // 2)
-        hori_mask = (kernel_x - kv_x).abs() <= K_W // 2
-        vert_mask = (kernel_y - kv_y).abs() <= K_H // 2
+        hori_mask = (kernel_x - K_W // 2 <= kv_x) & (kv_x <= kernel_x + K_W // 2)
+        vert_mask = (kernel_y - K_H // 2 <= kv_y) & (kv_y <= kernel_y + K_H // 2)
         return hori_mask & vert_mask
 
     tiled_natten_mask.__name__ = f"tiled_natten_c{W}x{H}_k{K_W}x{K_H}_t{T_W}x{T_H}"
@@ -168,8 +176,12 @@ def generate_morton_natten(
         # is clamped to a fixed distance (kernel half-length) from the canvas edge
         kernel_center_x = q_x.clamp(kernel_w // 2, (canvas_w - 1) - kernel_w // 2)
         kernel_center_y = q_y.clamp(kernel_h // 2, (canvas_h - 1) - kernel_h // 2)
-        hori_mask = (kernel_center_x - kv_x).abs() <= kernel_w // 2
-        vert_mask = (kernel_center_y - kv_y).abs() <= kernel_h // 2
+        hori_mask = (kernel_center_x - kernel_w // 2 <= kv_x) & (
+            kv_x <= kernel_center_x + kernel_w // 2
+        )
+        vert_mask = (kernel_center_y - kernel_h // 2 <= kv_y) & (
+            kv_y <= kernel_center_y + kernel_h // 2
+        )
         return hori_mask & vert_mask
 
     natten_mask_mod.__name__ = f"morton_natten_c{canvas_w}x{canvas_h}_k{kernel_w}x{kernel_h}"

--- a/test/test_natten.py
+++ b/test/test_natten.py
@@ -68,11 +68,6 @@ def run_natten(
     return results
 
 
-@pytest.mark.xfail(
-    torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 9,
-    reason="tiled NATTEN query gradients mismatch on Hopper (#408)",
-    strict=True,
-)
 def test_natten_masks(
     B=16,
     H=16,


### PR DESCRIPTION
## Human Note

## Agent note

Fix #408 by rewriting NATTEN's integer absolute-difference neighborhood predicates as equivalent
direct lower and upper bounds. CUDA 13 ptxas miscompiles the absolute-value form in
FlexAttention's H100 dQ kernel; the direct-bound expression preserves the mask while producing
correct gradients under normal optimized compilation.

Permutation round trips and logical masks were verified independently. The original source passes
with ptxas optimization disabled, and the rewritten predicates pass three fresh-cache runs with
normal optimization. The temporary Hopper expected-failure marker is removed.

## Test Plan

```bash
env -u PTXAS_OPTIONS PYTHONPATH=$PWD TORCHINDUCTOR_CACHE_DIR=/tmp/issue408-fixed-inductor TRITON_CACHE_DIR=/tmp/issue408-fixed-triton gpu-run --timeout 60 auto -- timeout --signal=TERM --kill-after=10s 300s pytest -q test/test_natten.py::test_natten_masks --tb=long
uvx ruff check attn_gym/masks/natten.py test/test_natten.py
uvx ruff format --check attn_gym/masks/natten.py test/test_natten.py
git diff --check
```

The full-size H100 regression passed three times with fresh caches: 17.13s, 17.59s, and 17.05s.
