### PR TITLE
Tune linear-attention decode kernels for Blackwell

### DIFF
--- a/attn_gym/linear/_delta_rule/decode.py
+++ b/attn_gym/linear/_delta_rule/decode.py
@@ -52,16 +52,23 @@ class GateTransform(Enum):
 def _decode_launch_config(
     value_dim: int,
     sequence_heads: int,
-    hopper_gate_kind: GateKind | None,
+    tuned_major: int | None,
+    gate_kind: GateKind,
 ) -> tuple[int, int]:
     """Select the value tile and warp count for one-token decode."""
     if value_dim <= 32:
         return min(triton.next_power_of_2(value_dim), 8), 4
-    if hopper_gate_kind is GateKind.SCALAR:
+    if tuned_major == 10:
+        if sequence_heads <= 32:
+            return min(triton.next_power_of_2(value_dim), 8), 4
+        if sequence_heads <= 128:
+            return min(triton.next_power_of_2(value_dim), 8), 2
+        return min(triton.next_power_of_2(value_dim), 8), 1
+    if tuned_major == 9 and gate_kind is GateKind.SCALAR:
         # The H100 scalar-gate crossover is between 96 and 104 sequence-heads.
         block_v = 8 if sequence_heads < 104 else 16
         num_warps = 2 if sequence_heads <= 8 else 1
-    elif hopper_gate_kind is GateKind.VECTOR:
+    elif tuned_major == 9 and gate_kind is GateKind.VECTOR:
         # Vector gates move the H100 crossover between 224 and 232 sequence-heads.
         block_v = 8 if sequence_heads < 232 else 16
         num_warps = 1
@@ -233,17 +240,24 @@ def launch_recurrent_delta_rule_decode(
     batch = packed_qkv.shape[0]
     heads, value_dim, key_dim = state_cache.shape[1:]
     assert key_heads > 0 and heads % key_heads == 0
-    hopper_gate_kind = (
-        gate_kind
-        if get_device_properties(packed_qkv.device).major == 9
-        and packed_qkv.dtype is torch.bfloat16
-        and key_dim == value_dim == 128
-        else None
-    )
+    major = get_device_properties(packed_qkv.device).major
+    measured_gdn_shape = packed_qkv.dtype is torch.bfloat16 and key_dim == value_dim == 128
+    tuned_major = None
+    if measured_gdn_shape and (
+        major == 9
+        or (
+            major == 10
+            and gate_kind is GateKind.SCALAR
+            and heads in (2, 4, 8, 16)
+            and batch <= 256
+        )
+    ):
+        tuned_major = major
     block_v, num_warps = _decode_launch_config(
         value_dim,
         batch * heads,
-        hopper_gate_kind,
+        tuned_major,
+        gate_kind,
     )
     grid = (triton.cdiv(value_dim, block_v) * batch * heads,)
     _recurrent_delta_rule_decode_kernel[grid](

--- a/attn_gym/linear/kda/fwd/triton/l2norm_fwd.py
+++ b/attn_gym/linear/kda/fwd/triton/l2norm_fwd.py
@@ -75,9 +75,17 @@ def l2norm_fwd_kernel(
     )
 
 
-def _l2norm_launch_config(rows: int, use_hopper_decode_config: bool) -> tuple[int, int]:
+def _l2norm_launch_config(rows: int, tuned_major: int | None) -> tuple[int, int]:
     """Select the rows per program and warp count for L2 normalization."""
-    if not use_hopper_decode_config or rows > 2048:
+    if tuned_major == 10:
+        if rows <= 8:
+            return 1, 1
+        if rows <= 32:
+            return 1, 4
+        if rows <= 512:
+            return 4, 4
+        return 8, 4
+    if tuned_major != 9 or rows > 2048:
         return 16, 4
     if rows <= 9:
         return 1, 1
@@ -103,14 +111,17 @@ def _l2norm_fwd_cuda(
     output = torch.empty(rows, head_dim, dtype=x.dtype, device=x.device)
     rstd = torch.empty(rows, dtype=torch.float32, device=x.device)
     block_dim = triton.next_power_of_2(head_dim)
-    use_hopper_decode_config = (
-        get_device_properties(x.device).major == 9
-        and x.dtype is torch.bfloat16
-        and head_dim == 128
-        and cu_seqlens is not None
-        and cu_seqlens.shape[0] == tokens + 1
+    major = get_device_properties(x.device).major
+    has_decode_metadata_shape = cu_seqlens is not None and cu_seqlens.shape[0] == tokens + 1
+    measured_decode_shape = (
+        x.dtype is torch.bfloat16 and head_dim == 128 and has_decode_metadata_shape
     )
-    block_tokens, num_warps = _l2norm_launch_config(rows, use_hopper_decode_config)
+    tuned_major = None
+    if measured_decode_shape and (
+        major == 9 or (major == 10 and heads in (2, 4, 8, 16) and tokens <= 256)
+    ):
+        tuned_major = major
+    block_tokens, num_warps = _l2norm_launch_config(rows, tuned_major)
     l2norm_fwd_kernel[(triton.cdiv(rows, block_tokens),)](
         x,
         output,

--- a/attn_gym/linear/short_conv/cute.py
+++ b/attn_gym/linear/short_conv/cute.py
@@ -2898,18 +2898,23 @@ def _compatible_config(config: ShortConvConfig, channels: int) -> ShortConvConfi
 def _default_decode_config(x: torch.Tensor, width: int, activation: str | None) -> ShortConvConfig:
     """Select the measured one-token schedule for the active architecture."""
     default = ShortConvTunedConfig.default(x.dtype).forward
-    if (
-        get_device_properties(x.device).major == 9
-        and x.dtype is torch.bfloat16
-        and width == 4
-        and activation == "silu"
-    ):
-        # Narrower channel ownership gives Qwen's small H100 decode grids more CTAs.
-        default = ShortConvConfig(
-            default.threads,
-            1 if x.shape[0] <= 8 else 2,
-            default.times_per_block,
-        )
+    if x.dtype is torch.bfloat16 and width == 4 and activation == "silu":
+        major = get_device_properties(x.device).major
+        if major == 9:
+            # Narrower channel ownership gives Qwen's small H100 decode grids more CTAs.
+            default = ShortConvConfig(
+                default.threads,
+                1 if x.shape[0] <= 8 else 2,
+                default.times_per_block,
+            )
+        elif major == 10 and x.shape[0] <= 256 and x.shape[1] in (768, 1536, 3072, 6144):
+            local_heads = x.shape[1] // (3 * 128)
+            sequence_heads = x.shape[0] * local_heads
+            default = ShortConvConfig(
+                default.threads,
+                1 if sequence_heads <= 128 else 2,
+                default.times_per_block,
+            )
     return _compatible_config(default, x.shape[1])
 
 

--- a/test/linear/test_gdn_decode.py
+++ b/test/linear/test_gdn_decode.py
@@ -18,24 +18,29 @@ pytestmark = pytest.mark.skipif(
 
 
 @pytest.mark.parametrize(
-    ("value_dim", "sequence_heads", "hopper_gate_kind", "expected"),
+    ("value_dim", "sequence_heads", "tuned_major", "gate_kind", "expected"),
     [
-        (32, 128, GateKind.SCALAR, (8, 4)),
-        (128, 8, GateKind.SCALAR, (8, 2)),
-        (128, 96, GateKind.SCALAR, (8, 1)),
-        (128, 104, GateKind.SCALAR, (16, 1)),
-        (128, 224, GateKind.VECTOR, (8, 1)),
-        (128, 232, GateKind.VECTOR, (16, 1)),
-        (128, 96, None, (16, 1)),
+        (32, 128, None, GateKind.SCALAR, (8, 4)),
+        (128, 8, 9, GateKind.SCALAR, (8, 2)),
+        (128, 96, 9, GateKind.SCALAR, (8, 1)),
+        (128, 104, 9, GateKind.SCALAR, (16, 1)),
+        (128, 224, 9, GateKind.VECTOR, (8, 1)),
+        (128, 232, 9, GateKind.VECTOR, (16, 1)),
+        (128, 32, 10, GateKind.SCALAR, (8, 4)),
+        (128, 34, 10, GateKind.SCALAR, (8, 2)),
+        (128, 128, 10, GateKind.SCALAR, (8, 2)),
+        (128, 130, 10, GateKind.SCALAR, (8, 1)),
+        (128, 96, None, GateKind.SCALAR, (16, 1)),
     ],
 )
 def test_decode_launch_config(
     value_dim: int,
     sequence_heads: int,
-    hopper_gate_kind: GateKind | None,
+    tuned_major: int | None,
+    gate_kind: GateKind,
     expected: tuple[int, int],
 ):
-    assert _decode_launch_config(value_dim, sequence_heads, hopper_gate_kind) == expected
+    assert _decode_launch_config(value_dim, sequence_heads, tuned_major, gate_kind) == expected
 
 
 def make_decode_inputs(
@@ -142,12 +147,13 @@ def test_decode_matches_reference(key_heads: int | None, dtype: torch.dtype, sca
     torch.testing.assert_close(inputs["state_cache"], expected_pool, rtol=1e-5, atol=1e-5)
 
 
-def test_hopper_decode_schedule_matches_reference():
-    if torch.cuda.get_device_capability()[0] != 9:
-        pytest.skip("Hopper-specific decode schedule")
+@pytest.mark.parametrize(("major", "heads"), [(9, 8), (10, 16)])
+def test_tuned_decode_schedule_matches_reference(major: int, heads: int):
+    if torch.cuda.get_device_capability()[0] != major:
+        pytest.skip(f"SM{major} decode schedule")
     inputs = make_decode_inputs(
         batch=1,
-        heads=8,
+        heads=heads,
         key_dim=128,
         value_dim=128,
         dtype=torch.bfloat16,
@@ -275,9 +281,27 @@ def test_decode_custom_op_registration():
     )
 
 
-def test_decode_fullgraph_and_cuda_graph():
+@pytest.mark.parametrize(
+    "decode_kwargs",
+    [
+        pytest.param({}, id="generic"),
+        pytest.param(
+            {
+                "batch": 1,
+                "heads": 16,
+                "key_dim": 128,
+                "value_dim": 128,
+                "dtype": torch.bfloat16,
+            },
+            id="blackwell",
+        ),
+    ],
+)
+def test_decode_fullgraph_and_cuda_graph(decode_kwargs: dict[str, object]):
     """The decode op compiles fullgraph and replays under CUDA graph capture."""
-    inputs = make_decode_inputs()
+    if decode_kwargs and torch.cuda.get_device_capability()[0] != 10:
+        pytest.skip("Blackwell-specific decode schedule")
+    inputs = make_decode_inputs(**decode_kwargs)
     initial_pool = inputs["state_cache"].clone()
     args = (
         inputs["packed_qkv"],

--- a/test/test_kda_kernels.py
+++ b/test/test_kda_kernels.py
@@ -189,21 +189,29 @@ _L2NORM_CASES = [(torch.float32, T, D, strided) for T, D, strided in L2NORM_SHAP
 
 # l2norm forward
 @pytest.mark.parametrize(
-    ("rows", "use_hopper_decode_config", "expected"),
+    ("rows", "tuned_major", "expected"),
     [
-        (1, True, (1, 1)),
-        (2, True, (1, 1)),
-        (9, True, (1, 1)),
-        (10, True, (4, 2)),
-        (2048, True, (4, 2)),
-        (2049, True, (16, 4)),
-        (128, False, (16, 4)),
+        (1, 9, (1, 1)),
+        (2, 9, (1, 1)),
+        (9, 9, (1, 1)),
+        (10, 9, (4, 2)),
+        (2048, 9, (4, 2)),
+        (2049, 9, (16, 4)),
+        (8, 10, (1, 1)),
+        (10, 10, (1, 4)),
+        (32, 10, (1, 4)),
+        (34, 10, (4, 4)),
+        (512, 10, (4, 4)),
+        (514, 10, (8, 4)),
+        (128, None, (16, 4)),
     ],
 )
 def test_l2norm_launch_config(
-    rows: int, use_hopper_decode_config: bool, expected: tuple[int, int]
+    rows: int,
+    tuned_major: int | None,
+    expected: tuple[int, int],
 ):
-    assert _l2norm_launch_config(rows, use_hopper_decode_config) == expected
+    assert _l2norm_launch_config(rows, tuned_major) == expected
 
 
 @pytest.mark.parametrize("dtype,T,D,strided", _L2NORM_CASES, ids=_case_id)
@@ -293,6 +301,33 @@ def test_l2norm_op_registration():
             cu_seqlens,
         ),
     )
+
+
+def test_l2norm_blackwell_kda_decode_matches_reference_and_replays():
+    if torch.cuda.get_device_capability()[0] != 10:
+        pytest.skip("Blackwell-specific decode schedule")
+    torch.manual_seed(2)
+    tokens, heads = 32, 4
+    qkv = torch.randn(1, tokens, 3, heads, 128, device=DEV, dtype=torch.bfloat16)
+    x = qkv[:, :, 0]
+    cu_seqlens = torch.arange(tokens + 1, device=DEV, dtype=torch.int32)
+
+    output = l2norm(x, cu_seqlens=cu_seqlens)
+    compiled_output = torch.compile(l2norm, fullgraph=True)(x, cu_seqlens=cu_seqlens)
+    expected = l2norm_fwd_ref(x.float())
+    torch.testing.assert_close(output.float(), expected, rtol=2e-2, atol=2e-3)
+    torch.testing.assert_close(compiled_output, output, rtol=0, atol=0)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = l2norm(x, cu_seqlens=cu_seqlens)
+
+    x.add_(0.25)
+    graph.replay()
+    torch.cuda.synchronize()
+    replayed = captured.clone()
+    expected = l2norm(x, cu_seqlens=cu_seqlens)
+    torch.testing.assert_close(replayed, expected, rtol=0, atol=0)
 
 
 def test_l2norm_ragged_matches_exact_active_prefix():

--- a/test/test_short_conv_cute.py
+++ b/test/test_short_conv_cute.py
@@ -201,23 +201,31 @@ def test_short_conv_forward_and_backward_match_pytorch(width: int):
 
 
 @pytest.mark.parametrize(
-    ("sequences", "width", "activation", "channels_per_thread"),
+    ("major", "sequences", "channels", "width", "activation", "channels_per_thread"),
     [
-        (8, 4, "silu", 1),
-        (9, 4, "silu", 2),
-        (8, 5, "silu", 4),
-        (8, 4, None, 4),
+        (9, 8, 6144, 4, "silu", 1),
+        (9, 9, 6144, 4, "silu", 2),
+        (9, 8, 6144, 5, "silu", 4),
+        (9, 8, 6144, 4, None, 4),
+        (10, 64, 768, 4, "silu", 1),
+        (10, 65, 768, 4, "silu", 2),
+        (10, 256, 6144, 4, "silu", 2),
+        (10, 257, 6144, 4, "silu", 4),
+        (10, 64, 384, 4, "silu", 4),
+        (10, 64, 768, 5, "silu", 4),
     ],
 )
-def test_short_conv_hopper_decode_defaults(
+def test_short_conv_tuned_decode_defaults(
+    major: int,
     sequences: int,
+    channels: int,
     width: int,
     activation: str | None,
     channels_per_thread: int,
 ):
-    if torch.cuda.get_device_capability()[0] != 9:
-        pytest.skip("Hopper-specific decode schedule")
-    x = torch.empty(sequences, 6144, device="cuda", dtype=torch.bfloat16)
+    if torch.cuda.get_device_capability()[0] != major:
+        pytest.skip(f"SM{major} decode schedule")
+    x = torch.empty(sequences, channels, device="cuda", dtype=torch.bfloat16)
     config = cute_backend._default_decode_config(x, width, activation)
     assert config == ShortConvConfig(128, channels_per_thread, 16)
 
@@ -1822,16 +1830,32 @@ def test_short_conv_decode_configured_dynamic_shapes(paged_short_conv_inputs):
         torch.testing.assert_close(actual_state, expected_state, rtol=0, atol=0)
 
 
-def test_short_conv_hopper_default_schedule_matches_reference(paged_short_conv_inputs):
-    if torch.cuda.get_device_capability()[0] != 9:
-        pytest.skip("Hopper-specific decode schedule")
-    x, weight, state, slots = paged_short_conv_inputs(sequences=64, channels=3072, slots=65)
+@pytest.mark.parametrize(
+    ("major", "sequences", "channels"),
+    [(9, 64, 3072), (10, 65, 768)],
+)
+def test_short_conv_tuned_default_schedule_matches_reference(
+    paged_short_conv_inputs,
+    major: int,
+    sequences: int,
+    channels: int,
+):
+    if torch.cuda.get_device_capability()[0] != major:
+        pytest.skip(f"SM{major} decode schedule")
+    x, weight, state, slots = paged_short_conv_inputs(
+        sequences=sequences,
+        channels=channels,
+        slots=sequences + 1,
+    )
     initial_state = state.clone()
     history = torch.cat([initial_state[slots.long()], x.unsqueeze(1)], dim=1)
+    expected_state = initial_state.clone()
+    expected_state[slots.long()] = history[:, 1:]
 
     actual = causal_conv1d_decode(x, weight, state, activation="silu", state_indices=slots)
 
     torch.testing.assert_close(actual, _reference(history, weight)[:, -1], rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(state, expected_state, rtol=0, atol=0)
 
 
 def test_short_conv_decode_advances_only_the_named_slots(paged_short_conv_inputs):
@@ -1931,10 +1955,22 @@ def test_short_conv_decode_validates_inputs_and_config(paged_short_conv_inputs):
         )
 
 
-def test_short_conv_decode_cuda_graph_replay(paged_short_conv_inputs):
+@pytest.mark.parametrize(
+    "input_kwargs",
+    [
+        pytest.param({}, id="generic"),
+        pytest.param(
+            {"sequences": 8, "channels": 1536, "slots": 9},
+            id="blackwell",
+        ),
+    ],
+)
+def test_short_conv_decode_cuda_graph_replay(paged_short_conv_inputs, input_kwargs):
     """Capture the one-token step and replay it from a reset history."""
     torch.manual_seed(8)
-    x, weight, state, slots = paged_short_conv_inputs()
+    if input_kwargs and torch.cuda.get_device_capability()[0] != 10:
+        pytest.skip("Blackwell-specific decode schedule")
+    x, weight, state, slots = paged_short_conv_inputs(**input_kwargs)
     initial_state = state.clone()
     causal_conv1d_decode(x, weight, state, activation="silu", state_indices=slots)
     torch.cuda.synchronize()


### PR DESCRIPTION
Tune linear-attention decode kernels for Blackwell

## Human Note

## Agent note

Add narrowly scoped SM10 launch policies for the BF16 width-4 SiLU short-convolution decode,
scalar GDN decode with K=V=128, and packed one-token-per-sequence L2 normalization. The selectors
cover the measured local-head and batch regions while preserving Hopper and generic fallbacks.

The launch helpers carry one optional tuned architecture rather than interacting Hopper/Blackwell
booleans. Tests pin selector boundaries, paged-state mutation, strict fullgraph compilation, and
CUDA Graph replay through the public APIs.

## Performance

Five alternating 60-iteration confirmation rounds on B200 produced these median legacy/public
speedups:

| Operation | Discovery | Holdout |
| --- | ---: | ---: |
| short conv | 1.207x | 1.207x |
| scalar GDN | 1.170x | 1.173x |
| packed L2 | 1.100x | 1.160x |
| composed short conv + GDN | 1.203x | 1.200x |

## Test Plan

```bash
pytest -n 6 -q test/test_short_conv_cute.py
pytest -n 6 -q test/linear/test_gdn_decode.py test/linear/test_gdn_fused.py
pytest -n 6 -q test/test_kda_kernels.py test/test_kda_training_example.py
prek run --all-files
git diff --check
```
