### PR TITLE
Add native KDA context parallelism

### DIFF
--- a/attn_gym/linear/_delta_rule/cute/__init__.py
+++ b/attn_gym/linear/_delta_rule/cute/__init__.py
@@ -1,6 +1,6 @@
 """Native CuTeDSL kernels shared by delta-rule attention variants."""
 
-from .affine_summary_fwd import affine_summary_fwd
-from .affine_summary_rev import affine_summary_rev
+from .affine_summary_fwd import build_state_summary
+from .affine_summary_rev import build_state_grad_summary
 
-__all__ = ["affine_summary_fwd", "affine_summary_rev"]
+__all__ = ["build_state_grad_summary", "build_state_summary"]

--- a/attn_gym/linear/_delta_rule/cute/__init__.py
+++ b/attn_gym/linear/_delta_rule/cute/__init__.py
@@ -1,0 +1,6 @@
+"""Native CuTeDSL kernels shared by delta-rule attention variants."""
+
+from .affine_summary_fwd import affine_summary_fwd
+from .affine_summary_rev import affine_summary_rev
+
+__all__ = ["affine_summary_fwd", "affine_summary_rev"]

--- a/attn_gym/linear/_delta_rule/cute/affine_summary_fwd.py
+++ b/attn_gym/linear/_delta_rule/cute/affine_summary_fwd.py
@@ -985,7 +985,7 @@ def _compile_affine_summary(dtype_name: str, heads: int, state_bn: int):
     )
 
 
-def affine_summary_fwd(
+def build_state_summary(
     kg: torch.Tensor,
     w: torch.Tensor,
     u: torch.Tensor,
@@ -1009,9 +1009,9 @@ def affine_summary_fwd(
     """
     assert kg.ndim == 4, f"kg must be 4D [1, T, H, K], got shape {tuple(kg.shape)}"
     batch, tokens, heads, key_dim = kg.shape
-    assert batch == 1, f"affine_summary_fwd requires B=1, got B={batch}"
-    assert tokens > 0, "affine_summary_fwd requires at least one token"
-    assert key_dim == KEY_DIM, f"affine_summary_fwd requires K={KEY_DIM}, got {key_dim}"
+    assert batch == 1, f"build_state_summary requires B=1, got B={batch}"
+    assert tokens > 0, "build_state_summary requires at least one token"
+    assert key_dim == KEY_DIM, f"build_state_summary requires K={KEY_DIM}, got {key_dim}"
     assert w.shape == kg.shape, f"w must match kg shape {tuple(kg.shape)}, got {tuple(w.shape)}"
     assert u.shape == (1, tokens, heads, VAL_DIM), (
         f"u must have shape {(1, tokens, heads, VAL_DIM)}, got {tuple(u.shape)}"
@@ -1036,7 +1036,7 @@ def affine_summary_fwd(
     if isinstance(kg, FakeTensor):
         return out
 
-    assert kg.is_cuda, "affine_summary_fwd requires CUDA tensors"
+    assert kg.is_cuda, "build_state_summary requires CUDA tensors"
     for name, tensor in (("kg", kg), ("w", w), ("u", u), ("cumulative_gate", cumulative_gate)):
         assert tensor.device == kg.device, f"{name} must be on {kg.device}, got {tensor.device}"
         assert tensor.is_contiguous(), f"{name} must be contiguous, got strides {tensor.stride()}"
@@ -1055,7 +1055,7 @@ def affine_summary_fwd(
             dim=1,
         )
     assert not requires_int64_abi(kg, w, u, cumulative_gate, out), (
-        "affine_summary_fwd currently requires int32-addressable tensors"
+        "build_state_summary currently requires int32-addressable tensors"
     )
 
     # BN=32 is faster per CTA (measured ~1.5x vs BN=64 on GB200); fall back to

--- a/attn_gym/linear/_delta_rule/cute/affine_summary_fwd.py
+++ b/attn_gym/linear/_delta_rule/cute/affine_summary_fwd.py
@@ -1,0 +1,1067 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""CuTeDSL forward affine-summary kernel for delta-rule context parallelism.
+
+One local shard of a delta-rule sequence acts on the recurrent state as an affine
+map ``H_out = H_in @ A + B``. This kernel computes that summary directly from the
+shared per-chunk WY factors (``kg``, ``w``, ``u``, ``cumulative_gate`` as produced
+by ``chunk_kda_fwd_intra``) instead of running the full recurrence twice with
+zero/identity probe states (see ``examples/kda_context_parallel.py``).
+
+Math (K-first augmented state ``X`` of shape ``[K, V + K]``, fp32):
+
+    X = [0 | I]
+    per 64-token chunk c:
+        Tmp        = W[c] @ X                 # [BT, V + K]
+        Tmp[:, :V] = U[c] - Tmp[:, :V]
+        Tmp[:, V:] =      - Tmp[:, V:]
+        X          = diag(exp2(gk_last[c])) @ X + Kg[c]^T @ Tmp
+
+The output is the V-first packed transpose ``X^T`` of shape ``[H, V + K, K]``:
+rows ``[0:V]`` hold the state bias and rows ``[V:V+K]`` the state transition.
+These are distinct from KDA's token-token query/key matrix ``A``.
+
+Architecture (SM100 warp specialization, mirrors ``kda/bwd/cute/chunk_delta_h_bwd.py``):
+  - One CTA per (BN-column tile of the augmented state, head); 6 warps.
+  - CUDA warps (0-3) keep the fp32 ``[K, BN]`` state tile in registers across all
+    chunks and produce the two SMEM MMA B operands per chunk.
+  - Load warp (4) TMA-stages ``w``, ``kg^T``, ``u``, and the chunk-final gate row.
+  - MMA warp (5) issues two SS-mode UMMA groups per chunk into TMEM:
+      MMA1: W  @ X          -> wx  (BT=64, BN, K=128)
+      MMA2: Kg^T @ [U; -wx] -> kt  (K=128, BN, K=64)
+    ``U`` rides its own TMA ring straight into an MMA2 B-operand pass, so the
+    ``Kg^T @ U`` product runs off the serial recurrence chain; the CUDA warps
+    only split ``-wx`` for the remaining accumulate passes.
+
+The fp32-valued MMA B operands (state ``X`` and ``wx``) are split into hi/lo
+halves of the I/O dtype and accumulated in two UMMA passes. The A operands
+(``w``, ``kg``) and ``u`` retain their original bf16/fp16 storage.
+
+Limitations:
+  - B=1, dense complete chunks only (``T % 64 == 0``), fixed K=V=128, BT=64.
+  - Contiguous inputs with an int32-addressable ABI; SM100 (tcgen05) only.
+"""
+
+# NOTE: no `from __future__ import annotations` — cute.struct requires
+# eager-evaluated annotations.
+
+from enum import IntEnum
+from typing import NamedTuple
+
+import cutlass
+import cutlass.utils.blackwell_helpers as sm100_utils
+import torch
+import torch.nn.functional as F
+from cuda.bindings import driver as cuda
+from cutlass import cute, pipeline, utils
+from cutlass.cute.nvgpu import cpasync, tcgen05
+from cutlass.cute.runtime import make_fake_compact_tensor
+from cutlass.cute.typing import Float32, Int32, Int64
+from torch._subclasses.fake_tensor import FakeTensor
+
+from attn_gym._backends.cute import compile_tvm_ffi, get_device_properties, jit_cache
+from attn_gym._backends.cute.target import get_compile_target
+from attn_gym._backends.cute.utils import requires_int64_abi
+
+BT = 64  # chunk size
+KEY_DIM = 128
+VAL_DIM = 128
+SUMMARY_DIM = VAL_DIM + KEY_DIM  # V-first packed [bias; transition] rows
+DATA_ALIGN_BYTES = 16
+
+_IO_TYPE_NAMES = {torch.bfloat16: "bf16", torch.float16: "fp16"}
+_CUTE_IO_TYPES = {"bf16": cutlass.BFloat16, "fp16": cutlass.Float16}
+
+
+class WarpRole(IntEnum):
+    """Warp-role boundaries in the affine-summary kernel."""
+
+    CUDA = 0
+    LOAD = 4
+    MMA = 5
+    END = 6
+
+
+class TmaOp(NamedTuple):
+    """One TMA copy atom and its tensor-map descriptor."""
+
+    atom: cute.CopyAtom
+    desc: cute.Tensor
+
+
+class TmaOps(NamedTuple):
+    """TMA operations owned by the affine-summary kernel."""
+
+    w: TmaOp
+    kg: TmaOp
+    u: TmaOp
+    gk: TmaOp
+
+
+class Mmas(NamedTuple):
+    """Tensor-core operations owned by the MMA warp."""
+
+    wx: cute.TiledMma
+    kt: cute.TiledMma
+    ktu: cute.TiledMma
+
+
+class SmemLayouts(NamedTuple):
+    """Shared-memory layouts in their device-kernel construction order."""
+
+    w: cute.ComposedLayout
+    kg: cute.ComposedLayout
+    u: cute.ComposedLayout
+    xb: cute.ComposedLayout
+    xb_store: cute.ComposedLayout
+    tmpb: cute.ComposedLayout
+    tmpb_store: cute.ComposedLayout
+
+
+class _AffineSummaryFwdOp:
+    """Warp-specialized SM100 chunk recurrence over one augmented-state column tile.
+
+    The fp32 ``[K, BN]`` state slice persists in CUDA-warp registers; each chunk
+    snapshots it (and later ``Tmp``) into SMEM as hi/lo I/O-dtype halves feeding
+    two-pass SS-mode UMMAs.
+    """
+
+    CUDA_WARP_IDS = tuple(range(WarpRole.CUDA, WarpRole.LOAD))
+    WARP_SZ = cute.arch.WARP_SIZE
+    CTA_THREADS = WarpRole.END * WARP_SZ
+
+    def __init__(self, dtype_name: str, heads: int, state_bn: int):
+        assert state_bn in (32, 64), f"state_bn must be 32 or 64, got {state_bn}"
+        assert SUMMARY_DIM % state_bn == 0
+        self.dtype_name = dtype_name
+        self.io_type = _CUTE_IO_TYPES[dtype_name]
+        self.heads = heads
+        self.BN = state_bn
+
+        # MMA tile shapes (M, N, K).
+        # MMA1: w @ X -> wx — w is (BT, K) K-major, X is (K, BN) snapshot in SMEM.
+        self.wx_tile = (BT, self.BN, KEY_DIM)
+        # MMA2: kg^T @ Tmp -> kt — kg^T is (K, BT) MN-major, Tmp is (BT, BN) in SMEM.
+        self.kt_tile = (KEY_DIM, self.BN, BT)
+
+        # TMA pipeline depths. The recurrence is a serial latency chain, so
+        # shallow rings are enough for the loads to run ahead of it.
+        self.w_depth = 2
+        self.kg_depth = 2
+        self.u_depth = 2
+        self.gk_depth = 2
+
+        self.tmem_free_bar = pipeline.NamedBarrier(
+            barrier_id=2,
+            num_threads=self.CTA_THREADS,
+        )
+        self.align = 1024
+
+    def get_name(self) -> str:
+        """Return a stable profiler and artifact name for this specialization."""
+        return f"delta_affine_summary_fwd_h{self.heads}_bn{self.BN}_{self.dtype_name}"
+
+    # ------------------------------------------------------------------
+    # Host-side setup (__call__): GMEM views → MMA → TMA → SMEM → launch
+    # ------------------------------------------------------------------
+
+    @cute.jit
+    def __call__(
+        self,
+        mKg: cute.Tensor,
+        mW: cute.Tensor,
+        mU: cute.Tensor,
+        mG: cute.Tensor,
+        mOut: cute.Tensor,
+        stream: cuda.CUstream,
+    ):
+        """Launch one CTA per (augmented-state column tile, head)."""
+        # Re-rank the dense [1, T, H, D] inputs into the logical TMA views.
+        g_w = cute.make_tensor(
+            mW.iterator,
+            cute.group_modes(cute.select(mW.layout, mode=[1, 3, 2, 0]), 2, 4),
+        )
+        g_kgt = cute.make_tensor(
+            mKg.iterator,
+            cute.group_modes(cute.select(mKg.layout, mode=[3, 1, 2, 0]), 2, 4),
+        )
+        g_u_vt = cute.make_tensor(
+            mU.iterator,
+            cute.group_modes(cute.select(mU.layout, mode=[3, 1, 2, 0]), 2, 4),
+        )
+        g_gk_k = cute.make_tensor(
+            mG.iterator,
+            cute.group_modes(cute.select(mG.layout, mode=[3, 1, 2, 0]), 2, 4),
+        )
+
+        # --- MMA configurations (SS-mode: both operands from SMEM) ---
+        # MMA1: w (A, K-major) × X snapshot (B, K-major) → wx.
+        mma_wx = sm100_utils.make_trivial_tiled_mma(
+            self.io_type,
+            tcgen05.OperandMajorMode.K,
+            tcgen05.OperandMajorMode.K,
+            Float32,
+            tcgen05.CtaGroup.ONE,
+            self.wx_tile[:2],
+            tcgen05.OperandSource.SMEM,
+        )
+        # MMA2: kg^T (A, MN-major) × Tmp (B, K-major) → kt.
+        mma_kt = sm100_utils.make_trivial_tiled_mma(
+            self.io_type,
+            tcgen05.OperandMajorMode.MN,
+            tcgen05.OperandMajorMode.K,
+            Float32,
+            tcgen05.CtaGroup.ONE,
+            self.kt_tile[:2],
+            tcgen05.OperandSource.SMEM,
+        )
+        # MMA2a: kg^T (A, MN-major) × U (B, MN-major, V-contiguous TMA) → kt.
+        # Same accumulator tile as MMA2; only the B major mode differs.
+        mma_ktu = sm100_utils.make_trivial_tiled_mma(
+            self.io_type,
+            tcgen05.OperandMajorMode.MN,
+            tcgen05.OperandMajorMode.MN,
+            Float32,
+            tcgen05.CtaGroup.ONE,
+            self.kt_tile[:2],
+            tcgen05.OperandSource.SMEM,
+        )
+        self.tm_wx, self.tm_kt, self.tm_tot = self._plan_tmem(mma_wx, mma_kt)
+
+        # --- SMEM staged layouts ---
+        # A operands ride their TMA rings; B operands hold hi/lo halves of the
+        # fp32-valued state and Tmp tiles (2 "stages" = the two MMA passes).
+        s_w_staged = sm100_utils.make_smem_layout_a(
+            mma_wx,
+            self.wx_tile,
+            self.io_type,
+            self.w_depth,
+        )
+        s_xb_staged = sm100_utils.make_smem_layout_b(mma_wx, self.wx_tile, self.io_type, 2)
+        s_xb_store_staged = sm100_utils.make_smem_layout_epi(
+            self.io_type,
+            utils.LayoutEnum.COL_MAJOR,
+            (KEY_DIM, self.BN),
+            2,
+        )
+        s_kg_staged = sm100_utils.make_smem_layout_a(
+            mma_kt,
+            self.kt_tile,
+            self.io_type,
+            self.kg_depth,
+        )
+        # u is TMA-loaded directly into its own MMA2a B-operand ring.
+        s_u_staged = sm100_utils.make_smem_layout_b(
+            mma_ktu,
+            self.kt_tile,
+            self.io_type,
+            self.u_depth,
+        )
+        s_tmpb_staged = sm100_utils.make_smem_layout_b(mma_kt, self.kt_tile, self.io_type, 2)
+        s_tmpb_store_staged = sm100_utils.make_smem_layout_epi(
+            self.io_type,
+            utils.LayoutEnum.COL_MAJOR,
+            (BT, self.BN),
+            2,
+        )
+
+        clust_lay = cute.tiled_divide(
+            cute.make_layout((1, 1, 1)),
+            (mma_wx.thr_id.shape,),
+        )
+
+        # --- TMA descriptors ---
+        tma_ld = cpasync.CopyBulkTensorTileG2SOp(tcgen05.CtaGroup.ONE)
+        s_w_one = cute.select(s_w_staged, mode=[0, 1, 2])
+        atom_w, desc_w = cute.nvgpu.make_tiled_tma_atom_A(
+            tma_ld,
+            g_w,
+            s_w_one,
+            self.wx_tile,
+            mma_wx,
+            clust_lay.shape,
+        )
+        s_kg_one = cute.select(s_kg_staged, mode=[0, 1, 2])
+        atom_kg, desc_kg = cute.nvgpu.make_tiled_tma_atom_A(
+            tma_ld,
+            g_kgt,
+            s_kg_one,
+            self.kt_tile,
+            mma_kt,
+            clust_lay.shape,
+        )
+        s_u_one = cute.select(s_u_staged, mode=[0, 1, 2])
+        atom_u, desc_u = cute.nvgpu.make_tiled_tma_atom_B(
+            tma_ld,
+            g_u_vt,
+            s_u_one,
+            self.kt_tile,
+            mma_ktu,
+            clust_lay.shape,
+        )
+        # gk: K×1 fp32 tile (last timestep per chunk).
+        s_gk_2d = cute.make_layout((KEY_DIM, 1))
+        atom_gk, desc_gk = cpasync.make_tiled_tma_atom(
+            tma_ld,
+            g_gk_k,
+            s_gk_2d,
+            (KEY_DIM, 1),
+        )
+
+        self.w_bytes = cute.size_in_bytes(self.io_type, s_w_one)
+        self.kg_bytes = cute.size_in_bytes(self.io_type, s_kg_one)
+        self.u_bytes = cute.size_in_bytes(self.io_type, s_u_one)
+        self.gk_bytes = cute.size_in_bytes(Float32, s_gk_2d)
+
+        io_type = self.io_type
+        align = self.align
+
+        @cute.struct
+        class Shared:
+            bar_w: cute.struct.MemRange[Int64, self.w_depth * 2]
+            bar_kg: cute.struct.MemRange[Int64, self.kg_depth * 2]
+            bar_u: cute.struct.MemRange[Int64, self.u_depth * 2]
+            bar_gk: cute.struct.MemRange[Int64, self.gk_depth * 2]
+            bar_xb: cute.struct.MemRange[Int64, 1 * 2]
+            bar_tmpb: cute.struct.MemRange[Int64, 1 * 2]
+            bar_wx: cute.struct.MemRange[Int64, 1 * 2]
+            bar_kt: cute.struct.MemRange[Int64, 1 * 2]
+            tmem_buf: Int32
+            sW: cute.struct.Align[cute.struct.MemRange[io_type, cute.cosize(s_w_staged)], align]
+            sKg: cute.struct.Align[cute.struct.MemRange[io_type, cute.cosize(s_kg_staged)], align]
+            sXb: cute.struct.Align[cute.struct.MemRange[io_type, cute.cosize(s_xb_staged)], align]
+            sTmpb: cute.struct.Align[
+                cute.struct.MemRange[io_type, cute.cosize(s_tmpb_staged)], align
+            ]
+            sU: cute.struct.Align[cute.struct.MemRange[io_type, cute.cosize(s_u_staged)], align]
+            sGK: cute.struct.Align[cute.struct.MemRange[Float32, KEY_DIM * self.gk_depth], 128]
+
+        self.shared_type = Shared
+
+        num_chunks = Int32(cute.size(mW.shape[1])) // BT
+        self.kernel.set_name_prefix(self.get_name())
+        self.kernel(
+            Mmas(mma_wx, mma_kt, mma_ktu),
+            TmaOps(
+                TmaOp(atom_w, desc_w),
+                TmaOp(atom_kg, desc_kg),
+                TmaOp(atom_u, desc_u),
+                TmaOp(atom_gk, desc_gk),
+            ),
+            mOut,
+            SmemLayouts(
+                s_w_staged,
+                s_kg_staged,
+                s_u_staged,
+                s_xb_staged,
+                s_xb_store_staged,
+                s_tmpb_staged,
+                s_tmpb_store_staged,
+            ),
+            num_chunks,
+        ).launch(
+            grid=(SUMMARY_DIM // self.BN, self.heads, 1),
+            block=(self.CTA_THREADS, 1, 1),
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
+
+    def _plan_tmem(self, mma_wx: cute.TiledMma, mma_kt: cute.TiledMma) -> tuple[int, int, int]:
+        """Assign disjoint TMEM column regions to the two accumulators."""
+        wx_shape = mma_wx.partition_shape_C(self.wx_tile[:2])
+        n_wx = tcgen05.find_tmem_tensor_col_offset(
+            mma_wx.make_fragment_C(cute.append(wx_shape, 1))
+        )
+        kt_shape = mma_kt.partition_shape_C(self.kt_tile[:2])
+        n_kt = tcgen05.find_tmem_tensor_col_offset(
+            mma_kt.make_fragment_C(cute.append(kt_shape, 1))
+        )
+        raw = n_wx + n_kt
+        total = 32
+        while total < raw:
+            total *= 2
+        assert total <= 512, f"TMEM overflow: {total}>512"
+        return 0, n_wx, total
+
+    # ------------------------------------------------------------------
+    # Warp roles
+    # ------------------------------------------------------------------
+
+    @cute.jit
+    def run_load(
+        self,
+        head,
+        col_tile,
+        is_value,
+        num_chunks,
+        tma,
+        mma_wx,
+        mma_kt,
+        mma_ktu,
+        sW,
+        sKg,
+        sU,
+        gk_3d,
+        pw_P,
+        pkg_P,
+        pu_P,
+        pgk_P,
+    ):
+        """Own the per-chunk TMA G2S loads for w, kg^T, u, and the gate row."""
+        batch = Int32(0)
+        tWs, tWg = self._part_a(tma.w.atom, tma.w.desc, sW, self.wx_tile, mma_wx, batch, head)
+        tKgs, tKgg = self._part_a(tma.kg.atom, tma.kg.desc, sKg, self.kt_tile, mma_kt, batch, head)
+        sUp, gUp = self._part_b(tma.u.atom, tma.u.desc, sU, self.kt_tile, mma_ktu, batch, head)
+        gGK_l = tma.gk.desc[None, None, (head, batch)]
+        sGKp, gGKp = self._part_epi(tma.gk.atom, gGK_l, (KEY_DIM, 1), gk_3d)
+
+        for ct in cutlass.range(0, num_chunks, unroll=0):
+            wh = pw_P.acquire_and_advance()
+            cute.copy(
+                atom=tma.w.atom,
+                src=tWg[None, ct, 0],
+                dst=tWs[None, wh.index],
+                tma_bar_ptr=wh.barrier,
+            )
+            kgh = pkg_P.acquire_and_advance()
+            cute.copy(
+                atom=tma.kg.atom,
+                src=tKgg[None, 0, ct],
+                dst=tKgs[None, kgh.index],
+                tma_bar_ptr=kgh.barrier,
+            )
+            if is_value:
+                uh = pu_P.acquire_and_advance()
+                cute.copy(
+                    atom=tma.u.atom,
+                    src=gUp[None, col_tile, ct],
+                    dst=sUp[None, uh.index],
+                    tma_bar_ptr=uh.barrier,
+                )
+            gkh = pgk_P.acquire_and_advance()
+            cute.copy(
+                atom=tma.gk.atom,
+                src=gGKp[(None, 0, ct * BT + BT - 1)],
+                dst=sGKp[None, gkh.index],
+                tma_bar_ptr=gkh.barrier,
+            )
+
+    @cute.jit
+    def run_mma(
+        self,
+        is_value,
+        num_chunks,
+        mma_wx,
+        mma_kt,
+        mma_ktu,
+        t_wx_acc,
+        t_w_a,
+        t_xb_b,
+        t_kt_acc,
+        t_kg_a,
+        t_kg_au,
+        t_u_b,
+        t_tmpb_b,
+        pw_C,
+        pkg_C,
+        pu_C,
+        pxb_C,
+        ptmpb_C,
+        pwx_P,
+        pkt_P,
+    ):
+        """Consume operand stages and produce the two TMEM results per chunk.
+
+        The kt accumulator gathers ``Kg^T @ U`` (value tiles, straight from the
+        TMA ring, off the recurrence critical path) plus two hi/lo accumulate
+        passes over ``Kg^T @ (-wx)``; MMA1 likewise runs two passes over the
+        hi/lo state snapshot, recovering ~fp32 operand precision.
+        """
+        for _ct in cutlass.range(0, num_chunks, unroll=0):
+            # --- MMA2a: kg^T(SMEM A) × U(SMEM B) → kt(TMEM), value tiles only ---
+            kgh = pkg_C.wait_and_advance()
+            ktd = pkt_P.acquire_and_advance()
+            if is_value:
+                uh = pu_C.wait_and_advance()
+                for kp in cutlass.range_constexpr(cute.size(t_kg_au, mode=[2])):
+                    mma_ktu.set(tcgen05.Field.ACCUMULATE, cutlass.Boolean(kp != 0))
+                    cute.gemm(
+                        mma_ktu,
+                        t_kt_acc[None, None, None, ktd.index],
+                        t_kg_au[None, None, kp, kgh.index],
+                        t_u_b[None, None, kp, uh.index],
+                        t_kt_acc[None, None, None, ktd.index],
+                    )
+                uh.release()
+
+            # --- MMA1: w(SMEM A) × X snapshot(SMEM B) → wx(TMEM) ---
+            xbh = pxb_C.wait_and_advance()
+            wh = pw_C.wait_and_advance()
+            wxd = pwx_P.acquire_and_advance()
+            for split in cutlass.range_constexpr(2):
+                for kp in cutlass.range_constexpr(cute.size(t_w_a, mode=[2])):
+                    mma_wx.set(tcgen05.Field.ACCUMULATE, cutlass.Boolean(split != 0 or kp != 0))
+                    cute.gemm(
+                        mma_wx,
+                        t_wx_acc[None, None, None, wxd.index],
+                        t_w_a[None, None, kp, wh.index],
+                        t_xb_b[None, None, kp, split],
+                        t_wx_acc[None, None, None, wxd.index],
+                    )
+            wxd.commit()
+            wh.release()
+            xbh.release()
+
+            # --- MMA2b: kg^T(SMEM A) × -wx hi/lo(SMEM B) → kt(TMEM) ---
+            tmpbh = ptmpb_C.wait_and_advance()
+            for split in cutlass.range_constexpr(2):
+                for kp in cutlass.range_constexpr(cute.size(t_kg_a, mode=[2])):
+                    # The first pass overwrites unless MMA2a already seeded kt.
+                    first = split == 0 and kp == 0
+                    mma_kt.set(tcgen05.Field.ACCUMULATE, is_value if first else True)
+                    cute.gemm(
+                        mma_kt,
+                        t_kt_acc[None, None, None, ktd.index],
+                        t_kg_a[None, None, kp, kgh.index],
+                        t_tmpb_b[None, None, kp, split],
+                        t_kt_acc[None, None, None, ktd.index],
+                    )
+            ktd.commit()
+            kgh.release()
+            tmpbh.release()
+
+    @cute.jit
+    def run_state(
+        self,
+        head,
+        col_base,
+        num_chunks,
+        mOut,
+        t_wx_acc,
+        t_kt_acc,
+        sXb_store,
+        sTmpb_store,
+        gk_buf,
+        pxb_P,
+        ptmpb_P,
+        pgk_C,
+        pwx_C,
+        pkt_C,
+    ):
+        """Own the fp32 state registers; produce B operands and fold in results."""
+        tid, _, _ = cute.arch.thread_idx()
+        local_tid = tid % (self.WARP_SZ * len(self.CUDA_WARP_IDS))
+
+        # --- T2R setup: read MMA1 (wx) accumulator (BT, BN fp32) from TMEM ---
+        t2r_wx_atom = cute.make_copy_atom(
+            tcgen05.Ld16x256bOp(tcgen05.Repetition(self.BN // 8), tcgen05.Pack.NONE),
+            Float32,
+        )
+        wx_flat = t_wx_acc[((None, None), 0, 0, None)]
+        tc_t2r_wx = tcgen05.make_tmem_copy(t2r_wx_atom, wx_flat[(None, None, 0)])
+        sl_wx = tc_t2r_wx.get_slice(local_tid)
+        p_t_wx = sl_wx.partition_S(wx_flat)
+
+        # --- T2R setup: read MMA2 (kt) accumulator (K, BN fp32) from TMEM ---
+        t2r_kt_atom = cute.make_copy_atom(
+            tcgen05.Ld16x256bOp(tcgen05.Repetition(self.BN // 8), tcgen05.Pack.NONE),
+            Float32,
+        )
+        kt_flat = t_kt_acc[((None, None), 0, 0, None)]
+        tc_t2r_kt = tcgen05.make_tmem_copy(t2r_kt_atom, kt_flat[(None, None, 0)])
+        sl_kt = tc_t2r_kt.get_slice(local_tid)
+        p_t_kt = sl_kt.partition_S(kt_flat)
+
+        # Identity tensors provide both coordinate maps and fragment shapes.
+        coords_tv = sl_wx.partition_D(cute.make_identity_tensor((BT, self.BN)))
+        coords_kv = sl_kt.partition_D(cute.make_identity_tensor((KEY_DIM, self.BN)))
+
+        # R2S X snapshot → sXb (COL_MAJOR, partition matches T2R kt).
+        r2s_atom_xb = sm100_utils.get_smem_store_op(
+            utils.LayoutEnum.COL_MAJOR,
+            self.io_type,
+            Float32,
+            tc_t2r_kt,
+        )
+        tc_r2s_xb = cute.make_tiled_copy_D(r2s_atom_xb, tc_t2r_kt)
+        thr_r2s_xb = tc_r2s_xb.get_slice(local_tid)
+
+        # R2S Tmp → sTmpb (COL_MAJOR, partition matches T2R wx).
+        r2s_atom_tmpb = sm100_utils.get_smem_store_op(
+            utils.LayoutEnum.COL_MAJOR,
+            self.io_type,
+            Float32,
+            tc_t2r_wx,
+        )
+        tc_r2s_tmpb = cute.make_tiled_copy_D(r2s_atom_tmpb, tc_t2r_wx)
+        thr_r2s_tmpb = tc_r2s_tmpb.get_slice(local_tid)
+
+        # X starts as this tile's slice of [0 | I]: value-tile columns are zero
+        # and identity-tile column (col_base + nc) carries a one at key row kc.
+        st = cute.make_rmem_tensor(coords_kv.shape, Float32)
+        for ei in cutlass.range(cute.size(st), unroll_full=True):
+            kc, nc = coords_kv[ei]
+            value = Float32(0.0)
+            if col_base + nc == VAL_DIM + kc:
+                value = Float32(1.0)
+            st[ei] = value
+
+        for _ct in cutlass.range(0, num_chunks, unroll=0):
+            # ---- Phase 1: R2S X hi/lo → sXb (B operand for MMA1) ----
+            xbh = pxb_P.acquire_and_advance()
+            st_hi = cute.make_rmem_tensor(st.shape, self.io_type)
+            st_hi.store(st.load().to(self.io_type))
+            st_lo = cute.make_rmem_tensor(st.shape, self.io_type)
+            st_lo.store((st.load() - st_hi.load().to(Float32)).to(self.io_type))
+            cute.copy(
+                tc_r2s_xb,
+                tc_r2s_xb.retile(st_hi),
+                thr_r2s_xb.partition_D(sXb_store[(None, None, 0)]),
+            )
+            cute.copy(
+                tc_r2s_xb,
+                tc_r2s_xb.retile(st_lo),
+                thr_r2s_xb.partition_D(sXb_store[(None, None, 1)]),
+            )
+            cute.arch.fence_proxy("async.shared", space="cta")
+            xbh.commit()
+
+            # ---- Phase 2: T2R wx = W @ X ----
+            wxh = pwx_C.wait_and_advance()
+            wx_reg = cute.make_rmem_tensor(coords_tv.shape, Float32)
+            cute.copy(tc_t2r_wx, p_t_wx[(None, None, None, wxh.index)], wx_reg)
+            cute.arch.fence_view_async_tmem_load()
+            wxh.release()
+
+            # ---- Phase 3: R2S -wx hi/lo (the U term accumulates via MMA2a) ----
+            tmpbh = ptmpb_P.acquire_and_advance()
+            tmp = cute.make_rmem_tensor(coords_tv.shape, Float32)
+            for ei in cutlass.range_constexpr(cute.size(tmp)):
+                tmp[ei] = Float32(0.0) - wx_reg[ei]
+            tmp_hi = cute.make_rmem_tensor(tmp.shape, self.io_type)
+            tmp_hi.store(tmp.load().to(self.io_type))
+            tmp_lo = cute.make_rmem_tensor(tmp.shape, self.io_type)
+            tmp_lo.store((tmp.load() - tmp_hi.load().to(Float32)).to(self.io_type))
+            cute.copy(
+                tc_r2s_tmpb,
+                tc_r2s_tmpb.retile(tmp_hi),
+                thr_r2s_tmpb.partition_D(sTmpb_store[(None, None, 0)]),
+            )
+            cute.copy(
+                tc_r2s_tmpb,
+                tc_r2s_tmpb.retile(tmp_lo),
+                thr_r2s_tmpb.partition_D(sTmpb_store[(None, None, 1)]),
+            )
+            cute.arch.fence_proxy("async.shared", space="cta")
+            tmpbh.commit()
+
+            # ---- Phase 4: decay X, then add kt = Kg^T @ Tmp ----
+            gkh = pgk_C.wait_and_advance()
+            for ei in cutlass.range(cute.size(st), unroll_full=True):
+                kc, nc = coords_kv[ei]
+                st[ei] = st[ei] * cute.math.exp2(gk_buf[kc, gkh.index], fastmath=True)
+            gkh.release()
+
+            kth = pkt_C.wait_and_advance()
+            kt_reg = cute.make_rmem_tensor(coords_kv.shape, Float32)
+            cute.copy(tc_t2r_kt, p_t_kt[(None, None, None, kth.index)], kt_reg)
+            cute.arch.fence_view_async_tmem_load()
+            kth.release()
+            for ei in cutlass.range_constexpr(cute.size(st)):
+                st[ei] = st[ei] + kt_reg[ei]
+
+        # Epilogue: store the V-first packed transpose out[h, col, k] = X[k, col].
+        for ei in cutlass.range(cute.size(st), unroll_full=True):
+            kc, nc = coords_kv[ei]
+            mOut[head, col_base + nc, kc] = st[ei]
+
+    # ------------------------------------------------------------------
+    # Device kernel
+    # ------------------------------------------------------------------
+
+    @cute.kernel
+    def kernel(
+        self,
+        mmas: Mmas,
+        tma: TmaOps,
+        mOut: cute.Tensor,
+        smem_layouts: SmemLayouts,
+        num_chunks: Int32,
+    ):
+        mma_wx, mma_kt, mma_ktu = mmas
+        (
+            s_w_staged,
+            s_kg_staged,
+            s_u_staged,
+            s_xb_staged,
+            s_xb_store_staged,
+            s_tmpb_staged,
+            s_tmpb_store_staged,
+        ) = smem_layouts
+        warp_id = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+
+        if warp_id == WarpRole.LOAD:
+            cpasync.prefetch_descriptor(tma.w.atom)
+            cpasync.prefetch_descriptor(tma.kg.atom)
+            cpasync.prefetch_descriptor(tma.u.atom)
+            cpasync.prefetch_descriptor(tma.gk.atom)
+
+        sa = utils.SmemAllocator()
+        sm = sa.allocate(self.shared_type)
+
+        gk_3d = sm.sGK.get_tensor(
+            cute.make_layout(
+                (KEY_DIM, 1, self.gk_depth),
+                stride=(1, KEY_DIM, KEY_DIM),
+            )
+        )
+        gk_buf = gk_3d[(None, 0, None)]
+
+        # #
+        # Pipeline creation
+        #
+        n_cuda = self.WARP_SZ * len(self.CUDA_WARP_IDS)
+
+        # w → MMA1 (TmaUmma)
+        pw_P, pw_C = pipeline.PipelineTmaUmma.create(
+            num_stages=self.w_depth,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            tx_count=self.w_bytes,
+            barrier_storage=sm.bar_w.data_ptr(),
+        ).make_participants()
+
+        # kg^T → MMA2 (TmaUmma)
+        pkg_P, pkg_C = pipeline.PipelineTmaUmma.create(
+            num_stages=self.kg_depth,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            tx_count=self.kg_bytes,
+            barrier_storage=sm.bar_kg.data_ptr(),
+        ).make_participants()
+
+        # u → MMA2 (TmaUmma)
+        pu_P, pu_C = pipeline.PipelineTmaUmma.create(
+            num_stages=self.u_depth,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            tx_count=self.u_bytes,
+            barrier_storage=sm.bar_u.data_ptr(),
+        ).make_participants()
+
+        # gk → CUDA warps (TmaAsync). Each consuming warp contributes one
+        # elected-lane arrival, so the group count is the warp count, not 128 threads.
+        pgk_P, pgk_C = pipeline.PipelineTmaAsync.create(
+            num_stages=self.gk_depth,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, len(self.CUDA_WARP_IDS)
+            ),
+            tx_count=self.gk_bytes,
+            barrier_storage=sm.bar_gk.data_ptr(),
+        ).make_participants()
+
+        # X snapshot → MMA1 (AsyncUmma, 1 stage covering both hi/lo halves)
+        pxb_P, pxb_C = pipeline.PipelineAsyncUmma.create(
+            num_stages=1,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, n_cuda),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            barrier_storage=sm.bar_xb.data_ptr(),
+        ).make_participants()
+
+        # Tmp → MMA2 (AsyncUmma, 1 stage covering both hi/lo halves)
+        ptmpb_P, ptmpb_C = pipeline.PipelineAsyncUmma.create(
+            num_stages=1,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, n_cuda),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            barrier_storage=sm.bar_tmpb.data_ptr(),
+        ).make_participants()
+
+        # MMA1 done → CUDA (UmmaAsync)
+        pwx_P, pwx_C = pipeline.PipelineUmmaAsync.create(
+            num_stages=1,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, n_cuda),
+            barrier_storage=sm.bar_wx.data_ptr(),
+        ).make_participants()
+
+        # MMA2 done → CUDA (UmmaAsync)
+        pkt_P, pkt_C = pipeline.PipelineUmmaAsync.create(
+            num_stages=1,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, n_cuda),
+            barrier_storage=sm.bar_kt.data_ptr(),
+        ).make_participants()
+
+        # #
+        # TMEM allocation
+        #
+        tmem_bar = pipeline.NamedBarrier(barrier_id=1, num_threads=self.CTA_THREADS)
+        tmem = utils.TmemAllocator(
+            sm.tmem_buf,
+            barrier_for_retrieve=tmem_bar,
+            allocator_warp_id=WarpRole.LOAD,
+        )
+        tmem.allocate(self.tm_tot)
+        tmem.wait_for_alloc()
+        tp = tmem.retrieve_ptr(Float32)
+
+        # #
+        # SMEM view tensors and MMA fragments
+        #
+        sW = sm.sW.get_tensor(s_w_staged.outer, swizzle=s_w_staged.inner)
+        sKg = sm.sKg.get_tensor(s_kg_staged.outer, swizzle=s_kg_staged.inner)
+        sU = sm.sU.get_tensor(s_u_staged.outer, swizzle=s_u_staged.inner)
+        sXb = sm.sXb.get_tensor(s_xb_staged.outer, swizzle=s_xb_staged.inner)
+        sXb_store = sm.sXb.get_tensor(s_xb_store_staged.outer, swizzle=s_xb_store_staged.inner)
+        sTmpb = sm.sTmpb.get_tensor(s_tmpb_staged.outer, swizzle=s_tmpb_staged.inner)
+        sTmpb_store = sm.sTmpb.get_tensor(
+            s_tmpb_store_staged.outer, swizzle=s_tmpb_store_staged.inner
+        )
+
+        t_w_a = mma_wx.make_fragment_A(sW)
+        t_xb_b = mma_wx.make_fragment_B(sXb)
+        wx_shape = mma_wx.partition_shape_C(self.wx_tile[:2])
+        wx_fk = mma_wx.make_fragment_C(cute.append(wx_shape, 1))
+        t_wx_acc = cute.make_tensor(tp + self.tm_wx, wx_fk.layout)
+
+        t_kg_a = mma_kt.make_fragment_A(sKg)
+        t_kg_au = mma_ktu.make_fragment_A(sKg)
+        t_u_b = mma_ktu.make_fragment_B(sU)
+        t_tmpb_b = mma_kt.make_fragment_B(sTmpb)
+        kt_shape = mma_kt.partition_shape_C(self.kt_tile[:2])
+        kt_fk = mma_kt.make_fragment_C(cute.append(kt_shape, 1))
+        t_kt_acc = cute.make_tensor(tp + self.tm_kt, kt_fk.layout)
+
+        # #
+        # Role dispatch: one CTA owns one (column tile, head) state slice.
+        #
+        col_tile, head, _ = cute.arch.block_idx()
+        col_base = col_tile * self.BN
+        is_value = col_base < VAL_DIM
+
+        if warp_id in self.CUDA_WARP_IDS:
+            self.run_state(
+                head=head,
+                col_base=col_base,
+                num_chunks=num_chunks,
+                mOut=mOut,
+                t_wx_acc=t_wx_acc,
+                t_kt_acc=t_kt_acc,
+                sXb_store=sXb_store,
+                sTmpb_store=sTmpb_store,
+                gk_buf=gk_buf,
+                pxb_P=pxb_P,
+                ptmpb_P=ptmpb_P,
+                pgk_C=pgk_C,
+                pwx_C=pwx_C,
+                pkt_C=pkt_C,
+            )
+        elif warp_id == WarpRole.LOAD:
+            self.run_load(
+                head=head,
+                col_tile=col_tile,
+                is_value=is_value,
+                num_chunks=num_chunks,
+                tma=tma,
+                mma_wx=mma_wx,
+                mma_kt=mma_kt,
+                mma_ktu=mma_ktu,
+                sW=sW,
+                sKg=sKg,
+                sU=sU,
+                gk_3d=gk_3d,
+                pw_P=pw_P,
+                pkg_P=pkg_P,
+                pu_P=pu_P,
+                pgk_P=pgk_P,
+            )
+        elif warp_id == WarpRole.MMA:
+            self.run_mma(
+                is_value=is_value,
+                num_chunks=num_chunks,
+                mma_wx=mma_wx,
+                mma_kt=mma_kt,
+                mma_ktu=mma_ktu,
+                t_wx_acc=t_wx_acc,
+                t_w_a=t_w_a,
+                t_xb_b=t_xb_b,
+                t_kt_acc=t_kt_acc,
+                t_kg_a=t_kg_a,
+                t_kg_au=t_kg_au,
+                t_u_b=t_u_b,
+                t_tmpb_b=t_tmpb_b,
+                pw_C=pw_C,
+                pkg_C=pkg_C,
+                pu_C=pu_C,
+                pxb_C=pxb_C,
+                ptmpb_C=ptmpb_C,
+                pwx_P=pwx_P,
+                pkt_P=pkt_P,
+            )
+
+        # TMEM teardown (all warps)
+        tmem.relinquish_alloc_permit()
+        self.tmem_free_bar.arrive_and_wait()
+        tmem.free(tp)
+
+    # ------------------------------------------------------------------
+    # TMA partition helpers
+    # ------------------------------------------------------------------
+
+    @cute.jit
+    def _part_a(self, atom, desc, smem, tile, mma, batch, head):
+        """Partition an A operand for TMA copy (SS-mode)."""
+        g = cute.local_tile(desc, cute.slice_(tile, (None, 0, None)), (None, None, (head, batch)))
+        part = mma.get_slice(0).partition_A(g)
+        return cpasync.tma_partition(
+            atom,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(smem, 0, 3),
+            cute.group_modes(part, 0, 3),
+        )
+
+    @cute.jit
+    def _part_b(self, atom, desc, smem, tile, mma, batch, head):
+        """Partition a TMA tensor as an MMA B operand."""
+        g = cute.local_tile(desc, cute.slice_(tile, (0, None, None)), (None, None, (head, batch)))
+        part = mma.get_slice(0).partition_B(g)
+        return cpasync.tma_partition(
+            atom,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(smem, 0, 3),
+            cute.group_modes(part, 0, 3),
+        )
+
+    @cute.jit
+    def _part_epi(self, atom, g_mnl, tile, s_buf):
+        """Partition for epilogue-style TMA."""
+        g_div = cute.flat_divide(g_mnl, tile)
+        sg = cute.group_modes(s_buf, 0, 2)
+        gg = cute.group_modes(g_div, 0, 2)
+        return cpasync.tma_partition(atom, 0, cute.make_layout(1), sg, gg)
+
+
+@jit_cache
+def _compile_affine_summary(dtype_name: str, heads: int, state_bn: int):
+    """Compile one dtype/head-count specialization from fake tensors."""
+    target = get_compile_target()
+    if target.device_type != "cuda" or target.capability is None or target.capability < (10, 0):
+        raise ValueError(
+            f"affine_summary_fwd requires an SM100 (CUDA capability >= 10.0) target; "
+            f"got target={target}"
+        )
+    tokens = cute.sym_int(divisibility=BT)
+
+    def factor(dtype, last_dim: int):
+        return make_fake_compact_tensor(
+            dtype,
+            (1, tokens, heads, last_dim),
+            stride_order=(3, 2, 1, 0),
+            assumed_align=DATA_ALIGN_BYTES,
+        )
+
+    io_dtype = _CUTE_IO_TYPES[dtype_name]
+    out = make_fake_compact_tensor(
+        Float32,
+        (heads, SUMMARY_DIM, KEY_DIM),
+        stride_order=(2, 1, 0),
+        assumed_align=DATA_ALIGN_BYTES,
+    )
+    return compile_tvm_ffi(
+        _AffineSummaryFwdOp(dtype_name, heads, state_bn),
+        factor(io_dtype, KEY_DIM),
+        factor(io_dtype, KEY_DIM),
+        factor(io_dtype, VAL_DIM),
+        factor(Float32, KEY_DIM),
+        out,
+    )
+
+
+def affine_summary_fwd(
+    kg: torch.Tensor,
+    w: torch.Tensor,
+    u: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+) -> torch.Tensor:
+    """Compute one shard's packed affine state summary from its WY chunk factors.
+
+    Args:
+        kg: Gated keys ``k * exp2(gk_last - gk)``, shape ``[1, T, H, 128]``,
+            bf16 or fp16.
+        w: WY factor ``w``, same shape and dtype as ``kg``.
+        u: WY pseudo-values ``u``, shape ``[1, T, H, 128]``, same dtype as ``kg``.
+        cumulative_gate: Cumulative log2 gates, shape ``[1, T, H, 128]``, fp32.
+
+    Returns:
+        FP32 tensor of shape ``[H, 256, 128]``, V-first packed as state bias then
+        state transition for ``H_out = H_in @ transition + bias``.
+
+    Supported scope: B=1, fixed K=V=128 and BT=64, contiguous int32-addressable
+    inputs, SM100. A partial final chunk is neutral-padded by the wrapper.
+    """
+    assert kg.ndim == 4, f"kg must be 4D [1, T, H, K], got shape {tuple(kg.shape)}"
+    batch, tokens, heads, key_dim = kg.shape
+    assert batch == 1, f"affine_summary_fwd requires B=1, got B={batch}"
+    assert tokens > 0, "affine_summary_fwd requires at least one token"
+    assert key_dim == KEY_DIM, f"affine_summary_fwd requires K={KEY_DIM}, got {key_dim}"
+    assert w.shape == kg.shape, f"w must match kg shape {tuple(kg.shape)}, got {tuple(w.shape)}"
+    assert u.shape == (1, tokens, heads, VAL_DIM), (
+        f"u must have shape {(1, tokens, heads, VAL_DIM)}, got {tuple(u.shape)}"
+    )
+    assert cumulative_gate.shape == kg.shape, (
+        f"cumulative_gate must match kg shape {tuple(kg.shape)}, "
+        f"got {tuple(cumulative_gate.shape)}"
+    )
+    assert kg.dtype in _IO_TYPE_NAMES, f"kg dtype must be bf16 or fp16, got {kg.dtype}"
+    assert w.dtype == kg.dtype and u.dtype == kg.dtype, (
+        f"kg/w/u dtypes must match, got {kg.dtype}/{w.dtype}/{u.dtype}"
+    )
+    assert cumulative_gate.dtype == torch.float32, (
+        f"cumulative_gate must be fp32, got {cumulative_gate.dtype}"
+    )
+
+    out = torch.empty(
+        (heads, SUMMARY_DIM, KEY_DIM),
+        dtype=torch.float32,
+        device=kg.device,
+    )
+    if isinstance(kg, FakeTensor):
+        return out
+
+    assert kg.is_cuda, "affine_summary_fwd requires CUDA tensors"
+    for name, tensor in (("kg", kg), ("w", w), ("u", u), ("cumulative_gate", cumulative_gate)):
+        assert tensor.device == kg.device, f"{name} must be on {kg.device}, got {tensor.device}"
+        assert tensor.is_contiguous(), f"{name} must be contiguous, got strides {tensor.stride()}"
+        assert tensor.data_ptr() % DATA_ALIGN_BYTES == 0, (
+            f"{name} data pointer must be {DATA_ALIGN_BYTES}-byte aligned"
+        )
+    pad = (-tokens) % BT
+    if pad:
+        padding = (0, 0, 0, 0, 0, pad)
+        kg, w, u = (F.pad(tensor, padding) for tensor in (kg, w, u))
+        cumulative_gate = torch.cat(
+            (
+                cumulative_gate,
+                cumulative_gate[:, -1:].expand(-1, pad, -1, -1),
+            ),
+            dim=1,
+        )
+    assert not requires_int64_abi(kg, w, u, cumulative_gate, out), (
+        "affine_summary_fwd currently requires int32-addressable tensors"
+    )
+
+    # BN=32 is faster per CTA (measured ~1.5x vs BN=64 on GB200); fall back to
+    # BN=64 only when the extra column tiles would spill past one CTA wave and
+    # serialize whole recurrence chains.
+    sm_count = get_device_properties(kg.device).multi_processor_count
+    state_bn = 32 if heads * (SUMMARY_DIM // 32) <= sm_count else 64
+    compiled = _compile_affine_summary(_IO_TYPE_NAMES[kg.dtype], heads, state_bn)
+    compiled(kg.detach(), w.detach(), u.detach(), cumulative_gate.detach(), out)
+    return out

--- a/attn_gym/linear/_delta_rule/cute/affine_summary_fwd.py
+++ b/attn_gym/linear/_delta_rule/cute/affine_summary_fwd.py
@@ -77,6 +77,20 @@ _IO_TYPE_NAMES = {torch.bfloat16: "bf16", torch.float16: "fp16"}
 _CUTE_IO_TYPES = {"bf16": cutlass.BFloat16, "fp16": cutlass.Float16}
 
 
+@cute.jit
+def _sequence_feature_head_batch_view(tensor):
+    """Re-rank ``[B,T,H,D]`` as ``[T,D,(H,B)]`` for a TMA operand."""
+    layout = cute.group_modes(cute.select(tensor.layout, mode=[1, 3, 2, 0]), 2, 4)
+    return cute.make_tensor(tensor.iterator, layout)
+
+
+@cute.jit
+def _feature_sequence_head_batch_view(tensor):
+    """Re-rank ``[B,T,H,D]`` as ``[D,T,(H,B)]`` for a TMA operand."""
+    layout = cute.group_modes(cute.select(tensor.layout, mode=[3, 1, 2, 0]), 2, 4)
+    return cute.make_tensor(tensor.iterator, layout)
+
+
 class WarpRole(IntEnum):
     """Warp-role boundaries in the affine-summary kernel."""
 
@@ -181,22 +195,10 @@ class _AffineSummaryFwdOp:
     ):
         """Launch one CTA per (augmented-state column tile, head)."""
         # Re-rank the dense [1, T, H, D] inputs into the logical TMA views.
-        g_w = cute.make_tensor(
-            mW.iterator,
-            cute.group_modes(cute.select(mW.layout, mode=[1, 3, 2, 0]), 2, 4),
-        )
-        g_kgt = cute.make_tensor(
-            mKg.iterator,
-            cute.group_modes(cute.select(mKg.layout, mode=[3, 1, 2, 0]), 2, 4),
-        )
-        g_u_vt = cute.make_tensor(
-            mU.iterator,
-            cute.group_modes(cute.select(mU.layout, mode=[3, 1, 2, 0]), 2, 4),
-        )
-        g_gk_k = cute.make_tensor(
-            mG.iterator,
-            cute.group_modes(cute.select(mG.layout, mode=[3, 1, 2, 0]), 2, 4),
-        )
+        g_w = _sequence_feature_head_batch_view(mW)
+        g_kgt = _feature_sequence_head_batch_view(mKg)
+        g_u_vt = _feature_sequence_head_batch_view(mU)
+        g_gk_k = _feature_sequence_head_batch_view(mG)
 
         # --- MMA configurations (SS-mode: both operands from SMEM) ---
         # MMA1: w (A, K-major) × X snapshot (B, K-major) → wx.
@@ -603,12 +605,11 @@ class _AffineSummaryFwdOp:
         # X starts as this tile's slice of [0 | I]: value-tile columns are zero
         # and identity-tile column (col_base + nc) carries a one at key row kc.
         st = cute.make_rmem_tensor(coords_kv.shape, Float32)
+        st.fill(Float32(0.0))
         for ei in cutlass.range(cute.size(st), unroll_full=True):
             kc, nc = coords_kv[ei]
-            value = Float32(0.0)
             if col_base + nc == VAL_DIM + kc:
-                value = Float32(1.0)
-            st[ei] = value
+                st[ei] = Float32(1.0)
 
         for _ct in cutlass.range(0, num_chunks, unroll=0):
             # ---- Phase 1: R2S X hi/lo → sXb (B operand for MMA1) ----

--- a/attn_gym/linear/_delta_rule/cute/affine_summary_rev.py
+++ b/attn_gym/linear/_delta_rule/cute/affine_summary_rev.py
@@ -1,0 +1,1382 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Blackwell TMA/UMMA reverse affine summaries for delta-rule context parallelism.
+
+The local backward recurrence is affine in its incoming final-state cotangent:
+``dH_in = dH_out @ R + C``. This kernel evaluates the recurrence on persistent
+``[K, BN]`` tiles of the augmented FP32 state ``X = [0 | I]`` and returns its
+V-first packed transpose ``[local_bias; reverse_transition]``.
+
+Each 224-thread CTA persistently owns augmented-column tiles. Four CUDA warps
+hold the FP32 state in registers, one warp issues TMA loads, one computes gate
+exponentials, and one issues the four UMMA operations. Bias tiles load the local
+output-gradient sources; transition tiles skip those streams entirely. Only the
+final FP32 summary is written to global memory.
+"""
+
+# NOTE: no `from __future__ import annotations` — cute.struct requires
+# eager-evaluated annotations.
+
+from enum import IntEnum
+from typing import NamedTuple
+
+import cutlass
+import cutlass.utils.blackwell_helpers as sm100_utils
+import torch
+import torch.nn.functional as F
+from cuda.bindings import driver as cuda
+from cutlass import Float32, Int32, cute, pipeline, utils
+from cutlass.cute.nvgpu import cpasync, tcgen05
+from cutlass.cute.runtime import make_fake_compact_tensor
+from cutlass.cute.typing import Int64
+from torch._subclasses.fake_tensor import FakeTensor
+
+from attn_gym._backends.cute import compile_tvm_ffi, get_device_properties, jit_cache
+from attn_gym._backends.cute.target import get_compile_target
+from attn_gym._backends.cute.utils import requires_int64_abi
+
+BT = 64
+KEY_DIM = 128
+VAL_DIM = 128
+SUMMARY_DIM = VAL_DIM + KEY_DIM
+DATA_ALIGN_BYTES = 16
+
+_IO_TYPE_NAMES = {torch.bfloat16: "bf16", torch.float16: "fp16"}
+_CUTE_IO_TYPES = {"bf16": cutlass.BFloat16, "fp16": cutlass.Float16}
+
+
+class WarpRole(IntEnum):
+    """Warp-role boundaries in the persistent summary kernel."""
+
+    STATE = 0
+    LOAD = 4
+    GATE = 5
+    MMA = 6
+    END = 7
+
+
+class TmaOp(NamedTuple):
+    """One TMA copy atom and its tensor-map descriptor."""
+
+    atom: cute.CopyAtom
+    desc: cute.Tensor
+
+
+class TmaOps(NamedTuple):
+    """TMA operations owned by the reverse-summary kernel."""
+
+    k: TmaOp
+    q: TmaOp
+    do: TmaOp
+    w: TmaOp
+    aqk: TmaOp
+    gate: TmaOp
+
+
+class Mmas(NamedTuple):
+    """Tensor-core operations owned by the MMA warp."""
+
+    dv: cute.TiledMma
+    qdo: cute.TiledMma
+    aqdo: cute.TiledMma
+    wdv: cute.TiledMma
+
+
+class SmemLayouts(NamedTuple):
+    """Shared-memory layouts in device-kernel construction order."""
+
+    k: cute.ComposedLayout
+    state: cute.ComposedLayout
+    state_store: cute.ComposedLayout
+    q: cute.ComposedLayout
+    do: cute.ComposedLayout
+    w: cute.ComposedLayout
+    dv: cute.ComposedLayout
+    dv_store: cute.ComposedLayout
+    aqk: cute.ComposedLayout
+
+
+class BlackwellDeltaAffineSummaryRev:
+    """Compute reverse affine summaries with persistent TMA/UMMA state tiles."""
+
+    STATE_WARP_IDS = tuple(range(WarpRole.STATE, WarpRole.LOAD))
+    WARP_SIZE = cute.arch.WARP_SIZE
+    CTA_THREADS = WarpRole.END * WARP_SIZE
+
+    def __init__(
+        self,
+        num_heads: int,
+        io_type: type[cutlass.Numeric],
+        head_bn: int,
+    ):
+        assert head_bn in (16, 32), f"BN must be 16 or 32, got {head_bn}"
+        self.num_heads = num_heads
+        self.io_type = io_type
+        self.acc_type = cutlass.Float32
+        self.BT = BT
+        self.BK = KEY_DIM
+        self.BN = head_bn
+
+        self.state_regs = 128 if head_bn == 16 else 160
+        self.aux_regs = 40
+
+        self.dv_tile = (self.BT, self.BN, self.BK)
+        self.qdo_tile = (self.BK, self.BN, self.BT)
+        self.aqdo_tile = (self.BT, self.BN, self.BT)
+        self.wdv_tile = (self.BK, self.BN, self.BT)
+
+        self.k_depth = 6 if head_bn == 16 else 4
+        self.q_depth = 2
+        self.do_depth = 2
+        self.w_depth = 2
+        self.aqk_depth = 2
+        self.gate_depth = 2
+        self.dv_acc_depth = 1
+        self.qdo_acc_depth = 1
+        self.wdv_acc_depth = 1
+
+        self.cluster = (1, 1, 1)
+        self.cta_group = tcgen05.CtaGroup.ONE
+        self.tmem_free_barrier = pipeline.NamedBarrier(
+            barrier_id=2,
+            num_threads=self.CTA_THREADS,
+        )
+        self.smem_alignment = 1024
+
+    def get_name(self) -> str:
+        """Return a stable artifact and profiler name for this specialization."""
+        dtype_name = "bf16" if self.io_type is cutlass.BFloat16 else "fp16"
+        return f"delta_affine_summary_rev_h{self.num_heads}_bn{self.BN}_{dtype_name}"
+
+    @cute.jit
+    def __call__(
+        self,
+        qg: cute.Tensor,
+        kg: cute.Tensor,
+        w: cute.Tensor,
+        dout: cute.Tensor,
+        aqk: cute.Tensor,
+        cumulative_gate: cute.Tensor,
+        out: cute.Tensor,
+        scale: Float32,
+        stream: cuda.CUstream,
+    ):
+        """Construct TMA/UMMA descriptors and launch the persistent kernel."""
+        g_k = cute.make_tensor(
+            kg.iterator,
+            cute.group_modes(cute.select(kg.layout, mode=[1, 3, 2, 0]), 2, 4),
+        )
+        g_qt = cute.make_tensor(
+            qg.iterator,
+            cute.group_modes(cute.select(qg.layout, mode=[3, 1, 2, 0]), 2, 4),
+        )
+        g_wt = cute.make_tensor(w.iterator, g_qt.layout)
+        g_gate = cute.make_tensor(
+            cumulative_gate.iterator,
+            cute.group_modes(cute.select(cumulative_gate.layout, mode=[3, 1, 2, 0]), 2, 4),
+        )
+        g_do = cute.make_tensor(
+            dout.iterator,
+            cute.group_modes(cute.select(dout.layout, mode=[3, 1, 2, 0]), 2, 4),
+        )
+        g_aqk = cute.make_tensor(
+            aqk.iterator,
+            cute.group_modes(cute.select(aqk.layout, mode=[3, 1, 2, 0]), 2, 4),
+        )
+
+        mma_dv = sm100_utils.make_trivial_tiled_mma(
+            self.io_type,
+            tcgen05.OperandMajorMode.K,
+            tcgen05.OperandMajorMode.K,
+            self.acc_type,
+            self.cta_group,
+            self.dv_tile[:2],
+            tcgen05.OperandSource.SMEM,
+        )
+        mma_qdo = sm100_utils.make_trivial_tiled_mma(
+            self.io_type,
+            tcgen05.OperandMajorMode.MN,
+            tcgen05.OperandMajorMode.MN,
+            self.acc_type,
+            self.cta_group,
+            self.qdo_tile[:2],
+            tcgen05.OperandSource.SMEM,
+        )
+        mma_aqdo = sm100_utils.make_trivial_tiled_mma(
+            self.io_type,
+            tcgen05.OperandMajorMode.MN,
+            tcgen05.OperandMajorMode.MN,
+            self.acc_type,
+            self.cta_group,
+            self.aqdo_tile[:2],
+            tcgen05.OperandSource.SMEM,
+        )
+        mma_wdv = sm100_utils.make_trivial_tiled_mma(
+            self.io_type,
+            tcgen05.OperandMajorMode.MN,
+            tcgen05.OperandMajorMode.K,
+            self.acc_type,
+            self.cta_group,
+            self.wdv_tile[:2],
+            tcgen05.OperandSource.SMEM,
+        )
+        mmas = Mmas(mma_dv, mma_qdo, mma_aqdo, mma_wdv)
+
+        self.tm_dv, self.tm_qdo, self.tm_wdv, self.tm_total = self._plan_tmem(mmas)
+
+        s_k = sm100_utils.make_smem_layout_a(
+            mma_dv,
+            self.dv_tile,
+            self.io_type,
+            self.k_depth,
+        )
+        s_state = sm100_utils.make_smem_layout_b(
+            mma_dv,
+            self.dv_tile,
+            self.io_type,
+            1,
+        )
+        s_state_store = sm100_utils.make_smem_layout_epi(
+            self.io_type,
+            utils.LayoutEnum.COL_MAJOR,
+            (self.BK, self.BN),
+            1,
+        )
+        s_q = sm100_utils.make_smem_layout_a(
+            mma_qdo,
+            self.qdo_tile,
+            self.io_type,
+            self.q_depth,
+        )
+        s_do = sm100_utils.make_smem_layout_b(
+            mma_qdo,
+            self.qdo_tile,
+            self.io_type,
+            self.do_depth,
+        )
+        s_w = sm100_utils.make_smem_layout_a(
+            mma_wdv,
+            self.wdv_tile,
+            self.io_type,
+            self.w_depth,
+        )
+        s_dv = sm100_utils.make_smem_layout_b(
+            mma_wdv,
+            self.wdv_tile,
+            self.io_type,
+            1,
+        )
+        s_dv_store = sm100_utils.make_smem_layout_epi(
+            self.io_type,
+            utils.LayoutEnum.COL_MAJOR,
+            (self.BT, self.BN),
+            1,
+        )
+        s_aqk = sm100_utils.make_smem_layout_a(
+            mma_aqdo,
+            self.aqdo_tile,
+            self.io_type,
+            self.aqk_depth,
+        )
+        smem_layouts = SmemLayouts(
+            s_k,
+            s_state,
+            s_state_store,
+            s_q,
+            s_do,
+            s_w,
+            s_dv,
+            s_dv_store,
+            s_aqk,
+        )
+
+        tma_load = cpasync.CopyBulkTensorTileG2SOp(self.cta_group)
+        cluster_layout = cute.tiled_divide(
+            cute.make_layout(self.cluster),
+            (mma_dv.thr_id.shape,),
+        )
+
+        s_k_one = cute.select(s_k, mode=[0, 1, 2])
+        atom_k, desc_k = cute.nvgpu.make_tiled_tma_atom_A(
+            tma_load,
+            g_k,
+            s_k_one,
+            self.dv_tile,
+            mma_dv,
+            cluster_layout.shape,
+        )
+        s_q_one = cute.select(s_q, mode=[0, 1, 2])
+        atom_q, desc_q = cute.nvgpu.make_tiled_tma_atom_A(
+            tma_load,
+            g_qt,
+            s_q_one,
+            self.qdo_tile,
+            mma_qdo,
+            cluster_layout.shape,
+        )
+        s_do_one = cute.select(s_do, mode=[0, 1, 2])
+        atom_do, desc_do = cute.nvgpu.make_tiled_tma_atom_B(
+            tma_load,
+            g_do,
+            s_do_one,
+            self.qdo_tile,
+            mma_qdo,
+            cluster_layout.shape,
+        )
+        s_w_one = cute.select(s_w, mode=[0, 1, 2])
+        atom_w, desc_w = cute.nvgpu.make_tiled_tma_atom_A(
+            tma_load,
+            g_wt,
+            s_w_one,
+            self.wdv_tile,
+            mma_wdv,
+            cluster_layout.shape,
+        )
+        s_aqk_one = cute.select(s_aqk, mode=[0, 1, 2])
+        atom_aqk, desc_aqk = cute.nvgpu.make_tiled_tma_atom_A(
+            tma_load,
+            g_aqk,
+            s_aqk_one,
+            self.aqdo_tile,
+            mma_aqdo,
+            cluster_layout.shape,
+        )
+        s_gate = cute.make_layout((self.BK, 1))
+        atom_gate, desc_gate = cpasync.make_tiled_tma_atom(
+            tma_load,
+            g_gate,
+            s_gate,
+            (self.BK, 1),
+        )
+        tma_ops = TmaOps(
+            TmaOp(atom_k, desc_k),
+            TmaOp(atom_q, desc_q),
+            TmaOp(atom_do, desc_do),
+            TmaOp(atom_w, desc_w),
+            TmaOp(atom_aqk, desc_aqk),
+            TmaOp(atom_gate, desc_gate),
+        )
+
+        self.k_bytes = cute.size_in_bytes(self.io_type, s_k_one)
+        self.q_bytes = cute.size_in_bytes(self.io_type, s_q_one)
+        self.do_bytes = cute.size_in_bytes(self.io_type, s_do_one)
+        self.w_bytes = cute.size_in_bytes(self.io_type, s_w_one)
+        self.aqk_bytes = cute.size_in_bytes(self.io_type, s_aqk_one)
+        self.gate_bytes = cute.size_in_bytes(Float32, s_gate)
+
+        @cute.struct
+        class SharedStorage:
+            bar_k: cute.struct.MemRange[Int64, self.k_depth * 2]
+            bar_q: cute.struct.MemRange[Int64, self.q_depth * 2]
+            bar_do: cute.struct.MemRange[Int64, self.do_depth * 2]
+            bar_w: cute.struct.MemRange[Int64, self.w_depth * 2]
+            bar_aqk: cute.struct.MemRange[Int64, self.aqk_depth * 2]
+            bar_gate: cute.struct.MemRange[Int64, self.gate_depth * 2]
+            bar_gate_ready: cute.struct.MemRange[Int64, self.gate_depth * 2]
+            bar_state: cute.struct.MemRange[Int64, 2]
+            bar_dv: cute.struct.MemRange[Int64, self.dv_acc_depth * 2]
+            bar_qdo: cute.struct.MemRange[Int64, self.qdo_acc_depth * 2]
+            bar_dv_operand: cute.struct.MemRange[Int64, 2]
+            bar_wdv: cute.struct.MemRange[Int64, self.wdv_acc_depth * 2]
+            tmem_buf: Int32
+            sK: cute.struct.Align[
+                cute.struct.MemRange[self.io_type, cute.cosize(s_k)], self.smem_alignment
+            ]
+            sState: cute.struct.Align[
+                cute.struct.MemRange[self.io_type, cute.cosize(s_state)], self.smem_alignment
+            ]
+            sQ: cute.struct.Align[
+                cute.struct.MemRange[self.io_type, cute.cosize(s_q)], self.smem_alignment
+            ]
+            sDo: cute.struct.Align[
+                cute.struct.MemRange[self.io_type, cute.cosize(s_do)], self.smem_alignment
+            ]
+            sW: cute.struct.Align[
+                cute.struct.MemRange[self.io_type, cute.cosize(s_w)], self.smem_alignment
+            ]
+            sDv: cute.struct.Align[
+                cute.struct.MemRange[self.io_type, cute.cosize(s_dv)], self.smem_alignment
+            ]
+            sAqk: cute.struct.Align[
+                cute.struct.MemRange[self.io_type, cute.cosize(s_aqk)], self.smem_alignment
+            ]
+            sGate: cute.struct.Align[cute.struct.MemRange[Float32, self.BK * self.gate_depth], 128]
+            sGateExp: cute.struct.Align[
+                cute.struct.MemRange[Float32, self.BK * self.gate_depth], 128
+            ]
+
+        self.shared_type = SharedStorage
+        self.kernel.set_name_prefix(self.get_name())
+        self.kernel(
+            mmas,
+            tma_ops,
+            out,
+            smem_layouts,
+            Int32(cute.size(w.shape[1])),
+            scale,
+        ).launch(
+            grid=self._launch_grid(),
+            block=(self.CTA_THREADS, 1, 1),
+            cluster=self.cluster,
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
+
+    @cute.jit
+    def _decode_work(self, work_index):
+        """Return the augmented-column tile and head for a work item."""
+        column_tiles = SUMMARY_DIM // self.BN
+        return work_index % column_tiles, work_index // column_tiles
+
+    @cute.jit
+    def run_state(
+        self,
+        block,
+        grid,
+        iterations,
+        chunks,
+        out,
+        t_dv_acc,
+        t_qdo_acc,
+        t_wdv_acc,
+        s_state_store,
+        s_dv_store,
+        state_producer,
+        dv_consumer,
+        dv_operand_producer,
+        gate_consumer,
+        qdo_consumer,
+        wdv_consumer,
+        gate_exp,
+        scale,
+    ):
+        """Keep one FP32 state tile in registers across the reverse chunk scan."""
+        cute.arch.setmaxregister_increase(self.state_regs)
+        tid, _, _ = cute.arch.thread_idx()
+        local_tid = tid % (self.WARP_SIZE * len(self.STATE_WARP_IDS))
+
+        t2r_dv_atom = cute.make_copy_atom(
+            tcgen05.Ld16x256bOp(tcgen05.Repetition(self.BN // 8), tcgen05.Pack.NONE),
+            self.acc_type,
+        )
+        dv_flat = t_dv_acc[((None, None), 0, 0, None)]
+        t2r_dv = tcgen05.make_tmem_copy(t2r_dv_atom, dv_flat[(None, None, 0)])
+        dv_slice = t2r_dv.get_slice(local_tid)
+        partitioned_dv = dv_slice.partition_S(dv_flat)
+
+        t2r_qdo_atom = cute.make_copy_atom(
+            tcgen05.Ld16x256bOp(tcgen05.Repetition(self.BN // 8), tcgen05.Pack.NONE),
+            self.acc_type,
+        )
+        qdo_flat = t_qdo_acc[((None, None), 0, 0, None)]
+        t2r_qdo = tcgen05.make_tmem_copy(t2r_qdo_atom, qdo_flat[(None, None, 0)])
+        qdo_slice = t2r_qdo.get_slice(local_tid)
+        partitioned_qdo = qdo_slice.partition_S(qdo_flat)
+
+        t2r_wdv_atom = cute.make_copy_atom(
+            tcgen05.Ld16x256bOp(tcgen05.Repetition(self.BN // 8), tcgen05.Pack.NONE),
+            self.acc_type,
+        )
+        wdv_flat = t_wdv_acc[((None, None), 0, 0, None)]
+        t2r_wdv = tcgen05.make_tmem_copy(t2r_wdv_atom, wdv_flat[(None, None, 0)])
+        wdv_slice = t2r_wdv.get_slice(local_tid)
+        partitioned_wdv = wdv_slice.partition_S(wdv_flat)
+
+        dv_coordinates = dv_slice.partition_D(
+            cute.make_identity_tensor(cute.dice(self.dv_tile, (1, 1, None)))
+        )
+        state_coordinates = qdo_slice.partition_D(
+            cute.make_identity_tensor(cute.dice(self.qdo_tile, (1, 1, None)))
+        )
+        wdv_coordinates = wdv_slice.partition_D(
+            cute.make_identity_tensor(cute.dice(self.qdo_tile, (1, 1, None)))
+        )
+        state = cute.make_rmem_tensor(state_coordinates.shape, self.acc_type)
+
+        r2s_state_atom = sm100_utils.get_smem_store_op(
+            utils.LayoutEnum.COL_MAJOR,
+            self.io_type,
+            self.acc_type,
+            t2r_qdo,
+        )
+        r2s_state = cute.make_tiled_copy_D(r2s_state_atom, t2r_qdo)
+        r2s_state_slice = r2s_state.get_slice(local_tid)
+
+        r2s_dv_atom = sm100_utils.get_smem_store_op(
+            utils.LayoutEnum.COL_MAJOR,
+            self.io_type,
+            self.acc_type,
+            t2r_dv,
+        )
+        r2s_dv = cute.make_tiled_copy_D(r2s_dv_atom, t2r_dv)
+        r2s_dv_slice = r2s_dv.get_slice(local_tid)
+
+        tile_index = Int32(0)
+        has_work = tile_index < iterations
+        while has_work:
+            column_tile, head = self._decode_work(block + tile_index * grid)
+            has_source = column_tile < VAL_DIM // self.BN
+
+            for element in cutlass.range(cute.size(state), unroll_full=True):
+                key, column = state_coordinates[element]
+                global_column = column_tile * self.BN + column
+                if global_column == VAL_DIM + key:
+                    state[element] = Float32(1.0)
+                else:
+                    state[element] = Float32(0.0)
+
+            for _chunk in cutlass.range(chunks, unroll=0):
+                state_handle = state_producer.acquire_and_advance()
+                state_io = cute.make_rmem_tensor(state.shape, self.io_type)
+                state_io.store(state.load().to(self.io_type))
+                cute.copy(
+                    r2s_state,
+                    r2s_state.retile(state_io),
+                    r2s_state_slice.partition_D(s_state_store[(None, None, 0)]),
+                )
+                cute.arch.fence_view_async_shared()
+                state_handle.commit()
+
+                dv_handle = dv_consumer.wait_and_advance()
+                dv = cute.make_rmem_tensor(dv_coordinates.shape, self.acc_type)
+                cute.copy(
+                    t2r_dv,
+                    partitioned_dv[(None, None, None, dv_handle.index)],
+                    dv,
+                )
+                cute.arch.fence_view_async_tmem_load()
+                dv_handle.release()
+
+                dv_operand_handle = dv_operand_producer.acquire_and_advance()
+                dv_io = cute.make_rmem_tensor(dv.shape, self.io_type)
+                dv_io.store(dv.load().to(self.io_type))
+                cute.copy(
+                    r2s_dv,
+                    r2s_dv.retile(dv_io),
+                    r2s_dv_slice.partition_D(s_dv_store[(None, None, 0)]),
+                )
+                cute.arch.fence_view_async_shared()
+                dv_operand_handle.commit()
+
+                gate_handle = gate_consumer.wait_and_advance()
+                for element in cutlass.range(cute.size(state), unroll_full=True):
+                    key, _column = state_coordinates[element]
+                    state[element] = state[element] * gate_exp[(key, gate_handle.index)]
+                gate_handle.release()
+
+                qdo = cute.make_rmem_tensor(state_coordinates.shape, self.acc_type)
+                if has_source:
+                    qdo_handle = qdo_consumer.wait_and_advance()
+                    cute.copy(
+                        t2r_qdo,
+                        partitioned_qdo[(None, None, None, qdo_handle.index)],
+                        qdo,
+                    )
+                    cute.arch.fence_view_async_tmem_load()
+                    qdo_handle.release()
+
+                wdv_handle = wdv_consumer.wait_and_advance()
+                wdv = cute.make_rmem_tensor(wdv_coordinates.shape, self.acc_type)
+                cute.copy(
+                    t2r_wdv,
+                    partitioned_wdv[(None, None, None, wdv_handle.index)],
+                    wdv,
+                )
+                cute.arch.fence_view_async_tmem_load()
+                wdv_handle.release()
+
+                if has_source:
+                    for element in cutlass.range_constexpr(cute.size(state)):
+                        state[element] = state[element] + qdo[element] * scale - wdv[element]
+                else:
+                    for element in cutlass.range_constexpr(cute.size(state)):
+                        state[element] = state[element] - wdv[element]
+
+            for element in cutlass.range(cute.size(state), unroll_full=True):
+                key, column = state_coordinates[element]
+                out[head, column_tile * self.BN + column, key] = state[element]
+
+            tile_index = tile_index + 1
+            has_work = tile_index < iterations
+
+    @cute.jit
+    def run_load(
+        self,
+        block,
+        grid,
+        iterations,
+        chunks,
+        mma_dv,
+        mma_qdo,
+        mma_aqdo,
+        mma_wdv,
+        tma,
+        s_k,
+        s_q,
+        s_do,
+        s_w,
+        s_aqk,
+        s_gate,
+        k_producer,
+        q_producer,
+        do_producer,
+        w_producer,
+        aqk_producer,
+        gate_producer,
+    ):
+        """Issue reverse-order TMA loads for all active operand streams."""
+        cute.arch.setmaxregister_decrease(self.aux_regs)
+        atom_k, desc_k = tma.k
+        atom_q, desc_q = tma.q
+        atom_do, desc_do = tma.do
+        atom_w, desc_w = tma.w
+        atom_aqk, desc_aqk = tma.aqk
+        atom_gate, desc_gate = tma.gate
+
+        tile_index = Int32(0)
+        has_work = tile_index < iterations
+        while has_work:
+            column_tile, head = self._decode_work(block + tile_index * grid)
+            has_source = column_tile < VAL_DIM // self.BN
+
+            k_smem, k_gmem = self._partition_a(atom_k, desc_k, s_k, self.dv_tile, mma_dv, head)
+            w_smem, w_gmem = self._partition_a(
+                atom_w,
+                desc_w,
+                s_w,
+                self.wdv_tile,
+                mma_wdv,
+                head,
+            )
+            gate_smem, gate_gmem = self._partition_epilogue(
+                atom_gate,
+                desc_gate[None, None, (head, 0)],
+                (self.BK, 1),
+                s_gate,
+            )
+            q_smem, q_gmem = self._partition_a(
+                atom_q,
+                desc_q,
+                s_q,
+                self.qdo_tile,
+                mma_qdo,
+                head,
+            )
+            do_smem, do_gmem = self._partition_b(
+                atom_do,
+                desc_do,
+                s_do,
+                self.qdo_tile,
+                mma_qdo,
+                head,
+            )
+            aqk_smem, aqk_gmem = self._partition_a(
+                atom_aqk,
+                desc_aqk,
+                s_aqk,
+                self.aqdo_tile,
+                mma_aqdo,
+                head,
+            )
+
+            for chunk in cutlass.range(chunks, unroll=0):
+                reverse_chunk = chunks - 1 - chunk
+
+                gate_handle = gate_producer.acquire_and_advance()
+                cute.copy(
+                    atom=atom_gate,
+                    src=gate_gmem[(None, 0, reverse_chunk * self.BT + self.BT - 1)],
+                    dst=gate_smem[None, gate_handle.index],
+                    tma_bar_ptr=gate_handle.barrier,
+                )
+
+                k_handle = k_producer.acquire_and_advance()
+                cute.copy(
+                    atom=atom_k,
+                    src=k_gmem[None, reverse_chunk, 0],
+                    dst=k_smem[None, k_handle.index],
+                    tma_bar_ptr=k_handle.barrier,
+                )
+                w_handle = w_producer.acquire_and_advance()
+                cute.copy(
+                    atom=atom_w,
+                    src=w_gmem[None, 0, reverse_chunk],
+                    dst=w_smem[None, w_handle.index],
+                    tma_bar_ptr=w_handle.barrier,
+                )
+
+                if has_source:
+                    q_handle = q_producer.acquire_and_advance()
+                    cute.copy(
+                        atom=atom_q,
+                        src=q_gmem[None, 0, reverse_chunk],
+                        dst=q_smem[None, q_handle.index],
+                        tma_bar_ptr=q_handle.barrier,
+                    )
+                    do_handle = do_producer.acquire_and_advance()
+                    cute.copy(
+                        atom=atom_do,
+                        src=do_gmem[None, column_tile, reverse_chunk],
+                        dst=do_smem[None, do_handle.index],
+                        tma_bar_ptr=do_handle.barrier,
+                    )
+                    aqk_handle = aqk_producer.acquire_and_advance()
+                    cute.copy(
+                        atom=atom_aqk,
+                        src=aqk_gmem[None, 0, reverse_chunk],
+                        dst=aqk_smem[None, aqk_handle.index],
+                        tma_bar_ptr=aqk_handle.barrier,
+                    )
+
+            tile_index = tile_index + 1
+            has_work = tile_index < iterations
+
+    @cute.jit
+    def run_gate(
+        self,
+        block,
+        grid,
+        iterations,
+        chunks,
+        gate,
+        gate_exp,
+        gate_consumer,
+        gate_ready_producer,
+    ):
+        """Transform cumulative log2 gate stages into multiplicative decays."""
+        cute.arch.setmaxregister_decrease(self.aux_regs)
+        tid, _, _ = cute.arch.thread_idx()
+        gate_tid = tid - WarpRole.GATE * self.WARP_SIZE
+
+        tile_index = Int32(0)
+        has_work = tile_index < iterations
+        while has_work:
+            for _chunk in cutlass.range(chunks, unroll=0):
+                gate_handle = gate_consumer.wait_and_advance()
+                ready_handle = gate_ready_producer.acquire_and_advance()
+                for index in cutlass.range(4, unroll_full=True):
+                    key = gate_tid * 4 + index
+                    gate_exp[(key, ready_handle.index)] = cute.exp2(gate[(key, gate_handle.index)])
+                gate_handle.release()
+                cute.arch.fence_view_async_shared()
+                ready_handle.commit()
+
+            tile_index = tile_index + 1
+            has_work = tile_index < iterations
+
+    @cute.jit
+    def run_mma(
+        self,
+        block,
+        grid,
+        iterations,
+        chunks,
+        mmas,
+        t_dv_acc,
+        t_k,
+        t_state,
+        t_qdo_acc,
+        t_q,
+        t_do,
+        t_aqk,
+        t_do_aq,
+        t_wdv_acc,
+        t_w,
+        t_dv,
+        state_consumer,
+        k_consumer,
+        dv_producer,
+        q_consumer,
+        do_consumer,
+        qdo_producer,
+        aqk_consumer,
+        dv_operand_consumer,
+        w_consumer,
+        wdv_producer,
+    ):
+        """Issue the four UMMA operations for each reverse chunk."""
+        cute.arch.setmaxregister_decrease(self.aux_regs)
+        mma_dv, mma_qdo, mma_aqdo, mma_wdv = mmas
+
+        tile_index = Int32(0)
+        has_work = tile_index < iterations
+        while has_work:
+            column_tile, _head = self._decode_work(block + tile_index * grid)
+            has_source = column_tile < VAL_DIM // self.BN
+
+            for _chunk in cutlass.range(chunks, unroll=0):
+                state_handle = state_consumer.wait_and_advance()
+                k_handle = k_consumer.wait_and_advance()
+                dv_handle = dv_producer.acquire_and_advance()
+                for k_block in cutlass.range(cute.size(t_k, mode=[2]), unroll_full=True):
+                    mma_dv.set(tcgen05.Field.ACCUMULATE, cutlass.Boolean(k_block != 0))
+                    cute.gemm(
+                        mma_dv,
+                        t_dv_acc[None, None, None, dv_handle.index],
+                        t_k[None, None, k_block, k_handle.index],
+                        t_state[None, None, k_block, state_handle.index],
+                        t_dv_acc[None, None, None, dv_handle.index],
+                    )
+                k_handle.release()
+                state_handle.release()
+
+                if has_source:
+                    q_handle = q_consumer.wait_and_advance()
+                    do_handle = do_consumer.wait_and_advance()
+                    aqk_handle = aqk_consumer.wait_and_advance()
+                    for k_block in cutlass.range(cute.size(t_aqk, mode=[2]), unroll_full=True):
+                        mma_aqdo.set(tcgen05.Field.ACCUMULATE, cutlass.Boolean(True))
+                        cute.gemm(
+                            mma_aqdo,
+                            t_dv_acc[None, None, None, dv_handle.index],
+                            t_aqk[None, None, k_block, aqk_handle.index],
+                            t_do_aq[None, None, k_block, do_handle.index],
+                            t_dv_acc[None, None, None, dv_handle.index],
+                        )
+                    aqk_handle.release()
+                    dv_handle.commit()
+
+                    qdo_handle = qdo_producer.acquire_and_advance()
+                    for k_block in cutlass.range(cute.size(t_q, mode=[2]), unroll_full=True):
+                        mma_qdo.set(tcgen05.Field.ACCUMULATE, cutlass.Boolean(k_block != 0))
+                        cute.gemm(
+                            mma_qdo,
+                            t_qdo_acc[None, None, None, qdo_handle.index],
+                            t_q[None, None, k_block, q_handle.index],
+                            t_do[None, None, k_block, do_handle.index],
+                            t_qdo_acc[None, None, None, qdo_handle.index],
+                        )
+                    qdo_handle.commit()
+                    q_handle.release()
+                    do_handle.release()
+                else:
+                    dv_handle.commit()
+
+                dv_operand_handle = dv_operand_consumer.wait_and_advance()
+                w_handle = w_consumer.wait_and_advance()
+                wdv_handle = wdv_producer.acquire_and_advance()
+                for k_block in cutlass.range(cute.size(t_w, mode=[2]), unroll_full=True):
+                    mma_wdv.set(tcgen05.Field.ACCUMULATE, cutlass.Boolean(k_block != 0))
+                    cute.gemm(
+                        mma_wdv,
+                        t_wdv_acc[None, None, None, wdv_handle.index],
+                        t_w[None, None, k_block, w_handle.index],
+                        t_dv[None, None, k_block, dv_operand_handle.index],
+                        t_wdv_acc[None, None, None, wdv_handle.index],
+                    )
+                wdv_handle.commit()
+                w_handle.release()
+                dv_operand_handle.release()
+
+            tile_index = tile_index + 1
+            has_work = tile_index < iterations
+
+    @cute.kernel
+    def kernel(
+        self,
+        mmas: Mmas,
+        tma: TmaOps,
+        out: cute.Tensor,
+        smem_layouts: SmemLayouts,
+        tokens: Int32,
+        scale: Float32,
+    ):
+        """Dispatch the persistent state, TMA, gate, and MMA warp roles."""
+        mma_dv, mma_qdo, mma_aqdo, mma_wdv = mmas
+        (
+            s_k_layout,
+            s_state_layout,
+            s_state_store_layout,
+            s_q_layout,
+            s_do_layout,
+            s_w_layout,
+            s_dv_layout,
+            s_dv_store_layout,
+            s_aqk_layout,
+        ) = smem_layouts
+        warp_id = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+
+        if warp_id == WarpRole.LOAD:
+            cpasync.prefetch_descriptor(tma.k.atom)
+            cpasync.prefetch_descriptor(tma.q.atom)
+            cpasync.prefetch_descriptor(tma.do.atom)
+            cpasync.prefetch_descriptor(tma.w.atom)
+            cpasync.prefetch_descriptor(tma.aqk.atom)
+            cpasync.prefetch_descriptor(tma.gate.atom)
+
+        allocator = utils.SmemAllocator()
+        storage = allocator.allocate(self.shared_type)
+
+        gate_3d = storage.sGate.get_tensor(
+            cute.make_layout(
+                (self.BK, 1, self.gate_depth),
+                stride=(1, self.BK, self.BK),
+            )
+        )
+        gate = gate_3d[(None, 0, None)]
+        gate_exp = storage.sGateExp.get_tensor(cute.make_layout((self.BK, self.gate_depth)))
+
+        k_producer, k_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=self.k_depth,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            tx_count=self.k_bytes,
+            barrier_storage=storage.bar_k.data_ptr(),
+        ).make_participants()
+        state_producer, state_consumer = pipeline.PipelineAsyncUmma.create(
+            num_stages=1,
+            producer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                self.WARP_SIZE * len(self.STATE_WARP_IDS),
+            ),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            barrier_storage=storage.bar_state.data_ptr(),
+        ).make_participants()
+        dv_producer, dv_consumer = pipeline.PipelineUmmaAsync.create(
+            num_stages=self.dv_acc_depth,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                self.WARP_SIZE * len(self.STATE_WARP_IDS),
+            ),
+            barrier_storage=storage.bar_dv.data_ptr(),
+        ).make_participants()
+        q_producer, q_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=self.q_depth,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            tx_count=self.q_bytes,
+            barrier_storage=storage.bar_q.data_ptr(),
+        ).make_participants()
+        do_producer, do_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=self.do_depth,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            tx_count=self.do_bytes,
+            barrier_storage=storage.bar_do.data_ptr(),
+        ).make_participants()
+        qdo_producer, qdo_consumer = pipeline.PipelineUmmaAsync.create(
+            num_stages=self.qdo_acc_depth,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                self.WARP_SIZE * len(self.STATE_WARP_IDS),
+            ),
+            barrier_storage=storage.bar_qdo.data_ptr(),
+        ).make_participants()
+        w_producer, w_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=self.w_depth,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            tx_count=self.w_bytes,
+            barrier_storage=storage.bar_w.data_ptr(),
+        ).make_participants()
+        dv_operand_producer, dv_operand_consumer = pipeline.PipelineAsyncUmma.create(
+            num_stages=1,
+            producer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                self.WARP_SIZE * len(self.STATE_WARP_IDS),
+            ),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            barrier_storage=storage.bar_dv_operand.data_ptr(),
+        ).make_participants()
+        wdv_producer, wdv_consumer = pipeline.PipelineUmmaAsync.create(
+            num_stages=self.wdv_acc_depth,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                self.WARP_SIZE * len(self.STATE_WARP_IDS),
+            ),
+            barrier_storage=storage.bar_wdv.data_ptr(),
+        ).make_participants()
+        aqk_producer, aqk_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=self.aqk_depth,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            tx_count=self.aqk_bytes,
+            barrier_storage=storage.bar_aqk.data_ptr(),
+        ).make_participants()
+        gate_producer, gate_consumer = pipeline.PipelineTmaAsync.create(
+            num_stages=self.gate_depth,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            tx_count=self.gate_bytes,
+            barrier_storage=storage.bar_gate.data_ptr(),
+        ).make_participants()
+        gate_ready_producer, gate_ready_consumer = pipeline.PipelineAsync.create(
+            num_stages=self.gate_depth,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, self.WARP_SIZE),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                self.WARP_SIZE * len(self.STATE_WARP_IDS),
+            ),
+            barrier_storage=storage.bar_gate_ready.data_ptr(),
+        ).make_participants()
+
+        tmem_barrier = pipeline.NamedBarrier(barrier_id=1, num_threads=self.CTA_THREADS)
+        tmem = utils.TmemAllocator(
+            storage.tmem_buf,
+            barrier_for_retrieve=tmem_barrier,
+            allocator_warp_id=WarpRole.LOAD,
+        )
+        tmem.allocate(self.tm_total)
+        tmem.wait_for_alloc()
+        tmem_pointer = tmem.retrieve_ptr(self.acc_type)
+
+        s_k = storage.sK.get_tensor(s_k_layout.outer, swizzle=s_k_layout.inner)
+        s_state = storage.sState.get_tensor(
+            s_state_layout.outer,
+            swizzle=s_state_layout.inner,
+        )
+        s_state_store = storage.sState.get_tensor(
+            s_state_store_layout.outer,
+            swizzle=s_state_store_layout.inner,
+        )
+        s_q = storage.sQ.get_tensor(s_q_layout.outer, swizzle=s_q_layout.inner)
+        s_do = storage.sDo.get_tensor(s_do_layout.outer, swizzle=s_do_layout.inner)
+        s_w = storage.sW.get_tensor(s_w_layout.outer, swizzle=s_w_layout.inner)
+        s_dv = storage.sDv.get_tensor(s_dv_layout.outer, swizzle=s_dv_layout.inner)
+        s_dv_store = storage.sDv.get_tensor(
+            s_dv_store_layout.outer,
+            swizzle=s_dv_store_layout.inner,
+        )
+        s_aqk = storage.sAqk.get_tensor(s_aqk_layout.outer, swizzle=s_aqk_layout.inner)
+
+        t_k = mma_dv.make_fragment_A(s_k)
+        t_state = mma_dv.make_fragment_B(s_state)
+        dv_shape = mma_dv.partition_shape_C(self.dv_tile[:2])
+        dv_fragment = mma_dv.make_fragment_C(cute.append(dv_shape, self.dv_acc_depth))
+        t_dv_acc = cute.make_tensor(tmem_pointer + self.tm_dv, dv_fragment.layout)
+
+        t_q = mma_qdo.make_fragment_A(s_q)
+        t_do = mma_qdo.make_fragment_B(s_do)
+        qdo_shape = mma_qdo.partition_shape_C(self.qdo_tile[:2])
+        qdo_fragment = mma_qdo.make_fragment_C(cute.append(qdo_shape, self.qdo_acc_depth))
+        t_qdo_acc = cute.make_tensor(tmem_pointer + self.tm_qdo, qdo_fragment.layout)
+
+        t_aqk = mma_aqdo.make_fragment_A(s_aqk)
+        t_do_aq = mma_aqdo.make_fragment_B(s_do)
+
+        t_w = mma_wdv.make_fragment_A(s_w)
+        t_dv = mma_wdv.make_fragment_B(s_dv)
+        wdv_shape = mma_wdv.partition_shape_C(self.wdv_tile[:2])
+        wdv_fragment = mma_wdv.make_fragment_C(cute.append(wdv_shape, self.wdv_acc_depth))
+        t_wdv_acc = cute.make_tensor(tmem_pointer + self.tm_wdv, wdv_fragment.layout)
+
+        block = cute.arch.block_idx()[0]
+        grid = cute.arch.grid_dim()[0]
+        work_tiles = self.num_heads * (SUMMARY_DIM // self.BN)
+        iterations = (work_tiles - block + grid - 1) // grid
+        chunks = tokens // self.BT
+
+        if warp_id in self.STATE_WARP_IDS:
+            self.run_state(
+                block,
+                grid,
+                iterations,
+                chunks,
+                out,
+                t_dv_acc,
+                t_qdo_acc,
+                t_wdv_acc,
+                s_state_store,
+                s_dv_store,
+                state_producer,
+                dv_consumer,
+                dv_operand_producer,
+                gate_ready_consumer,
+                qdo_consumer,
+                wdv_consumer,
+                gate_exp,
+                scale,
+            )
+        elif warp_id == WarpRole.LOAD:
+            self.run_load(
+                block,
+                grid,
+                iterations,
+                chunks,
+                mma_dv,
+                mma_qdo,
+                mma_aqdo,
+                mma_wdv,
+                tma,
+                s_k,
+                s_q,
+                s_do,
+                s_w,
+                s_aqk,
+                gate_3d,
+                k_producer,
+                q_producer,
+                do_producer,
+                w_producer,
+                aqk_producer,
+                gate_producer,
+            )
+        elif warp_id == WarpRole.GATE:
+            self.run_gate(
+                block,
+                grid,
+                iterations,
+                chunks,
+                gate,
+                gate_exp,
+                gate_consumer,
+                gate_ready_producer,
+            )
+        elif warp_id == WarpRole.MMA:
+            self.run_mma(
+                block,
+                grid,
+                iterations,
+                chunks,
+                mmas,
+                t_dv_acc,
+                t_k,
+                t_state,
+                t_qdo_acc,
+                t_q,
+                t_do,
+                t_aqk,
+                t_do_aq,
+                t_wdv_acc,
+                t_w,
+                t_dv,
+                state_consumer,
+                k_consumer,
+                dv_producer,
+                q_consumer,
+                do_consumer,
+                qdo_producer,
+                aqk_consumer,
+                dv_operand_consumer,
+                w_consumer,
+                wdv_producer,
+            )
+
+        tmem.relinquish_alloc_permit()
+        self.tmem_free_barrier.arrive_and_wait()
+        tmem.free(tmem_pointer)
+
+    @cute.jit
+    def _partition_a(self, atom, desc, smem, tile, mma, head):
+        """Partition a dense TMA tensor as an SS-mode MMA A operand."""
+        gmem = cute.local_tile(desc, cute.slice_(tile, (None, 0, None)), (None, None, (head, 0)))
+        partitioned = mma.get_slice(0).partition_A(gmem)
+        return cpasync.tma_partition(
+            atom,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(smem, 0, 3),
+            cute.group_modes(partitioned, 0, 3),
+        )
+
+    @cute.jit
+    def _partition_b(self, atom, desc, smem, tile, mma, head):
+        """Partition a dense TMA tensor as an SS-mode MMA B operand."""
+        gmem = cute.local_tile(desc, cute.slice_(tile, (0, None, None)), (None, None, (head, 0)))
+        partitioned = mma.get_slice(0).partition_B(gmem)
+        return cpasync.tma_partition(
+            atom,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(smem, 0, 3),
+            cute.group_modes(partitioned, 0, 3),
+        )
+
+    @cute.jit
+    def _partition_epilogue(self, atom, gmem, tile, smem):
+        """Partition a simple two-dimensional TMA tile."""
+        return cpasync.tma_partition(
+            atom,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(smem, 0, 2),
+            cute.group_modes(cute.flat_divide(gmem, tile), 0, 2),
+        )
+
+    def _plan_tmem(self, mmas: Mmas):
+        """Assign disjoint TMEM column regions to the three accumulators."""
+        mma_dv, mma_qdo, _mma_aqdo, mma_wdv = mmas
+        dv_shape = mma_dv.partition_shape_C(self.dv_tile[:2])
+        dv_columns = tcgen05.find_tmem_tensor_col_offset(
+            mma_dv.make_fragment_C(cute.append(dv_shape, self.dv_acc_depth))
+        )
+        qdo_shape = mma_qdo.partition_shape_C(self.qdo_tile[:2])
+        qdo_columns = tcgen05.find_tmem_tensor_col_offset(
+            mma_qdo.make_fragment_C(cute.append(qdo_shape, self.qdo_acc_depth))
+        )
+        wdv_shape = mma_wdv.partition_shape_C(self.wdv_tile[:2])
+        wdv_columns = tcgen05.find_tmem_tensor_col_offset(
+            mma_wdv.make_fragment_C(cute.append(wdv_shape, self.wdv_acc_depth))
+        )
+        dv_offset = 0
+        qdo_offset = dv_columns
+        wdv_offset = qdo_offset + qdo_columns
+        required = wdv_offset + wdv_columns
+        total = 1
+        while total < required:
+            total *= 2
+        assert total <= 512, f"TMEM overflow: {total}>512"
+        return dv_offset, qdo_offset, wdv_offset, total
+
+    def _launch_grid(self):
+        """Bound the persistent launch to the logical tile count and SM count."""
+        sm_count = get_compile_target().sm_count
+        if sm_count is None:
+            raise RuntimeError("affine_summary_rev compilation requires an SM count")
+        return (min(sm_count, self.num_heads * (SUMMARY_DIM // self.BN)), 1, 1)
+
+
+def select_summary_bn(heads: int, device: torch.device) -> int:
+    """Choose BN using the delta-H width heuristic over the augmented state."""
+    column_tiles_at_bn16 = (SUMMARY_DIM // 16) * heads
+    return 32 if column_tiles_at_bn16 > get_device_properties(device).multi_processor_count else 16
+
+
+@jit_cache
+def _compile_affine_summary_rev(dtype_name: str, heads: int, head_bn: int):
+    """Compile one reverse-summary dtype/head/tile specialization."""
+    target = get_compile_target()
+    if target.device_type != "cuda" or target.capability is None or target.capability < (10, 0):
+        raise ValueError(
+            f"affine_summary_rev requires a CUDA capability >= 10.0 target; got {target}"
+        )
+    tokens = cute.sym_int(divisibility=BT)
+
+    def factor(dtype, last_dim: int):
+        return make_fake_compact_tensor(
+            dtype,
+            (1, tokens, heads, last_dim),
+            stride_order=(3, 2, 1, 0),
+            assumed_align=DATA_ALIGN_BYTES,
+        )
+
+    io_dtype = _CUTE_IO_TYPES[dtype_name]
+    out = make_fake_compact_tensor(
+        Float32,
+        (heads, SUMMARY_DIM, KEY_DIM),
+        stride_order=(2, 1, 0),
+        assumed_align=DATA_ALIGN_BYTES,
+    )
+    return compile_tvm_ffi(
+        BlackwellDeltaAffineSummaryRev(heads, io_dtype, head_bn),
+        factor(io_dtype, KEY_DIM),
+        factor(io_dtype, KEY_DIM),
+        factor(io_dtype, KEY_DIM),
+        factor(io_dtype, VAL_DIM),
+        factor(io_dtype, BT),
+        factor(Float32, KEY_DIM),
+        out,
+        Float32(1.0),
+    )
+
+
+def affine_summary_rev(
+    qg: torch.Tensor,
+    kg: torch.Tensor,
+    w: torch.Tensor,
+    dout: torch.Tensor,
+    Aqk: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    scale: float,
+) -> torch.Tensor:
+    """Compute one shard's packed reverse affine summary.
+
+    Args:
+        qg: Gated queries, shape ``[1, T, H, 128]``, bf16 or fp16.
+        kg: Gated keys, with the same shape and dtype as ``qg``.
+        w: WY factor, with the same shape and dtype as ``qg``.
+        dout: Output gradient, shape ``[1, T, H, 128]``, same dtype as ``qg``.
+        Aqk: Intra-chunk query/key factor, shape ``[1, T, H, 64]``, same dtype as ``qg``.
+        cumulative_gate: Cumulative log2 gates, shape ``[1, T, H, 128]``, fp32.
+        scale: Query scaling factor used by the local backward recurrence.
+
+    Returns:
+        FP32 tensor of shape ``[H, 256, 128]``, V-first packed as local bias then
+        reverse transition for ``dH_in = dH_out @ transition + bias``.
+
+    Supported scope: B=1, fixed K=V=128 and BT=64, contiguous int32-addressable
+    inputs on Blackwell. A partial final chunk is neutral-padded by the wrapper.
+    """
+    assert qg.ndim == 4, f"qg must be 4D [1, T, H, K], got shape {tuple(qg.shape)}"
+    batch, tokens, heads, key_dim = qg.shape
+    assert batch == 1, f"affine_summary_rev requires B=1, got B={batch}"
+    assert tokens > 0, "affine_summary_rev requires at least one token"
+    assert key_dim == KEY_DIM, f"affine_summary_rev requires K={KEY_DIM}, got {key_dim}"
+    for name, tensor in (("kg", kg), ("w", w), ("dout", dout)):
+        assert tensor.shape == qg.shape, (
+            f"{name} must match qg shape {tuple(qg.shape)}, got {tuple(tensor.shape)}"
+        )
+    assert Aqk.shape == (1, tokens, heads, BT), (
+        f"Aqk must have shape {(1, tokens, heads, BT)}, got {tuple(Aqk.shape)}"
+    )
+    assert cumulative_gate.shape == qg.shape, (
+        f"cumulative_gate must match qg shape {tuple(qg.shape)}, "
+        f"got {tuple(cumulative_gate.shape)}"
+    )
+    assert qg.dtype in _IO_TYPE_NAMES, f"qg dtype must be bf16 or fp16, got {qg.dtype}"
+    for name, tensor in (("kg", kg), ("w", w), ("dout", dout), ("Aqk", Aqk)):
+        assert tensor.dtype == qg.dtype, (
+            f"{name} dtype must match qg dtype {qg.dtype}, got {tensor.dtype}"
+        )
+    assert cumulative_gate.dtype == torch.float32, (
+        f"cumulative_gate must be fp32, got {cumulative_gate.dtype}"
+    )
+
+    out = torch.empty(
+        (heads, SUMMARY_DIM, KEY_DIM),
+        dtype=torch.float32,
+        device=qg.device,
+    )
+    if isinstance(qg, FakeTensor):
+        return out
+
+    assert qg.is_cuda, "affine_summary_rev requires CUDA tensors"
+    inputs = (
+        ("qg", qg),
+        ("kg", kg),
+        ("w", w),
+        ("dout", dout),
+        ("Aqk", Aqk),
+        ("cumulative_gate", cumulative_gate),
+    )
+    for name, tensor in inputs:
+        assert tensor.device == qg.device, f"{name} must be on {qg.device}, got {tensor.device}"
+        assert tensor.is_contiguous(), f"{name} must be contiguous, got strides {tensor.stride()}"
+        assert tensor.data_ptr() % DATA_ALIGN_BYTES == 0, (
+            f"{name} data pointer must be {DATA_ALIGN_BYTES}-byte aligned"
+        )
+    pad = (-tokens) % BT
+    if pad:
+        padding = (0, 0, 0, 0, 0, pad)
+        qg, kg, w, dout, Aqk = (F.pad(tensor, padding) for tensor in (qg, kg, w, dout, Aqk))
+        cumulative_gate = torch.cat(
+            (
+                cumulative_gate,
+                cumulative_gate[:, -1:].expand(-1, pad, -1, -1),
+            ),
+            dim=1,
+        )
+    assert not requires_int64_abi(qg, kg, w, dout, Aqk, cumulative_gate, out), (
+        "affine_summary_rev currently requires int32-addressable tensors"
+    )
+
+    head_bn = select_summary_bn(heads, qg.device)
+    compiled = _compile_affine_summary_rev(_IO_TYPE_NAMES[qg.dtype], heads, head_bn)
+    compiled(
+        qg.detach(),
+        kg.detach(),
+        w.detach(),
+        dout.detach(),
+        Aqk.detach(),
+        cumulative_gate.detach(),
+        out,
+        Float32(scale),
+    )
+    return out

--- a/attn_gym/linear/_delta_rule/cute/affine_summary_rev.py
+++ b/attn_gym/linear/_delta_rule/cute/affine_summary_rev.py
@@ -1293,7 +1293,7 @@ def _compile_affine_summary_rev(dtype_name: str, heads: int, state_tile_width: i
     )
 
 
-def affine_summary_rev(
+def build_state_grad_summary(
     qg: torch.Tensor,
     kg: torch.Tensor,
     w: torch.Tensor,
@@ -1322,9 +1322,9 @@ def affine_summary_rev(
     """
     assert qg.ndim == 4, f"qg must be 4D [1, T, H, K], got shape {tuple(qg.shape)}"
     batch, tokens, heads, key_dim = qg.shape
-    assert batch == 1, f"affine_summary_rev requires B=1, got B={batch}"
-    assert tokens > 0, "affine_summary_rev requires at least one token"
-    assert key_dim == KEY_DIM, f"affine_summary_rev requires K={KEY_DIM}, got {key_dim}"
+    assert batch == 1, f"build_state_grad_summary requires B=1, got B={batch}"
+    assert tokens > 0, "build_state_grad_summary requires at least one token"
+    assert key_dim == KEY_DIM, f"build_state_grad_summary requires K={KEY_DIM}, got {key_dim}"
     for name, tensor in (("kg", kg), ("w", w), ("dout", dout)):
         assert tensor.shape == qg.shape, (
             f"{name} must match qg shape {tuple(qg.shape)}, got {tuple(tensor.shape)}"
@@ -1353,7 +1353,7 @@ def affine_summary_rev(
     if isinstance(qg, FakeTensor):
         return out
 
-    assert qg.is_cuda, "affine_summary_rev requires CUDA tensors"
+    assert qg.is_cuda, "build_state_grad_summary requires CUDA tensors"
     inputs = (
         ("qg", qg),
         ("kg", kg),
@@ -1380,7 +1380,7 @@ def affine_summary_rev(
             dim=1,
         )
     assert not requires_int64_abi(qg, kg, w, dout, Aqk, cumulative_gate, out), (
-        "affine_summary_rev currently requires int32-addressable tensors"
+        "build_state_grad_summary currently requires int32-addressable tensors"
     )
 
     state_tile_width = select_summary_tile_width(heads, qg.device)

--- a/attn_gym/linear/_delta_rule/cute/affine_summary_rev.py
+++ b/attn_gym/linear/_delta_rule/cute/affine_summary_rev.py
@@ -49,6 +49,20 @@ _IO_TYPE_NAMES = {torch.bfloat16: "bf16", torch.float16: "fp16"}
 _CUTE_IO_TYPES = {"bf16": cutlass.BFloat16, "fp16": cutlass.Float16}
 
 
+@cute.jit
+def _sequence_feature_head_batch_view(tensor):
+    """Re-rank ``[B,T,H,D]`` as ``[T,D,(H,B)]`` for a TMA operand."""
+    layout = cute.group_modes(cute.select(tensor.layout, mode=[1, 3, 2, 0]), 2, 4)
+    return cute.make_tensor(tensor.iterator, layout)
+
+
+@cute.jit
+def _feature_sequence_head_batch_view(tensor):
+    """Re-rank ``[B,T,H,D]`` as ``[D,T,(H,B)]`` for a TMA operand."""
+    layout = cute.group_modes(cute.select(tensor.layout, mode=[3, 1, 2, 0]), 2, 4)
+    return cute.make_tensor(tensor.iterator, layout)
+
+
 class WarpRole(IntEnum):
     """Warp-role boundaries in the persistent summary kernel."""
 
@@ -111,17 +125,20 @@ class BlackwellDeltaAffineSummaryRev:
         self,
         num_heads: int,
         io_type: type[cutlass.Numeric],
-        head_bn: int,
+        state_tile_width: int,
     ):
-        assert head_bn in (16, 32), f"BN must be 16 or 32, got {head_bn}"
+        # This limits columns handled by one CTA, not the number of attention heads.
+        assert state_tile_width in (16, 32), (
+            f"state tile width must be 16 or 32, got {state_tile_width}"
+        )
         self.num_heads = num_heads
         self.io_type = io_type
         self.acc_type = cutlass.Float32
         self.BT = BT
         self.BK = KEY_DIM
-        self.BN = head_bn
+        self.BN = state_tile_width
 
-        self.state_regs = 128 if head_bn == 16 else 160
+        self.state_regs = 128 if state_tile_width == 16 else 160
         self.aux_regs = 40
 
         self.dv_tile = (self.BT, self.BN, self.BK)
@@ -129,7 +146,7 @@ class BlackwellDeltaAffineSummaryRev:
         self.aqdo_tile = (self.BT, self.BN, self.BT)
         self.wdv_tile = (self.BK, self.BN, self.BT)
 
-        self.k_depth = 6 if head_bn == 16 else 4
+        self.k_depth = 6 if state_tile_width == 16 else 4
         self.q_depth = 2
         self.do_depth = 2
         self.w_depth = 2
@@ -166,28 +183,23 @@ class BlackwellDeltaAffineSummaryRev:
         stream: cuda.CUstream,
     ):
         """Construct TMA/UMMA descriptors and launch the persistent kernel."""
-        g_k = cute.make_tensor(
-            kg.iterator,
-            cute.group_modes(cute.select(kg.layout, mode=[1, 3, 2, 0]), 2, 4),
-        )
-        g_qt = cute.make_tensor(
-            qg.iterator,
-            cute.group_modes(cute.select(qg.layout, mode=[3, 1, 2, 0]), 2, 4),
-        )
-        g_wt = cute.make_tensor(w.iterator, g_qt.layout)
-        g_gate = cute.make_tensor(
-            cumulative_gate.iterator,
-            cute.group_modes(cute.select(cumulative_gate.layout, mode=[3, 1, 2, 0]), 2, 4),
-        )
-        g_do = cute.make_tensor(
-            dout.iterator,
-            cute.group_modes(cute.select(dout.layout, mode=[3, 1, 2, 0]), 2, 4),
-        )
-        g_aqk = cute.make_tensor(
-            aqk.iterator,
-            cute.group_modes(cute.select(aqk.layout, mode=[3, 1, 2, 0]), 2, 4),
-        )
+        g_k = _sequence_feature_head_batch_view(kg)
+        g_qt = _feature_sequence_head_batch_view(qg)
+        g_wt = _feature_sequence_head_batch_view(w)
+        g_gate = _feature_sequence_head_batch_view(cumulative_gate)
+        g_do = _feature_sequence_head_batch_view(dout)
+        g_aqk = _feature_sequence_head_batch_view(aqk)
 
+        # For one augmented-state tile X [K, BN], each reverse chunk evaluates:
+        #   dv    = kg @ X + Aqk^T @ dO       [BT, BN]
+        #   X     = decay * X + scale * qg^T @ dO - w^T @ dv
+        # dO is source-only: output gradients occupy the bias columns, while the
+        # transition columns are zero because they have no local output source.
+        # The four UMMAs below materialize those four matrix products. Separate
+        # operations are needed because their reduction dimensions and physical
+        # operand layouts differ, even when they share an output accumulator.
+
+        # MMA1: kg [BT,K] reads X [K,BN] to begin the local write gradient dv.
         mma_dv = sm100_utils.make_trivial_tiled_mma(
             self.io_type,
             tcgen05.OperandMajorMode.K,
@@ -197,6 +209,7 @@ class BlackwellDeltaAffineSummaryRev:
             self.dv_tile[:2],
             tcgen05.OperandSource.SMEM,
         )
+        # MMA2: qg^T [K,BT] reads dO [BT,BN] for the direct query contribution.
         mma_qdo = sm100_utils.make_trivial_tiled_mma(
             self.io_type,
             tcgen05.OperandMajorMode.MN,
@@ -206,6 +219,7 @@ class BlackwellDeltaAffineSummaryRev:
             self.qdo_tile[:2],
             tcgen05.OperandSource.SMEM,
         )
+        # MMA3: Aqk^T [BT,BT] reads dO and accumulates the local term into dv.
         mma_aqdo = sm100_utils.make_trivial_tiled_mma(
             self.io_type,
             tcgen05.OperandMajorMode.MN,
@@ -215,6 +229,7 @@ class BlackwellDeltaAffineSummaryRev:
             self.aqdo_tile[:2],
             tcgen05.OperandSource.SMEM,
         )
+        # MMA4: w^T [K,BT] reads the completed dv for the subtractive WY term.
         mma_wdv = sm100_utils.make_trivial_tiled_mma(
             self.io_type,
             tcgen05.OperandMajorMode.MN,
@@ -1233,14 +1248,15 @@ class BlackwellDeltaAffineSummaryRev:
         return (min(sm_count, self.num_heads * (SUMMARY_DIM // self.BN)), 1, 1)
 
 
-def select_summary_bn(heads: int, device: torch.device) -> int:
-    """Choose BN using the delta-H width heuristic over the augmented state."""
-    column_tiles_at_bn16 = (SUMMARY_DIM // 16) * heads
-    return 32 if column_tiles_at_bn16 > get_device_properties(device).multi_processor_count else 16
+def select_summary_tile_width(heads: int, device: torch.device) -> int:
+    """Choose the per-CTA state-column width from the available SM count."""
+    work_tiles_at_width_16 = (SUMMARY_DIM // 16) * heads
+    sm_count = get_device_properties(device).multi_processor_count
+    return 32 if work_tiles_at_width_16 > sm_count else 16
 
 
 @jit_cache
-def _compile_affine_summary_rev(dtype_name: str, heads: int, head_bn: int):
+def _compile_affine_summary_rev(dtype_name: str, heads: int, state_tile_width: int):
     """Compile one reverse-summary dtype/head/tile specialization."""
     target = get_compile_target()
     if target.device_type != "cuda" or target.capability is None or target.capability < (10, 0):
@@ -1265,7 +1281,7 @@ def _compile_affine_summary_rev(dtype_name: str, heads: int, head_bn: int):
         assumed_align=DATA_ALIGN_BYTES,
     )
     return compile_tvm_ffi(
-        BlackwellDeltaAffineSummaryRev(heads, io_dtype, head_bn),
+        BlackwellDeltaAffineSummaryRev(heads, io_dtype, state_tile_width),
         factor(io_dtype, KEY_DIM),
         factor(io_dtype, KEY_DIM),
         factor(io_dtype, KEY_DIM),
@@ -1367,8 +1383,8 @@ def affine_summary_rev(
         "affine_summary_rev currently requires int32-addressable tensors"
     )
 
-    head_bn = select_summary_bn(heads, qg.device)
-    compiled = _compile_affine_summary_rev(_IO_TYPE_NAMES[qg.dtype], heads, head_bn)
+    state_tile_width = select_summary_tile_width(heads, qg.device)
+    compiled = _compile_affine_summary_rev(_IO_TYPE_NAMES[qg.dtype], heads, state_tile_width)
     compiled(
         qg.detach(),
         kg.detach(),

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import torch
 
 from attn_gym.linear.kda.bwd.cute.chunk_delta_h_bwd import (
@@ -16,6 +18,157 @@ from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata
 from attn_gym.linear.kda.fwd.cute.recompute_w_u_fwd import recompute_w_u_fwd
 from attn_gym.linear.kda.fwd.triton.chunk_delta_h import chunk_gated_delta_rule_fwd_h
 from attn_gym.linear.kda.utils import profiler_range
+
+
+@dataclass
+class ChunkKDABwdPrepared:
+    """Consumable local tensors shared across the CP backward communication boundary."""
+
+    w: torch.Tensor | None
+    qg: torch.Tensor | None
+    kg: torch.Tensor | None
+    h: torch.Tensor | None
+    v_new: torch.Tensor | None
+    d_aqk: torch.Tensor | None
+
+
+def _prepare_chunk_kda_bwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    Akk: torch.Tensor,
+    do: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    metadata: RaggedChunkMetadata | None,
+    *,
+    scale: float,
+    chunk_size: int,
+    autotune: bool,
+) -> ChunkKDABwdPrepared:
+    """Recompute local forward state and output factors before CP communication."""
+    with profiler_range("kda/cute/backward_recompute_w_u"):
+        w, u, qg, kg = recompute_w_u_fwd(
+            q=q,
+            k=k,
+            v=v,
+            beta=beta,
+            A=Akk,
+            gk=g,
+            metadata=metadata,
+            chunk_size=chunk_size,
+            autotune=autotune,
+        )
+    assert qg is not None and kg is not None
+    with profiler_range("kda/triton/backward_recompute_state"):
+        h, v_new, _ = chunk_gated_delta_rule_fwd_h(
+            kg,
+            w,
+            u,
+            g,
+            initial_state,
+            chunk_size=chunk_size,
+            output_final_state=False,
+            metadata=metadata,
+            autotune=autotune,
+        )
+    with profiler_range("kda/triton/backward_daqk"):
+        d_aqk = chunk_kda_bwd_daqk(
+            v_new,
+            do,
+            scale,
+            chunk_size=chunk_size,
+            metadata=metadata,
+        )
+    return ChunkKDABwdPrepared(w, qg, kg, h, v_new, d_aqk)
+
+
+def _finish_chunk_kda_bwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    Aqk: torch.Tensor,
+    Akk: torch.Tensor,
+    do: torch.Tensor,
+    d_final_state: torch.Tensor | None,
+    initial_state: torch.Tensor | None,
+    metadata: RaggedChunkMetadata | None,
+    prepared: ChunkKDABwdPrepared,
+    *,
+    scale: float,
+    chunk_size: int,
+    fastmath: bool,
+    autotune: bool,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor | None,
+]:
+    """Finish local gradients while releasing prepared tensors at their last use."""
+    assert prepared.qg is not None and prepared.kg is not None and prepared.w is not None
+    with profiler_range("kda/cute/backward_delta_h"):
+        dh, d_initial_state, dv = blackwell_delta_h_bwd_dhu_dv_fused_dispatch(
+            prepared.qg,
+            prepared.kg,
+            prepared.w,
+            do,
+            Aqk,
+            gk=g,
+            h0=initial_state,
+            dht=d_final_state,
+            scale=scale,
+            chunk_size=chunk_size,
+            metadata=metadata,
+        )
+    prepared.qg = prepared.kg = prepared.w = None
+
+    assert prepared.v_new is not None and prepared.h is not None
+    with profiler_range("kda/cute/backward_wy_dqkg"):
+        dq, dk, dv, dg, db, dAkk = chunk_kda_bwd_wy_dqkg(
+            q,
+            k,
+            v,
+            prepared.v_new,
+            g,
+            beta,
+            Akk,
+            prepared.h,
+            do,
+            dh,
+            dv,
+            metadata,
+            scale=scale,
+            chunk_size=chunk_size,
+            fastmath=fastmath,
+            autotune=autotune,
+        )
+    prepared.h = prepared.v_new = None
+    del dh
+
+    assert prepared.d_aqk is not None
+    with profiler_range("kda/cute/backward_intra"):
+        dq, dk, dg, db = chunk_kda_bwd_intra(
+            q,
+            k,
+            g,
+            beta,
+            prepared.d_aqk,
+            dAkk,
+            dq,
+            dk,
+            db,
+            dg,
+            metadata,
+            autotune=autotune,
+        )
+    prepared.d_aqk = None
+    return dq, dk, dv, dg, db, d_initial_state
 
 
 def chunk_kda_bwd(
@@ -53,95 +206,40 @@ def chunk_kda_bwd(
     if tokens % chunk_size and metadata is None:
         raise ValueError("the composed KDA backward requires complete chunks")
 
-    # Forward deliberately saves only the minimal backward factors. Always
-    # reconstruct the large W/U, gated Q/K, state, and corrected-value
-    # intermediates here instead of retaining them for the lifetime of the graph.
-    with profiler_range("kda/cute/backward_recompute_w_u"):
-        w, u, qg, kg = recompute_w_u_fwd(
-            q=q,
-            k=k,
-            v=v,
-            beta=beta,
-            A=Akk,
-            gk=g,
-            metadata=metadata,
-            chunk_size=chunk_size,
-            autotune=autotune,
-        )
-    assert qg is not None and kg is not None
-    with profiler_range("kda/triton/backward_recompute_state"):
-        h, v_new, _ = chunk_gated_delta_rule_fwd_h(
-            kg,
-            w,
-            u,
-            g,
-            initial_state,
-            chunk_size=chunk_size,
-            output_final_state=False,
-            metadata=metadata,
-            autotune=autotune,
-        )
-    del u
-
-    with profiler_range("kda/triton/backward_daqk"):
-        dAqk = chunk_kda_bwd_daqk(
-            v_new,
-            do,
-            scale,
-            chunk_size=chunk_size,
-            metadata=metadata,
-        )
-    with profiler_range("kda/cute/backward_delta_h"):
-        dh, d_initial_state, dv = blackwell_delta_h_bwd_dhu_dv_fused_dispatch(
-            qg,
-            kg,
-            w,
-            do,
-            Aqk,
-            gk=g,
-            h0=initial_state,
-            dht=d_final_state,
-            scale=scale,
-            chunk_size=chunk_size,
-            metadata=metadata,
-        )
-    del w, qg, kg
-    with profiler_range("kda/cute/backward_wy_dqkg"):
-        dq, dk, dv, dg, db, dAkk = chunk_kda_bwd_wy_dqkg(
-            q,
-            k,
-            v,
-            v_new,
-            g,
-            beta,
-            Akk,
-            h,
-            do,
-            dh,
-            dv,
-            metadata,
-            scale=scale,
-            chunk_size=chunk_size,
-            fastmath=fastmath,
-            autotune=autotune,
-        )
-    del h, v_new, dh
-    with profiler_range("kda/cute/backward_intra"):
-        dq, dk, dg, db = chunk_kda_bwd_intra(
-            q,
-            k,
-            g,
-            beta,
-            dAqk,
-            dAkk,
-            dq,
-            dk,
-            db,
-            dg,
-            metadata,
-            autotune=autotune,
-        )
-    return dq, dk, dv, dg, db, d_initial_state
+    # Forward deliberately saves only minimal factors. Reconstruct large local
+    # tensors before the optional CP reverse-summary communication boundary.
+    prepared = _prepare_chunk_kda_bwd(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        Akk,
+        do,
+        initial_state,
+        metadata,
+        scale=scale,
+        chunk_size=chunk_size,
+        autotune=autotune,
+    )
+    return _finish_chunk_kda_bwd(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        Aqk,
+        Akk,
+        do,
+        d_final_state,
+        initial_state,
+        metadata,
+        prepared,
+        scale=scale,
+        chunk_size=chunk_size,
+        fastmath=fastmath,
+        autotune=autotune,
+    )
 
 
 __all__ = ["chunk_kda_bwd"]

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import NamedTuple
+
 import torch
 
 from attn_gym._backends.cute import (
@@ -131,6 +133,88 @@ def _validate_paged_private_abi(
         raise ValueError("has_initial_state must be contiguous bool with one entry per sequence")
 
 
+class ChunkKDAFactors(NamedTuple):
+    """Local KDA factors shared by state summary and output composition."""
+
+    w: torch.Tensor
+    u: torch.Tensor
+    kg: torch.Tensor
+    aqk: torch.Tensor
+    akk: torch.Tensor
+
+
+def _prepare_chunk_kda_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    metadata: RaggedChunkMetadata | None,
+    *,
+    scale: float,
+    autotune: bool,
+) -> ChunkKDAFactors:
+    """Compute the local factors needed by both CP summaries and ordinary output."""
+    with profiler_range("kda/fused/chunk_kda_fwd_intra"):
+        return ChunkKDAFactors(
+            *chunk_kda_fwd_intra(
+                q,
+                k,
+                v,
+                cumulative_gate,
+                beta,
+                scale,
+                metadata,
+                chunk_size=_CHUNK_SIZE,
+                profile_ranges=torch.autograd.profiler._is_profiler_enabled,
+                autotune=autotune,
+            )
+        )
+
+
+def _finish_chunk_kda_fwd(
+    q: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    factors: ChunkKDAFactors,
+    initial_state: torch.Tensor | None,
+    state_indices: torch.Tensor | None,
+    has_initial_state: torch.Tensor | None,
+    metadata: RaggedChunkMetadata | None,
+    *,
+    scale: float,
+    output_final_state: bool,
+    autotune: bool,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Apply an initial state and compose token outputs from prepared local factors."""
+    with profiler_range("kda/triton/inter_chunk_state"):
+        h, v_new, final_state = chunk_gated_delta_rule_fwd_h(
+            factors.kg,
+            factors.w,
+            factors.u,
+            cumulative_gate,
+            initial_state,
+            state_indices=state_indices,
+            has_initial_state=has_initial_state,
+            chunk_size=_CHUNK_SIZE,
+            output_final_state=output_final_state,
+            metadata=metadata,
+            autotune=autotune,
+        )
+    with profiler_range("kda/triton/output_composition"):
+        output = chunk_gla_fwd_o_gk(
+            q,
+            v_new,
+            cumulative_gate,
+            factors.aqk,
+            h,
+            scale,
+            chunk_size=_CHUNK_SIZE,
+            metadata=metadata,
+            autotune=autotune,
+        )
+    return output, final_state
+
+
 def _chunk_kda_fwd(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -147,46 +231,29 @@ def _chunk_kda_fwd(
     autotune: bool,
 ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor, torch.Tensor]:
     """Run the optimized KDA core using an already selected chunk schedule."""
-    with profiler_range("kda/fused/chunk_kda_fwd_intra"):
-        w, u, kg, Aqk, Akk = chunk_kda_fwd_intra(
-            q,
-            k,
-            v,
-            cumulative_gate,
-            beta,
-            scale,
-            metadata,
-            chunk_size=_CHUNK_SIZE,
-            profile_ranges=torch.autograd.profiler._is_profiler_enabled,
-            autotune=autotune,
-        )
-    with profiler_range("kda/triton/inter_chunk_state"):
-        h, v_new, final_state = chunk_gated_delta_rule_fwd_h(
-            kg,
-            w,
-            u,
-            cumulative_gate,
-            initial_state,
-            state_indices=state_indices,
-            has_initial_state=has_initial_state,
-            chunk_size=_CHUNK_SIZE,
-            output_final_state=output_final_state,
-            metadata=metadata,
-            autotune=autotune,
-        )
-    with profiler_range("kda/triton/output_composition"):
-        output = chunk_gla_fwd_o_gk(
-            q,
-            v_new,
-            cumulative_gate,
-            Aqk,
-            h,
-            scale,
-            chunk_size=_CHUNK_SIZE,
-            metadata=metadata,
-            autotune=autotune,
-        )
-    return output, final_state, Aqk, Akk
+    factors = _prepare_chunk_kda_fwd(
+        q,
+        k,
+        v,
+        cumulative_gate,
+        beta,
+        metadata,
+        scale=scale,
+        autotune=autotune,
+    )
+    output, final_state = _finish_chunk_kda_fwd(
+        q,
+        cumulative_gate,
+        factors,
+        initial_state,
+        state_indices,
+        has_initial_state,
+        metadata,
+        scale=scale,
+        output_final_state=output_final_state,
+        autotune=autotune,
+    )
+    return output, final_state, factors.aqk, factors.akk
 
 
 def _chunk_kda_fwd_shared(

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -103,12 +103,16 @@ token stream, so it can split at most one logical sequence. Each rank therefore 
 one fixed-size forward summary and one reverse summary, independent of how many complete local
 sequences it owns. The example validates local outputs, global endpoint states, and gradients
 against an unsharded execution; it can also capture forward, NCCL communication, and backward in
-one CUDA Graph and validate a changed-input replay.
+one CUDA Graph and validate a changed-input replay. Add `--profile` to export a Chrome trace for
+each rank; when transformer-nuggets is installed, the example also writes one merged multi-rank
+trace.
 
 ```bash
 torchrun --standalone --nproc_per_node=2 examples/kda_context_parallel.py
 
 torchrun --standalone --nproc_per_node=2 examples/kda_context_parallel.py --cuda-graph
+
+torchrun --standalone --nproc_per_node=2 examples/kda_context_parallel.py --profile
 ```
 
 ## Kernel Tuning

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -101,8 +101,7 @@ for sequence fragments crossing rank boundaries, then runs the ordinary local KD
 backward once with the composed boundary state. A contiguous rank boundary is one cut in the packed
 token stream, so it can split at most one logical sequence. Each rank therefore exchanges at most
 one fixed-size forward summary and one reverse summary, independent of how many complete local
-sequences it owns. The `--summary-backend public` option retains the zero/identity-probe formulation
-as a correctness oracle. The example validates local outputs, global endpoint states, and gradients
+sequences it owns. The example validates local outputs, global endpoint states, and gradients
 against an unsharded execution; it can also capture forward, NCCL communication, and backward in
 one CUDA Graph and validate a changed-input replay.
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -103,9 +103,8 @@ token stream, so it can split at most one logical sequence. Each rank therefore 
 one fixed-size forward summary and one reverse summary, independent of how many complete local
 sequences it owns. The example validates local outputs, global endpoint states, and gradients
 against an unsharded execution; it can also capture forward, NCCL communication, and backward in
-one CUDA Graph and validate a changed-input replay. Add `--profile` to export a Chrome trace for
-each rank; when transformer-nuggets is installed, the example also writes one merged multi-rank
-trace.
+one CUDA Graph and validate a changed-input replay. Add `--profile` to use transformer-nuggets to
+export one merged multi-rank trace in native Perfetto `.pftrace` format.
 
 ```bash
 torchrun --standalone --nproc_per_node=2 examples/kda_context_parallel.py

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -89,6 +89,29 @@ Implements a generic single-node ring-attention example launched with `torchrun`
 torchrun --standalone --nproc_per_node=4 examples/ring_attention.py --seq-len 131072
 ```
 
+## KDA Context Parallelism
+
+[`examples/kda_context_parallel.py`](https://github.com/meta-pytorch/attention-gym/blob/main/examples/kda_context_parallel.py)
+— Build packed KDA context parallelism from native CuTeDSL affine-summary kernels and PyTorch
+distributed collectives.
+
+The default backend computes forward and reverse `[bias; transition]` state summaries with Blackwell
+TMA/UMMA kernels; the reverse scan uses persistent work scheduling. It all-gathers only summaries
+for sequence fragments crossing rank boundaries, then runs the ordinary local KDA forward or
+backward once with the composed boundary state. A contiguous rank boundary is one cut in the packed
+token stream, so it can split at most one logical sequence. Each rank therefore exchanges at most
+one fixed-size forward summary and one reverse summary, independent of how many complete local
+sequences it owns. The `--summary-backend public` option retains the zero/identity-probe formulation
+as a correctness oracle. The example validates local outputs, global endpoint states, and gradients
+against an unsharded execution; it can also capture forward, NCCL communication, and backward in
+one CUDA Graph and validate a changed-input replay.
+
+```bash
+torchrun --standalone --nproc_per_node=2 examples/kda_context_parallel.py
+
+torchrun --standalone --nproc_per_node=2 examples/kda_context_parallel.py --cuda-graph
+```
+
 ## Kernel Tuning
 
 ### Autotune Replay

--- a/examples/kda_context_parallel.py
+++ b/examples/kda_context_parallel.py
@@ -76,28 +76,6 @@ def kernel_stage(name: str, annotate: bool, *, backward: bool = True):
 # and ordering remain uniform.
 
 
-class _AllGather(torch.autograd.Function):
-    """Autograd-enabled all-gather built from public distributed collectives."""
-
-    @staticmethod
-    def forward(ctx, tensor: torch.Tensor, group: dist.ProcessGroup) -> torch.Tensor:
-        ctx.group = group
-        gathered = tensor.new_empty(dist.get_world_size(group), *tensor.shape)
-        dist.all_gather_single(gathered, tensor.contiguous(), group=group)
-        return gathered
-
-    @staticmethod
-    def backward(ctx, grad_gathered: torch.Tensor) -> tuple[torch.Tensor, None]:
-        grad_tensor = torch.empty_like(grad_gathered[0])
-        dist.reduce_scatter_single(
-            grad_tensor,
-            grad_gathered.contiguous(),
-            op=dist.ReduceOp.SUM,
-            group=ctx.group,
-        )
-        return grad_tensor, None
-
-
 def partition_packed_sequences(
     global_cu_seqlens: tuple[int, ...],
     world_size: int,
@@ -133,137 +111,12 @@ def partition_packed_sequences(
     return tuple(shards)
 
 
-def build_state_summaries(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    gate: torch.Tensor,
-    beta: torch.Tensor,
-    cu_seqlens: torch.Tensor,
-    annotate: bool = False,
-) -> torch.Tensor:
-    """Recover each local fragment's ``H_out = H_in @ A + B`` summary."""
-    sequences = cu_seqlens.shape[0] - 1
-    heads, key_dim, value_dim = q.shape[2], q.shape[-1], v.shape[-1]
-    if value_dim != key_dim:
-        raise ValueError("the public identity-probe construction requires value_dim == key_dim")
-
-    zero = q.new_zeros(sequences, heads, value_dim, key_dim, dtype=torch.float32)
-    identity = torch.eye(key_dim, dtype=torch.float32, device=q.device).expand_as(zero)
-    with kernel_stage("cp/fwd/summary_zero", annotate):
-        _, bias = chunk_kda(
-            q,
-            k,
-            v,
-            gate,
-            beta,
-            initial_state=zero,
-            cu_seqlens=cu_seqlens,
-            output_final_state=True,
-            autotune=False,
-            impl="fused",
-        )
-    with kernel_stage("cp/fwd/summary_identity", annotate):
-        _, identity_final = chunk_kda(
-            q,
-            k,
-            v,
-            gate,
-            beta,
-            initial_state=identity,
-            cu_seqlens=cu_seqlens,
-            output_final_state=True,
-            autotune=False,
-            impl="fused",
-        )
-    if bias is None or identity_final is None:
-        raise RuntimeError("chunk_kda did not return its requested final state")
-    transition = identity_final - bias
-    return torch.cat((bias, transition), dim=-2)
-
-
 def merge_state(state: torch.Tensor, summary: torch.Tensor) -> torch.Tensor:
     """Merge a packed V-first affine summary into a recurrent state."""
     value_dim = state.shape[-2]
     bias = summary[..., :value_dim, :]
     transition = summary[..., value_dim:, :]
     return state @ transition + bias
-
-
-def context_parallel_kda(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    gate: torch.Tensor,
-    beta: torch.Tensor,
-    *,
-    group: dist.ProcessGroup,
-    shards: tuple[PackedShard, ...],
-    local_cu_seqlens: torch.Tensor,
-    annotate: bool = False,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    """Apply zero-state packed KDA to one contiguous context-parallel shard."""
-    rank = dist.get_rank(group)
-    shard = shards[rank]
-    shard_tokens = shard.cu_seqlens[-1]
-    if q.shape[0] != 1 or q.shape[1] != shard_tokens:
-        raise ValueError(f"rank inputs must have shape [1,{shard_tokens},H,D]")
-    if (
-        local_cu_seqlens.shape != (len(shard.cu_seqlens),)
-        or local_cu_seqlens.dtype != torch.int32
-        or local_cu_seqlens.device != q.device
-    ):
-        raise ValueError("local_cu_seqlens has invalid shape, dtype, or device")
-
-    # See NOTE [One crossing sequence per contiguous rank boundary].
-    continues_on_next_rank = (
-        rank + 1 < len(shards) and shard.sequence_ids[-1] == shards[rank + 1].sequence_ids[0]
-    )
-    if continues_on_next_rank:
-        boundary_start = shard.cu_seqlens[-2]
-        boundary_inputs = tuple(tensor[:, boundary_start:] for tensor in (q, k, v, gate, beta))
-        boundary_cu_seqlens = local_cu_seqlens[-2:] - local_cu_seqlens[-2]
-        local_summary = build_state_summaries(
-            *boundary_inputs,
-            boundary_cu_seqlens,
-            annotate,
-        )[0]
-    else:
-        # Keep collective autograd ordering identical when no state crosses this boundary.
-        anchor = q.reshape(-1)[0].float() * 0
-        local_summary = (
-            q.new_zeros(
-                q.shape[2],
-                v.shape[-1] + q.shape[-1],
-                q.shape[-1],
-                dtype=torch.float32,
-            )
-            + anchor
-        )
-    with kernel_stage("cp/fwd/all_gather", annotate):
-        gathered = _AllGather.apply(local_summary, group)
-
-    with kernel_stage("cp/fwd/exclusive_prefix", annotate):
-        states = _compose_forward_initial_states(gathered, q, v, rank, shards)
-        # Ranks with an empty prefix must still execute all-gather's backward collective.
-        states = states + gathered[rank].reshape(-1)[0] * 0
-
-    with kernel_stage("cp/fwd/local_output", annotate):
-        output, final_state = chunk_kda(
-            q,
-            k,
-            v,
-            gate,
-            beta,
-            initial_state=states,
-            cu_seqlens=local_cu_seqlens,
-            output_final_state=True,
-            autotune=False,
-            impl="fused",
-        )
-        if final_state is None:
-            raise RuntimeError("chunk_kda did not return its requested final state")
-        return output, final_state
 
 
 def _all_gather_tensor(tensor: torch.Tensor, group: dist.ProcessGroup) -> torch.Tensor:
@@ -530,7 +383,7 @@ class _CuteContextParallelKDA(torch.autograd.Function):
         return dq, dk, dv, d_gate, db, None, None, None, None, None, None, None
 
 
-def context_parallel_kda_cute(
+def context_parallel_kda(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
@@ -571,12 +424,6 @@ def parse_args() -> argparse.Namespace:
         help="Comma-separated nonempty packed sequence lengths.",
     )
     parser.add_argument("--heads", type=int, default=2)
-    parser.add_argument(
-        "--summary-backend",
-        choices=("cute", "public"),
-        default="cute",
-        help="Use native CuTeDSL affine summaries or the public zero/identity probes.",
-    )
     parser.add_argument(
         "--cuda-graph",
         action="store_true",
@@ -661,12 +508,8 @@ def main() -> None:
         global_cu_seqlens,
     )
 
-    cp_operation = (
-        context_parallel_kda_cute if args.summary_backend == "cute" else context_parallel_kda
-    )
-
     def run(inputs: tuple[torch.Tensor, ...], *, annotate: bool = False):
-        output, final_state = cp_operation(
+        output, final_state = context_parallel_kda(
             *inputs,
             group=dist.group.WORLD,
             shards=shards,

--- a/examples/kda_context_parallel.py
+++ b/examples/kda_context_parallel.py
@@ -24,7 +24,7 @@ import torch.distributed as dist
 import torch.nn.functional as F
 
 from attn_gym.linear import chunk_kda
-from attn_gym.linear._delta_rule.cute import affine_summary_fwd, affine_summary_rev
+from attn_gym.linear._delta_rule.cute import build_state_grad_summary, build_state_summary
 from attn_gym.linear.kda.bwd.cute.chunk_kda_bwd import (
     _finish_chunk_kda_bwd,
     _prepare_chunk_kda_bwd,
@@ -133,7 +133,7 @@ def partition_packed_sequences(
     return tuple(shards)
 
 
-def local_affine_summaries(
+def build_state_summaries(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
@@ -182,8 +182,8 @@ def local_affine_summaries(
     return torch.cat((bias, transition), dim=-2)
 
 
-def propagate_state(state: torch.Tensor, summary: torch.Tensor) -> torch.Tensor:
-    """Propagate a recurrent state through one packed V-first affine summary."""
+def merge_state(state: torch.Tensor, summary: torch.Tensor) -> torch.Tensor:
+    """Merge a packed V-first affine summary into a recurrent state."""
     value_dim = state.shape[-2]
     bias = summary[..., :value_dim, :]
     transition = summary[..., value_dim:, :]
@@ -223,7 +223,7 @@ def context_parallel_kda(
         boundary_start = shard.cu_seqlens[-2]
         boundary_inputs = tuple(tensor[:, boundary_start:] for tensor in (q, k, v, gate, beta))
         boundary_cu_seqlens = local_cu_seqlens[-2:] - local_cu_seqlens[-2]
-        local_summary = local_affine_summaries(
+        local_summary = build_state_summaries(
             *boundary_inputs,
             boundary_cu_seqlens,
             annotate,
@@ -304,7 +304,7 @@ def _compose_forward_initial_states(
     first_sequence = shard.sequence_ids[0]
     for predecessor, predecessor_shard in zip(gathered[:rank], shards[:rank], strict=True):
         if predecessor_shard.sequence_ids[-1] == first_sequence:
-            first_state = propagate_state(first_state, predecessor)
+            first_state = merge_state(first_state, predecessor)
     return torch.cat((first_state.unsqueeze(0), states[1:]), dim=0)
 
 
@@ -329,7 +329,7 @@ def _compose_reverse_final_states(
         successor = shards[successor_rank]
         if successor.sequence_ids[0] != last_sequence:
             continue
-        last_gradient = propagate_state(last_gradient, gathered[successor_rank])
+        last_gradient = merge_state(last_gradient, gathered[successor_rank])
     incoming = incoming.clone()
     incoming[-1] += last_gradient
     return incoming
@@ -378,7 +378,7 @@ class _CuteContextParallelKDA(torch.autograd.Function):
         if continues:
             start = shard.cu_seqlens[-2]
             with kernel_stage("cp/fwd/summary", annotate):
-                summary = affine_summary_fwd(
+                summary = build_state_summary(
                     factors.kg[:, start:],
                     factors.w[:, start:],
                     factors.u[:, start:],
@@ -477,7 +477,7 @@ class _CuteContextParallelKDA(torch.autograd.Function):
         if continues_from_previous:
             stop = shard.cu_seqlens[1]
             with kernel_stage("cp/bwd/summary", ctx.annotate, backward=False):
-                summary = affine_summary_rev(
+                summary = build_state_grad_summary(
                     prepared.qg[:, :stop],
                     prepared.kg[:, :stop],
                     prepared.w[:, :stop],
@@ -488,7 +488,7 @@ class _CuteContextParallelKDA(torch.autograd.Function):
                 )
             if d_final_state is not None:
                 value_dim = v.shape[-1]
-                bias = propagate_state(d_final_state[0], summary)
+                bias = merge_state(d_final_state[0], summary)
                 summary = torch.cat((bias, summary[..., value_dim:, :]), dim=-2)
         else:
             summary = _unused_summary(q)

--- a/examples/kda_context_parallel.py
+++ b/examples/kda_context_parallel.py
@@ -5,8 +5,9 @@ Each rank owns an equal contiguous token shard. Launch with:
     torchrun --standalone --nproc-per-node=2 examples/kda_context_parallel.py
 
 Add ``--cuda-graph`` to capture forward and backward together and validate a replay with
-changed inputs. The example requires one Blackwell GPU per rank because the fused KDA backend
-currently targets SM100 or newer.
+changed inputs. Add ``--profile`` to export per-rank Chrome traces and, when
+transformer-nuggets is installed, a merged trace. The example requires one Blackwell GPU per rank
+because the fused KDA backend currently targets SM100 or newer.
 """
 
 from __future__ import annotations
@@ -15,9 +16,13 @@ import argparse
 import bisect
 import gc
 import os
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
+from importlib import import_module
+from importlib.util import find_spec
 from itertools import accumulate, pairwise
+from pathlib import Path
 
 import torch
 import torch.distributed as dist
@@ -65,6 +70,30 @@ def kernel_stage(name: str, annotate: bool, *, backward: bool = True):
         annotation = mark_kernels(name, backward=backward)
     with torch.profiler.record_function(name), annotation:
         yield
+
+
+@contextmanager
+def profile_trace(
+    enabled: bool,
+    path: Path,
+    rank: int,
+) -> Iterator[torch.profiler.profile | None]:
+    """Export one rank's trace, preferring transformer-nuggets when installed."""
+    if not enabled:
+        yield None
+        return
+
+    if find_spec("transformer_nuggets") is not None:
+        profiler = import_module("transformer_nuggets.utils.benchmark").profiler
+        with profiler(path, record_shapes=True) as active_profiler:
+            yield active_profiler
+        return
+
+    rank_path = path.with_name(f"{path.stem}_rank_{rank}.json")
+    activities = [torch.profiler.ProfilerActivity.CPU, torch.profiler.ProfilerActivity.CUDA]
+    with torch.profiler.profile(activities=activities, record_shapes=True) as active_profiler:
+        yield active_profiler
+    active_profiler.export_chrome_trace(str(rank_path))
 
 
 # NOTE [One crossing sequence per contiguous rank boundary]
@@ -429,6 +458,11 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Capture forward and backward and validate a changed-input replay.",
     )
+    parser.add_argument(
+        "--profile",
+        action="store_true",
+        help="Export per-rank Chrome traces and a merged transformer-nuggets trace.",
+    )
     return parser.parse_args()
 
 
@@ -523,6 +557,40 @@ def main() -> None:
             gradients = torch.autograd.grad(loss, inputs)
         return output, final_state, gradients
 
+    profile_mode = "cuda_graph" if args.cuda_graph else "eager"
+    profile_path = Path(
+        f"kda_context_parallel_{profile_mode}_w{world_size}_t{tokens}_h{args.heads}"
+    ).resolve()
+
+    def record_profile(step: Callable[[], object], label: str) -> None:
+        """Capture one synchronized distributed step and merge rank traces when possible."""
+        dist.barrier()
+        with profile_trace(args.profile, profile_path, rank) as active_profiler:
+            with torch.profiler.record_function(f"cp/rank_{rank}/{label}"):
+                step()
+            torch.cuda.synchronize(device)
+            if active_profiler is not None:
+                active_profiler.step()
+        dist.barrier()
+
+        rank_path = profile_path.with_name(f"{profile_path.stem}_rank_{rank}.json")
+        if find_spec("transformer_nuggets") is None:
+            print(f"rank {rank}: profile={rank_path}", flush=True)
+        elif rank == 0:
+            merge_traces = import_module("transformer_nuggets.utils.merge_traces").merge_traces
+            merged_path = profile_path.with_name(f"{profile_path.stem}_merged.json.gz")
+            merge_traces(
+                [
+                    str(profile_path.with_name(f"{profile_path.stem}_rank_{index}.json"))
+                    for index in range(world_size)
+                ],
+                str(merged_path),
+                labels=[f"Rank {index} · GPU {index}" for index in range(world_size)],
+                align_timestamps=False,
+            )
+            print(f"profile={merged_path}", flush=True)
+        dist.barrier()
+
     output, final_state, gradients = run(local_inputs)
     global_reference_inputs = tuple(
         tensor.detach().clone().requires_grad_() for tensor in global_inputs
@@ -590,10 +658,15 @@ def main() -> None:
             torch.testing.assert_close(graph_state, eager_state, atol=0.15, rtol=0.15)
             for replayed, expected in zip(graph_gradients, eager_gradients, strict=True):
                 torch.testing.assert_close(replayed, expected, atol=0.15, rtol=0.15)
+            if args.profile:
+                record_profile(graph.replay, "cuda_graph_replay")
         finally:
             torch.cuda.synchronize(device)
             graph.reset()
             gc.collect()
+    elif args.profile:
+        profile_inputs = tuple(tensor.detach().clone().requires_grad_() for tensor in local_inputs)
+        record_profile(lambda: run(profile_inputs), "iteration")
 
     mode = " with CUDA Graph replay" if args.cuda_graph else ""
     print(f"rank {rank}: packed KDA CP passed{mode}", flush=True)

--- a/examples/kda_context_parallel.py
+++ b/examples/kda_context_parallel.py
@@ -1,0 +1,758 @@
+"""Run packed KDA context parallelism with native affine-summary kernels.
+
+Each rank owns an equal contiguous token shard. Launch with:
+
+    torchrun --standalone --nproc-per-node=2 examples/kda_context_parallel.py
+
+Add ``--cuda-graph`` to capture forward and backward together and validate a replay with
+changed inputs. The example requires one Blackwell GPU per rank because the fused KDA backend
+currently targets SM100 or newer.
+"""
+
+from __future__ import annotations
+
+import argparse
+import bisect
+import gc
+import os
+from contextlib import contextmanager, nullcontext
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+
+from attn_gym.linear import chunk_kda
+from attn_gym.linear._delta_rule.cute import affine_summary_fwd, affine_summary_rev
+from attn_gym.linear.kda.bwd.cute.chunk_kda_bwd import (
+    _finish_chunk_kda_bwd,
+    _prepare_chunk_kda_bwd,
+)
+from attn_gym.linear.kda.chunk_schedule import prepare_ragged_chunk_metadata
+from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata, chunk_capacity
+from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd import (
+    _finish_chunk_kda_fwd,
+    _normalize_packed_cotangent,
+    _prepare_chunk_kda_fwd,
+)
+from attn_gym.linear.kda.ops import _plain_gate_scan_op
+
+# NOTE [Example-local CP orchestration]
+# Keep the distributed autograd wrapper here while the CP contract is experimental, matching the
+# repository's ring-attention example. The reusable recurrence kernels live under _delta_rule/cute;
+# the private KDA prepare/finish seams prevent duplicate factor computation around collectives.
+_CHUNK_SIZE = 64
+
+
+@dataclass(frozen=True)
+class PackedShard:
+    """Packed sequence fragments intersecting one contiguous rank shard."""
+
+    cu_seqlens: tuple[int, ...]
+    sequence_ids: tuple[int, ...]
+
+
+@contextmanager
+def kernel_stage(name: str, annotate: bool, *, backward: bool = True):
+    """Label eager profiler ranges and optionally annotate captured CUDA Graph kernels."""
+    annotation = nullcontext()
+    if annotate:
+        from torch.cuda.graph_annotations import mark_kernels
+
+        annotation = mark_kernels(name, backward=backward)
+    with torch.profiler.record_function(name), annotation:
+        yield
+
+
+# NOTE [One crossing sequence per contiguous rank boundary]
+# A rank owns one contiguous interval of the globally ordered packed token stream. Its boundary
+# is one cut point and can split at most one logical sequence: only the last local fragment can
+# continue forward, and only the first can receive a reverse cotangent. Therefore every rank
+# exchanges one fixed `[H,V+K,K]` summary in each direction regardless of how many complete packed
+# sequences it owns. A boundary between sequences sends an unused placeholder so collective shapes
+# and ordering remain uniform.
+
+
+class _AllGather(torch.autograd.Function):
+    """Autograd-enabled all-gather built from public distributed collectives."""
+
+    @staticmethod
+    def forward(ctx, tensor: torch.Tensor, group: dist.ProcessGroup) -> torch.Tensor:
+        ctx.group = group
+        gathered = tensor.new_empty(dist.get_world_size(group), *tensor.shape)
+        dist.all_gather_single(gathered, tensor.contiguous(), group=group)
+        return gathered
+
+    @staticmethod
+    def backward(ctx, grad_gathered: torch.Tensor) -> tuple[torch.Tensor, None]:
+        grad_tensor = torch.empty_like(grad_gathered[0])
+        dist.reduce_scatter_single(
+            grad_tensor,
+            grad_gathered.contiguous(),
+            op=dist.ReduceOp.SUM,
+            group=ctx.group,
+        )
+        return grad_tensor, None
+
+
+def partition_packed_sequences(
+    global_cu_seqlens: tuple[int, ...],
+    world_size: int,
+) -> tuple[PackedShard, ...]:
+    """Partition nonempty packed sequences into equal contiguous token shards."""
+    if len(global_cu_seqlens) < 2 or global_cu_seqlens[0] != 0:
+        raise ValueError("global_cu_seqlens must start at zero and contain at least one sequence")
+    if any(end <= start for start, end in pairwise(global_cu_seqlens)):
+        raise ValueError("this example requires strictly increasing global_cu_seqlens")
+    total_tokens = global_cu_seqlens[-1]
+    if total_tokens % world_size:
+        raise ValueError("total tokens must be divisible by the context-parallel world size")
+
+    shard_tokens = total_tokens // world_size
+    shards = []
+    for rank in range(world_size):
+        rank_start = rank * shard_tokens
+        rank_end = rank_start + shard_tokens
+        first_sequence = bisect.bisect_right(global_cu_seqlens[1:], rank_start)
+        sequence_end = bisect.bisect_left(global_cu_seqlens[:-1], rank_end)
+        sequence_ids = tuple(range(first_sequence, sequence_end))
+        interior_offsets = (
+            offset - rank_start
+            for offset in global_cu_seqlens[first_sequence + 1 : sequence_end]
+            if rank_start < offset < rank_end
+        )
+        shards.append(
+            PackedShard(
+                cu_seqlens=(0, *interior_offsets, shard_tokens),
+                sequence_ids=sequence_ids,
+            )
+        )
+    return tuple(shards)
+
+
+def _chunk_kda_with_state(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Call public fused KDA and narrow its requested final state to a tensor."""
+    output, final_state = chunk_kda(
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        initial_state=initial_state,
+        cu_seqlens=cu_seqlens,
+        output_final_state=True,
+        autotune=False,
+        impl="fused",
+    )
+    assert final_state is not None
+    return output, final_state
+
+
+def local_affine_summaries(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    annotate: bool = False,
+) -> torch.Tensor:
+    """Recover each local fragment's ``H_out = H_in @ A + B`` summary."""
+    sequences = cu_seqlens.shape[0] - 1
+    heads, key_dim, value_dim = q.shape[2], q.shape[-1], v.shape[-1]
+    if value_dim != key_dim:
+        raise ValueError("the public identity-probe construction requires value_dim == key_dim")
+
+    zero = q.new_zeros(sequences, heads, value_dim, key_dim, dtype=torch.float32)
+    identity = torch.eye(key_dim, dtype=torch.float32, device=q.device).expand_as(zero)
+    with kernel_stage("cp/fwd/summary_zero", annotate):
+        _, bias = _chunk_kda_with_state(q, k, v, gate, beta, zero, cu_seqlens)
+    with kernel_stage("cp/fwd/summary_identity", annotate):
+        _, identity_final = _chunk_kda_with_state(q, k, v, gate, beta, identity, cu_seqlens)
+    transition = identity_final - bias
+    return torch.cat((bias, transition), dim=-2)
+
+
+def apply_summary(state: torch.Tensor, summary: torch.Tensor) -> torch.Tensor:
+    """Apply one packed V-first affine summary to a recurrent state."""
+    value_dim = state.shape[-2]
+    bias = summary[..., :value_dim, :]
+    transition = summary[..., value_dim:, :]
+    return state @ transition + bias
+
+
+def context_parallel_kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    *,
+    group: dist.ProcessGroup,
+    shards: tuple[PackedShard, ...],
+    local_cu_seqlens: torch.Tensor,
+    annotate: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Apply zero-state packed KDA to one contiguous context-parallel shard."""
+    rank = dist.get_rank(group)
+    shard = shards[rank]
+    shard_tokens = shard.cu_seqlens[-1]
+    if q.shape[0] != 1 or q.shape[1] != shard_tokens:
+        raise ValueError(f"rank inputs must have shape [1,{shard_tokens},H,D]")
+    if (
+        local_cu_seqlens.shape != (len(shard.cu_seqlens),)
+        or local_cu_seqlens.dtype != torch.int32
+        or local_cu_seqlens.device != q.device
+    ):
+        raise ValueError("local_cu_seqlens has invalid shape, dtype, or device")
+
+    # See NOTE [One crossing sequence per contiguous rank boundary].
+    continues_on_next_rank = (
+        rank + 1 < len(shards) and shard.sequence_ids[-1] == shards[rank + 1].sequence_ids[0]
+    )
+    if continues_on_next_rank:
+        boundary_start = shard.cu_seqlens[-2]
+        boundary_inputs = tuple(tensor[:, boundary_start:] for tensor in (q, k, v, gate, beta))
+        boundary_cu_seqlens = local_cu_seqlens[-2:] - local_cu_seqlens[-2]
+        local_summary = local_affine_summaries(
+            *boundary_inputs,
+            boundary_cu_seqlens,
+            annotate,
+        )[0]
+    else:
+        # Keep collective autograd ordering identical when no state crosses this boundary.
+        anchor = q.reshape(-1)[0].float() * 0
+        local_summary = (
+            q.new_zeros(
+                q.shape[2],
+                v.shape[-1] + q.shape[-1],
+                q.shape[-1],
+                dtype=torch.float32,
+            )
+            + anchor
+        )
+    with kernel_stage("cp/fwd/all_gather", annotate):
+        gathered = _AllGather.apply(local_summary, group)
+
+    with kernel_stage("cp/fwd/exclusive_prefix", annotate):
+        states = _compose_forward_initial_states(gathered, q, v, rank, shards)
+        # Ranks with an empty prefix must still execute all-gather's backward collective.
+        states = states + gathered[rank].reshape(-1)[0] * 0
+
+    with kernel_stage("cp/fwd/local_output", annotate):
+        return _chunk_kda_with_state(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            states,
+            local_cu_seqlens,
+        )
+
+
+def _all_gather_tensor(tensor: torch.Tensor, group: dist.ProcessGroup) -> torch.Tensor:
+    """Gather one fixed-size tensor from every rank without autograd registration."""
+    gathered = tensor.new_empty(dist.get_world_size(group), *tensor.shape)
+    dist.all_gather_single(gathered, tensor.contiguous(), group=group)
+    return gathered
+
+
+def _unused_summary(reference: torch.Tensor) -> torch.Tensor:
+    """Allocate one ignored fixed-shape summary for collective ordering."""
+    return torch.zeros(
+        reference.shape[2],
+        reference.shape[-1] * 2,
+        reference.shape[-1],
+        dtype=torch.float32,
+        device=reference.device,
+    )
+
+
+def _compose_forward_initial_states(
+    gathered: torch.Tensor,
+    q: torch.Tensor,
+    v: torch.Tensor,
+    rank: int,
+    shards: tuple[PackedShard, ...],
+) -> torch.Tensor:
+    """Compose predecessor transfers into the first local sequence state."""
+    shard = shards[rank]
+    states = q.new_zeros(
+        len(shard.sequence_ids),
+        q.shape[2],
+        v.shape[-1],
+        q.shape[-1],
+        dtype=torch.float32,
+    )
+    first_state = states[0]
+    first_sequence = shard.sequence_ids[0]
+    for predecessor, predecessor_shard in zip(gathered[:rank], shards[:rank], strict=True):
+        if predecessor_shard.sequence_ids[-1] == first_sequence:
+            first_state = apply_summary(first_state, predecessor)
+    return torch.cat((first_state.unsqueeze(0), states[1:]), dim=0)
+
+
+def _compose_reverse_final_states(
+    gathered: torch.Tensor,
+    d_final_state: torch.Tensor | None,
+    initial_state: torch.Tensor,
+    rank: int,
+    shards: tuple[PackedShard, ...],
+) -> torch.Tensor:
+    """Compose successor reverse transfers into the last local state cotangent."""
+    incoming = torch.zeros_like(initial_state) if d_final_state is None else d_final_state
+    shard = shards[rank]
+    last_sequence = shard.sequence_ids[-1]
+    # See NOTE [One crossing sequence per contiguous rank boundary].
+    continues = rank + 1 < len(shards) and shards[rank + 1].sequence_ids[0] == last_sequence
+    if not continues:
+        return incoming
+
+    last_gradient = torch.zeros_like(incoming[-1])
+    for successor_rank in range(len(shards) - 1, rank, -1):
+        successor = shards[successor_rank]
+        if successor.sequence_ids[0] != last_sequence:
+            continue
+        last_gradient = apply_summary(last_gradient, gathered[successor_rank])
+    incoming = incoming.clone()
+    incoming[-1] += last_gradient
+    return incoming
+
+
+class _CuteContextParallelKDA(torch.autograd.Function):
+    """Join native affine summaries, NCCL collectives, and the existing KDA core."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        local_cu_seqlens,
+        group,
+        shards,
+        scale,
+        fastmath,
+        autotune,
+        annotate,
+    ):
+        rank = dist.get_rank(group)
+        metadata = prepare_ragged_chunk_metadata(local_cu_seqlens, q.shape[1], _CHUNK_SIZE)
+        cumulative_gate = _plain_gate_scan_op(
+            gate, metadata.cu_seqlens, metadata.chunk_offsets, False
+        )
+        factors = _prepare_chunk_kda_fwd(
+            q,
+            k,
+            v,
+            cumulative_gate,
+            beta,
+            metadata,
+            scale=scale,
+            autotune=autotune,
+        )
+
+        shard = shards[rank]
+        # See NOTE [One crossing sequence per contiguous rank boundary].
+        continues = (
+            rank + 1 < len(shards) and shard.sequence_ids[-1] == shards[rank + 1].sequence_ids[0]
+        )
+        if continues:
+            start = shard.cu_seqlens[-2]
+            with kernel_stage("cp/fwd/summary", annotate):
+                summary = affine_summary_fwd(
+                    factors.kg[:, start:],
+                    factors.w[:, start:],
+                    factors.u[:, start:],
+                    cumulative_gate[:, start:],
+                )
+        else:
+            summary = _unused_summary(q)
+        with kernel_stage("cp/fwd/all_gather", annotate):
+            gathered = _all_gather_tensor(summary, group)
+        with kernel_stage("cp/fwd/exclusive_prefix", annotate):
+            initial_state = _compose_forward_initial_states(gathered, q, v, rank, shards)
+        with kernel_stage("cp/fwd/local_output", annotate):
+            output, final_state = _finish_chunk_kda_fwd(
+                q,
+                cumulative_gate,
+                factors,
+                initial_state,
+                None,
+                None,
+                metadata,
+                scale=scale,
+                output_final_state=True,
+                autotune=autotune,
+            )
+        assert final_state is not None
+
+        ctx.save_for_backward(
+            q,
+            k,
+            v,
+            cumulative_gate,
+            beta,
+            factors.aqk,
+            factors.akk,
+            initial_state,
+            metadata.cu_seqlens,
+            metadata.chunk_offsets,
+        )
+        ctx.group = group
+        ctx.shards = shards
+        ctx.scale = scale
+        ctx.fastmath = fastmath
+        ctx.autotune = autotune
+        ctx.annotate = annotate
+        ctx.set_materialize_grads(False)
+        return output, final_state
+
+    @staticmethod
+    @torch.autograd.function.once_differentiable
+    def backward(ctx, d_output, d_final_state):
+        (
+            q,
+            k,
+            v,
+            cumulative_gate,
+            beta,
+            aqk,
+            akk,
+            initial_state,
+            cu_seqlens,
+            chunk_offsets,
+        ) = ctx.saved_tensors
+        rank = dist.get_rank(ctx.group)
+        shards = ctx.shards
+        shard = shards[rank]
+        metadata = RaggedChunkMetadata(
+            cu_seqlens,
+            chunk_offsets,
+            chunk_capacity(q.shape[1], cu_seqlens.shape[0] - 1, _CHUNK_SIZE),
+            _CHUNK_SIZE,
+        )
+        if d_output is None:
+            d_output = torch.zeros_like(v)
+        else:
+            d_output = _normalize_packed_cotangent(d_output)
+        if d_final_state is not None:
+            d_final_state = _normalize_packed_cotangent(d_final_state.float())
+        prepared = _prepare_chunk_kda_bwd(
+            q,
+            k,
+            v,
+            cumulative_gate,
+            beta,
+            akk,
+            d_output,
+            initial_state,
+            metadata,
+            scale=ctx.scale,
+            chunk_size=_CHUNK_SIZE,
+            autotune=ctx.autotune,
+        )
+
+        continues_from_previous = (
+            rank > 0 and shards[rank - 1].sequence_ids[-1] == shard.sequence_ids[0]
+        )
+        if continues_from_previous:
+            stop = shard.cu_seqlens[1]
+            with kernel_stage("cp/bwd/summary", ctx.annotate, backward=False):
+                summary = affine_summary_rev(
+                    prepared.qg[:, :stop],
+                    prepared.kg[:, :stop],
+                    prepared.w[:, :stop],
+                    d_output[:, :stop],
+                    aqk[:, :stop],
+                    cumulative_gate[:, :stop],
+                    ctx.scale,
+                )
+            if d_final_state is not None:
+                value_dim = v.shape[-1]
+                bias = apply_summary(d_final_state[0], summary)
+                summary = torch.cat((bias, summary[..., value_dim:, :]), dim=-2)
+        else:
+            summary = _unused_summary(q)
+        with kernel_stage("cp/bwd/all_gather", ctx.annotate, backward=False):
+            gathered = _all_gather_tensor(summary, ctx.group)
+        with kernel_stage("cp/bwd/exclusive_suffix", ctx.annotate, backward=False):
+            incoming = _compose_reverse_final_states(
+                gathered,
+                d_final_state,
+                initial_state,
+                rank,
+                shards,
+            )
+        with kernel_stage("cp/bwd/local", ctx.annotate, backward=False):
+            dq, dk, dv, d_cumulative, db, _d_initial_state = _finish_chunk_kda_bwd(
+                q,
+                k,
+                v,
+                cumulative_gate,
+                beta,
+                aqk,
+                akk,
+                d_output,
+                incoming,
+                initial_state,
+                metadata,
+                prepared,
+                scale=ctx.scale,
+                chunk_size=_CHUNK_SIZE,
+                fastmath=ctx.fastmath,
+                autotune=ctx.autotune,
+            )
+        d_gate = _plain_gate_scan_op(
+            d_cumulative,
+            metadata.cu_seqlens,
+            metadata.chunk_offsets,
+            True,
+        )
+        return dq, dk, dv, d_gate, db, None, None, None, None, None, None, None
+
+
+def context_parallel_kda_cute(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    *,
+    group: dist.ProcessGroup,
+    shards: tuple[PackedShard, ...],
+    local_cu_seqlens: torch.Tensor,
+    annotate: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Apply packed KDA with native CuTeDSL forward/reverse affine summaries."""
+    scale = q.shape[-1] ** -0.5
+    fastmath = False
+    autotune = False
+    return _CuteContextParallelKDA.apply(
+        q,
+        k,
+        v,
+        gate.float(),
+        beta.float().contiguous(),
+        local_cu_seqlens,
+        group,
+        shards,
+        scale,
+        fastmath,
+        autotune,
+        annotate,
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse the example workload."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--sequence-lengths",
+        default="256,1280,512",
+        help="Comma-separated nonempty packed sequence lengths.",
+    )
+    parser.add_argument("--heads", type=int, default=2)
+    parser.add_argument(
+        "--summary-backend",
+        choices=("cute", "public"),
+        default="cute",
+        help="Use native CuTeDSL affine summaries or the public zero/identity probes.",
+    )
+    parser.add_argument(
+        "--cuda-graph",
+        action="store_true",
+        help="Capture forward and backward and validate a changed-input replay.",
+    )
+    return parser.parse_args()
+
+
+def make_inputs(
+    tokens: int,
+    heads: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, ...]:
+    """Create stable BF16 KDA inputs for validation."""
+    torch.manual_seed(123)
+    shape = (1, tokens, heads, 128)
+    q = torch.randn(shape, dtype=torch.bfloat16, device=device)
+    k = F.normalize(torch.randn_like(q), dim=-1)
+    v = torch.randn_like(q)
+    gate = F.logsigmoid(torch.randn_like(q))
+    beta = torch.sigmoid(torch.randn(shape[:3], dtype=torch.bfloat16, device=device))
+    return q, k, v, gate, beta
+
+
+def ending_state_count(
+    shard: PackedShard,
+    rank: int,
+    shard_tokens: int,
+    global_cu_seqlens: tuple[int, ...],
+) -> int:
+    """Count the prefix of local fragments ending on this rank."""
+    rank_end = (rank + 1) * shard_tokens
+    last_sequence_ends_later = global_cu_seqlens[shard.sequence_ids[-1] + 1] > rank_end
+    return len(shard.sequence_ids) - int(last_sequence_ends_later)
+
+
+def main() -> None:
+    """Run and validate the packed native-summary context-parallel example."""
+    args = parse_args()
+    local_rank = int(os.environ["LOCAL_RANK"])
+    device = torch.device(f"cuda:{local_rank}")
+    torch.cuda.set_device(device)
+    dist.init_process_group("nccl", device_id=device)
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    graph_annotations_available = False
+    if args.cuda_graph:
+        try:
+            from torch.cuda.graph_annotations import is_available
+        except ImportError:
+            pass
+        else:
+            graph_annotations_available = is_available()
+        if rank == 0 and not graph_annotations_available:
+            print(
+                "CUDA Graph capture is available, but kernel labels require PyTorch graph "
+                "annotations and CUDA >=13.1 tools-ID driver support.",
+                flush=True,
+            )
+
+    lengths = tuple(int(length) for length in args.sequence_lengths.split(","))
+    global_cu_seqlens = tuple(accumulate(lengths, initial=0))
+    shards = partition_packed_sequences(global_cu_seqlens, world_size)
+    tokens = global_cu_seqlens[-1]
+    shard_tokens = tokens // world_size
+    local_slice = slice(rank * shard_tokens, (rank + 1) * shard_tokens)
+    global_inputs = make_inputs(tokens, args.heads, device)
+    local_inputs = tuple(
+        tensor[:, local_slice].clone().requires_grad_() for tensor in global_inputs
+    )
+    local_shard = shards[rank]
+    local_cu_seqlens = torch.tensor(
+        local_shard.cu_seqlens,
+        dtype=torch.int32,
+        device=device,
+    )
+
+    final_state_count = ending_state_count(
+        local_shard,
+        rank,
+        shard_tokens,
+        global_cu_seqlens,
+    )
+
+    cp_operation = (
+        context_parallel_kda_cute if args.summary_backend == "cute" else context_parallel_kda
+    )
+
+    def run(inputs: tuple[torch.Tensor, ...], *, annotate: bool = False):
+        output, final_state = cp_operation(
+            *inputs,
+            group=dist.group.WORLD,
+            shards=shards,
+            local_cu_seqlens=local_cu_seqlens,
+            annotate=annotate,
+        )
+        loss = output.float().sum()
+        if final_state_count:
+            loss = loss + final_state[:final_state_count].sum()
+        with kernel_stage("cp/bwd", annotate, backward=False):
+            gradients = torch.autograd.grad(loss, inputs)
+        return output, final_state, gradients
+
+    output, final_state, gradients = run(local_inputs)
+    global_reference_inputs = tuple(
+        tensor.detach().clone().requires_grad_() for tensor in global_inputs
+    )
+    global_offsets = torch.tensor(global_cu_seqlens, dtype=torch.int32, device=device)
+    reference_output, reference_state = chunk_kda(
+        *global_reference_inputs,
+        cu_seqlens=global_offsets,
+        output_final_state=True,
+        autotune=False,
+        impl="fused",
+    )
+    assert reference_state is not None
+    reference_loss = reference_output.float().sum() + reference_state.sum()
+    reference_gradients = torch.autograd.grad(reference_loss, global_reference_inputs)
+
+    torch.testing.assert_close(output, reference_output[:, local_slice], atol=0.15, rtol=0.15)
+    if final_state_count:
+        first_sequence = local_shard.sequence_ids[0]
+        torch.testing.assert_close(
+            final_state[:final_state_count],
+            reference_state[first_sequence : first_sequence + final_state_count],
+            atol=0.15,
+            rtol=0.15,
+        )
+    for actual, expected in zip(gradients, reference_gradients, strict=True):
+        torch.testing.assert_close(actual, expected[:, local_slice], atol=0.15, rtol=0.15)
+
+    if args.cuda_graph:
+        capture_inputs = tuple(tensor.detach().clone().requires_grad_() for tensor in local_inputs)
+        warmup_stream = torch.cuda.Stream()
+        warmup_stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(warmup_stream):
+            run(tuple(tensor.detach().clone().requires_grad_() for tensor in capture_inputs))
+        warmup_stream.synchronize()
+        dist.barrier()
+
+        graph = torch.cuda.CUDAGraph()
+        try:
+            with torch.cuda.graph(
+                graph,
+                stream=warmup_stream,
+                enable_annotations=graph_annotations_available,
+            ):
+                graph_output, graph_state, graph_gradients = run(
+                    capture_inputs,
+                    annotate=graph_annotations_available,
+                )
+            torch.cuda.current_stream().wait_stream(warmup_stream)
+            captured_output = graph_output.clone()
+            torch.cuda.synchronize(device)
+
+            with torch.no_grad():
+                capture_inputs[0].mul_(0.75)
+                capture_inputs[2].mul_(0.5)
+            eager_inputs = tuple(
+                tensor.detach().clone().requires_grad_() for tensor in capture_inputs
+            )
+            eager_output, eager_state, eager_gradients = run(eager_inputs)
+            graph.replay()
+            torch.cuda.synchronize(device)
+            if torch.equal(graph_output, captured_output):
+                raise AssertionError("CUDA Graph replay did not observe changed inputs")
+            torch.testing.assert_close(graph_output, eager_output, atol=0.15, rtol=0.15)
+            torch.testing.assert_close(graph_state, eager_state, atol=0.15, rtol=0.15)
+            for replayed, expected in zip(graph_gradients, eager_gradients, strict=True):
+                torch.testing.assert_close(replayed, expected, atol=0.15, rtol=0.15)
+        finally:
+            torch.cuda.synchronize(device)
+            graph.reset()
+            gc.collect()
+
+    mode = " with CUDA Graph replay" if args.cuda_graph else ""
+    print(f"rank {rank}: packed KDA CP passed{mode}", flush=True)
+    torch.cuda.synchronize(device)
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    if "LOCAL_RANK" not in os.environ:
+        raise RuntimeError("launch with torchrun --standalone --nproc-per-node=<world_size>")
+    main()

--- a/examples/kda_context_parallel.py
+++ b/examples/kda_context_parallel.py
@@ -42,6 +42,8 @@ from attn_gym.linear.kda.ops import _plain_gate_scan_op
 # Keep the distributed autograd wrapper here while the CP contract is experimental, matching the
 # repository's ring-attention example. The reusable recurrence kernels live under _delta_rule/cute;
 # the private KDA prepare/finish seams prevent duplicate factor computation around collectives.
+# TODO: Decide which summary and prepare/finish seams belong in the public API before promoting
+# this orchestration out of the example.
 _CHUNK_SIZE = 64
 
 
@@ -131,32 +133,6 @@ def partition_packed_sequences(
     return tuple(shards)
 
 
-def _chunk_kda_with_state(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    gate: torch.Tensor,
-    beta: torch.Tensor,
-    initial_state: torch.Tensor,
-    cu_seqlens: torch.Tensor,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    """Call public fused KDA and narrow its requested final state to a tensor."""
-    output, final_state = chunk_kda(
-        q,
-        k,
-        v,
-        gate,
-        beta,
-        initial_state=initial_state,
-        cu_seqlens=cu_seqlens,
-        output_final_state=True,
-        autotune=False,
-        impl="fused",
-    )
-    assert final_state is not None
-    return output, final_state
-
-
 def local_affine_summaries(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -175,15 +151,39 @@ def local_affine_summaries(
     zero = q.new_zeros(sequences, heads, value_dim, key_dim, dtype=torch.float32)
     identity = torch.eye(key_dim, dtype=torch.float32, device=q.device).expand_as(zero)
     with kernel_stage("cp/fwd/summary_zero", annotate):
-        _, bias = _chunk_kda_with_state(q, k, v, gate, beta, zero, cu_seqlens)
+        _, bias = chunk_kda(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            initial_state=zero,
+            cu_seqlens=cu_seqlens,
+            output_final_state=True,
+            autotune=False,
+            impl="fused",
+        )
     with kernel_stage("cp/fwd/summary_identity", annotate):
-        _, identity_final = _chunk_kda_with_state(q, k, v, gate, beta, identity, cu_seqlens)
+        _, identity_final = chunk_kda(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            initial_state=identity,
+            cu_seqlens=cu_seqlens,
+            output_final_state=True,
+            autotune=False,
+            impl="fused",
+        )
+    if bias is None or identity_final is None:
+        raise RuntimeError("chunk_kda did not return its requested final state")
     transition = identity_final - bias
     return torch.cat((bias, transition), dim=-2)
 
 
-def apply_summary(state: torch.Tensor, summary: torch.Tensor) -> torch.Tensor:
-    """Apply one packed V-first affine summary to a recurrent state."""
+def propagate_state(state: torch.Tensor, summary: torch.Tensor) -> torch.Tensor:
+    """Propagate a recurrent state through one packed V-first affine summary."""
     value_dim = state.shape[-2]
     bias = summary[..., :value_dim, :]
     transition = summary[..., value_dim:, :]
@@ -249,15 +249,21 @@ def context_parallel_kda(
         states = states + gathered[rank].reshape(-1)[0] * 0
 
     with kernel_stage("cp/fwd/local_output", annotate):
-        return _chunk_kda_with_state(
+        output, final_state = chunk_kda(
             q,
             k,
             v,
             gate,
             beta,
-            states,
-            local_cu_seqlens,
+            initial_state=states,
+            cu_seqlens=local_cu_seqlens,
+            output_final_state=True,
+            autotune=False,
+            impl="fused",
         )
+        if final_state is None:
+            raise RuntimeError("chunk_kda did not return its requested final state")
+        return output, final_state
 
 
 def _all_gather_tensor(tensor: torch.Tensor, group: dist.ProcessGroup) -> torch.Tensor:
@@ -298,7 +304,7 @@ def _compose_forward_initial_states(
     first_sequence = shard.sequence_ids[0]
     for predecessor, predecessor_shard in zip(gathered[:rank], shards[:rank], strict=True):
         if predecessor_shard.sequence_ids[-1] == first_sequence:
-            first_state = apply_summary(first_state, predecessor)
+            first_state = propagate_state(first_state, predecessor)
     return torch.cat((first_state.unsqueeze(0), states[1:]), dim=0)
 
 
@@ -323,7 +329,7 @@ def _compose_reverse_final_states(
         successor = shards[successor_rank]
         if successor.sequence_ids[0] != last_sequence:
             continue
-        last_gradient = apply_summary(last_gradient, gathered[successor_rank])
+        last_gradient = propagate_state(last_gradient, gathered[successor_rank])
     incoming = incoming.clone()
     incoming[-1] += last_gradient
     return incoming
@@ -482,7 +488,7 @@ class _CuteContextParallelKDA(torch.autograd.Function):
                 )
             if d_final_state is not None:
                 value_dim = v.shape[-1]
-                bias = apply_summary(d_final_state[0], summary)
+                bias = propagate_state(d_final_state[0], summary)
                 summary = torch.cat((bias, summary[..., value_dim:, :]), dim=-2)
         else:
             summary = _unused_summary(q)

--- a/examples/kda_context_parallel.py
+++ b/examples/kda_context_parallel.py
@@ -5,9 +5,9 @@ Each rank owns an equal contiguous token shard. Launch with:
     torchrun --standalone --nproc-per-node=2 examples/kda_context_parallel.py
 
 Add ``--cuda-graph`` to capture forward and backward together and validate a replay with
-changed inputs. Add ``--profile`` to export per-rank Chrome traces and, when
-transformer-nuggets is installed, a merged trace. The example requires one Blackwell GPU per rank
-because the fused KDA backend currently targets SM100 or newer.
+changed inputs. Add ``--profile`` to export a merged native Perfetto trace using
+transformer-nuggets. The example requires one Blackwell GPU per rank because the fused KDA backend
+currently targets SM100 or newer.
 """
 
 from __future__ import annotations
@@ -20,7 +20,6 @@ from collections.abc import Callable, Iterator
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 from importlib import import_module
-from importlib.util import find_spec
 from itertools import accumulate, pairwise
 from pathlib import Path
 
@@ -73,27 +72,21 @@ def kernel_stage(name: str, annotate: bool, *, backward: bool = True):
 
 
 @contextmanager
-def profile_trace(
-    enabled: bool,
-    path: Path,
-    rank: int,
-) -> Iterator[torch.profiler.profile | None]:
-    """Export one rank's trace, preferring transformer-nuggets when installed."""
-    if not enabled:
-        yield None
-        return
-
-    if find_spec("transformer_nuggets") is not None:
+def profile_trace(path: Path) -> Iterator[torch.profiler.profile]:
+    """Record one native Perfetto trace per rank."""
+    try:
         profiler = import_module("transformer_nuggets.utils.benchmark").profiler
-        with profiler(path, record_shapes=True) as active_profiler:
-            yield active_profiler
-        return
+    except ImportError as error:
+        raise RuntimeError(
+            "--profile requires a transformer-nuggets build with native Perfetto support"
+        ) from error
 
-    rank_path = path.with_name(f"{path.stem}_rank_{rank}.json")
-    activities = [torch.profiler.ProfilerActivity.CPU, torch.profiler.ProfilerActivity.CUDA]
-    with torch.profiler.profile(activities=activities, record_shapes=True) as active_profiler:
+    with profiler(
+        path.with_suffix(".pftrace"),
+        record_shapes=True,
+        trace_format="track_event",
+    ) as active_profiler:
         yield active_profiler
-    active_profiler.export_chrome_trace(str(rank_path))
 
 
 # NOTE [One crossing sequence per contiguous rank boundary]
@@ -461,7 +454,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--profile",
         action="store_true",
-        help="Export per-rank Chrome traces and a merged transformer-nuggets trace.",
+        help="Export one merged native Perfetto trace with transformer-nuggets.",
     )
     return parser.parse_args()
 
@@ -563,27 +556,27 @@ def main() -> None:
     ).resolve()
 
     def record_profile(step: Callable[[], object], label: str) -> None:
-        """Capture one synchronized distributed step and merge rank traces when possible."""
+        """Capture one synchronized distributed step and merge its rank traces."""
         dist.barrier()
-        with profile_trace(args.profile, profile_path, rank) as active_profiler:
+        with profile_trace(profile_path) as active_profiler:
+            # Start the measured step together after rank-local profiler setup.
+            dist.barrier()
+            torch.cuda.synchronize(device)
             with torch.profiler.record_function(f"cp/rank_{rank}/{label}"):
                 step()
             torch.cuda.synchronize(device)
-            if active_profiler is not None:
-                active_profiler.step()
+            active_profiler.step()
         dist.barrier()
 
-        rank_path = profile_path.with_name(f"{profile_path.stem}_rank_{rank}.json")
-        if find_spec("transformer_nuggets") is None:
-            print(f"rank {rank}: profile={rank_path}", flush=True)
-        elif rank == 0:
+        if rank == 0:
             merge_traces = import_module("transformer_nuggets.utils.merge_traces").merge_traces
-            merged_path = profile_path.with_name(f"{profile_path.stem}_merged.json.gz")
+            rank_paths = [
+                profile_path.with_name(f"{profile_path.stem}_rank_{index}.pftrace")
+                for index in range(world_size)
+            ]
+            merged_path = profile_path.with_name(f"{profile_path.stem}_merged.pftrace")
             merge_traces(
-                [
-                    str(profile_path.with_name(f"{profile_path.stem}_rank_{index}.json"))
-                    for index in range(world_size)
-                ],
+                [str(path) for path in rank_paths],
                 str(merged_path),
                 labels=[f"Rank {index} · GPU {index}" for index in range(world_size)],
                 align_timestamps=False,

--- a/test/test_delta_affine_summary.py
+++ b/test/test_delta_affine_summary.py
@@ -6,9 +6,10 @@ import pytest
 import torch
 import torch.nn.functional as F
 
+pytest.importorskip("cutlass")
+
 from attn_gym.linear._delta_rule.cute import affine_summary_fwd, affine_summary_rev
 
-pytest.importorskip("cutlass")
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available() or torch.cuda.get_device_capability() < (10, 0),
     reason="the CuTeDSL affine summary requires CUDA capability 10.0 or newer",

--- a/test/test_delta_affine_summary.py
+++ b/test/test_delta_affine_summary.py
@@ -8,7 +8,7 @@ import torch.nn.functional as F
 
 pytest.importorskip("cutlass")
 
-from attn_gym.linear._delta_rule.cute import affine_summary_fwd, affine_summary_rev
+from attn_gym.linear._delta_rule.cute import build_state_grad_summary, build_state_summary
 
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available() or torch.cuda.get_device_capability() < (10, 0),
@@ -16,7 +16,7 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def affine_summary_reference(
+def state_summary_reference(
     kg: torch.Tensor,
     w: torch.Tensor,
     u: torch.Tensor,
@@ -54,7 +54,7 @@ def affine_summary_reference(
     return state.transpose(-2, -1).contiguous()
 
 
-def affine_summary_rev_reference(
+def state_grad_summary_reference(
     qg: torch.Tensor,
     kg: torch.Tensor,
     w: torch.Tensor,
@@ -113,8 +113,8 @@ def test_affine_summary_matches_fp32_reference(dtype, tokens, heads):
     u = torch.randn_like(kg) / 16
     cumulative_gate = -torch.rand(shape, dtype=torch.float32, device="cuda") / 8
 
-    actual = affine_summary_fwd(kg, w, u, cumulative_gate)
-    expected = affine_summary_reference(kg, w, u, cumulative_gate)
+    actual = build_state_summary(kg, w, u, cumulative_gate)
+    expected = state_summary_reference(kg, w, u, cumulative_gate)
 
     assert actual.shape == (heads, 256, 128)
     assert actual.dtype == torch.float32
@@ -123,7 +123,7 @@ def test_affine_summary_matches_fp32_reference(dtype, tokens, heads):
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.parametrize("tokens,heads", [(64, 1), (65, 2), (256, 3)])
-def test_affine_summary_rev_matches_fp32_reference(dtype, tokens, heads):
+def test_build_state_grad_summary_matches_fp32_reference(dtype, tokens, heads):
     torch.manual_seed(27)
     shape = (1, tokens, heads, 128)
     qg = torch.randn(shape, dtype=dtype, device="cuda") / 32
@@ -134,8 +134,8 @@ def test_affine_summary_rev_matches_fp32_reference(dtype, tokens, heads):
     cumulative_gate = -torch.rand(shape, dtype=torch.float32, device="cuda") / 8
     scale = 128**-0.5
 
-    actual = affine_summary_rev(qg, kg, w, dout, aqk, cumulative_gate, scale)
-    expected = affine_summary_rev_reference(qg, kg, w, dout, aqk, cumulative_gate, scale)
+    actual = build_state_grad_summary(qg, kg, w, dout, aqk, cumulative_gate, scale)
+    expected = state_grad_summary_reference(qg, kg, w, dout, aqk, cumulative_gate, scale)
 
     assert actual.shape == (heads, 256, 128)
     assert actual.dtype == torch.float32
@@ -154,20 +154,20 @@ def test_affine_summary_selector_variants_and_persistent_work():
     cumulative_gate = -torch.rand(shape, dtype=torch.float32, device="cuda") / 8
 
     torch.testing.assert_close(
-        affine_summary_fwd(kg, w, u, cumulative_gate),
-        affine_summary_reference(kg, w, u, cumulative_gate),
+        build_state_summary(kg, w, u, cumulative_gate),
+        state_summary_reference(kg, w, u, cumulative_gate),
         atol=2e-4,
         rtol=2e-4,
     )
     torch.testing.assert_close(
-        affine_summary_rev(qg, kg, w, dout, aqk, cumulative_gate, 128**-0.5),
-        affine_summary_rev_reference(qg, kg, w, dout, aqk, cumulative_gate, 128**-0.5),
+        build_state_grad_summary(qg, kg, w, dout, aqk, cumulative_gate, 128**-0.5),
+        state_grad_summary_reference(qg, kg, w, dout, aqk, cumulative_gate, 128**-0.5),
         atol=2e-4,
         rtol=2e-4,
     )
 
 
-def test_affine_summary_fwd_cuda_graph_replay():
+def test_build_state_summary_cuda_graph_replay():
     torch.manual_seed(29)
     shape = (1, 128, 2, 128)
     kg = torch.randn(shape, dtype=torch.bfloat16, device="cuda") / 16
@@ -175,20 +175,20 @@ def test_affine_summary_fwd_cuda_graph_replay():
     u = torch.randn_like(kg) / 16
     cumulative_gate = -torch.rand(shape, dtype=torch.float32, device="cuda") / 8
 
-    affine_summary_fwd(kg, w, u, cumulative_gate)
+    build_state_summary(kg, w, u, cumulative_gate)
     torch.cuda.synchronize()
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
-        actual = affine_summary_fwd(kg, w, u, cumulative_gate)
+        actual = build_state_summary(kg, w, u, cumulative_gate)
 
     u.mul_(0.5)
-    expected = affine_summary_reference(kg, w, u, cumulative_gate)
+    expected = state_summary_reference(kg, w, u, cumulative_gate)
     graph.replay()
     torch.cuda.synchronize()
     torch.testing.assert_close(actual, expected, atol=2e-4, rtol=2e-4)
 
 
-def test_affine_summary_rev_cuda_graph_replay():
+def test_build_state_grad_summary_cuda_graph_replay():
     torch.manual_seed(31)
     shape = (1, 128, 2, 128)
     qg = torch.randn(shape, dtype=torch.bfloat16, device="cuda") / 32
@@ -199,14 +199,14 @@ def test_affine_summary_rev_cuda_graph_replay():
     cumulative_gate = -torch.rand(shape, dtype=torch.float32, device="cuda") / 8
     scale = 128**-0.5
 
-    affine_summary_rev(qg, kg, w, dout, aqk, cumulative_gate, scale)
+    build_state_grad_summary(qg, kg, w, dout, aqk, cumulative_gate, scale)
     torch.cuda.synchronize()
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
-        actual = affine_summary_rev(qg, kg, w, dout, aqk, cumulative_gate, scale)
+        actual = build_state_grad_summary(qg, kg, w, dout, aqk, cumulative_gate, scale)
 
     dout.mul_(0.5)
-    expected = affine_summary_rev_reference(qg, kg, w, dout, aqk, cumulative_gate, scale)
+    expected = state_grad_summary_reference(qg, kg, w, dout, aqk, cumulative_gate, scale)
     graph.replay()
     torch.cuda.synchronize()
     torch.testing.assert_close(actual, expected, atol=2e-4, rtol=2e-4)

--- a/test/test_delta_affine_summary.py
+++ b/test/test_delta_affine_summary.py
@@ -1,0 +1,211 @@
+"""Tests for the shared CuTeDSL delta-rule affine-summary recurrence."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from attn_gym.linear._delta_rule.cute import affine_summary_fwd, affine_summary_rev
+
+pytest.importorskip("cutlass")
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (10, 0),
+    reason="the CuTeDSL affine summary requires CUDA capability 10.0 or newer",
+)
+
+
+def affine_summary_reference(
+    kg: torch.Tensor,
+    w: torch.Tensor,
+    u: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+) -> torch.Tensor:
+    """Evaluate the augmented affine recurrence in eager FP32."""
+    _, tokens, heads, key_dim = kg.shape
+    value_dim = u.shape[-1]
+    pad = (-tokens) % 64
+    if pad:
+        padding = (0, 0, 0, 0, 0, pad)
+        kg, w, u = (F.pad(tensor, padding) for tensor in (kg, w, u))
+        cumulative_gate = torch.cat(
+            (cumulative_gate, cumulative_gate[:, -1:].expand(-1, pad, -1, -1)),
+            dim=1,
+        )
+        tokens += pad
+    identity = torch.eye(key_dim, dtype=torch.float32, device=kg.device)
+    state = torch.cat(
+        (
+            torch.zeros(heads, key_dim, value_dim, dtype=torch.float32, device=kg.device),
+            identity.expand(heads, key_dim, key_dim),
+        ),
+        dim=-1,
+    )
+    for start in range(0, tokens, 64):
+        stop = start + 64
+        chunk_w = w[0, start:stop].transpose(0, 1).float()
+        chunk_kg = kg[0, start:stop].transpose(0, 1).float()
+        tmp = chunk_w @ state
+        tmp[..., :value_dim] = u[0, start:stop].transpose(0, 1).float() - tmp[..., :value_dim]
+        tmp[..., value_dim:].neg_()
+        decay = cumulative_gate[0, stop - 1].exp2().unsqueeze(-1)
+        state = state * decay + chunk_kg.transpose(-2, -1) @ tmp
+    return state.transpose(-2, -1).contiguous()
+
+
+def affine_summary_rev_reference(
+    qg: torch.Tensor,
+    kg: torch.Tensor,
+    w: torch.Tensor,
+    dout: torch.Tensor,
+    aqk: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    scale: float,
+) -> torch.Tensor:
+    """Evaluate the augmented reverse-affine recurrence in eager FP32."""
+    _, tokens, heads, key_dim = qg.shape
+    value_dim = dout.shape[-1]
+    pad = (-tokens) % 64
+    if pad:
+        padding = (0, 0, 0, 0, 0, pad)
+        qg, kg, w, dout, aqk = (F.pad(tensor, padding) for tensor in (qg, kg, w, dout, aqk))
+        cumulative_gate = torch.cat(
+            (cumulative_gate, cumulative_gate[:, -1:].expand(-1, pad, -1, -1)),
+            dim=1,
+        )
+        tokens += pad
+    identity = torch.eye(key_dim, dtype=torch.float32, device=qg.device)
+    state = torch.cat(
+        (
+            torch.zeros(heads, key_dim, value_dim, dtype=torch.float32, device=qg.device),
+            identity.expand(heads, key_dim, key_dim),
+        ),
+        dim=-1,
+    )
+    for start in range(tokens - 64, -1, -64):
+        stop = start + 64
+        chunk_kg = kg[0, start:stop].transpose(0, 1).float()
+        chunk_w = w[0, start:stop].transpose(0, 1).float()
+        chunk_qg = qg[0, start:stop].transpose(0, 1).float()
+        chunk_aqk = aqk[0, start:stop].transpose(0, 1).float()
+        dout_augmented = torch.zeros(
+            heads, 64, value_dim + key_dim, dtype=torch.float32, device=qg.device
+        )
+        dout_augmented[..., :value_dim] = dout[0, start:stop].transpose(0, 1).float()
+        corrected = chunk_kg @ state + chunk_aqk.transpose(-2, -1) @ dout_augmented
+        decay = cumulative_gate[0, stop - 1].exp2().unsqueeze(-1)
+        state = (
+            state * decay
+            + scale * chunk_qg.transpose(-2, -1) @ dout_augmented
+            - chunk_w.transpose(-2, -1) @ corrected
+        )
+    return state.transpose(-2, -1).contiguous()
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("tokens,heads", [(64, 1), (65, 2), (256, 3)])
+def test_affine_summary_matches_fp32_reference(dtype, tokens, heads):
+    torch.manual_seed(23)
+    shape = (1, tokens, heads, 128)
+    kg = torch.randn(shape, dtype=dtype, device="cuda") / 16
+    w = torch.randn_like(kg) / 16
+    u = torch.randn_like(kg) / 16
+    cumulative_gate = -torch.rand(shape, dtype=torch.float32, device="cuda") / 8
+
+    actual = affine_summary_fwd(kg, w, u, cumulative_gate)
+    expected = affine_summary_reference(kg, w, u, cumulative_gate)
+
+    assert actual.shape == (heads, 256, 128)
+    assert actual.dtype == torch.float32
+    torch.testing.assert_close(actual, expected, atol=2e-4, rtol=2e-4)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("tokens,heads", [(64, 1), (65, 2), (256, 3)])
+def test_affine_summary_rev_matches_fp32_reference(dtype, tokens, heads):
+    torch.manual_seed(27)
+    shape = (1, tokens, heads, 128)
+    qg = torch.randn(shape, dtype=dtype, device="cuda") / 32
+    kg = torch.randn_like(qg) / 32
+    w = torch.randn_like(qg) / 32
+    dout = torch.randn_like(qg) / 32
+    aqk = torch.randn(1, tokens, heads, 64, dtype=dtype, device="cuda") / 32
+    cumulative_gate = -torch.rand(shape, dtype=torch.float32, device="cuda") / 8
+    scale = 128**-0.5
+
+    actual = affine_summary_rev(qg, kg, w, dout, aqk, cumulative_gate, scale)
+    expected = affine_summary_rev_reference(qg, kg, w, dout, aqk, cumulative_gate, scale)
+
+    assert actual.shape == (heads, 256, 128)
+    assert actual.dtype == torch.float32
+    torch.testing.assert_close(actual, expected, atol=2e-4, rtol=2e-4)
+
+
+def test_affine_summary_selector_variants_and_persistent_work():
+    torch.manual_seed(28)
+    shape = (1, 64, 32, 128)
+    kg = torch.randn(shape, dtype=torch.bfloat16, device="cuda") / 32
+    w = torch.randn_like(kg) / 32
+    u = torch.randn_like(kg) / 32
+    qg = torch.randn_like(kg) / 32
+    dout = torch.randn_like(kg) / 32
+    aqk = torch.randn(1, 64, 32, 64, dtype=torch.bfloat16, device="cuda") / 32
+    cumulative_gate = -torch.rand(shape, dtype=torch.float32, device="cuda") / 8
+
+    torch.testing.assert_close(
+        affine_summary_fwd(kg, w, u, cumulative_gate),
+        affine_summary_reference(kg, w, u, cumulative_gate),
+        atol=2e-4,
+        rtol=2e-4,
+    )
+    torch.testing.assert_close(
+        affine_summary_rev(qg, kg, w, dout, aqk, cumulative_gate, 128**-0.5),
+        affine_summary_rev_reference(qg, kg, w, dout, aqk, cumulative_gate, 128**-0.5),
+        atol=2e-4,
+        rtol=2e-4,
+    )
+
+
+def test_affine_summary_fwd_cuda_graph_replay():
+    torch.manual_seed(29)
+    shape = (1, 128, 2, 128)
+    kg = torch.randn(shape, dtype=torch.bfloat16, device="cuda") / 16
+    w = torch.randn_like(kg) / 16
+    u = torch.randn_like(kg) / 16
+    cumulative_gate = -torch.rand(shape, dtype=torch.float32, device="cuda") / 8
+
+    affine_summary_fwd(kg, w, u, cumulative_gate)
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        actual = affine_summary_fwd(kg, w, u, cumulative_gate)
+
+    u.mul_(0.5)
+    expected = affine_summary_reference(kg, w, u, cumulative_gate)
+    graph.replay()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(actual, expected, atol=2e-4, rtol=2e-4)
+
+
+def test_affine_summary_rev_cuda_graph_replay():
+    torch.manual_seed(31)
+    shape = (1, 128, 2, 128)
+    qg = torch.randn(shape, dtype=torch.bfloat16, device="cuda") / 32
+    kg = torch.randn_like(qg) / 32
+    w = torch.randn_like(qg) / 32
+    dout = torch.randn_like(qg) / 32
+    aqk = torch.randn(1, 128, 2, 64, dtype=torch.bfloat16, device="cuda") / 32
+    cumulative_gate = -torch.rand(shape, dtype=torch.float32, device="cuda") / 8
+    scale = 128**-0.5
+
+    affine_summary_rev(qg, kg, w, dout, aqk, cumulative_gate, scale)
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        actual = affine_summary_rev(qg, kg, w, dout, aqk, cumulative_gate, scale)
+
+    dout.mul_(0.5)
+    expected = affine_summary_rev_reference(qg, kg, w, dout, aqk, cumulative_gate, scale)
+    graph.replay()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(actual, expected, atol=2e-4, rtol=2e-4)

--- a/test/test_kda_context_parallel.py
+++ b/test/test_kda_context_parallel.py
@@ -1,0 +1,80 @@
+"""Small CPU tests for context-parallel affine-summary routing."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+pytest.importorskip("cutlass")
+
+from examples.kda_context_parallel import (
+    PackedShard,
+    _compose_forward_initial_states,
+    _compose_reverse_final_states,
+)
+
+
+def _summary(transition: list[list[float]], bias: list[list[float]]) -> torch.Tensor:
+    transition_tensor = torch.tensor(transition, dtype=torch.float32).unsqueeze(0)
+    bias_tensor = torch.tensor(bias, dtype=torch.float32).unsqueeze(0)
+    return torch.cat((bias_tensor, transition_tensor), dim=-2)
+
+
+def _apply(state: torch.Tensor, summary: torch.Tensor) -> torch.Tensor:
+    """Independent affine-map oracle for the routing tests."""
+    return state @ summary[:, 2:, :] + summary[:, :2, :]
+
+
+def test_forward_prefix_propagates_one_sequence_across_three_shards():
+    summaries = torch.stack(
+        (
+            _summary([[1, 2], [0, 1]], [[1, 0], [0, 2]]),
+            _summary([[2, 0], [3, 1]], [[0, 1], [2, 0]]),
+            _summary([[1, 0], [0, 1]], [[9, 9], [9, 9]]),
+        )
+    )
+    shards = (
+        PackedShard(cu_seqlens=(0, 2), sequence_ids=(0,)),
+        PackedShard(cu_seqlens=(0, 2), sequence_ids=(0,)),
+        PackedShard(cu_seqlens=(0, 1, 2), sequence_ids=(0, 1)),
+    )
+    q = torch.empty(1, 2, 1, 2)
+    v = torch.empty_like(q)
+
+    states = _compose_forward_initial_states(summaries, q, v, rank=2, shards=shards)
+
+    expected_first = _apply(_apply(torch.zeros(1, 2, 2), summaries[0]), summaries[1])
+    torch.testing.assert_close(states[0], expected_first)
+    torch.testing.assert_close(states[1], torch.zeros_like(states[1]))
+
+
+def test_reverse_suffix_filters_sequences_and_adds_final_state_gradient():
+    summaries = torch.stack(
+        (
+            _summary([[1, 0], [0, 1]], [[9, 9], [9, 9]]),
+            _summary([[2, 1], [0, 1]], [[1, 0], [0, 1]]),
+            _summary([[1, 0], [2, 3]], [[0, 2], [1, 0]]),
+            _summary([[4, 0], [0, 4]], [[7, 7], [7, 7]]),
+        )
+    )
+    shards = (
+        PackedShard(cu_seqlens=(0, 1, 2), sequence_ids=(0, 1)),
+        PackedShard(cu_seqlens=(0, 2), sequence_ids=(1,)),
+        PackedShard(cu_seqlens=(0, 1, 2), sequence_ids=(1, 2)),
+        PackedShard(cu_seqlens=(0, 2), sequence_ids=(2,)),
+    )
+    initial_state = torch.zeros(2, 1, 2, 2)
+    d_final_state = torch.arange(8, dtype=torch.float32).reshape_as(initial_state)
+
+    gradients = _compose_reverse_final_states(
+        summaries,
+        d_final_state=d_final_state,
+        initial_state=initial_state,
+        rank=0,
+        shards=shards,
+    )
+
+    suffix = _apply(_apply(torch.zeros(1, 2, 2), summaries[2]), summaries[1])
+    expected = d_final_state.clone()
+    expected[-1] += suffix
+    torch.testing.assert_close(gradients, expected)


### PR DESCRIPTION
## Human Note

## Agent note

This adds native KDA context parallelism without gathering token activations. Each rank computes a
compact FP32 affine map for the sequence fragment crossing its boundary, all-gathers those
summaries, and composes the initial state needed by its ordinary local KDA execution. Backward uses
a separate reverse affine summary to compose the incoming `d_final_state`, then invokes the
existing local backward exactly once.

The two summary scans are native Blackwell TMA/UMMA kernels under the shared delta-rule namespace.
They retain FP32 state across chunks, support BF16/FP16 and partial tails, and avoid token-output or
per-chunk state stores. The implementation also splits the existing KDA forward/backward into
prepare and finish phases so factors are not recomputed around communication.

The affine recurrence itself  can be shared with GDN after W/U/KG are formed; KDA-specific behavior today
is in vector-gate loading, factor production, and the Aqk-based reverse source. A scalar-gate
specialization and fused GDN chunk factors would be needed before reusing this path for GDN.

## Performance

GB200, BF16, H=4, K=V=128, two ranks:

| Workload | One GPU | Native CP | Speedup | CP peak/GPU |
| --- | ---: | ---: | ---: | ---: |
| one sequence, T=1,048,576 | 78.57 ms | 56.13 ms | 1.40x | 0.503x |
| one sequence, T=4,194,304 | 313.73 ms | 223.23 ms | 1.41x | 0.501x |
| 1,049 packed documents, T=1,048,576 | 44.14 ms | 22.16 ms | 1.99x | 0.506x |

Focused NCU shows the kernels are serial-recurrence/grid-coverage limited rather than HBM-bound:
K1/K2 launch 32/64 blocks on 152 SMs, with 83-84% no-eligible cycles and only 1-3% DRAM throughput.

## Test Plan

```bash
pytest -n 6 test/test_delta_affine_summary.py test/test_kda_cute_forward.py test/test_kda_ragged_public_backward.py -q
torchrun --standalone --nproc-per-node=2 examples/kda_context_parallel.py --sequence-lengths 1000,1500,1500 --heads 2 --cuda-graph --profile
prek run --all-files
mkdocs build --strict
```


