### PR TITLE
Expand the KDA context-parallel example to the full module

### DIFF
--- a/attn_gym/testing/__init__.py
+++ b/attn_gym/testing/__init__.py
@@ -1,5 +1,12 @@
 """Shared test utilities for Attention Gym implementations."""
 
 from .kda import cumulative_sequence_offsets, strided_state_pool
+from .profiling import kernel_stage, profile_trace, record_distributed_profile
 
-__all__ = ["cumulative_sequence_offsets", "strided_state_pool"]
+__all__ = [
+    "cumulative_sequence_offsets",
+    "kernel_stage",
+    "profile_trace",
+    "record_distributed_profile",
+    "strided_state_pool",
+]

--- a/attn_gym/testing/profiling.py
+++ b/attn_gym/testing/profiling.py
@@ -1,0 +1,88 @@
+"""Profiling helpers for distributed example validation."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager, nullcontext
+from importlib import import_module
+from pathlib import Path
+
+import torch
+import torch.distributed as dist
+
+
+@contextmanager
+def kernel_stage(name: str, annotate: bool, *, backward: bool = True) -> Iterator[None]:
+    """Label eager profiler ranges and optionally annotate captured CUDA Graph kernels."""
+    annotation = nullcontext()
+    if annotate:
+        from torch.cuda.graph_annotations import mark_kernels
+
+        annotation = mark_kernels(name, backward=backward)
+    with torch.profiler.record_function(name), annotation:
+        yield
+
+
+@contextmanager
+def profile_trace(path: Path) -> Iterator[torch.profiler.profile]:
+    """Record one native Perfetto trace per rank."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        profiler = import_module("transformer_nuggets.utils.benchmark").profiler
+    except ImportError as error:
+        raise RuntimeError(
+            "profiling requires transformer-nuggets with native Perfetto support"
+        ) from error
+
+    with profiler(
+        path.with_suffix(".pftrace"),
+        record_shapes=True,
+        trace_format="track_event",
+    ) as active_profiler:
+        yield active_profiler
+
+
+def record_distributed_profile(
+    step: Callable[[], object],
+    path: Path,
+    label: str,
+    device: torch.device,
+) -> Path | None:
+    """Profile one synchronized world-group step and merge its native rank traces."""
+    try:
+        merge_traces = import_module("transformer_nuggets.utils.merge_traces").merge_traces
+    except ImportError as error:
+        raise RuntimeError(
+            "distributed profiling requires transformer-nuggets with native Perfetto support"
+        ) from error
+
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    dist.barrier()
+    with profile_trace(path) as active_profiler:
+        # Profiler initialization is rank-local, so align again after every profiler is active.
+        dist.barrier()
+        torch.cuda.synchronize(device)
+        with torch.profiler.record_function(f"cp/rank_{rank}/{label}"):
+            step()
+        torch.cuda.synchronize(device)
+        active_profiler.step()
+    dist.barrier()
+
+    merged_path = None
+    if rank == 0:
+        rank_paths = [
+            path.with_name(f"{path.stem}_rank_{index}.pftrace") for index in range(world_size)
+        ]
+        merged_path = path.with_name(f"{path.stem}_merged.pftrace")
+        merge_traces(
+            [str(rank_path) for rank_path in rank_paths],
+            str(merged_path),
+            labels=[f"Rank {index} · GPU {index}" for index in range(world_size)],
+            align_timestamps=False,
+        )
+    dist.barrier()
+    return merged_path
+
+
+__all__ = ["kernel_stage", "profile_trace", "record_distributed_profile"]

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -92,19 +92,20 @@ torchrun --standalone --nproc_per_node=4 examples/ring_attention.py --seq-len 13
 ## KDA Context Parallelism
 
 [`examples/kda_context_parallel.py`](https://github.com/meta-pytorch/attention-gym/blob/main/examples/kda_context_parallel.py)
-— Build packed KDA context parallelism from native CuTeDSL affine-summary kernels and PyTorch
-distributed collectives.
+— Run the complete transformer-style module from `kda_training.py` over packed context-parallel
+shards. This includes projections, Q/K/V short convolution, KDA, normalization, gating, and the
+output projection.
 
-The default backend computes forward and reverse `[bias; transition]` state summaries with Blackwell
-TMA/UMMA kernels; the reverse scan uses persistent work scheduling. It all-gathers only summaries
-for sequence fragments crossing rank boundaries, then runs the ordinary local KDA forward or
-backward once with the composed boundary state. A contiguous rank boundary is one cut in the packed
-token stream, so it can split at most one logical sequence. Each rank therefore exchanges at most
-one fixed-size forward summary and one reverse summary, independent of how many complete local
-sequences it owns. The example validates local outputs, global endpoint states, and gradients
-against an unsharded execution; it can also capture forward, NCCL communication, and backward in
-one CUDA Graph and validate a changed-input replay. Add `--profile` to use transformer-nuggets to
-export one merged multi-rank trace in native Perfetto `.pftrace` format.
+The short convolution all-gathers one fixed-size `W - 1` token halo per rank and routes its initial-
+state gradient back to the ranks that own those tokens. The KDA recurrence separately computes
+forward and reverse `[bias; transition]` state summaries with Blackwell TMA/UMMA kernels, all-gathers
+them, and composes the relevant prefix or suffix before running the ordinary local KDA kernel. A
+contiguous rank boundary is one cut in the packed token stream, so it can split at most one logical
+sequence. The example validates local outputs, convolution and KDA endpoint states, input gradients,
+and all-reduced parameter gradients against the complete unsharded module. It can also capture the
+full forward, NCCL communication, and backward in one CUDA Graph and validate a changed-input
+replay. Add `--profile` to use transformer-nuggets to export one merged multi-rank trace in native
+Perfetto `.pftrace` format.
 
 ```bash
 torchrun --standalone --nproc_per_node=2 examples/kda_context_parallel.py

--- a/examples/kda_context_parallel.py
+++ b/examples/kda_context_parallel.py
@@ -1,6 +1,9 @@
-"""Run packed KDA context parallelism with native affine-summary kernels.
+"""Train a complete packed KDA attention module with context parallelism.
 
-Each rank owns an equal contiguous token shard. Launch with:
+This reuses the transformer-style module from ``kda_training.py`` and distributes both
+stateful operations: a halo exchange supplies the short convolution's finite history, then
+native affine summaries supply the KDA recurrence's full-prefix state. Each rank owns an
+equal contiguous token shard. Launch with:
 
     torchrun --standalone --nproc-per-node=2 examples/kda_context_parallel.py
 
@@ -12,22 +15,22 @@ currently targets SM100 or newer.
 
 from __future__ import annotations
 
-import argparse
 import bisect
 import gc
 import os
-from collections.abc import Callable, Iterator
-from contextlib import contextmanager, nullcontext
+from collections.abc import Callable
 from dataclasses import dataclass
-from importlib import import_module
+from functools import partial
 from itertools import accumulate, pairwise
 from pathlib import Path
+from typing import Annotated
 
 import torch
 import torch.distributed as dist
 import torch.nn.functional as F
+import typer
+from torch.distributed._functional_collectives import all_gather_single
 
-from attn_gym.linear import chunk_kda
 from attn_gym.linear._delta_rule.cute import build_state_grad_summary, build_state_summary
 from attn_gym.linear.kda.bwd.cute.chunk_kda_bwd import (
     _finish_chunk_kda_bwd,
@@ -41,14 +44,20 @@ from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd import (
     _prepare_chunk_kda_fwd,
 )
 from attn_gym.linear.kda.ops import _plain_gate_scan_op
+from attn_gym.testing import kernel_stage, record_distributed_profile
+from examples.kda_training import KDAAttention, KDAAttentionOutput
 
-# NOTE [Example-local CP orchestration]
-# Keep the distributed autograd wrapper here while the CP contract is experimental, matching the
-# repository's ring-attention example. The reusable recurrence kernels live under _delta_rule/cute;
-# the private KDA prepare/finish seams prevent duplicate factor computation around collectives.
-# TODO: Decide which summary and prepare/finish seams belong in the public API before promoting
-# this orchestration out of the example.
-_CHUNK_SIZE = 64
+# The private prepare/finish seams avoid repeating factor computation around collectives.
+# TODO: Promote those seams before moving this orchestration out of the example.
+CHUNK_SIZE = 64
+
+# NOTE [One crossing sequence per contiguous rank boundary]
+# A rank owns one contiguous interval of the globally ordered packed token stream. Its boundary
+# is one cut point and can split at most one logical sequence: only the last local fragment can
+# continue forward, and only the first can receive a reverse cotangent. Therefore every rank
+# exchanges one fixed `[H,V+K,K]` summary in each direction regardless of how many complete packed
+# sequences it owns. A boundary between sequences sends an unused placeholder so collective shapes
+# and ordering remain uniform.
 
 
 @dataclass(frozen=True)
@@ -59,43 +68,21 @@ class PackedShard:
     sequence_ids: tuple[int, ...]
 
 
-@contextmanager
-def kernel_stage(name: str, annotate: bool, *, backward: bool = True):
-    """Label eager profiler ranges and optionally annotate captured CUDA Graph kernels."""
-    annotation = nullcontext()
-    if annotate:
-        from torch.cuda.graph_annotations import mark_kernels
+@dataclass(frozen=True)
+class PackedTrainingBatch:
+    """Global reference tensors and the corresponding rank-local packed shard."""
 
-        annotation = mark_kernels(name, backward=backward)
-    with torch.profiler.record_function(name), annotation:
-        yield
-
-
-@contextmanager
-def profile_trace(path: Path) -> Iterator[torch.profiler.profile]:
-    """Record one native Perfetto trace per rank."""
-    try:
-        profiler = import_module("transformer_nuggets.utils.benchmark").profiler
-    except ImportError as error:
-        raise RuntimeError(
-            "--profile requires a transformer-nuggets build with native Perfetto support"
-        ) from error
-
-    with profiler(
-        path.with_suffix(".pftrace"),
-        record_shapes=True,
-        trace_format="track_event",
-    ) as active_profiler:
-        yield active_profiler
-
-
-# NOTE [One crossing sequence per contiguous rank boundary]
-# A rank owns one contiguous interval of the globally ordered packed token stream. Its boundary
-# is one cut point and can split at most one logical sequence: only the last local fragment can
-# continue forward, and only the first can receive a reverse cotangent. Therefore every rank
-# exchanges one fixed `[H,V+K,K]` summary in each direction regardless of how many complete packed
-# sequences it owns. A boundary between sequences sends an unused placeholder so collective shapes
-# and ordering remain uniform.
+    global_hidden: torch.Tensor
+    global_target: torch.Tensor
+    global_offsets: torch.Tensor
+    local_hidden: torch.Tensor
+    local_target: torch.Tensor
+    local_offsets: torch.Tensor
+    local_slice: slice
+    first_sequence: int
+    completed_sequences: int
+    sequence_count: int
+    loss_scale: float
 
 
 def partition_packed_sequences(
@@ -141,77 +128,59 @@ def merge_state(state: torch.Tensor, summary: torch.Tensor) -> torch.Tensor:
     return state @ transition + bias
 
 
-def _all_gather_tensor(tensor: torch.Tensor, group: dist.ProcessGroup) -> torch.Tensor:
-    """Gather one fixed-size tensor from every rank without autograd registration."""
-    gathered = tensor.new_empty(dist.get_world_size(group), *tensor.shape)
-    dist.all_gather_single(gathered, tensor.contiguous(), group=group)
-    return gathered
-
-
-def _unused_summary(reference: torch.Tensor) -> torch.Tensor:
-    """Allocate one ignored fixed-shape summary for collective ordering."""
-    return torch.zeros(
-        reference.shape[2],
-        reference.shape[-1] * 2,
-        reference.shape[-1],
-        dtype=torch.float32,
-        device=reference.device,
-    )
-
-
-def _compose_forward_initial_states(
-    gathered: torch.Tensor,
-    q: torch.Tensor,
-    v: torch.Tensor,
-    rank: int,
-    shards: tuple[PackedShard, ...],
-) -> torch.Tensor:
-    """Compose predecessor transfers into the first local sequence state."""
-    shard = shards[rank]
-    states = q.new_zeros(
-        len(shard.sequence_ids),
-        q.shape[2],
-        v.shape[-1],
-        q.shape[-1],
-        dtype=torch.float32,
-    )
-    first_state = states[0]
-    first_sequence = shard.sequence_ids[0]
-    for predecessor, predecessor_shard in zip(gathered[:rank], shards[:rank], strict=True):
-        if predecessor_shard.sequence_ids[-1] == first_sequence:
-            first_state = merge_state(first_state, predecessor)
-    return torch.cat((first_state.unsqueeze(0), states[1:]), dim=0)
-
-
-def _compose_reverse_final_states(
-    gathered: torch.Tensor,
-    d_final_state: torch.Tensor | None,
-    initial_state: torch.Tensor,
-    rank: int,
-    shards: tuple[PackedShard, ...],
-) -> torch.Tensor:
-    """Compose successor reverse transfers into the last local state cotangent."""
-    incoming = torch.zeros_like(initial_state) if d_final_state is None else d_final_state
-    shard = shards[rank]
-    last_sequence = shard.sequence_ids[-1]
-    # See NOTE [One crossing sequence per contiguous rank boundary].
-    continues = rank + 1 < len(shards) and shards[rank + 1].sequence_ids[0] == last_sequence
-    if not continues:
-        return incoming
-
-    last_gradient = torch.zeros_like(incoming[-1])
-    for successor_rank in range(len(shards) - 1, rank, -1):
-        successor = shards[successor_rank]
-        if successor.sequence_ids[0] != last_sequence:
-            continue
-        last_gradient = merge_state(last_gradient, gathered[successor_rank])
-    incoming = incoming.clone()
-    incoming[-1] += last_gradient
-    return incoming
-
-
-class _CuteContextParallelKDA(torch.autograd.Function):
+class ContextParallelKDAFunction(torch.autograd.Function):
     """Join native affine summaries, NCCL collectives, and the existing KDA core."""
+
+    @staticmethod
+    def compose_forward_initial_states(
+        gathered: torch.Tensor,
+        q: torch.Tensor,
+        v: torch.Tensor,
+        rank: int,
+        shards: tuple[PackedShard, ...],
+    ) -> torch.Tensor:
+        """Compose predecessor transfers into the first local sequence state."""
+        shard = shards[rank]
+        states = q.new_zeros(
+            len(shard.sequence_ids),
+            q.shape[2],
+            v.shape[-1],
+            q.shape[-1],
+            dtype=torch.float32,
+        )
+        first_state = states[0]
+        first_sequence = shard.sequence_ids[0]
+        for predecessor, predecessor_shard in zip(gathered[:rank], shards[:rank], strict=True):
+            if predecessor_shard.sequence_ids[-1] == first_sequence:
+                first_state = merge_state(first_state, predecessor)
+        return torch.cat((first_state.unsqueeze(0), states[1:]), dim=0)
+
+    @staticmethod
+    def compose_reverse_final_states(
+        gathered: torch.Tensor,
+        d_final_state: torch.Tensor | None,
+        initial_state: torch.Tensor,
+        rank: int,
+        shards: tuple[PackedShard, ...],
+    ) -> torch.Tensor:
+        """Compose successor reverse transfers into the last local state cotangent."""
+        incoming = torch.zeros_like(initial_state) if d_final_state is None else d_final_state
+        shard = shards[rank]
+        last_sequence = shard.sequence_ids[-1]
+        # See NOTE [One crossing sequence per contiguous rank boundary].
+        continues = rank + 1 < len(shards) and shards[rank + 1].sequence_ids[0] == last_sequence
+        if not continues:
+            return incoming
+
+        last_gradient = torch.zeros_like(incoming[-1])
+        for successor_rank in range(len(shards) - 1, rank, -1):
+            successor = shards[successor_rank]
+            if successor.sequence_ids[0] != last_sequence:
+                continue
+            last_gradient = merge_state(last_gradient, gathered[successor_rank])
+        incoming = incoming.clone()
+        incoming[-1] += last_gradient
+        return incoming
 
     @staticmethod
     def forward(
@@ -230,7 +199,7 @@ class _CuteContextParallelKDA(torch.autograd.Function):
         annotate,
     ):
         rank = dist.get_rank(group)
-        metadata = prepare_ragged_chunk_metadata(local_cu_seqlens, q.shape[1], _CHUNK_SIZE)
+        metadata = prepare_ragged_chunk_metadata(local_cu_seqlens, q.shape[1], CHUNK_SIZE)
         cumulative_gate = _plain_gate_scan_op(
             gate, metadata.cu_seqlens, metadata.chunk_offsets, False
         )
@@ -260,11 +229,19 @@ class _CuteContextParallelKDA(torch.autograd.Function):
                     cumulative_gate[:, start:],
                 )
         else:
-            summary = _unused_summary(q)
+            summary = q.new_zeros(
+                q.shape[2],
+                v.shape[-1] + q.shape[-1],
+                q.shape[-1],
+                dtype=torch.float32,
+            )
         with kernel_stage("cp/fwd/all_gather", annotate):
-            gathered = _all_gather_tensor(summary, group)
+            gathered = summary.new_empty(dist.get_world_size(group), *summary.shape)
+            dist.all_gather_single(gathered, summary.contiguous(), group=group)
         with kernel_stage("cp/fwd/exclusive_prefix", annotate):
-            initial_state = _compose_forward_initial_states(gathered, q, v, rank, shards)
+            initial_state = ContextParallelKDAFunction.compose_forward_initial_states(
+                gathered, q, v, rank, shards
+            )
         with kernel_stage("cp/fwd/local_output", annotate):
             output, final_state = _finish_chunk_kda_fwd(
                 q,
@@ -322,8 +299,8 @@ class _CuteContextParallelKDA(torch.autograd.Function):
         metadata = RaggedChunkMetadata(
             cu_seqlens,
             chunk_offsets,
-            chunk_capacity(q.shape[1], cu_seqlens.shape[0] - 1, _CHUNK_SIZE),
-            _CHUNK_SIZE,
+            chunk_capacity(q.shape[1], cu_seqlens.shape[0] - 1, CHUNK_SIZE),
+            CHUNK_SIZE,
         )
         if d_output is None:
             d_output = torch.zeros_like(v)
@@ -342,7 +319,7 @@ class _CuteContextParallelKDA(torch.autograd.Function):
             initial_state,
             metadata,
             scale=ctx.scale,
-            chunk_size=_CHUNK_SIZE,
+            chunk_size=CHUNK_SIZE,
             autotune=ctx.autotune,
         )
 
@@ -366,11 +343,17 @@ class _CuteContextParallelKDA(torch.autograd.Function):
                 bias = merge_state(d_final_state[0], summary)
                 summary = torch.cat((bias, summary[..., value_dim:, :]), dim=-2)
         else:
-            summary = _unused_summary(q)
+            summary = q.new_zeros(
+                q.shape[2],
+                v.shape[-1] + q.shape[-1],
+                q.shape[-1],
+                dtype=torch.float32,
+            )
         with kernel_stage("cp/bwd/all_gather", ctx.annotate, backward=False):
-            gathered = _all_gather_tensor(summary, ctx.group)
+            gathered = summary.new_empty(dist.get_world_size(ctx.group), *summary.shape)
+            dist.all_gather_single(gathered, summary.contiguous(), group=ctx.group)
         with kernel_stage("cp/bwd/exclusive_suffix", ctx.annotate, backward=False):
-            incoming = _compose_reverse_final_states(
+            incoming = ContextParallelKDAFunction.compose_reverse_final_states(
                 gathered,
                 d_final_state,
                 initial_state,
@@ -392,7 +375,7 @@ class _CuteContextParallelKDA(torch.autograd.Function):
                 metadata,
                 prepared,
                 scale=ctx.scale,
-                chunk_size=_CHUNK_SIZE,
+                chunk_size=CHUNK_SIZE,
                 fastmath=ctx.fastmath,
                 autotune=ctx.autotune,
             )
@@ -418,10 +401,7 @@ def context_parallel_kda(
     annotate: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Apply packed KDA with native CuTeDSL forward/reverse affine summaries."""
-    scale = q.shape[-1] ** -0.5
-    fastmath = False
-    autotune = False
-    return _CuteContextParallelKDA.apply(
+    return ContextParallelKDAFunction.apply(
         q,
         k,
         v,
@@ -430,66 +410,337 @@ def context_parallel_kda(
         local_cu_seqlens,
         group,
         shards,
-        scale,
-        fastmath,
-        autotune,
+        q.shape[-1] ** -0.5,
+        False,
+        False,
         annotate,
     )
 
 
-def parse_args() -> argparse.Namespace:
-    """Parse the example workload."""
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--sequence-lengths",
-        default="256,1280,512",
-        help="Comma-separated nonempty packed sequence lengths.",
-    )
-    parser.add_argument("--heads", type=int, default=2)
-    parser.add_argument(
-        "--cuda-graph",
-        action="store_true",
-        help="Capture forward and backward and validate a changed-input replay.",
-    )
-    parser.add_argument(
-        "--profile",
-        action="store_true",
-        help="Export one merged native Perfetto trace with transformer-nuggets.",
-    )
-    return parser.parse_args()
+class ContextParallelKDAAttention(KDAAttention):
+    """The training example's complete KDA module with distributed state plumbing."""
+
+    def __init__(
+        self,
+        *args,
+        group: dist.ProcessGroup,
+        shards: tuple[PackedShard, ...],
+        global_cu_seqlens: tuple[int, ...],
+        **kwargs,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.cp_group = group
+        self.shards = shards
+        self.global_cu_seqlens = global_cu_seqlens
+
+    @staticmethod
+    def compose_conv_initial_states(
+        gathered_tails: torch.Tensor,
+        shard_tokens: int,
+        rank: int,
+        shards: tuple[PackedShard, ...],
+        global_cu_seqlens: tuple[int, ...],
+    ) -> torch.Tensor:
+        """Build packed short-convolution histories from fixed-size rank tails."""
+        state_length = gathered_tails.shape[1]
+        states = gathered_tails.new_zeros(
+            len(shards[rank].sequence_ids), state_length, gathered_tails.shape[-1]
+        )
+        boundary = rank * shard_tokens
+        sequence_start = global_cu_seqlens[shards[rank].sequence_ids[0]]
+        valid_length = min(state_length, boundary - sequence_start)
+        if valid_length:
+            stored_per_rank = min(state_length, shard_tokens)
+            predecessor_tokens = gathered_tails[:rank, -stored_per_rank:].flatten(0, 1)
+            states[0, -valid_length:] = predecessor_tokens[-valid_length:]
+        # Keep all ranks in the collective backward when the first sequence starts locally.
+        return states + gathered_tails.flatten()[0] * 0
+
+    @staticmethod
+    def build_conv_initial_states(
+        qkv: torch.Tensor,
+        group: dist.ProcessGroup,
+        shards: tuple[PackedShard, ...],
+        global_cu_seqlens: tuple[int, ...],
+        state_length: int,
+        annotate: bool,
+    ) -> torch.Tensor | None:
+        """All-gather rank tails and construct packed short-convolution histories."""
+        if state_length == 0:
+            return None
+        stored = min(state_length, qkv.shape[1])
+        tail = F.pad(qkv[0, -stored:], (0, 0, state_length - stored, 0))
+        with kernel_stage("cp/conv/halo", annotate):
+            gathered = all_gather_single(tail, gather_dim=0, group=group).view(
+                dist.get_world_size(group), state_length, qkv.shape[-1]
+            )
+        return ContextParallelKDAAttention.compose_conv_initial_states(
+            gathered,
+            qkv.shape[1],
+            dist.get_rank(group),
+            shards,
+            global_cu_seqlens,
+        )
+
+    def short_convolution(
+        self,
+        qkv: torch.Tensor,
+        initial_state: torch.Tensor | None,
+        *,
+        cu_seqlens: torch.Tensor | None = None,
+        return_final_state: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        if initial_state is not None:
+            raise ValueError("context parallelism constructs the short-convolution state")
+        state_length = self.qkv_conv1d.kernel_size[0] - 1
+        initial_state = self.build_conv_initial_states(
+            qkv,
+            self.cp_group,
+            self.shards,
+            self.global_cu_seqlens,
+            state_length,
+            self.enable_graph_annotations,
+        )
+        return super().short_convolution(
+            qkv,
+            initial_state,
+            cu_seqlens=cu_seqlens,
+            return_final_state=return_final_state,
+        )
+
+    def kda_core(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        gate: torch.Tensor,
+        beta: torch.Tensor,
+        initial_state: torch.Tensor | None,
+        *,
+        cu_seqlens: torch.Tensor | None = None,
+        return_final_state: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        if initial_state is not None:
+            raise ValueError("context parallelism constructs the KDA recurrent state")
+        if cu_seqlens is None:
+            raise ValueError("context parallel KDA requires local packed sequence boundaries")
+        output, final_state = context_parallel_kda(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            group=self.cp_group,
+            shards=self.shards,
+            local_cu_seqlens=cu_seqlens,
+            annotate=self.enable_graph_annotations,
+        )
+        return output, final_state if return_final_state else None
 
 
-def make_inputs(
-    tokens: int,
-    heads: int,
+def run_training_step(
+    module: KDAAttention,
+    hidden_states: torch.Tensor,
+    target: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    state_count: int,
+    loss_scale: float,
+    *,
+    annotate: bool = False,
+) -> tuple[KDAAttentionOutput, tuple[torch.Tensor, ...]]:
+    """Run the complete module and differentiate its token and endpoint losses."""
+    module.enable_graph_annotations = annotate
+    result = module(
+        hidden_states,
+        cu_seqlens=cu_seqlens,
+        return_final_state=True,
+    )
+    assert result.final_state is not None
+    assert result.final_conv_state is not None
+    loss = F.mse_loss(result.hidden_states.float(), target, reduction="sum") * loss_scale
+    if state_count:
+        loss = loss + 1e-4 * result.final_state[:state_count].square().sum()
+        loss = loss + 1e-4 * result.final_conv_state[:state_count].float().square().sum()
+    inputs = (hidden_states, *tuple(module.parameters()))
+    with kernel_stage("cp/bwd", annotate, backward=False):
+        gradients = torch.autograd.grad(loss, inputs)
+    return result, gradients
+
+
+def validate_against_reference(
+    model: ContextParallelKDAAttention,
+    reference_model: KDAAttention,
+    batch: PackedTrainingBatch,
+) -> None:
+    """Compare one sharded full-module backward with the unsharded module."""
+    result, gradients = run_training_step(
+        model,
+        batch.local_hidden,
+        batch.local_target,
+        batch.local_offsets,
+        batch.completed_sequences,
+        batch.loss_scale,
+    )
+    reference_hidden = batch.global_hidden.detach().clone().requires_grad_()
+    reference_result, reference_gradients = run_training_step(
+        reference_model,
+        reference_hidden,
+        batch.global_target,
+        batch.global_offsets,
+        batch.sequence_count,
+        batch.loss_scale,
+    )
+
+    # Rank partitioning changes accumulation order, so compare at input-precision accuracy.
+    assert_close = partial(
+        torch.testing.assert_close,
+        atol=torch.finfo(model.compute_dtype).eps,
+        rtol=torch.finfo(model.compute_dtype).eps,
+    )
+    assert_close(result.hidden_states, reference_result.hidden_states[:, batch.local_slice])
+    assert_close(gradients[0], reference_gradients[0][:, batch.local_slice])
+    if batch.completed_sequences:
+        local_states = slice(0, batch.completed_sequences)
+        global_states = slice(
+            batch.first_sequence,
+            batch.first_sequence + batch.completed_sequences,
+        )
+        assert_close(result.final_state[local_states], reference_result.final_state[global_states])
+        assert_close(
+            result.final_conv_state[local_states],
+            reference_result.final_conv_state[global_states],
+        )
+    for actual, expected in zip(gradients[1:], reference_gradients[1:], strict=True):
+        reduced = actual.detach().clone()
+        dist.all_reduce(reduced)
+        assert_close(reduced, expected)
+
+
+def validate_cuda_graph(
+    make_model: Callable[[], ContextParallelKDAAttention],
+    eager_model: ContextParallelKDAAttention,
+    batch: PackedTrainingBatch,
+    annotations: bool,
+    profile_path: Path | None,
     device: torch.device,
-) -> tuple[torch.Tensor, ...]:
-    """Create stable BF16 KDA inputs for validation."""
-    torch.manual_seed(123)
-    shape = (1, tokens, heads, 128)
-    q = torch.randn(shape, dtype=torch.bfloat16, device=device)
-    k = F.normalize(torch.randn_like(q), dim=-1)
-    v = torch.randn_like(q)
-    gate = F.logsigmoid(torch.randn_like(q))
-    beta = torch.sigmoid(torch.randn(shape[:3], dtype=torch.bfloat16, device=device))
-    return q, k, v, gate, beta
+) -> None:
+    """Capture the full distributed backward and compare a changed-input replay."""
+    warmup_stream = torch.cuda.Stream()
+    warmup_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(warmup_stream):
+        # Parameter AccumulateGrad nodes retain their first stream, so the captured path needs
+        # a fresh model whose warmup and eager replay oracle both run on this stream.
+        model = make_model()
+        model.load_state_dict(eager_model.state_dict())
+        capture_hidden = batch.local_hidden.detach().clone().requires_grad_()
+        run_training_step(
+            model,
+            capture_hidden.detach().clone().requires_grad_(),
+            batch.local_target,
+            batch.local_offsets,
+            batch.completed_sequences,
+            batch.loss_scale,
+        )
+    warmup_stream.synchronize()
+    gc.collect()
+    dist.barrier()
+
+    graph = torch.cuda.CUDAGraph()
+    try:
+        with torch.cuda.graph(graph, stream=warmup_stream, enable_annotations=annotations):
+            graph_result, graph_gradients = run_training_step(
+                model,
+                capture_hidden,
+                batch.local_target,
+                batch.local_offsets,
+                batch.completed_sequences,
+                batch.loss_scale,
+                annotate=annotations,
+            )
+        torch.cuda.current_stream().wait_stream(warmup_stream)
+        captured_output = graph_result.hidden_states.clone()
+        torch.cuda.synchronize(device)
+
+        with torch.no_grad():
+            capture_hidden.mul_(0.75)
+        with torch.cuda.stream(warmup_stream):
+            eager_hidden = capture_hidden.detach().clone().requires_grad_()
+            eager_result, eager_gradients = run_training_step(
+                model,
+                eager_hidden,
+                batch.local_target,
+                batch.local_offsets,
+                batch.completed_sequences,
+                batch.loss_scale,
+            )
+        warmup_stream.synchronize()
+        graph.replay()
+        torch.cuda.synchronize(device)
+        if torch.equal(graph_result.hidden_states, captured_output):
+            raise AssertionError("CUDA Graph replay did not observe changed inputs")
+        torch.testing.assert_close(graph_result, eager_result)
+        torch.testing.assert_close(graph_gradients, eager_gradients)
+        if profile_path is not None:
+            merged_path = record_distributed_profile(
+                graph.replay,
+                profile_path,
+                "cuda_graph_replay",
+                device,
+            )
+            if merged_path is not None:
+                print(f"profile={merged_path}", flush=True)
+    finally:
+        torch.cuda.synchronize(device)
+        graph.reset()
+        gc.collect()
 
 
-def ending_state_count(
-    shard: PackedShard,
-    rank: int,
-    shard_tokens: int,
-    global_cu_seqlens: tuple[int, ...],
-) -> int:
-    """Count the prefix of local fragments ending on this rank."""
-    rank_end = (rank + 1) * shard_tokens
-    last_sequence_ends_later = global_cu_seqlens[shard.sequence_ids[-1] + 1] > rank_end
-    return len(shard.sequence_ids) - int(last_sequence_ends_later)
+def profile_eager_step(
+    model: ContextParallelKDAAttention,
+    batch: PackedTrainingBatch,
+    profile_path: Path,
+    device: torch.device,
+) -> None:
+    """Profile one complete eager context-parallel forward and backward."""
+    hidden_states = batch.local_hidden.detach().clone().requires_grad_()
+    merged_path = record_distributed_profile(
+        lambda: run_training_step(
+            model,
+            hidden_states,
+            batch.local_target,
+            batch.local_offsets,
+            batch.completed_sequences,
+            batch.loss_scale,
+        ),
+        profile_path,
+        "iteration",
+        device,
+    )
+    if merged_path is not None:
+        print(f"profile={merged_path}", flush=True)
 
 
-def main() -> None:
-    """Run and validate the packed native-summary context-parallel example."""
-    args = parse_args()
+def main(
+    sequence_lengths: Annotated[
+        str,
+        typer.Option(help="Comma-separated nonempty packed sequence lengths."),
+    ] = "256,1280,512",
+    hidden_size: Annotated[int, typer.Option(min=1, help="Transformer hidden size.")] = 256,
+    heads: Annotated[int, typer.Option(min=1, help="Number of KDA heads.")] = 2,
+    short_conv_kernel_size: Annotated[
+        int,
+        typer.Option(min=1, help="Causal Q/K/V convolution width."),
+    ] = 4,
+    cuda_graph: Annotated[
+        bool,
+        typer.Option(help="Capture forward and backward and validate a changed-input replay."),
+    ] = False,
+    profile: Annotated[
+        bool,
+        typer.Option(help="Export a merged native Perfetto trace with transformer-nuggets."),
+    ] = False,
+) -> None:
+    """Run and validate the complete packed context-parallel KDA module."""
     local_rank = int(os.environ["LOCAL_RANK"])
     device = torch.device(f"cuda:{local_rank}")
     torch.cuda.set_device(device)
@@ -497,7 +748,7 @@ def main() -> None:
     rank = dist.get_rank()
     world_size = dist.get_world_size()
     graph_annotations_available = False
-    if args.cuda_graph:
+    if cuda_graph:
         try:
             from torch.cuda.graph_annotations import is_available
         except ImportError:
@@ -511,158 +762,83 @@ def main() -> None:
                 flush=True,
             )
 
-    lengths = tuple(int(length) for length in args.sequence_lengths.split(","))
+    lengths = tuple(int(length) for length in sequence_lengths.split(","))
     global_cu_seqlens = tuple(accumulate(lengths, initial=0))
     shards = partition_packed_sequences(global_cu_seqlens, world_size)
     tokens = global_cu_seqlens[-1]
     shard_tokens = tokens // world_size
     local_slice = slice(rank * shard_tokens, (rank + 1) * shard_tokens)
-    global_inputs = make_inputs(tokens, args.heads, device)
-    local_inputs = tuple(
-        tensor[:, local_slice].clone().requires_grad_() for tensor in global_inputs
-    )
     local_shard = shards[rank]
     local_cu_seqlens = torch.tensor(
         local_shard.cu_seqlens,
         dtype=torch.int32,
         device=device,
     )
-
-    final_state_count = ending_state_count(
-        local_shard,
-        rank,
-        shard_tokens,
-        global_cu_seqlens,
-    )
-
-    def run(inputs: tuple[torch.Tensor, ...], *, annotate: bool = False):
-        output, final_state = context_parallel_kda(
-            *inputs,
-            group=dist.group.WORLD,
-            shards=shards,
-            local_cu_seqlens=local_cu_seqlens,
-            annotate=annotate,
-        )
-        loss = output.float().sum()
-        if final_state_count:
-            loss = loss + final_state[:final_state_count].sum()
-        with kernel_stage("cp/bwd", annotate, backward=False):
-            gradients = torch.autograd.grad(loss, inputs)
-        return output, final_state, gradients
-
-    profile_mode = "cuda_graph" if args.cuda_graph else "eager"
-    profile_path = Path(
-        f"kda_context_parallel_{profile_mode}_w{world_size}_t{tokens}_h{args.heads}"
-    ).resolve()
-
-    def record_profile(step: Callable[[], object], label: str) -> None:
-        """Capture one synchronized distributed step and merge its rank traces."""
-        dist.barrier()
-        with profile_trace(profile_path) as active_profiler:
-            # Start the measured step together after rank-local profiler setup.
-            dist.barrier()
-            torch.cuda.synchronize(device)
-            with torch.profiler.record_function(f"cp/rank_{rank}/{label}"):
-                step()
-            torch.cuda.synchronize(device)
-            active_profiler.step()
-        dist.barrier()
-
-        if rank == 0:
-            merge_traces = import_module("transformer_nuggets.utils.merge_traces").merge_traces
-            rank_paths = [
-                profile_path.with_name(f"{profile_path.stem}_rank_{index}.pftrace")
-                for index in range(world_size)
-            ]
-            merged_path = profile_path.with_name(f"{profile_path.stem}_merged.pftrace")
-            merge_traces(
-                [str(path) for path in rank_paths],
-                str(merged_path),
-                labels=[f"Rank {index} · GPU {index}" for index in range(world_size)],
-                align_timestamps=False,
-            )
-            print(f"profile={merged_path}", flush=True)
-        dist.barrier()
-
-    output, final_state, gradients = run(local_inputs)
-    global_reference_inputs = tuple(
-        tensor.detach().clone().requires_grad_() for tensor in global_inputs
-    )
     global_offsets = torch.tensor(global_cu_seqlens, dtype=torch.int32, device=device)
-    reference_output, reference_state = chunk_kda(
-        *global_reference_inputs,
-        cu_seqlens=global_offsets,
-        output_final_state=True,
-        autotune=False,
-        impl="fused",
+    continues = (
+        rank + 1 < world_size and local_shard.sequence_ids[-1] == shards[rank + 1].sequence_ids[0]
     )
-    assert reference_state is not None
-    reference_loss = reference_output.float().sum() + reference_state.sum()
-    reference_gradients = torch.autograd.grad(reference_loss, global_reference_inputs)
+    final_state_count = len(local_shard.sequence_ids) - int(continues)
 
-    torch.testing.assert_close(output, reference_output[:, local_slice], atol=0.15, rtol=0.15)
-    if final_state_count:
-        first_sequence = local_shard.sequence_ids[0]
-        torch.testing.assert_close(
-            final_state[:final_state_count],
-            reference_state[first_sequence : first_sequence + final_state_count],
-            atol=0.15,
-            rtol=0.15,
+    torch.manual_seed(0)
+    model_options = {
+        "hidden_size": hidden_size,
+        "num_heads": heads,
+        "head_dim": 128,
+        "short_conv_kernel_size": short_conv_kernel_size,
+        "backend": "fused",
+        "device": device,
+    }
+    make_model = partial(
+        ContextParallelKDAAttention,
+        **model_options,
+        group=dist.group.WORLD,
+        shards=shards,
+        global_cu_seqlens=global_cu_seqlens,
+    )
+    model = make_model()
+    reference_model = KDAAttention(**model_options)
+    reference_model.load_state_dict(model.state_dict())
+
+    torch.manual_seed(123)
+    global_hidden = torch.randn(1, tokens, hidden_size, device=device)
+    global_target = torch.randn_like(global_hidden)
+    batch = PackedTrainingBatch(
+        global_hidden=global_hidden,
+        global_target=global_target,
+        global_offsets=global_offsets,
+        local_hidden=global_hidden[:, local_slice].clone().requires_grad_(),
+        local_target=global_target[:, local_slice],
+        local_offsets=local_cu_seqlens,
+        local_slice=local_slice,
+        first_sequence=local_shard.sequence_ids[0],
+        completed_sequences=final_state_count,
+        sequence_count=len(lengths),
+        loss_scale=1.0 / global_target.numel(),
+    )
+    validate_against_reference(model, reference_model, batch)
+    gc.collect()
+
+    profile_mode = "cuda_graph" if cuda_graph else "eager"
+    profile_path = Path(
+        "data",
+        f"kda_context_parallel_{profile_mode}_w{world_size}_t{tokens}_h{heads}"
+        f"_c{hidden_size}_conv{short_conv_kernel_size}",
+    ).resolve()
+    if cuda_graph:
+        validate_cuda_graph(
+            make_model,
+            model,
+            batch,
+            graph_annotations_available,
+            profile_path if profile else None,
+            device,
         )
-    for actual, expected in zip(gradients, reference_gradients, strict=True):
-        torch.testing.assert_close(actual, expected[:, local_slice], atol=0.15, rtol=0.15)
+    elif profile:
+        profile_eager_step(model, batch, profile_path, device)
 
-    if args.cuda_graph:
-        capture_inputs = tuple(tensor.detach().clone().requires_grad_() for tensor in local_inputs)
-        warmup_stream = torch.cuda.Stream()
-        warmup_stream.wait_stream(torch.cuda.current_stream())
-        with torch.cuda.stream(warmup_stream):
-            run(tuple(tensor.detach().clone().requires_grad_() for tensor in capture_inputs))
-        warmup_stream.synchronize()
-        dist.barrier()
-
-        graph = torch.cuda.CUDAGraph()
-        try:
-            with torch.cuda.graph(
-                graph,
-                stream=warmup_stream,
-                enable_annotations=graph_annotations_available,
-            ):
-                graph_output, graph_state, graph_gradients = run(
-                    capture_inputs,
-                    annotate=graph_annotations_available,
-                )
-            torch.cuda.current_stream().wait_stream(warmup_stream)
-            captured_output = graph_output.clone()
-            torch.cuda.synchronize(device)
-
-            with torch.no_grad():
-                capture_inputs[0].mul_(0.75)
-                capture_inputs[2].mul_(0.5)
-            eager_inputs = tuple(
-                tensor.detach().clone().requires_grad_() for tensor in capture_inputs
-            )
-            eager_output, eager_state, eager_gradients = run(eager_inputs)
-            graph.replay()
-            torch.cuda.synchronize(device)
-            if torch.equal(graph_output, captured_output):
-                raise AssertionError("CUDA Graph replay did not observe changed inputs")
-            torch.testing.assert_close(graph_output, eager_output, atol=0.15, rtol=0.15)
-            torch.testing.assert_close(graph_state, eager_state, atol=0.15, rtol=0.15)
-            for replayed, expected in zip(graph_gradients, eager_gradients, strict=True):
-                torch.testing.assert_close(replayed, expected, atol=0.15, rtol=0.15)
-            if args.profile:
-                record_profile(graph.replay, "cuda_graph_replay")
-        finally:
-            torch.cuda.synchronize(device)
-            graph.reset()
-            gc.collect()
-    elif args.profile:
-        profile_inputs = tuple(tensor.detach().clone().requires_grad_() for tensor in local_inputs)
-        record_profile(lambda: run(profile_inputs), "iteration")
-
-    mode = " with CUDA Graph replay" if args.cuda_graph else ""
-    print(f"rank {rank}: packed KDA CP passed{mode}", flush=True)
+    mode = " with CUDA Graph replay" if cuda_graph else ""
+    print(f"rank {rank}: full packed KDA CP passed{mode}", flush=True)
     torch.cuda.synchronize(device)
     dist.destroy_process_group()
 
@@ -670,4 +846,4 @@ def main() -> None:
 if __name__ == "__main__":
     if "LOCAL_RANK" not in os.environ:
         raise RuntimeError("launch with torchrun --standalone --nproc-per-node=<world_size>")
-    main()
+    typer.run(main)

--- a/examples/kda_training.py
+++ b/examples/kda_training.py
@@ -51,7 +51,6 @@ import torch
 import torch.nn.functional as F
 import typer
 from torch import nn
-from torch.cuda.graph_annotations import mark_kernels
 
 from attn_gym.linear.kda import (
     MAX_GATE_LOWER_BOUND_MAGNITUDE,
@@ -106,6 +105,13 @@ def _profile_trace(
     with torch.profiler.profile(activities=activities) as active_profiler:
         yield active_profiler
     active_profiler.export_chrome_trace(str(path))
+
+
+def mark_kernels(*args: Any, **kwargs: Any):
+    """Load optional CUDA Graph annotations only when they are requested."""
+    from torch.cuda.graph_annotations import mark_kernels as annotate
+
+    return annotate(*args, **kwargs)
 
 
 def annotate_kernels(name: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:

--- a/test/test_kda_context_parallel.py
+++ b/test/test_kda_context_parallel.py
@@ -1,4 +1,4 @@
-"""Small CPU tests for context-parallel affine-summary routing."""
+"""Small CPU tests for context-parallel state routing."""
 
 from __future__ import annotations
 
@@ -8,9 +8,9 @@ import torch
 pytest.importorskip("cutlass")
 
 from examples.kda_context_parallel import (
+    ContextParallelKDAAttention,
+    ContextParallelKDAFunction,
     PackedShard,
-    _compose_forward_initial_states,
-    _compose_reverse_final_states,
 )
 
 
@@ -23,6 +23,98 @@ def _summary(transition: list[list[float]], bias: list[list[float]]) -> torch.Te
 def _apply(state: torch.Tensor, summary: torch.Tensor) -> torch.Tensor:
     """Independent affine-map oracle for the routing tests."""
     return state @ summary[:, 2:, :] + summary[:, :2, :]
+
+
+def test_short_conv_halo_spans_multiple_small_shards_and_resets_at_documents():
+    global_cu_seqlens = (0, 1, 7, 8)
+    shards = (
+        PackedShard(cu_seqlens=(0, 1, 2), sequence_ids=(0, 1)),
+        PackedShard(cu_seqlens=(0, 2), sequence_ids=(1,)),
+        PackedShard(cu_seqlens=(0, 2), sequence_ids=(1,)),
+        PackedShard(cu_seqlens=(0, 1, 2), sequence_ids=(1, 2)),
+    )
+    gathered_tails = torch.tensor(
+        [
+            [[0.0], [0.0], [1.0]],
+            [[0.0], [2.0], [3.0]],
+            [[0.0], [4.0], [5.0]],
+            [[0.0], [6.0], [7.0]],
+        ]
+    )
+
+    rank_three = ContextParallelKDAAttention.compose_conv_initial_states(
+        gathered_tails,
+        shard_tokens=2,
+        rank=3,
+        shards=shards,
+        global_cu_seqlens=global_cu_seqlens,
+    )
+
+    torch.testing.assert_close(rank_three[0, :, 0], torch.tensor([3.0, 4.0, 5.0]))
+    torch.testing.assert_close(rank_three[1], torch.zeros_like(rank_three[1]))
+
+    reset_boundaries = (0, 2, 8)
+    reset_shards = (
+        PackedShard(cu_seqlens=(0, 2), sequence_ids=(0,)),
+        PackedShard(cu_seqlens=(0, 2), sequence_ids=(1,)),
+        PackedShard(cu_seqlens=(0, 2), sequence_ids=(1,)),
+        PackedShard(cu_seqlens=(0, 2), sequence_ids=(1,)),
+    )
+    reset = ContextParallelKDAAttention.compose_conv_initial_states(
+        gathered_tails,
+        shard_tokens=2,
+        rank=1,
+        shards=reset_shards,
+        global_cu_seqlens=reset_boundaries,
+    )
+    torch.testing.assert_close(reset, torch.zeros_like(reset))
+
+    partial_boundaries = (0, 3, 8)
+    partial_shards = (
+        PackedShard(cu_seqlens=(0, 2), sequence_ids=(0,)),
+        PackedShard(cu_seqlens=(0, 1, 2), sequence_ids=(0, 1)),
+        PackedShard(cu_seqlens=(0, 2), sequence_ids=(1,)),
+        PackedShard(cu_seqlens=(0, 2), sequence_ids=(1,)),
+    )
+    partial = ContextParallelKDAAttention.compose_conv_initial_states(
+        gathered_tails,
+        shard_tokens=2,
+        rank=2,
+        shards=partial_shards,
+        global_cu_seqlens=partial_boundaries,
+    )
+    torch.testing.assert_close(partial[0, :, 0], torch.tensor([0.0, 0.0, 3.0]))
+
+
+def test_short_conv_halo_backward_is_the_transpose_of_forward_routing():
+    global_cu_seqlens = (0, 1, 7, 8)
+    shards = (
+        PackedShard(cu_seqlens=(0, 1, 2), sequence_ids=(0, 1)),
+        PackedShard(cu_seqlens=(0, 2), sequence_ids=(1,)),
+        PackedShard(cu_seqlens=(0, 2), sequence_ids=(1,)),
+        PackedShard(cu_seqlens=(0, 1, 2), sequence_ids=(1, 2)),
+    )
+    gathered_tails = torch.zeros(4, 3, 1, requires_grad=True)
+    rank_two = ContextParallelKDAAttention.compose_conv_initial_states(
+        gathered_tails,
+        shard_tokens=2,
+        rank=2,
+        shards=shards,
+        global_cu_seqlens=global_cu_seqlens,
+    )
+    rank_three = ContextParallelKDAAttention.compose_conv_initial_states(
+        gathered_tails,
+        shard_tokens=2,
+        rank=3,
+        shards=shards,
+        global_cu_seqlens=global_cu_seqlens,
+    )
+    loss = (rank_two[0, :, 0] * torch.tensor([10.0, 20.0, 30.0])).sum()
+    loss += (rank_three[0, :, 0] * torch.tensor([40.0, 50.0, 60.0])).sum()
+
+    (tail_gradients,) = torch.autograd.grad(loss, gathered_tails)
+
+    torch.testing.assert_close(tail_gradients[1, :, 0], torch.tensor([0.0, 20.0, 70.0]))
 
 
 def test_forward_prefix_propagates_one_sequence_across_three_shards():
@@ -41,7 +133,9 @@ def test_forward_prefix_propagates_one_sequence_across_three_shards():
     q = torch.empty(1, 2, 1, 2)
     v = torch.empty_like(q)
 
-    states = _compose_forward_initial_states(summaries, q, v, rank=2, shards=shards)
+    states = ContextParallelKDAFunction.compose_forward_initial_states(
+        summaries, q, v, rank=2, shards=shards
+    )
 
     expected_first = _apply(_apply(torch.zeros(1, 2, 2), summaries[0]), summaries[1])
     torch.testing.assert_close(states[0], expected_first)
@@ -66,7 +160,7 @@ def test_reverse_suffix_filters_sequences_and_adds_final_state_gradient():
     initial_state = torch.zeros(2, 1, 2, 2)
     d_final_state = torch.arange(8, dtype=torch.float32).reshape_as(initial_state)
 
-    gradients = _compose_reverse_final_states(
+    gradients = ContextParallelKDAFunction.compose_reverse_final_states(
         summaries,
         d_final_state=d_final_state,
         initial_state=initial_state,


### PR DESCRIPTION
## Summary

- reuse the complete `KDAAttention` example module for context-parallel execution
- add differentiable packed short-convolution halo exchange alongside the native KDA summary scan
- validate full-module outputs, recurrent and convolution states, input gradients, and reduced parameter gradients against an unsharded run
- preserve eager profiling and CUDA Graph replay while moving reusable distributed/profile helpers into `attn_gym.testing`
- switch the example CLI to Typer and document the complete execution path

The convolution halo supports document-boundary resets and histories spanning multiple rank shards when `W - 1` exceeds the local shard length. Its all-gather uses a reduce-scatter autograd transpose.

## Validation

- `pytest -q test/test_kda_context_parallel.py test/test_kda_training_example.py`
- `CUDA_VISIBLE_DEVICES=0,1 .venv/bin/torchrun --standalone --nproc-per-node=2 examples/kda_context_parallel.py`
- `CUDA_VISIBLE_DEVICES=0,1 .venv/bin/torchrun --standalone --nproc-per-node=2 examples/kda_context_parallel.py --sequence-lengths 64,256,64 --hidden-size 256 --heads 2 --cuda-graph`
- `CUDA_VISIBLE_DEVICES=0,1 .venv/bin/torchrun --standalone --nproc-per-node=2 examples/kda_context_parallel.py --sequence-lengths 1,9 --hidden-size 64 --heads 1 --short-conv-kernel-size 8`
- `CUDA_VISIBLE_DEVICES=0,1 .venv/bin/torchrun --standalone --nproc-per-node=2 examples/kda_context_parallel.py --sequence-lengths 32,64,32 --hidden-size 64 --heads 1 --profile`
- `prek run --all-files`
