### PR TITLE
Support wide and misaligned KDA summary inputs

### DIFF
--- a/attn_gym/linear/_delta_rule/cute/affine_summary_fwd.py
+++ b/attn_gym/linear/_delta_rule/cute/affine_summary_fwd.py
@@ -43,7 +43,7 @@ halves of the I/O dtype and accumulated in two UMMA passes. The A operands
 
 Limitations:
   - B=1, dense complete chunks only (``T % 64 == 0``), fixed K=V=128, BT=64.
-  - Contiguous inputs with an int32-addressable ABI; SM100 (tcgen05) only.
+  - Contiguous inputs; SM100 (tcgen05) only.
 """
 
 # NOTE: no `from __future__ import annotations` — cute.struct requires
@@ -75,6 +75,11 @@ DATA_ALIGN_BYTES = 16
 
 _IO_TYPE_NAMES = {torch.bfloat16: "bf16", torch.float16: "fp16"}
 _CUTE_IO_TYPES = {"bf16": cutlass.BFloat16, "fp16": cutlass.Float16}
+
+
+def _aligned(tensor: torch.Tensor) -> torch.Tensor:
+    """Materialize the uncommon contiguous view that misses the TMA alignment."""
+    return tensor if tensor.data_ptr() % DATA_ALIGN_BYTES == 0 else tensor.clone()
 
 
 @cute.jit
@@ -148,13 +153,20 @@ class _AffineSummaryFwdOp:
     WARP_SZ = cute.arch.WARP_SIZE
     CTA_THREADS = WarpRole.END * WARP_SZ
 
-    def __init__(self, dtype_name: str, heads: int, state_bn: int):
+    def __init__(
+        self,
+        dtype_name: str,
+        heads: int,
+        state_bn: int,
+        use_int64_offsets: bool,
+    ):
         assert state_bn in (32, 64), f"state_bn must be 32 or 64, got {state_bn}"
         assert SUMMARY_DIM % state_bn == 0
         self.dtype_name = dtype_name
         self.io_type = _CUTE_IO_TYPES[dtype_name]
         self.heads = heads
         self.BN = state_bn
+        self.use_int64_offsets = use_int64_offsets
 
         # MMA tile shapes (M, N, K).
         # MMA1: w @ X -> wx — w is (BT, K) K-major, X is (K, BN) snapshot in SMEM.
@@ -177,7 +189,10 @@ class _AffineSummaryFwdOp:
 
     def get_name(self) -> str:
         """Return a stable profiler and artifact name for this specialization."""
-        return f"delta_affine_summary_fwd_h{self.heads}_bn{self.BN}_{self.dtype_name}"
+        return (
+            f"delta_affine_summary_fwd_h{self.heads}_bn{self.BN}_{self.dtype_name}"
+            f"_i64{int(self.use_int64_offsets)}"
+        )
 
     # ------------------------------------------------------------------
     # Host-side setup (__call__): GMEM views → MMA → TMA → SMEM → launch
@@ -950,7 +965,12 @@ class _AffineSummaryFwdOp:
 
 
 @jit_cache
-def _compile_affine_summary(dtype_name: str, heads: int, state_bn: int):
+def _compile_affine_summary(
+    dtype_name: str,
+    heads: int,
+    state_bn: int,
+    use_int64_offsets: bool,
+):
     """Compile one dtype/head-count specialization from fake tensors."""
     target = get_compile_target()
     if target.device_type != "cuda" or target.capability is None or target.capability < (10, 0):
@@ -958,7 +978,8 @@ def _compile_affine_summary(dtype_name: str, heads: int, state_bn: int):
             f"affine_summary_fwd requires an SM100 (CUDA capability >= 10.0) target; "
             f"got target={target}"
         )
-    tokens = cute.sym_int(divisibility=BT)
+    sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
+    tokens = sym_int(divisibility=BT)
 
     def factor(dtype, last_dim: int):
         return make_fake_compact_tensor(
@@ -976,7 +997,7 @@ def _compile_affine_summary(dtype_name: str, heads: int, state_bn: int):
         assumed_align=DATA_ALIGN_BYTES,
     )
     return compile_tvm_ffi(
-        _AffineSummaryFwdOp(dtype_name, heads, state_bn),
+        _AffineSummaryFwdOp(dtype_name, heads, state_bn, use_int64_offsets),
         factor(io_dtype, KEY_DIM),
         factor(io_dtype, KEY_DIM),
         factor(io_dtype, VAL_DIM),
@@ -1004,8 +1025,8 @@ def build_state_summary(
         FP32 tensor of shape ``[H, 256, 128]``, V-first packed as state bias then
         state transition for ``H_out = H_in @ transition + bias``.
 
-    Supported scope: B=1, fixed K=V=128 and BT=64, contiguous int32-addressable
-    inputs, SM100. A partial final chunk is neutral-padded by the wrapper.
+    Supported scope: B=1, fixed K=V=128 and BT=64, contiguous inputs on SM100.
+    A partial final chunk is neutral-padded by the wrapper.
     """
     assert kg.ndim == 4, f"kg must be 4D [1, T, H, K], got shape {tuple(kg.shape)}"
     batch, tokens, heads, key_dim = kg.shape
@@ -1040,9 +1061,7 @@ def build_state_summary(
     for name, tensor in (("kg", kg), ("w", w), ("u", u), ("cumulative_gate", cumulative_gate)):
         assert tensor.device == kg.device, f"{name} must be on {kg.device}, got {tensor.device}"
         assert tensor.is_contiguous(), f"{name} must be contiguous, got strides {tensor.stride()}"
-        assert tensor.data_ptr() % DATA_ALIGN_BYTES == 0, (
-            f"{name} data pointer must be {DATA_ALIGN_BYTES}-byte aligned"
-        )
+    kg, w, u, cumulative_gate = (_aligned(tensor) for tensor in (kg, w, u, cumulative_gate))
     pad = (-tokens) % BT
     if pad:
         padding = (0, 0, 0, 0, 0, pad)
@@ -1054,15 +1073,15 @@ def build_state_summary(
             ),
             dim=1,
         )
-    assert not requires_int64_abi(kg, w, u, cumulative_gate, out), (
-        "build_state_summary currently requires int32-addressable tensors"
-    )
+    use_int64_offsets = requires_int64_abi(kg, w, u, cumulative_gate, out)
 
     # BN=32 is faster per CTA (measured ~1.5x vs BN=64 on GB200); fall back to
     # BN=64 only when the extra column tiles would spill past one CTA wave and
     # serialize whole recurrence chains.
     sm_count = get_device_properties(kg.device).multi_processor_count
     state_bn = 32 if heads * (SUMMARY_DIM // 32) <= sm_count else 64
-    compiled = _compile_affine_summary(_IO_TYPE_NAMES[kg.dtype], heads, state_bn)
+    compiled = _compile_affine_summary(
+        _IO_TYPE_NAMES[kg.dtype], heads, state_bn, use_int64_offsets
+    )
     compiled(kg.detach(), w.detach(), u.detach(), cumulative_gate.detach(), out)
     return out

--- a/attn_gym/linear/_delta_rule/cute/affine_summary_rev.py
+++ b/attn_gym/linear/_delta_rule/cute/affine_summary_rev.py
@@ -49,6 +49,11 @@ _IO_TYPE_NAMES = {torch.bfloat16: "bf16", torch.float16: "fp16"}
 _CUTE_IO_TYPES = {"bf16": cutlass.BFloat16, "fp16": cutlass.Float16}
 
 
+def _aligned(tensor: torch.Tensor) -> torch.Tensor:
+    """Materialize the uncommon contiguous view that misses the TMA alignment."""
+    return tensor if tensor.data_ptr() % DATA_ALIGN_BYTES == 0 else tensor.clone()
+
+
 @cute.jit
 def _sequence_feature_head_batch_view(tensor):
     """Re-rank ``[B,T,H,D]`` as ``[T,D,(H,B)]`` for a TMA operand."""
@@ -126,6 +131,7 @@ class BlackwellDeltaAffineSummaryRev:
         num_heads: int,
         io_type: type[cutlass.Numeric],
         state_tile_width: int,
+        use_int64_offsets: bool,
     ):
         # This limits columns handled by one CTA, not the number of attention heads.
         assert state_tile_width in (16, 32), (
@@ -137,6 +143,7 @@ class BlackwellDeltaAffineSummaryRev:
         self.BT = BT
         self.BK = KEY_DIM
         self.BN = state_tile_width
+        self.use_int64_offsets = use_int64_offsets
 
         self.state_regs = 128 if state_tile_width == 16 else 160
         self.aux_regs = 40
@@ -167,7 +174,10 @@ class BlackwellDeltaAffineSummaryRev:
     def get_name(self) -> str:
         """Return a stable artifact and profiler name for this specialization."""
         dtype_name = "bf16" if self.io_type is cutlass.BFloat16 else "fp16"
-        return f"delta_affine_summary_rev_h{self.num_heads}_bn{self.BN}_{dtype_name}"
+        return (
+            f"delta_affine_summary_rev_h{self.num_heads}_bn{self.BN}_{dtype_name}"
+            f"_i64{int(self.use_int64_offsets)}"
+        )
 
     @cute.jit
     def __call__(
@@ -1256,14 +1266,20 @@ def select_summary_tile_width(heads: int, device: torch.device) -> int:
 
 
 @jit_cache
-def _compile_affine_summary_rev(dtype_name: str, heads: int, state_tile_width: int):
+def _compile_affine_summary_rev(
+    dtype_name: str,
+    heads: int,
+    state_tile_width: int,
+    use_int64_offsets: bool,
+):
     """Compile one reverse-summary dtype/head/tile specialization."""
     target = get_compile_target()
     if target.device_type != "cuda" or target.capability is None or target.capability < (10, 0):
         raise ValueError(
             f"affine_summary_rev requires a CUDA capability >= 10.0 target; got {target}"
         )
-    tokens = cute.sym_int(divisibility=BT)
+    sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
+    tokens = sym_int(divisibility=BT)
 
     def factor(dtype, last_dim: int):
         return make_fake_compact_tensor(
@@ -1281,7 +1297,12 @@ def _compile_affine_summary_rev(dtype_name: str, heads: int, state_tile_width: i
         assumed_align=DATA_ALIGN_BYTES,
     )
     return compile_tvm_ffi(
-        BlackwellDeltaAffineSummaryRev(heads, io_dtype, state_tile_width),
+        BlackwellDeltaAffineSummaryRev(
+            heads,
+            io_dtype,
+            state_tile_width,
+            use_int64_offsets,
+        ),
         factor(io_dtype, KEY_DIM),
         factor(io_dtype, KEY_DIM),
         factor(io_dtype, KEY_DIM),
@@ -1317,8 +1338,8 @@ def build_state_grad_summary(
         FP32 tensor of shape ``[H, 256, 128]``, V-first packed as local bias then
         reverse transition for ``dH_in = dH_out @ transition + bias``.
 
-    Supported scope: B=1, fixed K=V=128 and BT=64, contiguous int32-addressable
-    inputs on Blackwell. A partial final chunk is neutral-padded by the wrapper.
+    Supported scope: B=1, fixed K=V=128 and BT=64, contiguous inputs on Blackwell.
+    A partial final chunk is neutral-padded by the wrapper.
     """
     assert qg.ndim == 4, f"qg must be 4D [1, T, H, K], got shape {tuple(qg.shape)}"
     batch, tokens, heads, key_dim = qg.shape
@@ -1365,9 +1386,7 @@ def build_state_grad_summary(
     for name, tensor in inputs:
         assert tensor.device == qg.device, f"{name} must be on {qg.device}, got {tensor.device}"
         assert tensor.is_contiguous(), f"{name} must be contiguous, got strides {tensor.stride()}"
-        assert tensor.data_ptr() % DATA_ALIGN_BYTES == 0, (
-            f"{name} data pointer must be {DATA_ALIGN_BYTES}-byte aligned"
-        )
+    qg, kg, w, dout, Aqk, cumulative_gate = (_aligned(tensor) for _name, tensor in inputs)
     pad = (-tokens) % BT
     if pad:
         padding = (0, 0, 0, 0, 0, pad)
@@ -1379,12 +1398,12 @@ def build_state_grad_summary(
             ),
             dim=1,
         )
-    assert not requires_int64_abi(qg, kg, w, dout, Aqk, cumulative_gate, out), (
-        "build_state_grad_summary currently requires int32-addressable tensors"
-    )
+    use_int64_offsets = requires_int64_abi(qg, kg, w, dout, Aqk, cumulative_gate, out)
 
     state_tile_width = select_summary_tile_width(heads, qg.device)
-    compiled = _compile_affine_summary_rev(_IO_TYPE_NAMES[qg.dtype], heads, state_tile_width)
+    compiled = _compile_affine_summary_rev(
+        _IO_TYPE_NAMES[qg.dtype], heads, state_tile_width, use_int64_offsets
+    )
     compiled(
         qg.detach(),
         kg.detach(),

--- a/test/test_delta_affine_summary.py
+++ b/test/test_delta_affine_summary.py
@@ -16,6 +16,28 @@ pytestmark = pytest.mark.skipif(
 )
 
 
+def int64_stride_copy(tensor: torch.Tensor) -> torch.Tensor:
+    """Copy a B=1 tensor into a contiguous view whose unreachable batch stride needs int64."""
+    result = torch.empty_strided(
+        tensor.shape,
+        (2**31, *tensor.stride()[1:]),
+        dtype=tensor.dtype,
+        device=tensor.device,
+    )
+    result.copy_(tensor)
+    assert result.is_contiguous()
+    return result
+
+
+def misaligned_copy(tensor: torch.Tensor) -> torch.Tensor:
+    """Copy into contiguous storage beginning one element past an aligned allocation."""
+    storage = torch.empty(tensor.numel() + 1, dtype=tensor.dtype, device=tensor.device)
+    result = storage[1:].view(tensor.shape)
+    result.copy_(tensor)
+    assert result.is_contiguous() and result.data_ptr() % 16 != 0
+    return result
+
+
 def state_summary_reference(
     kg: torch.Tensor,
     w: torch.Tensor,
@@ -101,6 +123,74 @@ def state_grad_summary_reference(
             - chunk_w.transpose(-2, -1) @ corrected
         )
     return state.transpose(-2, -1).contiguous()
+
+
+def test_affine_summaries_support_int64_tensor_strides():
+    """Compile wide-address kernels for realistic long-sequence batch strides."""
+    torch.manual_seed(19)
+    shape = (1, 64, 1, 128)
+    qg = torch.randn(shape, dtype=torch.bfloat16, device="cuda") / 32
+    kg = torch.randn_like(qg) / 32
+    w = torch.randn_like(qg) / 32
+    u = torch.randn_like(qg) / 32
+    dout = torch.randn_like(qg) / 32
+    aqk = torch.randn(1, 64, 1, 64, dtype=torch.bfloat16, device="cuda") / 32
+    cumulative_gate = -torch.rand(shape, dtype=torch.float32, device="cuda") / 8
+
+    expected_forward = build_state_summary(kg, w, u, cumulative_gate)
+    expected_reverse = build_state_grad_summary(
+        qg,
+        kg,
+        w,
+        dout,
+        aqk,
+        cumulative_gate,
+        128**-0.5,
+    )
+    actual_forward = build_state_summary(
+        *(int64_stride_copy(tensor) for tensor in (kg, w, u, cumulative_gate))
+    )
+    actual_reverse = build_state_grad_summary(
+        *(int64_stride_copy(tensor) for tensor in (qg, kg, w, dout, aqk, cumulative_gate)),
+        128**-0.5,
+    )
+
+    torch.testing.assert_close(actual_forward, expected_forward, rtol=0, atol=0)
+    torch.testing.assert_close(actual_reverse, expected_reverse, rtol=0, atol=0)
+
+
+def test_affine_summaries_accept_misaligned_contiguous_storage():
+    """Normalize ordinary storage-offset views before constructing TMA descriptors."""
+    torch.manual_seed(21)
+    shape = (1, 64, 1, 128)
+    qg = torch.randn(shape, dtype=torch.bfloat16, device="cuda") / 32
+    kg = torch.randn_like(qg) / 32
+    w = torch.randn_like(qg) / 32
+    u = torch.randn_like(qg) / 32
+    dout = torch.randn_like(qg) / 32
+    aqk = torch.randn(1, 64, 1, 64, dtype=torch.bfloat16, device="cuda") / 32
+    cumulative_gate = -torch.rand(shape, dtype=torch.float32, device="cuda") / 8
+
+    expected_forward = build_state_summary(kg, w, u, cumulative_gate)
+    expected_reverse = build_state_grad_summary(
+        qg,
+        kg,
+        w,
+        dout,
+        aqk,
+        cumulative_gate,
+        128**-0.5,
+    )
+    actual_forward = build_state_summary(
+        *(misaligned_copy(tensor) for tensor in (kg, w, u, cumulative_gate))
+    )
+    actual_reverse = build_state_grad_summary(
+        *(misaligned_copy(tensor) for tensor in (qg, kg, w, dout, aqk, cumulative_gate)),
+        128**-0.5,
+    )
+
+    torch.testing.assert_close(actual_forward, expected_forward, rtol=0, atol=0)
+    torch.testing.assert_close(actual_reverse, expected_reverse, rtol=0, atol=0)
 
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])


### PR DESCRIPTION
## Summary

- add int64-stride specializations for the forward and reverse KDA state-summary kernels
- select the address width from all ABI-visible input and output tensors
- normalize uncommon contiguous storage-offset views that do not satisfy TMA alignment
- include address width in the compiled artifact/cache identity
- add regressions for both int64-sized strides and misaligned contiguous inputs

At realistic long-context shapes the otherwise-unused B=1 stride can exceed signed int32. For example, a local `[1, 524288, 32, 128]` tensor has stride 2^31, so the summary kernels previously rejected a two-rank million-token workload even though the surrounding KDA kernels support int64 addressing.

Likewise, PyTorch considers a storage-offset view contiguous even when its base pointer is not 16-byte aligned. The public wrapper now materializes only that uncommon case before constructing TMA descriptors.

## Validation

- `gpu-run auto -- .venv/bin/pytest -q test/test_delta_affine_summary.py` — 17 passed
- real `[1, 524288, 32, 128]` BF16 tensors (stride 2^31), forward and reverse summaries — passed exactly for the zero/identity case
- aligned and deliberately misaligned inputs produce bitwise-identical summaries
- `prek run --all-files`
