### PR TITLE
Initialize empty fresh paged KDA states

### DIFF
--- a/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
@@ -94,8 +94,6 @@ def _run_chunk_delta_h_sequence(
     o_v = i_v * BV + tl.arange(0, BV)
 
     if USE_STATE_INDICES:
-        if T == 0:
-            return
         i_state = tl.load(state_indices + i_n).to(tl.int64)
         if i_state <= 0:
             for i_t in tl.range(0, NT):

--- a/test/test_kda_cute_forward.py
+++ b/test/test_kda_cute_forward.py
@@ -510,6 +510,35 @@ def test_paged_chunk_kda_ignores_padding_slots():
     torch.testing.assert_close(storage[0], before[0], rtol=0, atol=0)
 
 
+def test_paged_chunk_kda_initializes_empty_new_slots():
+    """An empty fresh sequence still clears the newly assigned cache slot."""
+    torch.manual_seed(46)
+    inputs = tuple(tensor.detach() for tensor in _inputs(tokens=128, heads=2))
+    q, k, v, cumulative_gate, beta = inputs
+    cu_seqlens = torch.tensor([0, 0, 128, 128], device="cuda", dtype=torch.int32)
+    slots = torch.tensor([4, 2, 3], device="cuda", dtype=torch.int32)
+    has_initial_state = torch.tensor([False, False, True], device="cuda")
+    storage, pool = strided_state_pool(5, q.shape[2], 128, 128, prefix=0)
+    before = storage.clone()
+
+    paged_chunk_kda(
+        q,
+        k,
+        v,
+        cumulative_gate,
+        beta,
+        pool,
+        slots,
+        cu_seqlens=cu_seqlens,
+        has_initial_state=has_initial_state,
+    )
+
+    state_elements = pool[0].numel()
+    before_pool = before[:, :state_elements].view_as(pool)
+    torch.testing.assert_close(pool[4], torch.zeros_like(pool[4]), rtol=0, atol=0)
+    torch.testing.assert_close(pool[3], before_pool[3], rtol=0, atol=0)
+
+
 def test_paged_chunk_kda_zero_initializes_new_slots():
     torch.manual_seed(47)
     inputs = tuple(tensor.detach() for tensor in _inputs(tokens=128, heads=2))


### PR DESCRIPTION
## Summary

- initialize newly assigned paged KDA cache slots even when their packed sequence is empty
- preserve empty resumed slots and non-positive padding routes
- align `paged_chunk_kda` with the existing paged `recurrent_kda` behavior and documented `has_initial_state=False` contract

The inter-chunk recurrence already launches one CTA per logical sequence. Its paged path returned before applying the existing initial-state mask for zero-token sequences, leaving stale slot contents untouched. Removing that early return lets the normal masked load and final store write zero for fresh slots and preserve resumed slots.

Found by the public-interface fuzz campaign with a realistic empty packed request and a newly assigned serving-cache slot.

## Validation

- deterministic standalone repro: paged chunk and recurrent paths now both zero the empty fresh slot
- 8 targeted paged chunk/recurrent tests covering strided pools, padding routes, fresh slots, fullgraph compile, and CUDA Graph replay
- `prek run --all-files`

All GPU commands ran through `gpu-run`.
