### PR TITLE
Reject unsupported KDA summary export

### DIFF
--- a/attn_gym/linear/_delta_rule/cute/affine_summary_fwd.py
+++ b/attn_gym/linear/_delta_rule/cute/affine_summary_fwd.py
@@ -1006,6 +1006,7 @@ def _compile_affine_summary(
     )
 
 
+@torch.compiler.disable
 def build_state_summary(
     kg: torch.Tensor,
     w: torch.Tensor,
@@ -1055,7 +1056,10 @@ def build_state_summary(
         device=kg.device,
     )
     if isinstance(kg, FakeTensor):
-        return out
+        raise TypeError(
+            "build_state_summary does not support torch.export; run the context-parallel "
+            "summary eagerly or under CUDA Graph capture"
+        )
 
     assert kg.is_cuda, "build_state_summary requires CUDA tensors"
     for name, tensor in (("kg", kg), ("w", w), ("u", u), ("cumulative_gate", cumulative_gate)):

--- a/attn_gym/linear/_delta_rule/cute/affine_summary_rev.py
+++ b/attn_gym/linear/_delta_rule/cute/affine_summary_rev.py
@@ -1314,6 +1314,7 @@ def _compile_affine_summary_rev(
     )
 
 
+@torch.compiler.disable
 def build_state_grad_summary(
     qg: torch.Tensor,
     kg: torch.Tensor,
@@ -1372,7 +1373,10 @@ def build_state_grad_summary(
         device=qg.device,
     )
     if isinstance(qg, FakeTensor):
-        return out
+        raise TypeError(
+            "build_state_grad_summary does not support torch.export; run the context-parallel "
+            "summary eagerly or under CUDA Graph capture"
+        )
 
     assert qg.is_cuda, "build_state_grad_summary requires CUDA tensors"
     inputs = (

--- a/test/test_delta_affine_summary.py
+++ b/test/test_delta_affine_summary.py
@@ -257,6 +257,35 @@ def test_affine_summary_selector_variants_and_persistent_work():
     )
 
 
+def test_affine_summaries_reject_torch_export_instead_of_emitting_empty_outputs():
+    """Fail capture explicitly until the launchers become registered graph operators."""
+
+    class ForwardSummary(torch.nn.Module):
+        def forward(self, kg, w, u, cumulative_gate):
+            return build_state_summary(kg, w, u, cumulative_gate)
+
+    class ReverseSummary(torch.nn.Module):
+        def forward(self, qg, kg, w, dout, aqk, cumulative_gate):
+            return build_state_grad_summary(
+                qg,
+                kg,
+                w,
+                dout,
+                aqk,
+                cumulative_gate,
+                128**-0.5,
+            )
+
+    shape = (1, 64, 1, 128)
+    x = torch.zeros(shape, dtype=torch.bfloat16, device="cuda")
+    gate = torch.zeros(shape, dtype=torch.float32, device="cuda")
+    aqk = torch.zeros(1, 64, 1, 64, dtype=torch.bfloat16, device="cuda")
+    with pytest.raises(TypeError, match="build_state_summary does not support torch.export"):
+        torch.export.export(ForwardSummary(), (x, x, x, gate), strict=False)
+    with pytest.raises(TypeError, match="build_state_grad_summary does not support torch.export"):
+        torch.export.export(ReverseSummary(), (x, x, x, x, aqk, gate), strict=False)
+
+
 def test_build_state_summary_cuda_graph_replay():
     torch.manual_seed(29)
     shape = (1, 128, 2, 128)


### PR DESCRIPTION
## Summary

- mark the Python CuTeDSL summary launchers as Dynamo-disabled eager boundaries
- reject FakeTensor tracing explicitly until summaries are registered graph operators
- add regressions proving non-strict `torch.export` fails rather than emitting an uninitialized `aten.empty`

Before this change, exporting either summary silently replaced the kernel with an empty allocation. The resulting exported program ran successfully but differed from eager by up to O(1). Ordinary `torch.compile` still graph-breaks and executes the eager launcher correctly; CUDA Graph capture remains supported.

Found by the realistic public-interface fuzz campaign.

## Validation

- `gpu-run auto -- .venv/bin/pytest -q test/test_delta_affine_summary.py` — 16 passed
- ordinary `torch.compile(build_state_summary)` graph-break/eager execution — bitwise match
- forward and reverse CUDA Graph replay tests — passed
- `prek run --all-files`
