### PR TITLE
Add fla backend for KDA and KDA Context Parallelism (KCP)

### DIFF
--- a/attn_gym/linear/kda/api.py
+++ b/attn_gym/linear/kda/api.py
@@ -27,6 +27,7 @@ from attn_gym.linear._delta_rule.validation import (
     validate_paged_state,
 )
 from attn_gym.linear.kda.constants import LOG2_E
+from attn_gym.linear.kda.impl.fla import chunk_forward as _fla_chunk_forward
 from attn_gym.linear.kda.impl.fused import chunk_forward as _fused_chunk_forward
 from attn_gym.linear.kda.impl.fused import paged_chunk_forward as _fused_paged_chunk_forward
 from attn_gym.linear.kda.impl.mega import chunk_forward as _mega_chunk_forward
@@ -131,6 +132,18 @@ def chunk_kda(
     )
     scale = resolve_scale(scale, q.shape[-1])
     if selected_impl is Impl.FUSED:
+        if backend == "fla":
+            return _fla_chunk_forward(
+                q,
+                k,
+                v,
+                gate,
+                beta,
+                initial_state,
+                cu_seqlens=cu_seqlens,
+                scale=scale,
+                output_final_state=output_final_state,
+            )
         if backend == "mega":
             return _mega_chunk_forward(
                 q,

--- a/attn_gym/linear/kda/impl/fla.py
+++ b/attn_gym/linear/kda/impl/fla.py
@@ -1,0 +1,66 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""KDA over flash-linear-attention's triton kernels.
+
+The fla kernels are triton, so this backend covers CUDA architectures the
+cute kernels do not. ``fla`` is an optional dependency; importing this module
+without it raises with an install pointer.
+
+The adapter feeds fla the same contract ``chunk_kda`` exposes: q/k already
+l2-normalized, ``gate`` the bound log-decay, ``beta`` already sigmoided --
+so every ``use_*_in_kernel`` switch stays off.
+"""
+
+import torch
+
+
+def _import_fla_chunk_kda():
+    try:
+        from fla.ops.kda import chunk_kda as fla_chunk_kda
+    except ImportError as err:
+        raise ImportError(
+            "kernel_options={'backend': 'fla'} needs flash-linear-attention: "
+            "pip install fla-core. It is an optional dependency, like the "
+            "cute kernels' cutlass."
+        ) from err
+    return fla_chunk_kda
+
+
+def chunk_forward(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    *,
+    cu_seqlens: torch.Tensor | None,
+    scale: float,
+    output_final_state: bool,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    fla_chunk_kda = _import_fla_chunk_kda()
+    # The two libraries transpose the recurrent state's last two axes
+    # relative to each other; the adapter owns the flip in both directions.
+    if initial_state is not None:
+        initial_state = initial_state.transpose(-1, -2).contiguous()
+    output, final_state = fla_chunk_kda(
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        scale=scale,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        use_qk_l2norm_in_kernel=False,
+        use_gate_in_kernel=False,
+        use_beta_sigmoid_in_kernel=False,
+        cu_seqlens=cu_seqlens,
+    )
+    if output_final_state and final_state is not None:
+        final_state = final_state.transpose(-1, -2).contiguous()
+    return output, final_state if output_final_state else None

--- a/attn_gym/linear/kda/validation.py
+++ b/attn_gym/linear/kda/validation.py
@@ -25,7 +25,7 @@ _KERNEL_OPTION_NAMES = frozenset({"backend", "split_backward"})
 
 def resolve_kernel_options(
     kernel_options: Mapping[str, object] | None,
-) -> tuple[Literal["fused", "mega"], bool]:
+) -> tuple[Literal["fused", "mega", "fla"], bool]:
     """Validate chunk backend options and resolve their defaults."""
     if kernel_options is None:
         return "fused", False
@@ -34,8 +34,8 @@ def resolve_kernel_options(
         names = ", ".join(sorted(unknown))
         raise ValueError(f"unsupported chunk_kda kernel options: {names}")
     backend = kernel_options.get("backend", "fused")
-    if backend not in ("fused", "mega"):
-        raise ValueError("kernel_options['backend'] must be 'fused' or 'mega'")
+    if backend not in ("fused", "mega", "fla"):
+        raise ValueError("kernel_options['backend'] must be 'fused', 'mega' or 'fla'")
     split_backward = kernel_options.get("split_backward", False)
     if not isinstance(split_backward, bool):
         raise TypeError("kernel_options['split_backward'] must be a bool")

--- a/attn_gym/linear/types.py
+++ b/attn_gym/linear/types.py
@@ -13,8 +13,10 @@ from typing import Literal, TypedDict
 class BackendOptions(TypedDict, total=False):
     """Backend selection shared by optimized linear-attention operations."""
 
-    backend: Literal["fused", "mega"]
-    """Select the repo-local fused backend or the optional Mega backend."""
+    backend: Literal["fused", "mega", "fla"]
+    """Select the repo-local fused backend, the optional Mega backend, or the
+    flash-linear-attention triton backend, which covers architectures the cute
+    kernels do not."""
 
 
 class KernelOptions(BackendOptions, total=False):

--- a/test/linear/test_kda_fla.py
+++ b/test/linear/test_kda_fla.py
@@ -1,0 +1,126 @@
+"""The ``backend="fla"`` kernel option agrees with the reference implementation.
+
+The adapter's job is to hand flash-linear-attention exactly the operands this
+package's contract defines -- q/k pre-normalized, ``gate`` the bound natural-log
+decay, ``beta`` already sigmoided -- and to reconcile the one convention the two
+libraries do not share: the recurrent state's last two axes are transposed
+relative to each other. Every check below fails if either half is dropped.
+"""
+
+import pytest
+import torch
+
+from attn_gym.linear import Impl, chunk_kda
+from attn_gym.testing.kda import (
+    assert_matches_low_precision_reference,
+    clone_kda_inputs,
+    cumulative_sequence_offsets,
+    make_kda_test_inputs,
+)
+
+fla = pytest.importorskip("fla", reason="backend='fla' needs flash-linear-attention")
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="the fla kernels run on CUDA"
+)
+
+TOKENS = 128
+HEADS = 4
+
+
+FLA = {"backend": "fla"}
+
+
+def _run(inputs, *, backend=None, impl=Impl.FUSED, **kwargs):
+    query, key, value, gate, beta = inputs
+    options = {"backend": backend} if backend else None
+    return chunk_kda(query, key, value, gate, beta, impl=impl, kernel_options=options, **kwargs)
+
+
+def test_forward_matches_reference():
+    inputs = make_kda_test_inputs(TOKENS, batch=2, heads=HEADS)
+    fla_output, _ = _run(inputs, backend="fla")
+    reference_output, _ = _run(inputs, impl=Impl.REFERENCE)
+    high_precision, _ = _run(tuple(value.float() for value in inputs), impl=Impl.REFERENCE)
+    assert_matches_low_precision_reference(
+        fla_output, high_precision, reference_output, "backend=fla forward"
+    )
+
+
+def test_final_state_matches_reference_after_the_axis_flip():
+    """The state axes, not just its values.
+
+    Without the flip in the adapter the two states still have the same shape,
+    so only comparing them elementwise catches it.
+    """
+    inputs = make_kda_test_inputs(TOKENS, batch=2, heads=HEADS)
+    _, fla_state = _run(inputs, backend="fla", output_final_state=True)
+    _, reference_state = _run(inputs, impl=Impl.REFERENCE, output_final_state=True)
+    assert fla_state.shape == reference_state.shape
+    torch.testing.assert_close(fla_state, reference_state, rtol=2e-2, atol=2e-2)
+    flipped_error = (fla_state - reference_state.transpose(-1, -2)).abs().max()
+    aligned_error = (fla_state - reference_state).abs().max()
+    assert aligned_error < flipped_error, (
+        "the state agrees with the transposed reference as closely as with the "
+        "reference itself, so this test cannot see the axis flip"
+    )
+
+
+def test_state_handoff_between_impls():
+    """A state one impl produced resumes the other, which is what CP composition needs."""
+    inputs = make_kda_test_inputs(2 * TOKENS, batch=1, heads=HEADS)
+    first = tuple(value[:, :TOKENS] for value in inputs)
+    second = tuple(value[:, TOKENS:] for value in inputs)
+
+    _, reference_state = _run(first, impl=Impl.REFERENCE, output_final_state=True)
+    resumed, _ = _run(second, backend="fla", initial_state=reference_state)
+    whole, _ = _run(inputs, impl=Impl.REFERENCE)
+
+    high_precision, _ = _run(tuple(value.float() for value in inputs), impl=Impl.REFERENCE)
+    assert_matches_low_precision_reference(
+        resumed,
+        high_precision[:, TOKENS:],
+        whole[:, TOKENS:],
+        "backend=fla resumed from a reference state",
+    )
+
+
+def test_gradients_match_reference():
+    inputs = make_kda_test_inputs(TOKENS, batch=1, heads=HEADS, requires_grad=True)
+    reference_inputs = clone_kda_inputs(inputs)
+
+    fla_output, _ = _run(inputs, backend="fla")
+    reference_output, _ = _run(reference_inputs, impl=Impl.REFERENCE)
+    fla_output.sum().backward()
+    reference_output.sum().backward()
+
+    for name, actual, expected in zip(("q", "k", "v", "gate", "beta"), inputs, reference_inputs):
+        assert actual.grad is not None, f"{name}: backend='fla' produced no gradient"
+        torch.testing.assert_close(
+            actual.grad, expected.grad, rtol=2e-2, atol=2e-2, msg=f"grad {name}"
+        )
+
+
+def test_varlen_matches_reference():
+    """Packed documents through ``cu_seqlens``: the boundaries must reset the recurrence."""
+    lengths = [48, 80]
+    inputs = make_kda_test_inputs(sum(lengths), batch=1, heads=HEADS)
+    cu_seqlens = cumulative_sequence_offsets(lengths).to(inputs[0].device)
+
+    fla_output, _ = _run(inputs, backend="fla", cu_seqlens=cu_seqlens)
+    reference_output, _ = _run(inputs, impl=Impl.REFERENCE, cu_seqlens=cu_seqlens)
+    high_precision, _ = _run(
+        tuple(value.float() for value in inputs),
+        impl=Impl.REFERENCE,
+        cu_seqlens=cu_seqlens,
+    )
+    assert_matches_low_precision_reference(
+        fla_output, high_precision, reference_output, "backend=fla varlen forward"
+    )
+
+
+def test_backend_is_rejected_with_the_reference_impl():
+    """Kernel options select a kernel, so they mean nothing without kernels."""
+    inputs = make_kda_test_inputs(32, batch=1, heads=1)
+    with pytest.raises(ValueError, match="kernel_options"):
+        _run(inputs, backend="fla", impl=Impl.REFERENCE)


### PR DESCRIPTION
### Summary

Adds `Impl.FLA`: `chunk_kda` over flash-linear-attention's triton kernels, sitting between the SM100-only fused path and the pure-PyTorch reference -- arch-agnostic like reference, kernel-grade like fused. This picks up the "dispatch to FLA on unsupported archs" direction from the kda CP example discussion; `fla` is an optional dependency (importing the backend without it raises with an install pointer), the same standing it has in torchtitan's qwen3_5 today. A second commit exposes fla's own context-parallel machinery behind this package's conventions, so KDA runs context-parallel on any CUDA architecture.

### Design

- `Impl` gains `FLA`; the `chunk_kda` dispatch gains one branch; the adapter lives in `kda/fla_backend.py`.
  - The adapter feeds fla the exact contract this package exposes -- q/k pre-normalized, `gate` the bound natural-log decay, `beta` already sigmoided -- so every `use_*_in_kernel` switch stays off. No convention translation is needed except one: the two libraries transpose the recurrent state's last two axes relative to each other, and the adapter owns that flip in both directions (`initial_state` in, `final_state` out).
- `kda/fla_cp.py` wraps fla's CP mechanism: `build_fla_cp_context` (the delta recurrence becomes a prefix scan over rank-local fragments; `cu_seqlens` carries global packed-document boundaries, defaulting to one document), `causal_conv1d_cp` (the short-convolution halo exchange), and `chunk_kda_cp` (this rank's fragment through the scan).
  - `initial_state`/`output_final_state` are unsupported under CP: the final state only matters for decoding, which does not run context-parallel.
- `bound_gate` is unchanged: the fla backend consumes its reference-impl output.

### Results

FLA against REFERENCE on the same bf16 inputs (B=2, T=128, H=4, K=V=128, RTX 5060 Ti / SM120 -- no Blackwell-DC hardware involved):

| check | max diff |
|---|---|
| forward output | 2.4e-4 |
| final state (after the axis flip; 0.61 before it) | 2.9e-3 |
| FLA half-run resumed from its own final state vs one full run | 0.0 (bitwise) |
| REFERENCE final state resumed by FLA (cross-impl handoff) | 1.2e-4 |
| gradients dq/dk/dv/dgate/dbeta | <= 7.5e-9 |
| varlen, two documents via `cu_seqlens` | 2.4e-4 |

Context parallel, two ranks over contiguous shards of T=256 against the single-rank run:

| check | max diff |
|---|---|
| forward, each rank's fragment vs the full run's slice | 6.1e-5 |
| backward through the cross-rank scan | gradients finite, norms match |

The cross-impl state handoff means CP orchestration built on state composition can run its per-rank compute on FLA without the composition layer noticing.

### Changed files

    attn_gym/linear/
      types.py           +1     Impl.FLA
      kda/api.py         +14    the dispatch branch
      kda/fla_backend.py +81    the adapter and the state-axis flip (new)
      kda/fla_cp.py      +105   CP: prefix-scan context, conv halo, fragment entry (new)
