### PR TITLE
Add fused chunk GDN training backend

### DIFF
--- a/attn_gym/linear/gdn/api.py
+++ b/attn_gym/linear/gdn/api.py
@@ -11,6 +11,7 @@ from attn_gym.linear._delta_rule.validation import (
     validate_paged_state,
 )
 from attn_gym.linear.gdn.impl.reference import chunk_forward, recurrent_forward, reference_gdn
+from attn_gym.linear.gdn.ops import chunk_forward as fused_chunk_forward
 from attn_gym.linear.gdn.ops import recurrent_decode_forward
 from attn_gym.linear.gdn.ops import recurrent_forward as fused_recurrent_forward
 from attn_gym.linear.gdn.validation import validate_gdn_inputs
@@ -52,18 +53,30 @@ def chunk_gdn(
             unspecified.
         scale: Query scale. Defaults to ``1 / sqrt(K)``.
         output_final_state: Return the final recurrent state with the output.
-        impl: ``"reference"`` uses eager PyTorch. ``"fused"`` is reserved for the optimized
-            backend and currently raises ``NotImplementedError``.
+        impl: ``"reference"`` uses eager PyTorch. ``"fused"`` uses the training-capable
+            scalar-gate pipeline on SM100/SM103 with matching FP16/BF16 QKV and ``K = V = 128``.
+            It supports dense, packed, tail, empty-sequence, grouped-head, and stateful autograd
+            without imposing a lower bound on finite nonpositive gate values.
 
     Returns:
         The output in ``q.dtype`` and either the final recurrent state or ``None``.
     """
     selected_impl = resolve_impl(impl)
     validate_gdn_inputs(q, k, v, gate, beta, initial_state, cu_seqlens)
+    scale = resolve_scale(scale, q.shape[-1])
     if selected_impl is Impl.FUSED:
-        raise NotImplementedError("chunk_gdn impl='fused' is not implemented yet")
+        return fused_chunk_forward(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            initial_state,
+            cu_seqlens=cu_seqlens,
+            scale=scale,
+            output_final_state=output_final_state,
+        )
 
-    scale = q.shape[-1] ** -0.5 if scale is None else scale
     return reference_gdn(
         chunk_forward,
         q,

--- a/attn_gym/linear/gdn/bwd/__init__.py
+++ b/attn_gym/linear/gdn/bwd/__init__.py
@@ -1,0 +1,1 @@
+"""Fused chunk GDN backward kernels."""

--- a/attn_gym/linear/gdn/bwd/triton/__init__.py
+++ b/attn_gym/linear/gdn/bwd/triton/__init__.py
@@ -1,0 +1,1 @@
+"""Triton fused chunk GDN backward kernels."""

--- a/attn_gym/linear/gdn/bwd/triton/chunk_gdn_bwd_intra.py
+++ b/attn_gym/linear/gdn/bwd/triton/chunk_gdn_bwd_intra.py
@@ -1,0 +1,226 @@
+"""Numerically safe scalar-GDN intra-factor VJP."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from attn_gym.linear.kda.chunk_scheduler import (
+    RaggedChunkMetadata,
+    load_ragged_chunk_count,
+    load_ragged_chunk_work,
+)
+
+
+@triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
+@triton.jit(do_not_specialize=["T", "num_sequences"])
+def chunk_gdn_bwd_intra_kernel(
+    q,
+    k,
+    cumulative_gate,
+    beta,
+    d_aqk,
+    d_akk,
+    d_gate_raw,
+    d_q,
+    d_k,
+    d_beta,
+    d_gate,
+    cu_seqlens,
+    chunk_offsets,
+    T,
+    num_sequences,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    """Differentiate scalar-decayed QK/KK factors for one chunk and head."""
+    chunk = tl.program_id(0)
+    head = tl.program_id(1)
+    row = tl.arange(0, BT)
+    column = tl.arange(0, BT)
+    if IS_VARLEN:
+        if chunk >= load_ragged_chunk_count(chunk_offsets, num_sequences):
+            return
+        _sequence, _local_chunk, token_start, valid_tokens = load_ragged_chunk_work(
+            cu_seqlens, chunk_offsets, chunk, num_sequences, BT
+        )
+        token = token_start + row
+        token_mask = row < valid_tokens
+    else:
+        token = chunk * BT + row
+        token_mask = row < BT
+        valid_tokens = BT
+
+    gate = tl.load(cumulative_gate + token * H + head, mask=token_mask, other=0.0).to(tl.float32)
+    gate_delta = gate[:, None] - gate[None, :]
+    causal = (
+        (row[:, None] >= column[None, :])
+        & (row[:, None] < valid_tokens)
+        & (column[None, :] < valid_tokens)
+    )
+    strict = causal & (row[:, None] > column[None, :])
+    decay = tl.where(causal, tl.exp2(tl.where(causal, gate_delta, 0.0)), 0.0)
+
+    matrix_offset = token[:, None] * (H * BT) + head * BT + column[None, :]
+    d_aqk_tile = tl.load(d_aqk + matrix_offset, mask=token_mask[:, None], other=0.0).to(tl.float32)
+    d_aqk_tile = tl.where(causal, d_aqk_tile, 0.0)
+    d_akk_tile = tl.load(d_akk + matrix_offset, mask=token_mask[:, None], other=0.0).to(tl.float32)
+    d_akk_tile = tl.where(strict, d_akk_tile, 0.0)
+    beta_row = tl.load(beta + token * H + head, mask=token_mask, other=0.0).to(tl.float32)
+    aq_weight = d_aqk_tile * decay
+    kk_weight = d_akk_tile * decay * beta_row[:, None]
+
+    raw_qk = tl.zeros((BT, BT), dtype=tl.float32)
+    raw_kk = tl.zeros((BT, BT), dtype=tl.float32)
+    raw_gate_grad = tl.zeros((BT,), dtype=tl.float32)
+    for key_block in range(0, K, BK):
+        feature = key_block + tl.arange(0, BK)
+        q_tile = tl.load(
+            q + token[:, None] * (H * K) + head * K + feature[None, :],
+            mask=token_mask[:, None],
+            other=0.0,
+        )
+        k_tile = tl.load(
+            k + token[:, None] * (H * K) + head * K + feature[None, :],
+            mask=token_mask[:, None],
+            other=0.0,
+        )
+        raw_qk += tl.dot(q_tile, tl.trans(k_tile))
+        raw_kk += tl.dot(k_tile, tl.trans(k_tile))
+        gate_tile = tl.load(
+            d_gate_raw + token[:, None] * (H * K) + head * K + feature[None, :],
+            mask=token_mask[:, None],
+            other=0.0,
+        )
+        raw_gate_grad += tl.sum(gate_tile, axis=1)
+
+        d_q_tile = tl.dot(aq_weight.to(q_tile.dtype), k_tile)
+        d_k_tile = tl.dot(tl.trans(aq_weight).to(q_tile.dtype), q_tile)
+        d_k_tile += tl.dot(kk_weight.to(q_tile.dtype), k_tile)
+        d_k_tile += tl.dot(tl.trans(kk_weight).to(q_tile.dtype), k_tile)
+        output_offset = token[:, None] * (H * K) + head * K + feature[None, :]
+        tl.store(d_q + output_offset, d_q_tile.to(d_q.dtype.element_ty), mask=token_mask[:, None])
+        tl.store(d_k + output_offset, d_k_tile.to(d_k.dtype.element_ty), mask=token_mask[:, None])
+
+    d_beta_row = tl.sum(d_akk_tile * decay * raw_kk, axis=1)
+    gate_term = aq_weight * raw_qk + kk_weight * raw_kk
+    # Both sources are ln2-free natural-exponent contributions, so this reverse
+    # cumsum directly returns the gradient of the per-token natural-log gate.
+    d_gate_row = tl.cumsum(
+        raw_gate_grad + tl.sum(gate_term, axis=1) - tl.sum(gate_term, axis=0),
+        axis=0,
+        reverse=True,
+    )
+    tl.store(d_beta + token * H + head, d_beta_row, mask=token_mask)
+    tl.store(d_gate + token * H + head, d_gate_row, mask=token_mask)
+
+
+def chunk_gdn_bwd_intra_dense(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    d_aqk: torch.Tensor,
+    d_akk: torch.Tensor,
+    d_gate_raw: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Run dense B=1 BT64 scalar-GDN intra-factor gradients."""
+    batch, tokens, heads, key_dim = q.shape
+    if batch != 1 or tokens % 64 or key_dim != 128:
+        raise ValueError(
+            "dense fused chunk GDN backward requires B=1, complete BT64 chunks, and K=128"
+        )
+    if k.shape != q.shape or cumulative_gate.shape != q.shape[:3]:
+        raise ValueError("k must match q and cumulative_gate must have shape [B,T,H]")
+    expected_factor_shape = (batch, tokens, heads, 64)
+    if d_aqk.shape != expected_factor_shape or d_akk.shape != expected_factor_shape:
+        raise ValueError(f"factor gradients must have shape {expected_factor_shape}")
+    if d_gate_raw.shape != q.shape:
+        raise ValueError("d_gate_raw must match expanded q")
+
+    d_q = torch.empty_like(q, dtype=torch.float32)
+    d_k = torch.empty_like(k, dtype=torch.float32)
+    d_beta = torch.empty_like(beta, dtype=torch.float32)
+    d_gate = torch.empty_like(cumulative_gate, dtype=torch.float32)
+    chunk_gdn_bwd_intra_kernel[(tokens // 64, heads)](
+        q,
+        k,
+        cumulative_gate,
+        beta,
+        d_aqk,
+        d_akk,
+        d_gate_raw,
+        d_q,
+        d_k,
+        d_beta,
+        d_gate,
+        None,
+        None,
+        tokens,
+        0,
+        H=heads,
+        K=key_dim,
+        BT=64,
+        BK=64,
+        num_warps=4,
+        num_stages=2,
+    )
+    return d_q, d_k, d_beta, d_gate
+
+
+def chunk_gdn_bwd_intra_packed(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    d_aqk: torch.Tensor,
+    d_akk: torch.Tensor,
+    d_gate_raw: torch.Tensor,
+    metadata: RaggedChunkMetadata,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Run fixed-capacity packed scalar-GDN intra-factor gradients."""
+    metadata.validate_chunk_size(64)
+    batch, tokens, heads, key_dim = q.shape
+    if batch != 1 or key_dim != 128 or k.shape != q.shape:
+        raise ValueError("packed fused chunk GDN backward requires B=1 and K=128")
+    expected_factor_shape = (batch, tokens, heads, 64)
+    if d_aqk.shape != expected_factor_shape or d_akk.shape != expected_factor_shape:
+        raise ValueError(f"factor gradients must have shape {expected_factor_shape}")
+    if d_gate_raw.shape != q.shape:
+        raise ValueError("d_gate_raw must match expanded q")
+
+    d_q = torch.zeros_like(q, dtype=torch.float32)
+    d_k = torch.zeros_like(k, dtype=torch.float32)
+    d_beta = torch.zeros_like(beta, dtype=torch.float32)
+    d_gate = torch.zeros_like(cumulative_gate, dtype=torch.float32)
+    chunk_gdn_bwd_intra_kernel[(metadata.capacity, heads)](
+        q,
+        k,
+        cumulative_gate,
+        beta,
+        d_aqk,
+        d_akk,
+        d_gate_raw,
+        d_q,
+        d_k,
+        d_beta,
+        d_gate,
+        metadata.cu_seqlens,
+        metadata.chunk_offsets,
+        tokens,
+        metadata.cu_seqlens.shape[0] - 1,
+        H=heads,
+        K=key_dim,
+        BT=64,
+        BK=64,
+        num_warps=4,
+        num_stages=2,
+    )
+    return d_q, d_k, d_beta, d_gate
+
+
+__all__ = ["chunk_gdn_bwd_intra_dense", "chunk_gdn_bwd_intra_packed"]

--- a/attn_gym/linear/gdn/bwd/triton/chunk_gdn_bwd_recompute.py
+++ b/attn_gym/linear/gdn/bwd/triton/chunk_gdn_bwd_recompute.py
@@ -1,0 +1,147 @@
+"""Backward-only recomputation for scalar chunk GDN."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from attn_gym.linear.kda.chunk_scheduler import (
+    RaggedChunkMetadata,
+    load_ragged_chunk_count,
+    load_ragged_chunk_work,
+)
+
+
+@triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
+@triton.jit(do_not_specialize=["T", "num_sequences"])
+def chunk_gdn_recompute_aqk_kernel(
+    q,
+    k,
+    cumulative_gate,
+    aqk,
+    cu_seqlens,
+    chunk_offsets,
+    scale,
+    T,
+    num_sequences,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    """Recompute causal scalar-decayed QK without reciprocal gate factors."""
+    chunk = tl.program_id(0)
+    head = tl.program_id(1)
+    row = tl.arange(0, BT)
+    column = tl.arange(0, BT)
+    if IS_VARLEN:
+        if chunk >= load_ragged_chunk_count(chunk_offsets, num_sequences):
+            return
+        _sequence, _local_chunk, token_start, valid_tokens = load_ragged_chunk_work(
+            cu_seqlens, chunk_offsets, chunk, num_sequences, BT
+        )
+        token = token_start + row
+        token_mask = row < valid_tokens
+    else:
+        token = chunk * BT + row
+        token_mask = row < BT
+        valid_tokens = BT
+
+    qk = tl.zeros((BT, BT), dtype=tl.float32)
+    for key_block in range(0, K, BK):
+        feature = key_block + tl.arange(0, BK)
+        q_tile = tl.load(
+            q + token[:, None] * (H * K) + head * K + feature[None, :],
+            mask=token_mask[:, None],
+            other=0.0,
+        )
+        k_tile = tl.load(
+            k + token[:, None] * (H * K) + head * K + feature[None, :],
+            mask=token_mask[:, None],
+            other=0.0,
+        )
+        qk += tl.dot(q_tile, tl.trans(k_tile))
+
+    gate = tl.load(cumulative_gate + token * H + head, mask=token_mask, other=0.0).to(tl.float32)
+    gate_delta = gate[:, None] - gate[None, :]
+    causal = (
+        (row[:, None] >= column[None, :])
+        & (row[:, None] < valid_tokens)
+        & (column[None, :] < valid_tokens)
+    )
+    decay = tl.where(causal, tl.exp2(tl.where(causal, gate_delta, 0.0)), 0.0)
+    output_offset = token[:, None] * (H * BT) + head * BT + column[None, :]
+    tl.store(
+        aqk + output_offset,
+        tl.where(causal, qk * decay * scale, 0.0),
+        mask=token_mask[:, None],
+    )
+
+
+def chunk_gdn_recompute_aqk_dense(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    scale: float,
+) -> torch.Tensor:
+    """Run dense B=1 BT64 Aqk recomputation for the reused delta-H backward."""
+    batch, tokens, heads, key_dim = q.shape
+    if batch != 1 or tokens % 64 or key_dim != 128 or k.shape != q.shape:
+        raise ValueError("dense fused chunk GDN Aqk recompute requires B=1, BT64, and K=128")
+    aqk = torch.empty(batch, tokens, heads, 64, dtype=q.dtype, device=q.device)
+    chunk_gdn_recompute_aqk_kernel[(tokens // 64, heads)](
+        q,
+        k,
+        cumulative_gate,
+        aqk,
+        None,
+        None,
+        scale,
+        tokens,
+        0,
+        H=heads,
+        K=key_dim,
+        BT=64,
+        BK=32,
+        num_warps=8,
+        num_stages=2,
+    )
+    return aqk
+
+
+def chunk_gdn_recompute_aqk_packed(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    scale: float,
+    metadata: RaggedChunkMetadata,
+) -> torch.Tensor:
+    """Run fixed-capacity packed Aqk recomputation for reused delta-H backward."""
+    metadata.validate_chunk_size(64)
+    batch, tokens, heads, key_dim = q.shape
+    if batch != 1 or key_dim != 128 or k.shape != q.shape:
+        raise ValueError("packed fused chunk GDN Aqk recompute requires B=1 and K=128")
+    aqk = torch.zeros(batch, tokens, heads, 64, dtype=q.dtype, device=q.device)
+    chunk_gdn_recompute_aqk_kernel[(metadata.capacity, heads)](
+        q,
+        k,
+        cumulative_gate,
+        aqk,
+        metadata.cu_seqlens,
+        metadata.chunk_offsets,
+        scale,
+        tokens,
+        metadata.cu_seqlens.shape[0] - 1,
+        H=heads,
+        K=key_dim,
+        BT=64,
+        BK=32,
+        num_warps=8,
+        num_stages=2,
+    )
+    return aqk
+
+
+__all__ = ["chunk_gdn_recompute_aqk_dense", "chunk_gdn_recompute_aqk_packed"]

--- a/attn_gym/linear/gdn/fwd/__init__.py
+++ b/attn_gym/linear/gdn/fwd/__init__.py
@@ -1,0 +1,1 @@
+"""Fused chunk GDN forward kernels."""

--- a/attn_gym/linear/gdn/fwd/triton/__init__.py
+++ b/attn_gym/linear/gdn/fwd/triton/__init__.py
@@ -1,0 +1,1 @@
+"""Triton fused chunk GDN forward kernels."""

--- a/attn_gym/linear/gdn/fwd/triton/chunk_gdn_fwd_intra.py
+++ b/attn_gym/linear/gdn/fwd/triton/chunk_gdn_fwd_intra.py
@@ -1,0 +1,653 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+# Copyright (c) 2026 Meta Platforms, Inc. and affiliates.
+#
+# Portions are derived from flash-linear-attention and licensed under the MIT license;
+# see https://github.com/fla-org/flash-linear-attention/graphs/contributors.
+# The remaining portions use the BSD-style license in the repository root.
+
+"""Numerically safe scalar-GDN intra factors and W/U/kg production."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from attn_gym.linear.kda.chunk_scheduler import (
+    RaggedChunkMetadata,
+    load_ragged_chunk_count,
+    load_ragged_chunk_work,
+)
+from attn_gym.linear.kda.utils import autotune_cache_kwargs, exp2
+
+SOLVE_TRIL_DOT_PRECISION = tl.constexpr("tf32")
+
+
+@triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
+@triton.autotune(
+    configs=[
+        triton.Config({"BK": block_key}, num_warps=num_warps)
+        for block_key in (32, 64)
+        for num_warps in (1, 2, 4)
+    ],
+    key=["H", "HV", "K", "BC"],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["T", "num_sequences"])
+def chunk_gdn_fwd_kkt_solve_kernel(
+    k,
+    g,
+    beta,
+    A,
+    cu_seqlens,
+    chunk_offsets,
+    T,
+    num_sequences,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    """
+    Fused kernel: compute beta * K @ K^T (lower triangular) + solve_tril (I+A)^{-1} in one pass.
+
+    This kernel fuses chunk_scaled_dot_kkt_fwd and solve_tril into a single kernel,
+    avoiding the HBM round-trip for the intermediate A matrix.
+
+    Steps:
+    1. Compute all 10 lower-triangular [BC, BC] blocks of beta * K @ K^T in registers
+    2. Apply gate and beta scaling
+    3. Forward substitution on diagonal blocks
+    4. Block merge to get full (I+A)^{-1}
+    5. Write result to A (output)
+    """
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
+    i_b, i_h = i_bh // HV, i_bh % HV
+
+    if IS_VARLEN:
+        if i_t >= load_ragged_chunk_count(chunk_offsets, num_sequences):
+            return
+        i_n, i_t, token_start, _valid = load_ragged_chunk_work(
+            cu_seqlens, chunk_offsets, i_t, num_sequences, BT
+        )
+        bos = token_start - i_t * BT
+        eos = tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    if i_t * BT >= T:
+        return
+
+    i_tc0 = i_t * BT
+    i_tc1 = i_t * BT + BC
+    i_tc2 = i_t * BT + 2 * BC
+    i_tc3 = i_t * BT + 3 * BC
+
+    k += (bos * H + i_h // (HV // H)) * K
+    A += (bos * HV + i_h) * BT
+
+    o_i = tl.arange(0, BC)
+    m_tc0 = (i_tc0 + o_i) < T
+    m_tc1 = (i_tc1 + o_i) < T
+    m_tc2 = (i_tc2 + o_i) < T
+    m_tc3 = (i_tc3 + o_i) < T
+
+    # load beta for each sub-chunk
+    p_b0 = beta + bos * HV + i_h + (i_tc0 + o_i) * HV
+    p_b1 = beta + bos * HV + i_h + (i_tc1 + o_i) * HV
+    p_b2 = beta + bos * HV + i_h + (i_tc2 + o_i) * HV
+    p_b3 = beta + bos * HV + i_h + (i_tc3 + o_i) * HV
+    b_b0 = tl.load(p_b0, mask=m_tc0, other=0.0).to(tl.float32)
+    b_b1 = tl.load(p_b1, mask=m_tc1, other=0.0).to(tl.float32)
+    b_b2 = tl.load(p_b2, mask=m_tc2, other=0.0).to(tl.float32)
+    b_b3 = tl.load(p_b3, mask=m_tc3, other=0.0).to(tl.float32)
+
+    p_g0 = g + bos * HV + i_h + (i_tc0 + o_i) * HV
+    p_g1 = g + bos * HV + i_h + (i_tc1 + o_i) * HV
+    p_g2 = g + bos * HV + i_h + (i_tc2 + o_i) * HV
+    p_g3 = g + bos * HV + i_h + (i_tc3 + o_i) * HV
+    b_g0 = tl.load(p_g0, mask=m_tc0, other=0.0).to(tl.float32)
+    b_g1 = tl.load(p_g1, mask=m_tc1, other=0.0).to(tl.float32)
+    b_g2 = tl.load(p_g2, mask=m_tc2, other=0.0).to(tl.float32)
+    b_g3 = tl.load(p_g3, mask=m_tc3, other=0.0).to(tl.float32)
+
+    ############################################################################
+    # Step 1: compute all 10 lower-triangular [BC, BC] blocks of K @ K^T
+    ############################################################################
+
+    # 4 diagonal blocks
+    b_A00 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_A11 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_A22 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_A33 = tl.zeros([BC, BC], dtype=tl.float32)
+
+    # 6 off-diagonal blocks
+    b_A10 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_A20 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_A21 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_A30 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_A31 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_A32 = tl.zeros([BC, BC], dtype=tl.float32)
+
+    for i_k in range(tl.cdiv(K, BK)):
+        o_k = i_k * BK + tl.arange(0, BK)
+        p_k0 = k + (i_tc0 + o_i)[:, None] * (H * K) + o_k[None, :]
+        b_k0 = tl.load(p_k0, mask=m_tc0[:, None] & (o_k[None, :] < K), other=0.0)
+        # diagonal block 0
+        b_A00 += tl.dot(b_k0, tl.trans(b_k0))
+
+        if i_tc1 < T:
+            p_k1 = k + (i_tc1 + o_i)[:, None] * (H * K) + o_k[None, :]
+            b_k1 = tl.load(p_k1, mask=m_tc1[:, None] & (o_k[None, :] < K), other=0.0)
+            # diagonal block 1
+            b_A11 += tl.dot(b_k1, tl.trans(b_k1))
+            # off-diagonal (1,0)
+            b_A10 += tl.dot(b_k1, tl.trans(b_k0))
+
+            if i_tc2 < T:
+                p_k2 = k + (i_tc2 + o_i)[:, None] * (H * K) + o_k[None, :]
+                b_k2 = tl.load(p_k2, mask=m_tc2[:, None] & (o_k[None, :] < K), other=0.0)
+                # diagonal block 2
+                b_A22 += tl.dot(b_k2, tl.trans(b_k2))
+                # off-diagonal (2,0), (2,1)
+                b_A20 += tl.dot(b_k2, tl.trans(b_k0))
+                b_A21 += tl.dot(b_k2, tl.trans(b_k1))
+
+                if i_tc3 < T:
+                    p_k3 = k + (i_tc3 + o_i)[:, None] * (H * K) + o_k[None, :]
+                    b_k3 = tl.load(p_k3, mask=m_tc3[:, None] & (o_k[None, :] < K), other=0.0)
+                    # diagonal block 3
+                    b_A33 += tl.dot(b_k3, tl.trans(b_k3))
+                    # off-diagonal (3,0), (3,1), (3,2)
+                    b_A30 += tl.dot(b_k3, tl.trans(b_k0))
+                    b_A31 += tl.dot(b_k3, tl.trans(b_k1))
+                    b_A32 += tl.dot(b_k3, tl.trans(b_k2))
+
+    ############################################################################
+    # Step 2: apply gate and beta scaling
+    ############################################################################
+
+    # apply gate, beta scaling, and masking
+    # m_d: strictly lower triangular mask for diagonal blocks
+    # m_tc: boundary mask to prevent NaN from 0 * inf (IEEE 754) when
+    #   out-of-bounds g loads as 0 via boundary_check and exp2(0 - g_inbounds) overflows
+    m_d = o_i[:, None] > o_i[None, :]
+    m_I = o_i[:, None] == o_i[None, :]
+
+    mask00 = m_d & m_tc0[:, None] & m_tc0[None, :]
+    mask11 = m_d & m_tc1[:, None] & m_tc1[None, :]
+    mask22 = m_d & m_tc2[:, None] & m_tc2[None, :]
+    mask33 = m_d & m_tc3[:, None] & m_tc3[None, :]
+    mask10 = m_tc1[:, None] & m_tc0[None, :]
+    mask20 = m_tc2[:, None] & m_tc0[None, :]
+    mask21 = m_tc2[:, None] & m_tc1[None, :]
+    mask30 = m_tc3[:, None] & m_tc0[None, :]
+    mask31 = m_tc3[:, None] & m_tc1[None, :]
+    mask32 = m_tc3[:, None] & m_tc2[None, :]
+    b_A00 *= tl.where(mask00, exp2(tl.where(mask00, b_g0[:, None] - b_g0[None, :], 0.0)), 0.0)
+    b_A11 *= tl.where(mask11, exp2(tl.where(mask11, b_g1[:, None] - b_g1[None, :], 0.0)), 0.0)
+    b_A22 *= tl.where(mask22, exp2(tl.where(mask22, b_g2[:, None] - b_g2[None, :], 0.0)), 0.0)
+    b_A33 *= tl.where(mask33, exp2(tl.where(mask33, b_g3[:, None] - b_g3[None, :], 0.0)), 0.0)
+    b_A10 *= tl.where(mask10, exp2(tl.where(mask10, b_g1[:, None] - b_g0[None, :], 0.0)), 0.0)
+    b_A20 *= tl.where(mask20, exp2(tl.where(mask20, b_g2[:, None] - b_g0[None, :], 0.0)), 0.0)
+    b_A21 *= tl.where(mask21, exp2(tl.where(mask21, b_g2[:, None] - b_g1[None, :], 0.0)), 0.0)
+    b_A30 *= tl.where(mask30, exp2(tl.where(mask30, b_g3[:, None] - b_g0[None, :], 0.0)), 0.0)
+    b_A31 *= tl.where(mask31, exp2(tl.where(mask31, b_g3[:, None] - b_g1[None, :], 0.0)), 0.0)
+    b_A32 *= tl.where(mask32, exp2(tl.where(mask32, b_g3[:, None] - b_g2[None, :], 0.0)), 0.0)
+
+    # diagonal blocks: scaled by beta
+    b_A00 = b_A00 * b_b0[:, None]
+    b_A11 = b_A11 * b_b1[:, None]
+    b_A22 = b_A22 * b_b2[:, None]
+    b_A33 = b_A33 * b_b3[:, None]
+
+    # off-diagonal blocks: full block, scaled by beta
+    b_A10 = b_A10 * b_b1[:, None]
+    b_A20 = b_A20 * b_b2[:, None]
+    b_A21 = b_A21 * b_b2[:, None]
+    b_A30 = b_A30 * b_b3[:, None]
+    b_A31 = b_A31 * b_b3[:, None]
+    b_A32 = b_A32 * b_b3[:, None]
+
+    ############################################################################
+    # Step 3: forward substitution on diagonal blocks -> (I + A_diag)^{-1}
+    #
+    # Same algorithm as solve_tril, but rows are extracted from in-register
+    # [BC, BC] tensor via tl.sum(tl.where(mask, tensor, 0), 0) instead of
+    # tl.load from HBM.
+    ############################################################################
+
+    b_Ai00 = -b_A00
+    b_Ai11 = -b_A11
+    b_Ai22 = -b_A22
+    b_Ai33 = -b_A33
+
+    for i in range(2, min(BC, T - i_tc0)):
+        b_a00 = tl.sum(tl.where((o_i == i)[:, None], -b_A00, 0.0), 0)
+        b_a00 = tl.where(o_i < i, b_a00, 0.0)
+        b_a00 = b_a00 + tl.sum(b_a00[:, None] * b_Ai00, 0)
+        b_Ai00 = tl.where((o_i == i)[:, None], b_a00, b_Ai00)
+    for i in range(2, min(BC, T - i_tc1)):
+        b_a11 = tl.sum(tl.where((o_i == i)[:, None], -b_A11, 0.0), 0)
+        b_a11 = tl.where(o_i < i, b_a11, 0.0)
+        b_a11 = b_a11 + tl.sum(b_a11[:, None] * b_Ai11, 0)
+        b_Ai11 = tl.where((o_i == i)[:, None], b_a11, b_Ai11)
+    for i in range(2, min(BC, T - i_tc2)):
+        b_a22 = tl.sum(tl.where((o_i == i)[:, None], -b_A22, 0.0), 0)
+        b_a22 = tl.where(o_i < i, b_a22, 0.0)
+        b_a22 = b_a22 + tl.sum(b_a22[:, None] * b_Ai22, 0)
+        b_Ai22 = tl.where((o_i == i)[:, None], b_a22, b_Ai22)
+    for i in range(2, min(BC, T - i_tc3)):
+        b_a33 = tl.sum(tl.where((o_i == i)[:, None], -b_A33, 0.0), 0)
+        b_a33 = tl.where(o_i < i, b_a33, 0.0)
+        b_a33 = b_a33 + tl.sum(b_a33[:, None] * b_Ai33, 0)
+        b_Ai33 = tl.where((o_i == i)[:, None], b_a33, b_Ai33)
+
+    b_Ai00 += m_I
+    b_Ai11 += m_I
+    b_Ai22 += m_I
+    b_Ai33 += m_I
+
+    ############################################################################
+    # Step 4: block merge -> full (I + A)^{-1}
+    ############################################################################
+
+    b_Ai10 = -tl.dot(
+        tl.dot(b_Ai11, b_A10, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        b_Ai00,
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+    b_Ai21 = -tl.dot(
+        tl.dot(b_Ai22, b_A21, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        b_Ai11,
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+    b_Ai32 = -tl.dot(
+        tl.dot(b_Ai33, b_A32, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        b_Ai22,
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+
+    b_Ai20 = -tl.dot(
+        b_Ai22,
+        tl.dot(b_A20, b_Ai00, input_precision=SOLVE_TRIL_DOT_PRECISION)
+        + tl.dot(b_A21, b_Ai10, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+    b_Ai31 = -tl.dot(
+        b_Ai33,
+        tl.dot(b_A31, b_Ai11, input_precision=SOLVE_TRIL_DOT_PRECISION)
+        + tl.dot(b_A32, b_Ai21, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+    b_Ai30 = -tl.dot(
+        b_Ai33,
+        tl.dot(b_A30, b_Ai00, input_precision=SOLVE_TRIL_DOT_PRECISION)
+        + tl.dot(b_A31, b_Ai10, input_precision=SOLVE_TRIL_DOT_PRECISION)
+        + tl.dot(b_A32, b_Ai20, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+
+    ############################################################################
+    # Step 5: store full (I + A)^{-1} to output A
+    ############################################################################
+
+    p_A00 = A + (i_tc0 + o_i)[:, None] * (HV * BT) + o_i[None, :]
+    p_A10 = A + (i_tc1 + o_i)[:, None] * (HV * BT) + o_i[None, :]
+    p_A11 = A + (i_tc1 + o_i)[:, None] * (HV * BT) + (BC + o_i)[None, :]
+    p_A20 = A + (i_tc2 + o_i)[:, None] * (HV * BT) + o_i[None, :]
+    p_A21 = A + (i_tc2 + o_i)[:, None] * (HV * BT) + (BC + o_i)[None, :]
+    p_A22 = A + (i_tc2 + o_i)[:, None] * (HV * BT) + (2 * BC + o_i)[None, :]
+    p_A30 = A + (i_tc3 + o_i)[:, None] * (HV * BT) + o_i[None, :]
+    p_A31 = A + (i_tc3 + o_i)[:, None] * (HV * BT) + (BC + o_i)[None, :]
+    p_A32 = A + (i_tc3 + o_i)[:, None] * (HV * BT) + (2 * BC + o_i)[None, :]
+    p_A33 = A + (i_tc3 + o_i)[:, None] * (HV * BT) + (3 * BC + o_i)[None, :]
+
+    m_A0 = m_tc0[:, None] & (o_i[None, :] < BT)
+    m_A1 = m_tc1[:, None] & (o_i[None, :] < BT)
+    m_A2 = m_tc2[:, None] & (o_i[None, :] < BT)
+    m_A3 = m_tc3[:, None] & (o_i[None, :] < BT)
+    m_A11 = m_tc1[:, None] & ((BC + o_i)[None, :] < BT)
+    m_A21 = m_tc2[:, None] & ((BC + o_i)[None, :] < BT)
+    m_A22 = m_tc2[:, None] & ((2 * BC + o_i)[None, :] < BT)
+    m_A31 = m_tc3[:, None] & ((BC + o_i)[None, :] < BT)
+    m_A32 = m_tc3[:, None] & ((2 * BC + o_i)[None, :] < BT)
+    m_A33 = m_tc3[:, None] & ((3 * BC + o_i)[None, :] < BT)
+
+    tl.store(p_A00, b_Ai00.to(A.dtype.element_ty), mask=m_A0)
+    tl.store(p_A10, b_Ai10.to(A.dtype.element_ty), mask=m_A1)
+    tl.store(p_A11, b_Ai11.to(A.dtype.element_ty), mask=m_A11)
+    tl.store(p_A20, b_Ai20.to(A.dtype.element_ty), mask=m_A2)
+    tl.store(p_A21, b_Ai21.to(A.dtype.element_ty), mask=m_A21)
+    tl.store(p_A22, b_Ai22.to(A.dtype.element_ty), mask=m_A22)
+    tl.store(p_A30, b_Ai30.to(A.dtype.element_ty), mask=m_A3)
+    tl.store(p_A31, b_Ai31.to(A.dtype.element_ty), mask=m_A31)
+    tl.store(p_A32, b_Ai32.to(A.dtype.element_ty), mask=m_A32)
+    tl.store(p_A33, b_Ai33.to(A.dtype.element_ty), mask=m_A33)
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+        "STORE_QG": lambda args: args["q"] is not None,
+    }
+)
+@triton.jit(do_not_specialize=["T", "num_sequences"])
+def scalar_recompute_w_u_kg_kernel(
+    q,
+    k,
+    v,
+    beta,
+    inverse,
+    cumulative_gate,
+    w,
+    u,
+    restored_k,
+    qg,
+    cu_seqlens,
+    chunk_offsets,
+    T,
+    num_sequences,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    STORE_QG: tl.constexpr,
+):
+    """Compute W/U and kg while K, beta, gate, and the solved transition are resident."""
+    chunk = tl.program_id(0)
+    batch_head = tl.program_id(1)
+    batch = batch_head // HV
+    head = batch_head % HV
+    key_head = head // (HV // H)
+    row = tl.arange(0, BT)
+    column = tl.arange(0, BT)
+    if IS_VARLEN:
+        if chunk >= load_ragged_chunk_count(chunk_offsets, num_sequences):
+            return
+        _sequence, _local_chunk, token_start, valid_tokens = load_ragged_chunk_work(
+            cu_seqlens, chunk_offsets, chunk, num_sequences, BT
+        )
+        global_token = token_start + row
+        token_mask = row < valid_tokens
+    else:
+        global_token = batch * T + chunk * BT + row
+        token_mask = row < BT
+        valid_tokens = BT
+
+    beta_row = tl.load(beta + global_token * HV + head, mask=token_mask, other=0.0).to(tl.float32)
+    gate = tl.load(cumulative_gate + global_token * HV + head, mask=token_mask, other=0.0).to(
+        tl.float32
+    )
+    inverse_tile = tl.load(
+        inverse + global_token[:, None] * (HV * BT) + head * BT + column[None, :],
+        mask=token_mask[:, None],
+        other=0.0,
+    )
+
+    for value_block in range(0, V, BV):
+        value = value_block + tl.arange(0, BV)
+        v_tile = tl.load(
+            v + global_token[:, None] * (HV * V) + head * V + value[None, :],
+            mask=token_mask[:, None],
+            other=0.0,
+        )
+        u_tile = tl.dot(inverse_tile, (v_tile * beta_row[:, None]).to(v_tile.dtype))
+        tl.store(
+            u + global_token[:, None] * (HV * V) + head * V + value[None, :],
+            u_tile.to(u.dtype.element_ty),
+            mask=token_mask[:, None],
+        )
+
+    final_gate = tl.sum(tl.where(row == valid_tokens - 1, gate, 0.0), axis=0)
+    gate_exp = tl.exp2(gate)
+    restore = tl.exp2(final_gate - gate)
+    for key_block in range(0, K, BK):
+        feature = key_block + tl.arange(0, BK)
+        k_tile = tl.load(
+            k + global_token[:, None] * (H * K) + key_head * K + feature[None, :],
+            mask=token_mask[:, None],
+            other=0.0,
+        )
+        weighted_k = k_tile * (beta_row * gate_exp)[:, None]
+        w_tile = tl.dot(inverse_tile, weighted_k.to(k_tile.dtype))
+        output_offset = global_token[:, None] * (HV * K) + head * K + feature[None, :]
+        tl.store(w + output_offset, w_tile.to(w.dtype.element_ty), mask=token_mask[:, None])
+        tl.store(
+            restored_k + output_offset,
+            (k_tile * restore[:, None]).to(k_tile.dtype),
+            mask=token_mask[:, None],
+        )
+        if STORE_QG:
+            q_tile = tl.load(
+                q + global_token[:, None] * (H * K) + key_head * K + feature[None, :],
+                mask=token_mask[:, None],
+                other=0.0,
+            )
+            tl.store(
+                qg + output_offset,
+                (q_tile * gate_exp[:, None]).to(q_tile.dtype),
+                mask=token_mask[:, None],
+            )
+
+
+def chunk_gdn_fwd_intra_dense(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Run dense GQA-capable BT64 scalar KKT/solve and W/U/kg."""
+    batch, tokens, key_heads, key_dim = k.shape
+    value_heads, value_dim = v.shape[2:]
+    if (
+        tokens % 64
+        or key_dim != 128
+        or value_dim != 128
+        or v.shape[:2] != k.shape[:2]
+        or value_heads % key_heads
+    ):
+        raise ValueError("dense fused chunk GDN requires BT64, K=V=128, and H % HK == 0")
+    if (
+        cumulative_gate.shape != (batch, tokens, value_heads)
+        or beta.shape != cumulative_gate.shape
+    ):
+        raise ValueError("cumulative_gate and beta must follow value heads")
+    chunks = tokens // 64
+    inverse = torch.zeros(batch, tokens, value_heads, 64, dtype=k.dtype, device=k.device)
+    chunk_gdn_fwd_kkt_solve_kernel[(chunks, batch * value_heads)](
+        k=k,
+        g=cumulative_gate,
+        beta=beta,
+        A=inverse,
+        cu_seqlens=None,
+        chunk_offsets=None,
+        T=tokens,
+        num_sequences=0,
+        H=key_heads,
+        HV=value_heads,
+        K=key_dim,
+        BT=64,
+        BC=16,
+    )
+
+    w = k.new_empty(batch, tokens, value_heads, key_dim)
+    u = torch.empty_like(v)
+    restored_k = torch.empty_like(w)
+    scalar_recompute_w_u_kg_kernel[(chunks, batch * value_heads)](
+        q=None,
+        k=k,
+        v=v,
+        beta=beta,
+        inverse=inverse,
+        cumulative_gate=cumulative_gate,
+        w=w,
+        u=u,
+        restored_k=restored_k,
+        qg=None,
+        cu_seqlens=None,
+        chunk_offsets=None,
+        T=tokens,
+        num_sequences=0,
+        H=key_heads,
+        HV=value_heads,
+        K=key_dim,
+        V=value_dim,
+        BT=64,
+        BK=64,
+        BV=64,
+        num_warps=4,
+        num_stages=4,
+    )
+    return w, u, restored_k, inverse
+
+
+def chunk_gdn_fwd_intra_packed(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    metadata: RaggedChunkMetadata,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Run fixed-capacity packed scalar KKT/solve and W/U/kg."""
+    metadata.validate_chunk_size(64)
+    batch, tokens, key_heads, key_dim = k.shape
+    value_heads, value_dim = v.shape[2:]
+    if (
+        batch != 1
+        or key_dim != 128
+        or value_dim != 128
+        or v.shape[:2] != k.shape[:2]
+        or value_heads % key_heads
+    ):
+        raise ValueError("packed fused chunk GDN requires B=1, K=V=128, and H % HK == 0")
+    if (
+        cumulative_gate.shape != (batch, tokens, value_heads)
+        or beta.shape != cumulative_gate.shape
+    ):
+        raise ValueError("cumulative_gate and beta must follow value heads")
+
+    inverse = torch.zeros(batch, tokens, value_heads, 64, dtype=k.dtype, device=k.device)
+    chunk_gdn_fwd_kkt_solve_kernel[(metadata.capacity, value_heads)](
+        k=k,
+        g=cumulative_gate,
+        beta=beta,
+        A=inverse,
+        cu_seqlens=metadata.cu_seqlens,
+        chunk_offsets=metadata.chunk_offsets,
+        T=tokens,
+        num_sequences=metadata.cu_seqlens.shape[0] - 1,
+        H=key_heads,
+        HV=value_heads,
+        K=key_dim,
+        BT=64,
+        BC=16,
+    )
+
+    w = k.new_zeros(batch, tokens, value_heads, key_dim)
+    u = torch.zeros_like(v)
+    restored_k = torch.zeros_like(w)
+    scalar_recompute_w_u_kg_kernel[(metadata.capacity, value_heads)](
+        q=None,
+        k=k,
+        v=v,
+        beta=beta,
+        inverse=inverse,
+        cumulative_gate=cumulative_gate,
+        w=w,
+        u=u,
+        restored_k=restored_k,
+        qg=None,
+        cu_seqlens=metadata.cu_seqlens,
+        chunk_offsets=metadata.chunk_offsets,
+        T=tokens,
+        num_sequences=metadata.cu_seqlens.shape[0] - 1,
+        H=key_heads,
+        HV=value_heads,
+        K=key_dim,
+        V=value_dim,
+        BT=64,
+        BK=64,
+        BV=64,
+        num_warps=4,
+        num_stages=4,
+    )
+    return w, u, restored_k, inverse
+
+
+def chunk_gdn_recompute_w_u_qg_kg(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    inverse: torch.Tensor,
+    metadata: RaggedChunkMetadata | None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Recompute scalar W/U/qg/kg from the saved inverse without rebuilding KKT."""
+    batch, tokens, key_heads, key_dim = q.shape
+    value_heads, value_dim = v.shape[2:]
+    if (
+        k.shape != q.shape
+        or v.shape[:2] != q.shape[:2]
+        or value_heads % key_heads
+        or (key_dim, value_dim) != (128, 128)
+    ):
+        raise ValueError("fused chunk GDN recompute requires K=V=128 and H % HK == 0")
+    if metadata is not None:
+        metadata.validate_chunk_size(64)
+        if batch != 1:
+            raise ValueError("packed fused chunk GDN recompute requires B=1")
+    elif tokens % 64:
+        raise ValueError("dense fused chunk GDN recompute requires complete BT64 chunks")
+
+    factory = torch.zeros if metadata is not None else torch.empty
+    w = factory((batch, tokens, value_heads, key_dim), dtype=k.dtype, device=k.device)
+    u = factory(v.shape, dtype=v.dtype, device=v.device)
+    restored_k = factory(w.shape, dtype=w.dtype, device=w.device)
+    qg = factory(w.shape, dtype=w.dtype, device=w.device)
+    chunks = tokens // 64 if metadata is None else metadata.capacity
+    cu_seqlens = None if metadata is None else metadata.cu_seqlens
+    chunk_offsets = None if metadata is None else metadata.chunk_offsets
+    num_sequences = 0 if metadata is None else metadata.cu_seqlens.shape[0] - 1
+    scalar_recompute_w_u_kg_kernel[(chunks, batch * value_heads)](
+        q=q,
+        k=k,
+        v=v,
+        beta=beta,
+        inverse=inverse,
+        cumulative_gate=cumulative_gate,
+        w=w,
+        u=u,
+        restored_k=restored_k,
+        qg=qg,
+        cu_seqlens=cu_seqlens,
+        chunk_offsets=chunk_offsets,
+        T=tokens,
+        num_sequences=num_sequences,
+        H=key_heads,
+        HV=value_heads,
+        K=key_dim,
+        V=value_dim,
+        BT=64,
+        BK=64,
+        BV=64,
+        num_warps=4,
+        num_stages=4,
+    )
+    return w, u, qg, restored_k
+
+
+__all__ = [
+    "chunk_gdn_fwd_intra_dense",
+    "chunk_gdn_fwd_intra_packed",
+    "chunk_gdn_recompute_w_u_qg_kg",
+]

--- a/attn_gym/linear/gdn/fwd/triton/chunk_gdn_fwd_output.py
+++ b/attn_gym/linear/gdn/fwd/triton/chunk_gdn_fwd_output.py
@@ -1,0 +1,222 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+# Copyright (c) 2026 Meta Platforms, Inc. and affiliates.
+#
+# Portions are derived from flash-linear-attention and licensed under the MIT license;
+# see https://github.com/fla-org/flash-linear-attention/graphs/contributors.
+# The remaining portions use the BSD-style license in the repository root.
+
+"""Scalar-GDN output composition with on-the-fly causal QK."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from attn_gym.linear.kda.chunk_scheduler import (
+    RaggedChunkMetadata,
+    load_ragged_chunk_count,
+    load_ragged_chunk_work,
+)
+from attn_gym.linear.kda.utils import autotune_cache_kwargs, exp2
+
+
+@triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
+@triton.autotune(
+    configs=[
+        triton.Config({"BK": 128, "BV": 128}, num_warps=8, num_stages=3),
+        triton.Config({"BK": 64, "BV": 64}, num_warps=4, num_stages=3),
+        triton.Config({"BK": 32, "BV": 32}, num_warps=2, num_stages=3),
+    ],
+    key=["H", "HV", "K", "V", "BT"],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["T", "num_sequences"])
+def chunk_fwd_kernel_o(
+    q,
+    k,
+    v,
+    h,
+    g,
+    o,
+    cu_seqlens,
+    chunk_offsets,
+    scale,
+    T,
+    num_sequences,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2).to(tl.int64)
+    i_b, i_h = i_bh // HV, i_bh % HV
+
+    if IS_VARLEN:
+        if i_t >= load_ragged_chunk_count(chunk_offsets, num_sequences):
+            return
+        i_tg = i_t
+        i_n, i_t, token_start, _valid = load_ragged_chunk_work(
+            cu_seqlens, chunk_offsets, i_t, num_sequences, BT
+        )
+        bos = token_start - i_t * BT
+        eos = tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+        NT = tl.cdiv(T, BT)
+    else:
+        NT = tl.cdiv(T, BT)
+        i_tg = i_b * NT + i_t
+        bos, eos = i_b * T, i_b * T + T
+
+    # offset calculation
+    q += (bos * H + i_h // (HV // H)) * K
+    k += (bos * H + i_h // (HV // H)) * K
+    v += (bos * HV + i_h) * V
+    o += (bos * HV + i_h) * V
+    h += (i_tg * HV + i_h).to(tl.int64) * K * V
+
+    b_o = tl.zeros([BT, BV], dtype=tl.float32)
+    b_A = tl.zeros([BT, BT], dtype=tl.float32)
+
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
+    o_v = i_v * BV + tl.arange(0, BV)
+    for i_k in range(tl.cdiv(K, BK)):
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = o_k < K
+        p_q = q + o_t[:, None] * (H * K) + o_k[None, :]
+        p_k = k + o_k[:, None] + o_t[None, :] * (H * K)
+        p_h = h + o_k[:, None] * V + o_v[None, :]
+        m_h = m_k[:, None] & (o_v[None, :] < V)
+        # [BT, BK]
+        b_q = tl.load(p_q, mask=m_t[:, None] & m_k[None, :], other=0.0)
+        # [BK, BT]
+        b_k = tl.load(p_k, mask=m_k[:, None] & m_t[None, :], other=0.0)
+        b_h = tl.load(p_h, mask=m_h, other=0.0)
+
+        # [BT, BK] @ [BK, BV] -> [BT, BV]
+        b_o += tl.dot(b_q, b_h)
+        # [BT, BK] @ [BK, BT] -> [BT, BT]
+        b_A += tl.dot(b_q, b_k)
+
+    g += bos * HV + i_h
+    p_g = g + o_t * HV
+    b_g = tl.load(p_g, mask=m_t, other=0.0)
+    b_o = b_o * exp2(b_g)[:, None]
+    decay_mask = (o_t[:, None] >= o_t[None, :]) & (m_t[:, None] & m_t)
+    gate_delta = b_g[:, None] - b_g[None, :]
+    decay = tl.where(
+        decay_mask,
+        exp2(tl.where(decay_mask, gate_delta, 0.0)),
+        0.0,
+    )
+    b_A = b_A * decay
+    m_A = (o_t[:, None] >= o_t[None, :]) & (m_t[:, None] & m_t)
+    b_A = tl.where(m_A, b_A, 0)
+
+    p_v = v + o_t[:, None] * (HV * V) + o_v[None, :]
+    p_o = o + o_t[:, None] * (HV * V) + o_v[None, :]
+
+    b_v = tl.load(p_v, mask=m_t[:, None] & (o_v < V)[None, :], other=0.0)
+    # to fix mma -> mma layout conversion
+    # already solved by triton v3.2 or higher
+    b_o = b_o * scale + tl.dot(b_A.to(b_v.dtype), b_v) * scale
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_t[:, None] & (o_v < V)[None, :])
+
+
+def chunk_gdn_fwd_output_dense(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    h: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    scale: float,
+) -> torch.Tensor:
+    """Compose dense GQA-capable BT64 output without materializing Aqk."""
+    batch, tokens, key_heads, key_dim = q.shape
+    value_heads, value_dim = v.shape[2:]
+    if k.shape != q.shape or v.shape[:2] != q.shape[:2] or value_heads % key_heads:
+        raise ValueError("dense fused chunk GDN requires matching Q/K and H % HK == 0")
+    if tokens % 64 or (key_dim, value_dim) != (128, 128):
+        raise ValueError("dense fused chunk GDN requires complete BT64 chunks and K=V=128")
+    chunks = tokens // 64
+    if h.shape != (batch, chunks, value_heads, key_dim, value_dim):
+        raise ValueError("h must contain one [K,V] entry state per chunk and head")
+
+    output = torch.empty_like(v)
+
+    def grid(meta):
+        return (triton.cdiv(value_dim, meta["BV"]), chunks, batch * value_heads)
+
+    chunk_fwd_kernel_o[grid](
+        q=q,
+        k=k,
+        v=v,
+        h=h,
+        g=cumulative_gate,
+        o=output,
+        cu_seqlens=None,
+        chunk_offsets=None,
+        scale=scale,
+        T=tokens,
+        num_sequences=0,
+        H=key_heads,
+        HV=value_heads,
+        K=key_dim,
+        V=value_dim,
+        BT=64,
+    )
+    return output
+
+
+def chunk_gdn_fwd_output_packed(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    h: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    scale: float,
+    metadata: RaggedChunkMetadata,
+) -> torch.Tensor:
+    """Compose fixed-capacity packed GQA output without materializing Aqk."""
+    metadata.validate_chunk_size(64)
+    batch, tokens, key_heads, key_dim = q.shape
+    value_heads, value_dim = v.shape[2:]
+    if batch != 1 or k.shape != q.shape or v.shape[:2] != q.shape[:2]:
+        raise ValueError("packed fused chunk GDN requires B=1 and matching Q/K token axes")
+    if value_heads % key_heads or (key_dim, value_dim) != (128, 128):
+        raise ValueError("packed fused chunk GDN requires K=V=128 and H % HK == 0")
+    if h.shape != (batch, metadata.capacity, value_heads, key_dim, value_dim):
+        raise ValueError("h must contain one fixed-capacity [K,V] entry state per chunk")
+
+    output = torch.empty_like(v)
+
+    def grid(meta):
+        return (triton.cdiv(value_dim, meta["BV"]), metadata.capacity, value_heads)
+
+    chunk_fwd_kernel_o[grid](
+        q=q,
+        k=k,
+        v=v,
+        h=h,
+        g=cumulative_gate,
+        o=output,
+        cu_seqlens=metadata.cu_seqlens,
+        chunk_offsets=metadata.chunk_offsets,
+        scale=scale,
+        T=tokens,
+        num_sequences=metadata.cu_seqlens.shape[0] - 1,
+        H=key_heads,
+        HV=value_heads,
+        K=key_dim,
+        V=value_dim,
+        BT=64,
+    )
+    return output
+
+
+__all__ = ["chunk_gdn_fwd_output_dense", "chunk_gdn_fwd_output_packed"]

--- a/attn_gym/linear/gdn/fwd/triton/chunk_gdn_fwd_recurrence.py
+++ b/attn_gym/linear/gdn/fwd/triton/chunk_gdn_fwd_recurrence.py
@@ -1,0 +1,212 @@
+"""Dense scalar-gate specialization of the KDA inter-chunk state recurrence."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata
+
+
+@triton.jit(do_not_specialize=["T"])
+def chunk_gdn_fwd_recurrence_kernel(
+    k_desc,
+    w_desc,
+    u_desc,
+    v_new_desc,
+    h_desc,
+    cumulative_gate,
+    initial_state_desc,
+    final_state_desc,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BV: tl.constexpr,
+):
+    """Keep one KxBV state tile resident while traversing BT64 chunks."""
+    batch_head = tl.program_id(0)
+    value_tile = tl.program_id(1)
+    batch = batch_head // H
+    head = batch_head % H
+    state_vk = initial_state_desc.load([batch, head, value_tile * BV, 0])
+    state = tl.trans(tl.reshape(state_vk, [BV, K])).to(tl.float32)
+    for chunk in tl.range(0, T // BT, warp_specialize=True, num_stages=3):
+        token = chunk * BT
+        h_desc.store(
+            [batch, chunk, head, 0, value_tile * BV],
+            tl.reshape(state.to(k_desc.dtype), [1, 1, 1, K, BV]),
+        )
+        w = tl.reshape(w_desc.load([batch, token, head, 0]), [BT, K])
+        u = tl.reshape(u_desc.load([batch, token, head, value_tile * BV]), [BT, BV])
+        v_new = u.to(tl.float32) - tl.dot(w, state.to(w.dtype))
+        v_new_desc.store(
+            [batch, token, head, value_tile * BV],
+            tl.reshape(v_new.to(u.dtype), [1, BT, 1, BV]),
+        )
+
+        final_gate = tl.load(cumulative_gate + (batch * T + token + BT - 1) * H + head).to(
+            tl.float32
+        )
+        state *= tl.exp2(final_gate)
+        restored_key = tl.reshape(k_desc.load([batch, token, head, 0]), [BT, K])
+        state = tl.dot(tl.trans(restored_key), v_new.to(restored_key.dtype), acc=state)
+
+    final_state_desc.store(
+        [batch, head, value_tile * BV, 0],
+        tl.reshape(tl.trans(state), [1, 1, BV, K]),
+    )
+
+
+def chunk_gdn_fwd_recurrence_dense(
+    k: torch.Tensor,
+    w: torch.Tensor,
+    u: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    initial_state: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Run dense BT64 recurrence with precomputed restored keys."""
+    batch, tokens, heads, key_dim = k.shape
+    value_dim = u.shape[-1]
+    if tokens % 64 or (key_dim, value_dim) != (128, 128):
+        raise ValueError("dense fused chunk GDN requires complete BT64 chunks and K=V=128")
+    if w.shape != k.shape or cumulative_gate.shape != k.shape[:3]:
+        raise ValueError("w must match k and cumulative_gate must have shape [B,T,H]")
+    if initial_state.shape != (batch, heads, value_dim, key_dim):
+        raise ValueError("initial_state must have shape [B,H,V,K]")
+
+    chunks = tokens // 64
+    block_value = 64
+    h = torch.empty(batch, chunks, heads, key_dim, value_dim, dtype=k.dtype, device=k.device)
+    v_new = torch.empty_like(u)
+    final_state = torch.empty_like(initial_state)
+    chunk_gdn_fwd_recurrence_kernel[(batch * heads, value_dim // block_value)](
+        TensorDescriptor.from_tensor(k, [1, 64, 1, key_dim]),
+        TensorDescriptor.from_tensor(w, [1, 64, 1, key_dim]),
+        TensorDescriptor.from_tensor(u, [1, 64, 1, block_value]),
+        TensorDescriptor.from_tensor(v_new, [1, 64, 1, block_value]),
+        TensorDescriptor.from_tensor(h, [1, 1, 1, key_dim, block_value]),
+        cumulative_gate,
+        TensorDescriptor.from_tensor(initial_state, [1, 1, block_value, key_dim]),
+        TensorDescriptor.from_tensor(final_state, [1, 1, block_value, key_dim]),
+        tokens,
+        H=heads,
+        K=key_dim,
+        BT=64,
+        BV=block_value,
+        num_warps=4,
+        num_stages=3,
+    )
+    return h, v_new, final_state
+
+
+@triton.jit
+def chunk_gdn_fwd_recurrence_packed_kernel(
+    restored_k,
+    w,
+    u,
+    cumulative_gate,
+    initial_state,
+    h,
+    v_new,
+    final_state,
+    cu_seqlens,
+    chunk_offsets,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BV: tl.constexpr,
+):
+    """Traverse one packed sequence/head/value tile with a resident FP32 state."""
+    sequence_head = tl.program_id(0)
+    value_tile = tl.program_id(1)
+    sequence = sequence_head // H
+    head = sequence_head % H
+
+    bos = tl.load(cu_seqlens + sequence).to(tl.int64)
+    eos = tl.load(cu_seqlens + sequence + 1).to(tl.int64)
+    chunk_begin = tl.load(chunk_offsets + sequence).to(tl.int64)
+    chunks = (eos - bos + BT - 1) // BT
+    key = tl.arange(0, K)
+    value = value_tile * BV + tl.arange(0, BV)
+    state_offset = sequence * (H * V * K) + head * (V * K) + value[None, :] * K + key[:, None]
+    state = tl.load(initial_state + state_offset).to(tl.float32)
+    row = tl.arange(0, BT)
+
+    for local_chunk in tl.range(0, chunks):
+        global_chunk = chunk_begin + local_chunk
+        token_start = bos + local_chunk * BT
+        token = token_start + row
+        token_mask = token < eos
+        h_offset = global_chunk * (H * K * V) + head * (K * V) + key[:, None] * V + value[None, :]
+        tl.store(h + h_offset, state.to(h.dtype.element_ty))
+
+        w_offset = token[:, None] * (H * K) + head * K + key[None, :]
+        u_offset = token[:, None] * (H * V) + head * V + value[None, :]
+        w_tile = tl.load(w + w_offset, mask=token_mask[:, None], other=0.0)
+        u_tile = tl.load(u + u_offset, mask=token_mask[:, None], other=0.0)
+        corrected = u_tile.to(tl.float32) - tl.dot(w_tile, state.to(w_tile.dtype))
+        tl.store(
+            v_new + u_offset,
+            corrected.to(v_new.dtype.element_ty),
+            mask=token_mask[:, None],
+        )
+
+        final_token = tl.minimum(token_start + BT, eos) - 1
+        final_gate = tl.load(cumulative_gate + final_token * H + head).to(tl.float32)
+        state *= tl.exp2(final_gate)
+        restored = tl.load(restored_k + w_offset, mask=token_mask[:, None], other=0.0)
+        state = tl.dot(tl.trans(restored), corrected.to(restored.dtype), acc=state)
+
+    tl.store(final_state + state_offset, state)
+
+
+def chunk_gdn_fwd_recurrence_packed(
+    restored_k: torch.Tensor,
+    w: torch.Tensor,
+    u: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    initial_state: torch.Tensor,
+    metadata: RaggedChunkMetadata,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Run fixed-capacity packed recurrence with empty-sequence state identity."""
+    metadata.validate_chunk_size(64)
+    batch, tokens, heads, key_dim = restored_k.shape
+    value_dim = u.shape[-1]
+    num_sequences = metadata.cu_seqlens.shape[0] - 1
+    if batch != 1 or tokens == 0 or (key_dim, value_dim) != (128, 128):
+        raise ValueError("packed fused chunk GDN recurrence requires B=1, T>0, and K=V=128")
+    expected_state = (num_sequences, heads, value_dim, key_dim)
+    if initial_state.shape != expected_state:
+        raise ValueError(f"initial_state must have shape {expected_state}")
+
+    h = restored_k.new_empty(1, metadata.capacity, heads, key_dim, value_dim)
+    v_new = torch.empty_like(u)
+    final_state = torch.empty_like(initial_state)
+    block_value = 64
+    chunk_gdn_fwd_recurrence_packed_kernel[(num_sequences * heads, value_dim // block_value)](
+        restored_k,
+        w,
+        u,
+        cumulative_gate,
+        initial_state,
+        h,
+        v_new,
+        final_state,
+        metadata.cu_seqlens,
+        metadata.chunk_offsets,
+        H=heads,
+        K=key_dim,
+        V=value_dim,
+        BT=64,
+        BV=block_value,
+        num_warps=4,
+        num_stages=2,
+    )
+    return h, v_new, final_state
+
+
+__all__ = ["chunk_gdn_fwd_recurrence_dense", "chunk_gdn_fwd_recurrence_packed"]

--- a/attn_gym/linear/gdn/impl/chunk.py
+++ b/attn_gym/linear/gdn/impl/chunk.py
@@ -1,0 +1,475 @@
+"""Dense training-capable fused chunk GDN implementation."""
+
+from __future__ import annotations
+
+import torch
+
+from attn_gym._backends.cute import (
+    get_device_properties,
+    tensor_supports_contiguous_dim,
+    tensor_supports_tma,
+)
+from attn_gym._backends.triton.utils import requires_int64_offsets
+from attn_gym.linear.gdn.bwd.triton.chunk_gdn_bwd_intra import (
+    chunk_gdn_bwd_intra_dense,
+    chunk_gdn_bwd_intra_packed,
+)
+from attn_gym.linear.gdn.bwd.triton.chunk_gdn_bwd_recompute import (
+    chunk_gdn_recompute_aqk_dense,
+    chunk_gdn_recompute_aqk_packed,
+)
+from attn_gym.linear.gdn.fwd.triton.chunk_gdn_fwd_intra import (
+    chunk_gdn_fwd_intra_dense,
+    chunk_gdn_fwd_intra_packed,
+    chunk_gdn_recompute_w_u_qg_kg,
+)
+from attn_gym.linear.gdn.fwd.triton.chunk_gdn_fwd_output import (
+    chunk_gdn_fwd_output_dense,
+    chunk_gdn_fwd_output_packed,
+)
+from attn_gym.linear.gdn.fwd.triton.chunk_gdn_fwd_recurrence import (
+    chunk_gdn_fwd_recurrence_dense,
+    chunk_gdn_fwd_recurrence_packed,
+)
+from attn_gym.linear.kda.bwd.cute.chunk_delta_h_bwd import (
+    blackwell_delta_h_bwd_dhu_dv_fused_dispatch,
+)
+from attn_gym.linear.kda.bwd.cute.chunk_kda_bwd_wy_dqkg_fused import (
+    chunk_kda_bwd_wy_dqkg,
+)
+from attn_gym.linear.kda.bwd.triton.chunk_kda_bwd_daqk import chunk_kda_bwd_daqk
+from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata, chunk_capacity
+
+
+def normalize_tma_tensor(tensor: torch.Tensor) -> torch.Tensor:
+    """Copy only tensors that cannot satisfy a 16-byte TMA row contract."""
+    if tensor_supports_tma(tensor):
+        return tensor
+    return tensor.clone(memory_format=torch.contiguous_format)
+
+
+def normalize_compact_tensor(tensor: torch.Tensor, alignment_bytes: int = 128) -> torch.Tensor:
+    """Copy compact tensors whose slice origins miss the required alignment."""
+    if tensor.is_contiguous() and tensor_supports_contiguous_dim(
+        tensor, alignment_bytes=alignment_bytes
+    ):
+        return tensor
+    return tensor.clone(memory_format=torch.contiguous_format)
+
+
+def validate_blackwell(q: torch.Tensor) -> None:
+    """Reject unsupported devices at every real registered-op boundary."""
+    if get_device_properties(q.device).major < 10:
+        raise ValueError("fused chunk_gdn requires CUDA capability 10.0 or newer")
+
+
+def reject_int64_offsets(*tensors: torch.Tensor | None) -> None:
+    """Reject layouts that need the not-yet-implemented wide-address specialization."""
+    if requires_int64_offsets(*tensors):
+        raise ValueError("fused chunk_gdn does not yet support int64 tensor offsets")
+
+
+def zero_inactive_packed_gradients(
+    metadata: RaggedChunkMetadata,
+    dq: torch.Tensor,
+    dk: torch.Tensor,
+    dv: torch.Tensor,
+    d_gate: torch.Tensor,
+    db: torch.Tensor,
+) -> tuple[torch.Tensor, ...]:
+    """Zero physical capacity rows that no logical packed sequence owns."""
+    active = torch.arange(dq.shape[1], device=dq.device) < metadata.cu_seqlens[-1]
+    feature_mask = active.view(1, -1, 1, 1)
+    scalar_mask = active.view(1, -1, 1)
+    return (
+        torch.where(feature_mask, dq, 0.0),
+        torch.where(feature_mask, dk, 0.0),
+        torch.where(feature_mask, dv, 0.0),
+        torch.where(scalar_mask, d_gate, 0.0),
+        torch.where(scalar_mask, db, 0.0),
+    )
+
+
+def chunk_gdn_fwd_dense(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Run the dense B=1 BT64 scalar forward and return output, state, and inverse tape."""
+    validate_blackwell(q)
+    batch, tokens, key_heads, key_dim = q.shape
+    value_heads, value_dim = v.shape[2:]
+    if batch != 1 or tokens % 64 or (key_dim, value_dim) != (128, 128):
+        raise ValueError("dense fused chunk GDN requires B=1, complete BT64 chunks, and K=V=128")
+    if k.shape != q.shape or v.shape[:2] != q.shape[:2] or value_heads % key_heads:
+        raise ValueError("dense fused chunk GDN requires matching Q/K and H % HK == 0")
+    if cumulative_gate.shape != v.shape[:3] or beta.shape != v.shape[:3]:
+        raise ValueError("cumulative_gate and beta must have shape [B,T,H]")
+    if initial_state is None:
+        initial_state = torch.zeros(
+            batch,
+            value_heads,
+            value_dim,
+            key_dim,
+            dtype=torch.float32,
+            device=q.device,
+        )
+    reject_int64_offsets(q, k, v, cumulative_gate, beta, initial_state)
+    q, k, v = (normalize_tma_tensor(tensor) for tensor in (q, k, v))
+    cumulative_gate, beta, initial_state = (
+        normalize_compact_tensor(tensor) for tensor in (cumulative_gate, beta, initial_state)
+    )
+
+    w, u, restored_k, inverse = chunk_gdn_fwd_intra_dense(k, v, cumulative_gate, beta)
+    h, v_new, final_state = chunk_gdn_fwd_recurrence_dense(
+        restored_k,
+        w,
+        u,
+        cumulative_gate,
+        initial_state,
+    )
+    output = chunk_gdn_fwd_output_dense(q, k, v_new, h, cumulative_gate, scale)
+    return output, final_state, inverse
+
+
+def _gdn_chunk_fwd_cuda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Registered dense forward without a public final-state output."""
+    output, _state, inverse = chunk_gdn_fwd_dense(
+        q, k, v, cumulative_gate, beta, initial_state, scale
+    )
+    return output, inverse
+
+
+def _gdn_chunk_fwd_with_state_cuda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Registered dense forward with final state and inverse tape."""
+    return chunk_gdn_fwd_dense(q, k, v, cumulative_gate, beta, initial_state, scale)
+
+
+def chunk_gdn_fwd_packed(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    metadata: RaggedChunkMetadata,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Run fixed-capacity packed scalar forward and return output, state, and inverse tape."""
+    validate_blackwell(q)
+    batch, _tokens, key_heads, key_dim = q.shape
+    value_heads, value_dim = v.shape[2:]
+    num_sequences = metadata.cu_seqlens.shape[0] - 1
+    if batch != 1 or (key_dim, value_dim) != (128, 128):
+        raise ValueError("packed fused chunk GDN requires B=1 and K=V=128")
+    if k.shape != q.shape or v.shape[:2] != q.shape[:2] or value_heads % key_heads:
+        raise ValueError("packed fused chunk GDN requires matching Q/K and H % HK == 0")
+    if initial_state is None:
+        initial_state = torch.zeros(
+            num_sequences,
+            value_heads,
+            value_dim,
+            key_dim,
+            dtype=torch.float32,
+            device=q.device,
+        )
+    reject_int64_offsets(q, k, v, cumulative_gate, beta, initial_state)
+    q, k, v = (normalize_tma_tensor(tensor) for tensor in (q, k, v))
+    cumulative_gate, beta, initial_state = (
+        normalize_compact_tensor(tensor) for tensor in (cumulative_gate, beta, initial_state)
+    )
+
+    w, u, restored_k, inverse = chunk_gdn_fwd_intra_packed(k, v, cumulative_gate, beta, metadata)
+    h, v_new, final_state = chunk_gdn_fwd_recurrence_packed(
+        restored_k,
+        w,
+        u,
+        cumulative_gate,
+        initial_state,
+        metadata,
+    )
+    output = chunk_gdn_fwd_output_packed(q, k, v_new, h, cumulative_gate, scale, metadata)
+    return output, final_state, inverse
+
+
+def _gdn_chunk_fwd_packed_cuda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor,
+    chunk_offsets: torch.Tensor,
+    capacity: int,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Registered packed forward without a public final-state output."""
+    metadata = RaggedChunkMetadata(cu_seqlens, chunk_offsets, capacity, 64)
+    output, _state, inverse = chunk_gdn_fwd_packed(
+        q, k, v, cumulative_gate, beta, initial_state, metadata, scale
+    )
+    return output, inverse
+
+
+def _gdn_chunk_fwd_packed_with_state_cuda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor,
+    chunk_offsets: torch.Tensor,
+    capacity: int,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Registered packed forward with final state and inverse tape."""
+    metadata = RaggedChunkMetadata(cu_seqlens, chunk_offsets, capacity, 64)
+    return chunk_gdn_fwd_packed(q, k, v, cumulative_gate, beta, initial_state, metadata, scale)
+
+
+def chunk_gdn_bwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    inverse: torch.Tensor,
+    d_output: torch.Tensor,
+    d_final_state: torch.Tensor | None,
+    initial_state: torch.Tensor | None,
+    metadata: RaggedChunkMetadata | None,
+    scale: float,
+) -> tuple[torch.Tensor, ...]:
+    """Differentiate dense or packed fused chunk GDN through one shared protocol."""
+    validate_blackwell(q)
+    reject_int64_offsets(
+        q,
+        k,
+        v,
+        cumulative_gate,
+        beta,
+        inverse,
+        d_output,
+        d_final_state,
+        initial_state,
+    )
+    q, k, v = (normalize_tma_tensor(tensor) for tensor in (q, k, v))
+    cumulative_gate, beta, inverse, d_output = (
+        normalize_compact_tensor(tensor) for tensor in (cumulative_gate, beta, inverse, d_output)
+    )
+    if d_final_state is not None:
+        d_final_state = normalize_compact_tensor(d_final_state)
+    if initial_state is not None:
+        initial_state = normalize_compact_tensor(initial_state)
+
+    state_batch = q.shape[0] if metadata is None else metadata.cu_seqlens.shape[0] - 1
+    recurrence_state = initial_state
+    if recurrence_state is None:
+        recurrence_state = torch.zeros(
+            state_batch,
+            v.shape[2],
+            v.shape[-1],
+            q.shape[-1],
+            dtype=torch.float32,
+            device=q.device,
+        )
+    w, u, qg, kg = chunk_gdn_recompute_w_u_qg_kg(q, k, v, cumulative_gate, beta, inverse, metadata)
+    if metadata is None:
+        h, v_new, _final_state = chunk_gdn_fwd_recurrence_dense(
+            kg, w, u, cumulative_gate, recurrence_state
+        )
+    else:
+        h, v_new, _final_state = chunk_gdn_fwd_recurrence_packed(
+            kg, w, u, cumulative_gate, recurrence_state, metadata
+        )
+    d_aqk = chunk_kda_bwd_daqk(
+        v_new,
+        d_output,
+        scale,
+        chunk_size=64,
+        metadata=metadata,
+    )
+
+    # Reuse the proven vector-gate KDA gradient stages only after the scalar
+    # recompute; forward and backward preparation remain expansion-free.
+    groups = v.shape[2] // q.shape[2]
+    expanded_q, expanded_k = q, k
+    if groups > 1:
+        expanded_q, expanded_k = (tensor.repeat_interleave(groups, dim=2) for tensor in (q, k))
+    vector_gate = cumulative_gate.unsqueeze(-1).expand_as(expanded_q).contiguous()
+    aqk = (
+        chunk_gdn_recompute_aqk_dense(expanded_q, expanded_k, cumulative_gate, scale)
+        if metadata is None
+        else chunk_gdn_recompute_aqk_packed(
+            expanded_q, expanded_k, cumulative_gate, scale, metadata
+        )
+    )
+    dh, d_initial_state, dv = blackwell_delta_h_bwd_dhu_dv_fused_dispatch(
+        qg,
+        kg,
+        w,
+        d_output,
+        aqk,
+        gk=vector_gate,
+        h0=initial_state,
+        dht=d_final_state,
+        scale=scale,
+        chunk_size=64,
+        metadata=metadata,
+    )
+    dq, dk, dv, dg_raw, db, d_raw_akk = chunk_kda_bwd_wy_dqkg(
+        expanded_q,
+        expanded_k,
+        v,
+        v_new,
+        vector_gate,
+        beta,
+        inverse,
+        h,
+        d_output,
+        dh,
+        dv,
+        metadata,
+        scale=scale,
+        chunk_size=64,
+        fastmath=False,
+        autotune=False,
+    )
+    intra = (
+        chunk_gdn_bwd_intra_dense(
+            expanded_q,
+            expanded_k,
+            cumulative_gate,
+            beta,
+            d_aqk,
+            d_raw_akk,
+            dg_raw,
+        )
+        if metadata is None
+        else chunk_gdn_bwd_intra_packed(
+            expanded_q,
+            expanded_k,
+            cumulative_gate,
+            beta,
+            d_aqk,
+            d_raw_akk,
+            dg_raw,
+            metadata,
+        )
+    )
+    intra_dq, intra_dk, intra_db, d_gate = intra
+    dq = dq.float() + intra_dq
+    dk = dk.float() + intra_dk
+    if groups > 1:
+        dq = dq.view(*q.shape[:2], q.shape[2], groups, q.shape[3]).sum(3)
+        dk = dk.view(*k.shape[:2], k.shape[2], groups, k.shape[3]).sum(3)
+    dq = dq.to(q.dtype)
+    dk = dk.to(k.dtype)
+    db = db + intra_db
+    if metadata is not None:
+        dq, dk, dv, d_gate, db = zero_inactive_packed_gradients(metadata, dq, dk, dv, d_gate, db)
+    return dq, dk, dv, d_gate, db, d_initial_state
+
+
+def resolve_backward_metadata(
+    q: torch.Tensor,
+    cu_seqlens: torch.Tensor | None,
+    chunk_offsets: torch.Tensor | None,
+) -> RaggedChunkMetadata | None:
+    """Reconstruct shape-derived packed metadata for the merged backward schemas."""
+    if cu_seqlens is None:
+        assert chunk_offsets is None
+        return None
+    assert chunk_offsets is not None
+    return RaggedChunkMetadata(
+        cu_seqlens,
+        chunk_offsets,
+        chunk_capacity(q.shape[1], cu_seqlens.shape[0] - 1, 64),
+        64,
+    )
+
+
+def _gdn_chunk_bwd_cuda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    inverse: torch.Tensor,
+    d_output: torch.Tensor,
+    d_final_state: torch.Tensor | None,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+    chunk_offsets: torch.Tensor | None,
+    scale: float,
+) -> tuple[torch.Tensor, ...]:
+    """Registered dense or packed backward without an initial-state gradient output."""
+    dq, dk, dv, dg, db, _d_initial_state = chunk_gdn_bwd(
+        q,
+        k,
+        v,
+        cumulative_gate,
+        beta,
+        inverse,
+        d_output,
+        d_final_state,
+        initial_state,
+        resolve_backward_metadata(q, cu_seqlens, chunk_offsets),
+        scale,
+    )
+    return dq, dk, dv, dg, db
+
+
+def _gdn_chunk_bwd_with_state_grad_cuda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    inverse: torch.Tensor,
+    d_output: torch.Tensor,
+    d_final_state: torch.Tensor | None,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+    chunk_offsets: torch.Tensor | None,
+    scale: float,
+) -> tuple[torch.Tensor, ...]:
+    """Registered dense or packed backward preserving the initial-state gradient."""
+    return chunk_gdn_bwd(
+        q,
+        k,
+        v,
+        cumulative_gate,
+        beta,
+        inverse,
+        d_output,
+        d_final_state,
+        initial_state,
+        resolve_backward_metadata(q, cu_seqlens, chunk_offsets),
+        scale,
+    )
+
+
+__all__ = ["chunk_gdn_bwd", "chunk_gdn_fwd_dense", "chunk_gdn_fwd_packed"]

--- a/attn_gym/linear/gdn/ops.py
+++ b/attn_gym/linear/gdn/ops.py
@@ -6,6 +6,44 @@ import importlib
 
 import torch
 
+from attn_gym._backends.cute import get_device_properties
+from attn_gym.linear.kda.chunk_schedule import prepare_ragged_chunk_metadata
+from attn_gym.linear.kda.ops import _plain_gate_scan_op
+
+_CHUNK_ARGS = (
+    "(Tensor q, Tensor k, Tensor v, Tensor cumulative_gate, Tensor beta, "
+    "Tensor? initial_state, float scale)"
+)
+torch.library.define("attn_gym::gdn_chunk_fwd", _CHUNK_ARGS + " -> (Tensor, Tensor)")
+torch.library.define(
+    "attn_gym::gdn_chunk_fwd_with_state",
+    _CHUNK_ARGS + " -> (Tensor, Tensor, Tensor)",
+)
+_CHUNK_BWD_ARGS = (
+    "(Tensor q, Tensor k, Tensor v, Tensor cumulative_gate, Tensor beta, Tensor inverse, "
+    "Tensor d_output, Tensor? d_final_state, Tensor? initial_state, Tensor? cu_seqlens, "
+    "Tensor? chunk_offsets, float scale)"
+)
+torch.library.define(
+    "attn_gym::gdn_chunk_bwd",
+    _CHUNK_BWD_ARGS + " -> (Tensor, Tensor, Tensor, Tensor, Tensor)",
+)
+torch.library.define(
+    "attn_gym::gdn_chunk_bwd_with_state_grad",
+    _CHUNK_BWD_ARGS + " -> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor)",
+)
+_CHUNK_PACKED_ARGS = (
+    "(Tensor q, Tensor k, Tensor v, Tensor cumulative_gate, Tensor beta, "
+    "Tensor? initial_state, Tensor cu_seqlens, Tensor chunk_offsets, int capacity, float scale)"
+)
+torch.library.define(
+    "attn_gym::gdn_chunk_fwd_packed",
+    _CHUNK_PACKED_ARGS + " -> (Tensor, Tensor)",
+)
+torch.library.define(
+    "attn_gym::gdn_chunk_fwd_packed_with_state",
+    _CHUNK_PACKED_ARGS + " -> (Tensor, Tensor, Tensor)",
+)
 _RECURRENT_ARGS = (
     "(Tensor q, Tensor k, Tensor v, Tensor gate, Tensor beta, Tensor? initial_state, "
     "Tensor? cu_seqlens, float scale, bool autotune)"
@@ -23,6 +61,37 @@ torch.library.define(
     " Tensor(a!) state_cache, Tensor state_indices, Tensor? has_initial_state, Tensor(b!) out,"
     " float scale) -> ()",
 )
+
+
+def _chunk_backend():
+    try:
+        return importlib.import_module("attn_gym.linear.gdn.impl.chunk")
+    except ImportError as error:
+        raise ImportError("chunk_gdn(impl='fused') requires CUDA with Triton support") from error
+
+
+def _chunk_fwd_cuda(*args):
+    return _chunk_backend()._gdn_chunk_fwd_cuda(*args)
+
+
+def _chunk_fwd_with_state_cuda(*args):
+    return _chunk_backend()._gdn_chunk_fwd_with_state_cuda(*args)
+
+
+def _chunk_bwd_cuda(*args):
+    return _chunk_backend()._gdn_chunk_bwd_cuda(*args)
+
+
+def _chunk_bwd_with_state_grad_cuda(*args):
+    return _chunk_backend()._gdn_chunk_bwd_with_state_grad_cuda(*args)
+
+
+def _chunk_fwd_packed_cuda(*args):
+    return _chunk_backend()._gdn_chunk_fwd_packed_cuda(*args)
+
+
+def _chunk_fwd_packed_with_state_cuda(*args):
+    return _chunk_backend()._gdn_chunk_fwd_packed_with_state_cuda(*args)
 
 
 def _recurrent_backend():
@@ -50,6 +119,24 @@ def _recurrent_decode_cuda(*args):
     return _recurrent_backend()._gdn_recurrent_decode_cuda(*args)
 
 
+torch.library.impl("attn_gym::gdn_chunk_fwd", "CUDA", _chunk_fwd_cuda)
+torch.library.impl(
+    "attn_gym::gdn_chunk_fwd_with_state",
+    "CUDA",
+    _chunk_fwd_with_state_cuda,
+)
+torch.library.impl("attn_gym::gdn_chunk_bwd", "CUDA", _chunk_bwd_cuda)
+torch.library.impl(
+    "attn_gym::gdn_chunk_bwd_with_state_grad",
+    "CUDA",
+    _chunk_bwd_with_state_grad_cuda,
+)
+torch.library.impl("attn_gym::gdn_chunk_fwd_packed", "CUDA", _chunk_fwd_packed_cuda)
+torch.library.impl(
+    "attn_gym::gdn_chunk_fwd_packed_with_state",
+    "CUDA",
+    _chunk_fwd_packed_with_state_cuda,
+)
 torch.library.impl("attn_gym::gdn_recurrent_fwd", "CUDA", _recurrent_fwd_cuda)
 torch.library.impl(
     "attn_gym::gdn_recurrent_fwd_no_state",
@@ -66,6 +153,152 @@ torch.library.impl(
     "CUDA",
     _recurrent_decode_cuda,
 )
+
+
+@torch.library.register_fake("attn_gym::gdn_chunk_fwd")
+def _chunk_fwd_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    del k, cumulative_gate, beta, initial_state, scale
+    inverse = q.new_empty(q.shape[0], q.shape[1], v.shape[2], 64)
+    return torch.empty_like(v, dtype=q.dtype), inverse
+
+
+@torch.library.register_fake("attn_gym::gdn_chunk_fwd_with_state")
+def _chunk_fwd_with_state_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    output, inverse = _chunk_fwd_fake(q, k, v, cumulative_gate, beta, initial_state, scale)
+    final_state = q.new_empty(
+        q.shape[0], v.shape[2], v.shape[-1], q.shape[-1], dtype=torch.float32
+    )
+    return output, final_state, inverse
+
+
+@torch.library.register_fake("attn_gym::gdn_chunk_fwd_packed")
+def _chunk_fwd_packed_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor,
+    chunk_offsets: torch.Tensor,
+    capacity: int,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    del k, cumulative_gate, beta, initial_state, cu_seqlens, chunk_offsets, capacity, scale
+    inverse = q.new_empty(q.shape[0], q.shape[1], v.shape[2], 64)
+    return torch.empty_like(v, dtype=q.dtype), inverse
+
+
+@torch.library.register_fake("attn_gym::gdn_chunk_fwd_packed_with_state")
+def _chunk_fwd_packed_with_state_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor,
+    chunk_offsets: torch.Tensor,
+    capacity: int,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    output, inverse = _chunk_fwd_packed_fake(
+        q,
+        k,
+        v,
+        cumulative_gate,
+        beta,
+        initial_state,
+        cu_seqlens,
+        chunk_offsets,
+        capacity,
+        scale,
+    )
+    final_state = q.new_empty(
+        cu_seqlens.shape[0] - 1,
+        v.shape[2],
+        v.shape[-1],
+        q.shape[-1],
+        dtype=torch.float32,
+    )
+    return output, final_state, inverse
+
+
+@torch.library.register_fake("attn_gym::gdn_chunk_bwd")
+def _chunk_bwd_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    inverse: torch.Tensor,
+    d_output: torch.Tensor,
+    d_final_state: torch.Tensor | None,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+    chunk_offsets: torch.Tensor | None,
+    scale: float,
+) -> tuple[torch.Tensor, ...]:
+    del inverse, d_output, d_final_state, initial_state, cu_seqlens, chunk_offsets, scale
+    return (
+        torch.empty_like(q),
+        torch.empty_like(k),
+        torch.empty_like(v),
+        torch.empty_like(cumulative_gate),
+        torch.empty_like(beta),
+    )
+
+
+@torch.library.register_fake("attn_gym::gdn_chunk_bwd_with_state_grad")
+def _chunk_bwd_with_state_grad_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    inverse: torch.Tensor,
+    d_output: torch.Tensor,
+    d_final_state: torch.Tensor | None,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+    chunk_offsets: torch.Tensor | None,
+    scale: float,
+) -> tuple[torch.Tensor, ...]:
+    outputs = _chunk_bwd_fake(
+        q,
+        k,
+        v,
+        cumulative_gate,
+        beta,
+        inverse,
+        d_output,
+        d_final_state,
+        initial_state,
+        cu_seqlens,
+        chunk_offsets,
+        scale,
+    )
+    state_batch = q.shape[0] if cu_seqlens is None else cu_seqlens.shape[0] - 1
+    d_initial_state = q.new_empty(
+        state_batch, v.shape[2], v.shape[-1], q.shape[-1], dtype=torch.float32
+    )
+    return *outputs, d_initial_state
 
 
 @torch.library.register_fake("attn_gym::gdn_recurrent_fwd")
@@ -138,10 +371,196 @@ def _recurrent_decode_fake(
     """The decode op returns nothing and mutates preallocated buffers; no metadata to fake."""
 
 
+chunk_fwd_op = torch.ops.attn_gym.gdn_chunk_fwd.default
+chunk_fwd_with_state_op = torch.ops.attn_gym.gdn_chunk_fwd_with_state.default
+chunk_bwd_op = torch.ops.attn_gym.gdn_chunk_bwd.default
+chunk_bwd_with_state_grad_op = torch.ops.attn_gym.gdn_chunk_bwd_with_state_grad.default
+chunk_fwd_packed_op = torch.ops.attn_gym.gdn_chunk_fwd_packed.default
+chunk_fwd_packed_with_state_op = torch.ops.attn_gym.gdn_chunk_fwd_packed_with_state.default
 recurrent_fwd_op = torch.ops.attn_gym.gdn_recurrent_fwd.default
 recurrent_fwd_no_state_op = torch.ops.attn_gym.gdn_recurrent_fwd_no_state.default
 recurrent_fwd_paged_op = torch.ops.attn_gym.gdn_recurrent_fwd_paged.default
 recurrent_decode_op = torch.ops.attn_gym.gdn_recurrent_decode.default
+
+
+class _ChunkGDN(torch.autograd.Function):
+    """Attach first-order autograd to dense or fixed-capacity packed chunk operators."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        initial_state,
+        cu_seqlens,
+        chunk_offsets,
+        capacity,
+        scale,
+        output_final_state,
+    ):
+        cumulative_gate = _plain_gate_scan_op(
+            gate.unsqueeze(-1), cu_seqlens, chunk_offsets, False
+        ).squeeze(-1)
+        if cu_seqlens is None:
+            args = (q, k, v, cumulative_gate, beta, initial_state, scale)
+            if output_final_state:
+                output, final_state, inverse = chunk_fwd_with_state_op(*args)
+            else:
+                output, inverse = chunk_fwd_op(*args)
+        else:
+            args = (
+                q,
+                k,
+                v,
+                cumulative_gate,
+                beta,
+                initial_state,
+                cu_seqlens,
+                chunk_offsets,
+                capacity,
+                scale,
+            )
+            if output_final_state:
+                output, final_state, inverse = chunk_fwd_packed_with_state_op(*args)
+            else:
+                output, inverse = chunk_fwd_packed_op(*args)
+        ctx.save_for_backward(
+            q,
+            k,
+            v,
+            cumulative_gate,
+            beta,
+            inverse,
+            initial_state,
+            cu_seqlens,
+            chunk_offsets,
+        )
+        ctx.scale = scale
+        ctx.set_materialize_grads(False)
+        if output_final_state:
+            return output, final_state
+        return output
+
+    @staticmethod
+    @torch.autograd.function.once_differentiable
+    def backward(ctx, d_output, d_final_state=None):
+        (
+            q,
+            k,
+            v,
+            cumulative_gate,
+            beta,
+            inverse,
+            initial_state,
+            cu_seqlens,
+            chunk_offsets,
+        ) = ctx.saved_tensors
+        if d_output is None:
+            d_output = torch.zeros_like(v)
+        if torch.compiler.is_compiling():
+            args = (
+                q,
+                k,
+                v,
+                cumulative_gate,
+                beta,
+                inverse,
+                d_output,
+                d_final_state,
+                initial_state,
+                cu_seqlens,
+                chunk_offsets,
+                ctx.scale,
+            )
+            if initial_state is not None:
+                dq, dk, dv, d_gate, db, d_initial_state = chunk_bwd_with_state_grad_op(*args)
+            else:
+                dq, dk, dv, d_gate, db = chunk_bwd_op(*args)
+                d_initial_state = None
+        else:
+            backend = _chunk_backend()
+            metadata = backend.resolve_backward_metadata(q, cu_seqlens, chunk_offsets)
+            dq, dk, dv, d_gate, db, d_initial_state = backend.chunk_gdn_bwd(
+                q,
+                k,
+                v,
+                cumulative_gate,
+                beta,
+                inverse,
+                d_output,
+                d_final_state,
+                initial_state,
+                metadata,
+                ctx.scale,
+            )
+        return dq, dk, dv, d_gate, db, d_initial_state, None, None, None, None, None
+
+
+def chunk_forward(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    *,
+    cu_seqlens: torch.Tensor | None,
+    scale: float,
+    output_final_state: bool,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Normalize dense inputs and invoke the fused scalar chunk forward operator."""
+    if not q.is_cuda:
+        raise ValueError("chunk_gdn(impl='fused') requires CUDA tensors")
+    if q.dtype not in (torch.float16, torch.bfloat16) or k.dtype != q.dtype or v.dtype != q.dtype:
+        raise TypeError("chunk_gdn(impl='fused') requires matching float16 or bfloat16 QKV")
+    if q.shape[-1] != 128 or v.shape[-1] != 128:
+        raise ValueError("chunk_gdn(impl='fused') requires K=V=128")
+    if not torch.compiler.is_compiling() and get_device_properties(q.device).major < 10:
+        raise ValueError("chunk_gdn(impl='fused') requires CUDA capability 10.0 or newer")
+    output_shape = v.shape
+    batch, tokens = q.shape[:2]
+    if cu_seqlens is not None and batch != 1:
+        raise ValueError("explicit packed chunk_gdn requires batch size one")
+    if cu_seqlens is None and (batch != 1 or tokens % 64):
+        q = q.reshape(1, batch * tokens, q.shape[2], q.shape[3])
+        k = k.reshape(1, batch * tokens, k.shape[2], k.shape[3])
+        v = v.reshape(1, batch * tokens, v.shape[2], v.shape[3])
+        gate = gate.reshape(1, batch * tokens, gate.shape[2])
+        beta = beta.reshape(1, batch * tokens, beta.shape[2])
+        cu_seqlens = torch.arange(batch + 1, dtype=torch.int32, device=q.device) * tokens
+
+    metadata = (
+        prepare_ragged_chunk_metadata(cu_seqlens, q.shape[1], 64)
+        if cu_seqlens is not None
+        else None
+    )
+    q, k, v = (tensor.contiguous() for tensor in (q, k, v))
+    gate = gate.float().contiguous()
+    beta = beta.float().contiguous()
+    if initial_state is not None:
+        initial_state = initial_state.float().contiguous()
+    chunk_offsets = None if metadata is None else metadata.chunk_offsets
+    capacity = 0 if metadata is None else metadata.capacity
+    result = _ChunkGDN.apply(
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        initial_state,
+        cu_seqlens,
+        chunk_offsets,
+        capacity,
+        scale,
+        output_final_state,
+    )
+    if output_final_state:
+        output, final_state = result
+        return output.reshape(output_shape), final_state
+    return result.reshape(output_shape), None
 
 
 def recurrent_forward(
@@ -234,6 +653,13 @@ def recurrent_decode_forward(
 
 
 __all__ = [
+    "chunk_bwd_op",
+    "chunk_bwd_with_state_grad_op",
+    "chunk_forward",
+    "chunk_fwd_op",
+    "chunk_fwd_packed_op",
+    "chunk_fwd_packed_with_state_op",
+    "chunk_fwd_with_state_op",
     "recurrent_decode_forward",
     "recurrent_decode_op",
     "recurrent_forward",

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -21,6 +21,7 @@ with the slot count. `chunk_gdn` uses a chunk-parallel decomposition for trainin
 `recurrent_gdn` consumes
 tokens in order for decoding, inference prefill, and state-carrying correctness checks. The caller
 chooses the execution form explicitly. `impl="reference"` selects eager PyTorch;
+`chunk_gdn(..., impl="fused")` selects the training-capable Blackwell chunk pipeline, while
 `recurrent_gdn(..., impl="fused")` selects the inference-only Triton scan.
 
 ```python
@@ -32,7 +33,7 @@ output, final_state = chunk_gdn(
     value,
     gate,
     beta,
-    impl="reference",
+    impl="fused",
     output_final_state=True,
 )
 ```
@@ -43,20 +44,28 @@ output, final_state = chunk_gdn(
   with `cu_seqlens`.
 - Separate recurrent and chunked operations with explicit initial and final state.
 - CPU and CUDA execution through eager PyTorch operations.
+- A training-capable fused chunk implementation on SM100/SM103 with dense, packed, tail, empty-
+  sequence, grouped Q/K-head, initial/final-state, strict `torch.compile`, and CUDA Graph support.
 - An inference-only fused recurrent implementation on CUDA, including mutable paged state caches
   shaped `[num_slots, H, V, K]` selected by `state_indices`.
-- Autograd for reference inputs and initial state.
+- Autograd for the reference and fused chunk implementations, including initial-state gradients.
 - Q/K/V share one dtype. FP16 and BF16 inputs use FP32 recurrence math and state while returning
   output in the Q dtype.
 - Gate and beta may use independent floating dtypes and are converted to the recurrence compute
   dtype. A provided initial state uses FP32 for low-precision QKV.
 - FP64 reference inputs retain FP64 recurrence math and state.
 
+The fused chunk implementation requires SM100/SM103, matching FP16 or BF16 Q/K/V, and
+`K = V = 128`. Its scalar natural-log gate is not lower-bounded: the kernels contract raw QK/KK
+first and apply only masked, nonpositive causal decay differences, avoiding KDA's reciprocal gate
+factorization. The public chunk size is BT64; internal 16x16 blocks are only the hierarchical
+triangular-solve representation and do not constrain gate values or semantic chunking. Ordinary
+layouts use int32 addressing; layouts requiring int64 tensor offsets are rejected until every new
+kernel has a wide-address specialization.
+
 The fused recurrent implementation requires CUDA with Triton, Q/K/V in FP16, BF16, or FP32, and
 `K <= 256`. Packed offsets must begin at zero, be nondecreasing, and end within the physical token
-capacity. Output rows beyond the terminal offset are inactive capacity and unspecified. The fused
-chunk implementation is not implemented yet; unsupported implementation choices fail rather than
-falling back to the reference.
+capacity. Output rows beyond the terminal offset are inactive capacity and unspecified.
 
 ### Migration from the prototype API
 

--- a/test/linear/test_gdn.py
+++ b/test/linear/test_gdn.py
@@ -307,9 +307,7 @@ def test_impl_accepts_enum_and_string(function):
 
     with pytest.raises(ValueError, match="'fused', 'reference'"):
         function(*inputs[:-1], impl="eager")
-    error = NotImplementedError if function is chunk_gdn else ValueError
-    message = "impl='fused'" if function is chunk_gdn else "requires CUDA tensors"
-    with pytest.raises(error, match=message):
+    with pytest.raises(ValueError, match="requires CUDA tensors"):
         function(*inputs[:-1], impl=Impl.FUSED)
 
 

--- a/test/linear/test_gdn_chunk_fused.py
+++ b/test/linear/test_gdn_chunk_fused.py
@@ -1,0 +1,570 @@
+"""Numerical, registration, and compilation coverage for fused chunk GDN."""
+
+from __future__ import annotations
+
+from functools import partial
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from attn_gym.linear import chunk_gdn
+from attn_gym.linear.gdn.bwd.triton.chunk_gdn_bwd_intra import (
+    chunk_gdn_bwd_intra_dense,
+)
+from attn_gym.linear.gdn.ops import (
+    chunk_bwd_op,
+    chunk_bwd_with_state_grad_op,
+    chunk_fwd_op,
+    chunk_fwd_packed_op,
+    chunk_fwd_packed_with_state_op,
+    chunk_fwd_with_state_op,
+)
+from attn_gym.linear.kda.chunk_schedule import prepare_ragged_chunk_metadata
+from attn_gym.linear.kda.ops import _plain_gate_scan_op
+from attn_gym.testing.kda import assert_matches_low_precision_reference
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (10, 0),
+    reason="fused chunk GDN requires CUDA capability 10.0 or newer",
+)
+
+
+def make_inputs(
+    *,
+    batch: int = 1,
+    tokens: int = 64,
+    key_heads: int = 2,
+    value_heads: int = 2,
+    gate_kind: str = "mild",
+    dtype: torch.dtype = torch.bfloat16,
+    requires_grad: bool = False,
+) -> tuple[torch.Tensor, ...]:
+    """Create deterministic quantized inputs with a selected unbounded-gate regime."""
+    torch.manual_seed(23)
+    qk_shape = (batch, tokens, key_heads, 128)
+    value_shape = (batch, tokens, value_heads, 128)
+    q = F.normalize(torch.randn(qk_shape, device="cuda"), dim=-1).to(dtype)
+    k = F.normalize(torch.randn(qk_shape, device="cuda"), dim=-1).to(dtype)
+    v = torch.randn(value_shape, device="cuda", dtype=dtype)
+    match gate_kind:
+        case "mild":
+            gate = -F.softplus(torch.randn(value_shape[:3], device="cuda"))
+        case "spikes":
+            gate = torch.full(value_shape[:3], -0.1, device="cuda")
+            gate[:, 7::16] = -20.0
+        case "unbounded":
+            gate = torch.full(value_shape[:3], -20.0, device="cuda")
+        case _:
+            raise ValueError(f"unknown gate kind {gate_kind!r}")
+    beta = torch.sigmoid(torch.randn(value_shape[:3], device="cuda"))
+    state = torch.randn(batch, value_heads, 128, 128, device="cuda")
+    tensors = (q, k, v, gate, beta, state)
+    if requires_grad:
+        tensors = tuple(tensor.requires_grad_() for tensor in tensors)
+    return tensors
+
+
+def misaligned_like(tensor: torch.Tensor) -> torch.Tensor:
+    """Copy into contiguous storage beginning one element past an aligned allocation."""
+    storage = torch.empty(tensor.numel() + 1, dtype=tensor.dtype, device=tensor.device)
+    result = storage[1:].view(tensor.shape)
+    result.copy_(tensor)
+    assert result.is_contiguous() and result.data_ptr() % 16 != 0
+    return result
+
+
+def run_with_gradients(
+    inputs: tuple[torch.Tensor, ...],
+    impl: str,
+    cu_seqlens: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, ...]:
+    """Run output/state and all input gradients under one shared scalar loss."""
+    output, state = chunk_gdn(
+        *inputs[:5],
+        inputs[5],
+        cu_seqlens=cu_seqlens,
+        output_final_state=True,
+        impl=impl,
+    )
+    assert state is not None
+    gradients = torch.autograd.grad(
+        output.float().square().mean() + state.float().square().mean(), inputs
+    )
+    return output, state, *gradients
+
+
+@pytest.mark.parametrize(
+    ("batch", "tokens", "key_heads", "value_heads", "gate_kind", "lengths"),
+    [
+        (1, 64, 2, 2, "mild", None),
+        (1, 65, 1, 4, "spikes", None),
+        (2, 65, 1, 4, "mild", None),
+        (1, 64, 1, 1, "unbounded", None),
+        (1, 192, 1, 4, "spikes", [65, 0, 127]),
+    ],
+)
+def test_fused_chunk_matches_low_precision_reference(
+    batch: int,
+    tokens: int,
+    key_heads: int,
+    value_heads: int,
+    gate_kind: str,
+    lengths: list[int] | None,
+):
+    """Bound fused forward and all gradients by the eager low-precision error."""
+    inputs = make_inputs(
+        batch=batch,
+        tokens=tokens,
+        key_heads=key_heads,
+        value_heads=value_heads,
+        gate_kind=gate_kind,
+        requires_grad=True,
+    )
+    if lengths is not None:
+        offsets = [0]
+        for length in lengths:
+            offsets.append(offsets[-1] + length)
+        cu_seqlens = torch.tensor(offsets, device="cuda", dtype=torch.int32)
+        inputs = (
+            *inputs[:5],
+            torch.randn(
+                len(lengths),
+                value_heads,
+                128,
+                128,
+                device="cuda",
+                requires_grad=True,
+            ),
+        )
+    else:
+        cu_seqlens = None
+
+    fused_inputs = tuple(tensor.detach().clone().requires_grad_() for tensor in inputs)
+    reference_inputs = tuple(tensor.detach().clone().requires_grad_() for tensor in inputs)
+    golden_inputs = tuple(tensor.detach().double().requires_grad_() for tensor in inputs)
+    actual = run_with_gradients(fused_inputs, "fused", cu_seqlens)
+    expected = run_with_gradients(reference_inputs, "reference", cu_seqlens)
+    golden = run_with_gradients(golden_inputs, "reference", cu_seqlens)
+
+    for name, result, high_precision, reference in zip(
+        ("output", "state", "dq", "dk", "dv", "dgate", "dbeta", "dstate"),
+        actual,
+        golden,
+        expected,
+        strict=True,
+    ):
+        if high_precision.abs().max().item() < 1e-12:
+            assert torch.isfinite(result).all()
+            assert (result.double() - high_precision).abs().max().item() <= 1e-12
+        else:
+            assert_matches_low_precision_reference(result, high_precision, reference, name)
+
+    if lengths is not None:
+        torch.testing.assert_close(actual[1][1], inputs[5][1], rtol=0, atol=0)
+
+
+def test_fp16_fused_chunk_matches_reference():
+    """Validate the advertised FP16 forward and gradient path."""
+    inputs = make_inputs(tokens=64, dtype=torch.float16, requires_grad=True)
+    fused_inputs = tuple(tensor.detach().clone().requires_grad_() for tensor in inputs)
+    reference_inputs = tuple(tensor.detach().clone().requires_grad_() for tensor in inputs)
+    golden_inputs = tuple(tensor.detach().double().requires_grad_() for tensor in inputs)
+    actual = run_with_gradients(fused_inputs, "fused")
+    expected = run_with_gradients(reference_inputs, "reference")
+    golden = run_with_gradients(golden_inputs, "reference")
+    for name, result, high_precision, reference in zip(
+        ("output", "state", "dq", "dk", "dv", "dgate", "dbeta", "dstate"),
+        actual,
+        golden,
+        expected,
+        strict=True,
+    ):
+        if name == "dstate":
+            # dstate crosses both the forward state restage and reverse-state recurrence;
+            # account for both low-precision boundaries while retaining a normalized guard.
+            high = high_precision.double()
+            actual_error = (result.double() - high).abs().max().item()
+            reference_error = (reference.double() - high).abs().max().item()
+            rounding = torch.finfo(torch.float16).eps * high.abs().max().item()
+            assert actual_error <= 4 * (reference_error + rounding)
+            relative_rms = torch.linalg.vector_norm(
+                result.double() - high
+            ) / torch.linalg.vector_norm(high).clamp_min(1e-30)
+            assert relative_rms.item() <= 5e-2
+        else:
+            assert_matches_low_precision_reference(
+                result,
+                high_precision,
+                reference,
+                name,
+                source_dtype=torch.float16,
+            )
+
+
+def test_packed_tail_ignores_nan_capacity_slack():
+    """Never evaluate or consume storage beyond the terminal packed offset."""
+    q, k, v, gate, beta, _state = make_inputs(tokens=192)
+    state = torch.randn(2, v.shape[2], 128, 128, device="cuda")
+    active_tokens = 127
+    for tensor in (q, k, v, gate, beta):
+        tensor[:, active_tokens:] = torch.nan
+    cu_seqlens = torch.tensor([0, 65, active_tokens], device="cuda", dtype=torch.int32)
+    actual_output, actual_state = chunk_gdn(
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        state,
+        cu_seqlens=cu_seqlens,
+        output_final_state=True,
+        impl="fused",
+    )
+    expected_output, expected_state = chunk_gdn(
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        state,
+        cu_seqlens=cu_seqlens,
+        output_final_state=True,
+        impl="reference",
+    )
+    assert actual_state is not None and expected_state is not None
+    assert torch.isfinite(actual_output[:, :active_tokens]).all()
+    torch.testing.assert_close(
+        actual_output[:, :active_tokens],
+        expected_output[:, :active_tokens],
+        rtol=2e-2,
+        atol=2e-3,
+    )
+    torch.testing.assert_close(actual_state, expected_state, rtol=2e-2, atol=2e-3)
+
+
+def test_packed_backward_zeros_capacity_slack():
+    """Return exact zero gradients for physical rows beyond the terminal packed offset."""
+    inputs = make_inputs(tokens=192, requires_grad=True)
+    state = torch.randn(2, inputs[2].shape[2], 128, 128, device="cuda", requires_grad=True)
+    leaves = (*inputs[:5], state)
+    active_tokens = 127
+    cu_seqlens = torch.tensor([0, 65, active_tokens], device="cuda", dtype=torch.int32)
+    output, final_state = chunk_gdn(
+        *leaves[:5],
+        leaves[5],
+        cu_seqlens=cu_seqlens,
+        output_final_state=True,
+        impl="fused",
+    )
+    assert final_state is not None
+    gradients = torch.autograd.grad(
+        output[:, :active_tokens].float().square().mean() + final_state.float().square().mean(),
+        leaves,
+    )
+    for gradient in gradients[:5]:
+        torch.testing.assert_close(
+            gradient[:, active_tokens:],
+            torch.zeros_like(gradient[:, active_tokens:]),
+            rtol=0,
+            atol=0,
+        )
+
+
+def test_scalar_intra_masks_poisoned_akk_diagonal_and_upper():
+    """Treat only strict-lower dAkk entries as meaningful before any arithmetic."""
+    q, k, _v, _gate, beta, _state = make_inputs(tokens=64, key_heads=1, value_heads=1)
+    cumulative_gate = (-20.0 * torch.arange(1, 65, device="cuda")).view(1, 64, 1)
+    d_aqk = torch.randn(1, 64, 1, 64, device="cuda")
+    d_akk = torch.randn_like(d_aqk)
+    row = torch.arange(64, device="cuda")
+    strict = row[:, None] > row[None, :]
+    clean_d_akk = torch.where(strict[None, :, None, :], d_akk, 0.0)
+    poisoned_d_akk = torch.where(strict[None, :, None, :], d_akk, torch.nan)
+    d_gate_raw = torch.zeros_like(q, dtype=torch.float32)
+    expected = chunk_gdn_bwd_intra_dense(
+        q, k, cumulative_gate, beta, d_aqk, clean_d_akk, d_gate_raw
+    )
+    actual = chunk_gdn_bwd_intra_dense(
+        q, k, cumulative_gate, beta, d_aqk, poisoned_d_akk, d_gate_raw
+    )
+    for result, reference in zip(actual, expected, strict=True):
+        assert torch.isfinite(result).all()
+        torch.testing.assert_close(result, reference, rtol=0, atol=0)
+
+
+def test_misaligned_contiguous_inputs_and_cotangent():
+    """Normalize valid storage-offset views at the opaque kernel boundary."""
+    q, k, v, gate, beta, state = make_inputs(tokens=64)
+    misaligned_inputs = (
+        misaligned_like(q).requires_grad_(),
+        k.requires_grad_(),
+        v.requires_grad_(),
+        gate.requires_grad_(),
+        misaligned_like(beta).requires_grad_(),
+        misaligned_like(state).requires_grad_(),
+    )
+    output, final_state = chunk_gdn(
+        *misaligned_inputs[:5],
+        misaligned_inputs[5],
+        output_final_state=True,
+        impl="fused",
+    )
+    assert final_state is not None
+    gradients = torch.autograd.grad(
+        output.float().square().mean() + final_state.float().square().mean(),
+        misaligned_inputs,
+    )
+    assert torch.isfinite(output).all()
+    assert all(torch.isfinite(gradient).all() for gradient in gradients)
+
+    args, _output, state_output, inverse = raw_args()
+    misaligned_d_output = misaligned_like(torch.randn_like(args[2]))
+    backward_args = (
+        *args[:5],
+        inverse,
+        misaligned_d_output,
+        torch.randn_like(state_output),
+        args[5],
+        None,
+        None,
+        args[6],
+    )
+    outputs = chunk_bwd_with_state_grad_op(*backward_args)
+    assert all(torch.isfinite(result).all() for result in outputs)
+
+
+def test_no_state_output_only_and_state_only_gradients():
+    """Exercise no-state/no-final-state and a missing output cotangent."""
+    inputs = make_inputs(tokens=64, key_heads=1, value_heads=4, requires_grad=True)
+    output, state = chunk_gdn(*inputs[:5], impl="fused")
+    assert state is None
+    output_gradients = torch.autograd.grad(output.float().square().mean(), inputs[:5])
+    assert all(torch.isfinite(gradient).all() for gradient in output_gradients)
+
+    state_inputs = tuple(tensor.detach().clone().requires_grad_() for tensor in inputs)
+    _output, final_state = chunk_gdn(
+        *state_inputs[:5],
+        state_inputs[5],
+        output_final_state=True,
+        impl="fused",
+    )
+    assert final_state is not None
+    state_gradients = torch.autograd.grad(final_state.square().mean(), state_inputs)
+    assert all(torch.isfinite(gradient).all() for gradient in state_gradients)
+
+
+def test_int64_layouts_fail_before_kernel_launch(monkeypatch):
+    """Reject wide layouts until every new Triton kernel has an i64 specialization."""
+    import attn_gym.linear.gdn.impl.chunk as chunk_impl
+
+    monkeypatch.setattr(chunk_impl, "requires_int64_offsets", lambda *args: True)
+    inputs = make_inputs(tokens=64)
+    with pytest.raises(ValueError, match="int64 tensor offsets"):
+        chunk_gdn(*inputs[:5], impl="fused")
+
+
+def test_raw_ops_reject_pre_blackwell_devices(monkeypatch):
+    """Keep capability validation inside the real registered CUDA launcher."""
+    import attn_gym.linear.gdn.impl.chunk as chunk_impl
+
+    args, _output, _state, _inverse = raw_args()
+    monkeypatch.setattr(
+        chunk_impl,
+        "get_device_properties",
+        lambda device: SimpleNamespace(major=9),
+    )
+    with pytest.raises(ValueError, match="capability 10.0"):
+        chunk_fwd_with_state_op(*args)
+
+
+def raw_args(tokens: int = 64, heads: int = 2):
+    """Construct detached raw-op arguments and their forward tapes."""
+    q, k, v, gate, beta, state = make_inputs(tokens=tokens, key_heads=heads, value_heads=heads)
+    cumulative = _plain_gate_scan_op(gate.unsqueeze(-1), None, None, False).squeeze(-1)
+    args = (q, k, v, cumulative, beta, state, 128**-0.5)
+    with torch.no_grad():
+        output, final_state, inverse = chunk_fwd_with_state_op(*args)
+    return args, output, final_state, inverse
+
+
+def test_dense_raw_operator_registration():
+    """Validate dense forward/backward schemas, fakes, and AOT dispatch."""
+    args, output, final_state, inverse = raw_args()
+    torch.library.opcheck(chunk_fwd_op, args)
+    torch.library.opcheck(chunk_fwd_with_state_op, args)
+    backward_args = (
+        *args[:5],
+        inverse,
+        torch.randn_like(output),
+        torch.randn_like(final_state),
+        args[5],
+        None,
+        None,
+        args[6],
+    )
+    utilities = ("test_schema", "test_faketensor", "test_aot_dispatch_dynamic")
+    torch.library.opcheck(chunk_bwd_op, backward_args, test_utils=utilities)
+    torch.library.opcheck(chunk_bwd_with_state_grad_op, backward_args, test_utils=utilities)
+
+
+def test_packed_raw_operator_registration():
+    """Validate fixed-capacity packed forward/backward registrations."""
+    q, k, v, gate, beta, _state = make_inputs(tokens=128)
+    state = torch.randn(2, v.shape[2], 128, 128, device="cuda")
+    cu_seqlens = torch.tensor([0, 65, 128], device="cuda", dtype=torch.int32)
+    metadata = prepare_ragged_chunk_metadata(cu_seqlens, q.shape[1], 64)
+    cumulative = _plain_gate_scan_op(
+        gate.unsqueeze(-1), cu_seqlens, metadata.chunk_offsets, False
+    ).squeeze(-1)
+    args = (
+        q,
+        k,
+        v,
+        cumulative,
+        beta,
+        state,
+        cu_seqlens,
+        metadata.chunk_offsets,
+        metadata.capacity,
+        128**-0.5,
+    )
+    torch.library.opcheck(chunk_fwd_packed_op, args)
+    torch.library.opcheck(chunk_fwd_packed_with_state_op, args)
+    with torch.no_grad():
+        output, final_state, inverse = chunk_fwd_packed_with_state_op(*args)
+    backward_args = (
+        *args[:5],
+        inverse,
+        torch.randn_like(output),
+        torch.randn_like(final_state),
+        state,
+        cu_seqlens,
+        metadata.chunk_offsets,
+        128**-0.5,
+    )
+    utilities = ("test_schema", "test_faketensor", "test_aot_dispatch_dynamic")
+    torch.library.opcheck(chunk_bwd_op, backward_args, test_utils=utilities)
+    torch.library.opcheck(
+        chunk_bwd_with_state_grad_op,
+        backward_args,
+        test_utils=utilities,
+    )
+
+
+@pytest.mark.parametrize("packed", [False, True])
+def test_public_fullgraph_forward_backward(packed: bool):
+    """Compile the documented fused operation with strict forward/backward capture."""
+    tokens = 128 if packed else 64
+    inputs = make_inputs(tokens=tokens, key_heads=1, value_heads=4, requires_grad=True)
+    cu_seqlens = torch.tensor([0, 65, 128], device="cuda", dtype=torch.int32) if packed else None
+    if packed:
+        inputs = (
+            *inputs[:5],
+            torch.randn(2, 4, 128, 128, device="cuda", requires_grad=True),
+        )
+    expected_inputs = tuple(tensor.detach().clone().requires_grad_() for tensor in inputs)
+    expected = run_with_gradients(expected_inputs, "fused", cu_seqlens)
+    compiled = torch.compile(
+        partial(chunk_gdn, impl="fused", output_final_state=True),
+        fullgraph=True,
+    )
+    output, state = compiled(*inputs[:5], inputs[5], cu_seqlens=cu_seqlens)
+    assert state is not None
+    gradients = torch.autograd.grad(
+        output.float().square().mean() + state.float().square().mean(), inputs
+    )
+    actual = output, state, *gradients
+    for result, reference in zip(actual, expected, strict=True):
+        torch.testing.assert_close(result, reference, rtol=0, atol=0)
+
+
+def test_public_dynamic_tokens_forward_backward():
+    """Reuse one dynamic fullgraph callable across complete dense chunk counts."""
+    compiled = torch.compile(
+        partial(chunk_gdn, impl="fused", output_final_state=True),
+        fullgraph=True,
+        dynamic=True,
+    )
+    for tokens in (64, 128):
+        inputs = make_inputs(tokens=tokens, key_heads=1, value_heads=4, requires_grad=True)
+        output, state = compiled(*inputs[:5], inputs[5])
+        assert state is not None
+        gradients = torch.autograd.grad(
+            output.float().square().mean() + state.float().square().mean(), inputs
+        )
+        assert torch.isfinite(output).all()
+        assert all(torch.isfinite(gradient).all() for gradient in gradients)
+
+
+def test_backward_cuda_graph_replay():
+    """Capture and replay the training backward with fixed saved tensors."""
+    inputs = make_inputs(tokens=64, key_heads=1, value_heads=4, requires_grad=True)
+    output, state = chunk_gdn(
+        *inputs[:5],
+        inputs[5],
+        output_final_state=True,
+        impl="fused",
+    )
+    assert state is not None
+    d_output = torch.randn_like(output)
+    d_state = torch.randn_like(state)
+
+    def backward():
+        return torch.autograd.grad(
+            (output, state),
+            inputs,
+            grad_outputs=(d_output, d_state),
+            retain_graph=True,
+        )
+
+    backward()
+    torch.cuda.synchronize()
+    torch.autograd.graph.set_override_stale_capture_stream(True)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = backward()
+    graph.replay()
+    torch.cuda.synchronize()
+    actual = tuple(gradient.clone() for gradient in captured)
+    expected = backward()
+    torch.cuda.synchronize()
+    for result, reference in zip(actual, expected, strict=True):
+        torch.testing.assert_close(result, reference, rtol=0, atol=0)
+
+
+def test_packed_cuda_graph_replays_boundaries():
+    """Reread packed boundaries and chunk offsets on CUDA Graph replay."""
+    q, k, v, gate, beta, _state = make_inputs(tokens=128)
+    state = torch.randn(2, v.shape[2], 128, 128, device="cuda")
+    cu_seqlens = torch.tensor([0, 64, 128], device="cuda", dtype=torch.int32)
+
+    def run():
+        return chunk_gdn(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            state,
+            cu_seqlens=cu_seqlens,
+            output_final_state=True,
+            impl="fused",
+        )
+
+    for _ in range(2):
+        run()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = run()
+
+    cu_seqlens.copy_(torch.tensor([0, 65, 128], device="cuda", dtype=torch.int32))
+    graph.replay()
+    torch.cuda.synchronize()
+    actual = captured[0].clone(), captured[1].clone()
+    expected = run()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(actual[0], expected[0], rtol=0, atol=0)
+    torch.testing.assert_close(actual[1], expected[1], rtol=0, atol=0)


### PR DESCRIPTION
Stacked PRs:
 * __->__#422
 * #423


--- --- ---

Add fused chunk GDN training backend

## Human Note

## Agent note

Implement a repo-local, training-capable `chunk_gdn(..., impl="fused")` backend without an FLA
runtime dependency. The scalar-gate kernels contract raw KK/QK before applying masked causal decay,
so finite nonpositive gates remain valid without KDA's reciprocal-factor lower bound. The public
path supports dense and packed tails, empty sequences, GQA, initial/final state, autograd, fake/AOT
operators, strict fullgraph compilation, dynamic shapes, and CUDA Graph replay.

Backward safely recomputes Aqk, reuses the proven KDA delta-H/WY stages, and finishes with a tuned
scalar intra VJP that fuses K-channel gate reduction with the chunk-local reverse scan. Alignment,
unsupported wide offsets, inactive packed capacity, and pre-Blackwell devices fail or normalize at
the opaque boundary rather than reaching unsafe kernels.

## Performance

B200, B1/H64/K=V=128/BF16, fixed-pointer warm-cache medians:

| T | fused forward | FLA forward | fused backward | FLA backward |
|---:|---:|---:|---:|---:|
| 4096 | 406.6 us | 434.2 us | 1175.6 us | 1311.8 us |
| 8192 | 763.9 us | 820.3 us | 4737.5 us | 5184.0 us |

T1024 eager timing is launch/DVFS-bimodal. Under CUDA Graph replay, fused backward is 315.5 us
versus 372.4 us for FLA at T1024 and 1131.5 us versus 1299.6 us at T4096.

## Test Plan

```bash
gpu-run --timeout 30 auto -- timeout --signal=TERM --kill-after=5s 300s \
  .venv/bin/pytest -q -n 6 \
  test/linear/test_gdn.py test/linear/test_gdn_chunk_fused.py test/test_namespaces.py
files=(${(f)"$(git diff --name-only; git ls-files --others --exclude-standard)"}); \
  .venv/bin/prek run --files $files
.venv/bin/ruff check attn_gym/linear/gdn \
  test/linear/test_gdn.py test/linear/test_gdn_chunk_fused.py
```