### PR TITLE
Tune fused KDA backward register budget

### DIFF
--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_wy_dqkg_fused.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_wy_dqkg_fused.py
@@ -523,8 +523,9 @@ class ChunkKdaBwdWyDqkgFused:
         self.aux_warp_ids = (10, 11)  # WG2: Aux/Load/Store Aux
         self.threads_per_cta = self.threads_per_warp * 12  # 384 threads (3 WGs)
 
-        self.num_regs_cuda = 208
-        self.num_regs_others = 88
+        # Keep the CTA register pool fixed while favoring the long CUDA-core epilogue.
+        self.num_regs_cuda = 224
+        self.num_regs_others = 56
         if grid_waves < 1:
             raise ValueError(f"grid_waves must be positive, got {grid_waves}")
         self.grid_waves = grid_waves


### PR DESCRIPTION
Stacked PRs:
 * #422
 * __->__#423


--- --- ---

Tune fused KDA backward register budget

## Human Note

## Agent note

Shift the fixed CTA register budget from the four producer/MMA/aux warps to the eight
CUDA-core warps. Intra-kernel tracing showed the long CUDA epilogue gated the auxiliary dG
store, while a two-stage G buffer would exceed the kernel's shared-memory budget.

The generated SM100a kernel uses the requested 224/56 register split with no local-memory
allocation, and all six WY outputs remain bitwise identical to the previous split.

## Performance

B200, B1/H64/K=V=128/BF16, fixed-pointer warm-cache:

| workload | before | after | change |
|---|---:|---:|---:|
| isolated WY, T4096 | 295.38 us | 255.92 us | -13.4% |
| public GDN backward, T4096 | 1175.6 us | 1109.5 us | -5.6% |

## Test Plan

```bash
PYTHONPATH=$PWD TORCH_CUSTOM_PYTHONPATH=$PWD .venv/bin/pytest -n 6 \
  test/linear/test_gdn.py test/linear/test_gdn_chunk_fused.py test/test_namespaces.py -q
PYTHONPATH=$PWD TORCH_CUSTOM_PYTHONPATH=$PWD .venv/bin/pytest -n 6 \
  test/test_kda_kernels.py::test_chunk_kda_bwd_wy_dqkg_fused_cute \
  test/test_kda_ragged_bwd_wy.py -q
prek run --files attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_wy_dqkg_fused.py
```