### PR TITLE
Add fused chunk GDN training backend

### DIFF
--- a/attn_gym/_backends/cute/__init__.py
+++ b/attn_gym/_backends/cute/__init__.py
@@ -8,8 +8,11 @@ from .utils import (
     compile_tvm_ffi,
     get_device_properties,
     make_fake_strided_tensor,
+    normalize_compact_tensor,
+    normalize_tma_rows,
     tensor_supports_contiguous_dim,
     tensor_supports_tma,
+    tensor_supports_tma_rows,
 )
 
 __all__ = [
@@ -21,8 +24,11 @@ __all__ = [
     "get_device_properties",
     "jit_cache",
     "make_fake_strided_tensor",
+    "normalize_compact_tensor",
+    "normalize_tma_rows",
     "run_tunable",
     "tensor_supports_contiguous_dim",
     "tensor_supports_tma",
+    "tensor_supports_tma_rows",
     "tune",
 ]

--- a/attn_gym/_backends/cute/utils.py
+++ b/attn_gym/_backends/cute/utils.py
@@ -130,6 +130,34 @@ def tensor_supports_tma(tensor: torch.Tensor) -> bool:
     )
 
 
+def tensor_supports_tma_rows(tensor: torch.Tensor) -> bool:
+    """Return whether the last two modes form aligned, compact rows for TMA kernels."""
+    return (
+        tensor.ndim >= 2 and tensor.stride(-2) == tensor.shape[-1] and tensor_supports_tma(tensor)
+    )
+
+
+def normalize_tma_rows(tensor: torch.Tensor) -> torch.Tensor:
+    """Copy unless the tensor satisfies the aligned, compact-row TMA contract."""
+    if tensor_supports_tma_rows(tensor):
+        return tensor
+    return tensor.clone(memory_format=torch.contiguous_format)
+
+
+def normalize_compact_tensor(
+    tensor: torch.Tensor,
+    *,
+    alignment_bytes: int = 128,
+) -> torch.Tensor:
+    """Copy unless the full tensor is compact with aligned slice origins."""
+    if tensor.is_contiguous() and tensor_supports_contiguous_dim(
+        tensor,
+        alignment_bytes=alignment_bytes,
+    ):
+        return tensor
+    return tensor.clone(memory_format=torch.contiguous_format)
+
+
 def compile_tvm_ffi(
     entrypoint: Any,
     *compile_args: Any,
@@ -177,6 +205,9 @@ __all__ = [
     "compile_tvm_ffi",
     "get_device_properties",
     "make_fake_strided_tensor",
+    "normalize_compact_tensor",
+    "normalize_tma_rows",
     "tensor_supports_contiguous_dim",
     "tensor_supports_tma",
+    "tensor_supports_tma_rows",
 ]

--- a/attn_gym/linear/gdn/__init__.py
+++ b/attn_gym/linear/gdn/__init__.py
@@ -1,5 +1,5 @@
 """Gated delta rule attention."""
 
-from attn_gym.linear.gdn.api import chunk_gdn, recurrent_gdn, recurrent_gdn_decode
+from attn_gym.linear.gdn.api import KernelOptions, chunk_gdn, recurrent_gdn, recurrent_gdn_decode
 
-__all__ = ["chunk_gdn", "recurrent_gdn", "recurrent_gdn_decode"]
+__all__ = ["KernelOptions", "chunk_gdn", "recurrent_gdn", "recurrent_gdn_decode"]

--- a/attn_gym/linear/gdn/api.py
+++ b/attn_gym/linear/gdn/api.py
@@ -12,9 +12,11 @@ from attn_gym.linear._delta_rule.validation import (
 )
 from attn_gym.linear.gdn.impl.mega import chunk_forward as mega_chunk_forward
 from attn_gym.linear.gdn.impl.reference import chunk_forward, recurrent_forward, reference_gdn
+from attn_gym.linear.gdn.ops import chunk_forward as fused_chunk_forward
 from attn_gym.linear.gdn.ops import recurrent_decode_forward
 from attn_gym.linear.gdn.ops import recurrent_forward as fused_recurrent_forward
-from attn_gym.linear.gdn.validation import validate_gdn_inputs
+from attn_gym.linear.gdn.validation import resolve_kernel_options, validate_gdn_inputs
+from attn_gym.linear.types import BackendOptions as KernelOptions
 from attn_gym.linear.types import Impl, resolve_impl
 
 
@@ -30,6 +32,7 @@ def chunk_gdn(
     scale: float | None = None,
     output_final_state: bool = False,
     impl: Impl | str = Impl.REFERENCE,
+    kernel_options: KernelOptions | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Apply chunk-parallel gated delta rule attention for training and prefill.
 
@@ -53,17 +56,34 @@ def chunk_gdn(
             unspecified.
         scale: Query scale. Defaults to ``1 / sqrt(K)``.
         output_final_state: Return the final recurrent state with the output.
-        impl: ``"reference"`` uses eager PyTorch. ``"fused"`` uses the optional CuTeDSL 4.7
-            Mega backend on SM100/SM103 with FP16/BF16 QKV and ``K = V = 128``.
+        impl: ``"reference"`` uses eager PyTorch. ``"fused"`` uses the repo-local scalar chunk
+            pipeline on CUDA capability 9.0+ with FP16/BF16 QKV and ``K = V = 128``.
+        kernel_options: Backend-specific options for fused execution. The repo-local path is the
+            default; ``{"backend": "mega"}`` selects the optional CuTeDSL 4.7 Mega backend.
 
     Returns:
         The output in ``q.dtype`` and either the final recurrent state or ``None``.
     """
     selected_impl = resolve_impl(impl)
+    backend = resolve_kernel_options(kernel_options)
+    if selected_impl is Impl.REFERENCE and kernel_options:
+        raise ValueError("kernel_options are not supported with impl='reference'")
     validate_gdn_inputs(q, k, v, gate, beta, initial_state, cu_seqlens)
     scale = resolve_scale(scale, q.shape[-1])
     if selected_impl is Impl.FUSED:
-        return mega_chunk_forward(
+        if backend == "mega":
+            return mega_chunk_forward(
+                q,
+                k,
+                v,
+                gate,
+                beta,
+                initial_state,
+                cu_seqlens=cu_seqlens,
+                scale=scale,
+                output_final_state=output_final_state,
+            )
+        return fused_chunk_forward(
             q,
             k,
             v,
@@ -292,4 +312,4 @@ def recurrent_gdn_decode(
     )
 
 
-__all__ = ["chunk_gdn", "recurrent_gdn", "recurrent_gdn_decode"]
+__all__ = ["KernelOptions", "chunk_gdn", "recurrent_gdn", "recurrent_gdn_decode"]

--- a/attn_gym/linear/gdn/bwd/__init__.py
+++ b/attn_gym/linear/gdn/bwd/__init__.py
@@ -1,0 +1,1 @@
+"""Fused chunk GDN backward kernels."""

--- a/attn_gym/linear/gdn/bwd/triton/__init__.py
+++ b/attn_gym/linear/gdn/bwd/triton/__init__.py
@@ -1,0 +1,1 @@
+"""Triton fused chunk GDN backward kernels."""

--- a/attn_gym/linear/gdn/bwd/triton/chunk_gdn_bwd_delta_h.py
+++ b/attn_gym/linear/gdn/bwd/triton/chunk_gdn_bwd_delta_h.py
@@ -1,0 +1,440 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+# Copyright (c) 2026 Meta Platforms, Inc. and affiliates.
+#
+# Portions are derived from flash-linear-attention and licensed under the MIT license;
+# see https://github.com/fla-org/flash-linear-attention/graphs/contributors.
+# The remaining portions use the BSD-style license in the repository root.
+
+"""Scalar-gate delta-state backward specialized for BT64 and K=V=128."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from attn_gym._backends.triton.utils import ptr_offset
+from attn_gym.linear.kda.chunk_scheduler import (
+    RaggedChunkMetadata,
+    load_ragged_chunk_count,
+    load_ragged_chunk_work,
+    load_ragged_sequence_work,
+)
+
+
+@triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
+@triton.jit(do_not_specialize=["num_sequences"])
+def chunk_gdn_bwd_dv_local_kernel(
+    q,
+    k,
+    q_stride_t,
+    k_stride_t,
+    cumulative_gate,
+    d_output,
+    dv_local,
+    cu_seqlens,
+    chunk_offsets,
+    scale,
+    num_sequences,
+    H: tl.constexpr,
+    HK: tl.constexpr,
+    GROUPS: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    """Compute the causal within-chunk value gradient for one value head."""
+    chunk = tl.program_id(0).to(tl.int64)
+    head = tl.program_id(1).to(tl.int64)
+    if IS_VARLEN:
+        if chunk >= load_ragged_chunk_count(chunk_offsets, num_sequences):
+            return
+        _sequence, _local_chunk, token_start, valid_tokens = load_ragged_chunk_work(
+            cu_seqlens,
+            chunk_offsets,
+            chunk,
+            num_sequences,
+            BT,
+        )
+        token_start = token_start.to(tl.int64)
+    else:
+        token_start = chunk * BT
+        valid_tokens = BT
+
+    row = tl.arange(0, BT)
+    token = token_start + row
+    token_mask = row < valid_tokens
+    key_head = head // GROUPS
+    gate = tl.load(
+        cumulative_gate + ptr_offset((token, head), (H, 1)),
+        mask=token_mask,
+        other=0.0,
+    ).to(tl.float32)
+
+    attention = tl.zeros((BT, BT), dtype=tl.float32)
+    for key_start in range(0, K, BK):
+        key = key_start + tl.arange(0, BK)
+        q_offset = ptr_offset((token[:, None], key_head, key[None, :]), (q_stride_t, K, 1))
+        k_offset = ptr_offset((token[:, None], key_head, key[None, :]), (k_stride_t, K, 1))
+        q_tile = tl.load(q + q_offset, mask=token_mask[:, None], other=0.0)
+        k_tile = tl.load(k + k_offset, mask=token_mask[:, None], other=0.0)
+        attention += tl.dot(k_tile, tl.trans(q_tile)) * scale
+
+    active = token_mask[:, None] & token_mask[None, :]
+    causal_transpose = row[:, None] <= row[None, :]
+    gate_delta = tl.where(active, gate[None, :] - gate[:, None], 0.0)
+    attention = tl.where(
+        causal_transpose & active,
+        attention * tl.exp2(gate_delta),
+        0.0,
+    )
+
+    for value_start in range(0, V, BV):
+        value = value_start + tl.arange(0, BV)
+        output_offset = ptr_offset((token[:, None], head, value[None, :]), (H * V, V, 1))
+        output_tile = tl.load(
+            d_output + output_offset,
+            mask=token_mask[:, None],
+            other=0.0,
+        )
+        value_gradient = tl.dot(attention.to(output_tile.dtype), output_tile)
+        tl.store(
+            dv_local + output_offset,
+            value_gradient.to(dv_local.dtype.element_ty),
+            mask=token_mask[:, None],
+        )
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+        "STORE_INITIAL_STATE_GRADIENT": lambda args: args["d_initial_state"] is not None,
+        "USE_FINAL_STATE_GRADIENT": lambda args: args["d_final_state"] is not None,
+    }
+)
+@triton.jit(do_not_specialize=["T", "num_sequences"])
+def chunk_gdn_bwd_delta_h_kernel(
+    q,
+    k,
+    q_stride_t,
+    k_stride_t,
+    w,
+    cumulative_gate,
+    d_output,
+    d_final_state,
+    d_initial_state,
+    dv_local,
+    dh,
+    dv,
+    cu_seqlens,
+    chunk_offsets,
+    scale,
+    T,
+    num_sequences,
+    H: tl.constexpr,
+    HK: tl.constexpr,
+    GROUPS: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    STORE_INITIAL_STATE_GRADIENT: tl.constexpr,
+    USE_FINAL_STATE_GRADIENT: tl.constexpr,
+):
+    """Traverse one sequence/head/value tile while keeping its state gradient resident."""
+    sequence_head = tl.program_id(0).to(tl.int64)
+    value_tile = tl.program_id(1).to(tl.int64)
+    sequence = sequence_head // H
+    head = sequence_head % H
+    if IS_VARLEN:
+        sequence_begin, sequence_end, chunk_begin = load_ragged_sequence_work(
+            cu_seqlens, chunk_offsets, sequence
+        )
+        sequence_begin = sequence_begin.to(tl.int64)
+        sequence_end = sequence_end.to(tl.int64)
+        chunk_begin = chunk_begin.to(tl.int64)
+        chunk_count = (sequence_end - sequence_begin + BT - 1) // BT
+    else:
+        sequence_begin = 0
+        sequence_end = T
+        chunk_begin = 0
+        chunk_count = T // BT
+
+    row = tl.arange(0, BT)
+    value = value_tile * BV + tl.arange(0, BV)
+    key_1 = tl.arange(0, BK)
+    key_2 = BK + key_1
+    key_head = head // GROUPS
+    d_state_1 = tl.zeros((BK, BV), dtype=tl.float32)
+    d_state_2 = tl.zeros((BK, BV), dtype=tl.float32)
+
+    state_base = ptr_offset((sequence, head), (H * V * K, V * K))
+    if USE_FINAL_STATE_GRADIENT:
+        final_offset_1 = state_base + ptr_offset((value[:, None], key_1[None, :]), (K, 1))
+        final_offset_2 = state_base + ptr_offset((value[:, None], key_2[None, :]), (K, 1))
+        d_state_1 += tl.trans(tl.load(d_final_state + final_offset_1)).to(tl.float32)
+        d_state_2 += tl.trans(tl.load(d_final_state + final_offset_2)).to(tl.float32)
+
+    for local_chunk in range(chunk_count - 1, -1, -1):
+        global_chunk = chunk_begin + local_chunk
+        token_start = sequence_begin + local_chunk * BT
+        valid_tokens = tl.minimum(BT, sequence_end - token_start)
+        token = token_start + row
+        token_mask = row < valid_tokens
+
+        dh_base = ptr_offset((global_chunk, head), (H * K * V, K * V))
+        dh_offset_1 = dh_base + ptr_offset((key_1[:, None], value[None, :]), (V, 1))
+        dh_offset_2 = dh_base + ptr_offset((key_2[:, None], value[None, :]), (V, 1))
+        tl.store(dh + dh_offset_1, d_state_1.to(dh.dtype.element_ty))
+        tl.store(dh + dh_offset_2, d_state_2.to(dh.dtype.element_ty))
+
+        gate_offset = ptr_offset((token, head), (H, 1))
+        gate = tl.load(
+            cumulative_gate + gate_offset,
+            mask=token_mask,
+            other=0.0,
+        ).to(tl.float32)
+        final_gate = tl.sum(tl.where(row == valid_tokens - 1, gate, 0.0), axis=0)
+        restored_decay = tl.where(
+            token_mask,
+            tl.exp2(tl.where(token_mask, final_gate - gate, 0.0)),
+            0.0,
+        )
+
+        q_base = ptr_offset((token[:, None], key_head), (q_stride_t, K))
+        k_base = ptr_offset((token[:, None], key_head), (k_stride_t, K))
+        k_tile_1 = tl.load(
+            k + k_base + key_1[None, :],
+            mask=token_mask[:, None],
+            other=0.0,
+        )
+        k_tile_2 = tl.load(
+            k + k_base + key_2[None, :],
+            mask=token_mask[:, None],
+            other=0.0,
+        )
+        value_gradient = tl.dot(k_tile_1, d_state_1.to(k_tile_1.dtype))
+        value_gradient += tl.dot(k_tile_2, d_state_2.to(k_tile_2.dtype))
+        value_gradient *= restored_decay[:, None]
+
+        value_offset = ptr_offset((token[:, None], head, value[None, :]), (H * V, V, 1))
+        value_gradient += tl.load(
+            dv_local + value_offset,
+            mask=token_mask[:, None],
+            other=0.0,
+        )
+        tl.store(
+            dv + value_offset,
+            value_gradient.to(dv.dtype.element_ty),
+            mask=token_mask[:, None],
+        )
+
+        state_decay = tl.exp2(final_gate)
+        d_state_1 *= state_decay
+        d_state_2 *= state_decay
+        output_tile = tl.load(
+            d_output + value_offset,
+            mask=token_mask[:, None],
+            other=0.0,
+        )
+        query_decay = tl.where(token_mask, tl.exp2(gate), 0.0)
+        q_tile_1 = tl.load(
+            q + q_base + key_1[None, :],
+            mask=token_mask[:, None],
+            other=0.0,
+        )
+        q_tile_2 = tl.load(
+            q + q_base + key_2[None, :],
+            mask=token_mask[:, None],
+            other=0.0,
+        )
+        q_tile_1 = (q_tile_1 * query_decay[:, None]).to(q_tile_1.dtype)
+        q_tile_2 = (q_tile_2 * query_decay[:, None]).to(q_tile_2.dtype)
+
+        w_base = ptr_offset((token[:, None], head), (H * K, K))
+        w_tile_1 = tl.load(
+            w + w_base + key_1[None, :],
+            mask=token_mask[:, None],
+            other=0.0,
+        )
+        w_tile_2 = tl.load(
+            w + w_base + key_2[None, :],
+            mask=token_mask[:, None],
+            other=0.0,
+        )
+        d_state_1 += tl.dot(tl.trans(q_tile_1), output_tile) * scale
+        d_state_1 -= tl.dot(tl.trans(w_tile_1), value_gradient.to(w_tile_1.dtype))
+        d_state_2 += tl.dot(tl.trans(q_tile_2), output_tile) * scale
+        d_state_2 -= tl.dot(tl.trans(w_tile_2), value_gradient.to(w_tile_2.dtype))
+
+    if STORE_INITIAL_STATE_GRADIENT:
+        initial_offset_1 = state_base + ptr_offset((value[:, None], key_1[None, :]), (K, 1))
+        initial_offset_2 = state_base + ptr_offset((value[:, None], key_2[None, :]), (K, 1))
+        tl.store(d_initial_state + initial_offset_1, tl.trans(d_state_1))
+        tl.store(d_initial_state + initial_offset_2, tl.trans(d_state_2))
+
+
+def chunk_gdn_bwd_delta_h(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    w: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    d_output: torch.Tensor,
+    d_final_state: torch.Tensor | None,
+    initial_state: torch.Tensor | None,
+    metadata: RaggedChunkMetadata | None,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor]:
+    """Compute delta-state, initial-state, and corrected-value gradients.
+
+    Dense inputs use one complete B=1 token stream. Packed inputs use fixed-capacity
+    ragged metadata; inactive chunk slots and unowned physical tokens remain zero.
+    Public state tensors use ``[N, H, V, K]``, while ``dh`` uses ``[chunk, H, K, V]``.
+    """
+    bt = 64
+    key_dim = value_dim = 128
+    block_key = block_value = 64
+
+    if q.ndim != 4 or k.shape != q.shape:
+        raise ValueError("q and k must have matching [B,T,HK,K] shapes")
+    batch, tokens, key_heads, qk_dim = q.shape
+    if batch != 1 or qk_dim != key_dim:
+        raise ValueError("chunk_gdn_bwd_delta_h requires B=1 and K=128")
+    if d_output.ndim != 4:
+        raise ValueError("d_output must have shape [B,T,H,V]")
+    value_heads = d_output.shape[2]
+    if d_output.shape != (batch, tokens, value_heads, value_dim):
+        raise ValueError("d_output must match the Q/K token axes and have V=128")
+    if key_heads == 0 or value_heads % key_heads:
+        raise ValueError("the number of value heads must be divisible by the number of q/k heads")
+    if w.shape != (batch, tokens, value_heads, key_dim):
+        raise ValueError("w must have shape [B,T,H,K]")
+    if cumulative_gate.shape != (batch, tokens, value_heads):
+        raise ValueError("cumulative_gate must have shape [B,T,H]")
+    if q.dtype not in (torch.float16, torch.bfloat16):
+        raise TypeError("q, k, w, and d_output must use float16 or bfloat16")
+    if not (k.dtype == w.dtype == d_output.dtype == q.dtype):
+        raise TypeError("q, k, w, and d_output must have matching dtypes")
+
+    if metadata is None:
+        if tokens % bt:
+            raise ValueError("dense chunk_gdn_bwd_delta_h requires complete BT64 chunks")
+        num_sequences = 1
+        chunk_slots = tokens // bt
+        cu_seqlens = chunk_offsets = None
+    else:
+        metadata.validate_chunk_size(bt)
+        if (
+            metadata.cu_seqlens.ndim != 1
+            or metadata.cu_seqlens.shape[0] < 2
+            or metadata.chunk_offsets.shape != metadata.cu_seqlens.shape
+        ):
+            raise ValueError("packed metadata tensors must have matching [N+1] shapes")
+        if metadata.capacity < 0:
+            raise ValueError("packed metadata capacity must be nonnegative")
+        if (
+            metadata.cu_seqlens.dtype != torch.int32
+            or metadata.chunk_offsets.dtype != torch.int32
+            or not metadata.cu_seqlens.is_contiguous()
+            or not metadata.chunk_offsets.is_contiguous()
+        ):
+            raise ValueError("packed metadata tensors must be contiguous int32")
+        num_sequences = metadata.cu_seqlens.shape[0] - 1
+        chunk_slots = metadata.capacity
+        cu_seqlens = metadata.cu_seqlens
+        chunk_offsets = metadata.chunk_offsets
+
+    state_shape = (num_sequences, value_heads, value_dim, key_dim)
+    if initial_state is not None and initial_state.shape != state_shape:
+        raise ValueError(f"initial_state must have shape {state_shape}")
+    if d_final_state is not None and d_final_state.shape != state_shape:
+        raise ValueError(f"d_final_state must have shape {state_shape}")
+
+    tensors = (w, cumulative_gate, d_output)
+    optional_tensors = (() if d_final_state is None else (d_final_state,)) + (
+        () if initial_state is None else (initial_state,)
+    )
+    metadata_tensors = () if metadata is None else (cu_seqlens, chunk_offsets)
+    if any(tensor.device != q.device for tensor in tensors + optional_tensors + metadata_tensors):
+        raise ValueError("all tensors must be on the same device")
+    if any(not tensor.is_contiguous() for tensor in tensors + optional_tensors):
+        raise ValueError("chunk_gdn_bwd_delta_h requires contiguous tensors")
+
+    output_factory = torch.zeros if metadata is not None else torch.empty
+    dv_local = output_factory(d_output.shape, dtype=d_output.dtype, device=d_output.device)
+    dv = output_factory(d_output.shape, dtype=d_output.dtype, device=d_output.device)
+    dh = output_factory(
+        (chunk_slots, value_heads, key_dim, value_dim),
+        dtype=q.dtype,
+        device=q.device,
+    )
+    d_initial_state = (
+        torch.empty(state_shape, dtype=torch.float32, device=q.device)
+        if initial_state is not None
+        else None
+    )
+
+    groups = value_heads // key_heads
+    if chunk_slots:
+        chunk_gdn_bwd_dv_local_kernel[(chunk_slots, value_heads)](
+            q,
+            k,
+            q.stride(1),
+            k.stride(1),
+            cumulative_gate,
+            d_output,
+            dv_local,
+            cu_seqlens,
+            chunk_offsets,
+            scale,
+            num_sequences,
+            H=value_heads,
+            HK=key_heads,
+            GROUPS=groups,
+            K=key_dim,
+            V=value_dim,
+            BT=bt,
+            BK=32,
+            BV=32,
+            num_warps=4,
+            num_stages=2,
+        )
+
+    chunk_gdn_bwd_delta_h_kernel[(num_sequences * value_heads, value_dim // block_value)](
+        q,
+        k,
+        q.stride(1),
+        k.stride(1),
+        w,
+        cumulative_gate,
+        d_output,
+        d_final_state,
+        d_initial_state,
+        dv_local,
+        dh,
+        dv,
+        cu_seqlens,
+        chunk_offsets,
+        scale,
+        tokens,
+        num_sequences,
+        H=value_heads,
+        HK=key_heads,
+        GROUPS=groups,
+        K=key_dim,
+        V=value_dim,
+        BT=bt,
+        BK=block_key,
+        BV=block_value,
+        num_warps=4,
+        num_stages=2,
+    )
+    return dh, d_initial_state, dv
+
+
+__all__ = ["chunk_gdn_bwd_delta_h"]

--- a/attn_gym/linear/gdn/bwd/triton/chunk_gdn_bwd_intra.py
+++ b/attn_gym/linear/gdn/bwd/triton/chunk_gdn_bwd_intra.py
@@ -1,0 +1,236 @@
+"""Numerically safe scalar-GDN intra-factor VJP."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from attn_gym._backends.triton.utils import ptr_offset
+from attn_gym.linear.kda.chunk_scheduler import (
+    RaggedChunkMetadata,
+    load_ragged_chunk_count,
+    load_ragged_chunk_work,
+)
+
+
+@triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
+@triton.jit(do_not_specialize=["T", "num_sequences"])
+def chunk_gdn_bwd_intra_kernel(
+    q,
+    k,
+    q_stride_t,
+    k_stride_t,
+    cumulative_gate,
+    beta,
+    d_aqk,
+    d_akk,
+    d_gate_raw,
+    d_q,
+    d_k,
+    d_beta,
+    d_gate,
+    cu_seqlens,
+    chunk_offsets,
+    T,
+    num_sequences,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    """Differentiate scalar-decayed QK/KK factors for one chunk and head."""
+    chunk = tl.program_id(0)
+    head = tl.program_id(1)
+    row = tl.arange(0, BT)
+    column = tl.arange(0, BT)
+    if IS_VARLEN:
+        if chunk >= load_ragged_chunk_count(chunk_offsets, num_sequences):
+            return
+        _sequence, _local_chunk, token_start, valid_tokens = load_ragged_chunk_work(
+            cu_seqlens, chunk_offsets, chunk, num_sequences, BT
+        )
+        token = token_start + row
+        token_mask = row < valid_tokens
+    else:
+        token = chunk * BT + row
+        token_mask = row < BT
+        valid_tokens = BT
+
+    scalar_offset = ptr_offset((token, head), (H, 1))
+    gate = tl.load(cumulative_gate + scalar_offset, mask=token_mask, other=0.0).to(tl.float32)
+    gate_delta = gate[:, None] - gate[None, :]
+    causal = (
+        (row[:, None] >= column[None, :])
+        & (row[:, None] < valid_tokens)
+        & (column[None, :] < valid_tokens)
+    )
+    strict = causal & (row[:, None] > column[None, :])
+    decay = tl.where(causal, tl.exp2(tl.where(causal, gate_delta, 0.0)), 0.0)
+
+    matrix_offset = ptr_offset((token[:, None], head, column[None, :]), (H * BT, BT, 1))
+    d_aqk_tile = tl.load(d_aqk + matrix_offset, mask=token_mask[:, None], other=0.0).to(tl.float32)
+    d_aqk_tile = tl.where(causal, d_aqk_tile, 0.0)
+    d_akk_tile = tl.load(d_akk + matrix_offset, mask=token_mask[:, None], other=0.0).to(tl.float32)
+    d_akk_tile = tl.where(strict, d_akk_tile, 0.0)
+    beta_row = tl.load(beta + scalar_offset, mask=token_mask, other=0.0).to(tl.float32)
+    aq_weight = d_aqk_tile * decay
+    kk_weight = d_akk_tile * decay * beta_row[:, None]
+
+    raw_qk = tl.zeros((BT, BT), dtype=tl.float32)
+    raw_kk = tl.zeros((BT, BT), dtype=tl.float32)
+    raw_gate_grad = tl.zeros((BT,), dtype=tl.float32)
+    for key_block in range(0, K, BK):
+        feature = key_block + tl.arange(0, BK)
+        q_offset = ptr_offset((token[:, None], head, feature[None, :]), (q_stride_t, K, 1))
+        k_offset = ptr_offset((token[:, None], head, feature[None, :]), (k_stride_t, K, 1))
+        output_offset = ptr_offset((token[:, None], head, feature[None, :]), (H * K, K, 1))
+        q_tile = tl.load(
+            q + q_offset,
+            mask=token_mask[:, None],
+            other=0.0,
+        )
+        k_tile = tl.load(
+            k + k_offset,
+            mask=token_mask[:, None],
+            other=0.0,
+        )
+        raw_qk += tl.dot(q_tile, tl.trans(k_tile))
+        raw_kk += tl.dot(k_tile, tl.trans(k_tile))
+        gate_tile = tl.load(
+            d_gate_raw + output_offset,
+            mask=token_mask[:, None],
+            other=0.0,
+        )
+        raw_gate_grad += tl.sum(gate_tile, axis=1)
+
+        d_q_tile = tl.dot(aq_weight.to(q_tile.dtype), k_tile)
+        d_k_tile = tl.dot(tl.trans(aq_weight).to(q_tile.dtype), q_tile)
+        d_k_tile += tl.dot(kk_weight.to(q_tile.dtype), k_tile)
+        d_k_tile += tl.dot(tl.trans(kk_weight).to(q_tile.dtype), k_tile)
+        tl.store(d_q + output_offset, d_q_tile.to(d_q.dtype.element_ty), mask=token_mask[:, None])
+        tl.store(d_k + output_offset, d_k_tile.to(d_k.dtype.element_ty), mask=token_mask[:, None])
+
+    d_beta_row = tl.sum(d_akk_tile * decay * raw_kk, axis=1)
+    gate_term = aq_weight * raw_qk + kk_weight * raw_kk
+    # Both sources are ln2-free natural-exponent contributions, so this reverse
+    # cumsum directly returns the gradient of the per-token natural-log gate.
+    d_gate_row = tl.cumsum(
+        raw_gate_grad + tl.sum(gate_term, axis=1) - tl.sum(gate_term, axis=0),
+        axis=0,
+        reverse=True,
+    )
+    tl.store(d_beta + scalar_offset, d_beta_row, mask=token_mask)
+    tl.store(d_gate + scalar_offset, d_gate_row, mask=token_mask)
+
+
+def chunk_gdn_bwd_intra_dense(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    d_aqk: torch.Tensor,
+    d_akk: torch.Tensor,
+    d_gate_raw: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Run dense B=1 BT64 scalar-GDN intra-factor gradients."""
+    batch, tokens, heads, key_dim = q.shape
+    if batch != 1 or tokens % 64 or key_dim != 128:
+        raise ValueError(
+            "dense fused chunk GDN backward requires B=1, complete BT64 chunks, and K=128"
+        )
+    if k.shape != q.shape or cumulative_gate.shape != q.shape[:3]:
+        raise ValueError("k must match q and cumulative_gate must have shape [B,T,H]")
+    expected_factor_shape = (batch, tokens, heads, 64)
+    if d_aqk.shape != expected_factor_shape or d_akk.shape != expected_factor_shape:
+        raise ValueError(f"factor gradients must have shape {expected_factor_shape}")
+    if d_gate_raw.shape != q.shape:
+        raise ValueError("d_gate_raw must match expanded q")
+
+    d_q = torch.empty(q.shape, dtype=torch.float32, device=q.device)
+    d_k = torch.empty(k.shape, dtype=torch.float32, device=k.device)
+    d_beta = torch.empty_like(beta, dtype=torch.float32)
+    d_gate = torch.empty_like(cumulative_gate, dtype=torch.float32)
+    chunk_gdn_bwd_intra_kernel[(tokens // 64, heads)](
+        q,
+        k,
+        q.stride(1),
+        k.stride(1),
+        cumulative_gate,
+        beta,
+        d_aqk,
+        d_akk,
+        d_gate_raw,
+        d_q,
+        d_k,
+        d_beta,
+        d_gate,
+        None,
+        None,
+        tokens,
+        0,
+        H=heads,
+        K=key_dim,
+        BT=64,
+        BK=64,
+        num_warps=4,
+        num_stages=2,
+    )
+    return d_q, d_k, d_beta, d_gate
+
+
+def chunk_gdn_bwd_intra_packed(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    d_aqk: torch.Tensor,
+    d_akk: torch.Tensor,
+    d_gate_raw: torch.Tensor,
+    metadata: RaggedChunkMetadata,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Run fixed-capacity packed scalar-GDN intra-factor gradients."""
+    metadata.validate_chunk_size(64)
+    batch, tokens, heads, key_dim = q.shape
+    if batch != 1 or key_dim != 128 or k.shape != q.shape:
+        raise ValueError("packed fused chunk GDN backward requires B=1 and K=128")
+    expected_factor_shape = (batch, tokens, heads, 64)
+    if d_aqk.shape != expected_factor_shape or d_akk.shape != expected_factor_shape:
+        raise ValueError(f"factor gradients must have shape {expected_factor_shape}")
+    if d_gate_raw.shape != q.shape:
+        raise ValueError("d_gate_raw must match expanded q")
+
+    d_q = torch.zeros(q.shape, dtype=torch.float32, device=q.device)
+    d_k = torch.zeros(k.shape, dtype=torch.float32, device=k.device)
+    d_beta = torch.zeros_like(beta, dtype=torch.float32)
+    d_gate = torch.zeros_like(cumulative_gate, dtype=torch.float32)
+    chunk_gdn_bwd_intra_kernel[(metadata.capacity, heads)](
+        q,
+        k,
+        q.stride(1),
+        k.stride(1),
+        cumulative_gate,
+        beta,
+        d_aqk,
+        d_akk,
+        d_gate_raw,
+        d_q,
+        d_k,
+        d_beta,
+        d_gate,
+        metadata.cu_seqlens,
+        metadata.chunk_offsets,
+        tokens,
+        metadata.cu_seqlens.shape[0] - 1,
+        H=heads,
+        K=key_dim,
+        BT=64,
+        BK=64,
+        num_warps=4,
+        num_stages=2,
+    )
+    return d_q, d_k, d_beta, d_gate
+
+
+__all__ = ["chunk_gdn_bwd_intra_dense", "chunk_gdn_bwd_intra_packed"]

--- a/attn_gym/linear/gdn/bwd/triton/chunk_gdn_bwd_recompute.py
+++ b/attn_gym/linear/gdn/bwd/triton/chunk_gdn_bwd_recompute.py
@@ -1,0 +1,160 @@
+"""Backward-only recomputation for scalar chunk GDN."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from attn_gym._backends.triton.utils import ptr_offset
+from attn_gym.linear.kda.chunk_scheduler import (
+    RaggedChunkMetadata,
+    load_ragged_chunk_count,
+    load_ragged_chunk_work,
+)
+
+
+@triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
+@triton.jit(do_not_specialize=["T", "num_sequences"])
+def chunk_gdn_recompute_aqk_kernel(
+    q,
+    k,
+    q_stride_t,
+    k_stride_t,
+    cumulative_gate,
+    aqk,
+    cu_seqlens,
+    chunk_offsets,
+    scale,
+    T,
+    num_sequences,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    """Recompute causal scalar-decayed QK without reciprocal gate factors."""
+    chunk = tl.program_id(0)
+    head = tl.program_id(1)
+    row = tl.arange(0, BT)
+    column = tl.arange(0, BT)
+    if IS_VARLEN:
+        if chunk >= load_ragged_chunk_count(chunk_offsets, num_sequences):
+            return
+        _sequence, _local_chunk, token_start, valid_tokens = load_ragged_chunk_work(
+            cu_seqlens, chunk_offsets, chunk, num_sequences, BT
+        )
+        token = token_start + row
+        token_mask = row < valid_tokens
+    else:
+        token = chunk * BT + row
+        token_mask = row < BT
+        valid_tokens = BT
+
+    qk = tl.zeros((BT, BT), dtype=tl.float32)
+    for key_block in range(0, K, BK):
+        feature = key_block + tl.arange(0, BK)
+        q_offset = ptr_offset((token[:, None], head, feature[None, :]), (q_stride_t, K, 1))
+        k_offset = ptr_offset((token[:, None], head, feature[None, :]), (k_stride_t, K, 1))
+        q_tile = tl.load(
+            q + q_offset,
+            mask=token_mask[:, None],
+            other=0.0,
+        )
+        k_tile = tl.load(
+            k + k_offset,
+            mask=token_mask[:, None],
+            other=0.0,
+        )
+        qk += tl.dot(q_tile, tl.trans(k_tile))
+
+    gate = tl.load(
+        cumulative_gate + ptr_offset((token, head), (H, 1)),
+        mask=token_mask,
+        other=0.0,
+    ).to(tl.float32)
+    gate_delta = gate[:, None] - gate[None, :]
+    causal = (
+        (row[:, None] >= column[None, :])
+        & (row[:, None] < valid_tokens)
+        & (column[None, :] < valid_tokens)
+    )
+    decay = tl.where(causal, tl.exp2(tl.where(causal, gate_delta, 0.0)), 0.0)
+    output_offset = ptr_offset((token[:, None], head, column[None, :]), (H * BT, BT, 1))
+    tl.store(
+        aqk + output_offset,
+        tl.where(causal, qk * decay * scale, 0.0),
+        mask=token_mask[:, None],
+    )
+
+
+def chunk_gdn_recompute_aqk_dense(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    scale: float,
+) -> torch.Tensor:
+    """Run dense B=1 BT64 Aqk recomputation for the reused delta-H backward."""
+    batch, tokens, heads, key_dim = q.shape
+    if batch != 1 or tokens % 64 or key_dim != 128 or k.shape != q.shape:
+        raise ValueError("dense fused chunk GDN Aqk recompute requires B=1, BT64, and K=128")
+    aqk = torch.empty(batch, tokens, heads, 64, dtype=q.dtype, device=q.device)
+    chunk_gdn_recompute_aqk_kernel[(tokens // 64, heads)](
+        q,
+        k,
+        q.stride(1),
+        k.stride(1),
+        cumulative_gate,
+        aqk,
+        None,
+        None,
+        scale,
+        tokens,
+        0,
+        H=heads,
+        K=key_dim,
+        BT=64,
+        BK=32,
+        num_warps=8,
+        num_stages=2,
+    )
+    return aqk
+
+
+def chunk_gdn_recompute_aqk_packed(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    scale: float,
+    metadata: RaggedChunkMetadata,
+) -> torch.Tensor:
+    """Run fixed-capacity packed Aqk recomputation for reused delta-H backward."""
+    metadata.validate_chunk_size(64)
+    batch, tokens, heads, key_dim = q.shape
+    if batch != 1 or key_dim != 128 or k.shape != q.shape:
+        raise ValueError("packed fused chunk GDN Aqk recompute requires B=1 and K=128")
+    aqk = torch.zeros(batch, tokens, heads, 64, dtype=q.dtype, device=q.device)
+    chunk_gdn_recompute_aqk_kernel[(metadata.capacity, heads)](
+        q,
+        k,
+        q.stride(1),
+        k.stride(1),
+        cumulative_gate,
+        aqk,
+        metadata.cu_seqlens,
+        metadata.chunk_offsets,
+        scale,
+        tokens,
+        metadata.cu_seqlens.shape[0] - 1,
+        H=heads,
+        K=key_dim,
+        BT=64,
+        BK=32,
+        num_warps=8,
+        num_stages=2,
+    )
+    return aqk
+
+
+__all__ = ["chunk_gdn_recompute_aqk_dense", "chunk_gdn_recompute_aqk_packed"]

--- a/attn_gym/linear/gdn/bwd/triton/chunk_gdn_bwd_wy.py
+++ b/attn_gym/linear/gdn/bwd/triton/chunk_gdn_bwd_wy.py
@@ -1,0 +1,578 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+# Copyright (c) 2026 Meta Platforms, Inc. and affiliates.
+#
+# Portions are derived from flash-linear-attention and licensed under the MIT license;
+# see https://github.com/fla-org/flash-linear-attention/graphs/contributors.
+# The remaining portions use the BSD-style license in the repository root.
+"""Triton backward kernels for the scalar-GDN WY representation.
+
+``cumulative_gate`` contains per-chunk cumulative gates in log2 space.  The
+intermediate gate derivatives below intentionally omit ln(2): after the local
+reverse cumulative sum, they are gradients for the original natural-log gate.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from attn_gym._backends.triton.utils import ptr_offset
+from attn_gym.linear.kda.chunk_scheduler import (
+    RaggedChunkMetadata,
+    load_ragged_chunk_count,
+    load_ragged_chunk_work,
+)
+
+
+@triton.jit
+def _load_chunk_work(
+    chunk,
+    cu_seqlens,
+    chunk_offsets,
+    num_sequences,
+    BT: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    if IS_VARLEN:
+        if chunk >= load_ragged_chunk_count(chunk_offsets, num_sequences):
+            return -1, 0
+        _, _, token_start, valid_tokens = load_ragged_chunk_work(
+            cu_seqlens,
+            chunk_offsets,
+            chunk,
+            num_sequences,
+            BT,
+        )
+        return token_start, valid_tokens
+    return chunk * BT, BT
+
+
+@triton.jit
+def _load_last_gate(gate, valid_tokens, stride, BT: tl.constexpr):
+    rows = tl.arange(0, BT)
+    return tl.sum(
+        tl.load(gate + ptr_offset((rows,), (stride,)), mask=rows == valid_tokens - 1, other=0.0),
+        axis=0,
+    )
+
+
+@triton.jit
+def chunk_gdn_bwd_dqkwg_kernel(
+    q,
+    k,
+    q_stride_t,
+    k_stride_t,
+    v_new,
+    d_w,
+    cumulative_gate,
+    h,
+    d_output,
+    dh,
+    d_v_in,
+    d_q,
+    d_k,
+    d_gate_direct,
+    cu_seqlens,
+    chunk_offsets,
+    T,
+    num_sequences,
+    H: tl.constexpr,
+    HK: tl.constexpr,
+    GROUPS: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    SCALE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    key_tile = tl.program_id(0)
+    chunk = tl.program_id(1)
+    head = tl.program_id(2)
+
+    token_start, valid_tokens = _load_chunk_work(
+        chunk,
+        cu_seqlens,
+        chunk_offsets,
+        num_sequences,
+        BT,
+        IS_VARLEN,
+    )
+    if token_start < 0:
+        return
+
+    rows = tl.arange(0, BT)
+    keys = key_tile * BK + tl.arange(0, BK)
+    token = token_start + rows
+    token_mask = rows < valid_tokens
+    key_head = head // GROUPS
+
+    q_offset = ptr_offset((token[:, None], key_head, keys[None, :]), (q_stride_t, K, 1))
+    k_offset = ptr_offset((token[:, None], key_head, keys[None, :]), (k_stride_t, K, 1))
+    v_offset = ptr_offset((token[:, None], head), (H * V, V))
+    h_offset = ptr_offset((chunk, head), (H * K * V, K * V))
+
+    b_dq = tl.zeros((BT, BK), tl.float32)
+    b_dk = tl.zeros((BT, BK), tl.float32)
+    b_dw = tl.zeros((BT, BK), tl.float32)
+    b_ds = tl.zeros((BT, BT), tl.float32)
+    b_dg_last = tl.zeros((1,), tl.float32)
+
+    for value_start in range(0, V, BV):
+        values = value_start + tl.arange(0, BV)
+        value_mask = values < V
+        value_offsets = v_offset + values[None, :]
+        h_values = h_offset + ptr_offset((keys[None, :], values[:, None]), (V, 1))
+
+        b_h = tl.load(
+            h + h_values,
+            mask=value_mask[:, None] & (keys[None, :] < K),
+            other=0.0,
+        )
+        b_dh = tl.load(
+            dh + h_values,
+            mask=value_mask[:, None] & (keys[None, :] < K),
+            other=0.0,
+        )
+        b_do = tl.load(
+            d_output + value_offsets,
+            mask=token_mask[:, None] & value_mask[None, :],
+            other=0.0,
+        )
+        b_v_new = tl.load(
+            v_new + value_offsets,
+            mask=token_mask[:, None] & value_mask[None, :],
+            other=0.0,
+        )
+        b_du = tl.load(
+            d_v_in + value_offsets,
+            mask=token_mask[:, None] & value_mask[None, :],
+            other=0.0,
+        )
+
+        b_dg_last += tl.sum(b_h * b_dh)
+        b_ds += tl.dot(b_do, tl.trans(b_v_new))
+        b_dq += tl.dot(b_do, b_h)
+        b_dk += tl.dot(b_v_new, b_dh)
+        b_dw -= tl.dot(b_du, b_h)
+
+    gate_offsets = ptr_offset((token, head), (H, 1))
+    b_gate = tl.load(cumulative_gate + gate_offsets, mask=token_mask, other=0.0).to(tl.float32)
+    b_gate_last = _load_last_gate(
+        cumulative_gate + ptr_offset((token_start, head), (H, 1)),
+        valid_tokens,
+        H,
+        BT,
+    ).to(tl.float32)
+    b_q = tl.load(q + q_offset, mask=token_mask[:, None], other=0.0)
+    b_k = tl.load(k + k_offset, mask=token_mask[:, None], other=0.0)
+
+    b_dq *= tl.exp2(b_gate)[:, None] * SCALE
+    b_dk *= tl.where(token_mask, tl.exp2(b_gate_last - b_gate), 0.0)[:, None]
+    b_dg_last *= tl.exp2(b_gate_last)
+    b_dg_last += tl.sum(b_dk * b_k)
+
+    causal = rows[:, None] >= rows[None, :]
+    active = token_mask[:, None] & token_mask[None, :]
+    gate_delta = tl.where(active, b_gate[:, None] - b_gate[None, :], 0.0)
+    b_ds = tl.where(causal & active, b_ds * tl.exp2(gate_delta), 0.0) * SCALE
+    b_dq += tl.dot(b_ds.to(b_k.dtype), b_k)
+    b_dk += tl.dot(tl.trans(b_ds).to(b_q.dtype), b_q)
+
+    b_dg = tl.sum(b_dq * b_q, axis=1) - tl.sum(b_dk * b_k, axis=1)
+    b_dg += tl.where(rows == valid_tokens - 1, b_dg_last, 0.0)
+
+    d_q_offset = ptr_offset((token[:, None], head, keys[None, :]), (H * K, K, 1))
+    d_gate_offset = ptr_offset((key_tile, token, head), (T * H, H, 1))
+    tl.store(d_q + d_q_offset, b_dq, mask=token_mask[:, None])
+    tl.store(d_k + d_q_offset, b_dk, mask=token_mask[:, None])
+    tl.store(d_w + d_q_offset, b_dw, mask=token_mask[:, None])
+    tl.store(d_gate_direct + d_gate_offset, b_dg, mask=token_mask)
+
+
+@triton.jit
+def chunk_gdn_bwd_wy_kernel(
+    k,
+    v,
+    k_stride_t,
+    v_stride_t,
+    d_w,
+    cumulative_gate,
+    beta,
+    inverse,
+    d_v_in,
+    d_k,
+    d_v,
+    d_gate,
+    d_beta,
+    cu_seqlens,
+    chunk_offsets,
+    num_sequences,
+    H: tl.constexpr,
+    HK: tl.constexpr,
+    GROUPS: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    chunk = tl.program_id(0)
+    head = tl.program_id(1)
+
+    token_start, valid_tokens = _load_chunk_work(
+        chunk,
+        cu_seqlens,
+        chunk_offsets,
+        num_sequences,
+        BT,
+        IS_VARLEN,
+    )
+    if token_start < 0:
+        return
+
+    rows = tl.arange(0, BT)
+    columns = tl.arange(0, BT)
+    token = token_start + rows
+    token_mask = rows < valid_tokens
+    matrix_mask = token_mask[:, None] & token_mask[None, :]
+    key_head = head // GROUPS
+
+    gate_offsets = ptr_offset((token, head), (H, 1))
+    b_gate = tl.load(cumulative_gate + gate_offsets, mask=token_mask, other=0.0).to(tl.float32)
+    b_beta = tl.load(beta + gate_offsets, mask=token_mask, other=0.0).to(tl.float32)
+    b_inverse = tl.load(
+        inverse + ptr_offset((token[None, :], head, rows[:, None]), (H * BT, BT, 1)),
+        mask=matrix_mask,
+        other=0.0,
+    )
+
+    b_dinverse = tl.zeros((BT, BT), tl.float32)
+    b_dbeta = tl.zeros((BT,), tl.float32)
+    b_dgate = tl.zeros((BT,), tl.float32)
+    b_gate_exp = tl.exp2(b_gate)
+
+    for key_start in range(0, K, BK):
+        keys = key_start + tl.arange(0, BK)
+        key_mask = keys < K
+        k_offsets = ptr_offset((token[:, None], key_head, keys[None, :]), (k_stride_t, K, 1))
+        w_offsets = ptr_offset((token[:, None], head, keys[None, :]), (H * K, K, 1))
+        b_k = tl.load(k + k_offsets, mask=token_mask[:, None] & key_mask[None, :], other=0.0)
+        b_dw = tl.load(
+            d_w + w_offsets,
+            mask=token_mask[:, None] & key_mask[None, :],
+            other=0.0,
+        )
+        b_kbg = b_k * (b_beta * b_gate_exp)[:, None]
+        b_dinverse += tl.dot(b_dw, tl.trans(b_kbg).to(b_dw.dtype))
+
+        b_dkbg = tl.dot(b_inverse, b_dw)
+        b_dk = b_dkbg * (b_beta * b_gate_exp)[:, None]
+        b_dbeta += tl.sum(b_dkbg * b_k * b_gate_exp[:, None], axis=1)
+        b_dgate += tl.sum(b_dkbg * b_kbg, axis=1)
+        tl.store(d_k + w_offsets, b_dk, mask=token_mask[:, None] & key_mask[None, :])
+
+    for value_start in range(0, V, BV):
+        values = value_start + tl.arange(0, BV)
+        value_mask = values < V
+        v_offsets = ptr_offset((token[:, None], head, values[None, :]), (v_stride_t, V, 1))
+        b_v = tl.load(v + v_offsets, mask=token_mask[:, None] & value_mask[None, :], other=0.0)
+        b_du = tl.load(
+            d_v_in + v_offsets,
+            mask=token_mask[:, None] & value_mask[None, :],
+            other=0.0,
+        )
+        b_vb = b_v * b_beta[:, None]
+        b_dinverse += tl.dot(b_du, tl.trans(b_vb).to(b_du.dtype))
+
+        b_dvb = tl.dot(b_inverse, b_du)
+        b_dbeta += tl.sum(b_dvb * b_v, axis=1)
+        tl.store(
+            d_v + v_offsets,
+            b_dvb * b_beta[:, None],
+            mask=token_mask[:, None] & value_mask[None, :],
+        )
+
+    strict_lower = (rows[:, None] > columns[None, :]) & matrix_mask
+    b_dinverse = tl.where(strict_lower, b_dinverse, 0.0)
+    b_dinverse = tl.dot(b_dinverse.to(b_inverse.dtype), b_inverse)
+    b_dinverse = tl.dot(b_inverse, b_dinverse.to(b_inverse.dtype))
+    inverse_gate_delta = tl.where(
+        strict_lower,
+        b_gate[:, None] - b_gate[None, :],
+        0.0,
+    )
+    b_dinverse = tl.where(
+        strict_lower,
+        -b_dinverse * tl.exp2(inverse_gate_delta),
+        0.0,
+    ).to(b_inverse.dtype)
+
+    for key_start in range(0, K, BK):
+        keys = key_start + tl.arange(0, BK)
+        key_mask = keys < K
+        k_offsets = ptr_offset((token[:, None], key_head, keys[None, :]), (k_stride_t, K, 1))
+        dk_offsets = ptr_offset((token[:, None], head, keys[None, :]), (H * K, K, 1))
+        b_k = tl.load(k + k_offsets, mask=token_mask[:, None] & key_mask[None, :], other=0.0)
+        b_kb = b_k * b_beta[:, None]
+        b_dkb = tl.dot(b_dinverse, b_k)
+        b_dbeta += tl.sum(b_dkb * b_k, axis=1)
+        b_dk = b_dkb * b_beta[:, None]
+        b_dk += tl.trans(tl.dot(tl.trans(b_kb).to(b_dinverse.dtype), b_dinverse))
+        b_dk += tl.load(d_k + dk_offsets, mask=token_mask[:, None] & key_mask[None, :], other=0.0)
+        tl.store(d_k + dk_offsets, b_dk, mask=token_mask[:, None] & key_mask[None, :])
+
+        b_kkt = tl.dot(b_k, tl.trans(b_k)) * b_beta[:, None]
+        b_adin = b_dinverse.to(tl.float32) * b_kkt
+        b_dgate += tl.sum(b_adin, axis=1) - tl.sum(b_adin, axis=0)
+
+    scalar_offsets = ptr_offset((token, head), (H, 1))
+    tl.store(d_beta + scalar_offsets, b_dbeta, mask=token_mask)
+    tl.store(d_gate + scalar_offsets, b_dgate, mask=token_mask)
+
+
+@triton.jit
+def chunk_gdn_bwd_gate_cumsum_kernel(
+    d_gate_direct,
+    d_gate_wy,
+    d_gate,
+    cu_seqlens,
+    chunk_offsets,
+    T,
+    num_sequences,
+    H: tl.constexpr,
+    BT: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    chunk = tl.program_id(0)
+    head = tl.program_id(1)
+
+    token_start, valid_tokens = _load_chunk_work(
+        chunk,
+        cu_seqlens,
+        chunk_offsets,
+        num_sequences,
+        BT,
+        IS_VARLEN,
+    )
+    if token_start < 0:
+        return
+
+    rows = tl.arange(0, BT)
+    token = token_start + rows
+    token_mask = rows < valid_tokens
+    scalar_offsets = ptr_offset((token, head), (H, 1))
+    direct_stride = T * H
+    b_dgate = tl.load(d_gate_direct + scalar_offsets, mask=token_mask, other=0.0)
+    b_dgate += tl.load(
+        d_gate_direct + direct_stride + scalar_offsets,
+        mask=token_mask,
+        other=0.0,
+    )
+    b_dgate += tl.load(d_gate_wy + scalar_offsets, mask=token_mask, other=0.0)
+    b_dgate = tl.where(token_mask, b_dgate, 0.0)
+    b_dgate = tl.cumsum(b_dgate, axis=0, reverse=True)
+    tl.store(d_gate + scalar_offsets, b_dgate, mask=token_mask)
+
+
+def chunk_gdn_bwd_wy(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    v_new: torch.Tensor,
+    w: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    inverse: torch.Tensor,
+    h: torch.Tensor,
+    d_output: torch.Tensor,
+    dh: torch.Tensor,
+    dv: torch.Tensor,
+    metadata: RaggedChunkMetadata | None,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Differentiate scalar-GDN's chunk output and WY representation.
+
+    ``w`` supplies the forward WY layout; its values are not reread because
+    this routine produces the internal ``dW`` staging tensor. ``dv`` is the
+    cotangent of WY's ``U`` representation (including the recurrence/output
+    contributions assembled by the caller). The returned value gradient is
+    with respect to the original ``v``. Only active packed rows are part of the public contract;
+    callers own masking of inactive capacity.
+    """
+    bt = 64
+    key_dim = value_dim = 128
+    block_key = block_value = 64
+
+    if q.ndim != 4 or k.ndim != 4 or v.ndim != 4:
+        raise ValueError("q, k, and v must have shape [B, T, H, D]")
+    batch, tokens, key_heads, qk_dim = q.shape
+    value_heads = v.shape[2]
+    if (
+        batch != 1
+        or k.shape != (batch, tokens, key_heads, key_dim)
+        or qk_dim != key_dim
+        or v.shape != (batch, tokens, value_heads, value_dim)
+        or v_new.shape != v.shape
+        or d_output.shape != v.shape
+        or dv.shape != v.shape
+        or w.shape != (batch, tokens, value_heads, key_dim)
+        or cumulative_gate.shape != (batch, tokens, value_heads)
+        or beta.shape != (batch, tokens, value_heads)
+        or inverse.shape != (batch, tokens, value_heads, bt)
+    ):
+        raise ValueError("scalar GDN requires B=1, BT=64, and K=V=128")
+    if value_heads % key_heads:
+        raise ValueError("the number of value heads must be divisible by the number of q/k heads")
+    if not all(
+        tensor.is_contiguous()
+        for tensor in (
+            v_new,
+            w,
+            cumulative_gate,
+            beta,
+            inverse,
+            h,
+            d_output,
+            dh,
+            dv,
+        )
+    ):
+        raise ValueError("chunk_gdn_bwd_wy requires contiguous intermediate tensors")
+
+    if metadata is None:
+        if tokens % bt:
+            raise ValueError("dense scalar GDN requires a sequence length divisible by 64")
+        chunk_slots = tokens // bt
+        cu_seqlens = chunk_offsets = None
+    else:
+        metadata.validate_chunk_size(bt)
+        chunk_slots = metadata.capacity
+        cu_seqlens = metadata.cu_seqlens
+        chunk_offsets = metadata.chunk_offsets
+
+    state_shape = (batch, chunk_slots, value_heads, key_dim, value_dim)
+    compact_state_shape = state_shape[1:]
+    if h.shape not in (state_shape, compact_state_shape) or dh.shape not in (
+        state_shape,
+        compact_state_shape,
+    ):
+        raise ValueError("h and dh must have layout [chunk, H, K, V] (optionally prefixed by B=1)")
+
+    groups = value_heads // key_heads
+    output_factory = torch.zeros if metadata is not None else torch.empty
+    output_kwargs = {"device": q.device}
+    d_q_expanded = output_factory(
+        (batch, tokens, value_heads, key_dim), dtype=torch.float32, **output_kwargs
+    )
+    d_k_direct = output_factory(
+        (batch, tokens, value_heads, key_dim), dtype=torch.float32, **output_kwargs
+    )
+    d_k_wy = output_factory(
+        (batch, tokens, value_heads, key_dim), dtype=torch.float32, **output_kwargs
+    )
+    d_w = output_factory(w.shape, dtype=w.dtype, **output_kwargs)
+    d_value = output_factory(v.shape, dtype=v.dtype, **output_kwargs)
+    d_gate_direct = output_factory(
+        (key_dim // block_key, batch, tokens, value_heads),
+        dtype=cumulative_gate.dtype,
+        **output_kwargs,
+    )
+    d_gate_wy = output_factory(cumulative_gate.shape, dtype=cumulative_gate.dtype, **output_kwargs)
+    d_gate = output_factory(cumulative_gate.shape, dtype=cumulative_gate.dtype, **output_kwargs)
+    d_beta = output_factory(beta.shape, dtype=beta.dtype, **output_kwargs)
+
+    if chunk_slots:
+        direct_grid = (key_dim // block_key, chunk_slots, value_heads)
+        chunk_gdn_bwd_dqkwg_kernel[direct_grid](
+            q,
+            k,
+            q.stride(1),
+            k.stride(1),
+            v_new,
+            d_w,
+            cumulative_gate,
+            h,
+            d_output,
+            dh,
+            dv,
+            d_q_expanded,
+            d_k_direct,
+            d_gate_direct,
+            cu_seqlens,
+            chunk_offsets,
+            tokens,
+            0 if metadata is None else metadata.cu_seqlens.shape[0] - 1,
+            H=value_heads,
+            HK=key_heads,
+            GROUPS=groups,
+            K=key_dim,
+            V=value_dim,
+            BT=bt,
+            BK=block_key,
+            BV=block_value,
+            SCALE=scale,
+            IS_VARLEN=metadata is not None,
+            num_warps=4,
+            num_stages=2,
+        )
+        chunk_gdn_bwd_wy_kernel[(chunk_slots, value_heads)](
+            k,
+            v,
+            k.stride(1),
+            v.stride(1),
+            d_w,
+            cumulative_gate,
+            beta,
+            inverse,
+            dv,
+            d_k_wy,
+            d_value,
+            d_gate_wy,
+            d_beta,
+            cu_seqlens,
+            chunk_offsets,
+            0 if metadata is None else metadata.cu_seqlens.shape[0] - 1,
+            H=value_heads,
+            HK=key_heads,
+            GROUPS=groups,
+            K=key_dim,
+            V=value_dim,
+            BT=bt,
+            BK=block_key,
+            BV=block_value,
+            IS_VARLEN=metadata is not None,
+            num_warps=4,
+            num_stages=2,
+        )
+        chunk_gdn_bwd_gate_cumsum_kernel[(chunk_slots, value_heads)](
+            d_gate_direct,
+            d_gate_wy,
+            d_gate,
+            cu_seqlens,
+            chunk_offsets,
+            tokens,
+            0 if metadata is None else metadata.cu_seqlens.shape[0] - 1,
+            H=value_heads,
+            BT=bt,
+            IS_VARLEN=metadata is not None,
+            num_warps=2,
+            num_stages=2,
+        )
+
+    d_k_expanded = d_k_direct + d_k_wy
+    if groups == 1:
+        return d_q_expanded.to(q.dtype), d_k_expanded.to(k.dtype), d_value, d_gate, d_beta
+    return (
+        d_q_expanded.view(batch, tokens, key_heads, groups, key_dim).sum(dim=3).to(q.dtype),
+        d_k_expanded.view(batch, tokens, key_heads, groups, key_dim).sum(dim=3).to(k.dtype),
+        d_value,
+        d_gate,
+        d_beta,
+    )
+
+
+__all__ = ["chunk_gdn_bwd_wy"]

--- a/attn_gym/linear/gdn/fwd/__init__.py
+++ b/attn_gym/linear/gdn/fwd/__init__.py
@@ -1,0 +1,1 @@
+"""Fused chunk GDN forward kernels."""

--- a/attn_gym/linear/gdn/fwd/triton/__init__.py
+++ b/attn_gym/linear/gdn/fwd/triton/__init__.py
@@ -1,0 +1,1 @@
+"""Triton fused chunk GDN forward kernels."""

--- a/attn_gym/linear/gdn/fwd/triton/chunk_gdn_fwd_intra.py
+++ b/attn_gym/linear/gdn/fwd/triton/chunk_gdn_fwd_intra.py
@@ -1,0 +1,670 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+# Copyright (c) 2026 Meta Platforms, Inc. and affiliates.
+#
+# Portions are derived from flash-linear-attention and licensed under the MIT license;
+# see https://github.com/fla-org/flash-linear-attention/graphs/contributors.
+# The remaining portions use the BSD-style license in the repository root.
+
+"""Numerically safe scalar-GDN intra factors and W/U/kg production."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from attn_gym._backends.triton.utils import ptr_offset
+from attn_gym.linear.kda.chunk_scheduler import (
+    RaggedChunkMetadata,
+    load_ragged_chunk_count,
+    load_ragged_chunk_work,
+)
+from attn_gym.linear.kda.utils import autotune_cache_kwargs, exp2
+
+# Match FLA's fused GDN solve: the block-inverse merge multiplies FP32 intermediates,
+# so TF32 preserves more precision than narrowing them to BF16 while retaining tensor-core MMAs.
+# This setting does not change the public FP16/BF16 QKV contract.
+SOLVE_TRIL_DOT_PRECISION = tl.constexpr("tf32")
+
+
+@triton.jit
+def _solve_diagonal_block(matrix, row, valid_rows, BC: tl.constexpr):
+    """Invert one unit-lower triangular block with a statically unrolled solve."""
+    inverse = -matrix
+    for index in tl.static_range(2, BC):
+        solved_row = tl.sum(tl.where((row == index)[:, None], -matrix, 0.0), axis=0)
+        solved_row = tl.where(row < index, solved_row, 0.0)
+        solved_row += tl.sum(solved_row[:, None] * inverse, axis=0)
+        update = ((row == index) & (index < valid_rows))[:, None]
+        inverse = tl.where(update, solved_row, inverse)
+    return inverse
+
+
+@triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
+@triton.autotune(
+    configs=[
+        triton.Config({"BK": block_key}, num_warps=num_warps)
+        for block_key in (32, 64)
+        for num_warps in (1, 2, 4)
+    ],
+    key=["H", "HV", "K", "BC"],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["T", "num_sequences"])
+def chunk_gdn_fwd_kkt_solve_kernel(
+    k,
+    k_stride_t,
+    g,
+    beta,
+    A,
+    cu_seqlens,
+    chunk_offsets,
+    T,
+    num_sequences,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    """
+    Fused kernel: compute beta * K @ K^T (lower triangular) + solve_tril (I+A)^{-1} in one pass.
+
+    This kernel fuses chunk_scaled_dot_kkt_fwd and solve_tril into a single kernel,
+    avoiding the HBM round-trip for the intermediate A matrix.
+
+    Steps:
+    1. Compute all 10 lower-triangular [BC, BC] blocks of beta * K @ K^T in registers
+    2. Apply gate and beta scaling
+    3. Forward substitution on diagonal blocks
+    4. Block merge to get full (I+A)^{-1}
+    5. Write result to A (output)
+    """
+    i_t, i_bh = tl.program_id(0).to(tl.int64), tl.program_id(1)
+    i_b, i_h = i_bh // HV, i_bh % HV
+
+    if IS_VARLEN:
+        if i_t >= load_ragged_chunk_count(chunk_offsets, num_sequences):
+            return
+        i_n, i_t, token_start, _valid = load_ragged_chunk_work(
+            cu_seqlens, chunk_offsets, i_t, num_sequences, BT
+        )
+        bos = token_start - i_t * BT
+        eos = tl.load(cu_seqlens + ptr_offset((i_n + 1,), (1,))).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    if i_t * BT >= T:
+        return
+
+    i_tc0 = i_t * BT
+    i_tc1 = i_t * BT + BC
+    i_tc2 = i_t * BT + 2 * BC
+    i_tc3 = i_t * BT + 3 * BC
+
+    k += ptr_offset((bos, i_h // (HV // H)), (k_stride_t, K))
+    A += ptr_offset((bos, i_h), (HV * BT, BT))
+
+    o_i = tl.arange(0, BC)
+    m_tc0 = (i_tc0 + o_i) < T
+    m_tc1 = (i_tc1 + o_i) < T
+    m_tc2 = (i_tc2 + o_i) < T
+    m_tc3 = (i_tc3 + o_i) < T
+
+    # load beta for each sub-chunk
+    p_b0 = beta + ptr_offset((bos + i_tc0 + o_i, i_h), (HV, 1))
+    p_b1 = beta + ptr_offset((bos + i_tc1 + o_i, i_h), (HV, 1))
+    p_b2 = beta + ptr_offset((bos + i_tc2 + o_i, i_h), (HV, 1))
+    p_b3 = beta + ptr_offset((bos + i_tc3 + o_i, i_h), (HV, 1))
+    b_b0 = tl.load(p_b0, mask=m_tc0, other=0.0).to(tl.float32)
+    b_b1 = tl.load(p_b1, mask=m_tc1, other=0.0).to(tl.float32)
+    b_b2 = tl.load(p_b2, mask=m_tc2, other=0.0).to(tl.float32)
+    b_b3 = tl.load(p_b3, mask=m_tc3, other=0.0).to(tl.float32)
+
+    p_g0 = g + ptr_offset((bos + i_tc0 + o_i, i_h), (HV, 1))
+    p_g1 = g + ptr_offset((bos + i_tc1 + o_i, i_h), (HV, 1))
+    p_g2 = g + ptr_offset((bos + i_tc2 + o_i, i_h), (HV, 1))
+    p_g3 = g + ptr_offset((bos + i_tc3 + o_i, i_h), (HV, 1))
+    b_g0 = tl.load(p_g0, mask=m_tc0, other=0.0).to(tl.float32)
+    b_g1 = tl.load(p_g1, mask=m_tc1, other=0.0).to(tl.float32)
+    b_g2 = tl.load(p_g2, mask=m_tc2, other=0.0).to(tl.float32)
+    b_g3 = tl.load(p_g3, mask=m_tc3, other=0.0).to(tl.float32)
+
+    ############################################################################
+    # Step 1: compute all 10 lower-triangular [BC, BC] blocks of K @ K^T
+    ############################################################################
+
+    # 4 diagonal blocks
+    b_A00 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_A11 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_A22 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_A33 = tl.zeros([BC, BC], dtype=tl.float32)
+
+    # 6 off-diagonal blocks
+    b_A10 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_A20 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_A21 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_A30 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_A31 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_A32 = tl.zeros([BC, BC], dtype=tl.float32)
+
+    for i_k in range(tl.cdiv(K, BK)):
+        o_k = i_k * BK + tl.arange(0, BK)
+        p_k0 = k + ptr_offset((i_tc0 + o_i[:, None], o_k[None, :]), (k_stride_t, 1))
+        b_k0 = tl.load(p_k0, mask=m_tc0[:, None] & (o_k[None, :] < K), other=0.0)
+        # diagonal block 0
+        b_A00 += tl.dot(b_k0, tl.trans(b_k0))
+
+        if i_tc1 < T:
+            p_k1 = k + ptr_offset((i_tc1 + o_i[:, None], o_k[None, :]), (k_stride_t, 1))
+            b_k1 = tl.load(p_k1, mask=m_tc1[:, None] & (o_k[None, :] < K), other=0.0)
+            # diagonal block 1
+            b_A11 += tl.dot(b_k1, tl.trans(b_k1))
+            # off-diagonal (1,0)
+            b_A10 += tl.dot(b_k1, tl.trans(b_k0))
+
+            if i_tc2 < T:
+                p_k2 = k + ptr_offset((i_tc2 + o_i[:, None], o_k[None, :]), (k_stride_t, 1))
+                b_k2 = tl.load(p_k2, mask=m_tc2[:, None] & (o_k[None, :] < K), other=0.0)
+                # diagonal block 2
+                b_A22 += tl.dot(b_k2, tl.trans(b_k2))
+                # off-diagonal (2,0), (2,1)
+                b_A20 += tl.dot(b_k2, tl.trans(b_k0))
+                b_A21 += tl.dot(b_k2, tl.trans(b_k1))
+
+                if i_tc3 < T:
+                    p_k3 = k + ptr_offset((i_tc3 + o_i[:, None], o_k[None, :]), (k_stride_t, 1))
+                    b_k3 = tl.load(p_k3, mask=m_tc3[:, None] & (o_k[None, :] < K), other=0.0)
+                    # diagonal block 3
+                    b_A33 += tl.dot(b_k3, tl.trans(b_k3))
+                    # off-diagonal (3,0), (3,1), (3,2)
+                    b_A30 += tl.dot(b_k3, tl.trans(b_k0))
+                    b_A31 += tl.dot(b_k3, tl.trans(b_k1))
+                    b_A32 += tl.dot(b_k3, tl.trans(b_k2))
+
+    ############################################################################
+    # Step 2: apply gate and beta scaling
+    ############################################################################
+
+    # apply gate, beta scaling, and masking
+    # m_d: strictly lower triangular mask for diagonal blocks
+    # m_tc: boundary mask to prevent NaN from 0 * inf (IEEE 754) when
+    #   out-of-bounds g loads as 0 via boundary_check and exp2(0 - g_inbounds) overflows
+    m_d = o_i[:, None] > o_i[None, :]
+    m_I = o_i[:, None] == o_i[None, :]
+
+    mask00 = m_d & m_tc0[:, None] & m_tc0[None, :]
+    mask11 = m_d & m_tc1[:, None] & m_tc1[None, :]
+    mask22 = m_d & m_tc2[:, None] & m_tc2[None, :]
+    mask33 = m_d & m_tc3[:, None] & m_tc3[None, :]
+    mask10 = m_tc1[:, None] & m_tc0[None, :]
+    mask20 = m_tc2[:, None] & m_tc0[None, :]
+    mask21 = m_tc2[:, None] & m_tc1[None, :]
+    mask30 = m_tc3[:, None] & m_tc0[None, :]
+    mask31 = m_tc3[:, None] & m_tc1[None, :]
+    mask32 = m_tc3[:, None] & m_tc2[None, :]
+    b_A00 *= tl.where(mask00, exp2(tl.where(mask00, b_g0[:, None] - b_g0[None, :], 0.0)), 0.0)
+    b_A11 *= tl.where(mask11, exp2(tl.where(mask11, b_g1[:, None] - b_g1[None, :], 0.0)), 0.0)
+    b_A22 *= tl.where(mask22, exp2(tl.where(mask22, b_g2[:, None] - b_g2[None, :], 0.0)), 0.0)
+    b_A33 *= tl.where(mask33, exp2(tl.where(mask33, b_g3[:, None] - b_g3[None, :], 0.0)), 0.0)
+    b_A10 *= tl.where(mask10, exp2(tl.where(mask10, b_g1[:, None] - b_g0[None, :], 0.0)), 0.0)
+    b_A20 *= tl.where(mask20, exp2(tl.where(mask20, b_g2[:, None] - b_g0[None, :], 0.0)), 0.0)
+    b_A21 *= tl.where(mask21, exp2(tl.where(mask21, b_g2[:, None] - b_g1[None, :], 0.0)), 0.0)
+    b_A30 *= tl.where(mask30, exp2(tl.where(mask30, b_g3[:, None] - b_g0[None, :], 0.0)), 0.0)
+    b_A31 *= tl.where(mask31, exp2(tl.where(mask31, b_g3[:, None] - b_g1[None, :], 0.0)), 0.0)
+    b_A32 *= tl.where(mask32, exp2(tl.where(mask32, b_g3[:, None] - b_g2[None, :], 0.0)), 0.0)
+
+    # diagonal blocks: scaled by beta
+    b_A00 = b_A00 * b_b0[:, None]
+    b_A11 = b_A11 * b_b1[:, None]
+    b_A22 = b_A22 * b_b2[:, None]
+    b_A33 = b_A33 * b_b3[:, None]
+
+    # off-diagonal blocks: full block, scaled by beta
+    b_A10 = b_A10 * b_b1[:, None]
+    b_A20 = b_A20 * b_b2[:, None]
+    b_A21 = b_A21 * b_b2[:, None]
+    b_A30 = b_A30 * b_b3[:, None]
+    b_A31 = b_A31 * b_b3[:, None]
+    b_A32 = b_A32 * b_b3[:, None]
+
+    ############################################################################
+    # Step 3: forward substitution on diagonal blocks -> (I + A_diag)^{-1}
+    #
+    # Same algorithm as solve_tril, but rows are extracted from in-register
+    # [BC, BC] tensor via tl.sum(tl.where(mask, tensor, 0), 0) instead of
+    # tl.load from HBM.
+    ############################################################################
+
+    b_Ai00 = _solve_diagonal_block(b_A00, o_i, T - i_tc0, BC)
+    b_Ai11 = _solve_diagonal_block(b_A11, o_i, T - i_tc1, BC)
+    b_Ai22 = _solve_diagonal_block(b_A22, o_i, T - i_tc2, BC)
+    b_Ai33 = _solve_diagonal_block(b_A33, o_i, T - i_tc3, BC)
+
+    b_Ai00 += m_I
+    b_Ai11 += m_I
+    b_Ai22 += m_I
+    b_Ai33 += m_I
+
+    ############################################################################
+    # Step 4: block merge -> full (I + A)^{-1}
+    ############################################################################
+
+    b_Ai10 = -tl.dot(
+        tl.dot(b_Ai11, b_A10, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        b_Ai00,
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+    b_Ai21 = -tl.dot(
+        tl.dot(b_Ai22, b_A21, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        b_Ai11,
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+    b_Ai32 = -tl.dot(
+        tl.dot(b_Ai33, b_A32, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        b_Ai22,
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+
+    b_Ai20 = -tl.dot(
+        b_Ai22,
+        tl.dot(b_A20, b_Ai00, input_precision=SOLVE_TRIL_DOT_PRECISION)
+        + tl.dot(b_A21, b_Ai10, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+    b_Ai31 = -tl.dot(
+        b_Ai33,
+        tl.dot(b_A31, b_Ai11, input_precision=SOLVE_TRIL_DOT_PRECISION)
+        + tl.dot(b_A32, b_Ai21, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+    b_Ai30 = -tl.dot(
+        b_Ai33,
+        tl.dot(b_A30, b_Ai00, input_precision=SOLVE_TRIL_DOT_PRECISION)
+        + tl.dot(b_A31, b_Ai10, input_precision=SOLVE_TRIL_DOT_PRECISION)
+        + tl.dot(b_A32, b_Ai20, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+
+    ############################################################################
+    # Step 5: store full (I + A)^{-1} to output A
+    ############################################################################
+
+    p_A00 = A + ptr_offset((i_tc0 + o_i[:, None], o_i[None, :]), (HV * BT, 1))
+    p_A10 = A + ptr_offset((i_tc1 + o_i[:, None], o_i[None, :]), (HV * BT, 1))
+    p_A11 = A + ptr_offset((i_tc1 + o_i[:, None], BC + o_i[None, :]), (HV * BT, 1))
+    p_A20 = A + ptr_offset((i_tc2 + o_i[:, None], o_i[None, :]), (HV * BT, 1))
+    p_A21 = A + ptr_offset((i_tc2 + o_i[:, None], BC + o_i[None, :]), (HV * BT, 1))
+    p_A22 = A + ptr_offset((i_tc2 + o_i[:, None], 2 * BC + o_i[None, :]), (HV * BT, 1))
+    p_A30 = A + ptr_offset((i_tc3 + o_i[:, None], o_i[None, :]), (HV * BT, 1))
+    p_A31 = A + ptr_offset((i_tc3 + o_i[:, None], BC + o_i[None, :]), (HV * BT, 1))
+    p_A32 = A + ptr_offset((i_tc3 + o_i[:, None], 2 * BC + o_i[None, :]), (HV * BT, 1))
+    p_A33 = A + ptr_offset((i_tc3 + o_i[:, None], 3 * BC + o_i[None, :]), (HV * BT, 1))
+
+    m_A0 = m_tc0[:, None] & (o_i[None, :] < BT)
+    m_A1 = m_tc1[:, None] & (o_i[None, :] < BT)
+    m_A2 = m_tc2[:, None] & (o_i[None, :] < BT)
+    m_A3 = m_tc3[:, None] & (o_i[None, :] < BT)
+    m_A11 = m_tc1[:, None] & ((BC + o_i)[None, :] < BT)
+    m_A21 = m_tc2[:, None] & ((BC + o_i)[None, :] < BT)
+    m_A22 = m_tc2[:, None] & ((2 * BC + o_i)[None, :] < BT)
+    m_A31 = m_tc3[:, None] & ((BC + o_i)[None, :] < BT)
+    m_A32 = m_tc3[:, None] & ((2 * BC + o_i)[None, :] < BT)
+    m_A33 = m_tc3[:, None] & ((3 * BC + o_i)[None, :] < BT)
+
+    tl.store(p_A00, b_Ai00.to(A.dtype.element_ty), mask=m_A0)
+    tl.store(p_A10, b_Ai10.to(A.dtype.element_ty), mask=m_A1)
+    tl.store(p_A11, b_Ai11.to(A.dtype.element_ty), mask=m_A11)
+    tl.store(p_A20, b_Ai20.to(A.dtype.element_ty), mask=m_A2)
+    tl.store(p_A21, b_Ai21.to(A.dtype.element_ty), mask=m_A21)
+    tl.store(p_A22, b_Ai22.to(A.dtype.element_ty), mask=m_A22)
+    tl.store(p_A30, b_Ai30.to(A.dtype.element_ty), mask=m_A3)
+    tl.store(p_A31, b_Ai31.to(A.dtype.element_ty), mask=m_A31)
+    tl.store(p_A32, b_Ai32.to(A.dtype.element_ty), mask=m_A32)
+    tl.store(p_A33, b_Ai33.to(A.dtype.element_ty), mask=m_A33)
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+        "STORE_QG": lambda args: args["q"] is not None,
+    }
+)
+@triton.jit(do_not_specialize=["T", "num_sequences"])
+def scalar_recompute_w_u_kg_kernel(
+    q,
+    k,
+    v,
+    q_stride_t,
+    k_stride_t,
+    v_stride_t,
+    beta,
+    inverse,
+    cumulative_gate,
+    w,
+    u,
+    restored_k,
+    qg,
+    cu_seqlens,
+    chunk_offsets,
+    T,
+    num_sequences,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    STORE_QG: tl.constexpr,
+):
+    """Compute W/U and kg while K, beta, gate, and the solved transition are resident."""
+    chunk = tl.program_id(0)
+    batch_head = tl.program_id(1)
+    batch = batch_head // HV
+    head = batch_head % HV
+    key_head = head // (HV // H)
+    row = tl.arange(0, BT)
+    column = tl.arange(0, BT)
+    if IS_VARLEN:
+        if chunk >= load_ragged_chunk_count(chunk_offsets, num_sequences):
+            return
+        _sequence, _local_chunk, token_start, valid_tokens = load_ragged_chunk_work(
+            cu_seqlens, chunk_offsets, chunk, num_sequences, BT
+        )
+        global_token = token_start + row
+        token_mask = row < valid_tokens
+    else:
+        global_token = batch * T + chunk * BT + row
+        token_mask = row < BT
+        valid_tokens = BT
+
+    scalar_offset = ptr_offset((global_token, head), (HV, 1))
+    beta_row = tl.load(beta + scalar_offset, mask=token_mask, other=0.0).to(tl.float32)
+    gate = tl.load(cumulative_gate + scalar_offset, mask=token_mask, other=0.0).to(tl.float32)
+    inverse_tile = tl.load(
+        inverse + ptr_offset((global_token[:, None], head, column[None, :]), (HV * BT, BT, 1)),
+        mask=token_mask[:, None],
+        other=0.0,
+    )
+
+    for value_block in range(0, V, BV):
+        value = value_block + tl.arange(0, BV)
+        v_offset = ptr_offset((global_token[:, None], head, value[None, :]), (v_stride_t, V, 1))
+        output_offset = ptr_offset((global_token[:, None], head, value[None, :]), (HV * V, V, 1))
+        v_tile = tl.load(
+            v + v_offset,
+            mask=token_mask[:, None],
+            other=0.0,
+        )
+        u_tile = tl.dot(inverse_tile, (v_tile * beta_row[:, None]).to(v_tile.dtype))
+        tl.store(
+            u + output_offset,
+            u_tile.to(u.dtype.element_ty),
+            mask=token_mask[:, None],
+        )
+
+    final_gate = tl.sum(tl.where(row == valid_tokens - 1, gate, 0.0), axis=0)
+    gate_exp = tl.exp2(gate)
+    restore = tl.exp2(final_gate - gate)
+    for key_block in range(0, K, BK):
+        feature = key_block + tl.arange(0, BK)
+        k_tile = tl.load(
+            k
+            + ptr_offset((global_token[:, None], key_head, feature[None, :]), (k_stride_t, K, 1)),
+            mask=token_mask[:, None],
+            other=0.0,
+        )
+        weighted_k = k_tile * (beta_row * gate_exp)[:, None]
+        w_tile = tl.dot(inverse_tile, weighted_k.to(k_tile.dtype))
+        output_offset = ptr_offset((global_token[:, None], head, feature[None, :]), (HV * K, K, 1))
+        tl.store(w + output_offset, w_tile.to(w.dtype.element_ty), mask=token_mask[:, None])
+        tl.store(
+            restored_k + output_offset,
+            (k_tile * restore[:, None]).to(k_tile.dtype),
+            mask=token_mask[:, None],
+        )
+        if STORE_QG:
+            q_tile = tl.load(
+                q
+                + ptr_offset(
+                    (global_token[:, None], key_head, feature[None, :]), (q_stride_t, K, 1)
+                ),
+                mask=token_mask[:, None],
+                other=0.0,
+            )
+            tl.store(
+                qg + output_offset,
+                (q_tile * gate_exp[:, None]).to(q_tile.dtype),
+                mask=token_mask[:, None],
+            )
+
+
+def chunk_gdn_fwd_intra_dense(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Run dense GQA-capable BT64 scalar KKT/solve and W/U/kg."""
+    batch, tokens, key_heads, key_dim = k.shape
+    value_heads, value_dim = v.shape[2:]
+    if (
+        batch != 1
+        or tokens % 64
+        or key_dim != 128
+        or value_dim != 128
+        or v.shape[:2] != k.shape[:2]
+        or value_heads % key_heads
+    ):
+        raise ValueError("dense fused chunk GDN requires BT64, K=V=128, and H % HK == 0")
+    if (
+        cumulative_gate.shape != (batch, tokens, value_heads)
+        or beta.shape != cumulative_gate.shape
+    ):
+        raise ValueError("cumulative_gate and beta must follow value heads")
+    chunks = tokens // 64
+    inverse = torch.zeros(batch, tokens, value_heads, 64, dtype=k.dtype, device=k.device)
+    chunk_gdn_fwd_kkt_solve_kernel[(chunks, batch * value_heads)](
+        k=k,
+        k_stride_t=k.stride(1),
+        g=cumulative_gate,
+        beta=beta,
+        A=inverse,
+        cu_seqlens=None,
+        chunk_offsets=None,
+        T=tokens,
+        num_sequences=0,
+        H=key_heads,
+        HV=value_heads,
+        K=key_dim,
+        BT=64,
+        BC=16,
+    )
+
+    w = k.new_empty(batch, tokens, value_heads, key_dim)
+    u = torch.empty(v.shape, dtype=v.dtype, device=v.device)
+    restored_k = torch.empty_like(w)
+    scalar_recompute_w_u_kg_kernel[(chunks, batch * value_heads)](
+        q=None,
+        k=k,
+        v=v,
+        q_stride_t=0,
+        k_stride_t=k.stride(1),
+        v_stride_t=v.stride(1),
+        beta=beta,
+        inverse=inverse,
+        cumulative_gate=cumulative_gate,
+        w=w,
+        u=u,
+        restored_k=restored_k,
+        qg=None,
+        cu_seqlens=None,
+        chunk_offsets=None,
+        T=tokens,
+        num_sequences=0,
+        H=key_heads,
+        HV=value_heads,
+        K=key_dim,
+        V=value_dim,
+        BT=64,
+        BK=64,
+        BV=64,
+        num_warps=4,
+        num_stages=4,
+    )
+    return w, u, restored_k, inverse
+
+
+def chunk_gdn_fwd_intra_packed(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    metadata: RaggedChunkMetadata,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Run fixed-capacity packed scalar KKT/solve and W/U/kg."""
+    metadata.validate_chunk_size(64)
+    batch, tokens, key_heads, key_dim = k.shape
+    value_heads, value_dim = v.shape[2:]
+    if (
+        batch != 1
+        or key_dim != 128
+        or value_dim != 128
+        or v.shape[:2] != k.shape[:2]
+        or value_heads % key_heads
+    ):
+        raise ValueError("packed fused chunk GDN requires B=1, K=V=128, and H % HK == 0")
+    if (
+        cumulative_gate.shape != (batch, tokens, value_heads)
+        or beta.shape != cumulative_gate.shape
+    ):
+        raise ValueError("cumulative_gate and beta must follow value heads")
+
+    inverse = torch.zeros(batch, tokens, value_heads, 64, dtype=k.dtype, device=k.device)
+    chunk_gdn_fwd_kkt_solve_kernel[(metadata.capacity, value_heads)](
+        k=k,
+        k_stride_t=k.stride(1),
+        g=cumulative_gate,
+        beta=beta,
+        A=inverse,
+        cu_seqlens=metadata.cu_seqlens,
+        chunk_offsets=metadata.chunk_offsets,
+        T=tokens,
+        num_sequences=metadata.cu_seqlens.shape[0] - 1,
+        H=key_heads,
+        HV=value_heads,
+        K=key_dim,
+        BT=64,
+        BC=16,
+    )
+
+    w = k.new_zeros(batch, tokens, value_heads, key_dim)
+    u = torch.zeros(v.shape, dtype=v.dtype, device=v.device)
+    restored_k = torch.zeros_like(w)
+    scalar_recompute_w_u_kg_kernel[(metadata.capacity, value_heads)](
+        q=None,
+        k=k,
+        v=v,
+        q_stride_t=0,
+        k_stride_t=k.stride(1),
+        v_stride_t=v.stride(1),
+        beta=beta,
+        inverse=inverse,
+        cumulative_gate=cumulative_gate,
+        w=w,
+        u=u,
+        restored_k=restored_k,
+        qg=None,
+        cu_seqlens=metadata.cu_seqlens,
+        chunk_offsets=metadata.chunk_offsets,
+        T=tokens,
+        num_sequences=metadata.cu_seqlens.shape[0] - 1,
+        H=key_heads,
+        HV=value_heads,
+        K=key_dim,
+        V=value_dim,
+        BT=64,
+        BK=64,
+        BV=64,
+        num_warps=4,
+        num_stages=4,
+    )
+    return w, u, restored_k, inverse
+
+
+def chunk_gdn_recompute_w_u_qg_kg(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    inverse: torch.Tensor,
+    metadata: RaggedChunkMetadata | None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Recompute scalar W/U/qg/kg from the saved inverse without rebuilding KKT."""
+    batch, tokens, key_heads, key_dim = q.shape
+    value_heads, value_dim = v.shape[2:]
+    if (
+        k.shape != q.shape
+        or v.shape[:2] != q.shape[:2]
+        or value_heads % key_heads
+        or (key_dim, value_dim) != (128, 128)
+    ):
+        raise ValueError("fused chunk GDN recompute requires K=V=128 and H % HK == 0")
+    if metadata is not None:
+        metadata.validate_chunk_size(64)
+        if batch != 1:
+            raise ValueError("packed fused chunk GDN recompute requires B=1")
+    elif tokens % 64:
+        raise ValueError("dense fused chunk GDN recompute requires complete BT64 chunks")
+
+    factory = torch.zeros if metadata is not None else torch.empty
+    w = factory((batch, tokens, value_heads, key_dim), dtype=k.dtype, device=k.device)
+    u = factory(v.shape, dtype=v.dtype, device=v.device)
+    restored_k = factory(w.shape, dtype=w.dtype, device=w.device)
+    qg = factory(w.shape, dtype=w.dtype, device=w.device)
+    chunks = tokens // 64 if metadata is None else metadata.capacity
+    cu_seqlens = None if metadata is None else metadata.cu_seqlens
+    chunk_offsets = None if metadata is None else metadata.chunk_offsets
+    num_sequences = 0 if metadata is None else metadata.cu_seqlens.shape[0] - 1
+    scalar_recompute_w_u_kg_kernel[(chunks, batch * value_heads)](
+        q=q,
+        k=k,
+        v=v,
+        q_stride_t=q.stride(1),
+        k_stride_t=k.stride(1),
+        v_stride_t=v.stride(1),
+        beta=beta,
+        inverse=inverse,
+        cumulative_gate=cumulative_gate,
+        w=w,
+        u=u,
+        restored_k=restored_k,
+        qg=qg,
+        cu_seqlens=cu_seqlens,
+        chunk_offsets=chunk_offsets,
+        T=tokens,
+        num_sequences=num_sequences,
+        H=key_heads,
+        HV=value_heads,
+        K=key_dim,
+        V=value_dim,
+        BT=64,
+        BK=64,
+        BV=64,
+        num_warps=4,
+        num_stages=4,
+    )
+    return w, u, qg, restored_k
+
+
+__all__ = [
+    "chunk_gdn_fwd_intra_dense",
+    "chunk_gdn_fwd_intra_packed",
+    "chunk_gdn_recompute_w_u_qg_kg",
+]

--- a/attn_gym/linear/gdn/fwd/triton/chunk_gdn_fwd_output.py
+++ b/attn_gym/linear/gdn/fwd/triton/chunk_gdn_fwd_output.py
@@ -1,0 +1,233 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+# Copyright (c) 2026 Meta Platforms, Inc. and affiliates.
+#
+# Portions are derived from flash-linear-attention and licensed under the MIT license;
+# see https://github.com/fla-org/flash-linear-attention/graphs/contributors.
+# The remaining portions use the BSD-style license in the repository root.
+
+"""Scalar-GDN output composition with on-the-fly causal QK."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from attn_gym._backends.triton.utils import ptr_offset
+from attn_gym.linear.kda.chunk_scheduler import (
+    RaggedChunkMetadata,
+    load_ragged_chunk_count,
+    load_ragged_chunk_work,
+)
+from attn_gym.linear.kda.utils import autotune_cache_kwargs, exp2
+
+
+@triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
+@triton.autotune(
+    configs=[
+        triton.Config({"BK": 128, "BV": 128}, num_warps=8, num_stages=3),
+        triton.Config({"BK": 64, "BV": 64}, num_warps=4, num_stages=3),
+        triton.Config({"BK": 32, "BV": 32}, num_warps=2, num_stages=3),
+    ],
+    key=["H", "HV", "K", "V", "BT"],
+    **autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["T", "num_sequences"])
+def chunk_fwd_kernel_o(
+    q,
+    k,
+    v,
+    q_stride_t,
+    k_stride_t,
+    v_stride_t,
+    h,
+    g,
+    o,
+    cu_seqlens,
+    chunk_offsets,
+    scale,
+    T,
+    num_sequences,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1).to(tl.int64), tl.program_id(2).to(tl.int64)
+    i_b, i_h = i_bh // HV, i_bh % HV
+
+    if IS_VARLEN:
+        if i_t >= load_ragged_chunk_count(chunk_offsets, num_sequences):
+            return
+        i_tg = i_t
+        i_n, i_t, token_start, _valid = load_ragged_chunk_work(
+            cu_seqlens, chunk_offsets, i_t, num_sequences, BT
+        )
+        bos = token_start - i_t * BT
+        eos = tl.load(cu_seqlens + ptr_offset((i_n + 1,), (1,))).to(tl.int32)
+        T = eos - bos
+        NT = tl.cdiv(T, BT)
+    else:
+        NT = tl.cdiv(T, BT)
+        i_tg = i_b * NT + i_t
+        bos, eos = i_b * T, i_b * T + T
+
+    # offset calculation
+    key_head = i_h // (HV // H)
+    q += ptr_offset((bos, key_head), (q_stride_t, K))
+    k += ptr_offset((bos, key_head), (k_stride_t, K))
+    v += ptr_offset((bos, i_h), (v_stride_t, V))
+    o += ptr_offset((bos, i_h), (HV * V, V))
+    h += ptr_offset((i_tg, i_h), (HV * K * V, K * V))
+
+    b_o = tl.zeros([BT, BV], dtype=tl.float32)
+    b_A = tl.zeros([BT, BT], dtype=tl.float32)
+
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
+    o_v = i_v * BV + tl.arange(0, BV)
+    for i_k in range(tl.cdiv(K, BK)):
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = o_k < K
+        p_q = q + ptr_offset((o_t[:, None], o_k[None, :]), (q_stride_t, 1))
+        p_k = k + ptr_offset((o_k[:, None], o_t[None, :]), (1, k_stride_t))
+        p_h = h + ptr_offset((o_k[:, None], o_v[None, :]), (V, 1))
+        m_h = m_k[:, None] & (o_v[None, :] < V)
+        # [BT, BK]
+        b_q = tl.load(p_q, mask=m_t[:, None] & m_k[None, :], other=0.0)
+        # [BK, BT]
+        b_k = tl.load(p_k, mask=m_k[:, None] & m_t[None, :], other=0.0)
+        b_h = tl.load(p_h, mask=m_h, other=0.0)
+
+        # [BT, BK] @ [BK, BV] -> [BT, BV]
+        b_o += tl.dot(b_q, b_h)
+        # [BT, BK] @ [BK, BT] -> [BT, BT]
+        b_A += tl.dot(b_q, b_k)
+
+    g += ptr_offset((bos, i_h), (HV, 1))
+    p_g = g + ptr_offset((o_t,), (HV,))
+    b_g = tl.load(p_g, mask=m_t, other=0.0)
+    b_o = b_o * exp2(b_g)[:, None]
+    decay_mask = (o_t[:, None] >= o_t[None, :]) & (m_t[:, None] & m_t)
+    gate_delta = b_g[:, None] - b_g[None, :]
+    decay = tl.where(
+        decay_mask,
+        exp2(tl.where(decay_mask, gate_delta, 0.0)),
+        0.0,
+    )
+    b_A = b_A * decay
+    m_A = (o_t[:, None] >= o_t[None, :]) & (m_t[:, None] & m_t)
+    b_A = tl.where(m_A, b_A, 0)
+
+    p_v = v + ptr_offset((o_t[:, None], o_v[None, :]), (v_stride_t, 1))
+    p_o = o + ptr_offset((o_t[:, None], o_v[None, :]), (HV * V, 1))
+
+    b_v = tl.load(p_v, mask=m_t[:, None] & (o_v < V)[None, :], other=0.0)
+    # to fix mma -> mma layout conversion
+    # already solved by triton v3.2 or higher
+    b_o = b_o * scale + tl.dot(b_A.to(b_v.dtype), b_v) * scale
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_t[:, None] & (o_v < V)[None, :])
+
+
+def chunk_gdn_fwd_output_dense(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    h: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    scale: float,
+) -> torch.Tensor:
+    """Compose dense GQA-capable BT64 output without materializing Aqk."""
+    batch, tokens, key_heads, key_dim = q.shape
+    value_heads, value_dim = v.shape[2:]
+    if k.shape != q.shape or v.shape[:2] != q.shape[:2] or value_heads % key_heads:
+        raise ValueError("dense fused chunk GDN requires matching Q/K and H % HK == 0")
+    if batch != 1 or tokens % 64 or (key_dim, value_dim) != (128, 128):
+        raise ValueError("dense fused chunk GDN requires B=1, complete BT64 chunks, and K=V=128")
+    chunks = tokens // 64
+    if h.shape != (batch, chunks, value_heads, key_dim, value_dim):
+        raise ValueError("h must contain one [K,V] entry state per chunk and head")
+
+    output = torch.empty(v.shape, dtype=v.dtype, device=v.device)
+
+    def grid(meta):
+        return (triton.cdiv(value_dim, meta["BV"]), chunks, batch * value_heads)
+
+    chunk_fwd_kernel_o[grid](
+        q=q,
+        k=k,
+        v=v,
+        q_stride_t=q.stride(1),
+        k_stride_t=k.stride(1),
+        v_stride_t=v.stride(1),
+        h=h,
+        g=cumulative_gate,
+        o=output,
+        cu_seqlens=None,
+        chunk_offsets=None,
+        scale=scale,
+        T=tokens,
+        num_sequences=0,
+        H=key_heads,
+        HV=value_heads,
+        K=key_dim,
+        V=value_dim,
+        BT=64,
+    )
+    return output
+
+
+def chunk_gdn_fwd_output_packed(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    h: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    scale: float,
+    metadata: RaggedChunkMetadata,
+) -> torch.Tensor:
+    """Compose fixed-capacity packed GQA output without materializing Aqk."""
+    metadata.validate_chunk_size(64)
+    batch, tokens, key_heads, key_dim = q.shape
+    value_heads, value_dim = v.shape[2:]
+    if batch != 1 or k.shape != q.shape or v.shape[:2] != q.shape[:2]:
+        raise ValueError("packed fused chunk GDN requires B=1 and matching Q/K token axes")
+    if value_heads % key_heads or (key_dim, value_dim) != (128, 128):
+        raise ValueError("packed fused chunk GDN requires K=V=128 and H % HK == 0")
+    if h.shape != (batch, metadata.capacity, value_heads, key_dim, value_dim):
+        raise ValueError("h must contain one fixed-capacity [K,V] entry state per chunk")
+
+    output = torch.empty(v.shape, dtype=v.dtype, device=v.device)
+
+    def grid(meta):
+        return (triton.cdiv(value_dim, meta["BV"]), metadata.capacity, value_heads)
+
+    chunk_fwd_kernel_o[grid](
+        q=q,
+        k=k,
+        v=v,
+        q_stride_t=q.stride(1),
+        k_stride_t=k.stride(1),
+        v_stride_t=v.stride(1),
+        h=h,
+        g=cumulative_gate,
+        o=output,
+        cu_seqlens=metadata.cu_seqlens,
+        chunk_offsets=metadata.chunk_offsets,
+        scale=scale,
+        T=tokens,
+        num_sequences=metadata.cu_seqlens.shape[0] - 1,
+        H=key_heads,
+        HV=value_heads,
+        K=key_dim,
+        V=value_dim,
+        BT=64,
+    )
+    return output
+
+
+__all__ = ["chunk_gdn_fwd_output_dense", "chunk_gdn_fwd_output_packed"]

--- a/attn_gym/linear/gdn/fwd/triton/chunk_gdn_fwd_recurrence.py
+++ b/attn_gym/linear/gdn/fwd/triton/chunk_gdn_fwd_recurrence.py
@@ -1,0 +1,218 @@
+"""Dense scalar-gate specialization of the KDA inter-chunk state recurrence."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+from attn_gym._backends.triton.utils import ptr_offset
+from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata, load_ragged_sequence_work
+
+
+@triton.jit(do_not_specialize=["T"])
+def chunk_gdn_fwd_recurrence_kernel(
+    k_desc,
+    w_desc,
+    u_desc,
+    v_new_desc,
+    h_desc,
+    cumulative_gate,
+    initial_state_desc,
+    final_state_desc,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BV: tl.constexpr,
+):
+    """Keep one KxBV state tile resident while traversing BT64 chunks."""
+    batch_head = tl.program_id(0)
+    value_tile = tl.program_id(1)
+    batch = batch_head // H
+    head = batch_head % H
+    state_vk = initial_state_desc.load([batch, head, value_tile * BV, 0])
+    state = tl.trans(tl.reshape(state_vk, [BV, K])).to(tl.float32)
+    for chunk in tl.range(0, T // BT, warp_specialize=True, num_stages=3):
+        token = chunk * BT
+        h_desc.store(
+            [batch, chunk, head, 0, value_tile * BV],
+            tl.reshape(state.to(k_desc.dtype), [1, 1, 1, K, BV]),
+        )
+        w = tl.reshape(w_desc.load([batch, token, head, 0]), [BT, K])
+        u = tl.reshape(u_desc.load([batch, token, head, value_tile * BV]), [BT, BV])
+        v_new = u.to(tl.float32) - tl.dot(w, state.to(w.dtype))
+        v_new_desc.store(
+            [batch, token, head, value_tile * BV],
+            tl.reshape(v_new.to(u.dtype), [1, BT, 1, BV]),
+        )
+
+        final_gate = tl.load(
+            cumulative_gate + ptr_offset((batch * T + token + BT - 1, head), (H, 1))
+        ).to(tl.float32)
+        state *= tl.exp2(final_gate)
+        restored_key = tl.reshape(k_desc.load([batch, token, head, 0]), [BT, K])
+        state = tl.dot(tl.trans(restored_key), v_new.to(restored_key.dtype), acc=state)
+
+    final_state_desc.store(
+        [batch, head, value_tile * BV, 0],
+        tl.reshape(tl.trans(state), [1, 1, BV, K]),
+    )
+
+
+def chunk_gdn_fwd_recurrence_dense(
+    k: torch.Tensor,
+    w: torch.Tensor,
+    u: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    initial_state: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Run dense BT64 recurrence with precomputed restored keys."""
+    batch, tokens, heads, key_dim = k.shape
+    value_dim = u.shape[-1]
+    if tokens % 64 or (key_dim, value_dim) != (128, 128):
+        raise ValueError("dense fused chunk GDN requires complete BT64 chunks and K=V=128")
+    if w.shape != k.shape or cumulative_gate.shape != k.shape[:3]:
+        raise ValueError("w must match k and cumulative_gate must have shape [B,T,H]")
+    if initial_state.shape != (batch, heads, value_dim, key_dim):
+        raise ValueError("initial_state must have shape [B,H,V,K]")
+
+    chunks = tokens // 64
+    block_value = 64
+    h = torch.empty(batch, chunks, heads, key_dim, value_dim, dtype=k.dtype, device=k.device)
+    v_new = torch.empty_like(u)
+    final_state = torch.empty_like(initial_state)
+    chunk_gdn_fwd_recurrence_kernel[(batch * heads, value_dim // block_value)](
+        TensorDescriptor.from_tensor(k, [1, 64, 1, key_dim]),
+        TensorDescriptor.from_tensor(w, [1, 64, 1, key_dim]),
+        TensorDescriptor.from_tensor(u, [1, 64, 1, block_value]),
+        TensorDescriptor.from_tensor(v_new, [1, 64, 1, block_value]),
+        TensorDescriptor.from_tensor(h, [1, 1, 1, key_dim, block_value]),
+        cumulative_gate,
+        TensorDescriptor.from_tensor(initial_state, [1, 1, block_value, key_dim]),
+        TensorDescriptor.from_tensor(final_state, [1, 1, block_value, key_dim]),
+        tokens,
+        H=heads,
+        K=key_dim,
+        BT=64,
+        BV=block_value,
+        num_warps=4,
+        num_stages=3,
+    )
+    return h, v_new, final_state
+
+
+@triton.jit
+def chunk_gdn_fwd_recurrence_packed_kernel(
+    restored_k,
+    w,
+    u,
+    cumulative_gate,
+    initial_state,
+    h,
+    v_new,
+    final_state,
+    cu_seqlens,
+    chunk_offsets,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BV: tl.constexpr,
+):
+    """Traverse one packed sequence/head/value tile with a resident FP32 state."""
+    sequence_head = tl.program_id(0)
+    value_tile = tl.program_id(1)
+    sequence = sequence_head // H
+    head = sequence_head % H
+
+    bos, eos, chunk_begin = load_ragged_sequence_work(cu_seqlens, chunk_offsets, sequence)
+    bos, eos, chunk_begin = bos.to(tl.int64), eos.to(tl.int64), chunk_begin.to(tl.int64)
+    chunks = (eos - bos + BT - 1) // BT
+    key = tl.arange(0, K)
+    value = value_tile * BV + tl.arange(0, BV)
+    state_offset = ptr_offset(
+        (sequence, head, value[None, :], key[:, None]), (H * V * K, V * K, K, 1)
+    )
+    state = tl.load(initial_state + state_offset).to(tl.float32)
+    row = tl.arange(0, BT)
+
+    for local_chunk in tl.range(0, chunks):
+        global_chunk = chunk_begin + local_chunk
+        token_start = bos + local_chunk * BT
+        token = token_start + row
+        token_mask = token < eos
+        h_offset = ptr_offset(
+            (global_chunk, head, key[:, None], value[None, :]), (H * K * V, K * V, V, 1)
+        )
+        tl.store(h + h_offset, state.to(h.dtype.element_ty))
+
+        w_offset = ptr_offset((token[:, None], head, key[None, :]), (H * K, K, 1))
+        u_offset = ptr_offset((token[:, None], head, value[None, :]), (H * V, V, 1))
+        w_tile = tl.load(w + w_offset, mask=token_mask[:, None], other=0.0)
+        u_tile = tl.load(u + u_offset, mask=token_mask[:, None], other=0.0)
+        corrected = u_tile.to(tl.float32) - tl.dot(w_tile, state.to(w_tile.dtype))
+        tl.store(
+            v_new + u_offset,
+            corrected.to(v_new.dtype.element_ty),
+            mask=token_mask[:, None],
+        )
+
+        final_token = tl.minimum(token_start + BT, eos) - 1
+        final_gate = tl.load(cumulative_gate + ptr_offset((final_token, head), (H, 1))).to(
+            tl.float32
+        )
+        state *= tl.exp2(final_gate)
+        restored = tl.load(restored_k + w_offset, mask=token_mask[:, None], other=0.0)
+        state = tl.dot(tl.trans(restored), corrected.to(restored.dtype), acc=state)
+
+    tl.store(final_state + state_offset, state)
+
+
+def chunk_gdn_fwd_recurrence_packed(
+    restored_k: torch.Tensor,
+    w: torch.Tensor,
+    u: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    initial_state: torch.Tensor,
+    metadata: RaggedChunkMetadata,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Run fixed-capacity packed recurrence with empty-sequence state identity."""
+    metadata.validate_chunk_size(64)
+    batch, tokens, heads, key_dim = restored_k.shape
+    value_dim = u.shape[-1]
+    num_sequences = metadata.cu_seqlens.shape[0] - 1
+    if batch != 1 or tokens == 0 or (key_dim, value_dim) != (128, 128):
+        raise ValueError("packed fused chunk GDN recurrence requires B=1, T>0, and K=V=128")
+    expected_state = (num_sequences, heads, value_dim, key_dim)
+    if initial_state.shape != expected_state:
+        raise ValueError(f"initial_state must have shape {expected_state}")
+
+    h = restored_k.new_empty(1, metadata.capacity, heads, key_dim, value_dim)
+    v_new = torch.empty_like(u)
+    final_state = torch.empty_like(initial_state)
+    block_value = 64
+    chunk_gdn_fwd_recurrence_packed_kernel[(num_sequences * heads, value_dim // block_value)](
+        restored_k,
+        w,
+        u,
+        cumulative_gate,
+        initial_state,
+        h,
+        v_new,
+        final_state,
+        metadata.cu_seqlens,
+        metadata.chunk_offsets,
+        H=heads,
+        K=key_dim,
+        V=value_dim,
+        BT=64,
+        BV=block_value,
+        num_warps=4,
+        num_stages=2,
+    )
+    return h, v_new, final_state
+
+
+__all__ = ["chunk_gdn_fwd_recurrence_dense", "chunk_gdn_fwd_recurrence_packed"]

--- a/attn_gym/linear/gdn/impl/chunk.py
+++ b/attn_gym/linear/gdn/impl/chunk.py
@@ -1,0 +1,475 @@
+"""Dense training-capable fused chunk GDN implementation."""
+
+from __future__ import annotations
+
+import torch
+
+from attn_gym._backends.cute import (
+    get_device_properties,
+    normalize_compact_tensor,
+    normalize_tma_rows,
+)
+from attn_gym._backends.triton.utils import requires_int64_offsets
+from attn_gym.linear.gdn.bwd.triton.chunk_gdn_bwd_delta_h import chunk_gdn_bwd_delta_h
+from attn_gym.linear.gdn.bwd.triton.chunk_gdn_bwd_intra import (
+    chunk_gdn_bwd_intra_dense,
+    chunk_gdn_bwd_intra_packed,
+)
+from attn_gym.linear.gdn.bwd.triton.chunk_gdn_bwd_recompute import (
+    chunk_gdn_recompute_aqk_dense,
+    chunk_gdn_recompute_aqk_packed,
+)
+from attn_gym.linear.gdn.bwd.triton.chunk_gdn_bwd_wy import chunk_gdn_bwd_wy
+from attn_gym.linear.gdn.fwd.triton.chunk_gdn_fwd_intra import (
+    chunk_gdn_fwd_intra_dense,
+    chunk_gdn_fwd_intra_packed,
+    chunk_gdn_recompute_w_u_qg_kg,
+)
+from attn_gym.linear.gdn.fwd.triton.chunk_gdn_fwd_output import (
+    chunk_gdn_fwd_output_dense,
+    chunk_gdn_fwd_output_packed,
+)
+from attn_gym.linear.gdn.fwd.triton.chunk_gdn_fwd_recurrence import (
+    chunk_gdn_fwd_recurrence_dense,
+    chunk_gdn_fwd_recurrence_packed,
+)
+from attn_gym.linear.kda.bwd.cute.chunk_delta_h_bwd import (
+    blackwell_delta_h_bwd_dhu_dv_fused_dispatch,
+)
+from attn_gym.linear.kda.bwd.cute.chunk_kda_bwd_wy_dqkg_fused import (
+    chunk_kda_bwd_wy_dqkg,
+)
+from attn_gym.linear.kda.bwd.triton.chunk_kda_bwd_daqk import chunk_kda_bwd_daqk
+from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata, chunk_capacity
+
+
+def validate_supported_device(q: torch.Tensor) -> None:
+    """Reject devices older than the Hopper-capable fused implementation."""
+    if get_device_properties(q.device).major < 9:
+        raise ValueError("fused chunk_gdn requires CUDA capability 9.0 or newer")
+
+
+def use_blackwell_backward(q: torch.Tensor) -> bool:
+    """Select the CuTe backward only on its validated SM100/SM103 targets."""
+    properties = get_device_properties(q.device)
+    return properties.major == 10 and properties.minor in (0, 3)
+
+
+def reject_int64_offsets(*tensors: torch.Tensor | None) -> None:
+    """Reject layouts that need the not-yet-implemented wide-address specialization."""
+    if requires_int64_offsets(*tensors):
+        raise ValueError("fused chunk_gdn does not yet support int64 tensor offsets")
+
+
+def chunk_gdn_fwd_dense(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Run the dense B=1 BT64 scalar forward and return output, state, and inverse tape."""
+    validate_supported_device(q)
+    batch, tokens, key_heads, key_dim = q.shape
+    value_heads, value_dim = v.shape[2:]
+    if batch != 1 or tokens % 64 or (key_dim, value_dim) != (128, 128):
+        raise ValueError("dense fused chunk GDN requires B=1, complete BT64 chunks, and K=V=128")
+    if k.shape != q.shape or v.shape[:2] != q.shape[:2] or value_heads % key_heads:
+        raise ValueError("dense fused chunk GDN requires matching Q/K and H % HK == 0")
+    if cumulative_gate.shape != v.shape[:3] or beta.shape != v.shape[:3]:
+        raise ValueError("cumulative_gate and beta must have shape [B,T,H]")
+    if initial_state is None:
+        initial_state = torch.zeros(
+            batch,
+            value_heads,
+            value_dim,
+            key_dim,
+            dtype=torch.float32,
+            device=q.device,
+        )
+    reject_int64_offsets(q, k, v, cumulative_gate, beta, initial_state)
+    q, k, v = (normalize_tma_rows(tensor) for tensor in (q, k, v))
+    cumulative_gate, beta, initial_state = (
+        normalize_compact_tensor(tensor) for tensor in (cumulative_gate, beta, initial_state)
+    )
+
+    w, u, restored_k, inverse = chunk_gdn_fwd_intra_dense(k, v, cumulative_gate, beta)
+    h, v_new, final_state = chunk_gdn_fwd_recurrence_dense(
+        restored_k,
+        w,
+        u,
+        cumulative_gate,
+        initial_state,
+    )
+    output = chunk_gdn_fwd_output_dense(q, k, v_new, h, cumulative_gate, scale)
+    return output, final_state, inverse
+
+
+def _gdn_chunk_fwd_cuda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Registered dense forward without a public final-state output."""
+    output, _state, inverse = chunk_gdn_fwd_dense(
+        q, k, v, cumulative_gate, beta, initial_state, scale
+    )
+    return output, inverse
+
+
+def _gdn_chunk_fwd_with_state_cuda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Registered dense forward with final state and inverse tape."""
+    return chunk_gdn_fwd_dense(q, k, v, cumulative_gate, beta, initial_state, scale)
+
+
+def chunk_gdn_fwd_packed(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    metadata: RaggedChunkMetadata,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Run fixed-capacity packed scalar forward and return output, state, and inverse tape."""
+    validate_supported_device(q)
+    batch, _tokens, key_heads, key_dim = q.shape
+    value_heads, value_dim = v.shape[2:]
+    num_sequences = metadata.cu_seqlens.shape[0] - 1
+    if batch != 1 or (key_dim, value_dim) != (128, 128):
+        raise ValueError("packed fused chunk GDN requires B=1 and K=V=128")
+    if k.shape != q.shape or v.shape[:2] != q.shape[:2] or value_heads % key_heads:
+        raise ValueError("packed fused chunk GDN requires matching Q/K and H % HK == 0")
+    if initial_state is None:
+        initial_state = torch.zeros(
+            num_sequences,
+            value_heads,
+            value_dim,
+            key_dim,
+            dtype=torch.float32,
+            device=q.device,
+        )
+    reject_int64_offsets(q, k, v, cumulative_gate, beta, initial_state)
+    q, k, v = (normalize_tma_rows(tensor) for tensor in (q, k, v))
+    cumulative_gate, beta, initial_state = (
+        normalize_compact_tensor(tensor) for tensor in (cumulative_gate, beta, initial_state)
+    )
+
+    w, u, restored_k, inverse = chunk_gdn_fwd_intra_packed(k, v, cumulative_gate, beta, metadata)
+    h, v_new, final_state = chunk_gdn_fwd_recurrence_packed(
+        restored_k,
+        w,
+        u,
+        cumulative_gate,
+        initial_state,
+        metadata,
+    )
+    output = chunk_gdn_fwd_output_packed(q, k, v_new, h, cumulative_gate, scale, metadata)
+    return output, final_state, inverse
+
+
+def _gdn_chunk_fwd_packed_cuda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor,
+    chunk_offsets: torch.Tensor,
+    capacity: int,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Registered packed forward without a public final-state output."""
+    metadata = RaggedChunkMetadata(cu_seqlens, chunk_offsets, capacity, 64)
+    output, _state, inverse = chunk_gdn_fwd_packed(
+        q, k, v, cumulative_gate, beta, initial_state, metadata, scale
+    )
+    return output, inverse
+
+
+def _gdn_chunk_fwd_packed_with_state_cuda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor,
+    chunk_offsets: torch.Tensor,
+    capacity: int,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Registered packed forward with final state and inverse tape."""
+    metadata = RaggedChunkMetadata(cu_seqlens, chunk_offsets, capacity, 64)
+    return chunk_gdn_fwd_packed(q, k, v, cumulative_gate, beta, initial_state, metadata, scale)
+
+
+def chunk_gdn_bwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    inverse: torch.Tensor,
+    d_output: torch.Tensor,
+    d_final_state: torch.Tensor | None,
+    initial_state: torch.Tensor | None,
+    metadata: RaggedChunkMetadata | None,
+    scale: float,
+) -> tuple[torch.Tensor, ...]:
+    """Differentiate dense or packed fused chunk GDN through one shared protocol."""
+    validate_supported_device(q)
+    reject_int64_offsets(
+        q,
+        k,
+        v,
+        cumulative_gate,
+        beta,
+        inverse,
+        d_output,
+        d_final_state,
+        initial_state,
+    )
+    q, k, v = (normalize_tma_rows(tensor) for tensor in (q, k, v))
+    cumulative_gate, beta, inverse, d_output = (
+        normalize_compact_tensor(tensor) for tensor in (cumulative_gate, beta, inverse, d_output)
+    )
+    if d_final_state is not None:
+        d_final_state = normalize_compact_tensor(d_final_state)
+    if initial_state is not None:
+        initial_state = normalize_compact_tensor(initial_state)
+
+    state_batch = q.shape[0] if metadata is None else metadata.cu_seqlens.shape[0] - 1
+    recurrence_state = initial_state
+    if recurrence_state is None:
+        recurrence_state = torch.zeros(
+            state_batch,
+            v.shape[2],
+            v.shape[-1],
+            q.shape[-1],
+            dtype=torch.float32,
+            device=q.device,
+        )
+    w, u, qg, kg = chunk_gdn_recompute_w_u_qg_kg(q, k, v, cumulative_gate, beta, inverse, metadata)
+    if metadata is None:
+        h, v_new, _final_state = chunk_gdn_fwd_recurrence_dense(
+            kg, w, u, cumulative_gate, recurrence_state
+        )
+    else:
+        h, v_new, _final_state = chunk_gdn_fwd_recurrence_packed(
+            kg, w, u, cumulative_gate, recurrence_state, metadata
+        )
+
+    if not use_blackwell_backward(q):
+        dh, d_initial_state, dv = chunk_gdn_bwd_delta_h(
+            q,
+            k,
+            w,
+            cumulative_gate,
+            d_output,
+            d_final_state,
+            initial_state,
+            metadata,
+            scale,
+        )
+        dq, dk, dv, d_gate, db = chunk_gdn_bwd_wy(
+            q,
+            k,
+            v,
+            v_new,
+            w,
+            cumulative_gate,
+            beta,
+            inverse,
+            h,
+            d_output,
+            dh,
+            dv,
+            metadata,
+            scale,
+        )
+        return dq, dk, dv, d_gate, db, d_initial_state
+
+    d_aqk = chunk_kda_bwd_daqk(
+        v_new,
+        d_output,
+        scale,
+        chunk_size=64,
+        metadata=metadata,
+    )
+
+    # Reuse the proven vector-gate KDA gradient stages only after the scalar
+    # recompute; forward and backward preparation remain expansion-free.
+    groups = v.shape[2] // q.shape[2]
+    expanded_q, expanded_k = q, k
+    if groups > 1:
+        expanded_q, expanded_k = (tensor.repeat_interleave(groups, dim=2) for tensor in (q, k))
+    vector_gate = cumulative_gate.unsqueeze(-1).expand_as(expanded_q).contiguous()
+    aqk = (
+        chunk_gdn_recompute_aqk_dense(expanded_q, expanded_k, cumulative_gate, scale)
+        if metadata is None
+        else chunk_gdn_recompute_aqk_packed(
+            expanded_q, expanded_k, cumulative_gate, scale, metadata
+        )
+    )
+    dh, d_initial_state, dv = blackwell_delta_h_bwd_dhu_dv_fused_dispatch(
+        qg,
+        kg,
+        w,
+        d_output,
+        aqk,
+        gk=vector_gate,
+        h0=initial_state,
+        dht=d_final_state,
+        scale=scale,
+        chunk_size=64,
+        metadata=metadata,
+    )
+    dq, dk, dv, dg_raw, db, d_raw_akk = chunk_kda_bwd_wy_dqkg(
+        expanded_q,
+        expanded_k,
+        v,
+        v_new,
+        vector_gate,
+        beta,
+        inverse,
+        h,
+        d_output,
+        dh,
+        dv,
+        metadata,
+        scale=scale,
+        chunk_size=64,
+        fastmath=False,
+        autotune=False,
+    )
+    intra = (
+        chunk_gdn_bwd_intra_dense(
+            expanded_q,
+            expanded_k,
+            cumulative_gate,
+            beta,
+            d_aqk,
+            d_raw_akk,
+            dg_raw,
+        )
+        if metadata is None
+        else chunk_gdn_bwd_intra_packed(
+            expanded_q,
+            expanded_k,
+            cumulative_gate,
+            beta,
+            d_aqk,
+            d_raw_akk,
+            dg_raw,
+            metadata,
+        )
+    )
+    intra_dq, intra_dk, intra_db, d_gate = intra
+    dq = dq.float() + intra_dq
+    dk = dk.float() + intra_dk
+    if groups > 1:
+        dq = dq.view(*q.shape[:2], q.shape[2], groups, q.shape[3]).sum(3)
+        dk = dk.view(*k.shape[:2], k.shape[2], groups, k.shape[3]).sum(3)
+    dq = dq.to(q.dtype)
+    dk = dk.to(k.dtype)
+    db = db + intra_db
+    return dq, dk, dv, d_gate, db, d_initial_state
+
+
+def resolve_backward_metadata(
+    q: torch.Tensor,
+    cu_seqlens: torch.Tensor | None,
+    chunk_offsets: torch.Tensor | None,
+) -> RaggedChunkMetadata | None:
+    """Reconstruct shape-derived packed metadata for the merged backward schemas."""
+    if cu_seqlens is None:
+        assert chunk_offsets is None
+        return None
+    assert chunk_offsets is not None
+    return RaggedChunkMetadata(
+        cu_seqlens,
+        chunk_offsets,
+        chunk_capacity(q.shape[1], cu_seqlens.shape[0] - 1, 64),
+        64,
+    )
+
+
+def _gdn_chunk_bwd_cuda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    inverse: torch.Tensor,
+    d_output: torch.Tensor,
+    d_final_state: torch.Tensor | None,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+    chunk_offsets: torch.Tensor | None,
+    scale: float,
+) -> tuple[torch.Tensor, ...]:
+    """Registered dense or packed backward without an initial-state gradient output."""
+    dq, dk, dv, dg, db, _d_initial_state = chunk_gdn_bwd(
+        q,
+        k,
+        v,
+        cumulative_gate,
+        beta,
+        inverse,
+        d_output,
+        d_final_state,
+        initial_state,
+        resolve_backward_metadata(q, cu_seqlens, chunk_offsets),
+        scale,
+    )
+    return dq, dk, dv, dg, db
+
+
+def _gdn_chunk_bwd_with_state_grad_cuda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    inverse: torch.Tensor,
+    d_output: torch.Tensor,
+    d_final_state: torch.Tensor | None,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+    chunk_offsets: torch.Tensor | None,
+    scale: float,
+) -> tuple[torch.Tensor, ...]:
+    """Registered dense or packed backward preserving the initial-state gradient."""
+    return chunk_gdn_bwd(
+        q,
+        k,
+        v,
+        cumulative_gate,
+        beta,
+        inverse,
+        d_output,
+        d_final_state,
+        initial_state,
+        resolve_backward_metadata(q, cu_seqlens, chunk_offsets),
+        scale,
+    )
+
+
+__all__ = ["chunk_gdn_bwd", "chunk_gdn_fwd_dense", "chunk_gdn_fwd_packed"]

--- a/attn_gym/linear/gdn/ops.py
+++ b/attn_gym/linear/gdn/ops.py
@@ -6,6 +6,44 @@ import importlib
 
 import torch
 
+from attn_gym._backends.cute import get_device_properties
+from attn_gym.linear.kda.chunk_schedule import prepare_ragged_chunk_metadata
+from attn_gym.linear.kda.ops import _plain_gate_scan_op
+
+_CHUNK_ARGS = (
+    "(Tensor q, Tensor k, Tensor v, Tensor cumulative_gate, Tensor beta, "
+    "Tensor? initial_state, float scale)"
+)
+torch.library.define("attn_gym::gdn_chunk_fwd", _CHUNK_ARGS + " -> (Tensor, Tensor)")
+torch.library.define(
+    "attn_gym::gdn_chunk_fwd_with_state",
+    _CHUNK_ARGS + " -> (Tensor, Tensor, Tensor)",
+)
+_CHUNK_BWD_ARGS = (
+    "(Tensor q, Tensor k, Tensor v, Tensor cumulative_gate, Tensor beta, Tensor inverse, "
+    "Tensor d_output, Tensor? d_final_state, Tensor? initial_state, Tensor? cu_seqlens, "
+    "Tensor? chunk_offsets, float scale)"
+)
+torch.library.define(
+    "attn_gym::gdn_chunk_bwd",
+    _CHUNK_BWD_ARGS + " -> (Tensor, Tensor, Tensor, Tensor, Tensor)",
+)
+torch.library.define(
+    "attn_gym::gdn_chunk_bwd_with_state_grad",
+    _CHUNK_BWD_ARGS + " -> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor)",
+)
+_CHUNK_PACKED_ARGS = (
+    "(Tensor q, Tensor k, Tensor v, Tensor cumulative_gate, Tensor beta, "
+    "Tensor? initial_state, Tensor cu_seqlens, Tensor chunk_offsets, int capacity, float scale)"
+)
+torch.library.define(
+    "attn_gym::gdn_chunk_fwd_packed",
+    _CHUNK_PACKED_ARGS + " -> (Tensor, Tensor)",
+)
+torch.library.define(
+    "attn_gym::gdn_chunk_fwd_packed_with_state",
+    _CHUNK_PACKED_ARGS + " -> (Tensor, Tensor, Tensor)",
+)
 _RECURRENT_ARGS = (
     "(Tensor q, Tensor k, Tensor v, Tensor gate, Tensor beta, Tensor? initial_state, "
     "Tensor? cu_seqlens, float scale, bool autotune)"
@@ -23,6 +61,37 @@ torch.library.define(
     " Tensor(a!) state_cache, Tensor state_indices, Tensor? has_initial_state, Tensor(b!) out,"
     " float scale) -> ()",
 )
+
+
+def _chunk_backend():
+    try:
+        return importlib.import_module("attn_gym.linear.gdn.impl.chunk")
+    except ImportError as error:
+        raise ImportError("chunk_gdn(impl='fused') requires CUDA with Triton support") from error
+
+
+def _chunk_fwd_cuda(*args):
+    return _chunk_backend()._gdn_chunk_fwd_cuda(*args)
+
+
+def _chunk_fwd_with_state_cuda(*args):
+    return _chunk_backend()._gdn_chunk_fwd_with_state_cuda(*args)
+
+
+def _chunk_bwd_cuda(*args):
+    return _chunk_backend()._gdn_chunk_bwd_cuda(*args)
+
+
+def _chunk_bwd_with_state_grad_cuda(*args):
+    return _chunk_backend()._gdn_chunk_bwd_with_state_grad_cuda(*args)
+
+
+def _chunk_fwd_packed_cuda(*args):
+    return _chunk_backend()._gdn_chunk_fwd_packed_cuda(*args)
+
+
+def _chunk_fwd_packed_with_state_cuda(*args):
+    return _chunk_backend()._gdn_chunk_fwd_packed_with_state_cuda(*args)
 
 
 def _recurrent_backend():
@@ -50,6 +119,24 @@ def _recurrent_decode_cuda(*args):
     return _recurrent_backend()._gdn_recurrent_decode_cuda(*args)
 
 
+torch.library.impl("attn_gym::gdn_chunk_fwd", "CUDA", _chunk_fwd_cuda)
+torch.library.impl(
+    "attn_gym::gdn_chunk_fwd_with_state",
+    "CUDA",
+    _chunk_fwd_with_state_cuda,
+)
+torch.library.impl("attn_gym::gdn_chunk_bwd", "CUDA", _chunk_bwd_cuda)
+torch.library.impl(
+    "attn_gym::gdn_chunk_bwd_with_state_grad",
+    "CUDA",
+    _chunk_bwd_with_state_grad_cuda,
+)
+torch.library.impl("attn_gym::gdn_chunk_fwd_packed", "CUDA", _chunk_fwd_packed_cuda)
+torch.library.impl(
+    "attn_gym::gdn_chunk_fwd_packed_with_state",
+    "CUDA",
+    _chunk_fwd_packed_with_state_cuda,
+)
 torch.library.impl("attn_gym::gdn_recurrent_fwd", "CUDA", _recurrent_fwd_cuda)
 torch.library.impl(
     "attn_gym::gdn_recurrent_fwd_no_state",
@@ -66,6 +153,152 @@ torch.library.impl(
     "CUDA",
     _recurrent_decode_cuda,
 )
+
+
+@torch.library.register_fake("attn_gym::gdn_chunk_fwd")
+def _chunk_fwd_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    del k, cumulative_gate, beta, initial_state, scale
+    inverse = q.new_empty(q.shape[0], q.shape[1], v.shape[2], 64)
+    return torch.empty_like(v, dtype=q.dtype), inverse
+
+
+@torch.library.register_fake("attn_gym::gdn_chunk_fwd_with_state")
+def _chunk_fwd_with_state_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    output, inverse = _chunk_fwd_fake(q, k, v, cumulative_gate, beta, initial_state, scale)
+    final_state = q.new_empty(
+        q.shape[0], v.shape[2], v.shape[-1], q.shape[-1], dtype=torch.float32
+    )
+    return output, final_state, inverse
+
+
+@torch.library.register_fake("attn_gym::gdn_chunk_fwd_packed")
+def _chunk_fwd_packed_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor,
+    chunk_offsets: torch.Tensor,
+    capacity: int,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    del k, cumulative_gate, beta, initial_state, cu_seqlens, chunk_offsets, capacity, scale
+    inverse = q.new_empty(q.shape[0], q.shape[1], v.shape[2], 64)
+    return torch.empty_like(v, dtype=q.dtype), inverse
+
+
+@torch.library.register_fake("attn_gym::gdn_chunk_fwd_packed_with_state")
+def _chunk_fwd_packed_with_state_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor,
+    chunk_offsets: torch.Tensor,
+    capacity: int,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    output, inverse = _chunk_fwd_packed_fake(
+        q,
+        k,
+        v,
+        cumulative_gate,
+        beta,
+        initial_state,
+        cu_seqlens,
+        chunk_offsets,
+        capacity,
+        scale,
+    )
+    final_state = q.new_empty(
+        cu_seqlens.shape[0] - 1,
+        v.shape[2],
+        v.shape[-1],
+        q.shape[-1],
+        dtype=torch.float32,
+    )
+    return output, final_state, inverse
+
+
+@torch.library.register_fake("attn_gym::gdn_chunk_bwd")
+def _chunk_bwd_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    inverse: torch.Tensor,
+    d_output: torch.Tensor,
+    d_final_state: torch.Tensor | None,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+    chunk_offsets: torch.Tensor | None,
+    scale: float,
+) -> tuple[torch.Tensor, ...]:
+    del inverse, d_output, d_final_state, initial_state, cu_seqlens, chunk_offsets, scale
+    return (
+        torch.empty_like(q),
+        torch.empty_like(k),
+        torch.empty_like(v),
+        torch.empty_like(cumulative_gate),
+        torch.empty_like(beta),
+    )
+
+
+@torch.library.register_fake("attn_gym::gdn_chunk_bwd_with_state_grad")
+def _chunk_bwd_with_state_grad_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    inverse: torch.Tensor,
+    d_output: torch.Tensor,
+    d_final_state: torch.Tensor | None,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+    chunk_offsets: torch.Tensor | None,
+    scale: float,
+) -> tuple[torch.Tensor, ...]:
+    outputs = _chunk_bwd_fake(
+        q,
+        k,
+        v,
+        cumulative_gate,
+        beta,
+        inverse,
+        d_output,
+        d_final_state,
+        initial_state,
+        cu_seqlens,
+        chunk_offsets,
+        scale,
+    )
+    state_batch = q.shape[0] if cu_seqlens is None else cu_seqlens.shape[0] - 1
+    d_initial_state = q.new_empty(
+        state_batch, v.shape[2], v.shape[-1], q.shape[-1], dtype=torch.float32
+    )
+    return *outputs, d_initial_state
 
 
 @torch.library.register_fake("attn_gym::gdn_recurrent_fwd")
@@ -138,10 +371,199 @@ def _recurrent_decode_fake(
     """The decode op returns nothing and mutates preallocated buffers; no metadata to fake."""
 
 
+chunk_fwd_op = torch.ops.attn_gym.gdn_chunk_fwd.default
+chunk_fwd_with_state_op = torch.ops.attn_gym.gdn_chunk_fwd_with_state.default
+chunk_bwd_op = torch.ops.attn_gym.gdn_chunk_bwd.default
+chunk_bwd_with_state_grad_op = torch.ops.attn_gym.gdn_chunk_bwd_with_state_grad.default
+chunk_fwd_packed_op = torch.ops.attn_gym.gdn_chunk_fwd_packed.default
+chunk_fwd_packed_with_state_op = torch.ops.attn_gym.gdn_chunk_fwd_packed_with_state.default
 recurrent_fwd_op = torch.ops.attn_gym.gdn_recurrent_fwd.default
 recurrent_fwd_no_state_op = torch.ops.attn_gym.gdn_recurrent_fwd_no_state.default
 recurrent_fwd_paged_op = torch.ops.attn_gym.gdn_recurrent_fwd_paged.default
 recurrent_decode_op = torch.ops.attn_gym.gdn_recurrent_decode.default
+
+
+class _ChunkGDN(torch.autograd.Function):
+    """Attach first-order autograd to dense or fixed-capacity packed chunk operators."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        initial_state,
+        cu_seqlens,
+        chunk_offsets,
+        capacity,
+        scale,
+        output_final_state,
+    ):
+        cumulative_gate = _plain_gate_scan_op(
+            gate.unsqueeze(-1), cu_seqlens, chunk_offsets, False
+        ).squeeze(-1)
+        if cu_seqlens is None:
+            args = (q, k, v, cumulative_gate, beta, initial_state, scale)
+            if output_final_state:
+                output, final_state, inverse = chunk_fwd_with_state_op(*args)
+            else:
+                output, inverse = chunk_fwd_op(*args)
+        else:
+            args = (
+                q,
+                k,
+                v,
+                cumulative_gate,
+                beta,
+                initial_state,
+                cu_seqlens,
+                chunk_offsets,
+                capacity,
+                scale,
+            )
+            if output_final_state:
+                output, final_state, inverse = chunk_fwd_packed_with_state_op(*args)
+            else:
+                output, inverse = chunk_fwd_packed_op(*args)
+        ctx.save_for_backward(
+            q,
+            k,
+            v,
+            cumulative_gate,
+            beta,
+            inverse,
+            initial_state,
+            cu_seqlens,
+            chunk_offsets,
+        )
+        ctx.scale = scale
+        ctx.set_materialize_grads(False)
+        if output_final_state:
+            return output, final_state
+        return output
+
+    @staticmethod
+    @torch.autograd.function.once_differentiable
+    def backward(ctx, d_output, d_final_state=None):
+        (
+            q,
+            k,
+            v,
+            cumulative_gate,
+            beta,
+            inverse,
+            initial_state,
+            cu_seqlens,
+            chunk_offsets,
+        ) = ctx.saved_tensors
+        if d_output is None:
+            d_output = torch.zeros_like(v)
+        if torch.compiler.is_compiling():
+            args = (
+                q,
+                k,
+                v,
+                cumulative_gate,
+                beta,
+                inverse,
+                d_output,
+                d_final_state,
+                initial_state,
+                cu_seqlens,
+                chunk_offsets,
+                ctx.scale,
+            )
+            if initial_state is not None:
+                dq, dk, dv, d_gate, db, d_initial_state = chunk_bwd_with_state_grad_op(*args)
+            else:
+                dq, dk, dv, d_gate, db = chunk_bwd_op(*args)
+                d_initial_state = None
+        else:
+            backend = _chunk_backend()
+            metadata = backend.resolve_backward_metadata(q, cu_seqlens, chunk_offsets)
+            dq, dk, dv, d_gate, db, d_initial_state = backend.chunk_gdn_bwd(
+                q,
+                k,
+                v,
+                cumulative_gate,
+                beta,
+                inverse,
+                d_output,
+                d_final_state,
+                initial_state,
+                metadata,
+                ctx.scale,
+            )
+        return dq, dk, dv, d_gate, db, d_initial_state, None, None, None, None, None
+
+
+def chunk_forward(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    *,
+    cu_seqlens: torch.Tensor | None,
+    scale: float,
+    output_final_state: bool,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Route dense inputs and invoke the fused scalar chunk forward operator."""
+    if not q.is_cuda:
+        raise ValueError("chunk_gdn(impl='fused') requires CUDA tensors")
+    if q.dtype not in (torch.float16, torch.bfloat16) or k.dtype != q.dtype or v.dtype != q.dtype:
+        raise TypeError("chunk_gdn(impl='fused') requires matching float16 or bfloat16 QKV")
+    if q.shape[-1] != 128 or v.shape[-1] != 128:
+        raise ValueError("chunk_gdn(impl='fused') requires K=V=128")
+    # The dense recurrence uses Hopper TensorDescriptors/TMA; Blackwell additionally selects
+    # the CuTe backward, while Hopper uses the portable Triton backward.
+    if not torch.compiler.is_compiling() and get_device_properties(q.device).major < 9:
+        raise ValueError("chunk_gdn(impl='fused') requires CUDA capability 9.0 or newer")
+    output_shape = v.shape
+    batch, tokens = q.shape[:2]
+    if cu_seqlens is not None and batch != 1:
+        raise ValueError("explicit packed chunk_gdn requires batch size one")
+    # The dense kernels specialize for complete BT64 chunks. Flatten other dense inputs and
+    # synthesize one packed segment per batch row so tails stay masked and never cross batches.
+    if cu_seqlens is None and (batch != 1 or tokens % 64):
+        q = q.reshape(1, batch * tokens, q.shape[2], q.shape[3])
+        k = k.reshape(1, batch * tokens, k.shape[2], k.shape[3])
+        v = v.reshape(1, batch * tokens, v.shape[2], v.shape[3])
+        gate = gate.reshape(1, batch * tokens, gate.shape[2])
+        beta = beta.reshape(1, batch * tokens, beta.shape[2])
+        cu_seqlens = torch.arange(batch + 1, dtype=torch.int32, device=q.device) * tokens
+
+    metadata = (
+        prepare_ragged_chunk_metadata(cu_seqlens, q.shape[1], 64)
+        if cu_seqlens is not None
+        else None
+    )
+    gate = gate.float()
+    beta = beta.float()
+    if initial_state is not None:
+        initial_state = initial_state.float()
+    chunk_offsets = None if metadata is None else metadata.chunk_offsets
+    capacity = 0 if metadata is None else metadata.capacity
+    result = _ChunkGDN.apply(
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        initial_state,
+        cu_seqlens,
+        chunk_offsets,
+        capacity,
+        scale,
+        output_final_state,
+    )
+    if output_final_state:
+        output, final_state = result
+        return output.reshape(output_shape), final_state
+    return result.reshape(output_shape), None
 
 
 def recurrent_forward(
@@ -234,6 +656,13 @@ def recurrent_decode_forward(
 
 
 __all__ = [
+    "chunk_bwd_op",
+    "chunk_bwd_with_state_grad_op",
+    "chunk_forward",
+    "chunk_fwd_op",
+    "chunk_fwd_packed_op",
+    "chunk_fwd_packed_with_state_op",
+    "chunk_fwd_with_state_op",
     "recurrent_decode_forward",
     "recurrent_decode_op",
     "recurrent_forward",

--- a/attn_gym/linear/gdn/validation.py
+++ b/attn_gym/linear/gdn/validation.py
@@ -2,9 +2,30 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from typing import Literal
+
 import torch
 
 from attn_gym.linear._delta_rule.validation import validate_delta_rule_inputs
+
+_KERNEL_OPTION_NAMES = frozenset({"backend"})
+
+
+def resolve_kernel_options(
+    kernel_options: Mapping[str, object] | None,
+) -> Literal["fused", "mega"]:
+    """Validate chunk backend options while keeping the repo-local path as default."""
+    if kernel_options is None:
+        return "fused"
+    unknown = kernel_options.keys() - _KERNEL_OPTION_NAMES
+    if unknown:
+        names = ", ".join(sorted(unknown))
+        raise ValueError(f"unsupported chunk_gdn kernel options: {names}")
+    backend = kernel_options.get("backend", "fused")
+    if backend not in ("fused", "mega"):
+        raise ValueError("kernel_options['backend'] must be 'fused' or 'mega'")
+    return backend
 
 
 def validate_gdn_inputs(
@@ -44,4 +65,4 @@ def validate_gdn_inputs(
         )
 
 
-__all__ = ["validate_gdn_inputs"]
+__all__ = ["resolve_kernel_options", "validate_gdn_inputs"]

--- a/attn_gym/linear/kda/api.py
+++ b/attn_gym/linear/kda/api.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import sys
 from functools import partial
 from numbers import Real
-from typing import Literal, TypedDict
+from typing import Literal
 
 import torch
 
@@ -35,23 +35,13 @@ from attn_gym.linear.kda.naive import naive_chunk_kda, naive_recurrent_kda
 from attn_gym.linear.kda.ops import recurrent_decode_forward as _fused_recurrent_decode_forward
 from attn_gym.linear.kda.ops import recurrent_forward as _fused_recurrent_forward
 from attn_gym.linear.kda.validation import resolve_kernel_options, validate_kda_inputs
-from attn_gym.linear.types import Impl, resolve_impl
+from attn_gym.linear.types import Impl, KernelOptions, resolve_impl
 
 _CHUNK_SIZE = 64
 _DECODE_GATE_TRANSFORMS = {
     "bounded": True,
     "softplus": False,
 }
-
-
-class KernelOptions(TypedDict, total=False):
-    """Backend and experimental scheduling controls for :func:`chunk_kda`."""
-
-    backend: Literal["fused", "mega"]
-    """Select the default fused backend or the optional Mega CuTeDSL backend."""
-
-    split_backward: bool
-    """Approximate only Mega backward with schedule-selected forgetting-horizon splits."""
 
 
 def _resolve_decode_gate_transform(gate_transform: str) -> bool:

--- a/attn_gym/linear/kda/chunk_scheduler.py
+++ b/attn_gym/linear/kda/chunk_scheduler.py
@@ -301,6 +301,15 @@ def load_ragged_chunk_count(chunk_offsets, num_sequences):
 
 
 @triton.jit
+def load_ragged_sequence_work(cu_seqlens, chunk_offsets, sequence):
+    """Load one sequence's token bounds and first global chunk."""
+    begin = tl.load(cu_seqlens + sequence)
+    end = tl.load(cu_seqlens + sequence + 1)
+    chunk_begin = tl.load(chunk_offsets + sequence)
+    return begin, end, chunk_begin
+
+
+@triton.jit
 def load_ragged_task_count(chunk_offsets, num_sequences, subtasks_per_chunk):
     """Return the runtime number of active flattened chunk tasks.
 
@@ -449,6 +458,7 @@ __all__ = [
     "load_ragged_chunk_count",
     "load_ragged_chunk_work",
     "load_ragged_sequence_extent",
+    "load_ragged_sequence_work",
     "load_ragged_task_count",
     "prepare_ragged_chunk_metadata",
 ]

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py
@@ -8,8 +8,9 @@ import torch
 
 from attn_gym._backends.cute import (
     get_device_properties,
-    tensor_supports_contiguous_dim,
-    tensor_supports_tma,
+    normalize_compact_tensor,
+    normalize_tma_rows,
+    tensor_supports_tma_rows,
 )
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata, chunk_capacity
 from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd_intra import chunk_kda_fwd_intra
@@ -44,25 +45,6 @@ _CHUNK_SIZE = 64
 _HEAD_DIM = 128
 
 
-def _has_supported_qkv_layout(tensor: torch.Tensor) -> bool:
-    """Return whether QKV rows satisfy the vectorized kernel input contract."""
-    return tensor.stride(-2) == tensor.shape[-1] and tensor_supports_tma(tensor)
-
-
-def _normalize_qkv_layout(tensor: torch.Tensor) -> torch.Tensor:
-    """Copy only layouts unsupported by one or more composed KDA stages."""
-    if _has_supported_qkv_layout(tensor):
-        return tensor
-    return tensor.clone(memory_format=torch.contiguous_format)
-
-
-def _normalize_packed_cotangent(tensor: torch.Tensor) -> torch.Tensor:
-    """Provide the compact 128-byte-aligned ABI required by packed token gradients."""
-    if tensor.is_contiguous() and tensor_supports_contiguous_dim(tensor, alignment_bytes=128):
-        return tensor
-    return tensor.clone(memory_format=torch.contiguous_format)
-
-
 def _normalize_state_cotangent(tensor: torch.Tensor) -> torch.Tensor:
     """Preserve supported state strides and materialize broadcast cotangents."""
     if tensor.stride(-1) == 1 and all(stride >= 0 for stride in tensor.stride()):
@@ -94,7 +76,7 @@ def _validate_private_abi(
         raise ValueError("the private chunk_kda ABI requires a contiguous state key mode")
     if not all(tensor.is_contiguous() for tensor in contiguous_tensors):
         raise ValueError("the private chunk_kda ABI requires contiguous gate and beta")
-    if not all(_has_supported_qkv_layout(tensor) for tensor in (q, k, v)):
+    if not all(tensor_supports_tma_rows(tensor) for tensor in (q, k, v)):
         raise ValueError(
             "the private chunk_kda ABI requires QKV to have contiguous heads and "
             "16-byte-aligned token rows"
@@ -277,7 +259,7 @@ def _chunk_kda_fwd_shared(
     output_final_state: bool,
 ):
     """Keep the complete composed forward behind one compiler-opaque boundary."""
-    q, k, v = (_normalize_qkv_layout(tensor) for tensor in (q, k, v))
+    q, k, v = (normalize_tma_rows(tensor) for tensor in (q, k, v))
     _validate_private_abi(q, k, v, cumulative_gate, beta, initial_state)
     return _chunk_kda_fwd(
         q,
@@ -356,7 +338,7 @@ def _chunk_kda_fwd_ragged_shared(
     output_final_state: bool,
 ):
     """Run ragged forward with caller-prepared routing and fixed-schema factors."""
-    q, k, v = (_normalize_qkv_layout(tensor) for tensor in (q, k, v))
+    q, k, v = (normalize_tma_rows(tensor) for tensor in (q, k, v))
     _validate_private_abi(q, k, v, cumulative_gate, beta, initial_state)
     metadata = RaggedChunkMetadata(
         cu_seqlens,
@@ -448,7 +430,7 @@ def _chunk_kda_fwd_ragged_paged_cuda(
     chunk_offsets: torch.Tensor,
     autotune: bool,
 ) -> torch.Tensor:
-    q, k, v = (_normalize_qkv_layout(tensor) for tensor in (q, k, v))
+    q, k, v = (normalize_tma_rows(tensor) for tensor in (q, k, v))
     _validate_paged_private_abi(
         q,
         k,
@@ -509,14 +491,14 @@ def _prepare_chunk_kda_backward(
             chunk_capacity(q.shape[1], cu_seqlens.shape[0] - 1, _CHUNK_SIZE),
             _CHUNK_SIZE,
         )
-    q, k, v = (_normalize_qkv_layout(tensor) for tensor in (q, k, v))
+    q, k, v = (normalize_tma_rows(tensor) for tensor in (q, k, v))
     _validate_private_abi(q, k, v, cumulative_gate, beta, initial_state)
     if d_output is None:
         d_output = v.new_zeros(v.shape)
     elif metadata is not None:
-        d_output = _normalize_packed_cotangent(d_output)
+        d_output = normalize_compact_tensor(d_output)
     else:
-        d_output = _normalize_qkv_layout(d_output)
+        d_output = normalize_tma_rows(d_output)
     if d_final_state is not None:
         d_final_state = _normalize_state_cotangent(d_final_state.float())
     return q, k, v, metadata, d_output, d_final_state

--- a/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
@@ -28,6 +28,7 @@ from attn_gym.linear.kda.chunk_scheduler import (
     ScheduleKind,
     ScheduleRequest,
     load_ragged_sequence_extent,
+    load_ragged_sequence_work,
 )
 from attn_gym.linear.kda.ops import delta_h_op as _delta_h_op
 from attn_gym.linear.kda.ops import delta_h_paged_op as _delta_h_paged_op
@@ -82,9 +83,8 @@ def _run_chunk_delta_h_sequence(
     """
     i_n, i_h = i_nh // H, i_nh % H
     if IS_VARLEN:
-        bos = tl.load(cu_seqlens + i_n).to(tl.int32)
-        eos = tl.load(cu_seqlens + i_n + 1).to(tl.int32)
-        boh = tl.load(chunk_offsets + i_n).to(tl.int32)
+        bos, eos, boh = load_ragged_sequence_work(cu_seqlens, chunk_offsets, i_n)
+        bos, eos, boh = bos.to(tl.int32), eos.to(tl.int32), boh.to(tl.int32)
         T = eos - bos
     else:
         bos = i_n * T

--- a/attn_gym/linear/types.py
+++ b/attn_gym/linear/types.py
@@ -7,6 +7,21 @@
 """Types shared by public linear-attention operations."""
 
 from enum import Enum
+from typing import Literal, TypedDict
+
+
+class BackendOptions(TypedDict, total=False):
+    """Backend selection shared by optimized linear-attention operations."""
+
+    backend: Literal["fused", "mega"]
+    """Select the repo-local fused backend or the optional Mega backend."""
+
+
+class KernelOptions(BackendOptions, total=False):
+    """KDA backend controls and experimental scheduling options."""
+
+    split_backward: bool
+    """Allow KDA Mega to use its approximate split-backward schedule."""
 
 
 class Impl(str, Enum):
@@ -25,4 +40,4 @@ def resolve_impl(impl: Impl | str) -> Impl:
         raise ValueError(f"unknown impl {impl!r}; expected one of {valid}") from None
 
 
-__all__ = ["Impl", "resolve_impl"]
+__all__ = ["BackendOptions", "Impl", "KernelOptions", "resolve_impl"]

--- a/attn_gym/testing/gdn.py
+++ b/attn_gym/testing/gdn.py
@@ -12,32 +12,55 @@ from .kda import cumulative_sequence_offsets
 
 GatePattern = Literal[
     "mild",
+    "softplus",
     "uniform_negative_twenty",
     "isolated_negative_twenty",
+    "periodic_negative_twenty",
     "near_zero",
     "model_softplus",
 ]
 
 
 def make_gdn_test_inputs(
-    lengths: Sequence[int],
+    lengths: int | Sequence[int],
     *,
+    batch: int = 1,
     key_heads: int = 1,
     value_heads: int = 2,
     gate_pattern: GatePattern = "mild",
     dtype: torch.dtype = torch.bfloat16,
     seed: int = 31,
+    value_scale: float = 0.125,
+    state_scale: float = 0.01,
+    sigmoid_beta: bool = False,
     requires_grad: bool = False,
-) -> tuple[torch.Tensor, ...]:
-    """Create deterministic packed grouped-head GDN operands and FP32 state."""
+) -> tuple[torch.Tensor | None, ...]:
+    """Create deterministic dense or packed grouped-head GDN operands and FP32 state.
+
+    An integer ``lengths`` creates a dense ``[batch, lengths, ...]`` input and returns no
+    sequence offsets. A sequence creates a batch-one packed input and returns its offsets.
+    """
     generator = torch.Generator(device="cuda").manual_seed(seed)
-    tokens, dim = sum(lengths), 128
-    q_shape = (1, tokens, key_heads, dim)
-    value_shape = (1, tokens, value_heads, dim)
+    if isinstance(lengths, int):
+        tokens = lengths
+        state_batch = batch
+        cu_seqlens = None
+    else:
+        if batch != 1:
+            raise ValueError("packed GDN test inputs require batch=1")
+        tokens = sum(lengths)
+        state_batch = len(lengths)
+        cu_seqlens = cumulative_sequence_offsets(lengths)
+
+    dim = 128
+    q_shape = (batch, tokens, key_heads, dim)
+    value_shape = (batch, tokens, value_heads, dim)
     gate_shape = value_shape[:-1]
     q = F.normalize(torch.randn(q_shape, device="cuda", generator=generator), dim=-1).to(dtype)
     k = F.normalize(torch.randn(q_shape, device="cuda", generator=generator), dim=-1).to(dtype)
-    value = torch.randn(value_shape, device="cuda", dtype=dtype, generator=generator).div_(8)
+    value = torch.randn(value_shape, device="cuda", dtype=dtype, generator=generator).mul_(
+        value_scale
+    )
 
     match gate_pattern:
         case "mild":
@@ -46,6 +69,8 @@ def make_gdn_test_inputs(
                 .uniform_(0.5, 1.0, generator=generator)
                 .log_()
             )
+        case "softplus":
+            gate = -F.softplus(torch.randn(gate_shape, device="cuda", generator=generator))
         case "uniform_negative_twenty":
             gate = torch.full(gate_shape, -20.0, device="cuda")
         case "isolated_negative_twenty":
@@ -55,6 +80,9 @@ def make_gdn_test_inputs(
                 .log_()
             )
             gate[:, tokens // 2] = -20.0
+        case "periodic_negative_twenty":
+            gate = torch.full(gate_shape, -0.1, device="cuda")
+            gate[:, 7::16] = -20.0
         case "near_zero":
             gate = torch.empty(gate_shape, device="cuda").uniform_(-1e-4, 0.0, generator=generator)
         case "model_softplus":
@@ -65,20 +93,24 @@ def make_gdn_test_inputs(
         case _:
             raise ValueError(f"Unsupported gate pattern: {gate_pattern}")
 
-    beta = torch.rand(gate_shape, device="cuda", generator=generator)
+    beta = (
+        torch.randn(gate_shape, device="cuda", generator=generator).sigmoid_()
+        if sigmoid_beta
+        else torch.rand(gate_shape, device="cuda", generator=generator)
+    )
     initial_state = torch.randn(
-        len(lengths),
+        state_batch,
         value_heads,
         dim,
         dim,
         device="cuda",
         dtype=torch.float32,
         generator=generator,
-    ).div_(100)
+    ).mul_(state_scale)
     tensors = (q, k, value, gate, beta, initial_state)
     return (
         *(tensor.requires_grad_(requires_grad) for tensor in tensors),
-        cumulative_sequence_offsets(lengths),
+        cu_seqlens,
     )
 
 

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -21,8 +21,8 @@ slot count. `chunk_gdn` uses a chunk-parallel decomposition for training and pre
 `recurrent_gdn` consumes
 tokens in order for decoding, inference prefill, and state-carrying correctness checks. `chunk_gdn`
 defaults to eager PyTorch (`impl="reference"`); `chunk_gdn(..., impl="fused")` selects the
-training-capable Mega CuTeDSL backend, while
-`recurrent_gdn(..., impl="fused")` selects the inference-only Triton scan.
+repo-local scalar chunk pipeline. Pass `kernel_options={"backend": "mega"}` to select the optional
+Mega CuTeDSL backend. `recurrent_gdn(..., impl="fused")` selects the inference-only Triton scan.
 
 ```python
 from attn_gym.linear import chunk_gdn
@@ -44,8 +44,10 @@ output, final_state = chunk_gdn(
   with `cu_seqlens`.
 - Separate recurrent and chunked operations with explicit initial and final state.
 - CPU and CUDA execution through eager PyTorch operations.
-- A training-capable fused chunk implementation on SM100/SM103 with dense and packed inputs,
-  grouped Q/K heads, tails, empty sequences, initial/final state, and state gradients.
+- A repo-local fused chunk pipeline on CUDA capability 9.0+ with dense and packed inputs, grouped
+  Q/K heads,
+  tails, empty sequences, initial/final state, strict `torch.compile`, and CUDA Graph support.
+- An opt-in Mega fused chunk implementation with the same public training/state contract.
 - An inference-only fused recurrent implementation on CUDA, including mutable paged state caches
   shaped `[num_slots, H, V, K]` selected by `state_indices`.
 - Autograd for the reference and fused chunk implementations, including initial-state gradients.
@@ -55,9 +57,19 @@ output, final_state = chunk_gdn(
   dtype. A provided initial state uses FP32 for low-precision QKV.
 - FP64 reference inputs retain FP64 recurrence math and state.
 
-The fused chunk implementation requires the optional `mega` dependencies, SM100/SM103,
-FP16/BF16 Q/K/V, FP32 state, and `K = V = 128`. It consumes the scalar natural-log gate without a
-lower bound and uses exact execution without an approximate forgetting-horizon split.
+The repo-local fused chunk backend requires CUDA capability 9.0+, matching FP16 or BF16 Q/K/V,
+and
+`K = V = 128`, but has no Mega runtime dependency. Its scalar natural-log gate is not lower-bounded:
+kernels contract raw QK/KK before applying masked nonpositive causal decay differences. The public
+chunk size is BT64; internal 16x16 blocks are only the hierarchical triangular-solve representation.
+Layouts requiring int64 tensor offsets are rejected until every repo-local kernel has a
+wide-address path. Backward uses the tuned CuTe kernels on SM100/SM103 and portable Triton
+kernels on Hopper and other supported architectures.
+
+The Mega chunk backend requires the optional `mega` dependencies and SM100/SM103,
+FP16/BF16 Q/K/V, FP32 state, and `K = V = 128` contract. It also consumes the scalar natural-log
+gate without a lower bound and uses exact execution without an approximate forgetting-horizon
+split.
 
 The fused recurrent implementation requires CUDA with Triton, Q/K/V in FP16, BF16, or FP32, and
 `K <= 256`. Packed offsets must begin at zero, be nondecreasing, and end within the physical token

--- a/examples/kda_context_parallel.py
+++ b/examples/kda_context_parallel.py
@@ -31,6 +31,7 @@ import torch.nn.functional as F
 import typer
 from torch.distributed._functional_collectives import all_gather_single
 
+from attn_gym._backends.cute import normalize_compact_tensor
 from attn_gym.linear._delta_rule.cute import build_state_grad_summary, build_state_summary
 from attn_gym.linear.kda.bwd.cute.chunk_kda_bwd import (
     _finish_chunk_kda_bwd,
@@ -40,7 +41,6 @@ from attn_gym.linear.kda.chunk_schedule import prepare_ragged_chunk_metadata
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata, chunk_capacity
 from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd import (
     _finish_chunk_kda_fwd,
-    _normalize_packed_cotangent,
     _prepare_chunk_kda_fwd,
 )
 from attn_gym.linear.kda.ops import _plain_gate_scan_op
@@ -305,9 +305,9 @@ class ContextParallelKDAFunction(torch.autograd.Function):
         if d_output is None:
             d_output = torch.zeros_like(v)
         else:
-            d_output = _normalize_packed_cotangent(d_output)
+            d_output = normalize_compact_tensor(d_output)
         if d_final_state is not None:
-            d_final_state = _normalize_packed_cotangent(d_final_state.float())
+            d_final_state = normalize_compact_tensor(d_final_state.float())
         prepared = _prepare_chunk_kda_bwd(
             q,
             k,

--- a/test/gdn/mega/test_gdn_mega_training.py
+++ b/test/gdn/mega/test_gdn_mega_training.py
@@ -14,7 +14,7 @@ pytest.importorskip(
     reason="the CuTeDSL 4.7 GDN path requires nvidia-cutlass-dsl>=4.7",
 )
 
-from attn_gym.linear import chunk_gdn
+from attn_gym.linear import chunk_gdn as public_chunk_gdn
 from attn_gym.linear.gdn.impl.mega_ops import (
     chunk_gdn_mega_packed_bwd_op,
     chunk_gdn_mega_packed_bwd_with_state_op,
@@ -30,6 +30,15 @@ pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available() or torch.cuda.get_device_capability() not in ((10, 0), (10, 3)),
     reason="the CuTeDSL 4.7 GDN path requires SM100 or SM103",
 )
+
+_MEGA_KERNEL_OPTIONS = {"backend": "mega"}
+
+
+def chunk_gdn(*args, **kwargs):
+    """Route fused calls in this module through the Mega backend."""
+    if kwargs.get("impl") == "fused":
+        kwargs.setdefault("kernel_options", _MEGA_KERNEL_OPTIONS)
+    return public_chunk_gdn(*args, **kwargs)
 
 
 def reference_results(
@@ -304,7 +313,16 @@ v = torch.randn_like(q)
 gate = -torch.rand(shape[:3], device='cuda')
 beta = torch.rand(shape[:3], device='cuda')
 cu = torch.tensor({offsets!r}, dtype=torch.int32, device='cuda')
-chunk_gdn(q, k, v, gate, beta, cu_seqlens=cu, impl='fused')
+chunk_gdn(
+    q,
+    k,
+    v,
+    gate,
+    beta,
+    cu_seqlens=cu,
+    impl='fused',
+    kernel_options={{"backend": "mega"}},
+)
 torch.cuda.synchronize()
 """
     try:

--- a/test/linear/test_gdn.py
+++ b/test/linear/test_gdn.py
@@ -5,6 +5,7 @@ import torch.nn.functional as F
 from attn_gym.linear import Impl, chunk_gdn
 from attn_gym.linear import recurrent_gdn as _recurrent_gdn
 from attn_gym.linear._delta_rule.validation import validate_paged_state
+from attn_gym.linear.gdn.validation import resolve_kernel_options
 from attn_gym.testing import cumulative_sequence_offsets
 
 
@@ -307,11 +308,23 @@ def test_impl_accepts_enum_and_string(function):
 
     with pytest.raises(ValueError, match="'fused', 'reference'"):
         function(*inputs[:-1], impl="eager")
-    message = (
-        "Mega GDN backend requires CUDA" if function is chunk_gdn else "requires CUDA tensors"
-    )
-    with pytest.raises(ValueError, match=message):
+    with pytest.raises(ValueError, match="requires CUDA tensors"):
         function(*inputs[:-1], impl=Impl.FUSED)
+
+
+def test_chunk_kernel_options_are_strict():
+    """Keep the repo-local path as default and validate the Mega opt-in selector."""
+    assert resolve_kernel_options(None) == "fused"
+    assert resolve_kernel_options({}) == "fused"
+    inputs = make_inputs(sequence=2)
+    with pytest.raises(ValueError, match="unsupported chunk_gdn kernel options: unknown"):
+        chunk_gdn(*inputs[:-1], impl="fused", kernel_options={"unknown": True})
+    with pytest.raises(ValueError, match="must be 'fused' or 'mega'"):
+        chunk_gdn(*inputs[:-1], impl="fused", kernel_options={"backend": "other"})
+    with pytest.raises(ValueError, match="not supported with impl='reference'"):
+        chunk_gdn(*inputs[:-1], impl="reference", kernel_options={"backend": "mega"})
+    with pytest.raises(ValueError, match="Mega GDN backend requires CUDA"):
+        chunk_gdn(*inputs[:-1], impl="fused", kernel_options={"backend": "mega"})
 
 
 @pytest.mark.parametrize("function", [chunk_gdn, recurrent_gdn])

--- a/test/linear/test_gdn_chunk_fused.py
+++ b/test/linear/test_gdn_chunk_fused.py
@@ -1,0 +1,644 @@
+"""Numerical, registration, and compilation coverage for fused chunk GDN."""
+
+from __future__ import annotations
+
+from functools import partial
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from attn_gym._backends.cute import normalize_tma_rows
+from attn_gym.linear import active_token_mask, chunk_gdn, mask_inactive_token_gradients
+from attn_gym.linear.gdn.bwd.triton.chunk_gdn_bwd_intra import (
+    chunk_gdn_bwd_intra_dense,
+)
+from attn_gym.linear.gdn.ops import (
+    chunk_bwd_op,
+    chunk_bwd_with_state_grad_op,
+    chunk_fwd_op,
+    chunk_fwd_packed_op,
+    chunk_fwd_packed_with_state_op,
+    chunk_fwd_with_state_op,
+)
+from attn_gym.linear.kda.chunk_schedule import prepare_ragged_chunk_metadata
+from attn_gym.linear.kda.ops import _plain_gate_scan_op
+from attn_gym.testing import make_gdn_test_inputs
+from attn_gym.testing.kda import (
+    assert_matches_low_precision_reference,
+    cumulative_sequence_offsets,
+)
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (9, 0),
+    reason="fused chunk GDN requires CUDA capability 9.0 or newer",
+)
+
+
+def make_inputs(
+    *,
+    batch: int = 1,
+    tokens: int = 64,
+    key_heads: int = 2,
+    value_heads: int = 2,
+    gate_kind: str = "mild",
+    dtype: torch.dtype = torch.bfloat16,
+    requires_grad: bool = False,
+) -> tuple[torch.Tensor, ...]:
+    """Adapt the shared GDN fixture to this file's dense-input shorthand."""
+    gate_pattern = {
+        "mild": "softplus",
+        "spikes": "periodic_negative_twenty",
+        "unbounded": "uniform_negative_twenty",
+    }[gate_kind]
+    *inputs, cu_seqlens = make_gdn_test_inputs(
+        tokens,
+        batch=batch,
+        key_heads=key_heads,
+        value_heads=value_heads,
+        gate_pattern=gate_pattern,
+        dtype=dtype,
+        seed=23,
+        value_scale=1.0,
+        state_scale=1.0,
+        sigmoid_beta=True,
+        requires_grad=requires_grad,
+    )
+    assert cu_seqlens is None
+    return tuple(inputs)
+
+
+def misaligned_like(tensor: torch.Tensor) -> torch.Tensor:
+    """Copy into contiguous storage beginning one element past an aligned allocation."""
+    storage = torch.empty(tensor.numel() + 1, dtype=tensor.dtype, device=tensor.device)
+    result = storage[1:].view(tensor.shape)
+    result.copy_(tensor)
+    assert result.is_contiguous() and result.data_ptr() % 16 != 0
+    return result
+
+
+def token_strided_like(tensor: torch.Tensor) -> torch.Tensor:
+    """Copy into aligned storage with padding between otherwise compact token rows."""
+    batch, tokens, heads, dim = tensor.shape
+    storage = torch.empty(batch, tokens, heads * dim + 8, dtype=tensor.dtype, device=tensor.device)
+    result = storage[..., : heads * dim].view(tensor.shape)
+    result.copy_(tensor)
+    assert result.stride() == (tokens * (heads * dim + 8), heads * dim + 8, dim, 1)
+    return result
+
+
+def run_with_gradients(
+    inputs: tuple[torch.Tensor, ...],
+    impl: str,
+    cu_seqlens: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, ...]:
+    """Run output/state and all input gradients under one shared scalar loss."""
+    output, state = chunk_gdn(
+        *inputs[:5],
+        inputs[5],
+        cu_seqlens=cu_seqlens,
+        output_final_state=True,
+        impl=impl,
+    )
+    assert state is not None
+    gradients = torch.autograd.grad(
+        output.float().square().mean() + state.float().square().mean(), inputs
+    )
+    return output, state, *gradients
+
+
+def force_portable_backward(monkeypatch) -> None:
+    """Force the Hopper Triton backward while retaining the current GPU forward."""
+    import attn_gym.linear.gdn.impl.chunk as chunk_impl
+
+    monkeypatch.setattr(
+        chunk_impl,
+        "get_device_properties",
+        lambda device: SimpleNamespace(major=9),
+    )
+
+
+@pytest.mark.parametrize(
+    ("batch", "tokens", "key_heads", "value_heads", "gate_kind", "lengths", "portable"),
+    [
+        (1, 64, 2, 2, "mild", None, False),
+        (1, 65, 1, 4, "spikes", None, False),
+        (2, 65, 1, 4, "mild", None, False),
+        (1, 64, 1, 1, "unbounded", None, True),
+        (1, 64, 1, 64, "mild", None, True),
+        (1, 192, 1, 4, "spikes", [65, 0, 127], True),
+    ],
+)
+def test_fused_chunk_matches_low_precision_reference(
+    batch: int,
+    tokens: int,
+    key_heads: int,
+    value_heads: int,
+    gate_kind: str,
+    lengths: list[int] | None,
+    portable: bool,
+    monkeypatch,
+):
+    """Bound Blackwell and Hopper-route gradients by the eager low-precision error."""
+    if portable:
+        force_portable_backward(monkeypatch)
+    inputs = make_inputs(
+        batch=batch,
+        tokens=tokens,
+        key_heads=key_heads,
+        value_heads=value_heads,
+        gate_kind=gate_kind,
+        requires_grad=True,
+    )
+    if lengths is not None:
+        cu_seqlens = cumulative_sequence_offsets(lengths)
+        inputs = (
+            *inputs[:5],
+            torch.randn(
+                len(lengths),
+                value_heads,
+                128,
+                128,
+                device="cuda",
+                requires_grad=True,
+            ),
+        )
+    else:
+        cu_seqlens = None
+
+    fused_inputs = tuple(tensor.detach().clone().requires_grad_() for tensor in inputs)
+    reference_inputs = tuple(tensor.detach().clone().requires_grad_() for tensor in inputs)
+    golden_inputs = tuple(tensor.detach().double().requires_grad_() for tensor in inputs)
+    actual = run_with_gradients(fused_inputs, "fused", cu_seqlens)
+    expected = run_with_gradients(reference_inputs, "reference", cu_seqlens)
+    golden = run_with_gradients(golden_inputs, "reference", cu_seqlens)
+
+    for name, result, high_precision, reference in zip(
+        ("output", "state", "dq", "dk", "dv", "dgate", "dbeta", "dstate"),
+        actual,
+        golden,
+        expected,
+        strict=True,
+    ):
+        if high_precision.abs().max().item() < 1e-12:
+            assert torch.isfinite(result).all()
+            # The portable gate VJP subtracts two independently reduced FP32 terms.
+            # Uniform -20 gates underflow the true result to zero, leaving a sub-nanounit
+            # cancellation residue that is still far below low-precision significance.
+            zero_atol = 1e-9 if portable and name == "dgate" else 1e-12
+            assert (result.double() - high_precision).abs().max().item() <= zero_atol
+        else:
+            assert_matches_low_precision_reference(result, high_precision, reference, name)
+
+    if lengths is not None:
+        torch.testing.assert_close(actual[1][1], inputs[5][1], rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("portable", [False, True])
+def test_fp16_fused_chunk_matches_reference(portable: bool, monkeypatch):
+    """Validate FP16 forward and gradients on both backward implementations."""
+    if portable:
+        force_portable_backward(monkeypatch)
+    inputs = make_inputs(tokens=64, dtype=torch.float16, requires_grad=True)
+    fused_inputs = tuple(tensor.detach().clone().requires_grad_() for tensor in inputs)
+    reference_inputs = tuple(tensor.detach().clone().requires_grad_() for tensor in inputs)
+    golden_inputs = tuple(tensor.detach().double().requires_grad_() for tensor in inputs)
+    actual = run_with_gradients(fused_inputs, "fused")
+    expected = run_with_gradients(reference_inputs, "reference")
+    golden = run_with_gradients(golden_inputs, "reference")
+    for name, result, high_precision, reference in zip(
+        ("output", "state", "dq", "dk", "dv", "dgate", "dbeta", "dstate"),
+        actual,
+        golden,
+        expected,
+        strict=True,
+    ):
+        if name == "dstate":
+            # dstate crosses both the forward state restage and reverse-state recurrence;
+            # account for both low-precision boundaries while retaining a normalized guard.
+            high = high_precision.double()
+            actual_error = (result.double() - high).abs().max().item()
+            reference_error = (reference.double() - high).abs().max().item()
+            rounding = torch.finfo(torch.float16).eps * high.abs().max().item()
+            assert actual_error <= 4 * (reference_error + rounding)
+            relative_rms = torch.linalg.vector_norm(
+                result.double() - high
+            ) / torch.linalg.vector_norm(high).clamp_min(1e-30)
+            assert relative_rms.item() <= 5e-2
+        else:
+            assert_matches_low_precision_reference(
+                result,
+                high_precision,
+                reference,
+                name,
+                source_dtype=torch.float16,
+            )
+
+
+def test_packed_tail_ignores_nan_capacity_slack():
+    """Never evaluate or consume storage beyond the terminal packed offset."""
+    q, k, v, gate, beta, _state = make_inputs(tokens=192)
+    state = torch.randn(2, v.shape[2], 128, 128, device="cuda")
+    active_tokens = 127
+    for tensor in (q, k, v, gate, beta):
+        tensor[:, active_tokens:] = torch.nan
+    cu_seqlens = torch.tensor([0, 65, active_tokens], device="cuda", dtype=torch.int32)
+    actual_output, actual_state = chunk_gdn(
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        state,
+        cu_seqlens=cu_seqlens,
+        output_final_state=True,
+        impl="fused",
+    )
+    expected_output, expected_state = chunk_gdn(
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        state,
+        cu_seqlens=cu_seqlens,
+        output_final_state=True,
+        impl="reference",
+    )
+    assert actual_state is not None and expected_state is not None
+    assert torch.isfinite(actual_output[:, :active_tokens]).all()
+    torch.testing.assert_close(
+        actual_output[:, :active_tokens],
+        expected_output[:, :active_tokens],
+        rtol=2e-2,
+        atol=2e-3,
+    )
+    torch.testing.assert_close(actual_state, expected_state, rtol=2e-2, atol=2e-3)
+
+
+@pytest.mark.parametrize("portable", [False, True])
+def test_packed_caller_masks_inactive_capacity_gradients(portable: bool, monkeypatch):
+    """Block unspecified inactive gradients at the caller-to-ragged boundary."""
+    if portable:
+        force_portable_backward(monkeypatch)
+    inputs = make_inputs(tokens=192, requires_grad=True)
+    state = torch.randn(2, inputs[2].shape[2], 128, 128, device="cuda", requires_grad=True)
+    leaves = (*inputs[:5], state)
+    active_tokens = 127
+    cu_seqlens = torch.tensor([0, 65, active_tokens], device="cuda", dtype=torch.int32)
+    active_mask = active_token_mask(inputs[0], cu_seqlens)
+    masked_inputs = tuple(
+        mask_inactive_token_gradients(tensor, active_mask) for tensor in inputs[:5]
+    )
+    output, final_state = chunk_gdn(
+        *masked_inputs,
+        state,
+        cu_seqlens=cu_seqlens,
+        output_final_state=True,
+        impl="fused",
+    )
+    assert final_state is not None
+    gradients = torch.autograd.grad(
+        output[:, :active_tokens].float().square().mean() + final_state.float().square().mean(),
+        leaves,
+    )
+    for gradient in gradients[:5]:
+        torch.testing.assert_close(
+            gradient[:, active_tokens:],
+            torch.zeros_like(gradient[:, active_tokens:]),
+            rtol=0,
+            atol=0,
+        )
+
+
+def test_scalar_intra_masks_poisoned_akk_diagonal_and_upper():
+    """Treat only strict-lower dAkk entries as meaningful before any arithmetic."""
+    q, k, _v, _gate, beta, _state = make_inputs(tokens=64, key_heads=1, value_heads=1)
+    cumulative_gate = (-20.0 * torch.arange(1, 65, device="cuda")).view(1, 64, 1)
+    d_aqk = torch.randn(1, 64, 1, 64, device="cuda")
+    d_akk = torch.randn_like(d_aqk)
+    row = torch.arange(64, device="cuda")
+    strict = row[:, None] > row[None, :]
+    clean_d_akk = torch.where(strict[None, :, None, :], d_akk, 0.0)
+    poisoned_d_akk = torch.where(strict[None, :, None, :], d_akk, torch.nan)
+    d_gate_raw = torch.zeros_like(q, dtype=torch.float32)
+    expected = chunk_gdn_bwd_intra_dense(
+        q, k, cumulative_gate, beta, d_aqk, clean_d_akk, d_gate_raw
+    )
+    actual = chunk_gdn_bwd_intra_dense(
+        q, k, cumulative_gate, beta, d_aqk, poisoned_d_akk, d_gate_raw
+    )
+    for result, reference in zip(actual, expected, strict=True):
+        assert torch.isfinite(result).all()
+        torch.testing.assert_close(result, reference, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("tokens", [64, 65])
+def test_aligned_outer_strided_qkv_matches_compact(tokens: int):
+    """Preserve aligned token-strided QKV without changing forward or backward results."""
+    inputs = make_inputs(tokens=tokens, key_heads=1, value_heads=4, requires_grad=True)
+    expected_inputs = tuple(tensor.detach().clone().requires_grad_() for tensor in inputs)
+    strided_inputs = (
+        *(token_strided_like(tensor).requires_grad_() for tensor in inputs[:3]),
+        *(tensor.detach().clone().requires_grad_() for tensor in inputs[3:]),
+    )
+    assert all(
+        normalize_tma_rows(tensor).data_ptr() == tensor.data_ptr() for tensor in strided_inputs[:3]
+    )
+
+    expected = run_with_gradients(expected_inputs, "fused")
+    actual = run_with_gradients(strided_inputs, "fused")
+    for result, reference in zip(actual, expected, strict=True):
+        torch.testing.assert_close(result, reference, rtol=2e-2, atol=2e-3)
+
+
+def test_misaligned_contiguous_inputs_and_cotangent():
+    """Normalize valid storage-offset views at the opaque kernel boundary."""
+    q, k, v, gate, beta, state = make_inputs(tokens=64)
+    misaligned_inputs = (
+        misaligned_like(q).requires_grad_(),
+        k.requires_grad_(),
+        v.requires_grad_(),
+        gate.requires_grad_(),
+        misaligned_like(beta).requires_grad_(),
+        misaligned_like(state).requires_grad_(),
+    )
+    output, final_state = chunk_gdn(
+        *misaligned_inputs[:5],
+        misaligned_inputs[5],
+        output_final_state=True,
+        impl="fused",
+    )
+    assert final_state is not None
+    gradients = torch.autograd.grad(
+        output.float().square().mean() + final_state.float().square().mean(),
+        misaligned_inputs,
+    )
+    assert torch.isfinite(output).all()
+    assert all(torch.isfinite(gradient).all() for gradient in gradients)
+
+    args, _output, state_output, inverse = raw_args()
+    misaligned_d_output = misaligned_like(torch.randn_like(args[2]))
+    backward_args = (
+        *args[:5],
+        inverse,
+        misaligned_d_output,
+        torch.randn_like(state_output),
+        args[5],
+        None,
+        None,
+        args[6],
+    )
+    outputs = chunk_bwd_with_state_grad_op(*backward_args)
+    assert all(torch.isfinite(result).all() for result in outputs)
+
+
+def test_no_state_output_only_and_state_only_gradients():
+    """Exercise no-state/no-final-state and a missing output cotangent."""
+    inputs = make_inputs(tokens=64, key_heads=1, value_heads=4, requires_grad=True)
+    output, state = chunk_gdn(*inputs[:5], impl="fused")
+    assert state is None
+    output_gradients = torch.autograd.grad(output.float().square().mean(), inputs[:5])
+    assert all(torch.isfinite(gradient).all() for gradient in output_gradients)
+
+    state_inputs = tuple(tensor.detach().clone().requires_grad_() for tensor in inputs)
+    _output, final_state = chunk_gdn(
+        *state_inputs[:5],
+        state_inputs[5],
+        output_final_state=True,
+        impl="fused",
+    )
+    assert final_state is not None
+    state_gradients = torch.autograd.grad(final_state.square().mean(), state_inputs)
+    assert all(torch.isfinite(gradient).all() for gradient in state_gradients)
+
+
+def test_int64_layouts_fail_before_kernel_launch(monkeypatch):
+    """Reject wide layouts until every new Triton kernel has an i64 specialization."""
+    import attn_gym.linear.gdn.impl.chunk as chunk_impl
+
+    monkeypatch.setattr(chunk_impl, "requires_int64_offsets", lambda *args: True)
+    inputs = make_inputs(tokens=64)
+    with pytest.raises(ValueError, match="int64 tensor offsets"):
+        chunk_gdn(*inputs[:5], impl="fused")
+
+
+def test_raw_ops_reject_pre_hopper_devices(monkeypatch):
+    """Keep capability validation inside the real registered CUDA launcher."""
+    import attn_gym.linear.gdn.impl.chunk as chunk_impl
+
+    args, _output, _state, _inverse = raw_args()
+    monkeypatch.setattr(
+        chunk_impl,
+        "get_device_properties",
+        lambda device: SimpleNamespace(major=8),
+    )
+    with pytest.raises(ValueError, match="capability 9.0"):
+        chunk_fwd_with_state_op(*args)
+
+
+def raw_args(tokens: int = 64, heads: int = 2):
+    """Construct detached raw-op arguments and their forward tapes."""
+    q, k, v, gate, beta, state = make_inputs(tokens=tokens, key_heads=heads, value_heads=heads)
+    cumulative = _plain_gate_scan_op(gate.unsqueeze(-1), None, None, False).squeeze(-1)
+    args = (q, k, v, cumulative, beta, state, 128**-0.5)
+    with torch.no_grad():
+        output, final_state, inverse = chunk_fwd_with_state_op(*args)
+    return args, output, final_state, inverse
+
+
+def test_dense_raw_operator_registration():
+    """Validate dense forward/backward schemas, fakes, and AOT dispatch."""
+    args, output, final_state, inverse = raw_args()
+    torch.library.opcheck(chunk_fwd_op, args)
+    torch.library.opcheck(chunk_fwd_with_state_op, args)
+    backward_args = (
+        *args[:5],
+        inverse,
+        torch.randn_like(output),
+        torch.randn_like(final_state),
+        args[5],
+        None,
+        None,
+        args[6],
+    )
+    utilities = ("test_schema", "test_faketensor", "test_aot_dispatch_dynamic")
+    torch.library.opcheck(chunk_bwd_op, backward_args, test_utils=utilities)
+    torch.library.opcheck(chunk_bwd_with_state_grad_op, backward_args, test_utils=utilities)
+
+
+def test_packed_raw_operator_registration():
+    """Validate fixed-capacity packed forward/backward registrations."""
+    q, k, v, gate, beta, _state = make_inputs(tokens=128)
+    state = torch.randn(2, v.shape[2], 128, 128, device="cuda")
+    cu_seqlens = torch.tensor([0, 65, 128], device="cuda", dtype=torch.int32)
+    metadata = prepare_ragged_chunk_metadata(cu_seqlens, q.shape[1], 64)
+    cumulative = _plain_gate_scan_op(
+        gate.unsqueeze(-1), cu_seqlens, metadata.chunk_offsets, False
+    ).squeeze(-1)
+    args = (
+        q,
+        k,
+        v,
+        cumulative,
+        beta,
+        state,
+        cu_seqlens,
+        metadata.chunk_offsets,
+        metadata.capacity,
+        128**-0.5,
+    )
+    torch.library.opcheck(chunk_fwd_packed_op, args)
+    torch.library.opcheck(chunk_fwd_packed_with_state_op, args)
+    with torch.no_grad():
+        output, final_state, inverse = chunk_fwd_packed_with_state_op(*args)
+    backward_args = (
+        *args[:5],
+        inverse,
+        torch.randn_like(output),
+        torch.randn_like(final_state),
+        state,
+        cu_seqlens,
+        metadata.chunk_offsets,
+        128**-0.5,
+    )
+    utilities = ("test_schema", "test_faketensor", "test_aot_dispatch_dynamic")
+    torch.library.opcheck(chunk_bwd_op, backward_args, test_utils=utilities)
+    torch.library.opcheck(
+        chunk_bwd_with_state_grad_op,
+        backward_args,
+        test_utils=utilities,
+    )
+
+
+@pytest.mark.parametrize("packed", [False, True])
+@pytest.mark.parametrize("portable", [False, True])
+def test_public_fullgraph_forward_backward(packed: bool, portable: bool, monkeypatch):
+    """Compile both backward implementations with strict forward/backward capture."""
+    if portable:
+        force_portable_backward(monkeypatch)
+    tokens = 128 if packed else 64
+    inputs = make_inputs(tokens=tokens, key_heads=1, value_heads=4, requires_grad=True)
+    cu_seqlens = torch.tensor([0, 65, 128], device="cuda", dtype=torch.int32) if packed else None
+    if packed:
+        inputs = (
+            *inputs[:5],
+            torch.randn(2, 4, 128, 128, device="cuda", requires_grad=True),
+        )
+    expected_inputs = tuple(tensor.detach().clone().requires_grad_() for tensor in inputs)
+    expected = run_with_gradients(expected_inputs, "fused", cu_seqlens)
+    compiled = torch.compile(
+        partial(
+            chunk_gdn,
+            impl="fused",
+            output_final_state=True,
+        ),
+        fullgraph=True,
+    )
+    output, state = compiled(*inputs[:5], inputs[5], cu_seqlens=cu_seqlens)
+    assert state is not None
+    gradients = torch.autograd.grad(
+        output.float().square().mean() + state.float().square().mean(), inputs
+    )
+    actual = output, state, *gradients
+    for result, reference in zip(actual, expected, strict=True):
+        torch.testing.assert_close(result, reference, rtol=0, atol=0)
+
+
+def test_public_dynamic_tokens_forward_backward():
+    """Reuse one dynamic callable across the packed-tail and complete-chunk routes."""
+    compiled = torch.compile(
+        partial(
+            chunk_gdn,
+            impl="fused",
+            output_final_state=True,
+        ),
+        fullgraph=True,
+        dynamic=True,
+    )
+    for tokens in (63, 64, 65):
+        inputs = make_inputs(tokens=tokens, key_heads=1, value_heads=4, requires_grad=True)
+        reference_inputs = tuple(tensor.detach().clone().requires_grad_() for tensor in inputs)
+        expected = run_with_gradients(reference_inputs, "reference")
+        output, state = compiled(*inputs[:5], inputs[5])
+        assert state is not None
+        gradients = torch.autograd.grad(
+            output.float().square().mean() + state.float().square().mean(), inputs
+        )
+        for result, reference in zip((output, state, *gradients), expected, strict=True):
+            torch.testing.assert_close(result, reference, rtol=2e-2, atol=2e-3)
+
+
+@pytest.mark.parametrize("portable", [False, True])
+def test_backward_cuda_graph_replay(portable: bool, monkeypatch):
+    """Capture and replay both training backward implementations."""
+    if portable:
+        force_portable_backward(monkeypatch)
+    inputs = make_inputs(tokens=64, key_heads=1, value_heads=4, requires_grad=True)
+    output, state = chunk_gdn(
+        *inputs[:5],
+        inputs[5],
+        output_final_state=True,
+        impl="fused",
+    )
+    assert state is not None
+    d_output = torch.randn_like(output)
+    d_state = torch.randn_like(state)
+
+    def backward():
+        return torch.autograd.grad(
+            (output, state),
+            inputs,
+            grad_outputs=(d_output, d_state),
+            retain_graph=True,
+        )
+
+    backward()
+    torch.cuda.synchronize()
+    torch.autograd.graph.set_override_stale_capture_stream(True)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = backward()
+    graph.replay()
+    torch.cuda.synchronize()
+    actual = tuple(gradient.clone() for gradient in captured)
+    expected = backward()
+    torch.cuda.synchronize()
+    for result, reference in zip(actual, expected, strict=True):
+        torch.testing.assert_close(result, reference, rtol=0, atol=0)
+
+
+def test_packed_cuda_graph_replays_boundaries():
+    """Reread packed boundaries and chunk offsets on CUDA Graph replay."""
+    q, k, v, gate, beta, _state = make_inputs(tokens=128)
+    state = torch.randn(2, v.shape[2], 128, 128, device="cuda")
+    cu_seqlens = torch.tensor([0, 64, 128], device="cuda", dtype=torch.int32)
+
+    def run():
+        return chunk_gdn(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            state,
+            cu_seqlens=cu_seqlens,
+            output_final_state=True,
+            impl="fused",
+        )
+
+    for _ in range(2):
+        run()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = run()
+
+    cu_seqlens.copy_(torch.tensor([0, 65, 128], device="cuda", dtype=torch.int32))
+    graph.replay()
+    torch.cuda.synchronize()
+    actual = captured[0].clone(), captured[1].clone()
+    expected = run()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(actual[0], expected[0], rtol=0, atol=0)
+    torch.testing.assert_close(actual[1], expected[1], rtol=0, atol=0)


### PR DESCRIPTION
Stacked PRs:
 * #431
 * __->__#425


--- --- ---

Add fused chunk GDN training backend

## Human Note

## Agent note

Implement a repo-local, training-capable `chunk_gdn(..., impl="fused")` backend. The scalar-gate kernels contract raw KK/QK before applying masked causal decay,
so finite nonpositive gates remain valid without KDA's reciprocal-factor lower bound. The public
path supports dense and packed tails, empty sequences, GQA, initial/final state, autograd, fake/AOT
operators, strict fullgraph compilation, dynamic shapes, and CUDA Graph replay.

Backward safely recomputes Aqk, reuses the proven KDA delta-H/WY stages, and finishes with a tuned
scalar intra VJP that fuses K-channel gate reduction with the chunk-local reverse scan. Alignment,
unsupported wide offsets, inactive packed capacity, and pre-Blackwell devices fail or normalize at
the opaque boundary rather than reaching unsafe kernels.

## Performance

B200, B1/H64/K=V=128/BF16, fixed-pointer warm-cache medians:

| T | fused forward | fused backward | 
|---:|---:|---:|---:|---:|
| 4096 | 406.6 us  | 1175.6 us | 
| 8192 | 763.9 us | 4737.5 us | 

T1024 eager timing is launch/DVFS-bimodal. Under CUDA Graph replay, fused backward is 315.5 us at T1024 and 1131.5 us  us at T4096.

## Test Plan

```bash
gpu-run --timeout 30 auto -- timeout --signal=TERM --kill-after=5s 300s \
  .venv/bin/pytest -q -n 6 \
  test/linear/test_gdn.py test/linear/test_gdn_chunk_fused.py test/test_namespaces.py
files=(${(f)"$(git diff --name-only; git ls-files --others --exclude-standard)"}); \
  .venv/bin/prek run --files $files
.venv/bin/ruff check attn_gym/linear/gdn \
  test/linear/test_gdn.py test/linear/test_gdn_chunk_fused.py
```