### PR TITLE
Abstract Mega shared-memory layouts

### DIFF
--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_bprop_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_bprop_f16.py
@@ -125,7 +125,6 @@ from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.mma import mma_ss, mma_st
 from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.swizzle import (
     swizzle_box_offset_128b,
     swizzle_lin_S,
-    swizzle_xor_128b,
 )
 from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.tma import tma_load_tile, tma_store_commit, tma_store_tile, tma_store_wait, tma_tensormap_acquire
 from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.pointwise import (
@@ -1851,9 +1850,12 @@ def compute0_warp_group(
             # ---- gate prefix scan: cumulative log-gate per key channel -----------
             gate_raw = cute.make_rmem_tensor((cfg.b_t,), cutlass.Float32)
             for row in cutlass.range_constexpr(cfg.b_t):
-                f32_segment = prefix_dim // 32
-                f32_segment_dim = prefix_dim - f32_segment * 32
-                prefix_idx = f32_segment * (cfg.b_t * 32) + row * 32 + swizzle_xor_128b(row, f32_segment_dim, elem_bytes=4)
+                prefix_idx = swizzle_box_offset_128b(
+                    row,
+                    prefix_dim,
+                    box_rows=cfg.b_t,
+                    elem_bytes=4,
+                )
                 gate_raw[row] = (sGate_ptr + prefix_idx).load()
             g_prefix_regs = cute.make_rmem_tensor((cfg.b_t,), cutlass.Float32)
             if cutlass.const_expr(cfg.safe_gate):
@@ -1916,9 +1918,12 @@ def compute0_warp_group(
             bars.mb_decay_done[decay_stage].wait(operand_done_phase)
 
             for row in cutlass.range_constexpr(cfg.b_t):
-                f32_segment = prefix_dim // 32
-                f32_segment_dim = prefix_dim - f32_segment * 32
-                prefix_idx = f32_segment * (cfg.b_t * 32) + row * 32 + swizzle_xor_128b(row, f32_segment_dim, elem_bytes=4)
+                prefix_idx = swizzle_box_offset_128b(
+                    row,
+                    prefix_dim,
+                    box_rows=cfg.b_t,
+                    elem_bytes=4,
+                )
                 (sGate_ptr + prefix_idx).store(g_prefix_regs[row])
 
             # ---- state-scale diag: stage exp2(g_last) decay blocks ---------------
@@ -1931,14 +1936,12 @@ def compute0_warp_group(
             # ---- raw Q/K: SMEM -> TMEM ring (channel-major, for WG2) -------------
             qk_raw_stage = chunk_serial % cfg.tmem_qk_raw_stages
             bars.mb_qk_raw_done[qk_raw_stage].wait(((chunk_serial // cfg.tmem_qk_raw_stages) + 1) % 2)
-            raw_seg = prefix_dim // 64
-            raw_dim = prefix_dim - raw_seg * 64
             q_raw_words = cute.make_rmem_tensor((cfg.b_t // 2,), cutlass.Int32)
             k_raw_words = cute.make_rmem_tensor((cfg.b_t // 2,), cutlass.Int32)
             for t2 in cutlass.range_constexpr(cfg.b_t // 2):
                 t0 = 2 * t2
-                ridx0 = raw_seg * (cfg.b_t * 64) + t0 * 64 + swizzle_xor_128b(t0, raw_dim, elem_bytes=2)
-                ridx1 = raw_seg * (cfg.b_t * 64) + (t0 + 1) * 64 + swizzle_xor_128b(t0 + 1, raw_dim, elem_bytes=2)
+                ridx0 = swizzle_box_offset_128b(t0, prefix_dim, box_rows=cfg.b_t)
+                ridx1 = swizzle_box_offset_128b(t0 + 1, prefix_dim, box_rows=cfg.b_t)
                 q0 = (sQ_ptr + ridx0).load().to(cutlass.Float32)
                 q1 = (sQ_ptr + ridx1).load().to(cutlass.Float32)
                 k0 = (sK_ptr + ridx0).load().to(cutlass.Float32)
@@ -1972,9 +1975,11 @@ def compute0_warp_group(
             for dim_half in cutlass.range_constexpr(2):
                 dim_base = dim_half * (cfg.d_k // 2) + lane_in_row_group * 8
                 reg_base = dim_half * 8
-                f16_segment = dim_base // 64
-                f16_segment_dim = dim_base - f16_segment * 64
-                raw_f16_idx = f16_segment * (cfg.b_t * 64) + decay_row * 64 + swizzle_xor_128b(decay_row, f16_segment_dim, elem_bytes=2)
+                raw_f16_idx = swizzle_box_offset_128b(
+                    decay_row,
+                    dim_base,
+                    box_rows=cfg.b_t,
+                )
                 raw_q_frag = (sQ_ptr + raw_f16_idx).load(count=8, alignment=16)
                 raw_k_frag = (sK_ptr + raw_f16_idx).load(count=8, alignment=16)
                 raw_q_frag_f32 = raw_q_frag.to(cutlass.Float32)
@@ -2021,11 +2026,19 @@ def compute0_warp_group(
                 reg_base = dim_half * 8
                 for f32_group in cutlass.range_constexpr(2):
                     f32_dim_base = dim_base + f32_group * 4
-                    f32_segment = f32_dim_base // 32
-                    f32_segment_dim = f32_dim_base - f32_segment * 32
-                    g_prefix_idx = f32_segment * (cfg.b_t * 32) + decay_row * 32 + swizzle_xor_128b(decay_row, f32_segment_dim, elem_bytes=4)
+                    g_prefix_idx = swizzle_box_offset_128b(
+                        decay_row,
+                        f32_dim_base,
+                        box_rows=cfg.b_t,
+                        elem_bytes=4,
+                    )
                     exp_g_frag = (g_prefix_ptr + g_prefix_idx).load(count=4, alignment=16)
-                    exp_g_last_idx = f32_segment * (cfg.b_t * 32) + (cfg.b_t - 1) * 32 + swizzle_xor_128b((cfg.b_t - 1), f32_segment_dim, elem_bytes=4)
+                    exp_g_last_idx = swizzle_box_offset_128b(
+                        cfg.b_t - 1,
+                        f32_dim_base,
+                        box_rows=cfg.b_t,
+                        elem_bytes=4,
+                    )
                     exp_g_last_frag = (g_prefix_ptr + exp_g_last_idx).load(count=4, alignment=16)
                     f32_reg_base = reg_base + f32_group * 4
                     exp_g_regs[f32_reg_base] = exp_g_frag[0]
@@ -2071,9 +2084,11 @@ def compute0_warp_group(
                     (k_decay_pack[0], k_decay_pack[1], k_decay_pack[2], k_decay_pack[3]),
                     cutlass.Int32,
                 ).bitcast(cfg.io_dtype)
-                f16_segment = dim_base // 64
-                f16_segment_dim = dim_base - f16_segment * 64
-                op_idx = f16_segment * (cfg.b_t * 64) + decay_row * 64 + swizzle_xor_128b(decay_row, f16_segment_dim, elem_bytes=2)
+                op_idx = swizzle_box_offset_128b(
+                    decay_row,
+                    dim_base,
+                    box_rows=cfg.b_t,
+                )
                 (sK_inv_ptr + op_idx).store(k_inv_vec, alignment=16)
                 (sK_decay_ptr + op_idx).store(k_decay_vec, alignment=16)
             nvvm.fence_proxy("async.shared", space="cta")
@@ -2105,9 +2120,11 @@ def compute0_warp_group(
                     (k_restore_pack[0], k_restore_pack[1], k_restore_pack[2], k_restore_pack[3]),
                     cutlass.Int32,
                 ).bitcast(cfg.io_dtype)
-                f16_segment = dim_base // 64
-                f16_segment_dim = dim_base - f16_segment * 64
-                op_idx = f16_segment * (cfg.b_t * 64) + decay_row * 64 + swizzle_xor_128b(decay_row, f16_segment_dim, elem_bytes=2)
+                op_idx = swizzle_box_offset_128b(
+                    decay_row,
+                    dim_base,
+                    box_rows=cfg.b_t,
+                )
                 (sQ_decay_ptr + op_idx).store(q_decay_vec, alignment=16)
                 (sK_restore_ptr + op_idx).store(k_restore_vec, alignment=16)
             nvvm.fence_proxy("async.shared", space="cta")
@@ -2125,9 +2142,11 @@ def compute0_warp_group(
                             tuple(
                                 (
                                     state_src
-                                    + (value_dim // 64) * (cfg.d_v * 64)
-                                    + (v_seg * 64 + v_col8 * 8 + e) * 64
-                                    + swizzle_xor_128b(v_seg * 64 + v_col8 * 8 + e, value_dim % 64, elem_bytes=2)
+                                    + swizzle_box_offset_128b(
+                                        v_seg * 64 + v_col8 * 8 + e,
+                                        value_dim,
+                                        box_rows=cfg.d_v,
+                                    )
                                 ).load()
                                 for e in range(8)
                             ),
@@ -2185,6 +2204,16 @@ def compute1_warp_group(
     value_col_offset = ((lane // 8) & 1) * 8
     value_dim = tmem_subpartition * cfg.threads_per_warp + lane
     value_dim_base = tmem_subpartition * cfg.threads_per_warp
+    value_smem_offset0 = swizzle_box_offset_128b(
+        token_row_coord,
+        value_dim_base + value_col_offset,
+        box_rows=cfg.b_t,
+    )
+    value_smem_offset1 = swizzle_box_offset_128b(
+        token_row_coord,
+        value_dim_base + 16 + value_col_offset,
+        box_rows=cfg.b_t,
+    )
     cg1_tidx = warp_idx % 4 * cfg.threads_per_warp + lane
 
     raw_index = PipelineState.start(phase=0)
@@ -2248,7 +2277,7 @@ def compute1_warp_group(
                             (dstate_words[half * 4], dstate_words[half * 4 + 1], dstate_words[half * 4 + 2], dstate_words[half * 4 + 3]),
                             cutlass.Float32,
                         ).bitcast(cfg.io_dtype)
-                        h_addr = (d_base // 64) * (cfg.d_v * 64) + value_dim * 64 + swizzle_xor_128b(value_dim, d_base % 64, elem_bytes=2)
+                        h_addr = swizzle_box_offset_128b(value_dim, d_base, box_rows=cfg.d_v)
                         (smem_data_ptr(sDstate_raw) + h_addr).store(h_vec, alignment=16)
                 nvvm.fence_proxy("async.shared", space="cta")
                 bars.mb_dstate_smem_ready.arrive()
@@ -2272,18 +2301,12 @@ def compute1_warp_group(
             projection_col_id = tmem_col + cfg.tmem_state_k_acc_offset
             input_col_id = tmem_col + cfg.tmem_y_inp_offset
             raw_v_frag0 = nvvm.ldmatrix(
-                sV_ptr
-                + (value_dim_base + value_col_offset) // 64 * (cfg.b_t * 64)
-                + token_row_coord * 64
-                + swizzle_xor_128b(token_row_coord, (value_dim_base + value_col_offset) % 64, elem_bytes=2),
+                sV_ptr + value_smem_offset0,
                 4,
                 nvvm.MMALayout.COL,
             )
             raw_v_frag1 = nvvm.ldmatrix(
-                sV_ptr
-                + (value_dim_base + 16 + value_col_offset) // 64 * (cfg.b_t * 64)
-                + token_row_coord * 64
-                + swizzle_xor_128b(token_row_coord, (value_dim_base + 16 + value_col_offset) % 64, elem_bytes=2),
+                sV_ptr + value_smem_offset1,
                 4,
                 nvvm.MMALayout.COL,
             )
@@ -2367,19 +2390,13 @@ def compute1_warp_group(
                 u_pack0[reg_idx] = fp32_to_fp16(u_vec0[2 * reg_idx], u_vec0[2 * reg_idx + 1], dtype=cfg.io_dtype)
                 u_pack1[reg_idx] = fp32_to_fp16(u_vec1[2 * reg_idx], u_vec1[2 * reg_idx + 1], dtype=cfg.io_dtype)
             nvvm.stmatrix(
-                smem_data_ptr(sU_raw)
-                + (value_dim_base + value_col_offset) // 64 * (cfg.b_t * 64)
-                + token_row_coord * 64
-                + swizzle_xor_128b(token_row_coord, (value_dim_base + value_col_offset) % 64, elem_bytes=2),
+                smem_data_ptr(sU_raw) + value_smem_offset0,
                 u_pack0.load(),
                 nvvm.MMALayout.COL,
                 shape=nvvm.StoreShape.M8N8,
             )
             nvvm.stmatrix(
-                smem_data_ptr(sU_raw)
-                + (value_dim_base + 16 + value_col_offset) // 64 * (cfg.b_t * 64)
-                + token_row_coord * 64
-                + swizzle_xor_128b(token_row_coord, (value_dim_base + 16 + value_col_offset) % 64, elem_bytes=2),
+                smem_data_ptr(sU_raw) + value_smem_offset1,
                 u_pack1.load(),
                 nvvm.MMALayout.COL,
                 shape=nvvm.StoreShape.M8N8,
@@ -2395,16 +2412,8 @@ def compute1_warp_group(
             dy_vec1 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr((row_id1 << 16) + dy_col_id, cutlass.Float32), num=2)
 
             # ---- dY -> sdY: pack + store + publish (super warp's dM operand) -------
-            addr_lo0 = (
-                (value_dim_base + value_col_offset) // 64 * (cfg.b_t * 64)
-                + token_row_coord * 64
-                + swizzle_xor_128b(token_row_coord, (value_dim_base + value_col_offset) % 64, elem_bytes=2)
-            )
-            addr_lo1 = (
-                (value_dim_base + 16 + value_col_offset) // 64 * (cfg.b_t * 64)
-                + token_row_coord * 64
-                + swizzle_xor_128b(token_row_coord, (value_dim_base + 16 + value_col_offset) % 64, elem_bytes=2)
-            )
+            addr_lo0 = value_smem_offset0
+            addr_lo1 = value_smem_offset1
             dy_pack0 = cute.make_rmem_tensor((4,), cutlass.Int32)
             dy_pack1 = cute.make_rmem_tensor((4,), cutlass.Int32)
             for reg_idx in cutlass.range_constexpr(4):
@@ -2549,7 +2558,7 @@ def compute1_warp_group(
                             (dstate_words[half * 4], dstate_words[half * 4 + 1], dstate_words[half * 4 + 2], dstate_words[half * 4 + 3]),
                             cutlass.Float32,
                         ).bitcast(cfg.io_dtype)
-                        h_addr = (d_base // 64) * (cfg.d_v * 64) + value_dim * 64 + swizzle_xor_128b(value_dim, d_base % 64, elem_bytes=2)
+                        h_addr = swizzle_box_offset_128b(value_dim, d_base, box_rows=cfg.d_v)
                         (smem_data_ptr(sDstate_raw) + h_addr).store(h_vec, alignment=16)
                 nvvm.fence_proxy("async.shared", space="cta")
                 bars.mb_dstate_smem_ready.arrive()
@@ -2654,13 +2663,15 @@ def compute2_warp_group(
             bars.mb_k_decay_inv_ready[decay_stage].wait((chunk_serial // cfg.smem_decay_stages) % 2)
 
             # ---- per-channel gate factors ----------------------------------------
-            f32_seg = channel // 32
-            f32_dim = channel - f32_seg * 32
-            f16_seg = channel // 64
-            f16_dim = channel - f16_seg * 64
             eg = cute.make_rmem_tensor((cfg.b_t,), cutlass.Float32)
             for t in cutlass.range_constexpr(cfg.b_t):
-                eg[t] = (sGate_ptr + f32_seg * (cfg.b_t * 32) + t * 32 + swizzle_xor_128b(t, f32_dim, elem_bytes=4)).load()
+                gate_offset = swizzle_box_offset_128b(
+                    t,
+                    channel,
+                    box_rows=cfg.b_t,
+                    elem_bytes=4,
+                )
+                eg[t] = (sGate_ptr + gate_offset).load()
             egl = eg[cfg.b_t - 1]
             nvvm.fence_proxy("async.shared", space="cta")
             bars.mb_gate_done[raw_stage].arrive()
@@ -2694,8 +2705,16 @@ def compute2_warp_group(
                         for j in cutlass.range_constexpr(16):
                             v0 = pl * 64 + row_half * 32 + 2 * j
                             state_pair = cutlass.Vector.from_elements((state_vec[j],), cutlass.Float32).bitcast(cfg.io_dtype)
-                            dstate_addr0 = (channel // 64) * (cfg.d_v * 64) + v0 * 64 + swizzle_xor_128b(v0, channel % 64, elem_bytes=2)
-                            dstate_addr1 = (channel // 64) * (cfg.d_v * 64) + (v0 + 1) * 64 + swizzle_xor_128b(v0 + 1, channel % 64, elem_bytes=2)
+                            dstate_addr0 = swizzle_box_offset_128b(
+                                v0,
+                                channel,
+                                box_rows=cfg.d_v,
+                            )
+                            dstate_addr1 = swizzle_box_offset_128b(
+                                v0 + 1,
+                                channel,
+                                box_rows=cfg.d_v,
+                            )
                             hval0 = (smem_data_ptr(sDstate_raw) + dstate_addr0).load().to(cutlass.Float32)
                             hval1 = (smem_data_ptr(sDstate_raw) + dstate_addr1).load().to(cutlass.Float32)
                             hacc[(2 * j) % 8] = hacc[(2 * j) % 8] + hval0 * state_pair[0].to(cutlass.Float32)
@@ -2825,7 +2844,7 @@ def compute2_warp_group(
             dq_base = dq_stage * (cfg.b_t * cfg.d_k)
             dk_base = dk_stage * (cfg.b_t * cfg.d_k)
             for t in cutlass.range_constexpr(cfg.b_t):
-                out_idx = f16_seg * (cfg.b_t * 64) + t * 64 + swizzle_xor_128b(t, f16_dim, elem_bytes=2)
+                out_idx = swizzle_box_offset_128b(t, channel, box_rows=cfg.b_t)
                 (smem_data_ptr(sDq_raw) + dq_base + out_idx).store(dq_n[t].to(cfg.io_dtype))
                 (smem_data_ptr(sDk_raw) + dk_base + out_idx).store(dk_n[t].to(cfg.io_dtype))
             nvvm.fence_proxy("async.shared", space="cta")
@@ -2848,7 +2867,12 @@ def compute2_warp_group(
             dgate_stage = chunk_serial % cfg.smem_dgate_stages
             bars.mb_dgate_tmastg_done[dgate_stage].wait(((chunk_serial // cfg.smem_dgate_stages) + 1) % 2)
             for t in cutlass.range_constexpr(cfg.b_t):
-                dgate_idx = f32_seg * (cfg.b_t * 32) + t * 32 + swizzle_xor_128b(t, f32_dim, elem_bytes=4)
+                dgate_idx = swizzle_box_offset_128b(
+                    t,
+                    channel,
+                    box_rows=cfg.b_t,
+                    elem_bytes=4,
+                )
                 (smem_data_ptr(sDgate_raw) + dgate_idx).store(dgate_regs[t])
             nvvm.fence_proxy("async.shared", space="cta")
             bars.mb_dgate_tmastg_ready[dgate_stage].arrive()

--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_bprop_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_bprop_f16.py
@@ -122,7 +122,11 @@ from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.handles import (
     tma_slice_runtime_desc,
 )
 from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.mma import mma_ss, mma_step, mma_ts_step
-from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.swizzle import swizzle_lin_S, swizzle_xor_128b
+from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.swizzle import (
+    swizzle_box_offset_128b,
+    swizzle_lin_S,
+    swizzle_xor_128b,
+)
 from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.tma import tma_load_tile, tma_store_commit, tma_store_tile, tma_store_wait, tma_tensormap_acquire
 from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.pointwise import (
     f16x2_to_f32,
@@ -493,19 +497,11 @@ def epilogue_warp(
                 a_acc[accum_idx] = cutlass.Float32(0.0)
             for k_block in cutlass.range_constexpr(cfg.d_k // 16):
                 a_col = k_block * 16 + lhs_col_offset
-                a_seg = a_col // 64
-                a_frag = nvvm.ldmatrix(
-                    sQ_decay_ptr + a_seg * (cfg.b_t * 64) + lhs_row_coord * 64 + swizzle_xor_128b(lhs_row_coord, a_col - a_seg * 64, elem_bytes=2),
-                    4,
-                    nvvm.MMALayout.ROW,
-                )
+                a_offset = swizzle_box_offset_128b(lhs_row_coord, a_col, box_rows=cfg.b_t)
+                a_frag = nvvm.ldmatrix(sQ_decay_ptr + a_offset, 4, nvvm.MMALayout.ROW)
                 b_col = k_block * 16 + rhs_col_offset
-                b_seg = b_col // 64
-                b_frag = nvvm.ldmatrix(
-                    sK_inv_ptr + b_seg * (cfg.b_t * 64) + rhs_row_coord * 64 + swizzle_xor_128b(rhs_row_coord, b_col - b_seg * 64, elem_bytes=2),
-                    4,
-                    nvvm.MMALayout.ROW,
-                )
+                b_offset = swizzle_box_offset_128b(rhs_row_coord, b_col, box_rows=cfg.b_t)
+                b_frag = nvvm.ldmatrix(sK_inv_ptr + b_offset, 4, nvvm.MMALayout.ROW)
                 mma_step(
                     a_acc,
                     (a_frag[0], a_frag[1], a_frag[2], a_frag[3]),
@@ -539,18 +535,12 @@ def epilogue_warp(
                 da_acc[accum_idx] = cutlass.Float32(0.0)
             for k_block in cutlass.range_constexpr(cfg.d_v // 16):
                 a_col = k_block * 16 + lhs_col_offset
-                a_seg = a_col // 64
-                a_frag = nvvm.ldmatrix(
-                    sDo_ptr + a_seg * (cfg.b_t * 64) + lhs_row_coord * 64 + swizzle_xor_128b(lhs_row_coord, a_col - a_seg * 64, elem_bytes=2),
-                    4,
-                    nvvm.MMALayout.ROW,
-                )
+                a_offset = swizzle_box_offset_128b(lhs_row_coord, a_col, box_rows=cfg.b_t)
+                a_frag = nvvm.ldmatrix(sDo_ptr + a_offset, 4, nvvm.MMALayout.ROW)
                 b_col = k_block * 16 + rhs_col_offset
-                b_seg = b_col // 64
+                b_offset = swizzle_box_offset_128b(rhs_row_coord, b_col, box_rows=cfg.b_t)
                 b_frag = nvvm.ldmatrix(
-                    smem_data_ptr(sU_raw) + b_seg * (cfg.b_t * 64) + rhs_row_coord * 64 + swizzle_xor_128b(rhs_row_coord, b_col - b_seg * 64, elem_bytes=2),
-                    4,
-                    nvvm.MMALayout.ROW,
+                    smem_data_ptr(sU_raw) + b_offset, 4, nvvm.MMALayout.ROW
                 )
                 mma_step(
                     da_acc,
@@ -743,19 +733,11 @@ def super_mma_warp(
                 kk_acc[accum_idx] = cutlass.Float32(0.0)
             for k_block in cutlass.range_constexpr(cfg.d_k // 16):
                 a_col = k_block * 16 + lhs_col_offset
-                a_seg = a_col // 64
-                a_frag = nvvm.ldmatrix(
-                    sK_decay_ptr + a_seg * (cfg.b_t * 64) + kk_lhs_row * 64 + swizzle_xor_128b(kk_lhs_row, a_col - a_seg * 64, elem_bytes=2),
-                    4,
-                    nvvm.MMALayout.ROW,
-                )
+                a_offset = swizzle_box_offset_128b(kk_lhs_row, a_col, box_rows=cfg.b_t)
+                a_frag = nvvm.ldmatrix(sK_decay_ptr + a_offset, 4, nvvm.MMALayout.ROW)
                 b_col = k_block * 16 + rhs_col_offset
-                b_seg = b_col // 64
-                b_frag = nvvm.ldmatrix(
-                    sK_inv_ptr + b_seg * (cfg.b_t * 64) + rhs_row_coord * 64 + swizzle_xor_128b(rhs_row_coord, b_col - b_seg * 64, elem_bytes=2),
-                    4,
-                    nvvm.MMALayout.ROW,
-                )
+                b_offset = swizzle_box_offset_128b(rhs_row_coord, b_col, box_rows=cfg.b_t)
+                b_frag = nvvm.ldmatrix(sK_inv_ptr + b_offset, 4, nvvm.MMALayout.ROW)
                 mma_step(
                     kk_acc,
                     (a_frag[0], a_frag[1], a_frag[2], a_frag[3]),
@@ -855,18 +837,14 @@ def super_mma_warp(
                 dm_acc[accum_idx] = cutlass.Float32(0.0)
             for k_block in cutlass.range_constexpr(cfg.d_v // 16):
                 a_col = k_block * 16 + lhs_col_offset
-                a_seg = a_col // 64
+                a_offset = swizzle_box_offset_128b(lhs_row_coord, a_col, box_rows=cfg.b_t)
                 a_frag = nvvm.ldmatrix(
-                    smem_data_ptr(sDy_raw) + a_seg * (cfg.b_t * 64) + lhs_row_coord * 64 + swizzle_xor_128b(lhs_row_coord, a_col - a_seg * 64, elem_bytes=2),
-                    4,
-                    nvvm.MMALayout.ROW,
+                    smem_data_ptr(sDy_raw) + a_offset, 4, nvvm.MMALayout.ROW
                 )
                 b_col = k_block * 16 + rhs_col_offset
-                b_seg = b_col // 64
+                b_offset = swizzle_box_offset_128b(rhs_row_coord, b_col, box_rows=cfg.b_t)
                 b_frag = nvvm.ldmatrix(
-                    smem_data_ptr(sU_raw) + b_seg * (cfg.b_t * 64) + rhs_row_coord * 64 + swizzle_xor_128b(rhs_row_coord, b_col - b_seg * 64, elem_bytes=2),
-                    4,
-                    nvvm.MMALayout.ROW,
+                    smem_data_ptr(sU_raw) + b_offset, 4, nvvm.MMALayout.ROW
                 )
                 mma_step(
                     dm_acc,

--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_bprop_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_bprop_f16.py
@@ -123,8 +123,8 @@ from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.handles import (
 )
 from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.mma import mma_ss, mma_step, mma_ts_step
 from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.swizzle import (
+    swizzle_box_offset_32b,
     swizzle_box_offset_128b,
-    swizzle_lin_S,
 )
 from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.tma import tma_load_tile, tma_store_commit, tma_store_tile, tma_store_wait, tma_tensormap_acquire
 from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.pointwise import (
@@ -393,7 +393,11 @@ def epilogue_warp(
         stsm_row_coord = stsm_row_coord + cutlass.Int32(8)
     if lane // 8 >= 2:
         stsm_col_coord = cutlass.Int32(8)
-    stsm_idx = swizzle_lin_S(stsm_row_coord * cfg.b_t + stsm_col_coord, bbits=1, mbase=3, sshift=3)
+    stsm_idx = swizzle_box_offset_32b(
+        stsm_row_coord,
+        stsm_col_coord,
+        box_rows=cfg.b_t,
+    )
     row_lo = lane // 4
     row_hi = row_lo + cutlass.Int32(8)
 
@@ -691,7 +695,11 @@ def super_mma_warp(
         stsm_row_coord = stsm_row_coord + cutlass.Int32(8)
     if lane // 8 >= 2:
         stsm_col_coord = cutlass.Int32(8)
-    stsm_idx = swizzle_lin_S(stsm_row_coord * cfg.b_t + stsm_col_coord, bbits=1, mbase=3, sshift=3)
+    stsm_idx = swizzle_box_offset_32b(
+        stsm_row_coord,
+        stsm_col_coord,
+        box_rows=cfg.b_t,
+    )
     row_lo = lane // 4
     row_hi = row_lo + cutlass.Int32(8)
 
@@ -1929,8 +1937,11 @@ def compute0_warp_group(
             # ---- state-scale diag: stage exp2(g_last) decay blocks ---------------
             block = prefix_dim // cutlass.Int32(16)
             coord = prefix_dim - block * cutlass.Int32(16)
-            linear_idx = block * cutlass.Int32(256) + coord * cutlass.Int32(16) + coord
-            diag_idx = swizzle_lin_S(linear_idx, bbits=1, mbase=3, sshift=3)
+            diag_idx = block * cutlass.Int32(256) + swizzle_box_offset_32b(
+                coord,
+                coord,
+                box_rows=16,
+            )
             sState_scale_diag_ptr[diag_idx] = exp_g_last.to(cfg.io_dtype)
 
             # ---- raw Q/K: SMEM -> TMEM ring (channel-major, for WG2) -------------

--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_prefill_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_prefill_f16.py
@@ -131,7 +131,7 @@ from .tile_dsl.barrier import (
 )
 from .tile_dsl.handles import MmaDesc, SmemTile, smem_data_ptr, tma_slice_runtime_desc
 from .tile_dsl.mma import mma_step, mma_ts_step
-from .tile_dsl.swizzle import swizzle_lin_S, swizzle_xor_128b
+from .tile_dsl.swizzle import swizzle_box_offset_128b, swizzle_lin_S, swizzle_xor_128b
 from .tile_dsl.tma import tma_load_tile, tma_store_commit, tma_store_tile, tma_store_wait, tma_tensormap_acquire
 from .tile_dsl.pointwise import (
     opaque_f32_zero,
@@ -521,24 +521,17 @@ def super_mma_warp(
             for k_block in cutlass.range_constexpr((cfg.d_k // 16)):
                 # Load B operand
                 k_inv_col = k_block * 16 + rhs_col_offset
-                k_inv_segment = k_inv_col // 64
-                rhs_frag = nvvm.ldmatrix(
-                    sK_inv_ptr
-                    + k_inv_segment * (cfg.b_t * 64)
-                    + rhs_row_coord * 64
-                    + swizzle_xor_128b(rhs_row_coord, k_inv_col - k_inv_segment * 64, elem_bytes=2),
-                    4,
-                    nvvm.MMALayout.ROW,
+                rhs_offset = swizzle_box_offset_128b(
+                    rhs_row_coord, k_inv_col, box_rows=cfg.b_t
                 )
+                rhs_frag = nvvm.ldmatrix(sK_inv_ptr + rhs_offset, 4, nvvm.MMALayout.ROW)
                 # Load A operand
                 storage_key = (k_block * 16 + lhs_col_offset) ^ decay_key_mask
-                storage_slice = storage_key // 64
+                lhs_offset = swizzle_box_offset_128b(
+                    lhs_row_coord, storage_key, box_rows=cfg.b_t
+                )
                 kk_lhs_frag = nvvm.ldmatrix(
-                    sK_decay_ptr
-                    + storage_slice * (cfg.b_t * 64)
-                    + swizzle_xor_128b(lhs_row_coord, lhs_row_coord * 64 + storage_key - storage_slice * 64, elem_bytes=2),
-                    4,
-                    nvvm.MMALayout.ROW,
+                    sK_decay_ptr + lhs_offset, 4, nvvm.MMALayout.ROW
                 )
 
                 mma_step(
@@ -974,24 +967,17 @@ def epilogue_warp(
             for k_block in cutlass.range_constexpr((cfg.d_k // 16)):
                 # Load B operand
                 k_inv_col = k_block * 16 + rhs_col_offset
-                k_inv_segment = k_inv_col // 64
-                rhs_frag = nvvm.ldmatrix(
-                    sK_inv_ptr
-                    + k_inv_segment * (cfg.b_t * 64)
-                    + rhs_row_coord * 64
-                    + swizzle_xor_128b(rhs_row_coord, k_inv_col - k_inv_segment * 64, elem_bytes=2),
-                    4,
-                    nvvm.MMALayout.ROW,
+                rhs_offset = swizzle_box_offset_128b(
+                    rhs_row_coord, k_inv_col, box_rows=cfg.b_t
                 )
+                rhs_frag = nvvm.ldmatrix(sK_inv_ptr + rhs_offset, 4, nvvm.MMALayout.ROW)
                 # Load A operand
                 storage_key = (k_block * 16 + lhs_col_offset) ^ decay_key_mask
-                storage_slice = storage_key // 64
+                lhs_offset = swizzle_box_offset_128b(
+                    lhs_row_coord, storage_key, box_rows=cfg.b_t
+                )
                 a_lhs_frag = nvvm.ldmatrix(
-                    sQ_decay_ptr
-                    + storage_slice * (cfg.b_t * 64)
-                    + swizzle_xor_128b(lhs_row_coord, lhs_row_coord * 64 + storage_key - storage_slice * 64, elem_bytes=2),
-                    4,
-                    nvvm.MMALayout.ROW,
+                    sQ_decay_ptr + lhs_offset, 4, nvvm.MMALayout.ROW
                 )
 
                 mma_step(

--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_prefill_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_prefill_f16.py
@@ -131,7 +131,7 @@ from .tile_dsl.barrier import (
 )
 from .tile_dsl.handles import MmaDesc, SmemTile, smem_data_ptr, tma_slice_runtime_desc
 from .tile_dsl.mma import mma_step, mma_ts_step
-from .tile_dsl.swizzle import swizzle_box_offset_128b, swizzle_lin_S, swizzle_xor_128b
+from .tile_dsl.swizzle import swizzle_box_offset_128b, swizzle_lin_S
 from .tile_dsl.tma import tma_load_tile, tma_store_commit, tma_store_tile, tma_store_wait, tma_tensormap_acquire
 from .tile_dsl.pointwise import (
     opaque_f32_zero,
@@ -1151,12 +1151,14 @@ def compute0_warp_group(
             prefix_dim = cg0_local_warp * cfg.threads_per_warp + lane
 
             # ---- Gate prefix scan -----------------------------------------------
-            f32_segment = prefix_dim // 32
-            prefix_seg_base = f32_segment * (cfg.b_t * 32)
-            prefix_col = prefix_dim - f32_segment * 32
             gate_raw = cute.make_rmem_tensor((cfg.b_t,), cutlass.Float32)
             for row in cutlass.range_constexpr(cfg.b_t):
-                prefix_idx = prefix_seg_base + swizzle_xor_128b(row, row * 32 + prefix_col, elem_bytes=4)
+                prefix_idx = swizzle_box_offset_128b(
+                    row,
+                    prefix_dim,
+                    box_rows=cfg.b_t,
+                    elem_bytes=4,
+                )
                 gate_raw[row] = (sGate_ptr + prefix_idx).load()
             g_prefix_regs = cute.make_rmem_tensor((cfg.b_t,), cutlass.Float32)
             if cutlass.const_expr(cfg.safe_gate):
@@ -1210,7 +1212,12 @@ def compute0_warp_group(
 
             exp_g_last = g_prefix_regs[cfg.b_t - 1]
             for row in cutlass.range_constexpr(cfg.b_t):
-                prefix_idx = prefix_seg_base + swizzle_xor_128b(row, row * 32 + prefix_col, elem_bytes=4)
+                prefix_idx = swizzle_box_offset_128b(
+                    row,
+                    prefix_dim,
+                    box_rows=cfg.b_t,
+                    elem_bytes=4,
+                )
                 (sGate_ptr + prefix_idx).store(g_prefix_regs[row])
 
             # ---- state-scale diag: stage exp2(G_last) decay blocks ---------------
@@ -1239,9 +1246,11 @@ def compute0_warp_group(
             for dim_half in cutlass.range_constexpr(2):
                 dim_base = dim_half * (cfg.d_k // 2) + lane_in_row_group * 8
                 reg_base = dim_half * 8
-                f16_segment = dim_base // 64
-                f16_segment_dim = dim_base - f16_segment * 64
-                raw_f16_idx = f16_segment * (cfg.b_t * 64) + decay_row * 64 + swizzle_xor_128b(decay_row, f16_segment_dim, elem_bytes=2)
+                raw_f16_idx = swizzle_box_offset_128b(
+                    decay_row,
+                    dim_base,
+                    box_rows=cfg.b_t,
+                )
                 raw_q_frag = (sQ_ptr + raw_f16_idx).load(count=8, alignment=16)
                 raw_k_frag = (sK_ptr + raw_f16_idx).load(count=8, alignment=16)
                 raw_q_vec_f32 = raw_q_frag.to(cutlass.Float32)
@@ -1280,11 +1289,19 @@ def compute0_warp_group(
                 reg_base = dim_half * 8
                 for f32_group in cutlass.range_constexpr(2):
                     f32_dim_base = dim_base + f32_group * 4
-                    f32_segment = f32_dim_base // 32
-                    f32_segment_dim = f32_dim_base - f32_segment * 32
-                    g_prefix_idx = f32_segment * (cfg.b_t * 32) + decay_row * 32 + swizzle_xor_128b(decay_row, f32_segment_dim, elem_bytes=4)
+                    g_prefix_idx = swizzle_box_offset_128b(
+                        decay_row,
+                        f32_dim_base,
+                        box_rows=cfg.b_t,
+                        elem_bytes=4,
+                    )
                     exp_g_frag = (sGate_ptr + g_prefix_idx).load(count=4, alignment=16)
-                    exp_g_last_idx = f32_segment * (cfg.b_t * 32) + (cfg.b_t - 1) * 32 + swizzle_xor_128b((cfg.b_t - 1), f32_segment_dim, elem_bytes=4)
+                    exp_g_last_idx = swizzle_box_offset_128b(
+                        cfg.b_t - 1,
+                        f32_dim_base,
+                        box_rows=cfg.b_t,
+                        elem_bytes=4,
+                    )
                     exp_g_last_frag = (sGate_ptr + exp_g_last_idx).load(count=4, alignment=16)
                     f32_reg_base = reg_base + f32_group * 4
                     for j in cutlass.range_constexpr(4):
@@ -1333,14 +1350,17 @@ def compute0_warp_group(
                     operand_done_phase = ((cum_chunk // cfg.smem_decay_stages) + 1) % 2
                     bars.mb_decay_super_done[decay_stage].wait(operand_done_phase)
                     bars.mb_decay_tcgen05_done[decay_stage].wait(operand_done_phase)
-                f16_segment = dim_base // 64
-                f16_segment_dim = dim_base - f16_segment * 64
-                k_inv_swizzled_idx = f16_segment * (cfg.b_t * 64) + decay_row * 64 + swizzle_xor_128b(decay_row, f16_segment_dim, elem_bytes=2)
+                k_inv_swizzled_idx = swizzle_box_offset_128b(
+                    decay_row,
+                    dim_base,
+                    box_rows=cfg.b_t,
+                )
                 (sK_inv_ptr + k_inv_swizzled_idx).store(k_inv_vec, alignment=16)
                 storage_key = dim_base ^ decay_key_mask
-                storage_slice = storage_key // 64
-                decay_swizzled_idx = storage_slice * (cfg.b_t * 64) + swizzle_xor_128b(
-                    decay_row, decay_row * 64 + storage_key - storage_slice * 64, elem_bytes=2
+                decay_swizzled_idx = swizzle_box_offset_128b(
+                    decay_row,
+                    storage_key,
+                    box_rows=cfg.b_t,
                 )
                 (sK_decay_ptr + decay_swizzled_idx).store(k_decay_vec, alignment=16)
             nvvm.fence_proxy("async.shared", space="cta")
@@ -1374,9 +1394,10 @@ def compute0_warp_group(
                     cutlass.Int32,
                 ).bitcast(cfg.io_dtype)
                 storage_key = dim_base ^ decay_key_mask
-                storage_slice = storage_key // 64
-                decay_swizzled_idx = storage_slice * (cfg.b_t * 64) + swizzle_xor_128b(
-                    decay_row, decay_row * 64 + storage_key - storage_slice * 64, elem_bytes=2
+                decay_swizzled_idx = swizzle_box_offset_128b(
+                    decay_row,
+                    storage_key,
+                    box_rows=cfg.b_t,
                 )
                 (sQ_decay_ptr + decay_swizzled_idx).store(q_decay_vec, alignment=16)
 
@@ -1392,9 +1413,11 @@ def compute0_warp_group(
                     exp_g_last_pair = fp32_to_fp16(exp_g_last_regs[reg_base + dim0], exp_g_last_regs[reg_base + dim1], dtype=cfg.io_dtype)
                     k_restore_pack[pair_idx] = mul_f16x2(k_inv_pack[dim_half * 4 + pair_idx], exp_g_last_pair, cfg.io_dtype)
                 storage_row = decay_row ^ (cfg.b_t // 2)
-                f16_segment = dim_base // 64
-                f16_segment_dim = dim_base - f16_segment * 64
-                k_restore_idx = f16_segment * (cfg.b_t * 64) + storage_row * 64 + swizzle_xor_128b(storage_row, f16_segment_dim, elem_bytes=2)
+                k_restore_idx = swizzle_box_offset_128b(
+                    storage_row,
+                    dim_base,
+                    box_rows=cfg.b_t,
+                )
                 k_restore_vec = cutlass.Vector.from_elements(
                     (
                         k_restore_pack[0],
@@ -1461,15 +1484,15 @@ def compute1_warp_group(
     u_acc_addr = row_addr + tmem_col + cfg.tmem_u_acc_offset
     u_inp_addr = st_row_addr + tmem_col + cfg.tmem_u_inp_offset
     q_state_col_base = tmem_col + cfg.tmem_q_state_acc_offset
-    ov_swz_off0 = (
-        (value_dim_base + ov_col_coord) // 64 * (cfg.b_t * 64)
-        + ov_token_coord * 64
-        + swizzle_xor_128b(ov_token_coord, (value_dim_base + ov_col_coord) % 64, elem_bytes=2)
+    ov_swz_off0 = swizzle_box_offset_128b(
+        ov_token_coord,
+        value_dim_base + ov_col_coord,
+        box_rows=cfg.b_t,
     )
-    ov_swz_off = (
-        (value_dim_base + 16 + ov_col_coord) // 64 * (cfg.b_t * 64)
-        + ov_token_coord * 64
-        + swizzle_xor_128b(ov_token_coord, (value_dim_base + 16 + ov_col_coord) % 64, elem_bytes=2)
+    ov_swz_off = swizzle_box_offset_128b(
+        ov_token_coord,
+        value_dim_base + 16 + ov_col_coord,
+        box_rows=cfg.b_t,
     )
     state_k_acc_index = PipelineState.start(phase=0)
     u_acc_index = PipelineState.start(phase=0)

--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_prefill_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_prefill_f16.py
@@ -131,7 +131,7 @@ from .tile_dsl.barrier import (
 )
 from .tile_dsl.handles import MmaDesc, SmemTile, smem_data_ptr, tma_slice_runtime_desc
 from .tile_dsl.mma import mma_step, mma_ts_step
-from .tile_dsl.swizzle import swizzle_box_offset_128b, swizzle_lin_S
+from .tile_dsl.swizzle import swizzle_box_offset_32b, swizzle_box_offset_128b
 from .tile_dsl.tma import tma_load_tile, tma_store_commit, tma_store_tile, tma_store_wait, tma_tensormap_acquire
 from .tile_dsl.pointwise import (
     opaque_f32_zero,
@@ -494,7 +494,11 @@ def super_mma_warp(
         stsm_row_coord = stsm_row_coord + cutlass.Int32(8)
     if lane // 8 >= 2:
         stsm_col_coord = cutlass.Int32(8)
-    stsm_idx = swizzle_lin_S(stsm_row_coord * cfg.b_t + (stsm_col_coord ^ (cfg.b_t // 2)), bbits=1, mbase=3, sshift=3)
+    stsm_idx = swizzle_box_offset_32b(
+        stsm_row_coord,
+        stsm_col_coord ^ (cfg.b_t // 2),
+        box_rows=cfg.b_t,
+    )
     cum_chunk_base = cutlass.Int32(0)
     sched_state = PipelineState.start(phase=0)
     tile_idx = cutlass.Int32(bidx)
@@ -935,7 +939,11 @@ def epilogue_warp(
         stsm_row_coord = stsm_row_coord + cutlass.Int32(8)
     if lane // 8 >= 2:
         stsm_col_coord = cutlass.Int32(8)
-    stsm_idx = swizzle_lin_S(stsm_row_coord * cfg.b_t + (stsm_col_coord ^ (cfg.b_t // 2)), bbits=1, mbase=3, sshift=3)
+    stsm_idx = swizzle_box_offset_32b(
+        stsm_row_coord,
+        stsm_col_coord ^ (cfg.b_t // 2),
+        box_rows=cfg.b_t,
+    )
     cum_chunk_base = cutlass.Int32(0)
     sched_state = PipelineState.start(phase=0)
     tile_idx = cutlass.Int32(bidx)
@@ -1225,8 +1233,11 @@ def compute0_warp_group(
             block = prefix_dim // cutlass.Int32(16)
             coord = prefix_dim - block * cutlass.Int32(16)
             storage_col = coord ^ cutlass.Int32((cfg.b_t // 2))
-            linear_idx = block * cutlass.Int32(256) + coord * cutlass.Int32(16) + storage_col
-            diag_idx = swizzle_lin_S(linear_idx, bbits=1, mbase=3, sshift=3)
+            diag_idx = block * cutlass.Int32(256) + swizzle_box_offset_32b(
+                coord,
+                storage_col,
+                box_rows=16,
+            )
             sState_scale_diag_ptr[diag_idx] = exp_g_last.to(cfg.io_dtype)
 
             nvvm.barrier_cta_sync(cfg.cg0_group_sync_barrier_base_id + cg0_group_id, thread_count=cfg.cg0_threads_per_group)

--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_recompute_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_recompute_f16.py
@@ -133,7 +133,11 @@ from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.handles import (
     tma_slice_runtime_desc,
 )
 from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.mma import mma_step, mma_ts_step
-from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.swizzle import swizzle_lin_S, swizzle_xor_128b
+from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.swizzle import (
+    swizzle_box_offset_128b,
+    swizzle_lin_S,
+    swizzle_xor_128b,
+)
 from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.tma import tma_load_tile, tma_store_commit, tma_store_tile, tma_store_wait, tma_tensormap_acquire
 from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.pointwise import (
     opaque_f32_zero,
@@ -466,24 +470,17 @@ def super_mma_warp(
             for k_block in cutlass.range_constexpr((cfg.d_k // 16)):
                 # Load B operand
                 k_inv_col = k_block * 16 + rhs_col_offset
-                k_inv_segment = k_inv_col // 64
-                rhs_frag = nvvm.ldmatrix(
-                    sK_inv_ptr
-                    + k_inv_segment * (cfg.b_t * 64)
-                    + rhs_row_coord * 64
-                    + swizzle_xor_128b(rhs_row_coord, k_inv_col - k_inv_segment * 64, elem_bytes=2),
-                    4,
-                    nvvm.MMALayout.ROW,
+                rhs_offset = swizzle_box_offset_128b(
+                    rhs_row_coord, k_inv_col, box_rows=cfg.b_t
                 )
+                rhs_frag = nvvm.ldmatrix(sK_inv_ptr + rhs_offset, 4, nvvm.MMALayout.ROW)
                 # Load A operand
                 storage_key = (k_block * 16 + lhs_col_offset) ^ decay_key_mask
-                storage_slice = storage_key // 64
+                lhs_offset = swizzle_box_offset_128b(
+                    lhs_row_coord, storage_key, box_rows=cfg.b_t
+                )
                 kk_lhs_frag = nvvm.ldmatrix(
-                    sK_decay_ptr
-                    + storage_slice * (cfg.b_t * 64)
-                    + swizzle_xor_128b(lhs_row_coord, lhs_row_coord * 64 + storage_key - storage_slice * 64, elem_bytes=2),
-                    4,
-                    nvvm.MMALayout.ROW,
+                    sK_decay_ptr + lhs_offset, 4, nvvm.MMALayout.ROW
                 )
 
                 mma_step(

--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_recompute_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_recompute_f16.py
@@ -136,7 +136,6 @@ from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.mma import mma_step, mma_
 from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.swizzle import (
     swizzle_box_offset_128b,
     swizzle_lin_S,
-    swizzle_xor_128b,
 )
 from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.tma import tma_load_tile, tma_store_commit, tma_store_tile, tma_store_wait, tma_tensormap_acquire
 from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.pointwise import (
@@ -985,12 +984,14 @@ def compute0_warp_group(
             prefix_dim = cg0_local_warp * cfg.threads_per_warp + lane
 
             # ---- Gate prefix scan -----------------------------------------------
-            f32_segment = prefix_dim // 32
-            prefix_seg_base = f32_segment * (cfg.b_t * 32)
-            prefix_col = prefix_dim - f32_segment * 32
             gate_raw = cute.make_rmem_tensor((cfg.b_t,), cutlass.Float32)
             for row in cutlass.range_constexpr(cfg.b_t):
-                prefix_idx = prefix_seg_base + swizzle_xor_128b(row, row * 32 + prefix_col, elem_bytes=4)
+                prefix_idx = swizzle_box_offset_128b(
+                    row,
+                    prefix_dim,
+                    box_rows=cfg.b_t,
+                    elem_bytes=4,
+                )
                 gate_raw[row] = (sGate_ptr + prefix_idx).load()
             g_prefix_regs = cute.make_rmem_tensor((cfg.b_t,), cutlass.Float32)
             if cutlass.const_expr(cfg.safe_gate):
@@ -1044,7 +1045,12 @@ def compute0_warp_group(
 
             exp_g_last = g_prefix_regs[cfg.b_t - 1]
             for row in cutlass.range_constexpr(cfg.b_t):
-                prefix_idx = prefix_seg_base + swizzle_xor_128b(row, row * 32 + prefix_col, elem_bytes=4)
+                prefix_idx = swizzle_box_offset_128b(
+                    row,
+                    prefix_dim,
+                    box_rows=cfg.b_t,
+                    elem_bytes=4,
+                )
                 (sGate_ptr + prefix_idx).store(g_prefix_regs[row])
 
             # ---- state-scale diag: stage exp2(g_last) decay blocks ---------------
@@ -1069,9 +1075,11 @@ def compute0_warp_group(
             for dim_half in cutlass.range_constexpr(2):
                 dim_base = dim_half * (cfg.d_k // 2) + lane_in_row_group * 8
                 reg_base = dim_half * 8
-                f16_segment = dim_base // 64
-                f16_segment_dim = dim_base - f16_segment * 64
-                raw_f16_idx = f16_segment * (cfg.b_t * 64) + decay_row * 64 + swizzle_xor_128b(decay_row, f16_segment_dim, elem_bytes=2)
+                raw_f16_idx = swizzle_box_offset_128b(
+                    decay_row,
+                    dim_base,
+                    box_rows=cfg.b_t,
+                )
                 raw_k_frag = (sK_ptr + raw_f16_idx).load(count=8, alignment=16)
                 raw_k_vec_f32 = raw_k_frag.to(cutlass.Float32)
                 for dim_offset in cutlass.range_constexpr(8):
@@ -1100,11 +1108,19 @@ def compute0_warp_group(
                 reg_base = dim_half * 8
                 for f32_group in cutlass.range_constexpr(2):
                     f32_dim_base = dim_base + f32_group * 4
-                    f32_segment = f32_dim_base // 32
-                    f32_segment_dim = f32_dim_base - f32_segment * 32
-                    g_prefix_idx = f32_segment * (cfg.b_t * 32) + decay_row * 32 + swizzle_xor_128b(decay_row, f32_segment_dim, elem_bytes=4)
+                    g_prefix_idx = swizzle_box_offset_128b(
+                        decay_row,
+                        f32_dim_base,
+                        box_rows=cfg.b_t,
+                        elem_bytes=4,
+                    )
                     exp_g_frag = (sGate_ptr + g_prefix_idx).load(count=4, alignment=16)
-                    exp_g_last_idx = f32_segment * (cfg.b_t * 32) + (cfg.b_t - 1) * 32 + swizzle_xor_128b((cfg.b_t - 1), f32_segment_dim, elem_bytes=4)
+                    exp_g_last_idx = swizzle_box_offset_128b(
+                        cfg.b_t - 1,
+                        f32_dim_base,
+                        box_rows=cfg.b_t,
+                        elem_bytes=4,
+                    )
                     exp_g_last_frag = (sGate_ptr + exp_g_last_idx).load(count=4, alignment=16)
                     f32_reg_base = reg_base + f32_group * 4
                     for j in cutlass.range_constexpr(4):
@@ -1153,14 +1169,17 @@ def compute0_warp_group(
                     operand_done_phase = ((cum_chunk // cfg.smem_decay_stages) + 1) % 2
                     bars.mb_decay_super_done[decay_stage].wait(operand_done_phase)
                     bars.mb_decay_tcgen05_done[decay_stage].wait(operand_done_phase)
-                f16_segment = dim_base // 64
-                f16_segment_dim = dim_base - f16_segment * 64
-                k_inv_swizzled_idx = f16_segment * (cfg.b_t * 64) + decay_row * 64 + swizzle_xor_128b(decay_row, f16_segment_dim, elem_bytes=2)
+                k_inv_swizzled_idx = swizzle_box_offset_128b(
+                    decay_row,
+                    dim_base,
+                    box_rows=cfg.b_t,
+                )
                 (sK_inv_ptr + k_inv_swizzled_idx).store(k_inv_vec, alignment=16)
                 storage_key = dim_base ^ decay_key_mask
-                storage_slice = storage_key // 64
-                decay_swizzled_idx = storage_slice * (cfg.b_t * 64) + swizzle_xor_128b(
-                    decay_row, decay_row * 64 + storage_key - storage_slice * 64, elem_bytes=2
+                decay_swizzled_idx = swizzle_box_offset_128b(
+                    decay_row,
+                    storage_key,
+                    box_rows=cfg.b_t,
                 )
                 (sK_decay_ptr + decay_swizzled_idx).store(k_decay_vec, alignment=16)
             nvvm.fence_proxy("async.shared", space="cta")
@@ -1178,9 +1197,11 @@ def compute0_warp_group(
                     exp_g_last_pair = fp32_to_fp16(exp_g_last_regs[reg_base + dim0], exp_g_last_regs[reg_base + dim1], dtype=cfg.io_dtype)
                     k_restore_pack[pair_idx] = mul_f16x2(k_inv_pack[dim_half * 4 + pair_idx], exp_g_last_pair, cfg.io_dtype)
                 storage_row = decay_row ^ (cfg.b_t // 2)
-                f16_segment = dim_base // 64
-                f16_segment_dim = dim_base - f16_segment * 64
-                k_restore_idx = f16_segment * (cfg.b_t * 64) + storage_row * 64 + swizzle_xor_128b(storage_row, f16_segment_dim, elem_bytes=2)
+                k_restore_idx = swizzle_box_offset_128b(
+                    storage_row,
+                    dim_base,
+                    box_rows=cfg.b_t,
+                )
                 k_restore_vec = cutlass.Vector.from_elements(
                     (
                         k_restore_pack[0],
@@ -1249,20 +1270,16 @@ def compute1_warp_group(
     y_inp_col_id = tmem_col + cfg.tmem_y_inp_offset
     u_acc_addr = row_addr + tmem_col + cfg.tmem_u_acc_offset
     u_inp_addr = st_row_addr + tmem_col + cfg.tmem_u_inp_offset
-    v_swz_off0 = (
-        (value_dim_base + frag_col_offset) // 64 * (cfg.b_t * 64)
-        + frag_row_coord * 64
-        + swizzle_xor_128b(frag_row_coord, (value_dim_base + frag_col_offset) % 64, elem_bytes=2)
+    v_swz_off0 = swizzle_box_offset_128b(
+        frag_row_coord,
+        value_dim_base + frag_col_offset,
+        box_rows=cfg.b_t,
     )
-    v_swz_off = (
-        (value_dim_base + 16 + frag_col_offset) // 64 * (cfg.b_t * 64)
-        + frag_row_coord * 64
-        + swizzle_xor_128b(frag_row_coord, (value_dim_base + 16 + frag_col_offset) % 64, elem_bytes=2)
+    v_swz_off = swizzle_box_offset_128b(
+        frag_row_coord,
+        value_dim_base + 16 + frag_col_offset,
+        box_rows=cfg.b_t,
     )
-    checkpoint_swz_off0 = (value_dim_base + frag_col_offset) // 64 * (cfg.d_k * 64)
-    checkpoint_swz_col0 = (value_dim_base + frag_col_offset) % 64
-    checkpoint_swz_off = (value_dim_base + 16 + frag_col_offset) // 64 * (cfg.d_k * 64)
-    checkpoint_swz_col = (value_dim_base + 16 + frag_col_offset) % 64
     state_k_acc_index = PipelineState.start(phase=0)
     u_acc_index = PipelineState.start(phase=0)
     state_upd_index = PipelineState.start(phase=0)
@@ -1341,7 +1358,7 @@ def compute1_warp_group(
                                 )
                                 dk = sub * 16 + g * 8
                                 checkpoint_addr = (
-                                    checkpoint_stage_base + (dk // 64) * (cfg.d_v * 64) + value_dim * 64 + swizzle_xor_128b(value_dim, dk % 64, elem_bytes=2)
+                                    checkpoint_stage_base + swizzle_box_offset_128b(value_dim, dk, box_rows=cfg.d_v)
                                 )
                                 (sCheckpoint_ptr + checkpoint_addr).store(
                                     cutlass.Vector.from_elements(packs, cutlass.Int32).bitcast(cfg.io_dtype), alignment=16
@@ -1362,7 +1379,7 @@ def compute1_warp_group(
                         for g in cutlass.range_constexpr(2):
                             dk = sub * 16 + g * 8
                             checkpoint_addr = (
-                                checkpoint_stage_base + (dk // 64) * (cfg.d_v * 64) + value_dim * 64 + swizzle_xor_128b(value_dim, dk % 64, elem_bytes=2)
+                                checkpoint_stage_base + swizzle_box_offset_128b(value_dim, dk, box_rows=cfg.d_v)
                             )
                             (sCheckpoint_ptr + checkpoint_addr).store(
                                 cutlass.Vector.from_elements(zero_packs, cutlass.Int32).bitcast(cfg.io_dtype), alignment=16
@@ -1522,7 +1539,7 @@ def compute1_warp_group(
                             packs = tuple(fp32_to_fp16(checkpoint_vec[g * 8 + 2 * t], checkpoint_vec[g * 8 + 2 * t + 1], dtype=cfg.io_dtype) for t in range(4))
                             dk = k_base + g * 8
                             checkpoint_addr = (
-                                checkpoint_stage_base + (dk // 64) * (cfg.d_v * 64) + value_dim * 64 + swizzle_xor_128b(value_dim, dk % 64, elem_bytes=2)
+                                checkpoint_stage_base + swizzle_box_offset_128b(value_dim, dk, box_rows=cfg.d_v)
                             )
                             (sCheckpoint_ptr + checkpoint_addr).store(cutlass.Vector.from_elements(packs, cutlass.Int32).bitcast(cfg.io_dtype), alignment=16)
                     nvvm.fence_proxy("async.shared", space="cta")

--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_recompute_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_recompute_f16.py
@@ -134,8 +134,8 @@ from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.handles import (
 )
 from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.mma import mma_step, mma_ts_step
 from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.swizzle import (
+    swizzle_box_offset_32b,
     swizzle_box_offset_128b,
-    swizzle_lin_S,
 )
 from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.tma import tma_load_tile, tma_store_commit, tma_store_tile, tma_store_wait, tma_tensormap_acquire
 from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.pointwise import (
@@ -442,7 +442,11 @@ def super_mma_warp(
         stsm_row_coord = stsm_row_coord + cutlass.Int32(8)
     if lane // 8 >= 2:
         stsm_col_coord = cutlass.Int32(8)
-    stsm_idx = swizzle_lin_S(stsm_row_coord * cfg.b_t + (stsm_col_coord ^ (cfg.b_t // 2)), bbits=1, mbase=3, sshift=3)
+    stsm_idx = swizzle_box_offset_32b(
+        stsm_row_coord,
+        stsm_col_coord ^ (cfg.b_t // 2),
+        box_rows=cfg.b_t,
+    )
     cum_chunk_base = cutlass.Int32(0)
     sched_state = PipelineState.start(phase=0)
     tile_idx = cutlass.Int32(bidx)
@@ -1058,8 +1062,11 @@ def compute0_warp_group(
             block = prefix_dim // cutlass.Int32(16)
             coord = prefix_dim - block * cutlass.Int32(16)
             storage_col = coord ^ cutlass.Int32((cfg.b_t // 2))
-            linear_idx = block * cutlass.Int32(256) + coord * cutlass.Int32(16) + storage_col
-            diag_idx = swizzle_lin_S(linear_idx, bbits=1, mbase=3, sshift=3)
+            diag_idx = block * cutlass.Int32(256) + swizzle_box_offset_32b(
+                coord,
+                storage_col,
+                box_rows=16,
+            )
             sState_scale_diag_ptr[diag_idx] = exp_g_last.to(cfg.io_dtype)
 
             nvvm.barrier_cta_sync(cfg.cg0_group_sync_barrier_base_id + cg0_group_id, thread_count=cfg.cg0_threads_per_group)

--- a/attn_gym/linear/_delta_rule/mega/kernels/tile_dsl/swizzle.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/tile_dsl/swizzle.py
@@ -49,6 +49,25 @@ def swizzle_xor_32b(row, col_elem, *, elem_bytes: cutlass.Constexpr[int] = 2):
 
 
 @cute.jit
+def swizzle_box_offset_32b(
+    row,
+    col,
+    *,
+    box_rows: cutlass.Constexpr[int],
+    elem_bytes: cutlass.Constexpr[int] = 2,
+):
+    """Map a logical coordinate into segment-major 32-byte-swizzled storage."""
+    box_cols = cutlass.const_expr(32 // elem_bytes)
+    box = col // box_cols
+    col_in_box = col - box * box_cols
+    return (
+        box * box_rows * box_cols
+        + row * box_cols
+        + swizzle_xor_32b(row, col_in_box, elem_bytes=elem_bytes)
+    )
+
+
+@cute.jit
 def swizzle_xor(
     row: cutlass.Int32,
     col: cutlass.Int32,
@@ -81,15 +100,3 @@ def swizzle_lin_128b(
     shift = cutlass.const_expr(row_stride_log2 - chunk_log2)
     mask = cutlass.const_expr(0x7 << chunk_log2)
     return lin ^ ((lin >> shift) & mask)
-
-
-@cute.jit
-def swizzle_lin_S(
-    lin,
-    *,
-    bbits: cutlass.Constexpr[int],
-    mbase: cutlass.Constexpr[int],
-    sshift: cutlass.Constexpr[int],
-):
-    yyy = (lin >> cutlass.const_expr(mbase + sshift)) & cutlass.const_expr((1 << bbits) - 1)
-    return lin ^ (yyy << cutlass.const_expr(mbase))

--- a/attn_gym/linear/_delta_rule/mega/kernels/tile_dsl/swizzle.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/tile_dsl/swizzle.py
@@ -3,12 +3,31 @@
 
 
 import cutlass
-import cutlass.cute as cute
+from cutlass import cute
 
 
 @cute.jit
 def swizzle_xor_128b(row, col_elem, *, elem_bytes: cutlass.Constexpr[int] = 2):
     return col_elem ^ ((row & 7) * cutlass.const_expr(16 // elem_bytes))
+
+
+@cute.jit
+def swizzle_box_offset_128b(
+    row,
+    col,
+    *,
+    box_rows: cutlass.Constexpr[int],
+    elem_bytes: cutlass.Constexpr[int] = 2,
+):
+    """Map a logical coordinate into segment-major 128-byte-swizzled storage."""
+    box_cols = cutlass.const_expr(128 // elem_bytes)
+    box = col // box_cols
+    col_in_box = col - box * box_cols
+    return (
+        box * box_rows * box_cols
+        + row * box_cols
+        + swizzle_xor_128b(row, col_in_box, elem_bytes=elem_bytes)
+    )
 
 
 @cute.jit
@@ -55,7 +74,9 @@ def swizzle_xor(
 
 
 @cute.jit
-def swizzle_lin_128b(lin, *, row_stride_log2: cutlass.Constexpr[int], elem_bytes: cutlass.Constexpr[int] = 2):
+def swizzle_lin_128b(
+    lin, *, row_stride_log2: cutlass.Constexpr[int], elem_bytes: cutlass.Constexpr[int] = 2
+):
     chunk_log2 = cutlass.const_expr((16 // elem_bytes).bit_length() - 1)
     shift = cutlass.const_expr(row_stride_log2 - chunk_log2)
     mask = cutlass.const_expr(0x7 << chunk_log2)
@@ -63,6 +84,12 @@ def swizzle_lin_128b(lin, *, row_stride_log2: cutlass.Constexpr[int], elem_bytes
 
 
 @cute.jit
-def swizzle_lin_S(lin, *, bbits: cutlass.Constexpr[int], mbase: cutlass.Constexpr[int], sshift: cutlass.Constexpr[int]):
+def swizzle_lin_S(
+    lin,
+    *,
+    bbits: cutlass.Constexpr[int],
+    mbase: cutlass.Constexpr[int],
+    sshift: cutlass.Constexpr[int],
+):
     yyy = (lin >> cutlass.const_expr(mbase + sshift)) & cutlass.const_expr((1 << bbits) - 1)
     return lin ^ (yyy << cutlass.const_expr(mbase))

--- a/test/kda/mega/test_smem_swizzle.py
+++ b/test/kda/mega/test_smem_swizzle.py
@@ -1,0 +1,99 @@
+"""Pointwise validation for Mega shared-memory layout helpers."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+cutlass = pytest.importorskip("cutlass")
+cute = pytest.importorskip("cutlass.cute")
+
+from attn_gym._backends.cute import compile_tvm_ffi
+from attn_gym._backends.cute.cache import jit_cache
+from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.swizzle import (
+    swizzle_box_offset_128b,
+)
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() not in ((10, 0), (10, 3)),
+    reason="the Mega SMEM layout test requires SM100 or SM103",
+)
+
+_ROWS = 16
+_COLS = 128
+_ELEMENTS = _ROWS * _COLS
+_THREADS = 256
+
+
+@cute.kernel
+def write_swizzled_offsets(output: cute.Tensor) -> None:
+    """Write the physical offset for every logical coordinate in a 16x128 tile."""
+    thread_idx, _, _ = cute.arch.thread_idx()
+    block_idx = cute.arch.block_idx()[0]
+    index = block_idx * _THREADS + thread_idx
+    if index < _ELEMENTS:
+        row = index // _COLS
+        col = index % _COLS
+        output[index] = swizzle_box_offset_128b(row, col, box_rows=_ROWS)
+
+
+@cute.jit
+def launch_swizzled_offsets(output: cute.Tensor, stream) -> None:
+    """Launch the pointwise layout-map test kernel."""
+    write_swizzled_offsets(output).launch(
+        grid=((_ELEMENTS + _THREADS - 1) // _THREADS, 1, 1),
+        block=(_THREADS, 1, 1),
+        stream=stream,
+    )
+
+
+@jit_cache
+def compile_swizzled_offsets():
+    """Compile the fixed 16x128 offset-map test."""
+    output = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (_ELEMENTS,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    return compile_tvm_ffi(
+        launch_swizzled_offsets,
+        output,
+        name="mega_swizzle_box_offset_128b_test",
+    )
+
+
+def reference_offset(row: int, col: int) -> int:
+    """Evaluate the original segment-major SW128 address expression."""
+    segment = col // 64
+    col_in_segment = col - segment * 64
+    return segment * (_ROWS * 64) + row * 64 + (col_in_segment ^ ((row & 7) * 8))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_swizzle_box_offset_128b_matches_original_layout() -> None:
+    output = torch.empty(_ELEMENTS, dtype=torch.int32, device="cuda")
+    compile_swizzled_offsets()(output)
+
+    expected = torch.tensor(
+        [reference_offset(row, col) for row in range(_ROWS) for col in range(_COLS)],
+        dtype=torch.int32,
+        device="cuda",
+    )
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+    assert torch.equal(output.sort().values, torch.arange(_ELEMENTS, device="cuda"))
+
+    lane_starts = []
+    for lane in range(32):
+        lhs_row = lane % 8 + (8 if (lane // 8) % 2 else 0)
+        lhs_col_offset = 8 if lane // 8 >= 2 else 0
+        rhs_row = lane % 8 + (8 if lane // 16 else 0)
+        rhs_col_offset = 8 if (lane // 8) % 2 else 0
+        for k_block in range(8):
+            lane_starts.extend(
+                (
+                    reference_offset(lhs_row, k_block * 16 + lhs_col_offset),
+                    reference_offset(rhs_row, k_block * 16 + rhs_col_offset),
+                )
+            )
+    assert all(offset % 8 == 0 for offset in lane_starts)

--- a/test/kda/mega/test_smem_swizzle.py
+++ b/test/kda/mega/test_smem_swizzle.py
@@ -11,6 +11,7 @@ cute = pytest.importorskip("cutlass.cute")
 from attn_gym._backends.cute import compile_tvm_ffi
 from attn_gym._backends.cute.cache import jit_cache
 from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.swizzle import (
+    swizzle_box_offset_32b,
     swizzle_box_offset_128b,
 )
 
@@ -19,69 +20,179 @@ pytestmark = pytest.mark.skipif(
     reason="the Mega SMEM layout test requires SM100 or SM103",
 )
 
-_ROWS = 16
-_COLS = 128
-_ELEMENTS = _ROWS * _COLS
+_SW128_ROWS = 16
+_SW128_COLS = 128
+_SW128_ELEMENTS = _SW128_ROWS * _SW128_COLS
+_SW128_STATE_ROWS = 128
+_SW128_STATE_COLS = 128
+_SW128_STATE_ELEMENTS = _SW128_STATE_ROWS * _SW128_STATE_COLS
+_SW32_ROWS = 16
+_SW32_COLS = 16
+_SW32_ELEMENTS = _SW32_ROWS * _SW32_COLS
 _THREADS = 256
+_MAX_ELEMENTS = max(_SW128_ELEMENTS, _SW128_STATE_ELEMENTS, _SW32_ELEMENTS)
 
 
 @cute.kernel
-def write_swizzled_offsets(output: cute.Tensor) -> None:
-    """Write the physical offset for every logical coordinate in a 16x128 tile."""
+def write_swizzled_offsets(
+    output_128b_f16: cute.Tensor,
+    output_128b_f32: cute.Tensor,
+    output_128b_state: cute.Tensor,
+    output_32b: cute.Tensor,
+) -> None:
+    """Write every logical coordinate's physical offset for each live layout."""
     thread_idx, _, _ = cute.arch.thread_idx()
     block_idx = cute.arch.block_idx()[0]
     index = block_idx * _THREADS + thread_idx
-    if index < _ELEMENTS:
-        row = index // _COLS
-        col = index % _COLS
-        output[index] = swizzle_box_offset_128b(row, col, box_rows=_ROWS)
+    if index < _SW128_ELEMENTS:
+        row = index // _SW128_COLS
+        col = index % _SW128_COLS
+        output_128b_f16[index] = swizzle_box_offset_128b(
+            row,
+            col,
+            box_rows=_SW128_ROWS,
+        )
+        output_128b_f32[index] = swizzle_box_offset_128b(
+            row,
+            col,
+            box_rows=_SW128_ROWS,
+            elem_bytes=4,
+        )
+    if index < _SW128_STATE_ELEMENTS:
+        row = index // _SW128_STATE_COLS
+        col = index % _SW128_STATE_COLS
+        output_128b_state[index] = swizzle_box_offset_128b(
+            row,
+            col,
+            box_rows=_SW128_STATE_ROWS,
+        )
+    if index < _SW32_ELEMENTS:
+        row = index // _SW32_COLS
+        col = index % _SW32_COLS
+        output_32b[index] = swizzle_box_offset_32b(row, col, box_rows=_SW32_ROWS)
 
 
 @cute.jit
-def launch_swizzled_offsets(output: cute.Tensor, stream) -> None:
+def launch_swizzled_offsets(
+    output_128b_f16: cute.Tensor,
+    output_128b_f32: cute.Tensor,
+    output_128b_state: cute.Tensor,
+    output_32b: cute.Tensor,
+    stream,
+) -> None:
     """Launch the pointwise layout-map test kernel."""
-    write_swizzled_offsets(output).launch(
-        grid=((_ELEMENTS + _THREADS - 1) // _THREADS, 1, 1),
+    write_swizzled_offsets(
+        output_128b_f16,
+        output_128b_f32,
+        output_128b_state,
+        output_32b,
+    ).launch(
+        grid=((_MAX_ELEMENTS + _THREADS - 1) // _THREADS, 1, 1),
         block=(_THREADS, 1, 1),
         stream=stream,
     )
 
 
-@jit_cache
-def compile_swizzled_offsets():
-    """Compile the fixed 16x128 offset-map test."""
-    output = cute.runtime.make_fake_compact_tensor(
+def fake_output(elements: int):
+    """Create one compact int32 TVM-FFI output signature."""
+    return cute.runtime.make_fake_compact_tensor(
         cutlass.Int32,
-        (_ELEMENTS,),
+        (elements,),
         stride_order=(0,),
         assumed_align=16,
     )
+
+
+@jit_cache
+def compile_swizzled_offsets():
+    """Compile the fixed SW128 and SW32 offset-map test."""
     return compile_tvm_ffi(
         launch_swizzled_offsets,
-        output,
-        name="mega_swizzle_box_offset_128b_test",
+        fake_output(_SW128_ELEMENTS),
+        fake_output(_SW128_ELEMENTS),
+        fake_output(_SW128_STATE_ELEMENTS),
+        fake_output(_SW32_ELEMENTS),
+        name="mega_swizzle_box_offset_test",
     )
 
 
-def reference_offset(row: int, col: int) -> int:
+def reference_offset_128b(
+    row: int,
+    col: int,
+    *,
+    box_rows: int,
+    elem_bytes: int = 2,
+) -> int:
     """Evaluate the original segment-major SW128 address expression."""
-    segment = col // 64
-    col_in_segment = col - segment * 64
-    return segment * (_ROWS * 64) + row * 64 + (col_in_segment ^ ((row & 7) * 8))
+    box_cols = 128 // elem_bytes
+    box = col // box_cols
+    col_in_box = col - box * box_cols
+    return (
+        box * box_rows * box_cols
+        + row * box_cols
+        + (col_in_box ^ ((row & 7) * (16 // elem_bytes)))
+    )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
-def test_swizzle_box_offset_128b_matches_original_layout() -> None:
-    output = torch.empty(_ELEMENTS, dtype=torch.int32, device="cuda")
-    compile_swizzled_offsets()(output)
+def reference_offset_32b(row: int, col: int) -> int:
+    """Evaluate the original S<1,3,3> 16x16 address expression."""
+    return row * _SW32_COLS + (col ^ (((row >> 2) & 1) * 8))
 
-    expected = torch.tensor(
-        [reference_offset(row, col) for row in range(_ROWS) for col in range(_COLS)],
+
+def assert_bijective_offsets(actual: torch.Tensor, expected: torch.Tensor) -> None:
+    """Require pointwise equality and dense one-to-one physical coverage."""
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    assert torch.equal(actual.sort().values, torch.arange(actual.numel(), device="cuda"))
+
+
+def test_swizzle_box_offsets_match_original_layouts() -> None:
+    output_128b_f16 = torch.empty(_SW128_ELEMENTS, dtype=torch.int32, device="cuda")
+    output_128b_f32 = torch.empty(_SW128_ELEMENTS, dtype=torch.int32, device="cuda")
+    output_128b_state = torch.empty(_SW128_STATE_ELEMENTS, dtype=torch.int32, device="cuda")
+    output_32b = torch.empty(_SW32_ELEMENTS, dtype=torch.int32, device="cuda")
+    compile_swizzled_offsets()(
+        output_128b_f16,
+        output_128b_f32,
+        output_128b_state,
+        output_32b,
+    )
+
+    expected_128b_f16 = torch.tensor(
+        [
+            reference_offset_128b(row, col, box_rows=_SW128_ROWS)
+            for row in range(_SW128_ROWS)
+            for col in range(_SW128_COLS)
+        ],
         dtype=torch.int32,
         device="cuda",
     )
-    torch.testing.assert_close(output, expected, rtol=0, atol=0)
-    assert torch.equal(output.sort().values, torch.arange(_ELEMENTS, device="cuda"))
+    expected_128b_f32 = torch.tensor(
+        [
+            reference_offset_128b(row, col, box_rows=_SW128_ROWS, elem_bytes=4)
+            for row in range(_SW128_ROWS)
+            for col in range(_SW128_COLS)
+        ],
+        dtype=torch.int32,
+        device="cuda",
+    )
+    expected_128b_state = torch.tensor(
+        [
+            reference_offset_128b(row, col, box_rows=_SW128_STATE_ROWS)
+            for row in range(_SW128_STATE_ROWS)
+            for col in range(_SW128_STATE_COLS)
+        ],
+        dtype=torch.int32,
+        device="cuda",
+    )
+    expected_32b = torch.tensor(
+        [reference_offset_32b(row, col) for row in range(_SW32_ROWS) for col in range(_SW32_COLS)],
+        dtype=torch.int32,
+        device="cuda",
+    )
+    assert_bijective_offsets(output_128b_f16, expected_128b_f16)
+    assert_bijective_offsets(output_128b_f32, expected_128b_f32)
+    assert_bijective_offsets(output_128b_state, expected_128b_state)
+    assert_bijective_offsets(output_32b, expected_32b)
 
     lane_starts = []
     for lane in range(32):
@@ -92,8 +203,16 @@ def test_swizzle_box_offset_128b_matches_original_layout() -> None:
         for k_block in range(8):
             lane_starts.extend(
                 (
-                    reference_offset(lhs_row, k_block * 16 + lhs_col_offset),
-                    reference_offset(rhs_row, k_block * 16 + rhs_col_offset),
+                    reference_offset_128b(
+                        lhs_row,
+                        k_block * 16 + lhs_col_offset,
+                        box_rows=_SW128_ROWS,
+                    ),
+                    reference_offset_128b(
+                        rhs_row,
+                        k_block * 16 + rhs_col_offset,
+                        box_rows=_SW128_ROWS,
+                    ),
                 )
             )
     assert all(offset % 8 == 0 for offset in lane_starts)


### PR DESCRIPTION
Abstract Mega shared-memory layouts

## Human Note

## Agent note

Replace repeated segment-major SW128 and SW32 address arithmetic with named physical-layout
helpers. The migration covers Mega prefill, recompute, and bprop while deliberately keeping lane
ownership, stage selection, synchronization, `ldmatrix`/`stmatrix`, and descriptor ABI explicit.

Review the commits in order: the first introduces and proves the SW128 map, the second migrates all
SW128 scalar/vector and fragment accesses, and the third names the SW32 intermediate/diagonal map
and removes the obsolete raw bit-parameter helper.

Pointwise CuTeDSL tests cover FP16/BF16, FP32 gates, 128-row state/checkpoint storage, multiple
column boxes, bijectivity, bounds, and aligned matrix-fragment origins. The complete suite passes
apart from the pre-existing Sandwich/FLASH symbolic-scalar lowering failure on PyTorch 2.13.

## Performance

Matched B200 BF16 CUDA-graph replay is neutral to slightly faster. Bprop retains the same ptxas
resource usage (128 registers, five barriers, identical stack and spill counts) and emits eight
fewer SASS instructions after the broad SW128 migration.

| workload | baseline | candidate |
|---|---:|---:|
| T8192/H64 | 3174.71 us | 3172.56 us |
| T4096/H64 | 1627.03 us | 1624.91 us |
| packed 2x4096/H64 | 1866.41 us | 1864.80 us |

## Test Plan

```bash
pytest -n 6 -q test/kda/mega
pytest -n 6 -q -k "not test_sandwich_flex_flash_backend"
prek --all-files
uv lock --check
python benchmarks/kda.py --impl mega --case primary --case dense_t4096_h64 --case packed_balanced --dtype bfloat16 --rounds 7 --iterations 50 --warmups 5
```
