### PR TITLE
Port scalar GDN Mega kernels

### DIFF
--- a/attn_gym/linear/_delta_rule/mega/backward.py
+++ b/attn_gym/linear/_delta_rule/mega/backward.py
@@ -8,6 +8,7 @@ import torch
 
 from attn_gym._backends.cute import tensor_supports_contiguous_dim, tensor_supports_tma
 from attn_gym.linear._delta_rule.mega.kernels.common.host import tensormap_workspace_bytes
+from attn_gym.linear._delta_rule.mega.kernels.compat import initialized_cuda_device
 from attn_gym.linear._delta_rule.validation import resolve_scale
 from attn_gym.utils import ceildiv
 
@@ -36,7 +37,7 @@ def chunk_delta_rule_bwd_mega_packed(
     scale = resolve_scale(scale, q.shape[-1])
     if not q.is_cuda:
         raise ValueError("q must be a CUDA tensor")
-    with torch.cuda.device(q.device):
+    with initialized_cuda_device(q):
         if q.ndim != 4 or q.shape[0] != 1 or q.shape[-1] != 128:
             raise ValueError("q must have shape [1, T, H, 128]")
         if any(tensor.shape != q.shape for tensor in (k, value, gate, d_output)):

--- a/attn_gym/linear/_delta_rule/mega/gdn_backward.py
+++ b/attn_gym/linear/_delta_rule/mega/gdn_backward.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Torch launcher for scalar-GDN checkpoint recompute and Mega backward."""
+
+from __future__ import annotations
+
+import torch
+
+from attn_gym.linear._delta_rule.mega.kernels.common.host import tensormap_workspace_bytes
+from attn_gym.linear._delta_rule.mega.kernels.compat import (
+    checkpoint_capacity_bound,
+    initialized_cuda_device,
+)
+from attn_gym.linear._delta_rule.validation import resolve_scale
+from attn_gym.utils import ceildiv
+
+from .kernels import gdn_bprop_f16, gdn_recompute_f16
+from .schedule import prepare_mega_schedule
+
+_KERNEL_CHUNK_SIZE = 64
+_SCHEDULER_COUNTERS = 4
+_WORKSPACE_WORD_BYTES = 8
+
+
+def chunk_gdn_bwd_mega_packed(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    value: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    d_output: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    initial_state: torch.Tensor | None = None,
+    d_final_state: torch.Tensor | None = None,
+    *,
+    scale: float | None = None,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor | None,
+]:
+    """Run exact BT64 checkpoint recompute followed by scalar-GDN backward."""
+    scale = resolve_scale(scale, q.shape[-1])
+    if not q.is_cuda:
+        raise ValueError("q must be a CUDA tensor")
+    with initialized_cuda_device(q):
+        _, tokens, key_heads, key_dim = q.shape
+        heads = value.shape[2]
+        if k.shape != q.shape or heads % key_heads:
+            raise ValueError("k must match q and value heads must be divisible by query heads")
+        groups = heads // key_heads
+        if groups > 1:
+            # Temporary bridge until the kernel supports grouped-head reduction natively.
+            q_kernel = q.repeat_interleave(groups, dim=2).contiguous()
+            k_kernel = k.repeat_interleave(groups, dim=2).contiguous()
+        else:
+            q_kernel, k_kernel = q, k
+        num_sequences = cu_seqlens.shape[0] - 1
+        stream = torch.cuda.current_stream(q.device).cuda_stream
+        schedule = prepare_mega_schedule(
+            gate,
+            cu_seqlens,
+            tile_tokens=_KERNEL_CHUNK_SIZE,
+            counter_count=_SCHEDULER_COUNTERS,
+            split=False,
+            stream=stream,
+        )
+        checkpoints = torch.empty(
+            max(checkpoint_capacity_bound(tokens, num_sequences, _KERNEL_CHUNK_SIZE), 1),
+            heads,
+            value.shape[-1],
+            key_dim,
+            dtype=q.dtype,
+            device=q.device,
+        )
+        recompute_workspace = torch.empty(
+            ceildiv(
+                tensormap_workspace_bytes(gdn_recompute_f16, num_sequences),
+                _WORKSPACE_WORD_BYTES,
+            ),
+            dtype=torch.int64,
+            device=q.device,
+        )
+        backward_workspace = torch.empty(
+            ceildiv(
+                tensormap_workspace_bytes(gdn_bprop_f16, num_sequences),
+                _WORKSPACE_WORD_BYTES,
+            ),
+            dtype=torch.int64,
+            device=q.device,
+        )
+        d_initial_state = torch.empty_like(initial_state) if initial_state is not None else None
+        dq = torch.empty_like(q_kernel[0])
+        dk = torch.empty_like(k_kernel[0])
+        dv = torch.empty_like(value[0])
+        dgate = torch.empty_like(gate[0])
+        dbeta = torch.empty_like(beta[0])
+
+        gdn_recompute_f16.chunk_gdn_recompute_sm100(
+            k_kernel[0],
+            value[0],
+            gate[0],
+            beta[0],
+            cu_seqlens,
+            initial_state,
+            None,
+            checkpoint_every_n_tokens=_KERNEL_CHUNK_SIZE,
+            output_state_checkpoints=checkpoints,
+            work_items=schedule.work_items,
+            work_count=schedule.work_count,
+            sched_ctr=schedule.counters[:2],
+            sched_all=schedule.counters,
+            order_in_prologue=True,
+            log_gate=True,
+            tensormap_workspace=recompute_workspace,
+        )
+        backward_scheduler = (
+            schedule.counters[2:] if num_sequences * heads <= schedule.num_sms else None
+        )
+        gdn_bprop_f16.chunk_gdn_bwd_sm100(
+            q_kernel[0],
+            k_kernel[0],
+            value[0],
+            gate[0],
+            beta[0],
+            d_output[0],
+            checkpoints,
+            dq,
+            dk,
+            dv,
+            dgate,
+            dbeta,
+            cu_seqlens,
+            scale,
+            use_initial_state=initial_state is not None,
+            d_initial_state=d_initial_state,
+            d_final_state=d_final_state,
+            work_items=schedule.work_items,
+            work_count=schedule.work_count,
+            sched_ctr=backward_scheduler,
+            tensormap_workspace=backward_workspace,
+        )
+        if groups > 1:
+            reduced_dq = dq.reshape(tokens, key_heads, groups, key_dim).sum(2)
+            reduced_dk = dk.reshape(tokens, key_heads, groups, key_dim).sum(2)
+            dq = torch.empty_like(q[0]).copy_(reduced_dq)
+            dk = torch.empty_like(k[0]).copy_(reduced_dk)
+        return (
+            dq.unsqueeze(0),
+            dk.unsqueeze(0),
+            dv.unsqueeze(0),
+            dgate.unsqueeze(0),
+            dbeta.unsqueeze(0),
+            d_initial_state,
+        )
+
+
+__all__ = ["chunk_gdn_bwd_mega_packed"]

--- a/attn_gym/linear/_delta_rule/mega/gdn_forward.py
+++ b/attn_gym/linear/_delta_rule/mega/gdn_forward.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Torch launcher for the private CuTeDSL 4.7 scalar-GDN forward kernel."""
+
+from __future__ import annotations
+
+import torch
+
+from attn_gym._backends.cute import tensor_supports_contiguous_dim, tensor_supports_tma
+from attn_gym.linear._delta_rule.validation import resolve_scale
+from attn_gym.utils import ceildiv
+
+from .kernels import gdn_prefill_f16 as kernel
+from .kernels.common.host import tensormap_workspace_bytes
+from .kernels.compat import get_device_properties, tensor_device_index
+from .schedule import prepare_mega_schedule
+
+_SUPPORTED_IO_DTYPES = (torch.float16, torch.bfloat16)
+_WORKSPACE_WORD_BYTES = 8
+
+
+def validate_available(q: torch.Tensor) -> None:
+    """Validate the scalar-GDN device contract without launching work."""
+    if not q.is_cuda:
+        raise ValueError("the Mega GDN backend requires CUDA tensors")
+    properties = get_device_properties(tensor_device_index(q))
+    if (properties.major, properties.minor) not in ((10, 0), (10, 3)):
+        raise ValueError("the CuTeDSL 4.7 GDN backend requires SM100 or SM103")
+
+
+def run_forward_on_current_device(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    value: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    *,
+    scale: float | None,
+    output_final_state: bool,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Validate and launch one exact unsplit packed scalar-GDN forward."""
+    scale = resolve_scale(scale, q.shape[-1])
+    validate_available(q)
+    if q.ndim != 4 or q.shape[0] != 1 or q.shape[-1] != 128:
+        raise ValueError("q must have shape [1, T, HK, 128]")
+    if k.shape != q.shape:
+        raise ValueError("k must match q")
+    _, tokens, key_heads, key_dim = q.shape
+    if value.ndim != 4 or value.shape[:2] != (1, tokens) or value.shape[-1] != 128:
+        raise ValueError("value must have shape [1, T, H, 128]")
+    heads = value.shape[2]
+    if heads % key_heads:
+        raise ValueError("value heads must be a positive multiple of query/key heads")
+    if gate.shape != (1, tokens, heads) or beta.shape != gate.shape:
+        raise ValueError("gate and beta must have shape [1, T, H]")
+    if q.dtype not in _SUPPORTED_IO_DTYPES or k.dtype != q.dtype or value.dtype != q.dtype:
+        raise TypeError("q, k, and value must share dtype float16 or bfloat16")
+    if gate.dtype != torch.float32 or beta.dtype != torch.float32:
+        raise TypeError("gate and beta must be float32")
+
+    inputs = (q, k, value, gate, beta)
+    if any(not tensor.is_cuda for tensor in inputs):
+        raise ValueError("all inputs must be CUDA tensors")
+    if any(tensor.device != q.device for tensor in inputs[1:]):
+        raise ValueError("all inputs must be on q.device")
+    if any(not tensor_supports_tma(tensor) for tensor in (q, k, value)):
+        raise TypeError("q, k, and value require a TMA-compatible inner mode")
+    if any(
+        not tensor_supports_contiguous_dim(tensor, alignment_bytes=4) for tensor in (gate, beta)
+    ):
+        raise TypeError("gate and beta require a contiguous, element-aligned head mode")
+    if (
+        cu_seqlens.ndim != 1
+        or cu_seqlens.shape[0] < 2
+        or cu_seqlens.dtype != torch.int32
+        or not cu_seqlens.is_contiguous()
+        or not cu_seqlens.is_cuda
+        or cu_seqlens.device != q.device
+        or cu_seqlens.data_ptr() % 8
+    ):
+        raise TypeError("cu_seqlens must be aligned contiguous int32 on q.device")
+
+    num_sequences = cu_seqlens.shape[0] - 1
+    if initial_state is not None:
+        expected_state = (num_sequences, heads, 128, key_dim)
+        if initial_state.shape != expected_state or initial_state.dtype != torch.float32:
+            raise TypeError(f"initial_state must be float32 with shape {expected_state}")
+        if not initial_state.is_cuda or initial_state.device != q.device:
+            raise ValueError("initial_state must be on q.device")
+        if not tensor_supports_tma(initial_state):
+            raise TypeError("initial_state requires a TMA-compatible inner mode")
+
+    if output_final_state and initial_state is None:
+        initial_state = torch.zeros(
+            num_sequences,
+            heads,
+            128,
+            key_dim,
+            dtype=torch.float32,
+            device=q.device,
+        )
+    final_state = initial_state.clone() if output_final_state else None
+    output = torch.empty_like(value)
+    stream = torch.cuda.current_stream(q.device).cuda_stream
+    schedule = prepare_mega_schedule(
+        gate,
+        cu_seqlens,
+        tile_tokens=kernel.CFG.B_T,
+        counter_count=2,
+        split=False,
+        stream=stream,
+    )
+    tensormap_workspace = torch.empty(
+        ceildiv(tensormap_workspace_bytes(kernel, num_sequences), _WORKSPACE_WORD_BYTES),
+        dtype=torch.int64,
+        device=q.device,
+    )
+    kernel.chunk_gdn_sm100(
+        q[0],
+        k[0],
+        value[0],
+        gate[0],
+        beta[0],
+        output[0],
+        cu_seqlens,
+        initial_state,
+        final_state,
+        scale,
+        work_items=schedule.work_items,
+        work_count=schedule.work_count,
+        sched_ctr=schedule.counters,
+        log_gate=True,
+        tensormap_workspace=tensormap_workspace,
+    )
+    return output, final_state
+
+
+def run_forward(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    value: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    *,
+    scale: float | None,
+    output_final_state: bool,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Launch under the input tensor's CUDA device guard."""
+    if not q.is_cuda:
+        raise ValueError("q must be a CUDA tensor")
+    with torch.cuda.device(q.device):
+        return run_forward_on_current_device(
+            q,
+            k,
+            value,
+            gate,
+            beta,
+            cu_seqlens,
+            initial_state,
+            scale=scale,
+            output_final_state=output_final_state,
+        )
+
+
+__all__ = ["run_forward", "validate_available"]

--- a/attn_gym/linear/_delta_rule/mega/kernels/NOTICE.md
+++ b/attn_gym/linear/_delta_rule/mega/kernels/NOTICE.md
@@ -14,12 +14,18 @@ of files under the MIT License as declared by each file's SPDX identifier.
 
 ## Attention Gym adaptation
 
-The low-level KDA prefill, checkpoint-recompute, bprop kernels, and supporting helpers are adapted
-from NVIDIA's `cudnn-frontend` repository at commit
+The low-level KDA and scalar-GDN prefill, checkpoint-recompute, bprop kernels, and supporting
+helpers are adapted from NVIDIA's `cudnn-frontend` repository at commit
 `085d50b33691f06e2309f8e6724741a021985649`.
 
 Source mapping:
 
+- `linear_attention/frost/kernel/gdn_prefill_f16.py` ->
+  `_delta_rule/mega/kernels/gdn_prefill_f16.py`;
+- `linear_attention/frost/kernel/gdn_recompute_f16.py` ->
+  `_delta_rule/mega/kernels/gdn_recompute_f16.py`;
+- `linear_attention/frost/kernel/gdn_bprop_f16.py` ->
+  `_delta_rule/mega/kernels/gdn_bprop_f16.py`;
 - `linear_attention/frost/kernel/kda_prefill_f16.py` ->
   `_delta_rule/mega/kernels/kda_prefill_f16.py`;
 - `linear_attention/frost/kernel/kda_recompute_f16.py` ->

--- a/attn_gym/linear/_delta_rule/mega/kernels/README.md
+++ b/attn_gym/linear/_delta_rule/mega/kernels/README.md
@@ -1,16 +1,16 @@
 # Mega delta-rule CuTeDSL kernels
 
-This package contains the shared SM100/SM103 Mega kernels for delta-rule variants. The prefill,
-checkpoint-recompute, and bprop core is adapted from NVIDIA's Frost KDA implementation;
-`kda_plain_gate_bwd.py` is an Attention Gym-authored dense gate-gradient helper. The current KDA
-adapter owns public API selection, validation, and autograd, while a future GDN adapter can reuse
-the same implementation boundary.
+This package contains the shared SM100/SM103 Mega kernels for delta-rule variants. The KDA and
+scalar-GDN prefill, checkpoint-recompute, and bprop cores are adapted from NVIDIA's Frost
+implementations; `kda_plain_gate_bwd.py` is an Attention Gym-authored dense gate-gradient helper.
+Variant-owned adapters provide Torch validation and orchestration over the shared runtime.
 
 ## Raw specialization
 
 - CuTeDSL 4.7 or newer on NVIDIA SM100 or SM103.
 - Native FP16 or BF16 Q/K/V with K=V=128.
-- FP32 per-token natural-log gate increments and post-sigmoid beta.
+- FP32 per-token natural-log gate increments: `[T,H,K]` for KDA and `[T,H]` for GDN.
+- FP32 post-sigmoid beta.
 - Packed THD execution with contiguous int32 `cu_seqlens`, including tails and empty sequences.
 - Internal recurrent state and checkpoints use `[sequence, head, V, K]`.
 

--- a/attn_gym/linear/_delta_rule/mega/kernels/common/thd.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/common/thd.py
@@ -31,7 +31,7 @@ def emit_seq_load_descs(
     cu_seqlens,
     base_ptr,
     n_batch: cutlass.Int32,
-    row_stride: cutlass.Int32,
+    row_stride: cutlass.Int64,
     seq_ord: cutlass.Constexpr[int],
 ) -> None:
     """Build sequence-relative input maps except at the physical token endpoint.
@@ -82,7 +82,7 @@ def emit_seq_descs(
     cu_seqlens,
     base_ptr,
     n_batch: cutlass.Int32,
-    row_stride: cutlass.Int32,
+    row_stride: cutlass.Int64,
     seq_ord: cutlass.Constexpr[int],
 ) -> None:
     """Per-BATCH TMA-descriptor array for a VARLEN (THD) tensor whose base
@@ -126,7 +126,7 @@ def emit_checkpoint_seq_descs(
     cu_seqlens,
     base_ptr,
     n_batch: cutlass.Int32,
-    row_stride: cutlass.Int32,
+    row_stride: cutlass.Int64,
     every_n: cutlass.Int32,
     seq_ord: cutlass.Constexpr[int],
 ) -> None:

--- a/attn_gym/linear/_delta_rule/mega/kernels/compat.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/compat.py
@@ -1,12 +1,25 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Torch host utilities for the experimental CuTeDSL 4.7 KDA backend."""
+"""Torch host utilities for the experimental CuTeDSL 4.7 Mega backends."""
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from functools import cache
 
 import torch
+
+
+@contextmanager
+def initialized_cuda_device(tensor: torch.Tensor) -> Iterator[None]:
+    """Initialize TVM-FFI's CUDA runtime context and restore the caller's device."""
+    previous_device = torch.cuda.current_device()
+    torch.cuda.set_device(tensor.device)
+    try:
+        yield
+    finally:
+        torch.cuda.set_device(previous_device)
 
 
 def data_ptr(buffer: torch.Tensor) -> int:

--- a/attn_gym/linear/_delta_rule/mega/kernels/gdn_bprop_config.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/gdn_bprop_config.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# This kernel is derived from cuDNN, NVIDIA Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Gated DeltaNet (GDN) Cutlass-primitives bprop kernel config (fixed compile-time
+constants; the per-compile attributes live on ``GdnBwdCfg`` in the kernel
+file).
+
+Target arch: Blackwell SM100 (GB200) / SM103 (GB300).
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Cfg:
+    # --- tile shape ---
+    B_T: int = 64  # chunk size / token tile (the mma N or K of every GEMM)
+    D_K: int = 128  # query/key head dim
+    D_V: int = 128  # value head dim
+
+    # --- TMA descriptor pool ---
+
+    # --- warp assignments (12 warps total) ---
+    COMPUTE_GROUP_0_WARP_IDS: tuple[int, ...] = (
+        0,
+        1,
+        2,
+        3,
+    )  # T-pairwise / kk_epi / qk_epi / inverse / parts
+    COMPUTE_GROUP_1_WARP_IDS: tuple[int, ...] = (
+        4,
+        5,
+        6,
+        7,
+    )  # dH prep / dV-dK-dQ epilogues / dq dot
+    MMA_WARP_ID: int = 8
+    TMA_QKV_WARP_ID: int = 9
+    LOAD_GATE_BETA_WARP_ID: int = 10
+    EPILOGUE_WARP_ID: int = 11
+
+    # --- register split ---
+    NUM_REGS_COMPUTE_GROUP_0: int = 224
+    NUM_REGS_COMPUTE_GROUP_1: int = 248
+    NUM_REGS_OTHER: int = 32
+
+    THREADS_PER_WARP: int = 32
+
+    CLUSTER_SHAPE_MNK: tuple[int, int, int] = (1, 1, 1)
+    SMEM_SCHED_STAGES: int = 2
+
+    # --- SMEM stage counts ---
+    SMEM_Q_STAGES: int = 1
+    SMEM_K_STAGES: int = 2
+    SMEM_V_STAGES: int = 1
+    SMEM_T_INV_STAGES: int = 1
+    SMEM_A_STAGES: int = 1
+
+    # --- TMEM stage counts ---
+    TMEM_DH_ACC_STAGES: int = 1
+    TMEM_DVDK_ACC_STAGES: int = 1
+    TMEM_DH_INP_STAGES: int = 1
+    TMEM_SHARED_INP_STAGES: int = 2
+    TMEM_SHARED_ACC_STAGES: int = 2
+
+    BUFFER_ALIGN_BYTES: int = 1024
+
+
+CFG = Cfg()

--- a/attn_gym/linear/_delta_rule/mega/kernels/gdn_bprop_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/gdn_bprop_f16.py
@@ -1,0 +1,5821 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# This kernel is derived from cuDNN, NVIDIA Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Modified by Attention Gym in 2026: imports were relocated into this package.
+
+"""
+Chunked Gated Delta Net (GDN) BPROP kernel for Blackwell SM100 (Cutlass primitives).
+
+Algorithm overview (per chunk c, iterated c = NT-1 .. 0):
+  Inputs : Q[BT,DK], K[BT,DK], V[BT,DV], dO[BT,DV], S_c[DK,DV] (= checkpoint entry c-1,
+           the forward state ENTERING chunk c), Gate[BT], Beta[BT]
+  State  : dstate[DK,DV]  (state gradient, held in TMEM, accumulated backward)
+
+  MMA order.  A = the staged attention matrix
+  (CG0's A epilogue, sA); dO' = dO * cumprod_vals * scale (CG1 restage):
+  KK          : W_kk[BT,BT]  = K  @ K^T        -> shared acc   (for T)
+  QK          : W_qk[BT,BT]  = Q  @ K^T        -> shared acc   (for the A tile)
+  dV inter    : dV[DV,BT]    = dstate^T(TMEM) @ K^T -> the dV/dK slot
+                (acc=False; CG1 then scales it by decay_scale_vals IN PLACE)
+  KS          : KS[BT,DV]    = S^T(SMEM) @ K^T  -> shared acc
+  dU intra    : dV/dK slot  += dO^T(SMEM) @ A(SMEM)  (waits CG1's
+                in-place scale -> the accumulate is the reference's
+                dv2 = dv_intra + exp2(g_last-g)*(k@dh))
+  dstate Q-term : dstate    += dO'^T(TMEM) @ Q  (acc=False on the
+                first backward chunk = dstate init; the reference's
+                dh = dh*exp2(g_last) + (q*scale*exp2(g))^T @ do)
+  dY          : dY[DV,BT]    = dU^T(TMEM f16) @ T(SMEM) -> shared acc
+                (dY == dV == d(Y); T read TRANSPOSED vs prefill)
+  dA          : dA_eff[BT,BT]= dO(SMEM) @ U^T(SMEM) -> shared acc
+                (sV holds U; CG0 masks it -> sDa for dQ/dK)
+  dM core     : dM[BT,BT]    = dY(SMEM) @ U^T(SMEM) -- the WY
+                inverse backward T^T dT T^T collapsed via
+                T^T dU = dY and T Y = U (Beta folds through
+                sTinv's column scale into both factors); CG0
+                applies -strict(2^{g_i-g_j}) -> sDm (the reference's dA22;
+                both betas cancel against the K rows in the dM-terms)
+  dstate update-term : dstate += dY'^T(TMEM f16) @ K  (dY' = -cumprod_vals
+                * dY: the -(W^T @ dY) term; ready commits HERE)
+  dK dM-terms : dV/dK slot  += K^T @ dM^T + K^T @ dM  (the reference's
+                dk += dA22^T@K_beta / dk_beta += dA22@K folded, the
+                beta row scale cancelling with K_beta = beta*K)
+  dK state-path : SY[BT,DV]    = S^T(SMEM) @ dY^T(SMEM) -> the shared f16
+                input columns (dO'/dU/dY' dead by then); CG1 reads it as
+                -cumprod_vals[t] * (dY @ S^T)[t,:] and adds it to the banked
+                inter+attn dK terms
+
+  Per chunk CG1: restages dO' and dU and dY' -> the f16 input columns
+  (dY' overwrites dU), computes Y = V - cumprod_vals*(K @ state) in registers and stages
+  Y and g_k_state to their dedicated f16 TMEM slots (the U GEMM and
+  the dV-pass read them), stages Q^T over the Y slot after the dV pass,
+  loads dY and stages it plain to sdV (the dV output).
+
+SMEM layout (~226 KB of the 227 KB SM100 cap):
+  Buffer                           Size (B)  Stages
+  Q                                16384     1
+  K                                32768     2      <-- double-buffered (prefetch next chunk)
+  V                                16384     1      <-- overwritten in place by U
+  dO                               16384     1
+  state (checkpoint entry c-1)     32768     1      <-- io-dtype [DK,DV], TMA-loaded
+  T_inv                            8192      1      <-- inverse OUTPUT (upper tri = kernel-start zeros)
+  KK (strict-masked M_kk)          8192      1      <-- KK epi's only store; inverse input + dGate/dBeta
+  A staging / sDa                  8192      1      <-- ALIAS: A then the masked dA
+  dM staging (sDm)                 8192      1      <-- Step 8 -> dK dM-terms
+  dstate_entry (sDstate)                   32768     1      <-- f16 restage, dK-inter's A
+  dQ store staging                 16384     1
+  dK store staging                 16384     1
+  dV store staging                 16384     1
+  cumsumlog / cumprod / Beta       3 x 512   2      <-- in-place dGate/dBeta staging
+
+TMEM layout (512 cols; EXACTLY the prefill map, state->dstate, O->dV):
+  cols 0-128   : dstate accumulator (fp32)     <-- prefill: state acc
+  cols 128-192 : dV/dK accumulator (fp32)      <-- one slot, five sequential
+                 per-chunk productions (dV inter -> dU intra -> dK inter
+                 -> dK attn -> dK dM-terms), each with its own mbar pair
+  cols 192-256 : dstate input (f16 packed)     <-- prefill: state_inp
+  cols 256-384 : shared accumulators x2        <-- KK / A / k_state / U / dY / dA
+                                                    / dM core
+  cols 384-448 : shared inputs x2 (f16 packed) <-- dO' / dU / dY'; the dK
+                 state-path acc overwrites them after their last GEMM reads
+                 (CG1's state-path readout precedes its next-chunk restages)
+  cols 448-512 : Y (448) + g_k_state (480) f16 slots until the dV pass, then
+                 Q^T (448) until CG1's dQ dot reads it
+
+Warp assignments (12 warps = 384 threads):
+  warps 0-3     : compute group 0 - T-pairwise, KK epi, A epi, inverse
+  warps 4-7     : compute group 1 - dV epilogue, dstate scale + f16 restage
+                                    (later: Y = V - K*state -> TMEM, dY staging)
+  warp  8       : MMA warp       - issues the GEMMs
+  warp  9       : TMA load warp  - loads Q, K (double-buf), V, dO, state(=checkpoint)
+  warp  10      : gate warp      - loads Gate/Beta (double-buffered,
+                                    backward order) + stores dGate/dBeta
+  warp  11      : epilogue warp   - store dQ, dK, dV to global memory
+"""
+
+from dataclasses import dataclass
+from functools import cache, partial
+from typing import NamedTuple
+
+import cuda.bindings.driver as cuda_driver
+import cutlass
+import cutlass.experimental.primitives as nvvm
+from cutlass import cute
+from cutlass.experimental import cuda
+
+from attn_gym._backends.cute import compile_tvm_ffi
+from attn_gym._backends.cute.utils import requires_int64_abi
+
+from .common.elementwise import softplus
+from .common.host import get_dtype
+from .common.split_k import (
+    ORDER_CAPACITY,
+    ORDER_ELEMS,
+    ORDER_THREADS,
+    decode_work_item,
+    order_body,
+)
+from .common.thd import (
+    TENSOR_MAP_QWORDS,
+    emit_checkpoint_seq_descs,
+    emit_seq_descs,
+    emit_seq_load_descs,
+)
+from .common.tvm_ffi import (
+    make_counter_signature,
+    make_cu_seqlens_signature,
+    make_strided_signature_tensor,
+    make_work_items_signature,
+    make_workspace_signature,
+    validate_cu_seqlens,
+)
+from .compat import (
+    checkpoint_capacity_bound,
+    current_device,
+    get_device_properties,
+    tensor_device_index,
+    validate_tma_tensor,
+)
+from .gdn_bprop_config import CFG
+from .tile_dsl.barrier import (
+    MBarrier,
+    PipelineState,
+    Producer,
+    advance,
+)
+from .tile_dsl.handles import MmaDesc, SmemTile, smem_data_ptr, tma_slice_runtime_desc
+from .tile_dsl.mma import mma_ss, mma_step, mma_step_k8, mma_ts_step
+from .tile_dsl.pointwise import (
+    f16x2_to_f32,
+    fadd2,
+    ffma2,
+    fmul2,
+    fp32_to_fp16,
+    opaque_f32_zero,
+    sub_f16x2,
+)
+from .tile_dsl.swizzle import swizzle_lin_128b, swizzle_xor_128b
+from .tile_dsl.tma import (
+    tma_load_tile,
+    tma_store_commit,
+    tma_store_tile,
+    tma_store_wait,
+    tma_tensormap_acquire,
+)
+
+RCP_LN2 = 1.4426950408889634  # 1/ln(2): natural-log gates -> the kernel's log2 domain
+
+
+@cute.jit
+def smem_64x64_offset(row, col):
+    """Return the swizzled in-row offset for a 64-column shared-memory tile."""
+    return swizzle_xor_128b(row, col)
+
+
+@cute.jit
+def smem_64x64_linear_offset(offset):
+    """Convert a row-major BT=64 offset to the shared-memory swizzle."""
+    return swizzle_lin_128b(offset, row_stride_log2=6)
+
+
+class GdnBwdBars(NamedTuple):
+    """GDN bprop pipeline mbarrier inventory.
+
+    Every pipeline is a ``_ready``/``_done`` MBarrier pair over one ring: a
+    slot is acquired for filling by waiting ``_done`` and committed by
+    arriving ``_ready``; the reading side waits ``_ready`` and releases the
+    slot by arriving ``_done``.
+
+    Operand buffers read by both the MMA warp and a compute group carry a
+    SPLIT done pair (``_mma_done`` MMA_COMMIT + ``_cg?_done`` THREAD) and the
+    TMA warp waits BOTH: a plain arrive from the MMA warp fires at MMA issue,
+    not completion, which would release the buffer for reload mid-GEMM.
+    """
+
+    mb_q_ready: MBarrier
+    mb_q_mma_done: MBarrier
+    mb_q_cg1_done: MBarrier
+    mb_k_ready: MBarrier
+    mb_k_mma_done: MBarrier
+    mb_k_cg0_done: MBarrier
+    mb_v_ready: MBarrier
+    mb_v_mma_done: MBarrier
+    mb_do_ready: MBarrier
+    mb_do_mma_done: MBarrier
+    mb_state_ready: MBarrier
+    mb_state_mma_done: MBarrier
+
+    mb_gate_ready: MBarrier
+    mb_gate_done: MBarrier
+    mb_beta_ready: MBarrier
+    mb_beta_done: MBarrier
+
+    mb_dstate_acc_ready: MBarrier
+    mb_dstate_scale_acc_done: MBarrier
+    mb_du_scale_acc_ready: MBarrier
+    mb_du_scale_acc_done: MBarrier
+    mb_du_total_acc_ready: MBarrier
+    mb_dk_scale_acc_ready: MBarrier
+    mb_dk_scale_acc_done: MBarrier
+    mb_dk_attn_acc_ready: MBarrier
+    mb_dk_attn_acc_done: MBarrier
+    mb_dk_total_acc_ready: MBarrier
+    mb_dk_total_acc_done: MBarrier
+    mb_dq_acc_scale_ready: MBarrier
+    mb_dq_acc_scale_done: MBarrier
+    mb_dq_acc_total_ready: MBarrier
+    mb_dq_acc_total_done: MBarrier
+    mb_kk_acc_ready: MBarrier
+    mb_kk_acc_done: MBarrier
+    mb_a_acc_ready: MBarrier
+    mb_k_state_acc_ready: MBarrier
+    mb_u_acc_ready: MBarrier
+    mb_dy_acc_ready: MBarrier
+    mb_da_acc_ready: MBarrier
+    mb_dm_acc_ready: MBarrier
+    mb_dm_acc_done: MBarrier
+    mb_dk_state_path_acc_ready: MBarrier
+
+    mb_dstate_inp_ready: MBarrier
+    mb_dstate_inp_done: MBarrier
+    mb_do_prime_inp_ready: MBarrier
+    mb_du_inp_ready: MBarrier
+    mb_dyp_inp_ready: MBarrier
+    mb_y_ready: MBarrier
+
+    mb_t_inv_ready: MBarrier
+    mb_a_ready: MBarrier
+    mb_a_done: MBarrier
+    mb_u_ready: MBarrier
+    mb_dstate_smem_ready: MBarrier
+    mb_state_dot_dstate_done: MBarrier
+    mb_da_ready: MBarrier
+
+    mb_dbeta_cg1_ready: MBarrier
+    mb_dgate_cg1_ready: MBarrier
+
+    mb_dq_tmastg_ready: MBarrier
+    mb_dq_tmastg_done: MBarrier
+    mb_dk_tmastg_ready: MBarrier
+    mb_dk_tmastg_done: MBarrier
+    mb_dv_tmastg_ready: MBarrier
+    mb_dv_tmastg_done: MBarrier
+    mb_sdv_done: MBarrier
+
+    mb_tmem_done: MBarrier
+    mb_sched_ready: MBarrier
+    mb_sched_done: MBarrier
+
+
+def make_gdn_bars(cfg) -> GdnBwdBars:
+    """GdnBwdBars factory.  MUST be called from inside ``kernel`` (allocates SMEM;
+    the mbar rings sit ahead of the gate scalar arrays and data buffers)."""
+    ONE_LANE = 1
+    MMA_ARRIVERS = len([cfg.mma_warp_id])
+    GATE_WARP = cfg.threads_per_warp * len([cfg.load_gate_beta_warp_id])
+    EPI_WARP = cfg.threads_per_warp * len([cfg.epilogue_warp_id])
+    CG0_THREADS = cfg.threads_per_warp * len(cfg.compute_group_0_warp_ids)
+    CG1_THREADS = cfg.threads_per_warp * len(cfg.compute_group_1_warp_ids)
+    CG0_PLUS_CG1 = CG0_THREADS + CG1_THREADS
+
+    def alloc(n):
+        return cutlass.Array(cutlass.Int64, n, space=cutlass.AddressSpace.smem, alignment=16)
+
+    return GdnBwdBars(
+        mb_q_ready=MBarrier(
+            alloc(cfg.smem_q_stages),
+            stages=cfg.smem_q_stages,
+            init_count=ONE_LANE,
+            producer=Producer.TMA_LOAD,
+        ),
+        mb_q_mma_done=MBarrier(
+            alloc(cfg.smem_q_stages),
+            stages=cfg.smem_q_stages,
+            init_count=MMA_ARRIVERS,
+            producer=Producer.MMA_COMMIT,
+        ),
+        mb_q_cg1_done=MBarrier(
+            alloc(cfg.smem_q_stages),
+            stages=cfg.smem_q_stages,
+            init_count=CG1_THREADS,
+            producer=Producer.THREAD,
+        ),
+        mb_k_ready=MBarrier(
+            alloc(cfg.smem_k_stages),
+            stages=cfg.smem_k_stages,
+            init_count=ONE_LANE,
+            producer=Producer.TMA_LOAD,
+        ),
+        mb_k_mma_done=MBarrier(
+            alloc(cfg.smem_k_stages),
+            stages=cfg.smem_k_stages,
+            init_count=MMA_ARRIVERS,
+            producer=Producer.MMA_COMMIT,
+        ),
+        mb_k_cg0_done=MBarrier(
+            alloc(cfg.smem_k_stages),
+            stages=cfg.smem_k_stages,
+            init_count=CG0_THREADS,
+            producer=Producer.THREAD,
+        ),
+        mb_v_ready=MBarrier(
+            alloc(cfg.smem_v_stages),
+            stages=cfg.smem_v_stages,
+            init_count=ONE_LANE,
+            producer=Producer.TMA_LOAD,
+        ),
+        mb_v_mma_done=MBarrier(
+            alloc(cfg.smem_v_stages),
+            stages=cfg.smem_v_stages,
+            init_count=MMA_ARRIVERS,
+            producer=Producer.MMA_COMMIT,
+        ),
+        mb_do_ready=MBarrier(
+            alloc(cfg.smem_do_stages),
+            stages=cfg.smem_do_stages,
+            init_count=ONE_LANE,
+            producer=Producer.TMA_LOAD,
+        ),
+        mb_do_mma_done=MBarrier(
+            alloc(cfg.smem_do_stages),
+            stages=cfg.smem_do_stages,
+            init_count=MMA_ARRIVERS,
+            producer=Producer.MMA_COMMIT,
+        ),
+        mb_state_ready=MBarrier(
+            alloc(cfg.smem_state_stages),
+            stages=cfg.smem_state_stages,
+            init_count=ONE_LANE,
+            producer=Producer.TMA_LOAD,
+        ),
+        mb_state_mma_done=MBarrier(
+            alloc(cfg.smem_state_stages),
+            stages=cfg.smem_state_stages,
+            init_count=1,
+            producer=Producer.MMA_COMMIT,
+        ),
+        mb_gate_ready=MBarrier(
+            alloc(cfg.smem_gate_stages),
+            stages=cfg.smem_gate_stages,
+            init_count=GATE_WARP,
+            producer=Producer.THREAD,
+        ),
+        mb_gate_done=MBarrier(
+            alloc(cfg.smem_gate_stages),
+            stages=cfg.smem_gate_stages,
+            init_count=CG0_PLUS_CG1,
+            producer=Producer.THREAD,
+        ),
+        mb_beta_ready=MBarrier(
+            alloc(cfg.smem_beta_stages),
+            stages=cfg.smem_beta_stages,
+            init_count=GATE_WARP,
+            producer=Producer.THREAD,
+        ),
+        mb_beta_done=MBarrier(
+            alloc(cfg.smem_beta_stages),
+            stages=cfg.smem_beta_stages,
+            init_count=CG0_PLUS_CG1,
+            producer=Producer.THREAD,
+        ),
+        mb_dstate_acc_ready=MBarrier(
+            alloc(cfg.tmem_dstate_acc_stages),
+            stages=cfg.tmem_dstate_acc_stages,
+            init_count=MMA_ARRIVERS,
+            producer=Producer.MMA_COMMIT,
+        ),
+        mb_dstate_scale_acc_done=MBarrier(
+            alloc(cfg.tmem_dstate_acc_stages),
+            stages=cfg.tmem_dstate_acc_stages,
+            init_count=CG1_THREADS,
+            producer=Producer.THREAD,
+        ),
+        # five sequential per-chunk productions share the dV/dK TMEM slot
+        mb_du_scale_acc_ready=MBarrier(
+            alloc(1), stages=1, init_count=MMA_ARRIVERS, producer=Producer.MMA_COMMIT
+        ),
+        mb_du_scale_acc_done=MBarrier(
+            alloc(1), stages=1, init_count=CG1_THREADS, producer=Producer.THREAD
+        ),
+        mb_du_total_acc_ready=MBarrier(
+            alloc(1), stages=1, init_count=MMA_ARRIVERS, producer=Producer.MMA_COMMIT
+        ),
+        mb_dk_scale_acc_ready=MBarrier(
+            alloc(1), stages=1, init_count=MMA_ARRIVERS, producer=Producer.MMA_COMMIT
+        ),
+        mb_dk_scale_acc_done=MBarrier(
+            alloc(1), stages=1, init_count=CG0_THREADS, producer=Producer.THREAD
+        ),
+        mb_dk_attn_acc_ready=MBarrier(
+            alloc(1), stages=1, init_count=MMA_ARRIVERS, producer=Producer.MMA_COMMIT
+        ),
+        mb_dk_attn_acc_done=MBarrier(
+            alloc(1), stages=1, init_count=CG0_THREADS, producer=Producer.THREAD
+        ),
+        mb_dk_total_acc_ready=MBarrier(
+            alloc(1), stages=1, init_count=MMA_ARRIVERS, producer=Producer.MMA_COMMIT
+        ),
+        mb_dk_total_acc_done=MBarrier(
+            alloc(1), stages=1, init_count=CG1_THREADS, producer=Producer.THREAD
+        ),
+        mb_dq_acc_scale_ready=MBarrier(
+            alloc(1), stages=1, init_count=MMA_ARRIVERS, producer=Producer.MMA_COMMIT
+        ),
+        mb_dq_acc_scale_done=MBarrier(
+            alloc(1), stages=1, init_count=CG0_THREADS, producer=Producer.THREAD
+        ),
+        mb_dq_acc_total_ready=MBarrier(
+            alloc(1), stages=1, init_count=MMA_ARRIVERS, producer=Producer.MMA_COMMIT
+        ),
+        mb_dq_acc_total_done=MBarrier(
+            alloc(1), stages=1, init_count=CG1_THREADS, producer=Producer.THREAD
+        ),
+        # shared accumulators at STATIC columns: group A holds
+        # KK -> k_state -> dY -> dM core, group B holds A -> U -> dA.
+        mb_kk_acc_ready=MBarrier(
+            alloc(1), stages=1, init_count=MMA_ARRIVERS, producer=Producer.MMA_COMMIT
+        ),
+        mb_kk_acc_done=MBarrier(
+            alloc(1), stages=1, init_count=CG0_THREADS, producer=Producer.THREAD
+        ),
+        mb_a_acc_ready=MBarrier(
+            alloc(1), stages=1, init_count=MMA_ARRIVERS, producer=Producer.MMA_COMMIT
+        ),
+        mb_k_state_acc_ready=MBarrier(
+            alloc(1), stages=1, init_count=MMA_ARRIVERS, producer=Producer.MMA_COMMIT
+        ),
+        mb_u_acc_ready=MBarrier(
+            alloc(1), stages=1, init_count=MMA_ARRIVERS, producer=Producer.MMA_COMMIT
+        ),
+        mb_dy_acc_ready=MBarrier(
+            alloc(1), stages=1, init_count=MMA_ARRIVERS, producer=Producer.MMA_COMMIT
+        ),
+        mb_da_acc_ready=MBarrier(
+            alloc(1), stages=1, init_count=MMA_ARRIVERS, producer=Producer.MMA_COMMIT
+        ),
+        mb_dm_acc_ready=MBarrier(
+            alloc(1), stages=1, init_count=MMA_ARRIVERS, producer=Producer.MMA_COMMIT
+        ),
+        mb_dm_acc_done=MBarrier(
+            alloc(1), stages=1, init_count=CG0_THREADS, producer=Producer.THREAD
+        ),
+        mb_dk_state_path_acc_ready=MBarrier(
+            alloc(1), stages=1, init_count=MMA_ARRIVERS, producer=Producer.MMA_COMMIT
+        ),
+        mb_dstate_inp_ready=MBarrier(
+            alloc(cfg.tmem_dstate_inp_stages),
+            stages=cfg.tmem_dstate_inp_stages,
+            init_count=CG1_THREADS,
+            producer=Producer.THREAD,
+        ),
+        mb_dstate_inp_done=MBarrier(
+            alloc(cfg.tmem_dstate_inp_stages),
+            stages=cfg.tmem_dstate_inp_stages,
+            init_count=MMA_ARRIVERS,
+            producer=Producer.MMA_COMMIT,
+        ),
+        # f16 input restages at STATIC columns: dO' alone; dU and dY' overlap
+        mb_do_prime_inp_ready=MBarrier(
+            alloc(1), stages=1, init_count=CG1_THREADS, producer=Producer.THREAD
+        ),
+        mb_du_inp_ready=MBarrier(
+            alloc(1), stages=1, init_count=CG1_THREADS, producer=Producer.THREAD
+        ),
+        mb_dyp_inp_ready=MBarrier(
+            alloc(1), stages=1, init_count=CG1_THREADS, producer=Producer.THREAD
+        ),
+        mb_y_ready=MBarrier(alloc(1), stages=1, init_count=CG1_THREADS, producer=Producer.THREAD),
+        mb_t_inv_ready=MBarrier(
+            alloc(cfg.smem_t_inv_stages),
+            stages=cfg.smem_t_inv_stages,
+            init_count=CG0_THREADS,
+            producer=Producer.THREAD,
+        ),
+        mb_a_ready=MBarrier(
+            alloc(cfg.smem_a_stages),
+            stages=cfg.smem_a_stages,
+            init_count=CG0_THREADS,
+            producer=Producer.THREAD,
+        ),
+        mb_a_done=MBarrier(
+            alloc(cfg.smem_a_stages),
+            stages=cfg.smem_a_stages,
+            init_count=MMA_ARRIVERS,
+            producer=Producer.MMA_COMMIT,
+        ),
+        mb_u_ready=MBarrier(alloc(1), stages=1, init_count=CG1_THREADS, producer=Producer.THREAD),
+        mb_dstate_smem_ready=MBarrier(
+            alloc(1), stages=1, init_count=CG1_THREADS, producer=Producer.THREAD
+        ),
+        mb_state_dot_dstate_done=MBarrier(
+            alloc(1), stages=1, init_count=CG0_THREADS, producer=Producer.THREAD
+        ),
+        mb_da_ready=MBarrier(alloc(1), stages=1, init_count=CG0_THREADS, producer=Producer.THREAD),
+        mb_dbeta_cg1_ready=MBarrier(
+            alloc(1), stages=1, init_count=CG1_THREADS, producer=Producer.THREAD
+        ),
+        mb_dgate_cg1_ready=MBarrier(
+            alloc(1), stages=1, init_count=CG1_THREADS, producer=Producer.THREAD
+        ),
+        mb_dq_tmastg_ready=MBarrier(
+            alloc(cfg.smem_dq_stages),
+            stages=cfg.smem_dq_stages,
+            init_count=CG1_THREADS,
+            producer=Producer.THREAD,
+        ),
+        mb_dq_tmastg_done=MBarrier(
+            alloc(cfg.smem_dq_stages),
+            stages=cfg.smem_dq_stages,
+            init_count=EPI_WARP,
+            producer=Producer.THREAD,
+        ),
+        mb_dk_tmastg_ready=MBarrier(
+            alloc(cfg.smem_dk_stages),
+            stages=cfg.smem_dk_stages,
+            init_count=CG1_THREADS,
+            producer=Producer.THREAD,
+        ),
+        mb_dk_tmastg_done=MBarrier(
+            alloc(cfg.smem_dk_stages),
+            stages=cfg.smem_dk_stages,
+            init_count=EPI_WARP,
+            producer=Producer.THREAD,
+        ),
+        mb_dv_tmastg_ready=MBarrier(
+            alloc(cfg.smem_dv_stages),
+            stages=cfg.smem_dv_stages,
+            init_count=CG1_THREADS,
+            producer=Producer.THREAD,
+        ),
+        mb_dv_tmastg_done=MBarrier(
+            alloc(cfg.smem_dv_stages),
+            stages=cfg.smem_dv_stages,
+            init_count=EPI_WARP,
+            producer=Producer.THREAD,
+        ),
+        mb_sdv_done=MBarrier(
+            alloc(1), stages=1, init_count=MMA_ARRIVERS, producer=Producer.MMA_COMMIT
+        ),
+        mb_tmem_done=MBarrier(
+            alloc(1), stages=1, init_count=CG0_THREADS + CG1_THREADS, producer=Producer.THREAD
+        ),
+        mb_sched_ready=MBarrier(
+            alloc(cfg.sched_stages),
+            stages=cfg.sched_stages,
+            init_count=ONE_LANE,
+            producer=Producer.THREAD,
+        ),
+        mb_sched_done=MBarrier(
+            alloc(cfg.sched_stages),
+            stages=cfg.sched_stages,
+            init_count=11,
+            producer=Producer.THREAD,
+        ),
+    )
+
+
+# ---- Dynamic tile scheduler ------------------------------------------------------
+
+
+@cute.jit
+def sched_publish_next(cfg, bars, sSched, mSched, sched_state, tile_idx, num_ctas):
+    """TMA-LDG-warp side: pull the next tile off the global ticket, publish it."""
+    if cutlass.const_expr(cfg.dyn_sched):
+        bars.mb_sched_done[sched_state.idx].wait(sched_state.phase)
+        if nvvm.elect_sync():
+            fetched = cutlass.Int32(
+                nvvm.atomicrmw(
+                    "add", mSched.iterator, cutlass.Int32(1), mem_order="relaxed", syncscope="gpu"
+                )
+            )
+            sSched[sched_state.idx] = num_ctas + fetched
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+        next_tile = sSched[sched_state.idx]
+        if nvvm.elect_sync():
+            bars.mb_sched_ready[sched_state.idx].arrive()
+        return next_tile, advance(sched_state, cfg.sched_stages)
+    return tile_idx + num_ctas, sched_state
+
+
+@cute.jit
+def sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas):
+    """Consumer side: read the TMA-LDG warp's published next tile."""
+    if cutlass.const_expr(cfg.dyn_sched):
+        bars.mb_sched_ready[sched_state.idx].wait(sched_state.phase)
+        next_tile = sSched[sched_state.idx]
+        if nvvm.elect_sync():
+            bars.mb_sched_done[sched_state.idx].arrive()
+        return next_tile, advance(sched_state, cfg.sched_stages)
+    return tile_idx + num_ctas, sched_state
+
+
+@cute.jit
+def invert_diagonal_NxN(cfg, in_base, out_base, d, tidx, N: int = 8):
+    """Gauss-Jordan inversion of one diagonal NxN block, ``in_base`` -> ``out_base`` (f16 SMEM)."""
+    tidx_in_group = tidx % N
+    BT = cfg.b_t
+
+    row_lin_base = (d * N + tidx_in_group) * BT + d * N
+    row_phys = smem_64x64_linear_offset(row_lin_base)
+    row_ptr_in = (
+        cute.make_ptr(
+            cfg.io_dtype,
+            in_base,
+            mem_space=cute.AddressSpace.smem,
+            assumed_align=cfg.buffer_align_bytes,
+        )
+        + row_phys
+    )
+    row_ptr = (
+        cute.make_ptr(
+            cfg.io_dtype,
+            out_base,
+            mem_space=cute.AddressSpace.smem,
+            assumed_align=cfg.buffer_align_bytes,
+        )
+        + row_phys
+    )
+
+    row = [(row_ptr_in + j).load().to(cutlass.Float32) for j in range(N)]
+    for i in cutlass.range_constexpr(N):
+        row[i] = cutlass.Float32(1.0) if tidx_in_group == i else row[i]
+    for src_row in cutlass.range_constexpr(N - 1):
+        row_scale = -row[src_row]
+        for i in cutlass.range_constexpr(src_row):
+            shfl_val = nvvm.shfl_sync(
+                0xFFFFFFFF, row[i], src_row, 0b1100000011111, kind=nvvm.Shfl.IDX
+            )
+            row[i] = row[i] + row_scale * shfl_val if tidx_in_group > src_row else row[i]
+        row[src_row] = row_scale if tidx_in_group > src_row else row[src_row]
+
+    for j in cutlass.range_constexpr(N):
+        (row_ptr + j).store(row[j].to(cfg.io_dtype))
+
+
+@cute.jit
+def warp_reduce_scatter_frag_16_elems(vals, lane_id):
+    """Reduce-scatter 16 fragment token-partials (tcol = (lane%4)*2 +
+    (j//2)*8 + (j%2)); lane L returns the sums of tokens (L//4)*8 + (L%4)*2 and +1."""
+    cur = vals
+    for k in cutlass.range_constexpr(3):
+        off = cutlass.const_expr(4 << k)
+        hi_lane = (lane_id // off) % 2 == 1
+        nxt = []
+        for i in cutlass.range_constexpr(len(cur)):
+            if cutlass.const_expr((i & 2) == 0):
+                lo = cur[i]
+                hi = cur[i + 2]
+                send = lo if hi_lane else hi
+                recv = nvvm.shfl_sync(0xFFFFFFFF, send, off, 31, kind=nvvm.Shfl.BFLY)
+                keep = hi if hi_lane else lo
+                nxt.append(keep + recv)
+        cur = nxt
+    return cur[0], cur[1]
+
+
+@cute.jit
+def blockwise_diagonal_8x8_to_16x16(cfg, base_int, raw_base, d0, lane_id):
+    """Off-diagonal correction 8x8 -> 16x16 (C <- -D^{-1} C A^{-1}); raw C from ``raw_base``, writes on ``base_int``."""
+    bpe = cfg.io_dtype.width // 8
+    ldsm_x1_off = (lane_id % 8) * 64
+    d = nvvm.ldmatrix(
+        cutlass.inttoptr(
+            base_int + smem_64x64_linear_offset((d0 + 8) * 64 + d0 + 8 + ldsm_x1_off) * bpe,
+            cutlass.AddressSpace.smem,
+            cutlass.BFloat16,
+        ),
+        1,
+        nvvm.MMALayout.ROW,
+    )
+    c = nvvm.ldmatrix(
+        cutlass.inttoptr(
+            raw_base + smem_64x64_linear_offset((d0 + 8) * 64 + d0 + ldsm_x1_off) * bpe,
+            cutlass.AddressSpace.smem,
+            cutlass.BFloat16,
+        ),
+        1,
+        nvvm.MMALayout.COL,
+    )
+
+    # ---- T = -(D^{-1} @ C) -------------------------------------------------------
+    c_regs = cutlass.Array(cutlass.Float32, 4, alignment=16, space=cutlass.AddressSpace.rmem)
+    for i in cutlass.range_constexpr(4):
+        c_regs[i] = cutlass.Float32(0.0)
+    mma_step_k8(c_regs, [d, d], [c], k_step=0, M=16, N=8, ab_dtype=cfg.io_dtype)
+    for i in cutlass.range_constexpr(4):
+        c_regs[i] = -c_regs[i]
+    a_pack = [fp32_to_fp16(c_regs[2 * j], c_regs[2 * j + 1], dtype=cfg.io_dtype) for j in range(2)]
+
+    # ---- C = T @ A^{-1} ----------------------------------------------------------
+    ai = nvvm.ldmatrix(
+        cutlass.inttoptr(
+            base_int + smem_64x64_linear_offset(d0 * 64 + d0 + ldsm_x1_off) * bpe,
+            cutlass.AddressSpace.smem,
+            cutlass.BFloat16,
+        ),
+        1,
+        nvvm.MMALayout.COL,
+    )
+    o_regs = cutlass.Array(cutlass.Float32, 4, alignment=16, space=cutlass.AddressSpace.rmem)
+    for i in cutlass.range_constexpr(4):
+        o_regs[i] = cutlass.Float32(0.0)
+    mma_step_k8(o_regs, a_pack, [ai], k_step=0, M=16, N=8, ab_dtype=cfg.io_dtype)
+    o_pack = fp32_to_fp16(o_regs[0], o_regs[1], dtype=cfg.io_dtype)
+
+    # ---- store corrected C -------------------------------------------------------
+    nvvm.stmatrix(
+        cutlass.inttoptr(
+            base_int + smem_64x64_linear_offset((d0 + 8) * 64 + d0 + ldsm_x1_off) * bpe,
+            cutlass.AddressSpace.smem,
+            cutlass.BFloat16,
+        ),
+        o_pack,
+        nvvm.MMALayout.ROW,
+    )
+
+
+@cute.jit
+def blockwise_diagonal_16x16_to_32x32(cfg, base_int, raw_base, d0, lane_id):
+    """Off-diagonal correction 16x16 -> 32x32 (raw C from ``raw_base``)."""
+    bpe = cfg.io_dtype.width // 8
+    ldsm_x4_off = (lane_id % 16) * 64 + (lane_id // 16) * 8
+    d = list(
+        nvvm.ldmatrix(
+            cutlass.inttoptr(
+                base_int + smem_64x64_linear_offset((d0 + 16) * 64 + d0 + 16 + ldsm_x4_off) * bpe,
+                cutlass.AddressSpace.smem,
+                cutlass.BFloat16,
+            ),
+            4,
+            nvvm.MMALayout.ROW,
+        )
+    )
+    c = list(
+        nvvm.ldmatrix(
+            cutlass.inttoptr(
+                raw_base + smem_64x64_linear_offset((d0 + 16) * 64 + d0 + ldsm_x4_off) * bpe,
+                cutlass.AddressSpace.smem,
+                cutlass.BFloat16,
+            ),
+            4,
+            nvvm.MMALayout.COL,
+        )
+    )
+
+    # ---- T = -(D^{-1} @ C) -------------------------------------------------------
+    c_regs = cutlass.Array(cutlass.Float32, 8, alignment=16, space=cutlass.AddressSpace.rmem)
+    for i in cutlass.range_constexpr(8):
+        c_regs[i] = cutlass.Float32(0.0)
+    mma_step(c_regs, d, c, k_step=0, M=16, N=16, ab_dtype=cfg.io_dtype)
+    for i in cutlass.range_constexpr(8):
+        c_regs[i] = -c_regs[i]
+    a_pack = [fp32_to_fp16(c_regs[2 * j], c_regs[2 * j + 1], dtype=cfg.io_dtype) for j in range(4)]
+
+    # ---- C = T @ A^{-1} ----------------------------------------------------------
+    ai = list(
+        nvvm.ldmatrix(
+            cutlass.inttoptr(
+                base_int + smem_64x64_linear_offset(d0 * 64 + d0 + ldsm_x4_off) * bpe,
+                cutlass.AddressSpace.smem,
+                cutlass.BFloat16,
+            ),
+            4,
+            nvvm.MMALayout.COL,
+        )
+    )
+    o_regs = cutlass.Array(cutlass.Float32, 8, alignment=16, space=cutlass.AddressSpace.rmem)
+    for i in cutlass.range_constexpr(8):
+        o_regs[i] = cutlass.Float32(0.0)
+    mma_step(o_regs, a_pack, ai, k_step=0, M=16, N=16, ab_dtype=cfg.io_dtype)
+    o_pack = [fp32_to_fp16(o_regs[2 * j], o_regs[2 * j + 1], dtype=cfg.io_dtype) for j in range(4)]
+
+    # ---- store corrected C -------------------------------------------------------
+    nvvm.stmatrix(
+        cutlass.inttoptr(
+            base_int + smem_64x64_linear_offset((d0 + 16) * 64 + d0 + ldsm_x4_off) * bpe,
+            cutlass.AddressSpace.smem,
+            cutlass.BFloat16,
+        ),
+        o_pack,
+        nvvm.MMALayout.ROW,
+    )
+
+
+@cute.jit
+def blockwise_diagonal_32x32_to_64x64(cfg, base_int, raw_base, warp_id, lane_id):
+    """Off-diagonal correction 32x32 -> 64x64 (2 warps, one 16-row M-band each; raw C from ``raw_base``)."""
+    band = warp_id % 2
+    bpe = cfg.io_dtype.width // 8
+    ldsm_x4_off = (lane_id % 16) * 64 + (lane_id // 16) * 8
+    a_frags = []
+    for vs in cutlass.range_constexpr(2):
+        a_frags += list(
+            nvvm.ldmatrix(
+                cutlass.inttoptr(
+                    base_int
+                    + smem_64x64_linear_offset((32 + band * 16) * 64 + 32 + vs * 16 + ldsm_x4_off)
+                    * bpe,
+                    cutlass.AddressSpace.smem,
+                    cutlass.BFloat16,
+                ),
+                4,
+                nvvm.MMALayout.ROW,
+            )
+        )
+    b_frags = []
+    for vs in cutlass.range_constexpr(4):
+        b_frags += list(
+            nvvm.ldmatrix(
+                cutlass.inttoptr(
+                    raw_base
+                    + smem_64x64_linear_offset(
+                        (32 + (vs // 2) * 16) * 64 + (vs % 2) * 16 + ldsm_x4_off
+                    )
+                    * bpe,
+                    cutlass.AddressSpace.smem,
+                    cutlass.BFloat16,
+                ),
+                4,
+                nvvm.MMALayout.COL,
+            )
+        )
+
+    # ---- T = -(D^{-1} @ C) -------------------------------------------------------
+    c_regs = cutlass.Array(cutlass.Float32, 16, alignment=16, space=cutlass.AddressSpace.rmem)
+    for i in cutlass.range_constexpr(16):
+        c_regs[i] = cutlass.Float32(0.0)
+    for ks in cutlass.range_constexpr(2):
+        mma_step(
+            c_regs,
+            a_frags,
+            b_frags[ks * 8 : ks * 8 + 8],
+            k_step=ks,
+            M=16,
+            N=32,
+            ab_dtype=cfg.io_dtype,
+        )
+    for i in cutlass.range_constexpr(16):
+        c_regs[i] = -c_regs[i]
+    a_pack = [fp32_to_fp16(c_regs[2 * j], c_regs[2 * j + 1], dtype=cfg.io_dtype) for j in range(8)]
+
+    # ---- C = T @ A^{-1} ----------------------------------------------------------
+    ai_frags = []
+    for vs in cutlass.range_constexpr(4):
+        ai_frags += list(
+            nvvm.ldmatrix(
+                cutlass.inttoptr(
+                    base_int
+                    + smem_64x64_linear_offset(((vs // 2) * 16) * 64 + (vs % 2) * 16 + ldsm_x4_off)
+                    * bpe,
+                    cutlass.AddressSpace.smem,
+                    cutlass.BFloat16,
+                ),
+                4,
+                nvvm.MMALayout.COL,
+            )
+        )
+    o_regs = cutlass.Array(cutlass.Float32, 16, alignment=16, space=cutlass.AddressSpace.rmem)
+    for i in cutlass.range_constexpr(16):
+        o_regs[i] = cutlass.Float32(0.0)
+    for ks in cutlass.range_constexpr(2):
+        mma_step(
+            o_regs,
+            a_pack,
+            ai_frags[ks * 8 : ks * 8 + 8],
+            k_step=ks,
+            M=16,
+            N=32,
+            ab_dtype=cfg.io_dtype,
+        )
+    o_pack = [fp32_to_fp16(o_regs[2 * j], o_regs[2 * j + 1], dtype=cfg.io_dtype) for j in range(8)]
+
+    # ---- store corrected C -------------------------------------------------------
+    nvvm.barrier_cta_sync_aligned(
+        cfg.inverse_inner_barrier_id,
+        thread_count=cfg.inverse_inner_barrier_threads,
+    )
+    nvvm.stmatrix(
+        cutlass.inttoptr(
+            base_int + smem_64x64_linear_offset((32 + band * 16) * 64 + ldsm_x4_off) * bpe,
+            cutlass.AddressSpace.smem,
+            cutlass.BFloat16,
+        ),
+        o_pack[0:4],
+        nvvm.MMALayout.ROW,
+    )
+    nvvm.stmatrix(
+        cutlass.inttoptr(
+            base_int + smem_64x64_linear_offset((32 + band * 16) * 64 + 16 + ldsm_x4_off) * bpe,
+            cutlass.AddressSpace.smem,
+            cutlass.BFloat16,
+        ),
+        o_pack[4:8],
+        nvvm.MMALayout.ROW,
+    )
+
+
+@cute.jit
+def tmastg_warp(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    cu_seqlens,
+    mWorkItems,
+    sdQ_raw,
+    sdK_raw,
+    sdV_raw,
+    desc_dq_base,
+    desc_dk_base,
+    desc_dv_base,
+    sSched,
+    bars,
+):
+    """TMA-STG warp role (warp 11): persistent tile-scheduler loop + per-chunk
+    dQ/dK/dV TMA bulk-stores from the SMEM staging buffers to global memory."""
+    elect_one = nvvm.elect_sync()
+    nvvm.setmaxregister(cfg.num_regs_other, nvvm.SetMaxRegisterAction.DECREASE)
+    dq_index = PipelineState.start(phase=0)
+    dk_index = PipelineState.start(phase=0)
+    dv_index = PipelineState.start(phase=0)
+
+    sched_state = PipelineState.start(phase=0)
+    tile_idx = cutlass.Int32(bidx)
+    FIRST_STATE_CHUNK = 0 if cfg.use_initial_state else 1
+
+    bpe = cfg.io_dtype.width // 8
+    granule_elems = 128 // bpe
+    sdQ_tma = SmemTile(
+        base=sdQ_raw,
+        elems_per_stage=(cfg.dq_cosize // cfg.smem_dq_stages),
+        stages=cfg.smem_dq_stages,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=0,
+        tma_loads_per_tile=2,
+        tma_granu_elems=granule_elems,
+        tma_subtile_stride_elems=4096,
+    )
+    sdK_tma = SmemTile(
+        base=sdK_raw,
+        elems_per_stage=(cfg.dk_cosize // cfg.smem_dk_stages),
+        stages=cfg.smem_dk_stages,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=0,
+        tma_loads_per_tile=2,
+        tma_granu_elems=granule_elems,
+        tma_subtile_stride_elems=4096,
+    )
+    sdV_tma = SmemTile(
+        base=sdV_raw,
+        elems_per_stage=(cfg.dv_cosize // cfg.smem_dv_stages),
+        stages=cfg.smem_dv_stages,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=0,
+        tma_loads_per_tile=2,
+        tma_granu_elems=granule_elems,
+        tma_subtile_stride_elems=4096,
+    )
+    heads_out = cutlass.Int32(cfg.n_heads_out)
+    desc_qwords = cutlass.Int32(TENSOR_MAP_QWORDS)
+
+    while tile_idx < total_tiles:
+        (
+            batch_idx,
+            head_idx,
+            batch_start,
+            batch_end,
+            seqlen_b,
+            num_chunks_b,
+            wstart,
+            wend,
+            cstart,
+            cend,
+        ) = decode_work_item(cfg, tile_idx, mWorkItems)
+
+        head_q = head_idx if cfg.q_ratio == 1 else head_idx // cutlass.Int32(cfg.q_ratio)
+        head_k = head_idx if cfg.k_ratio == 1 else head_idx // cutlass.Int32(cfg.k_ratio)
+        head_v = head_idx if cfg.v_ratio == 1 else head_idx // cutlass.Int32(cfg.v_ratio)
+        slot = batch_idx * desc_qwords
+        desc_dq_slot = (desc_dq_base + slot).tospace(cutlass.AddressSpace.generic)
+        desc_dk_slot = (desc_dk_base + slot).tospace(cutlass.AddressSpace.generic)
+        desc_dv_slot = (desc_dv_base + slot).tospace(cutlass.AddressSpace.generic)
+        if elect_one:
+            tma_tensormap_acquire(desc_dq_slot)
+            tma_tensormap_acquire(desc_dk_slot)
+            tma_tensormap_acquire(desc_dv_slot)
+
+        for rev_idx in cutlass.range(cend - wstart):
+            chunk_idx = cend - 1 - rev_idx
+            tok_coord = chunk_idx * cutlass.Int32(cfg.b_t)
+
+            dv_idx = dv_index.idx
+            bars.mb_dv_tmastg_ready[dv_idx].wait(dv_index.phase)
+            dv_index = advance(dv_index, cfg.smem_dv_stages)
+            dv_slice = tma_slice_runtime_desc(desc_dv_slot, cutlass.Int32(0), head_v, tok_coord)
+            if chunk_idx < wend:
+                tma_store_tile(sdV_tma[dv_idx], dv_slice, acquire=False)
+                tma_store_commit()
+
+            dq_idx = dq_index.idx
+            bars.mb_dq_tmastg_ready[dq_idx].wait(dq_index.phase)
+            dq_index = advance(dq_index, cfg.smem_dq_stages)
+            dq_slice = tma_slice_runtime_desc(desc_dq_slot, cutlass.Int32(0), head_q, tok_coord)
+            if chunk_idx < wend:
+                tma_store_tile(sdQ_tma[dq_idx], dq_slice, acquire=False)
+                tma_store_commit()
+
+            dk_idx = dk_index.idx
+            bars.mb_dk_tmastg_ready[dk_idx].wait(dk_index.phase)
+            dk_index = advance(dk_index, cfg.smem_dk_stages)
+            dk_slice = tma_slice_runtime_desc(desc_dk_slot, cutlass.Int32(0), head_k, tok_coord)
+            if chunk_idx < wend:
+                tma_store_tile(sdK_tma[dk_idx], dk_slice, acquire=False)
+                tma_store_commit()
+
+            tma_store_wait(2)
+            bars.mb_dv_tmastg_done[dv_idx].arrive()
+            tma_store_wait(1)
+            bars.mb_dq_tmastg_done[dq_idx].arrive()
+            tma_store_wait(0)
+            bars.mb_dk_tmastg_done[dk_idx].arrive()
+        tile_idx, sched_state = sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas)
+
+
+@cute.jit
+def gate_beta_warp(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    cu_seqlens,
+    mWorkItems,
+    tidx,
+    mGate,
+    mA_log,
+    mDt_bias,
+    mBeta,
+    mDgate,
+    mDbeta,
+    sCumsumlog,
+    sCumprod,
+    sBeta,
+    sSched,
+    bars,
+):
+    """Gate/beta LOAD + STORE warp role (warp 10): per-chunk Gate/Beta G->S
+    loads and the dGate/dBeta stores."""
+    nvvm.setmaxregister(cfg.num_regs_other, nvvm.SetMaxRegisterAction.DECREASE)
+    gate_index = PipelineState.start(phase=1)
+    beta_index = PipelineState.start(phase=1)
+    gate_store_index = PipelineState.start(phase=0)
+    beta_store_index = PipelineState.start(phase=0)
+    lidx = tidx % cfg.threads_per_warp
+    n_cols = cfg.b_t // cfg.threads_per_warp
+    a_l2 = cutlass.Float32(0.0)
+    bias = cutlass.Float32(0.0)
+    sched_state = PipelineState.start(phase=0)
+    tile_idx = cutlass.Int32(bidx)
+    FIRST_STATE_CHUNK = 0 if cfg.use_initial_state else 1
+    while tile_idx < total_tiles:
+        (
+            batch_idx,
+            head_idx,
+            batch_start,
+            batch_end,
+            seqlen_b,
+            num_chunks_b,
+            wstart,
+            wend,
+            cstart,
+            cend,
+        ) = decode_work_item(cfg, tile_idx, mWorkItems)
+        num_item_chunks = cend - wstart
+        if cutlass.const_expr(cfg.safe_gate):
+            if num_item_chunks > 0:
+                # per-head transform constants, fixed for the whole tile
+                a_l2 = -cute.math.exp2(
+                    mA_log[head_idx].to(cutlass.Float32) * cutlass.Float32(RCP_LN2), fastmath=True
+                ) * cutlass.Float32(RCP_LN2)
+                bias = mDt_bias[head_idx].to(cutlass.Float32)
+        # dGate/dBeta ownership: mask stores past the item's write range
+        write_end = batch_start + wend * cfg.b_t
+        write_end = min(batch_end, write_end)
+
+        # ---- prefetch: the FIRST backward chunk's Gate/Beta ----------------------
+        if num_item_chunks > 0:
+            chunk_offset = batch_start + (cend - 1) * cfg.b_t
+            gGate = cute.domain_offset((chunk_offset,), mGate[None, head_idx])
+            gBeta = cute.domain_offset((chunk_offset,), mBeta[None, head_idx])
+            gate_idx = gate_index.idx
+            gate_index = advance(gate_index, cfg.smem_gate_stages)
+            pos_valid = [None] * n_cols
+            for col in cutlass.range_constexpr(n_cols):
+                pos = lidx + col * cfg.threads_per_warp
+                pos_valid[col] = cute.elem_less(chunk_offset + pos, batch_end)
+
+            # ---- Gate load: GMEM -> SMEM (OOB neutral: 1.0 -> log2 = 0.0) --------
+            gate_vals = [cutlass.Float32(0.0)] * n_cols
+            for col in cutlass.range_constexpr(n_cols):
+                pos = lidx + col * cfg.threads_per_warp
+                oob_neutral = (
+                    cutlass.Float32(0.0)
+                    if cutlass.const_expr(cfg.log_gate)
+                    else cutlass.Float32(1.0)
+                )
+                gate_vals[col] = gGate[pos] if pos_valid[col] else oob_neutral
+
+            if cutlass.const_expr(cfg.safe_gate):
+                for col in cutlass.range_constexpr(n_cols):
+                    contrib = a_l2 * softplus(gate_vals[col] + bias)
+                    gate_vals[col] = contrib if pos_valid[col] else cutlass.Float32(0.0)
+            elif cutlass.const_expr(cfg.log_gate):
+                for col in cutlass.range_constexpr(n_cols):
+                    gate_vals[col] = gate_vals[col] * cutlass.Float32(RCP_LN2)
+            else:
+                for col in cutlass.range_constexpr(n_cols):
+                    gate_vals[col] = cute.math.log2(gate_vals[col] + 1e-10, fastmath=True)
+            for offset in [1, 2, 4, 8, 16]:
+                for col in cutlass.range_constexpr(n_cols):
+                    n = nvvm.shfl_sync(0xFFFFFFFF, gate_vals[col], offset, 0, kind=nvvm.Shfl.UP)
+                    if lidx >= offset:
+                        gate_vals[col] = gate_vals[col] + n
+            for col in cutlass.range_constexpr(1, n_cols):
+                last_v = nvvm.shfl_sync(
+                    0xFFFFFFFF,
+                    gate_vals[col - 1],
+                    cfg.threads_per_warp - 1,
+                    cfg.threads_per_warp - 1,
+                    kind=nvvm.Shfl.IDX,
+                )
+                gate_vals[col] += last_v
+
+            for col in cutlass.range_constexpr(n_cols):
+                pos = lidx + col * cfg.threads_per_warp
+                sCumsumlog[pos, 0, gate_idx] = gate_vals[col]
+                sCumprod[pos, 0, gate_idx] = cute.math.exp2(gate_vals[col], fastmath=True)
+
+            bars.mb_gate_ready[gate_idx].arrive()
+
+            # ---- Beta load: GMEM -> SMEM (per-element cp.async) ------------------
+            beta_idx = beta_index.idx
+            beta_index = advance(beta_index, cfg.smem_beta_stages)
+            if cutlass.const_expr(cfg.beta_sigmoid):
+                # io-dtype logits -> sigmoid (tanh identity) -> fp32 SMEM
+                for col in cutlass.range_constexpr(n_cols):
+                    pos = lidx + col * cfg.threads_per_warp
+                    beta_value = cutlass.Float32(0.0)
+                    if pos_valid[col]:
+                        beta_value = gBeta[pos].to(cutlass.Float32)
+                        half = cutlass.Float32(0.5)
+                        beta_value = (
+                            (cute.math.tanh(beta_value * half, approx=True) * half + half)
+                            .to(mBeta.element_type)
+                            .to(cutlass.Float32)
+                        )
+                    sBeta[pos, 0, beta_idx] = beta_value
+                bars.mb_beta_ready[beta_idx].arrive()
+            else:
+                for col in cutlass.range_constexpr(n_cols):
+                    pos = lidx + col * cfg.threads_per_warp
+                    src = gBeta.iterator + gBeta.layout((pos,))
+                    dst = sBeta.iterator + sBeta.layout((pos, 0, beta_idx))
+                    cp_size = cutlass.Int32(4) * cutlass.Int32(pos_valid[col])
+                    nvvm.cp_async_shared_global(
+                        dst, src, 4, nvvm.LoadCacheModifier.CA, cp_size=cp_size
+                    )
+                nvvm.cp_async_mbarrier_arrive(bars.mb_beta_ready[beta_idx].smem_ptr, noinc=True)
+
+        for rev_idx in cutlass.range(num_item_chunks):
+            # ---- prefetch the NEXT chunk's Gate/Beta -----------------------------
+            if rev_idx + 1 < num_item_chunks:
+                chunk_offset = batch_start + (cend - 2 - rev_idx) * cfg.b_t
+                gGate = cute.domain_offset((chunk_offset,), mGate[None, head_idx])
+                gBeta = cute.domain_offset((chunk_offset,), mBeta[None, head_idx])
+                gate_idx = gate_index.idx
+                gate_index = advance(gate_index, cfg.smem_gate_stages)
+                pos_valid = [None] * n_cols
+                for col in cutlass.range_constexpr(n_cols):
+                    pos = lidx + col * cfg.threads_per_warp
+                    pos_valid[col] = cute.elem_less(chunk_offset + pos, batch_end)
+
+                gate_vals = [cutlass.Float32(0.0)] * n_cols
+                for col in cutlass.range_constexpr(n_cols):
+                    pos = lidx + col * cfg.threads_per_warp
+                    oob_neutral = (
+                        cutlass.Float32(0.0)
+                        if cutlass.const_expr(cfg.log_gate)
+                        else cutlass.Float32(1.0)
+                    )
+                    gate_vals[col] = gGate[pos] if pos_valid[col] else oob_neutral
+
+                if cutlass.const_expr(cfg.safe_gate):
+                    for col in cutlass.range_constexpr(n_cols):
+                        contrib = a_l2 * softplus(gate_vals[col] + bias)
+                        gate_vals[col] = contrib if pos_valid[col] else cutlass.Float32(0.0)
+                elif cutlass.const_expr(cfg.log_gate):
+                    for col in cutlass.range_constexpr(n_cols):
+                        gate_vals[col] = gate_vals[col] * cutlass.Float32(RCP_LN2)
+                else:
+                    for col in cutlass.range_constexpr(n_cols):
+                        gate_vals[col] = cute.math.log2(gate_vals[col] + 1e-10, fastmath=True)
+                for offset in [1, 2, 4, 8, 16]:
+                    for col in cutlass.range_constexpr(n_cols):
+                        n = nvvm.shfl_sync(
+                            0xFFFFFFFF, gate_vals[col], offset, 0, kind=nvvm.Shfl.UP
+                        )
+                        if lidx >= offset:
+                            gate_vals[col] = gate_vals[col] + n
+                for col in cutlass.range_constexpr(1, n_cols):
+                    last_v = nvvm.shfl_sync(
+                        0xFFFFFFFF,
+                        gate_vals[col - 1],
+                        cfg.threads_per_warp - 1,
+                        cfg.threads_per_warp - 1,
+                        kind=nvvm.Shfl.IDX,
+                    )
+                    gate_vals[col] += last_v
+
+                for col in cutlass.range_constexpr(n_cols):
+                    pos = lidx + col * cfg.threads_per_warp
+                    sCumsumlog[pos, 0, gate_idx] = gate_vals[col]
+                    sCumprod[pos, 0, gate_idx] = cute.math.exp2(gate_vals[col], fastmath=True)
+
+                bars.mb_gate_ready[gate_idx].arrive()
+
+                beta_idx = beta_index.idx
+                beta_index = advance(beta_index, cfg.smem_beta_stages)
+                if cutlass.const_expr(cfg.beta_sigmoid):
+                    # io-dtype logits -> sigmoid (tanh identity) -> fp32 SMEM
+                    for col in cutlass.range_constexpr(n_cols):
+                        pos = lidx + col * cfg.threads_per_warp
+                        beta_value = cutlass.Float32(0.0)
+                        if pos_valid[col]:
+                            beta_value = gBeta[pos].to(cutlass.Float32)
+                            half = cutlass.Float32(0.5)
+                            beta_value = (
+                                (cute.math.tanh(beta_value * half, approx=True) * half + half)
+                                .to(mBeta.element_type)
+                                .to(cutlass.Float32)
+                            )
+                        sBeta[pos, 0, beta_idx] = beta_value
+                    bars.mb_beta_ready[beta_idx].arrive()
+                else:
+                    for col in cutlass.range_constexpr(n_cols):
+                        pos = lidx + col * cfg.threads_per_warp
+                        src = gBeta.iterator + gBeta.layout((pos,))
+                        dst = sBeta.iterator + sBeta.layout((pos, 0, beta_idx))
+                        cp_size = cutlass.Int32(4) * cutlass.Int32(pos_valid[col])
+                        nvvm.cp_async_shared_global(
+                            dst, src, 4, nvvm.LoadCacheModifier.CA, cp_size=cp_size
+                        )
+                    nvvm.cp_async_mbarrier_arrive(
+                        bars.mb_beta_ready[beta_idx].smem_ptr, noinc=True
+                    )
+
+            # ---- store-ready wait + in-place store back --------------------------
+            st_offset = batch_start + (cend - 1 - rev_idx) * cfg.b_t
+            gGate_st = cute.domain_offset((st_offset,), mDgate[None, head_idx])
+            gBeta_st = cute.domain_offset((st_offset,), mDbeta[None, head_idx])
+            g_st_idx = gate_store_index.idx
+            bars.mb_gate_done[g_st_idx].wait(gate_store_index.phase)
+            gate_store_index = advance(gate_store_index, cfg.smem_gate_stages)
+            dgate_vals = [cutlass.Float32(0.0)] * n_cols
+            for col in cutlass.range_constexpr(n_cols):
+                pos = lidx + col * cfg.threads_per_warp
+                dgate_vals[col] = sCumsumlog[pos, 0, g_st_idx]
+            for offset in [1, 2, 4, 8, 16]:
+                for col in cutlass.range_constexpr(n_cols):
+                    n = nvvm.shfl_sync(
+                        0xFFFFFFFF, dgate_vals[col], offset, 31, kind=nvvm.Shfl.DOWN
+                    )
+                    if lidx < cfg.threads_per_warp - offset:
+                        dgate_vals[col] = dgate_vals[col] + n
+            for col in cutlass.range_constexpr(n_cols - 1):
+                rev_col = cutlass.const_expr(n_cols - 2 - col)
+                later_total = nvvm.shfl_sync(
+                    0xFFFFFFFF, dgate_vals[rev_col + 1], 0, 0, kind=nvvm.Shfl.IDX
+                )
+                dgate_vals[rev_col] = dgate_vals[rev_col] + later_total
+            for col in cutlass.range_constexpr(n_cols):
+                pos = lidx + col * cfg.threads_per_warp
+                if cute.elem_less(st_offset + pos, write_end):
+                    gGate_st[pos] = dgate_vals[col]
+            b_st_idx = beta_store_index.idx
+            bars.mb_beta_done[b_st_idx].wait(beta_store_index.phase)
+            beta_store_index = advance(beta_store_index, cfg.smem_beta_stages)
+            for col in cutlass.range_constexpr(n_cols):
+                pos = lidx + col * cfg.threads_per_warp
+                if cute.elem_less(st_offset + pos, write_end):
+                    if cutlass.const_expr(cfg.beta_sigmoid):
+                        gBeta_st[pos] = sBeta[pos, 0, b_st_idx].to(mDbeta.element_type)
+                    else:
+                        gBeta_st[pos] = sBeta[pos, 0, b_st_idx]
+        tile_idx, sched_state = sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas)
+
+
+@cute.jit
+def mma_warp(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    cu_seqlens,
+    mWorkItems,
+    tmem_base_slot,
+    sQ,
+    sQ_trans,
+    sK,
+    sK_trans,
+    sV,
+    sV_kmaj,
+    sdO,
+    sdO_kmaj,
+    sState,
+    sState_kmaj,
+    sTinv,
+    sTinv_trans,
+    sA,
+    sA_trans,
+    sDa,
+    sDa_trans,
+    sDstate,
+    sDm,
+    sDm_trans,
+    sdV_kmaj,
+    sSched,
+    bars,
+):
+    """MMA issuer role (warp 8): persistent scheduler loop issuing every
+    tcgen05 GEMM."""
+    elect_one = nvvm.elect_sync()
+
+    nvvm.setmaxregister(cfg.num_regs_other, nvvm.SetMaxRegisterAction.DECREASE)
+    kk_acc_index = PipelineState.start(phase=0)
+    dk_total_index = PipelineState.start(phase=1)
+    du_scale_index = PipelineState.start(phase=0)
+    dk_scale_index = PipelineState.start(phase=0)
+    dk_attn_index = PipelineState.start(phase=0)
+    dstate_acc_index = PipelineState.start(phase=0 if cfg.use_dstate_in else 1)
+    k_index = PipelineState.start(phase=0)
+    q_index = PipelineState.start(phase=0)
+    state_index = PipelineState.start(phase=0)
+    v_index = PipelineState.start(phase=0)
+    tinv_index = PipelineState.start(phase=0)
+    do_index = PipelineState.start(phase=0)
+    y_ready_index = PipelineState.start(phase=0)
+    u_index = PipelineState.start(phase=0)
+    da_ready_index = PipelineState.start(phase=0)
+    dv_ready_index = PipelineState.start(phase=0)
+    dm_index = PipelineState.start(phase=0)
+    dstate_smem_index = PipelineState.start(phase=0)
+    dq_scale_index = PipelineState.start(phase=0)
+    dq_total_index = PipelineState.start(phase=1)
+    a_index = PipelineState.start(phase=0)
+    do_prime_inp_ready = PipelineState.start(phase=0)
+    du_inp_ready = PipelineState.start(phase=0)
+    dyp_inp_ready = PipelineState.start(phase=0)
+    dstate_inp_index = PipelineState.start(phase=0)
+
+    nvvm.tcgen05_alloc(tmem_base_slot, cutlass.Int32(512), group=nvvm.CTAGroup.CTA_1)
+    nvvm.barrier_cta_sync_aligned(
+        cfg.tmem_alloc_barrier_id,
+        thread_count=cfg.tmem_alloc_barrier_threads,
+    )
+    tmem_base = tmem_base_slot.load()
+
+    # ---- chunk-invariant GEMM descriptors ----------------------------------------
+    bpe = cfg.io_dtype.width // 8
+    idesc_qk = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.b_t,
+        m_dim=cfg.b_t,
+    )
+    bmm_qk_desc = MmaDesc(
+        M=cfg.b_t,
+        N=cfg.b_t,
+        K=cfg.d_k,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=False,
+        cta_group=1,
+        idesc=idesc_qk,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    tmem_shared_acc_col = tmem_base + cfg.tmem_shared_acc_offset
+    tmem_shared_inp_col = tmem_base + cfg.tmem_shared_inp_offset
+    SHARED_INP_STAGE_COLS = cfg.b_t // 2
+    tmem_do_prime_col = tmem_shared_inp_col
+    tmem_du_col = tmem_shared_inp_col + SHARED_INP_STAGE_COLS
+    tmem_dyp_col = tmem_du_col
+    ACC_STAGE_COLS = cfg.b_t
+    tmem_acc_a = tmem_shared_acc_col
+    tmem_acc_b = tmem_shared_acc_col + ACC_STAGE_COLS
+    tmem_kk_col = tmem_acc_a
+    tmem_k_state_col = tmem_acc_a
+    tmem_dy_col = tmem_acc_a
+    tmem_dm_core_col = tmem_acc_a
+    tmem_a_col = tmem_acc_b
+    tmem_u_col = tmem_acc_b
+    tmem_da_col = tmem_acc_b
+    tmem_dk_state_path_col = tmem_shared_inp_col
+
+    idesc_dv = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.b_t,
+        m_dim=cfg.d_v,
+    )
+    bmm_dv_desc = MmaDesc(
+        M=cfg.d_v,
+        N=cfg.b_t,
+        K=cfg.d_k,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=False,
+        atranspose=False,
+        cta_group=1,
+        idesc=idesc_dv,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    tmem_dstate_inp_col = tmem_base + cfg.tmem_dstate_inp_offset
+    tmem_dvdk_acc_col = tmem_base + cfg.tmem_dvdk_acc_offset
+    DSTATE_INP_STAGE_COLS = cfg.d_k // 2
+
+    idesc_k_state = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.b_t,
+        m_dim=cfg.d_v,
+        a_major=1,
+    )
+    bmm_k_state_desc = MmaDesc(
+        M=cfg.d_v,
+        N=cfg.b_t,
+        K=cfg.d_k,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=False,
+        atranspose=True,
+        cta_group=1,
+        idesc=idesc_k_state,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    idesc_k_state_kmaj = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.b_t,
+        m_dim=cfg.d_v,
+    )
+    bmm_k_state_kmaj_desc = MmaDesc(
+        M=cfg.d_v,
+        N=cfg.b_t,
+        K=cfg.d_k,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=False,
+        atranspose=False,
+        cta_group=1,
+        idesc=idesc_k_state_kmaj,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+
+    idesc_du = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.b_t,
+        m_dim=cfg.d_v,
+        a_major=1,
+        b_major=1,
+    )
+    bmm_du_desc = MmaDesc(
+        M=cfg.d_v,
+        N=cfg.b_t,
+        K=cfg.b_t,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=True,
+        atranspose=True,
+        cta_group=1,
+        idesc=idesc_du,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    idesc_dstate_upd = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.d_v,
+        m_dim=cfg.d_k,
+        b_major=1,
+    )
+    bmm_dstate_upd_desc = MmaDesc(
+        M=cfg.d_k,
+        N=cfg.d_v,
+        K=cfg.b_t,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=True,
+        atranspose=False,
+        cta_group=1,
+        idesc=idesc_dstate_upd,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    SHARED_INP_STAGE_COLS = cfg.b_t // 2
+    tmem_do_prime_col = tmem_shared_inp_col
+    tmem_du_col = tmem_shared_inp_col + SHARED_INP_STAGE_COLS
+    tmem_dyp_col = tmem_du_col
+    tmem_shared_inp_col = tmem_base + cfg.tmem_shared_inp_offset
+    tmem_dstate_acc_col = tmem_base + cfg.tmem_dstate_acc_offset
+    tmem_y_col = tmem_base + cfg.tmem_y_offset
+
+    idesc_dy = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.b_t,
+        m_dim=cfg.d_v,
+        b_major=1,
+    )
+    bmm_dy_desc = MmaDesc(
+        M=cfg.d_v,
+        N=cfg.b_t,
+        K=cfg.b_t,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=True,
+        atranspose=False,
+        cta_group=1,
+        idesc=idesc_dy,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    idesc_da = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.b_t,
+        m_dim=cfg.b_t,
+    )
+    bmm_da_desc = MmaDesc(
+        M=cfg.b_t,
+        N=cfg.b_t,
+        K=cfg.d_v,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=False,
+        cta_group=1,
+        idesc=idesc_da,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+
+    idesc_u = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.b_t,
+        m_dim=cfg.d_v,
+    )
+    bmm_u_desc = MmaDesc(
+        M=cfg.d_v,
+        N=cfg.b_t,
+        K=cfg.b_t,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=False,
+        atranspose=False,
+        cta_group=1,
+        idesc=idesc_u,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    idesc_dqdk_inter_at = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.b_t,
+        m_dim=cfg.d_k,
+        a_major=1,
+    )
+    bmm_dqdk_inter_at_desc = MmaDesc(
+        M=cfg.d_k,
+        N=cfg.b_t,
+        K=cfg.d_v,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=False,
+        atranspose=True,
+        cta_group=1,
+        idesc=idesc_dqdk_inter_at,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    idesc_dka = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.b_t,
+        m_dim=cfg.d_k,
+        a_major=1,
+        b_major=1,
+    )
+    bmm_dka_desc = MmaDesc(
+        M=cfg.d_k,
+        N=cfg.b_t,
+        K=cfg.b_t,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=True,
+        atranspose=True,
+        cta_group=1,
+        idesc=idesc_dka,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    idesc_dqa = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.b_t,
+        m_dim=cfg.d_k,
+        a_major=1,
+    )
+    bmm_dqa_desc = MmaDesc(
+        M=cfg.d_k,
+        N=cfg.b_t,
+        K=cfg.b_t,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=False,
+        atranspose=True,
+        cta_group=1,
+        idesc=idesc_dqa,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+
+    do_prime_inp_ptr = nvvm.make_tmem_ptr(tmem_do_prime_col, cutlass.Int8)
+    y_inp_ptr = nvvm.make_tmem_ptr(tmem_y_col, cutlass.Int8)
+    du_inp_ptr = nvvm.make_tmem_ptr(tmem_du_col, cutlass.Int8)
+    dyp_inp_ptr = nvvm.make_tmem_ptr(tmem_dyp_col, cutlass.Int8)
+    kk_acc_ptr = nvvm.make_tmem_ptr(tmem_kk_col, cutlass.Float32)
+    a_acc_ptr = nvvm.make_tmem_ptr(tmem_a_col, cutlass.Float32)
+    k_state_acc_ptr = nvvm.make_tmem_ptr(tmem_k_state_col, cutlass.Float32)
+    u_acc_ptr = nvvm.make_tmem_ptr(tmem_u_col, cutlass.Float32)
+    dy_acc_ptr = nvvm.make_tmem_ptr(tmem_dy_col, cutlass.Float32)
+    da_acc_ptr = nvvm.make_tmem_ptr(tmem_da_col, cutlass.Float32)
+    dm_core_acc_ptr = nvvm.make_tmem_ptr(tmem_dm_core_col, cutlass.Float32)
+    dk_state_path_acc_ptr = nvvm.make_tmem_ptr(tmem_dk_state_path_col, cutlass.Float32)
+    dstate_acc_ptr = nvvm.make_tmem_ptr(tmem_dstate_acc_col, cutlass.Float32)
+    dq_acc_ptr = nvvm.make_tmem_ptr(tmem_dstate_inp_col, cutlass.Float32)
+    dvdk_acc_ptr = nvvm.make_tmem_ptr(tmem_dvdk_acc_col, cutlass.Float32)
+
+    # ---- warp-top descriptors (1-stage tiles are loop-constant; K advances) ----
+    d_q0 = sQ[0].desc()
+    d_k0 = sK[0].desc()
+    d_k_trans0 = sK_trans[0].desc()
+    d_q_trans0 = sQ_trans[0].desc()
+    d_do0 = sdO[0].desc()
+    d_do_kmaj0 = sdO_kmaj[0].desc()
+    d_state0 = sState[0].desc()
+    d_state_kmaj0 = sState_kmaj[0].desc()
+    d_tinv0 = sTinv[0].desc()
+    d_tinv_trans0 = sTinv_trans[0].desc()
+    d_a_trans0 = sA_trans[0].desc()
+    d_v_kmaj0 = sV_kmaj[0].desc()
+    d_dv_kmaj0 = sdV_kmaj[0].desc()
+    d_da0 = sDa[0].desc()
+    d_da_trans0 = sDa_trans[0].desc()
+    d_dm0 = sDm[0].desc()
+    d_dm_trans0 = sDm_trans[0].desc()
+    d_dstate0 = sDstate[0].desc()
+    K_STAGE_BYTES = (cfg.k_cosize // cfg.smem_k_stages) * (cfg.io_dtype.width // 8)
+
+    sched_state = PipelineState.start(phase=0)
+    tile_idx = cutlass.Int32(bidx)
+    FIRST_STATE_CHUNK = 0 if cfg.use_initial_state else 1
+    while tile_idx < total_tiles:
+        (
+            batch_idx,
+            head_idx,
+            batch_start,
+            batch_end,
+            seqlen_b,
+            num_chunks_b,
+            wstart,
+            wend,
+            cstart,
+            cend,
+        ) = decode_work_item(cfg, tile_idx, mWorkItems)
+        num_item_chunks = cend - wstart
+
+        # ---- chunks NT-2 .. 0 (backward): full body ------------------------------
+        for rev_idx in cutlass.range(num_item_chunks):
+            chunk_idx = cend - 1 - rev_idx
+            have_dstate = (
+                cutlass.Boolean(True) if cutlass.const_expr(cfg.use_dstate_in) else rev_idx > 0
+            )
+
+            # ---- KK = K(S) @ K^T -------------------------------------------------
+            k_idx = k_index.idx
+            bars.mb_k_ready[k_idx].wait(k_index.phase)
+            k_index = advance(k_index, cfg.smem_k_stages)
+
+            desc_k = d_k0.advance_start_address(k_idx * K_STAGE_BYTES)
+            mma_ss(
+                bmm_qk_desc,
+                desc_k,
+                desc_k,
+                kk_acc_ptr,
+                accumulate=False,
+            )
+
+            if elect_one:
+                bars.mb_kk_acc_ready[0].arrive(cta_group=1)
+
+            # ---- QK = Q(S) @ K^T -------------------------------------------------
+            q_idx = q_index.idx
+            bars.mb_q_ready[q_idx].wait(q_index.phase)
+            q_index = advance(q_index, cfg.smem_q_stages)
+
+            desc_q = d_q0
+            mma_ss(
+                bmm_qk_desc,
+                desc_q,
+                desc_k,
+                a_acc_ptr,
+                accumulate=False,
+            )
+
+            if elect_one:
+                bars.mb_a_acc_ready[0].arrive(cta_group=1)
+
+            # ---- k_state = state^T(S) @ K^T -----------------------------------------------
+            state_idx = state_index.idx
+            if chunk_idx >= FIRST_STATE_CHUNK:
+                bars.mb_state_ready[state_idx].wait(state_index.phase)
+                state_index = advance(state_index, cfg.smem_state_stages)
+                bars.mb_kk_acc_done[0].wait(kk_acc_index.phase)
+                kk_acc_index = advance(kk_acc_index, 1)
+                desc_state = d_state_kmaj0
+                mma_ss(
+                    bmm_k_state_kmaj_desc,
+                    desc_state,
+                    desc_k,
+                    k_state_acc_ptr,
+                    accumulate=False,
+                )
+                if elect_one:
+                    bars.mb_k_state_acc_ready[0].arrive(cta_group=1)
+
+            # ---- dV inter = dstate^T(T) @ K ------------------------------------------
+            dstate_inp_idx = dstate_inp_index.idx
+            if have_dstate:
+                bars.mb_dstate_inp_ready[dstate_inp_idx].wait(dstate_inp_index.phase)
+                dstate_inp_index = advance(dstate_inp_index, cfg.tmem_dstate_inp_stages)
+            bars.mb_dk_total_acc_done[0].wait(dk_total_index.phase)
+            dk_total_index = advance(dk_total_index, 1)
+
+            if have_dstate:
+                dstate_a_ptr = nvvm.make_tmem_ptr(
+                    tmem_dstate_inp_col + dstate_inp_idx * DSTATE_INP_STAGE_COLS, cutlass.Int8
+                )
+                for sub in cutlass.range_constexpr(bmm_dv_desc.num_subtiles_B):
+                    for k in cutlass.range_constexpr(bmm_dv_desc.sps_B):
+                        mma_ts_step(
+                            bmm_dv_desc,
+                            dstate_a_ptr.subview(
+                                sub * bmm_dv_desc.sps_B * bmm_dv_desc.tmem_advance_A
+                            ),
+                            desc_k + sub * (bmm_dv_desc.smem_subtile_B >> 4),
+                            dvdk_acc_ptr,
+                            k,
+                            cutlass.Boolean(sub + k > 0),
+                        )
+                if elect_one:
+                    bars.mb_du_scale_acc_ready[0].arrive(cta_group=1)
+                    bars.mb_dstate_inp_done[dstate_inp_idx].arrive(cta_group=1)
+
+            # ---- dQ inter = state(S) @ dO^T ------------------------------------------
+            do_idx = do_index.idx
+            bars.mb_do_ready[do_idx].wait(do_index.phase)
+            do_index = advance(do_index, cfg.smem_do_stages)
+            if chunk_idx >= FIRST_STATE_CHUNK:
+                bars.mb_dq_acc_total_done[0].wait(dq_total_index.phase)
+                dq_total_index = advance(dq_total_index, 1)
+                desc_state_kmaj_dq_inter = d_state0
+                desc_do_kmaj_dq_inter = d_do_kmaj0
+                mma_ss(
+                    bmm_dqdk_inter_at_desc,
+                    desc_state_kmaj_dq_inter,
+                    desc_do_kmaj_dq_inter,
+                    dq_acc_ptr,
+                    accumulate=False,
+                )
+                if elect_one:
+                    bars.mb_dq_acc_scale_ready[0].arrive(cta_group=1)
+
+            # ---- dU intra += dO^T(S) @ A -----------------------------------------
+            du_a_idx = a_index.idx
+            bars.mb_a_ready[du_a_idx].wait(a_index.phase)
+            a_index = advance(a_index, cfg.smem_a_stages)
+            if have_dstate:
+                bars.mb_du_scale_acc_done[0].wait(du_scale_index.phase)
+                du_scale_index = advance(du_scale_index, 1)
+
+            desc_do_mnmaj = d_do0
+            desc_a_t = d_a_trans0
+            mma_ss(
+                bmm_du_desc,
+                desc_do_mnmaj,
+                desc_a_t,
+                dvdk_acc_ptr,
+                accumulate=have_dstate,
+            )
+            if elect_one:
+                bars.mb_du_total_acc_ready[0].arrive(cta_group=1)
+
+            # ---- dstate update += dO'^T(T) @ Q ---------------------------------------
+            bars.mb_do_prime_inp_ready[0].wait(do_prime_inp_ready.phase)
+            do_prime_inp_ready = advance(do_prime_inp_ready, 1)
+            dstate_idx = dstate_acc_index.idx
+            bars.mb_dstate_scale_acc_done[dstate_idx].wait(dstate_acc_index.phase)
+            dstate_acc_index = advance(dstate_acc_index, cfg.tmem_dstate_acc_stages)
+
+            desc_q_t = d_q_trans0
+            for sub in cutlass.range_constexpr(bmm_dstate_upd_desc.num_subtiles_B):
+                for k in cutlass.range_constexpr(bmm_dstate_upd_desc.sps_B):
+                    mma_ts_step(
+                        bmm_dstate_upd_desc,
+                        do_prime_inp_ptr.subview(
+                            sub * bmm_dstate_upd_desc.sps_B * bmm_dstate_upd_desc.tmem_advance_A
+                        ),
+                        desc_q_t + sub * (bmm_dstate_upd_desc.smem_subtile_B >> 4),
+                        dstate_acc_ptr,
+                        k,
+                        cutlass.Boolean(True) if cutlass.const_expr(sub + k > 0) else have_dstate,
+                    )
+
+            # ---- U^T recompute = Y^T(T) @ T^T ------------------------------------
+            tinv_idx = tinv_index.idx
+            bars.mb_t_inv_ready[tinv_idx].wait(tinv_index.phase)
+            tinv_index = advance(tinv_index, cfg.smem_t_inv_stages)
+            bars.mb_y_ready[0].wait(y_ready_index.phase)
+            y_ready_index = advance(y_ready_index, 1)
+            v_idx = v_index.idx
+            v_index = advance(v_index, cfg.smem_v_stages)
+
+            desc_tinv = d_tinv0
+            for sub in cutlass.range_constexpr(bmm_u_desc.num_subtiles_B):
+                for k in cutlass.range_constexpr(bmm_u_desc.sps_B):
+                    mma_ts_step(
+                        bmm_u_desc,
+                        y_inp_ptr.subview(sub * bmm_u_desc.sps_B * bmm_u_desc.tmem_advance_A),
+                        desc_tinv + sub * (bmm_u_desc.smem_subtile_B >> 4),
+                        u_acc_ptr,
+                        k,
+                        cutlass.Boolean(sub + k > 0),
+                    )
+            if elect_one:
+                bars.mb_u_acc_ready[0].arrive(cta_group=1)
+
+            # ---- dY = dU^T(T) @ T ------------------------------------------------
+            bars.mb_du_inp_ready[0].wait(du_inp_ready.phase)
+            du_inp_ready = advance(du_inp_ready, 1)
+
+            desc_tinv_t = d_tinv_trans0
+            for sub in cutlass.range_constexpr(bmm_dy_desc.num_subtiles_B):
+                for k in cutlass.range_constexpr(bmm_dy_desc.sps_B):
+                    mma_ts_step(
+                        bmm_dy_desc,
+                        du_inp_ptr.subview(sub * bmm_dy_desc.sps_B * bmm_dy_desc.tmem_advance_A),
+                        desc_tinv_t + sub * (bmm_dy_desc.smem_subtile_B >> 4),
+                        dy_acc_ptr,
+                        k,
+                        cutlass.Boolean(sub + k > 0),
+                    )
+            if elect_one:
+                bars.mb_dy_acc_ready[0].arrive(cta_group=1)
+
+            # ---- dK_inter = dstate_entry(S) @ U^T ------------------------------------
+            bars.mb_u_ready[0].wait(u_index.phase)
+            u_index = advance(u_index, 1)
+            if have_dstate:
+                bars.mb_dstate_smem_ready[0].wait(dstate_smem_index.phase)
+                dstate_smem_index = advance(dstate_smem_index, 1)
+
+                desc_dstate = d_dstate0
+                desc_u_kmaj_dk_inter = d_v_kmaj0
+                mma_ss(
+                    bmm_dqdk_inter_at_desc,
+                    desc_dstate,
+                    desc_u_kmaj_dk_inter,
+                    dvdk_acc_ptr,
+                    accumulate=False,
+                )
+                if elect_one:
+                    bars.mb_dk_scale_acc_ready[0].arrive(cta_group=1)
+
+            # ---- dA_eff = dO(S) @ U^T --------------------------------------------
+            desc_do_kmaj_da = d_do_kmaj0
+            desc_u_kmaj_da = d_v_kmaj0
+            mma_ss(
+                bmm_da_desc,
+                desc_do_kmaj_da,
+                desc_u_kmaj_da,
+                da_acc_ptr,
+                accumulate=False,
+            )
+            if elect_one:
+                bars.mb_da_acc_ready[0].arrive(cta_group=1)
+                bars.mb_do_mma_done[do_idx].arrive(cta_group=1)
+
+            # ---- dM core = dY(S) @ U^T -------------------------------------------
+            dv_ready_idx = dv_ready_index.idx
+            bars.mb_dv_tmastg_ready[dv_ready_idx].wait(dv_ready_index.phase)
+            dv_ready_index = advance(dv_ready_index, cfg.smem_dv_stages)
+
+            desc_dy_kmaj_dm = d_dv_kmaj0
+            desc_u_kmaj_dm = d_v_kmaj0
+            mma_ss(
+                bmm_da_desc,
+                desc_dy_kmaj_dm,
+                desc_u_kmaj_dm,
+                dm_core_acc_ptr,
+                accumulate=False,
+            )
+            if elect_one:
+                bars.mb_dm_acc_ready[0].arrive(cta_group=1)
+                bars.mb_v_mma_done[v_idx].arrive(cta_group=1)
+
+            # ---- dstate update-term += dY'^T(T) @ K --------------------------------------
+            bars.mb_dyp_inp_ready[0].wait(dyp_inp_ready.phase)
+            dyp_inp_ready = advance(dyp_inp_ready, 1)
+
+            desc_k_t = d_k_trans0.advance_start_address(k_idx * K_STAGE_BYTES)
+            for sub in cutlass.range_constexpr(bmm_dstate_upd_desc.num_subtiles_B):
+                for k in cutlass.range_constexpr(bmm_dstate_upd_desc.sps_B):
+                    mma_ts_step(
+                        bmm_dstate_upd_desc,
+                        dyp_inp_ptr.subview(
+                            sub * bmm_dstate_upd_desc.sps_B * bmm_dstate_upd_desc.tmem_advance_A
+                        ),
+                        desc_k_t + sub * (bmm_dstate_upd_desc.smem_subtile_B >> 4),
+                        dstate_acc_ptr,
+                        k,
+                        cutlass.Boolean(True),
+                    )
+            if elect_one:
+                bars.mb_dstate_acc_ready[dstate_idx].arrive(cta_group=1)
+
+            # ---- dK attn += Q^T(S) @ dA ------------------------------------------
+            if have_dstate:
+                bars.mb_dk_scale_acc_done[0].wait(dk_scale_index.phase)
+                dk_scale_index = advance(dk_scale_index, 1)
+            bars.mb_da_ready[0].wait(da_ready_index.phase)
+            da_ready_index = advance(da_ready_index, 1)
+
+            desc_q_mnmaj_dk_attn = d_q_trans0
+            desc_da_t = d_da_trans0
+            mma_ss(
+                bmm_dka_desc,
+                desc_q_mnmaj_dk_attn,
+                desc_da_t,
+                dvdk_acc_ptr,
+                accumulate=have_dstate,
+            )
+            if elect_one:
+                bars.mb_dk_attn_acc_ready[0].arrive(cta_group=1)
+                bars.mb_q_mma_done[q_idx].arrive(cta_group=1)
+
+            # ---- dQ attn += K^T(S) @ dA ------------------------------------------
+            if chunk_idx >= FIRST_STATE_CHUNK:
+                bars.mb_dq_acc_scale_done[0].wait(dq_scale_index.phase)
+                dq_scale_index = advance(dq_scale_index, 1)
+            if chunk_idx < FIRST_STATE_CHUNK:
+                bars.mb_dq_acc_total_done[0].wait(dq_total_index.phase)
+                dq_total_index = advance(dq_total_index, 1)
+            desc_k_mnmaj_dq_attn = d_k_trans0.advance_start_address(k_idx * K_STAGE_BYTES)
+            desc_da = d_da0
+            if chunk_idx >= FIRST_STATE_CHUNK:
+                mma_ss(
+                    bmm_dqa_desc,
+                    desc_k_mnmaj_dq_attn,
+                    desc_da,
+                    dq_acc_ptr,
+                    accumulate=True,
+                )
+            if chunk_idx < FIRST_STATE_CHUNK:
+                mma_ss(
+                    bmm_dqa_desc,
+                    desc_k_mnmaj_dq_attn,
+                    desc_da,
+                    dq_acc_ptr,
+                    accumulate=False,
+                )
+            if elect_one:
+                bars.mb_dq_acc_total_ready[0].arrive(cta_group=1)
+                bars.mb_a_done[du_a_idx].arrive(cta_group=1)
+
+            # ---- dK state-path = state(S) @ dY^T -----------------------------------------
+            if chunk_idx >= FIRST_STATE_CHUNK:
+                desc_state_kmaj_spath = d_state0
+                desc_dy_kmaj_spath = d_dv_kmaj0
+                mma_ss(
+                    bmm_dqdk_inter_at_desc,
+                    desc_state_kmaj_spath,
+                    desc_dy_kmaj_spath,
+                    dk_state_path_acc_ptr,
+                    accumulate=False,
+                )
+                if elect_one:
+                    bars.mb_dk_state_path_acc_ready[0].arrive(cta_group=1)
+                    bars.mb_state_mma_done[state_idx].arrive(cta_group=1)
+            if elect_one:
+                bars.mb_sdv_done[0].arrive(cta_group=1)
+
+            # ---- dK dM-terms += K^T(S) @ dM^T + K^T(S) @ dM ----------------------
+            bars.mb_dm_acc_done[0].wait(dm_index.phase)
+            dm_index = advance(dm_index, 1)
+            bars.mb_dk_attn_acc_done[0].wait(dk_attn_index.phase)
+            dk_attn_index = advance(dk_attn_index, 1)
+            desc_k_mnmaj_dm_terms = d_k_trans0.advance_start_address(k_idx * K_STAGE_BYTES)
+            desc_dm_t = d_dm_trans0
+            mma_ss(
+                bmm_dka_desc,
+                desc_k_mnmaj_dm_terms,
+                desc_dm_t,
+                dvdk_acc_ptr,
+                accumulate=True,
+            )
+            desc_dm = d_dm0
+            mma_ss(
+                bmm_dqa_desc,
+                desc_k_mnmaj_dm_terms,
+                desc_dm,
+                dvdk_acc_ptr,
+                accumulate=True,
+            )
+            if elect_one:
+                bars.mb_dk_total_acc_ready[0].arrive(cta_group=1)
+                bars.mb_k_mma_done[k_idx].arrive(cta_group=1)
+
+        tile_idx, sched_state = sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas)
+
+    bars.mb_dk_total_acc_done[0].wait(dk_total_index.phase)
+
+    bars.mb_tmem_done[0].wait(0)
+    nvvm.tcgen05_relinquish_alloc_permit(group=nvvm.CTAGroup.CTA_1)
+    nvvm.tcgen05_dealloc(
+        nvvm.make_tmem_ptr(tmem_base, cutlass.Int8),
+        cutlass.Int32(512),
+        group=nvvm.CTAGroup.CTA_1,
+    )
+
+
+@cute.jit
+def tmaldg_warp(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    n_desc,
+    cu_seqlens,
+    mWorkItems,
+    sQ_raw,
+    sK_raw,
+    sV_raw,
+    sdO_raw,
+    sState_raw,
+    desc_q_base,
+    desc_k_base,
+    desc_v_base,
+    desc_do_base,
+    desc_checkpoint_base,
+    sSched,
+    mSched,
+    bars,
+):
+    """TMA-LDG warp role (warp 9): persistent tile loop issuing every
+    Q/K/V/dO/state TMA load."""
+    elect_one = nvvm.elect_sync()
+    nvvm.setmaxregister(cfg.num_regs_other, nvvm.SetMaxRegisterAction.DECREASE)
+    q_index = PipelineState.start(phase=1)
+    k_index = PipelineState.start(phase=1)
+    v_index = PipelineState.start(phase=1)
+    do_index = PipelineState.start(phase=1)
+    state_index = PipelineState.start(phase=1)
+    sched_state = PipelineState.start(phase=1)
+    tile_idx = cutlass.Int32(bidx)
+    FIRST_STATE_CHUNK = 0 if cfg.use_initial_state else 1
+
+    bpe = cfg.io_dtype.width // 8
+    granule_elems = 128 // bpe
+    bt = cfg.b_t
+    q_stage_elems = cfg.q_cosize // cfg.smem_q_stages
+    k_stage_elems = cfg.k_cosize // cfg.smem_k_stages
+    sQ_tma = SmemTile(
+        base=sQ_raw,
+        elems_per_stage=q_stage_elems,
+        stages=cfg.smem_q_stages,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=0,
+        tma_loads_per_tile=2,
+        tma_granu_elems=granule_elems,
+        tma_subtile_stride_elems=bt * granule_elems,
+    )
+    sK_tma = SmemTile(
+        base=sK_raw,
+        elems_per_stage=k_stage_elems,
+        stages=cfg.smem_k_stages,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=0,
+        tma_loads_per_tile=2,
+        tma_granu_elems=granule_elems,
+        tma_subtile_stride_elems=bt * granule_elems,
+    )
+    sV_tma = SmemTile(
+        base=sV_raw,
+        elems_per_stage=0,
+        stages=1,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=0,
+        tma_loads_per_tile=2,
+        tma_granu_elems=granule_elems,
+        tma_subtile_stride_elems=4096,
+    )
+    sdO_tma = SmemTile(
+        base=sdO_raw,
+        elems_per_stage=0,
+        stages=1,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=0,
+        tma_loads_per_tile=2,
+        tma_granu_elems=granule_elems,
+        tma_subtile_stride_elems=4096,
+    )
+    sCheckpoint_tma = SmemTile(
+        base=sState_raw,
+        elems_per_stage=(cfg.state_cosize // cfg.smem_state_stages),
+        stages=cfg.smem_state_stages,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=0,
+        tma_loads_per_tile=cfg.d_v // 64,
+        tma_granu_elems=64,
+        tma_subtile_stride_elems=cfg.d_k * 64,
+    )
+    heads_out = cutlass.Int32(cfg.n_heads_out)
+    desc_qwords = cutlass.Int32(TENSOR_MAP_QWORDS)
+    packed_tokens = cutlass.Int32(cu_seqlens[n_desc])
+
+    while tile_idx < total_tiles:
+        (
+            batch_idx,
+            head_idx,
+            batch_start,
+            batch_end,
+            seqlen_b,
+            num_chunks_b,
+            wstart,
+            wend,
+            cstart,
+            cend,
+        ) = decode_work_item(cfg, tile_idx, mWorkItems)
+
+        head_o = head_idx
+        head_q = head_idx if cfg.q_ratio == 1 else head_idx // cutlass.Int32(cfg.q_ratio)
+        head_k = head_idx if cfg.k_ratio == 1 else head_idx // cutlass.Int32(cfg.k_ratio)
+        head_v = head_idx if cfg.v_ratio == 1 else head_idx // cutlass.Int32(cfg.v_ratio)
+        slot = batch_idx * desc_qwords
+        desc_q_slot = (desc_q_base + slot).tospace(cutlass.AddressSpace.generic)
+        desc_k_slot = (desc_k_base + slot).tospace(cutlass.AddressSpace.generic)
+        desc_v_slot = (desc_v_base + slot).tospace(cutlass.AddressSpace.generic)
+        desc_do_slot = (desc_do_base + slot).tospace(cutlass.AddressSpace.generic)
+        desc_checkpoint_slot = (desc_checkpoint_base + slot).tospace(cutlass.AddressSpace.generic)
+        if elect_one:
+            tma_tensormap_acquire(desc_q_slot)
+            tma_tensormap_acquire(desc_k_slot)
+            tma_tensormap_acquire(desc_v_slot)
+            tma_tensormap_acquire(desc_do_slot)
+            tma_tensormap_acquire(desc_checkpoint_slot)
+        use_packed_coords = batch_end == packed_tokens
+
+        for rev_idx in cutlass.range(cend - wstart):
+            chunk_idx = cend - 1 - rev_idx
+            tok_coord = chunk_idx * cutlass.Int32(cfg.b_t)
+            input_tok_coord = batch_start + tok_coord if use_packed_coords else tok_coord
+
+            # ---- K load ----------------------------------------------------------
+            k_idx = k_index.idx
+            bars.mb_k_mma_done[k_idx].wait(k_index.phase)
+            bars.mb_k_cg0_done[k_idx].wait(k_index.phase)
+            k_index = advance(k_index, cfg.smem_k_stages)
+            if elect_one:
+                bars.mb_k_ready[k_idx].arrive(n_bytes=cfg.tma_k_bytes)
+            k_slice = tma_slice_runtime_desc(
+                desc_k_slot, cutlass.Int32(0), head_k, input_tok_coord
+            )
+            tma_load_tile(sK_tma[k_idx], k_slice, bars.mb_k_ready[k_idx].smem_ptr, acquire=False)
+
+            # ---- Q load ----------------------------------------------------------
+            q_idx = q_index.idx
+            bars.mb_q_mma_done[q_idx].wait(q_index.phase)
+            bars.mb_q_cg1_done[q_idx].wait(q_index.phase)
+            q_index = advance(q_index, cfg.smem_q_stages)
+            if elect_one:
+                bars.mb_q_ready[q_idx].arrive(n_bytes=cfg.tma_q_bytes)
+            q_slice = tma_slice_runtime_desc(
+                desc_q_slot, cutlass.Int32(0), head_q, input_tok_coord
+            )
+            tma_load_tile(sQ_tma[q_idx], q_slice, bars.mb_q_ready[q_idx].smem_ptr, acquire=False)
+
+            # ---- V load ----------------------------------------------------------
+            v_idx = v_index.idx
+            bars.mb_v_mma_done[v_idx].wait(v_index.phase)
+            v_index = advance(v_index, cfg.smem_v_stages)
+            if elect_one:
+                bars.mb_v_ready[v_idx].arrive(n_bytes=cfg.tma_v_bytes)
+            v_slice = tma_slice_runtime_desc(
+                desc_v_slot, cutlass.Int32(0), head_v, input_tok_coord
+            )
+            tma_load_tile(sV_tma[v_idx], v_slice, bars.mb_v_ready[v_idx].smem_ptr, acquire=False)
+
+            # ---- dO load ---------------------------------------------------------
+            do_idx = do_index.idx
+            bars.mb_do_mma_done[do_idx].wait(do_index.phase)
+            do_index = advance(do_index, cfg.smem_do_stages)
+            if elect_one:
+                bars.mb_do_ready[do_idx].arrive(n_bytes=cfg.tma_do_bytes)
+            do_slice = tma_slice_runtime_desc(
+                desc_do_slot, cutlass.Int32(0), head_o, input_tok_coord
+            )
+            tma_load_tile(
+                sdO_tma[do_idx], do_slice, bars.mb_do_ready[do_idx].smem_ptr, acquire=False
+            )
+
+            # ---- entering state ----------
+            if chunk_idx >= FIRST_STATE_CHUNK:
+                state_idx = state_index.idx
+                bars.mb_state_mma_done[state_idx].wait(state_index.phase)
+                state_index = advance(state_index, cfg.smem_state_stages)
+                if elect_one:
+                    bars.mb_state_ready[state_idx].arrive(n_bytes=cfg.tma_state_bytes)
+                checkpoint_slice = tma_slice_runtime_desc(
+                    desc_checkpoint_slot, cutlass.Int32(0), cutlass.Int32(0), chunk_idx, head_o
+                )
+                tma_load_tile(
+                    sCheckpoint_tma[state_idx],
+                    checkpoint_slice,
+                    bars.mb_state_ready[state_idx].smem_ptr,
+                    acquire=False,
+                )
+
+        tile_idx, sched_state = sched_publish_next(
+            cfg, bars, sSched, mSched, sched_state, tile_idx, num_ctas
+        )
+
+    for _ in range(cfg.smem_q_stages):
+        bars.mb_q_mma_done[q_index.idx].wait(q_index.phase)
+        bars.mb_q_cg1_done[q_index.idx].wait(q_index.phase)
+        q_index = advance(q_index, cfg.smem_q_stages)
+    for _ in range(cfg.smem_k_stages):
+        bars.mb_k_mma_done[k_index.idx].wait(k_index.phase)
+        bars.mb_k_cg0_done[k_index.idx].wait(k_index.phase)
+        k_index = advance(k_index, cfg.smem_k_stages)
+    for _ in range(cfg.smem_v_stages):
+        bars.mb_v_mma_done[v_index.idx].wait(v_index.phase)
+        v_index = advance(v_index, cfg.smem_v_stages)
+    for _ in range(cfg.smem_do_stages):
+        bars.mb_do_mma_done[do_index.idx].wait(do_index.phase)
+        do_index = advance(do_index, cfg.smem_do_stages)
+
+
+@cute.jit
+def compute0_warp_group(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    cu_seqlens,
+    mWorkItems,
+    tidx,
+    tmem_base_slot,
+    scale,
+    sCumsumlog,
+    sCumprod,
+    sBeta,
+    sTinv,
+    sKK,
+    sA,
+    sDa,
+    sDm,
+    sK,
+    sdQ,
+    sDstate,
+    sstate_flat,
+    sdstate_flat,
+    sSched,
+    bars,
+):
+    """Compute warp-group 0 role (warps 0-3): persistent scheduler loop
+    building each chunk's blockwise-inverse T and attention matrices."""
+
+    nvvm.setmaxregister(cfg.num_regs_compute_group_0, nvvm.SetMaxRegisterAction.INCREASE)
+    gate_index = PipelineState.start(phase=0)
+    beta_index = PipelineState.start(phase=0)
+    a_index = PipelineState.start(phase=1)
+    tinv_index = PipelineState.start(phase=1)
+    da_acc_index = PipelineState.start(phase=0)
+    dm_ready_index = PipelineState.start(phase=0)
+    cg0_dbeta_index = PipelineState.start(phase=0)
+
+    nvvm.barrier_cta_sync_aligned(
+        cfg.tmem_alloc_barrier_id,
+        thread_count=cfg.tmem_alloc_barrier_threads,
+    )
+    tmem_base = tmem_base_slot.load()
+
+    num_threads_cg0 = cfg.threads_per_warp * len(cfg.compute_group_0_warp_ids)
+    cg0_tidx = tidx % num_threads_cg0
+    warp_id = cg0_tidx // cfg.threads_per_warp
+    lane_id = cg0_tidx % cfg.threads_per_warp
+    bpe = cfg.io_dtype.width // 8
+    num_vals = 32
+    FRAG_COLS = 16
+    ACC_N_FRAGS = cfg.b_t // FRAG_COLS
+    store_row = warp_id * 16 + lane_id % 16
+    store_col = (lane_id // 16) * 8
+    tmem_warp_row = warp_id * cfg.threads_per_warp
+    tmem_shared_acc_col = tmem_base + cfg.tmem_shared_acc_offset
+    tmem_shared_inp_col = tmem_base + cfg.tmem_shared_inp_offset
+    SHARED_INP_STAGE_COLS = cfg.b_t // 2
+    tmem_do_prime_col = tmem_shared_inp_col
+    tmem_du_col = tmem_shared_inp_col + SHARED_INP_STAGE_COLS
+    tmem_dyp_col = tmem_du_col
+    ACC_STAGE_COLS = cfg.b_t
+    tmem_acc_a = tmem_shared_acc_col
+    tmem_acc_b = tmem_shared_acc_col + ACC_STAGE_COLS
+    tmem_kk_col = tmem_acc_a
+    tmem_k_state_col = tmem_acc_a
+    tmem_dy_col = tmem_acc_a
+    tmem_dm_core_col = tmem_acc_a
+    tmem_a_col = tmem_acc_b
+    tmem_u_col = tmem_acc_b
+    tmem_da_col = tmem_acc_b
+    tmem_dk_state_path_col = tmem_shared_inp_col
+    acc_zero = cfg.acc_dtype(0.0)
+    mask_zero = opaque_f32_zero()
+    frag_row = cg0_tidx % 8 + (cg0_tidx // 16 % 2) * 8
+    frag_col = (cg0_tidx // 8 % 2) * 8 + (cg0_tidx // 32 % 2) * 32
+    frag_slab_off = (cg0_tidx // 64) * 4096
+    sK_base_p = cute.make_ptr(
+        cfg.io_dtype,
+        sK[0].base,
+        mem_space=cute.AddressSpace.smem,
+        assumed_align=cfg.buffer_align_bytes,
+    )
+    k_stage_elems_cg0 = cfg.k_cosize // cfg.smem_k_stages
+    sdQ_base = cute.make_ptr(
+        cfg.io_dtype,
+        sdQ[0].base,
+        mem_space=cute.AddressSpace.smem,
+        assumed_align=cfg.buffer_align_bytes,
+    )
+    sdH_parts_p = cute.make_ptr(
+        cfg.io_dtype,
+        sDstate[0].base,
+        mem_space=cute.AddressSpace.smem,
+        assumed_align=cfg.buffer_align_bytes,
+    )
+    # dGate fold scratch in sKK
+    skk_red = cute.make_ptr(
+        cutlass.Float32,
+        sKK[0].base,
+        mem_space=cute.AddressSpace.smem,
+        assumed_align=cfg.buffer_align_bytes,
+    )
+    cg0_k_index = PipelineState.start(phase=0)
+    cg0_dgate_index = PipelineState.start(phase=0)
+    tmem_dvdk_acc_col = tmem_base + cfg.tmem_dvdk_acc_offset
+    tmem_dstate_inp_col = tmem_base + cfg.tmem_dstate_inp_offset
+    cg0_kk_ready = PipelineState.start(phase=0)
+    cg0_a_ready = PipelineState.start(phase=0)
+    cg0_dk_scale_ready = PipelineState.start(phase=0)
+    cg0_dq_scale_ready = PipelineState.start(phase=0)
+    cg0_dstate_smem_ready = PipelineState.start(phase=0)
+    cg0_dk_attn_ready = PipelineState.start(phase=0)
+    DSTATE_IN0 = 1 if cfg.use_dstate_in else 0
+
+    tinv_zero_ptr = cute.make_ptr(
+        cutlass.Int32,
+        sTinv[0].base,
+        mem_space=cute.AddressSpace.smem,
+        assumed_align=cfg.buffer_align_bytes,
+    )
+    for z in cutlass.range_constexpr(cfg.t_inv_cosize * bpe // 4 // num_threads_cg0):
+        (tinv_zero_ptr + cg0_tidx + z * num_threads_cg0).store(cutlass.Int32(0))
+
+    sched_state = PipelineState.start(phase=0)
+    tile_idx = cutlass.Int32(bidx)
+    FIRST_STATE_CHUNK = 0 if cfg.use_initial_state else 1
+    while tile_idx < total_tiles:
+        (
+            batch_idx,
+            head_idx,
+            batch_start,
+            batch_end,
+            seqlen_b,
+            num_chunks_b,
+            wstart,
+            wend,
+            cstart,
+            cend,
+        ) = decode_work_item(cfg, tile_idx, mWorkItems)
+        num_item_chunks = cend - wstart
+
+        for chunk_idx in cutlass.range(num_item_chunks):
+            # ---- T-pairwise ------------------------------------------------------
+            gate_idx = gate_index.idx
+            bars.mb_gate_ready[gate_idx].wait(gate_index.phase)
+            gate_index = advance(gate_index, cfg.smem_gate_stages)
+
+            row_cs = []
+            for r in cutlass.range_constexpr(2):
+                row_cs.append(sCumsumlog[warp_id * 16 + lane_id // 4 + r * 8, 0, gate_idx])
+            col_cs = []
+            for g in cutlass.range_constexpr(8):
+                for b in cutlass.range_constexpr(2):
+                    col_cs.append(sCumsumlog[(lane_id % 4) * 2 + g * 8 + b, 0, gate_idx])
+            decay_t = []
+            decay_t_strict = []
+            for k in cutlass.range_constexpr(num_vals):
+                crow = warp_id * 16 + lane_id // 4 + ((k // 2) % 2) * 8
+                ccol = (lane_id % 4) * 2 + ((k // 4) * 8 + k % 2)
+                decay_t.append(
+                    cute.math.exp2(
+                        row_cs[(k // 2) % 2] - col_cs[(k // 4) * 2 + (k % 2)], fastmath=True
+                    )
+                    if crow >= ccol
+                    else mask_zero
+                )
+                decay_t_strict.append(mask_zero if crow == ccol else decay_t[k])
+            last_cs = sCumsumlog[cfg.b_t - 1, 0, gate_idx]
+            decay_scale_fp32 = []
+            for i in cutlass.range_constexpr(16):
+                decay_scale_fp32.append(cute.math.exp2(last_cs - col_cs[i], fastmath=True))
+            decay_scale_vals = [decay_scale_fp32[(k // 4) * 2 + (k % 2)] for k in range(num_vals)]
+            cumprod_total = sCumprod[sCumprod.shape[0] - 1, 0, gate_idx]
+
+            beta_idx = beta_index.idx
+            bars.mb_beta_ready[beta_idx].wait(beta_index.phase)
+            beta_index = advance(beta_index, cfg.smem_beta_stages)
+
+            gBeta = []
+            for k in cutlass.range_constexpr(num_vals):
+                crow = warp_id * 16 + lane_id // 4 + ((k // 2) % 2) * 8
+                gBeta.append(sBeta[crow, 0, beta_idx])
+
+            # ---- KK epi:  M_kk[i,j] = W_kk[i,j] * T_strict[i,j] * Beta[i] --------
+            tinv_idx = tinv_index.idx
+            tinv_index = advance(tinv_index, cfg.smem_t_inv_stages)
+            bars.mb_kk_acc_ready[0].wait(cg0_kk_ready.phase)
+            cg0_kk_ready = advance(cg0_kk_ready, 1)
+
+            tinv_base = sTinv[tinv_idx].base
+            kk_base = sKK[tinv_idx].base
+            kk_vec = nvvm.tcgen05_ld(
+                "16x256b",
+                nvvm.make_tmem_ptr((tmem_warp_row << 16) + tmem_kk_col, cutlass.Float32),
+                num=8,
+            )
+            kk_pack = []
+            for k in cutlass.range_constexpr(num_vals // 2):
+                p0, p1 = fmul2(
+                    kk_vec[2 * k],
+                    kk_vec[2 * k + 1],
+                    decay_t_strict[2 * k],
+                    decay_t_strict[2 * k + 1],
+                )
+                v0, v1 = fmul2(p0, p1, gBeta[2 * k], gBeta[2 * k + 1])
+                kk_pack.append(fp32_to_fp16(v0, v1, dtype=cfg.io_dtype))
+            for c in cutlass.range_constexpr(ACC_N_FRAGS):
+                nvvm.stmatrix(
+                    cutlass.inttoptr(
+                        kk_base
+                        + (
+                            store_row * cfg.b_t
+                            + smem_64x64_offset(store_row, store_col + c * FRAG_COLS)
+                        )
+                        * bpe,
+                        cutlass.AddressSpace.smem,
+                        cutlass.BFloat16,
+                    ),
+                    [
+                        kk_pack[c * 4 + 0],
+                        kk_pack[c * 4 + 1],
+                        kk_pack[c * 4 + 2],
+                        kk_pack[c * 4 + 3],
+                    ],
+                    nvvm.MMALayout.ROW,
+                )
+            if chunk_idx < cend - FIRST_STATE_CHUNK:
+                bars.mb_kk_acc_done[0].arrive()
+
+            # ---- A epi:  A[i,j] = W_qk[i,j] * T[i,j] * scale ---------------------
+            a_idx = a_index.idx
+            a_phase = a_index.phase
+            a_index = advance(a_index, cfg.smem_a_stages)
+            bars.mb_a_acc_ready[0].wait(cg0_a_ready.phase)
+            cg0_a_ready = advance(cg0_a_ready, 1)
+
+            a_base = sA[a_idx].base
+            a_vec = nvvm.tcgen05_ld(
+                "16x256b",
+                nvvm.make_tmem_ptr((tmem_warp_row << 16) + tmem_a_col, cutlass.Float32),
+                num=8,
+            )
+            a_pack = []
+            for k in cutlass.range_constexpr(num_vals // 2):
+                p0, p1 = fmul2(a_vec[2 * k], a_vec[2 * k + 1], decay_t[2 * k], decay_t[2 * k + 1])
+                v0, v1 = fmul2(p0, p1, scale, scale)
+                a_pack.append(fp32_to_fp16(v0, v1, dtype=cfg.io_dtype))
+            bars.mb_a_done[a_idx].wait(a_phase)
+            for c in cutlass.range_constexpr(ACC_N_FRAGS):
+                nvvm.stmatrix(
+                    cutlass.inttoptr(
+                        a_base
+                        + (
+                            store_row * cfg.b_t
+                            + smem_64x64_offset(store_row, store_col + c * FRAG_COLS)
+                        )
+                        * bpe,
+                        cutlass.AddressSpace.smem,
+                        cutlass.BFloat16,
+                    ),
+                    [a_pack[c * 4 + 0], a_pack[c * 4 + 1], a_pack[c * 4 + 2], a_pack[c * 4 + 3]],
+                    nvvm.MMALayout.ROW,
+                )
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_a_ready[a_idx].arrive()
+
+            # ---- blockwise inverse:  T_inv = -------------------------------------
+            nvvm.barrier_cta_sync_aligned(
+                cfg.inverse_barrier_id,
+                thread_count=cfg.inverse_barrier_threads,
+            )
+            if warp_id < 2:
+                invert_diagonal_NxN(cfg, kk_base, tinv_base, cg0_tidx // 8, cg0_tidx, 8)
+            nvvm.barrier_cta_sync_aligned(
+                cfg.inverse_barrier_id,
+                thread_count=cfg.inverse_barrier_threads,
+            )
+
+            blockwise_diagonal_8x8_to_16x16(cfg, tinv_base, kk_base, warp_id * 16, lane_id)
+            nvvm.barrier_cta_sync_aligned(
+                cfg.inverse_barrier_id,
+                thread_count=cfg.inverse_barrier_threads,
+            )
+
+            if warp_id < 2:
+                blockwise_diagonal_16x16_to_32x32(cfg, tinv_base, kk_base, warp_id * 32, lane_id)
+            nvvm.barrier_cta_sync_aligned(
+                cfg.inverse_barrier_id,
+                thread_count=cfg.inverse_barrier_threads,
+            )
+
+            if warp_id < 2:
+                blockwise_diagonal_32x32_to_64x64(cfg, tinv_base, kk_base, warp_id, lane_id)
+            nvvm.barrier_cta_sync_aligned(
+                cfg.inverse_barrier_id,
+                thread_count=cfg.inverse_barrier_threads,
+            )
+
+            # ---- Beta column-scaling in place:  T_inv[i,j] *= Beta[j] ------------
+            beta_col = []
+            for k in cutlass.range_constexpr(num_vals):
+                beta_col.append(sBeta[(lane_id % 4) * 2 + ((k // 4) * 8 + k % 2), 0, beta_idx])
+            tinv_frags = []
+            for c in cutlass.range_constexpr(ACC_N_FRAGS):
+                tinv_frags += list(
+                    nvvm.ldmatrix(
+                        cutlass.inttoptr(
+                            tinv_base
+                            + (
+                                store_row * cfg.b_t
+                                + smem_64x64_offset(store_row, store_col + c * FRAG_COLS)
+                            )
+                            * bpe,
+                            cutlass.AddressSpace.smem,
+                            cutlass.BFloat16,
+                        ),
+                        4,
+                        nvvm.MMALayout.ROW,
+                    )
+                )
+            tinv_pack = []
+            for j in cutlass.range_constexpr(num_vals // 2):
+                lo, hi = f16x2_to_f32(tinv_frags[j], dtype=cfg.io_dtype)
+                s0, s1 = fmul2(lo, hi, beta_col[2 * j], beta_col[2 * j + 1])
+                tinv_pack.append(fp32_to_fp16(s0, s1, dtype=cfg.io_dtype))
+            for c in cutlass.range_constexpr(ACC_N_FRAGS):
+                nvvm.stmatrix(
+                    cutlass.inttoptr(
+                        tinv_base
+                        + (
+                            store_row * cfg.b_t
+                            + smem_64x64_offset(store_row, store_col + c * FRAG_COLS)
+                        )
+                        * bpe,
+                        cutlass.AddressSpace.smem,
+                        cutlass.BFloat16,
+                    ),
+                    [
+                        tinv_pack[c * 4 + 0],
+                        tinv_pack[c * 4 + 1],
+                        tinv_pack[c * 4 + 2],
+                        tinv_pack[c * 4 + 3],
+                    ],
+                    nvvm.MMALayout.ROW,
+                )
+
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_t_inv_ready[tinv_idx].arrive()
+
+            # ---- dQ inter rescale ------------------------------------------------
+            if chunk_idx < cend - FIRST_STATE_CHUNK:
+                cumprod_fp32 = []
+                for g in cutlass.range_constexpr(8):
+                    for b in cutlass.range_constexpr(2):
+                        cumprod_fp32.append(sCumprod[(lane_id % 4) * 2 + g * 8 + b, 0, gate_idx])
+                cumprod_vals = [cumprod_fp32[(k // 4) * 2 + (k % 2)] for k in range(num_vals)]
+                bars.mb_dq_acc_scale_ready[0].wait(cg0_dq_scale_ready.phase)
+                cg0_dq_scale_ready = advance(cg0_dq_scale_ready, 1)
+                dqi_ptrs = []
+                dqi_vecs = []
+                for sub in cutlass.range_constexpr(2):
+                    dqi_ptrs.append(
+                        nvvm.make_tmem_ptr(
+                            ((tmem_warp_row + sub * 16) << 16) + tmem_dstate_inp_col,
+                            cutlass.Float32,
+                        )
+                    )
+                    dqi_vecs.append(nvvm.tcgen05_ld("16x256b", dqi_ptrs[sub], num=8))
+                for sub in cutlass.range_constexpr(2):
+                    dqi_scaled = []
+                    for j in cutlass.range_constexpr(16):
+                        p0, p1 = fmul2(
+                            dqi_vecs[sub][2 * j],
+                            dqi_vecs[sub][2 * j + 1],
+                            cumprod_vals[2 * j],
+                            cumprod_vals[2 * j + 1],
+                        )
+                        s0, s1 = fmul2(p0, p1, scale, scale)
+                        dqi_scaled += [s0, s1]
+                    nvvm.tcgen05_st(
+                        "16x256b",
+                        dqi_ptrs[sub],
+                        cutlass.Vector.from_elements(tuple(dqi_scaled), cutlass.Float32),
+                    )
+                nvvm.tcgen05_wait("store")
+                bars.mb_dq_acc_scale_done[0].arrive()
+
+            # ---- dGate_last state dot dstate term ----------------------------------------
+            if chunk_idx + DSTATE_IN0 >= 1:
+                bars.mb_dstate_smem_ready[0].wait(cg0_dstate_smem_ready.phase)
+                cg0_dstate_smem_ready = advance(cg0_dstate_smem_ready, 1)
+            sdstate_base = sdstate_flat.iterator.toint()
+            sstate_base = sstate_flat.iterator.toint()
+            state_dot_dstate_lo = [
+                opaque_f32_zero(),
+                opaque_f32_zero(),
+                opaque_f32_zero(),
+                opaque_f32_zero(),
+            ]
+            state_dot_dstate_hi = [
+                opaque_f32_zero(),
+                opaque_f32_zero(),
+                opaque_f32_zero(),
+                opaque_f32_zero(),
+            ]
+            for oct_ in cutlass.range_constexpr(cfg.d_v // 8):
+                state_dot_off = (
+                    (oct_ // 8) * (cfg.d_k * 64)
+                    + cg0_tidx * 64
+                    + smem_64x64_offset(cg0_tidx, (oct_ % 8) * 8)
+                )
+                dstate_frag = cute.make_tensor(
+                    cute.make_ptr(
+                        cutlass.Int32,
+                        sdstate_base + state_dot_off * bpe,
+                        mem_space=cute.AddressSpace.smem,
+                        assumed_align=16,
+                    ),
+                    cute.make_layout(4),
+                ).load()
+                state_frag = cute.make_tensor(
+                    cute.make_ptr(
+                        cutlass.Int32,
+                        sstate_base + state_dot_off * bpe,
+                        mem_space=cute.AddressSpace.smem,
+                        assumed_align=16,
+                    ),
+                    cute.make_layout(4),
+                ).load()
+                for w in cutlass.range_constexpr(4):
+                    dstate_lo, dstate_hi = f16x2_to_f32(dstate_frag[w], dtype=cfg.io_dtype)
+                    state_lo, state_hi = f16x2_to_f32(state_frag[w], dtype=cfg.io_dtype)
+                    state_dot_dstate_lo[w], state_dot_dstate_hi[w] = ffma2(
+                        dstate_lo,
+                        dstate_hi,
+                        state_lo,
+                        state_hi,
+                        state_dot_dstate_lo[w],
+                        state_dot_dstate_hi[w],
+                    )
+            state_dot_dstate = (
+                (state_dot_dstate_lo[0] + state_dot_dstate_lo[1])
+                + (state_dot_dstate_lo[2] + state_dot_dstate_lo[3])
+            ) + (
+                (state_dot_dstate_hi[0] + state_dot_dstate_hi[1])
+                + (state_dot_dstate_hi[2] + state_dot_dstate_hi[3])
+            )
+            for off in [1, 2, 4, 8, 16]:
+                state_dot_dstate += nvvm.shfl_sync(
+                    0xFFFFFFFF, state_dot_dstate, off, 31, kind=nvvm.Shfl.BFLY
+                )
+            bars.mb_state_dot_dstate_done[0].arrive()
+
+            # ---- dK inter rescale ------------------------------------------------
+            cg0_k_idx = cg0_k_index.idx
+            cg0_k_index = advance(cg0_k_index, cfg.smem_k_stages)
+            k_dot_dk_inter = cutlass.Float32(0.0)
+            if chunk_idx + DSTATE_IN0 >= 1:
+                bars.mb_dk_scale_acc_ready[0].wait(cg0_dk_scale_ready.phase)
+                cg0_dk_scale_ready = advance(cg0_dk_scale_ready, 1)
+                k_dot_dk_inter_lo = [
+                    opaque_f32_zero(),
+                    opaque_f32_zero(),
+                    opaque_f32_zero(),
+                    opaque_f32_zero(),
+                ]
+                k_dot_dk_inter_hi = [
+                    opaque_f32_zero(),
+                    opaque_f32_zero(),
+                    opaque_f32_zero(),
+                    opaque_f32_zero(),
+                ]
+                dki_ptrs = []
+                dki_vecs = []
+                for sub in cutlass.range_constexpr(2):
+                    dki_ptrs.append(
+                        nvvm.make_tmem_ptr(
+                            ((tmem_warp_row + sub * 16) << 16) + tmem_dvdk_acc_col, cutlass.Float32
+                        )
+                    )
+                    dki_vecs.append(nvvm.tcgen05_ld("16x256b", dki_ptrs[sub], num=8))
+                for sub in cutlass.range_constexpr(2):
+                    dki_scaled = []
+                    for j in cutlass.range_constexpr(16):
+                        s0, s1 = fmul2(
+                            dki_vecs[sub][2 * j],
+                            dki_vecs[sub][2 * j + 1],
+                            decay_scale_vals[2 * j],
+                            decay_scale_vals[2 * j + 1],
+                        )
+                        dki_scaled += [s0, s1]
+                    nvvm.tcgen05_st(
+                        "16x256b",
+                        dki_ptrs[sub],
+                        cutlass.Vector.from_elements(tuple(dki_scaled), cutlass.Float32),
+                    )
+                    for m0 in cutlass.range_constexpr(4):
+                        frag_addr = (
+                            frag_slab_off
+                            + (frag_row + m0 * 16) * 64
+                            + smem_64x64_offset(frag_row + m0 * 16, frag_col + sub * 16)
+                        )
+                        k_frag = nvvm.ldmatrix(
+                            (sK_base_p + cg0_k_idx * k_stage_elems_cg0 + frag_addr).raw_ptr(),
+                            4,
+                            nvvm.MMALayout.COL,
+                        )
+                        for i in cutlass.range_constexpr(4):
+                            k_lo, k_hi = f16x2_to_f32(k_frag[i], dtype=cfg.io_dtype)
+                            k_dot_dk_inter_lo[i], k_dot_dk_inter_hi[i] = ffma2(
+                                dki_scaled[8 * m0 + 2 * i],
+                                dki_scaled[8 * m0 + 2 * i + 1],
+                                k_lo,
+                                k_hi,
+                                k_dot_dk_inter_lo[i],
+                                k_dot_dk_inter_hi[i],
+                            )
+                nvvm.tcgen05_wait("store")
+                bars.mb_dk_scale_acc_done[0].arrive()
+                k_dot_dk_inter = (
+                    (k_dot_dk_inter_lo[0] + k_dot_dk_inter_lo[1])
+                    + (k_dot_dk_inter_lo[2] + k_dot_dk_inter_lo[3])
+                ) + (
+                    (k_dot_dk_inter_hi[0] + k_dot_dk_inter_hi[1])
+                    + (k_dot_dk_inter_hi[2] + k_dot_dk_inter_hi[3])
+                )
+                for off in [1, 2, 4, 8, 16]:
+                    k_dot_dk_inter += nvvm.shfl_sync(
+                        0xFFFFFFFF, k_dot_dk_inter, off, 31, kind=nvvm.Shfl.BFLY
+                    )
+
+            # ---- dA epilogue -----------------------------------------------------
+            bars.mb_da_acc_ready[0].wait(da_acc_index.phase)
+            da_acc_index = advance(da_acc_index, 1)
+
+            da_base = sDa[0].base
+            da_vec = nvvm.tcgen05_ld(
+                "16x256b",
+                nvvm.make_tmem_ptr((tmem_warp_row << 16) + tmem_da_col, cutlass.Float32),
+                num=8,
+            )
+            da_pack = []
+            for k in cutlass.range_constexpr(num_vals // 2):
+                p0, p1 = fmul2(
+                    da_vec[2 * k], da_vec[2 * k + 1], decay_t[2 * k], decay_t[2 * k + 1]
+                )
+                v0, v1 = fmul2(p0, p1, scale, scale)
+                da_pack.append(fp32_to_fp16(v0, v1, dtype=cfg.io_dtype))
+            for c in cutlass.range_constexpr(ACC_N_FRAGS):
+                nvvm.stmatrix(
+                    cutlass.inttoptr(
+                        da_base
+                        + (
+                            store_row * cfg.b_t
+                            + smem_64x64_offset(store_row, store_col + c * FRAG_COLS)
+                        )
+                        * bpe,
+                        cutlass.AddressSpace.smem,
+                        cutlass.BFloat16,
+                    ),
+                    [
+                        da_pack[c * 4 + 0],
+                        da_pack[c * 4 + 1],
+                        da_pack[c * 4 + 2],
+                        da_pack[c * 4 + 3],
+                    ],
+                    nvvm.MMALayout.ROW,
+                )
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_da_ready[0].arrive()
+
+            # ---- dM epilogue -----------------------------------------------------
+            bars.mb_dm_acc_ready[0].wait(dm_ready_index.phase)
+            dm_ready_index = advance(dm_ready_index, 1)
+            dm_base = sDm[0].base
+            dm_vec = nvvm.tcgen05_ld(
+                "16x256b",
+                nvvm.make_tmem_ptr((tmem_warp_row << 16) + tmem_dm_core_col, cutlass.Float32),
+                num=8,
+            )
+
+            dm_pack = []
+            for k in cutlass.range_constexpr(num_vals // 2):
+                p0, p1 = fmul2(
+                    dm_vec[2 * k],
+                    dm_vec[2 * k + 1],
+                    decay_t_strict[2 * k],
+                    decay_t_strict[2 * k + 1],
+                )
+                v0 = cutlass.Float32(0.0) - p0
+                v1 = cutlass.Float32(0.0) - p1
+                dm_pack.append(fp32_to_fp16(v0, v1, dtype=cfg.io_dtype))
+            for c in cutlass.range_constexpr(ACC_N_FRAGS):
+                nvvm.stmatrix(
+                    cutlass.inttoptr(
+                        dm_base
+                        + (
+                            store_row * cfg.b_t
+                            + smem_64x64_offset(store_row, store_col + c * FRAG_COLS)
+                        )
+                        * bpe,
+                        cutlass.AddressSpace.smem,
+                        cutlass.BFloat16,
+                    ),
+                    [
+                        dm_pack[c * 4 + 0],
+                        dm_pack[c * 4 + 1],
+                        dm_pack[c * 4 + 2],
+                        dm_pack[c * 4 + 3],
+                    ],
+                    nvvm.MMALayout.ROW,
+                )
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_dm_acc_done[0].arrive()
+
+            # ---- dK attn read ----------------------------------------------------
+            bars.mb_dk_attn_acc_ready[0].wait(cg0_dk_attn_ready.phase)
+            cg0_dk_attn_ready = advance(cg0_dk_attn_ready, 1)
+            dks_regs = []
+            for sub in cutlass.range_constexpr(2):
+                dks_vec = nvvm.tcgen05_ld(
+                    "16x256b",
+                    nvvm.make_tmem_ptr(
+                        ((tmem_warp_row + sub * 16) << 16) + tmem_dvdk_acc_col, cutlass.Float32
+                    ),
+                    num=8,
+                )
+                dks_regs.append([dks_vec[k] for k in range(32)])
+            nvvm.tcgen05_wait("load")
+            bars.mb_dk_attn_acc_done[0].arrive()
+
+            # ---- dBeta/dGate M-terms: E = dM_core ⊙ M_kk(sKK, strict-masked). ----
+            kk_frag = []
+            for c in cutlass.range_constexpr(ACC_N_FRAGS):
+                kk_frag += list(
+                    nvvm.ldmatrix(
+                        cutlass.inttoptr(
+                            kk_base
+                            + (
+                                store_row * cfg.b_t
+                                + smem_64x64_offset(store_row, store_col + c * FRAG_COLS)
+                            )
+                            * bpe,
+                            cutlass.AddressSpace.smem,
+                            cutlass.BFloat16,
+                        ),
+                        4,
+                        nvvm.MMALayout.ROW,
+                    )
+                )
+            binv_row = [
+                cute.math.rcp(gBeta[0] + cutlass.Float32(1e-10), approx=True, ftz=True),
+                cute.math.rcp(gBeta[2] + cutlass.Float32(1e-10), approx=True, ftz=True),
+            ]
+            row_acc = [cutlass.Float32(0.0)] * 8
+            col_part = [opaque_f32_zero() for _ in range(16)]
+            for j in cutlass.range_constexpr(num_vals // 2):
+                klo, khi = f16x2_to_f32(kk_frag[j], dtype=cfg.io_dtype)
+                binv_j = binv_row[j % 2]
+                p_lo, p_hi = fmul2(dm_vec[2 * j], dm_vec[2 * j + 1], klo, khi)
+                e_lo, e_hi = fmul2(p_lo, p_hi, binv_j, binv_j)
+                row_acc[(j % 2) * 4 + (j // 2) % 4] += e_lo + e_hi
+                c0 = cutlass.const_expr((j // 2) * 2)
+                col_part[c0], col_part[c0 + 1] = fadd2(col_part[c0], col_part[c0 + 1], e_lo, e_hi)
+            row_part = [
+                (row_acc[0] + row_acc[1]) + (row_acc[2] + row_acc[3]),
+                (row_acc[4] + row_acc[5]) + (row_acc[6] + row_acc[7]),
+            ]
+            for off in [1, 2]:
+                for rp in cutlass.range_constexpr(2):
+                    row_part[rp] += nvvm.shfl_sync(
+                        0xFFFFFFFF, row_part[rp], off, 31, kind=nvvm.Shfl.BFLY
+                    )
+            bars.mb_dbeta_cg1_ready[0].wait(cg0_dbeta_index.phase)
+            cg0_dbeta_index = advance(cg0_dbeta_index, 1)
+            if lane_id % 4 == 0:
+                for rp in cutlass.range_constexpr(2):
+                    crow_r = warp_id * 16 + lane_id // 4 + rp * 8
+                    db = sBeta[crow_r, 0, beta_idx] - row_part[rp] * binv_row[rp]
+                    if cutlass.const_expr(cfg.beta_sigmoid):
+                        b = gBeta[2 * rp]
+                        db = db * (b - b * b)
+                    sBeta[crow_r, 0, beta_idx] = db
+
+            # ---- part reductions -------------------------------------------------
+            if chunk_idx + DSTATE_IN0 >= FIRST_STATE_CHUNK:
+                part_k = [acc_zero] * 16
+                for sub in cutlass.range_constexpr(2):
+                    for m0 in cutlass.range_constexpr(4):
+                        frag_addr = (
+                            frag_slab_off
+                            + (frag_row + m0 * 16) * 64
+                            + smem_64x64_offset(frag_row + m0 * 16, frag_col + sub * 16)
+                        )
+                        k_frag = nvvm.ldmatrix(
+                            (sK_base_p + cg0_k_idx * k_stage_elems_cg0 + frag_addr).raw_ptr(),
+                            4,
+                            nvvm.MMALayout.COL,
+                        )
+                        for i in cutlass.range_constexpr(4):
+                            k_lo, k_hi = f16x2_to_f32(k_frag[i], dtype=cfg.io_dtype)
+                            frag_e0 = cutlass.const_expr(8 * m0 + 2 * i)
+                            part_e0 = cutlass.const_expr((frag_e0 // 4) * 2 + (frag_e0 % 2))
+                            if cutlass.const_expr(sub == 0 and i % 2 == 0):
+                                part_k[part_e0], part_k[part_e0 + 1] = fmul2(
+                                    dks_regs[sub][frag_e0], dks_regs[sub][frag_e0 + 1], k_lo, k_hi
+                                )
+                            else:
+                                part_k[part_e0], part_k[part_e0 + 1] = ffma2(
+                                    dks_regs[sub][frag_e0],
+                                    dks_regs[sub][frag_e0 + 1],
+                                    k_lo,
+                                    k_hi,
+                                    part_k[part_e0],
+                                    part_k[part_e0 + 1],
+                                )
+                nvvm.fence_proxy("async.shared", space="cta")
+                bars.mb_k_cg0_done[cg0_k_idx].arrive()
+
+                dgate_part = [col_part[j] - part_k[j] for j in range(16)]
+                dgate_part_lo, dgate_part_hi = warp_reduce_scatter_frag_16_elems(
+                    dgate_part, lane_id
+                )
+                dgate_last_w = k_dot_dk_inter + (
+                    (cumprod_total * state_dot_dstate if chunk_idx + DSTATE_IN0 >= 1 else acc_zero)
+                    if chunk_idx < cend - FIRST_STATE_CHUNK
+                    else acc_zero
+                )
+                tok0 = (lane_id // 4) * 8 + (lane_id % 4) * 2
+                (skk_red + warp_id * 64 + tok0).store(dgate_part_lo)
+                (skk_red + warp_id * 64 + tok0 + 1).store(
+                    dgate_part_hi + dgate_last_w if lane_id == 31 else dgate_part_hi
+                )
+
+                bars.mb_dgate_cg1_ready[0].wait(cg0_dgate_index.phase)
+                cg0_dgate_index = advance(cg0_dgate_index, 1)
+                if lane_id % 4 == 0:
+                    for rp in cutlass.range_constexpr(2):
+                        crow_r = warp_id * 16 + lane_id // 4 + rp * 8
+                        sCumsumlog[crow_r, 0, gate_idx] = (
+                            sCumsumlog[crow_r, 0, gate_idx] - row_part[rp]
+                        )
+                nvvm.barrier_cta_sync_aligned(
+                    cfg.inverse_barrier_id, thread_count=cfg.inverse_barrier_threads
+                )
+                if cg0_tidx < 64:
+                    dgate_sum = (
+                        (skk_red + cg0_tidx).load()
+                        + (skk_red + 64 + cg0_tidx).load()
+                        + (skk_red + 128 + cg0_tidx).load()
+                        + (skk_red + 192 + cg0_tidx).load()
+                    )
+                    sCumsumlog[cg0_tidx, 0, gate_idx] = (
+                        sCumsumlog[cg0_tidx, 0, gate_idx] + dgate_sum
+                    )
+
+            if chunk_idx + DSTATE_IN0 < FIRST_STATE_CHUNK:
+                part_k = [acc_zero] * 16
+                for sub in cutlass.range_constexpr(2):
+                    for m0 in cutlass.range_constexpr(4):
+                        frag_addr = (
+                            frag_slab_off
+                            + (frag_row + m0 * 16) * 64
+                            + smem_64x64_offset(frag_row + m0 * 16, frag_col + sub * 16)
+                        )
+                        k_frag = nvvm.ldmatrix(
+                            (sK_base_p + cg0_k_idx * k_stage_elems_cg0 + frag_addr).raw_ptr(),
+                            4,
+                            nvvm.MMALayout.COL,
+                        )
+                        for i in cutlass.range_constexpr(4):
+                            k_lo, k_hi = f16x2_to_f32(k_frag[i], dtype=cfg.io_dtype)
+                            frag_e0 = cutlass.const_expr(8 * m0 + 2 * i)
+                            part_e0 = cutlass.const_expr((frag_e0 // 4) * 2 + (frag_e0 % 2))
+                            if cutlass.const_expr(sub == 0 and i % 2 == 0):
+                                part_k[part_e0], part_k[part_e0 + 1] = fmul2(
+                                    dks_regs[sub][frag_e0], dks_regs[sub][frag_e0 + 1], k_lo, k_hi
+                                )
+                            else:
+                                part_k[part_e0], part_k[part_e0 + 1] = ffma2(
+                                    dks_regs[sub][frag_e0],
+                                    dks_regs[sub][frag_e0 + 1],
+                                    k_lo,
+                                    k_hi,
+                                    part_k[part_e0],
+                                    part_k[part_e0 + 1],
+                                )
+                nvvm.fence_proxy("async.shared", space="cta")
+                bars.mb_k_cg0_done[cg0_k_idx].arrive()
+
+                dgate_part = [col_part[j] - part_k[j] for j in range(16)]
+                dgate_part_lo, dgate_part_hi = warp_reduce_scatter_frag_16_elems(
+                    dgate_part, lane_id
+                )
+                tok0 = (lane_id // 4) * 8 + (lane_id % 4) * 2
+                (skk_red + warp_id * 64 + tok0).store(dgate_part_lo)
+                (skk_red + warp_id * 64 + tok0 + 1).store(dgate_part_hi)
+
+                bars.mb_dgate_cg1_ready[0].wait(cg0_dgate_index.phase)
+                cg0_dgate_index = advance(cg0_dgate_index, 1)
+                if lane_id % 4 == 0:
+                    for rp in cutlass.range_constexpr(2):
+                        crow_r = warp_id * 16 + lane_id // 4 + rp * 8
+                        sCumsumlog[crow_r, 0, gate_idx] = (
+                            sCumsumlog[crow_r, 0, gate_idx] - row_part[rp]
+                        )
+                nvvm.barrier_cta_sync_aligned(
+                    cfg.inverse_barrier_id, thread_count=cfg.inverse_barrier_threads
+                )
+                if cg0_tidx < 64:
+                    dgate_sum = (
+                        (skk_red + cg0_tidx).load()
+                        + (skk_red + 64 + cg0_tidx).load()
+                        + (skk_red + 128 + cg0_tidx).load()
+                        + (skk_red + 192 + cg0_tidx).load()
+                    )
+                    sCumsumlog[cg0_tidx, 0, gate_idx] = (
+                        sCumsumlog[cg0_tidx, 0, gate_idx] + dgate_sum
+                    )
+
+            bars.mb_gate_done[gate_idx].arrive()
+            bars.mb_beta_done[beta_idx].arrive()
+        tile_idx, sched_state = sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas)
+    for _ in range(cfg.smem_a_stages):
+        bars.mb_a_done[a_index.idx].wait(a_index.phase)
+        a_index = advance(a_index, cfg.smem_a_stages)
+
+    bars.mb_tmem_done[0].arrive()
+
+
+@cute.jit
+def compute1_warp_group(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    cu_seqlens,
+    mWorkItems,
+    mDstate0_out,
+    mDstate_in,
+    tidx,
+    warp_idx,
+    tmem_base_slot,
+    scale,
+    sQ,
+    sK,
+    sV,
+    sdO,
+    sCumsumlog,
+    sCumprod,
+    sBeta,
+    sdQ,
+    sdK,
+    sdV,
+    sDstate,
+    sDa,
+    sDm,
+    sSched,
+    bars,
+):
+    """Compute warp-group 1 role (warps 4-7): persistent scheduler loop
+    running each chunk's gradient epilogues and stagings."""
+
+    v_index = PipelineState.start(phase=0)
+    do_index = PipelineState.start(phase=0)
+    gate_index = PipelineState.start(phase=0)
+    cg1_k_state_ready = PipelineState.start(phase=0)
+    cg1_u_ready = PipelineState.start(phase=0)
+    cg1_dy_ready = PipelineState.start(phase=0)
+    cg1_du_scale_ready = PipelineState.start(phase=0)
+    cg1_du_total_ready = PipelineState.start(phase=0)
+    cg1_dk_total_ready = PipelineState.start(phase=0)
+    dstate_acc_index = PipelineState.start(phase=0)
+    cg1_state_dot_dstate_index = PipelineState.start(phase=0)
+    dq_index = PipelineState.start(phase=1)
+    cg1_beta_index = PipelineState.start(phase=0)
+    sdv_done_index = PipelineState.start(phase=1)
+    cg1_dk_state_path_ready = PipelineState.start(phase=0)
+    dq_total_ready_index = PipelineState.start(phase=0)
+    dstate_inp_index = PipelineState.start(phase=1)
+    dk_index = PipelineState.start(phase=1)
+    dv_index = PipelineState.start(phase=1)
+
+    nvvm.setmaxregister(cfg.num_regs_compute_group_1, nvvm.SetMaxRegisterAction.INCREASE)
+    nvvm.barrier_cta_sync_aligned(
+        cfg.tmem_alloc_barrier_id,
+        thread_count=cfg.tmem_alloc_barrier_threads,
+    )
+    tmem_base = tmem_base_slot.load()
+
+    num_threads_cg1 = cfg.threads_per_warp * len(cfg.compute_group_1_warp_ids)
+    cg1_tidx = tidx % num_threads_cg1
+    lane_id = cg1_tidx % cfg.threads_per_warp
+    tmem_warp_row = (cg1_tidx // cfg.threads_per_warp) * cfg.threads_per_warp
+    ldtm_width = 32
+    sttm_width = ldtm_width // 2
+    num_state_subs = cutlass.const_expr(cfg.d_v // ldtm_width)
+    tmem_dstate_acc_col = tmem_base + cfg.tmem_dstate_acc_offset
+    tmem_dstate_inp_col = tmem_base + cfg.tmem_dstate_inp_offset
+    tmem_dvdk_acc_col = tmem_base + cfg.tmem_dvdk_acc_offset
+    tmem_shared_acc_col = tmem_base + cfg.tmem_shared_acc_offset
+    tmem_shared_inp_col = tmem_base + cfg.tmem_shared_inp_offset
+    SHARED_INP_STAGE_COLS = cfg.b_t // 2
+    tmem_do_prime_col = tmem_shared_inp_col
+    tmem_du_col = tmem_shared_inp_col + SHARED_INP_STAGE_COLS
+    tmem_dyp_col = tmem_du_col
+    tmem_y_col = tmem_base + cfg.tmem_y_offset
+    tmem_g_k_state_col = tmem_y_col + SHARED_INP_STAGE_COLS
+    ACC_STAGE_COLS = cfg.b_t
+    tmem_acc_a = tmem_shared_acc_col
+    tmem_acc_b = tmem_shared_acc_col + ACC_STAGE_COLS
+    tmem_kk_col = tmem_acc_a
+    tmem_k_state_col = tmem_acc_a
+    tmem_dy_col = tmem_acc_a
+    tmem_dm_core_col = tmem_acc_a
+    tmem_a_col = tmem_acc_b
+    tmem_u_col = tmem_acc_b
+    tmem_da_col = tmem_acc_b
+    tmem_dk_state_path_col = tmem_shared_inp_col
+    frag_row = cg1_tidx % 8 + (cg1_tidx // 16 % 2) * 8
+    frag_col = (cg1_tidx // 8 % 2) * 8 + (cg1_tidx // 32 % 2) * 32
+    frag_slab_off = (cg1_tidx // 64) * 4096
+    dv_stage_elems = cfg.dv_cosize // cfg.smem_dv_stages
+    sdV_base = cute.make_ptr(
+        cfg.io_dtype,
+        sdV[0].base,
+        mem_space=cute.AddressSpace.smem,
+        assumed_align=cfg.buffer_align_bytes,
+    )
+    v_stage_elems = cfg.v_cosize // cfg.smem_v_stages
+    sV_base = cute.make_ptr(
+        cfg.io_dtype,
+        sV[0].base,
+        mem_space=cute.AddressSpace.smem,
+        assumed_align=cfg.buffer_align_bytes,
+    )
+    sQ_base = cute.make_ptr(
+        cfg.io_dtype,
+        sQ[0].base,
+        mem_space=cute.AddressSpace.smem,
+        assumed_align=cfg.buffer_align_bytes,
+    )
+    do_stage_elems = cfg.do_cosize // cfg.smem_do_stages
+    sdO_base = cute.make_ptr(
+        cfg.io_dtype,
+        sdO[0].base,
+        mem_space=cute.AddressSpace.smem,
+        assumed_align=cfg.buffer_align_bytes,
+    )
+    dk_stage_elems = cfg.dk_cosize // cfg.smem_dk_stages
+    dq_stage_elems = cfg.dq_cosize // cfg.smem_dq_stages
+    sdQ_base = cute.make_ptr(
+        cfg.io_dtype,
+        sdQ[0].base,
+        mem_space=cute.AddressSpace.smem,
+        assumed_align=cfg.buffer_align_bytes,
+    )
+    sdK_base = cute.make_ptr(
+        cfg.io_dtype,
+        sdK[0].base,
+        mem_space=cute.AddressSpace.smem,
+        assumed_align=cfg.buffer_align_bytes,
+    )
+    sDstate_base_int = sDstate[0].base
+    sred_base = cute.make_ptr(
+        cutlass.Float32,
+        sdQ[0].base,
+        mem_space=cute.AddressSpace.smem,
+        assumed_align=cfg.buffer_align_bytes,
+    )
+    sdstate_red = cute.make_ptr(
+        cutlass.Float32,
+        sDstate[0].base,
+        mem_space=cute.AddressSpace.smem,
+        assumed_align=cfg.buffer_align_bytes,
+    )
+    dstate_done_idx = cutlass.Int32(0)
+    cg1_warp_id = cg1_tidx // cfg.threads_per_warp
+
+    sched_state = PipelineState.start(phase=0)
+    tile_idx = cutlass.Int32(bidx)
+    FIRST_STATE_CHUNK = 0 if cfg.use_initial_state else 1
+    while tile_idx < total_tiles:
+        (
+            batch_idx,
+            head_idx,
+            batch_start,
+            batch_end,
+            seqlen_b,
+            num_chunks_b,
+            wstart,
+            wend,
+            cstart,
+            cend,
+        ) = decode_work_item(cfg, tile_idx, mWorkItems)
+        num_item_chunks = cend - wstart
+
+        # ---- d_final_state prologue ----------------------------------------------
+        if cutlass.const_expr(cfg.use_dstate_in):
+            if num_item_chunks > 0:
+                gDstate_in = mDstate_in[None, None, head_idx, batch_idx]
+                seed_from_dstate_in = cend == num_chunks_b
+                dstate_inp_idx = dstate_inp_index.idx
+                bars.mb_dstate_inp_done[dstate_inp_idx].wait(dstate_inp_index.phase)
+                dstate_inp_index = advance(dstate_inp_index, cfg.tmem_dstate_inp_stages)
+                for sub in cutlass.range_constexpr(num_state_subs):
+                    dstate_in_vals = []
+                    for kk in cutlass.range_constexpr(ldtm_width):
+                        v = gDstate_in[cg1_tidx, sub * ldtm_width + kk]
+                        v = v if seed_from_dstate_in else cutlass.Float32(0.0)
+                        dstate_in_vals.append(v)
+                    nvvm.tcgen05_st(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(
+                            (tmem_warp_row << 16) + tmem_dstate_acc_col + sub * ldtm_width,
+                            cutlass.Float32,
+                        ),
+                        cutlass.Vector.from_elements(tuple(dstate_in_vals), cutlass.Float32),
+                    )
+                    dstate_in_pack = [
+                        fp32_to_fp16(
+                            dstate_in_vals[2 * j], dstate_in_vals[2 * j + 1], dtype=cfg.io_dtype
+                        )
+                        for j in range(16)
+                    ]
+                    nvvm.tcgen05_st(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(
+                            (tmem_warp_row << 16) + tmem_dstate_inp_col + sub * sttm_width,
+                            cutlass.Int32,
+                        ),
+                        cutlass.Vector.from_elements(tuple(dstate_in_pack), cutlass.Int32),
+                    )
+                nvvm.tcgen05_wait("store")
+                bars.mb_dstate_inp_ready[dstate_inp_idx].arrive()
+
+                for sub in cutlass.range_constexpr(num_state_subs):
+                    dstate_smem_vec = nvvm.tcgen05_ld(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(
+                            (tmem_warp_row << 16) + tmem_dstate_acc_col + sub * ldtm_width,
+                            cutlass.Float32,
+                        ),
+                        num=32,
+                    )
+                    for g in cutlass.range_constexpr(ldtm_width // 8):
+                        dstate_smem_pack = tuple(
+                            fp32_to_fp16(
+                                dstate_smem_vec[g * 8 + 2 * t],
+                                dstate_smem_vec[g * 8 + 2 * t + 1],
+                                dtype=cfg.io_dtype,
+                            )
+                            for t in range(4)
+                        )
+                        dstate_dk = sub * ldtm_width + g * 8
+                        dstate_addr = (
+                            (dstate_dk // 64) * (cfg.d_v * 64)
+                            + cg1_tidx * 64
+                            + smem_64x64_offset(cg1_tidx, dstate_dk % 64)
+                        )
+                        cutlass.inttoptr(
+                            sDstate_base_int + dstate_addr * 2,
+                            cutlass.AddressSpace.smem,
+                            cfg.io_dtype,
+                        ).store(
+                            cutlass.Vector.from_elements(dstate_smem_pack, cutlass.Int32).bitcast(
+                                cfg.io_dtype
+                            ),
+                            alignment=16,
+                        )
+                nvvm.fence_proxy("async.shared", space="cta")
+                bars.mb_dstate_smem_ready[0].arrive()
+
+        # ---- chunks NT-1 .. 0 (backward) ------------------------------------------
+        for rev_idx in cutlass.range(num_item_chunks):
+            chunk_idx = cend - 1 - rev_idx
+            have_dstate = (
+                cutlass.Boolean(True) if cutlass.const_expr(cfg.use_dstate_in) else rev_idx > 0
+            )
+            gate_idx = gate_index.idx
+            bars.mb_gate_ready[gate_idx].wait(gate_index.phase)
+            gate_index = advance(gate_index, cfg.smem_gate_stages)
+
+            beta_idx = cg1_beta_index.idx
+            bars.mb_beta_ready[beta_idx].wait(cg1_beta_index.phase)
+            cg1_beta_index = advance(cg1_beta_index, cfg.smem_beta_stages)
+
+            # ---- dstate rescale: dstate *= this chunk's cumprod --------------------------
+            if have_dstate:
+                cumprod_top = sCumprod[sCumprod.shape[0] - 1, 0, gate_idx]
+                for sub in cutlass.range_constexpr(num_state_subs):
+                    dstate_rescale_vec = nvvm.tcgen05_ld(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(
+                            (tmem_warp_row << 16) + tmem_dstate_acc_col + sub * ldtm_width,
+                            cutlass.Float32,
+                        ),
+                        num=32,
+                    )
+                    dstate_rescaled = []
+                    for j in cutlass.range_constexpr(16):
+                        h0, h1 = fmul2(
+                            dstate_rescale_vec[2 * j],
+                            dstate_rescale_vec[2 * j + 1],
+                            cumprod_top,
+                            cumprod_top,
+                        )
+                        dstate_rescaled += [h0, h1]
+                    nvvm.tcgen05_st(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(
+                            (tmem_warp_row << 16) + tmem_dstate_acc_col + sub * ldtm_width,
+                            cutlass.Float32,
+                        ),
+                        cutlass.Vector.from_elements(tuple(dstate_rescaled), cutlass.Float32),
+                    )
+                nvvm.tcgen05_wait("store")
+                bars.mb_dstate_scale_acc_done[dstate_done_idx].arrive()
+
+            num_vals = 32
+            cumprod_fp32 = []
+            for g in cutlass.range_constexpr(8):
+                for b in cutlass.range_constexpr(2):
+                    cumprod_fp32.append(sCumprod[(lane_id % 4) * 2 + g * 8 + b, 0, gate_idx])
+            cumprod_vals = [cumprod_fp32[(k // 4) * 2 + (k % 2)] for k in range(num_vals)]
+
+            # ---- dO' restage: dO * cumprod_vals * scale -> shared_inp TMEM -----------
+            do_idx = do_index.idx
+            bars.mb_do_ready[do_idx].wait(do_index.phase)
+            do_index = advance(do_index, cfg.smem_do_stages)
+            do_regs = [[cutlass.Float32(0.0), cutlass.Float32(0.0)] for _ in range(32)]
+            for c in cutlass.range_constexpr(8):
+                m0 = cutlass.const_expr(c % 4)
+                sub = cutlass.const_expr(c // 4)
+                do_frag = nvvm.ldmatrix(
+                    (
+                        sdO_base
+                        + do_idx * do_stage_elems
+                        + frag_slab_off
+                        + (frag_row + m0 * 16) * 64
+                        + smem_64x64_offset(frag_row + m0 * 16, frag_col + sub * 16)
+                    ).raw_ptr(),
+                    4,
+                    nvvm.MMALayout.COL,
+                )
+                for i in cutlass.range_constexpr(4):
+                    lo, hi = f16x2_to_f32(do_frag[i], dtype=cfg.io_dtype)
+                    p0, p1 = fmul2(
+                        lo, hi, cumprod_vals[8 * m0 + 2 * i], cumprod_vals[8 * m0 + 2 * i + 1]
+                    )
+                    do_regs[8 * m0 + 2 * i][sub], do_regs[8 * m0 + 2 * i + 1][sub] = fmul2(
+                        p0, p1, scale, scale
+                    )
+            for sub in cutlass.range_constexpr(2):
+                do_pack = [
+                    fp32_to_fp16(do_regs[2 * j][sub], do_regs[2 * j + 1][sub], dtype=cfg.io_dtype)
+                    for j in range(16)
+                ]
+                nvvm.tcgen05_st(
+                    "16x128b",
+                    nvvm.make_tmem_ptr(
+                        ((tmem_warp_row + sub * 16) << 16) + tmem_do_prime_col, cutlass.Int32
+                    ),
+                    cutlass.Vector.from_elements(tuple(do_pack), cutlass.Int32),
+                )
+            nvvm.tcgen05_wait("store")
+            bars.mb_do_prime_inp_ready[0].arrive()
+
+            # ---- dV inter: in-place decay scale ----------------------------------
+            if have_dstate:
+                last_cumsumlog = sCumsumlog[cfg.b_t - 1, 0, gate_idx]
+                col_cs_fp32 = []
+                for g in cutlass.range_constexpr(8):
+                    for b in cutlass.range_constexpr(2):
+                        col_cs_fp32.append(sCumsumlog[(lane_id % 4) * 2 + g * 8 + b, 0, gate_idx])
+                decay_scale_fp32 = []
+                for i in cutlass.range_constexpr(16):
+                    decay_scale_fp32.append(
+                        cute.math.exp2(last_cumsumlog - col_cs_fp32[i], fastmath=True)
+                    )
+                decay_scale_vals = [
+                    decay_scale_fp32[(k // 4) * 2 + (k % 2)] for k in range(num_vals)
+                ]
+                bars.mb_du_scale_acc_ready[0].wait(cg1_du_scale_ready.phase)
+                cg1_du_scale_ready = advance(cg1_du_scale_ready, 1)
+                dv_ptrs = []
+                dv_vecs = []
+                for sub in cutlass.range_constexpr(2):
+                    dv_ptrs.append(
+                        nvvm.make_tmem_ptr(
+                            ((tmem_warp_row + sub * 16) << 16) + tmem_dvdk_acc_col, cutlass.Float32
+                        )
+                    )
+                    dv_vecs.append(nvvm.tcgen05_ld("16x256b", dv_ptrs[sub], num=8))
+                for sub in cutlass.range_constexpr(2):
+                    dv_scaled = []
+                    for j in cutlass.range_constexpr(16):
+                        s0, s1 = fmul2(
+                            dv_vecs[sub][2 * j],
+                            dv_vecs[sub][2 * j + 1],
+                            decay_scale_vals[2 * j],
+                            decay_scale_vals[2 * j + 1],
+                        )
+                        dv_scaled += [s0, s1]
+                    nvvm.tcgen05_st(
+                        "16x256b",
+                        dv_ptrs[sub],
+                        cutlass.Vector.from_elements(tuple(dv_scaled), cutlass.Float32),
+                    )
+                nvvm.tcgen05_wait("store")
+                bars.mb_du_scale_acc_done[0].arrive()
+
+            # ---- Y staging:  Y = V - cumprod*(K @ state) -> f16 TMEM slots -----------
+            v_idx = v_index.idx
+            bars.mb_v_ready[v_idx].wait(v_index.phase)
+            v_index = advance(v_index, cfg.smem_v_stages)
+            if chunk_idx >= FIRST_STATE_CHUNK:
+                v_frags = [[cutlass.Int32(0), cutlass.Int32(0)] for _ in range(16)]
+                for c in cutlass.range_constexpr(8):
+                    m0 = cutlass.const_expr(c % 4)
+                    sub = cutlass.const_expr(c // 4)
+                    v_frag = nvvm.ldmatrix(
+                        (
+                            sV_base
+                            + v_idx * v_stage_elems
+                            + frag_slab_off
+                            + (frag_row + m0 * 16) * 64
+                            + smem_64x64_offset(frag_row + m0 * 16, frag_col + sub * 16)
+                        ).raw_ptr(),
+                        4,
+                        nvvm.MMALayout.COL,
+                    )
+                    for i in cutlass.range_constexpr(4):
+                        v_frags[4 * m0 + i][sub] = v_frag[i]
+                bars.mb_k_state_acc_ready[0].wait(cg1_k_state_ready.phase)
+                cg1_k_state_ready = advance(cg1_k_state_ready, 1)
+                for sub in cutlass.range_constexpr(2):
+                    k_state_vec = nvvm.tcgen05_ld(
+                        "16x256b",
+                        nvvm.make_tmem_ptr(
+                            ((tmem_warp_row + sub * 16) << 16) + tmem_k_state_col, cutlass.Float32
+                        ),
+                        num=8,
+                    )
+                    g_k_state_pack = []
+                    y_pack = []
+                    for j in cutlass.range_constexpr(16):
+                        g0, g1 = fmul2(
+                            k_state_vec[2 * j],
+                            k_state_vec[2 * j + 1],
+                            cumprod_vals[2 * j],
+                            cumprod_vals[2 * j + 1],
+                        )
+                        g_k_state_word = fp32_to_fp16(g0, g1, dtype=cfg.io_dtype)
+                        g_k_state_pack.append(g_k_state_word)
+                        y_pack.append(sub_f16x2(v_frags[j][sub], g_k_state_word, cfg.io_dtype))
+                    nvvm.tcgen05_st(
+                        "16x128b",
+                        nvvm.make_tmem_ptr(
+                            ((tmem_warp_row + sub * 16) << 16) + tmem_y_col, cutlass.Int32
+                        ),
+                        cutlass.Vector.from_elements(tuple(y_pack), cutlass.Int32),
+                    )
+                    nvvm.tcgen05_st(
+                        "16x128b",
+                        nvvm.make_tmem_ptr(
+                            ((tmem_warp_row + sub * 16) << 16) + tmem_g_k_state_col, cutlass.Int32
+                        ),
+                        cutlass.Vector.from_elements(tuple(g_k_state_pack), cutlass.Int32),
+                    )
+            if chunk_idx < FIRST_STATE_CHUNK:
+                for sub in cutlass.range_constexpr(2):
+                    v_pack = []
+                    for m0 in cutlass.range_constexpr(4):
+                        v_frag = nvvm.ldmatrix(
+                            (
+                                sV_base
+                                + v_idx * v_stage_elems
+                                + frag_slab_off
+                                + (frag_row + m0 * 16) * 64
+                                + smem_64x64_offset(frag_row + m0 * 16, frag_col + sub * 16)
+                            ).raw_ptr(),
+                            4,
+                            nvvm.MMALayout.COL,
+                        )
+                        for i in cutlass.range_constexpr(4):
+                            v_pack.append(v_frag[i])
+                    nvvm.tcgen05_st(
+                        "16x128b",
+                        nvvm.make_tmem_ptr(
+                            ((tmem_warp_row + sub * 16) << 16) + tmem_y_col, cutlass.Int32
+                        ),
+                        cutlass.Vector.from_elements(tuple(v_pack), cutlass.Int32),
+                    )
+            nvvm.tcgen05_wait("store")
+            bars.mb_y_ready[0].arrive()
+
+            # ---- dU restage: dV acc ----------------------------------------------
+            bars.mb_du_total_acc_ready[0].wait(cg1_du_total_ready.phase)
+            cg1_du_total_ready = advance(cg1_du_total_ready, 1)
+            for sub in cutlass.range_constexpr(2):
+                du_vec = nvvm.tcgen05_ld(
+                    "16x256b",
+                    nvvm.make_tmem_ptr(
+                        ((tmem_warp_row + sub * 16) << 16) + tmem_dvdk_acc_col, cutlass.Float32
+                    ),
+                    num=8,
+                )
+                du_pack = [
+                    fp32_to_fp16(du_vec[2 * j], du_vec[2 * j + 1], dtype=cfg.io_dtype)
+                    for j in range(16)
+                ]
+                nvvm.tcgen05_st(
+                    "16x128b",
+                    nvvm.make_tmem_ptr(
+                        ((tmem_warp_row + sub * 16) << 16) + tmem_du_col, cutlass.Int32
+                    ),
+                    cutlass.Vector.from_elements(tuple(du_pack), cutlass.Int32),
+                )
+            nvvm.tcgen05_wait("store")
+            bars.mb_du_inp_ready[0].arrive()
+
+            # ---- U readout -------------------------------------------------------
+            bars.mb_u_acc_ready[0].wait(cg1_u_ready.phase)
+            cg1_u_ready = advance(cg1_u_ready, 1)
+            u_regs = []
+            for sub in cutlass.range_constexpr(2):
+                u_vec = nvvm.tcgen05_ld(
+                    "16x256b",
+                    nvvm.make_tmem_ptr(
+                        ((tmem_warp_row + sub * 16) << 16) + tmem_u_col, cutlass.Float32
+                    ),
+                    num=8,
+                )
+                u_regs.append([u_vec[k] for k in range(32)])
+            for sub in cutlass.range_constexpr(2):
+                for m0 in cutlass.range_constexpr(4):
+                    u_pack = [
+                        fp32_to_fp16(
+                            u_regs[sub][8 * m0 + 2 * j],
+                            u_regs[sub][8 * m0 + 2 * j + 1],
+                            dtype=cfg.io_dtype,
+                        )
+                        for j in range(4)
+                    ]
+                    nvvm.stmatrix(
+                        (
+                            sV_base
+                            + v_idx * v_stage_elems
+                            + frag_slab_off
+                            + (frag_row + m0 * 16) * 64
+                            + smem_64x64_offset(frag_row + m0 * 16, frag_col + sub * 16)
+                        ).raw_ptr(),
+                        u_pack,
+                        nvvm.MMALayout.COL,
+                    )
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_u_ready[0].arrive()
+
+            # ---- dY --------------------------------------------------------------
+            bars.mb_dy_acc_ready[0].wait(cg1_dy_ready.phase)
+            cg1_dy_ready = advance(cg1_dy_ready, 1)
+            dy_regs = []
+            for sub in cutlass.range_constexpr(2):
+                dy_vec = nvvm.tcgen05_ld(
+                    "16x256b",
+                    nvvm.make_tmem_ptr(
+                        ((tmem_warp_row + sub * 16) << 16) + tmem_dy_col, cutlass.Float32
+                    ),
+                    num=8,
+                )
+                dy_regs.append([dy_vec[k] for k in range(32)])
+
+            # ---- dY' = -cumprod_vals * dY -> f16 shared_inp --------------------------
+            neg_one = cutlass.Float32(-1.0)
+            cumprod_neg_vals = [cumprod_vals[k] * neg_one for k in range(32)]
+            for sub in cutlass.range_constexpr(2):
+                dyp = []
+                for j in cutlass.range_constexpr(16):
+                    n0, n1 = fmul2(
+                        dy_regs[sub][2 * j],
+                        dy_regs[sub][2 * j + 1],
+                        cumprod_neg_vals[2 * j],
+                        cumprod_neg_vals[2 * j + 1],
+                    )
+                    dyp += [n0, n1]
+                dyp_pack = [
+                    fp32_to_fp16(dyp[2 * j], dyp[2 * j + 1], dtype=cfg.io_dtype) for j in range(16)
+                ]
+                nvvm.tcgen05_st(
+                    "16x128b",
+                    nvvm.make_tmem_ptr(
+                        ((tmem_warp_row + sub * 16) << 16) + tmem_dyp_col, cutlass.Int32
+                    ),
+                    cutlass.Vector.from_elements(tuple(dyp_pack), cutlass.Int32),
+                )
+            nvvm.tcgen05_wait("store")
+            bars.mb_dyp_inp_ready[0].arrive()
+
+            # ---- dV staging: dV = dY -> the sdV slot -----------------------------
+            dv_stg_idx = dv_index.idx
+            bars.mb_dv_tmastg_done[dv_stg_idx].wait(dv_index.phase)
+            dv_index = advance(dv_index, cfg.smem_dv_stages)
+            bars.mb_sdv_done[0].wait(sdv_done_index.phase)
+            sdv_done_index = advance(sdv_done_index, 1)
+            for sub in cutlass.range_constexpr(2):
+                for m0 in cutlass.range_constexpr(4):
+                    dv_pack = [
+                        fp32_to_fp16(
+                            dy_regs[sub][8 * m0 + 2 * j],
+                            dy_regs[sub][8 * m0 + 2 * j + 1],
+                            dtype=cfg.io_dtype,
+                        )
+                        for j in range(4)
+                    ]
+                    nvvm.stmatrix(
+                        (
+                            sdV_base
+                            + dv_stg_idx * dv_stage_elems
+                            + frag_slab_off
+                            + (frag_row + m0 * 16) * 64
+                            + smem_64x64_offset(frag_row + m0 * 16, frag_col + sub * 16)
+                        ).raw_ptr(),
+                        dv_pack,
+                        nvvm.MMALayout.COL,
+                    )
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_dv_tmastg_ready[dv_stg_idx].arrive()
+            dq_stg_idx = dq_index.idx
+            bars.mb_dq_tmastg_done[dq_stg_idx].wait(dq_index.phase)
+            dq_index = advance(dq_index, cfg.smem_dq_stages)
+            sred = sred_base + dq_stg_idx * (dq_stage_elems // 2)
+
+            # ---- dBeta/dGate V-terms: dBeta_t += rowsum(dV ⊙ Y)_t / Beta_t -------
+            part_y = [cutlass.Float32(0.0)] * 16
+            for sub in cutlass.range_constexpr(2):
+                y_vec = nvvm.tcgen05_ld(
+                    "16x128b",
+                    nvvm.make_tmem_ptr(
+                        ((tmem_warp_row + sub * 16) << 16) + tmem_y_col, cutlass.Int32
+                    ),
+                    num=8,
+                )
+                for j in cutlass.range_constexpr(16):
+                    lo, hi = f16x2_to_f32(y_vec[j], dtype=cfg.io_dtype)
+                    frag_e0 = cutlass.const_expr(2 * j)
+                    part_e0 = cutlass.const_expr((frag_e0 // 4) * 2 + (frag_e0 % 2))
+                    if cutlass.const_expr(sub == 0 and j % 2 == 0):
+                        part_y[part_e0], part_y[part_e0 + 1] = fmul2(
+                            dy_regs[sub][frag_e0], dy_regs[sub][frag_e0 + 1], lo, hi
+                        )
+                    else:
+                        part_y[part_e0], part_y[part_e0 + 1] = ffma2(
+                            dy_regs[sub][frag_e0],
+                            dy_regs[sub][frag_e0 + 1],
+                            lo,
+                            hi,
+                            part_y[part_e0],
+                            part_y[part_e0 + 1],
+                        )
+            py_lo, py_hi = warp_reduce_scatter_frag_16_elems(part_y, lane_id)
+            vt_tok0 = (lane_id // 4) * 8 + (lane_id % 4) * 2
+            if chunk_idx >= FIRST_STATE_CHUNK:
+                part_g = [cutlass.Float32(0.0)] * 16
+                for sub in cutlass.range_constexpr(2):
+                    g_k_state_vec = nvvm.tcgen05_ld(
+                        "16x128b",
+                        nvvm.make_tmem_ptr(
+                            ((tmem_warp_row + sub * 16) << 16) + tmem_g_k_state_col, cutlass.Int32
+                        ),
+                        num=8,
+                    )
+                    for j in cutlass.range_constexpr(16):
+                        lo, hi = f16x2_to_f32(g_k_state_vec[j], dtype=cfg.io_dtype)
+                        frag_e0 = cutlass.const_expr(2 * j)
+                        part_e0 = cutlass.const_expr((frag_e0 // 4) * 2 + (frag_e0 % 2))
+                        if cutlass.const_expr(sub == 0 and j % 2 == 0):
+                            part_g[part_e0], part_g[part_e0 + 1] = fmul2(
+                                dy_regs[sub][frag_e0], dy_regs[sub][frag_e0 + 1], lo, hi
+                            )
+                        else:
+                            part_g[part_e0], part_g[part_e0 + 1] = ffma2(
+                                dy_regs[sub][frag_e0],
+                                dy_regs[sub][frag_e0 + 1],
+                                lo,
+                                hi,
+                                part_g[part_e0],
+                                part_g[part_e0 + 1],
+                            )
+                pg_lo, pg_hi = warp_reduce_scatter_frag_16_elems(part_g, lane_id)
+                (sred + cg1_warp_id * 64 + vt_tok0).store(py_lo)
+                (sred + cg1_warp_id * 64 + vt_tok0 + 1).store(py_hi)
+                (sred + 256 + cg1_warp_id * 64 + vt_tok0).store(pg_lo)
+                (sred + 256 + cg1_warp_id * 64 + vt_tok0 + 1).store(pg_hi)
+                nvvm.barrier_cta_sync_aligned(
+                    cfg.cg1_barrier_id, thread_count=cfg.cg1_barrier_threads
+                )
+                if cg1_tidx < 64:
+                    binv_t = cute.math.rcp(
+                        sBeta[cg1_tidx, 0, beta_idx] + cutlass.Float32(1e-10),
+                        approx=True,
+                        ftz=True,
+                    )
+                    ysum = (
+                        (sred + cg1_tidx).load()
+                        + (sred + 64 + cg1_tidx).load()
+                        + (sred + 128 + cg1_tidx).load()
+                        + (sred + 192 + cg1_tidx).load()
+                    )
+                    gsum = (
+                        (sred + 256 + cg1_tidx).load()
+                        + (sred + 320 + cg1_tidx).load()
+                        + (sred + 384 + cg1_tidx).load()
+                        + (sred + 448 + cg1_tidx).load()
+                    )
+                    sBeta[cg1_tidx, 0, beta_idx] = ysum * binv_t
+                    sCumsumlog[cg1_tidx, 0, gate_idx] = cutlass.Float32(0.0) - gsum
+            if chunk_idx < FIRST_STATE_CHUNK:
+                (sred + cg1_warp_id * 64 + vt_tok0).store(py_lo)
+                (sred + cg1_warp_id * 64 + vt_tok0 + 1).store(py_hi)
+                nvvm.barrier_cta_sync_aligned(
+                    cfg.cg1_barrier_id, thread_count=cfg.cg1_barrier_threads
+                )
+                if cg1_tidx < 64:
+                    binv_t = cute.math.rcp(
+                        sBeta[cg1_tidx, 0, beta_idx] + cutlass.Float32(1e-10),
+                        approx=True,
+                        ftz=True,
+                    )
+                    ysum = (
+                        (sred + cg1_tidx).load()
+                        + (sred + 64 + cg1_tidx).load()
+                        + (sred + 128 + cg1_tidx).load()
+                        + (sred + 192 + cg1_tidx).load()
+                    )
+                    sBeta[cg1_tidx, 0, beta_idx] = ysum * binv_t
+                    sCumsumlog[cg1_tidx, 0, gate_idx] = cutlass.Float32(0.0)
+            bars.mb_beta_done[beta_idx].arrive()
+            bars.mb_dbeta_cg1_ready[0].arrive()
+            nvvm.barrier_cta_sync_aligned(cfg.cg1_barrier_id, thread_count=cfg.cg1_barrier_threads)
+
+            # ---- Q fragments held in registers -----------------------------------
+            q_frag = []
+            for sub in cutlass.range_constexpr(2):
+                q_words = []
+                for m0 in cutlass.range_constexpr(4):
+                    q_f16 = nvvm.ldmatrix(
+                        (
+                            sQ_base
+                            + frag_slab_off
+                            + (frag_row + m0 * 16) * 64
+                            + smem_64x64_offset(frag_row + m0 * 16, frag_col + sub * 16)
+                        ).raw_ptr(),
+                        4,
+                        nvvm.MMALayout.COL,
+                    )
+                    for i in cutlass.range_constexpr(4):
+                        q_words.append(q_f16[i])
+                q_frag.append(q_words)
+                nvvm.tcgen05_st(
+                    "16x128b",
+                    nvvm.make_tmem_ptr(
+                        ((tmem_warp_row + sub * 16) << 16) + tmem_y_col, cutlass.Int32
+                    ),
+                    cutlass.Vector.from_elements(tuple(q_words), cutlass.Int32),
+                )
+            nvvm.tcgen05_wait("store")
+            bars.mb_q_cg1_done[0].arrive()
+
+            # ---- dQ final read -> sdQ --------------------------------------------
+            bars.mb_dq_acc_total_ready[0].wait(dq_total_ready_index.phase)
+            dq_total_ready_index = advance(dq_total_ready_index, 1)
+            dq_regs = []
+            for sub in cutlass.range_constexpr(2):
+                dq_vec = nvvm.tcgen05_ld(
+                    "16x256b",
+                    nvvm.make_tmem_ptr(
+                        ((tmem_warp_row + sub * 16) << 16) + tmem_dstate_inp_col, cutlass.Float32
+                    ),
+                    num=8,
+                )
+                dq_regs.append([dq_vec[k] for k in range(32)])
+                for m0 in cutlass.range_constexpr(4):
+                    frag_addr = (
+                        frag_slab_off
+                        + (frag_row + m0 * 16) * 64
+                        + smem_64x64_offset(frag_row + m0 * 16, frag_col + sub * 16)
+                    )
+                    dq_pack = [
+                        fp32_to_fp16(
+                            dq_vec[8 * m0 + 2 * j], dq_vec[8 * m0 + 2 * j + 1], dtype=cfg.io_dtype
+                        )
+                        for j in range(4)
+                    ]
+                    nvvm.stmatrix(
+                        (sdQ_base + dq_stg_idx * dq_stage_elems + frag_addr).raw_ptr(),
+                        dq_pack,
+                        nvvm.MMALayout.COL,
+                    )
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_dq_acc_total_done[0].arrive()
+            bars.mb_dq_tmastg_ready[dq_stg_idx].arrive()
+
+            # ---- dQ dot (part_q) -------------------------------------------------
+            part_q = [cutlass.Float32(0.0)] * 16
+            for sub in cutlass.range_constexpr(2):
+                for m0 in cutlass.range_constexpr(4):
+                    for i in cutlass.range_constexpr(4):
+                        q_lo, q_hi = f16x2_to_f32(q_frag[sub][4 * m0 + i], dtype=cfg.io_dtype)
+                        frag_e0 = cutlass.const_expr(8 * m0 + 2 * i)
+                        part_e0 = cutlass.const_expr((frag_e0 // 4) * 2 + (frag_e0 % 2))
+                        if cutlass.const_expr(sub == 0 and i % 2 == 0):
+                            part_q[part_e0], part_q[part_e0 + 1] = fmul2(
+                                dq_regs[sub][frag_e0], dq_regs[sub][frag_e0 + 1], q_lo, q_hi
+                            )
+                        else:
+                            part_q[part_e0], part_q[part_e0 + 1] = ffma2(
+                                dq_regs[sub][frag_e0],
+                                dq_regs[sub][frag_e0 + 1],
+                                q_lo,
+                                q_hi,
+                                part_q[part_e0],
+                                part_q[part_e0 + 1],
+                            )
+            part_q_lo, part_q_hi = warp_reduce_scatter_frag_16_elems(part_q, lane_id)
+            tok0 = (lane_id // 4) * 8 + (lane_id % 4) * 2
+            (sdstate_red + (cg1_tidx // 32) * 64 + tok0).store(part_q_lo)
+            (sdstate_red + (cg1_tidx // 32) * 64 + tok0 + 1).store(part_q_hi)
+            nvvm.barrier_cta_sync_aligned(cfg.cg1_barrier_id, thread_count=cfg.cg1_barrier_threads)
+            if cg1_tidx < 64:
+                pq_sum = (
+                    (sdstate_red + cg1_tidx).load()
+                    + (sdstate_red + 64 + cg1_tidx).load()
+                    + (sdstate_red + 128 + cg1_tidx).load()
+                    + (sdstate_red + 192 + cg1_tidx).load()
+                )
+                sCumsumlog[cg1_tidx, 0, gate_idx] = sCumsumlog[cg1_tidx, 0, gate_idx] + pq_sum
+            bars.mb_gate_done[gate_idx].arrive()
+            bars.mb_dgate_cg1_ready[0].arrive()
+
+            # ---- NEXT-CHUNK dstate prep ----------------------------------------------
+            if chunk_idx >= wstart + 1:
+                dstate_idx = dstate_acc_index.idx
+                bars.mb_dstate_acc_ready[dstate_idx].wait(dstate_acc_index.phase)
+                dstate_acc_index = advance(dstate_acc_index, cfg.tmem_dstate_acc_stages)
+                dstate_done_idx = dstate_idx
+                dstate_inp_idx = dstate_inp_index.idx
+                bars.mb_dstate_inp_done[dstate_inp_idx].wait(dstate_inp_index.phase)
+                dstate_inp_index = advance(dstate_inp_index, cfg.tmem_dstate_inp_stages)
+                dstate_regs = [
+                    [cutlass.Float32(0.0) for _ in range(num_state_subs)] for _ in range(32)
+                ]
+                for sub in cutlass.range_constexpr(num_state_subs):
+                    dstate_vec = nvvm.tcgen05_ld(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(
+                            (tmem_warp_row << 16) + tmem_dstate_acc_col + sub * ldtm_width,
+                            cutlass.Float32,
+                        ),
+                        num=32,
+                    )
+                    for k in cutlass.range_constexpr(32):
+                        dstate_regs[k][sub] = dstate_vec[k]
+
+                    dstate_pack = [
+                        fp32_to_fp16(
+                            dstate_regs[2 * j][sub],
+                            dstate_regs[2 * j + 1][sub],
+                            dtype=cfg.io_dtype,
+                        )
+                        for j in range(16)
+                    ]
+                    nvvm.tcgen05_st(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(
+                            (tmem_warp_row << 16) + tmem_dstate_inp_col + sub * sttm_width,
+                            cutlass.Int32,
+                        ),
+                        cutlass.Vector.from_elements(tuple(dstate_pack), cutlass.Int32),
+                    )
+                nvvm.tcgen05_wait("store")
+                bars.mb_dstate_inp_ready[dstate_inp_idx].arrive()
+
+            # ---- dK fold ---------------------------------------------------------
+            dk_stg_idx = dk_index.idx
+            bars.mb_dk_tmastg_done[dk_stg_idx].wait(dk_index.phase)
+            dk_index = advance(dk_index, cfg.smem_dk_stages)
+            if chunk_idx >= FIRST_STATE_CHUNK:
+                bars.mb_dk_state_path_acc_ready[0].wait(cg1_dk_state_path_ready.phase)
+                cg1_dk_state_path_ready = advance(cg1_dk_state_path_ready, 1)
+                dk_state_path_vecs = []
+                for sub in cutlass.range_constexpr(2):
+                    dk_state_path_vecs.append(
+                        nvvm.tcgen05_ld(
+                            "16x256b",
+                            nvvm.make_tmem_ptr(
+                                ((tmem_warp_row + sub * 16) << 16) + tmem_dk_state_path_col,
+                                cutlass.Float32,
+                            ),
+                            num=8,
+                        )
+                    )
+                nvvm.tcgen05_wait("load")
+                dk_state_path_regs = []
+                for sub in cutlass.range_constexpr(2):
+                    dk_state_path_row = []
+                    for j in cutlass.range_constexpr(16):
+                        n0, n1 = fmul2(
+                            dk_state_path_vecs[sub][2 * j],
+                            dk_state_path_vecs[sub][2 * j + 1],
+                            cumprod_neg_vals[2 * j],
+                            cumprod_neg_vals[2 * j + 1],
+                        )
+                        dk_state_path_row += [n0, n1]
+                    dk_state_path_regs.append(dk_state_path_row)
+
+                bars.mb_dk_total_acc_ready[0].wait(cg1_dk_total_ready.phase)
+                cg1_dk_total_ready = advance(cg1_dk_total_ready, 1)
+                dmr_vecs = []
+                for sub in cutlass.range_constexpr(2):
+                    dmr_vecs.append(
+                        nvvm.tcgen05_ld(
+                            "16x256b",
+                            nvvm.make_tmem_ptr(
+                                ((tmem_warp_row + sub * 16) << 16) + tmem_dvdk_acc_col,
+                                cutlass.Float32,
+                            ),
+                            num=8,
+                        )
+                    )
+                nvvm.tcgen05_wait("load")
+                bars.mb_dk_total_acc_done[0].arrive()
+                for sub in cutlass.range_constexpr(2):
+                    dk_sum = [dmr_vecs[sub][k] + dk_state_path_regs[sub][k] for k in range(32)]
+                    for m0 in cutlass.range_constexpr(4):
+                        dk_pack = [
+                            fp32_to_fp16(
+                                dk_sum[8 * m0 + 2 * j],
+                                dk_sum[8 * m0 + 2 * j + 1],
+                                dtype=cfg.io_dtype,
+                            )
+                            for j in range(4)
+                        ]
+                        nvvm.stmatrix(
+                            (
+                                sdK_base
+                                + dk_stg_idx * dk_stage_elems
+                                + frag_slab_off
+                                + (frag_row + m0 * 16) * 64
+                                + smem_64x64_offset(frag_row + m0 * 16, frag_col + sub * 16)
+                            ).raw_ptr(),
+                            dk_pack,
+                            nvvm.MMALayout.COL,
+                        )
+                nvvm.fence_proxy("async.shared", space="cta")
+                bars.mb_dk_tmastg_ready[dk_stg_idx].arrive()
+            if chunk_idx < FIRST_STATE_CHUNK:
+                bars.mb_dk_total_acc_ready[0].wait(cg1_dk_total_ready.phase)
+                cg1_dk_total_ready = advance(cg1_dk_total_ready, 1)
+                dmr_vecs = []
+                for sub in cutlass.range_constexpr(2):
+                    dmr_vecs.append(
+                        nvvm.tcgen05_ld(
+                            "16x256b",
+                            nvvm.make_tmem_ptr(
+                                ((tmem_warp_row + sub * 16) << 16) + tmem_dvdk_acc_col,
+                                cutlass.Float32,
+                            ),
+                            num=8,
+                        )
+                    )
+                nvvm.tcgen05_wait("load")
+                bars.mb_dk_total_acc_done[0].arrive()
+                for sub in cutlass.range_constexpr(2):
+                    for m0 in cutlass.range_constexpr(4):
+                        dk_pack = [
+                            fp32_to_fp16(
+                                dmr_vecs[sub][8 * m0 + 2 * j],
+                                dmr_vecs[sub][8 * m0 + 2 * j + 1],
+                                dtype=cfg.io_dtype,
+                            )
+                            for j in range(4)
+                        ]
+                        nvvm.stmatrix(
+                            (
+                                sdK_base
+                                + dk_stg_idx * dk_stage_elems
+                                + frag_slab_off
+                                + (frag_row + m0 * 16) * 64
+                                + smem_64x64_offset(frag_row + m0 * 16, frag_col + sub * 16)
+                            ).raw_ptr(),
+                            dk_pack,
+                            nvvm.MMALayout.COL,
+                        )
+                nvvm.fence_proxy("async.shared", space="cta")
+                bars.mb_dk_tmastg_ready[dk_stg_idx].arrive()
+
+            # ---- dstate prep ---------------------------------------------------------
+            if chunk_idx >= wstart + 1:
+                bars.mb_state_dot_dstate_done[0].wait(cg1_state_dot_dstate_index.phase)
+                cg1_state_dot_dstate_index = advance(cg1_state_dot_dstate_index, 1)
+                for sub in cutlass.range_constexpr(num_state_subs):
+                    dstate_smem_vec = nvvm.tcgen05_ld(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(
+                            (tmem_warp_row << 16) + tmem_dstate_acc_col + sub * ldtm_width,
+                            cutlass.Float32,
+                        ),
+                        num=32,
+                    )
+                    for g in cutlass.range_constexpr(ldtm_width // 8):
+                        dstate_smem_pack = tuple(
+                            fp32_to_fp16(
+                                dstate_smem_vec[g * 8 + 2 * t],
+                                dstate_smem_vec[g * 8 + 2 * t + 1],
+                                dtype=cfg.io_dtype,
+                            )
+                            for t in range(4)
+                        )
+                        dstate_dk = sub * ldtm_width + g * 8
+                        dstate_addr = (
+                            (dstate_dk // 64) * (cfg.d_v * 64)
+                            + cg1_tidx * 64
+                            + smem_64x64_offset(cg1_tidx, dstate_dk % 64)
+                        )
+                        cutlass.inttoptr(
+                            sDstate_base_int + dstate_addr * 2,
+                            cutlass.AddressSpace.smem,
+                            cfg.io_dtype,
+                        ).store(
+                            cutlass.Vector.from_elements(dstate_smem_pack, cutlass.Int32).bitcast(
+                                cfg.io_dtype
+                            ),
+                            alignment=16,
+                        )
+                nvvm.fence_proxy("async.shared", space="cta")
+                bars.mb_dstate_smem_ready[0].arrive()
+
+            if chunk_idx < wstart + 1:
+                cg1_state_dot_dstate_index = advance(cg1_state_dot_dstate_index, 1)
+
+        # ---- dstate drain: with an initial state this is d_initial_state ----------------------
+        if num_item_chunks > 0:
+            dstate_idx = dstate_acc_index.idx
+            bars.mb_dstate_acc_ready[dstate_idx].wait(dstate_acc_index.phase)
+            dstate_acc_index = advance(dstate_acc_index, cfg.tmem_dstate_acc_stages)
+            if cutlass.const_expr(cfg.use_dstate0):
+                if wstart == 0:
+                    gDstate0 = mDstate0_out[None, None, head_idx, batch_idx]
+                    for sub in cutlass.range_constexpr(num_state_subs):
+                        dstate0_vec = nvvm.tcgen05_ld(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(
+                                (tmem_warp_row << 16) + tmem_dstate_acc_col + sub * ldtm_width,
+                                cutlass.Float32,
+                            ),
+                            num=32,
+                        )
+                        for kk in cutlass.range_constexpr(32):
+                            gDstate0[cg1_tidx, sub * ldtm_width + kk] = dstate0_vec[kk]
+            if cutlass.const_expr(not cfg.use_dstate_in):
+                bars.mb_dstate_scale_acc_done[dstate_idx].arrive()
+        else:
+            if cutlass.const_expr(cfg.use_dstate0):
+                write_passthrough = wstart == 0
+                if write_passthrough:
+                    gDstate0 = mDstate0_out[None, None, head_idx, batch_idx]
+                    if cutlass.const_expr(cfg.use_dstate_in):
+                        gDstate_in = mDstate_in[None, None, head_idx, batch_idx]
+                        for sub in cutlass.range_constexpr(num_state_subs):
+                            for kk in cutlass.range_constexpr(32):
+                                gDstate0[cg1_tidx, sub * ldtm_width + kk] = gDstate_in[
+                                    cg1_tidx, sub * ldtm_width + kk
+                                ]
+                    else:
+                        for sub in cutlass.range_constexpr(num_state_subs):
+                            for kk in cutlass.range_constexpr(32):
+                                gDstate0[cg1_tidx, sub * ldtm_width + kk] = cutlass.Float32(0.0)
+
+        tile_idx, sched_state = sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas)
+
+    bars.mb_tmem_done[0].arrive()
+
+    for _ in range(cfg.tmem_dstate_inp_stages):
+        bars.mb_dstate_inp_done[dstate_inp_index.idx].wait(dstate_inp_index.phase)
+        dstate_inp_index = advance(dstate_inp_index, cfg.tmem_dstate_inp_stages)
+    for _ in range(cfg.smem_dk_stages):
+        bars.mb_dk_tmastg_done[dk_index.idx].wait(dk_index.phase)
+        dk_index = advance(dk_index, cfg.smem_dk_stages)
+    for _ in range(cfg.smem_dv_stages):
+        bars.mb_dv_tmastg_done[dv_index.idx].wait(dv_index.phase)
+        dv_index = advance(dv_index, cfg.smem_dv_stages)
+
+
+@cute.jit
+def build_descs_body(
+    widx,
+    base_q,
+    base_k,
+    base_v,
+    base_do,
+    base_checkpoint,
+    base_dq,
+    base_dk,
+    base_dv,
+    desc_ws: cute.Tensor,
+    cu_seqlens: cute.Tensor,
+    q: cute.Tensor,
+    k: cute.Tensor,
+    v: cute.Tensor,
+    do: cute.Tensor,
+    state_checkpoints: cute.Tensor,
+    dq: cute.Tensor,
+    dk: cute.Tensor,
+    dv: cute.Tensor,
+    n_batch: cutlass.Int32,
+    q_row_stride: cutlass.Int64,
+    k_row_stride: cutlass.Int64,
+    v_row_stride: cutlass.Int64,
+    do_row_stride: cutlass.Int64,
+    checkpoint_row_stride: cutlass.Int64,
+    checkpoint_every_n: cutlass.Int32,
+    dq_row_stride: cutlass.Int64,
+    dk_row_stride: cutlass.Int64,
+    dv_row_stride: cutlass.Int64,
+) -> None:
+    """Build sequence-relative runtime TMA descriptors for each sequence."""
+    arr_words = n_batch * cutlass.Int32(TENSOR_MAP_QWORDS)
+    sub0 = cute.make_tensor(desc_ws.iterator, cute.make_layout((arr_words,), stride=(1,)))
+    sub1 = cute.make_tensor(
+        desc_ws.iterator + arr_words, cute.make_layout((arr_words,), stride=(1,))
+    )
+    sub2 = cute.make_tensor(
+        desc_ws.iterator + 2 * arr_words, cute.make_layout((arr_words,), stride=(1,))
+    )
+    sub3 = cute.make_tensor(
+        desc_ws.iterator + 3 * arr_words, cute.make_layout((arr_words,), stride=(1,))
+    )
+    sub4 = cute.make_tensor(
+        desc_ws.iterator + 4 * arr_words, cute.make_layout((arr_words,), stride=(1,))
+    )
+    sub5 = cute.make_tensor(
+        desc_ws.iterator + 5 * arr_words, cute.make_layout((arr_words,), stride=(1,))
+    )
+    sub6 = cute.make_tensor(
+        desc_ws.iterator + 6 * arr_words, cute.make_layout((arr_words,), stride=(1,))
+    )
+    sub7 = cute.make_tensor(
+        desc_ws.iterator + 7 * arr_words, cute.make_layout((arr_words,), stride=(1,))
+    )
+
+    if widx == 0 and nvvm.elect_sync():
+        emit_seq_load_descs(base_q, sub0, cu_seqlens, q, n_batch, q_row_stride, 2)
+        nvvm.fence_proxy_release(
+            nvvm.MemScope.GPU, from_proxy=nvvm.Proxy.GENERIC, to_proxy=nvvm.Proxy.TENSORMAP
+        )
+    if widx == 1 and nvvm.elect_sync():
+        emit_seq_load_descs(base_k, sub1, cu_seqlens, k, n_batch, k_row_stride, 2)
+        nvvm.fence_proxy_release(
+            nvvm.MemScope.GPU, from_proxy=nvvm.Proxy.GENERIC, to_proxy=nvvm.Proxy.TENSORMAP
+        )
+    if widx == 2 and nvvm.elect_sync():
+        emit_seq_load_descs(base_v, sub2, cu_seqlens, v, n_batch, v_row_stride, 2)
+        nvvm.fence_proxy_release(
+            nvvm.MemScope.GPU, from_proxy=nvvm.Proxy.GENERIC, to_proxy=nvvm.Proxy.TENSORMAP
+        )
+    if widx == 3 and nvvm.elect_sync():
+        emit_seq_load_descs(base_do, sub3, cu_seqlens, do, n_batch, do_row_stride, 2)
+        nvvm.fence_proxy_release(
+            nvvm.MemScope.GPU, from_proxy=nvvm.Proxy.GENERIC, to_proxy=nvvm.Proxy.TENSORMAP
+        )
+    if widx == 4 and nvvm.elect_sync():
+        emit_checkpoint_seq_descs(
+            base_checkpoint,
+            sub4,
+            cu_seqlens,
+            state_checkpoints,
+            n_batch,
+            checkpoint_row_stride,
+            checkpoint_every_n,
+            2,
+        )
+        nvvm.fence_proxy_release(
+            nvvm.MemScope.GPU, from_proxy=nvvm.Proxy.GENERIC, to_proxy=nvvm.Proxy.TENSORMAP
+        )
+    if widx == 5 and nvvm.elect_sync():
+        emit_seq_descs(base_dq, sub5, cu_seqlens, dq, n_batch, dq_row_stride, 2)
+        nvvm.fence_proxy_release(
+            nvvm.MemScope.GPU, from_proxy=nvvm.Proxy.GENERIC, to_proxy=nvvm.Proxy.TENSORMAP
+        )
+    if widx == 6 and nvvm.elect_sync():
+        emit_seq_descs(base_dk, sub6, cu_seqlens, dk, n_batch, dk_row_stride, 2)
+        nvvm.fence_proxy_release(
+            nvvm.MemScope.GPU, from_proxy=nvvm.Proxy.GENERIC, to_proxy=nvvm.Proxy.TENSORMAP
+        )
+    if widx == 7 and nvvm.elect_sync():
+        emit_seq_descs(base_dv, sub7, cu_seqlens, dv, n_batch, dv_row_stride, 2)
+        nvvm.fence_proxy_release(
+            nvvm.MemScope.GPU, from_proxy=nvvm.Proxy.GENERIC, to_proxy=nvvm.Proxy.TENSORMAP
+        )
+
+
+@cute.kernel
+def prologue_kernel(
+    run_order: cutlass.Constexpr[bool],
+    order_gen: cutlass.Constexpr[bool],
+    has_sched: cutlass.Constexpr[bool],
+    b_t: cutlass.Constexpr[int],
+    base_q: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    base_k: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    base_v: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    base_do: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    base_checkpoint: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    base_dq: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    base_dk: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    base_dv: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    desc_ws: cute.Tensor,
+    cu_seqlens: cute.Tensor,
+    q: cute.Tensor,
+    k: cute.Tensor,
+    v: cute.Tensor,
+    do: cute.Tensor,
+    state_checkpoints: cute.Tensor,
+    dq: cute.Tensor,
+    dk: cute.Tensor,
+    dv: cute.Tensor,
+    work_item_staging: cute.Tensor | None,
+    work_count: cute.Tensor,
+    work_items: cute.Tensor | None,
+    sched_all: cute.Tensor | None,
+    n_batch: cutlass.Int32,
+    q_row_stride: cutlass.Int64,
+    k_row_stride: cutlass.Int64,
+    v_row_stride: cutlass.Int64,
+    do_row_stride: cutlass.Int64,
+    checkpoint_row_stride: cutlass.Int64,
+    checkpoint_every_n: cutlass.Int32,
+    dq_row_stride: cutlass.Int64,
+    dk_row_stride: cutlass.Int64,
+    dv_row_stride: cutlass.Int64,
+) -> None:
+    """Order work and build the sequence-relative descriptor arrays."""
+    tidx, _, _ = cute.arch.thread_idx()
+    tidx = cutlass.Int32(tidx)
+    widx = tidx // cutlass.Int32(32)
+    if cutlass.const_expr(run_order):
+        s_key = cutlass.Array(
+            cutlass.Int32, ORDER_CAPACITY, space=cutlass.AddressSpace.smem, alignment=16
+        )
+        s_idx = cutlass.Array(
+            cutlass.Int32, ORDER_CAPACITY, space=cutlass.AddressSpace.smem, alignment=16
+        )
+        s_spread = cutlass.Array(cutlass.Int32, 2, space=cutlass.AddressSpace.smem, alignment=8)
+        heads_out = cutlass.Int32(do.shape[1])
+        order_body(
+            order_gen,
+            has_sched,
+            b_t,
+            ORDER_THREADS,
+            ORDER_ELEMS,
+            tidx,
+            heads_out,
+            heads_out * n_batch,
+            cu_seqlens,
+            work_item_staging,
+            work_count,
+            work_items,
+            sched_all,
+            s_key,
+            s_idx,
+            s_spread,
+        )
+    build_descs_body(
+        widx,
+        base_q,
+        base_k,
+        base_v,
+        base_do,
+        base_checkpoint,
+        base_dq,
+        base_dk,
+        base_dv,
+        desc_ws,
+        cu_seqlens,
+        q,
+        k,
+        v,
+        do,
+        state_checkpoints,
+        dq,
+        dk,
+        dv,
+        n_batch,
+        q_row_stride,
+        k_row_stride,
+        v_row_stride,
+        do_row_stride,
+        checkpoint_row_stride,
+        checkpoint_every_n,
+        dq_row_stride,
+        dk_row_stride,
+        dv_row_stride,
+    )
+
+
+@cute.jit
+def prologue(
+    io_dtype: cutlass.Constexpr,
+    b_t: cutlass.Constexpr[int],
+    run_order: cutlass.Constexpr[bool],
+    order_gen: cutlass.Constexpr[bool],
+    has_sched: cutlass.Constexpr[bool],
+    q: cute.Tensor,
+    k: cute.Tensor,
+    v: cute.Tensor,
+    do: cute.Tensor,
+    dq: cute.Tensor,
+    dk: cute.Tensor,
+    dv: cute.Tensor,
+    state_checkpoints: cute.Tensor,
+    cu_seqlens: cute.Tensor,
+    work_item_staging: cute.Tensor | None,
+    work_count: cute.Tensor,
+    work_items: cute.Tensor | None,
+    sched_all: cute.Tensor | None,
+    tensormap_workspace: cute.Tensor,
+    stream: cuda_driver.CUstream,
+) -> None:
+    """Build all TMA maps with sequence-relative token coordinates."""
+    h_q, h_k, h_v = q.shape[1], k.shape[1], v.shape[1]
+    heads_out = do.shape[1]
+    batch_size = cu_seqlens.shape[0] - 1
+    d_k, d_v = q.shape[2], v.shape[2]
+    seqlen = q.shape[0]
+    granule_elems = 128 // (io_dtype.width // 8)
+
+    q_headed = cute.make_tensor(
+        q.iterator, cute.make_layout((d_k, h_q, seqlen), stride=(1, q.stride[1], q.stride[0]))
+    )
+    k_headed = cute.make_tensor(
+        k.iterator, cute.make_layout((d_k, h_k, seqlen), stride=(1, k.stride[1], k.stride[0]))
+    )
+    v_headed = cute.make_tensor(
+        v.iterator, cute.make_layout((d_v, h_v, seqlen), stride=(1, v.stride[1], v.stride[0]))
+    )
+    do_headed = cute.make_tensor(
+        do.iterator,
+        cute.make_layout((d_v, heads_out, seqlen), stride=(1, do.stride[1], do.stride[0])),
+    )
+    dq_headed = cute.make_tensor(
+        dq.iterator, cute.make_layout((d_k, h_q, seqlen), stride=(1, dq.stride[1], dq.stride[0]))
+    )
+    dk_headed = cute.make_tensor(
+        dk.iterator, cute.make_layout((d_k, h_k, seqlen), stride=(1, dk.stride[1], dk.stride[0]))
+    )
+    dv_headed = cute.make_tensor(
+        dv.iterator, cute.make_layout((d_v, h_v, seqlen), stride=(1, dv.stride[1], dv.stride[0]))
+    )
+    swizzle = cuda.TensorMapSwizzle.s128b
+    base_q = cuda.create_tensor_map_tiled_from_view(
+        q_headed, box_dims=(granule_elems, 1, b_t), stride_order=(0, 1, 2), swizzle=swizzle
+    )
+    base_k = cuda.create_tensor_map_tiled_from_view(
+        k_headed, box_dims=(granule_elems, 1, b_t), stride_order=(0, 1, 2), swizzle=swizzle
+    )
+    base_v = cuda.create_tensor_map_tiled_from_view(
+        v_headed, box_dims=(granule_elems, 1, b_t), stride_order=(0, 1, 2), swizzle=swizzle
+    )
+    base_do = cuda.create_tensor_map_tiled_from_view(
+        do_headed, box_dims=(granule_elems, 1, b_t), stride_order=(0, 1, 2), swizzle=swizzle
+    )
+    base_dq = cuda.create_tensor_map_tiled_from_view(
+        dq_headed, box_dims=(granule_elems, 1, b_t), stride_order=(0, 1, 2), swizzle=swizzle
+    )
+    base_dk = cuda.create_tensor_map_tiled_from_view(
+        dk_headed, box_dims=(granule_elems, 1, b_t), stride_order=(0, 1, 2), swizzle=swizzle
+    )
+    base_dv = cuda.create_tensor_map_tiled_from_view(
+        dv_headed, box_dims=(granule_elems, 1, b_t), stride_order=(0, 1, 2), swizzle=swizzle
+    )
+    checkpoint_view = cute.make_tensor(
+        state_checkpoints.iterator,
+        cute.make_layout(
+            (
+                state_checkpoints.shape[3],
+                state_checkpoints.shape[2],
+                state_checkpoints.shape[0],
+                heads_out,
+            ),
+            stride=(
+                state_checkpoints.stride[3],
+                state_checkpoints.stride[2],
+                state_checkpoints.stride[0],
+                state_checkpoints.stride[1],
+            ),
+        ),
+    )
+    base_checkpoint = cuda.create_tensor_map_tiled_from_view(
+        checkpoint_view,
+        box_dims=(64, state_checkpoints.shape[2], 1, 1),
+        stride_order=(0, 1, 2, 3),
+        swizzle=swizzle,
+    )
+
+    prologue_kernel(
+        run_order,
+        order_gen,
+        has_sched,
+        b_t,
+        base_q,
+        base_k,
+        base_v,
+        base_do,
+        base_checkpoint,
+        base_dq,
+        base_dk,
+        base_dv,
+        tensormap_workspace,
+        cu_seqlens,
+        q,
+        k,
+        v,
+        do,
+        state_checkpoints,
+        dq,
+        dk,
+        dv,
+        work_item_staging,
+        work_count,
+        work_items,
+        sched_all,
+        cutlass.Int32(batch_size),
+        cutlass.Int64(q.stride[0]),
+        cutlass.Int64(k.stride[0]),
+        cutlass.Int64(v.stride[0]),
+        cutlass.Int64(do.stride[0]),
+        cutlass.Int64(state_checkpoints.stride[0]),
+        cutlass.Int32(b_t),
+        cutlass.Int64(dq.stride[0]),
+        cutlass.Int64(dk.stride[0]),
+        cutlass.Int64(dv.stride[0]),
+    ).launch(grid=(1, 1, 1), block=(ORDER_THREADS, 1, 1), stream=stream)
+
+
+class GdnBpropOp:
+    """Compile and launch one static BT=64 scalar-GDN backward configuration."""
+
+    def __init__(self, cfg: "GdnBwdCfg", use_int64_offsets: bool = False):
+        self.cfg = cfg
+        self.use_int64_offsets = use_int64_offsets
+
+    def get_name(self) -> str:
+        cfg = self.cfg
+        return (
+            f"gdn_mega_bprop_{cfg.io_dtype.__name__.lower()}_h{cfg.n_heads_out}"
+            f"_q{cfg.q_ratio}_k{cfg.k_ratio}_v{cfg.v_ratio}"
+            f"_s{int(cfg.use_dstate_in)}z{int(cfg.use_dstate0)}"
+            f"l{int(cfg.log_gate)}g{int(cfg.safe_gate)}b{int(cfg.beta_sigmoid)}"
+            f"i{int(cfg.use_initial_state)}d{int(cfg.dyn_sched)}"
+            f"_sm{cfg.max_active_clusters}_i64{int(self.use_int64_offsets)}"
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        gate: cute.Tensor,
+        a_log: cute.Tensor | None,
+        dt_bias: cute.Tensor | None,
+        beta: cute.Tensor,
+        dgate: cute.Tensor,
+        dbeta: cute.Tensor,
+        cu_seqlens: cute.Tensor,
+        d_initial_state: cute.Tensor | None,
+        d_final_state: cute.Tensor | None,
+        work_items: cute.Tensor,
+        work_count: cute.Tensor,
+        sched_ctr: cute.Tensor | None,
+        tensormap_workspace: cute.Tensor,
+        scale: cutlass.Float32,
+        stream,
+    ) -> None:
+        cfg = self.cfg
+        num_sequences = cu_seqlens.shape[0] - 1
+
+        @cute.struct
+        class SharedStorage:
+            q: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.q_cosize], cfg.buffer_align_bytes
+            ]
+            k: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.k_cosize], cfg.buffer_align_bytes
+            ]
+            do: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.do_cosize], cfg.buffer_align_bytes
+            ]
+            state: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.state_cosize], cfg.buffer_align_bytes
+            ]
+            t_inv: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.t_inv_cosize], cfg.buffer_align_bytes
+            ]
+            kk: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.t_inv_cosize], cfg.buffer_align_bytes
+            ]
+            a: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.a_cosize], cfg.buffer_align_bytes
+            ]
+            dm: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.a_cosize // cfg.smem_a_stages],
+                cfg.buffer_align_bytes,
+            ]
+            v: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.v_cosize], cfg.buffer_align_bytes
+            ]
+            dstate: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.d_k * cfg.d_v], cfg.buffer_align_bytes
+            ]
+            dq: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.dq_cosize], cfg.buffer_align_bytes
+            ]
+            dk: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.dk_cosize], cfg.buffer_align_bytes
+            ]
+            dv: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.dv_cosize], cfg.buffer_align_bytes
+            ]
+
+        kernel.set_name_prefix(self.get_name())
+        kernel(
+            cfg,
+            SharedStorage,
+            tensormap_workspace,
+            cutlass.Int32(num_sequences),
+            gate,
+            a_log,
+            dt_bias,
+            beta,
+            dgate,
+            dbeta,
+            cu_seqlens,
+            d_initial_state,
+            d_final_state,
+            work_items,
+            work_count,
+            sched_ctr,
+            scale,
+        ).launch(
+            grid=(cfg.max_active_clusters, 1, 1),
+            block=(cfg.threads_per_cta, 1, 1),
+            cluster=cfg.cluster_shape_mnk,
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
+
+
+@cute.kernel
+def kernel(
+    cfg: cutlass.Constexpr,
+    shared_type: cutlass.Constexpr,
+    tensormap_workspace: cute.Tensor,
+    n_desc: cutlass.Int32,
+    mGate: cute.Tensor,
+    mA_log: cute.Tensor | None,
+    mDt_bias: cute.Tensor | None,
+    mBeta: cute.Tensor,
+    mDgate: cute.Tensor,
+    mDbeta: cute.Tensor,
+    cu_seqlens: cute.Tensor,
+    mDstate0: cute.Tensor | None,
+    mDstate_in: cute.Tensor | None,
+    mWorkItems: cute.Tensor,
+    mCount: cute.Tensor,
+    mSched: cute.Tensor | None,
+    scale: cutlass.Float32,
+) -> None:
+    """Main scalar-GDN BT=64 backward kernel with persistent warp roles."""
+    tidx, _, _ = cute.arch.thread_idx()
+    warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+    bidx = cute.arch.block_idx()[0]
+    num_ctas = cute.arch.grid_dim()[0]
+    total_tiles = mCount[0]
+    assert mGate.element_type == cutlass.Float32
+    assert mBeta.element_type == cutlass.Float32
+    assert mDgate.element_type == cutlass.Float32
+    assert mDbeta.element_type == cutlass.Float32
+    assert cu_seqlens.element_type in (cutlass.Int32, cutlass.Int64)
+    if cutlass.const_expr(cfg.dyn_sched):
+        assert mSched is not None, "mSched must be provided if dyn_sched is True"
+
+    if cutlass.const_expr(mDstate0 is not None):
+        mDstate0 = cute.make_tensor(
+            mDstate0.iterator,
+            cute.make_layout(
+                (mDstate0.shape[2], mDstate0.shape[3], mDstate0.shape[1], mDstate0.shape[0]),
+                stride=(
+                    mDstate0.stride[2],
+                    mDstate0.stride[3],
+                    mDstate0.stride[1],
+                    mDstate0.stride[0],
+                ),
+            ),
+        )
+    if cutlass.const_expr(mDstate_in is not None):
+        mDstate_in = cute.make_tensor(
+            mDstate_in.iterator,
+            cute.make_layout(
+                (
+                    mDstate_in.shape[2],
+                    mDstate_in.shape[3],
+                    mDstate_in.shape[1],
+                    mDstate_in.shape[0],
+                ),
+                stride=(
+                    mDstate_in.stride[2],
+                    mDstate_in.stride[3],
+                    mDstate_in.stride[1],
+                    mDstate_in.stride[0],
+                ),
+            ),
+        )
+
+    desc_base_words = tensormap_workspace.iterator.raw_ptr()
+    desc_qwords = cutlass.Int32(TENSOR_MAP_QWORDS)
+    arr_words = n_desc * desc_qwords
+    desc_q_base = desc_base_words
+    desc_k_base = desc_base_words + arr_words
+    desc_v_base = desc_base_words + cutlass.Int32(2) * arr_words
+    desc_do_base = desc_base_words + cutlass.Int32(3) * arr_words
+    desc_checkpoint_base = desc_base_words + cutlass.Int32(4) * arr_words
+    desc_dq_base = desc_base_words + cutlass.Int32(5) * arr_words
+    desc_dk_base = desc_base_words + cutlass.Int32(6) * arr_words
+    desc_dv_base = desc_base_words + cutlass.Int32(7) * arr_words
+
+    SMEM = cutlass.AddressSpace.smem
+    bars = make_gdn_bars(cfg)
+    sSched = cutlass.Array(
+        cutlass.Int32, cfg.sched_stages, space=cutlass.AddressSpace.smem, alignment=16
+    )
+    tmem_base_slot = cutlass.Array(cutlass.Int32, 1, space=SMEM, alignment=16)
+    cumsumlog_smem_layout_staged = cute.make_layout((cfg.b_t, 1, cfg.smem_gate_stages))
+    beta_smem_layout_staged = cute.make_layout((cfg.b_t, 1, cfg.smem_beta_stages))
+    # Keep the scalar rings outside the 1 KiB-aligned operand struct so the
+    # double-buffered GDN pipeline fits in Blackwell's shared-memory limit.
+    cumsumlog_raw = cutlass.Array(
+        cutlass.Float32,
+        cute.cosize(cumsumlog_smem_layout_staged),
+        space=SMEM,
+        alignment=128,
+    )
+    cumprod_raw = cutlass.Array(
+        cutlass.Float32,
+        cute.cosize(cumsumlog_smem_layout_staged),
+        space=SMEM,
+        alignment=128,
+    )
+    beta_raw = cutlass.Array(
+        cutlass.Float32,
+        cute.cosize(beta_smem_layout_staged),
+        space=SMEM,
+        alignment=128,
+    )
+    storage = cutlass.utils.SmemAllocator().allocate(shared_type)
+
+    bpe = cfg.io_dtype.width // 8
+    SWZ = 2
+    LEAD = 16
+    STRIDE = 8 * 128
+    KT_LEAD = (cfg.d_v // 2) * 128
+    V_LEAD = (cfg.d_v // 2) * 128
+    STATE_LEAD = cfg.d_k * 128
+    sQ_raw = storage.q.get_tensor(cute.make_layout((cfg.q_cosize,)))
+    sQ = SmemTile(
+        base=smem_data_ptr(sQ_raw).toint(),
+        elems_per_stage=(cfg.q_cosize // cfg.smem_q_stages) * bpe,
+        stages=cfg.smem_q_stages,
+        leading_byte_offset=LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sK_raw = storage.k.get_tensor(cute.make_layout((cfg.k_cosize,)))
+    sK = SmemTile(
+        base=smem_data_ptr(sK_raw).toint(),
+        elems_per_stage=(cfg.k_cosize // cfg.smem_k_stages) * bpe,
+        stages=cfg.smem_k_stages,
+        leading_byte_offset=LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sK_trans = SmemTile(
+        base=smem_data_ptr(sK_raw).toint(),
+        elems_per_stage=(cfg.k_cosize // cfg.smem_k_stages) * bpe,
+        stages=cfg.smem_k_stages,
+        leading_byte_offset=KT_LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sQ_trans = SmemTile(
+        base=smem_data_ptr(sQ_raw).toint(),
+        elems_per_stage=(cfg.q_cosize // cfg.smem_q_stages) * bpe,
+        stages=cfg.smem_q_stages,
+        leading_byte_offset=KT_LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sdO_raw = storage.do.get_tensor(cute.make_layout((cfg.do_cosize,)))
+    sdO = SmemTile(
+        base=smem_data_ptr(sdO_raw).toint(),
+        elems_per_stage=(cfg.do_cosize // cfg.smem_do_stages) * bpe,
+        stages=cfg.smem_do_stages,
+        leading_byte_offset=V_LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sdO_kmaj = SmemTile(
+        base=smem_data_ptr(sdO_raw).toint(),
+        elems_per_stage=(cfg.do_cosize // cfg.smem_do_stages) * bpe,
+        stages=cfg.smem_do_stages,
+        leading_byte_offset=LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sState_raw = storage.state.get_tensor(cute.make_layout((cfg.state_cosize,)))
+    sState = SmemTile(
+        base=smem_data_ptr(sState_raw).toint(),
+        elems_per_stage=(cfg.state_cosize // cfg.smem_state_stages) * bpe,
+        stages=cfg.smem_state_stages,
+        leading_byte_offset=STATE_LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sState_kmaj = SmemTile(
+        base=smem_data_ptr(sState_raw).toint(),
+        elems_per_stage=(cfg.state_cosize // cfg.smem_state_stages) * bpe,
+        stages=cfg.smem_state_stages,
+        leading_byte_offset=LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sTinv_raw = storage.t_inv.get_tensor(cute.make_layout((cfg.t_inv_cosize,)))
+    sTinv = SmemTile(
+        base=smem_data_ptr(sTinv_raw).toint(),
+        elems_per_stage=(cfg.t_inv_cosize // cfg.smem_t_inv_stages) * bpe,
+        stages=cfg.smem_t_inv_stages,
+        leading_byte_offset=LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sTinv_trans = SmemTile(
+        base=smem_data_ptr(sTinv_raw).toint(),
+        elems_per_stage=(cfg.t_inv_cosize // cfg.smem_t_inv_stages) * bpe,
+        stages=cfg.smem_t_inv_stages,
+        leading_byte_offset=(cfg.b_t // 2) * 128,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sKK_raw = storage.kk.get_tensor(cute.make_layout((cfg.t_inv_cosize,)))
+    sKK = SmemTile(
+        base=smem_data_ptr(sKK_raw).toint(),
+        elems_per_stage=(cfg.t_inv_cosize // cfg.smem_t_inv_stages) * bpe,
+        stages=cfg.smem_t_inv_stages,
+        leading_byte_offset=LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sA_raw = storage.a.get_tensor(cute.make_layout((cfg.a_cosize,)))
+    sA = SmemTile(
+        base=smem_data_ptr(sA_raw).toint(),
+        elems_per_stage=(cfg.a_cosize // cfg.smem_a_stages) * bpe,
+        stages=cfg.smem_a_stages,
+        leading_byte_offset=LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sA_trans = SmemTile(
+        base=smem_data_ptr(sA_raw).toint(),
+        elems_per_stage=(cfg.a_cosize // cfg.smem_a_stages) * bpe,
+        stages=cfg.smem_a_stages,
+        leading_byte_offset=(cfg.b_t // 2) * 128,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sDa = SmemTile(
+        base=smem_data_ptr(sA_raw).toint(),
+        elems_per_stage=(cfg.a_cosize // cfg.smem_a_stages) * bpe,
+        stages=1,
+        leading_byte_offset=LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sDa_trans = SmemTile(
+        base=smem_data_ptr(sA_raw).toint(),
+        elems_per_stage=(cfg.a_cosize // cfg.smem_a_stages) * bpe,
+        stages=1,
+        leading_byte_offset=(cfg.b_t // 2) * 128,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sDm_raw = storage.dm.get_tensor(cute.make_layout((cfg.a_cosize // cfg.smem_a_stages,)))
+    sDm = SmemTile(
+        base=smem_data_ptr(sDm_raw).toint(),
+        elems_per_stage=(cfg.a_cosize // cfg.smem_a_stages) * bpe,
+        stages=1,
+        leading_byte_offset=LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sDm_trans = SmemTile(
+        base=smem_data_ptr(sDm_raw).toint(),
+        elems_per_stage=(cfg.a_cosize // cfg.smem_a_stages) * bpe,
+        stages=1,
+        leading_byte_offset=(cfg.b_t // 2) * 128,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    # sub-bank split: V + sDstate + dQ + dK + dV allocated last
+    sV_raw = storage.v.get_tensor(cute.make_layout((cfg.v_cosize,)))
+    sV = SmemTile(
+        base=smem_data_ptr(sV_raw).toint(),
+        elems_per_stage=(cfg.v_cosize // cfg.smem_v_stages) * bpe,
+        stages=cfg.smem_v_stages,
+        leading_byte_offset=V_LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sV_kmaj = SmemTile(
+        base=smem_data_ptr(sV_raw).toint(),
+        elems_per_stage=(cfg.v_cosize // cfg.smem_v_stages) * bpe,
+        stages=cfg.smem_v_stages,
+        leading_byte_offset=LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sDstate_raw = storage.dstate.get_tensor(cute.make_layout((cfg.d_k * cfg.d_v,)))
+    sDstate = SmemTile(
+        base=smem_data_ptr(sDstate_raw).toint(),
+        elems_per_stage=cfg.d_k * cfg.d_v * bpe,
+        stages=1,
+        leading_byte_offset=STATE_LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sdQ_raw = storage.dq.get_tensor(cute.make_layout((cfg.dq_cosize,)))
+    sdQ = SmemTile(
+        base=smem_data_ptr(sdQ_raw).toint(),
+        elems_per_stage=(cfg.dq_cosize // cfg.smem_dq_stages) * bpe,
+        stages=cfg.smem_dq_stages,
+        leading_byte_offset=LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sdK_raw = storage.dk.get_tensor(cute.make_layout((cfg.dk_cosize,)))
+    sdK = SmemTile(
+        base=smem_data_ptr(sdK_raw).toint(),
+        elems_per_stage=(cfg.dk_cosize // cfg.smem_dk_stages) * bpe,
+        stages=cfg.smem_dk_stages,
+        leading_byte_offset=LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sdV_raw = storage.dv.get_tensor(cute.make_layout((cfg.dv_cosize,)))
+    sdV = SmemTile(
+        base=smem_data_ptr(sdV_raw).toint(),
+        elems_per_stage=(cfg.dv_cosize // cfg.smem_dv_stages) * bpe,
+        stages=cfg.smem_dv_stages,
+        leading_byte_offset=LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sdV_kmaj = sdV
+    sdstate_flat = cute.make_tensor(
+        cute.make_ptr(
+            cfg.io_dtype,
+            smem_data_ptr(sDstate_raw).toint(),
+            mem_space=cute.AddressSpace.smem,
+            assumed_align=cfg.buffer_align_bytes,
+        ),
+        cute.make_layout(cfg.d_k * cfg.d_v),
+    )
+    sstate_flat = cute.make_tensor(
+        cute.make_ptr(
+            cfg.io_dtype,
+            smem_data_ptr(sState_raw).toint(),
+            mem_space=cute.AddressSpace.smem,
+            assumed_align=cfg.buffer_align_bytes,
+        ),
+        cute.make_layout(cfg.state_cosize),
+    )
+    sCumsumlog = cute.make_tensor(
+        cute.make_ptr(
+            cutlass.Float32,
+            smem_data_ptr(cumsumlog_raw).toint(),
+            mem_space=cute.AddressSpace.smem,
+            assumed_align=128,
+        ),
+        cumsumlog_smem_layout_staged,
+    )
+    sCumprod = cute.make_tensor(
+        cute.make_ptr(
+            cutlass.Float32,
+            smem_data_ptr(cumprod_raw).toint(),
+            mem_space=cute.AddressSpace.smem,
+            assumed_align=128,
+        ),
+        cumsumlog_smem_layout_staged,
+    )
+    sBeta = cute.make_tensor(
+        cute.make_ptr(
+            cutlass.Float32,
+            smem_data_ptr(beta_raw).toint(),
+            mem_space=cute.AddressSpace.smem,
+            assumed_align=128,
+        ),
+        beta_smem_layout_staged,
+    )
+
+    # ---- mbarrier init (all threads) ---------------------------------------------
+    for s_ in range(cfg.sched_stages):
+        bars.mb_sched_ready[s_].init()
+        bars.mb_sched_done[s_].init()
+    for s in range(cfg.smem_q_stages):
+        bars.mb_q_ready[s].init()
+        bars.mb_q_mma_done[s].init()
+        bars.mb_q_cg1_done[s].init()
+    for s in range(cfg.smem_k_stages):
+        bars.mb_k_ready[s].init()
+        bars.mb_k_mma_done[s].init()
+        bars.mb_k_cg0_done[s].init()
+    for s in range(cfg.smem_v_stages):
+        bars.mb_v_ready[s].init()
+        bars.mb_v_mma_done[s].init()
+    for s in range(cfg.smem_do_stages):
+        bars.mb_do_ready[s].init()
+        bars.mb_do_mma_done[s].init()
+    for s in range(cfg.smem_state_stages):
+        bars.mb_state_ready[s].init()
+        bars.mb_state_mma_done[s].init()
+    for s in range(cfg.smem_gate_stages):
+        bars.mb_gate_ready[s].init()
+        bars.mb_gate_done[s].init()
+    for s in range(cfg.smem_beta_stages):
+        bars.mb_beta_ready[s].init()
+        bars.mb_beta_done[s].init()
+    for s in range(cfg.tmem_dstate_acc_stages):
+        bars.mb_dstate_acc_ready[s].init()
+        bars.mb_dstate_scale_acc_done[s].init()
+    for b in (
+        bars.mb_du_scale_acc_ready,
+        bars.mb_du_scale_acc_done,
+        bars.mb_du_total_acc_ready,
+        bars.mb_dk_scale_acc_ready,
+        bars.mb_dk_scale_acc_done,
+        bars.mb_dk_attn_acc_ready,
+        bars.mb_dk_attn_acc_done,
+        bars.mb_dk_total_acc_ready,
+        bars.mb_dk_total_acc_done,
+    ):
+        b[0].init()
+    for b in (
+        bars.mb_kk_acc_ready,
+        bars.mb_kk_acc_done,
+        bars.mb_a_acc_ready,
+        bars.mb_k_state_acc_ready,
+        bars.mb_u_acc_ready,
+        bars.mb_dy_acc_ready,
+    ):
+        b[0].init()
+    for s in range(cfg.smem_t_inv_stages):
+        bars.mb_t_inv_ready[s].init()
+    for s in range(cfg.smem_a_stages):
+        bars.mb_a_ready[s].init()
+        bars.mb_a_done[s].init()
+    for s in range(cfg.tmem_dstate_inp_stages):
+        bars.mb_dstate_inp_ready[s].init()
+        bars.mb_dstate_inp_done[s].init()
+    for b in (
+        bars.mb_do_prime_inp_ready,
+        bars.mb_du_inp_ready,
+        bars.mb_dyp_inp_ready,
+    ):
+        b[0].init()
+    for s in range(cfg.smem_dq_stages):
+        bars.mb_dq_tmastg_ready[s].init()
+        bars.mb_dq_tmastg_done[s].init()
+    for s in range(cfg.smem_dk_stages):
+        bars.mb_dk_tmastg_ready[s].init()
+        bars.mb_dk_tmastg_done[s].init()
+    for s in range(cfg.smem_dv_stages):
+        bars.mb_dv_tmastg_ready[s].init()
+        bars.mb_dv_tmastg_done[s].init()
+    bars.mb_y_ready[0].init()
+    bars.mb_sdv_done[0].init()
+    bars.mb_u_ready[0].init()
+    bars.mb_dstate_smem_ready[0].init()
+    bars.mb_da_ready[0].init()
+    bars.mb_dq_acc_scale_ready[0].init()
+    bars.mb_dq_acc_scale_done[0].init()
+    bars.mb_dq_acc_total_ready[0].init()
+    bars.mb_dq_acc_total_done[0].init()
+    bars.mb_da_acc_ready[0].init()
+    bars.mb_dm_acc_ready[0].init()
+    bars.mb_dm_acc_done[0].init()
+    bars.mb_dbeta_cg1_ready[0].init()
+    bars.mb_dgate_cg1_ready[0].init()
+    bars.mb_state_dot_dstate_done[0].init()
+    bars.mb_dk_state_path_acc_ready[0].init()
+    bars.mb_tmem_done[0].init()
+
+    nvvm.fence_mbarrier_init()
+    nvvm.barrier_cta_sync()
+
+    # ---- warp specialization -----------------------------------------------------
+
+    if (
+        warp_idx >= cfg.compute_group_0_warp_ids[0]
+        and warp_idx <= cfg.compute_group_0_warp_ids[-1]
+    ):
+        compute0_warp_group(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            cu_seqlens,
+            mWorkItems,
+            tidx,
+            tmem_base_slot=tmem_base_slot,
+            scale=scale,
+            sCumsumlog=sCumsumlog,
+            sCumprod=sCumprod,
+            sBeta=sBeta,
+            sTinv=sTinv,
+            sKK=sKK,
+            sA=sA,
+            sDa=sDa,
+            sDm=sDm,
+            sK=sK,
+            sdQ=sdQ,
+            sDstate=sDstate,
+            sstate_flat=sstate_flat,
+            sdstate_flat=sdstate_flat,
+            sSched=sSched,
+            bars=bars,
+        )
+
+    if (
+        warp_idx >= cfg.compute_group_1_warp_ids[0]
+        and warp_idx <= cfg.compute_group_1_warp_ids[-1]
+    ):
+        compute1_warp_group(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            cu_seqlens,
+            mWorkItems,
+            mDstate0,
+            mDstate_in,
+            tidx,
+            warp_idx=warp_idx,
+            tmem_base_slot=tmem_base_slot,
+            scale=scale,
+            sQ=sQ,
+            sK=sK,
+            sV=sV,
+            sdO=sdO,
+            sCumsumlog=sCumsumlog,
+            sCumprod=sCumprod,
+            sBeta=sBeta,
+            sdQ=sdQ,
+            sdK=sdK,
+            sdV=sdV,
+            sDstate=sDstate,
+            sDa=sDa,
+            sDm=sDm,
+            sSched=sSched,
+            bars=bars,
+        )
+
+    elif warp_idx == cfg.mma_warp_id:
+        mma_warp(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            cu_seqlens,
+            mWorkItems,
+            tmem_base_slot=tmem_base_slot,
+            sQ=sQ,
+            sQ_trans=sQ_trans,
+            sK=sK,
+            sK_trans=sK_trans,
+            sV=sV,
+            sV_kmaj=sV_kmaj,
+            sdO=sdO,
+            sdO_kmaj=sdO_kmaj,
+            sState=sState,
+            sState_kmaj=sState_kmaj,
+            sTinv=sTinv,
+            sTinv_trans=sTinv_trans,
+            sA=sA,
+            sA_trans=sA_trans,
+            sDa=sDa,
+            sDa_trans=sDa_trans,
+            sDstate=sDstate,
+            sDm=sDm,
+            sDm_trans=sDm_trans,
+            sdV_kmaj=sdV_kmaj,
+            sSched=sSched,
+            bars=bars,
+        )
+
+    elif warp_idx == cfg.tma_qkv_warp_id:
+        tmaldg_warp(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            n_desc,
+            cu_seqlens,
+            mWorkItems,
+            mSched=mSched,
+            sQ_raw=sQ_raw,
+            sK_raw=sK_raw,
+            sV_raw=sV_raw,
+            sdO_raw=sdO_raw,
+            sState_raw=sState_raw,
+            desc_q_base=desc_q_base,
+            desc_k_base=desc_k_base,
+            desc_v_base=desc_v_base,
+            desc_do_base=desc_do_base,
+            desc_checkpoint_base=desc_checkpoint_base,
+            sSched=sSched,
+            bars=bars,
+        )
+
+    if warp_idx == cfg.load_gate_beta_warp_id:
+        gate_beta_warp(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            cu_seqlens,
+            mWorkItems,
+            tidx,
+            mGate=mGate,
+            mA_log=mA_log,
+            mDt_bias=mDt_bias,
+            mBeta=mBeta,
+            mDgate=mDgate,
+            mDbeta=mDbeta,
+            sCumsumlog=sCumsumlog,
+            sCumprod=sCumprod,
+            sBeta=sBeta,
+            sSched=sSched,
+            bars=bars,
+        )
+    if warp_idx == cfg.epilogue_warp_id:
+        tmastg_warp(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            cu_seqlens,
+            mWorkItems,
+            sdQ_raw=sdQ_raw,
+            sdK_raw=sdK_raw,
+            sdV_raw=sdV_raw,
+            desc_dq_base=desc_dq_base,
+            desc_dk_base=desc_dk_base,
+            desc_dv_base=desc_dv_base,
+            sSched=sSched,
+            bars=bars,
+        )
+
+
+@dataclass
+class GdnBwdCfg:
+    """Static BT=64 scalar-GDN backward-kernel configuration."""
+
+    io_dtype: type[cutlass.Numeric]
+    use_initial_state: bool
+    use_dstate_in: bool
+    use_dstate0: bool
+    q_ratio: int
+    k_ratio: int
+    v_ratio: int
+    n_heads_out: int
+    max_active_clusters: int
+    dyn_sched: bool = False
+    log_gate: bool = True
+    safe_gate: bool = False
+    beta_sigmoid: bool = False
+    acc_dtype: type[cutlass.Numeric] = cutlass.Float32
+
+    b_t: int = CFG.B_T
+    d_k: int = CFG.D_K
+    d_v: int = CFG.D_V
+    compute_group_0_warp_ids: tuple[int, ...] = CFG.COMPUTE_GROUP_0_WARP_IDS
+    compute_group_1_warp_ids: tuple[int, ...] = CFG.COMPUTE_GROUP_1_WARP_IDS
+    mma_warp_id: int = CFG.MMA_WARP_ID
+    tma_qkv_warp_id: int = CFG.TMA_QKV_WARP_ID
+    load_gate_beta_warp_id: int = CFG.LOAD_GATE_BETA_WARP_ID
+    epilogue_warp_id: int = CFG.EPILOGUE_WARP_ID
+    num_regs_compute_group_0: int = CFG.NUM_REGS_COMPUTE_GROUP_0
+    num_regs_compute_group_1: int = CFG.NUM_REGS_COMPUTE_GROUP_1
+    num_regs_other: int = CFG.NUM_REGS_OTHER
+    threads_per_warp: int = CFG.THREADS_PER_WARP
+    threads_per_cta: int = 0
+    cluster_shape_mnk: tuple[int, int, int] = CFG.CLUSTER_SHAPE_MNK
+    sched_stages: int = CFG.SMEM_SCHED_STAGES
+
+    tmem_alloc_barrier_id: int = 1
+    tmem_alloc_barrier_threads: int = 0
+    inverse_barrier_id: int = 2
+    inverse_barrier_threads: int = 0
+    inverse_inner_barrier_id: int = 3
+    inverse_inner_barrier_threads: int = 0
+    init_state_store_barrier_id: int = 4
+    init_state_store_barrier_threads: int = 0
+    cg1_barrier_id: int = 5
+    cg1_barrier_threads: int = 0
+
+    smem_q_stages: int = CFG.SMEM_Q_STAGES
+    smem_k_stages: int = CFG.SMEM_K_STAGES
+    smem_v_stages: int = CFG.SMEM_V_STAGES
+    smem_do_stages: int = 1
+    smem_state_stages: int = 1
+    smem_t_inv_stages: int = CFG.SMEM_T_INV_STAGES
+    smem_a_stages: int = CFG.SMEM_A_STAGES
+    smem_dq_stages: int = 1
+    smem_dk_stages: int = 1
+    smem_dv_stages: int = 1
+    smem_gate_stages: int = 2
+    smem_beta_stages: int = 2
+    tmem_dstate_acc_stages: int = CFG.TMEM_DH_ACC_STAGES
+    tmem_dvdk_acc_stages: int = CFG.TMEM_DVDK_ACC_STAGES
+    tmem_dstate_inp_stages: int = CFG.TMEM_DH_INP_STAGES
+    tmem_shared_inp_stages: int = CFG.TMEM_SHARED_INP_STAGES
+    tmem_shared_acc_stages: int = CFG.TMEM_SHARED_ACC_STAGES
+    tmem_dstate_acc_offset: int = 0
+    tmem_dvdk_acc_offset: int = 0
+    tmem_dstate_inp_offset: int = 0
+    tmem_shared_acc_offset: int = 0
+    tmem_shared_inp_offset: int = 0
+    tmem_y_offset: int = 0
+    buffer_align_bytes: int = CFG.BUFFER_ALIGN_BYTES
+
+    q_cosize: int = 0
+    k_cosize: int = 0
+    v_cosize: int = 0
+    do_cosize: int = 0
+    state_cosize: int = 0
+    t_inv_cosize: int = 0
+    a_cosize: int = 0
+    dq_cosize: int = 0
+    dk_cosize: int = 0
+    dv_cosize: int = 0
+    tma_q_bytes: int = 0
+    tma_k_bytes: int = 0
+    tma_v_bytes: int = 0
+    tma_do_bytes: int = 0
+    tma_state_bytes: int = 0
+
+
+def build_cfg(
+    io_dtype: type[cutlass.Numeric],
+    *,
+    use_initial_state: bool,
+    use_dstate_in: bool,
+    use_dstate0: bool,
+    q_ratio: int,
+    k_ratio: int,
+    v_ratio: int,
+    n_heads_out: int,
+    max_active_clusters: int,
+    dyn_sched: bool = False,
+) -> GdnBwdCfg:
+    """Build the fixed BT=64 natural-log scalar-GDN configuration."""
+    if io_dtype not in (cutlass.Float16, cutlass.BFloat16):
+        raise ValueError(f"io_dtype={io_dtype} is unsupported; expected Float16 or BFloat16")
+    if min(q_ratio, k_ratio, v_ratio, n_heads_out, max_active_clusters) <= 0:
+        raise ValueError("head ratios, head count, and active-cluster count must be positive")
+
+    cfg = GdnBwdCfg(
+        io_dtype=io_dtype,
+        use_initial_state=use_initial_state,
+        use_dstate_in=use_dstate_in,
+        use_dstate0=use_dstate0,
+        q_ratio=q_ratio,
+        k_ratio=k_ratio,
+        v_ratio=v_ratio,
+        n_heads_out=n_heads_out,
+        max_active_clusters=max_active_clusters,
+        dyn_sched=dyn_sched,
+    )
+    role_ids = (
+        *cfg.compute_group_0_warp_ids,
+        *cfg.compute_group_1_warp_ids,
+        cfg.mma_warp_id,
+        cfg.tma_qkv_warp_id,
+        cfg.load_gate_beta_warp_id,
+        cfg.epilogue_warp_id,
+    )
+    if tuple(sorted(role_ids)) != tuple(range(len(role_ids))):
+        raise ValueError("warp roles must be disjoint and cover contiguous IDs from zero")
+    for group in (cfg.compute_group_0_warp_ids, cfg.compute_group_1_warp_ids):
+        if len(group) != 4 or group != tuple(range(group[0], group[-1] + 1)):
+            raise ValueError("the fixed schedule requires contiguous four-warp compute groups")
+
+    cfg.threads_per_cta = len(role_ids) * cfg.threads_per_warp
+    cfg.tmem_alloc_barrier_threads = (
+        1 + len(cfg.compute_group_0_warp_ids) + len(cfg.compute_group_1_warp_ids)
+    ) * cfg.threads_per_warp
+    cfg.inverse_barrier_threads = len(cfg.compute_group_0_warp_ids) * cfg.threads_per_warp
+    cfg.inverse_inner_barrier_threads = 2 * cfg.threads_per_warp
+    cfg.init_state_store_barrier_threads = len(cfg.compute_group_1_warp_ids) * cfg.threads_per_warp
+    cfg.cg1_barrier_threads = len(cfg.compute_group_1_warp_ids) * cfg.threads_per_warp
+
+    cfg.tmem_dstate_acc_offset = 0
+    cfg.tmem_dvdk_acc_offset = cfg.tmem_dstate_acc_offset + cfg.tmem_dstate_acc_stages * 128
+    cfg.tmem_dstate_inp_offset = cfg.tmem_dvdk_acc_offset + cfg.tmem_dvdk_acc_stages * 64
+    cfg.tmem_shared_acc_offset = cfg.tmem_dstate_inp_offset + cfg.tmem_dstate_inp_stages * 64
+    cfg.tmem_shared_inp_offset = cfg.tmem_shared_acc_offset + cfg.tmem_shared_acc_stages * 64
+    cfg.tmem_y_offset = cfg.tmem_shared_inp_offset + cfg.tmem_shared_inp_stages * (cfg.b_t // 2)
+    if cfg.tmem_y_offset + cfg.b_t // 2 > 512:
+        raise ValueError("BT=64 GDN TMEM layout exceeds 512 columns")
+
+    cfg.q_cosize = cfg.smem_q_stages * cfg.b_t * cfg.d_k
+    cfg.k_cosize = cfg.smem_k_stages * cfg.b_t * cfg.d_k
+    cfg.v_cosize = cfg.smem_v_stages * cfg.b_t * cfg.d_v
+    cfg.do_cosize = cfg.smem_do_stages * cfg.b_t * cfg.d_v
+    cfg.state_cosize = cfg.smem_state_stages * cfg.d_k * cfg.d_v
+    cfg.t_inv_cosize = cfg.smem_t_inv_stages * cfg.b_t * cfg.b_t
+    cfg.a_cosize = cfg.smem_a_stages * cfg.b_t * cfg.b_t
+    cfg.dq_cosize = cfg.smem_dq_stages * cfg.b_t * cfg.d_k
+    cfg.dk_cosize = cfg.smem_dk_stages * cfg.b_t * cfg.d_k
+    cfg.dv_cosize = cfg.smem_dv_stages * cfg.b_t * cfg.d_v
+    element_bytes = io_dtype.width // 8
+    cfg.tma_q_bytes = cfg.b_t * cfg.d_k * element_bytes
+    cfg.tma_k_bytes = cfg.b_t * cfg.d_k * element_bytes
+    cfg.tma_v_bytes = cfg.b_t * cfg.d_v * element_bytes
+    cfg.tma_do_bytes = cfg.b_t * cfg.d_v * element_bytes
+    cfg.tma_state_bytes = cfg.d_k * cfg.d_v * element_bytes
+    return cfg
+
+
+TENSORMAP_DESC_ARRAYS = 8
+TENSORMAP_STATIC_SLOTS = 0
+
+
+@cache
+def get_compiled_cache(
+    io_dtype_str: str,
+    h_q: int,
+    h_k: int,
+    h_v: int,
+    use_dstate_in: bool,
+    use_dstate0: bool,
+    use_initial_state: bool,
+    dyn_sched: bool,
+    run_order: bool,
+    order_gen: bool,
+    use_int64_offsets: bool,
+    device_index: int,
+    device_major: int,
+    device_minor: int,
+    num_sm: int,
+):
+    return {}
+
+
+def _validate_scalar_fp32(name, tensor, expected_shape) -> None:
+    if tensor.shape != expected_shape:
+        raise ValueError(f"{name} must have shape {expected_shape}, got {tuple(tensor.shape)}")
+    if str(tensor.dtype) != "torch.float32":
+        raise ValueError(f"{name} must have dtype torch.float32, got {tensor.dtype}")
+    if tensor.data_ptr() % 4:
+        raise ValueError(f"{name} data pointer must be 4-byte aligned")
+    if tensor.stride(-1) != 1:
+        raise ValueError(f"{name} innermost stride must be one")
+    if any(stride < 0 for stride in tensor.stride()[:-1]):
+        raise ValueError(f"{name} outer strides must be nonnegative")
+
+
+def chunk_gdn_bwd_sm100(
+    q,
+    k,
+    v,
+    gate,
+    beta,
+    do,
+    state_checkpoints,
+    dq,
+    dk,
+    dv,
+    dgate,
+    dbeta,
+    cu_seqlens,
+    scale: float,
+    *,
+    use_initial_state: bool = False,
+    d_initial_state=None,
+    d_final_state=None,
+    work_items=None,
+    work_count=None,
+    sched_ctr=None,
+    sched_all=None,
+    work_item_scratch=None,
+    order_in_prologue: bool = False,
+    tensormap_workspace,
+) -> None:
+    """Run BT=64 scalar-GDN backward for packed ``[T, H, D]`` tensors.
+
+    ``gate``, ``beta``, ``dgate``, and ``dbeta`` are scalar ``[T, H]`` float32
+    tensors. ``gate`` is the natural logarithm of the decay. Checkpoints and
+    optional initial/final-state gradients use ``[rows, H, V, K]`` and
+    ``[B, H, V, K]`` layouts, respectively.
+    """
+    tma_tensors = (
+        ("q", q),
+        ("k", k),
+        ("v", v),
+        ("do", do),
+        ("state_checkpoints", state_checkpoints),
+        ("dq", dq),
+        ("dk", dk),
+        ("dv", dv),
+    )
+    for name, tensor in tma_tensors:
+        validate_tma_tensor(name, tensor)
+    for name, tensor in (("d_initial_state", d_initial_state), ("d_final_state", d_final_state)):
+        if tensor is not None:
+            validate_tma_tensor(name, tensor)
+    validate_cu_seqlens(cu_seqlens, assumed_align=8)
+    if tensormap_workspace.data_ptr() % 128:
+        raise ValueError("tensormap_workspace data pointer must be 128-byte aligned")
+    if str(tensormap_workspace.dtype) != "torch.int64":
+        raise ValueError("tensormap_workspace must have dtype torch.int64")
+    if work_items is None or work_count is None:
+        raise ValueError("work_items and work_count are required")
+    if str(work_items.dtype) != "torch.int32" or work_items.ndim != 2 or work_items.shape[1] != 8:
+        raise ValueError("work_items must be an int32 [rows, 8] tensor")
+    if str(work_count.dtype) != "torch.int32" or work_count.numel() != 1:
+        raise ValueError("work_count must be a one-element int32 tensor")
+    if work_items.stride(-1) != 1 or work_items.data_ptr() % 4 or work_count.data_ptr() % 4:
+        raise ValueError("work_items and work_count must be compact and 4-byte aligned")
+    if sched_ctr is not None and (
+        str(sched_ctr.dtype) != "torch.int32" or sched_ctr.data_ptr() % 4
+    ):
+        raise ValueError("sched_ctr must be a 4-byte-aligned int32 tensor")
+
+    tokens, h_q, d_k = q.shape
+    h_k, h_v = k.shape[1], v.shape[1]
+    h_out = max(h_q, h_v)
+    if d_k != CFG.D_K or k.shape != (tokens, h_k, CFG.D_K) or v.shape != (tokens, h_v, CFG.D_V):
+        raise ValueError("q, k, and v must have shape (T, H, 128)")
+    if do.shape != (tokens, h_out, CFG.D_V):
+        raise ValueError("do must have shape (T, H, 128) at the output head count")
+    if h_q != h_out or h_k != h_out:
+        raise ValueError("chunk_gdn_bwd_sm100 requires q and k head ratios of one")
+    for name, tensor, expected_shape in (
+        ("dq", dq, q.shape),
+        ("dk", dk, k.shape),
+        ("dv", dv, v.shape),
+    ):
+        if tensor.shape != expected_shape:
+            raise ValueError(f"{name} must match its corresponding input shape")
+    _validate_scalar_fp32("gate", gate, (tokens, h_out))
+    _validate_scalar_fp32("beta", beta, (tokens, h_out))
+    _validate_scalar_fp32("dgate", dgate, gate.shape)
+    _validate_scalar_fp32("dbeta", dbeta, beta.shape)
+
+    for name, heads in (("HQ", h_q), ("HK", h_k), ("HV", h_v)):
+        if h_out % heads:
+            raise ValueError(f"{name}={heads} must divide H={h_out}")
+    expected_state_shape = (None, h_out, CFG.D_V, CFG.D_K)
+    if state_checkpoints.ndim != 4 or state_checkpoints.shape[1:] != expected_state_shape[1:]:
+        raise ValueError("state_checkpoints must have shape [rows, H, 128, 128]")
+    required_checkpoint_rows = checkpoint_capacity_bound(tokens, cu_seqlens.shape[0] - 1, CFG.B_T)
+    if state_checkpoints.shape[0] < required_checkpoint_rows:
+        raise ValueError(
+            f"state_checkpoints requires at least {required_checkpoint_rows} rows, got {state_checkpoints.shape[0]}"
+        )
+    if str(state_checkpoints.dtype) != str(q.dtype):
+        raise ValueError("state_checkpoints dtype must match q")
+    state_shape = (cu_seqlens.shape[0] - 1, h_out, CFG.D_V, CFG.D_K)
+    for name, tensor in (("d_initial_state", d_initial_state), ("d_final_state", d_final_state)):
+        if tensor is not None:
+            if tensor.shape != state_shape or str(tensor.dtype) != "torch.float32":
+                raise ValueError(f"{name} must have shape {state_shape} and dtype torch.float32")
+    if any(tensor.device != q.device for _, tensor in tma_tensors):
+        raise ValueError("all TMA tensors must be on q.device")
+    scalar_tensors = (
+        gate,
+        beta,
+        dgate,
+        dbeta,
+        cu_seqlens,
+        work_items,
+        work_count,
+        tensormap_workspace,
+    )
+    optional_tensors = (d_initial_state, d_final_state, sched_ctr, sched_all, work_item_scratch)
+    if any(
+        tensor.device != q.device
+        for tensor in (*scalar_tensors, *optional_tensors)
+        if tensor is not None
+    ):
+        raise ValueError("all tensors must be on q.device")
+
+    use_dstate_in = d_final_state is not None
+    use_dstate0 = d_initial_state is not None
+    dyn_sched = sched_ctr is not None
+    run_order = order_in_prologue
+    order_gen = run_order and work_item_scratch is None
+    has_sched = run_order
+    if run_order and sched_all is None:
+        raise ValueError("order_in_prologue requires sched_all")
+
+    use_int64_offsets = requires_int64_abi(
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        do,
+        state_checkpoints,
+        dq,
+        dk,
+        dv,
+        dgate,
+        dbeta,
+        cu_seqlens,
+        d_initial_state,
+        d_final_state,
+        work_item_scratch,
+        work_items,
+        work_count,
+        sched_ctr,
+        sched_all,
+        tensormap_workspace,
+    )
+    device_index = tensor_device_index(q)
+    if current_device() != device_index:
+        raise ValueError("the active CUDA device must match q.device")
+    device_properties = get_device_properties(device_index)
+    num_sm = device_properties.multi_processor_count
+    cache = get_compiled_cache(
+        str(q.dtype),
+        h_q,
+        h_k,
+        h_v,
+        use_dstate_in,
+        use_dstate0,
+        use_initial_state,
+        dyn_sched,
+        run_order,
+        order_gen,
+        use_int64_offsets,
+        device_index,
+        device_properties.major,
+        device_properties.minor,
+        num_sm,
+    )
+
+    io_dtype = get_dtype(q.dtype)
+    sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
+    if "compiled" not in cache:
+        cfg = build_cfg(
+            io_dtype,
+            use_initial_state=use_initial_state,
+            use_dstate_in=use_dstate_in,
+            use_dstate0=use_dstate0,
+            q_ratio=h_out // h_q,
+            k_ratio=h_out // h_k,
+            v_ratio=h_out // h_v,
+            n_heads_out=h_out,
+            max_active_clusters=num_sm,
+            dyn_sched=dyn_sched,
+        )
+        op = GdnBpropOp(cfg, use_int64_offsets)
+        tokens_sym, sequence_entries, sequences, work_rows, sched_entries, workspace_words = (
+            sym_int() for _ in range(6)
+        )
+        scalar_tensor = partial(
+            make_strided_signature_tensor,
+            assumed_align=4,
+            use_int64_offsets=use_int64_offsets,
+        )
+        cache["compiled"] = compile_tvm_ffi(
+            op,
+            scalar_tensor(cutlass.Float32, (tokens_sym, h_out)),
+            None,
+            None,
+            scalar_tensor(cutlass.Float32, (tokens_sym, h_out)),
+            scalar_tensor(cutlass.Float32, (tokens_sym, h_out)),
+            scalar_tensor(cutlass.Float32, (tokens_sym, h_out)),
+            make_cu_seqlens_signature(sequence_entries),
+            make_strided_signature_tensor(
+                cutlass.Float32,
+                (sequences, h_out, CFG.D_V, CFG.D_K),
+                assumed_align=16,
+                use_int64_offsets=use_int64_offsets,
+            )
+            if use_dstate0
+            else None,
+            make_strided_signature_tensor(
+                cutlass.Float32,
+                (sequences, h_out, CFG.D_V, CFG.D_K),
+                assumed_align=16,
+                use_int64_offsets=use_int64_offsets,
+            )
+            if use_dstate_in
+            else None,
+            make_work_items_signature(work_rows),
+            make_counter_signature(),
+            make_counter_signature(sched_entries) if dyn_sched else None,
+            make_workspace_signature(workspace_words),
+            cutlass.Float32(scale),
+        )
+
+    if "prologue" not in cache:
+        (
+            tokens_sym,
+            checkpoint_rows,
+            sequence_entries,
+            work_rows,
+            sched_entries,
+            workspace_words,
+        ) = (sym_int() for _ in range(6))
+        tma_tensor = partial(
+            make_strided_signature_tensor,
+            assumed_align=16,
+            use_int64_offsets=use_int64_offsets,
+        )
+        work_items_signature = make_work_items_signature(work_rows)
+        cache["prologue"] = compile_tvm_ffi(
+            prologue,
+            io_dtype,
+            CFG.B_T,
+            run_order,
+            order_gen,
+            has_sched,
+            tma_tensor(io_dtype, (tokens_sym, h_q, CFG.D_K)),
+            tma_tensor(io_dtype, (tokens_sym, h_k, CFG.D_K)),
+            tma_tensor(io_dtype, (tokens_sym, h_v, CFG.D_V)),
+            tma_tensor(io_dtype, (tokens_sym, h_out, CFG.D_V)),
+            tma_tensor(io_dtype, (tokens_sym, h_q, CFG.D_K)),
+            tma_tensor(io_dtype, (tokens_sym, h_k, CFG.D_K)),
+            tma_tensor(io_dtype, (tokens_sym, h_v, CFG.D_V)),
+            tma_tensor(io_dtype, (checkpoint_rows, h_out, CFG.D_V, CFG.D_K)),
+            make_cu_seqlens_signature(sequence_entries),
+            work_items_signature if run_order and not order_gen else None,
+            make_counter_signature(),
+            work_items_signature,
+            make_counter_signature(sched_entries) if has_sched else None,
+            make_workspace_signature(workspace_words),
+            name=(
+                f"gdn_mega_bprop_prologue_{io_dtype.__name__.lower()}"
+                f"_hq{h_q}_hk{h_k}_hv{h_v}_ho{h_out}_r{int(run_order)}"
+                f"o{int(order_gen)}d{int(dyn_sched)}_i64{int(use_int64_offsets)}"
+            ),
+        )
+
+    cache["prologue"](
+        q,
+        k,
+        v,
+        do,
+        dq,
+        dk,
+        dv,
+        state_checkpoints,
+        cu_seqlens,
+        work_item_scratch if run_order and not order_gen else None,
+        work_count,
+        work_items,
+        sched_all if run_order else None,
+        tensormap_workspace,
+    )
+    cache["compiled"](
+        gate,
+        None,
+        None,
+        beta,
+        dgate,
+        dbeta,
+        cu_seqlens,
+        d_initial_state,
+        d_final_state,
+        work_items,
+        work_count,
+        sched_ctr,
+        tensormap_workspace,
+        scale,
+    )

--- a/attn_gym/linear/_delta_rule/mega/kernels/gdn_prefill_config.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/gdn_prefill_config.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# This kernel is derived from cuDNN, NVIDIA Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Gated DeltaNet (GDN) Cutlass-primitives prefill kernel config (fixed compile-time
+constants; the per-compile attributes live on ``GdnCfg`` in the kernel file).
+
+Target arch: Blackwell SM100 (GB200) / SM103 (GB300).
+"""
+
+from dataclasses import dataclass
+from typing import Tuple
+
+
+@dataclass(frozen=True)
+class Cfg:
+    # --- tile shape ---
+    B_T: int = 64  # chunk size / token tile (the mma N or K of every GEMM)
+    D_K: int = 128  # query/key head dim (contraction of GEMMs 1-4, M of GEMM 7)
+    D_V: int = 128  # value head dim (M of GEMMs 3-6, N of GEMM 7)
+
+    # --- TMA descriptor pool ---
+
+    # --- warp assignments (12 warps total) ---
+    COMPUTE_GROUP_0_WARP_IDS: Tuple[int, ...] = (
+        0,
+        1,
+        2,
+        3,
+    )  # T-pairwise / kk_epi / qk_epi / inverse
+    COMPUTE_GROUP_1_WARP_IDS: Tuple[int, ...] = (4, 5, 6, 7)  # kv_decay_v / v-k*state / epi ops
+    LOAD_GATE_BETA_WARP_ID: int = 8  # gate/beta chunk loads + TMEM lifecycle
+    TMA_QKV_WARP_ID: int = 9
+    MMA_WARP_ID: int = 10  # sole tcgen05 issuer: fused KK/QK pairs + KS/QS/U/QKV/KV per chunk
+    EPILOGUE_WARP_ID: int = 11
+
+    # --- register split ---
+    NUM_REGS_COMPUTE_GROUP_0: int = 224
+    NUM_REGS_COMPUTE_GROUP_1: int = 256
+    NUM_REGS_OTHER: int = 24
+
+    THREADS_PER_WARP: int = 32
+
+    CLUSTER_SHAPE_MNK: Tuple[int, int, int] = (1, 1, 1)
+
+    # --- SMEM stage counts ---
+    SMEM_SCHED_STAGES: int = 2
+    SMEM_KQ_STAGES: int = 4
+    SMEM_V_STAGES: int = 2
+    SMEM_T_INV_STAGES: int = 3
+    SMEM_A_STAGES: int = 3
+    SMEM_O_STAGES: int = 1
+    SMEM_GATE_STAGES: int = 3
+    SMEM_BETA_STAGES: int = 3
+
+    # --- TMEM stage counts ---
+    TMEM_KV_ACC_STAGES: int = 1
+    TMEM_Q_STATE_ACC_STAGES: int = 1
+    TMEM_STATE_INP_STAGES: int = 1
+    TMEM_CG0_ACC_STAGES: int = 2
+    TMEM_CG1_ACC_STAGES: int = 1
+
+    BUFFER_ALIGN_BYTES: int = 1024
+
+
+CFG = Cfg()

--- a/attn_gym/linear/_delta_rule/mega/kernels/gdn_prefill_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/gdn_prefill_f16.py
@@ -1,0 +1,4117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# This kernel is derived from cuDNN, NVIDIA Corporation.
+# Modified by Attention Gym in 2026: imports were relocated into this package.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Chunked Gated Delta Net (GDN) prefill kernel for Blackwell SM100 (Cutlass primitives)
+with optional per-chunk state-checkpoint output.
+
+Algorithm overview (per chunk c, tokens [cC, (c+1)C)):
+  Inputs : Q[BT,DK], K[BT,DK], V[BT,DV], Gate[BT] (scalar gate), Beta[BT] (scalar LR)
+  State  : S_prev[DK,DV]  (recurrent state, held in TMEM)
+
+  Preprocessing (compute warp group 0):
+    cumsumlog[t]     = sum_{l=0}^{t} log(gate_l)              cumulative log of gates
+    cumprod[t]       = exp(cumsumlog[t])                       cumulative product of gates
+    T_pairwise[i,j]  = cumprod[i] / cumprod[j]  (i>=j)       inter-token transfer weights
+    (stored in registers; 128 regs/thread)
+
+  GEMM 1 - KK   : W_kk[BT,BT]  = K  @ K^T       (lower-triangular intra scores)
+  GEMM 2 - QK   : W_qk[BT,BT]  = Q  @ K^T       (output attention scores)
+  GEMM 3 - K*state : KS[BT,DV] = K  @ S_prev    (key applied to state)
+  GEMM 4 - Q*state : QS[BT,DV] = Q  @ S_prev    (inter-chunk output, before T scaling)
+  GEMM 5 - U       : U[BT,DV]  = T_inv @ Y       (corrected value vectors)
+                      where T_inv = (I + M_kk)^{-1},  M_kk[i,j] = T[i,j]*Beta[i]*W_kk[i,j]  (lower-tri, hierarchical blockwise inverse)
+  GEMM 6 - QKV  : O_intra[BT,DV] = W_qkv @ U    (intra-chunk output)
+                   where W_qkv = T*Beta*W_qk (the A tile)
+  GEMM 7 - KV update : S_upd[DK,DV] = K^T @ (decay .* U)  (state update, BT contraction)
+                        where Y[BT,DV] = V - KS    (delta rule residuals, after decay)
+
+  Epilogue:
+    O[BT,DV]  = O_intra + T_col * QS             (combine intra + inter)
+    S_next    = cumprod[BT-1] * S_prev + S_upd        (update state in TMEM)
+
+Chunks run in PAIRS (CG0 warp halves invert chunk 0 / chunk 1 in parallel);
+odd counts pad with a neutral zero-filled chunk.
+
+SMEM layout (227 KB = full; stage counts live in gdn_prefill_config.py;
+enable_checkpoints compiles trim K/V stages to fit the checkpoint buffer):
+  Buffer                       Size (B)  Stages
+  Q                               16384       3
+  K                               16384       4
+  V                               16384       3
+  T_inv                            8192       3
+  A tile output                    8192       3
+  O store                         16384       2
+  checkpoint staging            DK*DV*2       1    <-- enable_checkpoints only
+  cumsumlog / cumprod / Beta        256       3
+  sched ticket ring                   4       2    <-- dyn_sched publish ring
+
+TMEM layout (512 columns):
+  Buffer                  Cols
+  state                   128     <-- DKxDV fp32 = 128x128x4B
+  Q*state / O acc          64     <-- BTxDV fp32 accumulator
+  state inp                64     <-- fp16 state staging (GEMMs 3/4 A operand)
+  cg0 shared acc          128     <-- 2-stage ring: KK0/KK1 then QK0/QK1
+  cg1 shared acc           64     <-- 1-stage ring: KS then U
+  Y + U input / decayed-U inp    64  <-- slot 0 = Y then U input, slot 1 = decayed U (b16)
+
+Warp assignments (12 warps = 384 threads):
+  warps 0-3     : compute group 0 - T-pairwise x2, KK_epi x2, pair inverse,
+                                    A_epi x2
+  warps 4-7     : compute group 1 - state restage/rescale, Y = V - K*state,
+                                    state*Q_epi, U_epi, QKV_epilogue
+  warp  8       : Gate/Beta loads
+  warp  9       : TMA load warp  - loads Q, K, V
+  warp  10      : MMA warp       - fused KK/QK pairs + K*state/Q*state/U/QKV/KV per chunk;
+                                    TMEM lifecycle
+  warp  11      : epilogue warp  - O then checkpoint TMA stores
+"""
+
+from dataclasses import dataclass
+from functools import lru_cache, partial
+from typing import NamedTuple, Optional, Tuple, Type
+
+import cuda.bindings.driver as cuda_driver
+import cutlass
+import cutlass.cute as cute
+import cutlass.experimental.cuda as cuda
+import cutlass.experimental.primitives as nvvm
+from cutlass.cutlass_dsl import min
+
+from attn_gym._backends.cute import compile_tvm_ffi
+from attn_gym._backends.cute.utils import requires_int64_abi
+
+from .common.elementwise import softplus
+from .common.host import get_dtype
+from .common.split_k import (
+    ORDER_CAPACITY,
+    ORDER_ELEMS,
+    ORDER_THREADS,
+    decode_work_item,
+    order_body,
+)
+from .common.thd import (
+    TENSOR_MAP_QWORDS,
+    emit_checkpoint_seq_descs,
+    emit_seq_descs,
+    emit_seq_load_descs,
+)
+from .common.tvm_ffi import (
+    make_compact_signature_tensor,
+    make_counter_signature,
+    make_cu_seqlens_signature,
+    make_strided_signature_tensor,
+    make_work_items_signature,
+    make_workspace_signature,
+    validate_cu_seqlens,
+)
+from .compat import (
+    checkpoint_capacity_bound,
+    current_device,
+    get_device_properties,
+    tensor_device_index,
+    validate_tma_tensor,
+)
+from .gdn_prefill_config import CFG
+from .tile_dsl.barrier import MBarrier, PipelineState, Producer, advance
+from .tile_dsl.handles import MmaDesc, SmemTile, smem_data_ptr, tma_slice_runtime_desc
+from .tile_dsl.mma import mma_ss, mma_step, mma_step_k8, mma_ts_step
+from .tile_dsl.pointwise import (
+    f16x2_to_f32,
+    fadd2,
+    fmul2,
+    fp32_to_fp16,
+    opaque_f32_zero,
+    sub_f16x2,
+)
+from .tile_dsl.swizzle import swizzle_lin_128b, swizzle_xor_128b
+from .tile_dsl.tma import (
+    tma_load_tile,
+    tma_store_commit,
+    tma_store_tile,
+    tma_store_wait,
+    tma_tensormap_acquire,
+)
+
+RCP_LN2: float = 1.4426950408889634  # natural-log gates -> kernel's log2 domain
+
+
+class GdnBars(NamedTuple):
+    """GDN pipeline mbarrier inventory.
+
+    Every pipeline is a ``_ready``/``_done`` MBarrier pair over one ring: a
+    slot is acquired for filling by waiting ``_done`` and committed by
+    arriving ``_ready``; the reading side waits ``_ready`` and releases the
+    slot by arriving ``_done``.
+    """
+
+    mb_kq_ready: MBarrier
+    mb_kq_done: MBarrier
+    mb_v_ready: MBarrier
+    mb_v_done: MBarrier
+
+    mb_gate_ready: MBarrier
+    mb_gate_done: MBarrier
+    mb_beta_ready: MBarrier
+    mb_beta_done: MBarrier
+
+    mb_state_acc_ready: MBarrier
+    mb_state_acc_scale_done: MBarrier
+    mb_o_acc_ready: MBarrier
+    mb_o_final_acc_ready: MBarrier
+    mb_o_state_scale_acc_done: MBarrier
+    mb_cg0_acc_ready: MBarrier
+    mb_cg0_acc_done: MBarrier
+
+    mb_state_inp_ready: MBarrier
+    mb_y_inp_ready: MBarrier
+    mb_u_inp_ready: MBarrier
+    mb_decay_u_inp_ready: MBarrier
+
+    mb_t_inv_ready: MBarrier
+    mb_t_inv_done: MBarrier
+    mb_a_ready: MBarrier
+    mb_a_done: MBarrier
+
+    mb_k_state_acc_ready: MBarrier
+    mb_u_acc_ready: MBarrier
+
+    mb_o_tmastg_ready: MBarrier
+    mb_o_tmastg_done: MBarrier
+
+    mb_checkpoint_tmastg_ready: MBarrier
+    mb_checkpoint_tmastg_done: MBarrier
+
+    mb_tmem_done: MBarrier
+
+    mb_sched_ready: MBarrier
+    mb_sched_done: MBarrier
+
+
+def make_gdn_bars(cfg) -> GdnBars:
+    """GdnBars factory.  MUST be called from inside ``kernel`` (allocates SMEM)."""
+    ONE_LANE = 1
+    MMA_ARRIVERS = len([cfg.mma_warp_id])
+    KQ_RELEASE_SITES = 1
+    GATE_WARP = cfg.threads_per_warp * len([cfg.load_gate_beta_warp_id])
+    EPI_WARP = cfg.threads_per_warp * len([cfg.epilogue_warp_id])
+    CG0_THREADS = cfg.threads_per_warp * len(cfg.compute_group_0_warp_ids)
+    CG1_THREADS = cfg.threads_per_warp * len(cfg.compute_group_1_warp_ids)
+    CG0_PLUS_CG1 = CG0_THREADS + CG1_THREADS
+
+    def alloc(n):
+        return cutlass.Array(cutlass.Int64, n, space=cutlass.AddressSpace.smem, alignment=16)
+
+    return GdnBars(
+        mb_kq_ready=MBarrier(
+            alloc(cfg.smem_kq_stages),
+            stages=cfg.smem_kq_stages,
+            init_count=ONE_LANE,
+            producer=Producer.TMA_LOAD,
+        ),
+        mb_kq_done=MBarrier(
+            alloc(cfg.smem_kq_stages),
+            stages=cfg.smem_kq_stages,
+            init_count=KQ_RELEASE_SITES,
+            producer=Producer.MMA_COMMIT,
+        ),
+        mb_v_ready=MBarrier(
+            alloc(cfg.smem_v_stages),
+            stages=cfg.smem_v_stages,
+            init_count=ONE_LANE,
+            producer=Producer.TMA_LOAD,
+        ),
+        mb_v_done=MBarrier(
+            alloc(cfg.smem_v_stages),
+            stages=cfg.smem_v_stages,
+            init_count=CG1_THREADS,
+            producer=Producer.THREAD,
+        ),
+        mb_gate_ready=MBarrier(
+            alloc(cfg.smem_gate_stages),
+            stages=cfg.smem_gate_stages,
+            init_count=GATE_WARP,
+            producer=Producer.THREAD,
+        ),
+        mb_gate_done=MBarrier(
+            alloc(cfg.smem_gate_stages),
+            stages=cfg.smem_gate_stages,
+            init_count=CG0_PLUS_CG1,
+            producer=Producer.THREAD,
+        ),
+        mb_beta_ready=MBarrier(
+            alloc(cfg.smem_beta_stages),
+            stages=cfg.smem_beta_stages,
+            init_count=GATE_WARP,
+            producer=Producer.THREAD,
+        ),
+        mb_beta_done=MBarrier(
+            alloc(cfg.smem_beta_stages),
+            stages=cfg.smem_beta_stages,
+            init_count=CG0_THREADS,
+            producer=Producer.THREAD,
+        ),
+        mb_state_acc_ready=MBarrier(
+            alloc(cfg.tmem_state_acc_stages),
+            stages=cfg.tmem_state_acc_stages,
+            init_count=MMA_ARRIVERS,
+            producer=Producer.MMA_COMMIT,
+        ),
+        mb_state_acc_scale_done=MBarrier(
+            alloc(cfg.tmem_state_acc_stages),
+            stages=cfg.tmem_state_acc_stages,
+            init_count=CG1_THREADS,
+            producer=Producer.THREAD,
+        ),
+        mb_o_acc_ready=MBarrier(
+            alloc(cfg.tmem_q_state_acc_stages),
+            stages=cfg.tmem_q_state_acc_stages,
+            init_count=MMA_ARRIVERS,
+            producer=Producer.MMA_COMMIT,
+        ),
+        mb_o_final_acc_ready=MBarrier(
+            alloc(cfg.tmem_q_state_acc_stages),
+            stages=cfg.tmem_q_state_acc_stages,
+            init_count=MMA_ARRIVERS,
+            producer=Producer.MMA_COMMIT,
+        ),
+        mb_o_state_scale_acc_done=MBarrier(
+            alloc(cfg.tmem_q_state_acc_stages),
+            stages=cfg.tmem_q_state_acc_stages,
+            init_count=CG1_THREADS,
+            producer=Producer.THREAD,
+        ),
+        mb_cg0_acc_ready=MBarrier(
+            alloc(cfg.tmem_cg0_acc_stages),
+            stages=cfg.tmem_cg0_acc_stages,
+            init_count=MMA_ARRIVERS,
+            producer=Producer.MMA_COMMIT,
+        ),
+        mb_cg0_acc_done=MBarrier(
+            alloc(cfg.tmem_cg0_acc_stages),
+            stages=cfg.tmem_cg0_acc_stages,
+            init_count=CG0_THREADS // 2,
+            producer=Producer.THREAD,
+        ),
+        mb_state_inp_ready=MBarrier(
+            alloc(cfg.tmem_state_inp_stages),
+            stages=cfg.tmem_state_inp_stages,
+            init_count=CG1_THREADS,
+            producer=Producer.THREAD,
+        ),
+        mb_y_inp_ready=MBarrier(
+            alloc(1), stages=1, init_count=CG1_THREADS, producer=Producer.THREAD
+        ),
+        mb_u_inp_ready=MBarrier(
+            alloc(1), stages=1, init_count=CG1_THREADS, producer=Producer.THREAD
+        ),
+        mb_decay_u_inp_ready=MBarrier(
+            alloc(1), stages=1, init_count=CG1_THREADS, producer=Producer.THREAD
+        ),
+        mb_t_inv_ready=MBarrier(
+            alloc(cfg.smem_t_inv_stages),
+            stages=cfg.smem_t_inv_stages,
+            init_count=CG0_THREADS,
+            producer=Producer.THREAD,
+        ),
+        mb_t_inv_done=MBarrier(
+            alloc(cfg.smem_t_inv_stages),
+            stages=cfg.smem_t_inv_stages,
+            init_count=MMA_ARRIVERS,
+            producer=Producer.MMA_COMMIT,
+        ),
+        mb_a_ready=MBarrier(
+            alloc(cfg.smem_a_stages),
+            stages=cfg.smem_a_stages,
+            init_count=CG0_THREADS // 2,
+            producer=Producer.THREAD,
+        ),
+        mb_a_done=MBarrier(
+            alloc(cfg.smem_a_stages),
+            stages=cfg.smem_a_stages,
+            init_count=MMA_ARRIVERS,
+            producer=Producer.MMA_COMMIT,
+        ),
+        mb_k_state_acc_ready=MBarrier(
+            alloc(1), stages=1, init_count=MMA_ARRIVERS, producer=Producer.MMA_COMMIT
+        ),
+        mb_u_acc_ready=MBarrier(
+            alloc(1), stages=1, init_count=MMA_ARRIVERS, producer=Producer.MMA_COMMIT
+        ),
+        mb_o_tmastg_ready=MBarrier(
+            alloc(cfg.smem_o_stages),
+            stages=cfg.smem_o_stages,
+            init_count=CG1_THREADS,
+            producer=Producer.THREAD,
+        ),
+        mb_o_tmastg_done=MBarrier(
+            alloc(cfg.smem_o_stages),
+            stages=cfg.smem_o_stages,
+            init_count=EPI_WARP,
+            producer=Producer.THREAD,
+        ),
+        mb_checkpoint_tmastg_ready=MBarrier(
+            alloc(cfg.smem_checkpoint_stages),
+            stages=cfg.smem_checkpoint_stages,
+            init_count=len(cfg.compute_group_1_warp_ids),
+            producer=Producer.THREAD,
+        ),
+        mb_checkpoint_tmastg_done=MBarrier(
+            alloc(cfg.smem_checkpoint_stages),
+            stages=cfg.smem_checkpoint_stages,
+            init_count=EPI_WARP,
+            producer=Producer.THREAD,
+        ),
+        mb_tmem_done=MBarrier(
+            alloc(1), stages=1, init_count=CG1_THREADS, producer=Producer.THREAD
+        ),
+        mb_sched_ready=MBarrier(
+            alloc(cfg.sched_stages),
+            stages=cfg.sched_stages,
+            init_count=1,
+            producer=Producer.THREAD,
+        ),
+        mb_sched_done=MBarrier(
+            alloc(cfg.sched_stages),
+            stages=cfg.sched_stages,
+            init_count=11,
+            producer=Producer.THREAD,
+        ),
+    )
+
+
+@cute.jit
+def invert_diagonal_NxN(cfg, base_int, d, tidx, N: int = 8):
+    """Gauss-Jordan inversion of one diagonal NxN block in-place (f16 SMEM)."""
+    tidx_in_group = tidx % N
+    BT = cfg.b_t
+
+    row_lin_base = (d * N + tidx_in_group) * BT + d * N
+    row_phys = swizzle_lin_128b(row_lin_base, row_stride_log2=6)
+    row_ptr = (
+        cute.make_ptr(
+            cfg.io_dtype,
+            base_int,
+            mem_space=cute.AddressSpace.smem,
+            assumed_align=cfg.buffer_align_bytes,
+        )
+        + row_phys
+    )
+
+    row = [(row_ptr + j).load().to(cutlass.Float32) for j in range(N)]
+    for i in cutlass.range_constexpr(N):
+        row[i] = cutlass.Float32(1.0) if tidx_in_group == i else row[i]
+    for src_row in cutlass.range_constexpr(N - 1):
+        row_scale = -row[src_row]
+        for i in cutlass.range_constexpr(src_row):
+            shfl_val = nvvm.shfl_sync(
+                0xFFFFFFFF, row[i], src_row, 0b1100000011111, kind=nvvm.Shfl.IDX
+            )
+            row[i] = row[i] + row_scale * shfl_val if tidx_in_group > src_row else row[i]
+        row[src_row] = row_scale if tidx_in_group > src_row else row[src_row]
+
+    for j in cutlass.range_constexpr(N):
+        (row_ptr + j).store(row[j].to(cfg.io_dtype))
+
+
+@cute.jit
+def blockwise_diagonal_8x8_to_16x16(cfg, base_int, d0, lane_id):
+    """Off-diagonal correction 8x8 -> 16x16 (C <- -D^{-1} C A^{-1})."""
+    bpe = cfg.io_dtype.width // 8
+    ldsm_x1_lane_off = (lane_id % 8) * 64
+    d = nvvm.ldmatrix(
+        cutlass.inttoptr(
+            base_int
+            + swizzle_lin_128b((d0 + 8) * 64 + d0 + 8 + ldsm_x1_lane_off, row_stride_log2=6) * bpe,
+            cutlass.AddressSpace.smem,
+            cutlass.BFloat16,
+        ),
+        1,
+        nvvm.MMALayout.ROW,
+    )
+    c = nvvm.ldmatrix(
+        cutlass.inttoptr(
+            base_int
+            + swizzle_lin_128b((d0 + 8) * 64 + d0 + ldsm_x1_lane_off, row_stride_log2=6) * bpe,
+            cutlass.AddressSpace.smem,
+            cutlass.BFloat16,
+        ),
+        1,
+        nvvm.MMALayout.COL,
+    )
+
+    # ---- T = -(D^{-1} @ C) -------------------------------------------------------
+    c_regs = cutlass.Array(cutlass.Float32, 4, alignment=16, space=cutlass.AddressSpace.rmem)
+    for i in cutlass.range_constexpr(4):
+        c_regs[i] = cutlass.Float32(0.0)
+    mma_step_k8(c_regs, [d, d], [c], k_step=0, M=16, N=8, ab_dtype=cfg.io_dtype)
+    for i in cutlass.range_constexpr(4):
+        c_regs[i] = -c_regs[i]
+    a_pack = [fp32_to_fp16(c_regs[2 * j], c_regs[2 * j + 1], dtype=cfg.io_dtype) for j in range(2)]
+
+    # ---- C = T @ A^{-1} ----------------------------------------------------------
+    ai_frag = nvvm.ldmatrix(
+        cutlass.inttoptr(
+            base_int + swizzle_lin_128b(d0 * 64 + d0 + ldsm_x1_lane_off, row_stride_log2=6) * bpe,
+            cutlass.AddressSpace.smem,
+            cutlass.BFloat16,
+        ),
+        1,
+        nvvm.MMALayout.COL,
+    )
+    o_regs = cutlass.Array(cutlass.Float32, 4, alignment=16, space=cutlass.AddressSpace.rmem)
+    for i in cutlass.range_constexpr(4):
+        o_regs[i] = cutlass.Float32(0.0)
+    mma_step_k8(o_regs, a_pack, [ai_frag], k_step=0, M=16, N=8, ab_dtype=cfg.io_dtype)
+    o_pack = fp32_to_fp16(o_regs[0], o_regs[1], dtype=cfg.io_dtype)
+
+    # ---- store corrected C -------------------------------------------------------
+    nvvm.stmatrix(
+        cutlass.inttoptr(
+            base_int
+            + swizzle_lin_128b((d0 + 8) * 64 + d0 + ldsm_x1_lane_off, row_stride_log2=6) * bpe,
+            cutlass.AddressSpace.smem,
+            cutlass.BFloat16,
+        ),
+        o_pack,
+        nvvm.MMALayout.ROW,
+    )
+
+
+@cute.jit
+def blockwise_diagonal_16x16_to_32x32(cfg, base_int, d0, lane_id):
+    """Off-diagonal correction 16x16 -> 32x32."""
+    bpe = cfg.io_dtype.width // 8
+    ldsm_x4_lane_off = (lane_id % 16) * 64 + (lane_id // 16) * 8
+    d = list(
+        nvvm.ldmatrix(
+            cutlass.inttoptr(
+                base_int
+                + swizzle_lin_128b((d0 + 16) * 64 + d0 + 16 + ldsm_x4_lane_off, row_stride_log2=6)
+                * bpe,
+                cutlass.AddressSpace.smem,
+                cutlass.BFloat16,
+            ),
+            4,
+            nvvm.MMALayout.ROW,
+        )
+    )
+    c = list(
+        nvvm.ldmatrix(
+            cutlass.inttoptr(
+                base_int
+                + swizzle_lin_128b((d0 + 16) * 64 + d0 + ldsm_x4_lane_off, row_stride_log2=6)
+                * bpe,
+                cutlass.AddressSpace.smem,
+                cutlass.BFloat16,
+            ),
+            4,
+            nvvm.MMALayout.COL,
+        )
+    )
+
+    # ---- T = -(D^{-1} @ C) -------------------------------------------------------
+    c_regs = cutlass.Array(cutlass.Float32, 8, alignment=16, space=cutlass.AddressSpace.rmem)
+    for i in cutlass.range_constexpr(8):
+        c_regs[i] = cutlass.Float32(0.0)
+    mma_step(c_regs, d, c, k_step=0, M=16, N=16, ab_dtype=cfg.io_dtype)
+    for i in cutlass.range_constexpr(8):
+        c_regs[i] = -c_regs[i]
+    a_pack = [fp32_to_fp16(c_regs[2 * j], c_regs[2 * j + 1], dtype=cfg.io_dtype) for j in range(4)]
+
+    # ---- C = T @ A^{-1} ----------------------------------------------------------
+    ai_frag = list(
+        nvvm.ldmatrix(
+            cutlass.inttoptr(
+                base_int
+                + swizzle_lin_128b(d0 * 64 + d0 + ldsm_x4_lane_off, row_stride_log2=6) * bpe,
+                cutlass.AddressSpace.smem,
+                cutlass.BFloat16,
+            ),
+            4,
+            nvvm.MMALayout.COL,
+        )
+    )
+    o_regs = cutlass.Array(cutlass.Float32, 8, alignment=16, space=cutlass.AddressSpace.rmem)
+    for i in cutlass.range_constexpr(8):
+        o_regs[i] = cutlass.Float32(0.0)
+    mma_step(o_regs, a_pack, ai_frag, k_step=0, M=16, N=16, ab_dtype=cfg.io_dtype)
+    o_pack = [fp32_to_fp16(o_regs[2 * j], o_regs[2 * j + 1], dtype=cfg.io_dtype) for j in range(4)]
+
+    # ---- store corrected C -------------------------------------------------------
+    nvvm.stmatrix(
+        cutlass.inttoptr(
+            base_int
+            + swizzle_lin_128b((d0 + 16) * 64 + d0 + ldsm_x4_lane_off, row_stride_log2=6) * bpe,
+            cutlass.AddressSpace.smem,
+            cutlass.BFloat16,
+        ),
+        o_pack,
+        nvvm.MMALayout.ROW,
+    )
+
+
+@cute.jit
+def blockwise_diagonal_32x32_to_64x64(cfg, base_int, warp_id, lane_id):
+    """Off-diagonal correction 32x32 -> 64x64 (2 warps, one 16-row M-band each)."""
+    band = warp_id % 2
+    bpe = cfg.io_dtype.width // 8
+    ldsm_x4_lane_off = (lane_id % 16) * 64 + (lane_id // 16) * 8
+    a_frags = []
+    for vs in cutlass.range_constexpr(2):
+        a_frags += list(
+            nvvm.ldmatrix(
+                cutlass.inttoptr(
+                    base_int
+                    + swizzle_lin_128b(
+                        (32 + band * 16) * 64 + 32 + vs * 16 + ldsm_x4_lane_off, row_stride_log2=6
+                    )
+                    * bpe,
+                    cutlass.AddressSpace.smem,
+                    cutlass.BFloat16,
+                ),
+                4,
+                nvvm.MMALayout.ROW,
+            )
+        )
+    b_frags = []
+    for vs in cutlass.range_constexpr(4):
+        b_frags += list(
+            nvvm.ldmatrix(
+                cutlass.inttoptr(
+                    base_int
+                    + swizzle_lin_128b(
+                        (32 + (vs // 2) * 16) * 64 + (vs % 2) * 16 + ldsm_x4_lane_off,
+                        row_stride_log2=6,
+                    )
+                    * bpe,
+                    cutlass.AddressSpace.smem,
+                    cutlass.BFloat16,
+                ),
+                4,
+                nvvm.MMALayout.COL,
+            )
+        )
+
+    # ---- T = -(D^{-1} @ C) -------------------------------------------------------
+    c_regs = cutlass.Array(cutlass.Float32, 16, alignment=16, space=cutlass.AddressSpace.rmem)
+    for i in cutlass.range_constexpr(16):
+        c_regs[i] = cutlass.Float32(0.0)
+    for ks in cutlass.range_constexpr(2):
+        mma_step(
+            c_regs,
+            a_frags,
+            b_frags[ks * 8 : ks * 8 + 8],
+            k_step=ks,
+            M=16,
+            N=32,
+            ab_dtype=cfg.io_dtype,
+        )
+    for i in cutlass.range_constexpr(16):
+        c_regs[i] = -c_regs[i]
+    a_pack = [fp32_to_fp16(c_regs[2 * j], c_regs[2 * j + 1], dtype=cfg.io_dtype) for j in range(8)]
+
+    # ---- C = T @ A^{-1} ----------------------------------------------------------
+    ai_frags = []
+    for vs in cutlass.range_constexpr(4):
+        ai_frags += list(
+            nvvm.ldmatrix(
+                cutlass.inttoptr(
+                    base_int
+                    + swizzle_lin_128b(
+                        ((vs // 2) * 16) * 64 + (vs % 2) * 16 + ldsm_x4_lane_off, row_stride_log2=6
+                    )
+                    * bpe,
+                    cutlass.AddressSpace.smem,
+                    cutlass.BFloat16,
+                ),
+                4,
+                nvvm.MMALayout.COL,
+            )
+        )
+    o_regs = cutlass.Array(cutlass.Float32, 16, alignment=16, space=cutlass.AddressSpace.rmem)
+    for i in cutlass.range_constexpr(16):
+        o_regs[i] = cutlass.Float32(0.0)
+    for ks in cutlass.range_constexpr(2):
+        mma_step(
+            o_regs,
+            a_pack,
+            ai_frags[ks * 8 : ks * 8 + 8],
+            k_step=ks,
+            M=16,
+            N=32,
+            ab_dtype=cfg.io_dtype,
+        )
+    o_pack = [fp32_to_fp16(o_regs[2 * j], o_regs[2 * j + 1], dtype=cfg.io_dtype) for j in range(8)]
+
+    # ---- store corrected C -------------------------------------------------------
+    nvvm.barrier_cta_sync_aligned(
+        cfg.inverse_barrier_id,
+        thread_count=cfg.inverse_barrier_threads,
+    )
+    nvvm.stmatrix(
+        cutlass.inttoptr(
+            base_int
+            + swizzle_lin_128b((32 + band * 16) * 64 + ldsm_x4_lane_off, row_stride_log2=6) * bpe,
+            cutlass.AddressSpace.smem,
+            cutlass.BFloat16,
+        ),
+        o_pack[0:4],
+        nvvm.MMALayout.ROW,
+    )
+    nvvm.stmatrix(
+        cutlass.inttoptr(
+            base_int
+            + swizzle_lin_128b((32 + band * 16) * 64 + 16 + ldsm_x4_lane_off, row_stride_log2=6)
+            * bpe,
+            cutlass.AddressSpace.smem,
+            cutlass.BFloat16,
+        ),
+        o_pack[4:8],
+        nvvm.MMALayout.ROW,
+    )
+
+
+# ---- Dynamic tile scheduler ------------------------------------------------------
+
+
+@cute.jit
+def sched_publish_next(cfg, bars, sSched, mSched, sched_state, tile_idx, num_ctas):
+    """TMA-LDG-warp side: pull the next tile off the global ticket, publish it."""
+    if cutlass.const_expr(cfg.dyn_sched):
+        bars.mb_sched_done[sched_state.idx].wait(sched_state.phase)
+        if nvvm.elect_sync():
+            fetched = cutlass.Int32(
+                nvvm.atomicrmw(
+                    "add", mSched.iterator, cutlass.Int32(1), mem_order="relaxed", syncscope="gpu"
+                )
+            )
+            sSched[sched_state.idx] = num_ctas + fetched
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+        next_tile = sSched[sched_state.idx]
+        if nvvm.elect_sync():
+            bars.mb_sched_ready[sched_state.idx].arrive()
+        return next_tile, advance(sched_state, cfg.sched_stages)
+    return tile_idx + num_ctas, sched_state
+
+
+@cute.jit
+def sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas):
+    """Consumer side: read the TMA-LDG warp's published next tile."""
+    if cutlass.const_expr(cfg.dyn_sched):
+        bars.mb_sched_ready[sched_state.idx].wait(sched_state.phase)
+        next_tile = sSched[sched_state.idx]
+        if nvvm.elect_sync():
+            bars.mb_sched_done[sched_state.idx].arrive()
+        return next_tile, advance(sched_state, cfg.sched_stages)
+    return tile_idx + num_ctas, sched_state
+
+
+@cute.jit
+def tmastg_warp(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    cu_seqlens,
+    mWorkItems,
+    checkpoint_every_n_tokens,
+    tidx,
+    sO_raw,
+    sCheckpoint_raw,
+    desc_o_base,
+    desc_checkpoint_base,
+    sSched,
+    bars,
+):
+    """Epilogue warp role (warp 11): persistent scheduler loop issuing the
+    per-chunk O and state-checkpoint TMA stores."""
+    elect_one = nvvm.elect_sync()
+    nvvm.setmaxregister(cfg.num_regs_other, nvvm.SetMaxRegisterAction.DECREASE)
+    o_index = PipelineState.start(phase=0)
+    lidx = tidx % cfg.threads_per_warp
+    sched_state = PipelineState.start(phase=0)
+    tile_idx = cutlass.Int32(bidx)
+
+    bpe = cfg.io_dtype.width // 8
+    elems_per_128b = 128 // bpe
+    sO_tma = SmemTile(
+        base=sO_raw,
+        elems_per_stage=(cfg.o_cosize // cfg.smem_o_stages),
+        stages=cfg.smem_o_stages,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=0,
+        tma_loads_per_tile=2,
+        tma_granu_elems=elems_per_128b,
+        tma_subtile_stride_elems=4096,
+    )
+    if cutlass.const_expr(cfg.enable_checkpoints):
+        checkpoint_elems_per_128b = 64
+        sCheckpoint_tma = SmemTile(
+            base=sCheckpoint_raw,
+            elems_per_stage=(cfg.checkpoint_cosize // cfg.smem_checkpoint_stages),
+            stages=cfg.smem_checkpoint_stages,
+            leading_byte_offset=0,
+            stride_byte_offset=0,
+            layout=0,
+            tma_loads_per_tile=cfg.d_v // checkpoint_elems_per_128b,
+            tma_granu_elems=checkpoint_elems_per_128b,
+            tma_subtile_stride_elems=cfg.d_k * checkpoint_elems_per_128b,
+        )
+        checkpoint_store_cnt = cutlass.Int32(0)
+        ckpt_chunks = checkpoint_every_n_tokens // cutlass.Int32(cfg.b_t)
+    heads_out = cutlass.Int32(cfg.n_heads_out)
+    desc_qwords = cutlass.Int32(TENSOR_MAP_QWORDS)
+
+    while tile_idx < total_tiles:
+        (
+            batch_idx,
+            head_idx,
+            batch_start,
+            batch_end,
+            seqlen_b,
+            num_chunks_b,
+            wstart,
+            wend,
+            cstart,
+            cend,
+        ) = decode_work_item(cfg, tile_idx, mWorkItems)
+        n_local = wend - cstart
+
+        head_o = head_idx
+        slot = batch_idx * desc_qwords
+        desc_o_slot = (desc_o_base + slot).tospace(cutlass.AddressSpace.generic)
+        if elect_one:
+            tma_tensormap_acquire(desc_o_slot)
+        if cutlass.const_expr(cfg.enable_checkpoints):
+            desc_checkpoint_slot = (desc_checkpoint_base + slot).tospace(
+                cutlass.AddressSpace.generic
+            )
+            checkpoint_coord = (wstart + ckpt_chunks - cutlass.Int32(1)) // ckpt_chunks
+            checkpoint_mod = (cstart + cutlass.Int32(1)) % ckpt_chunks
+            if elect_one:
+                tma_tensormap_acquire(desc_checkpoint_slot)
+
+        if n_local > 0:
+            if cutlass.const_expr(cfg.enable_checkpoints):
+                if wstart == 0:
+                    checkpoint_stage = checkpoint_store_cnt % cfg.smem_checkpoint_stages
+                    checkpoint_phase = (
+                        checkpoint_store_cnt // cfg.smem_checkpoint_stages
+                    ) & cutlass.Int32(1)
+                    bars.mb_checkpoint_tmastg_ready[checkpoint_stage].wait(checkpoint_phase)
+                    checkpoint_slice = tma_slice_runtime_desc(
+                        desc_checkpoint_slot,
+                        cutlass.Int32(0),
+                        cutlass.Int32(0),
+                        checkpoint_coord,
+                        head_o,
+                    )
+                    tma_store_tile(
+                        sCheckpoint_tma[checkpoint_stage], checkpoint_slice, acquire=False
+                    )
+                    tma_store_commit()
+                    tma_store_wait(0)
+                    bars.mb_checkpoint_tmastg_done[checkpoint_stage].arrive()
+                    checkpoint_coord += 1
+                    checkpoint_store_cnt = checkpoint_store_cnt + 1
+            for local_idx in cutlass.range(n_local):
+                chunk_idx = cstart + local_idx
+
+                did_o = cutlass.Int32(0)
+                o_idx = o_index.idx
+                bars.mb_o_tmastg_ready[o_idx].wait(o_index.phase)
+                o_index = advance(o_index, cfg.smem_o_stages)
+
+                if chunk_idx >= wstart and chunk_idx < wend:
+                    tok_coord = chunk_idx * cutlass.Int32(cfg.b_t)
+                    o_slice = tma_slice_runtime_desc(
+                        desc_o_slot, cutlass.Int32(0), head_o, tok_coord
+                    )
+                    tma_store_tile(sO_tma[o_idx], o_slice, acquire=False)
+                    tma_store_commit()
+                    did_o = cutlass.Int32(1)
+
+                did_checkpoint = cutlass.Int32(0)
+                if cutlass.const_expr(cfg.enable_checkpoints):
+                    checkpoint_stage = checkpoint_store_cnt % cfg.smem_checkpoint_stages
+                    checkpoint_phase = (
+                        checkpoint_store_cnt // cfg.smem_checkpoint_stages
+                    ) & cutlass.Int32(1)
+                    if chunk_idx >= wstart - 1 and chunk_idx < wend - 1:
+                        if checkpoint_mod == 0:
+                            bars.mb_checkpoint_tmastg_ready[checkpoint_stage].wait(
+                                checkpoint_phase
+                            )
+                            checkpoint_slice = tma_slice_runtime_desc(
+                                desc_checkpoint_slot,
+                                cutlass.Int32(0),
+                                cutlass.Int32(0),
+                                checkpoint_coord,
+                                head_o,
+                            )
+                            tma_store_tile(
+                                sCheckpoint_tma[checkpoint_stage], checkpoint_slice, acquire=False
+                            )
+                            tma_store_commit()
+                            checkpoint_coord += 1
+                            did_checkpoint = cutlass.Int32(1)
+                    checkpoint_mod = checkpoint_mod + cutlass.Int32(1)
+                    checkpoint_mod = (
+                        cutlass.Int32(0) if checkpoint_mod == ckpt_chunks else checkpoint_mod
+                    )
+
+                if cutlass.const_expr(cfg.enable_checkpoints):
+                    if did_o == 1 and did_checkpoint == 1:
+                        tma_store_wait(1)
+                        bars.mb_o_tmastg_done[o_idx].arrive()
+                        tma_store_wait(0)
+                        bars.mb_checkpoint_tmastg_done[checkpoint_stage].arrive()
+                        checkpoint_store_cnt = checkpoint_store_cnt + 1
+                    if did_o == 1 and did_checkpoint == 0:
+                        tma_store_wait(0)
+                        bars.mb_o_tmastg_done[o_idx].arrive()
+                    if did_o == 0:
+                        if did_checkpoint == 1:
+                            tma_store_wait(0)
+                            bars.mb_checkpoint_tmastg_done[checkpoint_stage].arrive()
+                            checkpoint_store_cnt = checkpoint_store_cnt + 1
+                        bars.mb_o_tmastg_done[o_idx].arrive()
+                else:
+                    if did_o == 1:
+                        tma_store_wait(0)
+                    bars.mb_o_tmastg_done[o_idx].arrive()
+
+        tile_idx, sched_state = sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas)
+
+
+@cute.jit
+def gate_beta_warp(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    cu_seqlens,
+    mWorkItems,
+    tidx,
+    mGate,
+    mA_log,
+    mDt_bias,
+    mBeta,
+    sCumsumlog,
+    sCumprod,
+    sBeta,
+    sSched,
+    bars,
+):
+    """Gate/Beta producer (warp 8): persistent scheduler loop + the
+    cumsum/cumprod/Beta chunk loads."""
+
+    nvvm.setmaxregister(cfg.num_regs_other, nvvm.SetMaxRegisterAction.DECREASE)
+    gate_index = PipelineState.start(phase=1)
+    beta_index = PipelineState.start(phase=1)
+    lidx = tidx % cfg.threads_per_warp
+
+    a_l2 = cutlass.Float32(0.0)
+    bias = cutlass.Float32(0.0)
+    sched_state = PipelineState.start(phase=0)
+    tile_idx = cutlass.Int32(bidx)
+    while tile_idx < total_tiles:
+        (
+            batch_idx,
+            head_idx,
+            batch_start,
+            batch_end,
+            seqlen_b,
+            num_chunks_b,
+            wstart,
+            wend,
+            cstart,
+            cend,
+        ) = decode_work_item(cfg, tile_idx, mWorkItems)
+        n_local = wend - cstart
+        if cutlass.const_expr(cfg.safe_gate):
+            if n_local > 0:
+                # per-head transform constants, fixed for the whole tile
+                a_l2 = -cute.math.exp2(
+                    mA_log[head_idx].to(cutlass.Float32) * cutlass.Float32(RCP_LN2), fastmath=True
+                ) * cutlass.Float32(RCP_LN2)
+                bias = mDt_bias[head_idx].to(cutlass.Float32)
+        if n_local > 0:
+            for local_idx in cutlass.range(n_local):
+                # ---- Gate load: GMEM -> SMEM (OOB neutral) -----------------------
+                chunk_idx = cstart + local_idx
+                n_cols = cfg.b_t // cfg.threads_per_warp
+                chunk_offset = batch_start + chunk_idx * cfg.b_t
+                gGateSeq = mGate[None, head_idx]
+                gBeta = cute.domain_offset((chunk_offset,), mBeta[None, head_idx])
+
+                gate_idx = gate_index.idx
+                gate_phase = gate_index.phase
+                gate_index = advance(gate_index, cfg.smem_gate_stages)
+
+                pos_valid = [None] * n_cols
+                gate_vals = [cutlass.Float32(0.0)] * n_cols
+                oob_neutral = (
+                    cutlass.Float32(0.0)
+                    if cutlass.const_expr(cfg.log_gate)
+                    else cutlass.Float32(1.0)
+                )
+                for col in cutlass.range_constexpr(n_cols):
+                    tok = chunk_offset + lidx + col * cfg.threads_per_warp
+                    pos_valid[col] = cute.elem_less(tok, batch_end)
+                    tok_clamped = min(tok, batch_end - 1)
+                    gate_vals[col] = gGateSeq[tok_clamped] if pos_valid[col] else oob_neutral
+
+                if cutlass.const_expr(cfg.safe_gate):
+                    # raw logits -> log2-domain decay: a_l2 * softplus(g + bias) (split-K scan arithmetic)
+                    for col in cutlass.range_constexpr(n_cols):
+                        contrib = a_l2 * softplus(gate_vals[col] + bias)
+                        gate_vals[col] = contrib if pos_valid[col] else cutlass.Float32(0.0)
+                elif cutlass.const_expr(cfg.log_gate):
+                    for col in cutlass.range_constexpr(n_cols):
+                        gate_vals[col] = gate_vals[col] * cutlass.Float32(RCP_LN2)
+                else:
+                    for col in cutlass.range_constexpr(n_cols):
+                        gate_vals[col] = cute.math.log2(gate_vals[col] + 1e-10, fastmath=True)
+                for offset in [1, 2, 4, 8, 16]:
+                    for col in cutlass.range_constexpr(n_cols):
+                        n = nvvm.shfl_sync(
+                            0xFFFFFFFF, gate_vals[col], offset, 0, kind=nvvm.Shfl.UP
+                        )
+                        if lidx >= offset:
+                            gate_vals[col] = gate_vals[col] + n
+                for col in cutlass.range_constexpr(1, n_cols):
+                    last_v = nvvm.shfl_sync(
+                        0xFFFFFFFF,
+                        gate_vals[col - 1],
+                        cfg.threads_per_warp - 1,
+                        cfg.threads_per_warp - 1,
+                        kind=nvvm.Shfl.IDX,
+                    )
+                    gate_vals[col] += last_v
+
+                bars.mb_gate_done[gate_idx].wait(gate_phase)
+                for col in cutlass.range_constexpr(n_cols):
+                    pos = lidx + col * cfg.threads_per_warp
+                    sCumsumlog[pos, 0, gate_idx] = gate_vals[col]
+                    sCumprod[pos, 0, gate_idx] = cute.math.exp2(gate_vals[col], fastmath=True)
+                bars.mb_gate_ready[gate_idx].arrive()
+
+                # ---- Beta load: GMEM -> SMEM (per-element cp.async) --------------------------
+                beta_idx = beta_index.idx
+                bars.mb_beta_done[beta_idx].wait(beta_index.phase)
+                beta_index = advance(beta_index, cfg.smem_beta_stages)
+                if cutlass.const_expr(cfg.beta_sigmoid):
+                    # io-dtype logits -> sigmoid (tanh identity) -> fp32 SMEM
+                    for col in cutlass.range_constexpr(n_cols):
+                        pos = lidx + col * cfg.threads_per_warp
+                        beta_value = cutlass.Float32(0.0)
+                        if pos_valid[col]:
+                            beta_value = gBeta[pos].to(cutlass.Float32)
+                            half = cutlass.Float32(0.5)
+                            beta_value = (
+                                (cute.math.tanh(beta_value * half, approx=True) * half + half)
+                                .to(mBeta.element_type)
+                                .to(cutlass.Float32)
+                            )
+                        sBeta[pos, 0, beta_idx] = beta_value
+                    bars.mb_beta_ready[beta_idx].arrive()
+                else:
+                    for col in cutlass.range_constexpr(n_cols):
+                        pos = lidx + col * cfg.threads_per_warp
+                        src = gBeta.iterator + gBeta.layout((pos,))
+                        dst = sBeta.iterator + sBeta.layout((pos, 0, beta_idx))
+                        cp_size = cutlass.Int32(4) * cutlass.Int32(pos_valid[col])
+                        nvvm.cp_async_shared_global(
+                            dst, src, 4, nvvm.LoadCacheModifier.CA, cp_size=cp_size
+                        )
+                    nvvm.cp_async_mbarrier_arrive(
+                        bars.mb_beta_ready[beta_idx].smem_ptr, noinc=True
+                    )
+        tile_idx, sched_state = sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas)
+
+    for _ in range(cfg.smem_gate_stages):
+        bars.mb_gate_done[gate_index.idx].wait(gate_index.phase)
+        gate_index = advance(gate_index, cfg.smem_gate_stages)
+    for _ in range(cfg.smem_beta_stages):
+        bars.mb_beta_done[beta_index.idx].wait(beta_index.phase)
+        beta_index = advance(beta_index, cfg.smem_beta_stages)
+
+
+@cute.jit
+def mma_warp(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    cu_seqlens,
+    mWorkItems,
+    tmem_base_slot,
+    sKQ,
+    sKQ_trans,
+    sTinv,
+    sA,
+    sSched,
+    bars,
+):
+    """MMA issuer role (warp 10): persistent scheduler loop issuing every
+    tcgen05 GEMM."""
+    elect_one = nvvm.elect_sync()
+
+    nvvm.setmaxregister(cfg.num_regs_other, nvvm.SetMaxRegisterAction.DECREASE)
+    o_acc_index = PipelineState.start(phase=1)
+    o_state_scale_index = PipelineState.start(phase=0)
+    kv_acc_index = PipelineState.start(phase=1)
+    kq_index = PipelineState.start(phase=0)
+    cg0_acc_index = PipelineState.start(phase=1)
+    kq_fused_index = PipelineState.start(phase=0)
+    tinv_index = PipelineState.start(phase=0)
+    a_index = PipelineState.start(phase=0)
+    state_inp_index = PipelineState.start(phase=0)
+    y_inp_ready = PipelineState.start(phase=0)
+    u_inp_ready = PipelineState.start(phase=0)
+    decay_u_inp_ready = PipelineState.start(phase=0)
+
+    nvvm.tcgen05_alloc(tmem_base_slot, cutlass.Int32(512), group=nvvm.CTAGroup.CTA_1)
+    nvvm.barrier_cta_sync_aligned(
+        cfg.tmem_alloc_barrier_id,
+        thread_count=cfg.tmem_alloc_barrier_threads,
+    )
+
+    # ---- chunk-invariant GEMM descriptors ----------------------------------------
+    idesc_qk = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.b_t,
+        m_dim=2 * cfg.b_t,
+    )
+    bmm_qk_desc = MmaDesc(
+        M=2 * cfg.b_t,
+        N=cfg.b_t,
+        K=cfg.d_k,
+        bpe_a=cfg.io_dtype.width // 8,
+        bpe_b=cfg.io_dtype.width // 8,
+        tile_k_hw=16,
+        btranspose=False,
+        cta_group=1,
+        idesc=idesc_qk,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    bpe = cfg.io_dtype.width // 8
+    idesc_q_state = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.b_t,
+        m_dim=cfg.d_v,
+    )
+    bmm_q_state_desc = MmaDesc(
+        M=cfg.d_v,
+        N=cfg.b_t,
+        K=cfg.d_k,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=False,
+        atranspose=False,
+        cta_group=1,
+        idesc=idesc_q_state,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    idesc_qkv_ts = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.b_t,
+        m_dim=cfg.d_v,
+    )
+    bmm_qkv_ts_desc = MmaDesc(
+        M=cfg.d_v,
+        N=cfg.b_t,
+        K=cfg.b_t,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=False,
+        atranspose=False,
+        cta_group=1,
+        idesc=idesc_qkv_ts,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    idesc_kv = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.d_v,
+        m_dim=cfg.d_k,
+        b_major=1,
+    )
+    bmm_kv_desc = MmaDesc(
+        M=cfg.d_k,
+        N=cfg.d_v,
+        K=cfg.b_t,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=True,
+        atranspose=False,
+        cta_group=1,
+        idesc=idesc_kv,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    KQ_SEG = (2 * cfg.b_t * 64 * bpe) >> 4
+    KQ_BOX = (cfg.b_t * 64 * bpe) >> 4
+    KQ_HALF_K = (cfg.d_k // 16) // 2
+    KQ_A_HALF = KQ_HALF_K * bmm_q_state_desc.tmem_advance_A
+
+    ACC_STAGE_COLS = cfg.b_t
+    KV_ACC_STAGE_COLS = cfg.d_v
+    STATE_INP_STAGE_COLS = cfg.d_k // 2
+    INP_SLOT_COLS = cfg.b_t // 2
+
+    tmem_base = tmem_base_slot.load()
+    tmem_cg0_acc_col_f = tmem_base + cfg.tmem_cg0_acc_offset
+    tmem_state_col = tmem_base + cfg.tmem_state_acc_offset
+    tmem_q_state_col = tmem_base + cfg.tmem_q_state_acc_offset
+    tmem_state_inp_col = tmem_base + cfg.tmem_state_inp_offset
+    tmem_inp_col = tmem_base + cfg.tmem_y_decay_u_inp_offset
+    y_inp_ptr = nvvm.make_tmem_ptr(tmem_inp_col, cutlass.Int8)
+    u_inp_ptr = nvvm.make_tmem_ptr(tmem_inp_col, cutlass.Int8)
+    decay_u_inp_ptr = nvvm.make_tmem_ptr(tmem_inp_col + INP_SLOT_COLS, cutlass.Int8)
+    k_state_acc_ptr = nvvm.make_tmem_ptr(tmem_base + cfg.tmem_cg1_acc_offset, cutlass.Float32)
+    u_acc_ptr = k_state_acc_ptr
+
+    sched_state = PipelineState.start(phase=0)
+    tile_idx = cutlass.Int32(bidx)
+    while tile_idx < total_tiles:
+        (
+            batch_idx,
+            head_idx,
+            batch_start,
+            batch_end,
+            seqlen_b,
+            num_chunks_b,
+            wstart,
+            wend,
+            cstart,
+            cend,
+        ) = decode_work_item(cfg, tile_idx, mWorkItems)
+        n_local = wend - cstart
+
+        # ---- fused KK^T/QK^T pair 0: each member issued ahead of the loop -------
+        if n_local > 0:
+            f0_acc_idx = cg0_acc_index.idx
+            bars.mb_cg0_acc_done[f0_acc_idx].wait(cg0_acc_index.phase)
+            cg0_acc_index = advance(cg0_acc_index, cfg.tmem_cg0_acc_stages)
+            kqf_idx = kq_fused_index.idx
+            bars.mb_kq_ready[kqf_idx].wait(kq_fused_index.phase)
+            kq_fused_index = advance(kq_fused_index, cfg.smem_kq_stages)
+            desc_kqf = sKQ[kqf_idx].desc()
+            acc_cg0 = nvvm.make_tmem_ptr(
+                tmem_cg0_acc_col_f + f0_acc_idx * cfg.b_t, cutlass.Float32
+            )
+            mma_ss(bmm_qk_desc, desc_kqf, desc_kqf, acc_cg0, accumulate=False, k_count=KQ_HALF_K)
+            mma_ss(
+                bmm_qk_desc,
+                desc_kqf + KQ_SEG,
+                desc_kqf + KQ_SEG,
+                acc_cg0,
+                accumulate=True,
+                k_count=KQ_HALF_K,
+            )
+            if elect_one:
+                bars.mb_cg0_acc_ready[f0_acc_idx].arrive(cta_group=1)
+        if n_local > 1:
+            pend_acc_idx = cg0_acc_index.idx
+            bars.mb_cg0_acc_done[pend_acc_idx].wait(cg0_acc_index.phase)
+            cg0_acc_index = advance(cg0_acc_index, cfg.tmem_cg0_acc_stages)
+            kqf_idx = kq_fused_index.idx
+            bars.mb_kq_ready[kqf_idx].wait(kq_fused_index.phase)
+            kq_fused_index = advance(kq_fused_index, cfg.smem_kq_stages)
+            desc_kqf = sKQ[kqf_idx].desc()
+            desc_kqf_b = desc_kqf + KQ_BOX
+            acc_cg0 = nvvm.make_tmem_ptr(
+                tmem_cg0_acc_col_f + pend_acc_idx * cfg.b_t, cutlass.Float32
+            )
+            mma_ss(bmm_qk_desc, desc_kqf, desc_kqf_b, acc_cg0, accumulate=False, k_count=KQ_HALF_K)
+            mma_ss(
+                bmm_qk_desc,
+                desc_kqf + KQ_SEG,
+                desc_kqf_b + KQ_SEG,
+                acc_cg0,
+                accumulate=True,
+                k_count=KQ_HALF_K,
+            )
+            if elect_one:
+                bars.mb_cg0_acc_ready[pend_acc_idx].arrive(cta_group=1)
+
+        for local_idx in cutlass.range(n_local):  # noqa: B007
+            if cutlass.const_expr(cfg.use_initial_state):
+                if local_idx == 0:
+                    if elect_one:
+                        bars.mb_state_acc_ready[kv_acc_index.idx].arrive(cta_group=1)
+                    kv_acc_index = advance(kv_acc_index, cfg.tmem_state_acc_stages)
+            have_state = (
+                cutlass.Boolean(True)
+                if cutlass.const_expr(cfg.use_initial_state)
+                else local_idx > 0
+            )
+
+            kq_idx = kq_index.idx
+            member = local_idx & 1
+            state_inp_idx = state_inp_index.idx
+            q_state_acc_idx = o_acc_index.idx
+            tinv_idx = tinv_index.idx
+            a_idx = a_index.idx
+            o_scale_idx = o_state_scale_index.idx
+            kv_acc_idx = kv_acc_index.idx
+            kq_member_off = member * KQ_BOX
+            desc_k = sKQ[kq_idx].desc() + kq_member_off
+            desc_q = sKQ[kq_idx].desc() + (KQ_BOX - kq_member_off)
+            desc_tinv = sTinv[tinv_idx].desc()
+            desc_a = sA[a_idx].desc()
+            desc_kt = sKQ_trans[kq_idx].desc() + kq_member_off
+            state_a_ptr = nvvm.make_tmem_ptr(
+                tmem_state_inp_col + state_inp_idx * STATE_INP_STAGE_COLS, cutlass.Int8
+            )
+            q_state_acc_ptr = nvvm.make_tmem_ptr(
+                tmem_q_state_col + q_state_acc_idx * ACC_STAGE_COLS, cutlass.Float32
+            )
+            qkv_acc_ptr = nvvm.make_tmem_ptr(
+                tmem_q_state_col + o_scale_idx * ACC_STAGE_COLS, cutlass.Float32
+            )
+            state_acc_ptr = nvvm.make_tmem_ptr(
+                tmem_state_col + kv_acc_idx * KV_ACC_STAGE_COLS, cutlass.Float32
+            )
+
+            kq_index = advance(kq_index, cfg.smem_kq_stages)
+
+            # ---- QK/KK lookahead (member 1) = [Q;K](S) @ K^T ---------------------
+            if member == 1:
+                if local_idx + 2 < n_local:
+                    pend_acc_idx = cg0_acc_index.idx
+                    bars.mb_cg0_acc_done[pend_acc_idx].wait(cg0_acc_index.phase)
+                    cg0_acc_index = advance(cg0_acc_index, cfg.tmem_cg0_acc_stages)
+                    kqf_idx = kq_fused_index.idx
+                    bars.mb_kq_ready[kqf_idx].wait(kq_fused_index.phase)
+                    kq_fused_index = advance(kq_fused_index, cfg.smem_kq_stages)
+                    desc_kqf = sKQ[kqf_idx].desc()
+                    desc_kqf_b = desc_kqf + KQ_BOX
+                    acc_cg0 = nvvm.make_tmem_ptr(
+                        tmem_cg0_acc_col_f + pend_acc_idx * cfg.b_t, cutlass.Float32
+                    )
+                    mma_ss(
+                        bmm_qk_desc,
+                        desc_kqf,
+                        desc_kqf_b,
+                        acc_cg0,
+                        accumulate=False,
+                        k_count=KQ_HALF_K,
+                    )
+                    mma_ss(
+                        bmm_qk_desc,
+                        desc_kqf + KQ_SEG,
+                        desc_kqf_b + KQ_SEG,
+                        acc_cg0,
+                        accumulate=True,
+                        k_count=KQ_HALF_K,
+                    )
+                    if elect_one:
+                        bars.mb_cg0_acc_ready[pend_acc_idx].arrive(cta_group=1)
+
+            # ---- K*state^T (GEMM 3) = state^T(T) @ K^T ------------------------------------
+            if have_state:
+                bars.mb_state_inp_ready[state_inp_idx].wait(state_inp_index.phase)
+                state_inp_index = advance(state_inp_index, cfg.tmem_state_inp_stages)
+
+                for k in cutlass.range_constexpr(KQ_HALF_K):
+                    mma_ts_step(
+                        bmm_q_state_desc,
+                        state_a_ptr,
+                        desc_k,
+                        k_state_acc_ptr,
+                        k,
+                        cutlass.Boolean(k > 0),
+                    )
+                for k in cutlass.range_constexpr(KQ_HALF_K):
+                    mma_ts_step(
+                        bmm_q_state_desc,
+                        state_a_ptr.subview(KQ_A_HALF),
+                        desc_k + KQ_SEG,
+                        k_state_acc_ptr,
+                        k,
+                        cutlass.Boolean(True),
+                    )
+                if elect_one:
+                    bars.mb_k_state_acc_ready[0].arrive(cta_group=1)
+
+            # ---- Q*state^T (GEMM 4) = state^T(T) @ Q^T ------------------------------------
+            o_acc_index = advance(o_acc_index, cfg.tmem_q_state_acc_stages)
+            if have_state:
+                for k in cutlass.range_constexpr(KQ_HALF_K):
+                    mma_ts_step(
+                        bmm_q_state_desc,
+                        state_a_ptr,
+                        desc_q,
+                        q_state_acc_ptr,
+                        k,
+                        cutlass.Boolean(k > 0),
+                    )
+                for k in cutlass.range_constexpr(KQ_HALF_K):
+                    mma_ts_step(
+                        bmm_q_state_desc,
+                        state_a_ptr.subview(KQ_A_HALF),
+                        desc_q + KQ_SEG,
+                        q_state_acc_ptr,
+                        k,
+                        cutlass.Boolean(True),
+                    )
+                if elect_one:
+                    bars.mb_o_acc_ready[q_state_acc_idx].arrive(cta_group=1)
+
+            # ---- U^T (GEMM 5) = Y^T(T) @ T_inv^T ---------------------------------------
+            bars.mb_t_inv_ready[tinv_idx].wait(tinv_index.phase)
+            tinv_index = advance(tinv_index, cfg.smem_t_inv_stages)
+            bars.mb_y_inp_ready[0].wait(y_inp_ready.phase)
+            y_inp_ready = advance(y_inp_ready, 1)
+            for k in cutlass.range_constexpr(cfg.b_t // 16):
+                mma_ts_step(
+                    bmm_qkv_ts_desc, y_inp_ptr, desc_tinv, u_acc_ptr, k, cutlass.Boolean(k > 0)
+                )
+            if elect_one:
+                bars.mb_u_acc_ready[0].arrive(cta_group=1)
+                bars.mb_t_inv_done[tinv_idx].arrive(cta_group=1)
+
+            # ---- KK/QK lookahead (member 0) = [K;Q](S) @ K^T ---------------------
+            if member == 0:
+                if local_idx + 2 < n_local:
+                    f0_acc_idx = cg0_acc_index.idx
+                    bars.mb_cg0_acc_done[f0_acc_idx].wait(cg0_acc_index.phase)
+                    cg0_acc_index = advance(cg0_acc_index, cfg.tmem_cg0_acc_stages)
+                    kqf_idx = kq_fused_index.idx
+                    bars.mb_kq_ready[kqf_idx].wait(kq_fused_index.phase)
+                    kq_fused_index = advance(kq_fused_index, cfg.smem_kq_stages)
+                    desc_kqf = sKQ[kqf_idx].desc()
+                    acc_cg0 = nvvm.make_tmem_ptr(
+                        tmem_cg0_acc_col_f + f0_acc_idx * cfg.b_t, cutlass.Float32
+                    )
+                    mma_ss(
+                        bmm_qk_desc,
+                        desc_kqf,
+                        desc_kqf,
+                        acc_cg0,
+                        accumulate=False,
+                        k_count=KQ_HALF_K,
+                    )
+                    mma_ss(
+                        bmm_qk_desc,
+                        desc_kqf + KQ_SEG,
+                        desc_kqf + KQ_SEG,
+                        acc_cg0,
+                        accumulate=True,
+                        k_count=KQ_HALF_K,
+                    )
+                    if elect_one:
+                        bars.mb_cg0_acc_ready[f0_acc_idx].arrive(cta_group=1)
+
+            # ---- O^T (GEMM 6) += U input^T(T) @ A^T ------------------------------
+            bars.mb_a_ready[a_idx].wait(a_index.phase)
+            a_index = advance(a_index, cfg.smem_a_stages)
+            if have_state:
+                bars.mb_o_state_scale_acc_done[o_scale_idx].wait(o_state_scale_index.phase)
+                o_state_scale_index = advance(o_state_scale_index, cfg.tmem_q_state_acc_stages)
+            bars.mb_u_inp_ready[0].wait(u_inp_ready.phase)
+            u_inp_ready = advance(u_inp_ready, 1)
+            for k in cutlass.range_constexpr(cfg.b_t // 16):
+                mma_ts_step(
+                    bmm_qkv_ts_desc,
+                    u_inp_ptr,
+                    desc_a,
+                    qkv_acc_ptr,
+                    k,
+                    cutlass.Boolean(True) if cutlass.const_expr(k > 0) else have_state,
+                )
+            if elect_one:
+                bars.mb_a_done[a_idx].arrive(cta_group=1)
+                bars.mb_o_final_acc_ready[o_scale_idx].arrive(cta_group=1)
+
+            # ---- state^T (GEMM 7) += decayed U^T(T) @ K ------------------------------
+            bars.mb_decay_u_inp_ready[0].wait(decay_u_inp_ready.phase)
+            decay_u_inp_ready = advance(decay_u_inp_ready, 1)
+            kv_acc_index = advance(kv_acc_index, cfg.tmem_state_acc_stages)
+            for k in cutlass.range_constexpr(cfg.b_t // 16):
+                mma_ts_step(
+                    bmm_kv_desc,
+                    decay_u_inp_ptr,
+                    desc_kt,
+                    state_acc_ptr,
+                    k,
+                    cutlass.Boolean(True) if cutlass.const_expr(k > 0) else have_state,
+                )
+            if elect_one:
+                bars.mb_state_acc_ready[kv_acc_idx].arrive(cta_group=1)
+                bars.mb_kq_done[kq_idx].arrive(cta_group=1)
+
+        tile_idx, sched_state = sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas)
+
+    bars.mb_tmem_done[0].wait(0)
+    nvvm.tcgen05_relinquish_alloc_permit(group=nvvm.CTAGroup.CTA_1)
+    nvvm.tcgen05_dealloc(
+        nvvm.make_tmem_ptr(tmem_base, cutlass.Int8),
+        cutlass.Int32(512),
+        group=nvvm.CTAGroup.CTA_1,
+    )
+
+
+@cute.jit
+def tmaldg_warp(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    n_desc,
+    cu_seqlens,
+    mWorkItems,
+    sKQ_raw,
+    sV_raw,
+    desc_q_base,
+    desc_k_base,
+    desc_v_base,
+    mSched,
+    sSched,
+    bars,
+):
+    """TMA-LDG warp role (warp 9): persistent scheduler loop + per-chunk
+    Q/K/V G->S TMA loads."""
+    elect_one = nvvm.elect_sync()
+    nvvm.setmaxregister(cfg.num_regs_other, nvvm.SetMaxRegisterAction.DECREASE)
+    kq_index = PipelineState.start(phase=1)
+    v_index = PipelineState.start(phase=1)
+    sched_state = PipelineState.start(phase=1)
+    tile_idx = cutlass.Int32(bidx)
+
+    bpe = cfg.io_dtype.width // 8
+    elems_per_128b = 128 // bpe
+    bt = cfg.b_t
+    kq_stage_elems = cfg.kq_cosize // cfg.smem_kq_stages
+    kq_box_elems = kq_stage_elems // 4
+    sKQ_lo_tma = SmemTile(
+        base=sKQ_raw,
+        elems_per_stage=kq_stage_elems,
+        stages=cfg.smem_kq_stages,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=0,
+        tma_loads_per_tile=2,
+        tma_granu_elems=elems_per_128b,
+        tma_subtile_stride_elems=2 * bt * elems_per_128b,
+    )
+    sV_tma = SmemTile(
+        base=sV_raw,
+        elems_per_stage=cfg.v_cosize // cfg.smem_v_stages,
+        stages=cfg.smem_v_stages,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=0,
+        tma_loads_per_tile=2,
+        tma_granu_elems=elems_per_128b,
+        tma_subtile_stride_elems=4096,
+    )
+    heads_out = cutlass.Int32(cfg.n_heads_out)
+    desc_qwords = cutlass.Int32(TENSOR_MAP_QWORDS)
+    packed_tokens = cutlass.Int32(cu_seqlens[n_desc])
+
+    while tile_idx < total_tiles:
+        (
+            batch_idx,
+            head_idx,
+            batch_start,
+            batch_end,
+            seqlen_b,
+            num_chunks_b,
+            wstart,
+            wend,
+            cstart,
+            cend,
+        ) = decode_work_item(cfg, tile_idx, mWorkItems)
+
+        head_q = head_idx if cfg.q_ratio == 1 else head_idx // cutlass.Int32(cfg.q_ratio)
+        head_k = head_idx if cfg.k_ratio == 1 else head_idx // cutlass.Int32(cfg.k_ratio)
+        head_v = head_idx if cfg.v_ratio == 1 else head_idx // cutlass.Int32(cfg.v_ratio)
+        slot = batch_idx * desc_qwords
+        desc_q_slot = (desc_q_base + slot).tospace(cutlass.AddressSpace.generic)
+        desc_k_slot = (desc_k_base + slot).tospace(cutlass.AddressSpace.generic)
+        desc_v_slot = (desc_v_base + slot).tospace(cutlass.AddressSpace.generic)
+        if elect_one:
+            tma_tensormap_acquire(desc_q_slot)
+            tma_tensormap_acquire(desc_k_slot)
+            tma_tensormap_acquire(desc_v_slot)
+        use_packed_coords = batch_end == packed_tokens
+
+        if wend > cstart:
+            kq_idx = kq_index.idx
+            bars.mb_kq_done[kq_idx].wait(kq_index.phase)
+            kq_index = advance(kq_index, cfg.smem_kq_stages)
+            if elect_one:
+                bars.mb_kq_ready[kq_idx].arrive(n_bytes=cfg.tma_kq_bytes)
+            tok_coord = cstart * cutlass.Int32(cfg.b_t)
+            input_tok_coord = batch_start + tok_coord if use_packed_coords else tok_coord
+            k_slice = tma_slice_runtime_desc(
+                desc_k_slot, cutlass.Int32(0), head_k, input_tok_coord
+            )
+            q_slice = tma_slice_runtime_desc(
+                desc_q_slot, cutlass.Int32(0), head_q, input_tok_coord
+            )
+            kq_tile = sKQ_lo_tma[kq_idx]
+            tma_load_tile(kq_tile, k_slice, bars.mb_kq_ready[kq_idx].smem_ptr, acquire=False)
+            tma_load_tile(
+                kq_tile.shifted(kq_box_elems),
+                q_slice,
+                bars.mb_kq_ready[kq_idx].smem_ptr,
+                acquire=False,
+            )
+            for chunk_idx in cutlass.range(cstart + 1, wend):
+                tok_coord = chunk_idx * cutlass.Int32(cfg.b_t)
+                input_tok_coord = batch_start + tok_coord if use_packed_coords else tok_coord
+
+                # ---- K + Q interleaved -------------------------------------------
+                kq_idx = kq_index.idx
+                bars.mb_kq_done[kq_idx].wait(kq_index.phase)
+                kq_index = advance(kq_index, cfg.smem_kq_stages)
+                if elect_one:
+                    bars.mb_kq_ready[kq_idx].arrive(n_bytes=cfg.tma_kq_bytes)
+                member = (chunk_idx - cstart) & 1
+                k_slice = tma_slice_runtime_desc(
+                    desc_k_slot, cutlass.Int32(0), head_k, input_tok_coord
+                )
+                q_slice = tma_slice_runtime_desc(
+                    desc_q_slot, cutlass.Int32(0), head_q, input_tok_coord
+                )
+                kq_tile = sKQ_lo_tma[kq_idx]
+                if member == 0:
+                    tma_load_tile(
+                        kq_tile, k_slice, bars.mb_kq_ready[kq_idx].smem_ptr, acquire=False
+                    )
+                    tma_load_tile(
+                        kq_tile.shifted(kq_box_elems),
+                        q_slice,
+                        bars.mb_kq_ready[kq_idx].smem_ptr,
+                        acquire=False,
+                    )
+                else:
+                    tma_load_tile(
+                        kq_tile, q_slice, bars.mb_kq_ready[kq_idx].smem_ptr, acquire=False
+                    )
+                    tma_load_tile(
+                        kq_tile.shifted(kq_box_elems),
+                        k_slice,
+                        bars.mb_kq_ready[kq_idx].smem_ptr,
+                        acquire=False,
+                    )
+
+                # ---- V load ------------------------------------------------------
+                v_idx = v_index.idx
+                bars.mb_v_done[v_idx].wait(v_index.phase)
+                v_index = advance(v_index, cfg.smem_v_stages)
+                if elect_one:
+                    bars.mb_v_ready[v_idx].arrive(n_bytes=cfg.tma_v_bytes)
+                v_tok = (chunk_idx - 1) * cutlass.Int32(cfg.b_t)
+                input_v_tok = batch_start + v_tok if use_packed_coords else v_tok
+                v_slice = tma_slice_runtime_desc(
+                    desc_v_slot, cutlass.Int32(0), head_v, input_v_tok
+                )
+                tma_load_tile(
+                    sV_tma[v_idx], v_slice, bars.mb_v_ready[v_idx].smem_ptr, acquire=False
+                )
+
+            v_idx = v_index.idx
+            bars.mb_v_done[v_idx].wait(v_index.phase)
+            v_index = advance(v_index, cfg.smem_v_stages)
+            if elect_one:
+                bars.mb_v_ready[v_idx].arrive(n_bytes=cfg.tma_v_bytes)
+            v_tok = (wend - cutlass.Int32(1)) * cutlass.Int32(cfg.b_t)
+            input_v_tok = batch_start + v_tok if use_packed_coords else v_tok
+            v_slice = tma_slice_runtime_desc(desc_v_slot, cutlass.Int32(0), head_v, input_v_tok)
+            tma_load_tile(sV_tma[v_idx], v_slice, bars.mb_v_ready[v_idx].smem_ptr, acquire=False)
+
+        tile_idx, sched_state = sched_publish_next(
+            cfg, bars, sSched, mSched, sched_state, tile_idx, num_ctas
+        )
+
+    for _ in range(cfg.smem_kq_stages):
+        bars.mb_kq_done[kq_index.idx].wait(kq_index.phase)
+        kq_index = advance(kq_index, cfg.smem_kq_stages)
+    for _ in range(cfg.smem_v_stages):
+        bars.mb_v_done[v_index.idx].wait(v_index.phase)
+        v_index = advance(v_index, cfg.smem_v_stages)
+
+
+@cute.jit
+def compute0_warp_group(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    cu_seqlens,
+    mWorkItems,
+    tidx,
+    tmem_base_slot,
+    scale,
+    sCumsumlog,
+    sBeta,
+    sTinv,
+    sA,
+    sCheckpoint_raw,
+    checkpoint_every_n_tokens,
+    sSched,
+    bars,
+):
+    """Compute warp-group 0 role (warps 0-3): persistent scheduler loop
+    computing each chunk pair's T_inv and A epilogues."""
+
+    nvvm.setmaxregister(cfg.num_regs_compute_group_0, nvvm.SetMaxRegisterAction.INCREASE)
+    gate_index = PipelineState.start(phase=0)
+    beta_index = PipelineState.start(phase=0)
+    cg0_acc_ready = PipelineState.start(phase=0)
+    tinv_index = PipelineState.start(phase=1)
+    a_index = PipelineState.start(phase=1)
+
+    nvvm.barrier_cta_sync_aligned(
+        cfg.tmem_alloc_barrier_id,
+        thread_count=cfg.tmem_alloc_barrier_threads,
+    )
+    tmem_base = tmem_base_slot.load()
+
+    num_threads_cg0 = cfg.threads_per_warp * len(cfg.compute_group_0_warp_ids)
+    cg0_tidx = tidx % num_threads_cg0
+    warp_id = cg0_tidx // cfg.threads_per_warp
+    lane_id = cg0_tidx % cfg.threads_per_warp
+    inverse_local_warp = warp_id % 2
+    pair_half = warp_id // 2
+    half_row_base = inverse_local_warp * 32
+    bpe = cfg.io_dtype.width // 8
+    num_vals = 32
+    FRAG_COLS = 16
+    ACC_N_FRAGS = cfg.b_t // FRAG_COLS
+    store_row = warp_id * 16 + lane_id % 16
+    store_row_frag = lane_id % 16
+    store_col = (lane_id // 16) * 8
+    tmem_warp_row = warp_id * cfg.threads_per_warp
+    tmem_cg0_acc_col = tmem_base + cfg.tmem_cg0_acc_offset
+    ACC_STAGE_COLS = cfg.b_t
+    mask_zero = opaque_f32_zero()
+    crow_lo = warp_id * 16 + lane_id // 4
+    crow_hi = crow_lo + 8
+
+    sched_state = PipelineState.start(phase=0)
+    tile_idx = cutlass.Int32(bidx)
+    while tile_idx < total_tiles:
+        (
+            batch_idx,
+            head_idx,
+            batch_start,
+            batch_end,
+            seqlen_b,
+            num_chunks_b,
+            wstart,
+            wend,
+            cstart,
+            cend,
+        ) = decode_work_item(cfg, tile_idx, mWorkItems)
+        n_local = wend - cstart
+        n_pairs = (n_local + 1) // 2
+
+        for pair_i in cutlass.range(n_pairs):
+            # An odd chunk count leaves the last pair with member 0 only; have_m1
+            # is uniform across CG0, so the shared barriers below stay aligned.
+            have_m1 = pair_i * 2 + 1 < n_local
+            do_kk = have_m1 or pair_half == 0
+            do_a = have_m1 or pair_half == 1
+
+            # ---- Gate rows for this warp's KK / A member roles -------------------
+            gate0_idx = gate_index.idx
+            bars.mb_gate_ready[gate0_idx].wait(gate_index.phase)
+            gate_index = advance(gate_index, cfg.smem_gate_stages)
+            gate1_idx = gate0_idx
+            if have_m1:
+                gate1_idx = gate_index.idx
+                bars.mb_gate_ready[gate1_idx].wait(gate_index.phase)
+                gate_index = advance(gate_index, cfg.smem_gate_stages)
+            kk_gate_idx = gate1_idx if pair_half == 1 else gate0_idx
+            a_gate_idx = gate0_idx if pair_half == 1 else gate1_idx
+
+            row_u0_lo = half_row_base + lane_id // 4
+            row_u0_hi = row_u0_lo + 8
+            row_u1_lo = row_u0_lo + 16
+            row_u1_hi = row_u0_lo + 24
+
+            kk_cumsumlog_rows = []
+            a_cumsumlog_rows = []
+            for r in (row_u0_lo, row_u0_hi, row_u1_lo, row_u1_hi):
+                kk_cumsumlog_rows.append(sCumsumlog[r, 0, kk_gate_idx])
+                a_cumsumlog_rows.append(sCumsumlog[r, 0, a_gate_idx])
+            kk_cumsumlog_cols = []
+            a_cumsumlog_cols = []
+            for g in cutlass.range_constexpr(8):
+                for b in cutlass.range_constexpr(2):
+                    ccol = (lane_id % 4) * 2 + g * 8 + b
+                    kk_cumsumlog_cols.append(sCumsumlog[ccol, 0, kk_gate_idx])
+                    a_cumsumlog_cols.append(sCumsumlog[ccol, 0, a_gate_idx])
+
+            decay_t_kk = []
+            decay_t_a = []
+            for u in cutlass.range_constexpr(2):
+                for k in cutlass.range_constexpr(num_vals):
+                    hi_row = ((k // 2) % 2) == 1
+                    crow_u0 = row_u0_hi if cutlass.const_expr(hi_row) else row_u0_lo
+                    crow_u1 = row_u1_hi if cutlass.const_expr(hi_row) else row_u1_lo
+                    crow = crow_u1 if cutlass.const_expr(u == 1) else crow_u0
+                    ccol = (lane_id % 4) * 2 + ((k // 4) * 8 + k % 2)
+                    is_lower = crow >= ccol
+                    kk_row_cumsumlog = kk_cumsumlog_rows[u * 2 + (1 if hi_row else 0)]
+                    a_row_cumsumlog = a_cumsumlog_rows[u * 2 + (1 if hi_row else 0)]
+                    col = (k // 4) * 2 + (k % 2)
+                    decay_t_kk.append(
+                        cute.math.exp2(kk_row_cumsumlog - kk_cumsumlog_cols[col], fastmath=True)
+                        if is_lower
+                        else mask_zero
+                    )
+                    decay_t_a.append(
+                        cute.math.exp2(a_row_cumsumlog - a_cumsumlog_cols[col], fastmath=True)
+                        if is_lower
+                        else mask_zero
+                    )
+            bars.mb_gate_done[gate0_idx].arrive()
+            if have_m1:
+                bars.mb_gate_done[gate1_idx].arrive()
+
+            beta0_idx = beta_index.idx
+            bars.mb_beta_ready[beta0_idx].wait(beta_index.phase)
+            beta_index = advance(beta_index, cfg.smem_beta_stages)
+            beta1_idx = beta0_idx
+            if have_m1:
+                beta1_idx = beta_index.idx
+                bars.mb_beta_ready[beta1_idx].wait(beta_index.phase)
+                beta_index = advance(beta_index, cfg.smem_beta_stages)
+            kk_beta_idx = beta1_idx if pair_half == 1 else beta0_idx
+            kk_beta = []
+            for r in (row_u0_lo, row_u0_hi, row_u1_lo, row_u1_hi):
+                kk_beta.append(sBeta[r, 0, kk_beta_idx])
+
+            # ---- KK_epi (each warp pair stages its own member) -------------------
+            acc0_idx = cg0_acc_ready.idx
+            acc0_phase = cg0_acc_ready.phase
+            cg0_acc_ready = advance(cg0_acc_ready, cfg.tmem_cg0_acc_stages)
+            acc1_idx = acc0_idx
+            acc1_phase = acc0_phase
+            if have_m1:
+                acc1_idx = cg0_acc_ready.idx
+                acc1_phase = cg0_acc_ready.phase
+                cg0_acc_ready = advance(cg0_acc_ready, cfg.tmem_cg0_acc_stages)
+            kk_acc_idx = acc1_idx if pair_half == 1 else acc0_idx
+            kk_acc_phase = acc1_phase if pair_half == 1 else acc0_phase
+            a_acc_idx = acc0_idx if pair_half == 1 else acc1_idx
+
+            tinv0_idx = tinv_index.idx
+            tinv0_phase = tinv_index.phase
+            tinv_index = advance(tinv_index, cfg.smem_t_inv_stages)
+            tinv1_idx = tinv0_idx
+            tinv1_phase = tinv0_phase
+            if have_m1:
+                tinv1_idx = tinv_index.idx
+                tinv1_phase = tinv_index.phase
+                tinv_index = advance(tinv_index, cfg.smem_t_inv_stages)
+            kk_tinv_idx = tinv1_idx if pair_half == 1 else tinv0_idx
+            kk_tinv_phase = tinv1_phase if pair_half == 1 else tinv0_phase
+
+            tinv0_base = smem_data_ptr(sTinv[tinv0_idx].base).toint()
+            tinv1_base = smem_data_ptr(sTinv[tinv1_idx].base).toint()
+            kk_base = tinv1_base if pair_half == 1 else tinv0_base
+            if do_kk:
+                bars.mb_cg0_acc_ready[kk_acc_idx].wait(kk_acc_phase)
+                kk_vec0 = nvvm.tcgen05_ld(
+                    "16x256b",
+                    nvvm.make_tmem_ptr(
+                        (tmem_warp_row << 16) + tmem_cg0_acc_col + kk_acc_idx * ACC_STAGE_COLS,
+                        cutlass.Float32,
+                    ),
+                    num=8,
+                )
+                kk_vec1 = nvvm.tcgen05_ld(
+                    "16x256b",
+                    nvvm.make_tmem_ptr(
+                        ((tmem_warp_row + 16) << 16)
+                        + tmem_cg0_acc_col
+                        + kk_acc_idx * ACC_STAGE_COLS,
+                        cutlass.Float32,
+                    ),
+                    num=8,
+                )
+                bars.mb_t_inv_done[kk_tinv_idx].wait(kk_tinv_phase)
+                for u in cutlass.range_constexpr(2):
+                    kk_vec = kk_vec1 if cutlass.const_expr(u == 1) else kk_vec0
+                    kk_pack = []
+                    for k in cutlass.range_constexpr(num_vals // 2):
+                        b0 = (
+                            kk_beta[u * 2 + 1]
+                            if cutlass.const_expr((k % 2) == 1)
+                            else kk_beta[u * 2]
+                        )
+                        p0, p1 = fmul2(
+                            kk_vec[2 * k],
+                            kk_vec[2 * k + 1],
+                            decay_t_kk[u * num_vals + 2 * k],
+                            decay_t_kk[u * num_vals + 2 * k + 1],
+                        )
+                        v0, v1 = fmul2(p0, p1, b0, b0)
+                        kk_pack.append(fp32_to_fp16(v0, v1, dtype=cfg.io_dtype))
+                    st_row = half_row_base + u * 16 + store_row_frag
+                    for c in cutlass.range_constexpr(ACC_N_FRAGS):
+                        nvvm.stmatrix(
+                            cutlass.inttoptr(
+                                kk_base
+                                + (
+                                    st_row * cfg.b_t
+                                    + swizzle_xor_128b(st_row, store_col + c * FRAG_COLS)
+                                )
+                                * bpe,
+                                cutlass.AddressSpace.smem,
+                                cutlass.BFloat16,
+                            ),
+                            [
+                                kk_pack[c * 4 + 0],
+                                kk_pack[c * 4 + 1],
+                                kk_pack[c * 4 + 2],
+                                kk_pack[c * 4 + 3],
+                            ],
+                            nvvm.MMALayout.ROW,
+                        )
+
+            # ---- pair inverse: warps 0-1 own matrix 0, warps 2-3 matrix 1 --------
+            # With no member 1 there is one matrix, so warps 2-3 idle through the
+            # per-warp steps; the barriers below stay unconditional.
+            inv_base = tinv0_base
+            if have_m1:
+                inv_base = tinv1_base if warp_id >= 2 else tinv0_base
+            do_inv = have_m1 or warp_id < 2
+
+            # diagonal 8x8 Gauss-Jordan, all four warps
+            nvvm.barrier_cta_sync_aligned(
+                cfg.inverse_barrier_id,
+                thread_count=cfg.inverse_barrier_threads,
+            )
+            if do_inv:
+                invert_diagonal_NxN(
+                    cfg,
+                    inv_base,
+                    (inverse_local_warp * cfg.threads_per_warp + lane_id) // 8,
+                    cg0_tidx,
+                    8,
+                )
+            nvvm.barrier_cta_sync_aligned(
+                cfg.inverse_barrier_id,
+                thread_count=cfg.inverse_barrier_threads,
+            )
+
+            # 8x8 -> 16x16 (both matrices per warp)
+            blockwise_diagonal_8x8_to_16x16(cfg, tinv0_base, warp_id * 16, lane_id)
+            if have_m1:
+                blockwise_diagonal_8x8_to_16x16(cfg, tinv1_base, warp_id * 16, lane_id)
+            nvvm.barrier_cta_sync_aligned(
+                cfg.inverse_barrier_id,
+                thread_count=cfg.inverse_barrier_threads,
+            )
+
+            # 16x16 -> 32x32, one tile per warp within the group
+            if do_inv:
+                blockwise_diagonal_16x16_to_32x32(cfg, inv_base, inverse_local_warp * 32, lane_id)
+            nvvm.barrier_cta_sync_aligned(
+                cfg.inverse_barrier_id,
+                thread_count=cfg.inverse_barrier_threads,
+            )
+
+            # 32x32 -> 64x64, two warps per matrix
+            # all four warps: this step carries its own CG0 barrier, and on the tail
+            # inv_base is matrix 0 for every warp so the duplicate band is identical
+            blockwise_diagonal_32x32_to_64x64(cfg, inv_base, inverse_local_warp, lane_id)
+            nvvm.barrier_cta_sync_aligned(
+                cfg.inverse_barrier_id,
+                thread_count=cfg.inverse_barrier_threads,
+            )
+
+            # ---- Beta column-scaling + publish, stage 0 --------------------------
+            beta_col = []
+            for k in cutlass.range_constexpr(num_vals):
+                beta_col.append(sBeta[(lane_id % 4) * 2 + ((k // 4) * 8 + k % 2), 0, beta0_idx])
+            tinv_frags = []
+            for c in cutlass.range_constexpr(ACC_N_FRAGS):
+                tinv_frags += list(
+                    nvvm.ldmatrix(
+                        cutlass.inttoptr(
+                            tinv0_base
+                            + (
+                                store_row * cfg.b_t
+                                + swizzle_xor_128b(store_row, store_col + c * FRAG_COLS)
+                            )
+                            * bpe,
+                            cutlass.AddressSpace.smem,
+                            cutlass.BFloat16,
+                        ),
+                        4,
+                        nvvm.MMALayout.ROW,
+                    )
+                )
+            tinv_pack = []
+            for j in cutlass.range_constexpr(num_vals // 2):
+                lo, hi = f16x2_to_f32(tinv_frags[j], dtype=cfg.io_dtype)
+                s0, s1 = fmul2(lo, hi, beta_col[2 * j], beta_col[2 * j + 1])
+                tinv_pack.append(fp32_to_fp16(s0, s1, dtype=cfg.io_dtype))
+            for c in cutlass.range_constexpr(ACC_N_FRAGS):
+                nvvm.stmatrix(
+                    cutlass.inttoptr(
+                        tinv0_base
+                        + (
+                            store_row * cfg.b_t
+                            + swizzle_xor_128b(store_row, store_col + c * FRAG_COLS)
+                        )
+                        * bpe,
+                        cutlass.AddressSpace.smem,
+                        cutlass.BFloat16,
+                    ),
+                    [
+                        tinv_pack[c * 4 + 0],
+                        tinv_pack[c * 4 + 1],
+                        tinv_pack[c * 4 + 2],
+                        tinv_pack[c * 4 + 3],
+                    ],
+                    nvvm.MMALayout.ROW,
+                )
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_t_inv_ready[tinv0_idx].arrive()
+            bars.mb_beta_done[beta0_idx].arrive()
+
+            if have_m1:
+                # ---- Beta column-scaling + publish, stage 1 --------------------------
+                beta_col = []
+                for k in cutlass.range_constexpr(num_vals):
+                    beta_col.append(
+                        sBeta[(lane_id % 4) * 2 + ((k // 4) * 8 + k % 2), 0, beta1_idx]
+                    )
+                tinv_frags = []
+                for c in cutlass.range_constexpr(ACC_N_FRAGS):
+                    tinv_frags += list(
+                        nvvm.ldmatrix(
+                            cutlass.inttoptr(
+                                tinv1_base
+                                + (
+                                    store_row * cfg.b_t
+                                    + swizzle_xor_128b(store_row, store_col + c * FRAG_COLS)
+                                )
+                                * bpe,
+                                cutlass.AddressSpace.smem,
+                                cutlass.BFloat16,
+                            ),
+                            4,
+                            nvvm.MMALayout.ROW,
+                        )
+                    )
+                tinv_pack = []
+                for j in cutlass.range_constexpr(num_vals // 2):
+                    lo, hi = f16x2_to_f32(tinv_frags[j], dtype=cfg.io_dtype)
+                    s0, s1 = fmul2(lo, hi, beta_col[2 * j], beta_col[2 * j + 1])
+                    tinv_pack.append(fp32_to_fp16(s0, s1, dtype=cfg.io_dtype))
+                for c in cutlass.range_constexpr(ACC_N_FRAGS):
+                    nvvm.stmatrix(
+                        cutlass.inttoptr(
+                            tinv1_base
+                            + (
+                                store_row * cfg.b_t
+                                + swizzle_xor_128b(store_row, store_col + c * FRAG_COLS)
+                            )
+                            * bpe,
+                            cutlass.AddressSpace.smem,
+                            cutlass.BFloat16,
+                        ),
+                        [
+                            tinv_pack[c * 4 + 0],
+                            tinv_pack[c * 4 + 1],
+                            tinv_pack[c * 4 + 2],
+                            tinv_pack[c * 4 + 3],
+                        ],
+                        nvvm.MMALayout.ROW,
+                    )
+                nvvm.fence_proxy("async.shared", space="cta")
+                bars.mb_t_inv_ready[tinv1_idx].arrive()
+                bars.mb_beta_done[beta1_idx].arrive()
+
+            # ---- A_epi (opposite member, both halves in parallel) ----------------
+            a0_idx = a_index.idx
+            a0_phase = a_index.phase
+            a_index = advance(a_index, cfg.smem_a_stages)
+            a1_idx = a0_idx
+            a1_phase = a0_phase
+            if have_m1:
+                a1_idx = a_index.idx
+                a1_phase = a_index.phase
+                a_index = advance(a_index, cfg.smem_a_stages)
+            my_a_idx = a0_idx if pair_half == 1 else a1_idx
+            my_a_phase = a0_phase if pair_half == 1 else a1_phase
+
+            if do_a:
+                a_base = smem_data_ptr(sA[my_a_idx].base).toint()
+                a_vec0 = nvvm.tcgen05_ld(
+                    "16x256b",
+                    nvvm.make_tmem_ptr(
+                        (tmem_warp_row << 16) + tmem_cg0_acc_col + a_acc_idx * ACC_STAGE_COLS,
+                        cutlass.Float32,
+                    ),
+                    num=8,
+                )
+                a_vec1 = nvvm.tcgen05_ld(
+                    "16x256b",
+                    nvvm.make_tmem_ptr(
+                        ((tmem_warp_row + 16) << 16)
+                        + tmem_cg0_acc_col
+                        + a_acc_idx * ACC_STAGE_COLS,
+                        cutlass.Float32,
+                    ),
+                    num=8,
+                )
+                nvvm.tcgen05_wait("load")
+                bars.mb_cg0_acc_done[a_acc_idx].arrive()
+                bars.mb_a_done[my_a_idx].wait(my_a_phase)
+                for u in cutlass.range_constexpr(2):
+                    a_vec = a_vec1 if cutlass.const_expr(u == 1) else a_vec0
+                    a_pack = []
+                    for k in cutlass.range_constexpr(num_vals // 2):
+                        p0, p1 = fmul2(
+                            a_vec[2 * k],
+                            a_vec[2 * k + 1],
+                            decay_t_a[u * num_vals + 2 * k],
+                            decay_t_a[u * num_vals + 2 * k + 1],
+                        )
+                        v0, v1 = fmul2(p0, p1, scale, scale)
+                        a_pack.append(fp32_to_fp16(v0, v1, dtype=cfg.io_dtype))
+                    st_row = half_row_base + u * 16 + store_row_frag
+                    for c in cutlass.range_constexpr(ACC_N_FRAGS):
+                        nvvm.stmatrix(
+                            cutlass.inttoptr(
+                                a_base
+                                + (
+                                    st_row * cfg.b_t
+                                    + swizzle_xor_128b(st_row, store_col + c * FRAG_COLS)
+                                )
+                                * bpe,
+                                cutlass.AddressSpace.smem,
+                                cutlass.BFloat16,
+                            ),
+                            [
+                                a_pack[c * 4 + 0],
+                                a_pack[c * 4 + 1],
+                                a_pack[c * 4 + 2],
+                                a_pack[c * 4 + 3],
+                            ],
+                            nvvm.MMALayout.ROW,
+                        )
+                nvvm.fence_proxy("async.shared", space="cta")
+                bars.mb_a_ready[my_a_idx].arrive()
+
+        tile_idx, sched_state = sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas)
+    for _ in range(cfg.smem_t_inv_stages):
+        bars.mb_t_inv_done[tinv_index.idx].wait(tinv_index.phase)
+        tinv_index = advance(tinv_index, cfg.smem_t_inv_stages)
+    for _ in range(cfg.smem_a_stages):
+        bars.mb_a_done[a_index.idx].wait(a_index.phase)
+        a_index = advance(a_index, cfg.smem_a_stages)
+
+
+@cute.jit
+def compute1_warp_group(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    cu_seqlens,
+    mWorkItems,
+    tidx,
+    warp_idx,
+    tmem_base_slot,
+    scale,
+    sV,
+    sCumsumlog,
+    sCumprod,
+    sBeta,
+    sO,
+    sCheckpoint_raw,
+    mState_init,
+    mState_out,
+    checkpoint_every_n_tokens,
+    sSched,
+    bars,
+):
+    """Compute warp-group 1 role (warps 4-7): persistent scheduler loop
+    running the per-chunk state-update and output epilogues."""
+    elect_one = nvvm.elect_sync()
+
+    v_index = PipelineState.start(phase=0)
+    gate_index = PipelineState.start(phase=0)
+    kv_acc_index = PipelineState.start(phase=0)
+    o_acc_ready_index = PipelineState.start(phase=0)
+    o_final_acc_ready_index = PipelineState.start(phase=0)
+    k_state_ready_index = PipelineState.start(phase=0)
+    u_acc_ready_index = PipelineState.start(phase=0)
+    state_acc_seed_index = PipelineState.start(phase=1)
+    o_index = PipelineState.start(phase=1)
+    state_inp_cnt = cutlass.Int32(0)
+    kv_done_idx = cutlass.Int32(0)
+
+    nvvm.setmaxregister(cfg.num_regs_compute_group_1, nvvm.SetMaxRegisterAction.INCREASE)
+    nvvm.barrier_cta_sync_aligned(
+        cfg.tmem_alloc_barrier_id,
+        thread_count=cfg.tmem_alloc_barrier_threads,
+    )
+    tmem_base = tmem_base_slot.load()
+
+    num_threads_cg1 = cfg.threads_per_warp * len(cfg.compute_group_1_warp_ids)
+    cg1_tidx = tidx % num_threads_cg1
+    lane_id = cg1_tidx % cfg.threads_per_warp
+    tmem_warp_row = (cg1_tidx // cfg.threads_per_warp) * cfg.threads_per_warp
+    ldtm_width = 32
+    sttm_width = ldtm_width // 2
+    num_state_subs = cutlass.const_expr(cfg.d_v // ldtm_width)
+    tmem_state_col = tmem_base + cfg.tmem_state_acc_offset
+    tmem_state_inp_col = tmem_base + cfg.tmem_state_inp_offset
+    tmem_q_state_col = tmem_base + cfg.tmem_q_state_acc_offset
+    tmem_inp_col = tmem_base + cfg.tmem_y_decay_u_inp_offset
+    ACC_STAGE_COLS = cfg.b_t
+    INP_SLOT_COLS = cfg.b_t // 2
+    tmem_k_state_col = tmem_base + cfg.tmem_cg1_acc_offset
+    tmem_u_acc_col = tmem_k_state_col
+    tmem_y_inp_col = tmem_inp_col
+    tmem_u_inp_col = tmem_inp_col
+    tmem_decay_v_col = tmem_inp_col + INP_SLOT_COLS
+    v_o_smem_tok = cg1_tidx % 8 + (cg1_tidx // 16 % 2) * 8
+    v_o_smem_col = (cg1_tidx // 8 % 2) * 8 + (cg1_tidx // 32 % 2) * 32
+    v_o_smem_subtile_off = (cg1_tidx // 64) * 4096
+    v_stage_elems = cfg.v_cosize // cfg.smem_v_stages
+    o_stage_elems = cfg.o_cosize // cfg.smem_o_stages
+    sV_base = cute.make_ptr(
+        cfg.io_dtype,
+        smem_data_ptr(sV[0].base).toint(),
+        mem_space=cute.AddressSpace.smem,
+        assumed_align=cfg.buffer_align_bytes,
+    )
+    sO_base = cute.make_ptr(
+        cfg.io_dtype,
+        smem_data_ptr(sO[0].base).toint(),
+        mem_space=cute.AddressSpace.smem,
+        assumed_align=cfg.buffer_align_bytes,
+    )
+    num_vals = 32
+    if cutlass.const_expr(cfg.enable_checkpoints):
+        sCheckpoint_base_int = smem_data_ptr(sCheckpoint_raw).toint()
+        checkpoint_cnt = cutlass.Int32(0)
+        checkpoint_smem_row = cg1_tidx % 8 + (cg1_tidx // 16 % 2) * 8
+        checkpoint_smem_col = (cg1_tidx // 8 % 2) * 8 + (cg1_tidx // 32 % 2) * 32
+
+    sched_state = PipelineState.start(phase=0)
+    tile_idx = cutlass.Int32(bidx)
+    while tile_idx < total_tiles:
+        (
+            batch_idx,
+            head_idx,
+            batch_start,
+            batch_end,
+            seqlen_b,
+            num_chunks_b,
+            wstart,
+            wend,
+            cstart,
+            cend,
+        ) = decode_work_item(cfg, tile_idx, mWorkItems)
+        n_local = wend - cstart
+        if cutlass.const_expr(cfg.enable_checkpoints):
+            ckpt_chunks = checkpoint_every_n_tokens // cutlass.Int32(cfg.b_t)
+            checkpoint_mod = cstart % ckpt_chunks
+        if n_local > 0:
+            if cutlass.const_expr(cfg.use_initial_state):
+                # ---- initial-state seed: initial_state GMEM -> state TMEM ---------------
+                gState_init = mState_init[None, None, head_idx, batch_idx]
+                kv_init_idx = state_acc_seed_index.idx
+                bars.mb_state_acc_scale_done[kv_init_idx].wait(state_acc_seed_index.phase)
+                state_acc_seed_index = advance(state_acc_seed_index, cfg.tmem_state_acc_stages)
+                seed_from_initial_state = cstart == 0
+                if seed_from_initial_state:
+                    for sub in cutlass.range_constexpr(num_state_subs):
+                        words = []
+                        for k in cutlass.range_constexpr(32):
+                            v = gState_init[cg1_tidx, sub * ldtm_width + k]
+                            if cutlass.const_expr(cfg.state_dtype != cfg.acc_dtype):
+                                v = v.to(cfg.acc_dtype)
+                            words.append(v)
+                        nvvm.tcgen05_st(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(
+                                (tmem_warp_row << 16) + tmem_state_col + sub * ldtm_width,
+                                cutlass.Float32,
+                            ),
+                            cutlass.Vector.from_elements(tuple(words), cutlass.Float32),
+                        )
+                else:
+                    for sub in cutlass.range_constexpr(num_state_subs):
+                        nvvm.tcgen05_st(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(
+                                (tmem_warp_row << 16) + tmem_state_col + sub * ldtm_width,
+                                cutlass.Float32,
+                            ),
+                            cutlass.Vector.from_elements(
+                                tuple(cutlass.Float32(0.0) for _ in range(32)), cutlass.Float32
+                            ),
+                        )
+                nvvm.tcgen05_wait("store")
+
+                nvvm.barrier_cta_sync_aligned(
+                    cfg.init_state_store_barrier_id,
+                    thread_count=cfg.init_state_store_barrier_threads,
+                )
+
+            for local_idx in cutlass.range(n_local):  # noqa: B007
+                chunk_idx = cstart + local_idx
+                if cutlass.const_expr(cfg.enable_checkpoints):
+                    do_checkpoint_now = checkpoint_mod == 0
+                    checkpoint_mod = checkpoint_mod + cutlass.Int32(1)
+                    checkpoint_mod = (
+                        cutlass.Int32(0) if checkpoint_mod == ckpt_chunks else checkpoint_mod
+                    )
+                if cutlass.const_expr(cfg.enable_checkpoints and not cfg.use_initial_state):
+                    if chunk_idx == 0 and wstart == 0:
+                        checkpoint_stage = checkpoint_cnt % cfg.smem_checkpoint_stages
+                        checkpoint_phase_done = cutlass.Int32(1) ^ (
+                            (checkpoint_cnt // cfg.smem_checkpoint_stages) & cutlass.Int32(1)
+                        )
+                        bars.mb_checkpoint_tmastg_done[checkpoint_stage].wait(
+                            checkpoint_phase_done
+                        )
+                        checkpoint_zero_ptr = cutlass.inttoptr(
+                            sCheckpoint_base_int + checkpoint_stage * cfg.d_k * cfg.d_v * 2,
+                            cutlass.AddressSpace.smem,
+                            cutlass.Int32,
+                        )
+                        for z in cutlass.range_constexpr(
+                            cfg.d_k * cfg.d_v // 2 // num_threads_cg1
+                        ):
+                            (checkpoint_zero_ptr + cg1_tidx + z * num_threads_cg1).store(
+                                cutlass.Int32(0)
+                            )
+                        nvvm.fence_proxy("async.shared", space="cta")
+                        if elect_one:
+                            bars.mb_checkpoint_tmastg_ready[checkpoint_stage].arrive()
+                        checkpoint_cnt = checkpoint_cnt + 1
+                valid_state = local_idx > 0
+                if cutlass.const_expr(cfg.use_initial_state):
+                    valid_state = cutlass.Boolean(True)
+                    state_acc_seed_index = advance(state_acc_seed_index, cfg.tmem_state_acc_stages)
+
+                gate_idx = gate_index.idx
+                bars.mb_gate_ready[gate_idx].wait(gate_index.phase)
+                gate_index = advance(gate_index, cfg.smem_gate_stages)
+                cumprod_total = sCumprod[sCumprod.shape[0] - 1, 0, gate_idx]
+
+                # ---- state restage + rescale -------------------------------------
+                if valid_state:
+                    kv_idx = kv_acc_index.idx
+                    bars.mb_state_acc_ready[kv_idx].wait(kv_acc_index.phase)
+                    kv_acc_index = advance(kv_acc_index, cfg.tmem_state_acc_stages)
+                    kv_done_idx = kv_idx
+
+                    state_regs = [
+                        [cutlass.Float32(0.0) for _ in range(num_state_subs)] for _ in range(32)
+                    ]
+                    state_inp_stage_idx = state_inp_cnt % cfg.tmem_state_inp_stages
+                    state_vecs = []
+                    for sub in cutlass.range_constexpr(num_state_subs):
+                        state_vecs.append(
+                            nvvm.tcgen05_ld(
+                                "32x32b",
+                                nvvm.make_tmem_ptr(
+                                    (tmem_warp_row << 16) + tmem_state_col + sub * ldtm_width,
+                                    cutlass.Float32,
+                                ),
+                                num=32,
+                            )
+                        )
+                    for sub in cutlass.range_constexpr(num_state_subs):
+                        for k in cutlass.range_constexpr(32):
+                            state_regs[k][sub] = state_vecs[sub][k]
+                        state_pack = [
+                            fp32_to_fp16(
+                                state_regs[2 * j][sub],
+                                state_regs[2 * j + 1][sub],
+                                dtype=cfg.io_dtype,
+                            )
+                            for j in range(16)
+                        ]
+                        nvvm.tcgen05_st(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(
+                                (tmem_warp_row << 16) + tmem_state_inp_col + sub * sttm_width,
+                                cutlass.Int32,
+                            ),
+                            cutlass.Vector.from_elements(tuple(state_pack), cutlass.Int32),
+                        )
+                    nvvm.tcgen05_wait("store")
+                    bars.mb_state_inp_ready[state_inp_stage_idx].arrive()
+                    state_inp_cnt = state_inp_cnt + 1
+
+                    if cutlass.const_expr(cfg.enable_checkpoints):
+                        # ---- state checkpoint ----------------------------------------
+                        do_checkpoint = do_checkpoint_now and chunk_idx < wend
+                        do_checkpoint = do_checkpoint and chunk_idx >= wstart
+                        if do_checkpoint:
+                            checkpoint_stage = checkpoint_cnt % cfg.smem_checkpoint_stages
+                            checkpoint_phase_done = cutlass.Int32(1) ^ (
+                                (checkpoint_cnt // cfg.smem_checkpoint_stages) & cutlass.Int32(1)
+                            )
+                            bars.mb_checkpoint_tmastg_done[checkpoint_stage].wait(
+                                checkpoint_phase_done
+                            )
+                            checkpoint_stage_base = checkpoint_stage * cfg.d_k * cfg.d_v
+                            for sub in cutlass.range_constexpr(num_state_subs):
+                                checkpoint_vec = nvvm.tcgen05_ld(
+                                    "32x32b",
+                                    nvvm.make_tmem_ptr(
+                                        (tmem_warp_row << 16) + tmem_state_col + sub * ldtm_width,
+                                        cutlass.Float32,
+                                    ),
+                                    num=32,
+                                )
+                                for g in cutlass.range_constexpr(ldtm_width // 8):
+                                    packs = tuple(
+                                        fp32_to_fp16(
+                                            checkpoint_vec[g * 8 + 2 * t],
+                                            checkpoint_vec[g * 8 + 2 * t + 1],
+                                            dtype=cfg.io_dtype,
+                                        )
+                                        for t in range(4)
+                                    )
+                                    dk = sub * ldtm_width + g * 8
+                                    checkpoint_addr = (
+                                        checkpoint_stage_base
+                                        + (dk // 64) * (cfg.d_v * 64)
+                                        + cg1_tidx * 64
+                                        + swizzle_xor_128b(cg1_tidx, dk % 64)
+                                    )
+                                    (smem_data_ptr(sCheckpoint_raw) + checkpoint_addr).store(
+                                        cutlass.Vector.from_elements(packs, cutlass.Int32).bitcast(
+                                            cfg.io_dtype
+                                        ),
+                                        alignment=16,
+                                    )
+                            nvvm.fence_proxy("async.shared", space="cta")
+                            if elect_one:
+                                bars.mb_checkpoint_tmastg_ready[checkpoint_stage].arrive()
+                            checkpoint_cnt = checkpoint_cnt + 1
+
+                    for sub in cutlass.range_constexpr(num_state_subs):
+                        state_scaled = []
+                        for j in cutlass.range_constexpr(16):
+                            s0, s1 = fmul2(
+                                state_regs[2 * j][sub],
+                                state_regs[2 * j + 1][sub],
+                                cumprod_total,
+                                cumprod_total,
+                            )
+                            state_scaled += [s0, s1]
+                        nvvm.tcgen05_st(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(
+                                (tmem_warp_row << 16) + tmem_state_col + sub * ldtm_width,
+                                cutlass.Float32,
+                            ),
+                            cutlass.Vector.from_elements(tuple(state_scaled), cutlass.Float32),
+                        )
+                    nvvm.tcgen05_wait("store")
+                    bars.mb_state_acc_scale_done[kv_idx].arrive()
+
+                # ---- per-row Gate register builds --------------------------------
+                cumprod_vals = []
+                for k in cutlass.range_constexpr(num_vals):
+                    cumprod_vals.append(
+                        sCumprod[(lane_id % 4) * 2 + ((k // 4) * 8 + k % 2), 0, gate_idx]
+                    )
+                last_cumsumlog = sCumsumlog[cfg.b_t - 1, 0, gate_idx]
+                cumsumlog_vals = []
+                for k in cutlass.range_constexpr(num_vals):
+                    cumsumlog_vals.append(
+                        sCumsumlog[(lane_id % 4) * 2 + ((k // 4) * 8 + k % 2), 0, gate_idx]
+                    )
+                decay_scale_vals = []
+                for k in cutlass.range_constexpr(0, num_vals, 2):
+                    d0, d1 = fadd2(
+                        last_cumsumlog, last_cumsumlog, -cumsumlog_vals[k], -cumsumlog_vals[k + 1]
+                    )
+                    decay_scale_vals.append(cute.math.exp2(d0, fastmath=True))
+                    decay_scale_vals.append(cute.math.exp2(d1, fastmath=True))
+                bars.mb_gate_done[gate_idx].arrive()
+
+                # ---- Y = V - K*state (packed 16-bit) -----------------------------
+                v_idx = v_index.idx
+                bars.mb_v_ready[v_idx].wait(v_index.phase)
+                v_index = advance(v_index, cfg.smem_v_stages)
+
+                v_frags = [[cutlass.Int32(0), cutlass.Int32(0)] for _ in range(16)]
+                for c in cutlass.range_constexpr(8):
+                    m0 = cutlass.const_expr(c % 4)
+                    sub = cutlass.const_expr(c // 4)
+                    v_frag = nvvm.ldmatrix(
+                        (
+                            sV_base
+                            + v_idx * v_stage_elems
+                            + v_o_smem_subtile_off
+                            + (v_o_smem_tok + m0 * 16) * 64
+                            + swizzle_xor_128b(v_o_smem_tok + m0 * 16, v_o_smem_col + sub * 16)
+                        ).raw_ptr(),
+                        4,
+                        nvvm.MMALayout.COL,
+                    )
+                    for i in cutlass.range_constexpr(4):
+                        v_frags[4 * m0 + i][sub] = v_frag[i]
+                if valid_state:
+                    bars.mb_k_state_acc_ready[0].wait(k_state_ready_index.phase)
+                    k_state_ready_index = advance(k_state_ready_index, 1)
+
+                    for sub in cutlass.range_constexpr(2):
+                        k_state_vec = nvvm.tcgen05_ld(
+                            "16x256b",
+                            nvvm.make_tmem_ptr(
+                                ((tmem_warp_row + sub * 16) << 16) + tmem_k_state_col,
+                                cutlass.Float32,
+                            ),
+                            num=8,
+                        )
+                        for j in cutlass.range_constexpr(16):
+                            s0, s1 = fmul2(
+                                k_state_vec[2 * j],
+                                k_state_vec[2 * j + 1],
+                                cumprod_vals[2 * j],
+                                cumprod_vals[2 * j + 1],
+                            )
+                            k_state_word = fp32_to_fp16(s0, s1, dtype=cfg.io_dtype)
+                            v_frags[j][sub] = sub_f16x2(
+                                v_frags[j][sub], k_state_word, cfg.io_dtype
+                            )
+                for sub in cutlass.range_constexpr(2):
+                    nvvm.tcgen05_st(
+                        "16x128b",
+                        nvvm.make_tmem_ptr(
+                            ((tmem_warp_row + sub * 16) << 16) + tmem_y_inp_col, cutlass.Int32
+                        ),
+                        cutlass.Vector.from_elements(
+                            tuple(v_frags[j][sub] for j in range(16)), cutlass.Int32
+                        ),
+                    )
+                nvvm.tcgen05_wait("store")
+                bars.mb_y_inp_ready[0].arrive()
+
+                # ---- state*Q_epi: Q*state *= cumprod * scale ----------------
+                if valid_state:
+                    q_state_idx = o_acc_ready_index.idx
+                    bars.mb_o_acc_ready[q_state_idx].wait(o_acc_ready_index.phase)
+                    o_acc_ready_index = advance(o_acc_ready_index, cfg.tmem_q_state_acc_stages)
+
+                    q_state_ptrs = []
+                    q_state_vecs = []
+                    for sub in cutlass.range_constexpr(2):
+                        q_state_ptrs.append(
+                            nvvm.make_tmem_ptr(
+                                ((tmem_warp_row + sub * 16) << 16)
+                                + tmem_q_state_col
+                                + q_state_idx * ACC_STAGE_COLS,
+                                cutlass.Float32,
+                            )
+                        )
+                        q_state_vecs.append(nvvm.tcgen05_ld("16x256b", q_state_ptrs[sub], num=8))
+                    for sub in cutlass.range_constexpr(2):
+                        q_state_scaled = []
+                        for j in cutlass.range_constexpr(16):
+                            p0, p1 = fmul2(
+                                q_state_vecs[sub][2 * j],
+                                q_state_vecs[sub][2 * j + 1],
+                                cumprod_vals[2 * j],
+                                cumprod_vals[2 * j + 1],
+                            )
+                            s0, s1 = fmul2(p0, p1, scale, scale)
+                            q_state_scaled += [s0, s1]
+                        nvvm.tcgen05_st(
+                            "16x256b",
+                            q_state_ptrs[sub],
+                            cutlass.Vector.from_elements(tuple(q_state_scaled), cutlass.Float32),
+                        )
+                    nvvm.tcgen05_wait("store")
+
+                    bars.mb_o_state_scale_acc_done[q_state_idx].arrive()
+
+                # ---- U_epi + decayed-U publish -----------------------------------
+                bars.mb_u_acc_ready[0].wait(u_acc_ready_index.phase)
+                u_acc_ready_index = advance(u_acc_ready_index, 1)
+                bars.mb_v_done[v_idx].arrive()
+
+                u_regs = [[cutlass.Float32(0.0), cutlass.Float32(0.0)] for _ in range(32)]
+                u_vecs = []
+                for sub in cutlass.range_constexpr(2):
+                    u_vecs.append(
+                        nvvm.tcgen05_ld(
+                            "16x256b",
+                            nvvm.make_tmem_ptr(
+                                ((tmem_warp_row + sub * 16) << 16) + tmem_u_acc_col,
+                                cutlass.Float32,
+                            ),
+                            num=8,
+                        )
+                    )
+                for sub in cutlass.range_constexpr(2):
+                    for k in cutlass.range_constexpr(32):
+                        u_regs[k][sub] = u_vecs[sub][k]
+
+                    u_pack = [
+                        fp32_to_fp16(
+                            u_regs[2 * j][sub], u_regs[2 * j + 1][sub], dtype=cfg.io_dtype
+                        )
+                        for j in range(16)
+                    ]
+                    nvvm.tcgen05_st(
+                        "16x128b",
+                        nvvm.make_tmem_ptr(
+                            ((tmem_warp_row + sub * 16) << 16) + tmem_u_inp_col, cutlass.Int32
+                        ),
+                        cutlass.Vector.from_elements(tuple(u_pack), cutlass.Int32),
+                    )
+                nvvm.tcgen05_wait("store")
+                bars.mb_u_inp_ready[0].arrive()
+
+                for sub in cutlass.range_constexpr(2):
+                    for j in cutlass.range_constexpr(16):
+                        u_regs[2 * j][sub], u_regs[2 * j + 1][sub] = fmul2(
+                            u_regs[2 * j][sub],
+                            u_regs[2 * j + 1][sub],
+                            decay_scale_vals[2 * j],
+                            decay_scale_vals[2 * j + 1],
+                        )
+                    decay_pack = [
+                        fp32_to_fp16(
+                            u_regs[2 * j][sub], u_regs[2 * j + 1][sub], dtype=cfg.io_dtype
+                        )
+                        for j in range(16)
+                    ]
+                    nvvm.tcgen05_st(
+                        "16x128b",
+                        nvvm.make_tmem_ptr(
+                            ((tmem_warp_row + sub * 16) << 16) + tmem_decay_v_col, cutlass.Int32
+                        ),
+                        cutlass.Vector.from_elements(tuple(decay_pack), cutlass.Int32),
+                    )
+                nvvm.tcgen05_wait("store")
+                bars.mb_decay_u_inp_ready[0].arrive()
+
+                # ---- QKV_epilogue: O acc TMEM -> sO SMEM -------------------------
+                o_scale_idx = o_final_acc_ready_index.idx
+                bars.mb_o_final_acc_ready[o_scale_idx].wait(o_final_acc_ready_index.phase)
+                o_final_acc_ready_index = advance(
+                    o_final_acc_ready_index, cfg.tmem_q_state_acc_stages
+                )
+
+                o_regs = []
+                for sub in cutlass.range_constexpr(2):
+                    o_vec = nvvm.tcgen05_ld(
+                        "16x256b",
+                        nvvm.make_tmem_ptr(
+                            ((tmem_warp_row + sub * 16) << 16)
+                            + tmem_q_state_col
+                            + o_scale_idx * ACC_STAGE_COLS,
+                            cutlass.Float32,
+                        ),
+                        num=8,
+                    )
+                    o_regs.append([o_vec[k] for k in range(32)])
+                nvvm.tcgen05_wait("load")
+                o_idx = o_index.idx
+                bars.mb_o_tmastg_done[o_idx].wait(o_index.phase)
+                o_index = advance(o_index, cfg.smem_o_stages)
+                for sub in cutlass.range_constexpr(2):
+                    for m0 in cutlass.range_constexpr(4):
+                        o_pack = [
+                            fp32_to_fp16(
+                                o_regs[sub][8 * m0 + 2 * j],
+                                o_regs[sub][8 * m0 + 2 * j + 1],
+                                dtype=cfg.io_dtype,
+                            )
+                            for j in range(4)
+                        ]
+                        nvvm.stmatrix(
+                            (
+                                sO_base
+                                + o_idx * o_stage_elems
+                                + v_o_smem_subtile_off
+                                + (v_o_smem_tok + m0 * 16) * 64
+                                + swizzle_xor_128b(v_o_smem_tok + m0 * 16, v_o_smem_col + sub * 16)
+                            ).raw_ptr(),
+                            o_pack,
+                            nvvm.MMALayout.COL,
+                        )
+                nvvm.fence_proxy("async.shared", space="cta")
+                bars.mb_o_tmastg_ready[o_idx].arrive()
+
+        # ---- final state: state TMEM -> GMEM -----------------------------------
+        if n_local > 0:
+            kv_last_idx = kv_acc_index.idx
+            bars.mb_state_acc_ready[kv_last_idx].wait(kv_acc_index.phase)
+            kv_acc_index = advance(kv_acc_index, cfg.tmem_state_acc_stages)
+            if cutlass.const_expr(cfg.store_final_state):
+                if wend == num_chunks_b:
+                    gState_out = mState_out[None, None, head_idx, batch_idx]
+                    for sub in cutlass.range_constexpr(num_state_subs):
+                        state_vec = nvvm.tcgen05_ld(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(
+                                (tmem_warp_row << 16) + tmem_state_col + sub * ldtm_width,
+                                cutlass.Float32,
+                            ),
+                            num=32,
+                        )
+                        for k in cutlass.range_constexpr(32):
+                            val = state_vec[k]
+                            if cutlass.const_expr(cfg.state_dtype != cfg.acc_dtype):
+                                val = val.to(cfg.state_dtype)
+                            gState_out[cg1_tidx, sub * ldtm_width + k] = val
+                bars.mb_state_acc_scale_done[kv_last_idx].arrive()
+            else:
+                bars.mb_state_acc_scale_done[kv_last_idx].arrive()
+        else:
+            if cutlass.const_expr(cfg.store_final_state):
+                write_passthrough = wend == num_chunks_b
+                if write_passthrough:
+                    gState_out = mState_out[None, None, head_idx, batch_idx]
+                    if cutlass.const_expr(cfg.use_initial_state):
+                        gState_in = mState_init[None, None, head_idx, batch_idx]
+                        for sub in cutlass.range_constexpr(num_state_subs):
+                            for k in cutlass.range_constexpr(32):
+                                gState_out[cg1_tidx, sub * ldtm_width + k] = gState_in[
+                                    cg1_tidx, sub * ldtm_width + k
+                                ]
+                    else:
+                        for sub in cutlass.range_constexpr(num_state_subs):
+                            for k in cutlass.range_constexpr(32):
+                                gState_out[cg1_tidx, sub * ldtm_width + k] = cutlass.Float32(
+                                    0.0
+                                ).to(cfg.state_dtype)
+
+        tile_idx, sched_state = sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas)
+
+    bars.mb_tmem_done[0].arrive()
+
+    for _ in range(cfg.smem_o_stages):
+        bars.mb_o_tmastg_done[o_index.idx].wait(o_index.phase)
+        o_index = advance(o_index, cfg.smem_o_stages)
+    if cutlass.const_expr(cfg.enable_checkpoints):
+        for _ in range(cfg.smem_checkpoint_stages):
+            checkpoint_stage = checkpoint_cnt % cfg.smem_checkpoint_stages
+            checkpoint_phase_done = cutlass.Int32(1) ^ (
+                (checkpoint_cnt // cfg.smem_checkpoint_stages) & cutlass.Int32(1)
+            )
+            bars.mb_checkpoint_tmastg_done[checkpoint_stage].wait(checkpoint_phase_done)
+            checkpoint_cnt = checkpoint_cnt + 1
+
+
+@cute.jit
+def build_descs_body(
+    widx,
+    base_q,
+    base_k,
+    base_v,
+    base_o,
+    base_checkpoint,
+    desc_ws: cute.Tensor,
+    cu_seqlens: cute.Tensor,
+    q: cute.Tensor,
+    k: cute.Tensor,
+    v: cute.Tensor,
+    o: Optional[cute.Tensor],
+    state_checkpoints_out: Optional[cute.Tensor],
+    n_batch: cutlass.Int32,
+    q_row_stride: cutlass.Int64,
+    k_row_stride: cutlass.Int64,
+    v_row_stride: cutlass.Int64,
+    o_row_stride: cutlass.Int64,
+    checkpoint_row_stride: cutlass.Int64,
+    checkpoint_every_n: cutlass.Int32,
+) -> None:
+    """Per-batch descriptor-array build, one warp per array. Runs inside the
+    prologue kernel after its order pass; warps past the array count fall
+    through the widx guards."""
+    arr_words = n_batch * cutlass.Int32(TENSOR_MAP_QWORDS)
+    sub0 = cute.make_tensor(desc_ws.iterator, cute.make_layout((arr_words,), stride=(1,)))
+    sub1 = cute.make_tensor(
+        desc_ws.iterator + arr_words, cute.make_layout((arr_words,), stride=(1,))
+    )
+    sub2 = cute.make_tensor(
+        desc_ws.iterator + 2 * arr_words, cute.make_layout((arr_words,), stride=(1,))
+    )
+    sub3 = cute.make_tensor(
+        desc_ws.iterator + 3 * arr_words, cute.make_layout((arr_words,), stride=(1,))
+    )
+    sub4 = cute.make_tensor(
+        desc_ws.iterator + 4 * arr_words, cute.make_layout((arr_words,), stride=(1,))
+    )
+
+    if widx == 0:
+        if nvvm.elect_sync():
+            emit_seq_load_descs(base_q, sub0, cu_seqlens, q, n_batch, q_row_stride, 2)
+            nvvm.fence_proxy_release(
+                nvvm.MemScope.GPU, from_proxy=nvvm.Proxy.GENERIC, to_proxy=nvvm.Proxy.TENSORMAP
+            )
+    if widx == 1:
+        if nvvm.elect_sync():
+            emit_seq_load_descs(base_k, sub1, cu_seqlens, k, n_batch, k_row_stride, 2)
+            nvvm.fence_proxy_release(
+                nvvm.MemScope.GPU, from_proxy=nvvm.Proxy.GENERIC, to_proxy=nvvm.Proxy.TENSORMAP
+            )
+    if widx == 2:
+        if nvvm.elect_sync():
+            emit_seq_load_descs(base_v, sub2, cu_seqlens, v, n_batch, v_row_stride, 2)
+            nvvm.fence_proxy_release(
+                nvvm.MemScope.GPU, from_proxy=nvvm.Proxy.GENERIC, to_proxy=nvvm.Proxy.TENSORMAP
+            )
+    if cutlass.const_expr(o is not None):
+        if widx == 3:
+            if nvvm.elect_sync():
+                emit_seq_descs(base_o, sub3, cu_seqlens, o, n_batch, o_row_stride, 2)
+                nvvm.fence_proxy_release(
+                    nvvm.MemScope.GPU, from_proxy=nvvm.Proxy.GENERIC, to_proxy=nvvm.Proxy.TENSORMAP
+                )
+    if cutlass.const_expr(state_checkpoints_out is not None):
+        if widx == 4:
+            if nvvm.elect_sync():
+                emit_checkpoint_seq_descs(
+                    base_checkpoint,
+                    sub4,
+                    cu_seqlens,
+                    state_checkpoints_out,
+                    n_batch,
+                    checkpoint_row_stride,
+                    checkpoint_every_n,
+                    2,
+                )
+                nvvm.fence_proxy_release(
+                    nvvm.MemScope.GPU, from_proxy=nvvm.Proxy.GENERIC, to_proxy=nvvm.Proxy.TENSORMAP
+                )
+
+
+@cute.kernel
+def prologue_kernel(
+    order_gen: cutlass.Constexpr[bool],
+    has_sched: cutlass.Constexpr[bool],
+    b_t: cutlass.Constexpr[int],
+    base_q: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    base_k: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    base_v: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    base_o: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    base_checkpoint: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    desc_ws: cute.Tensor,
+    cu_seqlens: cute.Tensor,
+    q: cute.Tensor,
+    k: cute.Tensor,
+    v: cute.Tensor,
+    o: Optional[cute.Tensor],
+    state_checkpoints_out: Optional[cute.Tensor],
+    mStaging: Optional[cute.Tensor],
+    mCount: cute.Tensor,
+    mWorkItems: cute.Tensor,
+    mSched: Optional[cute.Tensor],
+    n_batch: cutlass.Int32,
+    q_row_stride: cutlass.Int64,
+    k_row_stride: cutlass.Int64,
+    v_row_stride: cutlass.Int64,
+    o_row_stride: cutlass.Int64,
+    checkpoint_row_stride: cutlass.Int64,
+    checkpoint_every_n: cutlass.Int32,
+) -> None:
+    """Single-CTA prologue: LPT-order the work-item table and zero the sched
+    rings via :func:`order_body`, then build the per-batch TMA-descriptor
+    arrays via :func:`build_descs_body`, one warp per array (the extra warps
+    only take part in the order phase)."""
+    tidx, _, _ = cute.arch.thread_idx()
+    tidx = cutlass.Int32(tidx)
+    widx = tidx // cutlass.Int32(32)
+    sKey = cutlass.Array(
+        cutlass.Int32, ORDER_CAPACITY, space=cutlass.AddressSpace.smem, alignment=16
+    )
+    sIdx = cutlass.Array(
+        cutlass.Int32, ORDER_CAPACITY, space=cutlass.AddressSpace.smem, alignment=16
+    )
+    sSpread = cutlass.Array(cutlass.Int32, 2, space=cutlass.AddressSpace.smem, alignment=8)
+    n_heads_out = cutlass.Int32(q.shape[1] if q.shape[1] >= v.shape[1] else v.shape[1])
+    order_body(
+        order_gen,
+        has_sched,
+        b_t,
+        ORDER_THREADS,
+        ORDER_ELEMS,
+        tidx,
+        n_heads_out,
+        n_heads_out * n_batch,
+        cu_seqlens,
+        mStaging,
+        mCount,
+        mWorkItems,
+        mSched,
+        sKey,
+        sIdx,
+        sSpread,
+    )
+    build_descs_body(
+        widx,
+        base_q,
+        base_k,
+        base_v,
+        base_o,
+        base_checkpoint,
+        desc_ws,
+        cu_seqlens,
+        q,
+        k,
+        v,
+        o,
+        state_checkpoints_out,
+        n_batch,
+        q_row_stride,
+        k_row_stride,
+        v_row_stride,
+        o_row_stride,
+        checkpoint_row_stride,
+        checkpoint_every_n,
+    )
+
+
+@cute.jit
+def prologue(
+    io_dtype: cutlass.Constexpr,
+    b_t: cutlass.Constexpr[int],
+    order_gen: cutlass.Constexpr[bool],
+    has_sched: cutlass.Constexpr[bool],
+    q: cute.Tensor,
+    k: cute.Tensor,
+    v: cute.Tensor,
+    o: Optional[cute.Tensor],
+    cu_seqlens: cute.Tensor,
+    state_checkpoints_out: Optional[cute.Tensor],
+    work_item_staging: Optional[cute.Tensor],
+    work_count: cute.Tensor,
+    work_items: cute.Tensor,
+    sched_ctr: Optional[cute.Tensor],
+    checkpoint_every_n: cutlass.Int32,
+    tensormap_workspace: cute.Tensor,
+    stream: cuda_driver.CUstream,
+):
+    """One-launch prologue: LPT-order the work items and build the 5
+    per-(b,h) TMA-descriptor arrays (Q, K, V, O, checkpoints) into
+    ``tensormap_workspace``."""
+    h_q = q.shape[1]
+    h_k = k.shape[1]
+    h_v = v.shape[1]
+    batch_size = cu_seqlens.shape[0] - 1
+    heads_out = h_q if h_q >= h_v else h_v
+    d_v = v.shape[2]
+    bpe = io_dtype.width // 8
+    elems_per_128b = 128 // bpe
+    bt = b_t
+
+    q_row_stride, q_head_stride = q.stride[0], q.stride[1]
+    k_row_stride, k_head_stride = k.stride[0], k.stride[1]
+    v_row_stride, v_head_stride = v.stride[0], v.stride[1]
+
+    seqlen = q.shape[0]
+    d_k = q.shape[2]
+    q_headed = cute.make_tensor(
+        q.iterator, cute.make_layout((seqlen, h_q, d_k), stride=(q_row_stride, q_head_stride, 1))
+    )
+    k_headed = cute.make_tensor(
+        k.iterator, cute.make_layout((seqlen, h_k, d_k), stride=(k_row_stride, k_head_stride, 1))
+    )
+    v_headed = cute.make_tensor(
+        v.iterator, cute.make_layout((d_v, h_v, seqlen), stride=(1, v_head_stride, v_row_stride))
+    )
+    swz128 = cuda.TensorMapSwizzle.s128b
+    base_desc_q = cuda.create_tensor_map_tiled_from_view(
+        q_headed, box_dims=(bt, 1, elems_per_128b), stride_order=(2, 1, 0), swizzle=swz128
+    )
+    base_desc_k = cuda.create_tensor_map_tiled_from_view(
+        k_headed, box_dims=(bt, 1, elems_per_128b), stride_order=(2, 1, 0), swizzle=swz128
+    )
+    base_desc_v = cuda.create_tensor_map_tiled_from_view(
+        v_headed, box_dims=(elems_per_128b, 1, bt), stride_order=(0, 1, 2), swizzle=swz128
+    )
+
+    base_desc_o = base_desc_v
+    if cutlass.const_expr(o is not None):
+        o_headed = cute.make_tensor(
+            o.iterator,
+            cute.make_layout((d_v, heads_out, seqlen), stride=(1, o.stride[1], o.stride[0])),
+        )
+        base_desc_o = cuda.create_tensor_map_tiled_from_view(
+            o_headed, box_dims=(elems_per_128b, 1, bt), stride_order=(0, 1, 2), swizzle=swz128
+        )
+
+    base_desc_checkpoint = base_desc_v
+    if cutlass.const_expr(state_checkpoints_out is not None):
+        d_k_state = state_checkpoints_out.shape[2]
+        d_v_state = state_checkpoints_out.shape[3]
+        checkpoint_elems_per_128b = 128 // (state_checkpoints_out.element_type.width // 8)
+        checkpoint_view = cute.make_tensor(
+            state_checkpoints_out.iterator,
+            cute.make_layout(
+                (d_v_state, d_k_state, state_checkpoints_out.shape[0], heads_out),
+                stride=(
+                    state_checkpoints_out.stride[3],
+                    state_checkpoints_out.stride[2],
+                    state_checkpoints_out.stride[0],
+                    state_checkpoints_out.stride[1],
+                ),
+            ),
+        )
+        base_desc_checkpoint = cuda.create_tensor_map_tiled_from_view(
+            checkpoint_view,
+            box_dims=(checkpoint_elems_per_128b, d_k_state, 1, 1),
+            stride_order=(0, 1, 2, 3),
+            swizzle=swz128,
+        )
+
+    prologue_kernel(
+        order_gen,
+        has_sched,
+        b_t,
+        base_desc_q,
+        base_desc_k,
+        base_desc_v,
+        base_desc_o,
+        base_desc_checkpoint,
+        tensormap_workspace,
+        cu_seqlens,
+        q,
+        k,
+        v,
+        o,
+        state_checkpoints_out,
+        work_item_staging,
+        work_count,
+        work_items,
+        sched_ctr,
+        cutlass.Int32(batch_size),
+        cutlass.Int64(q_row_stride),
+        cutlass.Int64(k_row_stride),
+        cutlass.Int64(v_row_stride),
+        cutlass.Int64(o.stride[0] if o is not None else 0),
+        cutlass.Int64(state_checkpoints_out.stride[0] if state_checkpoints_out is not None else 0),
+        checkpoint_every_n,
+    ).launch(grid=(1, 1, 1), block=(ORDER_THREADS, 1, 1), stream=stream)
+
+
+@cute.jit
+def host(
+    cfg: cutlass.Constexpr,
+    q: cute.Tensor,
+    k: cute.Tensor,
+    v: cute.Tensor,
+    gate: cute.Tensor,
+    a_log: Optional[cute.Tensor],
+    dt_bias: Optional[cute.Tensor],
+    beta: cute.Tensor,
+    o: Optional[cute.Tensor],
+    cu_seqlens: cute.Tensor,
+    state_in: Optional[cute.Tensor],
+    state_out: Optional[cute.Tensor],
+    work_items: Optional[cute.Tensor],
+    work_count: Optional[cute.Tensor],
+    sched_ctr: Optional[cute.Tensor],
+    checkpoint_every_n_tokens: cutlass.Int32,
+    scale: cutlass.Float32,
+    tensormap_workspace: cute.Tensor,
+    stream: cuda_driver.CUstream,
+):
+    h_q = q.shape[1]
+    h_k = k.shape[1]
+    h_v = v.shape[1]
+    batch_size = cu_seqlens.shape[0] - 1
+    heads_out = h_q if h_q >= h_v else h_v
+
+    # ---- GQA reshapes: fold the head group into a --------------------------------
+    if cutlass.const_expr(cfg.is_GQA):
+        h_r = h_q // h_v
+        h_qv = h_v
+        q = cute.make_tensor(
+            q.iterator,
+            cute.make_layout(
+                (q.shape[0], q.shape[2], (h_r, h_v)),
+                stride=(q.stride[0], q.stride[2], (q.stride[1], h_r * q.stride[1])),
+            ),
+        )
+        k = cute.make_tensor(
+            k.iterator,
+            cute.make_layout(
+                (k.shape[0], k.shape[2], (h_r, h_v)),
+                stride=(k.stride[0], k.stride[2], (0, k.stride[1])),
+            ),
+        )
+        v = cute.make_tensor(
+            v.iterator,
+            cute.make_layout(
+                (v.shape[2], v.shape[0], (h_r, h_v)),
+                stride=(v.stride[2], v.stride[0], (0, v.stride[1])),
+            ),
+        )
+    else:
+        h_r = h_v // h_q
+        h_qv = h_q
+        q = cute.make_tensor(
+            q.iterator,
+            cute.make_layout(
+                (q.shape[0], q.shape[2], (h_r, h_q)),
+                stride=(q.stride[0], q.stride[2], (0, q.stride[1])),
+            ),
+        )
+        k = cute.make_tensor(
+            k.iterator,
+            cute.make_layout(
+                (k.shape[0], k.shape[2], (h_r, h_q)),
+                stride=(k.stride[0], k.stride[2], (0, k.stride[1])),
+            ),
+        )
+        v = cute.make_tensor(
+            v.iterator,
+            cute.make_layout(
+                (v.shape[2], v.shape[0], (h_r, h_q)),
+                stride=(v.stride[2], v.stride[0], (v.stride[1], h_r * v.stride[1])),
+            ),
+        )
+
+    gate = cute.make_tensor(
+        gate.iterator,
+        cute.make_layout(
+            (gate.shape[0], (h_r, h_qv)),
+            stride=(gate.stride[0], (gate.stride[1], h_r * gate.stride[1])),
+        ),
+    )
+    beta = cute.make_tensor(
+        beta.iterator,
+        cute.make_layout(
+            (beta.shape[0], (h_r, h_qv)),
+            stride=(beta.stride[0], (beta.stride[1], h_r * beta.stride[1])),
+        ),
+    )
+    if cutlass.const_expr(o is not None):
+        o = cute.make_tensor(
+            o.iterator,
+            cute.make_layout(
+                (o.shape[2], o.shape[0], (h_r, h_qv)),
+                stride=(o.stride[2], o.stride[0], (o.stride[1], h_r * o.stride[1])),
+            ),
+        )
+    if cutlass.const_expr(state_in is not None):
+        state_in = cute.make_tensor(
+            state_in.iterator,
+            cute.make_layout(
+                (state_in.shape[2], state_in.shape[3], (h_r, h_qv), state_in.shape[0]),
+                stride=(
+                    state_in.stride[2],
+                    state_in.stride[3],
+                    (state_in.stride[1], h_r * state_in.stride[1]),
+                    state_in.stride[0],
+                ),
+            ),
+        )
+    if cutlass.const_expr(state_out is not None):
+        state_out = cute.make_tensor(
+            state_out.iterator,
+            cute.make_layout(
+                (state_out.shape[2], state_out.shape[3], (h_r, h_qv), state_out.shape[0]),
+                stride=(
+                    state_out.stride[2],
+                    state_out.stride[3],
+                    (state_out.stride[1], h_r * state_out.stride[1]),
+                    state_out.stride[0],
+                ),
+            ),
+        )
+
+    # ---- SMEM sizing: per-buffer element cosizes ---------------------------------
+    bpe = cfg.io_dtype.width // 8
+    kq_tile_elems = 2 * cfg.b_t * cfg.d_k
+    v_tile_elems = cfg.d_v * cfg.b_t
+    tinv_tile_elems = cfg.b_t * cfg.b_t
+    a_tile_elems = cfg.b_t * cfg.b_t
+    o_tile_elems = cfg.d_v * cfg.b_t
+    cfg.kq_cosize = kq_tile_elems * cfg.smem_kq_stages
+    cfg.v_cosize = v_tile_elems * cfg.smem_v_stages
+    cfg.t_inv_cosize = tinv_tile_elems * cfg.smem_t_inv_stages
+    cfg.a_cosize = a_tile_elems * cfg.smem_a_stages
+    cfg.o_cosize = o_tile_elems * cfg.smem_o_stages
+    cfg.checkpoint_cosize = (
+        cfg.d_k * cfg.d_v * cfg.smem_checkpoint_stages if cfg.enable_checkpoints else 1
+    )
+
+    cumsumlog_smem_layout_staged = cute.make_layout((cfg.b_t, 1, cfg.smem_gate_stages))
+    beta_smem_layout_staged = cute.make_layout((cfg.b_t, 1, cfg.smem_beta_stages))
+
+    cfg.tma_kq_bytes = kq_tile_elems * bpe
+    cfg.tma_v_bytes = v_tile_elems * bpe
+    cfg.tma_o_bytes = o_tile_elems * bpe
+
+    cfg.n_heads_out = heads_out
+    cfg.q_ratio = heads_out // h_q
+    cfg.k_ratio = heads_out // h_k
+    cfg.v_ratio = heads_out // h_v
+    num_descs = batch_size
+
+    # ---- launch ------------------------------------------------------------------
+    # CUDA-graph-stable launch: fixed SM-count grid; shapes ride on buffer contents
+    grid_shape = (cfg.max_active_clusters, 1, 1)
+
+    @cute.struct
+    class SharedStorage:
+        output: cute.struct.Align[
+            cute.struct.MemRange[cfg.io_dtype, cfg.o_cosize], cfg.buffer_align_bytes
+        ]
+        checkpoint: cute.struct.Align[
+            cute.struct.MemRange[cfg.io_dtype, cfg.checkpoint_cosize], cfg.buffer_align_bytes
+        ]
+        kq: cute.struct.Align[
+            cute.struct.MemRange[cfg.io_dtype, cfg.kq_cosize], cfg.buffer_align_bytes
+        ]
+        cumsumlog: cute.struct.Align[
+            cute.struct.MemRange[cutlass.Float32, cute.cosize(cumsumlog_smem_layout_staged)], 128
+        ]
+        cumprod: cute.struct.Align[
+            cute.struct.MemRange[cutlass.Float32, cute.cosize(cumsumlog_smem_layout_staged)], 128
+        ]
+        beta: cute.struct.Align[
+            cute.struct.MemRange[cutlass.Float32, cute.cosize(beta_smem_layout_staged)], 128
+        ]
+        t_inv: cute.struct.Align[
+            cute.struct.MemRange[cfg.io_dtype, cfg.t_inv_cosize], cfg.buffer_align_bytes
+        ]
+        a: cute.struct.Align[
+            cute.struct.MemRange[cfg.io_dtype, cfg.a_cosize], cfg.buffer_align_bytes
+        ]
+        v: cute.struct.Align[
+            cute.struct.MemRange[cfg.io_dtype, cfg.v_cosize], cfg.buffer_align_bytes
+        ]
+
+    kernel(
+        cfg,
+        SharedStorage,
+        gate,
+        a_log,
+        dt_bias,
+        beta,
+        cu_seqlens,
+        state_in,
+        state_out,
+        work_items,
+        work_count,
+        sched_ctr,
+        checkpoint_every_n_tokens,
+        scale,
+        cumsumlog_smem_layout_staged,
+        beta_smem_layout_staged,
+        q,
+        k,
+        v,
+        o,
+        tensormap_workspace,
+        cutlass.Int32(num_descs),
+    ).launch(
+        grid=grid_shape,
+        block=(cfg.threads_per_cta, 1, 1),
+        cluster=cfg.cluster_shape_mnk,
+        stream=stream,
+        min_blocks_per_mp=1,
+    )
+
+
+@cute.kernel
+def kernel(
+    cfg: cutlass.Constexpr,
+    shared_type: cutlass.Constexpr,
+    mGate: cute.Tensor,
+    mA_log: Optional[cute.Tensor],
+    mDt_bias: Optional[cute.Tensor],
+    mBeta: cute.Tensor,
+    cu_seqlens: cute.Tensor,
+    mState_init: Optional[cute.Tensor],
+    mState_out: Optional[cute.Tensor],
+    mWorkItems: cute.Tensor,
+    mCount: cute.Tensor,
+    mSched: Optional[cute.Tensor],
+    checkpoint_every_n_tokens: cutlass.Int32,
+    scale: cutlass.Float32,
+    cumsumlog_smem_layout_staged: cute.Layout,
+    beta_smem_layout_staged: cute.Layout,
+    mQ,
+    mK,
+    mV,
+    mO,
+    tensormap_workspace: cute.Tensor,
+    n_desc: cutlass.Int32,
+):
+    """Main GDN chunked kernel: warp-specialized persistent tile loop."""
+    tidx, _, _ = cute.arch.thread_idx()
+    warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+    bidx = cute.arch.block_idx()[0]
+    num_ctas = cute.arch.grid_dim()[0]
+
+    total_tiles = mCount[0]
+    if cutlass.const_expr(cfg.dyn_sched):
+        assert mSched is not None, "mSched must be provided if dyn_sched is True"
+
+    if cutlass.const_expr(cfg.use_initial_state):
+        assert mState_init is not None, "mState_init must be provided if use_initial_state is True"
+    else:
+        assert mState_init is None, "mState_init must be None if use_initial_state is False"
+    if cutlass.const_expr(cfg.store_final_state):
+        assert mState_out is not None, "mState_out must be provided if store_final_state is True"
+    else:
+        assert mState_out is None, "mState_out must be None if store_final_state is False"
+
+    desc_base_words = tensormap_workspace.iterator.raw_ptr()
+    desc_qwords = cutlass.Int32(TENSOR_MAP_QWORDS)
+    arr_words = n_desc * desc_qwords
+    desc_q_base = desc_base_words
+    desc_k_base = desc_base_words + arr_words
+    desc_v_base = desc_base_words + cutlass.Int32(2) * arr_words
+    desc_o_base = desc_base_words + cutlass.Int32(3) * arr_words
+    desc_checkpoint_base = desc_base_words + cutlass.Int32(4) * arr_words
+
+    SMEM = cutlass.AddressSpace.smem
+
+    SWZ = 2
+    LEAD = 16
+    STRIDE = 8 * 128
+    KT_LEAD = (cfg.d_v // 2) * 128
+    V_LEAD = (cfg.d_v // 2) * 128
+    storage = cutlass.utils.SmemAllocator().allocate(shared_type)
+    sO_raw = storage.output.get_tensor(cute.make_layout((cfg.o_cosize,)))
+    sCheckpoint_raw = storage.checkpoint.get_tensor(cute.make_layout((cfg.checkpoint_cosize,)))
+    sKQ_raw = storage.kq.get_tensor(cute.make_layout((cfg.kq_cosize,)))
+    cumsumlog_raw = storage.cumsumlog.get_tensor(
+        cute.make_layout((cute.cosize(cumsumlog_smem_layout_staged),))
+    )
+    cumprod_raw = storage.cumprod.get_tensor(
+        cute.make_layout((cute.cosize(cumsumlog_smem_layout_staged),))
+    )
+    beta_raw = storage.beta.get_tensor(cute.make_layout((cute.cosize(beta_smem_layout_staged),)))
+    sTinv_raw = storage.t_inv.get_tensor(cute.make_layout((cfg.t_inv_cosize,)))
+    sA_raw = storage.a.get_tensor(cute.make_layout((cfg.a_cosize,)))
+    sV_raw = storage.v.get_tensor(cute.make_layout((cfg.v_cosize,)))
+    sO = SmemTile(
+        base=sO_raw,
+        elems_per_stage=cfg.o_cosize // cfg.smem_o_stages,
+        stages=cfg.smem_o_stages,
+        leading_byte_offset=LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sKQ = SmemTile(
+        base=sKQ_raw,
+        elems_per_stage=cfg.kq_cosize // cfg.smem_kq_stages,
+        stages=cfg.smem_kq_stages,
+        leading_byte_offset=LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sKQ_trans = SmemTile(
+        base=sKQ_raw,
+        elems_per_stage=cfg.kq_cosize // cfg.smem_kq_stages,
+        stages=cfg.smem_kq_stages,
+        leading_byte_offset=2 * KT_LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    bars = make_gdn_bars(cfg)
+    tmem_base_slot = cutlass.Array(cutlass.Int32, 1, space=SMEM, alignment=16)
+    sSched = cutlass.Array(cutlass.Int32, cfg.sched_stages, space=SMEM, alignment=16)
+    sTinv = SmemTile(
+        base=sTinv_raw,
+        elems_per_stage=cfg.t_inv_cosize // cfg.smem_t_inv_stages,
+        stages=cfg.smem_t_inv_stages,
+        leading_byte_offset=LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sA = SmemTile(
+        base=sA_raw,
+        elems_per_stage=cfg.a_cosize // cfg.smem_a_stages,
+        stages=cfg.smem_a_stages,
+        leading_byte_offset=LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sV = SmemTile(
+        base=sV_raw,
+        elems_per_stage=cfg.v_cosize // cfg.smem_v_stages,
+        stages=cfg.smem_v_stages,
+        leading_byte_offset=V_LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sCumsumlog = cute.make_tensor(
+        cute.make_ptr(
+            cutlass.Float32,
+            smem_data_ptr(cumsumlog_raw).toint(),
+            mem_space=cute.AddressSpace.smem,
+            assumed_align=128,
+        ),
+        cumsumlog_smem_layout_staged,
+    )
+    sCumprod = cute.make_tensor(
+        cute.make_ptr(
+            cutlass.Float32,
+            smem_data_ptr(cumprod_raw).toint(),
+            mem_space=cute.AddressSpace.smem,
+            assumed_align=128,
+        ),
+        cumsumlog_smem_layout_staged,
+    )
+    sBeta = cute.make_tensor(
+        cute.make_ptr(
+            cutlass.Float32,
+            smem_data_ptr(beta_raw).toint(),
+            mem_space=cute.AddressSpace.smem,
+            assumed_align=128,
+        ),
+        beta_smem_layout_staged,
+    )
+
+    # ---- mbarrier init (all threads) ---------------------------------------------
+    for s in range(cfg.smem_kq_stages):
+        bars.mb_kq_ready[s].init()
+        bars.mb_kq_done[s].init()
+    for s in range(cfg.smem_v_stages):
+        bars.mb_v_ready[s].init()
+        bars.mb_v_done[s].init()
+    for s in range(cfg.smem_gate_stages):
+        bars.mb_gate_ready[s].init()
+        bars.mb_gate_done[s].init()
+    for s in range(cfg.smem_beta_stages):
+        bars.mb_beta_ready[s].init()
+        bars.mb_beta_done[s].init()
+    for s in range(cfg.tmem_state_acc_stages):
+        bars.mb_state_acc_ready[s].init()
+        bars.mb_state_acc_scale_done[s].init()
+    for s in range(cfg.tmem_q_state_acc_stages):
+        bars.mb_o_acc_ready[s].init()
+        bars.mb_o_final_acc_ready[s].init()
+        bars.mb_o_state_scale_acc_done[s].init()
+    for s in range(cfg.tmem_cg0_acc_stages):
+        bars.mb_cg0_acc_ready[s].init()
+        bars.mb_cg0_acc_done[s].init()
+    bars.mb_k_state_acc_ready[0].init()
+    bars.mb_u_acc_ready[0].init()
+    for s in range(cfg.smem_t_inv_stages):
+        bars.mb_t_inv_ready[s].init()
+        bars.mb_t_inv_done[s].init()
+    for s in range(cfg.smem_a_stages):
+        bars.mb_a_ready[s].init()
+        bars.mb_a_done[s].init()
+    for s in range(cfg.tmem_state_inp_stages):
+        bars.mb_state_inp_ready[s].init()
+    for b in (bars.mb_y_inp_ready, bars.mb_u_inp_ready, bars.mb_decay_u_inp_ready):
+        b[0].init()
+    for s in range(cfg.smem_o_stages):
+        bars.mb_o_tmastg_ready[s].init()
+        bars.mb_o_tmastg_done[s].init()
+    for s in range(cfg.smem_checkpoint_stages):
+        bars.mb_checkpoint_tmastg_ready[s].init()
+        bars.mb_checkpoint_tmastg_done[s].init()
+    for s_ in range(cfg.sched_stages):
+        bars.mb_sched_ready[s_].init()
+        bars.mb_sched_done[s_].init()
+    bars.mb_tmem_done[0].init()
+
+    nvvm.fence_mbarrier_init()
+    nvvm.barrier_cta_sync()
+
+    # ---- warp specialization -----------------------------------------------------
+
+    if (
+        warp_idx >= cfg.compute_group_0_warp_ids[0]
+        and warp_idx <= cfg.compute_group_0_warp_ids[-1]
+    ):
+        compute0_warp_group(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            cu_seqlens,
+            mWorkItems,
+            tidx,
+            tmem_base_slot=tmem_base_slot,
+            scale=scale,
+            sCumsumlog=sCumsumlog,
+            sBeta=sBeta,
+            sTinv=sTinv,
+            sA=sA,
+            sCheckpoint_raw=sCheckpoint_raw,
+            checkpoint_every_n_tokens=checkpoint_every_n_tokens,
+            sSched=sSched,
+            bars=bars,
+        )
+
+    if (
+        warp_idx >= cfg.compute_group_1_warp_ids[0]
+        and warp_idx <= cfg.compute_group_1_warp_ids[-1]
+    ):
+        compute1_warp_group(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            cu_seqlens,
+            mWorkItems,
+            tidx,
+            warp_idx=warp_idx,
+            tmem_base_slot=tmem_base_slot,
+            scale=scale,
+            sV=sV,
+            sCumsumlog=sCumsumlog,
+            sCumprod=sCumprod,
+            sBeta=sBeta,
+            sO=sO,
+            sCheckpoint_raw=sCheckpoint_raw,
+            mState_init=mState_init,
+            mState_out=mState_out,
+            checkpoint_every_n_tokens=checkpoint_every_n_tokens,
+            sSched=sSched,
+            bars=bars,
+        )
+
+    elif warp_idx == cfg.load_gate_beta_warp_id:
+        gate_beta_warp(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            cu_seqlens,
+            mWorkItems,
+            tidx=tidx,
+            mGate=mGate,
+            mA_log=mA_log,
+            mDt_bias=mDt_bias,
+            mBeta=mBeta,
+            sCumsumlog=sCumsumlog,
+            sCumprod=sCumprod,
+            sBeta=sBeta,
+            sSched=sSched,
+            bars=bars,
+        )
+
+    elif warp_idx == cfg.mma_warp_id:
+        mma_warp(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            cu_seqlens,
+            mWorkItems,
+            tmem_base_slot=tmem_base_slot,
+            sKQ=sKQ,
+            sKQ_trans=sKQ_trans,
+            sTinv=sTinv,
+            sA=sA,
+            sSched=sSched,
+            bars=bars,
+        )
+
+    elif warp_idx == cfg.tma_qkv_warp_id:
+        tmaldg_warp(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            n_desc,
+            cu_seqlens,
+            mWorkItems,
+            sKQ_raw=sKQ_raw,
+            sV_raw=sV_raw,
+            desc_q_base=desc_q_base,
+            desc_k_base=desc_k_base,
+            desc_v_base=desc_v_base,
+            mSched=mSched,
+            sSched=sSched,
+            bars=bars,
+        )
+
+    if warp_idx == cfg.epilogue_warp_id:
+        tmastg_warp(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            cu_seqlens,
+            mWorkItems,
+            checkpoint_every_n_tokens=checkpoint_every_n_tokens,
+            tidx=tidx,
+            sO_raw=sO_raw,
+            sCheckpoint_raw=sCheckpoint_raw,
+            desc_o_base=desc_o_base,
+            desc_checkpoint_base=desc_checkpoint_base,
+            sSched=sSched,
+            bars=bars,
+        )
+
+
+@dataclass
+class GdnCfg:
+    """Per-compile GDN kernel knob, built by ``build_cfg``.
+
+    The per-compile parameters (dtypes, GQA, state flags) are the
+    ``cute.compile`` cache keys; the rest is derived from the module-global
+    ``CFG`` constants.  ``host`` stamps the shape-derived fields at trace
+    time.  Passed ``cfg``-first (a ``cutlass.Constexpr``) into ``host`` /
+    ``kernel`` and every warp body.
+    """
+
+    io_dtype: Type[cutlass.Numeric]
+    acc_dtype: Type[cutlass.Numeric]
+    state_dtype: Type[cutlass.Numeric]
+    max_active_clusters: int
+    is_GQA: bool
+    use_initial_state: bool
+    store_final_state: bool
+    enable_checkpoints: bool
+    log_gate: bool = False
+    safe_gate: bool = False
+    beta_sigmoid: bool = False
+    dyn_sched: bool = False
+    sched_stages: int = CFG.SMEM_SCHED_STAGES
+
+    # ---- fixed constants stamped from CFG by build_cfg ---------------------------
+    b_t: int = CFG.B_T
+    d_k: int = CFG.D_K
+    d_v: int = CFG.D_V
+    compute_group_0_warp_ids: Tuple[int, ...] = CFG.COMPUTE_GROUP_0_WARP_IDS
+    compute_group_1_warp_ids: Tuple[int, ...] = CFG.COMPUTE_GROUP_1_WARP_IDS
+    load_gate_beta_warp_id: int = CFG.LOAD_GATE_BETA_WARP_ID
+    tma_qkv_warp_id: int = CFG.TMA_QKV_WARP_ID
+    mma_warp_id: int = CFG.MMA_WARP_ID
+    epilogue_warp_id: int = CFG.EPILOGUE_WARP_ID
+    num_regs_compute_group_0: int = CFG.NUM_REGS_COMPUTE_GROUP_0
+    num_regs_compute_group_1: int = CFG.NUM_REGS_COMPUTE_GROUP_1
+    num_regs_other: int = CFG.NUM_REGS_OTHER
+    threads_per_warp: int = CFG.THREADS_PER_WARP
+    threads_per_cta: int = 0
+    cluster_shape_mnk: Tuple[int, int, int] = CFG.CLUSTER_SHAPE_MNK
+
+    # ---- named barrier slots (ids 1-4; 0 is the CTA-wide sync) -------------------
+    tmem_alloc_barrier_id: int = 1
+    tmem_alloc_barrier_threads: int = 0
+    inverse_barrier_id: int = 2
+    inverse_barrier_threads: int = 0
+    init_state_store_barrier_id: int = 4
+    init_state_store_barrier_threads: int = 0
+
+    # ---- SMEM / TMEM stage counts + TMEM column offsets --------------------------
+    smem_kq_stages: int = CFG.SMEM_KQ_STAGES
+    smem_v_stages: int = CFG.SMEM_V_STAGES
+    smem_t_inv_stages: int = CFG.SMEM_T_INV_STAGES
+    smem_a_stages: int = CFG.SMEM_A_STAGES
+    smem_o_stages: int = CFG.SMEM_O_STAGES
+    smem_checkpoint_stages: int = 1
+    smem_gate_stages: int = CFG.SMEM_GATE_STAGES
+    smem_beta_stages: int = CFG.SMEM_BETA_STAGES
+    tmem_state_acc_stages: int = CFG.TMEM_KV_ACC_STAGES
+    tmem_q_state_acc_stages: int = CFG.TMEM_Q_STATE_ACC_STAGES
+    tmem_state_inp_stages: int = CFG.TMEM_STATE_INP_STAGES
+    tmem_cg0_acc_stages: int = CFG.TMEM_CG0_ACC_STAGES
+    tmem_cg1_acc_stages: int = CFG.TMEM_CG1_ACC_STAGES
+    tmem_state_acc_offset: int = 0
+    tmem_q_state_acc_offset: int = 0
+    tmem_state_inp_offset: int = 0
+    tmem_cg0_acc_offset: int = 0
+    tmem_cg1_acc_offset: int = 0
+    tmem_y_decay_u_inp_offset: int = 0
+    buffer_align_bytes: int = CFG.BUFFER_ALIGN_BYTES
+
+    # ---- stamped by host at trace time (shape-derived) --------------------------
+    kq_cosize: int = 0
+    v_cosize: int = 0
+    t_inv_cosize: int = 0
+    a_cosize: int = 0
+    o_cosize: int = 0
+    checkpoint_cosize: int = 0
+    tma_kq_bytes: int = 0
+    tma_v_bytes: int = 0
+    tma_o_bytes: int = 0
+    n_heads_out: int = 0
+    q_ratio: int = 1
+    k_ratio: int = 1
+    v_ratio: int = 1
+
+
+def build_cfg(
+    io_dtype: Type[cutlass.Numeric],
+    state_dtype: Type[cutlass.Numeric],
+    *,
+    max_active_clusters: int,
+    is_GQA: bool,
+    use_initial_state: bool,
+    store_final_state: bool = True,
+    enable_checkpoints: bool = False,
+    log_gate: bool = False,
+    safe_gate: bool = False,
+    beta_sigmoid: bool = False,
+    dyn_sched: bool = False,
+) -> GdnCfg:
+    """Build the per-compile ``GdnCfg`` (io_dtype ∈ {Float16, BFloat16};
+    acc is always Float32)."""
+    if io_dtype not in (cutlass.Float16, cutlass.BFloat16):
+        raise ValueError(
+            f"io_dtype={io_dtype} not supported; only Float16 and BFloat16 are supported"
+        )
+    cfg = GdnCfg(
+        io_dtype=io_dtype,
+        acc_dtype=cutlass.Float32,
+        state_dtype=state_dtype,
+        max_active_clusters=max_active_clusters,
+        is_GQA=is_GQA,
+        use_initial_state=use_initial_state,
+        store_final_state=store_final_state,
+        enable_checkpoints=enable_checkpoints,
+        log_gate=log_gate,
+        safe_gate=safe_gate,
+        beta_sigmoid=beta_sigmoid,
+        dyn_sched=dyn_sched,
+    )
+    cfg.smem_checkpoint_stages = 1
+    # The base four-stage KQ allocation exceeds SM100's 227 KiB dynamic-SMEM limit
+    # after the structured shared-storage alignment required by the current DSL.
+    # Checkpointing needs one additional 128x128 state tile, so it uses two stages.
+    cfg.smem_kq_stages = 2 if enable_checkpoints else 3
+    if not use_initial_state:
+        cfg.num_regs_compute_group_1 = 232
+        cfg.num_regs_other = 48
+    n_cg0 = len(cfg.compute_group_0_warp_ids)
+    n_cg1 = len(cfg.compute_group_1_warp_ids)
+    cfg.threads_per_cta = cfg.threads_per_warp * (4 + n_cg0 + n_cg1)
+    cfg.tmem_alloc_barrier_threads = cfg.threads_per_warp * (1 + n_cg0 + n_cg1)
+    cfg.inverse_barrier_threads = cfg.threads_per_warp * n_cg0
+    cfg.init_state_store_barrier_threads = cfg.threads_per_warp * n_cg1
+    cfg.tmem_state_acc_offset = 0
+    cfg.tmem_q_state_acc_offset = cfg.tmem_state_acc_offset + cfg.tmem_state_acc_stages * 128
+    cfg.tmem_state_inp_offset = cfg.tmem_q_state_acc_offset + cfg.tmem_q_state_acc_stages * 64
+    cfg.tmem_cg0_acc_offset = cfg.tmem_state_inp_offset + cfg.tmem_state_inp_stages * 64
+    cfg.tmem_cg1_acc_offset = cfg.tmem_cg0_acc_offset + cfg.tmem_cg0_acc_stages * 64
+    cfg.tmem_y_decay_u_inp_offset = cfg.tmem_cg1_acc_offset + cfg.tmem_cg1_acc_stages * 64
+    return cfg
+
+
+TENSORMAP_DESC_ARRAYS = 5  # per-batch runtime TMA descriptors: Q, K, V, O, checkpoints
+TENSORMAP_STATIC_SLOTS = 0
+
+
+# ---------------------------------------------------------------------------
+
+
+@lru_cache(maxsize=None)
+def get_compiled_cache(
+    io_dtype_str: str,
+    state_dtype_str: str,
+    HQ: int,
+    HK: int,
+    HV: int,
+    is_gqa: bool,
+    use_initial_state: bool,
+    store_final_state: bool,
+    enable_checkpoints: bool,
+    log_gate: bool,
+    safe_gate: bool,
+    beta_sigmoid: bool,
+    dyn_sched: bool,
+    order_gen: bool,
+    use_int64_offsets: bool,
+    device_index: int,
+    device_major: int,
+    device_minor: int,
+    num_sm: int,
+):
+    """Return a mutable dict that lazily stores the compiled kernel."""
+    return {}
+
+
+def compile(
+    io_dtype,
+    state_dtype,
+    is_gqa: bool,
+    use_initial_state: bool,
+    store_final_state: bool,
+    enable_checkpoints: bool,
+    log_gate: bool,
+    safe_gate: bool,
+    beta_sigmoid: bool,
+    q_ratio: int,
+    k_ratio: int,
+    v_ratio: int,
+    n_heads_out: int,
+    dyn_sched: bool = False,
+    use_int64_offsets: bool = False,
+    *,
+    num_sm: int,
+    checkpoint_every_n_tokens: int,
+    scale: float,
+):
+    """JIT-compile one fake-tensor TVM-FFI GDN prefill signature."""
+    cfg = build_cfg(
+        io_dtype,
+        state_dtype,
+        max_active_clusters=num_sm,
+        is_GQA=is_gqa,
+        use_initial_state=use_initial_state,
+        store_final_state=store_final_state,
+        enable_checkpoints=enable_checkpoints,
+        log_gate=log_gate,
+        safe_gate=safe_gate,
+        beta_sigmoid=beta_sigmoid,
+        dyn_sched=dyn_sched,
+    )
+    sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
+    tokens, sequence_entries, sequences, work_rows, sched_entries, workspace_words = (
+        sym_int() for _ in range(6)
+    )
+    tma_tensor = partial(
+        make_strided_signature_tensor,
+        assumed_align=16,
+        use_int64_offsets=use_int64_offsets,
+    )
+    beta_dtype = io_dtype if beta_sigmoid else cutlass.Float32
+    return compile_tvm_ffi(
+        host,
+        cfg,
+        tma_tensor(io_dtype, (tokens, n_heads_out // q_ratio, 128)),
+        tma_tensor(io_dtype, (tokens, n_heads_out // k_ratio, 128)),
+        tma_tensor(io_dtype, (tokens, n_heads_out // v_ratio, 128)),
+        make_strided_signature_tensor(
+            cutlass.Float32,
+            (tokens, n_heads_out),
+            assumed_align=4,
+            use_int64_offsets=use_int64_offsets,
+        ),
+        make_compact_signature_tensor(cutlass.Float32, (n_heads_out,), assumed_align=4)
+        if safe_gate
+        else None,
+        make_compact_signature_tensor(cutlass.Float32, (n_heads_out,), assumed_align=4)
+        if safe_gate
+        else None,
+        make_strided_signature_tensor(
+            beta_dtype,
+            (tokens, n_heads_out),
+            assumed_align=beta_dtype.width // 8,
+            use_int64_offsets=use_int64_offsets,
+        ),
+        tma_tensor(io_dtype, (tokens, n_heads_out, 128)),
+        make_cu_seqlens_signature(sequence_entries),
+        tma_tensor(state_dtype, (sequences, n_heads_out, 128, 128)) if use_initial_state else None,
+        tma_tensor(state_dtype, (sequences, n_heads_out, 128, 128)) if store_final_state else None,
+        make_work_items_signature(work_rows),
+        make_counter_signature(),
+        make_counter_signature(sched_entries) if dyn_sched else None,
+        cutlass.Int32(checkpoint_every_n_tokens),
+        cutlass.Float32(scale),
+        make_workspace_signature(workspace_words),
+        name=(
+            f"gdn_mega_prefill_{io_dtype.__name__.lower()}_{state_dtype.__name__.lower()}"
+            f"_hq{n_heads_out // q_ratio}_hk{n_heads_out // k_ratio}"
+            f"_hv{n_heads_out // v_ratio}_g{int(is_gqa)}"
+            f"_i{int(use_initial_state)}f{int(store_final_state)}c{int(enable_checkpoints)}"
+            f"_l{int(log_gate)}s{int(safe_gate)}b{int(beta_sigmoid)}"
+            f"_d{int(dyn_sched)}_i64{int(use_int64_offsets)}"
+        ),
+    )
+
+
+def _validate_scalar_tensor(name, tensor) -> None:
+    if tensor.stride(-1) != 1:
+        raise ValueError(f"{name} innermost stride must be one")
+    if any(stride < 0 for stride in tensor.stride()[:-1]):
+        raise ValueError(f"{name} outer strides must be nonnegative")
+
+
+def chunk_gdn_sm100(
+    q,
+    k,
+    v,
+    gate,
+    beta,
+    output,
+    cu_seqlens,
+    initial_state,
+    output_state,
+    scale: float,
+    checkpoint_every_n_tokens: int = 0,
+    output_state_checkpoints=None,
+    work_items=None,
+    work_count=None,
+    sched_ctr=None,
+    log_gate: bool = False,
+    safe_gate: bool = False,
+    a_log=None,
+    dt_bias=None,
+    use_beta_sigmoid: bool = False,
+    work_item_scratch=None,
+    *,
+    tensormap_workspace,
+) -> None:
+    """Execute the Blackwell BT=64 scalar-GDN prefill kernel.
+
+    ``gate`` is scalar ``(total_tokens, HO)``. With ``log_gate=True``, its values are
+    natural-log decays; the kernel converts them to the log2 domain internally.
+    Outer tensor strides are dynamic, while innermost dimensions must be contiguous.
+    """
+    for name, tensor in (("q", q), ("k", k), ("v", v), ("output", output)):
+        validate_tma_tensor(name, tensor)
+    _validate_scalar_tensor("gate", gate)
+    _validate_scalar_tensor("beta", beta)
+    for name, tensor in (("initial_state", initial_state), ("output_state", output_state)):
+        if tensor is not None:
+            validate_tma_tensor(name, tensor)
+    if output_state_checkpoints is not None:
+        validate_tma_tensor("output_state_checkpoints", output_state_checkpoints)
+    validate_cu_seqlens(cu_seqlens, assumed_align=8)
+    if tensormap_workspace.data_ptr() % 128:
+        raise ValueError("tensormap_workspace data pointer must be 128-byte aligned")
+
+    tokens, h_q, d_k = q.shape
+    h_k = k.shape[1]
+    h_v = v.shape[1]
+    h_out = max(h_q, h_v)
+    if d_k != 128 or k.shape != (tokens, h_k, 128) or v.shape != (tokens, h_v, 128):
+        raise ValueError("q, k, and v must have shape (T, H, 128)")
+    if gate.shape != (tokens, h_out) or beta.shape != (tokens, h_out):
+        raise ValueError("gate and beta must have shape (T, HO)")
+    if output.shape != (tokens, h_out, 128):
+        raise ValueError("output must have shape (T, HO, 128)")
+    if checkpoint_every_n_tokens < 0:
+        raise ValueError("checkpoint interval must be zero or a positive tile multiple")
+    enable_checkpoints = checkpoint_every_n_tokens > 0
+    if enable_checkpoints and checkpoint_every_n_tokens % CFG.B_T:
+        raise ValueError(f"checkpoint interval must be a positive multiple of {CFG.B_T}")
+    if enable_checkpoints:
+        if output_state_checkpoints is None:
+            raise ValueError("checkpoint_every_n_tokens > 0 requires output_state_checkpoints")
+        if output_state_checkpoints.shape[1:] != (h_out, 128, 128):
+            raise ValueError("output_state_checkpoints must have shape (N, HO, 128, 128)")
+        required_checkpoint_rows = checkpoint_capacity_bound(
+            tokens, cu_seqlens.shape[0] - 1, checkpoint_every_n_tokens
+        )
+        if output_state_checkpoints.shape[0] < required_checkpoint_rows:
+            raise ValueError(
+                f"output_state_checkpoints requires at least {required_checkpoint_rows} rows, "
+                f"got {output_state_checkpoints.shape[0]}"
+            )
+        if output_state_checkpoints.dtype != q.dtype:
+            raise ValueError("output_state_checkpoints dtype must match q.dtype")
+    if work_items is None or work_count is None:
+        raise ValueError(
+            "work_items/work_count are required (the split-table stage builds them for every launch)"
+        )
+    if safe_gate and (a_log is None or dt_bias is None):
+        raise ValueError("safe_gate requires a_log and dt_bias")
+    if not safe_gate:
+        a_log = None
+        dt_bias = None
+    if a_log is not None:
+        _validate_scalar_tensor("a_log", a_log)
+    if dt_bias is not None:
+        _validate_scalar_tensor("dt_bias", dt_bias)
+
+    use_initial_state = initial_state is not None
+    store_final_state = output_state is not None
+    if (
+        initial_state is not None
+        and output_state is not None
+        and initial_state.dtype != output_state.dtype
+    ):
+        raise ValueError("initial_state and output_state dtypes must match")
+    if initial_state is not None:
+        state_dtype_src = initial_state.dtype
+    elif output_state is not None:
+        state_dtype_src = output_state.dtype
+    else:
+        state_dtype_src = "float32"
+
+    for name, heads in (("HQ", h_q), ("HK", h_k), ("HV", h_v)):
+        if h_out % heads:
+            raise ValueError(f"{name}={heads} must divide output heads {h_out}")
+    q_ratio = h_out // h_q
+    k_ratio = h_out // h_k
+    v_ratio = h_out // h_v
+    is_gqa = h_q >= h_v
+    dyn_sched = sched_ctr is not None
+    order_gen = work_item_scratch is None
+    checkpoints_for_descs = output_state_checkpoints if enable_checkpoints else None
+    use_int64_offsets = requires_int64_abi(
+        q,
+        k,
+        v,
+        gate,
+        a_log,
+        dt_bias,
+        beta,
+        output,
+        cu_seqlens,
+        initial_state,
+        output_state,
+        checkpoints_for_descs,
+        work_item_scratch,
+        work_items,
+        work_count,
+        sched_ctr,
+        tensormap_workspace,
+    )
+    device_index = tensor_device_index(q)
+    if current_device() != device_index:
+        raise ValueError("the active CUDA device must match q.device")
+    device_properties = get_device_properties(device_index)
+    num_sm = device_properties.multi_processor_count
+    cache = get_compiled_cache(
+        str(q.dtype),
+        str(state_dtype_src),
+        h_q,
+        h_k,
+        h_v,
+        is_gqa,
+        use_initial_state,
+        store_final_state,
+        enable_checkpoints,
+        log_gate,
+        safe_gate,
+        use_beta_sigmoid,
+        dyn_sched,
+        order_gen,
+        use_int64_offsets,
+        device_index,
+        device_properties.major,
+        device_properties.minor,
+        num_sm,
+    )
+
+    io_dtype = get_dtype(q.dtype)
+    if "compiled" not in cache:
+        cache["compiled"] = compile(
+            io_dtype,
+            get_dtype(state_dtype_src),
+            is_gqa,
+            use_initial_state,
+            store_final_state,
+            enable_checkpoints,
+            log_gate,
+            safe_gate,
+            use_beta_sigmoid,
+            q_ratio,
+            k_ratio,
+            v_ratio,
+            h_out,
+            dyn_sched,
+            use_int64_offsets,
+            num_sm=num_sm,
+            checkpoint_every_n_tokens=checkpoint_every_n_tokens,
+            scale=scale,
+        )
+
+    if "prologue" not in cache:
+        sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
+        tokens, sequence_entries, checkpoint_rows, work_rows, sched_entries, workspace_words = (
+            sym_int() for _ in range(6)
+        )
+        tma_tensor = partial(
+            make_strided_signature_tensor,
+            assumed_align=16,
+            use_int64_offsets=use_int64_offsets,
+        )
+        work_items_signature = make_work_items_signature(work_rows)
+        cache["prologue"] = compile_tvm_ffi(
+            prologue,
+            io_dtype,
+            CFG.B_T,
+            order_gen,
+            dyn_sched,
+            tma_tensor(io_dtype, (tokens, h_q, 128)),
+            tma_tensor(io_dtype, (tokens, h_k, 128)),
+            tma_tensor(io_dtype, (tokens, h_v, 128)),
+            tma_tensor(io_dtype, (tokens, h_out, 128)),
+            make_cu_seqlens_signature(sequence_entries),
+            tma_tensor(io_dtype, (checkpoint_rows, h_out, 128, 128))
+            if checkpoints_for_descs is not None
+            else None,
+            work_items_signature if not order_gen else None,
+            make_counter_signature(),
+            work_items_signature,
+            make_counter_signature(sched_entries) if dyn_sched else None,
+            cutlass.Int32(checkpoint_every_n_tokens),
+            make_workspace_signature(workspace_words),
+            name=(
+                f"gdn_mega_prefill_prologue_{io_dtype.__name__.lower()}"
+                f"_hq{h_q}_hk{h_k}_hv{h_v}_ho{h_out}"
+                f"_c{int(enable_checkpoints)}o{int(order_gen)}d{int(dyn_sched)}"
+                f"_i64{int(use_int64_offsets)}"
+            ),
+        )
+    cache["prologue"](
+        q,
+        k,
+        v,
+        output,
+        cu_seqlens,
+        checkpoints_for_descs,
+        work_item_scratch if not order_gen else None,
+        work_count,
+        work_items,
+        sched_ctr,
+        checkpoint_every_n_tokens,
+        tensormap_workspace,
+    )
+    cache["compiled"](
+        q,
+        k,
+        v,
+        gate,
+        a_log,
+        dt_bias,
+        beta,
+        output,
+        cu_seqlens,
+        initial_state if use_initial_state else None,
+        output_state if store_final_state else None,
+        work_items,
+        work_count,
+        sched_ctr,
+        checkpoint_every_n_tokens,
+        scale,
+        tensormap_workspace,
+    )

--- a/attn_gym/linear/_delta_rule/mega/kernels/gdn_recompute_config.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/gdn_recompute_config.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# This kernel is derived from cuDNN, NVIDIA Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Gated DeltaNet (GDN) Cutlass-primitives recompute (state/H-only) kernel config (fixed
+compile-time constants; the per-compile attributes live on ``GdnCfg`` in the kernel file).
+
+Target arch: Blackwell SM100 (GB200) / SM103 (GB300).
+"""
+
+from dataclasses import dataclass
+from typing import Tuple
+
+
+@dataclass(frozen=True)
+class Cfg:
+    # --- tile shape ---
+    B_T: int = 64  # chunk size / token tile (the mma N or K of every GEMM)
+    D_K: int = 128  # key head dim (contraction of GEMMs 1/3, M of GEMM 7)
+    D_V: int = 128  # value head dim (M of GEMMs 3/5, N of GEMM 7)
+
+    # --- TMA descriptor pool ---
+
+    # --- warp assignments (12 warps total) ---
+    COMPUTE_GROUP_0_WARP_IDS: Tuple[int, ...] = (0, 1, 2, 3)  # T-pairwise / kk_epi / inverse
+    COMPUTE_GROUP_1_WARP_IDS: Tuple[int, ...] = (4, 5, 6, 7)  # kv_decay_v / v-k*state / epi ops
+    LOAD_GATE_BETA_WARP_ID: int = 8  # gate/beta chunk loads + TMEM lifecycle
+    TMA_KV_WARP_ID: int = 9
+    MMA_WARP_ID: int = 10  # sole tcgen05 issuer: KK pairs + KS/U/KV per chunk
+    EPILOGUE_WARP_ID: int = 11
+
+    # --- register split ---
+    NUM_REGS_COMPUTE_GROUP_0: int = 224
+    NUM_REGS_COMPUTE_GROUP_1: int = 256
+    NUM_REGS_OTHER: int = 24
+
+    THREADS_PER_WARP: int = 32
+
+    CLUSTER_SHAPE_MNK: Tuple[int, int, int] = (1, 1, 1)
+
+    # --- SMEM stage counts ---
+    SMEM_SCHED_STAGES: int = 2
+    SMEM_KQ_STAGES: int = 4
+    SMEM_V_STAGES: int = 2
+    SMEM_T_INV_STAGES: int = 3
+    SMEM_GATE_STAGES: int = 3
+    SMEM_BETA_STAGES: int = 3
+
+    # --- TMEM stage counts ---
+    TMEM_KV_ACC_STAGES: int = 1
+    TMEM_STATE_INP_STAGES: int = 1
+    TMEM_CG0_ACC_STAGES: int = 2
+    TMEM_CG1_ACC_STAGES: int = 1
+
+    BUFFER_ALIGN_BYTES: int = 1024
+
+
+CFG = Cfg()

--- a/attn_gym/linear/_delta_rule/mega/kernels/gdn_recompute_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/gdn_recompute_f16.py
@@ -1,0 +1,3526 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# This kernel is derived from cuDNN, NVIDIA Corporation.
+# Modified by Attention Gym in 2026: imports were relocated into this package.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Chunked Gated Delta Net (GDN) recompute (state/checkpoint-only) kernel for Blackwell SM100
+(Cutlass primitives): the prefill state/checkpoint pipeline with the Q/O path removed.
+
+Algorithm overview (per chunk c, tokens [cC, (c+1)C)):
+  Inputs : K[BT,DK], V[BT,DV], Gate[BT] (scalar gate), Beta[BT] (scalar LR)
+  State  : S_prev[DK,DV]  (recurrent state, held in TMEM)
+
+  Preprocessing (compute warp group 0):
+    cumsumlog[t]     = sum_{l=0}^{t} log(Gate_l)              cumulative log of gates
+    cumprod[t]       = exp(cumsumlog[t])                       cumulative product of gates
+    T_pairwise[i,j]  = cumprod[i] / cumprod[j]  (i>=j)       inter-token transfer weights
+    (stored in registers; 128 regs/thread)
+
+  GEMM 1 - KK   : W_kk[BT,BT]  = K  @ K^T       (lower-triangular intra scores)
+  GEMM 3 - K*state : KS[BT,DV] = K  @ S_prev    (key applied to state)
+  GEMM 5 - U       : U[BT,DV]  = T_inv @ Y       (corrected value vectors)
+                      where T_inv = (I + M_kk)^{-1},  M_kk[i,j] = T[i,j]*Beta[i]*W_kk[i,j]  (lower-tri, hierarchical blockwise inverse)
+  GEMM 7 - KV update : S_upd[DK,DV] = K^T @ (decay .* U)  (state update, BT contraction)
+                        where Y[BT,DV] = V - KS    (delta rule residuals, after decay)
+
+  Epilogue:
+    S_next    = cumprod[BT-1] * S_prev + S_upd        (update state in TMEM)
+
+Chunks run in PAIRS (CG0 warp halves invert chunk 0 / chunk 1 in parallel);
+odd counts pad with a neutral zero-filled chunk.
+
+SMEM layout (stage counts live in gdn_recompute_config.py;
+enable_checkpoints compiles trim K stages to fit the checkpoint buffer):
+  Buffer                       Size (B)  Stages
+  K (two-box stage)               32768       4
+  V                               16384       3
+  T_inv                            8192       2
+  checkpoint staging            DK*DV*2       1    <-- enable_checkpoints only
+  cumsumlog / cumprod / Beta        256       3
+  sched ticket ring                   4       2    <-- dyn_sched publish ring
+
+TMEM layout (512 columns):
+  Buffer                  Cols
+  state                   128     <-- DKxDV fp32 = 128x128x4B
+  state inp                64     <-- fp16 state staging (GEMM 3 A operand)
+  cg0 shared acc          128     <-- 2-stage ring: KK0/KK1
+  cg1 shared acc           64     <-- 1-stage ring: KS then U
+  Y / decayed-U inp        64     <-- slot 0 = Y (V - K*state), slot 1 = decayed U (b16)
+
+Warp assignments (12 warps = 384 threads):
+  warps 0-3     : compute group 0 - T-pairwise x2, KK_epi x2, pair inverse
+  warps 4-7     : compute group 1 - state restage/rescale, Y = V - K*state,
+                                    U epilogue
+  warp  8       : Gate/Beta loads
+  warp  9       : TMA load warp  - loads K, V
+  warp  10      : MMA warp       - fused KK pairs + K*state/U/KV per chunk;
+                                    TMEM lifecycle
+  warp  11      : epilogue warp  - checkpoint TMA stores
+"""
+
+from dataclasses import dataclass
+from functools import lru_cache, partial
+from typing import NamedTuple, Optional, Tuple, Type
+
+import cuda.bindings.driver as cuda_driver
+import cutlass
+import cutlass.cute as cute
+import cutlass.experimental.cuda as cuda
+import cutlass.experimental.primitives as nvvm
+from cutlass.cutlass_dsl import min
+
+from attn_gym._backends.cute import compile_tvm_ffi
+from attn_gym._backends.cute.utils import requires_int64_abi
+
+from .common.elementwise import softplus
+from .common.host import get_dtype
+from .common.split_k import (
+    ORDER_CAPACITY,
+    ORDER_ELEMS,
+    ORDER_THREADS,
+    decode_work_item,
+    order_body,
+)
+from .common.thd import (
+    TENSOR_MAP_QWORDS,
+    emit_checkpoint_seq_descs,
+    emit_seq_load_descs,
+)
+from .common.tvm_ffi import (
+    make_compact_signature_tensor,
+    make_counter_signature,
+    make_cu_seqlens_signature,
+    make_strided_signature_tensor,
+    make_work_items_signature,
+    make_workspace_signature,
+    validate_cu_seqlens,
+)
+from .compat import (
+    checkpoint_capacity_bound,
+    current_device,
+    get_device_properties,
+    tensor_device_index,
+    validate_tma_tensor,
+)
+from .gdn_recompute_config import CFG
+from .tile_dsl.barrier import MBarrier, PipelineState, Producer, advance
+from .tile_dsl.handles import MmaDesc, SmemTile, smem_data_ptr, tma_slice_runtime_desc
+from .tile_dsl.mma import mma_ss, mma_step, mma_step_k8, mma_ts_step
+from .tile_dsl.pointwise import (
+    f16x2_to_f32,
+    fadd2,
+    fmul2,
+    fp32_to_fp16,
+    opaque_f32_zero,
+    sub_f16x2,
+)
+from .tile_dsl.swizzle import swizzle_lin_128b, swizzle_xor_128b
+from .tile_dsl.tma import (
+    tma_load_tile,
+    tma_store_commit,
+    tma_store_tile,
+    tma_store_wait,
+    tma_tensormap_acquire,
+)
+
+RCP_LN2: float = 1.4426950408889634  # natural-log gates -> kernel's log2 domain
+
+
+class GdnBars(NamedTuple):
+    """GDN pipeline mbarrier inventory.
+
+    Every pipeline is a ``_ready``/``_done`` MBarrier pair over one ring: a
+    slot is acquired for filling by waiting ``_done`` and committed by
+    arriving ``_ready``; the reading side waits ``_ready`` and releases the
+    slot by arriving ``_done``.
+    """
+
+    mb_kq_ready: MBarrier
+    mb_kq_done: MBarrier
+    mb_v_ready: MBarrier
+    mb_v_done: MBarrier
+
+    mb_gate_ready: MBarrier
+    mb_gate_done: MBarrier
+    mb_beta_ready: MBarrier
+    mb_beta_done: MBarrier
+
+    mb_state_acc_ready: MBarrier
+    mb_state_acc_scale_done: MBarrier
+    mb_cg0_acc_ready: MBarrier
+    mb_cg0_acc_done: MBarrier
+    mb_k_state_acc_ready: MBarrier
+    mb_u_acc_ready: MBarrier
+
+    mb_t_inv_ready: MBarrier
+    mb_t_inv_done: MBarrier
+    mb_state_inp_ready: MBarrier
+    mb_y_inp_ready: MBarrier
+    mb_decay_u_inp_ready: MBarrier
+
+    mb_checkpoint_tmastg_ready: MBarrier
+    mb_checkpoint_tmastg_done: MBarrier
+
+    mb_tmem_done: MBarrier
+    mb_sched_ready: MBarrier
+    mb_sched_done: MBarrier
+
+
+def make_gdn_bars(cfg) -> GdnBars:
+    """GdnBars factory.  MUST be called from inside ``kernel`` (allocates SMEM)."""
+    ONE_LANE = 1
+    MMA_ARRIVERS = len([cfg.mma_warp_id])
+    KQ_RELEASE_SITES = 1
+    GATE_WARP = cfg.threads_per_warp * len([cfg.load_gate_beta_warp_id])
+    EPI_WARP = cfg.threads_per_warp * len([cfg.epilogue_warp_id])
+    CG0_THREADS = cfg.threads_per_warp * len(cfg.compute_group_0_warp_ids)
+    CG1_THREADS = cfg.threads_per_warp * len(cfg.compute_group_1_warp_ids)
+    CG0_PLUS_CG1 = CG0_THREADS + CG1_THREADS
+
+    def alloc(n):
+        return cutlass.Array(cutlass.Int64, n, space=cutlass.AddressSpace.smem, alignment=16)
+
+    return GdnBars(
+        mb_kq_ready=MBarrier(
+            alloc(cfg.smem_kq_stages),
+            stages=cfg.smem_kq_stages,
+            init_count=ONE_LANE,
+            producer=Producer.TMA_LOAD,
+        ),
+        mb_kq_done=MBarrier(
+            alloc(cfg.smem_kq_stages),
+            stages=cfg.smem_kq_stages,
+            init_count=KQ_RELEASE_SITES,
+            producer=Producer.MMA_COMMIT,
+        ),
+        mb_v_ready=MBarrier(
+            alloc(cfg.smem_v_stages),
+            stages=cfg.smem_v_stages,
+            init_count=ONE_LANE,
+            producer=Producer.TMA_LOAD,
+        ),
+        mb_v_done=MBarrier(
+            alloc(cfg.smem_v_stages),
+            stages=cfg.smem_v_stages,
+            init_count=CG1_THREADS,
+            producer=Producer.THREAD,
+        ),
+        mb_gate_ready=MBarrier(
+            alloc(cfg.smem_gate_stages),
+            stages=cfg.smem_gate_stages,
+            init_count=GATE_WARP,
+            producer=Producer.THREAD,
+        ),
+        mb_gate_done=MBarrier(
+            alloc(cfg.smem_gate_stages),
+            stages=cfg.smem_gate_stages,
+            init_count=CG0_PLUS_CG1,
+            producer=Producer.THREAD,
+        ),
+        mb_beta_ready=MBarrier(
+            alloc(cfg.smem_beta_stages),
+            stages=cfg.smem_beta_stages,
+            init_count=GATE_WARP,
+            producer=Producer.THREAD,
+        ),
+        mb_beta_done=MBarrier(
+            alloc(cfg.smem_beta_stages),
+            stages=cfg.smem_beta_stages,
+            init_count=CG0_THREADS,
+            producer=Producer.THREAD,
+        ),
+        mb_state_acc_ready=MBarrier(
+            alloc(cfg.tmem_state_acc_stages),
+            stages=cfg.tmem_state_acc_stages,
+            init_count=MMA_ARRIVERS,
+            producer=Producer.MMA_COMMIT,
+        ),
+        mb_state_acc_scale_done=MBarrier(
+            alloc(cfg.tmem_state_acc_stages),
+            stages=cfg.tmem_state_acc_stages,
+            init_count=CG1_THREADS,
+            producer=Producer.THREAD,
+        ),
+        mb_cg0_acc_ready=MBarrier(
+            alloc(cfg.tmem_cg0_acc_stages),
+            stages=cfg.tmem_cg0_acc_stages,
+            init_count=MMA_ARRIVERS,
+            producer=Producer.MMA_COMMIT,
+        ),
+        mb_cg0_acc_done=MBarrier(
+            alloc(cfg.tmem_cg0_acc_stages),
+            stages=cfg.tmem_cg0_acc_stages,
+            init_count=CG0_THREADS // 2,
+            producer=Producer.THREAD,
+        ),
+        mb_k_state_acc_ready=MBarrier(
+            alloc(1), stages=1, init_count=MMA_ARRIVERS, producer=Producer.MMA_COMMIT
+        ),
+        mb_u_acc_ready=MBarrier(
+            alloc(1), stages=1, init_count=MMA_ARRIVERS, producer=Producer.MMA_COMMIT
+        ),
+        mb_t_inv_ready=MBarrier(
+            alloc(cfg.smem_t_inv_stages),
+            stages=cfg.smem_t_inv_stages,
+            init_count=CG0_THREADS,
+            producer=Producer.THREAD,
+        ),
+        mb_t_inv_done=MBarrier(
+            alloc(cfg.smem_t_inv_stages),
+            stages=cfg.smem_t_inv_stages,
+            init_count=MMA_ARRIVERS,
+            producer=Producer.MMA_COMMIT,
+        ),
+        mb_state_inp_ready=MBarrier(
+            alloc(cfg.tmem_state_inp_stages),
+            stages=cfg.tmem_state_inp_stages,
+            init_count=CG1_THREADS,
+            producer=Producer.THREAD,
+        ),
+        mb_y_inp_ready=MBarrier(
+            alloc(1), stages=1, init_count=CG1_THREADS, producer=Producer.THREAD
+        ),
+        mb_decay_u_inp_ready=MBarrier(
+            alloc(1), stages=1, init_count=CG1_THREADS, producer=Producer.THREAD
+        ),
+        mb_checkpoint_tmastg_ready=MBarrier(
+            alloc(cfg.smem_checkpoint_stages),
+            stages=cfg.smem_checkpoint_stages,
+            init_count=len(cfg.compute_group_1_warp_ids),
+            producer=Producer.THREAD,
+        ),
+        mb_checkpoint_tmastg_done=MBarrier(
+            alloc(cfg.smem_checkpoint_stages),
+            stages=cfg.smem_checkpoint_stages,
+            init_count=EPI_WARP,
+            producer=Producer.THREAD,
+        ),
+        mb_tmem_done=MBarrier(
+            alloc(1), stages=1, init_count=CG1_THREADS, producer=Producer.THREAD
+        ),
+        mb_sched_ready=MBarrier(
+            alloc(cfg.sched_stages),
+            stages=cfg.sched_stages,
+            init_count=1,
+            producer=Producer.THREAD,
+        ),
+        mb_sched_done=MBarrier(
+            alloc(cfg.sched_stages),
+            stages=cfg.sched_stages,
+            init_count=11,
+            producer=Producer.THREAD,
+        ),
+    )
+
+
+@cute.jit
+def invert_diagonal_NxN(cfg, base_int, d, tidx, N: int = 8):
+    """Gauss-Jordan inversion of one diagonal NxN block in-place (f16 SMEM)."""
+    tidx_in_group = tidx % N
+    BT = cfg.b_t
+
+    row_lin_base = (d * N + tidx_in_group) * BT + d * N
+    row_phys = swizzle_lin_128b(row_lin_base, row_stride_log2=6)
+    row_ptr = (
+        cute.make_ptr(
+            cfg.io_dtype,
+            base_int,
+            mem_space=cute.AddressSpace.smem,
+            assumed_align=cfg.buffer_align_bytes,
+        )
+        + row_phys
+    )
+
+    row = [(row_ptr + j).load().to(cutlass.Float32) for j in range(N)]
+    for i in cutlass.range_constexpr(N):
+        row[i] = cutlass.Float32(1.0) if tidx_in_group == i else row[i]
+    for src_row in cutlass.range_constexpr(N - 1):
+        row_scale = -row[src_row]
+        for i in cutlass.range_constexpr(src_row):
+            shfl_val = nvvm.shfl_sync(
+                0xFFFFFFFF, row[i], src_row, 0b1100000011111, kind=nvvm.Shfl.IDX
+            )
+            row[i] = row[i] + row_scale * shfl_val if tidx_in_group > src_row else row[i]
+        row[src_row] = row_scale if tidx_in_group > src_row else row[src_row]
+
+    for j in cutlass.range_constexpr(N):
+        (row_ptr + j).store(row[j].to(cfg.io_dtype))
+
+
+@cute.jit
+def blockwise_diagonal_8x8_to_16x16(cfg, base_int, d0, lane_id):
+    """Off-diagonal correction 8x8 -> 16x16 (C <- -D^{-1} C A^{-1})."""
+    bpe = cfg.io_dtype.width // 8
+    lds1 = (lane_id % 8) * 64
+    d = nvvm.ldmatrix(
+        cutlass.inttoptr(
+            base_int + swizzle_lin_128b((d0 + 8) * 64 + d0 + 8 + lds1, row_stride_log2=6) * bpe,
+            cutlass.AddressSpace.smem,
+            cutlass.BFloat16,
+        ),
+        1,
+        nvvm.MMALayout.ROW,
+    )
+    c = nvvm.ldmatrix(
+        cutlass.inttoptr(
+            base_int + swizzle_lin_128b((d0 + 8) * 64 + d0 + lds1, row_stride_log2=6) * bpe,
+            cutlass.AddressSpace.smem,
+            cutlass.BFloat16,
+        ),
+        1,
+        nvvm.MMALayout.COL,
+    )
+
+    # ---- T = -(D^{-1} @ C) -------------------------------------------------------
+    c_regs = cutlass.Array(cutlass.Float32, 4, alignment=16, space=cutlass.AddressSpace.rmem)
+    for i in cutlass.range_constexpr(4):
+        c_regs[i] = cutlass.Float32(0.0)
+    mma_step_k8(c_regs, [d, d], [c], k_step=0, M=16, N=8, ab_dtype=cfg.io_dtype)
+    for i in cutlass.range_constexpr(4):
+        c_regs[i] = -c_regs[i]
+    a_pack = [fp32_to_fp16(c_regs[2 * j], c_regs[2 * j + 1], dtype=cfg.io_dtype) for j in range(2)]
+
+    # ---- C = T @ A^{-1} ----------------------------------------------------------
+    ai = nvvm.ldmatrix(
+        cutlass.inttoptr(
+            base_int + swizzle_lin_128b(d0 * 64 + d0 + lds1, row_stride_log2=6) * bpe,
+            cutlass.AddressSpace.smem,
+            cutlass.BFloat16,
+        ),
+        1,
+        nvvm.MMALayout.COL,
+    )
+    o_regs = cutlass.Array(cutlass.Float32, 4, alignment=16, space=cutlass.AddressSpace.rmem)
+    for i in cutlass.range_constexpr(4):
+        o_regs[i] = cutlass.Float32(0.0)
+    mma_step_k8(o_regs, a_pack, [ai], k_step=0, M=16, N=8, ab_dtype=cfg.io_dtype)
+    o_pack = fp32_to_fp16(o_regs[0], o_regs[1], dtype=cfg.io_dtype)
+
+    # ---- store corrected C -------------------------------------------------------
+    nvvm.stmatrix(
+        cutlass.inttoptr(
+            base_int + swizzle_lin_128b((d0 + 8) * 64 + d0 + lds1, row_stride_log2=6) * bpe,
+            cutlass.AddressSpace.smem,
+            cutlass.BFloat16,
+        ),
+        o_pack,
+        nvvm.MMALayout.ROW,
+    )
+
+
+@cute.jit
+def blockwise_diagonal_16x16_to_32x32(cfg, base_int, d0, lane_id):
+    """Off-diagonal correction 16x16 -> 32x32."""
+    bpe = cfg.io_dtype.width // 8
+    lds4 = (lane_id % 16) * 64 + (lane_id // 16) * 8
+    d = list(
+        nvvm.ldmatrix(
+            cutlass.inttoptr(
+                base_int
+                + swizzle_lin_128b((d0 + 16) * 64 + d0 + 16 + lds4, row_stride_log2=6) * bpe,
+                cutlass.AddressSpace.smem,
+                cutlass.BFloat16,
+            ),
+            4,
+            nvvm.MMALayout.ROW,
+        )
+    )
+    c = list(
+        nvvm.ldmatrix(
+            cutlass.inttoptr(
+                base_int + swizzle_lin_128b((d0 + 16) * 64 + d0 + lds4, row_stride_log2=6) * bpe,
+                cutlass.AddressSpace.smem,
+                cutlass.BFloat16,
+            ),
+            4,
+            nvvm.MMALayout.COL,
+        )
+    )
+
+    # ---- T = -(D^{-1} @ C) -------------------------------------------------------
+    c_regs = cutlass.Array(cutlass.Float32, 8, alignment=16, space=cutlass.AddressSpace.rmem)
+    for i in cutlass.range_constexpr(8):
+        c_regs[i] = cutlass.Float32(0.0)
+    mma_step(c_regs, d, c, k_step=0, M=16, N=16, ab_dtype=cfg.io_dtype)
+    for i in cutlass.range_constexpr(8):
+        c_regs[i] = -c_regs[i]
+    a_pack = [fp32_to_fp16(c_regs[2 * j], c_regs[2 * j + 1], dtype=cfg.io_dtype) for j in range(4)]
+
+    # ---- C = T @ A^{-1} ----------------------------------------------------------
+    ai = list(
+        nvvm.ldmatrix(
+            cutlass.inttoptr(
+                base_int + swizzle_lin_128b(d0 * 64 + d0 + lds4, row_stride_log2=6) * bpe,
+                cutlass.AddressSpace.smem,
+                cutlass.BFloat16,
+            ),
+            4,
+            nvvm.MMALayout.COL,
+        )
+    )
+    o_regs = cutlass.Array(cutlass.Float32, 8, alignment=16, space=cutlass.AddressSpace.rmem)
+    for i in cutlass.range_constexpr(8):
+        o_regs[i] = cutlass.Float32(0.0)
+    mma_step(o_regs, a_pack, ai, k_step=0, M=16, N=16, ab_dtype=cfg.io_dtype)
+    o_pack = [fp32_to_fp16(o_regs[2 * j], o_regs[2 * j + 1], dtype=cfg.io_dtype) for j in range(4)]
+
+    # ---- store corrected C -------------------------------------------------------
+    nvvm.stmatrix(
+        cutlass.inttoptr(
+            base_int + swizzle_lin_128b((d0 + 16) * 64 + d0 + lds4, row_stride_log2=6) * bpe,
+            cutlass.AddressSpace.smem,
+            cutlass.BFloat16,
+        ),
+        o_pack,
+        nvvm.MMALayout.ROW,
+    )
+
+
+@cute.jit
+def blockwise_diagonal_32x32_to_64x64(cfg, base_int, warp_id, lane_id):
+    """Off-diagonal correction 32x32 -> 64x64 (2 warps, one 16-row M-band each)."""
+    band = warp_id % 2
+    bpe = cfg.io_dtype.width // 8
+    lds4 = (lane_id % 16) * 64 + (lane_id // 16) * 8
+    a_frags = []
+    for vs in cutlass.range_constexpr(2):
+        a_frags += list(
+            nvvm.ldmatrix(
+                cutlass.inttoptr(
+                    base_int
+                    + swizzle_lin_128b(
+                        (32 + band * 16) * 64 + 32 + vs * 16 + lds4, row_stride_log2=6
+                    )
+                    * bpe,
+                    cutlass.AddressSpace.smem,
+                    cutlass.BFloat16,
+                ),
+                4,
+                nvvm.MMALayout.ROW,
+            )
+        )
+    b_frags = []
+    for vs in cutlass.range_constexpr(4):
+        b_frags += list(
+            nvvm.ldmatrix(
+                cutlass.inttoptr(
+                    base_int
+                    + swizzle_lin_128b(
+                        (32 + (vs // 2) * 16) * 64 + (vs % 2) * 16 + lds4, row_stride_log2=6
+                    )
+                    * bpe,
+                    cutlass.AddressSpace.smem,
+                    cutlass.BFloat16,
+                ),
+                4,
+                nvvm.MMALayout.COL,
+            )
+        )
+
+    # ---- T = -(D^{-1} @ C) -------------------------------------------------------
+    c_regs = cutlass.Array(cutlass.Float32, 16, alignment=16, space=cutlass.AddressSpace.rmem)
+    for i in cutlass.range_constexpr(16):
+        c_regs[i] = cutlass.Float32(0.0)
+    for ks in cutlass.range_constexpr(2):
+        mma_step(
+            c_regs,
+            a_frags,
+            b_frags[ks * 8 : ks * 8 + 8],
+            k_step=ks,
+            M=16,
+            N=32,
+            ab_dtype=cfg.io_dtype,
+        )
+    for i in cutlass.range_constexpr(16):
+        c_regs[i] = -c_regs[i]
+    a_pack = [fp32_to_fp16(c_regs[2 * j], c_regs[2 * j + 1], dtype=cfg.io_dtype) for j in range(8)]
+
+    # ---- C = T @ A^{-1} ----------------------------------------------------------
+    ai_frags = []
+    for vs in cutlass.range_constexpr(4):
+        ai_frags += list(
+            nvvm.ldmatrix(
+                cutlass.inttoptr(
+                    base_int
+                    + swizzle_lin_128b(
+                        ((vs // 2) * 16) * 64 + (vs % 2) * 16 + lds4, row_stride_log2=6
+                    )
+                    * bpe,
+                    cutlass.AddressSpace.smem,
+                    cutlass.BFloat16,
+                ),
+                4,
+                nvvm.MMALayout.COL,
+            )
+        )
+    o_regs = cutlass.Array(cutlass.Float32, 16, alignment=16, space=cutlass.AddressSpace.rmem)
+    for i in cutlass.range_constexpr(16):
+        o_regs[i] = cutlass.Float32(0.0)
+    for ks in cutlass.range_constexpr(2):
+        mma_step(
+            o_regs,
+            a_pack,
+            ai_frags[ks * 8 : ks * 8 + 8],
+            k_step=ks,
+            M=16,
+            N=32,
+            ab_dtype=cfg.io_dtype,
+        )
+    o_pack = [fp32_to_fp16(o_regs[2 * j], o_regs[2 * j + 1], dtype=cfg.io_dtype) for j in range(8)]
+
+    # ---- store corrected C -------------------------------------------------------
+    nvvm.barrier_cta_sync_aligned(
+        cfg.inverse_barrier_id,
+        thread_count=cfg.inverse_barrier_threads,
+    )
+    nvvm.stmatrix(
+        cutlass.inttoptr(
+            base_int + swizzle_lin_128b((32 + band * 16) * 64 + lds4, row_stride_log2=6) * bpe,
+            cutlass.AddressSpace.smem,
+            cutlass.BFloat16,
+        ),
+        o_pack[0:4],
+        nvvm.MMALayout.ROW,
+    )
+    nvvm.stmatrix(
+        cutlass.inttoptr(
+            base_int
+            + swizzle_lin_128b((32 + band * 16) * 64 + 16 + lds4, row_stride_log2=6) * bpe,
+            cutlass.AddressSpace.smem,
+            cutlass.BFloat16,
+        ),
+        o_pack[4:8],
+        nvvm.MMALayout.ROW,
+    )
+
+
+# ---- Dynamic tile scheduler ------------------------------------------------------
+
+
+@cute.jit
+def sched_publish_next(cfg, bars, sSched, mSched, sched_state, tile_idx, num_ctas):
+    """TMA-LDG-warp side: pull the next tile off the global ticket, publish it."""
+    if cutlass.const_expr(cfg.dyn_sched):
+        bars.mb_sched_done[sched_state.idx].wait(sched_state.phase)
+        if nvvm.elect_sync():
+            fetched = cutlass.Int32(
+                nvvm.atomicrmw(
+                    "add", mSched.iterator, cutlass.Int32(1), mem_order="relaxed", syncscope="gpu"
+                )
+            )
+            sSched[sched_state.idx] = num_ctas + fetched
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+        next_tile = sSched[sched_state.idx]
+        if nvvm.elect_sync():
+            bars.mb_sched_ready[sched_state.idx].arrive()
+        return next_tile, advance(sched_state, cfg.sched_stages)
+    return tile_idx + num_ctas, sched_state
+
+
+@cute.jit
+def sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas):
+    """Consumer side: read the TMA-LDG warp's published next tile."""
+    if cutlass.const_expr(cfg.dyn_sched):
+        bars.mb_sched_ready[sched_state.idx].wait(sched_state.phase)
+        next_tile = sSched[sched_state.idx]
+        if nvvm.elect_sync():
+            bars.mb_sched_done[sched_state.idx].arrive()
+        return next_tile, advance(sched_state, cfg.sched_stages)
+    return tile_idx + num_ctas, sched_state
+
+
+@cute.jit
+def tmastg_warp(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    cu_seqlens,
+    mWorkItems,
+    checkpoint_every_n_tokens,
+    tidx,
+    sCheckpoint_raw,
+    desc_checkpoint_base,
+    sSched,
+    bars,
+):
+    """Epilogue warp role (warp 11): persistent scheduler loop issuing the
+    per-chunk checkpoint TMA stores."""
+    elect_one = nvvm.elect_sync()
+    nvvm.setmaxregister(cfg.num_regs_other, nvvm.SetMaxRegisterAction.DECREASE)
+    lidx = tidx % cfg.threads_per_warp
+    sched_state = PipelineState.start(phase=0)
+    tile_idx = cutlass.Int32(bidx)
+
+    if cutlass.const_expr(cfg.enable_checkpoints):
+        checkpoint_granu = 64
+        sCheckpoint_tma = SmemTile(
+            base=sCheckpoint_raw,
+            elems_per_stage=(cfg.checkpoint_cosize // cfg.smem_checkpoint_stages),
+            stages=cfg.smem_checkpoint_stages,
+            leading_byte_offset=0,
+            stride_byte_offset=0,
+            layout=0,
+            tma_loads_per_tile=cfg.d_v // checkpoint_granu,
+            tma_granu_elems=checkpoint_granu,
+            tma_subtile_stride_elems=cfg.d_k * checkpoint_granu,
+        )
+        checkpoint_store_cnt = cutlass.Int32(0)
+        ckpt_chunks = checkpoint_every_n_tokens // cutlass.Int32(cfg.b_t)
+    heads_out = cutlass.Int32(cfg.n_heads_out)
+    desc_qwords = cutlass.Int32(TENSOR_MAP_QWORDS)
+
+    while tile_idx < total_tiles:
+        (
+            batch_idx,
+            head_idx,
+            batch_start,
+            batch_end,
+            seqlen_b,
+            num_chunks_b,
+            wstart,
+            wend,
+            cstart,
+            cend,
+        ) = decode_work_item(cfg, tile_idx, mWorkItems)
+        n_local = wend - cstart
+
+        head_o = head_idx
+        slot = batch_idx * desc_qwords
+        if cutlass.const_expr(cfg.enable_checkpoints):
+            desc_checkpoint_slot = (desc_checkpoint_base + slot).tospace(
+                cutlass.AddressSpace.generic
+            )
+            checkpoint_coord = (wstart + ckpt_chunks - cutlass.Int32(1)) // ckpt_chunks
+            checkpoint_mod = cstart % ckpt_chunks
+            if elect_one:
+                tma_tensormap_acquire(desc_checkpoint_slot)
+
+        if n_local > 0:
+            for local_idx in cutlass.range(n_local):
+                chunk_idx = cstart + local_idx
+
+                did_checkpoint = cutlass.Int32(0)
+                if cutlass.const_expr(cfg.enable_checkpoints):
+                    checkpoint_stage = checkpoint_store_cnt % cfg.smem_checkpoint_stages
+                    checkpoint_phase = (
+                        checkpoint_store_cnt // cfg.smem_checkpoint_stages
+                    ) & cutlass.Int32(1)
+                    if chunk_idx >= wstart and chunk_idx < wend:
+                        if checkpoint_mod == 0:
+                            bars.mb_checkpoint_tmastg_ready[checkpoint_stage].wait(
+                                checkpoint_phase
+                            )
+                            checkpoint_slice = tma_slice_runtime_desc(
+                                desc_checkpoint_slot,
+                                cutlass.Int32(0),
+                                cutlass.Int32(0),
+                                checkpoint_coord,
+                                head_o,
+                            )
+                            tma_store_tile(
+                                sCheckpoint_tma[checkpoint_stage], checkpoint_slice, acquire=False
+                            )
+                            tma_store_commit()
+                            checkpoint_coord += 1
+                            did_checkpoint = cutlass.Int32(1)
+                    checkpoint_mod = checkpoint_mod + cutlass.Int32(1)
+                    checkpoint_mod = (
+                        cutlass.Int32(0) if checkpoint_mod == ckpt_chunks else checkpoint_mod
+                    )
+
+                    if did_checkpoint == 1:
+                        tma_store_wait(0)
+                        bars.mb_checkpoint_tmastg_done[checkpoint_stage].arrive()
+                        checkpoint_store_cnt = checkpoint_store_cnt + 1
+
+        tile_idx, sched_state = sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas)
+
+
+@cute.jit
+def gate_beta_warp(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    cu_seqlens,
+    mWorkItems,
+    tidx,
+    mGate,
+    mA_log,
+    mDt_bias,
+    mBeta,
+    sCumsumlog,
+    sCumprod,
+    sBeta,
+    sSched,
+    bars,
+):
+    """Gate/Beta producer (warp 8): persistent scheduler loop + the
+    cumsum/cumprod/Beta chunk loads."""
+
+    nvvm.setmaxregister(cfg.num_regs_other, nvvm.SetMaxRegisterAction.DECREASE)
+    gate_index = PipelineState.start(phase=1)
+    beta_index = PipelineState.start(phase=1)
+    lidx = tidx % cfg.threads_per_warp
+
+    a_l2 = cutlass.Float32(0.0)
+    bias = cutlass.Float32(0.0)
+    sched_state = PipelineState.start(phase=0)
+    tile_idx = cutlass.Int32(bidx)
+    while tile_idx < total_tiles:
+        (
+            batch_idx,
+            head_idx,
+            batch_start,
+            batch_end,
+            seqlen_b,
+            num_chunks_b,
+            wstart,
+            wend,
+            cstart,
+            cend,
+        ) = decode_work_item(cfg, tile_idx, mWorkItems)
+        n_local = wend - cstart
+        if cutlass.const_expr(cfg.safe_gate):
+            if n_local > 0:
+                # per-head transform constants, fixed for the whole tile
+                a_l2 = -cute.math.exp2(
+                    mA_log[head_idx].to(cutlass.Float32) * cutlass.Float32(RCP_LN2), fastmath=True
+                ) * cutlass.Float32(RCP_LN2)
+                bias = mDt_bias[head_idx].to(cutlass.Float32)
+        if n_local > 0:
+            for local_idx in cutlass.range(n_local):
+                # ---- Gate load: GMEM -> SMEM (OOB neutral) -----------------------
+                chunk_idx = cstart + local_idx
+                n_cols = cfg.b_t // cfg.threads_per_warp
+                chunk_offset = batch_start + chunk_idx * cfg.b_t
+                gGateSeq = mGate[None, head_idx]
+                gBeta = cute.domain_offset((chunk_offset,), mBeta[None, head_idx])
+
+                gate_idx = gate_index.idx
+                gate_phase = gate_index.phase
+                gate_index = advance(gate_index, cfg.smem_gate_stages)
+
+                pos_valid = [None] * n_cols
+                gate_vals = [cutlass.Float32(0.0)] * n_cols
+                oob_neutral = (
+                    cutlass.Float32(0.0)
+                    if cutlass.const_expr(cfg.log_gate)
+                    else cutlass.Float32(1.0)
+                )
+                for col in cutlass.range_constexpr(n_cols):
+                    tok = chunk_offset + lidx + col * cfg.threads_per_warp
+                    pos_valid[col] = cute.elem_less(tok, batch_end)
+                    tok_clamped = min(tok, batch_end - 1)
+                    gate_vals[col] = gGateSeq[tok_clamped] if pos_valid[col] else oob_neutral
+
+                if cutlass.const_expr(cfg.safe_gate):
+                    # raw logits -> log2-domain decay: a_l2 * softplus(g + bias) (split-K scan arithmetic)
+                    for col in cutlass.range_constexpr(n_cols):
+                        contrib = a_l2 * softplus(gate_vals[col] + bias)
+                        gate_vals[col] = contrib if pos_valid[col] else cutlass.Float32(0.0)
+                elif cutlass.const_expr(cfg.log_gate):
+                    for col in cutlass.range_constexpr(n_cols):
+                        gate_vals[col] = gate_vals[col] * cutlass.Float32(RCP_LN2)
+                else:
+                    for col in cutlass.range_constexpr(n_cols):
+                        gate_vals[col] = cute.math.log2(gate_vals[col] + 1e-10, fastmath=True)
+                for offset in [1, 2, 4, 8, 16]:
+                    for col in cutlass.range_constexpr(n_cols):
+                        n = nvvm.shfl_sync(
+                            0xFFFFFFFF, gate_vals[col], offset, 0, kind=nvvm.Shfl.UP
+                        )
+                        if lidx >= offset:
+                            gate_vals[col] = gate_vals[col] + n
+                for col in cutlass.range_constexpr(1, n_cols):
+                    last_v = nvvm.shfl_sync(
+                        0xFFFFFFFF,
+                        gate_vals[col - 1],
+                        cfg.threads_per_warp - 1,
+                        cfg.threads_per_warp - 1,
+                        kind=nvvm.Shfl.IDX,
+                    )
+                    gate_vals[col] += last_v
+
+                bars.mb_gate_done[gate_idx].wait(gate_phase)
+                for col in cutlass.range_constexpr(n_cols):
+                    pos = lidx + col * cfg.threads_per_warp
+                    sCumsumlog[pos, 0, gate_idx] = gate_vals[col]
+                    sCumprod[pos, 0, gate_idx] = cute.math.exp2(gate_vals[col], fastmath=True)
+
+                bars.mb_gate_ready[gate_idx].arrive()
+
+                # ---- Beta load: GMEM -> SMEM (per-element cp.async) --------------------------
+                beta_idx = beta_index.idx
+                bars.mb_beta_done[beta_idx].wait(beta_index.phase)
+                beta_index = advance(beta_index, cfg.smem_beta_stages)
+                if cutlass.const_expr(cfg.beta_sigmoid):
+                    # io-dtype logits -> sigmoid (tanh identity) -> fp32 SMEM
+                    for col in cutlass.range_constexpr(n_cols):
+                        pos = lidx + col * cfg.threads_per_warp
+                        beta_value = cutlass.Float32(0.0)
+                        if pos_valid[col]:
+                            beta_value = gBeta[pos].to(cutlass.Float32)
+                            half = cutlass.Float32(0.5)
+                            beta_value = (
+                                (cute.math.tanh(beta_value * half, approx=True) * half + half)
+                                .to(mBeta.element_type)
+                                .to(cutlass.Float32)
+                            )
+                        sBeta[pos, 0, beta_idx] = beta_value
+                    bars.mb_beta_ready[beta_idx].arrive()
+                else:
+                    for col in cutlass.range_constexpr(n_cols):
+                        pos = lidx + col * cfg.threads_per_warp
+                        src = gBeta.iterator + gBeta.layout((pos,))
+                        dst = sBeta.iterator + sBeta.layout((pos, 0, beta_idx))
+                        cp_size = cutlass.Int32(4) * cutlass.Int32(pos_valid[col])
+                        nvvm.cp_async_shared_global(
+                            dst, src, 4, nvvm.LoadCacheModifier.CA, cp_size=cp_size
+                        )
+                    nvvm.cp_async_mbarrier_arrive(
+                        bars.mb_beta_ready[beta_idx].smem_ptr, noinc=True
+                    )
+        tile_idx, sched_state = sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas)
+
+    for _ in range(cfg.smem_gate_stages):
+        bars.mb_gate_done[gate_index.idx].wait(gate_index.phase)
+        gate_index = advance(gate_index, cfg.smem_gate_stages)
+    for _ in range(cfg.smem_beta_stages):
+        bars.mb_beta_done[beta_index.idx].wait(beta_index.phase)
+        beta_index = advance(beta_index, cfg.smem_beta_stages)
+
+
+@cute.jit
+def mma_warp(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    cu_seqlens,
+    mWorkItems,
+    tmem_hold,
+    sKQ,
+    sKQ_trans,
+    sTinv,
+    sSched,
+    bars,
+):
+    """MMA issuer role (warp 10): persistent scheduler loop issuing every
+    tcgen05 GEMM."""
+    elect_one = nvvm.elect_sync()
+
+    nvvm.setmaxregister(cfg.num_regs_other, nvvm.SetMaxRegisterAction.DECREASE)
+    kv_acc_index = PipelineState.start(phase=1)
+    kq_index = PipelineState.start(phase=0)
+    cg0_acc_index = PipelineState.start(phase=1)
+    kq_fused_index = PipelineState.start(phase=0)
+    tinv_index = PipelineState.start(phase=0)
+    state_inp_index = PipelineState.start(phase=0)
+    y_inp_ready = PipelineState.start(phase=0)
+    decay_u_inp_ready = PipelineState.start(phase=0)
+
+    nvvm.tcgen05_alloc(tmem_hold, cutlass.Int32(512), group=nvvm.CTAGroup.CTA_1)
+    nvvm.barrier_cta_sync_aligned(
+        cfg.tmem_alloc_barrier_id,
+        thread_count=cfg.tmem_alloc_barrier_threads,
+    )
+
+    # ---- chunk-invariant GEMM descriptors ----------------------------------------
+    idesc_kk = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.b_t,
+        m_dim=2 * cfg.b_t,
+    )
+    bmm_kk_desc = MmaDesc(
+        M=2 * cfg.b_t,
+        N=cfg.b_t,
+        K=cfg.d_k,
+        bpe_a=cfg.io_dtype.width // 8,
+        bpe_b=cfg.io_dtype.width // 8,
+        tile_k_hw=16,
+        btranspose=False,
+        cta_group=1,
+        idesc=idesc_kk,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    bpe = cfg.io_dtype.width // 8
+    idesc_k_state = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.b_t,
+        m_dim=cfg.d_v,
+    )
+    bmm_k_state_desc = MmaDesc(
+        M=cfg.d_v,
+        N=cfg.b_t,
+        K=cfg.d_k,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=False,
+        atranspose=False,
+        cta_group=1,
+        idesc=idesc_k_state,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    idesc_u_ts = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.b_t,
+        m_dim=cfg.d_v,
+    )
+    bmm_u_ts_desc = MmaDesc(
+        M=cfg.d_v,
+        N=cfg.b_t,
+        K=cfg.b_t,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=False,
+        atranspose=False,
+        cta_group=1,
+        idesc=idesc_u_ts,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    idesc_kv = nvvm.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=cfg.io_dtype,
+        b_dtype=cfg.io_dtype,
+        n_dim=cfg.d_v,
+        m_dim=cfg.d_k,
+        b_major=1,
+    )
+    bmm_kv_desc = MmaDesc(
+        M=cfg.d_k,
+        N=cfg.d_v,
+        K=cfg.b_t,
+        bpe_a=bpe,
+        bpe_b=bpe,
+        tile_k_hw=16,
+        btranspose=True,
+        atranspose=False,
+        cta_group=1,
+        idesc=idesc_kv,
+        kind=nvvm.Tcgen05MMAKind.F16,
+    )
+    KQ_SEG = (2 * cfg.b_t * 64 * bpe) >> 4
+    KQ_BOX = (cfg.b_t * 64 * bpe) >> 4
+    KQ_HALF_K = (cfg.d_k // 16) // 2
+    KQ_A_HALF = KQ_HALF_K * bmm_k_state_desc.tmem_advance_A
+
+    KV_ACC_STAGE_COLS = cfg.d_v
+    STATE_INP_STAGE_COLS = cfg.d_k // 2
+    INP_SLOT_COLS = cfg.b_t // 2
+
+    tmem_base = tmem_hold.load()
+    tmem_cg0_acc_col_f = tmem_base + cfg.tmem_cg0_acc_offset
+    tmem_state_col = tmem_base + cfg.tmem_state_acc_offset
+    tmem_state_inp_col = tmem_base + cfg.tmem_state_inp_offset
+    tmem_inp_col = tmem_base + cfg.tmem_y_decay_u_inp_offset
+    y_inp_ptr = nvvm.make_tmem_ptr(tmem_inp_col, cutlass.Int8)
+    decay_u_inp_ptr = nvvm.make_tmem_ptr(tmem_inp_col + INP_SLOT_COLS, cutlass.Int8)
+    k_state_acc_ptr = nvvm.make_tmem_ptr(tmem_base + cfg.tmem_cg1_acc_offset, cutlass.Float32)
+    u_acc_ptr = k_state_acc_ptr
+
+    sched_state = PipelineState.start(phase=0)
+    tile_idx = cutlass.Int32(bidx)
+    while tile_idx < total_tiles:
+        (
+            batch_idx,
+            head_idx,
+            batch_start,
+            batch_end,
+            seqlen_b,
+            num_chunks_b,
+            wstart,
+            wend,
+            cstart,
+            cend,
+        ) = decode_work_item(cfg, tile_idx, mWorkItems)
+        n_local = wend - cstart
+
+        # ---- KK pair 0 = K(S) @ K^T, each member issued ahead of the loop -------
+        if n_local > 0:
+            member0_acc_idx = cg0_acc_index.idx
+            bars.mb_cg0_acc_done[member0_acc_idx].wait(cg0_acc_index.phase)
+            cg0_acc_index = advance(cg0_acc_index, cfg.tmem_cg0_acc_stages)
+            kqf_idx = kq_fused_index.idx
+            bars.mb_kq_ready[kqf_idx].wait(kq_fused_index.phase)
+            kq_fused_index = advance(kq_fused_index, cfg.smem_kq_stages)
+            desc_kqf = sKQ[kqf_idx].desc()
+            acc_cg0 = nvvm.make_tmem_ptr(
+                tmem_cg0_acc_col_f + member0_acc_idx * cfg.b_t, cutlass.Float32
+            )
+            mma_ss(bmm_kk_desc, desc_kqf, desc_kqf, acc_cg0, accumulate=False, k_count=KQ_HALF_K)
+            mma_ss(
+                bmm_kk_desc,
+                desc_kqf + KQ_SEG,
+                desc_kqf + KQ_SEG,
+                acc_cg0,
+                accumulate=True,
+                k_count=KQ_HALF_K,
+            )
+            if elect_one:
+                bars.mb_cg0_acc_ready[member0_acc_idx].arrive(cta_group=1)
+        if n_local > 1:
+            member1_acc_idx = cg0_acc_index.idx
+            bars.mb_cg0_acc_done[member1_acc_idx].wait(cg0_acc_index.phase)
+            cg0_acc_index = advance(cg0_acc_index, cfg.tmem_cg0_acc_stages)
+            kqf_idx = kq_fused_index.idx
+            bars.mb_kq_ready[kqf_idx].wait(kq_fused_index.phase)
+            kq_fused_index = advance(kq_fused_index, cfg.smem_kq_stages)
+            desc_kqf = sKQ[kqf_idx].desc()
+            desc_kqf_member1 = desc_kqf + KQ_BOX
+            acc_cg0 = nvvm.make_tmem_ptr(
+                tmem_cg0_acc_col_f + member1_acc_idx * cfg.b_t, cutlass.Float32
+            )
+            mma_ss(
+                bmm_kk_desc,
+                desc_kqf,
+                desc_kqf_member1,
+                acc_cg0,
+                accumulate=False,
+                k_count=KQ_HALF_K,
+            )
+            mma_ss(
+                bmm_kk_desc,
+                desc_kqf + KQ_SEG,
+                desc_kqf_member1 + KQ_SEG,
+                acc_cg0,
+                accumulate=True,
+                k_count=KQ_HALF_K,
+            )
+            if elect_one:
+                bars.mb_cg0_acc_ready[member1_acc_idx].arrive(cta_group=1)
+
+        for local_idx in cutlass.range(n_local):  # noqa: B007
+            if cutlass.const_expr(cfg.use_initial_state):
+                if local_idx == 0:
+                    if elect_one:
+                        bars.mb_state_acc_ready[kv_acc_index.idx].arrive(cta_group=1)
+                    kv_acc_index = advance(kv_acc_index, cfg.tmem_state_acc_stages)
+            have_state = (
+                cutlass.Boolean(True)
+                if cutlass.const_expr(cfg.use_initial_state)
+                else local_idx > 0
+            )
+
+            kq_idx = kq_index.idx
+            member = local_idx & 1
+            state_inp_idx = state_inp_index.idx
+            tinv_idx = tinv_index.idx
+            kv_acc_idx = kv_acc_index.idx
+            kq_member_off = member * KQ_BOX
+            desc_k = sKQ[kq_idx].desc() + kq_member_off
+            desc_tinv = sTinv[tinv_idx].desc()
+            desc_kt = sKQ_trans[kq_idx].desc() + kq_member_off
+            state_a_ptr = nvvm.make_tmem_ptr(
+                tmem_state_inp_col + state_inp_idx * STATE_INP_STAGE_COLS, cutlass.Int8
+            )
+            state_acc_ptr = nvvm.make_tmem_ptr(
+                tmem_state_col + kv_acc_idx * KV_ACC_STAGE_COLS, cutlass.Float32
+            )
+
+            kq_index = advance(kq_index, cfg.smem_kq_stages)
+
+            # ---- KK pair lookahead (member 1) = K(S) @ K^T -----------------------
+            if member == 1:
+                if local_idx + 2 < n_local:
+                    member1_acc_idx = cg0_acc_index.idx
+                    bars.mb_cg0_acc_done[member1_acc_idx].wait(cg0_acc_index.phase)
+                    cg0_acc_index = advance(cg0_acc_index, cfg.tmem_cg0_acc_stages)
+                    kqf_idx = kq_fused_index.idx
+                    bars.mb_kq_ready[kqf_idx].wait(kq_fused_index.phase)
+                    kq_fused_index = advance(kq_fused_index, cfg.smem_kq_stages)
+                    desc_kqf = sKQ[kqf_idx].desc()
+                    desc_kqf_member1 = desc_kqf + KQ_BOX
+                    acc_cg0 = nvvm.make_tmem_ptr(
+                        tmem_cg0_acc_col_f + member1_acc_idx * cfg.b_t, cutlass.Float32
+                    )
+                    mma_ss(
+                        bmm_kk_desc,
+                        desc_kqf,
+                        desc_kqf_member1,
+                        acc_cg0,
+                        accumulate=False,
+                        k_count=KQ_HALF_K,
+                    )
+                    mma_ss(
+                        bmm_kk_desc,
+                        desc_kqf + KQ_SEG,
+                        desc_kqf_member1 + KQ_SEG,
+                        acc_cg0,
+                        accumulate=True,
+                        k_count=KQ_HALF_K,
+                    )
+                    if elect_one:
+                        bars.mb_cg0_acc_ready[member1_acc_idx].arrive(cta_group=1)
+
+            # ---- K*state = state(T) @ K^T (GEMM 3) ----------------------------------------
+            if have_state:
+                bars.mb_state_inp_ready[state_inp_idx].wait(state_inp_index.phase)
+                state_inp_index = advance(state_inp_index, cfg.tmem_state_inp_stages)
+
+                for k in cutlass.range_constexpr(KQ_HALF_K):
+                    mma_ts_step(
+                        bmm_k_state_desc,
+                        state_a_ptr,
+                        desc_k,
+                        k_state_acc_ptr,
+                        k,
+                        cutlass.Boolean(k > 0),
+                    )
+                for k in cutlass.range_constexpr(KQ_HALF_K):
+                    mma_ts_step(
+                        bmm_k_state_desc,
+                        state_a_ptr.subview(KQ_A_HALF),
+                        desc_k + KQ_SEG,
+                        k_state_acc_ptr,
+                        k,
+                        cutlass.Boolean(True),
+                    )
+                if elect_one:
+                    bars.mb_k_state_acc_ready[0].arrive(cta_group=1)
+
+            # ---- U = Y(T) @ T_inv (GEMM 5) ---------------------------------------------
+            bars.mb_t_inv_ready[tinv_idx].wait(tinv_index.phase)
+            tinv_index = advance(tinv_index, cfg.smem_t_inv_stages)
+            bars.mb_y_inp_ready[0].wait(y_inp_ready.phase)
+            y_inp_ready = advance(y_inp_ready, 1)
+            for k in cutlass.range_constexpr(cfg.b_t // 16):
+                mma_ts_step(
+                    bmm_u_ts_desc, y_inp_ptr, desc_tinv, u_acc_ptr, k, cutlass.Boolean(k > 0)
+                )
+            if elect_one:
+                bars.mb_u_acc_ready[0].arrive(cta_group=1)
+                bars.mb_t_inv_done[tinv_idx].arrive(cta_group=1)
+
+            # ---- KK pair lookahead (member 0) = K(S) @ K^T -----------------------
+            if member == 0:
+                if local_idx + 2 < n_local:
+                    member0_acc_idx = cg0_acc_index.idx
+                    bars.mb_cg0_acc_done[member0_acc_idx].wait(cg0_acc_index.phase)
+                    cg0_acc_index = advance(cg0_acc_index, cfg.tmem_cg0_acc_stages)
+                    kqf_idx = kq_fused_index.idx
+                    bars.mb_kq_ready[kqf_idx].wait(kq_fused_index.phase)
+                    kq_fused_index = advance(kq_fused_index, cfg.smem_kq_stages)
+                    desc_kqf = sKQ[kqf_idx].desc()
+                    acc_cg0 = nvvm.make_tmem_ptr(
+                        tmem_cg0_acc_col_f + member0_acc_idx * cfg.b_t, cutlass.Float32
+                    )
+                    mma_ss(
+                        bmm_kk_desc,
+                        desc_kqf,
+                        desc_kqf,
+                        acc_cg0,
+                        accumulate=False,
+                        k_count=KQ_HALF_K,
+                    )
+                    mma_ss(
+                        bmm_kk_desc,
+                        desc_kqf + KQ_SEG,
+                        desc_kqf + KQ_SEG,
+                        acc_cg0,
+                        accumulate=True,
+                        k_count=KQ_HALF_K,
+                    )
+                    if elect_one:
+                        bars.mb_cg0_acc_ready[member0_acc_idx].arrive(cta_group=1)
+
+            # ---- state += decayed U(T) @ K (GEMM 7) ----------------------------------
+            bars.mb_decay_u_inp_ready[0].wait(decay_u_inp_ready.phase)
+            decay_u_inp_ready = advance(decay_u_inp_ready, 1)
+            kv_acc_index = advance(kv_acc_index, cfg.tmem_state_acc_stages)
+            for k in cutlass.range_constexpr(cfg.b_t // 16):
+                mma_ts_step(
+                    bmm_kv_desc,
+                    decay_u_inp_ptr,
+                    desc_kt,
+                    state_acc_ptr,
+                    k,
+                    cutlass.Boolean(True) if cutlass.const_expr(k > 0) else have_state,
+                )
+            if elect_one:
+                bars.mb_state_acc_ready[kv_acc_idx].arrive(cta_group=1)
+                bars.mb_kq_done[kq_idx].arrive(cta_group=1)
+
+        tile_idx, sched_state = sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas)
+
+    bars.mb_tmem_done[0].wait(0)
+    nvvm.tcgen05_relinquish_alloc_permit(group=nvvm.CTAGroup.CTA_1)
+    nvvm.tcgen05_dealloc(
+        nvvm.make_tmem_ptr(tmem_base, cutlass.Int8),
+        cutlass.Int32(512),
+        group=nvvm.CTAGroup.CTA_1,
+    )
+
+
+@cute.jit
+def tmaldg_warp(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    n_desc,
+    cu_seqlens,
+    mWorkItems,
+    sKQ_raw,
+    sV_raw,
+    desc_k_base,
+    desc_v_base,
+    mSched,
+    sSched,
+    bars,
+):
+    """TMA-LDG warp role (warp 9): persistent scheduler loop + per-chunk
+    K/V G->S TMA loads."""
+    elect_one = nvvm.elect_sync()
+    nvvm.setmaxregister(cfg.num_regs_other, nvvm.SetMaxRegisterAction.DECREASE)
+    kq_index = PipelineState.start(phase=1)
+    v_index = PipelineState.start(phase=1)
+    sched_state = PipelineState.start(phase=1)
+    tile_idx = cutlass.Int32(bidx)
+
+    bpe = cfg.io_dtype.width // 8
+    granu = 128 // bpe
+    bt = cfg.b_t
+    kq_stage_elems = cfg.kq_cosize // cfg.smem_kq_stages
+    kq_box_elems = kq_stage_elems // 4
+    sKQ_lo_tma = SmemTile(
+        base=sKQ_raw,
+        elems_per_stage=kq_stage_elems,
+        stages=cfg.smem_kq_stages,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=0,
+        tma_loads_per_tile=2,
+        tma_granu_elems=granu,
+        tma_subtile_stride_elems=2 * bt * granu,
+    )
+    sV_tma = SmemTile(
+        base=sV_raw,
+        elems_per_stage=cfg.v_cosize // cfg.smem_v_stages,
+        stages=cfg.smem_v_stages,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=0,
+        tma_loads_per_tile=2,
+        tma_granu_elems=granu,
+        tma_subtile_stride_elems=4096,
+    )
+    heads_out = cutlass.Int32(cfg.n_heads_out)
+    desc_qwords = cutlass.Int32(TENSOR_MAP_QWORDS)
+    packed_tokens = cutlass.Int32(cu_seqlens[n_desc])
+
+    while tile_idx < total_tiles:
+        (
+            batch_idx,
+            head_idx,
+            batch_start,
+            batch_end,
+            seqlen_b,
+            num_chunks_b,
+            wstart,
+            wend,
+            cstart,
+            cend,
+        ) = decode_work_item(cfg, tile_idx, mWorkItems)
+
+        head_k = head_idx if cfg.k_ratio == 1 else head_idx // cutlass.Int32(cfg.k_ratio)
+        head_v = head_idx if cfg.v_ratio == 1 else head_idx // cutlass.Int32(cfg.v_ratio)
+        slot = batch_idx * desc_qwords
+        desc_k_slot = (desc_k_base + slot).tospace(cutlass.AddressSpace.generic)
+        desc_v_slot = (desc_v_base + slot).tospace(cutlass.AddressSpace.generic)
+        if elect_one:
+            tma_tensormap_acquire(desc_k_slot)
+            tma_tensormap_acquire(desc_v_slot)
+        use_packed_coords = batch_end == packed_tokens
+
+        if wend > cstart:
+            kq_idx = kq_index.idx
+            bars.mb_kq_done[kq_idx].wait(kq_index.phase)
+            kq_index = advance(kq_index, cfg.smem_kq_stages)
+            if elect_one:
+                bars.mb_kq_ready[kq_idx].arrive(n_bytes=cfg.tma_kq_bytes)
+            tok_coord = cstart * cutlass.Int32(cfg.b_t)
+            input_tok_coord = batch_start + tok_coord if use_packed_coords else tok_coord
+            k_slice = tma_slice_runtime_desc(
+                desc_k_slot, cutlass.Int32(0), head_k, input_tok_coord
+            )
+            kq_tile = sKQ_lo_tma[kq_idx]
+            tma_load_tile(kq_tile, k_slice, bars.mb_kq_ready[kq_idx].smem_ptr, acquire=False)
+            for chunk_idx in cutlass.range(cstart + 1, wend):
+                tok_coord = chunk_idx * cutlass.Int32(cfg.b_t)
+                input_tok_coord = batch_start + tok_coord if use_packed_coords else tok_coord
+
+                # ---- K load ------------------------------------------------------
+                kq_idx = kq_index.idx
+                bars.mb_kq_done[kq_idx].wait(kq_index.phase)
+                kq_index = advance(kq_index, cfg.smem_kq_stages)
+                if elect_one:
+                    bars.mb_kq_ready[kq_idx].arrive(n_bytes=cfg.tma_kq_bytes)
+                member = (chunk_idx - cstart) & 1
+                k_slice = tma_slice_runtime_desc(
+                    desc_k_slot, cutlass.Int32(0), head_k, input_tok_coord
+                )
+                kq_tile = sKQ_lo_tma[kq_idx]
+                if member == 0:
+                    tma_load_tile(
+                        kq_tile, k_slice, bars.mb_kq_ready[kq_idx].smem_ptr, acquire=False
+                    )
+                else:
+                    tma_load_tile(
+                        kq_tile.shifted(kq_box_elems),
+                        k_slice,
+                        bars.mb_kq_ready[kq_idx].smem_ptr,
+                        acquire=False,
+                    )
+
+                # ---- V load ------------------------------------------------------
+                v_idx = v_index.idx
+                bars.mb_v_done[v_idx].wait(v_index.phase)
+                v_index = advance(v_index, cfg.smem_v_stages)
+                if elect_one:
+                    bars.mb_v_ready[v_idx].arrive(n_bytes=cfg.tma_v_bytes)
+                v_tok = (chunk_idx - 1) * cutlass.Int32(cfg.b_t)
+                input_v_tok = batch_start + v_tok if use_packed_coords else v_tok
+                v_slice = tma_slice_runtime_desc(
+                    desc_v_slot, cutlass.Int32(0), head_v, input_v_tok
+                )
+                tma_load_tile(
+                    sV_tma[v_idx], v_slice, bars.mb_v_ready[v_idx].smem_ptr, acquire=False
+                )
+
+            v_idx = v_index.idx
+            bars.mb_v_done[v_idx].wait(v_index.phase)
+            v_index = advance(v_index, cfg.smem_v_stages)
+            if elect_one:
+                bars.mb_v_ready[v_idx].arrive(n_bytes=cfg.tma_v_bytes)
+            v_tok = (wend - cutlass.Int32(1)) * cutlass.Int32(cfg.b_t)
+            input_v_tok = batch_start + v_tok if use_packed_coords else v_tok
+            v_slice = tma_slice_runtime_desc(desc_v_slot, cutlass.Int32(0), head_v, input_v_tok)
+            tma_load_tile(sV_tma[v_idx], v_slice, bars.mb_v_ready[v_idx].smem_ptr, acquire=False)
+
+        tile_idx, sched_state = sched_publish_next(
+            cfg, bars, sSched, mSched, sched_state, tile_idx, num_ctas
+        )
+
+    for _ in range(cfg.smem_kq_stages):
+        bars.mb_kq_done[kq_index.idx].wait(kq_index.phase)
+        kq_index = advance(kq_index, cfg.smem_kq_stages)
+    for _ in range(cfg.smem_v_stages):
+        bars.mb_v_done[v_index.idx].wait(v_index.phase)
+        v_index = advance(v_index, cfg.smem_v_stages)
+
+
+@cute.jit
+def compute0_warp_group(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    cu_seqlens,
+    mWorkItems,
+    tidx,
+    tmem_hold,
+    sCumsumlog,
+    sBeta,
+    sTinv,
+    sCheckpoint_raw,
+    checkpoint_every_n_tokens,
+    sSched,
+    bars,
+):
+    """Compute warp-group 0 role (warps 0-3): persistent scheduler loop
+    building the per-chunk beta-scaled T_inv operands."""
+
+    nvvm.setmaxregister(cfg.num_regs_compute_group_0, nvvm.SetMaxRegisterAction.INCREASE)
+    gate_index = PipelineState.start(phase=0)
+    beta_index = PipelineState.start(phase=0)
+    cg0_acc_ready = PipelineState.start(phase=0)
+    tinv_index = PipelineState.start(phase=1)
+
+    nvvm.barrier_cta_sync_aligned(
+        cfg.tmem_alloc_barrier_id,
+        thread_count=cfg.tmem_alloc_barrier_threads,
+    )
+    tmem_base = tmem_hold.load()
+
+    num_threads_cg0 = cfg.threads_per_warp * len(cfg.compute_group_0_warp_ids)
+    cg0_tidx = tidx % num_threads_cg0
+    warp_id = cg0_tidx // cfg.threads_per_warp
+    lane_id = cg0_tidx % cfg.threads_per_warp
+    inverse_local_warp = warp_id % 2
+    pair_half = warp_id // 2
+    half_row_base = inverse_local_warp * 32
+    bpe = cfg.io_dtype.width // 8
+    num_vals = 32
+    FRAG_COLS = 16
+    ACC_N_FRAGS = cfg.b_t // FRAG_COLS
+    store_row = warp_id * 16 + lane_id % 16
+    store_row_frag = lane_id % 16
+    store_col = (lane_id // 16) * 8
+    tmem_warp_row = warp_id * cfg.threads_per_warp
+    tmem_cg0_acc_col = tmem_base + cfg.tmem_cg0_acc_offset
+    ACC_STAGE_COLS = cfg.b_t
+    mask_zero = opaque_f32_zero()
+    crow_lo = warp_id * 16 + lane_id // 4
+    crow_hi = crow_lo + 8
+
+    sched_state = PipelineState.start(phase=0)
+    tile_idx = cutlass.Int32(bidx)
+    while tile_idx < total_tiles:
+        (
+            batch_idx,
+            head_idx,
+            batch_start,
+            batch_end,
+            seqlen_b,
+            num_chunks_b,
+            wstart,
+            wend,
+            cstart,
+            cend,
+        ) = decode_work_item(cfg, tile_idx, mWorkItems)
+        n_local = wend - cstart
+        n_pairs = (n_local + 1) // 2
+
+        for pair_i in cutlass.range(n_pairs):
+            # An odd chunk count leaves the last pair with member 0 only; have_m1
+            # is uniform across CG0, so the shared barriers below stay aligned.
+            have_m1 = pair_i * 2 + 1 < n_local
+            do_kk = have_m1 or pair_half == 0
+
+            # ---- Gate rows for this warp's KK member role ------------------------
+            gate0_idx = gate_index.idx
+            bars.mb_gate_ready[gate0_idx].wait(gate_index.phase)
+            gate_index = advance(gate_index, cfg.smem_gate_stages)
+            gate1_idx = gate0_idx
+            if have_m1:
+                gate1_idx = gate_index.idx
+                bars.mb_gate_ready[gate1_idx].wait(gate_index.phase)
+                gate_index = advance(gate_index, cfg.smem_gate_stages)
+            kk_gate_idx = gate1_idx if pair_half == 1 else gate0_idx
+
+            row_u0_lo = half_row_base + lane_id // 4
+            row_u0_hi = row_u0_lo + 8
+            row_u1_lo = row_u0_lo + 16
+            row_u1_hi = row_u0_lo + 24
+
+            kk_row_cumsumlog = []
+            for r in (row_u0_lo, row_u0_hi, row_u1_lo, row_u1_hi):
+                kk_row_cumsumlog.append(sCumsumlog[r, 0, kk_gate_idx])
+            kk_col_cumsumlog = []
+            for g in cutlass.range_constexpr(8):
+                for b in cutlass.range_constexpr(2):
+                    ccol = (lane_id % 4) * 2 + g * 8 + b
+                    kk_col_cumsumlog.append(sCumsumlog[ccol, 0, kk_gate_idx])
+
+            decay_t_kk = []
+            for u in cutlass.range_constexpr(2):
+                for k in cutlass.range_constexpr(num_vals):
+                    hi_row = ((k // 2) % 2) == 1
+                    crow_u0 = row_u0_hi if cutlass.const_expr(hi_row) else row_u0_lo
+                    crow_u1 = row_u1_hi if cutlass.const_expr(hi_row) else row_u1_lo
+                    crow = crow_u1 if cutlass.const_expr(u == 1) else crow_u0
+                    ccol = (lane_id % 4) * 2 + ((k // 4) * 8 + k % 2)
+                    is_lower = crow >= ccol
+                    row_cumsumlog = kk_row_cumsumlog[u * 2 + (1 if hi_row else 0)]
+                    col = (k // 4) * 2 + (k % 2)
+                    decay_t_kk.append(
+                        cute.math.exp2(row_cumsumlog - kk_col_cumsumlog[col], fastmath=True)
+                        if is_lower
+                        else mask_zero
+                    )
+            bars.mb_gate_done[gate0_idx].arrive()
+            if have_m1:
+                bars.mb_gate_done[gate1_idx].arrive()
+
+            beta0_idx = beta_index.idx
+            bars.mb_beta_ready[beta0_idx].wait(beta_index.phase)
+            beta_index = advance(beta_index, cfg.smem_beta_stages)
+            beta1_idx = beta0_idx
+            if have_m1:
+                beta1_idx = beta_index.idx
+                bars.mb_beta_ready[beta1_idx].wait(beta_index.phase)
+                beta_index = advance(beta_index, cfg.smem_beta_stages)
+            kk_beta_idx = beta1_idx if pair_half == 1 else beta0_idx
+            kk_beta = []
+            for r in (row_u0_lo, row_u0_hi, row_u1_lo, row_u1_hi):
+                kk_beta.append(sBeta[r, 0, kk_beta_idx])
+
+            # ---- KK_epi (each warp pair stages its own member) -------------------
+            acc0_idx = cg0_acc_ready.idx
+            acc0_phase = cg0_acc_ready.phase
+            cg0_acc_ready = advance(cg0_acc_ready, cfg.tmem_cg0_acc_stages)
+            acc1_idx = acc0_idx
+            acc1_phase = acc0_phase
+            if have_m1:
+                acc1_idx = cg0_acc_ready.idx
+                acc1_phase = cg0_acc_ready.phase
+                cg0_acc_ready = advance(cg0_acc_ready, cfg.tmem_cg0_acc_stages)
+            kk_acc_idx = acc1_idx if pair_half == 1 else acc0_idx
+            kk_acc_phase = acc1_phase if pair_half == 1 else acc0_phase
+
+            tinv0_idx = tinv_index.idx
+            tinv0_phase = tinv_index.phase
+            tinv_index = advance(tinv_index, cfg.smem_t_inv_stages)
+            tinv1_idx = tinv0_idx
+            tinv1_phase = tinv0_phase
+            if have_m1:
+                tinv1_idx = tinv_index.idx
+                tinv1_phase = tinv_index.phase
+                tinv_index = advance(tinv_index, cfg.smem_t_inv_stages)
+            kk_tinv_idx = tinv1_idx if pair_half == 1 else tinv0_idx
+            kk_tinv_phase = tinv1_phase if pair_half == 1 else tinv0_phase
+
+            tinv0_base = smem_data_ptr(sTinv[tinv0_idx].base).toint()
+            tinv1_base = smem_data_ptr(sTinv[tinv1_idx].base).toint()
+            kk_base = tinv1_base if pair_half == 1 else tinv0_base
+            if do_kk:
+                bars.mb_cg0_acc_ready[kk_acc_idx].wait(kk_acc_phase)
+                kk_vec0 = nvvm.tcgen05_ld(
+                    "16x256b",
+                    nvvm.make_tmem_ptr(
+                        (tmem_warp_row << 16) + tmem_cg0_acc_col + kk_acc_idx * ACC_STAGE_COLS,
+                        cutlass.Float32,
+                    ),
+                    num=8,
+                )
+                kk_vec1 = nvvm.tcgen05_ld(
+                    "16x256b",
+                    nvvm.make_tmem_ptr(
+                        ((tmem_warp_row + 16) << 16)
+                        + tmem_cg0_acc_col
+                        + kk_acc_idx * ACC_STAGE_COLS,
+                        cutlass.Float32,
+                    ),
+                    num=8,
+                )
+                nvvm.tcgen05_wait("load")
+                bars.mb_cg0_acc_done[kk_acc_idx].arrive()
+                bars.mb_t_inv_done[kk_tinv_idx].wait(kk_tinv_phase)
+                for u in cutlass.range_constexpr(2):
+                    kk_vec = kk_vec1 if cutlass.const_expr(u == 1) else kk_vec0
+                    kk_pack = []
+                    for k in cutlass.range_constexpr(num_vals // 2):
+                        row_beta = (
+                            kk_beta[u * 2 + 1]
+                            if cutlass.const_expr((k % 2) == 1)
+                            else kk_beta[u * 2]
+                        )
+                        p0, p1 = fmul2(
+                            kk_vec[2 * k],
+                            kk_vec[2 * k + 1],
+                            decay_t_kk[u * num_vals + 2 * k],
+                            decay_t_kk[u * num_vals + 2 * k + 1],
+                        )
+                        v0, v1 = fmul2(p0, p1, row_beta, row_beta)
+                        kk_pack.append(fp32_to_fp16(v0, v1, dtype=cfg.io_dtype))
+                    st_row = half_row_base + u * 16 + store_row_frag
+                    for c in cutlass.range_constexpr(ACC_N_FRAGS):
+                        nvvm.stmatrix(
+                            cutlass.inttoptr(
+                                kk_base
+                                + (
+                                    st_row * cfg.b_t
+                                    + swizzle_xor_128b(st_row, store_col + c * FRAG_COLS)
+                                )
+                                * bpe,
+                                cutlass.AddressSpace.smem,
+                                cutlass.BFloat16,
+                            ),
+                            [
+                                kk_pack[c * 4 + 0],
+                                kk_pack[c * 4 + 1],
+                                kk_pack[c * 4 + 2],
+                                kk_pack[c * 4 + 3],
+                            ],
+                            nvvm.MMALayout.ROW,
+                        )
+
+            # ---- pair inverse: warps 0-1 own matrix 0, warps 2-3 matrix 1 --------
+            # With no member 1 there is one matrix, so warps 2-3 idle through the
+            # per-warp steps; the barriers below stay unconditional.
+            inv_base = tinv0_base
+            if have_m1:
+                inv_base = tinv1_base if warp_id >= 2 else tinv0_base
+            do_inv = have_m1 or warp_id < 2
+
+            # diagonal 8x8 Gauss-Jordan, all four warps
+            nvvm.barrier_cta_sync_aligned(
+                cfg.inverse_barrier_id,
+                thread_count=cfg.inverse_barrier_threads,
+            )
+            if do_inv:
+                invert_diagonal_NxN(
+                    cfg,
+                    inv_base,
+                    (inverse_local_warp * cfg.threads_per_warp + lane_id) // 8,
+                    cg0_tidx,
+                    8,
+                )
+            nvvm.barrier_cta_sync_aligned(
+                cfg.inverse_barrier_id,
+                thread_count=cfg.inverse_barrier_threads,
+            )
+
+            # 8x8 -> 16x16 (both matrices per warp)
+            blockwise_diagonal_8x8_to_16x16(cfg, tinv0_base, warp_id * 16, lane_id)
+            if have_m1:
+                blockwise_diagonal_8x8_to_16x16(cfg, tinv1_base, warp_id * 16, lane_id)
+            nvvm.barrier_cta_sync_aligned(
+                cfg.inverse_barrier_id,
+                thread_count=cfg.inverse_barrier_threads,
+            )
+
+            # 16x16 -> 32x32, one tile per warp within the group
+            if do_inv:
+                blockwise_diagonal_16x16_to_32x32(cfg, inv_base, inverse_local_warp * 32, lane_id)
+            nvvm.barrier_cta_sync_aligned(
+                cfg.inverse_barrier_id,
+                thread_count=cfg.inverse_barrier_threads,
+            )
+
+            # 32x32 -> 64x64, two warps per matrix
+            # all four warps: this step carries its own CG0 barrier, and on the tail
+            # inv_base is matrix 0 for every warp so the duplicate band is identical
+            blockwise_diagonal_32x32_to_64x64(cfg, inv_base, inverse_local_warp, lane_id)
+            nvvm.barrier_cta_sync_aligned(
+                cfg.inverse_barrier_id,
+                thread_count=cfg.inverse_barrier_threads,
+            )
+
+            # ---- Beta column-scaling + publish, stage 0 --------------------------
+            beta_col = []
+            for k in cutlass.range_constexpr(num_vals):
+                beta_col.append(sBeta[(lane_id % 4) * 2 + ((k // 4) * 8 + k % 2), 0, beta0_idx])
+            tinv_frags = []
+            for c in cutlass.range_constexpr(ACC_N_FRAGS):
+                tinv_frags += list(
+                    nvvm.ldmatrix(
+                        cutlass.inttoptr(
+                            tinv0_base
+                            + (
+                                store_row * cfg.b_t
+                                + swizzle_xor_128b(store_row, store_col + c * FRAG_COLS)
+                            )
+                            * bpe,
+                            cutlass.AddressSpace.smem,
+                            cutlass.BFloat16,
+                        ),
+                        4,
+                        nvvm.MMALayout.ROW,
+                    )
+                )
+            tinv_pack = []
+            for j in cutlass.range_constexpr(num_vals // 2):
+                lo, hi = f16x2_to_f32(tinv_frags[j], dtype=cfg.io_dtype)
+                s0, s1 = fmul2(lo, hi, beta_col[2 * j], beta_col[2 * j + 1])
+                tinv_pack.append(fp32_to_fp16(s0, s1, dtype=cfg.io_dtype))
+            for c in cutlass.range_constexpr(ACC_N_FRAGS):
+                nvvm.stmatrix(
+                    cutlass.inttoptr(
+                        tinv0_base
+                        + (
+                            store_row * cfg.b_t
+                            + swizzle_xor_128b(store_row, store_col + c * FRAG_COLS)
+                        )
+                        * bpe,
+                        cutlass.AddressSpace.smem,
+                        cutlass.BFloat16,
+                    ),
+                    [
+                        tinv_pack[c * 4 + 0],
+                        tinv_pack[c * 4 + 1],
+                        tinv_pack[c * 4 + 2],
+                        tinv_pack[c * 4 + 3],
+                    ],
+                    nvvm.MMALayout.ROW,
+                )
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_t_inv_ready[tinv0_idx].arrive()
+            bars.mb_beta_done[beta0_idx].arrive()
+
+            if have_m1:
+                # ---- Beta column-scaling + publish, stage 1 --------------------------
+                beta_col = []
+                for k in cutlass.range_constexpr(num_vals):
+                    beta_col.append(
+                        sBeta[(lane_id % 4) * 2 + ((k // 4) * 8 + k % 2), 0, beta1_idx]
+                    )
+                tinv_frags = []
+                for c in cutlass.range_constexpr(ACC_N_FRAGS):
+                    tinv_frags += list(
+                        nvvm.ldmatrix(
+                            cutlass.inttoptr(
+                                tinv1_base
+                                + (
+                                    store_row * cfg.b_t
+                                    + swizzle_xor_128b(store_row, store_col + c * FRAG_COLS)
+                                )
+                                * bpe,
+                                cutlass.AddressSpace.smem,
+                                cutlass.BFloat16,
+                            ),
+                            4,
+                            nvvm.MMALayout.ROW,
+                        )
+                    )
+                tinv_pack = []
+                for j in cutlass.range_constexpr(num_vals // 2):
+                    lo, hi = f16x2_to_f32(tinv_frags[j], dtype=cfg.io_dtype)
+                    s0, s1 = fmul2(lo, hi, beta_col[2 * j], beta_col[2 * j + 1])
+                    tinv_pack.append(fp32_to_fp16(s0, s1, dtype=cfg.io_dtype))
+                for c in cutlass.range_constexpr(ACC_N_FRAGS):
+                    nvvm.stmatrix(
+                        cutlass.inttoptr(
+                            tinv1_base
+                            + (
+                                store_row * cfg.b_t
+                                + swizzle_xor_128b(store_row, store_col + c * FRAG_COLS)
+                            )
+                            * bpe,
+                            cutlass.AddressSpace.smem,
+                            cutlass.BFloat16,
+                        ),
+                        [
+                            tinv_pack[c * 4 + 0],
+                            tinv_pack[c * 4 + 1],
+                            tinv_pack[c * 4 + 2],
+                            tinv_pack[c * 4 + 3],
+                        ],
+                        nvvm.MMALayout.ROW,
+                    )
+                nvvm.fence_proxy("async.shared", space="cta")
+                bars.mb_t_inv_ready[tinv1_idx].arrive()
+                bars.mb_beta_done[beta1_idx].arrive()
+
+        tile_idx, sched_state = sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas)
+    for _ in range(cfg.smem_t_inv_stages):
+        bars.mb_t_inv_done[tinv_index.idx].wait(tinv_index.phase)
+        tinv_index = advance(tinv_index, cfg.smem_t_inv_stages)
+
+
+@cute.jit
+def compute1_warp_group(
+    cfg,
+    total_tiles,
+    bidx,
+    num_ctas,
+    cu_seqlens,
+    mWorkItems,
+    tidx,
+    warp_idx,
+    tmem_hold,
+    sV,
+    sCumsumlog,
+    sCumprod,
+    sBeta,
+    sCheckpoint_raw,
+    mState_init,
+    mState_out,
+    checkpoint_every_n_tokens,
+    sSched,
+    bars,
+):
+    """Compute warp-group 1 role (warps 4-7): persistent scheduler loop
+    owning the recurrent state from seed to final store."""
+    elect_one = nvvm.elect_sync()
+
+    v_index = PipelineState.start(phase=0)
+    gate_index = PipelineState.start(phase=0)
+    kv_acc_index = PipelineState.start(phase=0)
+    k_state_ready_index = PipelineState.start(phase=0)
+    u_acc_ready_index = PipelineState.start(phase=0)
+    state_acc_seed_index = PipelineState.start(phase=1)
+    state_inp_cnt = cutlass.Int32(0)
+    kv_done_idx = cutlass.Int32(0)
+
+    nvvm.setmaxregister(cfg.num_regs_compute_group_1, nvvm.SetMaxRegisterAction.INCREASE)
+    nvvm.barrier_cta_sync_aligned(
+        cfg.tmem_alloc_barrier_id,
+        thread_count=cfg.tmem_alloc_barrier_threads,
+    )
+    tmem_base = tmem_hold.load()
+
+    num_threads_cg1 = cfg.threads_per_warp * len(cfg.compute_group_1_warp_ids)
+    cg1_tidx = tidx % num_threads_cg1
+    lane_id = cg1_tidx % cfg.threads_per_warp
+    tmem_warp_row = (cg1_tidx // cfg.threads_per_warp) * cfg.threads_per_warp
+    ldtm_width = 32
+    sttm_width = ldtm_width // 2
+    num_state_subs = cutlass.const_expr(cfg.d_v // ldtm_width)
+    tmem_state_col = tmem_base + cfg.tmem_state_acc_offset
+    tmem_state_inp_col = tmem_base + cfg.tmem_state_inp_offset
+    tmem_inp_col = tmem_base + cfg.tmem_y_decay_u_inp_offset
+    INP_SLOT_COLS = cfg.b_t // 2
+    tmem_k_state_col = tmem_base + cfg.tmem_cg1_acc_offset
+    tmem_u_acc_col = tmem_k_state_col
+    tmem_y_inp_col = tmem_inp_col
+    tmem_decay_v_col = tmem_inp_col + INP_SLOT_COLS
+    v_frag_tok = cg1_tidx % 8 + (cg1_tidx // 16 % 2) * 8
+    v_frag_col = (cg1_tidx // 8 % 2) * 8 + (cg1_tidx // 32 % 2) * 32
+    v_frag_slab = (cg1_tidx // 64) * 4096
+    v_stage_elems = cfg.v_cosize // cfg.smem_v_stages
+    sV_base = cute.make_ptr(
+        cfg.io_dtype,
+        smem_data_ptr(sV[0].base).toint(),
+        mem_space=cute.AddressSpace.smem,
+        assumed_align=cfg.buffer_align_bytes,
+    )
+    num_vals = 32
+    if cutlass.const_expr(cfg.enable_checkpoints):
+        sCheckpoint_base_int = smem_data_ptr(sCheckpoint_raw).toint()
+        checkpoint_cnt = cutlass.Int32(0)
+        checkpoint_frag_row = cg1_tidx % 8 + (cg1_tidx // 16 % 2) * 8
+        checkpoint_frag_col = (cg1_tidx // 8 % 2) * 8 + (cg1_tidx // 32 % 2) * 32
+
+    sched_state = PipelineState.start(phase=0)
+    tile_idx = cutlass.Int32(bidx)
+    while tile_idx < total_tiles:
+        (
+            batch_idx,
+            head_idx,
+            batch_start,
+            batch_end,
+            seqlen_b,
+            num_chunks_b,
+            wstart,
+            wend,
+            cstart,
+            cend,
+        ) = decode_work_item(cfg, tile_idx, mWorkItems)
+        n_local = wend - cstart
+        if cutlass.const_expr(cfg.enable_checkpoints):
+            ckpt_chunks = checkpoint_every_n_tokens // cutlass.Int32(cfg.b_t)
+            checkpoint_mod = cstart % ckpt_chunks
+        if n_local > 0:
+            if cutlass.const_expr(cfg.use_initial_state):
+                # ---- initial-state seed: initial_state GMEM -> state TMEM ---------------
+                gState_init = mState_init[None, None, head_idx, batch_idx]
+                kv_init_idx = state_acc_seed_index.idx
+                bars.mb_state_acc_scale_done[kv_init_idx].wait(state_acc_seed_index.phase)
+                state_acc_seed_index = advance(state_acc_seed_index, cfg.tmem_state_acc_stages)
+                seed_from_initial_state = cstart == 0
+                if seed_from_initial_state:
+                    for sub in cutlass.range_constexpr(num_state_subs):
+                        words = []
+                        for k in cutlass.range_constexpr(32):
+                            v = gState_init[cg1_tidx, sub * ldtm_width + k]
+                            if cutlass.const_expr(cfg.state_dtype != cfg.acc_dtype):
+                                v = v.to(cfg.acc_dtype)
+                            words.append(v)
+                        nvvm.tcgen05_st(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(
+                                (tmem_warp_row << 16) + tmem_state_col + sub * ldtm_width,
+                                cutlass.Float32,
+                            ),
+                            cutlass.Vector.from_elements(tuple(words), cutlass.Float32),
+                        )
+                else:
+                    for sub in cutlass.range_constexpr(num_state_subs):
+                        nvvm.tcgen05_st(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(
+                                (tmem_warp_row << 16) + tmem_state_col + sub * ldtm_width,
+                                cutlass.Float32,
+                            ),
+                            cutlass.Vector.from_elements(
+                                tuple(cutlass.Float32(0.0) for _ in range(32)), cutlass.Float32
+                            ),
+                        )
+                nvvm.tcgen05_wait("store")
+
+                nvvm.barrier_cta_sync_aligned(
+                    cfg.init_state_store_barrier_id,
+                    thread_count=cfg.init_state_store_barrier_threads,
+                )
+
+            for local_idx in cutlass.range(n_local):  # noqa: B007
+                chunk_idx = cstart + local_idx
+                if cutlass.const_expr(cfg.enable_checkpoints):
+                    do_checkpoint_now = checkpoint_mod == 0
+                    checkpoint_mod = checkpoint_mod + cutlass.Int32(1)
+                    checkpoint_mod = (
+                        cutlass.Int32(0) if checkpoint_mod == ckpt_chunks else checkpoint_mod
+                    )
+                if cutlass.const_expr(cfg.enable_checkpoints and not cfg.use_initial_state):
+                    if chunk_idx == 0 and wstart == 0:
+                        checkpoint_stage = checkpoint_cnt % cfg.smem_checkpoint_stages
+                        checkpoint_phase_done = cutlass.Int32(1) ^ (
+                            (checkpoint_cnt // cfg.smem_checkpoint_stages) & cutlass.Int32(1)
+                        )
+                        bars.mb_checkpoint_tmastg_done[checkpoint_stage].wait(
+                            checkpoint_phase_done
+                        )
+                        checkpoint_zero_ptr = cutlass.inttoptr(
+                            sCheckpoint_base_int + checkpoint_stage * cfg.d_k * cfg.d_v * 2,
+                            cutlass.AddressSpace.smem,
+                            cutlass.Int32,
+                        )
+                        for z in cutlass.range_constexpr(
+                            cfg.d_k * cfg.d_v // 2 // num_threads_cg1
+                        ):
+                            (checkpoint_zero_ptr + cg1_tidx + z * num_threads_cg1).store(
+                                cutlass.Int32(0)
+                            )
+                        nvvm.fence_proxy("async.shared", space="cta")
+                        if elect_one:
+                            bars.mb_checkpoint_tmastg_ready[checkpoint_stage].arrive()
+                        checkpoint_cnt = checkpoint_cnt + 1
+                valid_state = local_idx > 0
+                if cutlass.const_expr(cfg.use_initial_state):
+                    valid_state = cutlass.Boolean(True)
+                    state_acc_seed_index = advance(state_acc_seed_index, cfg.tmem_state_acc_stages)
+
+                gate_idx = gate_index.idx
+                bars.mb_gate_ready[gate_idx].wait(gate_index.phase)
+                gate_index = advance(gate_index, cfg.smem_gate_stages)
+                cumprod_total = sCumprod[sCumprod.shape[0] - 1, 0, gate_idx]
+
+                # ---- state restage + rescale -------------------------------------
+                if valid_state:
+                    kv_idx = kv_acc_index.idx
+                    bars.mb_state_acc_ready[kv_idx].wait(kv_acc_index.phase)
+                    kv_acc_index = advance(kv_acc_index, cfg.tmem_state_acc_stages)
+                    kv_done_idx = kv_idx
+
+                    state_regs = [
+                        [cutlass.Float32(0.0) for _ in range(num_state_subs)] for _ in range(32)
+                    ]
+                    state_inp_stage_idx = state_inp_cnt % cfg.tmem_state_inp_stages
+                    state_vecs = []
+                    for sub in cutlass.range_constexpr(num_state_subs):
+                        state_vecs.append(
+                            nvvm.tcgen05_ld(
+                                "32x32b",
+                                nvvm.make_tmem_ptr(
+                                    (tmem_warp_row << 16) + tmem_state_col + sub * ldtm_width,
+                                    cutlass.Float32,
+                                ),
+                                num=32,
+                            )
+                        )
+                    for sub in cutlass.range_constexpr(num_state_subs):
+                        for k in cutlass.range_constexpr(32):
+                            state_regs[k][sub] = state_vecs[sub][k]
+                        state_pack = [
+                            fp32_to_fp16(
+                                state_regs[2 * j][sub],
+                                state_regs[2 * j + 1][sub],
+                                dtype=cfg.io_dtype,
+                            )
+                            for j in range(16)
+                        ]
+                        nvvm.tcgen05_st(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(
+                                (tmem_warp_row << 16) + tmem_state_inp_col + sub * sttm_width,
+                                cutlass.Int32,
+                            ),
+                            cutlass.Vector.from_elements(tuple(state_pack), cutlass.Int32),
+                        )
+                    nvvm.tcgen05_wait("store")
+                    bars.mb_state_inp_ready[state_inp_stage_idx].arrive()
+                    state_inp_cnt = state_inp_cnt + 1
+
+                    if cutlass.const_expr(cfg.enable_checkpoints):
+                        # ---- state checkpoint ----------------------------------------
+                        do_checkpoint = do_checkpoint_now and chunk_idx < wend
+                        do_checkpoint = do_checkpoint and chunk_idx >= wstart
+                        if do_checkpoint:
+                            checkpoint_stage = checkpoint_cnt % cfg.smem_checkpoint_stages
+                            checkpoint_phase_done = cutlass.Int32(1) ^ (
+                                (checkpoint_cnt // cfg.smem_checkpoint_stages) & cutlass.Int32(1)
+                            )
+                            bars.mb_checkpoint_tmastg_done[checkpoint_stage].wait(
+                                checkpoint_phase_done
+                            )
+                            checkpoint_stage_base = checkpoint_stage * cfg.d_k * cfg.d_v
+                            for sub in cutlass.range_constexpr(num_state_subs):
+                                checkpoint_vec = nvvm.tcgen05_ld(
+                                    "32x32b",
+                                    nvvm.make_tmem_ptr(
+                                        (tmem_warp_row << 16) + tmem_state_col + sub * ldtm_width,
+                                        cutlass.Float32,
+                                    ),
+                                    num=32,
+                                )
+                                for g in cutlass.range_constexpr(ldtm_width // 8):
+                                    packs = tuple(
+                                        fp32_to_fp16(
+                                            checkpoint_vec[g * 8 + 2 * t],
+                                            checkpoint_vec[g * 8 + 2 * t + 1],
+                                            dtype=cfg.io_dtype,
+                                        )
+                                        for t in range(4)
+                                    )
+                                    dk = sub * ldtm_width + g * 8
+                                    checkpoint_addr = (
+                                        checkpoint_stage_base
+                                        + (dk // 64) * (cfg.d_v * 64)
+                                        + cg1_tidx * 64
+                                        + swizzle_xor_128b(cg1_tidx, dk % 64)
+                                    )
+                                    (smem_data_ptr(sCheckpoint_raw) + checkpoint_addr).store(
+                                        cutlass.Vector.from_elements(packs, cutlass.Int32).bitcast(
+                                            cfg.io_dtype
+                                        ),
+                                        alignment=16,
+                                    )
+                            nvvm.fence_proxy("async.shared", space="cta")
+                            if elect_one:
+                                bars.mb_checkpoint_tmastg_ready[checkpoint_stage].arrive()
+                            checkpoint_cnt = checkpoint_cnt + 1
+
+                    for sub in cutlass.range_constexpr(num_state_subs):
+                        state_scaled = []
+                        for j in cutlass.range_constexpr(16):
+                            s0, s1 = fmul2(
+                                state_regs[2 * j][sub],
+                                state_regs[2 * j + 1][sub],
+                                cumprod_total,
+                                cumprod_total,
+                            )
+                            state_scaled += [s0, s1]
+                        nvvm.tcgen05_st(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(
+                                (tmem_warp_row << 16) + tmem_state_col + sub * ldtm_width,
+                                cutlass.Float32,
+                            ),
+                            cutlass.Vector.from_elements(tuple(state_scaled), cutlass.Float32),
+                        )
+                    nvvm.tcgen05_wait("store")
+                    bars.mb_state_acc_scale_done[kv_idx].arrive()
+
+                # ---- per-row Gate register builds --------------------------------
+                cumprod_vals = []
+                for k in cutlass.range_constexpr(num_vals):
+                    cumprod_vals.append(
+                        sCumprod[(lane_id % 4) * 2 + ((k // 4) * 8 + k % 2), 0, gate_idx]
+                    )
+                last_cumsumlog = sCumsumlog[cfg.b_t - 1, 0, gate_idx]
+                cumsumlog_vals = []
+                for k in cutlass.range_constexpr(num_vals):
+                    cumsumlog_vals.append(
+                        sCumsumlog[(lane_id % 4) * 2 + ((k // 4) * 8 + k % 2), 0, gate_idx]
+                    )
+                decay_scale_vals = []
+                for k in cutlass.range_constexpr(0, num_vals, 2):
+                    d0, d1 = fadd2(
+                        last_cumsumlog, last_cumsumlog, -cumsumlog_vals[k], -cumsumlog_vals[k + 1]
+                    )
+                    decay_scale_vals.append(cute.math.exp2(d0, fastmath=True))
+                    decay_scale_vals.append(cute.math.exp2(d1, fastmath=True))
+                bars.mb_gate_done[gate_idx].arrive()
+
+                # ---- Y = V - K*state (packed 16-bit) -----------------------------
+                v_idx = v_index.idx
+                bars.mb_v_ready[v_idx].wait(v_index.phase)
+                v_index = advance(v_index, cfg.smem_v_stages)
+
+                v_frags = [[cutlass.Int32(0), cutlass.Int32(0)] for _ in range(16)]
+                for c in cutlass.range_constexpr(8):
+                    tok_block = cutlass.const_expr(c % 4)
+                    sub = cutlass.const_expr(c // 4)
+                    v_frag = nvvm.ldmatrix(
+                        (
+                            sV_base
+                            + v_idx * v_stage_elems
+                            + v_frag_slab
+                            + (v_frag_tok + tok_block * 16) * 64
+                            + swizzle_xor_128b(v_frag_tok + tok_block * 16, v_frag_col + sub * 16)
+                        ).raw_ptr(),
+                        4,
+                        nvvm.MMALayout.COL,
+                    )
+                    for i in cutlass.range_constexpr(4):
+                        v_frags[4 * tok_block + i][sub] = v_frag[i]
+                if valid_state:
+                    bars.mb_k_state_acc_ready[0].wait(k_state_ready_index.phase)
+                    k_state_ready_index = advance(k_state_ready_index, 1)
+
+                    for sub in cutlass.range_constexpr(2):
+                        k_state_vec = nvvm.tcgen05_ld(
+                            "16x256b",
+                            nvvm.make_tmem_ptr(
+                                ((tmem_warp_row + sub * 16) << 16) + tmem_k_state_col,
+                                cutlass.Float32,
+                            ),
+                            num=8,
+                        )
+                        for j in cutlass.range_constexpr(16):
+                            s0, s1 = fmul2(
+                                k_state_vec[2 * j],
+                                k_state_vec[2 * j + 1],
+                                cumprod_vals[2 * j],
+                                cumprod_vals[2 * j + 1],
+                            )
+                            k_state_pack = fp32_to_fp16(s0, s1, dtype=cfg.io_dtype)
+                            v_frags[j][sub] = sub_f16x2(
+                                v_frags[j][sub], k_state_pack, cfg.io_dtype
+                            )
+                for sub in cutlass.range_constexpr(2):
+                    nvvm.tcgen05_st(
+                        "16x128b",
+                        nvvm.make_tmem_ptr(
+                            ((tmem_warp_row + sub * 16) << 16) + tmem_y_inp_col, cutlass.Int32
+                        ),
+                        cutlass.Vector.from_elements(
+                            tuple(v_frags[j][sub] for j in range(16)), cutlass.Int32
+                        ),
+                    )
+                nvvm.tcgen05_wait("store")
+                bars.mb_y_inp_ready[0].arrive()
+
+                # ---- U epilogue + decayed-U publish ------------------------------
+                bars.mb_u_acc_ready[0].wait(u_acc_ready_index.phase)
+                u_acc_ready_index = advance(u_acc_ready_index, 1)
+                bars.mb_v_done[v_idx].arrive()
+
+                u_acc_regs = [[cutlass.Float32(0.0), cutlass.Float32(0.0)] for _ in range(32)]
+                u_acc_vecs = []
+                for sub in cutlass.range_constexpr(2):
+                    u_acc_vecs.append(
+                        nvvm.tcgen05_ld(
+                            "16x256b",
+                            nvvm.make_tmem_ptr(
+                                ((tmem_warp_row + sub * 16) << 16) + tmem_u_acc_col,
+                                cutlass.Float32,
+                            ),
+                            num=8,
+                        )
+                    )
+                for sub in cutlass.range_constexpr(2):
+                    for k in cutlass.range_constexpr(32):
+                        u_acc_regs[k][sub] = u_acc_vecs[sub][k]
+
+                for sub in cutlass.range_constexpr(2):
+                    for j in cutlass.range_constexpr(16):
+                        u_acc_regs[2 * j][sub], u_acc_regs[2 * j + 1][sub] = fmul2(
+                            u_acc_regs[2 * j][sub],
+                            u_acc_regs[2 * j + 1][sub],
+                            decay_scale_vals[2 * j],
+                            decay_scale_vals[2 * j + 1],
+                        )
+                    decay_pack = [
+                        fp32_to_fp16(
+                            u_acc_regs[2 * j][sub], u_acc_regs[2 * j + 1][sub], dtype=cfg.io_dtype
+                        )
+                        for j in range(16)
+                    ]
+                    nvvm.tcgen05_st(
+                        "16x128b",
+                        nvvm.make_tmem_ptr(
+                            ((tmem_warp_row + sub * 16) << 16) + tmem_decay_v_col, cutlass.Int32
+                        ),
+                        cutlass.Vector.from_elements(tuple(decay_pack), cutlass.Int32),
+                    )
+                nvvm.tcgen05_wait("store")
+                bars.mb_decay_u_inp_ready[0].arrive()
+
+        # ---- final state: state TMEM -> GMEM -----------------------------------
+        if n_local > 0:
+            kv_last_idx = kv_acc_index.idx
+            bars.mb_state_acc_ready[kv_last_idx].wait(kv_acc_index.phase)
+            kv_acc_index = advance(kv_acc_index, cfg.tmem_state_acc_stages)
+            if cutlass.const_expr(cfg.store_final_state):
+                if wend == num_chunks_b:
+                    gState_out = mState_out[None, None, head_idx, batch_idx]
+                    for sub in cutlass.range_constexpr(num_state_subs):
+                        state_vec = nvvm.tcgen05_ld(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(
+                                (tmem_warp_row << 16) + tmem_state_col + sub * ldtm_width,
+                                cutlass.Float32,
+                            ),
+                            num=32,
+                        )
+                        for k in cutlass.range_constexpr(32):
+                            val = state_vec[k]
+                            if cutlass.const_expr(cfg.state_dtype != cfg.acc_dtype):
+                                val = val.to(cfg.state_dtype)
+                            gState_out[cg1_tidx, sub * ldtm_width + k] = val
+                bars.mb_state_acc_scale_done[kv_last_idx].arrive()
+            else:
+                bars.mb_state_acc_scale_done[kv_last_idx].arrive()
+        else:
+            if cutlass.const_expr(cfg.store_final_state):
+                write_passthrough = wend == num_chunks_b
+                if write_passthrough:
+                    gState_out = mState_out[None, None, head_idx, batch_idx]
+                    if cutlass.const_expr(cfg.use_initial_state):
+                        gState_in = mState_init[None, None, head_idx, batch_idx]
+                        for r in cutlass.range(num_state_subs * ldtm_width):
+                            gState_out[cg1_tidx, r] = gState_in[cg1_tidx, r]
+                    else:
+                        for sub in cutlass.range_constexpr(num_state_subs):
+                            for k in cutlass.range_constexpr(32):
+                                gState_out[cg1_tidx, sub * ldtm_width + k] = cutlass.Float32(
+                                    0.0
+                                ).to(cfg.state_dtype)
+
+        tile_idx, sched_state = sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas)
+
+    bars.mb_tmem_done[0].arrive()
+
+    if cutlass.const_expr(cfg.enable_checkpoints):
+        for _ in range(cfg.smem_checkpoint_stages):
+            checkpoint_stage = checkpoint_cnt % cfg.smem_checkpoint_stages
+            checkpoint_phase_done = cutlass.Int32(1) ^ (
+                (checkpoint_cnt // cfg.smem_checkpoint_stages) & cutlass.Int32(1)
+            )
+            bars.mb_checkpoint_tmastg_done[checkpoint_stage].wait(checkpoint_phase_done)
+            checkpoint_cnt = checkpoint_cnt + 1
+
+
+@cute.jit
+def build_descs_body(
+    widx,
+    base_k,
+    base_v,
+    base_checkpoint,
+    desc_ws: cute.Tensor,
+    cu_seqlens: cute.Tensor,
+    k: cute.Tensor,
+    v: cute.Tensor,
+    state_checkpoints_out: Optional[cute.Tensor],
+    n_batch: cutlass.Int32,
+    k_row_stride: cutlass.Int64,
+    v_row_stride: cutlass.Int64,
+    checkpoint_row_stride: cutlass.Int64,
+    checkpoint_every_n: cutlass.Int32,
+) -> None:
+    """Per-batch descriptor-array build, one warp per array. Runs inside the
+    prologue kernel after its order pass; warps past the array count fall
+    through the widx guards."""
+    arr_words = n_batch * cutlass.Int32(TENSOR_MAP_QWORDS)
+    desc_k_arr = cute.make_tensor(desc_ws.iterator, cute.make_layout((arr_words,), stride=(1,)))
+    desc_v_arr = cute.make_tensor(
+        desc_ws.iterator + arr_words, cute.make_layout((arr_words,), stride=(1,))
+    )
+    desc_checkpoint_arr = cute.make_tensor(
+        desc_ws.iterator + 2 * arr_words, cute.make_layout((arr_words,), stride=(1,))
+    )
+
+    if widx == 0:
+        if nvvm.elect_sync():
+            emit_seq_load_descs(base_k, desc_k_arr, cu_seqlens, k, n_batch, k_row_stride, 2)
+            nvvm.fence_proxy_release(
+                nvvm.MemScope.GPU, from_proxy=nvvm.Proxy.GENERIC, to_proxy=nvvm.Proxy.TENSORMAP
+            )
+    if widx == 1:
+        if nvvm.elect_sync():
+            emit_seq_load_descs(base_v, desc_v_arr, cu_seqlens, v, n_batch, v_row_stride, 2)
+            nvvm.fence_proxy_release(
+                nvvm.MemScope.GPU, from_proxy=nvvm.Proxy.GENERIC, to_proxy=nvvm.Proxy.TENSORMAP
+            )
+    if cutlass.const_expr(state_checkpoints_out is not None):
+        if widx == 2:
+            if nvvm.elect_sync():
+                emit_checkpoint_seq_descs(
+                    base_checkpoint,
+                    desc_checkpoint_arr,
+                    cu_seqlens,
+                    state_checkpoints_out,
+                    n_batch,
+                    checkpoint_row_stride,
+                    checkpoint_every_n,
+                    2,
+                )
+                nvvm.fence_proxy_release(
+                    nvvm.MemScope.GPU, from_proxy=nvvm.Proxy.GENERIC, to_proxy=nvvm.Proxy.TENSORMAP
+                )
+
+
+@cute.kernel
+def prologue_kernel(
+    run_order: cutlass.Constexpr[bool],
+    order_gen: cutlass.Constexpr[bool],
+    b_t: cutlass.Constexpr[int],
+    base_k: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    base_v: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    base_checkpoint: cutlass.GridConstant[cuda.tensor_map.TensorMap],
+    desc_ws: cute.Tensor,
+    cu_seqlens: cute.Tensor,
+    k: cute.Tensor,
+    v: cute.Tensor,
+    gate: cute.Tensor,
+    state_checkpoints_out: Optional[cute.Tensor],
+    mStaging: Optional[cute.Tensor],
+    mCount: cute.Tensor,
+    mWorkItems: cute.Tensor,
+    mSched: Optional[cute.Tensor],
+    n_batch: cutlass.Int32,
+    k_row_stride: cutlass.Int64,
+    v_row_stride: cutlass.Int64,
+    checkpoint_row_stride: cutlass.Int64,
+    checkpoint_every_n: cutlass.Int32,
+) -> None:
+    """Single-CTA prologue. Under ``run_order`` this kernel is the first
+    work-item-table consumer, so it LPT-orders the table and zeroes both
+    consumers' sched rings via :func:`order_body`; it then builds the
+    per-batch TMA-descriptor arrays via :func:`build_descs_body`, one warp
+    per array (the extra warps only take part in the order phase)."""
+    tidx, _, _ = cute.arch.thread_idx()
+    tidx = cutlass.Int32(tidx)
+    widx = tidx // cutlass.Int32(32)
+    if cutlass.const_expr(run_order):
+        sKey = cutlass.Array(
+            cutlass.Int32, ORDER_CAPACITY, space=cutlass.AddressSpace.smem, alignment=16
+        )
+        sIdx = cutlass.Array(
+            cutlass.Int32, ORDER_CAPACITY, space=cutlass.AddressSpace.smem, alignment=16
+        )
+        sSpread = cutlass.Array(cutlass.Int32, 2, space=cutlass.AddressSpace.smem, alignment=8)
+        n_heads_out = cutlass.Int32(gate.shape[1])
+        order_body(
+            order_gen,
+            True,
+            b_t,
+            ORDER_THREADS,
+            ORDER_ELEMS,
+            tidx,
+            n_heads_out,
+            n_heads_out * n_batch,
+            cu_seqlens,
+            mStaging,
+            mCount,
+            mWorkItems,
+            mSched,
+            sKey,
+            sIdx,
+            sSpread,
+        )
+    build_descs_body(
+        widx,
+        base_k,
+        base_v,
+        base_checkpoint,
+        desc_ws,
+        cu_seqlens,
+        k,
+        v,
+        state_checkpoints_out,
+        n_batch,
+        k_row_stride,
+        v_row_stride,
+        checkpoint_row_stride,
+        checkpoint_every_n,
+    )
+
+
+@cute.jit
+def prologue(
+    io_dtype: cutlass.Constexpr,
+    b_t: cutlass.Constexpr[int],
+    run_order: cutlass.Constexpr[bool],
+    order_gen: cutlass.Constexpr[bool],
+    k: cute.Tensor,
+    v: cute.Tensor,
+    gate: cute.Tensor,
+    cu_seqlens: cute.Tensor,
+    state_checkpoints_out: Optional[cute.Tensor],
+    work_item_staging: Optional[cute.Tensor],
+    work_count: cute.Tensor,
+    work_items: cute.Tensor,
+    sched_all: Optional[cute.Tensor],
+    checkpoint_every_n: cutlass.Int32,
+    tensormap_workspace: cute.Tensor,
+    stream: cuda_driver.CUstream,
+):
+    """One-launch prologue: LPT-order the work items (with ``run_order``, when
+    this kernel is the backward pair's first table consumer) and build the 3
+    per-batch TMA-descriptor arrays (K, V, checkpoints) into
+    ``tensormap_workspace``."""
+    h_k = k.shape[1]
+    h_v = v.shape[1]
+    batch_size = cu_seqlens.shape[0] - 1
+    d_v = v.shape[2]
+    bpe = io_dtype.width // 8
+    granu = 128 // bpe
+    bt = b_t
+
+    k_row_stride, k_head_stride = k.stride[0], k.stride[1]
+    v_row_stride, v_head_stride = v.stride[0], v.stride[1]
+
+    seqlen = k.shape[0]
+    d_k = k.shape[2]
+    k_headed = cute.make_tensor(
+        k.iterator, cute.make_layout((seqlen, h_k, d_k), stride=(k_row_stride, k_head_stride, 1))
+    )
+    v_headed = cute.make_tensor(
+        v.iterator, cute.make_layout((d_v, h_v, seqlen), stride=(1, v_head_stride, v_row_stride))
+    )
+    swz128 = cuda.TensorMapSwizzle.s128b
+    base_desc_k = cuda.create_tensor_map_tiled_from_view(
+        k_headed, box_dims=(bt, 1, granu), stride_order=(2, 1, 0), swizzle=swz128
+    )
+    base_desc_v = cuda.create_tensor_map_tiled_from_view(
+        v_headed, box_dims=(granu, 1, bt), stride_order=(0, 1, 2), swizzle=swz128
+    )
+
+    base_desc_checkpoint = base_desc_v
+    if cutlass.const_expr(state_checkpoints_out is not None):
+        d_k_state = state_checkpoints_out.shape[2]
+        d_v_state = state_checkpoints_out.shape[3]
+        checkpoint_granu = 128 // (state_checkpoints_out.element_type.width // 8)
+        checkpoint_view = cute.make_tensor(
+            state_checkpoints_out.iterator,
+            cute.make_layout(
+                (
+                    d_v_state,
+                    d_k_state,
+                    state_checkpoints_out.shape[0],
+                    state_checkpoints_out.shape[1],
+                ),
+                stride=(
+                    state_checkpoints_out.stride[3],
+                    state_checkpoints_out.stride[2],
+                    state_checkpoints_out.stride[0],
+                    state_checkpoints_out.stride[1],
+                ),
+            ),
+        )
+        base_desc_checkpoint = cuda.create_tensor_map_tiled_from_view(
+            checkpoint_view,
+            box_dims=(checkpoint_granu, d_k_state, 1, 1),
+            stride_order=(0, 1, 2, 3),
+            swizzle=swz128,
+        )
+
+    prologue_kernel(
+        run_order,
+        order_gen,
+        b_t,
+        base_desc_k,
+        base_desc_v,
+        base_desc_checkpoint,
+        tensormap_workspace,
+        cu_seqlens,
+        k,
+        v,
+        gate,
+        state_checkpoints_out,
+        work_item_staging,
+        work_count,
+        work_items,
+        sched_all,
+        cutlass.Int32(batch_size),
+        cutlass.Int64(k_row_stride),
+        cutlass.Int64(v_row_stride),
+        cutlass.Int64(state_checkpoints_out.stride[0] if state_checkpoints_out is not None else 0),
+        checkpoint_every_n,
+    ).launch(grid=(1, 1, 1), block=(ORDER_THREADS, 1, 1), stream=stream)
+
+
+@cute.jit
+def host(
+    cfg: cutlass.Constexpr,
+    k: cute.Tensor,
+    v: cute.Tensor,
+    gate: cute.Tensor,
+    a_log: Optional[cute.Tensor],
+    dt_bias: Optional[cute.Tensor],
+    beta: cute.Tensor,
+    cu_seqlens: cute.Tensor,
+    state_in: Optional[cute.Tensor],
+    state_out: Optional[cute.Tensor],
+    work_items: Optional[cute.Tensor],
+    work_count: Optional[cute.Tensor],
+    sched_ctr: Optional[cute.Tensor],
+    checkpoint_every_n_tokens: cutlass.Int32,
+    tensormap_workspace: cute.Tensor,
+    stream: cuda_driver.CUstream,
+):
+    h_k = k.shape[1]
+    h_v = v.shape[1]
+    batch_size = cu_seqlens.shape[0] - 1
+    heads_out = gate.shape[1]
+
+    # ---- GQA reshapes: fold the head group into a --------------------------------
+    if cutlass.const_expr(cfg.is_GQA):
+        h_ratio = heads_out // h_v
+        h_native = h_v
+        k = cute.make_tensor(
+            k.iterator,
+            cute.make_layout(
+                (k.shape[0], k.shape[2], (h_ratio, h_v)),
+                stride=(k.stride[0], k.stride[2], (0, k.stride[1])),
+            ),
+        )
+        v = cute.make_tensor(
+            v.iterator,
+            cute.make_layout(
+                (v.shape[2], v.shape[0], (h_ratio, h_v)),
+                stride=(v.stride[2], v.stride[0], (0, v.stride[1])),
+            ),
+        )
+    else:
+        h_ratio = h_v // h_k
+        h_native = h_k
+        k = cute.make_tensor(
+            k.iterator,
+            cute.make_layout(
+                (k.shape[0], k.shape[2], (h_ratio, h_k)),
+                stride=(k.stride[0], k.stride[2], (0, k.stride[1])),
+            ),
+        )
+        v = cute.make_tensor(
+            v.iterator,
+            cute.make_layout(
+                (v.shape[2], v.shape[0], (h_ratio, h_k)),
+                stride=(v.stride[2], v.stride[0], (v.stride[1], h_ratio * v.stride[1])),
+            ),
+        )
+
+    gate = cute.make_tensor(
+        gate.iterator,
+        cute.make_layout(
+            (gate.shape[0], (h_ratio, h_native)),
+            stride=(gate.stride[0], (gate.stride[1], h_ratio * gate.stride[1])),
+        ),
+    )
+    beta = cute.make_tensor(
+        beta.iterator,
+        cute.make_layout(
+            (beta.shape[0], (h_ratio, h_native)),
+            stride=(beta.stride[0], (beta.stride[1], h_ratio * beta.stride[1])),
+        ),
+    )
+    if cutlass.const_expr(state_in is not None):
+        state_in = cute.make_tensor(
+            state_in.iterator,
+            cute.make_layout(
+                (state_in.shape[2], state_in.shape[3], (h_ratio, h_native), state_in.shape[0]),
+                stride=(
+                    state_in.stride[2],
+                    state_in.stride[3],
+                    (state_in.stride[1], h_ratio * state_in.stride[1]),
+                    state_in.stride[0],
+                ),
+            ),
+        )
+    if cutlass.const_expr(state_out is not None):
+        state_out = cute.make_tensor(
+            state_out.iterator,
+            cute.make_layout(
+                (state_out.shape[2], state_out.shape[3], (h_ratio, h_native), state_out.shape[0]),
+                stride=(
+                    state_out.stride[2],
+                    state_out.stride[3],
+                    (state_out.stride[1], h_ratio * state_out.stride[1]),
+                    state_out.stride[0],
+                ),
+            ),
+        )
+
+    # ---- SMEM sizing: per-buffer element cosizes ---------------------------------
+    bpe = cfg.io_dtype.width // 8
+    kq_tile_elems = 2 * cfg.b_t * cfg.d_k
+    v_tile_elems = cfg.d_v * cfg.b_t
+    tinv_tile_elems = cfg.b_t * cfg.b_t
+    cfg.kq_cosize = kq_tile_elems * cfg.smem_kq_stages
+    cfg.v_cosize = v_tile_elems * cfg.smem_v_stages
+    cfg.t_inv_cosize = tinv_tile_elems * cfg.smem_t_inv_stages
+    cfg.checkpoint_cosize = (
+        cfg.d_k * cfg.d_v * cfg.smem_checkpoint_stages if cfg.enable_checkpoints else 1
+    )
+
+    cumsumlog_smem_layout_staged = cute.make_layout((cfg.b_t, 1, cfg.smem_gate_stages))
+    beta_smem_layout_staged = cute.make_layout((cfg.b_t, 1, cfg.smem_beta_stages))
+
+    cfg.tma_kq_bytes = (kq_tile_elems // 2) * bpe
+    cfg.tma_v_bytes = v_tile_elems * bpe
+
+    cfg.n_heads_out = heads_out
+    cfg.k_ratio = heads_out // h_k
+    cfg.v_ratio = heads_out // h_v
+    num_descs = batch_size
+
+    # ---- launch ------------------------------------------------------------------
+    grid_shape = (cfg.max_active_clusters, 1, 1)
+
+    @cute.struct
+    class SharedStorage:
+        checkpoint: cute.struct.Align[
+            cute.struct.MemRange[cfg.io_dtype, cfg.checkpoint_cosize], cfg.buffer_align_bytes
+        ]
+        kq: cute.struct.Align[
+            cute.struct.MemRange[cfg.io_dtype, cfg.kq_cosize], cfg.buffer_align_bytes
+        ]
+        cumsumlog: cute.struct.Align[
+            cute.struct.MemRange[cutlass.Float32, cute.cosize(cumsumlog_smem_layout_staged)], 128
+        ]
+        cumprod: cute.struct.Align[
+            cute.struct.MemRange[cutlass.Float32, cute.cosize(cumsumlog_smem_layout_staged)], 128
+        ]
+        beta: cute.struct.Align[
+            cute.struct.MemRange[cutlass.Float32, cute.cosize(beta_smem_layout_staged)], 128
+        ]
+        t_inv: cute.struct.Align[
+            cute.struct.MemRange[cfg.io_dtype, cfg.t_inv_cosize], cfg.buffer_align_bytes
+        ]
+        v: cute.struct.Align[
+            cute.struct.MemRange[cfg.io_dtype, cfg.v_cosize], cfg.buffer_align_bytes
+        ]
+
+    kernel(
+        cfg,
+        SharedStorage,
+        gate,
+        a_log,
+        dt_bias,
+        beta,
+        cu_seqlens,
+        state_in,
+        state_out,
+        work_items,
+        work_count,
+        sched_ctr,
+        checkpoint_every_n_tokens,
+        cumsumlog_smem_layout_staged,
+        beta_smem_layout_staged,
+        k,
+        v,
+        tensormap_workspace,
+        cutlass.Int32(num_descs),
+    ).launch(
+        grid=grid_shape,
+        block=(cfg.threads_per_cta, 1, 1),
+        cluster=cfg.cluster_shape_mnk,
+        stream=stream,
+        min_blocks_per_mp=1,
+    )
+
+
+@cute.kernel
+def kernel(
+    cfg: cutlass.Constexpr,
+    shared_type: cutlass.Constexpr,
+    mGate: cute.Tensor,
+    mA_log: Optional[cute.Tensor],
+    mDt_bias: Optional[cute.Tensor],
+    mBeta: cute.Tensor,
+    cu_seqlens: cute.Tensor,
+    mState_init: Optional[cute.Tensor],
+    mState_out: Optional[cute.Tensor],
+    mWorkItems: cute.Tensor,
+    mCount: cute.Tensor,
+    mSched: Optional[cute.Tensor],
+    checkpoint_every_n_tokens: cutlass.Int32,
+    cumsumlog_smem_layout_staged: cute.Layout,
+    beta_smem_layout_staged: cute.Layout,
+    mK,
+    mV,
+    tensormap_workspace: cute.Tensor,
+    n_desc: cutlass.Int32,
+):
+    """Main GDN chunked kernel: warp-specialized dispatch over (batch, head)
+    tiles."""
+    tidx, _, _ = cute.arch.thread_idx()
+    warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+    bidx = cute.arch.block_idx()[0]
+    num_ctas = cute.arch.grid_dim()[0]
+
+    total_tiles = mCount[0]
+    if cutlass.const_expr(cfg.dyn_sched):
+        assert mSched is not None, "mSched must be provided if dyn_sched is True"
+
+    if cutlass.const_expr(cfg.use_initial_state):
+        assert mState_init is not None, "mState_init must be provided if use_initial_state is True"
+    else:
+        assert mState_init is None, "mState_init must be None if use_initial_state is False"
+    if cutlass.const_expr(cfg.store_final_state):
+        assert mState_out is not None, "mState_out must be provided if store_final_state is True"
+    else:
+        assert mState_out is None, "mState_out must be None if store_final_state is False"
+
+    desc_base_words = tensormap_workspace.iterator.raw_ptr()
+    desc_qwords = cutlass.Int32(TENSOR_MAP_QWORDS)
+    arr_words = n_desc * desc_qwords
+    desc_k_base = desc_base_words
+    desc_v_base = desc_base_words + arr_words
+    desc_checkpoint_base = desc_base_words + cutlass.Int32(2) * arr_words
+
+    SMEM = cutlass.AddressSpace.smem
+
+    SWZ = 2
+    LEAD = 16
+    STRIDE = 8 * 128
+    KT_LEAD = (cfg.d_v // 2) * 128
+    V_LEAD = (cfg.d_v // 2) * 128
+    storage = cutlass.utils.SmemAllocator().allocate(shared_type)
+    sCheckpoint_raw = storage.checkpoint.get_tensor(cute.make_layout((cfg.checkpoint_cosize,)))
+    sKQ_raw = storage.kq.get_tensor(cute.make_layout((cfg.kq_cosize,)))
+    cumsumlog_raw = storage.cumsumlog.get_tensor(
+        cute.make_layout((cute.cosize(cumsumlog_smem_layout_staged),))
+    )
+    cumprod_raw = storage.cumprod.get_tensor(
+        cute.make_layout((cute.cosize(cumsumlog_smem_layout_staged),))
+    )
+    beta_raw = storage.beta.get_tensor(cute.make_layout((cute.cosize(beta_smem_layout_staged),)))
+    sTinv_raw = storage.t_inv.get_tensor(cute.make_layout((cfg.t_inv_cosize,)))
+    sV_raw = storage.v.get_tensor(cute.make_layout((cfg.v_cosize,)))
+    sKQ = SmemTile(
+        base=sKQ_raw,
+        elems_per_stage=cfg.kq_cosize // cfg.smem_kq_stages,
+        stages=cfg.smem_kq_stages,
+        leading_byte_offset=LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sKQ_trans = SmemTile(
+        base=sKQ_raw,
+        elems_per_stage=cfg.kq_cosize // cfg.smem_kq_stages,
+        stages=cfg.smem_kq_stages,
+        leading_byte_offset=2 * KT_LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    bars = make_gdn_bars(cfg)
+    tmem_hold = cutlass.Array(cutlass.Int32, 1, space=SMEM, alignment=16)
+    sSched = cutlass.Array(cutlass.Int32, cfg.sched_stages, space=SMEM, alignment=16)
+    sTinv = SmemTile(
+        base=sTinv_raw,
+        elems_per_stage=cfg.t_inv_cosize // cfg.smem_t_inv_stages,
+        stages=cfg.smem_t_inv_stages,
+        leading_byte_offset=LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sV = SmemTile(
+        base=sV_raw,
+        elems_per_stage=cfg.v_cosize // cfg.smem_v_stages,
+        stages=cfg.smem_v_stages,
+        leading_byte_offset=V_LEAD,
+        stride_byte_offset=STRIDE,
+        layout=SWZ,
+    )
+    sCumsumlog = cute.make_tensor(
+        cute.make_ptr(
+            cutlass.Float32,
+            smem_data_ptr(cumsumlog_raw).toint(),
+            mem_space=cute.AddressSpace.smem,
+            assumed_align=128,
+        ),
+        cumsumlog_smem_layout_staged,
+    )
+    sCumprod = cute.make_tensor(
+        cute.make_ptr(
+            cutlass.Float32,
+            smem_data_ptr(cumprod_raw).toint(),
+            mem_space=cute.AddressSpace.smem,
+            assumed_align=128,
+        ),
+        cumsumlog_smem_layout_staged,
+    )
+    sBeta = cute.make_tensor(
+        cute.make_ptr(
+            cutlass.Float32,
+            smem_data_ptr(beta_raw).toint(),
+            mem_space=cute.AddressSpace.smem,
+            assumed_align=128,
+        ),
+        beta_smem_layout_staged,
+    )
+
+    # ---- mbarrier init (all threads) ---------------------------------------------
+    for s in range(cfg.smem_kq_stages):
+        bars.mb_kq_ready[s].init()
+        bars.mb_kq_done[s].init()
+    for s in range(cfg.smem_v_stages):
+        bars.mb_v_ready[s].init()
+        bars.mb_v_done[s].init()
+    for s in range(cfg.smem_gate_stages):
+        bars.mb_gate_ready[s].init()
+        bars.mb_gate_done[s].init()
+    for s in range(cfg.smem_beta_stages):
+        bars.mb_beta_ready[s].init()
+        bars.mb_beta_done[s].init()
+    for s in range(cfg.tmem_state_acc_stages):
+        bars.mb_state_acc_ready[s].init()
+        bars.mb_state_acc_scale_done[s].init()
+    for s in range(cfg.tmem_cg0_acc_stages):
+        bars.mb_cg0_acc_ready[s].init()
+        bars.mb_cg0_acc_done[s].init()
+    bars.mb_k_state_acc_ready[0].init()
+    bars.mb_u_acc_ready[0].init()
+    for s in range(cfg.smem_t_inv_stages):
+        bars.mb_t_inv_ready[s].init()
+        bars.mb_t_inv_done[s].init()
+    for s in range(cfg.tmem_state_inp_stages):
+        bars.mb_state_inp_ready[s].init()
+    for b in (bars.mb_y_inp_ready, bars.mb_decay_u_inp_ready):
+        b[0].init()
+    for s in range(cfg.smem_checkpoint_stages):
+        bars.mb_checkpoint_tmastg_ready[s].init()
+        bars.mb_checkpoint_tmastg_done[s].init()
+    for s_ in range(cfg.sched_stages):
+        bars.mb_sched_ready[s_].init()
+        bars.mb_sched_done[s_].init()
+    bars.mb_tmem_done[0].init()
+
+    nvvm.fence_mbarrier_init()
+    nvvm.barrier_cta_sync()
+
+    # ---- warp specialization -----------------------------------------------------
+
+    if (
+        warp_idx >= cfg.compute_group_0_warp_ids[0]
+        and warp_idx <= cfg.compute_group_0_warp_ids[-1]
+    ):
+        compute0_warp_group(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            cu_seqlens,
+            mWorkItems,
+            tidx,
+            tmem_hold=tmem_hold,
+            sCumsumlog=sCumsumlog,
+            sBeta=sBeta,
+            sTinv=sTinv,
+            sCheckpoint_raw=sCheckpoint_raw,
+            checkpoint_every_n_tokens=checkpoint_every_n_tokens,
+            sSched=sSched,
+            bars=bars,
+        )
+
+    if (
+        warp_idx >= cfg.compute_group_1_warp_ids[0]
+        and warp_idx <= cfg.compute_group_1_warp_ids[-1]
+    ):
+        compute1_warp_group(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            cu_seqlens,
+            mWorkItems,
+            tidx,
+            warp_idx=warp_idx,
+            tmem_hold=tmem_hold,
+            sV=sV,
+            sCumsumlog=sCumsumlog,
+            sCumprod=sCumprod,
+            sBeta=sBeta,
+            sCheckpoint_raw=sCheckpoint_raw,
+            mState_init=mState_init,
+            mState_out=mState_out,
+            checkpoint_every_n_tokens=checkpoint_every_n_tokens,
+            sSched=sSched,
+            bars=bars,
+        )
+
+    elif warp_idx == cfg.load_gate_beta_warp_id:
+        gate_beta_warp(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            cu_seqlens,
+            mWorkItems,
+            tidx=tidx,
+            mGate=mGate,
+            mA_log=mA_log,
+            mDt_bias=mDt_bias,
+            mBeta=mBeta,
+            sCumsumlog=sCumsumlog,
+            sCumprod=sCumprod,
+            sBeta=sBeta,
+            sSched=sSched,
+            bars=bars,
+        )
+
+    elif warp_idx == cfg.mma_warp_id:
+        mma_warp(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            cu_seqlens,
+            mWorkItems,
+            tmem_hold=tmem_hold,
+            sKQ=sKQ,
+            sKQ_trans=sKQ_trans,
+            sTinv=sTinv,
+            sSched=sSched,
+            bars=bars,
+        )
+
+    elif warp_idx == cfg.tma_kv_warp_id:
+        tmaldg_warp(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            n_desc,
+            cu_seqlens,
+            mWorkItems,
+            sKQ_raw=sKQ_raw,
+            sV_raw=sV_raw,
+            desc_k_base=desc_k_base,
+            desc_v_base=desc_v_base,
+            mSched=mSched,
+            sSched=sSched,
+            bars=bars,
+        )
+
+    if warp_idx == cfg.epilogue_warp_id:
+        tmastg_warp(
+            cfg,
+            total_tiles,
+            bidx,
+            num_ctas,
+            cu_seqlens,
+            mWorkItems,
+            checkpoint_every_n_tokens=checkpoint_every_n_tokens,
+            tidx=tidx,
+            sCheckpoint_raw=sCheckpoint_raw,
+            desc_checkpoint_base=desc_checkpoint_base,
+            sSched=sSched,
+            bars=bars,
+        )
+
+
+@dataclass
+class GdnRecomputeCfg:
+    """Per-compile GDN kernel knob, built by ``build_cfg``.
+
+    The per-compile parameters (dtypes, GQA, state flags) are the
+    ``cute.compile`` cache keys; the rest is derived from the module-global
+    ``CFG`` constants.  ``host`` stamps the shape-derived fields at trace
+    time.  Passed ``cfg``-first (a ``cutlass.Constexpr``) into ``host`` /
+    ``kernel`` and every warp body.
+    """
+
+    io_dtype: Type[cutlass.Numeric]
+    acc_dtype: Type[cutlass.Numeric]
+    state_dtype: Type[cutlass.Numeric]
+    max_active_clusters: int
+    is_GQA: bool
+    use_initial_state: bool
+    store_final_state: bool
+    enable_checkpoints: bool
+    log_gate: bool = False
+    safe_gate: bool = False
+    beta_sigmoid: bool = False
+    dyn_sched: bool = False
+    sched_stages: int = CFG.SMEM_SCHED_STAGES
+
+    # ---- fixed constants stamped from CFG by build_cfg ---------------------------
+    b_t: int = CFG.B_T
+    d_k: int = CFG.D_K
+    d_v: int = CFG.D_V
+    compute_group_0_warp_ids: Tuple[int, ...] = CFG.COMPUTE_GROUP_0_WARP_IDS
+    compute_group_1_warp_ids: Tuple[int, ...] = CFG.COMPUTE_GROUP_1_WARP_IDS
+    load_gate_beta_warp_id: int = CFG.LOAD_GATE_BETA_WARP_ID
+    tma_kv_warp_id: int = CFG.TMA_KV_WARP_ID
+    mma_warp_id: int = CFG.MMA_WARP_ID
+    epilogue_warp_id: int = CFG.EPILOGUE_WARP_ID
+    num_regs_compute_group_0: int = CFG.NUM_REGS_COMPUTE_GROUP_0
+    num_regs_compute_group_1: int = CFG.NUM_REGS_COMPUTE_GROUP_1
+    num_regs_other: int = CFG.NUM_REGS_OTHER
+    threads_per_warp: int = CFG.THREADS_PER_WARP
+    threads_per_cta: int = 0
+    cluster_shape_mnk: Tuple[int, int, int] = CFG.CLUSTER_SHAPE_MNK
+
+    # ---- named barrier slots (ids 1-4; 0 is the CTA-wide sync) -------------------
+    tmem_alloc_barrier_id: int = 1
+    tmem_alloc_barrier_threads: int = 0
+    inverse_barrier_id: int = 2
+    inverse_barrier_threads: int = 0
+    init_state_store_barrier_id: int = 4
+    init_state_store_barrier_threads: int = 0
+
+    # ---- SMEM / TMEM stage counts + TMEM column offsets --------------------------
+    smem_kq_stages: int = CFG.SMEM_KQ_STAGES
+    smem_v_stages: int = CFG.SMEM_V_STAGES
+    smem_t_inv_stages: int = CFG.SMEM_T_INV_STAGES
+    smem_checkpoint_stages: int = 1
+    smem_gate_stages: int = CFG.SMEM_GATE_STAGES
+    smem_beta_stages: int = CFG.SMEM_BETA_STAGES
+    tmem_state_acc_stages: int = CFG.TMEM_KV_ACC_STAGES
+    tmem_state_inp_stages: int = CFG.TMEM_STATE_INP_STAGES
+    tmem_cg0_acc_stages: int = CFG.TMEM_CG0_ACC_STAGES
+    tmem_cg1_acc_stages: int = CFG.TMEM_CG1_ACC_STAGES
+    tmem_state_acc_offset: int = 0
+    tmem_state_inp_offset: int = 0
+    tmem_cg0_acc_offset: int = 0
+    tmem_cg1_acc_offset: int = 0
+    tmem_y_decay_u_inp_offset: int = 0
+    buffer_align_bytes: int = CFG.BUFFER_ALIGN_BYTES
+
+    # ---- stamped by host at trace time (shape-derived) --------------------------
+    kq_cosize: int = 0
+    v_cosize: int = 0
+    t_inv_cosize: int = 0
+    checkpoint_cosize: int = 0
+    tma_kq_bytes: int = 0
+    tma_v_bytes: int = 0
+    n_heads_out: int = 0
+    k_ratio: int = 1
+    v_ratio: int = 1
+
+
+def build_cfg(
+    io_dtype: Type[cutlass.Numeric],
+    state_dtype: Type[cutlass.Numeric],
+    *,
+    max_active_clusters: int,
+    is_GQA: bool,
+    use_initial_state: bool,
+    store_final_state: bool = True,
+    enable_checkpoints: bool = False,
+    log_gate: bool = False,
+    safe_gate: bool = False,
+    beta_sigmoid: bool = False,
+    dyn_sched: bool = False,
+) -> GdnRecomputeCfg:
+    """Build the per-compile ``GdnRecomputeCfg`` (io_dtype ∈ {Float16, BFloat16};
+    acc is always Float32)."""
+    if io_dtype not in (cutlass.Float16, cutlass.BFloat16):
+        raise ValueError(
+            f"io_dtype={io_dtype} not supported; only Float16 and BFloat16 are supported"
+        )
+    cfg = GdnRecomputeCfg(
+        io_dtype=io_dtype,
+        acc_dtype=cutlass.Float32,
+        state_dtype=state_dtype,
+        max_active_clusters=max_active_clusters,
+        is_GQA=is_GQA,
+        use_initial_state=use_initial_state,
+        store_final_state=store_final_state,
+        enable_checkpoints=enable_checkpoints,
+        log_gate=log_gate,
+        safe_gate=safe_gate,
+        beta_sigmoid=beta_sigmoid,
+        dyn_sched=dyn_sched,
+    )
+    cfg.smem_checkpoint_stages = 1
+    if enable_checkpoints:
+        cfg.smem_kq_stages = 3
+    if not use_initial_state:
+        cfg.num_regs_compute_group_1 = 232
+        cfg.num_regs_other = 48
+    n_cg0 = len(cfg.compute_group_0_warp_ids)
+    n_cg1 = len(cfg.compute_group_1_warp_ids)
+    cfg.threads_per_cta = cfg.threads_per_warp * (4 + n_cg0 + n_cg1)
+    cfg.tmem_alloc_barrier_threads = cfg.threads_per_warp * (1 + n_cg0 + n_cg1)
+    cfg.inverse_barrier_threads = cfg.threads_per_warp * n_cg0
+    cfg.init_state_store_barrier_threads = cfg.threads_per_warp * n_cg1
+    cfg.tmem_state_acc_offset = 0
+    cfg.tmem_state_inp_offset = cfg.tmem_state_acc_offset + cfg.tmem_state_acc_stages * 128
+    cfg.tmem_cg0_acc_offset = cfg.tmem_state_inp_offset + cfg.tmem_state_inp_stages * 64
+    cfg.tmem_cg1_acc_offset = cfg.tmem_cg0_acc_offset + cfg.tmem_cg0_acc_stages * 64
+    cfg.tmem_y_decay_u_inp_offset = cfg.tmem_cg1_acc_offset + cfg.tmem_cg1_acc_stages * 64
+    return cfg
+
+
+TENSORMAP_DESC_ARRAYS = 3  # per-batch runtime TMA descriptors: K, V, checkpoints
+TENSORMAP_STATIC_SLOTS = 0
+
+
+# ---------------------------------------------------------------------------
+
+
+@lru_cache(maxsize=None)
+def get_compiled_cache(
+    io_dtype_str: str,
+    state_dtype_str: str,
+    HK: int,
+    HV: int,
+    HO: int,
+    is_gqa: bool,
+    use_initial_state: bool,
+    store_final_state: bool,
+    enable_checkpoints: bool,
+    log_gate: bool,
+    safe_gate: bool,
+    beta_sigmoid: bool,
+    dyn_sched: bool,
+    run_order: bool,
+    order_gen: bool,
+    use_int64_offsets: bool,
+    device_index: int,
+    device_major: int,
+    device_minor: int,
+    num_sm: int,
+):
+    """Return a mutable dict that lazily stores compiled entry points."""
+    return {}
+
+
+def compile(
+    io_dtype,
+    state_dtype,
+    is_gqa: bool,
+    use_initial_state: bool,
+    store_final_state: bool,
+    enable_checkpoints: bool,
+    log_gate: bool,
+    safe_gate: bool,
+    beta_sigmoid: bool,
+    k_ratio: int,
+    v_ratio: int,
+    n_heads_out: int,
+    dyn_sched: bool = False,
+    use_int64_offsets: bool = False,
+    *,
+    num_sm: int,
+    checkpoint_every_n_tokens: int,
+):
+    """JIT-compile one fake-tensor TVM-FFI GDN recompute signature."""
+    cfg = build_cfg(
+        io_dtype,
+        state_dtype,
+        max_active_clusters=num_sm,
+        is_GQA=is_gqa,
+        use_initial_state=use_initial_state,
+        store_final_state=store_final_state,
+        enable_checkpoints=enable_checkpoints,
+        log_gate=log_gate,
+        safe_gate=safe_gate,
+        beta_sigmoid=beta_sigmoid,
+        dyn_sched=dyn_sched,
+    )
+    sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
+    tokens, sequence_entries, sequences, work_rows, sched_entries, workspace_words = (
+        sym_int() for _ in range(6)
+    )
+    tma_tensor = partial(
+        make_strided_signature_tensor,
+        assumed_align=16,
+        use_int64_offsets=use_int64_offsets,
+    )
+    beta_dtype = io_dtype if beta_sigmoid else cutlass.Float32
+    return compile_tvm_ffi(
+        host,
+        cfg,
+        tma_tensor(io_dtype, (tokens, n_heads_out // k_ratio, 128)),
+        tma_tensor(io_dtype, (tokens, n_heads_out // v_ratio, 128)),
+        make_strided_signature_tensor(
+            cutlass.Float32,
+            (tokens, n_heads_out),
+            assumed_align=4,
+            use_int64_offsets=use_int64_offsets,
+        ),
+        make_compact_signature_tensor(cutlass.Float32, (n_heads_out,), assumed_align=4)
+        if safe_gate
+        else None,
+        make_compact_signature_tensor(cutlass.Float32, (n_heads_out,), assumed_align=4)
+        if safe_gate
+        else None,
+        make_strided_signature_tensor(
+            beta_dtype,
+            (tokens, n_heads_out),
+            assumed_align=beta_dtype.width // 8,
+            use_int64_offsets=use_int64_offsets,
+        ),
+        make_cu_seqlens_signature(sequence_entries),
+        tma_tensor(state_dtype, (sequences, n_heads_out, 128, 128)) if use_initial_state else None,
+        tma_tensor(state_dtype, (sequences, n_heads_out, 128, 128)) if store_final_state else None,
+        make_work_items_signature(work_rows),
+        make_counter_signature(),
+        make_counter_signature(sched_entries) if dyn_sched else None,
+        cutlass.Int32(checkpoint_every_n_tokens),
+        make_workspace_signature(workspace_words),
+        name=(
+            f"gdn_mega_recompute_{io_dtype.__name__.lower()}_{state_dtype.__name__.lower()}"
+            f"_hk{n_heads_out // k_ratio}_hv{n_heads_out // v_ratio}_ho{n_heads_out}"
+            f"_g{int(is_gqa)}_i{int(use_initial_state)}f{int(store_final_state)}"
+            f"c{int(enable_checkpoints)}_l{int(log_gate)}s{int(safe_gate)}"
+            f"b{int(beta_sigmoid)}_d{int(dyn_sched)}_i64{int(use_int64_offsets)}"
+        ),
+    )
+
+
+def _validate_scalar_tensor(name, tensor) -> None:
+    if tensor.stride(-1) != 1:
+        raise ValueError(f"{name} innermost stride must be one")
+    if any(stride < 0 for stride in tensor.stride()[:-1]):
+        raise ValueError(f"{name} outer strides must be nonnegative")
+
+
+def chunk_gdn_recompute_sm100(
+    k,
+    v,
+    gate,
+    beta,
+    cu_seqlens,
+    initial_state,
+    output_state,
+    checkpoint_every_n_tokens: int = 0,
+    output_state_checkpoints=None,
+    work_items=None,
+    work_count=None,
+    sched_ctr=None,
+    sched_all=None,
+    work_item_scratch=None,
+    order_in_prologue: bool = False,
+    log_gate: bool = False,
+    safe_gate: bool = False,
+    a_log=None,
+    dt_bias=None,
+    use_beta_sigmoid: bool = False,
+    *,
+    tensormap_workspace,
+) -> None:
+    """Execute the Blackwell BT=64 scalar-GDN checkpoint recompute kernel.
+
+    ``gate`` is scalar ``(total_tokens, HO)``. With ``log_gate=True``, it holds
+    natural-log decays and is converted to the kernel's log2 domain internally.
+    Checkpoint row ``j`` is the entering state before token ``j * N`` in each
+    packed sequence; row zero is the provided initial state or zeros.
+    Outer tensor strides are dynamic, while innermost dimensions must be contiguous.
+    """
+    for name, tensor in (("k", k), ("v", v)):
+        validate_tma_tensor(name, tensor)
+    _validate_scalar_tensor("gate", gate)
+    _validate_scalar_tensor("beta", beta)
+    for name, tensor in (
+        ("initial_state", initial_state),
+        ("output_state", output_state),
+        ("output_state_checkpoints", output_state_checkpoints),
+    ):
+        if tensor is not None:
+            validate_tma_tensor(name, tensor)
+    validate_cu_seqlens(cu_seqlens, assumed_align=8)
+    if tensormap_workspace.data_ptr() % 128:
+        raise ValueError("tensormap_workspace data pointer must be 128-byte aligned")
+
+    tokens, h_k, d_k = k.shape
+    h_v = v.shape[1]
+    h_out = gate.shape[1]
+    if d_k != 128 or v.shape != (tokens, h_v, 128):
+        raise ValueError("k and v must have shape (T, H, 128)")
+    if gate.shape != (tokens, h_out) or beta.shape != (tokens, h_out):
+        raise ValueError("gate and beta must have shape (T, HO)")
+    if checkpoint_every_n_tokens < 0:
+        raise ValueError("checkpoint interval must be zero or a positive tile multiple")
+    enable_checkpoints = checkpoint_every_n_tokens > 0
+    if enable_checkpoints and checkpoint_every_n_tokens % CFG.B_T:
+        raise ValueError(f"checkpoint interval must be a positive multiple of {CFG.B_T}")
+    if enable_checkpoints:
+        if output_state_checkpoints is None:
+            raise ValueError("checkpoint_every_n_tokens > 0 requires output_state_checkpoints")
+        if output_state_checkpoints.shape[1:] != (h_out, 128, 128):
+            raise ValueError("output_state_checkpoints must have shape (N, HO, 128, 128)")
+        required_checkpoint_rows = checkpoint_capacity_bound(
+            tokens, cu_seqlens.shape[0] - 1, checkpoint_every_n_tokens
+        )
+        if output_state_checkpoints.shape[0] < required_checkpoint_rows:
+            raise ValueError(
+                f"output_state_checkpoints requires at least {required_checkpoint_rows} rows, "
+                f"got {output_state_checkpoints.shape[0]}"
+            )
+        if output_state_checkpoints.dtype != k.dtype:
+            raise ValueError("output_state_checkpoints dtype must match k.dtype")
+    if work_items is None or work_count is None:
+        raise ValueError(
+            "work_items/work_count are required (the split-table stage builds them for every launch)"
+        )
+    dyn_sched = sched_ctr is not None
+    run_order = order_in_prologue
+    order_gen = order_in_prologue and work_item_scratch is None
+    if run_order and sched_all is None:
+        raise ValueError(
+            "order_in_prologue requires sched_all (the prologue zeroes both consumers' sched rings)"
+        )
+
+    use_initial_state = initial_state is not None
+    store_final_state = output_state is not None
+    if not (enable_checkpoints or store_final_state):
+        raise ValueError("output_state_checkpoints or output_state is required")
+    if safe_gate and (a_log is None or dt_bias is None):
+        raise ValueError("safe_gate requires a_log and dt_bias")
+    if not safe_gate:
+        a_log = None
+        dt_bias = None
+    if a_log is not None:
+        _validate_scalar_tensor("a_log", a_log)
+    if dt_bias is not None:
+        _validate_scalar_tensor("dt_bias", dt_bias)
+    if (
+        initial_state is not None
+        and output_state is not None
+        and initial_state.dtype != output_state.dtype
+    ):
+        raise ValueError("initial_state and output_state dtypes must match")
+    if initial_state is not None:
+        state_dtype_src = initial_state.dtype
+    elif output_state is not None:
+        state_dtype_src = output_state.dtype
+    else:
+        state_dtype_src = "float32"
+
+    for name, heads in (("HK", h_k), ("HV", h_v)):
+        if h_out % heads:
+            raise ValueError(f"{name}={heads} must divide output heads {h_out}")
+    k_ratio = h_out // h_k
+    v_ratio = h_out // h_v
+    is_gqa = h_k >= h_v
+    checkpoints_for_descs = output_state_checkpoints if enable_checkpoints else None
+    use_int64_offsets = requires_int64_abi(
+        k,
+        v,
+        gate,
+        a_log,
+        dt_bias,
+        beta,
+        cu_seqlens,
+        initial_state,
+        output_state,
+        checkpoints_for_descs,
+        work_item_scratch,
+        work_items,
+        work_count,
+        sched_ctr,
+        sched_all,
+        tensormap_workspace,
+    )
+    device_index = tensor_device_index(k)
+    if current_device() != device_index:
+        raise ValueError("the active CUDA device must match k.device")
+    device_properties = get_device_properties(device_index)
+    num_sm = device_properties.multi_processor_count
+    cache = get_compiled_cache(
+        str(k.dtype),
+        str(state_dtype_src),
+        h_k,
+        h_v,
+        h_out,
+        is_gqa,
+        use_initial_state,
+        store_final_state,
+        enable_checkpoints,
+        log_gate,
+        safe_gate,
+        use_beta_sigmoid,
+        dyn_sched,
+        run_order,
+        order_gen,
+        use_int64_offsets,
+        device_index,
+        device_properties.major,
+        device_properties.minor,
+        num_sm,
+    )
+
+    io_dtype = get_dtype(k.dtype)
+    if "compiled" not in cache:
+        cache["compiled"] = compile(
+            io_dtype,
+            get_dtype(state_dtype_src),
+            is_gqa,
+            use_initial_state,
+            store_final_state,
+            enable_checkpoints,
+            log_gate,
+            safe_gate,
+            use_beta_sigmoid,
+            k_ratio,
+            v_ratio,
+            h_out,
+            dyn_sched,
+            use_int64_offsets,
+            num_sm=num_sm,
+            checkpoint_every_n_tokens=checkpoint_every_n_tokens,
+        )
+
+    if "prologue" not in cache:
+        sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
+        tokens, sequence_entries, checkpoint_rows, work_rows, sched_entries, workspace_words = (
+            sym_int() for _ in range(6)
+        )
+        tma_tensor = partial(
+            make_strided_signature_tensor,
+            assumed_align=16,
+            use_int64_offsets=use_int64_offsets,
+        )
+        work_items_signature = make_work_items_signature(work_rows)
+        cache["prologue"] = compile_tvm_ffi(
+            prologue,
+            io_dtype,
+            CFG.B_T,
+            run_order,
+            order_gen,
+            tma_tensor(io_dtype, (tokens, h_k, 128)),
+            tma_tensor(io_dtype, (tokens, h_v, 128)),
+            make_strided_signature_tensor(
+                cutlass.Float32,
+                (tokens, h_out),
+                assumed_align=4,
+                use_int64_offsets=use_int64_offsets,
+            ),
+            make_cu_seqlens_signature(sequence_entries),
+            tma_tensor(io_dtype, (checkpoint_rows, h_out, 128, 128))
+            if checkpoints_for_descs is not None
+            else None,
+            work_items_signature if run_order and not order_gen else None,
+            make_counter_signature(),
+            work_items_signature,
+            make_counter_signature(sched_entries) if run_order else None,
+            cutlass.Int32(checkpoint_every_n_tokens),
+            make_workspace_signature(workspace_words),
+            name=(
+                f"gdn_mega_recompute_prologue_{io_dtype.__name__.lower()}"
+                f"_hk{h_k}_hv{h_v}_ho{h_out}_c{int(enable_checkpoints)}"
+                f"_r{int(run_order)}o{int(order_gen)}d{int(dyn_sched)}"
+                f"_i64{int(use_int64_offsets)}"
+            ),
+        )
+    cache["prologue"](
+        k,
+        v,
+        gate,
+        cu_seqlens,
+        checkpoints_for_descs,
+        work_item_scratch if run_order else None,
+        work_count,
+        work_items,
+        sched_all if run_order else None,
+        checkpoint_every_n_tokens,
+        tensormap_workspace,
+    )
+    cache["compiled"](
+        k,
+        v,
+        gate,
+        a_log,
+        dt_bias,
+        beta,
+        cu_seqlens,
+        initial_state if use_initial_state else None,
+        output_state if store_final_state else None,
+        work_items,
+        work_count,
+        sched_ctr,
+        checkpoint_every_n_tokens,
+        tensormap_workspace,
+    )

--- a/attn_gym/testing/__init__.py
+++ b/attn_gym/testing/__init__.py
@@ -1,11 +1,13 @@
 """Shared test utilities for Attention Gym implementations."""
 
+from .gdn import make_gdn_test_inputs
 from .kda import cumulative_sequence_offsets, strided_state_pool
 from .profiling import kernel_stage, profile_trace, record_distributed_profile
 
 __all__ = [
     "cumulative_sequence_offsets",
     "kernel_stage",
+    "make_gdn_test_inputs",
     "profile_trace",
     "record_distributed_profile",
     "strided_state_pool",

--- a/attn_gym/testing/gdn.py
+++ b/attn_gym/testing/gdn.py
@@ -1,0 +1,85 @@
+"""Shared deterministic scalar-GDN test inputs."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Literal
+
+import torch
+import torch.nn.functional as F
+
+from .kda import cumulative_sequence_offsets
+
+GatePattern = Literal[
+    "mild",
+    "uniform_negative_twenty",
+    "isolated_negative_twenty",
+    "near_zero",
+    "model_softplus",
+]
+
+
+def make_gdn_test_inputs(
+    lengths: Sequence[int],
+    *,
+    key_heads: int = 1,
+    value_heads: int = 2,
+    gate_pattern: GatePattern = "mild",
+    dtype: torch.dtype = torch.bfloat16,
+    seed: int = 31,
+    requires_grad: bool = False,
+) -> tuple[torch.Tensor, ...]:
+    """Create deterministic packed grouped-head GDN operands and FP32 state."""
+    generator = torch.Generator(device="cuda").manual_seed(seed)
+    tokens, dim = sum(lengths), 128
+    q_shape = (1, tokens, key_heads, dim)
+    value_shape = (1, tokens, value_heads, dim)
+    gate_shape = value_shape[:-1]
+    q = F.normalize(torch.randn(q_shape, device="cuda", generator=generator), dim=-1).to(dtype)
+    k = F.normalize(torch.randn(q_shape, device="cuda", generator=generator), dim=-1).to(dtype)
+    value = torch.randn(value_shape, device="cuda", dtype=dtype, generator=generator).div_(8)
+
+    match gate_pattern:
+        case "mild":
+            gate = (
+                torch.empty(gate_shape, device="cuda")
+                .uniform_(0.5, 1.0, generator=generator)
+                .log_()
+            )
+        case "uniform_negative_twenty":
+            gate = torch.full(gate_shape, -20.0, device="cuda")
+        case "isolated_negative_twenty":
+            gate = (
+                torch.empty(gate_shape, device="cuda")
+                .uniform_(0.5, 1.0, generator=generator)
+                .log_()
+            )
+            gate[:, tokens // 2] = -20.0
+        case "near_zero":
+            gate = torch.empty(gate_shape, device="cuda").uniform_(-1e-4, 0.0, generator=generator)
+        case "model_softplus":
+            raw_gate = torch.randn(gate_shape, device="cuda", generator=generator)
+            a_log = torch.linspace(-0.5, 0.5, value_heads, device="cuda")
+            dt_bias = torch.linspace(-0.25, 0.25, value_heads, device="cuda")
+            gate = -a_log.exp().view(1, 1, -1) * F.softplus(raw_gate + dt_bias.view(1, 1, -1))
+        case _:
+            raise ValueError(f"Unsupported gate pattern: {gate_pattern}")
+
+    beta = torch.rand(gate_shape, device="cuda", generator=generator)
+    initial_state = torch.randn(
+        len(lengths),
+        value_heads,
+        dim,
+        dim,
+        device="cuda",
+        dtype=torch.float32,
+        generator=generator,
+    ).div_(100)
+    tensors = (q, k, value, gate, beta, initial_state)
+    return (
+        *(tensor.requires_grad_(requires_grad) for tensor in tensors),
+        cumulative_sequence_offsets(lengths),
+    )
+
+
+__all__ = ["make_gdn_test_inputs"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ linear = [
 ]
 
 mega = [
-    "nvidia-cutlass-dsl[cu13]>=4.7.0; sys_platform == 'linux'",
+    "nvidia-cutlass-dsl[cu13]>=4.7.0,<4.8.0; sys_platform == 'linux'",
     "cuda-python>=13.0; sys_platform == 'linux'",
     "apache-tvm-ffi>=0.1.12",
 ]
@@ -122,6 +122,12 @@ exclude = [
     "*.ipynb",
     # Vendored NVIDIA Apache-2.0/MIT source; lint the maintained Mega adapters instead.
     "attn_gym/linear/_delta_rule/mega/kernels/common",
+    "attn_gym/linear/_delta_rule/mega/kernels/gdn_bprop_config.py",
+    "attn_gym/linear/_delta_rule/mega/kernels/gdn_bprop_f16.py",
+    "attn_gym/linear/_delta_rule/mega/kernels/gdn_prefill_config.py",
+    "attn_gym/linear/_delta_rule/mega/kernels/gdn_prefill_f16.py",
+    "attn_gym/linear/_delta_rule/mega/kernels/gdn_recompute_config.py",
+    "attn_gym/linear/_delta_rule/mega/kernels/gdn_recompute_f16.py",
     "attn_gym/linear/_delta_rule/mega/kernels/kda_bprop_config.py",
     "attn_gym/linear/_delta_rule/mega/kernels/kda_bprop_f16.py",
     "attn_gym/linear/_delta_rule/mega/kernels/kda_prefill_config.py",

--- a/test/gdn/mega/test_gdn_mega_backward.py
+++ b/test/gdn/mega/test_gdn_mega_backward.py
@@ -1,0 +1,312 @@
+"""Private backward validation for the CuTeDSL 4.7 scalar-GDN kernels."""
+
+from __future__ import annotations
+
+from random import Random
+from typing import Literal
+
+import pytest
+import torch
+
+pytest.importorskip(
+    "cutlass.experimental",
+    reason="the CuTeDSL 4.7 GDN path requires nvidia-cutlass-dsl>=4.7",
+)
+
+from attn_gym.linear import chunk_gdn
+from attn_gym.linear._delta_rule.mega.gdn_backward import chunk_gdn_bwd_mega_packed
+from attn_gym.linear._delta_rule.mega.gdn_forward import run_forward
+from attn_gym.testing import make_gdn_test_inputs
+from attn_gym.testing.gdn import GatePattern
+from attn_gym.testing.kda import assert_matches_low_precision_reference
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() not in ((10, 0), (10, 3)),
+    reason="the CuTeDSL 4.7 GDN path requires SM100 or SM103",
+)
+
+BackwardStateMode = Literal["none", "initial", "cotangent"]
+
+
+_BACKWARD_CASES = (
+    pytest.param(
+        (65,),
+        torch.bfloat16,
+        1,
+        "isolated_negative_twenty",
+        "none",
+        id="t65-bf16-grouped-isolated-spike",
+    ),
+    pytest.param(
+        (128,),
+        torch.float16,
+        2,
+        "model_softplus",
+        "initial",
+        id="t128-fp16-equal-model-gate-initial",
+    ),
+    pytest.param(
+        (63, 65, 0),
+        torch.bfloat16,
+        1,
+        "near_zero",
+        "cotangent",
+        id="packed-bf16-grouped-near-zero-state-cotangent",
+    ),
+)
+
+_FUZZ_CASES = (
+    pytest.param(7, torch.bfloat16, 1, "mild", id="seed7-bf16-grouped-mild"),
+    pytest.param(29, torch.float16, 2, "model_softplus", id="seed29-fp16-equal-model-gate"),
+)
+
+
+def reference_forward(
+    inputs: tuple[torch.Tensor, ...],
+    precision: torch.dtype,
+    initial_state: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Evaluate stateful public eager GDN at source or FP64 operand precision."""
+    q, k, value, gate, beta, _state, cu_seqlens = inputs
+    output, final_state = chunk_gdn(
+        q.to(precision),
+        k.to(precision),
+        value.to(precision),
+        gate.to(precision),
+        beta.to(precision),
+        initial_state.to(precision),
+        cu_seqlens=cu_seqlens,
+        output_final_state=True,
+        impl="reference",
+    )
+    assert final_state is not None
+    return output, final_state
+
+
+def reference_gradients(
+    inputs: tuple[torch.Tensor, ...],
+    d_output: torch.Tensor,
+    precision: torch.dtype | None,
+    initial_state: torch.Tensor | None,
+    d_final_state: torch.Tensor | None,
+) -> tuple[torch.Tensor, ...]:
+    """Differentiate public eager GDN at source precision or independently in FP64."""
+    q, k, value, gate, beta, _state, cu_seqlens = inputs
+    operands = tuple(
+        tensor.detach().to(tensor.dtype if precision is None else precision).requires_grad_()
+        for tensor in (q, k, value, gate, beta)
+    )
+    state = (
+        None
+        if initial_state is None
+        else initial_state.detach()
+        .to(initial_state.dtype if precision is None else precision)
+        .requires_grad_()
+    )
+    targets = operands if state is None else (*operands, state)
+    output, final_state = chunk_gdn(
+        *operands,
+        state,
+        cu_seqlens=cu_seqlens,
+        output_final_state=d_final_state is not None,
+        impl="reference",
+    )
+    outputs = (output,) if final_state is None else (output, final_state)
+    cotangents = (d_output.to(output.dtype if precision is None else precision),)
+    if final_state is not None:
+        assert d_final_state is not None
+        cotangents += (d_final_state.to(final_state.dtype),)
+    return torch.autograd.grad(outputs, targets, cotangents)
+
+
+def make_cotangents(
+    value: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    *,
+    seed: int,
+    state_cotangent: bool,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Create deterministic output and optional final-state cotangents."""
+    generator = torch.Generator(device="cuda").manual_seed(seed)
+    d_output = torch.randn(
+        value.shape, dtype=value.dtype, device=value.device, generator=generator
+    )
+    if not state_cotangent:
+        return d_output, None
+    assert initial_state is not None
+    d_final_state = torch.randn(
+        initial_state.shape,
+        dtype=initial_state.dtype,
+        device=initial_state.device,
+        generator=generator,
+    )
+    return d_output, d_final_state
+
+
+def assert_gradients_match_references(
+    inputs: tuple[torch.Tensor, ...],
+    d_output: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    d_final_state: torch.Tensor | None,
+) -> tuple[torch.Tensor, ...]:
+    """Compare every private backward result with source-precision and FP64 eager GDN."""
+    source_gradients = reference_gradients(inputs, d_output, None, initial_state, d_final_state)
+    high_gradients = reference_gradients(
+        inputs, d_output, torch.float64, initial_state, d_final_state
+    )
+    actual_gradients = chunk_gdn_bwd_mega_packed(
+        *inputs[:5],
+        d_output,
+        inputs[6],
+        initial_state,
+        d_final_state,
+    )
+    names = ("dq", "dk", "dv", "dgate", "dbeta")
+    if initial_state is not None:
+        names += ("d_initial_state",)
+
+    for name, actual, high, source in zip(
+        names, actual_gradients[: len(names)], high_gradients, source_gradients, strict=True
+    ):
+        assert actual is not None
+        assert_matches_low_precision_reference(
+            actual,
+            high,
+            source,
+            name,
+            source_dtype=inputs[0].dtype,
+        )
+    if initial_state is None:
+        assert actual_gradients[-1] is None
+    return actual_gradients
+
+
+@pytest.mark.parametrize(
+    ("lengths", "dtype", "key_heads", "gate_pattern", "state_mode"), _BACKWARD_CASES
+)
+def test_gdn_mega_backward_matches_curated_matrix(
+    lengths: tuple[int, ...],
+    dtype: torch.dtype,
+    key_heads: int,
+    gate_pattern: GatePattern,
+    state_mode: BackwardStateMode,
+) -> None:
+    """Check grouped/equal heads, BT64 boundaries, gates, and all state-gradient modes."""
+    inputs = make_gdn_test_inputs(
+        lengths,
+        key_heads=key_heads,
+        value_heads=2,
+        gate_pattern=gate_pattern,
+        dtype=dtype,
+        seed=sum(lengths) + key_heads,
+    )
+    initial_state = None if state_mode == "none" else inputs[5]
+    d_output, d_final_state = make_cotangents(
+        inputs[2],
+        initial_state,
+        seed=sum(lengths) + 47,
+        state_cotangent=state_mode == "cotangent",
+    )
+    assert_gradients_match_references(inputs, d_output, initial_state, d_final_state)
+
+
+@pytest.mark.parametrize(
+    ("dtype", "key_heads"),
+    (
+        pytest.param(torch.bfloat16, 1, id="bf16-grouped"),
+        pytest.param(torch.float16, 2, id="fp16-equal"),
+    ),
+)
+def test_gdn_mega_backward_uniform_negative_twenty_is_finite(
+    dtype: torch.dtype, key_heads: int
+) -> None:
+    """Ensure the production backward stays finite for uniformly extreme scalar gates."""
+    inputs = make_gdn_test_inputs(
+        (129,),
+        key_heads=key_heads,
+        value_heads=2,
+        gate_pattern="uniform_negative_twenty",
+        dtype=dtype,
+        seed=131 + key_heads,
+    )
+    d_output, _ = make_cotangents(inputs[2], None, seed=137 + key_heads, state_cotangent=False)
+    gradients = chunk_gdn_bwd_mega_packed(*inputs[:5], d_output, inputs[6])[:5]
+    assert all(torch.isfinite(gradient).all() for gradient in gradients)
+
+
+def test_gdn_mega_backward_checkpoint_uses_v_by_k_state_at_token_64() -> None:
+    """Regression for loading the BT64 entering-state checkpoint with transposed V/K axes."""
+    inputs = make_gdn_test_inputs((65,), key_heads=2, value_heads=2, dtype=torch.float16, seed=149)
+    q, k, value, gate, beta, _state, cu_seqlens = inputs
+    key_index, value_index = 11, 17
+    q.zero_()
+    k.zero_()
+    value.zero_()
+    gate.zero_()
+    beta.zero_()
+    k[0, 0, 0, key_index] = 1
+    value[0, 0, 0, value_index] = 1
+    beta[0, 0, 0] = 1
+    q[0, 64, 0, key_index] = 1
+    d_output = torch.zeros_like(value)
+    d_output[0, 64, 0, value_index] = 1
+
+    source_gradients = reference_gradients(inputs, d_output, None, None, None)
+    high_gradients = reference_gradients(inputs, d_output, torch.float64, None, None)
+    actual_gradients = chunk_gdn_bwd_mega_packed(q, k, value, gate, beta, d_output, cu_seqlens)
+
+    # The checkpoint entering token 64 has S[V=17, K=11] != S[K=11, V=17].
+    assert_matches_low_precision_reference(
+        actual_gradients[0][0, 64, 0],
+        high_gradients[0][0, 64, 0],
+        source_gradients[0][0, 64, 0],
+        "dQ at the first token after the BT64 checkpoint",
+        source_dtype=q.dtype,
+    )
+
+
+def random_packed_lengths(seed: int) -> tuple[int, ...]:
+    """Generate a bounded deterministic multi-sequence shape with one empty sequence."""
+    random = Random(seed)
+    lengths = [random.randrange(1, 130) for _ in range(3)]
+    lengths.insert(random.randrange(4), 0)
+    return tuple(lengths)
+
+
+@pytest.mark.parametrize(("seed", "dtype", "key_heads", "gate_pattern"), _FUZZ_CASES)
+def test_gdn_mega_packed_differential_fuzz(
+    seed: int, dtype: torch.dtype, key_heads: int, gate_pattern: GatePattern
+) -> None:
+    """Differentially fuzz packed launcher paths against source-precision and FP64 eager GDN."""
+    inputs = make_gdn_test_inputs(
+        random_packed_lengths(seed),
+        key_heads=key_heads,
+        value_heads=2,
+        gate_pattern=gate_pattern,
+        dtype=dtype,
+        seed=seed,
+    )
+    d_output, d_final_state = make_cotangents(
+        inputs[2], inputs[5], seed=seed + 1, state_cotangent=True
+    )
+    source_output, source_state = reference_forward(inputs, torch.float32, inputs[5])
+    high_output, high_state = reference_forward(inputs, torch.float64, inputs[5])
+    actual_output, actual_state = run_forward(
+        *inputs[:5], inputs[6], inputs[5], scale=None, output_final_state=True
+    )
+    assert actual_state is not None
+    assert_matches_low_precision_reference(
+        actual_output,
+        high_output,
+        source_output,
+        "fuzz output",
+        source_dtype=dtype,
+    )
+    assert_matches_low_precision_reference(
+        actual_state,
+        high_state,
+        source_state,
+        "fuzz final state",
+        source_dtype=dtype,
+    )
+    assert_gradients_match_references(inputs, d_output, inputs[5], d_final_state)

--- a/test/gdn/mega/test_gdn_mega_forward.py
+++ b/test/gdn/mega/test_gdn_mega_forward.py
@@ -1,0 +1,212 @@
+"""Private forward validation for the CuTeDSL 4.7 scalar-GDN kernel."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import pytest
+import torch
+
+pytest.importorskip(
+    "cutlass.experimental",
+    reason="the CuTeDSL 4.7 GDN path requires nvidia-cutlass-dsl>=4.7",
+)
+
+from attn_gym.linear import chunk_gdn
+from attn_gym.linear._delta_rule.mega.gdn_forward import run_forward
+from attn_gym.testing import make_gdn_test_inputs
+from attn_gym.testing.gdn import GatePattern
+from attn_gym.testing.kda import assert_matches_low_precision_reference
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() not in ((10, 0), (10, 3)),
+    reason="the CuTeDSL 4.7 GDN path requires SM100 or SM103",
+)
+
+StateMode = Literal["none", "initial", "final", "initial_final"]
+
+
+_FORWARD_CASES = (
+    pytest.param(
+        (1,),
+        torch.float16,
+        2,
+        "mild",
+        "none",
+        id="t1-fp16-equal-mild-no-state",
+    ),
+    pytest.param(
+        (63,),
+        torch.bfloat16,
+        1,
+        "near_zero",
+        "initial",
+        id="t63-bf16-grouped-near-zero-initial",
+    ),
+    pytest.param(
+        (64,),
+        torch.bfloat16,
+        2,
+        "model_softplus",
+        "final",
+        id="t64-bf16-equal-model-gate-final",
+    ),
+    pytest.param(
+        (65,),
+        torch.float16,
+        1,
+        "isolated_negative_twenty",
+        "initial_final",
+        id="t65-fp16-grouped-isolated-spike-initial-final",
+    ),
+    pytest.param(
+        (127,),
+        torch.bfloat16,
+        1,
+        "mild",
+        "initial_final",
+        id="t127-bf16-grouped-mild-initial-final",
+    ),
+    pytest.param(
+        (128,),
+        torch.float16,
+        2,
+        "mild",
+        "initial_final",
+        id="t128-fp16-equal-mild-initial-final",
+    ),
+    pytest.param(
+        (129,),
+        torch.bfloat16,
+        1,
+        "uniform_negative_twenty",
+        "none",
+        id="t129-bf16-grouped-uniform-negative-twenty-no-state",
+    ),
+)
+
+
+def reference_forward(
+    inputs: tuple[torch.Tensor, ...],
+    precision: torch.dtype,
+    initial_state: torch.Tensor | None,
+    output_final_state: bool,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Evaluate the public eager GDN oracle at one operand precision."""
+    q, k, value, gate, beta, _state, cu_seqlens = inputs
+    return chunk_gdn(
+        q.to(precision),
+        k.to(precision),
+        value.to(precision),
+        gate.to(precision),
+        beta.to(precision),
+        None if initial_state is None else initial_state.to(precision),
+        cu_seqlens=cu_seqlens,
+        output_final_state=output_final_state,
+        impl="reference",
+    )
+
+
+def assert_forward_matches_references(
+    inputs: tuple[torch.Tensor, ...], initial_state: torch.Tensor | None, output_final_state: bool
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Compare the private launcher with source-precision and FP64 eager GDN."""
+    source_output, source_state = reference_forward(
+        inputs, torch.float32, initial_state, output_final_state
+    )
+    high_output, high_state = reference_forward(
+        inputs, torch.float64, initial_state, output_final_state
+    )
+    actual_output, actual_state = run_forward(
+        *inputs[:5],
+        inputs[6],
+        initial_state,
+        scale=None,
+        output_final_state=output_final_state,
+    )
+    assert_matches_low_precision_reference(
+        actual_output,
+        high_output,
+        source_output,
+        "output",
+        source_dtype=inputs[0].dtype,
+    )
+    if output_final_state:
+        assert actual_state is not None
+        assert source_state is not None
+        assert high_state is not None
+        assert_matches_low_precision_reference(
+            actual_state,
+            high_state,
+            source_state,
+            "final state",
+            source_dtype=inputs[0].dtype,
+        )
+    else:
+        assert actual_state is None
+    return actual_output, actual_state
+
+
+@pytest.mark.parametrize(
+    ("lengths", "dtype", "key_heads", "gate_pattern", "state_mode"), _FORWARD_CASES
+)
+def test_gdn_mega_forward_matches_curated_boundary_matrix(
+    lengths: tuple[int, ...],
+    dtype: torch.dtype,
+    key_heads: int,
+    gate_pattern: GatePattern,
+    state_mode: StateMode,
+) -> None:
+    """Check every BT64 boundary with a non-Cartesian dtype, head, gate, and state matrix."""
+    inputs = make_gdn_test_inputs(
+        lengths,
+        key_heads=key_heads,
+        value_heads=2,
+        gate_pattern=gate_pattern,
+        dtype=dtype,
+        seed=lengths[0] + key_heads,
+    )
+    initial_state = inputs[5] if state_mode in ("initial", "initial_final") else None
+    output_final_state = state_mode in ("final", "initial_final")
+    assert_forward_matches_references(inputs, initial_state, output_final_state)
+
+
+def test_gdn_mega_packed_second_sequence_uses_its_own_descriptors() -> None:
+    """Regression for sequence-relative TMA descriptors after the first packed sequence."""
+    inputs = make_gdn_test_inputs(
+        (1, 65, 0),
+        key_heads=1,
+        value_heads=2,
+        gate_pattern="mild",
+        dtype=torch.bfloat16,
+        seed=101,
+    )
+    source_output, source_state = reference_forward(inputs, torch.float32, inputs[5], True)
+    high_output, high_state = reference_forward(inputs, torch.float64, inputs[5], True)
+    actual_output, actual_state = run_forward(
+        *inputs[:5],
+        inputs[6],
+        inputs[5],
+        scale=None,
+        output_final_state=True,
+    )
+    assert actual_state is not None
+    assert source_state is not None
+    assert high_state is not None
+
+    second_sequence = slice(1, 66)
+    assert_matches_low_precision_reference(
+        actual_output[:, second_sequence],
+        high_output[:, second_sequence],
+        source_output[:, second_sequence],
+        "second packed sequence output",
+        source_dtype=inputs[0].dtype,
+    )
+    assert_matches_low_precision_reference(
+        actual_state[1],
+        high_state[1],
+        source_state[1],
+        "second packed sequence final state",
+        source_dtype=inputs[0].dtype,
+    )
+    torch.testing.assert_close(actual_state[2], inputs[5][2], rtol=0, atol=0)

--- a/test/gdn/mega/test_gdn_mega_layouts.py
+++ b/test/gdn/mega/test_gdn_mega_layouts.py
@@ -1,0 +1,368 @@
+"""Layout, alignment, and address-width coverage for private GDN Mega launchers."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+pytest.importorskip(
+    "cutlass.experimental",
+    reason="the CuTeDSL 4.7 GDN path requires nvidia-cutlass-dsl>=4.7",
+)
+
+from attn_gym._backends.cute.utils import requires_int64_abi
+from attn_gym.linear._delta_rule.mega.gdn_backward import chunk_gdn_bwd_mega_packed
+from attn_gym.linear._delta_rule.mega.gdn_forward import run_forward
+from attn_gym.testing import make_gdn_test_inputs
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() not in ((10, 0), (10, 3)),
+    reason="the CuTeDSL 4.7 GDN path requires SM100 or SM103",
+)
+
+
+def pad_last_mode(tensor: torch.Tensor, padding: int = 8) -> torch.Tensor:
+    """Copy a tensor into aligned rows with padding after the contiguous mode."""
+    storage = torch.empty(
+        *tensor.shape[:-1], tensor.shape[-1] + padding, dtype=tensor.dtype, device=tensor.device
+    )
+    return storage[..., : tensor.shape[-1]].copy_(tensor)
+
+
+def pad_scalar_rows(tensor: torch.Tensor, padding: int = 2) -> torch.Tensor:
+    """Copy `[B,T,H]` scalars into padded token rows while keeping H contiguous."""
+    storage = torch.empty(
+        tensor.shape[0],
+        tensor.shape[1],
+        tensor.shape[2] + padding,
+        dtype=tensor.dtype,
+        device=tensor.device,
+    )
+    return storage[..., : tensor.shape[2]].copy_(tensor)
+
+
+def pad_state_sequences(tensor: torch.Tensor, padding: int = 16) -> torch.Tensor:
+    """Copy `[N,H,V,K]` state into padded sequence slots with dense inner slabs."""
+    sequences, heads, value_dim, key_dim = tensor.shape
+    sequence_stride = heads * value_dim * key_dim + padding
+    storage = torch.empty(sequences * sequence_stride, dtype=tensor.dtype, device=tensor.device)
+    return torch.as_strided(
+        storage,
+        tensor.shape,
+        (sequence_stride, value_dim * key_dim, key_dim, 1),
+    ).copy_(tensor)
+
+
+def test_gdn_mega_outer_strides_match_compact_forward_and_backward() -> None:
+    """Dynamic outer strides must preserve all forward and backward values."""
+    inputs = make_gdn_test_inputs(
+        (65, 63), key_heads=2, value_heads=2, dtype=torch.bfloat16, seed=211
+    )
+    q, k, value, gate, beta, state, cu_seqlens = inputs
+    torch.manual_seed(223)
+    d_output = torch.randn_like(value)
+    d_final_state = torch.randn_like(state)
+    expected_forward = run_forward(
+        q, k, value, gate, beta, cu_seqlens, state, scale=None, output_final_state=True
+    )
+    expected_backward = chunk_gdn_bwd_mega_packed(
+        q,
+        k,
+        value,
+        gate,
+        beta,
+        d_output,
+        cu_seqlens,
+        state,
+        d_final_state,
+    )
+
+    strided = (
+        pad_last_mode(q),
+        pad_last_mode(k),
+        pad_last_mode(value),
+        pad_scalar_rows(gate),
+        pad_scalar_rows(beta),
+        pad_state_sequences(state),
+        cu_seqlens,
+    )
+    strided_d_output = pad_last_mode(d_output)
+    strided_d_final_state = pad_state_sequences(d_final_state)
+    actual_forward = run_forward(
+        *strided[:5],
+        strided[6],
+        strided[5],
+        scale=None,
+        output_final_state=True,
+    )
+    actual_backward = chunk_gdn_bwd_mega_packed(
+        *strided[:5],
+        strided_d_output,
+        strided[6],
+        strided[5],
+        strided_d_final_state,
+    )
+
+    for actual, expected in zip(actual_forward, expected_forward, strict=True):
+        assert actual is not None and expected is not None
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    for actual, expected in zip(actual_backward, expected_backward, strict=True):
+        assert actual is not None and expected is not None
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_gdn_mega_forward_rejects_misaligned_and_noncontiguous_inner_modes() -> None:
+    """The launcher must reject layouts that violate its advertised TMA signature."""
+    q, k, value, gate, beta, state, cu_seqlens = make_gdn_test_inputs(
+        (64,), key_heads=2, value_heads=2, dtype=torch.bfloat16, seed=227
+    )
+    storage = torch.empty(q.numel() + 1, dtype=q.dtype, device=q.device)
+    misaligned_q = storage[1:].view_as(q).copy_(q)
+    with pytest.raises(TypeError, match="TMA-compatible"):
+        run_forward(
+            misaligned_q,
+            k,
+            value,
+            gate,
+            beta,
+            cu_seqlens,
+            state,
+            scale=None,
+            output_final_state=True,
+        )
+
+    inner_storage = torch.empty(q.numel() * 2, dtype=q.dtype, device=q.device)
+    noncontiguous_inner_q = torch.as_strided(
+        inner_storage,
+        q.shape,
+        (q.stride(0) * 2, q.stride(1) * 2, q.stride(2) * 2, 2),
+    ).copy_(q)
+    with pytest.raises(TypeError, match="TMA-compatible"):
+        run_forward(
+            noncontiguous_inner_q,
+            k,
+            value,
+            gate,
+            beta,
+            cu_seqlens,
+            state,
+            scale=None,
+            output_final_state=True,
+        )
+
+
+def test_gdn_mega_forced_int64_forward_backward_matches_int32(monkeypatch) -> None:
+    """Every private kernel must preserve results under its int64 ABI specialization."""
+    from attn_gym.linear._delta_rule.mega.kernels import (
+        gdn_bprop_f16,
+        gdn_prefill_f16,
+        gdn_recompute_f16,
+    )
+
+    inputs = make_gdn_test_inputs(
+        (65, 63), key_heads=2, value_heads=2, dtype=torch.float16, seed=229
+    )
+    q, k, value, gate, beta, state, cu_seqlens = inputs
+    torch.manual_seed(233)
+    d_output = torch.randn_like(value)
+    d_final_state = torch.randn_like(state)
+    expected_forward = run_forward(
+        q, k, value, gate, beta, cu_seqlens, state, scale=None, output_final_state=True
+    )
+    expected_backward = chunk_gdn_bwd_mega_packed(
+        q,
+        k,
+        value,
+        gate,
+        beta,
+        d_output,
+        cu_seqlens,
+        state,
+        d_final_state,
+    )
+
+    for module in (gdn_prefill_f16, gdn_recompute_f16, gdn_bprop_f16):
+        monkeypatch.setattr(module, "requires_int64_abi", lambda *_: True)
+    actual_forward = run_forward(
+        q, k, value, gate, beta, cu_seqlens, state, scale=None, output_final_state=True
+    )
+    actual_backward = chunk_gdn_bwd_mega_packed(
+        q,
+        k,
+        value,
+        gate,
+        beta,
+        d_output,
+        cu_seqlens,
+        state,
+        d_final_state,
+    )
+
+    for actual, expected in zip(actual_forward, expected_forward, strict=True):
+        assert actual is not None and expected is not None
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    for actual, expected in zip(actual_backward, expected_backward, strict=True):
+        assert actual is not None and expected is not None
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_gdn_mega_active_offsets_past_int32_match_compact() -> None:
+    """Execute forward and backward with active Q/K addresses beyond signed int32."""
+    free_bytes, _ = torch.cuda.mem_get_info()
+    if free_bytes < 24 * 1024**3:
+        pytest.skip("active int64 GDN coverage requires at least 24 GiB free")
+
+    q, k, value, gate, beta, _state, cu_seqlens = make_gdn_test_inputs(
+        (2,), key_heads=1, value_heads=1, dtype=torch.bfloat16, seed=237
+    )
+    d_output = torch.randn_like(value)
+    expected_forward = run_forward(
+        q, k, value, gate, beta, cu_seqlens, None, scale=None, output_final_state=False
+    )
+    expected_backward = chunk_gdn_bwd_mega_packed(q, k, value, gate, beta, d_output, cu_seqlens)
+
+    active_stride = 2**31 + 128
+
+    def wide_tokens(tensor: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        storage = torch.empty(
+            active_stride + tensor.shape[-1], dtype=tensor.dtype, device=tensor.device
+        )
+        view = torch.as_strided(
+            storage,
+            tensor.shape,
+            (active_stride + tensor.shape[-1], active_stride, tensor.shape[-1], 1),
+        ).copy_(tensor)
+        return storage, view
+
+    q_storage, wide_q = wide_tokens(q)
+    k_storage, wide_k = wide_tokens(k)
+    assert requires_int64_abi(wide_q, wide_k)
+    actual_forward = run_forward(
+        wide_q,
+        wide_k,
+        value,
+        gate,
+        beta,
+        cu_seqlens,
+        None,
+        scale=None,
+        output_final_state=False,
+    )
+    actual_backward = chunk_gdn_bwd_mega_packed(
+        wide_q, wide_k, value, gate, beta, d_output, cu_seqlens
+    )
+    torch.testing.assert_close(actual_forward[0], expected_forward[0], rtol=0, atol=0)
+    for actual, expected in zip(actual_backward, expected_backward, strict=True):
+        if actual is None:
+            assert expected is None
+        else:
+            assert expected is not None
+            torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    del q_storage, k_storage
+
+
+def test_gdn_mega_oversized_singleton_stride_executes_int64_path() -> None:
+    """An ABI-visible oversized singleton stride must route wide without huge storage."""
+    q, k, value, gate, beta, state, cu_seqlens = make_gdn_test_inputs(
+        (1,), key_heads=2, value_heads=2, dtype=torch.bfloat16, seed=239
+    )
+    wide_gate = torch.empty_strided(
+        gate.shape,
+        (2**31 + 32, 2**31 + 16, 1),
+        dtype=gate.dtype,
+        device=gate.device,
+    ).copy_(gate)
+    assert requires_int64_abi(wide_gate)
+    expected = run_forward(
+        q, k, value, gate, beta, cu_seqlens, state, scale=None, output_final_state=True
+    )
+    actual = run_forward(
+        q,
+        k,
+        value,
+        wide_gate,
+        beta,
+        cu_seqlens,
+        state,
+        scale=None,
+        output_final_state=True,
+    )
+    for actual_tensor, expected_tensor in zip(actual, expected, strict=True):
+        assert actual_tensor is not None and expected_tensor is not None
+        torch.testing.assert_close(actual_tensor, expected_tensor, rtol=0, atol=0)
+
+
+def test_gdn_mega_terminal_capacity_slack_is_not_read() -> None:
+    """Poisoned physical rows beyond the terminal packed offset must not affect active work."""
+    q, k, value, gate, beta, state, cu_seqlens = make_gdn_test_inputs(
+        (65, 0, 63), key_heads=1, value_heads=2, dtype=torch.bfloat16, seed=241
+    )
+    torch.manual_seed(251)
+    d_output = torch.randn_like(value)
+    d_final_state = torch.randn_like(state)
+    expected_forward = run_forward(
+        q, k, value, gate, beta, cu_seqlens, state, scale=None, output_final_state=True
+    )
+    expected_backward = chunk_gdn_bwd_mega_packed(
+        q,
+        k,
+        value,
+        gate,
+        beta,
+        d_output,
+        cu_seqlens,
+        state,
+        d_final_state,
+    )
+
+    slack = 7
+
+    def poison_rows(tensor: torch.Tensor) -> torch.Tensor:
+        shape = (tensor.shape[0], slack, *tensor.shape[2:])
+        poison = torch.full(shape, torch.inf, dtype=tensor.dtype, device=tensor.device)
+        return torch.cat((tensor, poison), dim=1)
+
+    q_slack, k_slack, value_slack = (poison_rows(tensor) for tensor in (q, k, value))
+    gate_slack = torch.cat(
+        (gate, torch.full((1, slack, gate.shape[2]), 20.0, device=gate.device)), dim=1
+    )
+    beta_slack = torch.cat(
+        (beta, torch.full((1, slack, beta.shape[2]), torch.inf, device=beta.device)), dim=1
+    )
+    d_output_slack = poison_rows(d_output)
+    actual_forward = run_forward(
+        q_slack,
+        k_slack,
+        value_slack,
+        gate_slack,
+        beta_slack,
+        cu_seqlens,
+        state,
+        scale=None,
+        output_final_state=True,
+    )
+    actual_backward = chunk_gdn_bwd_mega_packed(
+        q_slack,
+        k_slack,
+        value_slack,
+        gate_slack,
+        beta_slack,
+        d_output_slack,
+        cu_seqlens,
+        state,
+        d_final_state,
+    )
+    active_tokens = q.shape[1]
+    torch.testing.assert_close(
+        actual_forward[0][:, :active_tokens], expected_forward[0], rtol=0, atol=0
+    )
+    assert actual_forward[1] is not None and expected_forward[1] is not None
+    torch.testing.assert_close(actual_forward[1], expected_forward[1], rtol=0, atol=0)
+    for index, (actual, expected) in enumerate(
+        zip(actual_backward, expected_backward, strict=True)
+    ):
+        assert actual is not None and expected is not None
+        if index < 5:
+            torch.testing.assert_close(actual[:, :active_tokens], expected, rtol=0, atol=0)
+        else:
+            torch.testing.assert_close(actual, expected, rtol=0, atol=0)

--- a/uv.lock
+++ b/uv.lock
@@ -138,7 +138,7 @@ requires-dist = [
     { name = "mkdocs-redirects", marker = "extra == 'docs'" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'" },
     { name = "nvidia-cutlass-dsl", extras = ["cu13"], marker = "sys_platform == 'linux' and extra == 'linear'", specifier = ">=4.5.0" },
-    { name = "nvidia-cutlass-dsl", extras = ["cu13"], marker = "sys_platform == 'linux' and extra == 'mega'", specifier = ">=4.7.0" },
+    { name = "nvidia-cutlass-dsl", extras = ["cu13"], marker = "sys_platform == 'linux' and extra == 'mega'", specifier = ">=4.7.0,<4.8.0" },
     { name = "prek", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'tests'" },
@@ -811,7 +811,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-8-attn-gym-mega' and extra == 'extra-8-attn-gym-tests')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [


### PR DESCRIPTION
Stacked PRs:
 * #429
 * #428
 * __->__#427


--- --- ---

Port scalar GDN Mega kernels

## Human Note

## Agent note

Port NVIDIA Frost's BT64 scalar-GDN prefill, checkpoint-recompute, and bprop kernels onto the
landed Mega runtime without routing scalar gates through KDA's bounded reciprocal rebase. This
layer includes the private Torch launchers, source attribution, terminal-safe packed TMA maps,
K-first checkpoint descriptors over public [V, K] storage, end-to-end int64 descriptor strides,
and the shared autograd-context CUDA device guard used by GDN and KDA.

The large kernel bodies intentionally remain close to the donor implementation for the initial
landing. They reuse the stable KDA Mega hierarchy around them: compact fake-tensor signatures with
only the required alignment, int32/int64 ABI selection, THD scheduling and TMA helpers, per-signature
TVM-FFI compilation caches, and device guards. Normal layouts remain zero-copy; the only deliberate
Q/K materialization is the temporary grouped-head backward bridge. Once both variants have settled,
launcher and configuration scaffolding can be extracted independently without coupling the scalar
GDN and vector-gated KDA arithmetic.

The private tests are intentionally part of the kernel-port layer. They cover every BT64 boundary,
packed second sequences and empty sequences, poisoned terminal capacity, checkpoint orientation,
FP16/BF16, extreme and model-style gates, grouped-head gradient reduction, outer strides,
misalignment rejection, forced int64, and active Q/K addresses beyond signed int32. CUTracer
random-delay stress at 5, 20, and 100 microseconds remained numerically correct and bitwise
repeatable for prefill, recompute, bprop, and their prologues.

## Test Plan

```bash
gpu-run auto -- uv run --extra mega --with pytest pytest \
  test/gdn/mega/test_gdn_mega_forward.py \
  test/gdn/mega/test_gdn_mega_backward.py \
  test/gdn/mega/test_gdn_mega_layouts.py \
  test/kda/mega/test_kda_mega_training.py::test_mega_forced_int64_forward_backward_matches_int32 -q

# CUTracer oracle was run for forward and backward at delay-ns 5000, 20000, and 100000.
```