### PR TITLE
Integrate the Mega GDN training backend

### DIFF
--- a/attn_gym/linear/gdn/api.py
+++ b/attn_gym/linear/gdn/api.py
@@ -10,6 +10,7 @@ from attn_gym.linear._delta_rule.validation import (
     validate_decode_inputs,
     validate_paged_state,
 )
+from attn_gym.linear.gdn.impl.mega import chunk_forward as mega_chunk_forward
 from attn_gym.linear.gdn.impl.reference import chunk_forward, recurrent_forward, reference_gdn
 from attn_gym.linear.gdn.ops import recurrent_decode_forward
 from attn_gym.linear.gdn.ops import recurrent_forward as fused_recurrent_forward
@@ -52,18 +53,28 @@ def chunk_gdn(
             unspecified.
         scale: Query scale. Defaults to ``1 / sqrt(K)``.
         output_final_state: Return the final recurrent state with the output.
-        impl: ``"reference"`` uses eager PyTorch. ``"fused"`` is reserved for the optimized
-            backend and currently raises ``NotImplementedError``.
+        impl: ``"reference"`` uses eager PyTorch. ``"fused"`` uses the optional CuTeDSL 4.7
+            Mega backend on SM100/SM103 with FP16/BF16 QKV and ``K = V = 128``.
 
     Returns:
         The output in ``q.dtype`` and either the final recurrent state or ``None``.
     """
     selected_impl = resolve_impl(impl)
     validate_gdn_inputs(q, k, v, gate, beta, initial_state, cu_seqlens)
+    scale = resolve_scale(scale, q.shape[-1])
     if selected_impl is Impl.FUSED:
-        raise NotImplementedError("chunk_gdn impl='fused' is not implemented yet")
+        return mega_chunk_forward(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            initial_state,
+            cu_seqlens=cu_seqlens,
+            scale=scale,
+            output_final_state=output_final_state,
+        )
 
-    scale = q.shape[-1] ** -0.5 if scale is None else scale
     return reference_gdn(
         chunk_forward,
         q,

--- a/attn_gym/linear/gdn/impl/mega.py
+++ b/attn_gym/linear/gdn/impl/mega.py
@@ -1,0 +1,214 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Autograd integration for the optional scalar-GDN Mega implementation."""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+
+from attn_gym.linear.gdn.impl.mega_ops import (
+    chunk_gdn_mega_packed_bwd_op,
+    chunk_gdn_mega_packed_bwd_with_state_op,
+    chunk_gdn_mega_packed_fwd_op,
+    chunk_gdn_mega_packed_fwd_with_initial_state_op,
+    chunk_gdn_mega_packed_fwd_with_state_op,
+    validate_mega_available,
+)
+from attn_gym.linear.kda.chunk_schedule import prepare_ragged_chunk_metadata
+
+_SUPPORTED_IO_DTYPES = (torch.float16, torch.bfloat16)
+_MEGA_DIM = 128
+_CHUNK_SIZE = 64
+
+
+def _pack_dense(tensor: Tensor) -> Tensor:
+    """Lower dense [B, T, ...] tensors to Mega's packed batch-one layout."""
+    return tensor.reshape(1, -1, *tensor.shape[2:])
+
+
+def _validate_mega_constraints(
+    q: Tensor,
+    k: Tensor,
+    value: Tensor,
+    gate: Tensor,
+    beta: Tensor,
+    initial_state: Tensor | None,
+) -> None:
+    """Validate the scalar-GDN restrictions imposed by the raw Mega launchers."""
+    if not q.is_cuda:
+        raise ValueError("the Mega GDN backend requires CUDA tensors")
+    if q.shape[0] != 1 or q.shape[-1] != _MEGA_DIM or value.shape[-1] != _MEGA_DIM:
+        raise ValueError("the Mega backend requires B=1 and K=V=128")
+    if q.dtype not in _SUPPORTED_IO_DTYPES or k.dtype != q.dtype or value.dtype != q.dtype:
+        raise TypeError("q, k, and value must share dtype float16 or bfloat16")
+    if gate.dtype != torch.float32 or beta.dtype != torch.float32:
+        raise TypeError("gate and beta must be float32")
+    if initial_state is not None and initial_state.dtype != torch.float32:
+        raise TypeError("initial_state must be float32")
+
+
+class ChunkGdnMegaPacked(torch.autograd.Function):
+    """Attach autograd to packed scalar-GDN Mega calls with optional recurrent state."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        q: Tensor,
+        k: Tensor,
+        value: Tensor,
+        gate: Tensor,
+        beta: Tensor,
+        initial_state: Tensor | None,
+        cu_seqlens: Tensor,
+        chunk_offsets: Tensor,
+        scale: float,
+        output_final_state: bool,
+    ) -> Tensor | tuple[Tensor, Tensor]:
+        ctx.has_initial_state = initial_state is not None
+        ctx.scale = scale
+        if initial_state is None:
+            output = chunk_gdn_mega_packed_fwd_op(
+                q, k, value, gate, beta, cu_seqlens, chunk_offsets, scale
+            )
+            ctx.save_for_backward(q, k, value, gate, beta, cu_seqlens)
+        elif output_final_state:
+            output, final_state = chunk_gdn_mega_packed_fwd_with_state_op(
+                q,
+                k,
+                value,
+                gate,
+                beta,
+                initial_state,
+                cu_seqlens,
+                chunk_offsets,
+                scale,
+            )
+            ctx.save_for_backward(q, k, value, gate, beta, initial_state, cu_seqlens)
+        else:
+            output = chunk_gdn_mega_packed_fwd_with_initial_state_op(
+                q,
+                k,
+                value,
+                gate,
+                beta,
+                initial_state,
+                cu_seqlens,
+                chunk_offsets,
+                scale,
+            )
+            ctx.save_for_backward(q, k, value, gate, beta, initial_state, cu_seqlens)
+        ctx.set_materialize_grads(False)
+        if output_final_state:
+            assert initial_state is not None
+            return output, final_state
+        return output
+
+    @staticmethod
+    @torch.autograd.function.once_differentiable
+    def backward(
+        ctx,
+        d_output: Tensor | None,
+        d_final_state: Tensor | None = None,
+    ) -> tuple[Tensor | None, ...]:
+        if not ctx.has_initial_state:
+            q, k, value, gate, beta, cu_seqlens = ctx.saved_tensors
+            gradients = chunk_gdn_mega_packed_bwd_op(
+                q,
+                k,
+                value,
+                gate,
+                beta,
+                torch.zeros_like(value) if d_output is None else d_output,
+                cu_seqlens,
+                ctx.scale,
+            )
+            return *gradients, None, None, None, None, None
+
+        q, k, value, gate, beta, initial_state, cu_seqlens = ctx.saved_tensors
+        return (
+            *chunk_gdn_mega_packed_bwd_with_state_op(
+                q,
+                k,
+                value,
+                gate,
+                beta,
+                torch.zeros_like(value) if d_output is None else d_output,
+                initial_state,
+                d_final_state,
+                cu_seqlens,
+                ctx.scale,
+            ),
+            None,
+            None,
+            None,
+            None,
+        )
+
+
+def chunk_forward(
+    q: Tensor,
+    k: Tensor,
+    value: Tensor,
+    gate: Tensor,
+    beta: Tensor,
+    initial_state: Tensor | None = None,
+    *,
+    cu_seqlens: Tensor | None = None,
+    scale: float,
+    output_final_state: bool = False,
+) -> tuple[Tensor, Tensor | None]:
+    """Run scalar GDN through the Mega backend behind the shared chunk contract."""
+    if not q.is_cuda:
+        raise ValueError("the Mega GDN backend requires CUDA tensors")
+    if not torch.compiler.is_compiling():
+        validate_mega_available(q)
+
+    gate, beta = (tensor.to(dtype=torch.float32) for tensor in (gate, beta))
+    batch = q.shape[0]
+    output_shape = value.shape
+    if cu_seqlens is None:
+        cu_seqlens = torch.arange(batch + 1, dtype=torch.int32, device=q.device) * q.shape[1]
+    elif batch != 1:
+        raise ValueError("packed cu_seqlens require q to have batch size one")
+    else:
+        cu_seqlens = cu_seqlens.contiguous()
+
+    if batch > 1:
+        q, k, value, gate, beta = (_pack_dense(tensor) for tensor in (q, k, value, gate, beta))
+
+    metadata = prepare_ragged_chunk_metadata(cu_seqlens, q.shape[1], _CHUNK_SIZE)
+    cu_seqlens = metadata.cu_seqlens
+    chunk_offsets = metadata.chunk_offsets
+
+    if output_final_state and initial_state is None:
+        initial_state = torch.zeros(
+            cu_seqlens.shape[0] - 1,
+            value.shape[2],
+            _MEGA_DIM,
+            _MEGA_DIM,
+            dtype=torch.float32,
+            device=q.device,
+        )
+
+    _validate_mega_constraints(q, k, value, gate, beta, initial_state)
+
+    result = ChunkGdnMegaPacked.apply(
+        q,
+        k,
+        value,
+        gate,
+        beta,
+        initial_state,
+        cu_seqlens,
+        chunk_offsets,
+        scale,
+        output_final_state,
+    )
+    if output_final_state:
+        output, final_state = result
+        return output.reshape(output_shape), final_state
+    return result.reshape(output_shape), None
+
+
+__all__ = ["chunk_forward"]

--- a/attn_gym/linear/gdn/impl/mega_ops.py
+++ b/attn_gym/linear/gdn/impl/mega_ops.py
@@ -1,0 +1,401 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Private registered operators around the optional scalar-GDN Mega launchers.
+
+The opaque operators keep CuTeDSL imports and launch-time setup outside captured graphs. Public
+input normalization and autograd live in :mod:`mega`; these operators own only fixed kernel ABIs.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import torch
+from torch import Tensor
+
+from attn_gym._backends.cute import tensor_supports_contiguous_dim, tensor_supports_tma
+
+torch.library.define(
+    "attn_gym::gdn_chunk_mega_packed_fwd",
+    "(Tensor q, Tensor k, Tensor value, Tensor gate, Tensor beta, Tensor cu_seqlens, "
+    "Tensor chunk_offsets, float scale) -> Tensor",
+)
+torch.library.define(
+    "attn_gym::gdn_chunk_mega_packed_fwd_with_initial_state",
+    "(Tensor q, Tensor k, Tensor value, Tensor gate, Tensor beta, Tensor initial_state, "
+    "Tensor cu_seqlens, Tensor chunk_offsets, float scale) -> Tensor",
+)
+torch.library.define(
+    "attn_gym::gdn_chunk_mega_packed_fwd_with_state",
+    "(Tensor q, Tensor k, Tensor value, Tensor gate, Tensor beta, Tensor initial_state, "
+    "Tensor cu_seqlens, Tensor chunk_offsets, float scale) -> (Tensor, Tensor)",
+)
+torch.library.define(
+    "attn_gym::gdn_chunk_mega_packed_bwd",
+    "(Tensor q, Tensor k, Tensor value, Tensor gate, Tensor beta, Tensor d_output, "
+    "Tensor cu_seqlens, float scale) -> (Tensor, Tensor, Tensor, Tensor, Tensor)",
+)
+torch.library.define(
+    "attn_gym::gdn_chunk_mega_packed_bwd_with_state",
+    "(Tensor q, Tensor k, Tensor value, Tensor gate, Tensor beta, Tensor d_output, "
+    "Tensor initial_state, Tensor? d_final_state, Tensor cu_seqlens, float scale) "
+    "-> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor)",
+)
+
+
+def _normalize_tma_tensor(tensor: Tensor) -> Tensor:
+    """Copy only runtime tensors that cannot satisfy the raw TMA ABI."""
+    return (
+        tensor
+        if tensor_supports_tma(tensor)
+        else tensor.clone(memory_format=torch.contiguous_format)
+    )
+
+
+def _normalize_scalar_tensor(tensor: Tensor) -> Tensor:
+    """Copy only scalar rows that cannot satisfy their contiguous-head ABI."""
+    return (
+        tensor
+        if tensor_supports_contiguous_dim(tensor, alignment_bytes=4)
+        else tensor.clone(memory_format=torch.contiguous_format)
+    )
+
+
+def _normalize_cu_seqlens(cu_seqlens: Tensor) -> Tensor:
+    """Copy routing metadata only when its raw launcher ABI requires it."""
+    if cu_seqlens.is_contiguous() and cu_seqlens.data_ptr() % 8 == 0:
+        return cu_seqlens
+    return cu_seqlens.clone(memory_format=torch.contiguous_format)
+
+
+def _empty_with_layout(template: Tensor) -> Tensor:
+    """Allocate a tensor with exactly the template's shape, dtype, device, and strides."""
+    return torch.empty_strided(
+        template.shape,
+        template.stride(),
+        dtype=template.dtype,
+        device=template.device,
+    )
+
+
+def _copy_to_layout(tensor: Tensor, template: Tensor) -> Tensor:
+    """Return a gradient/output with the fake-visible input layout."""
+    if tensor.stride() == template.stride():
+        return tensor
+    return _empty_with_layout(template).copy_(tensor)
+
+
+def _forward_backend() -> object:
+    """Lazily import the optional forward launcher."""
+    try:
+        return importlib.import_module("attn_gym.linear._delta_rule.mega.gdn_forward")
+    except ImportError as error:
+        raise ImportError("the Mega GDN backend requires CUDA and attn-gym[mega]") from error
+
+
+def _backward_backend() -> object:
+    """Lazily import the optional checkpoint-recompute and backward launcher."""
+    try:
+        return importlib.import_module("attn_gym.linear._delta_rule.mega.gdn_backward")
+    except ImportError as error:
+        raise ImportError("the Mega GDN backend requires CUDA and attn-gym[mega]") from error
+
+
+def validate_mega_available(q: Tensor) -> None:
+    """Fail before caller-side setup when the optional backend cannot run."""
+    _forward_backend().validate_available(q)
+
+
+def _packed_fwd_cuda(
+    q: Tensor,
+    k: Tensor,
+    value: Tensor,
+    gate: Tensor,
+    beta: Tensor,
+    cu_seqlens: Tensor,
+    chunk_offsets: Tensor,
+    scale: float,
+) -> Tensor:
+    del chunk_offsets
+    value_template = value
+    q, k, value = (_normalize_tma_tensor(tensor) for tensor in (q, k, value))
+    gate, beta = (_normalize_scalar_tensor(tensor) for tensor in (gate, beta))
+    cu_seqlens = _normalize_cu_seqlens(cu_seqlens)
+    output, _ = _forward_backend().run_forward(
+        q,
+        k,
+        value,
+        gate,
+        beta,
+        cu_seqlens,
+        None,
+        scale=scale,
+        output_final_state=False,
+    )
+    return _copy_to_layout(output, value_template)
+
+
+def _packed_fwd_with_initial_state_cuda(
+    q: Tensor,
+    k: Tensor,
+    value: Tensor,
+    gate: Tensor,
+    beta: Tensor,
+    initial_state: Tensor,
+    cu_seqlens: Tensor,
+    chunk_offsets: Tensor,
+    scale: float,
+) -> Tensor:
+    del chunk_offsets
+    value_template = value
+    q, k, value, initial_state = (
+        _normalize_tma_tensor(tensor) for tensor in (q, k, value, initial_state)
+    )
+    gate, beta = (_normalize_scalar_tensor(tensor) for tensor in (gate, beta))
+    cu_seqlens = _normalize_cu_seqlens(cu_seqlens)
+    output, _ = _forward_backend().run_forward(
+        q,
+        k,
+        value,
+        gate,
+        beta,
+        cu_seqlens,
+        initial_state,
+        scale=scale,
+        output_final_state=False,
+    )
+    return _copy_to_layout(output, value_template)
+
+
+def _packed_fwd_with_state_cuda(
+    q: Tensor,
+    k: Tensor,
+    value: Tensor,
+    gate: Tensor,
+    beta: Tensor,
+    initial_state: Tensor,
+    cu_seqlens: Tensor,
+    chunk_offsets: Tensor,
+    scale: float,
+) -> tuple[Tensor, Tensor]:
+    del chunk_offsets
+    value_template, state_template = value, initial_state
+    q, k, value, initial_state = (
+        _normalize_tma_tensor(tensor) for tensor in (q, k, value, initial_state)
+    )
+    gate, beta = (_normalize_scalar_tensor(tensor) for tensor in (gate, beta))
+    cu_seqlens = _normalize_cu_seqlens(cu_seqlens)
+    output, final_state = _forward_backend().run_forward(
+        q,
+        k,
+        value,
+        gate,
+        beta,
+        cu_seqlens,
+        initial_state,
+        scale=scale,
+        output_final_state=True,
+    )
+    assert final_state is not None
+    return _copy_to_layout(output, value_template), _copy_to_layout(final_state, state_template)
+
+
+def _packed_bwd_cuda(
+    q: Tensor,
+    k: Tensor,
+    value: Tensor,
+    gate: Tensor,
+    beta: Tensor,
+    d_output: Tensor,
+    cu_seqlens: Tensor,
+    scale: float,
+) -> tuple[Tensor, Tensor, Tensor, Tensor, Tensor]:
+    templates = (q, k, value, gate, beta)
+    q, k, value, d_output = (_normalize_tma_tensor(tensor) for tensor in (q, k, value, d_output))
+    gate, beta = (_normalize_scalar_tensor(tensor) for tensor in (gate, beta))
+    cu_seqlens = _normalize_cu_seqlens(cu_seqlens)
+    dq, dk, dv, dgate, dbeta, d_initial_state = _backward_backend().chunk_gdn_bwd_mega_packed(
+        q,
+        k,
+        value,
+        gate,
+        beta,
+        d_output,
+        cu_seqlens,
+        scale=scale,
+    )
+    assert d_initial_state is None
+    return tuple(
+        _copy_to_layout(gradient, template)
+        for gradient, template in zip((dq, dk, dv, dgate, dbeta), templates, strict=True)
+    )
+
+
+def _packed_bwd_with_state_cuda(
+    q: Tensor,
+    k: Tensor,
+    value: Tensor,
+    gate: Tensor,
+    beta: Tensor,
+    d_output: Tensor,
+    initial_state: Tensor,
+    d_final_state: Tensor | None,
+    cu_seqlens: Tensor,
+    scale: float,
+) -> tuple[Tensor, Tensor, Tensor, Tensor, Tensor, Tensor]:
+    templates = (q, k, value, gate, beta, initial_state)
+    q, k, value, d_output, initial_state = (
+        _normalize_tma_tensor(tensor) for tensor in (q, k, value, d_output, initial_state)
+    )
+    if d_final_state is not None:
+        d_final_state = _normalize_tma_tensor(d_final_state)
+    gate, beta = (_normalize_scalar_tensor(tensor) for tensor in (gate, beta))
+    cu_seqlens = _normalize_cu_seqlens(cu_seqlens)
+    dq, dk, dv, dgate, dbeta, d_initial_state = _backward_backend().chunk_gdn_bwd_mega_packed(
+        q,
+        k,
+        value,
+        gate,
+        beta,
+        d_output,
+        cu_seqlens,
+        initial_state,
+        d_final_state,
+        scale=scale,
+    )
+    assert d_initial_state is not None
+    return tuple(
+        _copy_to_layout(gradient, template)
+        for gradient, template in zip(
+            (dq, dk, dv, dgate, dbeta, d_initial_state), templates, strict=True
+        )
+    )
+
+
+torch.library.impl("attn_gym::gdn_chunk_mega_packed_fwd", "CUDA", _packed_fwd_cuda)
+torch.library.impl(
+    "attn_gym::gdn_chunk_mega_packed_fwd_with_initial_state",
+    "CUDA",
+    _packed_fwd_with_initial_state_cuda,
+)
+torch.library.impl(
+    "attn_gym::gdn_chunk_mega_packed_fwd_with_state",
+    "CUDA",
+    _packed_fwd_with_state_cuda,
+)
+torch.library.impl("attn_gym::gdn_chunk_mega_packed_bwd", "CUDA", _packed_bwd_cuda)
+torch.library.impl(
+    "attn_gym::gdn_chunk_mega_packed_bwd_with_state",
+    "CUDA",
+    _packed_bwd_with_state_cuda,
+)
+
+
+@torch.library.register_fake("attn_gym::gdn_chunk_mega_packed_fwd")
+def _packed_fwd_fake(
+    q: Tensor,
+    k: Tensor,
+    value: Tensor,
+    gate: Tensor,
+    beta: Tensor,
+    cu_seqlens: Tensor,
+    chunk_offsets: Tensor,
+    scale: float,
+) -> Tensor:
+    """Describe the output allocation made by the no-state forward launcher."""
+    return _empty_with_layout(value)
+
+
+@torch.library.register_fake("attn_gym::gdn_chunk_mega_packed_fwd_with_initial_state")
+def _packed_fwd_with_initial_state_fake(
+    q: Tensor,
+    k: Tensor,
+    value: Tensor,
+    gate: Tensor,
+    beta: Tensor,
+    initial_state: Tensor,
+    cu_seqlens: Tensor,
+    chunk_offsets: Tensor,
+    scale: float,
+) -> Tensor:
+    """Describe the output-only stateful forward launcher."""
+    return _empty_with_layout(value)
+
+
+@torch.library.register_fake("attn_gym::gdn_chunk_mega_packed_fwd_with_state")
+def _packed_fwd_with_state_fake(
+    q: Tensor,
+    k: Tensor,
+    value: Tensor,
+    gate: Tensor,
+    beta: Tensor,
+    initial_state: Tensor,
+    cu_seqlens: Tensor,
+    chunk_offsets: Tensor,
+    scale: float,
+) -> tuple[Tensor, Tensor]:
+    """Describe the forward output and launcher-cloned final state."""
+    return _empty_with_layout(value), _empty_with_layout(initial_state)
+
+
+def _gradient_allocation(tensor: Tensor) -> Tensor:
+    """Match the CUDA wrapper's exact-layout gradient allocation."""
+    return _empty_with_layout(tensor)
+
+
+@torch.library.register_fake("attn_gym::gdn_chunk_mega_packed_bwd")
+def _packed_bwd_fake(
+    q: Tensor,
+    k: Tensor,
+    value: Tensor,
+    gate: Tensor,
+    beta: Tensor,
+    d_output: Tensor,
+    cu_seqlens: Tensor,
+    scale: float,
+) -> tuple[Tensor, Tensor, Tensor, Tensor, Tensor]:
+    """Describe the five no-state backward gradients."""
+    return tuple(_gradient_allocation(tensor) for tensor in (q, k, value, gate, beta))
+
+
+@torch.library.register_fake("attn_gym::gdn_chunk_mega_packed_bwd_with_state")
+def _packed_bwd_with_state_fake(
+    q: Tensor,
+    k: Tensor,
+    value: Tensor,
+    gate: Tensor,
+    beta: Tensor,
+    d_output: Tensor,
+    initial_state: Tensor,
+    d_final_state: Tensor | None,
+    cu_seqlens: Tensor,
+    scale: float,
+) -> tuple[Tensor, Tensor, Tensor, Tensor, Tensor, Tensor]:
+    """Describe stateful backward gradients, including the initial-state cotangent."""
+    return (
+        *(_gradient_allocation(tensor) for tensor in (q, k, value, gate, beta)),
+        _empty_with_layout(initial_state),
+    )
+
+
+chunk_gdn_mega_packed_fwd_op = torch.ops.attn_gym.gdn_chunk_mega_packed_fwd.default
+chunk_gdn_mega_packed_fwd_with_initial_state_op = (
+    torch.ops.attn_gym.gdn_chunk_mega_packed_fwd_with_initial_state.default
+)
+chunk_gdn_mega_packed_fwd_with_state_op = (
+    torch.ops.attn_gym.gdn_chunk_mega_packed_fwd_with_state.default
+)
+chunk_gdn_mega_packed_bwd_op = torch.ops.attn_gym.gdn_chunk_mega_packed_bwd.default
+chunk_gdn_mega_packed_bwd_with_state_op = (
+    torch.ops.attn_gym.gdn_chunk_mega_packed_bwd_with_state.default
+)
+
+
+__all__ = [
+    "chunk_gdn_mega_packed_bwd_op",
+    "chunk_gdn_mega_packed_bwd_with_state_op",
+    "chunk_gdn_mega_packed_fwd_op",
+    "chunk_gdn_mega_packed_fwd_with_initial_state_op",
+    "chunk_gdn_mega_packed_fwd_with_state_op",
+    "validate_mega_available",
+]

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -19,8 +19,9 @@ output = scale * state @ query
 Public and persistent state uses axis order `[N, H, V, K]`; paged pools replace `N` with the
 slot count. `chunk_gdn` uses a chunk-parallel decomposition for training and prefill.
 `recurrent_gdn` consumes
-tokens in order for decoding, inference prefill, and state-carrying correctness checks. The caller
-chooses the execution form explicitly. `impl="reference"` selects eager PyTorch;
+tokens in order for decoding, inference prefill, and state-carrying correctness checks. `chunk_gdn`
+defaults to eager PyTorch (`impl="reference"`); `chunk_gdn(..., impl="fused")` selects the
+training-capable Mega CuTeDSL backend, while
 `recurrent_gdn(..., impl="fused")` selects the inference-only Triton scan.
 
 ```python
@@ -32,7 +33,7 @@ output, final_state = chunk_gdn(
     value,
     gate,
     beta,
-    impl="reference",
+    impl="fused",
     output_final_state=True,
 )
 ```
@@ -43,20 +44,25 @@ output, final_state = chunk_gdn(
   with `cu_seqlens`.
 - Separate recurrent and chunked operations with explicit initial and final state.
 - CPU and CUDA execution through eager PyTorch operations.
+- A training-capable fused chunk implementation on SM100/SM103 with dense and packed inputs,
+  grouped Q/K heads, tails, empty sequences, initial/final state, and state gradients.
 - An inference-only fused recurrent implementation on CUDA, including mutable paged state caches
   shaped `[num_slots, H, V, K]` selected by `state_indices`.
-- Autograd for reference inputs and initial state.
+- Autograd for the reference and fused chunk implementations, including initial-state gradients.
 - Q/K/V share one dtype. FP16 and BF16 inputs use FP32 recurrence math and state while returning
   output in the Q dtype.
 - Gate and beta may use independent floating dtypes and are converted to the recurrence compute
   dtype. A provided initial state uses FP32 for low-precision QKV.
 - FP64 reference inputs retain FP64 recurrence math and state.
 
+The fused chunk implementation requires the optional `mega` dependencies, SM100/SM103,
+FP16/BF16 Q/K/V, FP32 state, and `K = V = 128`. It consumes the scalar natural-log gate without a
+lower bound and uses exact execution without an approximate forgetting-horizon split.
+
 The fused recurrent implementation requires CUDA with Triton, Q/K/V in FP16, BF16, or FP32, and
 `K <= 256`. Packed offsets must begin at zero, be nondecreasing, and end within the physical token
-capacity. Output rows beyond the terminal offset are inactive capacity and unspecified. The fused
-chunk implementation is not implemented yet; unsupported implementation choices fail rather than
-falling back to the reference.
+capacity. Output rows beyond the terminal offset are inactive capacity and unspecified. Unsupported
+implementation choices fail rather than falling back to the reference.
 
 ### Migration from the prototype API
 

--- a/test/gdn/mega/test_gdn_mega_training.py
+++ b/test/gdn/mega/test_gdn_mega_training.py
@@ -1,0 +1,576 @@
+"""Public autograd and framework integration for scalar-GDN Mega."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+import torch
+
+pytest.importorskip(
+    "cutlass.experimental",
+    reason="the CuTeDSL 4.7 GDN path requires nvidia-cutlass-dsl>=4.7",
+)
+
+from attn_gym.linear import chunk_gdn
+from attn_gym.linear.gdn.impl.mega_ops import (
+    chunk_gdn_mega_packed_bwd_op,
+    chunk_gdn_mega_packed_bwd_with_state_op,
+    chunk_gdn_mega_packed_fwd_op,
+    chunk_gdn_mega_packed_fwd_with_initial_state_op,
+    chunk_gdn_mega_packed_fwd_with_state_op,
+)
+from attn_gym.linear.kda.chunk_schedule import prepare_ragged_chunk_metadata
+from attn_gym.testing import make_gdn_test_inputs
+from attn_gym.testing.kda import assert_matches_low_precision_reference, clone_kda_inputs
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() not in ((10, 0), (10, 3)),
+    reason="the CuTeDSL 4.7 GDN path requires SM100 or SM103",
+)
+
+
+def reference_results(
+    inputs: tuple[torch.Tensor, ...], precision: torch.dtype
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run the packed eager GDN oracle with final state in one precision."""
+    q, k, value, gate, beta, state, cu_seqlens = inputs
+    output, final_state = chunk_gdn(
+        q.to(precision),
+        k.to(precision),
+        value.to(precision),
+        gate.to(precision),
+        beta.to(precision),
+        state.to(precision),
+        cu_seqlens=cu_seqlens,
+        output_final_state=True,
+        impl="reference",
+    )
+    assert final_state is not None
+    return output, final_state
+
+
+def test_public_gdn_mega_packed_forward_and_six_gradients() -> None:
+    """Public fused execution must match eager output, state, and every gradient."""
+    inputs = make_gdn_test_inputs(
+        (65, 0, 63),
+        key_heads=1,
+        value_heads=2,
+        gate_pattern="isolated_negative_twenty",
+        requires_grad=True,
+        seed=307,
+    )
+    low = reference_results(inputs, torch.float32)
+    high = reference_results(inputs, torch.float64)
+    actual = chunk_gdn(
+        *inputs[:6],
+        cu_seqlens=inputs[6],
+        output_final_state=True,
+        impl="fused",
+    )
+    assert actual[1] is not None
+    for name, actual_tensor, high_tensor, low_tensor in zip(
+        ("output", "state"), actual, high, low, strict=True
+    ):
+        assert_matches_low_precision_reference(
+            actual_tensor,
+            high_tensor,
+            low_tensor,
+            name,
+            source_dtype=inputs[0].dtype,
+        )
+
+    torch.manual_seed(311)
+    cotangents = (torch.randn_like(actual[0]), torch.randn_like(actual[1]))
+    actual_gradients = torch.autograd.grad(actual, inputs[:6], cotangents)
+    low_targets = tuple(tensor.detach().float().requires_grad_() for tensor in inputs[:6])
+    high_targets = tuple(tensor.detach().double().requires_grad_() for tensor in inputs[:6])
+    low_result = chunk_gdn(
+        *low_targets,
+        cu_seqlens=inputs[6],
+        output_final_state=True,
+        impl="reference",
+    )
+    high_result = chunk_gdn(
+        *high_targets,
+        cu_seqlens=inputs[6],
+        output_final_state=True,
+        impl="reference",
+    )
+    low_gradients = torch.autograd.grad(
+        low_result,
+        low_targets,
+        tuple(cotangent.float() for cotangent in cotangents),
+    )
+    high_gradients = torch.autograd.grad(
+        high_result,
+        high_targets,
+        tuple(cotangent.double() for cotangent in cotangents),
+    )
+    for name, actual_gradient, high_gradient, low_gradient in zip(
+        ("dq", "dk", "dv", "dgate", "dbeta", "dstate"),
+        actual_gradients,
+        high_gradients,
+        low_gradients,
+        strict=True,
+    ):
+        assert_matches_low_precision_reference(
+            actual_gradient,
+            high_gradient,
+            low_gradient,
+            name,
+            source_dtype=inputs[0].dtype,
+        )
+
+
+def test_public_gdn_mega_grouped_h4_h12_forward_backward() -> None:
+    """A non-power-of-two Q/K sharing group must reduce gradients correctly."""
+    inputs = make_gdn_test_inputs(
+        (65,), key_heads=4, value_heads=12, dtype=torch.bfloat16, requires_grad=True, seed=310
+    )
+    actual = chunk_gdn(*inputs[:5], impl="fused")[0]
+    low_targets = tuple(tensor.detach().float().requires_grad_() for tensor in inputs[:5])
+    high_targets = tuple(tensor.detach().double().requires_grad_() for tensor in inputs[:5])
+    low = chunk_gdn(*low_targets, impl="reference")[0]
+    high = chunk_gdn(*high_targets, impl="reference")[0]
+    assert_matches_low_precision_reference(
+        actual, high, low, "H4/H12 output", source_dtype=inputs[0].dtype
+    )
+    d_output = torch.randn_like(actual)
+    actual_gradients = torch.autograd.grad(actual, inputs[:5], d_output)
+    low_gradients = torch.autograd.grad(low, low_targets, d_output.float())
+    high_gradients = torch.autograd.grad(high, high_targets, d_output.double())
+    for name, actual_gradient, high_gradient, low_gradient in zip(
+        ("dq", "dk", "dv", "dgate", "dbeta"),
+        actual_gradients,
+        high_gradients,
+        low_gradients,
+        strict=True,
+    ):
+        assert_matches_low_precision_reference(
+            actual_gradient,
+            high_gradient,
+            low_gradient,
+            f"H4/H12 {name}",
+            source_dtype=inputs[0].dtype,
+        )
+
+
+def test_public_gdn_mega_h64_custom_scale_forward_backward() -> None:
+    """Production head count and a non-default scale must match the eager oracle."""
+    inputs = make_gdn_test_inputs(
+        (64,), key_heads=64, value_heads=64, dtype=torch.bfloat16, requires_grad=True, seed=312
+    )
+    scale = 0.125
+    actual = chunk_gdn(*inputs[:5], scale=scale, impl="fused")[0]
+    low_targets = tuple(tensor.detach().float().requires_grad_() for tensor in inputs[:5])
+    high_targets = tuple(tensor.detach().double().requires_grad_() for tensor in inputs[:5])
+    low = chunk_gdn(*low_targets, scale=scale, impl="reference")[0]
+    high = chunk_gdn(*high_targets, scale=scale, impl="reference")[0]
+    assert_matches_low_precision_reference(
+        actual, high, low, "H64 custom-scale output", source_dtype=inputs[0].dtype
+    )
+    d_output = torch.randn_like(actual)
+    actual_gradients = torch.autograd.grad(actual, inputs[:5], d_output)
+    low_gradients = torch.autograd.grad(low, low_targets, d_output.float())
+    high_gradients = torch.autograd.grad(high, high_targets, d_output.double())
+    for name, actual_gradient, high_gradient, low_gradient in zip(
+        ("dq", "dk", "dv", "dgate", "dbeta"),
+        actual_gradients,
+        high_gradients,
+        low_gradients,
+        strict=True,
+    ):
+        assert_matches_low_precision_reference(
+            actual_gradient,
+            high_gradient,
+            low_gradient,
+            f"H64 custom-scale {name}",
+            source_dtype=inputs[0].dtype,
+        )
+
+
+def test_public_gdn_mega_dense_batch_lowers_to_packed() -> None:
+    """Dense B>1 calls must preserve reference outputs, states, and gradients."""
+    packed = make_gdn_test_inputs(
+        (65, 65), key_heads=1, value_heads=2, dtype=torch.float16, requires_grad=True, seed=313
+    )
+    dense = tuple(tensor.reshape(2, 65, *tensor.shape[2:]) for tensor in packed[:5])
+    state = packed[5]
+    expected = chunk_gdn(*dense, state, output_final_state=True, impl="reference")
+    actual = chunk_gdn(*dense, state, output_final_state=True, impl="fused")
+    assert actual[1] is not None and expected[1] is not None
+    torch.testing.assert_close(actual[0], expected[0], rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(actual[1], expected[1], rtol=2e-2, atol=2e-2)
+
+    d_output = torch.randn_like(actual[0])
+    d_state = torch.randn_like(actual[1])
+    actual_gradients = torch.autograd.grad(actual, (*dense, state), (d_output, d_state))
+    expected_gradients = torch.autograd.grad(expected, (*dense, state), (d_output, d_state))
+    for actual_gradient, expected_gradient in zip(
+        actual_gradients, expected_gradients, strict=True
+    ):
+        torch.testing.assert_close(actual_gradient, expected_gradient, rtol=5e-2, atol=5e-2)
+
+
+def test_gdn_mega_raw_operator_registration() -> None:
+    """Every fixed-arity raw schema must agree with runtime and fake metadata."""
+    q, k, value, gate, beta, state, cu_seqlens = make_gdn_test_inputs(
+        (65, 63), key_heads=1, value_heads=2, dtype=torch.bfloat16, seed=317
+    )
+    d_output = torch.randn_like(value)
+    d_state = torch.randn_like(state)
+    chunk_offsets = prepare_ragged_chunk_metadata(cu_seqlens, q.shape[1], 64).chunk_offsets
+    scale = 128**-0.5
+    test_utils = ("test_schema", "test_faketensor", "test_aot_dispatch_dynamic")
+    torch.library.opcheck(
+        chunk_gdn_mega_packed_fwd_op,
+        (q, k, value, gate, beta, cu_seqlens, chunk_offsets, scale),
+        test_utils=test_utils,
+    )
+    torch.library.opcheck(
+        chunk_gdn_mega_packed_fwd_with_initial_state_op,
+        (q, k, value, gate, beta, state, cu_seqlens, chunk_offsets, scale),
+        test_utils=test_utils,
+    )
+    torch.library.opcheck(
+        chunk_gdn_mega_packed_fwd_with_state_op,
+        (q, k, value, gate, beta, state, cu_seqlens, chunk_offsets, scale),
+        test_utils=test_utils,
+    )
+    torch.library.opcheck(
+        chunk_gdn_mega_packed_bwd_op,
+        (q, k, value, gate, beta, d_output, cu_seqlens, scale),
+        test_utils=test_utils,
+    )
+    for state_cotangent in (None, d_state):
+        torch.library.opcheck(
+            chunk_gdn_mega_packed_bwd_with_state_op,
+            (
+                q,
+                k,
+                value,
+                gate,
+                beta,
+                d_output,
+                state,
+                state_cotangent,
+                cu_seqlens,
+                scale,
+            ),
+            test_utils=test_utils,
+        )
+
+
+def test_gdn_mega_backward_fake_preserves_leading_strides() -> None:
+    """Backward fakes must expose the exact layouts returned by the CUDA wrapper."""
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    q, k, value, gate, beta, _state, cu_seqlens = make_gdn_test_inputs(
+        (65,), key_heads=2, value_heads=2, dtype=torch.bfloat16, seed=319
+    )
+    inputs = tuple(
+        torch.as_strided(
+            tensor,
+            tensor.shape,
+            (tensor.stride(0) + 16 // tensor.element_size(), *tensor.stride()[1:]),
+        )
+        for tensor in (q, k, value, gate, beta)
+    )
+    d_output = torch.randn_like(value)
+    arguments = (*inputs, d_output, cu_seqlens)
+    actual = chunk_gdn_mega_packed_bwd_op(*arguments, 128**-0.5)
+    with FakeTensorMode() as mode:
+        fake_arguments = tuple(mode.from_tensor(tensor) for tensor in arguments)
+        fake = chunk_gdn_mega_packed_bwd_op(*fake_arguments, 128**-0.5)
+
+    expected_strides = tuple(tensor.stride() for tensor in inputs)
+    assert tuple(tensor.stride() for tensor in actual) == expected_strides
+    assert tuple(tensor.stride() for tensor in fake) == expected_strides
+
+
+@pytest.mark.parametrize("offsets", ([1, 3], [0, 4, 3], [0, 9]))
+def test_public_gdn_mega_rejects_invalid_packed_offset_values(offsets: list[int]) -> None:
+    """Device-side boundary validation must fail before invalid TMA descriptors execute."""
+    code = f"""
+import torch
+from attn_gym.linear import chunk_gdn
+shape = (1, 8, 2, 128)
+q = torch.randn(shape, device='cuda', dtype=torch.bfloat16)
+k = torch.randn_like(q)
+v = torch.randn_like(q)
+gate = -torch.rand(shape[:3], device='cuda')
+beta = torch.rand(shape[:3], device='cuda')
+cu = torch.tensor({offsets!r}, dtype=torch.int32, device='cuda')
+chunk_gdn(q, k, v, gate, beta, cu_seqlens=cu, impl='fused')
+torch.cuda.synchronize()
+"""
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=60,
+            env={**os.environ, "CUDA_LAUNCH_BLOCKING": "1"},
+        )
+    except subprocess.TimeoutExpired:
+        pytest.fail("invalid packed offsets hung instead of failing validation")
+    assert result.returncode != 0, "invalid packed offsets reached the Mega kernel"
+
+
+def test_public_gdn_mega_casts_low_precision_gate_and_beta_with_gradients() -> None:
+    """FP32 gate normalization must preserve low-precision output and gradient accuracy."""
+    q, k, value, gate, beta, _state, _cu_seqlens = make_gdn_test_inputs(
+        (65,), key_heads=2, value_heads=2, dtype=torch.bfloat16, seed=327
+    )
+    quantized = tuple(
+        tensor.detach().to(torch.bfloat16).requires_grad_() for tensor in (q, k, value, gate, beta)
+    )
+    actual_inputs = clone_kda_inputs(quantized)
+    source_inputs = clone_kda_inputs(quantized)
+    high_inputs = clone_kda_inputs(quantized, dtype=torch.float64)
+    actual_output = chunk_gdn(*actual_inputs, impl="fused")[0]
+    source_output = chunk_gdn(*source_inputs, impl="reference")[0]
+    high_output = chunk_gdn(*high_inputs, impl="reference")[0]
+    d_output = torch.randn_like(actual_output)
+    actual_gradients = torch.autograd.grad(actual_output, actual_inputs, d_output)
+    source_gradients = torch.autograd.grad(source_output, source_inputs, d_output)
+    high_gradients = torch.autograd.grad(high_output, high_inputs, d_output.double())
+
+    assert_matches_low_precision_reference(
+        actual_output,
+        high_output,
+        source_output,
+        "low-precision gate output",
+        source_dtype=torch.bfloat16,
+    )
+    for name, actual, high, source in zip(
+        ("dq", "dk", "dv", "dgate", "dbeta"),
+        actual_gradients,
+        high_gradients,
+        source_gradients,
+        strict=True,
+    ):
+        assert actual.dtype == torch.bfloat16
+        assert_matches_low_precision_reference(
+            actual,
+            high,
+            source,
+            f"low-precision gate {name}",
+            source_dtype=torch.bfloat16,
+        )
+
+
+def test_public_gdn_mega_no_state_backward_initializes_cuda_device() -> None:
+    """The custom-autograd callback must restore a distinct caller CUDA device."""
+    if torch.cuda.device_count() < 2:
+        pytest.skip("CUDA device restoration requires at least two visible GPUs")
+    inputs = make_gdn_test_inputs((65,), key_heads=2, value_heads=2, requires_grad=True, seed=329)
+    output, final_state = chunk_gdn(*inputs[:5], impl="fused")
+    assert final_state is None
+    input_device = inputs[0].device.index
+    assert input_device is not None
+    caller_device = 1 if input_device == 0 else 0
+    with torch.cuda.device(caller_device):
+        gradients = torch.autograd.grad(output, inputs[:5], torch.randn_like(output))
+        assert torch.cuda.current_device() == caller_device
+    assert all(torch.isfinite(gradient).all() for gradient in gradients)
+
+
+@pytest.mark.parametrize("layout", ["misaligned", "inner_stride"])
+def test_public_compiled_gdn_normalizes_unsupported_q_layout(layout: str) -> None:
+    """Compiled public execution must match eager normalization for supported tensor values."""
+    q, k, value, gate, beta, _state, _cu_seqlens = make_gdn_test_inputs(
+        (65,), key_heads=2, value_heads=2, dtype=torch.bfloat16, seed=330
+    )
+    if layout == "misaligned":
+        storage = torch.empty(q.numel() + 1, dtype=q.dtype, device=q.device)
+        candidate_q = storage[1:].view_as(q).copy_(q)
+    else:
+        storage = torch.empty(q.numel() * 2, dtype=q.dtype, device=q.device)
+        candidate_q = torch.as_strided(
+            storage,
+            q.shape,
+            (q.stride(0) * 2, q.stride(1) * 2, q.stride(2) * 2, 2),
+        ).copy_(q)
+
+    @torch.compile(fullgraph=True)
+    def compiled(query, key, values, gates, betas):
+        return chunk_gdn(query, key, values, gates, betas, impl="fused")[0]
+
+    expected = chunk_gdn(candidate_q, k, value, gate, beta, impl="fused")[0]
+    actual = compiled(candidate_q, k, value, gate, beta)
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_public_gdn_mega_fullgraph_forward_backward() -> None:
+    """Strict compilation must retain the public stateful autograd contract."""
+    inputs = make_gdn_test_inputs(
+        (65, 0, 63), key_heads=1, value_heads=2, requires_grad=True, seed=331
+    )
+
+    @torch.compile(fullgraph=True)
+    def compiled(q, k, value, gate, beta, state, cu_seqlens):
+        return chunk_gdn(
+            q,
+            k,
+            value,
+            gate,
+            beta,
+            state,
+            cu_seqlens=cu_seqlens,
+            output_final_state=True,
+            impl="fused",
+        )
+
+    actual_inputs = (*clone_kda_inputs(inputs[:-1]), inputs[-1])
+    expected = chunk_gdn(*inputs[:6], cu_seqlens=inputs[6], output_final_state=True, impl="fused")
+    actual = compiled(*actual_inputs)
+    assert expected[1] is not None and actual[1] is not None
+    for actual_tensor, expected_tensor in zip(actual, expected, strict=True):
+        torch.testing.assert_close(actual_tensor, expected_tensor, rtol=0, atol=0)
+    cotangents = (torch.randn_like(actual[0]), torch.randn_like(actual[1]))
+    expected_gradients = torch.autograd.grad(expected, inputs[:6], cotangents)
+    actual_gradients = torch.autograd.grad(actual, actual_inputs[:6], cotangents)
+    for actual_gradient, expected_gradient in zip(
+        actual_gradients, expected_gradients, strict=True
+    ):
+        torch.testing.assert_close(actual_gradient, expected_gradient, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("mode", ["no_state", "initial_only", "final_from_zero"])
+def test_public_gdn_mega_fullgraph_output_arities(mode: str) -> None:
+    """Strict compilation must support every fixed-arity forward operator route."""
+    inputs = make_gdn_test_inputs((65,), key_heads=2, value_heads=2, seed=333)
+
+    @torch.compile(fullgraph=True)
+    def compiled(q, k, value, gate, beta, state):
+        if mode == "no_state":
+            return chunk_gdn(q, k, value, gate, beta, impl="fused")[0]
+        if mode == "initial_only":
+            return chunk_gdn(q, k, value, gate, beta, state, impl="fused")[0]
+        return chunk_gdn(q, k, value, gate, beta, output_final_state=True, impl="fused")
+
+    state = inputs[5]
+    if mode == "no_state":
+        expected = chunk_gdn(*inputs[:5], impl="fused")[0]
+    elif mode == "initial_only":
+        expected = chunk_gdn(*inputs[:5], state, impl="fused")[0]
+    else:
+        expected = chunk_gdn(*inputs[:5], output_final_state=True, impl="fused")
+    actual = compiled(*inputs[:5], state)
+    if isinstance(actual, tuple):
+        for actual_tensor, expected_tensor in zip(actual, expected, strict=True):
+            torch.testing.assert_close(actual_tensor, expected_tensor, rtol=0, atol=0)
+    else:
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_public_gdn_mega_dense_batch_fullgraph() -> None:
+    """Dense B>1 packing and output reshaping must remain inside one strict graph."""
+    packed = make_gdn_test_inputs(
+        (65, 65), key_heads=1, value_heads=2, dtype=torch.bfloat16, seed=335
+    )
+    dense = tuple(tensor.reshape(2, 65, *tensor.shape[2:]) for tensor in packed[:5])
+
+    @torch.compile(fullgraph=True)
+    def compiled(q, k, value, gate, beta, state):
+        return chunk_gdn(
+            q,
+            k,
+            value,
+            gate,
+            beta,
+            state,
+            output_final_state=True,
+            impl="fused",
+        )
+
+    expected = chunk_gdn(*dense, packed[5], output_final_state=True, impl="fused")
+    actual = compiled(*dense, packed[5])
+    for actual_tensor, expected_tensor in zip(actual, expected, strict=True):
+        assert actual_tensor is not None and expected_tensor is not None
+        torch.testing.assert_close(actual_tensor, expected_tensor, rtol=0, atol=0)
+
+
+def test_public_gdn_mega_dynamic_packed_sequence_count() -> None:
+    """One dynamic strict graph must accept changing packed sequence counts."""
+    inputs = make_gdn_test_inputs((128,), key_heads=2, value_heads=2, seed=336)
+
+    @torch.compile(fullgraph=True, dynamic=True)
+    def compiled(q, k, value, gate, beta, cu_seqlens):
+        return chunk_gdn(q, k, value, gate, beta, cu_seqlens=cu_seqlens, impl="fused")[0]
+
+    for lengths in ((64, 64), (31, 0, 33, 64)):
+        offsets = [0]
+        for length in lengths:
+            offsets.append(offsets[-1] + length)
+        cu_seqlens = torch.tensor(offsets, dtype=torch.int32, device="cuda")
+        expected = chunk_gdn(*inputs[:5], cu_seqlens=cu_seqlens, impl="fused")[0]
+        actual = compiled(*inputs[:5], cu_seqlens)
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_public_gdn_mega_dynamic_dense_tokens() -> None:
+    """One dynamic fullgraph callable must reuse the dense lowering across BT64 boundaries."""
+
+    @torch.compile(fullgraph=True, dynamic=True)
+    def compiled(q, k, value, gate, beta):
+        return chunk_gdn(q, k, value, gate, beta, impl="fused")[0]
+
+    for tokens in (63, 65, 129):
+        inputs = make_gdn_test_inputs(
+            (tokens,), key_heads=2, value_heads=2, dtype=torch.bfloat16, seed=337 + tokens
+        )
+        expected = chunk_gdn(*inputs[:5], impl="fused")[0]
+        actual = compiled(*inputs[:5])
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_public_gdn_mega_cuda_graph_replay() -> None:
+    """Compiled packed stateful forward/backward must capture and replay bitwise."""
+    inputs = make_gdn_test_inputs(
+        (65, 0, 63), key_heads=2, value_heads=2, requires_grad=True, seed=347
+    )
+
+    @torch.compile(fullgraph=True)
+    def compiled_forward(q, k, value, gate, beta, state, cu_seqlens):
+        return chunk_gdn(
+            q,
+            k,
+            value,
+            gate,
+            beta,
+            state,
+            cu_seqlens=cu_seqlens,
+            output_final_state=True,
+            impl="fused",
+        )
+
+    def step(q, k, value, gate, beta, state, cu_seqlens, d_output, d_state):
+        output, final_state = compiled_forward(q, k, value, gate, beta, state, cu_seqlens)
+        assert final_state is not None
+        return torch.autograd.grad(
+            (output, final_state),
+            (q, k, value, gate, beta, state),
+            (d_output, d_state),
+        )
+
+    d_output = torch.randn_like(inputs[2])
+    d_state = torch.randn_like(inputs[5])
+    expected = step(*inputs, d_output, d_state)
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    torch.autograd.graph.set_override_stale_capture_stream(True)
+    try:
+        with torch.cuda.graph(graph):
+            captured = step(*inputs, d_output, d_state)
+    finally:
+        torch.autograd.graph.set_override_stale_capture_stream(False)
+    graph.replay()
+    torch.cuda.synchronize()
+    for actual_gradient, expected_gradient in zip(captured, expected, strict=True):
+        torch.testing.assert_close(actual_gradient, expected_gradient, rtol=0, atol=0)

--- a/test/linear/test_gdn.py
+++ b/test/linear/test_gdn.py
@@ -307,9 +307,10 @@ def test_impl_accepts_enum_and_string(function):
 
     with pytest.raises(ValueError, match="'fused', 'reference'"):
         function(*inputs[:-1], impl="eager")
-    error = NotImplementedError if function is chunk_gdn else ValueError
-    message = "impl='fused'" if function is chunk_gdn else "requires CUDA tensors"
-    with pytest.raises(error, match=message):
+    message = (
+        "Mega GDN backend requires CUDA" if function is chunk_gdn else "requires CUDA tensors"
+    )
+    with pytest.raises(ValueError, match=message):
         function(*inputs[:-1], impl=Impl.FUSED)
 
 

--- a/test/test_mega_optional_import.py
+++ b/test/test_mega_optional_import.py
@@ -18,6 +18,8 @@ import attn_gym.linear
 
 assert "attn_gym.linear._delta_rule.mega.forward" not in sys.modules
 assert "attn_gym.linear._delta_rule.mega.backward" not in sys.modules
+assert "attn_gym.linear._delta_rule.mega.gdn_forward" not in sys.modules
+assert "attn_gym.linear._delta_rule.mega.gdn_backward" not in sys.modules
 assert not any(name.startswith("attn_gym.linear._delta_rule.mega.kernels") for name in sys.modules)
 assert not any(name.startswith("cutlass.experimental") for name in sys.modules)
 """


### PR DESCRIPTION
Stacked PRs:
 * #429
 * __->__#428


--- --- ---

Integrate the Mega GDN training backend

## Human Note

## Agent note

Expose the scalar Mega kernels through `chunk_gdn(..., impl="fused")` while keeping the eager
reference as the default. GDN owns fixed-arity registered operators, lazy CUDA dispatch, honest
fakes, once-differentiable autograd, dense-to-packed lowering, grouped-head gradients, and all
initial/final-state arities.

Packed boundaries are validated on device before the opaque forward operator and remain a graph
dependency, so malformed offsets cannot reach TMA descriptor construction. Runtime layout repair
lives inside the registered CUDA boundary, which keeps eager and fullgraph behavior consistent for
misaligned or non-contiguous inputs while preserving normal zero-copy layouts. The public tests
cover all schemas with opcheck, strict forward/backward compilation, dynamic token and sequence
counts, CUDA Graph replay, dense batches, low-precision gate casts, H64/custom scale, and H4/H12
head sharing.

## Test Plan

```bash
gpu-run auto -- uv run --extra mega --with pytest pytest \
  test/gdn/mega/test_gdn_mega_training.py \
  test/linear/test_gdn.py \
  test/linear/test_gdn_fused.py \
  test/linear/test_gdn_decode.py \
  test/test_mega_optional_import.py \
  test/test_namespaces.py -q
```