### PR TITLE
Add paged chunk GDN prefill

### DIFF
--- a/attn_gym/linear/__init__.py
+++ b/attn_gym/linear/__init__.py
@@ -9,7 +9,7 @@
 import importlib
 from typing import TYPE_CHECKING
 
-from attn_gym.linear.gdn import chunk_gdn, recurrent_gdn, recurrent_gdn_decode
+from attn_gym.linear.gdn import chunk_gdn, paged_chunk_gdn, recurrent_gdn, recurrent_gdn_decode
 from attn_gym.linear.kda import (
     KernelOptions,
     active_token_mask,
@@ -43,6 +43,7 @@ KDA_OPS = [
 
 GDN_OPS = [
     "chunk_gdn",
+    "paged_chunk_gdn",
     "recurrent_gdn",
     "recurrent_gdn_decode",
 ]

--- a/attn_gym/linear/gdn/__init__.py
+++ b/attn_gym/linear/gdn/__init__.py
@@ -1,5 +1,17 @@
 """Gated delta rule attention."""
 
-from attn_gym.linear.gdn.api import KernelOptions, chunk_gdn, recurrent_gdn, recurrent_gdn_decode
+from attn_gym.linear.gdn.api import (
+    KernelOptions,
+    chunk_gdn,
+    paged_chunk_gdn,
+    recurrent_gdn,
+    recurrent_gdn_decode,
+)
 
-__all__ = ["KernelOptions", "chunk_gdn", "recurrent_gdn", "recurrent_gdn_decode"]
+__all__ = [
+    "KernelOptions",
+    "chunk_gdn",
+    "paged_chunk_gdn",
+    "recurrent_gdn",
+    "recurrent_gdn_decode",
+]

--- a/attn_gym/linear/gdn/api.py
+++ b/attn_gym/linear/gdn/api.py
@@ -13,6 +13,7 @@ from attn_gym.linear._delta_rule.validation import (
 from attn_gym.linear.gdn.impl.mega import chunk_forward as mega_chunk_forward
 from attn_gym.linear.gdn.impl.reference import chunk_forward, recurrent_forward, reference_gdn
 from attn_gym.linear.gdn.ops import chunk_forward as fused_chunk_forward
+from attn_gym.linear.gdn.ops import paged_chunk_forward as fused_paged_chunk_forward
 from attn_gym.linear.gdn.ops import recurrent_decode_forward
 from attn_gym.linear.gdn.ops import recurrent_forward as fused_recurrent_forward
 from attn_gym.linear.gdn.validation import resolve_kernel_options, validate_gdn_inputs
@@ -106,6 +107,59 @@ def chunk_gdn(
         initial_state=initial_state,
         cu_seqlens=cu_seqlens,
         output_final_state=output_final_state,
+    )
+
+
+def paged_chunk_gdn(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    state_cache: torch.Tensor,
+    state_indices: torch.Tensor,
+    *,
+    cu_seqlens: torch.Tensor | None = None,
+    has_initial_state: torch.Tensor | None = None,
+    scale: float | None = None,
+) -> torch.Tensor:
+    """Apply inference-only chunk GDN while advancing a paged state cache in place.
+
+    Requires CUDA capability 10.0 or newer.
+
+    Args:
+        q: Queries shaped ``[B, T, HK, K]``. ``HK`` may divide the value-head count.
+        k: Keys shaped like ``q`` and using the same dtype.
+        v: Values shaped ``[B, T, H, V]`` and using the same dtype as ``q``.
+        gate: Floating per-token scalar natural-log decay shaped ``[B, T, H]``.
+        beta: Floating per-token write gate shaped ``[B, T, H]``.
+        state_cache: Mutable FP32 state pool shaped ``[num_slots, H, V, K]``.
+        state_indices: Contiguous int32 slot indices, one per logical sequence. Positive,
+            unique indices select slots to advance; non-positive indices produce zero output
+            and leave the cache untouched.
+        cu_seqlens: Optional packed offsets shaped ``[N + 1]`` for batch-one inputs. Values
+            must start at zero, be nondecreasing, and end at or before the physical token
+            capacity ``T``; the tensor defines one interval per ``state_indices`` entry.
+        has_initial_state: Optional contiguous boolean mask, one per logical sequence. False
+            entries start from zero and overwrite the selected slot.
+        scale: Query scale. Defaults to ``1 / sqrt(K)``.
+
+    Returns:
+        The output in ``q.dtype``. ``state_cache`` is advanced in place.
+    """
+    validate_gdn_inputs(q, k, v, gate, beta, None, cu_seqlens)
+    validate_paged_state(q, v, state_cache, cu_seqlens, state_indices, has_initial_state)
+    return fused_paged_chunk_forward(
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        state_cache,
+        state_indices,
+        cu_seqlens=cu_seqlens,
+        has_initial_state=has_initial_state,
+        scale=resolve_scale(scale, q.shape[-1]),
     )
 
 
@@ -312,4 +366,10 @@ def recurrent_gdn_decode(
     )
 
 
-__all__ = ["KernelOptions", "chunk_gdn", "recurrent_gdn", "recurrent_gdn_decode"]
+__all__ = [
+    "KernelOptions",
+    "chunk_gdn",
+    "paged_chunk_gdn",
+    "recurrent_gdn",
+    "recurrent_gdn_decode",
+]

--- a/attn_gym/linear/gdn/impl/chunk.py
+++ b/attn_gym/linear/gdn/impl/chunk.py
@@ -10,6 +10,7 @@ from attn_gym._backends.cute import (
     normalize_tma_rows,
 )
 from attn_gym._backends.triton.utils import requires_int64_offsets
+from attn_gym.linear._delta_rule.validation import validate_paged_state
 from attn_gym.linear.gdn.bwd.triton.chunk_gdn_bwd_delta_h import chunk_gdn_bwd_delta_h
 from attn_gym.linear.gdn.bwd.triton.chunk_gdn_bwd_intra import (
     chunk_gdn_bwd_intra_dense,
@@ -41,6 +42,7 @@ from attn_gym.linear.kda.bwd.cute.chunk_kda_bwd_wy_dqkg_fused import (
 )
 from attn_gym.linear.kda.bwd.triton.chunk_kda_bwd_daqk import chunk_kda_bwd_daqk
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata, chunk_capacity
+from attn_gym.linear.kda.fwd.triton.chunk_delta_h import chunk_gated_delta_rule_fwd_h
 
 
 def validate_supported_device(q: torch.Tensor) -> None:
@@ -218,6 +220,63 @@ def _gdn_chunk_fwd_packed_with_state_cuda(
     """Registered packed forward with final state and inverse tape."""
     metadata = RaggedChunkMetadata(cu_seqlens, chunk_offsets, capacity, 64)
     return chunk_gdn_fwd_packed(q, k, v, cumulative_gate, beta, initial_state, metadata, scale)
+
+
+def _gdn_chunk_fwd_packed_paged_cuda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    state_cache: torch.Tensor,
+    state_indices: torch.Tensor,
+    has_initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor,
+    chunk_offsets: torch.Tensor,
+    capacity: int,
+    scale: float,
+) -> torch.Tensor:
+    """Run packed scalar GDN while advancing selected cache slots in place."""
+    if get_device_properties(q.device).major < 10:
+        raise ValueError("paged fused chunk_gdn requires CUDA capability 10.0 or newer")
+    metadata = RaggedChunkMetadata(cu_seqlens, chunk_offsets, capacity, 64)
+    batch, _tokens, key_heads, key_dim = q.shape
+    value_heads, value_dim = v.shape[2:]
+    if batch != 1 or (key_dim, value_dim) != (128, 128):
+        raise ValueError("paged fused chunk GDN requires B=1 and K=V=128")
+    if k.shape != q.shape or v.shape[:2] != q.shape[:2] or value_heads % key_heads:
+        raise ValueError("paged fused chunk GDN requires matching Q/K and H % HK == 0")
+    if cumulative_gate.shape != v.shape[:3] or beta.shape != v.shape[:3]:
+        raise ValueError("cumulative_gate and beta must have shape [B,T,H]")
+    validate_paged_state(
+        q,
+        v,
+        state_cache,
+        cu_seqlens,
+        state_indices,
+        has_initial_state,
+    )
+    reject_int64_offsets(q, k, v, cumulative_gate, beta)
+    q, k, v = (normalize_tma_rows(tensor) for tensor in (q, k, v))
+    cumulative_gate, beta = (
+        normalize_compact_tensor(tensor) for tensor in (cumulative_gate, beta)
+    )
+
+    w, u, restored_k, _inverse = chunk_gdn_fwd_intra_packed(k, v, cumulative_gate, beta, metadata)
+    h, v_new, final_state = chunk_gated_delta_rule_fwd_h(
+        restored_k,
+        w,
+        u,
+        cumulative_gate,
+        state_cache,
+        state_indices=state_indices,
+        has_initial_state=has_initial_state,
+        output_final_state=False,
+        metadata=metadata,
+        autotune=False,
+    )
+    assert final_state is None
+    return chunk_gdn_fwd_output_packed(q, k, v_new, h, cumulative_gate, scale, metadata)
 
 
 def chunk_gdn_bwd(

--- a/attn_gym/linear/gdn/ops.py
+++ b/attn_gym/linear/gdn/ops.py
@@ -44,6 +44,12 @@ torch.library.define(
     "attn_gym::gdn_chunk_fwd_packed_with_state",
     _CHUNK_PACKED_ARGS + " -> (Tensor, Tensor, Tensor)",
 )
+torch.library.define(
+    "attn_gym::gdn_chunk_fwd_packed_paged",
+    "(Tensor q, Tensor k, Tensor v, Tensor cumulative_gate, Tensor beta, "
+    "Tensor(a!) state_cache, Tensor state_indices, Tensor? has_initial_state, "
+    "Tensor cu_seqlens, Tensor chunk_offsets, int capacity, float scale) -> Tensor",
+)
 _RECURRENT_ARGS = (
     "(Tensor q, Tensor k, Tensor v, Tensor gate, Tensor beta, Tensor? initial_state, "
     "Tensor? cu_seqlens, float scale, bool autotune)"
@@ -94,6 +100,10 @@ def _chunk_fwd_packed_with_state_cuda(*args):
     return _chunk_backend()._gdn_chunk_fwd_packed_with_state_cuda(*args)
 
 
+def _chunk_fwd_packed_paged_cuda(*args):
+    return _chunk_backend()._gdn_chunk_fwd_packed_paged_cuda(*args)
+
+
 def _recurrent_backend():
     try:
         return importlib.import_module("attn_gym.linear.gdn.impl.fused")
@@ -136,6 +146,11 @@ torch.library.impl(
     "attn_gym::gdn_chunk_fwd_packed_with_state",
     "CUDA",
     _chunk_fwd_packed_with_state_cuda,
+)
+torch.library.impl(
+    "attn_gym::gdn_chunk_fwd_packed_paged",
+    "CUDA",
+    _chunk_fwd_packed_paged_cuda,
 )
 torch.library.impl("attn_gym::gdn_recurrent_fwd", "CUDA", _recurrent_fwd_cuda)
 torch.library.impl(
@@ -238,6 +253,24 @@ def _chunk_fwd_packed_with_state_fake(
         dtype=torch.float32,
     )
     return output, final_state, inverse
+
+
+@torch.library.register_fake("attn_gym::gdn_chunk_fwd_packed_paged")
+def _chunk_fwd_packed_paged_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    state_cache: torch.Tensor,
+    state_indices: torch.Tensor,
+    has_initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor,
+    chunk_offsets: torch.Tensor,
+    capacity: int,
+    scale: float,
+) -> torch.Tensor:
+    return torch.empty(v.shape, dtype=q.dtype, device=v.device)
 
 
 @torch.library.register_fake("attn_gym::gdn_chunk_bwd")
@@ -377,6 +410,7 @@ chunk_bwd_op = torch.ops.attn_gym.gdn_chunk_bwd.default
 chunk_bwd_with_state_grad_op = torch.ops.attn_gym.gdn_chunk_bwd_with_state_grad.default
 chunk_fwd_packed_op = torch.ops.attn_gym.gdn_chunk_fwd_packed.default
 chunk_fwd_packed_with_state_op = torch.ops.attn_gym.gdn_chunk_fwd_packed_with_state.default
+chunk_fwd_packed_paged_op = torch.ops.attn_gym.gdn_chunk_fwd_packed_paged.default
 recurrent_fwd_op = torch.ops.attn_gym.gdn_recurrent_fwd.default
 recurrent_fwd_no_state_op = torch.ops.attn_gym.gdn_recurrent_fwd_no_state.default
 recurrent_fwd_paged_op = torch.ops.attn_gym.gdn_recurrent_fwd_paged.default
@@ -499,6 +533,16 @@ class _ChunkGDN(torch.autograd.Function):
         return dq, dk, dv, d_gate, db, d_initial_state, None, None, None, None, None
 
 
+def _validate_fused_chunk_qkv(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> None:
+    """Validate the dtype, device, and fixed dimensions shared by fused chunk paths."""
+    if not q.is_cuda:
+        raise ValueError("chunk_gdn(impl='fused') requires CUDA tensors")
+    if q.dtype not in (torch.float16, torch.bfloat16) or k.dtype != q.dtype or v.dtype != q.dtype:
+        raise TypeError("chunk_gdn(impl='fused') requires matching float16 or bfloat16 QKV")
+    if q.shape[-1] != 128 or v.shape[-1] != 128:
+        raise ValueError("chunk_gdn(impl='fused') requires K=V=128")
+
+
 def chunk_forward(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -512,12 +556,7 @@ def chunk_forward(
     output_final_state: bool,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Route dense inputs and invoke the fused scalar chunk forward operator."""
-    if not q.is_cuda:
-        raise ValueError("chunk_gdn(impl='fused') requires CUDA tensors")
-    if q.dtype not in (torch.float16, torch.bfloat16) or k.dtype != q.dtype or v.dtype != q.dtype:
-        raise TypeError("chunk_gdn(impl='fused') requires matching float16 or bfloat16 QKV")
-    if q.shape[-1] != 128 or v.shape[-1] != 128:
-        raise ValueError("chunk_gdn(impl='fused') requires K=V=128")
+    _validate_fused_chunk_qkv(q, k, v)
     # The dense recurrence uses Hopper TensorDescriptors/TMA; Blackwell additionally selects
     # the CuTe backward, while Hopper uses the portable Triton backward.
     if not torch.compiler.is_compiling() and get_device_properties(q.device).major < 9:
@@ -564,6 +603,63 @@ def chunk_forward(
         output, final_state = result
         return output.reshape(output_shape), final_state
     return result.reshape(output_shape), None
+
+
+def paged_chunk_forward(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    state_cache: torch.Tensor,
+    state_indices: torch.Tensor,
+    *,
+    cu_seqlens: torch.Tensor | None,
+    has_initial_state: torch.Tensor | None,
+    scale: float,
+) -> torch.Tensor:
+    """Normalize inputs and advance selected state-cache slots with chunk GDN."""
+    _validate_fused_chunk_qkv(q, k, v)
+    if not torch.compiler.is_compiling() and get_device_properties(q.device).major < 10:
+        raise ValueError("paged_chunk_gdn requires CUDA capability 10.0 or newer")
+    tensors = (q, k, v, gate, beta, state_cache)
+    if torch.is_grad_enabled() and any(tensor.requires_grad for tensor in tensors):
+        raise RuntimeError(
+            "paged_chunk_gdn is inference-only; call under torch.no_grad() or "
+            "torch.inference_mode()"
+        )
+
+    output_shape = v.shape
+    batch, tokens = q.shape[:2]
+    if cu_seqlens is None:
+        q = q.reshape(1, batch * tokens, q.shape[2], q.shape[3])
+        k = k.reshape(1, batch * tokens, k.shape[2], k.shape[3])
+        v = v.reshape(1, batch * tokens, v.shape[2], v.shape[3])
+        gate = gate.reshape(1, batch * tokens, gate.shape[2])
+        beta = beta.reshape(1, batch * tokens, beta.shape[2])
+        cu_seqlens = torch.arange(batch + 1, dtype=torch.int32, device=q.device) * tokens
+
+    metadata = prepare_ragged_chunk_metadata(cu_seqlens, q.shape[1], 64)
+    gate = gate.float()
+    beta = beta.float()
+    cumulative_gate = _plain_gate_scan_op(
+        gate.unsqueeze(-1), metadata.cu_seqlens, metadata.chunk_offsets, False
+    ).squeeze(-1)
+    output = chunk_fwd_packed_paged_op(
+        q,
+        k,
+        v,
+        cumulative_gate,
+        beta,
+        state_cache,
+        state_indices,
+        has_initial_state,
+        metadata.cu_seqlens,
+        metadata.chunk_offsets,
+        metadata.capacity,
+        scale,
+    )
+    return output.reshape(output_shape)
 
 
 def recurrent_forward(
@@ -661,8 +757,10 @@ __all__ = [
     "chunk_forward",
     "chunk_fwd_op",
     "chunk_fwd_packed_op",
+    "chunk_fwd_packed_paged_op",
     "chunk_fwd_packed_with_state_op",
     "chunk_fwd_with_state_op",
+    "paged_chunk_forward",
     "recurrent_decode_forward",
     "recurrent_decode_op",
     "recurrent_forward",

--- a/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""Inter-chunk KDA state recurrence.
+"""Inter-chunk scalar- and vector-gated delta-rule state recurrence.
 
 A single kernel (B=1, K=V=128, 64-token chunks, Blackwell) keeps the full
 [K, BV] state in one accumulator and overlaps next-chunk descriptor loads with
@@ -53,6 +53,7 @@ def _run_chunk_delta_h_sequence(
     k,
     w,
     u,
+    gk,
     v_new,
     T,
     i_nh,
@@ -73,6 +74,7 @@ def _run_chunk_delta_h_sequence(
     USE_STATE_INDICES: tl.constexpr,
     USE_HAS_INITIAL_STATE: tl.constexpr,
     USE_INT64_OFFSETS: tl.constexpr,
+    SCALAR_GATE: tl.constexpr,
 ):
     """Process one sequence, head, and value tile through the state recurrence.
 
@@ -157,8 +159,12 @@ def _run_chunk_delta_h_sequence(
             [0, tok, i_h, i_v * BV],
             tl.reshape(b_vnew.to(k.dtype.element_ty), [1, BT, 1, BV]),
         )
-        b_decay = tl.reshape(gk_desc.load([0, tok + BT - 1, i_h, 0]), [K])
-        b_h = b_h * exp2(b_decay)[:, None]
+        if SCALAR_GATE:
+            b_decay = tl.load(gk + (tok + BT - 1) * H + i_h)
+            b_h = b_h * exp2(b_decay)
+        else:
+            b_decay = tl.reshape(gk_desc.load([0, tok + BT - 1, i_h, 0]), [K])
+            b_h = b_h * exp2(b_decay)[:, None]
         b_k = tl.reshape(k_desc.load([0, tok, i_h, 0]), [BT, K])
         b_h = tl.dot(tl.permute(b_k, [1, 0]), b_vnew.to(k.dtype.element_ty), acc=b_h)
 
@@ -190,8 +196,12 @@ def _run_chunk_delta_h_sequence(
             b_vnew.to(k.dtype.element_ty),
             mask=m_t[:, None],
         )
-        b_decay = tl.reshape(gk_desc.load([0, bos + T - 1, i_h, 0]), [K])
-        b_h = b_h * exp2(b_decay)[:, None]
+        if SCALAR_GATE:
+            b_decay = tl.load(gk + (bos + T - 1) * H + i_h)
+            b_h = b_h * exp2(b_decay)
+        else:
+            b_decay = tl.reshape(gk_desc.load([0, bos + T - 1, i_h, 0]), [K])
+            b_h = b_h * exp2(b_decay)[:, None]
         b_k = tl.load(
             k + ptr_offset((o_t[:, None], i_h, o_k[None, :]), (H * K, K, 1)),
             mask=m_t[:, None],
@@ -223,6 +233,7 @@ def chunk_delta_h_kernel_k128_wsp(
     k,
     w,
     u,
+    gk,
     v_new,
     T,
     h0_stride_0,
@@ -247,6 +258,7 @@ def chunk_delta_h_kernel_k128_wsp(
     USE_STATE_INDICES: tl.constexpr,
     USE_HAS_INITIAL_STATE: tl.constexpr,
     USE_INT64_OFFSETS: tl.constexpr,
+    SCALAR_GATE: tl.constexpr,
 ):
     """Warp-specialized K=128 inter-chunk recurrence."""
     _run_chunk_delta_h_sequence(
@@ -265,6 +277,7 @@ def chunk_delta_h_kernel_k128_wsp(
         k,
         w,
         u,
+        gk,
         v_new,
         T,
         tl.program_id(0),
@@ -285,6 +298,7 @@ def chunk_delta_h_kernel_k128_wsp(
         USE_STATE_INDICES,
         USE_HAS_INITIAL_STATE,
         USE_INT64_OFFSETS,
+        SCALAR_GATE,
     )
 
 
@@ -305,6 +319,7 @@ def chunk_delta_h_kernel_k128_persistent(
     k,
     w,
     u,
+    gk,
     v_new,
     T,
     h0_stride_0,
@@ -328,6 +343,7 @@ def chunk_delta_h_kernel_k128_persistent(
     USE_STATE_INDICES: tl.constexpr,
     USE_HAS_INITIAL_STATE: tl.constexpr,
     USE_INT64_OFFSETS: tl.constexpr,
+    SCALAR_GATE: tl.constexpr,
     NUM_SEQUENCES: tl.constexpr,
     NUM_WORKERS: tl.constexpr,
 ):
@@ -354,6 +370,7 @@ def chunk_delta_h_kernel_k128_persistent(
             k,
             w,
             u,
+            gk,
             v_new,
             T,
             i_nh,
@@ -374,6 +391,7 @@ def chunk_delta_h_kernel_k128_persistent(
             USE_STATE_INDICES,
             USE_HAS_INITIAL_STATE,
             USE_INT64_OFFSETS,
+            SCALAR_GATE,
         )
 
 
@@ -431,7 +449,10 @@ def _delta_h_launch(
     value_dim = u.shape[-1]
     h = k.new_empty(batch, capacity, heads, key_dim, value_dim)
     v_new = torch.empty_like(u)
-    if not can_use_tma(gk):
+    scalar_gate = gk.ndim == 3
+    if scalar_gate:
+        gk = gk.contiguous()
+    elif not can_use_tma(gk):
         gk = gk.clone(memory_format=torch.contiguous_format)
     state_batch = batch if cu_seqlens is None else cu_seqlens.shape[0] - 1
     compact_state_strides = (heads * value_dim * key_dim, value_dim * key_dim, key_dim, 1)
@@ -449,7 +470,7 @@ def _delta_h_launch(
         TensorDescriptor.from_tensor(u, [1, _CHUNK_SIZE, 1, block_value_dim]),
         TensorDescriptor.from_tensor(v_new, [1, _CHUNK_SIZE, 1, block_value_dim]),
         TensorDescriptor.from_tensor(h, [1, 1, 1, key_dim, block_value_dim]),
-        TensorDescriptor.from_tensor(gk, [1, 1, 1, key_dim]),
+        TensorDescriptor.from_tensor(k if scalar_gate else gk, [1, 1, 1, key_dim]),
     )
     kernel_args = (
         *descriptors,
@@ -462,6 +483,7 @@ def _delta_h_launch(
         k,
         w,
         u,
+        gk,
         v_new,
         tokens,
         *h0_strides,
@@ -484,6 +506,7 @@ def _delta_h_launch(
         "USE_INT64_OFFSETS": requires_int64_offsets(
             k, w, u, gk, v_new, h, initial_state, final_state
         ),
+        "SCALAR_GATE": scalar_gate,
         "num_warps": 4,
     }
     value_tiles = value_dim // block_value_dim
@@ -612,9 +635,11 @@ def chunk_gated_delta_rule_fwd_h(
     metadata: RaggedChunkMetadata | None = None,
     autotune: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
-    """Run the fixed-length or packed inter-chunk KDA state recurrence.
+    """Run the fixed-length or packed inter-chunk delta-rule state recurrence.
 
-    ``autotune`` is accepted for launcher-ABI parity with the other stages;
+    ``gk`` may hold one cumulative log2 decay per key channel (KDA) or one
+    scalar decay per head (GDN). ``autotune`` is accepted for launcher-ABI
+    parity with the other stages;
     the warp-specialized kernel has a single fixed configuration, so pinned
     and autotuned launches are identical.
     """
@@ -649,8 +674,8 @@ def chunk_gated_delta_rule_fwd_h(
         )
     if not (k.dtype == w.dtype == u.dtype):
         raise TypeError("the inter-chunk state recurrence requires matching k, w, and u dtypes")
-    if w.shape != k.shape or gk.shape != k.shape:
-        raise ValueError("k, w, and gk must have the same shape")
+    if w.shape != k.shape or gk.shape not in (k.shape, k.shape[:3]):
+        raise ValueError("w must match k and gk must have shape [B,T,H,K] or [B,T,H]")
     if u.shape != (batch, tokens, heads, value_dim):
         raise ValueError("u must have shape [B, T, H, V]")
     if torch.cuda.get_device_capability(k.device)[0] < 10:

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -45,8 +45,10 @@ output, final_state = chunk_gdn(
 - Separate recurrent and chunked operations with explicit initial and final state.
 - CPU and CUDA execution through eager PyTorch operations.
 - A repo-local fused chunk pipeline on CUDA capability 9.0+ with dense and packed inputs, grouped
-  Q/K heads,
-  tails, empty sequences, initial/final state, strict `torch.compile`, and CUDA Graph support.
+  Q/K heads, tails, empty sequences, initial/final state, strict `torch.compile`, and CUDA Graph
+  support. On CUDA capability 10.0+, `paged_chunk_gdn` advances selected
+  `[num_slots, H, V, K]` cache rows in place for inference prefill without caller-side
+  gather/scatter copies.
 - An opt-in Mega fused chunk implementation with the same public training/state contract.
 - An inference-only fused recurrent implementation on CUDA, including mutable paged state caches
   shaped `[num_slots, H, V, K]` selected by `state_indices`.
@@ -96,6 +98,8 @@ advances the paged FP32 state pool in place through `state_indices`, so no separ
 elementwise kernels run per decode step.
 
 ::: attn_gym.linear.chunk_gdn
+
+::: attn_gym.linear.paged_chunk_gdn
 
 ::: attn_gym.linear.recurrent_gdn
 

--- a/test/linear/test_gdn_chunk_fused.py
+++ b/test/linear/test_gdn_chunk_fused.py
@@ -9,7 +9,13 @@ import pytest
 import torch
 
 from attn_gym._backends.cute import normalize_tma_rows
-from attn_gym.linear import active_token_mask, chunk_gdn, mask_inactive_token_gradients
+from attn_gym.linear import (
+    active_token_mask,
+    chunk_gdn,
+    mask_inactive_token_gradients,
+    paged_chunk_gdn,
+    recurrent_gdn,
+)
 from attn_gym.linear.gdn.bwd.triton.chunk_gdn_bwd_intra import (
     chunk_gdn_bwd_intra_dense,
 )
@@ -18,6 +24,7 @@ from attn_gym.linear.gdn.ops import (
     chunk_bwd_with_state_grad_op,
     chunk_fwd_op,
     chunk_fwd_packed_op,
+    chunk_fwd_packed_paged_op,
     chunk_fwd_packed_with_state_op,
     chunk_fwd_with_state_op,
 )
@@ -32,6 +39,10 @@ from attn_gym.testing.kda import (
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available() or torch.cuda.get_device_capability() < (9, 0),
     reason="fused chunk GDN requires CUDA capability 9.0 or newer",
+)
+requires_blackwell = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (10, 0),
+    reason="paged chunk GDN requires CUDA capability 10.0 or newer",
 )
 
 
@@ -274,6 +285,332 @@ def test_packed_tail_ignores_nan_capacity_slack():
         atol=2e-3,
     )
     torch.testing.assert_close(actual_state, expected_state, rtol=2e-2, atol=2e-3)
+
+
+@requires_blackwell
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_paged_chunk_rejects_unsupported_qkv_dtype(dtype: torch.dtype):
+    q, k, v, gate, beta, _state = make_inputs(tokens=64, key_heads=1, value_heads=2)
+    state_cache = torch.randn(3, 2, 128, 128, device="cuda")
+    state_indices = torch.tensor([1], device="cuda", dtype=torch.int32)
+
+    with torch.no_grad(), pytest.raises(TypeError, match="matching float16 or bfloat16 QKV"):
+        paged_chunk_gdn(
+            q.to(dtype),
+            k.to(dtype),
+            v.to(dtype),
+            gate,
+            beta,
+            state_cache,
+            state_indices,
+        )
+
+
+@requires_blackwell
+def test_paged_chunk_raw_operator_registration():
+    """Validate mutation, fake output layout, and dynamic AOT dispatch."""
+    q, k, v, gate, beta, _state = make_inputs(tokens=128, key_heads=1, value_heads=2)
+    v = token_strided_like(v)
+    cu_seqlens = torch.tensor([0, 64, 128], device="cuda", dtype=torch.int32)
+    metadata = prepare_ragged_chunk_metadata(cu_seqlens, q.shape[1], 64)
+    cumulative = _plain_gate_scan_op(
+        gate.unsqueeze(-1), cu_seqlens, metadata.chunk_offsets, False
+    ).squeeze(-1)
+    state_cache = torch.randn(4, 2, 128, 128, device="cuda")
+    state_indices = torch.tensor([3, 1], device="cuda", dtype=torch.int32)
+    has_initial_state = torch.tensor([True, False], device="cuda")
+
+    torch.library.opcheck(
+        chunk_fwd_packed_paged_op,
+        (
+            q,
+            k,
+            v,
+            cumulative,
+            beta,
+            state_cache,
+            state_indices,
+            has_initial_state,
+            cu_seqlens,
+            metadata.chunk_offsets,
+            metadata.capacity,
+            128**-0.5,
+        ),
+    )
+
+
+@requires_blackwell
+def test_paged_chunk_matches_gather_scatter():
+    """Advance selected slots directly without copying state through the caller."""
+    q, k, v, gate, beta, _state = make_inputs(
+        tokens=192,
+        key_heads=1,
+        value_heads=4,
+    )
+    q, k, v = (token_strided_like(tensor) for tensor in (q, k, v))
+    assert all(normalize_tma_rows(tensor).data_ptr() == tensor.data_ptr() for tensor in (q, k, v))
+    cu_seqlens = torch.tensor([0, 65, 192], device="cuda", dtype=torch.int32)
+    state_indices = torch.tensor([4, 2], device="cuda", dtype=torch.int32)
+    has_initial_state = torch.tensor([True, False], device="cuda")
+    state_elements = 4 * 128 * 128
+    storage = torch.randn(6, state_elements + 17, device="cuda")
+    state_cache = storage[:, :state_elements].view(6, 4, 128, 128)
+    expected_storage = storage.clone()
+    expected_cache = expected_storage[:, :state_elements].view_as(state_cache)
+    expected_initial_state = torch.stack((expected_cache[4], torch.zeros_like(expected_cache[2])))
+
+    expected_output, expected_state = chunk_gdn(
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        expected_initial_state,
+        cu_seqlens=cu_seqlens,
+        output_final_state=True,
+        impl="fused",
+    )
+    assert expected_state is not None
+    expected_cache[state_indices.long()] = expected_state
+
+    with torch.no_grad():
+        actual_output = paged_chunk_gdn(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            state_cache,
+            state_indices,
+            cu_seqlens=cu_seqlens,
+            has_initial_state=has_initial_state,
+        )
+
+    torch.testing.assert_close(actual_output, expected_output, rtol=0, atol=0)
+    torch.testing.assert_close(storage, expected_storage, rtol=0, atol=0)
+
+
+@requires_blackwell
+def test_paged_chunk_dense_batch_matches_gather_scatter():
+    q, k, v, gate, beta, _state = make_inputs(
+        batch=2,
+        tokens=65,
+        key_heads=1,
+        value_heads=2,
+    )
+    state_indices = torch.tensor([3, 1], device="cuda", dtype=torch.int32)
+    state_cache = torch.randn(5, 2, 128, 128, device="cuda")
+    expected_cache = state_cache.clone()
+
+    expected_output, expected_state = chunk_gdn(
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        expected_cache[state_indices.long()].clone(),
+        output_final_state=True,
+        impl="fused",
+    )
+    assert expected_state is not None
+    expected_cache[state_indices.long()] = expected_state
+
+    with torch.no_grad():
+        actual_output = paged_chunk_gdn(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            state_cache,
+            state_indices,
+        )
+
+    torch.testing.assert_close(actual_output, expected_output, rtol=0, atol=0)
+    torch.testing.assert_close(state_cache, expected_cache, rtol=0, atol=0)
+
+
+@requires_blackwell
+def test_paged_chunk_state_continues_in_recurrent_decode():
+    """Use one paged pool directly across chunk prefill and recurrent decode."""
+    q, k, v, gate, beta, _state = make_inputs(tokens=65, key_heads=1, value_heads=2)
+    state_indices = torch.tensor([3], device="cuda", dtype=torch.int32)
+    prefill_offsets = torch.tensor([0, 64], device="cuda", dtype=torch.int32)
+    decode_offsets = torch.tensor([0, 1], device="cuda", dtype=torch.int32)
+    initial_cache = torch.randn(5, 2, 128, 128, device="cuda")
+    expected_cache = initial_cache.clone()
+    actual_cache = initial_cache.clone()
+
+    with torch.no_grad():
+        _expected_prefill, expected_state = chunk_gdn(
+            q[:, :64],
+            k[:, :64],
+            v[:, :64],
+            gate[:, :64],
+            beta[:, :64],
+            expected_cache[state_indices.long()].clone(),
+            cu_seqlens=prefill_offsets,
+            output_final_state=True,
+            impl="fused",
+        )
+        assert expected_state is not None
+        expected_cache[state_indices.long()] = expected_state
+        expected_decode, _ = recurrent_gdn(
+            q[:, 64:],
+            k[:, 64:],
+            v[:, 64:],
+            gate[:, 64:],
+            beta[:, 64:],
+            expected_cache,
+            cu_seqlens=decode_offsets,
+            state_indices=state_indices,
+        )
+
+        paged_chunk_gdn(
+            q[:, :64],
+            k[:, :64],
+            v[:, :64],
+            gate[:, :64],
+            beta[:, :64],
+            actual_cache,
+            state_indices,
+            cu_seqlens=prefill_offsets,
+        )
+        actual_decode, _ = recurrent_gdn(
+            q[:, 64:],
+            k[:, 64:],
+            v[:, 64:],
+            gate[:, 64:],
+            beta[:, 64:],
+            actual_cache,
+            cu_seqlens=decode_offsets,
+            state_indices=state_indices,
+        )
+
+    torch.testing.assert_close(actual_decode, expected_decode, rtol=0, atol=0)
+    torch.testing.assert_close(actual_cache, expected_cache, rtol=0, atol=0)
+
+
+@requires_blackwell
+def test_paged_chunk_handles_padding_and_empty_fresh_slots():
+    """Null routes stay untouched while an empty newly assigned slot is cleared."""
+    q, k, v, gate, beta, _state = make_inputs(tokens=64, key_heads=1, value_heads=2)
+    cu_seqlens = torch.tensor([0, 0, 64], device="cuda", dtype=torch.int32)
+    state_indices = torch.tensor([3, 0], device="cuda", dtype=torch.int32)
+    has_initial_state = torch.tensor([False, True], device="cuda")
+    state_cache = torch.randn(5, 2, 128, 128, device="cuda")
+    original_cache = state_cache.clone()
+
+    with torch.no_grad():
+        output = paged_chunk_gdn(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            state_cache,
+            state_indices,
+            cu_seqlens=cu_seqlens,
+            has_initial_state=has_initial_state,
+        )
+
+    torch.testing.assert_close(output, torch.zeros_like(output), rtol=0, atol=0)
+    torch.testing.assert_close(state_cache[3], torch.zeros_like(state_cache[3]), rtol=0, atol=0)
+    torch.testing.assert_close(
+        state_cache[[0, 1, 2, 4]], original_cache[[0, 1, 2, 4]], rtol=0, atol=0
+    )
+
+
+@requires_blackwell
+def test_paged_chunk_fullgraph_compile():
+    """Keep paged mutation opaque and correctly aliased under fullgraph compilation."""
+    q, k, v, gate, beta, _state = make_inputs(tokens=65, key_heads=1, value_heads=2)
+    cu_seqlens = torch.tensor([0, 31, 65], device="cuda", dtype=torch.int32)
+    state_indices = torch.tensor([3, 1], device="cuda", dtype=torch.int32)
+    has_initial_state = torch.tensor([True, False], device="cuda")
+    initial_cache = torch.randn(5, 2, 128, 128, device="cuda")
+    expected_cache = initial_cache.clone()
+    actual_cache = initial_cache.clone()
+
+    def run(state_cache):
+        return paged_chunk_gdn(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            state_cache,
+            state_indices,
+            cu_seqlens=cu_seqlens,
+            has_initial_state=has_initial_state,
+        )
+
+    with torch.no_grad():
+        expected = run(expected_cache)
+        actual = torch.compile(run, fullgraph=True)(actual_cache)
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    torch.testing.assert_close(actual_cache, expected_cache, rtol=0, atol=0)
+
+
+@requires_blackwell
+def test_paged_chunk_cuda_graph_replay():
+    """Replay changed cache routing, values, and packed boundaries."""
+    q, k, v, gate, beta, _state = make_inputs(tokens=192, key_heads=1, value_heads=2)
+    cu_seqlens = torch.tensor([0, 64, 192], device="cuda", dtype=torch.int32)
+    state_indices = torch.tensor([5, 2], device="cuda", dtype=torch.int32)
+    state_elements = 2 * 128 * 128
+    storage = torch.randn(7, state_elements + 17, device="cuda")
+    state_cache = storage[:, :state_elements].view(7, 2, 128, 128)
+    with torch.no_grad():
+        paged_chunk_gdn(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            state_cache,
+            state_indices,
+            cu_seqlens=cu_seqlens,
+        )
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.no_grad(), torch.cuda.graph(graph):
+        output = paged_chunk_gdn(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            state_cache,
+            state_indices,
+            cu_seqlens=cu_seqlens,
+        )
+
+    with torch.no_grad():
+        storage.add_(0.25)
+        state_indices.copy_(torch.tensor([6, 1], device="cuda", dtype=torch.int32))
+        cu_seqlens.copy_(torch.tensor([0, 128, 192], device="cuda", dtype=torch.int32))
+        v.mul_(0.9)
+        expected_storage = storage.clone()
+        expected_cache = expected_storage[:, :state_elements].view_as(state_cache)
+        expected = paged_chunk_gdn(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            expected_cache,
+            state_indices,
+            cu_seqlens=cu_seqlens,
+        )
+
+    graph.replay()
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+    torch.testing.assert_close(storage, expected_storage, rtol=0, atol=0)
 
 
 @pytest.mark.parametrize("portable", [False, True])

--- a/test/test_namespaces.py
+++ b/test/test_namespaces.py
@@ -4,7 +4,7 @@ import sys
 import attn_gym
 import attn_gym.linear
 import attn_gym.sparse
-from attn_gym.linear import Impl, chunk_gdn, recurrent_gdn
+from attn_gym.linear import Impl, chunk_gdn, paged_chunk_gdn, recurrent_gdn
 from attn_gym.linear.kda.api import Impl as KDAImpl
 from attn_gym.linear.types import Impl as SharedImpl
 from attn_gym.masks import (
@@ -31,6 +31,7 @@ def test_linear_impl_uses_shared_owner():
 
 def test_gdn_operations_are_exported():
     assert callable(chunk_gdn)
+    assert callable(paged_chunk_gdn)
     assert callable(recurrent_gdn)
     assert "gated_delta_rule" not in attn_gym.linear.__all__
 


### PR DESCRIPTION
Stacked PRs:
 * __->__#431
 * #425


--- --- ---

Add paged chunk GDN prefill

Add an inference-only paged_chunk_gdn API that advances selected rows of an FP32 state cache in place without caller-side gather and scatter copies. Support packed and dense batches, fresh slots, null routes, grouped Q/K heads, and direct continuation into recurrent decode.

Reuse the fused scalar chunk stages and generalize the inter-chunk recurrence to accept either scalar GDN or vector KDA cumulative gates. Register the mutating operator with fake-tensor support and cover reference parity, strided state storage, empty sequences, strict fullgraph compilation, CUDA Graph replay, exports, and documentation.