### PR TITLE
Add paged short convolution prefill

### DIFF
--- a/attn_gym/linear/__init__.py
+++ b/attn_gym/linear/__init__.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from attn_gym.linear.short_conv import (
         causal_conv1d,
         causal_conv1d_decode,
+        paged_causal_conv1d,
         register_activation,
     )
 
@@ -56,6 +57,7 @@ GENERIC_OPS = [
     "causal_conv1d",
     "causal_conv1d_decode",
     "l2norm",
+    "paged_causal_conv1d",
     "mask_inactive_token_gradients",
     "mask_inactive_tokens",
     "register_activation",
@@ -63,7 +65,12 @@ GENERIC_OPS = [
 
 __all__ = GDN_OPS + GENERIC_OPS + KDA_OPS  # noqa: PLE0605 -- built from the op groups above
 
-_SHORT_CONV_EXPORTS = {"causal_conv1d", "causal_conv1d_decode", "register_activation"}
+_SHORT_CONV_EXPORTS = {
+    "causal_conv1d",
+    "causal_conv1d_decode",
+    "paged_causal_conv1d",
+    "register_activation",
+}
 
 
 def __getattr__(name: str):

--- a/attn_gym/linear/short_conv/__init__.py
+++ b/attn_gym/linear/short_conv/__init__.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
         ShortConvTunedConfig,
         causal_conv1d,
         causal_conv1d_decode,
+        paged_causal_conv1d,
         tune_causal_conv1d,
     )
 
@@ -30,6 +31,7 @@ _BACKEND_EXPORTS = {
     "ShortConvTunedConfig": "attn_gym.linear.short_conv.cute",
     "causal_conv1d": "attn_gym.linear.short_conv.cute",
     "causal_conv1d_decode": "attn_gym.linear.short_conv.cute",
+    "paged_causal_conv1d": "attn_gym.linear.short_conv.cute",
     "register_activation": "attn_gym.linear.short_conv.activations",
     "tune_causal_conv1d": "attn_gym.linear.short_conv.cute",
 }

--- a/attn_gym/linear/short_conv/cute.py
+++ b/attn_gym/linear/short_conv/cute.py
@@ -11,8 +11,9 @@ treats every batch row as an independent sequence. Dense inputs may supply their
 preceding ``W - 1`` input positions as functional state. An optional CUDA
 ``cu_seqlens`` tensor instead delimits independent sequences packed into ``[1, T, C]``.
 Its final offset is the dynamic active endpoint and may be smaller than the physical
-capacity ``T``. Each thread owns a compile-time number of adjacent channels. Forward
-stages its input window in registers, while backward computes input gradients and FP32
+capacity ``T``. Inference prefill and decode can instead address a mutable paged history
+pool directly. Each thread owns a compile-time number of adjacent channels. Forward stages
+its input window in registers, while backward computes input gradients and FP32
 weight-gradient partials followed by a Torch reduction.
 """
 
@@ -208,7 +209,7 @@ def load_history(
     channel_group: Int32,
     width: cutlass.Constexpr,
 ):
-    """Load one vector from a sequence's caller-provided causal history."""
+    """Load one vector from a sequence's compact caller-provided history."""
     state_offset = width - 1 + input_time - sequence_start
     return (
         initial_state[
@@ -220,6 +221,40 @@ def load_history(
         .load()
         .to(Float32)
     )
+
+
+@cute.jit
+def load_paged_history(
+    state: cute.Tensor,
+    state_indices: cute.Tensor,
+    has_initial_state: cute.Tensor | None,
+    sequence: Int32,
+    input_time: Int32,
+    sequence_start: Int32,
+    channel_group: Int32,
+    channels_per_thread: cutlass.Constexpr,
+    width: cutlass.Constexpr,
+):
+    """Load selected paged history, using zeros for null and fresh slots."""
+    values = cute.make_rmem_tensor((channels_per_thread,), Float32)
+    values.fill(Float32(0.0))
+    slot = state_indices[sequence]
+    if slot > 0:
+        state_offset = width - 1 + input_time - sequence_start
+        state_groups = cute.zipped_divide(state, (1, 1, channels_per_thread))
+        if cutlass.const_expr(has_initial_state is None):  # noqa: SIM114
+            values.store(
+                state_groups[((0, 0, None), (slot, state_offset, channel_group))]
+                .load()
+                .to(Float32)
+            )
+        elif has_initial_state[sequence]:
+            values.store(
+                state_groups[((0, 0, None), (slot, state_offset, channel_group))]
+                .load()
+                .to(Float32)
+            )
+    return values.load()
 
 
 @cute.jit
@@ -235,7 +270,7 @@ def history_dot(
     channels_per_thread: cutlass.Constexpr,
     width: cutlass.Constexpr,
 ):
-    """Evaluate an early convolution dot product from staged input and history."""
+    """Evaluate an early convolution dot product from staged input and compact history."""
     products = cute.make_rmem_tensor((channels_per_thread, width), Float32)
     for tap in cutlass.range_constexpr(width):
         input_time = output_time + tap - (width - 1)
@@ -250,6 +285,50 @@ def history_dot(
                     input_time,
                     sequence_start,
                     channel_group,
+                    width,
+                )
+            )
+        products[(None, tap)].store(input_value.load() * weights[(None, tap)].load())
+    return products.load().reduce(
+        cute.ReductionOp.ADD,
+        Float32(0.0),
+        reduction_profile=(None, 1),
+    )
+
+
+@cute.jit
+def paged_history_dot(
+    inputs: cute.Tensor,
+    weights: cute.Tensor,
+    state: cute.Tensor,
+    state_indices: cute.Tensor,
+    has_initial_state: cute.Tensor | None,
+    sequence: Int32,
+    output_time: Int32,
+    sequence_start: Int32,
+    input_offset: cutlass.Constexpr,
+    channel_group: Int32,
+    channels_per_thread: cutlass.Constexpr,
+    width: cutlass.Constexpr,
+):
+    """Evaluate an early convolution dot product from staged input and paged history."""
+    products = cute.make_rmem_tensor((channels_per_thread, width), Float32)
+    for tap in cutlass.range_constexpr(width):
+        input_time = output_time + tap - (width - 1)
+        input_value = cute.make_rmem_tensor((channels_per_thread,), Float32)
+        if input_time >= sequence_start:
+            input_value.store(inputs[(None, input_offset + tap)].load().to(Float32))
+        else:
+            input_value.store(
+                load_paged_history(
+                    state,
+                    state_indices,
+                    has_initial_state,
+                    sequence,
+                    input_time,
+                    sequence_start,
+                    channel_group,
+                    channels_per_thread,
                     width,
                 )
             )
@@ -365,6 +444,8 @@ class CausalConv1dSiluForward(ShortConvKernel):
         output: cute.Tensor,
         cu_seqlens: cute.Tensor | None,
         initial_state: cute.Tensor | None,
+        state_indices: cute.Tensor | None,
+        has_initial_state: cute.Tensor | None,
         full_endpoint: cutlass.Constexpr,
     ):
         """Compute the physical time tile owned by this CTA."""
@@ -386,7 +467,8 @@ class CausalConv1dSiluForward(ShortConvKernel):
 
             x_groups = cute.zipped_divide(x, (1, self.channels_per_thread))
             output_groups = cute.zipped_divide(output, (1, self.channels_per_thread))
-            if cutlass.const_expr(initial_state is not None):
+            initial_groups = initial_state
+            if cutlass.const_expr(initial_state is not None and state_indices is None):
                 initial_groups = cute.zipped_divide(initial_state, (1, self.channels_per_thread))
             inputs = cute.make_rmem_tensor(
                 (self.channels_per_thread, self.times_per_block + self.width - 1),
@@ -428,18 +510,34 @@ class CausalConv1dSiluForward(ShortConvKernel):
                     if cutlass.const_expr(initial_state is not None):
                         value = unrolled_dot(inputs, weights, time_offset, self.width)
                         if time - (self.width - 1) < sequence_start:
-                            value = history_dot(
-                                inputs,
-                                weights,
-                                initial_groups,
-                                sequence,
-                                Int32(time),
-                                sequence_start,
-                                time_offset,
-                                channel_group,
-                                self.channels_per_thread,
-                                self.width,
-                            )
+                            if cutlass.const_expr(state_indices is None):
+                                value = history_dot(
+                                    inputs,
+                                    weights,
+                                    initial_groups,
+                                    sequence,
+                                    Int32(time),
+                                    sequence_start,
+                                    time_offset,
+                                    channel_group,
+                                    self.channels_per_thread,
+                                    self.width,
+                                )
+                            else:
+                                value = paged_history_dot(
+                                    inputs,
+                                    weights,
+                                    initial_state,
+                                    state_indices,
+                                    has_initial_state,
+                                    sequence,
+                                    Int32(time),
+                                    sequence_start,
+                                    time_offset,
+                                    channel_group,
+                                    self.channels_per_thread,
+                                    self.width,
+                                )
                     elif cutlass.const_expr(cu_seqlens is None):
                         value = unrolled_dot(inputs, weights, time_offset, self.width)
                     else:
@@ -459,9 +557,17 @@ class CausalConv1dSiluForward(ShortConvKernel):
                                         + inputs[(None, time_offset + tap)].load().to(Float32)
                                         * weights[(None, tap)].load()
                                     )
+                    value = self.activation(value).to(self.dtype.cute_type)
+                    if cutlass.const_expr(state_indices is not None):  # noqa: SIM102
+                        if state_indices[sequence] <= 0:
+                            padding = cute.make_rmem_tensor(
+                                (self.channels_per_thread,), self.dtype.cute_type
+                            )
+                            padding.fill(self.dtype.cute_type(0.0))
+                            value = padding.load()
                     output_groups[
                         ((0, None), (self.flattened_row(batch, time), channel_group))
-                    ].store(self.activation(value).to(self.dtype.cute_type))
+                    ].store(value)
 
     @cute.kernel
     def kernel(
@@ -471,17 +577,46 @@ class CausalConv1dSiluForward(ShortConvKernel):
         output: cute.Tensor,
         cu_seqlens: cute.Tensor | None,
         initial_state: cute.Tensor | None,
+        state_indices: cute.Tensor | None,
+        has_initial_state: cute.Tensor | None,
     ):
         """Dispatch one capacity tile using the runtime packed endpoint."""
         time_block, _, _ = cute.arch.block_idx()
         if cutlass.const_expr(cu_seqlens is not None):
             active_endpoint = load_ragged_token_count(cu_seqlens)
             if active_endpoint == self.tokens:
-                self.run_tile(x, weight, output, cu_seqlens, initial_state, True)
+                self.run_tile(
+                    x,
+                    weight,
+                    output,
+                    cu_seqlens,
+                    initial_state,
+                    state_indices,
+                    has_initial_state,
+                    True,
+                )
             elif time_block * self.times_per_block < active_endpoint:
-                self.run_tile(x, weight, output, cu_seqlens, initial_state, False)
+                self.run_tile(
+                    x,
+                    weight,
+                    output,
+                    cu_seqlens,
+                    initial_state,
+                    state_indices,
+                    has_initial_state,
+                    False,
+                )
         else:
-            self.run_tile(x, weight, output, cu_seqlens, initial_state, True)
+            self.run_tile(
+                x,
+                weight,
+                output,
+                cu_seqlens,
+                initial_state,
+                state_indices,
+                has_initial_state,
+                True,
+            )
 
     @cute.jit
     def __call__(
@@ -493,7 +628,7 @@ class CausalConv1dSiluForward(ShortConvKernel):
         initial_state: cute.Tensor | None,
         stream,
     ):
-        """Launch the configured forward specialization."""
+        """Launch the configured functional forward specialization."""
         self.kernel.set_name_prefix(self.get_name())
         self.kernel(
             x,
@@ -501,6 +636,46 @@ class CausalConv1dSiluForward(ShortConvKernel):
             output,
             cu_seqlens,
             initial_state,
+            None,
+            None,
+        ).launch(
+            grid=(
+                cute.ceil_div(self.tokens, self.times_per_block),
+                cute.ceil_div(self.channels, self.threads * self.channels_per_thread),
+                self.batches,
+            ),
+            block=(self.threads, 1, 1),
+            stream=stream,
+        )
+
+
+class CausalConv1dPagedForward(CausalConv1dSiluForward):
+    """Launch forward with direct paged-history addressing."""
+
+    kernel_kind = "paged_fwd"
+
+    @cute.jit
+    def __call__(
+        self,
+        x: cute.Tensor,
+        weight: cute.Tensor,
+        output: cute.Tensor,
+        cu_seqlens: cute.Tensor | None,
+        state: cute.Tensor,
+        state_indices: cute.Tensor,
+        has_initial_state: cute.Tensor | None,
+        stream,
+    ):
+        """Launch the mutable-history forward specialization."""
+        self.kernel.set_name_prefix(self.get_name())
+        self.kernel(
+            x,
+            weight,
+            output,
+            cu_seqlens,
+            state,
+            state_indices,
+            has_initial_state,
         ).launch(
             grid=(
                 cute.ceil_div(self.tokens, self.times_per_block),
@@ -616,6 +791,88 @@ class CausalConv1dSiluDecode(ShortConvKernel):
             grid=(
                 cute.ceil_div(self.channels, self.threads * self.channels_per_thread),
                 cute.size(x, mode=[0]),
+                1,
+            ),
+            block=(self.threads, 1, 1),
+            stream=stream,
+        )
+
+
+class CausalConv1dPagedStateUpdate(ShortConvKernel):
+    """Write each sequence's final causal history directly into its selected slot."""
+
+    kernel_kind = "paged_state"
+    sequence_axis = "n"
+    time_tiled = False
+
+    @cute.kernel
+    def kernel(
+        self,
+        x: cute.Tensor,
+        state: cute.Tensor,
+        state_indices: cute.Tensor,
+        has_initial_state: cute.Tensor | None,
+        cu_seqlens: cute.Tensor | None,
+    ):
+        """Advance one selected history slot without a compact staging tensor."""
+        thread_idx, _, _ = cute.arch.thread_idx()
+        channel_block, sequence, _ = cute.arch.block_idx()
+        channel_group = channel_block * self.threads + thread_idx
+        channel = channel_group * self.channels_per_thread
+
+        if channel < self.channels:
+            slot = state_indices[sequence]
+            if slot > 0:
+                if cutlass.const_expr(cu_seqlens is None):
+                    sequence_start = self.upcast_offset(sequence) * self.tokens
+                    sequence_end = sequence_start + self.tokens
+                else:
+                    sequence_start = self.upcast_offset(Int32(cu_seqlens[sequence]))
+                    sequence_end = self.upcast_offset(Int32(cu_seqlens[sequence + 1]))
+                sequence_length = sequence_end - sequence_start
+                x_groups = cute.zipped_divide(x, (1, self.channels_per_thread))
+                state_groups = cute.zipped_divide(state, (1, 1, self.channels_per_thread))
+
+                for row in cutlass.range_constexpr(self.width - 1):
+                    values = cute.make_rmem_tensor(
+                        (self.channels_per_thread,), self.dtype.cute_type
+                    )
+                    values.fill(self.dtype.cute_type(0.0))
+                    input_time = sequence_end - (self.width - 1) + row
+                    if input_time >= sequence_start:
+                        values.store(x_groups[((0, None), (input_time, channel_group))].load())
+                    # For short sequences the source row is ``row + sequence_length``,
+                    # so ascending stores cannot overwrite a value before it is read.
+                    elif cutlass.const_expr(has_initial_state is None):  # noqa: SIM114
+                        values.store(
+                            state_groups[
+                                ((0, 0, None), (slot, row + sequence_length, channel_group))
+                            ].load()
+                        )
+                    elif has_initial_state[sequence]:
+                        values.store(
+                            state_groups[
+                                ((0, 0, None), (slot, row + sequence_length, channel_group))
+                            ].load()
+                        )
+                    state_groups[((0, 0, None), (slot, row, channel_group))].store(values.load())
+
+    @cute.jit
+    def __call__(
+        self,
+        x: cute.Tensor,
+        state: cute.Tensor,
+        state_indices: cute.Tensor,
+        has_initial_state: cute.Tensor | None,
+        cu_seqlens: cute.Tensor | None,
+        stream,
+    ):
+        """Launch one state-update task per sequence and channel group."""
+        self.kernel.set_name_prefix(self.get_name())
+        self.kernel(x, state, state_indices, has_initial_state, cu_seqlens).launch(
+            grid=(
+                cute.ceil_div(self.channels, self.threads * self.channels_per_thread),
+                self.sequences,
                 1,
             ),
             block=(self.threads, 1, 1),
@@ -2733,6 +2990,53 @@ def _validate_decode_inputs(
         )
 
 
+def _validate_paged_inputs(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    state: torch.Tensor,
+    state_indices: torch.Tensor,
+    has_initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+) -> None:
+    """Validate multi-token convolution over a mutable paged history pool."""
+    _validate_inputs(x, weight, cu_seqlens)
+    if weight.shape[1] < 2:
+        raise ValueError("paged causal convolution requires W >= 2; width one carries no history")
+
+    sequences = x.shape[0] if cu_seqlens is None else cu_seqlens.shape[0] - 1
+    channels = x.shape[2]
+    expected_tail = (weight.shape[1] - 1, channels)
+    if state.ndim != 3 or state.shape[1:] != expected_tail or state.shape[0] < 1:
+        raise ValueError(
+            f"state must have shape [num_slots, {expected_tail[0]}, {channels}], "
+            f"got {tuple(state.shape)}"
+        )
+    if state.dtype != x.dtype or state.device != x.device:
+        raise ValueError("state must match x dtype and be on x.device")
+    if state.stride()[1:] != (channels, 1):
+        raise ValueError("state must be contiguous within each [W - 1, C] slot")
+    if state.stride(0) < (weight.shape[1] - 1) * channels:
+        raise ValueError("state slots must not overlap")
+    if (
+        state_indices.shape != (sequences,)
+        or state_indices.dtype != torch.int32
+        or state_indices.device != x.device
+        or not state_indices.is_contiguous()
+    ):
+        raise ValueError(
+            f"state_indices must be contiguous int32 with shape ({sequences},) on x.device"
+        )
+    if has_initial_state is not None and (
+        has_initial_state.shape != (sequences,)
+        or has_initial_state.dtype != torch.bool
+        or has_initial_state.device != x.device
+        or not has_initial_state.is_contiguous()
+    ):
+        raise ValueError(
+            f"has_initial_state must be contiguous bool with shape ({sequences},) on x.device"
+        )
+
+
 def _aligned(tensor: torch.Tensor) -> torch.Tensor:
     """Materialize the uncommon contiguous view that misses the launcher ABI alignment."""
     return tensor if tensor.data_ptr() % 16 == 0 else tensor.clone()
@@ -3163,6 +3467,88 @@ def _fake_decode_state(dtype: ShortConvDType, width: int, channels: int):
     )
 
 
+def _fake_has_initial_state(enabled: bool):
+    """Create a runtime-bound fresh-slot mask or preserve the all-resumed specialization."""
+    if not enabled:
+        return None
+    return cute.runtime.make_fake_compact_tensor(
+        cutlass.Boolean,
+        (cute.sym_int32(),),
+        stride_order=(0,),
+        assumed_align=1,
+    )
+
+
+@jit_cache
+def _compile_paged_forward(
+    batches: int,
+    tokens: int,
+    channels: int,
+    width: int,
+    dtype: ShortConvDType,
+    config: ShortConvConfig,
+    num_sequences: int,
+    packed: bool,
+    use_has_initial_state: bool,
+    activation: Activation,
+    use_int64_offsets: bool = False,
+):
+    """Compile a forward specialization that reads history directly from paged slots."""
+    operation = CausalConv1dPagedForward(
+        batches,
+        tokens,
+        channels,
+        width,
+        config,
+        dtype,
+        activation.forward,
+        use_int64_offsets,
+    )
+    return compile_tvm_ffi(
+        operation,
+        _fake_matrix(dtype, batches * tokens, channels),
+        _fake_matrix(dtype, channels, width),
+        _fake_matrix(dtype, batches * tokens, channels),
+        _fake_cu_seqlens(num_sequences if packed else None),
+        _fake_decode_state(dtype, width, channels),
+        _fake_state_indices(True),
+        _fake_has_initial_state(use_has_initial_state),
+    )
+
+
+@jit_cache
+def _compile_paged_state_update(
+    batches: int,
+    tokens: int,
+    channels: int,
+    width: int,
+    dtype: ShortConvDType,
+    config: ShortConvConfig,
+    num_sequences: int,
+    packed: bool,
+    use_has_initial_state: bool,
+    use_int64_offsets: bool = False,
+):
+    """Compile the direct final-history write for paged prefill."""
+    operation = CausalConv1dPagedStateUpdate(
+        num_sequences,
+        tokens,
+        channels,
+        width,
+        config,
+        dtype,
+        use_int64_offsets,
+    )
+    return compile_tvm_ffi(
+        operation,
+        _fake_matrix(dtype, batches * tokens, channels),
+        _fake_decode_state(dtype, width, channels),
+        _fake_state_indices(True),
+        _fake_has_initial_state(use_has_initial_state),
+        _fake_cu_seqlens(num_sequences if packed else None),
+    )
+
+
 @jit_cache
 def _compile_decode(
     channels: int,
@@ -3215,6 +3601,72 @@ def _launch_decode(
     return output
 
 
+def _launch_paged_forward(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    state: torch.Tensor,
+    state_indices: torch.Tensor,
+    has_initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+    config: ShortConvConfig,
+    *,
+    activation: str | None,
+) -> torch.Tensor:
+    """Run paged prefill and advance selected history slots in place."""
+    resolved_activation = resolve_activation(activation)
+    x, weight = _aligned(x), _aligned(weight)
+    if state.data_ptr() % 16 != 0:
+        raise ValueError("state storage must be 16-byte aligned for the in-place advance")
+    batches, tokens, channels = x.shape
+    width = weight.shape[1]
+    num_sequences = state_indices.shape[0]
+    packed = cu_seqlens is not None
+    _validate_config(config, channels, "forward_config")
+    dtype = SHORT_CONV_DTYPES[x.dtype]
+    output = torch.empty_like(x)
+    use_int64_offsets = requires_int64_abi(x, output)
+    _compile_paged_forward(
+        batches,
+        tokens,
+        channels,
+        width,
+        dtype,
+        config,
+        num_sequences,
+        packed,
+        has_initial_state is not None,
+        resolved_activation,
+        use_int64_offsets,
+    )(
+        x.view(batches * tokens, channels),
+        weight,
+        output.view(batches * tokens, channels),
+        cu_seqlens,
+        state,
+        state_indices,
+        has_initial_state,
+    )
+    _compile_paged_state_update(
+        batches,
+        tokens,
+        channels,
+        width,
+        dtype,
+        ShortConvConfig(config.threads, config.channels_per_thread, 1),
+        num_sequences,
+        packed,
+        has_initial_state is not None,
+        use_int64_offsets,
+    )(
+        x.view(batches * tokens, channels),
+        state,
+        state_indices,
+        has_initial_state,
+        cu_seqlens,
+    )
+    return output
+
+
 def _cute_short_conv_fwd_cuda(
     x: torch.Tensor,
     weight: torch.Tensor,
@@ -3247,6 +3699,50 @@ def _default_forward_fake(
     activation: str | None = None,
 ) -> torch.Tensor:
     del weight, cu_seqlens, initial_state, activation
+    return torch.empty_like(x)
+
+
+def _cute_short_conv_paged_fwd_cuda(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    state: torch.Tensor,
+    state_indices: torch.Tensor,
+    has_initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+    *,
+    activation: str | None = None,
+) -> torch.Tensor:
+    """Launch paged prefill with the tuned forward defaults."""
+    _validate_paged_inputs(x, weight, state, state_indices, has_initial_state, cu_seqlens)
+    default = ShortConvTunedConfig.default(x.dtype, packed=cu_seqlens is not None).forward
+    config = _compatible_config(default, x.shape[2])
+    return _launch_paged_forward(
+        x,
+        weight,
+        state,
+        state_indices,
+        has_initial_state,
+        cu_seqlens,
+        config,
+        activation=activation,
+    )
+
+
+torch.library.impl("attn_gym::_cute_short_conv_paged_fwd", "CUDA", _cute_short_conv_paged_fwd_cuda)
+
+
+@torch.library.register_fake("attn_gym::_cute_short_conv_paged_fwd")
+def _paged_forward_fake(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    state: torch.Tensor,
+    state_indices: torch.Tensor,
+    has_initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+    *,
+    activation: str | None = None,
+) -> torch.Tensor:
+    del weight, state, state_indices, has_initial_state, cu_seqlens, activation
     return torch.empty_like(x)
 
 
@@ -3956,6 +4452,68 @@ def causal_conv1d(
     )
 
 
+def paged_causal_conv1d(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    state_cache: torch.Tensor,
+    state_indices: torch.Tensor,
+    *,
+    activation: str | None = None,
+    cu_seqlens: torch.Tensor | None = None,
+    has_initial_state: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Apply multi-token convolution while advancing a paged history in place.
+
+    Args:
+        x: Contiguous ``[B, T, C]`` input. With ``cu_seqlens``, ``B`` must be one
+            and the physical token axis contains packed logical sequences.
+        weight: Contiguous depthwise weights ``[C, W]`` with ``W >= 2``.
+        state_cache: Mutable history pool ``[num_slots, W - 1, C]``. Each slot
+            must be compact, while padding between slots is supported. The storage
+            base must be 16-byte aligned.
+        state_indices: Contiguous int32 slot indices, one per logical sequence.
+            Positive indices must be unique and less than ``state_cache.shape[0]``.
+            Non-positive entries produce zero output and leave the pool untouched.
+        activation: Any registered activation name, or ``None``.
+        cu_seqlens: Optional contiguous int32 packed boundaries ``[N + 1]``.
+        has_initial_state: Optional contiguous bool mask with one entry per
+            sequence. False entries read zero history before overwriting the slot.
+
+    Returns:
+        The activated output with the same shape and dtype as ``x``. For packed input,
+        only rows before ``cu_seqlens[-1]`` are defined. ``state_cache`` is advanced in place.
+        Empty fresh sequences clear their selected history; empty resumed sequences
+        preserve it.
+
+    This operation is inference-only. Use :func:`causal_conv1d` for autograd.
+    """
+    resolve_activation(activation)
+    _validate_paged_inputs(
+        x,
+        weight,
+        state_cache,
+        state_indices,
+        has_initial_state,
+        cu_seqlens,
+    )
+    if torch.is_grad_enabled() and any(
+        tensor.requires_grad for tensor in (x, weight, state_cache)
+    ):
+        raise RuntimeError(
+            "paged_causal_conv1d is inference-only and has no backward; use "
+            "causal_conv1d for training or call under torch.no_grad()"
+        )
+    return short_conv_ops.short_conv_paged_forward_op(
+        x,
+        weight,
+        state_cache,
+        state_indices,
+        has_initial_state,
+        cu_seqlens,
+        activation=activation,
+    )
+
+
 def causal_conv1d_decode(
     x: torch.Tensor,
     weight: torch.Tensor,
@@ -4024,5 +4582,6 @@ __all__ = [
     "ShortConvTunedConfig",
     "causal_conv1d",
     "causal_conv1d_decode",
+    "paged_causal_conv1d",
     "tune_causal_conv1d",
 ]

--- a/attn_gym/linear/short_conv/ops.py
+++ b/attn_gym/linear/short_conv/ops.py
@@ -26,6 +26,11 @@ torch.library.define(
     " *, str? activation=None) -> Tensor",
 )
 torch.library.define(
+    "attn_gym::_cute_short_conv_paged_fwd",
+    "(Tensor x, Tensor weight, Tensor(a!) state, Tensor state_indices,"
+    " Tensor? has_initial_state, Tensor? cu_seqlens, *, str? activation=None) -> Tensor",
+)
+torch.library.define(
     "attn_gym::_cute_short_conv_configured_decode",
     "(Tensor x, Tensor weight, Tensor(a!) state, Tensor? state_indices,"
     " int forward_threads, int forward_channels, int forward_times,"
@@ -65,6 +70,7 @@ torch.library.define(
 short_conv_forward_op = torch.ops.attn_gym._cute_short_conv_fwd.default
 short_conv_backward_op = torch.ops.attn_gym._cute_short_conv_bwd.default
 short_conv_decode_op = torch.ops.attn_gym._cute_short_conv_decode.default
+short_conv_paged_forward_op = torch.ops.attn_gym._cute_short_conv_paged_fwd.default
 short_conv_configured_forward_op = torch.ops.attn_gym._cute_short_conv_configured_fwd.default
 short_conv_configured_backward_op = torch.ops.attn_gym._cute_short_conv_configured_bwd.default
 short_conv_configured_backward_with_state_grad_op = (
@@ -80,4 +86,5 @@ __all__ = [
     "short_conv_configured_forward_op",
     "short_conv_decode_op",
     "short_conv_forward_op",
+    "short_conv_paged_forward_op",
 ]

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -105,6 +105,23 @@ elementwise kernels run per decode step.
 
 ::: attn_gym.linear.recurrent_gdn_decode
 
+## Stateful Short Convolution
+
+`causal_conv1d` is the differentiable dense or packed operation. It accepts compact
+per-sequence history and can return a newly allocated final history. Serving callers can keep
+history in a shared `[num_slots, W - 1, C]` pool instead: `paged_causal_conv1d` reads selected
+slots during multi-token prefill and advances them in place, while `causal_conv1d_decode` does
+the same for one token per sequence. Both are inference-only and support padding between slots.
+Positive `state_indices` must be unique and within the pool; non-positive routes return zero without
+touching it. `has_initial_state=False` gives paged prefill a zero history before it overwrites a
+fresh slot.
+
+::: attn_gym.linear.causal_conv1d
+
+::: attn_gym.linear.paged_causal_conv1d
+
+::: attn_gym.linear.causal_conv1d_decode
+
 ## Kimi Delta Attention
 
 The KDA references use token-major tensors: query, key, and per-channel gate are

--- a/test/test_namespaces.py
+++ b/test/test_namespaces.py
@@ -70,6 +70,7 @@ def test_base_import_does_not_require_numpy():
     subprocess.run([sys.executable, "-c", script], check=True)
 
 
-def test_short_conv_decode_uses_decode_name():
+def test_short_conv_operations_are_exported():
     assert "causal_conv1d_decode" in attn_gym.linear.__all__
+    assert "paged_causal_conv1d" in attn_gym.linear.__all__
     assert "causal_conv1d_update" not in attn_gym.linear.__all__

--- a/test/test_short_conv_cute.py
+++ b/test/test_short_conv_cute.py
@@ -18,6 +18,7 @@ from attn_gym.linear.short_conv.cute import (
     _candidate_configs,
     causal_conv1d,
     causal_conv1d_decode,
+    paged_causal_conv1d,
     tune_causal_conv1d,
 )
 from attn_gym.linear.short_conv.ops import (
@@ -40,6 +41,9 @@ from attn_gym.linear.short_conv.ops import (
 )
 from attn_gym.linear.short_conv.ops import (
     short_conv_forward_op as _forward_op,
+)
+from attn_gym.linear.short_conv.ops import (
+    short_conv_paged_forward_op as _paged_forward_op,
 )
 
 
@@ -156,6 +160,48 @@ def _misaligned_inputs(tokens: int = 17, channels: int = 12, width: int = 4):
     assert x.is_contiguous() and x.data_ptr() % 16 != 0
     assert weight.is_contiguous() and weight.data_ptr() % 16 != 0
     return x, weight
+
+
+def _paged_prefill_reference(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    state: torch.Tensor,
+    state_indices: torch.Tensor,
+    has_initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Apply the existing compact-state path around explicit gather and scatter."""
+    sequences = x.shape[0] if cu_seqlens is None else cu_seqlens.shape[0] - 1
+    initial_state = x.new_zeros(sequences, weight.shape[1] - 1, x.shape[2])
+    for sequence, slot in enumerate(state_indices.cpu().tolist()):
+        resumed = has_initial_state is None or bool(has_initial_state[sequence].item())
+        if slot > 0 and resumed:
+            initial_state[sequence].copy_(state[slot])
+    output, final_state = causal_conv1d(
+        x,
+        weight,
+        activation="silu",
+        cu_seqlens=cu_seqlens,
+        initial_state=initial_state,
+        return_final_state=True,
+    )
+    expected_state = state.clone()
+    if cu_seqlens is None:
+        for sequence, slot in enumerate(state_indices.cpu().tolist()):
+            if slot > 0:
+                expected_state[slot].copy_(final_state[sequence])
+            else:
+                output[sequence].zero_()
+    else:
+        offsets = cu_seqlens.cpu().tolist()
+        for sequence, (slot, (start, end)) in enumerate(
+            zip(state_indices.cpu().tolist(), pairwise(offsets), strict=True)
+        ):
+            if slot > 0:
+                expected_state[slot].copy_(final_state[sequence])
+            else:
+                output[:, start:end].zero_()
+    return output, expected_state
 
 
 def _decode_conv(x, weight, activation="silu"):
@@ -1784,6 +1830,350 @@ def test_short_conv_decode_registered_custom_activation():
     actual = _decode_conv(x, weight, "tanh")
     expected = torch.tanh(_plain_conv_reference(x, weight))
     torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("packed", [False, True])
+def test_paged_short_conv_prefill_matches_gather_scatter(
+    packed: bool,
+    dtype: torch.dtype,
+):
+    """Read and advance selected slots without compact caller-side state copies."""
+    torch.manual_seed(101)
+    channels, width = 12, 4
+    if packed:
+        lengths = (5, 16, 19)
+        offsets = torch.tensor((0, 5, 21, 40), device="cuda", dtype=torch.int32)
+        x = torch.randn(1, sum(lengths), channels, device="cuda", dtype=dtype)
+        state_indices = torch.tensor((4, 2, 5), device="cuda", dtype=torch.int32)
+    else:
+        offsets = None
+        x = torch.randn(3, 5, channels, device="cuda", dtype=dtype)
+        state_indices = torch.tensor((4, 0, 5), device="cuda", dtype=torch.int32)
+    weight = torch.randn(channels, width, device="cuda", dtype=x.dtype)
+    has_initial_state = torch.tensor((False, True, False), device="cuda")
+    state = torch.randn(7, width - 1, channels, device="cuda", dtype=x.dtype)
+    expected_output, expected_state = _paged_prefill_reference(
+        x,
+        weight,
+        state,
+        state_indices,
+        has_initial_state,
+        offsets,
+    )
+
+    with torch.no_grad():
+        actual = paged_causal_conv1d(
+            x,
+            weight,
+            state,
+            state_indices,
+            activation="silu",
+            cu_seqlens=offsets,
+            has_initial_state=has_initial_state,
+        )
+
+    torch.testing.assert_close(actual, expected_output, rtol=0, atol=0)
+    torch.testing.assert_close(state, expected_state, rtol=0, atol=0)
+
+
+def test_paged_short_conv_prefill_forced_int64_matches_default(monkeypatch):
+    """Widen paged input addresses without changing output or state mutation."""
+    torch.manual_seed(107)
+    channels, width = 12, 4
+    offsets = torch.tensor((0, 2, 7), device="cuda", dtype=torch.int32)
+    x = torch.randn(1, 7, channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(channels, width, device="cuda", dtype=x.dtype)
+    state_indices = torch.tensor((4, 2), device="cuda", dtype=torch.int32)
+    initial_state = torch.randn(6, width - 1, channels, device="cuda", dtype=x.dtype)
+
+    expected_state = initial_state.clone()
+    actual_state = initial_state.clone()
+    with torch.no_grad():
+        expected = paged_causal_conv1d(
+            x,
+            weight,
+            expected_state,
+            state_indices,
+            activation="silu",
+            cu_seqlens=offsets,
+        )
+        monkeypatch.setattr(cute_backend, "requires_int64_abi", lambda *tensors: True)
+        actual = paged_causal_conv1d(
+            x,
+            weight,
+            actual_state,
+            state_indices,
+            activation="silu",
+            cu_seqlens=offsets,
+        )
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    torch.testing.assert_close(actual_state, expected_state, rtol=0, atol=0)
+
+
+def test_paged_short_conv_prefill_handles_null_routes_and_strided_slots():
+    """Leave null routes and page padding untouched while advancing live slots."""
+    torch.manual_seed(102)
+    channels, width = 12, 4
+    offsets = torch.tensor((0, 2, 5, 6), device="cuda", dtype=torch.int32)
+    x = torch.randn(1, 6, channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(channels, width, device="cuda", dtype=x.dtype)
+    state_indices = torch.tensor((3, 0, -1), device="cuda", dtype=torch.int32)
+    has_initial_state = torch.tensor((True, False, False), device="cuda")
+    state_elements = (width - 1) * channels
+    storage = torch.randn(6, state_elements + 8, device="cuda", dtype=x.dtype)
+    state = storage[:, :state_elements].view(6, width - 1, channels)
+    expected_output, expected_state = _paged_prefill_reference(
+        x,
+        weight,
+        state,
+        state_indices,
+        has_initial_state,
+        offsets,
+    )
+    expected_storage = storage.clone()
+    expected_storage[:, :state_elements].view_as(state).copy_(expected_state)
+
+    with torch.no_grad():
+        actual = paged_causal_conv1d(
+            x,
+            weight,
+            state,
+            state_indices,
+            activation="silu",
+            cu_seqlens=offsets,
+            has_initial_state=has_initial_state,
+        )
+
+    torch.testing.assert_close(actual, expected_output, rtol=0, atol=0)
+    torch.testing.assert_close(storage, expected_storage, rtol=0, atol=0)
+
+
+def test_paged_short_conv_prefill_all_empty_fresh_and_resumed_slots():
+    """Clear fresh empty slots while preserving resumed empty histories."""
+    torch.manual_seed(106)
+    channels, width = 12, 4
+    x = torch.randn(1, 4, channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(channels, width, device="cuda", dtype=x.dtype)
+    state = torch.randn(6, width - 1, channels, device="cuda", dtype=x.dtype)
+    original = state.clone()
+    state_indices = torch.tensor((4, 2), device="cuda", dtype=torch.int32)
+    has_initial_state = torch.tensor((False, True), device="cuda")
+    offsets = torch.tensor((0, 0, 0), device="cuda", dtype=torch.int32)
+
+    with torch.no_grad():
+        paged_causal_conv1d(
+            x,
+            weight,
+            state,
+            state_indices,
+            activation="silu",
+            cu_seqlens=offsets,
+            has_initial_state=has_initial_state,
+        )
+
+    torch.testing.assert_close(state[4], torch.zeros_like(state[4]), rtol=0, atol=0)
+    torch.testing.assert_close(state[2], original[2], rtol=0, atol=0)
+    torch.testing.assert_close(state[[0, 1, 3, 5]], original[[0, 1, 3, 5]], rtol=0, atol=0)
+
+
+def test_paged_short_conv_prefill_continues_in_decode():
+    """Share one paged history pool directly between prefill and one-token decode."""
+    torch.manual_seed(103)
+    channels, width = 12, 4
+    offsets = torch.tensor((0, 2, 7), device="cuda", dtype=torch.int32)
+    x = torch.randn(1, 7, channels, device="cuda", dtype=torch.bfloat16)
+    next_token = torch.randn(2, channels, device="cuda", dtype=x.dtype)
+    weight = torch.randn(channels, width, device="cuda", dtype=x.dtype)
+    state_indices = torch.tensor((4, 2), device="cuda", dtype=torch.int32)
+    has_initial_state = torch.tensor((False, True), device="cuda")
+    state = torch.randn(6, width - 1, channels, device="cuda", dtype=x.dtype)
+    _expected_prefill, expected_state = _paged_prefill_reference(
+        x,
+        weight,
+        state,
+        state_indices,
+        has_initial_state,
+        offsets,
+    )
+
+    with torch.no_grad():
+        expected_decode = causal_conv1d_decode(
+            next_token,
+            weight,
+            expected_state,
+            activation="silu",
+            state_indices=state_indices,
+        )
+        paged_causal_conv1d(
+            x,
+            weight,
+            state,
+            state_indices,
+            activation="silu",
+            cu_seqlens=offsets,
+            has_initial_state=has_initial_state,
+        )
+        actual_decode = causal_conv1d_decode(
+            next_token,
+            weight,
+            state,
+            activation="silu",
+            state_indices=state_indices,
+        )
+
+    torch.testing.assert_close(actual_decode, expected_decode, rtol=0, atol=0)
+    torch.testing.assert_close(state, expected_state, rtol=0, atol=0)
+
+
+def test_paged_short_conv_prefill_fullgraph_and_registration():
+    """Keep paged mutation opaque under opcheck and strict graph capture."""
+    torch.manual_seed(104)
+    channels, width = 6, 4
+    offsets = torch.tensor((0, 2, 7), device="cuda", dtype=torch.int32)
+    x = torch.randn(1, 7, channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(channels, width, device="cuda", dtype=x.dtype)
+    state_indices = torch.tensor((4, 2), device="cuda", dtype=torch.int32)
+    has_initial_state = torch.tensor((True, False), device="cuda")
+    initial_state = torch.randn(6, width - 1, channels, device="cuda", dtype=x.dtype)
+    torch.library.opcheck(
+        _paged_forward_op,
+        (x, weight, initial_state.clone(), state_indices, has_initial_state, offsets),
+    )
+    dense_x = torch.randn(2, 5, channels, device="cuda", dtype=x.dtype)
+    torch.library.opcheck(
+        _paged_forward_op,
+        (dense_x, weight, initial_state.clone(), state_indices, None, None),
+    )
+
+    def run(state):
+        return paged_causal_conv1d(
+            x,
+            weight,
+            state,
+            state_indices,
+            activation="silu",
+            cu_seqlens=offsets,
+            has_initial_state=has_initial_state,
+        )
+
+    expected_state = initial_state.clone()
+    actual_state = initial_state.clone()
+    with torch.no_grad():
+        expected = run(expected_state)
+        actual = torch.compile(run, fullgraph=True)(actual_state)
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    torch.testing.assert_close(actual_state, expected_state, rtol=0, atol=0)
+
+
+def test_paged_short_conv_prefill_dynamic_dense_tokens():
+    """Reuse one strict graph across dense token counts without recompilation."""
+    torch.manual_seed(108)
+    channels, width = 12, 4
+    weight = torch.randn(channels, width, device="cuda", dtype=torch.bfloat16)
+    state_indices = torch.tensor((4, 2), device="cuda", dtype=torch.int32)
+
+    def run(x, state):
+        return paged_causal_conv1d(x, weight, state, state_indices, activation="silu")
+
+    compiled = torch.compile(run, fullgraph=True, dynamic=True)
+    with torch._dynamo.config.patch(error_on_recompile=True), torch.no_grad():
+        for tokens in (5, 9):
+            x = torch.randn(2, tokens, channels, device="cuda", dtype=weight.dtype)
+            initial_state = torch.randn(6, width - 1, channels, device="cuda", dtype=weight.dtype)
+            expected_state = initial_state.clone()
+            actual_state = initial_state.clone()
+            expected_output, expected_state = _paged_prefill_reference(
+                x,
+                weight,
+                expected_state,
+                state_indices,
+                None,
+                None,
+            )
+            actual_output = compiled(x, actual_state)
+            torch.testing.assert_close(actual_output, expected_output, rtol=0, atol=0)
+            torch.testing.assert_close(actual_state, expected_state, rtol=0, atol=0)
+
+
+def test_paged_short_conv_prefill_cuda_graph_replays_routing():
+    """Replay changed boundaries, freshness, slot routing, and input values."""
+    torch.manual_seed(105)
+    channels, width = 12, 4
+    x = torch.randn(1, 8, channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(channels, width, device="cuda", dtype=x.dtype)
+    state = torch.randn(7, width - 1, channels, device="cuda", dtype=x.dtype)
+    state_indices = torch.tensor((4, 2), device="cuda", dtype=torch.int32)
+    has_initial_state = torch.tensor((True, False), device="cuda")
+    offsets = torch.tensor((0, 3, 8), device="cuda", dtype=torch.int32)
+
+    with torch.no_grad():
+        paged_causal_conv1d(
+            x,
+            weight,
+            state,
+            state_indices,
+            activation="silu",
+            cu_seqlens=offsets,
+            has_initial_state=has_initial_state,
+        )
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.no_grad(), torch.cuda.graph(graph):
+        output = paged_causal_conv1d(
+            x,
+            weight,
+            state,
+            state_indices,
+            activation="silu",
+            cu_seqlens=offsets,
+            has_initial_state=has_initial_state,
+        )
+
+    with torch.no_grad():
+        x.add_(0.25)
+        state.normal_()
+        state_indices.copy_(torch.tensor((5, 1), device="cuda", dtype=torch.int32))
+        has_initial_state.copy_(torch.tensor((False, True), device="cuda"))
+        offsets.copy_(torch.tensor((0, 5, 8), device="cuda", dtype=torch.int32))
+        expected_output, expected_state = _paged_prefill_reference(
+            x,
+            weight,
+            state,
+            state_indices,
+            has_initial_state,
+            offsets,
+        )
+
+    graph.replay()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(output, expected_output, rtol=0, atol=0)
+    torch.testing.assert_close(state, expected_state, rtol=0, atol=0)
+
+
+def test_paged_short_conv_prefill_rejects_autograd_and_malformed_state():
+    x, weight = _inputs(tokens=4, channels=12, width=4)
+    state = torch.randn(4, 3, 12, device="cuda", dtype=x.dtype)
+    state_indices = torch.tensor((2,), device="cuda", dtype=torch.int32)
+    with pytest.raises(RuntimeError, match="inference-only"):
+        paged_causal_conv1d(x, weight, state, state_indices)
+    with pytest.raises(ValueError, match="W >= 2"):
+        paged_causal_conv1d(
+            x.detach(),
+            weight[:, :1].detach().contiguous(),
+            state[:, :0],
+            state_indices,
+        )
+    with pytest.raises(ValueError, match="has_initial_state"):
+        paged_causal_conv1d(
+            x.detach(),
+            weight.detach(),
+            state,
+            state_indices,
+            has_initial_state=torch.ones(2, device="cuda", dtype=torch.bool),
+        )
 
 
 def test_short_conv_decode_activation_registration_contract():


### PR DESCRIPTION
Add paged short convolution prefill

## Human Note

## Agent note

Add an inference-only `paged_causal_conv1d` path for dense and packed multi-token prefill. It reads
selected `[num_slots, W - 1, C]` history rows directly, uses zero history for fresh slots, and
advances the selected rows in place without allocating compact gather/final-state/scatter buffers.
The existing functional training path and one-token decode path retain their public contracts.

The implementation reuses the time-tiled forward computation with a paged-history specialization,
then launches a small direct state-update kernel so empty fresh and resumed sequences have explicit,
race-free behavior. The mutating operator has fake-tensor registration and supports padded slot
strides, null routes, strict fullgraph compilation, CUDA Graph replay, and direct continuation into
`causal_conv1d_decode`.

## Performance

GB200, BF16, W=4, C=12288, fixed-pointer warm-cache CUDA Graph medians over 101 replays:

| N | tokens/sequence | old gather/conv/scatter | paged | speedup |
|---:|---:|---:|---:|---:|
| 1 | 16 | 28.74 us | 10.14 us | 2.833x |
| 8 | 16 | 39.20 us | 12.54 us | 3.125x |
| 64 | 16 | 60.06 us | 24.96 us | 2.406x |
| 8 | 128 | 46.21 us | 20.99 us | 2.201x |
| 32 | 256 | 150.50 us | 125.60 us | 1.198x |

## Test Plan

```bash
gpu-run --timeout 120 auto -- timeout --signal=TERM --kill-after=5s 240s \
  .venv/bin/pytest -q -n 6 test/test_short_conv_cute.py test/test_namespaces.py
files=(${(f)"$(git diff --name-only HEAD^)"}); .venv/bin/prek run --files $files
.venv/bin/ruff check attn_gym/linear/short_conv test/test_short_conv_cute.py \
  test/test_namespaces.py
```