### PR TITLE
Fix selected attention CuTe LSE layout

### DIFF
--- a/attn_gym/sparse/selected_attention/impl/cute.py
+++ b/attn_gym/sparse/selected_attention/impl/cute.py
@@ -172,6 +172,5 @@ def selected_attention(
         return_lse=True,
     )
 
-    # Back to BHSD: (batch, nheads, seqlen, hdim)
-    # FA4 returns out as (batch, seqlen, nheads, hdim) and lse as (batch, nheads, seqlen).
-    return out.permute(0, 2, 1, 3), lse
+    # FA4's MLA path returns both tensors with sequence before heads.
+    return out.permute(0, 2, 1, 3), lse.permute(0, 2, 1)


### PR DESCRIPTION
## Human Note

## Agent note

FA4 switches selected attention to its MLA path because K and V share storage and the head dimension
is 512. That path returns LSE in batch-sequence-head layout, unlike standard FA4 attention. Permute
LSE alongside the output so selected attention preserves its documented batch-head-sequence API.

## Test Plan

```bash
PYTHONPATH=$PWD gpu-run --timeout 30 auto -- timeout --signal=TERM --kill-after=5s 180s \
  .venv/bin/pytest -q test/test_selected_attention_cute.py::test_cute_lse_matches_manual_computation
.venv/bin/ruff check attn_gym/sparse/selected_attention/impl/cute.py
.venv/bin/ruff format --check attn_gym/sparse/selected_attention/impl/cute.py
git diff --check
```
