### PR TITLE
Enable paged GDN prefill on Hopper

### DIFF
--- a/attn_gym/linear/gdn/api.py
+++ b/attn_gym/linear/gdn/api.py
@@ -125,7 +125,7 @@ def paged_chunk_gdn(
 ) -> torch.Tensor:
     """Apply inference-only chunk GDN while advancing a paged state cache in place.
 
-    Requires CUDA capability 10.0 or newer.
+    Requires CUDA capability 9.0 or newer.
 
     Args:
         q: Queries shaped ``[B, T, HK, K]``. ``HK`` may divide the value-head count.

--- a/attn_gym/linear/gdn/impl/chunk.py
+++ b/attn_gym/linear/gdn/impl/chunk.py
@@ -237,8 +237,7 @@ def _gdn_chunk_fwd_packed_paged_cuda(
     scale: float,
 ) -> torch.Tensor:
     """Run packed scalar GDN while advancing selected cache slots in place."""
-    if get_device_properties(q.device).major < 10:
-        raise ValueError("paged fused chunk_gdn requires CUDA capability 10.0 or newer")
+    validate_supported_device(q)
     metadata = RaggedChunkMetadata(cu_seqlens, chunk_offsets, capacity, 64)
     batch, _tokens, key_heads, key_dim = q.shape
     value_heads, value_dim = v.shape[2:]

--- a/attn_gym/linear/gdn/ops.py
+++ b/attn_gym/linear/gdn/ops.py
@@ -541,6 +541,10 @@ def _validate_fused_chunk_qkv(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor)
         raise TypeError("chunk_gdn(impl='fused') requires matching float16 or bfloat16 QKV")
     if q.shape[-1] != 128 or v.shape[-1] != 128:
         raise ValueError("chunk_gdn(impl='fused') requires K=V=128")
+    # The recurrence uses Hopper TensorDescriptors/TMA; Blackwell additionally selects the CuTe
+    # backward, while Hopper uses the portable Triton backward.
+    if not torch.compiler.is_compiling() and get_device_properties(q.device).major < 9:
+        raise ValueError("fused chunk GDN requires CUDA capability 9.0 or newer")
 
 
 def chunk_forward(
@@ -557,10 +561,6 @@ def chunk_forward(
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Route dense inputs and invoke the fused scalar chunk forward operator."""
     _validate_fused_chunk_qkv(q, k, v)
-    # The dense recurrence uses Hopper TensorDescriptors/TMA; Blackwell additionally selects
-    # the CuTe backward, while Hopper uses the portable Triton backward.
-    if not torch.compiler.is_compiling() and get_device_properties(q.device).major < 9:
-        raise ValueError("chunk_gdn(impl='fused') requires CUDA capability 9.0 or newer")
     output_shape = v.shape
     batch, tokens = q.shape[:2]
     if cu_seqlens is not None and batch != 1:
@@ -620,8 +620,6 @@ def paged_chunk_forward(
 ) -> torch.Tensor:
     """Normalize inputs and advance selected state-cache slots with chunk GDN."""
     _validate_fused_chunk_qkv(q, k, v)
-    if not torch.compiler.is_compiling() and get_device_properties(q.device).major < 10:
-        raise ValueError("paged_chunk_gdn requires CUDA capability 10.0 or newer")
     tensors = (q, k, v, gate, beta, state_cache)
     if torch.is_grad_enabled() and any(tensor.requires_grad for tensor in tensors):
         raise RuntimeError(

--- a/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
@@ -678,8 +678,8 @@ def chunk_gated_delta_rule_fwd_h(
         raise ValueError("w must match k and gk must have shape [B,T,H,K] or [B,T,H]")
     if u.shape != (batch, tokens, heads, value_dim):
         raise ValueError("u must have shape [B, T, H, V]")
-    if torch.cuda.get_device_capability(k.device)[0] < 10:
-        raise ValueError("the inter-chunk state recurrence requires CUDA capability 10.0 or newer")
+    if torch.cuda.get_device_capability(k.device)[0] < 9:
+        raise ValueError("the inter-chunk state recurrence requires CUDA capability 9.0 or newer")
     state_batch = batch if cu_seqlens is None else cu_seqlens.shape[0] - 1
     expected_state_shape = (state_batch, heads, value_dim, key_dim)
     if state_indices is not None:

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -46,7 +46,7 @@ output, final_state = chunk_gdn(
 - CPU and CUDA execution through eager PyTorch operations.
 - A repo-local fused chunk pipeline on CUDA capability 9.0+ with dense and packed inputs, grouped
   Q/K heads, tails, empty sequences, initial/final state, strict `torch.compile`, and CUDA Graph
-  support. On CUDA capability 10.0+, `paged_chunk_gdn` advances selected
+  support. On CUDA capability 9.0+, `paged_chunk_gdn` advances selected
   `[num_slots, H, V, K]` cache rows in place for inference prefill without caller-side
   gather/scatter copies.
 - An opt-in Mega fused chunk implementation with the same public training/state contract.

--- a/test/linear/test_gdn_chunk_fused.py
+++ b/test/linear/test_gdn_chunk_fused.py
@@ -40,10 +40,6 @@ pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available() or torch.cuda.get_device_capability() < (9, 0),
     reason="fused chunk GDN requires CUDA capability 9.0 or newer",
 )
-requires_blackwell = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (10, 0),
-    reason="paged chunk GDN requires CUDA capability 10.0 or newer",
-)
 
 
 def make_inputs(
@@ -346,20 +342,22 @@ def test_chunk_state_continues_in_recurrent_decode():
     torch.testing.assert_close(actual_state, expected_state, rtol=2e-2, atol=2e-3)
 
 
-@pytest.mark.skipif(
-    torch.cuda.get_device_capability() >= (10, 0),
-    reason="pre-Blackwell capability guard only",
-)
-def test_paged_chunk_rejects_pre_blackwell():
-    """Keep the Blackwell-only paged prefill boundary explicit on Hopper."""
+def test_paged_chunk_rejects_pre_hopper(monkeypatch):
+    """Keep the minimum device capability guard at the public boundary."""
+    import attn_gym.linear.gdn.ops as gdn_ops
+
+    monkeypatch.setattr(
+        gdn_ops,
+        "get_device_properties",
+        lambda device: SimpleNamespace(major=8),
+    )
     q, k, v, gate, beta, _state = make_inputs(tokens=64, key_heads=1, value_heads=2)
     state_cache = torch.randn(3, 2, 128, 128, device="cuda")
     state_indices = torch.tensor([1], device="cuda", dtype=torch.int32)
-    with torch.no_grad(), pytest.raises(ValueError, match="CUDA capability 10.0"):
+    with torch.no_grad(), pytest.raises(ValueError, match="CUDA capability 9.0"):
         paged_chunk_gdn(q, k, v, gate, beta, state_cache, state_indices)
 
 
-@requires_blackwell
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
 def test_paged_chunk_rejects_unsupported_qkv_dtype(dtype: torch.dtype):
     q, k, v, gate, beta, _state = make_inputs(tokens=64, key_heads=1, value_heads=2)
@@ -378,7 +376,6 @@ def test_paged_chunk_rejects_unsupported_qkv_dtype(dtype: torch.dtype):
         )
 
 
-@requires_blackwell
 def test_paged_chunk_raw_operator_registration():
     """Validate mutation, fake output layout, and dynamic AOT dispatch."""
     q, k, v, gate, beta, _state = make_inputs(tokens=128, key_heads=1, value_heads=2)
@@ -411,7 +408,6 @@ def test_paged_chunk_raw_operator_registration():
     )
 
 
-@requires_blackwell
 def test_paged_chunk_matches_gather_scatter():
     """Advance selected slots directly without copying state through the caller."""
     q, k, v, gate, beta, _state = make_inputs(
@@ -462,7 +458,6 @@ def test_paged_chunk_matches_gather_scatter():
     torch.testing.assert_close(storage, expected_storage, rtol=0, atol=0)
 
 
-@requires_blackwell
 def test_paged_chunk_dense_batch_matches_gather_scatter():
     q, k, v, gate, beta, _state = make_inputs(
         batch=2,
@@ -502,7 +497,6 @@ def test_paged_chunk_dense_batch_matches_gather_scatter():
     torch.testing.assert_close(state_cache, expected_cache, rtol=0, atol=0)
 
 
-@requires_blackwell
 def test_paged_chunk_state_continues_in_recurrent_decode():
     """Use one paged pool directly across chunk prefill and recurrent decode."""
     q, k, v, gate, beta, _state = make_inputs(tokens=65, key_heads=1, value_heads=2)
@@ -563,7 +557,6 @@ def test_paged_chunk_state_continues_in_recurrent_decode():
     torch.testing.assert_close(actual_cache, expected_cache, rtol=0, atol=0)
 
 
-@requires_blackwell
 def test_paged_chunk_handles_padding_and_empty_fresh_slots():
     """Null routes stay untouched while an empty newly assigned slot is cleared."""
     q, k, v, gate, beta, _state = make_inputs(tokens=64, key_heads=1, value_heads=2)
@@ -593,7 +586,6 @@ def test_paged_chunk_handles_padding_and_empty_fresh_slots():
     )
 
 
-@requires_blackwell
 def test_paged_chunk_fullgraph_compile():
     """Keep paged mutation opaque and correctly aliased under fullgraph compilation."""
     q, k, v, gate, beta, _state = make_inputs(tokens=65, key_heads=1, value_heads=2)
@@ -625,7 +617,6 @@ def test_paged_chunk_fullgraph_compile():
     torch.testing.assert_close(actual_cache, expected_cache, rtol=0, atol=0)
 
 
-@requires_blackwell
 def test_paged_chunk_cuda_graph_replay():
     """Replay changed cache routing, values, and packed boundaries."""
     q, k, v, gate, beta, _state = make_inputs(tokens=192, key_heads=1, value_heads=2)

--- a/test/test_kda_kernels.py
+++ b/test/test_kda_kernels.py
@@ -699,8 +699,8 @@ def _fwd_h_ref(k, w, v, gk, h0, chunk_size=64):
     ids=["single-fp16", "multi-state-bf16", "tail-bf16"],
 )
 @pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (10, 0),
-    reason="the KDA recurrence requires CUDA capability 10.0",
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (9, 0),
+    reason="the KDA recurrence requires CUDA capability 9.0",
 )
 def test_chunk_delta_h_fwd(dtype, T, use_h0):
     torch.manual_seed(12)
@@ -735,8 +735,8 @@ def test_chunk_delta_h_fwd(dtype, T, use_h0):
 
 
 @pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (10, 0),
-    reason="the KDA recurrence requires CUDA capability 10.0",
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (9, 0),
+    reason="the KDA recurrence requires CUDA capability 9.0",
 )
 def test_chunk_delta_h_fwd_fp32_path():
     """FP32 takes the non-warp-specialized BV=32 launch; dots still run in TF32."""


### PR DESCRIPTION
Enable paged GDN prefill on Hopper

## Human Note

## Agent note

Enable the existing paged chunk-GDN path and its shared inter-chunk state recurrence on SM90. The
Triton recurrence already lowers to Hopper HGMMA/TMA and passes its FP16, BF16, FP32, packed-tail,
paged-state, compile, and CUDA Graph contracts; the capability-10 guards and Blackwell-only test
markers were conservative validation limits rather than implementation requirements.

Centralize the fused chunk capability check so ordinary and paged GDN share the same SM90 boundary,
retain the registered raw-op guard, enable the recurrence and paged-cache tests on H100, and update
the public API documentation. CUTracer random-delay stress of the Hopper recurrence passed at 5,
20, and 100 microseconds. The final repository run passed 860 tests with 365 architecture-specific
skips.

TorchTitan PR #4389 was also exercised end to end on H100 with TP=1 and FULL_AND_PIECEWISE CUDA
graphs: paged convolution prefill, paged GDN prefill, recurrent decode, prefix-cache continuation,
and mixed decode+prefill all passed.

## Performance

Fixed-pointer, warm-cache public `paged_chunk_gdn` on H100, BF16, HK=8, H=16, K=V=128, FP32 state:

| Sequences | Tokens | Median latency |
| ---: | ---: | ---: |
| 1 | 1024 | 697.18 us |
| 8 | 1024 | 691.39 us |
| 8 | 4096 | 694.53 us |
| 32 | 4096 | 693.15 us |
| 64 | 8192 | 707.92 us |

TorchTitan Qwen3.5 debug model, H100 TP=1, prompt=128, generation=64, FULL_AND_PIECEWISE graphs:

| Batch | Median output tok/s |
| ---: | ---: |
| 1 | 439.8 |
| 2 | 850.7 |
| 4 | 1623.3 |
| 8 | 3017.6 |
| 16 | 5464.6 |

## Test Plan

```bash
gpu-run --timeout 30 auto -- timeout --signal=TERM --kill-after=10s 3600s env PYTHONPATH=$PWD TORCH_CUSTOM_PYTHONPATH=$PWD /home/dev/.venvs/nightly/bin/pytest -q
gpu-run --timeout 30 auto -- timeout --signal=TERM --kill-after=10s 1200s env PYTHONPATH=$PWD TORCH_CUSTOM_PYTHONPATH=$PWD /home/dev/.venvs/nightly/bin/pytest -q test/linear/test_gdn_chunk_fused.py test/test_kda_kernels.py::test_chunk_delta_h_fwd test/test_kda_kernels.py::test_chunk_delta_h_fwd_fp32_path
prek --all-files
```