### PR TITLE
Enable fused GDN on Ampere

### DIFF
--- a/attn_gym/linear/gdn/api.py
+++ b/attn_gym/linear/gdn/api.py
@@ -58,7 +58,7 @@ def chunk_gdn(
         scale: Query scale. Defaults to ``1 / sqrt(K)``.
         output_final_state: Return the final recurrent state with the output.
         impl: ``"reference"`` uses eager PyTorch. ``"fused"`` uses the repo-local scalar chunk
-            pipeline on CUDA capability 9.0+ with FP16/BF16 QKV and ``K = V = 128``.
+            pipeline on CUDA capability 8.0+ with FP16/BF16 QKV and ``K = V = 128``.
         kernel_options: Backend-specific options for fused execution. The repo-local path is the
             default; ``{"backend": "mega"}`` selects the optional CuTeDSL 4.7 Mega backend.
 
@@ -125,7 +125,7 @@ def paged_chunk_gdn(
 ) -> torch.Tensor:
     """Apply inference-only chunk GDN while advancing a paged state cache in place.
 
-    Requires CUDA capability 9.0 or newer.
+    Requires CUDA capability 8.0 or newer.
 
     Args:
         q: Queries shaped ``[B, T, HK, K]``. ``HK`` may divide the value-head count.

--- a/attn_gym/linear/gdn/impl/chunk.py
+++ b/attn_gym/linear/gdn/impl/chunk.py
@@ -46,9 +46,9 @@ from attn_gym.linear.kda.fwd.triton.chunk_delta_h import chunk_gated_delta_rule_
 
 
 def validate_supported_device(q: torch.Tensor) -> None:
-    """Reject devices older than the Hopper-capable fused implementation."""
-    if get_device_properties(q.device).major < 9:
-        raise ValueError("fused chunk_gdn requires CUDA capability 9.0 or newer")
+    """Reject devices older than the Ampere-capable fused implementation."""
+    if get_device_properties(q.device).major < 8:
+        raise ValueError("fused chunk_gdn requires CUDA capability 8.0 or newer")
 
 
 def use_blackwell_backward(q: torch.Tensor) -> bool:

--- a/attn_gym/linear/gdn/ops.py
+++ b/attn_gym/linear/gdn/ops.py
@@ -541,10 +541,10 @@ def _validate_fused_chunk_qkv(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor)
         raise TypeError("chunk_gdn(impl='fused') requires matching float16 or bfloat16 QKV")
     if q.shape[-1] != 128 or v.shape[-1] != 128:
         raise ValueError("chunk_gdn(impl='fused') requires K=V=128")
-    # The recurrence uses Hopper TensorDescriptors/TMA; Blackwell additionally selects the CuTe
-    # backward, while Hopper uses the portable Triton backward.
-    if not torch.compiler.is_compiling() and get_device_properties(q.device).major < 9:
-        raise ValueError("fused chunk GDN requires CUDA capability 9.0 or newer")
+    # Triton lowers TensorDescriptor accesses to pointer operations before Hopper. Blackwell
+    # additionally selects the CuTe backward; Ampere and Hopper use the portable Triton backward.
+    if not torch.compiler.is_compiling() and get_device_properties(q.device).major < 8:
+        raise ValueError("fused chunk GDN requires CUDA capability 8.0 or newer")
 
 
 def chunk_forward(

--- a/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
@@ -678,8 +678,8 @@ def chunk_gated_delta_rule_fwd_h(
         raise ValueError("w must match k and gk must have shape [B,T,H,K] or [B,T,H]")
     if u.shape != (batch, tokens, heads, value_dim):
         raise ValueError("u must have shape [B, T, H, V]")
-    if torch.cuda.get_device_capability(k.device)[0] < 9:
-        raise ValueError("the inter-chunk state recurrence requires CUDA capability 9.0 or newer")
+    if torch.cuda.get_device_capability(k.device)[0] < 8:
+        raise ValueError("the inter-chunk state recurrence requires CUDA capability 8.0 or newer")
     state_batch = batch if cu_seqlens is None else cu_seqlens.shape[0] - 1
     expected_state_shape = (state_batch, heads, value_dim, key_dim)
     if state_indices is not None:

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -44,9 +44,9 @@ output, final_state = chunk_gdn(
   with `cu_seqlens`.
 - Separate recurrent and chunked operations with explicit initial and final state.
 - CPU and CUDA execution through eager PyTorch operations.
-- A repo-local fused chunk pipeline on CUDA capability 9.0+ with dense and packed inputs, grouped
+- A repo-local fused chunk pipeline on CUDA capability 8.0+ with dense and packed inputs, grouped
   Q/K heads, tails, empty sequences, initial/final state, strict `torch.compile`, and CUDA Graph
-  support. On CUDA capability 9.0+, `paged_chunk_gdn` advances selected
+  support. On CUDA capability 8.0+, `paged_chunk_gdn` advances selected
   `[num_slots, H, V, K]` cache rows in place for inference prefill without caller-side
   gather/scatter copies.
 - An opt-in Mega fused chunk implementation with the same public training/state contract.
@@ -59,14 +59,14 @@ output, final_state = chunk_gdn(
   dtype. A provided initial state uses FP32 for low-precision QKV.
 - FP64 reference inputs retain FP64 recurrence math and state.
 
-The repo-local fused chunk backend requires CUDA capability 9.0+, matching FP16 or BF16 Q/K/V,
+The repo-local fused chunk backend requires CUDA capability 8.0+, matching FP16 or BF16 Q/K/V,
 and
 `K = V = 128`, but has no Mega runtime dependency. Its scalar natural-log gate is not lower-bounded:
 kernels contract raw QK/KK before applying masked nonpositive causal decay differences. The public
 chunk size is BT64; internal 16x16 blocks are only the hierarchical triangular-solve representation.
 Layouts requiring int64 tensor offsets are rejected until every repo-local kernel has a
 wide-address path. Backward uses the tuned CuTe kernels on SM100/SM103 and portable Triton
-kernels on Hopper and other supported architectures.
+kernels on Ampere, Hopper, and other supported architectures.
 
 The Mega chunk backend requires the optional `mega` dependencies and SM100/SM103,
 FP16/BF16 Q/K/V, FP32 state, and `K = V = 128` contract. It also consumes the scalar natural-log

--- a/test/linear/test_gdn_chunk_fused.py
+++ b/test/linear/test_gdn_chunk_fused.py
@@ -37,8 +37,8 @@ from attn_gym.testing.kda import (
 )
 
 pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (9, 0),
-    reason="fused chunk GDN requires CUDA capability 9.0 or newer",
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (8, 0),
+    reason="fused chunk GDN requires CUDA capability 8.0 or newer",
 )
 
 
@@ -342,19 +342,19 @@ def test_chunk_state_continues_in_recurrent_decode():
     torch.testing.assert_close(actual_state, expected_state, rtol=2e-2, atol=2e-3)
 
 
-def test_paged_chunk_rejects_pre_hopper(monkeypatch):
+def test_paged_chunk_rejects_pre_ampere(monkeypatch):
     """Keep the minimum device capability guard at the public boundary."""
     import attn_gym.linear.gdn.ops as gdn_ops
 
     monkeypatch.setattr(
         gdn_ops,
         "get_device_properties",
-        lambda device: SimpleNamespace(major=8),
+        lambda device: SimpleNamespace(major=7),
     )
     q, k, v, gate, beta, _state = make_inputs(tokens=64, key_heads=1, value_heads=2)
     state_cache = torch.randn(3, 2, 128, 128, device="cuda")
     state_indices = torch.tensor([1], device="cuda", dtype=torch.int32)
-    with torch.no_grad(), pytest.raises(ValueError, match="CUDA capability 9.0"):
+    with torch.no_grad(), pytest.raises(ValueError, match="CUDA capability 8.0"):
         paged_chunk_gdn(q, k, v, gate, beta, state_cache, state_indices)
 
 
@@ -860,7 +860,7 @@ def test_int64_layouts_fail_before_kernel_launch(monkeypatch):
         chunk_gdn(*inputs[:5], impl="fused")
 
 
-def test_raw_ops_reject_pre_hopper_devices(monkeypatch):
+def test_raw_ops_reject_pre_ampere_devices(monkeypatch):
     """Keep capability validation inside the real registered CUDA launcher."""
     import attn_gym.linear.gdn.impl.chunk as chunk_impl
 
@@ -868,9 +868,9 @@ def test_raw_ops_reject_pre_hopper_devices(monkeypatch):
     monkeypatch.setattr(
         chunk_impl,
         "get_device_properties",
-        lambda device: SimpleNamespace(major=8),
+        lambda device: SimpleNamespace(major=7),
     )
-    with pytest.raises(ValueError, match="capability 9.0"):
+    with pytest.raises(ValueError, match="capability 8.0"):
         chunk_fwd_with_state_op(*args)
 
 

--- a/test/test_kda_kernels.py
+++ b/test/test_kda_kernels.py
@@ -699,8 +699,8 @@ def _fwd_h_ref(k, w, v, gk, h0, chunk_size=64):
     ids=["single-fp16", "multi-state-bf16", "tail-bf16"],
 )
 @pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (9, 0),
-    reason="the KDA recurrence requires CUDA capability 9.0",
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (8, 0),
+    reason="the KDA recurrence requires CUDA capability 8.0",
 )
 def test_chunk_delta_h_fwd(dtype, T, use_h0):
     torch.manual_seed(12)
@@ -735,8 +735,8 @@ def test_chunk_delta_h_fwd(dtype, T, use_h0):
 
 
 @pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (9, 0),
-    reason="the KDA recurrence requires CUDA capability 9.0",
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (8, 0),
+    reason="the KDA recurrence requires CUDA capability 8.0",
 )
 def test_chunk_delta_h_fwd_fp32_path():
     """FP32 takes the non-warp-specialized BV=32 launch; dots still run in TF32."""

--- a/test/test_short_conv_cute.py
+++ b/test/test_short_conv_cute.py
@@ -58,8 +58,8 @@ def test_kda_backward_compatibility_exports():
 
 
 pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (9, 0),
-    reason="the CuTeDSL short convolution requires CUDA capability 9.0 or newer",
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (8, 0),
+    reason="the CuTeDSL short convolution requires CUDA capability 8.0 or newer",
 )
 
 


### PR DESCRIPTION
## Human Note

## Agent note

Lower the repo-local fused chunk GDN capability floor from Hopper to Ampere. The forward and
portable backward are Triton kernels; pre-Hopper TensorDescriptor accesses lower to pointer
operations, while the Blackwell-only CuTe backward selection remains unchanged.

The shared inter-chunk recurrence now accepts Ampere for paged GDN prefill. The existing
short-convolution implementation had no Hopper-only runtime guard, so its correctness, paging,
compile, and CUDA Graph tests now run on CUDA capability 8.0 and newer as well. Mega GDN/KDA and
the CuTe KDA core retain their existing Blackwell-specific requirements.

No Ampere gpu-dev capacity was available on September 1, 2026. Both queued reservations were
cancelled rather than left waiting indefinitely, so real SM80/SM86 execution remains the explicit
validation gap.

## Test Plan

```bash
pytest -q -n 6 test/linear/test_gdn_chunk_fused.py
# 45 passed

pytest -q test/test_kda_kernels.py -k "test_chunk_delta_h_fwd"
# 4 passed, 62 deselected

pytest -q \
  test/test_short_conv_cute.py::test_short_conv_forward_and_backward_match_pytorch \
  test/test_short_conv_cute.py::test_short_conv_packed_forward_and_backward_match_independent_sequences \
  test/test_short_conv_cute.py::test_short_conv_packed_stateful_tma_backward_matches_reference_and_fallback \
  test/test_short_conv_cute.py::test_paged_short_conv_prefill_matches_gather_scatter \
  test/test_short_conv_cute.py::test_short_conv_fullgraph_forward_and_backward \
  test/test_short_conv_cute.py::test_short_conv_packed_stateful_fullgraph_forward_and_backward \
  test/test_short_conv_cute.py::test_short_conv_cuda_graph_replay \
  test/test_short_conv_cute.py::test_paged_short_conv_prefill_cuda_graph_replays_routing
# 16 passed

pytest -q -n 6
# 860 passed, 365 skipped

prek run --all-files
```
