### PR TITLE
Make shared KDA stages Hopper-compatible

### DIFF
--- a/attn_gym/_backends/cute/target.py
+++ b/attn_gym/_backends/cute/target.py
@@ -18,6 +18,16 @@ class CompileTarget:
     name: str | None = None
     sm_count: int | None = None
 
+    @property
+    def effective_capability(self) -> tuple[int, int] | None:
+        """Return the configured code-generation target or the physical capability."""
+        if self.configured_arch is None:
+            return self.capability
+        arch = self.configured_arch.removeprefix("sm_").removesuffix("a")
+        if not arch.isdecimal() or len(arch) < 2:
+            raise ValueError(f"invalid configured CUDA architecture {self.configured_arch!r}")
+        return divmod(int(arch), 10)
+
 
 _target: CompileTarget | None = None
 _target_lock = threading.Lock()

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_intra.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_intra.py
@@ -888,6 +888,7 @@ def _chunk_kda_bwd_intra_hmma_grid_kernel(
     grid_chunks: Constexpr,
     ragged: Constexpr,
     use_int64_offsets: Constexpr,
+    use_packed_f32x2: Constexpr,
 ):
     tidx, _, _ = cute.arch.thread_idx()
     # Grid is (KC_TOTAL, grid_chunks, H), mirroring Triton's for-loop variant.
@@ -1679,7 +1680,12 @@ def _chunk_kda_bwd_intra_hmma_grid_kernel(
                 )
                 dq_add0 = q_acc0 * qscale_prev0 + q_diag0 * qscale_diag0
                 dq_add1 = q_acc1 * qscale_prev1 + q_diag1 * qscale_diag1
-                dq_out0, dq_out1 = cute.arch.add_packed_f32x2((dq_in0, dq_in1), (dq_add0, dq_add1))
+                if cutlass.const_expr(use_packed_f32x2):
+                    dq_out0, dq_out1 = cute.arch.add_packed_f32x2(
+                        (dq_in0, dq_in1), (dq_add0, dq_add1)
+                    )
+                else:
+                    dq_out0, dq_out1 = dq_in0 + dq_add0, dq_in1 + dq_add1
                 if lane_row == 0:
                     dq_word0 = _cvt_half2_f32(dq_out0, dq_out1, mDq2.element_type)
                 else:
@@ -1692,7 +1698,12 @@ def _chunk_kda_bwd_intra_hmma_grid_kernel(
                 dk_beta1 = dk_qk1 * beta_row
                 dk_add0 = dk_beta0 + dkt0
                 dk_add1 = dk_beta1 + dkt1
-                dk_out0, dk_out1 = cute.arch.add_packed_f32x2((dk_in0, dk_in1), (dk_add0, dk_add1))
+                if cutlass.const_expr(use_packed_f32x2):
+                    dk_out0, dk_out1 = cute.arch.add_packed_f32x2(
+                        (dk_in0, dk_in1), (dk_add0, dk_add1)
+                    )
+                else:
+                    dk_out0, dk_out1 = dk_in0 + dk_add0, dk_in1 + dk_add1
                 if lane_row == 0:
                     dk_word0 = _cvt_half2_f32(dk_out0, dk_out1, mDk2.element_type)
                 else:
@@ -1869,12 +1880,14 @@ class ChunkKdaBwdIntraHmmaGrid:
         capacity: int,
         grid_chunks: int,
         ragged: bool,
-        use_int64_offsets: bool = False,
+        use_int64_offsets: bool,
+        use_packed_f32x2: bool,
     ):
         self.capacity = capacity
         self.grid_chunks = grid_chunks
         self.ragged = ragged
         self.use_int64_offsets = use_int64_offsets
+        self.use_packed_f32x2 = use_packed_f32x2
 
     @cute.jit
     def __call__(
@@ -1917,6 +1930,7 @@ class ChunkKdaBwdIntraHmmaGrid:
             self.grid_chunks,
             self.ragged,
             self.use_int64_offsets,
+            self.use_packed_f32x2,
         ).launch(
             grid=(KC_TOTAL, self.grid_chunks, cute.size(mQ.shape[2])),
             block=(32, 1, 1),
@@ -1942,11 +1956,14 @@ def _compile_chunk_kda_bwd_intra(
     """Compile one persistent intra-chunk backward specialization."""
     if not 1 <= grid_chunks <= capacity:
         raise ValueError(f"grid_chunks must be in [1, {capacity}], got {grid_chunks}")
+    target = get_compile_target()
+    capability = target.effective_capability
     op = ChunkKdaBwdIntraHmmaGrid(
         capacity=capacity,
         grid_chunks=grid_chunks,
         ragged=ragged,
         use_int64_offsets=use_int64_offsets,
+        use_packed_f32x2=capability is not None and capability >= (10, 0),
     )
     tokens, sequences = cute.sym_int(), cute.sym_int()
     sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int

--- a/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
@@ -6,12 +6,12 @@
 
 """Inter-chunk scalar- and vector-gated delta-rule state recurrence.
 
-A single kernel (B=1, K=V=128, 64-token chunks, Blackwell) keeps the full
-[K, BV] state in one accumulator and overlaps next-chunk descriptor loads with
-the serially dependent state MMAs; 16-bit inputs run the tuned warp-specialized
-schedule and FP32 a smaller ordinarily pipelined one. Host-side tensor
-descriptors do not survive dynamo/inductor tracing, so the launch sits behind a
-compiler-opaque ``torch.library`` op pair.
+A single kernel (B=1, K=V=128, 64-token chunks) keeps the full [K, BV] state in
+one accumulator. Blackwell overlaps descriptor loads with the serial state MMAs
+through warp specialization; Hopper and FP32 use ordinary pipelining because the
+Hopper warp-specialization pass cannot commit this kernel's descriptor stores.
+Host-side tensor descriptors do not survive Dynamo/Inductor tracing, so the
+launch sits behind a compiler-opaque ``torch.library`` op pair.
 """
 
 from __future__ import annotations
@@ -21,6 +21,7 @@ import triton
 import triton.language as tl
 from triton.tools.tensor_descriptor import TensorDescriptor
 
+from attn_gym._backends.cute.utils import get_device_properties
 from attn_gym._backends.triton.utils import can_use_tma, ptr_offset, requires_int64_offsets
 from attn_gym.linear.kda.chunk_scheduler import (
     GridScheduler,
@@ -260,7 +261,7 @@ def chunk_delta_h_kernel_k128_wsp(
     USE_INT64_OFFSETS: tl.constexpr,
     SCALAR_GATE: tl.constexpr,
 ):
-    """Warp-specialized K=128 inter-chunk recurrence."""
+    """Primary K=128 inter-chunk recurrence launcher."""
     _run_chunk_delta_h_sequence(
         k_desc,
         w_desc,
@@ -458,11 +459,11 @@ def _delta_h_launch(
     compact_state_strides = (heads * value_dim * key_dim, value_dim * key_dim, key_dim, 1)
     h0_strides = initial_state.stride() if initial_state is not None else compact_state_strides
     ht_strides = final_state.stride() if final_state is not None else compact_state_strides
-    # FP32 tiles double the descriptor staging past the shared-memory limit
-    # at the 16-bit tile shape, and warp specialization pins its own stage
-    # count; for 4-byte inputs halve the value tile and use an ordinarily
-    # pipelined loop instead. 16-bit inputs keep the tuned contract schedule.
+    # FP32 tiles double the descriptor staging past the shared-memory limit at
+    # the 16-bit tile shape. Hopper also uses ordinary pipelining: its Triton
+    # warp-specialization pass cannot commit the descriptor stores in this loop.
     use_16bit_config = k.element_size() == 2
+    use_warp_specialization = use_16bit_config and get_device_properties(k.device).major >= 10
     block_value_dim = _BLOCK_VALUE_DIM if use_16bit_config else _BLOCK_VALUE_DIM // 2
     descriptors = (
         TensorDescriptor.from_tensor(k, [1, _CHUNK_SIZE, 1, key_dim]),
@@ -497,8 +498,8 @@ def _delta_h_launch(
         "V": value_dim,
         "BT": _CHUNK_SIZE,
         "BV": block_value_dim,
-        "WARP_SPECIALIZE": use_16bit_config,
-        "NUM_STAGES": 3 if use_16bit_config else 2,
+        "WARP_SPECIALIZE": use_warp_specialization,
+        "NUM_STAGES": 3 if use_warp_specialization else 2,
         "USE_INITIAL_STATE": initial_state is not None,
         "STORE_FINAL_STATE": final_state is not None,
         "USE_STATE_INDICES": state_indices is not None,
@@ -522,9 +523,10 @@ def _delta_h_launch(
             schedule,
         )
     if sequence_workers:
-        # Keep one machine-sized wave warp-specialized, then stride persistent workers
-        # over the remaining work; Triton cannot warp-specialize the nested loop. This
-        # reduced N=512, M=32 graph replay from 1.22 ms to 0.68 ms on B200.
+        # Keep one machine-sized wave on the primary schedule, then stride persistent
+        # workers over the remaining work. Blackwell warp-specializes the first launch;
+        # Hopper uses ordinary pipelining. This reduced N=512, M=32 graph replay from
+        # 1.22 ms to 0.68 ms on B200.
         chunk_delta_h_kernel_k128_wsp[(sequence_workers, value_tiles)](
             *kernel_args,
             **kernel_options,
@@ -678,7 +680,7 @@ def chunk_gated_delta_rule_fwd_h(
         raise ValueError("w must match k and gk must have shape [B,T,H,K] or [B,T,H]")
     if u.shape != (batch, tokens, heads, value_dim):
         raise ValueError("u must have shape [B, T, H, V]")
-    if torch.cuda.get_device_capability(k.device)[0] < 8:
+    if not torch.compiler.is_compiling() and get_device_properties(k.device).major < 8:
         raise ValueError("the inter-chunk state recurrence requires CUDA capability 8.0 or newer")
     state_batch = batch if cu_seqlens is None else cu_seqlens.shape[0] - 1
     expected_state_shape = (state_batch, heads, value_dim, key_dim)

--- a/test/test_cute_cache.py
+++ b/test/test_cute_cache.py
@@ -893,6 +893,32 @@ def test_bad_fork_check_precedes_cached_target_lookup(monkeypatch):
         cute_target._query_compile_target.cache_clear()
 
 
+@pytest.mark.parametrize(
+    ("configured_arch", "physical", "expected"),
+    (
+        ("sm_90a", (10, 0), (9, 0)),
+        ("sm_100a", (9, 0), (10, 0)),
+        ("sm_103a", (10, 0), (10, 3)),
+        (None, (10, 3), (10, 3)),
+        (None, None, None),
+    ),
+)
+def test_compile_target_effective_capability(configured_arch, physical, expected):
+    """Prefer an explicit code-generation architecture over the physical GPU."""
+    target = cute_target.CompileTarget(
+        device_type="cuda",
+        configured_arch=configured_arch,
+        capability=physical,
+    )
+    assert target.effective_capability == expected
+
+
+def test_compile_target_rejects_invalid_configured_architecture():
+    target = cute_target.CompileTarget(device_type="cuda", configured_arch="native")
+    with pytest.raises(ValueError, match="configured CUDA architecture"):
+        _ = target.effective_capability
+
+
 def test_explicit_target_avoids_device_discovery(monkeypatch):
     target = cute_target.CompileTarget(
         device_type="cuda",

--- a/test/test_kda_ragged_bwd_intra.py
+++ b/test/test_kda_ragged_bwd_intra.py
@@ -19,8 +19,8 @@ from attn_gym.testing.kda import (
 )
 
 pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (10, 0),
-    reason="the CuTe KDA backward stage requires CUDA capability 10.0 or newer",
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (9, 0),
+    reason="the CuTe KDA backward stage requires CUDA capability 9.0 or newer",
 )
 
 

--- a/test/test_kda_ragged_recurrence.py
+++ b/test/test_kda_ragged_recurrence.py
@@ -20,8 +20,8 @@ from attn_gym.linear.kda.fwd.triton.chunk_delta_h import (
 from attn_gym.testing import cumulative_sequence_offsets
 
 pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (10, 0),
-    reason="the KDA recurrence kernel requires CUDA capability 10.0",
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (8, 0),
+    reason="the KDA recurrence kernel requires CUDA capability 8.0 or newer",
 )
 
 


### PR DESCRIPTION
Stacked PRs:
 * #439
 * #438
 * __->__#437


--- --- ---

Make shared KDA stages Hopper-compatible

## Human Note

## Agent note

Keep the shared inter-chunk recurrence on its existing descriptor implementation, but disable
Triton's unsupported Hopper warp-specialization schedule. Make the CuTe bwd-intra epilogue select
ordinary FP32 additions on SM90 instead of Blackwell's packed F32x2 operation. Blackwell retains
its existing schedules, while the recurrence keeps the newly landed SM80 minimum.

## Test Plan

```bash
pytest -n 6 test/test_kda_ragged_recurrence.py test/test_kda_ragged_bwd_intra.py
```