### PR TITLE
Add native Hopper chunk KDA training

### DIFF
--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd.py
@@ -1,4 +1,4 @@
-"""Composed fixed-length and packed Blackwell KDA core backward."""
+"""Composed fixed-length and packed architecture-routed KDA core backward."""
 
 from __future__ import annotations
 
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 
 import torch
 
+from attn_gym._backends.cute.utils import get_device_properties
 from attn_gym.linear.kda.bwd.cute.chunk_delta_h_bwd import (
     blackwell_delta_h_bwd_dhu_dv_fused_dispatch,
 )
@@ -14,6 +15,10 @@ from attn_gym.linear.kda.bwd.cute.chunk_kda_bwd_wy_dqkg_fused import (
     chunk_kda_bwd_wy_dqkg,
 )
 from attn_gym.linear.kda.bwd.triton.chunk_kda_bwd_daqk import chunk_kda_bwd_daqk
+from attn_gym.linear.kda.bwd.triton.chunk_kda_bwd_delta_h_triton import (
+    chunk_kda_bwd_delta_h_triton,
+)
+from attn_gym.linear.kda.bwd.triton.chunk_kda_bwd_wy_triton import chunk_kda_bwd_wy_triton
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata
 from attn_gym.linear.kda.fwd.cute.recompute_w_u_fwd import recompute_w_u_fwd
 from attn_gym.linear.kda.fwd.triton.chunk_delta_h import chunk_gated_delta_rule_fwd_h
@@ -112,42 +117,76 @@ def _finish_chunk_kda_bwd(
 ]:
     """Finish local gradients while releasing prepared tensors at their last use."""
     assert prepared.qg is not None and prepared.kg is not None and prepared.w is not None
-    with profiler_range("kda/cute/backward_delta_h"):
-        dh, d_initial_state, dv = blackwell_delta_h_bwd_dhu_dv_fused_dispatch(
-            prepared.qg,
-            prepared.kg,
-            prepared.w,
-            do,
-            Aqk,
-            gk=g,
-            h0=initial_state,
-            dht=d_final_state,
-            scale=scale,
-            chunk_size=chunk_size,
-            metadata=metadata,
-        )
+    use_triton_backend = get_device_properties(q.device).major < 10
+    range_backend = "triton" if use_triton_backend else "cute"
+    with profiler_range(f"kda/{range_backend}/backward_delta_h"):
+        if use_triton_backend:
+            dh, d_initial_state, dv = chunk_kda_bwd_delta_h_triton(
+                prepared.qg,
+                prepared.kg,
+                prepared.w,
+                do,
+                Aqk,
+                gk=g,
+                initial_state=initial_state,
+                d_final_state=d_final_state,
+                scale=scale,
+                metadata=metadata,
+            )
+        else:
+            dh, d_initial_state, dv = blackwell_delta_h_bwd_dhu_dv_fused_dispatch(
+                prepared.qg,
+                prepared.kg,
+                prepared.w,
+                do,
+                Aqk,
+                gk=g,
+                h0=initial_state,
+                dht=d_final_state,
+                scale=scale,
+                chunk_size=chunk_size,
+                metadata=metadata,
+            )
     prepared.qg = prepared.kg = prepared.w = None
 
     assert prepared.v_new is not None and prepared.h is not None
-    with profiler_range("kda/cute/backward_wy_dqkg"):
-        dq, dk, dv, dg, db, dAkk = chunk_kda_bwd_wy_dqkg(
-            q,
-            k,
-            v,
-            prepared.v_new,
-            g,
-            beta,
-            Akk,
-            prepared.h,
-            do,
-            dh,
-            dv,
-            metadata,
-            scale=scale,
-            chunk_size=chunk_size,
-            fastmath=fastmath,
-            autotune=autotune,
-        )
+    with profiler_range(f"kda/{range_backend}/backward_wy_dqkg"):
+        if use_triton_backend:
+            dq, dk, dv, dg, db, dAkk = chunk_kda_bwd_wy_triton(
+                q,
+                k,
+                v,
+                prepared.v_new,
+                g,
+                beta,
+                Akk,
+                prepared.h,
+                do,
+                dh,
+                dv,
+                metadata,
+                scale=scale,
+                fastmath=fastmath,
+            )
+        else:
+            dq, dk, dv, dg, db, dAkk = chunk_kda_bwd_wy_dqkg(
+                q,
+                k,
+                v,
+                prepared.v_new,
+                g,
+                beta,
+                Akk,
+                prepared.h,
+                do,
+                dh,
+                dv,
+                metadata,
+                scale=scale,
+                chunk_size=chunk_size,
+                fastmath=fastmath,
+                autotune=autotune,
+            )
     prepared.h = prepared.v_new = None
     del dh
 

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_intra.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_intra.py
@@ -412,6 +412,30 @@ def _cvt_half2_f32(a, b, io_type):
 
 
 @dsl_user_op
+def _st_shared_f32(
+    smem_ptr: cute.Pointer,
+    value: Float32,
+    *,
+    loc=None,
+    ip=None,
+) -> None:
+    """Store one FP32 register as an untyped shared-memory word."""
+    smem_addr = smem_ptr.toint(loc=loc, ip=ip).ir_value()
+    value_bits = llvm.bitcast(T.i32(), Float32(value).ir_value(loc=loc, ip=ip), loc=loc, ip=ip)
+    llvm.inline_asm(
+        None,
+        [smem_addr, value_bits],
+        "st.shared.b32 [$0], $1;",
+        "r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
 def _st_shared_f32x4_v2_b64(
     smem_ptr: cute.Pointer,
     a: Float32,
@@ -729,19 +753,38 @@ def _hmma_stmatrix_source_from_lane_values(b0, b1, tidx, source_reg: Constexpr):
 
 
 @cute.jit
-def _hmma_stage_b_group_stmatrix(sB, b0, b1, tidx):
-    store_bytes = ((tidx << 4) & 368) ^ (Int32(160) if (tidx & 8) != 0 else Int32(0))
-    _stmatrix_x4_b16_f32(
-        sB.iterator + (store_bytes // 2),
-        _hmma_stmatrix_source_from_lane_values(b0, b1, tidx, 0),
-        _hmma_stmatrix_source_from_lane_values(b0, b1, tidx, 1),
-        _hmma_stmatrix_source_from_lane_values(b0, b1, tidx, 2),
-        _hmma_stmatrix_source_from_lane_values(b0, b1, tidx, 3),
-    )
+def _hmma_stage_b_group_shared_store(sB, value, tidx, source_reg: Constexpr):
+    """Store one stmatrix source register with the equivalent SM80 lane mapping.
+
+    The byte offset is ``4 * (lane & 0b10111) + 128 * register +
+    32 * (lane_bit_3 ^ register_bit_0)``.
+    """
+    lane_bytes = (tidx & 23) * 4
+    source_low_bit = source_reg & 1
+    lane_row_bit = Int32(1) if (tidx & 8) != 0 else Int32(0)
+    store_bytes = lane_bytes + source_reg * 128 + (lane_row_bit ^ source_low_bit) * 32
+    _st_shared_f32(sB.iterator + (store_bytes // 2), value)
 
 
 @cute.jit
-def _hmma_load_b_group_stmatrix(sB, tidx):
+def _hmma_stage_b_group(sB, b0, b1, tidx, use_stmatrix: Constexpr):
+    """Stage one MMA B group with stmatrix on SM90+ or scalar stores on SM80."""
+    r0 = _hmma_stmatrix_source_from_lane_values(b0, b1, tidx, 0)
+    r1 = _hmma_stmatrix_source_from_lane_values(b0, b1, tidx, 1)
+    r2 = _hmma_stmatrix_source_from_lane_values(b0, b1, tidx, 2)
+    r3 = _hmma_stmatrix_source_from_lane_values(b0, b1, tidx, 3)
+    if cutlass.const_expr(use_stmatrix):
+        store_bytes = ((tidx << 4) & 368) ^ (Int32(160) if (tidx & 8) != 0 else Int32(0))
+        _stmatrix_x4_b16_f32(sB.iterator + (store_bytes // 2), r0, r1, r2, r3)
+    else:
+        _hmma_stage_b_group_shared_store(sB, r0, tidx, 0)
+        _hmma_stage_b_group_shared_store(sB, r1, tidx, 1)
+        _hmma_stage_b_group_shared_store(sB, r2, tidx, 2)
+        _hmma_stage_b_group_shared_store(sB, r3, tidx, 3)
+
+
+@cute.jit
+def _hmma_load_b_group_staged(sB, tidx):
     load_bytes = ((tidx << 4) & 320) | ((tidx & 3) * 8)
     load_bytes = load_bytes | (Int32(160) if (tidx & 8) != 0 else Int32(0))
     packed0 = _ld_shared_u32(sB.iterator + (load_bytes // 2))
@@ -889,6 +932,7 @@ def _chunk_kda_bwd_intra_hmma_grid_kernel(
     ragged: Constexpr,
     use_int64_offsets: Constexpr,
     use_packed_f32x2: Constexpr,
+    use_stmatrix: Constexpr,
 ):
     tidx, _, _ = cute.arch.thread_idx()
     # Grid is (KC_TOTAL, grid_chunks, H), mirroring Triton's for-loop variant.
@@ -1197,9 +1241,9 @@ def _chunk_kda_bwd_intra_hmma_grid_kernel(
                     b1 = kb1 * cute.math.exp2(gref - gk1, fastmath=True)
                     b0 = b0 if key0 < valid else z
                     b1 = b1 if key1 < valid else z
-                    _hmma_stage_b_group_stmatrix(sEpi_tile, b0, b1, tidx)
+                    _hmma_stage_b_group(sEpi_tile, b0, b1, tidx, use_stmatrix)
                     cute.arch.sync_warp()
-                    b0, b1 = _hmma_load_b_group_stmatrix(sEpi_tile, tidx)
+                    b0, b1 = _hmma_load_b_group_staged(sEpi_tile, tidx)
                     if group == 0:
                         q00, q01, q02, q03 = _mma_tf32_m16n8k8(
                             aq0, aq1, aq2, aq3, b0, b1, q00, q01, q02, q03
@@ -1316,9 +1360,9 @@ def _chunk_kda_bwd_intra_hmma_grid_kernel(
                 b1 = kb1 * cute.math.exp2(gref - gk1, fastmath=True)
                 b0 = b0 if key0 < valid else z
                 b1 = b1 if key1 < valid else z
-                _hmma_stage_b_group_stmatrix(sEpi_tile, b0, b1, tidx)
+                _hmma_stage_b_group(sEpi_tile, b0, b1, tidx, use_stmatrix)
                 cute.arch.sync_warp()
-                b0, b1 = _hmma_load_b_group_stmatrix(sEpi_tile, tidx)
+                b0, b1 = _hmma_load_b_group_staged(sEpi_tile, tidx)
                 if group == 0:
                     qd00, qd01, qd02, qd03 = _mma_tf32_m16n8k8(
                         aq0, aq1, aq2, aq3, b0, b1, qd00, qd01, qd02, qd03
@@ -1882,12 +1926,14 @@ class ChunkKdaBwdIntraHmmaGrid:
         ragged: bool,
         use_int64_offsets: bool,
         use_packed_f32x2: bool,
+        use_stmatrix: bool,
     ):
         self.capacity = capacity
         self.grid_chunks = grid_chunks
         self.ragged = ragged
         self.use_int64_offsets = use_int64_offsets
         self.use_packed_f32x2 = use_packed_f32x2
+        self.use_stmatrix = use_stmatrix
 
     @cute.jit
     def __call__(
@@ -1931,6 +1977,7 @@ class ChunkKdaBwdIntraHmmaGrid:
             self.ragged,
             self.use_int64_offsets,
             self.use_packed_f32x2,
+            self.use_stmatrix,
         ).launch(
             grid=(KC_TOTAL, self.grid_chunks, cute.size(mQ.shape[2])),
             block=(32, 1, 1),
@@ -1958,12 +2005,15 @@ def _compile_chunk_kda_bwd_intra(
         raise ValueError(f"grid_chunks must be in [1, {capacity}], got {grid_chunks}")
     target = get_compile_target()
     capability = target.effective_capability
+    if target.device_type != "cuda" or capability is None or capability < (8, 0):
+        raise ValueError(f"KDA backward intra requires CUDA capability >= 8.0; got {target}")
     op = ChunkKdaBwdIntraHmmaGrid(
         capacity=capacity,
         grid_chunks=grid_chunks,
         ragged=ragged,
         use_int64_offsets=use_int64_offsets,
-        use_packed_f32x2=capability is not None and capability >= (10, 0),
+        use_packed_f32x2=capability >= (10, 0),
+        use_stmatrix=capability >= (9, 0),
     )
     tokens, sequences = cute.sym_int(), cute.sym_int()
     sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int

--- a/attn_gym/linear/kda/bwd/triton/chunk_kda_bwd_delta_h_triton.py
+++ b/attn_gym/linear/kda/bwd/triton/chunk_kda_bwd_delta_h_triton.py
@@ -1,0 +1,383 @@
+# Copyright (c) 2026 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Triton KDA reverse delta-H recurrence for the fixed BT64, K=V=128 path.
+
+One ``(sequence, head, BV=64)`` Triton program computes each chunk's
+``Aqk^T @ dO`` contribution and keeps the K-by-BV state cotangent in FP32 while
+traversing chunks in reverse. Packed tails use masked pointer accesses, and
+capacity slots without runtime work remain zero.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+from torch._subclasses.fake_tensor import FakeTensor
+
+from attn_gym._backends.triton.utils import ptr_offset, requires_int64_offsets
+from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata, load_ragged_sequence_work
+
+_CHUNK_SIZE = 64
+_HEAD_DIM = 128
+_VALUE_DIM = 128
+_BLOCK_KEY = 64
+_BLOCK_VALUE = 64
+_SUPPORTED_DTYPES = (torch.float16, torch.bfloat16)
+
+
+@triton.jit(do_not_specialize=["T"])
+def chunk_kda_bwd_delta_h_triton_kernel(
+    qg,
+    kg,
+    w,
+    d_output,
+    aqk,
+    gk,
+    d_final_state,
+    d_initial_state,
+    dh,
+    dv,
+    cu_seqlens,
+    chunk_offsets,
+    scale,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_RAGGED: tl.constexpr,
+    USE_FINAL_STATE: tl.constexpr,
+    STORE_INITIAL_STATE: tl.constexpr,
+    USE_INT64_OFFSETS: tl.constexpr,
+):
+    """Traverse one sequence/head/value tile with an FP32 state cotangent."""
+    sequence_head = tl.program_id(0)
+    value_tile = tl.program_id(1)
+    if USE_INT64_OFFSETS:
+        sequence_head = sequence_head.to(tl.int64)
+        value_tile = value_tile.to(tl.int64)
+        T = T.to(tl.int64)
+    sequence = sequence_head // H
+    head = sequence_head % H
+
+    if IS_RAGGED:
+        sequence_begin, sequence_end, chunk_begin = load_ragged_sequence_work(
+            cu_seqlens,
+            chunk_offsets,
+            sequence,
+        )
+        if USE_INT64_OFFSETS:
+            sequence_begin = sequence_begin.to(tl.int64)
+            sequence_end = sequence_end.to(tl.int64)
+            chunk_begin = chunk_begin.to(tl.int64)
+        chunk_count = (sequence_end - sequence_begin + BT - 1) // BT
+    else:
+        sequence_begin = T * 0
+        sequence_end = T
+        chunk_begin = T * 0
+        chunk_count = T // BT
+
+    row = tl.arange(0, BT)
+    key_1 = tl.arange(0, BK)
+    key_2 = BK + key_1
+    value = value_tile * BV + tl.arange(0, BV)
+    value_mask = value < V
+    d_state_1 = tl.zeros((BK, BV), dtype=tl.float32)
+    d_state_2 = tl.zeros((BK, BV), dtype=tl.float32)
+
+    state_base = ptr_offset((sequence, head), (H * V * K, V * K))
+    if USE_FINAL_STATE:
+        final_offset_1 = state_base + ptr_offset(
+            (value[None, :], key_1[:, None]),
+            (K, 1),
+        )
+        final_offset_2 = state_base + ptr_offset(
+            (value[None, :], key_2[:, None]),
+            (K, 1),
+        )
+        d_state_1 += tl.load(
+            d_final_state + final_offset_1,
+            mask=value_mask[None, :],
+            other=0.0,
+        ).to(tl.float32)
+        d_state_2 += tl.load(
+            d_final_state + final_offset_2,
+            mask=value_mask[None, :],
+            other=0.0,
+        ).to(tl.float32)
+
+    for local_chunk in range(chunk_count - 1, -1, -1):
+        global_chunk = chunk_begin + local_chunk
+        token_start = sequence_begin + local_chunk * BT
+        valid_tokens = tl.minimum(BT, sequence_end - token_start)
+        token = token_start + row
+        token_mask = row < valid_tokens
+
+        dh_base = ptr_offset((global_chunk, head), (H * K * V, K * V))
+        dh_offset_1 = dh_base + ptr_offset(
+            (key_1[:, None], value[None, :]),
+            (V, 1),
+        )
+        dh_offset_2 = dh_base + ptr_offset(
+            (key_2[:, None], value[None, :]),
+            (V, 1),
+        )
+        tl.store(
+            dh + dh_offset_1,
+            d_state_1.to(dh.dtype.element_ty),
+            mask=value_mask[None, :],
+        )
+        tl.store(
+            dh + dh_offset_2,
+            d_state_2.to(dh.dtype.element_ty),
+            mask=value_mask[None, :],
+        )
+
+        key_base = ptr_offset((token[:, None], head), (H * K, K))
+        kg_tile_1 = tl.load(
+            kg + key_base + key_1[None, :],
+            mask=token_mask[:, None],
+            other=0.0,
+        )
+        kg_tile_2 = tl.load(
+            kg + key_base + key_2[None, :],
+            mask=token_mask[:, None],
+            other=0.0,
+        )
+        value_gradient = tl.dot(kg_tile_1, d_state_1.to(kg_tile_1.dtype))
+        value_gradient += tl.dot(kg_tile_2, d_state_2.to(kg_tile_2.dtype))
+
+        value_offset = ptr_offset(
+            (token[:, None], head, value[None, :]),
+            (H * V, V, 1),
+        )
+        output_tile = tl.load(
+            d_output + value_offset,
+            mask=token_mask[:, None] & value_mask[None, :],
+            other=0.0,
+        )
+        causal = row[:, None] >= row[None, :]
+        aqk_tile = tl.load(
+            aqk
+            + ptr_offset(
+                (token[:, None], head, row[None, :]),
+                (H * BT, BT, 1),
+            ),
+            mask=token_mask[:, None] & token_mask[None, :] & causal,
+            other=0.0,
+        )
+        value_gradient += tl.dot(tl.trans(aqk_tile), output_tile)
+        tl.store(
+            dv + value_offset,
+            value_gradient.to(dv.dtype.element_ty),
+            mask=token_mask[:, None] & value_mask[None, :],
+        )
+
+        last_token = token_start + valid_tokens - 1
+        gate_base = ptr_offset((last_token, head), (H * K, K))
+        gate_1 = tl.load(gk + gate_base + key_1).to(tl.float32)
+        gate_2 = tl.load(gk + gate_base + key_2).to(tl.float32)
+        d_state_1 *= tl.exp2(gate_1)[:, None]
+        d_state_2 *= tl.exp2(gate_2)[:, None]
+
+        qg_tile_1 = tl.load(
+            qg + key_base + key_1[None, :],
+            mask=token_mask[:, None],
+            other=0.0,
+        )
+        qg_tile_2 = tl.load(
+            qg + key_base + key_2[None, :],
+            mask=token_mask[:, None],
+            other=0.0,
+        )
+        d_state_1 += tl.dot(tl.trans(qg_tile_1), output_tile) * scale
+        d_state_2 += tl.dot(tl.trans(qg_tile_2), output_tile) * scale
+
+        w_tile_1 = tl.load(
+            w + key_base + key_1[None, :],
+            mask=token_mask[:, None],
+            other=0.0,
+        )
+        w_tile_2 = tl.load(
+            w + key_base + key_2[None, :],
+            mask=token_mask[:, None],
+            other=0.0,
+        )
+        narrowed_value_gradient = value_gradient.to(w_tile_1.dtype)
+        d_state_1 -= tl.dot(tl.trans(w_tile_1), narrowed_value_gradient)
+        d_state_2 -= tl.dot(tl.trans(w_tile_2), narrowed_value_gradient)
+
+    if STORE_INITIAL_STATE:
+        initial_offset_1 = state_base + ptr_offset(
+            (value[None, :], key_1[:, None]),
+            (K, 1),
+        )
+        initial_offset_2 = state_base + ptr_offset(
+            (value[None, :], key_2[:, None]),
+            (K, 1),
+        )
+        tl.store(
+            d_initial_state + initial_offset_1,
+            d_state_1,
+            mask=value_mask[None, :],
+        )
+        tl.store(
+            d_initial_state + initial_offset_2,
+            d_state_2,
+            mask=value_mask[None, :],
+        )
+
+
+def chunk_kda_bwd_delta_h_triton(
+    qg: torch.Tensor,
+    kg: torch.Tensor,
+    w: torch.Tensor,
+    d_output: torch.Tensor,
+    aqk: torch.Tensor,
+    *,
+    gk: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    d_final_state: torch.Tensor | None,
+    scale: float,
+    metadata: RaggedChunkMetadata | None,
+) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor]:
+    """Run the Triton KDA reverse delta-H stage.
+
+    Args:
+        qg: Gated queries with shape ``[1, T, H, 128]``.
+        kg: Gated keys with the same shape and dtype as ``qg``.
+        w: Delta-rule weights with the same shape and dtype as ``qg``.
+        d_output: Output cotangent with shape ``[1, T, H, 128]``.
+        aqk: Intra-chunk factor with shape ``[1, T, H, 64]``.
+        gk: FP32 cumulative key gate with shape ``[1, T, H, 128]``.
+        initial_state: Optional FP32 state ``[N, H, 128, 128]``. Its presence
+            requests the initial-state cotangent; its values are not read.
+        d_final_state: Optional FP32 final-state cotangent with the state shape.
+        scale: Query/output contribution scale.
+        metadata: Packed BT64 routing, or ``None`` for complete dense chunks.
+
+    Returns:
+        ``(dh, d_initial_state, dv)`` where ``dh`` has shape
+        ``[1, capacity, H, 128, 128]`` in the input dtype,
+        ``d_initial_state`` is optional FP32 ``[N, H, 128, 128]``, and ``dv``
+        matches ``d_output``.
+    """
+    if qg.ndim != 4:
+        raise ValueError(f"qg must be 4D, got shape {tuple(qg.shape)}")
+    batch, tokens, heads, key_dim = qg.shape
+    expected_key_shape = (1, tokens, heads, _HEAD_DIM)
+    expected_value_shape = (1, tokens, heads, _VALUE_DIM)
+    if batch != 1 or heads < 1 or key_dim != _HEAD_DIM:
+        raise ValueError("Hopper delta-H requires qg shape [1, T, H, 128] with H >= 1")
+    if kg.shape != expected_key_shape or w.shape != expected_key_shape:
+        raise ValueError(f"kg and w must have shape {expected_key_shape}")
+    if d_output.shape != expected_value_shape:
+        raise ValueError(f"d_output must have shape {expected_value_shape}")
+    if aqk.shape != (1, tokens, heads, _CHUNK_SIZE):
+        raise ValueError(f"aqk must have shape {(1, tokens, heads, _CHUNK_SIZE)}")
+    if gk.shape != expected_key_shape:
+        raise ValueError(f"gk must have shape {expected_key_shape}")
+    if qg.dtype not in _SUPPORTED_DTYPES or any(
+        tensor.dtype != qg.dtype for tensor in (kg, w, d_output, aqk)
+    ):
+        raise TypeError("qg, kg, w, d_output, and aqk must share dtype float16 or bfloat16")
+    if gk.dtype != torch.float32:
+        raise TypeError("gk must use float32")
+
+    inputs = (qg, kg, w, d_output, aqk, gk)
+    if not qg.is_cuda or any(tensor.device != qg.device for tensor in inputs):
+        raise ValueError("Hopper delta-H requires all inputs on the same CUDA device")
+    if any(not tensor.is_contiguous() for tensor in inputs):
+        raise ValueError("Hopper delta-H requires contiguous inputs")
+
+    if metadata is None:
+        if tokens % _CHUNK_SIZE:
+            raise ValueError(f"dense Hopper delta-H requires complete BT64 chunks, got T={tokens}")
+        cu_seqlens = None
+        chunk_offsets = None
+        num_sequences = 1
+        capacity = tokens // _CHUNK_SIZE
+    else:
+        metadata.validate_chunk_size(_CHUNK_SIZE)
+        cu_seqlens = metadata.cu_seqlens
+        chunk_offsets = metadata.chunk_offsets
+        num_sequences = cu_seqlens.shape[0] - 1
+        capacity = metadata.capacity
+
+    state_shape = (num_sequences, heads, _VALUE_DIM, _HEAD_DIM)
+    for name, state in (("initial_state", initial_state), ("d_final_state", d_final_state)):
+        if state is not None and state.shape != state_shape:
+            raise ValueError(f"{name} must have shape {state_shape}, got {tuple(state.shape)}")
+        if state is not None and (state.dtype != torch.float32 or state.device != qg.device):
+            raise TypeError(f"{name} must be float32 on qg.device")
+    if d_final_state is not None and not d_final_state.is_contiguous():
+        raise TypeError("d_final_state must be contiguous")
+
+    output_factory = torch.zeros if metadata is not None else torch.empty
+    dh = output_factory(
+        (1, capacity, heads, _HEAD_DIM, _VALUE_DIM),
+        dtype=qg.dtype,
+        device=qg.device,
+    )
+    dv = output_factory(d_output.shape, dtype=d_output.dtype, device=d_output.device)
+    d_initial_state = (
+        torch.empty(state_shape, dtype=torch.float32, device=qg.device)
+        if initial_state is not None
+        else None
+    )
+    if isinstance(qg, FakeTensor):
+        return dh, d_initial_state, dv
+
+    use_int64_offsets = requires_int64_offsets(
+        qg,
+        kg,
+        w,
+        d_output,
+        aqk,
+        gk,
+        d_final_state,
+        dh,
+        d_initial_state,
+        dv,
+        cu_seqlens,
+        chunk_offsets,
+    )
+    chunk_kda_bwd_delta_h_triton_kernel[(num_sequences * heads, _VALUE_DIM // _BLOCK_VALUE)](
+        qg,
+        kg,
+        w,
+        d_output,
+        aqk,
+        gk,
+        d_final_state,
+        d_initial_state,
+        dh,
+        dv,
+        cu_seqlens,
+        chunk_offsets,
+        float(scale),
+        tokens,
+        H=heads,
+        K=_HEAD_DIM,
+        V=_VALUE_DIM,
+        BT=_CHUNK_SIZE,
+        BK=_BLOCK_KEY,
+        BV=_BLOCK_VALUE,
+        IS_RAGGED=metadata is not None,
+        USE_FINAL_STATE=d_final_state is not None,
+        STORE_INITIAL_STATE=initial_state is not None,
+        USE_INT64_OFFSETS=use_int64_offsets,
+        num_warps=4,
+        num_stages=2,
+    )
+    return dh, d_initial_state, dv
+
+
+__all__ = ["chunk_kda_bwd_delta_h_triton"]

--- a/attn_gym/linear/kda/bwd/triton/chunk_kda_bwd_wy_triton.py
+++ b/attn_gym/linear/kda/bwd/triton/chunk_kda_bwd_wy_triton.py
@@ -1,0 +1,685 @@
+# Copyright (c) 2026 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Correctness-first Triton KDA WY/dQKG backward for BT64 and K=V=128.
+
+The implementation follows the KDA inverse's channelwise-gated VJP rather than
+scalar GDN's gate algebra. Its three stages compute ``dQ/dW`` from state products,
+apply ``A.T`` to form ``dK/dV/dG/dBeta``, then evaluate
+``dA = -A.T @ tril(beta * (dV @ V.T + dW @ KG.T), -1) @ A.T``. Matrix products
+accumulate in FP32, while the internal dW staging tensor and public dV result use
+the FP16/BF16 input dtype.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+from torch._subclasses.fake_tensor import FakeTensor
+
+from attn_gym._backends.triton.utils import ptr_offset, requires_int64_offsets
+from attn_gym.linear.kda.chunk_scheduler import (
+    RaggedChunkMetadata,
+    load_ragged_chunk_count,
+    load_ragged_chunk_work,
+)
+from attn_gym.linear.kda.utils import masked_exp2
+
+_CHUNK_SIZE = 64
+_HEAD_DIM = 128
+_VALUE_DIM = 128
+_BLOCK_KEY = 32
+_BLOCK_VALUE = 32
+_KEY_TILES = _HEAD_DIM // _BLOCK_KEY
+_SUPPORTED_DTYPES = (torch.float16, torch.bfloat16)
+
+
+@triton.jit
+def _load_chunk_work(
+    global_chunk,
+    cu_seqlens,
+    chunk_offsets,
+    num_sequences,
+    BT: tl.constexpr,
+    IS_RAGGED: tl.constexpr,
+    USE_INT64_OFFSETS: tl.constexpr,
+):
+    """Decode one known-active dense or packed chunk."""
+    if IS_RAGGED:
+        _, _, token_start, valid_tokens = load_ragged_chunk_work(
+            cu_seqlens,
+            chunk_offsets,
+            global_chunk,
+            num_sequences,
+            BT,
+        )
+    else:
+        if USE_INT64_OFFSETS:
+            global_chunk = global_chunk.to(tl.int64)
+        token_start = global_chunk * BT
+        valid_tokens = global_chunk * 0 + BT
+    if USE_INT64_OFFSETS:
+        token_start = token_start.to(tl.int64)
+        valid_tokens = valid_tokens.to(tl.int64)
+    return token_start, valid_tokens
+
+
+@triton.jit(do_not_specialize=["num_sequences"])
+def chunk_kda_bwd_wy_direct_triton_kernel(
+    q,
+    k,
+    v_new,
+    gate,
+    h,
+    d_output,
+    dh,
+    dv,
+    dq,
+    dk,
+    dg,
+    dw,
+    cu_seqlens,
+    chunk_offsets,
+    num_sequences,
+    scale,
+    q_stride_t,
+    q_stride_h,
+    k_stride_t,
+    k_stride_h,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_RAGGED: tl.constexpr,
+    USE_INT64_OFFSETS: tl.constexpr,
+    FASTMATH: tl.constexpr,
+):
+    """Compute dQ, the state part of dK/dG, and low-precision dW."""
+    global_chunk = tl.program_id(0)
+    head = tl.program_id(1)
+    key_tile = tl.program_id(2)
+    if IS_RAGGED and global_chunk >= load_ragged_chunk_count(chunk_offsets, num_sequences):
+        return
+    token_start, valid_tokens = _load_chunk_work(
+        global_chunk,
+        cu_seqlens,
+        chunk_offsets,
+        num_sequences,
+        BT,
+        IS_RAGGED,
+        USE_INT64_OFFSETS,
+    )
+    if USE_INT64_OFFSETS:
+        global_chunk = global_chunk.to(tl.int64)
+        head = head.to(tl.int64)
+        key_tile = key_tile.to(tl.int64)
+
+    row = tl.arange(0, BT)
+    key = key_tile * BK + tl.arange(0, BK)
+    token = token_start + row
+    token_mask = row < valid_tokens
+    key_mask = key < K
+    matrix_mask = token_mask[:, None] & key_mask[None, :]
+
+    dq_accumulator = tl.zeros((BT, BK), dtype=tl.float32)
+    dk_accumulator = tl.zeros((BT, BK), dtype=tl.float32)
+    dw_accumulator = tl.zeros((BT, BK), dtype=tl.float32)
+    state_gate_gradient = tl.zeros((BK,), dtype=tl.float32)
+
+    for value_start in tl.static_range(0, V, BV):
+        value = value_start + tl.arange(0, BV)
+        value_mask = value < V
+        token_value_offset = ptr_offset(
+            (token[:, None], head, value[None, :]),
+            (H * V, V, 1),
+        )
+        state_offset = ptr_offset(
+            (global_chunk, head, key[:, None], value[None, :]),
+            (H * K * V, K * V, V, 1),
+        )
+        value_tile_mask = token_mask[:, None] & value_mask[None, :]
+        state_tile_mask = key_mask[:, None] & value_mask[None, :]
+
+        output_tile = tl.load(
+            d_output + token_value_offset,
+            mask=value_tile_mask,
+            other=0.0,
+        )
+        v_new_tile = tl.load(v_new + token_value_offset, mask=value_tile_mask, other=0.0)
+        dv_tile = tl.load(dv + token_value_offset, mask=value_tile_mask, other=0.0)
+        h_tile = tl.load(h + state_offset, mask=state_tile_mask, other=0.0)
+        dh_tile = tl.load(dh + state_offset, mask=state_tile_mask, other=0.0)
+
+        dq_accumulator += tl.dot(output_tile, tl.trans(h_tile))
+        dk_accumulator += tl.dot(v_new_tile, tl.trans(dh_tile))
+        dw_accumulator -= tl.dot(dv_tile, tl.trans(h_tile))
+        state_gate_gradient += tl.sum(h_tile.to(tl.float32) * dh_tile, axis=1)
+
+    q_offset = ptr_offset(
+        (token[:, None], head, key[None, :]),
+        (q_stride_t, q_stride_h, 1),
+    )
+    k_offset = ptr_offset(
+        (token[:, None], head, key[None, :]),
+        (k_stride_t, k_stride_h, 1),
+    )
+    compact_key_offset = ptr_offset(
+        (token[:, None], head, key[None, :]),
+        (H * K, K, 1),
+    )
+    q_tile = tl.load(q + q_offset, mask=matrix_mask, other=0.0)
+    k_tile = tl.load(k + k_offset, mask=matrix_mask, other=0.0)
+    gate_tile = tl.load(gate + compact_key_offset, mask=matrix_mask, other=0.0).to(tl.float32)
+
+    last_token = token_start + valid_tokens - 1
+    last_gate_offset = ptr_offset((last_token, head, key), (H * K, K, 1))
+    last_gate = tl.load(gate + last_gate_offset, mask=key_mask, other=0.0).to(tl.float32)
+    gate_exp = masked_exp2(gate_tile, matrix_mask, FASTMATH)
+    reverse_decay = masked_exp2(last_gate[None, :] - gate_tile, matrix_mask, FASTMATH)
+
+    dq_tile = dq_accumulator * gate_exp * scale
+    dk_state = dk_accumulator * reverse_decay
+    k_dk_state = k_tile.to(tl.float32) * dk_state
+    dg_tile = q_tile.to(tl.float32) * dq_tile - k_dk_state
+    last_gradient = state_gate_gradient * masked_exp2(last_gate, key_mask, FASTMATH)
+    last_gradient += tl.sum(k_dk_state, axis=0)
+    dg_tile += tl.where(row[:, None] == valid_tokens - 1, last_gradient[None, :], 0.0)
+
+    tl.store(dq + compact_key_offset, dq_tile, mask=matrix_mask)
+    tl.store(dk + compact_key_offset, dk_state, mask=matrix_mask)
+    tl.store(dg + compact_key_offset, dg_tile, mask=matrix_mask)
+    tl.store(
+        dw + compact_key_offset,
+        dw_accumulator.to(dw.dtype.element_ty),
+        mask=matrix_mask,
+    )
+
+
+@triton.jit(do_not_specialize=["num_sequences"])
+def chunk_kda_bwd_wy_apply_triton_kernel(
+    k,
+    v,
+    gate,
+    beta,
+    inverse,
+    dw,
+    dv,
+    dk,
+    d_value,
+    dg,
+    db,
+    cu_seqlens,
+    chunk_offsets,
+    num_sequences,
+    k_stride_t,
+    k_stride_h,
+    v_stride_t,
+    v_stride_h,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_RAGGED: tl.constexpr,
+    USE_INT64_OFFSETS: tl.constexpr,
+    FASTMATH: tl.constexpr,
+):
+    """Apply A^T to dW/dV and emit dK/dV/dG/dBeta in one chunk program."""
+    global_chunk = tl.program_id(0)
+    head = tl.program_id(1)
+    if IS_RAGGED and global_chunk >= load_ragged_chunk_count(chunk_offsets, num_sequences):
+        return
+    token_start, valid_tokens = _load_chunk_work(
+        global_chunk,
+        cu_seqlens,
+        chunk_offsets,
+        num_sequences,
+        BT,
+        IS_RAGGED,
+        USE_INT64_OFFSETS,
+    )
+    if USE_INT64_OFFSETS:
+        global_chunk = global_chunk.to(tl.int64)
+        head = head.to(tl.int64)
+
+    row = tl.arange(0, BT)
+    column = tl.arange(0, BT)
+    token = token_start + row
+    token_mask = row < valid_tokens
+    inverse_mask = token_mask[:, None] & (column[None, :] < valid_tokens)
+    inverse_offset = ptr_offset(
+        (token[:, None], head, column[None, :]),
+        (H * BT, BT, 1),
+    )
+    inverse_tile = tl.load(inverse + inverse_offset, mask=inverse_mask, other=0.0)
+    beta_offset = ptr_offset((token, head), (H, 1))
+    beta_tile = tl.load(beta + beta_offset, mask=token_mask, other=0.0).to(tl.float32)
+    db_accumulator = tl.zeros((BT,), dtype=tl.float32)
+
+    for key_start in tl.static_range(0, K, BK):
+        key = key_start + tl.arange(0, BK)
+        key_mask = key < K
+        key_matrix_mask = token_mask[:, None] & key_mask[None, :]
+        compact_key_offset = ptr_offset(
+            (token[:, None], head, key[None, :]),
+            (H * K, K, 1),
+        )
+        dw_tile = tl.load(dw + compact_key_offset, mask=key_matrix_mask, other=0.0)
+        dkgb = tl.dot(tl.trans(inverse_tile), dw_tile)
+        k_offset = ptr_offset(
+            (token[:, None], head, key[None, :]),
+            (k_stride_t, k_stride_h, 1),
+        )
+        k_tile = tl.load(k + k_offset, mask=key_matrix_mask, other=0.0)
+        gate_tile = tl.load(
+            gate + compact_key_offset,
+            mask=key_matrix_mask,
+            other=0.0,
+        ).to(tl.float32)
+        gate_exp = masked_exp2(gate_tile, key_matrix_mask, FASTMATH)
+        kg = k_tile.to(tl.float32) * gate_exp
+        dk_tile = tl.load(dk + compact_key_offset, mask=key_matrix_mask, other=0.0)
+        dg_tile = tl.load(dg + compact_key_offset, mask=key_matrix_mask, other=0.0)
+        dk_tile += dkgb * (beta_tile[:, None] * gate_exp)
+        dg_tile += kg * dkgb * beta_tile[:, None]
+        db_accumulator += tl.sum(dkgb * kg, axis=1)
+        tl.store(dk + compact_key_offset, dk_tile, mask=key_matrix_mask)
+        tl.store(dg + compact_key_offset, dg_tile, mask=key_matrix_mask)
+
+    for value_start in tl.static_range(0, V, BV):
+        value = value_start + tl.arange(0, BV)
+        value_mask = value < V
+        value_matrix_mask = token_mask[:, None] & value_mask[None, :]
+        compact_value_offset = ptr_offset(
+            (token[:, None], head, value[None, :]),
+            (H * V, V, 1),
+        )
+        dv_tile = tl.load(dv + compact_value_offset, mask=value_matrix_mask, other=0.0)
+        dvb = tl.dot(tl.trans(inverse_tile), dv_tile)
+        v_offset = ptr_offset(
+            (token[:, None], head, value[None, :]),
+            (v_stride_t, v_stride_h, 1),
+        )
+        v_tile = tl.load(v + v_offset, mask=value_matrix_mask, other=0.0)
+        db_accumulator += tl.sum(dvb * v_tile.to(tl.float32), axis=1)
+        tl.store(
+            d_value + compact_value_offset,
+            (dvb * beta_tile[:, None]).to(d_value.dtype.element_ty),
+            mask=value_matrix_mask,
+        )
+
+    tl.store(db + beta_offset, db_accumulator, mask=token_mask)
+
+
+@triton.jit(do_not_specialize=["num_sequences"])
+def chunk_kda_bwd_wy_dA_triton_kernel(
+    k,
+    v,
+    gate,
+    beta,
+    inverse,
+    dw,
+    dv,
+    d_inverse,
+    cu_seqlens,
+    chunk_offsets,
+    num_sequences,
+    k_stride_t,
+    k_stride_h,
+    v_stride_t,
+    v_stride_h,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_RAGGED: tl.constexpr,
+    USE_INT64_OFFSETS: tl.constexpr,
+    FASTMATH: tl.constexpr,
+):
+    """Form the strict-lower dAkk VJP for one chunk and head."""
+    global_chunk = tl.program_id(0)
+    head = tl.program_id(1)
+    if IS_RAGGED and global_chunk >= load_ragged_chunk_count(chunk_offsets, num_sequences):
+        return
+    token_start, valid_tokens = _load_chunk_work(
+        global_chunk,
+        cu_seqlens,
+        chunk_offsets,
+        num_sequences,
+        BT,
+        IS_RAGGED,
+        USE_INT64_OFFSETS,
+    )
+    if USE_INT64_OFFSETS:
+        global_chunk = global_chunk.to(tl.int64)
+        head = head.to(tl.int64)
+
+    row = tl.arange(0, BT)
+    column = tl.arange(0, BT)
+    row_token = token_start + row
+    column_token = token_start + column
+    row_mask = row < valid_tokens
+    column_mask = column < valid_tokens
+    matrix_mask = row_mask[:, None] & column_mask[None, :]
+    dA_repr = tl.zeros((BT, BT), dtype=tl.float32)
+
+    for value_start in tl.static_range(0, V, BV):
+        value = value_start + tl.arange(0, BV)
+        value_mask = value < V
+        dv_offset = ptr_offset(
+            (row_token[:, None], head, value[None, :]),
+            (H * V, V, 1),
+        )
+        v_offset = ptr_offset(
+            (column_token[:, None], head, value[None, :]),
+            (v_stride_t, v_stride_h, 1),
+        )
+        dv_tile = tl.load(
+            dv + dv_offset,
+            mask=row_mask[:, None] & value_mask[None, :],
+            other=0.0,
+        )
+        v_tile = tl.load(
+            v + v_offset,
+            mask=column_mask[:, None] & value_mask[None, :],
+            other=0.0,
+        )
+        dA_repr += tl.dot(dv_tile, tl.trans(v_tile))
+
+    for key_start in tl.static_range(0, K, BK):
+        key = key_start + tl.arange(0, BK)
+        key_mask = key < K
+        dw_offset = ptr_offset(
+            (row_token[:, None], head, key[None, :]),
+            (H * K, K, 1),
+        )
+        k_offset = ptr_offset(
+            (column_token[:, None], head, key[None, :]),
+            (k_stride_t, k_stride_h, 1),
+        )
+        gate_offset = ptr_offset(
+            (column_token[:, None], head, key[None, :]),
+            (H * K, K, 1),
+        )
+        dw_tile = tl.load(
+            dw + dw_offset,
+            mask=row_mask[:, None] & key_mask[None, :],
+            other=0.0,
+        )
+        k_tile = tl.load(
+            k + k_offset,
+            mask=column_mask[:, None] & key_mask[None, :],
+            other=0.0,
+        )
+        gate_mask = column_mask[:, None] & key_mask[None, :]
+        gate_tile = tl.load(gate + gate_offset, mask=gate_mask, other=0.0).to(tl.float32)
+        kg_tile = (k_tile.to(tl.float32) * masked_exp2(gate_tile, gate_mask, FASTMATH)).to(
+            k_tile.dtype
+        )
+        dA_repr += tl.dot(dw_tile, tl.trans(kg_tile))
+
+    beta_offset = ptr_offset((column_token, head), (H, 1))
+    beta_column = tl.load(beta + beta_offset, mask=column_mask, other=0.0).to(tl.float32)
+    strict_lower = (row[:, None] > column[None, :]) & matrix_mask
+    dA_repr = tl.where(strict_lower, dA_repr * beta_column[None, :], 0.0)
+
+    inverse_offset = ptr_offset(
+        (row_token[:, None], head, column[None, :]),
+        (H * BT, BT, 1),
+    )
+    inverse_tile = tl.load(inverse + inverse_offset, mask=matrix_mask, other=0.0)
+    inverse_fp32 = inverse_tile.to(tl.float32)
+    right_product = tl.dot(dA_repr, tl.trans(inverse_fp32), input_precision="tf32")
+    result = -tl.dot(tl.trans(inverse_fp32), right_product, input_precision="tf32")
+    result = tl.where(strict_lower, result, 0.0)
+    tl.store(d_inverse + inverse_offset, result, mask=row_mask[:, None])
+
+
+def chunk_kda_bwd_wy_triton(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    v_new: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    A: torch.Tensor,
+    h: torch.Tensor,
+    d_output: torch.Tensor,
+    dh: torch.Tensor,
+    dv: torch.Tensor,
+    metadata: RaggedChunkMetadata | None,
+    *,
+    scale: float,
+    fastmath: bool = False,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    """Differentiate Triton KDA's WY representation and chunk-level state path.
+
+    Args:
+        q: Queries with shape ``[1, T, H, 128]``.
+        k: Keys with the same shape and dtype as ``q``.
+        v: Values with the same shape and dtype as ``q``.
+        v_new: Recomputed WY values with the same shape and dtype as ``q``.
+        g: FP32 cumulative per-channel log2 gate with shape ``[1, T, H, 128]``.
+        beta: FP32 update strength with shape ``[1, T, H]``.
+        A: Recomputed inverse with shape ``[1, T, H, 64]`` in the QKV dtype.
+        h: Chunk-start state tape ``[1, capacity, H, 128, 128]`` in the QKV dtype.
+        d_output: Output cotangent with the same shape and dtype as ``v``.
+        dh: Chunk state cotangent tape with the same shape and dtype as ``h``.
+        dv: Incoming WY-value cotangent with the same shape and dtype as ``v``.
+        metadata: Packed BT64 routing, or ``None`` for complete dense chunks.
+        scale: Query/output scale; it multiplies only ``dq``.
+        fastmath: Use approximate exponentials instead of libdevice exponentials.
+
+    Returns:
+        ``(dq, dk, dv, dg, db, dA)``. ``dq``, ``dk``, ``dg``, ``db``, and ``dA``
+        are FP32; the returned ``dv`` uses the QKV dtype. Packed capacity outside
+        active sequences is zero.
+    """
+    if q.ndim != 4:
+        raise ValueError(f"q must be 4D, got shape {tuple(q.shape)}")
+    batch, tokens, heads, key_dim = q.shape
+    token_shape = (1, tokens, heads, _HEAD_DIM)
+    if batch != 1 or heads < 1 or key_dim != _HEAD_DIM:
+        raise ValueError("Triton WY requires q shape [1, T, H, 128] with H >= 1")
+    for name, tensor in (
+        ("k", k),
+        ("v", v),
+        ("v_new", v_new),
+        ("d_output", d_output),
+        ("dv", dv),
+    ):
+        if tensor.shape != token_shape:
+            raise ValueError(f"{name} must have shape {token_shape}, got {tuple(tensor.shape)}")
+    if g.shape != token_shape:
+        raise ValueError(f"g must have shape {token_shape}, got {tuple(g.shape)}")
+    if beta.shape != token_shape[:3]:
+        raise ValueError(f"beta must have shape {token_shape[:3]}, got {tuple(beta.shape)}")
+    if A.shape != (1, tokens, heads, _CHUNK_SIZE):
+        raise ValueError(
+            f"A must have shape {(1, tokens, heads, _CHUNK_SIZE)}, got {tuple(A.shape)}"
+        )
+
+    low_precision_inputs = (k, v, v_new, A, d_output, dv)
+    if q.dtype not in _SUPPORTED_DTYPES or any(
+        tensor.dtype != q.dtype for tensor in low_precision_inputs
+    ):
+        raise TypeError("q, k, v, v_new, A, d_output, and dv must share dtype float16 or bfloat16")
+    if g.dtype != torch.float32 or beta.dtype != torch.float32:
+        raise TypeError("g and beta must use float32")
+    inputs = (q, k, v, v_new, g, beta, A, d_output, dv)
+    if not q.is_cuda or any(tensor.device != q.device for tensor in inputs):
+        raise ValueError("Triton WY requires all inputs on the same CUDA device")
+    if any(tensor.stride(-1) != 1 for tensor in (q, k, v)):
+        raise ValueError("q, k, and v must be contiguous in their last dimension")
+    if any(not tensor.is_contiguous() for tensor in (v_new, g, beta, A, d_output, dv)):
+        raise ValueError("v_new, g, beta, A, d_output, and dv must be contiguous")
+
+    if metadata is None:
+        if tokens % _CHUNK_SIZE:
+            raise ValueError(f"dense Triton WY requires complete BT64 chunks, got T={tokens}")
+        cu_seqlens = None
+        chunk_offsets = None
+        num_sequences = 1
+        capacity = tokens // _CHUNK_SIZE
+    else:
+        metadata.validate_chunk_size(_CHUNK_SIZE)
+        cu_seqlens = metadata.cu_seqlens
+        chunk_offsets = metadata.chunk_offsets
+        num_sequences = cu_seqlens.shape[0] - 1
+        capacity = metadata.capacity
+
+    state_shape = (1, capacity, heads, _HEAD_DIM, _VALUE_DIM)
+    for name, tensor in (("h", h), ("dh", dh)):
+        if tensor.shape != state_shape:
+            raise ValueError(f"{name} must have shape {state_shape}, got {tuple(tensor.shape)}")
+        if tensor.dtype != q.dtype or tensor.device != q.device or not tensor.is_contiguous():
+            raise TypeError(f"{name} must be contiguous on q.device with dtype {q.dtype}")
+
+    output_factory = torch.zeros_like if metadata is not None else torch.empty_like
+    dq = output_factory(g, memory_format=torch.contiguous_format)
+    dk = output_factory(g, memory_format=torch.contiguous_format)
+    d_value = output_factory(v, memory_format=torch.contiguous_format)
+    dg = output_factory(g, memory_format=torch.contiguous_format)
+    db = output_factory(beta, memory_format=torch.contiguous_format)
+    dA = output_factory(A, dtype=torch.float32, memory_format=torch.contiguous_format)
+    if isinstance(q, FakeTensor) or tokens == 0:
+        return dq, dk, d_value, dg, db, dA
+
+    dw = torch.empty_like(q, memory_format=torch.contiguous_format)
+    use_int64_offsets = requires_int64_offsets(
+        q,
+        k,
+        v,
+        v_new,
+        g,
+        beta,
+        A,
+        h,
+        d_output,
+        dh,
+        dv,
+        dq,
+        dk,
+        d_value,
+        dg,
+        db,
+        dA,
+        dw,
+        cu_seqlens,
+        chunk_offsets,
+    )
+    ragged = metadata is not None
+
+    direct_grid = (capacity, heads, _KEY_TILES)
+    chunk_kda_bwd_wy_direct_triton_kernel[direct_grid](
+        q[0],
+        k[0],
+        v_new[0],
+        g[0],
+        h[0],
+        d_output[0],
+        dh[0],
+        dv[0],
+        dq[0],
+        dk[0],
+        dg[0],
+        dw[0],
+        cu_seqlens,
+        chunk_offsets,
+        num_sequences,
+        float(scale),
+        q.stride(1),
+        q.stride(2),
+        k.stride(1),
+        k.stride(2),
+        H=heads,
+        K=_HEAD_DIM,
+        V=_VALUE_DIM,
+        BT=_CHUNK_SIZE,
+        BK=_BLOCK_KEY,
+        BV=_BLOCK_VALUE,
+        IS_RAGGED=ragged,
+        USE_INT64_OFFSETS=use_int64_offsets,
+        FASTMATH=fastmath,
+        num_warps=4,
+        num_stages=2,
+    )
+    chunk_kda_bwd_wy_apply_triton_kernel[(capacity, heads)](
+        k[0],
+        v[0],
+        g[0],
+        beta[0],
+        A[0],
+        dw[0],
+        dv[0],
+        dk[0],
+        d_value[0],
+        dg[0],
+        db[0],
+        cu_seqlens,
+        chunk_offsets,
+        num_sequences,
+        k.stride(1),
+        k.stride(2),
+        v.stride(1),
+        v.stride(2),
+        H=heads,
+        K=_HEAD_DIM,
+        V=_VALUE_DIM,
+        BT=_CHUNK_SIZE,
+        BK=_BLOCK_KEY,
+        BV=_BLOCK_VALUE,
+        IS_RAGGED=ragged,
+        USE_INT64_OFFSETS=use_int64_offsets,
+        FASTMATH=fastmath,
+        num_warps=4,
+        num_stages=2,
+    )
+    chunk_kda_bwd_wy_dA_triton_kernel[(capacity, heads)](
+        k[0],
+        v[0],
+        g[0],
+        beta[0],
+        A[0],
+        dw[0],
+        dv[0],
+        dA[0],
+        cu_seqlens,
+        chunk_offsets,
+        num_sequences,
+        k.stride(1),
+        k.stride(2),
+        v.stride(1),
+        v.stride(2),
+        H=heads,
+        K=_HEAD_DIM,
+        V=_VALUE_DIM,
+        BT=_CHUNK_SIZE,
+        BK=_BLOCK_KEY,
+        BV=_BLOCK_VALUE,
+        IS_RAGGED=ragged,
+        USE_INT64_OFFSETS=use_int64_offsets,
+        FASTMATH=fastmath,
+        num_warps=4,
+        num_stages=2,
+    )
+    return dq, dk, d_value, dg, db, dA
+
+
+__all__ = ["chunk_kda_bwd_wy_triton"]

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py
@@ -1,4 +1,4 @@
-"""Composed fixed-length and packed Blackwell KDA core forward."""
+"""Composed fixed-length and packed architecture-routed KDA core forward."""
 
 from __future__ import annotations
 
@@ -81,8 +81,8 @@ def _validate_private_abi(
             "the private chunk_kda ABI requires QKV to have contiguous heads and "
             "16-byte-aligned token rows"
         )
-    if get_device_properties(q.device).major < 10:
-        raise ValueError("the CuTe KDA core requires CUDA capability 10.0 or newer")
+    if get_device_properties(q.device).major < 8:
+        raise ValueError("the fused KDA core requires CUDA capability 8.0 or newer")
 
 
 def _validate_paged_private_abi(
@@ -501,6 +501,10 @@ def _prepare_chunk_kda_backward(
         d_output = normalize_tma_rows(d_output)
     if d_final_state is not None:
         d_final_state = _normalize_state_cotangent(d_final_state.float())
+    if get_device_properties(q.device).major < 10:
+        d_output = d_output.contiguous()
+        if d_final_state is not None:
+            d_final_state = d_final_state.contiguous()
     return q, k, v, metadata, d_output, d_final_state
 
 

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_intra.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_intra.py
@@ -4,8 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 #
-# KDA forward factor composition. BF16 uses the persistent intra engine; FP16
-# uses the FP32/TF32 diagonal stage plus CuTe K3b/K4b to preserve gate range.
+# KDA forward factor composition. Pre-Blackwell GPUs use the FP32/TF32 BC16
+# diagonal stage plus Triton K3/K4; Blackwell retains its CuTe factor engines.
 
 from __future__ import annotations
 
@@ -14,6 +14,7 @@ from contextlib import nullcontext
 import torch
 from torch._subclasses.fake_tensor import FakeTensor
 
+from attn_gym._backends.cute.utils import get_device_properties
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata
 from attn_gym.linear.kda.constants import DEFAULT_CHUNK_SIZE
 from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd_inter_solve import (
@@ -26,6 +27,12 @@ from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd_intra_engine import kda_intra_en
 from attn_gym.linear.kda.fwd.cute.recompute_w_u_fwd import recompute_w_u_fwd
 from attn_gym.linear.kda.fwd.triton.chunk_kda_fwd_intra_sub_chunk_forloop import (
     chunk_kda_fwd_intra_diagonal,
+)
+from attn_gym.linear.kda.fwd.triton.chunk_kda_fwd_k3_triton import (
+    chunk_kda_fwd_k3b_triton,
+)
+from attn_gym.linear.kda.fwd.triton.chunk_kda_fwd_k4_triton import (
+    chunk_kda_fwd_k4b_triton,
 )
 
 
@@ -49,6 +56,11 @@ def chunk_kda_fwd_factors(
     if isinstance(k, FakeTensor):
         shape = (batch, tokens, heads, chunk_size)
         return k.new_empty(shape), k.new_empty(shape)
+
+    if get_device_properties(k.device).major < 10:
+        Aqk, Akkd = chunk_kda_fwd_intra_diagonal(q, k, gk, beta, scale, metadata, chunk_size)
+        AkkOD = chunk_kda_fwd_k3b_triton(q, k, gk, beta, Aqk, scale, metadata)
+        return Aqk, chunk_kda_fwd_k4b_triton(AkkOD, Akkd, metadata, output_dtype=q.dtype)
 
     if q.dtype == torch.float16:
         # The engine stores two-sided diagonal rebase factors in the I/O dtype. Their

--- a/attn_gym/linear/kda/fwd/triton/chunk_kda_fwd_intra_sub_chunk_forloop.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_kda_fwd_intra_sub_chunk_forloop.py
@@ -8,15 +8,15 @@
 #
 # Computes the diagonal 16x16 Aqk/Akk sub-blocks of each 64-token chunk and
 # inverts each diagonal Akk block by forward substitution. The off-diagonal
-# blocks and the full 64x64 block-triangular inverse are handled by the CuTe
-# K3b/K4b kernels. Only ``chunk_kda_fwd_kernel_intra_sub_chunk_forloop`` is
-# consumed by the CuTe forward path
-# (attn_gym.linear.kda.fwd.cute.chunk_kda_fwd_intra).
+# blocks and the full 64x64 block-triangular inverse are handled by the
+# architecture-selected K3/K4 stages. ``chunk_kda_fwd_kernel_intra_sub_chunk_forloop``
+# is consumed by the composed forward path in ``fwd.cute.chunk_kda_fwd_intra``.
 
 import torch
 import triton
 import triton.language as tl
 
+from attn_gym._backends.cute.utils import get_device_properties
 from attn_gym._backends.triton.utils import ptr_offset, requires_int64_offsets
 from attn_gym.linear.kda.chunk_scheduler import (
     RaggedChunkMetadata,
@@ -251,10 +251,7 @@ def chunk_kda_fwd_intra_diagonal(
     subchunk_size = 16
     subchunks = triton.cdiv(chunk_size, subchunk_size)
     capacity = triton.cdiv(tokens, chunk_size) if metadata is None else metadata.capacity
-    grid_chunks = min(
-        torch.cuda.get_device_properties(k.device).multi_processor_count,
-        capacity,
-    )
+    grid_chunks = min(get_device_properties(k.device).multi_processor_count, capacity)
     Aqk = torch.empty(
         (batch, tokens, heads, chunk_size),
         device=k.device,

--- a/attn_gym/linear/kda/fwd/triton/chunk_kda_fwd_k3_triton.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_kda_fwd_k3_triton.py
@@ -1,0 +1,543 @@
+# Copyright (c) 2026 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Triton KDA K3 off-diagonal factors over the existing BT64/BC16 ABI."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+from torch._subclasses.fake_tensor import FakeTensor
+
+from attn_gym._backends.triton.utils import ptr_offset, requires_int64_offsets
+from attn_gym.linear.kda.chunk_scheduler import (
+    RaggedChunkMetadata,
+    load_ragged_chunk_count,
+    load_ragged_chunk_work,
+)
+from attn_gym.linear.kda.utils import masked_exp2
+
+_CHUNK_SIZE = 64
+_SUBCHUNK_SIZE = 16
+_HEAD_DIM = 128
+_OFFDIAGONAL_BLOCKS = 6
+
+
+@triton.jit
+def _store_k3_block(
+    aqk,
+    akk_od,
+    aqk_block,
+    akk_block,
+    row_valid,
+    col_valid,
+    token_start,
+    global_chunk,
+    head,
+    aqk_stride_t,
+    aqk_stride_h,
+    scale,
+    H: tl.constexpr,
+    BC: tl.constexpr,
+    PAIR: tl.constexpr,
+    ROW_BLOCK: tl.constexpr,
+    COL_BLOCK: tl.constexpr,
+):
+    """Store one K3 block into the existing Aqk and temporary Akk layouts."""
+    row = tl.arange(0, BC)
+    output_rows = token_start + ROW_BLOCK * BC + row
+    output_cols = COL_BLOCK * BC + row
+    aqk_value = tl.where(col_valid[None, :], aqk_block * scale, 0.0)
+    tl.store(
+        aqk
+        + ptr_offset(
+            (output_rows[:, None], head, output_cols[None, :]),
+            (aqk_stride_t, aqk_stride_h, 1),
+        ),
+        aqk_value,
+        mask=row_valid[:, None],
+    )
+
+    element = row[:, None] * BC + row[None, :]
+    output_row = global_chunk * 6 + PAIR
+    output_col = head * BC * BC + element
+    tl.store(
+        akk_od + ptr_offset((output_row, output_col), (H * BC * BC, 1)),
+        tl.where(row_valid[:, None] & col_valid[None, :], akk_block, 0.0),
+    )
+
+
+@triton.jit
+def _zero_aqk_block(
+    aqk,
+    row_valid,
+    token_start,
+    head,
+    aqk_stride_t,
+    aqk_stride_h,
+    BC: tl.constexpr,
+    ROW_BLOCK: tl.constexpr,
+    COL_BLOCK: tl.constexpr,
+):
+    """Define one block-strictly-upper Aqk tile as zero."""
+    row = tl.arange(0, BC)
+    output_rows = token_start + ROW_BLOCK * BC + row
+    output_cols = COL_BLOCK * BC + row
+    tl.store(
+        aqk
+        + ptr_offset(
+            (output_rows[:, None], head, output_cols[None, :]),
+            (aqk_stride_t, aqk_stride_h, 1),
+        ),
+        0.0,
+        mask=row_valid[:, None],
+    )
+
+
+@triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
+@triton.jit(do_not_specialize=["num_sequences"])
+def chunk_kda_fwd_k3_triton_kernel(
+    q,
+    k,
+    gate,
+    beta,
+    aqk,
+    akk_od,
+    cu_seqlens,
+    chunk_offsets,
+    num_sequences,
+    scale,
+    q_stride_t,
+    q_stride_h,
+    k_stride_t,
+    k_stride_h,
+    gate_stride_t,
+    gate_stride_h,
+    beta_stride_t,
+    beta_stride_h,
+    aqk_stride_t,
+    aqk_stride_h,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    USE_INT64_OFFSETS: tl.constexpr,
+):
+    """Produce six off-diagonal Aqk/Akk blocks for one chunk and head."""
+    global_chunk = tl.program_id(0)
+    head = tl.program_id(1)
+    if USE_INT64_OFFSETS:
+        global_chunk = global_chunk.to(tl.int64)
+        head = head.to(tl.int64)
+
+    if IS_VARLEN:
+        active_chunks = load_ragged_chunk_count(chunk_offsets, num_sequences)
+        if global_chunk >= active_chunks:
+            return
+        _, _, token_start, valid_tokens = load_ragged_chunk_work(
+            cu_seqlens,
+            chunk_offsets,
+            global_chunk,
+            num_sequences,
+            BT,
+        )
+        if USE_INT64_OFFSETS:
+            token_start = token_start.to(tl.int64)
+            valid_tokens = valid_tokens.to(tl.int64)
+    else:
+        token_start = global_chunk * BT
+        valid_tokens = BT
+
+    row = tl.arange(0, BC)
+    key = tl.arange(0, BK)
+    row_valid0 = row < tl.maximum(tl.minimum(valid_tokens, BC), 0)
+    row_valid1 = row < tl.maximum(tl.minimum(valid_tokens - BC, BC), 0)
+    row_valid2 = row < tl.maximum(tl.minimum(valid_tokens - 2 * BC, BC), 0)
+    row_valid3 = row < tl.maximum(tl.minimum(valid_tokens - 3 * BC, BC), 0)
+    has_block1 = valid_tokens > BC
+    has_block2 = valid_tokens > 2 * BC
+    has_block3 = valid_tokens > 3 * BC
+
+    # BT64 has four BC16 blocks and therefore exactly six strict-lower pairs.
+    # Keep the fixed MMA graph explicit so each accumulator maps directly to the K4 ABI.
+    aqk10 = tl.zeros([BC, BC], dtype=tl.float32)
+    aqk20 = tl.zeros([BC, BC], dtype=tl.float32)
+    aqk21 = tl.zeros([BC, BC], dtype=tl.float32)
+    aqk30 = tl.zeros([BC, BC], dtype=tl.float32)
+    aqk31 = tl.zeros([BC, BC], dtype=tl.float32)
+    aqk32 = tl.zeros([BC, BC], dtype=tl.float32)
+    akk10 = tl.zeros([BC, BC], dtype=tl.float32)
+    akk20 = tl.zeros([BC, BC], dtype=tl.float32)
+    akk21 = tl.zeros([BC, BC], dtype=tl.float32)
+    akk30 = tl.zeros([BC, BC], dtype=tl.float32)
+    akk31 = tl.zeros([BC, BC], dtype=tl.float32)
+    akk32 = tl.zeros([BC, BC], dtype=tl.float32)
+
+    for key_tile in tl.static_range(0, K, BK):
+        key_offset = key_tile + key
+        key_valid = key_offset < K
+
+        block0_rows = token_start + row
+        block1_rows = token_start + BC + row
+        block2_rows = token_start + 2 * BC + row
+        block3_rows = token_start + 3 * BC + row
+
+        q1_ptr = q + ptr_offset(
+            (block1_rows[:, None], head, key_offset[None, :]),
+            (q_stride_t, q_stride_h, 1),
+        )
+        q2_ptr = q + ptr_offset(
+            (block2_rows[:, None], head, key_offset[None, :]),
+            (q_stride_t, q_stride_h, 1),
+        )
+        q3_ptr = q + ptr_offset(
+            (block3_rows[:, None], head, key_offset[None, :]),
+            (q_stride_t, q_stride_h, 1),
+        )
+        k0_ptr = k + ptr_offset(
+            (block0_rows[:, None], head, key_offset[None, :]),
+            (k_stride_t, k_stride_h, 1),
+        )
+        k1_ptr = k + ptr_offset(
+            (block1_rows[:, None], head, key_offset[None, :]),
+            (k_stride_t, k_stride_h, 1),
+        )
+        k2_ptr = k + ptr_offset(
+            (block2_rows[:, None], head, key_offset[None, :]),
+            (k_stride_t, k_stride_h, 1),
+        )
+        k3_ptr = k + ptr_offset(
+            (block3_rows[:, None], head, key_offset[None, :]),
+            (k_stride_t, k_stride_h, 1),
+        )
+        gate0_ptr = gate + ptr_offset(
+            (block0_rows[:, None], head, key_offset[None, :]),
+            (gate_stride_t, gate_stride_h, 1),
+        )
+        gate1_ptr = gate + ptr_offset(
+            (block1_rows[:, None], head, key_offset[None, :]),
+            (gate_stride_t, gate_stride_h, 1),
+        )
+        gate2_ptr = gate + ptr_offset(
+            (block2_rows[:, None], head, key_offset[None, :]),
+            (gate_stride_t, gate_stride_h, 1),
+        )
+        gate3_ptr = gate + ptr_offset(
+            (block3_rows[:, None], head, key_offset[None, :]),
+            (gate_stride_t, gate_stride_h, 1),
+        )
+
+        mask0 = row_valid0[:, None] & key_valid[None, :]
+        mask1 = row_valid1[:, None] & key_valid[None, :]
+        mask2 = row_valid2[:, None] & key_valid[None, :]
+        mask3 = row_valid3[:, None] & key_valid[None, :]
+        q1 = tl.load(q1_ptr, mask=mask1, other=0.0)
+        q2 = tl.load(q2_ptr, mask=mask2, other=0.0)
+        q3 = tl.load(q3_ptr, mask=mask3, other=0.0)
+        k0 = tl.load(k0_ptr, mask=mask0, other=0.0)
+        k1 = tl.load(k1_ptr, mask=mask1, other=0.0)
+        k2 = tl.load(k2_ptr, mask=mask2, other=0.0)
+        k3 = tl.load(k3_ptr, mask=mask3, other=0.0)
+        gate0 = tl.load(gate0_ptr, mask=mask0, other=0.0).to(tl.float32)
+        gate1 = tl.load(gate1_ptr, mask=mask1, other=0.0).to(tl.float32)
+        gate2 = tl.load(gate2_ptr, mask=mask2, other=0.0).to(tl.float32)
+        gate3 = tl.load(gate3_ptr, mask=mask3, other=0.0).to(tl.float32)
+
+        reference1 = tl.load(
+            gate
+            + ptr_offset(
+                (token_start + BC, head, key_offset),
+                (gate_stride_t, gate_stride_h, 1),
+            ),
+            mask=has_block1 & key_valid,
+            other=0.0,
+        ).to(tl.float32)
+        reference2 = tl.load(
+            gate
+            + ptr_offset(
+                (token_start + 2 * BC, head, key_offset),
+                (gate_stride_t, gate_stride_h, 1),
+            ),
+            mask=has_block2 & key_valid,
+            other=0.0,
+        ).to(tl.float32)
+        reference3 = tl.load(
+            gate
+            + ptr_offset(
+                (token_start + 3 * BC, head, key_offset),
+                (gate_stride_t, gate_stride_h, 1),
+            ),
+            mask=has_block3 & key_valid,
+            other=0.0,
+        ).to(tl.float32)
+
+        row_scale1 = masked_exp2(gate1 - reference1[None, :], mask1)
+        row_scale2 = masked_exp2(gate2 - reference2[None, :], mask2)
+        row_scale3 = masked_exp2(gate3 - reference3[None, :], mask3)
+        qg1 = (q1 * row_scale1).to(q.dtype.element_ty)
+        qg2 = (q2 * row_scale2).to(q.dtype.element_ty)
+        qg3 = (q3 * row_scale3).to(q.dtype.element_ty)
+        kg1 = (k1 * row_scale1).to(k.dtype.element_ty)
+        kg2 = (k2 * row_scale2).to(k.dtype.element_ty)
+        kg3 = (k3 * row_scale3).to(k.dtype.element_ty)
+
+        k0g1 = (k0 * masked_exp2(reference1[None, :] - gate0, mask0)).to(k.dtype.element_ty)
+        k0g2 = (k0 * masked_exp2(reference2[None, :] - gate0, mask0)).to(k.dtype.element_ty)
+        k1g2 = (k1 * masked_exp2(reference2[None, :] - gate1, mask1)).to(k.dtype.element_ty)
+        k0g3 = (k0 * masked_exp2(reference3[None, :] - gate0, mask0)).to(k.dtype.element_ty)
+        k1g3 = (k1 * masked_exp2(reference3[None, :] - gate1, mask1)).to(k.dtype.element_ty)
+        k2g3 = (k2 * masked_exp2(reference3[None, :] - gate2, mask2)).to(k.dtype.element_ty)
+
+        aqk10 += tl.dot(qg1, tl.trans(k0g1))
+        aqk20 += tl.dot(qg2, tl.trans(k0g2))
+        aqk21 += tl.dot(qg2, tl.trans(k1g2))
+        aqk30 += tl.dot(qg3, tl.trans(k0g3))
+        aqk31 += tl.dot(qg3, tl.trans(k1g3))
+        aqk32 += tl.dot(qg3, tl.trans(k2g3))
+        akk10 += tl.dot(kg1, tl.trans(k0g1))
+        akk20 += tl.dot(kg2, tl.trans(k0g2))
+        akk21 += tl.dot(kg2, tl.trans(k1g2))
+        akk30 += tl.dot(kg3, tl.trans(k0g3))
+        akk31 += tl.dot(kg3, tl.trans(k1g3))
+        akk32 += tl.dot(kg3, tl.trans(k2g3))
+
+    beta_row = tl.arange(0, BC)
+    beta1 = tl.load(
+        beta
+        + ptr_offset(
+            (token_start + BC + beta_row, head),
+            (beta_stride_t, beta_stride_h),
+        ),
+        mask=row_valid1,
+        other=0.0,
+    ).to(tl.float32)
+    beta2 = tl.load(
+        beta
+        + ptr_offset(
+            (token_start + 2 * BC + beta_row, head),
+            (beta_stride_t, beta_stride_h),
+        ),
+        mask=row_valid2,
+        other=0.0,
+    ).to(tl.float32)
+    beta3 = tl.load(
+        beta
+        + ptr_offset(
+            (token_start + 3 * BC + beta_row, head),
+            (beta_stride_t, beta_stride_h),
+        ),
+        mask=row_valid3,
+        other=0.0,
+    ).to(tl.float32)
+
+    _store_k3_block(
+        aqk,
+        akk_od,
+        aqk10,
+        akk10 * beta1[:, None],
+        row_valid1,
+        row_valid0,
+        token_start,
+        global_chunk,
+        head,
+        aqk_stride_t,
+        aqk_stride_h,
+        scale,
+        H,
+        BC,
+        0,
+        1,
+        0,
+    )
+    _store_k3_block(
+        aqk,
+        akk_od,
+        aqk20,
+        akk20 * beta2[:, None],
+        row_valid2,
+        row_valid0,
+        token_start,
+        global_chunk,
+        head,
+        aqk_stride_t,
+        aqk_stride_h,
+        scale,
+        H,
+        BC,
+        1,
+        2,
+        0,
+    )
+    _store_k3_block(
+        aqk,
+        akk_od,
+        aqk21,
+        akk21 * beta2[:, None],
+        row_valid2,
+        row_valid1,
+        token_start,
+        global_chunk,
+        head,
+        aqk_stride_t,
+        aqk_stride_h,
+        scale,
+        H,
+        BC,
+        2,
+        2,
+        1,
+    )
+    _store_k3_block(
+        aqk,
+        akk_od,
+        aqk30,
+        akk30 * beta3[:, None],
+        row_valid3,
+        row_valid0,
+        token_start,
+        global_chunk,
+        head,
+        aqk_stride_t,
+        aqk_stride_h,
+        scale,
+        H,
+        BC,
+        3,
+        3,
+        0,
+    )
+    _store_k3_block(
+        aqk,
+        akk_od,
+        aqk31,
+        akk31 * beta3[:, None],
+        row_valid3,
+        row_valid1,
+        token_start,
+        global_chunk,
+        head,
+        aqk_stride_t,
+        aqk_stride_h,
+        scale,
+        H,
+        BC,
+        4,
+        3,
+        1,
+    )
+    _store_k3_block(
+        aqk,
+        akk_od,
+        aqk32,
+        akk32 * beta3[:, None],
+        row_valid3,
+        row_valid2,
+        token_start,
+        global_chunk,
+        head,
+        aqk_stride_t,
+        aqk_stride_h,
+        scale,
+        H,
+        BC,
+        5,
+        3,
+        2,
+    )
+    _zero_aqk_block(aqk, row_valid0, token_start, head, aqk_stride_t, aqk_stride_h, BC, 0, 1)
+    _zero_aqk_block(aqk, row_valid0, token_start, head, aqk_stride_t, aqk_stride_h, BC, 0, 2)
+    _zero_aqk_block(aqk, row_valid0, token_start, head, aqk_stride_t, aqk_stride_h, BC, 0, 3)
+    _zero_aqk_block(aqk, row_valid1, token_start, head, aqk_stride_t, aqk_stride_h, BC, 1, 2)
+    _zero_aqk_block(aqk, row_valid1, token_start, head, aqk_stride_t, aqk_stride_h, BC, 1, 3)
+    _zero_aqk_block(aqk, row_valid2, token_start, head, aqk_stride_t, aqk_stride_h, BC, 2, 3)
+
+
+def chunk_kda_fwd_k3b_triton(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    aqk: torch.Tensor,
+    scale: float,
+    metadata: RaggedChunkMetadata | None,
+) -> torch.Tensor:
+    """Complete the caller-owned Aqk tensor and return the temporary Akk blocks."""
+    batch, tokens, heads, key_dim = q.shape
+    capacity = tokens // _CHUNK_SIZE if metadata is None else metadata.capacity
+    if batch != 1 or key_dim != _HEAD_DIM or k.shape != q.shape:
+        raise ValueError("Triton K3 requires B=1 and matching Q/K with K=128")
+    if q.dtype not in (torch.float16, torch.bfloat16) or k.dtype != q.dtype:
+        raise TypeError("Triton K3 requires matching FP16 or BF16 Q/K")
+    if gate.shape != q.shape or gate.dtype != torch.float32:
+        raise TypeError("Triton K3 requires an FP32 gate shaped like Q")
+    if beta.shape != q.shape[:3] or beta.dtype != torch.float32:
+        raise TypeError("Triton K3 requires FP32 beta shaped [1, T, H]")
+    if aqk.shape != (batch, tokens, heads, _CHUNK_SIZE) or aqk.dtype != q.dtype:
+        raise TypeError("Triton K3 requires Aqk shaped [1, T, H, 64] in the Q dtype")
+    if metadata is None and tokens % _CHUNK_SIZE:
+        raise ValueError("dense Triton K3 requires complete 64-token chunks")
+    if metadata is not None:
+        metadata.validate_chunk_size(_CHUNK_SIZE)
+
+    akk_od = torch.empty(
+        capacity * _OFFDIAGONAL_BLOCKS,
+        heads * _SUBCHUNK_SIZE * _SUBCHUNK_SIZE,
+        dtype=torch.float32,
+        device=q.device,
+    )
+    if isinstance(q, FakeTensor) or capacity == 0:
+        return akk_od
+
+    q_view, k_view, gate_view = q[0], k[0], gate[0]
+    beta_view, output_view = beta[0], aqk[0]
+    cu_seqlens = None if metadata is None else metadata.cu_seqlens
+    chunk_offsets = None if metadata is None else metadata.chunk_offsets
+    chunk_kda_fwd_k3_triton_kernel[(capacity, heads)](
+        q_view,
+        k_view,
+        gate_view,
+        beta_view,
+        output_view,
+        akk_od,
+        cu_seqlens,
+        chunk_offsets,
+        0 if metadata is None else metadata.cu_seqlens.shape[0] - 1,
+        float(scale),
+        q_view.stride(0),
+        q_view.stride(1),
+        k_view.stride(0),
+        k_view.stride(1),
+        gate_view.stride(0),
+        gate_view.stride(1),
+        beta_view.stride(0),
+        beta_view.stride(1),
+        output_view.stride(0),
+        output_view.stride(1),
+        H=heads,
+        K=key_dim,
+        BT=_CHUNK_SIZE,
+        BC=_SUBCHUNK_SIZE,
+        BK=32,
+        USE_INT64_OFFSETS=requires_int64_offsets(
+            q_view,
+            k_view,
+            gate_view,
+            beta_view,
+            output_view,
+            akk_od,
+            cu_seqlens,
+            chunk_offsets,
+        ),
+        num_warps=4,
+        num_stages=2,
+    )
+    return akk_od
+
+
+__all__ = ["chunk_kda_fwd_k3b_triton"]

--- a/attn_gym/linear/kda/fwd/triton/chunk_kda_fwd_k4_triton.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_kda_fwd_k4_triton.py
@@ -1,0 +1,313 @@
+# Copyright (c) 2026 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Portable Triton KDA K4 assembly from BC16 block factors.
+
+The kernel owns only the BT64 K4 stage: one Triton program loads the six FP32
+strictly-lower blocks and four pre-inverted diagonal blocks for a ``(chunk,
+head)`` pair, applies the fixed 4x4 block-inverse recurrence, and writes the
+causal 64x64 inverse in the KDA output dtype. Dense and packed layouts share the
+same block ABI; packed work is decoded entirely from device metadata.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+from torch._subclasses.fake_tensor import FakeTensor
+
+from attn_gym._backends.triton.utils import requires_int64_offsets
+from attn_gym.linear.kda.chunk_scheduler import (
+    RaggedChunkMetadata,
+    load_ragged_chunk_count,
+    load_ragged_chunk_work,
+)
+
+_CHUNK_SIZE = 64
+_SUBCHUNK_SIZE = 16
+_OFFDIAGONAL_BLOCKS = 6
+_SUPPORTED_OUTPUT_DTYPES = (torch.float16, torch.bfloat16)
+
+
+@triton.jit
+def load_diagonal_block(
+    Akkd, token_start, head, block, valid_rows, H: tl.constexpr, BC: tl.constexpr
+):
+    """Load one pre-inverted BC16 diagonal block and enforce its causal shape."""
+    row = tl.arange(0, BC)
+    column = tl.arange(0, BC)
+    token = token_start + block * BC + row[:, None]
+    offset = (token * H + head) * BC + column[None, :]
+    value = tl.load(Akkd + offset, mask=row[:, None] < valid_rows, other=0.0)
+    return tl.where(column[None, :] <= row[:, None], value, 0.0)
+
+
+@triton.jit
+def load_offdiagonal_block(
+    AkkOD,
+    chunk,
+    head,
+    block,
+    valid_rows,
+    valid_columns,
+    H: tl.constexpr,
+    BC: tl.constexpr,
+    OFFDIAGONAL_BLOCKS: tl.constexpr,
+):
+    """Load one K3-compatible FP32 off-diagonal block with tail masking."""
+    row = tl.arange(0, BC)
+    column = tl.arange(0, BC)
+    block_row = chunk * OFFDIAGONAL_BLOCKS + block
+    offset = (block_row * H + head) * (BC * BC) + row[:, None] * BC + column[None, :]
+    mask = (row[:, None] < valid_rows) & (column[None, :] < valid_columns)
+    return tl.load(AkkOD + offset, mask=mask, other=0.0)
+
+
+@triton.jit
+def narrow_dot(left, right, output_type: tl.constexpr):
+    """Run one KDA block product after narrowing both operands to the output dtype."""
+    return tl.dot(left.to(output_type), right.to(output_type))
+
+
+@triton.jit
+def store_block(
+    output,
+    value,
+    token_start,
+    head,
+    row_block,
+    column_block,
+    valid_rows,
+    valid_columns,
+    H: tl.constexpr,
+    TRIANGULAR: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+):
+    """Store one output BC16 block, explicitly zeroing masked columns and upper entries."""
+    row = tl.arange(0, BC)
+    column = tl.arange(0, BC)
+    token = token_start + row_block * BC + row[:, None]
+    output_column = column_block * BC + column[None, :]
+    offset = (token * H + head) * BT + output_column
+    value = tl.where(column[None, :] < valid_columns, value, 0.0)
+    if TRIANGULAR:
+        value = tl.where(column[None, :] <= row[:, None], value, 0.0)
+    tl.store(
+        output + offset,
+        value.to(output.dtype.element_ty),
+        mask=row[:, None] < valid_rows,
+    )
+
+
+@triton.heuristics(
+    {
+        "IS_RAGGED": lambda args: args["cu_seqlens"] is not None,
+        "USE_INT64_OFFSETS": lambda args: requires_int64_offsets(
+            args["AkkOD"],
+            args["Akkd"],
+            args["output"],
+            args["cu_seqlens"],
+            args["chunk_offsets"],
+        ),
+    }
+)
+@triton.jit(do_not_specialize=["T", "num_sequences"])
+def chunk_kda_fwd_k4b_triton_kernel(
+    AkkOD,
+    Akkd,
+    output,
+    cu_seqlens,
+    chunk_offsets,
+    T,
+    num_sequences,
+    H: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    OFFDIAGONAL_BLOCKS: tl.constexpr,
+    IS_RAGGED: tl.constexpr,
+    USE_INT64_OFFSETS: tl.constexpr,
+):
+    """Assemble one KDA BT64 inverse for each statically scheduled chunk and head."""
+    chunk = tl.program_id(0)
+    head = tl.program_id(1)
+    if IS_RAGGED:
+        if chunk >= load_ragged_chunk_count(chunk_offsets, num_sequences):
+            return
+        _, _, token_start, valid_tokens = load_ragged_chunk_work(
+            cu_seqlens,
+            chunk_offsets,
+            chunk,
+            num_sequences,
+            BT,
+        )
+        if USE_INT64_OFFSETS:
+            chunk = chunk.to(tl.int64)
+            head = head.to(tl.int64)
+            token_start = token_start.to(tl.int64)
+    else:
+        if USE_INT64_OFFSETS:
+            chunk = chunk.to(tl.int64)
+            head = head.to(tl.int64)
+            T = T.to(tl.int64)
+        token_start = chunk * BT
+        valid_tokens = T - token_start
+
+    output_type: tl.constexpr = output.dtype.element_ty
+    valid0 = tl.maximum(0, tl.minimum(BC, valid_tokens))
+    valid1 = tl.maximum(0, tl.minimum(BC, valid_tokens - BC))
+    valid2 = tl.maximum(0, tl.minimum(BC, valid_tokens - 2 * BC))
+    valid3 = tl.maximum(0, tl.minimum(BC, valid_tokens - 3 * BC))
+
+    inverse00 = load_diagonal_block(Akkd, token_start, head, 0, valid0, H, BC)
+    inverse11 = load_diagonal_block(Akkd, token_start, head, 1, valid1, H, BC)
+    inverse22 = load_diagonal_block(Akkd, token_start, head, 2, valid2, H, BC)
+    inverse33 = load_diagonal_block(Akkd, token_start, head, 3, valid3, H, BC)
+
+    block10 = load_offdiagonal_block(
+        AkkOD, chunk, head, 0, valid1, valid0, H, BC, OFFDIAGONAL_BLOCKS
+    )
+    block20 = load_offdiagonal_block(
+        AkkOD, chunk, head, 1, valid2, valid0, H, BC, OFFDIAGONAL_BLOCKS
+    )
+    block21 = load_offdiagonal_block(
+        AkkOD, chunk, head, 2, valid2, valid1, H, BC, OFFDIAGONAL_BLOCKS
+    )
+    block30 = load_offdiagonal_block(
+        AkkOD, chunk, head, 3, valid3, valid0, H, BC, OFFDIAGONAL_BLOCKS
+    )
+    block31 = load_offdiagonal_block(
+        AkkOD, chunk, head, 4, valid3, valid1, H, BC, OFFDIAGONAL_BLOCKS
+    )
+    block32 = load_offdiagonal_block(
+        AkkOD, chunk, head, 5, valid3, valid2, H, BC, OFFDIAGONAL_BLOCKS
+    )
+
+    inverse10 = -narrow_dot(narrow_dot(inverse11, block10, output_type), inverse00, output_type)
+    inverse21 = -narrow_dot(narrow_dot(inverse22, block21, output_type), inverse11, output_type)
+    inverse32 = -narrow_dot(narrow_dot(inverse33, block32, output_type), inverse22, output_type)
+    inverse20 = -narrow_dot(
+        inverse22,
+        narrow_dot(block20, inverse00, output_type) + narrow_dot(block21, inverse10, output_type),
+        output_type,
+    )
+    inverse31 = -narrow_dot(
+        inverse33,
+        narrow_dot(block31, inverse11, output_type) + narrow_dot(block32, inverse21, output_type),
+        output_type,
+    )
+    inverse30 = -narrow_dot(
+        inverse33,
+        narrow_dot(block30, inverse00, output_type)
+        + narrow_dot(block31, inverse10, output_type)
+        + narrow_dot(block32, inverse20, output_type),
+        output_type,
+    )
+
+    zero = tl.zeros([BC, BC], dtype=tl.float32)
+    store_block(output, inverse00, token_start, head, 0, 0, valid0, valid0, H, True, BT, BC)
+    store_block(output, zero, token_start, head, 0, 1, valid0, valid1, H, False, BT, BC)
+    store_block(output, zero, token_start, head, 0, 2, valid0, valid2, H, False, BT, BC)
+    store_block(output, zero, token_start, head, 0, 3, valid0, valid3, H, False, BT, BC)
+    store_block(output, inverse10, token_start, head, 1, 0, valid1, valid0, H, False, BT, BC)
+    store_block(output, inverse11, token_start, head, 1, 1, valid1, valid1, H, True, BT, BC)
+    store_block(output, zero, token_start, head, 1, 2, valid1, valid2, H, False, BT, BC)
+    store_block(output, zero, token_start, head, 1, 3, valid1, valid3, H, False, BT, BC)
+    store_block(output, inverse20, token_start, head, 2, 0, valid2, valid0, H, False, BT, BC)
+    store_block(output, inverse21, token_start, head, 2, 1, valid2, valid1, H, False, BT, BC)
+    store_block(output, inverse22, token_start, head, 2, 2, valid2, valid2, H, True, BT, BC)
+    store_block(output, zero, token_start, head, 2, 3, valid2, valid3, H, False, BT, BC)
+    store_block(output, inverse30, token_start, head, 3, 0, valid3, valid0, H, False, BT, BC)
+    store_block(output, inverse31, token_start, head, 3, 1, valid3, valid1, H, False, BT, BC)
+    store_block(output, inverse32, token_start, head, 3, 2, valid3, valid2, H, False, BT, BC)
+    store_block(output, inverse33, token_start, head, 3, 3, valid3, valid3, H, True, BT, BC)
+
+
+def chunk_kda_fwd_k4b_triton(
+    AkkOD: torch.Tensor,
+    Akkd: torch.Tensor,
+    metadata: RaggedChunkMetadata | None,
+    *,
+    output_dtype: torch.dtype,
+) -> torch.Tensor:
+    """Assemble dense or packed BT64 KDA inverse blocks with Triton.
+
+    Args:
+        AkkOD: Contiguous FP32 K3 factors with shape ``[capacity * 6, H * 256]``
+            and block order ``(10, 20, 21, 30, 31, 32)``.
+        Akkd: Contiguous FP32 pre-inverted diagonal factors with shape
+            ``[1, T, H, 16]``.
+        metadata: Packed chunk routing, or ``None`` for complete dense chunks.
+        output_dtype: Output storage dtype, either FP16 or BF16.
+
+    Returns:
+        The causal inverse with shape ``[1, T, H, 64]``.
+    """
+    if Akkd.ndim != 4:
+        raise ValueError(f"Akkd must be 4D, got shape {tuple(Akkd.shape)}")
+    batch, tokens, heads, diagonal_width = Akkd.shape
+    if batch != 1 or diagonal_width != _SUBCHUNK_SIZE or heads < 1:
+        raise ValueError(
+            "Triton K4 requires Akkd shape [1, T, H, 16] with at least one head, "
+            f"got {tuple(Akkd.shape)}"
+        )
+    if AkkOD.ndim != 2:
+        raise ValueError(f"AkkOD must be 2D, got shape {tuple(AkkOD.shape)}")
+    if output_dtype not in _SUPPORTED_OUTPUT_DTYPES:
+        raise TypeError("Triton K4 output_dtype must be torch.float16 or torch.bfloat16")
+    if AkkOD.dtype != torch.float32 or Akkd.dtype != torch.float32:
+        raise TypeError("Triton K4 requires FP32 AkkOD and Akkd")
+    if AkkOD.device != Akkd.device or not Akkd.is_cuda:
+        raise ValueError("Triton K4 requires AkkOD and Akkd on the same CUDA device")
+    if not AkkOD.is_contiguous() or not Akkd.is_contiguous():
+        raise ValueError("Triton K4 requires contiguous AkkOD and Akkd")
+
+    if metadata is None:
+        if tokens % _CHUNK_SIZE:
+            raise ValueError(f"dense Triton K4 requires complete BT64 chunks, got T={tokens}")
+        capacity = tokens // _CHUNK_SIZE
+        cu_seqlens = None
+        chunk_offsets = None
+        num_sequences = 0
+    else:
+        metadata.validate_chunk_size(_CHUNK_SIZE)
+        cu_seqlens = metadata.cu_seqlens
+        chunk_offsets = metadata.chunk_offsets
+        capacity = metadata.capacity
+        num_sequences = cu_seqlens.shape[0] - 1
+
+    expected_shape = (capacity * _OFFDIAGONAL_BLOCKS, heads * _SUBCHUNK_SIZE**2)
+    if AkkOD.shape != expected_shape:
+        raise ValueError(f"AkkOD must have shape {expected_shape}, got {tuple(AkkOD.shape)}")
+
+    output = torch.empty(
+        (batch, tokens, heads, _CHUNK_SIZE),
+        dtype=output_dtype,
+        device=Akkd.device,
+    )
+    if isinstance(Akkd, FakeTensor) or capacity == 0:
+        return output
+
+    chunk_kda_fwd_k4b_triton_kernel[(capacity, heads)](
+        AkkOD=AkkOD,
+        Akkd=Akkd,
+        output=output,
+        cu_seqlens=cu_seqlens,
+        chunk_offsets=chunk_offsets,
+        T=tokens,
+        num_sequences=num_sequences,
+        H=heads,
+        BT=_CHUNK_SIZE,
+        BC=_SUBCHUNK_SIZE,
+        OFFDIAGONAL_BLOCKS=_OFFDIAGONAL_BLOCKS,
+        num_warps=4,
+        num_stages=2,
+    )
+    return output
+
+
+__all__ = ["chunk_kda_fwd_k4b_triton"]

--- a/attn_gym/linear/kda/impl/fused.py
+++ b/attn_gym/linear/kda/impl/fused.py
@@ -24,11 +24,11 @@ _HEAD_DIM = 128
 def _validate_fused_constraints(q: torch.Tensor, v: torch.Tensor) -> None:
     """Validate constraints shared by every fused chunk launcher."""
     if not q.is_cuda:
-        raise ValueError("the CuTe KDA core requires CUDA tensors")
+        raise ValueError("the fused KDA core requires CUDA tensors")
     if q.shape[-1] != _HEAD_DIM or v.shape[-1] != _HEAD_DIM:
-        raise ValueError("the CuTe KDA core requires K=V=128")
-    if not torch.compiler.is_compiling() and get_device_properties(q.device).major < 10:
-        raise ValueError("the CuTe KDA core requires CUDA capability 10.0 or newer")
+        raise ValueError("the fused KDA core requires K=V=128")
+    if not torch.compiler.is_compiling() and get_device_properties(q.device).major < 8:
+        raise ValueError("the fused KDA core requires CUDA capability 8.0 or newer")
 
 
 class _ChunkKDA(torch.autograd.Function):

--- a/attn_gym/linear/kda/utils.py
+++ b/attn_gym/linear/kda/utils.py
@@ -27,6 +27,7 @@ import torch
 import triton
 import triton.language as tl
 from packaging import version
+from triton.language.extra import libdevice
 
 from attn_gym._backends.triton import utils as triton_utils
 
@@ -119,6 +120,14 @@ triton_utils.configure_triton_allocator()
 # Triton math ops
 # ---------------------------------------------------------------------------
 exp2 = tl.math.exp2
+
+
+@triton.jit
+def masked_exp2(value, mask, FASTMATH: tl.constexpr = True):
+    """Mask exponent inputs and select approximate or precise exponentiation."""
+    exponent = tl.where(mask, value, 0.0)
+    result = exp2(exponent) if FASTMATH else libdevice.exp2(exponent)
+    return tl.where(mask, result, 0.0)
 
 
 @triton.jit

--- a/test/test_kda_compile_dynamic_shapes.py
+++ b/test/test_kda_compile_dynamic_shapes.py
@@ -22,8 +22,8 @@ def offsets(sequence_count: int) -> torch.Tensor:
 
 def test_compiled_chunk_kda_accepts_varying_packed_sequence_count():
     """Vary sequence counts through the composed core and shared scheduler."""
-    if torch.cuda.get_device_capability() < (10, 0):
-        pytest.skip("the CuTe KDA core requires CUDA capability 10.0 or newer")
+    if torch.cuda.get_device_capability() < (8, 0):
+        pytest.skip("the fused KDA core requires CUDA capability 8.0 or newer")
     inputs = make_kda_test_inputs(TOKENS)
     compiled = torch.compile(chunk_kda, fullgraph=True, dynamic=True)
     for sequence_count in (2, 4):

--- a/test/test_kda_gate_semantics.py
+++ b/test/test_kda_gate_semantics.py
@@ -265,8 +265,8 @@ def test_bound_gate_operator_registration():
 
 
 @pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (10, 0),
-    reason="the fused chunk KDA core requires CUDA capability 10.0 or newer",
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (8, 0),
+    reason="the fused chunk KDA core requires CUDA capability 8.0 or newer",
 )
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 def test_fused_chunk_gate_range_boundary_is_finite(dtype):

--- a/test/test_kda_hopper.py
+++ b/test/test_kda_hopper.py
@@ -1,0 +1,551 @@
+"""Native SM90 KDA forward, backward, and compiler integration tests."""
+
+from __future__ import annotations
+
+import importlib
+from functools import partial
+
+import pytest
+import torch
+
+pytest.importorskip("cutlass")
+
+from attn_gym.linear import Impl, chunk_kda, paged_chunk_kda
+from attn_gym.linear._delta_rule.reference import packed_delta_rule_reference
+from attn_gym.linear.kda.bwd.triton.chunk_kda_bwd_delta_h_triton import (
+    chunk_kda_bwd_delta_h_triton,
+)
+from attn_gym.linear.kda.constants import LOG2_E
+from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd import (
+    _chunk_kda_bwd_with_state_grad_op,
+    _chunk_kda_fwd_with_state_op,
+)
+from attn_gym.linear.kda.naive import chunk_cumsum_ref, naive_chunk_kda
+from attn_gym.testing.kda import (
+    assert_matches_low_precision_reference,
+    clone_kda_inputs,
+    cumulative_sequence_offsets,
+    make_kda_test_inputs,
+    strided_state_pool,
+)
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] != 9,
+    reason="the native Hopper KDA route requires CUDA capability 9.x",
+)
+
+
+def _high_precision_reference(
+    inputs: tuple[torch.Tensor, ...],
+    cu_seqlens: torch.Tensor | None,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Evaluate the public natural-log gate contract without its FP32 cast."""
+    q, k, v, gate, beta, initial_state = inputs
+    dense_op = partial(naive_chunk_kda, chunk_size=64)
+    if cu_seqlens is None:
+        return dense_op(
+            q,
+            k,
+            v,
+            gate * LOG2_E,
+            beta,
+            initial_state=initial_state,
+            scale=128**-0.5,
+            output_final_state=True,
+        )
+    return packed_delta_rule_reference(
+        dense_op,
+        q,
+        k,
+        v,
+        gate * LOG2_E,
+        beta,
+        initial_state,
+        cu_seqlens,
+        True,
+        scale=128**-0.5,
+    )
+
+
+def _training_inputs(
+    dtype: torch.dtype,
+    lengths: list[int] | None,
+) -> tuple[tuple[torch.Tensor, ...], torch.Tensor | None]:
+    """Create one dense or packed stateful training case from quantized inputs."""
+    tokens = 128 if lengths is None else sum(lengths)
+    inputs = make_kda_test_inputs(
+        tokens,
+        batch=1,
+        heads=2,
+        dtype=dtype,
+        normalize_qk=True,
+        gate_scale=0.5,
+        requires_grad=True,
+    )
+    sequences = 1 if lengths is None else len(lengths)
+    initial_state = (
+        torch.randn(sequences, 2, 128, 128, device="cuda", dtype=torch.float32) / 32
+    ).requires_grad_()
+    cu_seqlens = None if lengths is None else cumulative_sequence_offsets(lengths)
+    return (*inputs, initial_state), cu_seqlens
+
+
+def _assert_training_matches_reference(
+    actual_inputs: tuple[torch.Tensor, ...],
+    cu_seqlens: torch.Tensor | None,
+    dtype: torch.dtype,
+    *,
+    fastmath: bool = False,
+) -> None:
+    """Bound one fused training case by its low-precision eager error."""
+    reference_inputs = clone_kda_inputs(actual_inputs)
+    high_inputs = clone_kda_inputs(actual_inputs, dtype=torch.float64)
+    actual_output, actual_state = chunk_kda(
+        *actual_inputs,
+        cu_seqlens=cu_seqlens,
+        output_final_state=True,
+        fastmath=fastmath,
+        autotune=False,
+    )
+    reference_output, reference_state = chunk_kda(
+        *reference_inputs,
+        cu_seqlens=cu_seqlens,
+        output_final_state=True,
+        impl=Impl.REFERENCE,
+    )
+    high_output, high_state = _high_precision_reference(high_inputs, cu_seqlens)
+    assert actual_state is not None and reference_state is not None and high_state is not None
+    assert_matches_low_precision_reference(
+        actual_output,
+        high_output,
+        reference_output,
+        "Hopper chunk KDA output",
+        source_dtype=dtype,
+    )
+    assert_matches_low_precision_reference(
+        actual_state,
+        high_state,
+        reference_state,
+        "Hopper chunk KDA final state",
+        source_dtype=dtype,
+    )
+
+    d_output = torch.randn_like(actual_output)
+    d_state = torch.randn_like(actual_state)
+    actual_gradients = torch.autograd.grad(
+        (actual_output, actual_state), actual_inputs, (d_output, d_state)
+    )
+    reference_gradients = torch.autograd.grad(
+        (reference_output, reference_state), reference_inputs, (d_output, d_state)
+    )
+    high_gradients = torch.autograd.grad(
+        (high_output, high_state), high_inputs, (d_output.double(), d_state.double())
+    )
+    for name, actual, high, reference in zip(
+        ("q", "k", "v", "gate", "beta", "initial_state"),
+        actual_gradients,
+        high_gradients,
+        reference_gradients,
+        strict=True,
+    ):
+        assert_matches_low_precision_reference(
+            actual,
+            high,
+            reference,
+            f"Hopper chunk KDA gradient {name}",
+            source_dtype=dtype,
+        )
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("lengths", [None, [65, 0, 63]], ids=["dense", "packed"])
+def test_hopper_training_matches_low_precision_reference(
+    dtype: torch.dtype,
+    lengths: list[int] | None,
+):
+    """Cover ordinary dense and packed Hopper training."""
+    inputs, cu_seqlens = _training_inputs(dtype, lengths)
+    _assert_training_matches_reference(inputs, cu_seqlens, dtype)
+
+
+def test_hopper_fastmath_backward_matches_reference(monkeypatch):
+    """Exercise and verify fastmath plumbing in the native SM90 WY backward."""
+    import attn_gym.linear.kda.bwd.cute.chunk_kda_bwd as backward_module
+
+    original = backward_module.chunk_kda_bwd_wy_triton
+    received_fastmath: list[bool] = []
+
+    def capture_fastmath(*args, **kwargs):
+        received_fastmath.append(kwargs["fastmath"])
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(backward_module, "chunk_kda_bwd_wy_triton", capture_fastmath)
+    inputs, cu_seqlens = _training_inputs(torch.bfloat16, [65, 63])
+    _assert_training_matches_reference(inputs, cu_seqlens, torch.bfloat16, fastmath=True)
+    assert received_fastmath == [True]
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("lengths", [None, [65, 63]], ids=["dense", "packed"])
+def test_hopper_bc16_rebase_matches_reference_at_lower_bound_five(
+    dtype: torch.dtype,
+    lengths: list[int] | None,
+):
+    """Pin the BC16 rebase numerics at the model's default gate lower bound."""
+    inputs, cu_seqlens = _training_inputs(dtype, lengths)
+    gate = torch.full_like(inputs[3], -5.0, requires_grad=True)
+    actual_inputs = (*inputs[:3], gate, *inputs[4:])
+    reference_inputs = clone_kda_inputs(actual_inputs)
+    actual_output, actual_state = chunk_kda(
+        *actual_inputs,
+        cu_seqlens=cu_seqlens,
+        output_final_state=True,
+        autotune=False,
+    )
+    reference_output, reference_state = chunk_kda(
+        *reference_inputs,
+        cu_seqlens=cu_seqlens,
+        output_final_state=True,
+        impl=Impl.REFERENCE,
+    )
+    assert actual_state is not None and reference_state is not None
+    atol = 6e-3 if dtype is torch.bfloat16 else 5e-4
+    torch.testing.assert_close(actual_output, reference_output, rtol=3e-2, atol=atol)
+    torch.testing.assert_close(actual_state, reference_state, rtol=3e-2, atol=atol)
+
+    d_output = torch.randn_like(actual_output)
+    d_state = torch.randn_like(actual_state)
+    actual_gradients = torch.autograd.grad(
+        (actual_output, actual_state), actual_inputs, (d_output, d_state)
+    )
+    reference_gradients = torch.autograd.grad(
+        (reference_output, reference_state), reference_inputs, (d_output, d_state)
+    )
+    for actual, reference in zip(actual_gradients, reference_gradients, strict=True):
+        assert torch.isfinite(actual).all()
+        torch.testing.assert_close(actual, reference, rtol=3e-2, atol=atol)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_hopper_delta_h_masks_upper_aqk(dtype: torch.dtype):
+    """Ignore poisoned upper-triangular Aqk entries in the reverse recurrence."""
+    torch.manual_seed(97)
+    shape = (1, 64, 1, 128)
+    qg = torch.randn(shape, device="cuda", dtype=dtype) / 8
+    kg = torch.randn_like(qg) / 8
+    w = torch.randn_like(qg) / 8
+    d_output = torch.randn_like(qg) / 8
+    gate = -torch.rand(shape, device="cuda")
+    aqk = torch.randn(1, 64, 1, 64, device="cuda", dtype=dtype) / 8
+    upper = torch.ones(64, 64, dtype=torch.bool, device="cuda").triu(1)
+    aqk[0, :, 0].masked_fill_(upper, 0)
+    poisoned = aqk.clone()
+    poisoned[0, :, 0].masked_fill_(upper, float("nan"))
+
+    def run(factors: torch.Tensor):
+        return chunk_kda_bwd_delta_h_triton(
+            qg,
+            kg,
+            w,
+            d_output,
+            factors,
+            gk=gate,
+            initial_state=None,
+            d_final_state=None,
+            scale=128**-0.5,
+            metadata=None,
+        )
+
+    expected = run(aqk)
+    actual = run(poisoned)
+    for poisoned_output, neutral_output in zip(actual, expected, strict=True):
+        if poisoned_output is None:
+            assert neutral_output is None
+        else:
+            assert neutral_output is not None
+            torch.testing.assert_close(poisoned_output, neutral_output, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_hopper_final_state_only_gradient(dtype: torch.dtype):
+    """Exercise a final-state cotangent when the output cotangent is absent."""
+    actual_inputs, cu_seqlens = _training_inputs(dtype, [65, 0, 63])
+    reference_inputs = clone_kda_inputs(actual_inputs)
+    high_inputs = clone_kda_inputs(actual_inputs, dtype=torch.float64)
+    _, actual_state = chunk_kda(
+        *actual_inputs,
+        cu_seqlens=cu_seqlens,
+        output_final_state=True,
+        autotune=False,
+    )
+    _, reference_state = chunk_kda(
+        *reference_inputs,
+        cu_seqlens=cu_seqlens,
+        output_final_state=True,
+        impl=Impl.REFERENCE,
+    )
+    _, high_state = _high_precision_reference(high_inputs, cu_seqlens)
+    assert actual_state is not None and reference_state is not None and high_state is not None
+    d_state = torch.randn_like(actual_state)
+    actual_gradients = torch.autograd.grad(actual_state, actual_inputs[1:], d_state)
+    reference_gradients = torch.autograd.grad(reference_state, reference_inputs[1:], d_state)
+    high_gradients = torch.autograd.grad(high_state, high_inputs[1:], d_state.double())
+    for name, actual, high, reference in zip(
+        ("k", "v", "gate", "beta", "initial_state"),
+        actual_gradients,
+        high_gradients,
+        reference_gradients,
+        strict=True,
+    ):
+        assert_matches_low_precision_reference(
+            actual,
+            high,
+            reference,
+            f"Hopper final-state-only gradient {name}",
+            source_dtype=dtype,
+        )
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_hopper_fullgraph_forward_backward(dtype: torch.dtype):
+    """Keep the public Hopper route inside one strict compiled training graph."""
+    eager_inputs, cu_seqlens = _training_inputs(dtype, [65, 63])
+    compiled_inputs = clone_kda_inputs(eager_inputs)
+
+    def operation(*args):
+        return chunk_kda(
+            *args,
+            cu_seqlens=cu_seqlens,
+            output_final_state=True,
+            autotune=False,
+        )
+
+    expected_output, expected_state = operation(*eager_inputs)
+    actual_output, actual_state = torch.compile(operation, fullgraph=True)(*compiled_inputs)
+    assert expected_state is not None and actual_state is not None
+    torch.testing.assert_close(actual_output, expected_output, rtol=0, atol=0)
+    torch.testing.assert_close(actual_state, expected_state, rtol=0, atol=0)
+
+    d_output = torch.randn_like(expected_output)
+    d_state = torch.randn_like(expected_state)
+    expected_gradients = torch.autograd.grad(
+        (expected_output, expected_state), eager_inputs, (d_output, d_state)
+    )
+    actual_gradients = torch.autograd.grad(
+        (actual_output, actual_state), compiled_inputs, (d_output, d_state)
+    )
+    for actual, expected in zip(actual_gradients, expected_gradients, strict=True):
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_hopper_raw_operator_registration():
+    """Validate the unchanged opaque schemas against the real SM90 launchers."""
+    inputs, _cu_seqlens = _training_inputs(torch.bfloat16, None)
+    q, k, v, gate, beta, initial_state = inputs
+    cumulative_gate = chunk_cumsum_ref(gate * LOG2_E, 64)
+    forward_args = (
+        q.detach(),
+        k.detach(),
+        v.detach(),
+        cumulative_gate.detach(),
+        beta.detach(),
+        initial_state.detach(),
+        128**-0.5,
+        False,
+    )
+    torch.library.opcheck(
+        _chunk_kda_fwd_with_state_op,
+        forward_args,
+        rtol=2e-2,
+        atol=2e-3,
+    )
+    with torch.no_grad():
+        _output, state, aqk, akk = _chunk_kda_fwd_with_state_op(*forward_args)
+    torch.library.opcheck(
+        _chunk_kda_bwd_with_state_grad_op,
+        (
+            q.detach(),
+            k.detach(),
+            v.detach(),
+            cumulative_gate.detach(),
+            beta.detach(),
+            aqk,
+            akk,
+            None,
+            None,
+            None,
+            torch.randn_like(state),
+            initial_state.detach(),
+            128**-0.5,
+            False,
+            False,
+        ),
+        test_utils=("test_schema", "test_faketensor", "test_aot_dispatch_dynamic"),
+        rtol=2e-2,
+        atol=2e-3,
+    )
+
+
+def test_hopper_outer_strided_cotangents():
+    """Normalize supported output/state cotangent layouts at the SM90 boundary."""
+    actual_inputs, cu_seqlens = _training_inputs(torch.bfloat16, [65, 63])
+    expected_inputs = clone_kda_inputs(actual_inputs)
+    actual_output, actual_state = chunk_kda(
+        *actual_inputs,
+        cu_seqlens=cu_seqlens,
+        output_final_state=True,
+        autotune=False,
+    )
+    expected_output, expected_state = chunk_kda(
+        *expected_inputs,
+        cu_seqlens=cu_seqlens,
+        output_final_state=True,
+        autotune=False,
+    )
+    assert actual_state is not None and expected_state is not None
+
+    d_output = torch.randn(
+        actual_output.shape[0],
+        actual_output.shape[2],
+        actual_output.shape[1],
+        actual_output.shape[3],
+        device="cuda",
+        dtype=actual_output.dtype,
+    ).permute(0, 2, 1, 3)
+    state_storage, d_state = strided_state_pool(2, 2, 128, 128, prefix=0)
+    assert not d_output.is_contiguous() and not d_state.is_contiguous()
+    actual_gradients = torch.autograd.grad(
+        (actual_output, actual_state), actual_inputs, (d_output, d_state)
+    )
+    expected_gradients = torch.autograd.grad(
+        (expected_output, expected_state),
+        expected_inputs,
+        (d_output.contiguous(), d_state.contiguous()),
+    )
+    del state_storage
+    for actual, expected in zip(actual_gradients, expected_gradients, strict=True):
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_hopper_cuda_graph_replays_packed_boundaries_and_backward():
+    """Replay changed packed boundaries through the complete SM90 training route."""
+    inputs, _ = _training_inputs(torch.bfloat16, [64, 64])
+    cu_seqlens = cumulative_sequence_offsets([64, 64])
+    warm_output, warm_state = chunk_kda(
+        *inputs,
+        cu_seqlens=cu_seqlens,
+        output_final_state=True,
+        autotune=False,
+    )
+    assert warm_state is not None
+    torch.autograd.grad(warm_output.float().sum() + warm_state.sum(), inputs)
+    torch.cuda.synchronize()
+    torch.autograd.graph.set_override_stale_capture_stream(True)
+    try:
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            output, state = chunk_kda(
+                *inputs,
+                cu_seqlens=cu_seqlens,
+                output_final_state=True,
+                autotune=False,
+            )
+            assert state is not None
+            gradients = torch.autograd.grad(output.float().sum() + state.sum(), inputs)
+    finally:
+        torch.autograd.graph.set_override_stale_capture_stream(False)
+
+    with torch.no_grad():
+        inputs[2].mul_(0.5)
+        cu_seqlens.copy_(cumulative_sequence_offsets([65, 63]))
+    expected_inputs = clone_kda_inputs(inputs)
+    expected_output, expected_state = chunk_kda(
+        *expected_inputs,
+        cu_seqlens=cu_seqlens,
+        output_final_state=True,
+        autotune=False,
+    )
+    assert expected_state is not None
+    expected_gradients = torch.autograd.grad(
+        expected_output.float().sum() + expected_state.sum(), expected_inputs
+    )
+    graph.replay()
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(output, expected_output, rtol=0, atol=0)
+    torch.testing.assert_close(state, expected_state, rtol=0, atol=0)
+    for actual, expected in zip(gradients, expected_gradients, strict=True):
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_hopper_int64_specializations_match_default(monkeypatch):
+    """Force every new wide-address path and preserve public outputs and gradients."""
+    packed_offsets = cumulative_sequence_offsets([65, 63])
+
+    def run(cu_seqlens: torch.Tensor | None):
+        inputs = make_kda_test_inputs(
+            128,
+            batch=1,
+            heads=1,
+            dtype=torch.bfloat16,
+            normalize_qk=True,
+            requires_grad=True,
+        )
+        output, _ = chunk_kda(
+            *inputs,
+            cu_seqlens=cu_seqlens,
+            autotune=False,
+        )
+        gradients = torch.autograd.grad(output.float().square().sum(), inputs)
+        return output, *gradients
+
+    expected = (run(None), run(packed_offsets))
+    for module_name, attribute in (
+        (
+            "attn_gym.linear.kda.fwd.triton.chunk_kda_fwd_intra_sub_chunk_forloop",
+            "requires_int64_offsets",
+        ),
+        ("attn_gym.linear.kda.fwd.triton.chunk_kda_fwd_k3_triton", "requires_int64_offsets"),
+        ("attn_gym.linear.kda.fwd.triton.chunk_kda_fwd_k4_triton", "requires_int64_offsets"),
+        ("attn_gym.linear.kda.fwd.triton.recompute_w_u", "requires_int64_offsets"),
+        ("attn_gym.linear.kda.fwd.triton.chunk_delta_h", "requires_int64_offsets"),
+        ("attn_gym.linear.kda.fwd.triton.chunk_gla_fwd_o", "requires_int64_offsets"),
+        ("attn_gym.linear.kda.bwd.triton.chunk_kda_bwd_daqk", "requires_int64_offsets"),
+        (
+            "attn_gym.linear.kda.bwd.triton.chunk_kda_bwd_delta_h_triton",
+            "requires_int64_offsets",
+        ),
+        (
+            "attn_gym.linear.kda.bwd.triton.chunk_kda_bwd_wy_triton",
+            "requires_int64_offsets",
+        ),
+        ("attn_gym.linear.kda.bwd.cute.chunk_kda_bwd_intra", "requires_int64_abi"),
+    ):
+        monkeypatch.setattr(importlib.import_module(module_name), attribute, lambda *_args: True)
+
+    actual = (run(None), run(packed_offsets))
+    for wide_case, normal_case in zip(actual, expected, strict=True):
+        for wide, normal in zip(wide_case, normal_case, strict=True):
+            torch.testing.assert_close(wide, normal, rtol=0, atol=0)
+
+
+def test_paged_chunk_kda_uses_pre_blackwell_route():
+    """Advance paged state through the same portable factors as ordinary prefill."""
+    inputs = tuple(
+        tensor.detach() for tensor in make_kda_test_inputs(64, batch=1, heads=1, normalize_qk=True)
+    )
+    state_cache = torch.randn(2, 1, 128, 128, device="cuda")
+    expected_cache = state_cache.clone()
+    state_indices = torch.ones(1, device="cuda", dtype=torch.int32)
+    with torch.no_grad():
+        expected_output, expected_state = chunk_kda(
+            *inputs,
+            expected_cache[state_indices.long()].clone(),
+            output_final_state=True,
+            autotune=False,
+        )
+        output = paged_chunk_kda(*inputs, state_cache, state_indices, autotune=False)
+    assert expected_state is not None
+    expected_cache[state_indices.long()] = expected_state
+    torch.testing.assert_close(output, expected_output, rtol=0, atol=0)
+    torch.testing.assert_close(state_cache, expected_cache, rtol=0, atol=0)

--- a/test/test_kda_impl_dispatch.py
+++ b/test/test_kda_impl_dispatch.py
@@ -15,7 +15,7 @@ from attn_gym.linear._delta_rule.validation import validate_paged_state
 
 pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="KDA ops require CUDA")
 
-BLACKWELL = torch.cuda.is_available() and torch.cuda.get_device_capability() >= (10, 0)
+FUSED_CHUNK = torch.cuda.is_available() and torch.cuda.get_device_capability() >= (8, 0)
 
 
 def _inputs(
@@ -136,7 +136,7 @@ def test_recurrent_reference_is_differentiable():
     assert q.grad is not None and v.grad is not None
 
 
-@pytest.mark.skipif(not BLACKWELL, reason="fused chunk_kda requires CUDA capability 10.0")
+@pytest.mark.skipif(not FUSED_CHUNK, reason="fused chunk_kda requires CUDA capability 8.0")
 def test_chunk_reference_matches_fused():
     """Agree across implementations through the per-token gate contract."""
     q, k, v, gate, beta = _inputs(tokens=100, head_dim=128, dtype=torch.bfloat16, seed=2)
@@ -149,7 +149,7 @@ def test_chunk_reference_matches_fused():
     torch.testing.assert_close(fused_state, reference_state, rtol=2e-2, atol=2e-2)
 
 
-@pytest.mark.skipif(not BLACKWELL, reason="fused chunk_kda requires CUDA capability 10.0")
+@pytest.mark.skipif(not FUSED_CHUNK, reason="fused chunk_kda requires CUDA capability 8.0")
 def test_chunk_reference_packed_matches_fused():
     """Match the fused ragged path per sequence, including empty slots."""
     q, k, v, gate, beta = _inputs(batch=1, tokens=150, head_dim=128, dtype=torch.bfloat16, seed=3)
@@ -229,7 +229,7 @@ def test_chunk_reference_rejects_fastmath():
         chunk_kda(q, k, v, gate, beta, fastmath=True, impl="reference")
 
 
-@pytest.mark.skipif(not BLACKWELL, reason="fused chunk_kda requires CUDA capability 10.0")
+@pytest.mark.skipif(not FUSED_CHUNK, reason="fused chunk_kda requires CUDA capability 8.0")
 def test_chunk_autotune_flag_is_deterministic_and_accurate():
     """autotune=False pins fixed heuristic configs without changing the math contract."""
     q, k, v, gate, beta = _inputs(tokens=128, head_dim=128, dtype=torch.bfloat16, seed=5)

--- a/test/test_kda_imports.py
+++ b/test/test_kda_imports.py
@@ -124,8 +124,8 @@ def test_masking_cuda_falls_back_without_triton():
 
 
 @pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (10, 0),
-    reason="cold fused chunk compilation requires CUDA capability 10.0 or newer",
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (8, 0),
+    reason="cold fused chunk compilation requires CUDA capability 8.0 or newer",
 )
 def test_chunk_kda_cold_public_fullgraph_compile():
     """Register operator contracts before the first fused call enters Dynamo."""

--- a/test/test_kda_ragged_bwd_intra.py
+++ b/test/test_kda_ragged_bwd_intra.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import math
+import os
+import subprocess
+import sys
+from pathlib import Path
 
 import pytest
 import torch
@@ -19,9 +23,30 @@ from attn_gym.testing.kda import (
 )
 
 pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (9, 0),
-    reason="the CuTe KDA backward stage requires CUDA capability 9.0 or newer",
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (8, 0),
+    reason="the CuTe KDA backward stage requires CUDA capability 8.0 or newer",
 )
+
+
+def test_bwd_intra_compiles_for_sm80():
+    """Compile the scalar-store specialization without emitting stmatrix."""
+    source = """
+import torch
+from attn_gym.linear.kda.bwd.cute import chunk_kda_bwd_intra as module
+
+module._compile_chunk_kda_bwd_intra(
+    heads=1,
+    capacity=1,
+    grid_chunks=1,
+    ragged=False,
+    io_type=module._IO_TYPES[torch.bfloat16],
+    use_int64_offsets=False,
+)
+"""
+    environment = os.environ.copy()
+    environment["CUTE_DSL_ARCH"] = "sm_80"
+    environment["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
+    subprocess.run([sys.executable, "-c", source], env=environment, check=True, timeout=180)
 
 
 def _metadata(lengths: list[int]):

--- a/test/test_kda_recurrent.py
+++ b/test/test_kda_recurrent.py
@@ -28,7 +28,7 @@ pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available(), reason="recurrent_kda requires CUDA"
 )
 
-BLACKWELL = torch.cuda.is_available() and torch.cuda.get_device_capability() >= (10, 0)
+FUSED_CHUNK = torch.cuda.is_available() and torch.cuda.get_device_capability() >= (8, 0)
 
 
 def _inputs(
@@ -263,7 +263,7 @@ def test_recurrent_grouped_heads_registration():
     )
 
 
-@pytest.mark.skipif(not BLACKWELL, reason="chunk_kda requires CUDA capability 10.0")
+@pytest.mark.skipif(not FUSED_CHUNK, reason="chunk_kda requires CUDA capability 8.0")
 def test_recurrent_agrees_with_chunked_core():
     """Cross-check the decode scan against the training core on shared inputs."""
     from attn_gym.linear import chunk_kda


### PR DESCRIPTION
Stacked PRs:
 * #439
 * __->__#438


--- --- ---

Add native Hopper chunk KDA training

## Human Note

## Agent note

Add an SM90 route behind the existing fused chunk-KDA API without changing its public contract.
The forward keeps the BC16 numerical rebase and composes new Triton K3/K4 factors with the shared
scan, W/U, recurrence, and output stages. The backward adds Triton delta-H and WY/dQKG stages while
reusing dAQK, bwd-intra, and the reverse gate scan. SM100/SM103 keeps the existing CuTe path, and
paged chunk prefill remains Blackwell-only.

## Performance

H100, `B=1,T=4096,H=16,K=V=128`, warm fixed tensors, eager public API, `autotune=False`:

| mode | BF16 | FP16 | launches |
|---|---:|---:|---:|
| forward | 349.3 us | 344.2 us | 7 |
| isolated backward | 1293.4 us | 1227.2 us | 10 |
| forward + backward | 2725.2 us | 2844.2 us | 17 |

Incremental training peak memory is 0.407 GiB for both dtypes.

## Test Plan

```bash
pytest -n 6 test/test_kda_hopper.py test/test_kda_gate_semantics.py \
  test/test_kda_ragged_bwd_daqk.py test/test_kda_impl_dispatch.py \
  test/test_kda_compile_dynamic_shapes.py test/test_kda_imports.py \
  test/test_kda.py test/test_kda_ragged_public_backward.py
python agent_space/benchmark_hopper_forward.py
python agent_space/benchmark_hopper_backward.py
python agent_space/benchmark_hopper_training.py
```