### PR TITLE
Run Modal tests only on main

### DIFF
--- a/.github/workflows/modal-tests.yml
+++ b/.github/workflows/modal-tests.yml
@@ -1,7 +1,6 @@
 name: modal-tests
 
 on:
-  pull_request:
   push:
     branches:
       - main
@@ -12,7 +11,6 @@ permissions:
 
 jobs:
   pytest:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:


### PR DESCRIPTION
## Human Note

## Agent note

Remove the pull-request trigger from the Modal B200 workflow to avoid paying for GPU validation on
every PR. Keep automatic validation on pushes to main and retain manual workflow dispatch.

## Test Plan

```bash
prek run check-yaml --files .github/workflows/modal-tests.yml
```
