### PR TITLE
Route SM120 KDA through portable kernels

### DIFF
--- a/attn_gym/linear/kda/bwd/cute/chunk_delta_h_bwd.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_delta_h_bwd.py
@@ -52,6 +52,7 @@ from attn_gym._backends.cute.cache import jit_cache
 from attn_gym._backends.cute.target import get_compile_target
 from attn_gym._backends.cute.utils import compile_tvm_ffi, requires_int64_abi
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata
+from attn_gym.linear.kda.constants import is_sm100_kda_capability
 from attn_gym.linear.kda.fwd.cute.chunk_scheduler_cute import load_ragged_sequence_extent
 from attn_gym.utils import ceildiv
 
@@ -2223,6 +2224,9 @@ def requires_dynamic_state_layout(*states: torch.Tensor) -> bool:
 @jit_cache
 def _compile_delta_h_bwd(H, bv, io_type, use_int64_offsets, dynamic_state_layout):
     """Compile one dense BlackwellDeltaHBwd variant."""
+    target = get_compile_target()
+    if target.device_type != "cuda" or not is_sm100_kda_capability(target.effective_capability):
+        raise ValueError(f"KDA delta-H backward requires an SM100 or SM103 target; got {target}")
     K = V = 128
     chunk_size = 64
     kern = BlackwellDeltaHBwd(
@@ -2288,6 +2292,9 @@ def _compile_delta_h_bwd_packed(
     dynamic_state_layout: bool,
 ):
     """Compile one packed fused specialization with a width-matched TVM ABI."""
+    target = get_compile_target()
+    if target.device_type != "cuda" or not is_sm100_kda_capability(target.effective_capability):
+        raise ValueError(f"KDA delta-H backward requires an SM100 or SM103 target; got {target}")
     key_dim = value_dim = 128
     chunk_size = 64
     kernel = BlackwellDeltaHBwd(

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 
 import torch
 
-from attn_gym._backends.cute.utils import get_device_properties
 from attn_gym.linear.kda.bwd.cute.chunk_delta_h_bwd import (
     blackwell_delta_h_bwd_dhu_dv_fused_dispatch,
 )
@@ -22,7 +21,7 @@ from attn_gym.linear.kda.bwd.triton.chunk_kda_bwd_wy_triton import chunk_kda_bwd
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata
 from attn_gym.linear.kda.fwd.cute.recompute_w_u_fwd import recompute_w_u_fwd
 from attn_gym.linear.kda.fwd.triton.chunk_delta_h import chunk_gated_delta_rule_fwd_h
-from attn_gym.linear.kda.utils import profiler_range
+from attn_gym.linear.kda.utils import is_sm100_kda_target, profiler_range
 
 
 @dataclass
@@ -117,7 +116,7 @@ def _finish_chunk_kda_bwd(
 ]:
     """Finish local gradients while releasing prepared tensors at their last use."""
     assert prepared.qg is not None and prepared.kg is not None and prepared.w is not None
-    use_triton_backend = get_device_properties(q.device).major < 10
+    use_triton_backend = not is_sm100_kda_target(q.device)
     range_backend = "triton" if use_triton_backend else "cute"
     with profiler_range(f"kda/{range_backend}/backward_delta_h"):
         if use_triton_backend:

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_intra.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_intra.py
@@ -28,7 +28,7 @@ from attn_gym._backends.cute.target import CompileTarget, detect_compile_target,
 from attn_gym._backends.cute.utils import requires_int64_abi
 from attn_gym._backends.triton.utils import requires_int64_offsets
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata
-from attn_gym.linear.kda.constants import LN2
+from attn_gym.linear.kda.constants import LN2, is_sm100_kda_capability
 from attn_gym.linear.kda.fwd.cute.chunk_scheduler_cute import (
     load_ragged_chunk_count,
     load_ragged_chunk_work,
@@ -2012,7 +2012,7 @@ def _compile_chunk_kda_bwd_intra(
         grid_chunks=grid_chunks,
         ragged=ragged,
         use_int64_offsets=use_int64_offsets,
-        use_packed_f32x2=capability >= (10, 0),
+        use_packed_f32x2=is_sm100_kda_capability(capability),
         use_stmatrix=capability >= (9, 0),
     )
     tokens, sequences = cute.sym_int(), cute.sym_int()

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_wy_dqkg_fused.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_wy_dqkg_fused.py
@@ -44,6 +44,7 @@ from attn_gym._backends.cute import compile_tvm_ffi, jit_cache, run_tunable
 from attn_gym._backends.cute.target import CompileTarget, detect_compile_target, get_compile_target
 from attn_gym._backends.cute.utils import requires_int64_abi
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata
+from attn_gym.linear.kda.constants import is_sm100_kda_capability
 from attn_gym.linear.kda.fwd.cute.chunk_scheduler_cute import (
     load_ragged_chunk_count,
     load_ragged_chunk_work,
@@ -244,7 +245,7 @@ _torch_to_cutlass_dtype = {
 def require_blackwell_target() -> None:
     """Reject compilation targets that cannot execute this SM100/SM103 kernel."""
     target = get_compile_target()
-    if target.device_type != "cuda" or target.capability not in ((10, 0), (10, 3)):
+    if target.device_type != "cuda" or not is_sm100_kda_capability(target.effective_capability):
         raise RuntimeError(
             f"chunk_kda_bwd_wy_dqkg_fused requires Blackwell (SM100/SM103), got target={target}"
         )

--- a/attn_gym/linear/kda/constants.py
+++ b/attn_gym/linear/kda/constants.py
@@ -11,6 +11,13 @@ import math
 LN2 = math.log(2.0)
 LOG2_E = math.log2(math.e)
 DEFAULT_CHUNK_SIZE = 64
+SM100_KDA_CAPABILITIES = frozenset(((10, 0), (10, 3)))
+
+
+def is_sm100_kda_capability(capability: tuple[int, int] | None) -> bool:
+    """Return whether a CUDA capability supports the SM100-specific KDA kernels."""
+    return capability in SM100_KDA_CAPABILITIES
+
 
 # The causal intra-chunk reference spans 15 steps. Keep the rebase exponent below
 # FP32's overflow boundary; equality can round to exp2(128) and produce non-finite values.
@@ -29,4 +36,6 @@ __all__ = [
     "LN2",
     "LOG2_E",
     "MAX_GATE_LOWER_BOUND_MAGNITUDE",
+    "SM100_KDA_CAPABILITIES",
+    "is_sm100_kda_capability",
 ]

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py
@@ -37,7 +37,7 @@ from attn_gym.linear.kda.ops import (
 from attn_gym.linear.kda.ops import (
     chunk_fwd_with_state_op as _chunk_kda_fwd_with_state_op,
 )
-from attn_gym.linear.kda.utils import profiler_range
+from attn_gym.linear.kda.utils import is_sm100_kda_target, profiler_range
 
 # TODO: Revisit model-approved chunk sizes: this is a major performance lever,
 # but it changes the KDA decomposition and rounding order, so it can affect numerics.
@@ -501,7 +501,7 @@ def _prepare_chunk_kda_backward(
         d_output = normalize_tma_rows(d_output)
     if d_final_state is not None:
         d_final_state = _normalize_state_cotangent(d_final_state.float())
-    if get_device_properties(q.device).major < 10:
+    if not is_sm100_kda_target(q.device):
         d_output = d_output.contiguous()
         if d_final_state is not None:
             d_final_state = d_final_state.contiguous()

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_inter_solve.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_inter_solve.py
@@ -32,7 +32,7 @@ from attn_gym.linear.kda.chunk_schedule import (
     validate_schedule_request,
 )
 from attn_gym.linear.kda.chunk_scheduler import GridScheduler
-from attn_gym.linear.kda.constants import DEFAULT_CHUNK_SIZE
+from attn_gym.linear.kda.constants import DEFAULT_CHUNK_SIZE, is_sm100_kda_capability
 from attn_gym.linear.kda.fwd.cute.chunk_kda_k3b_offdiag_cutedsl import (
     ChunkKDAFwdK3bOffdiagCuteDSL,
 )
@@ -58,8 +58,8 @@ _IO_TYPES = {
 
 def _check_compile_target() -> None:
     target = get_compile_target()
-    if target.device_type != "cuda" or target.capability is None or target.capability < (10, 0):
-        raise ValueError(f"KDA inter-solve requires CUDA capability >= 10.0; got target={target}")
+    if target.device_type != "cuda" or not is_sm100_kda_capability(target.effective_capability):
+        raise ValueError(f"KDA inter-solve requires an SM100 or SM103 target; got {target}")
 
 
 def _validate_specialization(head_dim: int, chunk_size: int, subchunk_size: int) -> int:

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_intra.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_intra.py
@@ -4,8 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 #
-# KDA forward factor composition. Pre-Blackwell GPUs use the FP32/TF32 BC16
-# diagonal stage plus Triton K3/K4; Blackwell retains its CuTe factor engines.
+# KDA forward factor composition. SM100/SM103 retains its CuTe factor engines;
+# every other supported GPU uses the FP32/TF32 BC16 stage plus Triton K3/K4.
 
 from __future__ import annotations
 
@@ -14,7 +14,6 @@ from contextlib import nullcontext
 import torch
 from torch._subclasses.fake_tensor import FakeTensor
 
-from attn_gym._backends.cute.utils import get_device_properties
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata
 from attn_gym.linear.kda.constants import DEFAULT_CHUNK_SIZE
 from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd_inter_solve import (
@@ -34,6 +33,7 @@ from attn_gym.linear.kda.fwd.triton.chunk_kda_fwd_k3_triton import (
 from attn_gym.linear.kda.fwd.triton.chunk_kda_fwd_k4_triton import (
     chunk_kda_fwd_k4b_triton,
 )
+from attn_gym.linear.kda.utils import is_sm100_kda_target
 
 
 def chunk_kda_fwd_factors(
@@ -57,7 +57,7 @@ def chunk_kda_fwd_factors(
         shape = (batch, tokens, heads, chunk_size)
         return k.new_empty(shape), k.new_empty(shape)
 
-    if get_device_properties(k.device).major < 10:
+    if not is_sm100_kda_target(k.device):
         Aqk, Akkd = chunk_kda_fwd_intra_diagonal(q, k, gk, beta, scale, metadata, chunk_size)
         AkkOD = chunk_kda_fwd_k3b_triton(q, k, gk, beta, Aqk, scale, metadata)
         return Aqk, chunk_kda_fwd_k4b_triton(AkkOD, Akkd, metadata, output_dtype=q.dtype)

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_intra_engine.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_intra_engine.py
@@ -44,6 +44,7 @@ from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata
 from attn_gym.linear.kda.chunk_scheduler import (
     load_ragged_chunk_work as _tl_load_ragged_chunk_work,
 )
+from attn_gym.linear.kda.constants import is_sm100_kda_capability
 from attn_gym.linear.kda.fwd.cute.chunk_scheduler_cute import load_ragged_chunk_work
 
 
@@ -953,6 +954,9 @@ def _compile_intra_engine_fwd(
     varlen: bool,
     use_int64_offsets: bool,
 ):
+    target = get_compile_target()
+    if target.device_type != "cuda" or not is_sm100_kda_capability(target.effective_capability):
+        raise ValueError(f"KDA intra engine requires an SM100 or SM103 target; got {target}")
     op = KdaIntraFwdEngine(
         head_dim=head_dim,
         num_heads=H,

--- a/attn_gym/linear/kda/fwd/cute/recompute_w_u_fwd.py
+++ b/attn_gym/linear/kda/fwd/cute/recompute_w_u_fwd.py
@@ -80,6 +80,7 @@ from torch._subclasses.fake_tensor import FakeTensor
 from attn_gym._backends.cute import compile_tvm_ffi, jit_cache
 from attn_gym._backends.cute.target import get_compile_target
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata, ScheduleRequest
+from attn_gym.linear.kda.constants import is_sm100_kda_capability
 from attn_gym.linear.kda.fwd.cute.chunk_scheduler_cute import load_ragged_chunk_work
 from attn_gym.linear.kda.fwd.triton.recompute_w_u import recompute_w_u_fwd_triton
 
@@ -1331,13 +1332,11 @@ def _compile_recompute_w_u(
     target = get_compile_target()
     if (
         target.device_type != "cuda"
-        or target.capability is None
-        or target.capability < (10, 0)
+        or not is_sm100_kda_capability(target.effective_capability)
         or target.sm_count is None
     ):
         raise ValueError(
-            "KDA recompute requires a CUDA capability >= 10.0 target with a known SM count; "
-            f"got target={target}"
+            f"KDA recompute requires an SM100 or SM103 target with a known SM count; got {target}"
         )
     assert chunk_size == BT, f"KDA recompute requires chunk_size={BT}, got {chunk_size}"
     assert key_dim == KEY_DIM, f"KDA recompute requires key_dim={KEY_DIM}, got {key_dim}"

--- a/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
@@ -34,7 +34,7 @@ from attn_gym.linear.kda.chunk_scheduler import (
 from attn_gym.linear.kda.ops import delta_h_op as _delta_h_op
 from attn_gym.linear.kda.ops import delta_h_paged_op as _delta_h_paged_op
 from attn_gym.linear.kda.ops import delta_h_with_state_op as _delta_h_with_state_op
-from attn_gym.linear.kda.utils import exp2
+from attn_gym.linear.kda.utils import exp2, is_sm100_kda_target
 
 
 @triton.jit
@@ -462,8 +462,9 @@ def _delta_h_launch(
     # FP32 tiles double the descriptor staging past the shared-memory limit at
     # the 16-bit tile shape. Hopper also uses ordinary pipelining: its Triton
     # warp-specialization pass cannot commit the descriptor stores in this loop.
+    # SM120 also uses ordinary pipelining because this schedule is SM100-specific.
     use_16bit_config = k.element_size() == 2
-    use_warp_specialization = use_16bit_config and get_device_properties(k.device).major >= 10
+    use_warp_specialization = use_16bit_config and is_sm100_kda_target(k.device)
     block_value_dim = _BLOCK_VALUE_DIM if use_16bit_config else _BLOCK_VALUE_DIM // 2
     descriptors = (
         TensorDescriptor.from_tensor(k, [1, _CHUNK_SIZE, 1, key_dim]),

--- a/attn_gym/linear/kda/utils.py
+++ b/attn_gym/linear/kda/utils.py
@@ -30,6 +30,7 @@ from packaging import version
 from triton.language.extra import libdevice
 
 from attn_gym._backends.triton import utils as triton_utils
+from attn_gym.linear.kda.constants import is_sm100_kda_capability
 
 SUPPORTS_AUTOTUNE_CACHE = triton_utils.SUPPORTS_AUTOTUNE_CACHE
 autotune_cache_kwargs = triton_utils.autotune_cache_kwargs
@@ -105,6 +106,14 @@ IS_NVIDIA = device_platform == "cuda"
 IS_NVIDIA_BLACKWELL = IS_NVIDIA and torch.cuda.get_device_capability()[0] in (10, 12)
 IS_TF32_SUPPORTED = IS_NVIDIA and torch.cuda.get_device_capability(0)[0] >= 8
 IS_GATHER_SUPPORTED = hasattr(triton.language, "gather")
+
+
+@lru_cache(maxsize=8)
+def is_sm100_kda_target(device: torch.device) -> bool:
+    """Return whether a physical device should use the SM100-specific KDA route."""
+    properties = torch.cuda.get_device_properties(device)
+    return is_sm100_kda_capability((properties.major, properties.minor))
+
 
 if IS_NVIDIA and not IS_TF32_SUPPORTED:
     # Make old cards happy, since triton will use tf32 by default.

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -150,7 +150,9 @@ contract. A correctness-first integration can keep the KDA unit under an FP32 po
 its projections explicitly compute in BF16; isolating only the strict-FP32 decay state is
 a future bandwidth optimization.
 The optimized `chunk_kda` core requires Ampere or newer and `head_dim=128`; its public
-boundary accepts FP16, BF16, or FP32 inputs. Homogeneous FP16 and BF16 Q/K/V stay in their input dtype, while
+boundary accepts FP16, BF16, or FP32 inputs. SM100/SM103 select the specialized CuTe path;
+SM120 and earlier supported architectures use the portable Triton stages. Homogeneous FP16 and
+BF16 Q/K/V stay in their input dtype, while
 FP32 or mixed-dtype inputs retain the existing BF16 normalization. The core chunks internally at
 64 tokens. Complete `B=1` inputs whose length is a multiple of the chunk size run on the
 direct dense route; other dense `[B, T, H, D]` inputs are lowered internally to

--- a/test/test_kda_chunk_scheduler.py
+++ b/test/test_kda_chunk_scheduler.py
@@ -226,8 +226,8 @@ def _decode_ragged_chunk_work_cute(*args, **kwargs):
 
 
 requires_cute = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (10, 0),
-    reason="the CuTeDSL KDA scheduler test requires CUDA capability 10.0 or newer",
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() not in ((10, 0), (10, 3)),
+    reason="the CuTeDSL KDA scheduler test requires an SM100 or SM103 GPU",
 )
 
 

--- a/test/test_kda_cute_inter_solve.py
+++ b/test/test_kda_cute_inter_solve.py
@@ -71,8 +71,8 @@ def test_ragged_fake_tensors_reject_legacy_boolean_schedule():
 
 
 @pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (10, 0),
-    reason="the CuTeDSL KDA inter-solve requires CUDA capability 10.0 or newer",
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() not in ((10, 0), (10, 3)),
+    reason="the CuTeDSL KDA inter-solve requires an SM100 or SM103 GPU",
 )
 def test_inter_solve_reuses_compiled_specializations(tmp_path, monkeypatch):
     pytest.importorskip("cutlass")

--- a/test/test_kda_cute_recompute.py
+++ b/test/test_kda_cute_recompute.py
@@ -16,8 +16,8 @@ from attn_gym.linear.kda.chunk_scheduler import (
 pytest.importorskip("cutlass")
 
 pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (10, 0),
-    reason="the CuTeDSL KDA recompute kernel requires CUDA capability 10.0 or newer",
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() not in ((10, 0), (10, 3)),
+    reason="the CuTeDSL KDA recompute kernel requires an SM100 or SM103 GPU",
 )
 
 

--- a/test/test_kda_impl_dispatch.py
+++ b/test/test_kda_impl_dispatch.py
@@ -12,10 +12,29 @@ import torch.nn.functional as F
 
 from attn_gym.linear import Impl, KernelOptions, chunk_kda, recurrent_kda
 from attn_gym.linear._delta_rule.validation import validate_paged_state
+from attn_gym.linear.kda.constants import is_sm100_kda_capability
+from attn_gym.linear.kda.utils import is_sm100_kda_target
 
 pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="KDA ops require CUDA")
 
 FUSED_CHUNK = torch.cuda.is_available() and torch.cuda.get_device_capability() >= (8, 0)
+
+
+@pytest.mark.parametrize(
+    ("capability", "expected"),
+    [((8, 0), False), ((9, 0), False), ((10, 0), True), ((10, 3), True), ((12, 0), False)],
+)
+def test_sm100_kda_route_is_exact(monkeypatch, capability, expected):
+    """Keep SM120 and earlier architectures off SM100-specific kernels."""
+    assert is_sm100_kda_capability(capability) is expected
+
+    class Properties:
+        major, minor = capability
+
+    monkeypatch.setattr(torch.cuda, "get_device_properties", lambda _device: Properties())
+    is_sm100_kda_target.cache_clear()
+    assert is_sm100_kda_target(torch.device("cuda")) is expected
+    is_sm100_kda_target.cache_clear()
 
 
 def _inputs(

--- a/test/test_kda_kernels.py
+++ b/test/test_kda_kernels.py
@@ -45,7 +45,10 @@ from attn_gym.testing.kda import (
     bwd_wy_dqkg_reference as _bwd_wy_dqkg_ref,
 )
 
-IS_SM100 = torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 10
+IS_SM100 = torch.cuda.is_available() and torch.cuda.get_device_capability() in (
+    (10, 0),
+    (10, 3),
+)
 
 try:
     from attn_gym.linear.kda.bwd.cute import chunk_delta_h_bwd as delta_h_bwd

--- a/test/test_kda_ragged_bwd_intra.py
+++ b/test/test_kda_ragged_bwd_intra.py
@@ -28,8 +28,9 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def test_bwd_intra_compiles_for_sm80():
-    """Compile the scalar-store specialization without emitting stmatrix."""
+@pytest.mark.parametrize("architecture", ["sm_80", "sm_120"])
+def test_bwd_intra_compiles_for_portable_targets(architecture: str):
+    """Compile the portable specialization without SM100-only instructions."""
     source = """
 import torch
 from attn_gym.linear.kda.bwd.cute import chunk_kda_bwd_intra as module
@@ -44,7 +45,7 @@ module._compile_chunk_kda_bwd_intra(
 )
 """
     environment = os.environ.copy()
-    environment["CUTE_DSL_ARCH"] = "sm_80"
+    environment["CUTE_DSL_ARCH"] = architecture
     environment["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
     subprocess.run([sys.executable, "-c", source], env=environment, check=True, timeout=180)
 

--- a/test/test_kda_ragged_forward_stages.py
+++ b/test/test_kda_ragged_forward_stages.py
@@ -9,8 +9,8 @@ from attn_gym.linear.kda.chunk_scheduler import prepare_ragged_chunk_metadata
 from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd_intra import chunk_kda_fwd_intra
 
 pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (10, 0),
-    reason="the CuTe KDA forward stages require CUDA capability 10.0 or newer",
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() not in ((10, 0), (10, 3)),
+    reason="the CuTe KDA forward stages require an SM100 or SM103 GPU",
 )
 
 

--- a/test/test_kda_ragged_k3.py
+++ b/test/test_kda_ragged_k3.py
@@ -12,8 +12,8 @@ from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd_inter_solve import (
 from attn_gym.testing import cumulative_sequence_offsets
 
 pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (10, 0),
-    reason="the CuTe K3 kernel requires CUDA capability 10.0 or newer",
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() not in ((10, 0), (10, 3)),
+    reason="the CuTe K3 kernel requires an SM100 or SM103 GPU",
 )
 
 _BLOCK_PAIRS = ((1, 0), (2, 0), (2, 1), (3, 0), (3, 1), (3, 2))

--- a/test/test_kda_ragged_k4.py
+++ b/test/test_kda_ragged_k4.py
@@ -20,8 +20,8 @@ from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd_inter_solve import (
 from attn_gym.testing import cumulative_sequence_offsets
 
 pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (10, 0),
-    reason="the CuTe K4 kernel requires CUDA capability 10.0 or newer",
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() not in ((10, 0), (10, 3)),
+    reason="the CuTe K4 kernel requires an SM100 or SM103 GPU",
 )
 
 _BLOCK_PAIRS = ((1, 0), (2, 0), (2, 1), (3, 0), (3, 1), (3, 2))


### PR DESCRIPTION
Route SM120 KDA through portable kernels

## Human Note

## Agent note

The KDA selector treated every capability at or above SM100 as if it supported the datacenter
SM100/SM103 tcgen05, TMEM, packed-add, and warp-specialized schedules. That incorrectly routes
SM120 consumer Blackwell GPUs into architecture-conditional kernels that are not compatible with
SM120.

Define the SM100 KDA capability set once as `(10, 0)` and `(10, 3)`. Use it for runtime dispatch,
compile-target validation, packed-add selection, and recurrence warp specialization. SM120 now uses
the same portable Triton and ordinary-pipeline route as Ampere and Hopper. Compile guards consult
the effective configured architecture so cross-target builds cannot emit SM100-only instructions
into an SM120 artifact.

## Test Plan

```bash
pytest -n 6 test/test_kda_impl_dispatch.py test/test_kda_hopper.py \
  test/test_kda_ragged_bwd_intra.py test/test_kda_recurrent.py
pytest -n 6 test/test_kda_compile_dynamic_shapes.py test/test_kda_imports.py \
  test/test_kda_gate_semantics.py
pytest test/test_kda_impl_dispatch.py::test_sm100_kda_route_is_exact \
  test/test_kda_ragged_bwd_intra.py::test_bwd_intra_compiles_for_portable_targets
ruff check attn_gym/linear/kda test/test_kda_impl_dispatch.py \
  test/test_kda_ragged_bwd_intra.py
```