### PR TITLE
Allow Triton descriptor fallback on Ampere

### DIFF
--- a/attn_gym/_backends/triton/utils.py
+++ b/attn_gym/_backends/triton/utils.py
@@ -76,9 +76,9 @@ def requires_int64_offsets(*tensors: torch.Tensor | None) -> bool:
     )
 
 
-def can_use_tma(tensor: torch.Tensor) -> bool:
-    """Return whether a tensor can be accessed with a TMA tensor descriptor."""
-    if not tensor.is_cuda or torch.cuda.get_device_capability(tensor.device)[0] < 9:
+def can_use_tensor_descriptor(tensor: torch.Tensor) -> bool:
+    """Return whether a tensor satisfies Triton tensor-descriptor layout constraints."""
+    if not tensor.is_cuda:
         return False
 
     element_size = tensor.element_size()
@@ -90,6 +90,15 @@ def can_use_tma(tensor: torch.Tensor) -> bool:
         and tensor.stride(-1) == 1
         and storage_is_aligned
         and all(stride * element_size % 16 == 0 for stride in tensor.stride()[:-1])
+    )
+
+
+def can_use_tma(tensor: torch.Tensor) -> bool:
+    """Return whether a compatible descriptor can use hardware TMA."""
+    return (
+        tensor.is_cuda
+        and torch.cuda.get_device_capability(tensor.device)[0] >= 9
+        and can_use_tensor_descriptor(tensor)
     )
 
 

--- a/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_delta_h.py
@@ -10,8 +10,9 @@ A single kernel (B=1, K=V=128, 64-token chunks) keeps the full [K, BV] state in
 one accumulator. Blackwell overlaps descriptor loads with the serial state MMAs
 through warp specialization; Hopper and FP32 use ordinary pipelining because the
 Hopper warp-specialization pass cannot commit this kernel's descriptor stores.
-Host-side tensor descriptors do not survive Dynamo/Inductor tracing, so the
-launch sits behind a compiler-opaque ``torch.library`` op pair.
+Host-side tensor descriptors use hardware TMA where available and Triton
+fallback lowering on SM80. They do not survive Dynamo/Inductor tracing, so
+the launch sits behind a compiler-opaque ``torch.library`` op pair.
 """
 
 from __future__ import annotations
@@ -22,7 +23,11 @@ import triton.language as tl
 from triton.tools.tensor_descriptor import TensorDescriptor
 
 from attn_gym._backends.cute.utils import get_device_properties
-from attn_gym._backends.triton.utils import can_use_tma, ptr_offset, requires_int64_offsets
+from attn_gym._backends.triton.utils import (
+    can_use_tensor_descriptor,
+    ptr_offset,
+    requires_int64_offsets,
+)
 from attn_gym.linear.kda.chunk_scheduler import (
     GridScheduler,
     RaggedChunkMetadata,
@@ -453,7 +458,7 @@ def _delta_h_launch(
     scalar_gate = gk.ndim == 3
     if scalar_gate:
         gk = gk.contiguous()
-    elif not can_use_tma(gk):
+    elif not can_use_tensor_descriptor(gk):
         gk = gk.clone(memory_format=torch.contiguous_format)
     state_batch = batch if cu_seqlens is None else cu_seqlens.shape[0] - 1
     compact_state_strides = (heads * value_dim * key_dim, value_dim * key_dim, key_dim, 1)
@@ -742,7 +747,7 @@ def chunk_gated_delta_rule_fwd_h(
             )
         return h, torch.empty_like(u), final_state
 
-    if not all(can_use_tma(t) for t in (k, w, u)):
+    if not all(can_use_tensor_descriptor(t) for t in (k, w, u)):
         raise ValueError(
             "the inter-chunk state recurrence requires 16-byte-aligned, "
             "last-dimension-contiguous k, w, and u"

--- a/test/test_kda_ragged_autograd_ops.py
+++ b/test/test_kda_ragged_autograd_ops.py
@@ -19,8 +19,8 @@ from attn_gym.linear.kda.naive import chunk_cumsum_ref
 from attn_gym.testing.kda import cumulative_sequence_offsets, make_kda_test_inputs
 
 pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.get_device_capability() not in ((10, 0), (10, 3)),
-    reason="the CuTe KDA core requires CUDA capability 10.0 or 10.3",
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (8, 0),
+    reason="the fused KDA core requires CUDA capability 8.0 or newer",
 )
 
 

--- a/test/test_kda_ragged_public_backward.py
+++ b/test/test_kda_ragged_public_backward.py
@@ -20,8 +20,8 @@ from attn_gym.testing.kda import (
 )
 
 pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.get_device_capability() not in ((10, 0), (10, 3)),
-    reason="the CuTe KDA core requires CUDA capability 10.0 or 10.3",
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (8, 0),
+    reason="the fused KDA core requires CUDA capability 8.0 or newer",
 )
 
 

--- a/test/test_kda_ragged_recurrence.py
+++ b/test/test_kda_ragged_recurrence.py
@@ -84,6 +84,16 @@ def test_ragged_recurrence_matches_independent_sequences():
     torch.testing.assert_close(final_state, torch.stack(expected_final), rtol=0, atol=0)
 
 
+def test_tensor_descriptor_compatibility_does_not_require_hardware_tma(monkeypatch):
+    """Allow Triton descriptor fallback on SM80 without advertising hardware TMA."""
+    from attn_gym._backends.triton.utils import can_use_tensor_descriptor, can_use_tma
+
+    tensor = torch.empty(1, 64, 1, 128, device="cuda", dtype=torch.bfloat16)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda _device=None: (8, 0))
+    assert can_use_tensor_descriptor(tensor)
+    assert not can_use_tma(tensor)
+
+
 def test_recurrence_normalizes_misaligned_compact_gate():
     from attn_gym._backends.triton.utils import can_use_tma
 


### PR DESCRIPTION
Allow Triton descriptor fallback on Ampere

## Human Note

## Agent note

The fused KDA recurrence rejected every pre-SM90 device before launch because `can_use_tma()`
combined two different questions: whether a tensor satisfies Triton tensor-descriptor layout rules,
and whether the GPU has hardware TMA. Current Triton can lower descriptor loads and stores through a
fallback on SM80, so the guard prevented a supported execution path.

Separate descriptor compatibility from hardware-TMA availability. Keep the architecture-aware
`can_use_tma()` predicate for kernels that deliberately select TMA, while `chunk_delta_h` now accepts
any descriptor-compatible layout and lets Triton choose hardware TMA or fallback lowering. Lower the
public ragged KDA tests to the actual SM80 capability floor.

## Test Plan

```bash
pytest -n 6 test/test_kda_ragged_recurrence.py test/test_kda_impl_dispatch.py \
  test/test_kda_ragged_public_backward.py test/test_kda_ragged_autograd_ops.py \
  test/test_kda_gate_semantics.py::test_fused_chunk_gate_range_boundary_is_finite
modal run agent_space/modal_tensor_descriptor_probe.py
modal run agent_space/modal_ampere_kda.py
```

Modal A100-SXM4-80GB validation: 51 fused KDA forward, backward, packed, fullgraph, CUDA Graph,
opcheck, and numerical tests passed in 130.66 seconds.