### PR TITLE
Fix Mega kernel synchronization edge cases

### DIFF
--- a/attn_gym/linear/_delta_rule/mega/gdn_backward.py
+++ b/attn_gym/linear/_delta_rule/mega/gdn_backward.py
@@ -44,6 +44,8 @@ def chunk_gdn_bwd_mega_packed(
 ]:
     """Run exact BT64 checkpoint recompute followed by scalar-GDN backward."""
     scale = resolve_scale(scale, q.shape[-1])
+    if d_output.dtype != q.dtype:
+        raise TypeError(f"d_output must use q.dtype ({q.dtype}), got {d_output.dtype}")
     if not q.is_cuda:
         raise ValueError("q must be a CUDA tensor")
     with initialized_cuda_device(q):

--- a/attn_gym/linear/_delta_rule/mega/kernels/gdn_bprop_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/gdn_bprop_f16.py
@@ -5039,97 +5039,98 @@ def kernel(
         beta_smem_layout_staged,
     )
 
-    # ---- mbarrier init (all threads) ---------------------------------------------
-    for s_ in range(cfg.sched_stages):
-        bars.mb_sched_ready[s_].init()
-        bars.mb_sched_done[s_].init()
-    for s in range(cfg.smem_q_stages):
-        bars.mb_q_ready[s].init()
-        bars.mb_q_mma_done[s].init()
-        bars.mb_q_cg1_done[s].init()
-    for s in range(cfg.smem_k_stages):
-        bars.mb_k_ready[s].init()
-        bars.mb_k_mma_done[s].init()
-        bars.mb_k_cg0_done[s].init()
-    for s in range(cfg.smem_v_stages):
-        bars.mb_v_ready[s].init()
-        bars.mb_v_mma_done[s].init()
-    for s in range(cfg.smem_do_stages):
-        bars.mb_do_ready[s].init()
-        bars.mb_do_mma_done[s].init()
-    for s in range(cfg.smem_state_stages):
-        bars.mb_state_ready[s].init()
-        bars.mb_state_mma_done[s].init()
-    for s in range(cfg.smem_gate_stages):
-        bars.mb_gate_ready[s].init()
-        bars.mb_gate_done[s].init()
-    for s in range(cfg.smem_beta_stages):
-        bars.mb_beta_ready[s].init()
-        bars.mb_beta_done[s].init()
-    for s in range(cfg.tmem_dstate_acc_stages):
-        bars.mb_dstate_acc_ready[s].init()
-        bars.mb_dstate_scale_acc_done[s].init()
-    for b in (
-        bars.mb_du_scale_acc_ready,
-        bars.mb_du_scale_acc_done,
-        bars.mb_du_total_acc_ready,
-        bars.mb_dk_scale_acc_ready,
-        bars.mb_dk_scale_acc_done,
-        bars.mb_dk_attn_acc_ready,
-        bars.mb_dk_attn_acc_done,
-        bars.mb_dk_total_acc_ready,
-        bars.mb_dk_total_acc_done,
-    ):
-        b[0].init()
-    for b in (
-        bars.mb_kk_acc_ready,
-        bars.mb_kk_acc_done,
-        bars.mb_a_acc_ready,
-        bars.mb_k_state_acc_ready,
-        bars.mb_u_acc_ready,
-        bars.mb_dy_acc_ready,
-    ):
-        b[0].init()
-    for s in range(cfg.smem_t_inv_stages):
-        bars.mb_t_inv_ready[s].init()
-    for s in range(cfg.smem_a_stages):
-        bars.mb_a_ready[s].init()
-        bars.mb_a_done[s].init()
-    for s in range(cfg.tmem_dstate_inp_stages):
-        bars.mb_dstate_inp_ready[s].init()
-        bars.mb_dstate_inp_done[s].init()
-    for b in (
-        bars.mb_do_prime_inp_ready,
-        bars.mb_du_inp_ready,
-        bars.mb_dyp_inp_ready,
-    ):
-        b[0].init()
-    for s in range(cfg.smem_dq_stages):
-        bars.mb_dq_tmastg_ready[s].init()
-        bars.mb_dq_tmastg_done[s].init()
-    for s in range(cfg.smem_dk_stages):
-        bars.mb_dk_tmastg_ready[s].init()
-        bars.mb_dk_tmastg_done[s].init()
-    for s in range(cfg.smem_dv_stages):
-        bars.mb_dv_tmastg_ready[s].init()
-        bars.mb_dv_tmastg_done[s].init()
-    bars.mb_y_ready[0].init()
-    bars.mb_sdv_done[0].init()
-    bars.mb_u_ready[0].init()
-    bars.mb_dstate_smem_ready[0].init()
-    bars.mb_da_ready[0].init()
-    bars.mb_dq_acc_scale_ready[0].init()
-    bars.mb_dq_acc_scale_done[0].init()
-    bars.mb_dq_acc_total_ready[0].init()
-    bars.mb_dq_acc_total_done[0].init()
-    bars.mb_da_acc_ready[0].init()
-    bars.mb_dm_acc_ready[0].init()
-    bars.mb_dm_acc_done[0].init()
-    bars.mb_dbeta_cg1_ready[0].init()
-    bars.mb_dgate_cg1_ready[0].init()
-    bars.mb_state_dot_dstate_done[0].init()
-    bars.mb_dk_state_path_acc_ready[0].init()
-    bars.mb_tmem_done[0].init()
+    # ---- mbarrier init -----------------------------------------------------------
+    if tidx == 0:
+        for s_ in range(cfg.sched_stages):
+            bars.mb_sched_ready[s_].init()
+            bars.mb_sched_done[s_].init()
+        for s in range(cfg.smem_q_stages):
+            bars.mb_q_ready[s].init()
+            bars.mb_q_mma_done[s].init()
+            bars.mb_q_cg1_done[s].init()
+        for s in range(cfg.smem_k_stages):
+            bars.mb_k_ready[s].init()
+            bars.mb_k_mma_done[s].init()
+            bars.mb_k_cg0_done[s].init()
+        for s in range(cfg.smem_v_stages):
+            bars.mb_v_ready[s].init()
+            bars.mb_v_mma_done[s].init()
+        for s in range(cfg.smem_do_stages):
+            bars.mb_do_ready[s].init()
+            bars.mb_do_mma_done[s].init()
+        for s in range(cfg.smem_state_stages):
+            bars.mb_state_ready[s].init()
+            bars.mb_state_mma_done[s].init()
+        for s in range(cfg.smem_gate_stages):
+            bars.mb_gate_ready[s].init()
+            bars.mb_gate_done[s].init()
+        for s in range(cfg.smem_beta_stages):
+            bars.mb_beta_ready[s].init()
+            bars.mb_beta_done[s].init()
+        for s in range(cfg.tmem_dstate_acc_stages):
+            bars.mb_dstate_acc_ready[s].init()
+            bars.mb_dstate_scale_acc_done[s].init()
+        for b in (
+            bars.mb_du_scale_acc_ready,
+            bars.mb_du_scale_acc_done,
+            bars.mb_du_total_acc_ready,
+            bars.mb_dk_scale_acc_ready,
+            bars.mb_dk_scale_acc_done,
+            bars.mb_dk_attn_acc_ready,
+            bars.mb_dk_attn_acc_done,
+            bars.mb_dk_total_acc_ready,
+            bars.mb_dk_total_acc_done,
+        ):
+            b[0].init()
+        for b in (
+            bars.mb_kk_acc_ready,
+            bars.mb_kk_acc_done,
+            bars.mb_a_acc_ready,
+            bars.mb_k_state_acc_ready,
+            bars.mb_u_acc_ready,
+            bars.mb_dy_acc_ready,
+        ):
+            b[0].init()
+        for s in range(cfg.smem_t_inv_stages):
+            bars.mb_t_inv_ready[s].init()
+        for s in range(cfg.smem_a_stages):
+            bars.mb_a_ready[s].init()
+            bars.mb_a_done[s].init()
+        for s in range(cfg.tmem_dstate_inp_stages):
+            bars.mb_dstate_inp_ready[s].init()
+            bars.mb_dstate_inp_done[s].init()
+        for b in (
+            bars.mb_do_prime_inp_ready,
+            bars.mb_du_inp_ready,
+            bars.mb_dyp_inp_ready,
+        ):
+            b[0].init()
+        for s in range(cfg.smem_dq_stages):
+            bars.mb_dq_tmastg_ready[s].init()
+            bars.mb_dq_tmastg_done[s].init()
+        for s in range(cfg.smem_dk_stages):
+            bars.mb_dk_tmastg_ready[s].init()
+            bars.mb_dk_tmastg_done[s].init()
+        for s in range(cfg.smem_dv_stages):
+            bars.mb_dv_tmastg_ready[s].init()
+            bars.mb_dv_tmastg_done[s].init()
+        bars.mb_y_ready[0].init()
+        bars.mb_sdv_done[0].init()
+        bars.mb_u_ready[0].init()
+        bars.mb_dstate_smem_ready[0].init()
+        bars.mb_da_ready[0].init()
+        bars.mb_dq_acc_scale_ready[0].init()
+        bars.mb_dq_acc_scale_done[0].init()
+        bars.mb_dq_acc_total_ready[0].init()
+        bars.mb_dq_acc_total_done[0].init()
+        bars.mb_da_acc_ready[0].init()
+        bars.mb_dm_acc_ready[0].init()
+        bars.mb_dm_acc_done[0].init()
+        bars.mb_dbeta_cg1_ready[0].init()
+        bars.mb_dgate_cg1_ready[0].init()
+        bars.mb_state_dot_dstate_done[0].init()
+        bars.mb_dk_state_path_acc_ready[0].init()
+        bars.mb_tmem_done[0].init()
 
     nvvm.fence_mbarrier_init()
     nvvm.barrier_cta_sync()
@@ -5581,6 +5582,8 @@ def chunk_gdn_bwd_sm100(
         raise ValueError("q, k, and v must have shape (T, H, 128)")
     if do.shape != (tokens, h_out, CFG.D_V):
         raise ValueError("do must have shape (T, H, 128) at the output head count")
+    if do.dtype != q.dtype:
+        raise TypeError(f"do must use q.dtype ({q.dtype}), got {do.dtype}")
     if h_q != h_out or h_k != h_out:
         raise ValueError("chunk_gdn_bwd_sm100 requires q and k head ratios of one")
     for name, tensor, expected_shape in (

--- a/attn_gym/linear/_delta_rule/mega/kernels/gdn_prefill_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/gdn_prefill_f16.py
@@ -1266,8 +1266,6 @@ def mma_warp(
         for local_idx in cutlass.range(n_local):  # noqa: B007
             if cutlass.const_expr(cfg.use_initial_state):
                 if local_idx == 0:
-                    if elect_one:
-                        bars.mb_state_acc_ready[kv_acc_index.idx].arrive(cta_group=1)
                     kv_acc_index = advance(kv_acc_index, cfg.tmem_state_acc_stages)
             have_state = (
                 cutlass.Boolean(True)
@@ -2339,8 +2337,11 @@ def compute1_warp_group(
                 # ---- state restage + rescale -------------------------------------
                 if valid_state:
                     kv_idx = kv_acc_index.idx
-                    bars.mb_state_acc_ready[kv_idx].wait(kv_acc_index.phase)
-                    kv_acc_index = advance(kv_acc_index, cfg.tmem_state_acc_stages)
+                    # CG1 writes the seeded state itself; only subsequent states
+                    # arrive through the MMA-owned state accumulator barrier.
+                    if local_idx > 0:
+                        bars.mb_state_acc_ready[kv_idx].wait(kv_acc_index.phase)
+                        kv_acc_index = advance(kv_acc_index, cfg.tmem_state_acc_stages)
                     kv_done_idx = kv_idx
 
                     state_regs = [
@@ -3409,51 +3410,52 @@ def kernel(
         beta_smem_layout_staged,
     )
 
-    # ---- mbarrier init (all threads) ---------------------------------------------
-    for s in range(cfg.smem_kq_stages):
-        bars.mb_kq_ready[s].init()
-        bars.mb_kq_done[s].init()
-    for s in range(cfg.smem_v_stages):
-        bars.mb_v_ready[s].init()
-        bars.mb_v_done[s].init()
-    for s in range(cfg.smem_gate_stages):
-        bars.mb_gate_ready[s].init()
-        bars.mb_gate_done[s].init()
-    for s in range(cfg.smem_beta_stages):
-        bars.mb_beta_ready[s].init()
-        bars.mb_beta_done[s].init()
-    for s in range(cfg.tmem_state_acc_stages):
-        bars.mb_state_acc_ready[s].init()
-        bars.mb_state_acc_scale_done[s].init()
-    for s in range(cfg.tmem_q_state_acc_stages):
-        bars.mb_o_acc_ready[s].init()
-        bars.mb_o_final_acc_ready[s].init()
-        bars.mb_o_state_scale_acc_done[s].init()
-    for s in range(cfg.tmem_cg0_acc_stages):
-        bars.mb_cg0_acc_ready[s].init()
-        bars.mb_cg0_acc_done[s].init()
-    bars.mb_k_state_acc_ready[0].init()
-    bars.mb_u_acc_ready[0].init()
-    for s in range(cfg.smem_t_inv_stages):
-        bars.mb_t_inv_ready[s].init()
-        bars.mb_t_inv_done[s].init()
-    for s in range(cfg.smem_a_stages):
-        bars.mb_a_ready[s].init()
-        bars.mb_a_done[s].init()
-    for s in range(cfg.tmem_state_inp_stages):
-        bars.mb_state_inp_ready[s].init()
-    for b in (bars.mb_y_inp_ready, bars.mb_u_inp_ready, bars.mb_decay_u_inp_ready):
-        b[0].init()
-    for s in range(cfg.smem_o_stages):
-        bars.mb_o_tmastg_ready[s].init()
-        bars.mb_o_tmastg_done[s].init()
-    for s in range(cfg.smem_checkpoint_stages):
-        bars.mb_checkpoint_tmastg_ready[s].init()
-        bars.mb_checkpoint_tmastg_done[s].init()
-    for s_ in range(cfg.sched_stages):
-        bars.mb_sched_ready[s_].init()
-        bars.mb_sched_done[s_].init()
-    bars.mb_tmem_done[0].init()
+    # ---- mbarrier init -----------------------------------------------------------
+    if tidx == 0:
+        for s in range(cfg.smem_kq_stages):
+            bars.mb_kq_ready[s].init()
+            bars.mb_kq_done[s].init()
+        for s in range(cfg.smem_v_stages):
+            bars.mb_v_ready[s].init()
+            bars.mb_v_done[s].init()
+        for s in range(cfg.smem_gate_stages):
+            bars.mb_gate_ready[s].init()
+            bars.mb_gate_done[s].init()
+        for s in range(cfg.smem_beta_stages):
+            bars.mb_beta_ready[s].init()
+            bars.mb_beta_done[s].init()
+        for s in range(cfg.tmem_state_acc_stages):
+            bars.mb_state_acc_ready[s].init()
+            bars.mb_state_acc_scale_done[s].init()
+        for s in range(cfg.tmem_q_state_acc_stages):
+            bars.mb_o_acc_ready[s].init()
+            bars.mb_o_final_acc_ready[s].init()
+            bars.mb_o_state_scale_acc_done[s].init()
+        for s in range(cfg.tmem_cg0_acc_stages):
+            bars.mb_cg0_acc_ready[s].init()
+            bars.mb_cg0_acc_done[s].init()
+        bars.mb_k_state_acc_ready[0].init()
+        bars.mb_u_acc_ready[0].init()
+        for s in range(cfg.smem_t_inv_stages):
+            bars.mb_t_inv_ready[s].init()
+            bars.mb_t_inv_done[s].init()
+        for s in range(cfg.smem_a_stages):
+            bars.mb_a_ready[s].init()
+            bars.mb_a_done[s].init()
+        for s in range(cfg.tmem_state_inp_stages):
+            bars.mb_state_inp_ready[s].init()
+        for b in (bars.mb_y_inp_ready, bars.mb_u_inp_ready, bars.mb_decay_u_inp_ready):
+            b[0].init()
+        for s in range(cfg.smem_o_stages):
+            bars.mb_o_tmastg_ready[s].init()
+            bars.mb_o_tmastg_done[s].init()
+        for s in range(cfg.smem_checkpoint_stages):
+            bars.mb_checkpoint_tmastg_ready[s].init()
+            bars.mb_checkpoint_tmastg_done[s].init()
+        for s_ in range(cfg.sched_stages):
+            bars.mb_sched_ready[s_].init()
+            bars.mb_sched_done[s_].init()
+        bars.mb_tmem_done[0].init()
 
     nvvm.fence_mbarrier_init()
     nvvm.barrier_cta_sync()

--- a/attn_gym/linear/_delta_rule/mega/kernels/gdn_recompute_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/gdn_recompute_f16.py
@@ -1116,8 +1116,6 @@ def mma_warp(
         for local_idx in cutlass.range(n_local):  # noqa: B007
             if cutlass.const_expr(cfg.use_initial_state):
                 if local_idx == 0:
-                    if elect_one:
-                        bars.mb_state_acc_ready[kv_acc_index.idx].arrive(cta_group=1)
                     kv_acc_index = advance(kv_acc_index, cfg.tmem_state_acc_stages)
             have_state = (
                 cutlass.Boolean(True)
@@ -2003,8 +2001,11 @@ def compute1_warp_group(
                 # ---- state restage + rescale -------------------------------------
                 if valid_state:
                     kv_idx = kv_acc_index.idx
-                    bars.mb_state_acc_ready[kv_idx].wait(kv_acc_index.phase)
-                    kv_acc_index = advance(kv_acc_index, cfg.tmem_state_acc_stages)
+                    # CG1 writes the seeded state itself; only subsequent states
+                    # arrive through the MMA-owned state accumulator barrier.
+                    if local_idx > 0:
+                        bars.mb_state_acc_ready[kv_idx].wait(kv_acc_index.phase)
+                        kv_acc_index = advance(kv_acc_index, cfg.tmem_state_acc_stages)
                     kv_done_idx = kv_idx
 
                     state_regs = [
@@ -2848,41 +2849,42 @@ def kernel(
         beta_smem_layout_staged,
     )
 
-    # ---- mbarrier init (all threads) ---------------------------------------------
-    for s in range(cfg.smem_kq_stages):
-        bars.mb_kq_ready[s].init()
-        bars.mb_kq_done[s].init()
-    for s in range(cfg.smem_v_stages):
-        bars.mb_v_ready[s].init()
-        bars.mb_v_done[s].init()
-    for s in range(cfg.smem_gate_stages):
-        bars.mb_gate_ready[s].init()
-        bars.mb_gate_done[s].init()
-    for s in range(cfg.smem_beta_stages):
-        bars.mb_beta_ready[s].init()
-        bars.mb_beta_done[s].init()
-    for s in range(cfg.tmem_state_acc_stages):
-        bars.mb_state_acc_ready[s].init()
-        bars.mb_state_acc_scale_done[s].init()
-    for s in range(cfg.tmem_cg0_acc_stages):
-        bars.mb_cg0_acc_ready[s].init()
-        bars.mb_cg0_acc_done[s].init()
-    bars.mb_k_state_acc_ready[0].init()
-    bars.mb_u_acc_ready[0].init()
-    for s in range(cfg.smem_t_inv_stages):
-        bars.mb_t_inv_ready[s].init()
-        bars.mb_t_inv_done[s].init()
-    for s in range(cfg.tmem_state_inp_stages):
-        bars.mb_state_inp_ready[s].init()
-    for b in (bars.mb_y_inp_ready, bars.mb_decay_u_inp_ready):
-        b[0].init()
-    for s in range(cfg.smem_checkpoint_stages):
-        bars.mb_checkpoint_tmastg_ready[s].init()
-        bars.mb_checkpoint_tmastg_done[s].init()
-    for s_ in range(cfg.sched_stages):
-        bars.mb_sched_ready[s_].init()
-        bars.mb_sched_done[s_].init()
-    bars.mb_tmem_done[0].init()
+    # ---- mbarrier init -----------------------------------------------------------
+    if tidx == 0:
+        for s in range(cfg.smem_kq_stages):
+            bars.mb_kq_ready[s].init()
+            bars.mb_kq_done[s].init()
+        for s in range(cfg.smem_v_stages):
+            bars.mb_v_ready[s].init()
+            bars.mb_v_done[s].init()
+        for s in range(cfg.smem_gate_stages):
+            bars.mb_gate_ready[s].init()
+            bars.mb_gate_done[s].init()
+        for s in range(cfg.smem_beta_stages):
+            bars.mb_beta_ready[s].init()
+            bars.mb_beta_done[s].init()
+        for s in range(cfg.tmem_state_acc_stages):
+            bars.mb_state_acc_ready[s].init()
+            bars.mb_state_acc_scale_done[s].init()
+        for s in range(cfg.tmem_cg0_acc_stages):
+            bars.mb_cg0_acc_ready[s].init()
+            bars.mb_cg0_acc_done[s].init()
+        bars.mb_k_state_acc_ready[0].init()
+        bars.mb_u_acc_ready[0].init()
+        for s in range(cfg.smem_t_inv_stages):
+            bars.mb_t_inv_ready[s].init()
+            bars.mb_t_inv_done[s].init()
+        for s in range(cfg.tmem_state_inp_stages):
+            bars.mb_state_inp_ready[s].init()
+        for b in (bars.mb_y_inp_ready, bars.mb_decay_u_inp_ready):
+            b[0].init()
+        for s in range(cfg.smem_checkpoint_stages):
+            bars.mb_checkpoint_tmastg_ready[s].init()
+            bars.mb_checkpoint_tmastg_done[s].init()
+        for s_ in range(cfg.sched_stages):
+            bars.mb_sched_ready[s_].init()
+            bars.mb_sched_done[s_].init()
+        bars.mb_tmem_done[0].init()
 
     nvvm.fence_mbarrier_init()
     nvvm.barrier_cta_sync()

--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_bprop_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_bprop_f16.py
@@ -1538,8 +1538,9 @@ def tcgen05_mma_warp(
                 bars.mb_decay_done[decay_stage].arrive(cta_group=1)
 
         # ---- tile end: WG1's dstate0 drain gates the next tile's dstate reuse ------------
-        bars.mb_dstate0_acc_stored.wait(dstate0_index.phase)
-        dstate0_index = advance(dstate0_index, 1)
+        if num_compute_chunks > 0:
+            bars.mb_dstate0_acc_stored.wait(dstate0_index.phase)
+            dstate0_index = advance(dstate0_index, 1)
         chunk_serial_base += num_compute_chunks
         tile_idx, sched_state = sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas)
     bars.mb_tmem_done[0].wait(0)
@@ -2598,7 +2599,8 @@ def compute1_warp_group(
                             mDstate0[batch_idx, head_idx, value_dim, kd] = mDstate_in[batch_idx, head_idx, value_dim, kd]
                         else:
                             mDstate0[batch_idx, head_idx, value_dim, kd] = cutlass.Float32(0.0)
-        bars.mb_dstate0_acc_stored.arrive()
+        if num_compute_chunks > 0:
+            bars.mb_dstate0_acc_stored.arrive()
         chunk_serial_base += num_compute_chunks
         tile_idx, sched_state = sched_next_tile(cfg, bars, sSched, sched_state, tile_idx, num_ctas)
 

--- a/test/gdn/mega/test_gdn_mega_backward.py
+++ b/test/gdn/mega/test_gdn_mega_backward.py
@@ -234,6 +234,22 @@ def test_gdn_mega_backward_uniform_negative_twenty_is_finite(
     assert all(torch.isfinite(gradient).all() for gradient in gradients)
 
 
+def test_gdn_mega_backward_rejects_mismatched_output_gradient_dtype() -> None:
+    q, k, value, gate, beta, _state, cu_seqlens = make_gdn_test_inputs(
+        (64,), key_heads=1, value_heads=1, dtype=torch.bfloat16, seed=143
+    )
+    with pytest.raises(TypeError, match="d_output must use q.dtype"):
+        chunk_gdn_bwd_mega_packed(
+            q,
+            k,
+            value,
+            gate,
+            beta,
+            torch.randn_like(value, dtype=torch.float32),
+            cu_seqlens,
+        )
+
+
 def test_gdn_mega_backward_checkpoint_uses_v_by_k_state_at_token_64() -> None:
     """Regression for loading the BT64 entering-state checkpoint with transposed V/K axes."""
     inputs = make_gdn_test_inputs((65,), key_heads=2, value_heads=2, dtype=torch.float16, seed=149)

--- a/test/gdn/mega/test_gdn_mega_training.py
+++ b/test/gdn/mega/test_gdn_mega_training.py
@@ -548,6 +548,73 @@ def test_public_gdn_mega_dynamic_dense_tokens() -> None:
         torch.testing.assert_close(actual, expected, rtol=0, atol=0)
 
 
+@pytest.mark.skipif(
+    os.environ.get("ATTN_GYM_RUN_STRESS_TESTS") != "1",
+    reason="set ATTN_GYM_RUN_STRESS_TESTS=1 to run repeated-launch stress tests",
+)
+def test_public_gdn_mega_repeated_stateful_launches_cross_wave_boundary() -> None:
+    """Persistent CTAs must preserve barrier phases across their fourth logical item."""
+    inputs = make_gdn_test_inputs(
+        (128,) * 29,
+        key_heads=8,
+        value_heads=16,
+        requires_grad=False,
+        seed=353,
+    )
+    q, k, value, gate, beta, state, cu_seqlens = inputs
+    with torch.no_grad():
+        for _ in range(1000):
+            chunk_gdn(
+                q,
+                k,
+                value,
+                gate,
+                beta,
+                state,
+                cu_seqlens=cu_seqlens,
+                output_final_state=True,
+                impl="fused",
+            )
+            torch.cuda.synchronize()
+
+
+@pytest.mark.skipif(
+    os.environ.get("ATTN_GYM_RUN_STRESS_TESTS") != "1",
+    reason="set ATTN_GYM_RUN_STRESS_TESTS=1 to run repeated-launch stress tests",
+)
+def test_public_gdn_mega_repeated_backward_crosses_wave_boundary() -> None:
+    """Recompute and backward barriers must survive persistent CTA reuse."""
+    inputs = make_gdn_test_inputs(
+        (128,) * 29,
+        key_heads=8,
+        value_heads=16,
+        requires_grad=True,
+        seed=419,
+    )
+    q, k, value, gate, beta, state, cu_seqlens = inputs
+    d_output = torch.randn_like(value)
+    d_state = torch.randn_like(state)
+    for _ in range(500):
+        output, final_state = chunk_gdn(
+            q,
+            k,
+            value,
+            gate,
+            beta,
+            state,
+            cu_seqlens=cu_seqlens,
+            output_final_state=True,
+            impl="fused",
+        )
+        assert final_state is not None
+        torch.autograd.grad(
+            (output, final_state),
+            (q, k, value, gate, beta, state),
+            (d_output, d_state),
+        )
+        torch.cuda.synchronize()
+
+
 def test_public_gdn_mega_cuda_graph_replay() -> None:
     """Compiled packed stateful forward/backward must capture and replay bitwise."""
     inputs = make_gdn_test_inputs(

--- a/test/kda/mega/test_kda_mega_training.py
+++ b/test/kda/mega/test_kda_mega_training.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+import os
 from itertools import accumulate
 
 import pytest
@@ -750,6 +751,47 @@ def test_mega_rejects_mismatched_value_and_beta_shapes() -> None:
             inputs[4].repeat(2, 1, 1),
             kernel_options={"backend": "mega"},
         )
+
+
+@pytest.mark.skipif(
+    os.environ.get("ATTN_GYM_RUN_STRESS_TESTS") != "1",
+    reason="set ATTN_GYM_RUN_STRESS_TESTS=1 to run repeated-launch stress tests",
+)
+def test_mega_repeated_backward_with_empty_sequences() -> None:
+    """Empty work items must not advance the dstate handshake phase."""
+    from attn_gym.linear import chunk_kda
+
+    lengths = tuple(0 if index % 2 == 0 else 128 for index in range(29))
+    q, k, value, gate, beta = make_kda_test_inputs(
+        sum(lengths),
+        heads=16,
+        seed=421,
+        normalize_qk=True,
+        requires_grad=True,
+    )
+    state = (torch.randn(29, 16, D, D, device="cuda") / 100).requires_grad_()
+    cu_seqlens = cumulative_sequence_offsets(lengths)
+    d_output = torch.randn_like(value)
+    d_state = torch.randn_like(state)
+    for _ in range(500):
+        output, final_state = chunk_kda(
+            q,
+            k,
+            value,
+            gate,
+            beta,
+            state,
+            cu_seqlens=cu_seqlens,
+            output_final_state=True,
+            kernel_options={"backend": "mega"},
+        )
+        assert final_state is not None
+        torch.autograd.grad(
+            (output, final_state),
+            (q, k, value, gate, beta, state),
+            (d_output, d_state),
+        )
+        torch.cuda.synchronize()
 
 
 def test_mega_packed_h64_exact_tail_with_trailing_empty_is_finite() -> None:

--- a/test/test_selected_attention_cute.py
+++ b/test/test_selected_attention_cute.py
@@ -12,6 +12,8 @@ import math
 import pytest
 import torch
 
+pytest.importorskip("flash_attn.cute", reason="selected-attention CuTe tests require FA4")
+
 from attn_gym.sparse.selected_attention import AuxRequest, selected_attention
 
 


### PR DESCRIPTION
Stacked PRs:
 * #440
 * __->__#444


--- --- ---

Fix Mega kernel synchronization edge cases

## Human Note

## Agent note

Fix persistent GDN state handling by assigning initial-state readiness to the
warpgroup that writes the TMEM seed and reserving the MMA-owned barrier for
subsequent MMA-produced states. Initialize GDN mbarriers exactly once per CTA,
and keep KDA backward from advancing its dstate handshake for empty work items.

Add dtype validation and opt-in repeated-launch regressions covering forward and
backward execution beyond persistent-grid phase boundaries.

## Test Plan

```bash
ATTN_GYM_RUN_STRESS_TESTS=1 pytest -q \
  test/gdn/mega/test_gdn_mega_training.py::test_public_gdn_mega_repeated_stateful_launches_cross_wave_boundary \
  test/gdn/mega/test_gdn_mega_training.py::test_public_gdn_mega_repeated_backward_crosses_wave_boundary \
  test/kda/mega/test_kda_mega_training.py::test_mega_repeated_backward_with_empty_sequences
pytest -n 6 test/gdn/mega test/kda/mega
```