### PR TITLE
Enable KDA context parallelism on Hopper

### DIFF
--- a/attn_gym/linear/_delta_rule/cute/affine_summary_fwd.py
+++ b/attn_gym/linear/_delta_rule/cute/affine_summary_fwd.py
@@ -66,6 +66,7 @@ from torch._subclasses.fake_tensor import FakeTensor
 from attn_gym._backends.cute import compile_tvm_ffi, get_device_properties, jit_cache
 from attn_gym._backends.cute.target import get_compile_target
 from attn_gym._backends.cute.utils import requires_int64_abi
+from attn_gym.linear.kda.constants import is_sm100_kda_capability
 
 BT = 64  # chunk size
 KEY_DIM = 128
@@ -973,11 +974,8 @@ def _compile_affine_summary(
 ):
     """Compile one dtype/head-count specialization from fake tensors."""
     target = get_compile_target()
-    if target.device_type != "cuda" or target.capability is None or target.capability < (10, 0):
-        raise ValueError(
-            f"affine_summary_fwd requires an SM100 (CUDA capability >= 10.0) target; "
-            f"got target={target}"
-        )
+    if target.device_type != "cuda" or not is_sm100_kda_capability(target.effective_capability):
+        raise ValueError(f"affine_summary_fwd requires an SM100/SM103 target; got {target}")
     sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
     tokens = sym_int(divisibility=BT)
 
@@ -1026,13 +1024,15 @@ def build_state_summary(
         FP32 tensor of shape ``[H, 256, 128]``, V-first packed as state bias then
         state transition for ``H_out = H_in @ transition + bias``.
 
-    Supported scope: B=1, fixed K=V=128 and BT=64, contiguous inputs on SM100.
+    Supported scope: B=1, fixed K=V=128 and BT=64, contiguous CUDA inputs.
+    SM100 uses the native UMMA kernel; other capability 8.0+ targets use Triton.
     A partial final chunk is neutral-padded by the wrapper.
     """
     assert kg.ndim == 4, f"kg must be 4D [1, T, H, K], got shape {tuple(kg.shape)}"
     batch, tokens, heads, key_dim = kg.shape
     assert batch == 1, f"build_state_summary requires B=1, got B={batch}"
     assert tokens > 0, "build_state_summary requires at least one token"
+    assert heads > 0, "build_state_summary requires at least one head"
     assert key_dim == KEY_DIM, f"build_state_summary requires K={KEY_DIM}, got {key_dim}"
     assert w.shape == kg.shape, f"w must match kg shape {tuple(kg.shape)}, got {tuple(w.shape)}"
     assert u.shape == (1, tokens, heads, VAL_DIM), (
@@ -1065,7 +1065,6 @@ def build_state_summary(
     for name, tensor in (("kg", kg), ("w", w), ("u", u), ("cumulative_gate", cumulative_gate)):
         assert tensor.device == kg.device, f"{name} must be on {kg.device}, got {tensor.device}"
         assert tensor.is_contiguous(), f"{name} must be contiguous, got strides {tensor.stride()}"
-    kg, w, u, cumulative_gate = (_aligned(tensor) for tensor in (kg, w, u, cumulative_gate))
     pad = (-tokens) % BT
     if pad:
         padding = (0, 0, 0, 0, 0, pad)
@@ -1077,12 +1076,30 @@ def build_state_summary(
             ),
             dim=1,
         )
+    properties = get_device_properties(kg.device)
+    capability = (properties.major, properties.minor)
+    if capability < (8, 0):
+        raise ValueError(f"affine_summary_fwd requires CUDA capability 8.0+, got {capability}")
+    if not is_sm100_kda_capability(capability):
+        if capability[0] in (10, 12):
+            from attn_gym._backends.triton.utils import configure_triton_allocator
+
+            with torch.cuda.device(kg.device):
+                configure_triton_allocator()
+        from attn_gym.linear._delta_rule.triton.affine_summary_fwd import (
+            launch_affine_summary_fwd,
+        )
+
+        launch_affine_summary_fwd(kg, w, u, cumulative_gate, out, capability)
+        return out
+
+    kg, w, u, cumulative_gate = (_aligned(tensor) for tensor in (kg, w, u, cumulative_gate))
     use_int64_offsets = requires_int64_abi(kg, w, u, cumulative_gate, out)
 
     # BN=32 is faster per CTA (measured ~1.5x vs BN=64 on GB200); fall back to
     # BN=64 only when the extra column tiles would spill past one CTA wave and
     # serialize whole recurrence chains.
-    sm_count = get_device_properties(kg.device).multi_processor_count
+    sm_count = properties.multi_processor_count
     state_bn = 32 if heads * (SUMMARY_DIM // 32) <= sm_count else 64
     compiled = _compile_affine_summary(
         _IO_TYPE_NAMES[kg.dtype], heads, state_bn, use_int64_offsets

--- a/attn_gym/linear/_delta_rule/cute/affine_summary_rev.py
+++ b/attn_gym/linear/_delta_rule/cute/affine_summary_rev.py
@@ -38,6 +38,7 @@ from torch._subclasses.fake_tensor import FakeTensor
 from attn_gym._backends.cute import compile_tvm_ffi, get_device_properties, jit_cache
 from attn_gym._backends.cute.target import get_compile_target
 from attn_gym._backends.cute.utils import requires_int64_abi
+from attn_gym.linear.kda.constants import is_sm100_kda_capability
 
 BT = 64
 KEY_DIM = 128
@@ -1274,10 +1275,8 @@ def _compile_affine_summary_rev(
 ):
     """Compile one reverse-summary dtype/head/tile specialization."""
     target = get_compile_target()
-    if target.device_type != "cuda" or target.capability is None or target.capability < (10, 0):
-        raise ValueError(
-            f"affine_summary_rev requires a CUDA capability >= 10.0 target; got {target}"
-        )
+    if target.device_type != "cuda" or not is_sm100_kda_capability(target.effective_capability):
+        raise ValueError(f"affine_summary_rev requires an SM100/SM103 target; got {target}")
     sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
     tokens = sym_int(divisibility=BT)
 
@@ -1339,13 +1338,15 @@ def build_state_grad_summary(
         FP32 tensor of shape ``[H, 256, 128]``, V-first packed as local bias then
         reverse transition for ``dH_in = dH_out @ transition + bias``.
 
-    Supported scope: B=1, fixed K=V=128 and BT=64, contiguous inputs on Blackwell.
+    Supported scope: B=1, fixed K=V=128 and BT=64, contiguous CUDA inputs.
+    SM100 uses the native UMMA kernel; other capability 8.0+ targets use Triton.
     A partial final chunk is neutral-padded by the wrapper.
     """
     assert qg.ndim == 4, f"qg must be 4D [1, T, H, K], got shape {tuple(qg.shape)}"
     batch, tokens, heads, key_dim = qg.shape
     assert batch == 1, f"build_state_grad_summary requires B=1, got B={batch}"
     assert tokens > 0, "build_state_grad_summary requires at least one token"
+    assert heads > 0, "build_state_grad_summary requires at least one head"
     assert key_dim == KEY_DIM, f"build_state_grad_summary requires K={KEY_DIM}, got {key_dim}"
     for name, tensor in (("kg", kg), ("w", w), ("dout", dout)):
         assert tensor.shape == qg.shape, (
@@ -1390,7 +1391,6 @@ def build_state_grad_summary(
     for name, tensor in inputs:
         assert tensor.device == qg.device, f"{name} must be on {qg.device}, got {tensor.device}"
         assert tensor.is_contiguous(), f"{name} must be contiguous, got strides {tensor.stride()}"
-    qg, kg, w, dout, Aqk, cumulative_gate = (_aligned(tensor) for _name, tensor in inputs)
     pad = (-tokens) % BT
     if pad:
         padding = (0, 0, 0, 0, 0, pad)
@@ -1402,6 +1402,34 @@ def build_state_grad_summary(
             ),
             dim=1,
         )
+    properties = get_device_properties(qg.device)
+    capability = (properties.major, properties.minor)
+    if capability < (8, 0):
+        raise ValueError(f"affine_summary_rev requires CUDA capability 8.0+, got {capability}")
+    if not is_sm100_kda_capability(capability):
+        if capability[0] in (10, 12):
+            from attn_gym._backends.triton.utils import configure_triton_allocator
+
+            with torch.cuda.device(qg.device):
+                configure_triton_allocator()
+        from attn_gym.linear._delta_rule.triton.affine_summary_rev import (
+            launch_affine_summary_rev,
+        )
+
+        launch_affine_summary_rev(
+            qg,
+            kg,
+            w,
+            dout,
+            Aqk,
+            cumulative_gate,
+            scale,
+            out,
+            capability,
+        )
+        return out
+
+    qg, kg, w, dout, Aqk, cumulative_gate = (_aligned(tensor) for _name, tensor in inputs)
     use_int64_offsets = requires_int64_abi(qg, kg, w, dout, Aqk, cumulative_gate, out)
 
     state_tile_width = select_summary_tile_width(heads, qg.device)

--- a/attn_gym/linear/_delta_rule/triton/__init__.py
+++ b/attn_gym/linear/_delta_rule/triton/__init__.py
@@ -1,0 +1,1 @@
+"""Portable Triton kernels shared by delta-rule implementations."""

--- a/attn_gym/linear/_delta_rule/triton/affine_summary_fwd.py
+++ b/attn_gym/linear/_delta_rule/triton/affine_summary_fwd.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2026 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Portable Triton forward affine summaries for delta-rule context parallelism.
+
+Each program keeps one FP32 ``[128, BN]`` augmented-state tile resident while
+scanning complete BT64 chunks. Raw compact-layout pointers avoid host tensor
+descriptors, allocations, and synchronization in the launch path, so a warmed
+specialization can be captured directly by a CUDA Graph.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from attn_gym._backends.triton.utils import ptr_offset, requires_int64_offsets
+
+_CHUNK_SIZE = 64
+_KEY_DIM = 128
+_VALUE_DIM = 128
+_SUMMARY_DIM = _VALUE_DIM + _KEY_DIM
+
+
+def _select_block_columns(heads: int, capability: tuple[int, int]) -> int:
+    """Select the measured Hopper column tile or a conservative portable default."""
+    if capability != (9, 0):
+        return 16
+    if heads <= 8:
+        return 8
+    if heads <= 24:
+        return 16
+    return 32
+
+
+@triton.jit(do_not_specialize=["T"])
+def affine_summary_fwd_kernel(
+    kg,
+    w,
+    u,
+    cumulative_gate,
+    out,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BN: tl.constexpr,
+    USE_INT64_OFFSETS: tl.constexpr,
+):
+    """Scan one head and augmented-state column tile through all BT64 chunks."""
+    head = tl.program_id(0)
+    column_tile = tl.program_id(1)
+    if USE_INT64_OFFSETS:
+        head = head.to(tl.int64)
+        column_tile = column_tile.to(tl.int64)
+
+    key = tl.arange(0, K)
+    row = tl.arange(0, BT)
+    column = column_tile * BN + tl.arange(0, BN)
+    state = tl.where(column[None, :] == V + key[:, None], 1.0, 0.0).to(tl.float32)
+
+    for chunk in tl.range(0, T // BT):
+        if USE_INT64_OFFSETS:
+            token_start = chunk.to(tl.int64) * BT
+        else:
+            token_start = chunk * BT
+        token = token_start + row
+
+        token_key_offset = ptr_offset(
+            (token[:, None], head, key[None, :]),
+            (H * K, K, 1),
+        )
+        w_tile = tl.load(w + token_key_offset)
+        u_tile = tl.load(
+            u
+            + ptr_offset(
+                (token[:, None], head, column[None, :]),
+                (H * V, V, 1),
+            ),
+            mask=column[None, :] < V,
+            other=0.0,
+        )
+        state_hi = state.to(w_tile.dtype)
+        state_lo = (state - state_hi.to(tl.float32)).to(w_tile.dtype)
+        tmp = u_tile.to(tl.float32) - tl.dot(w_tile, state_hi)
+        tmp -= tl.dot(w_tile, state_lo)
+
+        gate_offset = ptr_offset(
+            (token_start + BT - 1, head, key),
+            (H * K, K, 1),
+        )
+        state *= tl.exp2(tl.load(cumulative_gate + gate_offset))[:, None]
+
+        kg_tile = tl.load(kg + token_key_offset)
+        tmp_hi = tmp.to(kg_tile.dtype)
+        tmp_lo = (tmp - tmp_hi.to(tl.float32)).to(kg_tile.dtype)
+        state = tl.dot(tl.trans(kg_tile), tmp_hi, acc=state)
+        state = tl.dot(tl.trans(kg_tile), tmp_lo, acc=state)
+
+    out_offset = ptr_offset(
+        (head, column[None, :], key[:, None]),
+        ((V + K) * K, K, 1),
+    )
+    tl.store(out + out_offset, state)
+
+
+def launch_affine_summary_fwd(
+    kg: torch.Tensor,
+    w: torch.Tensor,
+    u: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    out: torch.Tensor,
+    capability: tuple[int, int],
+) -> None:
+    """Launch a validated, BT64-padded summary into a preallocated FP32 output."""
+    _, tokens, heads, _ = kg.shape
+    block_columns = _select_block_columns(heads, capability)
+    affine_summary_fwd_kernel[(heads, _SUMMARY_DIM // block_columns)](
+        kg,
+        w,
+        u,
+        cumulative_gate,
+        out,
+        tokens,
+        H=heads,
+        K=_KEY_DIM,
+        V=_VALUE_DIM,
+        BT=_CHUNK_SIZE,
+        BN=block_columns,
+        USE_INT64_OFFSETS=requires_int64_offsets(kg, w, u, cumulative_gate, out),
+        num_warps=8 if block_columns == 32 else 4,
+        num_stages=2,
+    )

--- a/attn_gym/linear/_delta_rule/triton/affine_summary_rev.py
+++ b/attn_gym/linear/_delta_rule/triton/affine_summary_rev.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2026 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Portable Triton reverse affine summaries for delta-rule context parallelism.
+
+Each program keeps one FP32 ``[128, BN]`` augmented-state tile resident while
+scanning complete BT64 chunks backward. Raw compact-layout pointers avoid host
+tensor descriptors, allocations, and synchronization in the launch path, so a
+warmed specialization can be captured directly by a CUDA Graph.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from attn_gym._backends.triton.utils import ptr_offset, requires_int64_offsets
+
+_CHUNK_SIZE = 64
+_KEY_DIM = 128
+_VALUE_DIM = 128
+_SUMMARY_DIM = _VALUE_DIM + _KEY_DIM
+
+
+def _select_block_columns(heads: int, capability: tuple[int, int]) -> int:
+    """Select the measured Hopper column tile or a conservative portable default."""
+    if capability != (9, 0):
+        return 16
+    if heads <= 4:
+        return 8
+    if heads <= 8:
+        return 16
+    return 32
+
+
+@triton.jit(do_not_specialize=["T"])
+def affine_summary_rev_kernel(
+    qg,
+    kg,
+    w,
+    dout,
+    aqk,
+    cumulative_gate,
+    out,
+    scale,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BN: tl.constexpr,
+    USE_INT64_OFFSETS: tl.constexpr,
+):
+    """Scan one head and augmented-state column tile backward through BT64 chunks."""
+    head = tl.program_id(0)
+    column_tile = tl.program_id(1)
+    if USE_INT64_OFFSETS:
+        head = head.to(tl.int64)
+        column_tile = column_tile.to(tl.int64)
+
+    key = tl.arange(0, K)
+    row = tl.arange(0, BT)
+    column = column_tile * BN + tl.arange(0, BN)
+    state = tl.where(column[None, :] == V + key[:, None], 1.0, 0.0).to(tl.float32)
+
+    for chunk in range(T // BT - 1, -1, -1):
+        if USE_INT64_OFFSETS:
+            token_start = chunk.to(tl.int64) * BT
+        else:
+            token_start = chunk * BT
+        token = token_start + row
+
+        token_key_offset = ptr_offset(
+            (token[:, None], head, key[None, :]),
+            (H * K, K, 1),
+        )
+        kg_tile = tl.load(kg + token_key_offset)
+        corrected = tl.dot(kg_tile, state.to(kg_tile.dtype))
+
+        dout_tile = tl.load(
+            dout
+            + ptr_offset(
+                (token[:, None], head, column[None, :]),
+                (H * V, V, 1),
+            ),
+            mask=column[None, :] < V,
+            other=0.0,
+        )
+        aqk_tile = tl.load(
+            aqk
+            + ptr_offset(
+                (token[:, None], head, row[None, :]),
+                (H * BT, BT, 1),
+            )
+        )
+        corrected = tl.dot(tl.trans(aqk_tile), dout_tile, acc=corrected)
+
+        gate_offset = ptr_offset(
+            (token_start + BT - 1, head, key),
+            (H * K, K, 1),
+        )
+        state *= tl.exp2(tl.load(cumulative_gate + gate_offset))[:, None]
+
+        qg_tile = tl.load(qg + token_key_offset)
+        state += tl.dot(tl.trans(qg_tile), dout_tile) * scale
+        w_tile = tl.load(w + token_key_offset)
+        state -= tl.dot(tl.trans(w_tile), corrected.to(w_tile.dtype))
+
+    out_offset = ptr_offset(
+        (head, column[None, :], key[:, None]),
+        ((V + K) * K, K, 1),
+    )
+    tl.store(out + out_offset, state)
+
+
+def launch_affine_summary_rev(
+    qg: torch.Tensor,
+    kg: torch.Tensor,
+    w: torch.Tensor,
+    dout: torch.Tensor,
+    aqk: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    scale: float,
+    out: torch.Tensor,
+    capability: tuple[int, int],
+) -> None:
+    """Launch a validated, BT64-padded summary into a preallocated FP32 output."""
+    _, tokens, heads, _ = qg.shape
+    block_columns = _select_block_columns(heads, capability)
+    affine_summary_rev_kernel[(heads, _SUMMARY_DIM // block_columns)](
+        qg,
+        kg,
+        w,
+        dout,
+        aqk,
+        cumulative_gate,
+        out,
+        float(scale),
+        tokens,
+        H=heads,
+        K=_KEY_DIM,
+        V=_VALUE_DIM,
+        BT=_CHUNK_SIZE,
+        BN=block_columns,
+        USE_INT64_OFFSETS=requires_int64_offsets(
+            qg,
+            kg,
+            w,
+            dout,
+            aqk,
+            cumulative_gate,
+            out,
+        ),
+        num_warps=8 if block_columns == 32 else 4,
+        num_stages=2,
+    )

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -98,17 +98,20 @@ output projection.
 
 The short convolution all-gathers one fixed-size `W - 1` token halo per rank and routes its initial-
 state gradient back to the ranks that own those tokens. The KDA recurrence separately computes
-forward and reverse `[bias; transition]` state summaries with Blackwell TMA/UMMA kernels, all-gathers
-them, and composes the relevant prefix or suffix before running the ordinary local KDA kernel. A
-contiguous rank boundary is one cut in the packed token stream, so it can split at most one logical
+forward and reverse `[bias; transition]` state summaries with portable Triton kernels on Hopper or
+native TMA/UMMA kernels on SM100, all-gathers them, and composes the relevant prefix or suffix
+before running the ordinary local KDA kernel. A contiguous rank boundary is one cut in the packed
+token stream, so it can split at most one logical
 sequence. The example validates local outputs, convolution and KDA endpoint states, input gradients,
 and all-reduced parameter gradients against the complete unsharded module. It can also capture the
 full forward, NCCL communication, and backward in one CUDA Graph and validate a changed-input
-replay. Add `--profile` to use transformer-nuggets to export one merged multi-rank trace in native
-Perfetto `.pftrace` format.
+replay. Use `--compute-dtype=float16` to exercise the FP16 route. Add `--profile` to use
+transformer-nuggets to export one merged multi-rank trace in native Perfetto `.pftrace` format.
 
 ```bash
 torchrun --standalone --nproc_per_node=2 examples/kda_context_parallel.py
+
+torchrun --standalone --nproc_per_node=2 examples/kda_context_parallel.py --compute-dtype=float16
 
 torchrun --standalone --nproc_per_node=2 examples/kda_context_parallel.py --cuda-graph
 

--- a/examples/kda_context_parallel.py
+++ b/examples/kda_context_parallel.py
@@ -7,10 +7,11 @@ equal contiguous token shard. Launch with:
 
     torchrun --standalone --nproc-per-node=2 examples/kda_context_parallel.py
 
-Add ``--cuda-graph`` to capture forward and backward together and validate a replay with
-changed inputs. Add ``--profile`` to export a merged native Perfetto trace using
-transformer-nuggets. The example requires one Blackwell GPU per rank because the fused KDA backend
-currently targets SM100 or newer.
+Add ``--compute-dtype=float16`` to validate the FP16 route. Add ``--cuda-graph`` to capture
+forward and backward together and validate a replay with changed inputs. Add ``--profile`` to
+export a merged native Perfetto trace using transformer-nuggets. The example requires one Hopper
+or datacenter Blackwell GPU per rank. Affine summaries use portable Triton kernels on Hopper and
+native UMMA kernels on SM100.
 """
 
 from __future__ import annotations
@@ -45,7 +46,7 @@ from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd import (
 )
 from attn_gym.linear.kda.ops import _plain_gate_scan_op
 from attn_gym.testing import kernel_stage, record_distributed_profile
-from examples.kda_training import KDAAttention, KDAAttentionOutput
+from examples.kda_training import ComputeDTypeOption, KDAAttention, KDAAttentionOutput
 
 # The private prepare/finish seams avoid repeating factor computation around collectives.
 # TODO: Promote those seams before moving this orchestration out of the example.
@@ -727,6 +728,10 @@ def main(
     ] = "256,1280,512",
     hidden_size: Annotated[int, typer.Option(min=1, help="Transformer hidden size.")] = 256,
     heads: Annotated[int, typer.Option(min=1, help="Number of KDA heads.")] = 2,
+    compute_dtype: Annotated[
+        ComputeDTypeOption,
+        typer.Option(help="Use float16 or bfloat16 projection and kernel inputs."),
+    ] = ComputeDTypeOption.BFLOAT16,
     short_conv_kernel_size: Annotated[
         int,
         typer.Option(min=1, help="Causal Q/K/V convolution width."),
@@ -787,6 +792,7 @@ def main(
         "head_dim": 128,
         "short_conv_kernel_size": short_conv_kernel_size,
         "backend": "fused",
+        "compute_dtype": getattr(torch, compute_dtype.value),
         "device": device,
     }
     make_model = partial(
@@ -822,8 +828,8 @@ def main(
     profile_mode = "cuda_graph" if cuda_graph else "eager"
     profile_path = Path(
         "data",
-        f"kda_context_parallel_{profile_mode}_w{world_size}_t{tokens}_h{heads}"
-        f"_c{hidden_size}_conv{short_conv_kernel_size}",
+        f"kda_context_parallel_{profile_mode}_{compute_dtype.value}_w{world_size}_t{tokens}"
+        f"_h{heads}_c{hidden_size}_conv{short_conv_kernel_size}",
     ).resolve()
     if cuda_graph:
         validate_cuda_graph(

--- a/test/test_delta_affine_summary.py
+++ b/test/test_delta_affine_summary.py
@@ -1,4 +1,4 @@
-"""Tests for the shared CuTeDSL delta-rule affine-summary recurrence."""
+"""Tests for the architecture-routed delta-rule affine-summary recurrence."""
 
 from __future__ import annotations
 
@@ -8,12 +8,29 @@ import torch.nn.functional as F
 
 pytest.importorskip("cutlass")
 
+import attn_gym.linear._delta_rule.triton.affine_summary_fwd as portable_fwd
+import attn_gym.linear._delta_rule.triton.affine_summary_rev as portable_rev
 from attn_gym.linear._delta_rule.cute import build_state_grad_summary, build_state_summary
+from attn_gym.linear.kda.constants import is_sm100_kda_capability
 
 pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (10, 0),
-    reason="the CuTeDSL affine summary requires CUDA capability 10.0 or newer",
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (8, 0),
+    reason="the affine summaries require CUDA capability 8.0 or newer",
 )
+
+
+def make_summary_inputs(seed: int):
+    """Create one nontrivial BF16 input set for summary infrastructure tests."""
+    torch.manual_seed(seed)
+    shape = (1, 64, 1, 128)
+    qg = torch.randn(shape, dtype=torch.bfloat16, device="cuda") / 32
+    kg = torch.randn_like(qg) / 32
+    w = torch.randn_like(qg) / 32
+    u = torch.randn_like(qg) / 32
+    dout = torch.randn_like(qg) / 32
+    aqk = torch.randn(1, 64, 1, 64, dtype=torch.bfloat16, device="cuda") / 32
+    cumulative_gate = -torch.rand(shape, dtype=torch.float32, device="cuda") / 8
+    return qg, kg, w, u, dout, aqk, cumulative_gate
 
 
 def int64_stride_copy(tensor: torch.Tensor) -> torch.Tensor:
@@ -127,15 +144,7 @@ def state_grad_summary_reference(
 
 def test_affine_summaries_support_int64_tensor_strides():
     """Compile wide-address kernels for realistic long-sequence batch strides."""
-    torch.manual_seed(19)
-    shape = (1, 64, 1, 128)
-    qg = torch.randn(shape, dtype=torch.bfloat16, device="cuda") / 32
-    kg = torch.randn_like(qg) / 32
-    w = torch.randn_like(qg) / 32
-    u = torch.randn_like(qg) / 32
-    dout = torch.randn_like(qg) / 32
-    aqk = torch.randn(1, 64, 1, 64, dtype=torch.bfloat16, device="cuda") / 32
-    cumulative_gate = -torch.rand(shape, dtype=torch.float32, device="cuda") / 8
+    qg, kg, w, u, dout, aqk, cumulative_gate = make_summary_inputs(19)
 
     expected_forward = build_state_summary(kg, w, u, cumulative_gate)
     expected_reverse = build_state_grad_summary(
@@ -159,17 +168,45 @@ def test_affine_summaries_support_int64_tensor_strides():
     torch.testing.assert_close(actual_reverse, expected_reverse, rtol=0, atol=0)
 
 
+def test_portable_affine_summaries_support_forced_int64_offsets(monkeypatch):
+    """Keep the portable launchers' wide-address specialization executable."""
+    capability = torch.cuda.get_device_capability()
+    if is_sm100_kda_capability(capability):
+        pytest.skip("SM100 uses the native CuTeDSL affine summaries")
+
+    qg, kg, w, u, dout, aqk, cumulative_gate = make_summary_inputs(20)
+
+    expected_forward = build_state_summary(kg, w, u, cumulative_gate)
+    expected_reverse = build_state_grad_summary(
+        qg,
+        kg,
+        w,
+        dout,
+        aqk,
+        cumulative_gate,
+        128**-0.5,
+    )
+    monkeypatch.setattr(portable_fwd, "requires_int64_offsets", lambda *_tensors: True)
+    monkeypatch.setattr(portable_rev, "requires_int64_offsets", lambda *_tensors: True)
+
+    actual_forward = build_state_summary(kg, w, u, cumulative_gate)
+    actual_reverse = build_state_grad_summary(
+        qg,
+        kg,
+        w,
+        dout,
+        aqk,
+        cumulative_gate,
+        128**-0.5,
+    )
+
+    torch.testing.assert_close(actual_forward, expected_forward, rtol=0, atol=0)
+    torch.testing.assert_close(actual_reverse, expected_reverse, rtol=0, atol=0)
+
+
 def test_affine_summaries_accept_misaligned_contiguous_storage():
     """Normalize ordinary storage-offset views before constructing TMA descriptors."""
-    torch.manual_seed(21)
-    shape = (1, 64, 1, 128)
-    qg = torch.randn(shape, dtype=torch.bfloat16, device="cuda") / 32
-    kg = torch.randn_like(qg) / 32
-    w = torch.randn_like(qg) / 32
-    u = torch.randn_like(qg) / 32
-    dout = torch.randn_like(qg) / 32
-    aqk = torch.randn(1, 64, 1, 64, dtype=torch.bfloat16, device="cuda") / 32
-    cumulative_gate = -torch.rand(shape, dtype=torch.float32, device="cuda") / 8
+    qg, kg, w, u, dout, aqk, cumulative_gate = make_summary_inputs(21)
 
     expected_forward = build_state_summary(kg, w, u, cumulative_gate)
     expected_reverse = build_state_grad_summary(
@@ -194,7 +231,10 @@ def test_affine_summaries_accept_misaligned_contiguous_storage():
 
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
-@pytest.mark.parametrize("tokens,heads", [(64, 1), (65, 2), (256, 3)])
+@pytest.mark.parametrize(
+    "tokens,heads",
+    [(64, 1), (65, 2), (256, 3), (64, 8), (64, 12), (512, 2), (2048, 1)],
+)
 def test_affine_summary_matches_fp32_reference(dtype, tokens, heads):
     torch.manual_seed(23)
     shape = (1, tokens, heads, 128)
@@ -212,7 +252,10 @@ def test_affine_summary_matches_fp32_reference(dtype, tokens, heads):
 
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
-@pytest.mark.parametrize("tokens,heads", [(64, 1), (65, 2), (256, 3)])
+@pytest.mark.parametrize(
+    "tokens,heads",
+    [(64, 1), (65, 2), (256, 3), (64, 8), (64, 12), (512, 2), (2048, 1)],
+)
 def test_build_state_grad_summary_matches_fp32_reference(dtype, tokens, heads):
     torch.manual_seed(27)
     shape = (1, tokens, heads, 128)


### PR DESCRIPTION
## Human Note

## Agent note

The context-parallel protocol was architecture-neutral, but both affine-summary recurrences used
SM100-only TMA/UMMA kernels. Meaningful sequences crossing rank boundaries therefore failed on
Hopper before the first summary collective.

Add one-launch Triton forward and reverse summaries that retain the FP32 augmented state while
scanning local BT64 chunks. The forward uses high/low input-dtype splits to preserve the existing
long-scan numerical contract. Shared builders continue to own validation, tail padding, and exact
architecture dispatch: SM100/SM103 retain the native CuTeDSL fast path, while other supported CUDA
targets use Triton. All multidimensional Triton addresses use the shared `ptr_offset` helper, TMA
alignment remains native-path-only, and Triton imports do not initialize CUDA.

Expose the compute dtype in the complete CP example so BF16 and FP16 both receive end-to-end eager
and CUDA Graph validation.

## Performance

H100 80 GB, BF16, fixed warm tensors, 200 post-warmup samples:

| Summary shape | Triton forward | Triton reverse |
| --- | ---: | ---: |
| T512, H2 | 15.28 us | 15.08 us |
| T2048, H16 | 69.71 us | 78.04 us |

At T512/H2, the eager FP32 PyTorch recurrence measured 247.48 us forward and 370.14 us reverse.

Full-module strong scaling for one global T=131072 sequence, hidden size 1024, H=8, fused bound
gate, and no external replicated-parameter gradient reduction:

| ranks | BF16 step | FP16 step | peak allocated per rank |
| ---: | ---: | ---: | ---: |
| 1 | 50.19 ms | 49.95 ms | 9.39 GiB |
| 2 | 29.36 ms | 29.29 ms | 4.75 GiB |
| 4 | 16.79 ms | 16.77 ms | 2.42 GiB |

## Test Plan

```bash
gpu-run --timeout 30 auto -- timeout --signal=TERM --kill-after=5s 300s .venv/bin/pytest -q test/test_delta_affine_summary.py
.venv/bin/pytest -q test/test_kda_context_parallel.py test/test_kda_imports.py test/test_namespaces.py
timeout --signal=TERM --kill-after=10s 300s env PYTHONPATH=$PWD NCCL_DEBUG=WARN .venv/bin/torchrun --standalone --nproc-per-node=4 examples/kda_context_parallel.py
timeout --signal=TERM --kill-after=10s 300s env PYTHONPATH=$PWD NCCL_DEBUG=WARN .venv/bin/torchrun --standalone --nproc-per-node=4 examples/kda_context_parallel.py --cuda-graph
timeout --signal=TERM --kill-after=10s 300s env PYTHONPATH=$PWD NCCL_DEBUG=WARN .venv/bin/torchrun --standalone --nproc-per-node=4 examples/kda_context_parallel.py --compute-dtype=float16 --cuda-graph
files=(${(f)"$(git diff --cached --name-only)"}); .venv/bin/prek run --files $files
```
