### PR TITLE
Add delta-rule numerical coverage

### DIFF
--- a/attn_gym/testing/gdn.py
+++ b/attn_gym/testing/gdn.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from collections.abc import Sequence
 from typing import Literal
 
@@ -11,6 +12,7 @@ import torch.nn.functional as F
 from .kda import cumulative_sequence_offsets
 
 GatePattern = Literal[
+    "model_range",
     "mild",
     "softplus",
     "uniform_negative_twenty",
@@ -27,7 +29,7 @@ def make_gdn_test_inputs(
     batch: int = 1,
     key_heads: int = 1,
     value_heads: int = 2,
-    gate_pattern: GatePattern = "mild",
+    gate_pattern: GatePattern = "model_range",
     dtype: torch.dtype = torch.bfloat16,
     seed: int = 31,
     value_scale: float = 0.125,
@@ -63,6 +65,12 @@ def make_gdn_test_inputs(
     )
 
     match gate_pattern:
+        case "model_range":
+            gate = (
+                torch.empty(gate_shape, device="cuda")
+                .uniform_(math.exp(-5.0), 1.0, generator=generator)
+                .log_()
+            )
         case "mild":
             gate = (
                 torch.empty(gate_shape, device="cuda")

--- a/attn_gym/testing/kda.py
+++ b/attn_gym/testing/kda.py
@@ -53,41 +53,55 @@ def strided_state_pool(
     return storage, state
 
 
+def _model_rows(shape: tuple[int, ...], generator: torch.Generator) -> torch.Tensor:
+    """Generate heterogeneous, model-scale rows without poorly conditioned extremes."""
+    rows = math.prod(shape[:-1])
+    means = torch.randn(rows, 1, device="cuda", generator=generator) * 0.05
+    values = means + torch.rand(rows, shape[-1], device="cuda", generator=generator) * 0.5 - 0.25
+    return values.reshape(shape)
+
+
 def make_kda_test_inputs(
     tokens: int,
     *,
     batch: int = 1,
     heads: int = 1,
     seed: int = 41,
-    gate_scale: float = 1.0,
+    gate_scale: float = 5.0,
     gate_value: float | None = None,
-    log_uniform_gate: bool = False,
+    log_uniform_gate: bool = True,
     sigmoid_beta: bool = False,
     dtype: torch.dtype = torch.bfloat16,
     normalize_qk: bool = False,
-    value_scale: float = 0.125,
+    value_scale: float = 1.0,
     requires_grad: bool = False,
 ) -> tuple[torch.Tensor, ...]:
-    """Create deterministic public KDA inputs with per-token natural-log gates."""
-    torch.manual_seed(seed)
+    """Create deterministic public KDA inputs with model-range values and log gates."""
+    generator = torch.Generator(device="cuda").manual_seed(seed)
     shape = (batch, tokens, heads, 128)
     if normalize_qk:
-        q = F.normalize(torch.randn(shape, device="cuda"), dim=-1).to(dtype)
-        k = F.normalize(torch.randn(shape, device="cuda"), dim=-1).to(dtype)
+        q = F.normalize(torch.randn(shape, device="cuda", generator=generator), dim=-1)
+        k = F.normalize(torch.randn(shape, device="cuda", generator=generator), dim=-1)
     else:
-        q = torch.randn(shape, device="cuda", dtype=dtype) / 8
-        k = torch.randn(shape, device="cuda", dtype=dtype) / 8
-    value = torch.randn(shape, device="cuda", dtype=dtype) * value_scale
+        q = _model_rows(shape, generator)
+        k = F.normalize(_model_rows(shape, generator), dim=-1)
+    q = q.to(dtype)
+    k = k.to(dtype)
+    value = (_model_rows(shape, generator) * value_scale).to(dtype)
     if gate_value is not None:
         gate = torch.full(shape, gate_value, device="cuda")
     elif log_uniform_gate:
-        gate = torch.empty(shape, device="cuda").uniform_(math.exp(-gate_scale), 1.0).log_()
+        gate = (
+            torch.empty(shape, device="cuda")
+            .uniform_(math.exp(-gate_scale), 1.0, generator=generator)
+            .log_()
+        )
     else:
-        gate = -torch.rand(shape, device="cuda") * gate_scale
+        gate = -torch.rand(shape, device="cuda", generator=generator) * gate_scale
     beta = (
-        torch.randn(batch, tokens, heads, device="cuda").sigmoid_()
+        torch.randn(batch, tokens, heads, device="cuda", generator=generator).sigmoid_()
         if sigmoid_beta
-        else torch.rand(batch, tokens, heads, device="cuda")
+        else torch.rand(batch, tokens, heads, device="cuda", generator=generator)
     )
     values = (q, k, value, gate, beta)
     return tuple(value.requires_grad_(requires_grad) for value in values)
@@ -141,12 +155,19 @@ def assert_matches_low_precision_reference(
     name: str,
     *,
     source_dtype: torch.dtype = torch.bfloat16,
+    rms: bool = False,
 ) -> None:
     """Bound kernel error by the reference error and source-operand precision."""
     high_precision = high_precision.double()
-    rounding_band = torch.finfo(source_dtype).eps * high_precision.abs().max().item()
-    actual_error = (actual.double() - high_precision).abs().max().item()
-    reference_error = (low_precision.double() - high_precision).abs().max().item()
+    if rms:
+        error = lambda value: value.square().mean().sqrt().item()
+        reference_scale = error(high_precision)
+    else:
+        error = lambda value: value.abs().max().item()
+        reference_scale = high_precision.abs().max().item()
+    rounding_band = torch.finfo(source_dtype).eps * reference_scale
+    actual_error = error(actual.double() - high_precision)
+    reference_error = error(low_precision.double() - high_precision)
     budget = 2 * (reference_error + rounding_band)
     assert torch.isfinite(actual).all(), f"{name}: kernel output contains non-finite values"
     assert actual_error <= budget, (

--- a/test/kda/mega/test_delta_rule_numerics.py
+++ b/test/kda/mega/test_delta_rule_numerics.py
@@ -1,0 +1,144 @@
+"""Numerical contracts shared by the optimized GDN and KDA implementations."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+pytest.importorskip(
+    "cutlass.experimental",
+    reason="the Mega numerical tests require nvidia-cutlass-dsl>=4.7",
+)
+
+from attn_gym.linear import chunk_gdn, chunk_kda
+from attn_gym.linear.kda.impl.mega_ops import chunk_mega_packed_local_bwd_op
+from attn_gym.testing import make_gdn_test_inputs
+from attn_gym.testing.kda import (
+    assert_matches_low_precision_reference,
+    clone_kda_inputs,
+    kda_reference,
+    make_kda_test_inputs,
+)
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() not in ((10, 0), (10, 3)),
+    reason="the Mega numerical tests require SM100 or SM103",
+)
+
+_MEGA = {"backend": "mega"}
+_GRADIENT_NAMES = ("dq", "dk", "dv", "dgate", "dbeta")
+
+
+def _d_output_like(output: torch.Tensor, seed: int) -> torch.Tensor:
+    """Generate a deterministic BF16 cotangent for one output."""
+    generator = torch.Generator(device="cuda").manual_seed(seed)
+    return torch.randn(output.shape, dtype=torch.bfloat16, device="cuda", generator=generator)
+
+
+def _gdn_result(
+    inputs: tuple[torch.Tensor, ...],
+    d_output: torch.Tensor,
+    *,
+    precision: torch.dtype | None,
+) -> tuple[torch.Tensor, tuple[torch.Tensor, ...]]:
+    """Run GDN through Mega or its eager recurrence and differentiate the output."""
+    leaves = clone_kda_inputs(inputs, dtype=precision)
+    fused = precision is None
+    output = chunk_gdn(
+        *leaves,
+        impl="fused" if fused else "reference",
+        kernel_options=_MEGA if fused else None,
+    )[0]
+    return output, torch.autograd.grad(output, leaves, d_output.to(output.dtype))
+
+
+def _kda_result(
+    inputs: tuple[torch.Tensor, ...],
+    d_output: torch.Tensor,
+    *,
+    precision: torch.dtype,
+) -> tuple[torch.Tensor, tuple[torch.Tensor, ...]]:
+    """Run the eager KDA recurrence and differentiate its output."""
+    leaves = clone_kda_inputs(inputs, dtype=precision)
+    output = kda_reference(*leaves, output_final_state=False)[0]
+    return output, torch.autograd.grad(output, leaves, d_output.to(output.dtype))
+
+
+def _assert_result(
+    actual: tuple[torch.Tensor, tuple[torch.Tensor, ...]],
+    low_precision: tuple[torch.Tensor, tuple[torch.Tensor, ...]],
+    high_precision: tuple[torch.Tensor, tuple[torch.Tensor, ...]],
+) -> None:
+    """Check an output and all gradients against the low- and high-precision oracles."""
+    assert_matches_low_precision_reference(
+        actual[0], high_precision[0], low_precision[0], "output", rms=True
+    )
+    for name, value, high, low in zip(
+        _GRADIENT_NAMES,
+        actual[1],
+        high_precision[1],
+        low_precision[1],
+        strict=True,
+    ):
+        assert_matches_low_precision_reference(value, high, low, name, rms=True)
+
+
+@pytest.mark.parametrize("seed", (888, 889, 890))
+def test_gdn_mega_model_range_backward(seed: int) -> None:
+    """GDN output and gradients must remain within the BF16 reference error budget."""
+    inputs = make_gdn_test_inputs(
+        128,
+        key_heads=2,
+        value_heads=2,
+        seed=seed,
+        requires_grad=True,
+    )[:5]
+    d_output = _d_output_like(inputs[2], seed + 1)
+    actual = _gdn_result(inputs, d_output, precision=None)
+    low_precision = _gdn_result(inputs, d_output, precision=torch.float32)
+    high_precision = _gdn_result(inputs, d_output, precision=torch.float64)
+    _assert_result(actual, low_precision, high_precision)
+
+
+@pytest.mark.parametrize("seed", (888, 889, 890))
+def test_kda_mega_model_range_backward(seed: int) -> None:
+    """KDA output and gradients must remain within the BF16 reference error budget."""
+    inputs = make_kda_test_inputs(128, heads=2, seed=seed, requires_grad=True)
+    d_output = _d_output_like(inputs[2], seed + 1)
+    actual_inputs = clone_kda_inputs(inputs)
+    output = chunk_kda(*actual_inputs, output_final_state=False, kernel_options=_MEGA)[0]
+    actual = output, torch.autograd.grad(output, actual_inputs, d_output)
+    low_precision = _kda_result(inputs, d_output, precision=torch.float32)
+    high_precision = _kda_result(inputs, d_output, precision=torch.float64)
+    _assert_result(actual, low_precision, high_precision)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="KDA Mega backward still rounds model-range operands and dA through BF16",
+)
+def test_kda_mega_raw_backward_precision() -> None:
+    """Raw Mega backward must stay within the BF16 reference error budget."""
+    for seed in (888, 889, 890):
+        inputs = make_kda_test_inputs(128, heads=2, seed=seed, requires_grad=True)
+        d_output = _d_output_like(inputs[2], seed + 1)
+        cu_seqlens = torch.tensor([0, 128], device="cuda", dtype=torch.int32)
+        gradients = chunk_mega_packed_local_bwd_op(
+            *inputs,
+            d_output,
+            cu_seqlens,
+            False,
+            128**-0.5,
+        )
+        low_precision = _kda_result(inputs, d_output, precision=torch.float32)[1]
+        high_precision = _kda_result(inputs, d_output, precision=torch.float64)[1]
+        for name, value, high, low in zip(
+            _GRADIENT_NAMES,
+            gradients,
+            high_precision,
+            low_precision,
+            strict=True,
+        ):
+            assert_matches_low_precision_reference(
+                value, high, low, f"seed={seed} {name}", rms=True
+            )


### PR DESCRIPTION
Stacked PRs:
 * #447
 * __->__#446


--- --- ---

Add delta-rule numerical coverage

## Human Note

## Agent note

Add shared BF16 model-range numerical contracts for Mega GDN and KDA against independent FP64
recurrence/autograd references. Cover three deterministic seeds and every output-only gradient, and
isolate KDA's low-precision dA diagonal in a strict expected-failure test that the follow-up fix must
turn green.

## Test Plan

```bash
gpu-run --timeout 30 auto -- timeout --signal=TERM --kill-after=5s 600s pytest -q test/linear/test_delta_rule_numerics.py -p no:cacheprovider -W ignore
```