### PR TITLE
Improve Mega KDA numerical stability

### DIFF
--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_bprop_config.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_bprop_config.py
@@ -58,6 +58,7 @@ class Cfg:
     SMEM_S_STAGES: int = 1
     SMEM_DECAY_STAGES: int = 2
     SMEM_INTERMEDIATE_STAGES: int = 2
+    SMEM_DA_DIAG_STAGES: int = 4
     SMEM_STATE_SCALE_DIAG_STAGES: int = 2
     SMEM_DQ_STAGES: int = 1
     SMEM_DK_STAGES: int = 1

--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_bprop_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_bprop_f16.py
@@ -202,6 +202,8 @@ class KdaBwdBars(NamedTuple):
     mb_a_done: MBarrier
     mb_da_ready: MBarrier
     mb_da_done: MBarrier
+    mb_da_diag_ready: MBarrier
+    mb_da_diag_done: MBarrier
     mb_dm_ready: MBarrier
     mb_dm_done: MBarrier
     mb_u_smem_ready: MBarrier
@@ -286,6 +288,8 @@ def make_kda_bwd_bars(cfg) -> KdaBwdBars:
         mb_a_done=MBarrier(alloc(cfg.smem_intermediate_stages), stages=cfg.smem_intermediate_stages, init_count=MMA, producer=Producer.MMA_COMMIT),
         mb_da_ready=MBarrier(alloc(cfg.smem_intermediate_stages), stages=cfg.smem_intermediate_stages, init_count=WARP, producer=Producer.THREAD),
         mb_da_done=MBarrier(alloc(cfg.smem_intermediate_stages), stages=cfg.smem_intermediate_stages, init_count=MMA, producer=Producer.MMA_COMMIT),
+        mb_da_diag_ready=MBarrier(alloc(cfg.smem_da_diag_stages), stages=cfg.smem_da_diag_stages, init_count=WARP, producer=Producer.THREAD),
+        mb_da_diag_done=MBarrier(alloc(cfg.smem_da_diag_stages), stages=cfg.smem_da_diag_stages, init_count=CG2, producer=Producer.THREAD),
         mb_dm_ready=MBarrier(alloc(cfg.smem_intermediate_stages), stages=cfg.smem_intermediate_stages, init_count=WARP, producer=Producer.THREAD),
         mb_dm_done=MBarrier(alloc(cfg.smem_intermediate_stages), stages=cfg.smem_intermediate_stages, init_count=MMA, producer=Producer.MMA_COMMIT),
         mb_u_smem_ready=MBarrier(alloc(1), stages=1, init_count=CG1, producer=Producer.THREAD),
@@ -365,6 +369,7 @@ def epilogue_warp(
     sDo_raw,
     sU_raw,
     sIntermediate_raw,
+    sDaDiag_raw,
     sDq_raw,
     sDk_raw,
     sDv_raw,
@@ -402,12 +407,14 @@ def epilogue_warp(
     row_hi = row_lo + cutlass.Int32(8)
 
     tril_incl_mask = cutlass.Int32(0)
+    tril_strict_mask = cutlass.Int32(0)
     for accum_idx in cutlass.range_constexpr(8):
         row_coord = row_hi if cutlass.const_expr(accum_idx % 4 >= 2) else row_lo
         col_coord = (accum_idx // 4) * 8 + 2 * (lane % 4)
         if cutlass.const_expr(accum_idx % 2 == 1):
             col_coord = col_coord + cutlass.Int32(1)
         tril_incl_mask = tril_incl_mask | (cutlass.Int32(1 << accum_idx) if row_coord >= col_coord else cutlass.Int32(0))
+        tril_strict_mask = tril_strict_mask | (cutlass.Int32(1 << accum_idx) if row_coord > col_coord else cutlass.Int32(0))
     raw_index = PipelineState.start(phase=0)
     u_index = PipelineState.start(phase=0)
     chunk_serial_base = cutlass.Int32(0)
@@ -558,8 +565,27 @@ def epilogue_warp(
             # licenses the TMA reload (sDo)
             nvvm.fence_proxy("async.shared", space="cta")
             bars.mb_do_done[raw_stage].arrive()
+
+            # ---- dA diagonal: retain FP32 values outside the scaled MMA path ----
+            da_diag_stage = chunk_serial % cfg.smem_da_diag_stages
+            bars.mb_da_diag_done[da_diag_stage].wait(
+                ((chunk_serial // cfg.smem_da_diag_stages) + 1) % 2
+            )
             for accum_idx in cutlass.range_constexpr(8):
-                da_acc[accum_idx] = da_acc[accum_idx] if (tril_incl_mask >> accum_idx) & 1 else cutlass.Float32(0.0)
+                diag_row = row_hi if cutlass.const_expr(accum_idx % 4 >= 2) else row_lo
+                diag_col = (accum_idx // 4) * 8 + 2 * (lane % 4)
+                if cutlass.const_expr(accum_idx % 2 == 1):
+                    diag_col = diag_col + cutlass.Int32(1)
+                if diag_row == diag_col:
+                    sDaDiag_raw[da_diag_stage * cfg.b_t + diag_row] = da_acc[accum_idx]
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_da_diag_ready[da_diag_stage].arrive()
+            for accum_idx in cutlass.range_constexpr(8):
+                da_acc[accum_idx] = (
+                    da_acc[accum_idx]
+                    if (tril_strict_mask >> accum_idx) & 1
+                    else cutlass.Float32(0.0)
+                )
             bars.mb_da_done[intermediate_stage].wait(((chunk_serial // cfg.smem_intermediate_stages) + 1) % 2)
             nvvm.stmatrix(
                 sIntermediate_ptr + 2 * (cfg.b_t * cfg.b_t) + stsm_idx,
@@ -1976,6 +2002,7 @@ def compute0_warp_group(
             nvvm.barrier_cta_sync(cfg.cg0_sync_barrier_id, thread_count=cfg.cg0_threads)
 
             k_inv_pack = cute.make_rmem_tensor((2 * 4,), cutlass.Int32)
+            k_restore_pack = cute.make_rmem_tensor((2 * 4,), cutlass.Int32)
             raw_q_regs = cute.make_rmem_tensor((2 * 8,), cutlass.Float32)
             raw_k_regs = cute.make_rmem_tensor((2 * 8,), cutlass.Float32)
             # ---- optional Q/K L2-norm --------------------------------------------
@@ -2075,13 +2102,30 @@ def compute0_warp_group(
                     raw_reg_idx0 = reg_base + dim0
                     raw_reg_idx1 = reg_base + dim1
                     k_value0, k_value1 = fmul2(raw_k_regs[raw_reg_idx0], raw_k_regs[raw_reg_idx1], k_inv_norm, k_inv_norm)
-                    k_pair = fp32_to_fp16(k_value0, k_value1, dtype=cfg.io_dtype)
-                    exp_g_pair = fp32_to_fp16(exp_g_regs[raw_reg_idx0], exp_g_regs[raw_reg_idx1], dtype=cfg.io_dtype)
-                    k_decay_pack[pair_idx] = mul_f16x2(k_pair, exp_g_pair, cfg.io_dtype)
+                    k_decay0, k_decay1 = fmul2(
+                        k_value0,
+                        k_value1,
+                        exp_g_regs[raw_reg_idx0],
+                        exp_g_regs[raw_reg_idx1],
+                    )
+                    k_decay_pack[pair_idx] = fp32_to_fp16(
+                        k_decay0, k_decay1, dtype=cfg.io_dtype
+                    )
                     exp_neg_g0 = cute.math.rcp(exp_g_regs[raw_reg_idx0], approx=True, ftz=True)
                     exp_neg_g1 = cute.math.rcp(exp_g_regs[raw_reg_idx1], approx=True, ftz=True)
-                    exp_neg_pair = fp32_to_fp16(exp_neg_g0, exp_neg_g1, dtype=cfg.io_dtype)
-                    k_inv_pack[dim_half * 4 + pair_idx] = mul_f16x2(k_pair, exp_neg_pair, cfg.io_dtype)
+                    k_inv0, k_inv1 = fmul2(k_value0, k_value1, exp_neg_g0, exp_neg_g1)
+                    k_inv_pack[dim_half * 4 + pair_idx] = fp32_to_fp16(
+                        k_inv0, k_inv1, dtype=cfg.io_dtype
+                    )
+                    k_restore0, k_restore1 = fmul2(
+                        k_inv0,
+                        k_inv1,
+                        exp_g_last_regs[raw_reg_idx0],
+                        exp_g_last_regs[raw_reg_idx1],
+                    )
+                    k_restore_pack[dim_half * 4 + pair_idx] = fp32_to_fp16(
+                        k_restore0, k_restore1, dtype=cfg.io_dtype
+                    )
 
                 k_inv_vec = cutlass.Vector.from_elements(
                     (
@@ -2111,25 +2155,33 @@ def compute0_warp_group(
                 dim_base = dim_half * (cfg.d_k // 2) + lane_in_row_group * 8
                 reg_base = dim_half * 8
                 q_decay_pack = cute.make_rmem_tensor((4,), cutlass.Int32)
-                k_restore_pack = cute.make_rmem_tensor((4,), cutlass.Int32)
                 for pair_idx in cutlass.range_constexpr(4):
                     dim0 = pair_idx * 2
                     dim1 = dim0 + 1
                     raw_reg_idx0 = reg_base + dim0
                     raw_reg_idx1 = reg_base + dim1
                     q_value0, q_value1 = fmul2(raw_q_regs[raw_reg_idx0], raw_q_regs[raw_reg_idx1], q_stage_norm, q_stage_norm)
-                    q_pair = fp32_to_fp16(q_value0, q_value1, dtype=cfg.io_dtype)
-                    exp_g_pair = fp32_to_fp16(exp_g_regs[raw_reg_idx0], exp_g_regs[raw_reg_idx1], dtype=cfg.io_dtype)
-                    q_decay_pack[pair_idx] = mul_f16x2(q_pair, exp_g_pair, cfg.io_dtype)
-                    exp_g_last_pair = fp32_to_fp16(exp_g_last_regs[raw_reg_idx0], exp_g_last_regs[raw_reg_idx1], dtype=cfg.io_dtype)
-                    k_restore_pack[pair_idx] = mul_f16x2(k_inv_pack[dim_half * 4 + pair_idx], exp_g_last_pair, cfg.io_dtype)
+                    q_decay0, q_decay1 = fmul2(
+                        q_value0,
+                        q_value1,
+                        exp_g_regs[raw_reg_idx0],
+                        exp_g_regs[raw_reg_idx1],
+                    )
+                    q_decay_pack[pair_idx] = fp32_to_fp16(
+                        q_decay0, q_decay1, dtype=cfg.io_dtype
+                    )
 
                 q_decay_vec = cutlass.Vector.from_elements(
                     (q_decay_pack[0], q_decay_pack[1], q_decay_pack[2], q_decay_pack[3]),
                     cutlass.Int32,
                 ).bitcast(cfg.io_dtype)
                 k_restore_vec = cutlass.Vector.from_elements(
-                    (k_restore_pack[0], k_restore_pack[1], k_restore_pack[2], k_restore_pack[3]),
+                    (
+                        k_restore_pack[dim_half * 4],
+                        k_restore_pack[dim_half * 4 + 1],
+                        k_restore_pack[dim_half * 4 + 2],
+                        k_restore_pack[dim_half * 4 + 3],
+                    ),
                     cutlass.Int32,
                 ).bitcast(cfg.io_dtype)
                 op_idx = swizzle_box_offset_128b(
@@ -2621,6 +2673,7 @@ def compute2_warp_group(
     warp_idx,
     sGate_raw,
     sNorm_raw,
+    sDaDiag_raw,
     sDq_raw,
     sDk_raw,
     sRed1_raw,
@@ -2795,6 +2848,16 @@ def compute2_warp_group(
             nvvm.tcgen05_wait("load")
             bars.mb_dqk_acc_done.arrive()
 
+            # ---- dA diagonal: Gamma-free FP32 dQ/dK terms -----------------------
+            da_diag_stage = chunk_serial % cfg.smem_da_diag_stages
+            bars.mb_da_diag_ready[da_diag_stage].wait(
+                (chunk_serial // cfg.smem_da_diag_stages) % 2
+            )
+            da_diag = cute.make_rmem_tensor((cfg.b_t,), cutlass.Float32)
+            for t in cutlass.range_constexpr(cfg.b_t):
+                da_diag[t] = sDaDiag_raw[da_diag_stage * cfg.b_t + t] * scale
+            bars.mb_da_diag_done[da_diag_stage].arrive()
+
             # ---- dGate finalize --------------------------------------------------
             qf_words = nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(row_addr + qraw_col, cutlass.Float32), num=cfg.b_t // 2)
             kf_words = nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(row_addr + kraw_col, cutlass.Float32), num=cfg.b_t // 2)
@@ -2806,6 +2869,8 @@ def compute2_warp_group(
                 if cutlass.const_expr(cfg.l2norm):
                     q_v = q_v * sNorm_raw[norm_base + t]
                     k_v = k_v * sNorm_raw[norm_base + cfg.b_t + t]
+                dq_n[t] = dq_n[t] + da_diag[t] * k_v
+                dk_n[t] = dk_n[t] + da_diag[t] * q_v
                 dgate_regs[t] = q_v * dq_n[t] + k_v * (cutlass.Float32(2.0) * dgate_regs[t] - dk_n[t])
             dgate_regs[cfg.b_t - 1] = dgate_regs[cfg.b_t - 1] + ((dgate_last_acc[0] + dgate_last_acc[1]) + (dgate_last_acc[2] + dgate_last_acc[3]))
 
@@ -3425,6 +3490,12 @@ def kernel(
     sRed_raw = cutlass.Array(cutlass.Float32, 4 * cfg.b_t, space=SMEM, alignment=64)
     sRed1_raw = cutlass.Array(cutlass.Float32, 4 * cfg.b_t, space=SMEM, alignment=64)
     sBetaM_raw = cutlass.Array(cutlass.Float32, cfg.b_t, space=SMEM, alignment=64)
+    sDaDiag_raw = cutlass.Array(
+        cutlass.Float32,
+        cfg.smem_da_diag_stages * cfg.b_t,
+        space=SMEM,
+        alignment=64,
+    )
     storage = cutlass.utils.SmemAllocator().allocate(shared_type)
     sState_raw = storage.state.get_tensor(cute.make_layout((cfg.state_cosize,)))
     sDstate_raw = storage.dstate.get_tensor(cute.make_layout((cfg.d_k * cfg.d_v,)))
@@ -3641,6 +3712,9 @@ def kernel(
                 bars.mb_dm_done[stage].init()
     elif warp_idx == cfg.epilogue_warp_id:
         if elect_one:
+            for stage in cutlass.range_constexpr(cfg.smem_da_diag_stages):
+                bars.mb_da_diag_ready[stage].init()
+                bars.mb_da_diag_done[stage].init()
             for stage in cutlass.range_constexpr(cfg.smem_dq_stages):
                 bars.mb_dq_tmastg_ready[stage].init()
                 bars.mb_dq_tmastg_done[stage].init()
@@ -3748,6 +3822,7 @@ def kernel(
             sDo_raw,
             sU_raw,
             sIntermediate_raw,
+            sDaDiag_raw,
             sDq_raw,
             sDk_raw,
             sDv_raw,
@@ -3801,6 +3876,7 @@ def kernel(
             warp_idx,
             sGate_raw,
             sNorm_raw,
+            sDaDiag_raw,
             sDq_raw,
             sDk_raw,
             sRed1_raw,
@@ -3891,6 +3967,7 @@ class KdaBwdCfg:
     smem_state_stages: int = CFG.SMEM_S_STAGES
     smem_decay_stages: int = CFG.SMEM_DECAY_STAGES
     smem_intermediate_stages: int = CFG.SMEM_INTERMEDIATE_STAGES
+    smem_da_diag_stages: int = CFG.SMEM_DA_DIAG_STAGES
     smem_dq_stages: int = CFG.SMEM_DQ_STAGES
     smem_dk_stages: int = CFG.SMEM_DK_STAGES
     smem_dgate_stages: int = CFG.SMEM_DGATE_STAGES

--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_prefill_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_prefill_f16.py
@@ -1247,6 +1247,7 @@ def compute0_warp_group(
             bars.mb_q_ready[raw_bar_stage].wait((cum_chunk // cfg.smem_raw_bar_stages) % 2)
             bars.mb_k_ready[raw_bar_stage].wait((cum_chunk // cfg.smem_raw_bar_stages) % 2)
             k_inv_pack = cute.make_rmem_tensor((2 * 4,), cutlass.Int32)
+            k_restore_pack = cute.make_rmem_tensor((2 * 4,), cutlass.Int32)
             raw_q_regs = cute.make_rmem_tensor((2 * 8,), cutlass.Float32)
             raw_k_regs = cute.make_rmem_tensor((2 * 8,), cutlass.Float32)
 
@@ -1333,13 +1334,30 @@ def compute0_warp_group(
                     raw_reg_idx0 = reg_base + dim0
                     raw_reg_idx1 = reg_base + dim1
                     k_value0, k_value1 = fmul2(raw_k_regs[raw_reg_idx0], raw_k_regs[raw_reg_idx1], k_inv_norm, k_inv_norm)
-                    k_pair = fp32_to_fp16(k_value0, k_value1, dtype=cfg.io_dtype)
-                    exp_g_pair = fp32_to_fp16(exp_g_regs[raw_reg_idx0], exp_g_regs[raw_reg_idx1], dtype=cfg.io_dtype)
-                    k_decay_pack[pair_idx] = mul_f16x2(k_pair, exp_g_pair, cfg.io_dtype)
+                    k_decay0, k_decay1 = fmul2(
+                        k_value0,
+                        k_value1,
+                        exp_g_regs[raw_reg_idx0],
+                        exp_g_regs[raw_reg_idx1],
+                    )
+                    k_decay_pack[pair_idx] = fp32_to_fp16(
+                        k_decay0, k_decay1, dtype=cfg.io_dtype
+                    )
                     exp_neg_g0 = cute.math.rcp(exp_g_regs[raw_reg_idx0], approx=True, ftz=True)
                     exp_neg_g1 = cute.math.rcp(exp_g_regs[raw_reg_idx1], approx=True, ftz=True)
-                    exp_neg_pair = fp32_to_fp16(exp_neg_g0, exp_neg_g1, dtype=cfg.io_dtype)
-                    k_inv_pack[dim_half * 4 + pair_idx] = mul_f16x2(k_pair, exp_neg_pair, cfg.io_dtype)
+                    k_inv0, k_inv1 = fmul2(k_value0, k_value1, exp_neg_g0, exp_neg_g1)
+                    k_inv_pack[dim_half * 4 + pair_idx] = fp32_to_fp16(
+                        k_inv0, k_inv1, dtype=cfg.io_dtype
+                    )
+                    k_restore0, k_restore1 = fmul2(
+                        k_inv0,
+                        k_inv1,
+                        exp_g_last_regs[raw_reg_idx0],
+                        exp_g_last_regs[raw_reg_idx1],
+                    )
+                    k_restore_pack[dim_half * 4 + pair_idx] = fp32_to_fp16(
+                        k_restore0, k_restore1, dtype=cfg.io_dtype
+                    )
 
                 k_inv_vec = cutlass.Vector.from_elements(
                     (
@@ -1393,9 +1411,15 @@ def compute0_warp_group(
                     raw_reg_idx0 = reg_base + dim0
                     raw_reg_idx1 = reg_base + dim1
                     q_value0, q_value1 = fmul2(raw_q_regs[raw_reg_idx0], raw_q_regs[raw_reg_idx1], q_inv_norm, q_inv_norm)
-                    q_pair = fp32_to_fp16(q_value0, q_value1, dtype=cfg.io_dtype)
-                    exp_g_pair = fp32_to_fp16(exp_g_regs[raw_reg_idx0], exp_g_regs[raw_reg_idx1], dtype=cfg.io_dtype)
-                    q_decay_pack[pair_idx] = mul_f16x2(q_pair, exp_g_pair, cfg.io_dtype)
+                    q_decay0, q_decay1 = fmul2(
+                        q_value0,
+                        q_value1,
+                        exp_g_regs[raw_reg_idx0],
+                        exp_g_regs[raw_reg_idx1],
+                    )
+                    q_decay_pack[pair_idx] = fp32_to_fp16(
+                        q_decay0, q_decay1, dtype=cfg.io_dtype
+                    )
 
                 q_decay_vec = cutlass.Vector.from_elements(
                     (
@@ -1418,13 +1442,6 @@ def compute0_warp_group(
             bars.mb_k_restore_done[decay_stage].wait(((cum_chunk // cfg.smem_decay_stages + 1) % 2))
             for dim_half in cutlass.range_constexpr(2):
                 dim_base = dim_half * (cfg.d_k // 2) + lane_in_row_group * 8
-                reg_base = dim_half * 8
-                k_restore_pack = cute.make_rmem_tensor((4,), cutlass.Int32)
-                for pair_idx in cutlass.range_constexpr(4):
-                    dim0 = pair_idx * 2
-                    dim1 = dim0 + 1
-                    exp_g_last_pair = fp32_to_fp16(exp_g_last_regs[reg_base + dim0], exp_g_last_regs[reg_base + dim1], dtype=cfg.io_dtype)
-                    k_restore_pack[pair_idx] = mul_f16x2(k_inv_pack[dim_half * 4 + pair_idx], exp_g_last_pair, cfg.io_dtype)
                 storage_row = decay_row ^ (cfg.b_t // 2)
                 k_restore_idx = swizzle_box_offset_128b(
                     storage_row,
@@ -1433,10 +1450,10 @@ def compute0_warp_group(
                 )
                 k_restore_vec = cutlass.Vector.from_elements(
                     (
-                        k_restore_pack[0],
-                        k_restore_pack[1],
-                        k_restore_pack[2],
-                        k_restore_pack[3],
+                        k_restore_pack[dim_half * 4],
+                        k_restore_pack[dim_half * 4 + 1],
+                        k_restore_pack[dim_half * 4 + 2],
+                        k_restore_pack[dim_half * 4 + 3],
                     ),
                     cutlass.Int32,
                 ).bitcast(cfg.io_dtype)

--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_recompute_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_recompute_f16.py
@@ -1073,6 +1073,7 @@ def compute0_warp_group(
 
             bars.mb_k_ready[raw_stage].wait((cum_chunk // cfg.smem_raw_stages) % 2)
             k_inv_pack = cute.make_rmem_tensor((2 * 4,), cutlass.Int32)
+            k_restore_pack = cute.make_rmem_tensor((2 * 4,), cutlass.Int32)
             raw_k_regs = cute.make_rmem_tensor((2 * 8,), cutlass.Float32)
 
             # ---- optional K L2-norm + K_inv staging ------------------------------
@@ -1146,13 +1147,30 @@ def compute0_warp_group(
                     raw_reg_idx0 = reg_base + dim0
                     raw_reg_idx1 = reg_base + dim1
                     k_value0, k_value1 = fmul2(raw_k_regs[raw_reg_idx0], raw_k_regs[raw_reg_idx1], k_inv_norm, k_inv_norm)
-                    k_pair = fp32_to_fp16(k_value0, k_value1, dtype=cfg.io_dtype)
-                    exp_g_pair = fp32_to_fp16(exp_g_regs[raw_reg_idx0], exp_g_regs[raw_reg_idx1], dtype=cfg.io_dtype)
-                    k_decay_pack[pair_idx] = mul_f16x2(k_pair, exp_g_pair, cfg.io_dtype)
+                    k_decay0, k_decay1 = fmul2(
+                        k_value0,
+                        k_value1,
+                        exp_g_regs[raw_reg_idx0],
+                        exp_g_regs[raw_reg_idx1],
+                    )
+                    k_decay_pack[pair_idx] = fp32_to_fp16(
+                        k_decay0, k_decay1, dtype=cfg.io_dtype
+                    )
                     exp_neg_g0 = cute.math.rcp(exp_g_regs[raw_reg_idx0], approx=True, ftz=True)
                     exp_neg_g1 = cute.math.rcp(exp_g_regs[raw_reg_idx1], approx=True, ftz=True)
-                    exp_neg_pair = fp32_to_fp16(exp_neg_g0, exp_neg_g1, dtype=cfg.io_dtype)
-                    k_inv_pack[dim_half * 4 + pair_idx] = mul_f16x2(k_pair, exp_neg_pair, cfg.io_dtype)
+                    k_inv0, k_inv1 = fmul2(k_value0, k_value1, exp_neg_g0, exp_neg_g1)
+                    k_inv_pack[dim_half * 4 + pair_idx] = fp32_to_fp16(
+                        k_inv0, k_inv1, dtype=cfg.io_dtype
+                    )
+                    k_restore0, k_restore1 = fmul2(
+                        k_inv0,
+                        k_inv1,
+                        exp_g_last_regs[raw_reg_idx0],
+                        exp_g_last_regs[raw_reg_idx1],
+                    )
+                    k_restore_pack[dim_half * 4 + pair_idx] = fp32_to_fp16(
+                        k_restore0, k_restore1, dtype=cfg.io_dtype
+                    )
 
                 k_inv_vec = cutlass.Vector.from_elements(
                     (
@@ -1196,13 +1214,6 @@ def compute0_warp_group(
             bars.mb_k_restore_done[decay_stage].wait(((cum_chunk // cfg.smem_decay_stages + 1) % 2))
             for dim_half in cutlass.range_constexpr(2):
                 dim_base = dim_half * (cfg.d_k // 2) + lane_in_row_group * 8
-                reg_base = dim_half * 8
-                k_restore_pack = cute.make_rmem_tensor((4,), cutlass.Int32)
-                for pair_idx in cutlass.range_constexpr(4):
-                    dim0 = pair_idx * 2
-                    dim1 = dim0 + 1
-                    exp_g_last_pair = fp32_to_fp16(exp_g_last_regs[reg_base + dim0], exp_g_last_regs[reg_base + dim1], dtype=cfg.io_dtype)
-                    k_restore_pack[pair_idx] = mul_f16x2(k_inv_pack[dim_half * 4 + pair_idx], exp_g_last_pair, cfg.io_dtype)
                 storage_row = decay_row ^ (cfg.b_t // 2)
                 k_restore_idx = swizzle_box_offset_128b(
                     storage_row,
@@ -1211,10 +1222,10 @@ def compute0_warp_group(
                 )
                 k_restore_vec = cutlass.Vector.from_elements(
                     (
-                        k_restore_pack[0],
-                        k_restore_pack[1],
-                        k_restore_pack[2],
-                        k_restore_pack[3],
+                        k_restore_pack[dim_half * 4],
+                        k_restore_pack[dim_half * 4 + 1],
+                        k_restore_pack[dim_half * 4 + 2],
+                        k_restore_pack[dim_half * 4 + 3],
                     ),
                     cutlass.Int32,
                 ).bitcast(cfg.io_dtype)

--- a/test/kda/mega/test_delta_rule_numerics.py
+++ b/test/kda/mega/test_delta_rule_numerics.py
@@ -113,10 +113,6 @@ def test_kda_mega_model_range_backward(seed: int) -> None:
     _assert_result(actual, low_precision, high_precision)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="KDA Mega backward still rounds model-range operands and dA through BF16",
-)
 def test_kda_mega_raw_backward_precision() -> None:
     """Raw Mega backward must stay within the BF16 reference error budget."""
     for seed in (888, 889, 890):


### PR DESCRIPTION
Stacked PRs:
 * __->__#447
 * #446


--- --- ---

Improve Mega KDA numerical stability

## Human Note

## Agent note

Construct KDA decay, inverse, and restore operands in FP32 and round only once when staging them in
low precision. Preserve the backward dA diagonal in a separate FP32 ring and add its Gamma-free dQ
and dK contributions outside the low-precision triangular MMA path. Remove the numerical test's
expected-failure marker now that model-range raw Mega gradients satisfy the calibrated FP64 contract.

## Test Plan

```bash
gpu-run --timeout 30 auto -- timeout --signal=TERM --kill-after=5s 600s env CUTE_DSL_NO_CACHE=1 pytest -q test/linear/test_delta_rule_numerics.py -p no:cacheprovider -W ignore
gpu-run --timeout 30 auto -- timeout --signal=TERM --kill-after=5s 1500s pytest -n 6 test/kda/mega -q -p no:cacheprovider -W ignore
```