### PR TITLE
Fix CuTeDSL compatibility and affine-summary tails

### DIFF
--- a/attn_gym/linear/_delta_rule/cute/affine_summary_fwd.py
+++ b/attn_gym/linear/_delta_rule/cute/affine_summary_fwd.py
@@ -220,8 +220,9 @@ class _AffineSummaryFwdOp:
         # MMA1: w (A, K-major) × X snapshot (B, K-major) → wx.
         mma_wx = sm100_utils.make_trivial_tiled_mma(
             self.io_type,
-            tcgen05.OperandMajorMode.K,
-            tcgen05.OperandMajorMode.K,
+            self.io_type,
+            cute.nvgpu.OperandMajorMode.K,
+            cute.nvgpu.OperandMajorMode.K,
             Float32,
             tcgen05.CtaGroup.ONE,
             self.wx_tile[:2],
@@ -230,8 +231,9 @@ class _AffineSummaryFwdOp:
         # MMA2: kg^T (A, MN-major) × Tmp (B, K-major) → kt.
         mma_kt = sm100_utils.make_trivial_tiled_mma(
             self.io_type,
-            tcgen05.OperandMajorMode.MN,
-            tcgen05.OperandMajorMode.K,
+            self.io_type,
+            cute.nvgpu.OperandMajorMode.MN,
+            cute.nvgpu.OperandMajorMode.K,
             Float32,
             tcgen05.CtaGroup.ONE,
             self.kt_tile[:2],
@@ -241,8 +243,9 @@ class _AffineSummaryFwdOp:
         # Same accumulator tile as MMA2; only the B major mode differs.
         mma_ktu = sm100_utils.make_trivial_tiled_mma(
             self.io_type,
-            tcgen05.OperandMajorMode.MN,
-            tcgen05.OperandMajorMode.MN,
+            self.io_type,
+            cute.nvgpu.OperandMajorMode.MN,
+            cute.nvgpu.OperandMajorMode.MN,
             Float32,
             tcgen05.CtaGroup.ONE,
             self.kt_tile[:2],

--- a/attn_gym/linear/_delta_rule/cute/affine_summary_rev.py
+++ b/attn_gym/linear/_delta_rule/cute/affine_summary_rev.py
@@ -213,8 +213,9 @@ class BlackwellDeltaAffineSummaryRev:
         # MMA1: kg [BT,K] reads X [K,BN] to begin the local write gradient dv.
         mma_dv = sm100_utils.make_trivial_tiled_mma(
             self.io_type,
-            tcgen05.OperandMajorMode.K,
-            tcgen05.OperandMajorMode.K,
+            self.io_type,
+            cute.nvgpu.OperandMajorMode.K,
+            cute.nvgpu.OperandMajorMode.K,
             self.acc_type,
             self.cta_group,
             self.dv_tile[:2],
@@ -223,8 +224,9 @@ class BlackwellDeltaAffineSummaryRev:
         # MMA2: qg^T [K,BT] reads dO [BT,BN] for the direct query contribution.
         mma_qdo = sm100_utils.make_trivial_tiled_mma(
             self.io_type,
-            tcgen05.OperandMajorMode.MN,
-            tcgen05.OperandMajorMode.MN,
+            self.io_type,
+            cute.nvgpu.OperandMajorMode.MN,
+            cute.nvgpu.OperandMajorMode.MN,
             self.acc_type,
             self.cta_group,
             self.qdo_tile[:2],
@@ -233,8 +235,9 @@ class BlackwellDeltaAffineSummaryRev:
         # MMA3: Aqk^T [BT,BT] reads dO and accumulates the local term into dv.
         mma_aqdo = sm100_utils.make_trivial_tiled_mma(
             self.io_type,
-            tcgen05.OperandMajorMode.MN,
-            tcgen05.OperandMajorMode.MN,
+            self.io_type,
+            cute.nvgpu.OperandMajorMode.MN,
+            cute.nvgpu.OperandMajorMode.MN,
             self.acc_type,
             self.cta_group,
             self.aqdo_tile[:2],
@@ -243,8 +246,9 @@ class BlackwellDeltaAffineSummaryRev:
         # MMA4: w^T [K,BT] reads the completed dv for the subtractive WY term.
         mma_wdv = sm100_utils.make_trivial_tiled_mma(
             self.io_type,
-            tcgen05.OperandMajorMode.MN,
-            tcgen05.OperandMajorMode.K,
+            self.io_type,
+            cute.nvgpu.OperandMajorMode.MN,
+            cute.nvgpu.OperandMajorMode.K,
             self.acc_type,
             self.cta_group,
             self.wdv_tile[:2],
@@ -1429,7 +1433,9 @@ def build_state_grad_summary(
         )
         return out
 
-    qg, kg, w, dout, Aqk, cumulative_gate = (_aligned(tensor) for _name, tensor in inputs)
+    qg, kg, w, dout, Aqk, cumulative_gate = (
+        _aligned(tensor) for tensor in (qg, kg, w, dout, Aqk, cumulative_gate)
+    )
     use_int64_offsets = requires_int64_abi(qg, kg, w, dout, Aqk, cumulative_gate, out)
 
     state_tile_width = select_summary_tile_width(heads, qg.device)

--- a/attn_gym/linear/kda/bwd/cute/chunk_delta_h_bwd.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_delta_h_bwd.py
@@ -516,8 +516,9 @@ class BlackwellDeltaHBwd:
         # MMA1: k @ dh → dv  — k is (BT,BK) as A K-major, dh is (BK,BV) as B K-major
         mma_dv = sm100_utils.make_trivial_tiled_mma(
             self.io_type,
-            tcgen05.OperandMajorMode.K,  # A (k): K-major
-            tcgen05.OperandMajorMode.K,  # B (dh): K-major
+            self.io_type,
+            cute.nvgpu.OperandMajorMode.K,  # A (k): K-major
+            cute.nvgpu.OperandMajorMode.K,  # B (dh): K-major
             self.acc_type,
             self.cta_group,
             self.dv_tile[:2],  # (BT=64, BV=16)
@@ -526,8 +527,9 @@ class BlackwellDeltaHBwd:
         # MMA2: q^T @ do → qdo  — q^T is (BK,BT) A MN-major, do is (BT,BV) B MN-major
         mma_qdo = sm100_utils.make_trivial_tiled_mma(
             self.io_type,
-            tcgen05.OperandMajorMode.MN,  # A (q^T): MN-major
-            tcgen05.OperandMajorMode.MN,  # B (do): MN-major (V-contiguous)
+            self.io_type,
+            cute.nvgpu.OperandMajorMode.MN,  # A (q^T): MN-major
+            cute.nvgpu.OperandMajorMode.MN,  # B (do): MN-major (V-contiguous)
             self.acc_type,
             self.cta_group,
             self.qdo_tile[:2],  # (BK=128, BV=16)
@@ -537,8 +539,9 @@ class BlackwellDeltaHBwd:
         aqdo_tile = (self.BT, self.BV, self.BT)
         mma_aqdo = sm100_utils.make_trivial_tiled_mma(
             self.io_type,
-            tcgen05.OperandMajorMode.MN,
-            tcgen05.OperandMajorMode.MN,
+            self.io_type,
+            cute.nvgpu.OperandMajorMode.MN,
+            cute.nvgpu.OperandMajorMode.MN,
             self.acc_type,
             self.cta_group,
             aqdo_tile[:2],
@@ -548,8 +551,9 @@ class BlackwellDeltaHBwd:
         # MMA3: w @ dv2 → wdv  — w is (BK,BT) A MN-major, dv2 is (BT,BV) B K-major
         mma_wdv = sm100_utils.make_trivial_tiled_mma(
             self.io_type,
-            tcgen05.OperandMajorMode.MN,  # A (w^T): MN-major
-            tcgen05.OperandMajorMode.K,  # B (dv2): K-major
+            self.io_type,
+            cute.nvgpu.OperandMajorMode.MN,  # A (w^T): MN-major
+            cute.nvgpu.OperandMajorMode.K,  # B (dv2): K-major
             self.acc_type,
             self.cta_group,
             self.wdv_tile[:2],  # (BK=128, BV=16)

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_wy_dqkg_fused.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_wy_dqkg_fused.py
@@ -744,8 +744,9 @@ class ChunkKdaBwdWyDqkgFused:
         #    dq += do @ h, dk += vnew @ dh, dw += dv @ h
         vloop_tiled_mma = sm100_utils.make_trivial_tiled_mma(
             self.io_dtype,
-            tcgen05.OperandMajorMode.K,  # A: K-major
-            tcgen05.OperandMajorMode.K,  # B: K-major
+            self.io_dtype,
+            cute.nvgpu.OperandMajorMode.K,  # A: K-major
+            cute.nvgpu.OperandMajorMode.K,  # B: K-major
             self.acc_dtype,
             self.cta_group,
             self.vloop_gemm_tiler[:2],  # (64, 128)
@@ -756,8 +757,9 @@ class ChunkKdaBwdWyDqkgFused:
         #    dA += dv @ v^T, dA += dw @ kg^T
         dA_vloop_tiled_mma = sm100_utils.make_trivial_tiled_mma(
             self.io_dtype,
-            tcgen05.OperandMajorMode.K,
-            tcgen05.OperandMajorMode.K,
+            self.io_dtype,
+            cute.nvgpu.OperandMajorMode.K,
+            cute.nvgpu.OperandMajorMode.K,
             self.acc_dtype,
             self.cta_group,
             self.dA_vloop_tiler[:2],  # (64, 64)
@@ -768,8 +770,9 @@ class ChunkKdaBwdWyDqkgFused:
         #    dvb = A @ dv, dkgb = A @ dw
         dvb_tiled_mma = sm100_utils.make_trivial_tiled_mma(
             self.io_dtype,
-            tcgen05.OperandMajorMode.MN,
-            tcgen05.OperandMajorMode.MN,
+            self.io_dtype,
+            cute.nvgpu.OperandMajorMode.MN,
+            cute.nvgpu.OperandMajorMode.MN,
             self.acc_dtype,
             self.cta_group,
             self.dvb_tiler[:2],  # (64, 64)
@@ -778,8 +781,9 @@ class ChunkKdaBwdWyDqkgFused:
         # dkgb_tiled_mma: SS MN,MN (64,128) - dkgb
         dkgb_tiled_mma = sm100_utils.make_trivial_tiled_mma(
             self.io_dtype,
-            tcgen05.OperandMajorMode.MN,
-            tcgen05.OperandMajorMode.MN,
+            self.io_dtype,
+            cute.nvgpu.OperandMajorMode.MN,
+            cute.nvgpu.OperandMajorMode.MN,
             self.acc_dtype,
             self.cta_group,
             self.kloop_dkgb_tiler[:2],  # (64, 128)
@@ -789,8 +793,9 @@ class ChunkKdaBwdWyDqkgFused:
         # dA += dw @ kg^T
         dA_kloop_tiled_mma = sm100_utils.make_trivial_tiled_mma(
             self.io_dtype,
-            tcgen05.OperandMajorMode.K,
-            tcgen05.OperandMajorMode.K,
+            self.io_dtype,
+            cute.nvgpu.OperandMajorMode.K,
+            cute.nvgpu.OperandMajorMode.K,
             self.acc_dtype,
             self.cta_group,
             self.kloop_dA_tiler[:2],  # (64, 64)
@@ -800,8 +805,9 @@ class ChunkKdaBwdWyDqkgFused:
         # dA = dA @ A
         dA2post_tiled_mma = sm100_utils.make_trivial_tiled_mma(
             self.io_dtype,
-            tcgen05.OperandMajorMode.K,
-            tcgen05.OperandMajorMode.K,
+            self.io_dtype,
+            cute.nvgpu.OperandMajorMode.K,
+            cute.nvgpu.OperandMajorMode.K,
             self.acc_dtype,
             self.cta_group,
             self.dApost_tiler[:2],  # (64, 64)
@@ -812,8 +818,9 @@ class ChunkKdaBwdWyDqkgFused:
         # dA = A @ dA
         dA3post_tiled_mma = sm100_utils.make_trivial_tiled_mma(
             self.io_dtype,
-            tcgen05.OperandMajorMode.MN,
-            tcgen05.OperandMajorMode.MN,
+            self.io_dtype,
+            cute.nvgpu.OperandMajorMode.MN,
+            cute.nvgpu.OperandMajorMode.MN,
             self.acc_dtype,
             self.cta_group,
             self.dApost_tiler[:2],  # (64, 64)

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_intra_engine.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_intra_engine.py
@@ -254,8 +254,9 @@ class KdaIntraFwdEngine:
 
         mma_s = sm100_utils.make_trivial_tiled_mma(
             self.io_type,
-            tcgen05.OperandMajorMode.K,
-            tcgen05.OperandMajorMode.K,
+            self.io_type,
+            cute.nvgpu.OperandMajorMode.K,
+            cute.nvgpu.OperandMajorMode.K,
             self.acc_type,
             self.cta_group,
             self.s_tile[:2],
@@ -267,8 +268,9 @@ class KdaIntraFwdEngine:
         strip_tile = (self.mma_rows, 16, BK)
         mma16 = sm100_utils.make_trivial_tiled_mma(
             self.io_type,
-            tcgen05.OperandMajorMode.K,
-            tcgen05.OperandMajorMode.K,
+            self.io_type,
+            cute.nvgpu.OperandMajorMode.K,
+            cute.nvgpu.OperandMajorMode.K,
             self.acc_type,
             self.cta_group,
             strip_tile[:2],

--- a/attn_gym/linear/kda/fwd/cute/recompute_w_u_fwd.py
+++ b/attn_gym/linear/kda/fwd/cute/recompute_w_u_fwd.py
@@ -157,16 +157,16 @@ def _mma_config(precision: MmaPrecision):
             MMA_INST_SHAPE_MNK_BF16,
             tcgen05.CtaGroup.ONE,
             tcgen05.OperandSource.SMEM,
-            tcgen05.OperandMajorMode.K,
-            tcgen05.OperandMajorMode.MN,
+            cute.nvgpu.OperandMajorMode.K,
+            cute.nvgpu.OperandMajorMode.MN,
         )
         return op, cutlass.BFloat16
     op = tcgen05.MmaTF32Op(
         MMA_INST_SHAPE_MNK,
         tcgen05.CtaGroup.ONE,
         tcgen05.OperandSource.SMEM,
-        tcgen05.OperandMajorMode.K,
-        tcgen05.OperandMajorMode.MN,
+        cute.nvgpu.OperandMajorMode.K,
+        cute.nvgpu.OperandMajorMode.MN,
     )
     return op, MMA_DTYPE
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ source = "vcs"
 # ---------- PYTEST ------------
 [tool.pytest.ini_options]
 testpaths = ["test"]
+norecursedirs = ["agent_space"]
 markers = ["full_autotune: exercise every production Triton autotuning candidate"]
 
 # ---------- RUFF ------------


### PR DESCRIPTION
## Human Note

## Agent note

Migrate the maintained Blackwell KDA kernels to the current CuTeDSL operand-major namespace and the
separate A/B dtype overload for `make_trivial_tiled_mma`. Both APIs are available at the repository's
CuTeDSL 4.5.0 minimum, and the updated kernels were exercised with 4.6.2 and 4.7.1.

Fix reverse affine-summary tail handling: the wrapper padded the tensors but later aligned and
launched a tuple captured before padding, causing non-multiple-of-64 lengths such as T=65 to fail the
TVM-FFI divisibility contract. Also exclude the ignored `agent_space` directory from recursive pytest
collection so `pytest .` does not collect local scratch repros.

The broad run excludes `test_sandwich_flex_flash_backend`, an independently reproduced current
Torch/FlashAttention regression: dynamic compilation rejects its captured scalar, while static and
capture-free variants compile but produce incorrect FlexFlash output. Plain and causal FlexFlash
controls pass, so that issue is intentionally not papered over here.

## Test Plan

```bash
CUTE_DSL_NO_CACHE=1 pytest -n 6 test/test_delta_affine_summary.py -q
CC=/opt/rh/gcc-toolset-15/root/usr/bin/gcc CXX=/opt/rh/gcc-toolset-15/root/usr/bin/g++ pytest -n 6 -k "not test_sandwich_flex_flash_backend" -q
pytest --collect-only -q .
prek run --all-files
```
