### PR TITLE
Strengthen delta-rule numerical contracts

### DIFF
--- a/attn_gym/testing/kda.py
+++ b/attn_gym/testing/kda.py
@@ -155,24 +155,44 @@ def assert_matches_low_precision_reference(
     name: str,
     *,
     source_dtype: torch.dtype = torch.bfloat16,
-    rms: bool = False,
 ) -> None:
-    """Bound kernel error by the reference error and source-operand precision."""
+    """Bound pointwise kernel error by reference error and source precision."""
     high_precision = high_precision.double()
-    if rms:
-        error = lambda value: value.square().mean().sqrt().item()
-        reference_scale = error(high_precision)
-    else:
-        error = lambda value: value.abs().max().item()
-        reference_scale = high_precision.abs().max().item()
-    rounding_band = torch.finfo(source_dtype).eps * reference_scale
-    actual_error = error(actual.double() - high_precision)
-    reference_error = error(low_precision.double() - high_precision)
+    rounding_band = torch.finfo(source_dtype).eps * high_precision.abs().max().item()
+    actual_error = (actual.double() - high_precision).abs().max().item()
+    reference_error = (low_precision.double() - high_precision).abs().max().item()
     budget = 2 * (reference_error + rounding_band)
     assert torch.isfinite(actual).all(), f"{name}: kernel output contains non-finite values"
     assert actual_error <= budget, (
         f"{name}: kernel error {actual_error:.3e} exceeds {budget:.3e} "
         f"(reference error {reference_error:.3e})"
+    )
+
+
+def assert_relative_rms_within(
+    actual: torch.Tensor,
+    expected: torch.Tensor,
+    name: str,
+    *,
+    max_eps: float,
+    source_dtype: torch.dtype = torch.bfloat16,
+) -> None:
+    """Bound aggregate relative RMS error in units of source-dtype epsilon.
+
+    A zero reference has a zero budget and therefore requires an exactly zero result.
+    """
+    assert torch.isfinite(actual).all(), f"{name}: kernel output contains non-finite values"
+    expected = expected.double()
+    error = (actual.double() - expected).square().mean().sqrt().item()
+    scale = expected.square().mean().sqrt().item()
+    if scale == 0:
+        assert error == 0, f"{name}: expected exact zero, got RMS error {error:.3e}"
+        return
+    relative_error = error / scale
+    limit = max_eps * torch.finfo(source_dtype).eps
+    assert relative_error <= limit, (
+        f"{name}: relative RMS error {relative_error:.3e} exceeds {limit:.3e} "
+        f"({relative_error / torch.finfo(source_dtype).eps:.2f} {source_dtype} eps)"
     )
 
 
@@ -380,6 +400,7 @@ def bwd_wy_dqkg_reference(
 
 __all__ = [
     "assert_matches_low_precision_reference",
+    "assert_relative_rms_within",
     "bwd_daqk_reference",
     "bwd_intra_reference",
     "bwd_wy_dqkg_reference",

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -9,11 +9,13 @@ for an existing helper:
 - `cumulative_sequence_offsets(lengths)` — packed `cu_seqlens` boundary tensors
 - `make_kda_test_inputs(tokens, ...)` / `clone_kda_inputs(...)` — public KDA operands
   with production dtypes and independent autograd leaves
-- `assert_matches_low_precision_reference(...)` — data-derived error budgets instead of
-  hand-tuned rtol/atol
+- `assert_matches_low_precision_reference(...)` — data-derived pointwise error budgets
+- `assert_relative_rms_within(...)` — aggregate error budgets measured in source-dtype epsilon
 - fp64 backward oracles (`bwd_intra_reference`, `bwd_wy_dqkg_reference`, ...)
 
 When a helper you are about to write would have a second caller — or duplicates the
 shape/dtype/seed conventions of an existing one — add or extend it in
 `attn_gym/testing/` instead of keeping a private copy in the test file. Local `_inputs`
-style helpers are fine only for operand sets no shared factory covers.
+style helpers are fine only for operand sets no shared factory covers. Numerical kernel
+contracts should pair a pointwise maximum-error check with an aggregate relative-RMS check;
+either metric alone can hide a different class of regression.

--- a/test/kda/mega/test_delta_rule_numerics.py
+++ b/test/kda/mega/test_delta_rule_numerics.py
@@ -10,11 +10,12 @@ pytest.importorskip(
     reason="the Mega numerical tests require nvidia-cutlass-dsl>=4.7",
 )
 
-from attn_gym.linear import chunk_gdn, chunk_kda
+from attn_gym.linear import chunk_gdn, chunk_kda, recurrent_gdn
 from attn_gym.linear.kda.impl.mega_ops import chunk_mega_packed_local_bwd_op
 from attn_gym.testing import make_gdn_test_inputs
 from attn_gym.testing.kda import (
     assert_matches_low_precision_reference,
+    assert_relative_rms_within,
     clone_kda_inputs,
     kda_reference,
     make_kda_test_inputs,
@@ -27,6 +28,10 @@ pytestmark = pytest.mark.skipif(
 
 _MEGA = {"backend": "mega"}
 _GRADIENT_NAMES = ("dq", "dk", "dv", "dgate", "dbeta")
+# On GB200, healthy GDN/KDA paths measure at most 0.82 BF16 eps; the superseded
+# KDA rounding path measures 1.97--2.13 eps for dGate. This limit retains at least
+# 1.5x headroom from both ranges without encoding a different constant per result.
+_RMS_EPS_LIMIT = 1.25
 
 
 def _d_output_like(output: torch.Tensor, seed: int) -> torch.Tensor:
@@ -43,12 +48,10 @@ def _gdn_result(
 ) -> tuple[torch.Tensor, tuple[torch.Tensor, ...]]:
     """Run GDN through Mega or its eager recurrence and differentiate the output."""
     leaves = clone_kda_inputs(inputs, dtype=precision)
-    fused = precision is None
-    output = chunk_gdn(
-        *leaves,
-        impl="fused" if fused else "reference",
-        kernel_options=_MEGA if fused else None,
-    )[0]
+    if precision is None:
+        output = chunk_gdn(*leaves, impl="fused", kernel_options=_MEGA)[0]
+    else:
+        output = recurrent_gdn(*leaves, impl="reference")[0]
     return output, torch.autograd.grad(output, leaves, d_output.to(output.dtype))
 
 
@@ -64,15 +67,30 @@ def _kda_result(
     return output, torch.autograd.grad(output, leaves, d_output.to(output.dtype))
 
 
+def _assert_value(
+    actual: torch.Tensor,
+    high_precision: torch.Tensor,
+    low_precision: torch.Tensor,
+    name: str,
+) -> None:
+    """Check localized error and aggregate error measured in BF16 epsilon."""
+    assert_matches_low_precision_reference(actual, high_precision, low_precision, name)
+    assert_relative_rms_within(
+        actual,
+        high_precision,
+        name,
+        max_eps=_RMS_EPS_LIMIT,
+        source_dtype=torch.bfloat16,
+    )
+
+
 def _assert_result(
     actual: tuple[torch.Tensor, tuple[torch.Tensor, ...]],
     low_precision: tuple[torch.Tensor, tuple[torch.Tensor, ...]],
     high_precision: tuple[torch.Tensor, tuple[torch.Tensor, ...]],
 ) -> None:
     """Check an output and all gradients against the low- and high-precision oracles."""
-    assert_matches_low_precision_reference(
-        actual[0], high_precision[0], low_precision[0], "output", rms=True
-    )
+    _assert_value(actual[0], high_precision[0], low_precision[0], "output")
     for name, value, high, low in zip(
         _GRADIENT_NAMES,
         actual[1],
@@ -80,7 +98,48 @@ def _assert_result(
         low_precision[1],
         strict=True,
     ):
-        assert_matches_low_precision_reference(value, high, low, name, rms=True)
+        _assert_value(value, high, low, name)
+
+
+@pytest.mark.parametrize("family", ("gdn", "kda"))
+def test_mega_exact_orthogonal_writes(family: str) -> None:
+    """Orthogonal unit writes must cross all chunk boundaries without rounding."""
+    identity = torch.eye(128, device="cuda", dtype=torch.bfloat16)
+    k = identity[None, :, None, :]
+    q = identity.roll(64, dims=0)[None, :, None, :]
+    value = identity.roll(1, dims=-1)[None, :, None, :]
+    beta = torch.ones(1, 128, 1, device="cuda")
+    gate = torch.zeros_like(q, dtype=torch.float32) if family == "kda" else torch.zeros_like(beta)
+
+    if family == "gdn":
+        output, state = chunk_gdn(
+            q,
+            k,
+            value,
+            gate,
+            beta,
+            scale=1.0,
+            output_final_state=True,
+            impl="fused",
+            kernel_options=_MEGA,
+        )
+    else:
+        output, state = chunk_kda(
+            q,
+            k,
+            value,
+            gate,
+            beta,
+            scale=1.0,
+            output_final_state=True,
+            kernel_options=_MEGA,
+        )
+
+    expected_output = value.roll(64, dims=1)
+    expected_output[:, :64] = 0
+    assert state is not None
+    assert torch.equal(output, expected_output)
+    assert torch.equal(state, value[0, :, 0].T[None, None].to(state.dtype))
 
 
 @pytest.mark.parametrize("seed", (888, 889, 890))
@@ -101,8 +160,8 @@ def test_gdn_mega_model_range_backward(seed: int) -> None:
 
 
 @pytest.mark.parametrize("seed", (888, 889, 890))
-def test_kda_mega_model_range_backward(seed: int) -> None:
-    """KDA output and gradients must remain within the BF16 reference error budget."""
+def test_kda_mega_forward_and_public_backward_model_range(seed: int) -> None:
+    """Mega forward and the public fallback backward must meet the BF16 error budget."""
     inputs = make_kda_test_inputs(128, heads=2, seed=seed, requires_grad=True)
     d_output = _d_output_like(inputs[2], seed + 1)
     actual_inputs = clone_kda_inputs(inputs)
@@ -113,28 +172,26 @@ def test_kda_mega_model_range_backward(seed: int) -> None:
     _assert_result(actual, low_precision, high_precision)
 
 
-def test_kda_mega_raw_backward_precision() -> None:
+@pytest.mark.parametrize("seed", (888, 889, 890))
+def test_kda_mega_raw_backward_precision(seed: int) -> None:
     """Raw Mega backward must stay within the BF16 reference error budget."""
-    for seed in (888, 889, 890):
-        inputs = make_kda_test_inputs(128, heads=2, seed=seed, requires_grad=True)
-        d_output = _d_output_like(inputs[2], seed + 1)
-        cu_seqlens = torch.tensor([0, 128], device="cuda", dtype=torch.int32)
-        gradients = chunk_mega_packed_local_bwd_op(
-            *inputs,
-            d_output,
-            cu_seqlens,
-            False,
-            128**-0.5,
-        )
-        low_precision = _kda_result(inputs, d_output, precision=torch.float32)[1]
-        high_precision = _kda_result(inputs, d_output, precision=torch.float64)[1]
-        for name, value, high, low in zip(
-            _GRADIENT_NAMES,
-            gradients,
-            high_precision,
-            low_precision,
-            strict=True,
-        ):
-            assert_matches_low_precision_reference(
-                value, high, low, f"seed={seed} {name}", rms=True
-            )
+    inputs = make_kda_test_inputs(128, heads=2, seed=seed, requires_grad=True)
+    d_output = _d_output_like(inputs[2], seed + 1)
+    cu_seqlens = torch.tensor([0, 128], device="cuda", dtype=torch.int32)
+    gradients = chunk_mega_packed_local_bwd_op(
+        *inputs,
+        d_output,
+        cu_seqlens,
+        False,
+        128**-0.5,
+    )
+    low_precision = _kda_result(inputs, d_output, precision=torch.float32)[1]
+    high_precision = _kda_result(inputs, d_output, precision=torch.float64)[1]
+    for name, value, high, low in zip(
+        _GRADIENT_NAMES,
+        gradients,
+        high_precision,
+        low_precision,
+        strict=True,
+    ):
+        _assert_value(value, high, low, f"seed={seed} {name}")

--- a/test/test_kda.py
+++ b/test/test_kda.py
@@ -10,6 +10,17 @@ from attn_gym.linear.kda.naive import (
     naive_chunk_kda,
     naive_recurrent_kda,
 )
+from attn_gym.testing.kda import assert_relative_rms_within
+
+
+def test_relative_rms_zero_reference_requires_exact_zero() -> None:
+    """A zero reference must not give small nonzero results an artificial budget."""
+    expected = torch.zeros(4)
+    assert_relative_rms_within(expected, expected, "zero", max_eps=1.25)
+
+    tiny_nonzero = torch.full_like(expected, torch.finfo(torch.bfloat16).tiny)
+    with pytest.raises(AssertionError, match="expected exact zero"):
+        assert_relative_rms_within(tiny_nonzero, expected, "zero", max_eps=1.25)
 
 
 def make_inputs(seq_len: int) -> tuple[torch.Tensor, ...]:


### PR DESCRIPTION
Strengthen delta-rule numerical contracts

## Human Note

## Agent note

Keep the existing independent GDN and KDA references as the semantic oracles, and add an aggregate error contract expressed in BF16 epsilon alongside the existing pointwise bound. The calibrated 1.25-epsilon limit leaves at least 1.5x separation between the corrected and superseded Mega KDA dGate paths. Add an exact orthogonal-write case that exercises state transport across GDN and KDA chunk boundaries, use the recurrent GDN reference for independence, and parameterize raw-backward seeds for isolated failures.

## Test Plan

```bash
gpu-run --timeout 60 auto -- env CUTE_DSL_NO_CACHE=1 pytest -q test/kda/mega/test_delta_rule_numerics.py -p no:cacheprovider -W ignore
gpu-run --timeout 120 auto -- pytest -n 6 -q test/kda/mega -p no:cacheprovider -W ignore
gpu-run --timeout 120 auto -- pytest -n 6 -q test/gdn/mega -p no:cacheprovider -W ignore
```