### PR TITLE
Use static ragged KDA output scheduling on Hopper

### DIFF
--- a/attn_gym/linear/kda/fwd/triton/chunk_gla_fwd_o.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_gla_fwd_o.py
@@ -16,6 +16,7 @@ import triton
 import triton.language as tl
 from triton.tools.tensor_descriptor import TensorDescriptor
 
+from attn_gym._backends.cute.utils import get_device_properties
 from attn_gym._backends.triton.utils import (
     PinnedConfigKernel,
     can_use_tma,
@@ -502,6 +503,17 @@ def _can_use_tensor_descriptors(*tensors: torch.Tensor) -> bool:
 _PINNED_FWD_O = PinnedConfigKernel(chunk_gla_fwd_kernel_o)
 
 
+def _select_ragged_output_schedule_kind(
+    request: ScheduleRequest,
+    resolved_kind: ScheduleKind,
+    device_major: int,
+) -> ScheduleKind:
+    """Keep Hopper on its faster static ragged-TMA launch under automatic selection."""
+    if request is ScheduleRequest.AUTO and device_major == 9:
+        return ScheduleKind.STATIC
+    return resolved_kind
+
+
 def chunk_gla_fwd_o_gk(
     q: torch.Tensor,
     v: torch.Tensor,
@@ -631,7 +643,12 @@ def chunk_gla_fwd_o_gk(
                 # past the dense register budget and loses a resident CTA.
                 "maxnreg": 136,
             }
-            if resolved.kind is ScheduleKind.PERSISTENT:
+            schedule_kind = _select_ragged_output_schedule_kind(
+                schedule,
+                resolved.kind,
+                get_device_properties(q.device).major,
+            )
+            if schedule_kind is ScheduleKind.PERSISTENT:
                 chunk_gla_fwd_kernel_o_ragged_tma_persistent[(resolved.workers,)](
                     *args, num_workers=resolved.workers, **kwargs
                 )

--- a/test/test_kda_ragged_output.py
+++ b/test/test_kda_ragged_output.py
@@ -6,12 +6,36 @@ import pytest
 import torch
 
 import attn_gym.linear.kda.fwd.triton.chunk_gla_fwd_o as output_module
-from attn_gym.linear.kda.chunk_scheduler import ScheduleRequest, prepare_ragged_chunk_metadata
+from attn_gym.linear.kda.chunk_scheduler import (
+    ScheduleKind,
+    ScheduleRequest,
+    prepare_ragged_chunk_metadata,
+)
 
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available(),
     reason="the KDA output kernel requires CUDA",
 )
+
+
+@pytest.mark.parametrize(
+    ("schedule_request", "resolved", "device_major", "expected"),
+    [
+        (ScheduleRequest.AUTO, ScheduleKind.PERSISTENT, 9, ScheduleKind.STATIC),
+        (ScheduleRequest.AUTO, ScheduleKind.PERSISTENT, 10, ScheduleKind.PERSISTENT),
+        (ScheduleRequest.PERSISTENT, ScheduleKind.PERSISTENT, 9, ScheduleKind.PERSISTENT),
+        (ScheduleRequest.STATIC, ScheduleKind.STATIC, 9, ScheduleKind.STATIC),
+    ],
+)
+def test_ragged_output_schedule_selection(schedule_request, resolved, device_major, expected):
+    assert (
+        output_module._select_ragged_output_schedule_kind(
+            schedule_request,
+            resolved,
+            device_major,
+        )
+        is expected
+    )
 
 
 def _reference(


### PR DESCRIPTION
Use static ragged KDA output scheduling on Hopper

## Human Note

## Agent note

The generic over-capture scheduler selects the persistent ragged-TMA output kernel for the
Qwen3-8B Hopper workload. On H100, the bounded worker loop is consistently slower than launching
the existing static capacity grid, including sparse active-prefix cases where the two approaches
reach parity.

Keep automatic Hopper selection on the static ragged-TMA kernel while preserving explicit schedule
requests and the existing Blackwell policy. A small pure selector test pins the architecture and
request behavior.

## Performance

BF16 H100, K=V=128, BT=64, fixed-pointer warm-buffer timing:

| Workload | Static | Persistent | Speedup |
|---|---:|---:|---:|
| T=6144, H=32, 7/128 active sequences | 151.6 us | 201.1 us | 1.33x |

A 13-case sweep over T=4096-16384, H=16/32/64, full and sparse active prefixes, and
32/128/256 sequence slots found static 1.19-1.44x faster for normal workloads and within 1% of
persistent at the most sparse points.

## Test Plan

```bash
.venv/bin/pytest test/test_kda_ragged_output.py
.venv/bin/pytest -n 6 test/test_kda_ragged_public_backward.py
prek --files attn_gym/linear/kda/fwd/triton/chunk_gla_fwd_o.py test/test_kda_ragged_output.py
```
