### PR TITLE
Add staged delta-rule primitives and a context-parallel recipe for KDA and GDN

### DIFF
--- a/attn_gym/linear/context_parallel.py
+++ b/attn_gym/linear/context_parallel.py
@@ -1,0 +1,455 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Context parallelism for delta-rule attention: ownership plans, state routing, one recipe.
+
+Data model. The global packed stream is a list of sequences. Each rank owns any set of global token
+ranges and lays them out back to back as its local packed input. The plan cuts those ranges at
+sequence boundaries into :class:`Fragment` pieces, one local ``cu_seqlens`` segment each, so
+contiguous shards, zig-zag load balancing, and document-aligned partitions are just different range
+lists. Because the recurrence is affine (see ``attn_gym.linear.state_summary``), a fragment's entry
+state is its predecessors' summaries folded from zero and its exit cotangent is its successors'
+reverse summaries folded from zero.
+
+Communication model. Every rank fills ``plan.slots`` summary slots in local order (identity where
+nobody downstream needs one) and all-gathers them once per direction, so every
+``gathered[rank][slot]`` index is a host-static integer and CUDA Graph capture works as long as the
+plan does not change. The short-convolution halo reuses the plan: each fragment's history is the
+tail of its predecessor fragments.
+
+Ops. ``context_parallel_chunk`` is generic over the delta-rule variant through a :class:`StagedOp`
+pair of ``prepare`` / ``prepare_backward`` callables whose handles expose ``state_summary``,
+``run``, and ``saved`` (``attn_gym.linear.kda.stages``, ``attn_gym.linear.gdn.stages``). It is one
+recipe, not an extension point: for a point-to-point pipeline, a recursive-doubling scan over
+``compose_summaries``, DTensor, or communication overlap, copy the autograd function and swap the
+collective.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from typing import NamedTuple, Protocol
+
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch.distributed._functional_collectives import all_gather_single
+
+from attn_gym.linear.kda.utils import profiler_range
+from attn_gym.linear.state_summary import merge_state, neutral_summary
+
+
+@dataclass(frozen=True)
+class Fragment:
+    """A contiguous global token range ``[start, stop)`` lying inside one logical sequence."""
+
+    sequence: int
+    start: int
+    stop: int
+
+    @property
+    def length(self) -> int:
+        return self.stop - self.start
+
+
+# ``(rank, slot)`` address of a fragment in every rank's gathered buffer.
+Slot = tuple[int, int]
+
+
+def _cut_at_sequences(
+    global_cu_seqlens: Sequence[int], token_ranges: Sequence[tuple[int, int]]
+) -> tuple[Fragment, ...]:
+    fragments = []
+    for range_start, range_stop in token_ranges:
+        for sequence, (seq_start, seq_stop) in enumerate(pairwise(global_cu_seqlens)):
+            start, stop = max(range_start, seq_start), min(range_stop, seq_stop)
+            if start < stop:
+                fragments.append(Fragment(sequence, start, stop))
+    return tuple(fragments)
+
+
+def _validate_tiling(
+    global_cu_seqlens: Sequence[int], token_ranges: Sequence[Sequence[tuple[int, int]]]
+) -> None:
+    """Require the ranks' token ranges to tile ``[0, total_tokens)`` exactly once."""
+    if len(global_cu_seqlens) < 2 or global_cu_seqlens[0] != 0:
+        raise ValueError("global_cu_seqlens must start at zero and contain at least one sequence")
+    if any(end < start for start, end in pairwise(global_cu_seqlens)):
+        raise ValueError("global_cu_seqlens must be nondecreasing")
+    if not token_ranges or any(not ranges for ranges in token_ranges):
+        raise ValueError("every rank must own at least one token range")
+    for start, stop in (bounds for ranges in token_ranges for bounds in ranges):
+        if start >= stop:
+            raise ValueError(f"token range [{start}, {stop}) is empty")
+    ordered = sorted(bounds for ranges in token_ranges for bounds in ranges)
+    covered = [0, *(stop for _, stop in ordered)]
+    starts = [start for start, _ in ordered]
+    if starts != covered[:-1] or covered[-1] != global_cu_seqlens[-1]:
+        raise ValueError(
+            f"token ranges must tile [0, {global_cu_seqlens[-1]}) exactly once, got {ordered}"
+        )
+
+
+@dataclass(frozen=True)
+class ContextParallelPlan:
+    """Host-static routing for one rank derived from every rank's token ownership.
+
+    Attributes:
+        table: ``table[rank][slot]`` is the fragment at local packed segment ``slot`` on ``rank``.
+        rank: This rank's row in ``table``.
+        fragments: This rank's fragments in local packed order.
+        cu_seqlens: Local packed offsets, one segment per fragment.
+        slots: Gather slots per rank, ``max(len(row) for row in table)``.
+        predecessors: Per local fragment, the addresses of the same sequence's earlier fragments
+            in increasing token order.
+        successors: Per local fragment, the addresses of the same sequence's later fragments in
+            decreasing token order, i.e. the order a reverse fold visits them.
+        terminal: Local indices of fragments that end their sequence, whose exit states are the
+            sequence's true final states.
+    """
+
+    table: tuple[tuple[Fragment, ...], ...]
+    rank: int
+    fragments: tuple[Fragment, ...]
+    cu_seqlens: tuple[int, ...]
+    slots: int
+    predecessors: tuple[tuple[Slot, ...], ...]
+    successors: tuple[tuple[Slot, ...], ...]
+    terminal: tuple[int, ...]
+
+    @classmethod
+    def from_token_ranges(
+        cls,
+        global_cu_seqlens: Sequence[int],
+        token_ranges: Sequence[Sequence[tuple[int, int]]],
+        rank: int,
+    ) -> ContextParallelPlan:
+        """Build ``rank``'s plan from every rank's half-open global token ranges.
+
+        ``token_ranges[rank]`` lists the ranges in the order that rank lays them out locally; the
+        plan cuts each range at sequence boundaries. Together the ranges must cover
+        ``[0, total_tokens)`` exactly once.
+        """
+        _validate_tiling(global_cu_seqlens, token_ranges)
+        if not 0 <= rank < len(token_ranges):
+            raise ValueError(f"rank {rank} is outside a table of {len(token_ranges)} ranks")
+        table = tuple(_cut_at_sequences(global_cu_seqlens, ranges) for ranges in token_ranges)
+        addresses = {
+            fragment: (owner, slot)
+            for owner, row in enumerate(table)
+            for slot, fragment in enumerate(row)
+        }
+        by_sequence: dict[int, list[Fragment]] = {}
+        for fragment in addresses:
+            by_sequence.setdefault(fragment.sequence, []).append(fragment)
+        for siblings in by_sequence.values():
+            siblings.sort(key=lambda fragment: fragment.start)
+
+        local = table[rank]
+        predecessors, successors, terminal = [], [], []
+        for index, fragment in enumerate(local):
+            siblings = by_sequence[fragment.sequence]
+            earlier = [f for f in siblings if f.start < fragment.start]
+            later = [f for f in siblings if f.start > fragment.start]
+            predecessors.append(tuple(addresses[f] for f in earlier))
+            successors.append(tuple(addresses[f] for f in reversed(later)))
+            if not later:
+                terminal.append(index)
+        return cls(
+            table=table,
+            rank=rank,
+            fragments=local,
+            cu_seqlens=tuple(accumulate((f.length for f in local), initial=0)),
+            slots=max(len(row) for row in table),
+            predecessors=tuple(predecessors),
+            successors=tuple(successors),
+            terminal=tuple(terminal),
+        )
+
+    def global_token_ids(self, device: torch.device | str) -> torch.Tensor:
+        """Global token id of every local token, for slicing global tensors into local ones."""
+        return torch.cat([torch.arange(f.start, f.stop, device=device) for f in self.fragments])
+
+
+def _check_group(plan: ContextParallelPlan, group: dist.ProcessGroup, tokens: int) -> None:
+    """Reject a plan built for a different group, rank, or local token count (host-only)."""
+    if dist.get_world_size(group) != len(plan.table):
+        raise ValueError(
+            f"plan has {len(plan.table)} ranks but the group has {dist.get_world_size(group)}"
+        )
+    if dist.get_rank(group) != plan.rank:
+        raise ValueError(f"plan was built for rank {plan.rank}, running on {dist.get_rank(group)}")
+    if tokens != plan.cu_seqlens[-1]:
+        raise ValueError(
+            f"plan owns {plan.cu_seqlens[-1]} local tokens but the input has {tokens}"
+        )
+
+
+def _all_gather_slots(local_slots: torch.Tensor, group: dist.ProcessGroup) -> torch.Tensor:
+    """Gather every rank's ``[slots, ...]`` buffer into ``[world, slots, ...]``."""
+    gathered = local_slots.new_empty(dist.get_world_size(group), *local_slots.shape)
+    with profiler_range("cp/all_gather"):
+        dist.all_gather_single(gathered, local_slots.contiguous(), group=group)
+    return gathered
+
+
+def _fold_chains(gathered: torch.Tensor, chains: Sequence[Sequence[Slot]]) -> list[torch.Tensor]:
+    """Apply each chain of gathered summaries to the zero state, sharing common prefixes.
+
+    Fragments of one sequence fold through the same earlier fragments in the same order, so a
+    rank that owns many pieces of one sequence needs O(pieces) merges, not O(pieces**2).
+    """
+    heads, packed, key_dim = gathered.shape[-3:]
+    zero = gathered.new_zeros(heads, packed - key_dim, key_dim)
+    after: dict[tuple[Slot, ...], torch.Tensor] = {(): zero}
+    states = []
+    for chain in chains:
+        prefix = tuple(chain)
+        for length in range(1, len(prefix) + 1):
+            if prefix[:length] not in after:
+                after[prefix[:length]] = merge_state(
+                    after[prefix[: length - 1]], gathered[prefix[length - 1]]
+                )
+        states.append(after[prefix])
+    return states
+
+
+def compose_entry_states(gathered: torch.Tensor, plan: ContextParallelPlan) -> torch.Tensor:
+    """Fold each local fragment's predecessor summaries from the zero state.
+
+    ``gathered`` is ``[world, slots, HV, V + K, K]``; the result is ``[N, HV, V, K]``.
+    """
+    return torch.stack(_fold_chains(gathered, plan.predecessors))
+
+
+def compose_exit_cotangents(
+    gathered: torch.Tensor,
+    d_final_state: torch.Tensor | None,
+    plan: ContextParallelPlan,
+) -> torch.Tensor:
+    """Fold each local fragment's successor reverse summaries onto its own exit cotangent."""
+    incoming = torch.stack(_fold_chains(gathered, plan.successors))
+    return incoming if d_final_state is None else incoming + d_final_state
+
+
+def compose_conv_histories(
+    gathered_tails: torch.Tensor, plan: ContextParallelPlan
+) -> torch.Tensor:
+    """Build each local fragment's ``W - 1`` token history from predecessor tails.
+
+    ``gathered_tails`` is ``[world, slots, W - 1, C]`` where each slot holds the last ``W - 1``
+    tokens of that fragment, front-padded with zeros when the fragment is shorter. Concatenating
+    predecessor tails in token order and keeping the last valid tokens yields exactly the tokens
+    preceding the fragment, however short the predecessors are.
+    """
+    history_length = gathered_tails.shape[-2]
+    histories = []
+    for sources in plan.predecessors:
+        pieces = [
+            gathered_tails[owner, slot, -min(history_length, plan.table[owner][slot].length) :]
+            for owner, slot in sources
+        ]
+        history = gathered_tails.new_zeros(history_length, gathered_tails.shape[-1])
+        valid = min(history_length, sum(piece.shape[0] for piece in pieces))
+        if valid:
+            history = torch.cat((history[:-valid], torch.cat(pieces)[-valid:]))
+        histories.append(history)
+    # Every rank must stay in the collective's backward, even one whose fragments all start
+    # sequences; the zero-weighted term keeps the reduce-scatter in its graph.
+    return torch.stack(histories) + gathered_tails.flatten()[0] * 0
+
+
+def context_parallel_conv_history(
+    qkv: torch.Tensor,
+    plan: ContextParallelPlan,
+    group: dist.ProcessGroup,
+    history_length: int,
+) -> torch.Tensor | None:
+    """Exchange fragment tails and return ``causal_conv1d``'s packed ``initial_state``.
+
+    ``qkv`` is the rank's local ``[1, T, C]`` packed input. The collective is differentiable, so
+    gradients flow back to the ranks that own the history tokens.
+    """
+    if history_length == 0:
+        return None
+    _check_group(plan, group, qkv.shape[1])
+    tails = []
+    for fragment, (start, stop) in zip(plan.fragments, pairwise(plan.cu_seqlens), strict=True):
+        stored = min(history_length, fragment.length)
+        tails.append(F.pad(qkv[0, stop - stored : stop], (0, 0, history_length - stored, 0)))
+    tails.extend([qkv.new_zeros(history_length, qkv.shape[-1])] * (plan.slots - len(tails)))
+    with profiler_range("cp/conv_halo"):
+        gathered = all_gather_single(torch.stack(tails), gather_dim=0, group=group).view(
+            len(plan.table), plan.slots, history_length, qkv.shape[-1]
+        )
+    return compose_conv_histories(gathered, plan)
+
+
+class PreparedForward(Protocol):
+    """Forward handle of a staged delta-rule op."""
+
+    @property
+    def saved(self) -> NamedTuple: ...
+
+    def state_summary(self, start: int, stop: int) -> torch.Tensor: ...
+
+    def run(
+        self, initial_state: torch.Tensor | None, *, output_final_state: bool
+    ) -> tuple[torch.Tensor, torch.Tensor | None]: ...
+
+
+class PreparedBackward(Protocol):
+    """Backward handle of a staged delta-rule op."""
+
+    def state_grad_summary(self, start: int, stop: int) -> torch.Tensor: ...
+
+    def run(self, d_final_state: torch.Tensor | None) -> tuple[torch.Tensor, ...]: ...
+
+
+class StagedOp(NamedTuple):
+    """A delta-rule variant's staged entry points with every op-specific option already bound.
+
+    ``prepare(q, k, v, gate, beta, *, cu_seqlens)`` returns a :class:`PreparedForward`;
+    ``prepare_backward(saved, d_output, initial_state)`` returns a :class:`PreparedBackward`,
+    where ``saved`` is the forward handle's ``saved`` NamedTuple rebuilt from
+    ``ctx.saved_tensors``.
+    """
+
+    prepare: Callable[..., PreparedForward]
+    prepare_backward: Callable[..., PreparedBackward]
+
+
+def summary_slots(
+    prepared: PreparedForward, plan: ContextParallelPlan, neutral: torch.Tensor
+) -> torch.Tensor:
+    """Fill this rank's ``[slots, HV, V + K, K]`` forward slots; identity where nobody needs one."""
+    slots = [neutral] * plan.slots
+    with profiler_range("cp/state_summary"):
+        for index, (start, stop) in enumerate(pairwise(plan.cu_seqlens)):
+            if plan.successors[index]:
+                slots[index] = prepared.state_summary(start, stop)
+    return torch.stack(slots)
+
+
+def grad_summary_slots(
+    grads: PreparedBackward,
+    d_final_state: torch.Tensor | None,
+    plan: ContextParallelPlan,
+    neutral: torch.Tensor,
+) -> torch.Tensor:
+    """Fill this rank's reverse slots, folding the loss's direct exit-state cotangent into each.
+
+    Upstream ranks need the total cotangent leaving a fragment, so the bias sent is
+    ``d_final_state @ R + C`` rather than the summary's zero-exit bias ``C``.
+    """
+    value_dim = neutral.shape[-2] - neutral.shape[-1]
+    slots = [neutral] * plan.slots
+    with profiler_range("cp/state_grad_summary"):
+        for index, (start, stop) in enumerate(pairwise(plan.cu_seqlens)):
+            if not plan.predecessors[index]:
+                continue
+            summary = grads.state_grad_summary(start, stop)
+            if d_final_state is not None:
+                summary = torch.cat(
+                    (merge_state(d_final_state[index], summary), summary[:, value_dim:]), dim=-2
+                )
+            slots[index] = summary
+    return torch.stack(slots)
+
+
+class _ContextParallelChunk(torch.autograd.Function):
+    """Explicit-adjoint delta rule: summaries and one all-gather in each direction."""
+
+    @staticmethod
+    def forward(ctx, q, k, v, gate, beta, cu_seqlens, plan, group, stages):
+        prepared = stages.prepare(q, k, v, gate, beta, cu_seqlens=cu_seqlens)
+        neutral = neutral_summary(v.shape[2], v.shape[-1], q.shape[-1], device=q.device)
+        gathered = _all_gather_slots(summary_slots(prepared, plan, neutral), group)
+        initial_state = compose_entry_states(gathered, plan)
+        with profiler_range("cp/run"):
+            output, final_state = prepared.run(initial_state, output_final_state=True)
+        assert final_state is not None
+
+        saved = prepared.saved
+        ctx.save_for_backward(*saved, initial_state)
+        ctx.saved_type = type(saved)
+        ctx.plan = plan
+        ctx.group = group
+        ctx.stages = stages
+        ctx.set_materialize_grads(False)
+        return output, final_state
+
+    @staticmethod
+    @torch.autograd.function.once_differentiable
+    def backward(ctx, d_output, d_final_state):
+        *saved, initial_state = ctx.saved_tensors
+        grads = ctx.stages.prepare_backward(ctx.saved_type._make(saved), d_output, initial_state)
+        neutral = neutral_summary(*initial_state.shape[1:], device=initial_state.device)
+        gathered = _all_gather_slots(
+            grad_summary_slots(grads, d_final_state, ctx.plan, neutral), ctx.group
+        )
+        exit_cotangent = compose_exit_cotangents(gathered, d_final_state, ctx.plan)
+        with profiler_range("cp/run"):
+            dq, dk, dv, dgate, dbeta, _d_initial_state = grads.run(exit_cotangent)
+        return dq, dk, dv, dgate, dbeta, None, None, None, None
+
+
+def context_parallel_chunk(
+    stages: StagedOp,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    *,
+    cu_seqlens: torch.Tensor,
+    plan: ContextParallelPlan,
+    group: dist.ProcessGroup,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run a staged delta-rule op over this rank's fragments with state exchanged by all-gather.
+
+    Args:
+        stages: The op's entry points; ``attn_gym.linear.kda.context_parallel_kda`` and
+            ``attn_gym.linear.gdn.context_parallel_gdn`` bind them with the op's options.
+        q: This rank's local packed queries laid out as ``plan.fragments``; ``k``, ``v``,
+            ``gate``, and ``beta`` follow the same layout and the op's ``chunk_*`` contract.
+        cu_seqlens: Device ``int32`` copy of ``plan.cu_seqlens``.
+        plan: Routing for this rank from ``ContextParallelPlan.from_token_ranges``.
+        group: Process group containing exactly the plan's ranks, in order.
+
+    Returns:
+        The local output and one FP32 ``[N, HV, V, K]`` exit state per local fragment. Only the
+        entries listed in ``plan.terminal`` are the sequences' true final states; the others are
+        intermediate states that the owner of the next fragment continued from.
+
+    ``initial_state`` is not accepted: every sequence starts from zero and the plan supplies the
+    entry states. Every rank in ``group`` must call this function the same number of times.
+    """
+    _check_group(plan, group, q.shape[1])
+    if cu_seqlens.shape[0] != len(plan.fragments) + 1:
+        raise ValueError(
+            f"cu_seqlens describes {cu_seqlens.shape[0] - 1} segments but the plan has "
+            f"{len(plan.fragments)} fragments"
+        )
+    return _ContextParallelChunk.apply(q, k, v, gate, beta, cu_seqlens, plan, group, stages)
+
+
+__all__ = [
+    "ContextParallelPlan",
+    "Fragment",
+    "PreparedBackward",
+    "PreparedForward",
+    "StagedOp",
+    "compose_conv_histories",
+    "compose_entry_states",
+    "compose_exit_cotangents",
+    "context_parallel_chunk",
+    "context_parallel_conv_history",
+    "grad_summary_slots",
+    "summary_slots",
+]

--- a/attn_gym/linear/gdn/__init__.py
+++ b/attn_gym/linear/gdn/__init__.py
@@ -1,5 +1,7 @@
 """Gated delta rule attention."""
 
+import importlib
+
 from attn_gym.linear.gdn.api import (
     KernelOptions,
     chunk_gdn,
@@ -8,10 +10,36 @@ from attn_gym.linear.gdn.api import (
     recurrent_gdn_decode,
 )
 
-__all__ = [
-    "KernelOptions",
-    "chunk_gdn",
-    "paged_chunk_gdn",
-    "recurrent_gdn",
-    "recurrent_gdn_decode",
-]
+# Note: Lazy Imports (see attn_gym/linear/__init__.py). Staged primitives around the affine
+# state boundary (stages.py) and the all-gather recipe over them.
+_BACKEND_EXPORTS = {
+    "ChunkGDNSaved": "attn_gym.linear.gdn.stages",
+    "chunk_gdn_prepare": "attn_gym.linear.gdn.stages",
+    "chunk_gdn_prepare_backward": "attn_gym.linear.gdn.stages",
+    "context_parallel_gdn": "attn_gym.linear.gdn.context_parallel",
+}
+
+
+def __getattr__(name: str):
+    module_name = _BACKEND_EXPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError as error:
+        raise ImportError(
+            f"{name} requires the optional CUDA kernel backends: pip install attn-gym[linear]"
+        ) from error
+    return getattr(module, name)
+
+
+__all__ = sorted(  # noqa: PLE0605 -- backend exports resolve lazily
+    [
+        "KernelOptions",
+        "chunk_gdn",
+        "paged_chunk_gdn",
+        "recurrent_gdn",
+        "recurrent_gdn_decode",
+        *_BACKEND_EXPORTS,
+    ]
+)

--- a/attn_gym/linear/gdn/context_parallel.py
+++ b/attn_gym/linear/gdn/context_parallel.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""GDN bound to the delta-rule context-parallel recipe."""
+
+from __future__ import annotations
+
+from functools import partial
+
+import torch
+import torch.distributed as dist
+
+from attn_gym.linear.context_parallel import ContextParallelPlan, StagedOp, context_parallel_chunk
+from attn_gym.linear.gdn.stages import chunk_gdn_prepare, chunk_gdn_prepare_backward
+
+
+def context_parallel_gdn(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    *,
+    cu_seqlens: torch.Tensor,
+    plan: ContextParallelPlan,
+    group: dist.ProcessGroup,
+    scale: float | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run fused ``chunk_gdn`` over this rank's fragments with state exchanged by all-gather.
+
+    See ``attn_gym.linear.context_parallel.context_parallel_chunk`` for the argument contract;
+    ``scale`` follows ``chunk_gdn``.
+    """
+    stages = StagedOp(
+        partial(chunk_gdn_prepare, scale=scale), partial(chunk_gdn_prepare_backward, scale=scale)
+    )
+    return context_parallel_chunk(
+        stages, q, k, v, gate, beta, cu_seqlens=cu_seqlens, plan=plan, group=group
+    )
+
+
+__all__ = ["context_parallel_gdn"]

--- a/attn_gym/linear/gdn/impl/chunk.py
+++ b/attn_gym/linear/gdn/impl/chunk.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import NamedTuple
+
 import torch
 
 from attn_gym._backends.cute import (
@@ -63,6 +65,59 @@ def reject_int64_offsets(*tensors: torch.Tensor | None) -> None:
         raise ValueError("fused chunk_gdn does not yet support int64 tensor offsets")
 
 
+class ChunkGDNFactors(NamedTuple):
+    """Local WY factors shared by context-parallel state summaries and output composition."""
+
+    w: torch.Tensor
+    u: torch.Tensor
+    kg: torch.Tensor
+    inverse: torch.Tensor
+
+
+def _prepare_chunk_gdn_fwd(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    metadata: RaggedChunkMetadata | None,
+) -> ChunkGDNFactors:
+    """Run the intra-chunk factorization on already normalized inputs."""
+    if metadata is None:
+        return ChunkGDNFactors(*chunk_gdn_fwd_intra_dense(k, v, cumulative_gate, beta))
+    return ChunkGDNFactors(*chunk_gdn_fwd_intra_packed(k, v, cumulative_gate, beta, metadata))
+
+
+def _finish_chunk_gdn_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    factors: ChunkGDNFactors,
+    cumulative_gate: torch.Tensor,
+    initial_state: torch.Tensor,
+    metadata: RaggedChunkMetadata | None,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run the state recurrence and output composition from prepared factors."""
+    if metadata is None:
+        h, v_new, final_state = chunk_gdn_fwd_recurrence_dense(
+            factors.kg, factors.w, factors.u, cumulative_gate, initial_state
+        )
+        output = chunk_gdn_fwd_output_dense(q, k, v_new, h, cumulative_gate, scale)
+    else:
+        h, v_new, final_state = chunk_gdn_fwd_recurrence_packed(
+            factors.kg, factors.w, factors.u, cumulative_gate, initial_state, metadata
+        )
+        output = chunk_gdn_fwd_output_packed(q, k, v_new, h, cumulative_gate, scale, metadata)
+    return output, final_state
+
+
+def zero_state(
+    q: torch.Tensor, v: torch.Tensor, metadata: RaggedChunkMetadata | None
+) -> torch.Tensor:
+    """FP32 ``[N, HV, V, K]`` zeros, one per packed sequence (per batch row when dense)."""
+    sequences = q.shape[0] if metadata is None else metadata.cu_seqlens.shape[0] - 1
+    return q.new_zeros(sequences, v.shape[2], v.shape[-1], q.shape[-1], dtype=torch.float32)
+
+
 def chunk_gdn_fwd_dense(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -83,30 +138,18 @@ def chunk_gdn_fwd_dense(
     if cumulative_gate.shape != v.shape[:3] or beta.shape != v.shape[:3]:
         raise ValueError("cumulative_gate and beta must have shape [B,T,H]")
     if initial_state is None:
-        initial_state = torch.zeros(
-            batch,
-            value_heads,
-            value_dim,
-            key_dim,
-            dtype=torch.float32,
-            device=q.device,
-        )
+        initial_state = zero_state(q, v, None)
     reject_int64_offsets(q, k, v, cumulative_gate, beta, initial_state)
     q, k, v = (normalize_tma_rows(tensor) for tensor in (q, k, v))
     cumulative_gate, beta, initial_state = (
         normalize_compact_tensor(tensor) for tensor in (cumulative_gate, beta, initial_state)
     )
 
-    w, u, restored_k, inverse = chunk_gdn_fwd_intra_dense(k, v, cumulative_gate, beta)
-    h, v_new, final_state = chunk_gdn_fwd_recurrence_dense(
-        restored_k,
-        w,
-        u,
-        cumulative_gate,
-        initial_state,
+    factors = _prepare_chunk_gdn_fwd(k, v, cumulative_gate, beta, None)
+    output, final_state = _finish_chunk_gdn_fwd(
+        q, k, factors, cumulative_gate, initial_state, None, scale
     )
-    output = chunk_gdn_fwd_output_dense(q, k, v_new, h, cumulative_gate, scale)
-    return output, final_state, inverse
+    return output, final_state, factors.inverse
 
 
 def _gdn_chunk_fwd_cuda(
@@ -152,37 +195,23 @@ def chunk_gdn_fwd_packed(
     validate_supported_device(q)
     batch, _tokens, key_heads, key_dim = q.shape
     value_heads, value_dim = v.shape[2:]
-    num_sequences = metadata.cu_seqlens.shape[0] - 1
     if batch != 1 or (key_dim, value_dim) != (128, 128):
         raise ValueError("packed fused chunk GDN requires B=1 and K=V=128")
     if k.shape != q.shape or v.shape[:2] != q.shape[:2] or value_heads % key_heads:
         raise ValueError("packed fused chunk GDN requires matching Q/K and H % HK == 0")
     if initial_state is None:
-        initial_state = torch.zeros(
-            num_sequences,
-            value_heads,
-            value_dim,
-            key_dim,
-            dtype=torch.float32,
-            device=q.device,
-        )
+        initial_state = zero_state(q, v, metadata)
     reject_int64_offsets(q, k, v, cumulative_gate, beta, initial_state)
     q, k, v = (normalize_tma_rows(tensor) for tensor in (q, k, v))
     cumulative_gate, beta, initial_state = (
         normalize_compact_tensor(tensor) for tensor in (cumulative_gate, beta, initial_state)
     )
 
-    w, u, restored_k, inverse = chunk_gdn_fwd_intra_packed(k, v, cumulative_gate, beta, metadata)
-    h, v_new, final_state = chunk_gdn_fwd_recurrence_packed(
-        restored_k,
-        w,
-        u,
-        cumulative_gate,
-        initial_state,
-        metadata,
+    factors = _prepare_chunk_gdn_fwd(k, v, cumulative_gate, beta, metadata)
+    output, final_state = _finish_chunk_gdn_fwd(
+        q, k, factors, cumulative_gate, initial_state, metadata, scale
     )
-    output = chunk_gdn_fwd_output_packed(q, k, v_new, h, cumulative_gate, scale, metadata)
-    return output, final_state, inverse
+    return output, final_state, factors.inverse
 
 
 def _gdn_chunk_fwd_packed_cuda(
@@ -278,6 +307,40 @@ def _gdn_chunk_fwd_packed_paged_cuda(
     return chunk_gdn_fwd_output_packed(q, k, v_new, h, cumulative_gate, scale, metadata)
 
 
+class ChunkGDNBwdPrepared(NamedTuple):
+    """Recomputed local tensors shared across the context-parallel backward boundary."""
+
+    w: torch.Tensor
+    qg: torch.Tensor
+    kg: torch.Tensor
+    h: torch.Tensor
+    v_new: torch.Tensor
+
+
+def _prepare_chunk_gdn_bwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    inverse: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    metadata: RaggedChunkMetadata | None,
+) -> ChunkGDNBwdPrepared:
+    """Recompute local factors and forward state on normalized inputs before communication."""
+    recurrence_state = zero_state(q, v, metadata) if initial_state is None else initial_state
+    w, u, qg, kg = chunk_gdn_recompute_w_u_qg_kg(q, k, v, cumulative_gate, beta, inverse, metadata)
+    if metadata is None:
+        h, v_new, _final_state = chunk_gdn_fwd_recurrence_dense(
+            kg, w, u, cumulative_gate, recurrence_state
+        )
+    else:
+        h, v_new, _final_state = chunk_gdn_fwd_recurrence_packed(
+            kg, w, u, cumulative_gate, recurrence_state, metadata
+        )
+    return ChunkGDNBwdPrepared(w, qg, kg, h, v_new)
+
+
 def chunk_gdn_bwd(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -312,28 +375,41 @@ def chunk_gdn_bwd(
         d_final_state = normalize_compact_tensor(d_final_state)
     if initial_state is not None:
         initial_state = normalize_compact_tensor(initial_state)
+    prepared = _prepare_chunk_gdn_bwd(
+        q, k, v, cumulative_gate, beta, inverse, initial_state, metadata
+    )
+    return _finish_chunk_gdn_bwd(
+        q,
+        k,
+        v,
+        cumulative_gate,
+        beta,
+        inverse,
+        d_output,
+        d_final_state,
+        initial_state,
+        metadata,
+        prepared,
+        scale,
+    )
 
-    state_batch = q.shape[0] if metadata is None else metadata.cu_seqlens.shape[0] - 1
-    recurrence_state = initial_state
-    if recurrence_state is None:
-        recurrence_state = torch.zeros(
-            state_batch,
-            v.shape[2],
-            v.shape[-1],
-            q.shape[-1],
-            dtype=torch.float32,
-            device=q.device,
-        )
-    w, u, qg, kg = chunk_gdn_recompute_w_u_qg_kg(q, k, v, cumulative_gate, beta, inverse, metadata)
-    if metadata is None:
-        h, v_new, _final_state = chunk_gdn_fwd_recurrence_dense(
-            kg, w, u, cumulative_gate, recurrence_state
-        )
-    else:
-        h, v_new, _final_state = chunk_gdn_fwd_recurrence_packed(
-            kg, w, u, cumulative_gate, recurrence_state, metadata
-        )
 
+def _finish_chunk_gdn_bwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    inverse: torch.Tensor,
+    d_output: torch.Tensor,
+    d_final_state: torch.Tensor | None,
+    initial_state: torch.Tensor | None,
+    metadata: RaggedChunkMetadata | None,
+    prepared: ChunkGDNBwdPrepared,
+    scale: float,
+) -> tuple[torch.Tensor, ...]:
+    """Finish the local gradients from recomputed factors and the exit-state cotangent."""
+    w, qg, kg, h, v_new = prepared
     if not use_blackwell_backward(q):
         dh, d_initial_state, dv = chunk_gdn_bwd_delta_h(
             q,

--- a/attn_gym/linear/gdn/stages.py
+++ b/attn_gym/linear/gdn/stages.py
@@ -1,0 +1,277 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Staged fused GDN around the affine state boundary; see ``attn_gym.linear.kda.stages``.
+
+The gated delta rule is KDA with one scalar decay per head instead of a per-channel vector, so
+its summaries reuse the per-channel summary kernels with the gate broadcast across channels. The
+handles follow the same protocol as the KDA stages and plug into
+``attn_gym.linear.context_parallel`` unchanged.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import cached_property
+from typing import NamedTuple
+
+import torch
+
+from attn_gym._backends.cute import normalize_compact_tensor, normalize_tma_rows
+from attn_gym.linear._delta_rule.cute import build_state_grad_summary, build_state_summary
+from attn_gym.linear._delta_rule.validation import resolve_scale
+from attn_gym.linear.gdn.bwd.triton.chunk_gdn_bwd_recompute import (
+    chunk_gdn_recompute_aqk_dense,
+    chunk_gdn_recompute_aqk_packed,
+)
+from attn_gym.linear.gdn.impl.chunk import (
+    ChunkGDNBwdPrepared,
+    ChunkGDNFactors,
+    _finish_chunk_gdn_bwd,
+    _finish_chunk_gdn_fwd,
+    _prepare_chunk_gdn_bwd,
+    _prepare_chunk_gdn_fwd,
+    reject_int64_offsets,
+    resolve_backward_metadata,
+    zero_state,
+)
+from attn_gym.linear.gdn.ops import _validate_fused_chunk_qkv
+from attn_gym.linear.gdn.validation import validate_gdn_inputs
+from attn_gym.linear.kda.chunk_schedule import RaggedChunkMetadata, prepare_ragged_chunk_metadata
+from attn_gym.linear.kda.ops import _plain_gate_scan_op
+from attn_gym.linear.kda.stages import _check_token_range
+
+_CHUNK_SIZE = 64
+
+
+def _vector_gate(cumulative_gate: torch.Tensor, key_dim: int) -> torch.Tensor:
+    """Broadcast the per-head scalar gate to the per-channel layout the summary kernels read."""
+    return cumulative_gate.unsqueeze(-1).expand(*cumulative_gate.shape, key_dim).contiguous()
+
+
+class ChunkGDNSaved(NamedTuple):
+    """Forward tensors an autograd function stores for ``chunk_gdn_prepare_backward``."""
+
+    q: torch.Tensor
+    k: torch.Tensor
+    v: torch.Tensor
+    cumulative_gate: torch.Tensor
+    beta: torch.Tensor
+    inverse: torch.Tensor
+    cu_seqlens: torch.Tensor | None
+    chunk_offsets: torch.Tensor | None
+
+
+@dataclass
+class ChunkGDNPrepared:
+    """Local forward factors shared by ``state_summary`` and ``run``."""
+
+    saved: ChunkGDNSaved
+    factors: ChunkGDNFactors
+    metadata: RaggedChunkMetadata | None
+    scale: float
+
+    def state_summary(self, start: int, stop: int) -> torch.Tensor:
+        """Return the FP32 ``[HV, V + K, K]`` map of tokens ``[start, stop)`` from the zero state.
+
+        See NOTE [Summary ranges are whole sequences] in ``attn_gym.linear.kda.stages``.
+        """
+        saved = self.saved
+        _check_token_range(saved.q.shape[1], start, stop)
+        return build_state_summary(
+            self.factors.kg[:, start:stop],
+            self.factors.w[:, start:stop],
+            self.factors.u[:, start:stop],
+            _vector_gate(saved.cumulative_gate[:, start:stop], saved.q.shape[-1]),
+        )
+
+    def run(
+        self,
+        initial_state: torch.Tensor | None = None,
+        *,
+        output_final_state: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Finish the local forward from one FP32 ``[N, HV, V, K]`` entry state per sequence."""
+        saved = self.saved
+        if initial_state is None:
+            initial_state = zero_state(saved.q, saved.v, self.metadata)
+        output, final_state = _finish_chunk_gdn_fwd(
+            saved.q,
+            saved.k,
+            self.factors,
+            saved.cumulative_gate,
+            normalize_compact_tensor(initial_state.float()),
+            self.metadata,
+            self.scale,
+        )
+        return output, final_state if output_final_state else None
+
+
+def chunk_gdn_prepare(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    *,
+    cu_seqlens: torch.Tensor | None = None,
+    scale: float | None = None,
+) -> ChunkGDNPrepared:
+    """Run the factor half of fused ``chunk_gdn`` and return a handle for summaries and output.
+
+    Arguments follow ``chunk_gdn`` with the batch dimension fixed to one so token offsets index
+    one packed stream.
+    """
+    validate_gdn_inputs(q, k, v, gate, beta, None, cu_seqlens)
+    _validate_fused_chunk_qkv(q, k, v)
+    if q.shape[0] != 1:
+        raise ValueError("chunk_gdn_prepare requires B=1; pack sequences with cu_seqlens")
+    tokens = q.shape[1]
+    if cu_seqlens is None and tokens % _CHUNK_SIZE:
+        # A partial tail runs as one packed sequence; arange keeps the launch capture-safe.
+        cu_seqlens = torch.arange(2, dtype=torch.int32, device=q.device) * tokens
+    metadata = (
+        None
+        if cu_seqlens is None
+        else prepare_ragged_chunk_metadata(cu_seqlens, tokens, _CHUNK_SIZE)
+    )
+    cu_seqlens = None if metadata is None else metadata.cu_seqlens
+    chunk_offsets = None if metadata is None else metadata.chunk_offsets
+    scale = resolve_scale(scale, q.shape[-1])
+    q, k, v = (normalize_tma_rows(tensor) for tensor in (q, k, v))
+    beta = normalize_compact_tensor(beta.float())
+    cumulative_gate = normalize_compact_tensor(
+        _plain_gate_scan_op(gate.float().unsqueeze(-1), cu_seqlens, chunk_offsets, False).squeeze(
+            -1
+        )
+    )
+    reject_int64_offsets(q, k, v, cumulative_gate, beta)
+    factors = _prepare_chunk_gdn_fwd(k, v, cumulative_gate, beta, metadata)
+    saved = ChunkGDNSaved(
+        q, k, v, cumulative_gate, beta, factors.inverse, cu_seqlens, chunk_offsets
+    )
+    return ChunkGDNPrepared(saved, factors, metadata, scale)
+
+
+@dataclass
+class ChunkGDNBackward:
+    """Recomputed local backward tensors shared by ``state_grad_summary`` and ``run``."""
+
+    saved: ChunkGDNSaved
+    d_output: torch.Tensor
+    initial_state: torch.Tensor | None
+    metadata: RaggedChunkMetadata | None
+    prepared: ChunkGDNBwdPrepared
+    scale: float
+
+    @cached_property
+    def aqk(self) -> torch.Tensor:
+        """Intra-chunk Q/K factor for the reverse summary; the scalar backward does not otherwise
+        materialize it on pre-Blackwell targets, so it is computed once on first use."""
+        saved = self.saved
+        groups = saved.v.shape[2] // saved.q.shape[2]
+        q, k = (
+            tensor.repeat_interleave(groups, dim=2) if groups > 1 else tensor
+            for tensor in (saved.q, saved.k)
+        )
+        if self.metadata is None:
+            return chunk_gdn_recompute_aqk_dense(q, k, saved.cumulative_gate, self.scale)
+        return chunk_gdn_recompute_aqk_packed(
+            q, k, saved.cumulative_gate, self.scale, self.metadata
+        )
+
+    def state_grad_summary(self, start: int, stop: int) -> torch.Tensor:
+        """Return the FP32 ``[HV, V + K, K]`` reverse map of tokens ``[start, stop)``.
+
+        See ``ChunkKDABackward.state_grad_summary`` for the bias convention.
+        """
+        saved = self.saved
+        _check_token_range(saved.q.shape[1], start, stop)
+        return build_state_grad_summary(
+            self.prepared.qg[:, start:stop],
+            self.prepared.kg[:, start:stop],
+            self.prepared.w[:, start:stop],
+            self.d_output[:, start:stop],
+            self.aqk[:, start:stop],
+            _vector_gate(saved.cumulative_gate[:, start:stop], saved.q.shape[-1]),
+            self.scale,
+        )
+
+    def run(
+        self, d_final_state: torch.Tensor | None = None
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor | None,
+    ]:
+        """Finish the local backward from one FP32 ``[N, HV, V, K]`` exit cotangent per sequence.
+
+        Returns ``(dq, dk, dv, dgate, dbeta, d_initial_state)``; the last is ``None`` when the
+        forward ran without an entry state.
+        """
+        if d_final_state is not None:
+            d_final_state = normalize_compact_tensor(d_final_state.float())
+        saved = self.saved
+        return _finish_chunk_gdn_bwd(
+            saved.q,
+            saved.k,
+            saved.v,
+            saved.cumulative_gate,
+            saved.beta,
+            saved.inverse,
+            self.d_output,
+            d_final_state,
+            self.initial_state,
+            self.metadata,
+            self.prepared,
+            self.scale,
+        )
+
+
+def chunk_gdn_prepare_backward(
+    saved: ChunkGDNSaved,
+    d_output: torch.Tensor | None,
+    initial_state: torch.Tensor | None,
+    *,
+    scale: float | None = None,
+) -> ChunkGDNBackward:
+    """Recompute the local backward tensors before any reverse-summary exchange.
+
+    ``initial_state`` is the entry state the forward ``run`` consumed and ``scale`` must match the
+    forward call.
+    """
+    metadata = resolve_backward_metadata(saved.q, saved.cu_seqlens, saved.chunk_offsets)
+    scale = resolve_scale(scale, saved.q.shape[-1])
+    if d_output is None:
+        d_output = torch.zeros_like(saved.v)
+    else:
+        d_output = normalize_compact_tensor(d_output.to(saved.v.dtype))
+    if initial_state is not None:
+        initial_state = normalize_compact_tensor(initial_state.float())
+    reject_int64_offsets(d_output, initial_state)
+    prepared = _prepare_chunk_gdn_bwd(
+        saved.q,
+        saved.k,
+        saved.v,
+        saved.cumulative_gate,
+        saved.beta,
+        saved.inverse,
+        initial_state,
+        metadata,
+    )
+    return ChunkGDNBackward(saved, d_output, initial_state, metadata, prepared, scale)
+
+
+__all__ = [
+    "ChunkGDNBackward",
+    "ChunkGDNPrepared",
+    "ChunkGDNSaved",
+    "chunk_gdn_prepare",
+    "chunk_gdn_prepare_backward",
+]

--- a/attn_gym/linear/kda/__init__.py
+++ b/attn_gym/linear/kda/__init__.py
@@ -30,7 +30,15 @@ from attn_gym.linear.kda.masking import (
 )
 
 # Note: Lazy Imports (see attn_gym/linear/__init__.py)
-_BACKEND_EXPORTS = {"l2norm": "attn_gym.linear.kda.fwd.triton.l2norm_fwd"}
+_BACKEND_EXPORTS = {
+    "l2norm": "attn_gym.linear.kda.fwd.triton.l2norm_fwd",
+    # Staged primitives around the affine state boundary (stages.py) and the all-gather recipe
+    # over them. Ownership plans live in attn_gym.linear.context_parallel.
+    "ChunkKDASaved": "attn_gym.linear.kda.stages",
+    "chunk_kda_prepare": "attn_gym.linear.kda.stages",
+    "chunk_kda_prepare_backward": "attn_gym.linear.kda.stages",
+    "context_parallel_kda": "attn_gym.linear.kda.context_parallel",
+}
 # Backward compat: these moved to attn_gym.linear.short_conv, which owns their
 # lazy resolution and error message; import them from attn_gym.linear instead.
 _SHORT_CONV_BC = {"causal_conv1d", "causal_conv1d_decode", "register_activation"}
@@ -45,7 +53,9 @@ def __getattr__(name: str):
     try:
         module = importlib.import_module(module_name)
     except ImportError as error:
-        raise ImportError(f"{name} requires CUDA with Triton support") from error
+        raise ImportError(
+            f"{name} requires the optional CUDA kernel backends: pip install attn-gym[linear]"
+        ) from error
     return getattr(module, name)
 
 

--- a/attn_gym/linear/kda/context_parallel.py
+++ b/attn_gym/linear/kda/context_parallel.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""KDA bound to the delta-rule context-parallel recipe."""
+
+from __future__ import annotations
+
+from functools import partial
+
+import torch
+import torch.distributed as dist
+
+from attn_gym.linear.context_parallel import ContextParallelPlan, StagedOp, context_parallel_chunk
+from attn_gym.linear.kda.stages import chunk_kda_prepare, chunk_kda_prepare_backward
+
+
+def context_parallel_kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    *,
+    cu_seqlens: torch.Tensor,
+    plan: ContextParallelPlan,
+    group: dist.ProcessGroup,
+    scale: float | None = None,
+    autotune: bool = True,
+    fastmath: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run fused ``chunk_kda`` over this rank's fragments with state exchanged by all-gather.
+
+    See ``attn_gym.linear.context_parallel.context_parallel_chunk`` for the argument contract;
+    ``scale``, ``autotune``, and ``fastmath`` follow ``chunk_kda``.
+    """
+    stages = StagedOp(
+        partial(chunk_kda_prepare, scale=scale, autotune=autotune),
+        partial(chunk_kda_prepare_backward, scale=scale, autotune=autotune, fastmath=fastmath),
+    )
+    return context_parallel_chunk(
+        stages, q, k, v, gate, beta, cu_seqlens=cu_seqlens, plan=plan, group=group
+    )
+
+
+__all__ = ["context_parallel_kda"]

--- a/attn_gym/linear/kda/stages.py
+++ b/attn_gym/linear/kda/stages.py
@@ -1,0 +1,329 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Staged fused KDA around a public affine state boundary.
+
+``chunk_kda`` runs the fused core as one autograd function. Schemes that move recurrent state
+between devices (context parallelism, pipelined state handoff, ...) need the same core split around
+a communication point in both directions::
+
+    prepared = chunk_kda_prepare(q, k, v, gate, beta, cu_seqlens=cu_seqlens)  # WY factors, once
+    summary = prepared.state_summary(start, stop)             # [bias; transition] of one sequence
+    ...exchange summaries, compose each sequence's entry state...
+    output, final_state = prepared.run(initial_state, output_final_state=True)
+
+    grads = chunk_kda_prepare_backward(saved, d_output, initial_state, scale=scale)
+    grad_summary = grads.state_grad_summary(start, stop)
+    ...exchange, compose each sequence's exit cotangent...
+    dq, dk, dv, dgate, dbeta, d_initial_state = grads.run(d_final_state)
+
+The handles keep the factor tensors private, so the contract is the affine summary described in
+``attn_gym.linear.state_summary``: an FP32 ``[HV, V + K, K]`` map packed as ``[bias; transition]``.
+Which tokens a device owns and how summaries travel are the caller's decisions;
+``attn_gym.linear.context_parallel`` is one all-gather composition built only on these handles.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import NamedTuple
+
+import torch
+
+from attn_gym._backends.cute import normalize_compact_tensor, normalize_tma_rows
+from attn_gym.linear._delta_rule.cute import build_state_grad_summary, build_state_summary
+from attn_gym.linear._delta_rule.validation import resolve_scale
+from attn_gym.linear.kda.bwd.cute.chunk_kda_bwd import (
+    ChunkKDABwdPrepared,
+    _finish_chunk_kda_bwd,
+    _prepare_chunk_kda_bwd,
+)
+from attn_gym.linear.kda.chunk_schedule import (
+    RaggedChunkMetadata,
+    chunk_capacity,
+    prepare_ragged_chunk_metadata,
+)
+from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd import (
+    ChunkKDAFactors,
+    _finish_chunk_kda_fwd,
+    _prepare_chunk_kda_fwd,
+)
+from attn_gym.linear.kda.impl.fused import _validate_fused_constraints
+from attn_gym.linear.kda.ops import _plain_gate_scan_op
+from attn_gym.linear.kda.validation import validate_kda_inputs
+
+_CHUNK_SIZE = 64
+
+
+class ChunkKDASaved(NamedTuple):
+    """Forward tensors an autograd function stores for ``chunk_kda_prepare_backward``.
+
+    Every field is a tensor or ``None`` so the tuple can be splatted into
+    ``ctx.save_for_backward`` and rebuilt from ``ctx.saved_tensors``.
+    """
+
+    q: torch.Tensor
+    k: torch.Tensor
+    v: torch.Tensor
+    cumulative_gate: torch.Tensor
+    beta: torch.Tensor
+    aqk: torch.Tensor
+    akk: torch.Tensor
+    cu_seqlens: torch.Tensor | None
+    chunk_offsets: torch.Tensor | None
+
+
+def _metadata_from_saved(saved: ChunkKDASaved) -> RaggedChunkMetadata | None:
+    if saved.cu_seqlens is None:
+        return None
+    assert saved.chunk_offsets is not None
+    tokens = saved.q.shape[1]
+    return RaggedChunkMetadata(
+        saved.cu_seqlens,
+        saved.chunk_offsets,
+        chunk_capacity(tokens, saved.cu_seqlens.shape[0] - 1, _CHUNK_SIZE),
+        _CHUNK_SIZE,
+    )
+
+
+def _check_token_range(tokens: int, start: int, stop: int) -> None:
+    """Reject bounds outside the stream; see NOTE [Summary ranges are whole sequences]."""
+    if not 0 <= start < stop <= tokens:
+        raise ValueError(f"summary range [{start}, {stop}) must lie inside [0, {tokens})")
+
+
+# NOTE [Summary ranges are whole sequences]
+# The WY factors are chunked relative to each packed sequence's first token, so a summary is only
+# meaningful over a range that starts at a sequence start and ends at that sequence's end. The
+# bounds are host integers rather than reads from ``cu_seqlens`` so CUDA Graph capture never needs
+# a device sync; callers own the packed layout and already know these offsets.
+
+
+@dataclass
+class ChunkKDAPrepared:
+    """Local forward factors shared by ``state_summary`` and ``run``.
+
+    The factors are large; release the handle once ``run`` has produced the output.
+    """
+
+    saved: ChunkKDASaved
+    factors: ChunkKDAFactors
+    metadata: RaggedChunkMetadata | None
+    scale: float
+    autotune: bool
+
+    def state_summary(self, start: int, stop: int) -> torch.Tensor:
+        """Return the FP32 ``[HV, V + K, K]`` map of tokens ``[start, stop)`` from the zero state.
+
+        See NOTE [Summary ranges are whole sequences].
+        """
+        _check_token_range(self.saved.q.shape[1], start, stop)
+        return build_state_summary(
+            self.factors.kg[:, start:stop],
+            self.factors.w[:, start:stop],
+            self.factors.u[:, start:stop],
+            self.saved.cumulative_gate[:, start:stop],
+        )
+
+    def run(
+        self,
+        initial_state: torch.Tensor | None = None,
+        *,
+        output_final_state: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Finish the local forward from one FP32 ``[N, HV, V, K]`` entry state per sequence."""
+        if initial_state is not None:
+            initial_state = initial_state.float().contiguous()
+        return _finish_chunk_kda_fwd(
+            self.saved.q,
+            self.saved.cumulative_gate,
+            self.factors,
+            initial_state,
+            None,
+            None,
+            self.metadata,
+            scale=self.scale,
+            output_final_state=output_final_state,
+            autotune=self.autotune,
+        )
+
+
+def chunk_kda_prepare(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    *,
+    cu_seqlens: torch.Tensor | None = None,
+    scale: float | None = None,
+    autotune: bool = True,
+) -> ChunkKDAPrepared:
+    """Run the factor half of fused ``chunk_kda`` and return a handle for summaries and output.
+
+    Arguments follow ``chunk_kda`` with two restrictions: ``q``/``k``/``v`` must already share a
+    float16 or bfloat16 dtype (no silent cast, because the caller owns autograd), and the batch
+    dimension must be one so token offsets index one packed stream.
+    """
+    validate_kda_inputs(
+        q, k, v, gate, beta, None, cu_seqlens, op_name="chunk_kda_prepare", gate_name="gate"
+    )
+    _validate_fused_constraints(q, v)
+    if q.dtype not in (torch.float16, torch.bfloat16) or k.dtype != q.dtype or v.dtype != q.dtype:
+        raise TypeError(
+            "chunk_kda_prepare requires q, k, and v to share dtype float16 or bfloat16"
+        )
+    if q.shape[0] != 1:
+        raise ValueError("chunk_kda_prepare requires B=1; pack sequences with cu_seqlens")
+    q, k, v = (normalize_tma_rows(tensor) for tensor in (q, k, v))
+    tokens = q.shape[1]
+    if cu_seqlens is None and tokens % _CHUNK_SIZE:
+        # A partial tail runs as one packed sequence; arange keeps the launch capture-safe.
+        cu_seqlens = torch.arange(2, dtype=torch.int32, device=q.device) * tokens
+    metadata = (
+        None
+        if cu_seqlens is None
+        else prepare_ragged_chunk_metadata(cu_seqlens, tokens, _CHUNK_SIZE)
+    )
+    cu_seqlens = None if metadata is None else metadata.cu_seqlens
+    chunk_offsets = None if metadata is None else metadata.chunk_offsets
+    scale = resolve_scale(scale, q.shape[-1])
+    beta = normalize_compact_tensor(beta.float())
+    cumulative_gate = _plain_gate_scan_op(gate.float(), cu_seqlens, chunk_offsets, False)
+    factors = _prepare_chunk_kda_fwd(
+        q, k, v, cumulative_gate, beta, metadata, scale=scale, autotune=autotune
+    )
+    saved = ChunkKDASaved(
+        q, k, v, cumulative_gate, beta, factors.aqk, factors.akk, cu_seqlens, chunk_offsets
+    )
+    return ChunkKDAPrepared(saved, factors, metadata, scale, autotune)
+
+
+@dataclass
+class ChunkKDABackward:
+    """Recomputed local backward tensors shared by ``state_grad_summary`` and ``run``.
+
+    ``run`` consumes the recomputed tensors at their last use, so call it once and last.
+    """
+
+    saved: ChunkKDASaved
+    d_output: torch.Tensor
+    initial_state: torch.Tensor | None
+    metadata: RaggedChunkMetadata | None
+    prepared: ChunkKDABwdPrepared
+    scale: float
+    autotune: bool
+    fastmath: bool
+
+    def state_grad_summary(self, start: int, stop: int) -> torch.Tensor:
+        """Return the FP32 ``[HV, V + K, K]`` reverse map of tokens ``[start, stop)``.
+
+        Its bias is the range's own contribution to the entry-state cotangent given a zero exit
+        cotangent; callers with a nonzero exit cotangent fold it in with ``merge_state`` before
+        sending the summary upstream. See NOTE [Summary ranges are whole sequences].
+        """
+        _check_token_range(self.saved.q.shape[1], start, stop)
+        assert self.prepared.qg is not None and self.prepared.kg is not None
+        assert self.prepared.w is not None
+        return build_state_grad_summary(
+            self.prepared.qg[:, start:stop],
+            self.prepared.kg[:, start:stop],
+            self.prepared.w[:, start:stop],
+            self.d_output[:, start:stop],
+            self.saved.aqk[:, start:stop],
+            self.saved.cumulative_gate[:, start:stop],
+            self.scale,
+        )
+
+    def run(
+        self, d_final_state: torch.Tensor | None = None
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor | None,
+    ]:
+        """Finish the local backward from one FP32 ``[N, HV, V, K]`` exit cotangent per sequence.
+
+        Returns ``(dq, dk, dv, dgate, dbeta, d_initial_state)``; the last is ``None`` when the
+        forward ran without an entry state.
+        """
+        if d_final_state is not None:
+            d_final_state = normalize_compact_tensor(d_final_state.float())
+        saved = self.saved
+        dq, dk, dv, d_cumulative, dbeta, d_initial_state = _finish_chunk_kda_bwd(
+            saved.q,
+            saved.k,
+            saved.v,
+            saved.cumulative_gate,
+            saved.beta,
+            saved.aqk,
+            saved.akk,
+            self.d_output,
+            d_final_state,
+            self.initial_state,
+            self.metadata,
+            self.prepared,
+            scale=self.scale,
+            chunk_size=_CHUNK_SIZE,
+            fastmath=self.fastmath,
+            autotune=self.autotune,
+        )
+        dgate = _plain_gate_scan_op(d_cumulative, saved.cu_seqlens, saved.chunk_offsets, True)
+        return dq, dk, dv, dgate, dbeta, d_initial_state
+
+
+def chunk_kda_prepare_backward(
+    saved: ChunkKDASaved,
+    d_output: torch.Tensor | None,
+    initial_state: torch.Tensor | None,
+    *,
+    scale: float | None = None,
+    autotune: bool = True,
+    fastmath: bool = False,
+) -> ChunkKDABackward:
+    """Recompute the local backward tensors before any reverse-summary exchange.
+
+    ``initial_state`` is the entry state the forward ``run`` consumed and ``scale`` must match
+    the forward call; both live outside ``saved`` because the caller's autograd function owns
+    them. ``fastmath`` applies to the gradient kernels as in ``chunk_kda``.
+    """
+    metadata = _metadata_from_saved(saved)
+    if d_output is None:
+        d_output = torch.zeros_like(saved.v)
+    else:
+        d_output = normalize_compact_tensor(d_output.to(saved.v.dtype))
+    if initial_state is not None:
+        initial_state = initial_state.float().contiguous()
+    scale = resolve_scale(scale, saved.q.shape[-1])
+    prepared = _prepare_chunk_kda_bwd(
+        saved.q,
+        saved.k,
+        saved.v,
+        saved.cumulative_gate,
+        saved.beta,
+        saved.akk,
+        d_output,
+        initial_state,
+        metadata,
+        scale=scale,
+        chunk_size=_CHUNK_SIZE,
+        autotune=autotune,
+    )
+    return ChunkKDABackward(
+        saved, d_output, initial_state, metadata, prepared, scale, autotune, fastmath
+    )
+
+
+__all__ = [
+    "ChunkKDABackward",
+    "ChunkKDAPrepared",
+    "ChunkKDASaved",
+    "chunk_kda_prepare",
+    "chunk_kda_prepare_backward",
+]

--- a/attn_gym/linear/state_summary.py
+++ b/attn_gym/linear/state_summary.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Affine state-summary algebra shared by every delta-rule variant.
+
+Each delta-rule token step is affine in the V-major recurrent state ``H: [V, K]`` (one per value
+head ``HV``; GQA key heads are already expanded by the factor kernels)::
+
+    H_t = H_{t-1} @ A_t + B_t      A_t = diag(exp g_t) (I - beta_t k_t k_t^T),  B_t = beta_t v_t k_t^T
+
+so any token range collapses to one FP32 map ``H_out = H_in @ A + B``, packed here as
+``[HV, V + K, K] = [bias; transition]``. Reverse summaries pack the cotangent map
+``dH_in = dH_out @ R + C`` the same way. These helpers are pure PyTorch; the per-op ``stages``
+modules produce the summaries and ``attn_gym.linear.context_parallel`` moves them between ranks.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+def neutral_summary(
+    heads: int, value_dim: int, key_dim: int, *, device: torch.device | str
+) -> torch.Tensor:
+    """Return the identity map ``[0; I]``: ``merge_state(state, neutral) == state``.
+
+    Collectives need every participant to contribute a same-shaped tensor even when nobody
+    consumes its slot; the identity is the harmless filler.
+    """
+    summary = torch.zeros(heads, value_dim + key_dim, key_dim, dtype=torch.float32, device=device)
+    summary[:, value_dim:, :] = torch.eye(key_dim, dtype=torch.float32, device=device)
+    return summary
+
+
+def merge_state(state: torch.Tensor, summary: torch.Tensor) -> torch.Tensor:
+    """Apply a packed ``[bias; transition]`` summary to a V-major state: ``state @ A + B``."""
+    value_dim = state.shape[-2]
+    return state @ summary[..., value_dim:, :] + summary[..., :value_dim, :]
+
+
+def compose_summaries(first: torch.Tensor, then: torch.Tensor) -> torch.Tensor:
+    """Compose two summaries into the map that applies ``first`` and then ``then``.
+
+    ``(A0, B0) ∘ (A1, B1) = (A0 @ A1, B0 @ A1 + B1)``. Folding predecessors from the zero state
+    with ``merge_state`` gives the same entry state; composition is for scans that combine maps
+    before any state is known.
+    """
+    value_dim = first.shape[-2] - first.shape[-1]
+    bias, transition = first[..., :value_dim, :], first[..., value_dim:, :]
+    return torch.cat((merge_state(bias, then), transition @ then[..., value_dim:, :]), dim=-2)
+
+
+__all__ = ["compose_summaries", "merge_state", "neutral_summary"]

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -93,23 +93,27 @@ torchrun --standalone --nproc_per_node=4 examples/ring_attention.py --seq-len 13
 
 [`examples/kda_context_parallel.py`](https://github.com/meta-pytorch/attention-gym/blob/main/examples/kda_context_parallel.py)
 — Run the complete transformer-style module from `kda_training.py` over packed context-parallel
-shards. This includes projections, Q/K/V short convolution, KDA, normalization, gating, and the
-output projection.
+fragments using the reference recipe in `attn_gym.linear.context_parallel` (see
+[Context Parallelism](linear.md#context-parallelism)). This includes projections, Q/K/V short
+convolution, KDA, normalization, gating, and the output projection.
 
-The short convolution all-gathers one fixed-size `W - 1` token halo per rank and routes its initial-
-state gradient back to the ranks that own those tokens. The KDA recurrence separately computes
-forward and reverse `[bias; transition]` state summaries with portable Triton kernels on Hopper or
-native TMA/UMMA kernels on SM100, all-gathers them, and composes the relevant prefix or suffix
-before running the ordinary local KDA kernel. A contiguous rank boundary is one cut in the packed
-token stream, so it can split at most one logical
-sequence. The example validates local outputs, convolution and KDA endpoint states, input gradients,
-and all-reduced parameter gradients against the complete unsharded module. It can also capture the
-full forward, NCCL communication, and backward in one CUDA Graph and validate a changed-input
-replay. Use `--compute-dtype=float16` to exercise the FP16 route. Add `--profile` to use
-transformer-nuggets to export one merged multi-rank trace in native Perfetto `.pftrace` format.
+Each rank owns global token ranges chosen in a dozen lines of plain Python (`token_ranges` in the
+example): `--partition contiguous` gives each rank one block, while `--partition zigzag` gives it two
+mirrored blocks, matching the layout hybrid models inherit from ring softmax attention. The short convolution all-gathers one `W - 1` token tail per fragment and routes its
+initial-state gradient back to the owning ranks. The KDA recurrence computes forward and reverse
+`[bias; transition]` state summaries with portable Triton kernels on Hopper or native TMA/UMMA
+kernels on SM100, all-gathers them, and folds each fragment's predecessors or successors before
+running the ordinary local KDA kernel. The example validates local outputs, convolution and KDA
+endpoint states, input gradients, and all-reduced parameter gradients against the complete
+unsharded module. It can also capture the full forward, NCCL communication, and backward in one
+CUDA Graph and validate a changed-input replay. Use `--compute-dtype=float16` to exercise the FP16
+route. Add `--profile` to use transformer-nuggets to export one merged multi-rank trace in native
+Perfetto `.pftrace` format.
 
 ```bash
 torchrun --standalone --nproc_per_node=2 examples/kda_context_parallel.py
+
+torchrun --standalone --nproc_per_node=2 examples/kda_context_parallel.py --partition zigzag
 
 torchrun --standalone --nproc_per_node=2 examples/kda_context_parallel.py --compute-dtype=float16
 

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -389,3 +389,97 @@ forgetting-horizon splitting. Install the `mega` extra to use this backend.
 ::: attn_gym.linear.recurrent_kda_decode
 
 ::: attn_gym.linear.Impl
+
+## Context Parallelism
+
+Every delta-rule token step is affine in the V-major recurrent state, so any token range
+collapses to one FP32 map `H_out = H_in @ A + B`, packed as `[HV, V + K, K] = [bias; transition]`
+(one map per value head; GQA key heads are expanded by the factor kernels).
+Context parallelism is therefore a prefix scan over these summaries, and the same machinery serves
+KDA and GDN (whose scalar per-head gate broadcasts onto the per-channel summary kernels). The
+public surface has three tiers so that new partitionings or communication topologies never add
+options to an op.
+
+**Primitives** (`attn_gym.linear.kda.chunk_kda_prepare` / `chunk_kda_prepare_backward`, and
+`attn_gym.linear.gdn.chunk_gdn_prepare` / `chunk_gdn_prepare_backward`) split the fused core
+around the communication point without exposing its WY factors:
+
+```python
+from attn_gym.linear.kda import chunk_kda_prepare, chunk_kda_prepare_backward
+
+prepared = chunk_kda_prepare(q, k, v, gate, beta, cu_seqlens=cu_seqlens)
+summary = prepared.state_summary(start, stop)  # [bias; transition] of one local sequence
+# ...exchange summaries and compose each sequence's entry state...
+output, final_state = prepared.run(initial_state, output_final_state=True)
+
+grads = chunk_kda_prepare_backward(prepared.saved, d_output, initial_state)
+grad_summary = grads.state_grad_summary(start, stop)  # reverse map [bias; transition]
+# ...exchange and compose each sequence's exit cotangent...
+dq, dk, dv, dgate, dbeta, _ = grads.run(d_final_state)
+```
+
+`start`/`stop` are host integers naming exactly one local `cu_seqlens` segment, so CUDA Graph
+capture never syncs. `attn_gym.linear.state_summary` holds the pure-PyTorch algebra on summaries
+(`merge_state`, `compose_summaries`, `neutral_summary`).
+
+**Ownership plans** (`attn_gym.linear.context_parallel.ContextParallelPlan`) describe which global
+token ranges each rank owns. You choose the ranges in plain Python; the plan cuts them at sequence
+boundaries into `Fragment`s, one local `cu_seqlens` segment each, and derives host-static routing:
+which fragments need a forward or reverse summary, which gathered slots to fold for each entry
+state or exit cotangent, and which local fragments end their sequence and therefore hold true final
+states. Two pieces of one document on the same rank are simply two local segments whose entry
+states the recipe supplies, so contiguous shards, zig-zag load balancing, and document-aligned
+partitions differ only in the range lists. The ranges must tile `[0, total_tokens)` exactly once.
+[`examples/kda_context_parallel.py`](https://github.com/meta-pytorch/attention-gym/blob/main/examples/kda_context_parallel.py)
+builds contiguous and zig-zag range lists in a dozen lines.
+
+**Reference recipe** (`attn_gym.linear.context_parallel.context_parallel_chunk`, bound as
+`attn_gym.linear.kda.context_parallel_kda` and `attn_gym.linear.gdn.context_parallel_gdn`) moves
+summaries with one padded all-gather per direction and owns the autograd function; it is generic
+over the op through a `StagedOp` pair of the two `prepare` entry points.
+`context_parallel_conv_history` builds the short convolution's `initial_state` from the same plan.
+The recipe is one composition, not an extension point: for a point-to-point pipeline, a
+recursive-doubling scan over `compose_summaries`, DTensor, or communication overlap, copy the
+autograd function and swap the collective; the primitives and plans are unchanged. Sharding does
+not cost accuracy: against an FP32 reference, sharded gradients match the unsharded fused op's error
+to within noise for both ops.
+
+```python
+from attn_gym.linear.context_parallel import ContextParallelPlan
+from attn_gym.linear.kda import context_parallel_kda
+
+# Two ranks; the packed stream split down the middle.
+total_tokens = global_cu_seqlens[-1]
+half = total_tokens // 2
+plan = ContextParallelPlan.from_token_ranges(
+    global_cu_seqlens, [[(0, half)], [(half, total_tokens)]], rank
+)
+token_ids = plan.global_token_ids(device)  # slice global tensors into local ones
+cu_seqlens = torch.tensor(plan.cu_seqlens, dtype=torch.int32, device=device)
+output, final_state = context_parallel_kda(
+    q, k, v, gate, beta, cu_seqlens=cu_seqlens, plan=plan, group=group
+)
+true_final_states = final_state[list(plan.terminal)]
+```
+
+The recipe starts each sequence from zero, always returns every fragment's exit state, and does
+not accept `initial_state` or `output_final_state=False`. A captured CUDA Graph is valid only for
+its fixed plan.
+
+::: attn_gym.linear.context_parallel.context_parallel_chunk
+
+::: attn_gym.linear.kda.context_parallel.context_parallel_kda
+
+::: attn_gym.linear.gdn.context_parallel.context_parallel_gdn
+
+::: attn_gym.linear.context_parallel.ContextParallelPlan
+
+::: attn_gym.linear.context_parallel.Fragment
+
+::: attn_gym.linear.kda.stages.chunk_kda_prepare
+
+::: attn_gym.linear.kda.stages.chunk_kda_prepare_backward
+
+::: attn_gym.linear.gdn.stages.chunk_gdn_prepare
+
+::: attn_gym.linear.gdn.stages.chunk_gdn_prepare_backward

--- a/examples/kda_context_parallel.py
+++ b/examples/kda_context_parallel.py
@@ -1,28 +1,29 @@
 """Train a complete packed KDA attention module with context parallelism.
 
-This reuses the transformer-style module from ``kda_training.py`` and distributes both
-stateful operations: a halo exchange supplies the short convolution's finite history, then
-native affine summaries supply the KDA recurrence's full-prefix state. Each rank owns an
-equal contiguous token shard. Launch with:
+This reuses the transformer-style module from ``kda_training.py`` and distributes both stateful
+operations through the reference recipe in ``attn_gym.linear.context_parallel``: a halo
+exchange supplies the short convolution's finite history, then affine state summaries supply the
+KDA recurrence's full-prefix state. Each rank owns a list of global token ranges chosen here in
+plain Python (``token_ranges``), so the same code validates contiguous shards and zig-zag load
+balancing. Launch with:
 
     torchrun --standalone --nproc-per-node=2 examples/kda_context_parallel.py
 
-Add ``--compute-dtype=float16`` to validate the FP16 route. Add ``--cuda-graph`` to capture
-forward and backward together and validate a replay with changed inputs. Add ``--profile`` to
-export a merged native Perfetto trace using transformer-nuggets. The example requires one Hopper
-or datacenter Blackwell GPU per rank. Affine summaries use portable Triton kernels on Hopper and
-native UMMA kernels on SM100.
+Add ``--partition zigzag`` to give each rank two mirrored blocks, ``--compute-dtype=float16``
+to validate the FP16 route, ``--cuda-graph`` to capture forward and backward together and validate
+a replay with changed inputs, and ``--profile`` to export a merged native Perfetto trace using
+transformer-nuggets. The example requires one Hopper or datacenter Blackwell GPU per rank.
 """
 
 from __future__ import annotations
 
-import bisect
 import gc
 import os
 from collections.abc import Callable
 from dataclasses import dataclass
+from enum import Enum
 from functools import partial
-from itertools import accumulate, pairwise
+from itertools import accumulate
 from pathlib import Path
 from typing import Annotated
 
@@ -30,48 +31,47 @@ import torch
 import torch.distributed as dist
 import torch.nn.functional as F
 import typer
-from torch.distributed._functional_collectives import all_gather_single
 
-from attn_gym._backends.cute import normalize_compact_tensor
-from attn_gym.linear._delta_rule.cute import build_state_grad_summary, build_state_summary
-from attn_gym.linear.kda.bwd.cute.chunk_kda_bwd import (
-    _finish_chunk_kda_bwd,
-    _prepare_chunk_kda_bwd,
-)
-from attn_gym.linear.kda.chunk_schedule import prepare_ragged_chunk_metadata
-from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata, chunk_capacity
-from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd import (
-    _finish_chunk_kda_fwd,
-    _prepare_chunk_kda_fwd,
-)
-from attn_gym.linear.kda.ops import _plain_gate_scan_op
+from attn_gym.linear.context_parallel import ContextParallelPlan, context_parallel_conv_history
+from attn_gym.linear.kda.context_parallel import context_parallel_kda
 from attn_gym.testing import kernel_stage, record_distributed_profile
 from examples.kda_training import ComputeDTypeOption, KDAAttention, KDAAttentionOutput
 
-# The private prepare/finish seams avoid repeating factor computation around collectives.
-# TODO: Promote those seams before moving this orchestration out of the example.
-CHUNK_SIZE = 64
 
-# NOTE [One crossing sequence per contiguous rank boundary]
-# A rank owns one contiguous interval of the globally ordered packed token stream. Its boundary
-# is one cut point and can split at most one logical sequence: only the last local fragment can
-# continue forward, and only the first can receive a reverse cotangent. Therefore every rank
-# exchanges one fixed `[H,V+K,K]` summary in each direction regardless of how many complete packed
-# sequences it owns. A boundary between sequences sends an unused placeholder so collective shapes
-# and ordering remain uniform.
+class PartitionOption(str, Enum):
+    CONTIGUOUS = "contiguous"
+    ZIGZAG = "zigzag"
 
 
-@dataclass(frozen=True)
-class PackedShard:
-    """Packed sequence fragments intersecting one contiguous rank shard."""
+def token_ranges(
+    tokens: int, world_size: int, partition: PartitionOption
+) -> list[list[tuple[int, int]]]:
+    """Choose which global token ranges each rank owns, in its local layout order.
 
-    cu_seqlens: tuple[int, ...]
-    sequence_ids: tuple[int, ...]
+    Contiguous gives rank ``r`` block ``r`` of ``W`` equal blocks. Zig-zag gives it blocks ``r``
+    and ``2W - 1 - r`` of ``2W``: the load-balanced layout ring softmax attention uses for causal
+    masks, which a hybrid model's KDA layers inherit. Any other assignment is just a different
+    list; the plan cuts ranges at sequence boundaries itself.
+    """
+    blocks = world_size if partition is PartitionOption.CONTIGUOUS else 2 * world_size
+    if tokens % blocks:
+        raise ValueError(f"{tokens} tokens do not split into {blocks} equal blocks")
+    size = tokens // blocks
+    owned = [
+        [rank] if partition is PartitionOption.CONTIGUOUS else [rank, blocks - 1 - rank]
+        for rank in range(world_size)
+    ]
+    return [[(block * size, (block + 1) * size) for block in blocks_of] for blocks_of in owned]
 
 
 @dataclass(frozen=True)
 class PackedTrainingBatch:
-    """Global reference tensors and the corresponding rank-local packed shard."""
+    """Global reference tensors and this rank's fragments of them.
+
+    ``token_ids`` maps local positions to global token ids; ``terminal_index`` lists the local
+    fragments that end their sequence and ``terminal_sequences`` the matching global sequence
+    ids, so endpoint states can be compared with the unsharded run.
+    """
 
     global_hidden: torch.Tensor
     global_target: torch.Tensor
@@ -79,343 +79,10 @@ class PackedTrainingBatch:
     local_hidden: torch.Tensor
     local_target: torch.Tensor
     local_offsets: torch.Tensor
-    local_slice: slice
-    first_sequence: int
-    completed_sequences: int
-    sequence_count: int
+    token_ids: torch.Tensor
+    terminal_index: torch.Tensor
+    terminal_sequences: torch.Tensor
     loss_scale: float
-
-
-def partition_packed_sequences(
-    global_cu_seqlens: tuple[int, ...],
-    world_size: int,
-) -> tuple[PackedShard, ...]:
-    """Partition nonempty packed sequences into equal contiguous token shards."""
-    if len(global_cu_seqlens) < 2 or global_cu_seqlens[0] != 0:
-        raise ValueError("global_cu_seqlens must start at zero and contain at least one sequence")
-    if any(end <= start for start, end in pairwise(global_cu_seqlens)):
-        raise ValueError("this example requires strictly increasing global_cu_seqlens")
-    total_tokens = global_cu_seqlens[-1]
-    if total_tokens % world_size:
-        raise ValueError("total tokens must be divisible by the context-parallel world size")
-
-    shard_tokens = total_tokens // world_size
-    shards = []
-    for rank in range(world_size):
-        rank_start = rank * shard_tokens
-        rank_end = rank_start + shard_tokens
-        first_sequence = bisect.bisect_right(global_cu_seqlens[1:], rank_start)
-        sequence_end = bisect.bisect_left(global_cu_seqlens[:-1], rank_end)
-        sequence_ids = tuple(range(first_sequence, sequence_end))
-        interior_offsets = (
-            offset - rank_start
-            for offset in global_cu_seqlens[first_sequence + 1 : sequence_end]
-            if rank_start < offset < rank_end
-        )
-        shards.append(
-            PackedShard(
-                cu_seqlens=(0, *interior_offsets, shard_tokens),
-                sequence_ids=sequence_ids,
-            )
-        )
-    return tuple(shards)
-
-
-def merge_state(state: torch.Tensor, summary: torch.Tensor) -> torch.Tensor:
-    """Merge a packed V-first affine summary into a recurrent state."""
-    value_dim = state.shape[-2]
-    bias = summary[..., :value_dim, :]
-    transition = summary[..., value_dim:, :]
-    return state @ transition + bias
-
-
-class ContextParallelKDAFunction(torch.autograd.Function):
-    """Join native affine summaries, NCCL collectives, and the existing KDA core."""
-
-    @staticmethod
-    def compose_forward_initial_states(
-        gathered: torch.Tensor,
-        q: torch.Tensor,
-        v: torch.Tensor,
-        rank: int,
-        shards: tuple[PackedShard, ...],
-    ) -> torch.Tensor:
-        """Compose predecessor transfers into the first local sequence state."""
-        shard = shards[rank]
-        states = q.new_zeros(
-            len(shard.sequence_ids),
-            q.shape[2],
-            v.shape[-1],
-            q.shape[-1],
-            dtype=torch.float32,
-        )
-        first_state = states[0]
-        first_sequence = shard.sequence_ids[0]
-        for predecessor, predecessor_shard in zip(gathered[:rank], shards[:rank], strict=True):
-            if predecessor_shard.sequence_ids[-1] == first_sequence:
-                first_state = merge_state(first_state, predecessor)
-        return torch.cat((first_state.unsqueeze(0), states[1:]), dim=0)
-
-    @staticmethod
-    def compose_reverse_final_states(
-        gathered: torch.Tensor,
-        d_final_state: torch.Tensor | None,
-        initial_state: torch.Tensor,
-        rank: int,
-        shards: tuple[PackedShard, ...],
-    ) -> torch.Tensor:
-        """Compose successor reverse transfers into the last local state cotangent."""
-        incoming = torch.zeros_like(initial_state) if d_final_state is None else d_final_state
-        shard = shards[rank]
-        last_sequence = shard.sequence_ids[-1]
-        # See NOTE [One crossing sequence per contiguous rank boundary].
-        continues = rank + 1 < len(shards) and shards[rank + 1].sequence_ids[0] == last_sequence
-        if not continues:
-            return incoming
-
-        last_gradient = torch.zeros_like(incoming[-1])
-        for successor_rank in range(len(shards) - 1, rank, -1):
-            successor = shards[successor_rank]
-            if successor.sequence_ids[0] != last_sequence:
-                continue
-            last_gradient = merge_state(last_gradient, gathered[successor_rank])
-        incoming = incoming.clone()
-        incoming[-1] += last_gradient
-        return incoming
-
-    @staticmethod
-    def forward(
-        ctx,
-        q,
-        k,
-        v,
-        gate,
-        beta,
-        local_cu_seqlens,
-        group,
-        shards,
-        scale,
-        fastmath,
-        autotune,
-        annotate,
-    ):
-        rank = dist.get_rank(group)
-        metadata = prepare_ragged_chunk_metadata(local_cu_seqlens, q.shape[1], CHUNK_SIZE)
-        cumulative_gate = _plain_gate_scan_op(
-            gate, metadata.cu_seqlens, metadata.chunk_offsets, False
-        )
-        factors = _prepare_chunk_kda_fwd(
-            q,
-            k,
-            v,
-            cumulative_gate,
-            beta,
-            metadata,
-            scale=scale,
-            autotune=autotune,
-        )
-
-        shard = shards[rank]
-        # See NOTE [One crossing sequence per contiguous rank boundary].
-        continues = (
-            rank + 1 < len(shards) and shard.sequence_ids[-1] == shards[rank + 1].sequence_ids[0]
-        )
-        if continues:
-            start = shard.cu_seqlens[-2]
-            with kernel_stage("cp/fwd/summary", annotate):
-                summary = build_state_summary(
-                    factors.kg[:, start:],
-                    factors.w[:, start:],
-                    factors.u[:, start:],
-                    cumulative_gate[:, start:],
-                )
-        else:
-            summary = q.new_zeros(
-                q.shape[2],
-                v.shape[-1] + q.shape[-1],
-                q.shape[-1],
-                dtype=torch.float32,
-            )
-        with kernel_stage("cp/fwd/all_gather", annotate):
-            gathered = summary.new_empty(dist.get_world_size(group), *summary.shape)
-            dist.all_gather_single(gathered, summary.contiguous(), group=group)
-        with kernel_stage("cp/fwd/exclusive_prefix", annotate):
-            initial_state = ContextParallelKDAFunction.compose_forward_initial_states(
-                gathered, q, v, rank, shards
-            )
-        with kernel_stage("cp/fwd/local_output", annotate):
-            output, final_state = _finish_chunk_kda_fwd(
-                q,
-                cumulative_gate,
-                factors,
-                initial_state,
-                None,
-                None,
-                metadata,
-                scale=scale,
-                output_final_state=True,
-                autotune=autotune,
-            )
-        assert final_state is not None
-
-        ctx.save_for_backward(
-            q,
-            k,
-            v,
-            cumulative_gate,
-            beta,
-            factors.aqk,
-            factors.akk,
-            initial_state,
-            metadata.cu_seqlens,
-            metadata.chunk_offsets,
-        )
-        ctx.group = group
-        ctx.shards = shards
-        ctx.scale = scale
-        ctx.fastmath = fastmath
-        ctx.autotune = autotune
-        ctx.annotate = annotate
-        ctx.set_materialize_grads(False)
-        return output, final_state
-
-    @staticmethod
-    @torch.autograd.function.once_differentiable
-    def backward(ctx, d_output, d_final_state):
-        (
-            q,
-            k,
-            v,
-            cumulative_gate,
-            beta,
-            aqk,
-            akk,
-            initial_state,
-            cu_seqlens,
-            chunk_offsets,
-        ) = ctx.saved_tensors
-        rank = dist.get_rank(ctx.group)
-        shards = ctx.shards
-        shard = shards[rank]
-        metadata = RaggedChunkMetadata(
-            cu_seqlens,
-            chunk_offsets,
-            chunk_capacity(q.shape[1], cu_seqlens.shape[0] - 1, CHUNK_SIZE),
-            CHUNK_SIZE,
-        )
-        if d_output is None:
-            d_output = torch.zeros_like(v)
-        else:
-            d_output = normalize_compact_tensor(d_output)
-        if d_final_state is not None:
-            d_final_state = normalize_compact_tensor(d_final_state.float())
-        prepared = _prepare_chunk_kda_bwd(
-            q,
-            k,
-            v,
-            cumulative_gate,
-            beta,
-            akk,
-            d_output,
-            initial_state,
-            metadata,
-            scale=ctx.scale,
-            chunk_size=CHUNK_SIZE,
-            autotune=ctx.autotune,
-        )
-
-        continues_from_previous = (
-            rank > 0 and shards[rank - 1].sequence_ids[-1] == shard.sequence_ids[0]
-        )
-        if continues_from_previous:
-            stop = shard.cu_seqlens[1]
-            with kernel_stage("cp/bwd/summary", ctx.annotate, backward=False):
-                summary = build_state_grad_summary(
-                    prepared.qg[:, :stop],
-                    prepared.kg[:, :stop],
-                    prepared.w[:, :stop],
-                    d_output[:, :stop],
-                    aqk[:, :stop],
-                    cumulative_gate[:, :stop],
-                    ctx.scale,
-                )
-            if d_final_state is not None:
-                value_dim = v.shape[-1]
-                bias = merge_state(d_final_state[0], summary)
-                summary = torch.cat((bias, summary[..., value_dim:, :]), dim=-2)
-        else:
-            summary = q.new_zeros(
-                q.shape[2],
-                v.shape[-1] + q.shape[-1],
-                q.shape[-1],
-                dtype=torch.float32,
-            )
-        with kernel_stage("cp/bwd/all_gather", ctx.annotate, backward=False):
-            gathered = summary.new_empty(dist.get_world_size(ctx.group), *summary.shape)
-            dist.all_gather_single(gathered, summary.contiguous(), group=ctx.group)
-        with kernel_stage("cp/bwd/exclusive_suffix", ctx.annotate, backward=False):
-            incoming = ContextParallelKDAFunction.compose_reverse_final_states(
-                gathered,
-                d_final_state,
-                initial_state,
-                rank,
-                shards,
-            )
-        with kernel_stage("cp/bwd/local", ctx.annotate, backward=False):
-            dq, dk, dv, d_cumulative, db, _d_initial_state = _finish_chunk_kda_bwd(
-                q,
-                k,
-                v,
-                cumulative_gate,
-                beta,
-                aqk,
-                akk,
-                d_output,
-                incoming,
-                initial_state,
-                metadata,
-                prepared,
-                scale=ctx.scale,
-                chunk_size=CHUNK_SIZE,
-                fastmath=ctx.fastmath,
-                autotune=ctx.autotune,
-            )
-        d_gate = _plain_gate_scan_op(
-            d_cumulative,
-            metadata.cu_seqlens,
-            metadata.chunk_offsets,
-            True,
-        )
-        return dq, dk, dv, d_gate, db, None, None, None, None, None, None, None
-
-
-def context_parallel_kda(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    gate: torch.Tensor,
-    beta: torch.Tensor,
-    *,
-    group: dist.ProcessGroup,
-    shards: tuple[PackedShard, ...],
-    local_cu_seqlens: torch.Tensor,
-    annotate: bool = False,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    """Apply packed KDA with native CuTeDSL forward/reverse affine summaries."""
-    return ContextParallelKDAFunction.apply(
-        q,
-        k,
-        v,
-        gate.float(),
-        beta.float().contiguous(),
-        local_cu_seqlens,
-        group,
-        shards,
-        q.shape[-1] ** -0.5,
-        False,
-        False,
-        annotate,
-    )
 
 
 class ContextParallelKDAAttention(KDAAttention):
@@ -425,63 +92,12 @@ class ContextParallelKDAAttention(KDAAttention):
         self,
         *args,
         group: dist.ProcessGroup,
-        shards: tuple[PackedShard, ...],
-        global_cu_seqlens: tuple[int, ...],
+        plan: ContextParallelPlan,
         **kwargs,
     ) -> None:
         super().__init__(*args, **kwargs)
         self.cp_group = group
-        self.shards = shards
-        self.global_cu_seqlens = global_cu_seqlens
-
-    @staticmethod
-    def compose_conv_initial_states(
-        gathered_tails: torch.Tensor,
-        shard_tokens: int,
-        rank: int,
-        shards: tuple[PackedShard, ...],
-        global_cu_seqlens: tuple[int, ...],
-    ) -> torch.Tensor:
-        """Build packed short-convolution histories from fixed-size rank tails."""
-        state_length = gathered_tails.shape[1]
-        states = gathered_tails.new_zeros(
-            len(shards[rank].sequence_ids), state_length, gathered_tails.shape[-1]
-        )
-        boundary = rank * shard_tokens
-        sequence_start = global_cu_seqlens[shards[rank].sequence_ids[0]]
-        valid_length = min(state_length, boundary - sequence_start)
-        if valid_length:
-            stored_per_rank = min(state_length, shard_tokens)
-            predecessor_tokens = gathered_tails[:rank, -stored_per_rank:].flatten(0, 1)
-            states[0, -valid_length:] = predecessor_tokens[-valid_length:]
-        # Keep all ranks in the collective backward when the first sequence starts locally.
-        return states + gathered_tails.flatten()[0] * 0
-
-    @staticmethod
-    def build_conv_initial_states(
-        qkv: torch.Tensor,
-        group: dist.ProcessGroup,
-        shards: tuple[PackedShard, ...],
-        global_cu_seqlens: tuple[int, ...],
-        state_length: int,
-        annotate: bool,
-    ) -> torch.Tensor | None:
-        """All-gather rank tails and construct packed short-convolution histories."""
-        if state_length == 0:
-            return None
-        stored = min(state_length, qkv.shape[1])
-        tail = F.pad(qkv[0, -stored:], (0, 0, state_length - stored, 0))
-        with kernel_stage("cp/conv/halo", annotate):
-            gathered = all_gather_single(tail, gather_dim=0, group=group).view(
-                dist.get_world_size(group), state_length, qkv.shape[-1]
-            )
-        return ContextParallelKDAAttention.compose_conv_initial_states(
-            gathered,
-            qkv.shape[1],
-            dist.get_rank(group),
-            shards,
-            global_cu_seqlens,
-        )
+        self.plan = plan
 
     def short_convolution(
         self,
@@ -493,15 +109,10 @@ class ContextParallelKDAAttention(KDAAttention):
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         if initial_state is not None:
             raise ValueError("context parallelism constructs the short-convolution state")
-        state_length = self.qkv_conv1d.kernel_size[0] - 1
-        initial_state = self.build_conv_initial_states(
-            qkv,
-            self.cp_group,
-            self.shards,
-            self.global_cu_seqlens,
-            state_length,
-            self.enable_graph_annotations,
-        )
+        with kernel_stage("cp/conv/halo", self.enable_graph_annotations):
+            initial_state = context_parallel_conv_history(
+                qkv, self.plan, self.cp_group, self.qkv_conv1d.kernel_size[0] - 1
+            )
         return super().short_convolution(
             qkv,
             initial_state,
@@ -531,10 +142,10 @@ class ContextParallelKDAAttention(KDAAttention):
             v,
             gate,
             beta,
+            cu_seqlens=cu_seqlens,
+            plan=self.plan,
             group=self.cp_group,
-            shards=self.shards,
-            local_cu_seqlens=cu_seqlens,
-            annotate=self.enable_graph_annotations,
+            fastmath=self.fastmath,
         )
         return output, final_state if return_final_state else None
 
@@ -544,7 +155,7 @@ def run_training_step(
     hidden_states: torch.Tensor,
     target: torch.Tensor,
     cu_seqlens: torch.Tensor,
-    state_count: int,
+    state_index: torch.Tensor,
     loss_scale: float,
     *,
     annotate: bool = False,
@@ -559,9 +170,9 @@ def run_training_step(
     assert result.final_state is not None
     assert result.final_conv_state is not None
     loss = F.mse_loss(result.hidden_states.float(), target, reduction="sum") * loss_scale
-    if state_count:
-        loss = loss + 1e-4 * result.final_state[:state_count].square().sum()
-        loss = loss + 1e-4 * result.final_conv_state[:state_count].float().square().sum()
+    # Only true sequence ends carry a loss; intermediate fragment states are handed downstream.
+    loss = loss + 1e-4 * result.final_state[state_index].square().sum()
+    loss = loss + 1e-4 * result.final_conv_state[state_index].float().square().sum()
     inputs = (hidden_states, *tuple(module.parameters()))
     with kernel_stage("cp/bwd", annotate, backward=False):
         gradients = torch.autograd.grad(loss, inputs)
@@ -579,7 +190,7 @@ def validate_against_reference(
         batch.local_hidden,
         batch.local_target,
         batch.local_offsets,
-        batch.completed_sequences,
+        batch.terminal_index,
         batch.loss_scale,
     )
     reference_hidden = batch.global_hidden.detach().clone().requires_grad_()
@@ -588,7 +199,7 @@ def validate_against_reference(
         reference_hidden,
         batch.global_target,
         batch.global_offsets,
-        batch.sequence_count,
+        torch.arange(batch.global_offsets.shape[0] - 1, device=reference_hidden.device),
         batch.loss_scale,
     )
 
@@ -598,19 +209,16 @@ def validate_against_reference(
         atol=torch.finfo(model.compute_dtype).eps,
         rtol=torch.finfo(model.compute_dtype).eps,
     )
-    assert_close(result.hidden_states, reference_result.hidden_states[:, batch.local_slice])
-    assert_close(gradients[0], reference_gradients[0][:, batch.local_slice])
-    if batch.completed_sequences:
-        local_states = slice(0, batch.completed_sequences)
-        global_states = slice(
-            batch.first_sequence,
-            batch.first_sequence + batch.completed_sequences,
-        )
-        assert_close(result.final_state[local_states], reference_result.final_state[global_states])
-        assert_close(
-            result.final_conv_state[local_states],
-            reference_result.final_conv_state[global_states],
-        )
+    assert_close(result.hidden_states, reference_result.hidden_states[:, batch.token_ids])
+    assert_close(gradients[0], reference_gradients[0][:, batch.token_ids])
+    assert_close(
+        result.final_state[batch.terminal_index],
+        reference_result.final_state[batch.terminal_sequences],
+    )
+    assert_close(
+        result.final_conv_state[batch.terminal_index],
+        reference_result.final_conv_state[batch.terminal_sequences],
+    )
     for actual, expected in zip(gradients[1:], reference_gradients[1:], strict=True):
         reduced = actual.detach().clone()
         dist.all_reduce(reduced)
@@ -639,7 +247,7 @@ def validate_cuda_graph(
             capture_hidden.detach().clone().requires_grad_(),
             batch.local_target,
             batch.local_offsets,
-            batch.completed_sequences,
+            batch.terminal_index,
             batch.loss_scale,
         )
     warmup_stream.synchronize()
@@ -654,7 +262,7 @@ def validate_cuda_graph(
                 capture_hidden,
                 batch.local_target,
                 batch.local_offsets,
-                batch.completed_sequences,
+                batch.terminal_index,
                 batch.loss_scale,
                 annotate=annotations,
             )
@@ -671,7 +279,7 @@ def validate_cuda_graph(
                 eager_hidden,
                 batch.local_target,
                 batch.local_offsets,
-                batch.completed_sequences,
+                batch.terminal_index,
                 batch.loss_scale,
             )
         warmup_stream.synchronize()
@@ -710,7 +318,7 @@ def profile_eager_step(
             hidden_states,
             batch.local_target,
             batch.local_offsets,
-            batch.completed_sequences,
+            batch.terminal_index,
             batch.loss_scale,
         ),
         profile_path,
@@ -726,6 +334,10 @@ def main(
         str,
         typer.Option(help="Comma-separated nonempty packed sequence lengths."),
     ] = "256,1280,512",
+    partition: Annotated[
+        PartitionOption,
+        typer.Option(help="How ranks own fragments of the packed stream."),
+    ] = PartitionOption.CONTIGUOUS,
     hidden_size: Annotated[int, typer.Option(min=1, help="Transformer hidden size.")] = 256,
     heads: Annotated[int, typer.Option(min=1, help="Number of KDA heads.")] = 2,
     compute_dtype: Annotated[
@@ -769,21 +381,11 @@ def main(
 
     lengths = tuple(int(length) for length in sequence_lengths.split(","))
     global_cu_seqlens = tuple(accumulate(lengths, initial=0))
-    shards = partition_packed_sequences(global_cu_seqlens, world_size)
     tokens = global_cu_seqlens[-1]
-    shard_tokens = tokens // world_size
-    local_slice = slice(rank * shard_tokens, (rank + 1) * shard_tokens)
-    local_shard = shards[rank]
-    local_cu_seqlens = torch.tensor(
-        local_shard.cu_seqlens,
-        dtype=torch.int32,
-        device=device,
+    plan = ContextParallelPlan.from_token_ranges(
+        global_cu_seqlens, token_ranges(tokens, world_size, partition), rank
     )
-    global_offsets = torch.tensor(global_cu_seqlens, dtype=torch.int32, device=device)
-    continues = (
-        rank + 1 < world_size and local_shard.sequence_ids[-1] == shards[rank + 1].sequence_ids[0]
-    )
-    final_state_count = len(local_shard.sequence_ids) - int(continues)
+    token_ids = plan.global_token_ids(device)
 
     torch.manual_seed(0)
     model_options = {
@@ -796,11 +398,7 @@ def main(
         "device": device,
     }
     make_model = partial(
-        ContextParallelKDAAttention,
-        **model_options,
-        group=dist.group.WORLD,
-        shards=shards,
-        global_cu_seqlens=global_cu_seqlens,
+        ContextParallelKDAAttention, **model_options, group=dist.group.WORLD, plan=plan
     )
     model = make_model()
     reference_model = KDAAttention(**model_options)
@@ -812,14 +410,17 @@ def main(
     batch = PackedTrainingBatch(
         global_hidden=global_hidden,
         global_target=global_target,
-        global_offsets=global_offsets,
-        local_hidden=global_hidden[:, local_slice].clone().requires_grad_(),
-        local_target=global_target[:, local_slice],
-        local_offsets=local_cu_seqlens,
-        local_slice=local_slice,
-        first_sequence=local_shard.sequence_ids[0],
-        completed_sequences=final_state_count,
-        sequence_count=len(lengths),
+        global_offsets=torch.tensor(global_cu_seqlens, dtype=torch.int32, device=device),
+        local_hidden=global_hidden[:, token_ids].clone().requires_grad_(),
+        local_target=global_target[:, token_ids],
+        local_offsets=torch.tensor(plan.cu_seqlens, dtype=torch.int32, device=device),
+        token_ids=token_ids,
+        terminal_index=torch.tensor(plan.terminal, dtype=torch.long, device=device),
+        terminal_sequences=torch.tensor(
+            [plan.fragments[index].sequence for index in plan.terminal],
+            dtype=torch.long,
+            device=device,
+        ),
         loss_scale=1.0 / global_target.numel(),
     )
     validate_against_reference(model, reference_model, batch)
@@ -828,8 +429,8 @@ def main(
     profile_mode = "cuda_graph" if cuda_graph else "eager"
     profile_path = Path(
         "data",
-        f"kda_context_parallel_{profile_mode}_{compute_dtype.value}_w{world_size}_t{tokens}"
-        f"_h{heads}_c{hidden_size}_conv{short_conv_kernel_size}",
+        f"kda_context_parallel_{profile_mode}_{partition.value}_{compute_dtype.value}"
+        f"_w{world_size}_t{tokens}_h{heads}_c{hidden_size}_conv{short_conv_kernel_size}",
     ).resolve()
     if cuda_graph:
         validate_cuda_graph(
@@ -844,7 +445,7 @@ def main(
         profile_eager_step(model, batch, profile_path, device)
 
     mode = " with CUDA Graph replay" if cuda_graph else ""
-    print(f"rank {rank}: full packed KDA CP passed{mode}", flush=True)
+    print(f"rank {rank}: full packed KDA CP ({partition.value}) passed{mode}", flush=True)
     torch.cuda.synchronize(device)
     dist.destroy_process_group()
 

--- a/test/test_context_parallel_distributed.py
+++ b/test/test_context_parallel_distributed.py
@@ -1,0 +1,112 @@
+"""Two-GPU NCCL check of the public context-parallel recipe against the unsharded ops.
+
+The single-GPU stages tests drive ``prepare``/``run`` and the fold helpers directly; this test
+runs ``context_parallel_kda``/``context_parallel_gdn`` themselves, so the autograd Function, the
+all-gather, and the ``d_final_state=None`` backward path are exercised end to end.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+from functools import partial
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+pytestmark = pytest.mark.skipif(
+    torch.cuda.device_count() < 2, reason="needs two visible CUDA devices"
+)
+
+CU_SEQLENS = (0, 40, 232, 384)
+HEADS, HEAD_DIM = 2, 128
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _rank_main(rank: int, world: int, port: int, op_name: str, final_state_loss: bool) -> None:
+    from attn_gym.linear.context_parallel import ContextParallelPlan
+    from attn_gym.linear.gdn import chunk_gdn, context_parallel_gdn
+    from attn_gym.linear.kda import chunk_kda, context_parallel_kda
+
+    device = torch.device("cuda", rank)
+    torch.cuda.set_device(device)
+    os.environ.update(MASTER_ADDR="127.0.0.1", MASTER_PORT=str(port))
+    dist.init_process_group("nccl", rank=rank, world_size=world, device_id=device)
+    try:
+        tokens = CU_SEQLENS[-1]
+        generator = torch.Generator(device=device).manual_seed(0)
+        randn = partial(torch.randn, device=device, generator=generator)
+        q = torch.nn.functional.normalize(randn(1, tokens, HEADS, HEAD_DIM), dim=-1).bfloat16()
+        k = torch.nn.functional.normalize(randn(1, tokens, HEADS, HEAD_DIM), dim=-1).bfloat16()
+        v = randn(1, tokens, HEADS, HEAD_DIM).bfloat16()
+        gate_shape = (1, tokens, HEADS) + ((HEAD_DIM,) if op_name == "kda" else ())
+        gate = -torch.rand(gate_shape, device=device, generator=generator)
+        beta = torch.rand(1, tokens, HEADS, device=device, generator=generator)
+        d_output = randn(1, tokens, HEADS, HEAD_DIM).bfloat16()
+        d_final = randn(len(CU_SEQLENS) - 1, HEADS, HEAD_DIM, HEAD_DIM)
+
+        # Unsharded oracle with the same loss structure.
+        inputs = tuple(t.clone().requires_grad_() for t in (q, k, v, gate, beta))
+        chunk = chunk_kda if op_name == "kda" else chunk_gdn
+        offsets = torch.tensor(CU_SEQLENS, dtype=torch.int32, device=device)
+        output, final = chunk(*inputs, cu_seqlens=offsets, output_final_state=True)
+        outputs = (output, final) if final_state_loss else (output,)
+        cotangents = (d_output, d_final) if final_state_loss else (d_output,)
+        expected_grads = torch.autograd.grad(outputs, inputs, grad_outputs=cotangents)
+
+        # Zig-zag: rank r owns blocks r and 2 * world - 1 - r of 2 * world equal blocks.
+        block = tokens // (2 * world)
+        ranges = [
+            [(r * block, (r + 1) * block), ((2 * world - 1 - r) * block, (2 * world - r) * block)]
+            for r in range(world)
+        ]
+        plan = ContextParallelPlan.from_token_ranges(CU_SEQLENS, ranges, rank)
+        ids = plan.global_token_ids(device)
+        local = tuple(t[:, ids].clone().requires_grad_() for t in (q, k, v, gate, beta))
+        cp = context_parallel_kda if op_name == "kda" else context_parallel_gdn
+        local_output, exit_states = cp(
+            *local,
+            cu_seqlens=torch.tensor(plan.cu_seqlens, dtype=torch.int32, device=device),
+            plan=plan,
+            group=dist.group.WORLD,
+        )
+        local_outputs = (local_output,)
+        local_cotangents = [d_output[:, ids]]
+        if final_state_loss:
+            d_exit = torch.zeros_like(exit_states)
+            for index in plan.terminal:
+                d_exit[index] = d_final[plan.fragments[index].sequence]
+            local_outputs = (local_output, exit_states)
+            local_cotangents.append(d_exit)
+        grads = torch.autograd.grad(local_outputs, local, grad_outputs=local_cotangents)
+
+        eps = torch.finfo(torch.bfloat16).eps
+        for actual, expected in zip(
+            (local_output, *grads), (output[:, ids], *(g[:, ids] for g in expected_grads))
+        ):
+            expected = expected.float()
+            torch.testing.assert_close(
+                actual.float(),
+                expected,
+                atol=eps * max(expected.abs().max().item(), 1.0),
+                rtol=eps,
+            )
+        for index in plan.terminal:
+            torch.testing.assert_close(
+                exit_states[index], final[plan.fragments[index].sequence], atol=eps, rtol=eps
+            )
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.parametrize("op_name", ["kda", "gdn"])
+@pytest.mark.parametrize("final_state_loss", [True, False], ids=["with-final", "output-only"])
+def test_context_parallel_matches_unsharded_op_on_two_ranks(op_name, final_state_loss):
+    mp.spawn(_rank_main, args=(2, _free_port(), op_name, final_state_loss), nprocs=2, join=True)

--- a/test/test_delta_rule_stages.py
+++ b/test/test_delta_rule_stages.py
@@ -1,0 +1,303 @@
+"""Staged KDA/GDN primitives and the context-parallel recipe simulated in one process."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from functools import partial
+from typing import NamedTuple
+
+import pytest
+import torch
+
+pytest.importorskip("cutlass")
+
+from attn_gym.linear.context_parallel import (
+    ContextParallelPlan,
+    compose_entry_states,
+    compose_exit_cotangents,
+    grad_summary_slots,
+    summary_slots,
+)
+from attn_gym.linear.gdn import chunk_gdn
+from attn_gym.linear.gdn.stages import chunk_gdn_prepare, chunk_gdn_prepare_backward
+from attn_gym.linear.kda import chunk_kda
+from attn_gym.linear.kda.stages import chunk_kda_prepare, chunk_kda_prepare_backward
+from attn_gym.linear.state_summary import compose_summaries, merge_state, neutral_summary
+
+HEAD_DIM = 128
+
+requires_kda_target = pytest.mark.skipif(
+    not (torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 8),
+    reason="fused delta-rule kernels require CUDA capability 8.0+",
+)
+
+
+class Op(NamedTuple):
+    """One delta-rule variant: its public op plus staged entry points and input generator."""
+
+    chunk: Callable[..., tuple[torch.Tensor, torch.Tensor | None]]
+    reference: Callable[..., tuple[torch.Tensor, torch.Tensor | None]]
+    prepare: Callable[..., object]
+    prepare_backward: Callable[..., object]
+    key_heads: int
+    value_heads: int
+    vector_gate: bool  # KDA gates are per channel [1, T, HV, K]; GDN gates are per head [1, T, HV]
+
+    def make_inputs(self, tokens: int, seed: int, dtype: torch.dtype = torch.bfloat16):
+        """Unit-norm Q/K, random V, negative log gates, and beta in (0, 1)."""
+        generator = torch.Generator(device="cuda").manual_seed(seed)
+        randn = partial(torch.randn, device="cuda", generator=generator)
+        q = torch.nn.functional.normalize(randn(1, tokens, self.key_heads, HEAD_DIM), dim=-1)
+        k = torch.nn.functional.normalize(randn(1, tokens, self.key_heads, HEAD_DIM), dim=-1)
+        v = randn(1, tokens, self.value_heads, HEAD_DIM)
+        gate_shape = (1, tokens, self.value_heads) + ((HEAD_DIM,) if self.vector_gate else ())
+        gate = -torch.rand(gate_shape, device="cuda", generator=generator)
+        beta = torch.rand(1, tokens, self.value_heads, device="cuda", generator=generator)
+        return q.to(dtype), k.to(dtype), v.to(dtype), gate, beta
+
+
+KDA = Op(
+    chunk_kda,
+    partial(chunk_kda, impl="reference"),
+    chunk_kda_prepare,
+    chunk_kda_prepare_backward,
+    key_heads=2,
+    value_heads=2,
+    vector_gate=True,
+)
+GDN = Op(
+    partial(chunk_gdn, impl="fused"),
+    partial(chunk_gdn, impl="reference"),
+    chunk_gdn_prepare,
+    chunk_gdn_prepare_backward,
+    key_heads=2,
+    value_heads=2,
+    vector_gate=False,
+)
+op_param = pytest.mark.parametrize(
+    "op",
+    [
+        pytest.param(KDA, id="kda"),
+        pytest.param(GDN, id="gdn"),
+        pytest.param(GDN._replace(key_heads=1), id="gdn-gqa"),
+    ],
+)
+
+
+def assert_close(actual: torch.Tensor, expected: torch.Tensor, dtype: torch.dtype) -> None:
+    # Sharding changes accumulation order and low-precision outputs round at the tensor's
+    # magnitude, so allow one input-precision ulp of the largest expected value.
+    eps = torch.finfo(dtype).eps
+    expected = expected.float()
+    torch.testing.assert_close(
+        actual.float(), expected, atol=eps * max(expected.abs().max().item(), 1.0), rtol=eps
+    )
+
+
+def relative_rms_error(actual: torch.Tensor, reference: torch.Tensor) -> float:
+    """Relative RMS error against an FP32 oracle."""
+    return ((actual.float() - reference).square().mean() / reference.square().mean()).sqrt().item()
+
+
+def test_summary_algebra_composes_like_sequential_merges():
+    generator = torch.Generator().manual_seed(0)
+    first = torch.randn(2, 6, 4, generator=generator)
+    then = torch.randn(2, 6, 4, generator=generator)
+    state = torch.randn(2, 2, 4, generator=generator)
+
+    sequential = merge_state(merge_state(state, first), then)
+    composed = compose_summaries(first, then)
+    torch.testing.assert_close(merge_state(state, composed), sequential)
+    # Spelled out: (A0, B0) then (A1, B1) is (A0 @ A1, B0 @ A1 + B1), packed [bias; transition].
+    bias, transition = first[:, :2], first[:, 2:]
+    torch.testing.assert_close(
+        composed, torch.cat((bias @ then[:, 2:] + then[:, :2], transition @ then[:, 2:]), dim=1)
+    )
+
+    identity = neutral_summary(2, 2, 4, device="cpu")
+    torch.testing.assert_close(merge_state(state, identity), state)
+    torch.testing.assert_close(compose_summaries(identity, first), first)
+    torch.testing.assert_close(compose_summaries(first, identity), first)
+
+
+@requires_kda_target
+@op_param
+def test_prepare_run_matches_chunk_op_with_packed_initial_state(op):
+    """``prepare`` + ``run`` is the public op's own kernel sequence, so results are bitwise equal."""
+    q, k, v, gate, beta = op.make_inputs(320, seed=1)
+    cu_seqlens = torch.tensor([0, 100, 320], dtype=torch.int32, device="cuda")
+    initial_state = torch.randn(2, op.value_heads, HEAD_DIM, HEAD_DIM, device="cuda")
+
+    expected, expected_state = op.chunk(
+        q, k, v, gate, beta, initial_state, cu_seqlens=cu_seqlens, output_final_state=True
+    )
+    prepared = op.prepare(q, k, v, gate, beta, cu_seqlens=cu_seqlens)
+    output, final_state = prepared.run(initial_state, output_final_state=True)
+
+    torch.testing.assert_close(output, expected, atol=0, rtol=0)
+    torch.testing.assert_close(final_state, expected_state, atol=0, rtol=0)
+
+
+@requires_kda_target
+@op_param
+@pytest.mark.parametrize("tokens", [128, 70], ids=["complete-chunks", "partial-tail"])
+def test_prepare_run_matches_chunk_op_unpacked_with_strided_qkv(op, tokens):
+    """Unpacked inputs and last-dim-strided Q/K/V follow the same normalization as the op."""
+    q, k, v, gate, beta = op.make_inputs(tokens, seed=6)
+    q, k, v = (torch.stack((tensor, tensor), dim=-1)[..., 0] for tensor in (q, k, v))
+    assert q.stride(-1) == 2
+
+    # The fused ops accept either layout and the stages normalize strided inputs themselves; the
+    # reference gets compact copies so the same call also serves ops that reject strides.
+    expected, _ = op.chunk(q.contiguous(), k.contiguous(), v.contiguous(), gate, beta)
+    output, final_state = op.prepare(q, k, v, gate, beta).run()
+
+    torch.testing.assert_close(output, expected, atol=0, rtol=0)
+    assert final_state is None
+
+
+@requires_kda_target
+@op_param
+def test_state_summary_matches_zero_and_identity_probes(op):
+    """``final(H) = H @ A + B`` for every H, so zero and identity probes recover ``[B; A]``."""
+    q, k, v, gate, beta = op.make_inputs(200, seed=2)
+    cu_seqlens = torch.tensor([0, 72, 200], dtype=torch.int32, device="cuda")
+    prepared = op.prepare(q, k, v, gate, beta, cu_seqlens=cu_seqlens)
+
+    zero = torch.zeros(2, op.value_heads, HEAD_DIM, HEAD_DIM, device="cuda")
+    identity = torch.eye(HEAD_DIM, device="cuda").expand_as(zero).contiguous()
+    _, bias = op.chunk(q, k, v, gate, beta, zero, cu_seqlens=cu_seqlens, output_final_state=True)
+    _, shifted = op.chunk(
+        q, k, v, gate, beta, identity, cu_seqlens=cu_seqlens, output_final_state=True
+    )
+    for index, (start, stop) in enumerate(((0, 72), (72, 200))):
+        summary = prepared.state_summary(start, stop)
+        assert summary.shape == (op.value_heads, 2 * HEAD_DIM, HEAD_DIM)
+        assert_close(summary[:, :HEAD_DIM], bias[index], torch.bfloat16)
+        assert_close(summary[:, HEAD_DIM:], shifted[index] - bias[index], torch.bfloat16)
+
+
+@requires_kda_target
+def test_state_summary_rejects_ranges_outside_the_stream():
+    q, k, v, gate, beta = KDA.make_inputs(128, seed=3)
+    prepared = chunk_kda_prepare(q, k, v, gate, beta)
+    with pytest.raises(ValueError, match="summary range"):
+        prepared.state_summary(64, 200)
+    with pytest.raises(ValueError, match="summary range"):
+        prepared.state_summary(64, 64)
+
+
+class RankResult(NamedTuple):
+    plan: ContextParallelPlan
+    token_ids: torch.Tensor
+    output: torch.Tensor
+    final_state: torch.Tensor
+    grads: tuple[torch.Tensor, ...]  # dq, dk, dv, dgate, dbeta
+
+
+def simulate_context_parallel(
+    op: Op, global_cu_seqlens, token_ranges, inputs, d_output, d_final_state
+) -> list[RankResult]:
+    """Run the recipe for every rank in one process, replacing each all-gather with a stack."""
+    q, _, v, _, _ = inputs
+    device = q.device
+    ranks = range(len(token_ranges))
+    plans = [
+        ContextParallelPlan.from_token_ranges(global_cu_seqlens, token_ranges, rank)
+        for rank in ranks
+    ]
+    token_ids = [plan.global_token_ids(device) for plan in plans]
+    prepared = [
+        op.prepare(
+            *(tensor[:, token_ids[r]] for tensor in inputs),
+            cu_seqlens=torch.tensor(plans[r].cu_seqlens, dtype=torch.int32, device=device),
+        )
+        for r in ranks
+    ]
+    neutral = neutral_summary(v.shape[2], v.shape[-1], q.shape[-1], device=device)
+
+    gathered = torch.stack([summary_slots(prepared[r], plans[r], neutral) for r in ranks])
+    initial_states = [compose_entry_states(gathered, plans[r]) for r in ranks]
+    forward = [prepared[r].run(initial_states[r], output_final_state=True) for r in ranks]
+
+    # The loss's state cotangent reaches only the fragments that end their sequence.
+    d_exit_states = [
+        torch.stack(
+            [
+                d_final_state[fragment.sequence]
+                if index in plan.terminal
+                else torch.zeros_like(d_final_state[0])
+                for index, fragment in enumerate(plan.fragments)
+            ]
+        )
+        for plan in plans
+    ]
+    grads = [
+        op.prepare_backward(prepared[r].saved, d_output[:, token_ids[r]], initial_states[r])
+        for r in ranks
+    ]
+    gathered = torch.stack(
+        [grad_summary_slots(grads[r], d_exit_states[r], plans[r], neutral) for r in ranks]
+    )
+    input_grads = [
+        grads[r].run(compose_exit_cotangents(gathered, d_exit_states[r], plans[r]))[:5]
+        for r in ranks
+    ]
+    return [RankResult(plans[r], token_ids[r], *forward[r], input_grads[r]) for r in ranks]
+
+
+# Sequences [0, 40), [40, 232), [232, 384); each entry lists one rank's global token ranges.
+CU_SEQLENS = (0, 40, 232, 384)
+LAYOUTS = [
+    pytest.param([[(0, 192)], [(192, 384)]], id="contiguous-2"),
+    pytest.param([[(0, 96), (288, 384)], [(96, 192), (192, 288)]], id="zigzag-2"),
+    pytest.param(
+        [[(0, 64), (320, 384)], [(64, 128), (256, 320)], [(128, 192), (192, 256)]], id="zigzag-3"
+    ),
+    # Uneven ownership: rank 0 holds one short piece, rank 1 the rest in reversed order.
+    pytest.param([[(96, 160)], [(160, 384), (0, 96)]], id="uneven-reordered"),
+]
+
+
+@requires_kda_target
+@op_param
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "fp16"])
+@pytest.mark.parametrize("layout", LAYOUTS)
+def test_simulated_context_parallel_matches_unsharded_op(op, layout, dtype):
+    q, k, v, gate, beta = op.make_inputs(CU_SEQLENS[-1], seed=4, dtype=dtype)
+    inputs = tuple(tensor.detach().clone().requires_grad_() for tensor in (q, k, v, gate, beta))
+    offsets = torch.tensor(CU_SEQLENS, dtype=torch.int32, device="cuda")
+
+    output, final_state = op.chunk(*inputs, cu_seqlens=offsets, output_final_state=True)
+    generator = torch.Generator(device="cuda").manual_seed(5)
+    d_output = torch.randn(output.shape, device="cuda", generator=generator).to(output.dtype)
+    d_final_state = torch.randn(final_state.shape, device="cuda", generator=generator)
+    expected_grads = torch.autograd.grad(
+        (output, final_state), inputs, grad_outputs=(d_output, d_final_state)
+    )
+
+    # Sharding must not cost accuracy: measure both paths against the FP32 eager oracle.
+    f32 = tuple(tensor.detach().float().requires_grad_() for tensor in (q, k, v, gate, beta))
+    ref_output, ref_final = op.reference(*f32, cu_seqlens=offsets, output_final_state=True)
+    ref_grads = torch.autograd.grad(
+        (ref_output, ref_final), f32, grad_outputs=(d_output.float(), d_final_state)
+    )
+
+    results = simulate_context_parallel(
+        op, CU_SEQLENS, layout, (q, k, v, gate, beta), d_output, d_final_state
+    )
+    for result in results:
+        ids = result.token_ids
+        assert_close(result.output, output[:, ids], dtype)
+        for index in result.plan.terminal:
+            sequence = result.plan.fragments[index].sequence
+            assert_close(result.final_state[index], final_state[sequence], dtype)
+        for actual, expected, reference in zip(
+            result.grads, expected_grads, ref_grads, strict=True
+        ):
+            assert_close(actual, expected[:, ids], dtype)
+            sharded = relative_rms_error(actual, reference[:, ids])
+            unsharded = relative_rms_error(expected[:, ids], reference[:, ids])
+            # Small fragments give noisy per-rank statistics; a systematic precision loss in the
+            # summary path shows up as a multiple, not a fraction, of the unsharded error.
+            assert sharded <= 1.5 * unsharded + 1e-6, (sharded, unsharded)

--- a/test/test_kda_context_parallel.py
+++ b/test/test_kda_context_parallel.py
@@ -1,174 +1,234 @@
-"""Small CPU tests for context-parallel state routing."""
+"""Small CPU tests for context-parallel ownership plans and state routing."""
 
 from __future__ import annotations
 
 import pytest
 import torch
 
-pytest.importorskip("cutlass")
-
-from examples.kda_context_parallel import (
-    ContextParallelKDAAttention,
-    ContextParallelKDAFunction,
-    PackedShard,
+import attn_gym.linear.context_parallel as cpmod
+from attn_gym.linear.context_parallel import (
+    ContextParallelPlan,
+    Fragment,
+    compose_conv_histories,
+    compose_entry_states,
+    compose_exit_cotangents,
 )
 
+VALUE_DIM = 2
+KEY_DIM = 2
 
-def _summary(transition: list[list[float]], bias: list[list[float]]) -> torch.Tensor:
-    transition_tensor = torch.tensor(transition, dtype=torch.float32).unsqueeze(0)
-    bias_tensor = torch.tensor(bias, dtype=torch.float32).unsqueeze(0)
-    return torch.cat((bias_tensor, transition_tensor), dim=-2)
+# Sequences [0,1), [1,7), [7,8) over four ranks of two contiguous tokens each.
+CONV_CU_SEQLENS = (0, 1, 7, 8)
+CONV_RANGES = [[(0, 2)], [(2, 4)], [(4, 6)], [(6, 8)]]
+CONV_PLANS = [
+    ContextParallelPlan.from_token_ranges(CONV_CU_SEQLENS, CONV_RANGES, rank) for rank in range(4)
+]
 
 
-def _apply(state: torch.Tensor, summary: torch.Tensor) -> torch.Tensor:
+def summary(transition: list[list[float]], bias: list[list[float]]) -> torch.Tensor:
+    """One-head ``[bias; transition]`` summary."""
+    return torch.cat(
+        (torch.tensor(bias, dtype=torch.float32), torch.tensor(transition, dtype=torch.float32))
+    ).unsqueeze(0)
+
+
+def apply(state: torch.Tensor, packed: torch.Tensor) -> torch.Tensor:
     """Independent affine-map oracle for the routing tests."""
-    return state @ summary[:, 2:, :] + summary[:, :2, :]
+    return state @ packed[:, VALUE_DIM:, :] + packed[:, :VALUE_DIM, :]
 
 
-def test_short_conv_halo_spans_multiple_small_shards_and_resets_at_documents():
-    global_cu_seqlens = (0, 1, 7, 8)
-    shards = (
-        PackedShard(cu_seqlens=(0, 1, 2), sequence_ids=(0, 1)),
-        PackedShard(cu_seqlens=(0, 2), sequence_ids=(1,)),
-        PackedShard(cu_seqlens=(0, 2), sequence_ids=(1,)),
-        PackedShard(cu_seqlens=(0, 1, 2), sequence_ids=(1, 2)),
+UNUSED = summary([[7, 7], [7, 7]], [[7, 7], [7, 7]])
+
+
+def with_unused_slot(first: torch.Tensor) -> torch.Tensor:
+    """One rank's two gather slots where only the first is consumed."""
+    return torch.stack((first, UNUSED))
+
+
+@pytest.mark.parametrize(
+    ("cu_seqlens", "ranges", "message"),
+    [
+        pytest.param((0, 4), [[(0, 2)], [(3, 4)]], "tile", id="gap"),
+        pytest.param((0, 4), [[(0, 2)], [(1, 4)]], "tile", id="overlap"),
+        pytest.param((0, 4), [[(1, 4)]], "tile", id="missing-prefix"),
+        pytest.param((0, 4), [[(0, 3)]], "tile", id="missing-suffix"),
+        pytest.param((0, 4), [[(0, 2)], [(2, 4), (0, 2)]], "tile", id="duplicate"),
+        pytest.param((0, 4), [[(0, 4)], []], "at least one", id="empty-rank"),
+        pytest.param((0, 4), [[(2, 2), (0, 4)]], "empty", id="empty-range"),
+        pytest.param((0,), [[(0, 4)]], "at least one sequence", id="no-sequences"),
+        pytest.param((1, 4), [[(0, 4)]], "start at zero", id="offset-stream"),
+        pytest.param((0, 4, 2), [[(0, 4)]], "nondecreasing", id="decreasing-offsets"),
+    ],
+)
+def test_plan_rejects_ranges_that_do_not_tile_the_stream(cu_seqlens, ranges, message):
+    with pytest.raises(ValueError, match=message):
+        ContextParallelPlan.from_token_ranges(cu_seqlens, ranges, rank=0)
+
+
+def test_plan_rejects_rank_outside_table():
+    with pytest.raises(ValueError, match="rank 2"):
+        ContextParallelPlan.from_token_ranges((0, 4), [[(0, 2)], [(2, 4)]], rank=2)
+
+
+def test_plan_cuts_ranges_at_sequences_and_orders_neighbors():
+    # A = [0, 8), B = [8, 12); rank 0 owns A[0:2], then the block [6, 10) spanning A and B.
+    ranges = [[(0, 2), (6, 10)], [(2, 6), (10, 12)]]
+
+    plan = ContextParallelPlan.from_token_ranges((0, 8, 12), ranges, rank=0)
+    assert plan.fragments == (Fragment(0, 0, 2), Fragment(0, 6, 8), Fragment(1, 8, 10))
+    assert plan.table[1] == (Fragment(0, 2, 6), Fragment(1, 10, 12))
+    assert plan.cu_seqlens == (0, 2, 4, 6)
+    assert plan.slots == 3
+    assert plan.predecessors == ((), ((0, 0), (1, 0)), ())
+    assert plan.successors == (((0, 1), (1, 0)), (), ((1, 1),))
+    assert plan.terminal == (1,)
+    assert plan.global_token_ids("cpu").tolist() == [0, 1, 6, 7, 8, 9]
+
+    other = ContextParallelPlan.from_token_ranges((0, 8, 12), ranges, rank=1)
+    assert other.slots == 3
+    assert other.predecessors == (((0, 0),), ((0, 2),))
+    assert other.successors == (((0, 1),), ())
+    assert other.terminal == (1,)
+
+
+def test_plan_skips_empty_sequences_and_chains_adjacent_ranges_on_one_rank():
+    # Sequence 1 is empty, so it owns no fragment anywhere while sequence 2 keeps its index.
+    ranges = [[(0, 2), (2, 4)], [(4, 8)]]
+    plan = ContextParallelPlan.from_token_ranges((0, 4, 4, 8), ranges, rank=0)
+    assert plan.fragments == (Fragment(0, 0, 2), Fragment(0, 2, 4))
+    assert plan.predecessors == ((), ((0, 0),))
+    assert plan.terminal == (1,)
+    other = ContextParallelPlan.from_token_ranges((0, 4, 4, 8), ranges, rank=1)
+    assert other.fragments == (Fragment(2, 4, 8),)
+    assert other.predecessors == ((),)
+
+
+def test_entry_states_share_prefixes_across_fragments_of_one_sequence(monkeypatch):
+    """A rank holding many pieces of one sequence folds each predecessor once, not per piece."""
+    pieces = [(i * 4, (i + 1) * 4) for i in range(8)]
+    plan = ContextParallelPlan.from_token_ranges((0, 32), [pieces[:4], pieces[4:]], rank=1)
+    gathered = torch.randn(2, 4, 1, 3, 2)
+    merges = []
+    merge_state = cpmod.merge_state
+    monkeypatch.setattr(cpmod, "merge_state", lambda s, a: merges.append(1) or merge_state(s, a))
+    entry = compose_entry_states(gathered, plan)
+    # Fragments 4..7 have 4..7 predecessors each; the shared prefix means 7 merges, not 22.
+    assert len(merges) == 7
+    expected = torch.zeros(1, 1, 2)
+    for owner, slot in plan.predecessors[-1]:
+        expected = merge_state(expected, gathered[owner, slot])
+    torch.testing.assert_close(entry[-1], expected)
+
+
+def test_entry_and_exit_folds_follow_fragment_geometry_for_every_fragment():
+    """Independently derive each fragment's chain from token order and compare both folds."""
+    cu_seqlens = (0, 5, 5, 12, 16)
+    ranges = [[(0, 3), (13, 16)], [(3, 7), (11, 13)], [(7, 11)]]
+    plans = [ContextParallelPlan.from_token_ranges(cu_seqlens, ranges, rank) for rank in range(3)]
+    generator = torch.Generator().manual_seed(3)
+    gathered = torch.randn(3, max(p.slots for p in plans), 1, 4, 2, generator=generator)
+    everything = [(r, s, f) for r, row in enumerate(plans[0].table) for s, f in enumerate(row)]
+    zero = torch.zeros(1, VALUE_DIM, KEY_DIM)
+    for plan in plans:
+        entries = compose_entry_states(gathered, plan)
+        exits = compose_exit_cotangents(gathered, None, plan)
+        for index, fragment in enumerate(plan.fragments):
+            siblings = [(r, s, f) for r, s, f in everything if f.sequence == fragment.sequence]
+            earlier = sorted((f.start, r, s) for r, s, f in siblings if f.start < fragment.start)
+            later = sorted((f.start, r, s) for r, s, f in siblings if f.start > fragment.start)
+            entry = zero
+            for _, r, s in earlier:
+                entry = apply(entry, gathered[r, s])
+            exit_cotangent = zero
+            for _, r, s in reversed(later):
+                exit_cotangent = apply(exit_cotangent, gathered[r, s])
+            torch.testing.assert_close(entries[index], entry)
+            torch.testing.assert_close(exits[index], exit_cotangent)
+            assert (index in plan.terminal) == (not later)
+
+
+def test_plan_handles_leading_and_trailing_empty_sequences():
+    plan = ContextParallelPlan.from_token_ranges((0, 0, 4, 4), [[(0, 4)]], rank=0)
+    assert plan.fragments == (Fragment(1, 0, 4),)
+    assert plan.terminal == (0,)
+    with pytest.raises(ValueError, match="empty"):
+        ContextParallelPlan.from_token_ranges((0, 0), [[(0, 0)]], rank=0)
+
+
+def test_entry_states_fold_predecessors_from_zero_in_token_order():
+    ranges = [[(0, 2), (9, 10)], [(2, 4)], [(4, 9)]]
+    plans = [ContextParallelPlan.from_token_ranges((0, 9, 10), ranges, rank) for rank in range(3)]
+    gathered = torch.stack(
+        (
+            with_unused_slot(summary([[1, 2], [0, 1]], [[1, 0], [0, 2]])),
+            with_unused_slot(summary([[2, 0], [3, 1]], [[0, 1], [2, 0]])),
+            with_unused_slot(summary([[5, 5], [5, 5]], [[5, 5], [5, 5]])),
+        )
     )
-    gathered_tails = torch.tensor(
+
+    zero = torch.zeros(1, VALUE_DIM, KEY_DIM)
+    torch.testing.assert_close(
+        compose_entry_states(gathered, plans[2])[0],
+        apply(apply(zero, gathered[0, 0]), gathered[1, 0]),
+    )
+    torch.testing.assert_close(
+        compose_entry_states(gathered, plans[0]), torch.zeros(2, 1, VALUE_DIM, KEY_DIM)
+    )
+
+
+def test_exit_cotangents_fold_successors_in_reverse_and_add_the_direct_term():
+    # Sequences [0,1), [1,5), [5,8); rank 0 owns the first token of each of the first two.
+    ranges = [[(0, 2)], [(2, 4)], [(4, 6)], [(6, 8)]]
+    plan = ContextParallelPlan.from_token_ranges((0, 1, 5, 8), ranges, rank=0)
+    gathered = torch.stack(
+        (
+            with_unused_slot(summary([[1, 0], [0, 1]], [[9, 9], [9, 9]])),
+            with_unused_slot(summary([[2, 1], [0, 1]], [[1, 0], [0, 1]])),
+            with_unused_slot(summary([[1, 0], [2, 3]], [[0, 2], [1, 0]])),
+            with_unused_slot(summary([[4, 0], [0, 4]], [[7, 7], [7, 7]])),
+        )
+    )
+    d_final_state = torch.arange(8, dtype=torch.float32).reshape(2, 1, VALUE_DIM, KEY_DIM)
+
+    zero = torch.zeros(1, VALUE_DIM, KEY_DIM)
+    # Fragment 1 (sequence 1) continues on ranks 1 then 2; the fold visits the farthest first.
+    suffix = apply(apply(zero, gathered[2, 0]), gathered[1, 0])
+    expected = d_final_state.clone()
+    expected[1] += suffix
+    torch.testing.assert_close(compose_exit_cotangents(gathered, d_final_state, plan), expected)
+    torch.testing.assert_close(
+        compose_exit_cotangents(gathered, None, plan), torch.stack((zero, suffix))
+    )
+
+
+def test_short_conv_histories_span_short_predecessors_and_reset_at_sequences():
+    tails = torch.tensor(
         [
-            [[0.0], [0.0], [1.0]],
-            [[0.0], [2.0], [3.0]],
-            [[0.0], [4.0], [5.0]],
-            [[0.0], [6.0], [7.0]],
+            [[[0.0], [0.0], [1.0]], [[0.0], [0.0], [1.5]]],
+            [[[0.0], [2.0], [3.0]], [[0.0], [0.0], [0.0]]],
+            [[[0.0], [4.0], [5.0]], [[0.0], [0.0], [0.0]]],
+            [[[0.0], [0.0], [6.0]], [[0.0], [0.0], [7.0]]],
         ]
     )
-
-    rank_three = ContextParallelKDAAttention.compose_conv_initial_states(
-        gathered_tails,
-        shard_tokens=2,
-        rank=3,
-        shards=shards,
-        global_cu_seqlens=global_cu_seqlens,
-    )
-
+    rank_three = compose_conv_histories(tails, CONV_PLANS[3])
     torch.testing.assert_close(rank_three[0, :, 0], torch.tensor([3.0, 4.0, 5.0]))
     torch.testing.assert_close(rank_three[1], torch.zeros_like(rank_three[1]))
-
-    reset_boundaries = (0, 2, 8)
-    reset_shards = (
-        PackedShard(cu_seqlens=(0, 2), sequence_ids=(0,)),
-        PackedShard(cu_seqlens=(0, 2), sequence_ids=(1,)),
-        PackedShard(cu_seqlens=(0, 2), sequence_ids=(1,)),
-        PackedShard(cu_seqlens=(0, 2), sequence_ids=(1,)),
+    torch.testing.assert_close(
+        compose_conv_histories(tails, CONV_PLANS[1])[0, :, 0], torch.tensor([0.0, 0.0, 1.5])
     )
-    reset = ContextParallelKDAAttention.compose_conv_initial_states(
-        gathered_tails,
-        shard_tokens=2,
-        rank=1,
-        shards=reset_shards,
-        global_cu_seqlens=reset_boundaries,
-    )
-    torch.testing.assert_close(reset, torch.zeros_like(reset))
-
-    partial_boundaries = (0, 3, 8)
-    partial_shards = (
-        PackedShard(cu_seqlens=(0, 2), sequence_ids=(0,)),
-        PackedShard(cu_seqlens=(0, 1, 2), sequence_ids=(0, 1)),
-        PackedShard(cu_seqlens=(0, 2), sequence_ids=(1,)),
-        PackedShard(cu_seqlens=(0, 2), sequence_ids=(1,)),
-    )
-    partial = ContextParallelKDAAttention.compose_conv_initial_states(
-        gathered_tails,
-        shard_tokens=2,
-        rank=2,
-        shards=partial_shards,
-        global_cu_seqlens=partial_boundaries,
-    )
-    torch.testing.assert_close(partial[0, :, 0], torch.tensor([0.0, 0.0, 3.0]))
 
 
-def test_short_conv_halo_backward_is_the_transpose_of_forward_routing():
-    global_cu_seqlens = (0, 1, 7, 8)
-    shards = (
-        PackedShard(cu_seqlens=(0, 1, 2), sequence_ids=(0, 1)),
-        PackedShard(cu_seqlens=(0, 2), sequence_ids=(1,)),
-        PackedShard(cu_seqlens=(0, 2), sequence_ids=(1,)),
-        PackedShard(cu_seqlens=(0, 1, 2), sequence_ids=(1, 2)),
-    )
-    gathered_tails = torch.zeros(4, 3, 1, requires_grad=True)
-    rank_two = ContextParallelKDAAttention.compose_conv_initial_states(
-        gathered_tails,
-        shard_tokens=2,
-        rank=2,
-        shards=shards,
-        global_cu_seqlens=global_cu_seqlens,
-    )
-    rank_three = ContextParallelKDAAttention.compose_conv_initial_states(
-        gathered_tails,
-        shard_tokens=2,
-        rank=3,
-        shards=shards,
-        global_cu_seqlens=global_cu_seqlens,
-    )
+def test_short_conv_history_backward_is_the_transpose_of_forward_routing():
+    tails = torch.zeros(4, 2, 3, 1, requires_grad=True)
+    rank_two = compose_conv_histories(tails, CONV_PLANS[2])
+    rank_three = compose_conv_histories(tails, CONV_PLANS[3])
     loss = (rank_two[0, :, 0] * torch.tensor([10.0, 20.0, 30.0])).sum()
     loss += (rank_three[0, :, 0] * torch.tensor([40.0, 50.0, 60.0])).sum()
 
-    (tail_gradients,) = torch.autograd.grad(loss, gathered_tails)
+    (tail_gradients,) = torch.autograd.grad(loss, tails)
 
-    torch.testing.assert_close(tail_gradients[1, :, 0], torch.tensor([0.0, 20.0, 70.0]))
-
-
-def test_forward_prefix_propagates_one_sequence_across_three_shards():
-    summaries = torch.stack(
-        (
-            _summary([[1, 2], [0, 1]], [[1, 0], [0, 2]]),
-            _summary([[2, 0], [3, 1]], [[0, 1], [2, 0]]),
-            _summary([[1, 0], [0, 1]], [[9, 9], [9, 9]]),
-        )
-    )
-    shards = (
-        PackedShard(cu_seqlens=(0, 2), sequence_ids=(0,)),
-        PackedShard(cu_seqlens=(0, 2), sequence_ids=(0,)),
-        PackedShard(cu_seqlens=(0, 1, 2), sequence_ids=(0, 1)),
-    )
-    q = torch.empty(1, 2, 1, 2)
-    v = torch.empty_like(q)
-
-    states = ContextParallelKDAFunction.compose_forward_initial_states(
-        summaries, q, v, rank=2, shards=shards
-    )
-
-    expected_first = _apply(_apply(torch.zeros(1, 2, 2), summaries[0]), summaries[1])
-    torch.testing.assert_close(states[0], expected_first)
-    torch.testing.assert_close(states[1], torch.zeros_like(states[1]))
-
-
-def test_reverse_suffix_filters_sequences_and_adds_final_state_gradient():
-    summaries = torch.stack(
-        (
-            _summary([[1, 0], [0, 1]], [[9, 9], [9, 9]]),
-            _summary([[2, 1], [0, 1]], [[1, 0], [0, 1]]),
-            _summary([[1, 0], [2, 3]], [[0, 2], [1, 0]]),
-            _summary([[4, 0], [0, 4]], [[7, 7], [7, 7]]),
-        )
-    )
-    shards = (
-        PackedShard(cu_seqlens=(0, 1, 2), sequence_ids=(0, 1)),
-        PackedShard(cu_seqlens=(0, 2), sequence_ids=(1,)),
-        PackedShard(cu_seqlens=(0, 1, 2), sequence_ids=(1, 2)),
-        PackedShard(cu_seqlens=(0, 2), sequence_ids=(2,)),
-    )
-    initial_state = torch.zeros(2, 1, 2, 2)
-    d_final_state = torch.arange(8, dtype=torch.float32).reshape_as(initial_state)
-
-    gradients = ContextParallelKDAFunction.compose_reverse_final_states(
-        summaries,
-        d_final_state=d_final_state,
-        initial_state=initial_state,
-        rank=0,
-        shards=shards,
-    )
-
-    suffix = _apply(_apply(torch.zeros(1, 2, 2), summaries[2]), summaries[1])
-    expected = d_final_state.clone()
-    expected[-1] += suffix
-    torch.testing.assert_close(gradients, expected)
+    # Rank 1's last token feeds rank 2's history[2] (weight 30) and rank 3's history[0] (40).
+    torch.testing.assert_close(tail_gradients[1, 0, :, 0], torch.tensor([0.0, 20.0, 70.0]))
+    # Rank 0 starts both of its sequences yet must stay connected to the gathered tails so its
+    # reduce-scatter participates in the collective's backward.
+    assert compose_conv_histories(tails, CONV_PLANS[0]).requires_grad


### PR DESCRIPTION

## Human Note

## Agent note

### What this adds

Context parallelism for the delta-rule ops (KDA and GDN) as a small set of composable pieces instead of
one monolithic `chunk_kda_cp`. The idea: every delta-rule token step is affine in the recurrent state, so
any run of tokens collapses to one FP32 map `H_out = H_in @ A + B`, stored as `[HV, V+K, K] = [bias;
transition]` (one map per value head). Each rank summarizes the tokens it owns, ranks exchange those summaries, each rank folds
its predecessors' summaries into an entry state, and runs the ordinary local kernel. Backward is the
mirror image with a reverse summary `dH_in = dH_out @ R + C`. Everything here is built from that fact.

Follow-up to the discussion on #421: the library exposes capability, not a recipe that grows a flag per
partition or topology.

### Using it

**One call, the common case.** You decide which global token ranges each rank owns; the plan does the rest.

```python
from attn_gym.linear.context_parallel import ContextParallelPlan
from attn_gym.linear.kda import context_parallel_kda          # or attn_gym.linear.gdn.context_parallel_gdn

# Every rank builds the same table. Here: zig-zag over 2W equal blocks (what ring softmax CP uses).
blocks = 2 * world_size
size = total_tokens // blocks
token_ranges = [[(r * size, (r + 1) * size), ((blocks - 1 - r) * size, (blocks - r) * size)]
                for r in range(world_size)]

plan = ContextParallelPlan.from_token_ranges(global_cu_seqlens, token_ranges, rank)
token_ids = plan.global_token_ids(device)                     # slice global tensors into this rank's local ones
cu_seqlens = torch.tensor(plan.cu_seqlens, dtype=torch.int32, device=device)

output, final_state = context_parallel_kda(
    q, k, v, gate, beta, cu_seqlens=cu_seqlens, plan=plan, group=cp_group
)
true_final_states = final_state[list(plan.terminal)]         # only fragments that end their sequence
```

Contiguous shards are `[[(r * size, (r + 1) * size)] for r in range(world_size)]`; document-aligned or
uneven partitions are just other lists. The plan cuts ranges at sequence boundaries into `Fragment`s, one
local `cu_seqlens` segment each, so two pieces of the same document on one rank are simply two local
segments whose entry states the recipe supplies. The short-conv halo uses the same plan:
`context_parallel_conv_history(qkv, plan, group, kernel_size - 1)` returns `causal_conv1d`'s
`initial_state`.

**The primitives, when you want your own communication.** This is what the recipe is made of:

```python
from attn_gym.linear.kda import chunk_kda_prepare, chunk_kda_prepare_backward
from attn_gym.linear.state_summary import merge_state, compose_summaries, neutral_summary

# forward
prepared = chunk_kda_prepare(q, k, v, gate, beta, cu_seqlens=cu_seqlens)   # WY factors, computed once
summary = prepared.state_summary(start, stop)        # [bias; transition] of one local sequence, FP32
# ... move summaries however you like ...
entry = merge_state(zero_state, predecessor_summary)  # fold predecessors left to right from zero
output, final_state = prepared.run(entry_states, output_final_state=True)

# backward (inside your autograd.Function; prepared.saved is the NamedTuple to save_for_backward)
grads = chunk_kda_prepare_backward(saved, d_output, entry_states)
grad_summary = grads.state_grad_summary(start, stop)  # reverse map [C; R]
# ... exchange, fold successors from the far end ...
dq, dk, dv, dgate, dbeta, _ = grads.run(exit_cotangents)
```

`start`/`stop` are host ints naming exactly one local `cu_seqlens` segment, so nothing syncs and CUDA
Graph capture works. `compose_summaries(first, then)` combines two maps before any state is known (for
scans). `neutral_summary` is the identity, the right filler for a collective slot nobody reads.

### What is supported

- KDA and GDN (including GQA, `HK < HV`), fp16/bf16 Q/K/V, packed `cu_seqlens`, arbitrary fragment
  sizes (partial chunks are handled), any number of fragments per rank (unequal counts are padded in the
  all-gather).
- Exact final states for every fragment; `plan.terminal` tells you which ones are real sequence ends.
  The loss may attach to any of them.
- Full backward with all five input gradients. Against an FP32 reference the sharded gradients have the
  same error as the unsharded fused op (checked to 2-3 digits on 2 GPUs for both ops, both layouts).
- CUDA Graph capture of the whole forward + collectives + backward, as long as the plan is fixed.
- Hopper and datacenter Blackwell (summary kernels: Triton on Hopper, native UMMA on SM100).

### What it assumes

- Every sequence starts from the zero state; `initial_state` is not accepted under the recipe (same
  stance as FLA). Use the primitives if you need something else.
- `token_ranges` must tile `[0, total_tokens)` exactly once, every rank must own at least one range, and
  all ranks build the same table. `check_group` rejects a plan whose world size, rank, or local token
  count disagrees with the group and input.
- The device `cu_seqlens` you pass must be `plan.cu_seqlens`; this is not verifiable without a sync, so
  it is a contract.
- A captured CUDA Graph is valid for one plan; changing the partition means recapturing.
- B = 1 (pack sequences), matching fp16/bf16 Q/K/V, and the fused kernels' `K = V = 128`.

### How to extend

- **Another partition:** write a different `token_ranges` list. Nothing else changes.
- **Another topology** (P2P pipeline, recursive-doubling scan over `compose_summaries`, DTensor,
  comm/compute overlap): copy `_ContextParallelChunk` in `attn_gym/linear/context_parallel.py` and swap
  the collective. The primitives and plans are unchanged; the compose helpers are pure functions you can
  reuse.
- **Another delta-rule op:** provide `prepare` / `prepare_backward` with the same handle protocol and pass
  them as a `StagedOp`. GDN is the worked example: `gdn/impl/chunk.py` is split into the same
  prepare/finish seams (behavior-preserving; public `chunk_gdn_bwd` composes them), `gdn/stages.py` wraps
  them, and `gdn/context_parallel.py` is 45 lines of binding.
- **Mega backend:** not wired. Mega keeps the WY factors on chip so there is no `prepare` output for the
  summary kernel; a Mega summary mode would slot in as another `StagedOp`.

### Room to grow (deliberately not in this PR)

```text
comm/compute overlap    the shipped recipe blocks on one all-gather per direction; the primitives let a
                        caller launch state_summary, start the collective, run other layer work, then run
scan instead of gather  the gathered buffer is W x slots x summary; recursive doubling over
                        compose_summaries would be O(log W) exchanges of one summary each
fully fused forwards    Mega keeps WY factors on chip, so there is no prepare output to summarize; a Mega
                        summary mode (augmented [0 | I] state) is the follow-up
```

### Review order

`state_summary.py` -> `kda/stages.py` -> `gdn/impl/chunk.py` (pure split) -> `gdn/stages.py` ->
`context_parallel.py` -> the two thin bindings -> example -> tests. Two fixes surfaced by review along the
way: the staged path skipped `normalize_tma_rows`, so strided Q/K/V that `chunk_kda` accepts failed in
TVM-FFI, and `beta` slices need `normalize_compact_tensor` rather than `.contiguous()`.

## Test Plan

```bash
pytest -n 6 test/test_delta_rule_stages.py test/test_kda_context_parallel.py test/test_namespaces.py \
  test/test_kda_training_example.py test/test_delta_affine_summary.py test/test_short_conv_cute.py \
  test/linear/test_gdn_chunk_fused.py test/linear/test_gdn_fused.py test/linear/test_gdn.py \
  test/test_mega_optional_import.py   # 323 passed, 6 skipped (GB200)
CUDA_VISIBLE_DEVICES=0,1 pytest test/test_context_parallel_distributed.py   # 4 passed, 2 x GB200
torchrun --standalone --nproc-per-node=2 examples/kda_context_parallel.py
torchrun --standalone --nproc-per-node=2 examples/kda_context_parallel.py --partition zigzag
torchrun --standalone --nproc-per-node=2 examples/kda_context_parallel.py --partition zigzag --compute-dtype float16
torchrun --standalone --nproc-per-node=2 examples/kda_context_parallel.py --cuda-graph
torchrun --standalone --nproc-per-node=2 examples/kda_context_parallel.py --partition zigzag --cuda-graph
ruff check . && ruff format --check attn_gym examples test && mkdocs build
```

`test_delta_rule_stages.py` simulates the full recipe single-process for kda / gdn / gdn-gqa across
contiguous-2, zigzag-2, zigzag-3, and an uneven reordered table in bf16 and fp16, and asserts sharded
gradient error against an FP32 oracle is no worse than the unsharded fused op's.
`test_context_parallel_distributed.py` (skipped below two GPUs) spawns two NCCL ranks and runs the public
`context_parallel_kda` / `context_parallel_gdn` themselves on a zig-zag plan, with and without a
final-state loss term, so the autograd Function, the all-gather, and the `d_final_state=None` backward
path are exercised end to end against the unsharded op. `compose_entry_states` / `compose_exit_cotangents`
fold shared chain prefixes once (`_fold_chains`, keyed by prefix), which keeps a rank that owns many
pieces of one sequence at O(pieces) merges; a test pins 7 merges for 8 pieces instead of 22.

