### PR TITLE
Add documentation section indexes

### DIFF
--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -1,0 +1,5 @@
+# Development
+
+Resources for developing and maintaining Attention Gym.
+
+- **[CI Health](ci-health.md)** — inspect recent GitHub Actions reliability, execution time, and test failures.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,0 +1,6 @@
+# Guides
+
+Practical guidance for using Attention Gym and PyTorch attention features in real workloads.
+
+- **[Ragged CUDA Graphs](ragged-cuda-graphs.md)** — capture and replay variable-length attention workloads efficiently, from device-driven scheduling to graph capacity planning.
+- **[Deterministic FlexAttention](../determinism.md)** — understand sources of nondeterminism and configure deterministic forward and backward execution.

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ It provides ready-to-use **mask functions** and **score mods** that you can comp
 
 - **[Getting Started](getting-started.md)** — install Attention Gym and build your first mask
 - **[Core Concepts](concepts.md)** — understand how `mask_mod`, `score_mod`, and `BlockMask` work together
-- **Guides** — learn about [ragged CUDA Graphs](guides/ragged-cuda-graphs.md) and [deterministic FlexAttention](determinism.md)
+- **[Guides](guides/index.md)** — learn about ragged CUDA Graphs and deterministic FlexAttention
 - **Reference** — browse [masks](masks.md), [score mods](mods.md), [linear attention](linear.md), and [utilities](utilities.md)
 - **[Examples](examples.md)** — explore benchmarks, MLA, paged attention, distributed attention, and advanced patterns
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ theme:
   features:
     - content.code.annotate
     - content.code.copy
+    - navigation.indexes
     - navigation.top
     - toc.follow
   logo: assets/hero.png
@@ -63,6 +64,7 @@ nav:
       - Getting Started: getting-started.md
       - Core Concepts: concepts.md
   - Guides:
+      - guides/index.md
       - Ragged CUDA Graphs: guides/ragged-cuda-graphs.md
       - Determinism: determinism.md
   - Reference:
@@ -72,6 +74,7 @@ nav:
       - Utilities: utilities.md
   - Examples: examples.md
   - Development:
+      - developers/index.md
       - CI Health: developers/ci-health.md
 
 markdown_extensions:


### PR DESCRIPTION
## Human Note

## Agent note

The Guides and Development documentation directories had article pages but no landing pages, so their
section URLs returned 404s. Add concise section indexes, enable Material navigation indexes, and link
the Guides index from the site home page.

## Test Plan

```bash
DISABLE_MKDOCS_2_WARNING=true .venv/bin/mkdocs build --strict
git diff --check
```
