### PR TITLE
Run the Mega backend under context parallelism

### DIFF
--- a/attn_gym/linear/kda/context_parallel.py
+++ b/attn_gym/linear/kda/context_parallel.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from functools import partial
 
 import torch
@@ -30,14 +31,17 @@ def context_parallel_kda(
     scale: float | None = None,
     autotune: bool = True,
     fastmath: bool = False,
+    kernel_options: Mapping[str, object] | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Run fused ``chunk_kda`` over this rank's fragments with state exchanged by all-gather.
+    """Run ``chunk_kda`` over this rank's fragments with state exchanged by all-gather.
 
     See ``attn_gym.linear.context_parallel.context_parallel_chunk`` for the argument contract;
-    ``scale``, ``autotune``, and ``fastmath`` follow ``chunk_kda``.
+    ``scale``, ``autotune``, ``fastmath``, and ``kernel_options`` follow ``chunk_kda``. With
+    ``kernel_options={"backend": "mega"}`` the local pass runs on Mega and fused factors are
+    computed only for fragments that must send a summary.
     """
     stages = StagedOp(
-        partial(chunk_kda_prepare, scale=scale, autotune=autotune),
+        partial(chunk_kda_prepare, scale=scale, autotune=autotune, kernel_options=kernel_options),
         partial(chunk_kda_prepare_backward, scale=scale, autotune=autotune, fastmath=fastmath),
     )
     return context_parallel_chunk(

--- a/attn_gym/linear/kda/impl/mega.py
+++ b/attn_gym/linear/kda/impl/mega.py
@@ -321,10 +321,6 @@ def validate_mega_constraints(
             raise TypeError("Mega beta requires a contiguous, element-aligned inner mode")
         if cu_seqlens is not None and cu_seqlens.data_ptr() % 8:
             raise TypeError("Mega cu_seqlens must be 8-byte aligned")
-    if cu_seqlens is None and q.shape[1] % _CHUNK_SIZE:
-        raise ValueError(
-            "dense Mega execution requires T divisible by 64; pass cu_seqlens for tails"
-        )
 
 
 def chunk_forward(
@@ -355,7 +351,14 @@ def chunk_forward(
     if not torch.compiler.is_compiling():
         validate_mega_available(q)
 
-    if cu_seqlens is None and initial_state is None and not output_final_state:
+    # The dense kernels specialize for complete BT64 chunks; a partial tail takes the packed path
+    # with synthesized boundaries, as the fused backend does.
+    if (
+        cu_seqlens is None
+        and initial_state is None
+        and not output_final_state
+        and q.shape[1] % _CHUNK_SIZE == 0
+    ):
         validate_mega_constraints(q, k, value, gate, beta, None, None)
         dense_cu_seqlens = torch.arange(2, dtype=torch.int32, device=q.device) * q.shape[1]
         return (

--- a/attn_gym/linear/kda/stages.py
+++ b/attn_gym/linear/kda/stages.py
@@ -28,6 +28,7 @@ Which tokens a device owns and how summaries travel are the caller's decisions;
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import NamedTuple
 
@@ -51,9 +52,16 @@ from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd import (
     _finish_chunk_kda_fwd,
     _prepare_chunk_kda_fwd,
 )
+from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd_intra import chunk_kda_fwd_factors
 from attn_gym.linear.kda.impl.fused import _validate_fused_constraints
+from attn_gym.linear.kda.impl.mega import validate_mega_constraints
+from attn_gym.linear.kda.impl.mega_ops import (
+    chunk_mega_packed_fwd_with_initial_state_op,
+    chunk_mega_packed_fwd_with_state_op,
+    validate_mega_available,
+)
 from attn_gym.linear.kda.ops import _plain_gate_scan_op
-from attn_gym.linear.kda.validation import validate_kda_inputs
+from attn_gym.linear.kda.validation import resolve_kernel_options, validate_kda_inputs
 
 _CHUNK_SIZE = 64
 
@@ -62,7 +70,8 @@ class ChunkKDASaved(NamedTuple):
     """Forward tensors an autograd function stores for ``chunk_kda_prepare_backward``.
 
     Every field is a tensor or ``None`` so the tuple can be splatted into
-    ``ctx.save_for_backward`` and rebuilt from ``ctx.saved_tensors``.
+    ``ctx.save_for_backward`` and rebuilt from ``ctx.saved_tensors``. ``aqk``/``akk`` are
+    ``None`` when the forward did not materialize them (Mega); backward recomputes them.
     """
 
     q: torch.Tensor
@@ -70,8 +79,8 @@ class ChunkKDASaved(NamedTuple):
     v: torch.Tensor
     cumulative_gate: torch.Tensor
     beta: torch.Tensor
-    aqk: torch.Tensor
-    akk: torch.Tensor
+    aqk: torch.Tensor | None
+    akk: torch.Tensor | None
     cu_seqlens: torch.Tensor | None
     chunk_offsets: torch.Tensor | None
 
@@ -151,6 +160,78 @@ class ChunkKDAPrepared:
         )
 
 
+@dataclass
+class ChunkKDAMegaPrepared:
+    """Mega forward handle: on-chip factors for ``run``, fused factors only for summaries.
+
+    Mega never materializes the WY factors, so ``run`` executes the Mega with-state kernel over the
+    whole local stream and ``state_summary`` computes the fused factors for just the requested
+    sequence. Ranks whose fragments all end their sequence never pay for them, and packed streams
+    pay only for the fragments that continue elsewhere. Backward recomputes the intra factors, as
+    Mega does today.
+    """
+
+    saved: ChunkKDASaved  # aqk/akk are None: Mega keeps them on chip
+    gate: torch.Tensor
+    metadata: RaggedChunkMetadata
+    scale: float
+    autotune: bool
+
+    def state_summary(self, start: int, stop: int) -> torch.Tensor:
+        """Return the FP32 ``[HV, V + K, K]`` map of tokens ``[start, stop)`` from the zero state.
+
+        See NOTE [Summary ranges are whole sequences].
+        """
+        saved = self.saved
+        _check_token_range(saved.q.shape[1], start, stop)
+        # One whole sequence starts at ``start``, so its chunk grid and cumulative gate are
+        # unchanged when it is factored as a stream of its own.
+        tokens = stop - start
+        metadata = None
+        if tokens % _CHUNK_SIZE:
+            cu_seqlens = torch.arange(2, dtype=torch.int32, device=saved.q.device) * tokens
+            metadata = prepare_ragged_chunk_metadata(cu_seqlens, tokens, _CHUNK_SIZE)
+        q, k, v = (normalize_tma_rows(t[:, start:stop]) for t in (saved.q, saved.k, saved.v))
+        cumulative_gate, beta = (
+            normalize_compact_tensor(t[:, start:stop]) for t in (saved.cumulative_gate, saved.beta)
+        )
+        factors = _prepare_chunk_kda_fwd(
+            q, k, v, cumulative_gate, beta, metadata, scale=self.scale, autotune=self.autotune
+        )
+        return build_state_summary(factors.kg, factors.w, factors.u, cumulative_gate)
+
+    def run(
+        self,
+        initial_state: torch.Tensor | None = None,
+        *,
+        output_final_state: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Run the Mega with-state kernel from one FP32 ``[N, HV, V, K]`` entry state per sequence."""
+        saved = self.saved
+        if initial_state is None:
+            sequences = self.metadata.cu_seqlens.shape[0] - 1
+            initial_state = saved.q.new_zeros(
+                sequences,
+                saved.v.shape[2],
+                saved.v.shape[-1],
+                saved.q.shape[-1],
+                dtype=torch.float32,
+            )
+        args = (
+            saved.q,
+            saved.k,
+            saved.v,
+            self.gate,
+            saved.beta,
+            initial_state.float().contiguous(),
+            self.metadata.cu_seqlens,
+            self.scale,
+        )
+        if output_final_state:
+            return chunk_mega_packed_fwd_with_state_op(*args)
+        return chunk_mega_packed_fwd_with_initial_state_op(*args), None
+
+
 def chunk_kda_prepare(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -161,13 +242,19 @@ def chunk_kda_prepare(
     cu_seqlens: torch.Tensor | None = None,
     scale: float | None = None,
     autotune: bool = True,
-) -> ChunkKDAPrepared:
-    """Run the factor half of fused ``chunk_kda`` and return a handle for summaries and output.
+    kernel_options: Mapping[str, object] | None = None,
+) -> ChunkKDAPrepared | ChunkKDAMegaPrepared:
+    """Run the factor half of ``chunk_kda`` and return a handle for summaries and output.
 
     Arguments follow ``chunk_kda`` with two restrictions: ``q``/``k``/``v`` must already share a
     float16 or bfloat16 dtype (no silent cast, because the caller owns autograd), and the batch
     dimension must be one so token offsets index one packed stream.
+    ``kernel_options={"backend": "mega"}`` runs the local pass with Mega and computes fused factors
+    only when a summary is requested; the split schedules are not available with entry states.
     """
+    backend, split_backward, split_forward = resolve_kernel_options(kernel_options)
+    if split_backward or split_forward:
+        raise ValueError("split schedules are not supported by chunk_kda_prepare")
     validate_kda_inputs(
         q, k, v, gate, beta, None, cu_seqlens, op_name="chunk_kda_prepare", gate_name="gate"
     )
@@ -180,8 +267,9 @@ def chunk_kda_prepare(
         raise ValueError("chunk_kda_prepare requires B=1; pack sequences with cu_seqlens")
     q, k, v = (normalize_tma_rows(tensor) for tensor in (q, k, v))
     tokens = q.shape[1]
-    if cu_seqlens is None and tokens % _CHUNK_SIZE:
-        # A partial tail runs as one packed sequence; arange keeps the launch capture-safe.
+    # Mega's with-state kernels are packed-only, so it always gets explicit boundaries; arange
+    # keeps the launch capture-safe.
+    if cu_seqlens is None and (tokens % _CHUNK_SIZE or backend == "mega"):
         cu_seqlens = torch.arange(2, dtype=torch.int32, device=q.device) * tokens
     metadata = (
         None
@@ -192,7 +280,17 @@ def chunk_kda_prepare(
     chunk_offsets = None if metadata is None else metadata.chunk_offsets
     scale = resolve_scale(scale, q.shape[-1])
     beta = normalize_compact_tensor(beta.float())
-    cumulative_gate = _plain_gate_scan_op(gate.float(), cu_seqlens, chunk_offsets, False)
+    gate = gate.float()
+    cumulative_gate = _plain_gate_scan_op(gate, cu_seqlens, chunk_offsets, False)
+    if backend == "mega":
+        assert metadata is not None
+        validate_mega_available(q)
+        gate = normalize_compact_tensor(gate)
+        validate_mega_constraints(q, k, v, gate, beta, None, metadata.cu_seqlens)
+        saved = ChunkKDASaved(
+            q, k, v, cumulative_gate, beta, None, None, cu_seqlens, chunk_offsets
+        )
+        return ChunkKDAMegaPrepared(saved, gate, metadata, scale, autotune)
     factors = _prepare_chunk_kda_fwd(
         q, k, v, cumulative_gate, beta, metadata, scale=scale, autotune=autotune
     )
@@ -301,6 +399,13 @@ def chunk_kda_prepare_backward(
     if initial_state is not None:
         initial_state = initial_state.float().contiguous()
     scale = resolve_scale(scale, saved.q.shape[-1])
+    if saved.aqk is None:
+        # Mega forwards keep the intra factors on chip; rebuild them as Mega's backward does.
+        aqk, akk = chunk_kda_fwd_factors(
+            saved.q, saved.k, saved.cumulative_gate, saved.beta, scale, metadata
+        )
+        saved = saved._replace(aqk=aqk, akk=akk)
+    assert saved.akk is not None
     prepared = _prepare_chunk_kda_bwd(
         saved.q,
         saved.k,
@@ -322,6 +427,7 @@ def chunk_kda_prepare_backward(
 
 __all__ = [
     "ChunkKDABackward",
+    "ChunkKDAMegaPrepared",
     "ChunkKDAPrepared",
     "ChunkKDASaved",
     "chunk_kda_prepare",

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -357,9 +357,9 @@ FP16/BF16 training backend for
 applications that already hold per-token natural-log gate increments. Q/K/V share one dtype. It uses
 public CuTeDSL 4.7 primitives and has no cuDNN Frontend runtime dependency. Like the other
 implementations, it returns `(output, final_state)`; request the latter with
-`output_final_state=True`. Dense no-state calls require T divisible by 64 and omit `cu_seqlens`,
-while packed/stateful calls pass explicit contiguous int32 boundaries and FP32 `[N, H, V, K]`
-states. Q/K/V/gate/state accept TMA-compatible innermost modes with aligned dynamic outer strides;
+`output_final_state=True`. Dense no-state calls with complete 64-token chunks use the dense kernels
+and partial tails take the packed path with synthesized boundaries; packed/stateful calls pass
+explicit contiguous int32 boundaries and FP32 `[N, H, V, K]` states. Q/K/V/gate/state accept TMA-compatible innermost modes with aligned dynamic outer strides;
 beta requires an element-aligned contiguous inner mode. By default the forward is exact and
 unsplit: one persistent work item per sequence and head, which leaves the GPU underused for a few
 long sequences at low head counts. FP16 and BF16 use exact backward execution by default; eligible
@@ -465,6 +465,12 @@ true_final_states = final_state[list(plan.terminal)]
 The recipe starts each sequence from zero, always returns every fragment's exit state, and does
 not accept `initial_state` or `output_final_state=False`. A captured CUDA Graph is valid only for
 its fixed plan.
+
+`kernel_options={"backend": "mega"}` makes `chunk_kda_prepare` and `context_parallel_kda` run each
+local pass with Mega from the composed entry state. Because Mega keeps WY factors on chip, the
+forward materializes fused factors only for fragments that send a summary, lazily and only over
+that fragment. Backward recomputes the local fused factors and uses Mega's existing with-state
+route through the fused staged backward.
 
 ::: attn_gym.linear.context_parallel.context_parallel_chunk
 

--- a/test/kda/mega/test_kda_mega_training.py
+++ b/test/kda/mega/test_kda_mega_training.py
@@ -782,13 +782,24 @@ def test_mega_composed_state_only_backward(dtype: torch.dtype) -> None:
         _assert_reference(actual_grad, high_grad, low_grad, f"state-only gradient {index}", dtype)
 
 
-def test_mega_dense_tail_rejected_at_public_boundary() -> None:
+def test_mega_dense_tail_takes_the_packed_path() -> None:
+    """A partial final chunk without boundaries runs as one packed sequence, like fused does."""
     from attn_gym.linear import chunk_kda
 
-    inputs = _make_inputs(requires_grad=False)
-    dense_tail = tuple(tensor[:, :65].contiguous() for tensor in inputs[:5])
-    with pytest.raises(ValueError, match="T divisible by 64"):
-        chunk_kda(*dense_tail, kernel_options={"backend": "mega"})
+    inputs = _make_inputs(requires_grad=True)
+    implicit = tuple(tensor[:, :65].detach().clone().requires_grad_() for tensor in inputs[:5])
+    explicit = tuple(tensor.detach().clone().requires_grad_() for tensor in implicit)
+    offsets = torch.tensor([0, 65], dtype=torch.int32, device=implicit[0].device)
+    output, _ = chunk_kda(*implicit, kernel_options={"backend": "mega"})
+    expected, _ = chunk_kda(*explicit, cu_seqlens=offsets, kernel_options={"backend": "mega"})
+    torch.testing.assert_close(output, expected, atol=0, rtol=0)
+    d_output = torch.randn_like(output)
+    for actual, reference in zip(
+        torch.autograd.grad(output, implicit, d_output),
+        torch.autograd.grad(expected, explicit, d_output),
+        strict=True,
+    ):
+        torch.testing.assert_close(actual, reference, atol=0, rtol=0)
 
 
 def test_mega_rejects_mismatched_value_and_beta_shapes() -> None:

--- a/test/test_delta_rule_stages.py
+++ b/test/test_delta_rule_stages.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 from collections.abc import Callable
 from functools import partial
 from typing import NamedTuple
@@ -74,10 +75,25 @@ GDN = Op(
     value_heads=2,
     vector_gate=False,
 )
+MEGA = {"backend": "mega"}
+requires_mega = pytest.mark.skipif(
+    importlib.util.find_spec("cutlass.experimental") is None
+    or not torch.cuda.is_available()
+    or torch.cuda.get_device_capability() not in ((10, 0), (10, 3)),
+    reason="Mega requires CuTeDSL>=4.7 on SM100/SM103",
+)
 op_param = pytest.mark.parametrize(
     "op",
     [
         pytest.param(KDA, id="kda"),
+        pytest.param(
+            KDA._replace(
+                chunk=partial(chunk_kda, kernel_options=MEGA),
+                prepare=partial(chunk_kda_prepare, kernel_options=MEGA),
+            ),
+            id="kda-mega",
+            marks=requires_mega,
+        ),
         pytest.param(GDN, id="gdn"),
         pytest.param(GDN._replace(key_heads=1), id="gdn-gqa"),
     ],
@@ -148,7 +164,7 @@ def test_prepare_run_matches_chunk_op_unpacked_with_strided_qkv(op, tokens):
     assert q.stride(-1) == 2
 
     # The fused ops accept either layout and the stages normalize strided inputs themselves; the
-    # reference gets compact copies so the same call also serves ops that reject strides.
+    # public Mega op rejects strides, so every reference gets compact copies.
     expected, _ = op.chunk(q.contiguous(), k.contiguous(), v.contiguous(), gate, beta)
     output, final_state = op.prepare(q, k, v, gate, beta).run()
 
@@ -185,6 +201,47 @@ def test_state_summary_rejects_ranges_outside_the_stream():
         prepared.state_summary(64, 200)
     with pytest.raises(ValueError, match="summary range"):
         prepared.state_summary(64, 64)
+
+
+@requires_kda_target
+@requires_mega
+@pytest.mark.parametrize("bounds", [(0, 72), (72, 200)], ids=["partial-tail", "aligned-offset"])
+def test_mega_state_summary_replays_under_cuda_graph(bounds):
+    """The lazily factored fragment builds its boundaries on device, so capture never syncs."""
+    q, k, v, gate, beta = KDA.make_inputs(200, seed=7)
+    cu_seqlens = torch.tensor([0, 72, 200], dtype=torch.int32, device="cuda")
+    prepared = chunk_kda_prepare(q, k, v, gate, beta, cu_seqlens=cu_seqlens, kernel_options=MEGA)
+    expected = prepared.state_summary(*bounds)
+
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        prepared.state_summary(*bounds)
+    torch.cuda.current_stream().wait_stream(stream)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = prepared.state_summary(*bounds)
+    graph.replay()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(captured, expected, atol=0, rtol=0)
+    # Replay must recompute from the captured inputs rather than replay stale results.
+    prepared.saved.v.mul_(0.5)
+    fresh = prepared.state_summary(*bounds)
+    graph.replay()
+    torch.cuda.synchronize()
+    assert not torch.equal(captured, expected)
+    torch.testing.assert_close(captured, fresh, atol=0, rtol=0)
+
+
+@requires_kda_target
+@requires_mega
+def test_mega_prepare_rejects_split_schedules():
+    q, k, v, gate, beta = KDA.make_inputs(128, seed=8)
+    for option in ("split_backward", "split_forward"):
+        with pytest.raises(ValueError, match="split schedules"):
+            chunk_kda_prepare(
+                q, k, v, gate, beta, kernel_options={"backend": "mega", option: True}
+            )
 
 
 class RankResult(NamedTuple):


### PR DESCRIPTION

## Human Note

## Agent note

Stacked on #453. `chunk_kda_prepare(..., kernel_options={"backend": "mega"})` and
`context_parallel_kda(..., kernel_options=...)` now run each rank's local pass on the Mega kernel from the
composed entry state, which is exactly how Mega already runs with an `initial_state`.

The split follows what Mega can and cannot do. Job B, running a fragment from its entry state to output
and exit state, is `chunk_mega_packed_fwd_with_state_op` unchanged; nothing is materialized. Job A,
producing a fragment's `[bias; transition]` summary, needs the WY factors that Mega keeps on chip, so
`ChunkKDAMegaPrepared.state_summary` factors just the requested sequence (a whole local segment, so its
chunk grid is unchanged when treated as a stream of its own); ranks whose fragments all end their sequence
never pay for it, and packed streams pay only for the fragments that continue on another rank. For packed-document workloads the summarized fragment
is a few hundred tokens and the extra pass is negligible; for one long sequence per rank it is one intra
pass plus the summary kernel over the shard, on top of Mega's on-chip run. Backward is Mega's existing
with-state route: `ChunkKDASaved.aqk/akk` may now be `None`, and `chunk_kda_prepare_backward` rebuilds
them with `chunk_kda_fwd_factors` the way `_chunk_kda_bwd_shared` does, then reuses the fused staged
backward and the reverse summary kernel unchanged. `split_backward` is rejected because staged runs always
carry a state.

Also fixes the public Mega wrapper's dense no-state path, which rejected `T % 64 != 0` with "pass
cu_seqlens for tails". Inputs are not padded to 64 in practice; a partial tail now takes the packed path
with synthesized `[0, T]` boundaries, exactly as the fused backend and Mega's own with-state route already
did. The test that pinned the rejection now asserts the tail result equals the explicit-boundary result.

Against an FP32 reference on two GB200s, sharded Mega gradients match unsharded Mega error to 2-3 digits
for contiguous and zig-zag plans. The Mega summary mode (augmented `[0 | I]` state on chip) remains the
follow-up that would remove job A's HBM pass; it would replace `state_summary` behind the same handle.

## Performance

Mega under CP is faster exactly where Mega is faster on one GPU: many sequences or many heads. Its
persistent kernel has one work item per (sequence, head), so one long sequence at H=4 leaves most SMs idle
regardless of CP, while packed documents fill the machine. Two GB200s, bf16, H=4, K=V=128, one
`context_parallel_kda` forward+backward step, CUDA-event timing, max over ranks, best of 3 interleaved
rounds, same seeded tensors and plan for both backends (`agent_space/bench_cp_mega.py`):

| workload (global)            | plan       | fused CP | Mega CP  | fused / Mega |
|------------------------------|------------|---------:|---------:|-------------:|
| 1 sequence, 131k tokens      | contiguous |  2.78 ms |  5.19 ms | 0.54x        |
| 1 sequence, 524k tokens      | contiguous | 10.90 ms | 20.46 ms | 0.53x        |
| 1 sequence, 1M tokens        | contiguous | 21.69 ms | 40.84 ms | 0.53x        |
| 1 sequence, 1M tokens        | zig-zag    | 18.30 ms | 26.76 ms | 0.68x        |
| 1024 x 1k-token docs, 1M     | contiguous |  6.80 ms |  2.32 ms | 2.94x        |

Single-GPU reference on the same per-rank shapes (`chunk_kda`, no CP): 524k x 1 sequence fused 11.8 ms
vs Mega 28.0 ms (0.42x); 524k as 512 docs fused 5.9 ms vs Mega 1.3 ms (4.4x); at H=32, 131k x 1
sequence Mega is 1.5x faster and 128 docs 4.8x. CP adds about 1 ms per step for either backend (summary
kernels on the boundary fragments, two all-gathers, composes), which is why the packed-docs ratio is 2.9x
under CP versus 4.4x alone. For one long sequence the dominant CP cost is the forward/reverse summary
kernel over the whole shard (roughly equal to the local forward+backward itself); that is the serial
per-chunk chain in K1/K2, not the backend, and zig-zag halves it by halving fragment length.

## Test Plan

```bash
# .venv-mega: -e '.[mega,dev]' (CuTeDSL 4.7.1) on SM100; default env skips the kda-mega cases
pytest -n 4 test/test_delta_rule_stages.py                     # 50 passed (mega env)
pytest -n 6 test/test_delta_rule_stages.py test/test_kda_context_parallel.py \
  test/test_namespaces.py test/test_kda_training_example.py     # 69 passed, 12 skipped (default env)
torchrun --standalone --nproc-per-node=2 agent_space/cp_gdn_smoke.py kda contiguous notune mega
torchrun --standalone --nproc-per-node=2 agent_space/cp_gdn_smoke.py kda zigzag notune mega
ruff check . && mkdocs build
```

