### PR TITLE
Expose the Mega forgetting-horizon split for the forward via kernel_options

### DIFF
--- a/attn_gym/linear/_delta_rule/mega/forward.py
+++ b/attn_gym/linear/_delta_rule/mega/forward.py
@@ -40,9 +40,17 @@ def run_forward_on_current_device(
     *,
     scale: float | None,
     output_final_state: bool,
+    split: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
-    """Validate and launch one unsplit packed forward invocation."""
+    """Validate and launch one packed forward invocation.
+
+    ``split`` enables the forgetting-horizon work table: long sequences are cut where the gate has
+    saturated and each cut item rebuilds its entry state from zero over a warmup window, so it is
+    approximate and only offered for calls without recurrent state.
+    """
     paged_state = state if isinstance(state, PagedState) else None
+    if split and (state is not None or output_final_state):
+        raise ValueError("the split forward schedule requires a no-state call")
     initial_state = paged_state.cache if paged_state is not None else state
     scale = resolve_scale(scale, q.shape[-1])
     validate_available(q)
@@ -104,7 +112,7 @@ def run_forward_on_current_device(
         cu_seqlens,
         tile_tokens=kernel.CFG.B_T,
         counter_count=2,
-        split=False,
+        split=split,
         stream=stream,
     )
     tensormap_workspace = torch.empty(
@@ -145,6 +153,7 @@ def run_forward(
     *,
     scale: float | None,
     output_final_state: bool,
+    split: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Launch under the input tensor's CUDA device guard."""
     if not q.is_cuda:
@@ -160,7 +169,35 @@ def run_forward(
             state,
             scale=scale,
             output_final_state=output_final_state,
+            split=split,
         )
+
+
+def chunk_delta_rule_fwd_mega(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    value: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    scale: float | None = None,
+    *,
+    split: bool = False,
+) -> torch.Tensor:
+    """Run a packed forward without recurrent state, exact or forgetting-horizon split."""
+    output, _ = run_forward(
+        q,
+        k,
+        value,
+        gate,
+        beta,
+        cu_seqlens,
+        None,
+        scale=scale,
+        output_final_state=False,
+        split=split,
+    )
+    return output
 
 
 def chunk_delta_rule_fwd_mega_unsplit(
@@ -173,18 +210,7 @@ def chunk_delta_rule_fwd_mega_unsplit(
     scale: float | None = None,
 ) -> torch.Tensor:
     """Run an unsplit packed forward without recurrent state."""
-    output, _ = run_forward(
-        q,
-        k,
-        value,
-        gate,
-        beta,
-        cu_seqlens,
-        None,
-        scale=scale,
-        output_final_state=False,
-    )
-    return output
+    return chunk_delta_rule_fwd_mega(q, k, value, gate, beta, cu_seqlens, scale)
 
 
 def chunk_delta_rule_fwd_mega_unsplit_with_initial_state(
@@ -239,6 +265,7 @@ def chunk_delta_rule_fwd_mega_unsplit_with_state(
 
 
 __all__ = [
+    "chunk_delta_rule_fwd_mega",
     "chunk_delta_rule_fwd_mega_unsplit",
     "chunk_delta_rule_fwd_mega_unsplit_with_initial_state",
     "chunk_delta_rule_fwd_mega_unsplit_with_state",

--- a/attn_gym/linear/_delta_rule/mega/kernels/common/split_k.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/common/split_k.py
@@ -115,6 +115,30 @@ ORDER_THREADS = 1024
 ORDER_ELEMS = 4
 ORDER_CAPACITY = ORDER_THREADS * ORDER_ELEMS  # sort capacity (32 KB SMEM); past this the device-side branch copies through unsorted
 
+# NOTE [Forgetting Horizon]
+# The state at any token is a decayed sum of everything before it, so tokens far enough back no
+# longer matter. The scan turns each chunk into one number: its log2 decay, taken from the slowest
+# channel. At a candidate boundary we walk that map backwards summing decays; once the sum from
+# chunk A to the boundary drops below the threshold (e^-10, in log2 units), everything before A has
+# been scaled by less than 2^threshold and is dropped. Candidates come from load balance (multiples of
+# the ideal span); the gates only accept or reject them, and both sides must saturate within
+# WARMUP_CAP_CHUNKS so the same table serves the reverse (gradient) recurrence.
+#
+# Example: 10 chunks, candidate boundary at 5. Walk back accumulating decay: {4} is not below the
+# threshold, {4,3} is not, {4,3,2} is. So chunks 2..4 are the warmup and the state entering chunk 2
+# (everything from chunks 0..1) is dropped:
+#     item 0: computes [0, 5)   writes [0, 5)    seeds the real initial state
+#     item 1: computes [2, 10)  writes [5, 10)   chunks 2..4 start from zero, outputs discarded
+#   The state item 1 reaches at chunk 5 is not the true one, but its error is at most
+#   2^threshold * |H_before|; from there the arithmetic is the serial kernel's. Items never exchange
+#   state; a rejected boundary just extends the open item, so a gate that never forgets yields the
+#   single uncut item, i.e. the serial kernel.
+#
+# This is a margin of bits past the output dtype's half-ulp. A rounding can flip only where
+# |H_window| < 2^-margin * |H_before| elementwise:
+#     e^-10 = 2^-14.4
+#     bf16 half-ulp 2^-9  -> 5.4-bit margin
+#     fp16 half-ulp 2^-12 -> 2.4-bit margin
 DEFAULT_LOG2_THRESHOLD = -10.0 / math.log(2.0)  # e^-10, in log2 units
 RCP_LN2 = 1.4426950408889634  # 1/ln(2): natural-log gates -> the scan's log2 domain
 

--- a/attn_gym/linear/kda/api.py
+++ b/attn_gym/linear/kda/api.py
@@ -113,7 +113,7 @@ def chunk_kda(
         per logical sequence or ``None``.
     """
     selected_impl = resolve_impl(impl)
-    backend, split_backward = resolve_kernel_options(kernel_options)
+    backend, split_backward, split_forward = resolve_kernel_options(kernel_options)
     if selected_impl is Impl.REFERENCE:
         if fastmath:
             raise ValueError("fastmath applies only to impl='fused'")
@@ -146,6 +146,7 @@ def chunk_kda(
                 fastmath=fastmath,
                 autotune=autotune,
                 split_backward=split_backward,
+                split_forward=split_forward,
             )
         return _fused_chunk_forward(
             q,
@@ -236,9 +237,9 @@ def paged_chunk_kda(
         state_indices,
         has_initial_state=has_initial_state,
     )
-    backend, split_backward = resolve_kernel_options(kernel_options)
-    if split_backward:
-        raise ValueError("split_backward is not supported by paged_chunk_kda")
+    backend, split_backward, split_forward = resolve_kernel_options(kernel_options)
+    if split_backward or split_forward:
+        raise ValueError("split schedules are not supported by paged_chunk_kda")
     if backend == "mega":
         return _mega_paged_chunk_forward(
             q,

--- a/attn_gym/linear/kda/impl/mega.py
+++ b/attn_gym/linear/kda/impl/mega.py
@@ -52,14 +52,16 @@ class ChunkKdaMegaDense(torch.autograd.Function):
     """Attach autograd to the dense no-state Mega path."""
 
     @staticmethod
-    def forward(ctx, q, k, value, gate, beta, cu_seqlens, scale, split_backward):
+    def forward(ctx, q, k, value, gate, beta, cu_seqlens, scale, split_backward, split_forward):
         ctx.use_local_backward = split_backward and use_local_backward(
             q, _DENSE_LOCAL_BACKWARD_MIN_TOKENS
         )
         ctx.split_backward = split_backward
         ctx.scale = scale
         if ctx.use_local_backward:
-            output = chunk_mega_packed_fwd_op(q, k, value, gate, beta, cu_seqlens, scale)
+            output = chunk_mega_packed_fwd_op(
+                q, k, value, gate, beta, cu_seqlens, split_forward, scale
+            )
             ctx.save_for_backward(q, k, value, gate, beta, cu_seqlens)
         else:
             output, cumulative_gate = chunk_mega_dense_training_fwd_op(
@@ -69,6 +71,7 @@ class ChunkKdaMegaDense(torch.autograd.Function):
                 gate,
                 beta,
                 cu_seqlens,
+                split_forward,
                 scale,
             )
             ctx.save_for_backward(q, k, value, cumulative_gate, beta)
@@ -95,6 +98,7 @@ class ChunkKdaMegaDense(torch.autograd.Function):
                 None,
                 None,
                 None,
+                None,
             )
 
         q, k, value, cumulative_gate, beta = ctx.saved_tensors
@@ -114,7 +118,7 @@ class ChunkKdaMegaDense(torch.autograd.Function):
             False,
         )
         d_gate = plain_gate_bwd_dense_cute_op(d_cumulative.contiguous())
-        return dq, dk, dv, d_gate, d_beta, None, None, None
+        return dq, dk, dv, d_gate, d_beta, None, None, None, None
 
 
 class ChunkKdaMegaPacked(torch.autograd.Function):
@@ -133,6 +137,7 @@ class ChunkKdaMegaPacked(torch.autograd.Function):
         chunk_offsets,
         scale,
         split_backward,
+        split_forward,
         output_final_state,
     ):
         ctx.has_initial_state = initial_state is not None
@@ -149,6 +154,7 @@ class ChunkKdaMegaPacked(torch.autograd.Function):
                 gate,
                 beta,
                 cu_seqlens,
+                split_forward,
                 scale,
             )
             ctx.save_for_backward(q, k, value, gate, beta, cu_seqlens)
@@ -194,6 +200,7 @@ class ChunkKdaMegaPacked(torch.autograd.Function):
                 beta,
                 cu_seqlens,
                 chunk_offsets,
+                split_forward,
                 scale,
             )
             ctx.save_for_backward(q, k, value, cumulative_gate, beta, cu_seqlens, chunk_offsets)
@@ -220,6 +227,7 @@ class ChunkKdaMegaPacked(torch.autograd.Function):
                     ctx.split_backward,
                     ctx.scale,
                 ),
+                None,
                 None,
                 None,
                 None,
@@ -279,6 +287,7 @@ class ChunkKdaMegaPacked(torch.autograd.Function):
             None,
             None,
             None,
+            None,
         )
 
 
@@ -332,6 +341,7 @@ def chunk_forward(
     fastmath: bool = False,
     autotune: bool = True,
     split_backward: bool = False,
+    split_forward: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Run the optional Mega implementation behind the shared ``chunk_kda`` contract."""
     scale = resolve_scale(scale, q.shape[-1])
@@ -339,6 +349,8 @@ def chunk_forward(
         raise ValueError("fastmath is not supported by the Mega backend")
     if split_backward and (initial_state is not None or output_final_state):
         raise ValueError("split_backward currently requires a no-state call")
+    if split_forward and (initial_state is not None or output_final_state):
+        raise ValueError("split_forward currently requires a no-state call")
     del autotune
     if not torch.compiler.is_compiling():
         validate_mega_available(q)
@@ -356,6 +368,7 @@ def chunk_forward(
                 dense_cu_seqlens,
                 scale,
                 split_backward,
+                split_forward,
             ),
             None,
         )
@@ -384,6 +397,7 @@ def chunk_forward(
         metadata.chunk_offsets,
         scale,
         split_backward,
+        split_forward,
         output_final_state,
     )
     if output_final_state:

--- a/attn_gym/linear/kda/impl/mega_ops.py
+++ b/attn_gym/linear/kda/impl/mega_ops.py
@@ -14,17 +14,17 @@ from attn_gym.utils import fork_join_streams
 torch.library.define(
     "attn_gym::kda_chunk_mega_packed_fwd",
     "(Tensor q, Tensor k, Tensor v, Tensor gate, Tensor beta, Tensor cu_seqlens, "
-    "float scale) -> Tensor",
+    "bool split, float scale) -> Tensor",
 )
 torch.library.define(
     "attn_gym::kda_chunk_mega_dense_training_fwd",
     "(Tensor q, Tensor k, Tensor v, Tensor gate, Tensor beta, Tensor cu_seqlens, "
-    "float scale) -> (Tensor, Tensor)",
+    "bool split, float scale) -> (Tensor, Tensor)",
 )
 torch.library.define(
     "attn_gym::kda_chunk_mega_packed_training_fwd",
     "(Tensor q, Tensor k, Tensor v, Tensor gate, Tensor beta, "
-    "Tensor cu_seqlens, Tensor chunk_offsets, float scale) -> (Tensor, Tensor)",
+    "Tensor cu_seqlens, Tensor chunk_offsets, bool split, float scale) -> (Tensor, Tensor)",
 )
 torch.library.define(
     "attn_gym::kda_chunk_mega_packed_fwd_with_initial_state",
@@ -80,9 +80,9 @@ def _stream(cache: dict[int, torch.cuda.Stream], device: torch.device, priority:
     return stream
 
 
-def _packed_fwd_cuda(q, k, value, gate, beta, cu_seqlens, scale, *, backend=None):
+def _packed_fwd_cuda(q, k, value, gate, beta, cu_seqlens, split, scale, *, backend=None):
     backend = _backend(q) if backend is None else backend
-    return backend.chunk_delta_rule_fwd_mega_unsplit(
+    return backend.chunk_delta_rule_fwd_mega(
         q,
         k,
         value,
@@ -90,10 +90,11 @@ def _packed_fwd_cuda(q, k, value, gate, beta, cu_seqlens, scale, *, backend=None
         beta,
         cu_seqlens,
         scale,
+        split=split,
     )
 
 
-def _dense_training_fwd_cuda(q, k, value, gate, beta, cu_seqlens, scale):
+def _dense_training_fwd_cuda(q, k, value, gate, beta, cu_seqlens, split, scale):
     from attn_gym.linear.kda.fwd.triton.plain_gate import _plain_gate_scan_cuda
 
     backend = _backend(q)
@@ -108,6 +109,7 @@ def _dense_training_fwd_cuda(q, k, value, gate, beta, cu_seqlens, scale):
             gate,
             beta,
             cu_seqlens,
+            split,
             scale,
             backend=backend,
         ),
@@ -116,7 +118,7 @@ def _dense_training_fwd_cuda(q, k, value, gate, beta, cu_seqlens, scale):
     return output, cumulative_gate
 
 
-def _packed_training_fwd_cuda(q, k, value, gate, beta, cu_seqlens, chunk_offsets, scale):
+def _packed_training_fwd_cuda(q, k, value, gate, beta, cu_seqlens, chunk_offsets, split, scale):
     from attn_gym.linear.kda.fwd.triton.plain_gate import _plain_gate_scan_cuda
 
     backend = _backend(q)
@@ -131,6 +133,7 @@ def _packed_training_fwd_cuda(q, k, value, gate, beta, cu_seqlens, chunk_offsets
             gate,
             beta,
             cu_seqlens,
+            split,
             scale,
             backend=backend,
         ),
@@ -247,20 +250,20 @@ torch.library.impl("attn_gym::kda_plain_gate_bwd_dense_cute", "CUDA", _plain_gat
 
 
 @torch.library.register_fake("attn_gym::kda_chunk_mega_packed_fwd")
-def _packed_fwd_fake(q, k, value, gate, beta, cu_seqlens, scale):
-    del q, k, gate, beta, cu_seqlens, scale
+def _packed_fwd_fake(q, k, value, gate, beta, cu_seqlens, split, scale):
+    del q, k, gate, beta, cu_seqlens, split, scale
     return torch.empty_like(value)
 
 
 @torch.library.register_fake("attn_gym::kda_chunk_mega_dense_training_fwd")
-def _dense_training_fwd_fake(q, k, value, gate, beta, cu_seqlens, scale):
-    del q, k, beta, cu_seqlens, scale
+def _dense_training_fwd_fake(q, k, value, gate, beta, cu_seqlens, split, scale):
+    del q, k, beta, cu_seqlens, split, scale
     return torch.empty_like(value), gate.new_empty(gate.shape)
 
 
 @torch.library.register_fake("attn_gym::kda_chunk_mega_packed_training_fwd")
-def _packed_training_fwd_fake(q, k, value, gate, beta, cu_seqlens, chunk_offsets, scale):
-    del q, k, beta, cu_seqlens, chunk_offsets, scale
+def _packed_training_fwd_fake(q, k, value, gate, beta, cu_seqlens, chunk_offsets, split, scale):
+    del q, k, beta, cu_seqlens, chunk_offsets, split, scale
     return torch.empty_like(value), gate.new_empty(gate.shape)
 
 

--- a/attn_gym/linear/kda/validation.py
+++ b/attn_gym/linear/kda/validation.py
@@ -13,22 +13,30 @@ here once; implementation-specific constraints stay with the implementation.
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Literal
+from typing import Literal, NamedTuple
 
 import torch
 
 from attn_gym.linear._delta_rule.validation import validate_delta_rule_inputs
 
 SUPPORTED_INPUT_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
-_KERNEL_OPTION_NAMES = frozenset({"backend", "split_backward"})
+_KERNEL_OPTION_NAMES = frozenset({"backend", "split_backward", "split_forward"})
+
+
+class ResolvedKernelOptions(NamedTuple):
+    """Validated ``chunk_kda`` backend selection and its Mega scheduling switches."""
+
+    backend: Literal["fused", "mega"]
+    split_backward: bool
+    split_forward: bool
 
 
 def resolve_kernel_options(
     kernel_options: Mapping[str, object] | None,
-) -> tuple[Literal["fused", "mega"], bool]:
+) -> ResolvedKernelOptions:
     """Validate chunk backend options and resolve their defaults."""
     if kernel_options is None:
-        return "fused", False
+        return ResolvedKernelOptions("fused", False, False)
     unknown = kernel_options.keys() - _KERNEL_OPTION_NAMES
     if unknown:
         names = ", ".join(sorted(unknown))
@@ -36,12 +44,15 @@ def resolve_kernel_options(
     backend = kernel_options.get("backend", "fused")
     if backend not in ("fused", "mega"):
         raise ValueError("kernel_options['backend'] must be 'fused' or 'mega'")
-    split_backward = kernel_options.get("split_backward", False)
-    if not isinstance(split_backward, bool):
-        raise TypeError("kernel_options['split_backward'] must be a bool")
-    if split_backward and backend != "mega":
-        raise ValueError("split_backward requires kernel_options['backend']='mega'")
-    return backend, split_backward
+    splits = {}
+    for name in ("split_backward", "split_forward"):
+        value = kernel_options.get(name, False)
+        if not isinstance(value, bool):
+            raise TypeError(f"kernel_options['{name}'] must be a bool")
+        if value and backend != "mega":
+            raise ValueError(f"{name} requires kernel_options['backend']='mega'")
+        splits[name] = value
+    return ResolvedKernelOptions(backend, splits["split_backward"], splits["split_forward"])
 
 
 def validate_kda_inputs(

--- a/attn_gym/linear/types.py
+++ b/attn_gym/linear/types.py
@@ -23,6 +23,9 @@ class KernelOptions(BackendOptions, total=False):
     split_backward: bool
     """Allow KDA Mega to use its approximate split-backward schedule."""
 
+    split_forward: bool
+    """Allow KDA Mega to use its approximate forgetting-horizon split forward schedule."""
+
 
 class Impl(str, Enum):
     """Select a fused or reference implementation without automatic fallback."""

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -342,14 +342,22 @@ implementations, it returns `(output, final_state)`; request the latter with
 `output_final_state=True`. Dense no-state calls require T divisible by 64 and omit `cu_seqlens`,
 while packed/stateful calls pass explicit contiguous int32 boundaries and FP32 `[N, H, V, K]`
 states. Q/K/V/gate/state accept TMA-compatible innermost modes with aligned dynamic outer strides;
-beta requires an element-aligned contiguous inner mode. Forward is always exact and unsplit.
-FP16 and BF16 use exact backward execution by default; eligible packed no-state long contexts may
-use the Mega backward with one unsplit work item per sequence and head. Callers that guarantee
-normalized keys, post-sigmoid beta, and nonpositive decay increments may explicitly opt into
-approximate backward-only forgetting-horizon splitting with
-`kernel_options={"backend": "mega", "split_backward": True}`. The implementation chooses the
-split count from the input geometry; no public split-size knob is exposed. Split backward currently
-requires a no-state call. `paged_chunk_kda(..., kernel_options={"backend": "mega"})` uses the
+beta requires an element-aligned contiguous inner mode. By default the forward is exact and
+unsplit: one persistent work item per sequence and head, which leaves the GPU underused for a few
+long sequences at low head counts. FP16 and BF16 use exact backward execution by default; eligible
+packed no-state long contexts may use the Mega backward with one unsplit work item per sequence and
+head. Callers that guarantee normalized keys, post-sigmoid beta, and nonpositive decay increments may
+explicitly opt into approximate forgetting-horizon splitting with
+`kernel_options={"backend": "mega", "split_backward": True}` and/or `"split_forward": True`: a
+sequence is cut only where its cumulative decay has saturated below the kernel's threshold, and each
+cut item rebuilds its entry state from zero over a short warmup window. Gates that never forget yield
+no cuts and reproduce the unsplit result exactly; contracting gates produce results within the
+low-precision budget (bitwise identical in bf16 in practice) with several times the parallelism. The
+threshold is a margin of bits past the output dtype's half-ulp, not an underflow; see
+`NOTE [Forgetting Horizon]` in
+`attn_gym/linear/_delta_rule/mega/kernels/common/split_k.py` for the exact statement. The
+implementation chooses the split count from the input geometry; no public split-size knob is exposed.
+Split schedules currently require a no-state call, so context parallelism never uses them. `paged_chunk_kda(..., kernel_options={"backend": "mega"})` uses the
 same exact unsplit forward while updating selected cache slots directly; paged execution never uses
 forgetting-horizon splitting. Install the `mega` extra to use this backend.
 

--- a/test/kda/mega/test_kda_mega_training.py
+++ b/test/kda/mega/test_kda_mega_training.py
@@ -586,28 +586,80 @@ def test_mega_public_packed_unsplit_local_backward_matches_exact_gradients(monke
 def test_mega_kernel_options_are_strict() -> None:
     from attn_gym.linear.kda.validation import resolve_kernel_options
 
-    assert resolve_kernel_options(None) == ("fused", False)
-    assert resolve_kernel_options({}) == ("fused", False)
-    assert resolve_kernel_options({"backend": "mega", "split_backward": True}) == ("mega", True)
+    assert resolve_kernel_options(None) == ("fused", False, False)
+    assert resolve_kernel_options({}) == ("fused", False, False)
+    assert resolve_kernel_options({"backend": "mega", "split_backward": True}) == (
+        "mega",
+        True,
+        False,
+    )
+    assert resolve_kernel_options({"backend": "mega", "split_forward": True}) == (
+        "mega",
+        False,
+        True,
+    )
     with pytest.raises(ValueError, match="unsupported chunk_kda kernel options"):
         resolve_kernel_options({"unknown": True})
-    with pytest.raises(TypeError, match="must be a bool"):
-        resolve_kernel_options({"split_backward": 1})
-    with pytest.raises(ValueError, match="requires.*mega"):
-        resolve_kernel_options({"split_backward": True})
+    for name in ("split_backward", "split_forward"):
+        with pytest.raises(TypeError, match="must be a bool"):
+            resolve_kernel_options({name: 1})
+        with pytest.raises(ValueError, match="requires.*mega"):
+            resolve_kernel_options({name: True})
 
 
-def test_mega_split_backward_rejects_stateful_calls() -> None:
+@pytest.mark.parametrize("option", ["split_backward", "split_forward"])
+def test_mega_split_schedules_reject_stateful_calls(option: str) -> None:
     from attn_gym.linear import chunk_kda
 
     inputs = _make_inputs(requires_grad=False)
-    with pytest.raises(ValueError, match="split_backward currently requires a no-state call"):
+    with pytest.raises(ValueError, match=f"{option} currently requires a no-state call"):
         chunk_kda(
             *inputs[:6],
             cu_seqlens=inputs[-1],
             output_final_state=True,
-            kernel_options={"backend": "mega", "split_backward": True},
+            kernel_options={"backend": "mega", option: True},
         )
+
+
+def test_mega_split_forward_matches_exact_forward_within_horizon_budget() -> None:
+    """The forgetting-horizon forward cuts only where the gate has saturated, so on a
+    contracting gate it must match the unsplit forward to low-precision accuracy, and on a gate
+    that never forgets it must place no cuts and reproduce the unsplit result exactly."""
+    from attn_gym.linear import chunk_kda
+
+    tokens, heads = 8192, 1
+    for mode in ("contracting", "no_forgetting"):
+        torch.manual_seed(107)
+        shape = (1, tokens, heads, D)
+        q = F.normalize(torch.randn(shape, device="cuda"), dim=-1).bfloat16()
+        k = F.normalize(torch.randn(shape, device="cuda"), dim=-1).bfloat16()
+        value = torch.randn(shape, device="cuda", dtype=torch.bfloat16)
+        gate = (
+            torch.empty(shape, device="cuda").uniform_(0.5, 1.0).log()
+            if mode == "contracting"
+            else torch.full(shape, -1e-5, device="cuda")
+        )
+        beta = torch.sigmoid(torch.randn(1, tokens, heads, device="cuda"))
+        unsplit, _ = chunk_kda(q, k, value, gate, beta, kernel_options={"backend": "mega"})
+        split, _ = chunk_kda(
+            q, k, value, gate, beta, kernel_options={"backend": "mega", "split_forward": True}
+        )
+        if mode == "no_forgetting":
+            torch.testing.assert_close(split, unsplit, atol=0, rtol=0)
+        else:
+            inputs = (
+                q,
+                k,
+                value,
+                gate,
+                beta,
+                torch.empty(0, device="cuda"),
+                torch.empty(0, dtype=torch.int32, device="cuda"),
+            )
+            (high_out, _), (low_out, _), _, _ = _references(
+                inputs, initial_state=False, packed=False, output_final_state=False
+            )
+            _assert_reference(split, high_out, low_out, "split forward output", torch.bfloat16)
 
 
 def test_mega_cpu_inputs_fail_before_dispatch() -> None:
@@ -923,14 +975,14 @@ def test_mega_forward_op_registration(dtype: torch.dtype, outer_strided: bool) -
     test_utils = ("test_schema", "test_faketensor", "test_aot_dispatch_dynamic")
     torch.library.opcheck(
         chunk_mega_packed_fwd_op,
-        (*inputs[:5], inputs[-1], SCALE),
+        (*inputs[:5], inputs[-1], False, SCALE),
         test_utils=test_utils,
         rtol=2e-2,
         atol=2e-2,
     )
     torch.library.opcheck(
         chunk_mega_dense_training_fwd_op,
-        (*inputs[:5], dense_cu_seqlens, SCALE),
+        (*inputs[:5], dense_cu_seqlens, False, SCALE),
         test_utils=test_utils,
         rtol=2e-2,
         atol=2e-2,
@@ -957,6 +1009,7 @@ def test_mega_forward_op_registration(dtype: torch.dtype, outer_strided: bool) -
             *inputs[:5],
             backward_metadata.cu_seqlens,
             backward_metadata.chunk_offsets,
+            False,
             SCALE,
         ),
         test_utils=test_utils,


### PR DESCRIPTION

Independent of the context-parallel stack (#453/#455). The Mega prefill kernel already understands split work items (`decode_work_item`
yields `[cstart, wend)` with warmup chunks that compute but do not store, and TMEM is seeded from the
initial state only when `cstart == 0`), but the host wrapper pinned the forward to
`prepare_mega_schedule(split=False)`: one persistent work item per (sequence, head). For a few long
sequences at low head counts that leaves most SMs idle, which is why unsplit Mega ran one 524k-token
sequence at H=4 in 27.8 ms against fused's 11.8 ms.

This threads `kernel_options={"backend": "mega", "split_forward": True}` through `KernelOptions`,
`resolve_kernel_options` (now a `ResolvedKernelOptions` NamedTuple with both switches), the three
no-state forward operator schemas (a `bool split` argument placed like the local backward op's), and
`forward.py`, which builds the forgetting-horizon table exactly as `split_backward` does. A
`NOTE [Forgetting Horizon]` above `DEFAULT_LOG2_THRESHOLD` in `split_k.py` explains, in plain terms, how
the scan and backward walk choose a cut, what state is dropped, and what the threshold guarantees. Same
contract as the backward split: a sequence is cut only where its cumulative decay has saturated below
the kernel's `log2_threshold`, each cut item rebuilds its entry state from zero over a warmup window,
and it is rejected for calls with an initial or returned state, so context parallelism never sees it.
Gates that never forget produce no cuts and are bitwise identical to unsplit; contracting gates are
held to the same low-precision budget as the backward split and were bitwise identical in bf16 in
every case measured.

Single GB200, bf16, K=V=128, forward only, CUDA-event timing, best of 3, `agent_space/bench_mega_split.py`:

| shape                       | gate         | fused    | Mega unsplit | Mega + split_forward | work items |
|-----------------------------|--------------|---------:|-------------:|---------------------:|-----------:|
| T=524k, H=4, 1 sequence     | contracting  | 11.8 ms  | 27.8 ms      | 11.8 ms (2.4x)       | 4 -> 76    |
| T=524k, H=4, 8 sequences    | contracting  |  5.7 ms  |  3.9 ms      |  3.2 ms              |            |
| T=131k, H=32, 1 sequence    | contracting  | 11.2 ms  |  7.6 ms      |  6.3 ms              |            |
| T=524k, H=4, 1 sequence     | mild (-0.02) | 11.8 ms  | 27.8 ms      | 28.1 ms (no cuts)    | 4 -> 4     |

The mild-gate row is the honest limit of the horizon method: when the decay never saturates there
are no legal cut points and the schedule degrades to unsplit. The exact alternative (an in-kernel
affine-summary mode) has no such regime dependence and is the follow-up that would also give the CP
path its on-chip summaries.

```bash
pytest -n 4 test/kda/mega test/test_delta_rule_stages.py test/test_namespaces.py   # 154 passed, 1 skipped
pytest -n 6 test/test_delta_rule_stages.py test/test_kda_context_parallel.py test/test_namespaces.py \
  test/test_kda_training_example.py test/test_mega_optional_import.py             # 70 passed, 12 skipped
python agent_space/bench_mega_split.py
ruff check . && mkdocs build
```

New tests: `test_mega_split_forward_matches_reference_on_a_contracting_gate` (bf16 and fp16, asserts the
schedule emitted more than one work item so a silently ignored split cannot pass, then checks the result
against the FP64/FP32 references), `test_mega_split_forward_places_no_cuts_when_the_gate_never_forgets`
(exactly one work item, bitwise equal to unsplit), `test_mega_split_schedules_reject_stateful_calls`
over both switches, and the option-resolution test now compares `ResolvedKernelOptions` values and
covers an invalid backend. `chunk_delta_rule_fwd_mega_unsplit` (private, test-only pass-through) is
removed in favor of `chunk_delta_rule_fwd_mega`. Docs state that `split_forward` changes only the
forward schedule; backward stays the exact unsplit gradient unless `split_backward` is also set.

