### PR TITLE
Guard short-conv TMA gradients by GPU capability

### DIFF
--- a/attn_gym/linear/short_conv/cute.py
+++ b/attn_gym/linear/short_conv/cute.py
@@ -57,6 +57,7 @@ SHORT_CONV_DTYPES = {
 }
 
 
+_MINIMUM_TMA_CAPABILITY = (9, 0)
 _PERSISTENT_TMA_DX_CTAS_PER_SM = 8
 
 
@@ -2706,14 +2707,16 @@ def supports_tma(
     selected_config: ShortConvConfig | None,
     channels: int,
     width: int,
+    capability: tuple[int, int],
 ) -> bool:
-    """Return whether the TMA gradient kernels support this static schedule.
+    """Return whether the target and static schedule support a TMA gradient kernel.
 
     TMA zero-fills out-of-bounds token rows, so any token count works; only the
-    schedule's channel and stage divisibility matter.
+    target capability and schedule's channel and stage divisibility matter.
     """
     return (
-        config == selected_config
+        capability >= _MINIMUM_TMA_CAPABILITY
+        and config == selected_config
         and width > 1
         and channels % (config.threads * config.channels_per_thread) == 0
         and config.times_per_block % operation_type.tma_stage_tokens == 0
@@ -2726,6 +2729,7 @@ def _input_gradient_uses_tma(
     num_sequences: int | None,
     channels: int,
     width: int,
+    capability: tuple[int, int],
 ) -> bool:
     """Return whether this specialization uses the staged input-gradient kernel."""
     return supports_tma(
@@ -2736,6 +2740,7 @@ def _input_gradient_uses_tma(
         else tuned_config(dtype, packed=num_sequences is not None).input_gradient,
         channels,
         width,
+        capability,
     )
 
 
@@ -2750,12 +2755,20 @@ def _compile_input_gradient(
     num_sequences: int | None,
     has_initial_state: bool,
     activation: Activation,
+    capability: tuple[int, int],
     time_workers: int = 0,
     use_int64_offsets: bool = False,
 ):
     """Compile one static or explicitly persistent TMA input-gradient specialization."""
     derivative = activation.derivative
-    use_tma = _input_gradient_uses_tma(dtype, config, num_sequences, channels, width)
+    use_tma = _input_gradient_uses_tma(
+        dtype,
+        config,
+        num_sequences,
+        channels,
+        width,
+        capability,
+    )
     if time_workers:
         assert use_tma and num_sequences is not None, (
             "persistent input-gradient scheduling requires a packed TMA specialization"
@@ -2812,6 +2825,7 @@ def _compile_weight_gradient(
     num_sequences: int | None,
     has_initial_state: bool,
     activation: Activation,
+    capability: tuple[int, int],
     use_int64_offsets: bool = False,
 ):
     """Compile one static weight-gradient specialization."""
@@ -2829,6 +2843,7 @@ def _compile_weight_gradient(
         tuned_config(dtype, packed=num_sequences is not None).weight_gradient,
         channels,
         width,
+        capability,
     )
     operation_type = (
         CausalConv1dSiluWeightGradientPartialsTma
@@ -3104,6 +3119,8 @@ def _launch_backward(
     width = weight.shape[1]
     dtype = SHORT_CONV_DTYPES[x.dtype]
     num_sequences = None if cu_seqlens is None else cu_seqlens.shape[0] - 1
+    properties = get_device_properties(x.device)
+    capability = (properties.major, properties.minor)
     input_time_workers = 0
     if persistent_tma_input_gradient:
         if num_sequences is None or not _input_gradient_uses_tma(
@@ -3112,6 +3129,7 @@ def _launch_backward(
             num_sequences,
             channels,
             width,
+            capability,
         ):
             raise ValueError(
                 "persistent TMA input gradients require a packed staged specialization"
@@ -3129,6 +3147,7 @@ def _launch_backward(
         num_sequences,
         initial_state is not None,
         resolved_activation,
+        capability,
         input_time_workers,
         requires_int64_abi(x, grad_output, grad_x),
     )(
@@ -3162,6 +3181,7 @@ def _launch_backward(
         num_sequences,
         initial_state is not None,
         resolved_activation,
+        capability,
         requires_int64_abi(x, grad_output),
     )(
         x.view(batches * tokens, channels),
@@ -4402,12 +4422,18 @@ def causal_conv1d(
         if cu_seqlens is None:
             raise ValueError("persistent TMA input gradients require packed cu_seqlens")
         descriptor = SHORT_CONV_DTYPES[x.dtype]
+        # The opaque backward launcher validates the physical capability at execution time.
+        capability = _MINIMUM_TMA_CAPABILITY
+        if not torch.compiler.is_compiling():
+            properties = get_device_properties(x.device)
+            capability = (properties.major, properties.minor)
         if not _input_gradient_uses_tma(
             descriptor,
             input_grad,
             cu_seqlens.shape[0] - 1,
             channels,
             weight.shape[1],
+            capability,
         ):
             raise ValueError(
                 "persistent TMA input gradients require the staged input-gradient specialization"

--- a/test/test_short_conv_cute.py
+++ b/test/test_short_conv_cute.py
@@ -348,6 +348,7 @@ def test_short_conv_packed_defaults_select_tma(dtype: torch.dtype):
         cute_backend.tuned_config(descriptor, packed=True).input_gradient,
         512,
         4,
+        (9, 0),
     )
     assert cute_backend.supports_tma(
         cute_backend.CausalConv1dSiluWeightGradientPartialsTma,
@@ -355,7 +356,71 @@ def test_short_conv_packed_defaults_select_tma(dtype: torch.dtype):
         cute_backend.tuned_config(descriptor, packed=True).weight_gradient,
         512,
         4,
+        (9, 0),
     )
+
+
+@pytest.mark.parametrize("capability", [(8, 0), (8, 6)])
+@pytest.mark.parametrize(
+    ("operation_type", "config_name"),
+    [
+        (cute_backend.CausalConv1dSiluInputGradientTma, "input_gradient"),
+        (cute_backend.CausalConv1dSiluWeightGradientPartialsTma, "weight_gradient"),
+    ],
+)
+def test_short_conv_ampere_defaults_reject_tma(capability, operation_type, config_name):
+    """Route Ampere gradient schedules through their portable fallbacks."""
+    descriptor = cute_backend.SHORT_CONV_DTYPES[torch.bfloat16]
+    defaults = cute_backend.tuned_config(descriptor, packed=True)
+    config = getattr(defaults, config_name)
+    assert not cute_backend.supports_tma(
+        operation_type,
+        config,
+        config,
+        512,
+        4,
+        capability,
+    )
+
+
+def test_short_conv_ampere_compiles_portable_gradients(monkeypatch):
+    """Construct portable gradient operations for otherwise TMA-eligible Ampere shapes."""
+    monkeypatch.setattr(
+        cute_backend,
+        "compile_tvm_ffi",
+        lambda operation, *args, **kwargs: operation,
+    )
+    descriptor = cute_backend.SHORT_CONV_DTYPES[torch.bfloat16]
+    defaults = cute_backend.tuned_config(descriptor, packed=True)
+    activation = cute_backend.resolve_activation("silu")
+
+    input_gradient = cute_backend._compile_input_gradient.__wrapped__(
+        1,
+        24,
+        512,
+        4,
+        descriptor,
+        defaults.input_gradient,
+        2,
+        False,
+        activation,
+        (8, 6),
+    )
+    weight_gradient = cute_backend._compile_weight_gradient.__wrapped__(
+        1,
+        24,
+        256,
+        4,
+        descriptor,
+        defaults.weight_gradient,
+        2,
+        False,
+        activation,
+        (8, 6),
+    )
+
+    assert type(input_gradient) is cute_backend.CausalConv1dSiluInputGradient
+    assert type(weight_gradient) is cute_backend.CausalConv1dSiluWeightGradientPartials
 
 
 def test_short_conv_tma_rejects_partial_channel_tiles():


### PR DESCRIPTION
## Human Note

## Agent note

Short-convolution gradient dispatch treated a matching schedule shape as sufficient for TMA,
so Attention Gym 0.0.7 selected SM90-only kernels on Ampere instead of the existing portable
implementations. This passes the physical CUDA capability through input- and weight-gradient
selection and cached compilation, requiring SM90 or newer before constructing either TMA
operation.

Eager validation remains for explicitly persistent TMA input gradients, while compiled execution
defers the physical-device check to the opaque backward launcher. Selector and operation-
construction regressions cover SM80 and SM86, and the existing packed BF16 and persistent SM90
paths remain covered.

Fixes #458.

## Test Plan

```bash
.venv/bin/ruff check attn_gym/linear/short_conv/cute.py test/test_short_conv_cute.py
.venv/bin/ruff format --check attn_gym/linear/short_conv/cute.py test/test_short_conv_cute.py
gpu-run --timeout 30 auto -- timeout --signal=TERM --kill-after=5s 240s .venv/bin/pytest -q test/test_short_conv_cute.py::test_short_conv_packed_defaults_select_tma test/test_short_conv_cute.py::test_short_conv_ampere_defaults_reject_tma test/test_short_conv_cute.py::test_short_conv_ampere_compiles_portable_gradients test/test_short_conv_cute.py::test_short_conv_packed_tma_backward_matches_fallback test/test_short_conv_cute.py::test_short_conv_public_persistent_tma_input_gradient_matches_static
git diff --check
```
