### PR TITLE
Pass GPU capability through short-conv tuning

### DIFF
--- a/attn_gym/linear/short_conv/cute.py
+++ b/attn_gym/linear/short_conv/cute.py
@@ -3334,6 +3334,8 @@ def tune_causal_conv1d(
     batches, tokens, channels = x.shape
     width = weight.shape[1]
     dtype = SHORT_CONV_DTYPES[x.dtype]
+    properties = get_device_properties(x.device)
+    capability = (properties.major, properties.minor)
     packed = cu_seqlens is not None
     num_sequences = None if cu_seqlens is None else cu_seqlens.shape[0] - 1
     x_matrix = x.view(batches * tokens, channels)
@@ -3397,6 +3399,7 @@ def tune_causal_conv1d(
             num_sequences,
             kernel_initial_state is not None,
             resolved_activation,
+            capability,
         ),
         parallel_compile=parallel_compile,
     )
@@ -3440,6 +3443,7 @@ def tune_causal_conv1d(
             num_sequences,
             kernel_initial_state is not None,
             resolved_activation,
+            capability,
         ),
         parallel_compile=parallel_compile,
     )

--- a/test/test_short_conv_cute.py
+++ b/test/test_short_conv_cute.py
@@ -1,6 +1,7 @@
 """Correctness and integration tests for the CuTeDSL short convolution."""
 
 import sys
+from inspect import signature
 from itertools import pairwise
 from types import FunctionType
 
@@ -1006,6 +1007,38 @@ def test_short_conv_accepts_misaligned_contiguous_storage():
     x, weight = _misaligned_inputs()
 
     _assert_conv_matches(causal_conv1d, x, weight)
+
+
+def test_short_conv_tuning_projects_device_capability(monkeypatch):
+    """Keep every tuning compile projection compatible with its cached compiler."""
+    compile_calls = {}
+
+    def fake_tune(configs, compile_fn, launch, *, compile_call, parallel_compile):
+        config = next(iter(configs))
+        projected = compile_call(config)
+        signature(compile_fn.__wrapped__).bind(*projected)
+        compile_calls[compile_fn] = projected
+        return config
+
+    class AmpereProperties:
+        major = 8
+        minor = 6
+
+    monkeypatch.setattr(cute_backend, "get_device_properties", lambda _device: AmpereProperties())
+    monkeypatch.setattr(cute_backend, "tune", fake_tune)
+    x, weight = _inputs(channels=6, width=3)
+    config = ShortConvConfig(128, 2, 8)
+    tune_causal_conv1d(
+        x,
+        weight,
+        torch.randn_like(x),
+        forward_configs=(config,),
+        input_grad_configs=(config,),
+        weight_grad_configs=(config,),
+    )
+
+    assert compile_calls[cute_backend._compile_input_gradient][-1] == (8, 6)
+    assert compile_calls[cute_backend._compile_weight_gradient][-1] == (8, 6)
 
 
 def test_short_conv_explicit_config_and_tuning_flow():


### PR DESCRIPTION
## Human Note

## Agent note

The capability-aware gradient compiler signatures added in #459 were not reflected in
`tune_causal_conv1d` compile projections. Public tuning therefore raised a missing-argument
`TypeError` before benchmarking input- or weight-gradient candidates.

This derives capability from the tuned tensor device and appends it to both gradient compile calls.
A projection-level regression binds every compile tuple against its cached compiler signature and
asserts that SM86 capability reaches both gradient compilers.

Follow-up to #459 and the automated review comment on that PR.

## Test Plan

```bash
.venv/bin/ruff check attn_gym/linear/short_conv/cute.py test/test_short_conv_cute.py
.venv/bin/ruff format --check attn_gym/linear/short_conv/cute.py test/test_short_conv_cute.py
.venv/bin/pytest -q test/test_short_conv_cute.py::test_short_conv_tuning_projects_device_capability
gpu-run --timeout 30 auto -- timeout --signal=TERM --kill-after=5s 240s .venv/bin/pytest -q test/test_short_conv_cute.py::test_short_conv_explicit_config_and_tuning_flow
git diff --check
```
