### PR TITLE
Exclude diagonal terms from fused KDA gate gradients

### DIFF
--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_intra.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_intra.py
@@ -1273,14 +1273,16 @@ def _chunk_kda_bwd_intra_hmma_grid_kernel(
                             ak0, ak1, ak2, ak3, b0, b1, k30, k31, k32, k33
                         )
 
+        # Keep i == j out of the gate-factored MMAs. Its gate-independent
+        # dq/dk/dbeta contributions are restored directly in the epilogue.
         key_base = row_base
         for k_outer in cutlass.range_constexpr(2):
             key0 = key_base + k_outer * 8 + 2 * tid
             key1 = key0 + 1
-            keep00 = (k_outer * 8 + 2 * tid) <= gid
-            keep01 = (k_outer * 8 + 2 * tid + 1) <= gid
-            keep10 = (k_outer * 8 + 2 * tid) <= (gid + 8)
-            keep11 = (k_outer * 8 + 2 * tid + 1) <= (gid + 8)
+            keep00 = (k_outer * 8 + 2 * tid) < gid
+            keep01 = (k_outer * 8 + 2 * tid + 1) < gid
+            keep10 = (k_outer * 8 + 2 * tid) < (gid + 8)
+            keep11 = (k_outer * 8 + 2 * tid + 1) < (gid + 8)
             aq0, aq2 = _hmma_load_da_pair_pred(
                 mdAqk,
                 row_start,
@@ -1487,10 +1489,10 @@ def _chunk_kda_bwd_intra_hmma_grid_kernel(
         for k_outer in cutlass.range_constexpr(2):
             query0 = row_base + k_outer * 8 + 2 * tid
             query1 = query0 + 1
-            keep00 = gid <= (k_outer * 8 + 2 * tid)
-            keep01 = gid <= (k_outer * 8 + 2 * tid + 1)
-            keep10 = (gid + 8) <= (k_outer * 8 + 2 * tid)
-            keep11 = (gid + 8) <= (k_outer * 8 + 2 * tid + 1)
+            keep00 = gid < (k_outer * 8 + 2 * tid)
+            keep01 = gid < (k_outer * 8 + 2 * tid + 1)
+            keep10 = (gid + 8) < (k_outer * 8 + 2 * tid)
+            keep11 = (gid + 8) < (k_outer * 8 + 2 * tid + 1)
             aq0 = _hmma_load_da_pred(mdAqk, row_start, head_idx, query0, row0, valid, keep00)
             aq1 = _hmma_load_da_pred(mdAqk, row_start, head_idx, query0, row1, valid, keep10)
             aq2 = _hmma_load_da_pred(mdAqk, row_start, head_idx, query1, row0, valid, keep01)
@@ -1578,6 +1580,20 @@ def _chunk_kda_bwd_intra_hmma_grid_kernel(
                         ak0, ak1, ak2, ak3, c0, c1, d30, d31, d32, d33
                     )
 
+        daq_diag0 = z
+        daq_diag1 = z
+        dak_diag0 = z
+        dak_diag1 = z
+        if tid == 0:
+            daq_diag0 = _hmma_load_da(mdAqk, row_start, head_idx, row0, row0, valid)
+            daq_diag1 = _hmma_load_da(mdAqk, row_start, head_idx, row1, row1, valid)
+            dak_diag0 = _hmma_load_da(mdAkk, row_start, head_idx, row0, row0, valid)
+            dak_diag1 = _hmma_load_da(mdAkk, row_start, head_idx, row1, row1, valid)
+        diagonal_lane = gid * 4
+        daq_diag0 = cute.arch.shuffle_sync(daq_diag0, diagonal_lane)
+        daq_diag1 = cute.arch.shuffle_sync(daq_diag1, diagonal_lane)
+        dak_diag0 = cute.arch.shuffle_sync(dak_diag0, diagonal_lane)
+        dak_diag1 = cute.arch.shuffle_sync(dak_diag1, diagonal_lane)
         db_acc0 = z
         db_acc1 = z
         dq_top0 = Int32(0)
@@ -1722,8 +1738,12 @@ def _chunk_kda_bwd_intra_hmma_grid_kernel(
                     mDg.iterator + out_row * dg_row_stride + head_idx * dg_head_stride + col0,
                     row_valid,
                 )
-                dq_add0 = q_acc0 * qscale_prev0 + q_diag0 * qscale_diag0
-                dq_add1 = q_acc1 * qscale_prev1 + q_diag1 * qscale_diag1
+                dq_strict0 = q_acc0 * qscale_prev0 + q_diag0 * qscale_diag0
+                dq_strict1 = q_acc1 * qscale_prev1 + q_diag1 * qscale_diag1
+                daq_diag = daq_diag0 if lane_row == 0 else daq_diag1
+                dak_diag = dak_diag0 if lane_row == 0 else dak_diag1
+                dq_add0 = dq_strict0 + daq_diag * kval0
+                dq_add1 = dq_strict1 + daq_diag * kval1
                 if cutlass.const_expr(use_packed_f32x2):
                     dq_out0, dq_out1 = cute.arch.add_packed_f32x2(
                         (dq_in0, dq_in1), (dq_add0, dq_add1)
@@ -1740,8 +1760,9 @@ def _chunk_kda_bwd_intra_hmma_grid_kernel(
                 dkt1 = d_acc1 * dscale1 + t_acc1 * tscale1
                 dk_beta0 = dk_qk0 * beta_row
                 dk_beta1 = dk_qk1 * beta_row
-                dk_add0 = dk_beta0 + dkt0
-                dk_add1 = dk_beta1 + dkt1
+                dk_diag_scale = Float32(2.0) * dak_diag * beta_row
+                dk_add0 = dk_beta0 + dkt0 + daq_diag * qval0 + dk_diag_scale * kval0
+                dk_add1 = dk_beta1 + dkt1 + daq_diag * qval1 + dk_diag_scale * kval1
                 if cutlass.const_expr(use_packed_f32x2):
                     dk_out0, dk_out1 = cute.arch.add_packed_f32x2(
                         (dk_in0, dk_in1), (dk_add0, dk_add1)
@@ -1752,15 +1773,17 @@ def _chunk_kda_bwd_intra_hmma_grid_kernel(
                     dk_word0 = _cvt_half2_f32(dk_out0, dk_out1, mDk2.element_type)
                 else:
                     dk_word1 = _cvt_half2_f32(dk_out0, dk_out1, mDk2.element_type)
-                dg_out0 = (dg_in0 + dq_add0 * qval0 + (dk_beta0 - dkt0) * kval0) * Float32(LN2)
-                dg_out1 = (dg_in1 + dq_add1 * qval1 + (dk_beta1 - dkt1) * kval1) * Float32(LN2)
+                dg_out0 = (dg_in0 + dq_strict0 * qval0 + (dk_beta0 - dkt0) * kval0) * Float32(LN2)
+                dg_out1 = (dg_in1 + dq_strict1 * qval1 + (dk_beta1 - dkt1) * kval1) * Float32(LN2)
                 if lane_row == 0:
                     dg_top0 = dg_out0
                     dg_top1 = dg_out1
                 else:
                     dg_bottom0 = dg_out0
                     dg_bottom1 = dg_out1
-                db_pair = dk_qk0 * kval0 + dk_qk1 * kval1
+                db_pair = (
+                    dk_qk0 * kval0 + dk_qk1 * kval1 + dak_diag * (kval0 * kval0 + kval1 * kval1)
+                )
                 if lane_row == 0:
                     db_acc0 = db_acc0 + db_pair
                 else:

--- a/test/test_kda_ragged_bwd_intra.py
+++ b/test/test_kda_ragged_bwd_intra.py
@@ -166,6 +166,39 @@ def test_ragged_bwd_intra_matches_independent_numerical_reference(dtype: torch.d
         )
 
 
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_bwd_intra_diagonal_is_gate_independent(dtype: torch.dtype) -> None:
+    """Diagonal pairwise terms affect Q/K/beta gradients, but never the gate."""
+    inputs = list(_inputs(64, dtype))
+    dAqk = torch.zeros_like(inputs[4])
+    dAkk = torch.zeros_like(inputs[5])
+    diagonal = torch.arange(64, device="cuda")
+    dAqk[0, diagonal, 0, diagonal] = torch.linspace(-2, 2, 64, device="cuda")
+    dAkk[0, diagonal, 0, diagonal] = torch.linspace(1, -1, 64, device="cuda")
+    inputs[4:6] = (dAqk, dAkk)
+    inputs[6:] = tuple(torch.zeros_like(tensor) for tensor in inputs[6:])
+
+    dq, dk, dg, db = _run(tuple(inputs), [64])
+    reference = bwd_intra_reference(*inputs[:6])
+    high_precision = bwd_intra_reference(*(tensor.double() for tensor in inputs[:6]))
+
+    assert torch.count_nonzero(dg) == 0
+    for name, actual, expected, low_precision in zip(
+        ("dq", "dk", "dbeta"),
+        (dq, dk, db),
+        high_precision[:3],
+        reference[:3],
+        strict=True,
+    ):
+        assert_matches_low_precision_reference(
+            actual,
+            expected,
+            low_precision,
+            name,
+            source_dtype=dtype,
+        )
+
+
 def test_ragged_bwd_intra_rejects_mismatched_chunk_size():
     metadata = prepare_ragged_chunk_metadata(cumulative_sequence_offsets([64]), 64, 32)
     with pytest.raises(ValueError, match="metadata chunk size"):


### PR DESCRIPTION
## Summary

- exclude `i == j` terms from the gate-factored portable KDA backward MMAs
- restore their gate-independent `dq`, `dk`, and `dbeta` contributions directly in FP32
- add an exact BF16/FP16 regression proving diagonal pairwise terms contribute zero to `dgate`

The diagonal decay is `2^(g_i - g_i) = 1`, so its gate derivative is exactly zero. Previously its row and column contributions traveled through separate TF32 MMA paths and were expected to cancel numerically. Their rounding residue dominated the true gradient for saturated gates.

At a constant gate of `-5`, relative RMS `dgate` error improved from 59.04 BF16 eps to 0.67 eps. A diagonal-only case improved from max `|dgate| = 2.86e-3` to exact zero.

## Performance

CUDA Graph replay of the public fused backward on GB200, averaged median timings:

| Shape | Baseline | Fixed | Delta |
|---|---:|---:|---:|
| T=128, H=2 | 47.16 us | 47.54 us | +0.82% |
| T=1024, H=16 | 118.73 us | 118.54 us | -0.15% |
| T=4096, H=16 | 383.65 us | 381.05 us | -0.68% |

The isolated intra-backward primitive measured +0.03%, +1.59%, and +3.75% respectively, but no material regression is visible at the public backward endpoint. Kernel resources changed from 168 to 162 registers with no stack or shared-memory increase.

## Test plan

- `pytest -q test/test_kda_ragged_bwd_intra.py`
- `pytest -q test/test_kda_kernels.py`
- `pytest -q test/kda/mega/test_delta_rule_numerics.py`
- `pytest -q test/test_kda_ragged_public_backward.py test/test_kda_ragged_autograd_ops.py`
- SM80 and SM120 portable cross-compilation through the ragged intra-backward suite
