### PR TITLE
Simplify Mega split-forward plumbing

### DIFF
--- a/attn_gym/linear/_delta_rule/mega/forward.py
+++ b/attn_gym/linear/_delta_rule/mega/forward.py
@@ -200,19 +200,6 @@ def chunk_delta_rule_fwd_mega(
     return output
 
 
-def chunk_delta_rule_fwd_mega_unsplit(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    value: torch.Tensor,
-    gate: torch.Tensor,
-    beta: torch.Tensor,
-    cu_seqlens: torch.Tensor,
-    scale: float | None = None,
-) -> torch.Tensor:
-    """Run an unsplit packed forward without recurrent state."""
-    return chunk_delta_rule_fwd_mega(q, k, value, gate, beta, cu_seqlens, scale)
-
-
 def chunk_delta_rule_fwd_mega_unsplit_with_initial_state(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -266,7 +253,6 @@ def chunk_delta_rule_fwd_mega_unsplit_with_state(
 
 __all__ = [
     "chunk_delta_rule_fwd_mega",
-    "chunk_delta_rule_fwd_mega_unsplit",
     "chunk_delta_rule_fwd_mega_unsplit_with_initial_state",
     "chunk_delta_rule_fwd_mega_unsplit_with_state",
 ]

--- a/attn_gym/linear/kda/validation.py
+++ b/attn_gym/linear/kda/validation.py
@@ -20,7 +20,6 @@ import torch
 from attn_gym.linear._delta_rule.validation import validate_delta_rule_inputs
 
 SUPPORTED_INPUT_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
-_KERNEL_OPTION_NAMES = frozenset({"backend", "split_backward", "split_forward"})
 
 
 class ResolvedKernelOptions(NamedTuple):
@@ -37,7 +36,7 @@ def resolve_kernel_options(
     """Validate chunk backend options and resolve their defaults."""
     if kernel_options is None:
         return ResolvedKernelOptions("fused", False, False)
-    unknown = kernel_options.keys() - _KERNEL_OPTION_NAMES
+    unknown = kernel_options.keys() - ResolvedKernelOptions._fields
     if unknown:
         names = ", ".join(sorted(unknown))
         raise ValueError(f"unsupported chunk_kda kernel options: {names}")

--- a/test/kda/mega/test_kda_mega_forward.py
+++ b/test/kda/mega/test_kda_mega_forward.py
@@ -10,7 +10,7 @@ pytest.importorskip(
 
 from attn_gym.linear._delta_rule.mega import forward as adapter
 from attn_gym.linear._delta_rule.mega.forward import (
-    chunk_delta_rule_fwd_mega_unsplit,
+    chunk_delta_rule_fwd_mega,
     chunk_delta_rule_fwd_mega_unsplit_with_state,
 )
 from attn_gym.linear._delta_rule.mega.kernels.common.split_k import (
@@ -88,13 +88,13 @@ def test_mega_forward_packed_tail_empty_and_deterministic(dtype: torch.dtype) ->
     high_precision, _ = _reference_forward(
         q, k, value, gate, beta, zero_state, cu_seqlens, torch.float64
     )
-    actual = chunk_delta_rule_fwd_mega_unsplit(q, k, value, gate, beta, cu_seqlens)
+    actual = chunk_delta_rule_fwd_mega(q, k, value, gate, beta, cu_seqlens)
     assert_matches_low_precision_reference(
         actual, high_precision, low_precision, "output", source_dtype=dtype
     )
     for _ in range(20):
         torch.testing.assert_close(
-            chunk_delta_rule_fwd_mega_unsplit(q, k, value, gate, beta, cu_seqlens),
+            chunk_delta_rule_fwd_mega(q, k, value, gate, beta, cu_seqlens),
             actual,
             rtol=0,
             atol=0,
@@ -204,7 +204,7 @@ def test_mega_forward_rejects_misaligned_tma() -> None:
     storage = torch.empty(q.numel() + 1, dtype=q.dtype, device="cuda")
     misaligned_q = storage[1:].view_as(q)
     with pytest.raises(TypeError, match="TMA-compatible inner mode"):
-        adapter.chunk_delta_rule_fwd_mega_unsplit(misaligned_q, k, value, gate, beta, cu_seqlens)
+        adapter.chunk_delta_rule_fwd_mega(misaligned_q, k, value, gate, beta, cu_seqlens)
 
 
 def test_mega_public_forward_preserves_large_finite_state() -> None:


### PR DESCRIPTION
Follow-up cleanup for #456. Removes the redundant private unsplit-forward alias and derives accepted kernel-option names directly from `ResolvedKernelOptions._fields`.

Validation: `pytest -n 6` (1289 passed, 37 skipped).
