### PR TITLE
Evaluate the KDA L2-norm backward from the exact input

### DIFF
--- a/.agents/skills/worktree-env-setup/SKILL.md
+++ b/.agents/skills/worktree-env-setup/SKILL.md
@@ -25,7 +25,13 @@ Notes:
 - uv hard-links wheels from its cache, so after the first nightly download this
   takes seconds and costs almost no extra disk per worktree.
 - Activate `.venv` before installing so an already-active foreign environment is not modified.
-- `--prerelease allow` is required for the `flash-attn-4` beta in `[tests]`.
+- `--prerelease allow` is required for the `flash-attn-4` beta in `[tests]`, but it also lets
+  the open `[linear]` bound resolve to `nvidia-cutlass-dsl` dev releases (4.8.0.dev0 breaks
+  `tcgen05_mma_ws(..., mma_kind=)` in the fused CuTeDSL backward). Pin it afterwards:
+  `uv pip install "nvidia-cutlass-dsl[cu13]==4.7.1"`.
+- A `.venv` symlink into another worktree is not isolation: its editable `.pth` still
+  points at that worktree, so pytest imports the other checkout's `attn_gym`. Replace it
+  with a real per-worktree env.
 - Do not use `uv sync`/`uv.lock`: nightly torch churns daily and CI uses the
   imperative `uv pip` flow above, not a lockfile.
 - Drop `[linear]` if CuTeDSL/TVM-FFI kernels are not needed (CPU-only work).

--- a/attn_gym/linear/kda/bwd/triton/l2norm_bwd.py
+++ b/attn_gym/linear/kda/bwd/triton/l2norm_bwd.py
@@ -12,10 +12,11 @@
 #
 # Differentiating y w.r.t. x gives the Jacobian
 #     dy_i/dx_j = rstd * delta_ij - rstd^3 * x_i * x_j ,
-# and contracting with the upstream gradient dy, then substituting x = y / rstd,
-# collapses to the row-local rule
+# and contracting with the upstream gradient dy gives the row-local rule
 #     dx = rstd * (dy - y * <dy, y>),      <dy, y> = sum_d dy_d * y_d.
-# Only y and rstd (both produced by the forward) are needed -- x is not.
+# y = x * rstd is recomputed in fp32 from the exact input rather than read back from the
+# rounded forward output: for a radial dy the bracket cancels down to y * eps * rstd^2,
+# which a bf16/fp16 y cannot resolve.
 
 from __future__ import annotations
 
@@ -35,13 +36,13 @@ _BT_LIST = [8, 16, 32, 64, 128]
 )
 @triton.jit(do_not_specialize=["N_ROWS"])
 def l2norm_bwd_kernel(
-    y,
+    x,
     rstd,
     dy,
     dx,
     N_ROWS,
     cu_seqlens,
-    Y_STRIDES: tl.constexpr,
+    X_STRIDES: tl.constexpr,
     RSTD_STRIDES: tl.constexpr,
     DY_STRIDES: tl.constexpr,
     DX_STRIDES: tl.constexpr,
@@ -67,29 +68,19 @@ def l2norm_bwd_kernel(
     m_row = o_row < N_ROWS
     mask = m_row[:, None] & (o_d[None, :] < D)
 
-    b_y = tl.load(
-        y + ptr_offset((o_row[:, None], o_d[None, :]), Y_STRIDES),
-        mask=mask,
-        other=0.0,
-    ).to(tl.float32)
-    b_dy = tl.load(
-        dy
-        + ptr_offset(
-            (
-                (o_bt // TOKENS)[:, None],
-                (o_bt % TOKENS)[:, None],
-                (o_row % HEADS)[:, None],
-                o_d[None, :],
-            ),
-            DY_STRIDES,
-        ),
-        mask=mask,
-        other=0.0,
-    ).to(tl.float32)
+    o_bthd = (
+        (o_bt // TOKENS)[:, None],
+        (o_bt % TOKENS)[:, None],
+        (o_row % HEADS)[:, None],
+        o_d[None, :],
+    )
+    b_x = tl.load(x + ptr_offset(o_bthd, X_STRIDES), mask=mask, other=0.0).to(tl.float32)
+    b_dy = tl.load(dy + ptr_offset(o_bthd, DY_STRIDES), mask=mask, other=0.0).to(tl.float32)
     b_rstd = tl.load(rstd + ptr_offset((o_row,), RSTD_STRIDES), mask=m_row, other=0.0).to(
         tl.float32
     )
 
+    b_y = b_x * b_rstd[:, None]
     b_dot = tl.sum(b_dy * b_y, 1)
     b_dx = b_rstd[:, None] * (b_dy - b_y * b_dot[:, None])
     tl.store(

--- a/attn_gym/linear/kda/fwd/triton/l2norm_fwd.py
+++ b/attn_gym/linear/kda/fwd/triton/l2norm_fwd.py
@@ -165,12 +165,12 @@ def _l2norm_fwd_fake(
 
 torch.library.define(
     "attn_gym::kda_l2norm_bwd",
-    "(Tensor output, Tensor rstd, Tensor d_output, Tensor? cu_seqlens=None) -> Tensor",
+    "(Tensor x, Tensor rstd, Tensor d_output, Tensor? cu_seqlens=None) -> Tensor",
 )
 
 
 def _l2norm_bwd_cuda(
-    output: torch.Tensor,
+    x: torch.Tensor,
     rstd: torch.Tensor,
     d_output: torch.Tensor,
     cu_seqlens: torch.Tensor | None = None,
@@ -178,19 +178,19 @@ def _l2norm_bwd_cuda(
     """Launch L2Norm backward behind the same opaque stride boundary."""
     from attn_gym.linear.kda.bwd.triton.l2norm_bwd import l2norm_bwd_kernel
 
-    rows, head_dim = output.shape
-    _, tokens, heads, _ = d_output.shape
-    d_input = torch.empty_like(output)
+    _, tokens, heads, head_dim = x.shape
+    rows = x.numel() // head_dim
+    d_input = torch.empty(rows, head_dim, dtype=x.dtype, device=x.device)
     block_dim = triton.next_power_of_2(head_dim)
     grid = lambda meta: (triton.cdiv(rows, meta["BT"]),)
     l2norm_bwd_kernel[grid](
-        output,
+        x,
         rstd,
         d_output,
         d_input,
         rows,
         cu_seqlens,
-        Y_STRIDES=output.stride(),
+        X_STRIDES=x.stride(),
         RSTD_STRIDES=rstd.stride(),
         DY_STRIDES=d_output.stride(),
         DX_STRIDES=d_input.stride(),
@@ -202,7 +202,7 @@ def _l2norm_bwd_cuda(
         NUM_SEQUENCES=0 if cu_seqlens is None else cu_seqlens.shape[0] - 1,
         IS_VARLEN=cu_seqlens is not None,
     )
-    return d_input
+    return d_input.view_as(x)
 
 
 torch.library.impl("attn_gym::kda_l2norm_bwd", "CUDA", _l2norm_bwd_cuda)
@@ -210,14 +210,14 @@ torch.library.impl("attn_gym::kda_l2norm_bwd", "CUDA", _l2norm_bwd_cuda)
 
 @torch.library.register_fake("attn_gym::kda_l2norm_bwd")
 def _l2norm_bwd_fake(
-    output: torch.Tensor,
+    x: torch.Tensor,
     rstd: torch.Tensor,
     d_output: torch.Tensor,
     cu_seqlens: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Describe input-gradient metadata without reading the packed endpoint."""
     del rstd, d_output, cu_seqlens
-    return torch.empty_like(output)
+    return torch.empty_like(x, memory_format=torch.contiguous_format)
 
 
 _l2norm_fwd_op = torch.ops.attn_gym.kda_l2norm_fwd.default
@@ -233,22 +233,20 @@ class _L2Norm(torch.autograd.Function):
         cu_seqlens: torch.Tensor | None,
     ) -> torch.Tensor:
         output, rstd = _l2norm_fwd_op(x, eps, cu_seqlens)
-        output_2d = output.view(-1, x.shape[-1])
+        # Save the exact x, not the rounded output; see the numerics note in l2norm_bwd.py.
         if cu_seqlens is None:
-            ctx.save_for_backward(output_2d, rstd)
+            ctx.save_for_backward(x, rstd)
         else:
-            ctx.save_for_backward(output_2d, rstd, cu_seqlens)
-        ctx.input_shape = x.shape
+            ctx.save_for_backward(x, rstd, cu_seqlens)
         ctx.is_ragged = cu_seqlens is not None
         return output
 
     @staticmethod
     @torch.autograd.function.once_differentiable
     def backward(ctx, d_output: torch.Tensor):
-        output, rstd, *metadata = ctx.saved_tensors
+        x, rstd, *metadata = ctx.saved_tensors
         cu_seqlens = metadata[0] if ctx.is_ragged else None
-        d_input = _l2norm_bwd_op(output, rstd, d_output, cu_seqlens)
-        return d_input.view(ctx.input_shape), None, None
+        return _l2norm_bwd_op(x, rstd, d_output, cu_seqlens), None, None
 
 
 def l2norm(

--- a/attn_gym/linear/kda/naive.py
+++ b/attn_gym/linear/kda/naive.py
@@ -294,21 +294,22 @@ def l2norm_fwd_ref(x: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
     return (xc * rstd).to(x.dtype)
 
 
-def l2norm_bwd_ref(y: torch.Tensor, rstd: torch.Tensor, dy: torch.Tensor) -> torch.Tensor:
-    """Gradient of the L2 norm: ``dx = rstd * (dy - y * <dy, y>)``.
+def l2norm_bwd_ref(x: torch.Tensor, rstd: torch.Tensor, dy: torch.Tensor) -> torch.Tensor:
+    """Gradient of the L2 norm: ``dx = rstd * (dy - y * <dy, y>)`` with ``y = x * rstd``.
 
-    Naive counterpart of ``l2norm_bwd_kernel``. Runs in fp32 (or fp64 when ``y`` is fp64)
-    to match the kernel's accumulation, then downcasts to ``y.dtype``.
+    Naive counterpart of ``l2norm_bwd_kernel``. Recomputes ``y`` from the exact input in
+    fp32 (or fp64 when ``x`` is fp64) to match the kernel, then downcasts to ``x.dtype``.
 
     Args:
-        y: normalized forward output; shape ``(..., D)``.
+        x: forward input; shape ``(..., D)``.
         rstd: reciprocal std saved by the forward pass, broadcastable over the last dim.
         dy: upstream gradient w.r.t. ``y``; shape ``(..., D)``.
     """
-    dtype = torch.promote_types(y.dtype, torch.float32)
-    yc, dyc, rc = y.to(dtype), dy.to(dtype), rstd.to(dtype)
+    dtype = torch.promote_types(x.dtype, torch.float32)
+    xc, dyc, rc = x.to(dtype), dy.to(dtype), rstd.to(dtype)
+    yc = xc * rc
     dot = (dyc * yc).sum(-1, keepdim=True)
-    return (rc * (dyc - yc * dot)).to(y.dtype)
+    return (rc * (dyc - yc * dot)).to(x.dtype)
 
 
 def chunk_cumsum_ref(

--- a/test/test_kda_kernels.py
+++ b/test/test_kda_kernels.py
@@ -282,28 +282,68 @@ def test_l2norm_autograd_wrapper(dtype):
     )
 
 
+@pytest.mark.parametrize("dtype", DTYPES[1:], ids=_case_id)
+@pytest.mark.parametrize("row_norm", [1e-2, 3e-2])
+@pytest.mark.parametrize("direction", ["radial", "random"])
+def test_l2norm_autograd_gradient_direction(dtype, row_norm, direction):
+    """Resolve the radial gradient ``y * eps * rstd^2``, which a rounded ``y`` tape cannot.
+
+    Row norms stay within ~30x of ``sqrt(eps)`` so the fp32 cancellation itself remains
+    well below half-precision rounding (see the header of bwd/triton/l2norm_bwd.py).
+    """
+    torch.manual_seed(2)
+    eps = 1e-6
+    x = torch.randn(1, 64, 2, 128, device=DEV, dtype=torch.float64)
+    x = (x / x.norm(dim=-1, keepdim=True) * row_norm).to(dtype).requires_grad_()
+    x32 = x.detach().float().requires_grad_()
+    expected = l2norm_fwd_ref(x32, eps)
+    d_output = expected.detach() if direction == "radial" else torch.randn_like(expected)
+    d_output = d_output.to(dtype)
+    expected_gradient = torch.autograd.grad(expected, x32, d_output.float())[0]
+
+    actual_gradient = torch.autograd.grad(l2norm(x, eps), x, d_output)[0]
+
+    # One output rounding, plus the same rounding at the shared row scale for near-zero
+    # elements.
+    rounding = torch.finfo(dtype).eps
+    torch.testing.assert_close(
+        actual_gradient.float(),
+        expected_gradient,
+        rtol=2 * rounding,
+        atol=rounding * expected_gradient.abs().max().item(),
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES, ids=_case_id)
+def test_l2norm_autograd_below_floor_rows(dtype):
+    """Check zero and sub-floor rows, where the projection term vanishes."""
+    torch.manual_seed(3)
+    eps = 1e-6
+    x = torch.zeros(1, 2, 1, 128, device=DEV, dtype=dtype)
+    x[0, 1] = 1e-5 / 128**0.5
+    x.requires_grad_()
+    x64 = x.detach().double().requires_grad_()
+    d_output = torch.randn_like(x)
+
+    actual_gradient = torch.autograd.grad(l2norm(x, eps), x, d_output)[0]
+
+    expected_gradient = torch.autograd.grad(l2norm_fwd_ref(x64, eps), x64, d_output.double())[0]
+    torch.testing.assert_close(
+        actual_gradient.double(), expected_gradient, rtol=2 * torch.finfo(dtype).eps, atol=0
+    )
+
+
 def test_l2norm_op_registration():
     x = torch.randn(1, 17, 3, 128, device=DEV, dtype=torch.bfloat16)
     cu_seqlens = torch.tensor([0, 9, 17, 17], device=DEV, dtype=torch.int32)
     torch.library.opcheck(_l2norm_fwd_op, (x, 1e-6))
     torch.library.opcheck(_l2norm_fwd_op, (x, 1e-6, cu_seqlens))
 
-    output, rstd = _l2norm_fwd_op(x, 1e-6)
-    d_output = torch.randn_like(output)
-    torch.library.opcheck(
-        _l2norm_bwd_op,
-        (output.view(-1, output.shape[-1]), rstd, d_output),
-    )
-    ragged_output, ragged_rstd = _l2norm_fwd_op(x, 1e-6, cu_seqlens)
-    torch.library.opcheck(
-        _l2norm_bwd_op,
-        (
-            ragged_output.view(-1, ragged_output.shape[-1]),
-            ragged_rstd,
-            d_output,
-            cu_seqlens,
-        ),
-    )
+    _, rstd = _l2norm_fwd_op(x, 1e-6)
+    d_output = torch.randn_like(x)
+    torch.library.opcheck(_l2norm_bwd_op, (x, rstd, d_output))
+    _, ragged_rstd = _l2norm_fwd_op(x, 1e-6, cu_seqlens)
+    torch.library.opcheck(_l2norm_bwd_op, (x, ragged_rstd, d_output, cu_seqlens))
 
 
 def test_l2norm_blackwell_kda_decode_matches_reference_and_replays():
@@ -484,7 +524,7 @@ def test_l2norm_rejects_empty_outer_dimension():
         l2norm(torch.empty(1, 0, 2, 128, device=DEV))
 
 
-# l2norm backward   dx = rstd * (dy - y * <dy, y>)
+# l2norm backward   dx = rstd * (dy - y * <dy, y>),  y = x * rstd
 @pytest.mark.parametrize("dtype,T,D,strided", _L2NORM_CASES, ids=_case_id)
 def test_l2norm_bwd(dtype, T, D, strided):
     torch.manual_seed(1)
@@ -492,35 +532,32 @@ def test_l2norm_bwd(dtype, T, D, strided):
     x64 = torch.randn(T, D, device=DEV, dtype=torch.float64)
     dy64 = torch.randn(T, D, device=DEV, dtype=torch.float64)
     rstd64 = 1.0 / torch.sqrt((x64 * x64).sum(-1, keepdim=True) + eps)
-    y64 = x64 * rstd64
 
-    golden = l2norm_bwd_ref(y64, rstd64, dy64)
+    golden = l2norm_bwd_ref(x64, rstd64, dy64)
 
-    # kernel inputs are the low-precision y/rstd/dy
-    y = y64.to(dtype)
+    x = x64.to(dtype)
     dy = dy64.to(dtype)
     rstd = rstd64.squeeze(-1).to(torch.float32)
     if strided:
-        y, dy, rstd = map(_strided_copy, (y, dy, rstd))
+        x, dy, rstd = map(_strided_copy, (x, dy, rstd))
 
-    ref = l2norm_bwd_ref(y, rstd.unsqueeze(-1), dy)
+    ref = l2norm_bwd_ref(x, rstd.unsqueeze(-1), dy)
 
     BD = triton.next_power_of_2(D)
 
-    dx = _empty_strided_like(y) if strided else torch.empty_like(y)
+    dx = _empty_strided_like(x) if strided else torch.empty_like(x)
     grid = lambda meta: (triton.cdiv(T, meta["BT"]),)
     # Present physical [T, D] storage to the kernel as logical [1, T, 1, D].
-    dy_strides = (0, dy.stride(0), 0, dy.stride(1))
     l2norm_bwd_kernel[grid](
-        y,
+        x,
         rstd,
         dy,
         dx,
         T,
         None,
-        Y_STRIDES=y.stride(),
+        X_STRIDES=(0, x.stride(0), 0, x.stride(1)),
         RSTD_STRIDES=rstd.stride(),
-        DY_STRIDES=dy_strides,
+        DY_STRIDES=(0, dy.stride(0), 0, dy.stride(1)),
         DX_STRIDES=dx.stride(),
         TOKENS=T,
         HEADS=1,


### PR DESCRIPTION
## Human Note

## Agent note

The KDA L2-norm backward computes `dx = rstd * (dy - y * <dy, y>)`, which is the correct derivative, but
it was fed the rounded bf16/fp16 forward output `y`. For a radial upstream gradient (`dy ∝ y`) the bracket
cancels down to `y * eps * rstd^2`, a residual far below the relative error of a half-precision `y`. Against
fp64 autograd in bf16 the radial component was off by 17% at row norm 1e-2 and >100% at row norm 1e-1;
for generic `dy` the error hides under output rounding, which is why the existing random-gradient test
never caught it.

The fix saves the exact input `x` plus the fp32 `rstd` instead of the output, and the Triton backward
recomputes `y = x * rstd` in fp32. `attn_gym::kda_l2norm_bwd` now takes `(x, rstd, d_output, cu_seqlens?)`
and returns a contiguous tensor shaped like `x`; `l2norm_bwd_ref` mirrors the new tape. Ragged endpoints
and strided inputs are unchanged. The in-kernel Mega L2NORM specialization is not reachable through the
public adapters (`use_qk_l2norm_in_kernel` is never passed) and is left alone.

The second commit is unrelated housekeeping for `worktree-env-setup`: `--prerelease allow` currently lets
the open `[linear]` bound pull `nvidia-cutlass-dsl` 4.8.0.dev0, which breaks the fused CuTeDSL backward
(`tcgen05_mma_ws(mma_kind=)`), and a `.venv` symlink into another worktree silently imports that worktree's
`attn_gym`. Capping `[linear]` at `<4.8.0` in `pyproject.toml` like `[mega]` would be the durable fix.

## Performance

No change. Peak memory is identical in the fused training example because `q`/`k` are views of the
`silu(conv)` tensor that `v` already keeps alive, and the backward reads the same number of bytes. In flows
where `x` is not otherwise alive this costs one extra half-precision `[B, T, H, D]` tensor per call.

| fused KDA example, B=1 T=16384 C=2304 H=32 D=128 bf16, GB200 | old (y tape) | new (x tape) |
|---|---|---|
| peak allocated, eager | 4.394 GiB | 4.394 GiB |
| peak allocated, `torch.compile` | 4.394 GiB | 4.394 GiB |
| `l2norm` fwd | 45.7 µs | 45.1 µs |
| `l2norm` bwd | 104.1 µs | 103.7 µs |

## Test Plan

New `test_l2norm_autograd_gradient_direction[radial-*]` cases fail on the previous tape (4 failed / 7 passed
with the fix stashed) and pass with it.

```bash
pytest -n 6 test/test_kda_kernels.py test/test_kda_training_example.py test/test_kda_compile_dynamic_shapes.py test/test_kda_ragged_autograd_ops.py test/test_kda_triton_backward_storage.py
ruff check && ruff format --check
```
