### PR TITLE
Pin the FP32 state contract of the fused delta-rule paths

### DIFF
--- a/attn_gym/linear/gdn/bwd/triton/chunk_gdn_bwd_wy.py
+++ b/attn_gym/linear/gdn/bwd/triton/chunk_gdn_bwd_wy.py
@@ -152,7 +152,9 @@ def chunk_gdn_bwd_dqkwg_kernel(
             other=0.0,
         )
 
-        b_dg_last += tl.sum(b_h.to(b_dh.dtype) * b_dh)
+        # Contract the state tapes in FP32: a low-precision product and reduction would round
+        # the per-chunk state term of the gate gradient to source-dtype precision.
+        b_dg_last += tl.sum(b_h.to(tl.float32) * b_dh.to(tl.float32))
         b_ds += tl.dot(b_do, tl.trans(b_v_new))
         b_dq += tl.dot(b_do, b_h)
         b_dk += tl.dot(b_v_new.to(b_dh.dtype), b_dh)

--- a/attn_gym/linear/gdn/bwd/triton/chunk_gdn_bwd_wy.py
+++ b/attn_gym/linear/gdn/bwd/triton/chunk_gdn_bwd_wy.py
@@ -152,8 +152,7 @@ def chunk_gdn_bwd_dqkwg_kernel(
             other=0.0,
         )
 
-        # Contract the state tapes in FP32: a low-precision product and reduction would round
-        # the per-chunk state term of the gate gradient to source-dtype precision.
+        # Accumulate the state term of dGate in FP32 rather than the source dtype.
         b_dg_last += tl.sum(b_h.to(tl.float32) * b_dh.to(tl.float32))
         b_ds += tl.dot(b_do, tl.trans(b_v_new))
         b_dq += tl.dot(b_do, b_h)

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -60,6 +60,21 @@ output, final_state = chunk_gdn(
   dtype. A provided initial state uses FP32 for low-precision QKV.
 - FP64 reference inputs retain FP64 recurrence math and state.
 
+!!! note "What the fused paths keep in FP32"
+
+    Every optimized GDN and KDA path (repo-local fused and Mega) carries the recurrent state
+    from `initial_state` to `final_state`, and the state cotangent from `d_final_state` to
+    `d_initial_state`, in FP32 accumulators with FP32 decay. The chunk-entry state that each
+    chunk reads, the per-chunk state checkpoints, and the per-chunk state-cotangent tape are
+    staged in the Q/K/V dtype because they are tensor-core operands. BF16 shares the FP32
+    exponent range, so this only costs mantissa precision. FP16 also limits the range: state
+    values above 65504 become non-finite when a chunk reads them, and cotangent values below
+    `2^-24` vanish (and lose precision below `2^-14`) before they reach `dgate`, `dk`, and `dv`.
+    Keep FP16 states and state cotangents within the FP16 normal range, for example through loss
+    scaling, or use BF16 when state magnitudes can leave it. The Mega KDA backend additionally
+    applies the per-chunk decay to the carried state through a low-precision diagonal MMA, so
+    its `final_state` carries Q/K/V-dtype rounding instead of the FP32 carry.
+
 The repo-local fused chunk backend requires CUDA capability 8.0+, matching FP16 or BF16 Q/K/V,
 and
 `K = V = 128`, but has no Mega runtime dependency. Its scalar natural-log gate is not lower-bounded:
@@ -171,11 +186,14 @@ parameterized gate producers: callers still need the masking rules below because
 
     Use L2-normalized Q/K with FP16, as the training example does. Unnormalized Q/K can easily
     produce attention or solve factors outside the FP16 range. Unusually large V or initial-state
-    carries can likewise overflow the FP16 chunk-state and value intermediates. The GEMMs
-    accumulate in FP32, but their results are converted back to FP16 when used as inputs to the
-    next GEMM; an overflow at that conversion cannot be recovered by the next FP32 accumulator.
-    BF16 uses the same storage size with a much larger exponent range, so it is substantially less
-    likely to hit these issues, although sufficiently large values can overflow any finite dtype.
+    carries can likewise overflow the FP16 chunk-state and value intermediates, and small
+    final-state cotangents underflow the FP16 state-cotangent tape in the backward pass. The
+    GEMMs accumulate in FP32, but their results are converted back to FP16 when used as inputs to
+    the next GEMM; an overflow or underflow at that conversion cannot be recovered by the next
+    FP32 accumulator. BF16 uses the same storage size with a much larger exponent range, so it is
+    substantially less likely to hit these issues, although sufficiently large values can overflow
+    any finite dtype. See the FP32-state note in the Gated Delta Rule section for the exact
+    boundary between the FP32 carry and the low-precision staging.
 
 A captured graph with sequence capacity `N` keeps `cu_seqlens.shape == (N + 1,)`. If a
 replay has `M <= N` nonempty sequences and `L <= T` active tokens, repeat the terminal

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -68,12 +68,15 @@ output, final_state = chunk_gdn(
     chunk reads, the per-chunk state checkpoints, and the per-chunk state-cotangent tape are
     staged in the Q/K/V dtype because they are tensor-core operands. BF16 shares the FP32
     exponent range, so this only costs mantissa precision. FP16 also limits the range: state
-    values above 65504 become non-finite when a chunk reads them, and cotangent values below
-    `2^-24` vanish (and lose precision below `2^-14`) before they reach `dgate`, `dk`, and `dv`.
-    Keep FP16 states and state cotangents within the FP16 normal range, for example through loss
-    scaling, or use BF16 when state magnitudes can leave it. The Mega KDA backend additionally
-    applies the per-chunk decay to the carried state through a low-precision diagonal MMA, so
-    its `final_state` carries Q/K/V-dtype rounding instead of the FP32 carry.
+    values that round beyond the FP16 finite range (about 65504) become non-finite when a chunk
+    reads them, and cotangent values in the FP16 subnormal range (below `2^-14`) lose precision
+    or round to zero before they reach `dgate`, `dk`, and `dv`. Keep FP16 states and state
+    cotangents within the FP16 normal range, for example through loss scaling, or use BF16 when
+    state magnitudes can leave it. Use L2-normalized Q/K with FP16, as the training example does:
+    unnormalized Q/K or unusually large V can likewise push attention, solve, and value
+    intermediates outside the FP16 range between FP32-accumulating GEMMs. The Mega KDA backend
+    additionally applies the per-chunk decay to the carried state, and to the state cotangent of
+    its no-state local backward, through a diagonal MMA in the Q/K/V dtype rather than in FP32.
 
 The repo-local fused chunk backend requires CUDA capability 8.0+, matching FP16 or BF16 Q/K/V,
 and
@@ -184,16 +187,10 @@ parameterized gate producers: callers still need the masking rules below because
 
 !!! warning "FP16 intermediate range"
 
-    Use L2-normalized Q/K with FP16, as the training example does. Unnormalized Q/K can easily
-    produce attention or solve factors outside the FP16 range. Unusually large V or initial-state
-    carries can likewise overflow the FP16 chunk-state and value intermediates, and small
-    final-state cotangents underflow the FP16 state-cotangent tape in the backward pass. The
-    GEMMs accumulate in FP32, but their results are converted back to FP16 when used as inputs to
-    the next GEMM; an overflow or underflow at that conversion cannot be recovered by the next
-    FP32 accumulator. BF16 uses the same storage size with a much larger exponent range, so it is
-    substantially less likely to hit these issues, although sufficiently large values can overflow
-    any finite dtype. See the FP32-state note in the Gated Delta Rule section for the exact
-    boundary between the FP32 carry and the low-precision staging.
+    Use L2-normalized Q/K with FP16, as the training example does, and keep states and state
+    cotangents within the FP16 normal range. See "What the fused paths keep in FP32" in the
+    Gated Delta Rule section for the boundary between the FP32 carry and the Q/K/V-dtype staging
+    that this shares with GDN.
 
 A captured graph with sequence capacity `N` keeps `cu_seqlens.shape == (N + 1,)`. If a
 replay has `M <= N` nonempty sequences and `L <= T` active tokens, repeat the terminal

--- a/test/linear/test_delta_rule_state_precision.py
+++ b/test/linear/test_delta_rule_state_precision.py
@@ -15,7 +15,11 @@ import pytest
 import torch
 
 from attn_gym.linear import chunk_gdn, chunk_kda, recurrent_gdn
-from attn_gym.testing.kda import assert_relative_rms_within, kda_reference
+from attn_gym.testing.kda import (
+    assert_matches_low_precision_reference,
+    assert_relative_rms_within,
+    kda_reference,
+)
 
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available() or torch.cuda.get_device_capability() < (8, 0),
@@ -35,18 +39,24 @@ _MEGA_SKIP = pytest.mark.skipif(
     not _mega_available(),
     reason="the Mega backend requires nvidia-cutlass-dsl>=4.7 on SM100/SM103",
 )
+# Documented limitations: only the contract assertions may fail, and they must keep failing.
 _FP16_STATE_RANGE = pytest.mark.xfail(
     strict=True,
+    raises=AssertionError,
     reason="FP16 execution stages chunk-entry states as FP16 MMA operands; 65536 overflows",
 )
 _FP16_COTANGENT_RANGE = pytest.mark.xfail(
     strict=True,
+    raises=AssertionError,
     reason="FP16 execution stages state cotangents as FP16 tapes; 2^-25 flushes to zero",
 )
 _MEGA_KDA_CARRY = pytest.mark.xfail(
     strict=True,
-    reason="Mega KDA decays the carried state through a b16 diagonal MMA instead of FP32",
+    raises=AssertionError,
+    reason="Mega KDA decays the carried state through a Q/K/V-dtype diagonal MMA, not in FP32",
 )
+# The FP32 carry may differ from the eager reference only by log2-domain gate conversions.
+_FP32_CARRY_RTOL = 1e-5
 
 _FAMILIES = ("gdn", "kda")
 _DTYPES = (pytest.param(torch.bfloat16, id="bf16"), pytest.param(torch.float16, id="fp16"))
@@ -91,6 +101,18 @@ def _run(
     return output, state
 
 
+def _assert_fp32_carry(actual: torch.Tensor, expected: torch.Tensor, name: str) -> None:
+    """Check an FP32-carried result pointwise and in aggregate against the FP32 reference."""
+    torch.testing.assert_close(actual, expected, rtol=_FP32_CARRY_RTOL, atol=0.0)
+    assert_relative_rms_within(
+        actual,
+        expected,
+        name,
+        max_eps=_FP32_CARRY_RTOL / torch.finfo(torch.float32).eps,
+        source_dtype=torch.float32,
+    )
+
+
 @pytest.mark.parametrize("dtype", _DTYPES)
 @pytest.mark.parametrize("kernel_options", _BACKENDS)
 @pytest.mark.parametrize("family", _FAMILIES)
@@ -111,7 +133,7 @@ def test_large_state_decays_in_fp32(
 
     assert torch.equal(output, torch.zeros_like(output))
     assert expected[0, 0, 0, 0].item() == pytest.approx(65536.0 * math.exp(-4.0))
-    torch.testing.assert_close(state, expected, rtol=1e-5, atol=0.0)
+    _assert_fp32_carry(state, expected, "final_state")
 
 
 @pytest.mark.parametrize("dtype", _DTYPES)
@@ -137,5 +159,9 @@ def test_tiny_final_state_cotangent_reaches_gate_gradient(
     expected_d_gate, expected_d_initial_state = gradients("ref")
 
     assert (expected_d_gate != 0).all()
+    # The gate term reads the Q/K/V-dtype state checkpoint, so it carries source-dtype rounding.
+    assert_matches_low_precision_reference(
+        d_gate, expected_d_gate, expected_d_gate, "dgate", source_dtype=dtype
+    )
     assert_relative_rms_within(d_gate, expected_d_gate, "dgate", max_eps=1.25, source_dtype=dtype)
-    torch.testing.assert_close(d_initial_state, expected_d_initial_state, rtol=1e-5, atol=0.0)
+    _assert_fp32_carry(d_initial_state, expected_d_initial_state, "d_initial_state")

--- a/test/linear/test_delta_rule_state_precision.py
+++ b/test/linear/test_delta_rule_state_precision.py
@@ -1,0 +1,141 @@
+"""Dynamic-range contracts for the FP32 recurrent state of the optimized delta-rule paths.
+
+The fused GDN and KDA implementations carry the recurrent state and its cotangent in FP32
+between chunks, but stage the chunk-entry state and the per-chunk state cotangent as
+low-precision MMA operands and tapes. These tests pin what survives that policy: BF16 shares
+the FP32 exponent range and must transport adversarially large states and tiny final-state
+cotangents; FP16 cannot, which the documented ``xfail`` entries record.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+from attn_gym.linear import chunk_gdn, chunk_kda, recurrent_gdn
+from attn_gym.testing.kda import assert_relative_rms_within, kda_reference
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (8, 0),
+    reason="the fused delta-rule paths require CUDA capability 8.0 or newer",
+)
+
+
+def _mega_available() -> bool:
+    try:
+        import cutlass.experimental  # noqa: F401
+    except ImportError:
+        return False
+    return torch.cuda.is_available() and torch.cuda.get_device_capability() in ((10, 0), (10, 3))
+
+
+_MEGA_SKIP = pytest.mark.skipif(
+    not _mega_available(),
+    reason="the Mega backend requires nvidia-cutlass-dsl>=4.7 on SM100/SM103",
+)
+_FP16_STATE_RANGE = pytest.mark.xfail(
+    strict=True,
+    reason="FP16 execution stages chunk-entry states as FP16 MMA operands; 65536 overflows",
+)
+_FP16_COTANGENT_RANGE = pytest.mark.xfail(
+    strict=True,
+    reason="FP16 execution stages state cotangents as FP16 tapes; 2^-25 flushes to zero",
+)
+_MEGA_KDA_CARRY = pytest.mark.xfail(
+    strict=True,
+    reason="Mega KDA decays the carried state through a b16 diagonal MMA instead of FP32",
+)
+
+_FAMILIES = ("gdn", "kda")
+_DTYPES = (pytest.param(torch.bfloat16, id="bf16"), pytest.param(torch.float16, id="fp16"))
+_BACKENDS = (
+    pytest.param(None, id="fused"),
+    pytest.param({"backend": "mega"}, id="mega", marks=_MEGA_SKIP),
+)
+
+
+def _zero_inputs(
+    family: str, dtype: torch.dtype, tokens: int, gate_value: float
+) -> tuple[torch.Tensor, ...]:
+    """Zero Q/K/V with a constant natural-log gate, isolating the state-carry dataflow."""
+    shape = (1, tokens, 1, 128)
+    q, k, v = (torch.zeros(shape, device="cuda", dtype=dtype) for _ in range(3))
+    gate_shape = shape if family == "kda" else shape[:-1]
+    gate = torch.full(gate_shape, gate_value, device="cuda")
+    beta = torch.full(shape[:-1], 0.5, device="cuda")
+    return q, k, v, gate, beta
+
+
+def _run(
+    family: str,
+    kernel_options: dict[str, str] | None,
+    inputs: tuple[torch.Tensor, ...],
+    initial_state: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run the optimized path or the eager FP32 reference when ``kernel_options`` is ``"ref"``."""
+    if kernel_options == "ref":
+        if family == "gdn":
+            return recurrent_gdn(*inputs, initial_state, impl="reference", output_final_state=True)
+        return kda_reference(*inputs, initial_state, output_final_state=True)
+    fn = chunk_gdn if family == "gdn" else chunk_kda
+    output, state = fn(
+        *inputs,
+        initial_state,
+        impl="fused",
+        output_final_state=True,
+        kernel_options=kernel_options,
+    )
+    assert state is not None
+    return output, state
+
+
+@pytest.mark.parametrize("dtype", _DTYPES)
+@pytest.mark.parametrize("kernel_options", _BACKENDS)
+@pytest.mark.parametrize("family", _FAMILIES)
+def test_large_state_decays_in_fp32(
+    family: str, kernel_options: dict[str, str] | None, dtype: torch.dtype, request
+) -> None:
+    """An FP32 state element above the FP16 range must decay to its FP32 value without NaNs."""
+    if dtype is torch.float16:
+        request.applymarker(_FP16_STATE_RANGE)
+    elif family == "kda" and kernel_options is not None:
+        request.applymarker(_MEGA_KDA_CARRY)
+    inputs = _zero_inputs(family, dtype, tokens=1, gate_value=-4.0)
+    initial_state = torch.zeros(1, 1, 128, 128, device="cuda")
+    initial_state[0, 0, 0, 0] = 65536.0
+
+    output, state = _run(family, kernel_options, inputs, initial_state)
+    _, expected = _run(family, "ref", inputs, initial_state)
+
+    assert torch.equal(output, torch.zeros_like(output))
+    assert expected[0, 0, 0, 0].item() == pytest.approx(65536.0 * math.exp(-4.0))
+    torch.testing.assert_close(state, expected, rtol=1e-5, atol=0.0)
+
+
+@pytest.mark.parametrize("dtype", _DTYPES)
+@pytest.mark.parametrize("kernel_options", _BACKENDS)
+@pytest.mark.parametrize("family", _FAMILIES)
+def test_tiny_final_state_cotangent_reaches_gate_gradient(
+    family: str, kernel_options: dict[str, str] | None, dtype: torch.dtype, request
+) -> None:
+    """A final-state cotangent below the FP16 range must still produce the gate gradient."""
+    if dtype is torch.float16:
+        request.applymarker(_FP16_COTANGENT_RANGE)
+    inputs = _zero_inputs(family, dtype, tokens=64, gate_value=-0.01)
+    initial_state = torch.ones(1, 1, 128, 128, device="cuda")
+    d_final_state = torch.full_like(initial_state, 2.0**-25)
+
+    def gradients(options):
+        gate = inputs[3].clone().requires_grad_(True)
+        state_leaf = initial_state.clone().requires_grad_(True)
+        _, state = _run(family, options, (*inputs[:3], gate, inputs[4]), state_leaf)
+        return torch.autograd.grad((state,), (gate, state_leaf), (d_final_state,))
+
+    d_gate, d_initial_state = gradients(kernel_options)
+    expected_d_gate, expected_d_initial_state = gradients("ref")
+
+    assert (expected_d_gate != 0).all()
+    assert_relative_rms_within(d_gate, expected_d_gate, "dgate", max_eps=1.25, source_dtype=dtype)
+    torch.testing.assert_close(d_initial_state, expected_d_initial_state, rtol=1e-5, atol=0.0)

--- a/test/linear/test_gdn_chunk_fused.py
+++ b/test/linear/test_gdn_chunk_fused.py
@@ -883,8 +883,12 @@ def test_state_gate_term_contracts_in_fp32(dtype: torch.dtype, portable: bool, m
 
     actual = d_gate("fused", dtype, torch.float32)
     expected = d_gate("reference", torch.float64, torch.float64)
-    # Measured: 0.001--0.009 eps with FP32 contraction versus 0.02--0.34 eps when the portable
-    # kernel rounded the product and reduction to the source dtype.
+    low_precision = d_gate("reference", torch.float32, torch.float32)
+    # Measured for this seed: below 0.01 eps with FP32 accumulation on both backends versus
+    # 0.21 (BF16) and 0.22 (FP16) eps when the portable kernel accumulated in the source dtype.
+    assert_matches_low_precision_reference(
+        actual, expected, low_precision, "dgate", source_dtype=dtype
+    )
     assert_relative_rms_within(actual, expected, "dgate", max_eps=0.05, source_dtype=dtype)
 
 

--- a/test/linear/test_gdn_chunk_fused.py
+++ b/test/linear/test_gdn_chunk_fused.py
@@ -33,6 +33,7 @@ from attn_gym.linear.kda.ops import _plain_gate_scan_op
 from attn_gym.testing import make_gdn_test_inputs
 from attn_gym.testing.kda import (
     assert_matches_low_precision_reference,
+    assert_relative_rms_within,
     cumulative_sequence_offsets,
 )
 
@@ -848,6 +849,43 @@ def test_fp16_no_initial_state_final_state_gradients(batch: int, tokens: int):
                 name,
                 source_dtype=torch.float16,
             )
+
+
+@pytest.mark.parametrize("portable", [False, True])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_state_gate_term_contracts_in_fp32(dtype: torch.dtype, portable: bool, monkeypatch):
+    """The <state, state cotangent> gate term must not round to source-dtype precision.
+
+    Zero Q/K/V leave the gate gradient with only the per-chunk state term. Positive operands
+    avoid cancellation, so tape rounding averages out and any remaining error comes from
+    contracting the tapes in low precision.
+    """
+    if portable:
+        force_portable_backward(monkeypatch)
+    tokens = 64
+    generator = torch.Generator(device="cuda").manual_seed(2)
+    shape = (1, tokens, 1, 128)
+    q, k, v = (torch.zeros(shape, device="cuda", dtype=dtype) for _ in range(3))
+    gate = -torch.rand((1, tokens, 1), device="cuda", generator=generator) * 0.02
+    beta = torch.full((1, tokens, 1), 0.5, device="cuda")
+    initial_state = torch.rand((1, 1, 128, 128), device="cuda", generator=generator) * 0.1
+    d_state = torch.rand((1, 1, 128, 128), device="cuda", generator=generator) * 0.01
+
+    def d_gate(impl: str, qkv_dtype: torch.dtype, state_dtype: torch.dtype) -> torch.Tensor:
+        gate_leaf = gate.to(state_dtype).requires_grad_(True)
+        args = (q.to(qkv_dtype), k.to(qkv_dtype), v.to(qkv_dtype), gate_leaf, beta.to(state_dtype))
+        state = initial_state.to(state_dtype)
+        if impl == "fused":
+            _, final_state = chunk_gdn(*args, state, impl=impl, output_final_state=True)
+        else:
+            _, final_state = recurrent_gdn(*args, state, impl=impl, output_final_state=True)
+        return torch.autograd.grad((final_state,), (gate_leaf,), (d_state.to(state_dtype),))[0]
+
+    actual = d_gate("fused", dtype, torch.float32)
+    expected = d_gate("reference", torch.float64, torch.float64)
+    # Measured: 0.001--0.009 eps with FP32 contraction versus 0.02--0.34 eps when the portable
+    # kernel rounded the product and reduction to the source dtype.
+    assert_relative_rms_within(actual, expected, "dgate", max_eps=0.05, source_dtype=dtype)
 
 
 def test_int64_layouts_fail_before_kernel_launch(monkeypatch):


### PR DESCRIPTION
## Human Note

## Agent note

Both reported failures reproduce only with FP16 Q/K/V and are the two directions of one policy: every
fused GDN/KDA path (Triton, CuTe, and Mega) carries the recurrent state and its cotangent in FP32 with
FP32 decay, but stages the chunk-entry state and the per-chunk state-cotangent tape in the Q/K/V dtype
because they feed tensor-core GEMMs. An FP32 state element of 65536 is carried correctly (1200.33 after
the decay) yet becomes inf when the unscaled chunk-entry state is read as an FP16 operand, and 0 * inf
poisons the chunk; a 2^-25 final-state cotangent flushes to zero in the FP16 tape before the gate, dK,
and dV state terms. There is no decay-first formulation for the W*h and Q*h GEMMs (exp(g_t - g_end) >= 1
would overflow instead), and a wider tape cannot feed the dK/dV GEMMs without a conversion pass, so the
contract is documented rather than paid for with a broad kernel cost. BF16 shares the FP32 exponent
range and passes the exact dynamic-range regressions on both backends and both families.

The one gratuitous narrowing found while mapping the dataflow is in the portable Triton GDN WY kernel,
which multiplied and reduced the <h, dh> gate term in the source dtype; the KDA Triton and CuTe kernels
already contract it in FP32. With zero Q/K/V and positive state/cotangent, the isolated state term of
dgate improves from 0.02--0.34 eps to 0.001--0.009 eps, and with cancellation from 4.5--4.9 to
0.15--2.3 BF16 eps, matching the CuTe path exactly.

The Mega KDA backend is the one genuine deviation from the FP32 carry: it applies the per-chunk decay
through a b16 diagonal MMA (state and dstate), re-rounding the carried state every 16 tokens. Model-range
impact is modest (final-state rel-RMS 3.6e-3 vs 2.7e-3 fused at T=256 BF16), so it is documented and
pinned with a strict xfail instead of re-plumbing the kernel here.

## Performance

Portable GDN backward, T=8192, H=8, BF16, GB200, triton do_bench (5 samples, 2 valid interleaved A/B
rounds): 796--798 us with the FP32 contraction vs 795--797 us before; no measurable cost.

## Test Plan

```bash
gpu-run --timeout 300 auto -- pytest -n 6 -q test/linear/test_gdn_chunk_fused.py test/linear/test_delta_rule_state_precision.py test/gdn/mega test/kda/mega/test_delta_rule_numerics.py -p no:cacheprovider -W ignore
gpu-run --timeout 300 auto -- python agent_space/repro_state_precision.py
gpu-run --timeout 300 auto -- python agent_space/measure_dg_last.py positive
```
