### PR TITLE
Keep the KDA Mega delta residual in FP32 until the MMA pack

### DIFF
--- a/.agents/skills/worktree-env-setup/SKILL.md
+++ b/.agents/skills/worktree-env-setup/SKILL.md
@@ -48,9 +48,16 @@ another worktree or a shared `~/.venvs/*` env for attn_gym imports.
 ## Verifying isolation
 
 ```bash
-python -c "import attn_gym; print(attn_gym.__file__)"
+cd /tmp && python -c "import attn_gym; print(attn_gym.__file__)"
 ```
 
 The printed path must be inside the current worktree. If it points at another
 checkout, the editable install is wrong — rerun the `-e '.[tests,linear,dev]'`
 install from this worktree root.
+
+Run the check from outside the repo root. From the root, `python -c` puts the
+current directory first on `sys.path` and masks a wrong editable install, while
+`python agent_space/script.py` and `pytest` (whose `test/` has no `__init__.py`)
+put the *script* directory first and silently import the other checkout. A
+`.venv` symlinked to another worktree's env fails exactly this way: edits appear
+to have no effect because the kernels compile from the other tree.

--- a/.agents/skills/worktree-env-setup/SKILL.md
+++ b/.agents/skills/worktree-env-setup/SKILL.md
@@ -7,7 +7,11 @@ description: Sets up an isolated per-worktree Python environment for attention-g
 
 Each attention-gym worktree gets its own `.venv` so editable installs, concurrent
 agents, and test runs never cross-import another checkout. Never reuse a shared
-env's editable install across worktrees.
+env's editable install across worktrees, and never `ln -s` another worktree's
+`.venv` as a shortcut: an editable install is a `.pth` file naming one checkout,
+so a shared env makes every other worktree run that checkout's sources. A fresh
+`uv venv` plus hard-linked wheels costs seconds; a wrong import costs hours. If
+`.venv` already exists as a symlink, `rm .venv` and rebuild it below.
 
 ## Setup
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,12 @@ python attn_gym/masks/causal.py
 
 ## Development
 
+Every worktree needs its own `.venv` with an editable install of *this* checkout (see the
+`worktree-env-setup` skill; `uv` hard-links wheels, so it takes seconds). Never symlink or
+reuse a sibling worktree's `.venv`: its editable install resolves `attn_gym` to the other
+checkout, so scripts and pytest silently run the wrong sources. `test/conftest.py` refuses to
+start when that happens.
+
 ```bash
 pytest -n 6                     # run tests in parallel (strongly preferred)
 pytest -n 6 test/test_kda.py    # one file, same parallelism

--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_bprop_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_bprop_f16.py
@@ -128,15 +128,14 @@ from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.swizzle import (
 )
 from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.tma import tma_load_tile, tma_store_commit, tma_store_tile, tma_store_wait, tma_tensormap_acquire
 from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.pointwise import (
+    beta_residual_f16x2,
     f16x2_to_f32,
     fadd2,
     ffma2,
     fmul2,
     fp32_to_fp16,
     movmatrix_16b,
-    mul_f16x2,
     opaque_f32_zero,
-    sub_f16x2,
 )
 
 LOG2_E: float = 1.4426950408889634
@@ -2380,14 +2379,16 @@ def compute1_warp_group(
             bars.mb_v_done[raw_index.idx].arrive()
 
             bars.mb_beta_ready[chunk_serial % cfg.smem_beta_stages].wait((chunk_serial // cfg.smem_beta_stages) % 2)
-            beta_pairs = cute.make_rmem_tensor((2,), cutlass.Int32)
-            for half in cutlass.range_constexpr(2):
-                token0 = ((half * 4 + (lane & 3)) ^ 4) * 2
-                beta0 = (sBeta_ptr + token0).load().to(cutlass.Float32)
-                beta1 = (sBeta_ptr + token0 + 1).load().to(cutlass.Float32)
-                beta_pairs[half] = fp32_to_fp16(beta0, beta1, dtype=cfg.io_dtype)
-            diff_w0 = cute.make_rmem_tensor((4,), cutlass.Int32)
-            diff_w1 = cute.make_rmem_tensor((4,), cutlass.Int32)
+            # Both the ldmatrix V fragment and the 16x256b state_k / Y pair index run in the same
+            # token-pair order; only beta needs the ^4 half swap, so stage it in pair order too.
+            beta_regs = cute.make_rmem_tensor((8,), cutlass.Float32)
+            for pair in cutlass.range_constexpr(4):
+                token0 = (((1 - pair // 2) * 4 + (lane & 3)) ^ 4) * 2
+                beta_regs[2 * pair] = (sBeta_ptr + token0).load().to(cutlass.Float32)
+                beta_regs[2 * pair + 1] = (sBeta_ptr + token0 + 1).load().to(cutlass.Float32)
+            # fp32 residual V - state_k, kept for the dBeta v-term below
+            diff_w0 = cute.make_rmem_tensor((8,), cutlass.Float32)
+            diff_w1 = cute.make_rmem_tensor((8,), cutlass.Float32)
             y_inp_pack0 = cute.make_rmem_tensor((4,), cutlass.Int32)
             y_inp_pack1 = cute.make_rmem_tensor((4,), cutlass.Int32)
             if chunk_idx >= FIRST_STATE_CHUNK:
@@ -2395,29 +2396,23 @@ def compute1_warp_group(
                 state_k_index = advance(state_k_index, 1)
                 state_k_vec0 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr((row_id0 << 16) + projection_col_id, cutlass.Float32), num=2)
                 state_k_vec1 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr((row_id1 << 16) + projection_col_id, cutlass.Float32), num=2)
-                for reg_idx in cutlass.range_constexpr(4):
-                    raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
-                    frag_pair = (reg_idx ^ 2) * 2
-                    state_k_pair = fp32_to_fp16(state_k_vec0[frag_pair], state_k_vec0[frag_pair + 1], dtype=cfg.io_dtype)
-                    diff_pair = sub_f16x2(raw_v_frag0[raw_matrix], state_k_pair, cfg.io_dtype)
-                    diff_w0[reg_idx ^ 2] = diff_pair
-                    y_inp_pack0[reg_idx ^ 2] = mul_f16x2(beta_pairs[reg_idx // 2], diff_pair, cfg.io_dtype)
-                for reg_idx in cutlass.range_constexpr(4):
-                    raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
-                    frag_pair = (reg_idx ^ 2) * 2
-                    state_k_pair = fp32_to_fp16(state_k_vec1[frag_pair], state_k_vec1[frag_pair + 1], dtype=cfg.io_dtype)
-                    diff_pair = sub_f16x2(raw_v_frag1[raw_matrix], state_k_pair, cfg.io_dtype)
-                    diff_w1[reg_idx ^ 2] = diff_pair
-                    y_inp_pack1[reg_idx ^ 2] = mul_f16x2(beta_pairs[reg_idx // 2], diff_pair, cfg.io_dtype)
+                for pair in cutlass.range_constexpr(4):
+                    lo, hi = 2 * pair, 2 * pair + 1
+                    y_inp_pack0[pair], diff_w0[lo], diff_w0[hi] = beta_residual_f16x2(
+                        raw_v_frag0[pair], beta_regs[lo], beta_regs[hi], state_k_vec0[lo], state_k_vec0[hi], dtype=cfg.io_dtype
+                    )
+                    y_inp_pack1[pair], diff_w1[lo], diff_w1[hi] = beta_residual_f16x2(
+                        raw_v_frag1[pair], beta_regs[lo], beta_regs[hi], state_k_vec1[lo], state_k_vec1[hi], dtype=cfg.io_dtype
+                    )
             if chunk_idx < FIRST_STATE_CHUNK:
-                for reg_idx in cutlass.range_constexpr(4):
-                    raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
-                    diff_w0[reg_idx ^ 2] = raw_v_frag0[raw_matrix]
-                    y_inp_pack0[reg_idx ^ 2] = mul_f16x2(beta_pairs[reg_idx // 2], raw_v_frag0[raw_matrix], cfg.io_dtype)
-                for reg_idx in cutlass.range_constexpr(4):
-                    raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
-                    diff_w1[reg_idx ^ 2] = raw_v_frag1[raw_matrix]
-                    y_inp_pack1[reg_idx ^ 2] = mul_f16x2(beta_pairs[reg_idx // 2], raw_v_frag1[raw_matrix], cfg.io_dtype)
+                for pair in cutlass.range_constexpr(4):
+                    lo, hi = 2 * pair, 2 * pair + 1
+                    y_inp_pack0[pair], diff_w0[lo], diff_w0[hi] = beta_residual_f16x2(
+                        raw_v_frag0[pair], beta_regs[lo], beta_regs[hi], dtype=cfg.io_dtype
+                    )
+                    y_inp_pack1[pair], diff_w1[lo], diff_w1[hi] = beta_residual_f16x2(
+                        raw_v_frag1[pair], beta_regs[lo], beta_regs[hi], dtype=cfg.io_dtype
+                    )
             nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(row_addr_lo + input_col_id, cutlass.Int8), y_inp_pack0.load())
             nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(row_addr_hi + input_col_id, cutlass.Int8), y_inp_pack1.load())
             nvvm.tcgen05_wait("store")
@@ -2530,12 +2525,10 @@ def compute1_warp_group(
             for s in cutlass.range_constexpr(4):
                 tok4[s] = cutlass.Float32(0.0)
             for j in cutlass.range_constexpr(4):
-                d0_lo, d0_hi = f16x2_to_f32(diff_w0[j], dtype=cfg.io_dtype)
-                d1_lo, d1_hi = f16x2_to_f32(diff_w1[j], dtype=cfg.io_dtype)
                 s_lo = cutlass.const_expr(2 * (j // 2))
                 s_hi = cutlass.const_expr(2 * (j // 2) + 1)
-                t_lo, t_hi = ffma2(dy_vec0[2 * j], dy_vec0[2 * j + 1], d0_lo, d0_hi, tok4[s_lo], tok4[s_hi])
-                t_lo, t_hi = ffma2(dy_vec1[2 * j], dy_vec1[2 * j + 1], d1_lo, d1_hi, t_lo, t_hi)
+                t_lo, t_hi = ffma2(dy_vec0[2 * j], dy_vec0[2 * j + 1], diff_w0[2 * j], diff_w0[2 * j + 1], tok4[s_lo], tok4[s_hi])
+                t_lo, t_hi = ffma2(dy_vec1[2 * j], dy_vec1[2 * j + 1], diff_w1[2 * j], diff_w1[2 * j + 1], t_lo, t_hi)
                 tok4[s_lo] = t_lo
                 tok4[s_hi] = t_hi
 

--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_prefill_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_prefill_f16.py
@@ -142,9 +142,8 @@ from .tile_dsl.pointwise import (
     fmul2,
     ffma2,
     movmatrix_16b,
-    mul_f16x2,
+    beta_residual_f16x2,
     fp32_to_fp16,
-    sub_f16x2,
 )
 
 LOG2_E: float = 1.4426950408889634
@@ -1618,51 +1617,52 @@ def compute1_warp_group(
                 state_k_vec0 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr(row_addr + state_k_col_id, cutlass.Float32), num=2)
                 state_k_vec1 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr(row16_addr + state_k_col_id, cutlass.Float32), num=2)
 
-            beta_pack = cute.make_rmem_tensor((4,), cutlass.Int32)
+            beta_regs = cute.make_rmem_tensor((8,), cutlass.Float32)
             for reg_idx in cutlass.range_constexpr(4):
                 token0 = (((reg_idx // 2) * 4 + (lane & 3)) ^ 4) * 2
-                beta0 = (sBeta_ptr + token0).load().to(cutlass.Float32)
-                beta1 = (sBeta_ptr + token0 + 1).load().to(cutlass.Float32)
-                beta_pack[reg_idx] = fp32_to_fp16(beta0, beta1, dtype=cfg.io_dtype)
+                beta_regs[2 * reg_idx] = (sBeta_ptr + token0).load().to(cutlass.Float32)
+                beta_regs[2 * reg_idx + 1] = (sBeta_ptr + token0 + 1).load().to(cutlass.Float32)
             y_inp_pack0 = cute.make_rmem_tensor((4,), cutlass.Int32)
             for reg_idx in cutlass.range_constexpr(4):
                 raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
                 frag_pair = (reg_idx ^ 2) * 2
                 if cutlass.const_expr(mState_init is not None):
-                    state_k_val0, state_k_val1 = state_k_vec0[frag_pair], state_k_vec0[frag_pair + 1]
-                    state_k_pair = fp32_to_fp16(state_k_val0, state_k_val1, dtype=cfg.io_dtype)
-                    diff_pair = sub_f16x2(
+                    y_inp_pack0[reg_idx], _, _ = beta_residual_f16x2(
                         raw_v_frag0[raw_matrix],
-                        state_k_pair,
-                        cfg.io_dtype,
+                        beta_regs[2 * reg_idx],
+                        beta_regs[2 * reg_idx + 1],
+                        state_k_vec0[frag_pair],
+                        state_k_vec0[frag_pair + 1],
+                        dtype=cfg.io_dtype,
                     )
                 else:
-                    diff_pair = raw_v_frag0[raw_matrix]
-                y_inp_pack0[reg_idx] = mul_f16x2(
-                    beta_pack[reg_idx],
-                    diff_pair,
-                    cfg.io_dtype,
-                )
+                    y_inp_pack0[reg_idx], _, _ = beta_residual_f16x2(
+                        raw_v_frag0[raw_matrix],
+                        beta_regs[2 * reg_idx],
+                        beta_regs[2 * reg_idx + 1],
+                        dtype=cfg.io_dtype,
+                    )
 
             y_inp_pack1 = cute.make_rmem_tensor((4,), cutlass.Int32)
             for reg_idx in cutlass.range_constexpr(4):
                 raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
                 frag_pair = (reg_idx ^ 2) * 2
                 if cutlass.const_expr(mState_init is not None):
-                    state_k_val0, state_k_val1 = state_k_vec1[frag_pair], state_k_vec1[frag_pair + 1]
-                    state_k_pair = fp32_to_fp16(state_k_val0, state_k_val1, dtype=cfg.io_dtype)
-                    diff_pair = sub_f16x2(
+                    y_inp_pack1[reg_idx], _, _ = beta_residual_f16x2(
                         raw_v_frag1[raw_matrix],
-                        state_k_pair,
-                        cfg.io_dtype,
+                        beta_regs[2 * reg_idx],
+                        beta_regs[2 * reg_idx + 1],
+                        state_k_vec1[frag_pair],
+                        state_k_vec1[frag_pair + 1],
+                        dtype=cfg.io_dtype,
                     )
                 else:
-                    diff_pair = raw_v_frag1[raw_matrix]
-                y_inp_pack1[reg_idx] = mul_f16x2(
-                    beta_pack[reg_idx],
-                    diff_pair,
-                    cfg.io_dtype,
-                )
+                    y_inp_pack1[reg_idx], _, _ = beta_residual_f16x2(
+                        raw_v_frag1[raw_matrix],
+                        beta_regs[2 * reg_idx],
+                        beta_regs[2 * reg_idx + 1],
+                        dtype=cfg.io_dtype,
+                    )
 
             nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row_addr + y_inp_col_id, cutlass.Int8), y_inp_pack0.load())
             nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row16_addr + y_inp_col_id, cutlass.Int8), y_inp_pack1.load())
@@ -1785,44 +1785,35 @@ def compute1_warp_group(
             state_k_vec0 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr(row_addr + state_k_col_id, cutlass.Float32), num=2)
             state_k_vec1 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr(row16_addr + state_k_col_id, cutlass.Float32), num=2)
 
-            beta_pack = cute.make_rmem_tensor((4,), cutlass.Int32)
+            beta_regs = cute.make_rmem_tensor((8,), cutlass.Float32)
             for reg_idx in cutlass.range_constexpr(4):
                 token0 = (((reg_idx // 2) * 4 + (lane & 3)) ^ 4) * 2
-                beta0 = (sBeta_ptr + token0).load().to(cutlass.Float32)
-                beta1 = (sBeta_ptr + token0 + 1).load().to(cutlass.Float32)
-                beta_pack[reg_idx] = fp32_to_fp16(beta0, beta1, dtype=cfg.io_dtype)
+                beta_regs[2 * reg_idx] = (sBeta_ptr + token0).load().to(cutlass.Float32)
+                beta_regs[2 * reg_idx + 1] = (sBeta_ptr + token0 + 1).load().to(cutlass.Float32)
             y_inp_pack0 = cute.make_rmem_tensor((4,), cutlass.Int32)
             for reg_idx in cutlass.range_constexpr(4):
                 raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
                 frag_pair = (reg_idx ^ 2) * 2
-                state_k_val0, state_k_val1 = state_k_vec0[frag_pair], state_k_vec0[frag_pair + 1]
-                state_k_pair = fp32_to_fp16(state_k_val0, state_k_val1, dtype=cfg.io_dtype)
-                diff_pair = sub_f16x2(
+                y_inp_pack0[reg_idx], _, _ = beta_residual_f16x2(
                     raw_v_frag0[raw_matrix],
-                    state_k_pair,
-                    cfg.io_dtype,
-                )
-                y_inp_pack0[reg_idx] = mul_f16x2(
-                    beta_pack[reg_idx],
-                    diff_pair,
-                    cfg.io_dtype,
+                    beta_regs[2 * reg_idx],
+                    beta_regs[2 * reg_idx + 1],
+                    state_k_vec0[frag_pair],
+                    state_k_vec0[frag_pair + 1],
+                    dtype=cfg.io_dtype,
                 )
 
             y_inp_pack1 = cute.make_rmem_tensor((4,), cutlass.Int32)
             for reg_idx in cutlass.range_constexpr(4):
                 raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
                 frag_pair = (reg_idx ^ 2) * 2
-                state_k_val0, state_k_val1 = state_k_vec1[frag_pair], state_k_vec1[frag_pair + 1]
-                state_k_pair = fp32_to_fp16(state_k_val0, state_k_val1, dtype=cfg.io_dtype)
-                diff_pair = sub_f16x2(
+                y_inp_pack1[reg_idx], _, _ = beta_residual_f16x2(
                     raw_v_frag1[raw_matrix],
-                    state_k_pair,
-                    cfg.io_dtype,
-                )
-                y_inp_pack1[reg_idx] = mul_f16x2(
-                    beta_pack[reg_idx],
-                    diff_pair,
-                    cfg.io_dtype,
+                    beta_regs[2 * reg_idx],
+                    beta_regs[2 * reg_idx + 1],
+                    state_k_vec1[frag_pair],
+                    state_k_vec1[frag_pair + 1],
+                    dtype=cfg.io_dtype,
                 )
 
             nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row_addr + y_inp_col_id, cutlass.Int8), y_inp_pack0.load())

--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_recompute_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_recompute_f16.py
@@ -145,9 +145,8 @@ from attn_gym.linear._delta_rule.mega.kernels.tile_dsl.pointwise import (
     fmul2,
     ffma2,
     movmatrix_16b,
-    mul_f16x2,
+    beta_residual_f16x2,
     fp32_to_fp16,
-    sub_f16x2,
 )
 
 LOG2_E: float = 1.4426950408889634
@@ -1424,51 +1423,52 @@ def compute1_warp_group(
                 state_k_vec0 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr(row_addr + statek_col_id, cutlass.Float32), num=2)
                 state_k_vec1 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr(row16_addr + statek_col_id, cutlass.Float32), num=2)
 
-            beta_pack = cute.make_rmem_tensor((4,), cutlass.Int32)
+            beta_regs = cute.make_rmem_tensor((8,), cutlass.Float32)
             for reg_idx in cutlass.range_constexpr(4):
                 token0 = (((reg_idx // 2) * 4 + (lane & 3)) ^ 4) * 2
-                beta0 = (sBeta_ptr + token0).load().to(cutlass.Float32)
-                beta1 = (sBeta_ptr + token0 + 1).load().to(cutlass.Float32)
-                beta_pack[reg_idx] = fp32_to_fp16(beta0, beta1, dtype=cfg.io_dtype)
+                beta_regs[2 * reg_idx] = (sBeta_ptr + token0).load().to(cutlass.Float32)
+                beta_regs[2 * reg_idx + 1] = (sBeta_ptr + token0 + 1).load().to(cutlass.Float32)
             y_inp_pack0 = cute.make_rmem_tensor((4,), cutlass.Int32)
             for reg_idx in cutlass.range_constexpr(4):
                 raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
                 frag_pair = (reg_idx ^ 2) * 2
                 if cutlass.const_expr(mState_init is not None):
-                    state_k_val0, state_k_val1 = state_k_vec0[frag_pair], state_k_vec0[frag_pair + 1]
-                    state_k_pair = fp32_to_fp16(state_k_val0, state_k_val1, dtype=cfg.io_dtype)
-                    diff_pair = sub_f16x2(
+                    y_inp_pack0[reg_idx], _, _ = beta_residual_f16x2(
                         raw_v_frag0[raw_matrix],
-                        state_k_pair,
-                        cfg.io_dtype,
+                        beta_regs[2 * reg_idx],
+                        beta_regs[2 * reg_idx + 1],
+                        state_k_vec0[frag_pair],
+                        state_k_vec0[frag_pair + 1],
+                        dtype=cfg.io_dtype,
                     )
                 else:
-                    diff_pair = raw_v_frag0[raw_matrix]
-                y_inp_pack0[reg_idx] = mul_f16x2(
-                    beta_pack[reg_idx],
-                    diff_pair,
-                    cfg.io_dtype,
-                )
+                    y_inp_pack0[reg_idx], _, _ = beta_residual_f16x2(
+                        raw_v_frag0[raw_matrix],
+                        beta_regs[2 * reg_idx],
+                        beta_regs[2 * reg_idx + 1],
+                        dtype=cfg.io_dtype,
+                    )
 
             y_inp_pack1 = cute.make_rmem_tensor((4,), cutlass.Int32)
             for reg_idx in cutlass.range_constexpr(4):
                 raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
                 frag_pair = (reg_idx ^ 2) * 2
                 if cutlass.const_expr(mState_init is not None):
-                    state_k_val0, state_k_val1 = state_k_vec1[frag_pair], state_k_vec1[frag_pair + 1]
-                    state_k_pair = fp32_to_fp16(state_k_val0, state_k_val1, dtype=cfg.io_dtype)
-                    diff_pair = sub_f16x2(
+                    y_inp_pack1[reg_idx], _, _ = beta_residual_f16x2(
                         raw_v_frag1[raw_matrix],
-                        state_k_pair,
-                        cfg.io_dtype,
+                        beta_regs[2 * reg_idx],
+                        beta_regs[2 * reg_idx + 1],
+                        state_k_vec1[frag_pair],
+                        state_k_vec1[frag_pair + 1],
+                        dtype=cfg.io_dtype,
                     )
                 else:
-                    diff_pair = raw_v_frag1[raw_matrix]
-                y_inp_pack1[reg_idx] = mul_f16x2(
-                    beta_pack[reg_idx],
-                    diff_pair,
-                    cfg.io_dtype,
-                )
+                    y_inp_pack1[reg_idx], _, _ = beta_residual_f16x2(
+                        raw_v_frag1[raw_matrix],
+                        beta_regs[2 * reg_idx],
+                        beta_regs[2 * reg_idx + 1],
+                        dtype=cfg.io_dtype,
+                    )
 
             nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row_addr + y_inp_col_id, cutlass.Int8), y_inp_pack0.load())
             nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row16_addr + y_inp_col_id, cutlass.Int8), y_inp_pack1.load())
@@ -1586,44 +1586,35 @@ def compute1_warp_group(
             state_k_vec0 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr(row_addr + statek_col_id, cutlass.Float32), num=2)
             state_k_vec1 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr(row16_addr + statek_col_id, cutlass.Float32), num=2)
 
-            beta_pack = cute.make_rmem_tensor((4,), cutlass.Int32)
+            beta_regs = cute.make_rmem_tensor((8,), cutlass.Float32)
             for reg_idx in cutlass.range_constexpr(4):
                 token0 = (((reg_idx // 2) * 4 + (lane & 3)) ^ 4) * 2
-                beta0 = (sBeta_ptr + token0).load().to(cutlass.Float32)
-                beta1 = (sBeta_ptr + token0 + 1).load().to(cutlass.Float32)
-                beta_pack[reg_idx] = fp32_to_fp16(beta0, beta1, dtype=cfg.io_dtype)
+                beta_regs[2 * reg_idx] = (sBeta_ptr + token0).load().to(cutlass.Float32)
+                beta_regs[2 * reg_idx + 1] = (sBeta_ptr + token0 + 1).load().to(cutlass.Float32)
             y_inp_pack0 = cute.make_rmem_tensor((4,), cutlass.Int32)
             for reg_idx in cutlass.range_constexpr(4):
                 raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
                 frag_pair = (reg_idx ^ 2) * 2
-                state_k_val0, state_k_val1 = state_k_vec0[frag_pair], state_k_vec0[frag_pair + 1]
-                state_k_pair = fp32_to_fp16(state_k_val0, state_k_val1, dtype=cfg.io_dtype)
-                diff_pair = sub_f16x2(
+                y_inp_pack0[reg_idx], _, _ = beta_residual_f16x2(
                     raw_v_frag0[raw_matrix],
-                    state_k_pair,
-                    cfg.io_dtype,
-                )
-                y_inp_pack0[reg_idx] = mul_f16x2(
-                    beta_pack[reg_idx],
-                    diff_pair,
-                    cfg.io_dtype,
+                    beta_regs[2 * reg_idx],
+                    beta_regs[2 * reg_idx + 1],
+                    state_k_vec0[frag_pair],
+                    state_k_vec0[frag_pair + 1],
+                    dtype=cfg.io_dtype,
                 )
 
             y_inp_pack1 = cute.make_rmem_tensor((4,), cutlass.Int32)
             for reg_idx in cutlass.range_constexpr(4):
                 raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
                 frag_pair = (reg_idx ^ 2) * 2
-                state_k_val0, state_k_val1 = state_k_vec1[frag_pair], state_k_vec1[frag_pair + 1]
-                state_k_pair = fp32_to_fp16(state_k_val0, state_k_val1, dtype=cfg.io_dtype)
-                diff_pair = sub_f16x2(
+                y_inp_pack1[reg_idx], _, _ = beta_residual_f16x2(
                     raw_v_frag1[raw_matrix],
-                    state_k_pair,
-                    cfg.io_dtype,
-                )
-                y_inp_pack1[reg_idx] = mul_f16x2(
-                    beta_pack[reg_idx],
-                    diff_pair,
-                    cfg.io_dtype,
+                    beta_regs[2 * reg_idx],
+                    beta_regs[2 * reg_idx + 1],
+                    state_k_vec1[frag_pair],
+                    state_k_vec1[frag_pair + 1],
+                    dtype=cfg.io_dtype,
                 )
 
             nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row_addr + y_inp_col_id, cutlass.Int8), y_inp_pack0.load())

--- a/attn_gym/linear/_delta_rule/mega/kernels/tile_dsl/pointwise.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/tile_dsl/pointwise.py
@@ -254,6 +254,23 @@ def mul_f16x2(lhs: cutlass.Int32, rhs: cutlass.Int32, input_dtype: cutlass.Const
 
 
 @cute.jit
+def beta_residual_f16x2(v_pair: cutlass.Int32, beta_lo, beta_hi, state_k_lo=None, state_k_hi=None, *, dtype=cutlass.Float16):
+    """Stage the delta-rule update ``beta * (v - state_k)`` for one packed pair.
+
+    ``v`` arrives as a packed b16 pair and ``state_k`` as the fp32 MMA
+    accumulator; ``state_k`` may be omitted when no state is carried in.  The
+    subtraction and beta scaling run in fp32 so the only rounding is the
+    final pack into the b16 MMA operand.  Also returns the fp32 residual for
+    consumers such as the dBeta v-term.
+    """
+    v_lo, v_hi = f16x2_to_f32(v_pair, dtype=dtype)
+    if cutlass.const_expr(state_k_lo is not None):
+        v_lo, v_hi = fadd2(v_lo, v_hi, -state_k_lo, -state_k_hi)
+    y_lo, y_hi = fmul2(beta_lo, beta_hi, v_lo, v_hi)
+    return fp32_to_fp16(y_lo, y_hi, dtype=dtype), v_lo, v_hi
+
+
+@cute.jit
 def sigmoid_f16x2(logit_pair: cutlass.Int32, input_dtype: cutlass.Constexpr):
     """Sigmoid of a packed 16-bit logit pair, returned as two fp32 values."""
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,9 +1,26 @@
 """Shared pytest fixtures."""
 
 from collections.abc import Callable, Iterator
+from pathlib import Path
 
 import pytest
 import torch
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Refuse to test one checkout's sources through another worktree's editable install."""
+    import attn_gym
+
+    package_root = Path(attn_gym.__file__).resolve().parent.parent
+    repo_root = Path(__file__).resolve().parent.parent
+    if package_root == repo_root or "site-packages" in package_root.parts:
+        return
+    raise pytest.UsageError(
+        f"attn_gym imports from {package_root}, not this checkout {repo_root}. The active "
+        "environment's editable install (or a `.venv` symlinked to another worktree) points at "
+        "a sibling checkout; follow .agents/skills/worktree-env-setup/SKILL.md to create this "
+        "worktree's own .venv."
+    )
 
 
 @pytest.fixture

--- a/test/kda/mega/test_delta_rule_numerics.py
+++ b/test/kda/mega/test_delta_rule_numerics.py
@@ -142,6 +142,57 @@ def test_mega_exact_orthogonal_writes(family: str) -> None:
     assert torch.equal(state, value[0, :, 0].T[None, None].to(state.dtype))
 
 
+@pytest.mark.parametrize("dtype", (torch.bfloat16, torch.float16))
+def test_kda_mega_delta_residual_keeps_fp32_precision(dtype: torch.dtype) -> None:
+    """``beta * (v - state @ k)`` must not round ``state @ k`` to the I/O dtype first.
+
+    Tokens 0 and 1 write ``state[k0, v0] = 4096`` and ``state[k1, v0] = 2``. Token 16
+    reads both with ``k = e0 + e1`` and ``v = 4096 e0``, so ``state @ k = 4098`` and the
+    residual is exactly ``-2``; rounding the contraction to BF16 or FP16 first gives 4096
+    and a zero residual. Token 32 then reads ``state[k1]`` so the recomputed state used
+    by the raw backward also depends on the residual.
+    """
+    tokens = 64
+    shape = (1, tokens, 1, 128)
+    q = torch.zeros(shape, device="cuda", dtype=dtype)
+    k = torch.zeros_like(q)
+    value = torch.zeros_like(q)
+    gate = torch.zeros(shape, device="cuda", dtype=torch.float32)
+    beta = torch.zeros((1, tokens, 1), device="cuda", dtype=torch.float32)
+    k[0, 0, 0, 0] = 1
+    value[0, 0, 0, 0] = 4096
+    beta[0, 0, 0] = 1
+    k[0, 1, 0, 1] = 1
+    value[0, 1, 0, 0] = 2
+    beta[0, 1, 0] = 1
+    q[0, 16, 0, 1] = 1
+    k[0, 16, 0, :2] = 1
+    value[0, 16, 0, 0] = 4096
+    beta[0, 16, 0] = 0.25
+    q[0, 32, 0, 1] = 1
+    d_output = torch.zeros_like(value)
+    d_output[0, 16, 0, 0] = 64
+    d_output[0, 32, 0, 0] = 64
+
+    inputs = (q, k, value, gate, beta)
+    output = chunk_kda(*inputs, scale=1.0, autotune=False, kernel_options=_MEGA)[0]
+    cu_seqlens = torch.tensor([0, tokens], device="cuda", dtype=torch.int32)
+    dq, _, _, _, dbeta = chunk_mega_packed_local_bwd_op(*inputs, d_output, cu_seqlens, False, 1.0)
+
+    leaves = clone_kda_inputs(
+        tuple(tensor.requires_grad_() for tensor in inputs), dtype=torch.float64
+    )
+    expected_output = kda_reference(*leaves, scale=1.0, output_final_state=False)[0]
+    expected_dq, expected_dbeta = torch.autograd.grad(
+        expected_output, (leaves[0], leaves[4]), d_output.to(torch.float64)
+    )
+
+    assert output[0, 16, 0, 0].item() == expected_output[0, 16, 0, 0].item() == 1.5
+    assert output[0, 32, 0, 0].item() == expected_output[0, 32, 0, 0].item() == 1.5
+    assert dbeta[0, 16, 0].item() == expected_dbeta[0, 16, 0].item() == -256
+    assert dq[0, 32, 0, 1].item() == expected_dq[0, 32, 0, 1].item() == 96
+
+
 @pytest.mark.parametrize("seed", (888, 889, 890))
 def test_gdn_mega_model_range_backward(seed: int) -> None:
     """GDN output and gradients must remain within the BF16 reference error budget."""


### PR DESCRIPTION
## Human Note

## Agent note

The three KDA Mega kernels (prefill, checkpoint recompute, backward) stage the delta-rule update
`Y = beta * (V - state @ K)` for the U solve by converting the FP32 `state @ K` accumulator to the I/O
dtype, subtracting in packed BF16/FP16, and multiplying by a separately rounded BF16/FP16 beta. When
`state @ K` is large relative to the residual, the first conversion swallows the residual before the
subtraction happens: with `state @ K = 4098` and `v = 4096`, both BF16 and FP16 round the contraction
to 4096 and the exact residual `-2` becomes 0. The forward output, the recomputed checkpoint states, and
the backward `dBeta` v-term (which reused the same packed residual) all inherited the error; the
reference recurrence produces output `1.5` and `dBeta = -256` where Mega produced `2.0` and `0`. This is
the regime a converged delta-rule model lives in (the state already predicts `v`, the correction is
small), so the zeroed residual means the update silently does not happen.

The fix adds `beta_residual_f16x2` in `tile_dsl/pointwise.py`: unpack the raw `V` pair to FP32, form
`V - state @ K` with `fadd2`, scale by the FP32 beta with `fmul2`, and pack once for the b16 MMA operand.
The helper also returns the FP32 residual, so the backward `dBeta` v-term now consumes the exact
residual instead of unpacking a rounded b16 copy. All five staging sites (both prefill and recompute
forms plus bprop) go through the same helper, so forward, recompute, and backward stay bit-consistent
with each other.

On the existing model-range oracle (rel. RMS vs the FP64 recurrence, BF16 eps; all already inside the
1.25-eps budget), output error drops from 0.50-0.54 to 0.45-0.48 eps, raw-backward `dq`/`dk` from
0.45-0.47 to 0.39-0.41, `dgate` from 0.79-0.82 to 0.75-0.79; `dv` and the public-fallback gradients are
unchanged. The constructed regression is what actually distinguishes the two rounding orders.

Not changed here: the recurrent state is still re-rounded to the I/O dtype once per chunk because the
decay `S <- S @ diag(exp2(g_last))` reads the packed b16 state view as its A operand (the final state
for the repro is 4096 instead of 4095). That is a separate MMA-operand contract. The GDN Mega kernels
share the same `state @ K -> b16 -> sub` staging pattern and are also unchanged.

The last two commits are fallout from the investigation: several sibling worktrees `ln -s` another
worktree's `.venv`, whose editable `.pth` names yet another checkout, so `pytest` and
`python agent_space/script.py` silently imported the wrong sources and kernel edits appeared to have no
effect. `test/conftest.py` now raises a `UsageError` when `attn_gym` resolves outside the checkout
(installed `site-packages` copies, as in CI, still pass), `AGENTS.md` states the per-worktree `.venv`
requirement, and the `worktree-env-setup` skill documents the trap and the recovery.

## Performance

Cost is a few extra CG1 ALU ops per chunk on the prefill's critical path; register count, stack size,
and local-memory instruction counts are unchanged for all three kernels (`REG:128`, bprop `STACK:248`,
`LDL/STL` 44/31 before and after; SASS grows by 32/32/16 instructions). Across the full
`benchmarks/chunk_delta.py --op kda` matrix on GB200 (median of round medians, baseline vs fix on the
same GPU): forward +0.5% to +1.9% (worst on `h16` shapes, where less MMA work hides the latency),
backward -0.1% to +0.5% (noise), train step +0.0% to +0.7%. FP16 matches BF16.

| case (BF16)        | fwd base | fwd fix | Δ      | bwd base | bwd fix | Δ      | step base | step fix | Δ      |
|--------------------|---------:|--------:|-------:|---------:|--------:|-------:|----------:|---------:|-------:|
| dense_t1024_h16    |   71.8   |   72.3  | +0.7%  |  150.0   |  150.2  | +0.1%  |   216.6   |   218.0  | +0.7%  |
| dense_t1024_h64    |   79.2   |   79.9  | +0.9%  |  386.8   |  387.3  | +0.1%  |   459.2   |   459.8  | +0.1%  |
| dense_t4096_h16    |  236.6   |  241.2  | +1.9%  |  448.8   |  448.7  | -0.0%  |   680.5   |   684.8  | +0.6%  |
| dense_t4096_h64    |  250.0   |  253.0  | +1.2%  | 1356.9   | 1356.7  | -0.0%  |  1600.7   |  1602.2  | +0.1%  |
| dense_t8192_h64    |  474.2   |  478.9  | +1.0%  | 2645.1   | 2648.0  | +0.1%  |  3117.8   |  3122.9  | +0.2%  |
| dense_t32768_h16   | 1735.3   | 1764.5  | +1.7%  | 3166.8   | 3166.3  | -0.0%  |  4920.5   |  4951.0  | +0.6%  |
| dense_t32768_h64   | 1831.9   | 1847.8  | +0.9%  | 10464.9  | 10456.4 | -0.1%  | 12264.5   | 12292.1  | +0.2%  |
| packed_balanced    |  239.9   |  242.0  | +0.9%  | 1589.3   | 1596.7  | +0.5%  |  1816.5   |  1827.7  | +0.6%  |
| packed_imbalanced  |  253.6   |  255.2  | +0.6%  | 1497.9   | 1506.0  | +0.5%  |  1739.5   |  1749.3  | +0.6%  |
| packed_many_short  |  157.5   |  159.9  | +1.6%  |  756.7   |  759.1  | +0.3%  |   907.4   |   911.7  | +0.5%  |

Units: microseconds. `dense_t1024_h16`, `dense_t8192_h64`, `packed_many_short` are medians over 2
baseline / 3 fix runs; the rest are single matched runs.

## Test Plan

```bash
pytest -n 2 test/kda/mega/test_delta_rule_numerics.py -k delta_residual   # fails on main, passes here
pytest -n 6 test/kda/mega test/test_kda_impl_dispatch.py test/test_mega_optional_import.py
pytest -n 6 test/gdn/mega test/linear/test_gdn.py test/test_kda_training_example.py
python benchmarks/chunk_delta.py --op kda            # all cases, baseline and fix, same GPU
python benchmarks/chunk_delta.py --op kda --dtype float16 --case dense_t1024_h16 --case dense_t8192_h64 --case packed_many_short
/path/to/other-worktree/.venv/bin/pytest test/test_kda_imports.py   # UsageError from the conftest gate
```
