### PR TITLE
Split reverse affine-summary operands hi/lo to match forward

### DIFF
--- a/attn_gym/linear/_delta_rule/cute/affine_summary_fwd.py
+++ b/attn_gym/linear/_delta_rule/cute/affine_summary_fwd.py
@@ -255,7 +255,7 @@ class _AffineSummaryFwdOp:
 
         # --- SMEM staged layouts ---
         # A operands ride their TMA rings; B operands hold hi/lo halves of the
-        # fp32-valued state and Tmp tiles (2 "stages" = the two MMA passes).
+        # fp32-valued state and Tmp tiles, one pipeline stage per half.
         s_w_staged = sm100_utils.make_smem_layout_a(
             mma_wx,
             self.wx_tile,
@@ -347,8 +347,8 @@ class _AffineSummaryFwdOp:
             bar_kg: cute.struct.MemRange[Int64, self.kg_depth * 2]
             bar_u: cute.struct.MemRange[Int64, self.u_depth * 2]
             bar_gk: cute.struct.MemRange[Int64, self.gk_depth * 2]
-            bar_xb: cute.struct.MemRange[Int64, 1 * 2]
-            bar_tmpb: cute.struct.MemRange[Int64, 1 * 2]
+            bar_xb: cute.struct.MemRange[Int64, 2 * 2]
+            bar_tmpb: cute.struct.MemRange[Int64, 2 * 2]
             bar_wx: cute.struct.MemRange[Int64, 1 * 2]
             bar_kt: cute.struct.MemRange[Int64, 1 * 2]
             tmem_buf: Int32
@@ -520,26 +520,27 @@ class _AffineSummaryFwdOp:
                 uh.release()
 
             # --- MMA1: w(SMEM A) × X snapshot(SMEM B) → wx(TMEM) ---
-            xbh = pxb_C.wait_and_advance()
             wh = pw_C.wait_and_advance()
             wxd = pwx_P.acquire_and_advance()
             for split in cutlass.range_constexpr(2):
+                # Each hi/lo half is one pipeline stage, published separately.
+                xbh = pxb_C.wait_and_advance()
                 for kp in cutlass.range_constexpr(cute.size(t_w_a, mode=[2])):
                     mma_wx.set(tcgen05.Field.ACCUMULATE, cutlass.Boolean(split != 0 or kp != 0))
                     cute.gemm(
                         mma_wx,
                         t_wx_acc[None, None, None, wxd.index],
                         t_w_a[None, None, kp, wh.index],
-                        t_xb_b[None, None, kp, split],
+                        t_xb_b[None, None, kp, xbh.index],
                         t_wx_acc[None, None, None, wxd.index],
                     )
+                xbh.release()
             wxd.commit()
             wh.release()
-            xbh.release()
 
             # --- MMA2b: kg^T(SMEM A) × -wx hi/lo(SMEM B) → kt(TMEM) ---
-            tmpbh = ptmpb_C.wait_and_advance()
             for split in cutlass.range_constexpr(2):
+                tmpbh = ptmpb_C.wait_and_advance()
                 for kp in cutlass.range_constexpr(cute.size(t_kg_a, mode=[2])):
                     # The first pass overwrites unless MMA2a already seeded kt.
                     first = split == 0 and kp == 0
@@ -548,12 +549,12 @@ class _AffineSummaryFwdOp:
                         mma_kt,
                         t_kt_acc[None, None, None, ktd.index],
                         t_kg_a[None, None, kp, kgh.index],
-                        t_tmpb_b[None, None, kp, split],
+                        t_tmpb_b[None, None, kp, tmpbh.index],
                         t_kt_acc[None, None, None, ktd.index],
                     )
+                tmpbh.release()
             ktd.commit()
             kgh.release()
-            tmpbh.release()
 
     @cute.jit
     def run_state(
@@ -632,20 +633,25 @@ class _AffineSummaryFwdOp:
 
         for _ct in cutlass.range(0, num_chunks, unroll=0):
             # ---- Phase 1: R2S X hi/lo → sXb (B operand for MMA1) ----
+            # Publish the hi half as soon as it exists so MMA1 starts its first
+            # pass while the lo residual is still being formed and stored.
             xbh = pxb_P.acquire_and_advance()
             st_hi = cute.make_rmem_tensor(st.shape, self.io_type)
             st_hi.store(st.load().to(self.io_type))
+            cute.copy(
+                tc_r2s_xb,
+                tc_r2s_xb.retile(st_hi),
+                thr_r2s_xb.partition_D(sXb_store[(None, None, xbh.index)]),
+            )
+            cute.arch.fence_proxy("async.shared", space="cta")
+            xbh.commit()
+            xbh = pxb_P.acquire_and_advance()
             st_lo = cute.make_rmem_tensor(st.shape, self.io_type)
             st_lo.store((st.load() - st_hi.load().to(Float32)).to(self.io_type))
             cute.copy(
                 tc_r2s_xb,
-                tc_r2s_xb.retile(st_hi),
-                thr_r2s_xb.partition_D(sXb_store[(None, None, 0)]),
-            )
-            cute.copy(
-                tc_r2s_xb,
                 tc_r2s_xb.retile(st_lo),
-                thr_r2s_xb.partition_D(sXb_store[(None, None, 1)]),
+                thr_r2s_xb.partition_D(sXb_store[(None, None, xbh.index)]),
             )
             cute.arch.fence_proxy("async.shared", space="cta")
             xbh.commit()
@@ -664,17 +670,20 @@ class _AffineSummaryFwdOp:
                 tmp[ei] = Float32(0.0) - wx_reg[ei]
             tmp_hi = cute.make_rmem_tensor(tmp.shape, self.io_type)
             tmp_hi.store(tmp.load().to(self.io_type))
+            cute.copy(
+                tc_r2s_tmpb,
+                tc_r2s_tmpb.retile(tmp_hi),
+                thr_r2s_tmpb.partition_D(sTmpb_store[(None, None, tmpbh.index)]),
+            )
+            cute.arch.fence_proxy("async.shared", space="cta")
+            tmpbh.commit()
+            tmpbh = ptmpb_P.acquire_and_advance()
             tmp_lo = cute.make_rmem_tensor(tmp.shape, self.io_type)
             tmp_lo.store((tmp.load() - tmp_hi.load().to(Float32)).to(self.io_type))
             cute.copy(
                 tc_r2s_tmpb,
-                tc_r2s_tmpb.retile(tmp_hi),
-                thr_r2s_tmpb.partition_D(sTmpb_store[(None, None, 0)]),
-            )
-            cute.copy(
-                tc_r2s_tmpb,
                 tc_r2s_tmpb.retile(tmp_lo),
-                thr_r2s_tmpb.partition_D(sTmpb_store[(None, None, 1)]),
+                thr_r2s_tmpb.partition_D(sTmpb_store[(None, None, tmpbh.index)]),
             )
             cute.arch.fence_proxy("async.shared", space="cta")
             tmpbh.commit()
@@ -785,17 +794,17 @@ class _AffineSummaryFwdOp:
             barrier_storage=sm.bar_gk.data_ptr(),
         ).make_participants()
 
-        # X snapshot → MMA1 (AsyncUmma, 1 stage covering both hi/lo halves)
+        # X snapshot → MMA1 (AsyncUmma, one stage per hi/lo half)
         pxb_P, pxb_C = pipeline.PipelineAsyncUmma.create(
-            num_stages=1,
+            num_stages=2,
             producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, n_cuda),
             consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
             barrier_storage=sm.bar_xb.data_ptr(),
         ).make_participants()
 
-        # Tmp → MMA2 (AsyncUmma, 1 stage covering both hi/lo halves)
+        # Tmp → MMA2 (AsyncUmma, one stage per hi/lo half)
         ptmpb_P, ptmpb_C = pipeline.PipelineAsyncUmma.create(
-            num_stages=1,
+            num_stages=2,
             producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, n_cuda),
             consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
             barrier_storage=sm.bar_tmpb.data_ptr(),

--- a/attn_gym/linear/_delta_rule/cute/affine_summary_rev.py
+++ b/attn_gym/linear/_delta_rule/cute/affine_summary_rev.py
@@ -269,8 +269,8 @@ class BlackwellDeltaAffineSummaryRev:
             self.io_type,
             self.k_depth,
         )
-        # B operands hold hi/lo halves of the FP32 state and dv tiles; the two
-        # "stages" are the two accumulate passes of one MMA, not a pipeline ring.
+        # B operands hold hi/lo halves of the FP32 state and dv tiles. Each half is
+        # one pipeline stage consumed by one accumulate pass of the same MMA.
         s_state = sm100_utils.make_smem_layout_b(
             mma_dv,
             self.dv_tile,
@@ -414,10 +414,10 @@ class BlackwellDeltaAffineSummaryRev:
             bar_aqk: cute.struct.MemRange[Int64, self.aqk_depth * 2]
             bar_gate: cute.struct.MemRange[Int64, self.gate_depth * 2]
             bar_gate_ready: cute.struct.MemRange[Int64, self.gate_depth * 2]
-            bar_state: cute.struct.MemRange[Int64, 2]
+            bar_state: cute.struct.MemRange[Int64, 2 * 2]
             bar_dv: cute.struct.MemRange[Int64, self.dv_acc_depth * 2]
             bar_qdo: cute.struct.MemRange[Int64, self.qdo_acc_depth * 2]
-            bar_dv_operand: cute.struct.MemRange[Int64, 2]
+            bar_dv_operand: cute.struct.MemRange[Int64, 2 * 2]
             bar_wdv: cute.struct.MemRange[Int64, self.wdv_acc_depth * 2]
             tmem_buf: Int32
             sK: cute.struct.Align[
@@ -567,23 +567,28 @@ class BlackwellDeltaAffineSummaryRev:
                     state[element] = Float32(0.0)
 
             for _chunk in cutlass.range(chunks, unroll=0):
-                state_handle = state_producer.acquire_and_advance()
+                # Publish the hi half as soon as it exists so MMA1 starts its first
+                # pass while the lo residual is still being formed and stored.
+                hi_handle = state_producer.acquire_and_advance()
                 state_hi = cute.make_rmem_tensor(state.shape, self.io_type)
                 state_hi.store(state.load().to(self.io_type))
+                cute.copy(
+                    r2s_state,
+                    r2s_state.retile(state_hi),
+                    r2s_state_slice.partition_D(s_state_store[(None, None, hi_handle.index)]),
+                )
+                cute.arch.fence_view_async_shared()
+                hi_handle.commit()
+                lo_handle = state_producer.acquire_and_advance()
                 state_lo = cute.make_rmem_tensor(state.shape, self.io_type)
                 state_lo.store((state.load() - state_hi.load().to(Float32)).to(self.io_type))
                 cute.copy(
                     r2s_state,
-                    r2s_state.retile(state_hi),
-                    r2s_state_slice.partition_D(s_state_store[(None, None, 0)]),
-                )
-                cute.copy(
-                    r2s_state,
                     r2s_state.retile(state_lo),
-                    r2s_state_slice.partition_D(s_state_store[(None, None, 1)]),
+                    r2s_state_slice.partition_D(s_state_store[(None, None, lo_handle.index)]),
                 )
                 cute.arch.fence_view_async_shared()
-                state_handle.commit()
+                lo_handle.commit()
 
                 dv_handle = dv_consumer.wait_and_advance()
                 dv = cute.make_rmem_tensor(dv_coordinates.shape, self.acc_type)
@@ -595,23 +600,26 @@ class BlackwellDeltaAffineSummaryRev:
                 cute.arch.fence_view_async_tmem_load()
                 dv_handle.release()
 
-                dv_operand_handle = dv_operand_producer.acquire_and_advance()
+                hi_handle = dv_operand_producer.acquire_and_advance()
                 dv_hi = cute.make_rmem_tensor(dv.shape, self.io_type)
                 dv_hi.store(dv.load().to(self.io_type))
+                cute.copy(
+                    r2s_dv,
+                    r2s_dv.retile(dv_hi),
+                    r2s_dv_slice.partition_D(s_dv_store[(None, None, hi_handle.index)]),
+                )
+                cute.arch.fence_view_async_shared()
+                hi_handle.commit()
+                lo_handle = dv_operand_producer.acquire_and_advance()
                 dv_lo = cute.make_rmem_tensor(dv.shape, self.io_type)
                 dv_lo.store((dv.load() - dv_hi.load().to(Float32)).to(self.io_type))
                 cute.copy(
                     r2s_dv,
-                    r2s_dv.retile(dv_hi),
-                    r2s_dv_slice.partition_D(s_dv_store[(None, None, 0)]),
-                )
-                cute.copy(
-                    r2s_dv,
                     r2s_dv.retile(dv_lo),
-                    r2s_dv_slice.partition_D(s_dv_store[(None, None, 1)]),
+                    r2s_dv_slice.partition_D(s_dv_store[(None, None, lo_handle.index)]),
                 )
                 cute.arch.fence_view_async_shared()
-                dv_operand_handle.commit()
+                lo_handle.commit()
 
                 gate_handle = gate_consumer.wait_and_advance()
                 for element in cutlass.range(cute.size(state), unroll_full=True):
@@ -864,31 +872,16 @@ class BlackwellDeltaAffineSummaryRev:
             has_source = column_tile < VAL_DIM // self.BN
 
             for _chunk in cutlass.range(chunks, unroll=0):
-                state_handle = state_consumer.wait_and_advance()
-                k_handle = k_consumer.wait_and_advance()
+                # The source products do not depend on the state, so they run while
+                # the state warps are still producing the X snapshot: Aqk^T dO seeds
+                # the dv accumulator and qg^T dO completes off the recurrence chain.
                 dv_handle = dv_producer.acquire_and_advance()
-                for split in cutlass.range_constexpr(2):
-                    for k_block in cutlass.range(cute.size(t_k, mode=[2]), unroll_full=True):
-                        mma_dv.set(
-                            tcgen05.Field.ACCUMULATE,
-                            cutlass.Boolean(split != 0 or k_block != 0),
-                        )
-                        cute.gemm(
-                            mma_dv,
-                            t_dv_acc[None, None, None, dv_handle.index],
-                            t_k[None, None, k_block, k_handle.index],
-                            t_state[None, None, k_block, split],
-                            t_dv_acc[None, None, None, dv_handle.index],
-                        )
-                k_handle.release()
-                state_handle.release()
-
                 if has_source:
                     q_handle = q_consumer.wait_and_advance()
                     do_handle = do_consumer.wait_and_advance()
                     aqk_handle = aqk_consumer.wait_and_advance()
                     for k_block in cutlass.range(cute.size(t_aqk, mode=[2]), unroll_full=True):
-                        mma_aqdo.set(tcgen05.Field.ACCUMULATE, cutlass.Boolean(True))
+                        mma_aqdo.set(tcgen05.Field.ACCUMULATE, cutlass.Boolean(k_block != 0))
                         cute.gemm(
                             mma_aqdo,
                             t_dv_acc[None, None, None, dv_handle.index],
@@ -897,7 +890,6 @@ class BlackwellDeltaAffineSummaryRev:
                             t_dv_acc[None, None, None, dv_handle.index],
                         )
                     aqk_handle.release()
-                    dv_handle.commit()
 
                     qdo_handle = qdo_producer.acquire_and_advance()
                     for k_block in cutlass.range(cute.size(t_q, mode=[2]), unroll_full=True):
@@ -912,13 +904,32 @@ class BlackwellDeltaAffineSummaryRev:
                     qdo_handle.commit()
                     q_handle.release()
                     do_handle.release()
-                else:
-                    dv_handle.commit()
 
-                dv_operand_handle = dv_operand_consumer.wait_and_advance()
+                k_handle = k_consumer.wait_and_advance()
+                for split in cutlass.range_constexpr(2):
+                    # Each hi/lo half is one pipeline stage, published separately.
+                    state_handle = state_consumer.wait_and_advance()
+                    for k_block in cutlass.range(cute.size(t_k, mode=[2]), unroll_full=True):
+                        # The first pass overwrites unless Aqk^T dO already seeded dv.
+                        mma_dv.set(
+                            tcgen05.Field.ACCUMULATE,
+                            cutlass.Boolean(split != 0) | (k_block != 0) | has_source,
+                        )
+                        cute.gemm(
+                            mma_dv,
+                            t_dv_acc[None, None, None, dv_handle.index],
+                            t_k[None, None, k_block, k_handle.index],
+                            t_state[None, None, k_block, state_handle.index],
+                            t_dv_acc[None, None, None, dv_handle.index],
+                        )
+                    state_handle.release()
+                k_handle.release()
+                dv_handle.commit()
+
                 w_handle = w_consumer.wait_and_advance()
                 wdv_handle = wdv_producer.acquire_and_advance()
                 for split in cutlass.range_constexpr(2):
+                    dv_operand_handle = dv_operand_consumer.wait_and_advance()
                     for k_block in cutlass.range(cute.size(t_w, mode=[2]), unroll_full=True):
                         mma_wdv.set(
                             tcgen05.Field.ACCUMULATE,
@@ -928,12 +939,12 @@ class BlackwellDeltaAffineSummaryRev:
                             mma_wdv,
                             t_wdv_acc[None, None, None, wdv_handle.index],
                             t_w[None, None, k_block, w_handle.index],
-                            t_dv[None, None, k_block, split],
+                            t_dv[None, None, k_block, dv_operand_handle.index],
                             t_wdv_acc[None, None, None, wdv_handle.index],
                         )
+                    dv_operand_handle.release()
                 wdv_handle.commit()
                 w_handle.release()
-                dv_operand_handle.release()
 
             tile_index = tile_index + 1
             has_work = tile_index < iterations
@@ -990,9 +1001,9 @@ class BlackwellDeltaAffineSummaryRev:
             tx_count=self.k_bytes,
             barrier_storage=storage.bar_k.data_ptr(),
         ).make_participants()
-        # X snapshot → MMA1 (AsyncUmma, 1 stage covering both hi/lo halves)
+        # X snapshot → MMA1 (AsyncUmma, one stage per hi/lo half)
         state_producer, state_consumer = pipeline.PipelineAsyncUmma.create(
-            num_stages=1,
+            num_stages=2,
             producer_group=pipeline.CooperativeGroup(
                 pipeline.Agent.Thread,
                 self.WARP_SIZE * len(self.STATE_WARP_IDS),
@@ -1039,9 +1050,9 @@ class BlackwellDeltaAffineSummaryRev:
             tx_count=self.w_bytes,
             barrier_storage=storage.bar_w.data_ptr(),
         ).make_participants()
-        # dv snapshot → MMA4 (AsyncUmma, 1 stage covering both hi/lo halves)
+        # dv snapshot → MMA4 (AsyncUmma, one stage per hi/lo half)
         dv_operand_producer, dv_operand_consumer = pipeline.PipelineAsyncUmma.create(
-            num_stages=1,
+            num_stages=2,
             producer_group=pipeline.CooperativeGroup(
                 pipeline.Agent.Thread,
                 self.WARP_SIZE * len(self.STATE_WARP_IDS),

--- a/attn_gym/linear/_delta_rule/cute/affine_summary_rev.py
+++ b/attn_gym/linear/_delta_rule/cute/affine_summary_rev.py
@@ -16,6 +16,11 @@ hold the FP32 state in registers, one warp issues TMA loads, one computes gate
 exponentials, and one issues the four UMMA operations. Bias tiles load the local
 output-gradient sources; transition tiles skip those streams entirely. Only the
 final FP32 summary is written to global memory.
+
+The fp32-valued MMA B operands (state ``X`` and the corrected write gradient
+``dv``) are split into hi/lo halves of the I/O dtype and accumulated in two UMMA
+passes, exactly as the forward summary treats ``X`` and ``wx``, so the reverse
+transition is the transpose of the map the forward summary actually evaluates.
 """
 
 # NOTE: no `from __future__ import annotations` — cute.struct requires
@@ -264,17 +269,19 @@ class BlackwellDeltaAffineSummaryRev:
             self.io_type,
             self.k_depth,
         )
+        # B operands hold hi/lo halves of the FP32 state and dv tiles; the two
+        # "stages" are the two accumulate passes of one MMA, not a pipeline ring.
         s_state = sm100_utils.make_smem_layout_b(
             mma_dv,
             self.dv_tile,
             self.io_type,
-            1,
+            2,
         )
         s_state_store = sm100_utils.make_smem_layout_epi(
             self.io_type,
             utils.LayoutEnum.COL_MAJOR,
             (self.BK, self.BN),
-            1,
+            2,
         )
         s_q = sm100_utils.make_smem_layout_a(
             mma_qdo,
@@ -298,13 +305,13 @@ class BlackwellDeltaAffineSummaryRev:
             mma_wdv,
             self.wdv_tile,
             self.io_type,
-            1,
+            2,
         )
         s_dv_store = sm100_utils.make_smem_layout_epi(
             self.io_type,
             utils.LayoutEnum.COL_MAJOR,
             (self.BT, self.BN),
-            1,
+            2,
         )
         s_aqk = sm100_utils.make_smem_layout_a(
             mma_aqdo,
@@ -561,12 +568,19 @@ class BlackwellDeltaAffineSummaryRev:
 
             for _chunk in cutlass.range(chunks, unroll=0):
                 state_handle = state_producer.acquire_and_advance()
-                state_io = cute.make_rmem_tensor(state.shape, self.io_type)
-                state_io.store(state.load().to(self.io_type))
+                state_hi = cute.make_rmem_tensor(state.shape, self.io_type)
+                state_hi.store(state.load().to(self.io_type))
+                state_lo = cute.make_rmem_tensor(state.shape, self.io_type)
+                state_lo.store((state.load() - state_hi.load().to(Float32)).to(self.io_type))
                 cute.copy(
                     r2s_state,
-                    r2s_state.retile(state_io),
+                    r2s_state.retile(state_hi),
                     r2s_state_slice.partition_D(s_state_store[(None, None, 0)]),
+                )
+                cute.copy(
+                    r2s_state,
+                    r2s_state.retile(state_lo),
+                    r2s_state_slice.partition_D(s_state_store[(None, None, 1)]),
                 )
                 cute.arch.fence_view_async_shared()
                 state_handle.commit()
@@ -582,12 +596,19 @@ class BlackwellDeltaAffineSummaryRev:
                 dv_handle.release()
 
                 dv_operand_handle = dv_operand_producer.acquire_and_advance()
-                dv_io = cute.make_rmem_tensor(dv.shape, self.io_type)
-                dv_io.store(dv.load().to(self.io_type))
+                dv_hi = cute.make_rmem_tensor(dv.shape, self.io_type)
+                dv_hi.store(dv.load().to(self.io_type))
+                dv_lo = cute.make_rmem_tensor(dv.shape, self.io_type)
+                dv_lo.store((dv.load() - dv_hi.load().to(Float32)).to(self.io_type))
                 cute.copy(
                     r2s_dv,
-                    r2s_dv.retile(dv_io),
+                    r2s_dv.retile(dv_hi),
                     r2s_dv_slice.partition_D(s_dv_store[(None, None, 0)]),
+                )
+                cute.copy(
+                    r2s_dv,
+                    r2s_dv.retile(dv_lo),
+                    r2s_dv_slice.partition_D(s_dv_store[(None, None, 1)]),
                 )
                 cute.arch.fence_view_async_shared()
                 dv_operand_handle.commit()
@@ -828,7 +849,11 @@ class BlackwellDeltaAffineSummaryRev:
         w_consumer,
         wdv_producer,
     ):
-        """Issue the four UMMA operations for each reverse chunk."""
+        """Issue the four UMMA operations for each reverse chunk.
+
+        MMA1 (``kg @ X``) and MMA4 (``w^T @ dv``) each run two accumulate passes
+        over the hi/lo halves of their fp32-valued B operand.
+        """
         cute.arch.setmaxregister_decrease(self.aux_regs)
         mma_dv, mma_qdo, mma_aqdo, mma_wdv = mmas
 
@@ -842,15 +867,19 @@ class BlackwellDeltaAffineSummaryRev:
                 state_handle = state_consumer.wait_and_advance()
                 k_handle = k_consumer.wait_and_advance()
                 dv_handle = dv_producer.acquire_and_advance()
-                for k_block in cutlass.range(cute.size(t_k, mode=[2]), unroll_full=True):
-                    mma_dv.set(tcgen05.Field.ACCUMULATE, cutlass.Boolean(k_block != 0))
-                    cute.gemm(
-                        mma_dv,
-                        t_dv_acc[None, None, None, dv_handle.index],
-                        t_k[None, None, k_block, k_handle.index],
-                        t_state[None, None, k_block, state_handle.index],
-                        t_dv_acc[None, None, None, dv_handle.index],
-                    )
+                for split in cutlass.range_constexpr(2):
+                    for k_block in cutlass.range(cute.size(t_k, mode=[2]), unroll_full=True):
+                        mma_dv.set(
+                            tcgen05.Field.ACCUMULATE,
+                            cutlass.Boolean(split != 0 or k_block != 0),
+                        )
+                        cute.gemm(
+                            mma_dv,
+                            t_dv_acc[None, None, None, dv_handle.index],
+                            t_k[None, None, k_block, k_handle.index],
+                            t_state[None, None, k_block, split],
+                            t_dv_acc[None, None, None, dv_handle.index],
+                        )
                 k_handle.release()
                 state_handle.release()
 
@@ -889,15 +918,19 @@ class BlackwellDeltaAffineSummaryRev:
                 dv_operand_handle = dv_operand_consumer.wait_and_advance()
                 w_handle = w_consumer.wait_and_advance()
                 wdv_handle = wdv_producer.acquire_and_advance()
-                for k_block in cutlass.range(cute.size(t_w, mode=[2]), unroll_full=True):
-                    mma_wdv.set(tcgen05.Field.ACCUMULATE, cutlass.Boolean(k_block != 0))
-                    cute.gemm(
-                        mma_wdv,
-                        t_wdv_acc[None, None, None, wdv_handle.index],
-                        t_w[None, None, k_block, w_handle.index],
-                        t_dv[None, None, k_block, dv_operand_handle.index],
-                        t_wdv_acc[None, None, None, wdv_handle.index],
-                    )
+                for split in cutlass.range_constexpr(2):
+                    for k_block in cutlass.range(cute.size(t_w, mode=[2]), unroll_full=True):
+                        mma_wdv.set(
+                            tcgen05.Field.ACCUMULATE,
+                            cutlass.Boolean(split != 0 or k_block != 0),
+                        )
+                        cute.gemm(
+                            mma_wdv,
+                            t_wdv_acc[None, None, None, wdv_handle.index],
+                            t_w[None, None, k_block, w_handle.index],
+                            t_dv[None, None, k_block, split],
+                            t_wdv_acc[None, None, None, wdv_handle.index],
+                        )
                 wdv_handle.commit()
                 w_handle.release()
                 dv_operand_handle.release()
@@ -957,6 +990,7 @@ class BlackwellDeltaAffineSummaryRev:
             tx_count=self.k_bytes,
             barrier_storage=storage.bar_k.data_ptr(),
         ).make_participants()
+        # X snapshot → MMA1 (AsyncUmma, 1 stage covering both hi/lo halves)
         state_producer, state_consumer = pipeline.PipelineAsyncUmma.create(
             num_stages=1,
             producer_group=pipeline.CooperativeGroup(
@@ -1005,6 +1039,7 @@ class BlackwellDeltaAffineSummaryRev:
             tx_count=self.w_bytes,
             barrier_storage=storage.bar_w.data_ptr(),
         ).make_participants()
+        # dv snapshot → MMA4 (AsyncUmma, 1 stage covering both hi/lo halves)
         dv_operand_producer, dv_operand_consumer = pipeline.PipelineAsyncUmma.create(
             num_stages=1,
             producer_group=pipeline.CooperativeGroup(

--- a/attn_gym/linear/_delta_rule/triton/affine_summary_rev.py
+++ b/attn_gym/linear/_delta_rule/triton/affine_summary_rev.py
@@ -10,6 +10,11 @@ Each program keeps one FP32 ``[128, BN]`` augmented-state tile resident while
 scanning complete BT64 chunks backward. Raw compact-layout pointers avoid host
 tensor descriptors, allocations, and synchronization in the launch path, so a
 warmed specialization can be captured directly by a CUDA Graph.
+
+The fp32-valued ``tl.dot`` operands (state and corrected write gradient) are
+split into hi/lo halves of the I/O dtype and accumulated in two passes, exactly
+as the forward summary treats its state and residual, so the reverse transition
+is the transpose of the map the forward summary actually evaluates.
 """
 
 from __future__ import annotations
@@ -79,7 +84,10 @@ def affine_summary_rev_kernel(
             (H * K, K, 1),
         )
         kg_tile = tl.load(kg + token_key_offset)
-        corrected = tl.dot(kg_tile, state.to(kg_tile.dtype))
+        state_hi = state.to(kg_tile.dtype)
+        state_lo = (state - state_hi.to(tl.float32)).to(kg_tile.dtype)
+        corrected = tl.dot(kg_tile, state_hi)
+        corrected = tl.dot(kg_tile, state_lo, acc=corrected)
 
         dout_tile = tl.load(
             dout
@@ -108,7 +116,10 @@ def affine_summary_rev_kernel(
         qg_tile = tl.load(qg + token_key_offset)
         state += tl.dot(tl.trans(qg_tile), dout_tile) * scale
         w_tile = tl.load(w + token_key_offset)
-        state -= tl.dot(tl.trans(w_tile), corrected.to(w_tile.dtype))
+        corrected_hi = corrected.to(w_tile.dtype)
+        corrected_lo = (corrected - corrected_hi.to(tl.float32)).to(w_tile.dtype)
+        state -= tl.dot(tl.trans(w_tile), corrected_hi)
+        state -= tl.dot(tl.trans(w_tile), corrected_lo)
 
     out_offset = ptr_offset(
         (head, column[None, :], key[:, None]),

--- a/test/test_delta_affine_summary.py
+++ b/test/test_delta_affine_summary.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+from functools import partial, reduce
+from itertools import pairwise
+
 import pytest
 import torch
 import torch.nn.functional as F
 
 pytest.importorskip("cutlass")
 
+import attn_gym.linear._delta_rule.cute.affine_summary_fwd as native_fwd
+import attn_gym.linear._delta_rule.cute.affine_summary_rev as native_rev
 import attn_gym.linear._delta_rule.triton.affine_summary_fwd as portable_fwd
 import attn_gym.linear._delta_rule.triton.affine_summary_rev as portable_rev
 from attn_gym.linear._delta_rule.cute import build_state_grad_summary, build_state_summary
@@ -18,17 +23,51 @@ pytestmark = pytest.mark.skipif(
     reason="the affine summaries require CUDA capability 8.0 or newer",
 )
 
+VALUE_DIM = 128
 
-def make_summary_inputs(seed: int):
-    """Create one nontrivial BF16 input set for summary infrastructure tests."""
+
+@pytest.fixture(params=["routed", "portable"])
+def summary_backend(request, monkeypatch):
+    """Run the routed backend, or force the public wrappers onto the portable Triton path."""
+    if request.param == "portable":
+        if not is_sm100_kda_capability(torch.cuda.get_device_capability()):
+            pytest.skip("the routed backend is already the portable Triton path")
+        for module in (native_fwd, native_rev):
+            monkeypatch.setattr(module, "is_sm100_kda_capability", lambda _capability: False)
+
+
+def compose_summaries(first: torch.Tensor, second: torch.Tensor) -> torch.Tensor:
+    """Compose V-first packed summaries so ``state @ R1 + b1`` feeds ``@ R2 + b2``."""
+    bias_1, transition_1 = first[:, :VALUE_DIM], first[:, VALUE_DIM:]
+    bias_2, transition_2 = second[:, :VALUE_DIM], second[:, VALUE_DIM:]
+    return torch.cat((bias_1 @ transition_2 + bias_2, transition_1 @ transition_2), dim=1)
+
+
+def shard_summaries(summary, tensors, boundaries: tuple[int, ...]) -> list[torch.Tensor]:
+    """Summarize each token shard delimited by ``boundaries``, in token order."""
+    endpoints = (0, *boundaries, tensors[0].shape[1])
+    return [
+        summary(*(tensor[:, start:stop] for tensor in tensors))
+        for start, stop in pairwise(endpoints)
+    ]
+
+
+def make_summary_inputs(
+    seed: int,
+    dtype: torch.dtype = torch.bfloat16,
+    tokens: int = 64,
+    heads: int = 1,
+    divisor: float = 32,
+) -> tuple[torch.Tensor, ...]:
+    """Create one nontrivial deterministic input set for both affine summaries."""
     torch.manual_seed(seed)
-    shape = (1, 64, 1, 128)
-    qg = torch.randn(shape, dtype=torch.bfloat16, device="cuda") / 32
-    kg = torch.randn_like(qg) / 32
-    w = torch.randn_like(qg) / 32
-    u = torch.randn_like(qg) / 32
-    dout = torch.randn_like(qg) / 32
-    aqk = torch.randn(1, 64, 1, 64, dtype=torch.bfloat16, device="cuda") / 32
+    shape = (1, tokens, heads, 128)
+    qg = torch.randn(shape, dtype=dtype, device="cuda") / divisor
+    kg = torch.randn_like(qg) / divisor
+    w = torch.randn_like(qg) / divisor
+    u = torch.randn_like(qg) / divisor
+    dout = torch.randn_like(qg) / divisor
+    aqk = torch.randn(1, tokens, heads, 64, dtype=dtype, device="cuda") / divisor
     cumulative_gate = -torch.rand(shape, dtype=torch.float32, device="cuda") / 8
     return qg, kg, w, u, dout, aqk, cumulative_gate
 
@@ -297,6 +336,96 @@ def test_affine_summary_selector_variants_and_persistent_work():
         state_grad_summary_reference(qg, kg, w, dout, aqk, cumulative_gate, 128**-0.5),
         atol=2e-4,
         rtol=2e-4,
+    )
+
+
+@pytest.mark.usefixtures("summary_backend")
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_reverse_summary_cancels_exactly_like_forward(dtype):
+    """Reverse must split its FP32 state hi/lo like forward so exact cancellations survive.
+
+    Chunk 0 zeroes transition entry (0, 0); chunk 1 then multiplies by ``-eps``, where
+    ``1 + eps`` is FP32-exact but rounds to ``1`` in ``dtype``. Forward returns an exact
+    zero; a reverse scan that narrows its state once returns ``eps`` instead.
+    """
+    eps = 2.0**-9 if dtype is torch.bfloat16 else 2.0**-12
+    shape = (1, 128, 1, 128)
+    zeros = torch.zeros(shape, dtype=dtype, device="cuda")
+    kg = zeros.clone()
+    w = zeros.clone()
+    kg[0, 0, 0, 0] = 1
+    w[0, 0, 0, 0] = 1
+    kg[0, 64, 0, 0] = 1
+    w[0, 64, 0, 0] = -eps
+    aqk = torch.zeros(1, 128, 1, 64, dtype=dtype, device="cuda")
+    cumulative_gate = torch.zeros(shape, dtype=torch.float32, device="cuda")
+
+    expected = torch.zeros(1, 256, 128, dtype=torch.float32, device="cuda")
+    expected[0, VALUE_DIM:] = torch.eye(128, device="cuda")
+    expected[0, VALUE_DIM, 0] = 0
+
+    torch.testing.assert_close(
+        build_state_summary(kg, w, zeros, cumulative_gate), expected, rtol=0, atol=0
+    )
+    torch.testing.assert_close(
+        build_state_grad_summary(zeros, kg, w, zeros, aqk, cumulative_gate, 1.0),
+        expected,
+        rtol=0,
+        atol=0,
+    )
+
+
+@pytest.mark.usefixtures("summary_backend")
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("tokens,heads", [(256, 2), (2048, 1), (512, 16)])
+def test_reverse_transition_is_adjoint_of_forward_transition(dtype, tokens, heads):
+    """Bound ``<state @ R, cotangent> - <state, cotangent @ R_rev>`` for every pair.
+
+    The operator norm of ``R - R_rev^T`` bounds that defect relative to the Frobenius
+    norms of any state/cotangent pair. A reverse scan that narrows its state once lands
+    at 5e-4 or worse on these shapes; the hi/lo scan stays below 1e-4.
+    """
+    qg, kg, w, u, dout, aqk, cumulative_gate = make_summary_inputs(
+        37, dtype, tokens, heads, divisor=16
+    )
+
+    transition = build_state_summary(kg, w, u, cumulative_gate)[:, VALUE_DIM:]
+    reverse_transition = build_state_grad_summary(
+        qg, kg, w, dout, aqk, cumulative_gate, 128**-0.5
+    )[:, VALUE_DIM:]
+
+    adjoint_defect = torch.linalg.matrix_norm(
+        transition - reverse_transition.transpose(-2, -1), ord=2
+    )
+    assert (adjoint_defect <= 2e-4).all(), adjoint_defect
+
+
+@pytest.mark.usefixtures("summary_backend")
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("boundaries", [(256,), (64, 320), (128, 256, 384)])
+def test_affine_summaries_are_invariant_to_shard_boundaries(dtype, boundaries):
+    """Composing per-shard summaries must match the unsharded scan in both directions."""
+    qg, kg, w, u, dout, aqk, cumulative_gate = make_summary_inputs(
+        41, dtype, tokens=512, heads=2, divisor=16
+    )
+    reverse_summary = partial(build_state_grad_summary, scale=128**-0.5)
+
+    forward_shards = shard_summaries(build_state_summary, (kg, w, u, cumulative_gate), boundaries)
+    torch.testing.assert_close(
+        reduce(compose_summaries, forward_shards),
+        build_state_summary(kg, w, u, cumulative_gate),
+        atol=2e-5,
+        rtol=2e-5,
+    )
+    # The cotangent flows through the last shard first.
+    reverse_shards = shard_summaries(
+        reverse_summary, (qg, kg, w, dout, aqk, cumulative_gate), boundaries
+    )
+    torch.testing.assert_close(
+        reduce(compose_summaries, reversed(reverse_shards)),
+        reverse_summary(qg, kg, w, dout, aqk, cumulative_gate),
+        atol=2e-5,
+        rtol=2e-5,
     )
 
 


### PR DESCRIPTION
## Human Note

## Agent note

The forward affine summary feeds its FP32 state and residual to the tensor cores as high/low
bf16/fp16 pairs (two accumulate passes per MMA), so its transition is accurate to roughly 16 to 22
mantissa bits. Both reverse summaries narrowed the corresponding FP32 quantities once: the state
before `kg @ X` and the corrected write gradient before `w^T @ dv`. The reverse was therefore not
the transpose of the numerical map forward evaluates. A two-chunk case with `kg[0] = w[0] = 1`,
`kg[64] = 1`, `w[64] = -eps` (where `1 + eps` is FP32-exact but rounds to 1 in the IO dtype) gives
a forward transition entry of exactly 0 while the reverse returned `eps`; on random inputs the
transpose mismatch was ~6e-4 (bf16) / ~8e-5 (fp16), and reverse shard composition drifted from
the unsharded scan by the same amount while the forward stayed at ~1e-6.

**Commit 1** makes both reverse backends use the same hi/lo decomposition as forward at both
narrowing points. The CuTe kernel doubles the `state`/`dv` B-operand SMEM to hold the two halves
and runs the `dv` and `wdv` UMMAs as two accumulate passes, mirroring the forward kernel; the
Triton kernel adds the second `tl.dot` per product. No metadata or layout format changes. The
transpose mismatch drops to ~1e-6 and reverse shard-composition error now matches forward.

**Commit 2** recovers most of the resulting latency with two scheduling changes found by IKET
intra-kernel profiling (transformer-nuggets pipeline profiler): `Aqk^T dO` seeds the dv
accumulator and `qg^T dO` is issued before the MMA warp waits for the state snapshot (they do not
depend on it), and each hi/lo half gets its own pipeline stage so the hi pass starts while the
state warps are still forming lo. Profiled per-chunk chain: 900 ns (pre-fix) -> 1340 ns (commit 1)
-> 1090 ns (commit 2). No numerical-format change.

**Commit 3** applies the one-stage-per-half trick to the forward kernel as well; its output is
bitwise identical and it gets 8-11% faster.

Tests add the exact scalar cancellation regression, an adjoint check that bounds the operator
norm of `R - R_rev^T` at 2e-4 (old kernels sit at 5e-4 to 3e-2), and shard-boundary invariance
across two-, three-, and four-shard decompositions; each runs through the routed backend and, on
SM100, again with the public wrappers forced onto the portable Triton path.

## Performance

GB200 (nvidia-cutlass-dsl 4.7.1), bf16, warm fixed-pointer CUDA-event timing, median of 3
interleaved rounds (spread < 0.5 us). Reverse CuTe summary in us; "pre-fix" is `main`:

| T x H      | pre-fix | commit 1 | commit 2 | c2 vs c1 | c2 vs pre-fix |
|------------|--------:|---------:|---------:|---------:|--------------:|
| 4096 x 1   |    57.1 |     80.1 |     64.4 |    0.80x |         1.13x |
| 4096 x 8   |    58.2 |     81.5 |     66.0 |    0.81x |         1.13x |
| 16384 x 1  |   210.4 |    305.0 |    243.4 |    0.80x |         1.16x |
| 16384 x 16 |   254.8 |    394.2 |    331.8 |    0.84x |         1.30x |

Forward CuTe summary, commit 3 vs before (bitwise-identical output):

| T x H      | before | after | ratio |
|------------|-------:|------:|------:|
| 4096 x 1   |   82.2 |  75.7 | 0.92x |
| 16384 x 1  |  311.8 | 283.3 | 0.91x |
| 16384 x 16 |  313.5 | 286.2 | 0.91x |
| 16384 x 32 |  464.9 | 413.3 | 0.89x |

Portable Triton reverse: 1.33-1.41x vs pre-fix (commit 1 only; no scheduling change there). The
BN=16/32 tile selector still picks the faster width on both sides of its H boundary. A follow-up
experiment issuing `kg @ [X_hi | X_lo]` as one N=2*BN MMA was correct but not faster (the second
TMEM load + fp32 add per accumulator and the lost early-hi overlap cancel the halved issue count).

## Test Plan

```bash
pytest -n 6 test/test_delta_affine_summary.py test/test_kda_context_parallel.py
torchrun --standalone --nproc_per_node=2 examples/kda_context_parallel.py
torchrun --standalone --nproc_per_node=2 examples/kda_context_parallel.py --compute-dtype=float16 --cuda-graph
```
