### PR TITLE
Document Mega KDA gate range

### DIFF
--- a/attn_gym/linear/kda/api.py
+++ b/attn_gym/linear/kda/api.py
@@ -82,10 +82,13 @@ def chunk_kda(
         gate: Finite, nonpositive per-token natural-log decay shaped like ``q``. At
             each token the previous state is multiplied channelwise by ``exp(gate)``.
             Pass per-token values, not cumulative gates; chunking and log-base conversion
-            are internal. The fused chunk implementation requires values to remain in
-            approximately ``[-5.914, 0]`` for its FP32 intra-chunk rebase; this
-            implementation limit is not shared by reference or recurrent execution and
-            is documented rather than checked with a runtime tensor reduction.
+            are internal. The repo-local fused implementation requires approximately
+            ``[-5.914, 0]``. Mega BF16 instead requires every aligned 16-token
+            per-channel sum to exceed ``-126 * ln(2)``; a uniform
+            ``lower_bound >= -5.45`` is safe, including
+            the common ``-5`` bound. Mega stages these MMA operands in the Q/K dtype rather
+            than TF32, so Mega FP16 does not support usual model-range gates. These limits
+            are not checked at runtime and do not apply to reference or recurrent execution.
         beta: Per-token write gate shaped ``[B, T, H]``.
         initial_state: Starting recurrent state, with one ``[H, V, K]`` entry per
             logical sequence.

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -327,9 +327,12 @@ natural-log decay before any prefix sum. `chunk_kda` owns the natural-log-to-log
 conversion and its sequence-local BT64 cumulative sum; `recurrent_kda` performs only the
 conversion because recurrence consumes one token decay at a time. This keeps chunking out
 of model code and lets callers switch execution modes without changing gate
-representation. Custom producers should return finite, nonpositive values; the fused chunk
-backend additionally requires approximately `[-5.914, 0]`; this tensor-value range is
-not checked at runtime. The training example uses the Kimi-style FP32 transform
+representation. Custom producers should return finite, nonpositive values. The repo-local fused
+backend requires approximately `[-5.914, 0]`. Mega BF16 instead requires every aligned 16-token
+per-channel sum to exceed `-126 * ln(2)`; a uniform `lower_bound >= -5.45` is safe, including the
+common `-5` bound. Mega stages these MMA operands in the Q/K dtype rather than TF32, so Mega FP16 does
+not support usual model-range gates. These limits are not checked at runtime. The training example
+uses the Kimi-style FP32 transform
 `lower_bound * sigmoid(exp(A_log) * (raw_gate.float() + dt_bias))`, but that model policy is not
 part of the public KDA API.
 


### PR DESCRIPTION
## Summary

- document the BF16 gate-prefix range required by the Mega KDA backend
- clarify that the common `-5` lower bound is safe for its 16-token prefixes
- distinguish Mega's Q/K-dtype diagonal MMA operands from the repo-local TF32 path and warn that Mega FP16 does not support usual model-range gates

## Test plan

- `ruff format --check attn_gym/linear/kda/api.py`
- `git diff --check`

Documentation only; no runtime behavior changes.
