### PR TITLE
Fix Mega split-forward note margins, docs, and test coverage

### DIFF
--- a/attn_gym/linear/_delta_rule/mega/kernels/common/split_k.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/common/split_k.py
@@ -134,11 +134,11 @@ ORDER_CAPACITY = ORDER_THREADS * ORDER_ELEMS  # sort capacity (32 KB SMEM); past
 #   state; a rejected boundary just extends the open item, so a gate that never forgets yields the
 #   single uncut item, i.e. the serial kernel.
 #
-# This is a margin of bits past the output dtype's half-ulp. A rounding can flip only where
-# |H_window| < 2^-margin * |H_before| elementwise:
+# This is a margin of bits past the output dtype's relative half-ulp. A rounding can flip only
+# where |H_window| < 2^-margin * |H_before| elementwise:
 #     e^-10 = 2^-14.4
-#     bf16 half-ulp 2^-9  -> 5.4-bit margin
-#     fp16 half-ulp 2^-12 -> 2.4-bit margin
+#     bf16 half-ulp 2^-8  -> 6.4-bit margin
+#     fp16 half-ulp 2^-11 -> 3.4-bit margin
 DEFAULT_LOG2_THRESHOLD = -10.0 / math.log(2.0)  # e^-10, in log2 units
 RCP_LN2 = 1.4426950408889634  # 1/ln(2): natural-log gates -> the scan's log2 domain
 

--- a/attn_gym/linear/kda/api.py
+++ b/attn_gym/linear/kda/api.py
@@ -119,7 +119,7 @@ def chunk_kda(
         per logical sequence or ``None``.
     """
     selected_impl = resolve_impl(impl)
-    backend, split_backward, split_forward = resolve_kernel_options(kernel_options)
+    options = resolve_kernel_options(kernel_options)
     if selected_impl is Impl.REFERENCE:
         if fastmath:
             raise ValueError("fastmath applies only to impl='fused'")
@@ -138,7 +138,7 @@ def chunk_kda(
     )
     scale = resolve_scale(scale, q.shape[-1])
     if selected_impl is Impl.FUSED:
-        if backend == "mega":
+        if options.backend == "mega":
             return _mega_chunk_forward(
                 q,
                 k,
@@ -151,8 +151,8 @@ def chunk_kda(
                 output_final_state=output_final_state,
                 fastmath=fastmath,
                 autotune=autotune,
-                split_backward=split_backward,
-                split_forward=split_forward,
+                split_backward=options.split_backward,
+                split_forward=options.split_forward,
             )
         return _fused_chunk_forward(
             q,
@@ -218,8 +218,8 @@ def paged_chunk_kda(
         autotune: For the repo-local fused backend, benchmark candidate kernel
             configurations when true; Mega uses its fixed schedule.
         kernel_options: Backend-specific options. ``{"backend": "mega"}`` selects
-            the optional CuTeDSL 4.7 Mega backend. ``split_backward`` is not applicable
-            to this inference-only operation.
+            the optional CuTeDSL 4.7 Mega backend. ``split_backward`` and
+            ``split_forward`` are not supported by this paged operation.
 
     Returns:
         The output in ``q.dtype``. ``state_cache`` is advanced in place.
@@ -243,10 +243,10 @@ def paged_chunk_kda(
         state_indices,
         has_initial_state=has_initial_state,
     )
-    backend, split_backward, split_forward = resolve_kernel_options(kernel_options)
-    if split_backward or split_forward:
+    options = resolve_kernel_options(kernel_options)
+    if options.split_backward or options.split_forward:
         raise ValueError("split schedules are not supported by paged_chunk_kda")
-    if backend == "mega":
+    if options.backend == "mega":
         return _mega_paged_chunk_forward(
             q,
             k,

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -365,17 +365,18 @@ unsplit: one persistent work item per sequence and head, which leaves the GPU un
 long sequences at low head counts. FP16 and BF16 use exact backward execution by default; eligible
 packed no-state long contexts may use the Mega backward with one unsplit work item per sequence and
 head. Callers that guarantee normalized keys, post-sigmoid beta, and nonpositive decay increments may
-explicitly opt into approximate forgetting-horizon splitting with
-`kernel_options={"backend": "mega", "split_backward": True}` and/or `"split_forward": True`: a
-sequence is cut only where its cumulative decay has saturated below the kernel's threshold, and each
-cut item rebuilds its entry state from zero over a short warmup window. Gates that never forget yield
-no cuts and reproduce the unsplit result exactly; contracting gates produce results within the
-low-precision budget (bitwise identical in bf16 in practice) with several times the parallelism. The
-threshold is a margin of bits past the output dtype's half-ulp, not an underflow; see
-`NOTE [Forgetting Horizon]` in
-`attn_gym/linear/_delta_rule/mega/kernels/common/split_k.py` for the exact statement. The
-implementation chooses the split count from the input geometry; no public split-size knob is exposed.
-Split schedules currently require a no-state call, so context parallelism never uses them. `paged_chunk_kda(..., kernel_options={"backend": "mega"})` uses the
+set `split_backward` and/or `split_forward` to `True` in a Mega `kernel_options` mapping to opt into
+approximate forgetting-horizon splitting: a sequence is cut only where its cumulative decay has
+crossed the kernel's threshold, and each cut item rebuilds its entry state from zero over a short
+warmup window. Gates that never forget produce no cuts and reproduce the unsplit result exactly; when
+cuts are accepted the result stays within the low-precision error budget while exposing several
+times the parallel work. The threshold is a margin of bits past the output dtype's half-ulp, not an
+underflow; see `NOTE [Forgetting Horizon]` in
+`attn_gym/linear/_delta_rule/mega/kernels/common/split_k.py`. `split_forward` affects only the
+forward recurrence: unless `split_backward` is also enabled, backward computes the exact unsplit
+recurrence's gradient rather than the derivative of the split forward. The implementation chooses
+the split count from the input geometry; no public split-size knob is exposed. Split schedules
+currently require a no-state call, so context parallelism never uses them. `paged_chunk_kda(..., kernel_options={"backend": "mega"})` uses the
 same exact unsplit forward while updating selected cache slots directly; paged execution never uses
 forgetting-horizon splitting. Install the `mega` extra to use this backend.
 

--- a/test/kda/mega/test_kda_mega_training.py
+++ b/test/kda/mega/test_kda_mega_training.py
@@ -584,22 +584,21 @@ def test_mega_public_packed_unsplit_local_backward_matches_exact_gradients(monke
 
 
 def test_mega_kernel_options_are_strict() -> None:
-    from attn_gym.linear.kda.validation import resolve_kernel_options
+    from attn_gym.linear.kda.validation import ResolvedKernelOptions, resolve_kernel_options
 
-    assert resolve_kernel_options(None) == ("fused", False, False)
-    assert resolve_kernel_options({}) == ("fused", False, False)
+    fused = ResolvedKernelOptions("fused", split_backward=False, split_forward=False)
+    assert resolve_kernel_options(None) == fused
+    assert resolve_kernel_options({}) == fused
     assert resolve_kernel_options({"backend": "mega", "split_backward": True}) == (
-        "mega",
-        True,
-        False,
+        ResolvedKernelOptions("mega", split_backward=True, split_forward=False)
     )
     assert resolve_kernel_options({"backend": "mega", "split_forward": True}) == (
-        "mega",
-        False,
-        True,
+        ResolvedKernelOptions("mega", split_backward=False, split_forward=True)
     )
     with pytest.raises(ValueError, match="unsupported chunk_kda kernel options"):
         resolve_kernel_options({"unknown": True})
+    with pytest.raises(ValueError, match="must be 'fused' or 'mega'"):
+        resolve_kernel_options({"backend": "triton"})
     for name in ("split_backward", "split_forward"):
         with pytest.raises(TypeError, match="must be a bool"):
             resolve_kernel_options({name: 1})
@@ -621,45 +620,55 @@ def test_mega_split_schedules_reject_stateful_calls(option: str) -> None:
         )
 
 
-def test_mega_split_forward_matches_exact_forward_within_horizon_budget() -> None:
-    """The forgetting-horizon forward cuts only where the gate has saturated, so on a
-    contracting gate it must match the unsplit forward to low-precision accuracy, and on a gate
-    that never forgets it must place no cuts and reproduce the unsplit result exactly."""
-    from attn_gym.linear import chunk_kda
+def _split_forward_pair(
+    monkeypatch, dtype: torch.dtype, **gate: float
+) -> tuple[tuple[torch.Tensor, ...], torch.Tensor, torch.Tensor, int]:
+    """Unsplit and forgetting-horizon Mega forwards of one long dense stream.
 
-    tokens, heads = 8192, 1
-    for mode in ("contracting", "no_forgetting"):
-        torch.manual_seed(107)
-        shape = (1, tokens, heads, D)
-        q = F.normalize(torch.randn(shape, device="cuda"), dim=-1).bfloat16()
-        k = F.normalize(torch.randn(shape, device="cuda"), dim=-1).bfloat16()
-        value = torch.randn(shape, device="cuda", dtype=torch.bfloat16)
-        gate = (
-            torch.empty(shape, device="cuda").uniform_(0.5, 1.0).log()
-            if mode == "contracting"
-            else torch.full(shape, -1e-5, device="cuda")
-        )
-        beta = torch.sigmoid(torch.randn(1, tokens, heads, device="cuda"))
-        unsplit, _ = chunk_kda(q, k, value, gate, beta, kernel_options={"backend": "mega"})
-        split, _ = chunk_kda(
-            q, k, value, gate, beta, kernel_options={"backend": "mega", "split_forward": True}
-        )
-        if mode == "no_forgetting":
-            torch.testing.assert_close(split, unsplit, atol=0, rtol=0)
-        else:
-            inputs = (
-                q,
-                k,
-                value,
-                gate,
-                beta,
-                torch.empty(0, device="cuda"),
-                torch.empty(0, dtype=torch.int32, device="cuda"),
-            )
-            (high_out, _), (low_out, _), _, _ = _references(
-                inputs, initial_state=False, packed=False, output_final_state=False
-            )
-            _assert_reference(split, high_out, low_out, "split forward output", torch.bfloat16)
+    Returns the inputs, both outputs, and the number of work items the split schedule emitted.
+    """
+    from attn_gym.linear import chunk_kda
+    from attn_gym.linear._delta_rule.mega import forward, schedule
+
+    inputs = make_kda_test_inputs(
+        8192, seed=107, normalize_qk=True, sigmoid_beta=True, dtype=dtype, **gate
+    )
+    unsplit, _ = chunk_kda(*inputs, kernel_options={"backend": "mega"})
+    schedules = []
+
+    def recording_schedule(*args, **kwargs):
+        schedules.append(schedule.prepare_mega_schedule(*args, **kwargs))
+        return schedules[-1]
+
+    monkeypatch.setattr(forward, "prepare_mega_schedule", recording_schedule)
+    split, _ = chunk_kda(*inputs, kernel_options={"backend": "mega", "split_forward": True})
+    torch.cuda.synchronize()
+    (recorded,) = schedules
+    return inputs, unsplit, split, int(recorded.work_count.item())
+
+
+def test_mega_split_forward_places_no_cuts_when_the_gate_never_forgets(monkeypatch) -> None:
+    _, unsplit, split, work_items = _split_forward_pair(
+        monkeypatch, torch.bfloat16, gate_value=-1e-5
+    )
+    assert work_items == 1
+    torch.testing.assert_close(split, unsplit, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_mega_split_forward_matches_reference_on_a_contracting_gate(monkeypatch, dtype) -> None:
+    """Cuts land only where the gate has saturated, so the result stays within the budget."""
+    inputs, _, split, work_items = _split_forward_pair(
+        monkeypatch, dtype, gate_scale=math.log(2.0)
+    )
+    assert work_items > 1, "the contracting gate must actually be cut"
+    high, _ = kda_reference(
+        *clone_kda_inputs(inputs, dtype=torch.float64), output_final_state=False
+    )
+    low, _ = kda_reference(
+        *clone_kda_inputs(inputs, dtype=torch.float32), output_final_state=False
+    )
+    _assert_reference(split, high, low, "split forward output", dtype)
 
 
 def test_mega_cpu_inputs_fail_before_dispatch() -> None:


### PR DESCRIPTION

## Human Note

## Agent note

Follow-up to #456, which merged before its last review round landed.

- `NOTE [Forgetting Horizon]`: the bf16/fp16 relative half-ulps are 2^-8 and 2^-11, so the margins
  past the e^-10 = 2^-14.4 threshold are 6.4 and 3.4 bits, not 5.4 and 2.4.
- `docs/linear.md`: drop the "bitwise identical in bf16 in practice" generalization and the invalid
  `and/or "split_forward": True` option example; state that `split_forward` only changes the forward
  schedule and backward stays the exact unsplit gradient unless `split_backward` is also set.
- `api.py`: read `ResolvedKernelOptions` by field name; the paged docstring names both switches.
- Tests: the contracting-gate split-forward test asserts the schedule emitted more than one work item
  (a silently ignored `split_forward` previously passed), runs in bf16 and fp16, and uses the shared
  input factory; the no-forgetting case asserts exactly one item and bitwise equality; the
  kernel-options test compares `ResolvedKernelOptions` values and covers an invalid backend.

Validation: `.venv-mega` `pytest -n 4 test/kda/mega/test_kda_mega_training.py
test/kda/mega/test_kda_mega_forward.py` 50 passed, 1 skipped; ruff and mkdocs clean.
