### PR TITLE
Segment the affine-summary chunk chains across idle SMs

### DIFF
--- a/attn_gym/linear/_delta_rule/cute/affine_summary_fwd.py
+++ b/attn_gym/linear/_delta_rule/cute/affine_summary_fwd.py
@@ -26,9 +26,12 @@ rows ``[0:V]`` hold the state bias and rows ``[V:V+K]`` the state transition.
 These are distinct from KDA's token-token query/key matrix ``A``.
 
 Architecture (SM100 warp specialization, mirrors ``kda/bwd/cute/chunk_delta_h_bwd.py``):
-  - One CTA per (BN-column tile of the augmented state, head); 6 warps.
-  - CUDA warps (0-3) keep the fp32 ``[K, BN]`` state tile in registers across all
-    chunks and produce the two SMEM MMA B operands per chunk.
+  - One CTA per (BN-column tile of the augmented state, head, chunk segment); 6 warps.
+    The recurrence is a serial latency chain (~1.1 us per chunk at BN=32), so when
+    ``heads * tiles`` leaves SMs idle the wrapper splits the chunks into segments that
+    each scan from ``[0 | I]`` and composes the segment maps on the host.
+  - CUDA warps (0-3) keep the fp32 ``[K, BN]`` state tile in registers across the
+    segment's chunks and produce the two SMEM MMA B operands per chunk.
   - Load warp (4) TMA-stages ``w``, ``kg^T``, ``u``, and the chunk-final gate row.
   - MMA warp (5) issues two SS-mode UMMA groups per chunk into TMEM:
       MMA1: W  @ X          -> wx  (BT=64, BN, K=128)
@@ -67,6 +70,7 @@ from attn_gym._backends.cute import compile_tvm_ffi, get_device_properties, jit_
 from attn_gym._backends.cute.target import get_compile_target
 from attn_gym._backends.cute.utils import requires_int64_abi
 from attn_gym.linear.kda.constants import is_sm100_kda_capability
+from attn_gym.utils import cdiv
 
 BT = 64  # chunk size
 KEY_DIM = 128
@@ -207,9 +211,10 @@ class _AffineSummaryFwdOp:
         mU: cute.Tensor,
         mG: cute.Tensor,
         mOut: cute.Tensor,
+        chunks_per_segment: Int32,
         stream: cuda.CUstream,
     ):
-        """Launch one CTA per (augmented-state column tile, head)."""
+        """Launch one CTA per (augmented-state column tile, head, chunk segment)."""
         # Re-rank the dense [1, T, H, D] inputs into the logical TMA views.
         g_w = _sequence_feature_head_batch_view(mW)
         g_kgt = _feature_sequence_head_batch_view(mKg)
@@ -384,8 +389,9 @@ class _AffineSummaryFwdOp:
                 s_tmpb_store_staged,
             ),
             num_chunks,
+            chunks_per_segment,
         ).launch(
-            grid=(SUMMARY_DIM // self.BN, self.heads, 1),
+            grid=(SUMMARY_DIM // self.BN, self.heads, cute.size(mOut.shape[0])),
             block=(self.CTA_THREADS, 1, 1),
             stream=stream,
             min_blocks_per_mp=1,
@@ -418,7 +424,8 @@ class _AffineSummaryFwdOp:
         head,
         col_tile,
         is_value,
-        num_chunks,
+        chunk_begin,
+        chunk_end,
         tma,
         mma_wx,
         mma_kt,
@@ -440,7 +447,7 @@ class _AffineSummaryFwdOp:
         gGK_l = tma.gk.desc[None, None, (head, batch)]
         sGKp, gGKp = self._part_epi(tma.gk.atom, gGK_l, (KEY_DIM, 1), gk_3d)
 
-        for ct in cutlass.range(0, num_chunks, unroll=0):
+        for ct in cutlass.range(chunk_begin, chunk_end, unroll=0):
             wh = pw_P.acquire_and_advance()
             cute.copy(
                 atom=tma.w.atom,
@@ -560,6 +567,7 @@ class _AffineSummaryFwdOp:
     def run_state(
         self,
         head,
+        segment,
         col_base,
         num_chunks,
         mOut,
@@ -703,10 +711,10 @@ class _AffineSummaryFwdOp:
             for ei in cutlass.range_constexpr(cute.size(st)):
                 st[ei] = st[ei] + kt_reg[ei]
 
-        # Epilogue: store the V-first packed transpose out[h, col, k] = X[k, col].
+        # Epilogue: store the V-first packed transpose out[s, h, col, k] = X[k, col].
         for ei in cutlass.range(cute.size(st), unroll_full=True):
             kc, nc = coords_kv[ei]
-            mOut[head, col_base + nc, kc] = st[ei]
+            mOut[segment, head, col_base + nc, kc] = st[ei]
 
     # ------------------------------------------------------------------
     # Device kernel
@@ -720,6 +728,7 @@ class _AffineSummaryFwdOp:
         mOut: cute.Tensor,
         smem_layouts: SmemLayouts,
         num_chunks: Int32,
+        chunks_per_segment: Int32,
     ):
         mma_wx, mma_kt, mma_ktu = mmas
         (
@@ -836,6 +845,10 @@ class _AffineSummaryFwdOp:
             allocator_warp_id=WarpRole.LOAD,
         )
         tmem.allocate(self.tm_tot)
+        # Relinquish the permit immediately: it only promises this CTA allocates no more TMEM,
+        # while the columns just allocated stay owned until ``tmem.free``. Holding it to exit
+        # blocks a co-resident CTA's allocation and serializes chains that would overlap.
+        tmem.relinquish_alloc_permit()
         tmem.wait_for_alloc()
         tp = tmem.retrieve_ptr(Float32)
 
@@ -867,17 +880,21 @@ class _AffineSummaryFwdOp:
         t_kt_acc = cute.make_tensor(tp + self.tm_kt, kt_fk.layout)
 
         # #
-        # Role dispatch: one CTA owns one (column tile, head) state slice.
+        # Role dispatch: one CTA owns one (column tile, head, chunk segment) state slice.
         #
-        col_tile, head, _ = cute.arch.block_idx()
+        col_tile, head, segment = cute.arch.block_idx()
         col_base = col_tile * self.BN
         is_value = col_base < VAL_DIM
+        # Each segment scans its own chunk range from [0 | I]; the host composes them.
+        chunk_begin = segment * chunks_per_segment  # < num_chunks: plan_segments drops empties
+        chunk_end = cutlass.min(chunk_begin + chunks_per_segment, num_chunks)
 
         if warp_id in self.CUDA_WARP_IDS:
             self.run_state(
                 head=head,
+                segment=segment,
                 col_base=col_base,
-                num_chunks=num_chunks,
+                num_chunks=chunk_end - chunk_begin,
                 mOut=mOut,
                 t_wx_acc=t_wx_acc,
                 t_kt_acc=t_kt_acc,
@@ -895,7 +912,8 @@ class _AffineSummaryFwdOp:
                 head=head,
                 col_tile=col_tile,
                 is_value=is_value,
-                num_chunks=num_chunks,
+                chunk_begin=chunk_begin,
+                chunk_end=chunk_end,
                 tma=tma,
                 mma_wx=mma_wx,
                 mma_kt=mma_kt,
@@ -912,7 +930,7 @@ class _AffineSummaryFwdOp:
         elif warp_id == WarpRole.MMA:
             self.run_mma(
                 is_value=is_value,
-                num_chunks=num_chunks,
+                num_chunks=chunk_end - chunk_begin,
                 mma_wx=mma_wx,
                 mma_kt=mma_kt,
                 mma_ktu=mma_ktu,
@@ -934,7 +952,6 @@ class _AffineSummaryFwdOp:
             )
 
         # TMEM teardown (all warps)
-        tmem.relinquish_alloc_permit()
         self.tmem_free_bar.arrive_and_wait()
         tmem.free(tp)
 
@@ -1002,8 +1019,8 @@ def _compile_affine_summary(
     io_dtype = _CUTE_IO_TYPES[dtype_name]
     out = make_fake_compact_tensor(
         Float32,
-        (heads, SUMMARY_DIM, KEY_DIM),
-        stride_order=(2, 1, 0),
+        (sym_int(), heads, SUMMARY_DIM, KEY_DIM),
+        stride_order=(3, 2, 1, 0),
         assumed_align=DATA_ALIGN_BYTES,
     )
     return compile_tvm_ffi(
@@ -1013,7 +1030,52 @@ def _compile_affine_summary(
         factor(io_dtype, VAL_DIM),
         factor(Float32, KEY_DIM),
         out,
+        Int32(1),
     )
+
+
+# Each pairwise fold level costs two small launches (~8 us) while a chunk costs ~1.1-1.3 us, so a
+# segment must carry enough chunks for the shortened chain to pay for the fold. Measured crossover
+# on GB200 is ~32 chunks total; 16 chunks per segment keeps every split a win.
+MIN_CHUNKS_PER_SEGMENT = 16
+
+
+def plan_segments(num_chunks: int, work_tiles: int, sm_count: int) -> tuple[int, int]:
+    """Return ``(segments, chunks_per_segment)`` filling idle SMs with chunk segments.
+
+    The chunk recurrence is a serial chain per CTA, so when ``work_tiles`` (column tiles times
+    heads) leaves SMs idle the chunks are split into segments that each scan from ``[0 | I]``
+    and ``compose_segment_summaries`` folds the segment maps.
+    """
+    # ``segments`` is an upper bound from available SMs and the minimum useful segment length.
+    # After rounding up the chunks per segment, recompute how many non-empty segments are needed.
+    segments = max(1, min(num_chunks // MIN_CHUNKS_PER_SEGMENT, sm_count // work_tiles))
+    chunks_per_segment = cdiv(num_chunks, segments)
+    return cdiv(num_chunks, chunks_per_segment), chunks_per_segment
+
+
+def compose_segment_summaries(summaries: torch.Tensor) -> torch.Tensor:
+    """Fold ``[S, H, V + K, K]`` consecutive segment maps into one, pairwise from the left.
+
+    ``(A0, B0)`` then ``(A1, B1)`` composes to ``(A0 @ A1, B0 @ A1 + B1)``; each level composes
+    adjacent pairs with two launches (one matmul, one bias add), so the fold costs log2(S) levels
+    rather than S - 1 sequential compositions. The fold runs in FP64 so its precision does not
+    depend on the caller's float32 matmul mode (TF32 would otherwise leak into the summary); the
+    operands are at most a few megabytes, so the cast is negligible next to the kernel.
+    """
+    if summaries.shape[0] == 1:
+        return summaries[0]
+    value_dim = summaries.shape[-2] - summaries.shape[-1]
+    summaries = summaries.double()
+    while summaries.shape[0] > 1:
+        pairs = 2 * (summaries.shape[0] // 2)
+        first, then = summaries[0:pairs:2], summaries[1:pairs:2]
+        composed = first @ then[..., value_dim:, :]
+        composed[..., :value_dim, :] += then[..., :value_dim, :]
+        summaries = (
+            composed if pairs == summaries.shape[0] else torch.cat((composed, summaries[pairs:]))
+        )
+    return summaries[0].float()
 
 
 @torch.compiler.disable
@@ -1062,11 +1124,6 @@ def build_state_summary(
         f"cumulative_gate must be fp32, got {cumulative_gate.dtype}"
     )
 
-    out = torch.empty(
-        (heads, SUMMARY_DIM, KEY_DIM),
-        dtype=torch.float32,
-        device=kg.device,
-    )
     if isinstance(kg, FakeTensor):
         raise TypeError(
             "build_state_summary does not support torch.export; run the context-parallel "
@@ -1102,19 +1159,32 @@ def build_state_summary(
             launch_affine_summary_fwd,
         )
 
+        out = torch.empty((heads, SUMMARY_DIM, KEY_DIM), dtype=torch.float32, device=kg.device)
         launch_affine_summary_fwd(kg, w, u, cumulative_gate, out, capability)
         return out
 
     kg, w, u, cumulative_gate = (_aligned(tensor) for tensor in (kg, w, u, cumulative_gate))
-    use_int64_offsets = requires_int64_abi(kg, w, u, cumulative_gate, out)
-
     # BN=32 is faster per CTA (measured ~1.5x vs BN=64 on GB200); fall back to
     # BN=64 only when the extra column tiles would spill past one CTA wave and
     # serialize whole recurrence chains.
     sm_count = properties.multi_processor_count
     state_bn = 32 if heads * (SUMMARY_DIM // 32) <= sm_count else 64
+    segments, chunks_per_segment = plan_segments(
+        kg.shape[1] // BT, heads * (SUMMARY_DIM // state_bn), sm_count
+    )
+    segment_out = torch.empty(
+        (segments, heads, SUMMARY_DIM, KEY_DIM), dtype=torch.float32, device=kg.device
+    )
+    use_int64_offsets = requires_int64_abi(kg, w, u, cumulative_gate, segment_out)
     compiled = _compile_affine_summary(
         _IO_TYPE_NAMES[kg.dtype], heads, state_bn, use_int64_offsets
     )
-    compiled(kg.detach(), w.detach(), u.detach(), cumulative_gate.detach(), out)
-    return out
+    compiled(
+        kg.detach(),
+        w.detach(),
+        u.detach(),
+        cumulative_gate.detach(),
+        segment_out,
+        chunks_per_segment,
+    )
+    return compose_segment_summaries(segment_out)

--- a/attn_gym/linear/_delta_rule/cute/affine_summary_rev.py
+++ b/attn_gym/linear/_delta_rule/cute/affine_summary_rev.py
@@ -11,11 +11,17 @@ The local backward recurrence is affine in its incoming final-state cotangent:
 ``[K, BN]`` tiles of the augmented FP32 state ``X = [0 | I]`` and returns its
 V-first packed transpose ``[local_bias; reverse_transition]``.
 
-Each 224-thread CTA persistently owns augmented-column tiles. Four CUDA warps
-hold the FP32 state in registers, one warp issues TMA loads, one computes gate
-exponentials, and one issues the four UMMA operations. Bias tiles load the local
-output-gradient sources; transition tiles skip those streams entirely. Only the
-final FP32 summary is written to global memory.
+Each 224-thread CTA persistently owns work items, one (augmented-column tile,
+head, chunk segment) each. Four CUDA warps hold the FP32 state in registers, one
+warp issues TMA loads, one computes gate exponentials, and one issues the four
+UMMA operations. Bias tiles load the local output-gradient sources; transition
+tiles skip those streams entirely. Only the final FP32 summary is written to
+global memory.
+
+The chunk recurrence is a serial latency chain (~1.3 us per chunk at BN=32), so
+when ``heads * tiles`` leaves SMs idle the wrapper splits the chunks into
+segments that each scan from ``[0 | I]`` and composes the segment maps on the
+host; see ``compose_segment_summaries`` in the forward module.
 
 The fp32-valued MMA B operands (state ``X`` and the corrected write gradient
 ``dv``) are split into hi/lo halves of the I/O dtype and accumulated in two UMMA
@@ -43,6 +49,10 @@ from torch._subclasses.fake_tensor import FakeTensor
 from attn_gym._backends.cute import compile_tvm_ffi, get_device_properties, jit_cache
 from attn_gym._backends.cute.target import get_compile_target
 from attn_gym._backends.cute.utils import requires_int64_abi
+from attn_gym.linear._delta_rule.cute.affine_summary_fwd import (
+    compose_segment_summaries,
+    plan_segments,
+)
 from attn_gym.linear.kda.constants import is_sm100_kda_capability
 
 BT = 64
@@ -131,27 +141,24 @@ class BlackwellDeltaAffineSummaryRev:
     STATE_WARP_IDS = tuple(range(WarpRole.STATE, WarpRole.LOAD))
     WARP_SIZE = cute.arch.WARP_SIZE
     CTA_THREADS = WarpRole.END * WARP_SIZE
+    # Augmented-state columns per CTA. A BN=16 tile covered half the columns for only ~25% less
+    # time per chunk; chunk segments fill idle SMs instead.
+    BN = 32
 
     def __init__(
         self,
         num_heads: int,
         io_type: type[cutlass.Numeric],
-        state_tile_width: int,
         use_int64_offsets: bool,
     ):
-        # This limits columns handled by one CTA, not the number of attention heads.
-        assert state_tile_width in (16, 32), (
-            f"state tile width must be 16 or 32, got {state_tile_width}"
-        )
         self.num_heads = num_heads
         self.io_type = io_type
         self.acc_type = cutlass.Float32
         self.BT = BT
         self.BK = KEY_DIM
-        self.BN = state_tile_width
         self.use_int64_offsets = use_int64_offsets
 
-        self.state_regs = 128 if state_tile_width == 16 else 160
+        self.state_regs = 160
         self.aux_regs = 40
 
         self.dv_tile = (self.BT, self.BN, self.BK)
@@ -159,7 +166,7 @@ class BlackwellDeltaAffineSummaryRev:
         self.aqdo_tile = (self.BT, self.BN, self.BT)
         self.wdv_tile = (self.BK, self.BN, self.BT)
 
-        self.k_depth = 6 if state_tile_width == 16 else 4
+        self.k_depth = 4
         self.q_depth = 2
         self.do_depth = 2
         self.w_depth = 2
@@ -196,6 +203,7 @@ class BlackwellDeltaAffineSummaryRev:
         cumulative_gate: cute.Tensor,
         out: cute.Tensor,
         scale: Float32,
+        chunks_per_segment: Int32,
         stream: cuda.CUstream,
     ):
         """Construct TMA/UMMA descriptors and launch the persistent kernel."""
@@ -455,8 +463,9 @@ class BlackwellDeltaAffineSummaryRev:
             smem_layouts,
             Int32(cute.size(w.shape[1])),
             scale,
+            chunks_per_segment,
         ).launch(
-            grid=self._launch_grid(),
+            grid=self._launch_grid(cute.size(out.shape[0])),
             block=(self.CTA_THREADS, 1, 1),
             cluster=self.cluster,
             stream=stream,
@@ -464,10 +473,20 @@ class BlackwellDeltaAffineSummaryRev:
         )
 
     @cute.jit
-    def _decode_work(self, work_index):
-        """Return the augmented-column tile and head for a work item."""
+    def _decode_work(self, work_index, chunks, chunks_per_segment):
+        """Return the augmented-column tile, head, and chunk range of a work item.
+
+        Each segment scans its own chunk range from ``[0 | I]``; the host composes them.
+        """
+        # ``column_tiles`` and ``num_heads`` are compile-time constants, so these divisions lower
+        # to shifts and multiply-high sequences; they also run once per work item, not per chunk.
         column_tiles = SUMMARY_DIM // self.BN
-        return work_index % column_tiles, work_index // column_tiles
+        column_tile = work_index % column_tiles
+        head = (work_index // column_tiles) % self.num_heads
+        segment = work_index // (column_tiles * self.num_heads)
+        chunk_begin = segment * chunks_per_segment  # < chunks: plan_segments drops empties
+        chunk_end = cutlass.min(chunk_begin + chunks_per_segment, chunks)
+        return column_tile, head, segment, chunk_begin, chunk_end
 
     @cute.jit
     def run_state(
@@ -476,6 +495,7 @@ class BlackwellDeltaAffineSummaryRev:
         grid,
         iterations,
         chunks,
+        chunks_per_segment,
         out,
         t_dv_acc,
         t_qdo_acc,
@@ -555,7 +575,9 @@ class BlackwellDeltaAffineSummaryRev:
         tile_index = Int32(0)
         has_work = tile_index < iterations
         while has_work:
-            column_tile, head = self._decode_work(block + tile_index * grid)
+            column_tile, head, segment, chunk_begin, chunk_end = self._decode_work(
+                block + tile_index * grid, chunks, chunks_per_segment
+            )
             has_source = column_tile < VAL_DIM // self.BN
 
             for element in cutlass.range(cute.size(state), unroll_full=True):
@@ -566,7 +588,7 @@ class BlackwellDeltaAffineSummaryRev:
                 else:
                     state[element] = Float32(0.0)
 
-            for _chunk in cutlass.range(chunks, unroll=0):
+            for _chunk in cutlass.range(chunk_begin, chunk_end, unroll=0):
                 # Publish the hi half as soon as it exists so MMA1 starts its first
                 # pass while the lo residual is still being formed and stored.
                 hi_handle = state_producer.acquire_and_advance()
@@ -657,7 +679,7 @@ class BlackwellDeltaAffineSummaryRev:
 
             for element in cutlass.range(cute.size(state), unroll_full=True):
                 key, column = state_coordinates[element]
-                out[head, column_tile * self.BN + column, key] = state[element]
+                out[segment, head, column_tile * self.BN + column, key] = state[element]
 
             tile_index = tile_index + 1
             has_work = tile_index < iterations
@@ -669,6 +691,7 @@ class BlackwellDeltaAffineSummaryRev:
         grid,
         iterations,
         chunks,
+        chunks_per_segment,
         mma_dv,
         mma_qdo,
         mma_aqdo,
@@ -699,7 +722,9 @@ class BlackwellDeltaAffineSummaryRev:
         tile_index = Int32(0)
         has_work = tile_index < iterations
         while has_work:
-            column_tile, head = self._decode_work(block + tile_index * grid)
+            column_tile, head, _segment, chunk_begin, chunk_end = self._decode_work(
+                block + tile_index * grid, chunks, chunks_per_segment
+            )
             has_source = column_tile < VAL_DIM // self.BN
 
             k_smem, k_gmem = self._partition_a(atom_k, desc_k, s_k, self.dv_tile, mma_dv, head)
@@ -742,8 +767,8 @@ class BlackwellDeltaAffineSummaryRev:
                 head,
             )
 
-            for chunk in cutlass.range(chunks, unroll=0):
-                reverse_chunk = chunks - 1 - chunk
+            for chunk in cutlass.range(chunk_begin, chunk_end, unroll=0):
+                reverse_chunk = chunk_end - 1 - (chunk - chunk_begin)
 
                 gate_handle = gate_producer.acquire_and_advance()
                 cute.copy(
@@ -801,6 +826,7 @@ class BlackwellDeltaAffineSummaryRev:
         grid,
         iterations,
         chunks,
+        chunks_per_segment,
         gate,
         gate_exp,
         gate_consumer,
@@ -814,7 +840,10 @@ class BlackwellDeltaAffineSummaryRev:
         tile_index = Int32(0)
         has_work = tile_index < iterations
         while has_work:
-            for _chunk in cutlass.range(chunks, unroll=0):
+            _, _, _, chunk_begin, chunk_end = self._decode_work(
+                block + tile_index * grid, chunks, chunks_per_segment
+            )
+            for _chunk in cutlass.range(chunk_begin, chunk_end, unroll=0):
                 gate_handle = gate_consumer.wait_and_advance()
                 ready_handle = gate_ready_producer.acquire_and_advance()
                 for index in cutlass.range(4, unroll_full=True):
@@ -834,6 +863,7 @@ class BlackwellDeltaAffineSummaryRev:
         grid,
         iterations,
         chunks,
+        chunks_per_segment,
         mmas,
         t_dv_acc,
         t_k,
@@ -868,10 +898,12 @@ class BlackwellDeltaAffineSummaryRev:
         tile_index = Int32(0)
         has_work = tile_index < iterations
         while has_work:
-            column_tile, _head = self._decode_work(block + tile_index * grid)
+            column_tile, _head, _segment, chunk_begin, chunk_end = self._decode_work(
+                block + tile_index * grid, chunks, chunks_per_segment
+            )
             has_source = column_tile < VAL_DIM // self.BN
 
-            for _chunk in cutlass.range(chunks, unroll=0):
+            for _chunk in cutlass.range(chunk_begin, chunk_end, unroll=0):
                 # The source products do not depend on the state, so they run while
                 # the state warps are still producing the X snapshot: Aqk^T dO seeds
                 # the dv accumulator and qg^T dO completes off the recurrence chain.
@@ -958,6 +990,7 @@ class BlackwellDeltaAffineSummaryRev:
         smem_layouts: SmemLayouts,
         tokens: Int32,
         scale: Float32,
+        chunks_per_segment: Int32,
     ):
         """Dispatch the persistent state, TMA, gate, and MMA warp roles."""
         mma_dv, mma_qdo, mma_aqdo, mma_wdv = mmas
@@ -1100,6 +1133,10 @@ class BlackwellDeltaAffineSummaryRev:
             allocator_warp_id=WarpRole.LOAD,
         )
         tmem.allocate(self.tm_total)
+        # Relinquish the permit immediately: it only promises this CTA allocates no more TMEM,
+        # while the columns just allocated stay owned until ``tmem.free``. Holding it to exit
+        # blocks a co-resident CTA's allocation and serializes chains that would overlap.
+        tmem.relinquish_alloc_permit()
         tmem.wait_for_alloc()
         tmem_pointer = tmem.retrieve_ptr(self.acc_type)
 
@@ -1145,8 +1182,8 @@ class BlackwellDeltaAffineSummaryRev:
 
         block = cute.arch.block_idx()[0]
         grid = cute.arch.grid_dim()[0]
-        work_tiles = self.num_heads * (SUMMARY_DIM // self.BN)
-        iterations = (work_tiles - block + grid - 1) // grid
+        work_items = self.num_heads * (SUMMARY_DIM // self.BN) * cute.size(out.shape[0])
+        iterations = (work_items - block + grid - 1) // grid
         chunks = tokens // self.BT
 
         if warp_id in self.STATE_WARP_IDS:
@@ -1155,6 +1192,7 @@ class BlackwellDeltaAffineSummaryRev:
                 grid,
                 iterations,
                 chunks,
+                chunks_per_segment,
                 out,
                 t_dv_acc,
                 t_qdo_acc,
@@ -1176,6 +1214,7 @@ class BlackwellDeltaAffineSummaryRev:
                 grid,
                 iterations,
                 chunks,
+                chunks_per_segment,
                 mma_dv,
                 mma_qdo,
                 mma_aqdo,
@@ -1200,6 +1239,7 @@ class BlackwellDeltaAffineSummaryRev:
                 grid,
                 iterations,
                 chunks,
+                chunks_per_segment,
                 gate,
                 gate_exp,
                 gate_consumer,
@@ -1211,6 +1251,7 @@ class BlackwellDeltaAffineSummaryRev:
                 grid,
                 iterations,
                 chunks,
+                chunks_per_segment,
                 mmas,
                 t_dv_acc,
                 t_k,
@@ -1235,7 +1276,6 @@ class BlackwellDeltaAffineSummaryRev:
                 wdv_producer,
             )
 
-        tmem.relinquish_alloc_permit()
         self.tmem_free_barrier.arrive_and_wait()
         tmem.free(tmem_pointer)
 
@@ -1301,29 +1341,22 @@ class BlackwellDeltaAffineSummaryRev:
         assert total <= 512, f"TMEM overflow: {total}>512"
         return dv_offset, qdo_offset, wdv_offset, total
 
-    def _launch_grid(self):
-        """Bound the persistent launch to the logical tile count and SM count."""
+    def _launch_grid(self, segments):
+        """Bound the persistent launch to the work-item count and SM count."""
         sm_count = get_compile_target().sm_count
         if sm_count is None:
             raise RuntimeError("affine_summary_rev compilation requires an SM count")
-        return (min(sm_count, self.num_heads * (SUMMARY_DIM // self.BN)), 1, 1)
-
-
-def select_summary_tile_width(heads: int, device: torch.device) -> int:
-    """Choose the per-CTA state-column width from the available SM count."""
-    work_tiles_at_width_16 = (SUMMARY_DIM // 16) * heads
-    sm_count = get_device_properties(device).multi_processor_count
-    return 32 if work_tiles_at_width_16 > sm_count else 16
+        work_items = self.num_heads * (SUMMARY_DIM // self.BN) * segments
+        return (cutlass.min(Int32(sm_count), work_items), 1, 1)
 
 
 @jit_cache
 def _compile_affine_summary_rev(
     dtype_name: str,
     heads: int,
-    state_tile_width: int,
     use_int64_offsets: bool,
 ):
-    """Compile one reverse-summary dtype/head/tile specialization."""
+    """Compile one reverse-summary dtype/head specialization."""
     target = get_compile_target()
     if target.device_type != "cuda" or not is_sm100_kda_capability(target.effective_capability):
         raise ValueError(f"affine_summary_rev requires an SM100/SM103 target; got {target}")
@@ -1341,15 +1374,14 @@ def _compile_affine_summary_rev(
     io_dtype = _CUTE_IO_TYPES[dtype_name]
     out = make_fake_compact_tensor(
         Float32,
-        (heads, SUMMARY_DIM, KEY_DIM),
-        stride_order=(2, 1, 0),
+        (sym_int(), heads, SUMMARY_DIM, KEY_DIM),
+        stride_order=(3, 2, 1, 0),
         assumed_align=DATA_ALIGN_BYTES,
     )
     return compile_tvm_ffi(
         BlackwellDeltaAffineSummaryRev(
             heads,
             io_dtype,
-            state_tile_width,
             use_int64_offsets,
         ),
         factor(io_dtype, KEY_DIM),
@@ -1360,6 +1392,7 @@ def _compile_affine_summary_rev(
         factor(Float32, KEY_DIM),
         out,
         Float32(1.0),
+        Int32(1),
     )
 
 
@@ -1418,11 +1451,6 @@ def build_state_grad_summary(
         f"cumulative_gate must be fp32, got {cumulative_gate.dtype}"
     )
 
-    out = torch.empty(
-        (heads, SUMMARY_DIM, KEY_DIM),
-        dtype=torch.float32,
-        device=qg.device,
-    )
     if isinstance(qg, FakeTensor):
         raise TypeError(
             "build_state_grad_summary does not support torch.export; run the context-parallel "
@@ -1466,6 +1494,7 @@ def build_state_grad_summary(
             launch_affine_summary_rev,
         )
 
+        out = torch.empty((heads, SUMMARY_DIM, KEY_DIM), dtype=torch.float32, device=qg.device)
         launch_affine_summary_rev(
             qg,
             kg,
@@ -1482,12 +1511,16 @@ def build_state_grad_summary(
     qg, kg, w, dout, Aqk, cumulative_gate = (
         _aligned(tensor) for tensor in (qg, kg, w, dout, Aqk, cumulative_gate)
     )
-    use_int64_offsets = requires_int64_abi(qg, kg, w, dout, Aqk, cumulative_gate, out)
-
-    state_tile_width = select_summary_tile_width(heads, qg.device)
-    compiled = _compile_affine_summary_rev(
-        _IO_TYPE_NAMES[qg.dtype], heads, state_tile_width, use_int64_offsets
+    segments, chunks_per_segment = plan_segments(
+        qg.shape[1] // BT,
+        heads * (SUMMARY_DIM // BlackwellDeltaAffineSummaryRev.BN),
+        get_device_properties(qg.device).multi_processor_count,
     )
+    segment_out = torch.empty(
+        (segments, heads, SUMMARY_DIM, KEY_DIM), dtype=torch.float32, device=qg.device
+    )
+    use_int64_offsets = requires_int64_abi(qg, kg, w, dout, Aqk, cumulative_gate, segment_out)
+    compiled = _compile_affine_summary_rev(_IO_TYPE_NAMES[qg.dtype], heads, use_int64_offsets)
     compiled(
         qg.detach(),
         kg.detach(),
@@ -1495,7 +1528,11 @@ def build_state_grad_summary(
         dout.detach(),
         Aqk.detach(),
         cumulative_gate.detach(),
-        out,
+        segment_out,
         Float32(scale),
+        chunks_per_segment,
     )
-    return out
+    if segments == 1:
+        return segment_out[0]
+    # The cotangent flows through the last segment first.
+    return compose_segment_summaries(segment_out.flip(0))

--- a/test/test_delta_affine_summary.py
+++ b/test/test_delta_affine_summary.py
@@ -17,6 +17,7 @@ import attn_gym.linear._delta_rule.triton.affine_summary_fwd as portable_fwd
 import attn_gym.linear._delta_rule.triton.affine_summary_rev as portable_rev
 from attn_gym.linear._delta_rule.cute import build_state_grad_summary, build_state_summary
 from attn_gym.linear.kda.constants import is_sm100_kda_capability
+from attn_gym.testing.kda import assert_relative_rms_within
 
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available() or torch.cuda.get_device_capability() < (8, 0),
@@ -398,6 +399,97 @@ def test_reverse_transition_is_adjoint_of_forward_transition(dtype, tokens, head
         transition - reverse_transition.transpose(-2, -1), ord=2
     )
     assert (adjoint_defect <= 2e-4).all(), adjoint_defect
+
+
+@pytest.mark.parametrize(
+    ("num_chunks", "work_tiles", "sm_count", "expected"),
+    [
+        pytest.param(512, 64, 148, (2, 256), id="two-segments"),
+        pytest.param(512, 128, 148, (1, 512), id="one-wave-already"),
+        pytest.param(512, 256, 148, (1, 512), id="oversubscribed"),
+        pytest.param(512, 8, 148, (18, 29), id="sm-bound"),
+        pytest.param(3, 8, 148, (1, 3), id="short-chain-stays-whole"),
+        pytest.param(31, 8, 148, (1, 31), id="just-below-two-segments"),
+        pytest.param(32, 8, 148, (2, 16), id="first-split"),
+        pytest.param(70, 8, 32, (4, 18), id="ragged-tail"),
+        pytest.param(65, 8, 32, (4, 17), id="rounding-drops-a-segment"),
+    ],
+)
+def test_plan_segments_fills_one_wave_without_empty_or_tiny_segments(
+    num_chunks, work_tiles, sm_count, expected
+):
+    segments, chunks_per_segment = native_fwd.plan_segments(num_chunks, work_tiles, sm_count)
+    assert (segments, chunks_per_segment) == expected
+    assert (segments - 1) * chunks_per_segment < num_chunks <= segments * chunks_per_segment
+    # A fold level costs more than several chunks, so no split may produce short segments.
+    assert segments == 1 or chunks_per_segment >= native_fwd.MIN_CHUNKS_PER_SEGMENT
+
+
+@pytest.mark.parametrize("segments", [1, 3, 5, 8])
+def test_compose_segment_summaries_matches_sequential_composition(segments):
+    """The pairwise fold, including its odd tail, equals left-to-right composition."""
+    generator = torch.Generator().manual_seed(5)
+    summaries = torch.randn(segments, 2, 256, 128, generator=generator) / 16
+    summaries[:, :, VALUE_DIM:] += torch.eye(128)
+    expected = reduce(compose_summaries, summaries.unbind(0))
+    torch.testing.assert_close(
+        native_fwd.compose_segment_summaries(summaries), expected, atol=1e-5, rtol=1e-5
+    )
+
+
+def test_compose_segment_summaries_ignores_the_float32_matmul_mode():
+    """The fold must not pick up TF32 from ``torch.set_float32_matmul_precision("high")``."""
+    generator = torch.Generator(device="cuda").manual_seed(6)
+    summaries = torch.randn(4, 2, 256, 128, device="cuda", generator=generator) / 16
+    summaries[:, :, VALUE_DIM:] += torch.eye(128, device="cuda")
+    exact = reduce(compose_summaries, summaries.double().unbind(0)).float()
+    precision = torch.get_float32_matmul_precision()
+    torch.set_float32_matmul_precision("high")
+    try:
+        folded = native_fwd.compose_segment_summaries(summaries)
+    finally:
+        torch.set_float32_matmul_precision(precision)
+    # TF32 rounds operands to 10 mantissa bits (~1e-3 relative); an FP64 fold stays within a few
+    # FP32 ulps of the exact composition.
+    torch.testing.assert_close(folded, exact, atol=1e-6, rtol=1e-6)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available()
+    or not is_sm100_kda_capability(torch.cuda.get_device_capability()),
+    reason="segmented launches are specific to the native SM100 kernels",
+)
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_native_segmented_summaries_match_single_segment_scans(dtype, monkeypatch):
+    """Splitting the chunk chain across idle SMs must only reorder FP32 composition."""
+    qg, kg, w, u, dout, aqk, cumulative_gate = make_summary_inputs(
+        43, dtype, tokens=2048, heads=1, divisor=16
+    )
+    reverse_summary = partial(build_state_grad_summary, scale=128**-0.5)
+    segmented = (
+        build_state_summary(kg, w, u, cumulative_gate),
+        reverse_summary(qg, kg, w, dout, aqk, cumulative_gate),
+    )
+
+    plans = []
+    plan_segments = native_fwd.plan_segments
+
+    def single_segment(num_chunks, work_tiles, sm_count):
+        plans.append(plan_segments(num_chunks, work_tiles, sm_count))
+        return 1, num_chunks
+
+    monkeypatch.setattr(native_fwd, "plan_segments", single_segment)
+    monkeypatch.setattr(native_rev, "plan_segments", single_segment)
+    unsegmented = (
+        build_state_summary(kg, w, u, cumulative_gate),
+        reverse_summary(qg, kg, w, dout, aqk, cumulative_gate),
+    )
+    assert all(segments > 1 for segments, _ in plans), plans
+    for name, actual, expected in zip(("forward", "reverse"), segmented, unsegmented, strict=True):
+        torch.testing.assert_close(actual, expected, atol=2e-5, rtol=2e-5)
+        assert_relative_rms_within(
+            actual, expected, f"segmented {name} summary", max_eps=64, source_dtype=torch.float32
+        )
 
 
 @pytest.mark.usefixtures("summary_backend")


### PR DESCRIPTION

## Human Note

## Agent note

Both native affine-summary kernels (`affine_summary_fwd.py`, `affine_summary_rev.py`) walk the
chunk recurrence as a serial latency chain: 1.1 us/chunk forward and 1.27 us/chunk reverse at
BN=32, independent of how many CTAs are resident. One CTA per (column tile, head) therefore uses
`8 * heads` of the 148 SMs and runs the same wall time at H=1 as at H=16 (570 us forward /
480 us reverse for 512 chunks). Context-parallel summaries at H=8 cost as much as the local
forward itself.

This PR adds a chunk-segment axis to both launches. `plan_segments` splits the chunks into
`min(num_chunks // 16, sm_count // work_tiles)` segments so one wave fills the machine without
producing segments shorter than 16 chunks (a fold level costs ~8 us against ~1.1-1.3 us per chunk;
the measured crossover is ~32 chunks, so short fragments stay unsegmented and are never slower).
Each segment scans from `[0 | I]` and `compose_segment_summaries` folds the segment maps pairwise
on the host (one matmul plus one bias add per level). The fold runs in FP64 so its precision does
not depend on the caller's `float32_matmul_precision`: under `"high"`, an FP32 fold would silently
compose in TF32 (1.9e-3 error on the test's operands); the FP64 cast costs ~4 us at 18 segments. The forward grid gains a z dimension; the
persistent reverse kernel decodes (tile, head, segment) per work item and keeps its dynamic grid
bounded by the SM count. The reverse selector's BN=16 tile is removed: it covered half the
columns per chunk for only ~25% less time per chunk, so BN=32 plus segments dominates it at
every head count, so the reverse class's BN=16 generality (constructor parameter, register and
ring-depth branches, cache-key dimension) is collapsed to a constant. Both kernels relinquish
their TMEM allocation permit right after allocating; holding it to kernel exit blocked a
co-resident CTA's allocation and serialized two CTAs that fit on one SM (forward measured 2.0x ->
1.55x wall time for 2 CTAs/SM, though the selector does not oversubscribe today).

GB200, bf16, T=32768 (512 chunks), before -> after:

| H  | forward         | reverse          |
|----|-----------------|------------------|
| 1  | 563 -> 79 us    | 480 -> 88 us     |
| 2  | 569 -> 113 us   | 480 -> 124 us    |
| 4  | 566 -> 166 us   | 480 -> 187 us    |
| 8  | 570 -> 303 us   | 483 -> 338 us    |
| 16 | 569 -> 568 us   | 652 -> 633 us    |
| 32 | 823 -> 824 us   | 1301 -> 1262 us  |

T=131072, H=4: forward 2256 -> 595 us, reverse 1909 -> 664 us. Short chains (<= 31 chunks) are
bitwise unchanged: one segment, no fold. A GDN CP fragment at T=32768,
HV=8 goes from 637 -> 365 us (`state_summary`) and 550 -> 401 us (`state_grad_summary`).

Numerics: composing segment maps is the same FP32 algebra the CP recipe already applies across
ranks; `test_affine_summaries_are_invariant_to_shard_boundaries` bounded it at 2e-5 before this
change. New tests pin `plan_segments` (including the short-chain and first-split boundaries), check the
pairwise fold (including its odd tail, which a 148-SM part never reaches) against sequential
composition, check the fold ignores `set_float32_matmul_precision("high")`, and compare the
segmented launches against forced single-segment scans pointwise at 2e-5 plus a relative-RMS
bound; the exact-cancellation and adjoint tests still pass. The remaining
overhead at high segment counts is the host fold (~40 us at 18 segments); an in-kernel compose
would remove it.

Validation: `pytest -n 6 test/test_delta_affine_summary.py test/linear/test_delta_rule_state_precision.py
test/test_kda_cute_forward.py test/test_kda_hopper.py` 133 passed; `.venv-mega` Mega training +
numerics 57 passed; ruff clean.

