### PR TITLE
Add staged KDA primitives around the affine state boundary

### DIFF
--- a/attn_gym/linear/_delta_rule/validation.py
+++ b/attn_gym/linear/_delta_rule/validation.py
@@ -76,6 +76,16 @@ def validate_delta_rule_inputs(
         raise ValueError("all inputs must be on the same device")
 
 
+def check_summary_range(tokens: int, start: int, stop: int) -> None:
+    """Reject a summary range outside ``[0, tokens)``.
+
+    Only the bounds are checked; see NOTE [Summary ranges are whole chunks of one subsequence]
+    in ``attn_gym.linear.kda.stages``.
+    """
+    if not 0 <= start < stop <= tokens:
+        raise ValueError(f"summary range [{start}, {stop}) must lie inside [0, {tokens})")
+
+
 def resolve_scale(scale: float | None, key_dim: int) -> float:
     """Resolve a query-scale override to a validated float, defaulting to ``1/sqrt(K)``."""
     if scale is None:

--- a/attn_gym/linear/kda/__init__.py
+++ b/attn_gym/linear/kda/__init__.py
@@ -30,7 +30,13 @@ from attn_gym.linear.kda.masking import (
 )
 
 # Note: Lazy Imports (see attn_gym/linear/__init__.py)
-_BACKEND_EXPORTS = {"l2norm": "attn_gym.linear.kda.fwd.triton.l2norm_fwd"}
+_BACKEND_EXPORTS = {
+    "l2norm": "attn_gym.linear.kda.fwd.triton.l2norm_fwd",
+    # Staged primitives around the affine state boundary (stages.py).
+    "ChunkKDASaved": "attn_gym.linear.kda.stages",
+    "chunk_kda_prepare": "attn_gym.linear.kda.stages",
+    "chunk_kda_prepare_backward": "attn_gym.linear.kda.stages",
+}
 # Backward compat: these moved to attn_gym.linear.short_conv, which owns their
 # lazy resolution and error message; import them from attn_gym.linear instead.
 _SHORT_CONV_BC = {"causal_conv1d", "causal_conv1d_decode", "register_activation"}
@@ -45,7 +51,9 @@ def __getattr__(name: str):
     try:
         module = importlib.import_module(module_name)
     except ImportError as error:
-        raise ImportError(f"{name} requires CUDA with Triton support") from error
+        raise ImportError(
+            f"{name} requires the optional CUDA kernel backends: pip install attn-gym[linear]"
+        ) from error
     return getattr(module, name)
 
 

--- a/attn_gym/linear/kda/stages.py
+++ b/attn_gym/linear/kda/stages.py
@@ -1,0 +1,347 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Staged fused KDA around a public affine state boundary.
+
+``chunk_kda`` runs the fused core as one autograd function. Schemes that move recurrent state
+between devices (context parallelism, pipelined state handoff, ...) need the same core split around
+a communication point in both directions::
+
+    prepared = chunk_kda_prepare(q, k, v, gate, beta, cu_seqlens=cu_seqlens)  # WY factors, once
+    summary = prepared.state_summary(start, stop)          # [bias; transition] of one subsequence
+    ...exchange summaries, compose each subsequence's entry state...
+    output, final_state = prepared.run(initial_state, output_final_state=True)
+
+    grads = chunk_kda_prepare_backward(saved, d_output, initial_state, scale=prepared.scale)
+    grad_summary = grads.state_grad_summary(start, stop)
+    ...exchange, compose each subsequence's exit cotangent...
+    dq, dk, dv, dgate, dbeta, d_initial_state = grads.run(d_final_state)
+
+The handles keep the factor tensors private, so the contract is the affine summary described in
+``attn_gym.linear.state_summary``: an FP32 ``[HV, V + K, K]`` map packed as ``[bias; transition]``.
+Which tokens a device owns and how summaries travel are the caller's decisions; a context-parallel
+recipe is one composition built only on these handles.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import NamedTuple
+
+import torch
+
+from attn_gym._backends.cute import normalize_compact_tensor, normalize_tma_rows
+from attn_gym.linear._delta_rule.cute import build_state_grad_summary, build_state_summary
+from attn_gym.linear._delta_rule.validation import check_summary_range, resolve_scale
+from attn_gym.linear.kda.bwd.cute.chunk_kda_bwd import (
+    ChunkKDABwdPrepared,
+    _finish_chunk_kda_bwd,
+    _prepare_chunk_kda_bwd,
+)
+from attn_gym.linear.kda.chunk_schedule import (
+    RaggedChunkMetadata,
+    chunk_capacity,
+    prepare_ragged_chunk_metadata,
+)
+from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd import (
+    ChunkKDAFactors,
+    _finish_chunk_kda_fwd,
+    _prepare_chunk_kda_fwd,
+)
+from attn_gym.linear.kda.impl.fused import _validate_fused_constraints
+from attn_gym.linear.kda.ops import _plain_gate_scan_op
+from attn_gym.linear.kda.validation import validate_kda_inputs
+
+CHUNK_SIZE = 64
+"""Token block of the fused kernels; see NOTE [Summary ranges are whole chunks of one subsequence]
+below."""
+
+
+class ChunkKDASaved(NamedTuple):
+    """Forward tensors an autograd function stores for ``chunk_kda_prepare_backward``.
+
+    Every field is a tensor or ``None`` so the tuple can be splatted into
+    ``ctx.save_for_backward`` and rebuilt from ``ctx.saved_tensors``.
+    """
+
+    q: torch.Tensor
+    k: torch.Tensor
+    v: torch.Tensor
+    cumulative_gate: torch.Tensor
+    beta: torch.Tensor
+    aqk: torch.Tensor
+    akk: torch.Tensor
+    cu_seqlens: torch.Tensor | None
+    chunk_offsets: torch.Tensor | None
+
+
+def _metadata_from_saved(saved: ChunkKDASaved) -> RaggedChunkMetadata | None:
+    if saved.cu_seqlens is None:
+        return None
+    assert saved.chunk_offsets is not None
+    tokens = saved.q.shape[1]
+    return RaggedChunkMetadata(
+        saved.cu_seqlens,
+        saved.chunk_offsets,
+        chunk_capacity(tokens, saved.cu_seqlens.shape[0] - 1, CHUNK_SIZE),
+        CHUNK_SIZE,
+    )
+
+
+# NOTE [Summary ranges are whole chunks of one subsequence]
+# ``state_summary(start, stop)`` and ``state_grad_summary(start, stop)`` take LOCAL span offsets
+# (see NOTE [Terminology] in ``attn_gym.linear.state_summary``). The factor kernels lay 64-token
+# chunks from each subsequence's first token, and every chunk's factors are scaled toward that
+# chunk's last token, so a summary is exact only over whole chunks of one subsequence:
+#
+#     start = sub_start + CHUNK_SIZE * i
+#     stop  = sub_start + CHUNK_SIZE * j   or   stop = sub_end   (the partial tail chunk is fine)
+#     [start, stop) must not cross a ``cu_seqlens`` boundary
+#
+# The recipe always passes one whole subsequence, ``(cu_seqlens[i], cu_seqlens[i + 1])``, which
+# satisfies this trivially. A range that starts or stops mid-chunk, or spans two subsequences,
+# returns a plausible but wrong map. The methods only bounds-check: the boundaries are host
+# integers the caller already holds, and comparing them against the device ``cu_seqlens`` would
+# force a sync inside CUDA Graph capture.
+
+
+def _normalize_state(state: torch.Tensor | None) -> torch.Tensor | None:
+    """FP32 entry state with a unit-stride key mode, as the recurrence kernels read it.
+
+    Only the key mode must be contiguous, so a batch or head slice of a larger state buffer is
+    passed through without a copy.
+    """
+    if state is None:
+        return None
+    state = state.float()
+    return state if state.stride(-1) == 1 else state.contiguous()
+
+
+@dataclass
+class ChunkKDAPrepared:
+    """Local forward factors shared by ``state_summary`` and ``run``.
+
+    The factors are large; release the handle once ``run`` has produced the output.
+    """
+
+    saved: ChunkKDASaved
+    factors: ChunkKDAFactors
+    metadata: RaggedChunkMetadata | None
+    scale: float
+    autotune: bool
+
+    def state_summary(self, start: int, stop: int) -> torch.Tensor:
+        """Return the FP32 ``[HV, V + K, K]`` map of tokens ``[start, stop)`` from the zero state.
+
+        See NOTE [Summary ranges are whole chunks of one subsequence].
+        """
+        check_summary_range(self.saved.q.shape[1], start, stop)
+        return build_state_summary(
+            self.factors.kg[:, start:stop],
+            self.factors.w[:, start:stop],
+            self.factors.u[:, start:stop],
+            self.saved.cumulative_gate[:, start:stop],
+        )
+
+    def run(
+        self,
+        initial_state: torch.Tensor | None = None,
+        *,
+        output_final_state: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Finish the local forward from one FP32 ``[N, HV, V, K]`` entry state per sequence."""
+        return _finish_chunk_kda_fwd(
+            self.saved.q,
+            self.saved.cumulative_gate,
+            self.factors,
+            _normalize_state(initial_state),
+            None,
+            None,
+            self.metadata,
+            scale=self.scale,
+            output_final_state=output_final_state,
+            autotune=self.autotune,
+        )
+
+
+def chunk_kda_prepare(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    *,
+    cu_seqlens: torch.Tensor | None = None,
+    scale: float | None = None,
+    autotune: bool = True,
+) -> ChunkKDAPrepared:
+    """Run the factor half of fused ``chunk_kda`` and return a handle for summaries and output.
+
+    Arguments follow ``chunk_kda`` with two restrictions: ``q``/``k``/``v`` must already share a
+    float16 or bfloat16 dtype (no silent cast, because the caller owns autograd), and the batch
+    dimension must be one so token offsets index one packed span (NOTE [Terminology] in
+    ``attn_gym.linear.state_summary``).
+    """
+    validate_kda_inputs(
+        q, k, v, gate, beta, None, cu_seqlens, op_name="chunk_kda_prepare", gate_name="gate"
+    )
+    _validate_fused_constraints(q, v)
+    if q.dtype not in (torch.float16, torch.bfloat16) or k.dtype != q.dtype or v.dtype != q.dtype:
+        raise TypeError(
+            "chunk_kda_prepare requires q, k, and v to share dtype float16 or bfloat16"
+        )
+    if q.shape[0] != 1:
+        raise ValueError("chunk_kda_prepare requires B=1; pack sequences with cu_seqlens")
+    q, k, v = (normalize_tma_rows(tensor) for tensor in (q, k, v))
+    tokens = q.shape[1]
+    if cu_seqlens is None and tokens % CHUNK_SIZE:
+        # A partial tail runs as one packed sequence; arange keeps the launch capture-safe.
+        cu_seqlens = torch.arange(2, dtype=torch.int32, device=q.device) * tokens
+    metadata = (
+        None
+        if cu_seqlens is None
+        else prepare_ragged_chunk_metadata(cu_seqlens, tokens, CHUNK_SIZE)
+    )
+    cu_seqlens = None if metadata is None else metadata.cu_seqlens
+    chunk_offsets = None if metadata is None else metadata.chunk_offsets
+    scale = resolve_scale(scale, q.shape[-1])
+    beta = normalize_compact_tensor(beta.float())
+    cumulative_gate = _plain_gate_scan_op(gate.float(), cu_seqlens, chunk_offsets, False)
+    factors = _prepare_chunk_kda_fwd(
+        q, k, v, cumulative_gate, beta, metadata, scale=scale, autotune=autotune
+    )
+    saved = ChunkKDASaved(
+        q, k, v, cumulative_gate, beta, factors.aqk, factors.akk, cu_seqlens, chunk_offsets
+    )
+    return ChunkKDAPrepared(saved, factors, metadata, scale, autotune)
+
+
+@dataclass
+class ChunkKDABackward:
+    """Recomputed local backward tensors shared by ``state_grad_summary`` and ``run``.
+
+    ``run`` consumes the recomputed tensors at their last use, so call it once and last.
+    """
+
+    saved: ChunkKDASaved
+    d_output: torch.Tensor
+    initial_state: torch.Tensor | None
+    metadata: RaggedChunkMetadata | None
+    prepared: ChunkKDABwdPrepared
+    scale: float
+    autotune: bool
+    fastmath: bool
+
+    def state_grad_summary(self, start: int, stop: int) -> torch.Tensor:
+        """Return the FP32 ``[HV, V + K, K]`` reverse map of tokens ``[start, stop)``.
+
+        Packed as ``[C; R]`` with ``d_entry_state = d_exit_state @ R + C``, where ``C`` is the
+        cotangent the range's own ``d_output`` sends to its entry state. See
+        NOTE [Summary ranges are whole chunks of one subsequence].
+        """
+        check_summary_range(self.saved.q.shape[1], start, stop)
+        assert self.prepared.qg is not None and self.prepared.kg is not None
+        assert self.prepared.w is not None
+        return build_state_grad_summary(
+            self.prepared.qg[:, start:stop],
+            self.prepared.kg[:, start:stop],
+            self.prepared.w[:, start:stop],
+            self.d_output[:, start:stop],
+            self.saved.aqk[:, start:stop],
+            self.saved.cumulative_gate[:, start:stop],
+            self.scale,
+        )
+
+    def run(
+        self, d_final_state: torch.Tensor | None = None
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor | None,
+    ]:
+        """Finish the local backward from one FP32 ``[N, HV, V, K]`` exit cotangent per sequence.
+
+        Returns ``(dq, dk, dv, dgate, dbeta, d_initial_state)``; the last is ``None`` when the
+        forward ran without an entry state.
+        """
+        if d_final_state is not None:
+            d_final_state = normalize_compact_tensor(d_final_state.float())
+        saved = self.saved
+        dq, dk, dv, d_cumulative, dbeta, d_initial_state = _finish_chunk_kda_bwd(
+            saved.q,
+            saved.k,
+            saved.v,
+            saved.cumulative_gate,
+            saved.beta,
+            saved.aqk,
+            saved.akk,
+            self.d_output,
+            d_final_state,
+            self.initial_state,
+            self.metadata,
+            self.prepared,
+            scale=self.scale,
+            chunk_size=CHUNK_SIZE,
+            fastmath=self.fastmath,
+            autotune=self.autotune,
+        )
+        dgate = _plain_gate_scan_op(d_cumulative, saved.cu_seqlens, saved.chunk_offsets, True)
+        return dq, dk, dv, dgate, dbeta, d_initial_state
+
+
+def chunk_kda_prepare_backward(
+    saved: ChunkKDASaved,
+    d_output: torch.Tensor | None,
+    initial_state: torch.Tensor | None,
+    *,
+    scale: float,
+    autotune: bool = True,
+    fastmath: bool = False,
+) -> ChunkKDABackward:
+    """Recompute the local backward tensors before any reverse-summary exchange.
+
+    ``initial_state`` is the entry state the forward ``run`` consumed and ``scale`` is the
+    forward handle's resolved ``prepared.scale``; there is no default because a silently
+    re-derived scale would corrupt every gradient. Both live outside ``saved`` because the
+    caller's autograd function owns them. ``fastmath`` applies to the gradient kernels as in
+    ``chunk_kda``.
+    """
+    metadata = _metadata_from_saved(saved)
+    if d_output is None:
+        d_output = torch.zeros_like(saved.v)
+    else:
+        d_output = normalize_compact_tensor(d_output.to(saved.v.dtype))
+    initial_state = _normalize_state(initial_state)  # The backward recomputes the chain from it.
+    scale = float(scale)
+    prepared = _prepare_chunk_kda_bwd(
+        saved.q,
+        saved.k,
+        saved.v,
+        saved.cumulative_gate,
+        saved.beta,
+        saved.akk,
+        d_output,
+        initial_state,
+        metadata,
+        scale=scale,
+        chunk_size=CHUNK_SIZE,
+        autotune=autotune,
+    )
+    return ChunkKDABackward(
+        saved, d_output, initial_state, metadata, prepared, scale, autotune, fastmath
+    )
+
+
+__all__ = [
+    "ChunkKDABackward",
+    "ChunkKDAPrepared",
+    "ChunkKDASaved",
+    "chunk_kda_prepare",
+    "chunk_kda_prepare_backward",
+]

--- a/attn_gym/linear/state_summary.py
+++ b/attn_gym/linear/state_summary.py
@@ -1,0 +1,168 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Affine state-summary algebra shared by every delta-rule variant.
+
+Each delta-rule token step is affine in the V-major recurrent state ``H: [V, K]`` (one per value
+head ``HV``; GQA key heads are already expanded by the factor kernels)::
+
+    H_t = H_{t-1} @ A_t + B_t      A_t = diag(exp g_t) (I - beta_t k_t k_t^T),  B_t = beta_t v_t k_t^T
+
+so any token range collapses to one FP32 map ``H_out = H_in @ A + B``, packed here as
+``[HV, V + K, K] = [bias; transition]``. Reverse summaries pack the cotangent map
+``dH_in = dH_out @ R + C`` the same way. These helpers are pure PyTorch; the per-op ``stages``
+modules produce the summaries and the caller moves them between devices.
+
+NOTE [Terminology]
+The staged primitives, ownership plans, and the context-parallel recipe share one vocabulary and
+two index spaces. GLOBAL means the whole stream one context-parallel group processes: one
+data-parallel replica's tokens, so "global" here is DP-local. ``cp_rank`` is the rank within that
+CP group. Anything a plan is built from is GLOBAL; anything that touches a tensor on a rank is
+LOCAL.
+
+    global stream   the whole packed token stream, ``cu_seqlens_global``            GLOBAL
+    sequence        one document in the global stream                               GLOBAL
+    fragment        one contiguous global token range a rank owns; may cover        GLOBAL
+                    several sequences; a rank owns a list of them (one for a
+                    contiguous shard, two for zig-zag, more for finer balancing).
+                    The loader or sharder chooses the fragment table; the plan
+                    only derives routing from it
+    subsequence     the tokens of one fragment that belong to one sequence; a       GLOBAL
+                    fragment covering several sequences has several subsequences,
+                    and each becomes one ``cu_seqlens`` segment of the owner's span
+    span            the concatenation of a rank's fragments, in the order it        LOCAL
+                    listed them: the packed ``q``/``k``/``v``/``output`` tensors on
+                    that rank, with ``cu_seqlens`` marking its subsequence boundaries
+    chunk           the ``kda.stages.CHUNK_SIZE`` (64) token block the fused         LOCAL
+                    kernels work in (WY factors and one state step per block);
+                    every subsequence is chunked on its own, starting at its first
+                    token, so its last chunk may be partial and no fragment cut
+                    needs to be chunk-aligned
+    summary         the ``[bias; transition]`` map of a token range of the span     LOCAL range
+    slot            ``gathered[rank][i]``: the summary of that rank's i-th          (rank, index)
+                    subsequence, or the identity ``[0; I]`` when nobody needs it
+    predecessors /  subsequences of the same sequence earlier / later in global     (rank, slot)
+    successors      order; the only cross-rank references a plan holds
+    terminal        subsequences that end their sequence; true final states         LOCAL index
+                    live there
+
+How they nest, for ``cu_seqlens_global = (0, 40, 232, 384)`` and the zig-zag fragment table
+``fragments_global = [[(0, 96), (288, 384)], [(96, 192), (192, 288)]]``::
+
+    GLOBAL
+    tokens      0     40             96       192   232      288      384
+    sequences   |- s0 -|------------ s1 --------------|-------- s2 --------|
+    rank 0       [====== frag A ======]                        [= frag B =]
+    rank 1                             [ frag C ][= frag D ==]
+
+    LOCAL (one span per rank; each cell is one subsequence; cu_seqlens values are that rank's own)
+    rank 0 span   A∩s0 | A∩s1 | B∩s2        cu_seqlens (0, 40, 96, 192)
+    rank 1 span   C∩s1 | D∩s1 | D∩s2        cu_seqlens (0, 96, 136, 192)
+
+    chains        s1: A∩s1 -> C∩s1 -> D∩s1        s2: D∩s2 -> B∩s2        s0: A∩s0 alone
+
+Who passes which indices, for rank 1 above. Names ending in ``_global`` live in the GLOBAL index
+space; everything else is LOCAL to this rank's span. The plan's inputs and every plan field are
+host Python integers; the only offsets tensor the kernels ever see is the span's own::
+
+    # Host: routing; ``cp_rank`` picks this rank's row of the fragment table.
+    cu_seqlens_global = (0, 40, 232, 384)
+    fragments_global = [[(0, 96), (288, 384)], [(96, 192), (192, 288)]]
+    plan = ContextParallelPlan.from_fragments(cu_seqlens_global, fragments_global, cp_rank=1)
+    plan.subsequences -> (C∩s1 [96,192), D∩s1 [192,232), D∩s2 [232,288))
+    plan.cu_seqlens -> (0, 96, 136, 192)
+
+    # Device: the loader lays out fragments_global[1] back to back, in that order, so the span's
+    # tokens match plan.subsequences.
+    input_ids = <fragments_global[1] flattened by the loader>                 # [1, 192]
+    q, k, v, gate, beta = embed / project / short-conv the span               # [1, 192, HV, 128]
+    cu_seqlens = torch.tensor(plan.cu_seqlens, dtype=torch.int32, device=device)
+
+    # Device: all offsets LOCAL.
+    prepared = chunk_kda_prepare(q, k, v, gate, beta, cu_seqlens=cu_seqlens)
+    slots = summary_slots(prepared, plan, neutral_summary(HV, 128, 128, device=device))
+    #   one entry per local subsequence, in span order, padded to plan.slots:
+    #   slot 0: prepared.state_summary(0, 96)      C∩s1 has a successor (D∩s1)
+    #   slot 1: identity [0; I]                    D∩s1 ends s1, nobody needs it
+    #   slot 2: prepared.state_summary(136, 192)   D∩s2 has a successor (rank 0's B∩s2)
+    gathered = all_gather(slots)                              # [world, plan.slots, HV, V + K, K]
+    initial_state = compose_entry_states(gathered, plan)      # one per subsequence
+    #   C∩s1: merge(0, gathered[0][1])
+    #   D∩s1: merge(merge(0, gathered[0][1]), gathered[1][0])
+    #   D∩s2: 0
+    output, exit_states = prepared.run(initial_state, output_final_state=True)
+    #   exit_states holds one state per subsequence; only plan.terminal entries are a sequence's
+    #   true final state (here D∩s1's, for s1), the rest are intermediate. Callers that never use
+    #   final states pass output_final_state=False; the backward needs neither.
+    exit_states[list(plan.terminal)]
+
+The key contract: ``state_summary`` is always called with consecutive entries of the span's own
+``plan.cu_seqlens`` (LOCAL), so every summary covers exactly one whole subsequence.
+
+What the table does not constrain:
+
+- Ranks need not own equal token counts. Nothing is exchanged per token; the gather is over
+  ``plan.slots`` fixed-shape summaries, so spans of different lengths are fine.
+- Zero-length subsequences are legal: the kernels treat a repeated ``cu_seqlens`` entry as an
+  ordinary empty sequence with an unused state row, and the plan never asks one for a summary.
+- Summary work is bounded by fragments, not documents. Only a fragment's last subsequence can have
+  a successor and only its first can have predecessors; interior subsequences are whole documents
+  that start from zero. So a rank computes at most one summary per fragment it owns, and no chain
+  is longer than the number of fragments in the table.
+
+CUDA Graph capture is valid for one *plan*, not merely one set of shapes. Fixing shapes is the
+easy part: the loader pads the span with a padding *document* (its own sequence, loss-masked) and
+the subsequence count could be padded with empty ones. But ``state_summary(start, stop)`` bakes
+host offsets into the launch and ``compose_entry_states`` bakes the ``(rank, slot)`` chains into
+indexing ops, so a replay also needs the same ``cu_seqlens_global`` and therefore the same
+subsequence layout. Replaying across sampled document layouts would need summaries over all
+``N`` local segments from device ``cu_seqlens`` and device-tensor routing; neither exists yet.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+def neutral_summary(
+    heads: int, value_dim: int, key_dim: int, *, device: torch.device | str
+) -> torch.Tensor:
+    """Return the identity map ``[0; I]``: ``merge_state(state, neutral) == state``.
+
+    Collectives need every participant to contribute a same-shaped tensor even when nobody
+    consumes its slot; the identity is the harmless filler.
+    """
+    summary = torch.zeros(heads, value_dim + key_dim, key_dim, dtype=torch.float32, device=device)
+    summary[:, value_dim:, :] = torch.eye(key_dim, dtype=torch.float32, device=device)
+    return summary
+
+
+def merge_state(state: torch.Tensor, summary: torch.Tensor) -> torch.Tensor:
+    """Apply a packed ``[bias; transition]`` summary to a V-major state: ``state @ A + B``.
+
+    The product runs in FP64 so the result does not depend on the caller's
+    ``torch.get_float32_matmul_precision()``: under ``"high"`` an FP32 matmul silently rounds
+    the operands to TF32, and these maps are small enough that the cast is negligible.
+    """
+    value_dim = state.shape[-2]
+    merged = state.double() @ summary[..., value_dim:, :].double() + summary[..., :value_dim, :]
+    return merged.to(state.dtype)
+
+
+def compose_summaries(first: torch.Tensor, then: torch.Tensor) -> torch.Tensor:
+    """Compose two summaries into the map that applies ``first`` and then ``then``.
+
+    ``(A0, B0) ∘ (A1, B1) = (A0 @ A1, B0 @ A1 + B1)``. Folding predecessors from the zero state
+    with ``merge_state`` gives the same entry state; composition is for scans that combine maps
+    before any state is known.
+    """
+    value_dim = first.shape[-2] - first.shape[-1]
+    bias, transition = first[..., :value_dim, :], first[..., value_dim:, :]
+    composed_transition = (transition.double() @ then[..., value_dim:, :].double()).to(first.dtype)
+    return torch.cat((merge_state(bias, then), composed_transition), dim=-2)
+
+
+__all__ = ["compose_summaries", "merge_state", "neutral_summary"]

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -389,3 +389,74 @@ forgetting-horizon splitting. Install the `mega` extra to use this backend.
 ::: attn_gym.linear.recurrent_kda_decode
 
 ::: attn_gym.linear.Impl
+
+## Staged Primitives
+
+Every delta-rule token step is affine in the V-major recurrent state, so any token range
+collapses to one FP32 map `H_out = H_in @ A + B`, packed as `[HV, V + K, K] = [bias; transition]`
+(one map per value head; GQA key heads are expanded by the factor kernels). Moving state between
+devices (context parallelism, pipelined state handoff, ...) is therefore a prefix scan over these
+summaries, and it needs the fused core split around the communication point in both directions.
+
+### Terminology and index spaces
+
+Anything a plan is built from is **global**; anything that touches a tensor on a rank is
+**local**. `attn_gym.linear.state_summary` carries the canonical `NOTE [Terminology]`.
+
+| term | meaning | space |
+|---|---|---|
+| global stream | the whole packed token stream, `cu_seqlens_global` | global |
+| sequence | one document in the global stream | global |
+| fragment | one contiguous global token range a rank owns; may cover several sequences. A rank owns a list of them: one for a contiguous shard, two for zig-zag | global |
+| subsequence | the tokens of one fragment that belong to one sequence; a fragment covering several sequences has several subsequences, and each becomes one `cu_seqlens` segment of the owner's span | global |
+| span | the concatenation of a rank's fragments, in the order it listed them: the packed `q`/`k`/`v`/`output` tensors on that rank, with `cu_seqlens` marking its subsequence boundaries | local |
+| chunk | the `attn_gym.linear.kda.stages.CHUNK_SIZE` (64) token block the fused kernels work in (WY factors and one state step per block); every subsequence is chunked on its own, starting at its first token, so its last chunk may be partial and no fragment cut needs to be chunk-aligned | local |
+| summary | the `[bias; transition]` map of a token range of the span | local range |
+| slot | `gathered[rank][i]`: the summary of that rank's `i`-th subsequence, or the identity | (rank, index) |
+| predecessors / successors | subsequences of the same sequence earlier / later in global order | (rank, slot) |
+| terminal | subsequences that end their sequence; true final states live there | local index |
+
+Fragment cut points are arbitrary global tokens: chunking restarts at every subsequence, so they
+need no alignment to sequences or chunks. With `cu_seqlens_global = (0, 40, 232, 384)` and the
+zig-zag table `fragments_global = [[(0, 96), (288, 384)], [(96, 192), (192, 288)]]`:
+
+```text
+global tokens   0     40             96       192   232      288      384
+sequences       |- s0 -|------------ s1 --------------|-------- s2 --------|
+rank 0           [====== frag A ======]                        [= frag B =]
+rank 1                                 [ frag C ][= frag D ==]
+
+rank 0 span:  A∩s0 | A∩s1 | B∩s2     local cu_seqlens (0, 40, 96, 192)
+rank 1 span:  C∩s1 | D∩s1 | D∩s2     local cu_seqlens (0, 96, 136, 192)
+chains:       s1 = A∩s1 -> C∩s1 -> D∩s1        s2 = D∩s2 -> B∩s2
+```
+
+`state_summary(start, stop)` takes **local** span offsets and is exact over whole chunks of one
+subsequence: `start = sub_start + 64·i`, `stop = sub_start + 64·j` or the subsequence end, never
+crossing a `cu_seqlens` boundary. The recipe always passes one whole subsequence,
+`(cu_seqlens[i], cu_seqlens[i + 1])`.
+
+`attn_gym.linear.kda.chunk_kda_prepare` / `chunk_kda_prepare_backward` do that split without
+exposing the WY factors:
+
+```python
+from attn_gym.linear.kda import chunk_kda_prepare, chunk_kda_prepare_backward
+
+prepared = chunk_kda_prepare(q, k, v, gate, beta, cu_seqlens=cu_seqlens)
+summary = prepared.state_summary(start, stop)  # [bias; transition] of one local sequence
+# ...exchange summaries and compose each sequence's entry state...
+output, final_state = prepared.run(initial_state, output_final_state=True)
+
+grads = chunk_kda_prepare_backward(prepared.saved, d_output, initial_state, scale=prepared.scale)
+grad_summary = grads.state_grad_summary(start, stop)  # reverse map [bias; transition]
+# ...exchange and compose each sequence's exit cotangent...
+dq, dk, dv, dgate, dbeta, _ = grads.run(d_final_state)
+```
+
+`start`/`stop` are host integers naming exactly one local `cu_seqlens` segment, so CUDA Graph
+capture never syncs. `attn_gym.linear.state_summary` holds the pure-PyTorch algebra on summaries
+(`merge_state`, `compose_summaries`, `neutral_summary`).
+
+::: attn_gym.linear.kda.stages.chunk_kda_prepare
+
+::: attn_gym.linear.kda.stages.chunk_kda_prepare_backward

--- a/test/test_delta_rule_stages.py
+++ b/test/test_delta_rule_stages.py
@@ -1,0 +1,373 @@
+"""Staged delta-rule primitives: ``prepare`` / ``run`` / state summaries against the public ops."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from functools import partial
+from typing import NamedTuple
+
+import pytest
+import torch
+
+pytest.importorskip("cutlass")
+
+from attn_gym.linear.kda import chunk_kda
+from attn_gym.linear.kda.stages import chunk_kda_prepare, chunk_kda_prepare_backward
+from attn_gym.linear.state_summary import compose_summaries, merge_state, neutral_summary
+from attn_gym.testing.kda import (
+    assert_matches_low_precision_reference,
+    assert_relative_rms_within,
+    make_kda_test_inputs,
+)
+
+HEAD_DIM = 128
+
+requires_kda_target = pytest.mark.skipif(
+    not (torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 8),
+    reason="fused delta-rule kernels require CUDA capability 8.0+",
+)
+
+
+Inputs = tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]
+
+
+class Op(NamedTuple):
+    """One delta-rule variant: its public op, staged entry points, and shared input factory."""
+
+    chunk: Callable[..., tuple[torch.Tensor, torch.Tensor | None]]
+    reference: Callable[..., tuple[torch.Tensor, torch.Tensor | None]]
+    prepare: Callable[..., object]
+    prepare_backward: Callable[..., object]
+    factory: Callable[..., Inputs]  # (tokens, *, key_heads, value_heads, seed, dtype)
+    key_heads: int
+    value_heads: int
+
+    def make_inputs(self, tokens: int, seed: int, dtype: torch.dtype = torch.bfloat16) -> Inputs:
+        return self.factory(
+            tokens, key_heads=self.key_heads, value_heads=self.value_heads, seed=seed, dtype=dtype
+        )
+
+
+def kda_inputs(tokens: int, *, key_heads: int, value_heads: int, seed: int, dtype) -> Inputs:
+    assert key_heads == value_heads, "KDA has no grouped key heads"
+    return make_kda_test_inputs(
+        tokens, heads=value_heads, seed=seed, dtype=dtype, normalize_qk=True
+    )
+
+
+KDA = Op(
+    chunk_kda,
+    partial(chunk_kda, impl="reference"),
+    chunk_kda_prepare,
+    chunk_kda_prepare_backward,
+    kda_inputs,
+    key_heads=2,
+    value_heads=2,
+)
+op_param = pytest.mark.parametrize("op", [pytest.param(KDA, id="kda")])
+
+
+def test_summary_algebra_composes_like_sequential_merges():
+    generator = torch.Generator().manual_seed(0)
+    first = torch.randn(2, 6, 4, generator=generator)
+    then = torch.randn(2, 6, 4, generator=generator)
+    state = torch.randn(2, 2, 4, generator=generator)
+
+    sequential = merge_state(merge_state(state, first), then)
+    composed = compose_summaries(first, then)
+    torch.testing.assert_close(merge_state(state, composed), sequential)
+    # Spelled out: (A0, B0) then (A1, B1) is (A0 @ A1, B0 @ A1 + B1), packed [bias; transition].
+    bias, transition = first[:, :2], first[:, 2:]
+    torch.testing.assert_close(
+        composed, torch.cat((bias @ then[:, 2:] + then[:, :2], transition @ then[:, 2:]), dim=1)
+    )
+
+    identity = neutral_summary(2, 2, 4, device="cpu")
+    torch.testing.assert_close(merge_state(state, identity), state)
+    torch.testing.assert_close(compose_summaries(identity, first), first)
+    torch.testing.assert_close(compose_summaries(first, identity), first)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="TF32 is a CUDA matmul mode")
+def test_summary_algebra_ignores_the_float32_matmul_mode():
+    """``set_float32_matmul_precision("high")`` must not round state routing to TF32."""
+    generator = torch.Generator(device="cuda").manual_seed(7)
+    first = torch.randn(2, 2 * HEAD_DIM, HEAD_DIM, device="cuda", generator=generator) / 16
+    then = torch.randn(2, 2 * HEAD_DIM, HEAD_DIM, device="cuda", generator=generator) / 16
+    state = torch.randn(2, HEAD_DIM, HEAD_DIM, device="cuda", generator=generator)
+    exact_state = (state.double() @ then[:, HEAD_DIM:].double() + then[:, :HEAD_DIM]).float()
+    exact_composed = torch.cat(
+        (
+            first[:, :HEAD_DIM].double() @ then[:, HEAD_DIM:].double() + then[:, :HEAD_DIM],
+            first[:, HEAD_DIM:].double() @ then[:, HEAD_DIM:].double(),
+        ),
+        dim=1,
+    ).float()
+
+    precision = torch.get_float32_matmul_precision()
+    torch.set_float32_matmul_precision("high")
+    try:
+        merged = merge_state(state, then)
+        composed = compose_summaries(first, then)
+    finally:
+        torch.set_float32_matmul_precision(precision)
+    # TF32 keeps 10 mantissa bits (~1e-3 relative); an FP64 product stays within FP32 rounding.
+    torch.testing.assert_close(merged, exact_state, atol=1e-6, rtol=1e-6)
+    torch.testing.assert_close(composed, exact_composed, atol=1e-6, rtol=1e-6)
+
+
+@requires_kda_target
+@op_param
+def test_prepare_run_matches_chunk_op_with_packed_initial_state(op):
+    """``prepare`` + ``run`` is the public op's own kernel sequence, so results are bitwise equal."""
+    q, k, v, gate, beta = op.make_inputs(320, seed=1)
+    cu_seqlens = torch.tensor([0, 100, 320], dtype=torch.int32, device="cuda")
+    initial_state = torch.randn(2, op.value_heads, HEAD_DIM, HEAD_DIM, device="cuda")
+
+    expected, expected_state = op.chunk(
+        q, k, v, gate, beta, initial_state, cu_seqlens=cu_seqlens, output_final_state=True
+    )
+    prepared = op.prepare(q, k, v, gate, beta, cu_seqlens=cu_seqlens)
+    output, final_state = prepared.run(initial_state, output_final_state=True)
+
+    torch.testing.assert_close(output, expected, atol=0, rtol=0)
+    torch.testing.assert_close(final_state, expected_state, atol=0, rtol=0)
+
+    # A head slice of a larger state buffer has a unit key stride but is not contiguous.
+    wide = torch.randn(2, 2 * op.value_heads, HEAD_DIM, HEAD_DIM, device="cuda")
+    sliced = wide[:, ::2]
+    assert not sliced.is_contiguous()
+    expected, expected_state = op.chunk(
+        q, k, v, gate, beta, sliced.contiguous(), cu_seqlens=cu_seqlens, output_final_state=True
+    )
+    output, final_state = prepared.run(sliced, output_final_state=True)
+    torch.testing.assert_close(output, expected, atol=0, rtol=0)
+    torch.testing.assert_close(final_state, expected_state, atol=0, rtol=0)
+
+
+@requires_kda_target
+@op_param
+@pytest.mark.parametrize("tokens", [128, 70], ids=["complete-chunks", "partial-tail"])
+def test_prepare_run_matches_chunk_op_unpacked_with_strided_qkv(op, tokens):
+    """Unpacked inputs and last-dim-strided Q/K/V follow the same normalization as the op."""
+    q, k, v, gate, beta = op.make_inputs(tokens, seed=6)
+    q, k, v = (torch.stack((tensor, tensor), dim=-1)[..., 0] for tensor in (q, k, v))
+    assert q.stride(-1) == 2
+
+    # The fused ops accept either layout and the stages normalize strided inputs themselves; the
+    # reference gets compact copies so the same call also serves ops that reject strides.
+    expected, _ = op.chunk(q.contiguous(), k.contiguous(), v.contiguous(), gate, beta)
+    output, final_state = op.prepare(q, k, v, gate, beta).run()
+
+    torch.testing.assert_close(output, expected, atol=0, rtol=0)
+    assert final_state is None
+
+
+@requires_kda_target
+@op_param
+def test_state_summary_matches_zero_and_identity_probes(op):
+    """``final(H) = H @ A + B`` for every H, so zero and identity probes recover ``[B; A]``."""
+    q, k, v, gate, beta = op.make_inputs(200, seed=2)
+    # Model-range gates forget everything over 72 tokens; keep the transition above rounding.
+    gate = gate / 50
+    cu_seqlens = torch.tensor([0, 72, 200], dtype=torch.int32, device="cuda")
+    prepared = op.prepare(q, k, v, gate, beta, cu_seqlens=cu_seqlens)
+
+    zero = torch.zeros(2, op.value_heads, HEAD_DIM, HEAD_DIM, device="cuda")
+    identity = torch.eye(HEAD_DIM, device="cuda").expand_as(zero).contiguous()
+
+    def probe(run, *inputs):
+        _, bias = run(*inputs, zero, cu_seqlens=cu_seqlens, output_final_state=True)
+        _, shifted = run(*inputs, identity, cu_seqlens=cu_seqlens, output_final_state=True)
+        return bias, shifted - bias
+
+    fused = probe(op.chunk, q, k, v, gate, beta)
+    oracle = probe(op.reference, q.float(), k.float(), v.float(), gate, beta)
+    for index, (start, stop) in enumerate(((0, 72), (72, 200))):
+        summary = prepared.state_summary(start, stop)
+        assert summary.shape == (op.value_heads, 2 * HEAD_DIM, HEAD_DIM)
+        assert_summary_parts_match(summary, fused, oracle, index)
+
+
+def assert_summary_parts_match(summary, fused, oracle, index: int) -> None:
+    """Check ``[bias; transition]`` against probes of the fused op and the FP32 oracle."""
+    for name, part, low, high in zip(
+        ("bias", "transition"), summary.split(HEAD_DIM, dim=1), fused, oracle, strict=True
+    ):
+        assert_matches_low_precision_reference(part, high[index], low[index], name)
+        assert_relative_rms_within(part, high[index], name, max_eps=1.0)
+
+
+@requires_kda_target
+@op_param
+@pytest.mark.parametrize("scale", [None, 0.5], ids=["default-scale", "custom-scale"])
+@pytest.mark.parametrize(
+    "loss", ["both", "output-only", "final-state-only"], ids=lambda loss: f"loss-{loss}"
+)
+@pytest.mark.parametrize("state", ["contiguous", "strided-key", "none"])
+def test_prepare_backward_run_matches_chunk_op_gradients(op, scale, loss, state):
+    """The staged backward is the op's own kernel sequence, so all six gradients are bitwise.
+
+    Covers the cotangents the staged API makes optional (``d_output=None``, no final-state loss)
+    and the entry-state layouts ``run`` accepts: none, contiguous, and a key-strided view.
+    """
+    inputs = op.make_inputs(320, seed=7)
+    cu_seqlens = torch.tensor([0, 100, 320], dtype=torch.int32, device="cuda")
+    generator = torch.Generator(device="cuda").manual_seed(8)
+    wide = torch.randn(
+        2, op.value_heads, HEAD_DIM, 2 * HEAD_DIM, device="cuda", generator=generator
+    )
+    initial_state = {
+        "contiguous": wide[..., :HEAD_DIM].contiguous(),
+        "strided-key": wide[..., ::2],
+        "none": None,
+    }[state]
+    d_final_state = torch.randn(
+        2, op.value_heads, HEAD_DIM, HEAD_DIM, device="cuda", generator=generator
+    )
+
+    leaves = tuple(tensor.detach().clone().requires_grad_() for tensor in inputs) + (
+        () if initial_state is None else (initial_state.detach().clone().requires_grad_(),)
+    )
+    output, final_state = op.chunk(
+        *leaves, cu_seqlens=cu_seqlens, output_final_state=True, scale=scale
+    )
+    d_output = torch.randn(output.shape, device="cuda", generator=generator).to(output.dtype)
+    if loss == "output-only":
+        expected = torch.autograd.grad(output, leaves, d_output)
+        d_final_state = torch.zeros_like(d_final_state)
+    elif loss == "final-state-only":
+        expected = torch.autograd.grad(final_state, leaves, d_final_state)
+        d_output = None
+    else:
+        expected = torch.autograd.grad((output, final_state), leaves, (d_output, d_final_state))
+
+    prepared = op.prepare(*inputs, cu_seqlens=cu_seqlens, scale=scale)
+    prepared.run(initial_state, output_final_state=True)
+    grads = op.prepare_backward(prepared.saved, d_output, initial_state, scale=prepared.scale)
+    actual = grads.run(d_final_state)
+
+    assert len(actual) == 6
+    names = ("dq", "dk", "dv", "dgate", "dbeta", "d_initial_state")
+    if initial_state is None:
+        assert actual[5] is None
+        actual, names = actual[:5], names[:5]
+    for name, got, want in zip(names, actual, expected, strict=True):
+        torch.testing.assert_close(
+            got, want, atol=0, rtol=0, msg=lambda m, name=name: f"{name}: {m}"
+        )
+
+
+@requires_kda_target
+@op_param
+def test_state_grad_summary_matches_zero_and_identity_probes(op):
+    """``d_entry = d_exit @ R + C``, so zero and identity exit cotangents recover ``[C; R]``."""
+    q, k, v, gate, beta = op.make_inputs(200, seed=9)
+    gate = gate / 50  # As in the forward probe: keep the transition above rounding.
+    cu_seqlens = torch.tensor([0, 72, 200], dtype=torch.int32, device="cuda")
+    zero = torch.zeros(2, op.value_heads, HEAD_DIM, HEAD_DIM, device="cuda")
+    identity = torch.eye(HEAD_DIM, device="cuda").expand_as(zero).contiguous()
+    d_output = torch.randn(
+        v.shape, device="cuda", generator=torch.Generator(device="cuda").manual_seed(10)
+    )
+
+    def probe(run, *inputs):
+        def d_entry_state(d_exit_state):
+            entry = zero.clone().requires_grad_()
+            output, final_state = run(
+                *inputs, entry, cu_seqlens=cu_seqlens, output_final_state=True
+            )
+            (grad,) = torch.autograd.grad(
+                (output, final_state), entry, (d_output.to(output.dtype), d_exit_state)
+            )
+            return grad
+
+        bias = d_entry_state(zero)
+        return bias, d_entry_state(identity) - bias
+
+    fused = probe(op.chunk, q, k, v, gate, beta)
+    oracle = probe(op.reference, q.float(), k.float(), v.float(), gate, beta)
+    prepared = op.prepare(q, k, v, gate, beta, cu_seqlens=cu_seqlens)
+    prepared.run(zero, output_final_state=True)
+    grads = op.prepare_backward(prepared.saved, d_output.to(v.dtype), zero, scale=prepared.scale)
+    for index, (start, stop) in enumerate(((0, 72), (72, 200))):
+        summary = grads.state_grad_summary(start, stop)
+        assert summary.shape == (op.value_heads, 2 * HEAD_DIM, HEAD_DIM)
+        assert_summary_parts_match(summary, fused, oracle, index)
+
+
+@requires_kda_target
+@op_param
+def test_summaries_are_exact_over_whole_chunks_of_one_subsequence(op):
+    """NOTE [Summary ranges are whole chunks of one subsequence]: interior chunk runs compose."""
+    q, k, v, gate, beta = op.make_inputs(520, seed=11)
+    gate = gate / 50
+    # Subsequences [0, 72) and [72, 520); the second has chunk boundaries at 72 + 64 * i.
+    cu_seqlens = torch.tensor([0, 72, 520], dtype=torch.int32, device="cuda")
+    d_output = torch.randn(
+        v.shape, device="cuda", generator=torch.Generator(device="cuda").manual_seed(12)
+    )
+    zero = torch.zeros(2, op.value_heads, HEAD_DIM, HEAD_DIM, device="cuda")
+    prepared = op.prepare(q, k, v, gate, beta, cu_seqlens=cu_seqlens)
+    prepared.run(zero, output_final_state=True)
+    grads = op.prepare_backward(prepared.saved, d_output.to(v.dtype), zero, scale=prepared.scale)
+
+    one = torch.zeros(1, op.value_heads, HEAD_DIM, HEAD_DIM, device="cuda")
+    identity = torch.eye(HEAD_DIM, device="cuda").expand_as(one).contiguous()
+
+    def oracle(start, stop):
+        """Run the FP32 reference on the token range as a sequence of its own and probe it."""
+        sliced = [tensor[:, start:stop] for tensor in (q, k, v, gate, beta)]
+        inputs = [tensor.float() for tensor in sliced[:3]] + sliced[3:]
+
+        def d_entry_state(d_exit_state):
+            entry = one.clone().requires_grad_()
+            output, final_state = op.reference(*inputs, entry, output_final_state=True)
+            (grad,) = torch.autograd.grad(
+                (output, final_state), entry, (d_output[:, start:stop], d_exit_state)
+            )
+            return grad
+
+        _, bias = op.reference(*inputs, one, output_final_state=True)
+        _, shifted = op.reference(*inputs, identity, output_final_state=True)
+        reverse_bias = d_entry_state(one)
+        forward = torch.cat((bias, shifted - bias), dim=-2)[0]
+        reverse = torch.cat((reverse_bias, d_entry_state(identity) - reverse_bias), dim=-2)[0]
+        return forward, reverse
+
+    def standalone(start, stop):
+        """The staged summaries of the token range run as a stream of its own."""
+        sliced = [tensor[:, start:stop] for tensor in (q, k, v, gate, beta)]
+        own = op.prepare(*sliced)
+        own.run(one, output_final_state=True)
+        own_grads = op.prepare_backward(
+            own.saved, d_output[:, start:stop].to(v.dtype), one, scale=own.scale
+        )
+        return own.state_summary(0, stop - start), own_grads.state_grad_summary(0, stop - start)
+
+    # (start, stop) pairs on the second subsequence's chunk grid: interior runs, a single chunk,
+    # a run ending at the subsequence end, and the first chunk alone. The interior summary must
+    # match the same range summarized on its own, pointwise within that run's own error against
+    # the FP32 oracle and in aggregate.
+    for start, stop in ((136, 264), (200, 456), (136, 200), (392, 520), (72, 136)):
+        oracles = oracle(start, stop)
+        for name, actual, expected, low in zip(
+            ("forward", "reverse"),
+            (prepared.state_summary(start, stop), grads.state_grad_summary(start, stop)),
+            oracles,
+            standalone(start, stop),
+            strict=True,
+        ):
+            label = f"{name} [{start}, {stop})"
+            assert_matches_low_precision_reference(actual, expected, low, label)
+            assert_relative_rms_within(actual, expected, label, max_eps=1.0)
+
+
+@requires_kda_target
+def test_state_summary_rejects_ranges_outside_the_stream():
+    q, k, v, gate, beta = KDA.make_inputs(128, seed=3)
+    prepared = chunk_kda_prepare(q, k, v, gate, beta)
+    with pytest.raises(ValueError, match="summary range"):
+        prepared.state_summary(64, 200)
+    with pytest.raises(ValueError, match="summary range"):
+        prepared.state_summary(64, 64)


### PR DESCRIPTION
Stacked PRs:
 * #474
 * #473
 * #472
 * #478
 * #477
 * #471
 * __->__#470


--- --- ---

Add staged KDA primitives around the affine state boundary

Every delta-rule token step is affine in the recurrent state, so any token range collapses to one
FP32 `[bias; transition]` map. Anything that moves state between devices needs the fused KDA core
split around that boundary in both directions, without exposing the WY factors.

`attn_gym.linear.kda.stages` adds `chunk_kda_prepare` -> `ChunkKDAPrepared` (`state_summary(start,
stop)`, `run(initial_state)`, `saved`) and `chunk_kda_prepare_backward` -> `ChunkKDABackward`
(`state_grad_summary`, `run(d_final_state)`); `prepare` + `run` is the public op's own kernel
sequence, so results are bitwise equal. The backward takes the forward handle's resolved
`prepared.scale` with no default, so a mismatched scale cannot be re-derived silently, and `run`
accepts any entry state with a unit key stride without copying. `attn_gym.linear.state_summary` holds the pure-PyTorch
algebra on summaries (`merge_state`, `compose_summaries`, `neutral_summary`). `start`/`stop` are
host integers naming one local `cu_seqlens` segment, so CUDA Graph capture never syncs.

Tests use the shared `make_kda_test_inputs` factory and the shared pointwise and relative-RMS
error budgets against the FP32 reference. `prepare` + `run` and `prepare_backward` + `run` (with
an entry state, an exit cotangent, and a custom scale) are bitwise against `chunk_kda` and its
autograd; zero / identity probes of the initial state and of the exit cotangent recover the forward
`[B; A]` and reverse `[C; R]` summaries; interior chunk runs of one subsequence match the
reference run on that slice.

`NOTE [Terminology]` in `state_summary.py` (mirrored in `docs/linear.md`) fixes the vocabulary and
index spaces the whole stack uses: global stream / sequence / fragment / subsequence (global),
span / chunk / summary (local), slot / predecessors / successors / terminal (routing). The summary
contract is stated precisely: exact over whole chunks of one subsequence, with `CHUNK_SIZE`
public.

## Human Note

## Agent note

First of seven (split out of #453). GDN stages, the device-bounds summary kernels and
handles, ownership plans, the all-gather recipe, and Mega under CP follow in the stack.