### PR TITLE
Add staged GDN primitives on the fused chunk path

### DIFF
--- a/attn_gym/linear/_delta_rule/span.py
+++ b/attn_gym/linear/_delta_rule/span.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Span preparation shared by the staged KDA and GDN primitives."""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+import torch
+
+from attn_gym._backends.cute import normalize_compact_tensor, normalize_tma_rows
+from attn_gym.linear._delta_rule.validation import resolve_scale
+from attn_gym.linear.kda.chunk_schedule import RaggedChunkMetadata, prepare_ragged_chunk_metadata
+
+CHUNK_SIZE = 64
+
+
+class PreparedSpan(NamedTuple):
+    """Normalized operands and chunk schedule of one ``B=1`` span."""
+
+    q: torch.Tensor
+    k: torch.Tensor
+    v: torch.Tensor
+    beta: torch.Tensor  # FP32, compact
+    metadata: RaggedChunkMetadata | None  # None on the dense path
+    cu_seqlens: torch.Tensor | None
+    chunk_offsets: torch.Tensor | None
+    scale: float
+
+
+def prepare_span(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    *,
+    cu_seqlens: torch.Tensor | None,
+    scale: float | None,
+) -> PreparedSpan:
+    """Normalize the operands of a ``B=1`` span and build its chunk schedule.
+
+    A dense span with a partial tail chunk runs as one packed sequence; ``torch.arange`` keeps that
+    launch capture-safe.
+    """
+    if q.shape[0] != 1:
+        raise ValueError("staged primitives require B=1; pack sequences with cu_seqlens")
+    tokens = q.shape[1]
+    if cu_seqlens is None and tokens % CHUNK_SIZE:
+        cu_seqlens = torch.arange(2, dtype=torch.int32, device=q.device) * tokens
+    metadata = (
+        None
+        if cu_seqlens is None
+        else prepare_ragged_chunk_metadata(cu_seqlens, tokens, CHUNK_SIZE)
+    )
+    q, k, v = (normalize_tma_rows(tensor) for tensor in (q, k, v))
+    return PreparedSpan(
+        q,
+        k,
+        v,
+        normalize_compact_tensor(beta.float()),
+        metadata,
+        None if metadata is None else metadata.cu_seqlens,
+        None if metadata is None else metadata.chunk_offsets,
+        resolve_scale(scale, q.shape[-1]),
+    )
+
+
+def zero_state(
+    q: torch.Tensor, v: torch.Tensor, metadata: RaggedChunkMetadata | None
+) -> torch.Tensor:
+    """FP32 ``[N, HV, V, K]`` zeros, one per packed sequence (per batch row when dense)."""
+    sequences = q.shape[0] if metadata is None else metadata.cu_seqlens.shape[0] - 1
+    return q.new_zeros(sequences, v.shape[2], v.shape[-1], q.shape[-1], dtype=torch.float32)

--- a/attn_gym/linear/_lazy.py
+++ b/attn_gym/linear/_lazy.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Module ``__getattr__`` factory for backend-backed exports (see Note: Lazy Imports)."""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Callable, Mapping
+
+
+def lazy_exports(
+    module_name: str, exports: Mapping[str, str], *, requirement: str
+) -> Callable[[str], object]:
+    """Return a module ``__getattr__`` that imports each export's owning module on first use.
+
+    ``exports`` maps a public name to the module that defines it. A missing optional dependency
+    surfaces as ``ImportError("<name> requires the optional <requirement>: pip install ...")``.
+    """
+
+    def __getattr__(name: str) -> object:
+        owner = exports.get(name)
+        if owner is None:
+            raise AttributeError(f"module {module_name!r} has no attribute {name!r}")
+        try:
+            module = importlib.import_module(owner)
+        except ImportError as error:
+            raise ImportError(
+                f"{name} requires the optional {requirement}: pip install attn-gym[linear]"
+            ) from error
+        return getattr(module, name)
+
+    return __getattr__

--- a/attn_gym/linear/gdn/__init__.py
+++ b/attn_gym/linear/gdn/__init__.py
@@ -1,5 +1,6 @@
 """Gated delta rule attention."""
 
+from attn_gym.linear._lazy import lazy_exports
 from attn_gym.linear.gdn.api import (
     KernelOptions,
     chunk_gdn,
@@ -8,10 +9,24 @@ from attn_gym.linear.gdn.api import (
     recurrent_gdn_decode,
 )
 
-__all__ = [
-    "KernelOptions",
-    "chunk_gdn",
-    "paged_chunk_gdn",
-    "recurrent_gdn",
-    "recurrent_gdn_decode",
-]
+# Note: Lazy Imports (see attn_gym/linear/__init__.py)
+_BACKEND_EXPORTS = {
+    "ChunkGDNSaved": "attn_gym.linear.gdn.stages",
+    "chunk_gdn_prepare": "attn_gym.linear.gdn.stages",
+    "chunk_gdn_prepare_backward": "attn_gym.linear.gdn.stages",
+}
+
+
+__getattr__ = lazy_exports(__name__, _BACKEND_EXPORTS, requirement="CUDA kernel backends")
+
+
+__all__ = sorted(  # noqa: PLE0605 -- backend exports resolve lazily
+    [
+        "KernelOptions",
+        "chunk_gdn",
+        "paged_chunk_gdn",
+        "recurrent_gdn",
+        "recurrent_gdn_decode",
+        *_BACKEND_EXPORTS,
+    ]
+)

--- a/attn_gym/linear/gdn/impl/chunk.py
+++ b/attn_gym/linear/gdn/impl/chunk.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import NamedTuple
+
 import torch
 
 from attn_gym._backends.cute import (
@@ -10,6 +12,7 @@ from attn_gym._backends.cute import (
     normalize_tma_rows,
 )
 from attn_gym._backends.triton.utils import requires_int64_offsets
+from attn_gym.linear._delta_rule.span import zero_state
 from attn_gym.linear._delta_rule.validation import validate_paged_state
 from attn_gym.linear.gdn.bwd.triton.chunk_gdn_bwd_delta_h import chunk_gdn_bwd_delta_h
 from attn_gym.linear.gdn.bwd.triton.chunk_gdn_bwd_intra import (
@@ -63,6 +66,51 @@ def reject_int64_offsets(*tensors: torch.Tensor | None) -> None:
         raise ValueError("fused chunk_gdn does not yet support int64 tensor offsets")
 
 
+class ChunkGDNFactors(NamedTuple):
+    """Local WY factors shared by context-parallel state summaries and output composition."""
+
+    w: torch.Tensor
+    u: torch.Tensor
+    kg: torch.Tensor
+    inverse: torch.Tensor
+
+
+def _prepare_chunk_gdn_fwd(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    metadata: RaggedChunkMetadata | None,
+) -> ChunkGDNFactors:
+    """Run the intra-chunk factorization on already normalized inputs."""
+    if metadata is None:
+        return ChunkGDNFactors(*chunk_gdn_fwd_intra_dense(k, v, cumulative_gate, beta))
+    return ChunkGDNFactors(*chunk_gdn_fwd_intra_packed(k, v, cumulative_gate, beta, metadata))
+
+
+def _finish_chunk_gdn_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    factors: ChunkGDNFactors,
+    cumulative_gate: torch.Tensor,
+    initial_state: torch.Tensor,
+    metadata: RaggedChunkMetadata | None,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run the state recurrence and output composition from prepared factors."""
+    if metadata is None:
+        h, v_new, final_state = chunk_gdn_fwd_recurrence_dense(
+            factors.kg, factors.w, factors.u, cumulative_gate, initial_state
+        )
+        output = chunk_gdn_fwd_output_dense(q, k, v_new, h, cumulative_gate, scale)
+    else:
+        h, v_new, final_state = chunk_gdn_fwd_recurrence_packed(
+            factors.kg, factors.w, factors.u, cumulative_gate, initial_state, metadata
+        )
+        output = chunk_gdn_fwd_output_packed(q, k, v_new, h, cumulative_gate, scale, metadata)
+    return output, final_state
+
+
 def chunk_gdn_fwd_dense(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -83,30 +131,18 @@ def chunk_gdn_fwd_dense(
     if cumulative_gate.shape != v.shape[:3] or beta.shape != v.shape[:3]:
         raise ValueError("cumulative_gate and beta must have shape [B,T,H]")
     if initial_state is None:
-        initial_state = torch.zeros(
-            batch,
-            value_heads,
-            value_dim,
-            key_dim,
-            dtype=torch.float32,
-            device=q.device,
-        )
+        initial_state = zero_state(q, v, None)
     reject_int64_offsets(q, k, v, cumulative_gate, beta, initial_state)
     q, k, v = (normalize_tma_rows(tensor) for tensor in (q, k, v))
     cumulative_gate, beta, initial_state = (
         normalize_compact_tensor(tensor) for tensor in (cumulative_gate, beta, initial_state)
     )
 
-    w, u, restored_k, inverse = chunk_gdn_fwd_intra_dense(k, v, cumulative_gate, beta)
-    h, v_new, final_state = chunk_gdn_fwd_recurrence_dense(
-        restored_k,
-        w,
-        u,
-        cumulative_gate,
-        initial_state,
+    factors = _prepare_chunk_gdn_fwd(k, v, cumulative_gate, beta, None)
+    output, final_state = _finish_chunk_gdn_fwd(
+        q, k, factors, cumulative_gate, initial_state, None, scale
     )
-    output = chunk_gdn_fwd_output_dense(q, k, v_new, h, cumulative_gate, scale)
-    return output, final_state, inverse
+    return output, final_state, factors.inverse
 
 
 def _gdn_chunk_fwd_cuda(
@@ -152,37 +188,23 @@ def chunk_gdn_fwd_packed(
     validate_supported_device(q)
     batch, _tokens, key_heads, key_dim = q.shape
     value_heads, value_dim = v.shape[2:]
-    num_sequences = metadata.cu_seqlens.shape[0] - 1
     if batch != 1 or (key_dim, value_dim) != (128, 128):
         raise ValueError("packed fused chunk GDN requires B=1 and K=V=128")
     if k.shape != q.shape or v.shape[:2] != q.shape[:2] or value_heads % key_heads:
         raise ValueError("packed fused chunk GDN requires matching Q/K and H % HK == 0")
     if initial_state is None:
-        initial_state = torch.zeros(
-            num_sequences,
-            value_heads,
-            value_dim,
-            key_dim,
-            dtype=torch.float32,
-            device=q.device,
-        )
+        initial_state = zero_state(q, v, metadata)
     reject_int64_offsets(q, k, v, cumulative_gate, beta, initial_state)
     q, k, v = (normalize_tma_rows(tensor) for tensor in (q, k, v))
     cumulative_gate, beta, initial_state = (
         normalize_compact_tensor(tensor) for tensor in (cumulative_gate, beta, initial_state)
     )
 
-    w, u, restored_k, inverse = chunk_gdn_fwd_intra_packed(k, v, cumulative_gate, beta, metadata)
-    h, v_new, final_state = chunk_gdn_fwd_recurrence_packed(
-        restored_k,
-        w,
-        u,
-        cumulative_gate,
-        initial_state,
-        metadata,
+    factors = _prepare_chunk_gdn_fwd(k, v, cumulative_gate, beta, metadata)
+    output, final_state = _finish_chunk_gdn_fwd(
+        q, k, factors, cumulative_gate, initial_state, metadata, scale
     )
-    output = chunk_gdn_fwd_output_packed(q, k, v_new, h, cumulative_gate, scale, metadata)
-    return output, final_state, inverse
+    return output, final_state, factors.inverse
 
 
 def _gdn_chunk_fwd_packed_cuda(
@@ -278,6 +300,40 @@ def _gdn_chunk_fwd_packed_paged_cuda(
     return chunk_gdn_fwd_output_packed(q, k, v_new, h, cumulative_gate, scale, metadata)
 
 
+class ChunkGDNBwdPrepared(NamedTuple):
+    """Recomputed local tensors shared across the context-parallel backward boundary."""
+
+    w: torch.Tensor
+    qg: torch.Tensor
+    kg: torch.Tensor
+    h: torch.Tensor
+    v_new: torch.Tensor
+
+
+def _prepare_chunk_gdn_bwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    inverse: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    metadata: RaggedChunkMetadata | None,
+) -> ChunkGDNBwdPrepared:
+    """Recompute local factors and forward state on normalized inputs before communication."""
+    recurrence_state = zero_state(q, v, metadata) if initial_state is None else initial_state
+    w, u, qg, kg = chunk_gdn_recompute_w_u_qg_kg(q, k, v, cumulative_gate, beta, inverse, metadata)
+    if metadata is None:
+        h, v_new, _final_state = chunk_gdn_fwd_recurrence_dense(
+            kg, w, u, cumulative_gate, recurrence_state
+        )
+    else:
+        h, v_new, _final_state = chunk_gdn_fwd_recurrence_packed(
+            kg, w, u, cumulative_gate, recurrence_state, metadata
+        )
+    return ChunkGDNBwdPrepared(w, qg, kg, h, v_new)
+
+
 def chunk_gdn_bwd(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -312,28 +368,46 @@ def chunk_gdn_bwd(
         d_final_state = normalize_compact_tensor(d_final_state)
     if initial_state is not None:
         initial_state = normalize_compact_tensor(initial_state)
+    prepared = _prepare_chunk_gdn_bwd(
+        q, k, v, cumulative_gate, beta, inverse, initial_state, metadata
+    )
+    return _finish_chunk_gdn_bwd(
+        q,
+        k,
+        v,
+        cumulative_gate,
+        beta,
+        inverse,
+        d_output,
+        d_final_state,
+        initial_state,
+        metadata,
+        prepared,
+        scale,
+    )
 
-    state_batch = q.shape[0] if metadata is None else metadata.cu_seqlens.shape[0] - 1
-    recurrence_state = initial_state
-    if recurrence_state is None:
-        recurrence_state = torch.zeros(
-            state_batch,
-            v.shape[2],
-            v.shape[-1],
-            q.shape[-1],
-            dtype=torch.float32,
-            device=q.device,
-        )
-    w, u, qg, kg = chunk_gdn_recompute_w_u_qg_kg(q, k, v, cumulative_gate, beta, inverse, metadata)
-    if metadata is None:
-        h, v_new, _final_state = chunk_gdn_fwd_recurrence_dense(
-            kg, w, u, cumulative_gate, recurrence_state
-        )
-    else:
-        h, v_new, _final_state = chunk_gdn_fwd_recurrence_packed(
-            kg, w, u, cumulative_gate, recurrence_state, metadata
-        )
 
+def _finish_chunk_gdn_bwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    beta: torch.Tensor,
+    inverse: torch.Tensor,
+    d_output: torch.Tensor,
+    d_final_state: torch.Tensor | None,
+    initial_state: torch.Tensor | None,
+    metadata: RaggedChunkMetadata | None,
+    prepared: ChunkGDNBwdPrepared,
+    scale: float,
+    aqk: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, ...]:
+    """Finish the local gradients from recomputed factors and the exit-state cotangent.
+
+    ``aqk`` is the expanded-head intra-chunk Q/K factor when the caller already holds it (the
+    staged reverse summary computes it first); the Blackwell path recomputes it otherwise.
+    """
+    w, qg, kg, h, v_new = prepared
     if not use_blackwell_backward(q):
         dh, d_initial_state, dv = chunk_gdn_bwd_delta_h(
             q,
@@ -379,13 +453,14 @@ def chunk_gdn_bwd(
     if groups > 1:
         expanded_q, expanded_k = (tensor.repeat_interleave(groups, dim=2) for tensor in (q, k))
     vector_gate = cumulative_gate.unsqueeze(-1).expand_as(expanded_q).contiguous()
-    aqk = (
-        chunk_gdn_recompute_aqk_dense(expanded_q, expanded_k, cumulative_gate, scale)
-        if metadata is None
-        else chunk_gdn_recompute_aqk_packed(
-            expanded_q, expanded_k, cumulative_gate, scale, metadata
+    if aqk is None:
+        aqk = (
+            chunk_gdn_recompute_aqk_dense(expanded_q, expanded_k, cumulative_gate, scale)
+            if metadata is None
+            else chunk_gdn_recompute_aqk_packed(
+                expanded_q, expanded_k, cumulative_gate, scale, metadata
+            )
         )
-    )
     dh, d_initial_state, dv = blackwell_delta_h_bwd_dhu_dv_fused_dispatch(
         qg,
         kg,

--- a/attn_gym/linear/gdn/stages.py
+++ b/attn_gym/linear/gdn/stages.py
@@ -1,0 +1,272 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Staged fused GDN around the affine state boundary; see ``attn_gym.linear.kda.stages``.
+
+The gated delta rule is KDA with one scalar decay per head instead of a per-channel vector, so
+its summaries reuse the per-channel summary kernels with the gate broadcast across channels. The
+handles follow the same protocol as the KDA stages, so anything built on those handles runs GDN
+unchanged.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import cached_property
+from typing import NamedTuple
+
+import torch
+
+from attn_gym._backends.cute import normalize_compact_tensor
+from attn_gym.linear._delta_rule.cute import build_state_grad_summary, build_state_summary
+from attn_gym.linear._delta_rule.span import prepare_span, zero_state
+from attn_gym.linear._delta_rule.validation import check_summary_range
+from attn_gym.linear.gdn.bwd.triton.chunk_gdn_bwd_recompute import (
+    chunk_gdn_recompute_aqk_dense,
+    chunk_gdn_recompute_aqk_packed,
+)
+from attn_gym.linear.gdn.impl.chunk import (
+    ChunkGDNBwdPrepared,
+    ChunkGDNFactors,
+    _finish_chunk_gdn_bwd,
+    _finish_chunk_gdn_fwd,
+    _prepare_chunk_gdn_bwd,
+    _prepare_chunk_gdn_fwd,
+    reject_int64_offsets,
+    resolve_backward_metadata,
+)
+from attn_gym.linear.gdn.ops import _validate_fused_chunk_qkv
+from attn_gym.linear.gdn.validation import validate_gdn_inputs
+from attn_gym.linear.kda.chunk_schedule import RaggedChunkMetadata
+from attn_gym.linear.kda.ops import _plain_gate_scan_op
+
+
+def _vector_gate(cumulative_gate: torch.Tensor, key_dim: int) -> torch.Tensor:
+    """Broadcast the per-head scalar gate to the per-channel layout the summary kernels read.
+
+    Perf: this materializes an FP32 ``[1, T, H, K]`` temporary per summary call (512 MiB at 32k
+    tokens and 32 heads). A scalar-gate specialization of the summary kernels would remove it; the
+    fused SM100 backward pays the same expansion today.
+    """
+    return cumulative_gate.unsqueeze(-1).expand(*cumulative_gate.shape, key_dim).contiguous()
+
+
+class ChunkGDNSaved(NamedTuple):
+    """Forward tensors an autograd function stores for ``chunk_gdn_prepare_backward``."""
+
+    q: torch.Tensor
+    k: torch.Tensor
+    v: torch.Tensor
+    cumulative_gate: torch.Tensor
+    beta: torch.Tensor
+    inverse: torch.Tensor
+    cu_seqlens: torch.Tensor | None
+    chunk_offsets: torch.Tensor | None
+
+
+@dataclass
+class ChunkGDNPrepared:
+    """Local forward factors shared by ``state_summary`` and ``run``."""
+
+    saved: ChunkGDNSaved
+    factors: ChunkGDNFactors
+    metadata: RaggedChunkMetadata | None
+    scale: float
+
+    def state_summary(self, start: int, stop: int) -> torch.Tensor:
+        """Return the FP32 ``[HV, V + K, K]`` map of tokens ``[start, stop)`` from the zero state.
+
+        See NOTE [Summary ranges are whole chunks of one subsequence] in
+        ``attn_gym.linear.kda.stages``.
+        """
+        saved = self.saved
+        check_summary_range(saved.q.shape[1], start, stop)
+        return build_state_summary(
+            self.factors.kg[:, start:stop],
+            self.factors.w[:, start:stop],
+            self.factors.u[:, start:stop],
+            _vector_gate(saved.cumulative_gate[:, start:stop], saved.q.shape[-1]),
+        )
+
+    def run(
+        self,
+        initial_state: torch.Tensor | None = None,
+        *,
+        output_final_state: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Finish the local forward from one FP32 ``[N, HV, V, K]`` entry state per sequence."""
+        saved = self.saved
+        if initial_state is None:
+            initial_state = zero_state(saved.q, saved.v, self.metadata)
+        else:
+            initial_state = normalize_compact_tensor(initial_state.float())
+            reject_int64_offsets(initial_state)
+        output, final_state = _finish_chunk_gdn_fwd(
+            saved.q,
+            saved.k,
+            self.factors,
+            saved.cumulative_gate,
+            initial_state,
+            self.metadata,
+            self.scale,
+        )
+        return output, final_state if output_final_state else None
+
+
+def chunk_gdn_prepare(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    *,
+    cu_seqlens: torch.Tensor | None = None,
+    scale: float | None = None,
+) -> ChunkGDNPrepared:
+    """Run the factor half of fused ``chunk_gdn`` and return a handle for summaries and output.
+
+    Arguments follow ``chunk_gdn`` with the batch dimension fixed to one so token offsets index
+    one packed stream.
+    """
+    validate_gdn_inputs(q, k, v, gate, beta, None, cu_seqlens)
+    _validate_fused_chunk_qkv(q, k, v)
+    q, k, v, beta, metadata, cu_seqlens, chunk_offsets, scale = prepare_span(
+        q, k, v, beta, cu_seqlens=cu_seqlens, scale=scale
+    )
+    cumulative_gate = normalize_compact_tensor(
+        _plain_gate_scan_op(gate.float().unsqueeze(-1), cu_seqlens, chunk_offsets, False).squeeze(
+            -1
+        )
+    )
+    reject_int64_offsets(q, k, v, cumulative_gate, beta)
+    factors = _prepare_chunk_gdn_fwd(k, v, cumulative_gate, beta, metadata)
+    saved = ChunkGDNSaved(
+        q, k, v, cumulative_gate, beta, factors.inverse, cu_seqlens, chunk_offsets
+    )
+    return ChunkGDNPrepared(saved, factors, metadata, scale)
+
+
+@dataclass
+class ChunkGDNBackward:
+    """Recomputed local backward tensors shared by ``state_grad_summary`` and ``run``."""
+
+    saved: ChunkGDNSaved
+    d_output: torch.Tensor
+    initial_state: torch.Tensor | None
+    metadata: RaggedChunkMetadata | None
+    prepared: ChunkGDNBwdPrepared
+    scale: float
+
+    @cached_property
+    def aqk(self) -> torch.Tensor:
+        """Intra-chunk Q/K factor for the reverse summary; the scalar backward does not otherwise
+        materialize it on pre-Blackwell targets, so it is computed once on first use."""
+        saved = self.saved
+        groups = saved.v.shape[2] // saved.q.shape[2]
+        q, k = (
+            tensor.repeat_interleave(groups, dim=2) if groups > 1 else tensor
+            for tensor in (saved.q, saved.k)
+        )
+        if self.metadata is None:
+            return chunk_gdn_recompute_aqk_dense(q, k, saved.cumulative_gate, self.scale)
+        return chunk_gdn_recompute_aqk_packed(
+            q, k, saved.cumulative_gate, self.scale, self.metadata
+        )
+
+    def state_grad_summary(self, start: int, stop: int) -> torch.Tensor:
+        """Return the FP32 ``[HV, V + K, K]`` reverse map of tokens ``[start, stop)``.
+
+        See ``ChunkKDABackward.state_grad_summary`` for the bias convention.
+        """
+        saved = self.saved
+        check_summary_range(saved.q.shape[1], start, stop)
+        return build_state_grad_summary(
+            self.prepared.qg[:, start:stop],
+            self.prepared.kg[:, start:stop],
+            self.prepared.w[:, start:stop],
+            self.d_output[:, start:stop],
+            self.aqk[:, start:stop],
+            _vector_gate(saved.cumulative_gate[:, start:stop], saved.q.shape[-1]),
+            self.scale,
+        )
+
+    def run(
+        self, d_final_state: torch.Tensor | None = None
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor | None,
+    ]:
+        """Finish the local backward from one FP32 ``[N, HV, V, K]`` exit cotangent per sequence.
+
+        Returns ``(dq, dk, dv, dgate, dbeta, d_initial_state)``; the last is ``None`` when the
+        forward ran without an entry state.
+        """
+        if d_final_state is not None:
+            d_final_state = normalize_compact_tensor(d_final_state.float())
+            reject_int64_offsets(d_final_state)
+        saved = self.saved
+        return _finish_chunk_gdn_bwd(
+            saved.q,
+            saved.k,
+            saved.v,
+            saved.cumulative_gate,
+            saved.beta,
+            saved.inverse,
+            self.d_output,
+            d_final_state,
+            self.initial_state,
+            self.metadata,
+            self.prepared,
+            self.scale,
+            aqk=self.__dict__.get("aqk"),  # Reuse it only when the reverse summary computed it.
+        )
+
+
+def chunk_gdn_prepare_backward(
+    saved: ChunkGDNSaved,
+    d_output: torch.Tensor | None,
+    initial_state: torch.Tensor | None,
+    *,
+    scale: float,
+) -> ChunkGDNBackward:
+    """Recompute the local backward tensors before any reverse-summary exchange.
+
+    ``initial_state`` is the entry state the forward ``run`` consumed and ``scale`` is the forward
+    handle's resolved ``prepared.scale``; see ``chunk_kda_prepare_backward``.
+    """
+    metadata = resolve_backward_metadata(saved.q, saved.cu_seqlens, saved.chunk_offsets)
+    scale = float(scale)
+    if d_output is None:
+        d_output = torch.zeros_like(saved.v)
+    else:
+        d_output = normalize_compact_tensor(d_output.to(saved.v.dtype))
+    if initial_state is not None:
+        initial_state = normalize_compact_tensor(initial_state.float())
+    reject_int64_offsets(d_output, initial_state)
+    prepared = _prepare_chunk_gdn_bwd(
+        saved.q,
+        saved.k,
+        saved.v,
+        saved.cumulative_gate,
+        saved.beta,
+        saved.inverse,
+        initial_state,
+        metadata,
+    )
+    return ChunkGDNBackward(saved, d_output, initial_state, metadata, prepared, scale)
+
+
+__all__ = [
+    "ChunkGDNBackward",
+    "ChunkGDNPrepared",
+    "ChunkGDNSaved",
+    "chunk_gdn_prepare",
+    "chunk_gdn_prepare_backward",
+]

--- a/attn_gym/linear/kda/__init__.py
+++ b/attn_gym/linear/kda/__init__.py
@@ -12,8 +12,7 @@ and the naive oracles in
 ``attn_gym.linear.kda.naive`` serve ``impl="reference"``.
 """
 
-import importlib
-
+from attn_gym.linear._lazy import lazy_exports
 from attn_gym.linear.kda.api import (
     KernelOptions,
     chunk_kda,
@@ -37,24 +36,15 @@ _BACKEND_EXPORTS = {
     "chunk_kda_prepare": "attn_gym.linear.kda.stages",
     "chunk_kda_prepare_backward": "attn_gym.linear.kda.stages",
 }
-# Backward compat: these moved to attn_gym.linear.short_conv, which owns their
-# lazy resolution and error message; import them from attn_gym.linear instead.
-_SHORT_CONV_BC = {"causal_conv1d", "causal_conv1d_decode", "register_activation"}
-
-
-def __getattr__(name: str):
-    if name in _SHORT_CONV_BC:
-        return getattr(importlib.import_module("attn_gym.linear.short_conv"), name)
-    module_name = _BACKEND_EXPORTS.get(name)
-    if module_name is None:
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-    try:
-        module = importlib.import_module(module_name)
-    except ImportError as error:
-        raise ImportError(
-            f"{name} requires the optional CUDA kernel backends: pip install attn-gym[linear]"
-        ) from error
-    return getattr(module, name)
+# Backward compat: these moved to attn_gym.linear.short_conv, whose own lazy resolution supplies
+# the error message; import them from attn_gym.linear instead.
+_SHORT_CONV_BC = {
+    name: "attn_gym.linear.short_conv"
+    for name in ("causal_conv1d", "causal_conv1d_decode", "register_activation")
+}
+__getattr__ = lazy_exports(
+    __name__, _BACKEND_EXPORTS | _SHORT_CONV_BC, requirement="CUDA kernel backends"
+)
 
 
 __all__ = sorted(  # noqa: PLE0605 -- backend exports resolve lazily

--- a/attn_gym/linear/kda/stages.py
+++ b/attn_gym/linear/kda/stages.py
@@ -33,9 +33,10 @@ from typing import NamedTuple
 
 import torch
 
-from attn_gym._backends.cute import normalize_compact_tensor, normalize_tma_rows
+from attn_gym._backends.cute import normalize_compact_tensor
 from attn_gym.linear._delta_rule.cute import build_state_grad_summary, build_state_summary
-from attn_gym.linear._delta_rule.validation import check_summary_range, resolve_scale
+from attn_gym.linear._delta_rule.span import CHUNK_SIZE, prepare_span
+from attn_gym.linear._delta_rule.validation import check_summary_range
 from attn_gym.linear.kda.bwd.cute.chunk_kda_bwd import (
     ChunkKDABwdPrepared,
     _finish_chunk_kda_bwd,
@@ -44,7 +45,6 @@ from attn_gym.linear.kda.bwd.cute.chunk_kda_bwd import (
 from attn_gym.linear.kda.chunk_schedule import (
     RaggedChunkMetadata,
     chunk_capacity,
-    prepare_ragged_chunk_metadata,
 )
 from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd import (
     ChunkKDAFactors,
@@ -55,7 +55,6 @@ from attn_gym.linear.kda.impl.fused import _validate_fused_constraints
 from attn_gym.linear.kda.ops import _plain_gate_scan_op
 from attn_gym.linear.kda.validation import validate_kda_inputs
 
-CHUNK_SIZE = 64
 """Token block of the fused kernels; see NOTE [Summary ranges are whole chunks of one subsequence]
 below."""
 
@@ -193,22 +192,9 @@ def chunk_kda_prepare(
         raise TypeError(
             "chunk_kda_prepare requires q, k, and v to share dtype float16 or bfloat16"
         )
-    if q.shape[0] != 1:
-        raise ValueError("chunk_kda_prepare requires B=1; pack sequences with cu_seqlens")
-    q, k, v = (normalize_tma_rows(tensor) for tensor in (q, k, v))
-    tokens = q.shape[1]
-    if cu_seqlens is None and tokens % CHUNK_SIZE:
-        # A partial tail runs as one packed sequence; arange keeps the launch capture-safe.
-        cu_seqlens = torch.arange(2, dtype=torch.int32, device=q.device) * tokens
-    metadata = (
-        None
-        if cu_seqlens is None
-        else prepare_ragged_chunk_metadata(cu_seqlens, tokens, CHUNK_SIZE)
+    q, k, v, beta, metadata, cu_seqlens, chunk_offsets, scale = prepare_span(
+        q, k, v, beta, cu_seqlens=cu_seqlens, scale=scale
     )
-    cu_seqlens = None if metadata is None else metadata.cu_seqlens
-    chunk_offsets = None if metadata is None else metadata.chunk_offsets
-    scale = resolve_scale(scale, q.shape[-1])
-    beta = normalize_compact_tensor(beta.float())
     cumulative_gate = _plain_gate_scan_op(gate.float(), cu_seqlens, chunk_offsets, False)
     factors = _prepare_chunk_kda_fwd(
         q, k, v, cumulative_gate, beta, metadata, scale=scale, autotune=autotune

--- a/attn_gym/linear/short_conv/__init__.py
+++ b/attn_gym/linear/short_conv/__init__.py
@@ -8,8 +8,9 @@
 
 from __future__ import annotations
 
-import importlib
 from typing import TYPE_CHECKING
+
+from attn_gym.linear._lazy import lazy_exports
 
 # Registers the torch-only operator schemas; the CuTeDSL backend stays unimported
 # until an exported name is first resolved.
@@ -39,14 +40,4 @@ _BACKEND_EXPORTS = {
 __all__ = sorted(_BACKEND_EXPORTS)  # noqa: PLE0605 -- backend exports resolve lazily
 
 
-def __getattr__(name: str):
-    module_name = _BACKEND_EXPORTS.get(name)
-    if module_name is None:
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-    try:
-        module = importlib.import_module(module_name)
-    except ImportError as error:
-        raise ImportError(
-            f"{name} requires the optional CuTeDSL backend: pip install attn-gym[linear]"
-        ) from error
-    return getattr(module, name)
+__getattr__ = lazy_exports(__name__, _BACKEND_EXPORTS, requirement="CuTeDSL backend")

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -397,6 +397,8 @@ collapses to one FP32 map `H_out = H_in @ A + B`, packed as `[HV, V + K, K] = [b
 (one map per value head; GQA key heads are expanded by the factor kernels). Moving state between
 devices (context parallelism, pipelined state handoff, ...) is therefore a prefix scan over these
 summaries, and it needs the fused core split around the communication point in both directions.
+The same machinery serves KDA and GDN (whose scalar per-head gate broadcasts onto the per-channel
+summary kernels).
 
 ### Terminology and index spaces
 
@@ -436,7 +438,8 @@ subsequence: `start = sub_start + 64·i`, `stop = sub_start + 64·j` or the subs
 crossing a `cu_seqlens` boundary. The recipe always passes one whole subsequence,
 `(cu_seqlens[i], cu_seqlens[i + 1])`.
 
-`attn_gym.linear.kda.chunk_kda_prepare` / `chunk_kda_prepare_backward` do that split without
+`attn_gym.linear.kda.chunk_kda_prepare` / `chunk_kda_prepare_backward` and
+`attn_gym.linear.gdn.chunk_gdn_prepare` / `chunk_gdn_prepare_backward` do that split without
 exposing the WY factors:
 
 ```python
@@ -460,3 +463,7 @@ capture never syncs. `attn_gym.linear.state_summary` holds the pure-PyTorch alge
 ::: attn_gym.linear.kda.stages.chunk_kda_prepare
 
 ::: attn_gym.linear.kda.stages.chunk_kda_prepare_backward
+
+::: attn_gym.linear.gdn.stages.chunk_gdn_prepare
+
+::: attn_gym.linear.gdn.stages.chunk_gdn_prepare_backward

--- a/test/test_delta_rule_stages.py
+++ b/test/test_delta_rule_stages.py
@@ -1,4 +1,4 @@
-"""Staged delta-rule primitives: ``prepare`` / ``run`` / state summaries against the public ops."""
+"""Staged KDA/GDN primitives: ``prepare`` / ``run`` / state summaries against the public ops."""
 
 from __future__ import annotations
 
@@ -11,9 +11,12 @@ import torch
 
 pytest.importorskip("cutlass")
 
+from attn_gym.linear.gdn import chunk_gdn
+from attn_gym.linear.gdn.stages import chunk_gdn_prepare, chunk_gdn_prepare_backward
 from attn_gym.linear.kda import chunk_kda
 from attn_gym.linear.kda.stages import chunk_kda_prepare, chunk_kda_prepare_backward
 from attn_gym.linear.state_summary import compose_summaries, merge_state, neutral_summary
+from attn_gym.testing.gdn import make_gdn_test_inputs
 from attn_gym.testing.kda import (
     assert_matches_low_precision_reference,
     assert_relative_rms_within,
@@ -55,6 +58,12 @@ def kda_inputs(tokens: int, *, key_heads: int, value_heads: int, seed: int, dtyp
     )
 
 
+def gdn_inputs(tokens: int, *, key_heads: int, value_heads: int, seed: int, dtype) -> Inputs:
+    return make_gdn_test_inputs(
+        tokens, key_heads=key_heads, value_heads=value_heads, seed=seed, dtype=dtype
+    )[:5]
+
+
 KDA = Op(
     chunk_kda,
     partial(chunk_kda, impl="reference"),
@@ -64,7 +73,23 @@ KDA = Op(
     key_heads=2,
     value_heads=2,
 )
-op_param = pytest.mark.parametrize("op", [pytest.param(KDA, id="kda")])
+GDN = Op(
+    partial(chunk_gdn, impl="fused"),
+    partial(chunk_gdn, impl="reference"),
+    chunk_gdn_prepare,
+    chunk_gdn_prepare_backward,
+    gdn_inputs,
+    key_heads=2,
+    value_heads=2,
+)
+op_param = pytest.mark.parametrize(
+    "op",
+    [
+        pytest.param(KDA, id="kda"),
+        pytest.param(GDN, id="gdn"),
+        pytest.param(GDN._replace(key_heads=1), id="gdn-gqa"),
+    ],
+)
 
 
 def test_summary_algebra_composes_like_sequential_merges():
@@ -205,17 +230,24 @@ def assert_summary_parts_match(summary, fused, oracle, index: int) -> None:
     "loss", ["both", "output-only", "final-state-only"], ids=lambda loss: f"loss-{loss}"
 )
 @pytest.mark.parametrize("state", ["contiguous", "strided-key", "none"])
-def test_prepare_backward_run_matches_chunk_op_gradients(op, scale, loss, state):
+@pytest.mark.parametrize("packing", ["packed", "dense"])
+def test_prepare_backward_run_matches_chunk_op_gradients(op, scale, loss, state, packing):
     """The staged backward is the op's own kernel sequence, so all six gradients are bitwise.
 
-    Covers the cotangents the staged API makes optional (``d_output=None``, no final-state loss)
-    and the entry-state layouts ``run`` accepts: none, contiguous, and a key-strided view.
+    Covers the cotangents the staged API makes optional (``d_output=None``, no final-state loss),
+    the entry-state layouts ``run`` accepts (none, contiguous, a key-strided view), and both chunk
+    schedules: packed ``cu_seqlens`` and a dense span of complete chunks (``metadata is None``).
     """
     inputs = op.make_inputs(320, seed=7)
-    cu_seqlens = torch.tensor([0, 100, 320], dtype=torch.int32, device="cuda")
+    if packing == "packed":
+        cu_seqlens = torch.tensor([0, 100, 320], dtype=torch.int32, device="cuda")
+        sequences = 2
+    else:
+        cu_seqlens = None
+        sequences = 1
     generator = torch.Generator(device="cuda").manual_seed(8)
     wide = torch.randn(
-        2, op.value_heads, HEAD_DIM, 2 * HEAD_DIM, device="cuda", generator=generator
+        sequences, op.value_heads, HEAD_DIM, 2 * HEAD_DIM, device="cuda", generator=generator
     )
     initial_state = {
         "contiguous": wide[..., :HEAD_DIM].contiguous(),
@@ -223,7 +255,7 @@ def test_prepare_backward_run_matches_chunk_op_gradients(op, scale, loss, state)
         "none": None,
     }[state]
     d_final_state = torch.randn(
-        2, op.value_heads, HEAD_DIM, HEAD_DIM, device="cuda", generator=generator
+        sequences, op.value_heads, HEAD_DIM, HEAD_DIM, device="cuda", generator=generator
     )
 
     leaves = tuple(tensor.detach().clone().requires_grad_() for tensor in inputs) + (
@@ -245,6 +277,7 @@ def test_prepare_backward_run_matches_chunk_op_gradients(op, scale, loss, state)
     prepared = op.prepare(*inputs, cu_seqlens=cu_seqlens, scale=scale)
     prepared.run(initial_state, output_final_state=True)
     grads = op.prepare_backward(prepared.saved, d_output, initial_state, scale=prepared.scale)
+    grads.state_grad_summary(0, 64)  # The exchange order: summary first, so run reuses its Aqk.
     actual = grads.run(d_final_state)
 
     assert len(actual) == 6


### PR DESCRIPTION
Stacked PRs:
 * #474
 * #473
 * #472
 * #478
 * #477
 * __->__#471


--- --- ---

Add staged GDN primitives on the fused chunk path

Splits `gdn/impl/chunk.py`'s fused forward and backward into `_prepare_*` / `_finish_*` halves
around the affine state boundary and exposes them as `attn_gym.linear.gdn.chunk_gdn_prepare` ->
`ChunkGDNPrepared` and `chunk_gdn_prepare_backward`, following the KDA stage protocol. The gated
delta rule is KDA with one scalar decay per head, so `_vector_gate` broadcasts the gate onto the
per-channel summary kernels (an FP32 `[1, T, H, K]` temporary per call; a scalar-gate summary
specialization is the noted follow-up). The backward's `aqk` is a lazy `cached_property` because
only the reverse summary needs it, and `run` hands the cached value to the Blackwell finisher so
the exchange order (summary, then run) does not recompute it. `run` rejects int64-offset states
like the public op.

The span prologue the two stage modules shared verbatim (partial-tail `arange`, ragged metadata,
`resolve_scale`, operand normalization) moves to `attn_gym.linear._delta_rule.span.prepare_span`,
with `zero_state` and `CHUNK_SIZE` beside it; `zero_state` replaces the four hand-rolled zero-state
sites in `gdn/impl/chunk.py`. The three copies of the lazy `__getattr__` export shim in
`kda`, `gdn`, and `short_conv` collapse into `attn_gym.linear._lazy.lazy_exports`.

The stage tests now run over KDA, GDN, and GQA GDN via `Op` variants, and the gradient test adds
a dense (`cu_seqlens=None`) schedule next to the packed one; `prepare` + `run` stays bitwise equal
to `chunk_gdn(impl="fused")`.

## Human Note

## Agent note

Second of seven (split out of #453).