### PR TITLE
Add context-parallel ownership plans and state routing

### DIFF
--- a/attn_gym/linear/context_parallel.py
+++ b/attn_gym/linear/context_parallel.py
@@ -1,0 +1,469 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Context parallelism for delta-rule attention: ownership plans and state routing.
+
+Data model (NOTE [Terminology] in ``attn_gym.linear.state_summary``). The global stream is a list
+of sequences. Each rank owns a list of fragments, contiguous global token ranges, and lays them out
+back to back as its span. The plan cuts every fragment at sequence boundaries into
+:class:`Subsequence` pieces, one local ``cu_seqlens`` segment each, so contiguous shards, zig-zag
+load balancing, and document-aligned partitions are just different fragment lists. Because the
+recurrence is affine, a subsequence's entry state is its predecessors' summaries folded from zero
+and its exit cotangent is its successors' reverse summaries folded from zero.
+
+Communication model. Only a fragment's last subsequence can continue on another fragment and only
+its first can continue from one, so every rank fills one slot per fragment (``plan.slots`` is the
+widest fragment list): forward, the summary of the fragment's last subsequence; backward, the
+reverse map of its first; the identity where nobody downstream needs one. The slots are exchanged
+once per direction. :meth:`ContextParallelPlan.routing` materializes a layout as device tensors
+(token ranges for the summary launches, flat slot indices for the folds); by default sized for that
+layout, or padded to caller-given caps (fragments per rank, subsequences per span) so a recipe
+built on them replays under one CUDA Graph across document layouts and fragment tables. The
+composition helpers here are pure tensor code over the gathered ``[world, slots, ...]`` buffers;
+the collective that fills them is the caller's. The short-convolution halo reuses the same slots:
+each fragment's slot holds the tail of its last subsequence.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from typing import NamedTuple, Protocol
+
+import torch
+
+from attn_gym.linear.kda.utils import profiler_range
+from attn_gym.linear.state_summary import merge_state, neutral_summary
+
+
+@dataclass(frozen=True)
+class Subsequence:
+    """The part of one fragment inside one sequence: global tokens ``[start, stop)``."""
+
+    sequence: int
+    start: int
+    stop: int
+
+    @property
+    def length(self) -> int:
+        return self.stop - self.start
+
+
+# One contiguous global token range a rank owns, as the subsequences it is cut into, in token
+# order; its range is ``fragment[0].start`` to ``fragment[-1].stop``.
+Fragment = tuple[Subsequence, ...]
+
+# ``(cp_rank, fragment)`` address of a slot in every rank's gathered buffer.
+Slot = tuple[int, int]
+
+
+def _cut_at_sequences(
+    cu_seqlens_global: Sequence[int], fragment_start: int, fragment_stop: int
+) -> Fragment:
+    subsequences = []
+    for sequence, (seq_start, seq_stop) in enumerate(pairwise(cu_seqlens_global)):
+        start, stop = max(fragment_start, seq_start), min(fragment_stop, seq_stop)
+        if start < stop:
+            subsequences.append(Subsequence(sequence, start, stop))
+    return tuple(subsequences)
+
+
+def _validate_tiling(
+    cu_seqlens_global: Sequence[int], fragments: Sequence[Sequence[tuple[int, int]]]
+) -> None:
+    """Require the ranks' fragments to tile ``[0, total_tokens)`` exactly once."""
+    if len(cu_seqlens_global) < 2 or cu_seqlens_global[0] != 0:
+        raise ValueError("cu_seqlens_global must start at zero and contain at least one sequence")
+    if any(end < start for start, end in pairwise(cu_seqlens_global)):
+        raise ValueError("cu_seqlens_global must be nondecreasing")
+    if not fragments or any(not owned for owned in fragments):
+        raise ValueError("every rank must own at least one fragment")
+    for start, stop in (bounds for owned in fragments for bounds in owned):
+        if start >= stop:
+            raise ValueError(f"fragment [{start}, {stop}) is empty")
+    ordered = sorted(bounds for owned in fragments for bounds in owned)
+    covered = [0, *(stop for _, stop in ordered)]
+    starts = [start for start, _ in ordered]
+    if starts != covered[:-1] or covered[-1] != cu_seqlens_global[-1]:
+        raise ValueError(
+            f"fragments must tile [0, {cu_seqlens_global[-1]}) exactly once, got {ordered}"
+        )
+
+
+@dataclass(frozen=True)
+class ContextParallelRouting:
+    """One layout of a plan as fixed-shape device tensors; see :meth:`ContextParallelPlan.routing`.
+
+    Every shape depends only on the caps (``slots``, ``max_subsequences``, ``conv_history``) and
+    the span length, so a CUDA Graph captured around a recipe that reads them replays with the
+    tensors of another layout copied in place. Predecessors and successors are stored per local
+    fragment, since only a fragment's first subsequence has predecessors and only its last has
+    successors;
+    ``entry_sources`` and ``exit_sources`` map every span segment to its fragment's folded state or
+    to zero.
+
+    Attributes:
+        cu_seqlens: ``int32 [max_subsequences + 1]`` span offsets, padded with the span length.
+        forward_bounds: ``int32 [slots, 2]`` range of each local fragment's last subsequence when
+            it continues elsewhere, else empty; feeds ``state_summaries``.
+        reverse_bounds: ``int32 [slots, 2]`` range of each local fragment's first subsequence
+            when it continues from elsewhere, else empty; feeds ``state_grad_summaries``.
+        reverse_sources: ``int64 [slots]`` local index of each fragment's first subsequence, whose
+            exit-state cotangent is folded into the reverse slot's bias.
+        predecessors: ``int64 [slots, world * slots - 1]`` flat ``cp_rank * slots + fragment``
+            indices of the slots before each fragment in its sequence, in token order, padded
+            with ``world * slots`` (the identity).
+        successors: Same for each fragment's successors, in reverse token order.
+        entry_sources: ``int64 [max_subsequences]`` local fragment whose folded predecessors are
+            a segment's entry state, or ``slots`` for a segment that starts its sequence.
+        exit_sources: Same for exit cotangents: the fragment whose folded successors apply, or
+            ``slots`` for a segment that ends its sequence (or is padding).
+        terminal: ``bool [max_subsequences]`` marks subsequences that end their sequence.
+        tail_sources: ``int64 [slots, conv_history]`` span token behind each position of the
+            fragment's tail row, or ``tokens`` (a zero row) where the tail is shorter or the slot
+            is unused; feeds ``context_parallel_conv_history``.
+        conv_sources: ``int64 [max_subsequences, conv_history]`` flat
+            ``(rank * slots + fragment) * conv_history + position`` index into the gathered tails
+            for each token preceding a segment, or ``world * slots * conv_history`` (zero row).
+    """
+
+    cp_rank: int
+    world: int
+    slots: int
+    tokens: int
+    cu_seqlens: torch.Tensor
+    forward_bounds: torch.Tensor
+    reverse_bounds: torch.Tensor
+    reverse_sources: torch.Tensor
+    predecessors: torch.Tensor
+    successors: torch.Tensor
+    entry_sources: torch.Tensor
+    exit_sources: torch.Tensor
+    terminal: torch.Tensor
+    tail_sources: torch.Tensor
+    conv_sources: torch.Tensor
+
+
+@dataclass(frozen=True)
+class ContextParallelPlan:
+    """Host ownership and routing metadata for one rank, derived from every rank's fragments.
+
+    Attributes:
+        table: ``table[cp_rank][slot]`` is that rank's fragment behind gather slot ``slot``.
+        cp_rank: This rank's row in ``table``: its rank within the context-parallel group.
+        predecessors: Per local fragment, the slots of the same sequence's pieces before its
+            first subsequence, in increasing token order.
+        successors: Per local fragment, the slots of the same sequence's pieces after its last
+            subsequence, in decreasing token order, i.e. the order a reverse fold visits them.
+        terminal: Local indices of subsequences that end their sequence, whose exit states are
+            the sequence's true final states.
+    """
+
+    table: tuple[tuple[Fragment, ...], ...]
+    cp_rank: int
+    predecessors: tuple[tuple[Slot, ...], ...]
+    successors: tuple[tuple[Slot, ...], ...]
+    terminal: tuple[int, ...]
+
+    @classmethod
+    def from_fragments(
+        cls,
+        cu_seqlens_global: Sequence[int],
+        fragments: Sequence[Sequence[tuple[int, int]]],
+        cp_rank: int,
+    ) -> ContextParallelPlan:
+        """Build ``cp_rank``'s plan from every rank's fragments, half-open global token ranges.
+
+        ``fragments[cp_rank]`` lists that rank's fragments in span order; the plan cuts each one at
+        sequence boundaries. Cut points need no alignment to sequences or chunks. Together the
+        fragments must tile ``[0, total_tokens)`` exactly once.
+        """
+        _validate_tiling(cu_seqlens_global, fragments)
+        if not 0 <= cp_rank < len(fragments):
+            raise ValueError(f"cp_rank {cp_rank} is outside a table of {len(fragments)} ranks")
+        table = tuple(
+            tuple(_cut_at_sequences(cu_seqlens_global, start, stop) for start, stop in owned)
+            for owned in fragments
+        )
+        # Every fragment holds at most one piece of a given sequence, so each sequence's pieces
+        # order its ``(cp_rank, fragment)`` slots by token.
+        order: dict[int, list[tuple[int, Slot]]] = {}
+        for owner, row in enumerate(table):
+            for index, fragment in enumerate(row):
+                for piece in fragment:
+                    order.setdefault(piece.sequence, []).append((piece.start, (owner, index)))
+        for slots_of_sequence in order.values():
+            slots_of_sequence.sort()
+
+        # Only a fragment's first subsequence can be continued and only its last can continue.
+        def neighbors(slot: int, piece: Subsequence) -> tuple[list[Slot], list[Slot]]:
+            sequence_slots = [address for _, address in order[piece.sequence]]
+            here = sequence_slots.index((cp_rank, slot))
+            return sequence_slots[:here], sequence_slots[here + 1 :]
+
+        local = table[cp_rank]
+        subsequences = [piece for fragment in local for piece in fragment]
+        return cls(
+            table=table,
+            cp_rank=cp_rank,
+            predecessors=tuple(
+                tuple(neighbors(slot, fragment[0])[0]) for slot, fragment in enumerate(local)
+            ),
+            successors=tuple(
+                tuple(reversed(neighbors(slot, fragment[-1])[1]))
+                for slot, fragment in enumerate(local)
+            ),
+            terminal=tuple(
+                index
+                for index, piece in enumerate(subsequences)
+                if piece.stop == cu_seqlens_global[piece.sequence + 1]
+            ),
+        )
+
+    @property
+    def fragments(self) -> tuple[Fragment, ...]:
+        """This rank's fragments in span order."""
+        return self.table[self.cp_rank]
+
+    @property
+    def subsequences(self) -> tuple[Subsequence, ...]:
+        """This rank's subsequences in span order."""
+        return tuple(piece for fragment in self.fragments for piece in fragment)
+
+    @property
+    def cu_seqlens(self) -> tuple[int, ...]:
+        """Span offsets, one segment per subsequence."""
+        return tuple(accumulate((s.length for s in self.subsequences), initial=0))
+
+    @property
+    def slots(self) -> int:
+        """Gather slots per rank: one per fragment of the widest row."""
+        return max(len(row) for row in self.table)
+
+    def global_token_ids(self, device: torch.device | str) -> torch.Tensor:
+        """Global token id of every span token: the bridge from global tensors to the span."""
+        return torch.cat(
+            [torch.arange(f[0].start, f[-1].stop, device=device) for f in self.fragments]
+        )
+
+    def routing(
+        self,
+        device: torch.device | str,
+        *,
+        slots: int | None = None,
+        max_subsequences: int | None = None,
+        conv_history: int = 0,
+    ) -> ContextParallelRouting:
+        """Materialize this layout as device tensors; the caps make the shapes layout-independent.
+
+        By default every tensor is sized for this layout alone. Under CUDA Graph replay pass the
+        caps the loader promises never to exceed: ``slots`` (fragments per rank; default this
+        table's maximum) and ``max_subsequences`` (segments per span; default this layout's
+        count). Every layout within the caps and with the same span length then yields identically
+        shaped tensors, whatever its fragment table. ``conv_history`` is the short convolution's
+        ``W - 1`` (0: no halo tensors). Predecessor and successor rows are ``world * slots - 1`` wide.
+        """
+        cu_seqlens = self.cu_seqlens
+        count = len(cu_seqlens) - 1
+        if max_subsequences is None:
+            max_subsequences = count
+        if count > max_subsequences:
+            raise ValueError(
+                f"layout has {count} subsequences but max_subsequences is {max_subsequences}"
+            )
+        if slots is None:
+            slots = self.slots
+        if self.slots > slots:
+            raise ValueError(f"a rank owns {self.slots} fragments but slots is {slots}")
+        world = len(self.table)
+        width = world * slots - 1  # the most slots a sequence can have before or after a fragment
+        identity = world * slots
+        tokens = cu_seqlens[-1]
+
+        def flat(addresses: Sequence[Slot]) -> list[int]:
+            indices = [owner * slots + slot for owner, slot in addresses]
+            return indices + [identity] * (width - len(indices))
+
+        forward_bounds = [[0, 0]] * slots
+        reverse_bounds = [[0, 0]] * slots
+        reverse_sources = [0] * slots
+        predecessors = [flat(())] * slots
+        successors = [flat(())] * slots
+        entry_sources = [slots] * max_subsequences
+        exit_sources = [slots] * max_subsequences
+        tail_sources = [[tokens] * conv_history for _ in range(slots)]
+        conv_sources = [[identity * conv_history] * conv_history for _ in range(max_subsequences)]
+        first = 0
+        for slot, fragment in enumerate(self.fragments):
+            last = first + len(fragment) - 1
+            if self.predecessors[slot]:
+                reverse_bounds[slot] = [cu_seqlens[first], cu_seqlens[first + 1]]
+                reverse_sources[slot] = first
+                predecessors[slot] = flat(self.predecessors[slot])
+                entry_sources[first] = slot
+            if self.successors[slot]:
+                forward_bounds[slot] = [cu_seqlens[last], cu_seqlens[last + 1]]
+                successors[slot] = flat(self.successors[slot])
+                exit_sources[last] = slot
+            stored = min(conv_history, fragment[-1].length)
+            stop = cu_seqlens[last + 1]
+            tail_sources[slot][conv_history - stored :] = range(stop - stored, stop)
+            # Predecessor tails in token order, each truncated to its real length; keep the last
+            # ``conv_history`` tokens, front-padded with the zero row.
+            picked: list[int] = []
+            for owner, source in self.predecessors[slot]:
+                stored = min(conv_history, self.table[owner][source][-1].length)
+                base = (owner * slots + source) * conv_history
+                picked.extend(range(base + conv_history - stored, base + conv_history))
+            picked = picked[max(len(picked) - conv_history, 0) :]
+            conv_sources[first][conv_history - len(picked) :] = picked
+            first = last + 1
+        terminal = [index in self.terminal for index in range(max_subsequences)]
+
+        def tensor(values, dtype):
+            return torch.tensor(values, dtype=dtype, device=device)
+
+        return ContextParallelRouting(
+            cp_rank=self.cp_rank,
+            world=world,
+            slots=slots,
+            tokens=tokens,
+            cu_seqlens=tensor([*cu_seqlens] + [tokens] * (max_subsequences - count), torch.int32),
+            forward_bounds=tensor(forward_bounds, torch.int32),
+            reverse_bounds=tensor(reverse_bounds, torch.int32),
+            reverse_sources=tensor(reverse_sources, torch.int64),
+            predecessors=tensor(predecessors, torch.int64),
+            successors=tensor(successors, torch.int64),
+            entry_sources=tensor(entry_sources, torch.int64),
+            exit_sources=tensor(exit_sources, torch.int64),
+            terminal=tensor(terminal, torch.bool),
+            tail_sources=tensor(tail_sources, torch.int64),
+            conv_sources=tensor(conv_sources, torch.int64),
+        )
+
+
+def fold_slots(gathered: torch.Tensor, sources: torch.Tensor) -> torch.Tensor:
+    """Apply gathered summaries to the zero state, one row of slots at a time.
+
+    ``gathered`` is ``[world, slots, HV, V + K, K]`` and ``sources`` is ``int64 [rows, L]`` of
+    flat ``cp_rank * slots + fragment`` indices in application order, padded with
+    ``world * slots``, which addresses the identity appended here. Every row costs ``L`` merges
+    regardless of how many real slots it names, so the launch sequence is fixed and CUDA Graph
+    capturable.
+    """
+    heads, packed, key_dim = gathered.shape[-3:]
+    neutral = neutral_summary(heads, packed - key_dim, key_dim, device=gathered.device)
+    flat = torch.cat((gathered.flatten(0, 1), neutral.unsqueeze(0)))
+    state = gathered.new_zeros(sources.shape[0], heads, packed - key_dim, key_dim)
+    for step in range(sources.shape[1]):
+        state = merge_state(state, flat[sources[:, step]])
+    return state
+
+
+def _scatter_folds(folded: torch.Tensor, sources: torch.Tensor) -> torch.Tensor:
+    """Map ``[slots, ...]`` folded states onto span segments; source ``slots`` selects zero."""
+    return torch.cat((folded, folded.new_zeros(1, *folded.shape[1:])))[sources]
+
+
+def compose_entry_states(gathered: torch.Tensor, routing: ContextParallelRouting) -> torch.Tensor:
+    """Fold each fragment's predecessor summaries from zero and place them on its first segment.
+
+    ``gathered`` is ``[world, slots, HV, V + K, K]``; the result is
+    ``[max_subsequences, HV, V, K]``, zero for every segment that starts its sequence.
+    """
+    return _scatter_folds(fold_slots(gathered, routing.predecessors), routing.entry_sources)
+
+
+def compose_exit_cotangents(
+    gathered: torch.Tensor, d_final_state: torch.Tensor, routing: ContextParallelRouting
+) -> torch.Tensor:
+    """Fold each fragment's successor reverse maps onto its last segment's exit cotangent.
+
+    ``d_final_state`` is the loss's own cotangent on every segment's exit state (zeros where the
+    loss does not touch it); the fold adds what flows back from other ranks.
+    """
+    incoming = _scatter_folds(fold_slots(gathered, routing.successors), routing.exit_sources)
+    return incoming + d_final_state
+
+
+def compose_conv_histories(
+    gathered_tails: torch.Tensor, routing: ContextParallelRouting
+) -> torch.Tensor:
+    """The ``conv_history`` tokens before each span segment, ``[max_subsequences, history, C]``.
+
+    A short convolution at a segment's first tokens needs the tokens just before it, which end
+    some other fragment, possibly on another rank. ``gathered_tails`` is every rank's slot tails,
+    ``[world * slots, history, C]``; ``routing.conv_sources[segment, i]`` names the gathered token
+    that is history position ``i`` (or the appended zero row when the sequence starts there), so
+    the composition is one gather. Indexing keeps every rank's tails in the collective's backward,
+    even ranks whose segments all start sequences.
+    """
+    flat = gathered_tails.flatten(0, 1)
+    return torch.cat((flat, flat.new_zeros(1, flat.shape[-1])))[routing.conv_sources]
+
+
+class PreparedForward(Protocol):
+    """Forward handle of a staged delta-rule op."""
+
+    @property
+    def saved(self) -> NamedTuple: ...
+
+    def state_summaries(self, bounds: torch.Tensor) -> torch.Tensor: ...
+
+    def run(
+        self, initial_state: torch.Tensor | None, *, output_final_state: bool
+    ) -> tuple[torch.Tensor, torch.Tensor | None]: ...
+
+
+class PreparedBackward(Protocol):
+    """Backward handle of a staged delta-rule op."""
+
+    def state_grad_summaries(self, bounds: torch.Tensor) -> torch.Tensor: ...
+
+    def run(self, d_final_state: torch.Tensor | None) -> tuple[torch.Tensor, ...]: ...
+
+
+def summary_slots(prepared: PreparedForward, routing: ContextParallelRouting) -> torch.Tensor:
+    """This rank's ``[slots, HV, V + K, K]`` forward slots: each fragment's last subsequence.
+
+    Fragments whose last subsequence ends its sequence have an empty range and send the identity.
+    """
+    with profiler_range("cp/state_summaries"):
+        return prepared.state_summaries(routing.forward_bounds)
+
+
+def grad_summary_slots(
+    grads: PreparedBackward, d_final_state: torch.Tensor, routing: ContextParallelRouting
+) -> torch.Tensor:
+    """This rank's reverse slots: each fragment's first subsequence, with the loss folded in.
+
+    Upstream ranks need the total cotangent leaving that subsequence, so the bias sent is
+    ``d_final_state @ R + C`` rather than the summary's zero-exit bias ``C``. A fragment whose
+    first subsequence starts its sequence sends a slot nobody folds, so its bias is
+    irrelevant.
+    """
+    with profiler_range("cp/state_grad_summary"):
+        slots = grads.state_grad_summaries(routing.reverse_bounds)
+    value_dim = d_final_state.shape[-2]
+    direct = d_final_state[routing.reverse_sources]
+    return torch.cat((merge_state(direct, slots), slots[..., value_dim:, :]), dim=-2)
+
+
+__all__ = [
+    "ContextParallelPlan",
+    "ContextParallelRouting",
+    "Fragment",
+    "PreparedBackward",
+    "PreparedForward",
+    "Subsequence",
+    "compose_conv_histories",
+    "compose_entry_states",
+    "compose_exit_cotangents",
+    "fold_slots",
+    "grad_summary_slots",
+    "summary_slots",
+]

--- a/attn_gym/linear/state_summary.py
+++ b/attn_gym/linear/state_summary.py
@@ -9,19 +9,21 @@
 Each delta-rule token step is affine in the V-major recurrent state ``H: [V, K]`` (one per value
 head ``HV``; GQA key heads are already expanded by the factor kernels)::
 
-    H_t = H_{t-1} @ A_t + B_t      A_t = diag(exp g_t) (I - beta_t k_t k_t^T),  B_t = beta_t v_t k_t^T
+    H_t = H_{t-1} @ A_t + B_t
+    A_t = diag(exp g_t) (I - beta_t k_t k_t^T)
+    B_t = beta_t v_t k_t^T
 
 so any token range collapses to one FP32 map ``H_out = H_in @ A + B``, packed here as
 ``[HV, V + K, K] = [bias; transition]``. Reverse summaries pack the cotangent map
 ``dH_in = dH_out @ R + C`` the same way. These helpers are pure PyTorch; the per-op ``stages``
-modules produce the summaries and the caller moves them between devices.
+modules produce the summaries and ``attn_gym.linear.context_parallel`` moves them between ranks.
 
 NOTE [Terminology]
-The staged primitives, ownership plans, and the context-parallel recipe share one vocabulary and
-two index spaces. GLOBAL means the whole stream one context-parallel group processes: one
-data-parallel replica's tokens, so "global" here is DP-local. ``cp_rank`` is the rank within that
-CP group. Anything a plan is built from is GLOBAL; anything that touches a tensor on a rank is
-LOCAL.
+The staged primitives, ownership plans, and any context-parallel recipe over them share one
+vocabulary and two index spaces. GLOBAL means the whole stream one context-parallel group
+processes: one data-parallel replica's tokens, so "global" here is DP-local. ``cp_rank`` is the
+rank within that CP group. Anything a plan is built from is GLOBAL; anything that touches a tensor
+on a rank is LOCAL.
 
     global stream   the whole packed token stream, ``cu_seqlens_global``            GLOBAL
     sequence        one document in the global stream                               GLOBAL
@@ -42,10 +44,13 @@ LOCAL.
                     token, so its last chunk may be partial and no fragment cut
                     needs to be chunk-aligned
     summary         the ``[bias; transition]`` map of a token range of the span     LOCAL range
-    slot            ``gathered[rank][i]``: the summary of that rank's i-th          (rank, index)
-                    subsequence, or the identity ``[0; I]`` when nobody needs it
-    predecessors /  subsequences of the same sequence earlier / later in global     (rank, slot)
-    successors      order; the only cross-rank references a plan holds
+    slot            ``gathered[cp_rank][f]``: one per fragment. Forward, the   (cp_rank, fragment)
+                    summary of fragment f's last subsequence; backward, the
+                    reverse map of its first; the identity ``[0; I]`` when
+                    nobody needs it
+    predecessors /  a fragment's predecessors are the slots holding its       (cp_rank, fragment)
+    successors      sequence's earlier pieces, in token order; its successors
+                    the later ones. The only cross-rank references a plan holds
     terminal        subsequences that end their sequence; true final states         LOCAL index
                     live there
 
@@ -62,11 +67,11 @@ How they nest, for ``cu_seqlens_global = (0, 40, 232, 384)`` and the zig-zag fra
     rank 0 span   A∩s0 | A∩s1 | B∩s2        cu_seqlens (0, 40, 96, 192)
     rank 1 span   C∩s1 | D∩s1 | D∩s2        cu_seqlens (0, 96, 136, 192)
 
-    chains        s1: A∩s1 -> C∩s1 -> D∩s1        s2: D∩s2 -> B∩s2        s0: A∩s0 alone
+    slot order    s1: A∩s1 -> C∩s1 -> D∩s1        s2: D∩s2 -> B∩s2        s0: A∩s0 alone
 
 Who passes which indices, for rank 1 above. Names ending in ``_global`` live in the GLOBAL index
-space; everything else is LOCAL to this rank's span. The plan's inputs and every plan field are
-host Python integers; the only offsets tensor the kernels ever see is the span's own::
+space; everything else is LOCAL to this rank's span. The plan is host metadata built from Python
+integers; ``plan.routing(device)`` turns it into the span-local tensors the kernels read::
 
     # Host: routing; ``cp_rank`` picks this rank's row of the fragment table.
     cu_seqlens_global = (0, 40, 232, 384)
@@ -79,47 +84,54 @@ host Python integers; the only offsets tensor the kernels ever see is the span's
     # tokens match plan.subsequences.
     input_ids = <fragments_global[1] flattened by the loader>                 # [1, 192]
     q, k, v, gate, beta = embed / project / short-conv the span               # [1, 192, HV, 128]
-    cu_seqlens = torch.tensor(plan.cu_seqlens, dtype=torch.int32, device=device)
 
-    # Device: all offsets LOCAL.
-    prepared = chunk_kda_prepare(q, k, v, gate, beta, cu_seqlens=cu_seqlens)
-    slots = summary_slots(prepared, plan, neutral_summary(HV, 128, 128, device=device))
-    #   one entry per local subsequence, in span order, padded to plan.slots:
-    #   slot 0: state_summaries(bounds)[0] over [0, 96)     C∩s1 has a successor (D∩s1)
-    #   slot 1: identity [0; I]                             D∩s1 ends s1, nobody needs it
-    #   slot 2: state_summaries(bounds)[2] over [136, 192)  D∩s2 has a successor (rank 0's B∩s2)
+    # Device: all offsets LOCAL, all of them read from the routing tensors.
+    routing = plan.routing(device)
+    prepared = chunk_kda_prepare(q, k, v, gate, beta, cu_seqlens=routing.cu_seqlens)
+    slots = summary_slots(prepared, routing)                  # state_summaries(forward_bounds)
+    #   one entry per local fragment, in span order; routing.forward_bounds is
+    #   slot 0 (frag C): [0, 96)      C∩s1 is C's last subsequence, continued by D∩s1
+    #   slot 1 (frag D): [136, 192)   D∩s2 is D's last subsequence, continued by B∩s2
     gathered = all_gather(slots)                              # [world, plan.slots, HV, V + K, K]
-    initial_state = compose_entry_states(gathered, plan)      # one per subsequence
-    #   C∩s1: merge(0, gathered[0][1])
-    #   D∩s1: merge(merge(0, gathered[0][1]), gathered[1][0])
+    initial_state = compose_entry_states(gathered, routing)   # one per subsequence
+    #   C∩s1: merge(0, gathered[0][0])                        A∩s1 is rank 0's fragment A
+    #   D∩s1: merge(merge(0, gathered[0][0]), gathered[1][0])
     #   D∩s2: 0
     output, exit_states = prepared.run(initial_state, output_final_state=True)
-    #   exit_states holds one state per subsequence; only plan.terminal entries are a sequence's
+    #   exit_states holds one state per subsequence; only routing.terminal rows are a sequence's
     #   true final state (here D∩s1's, for s1), the rest are intermediate. Callers that never use
     #   final states pass output_final_state=False; the backward needs neither.
-    exit_states[list(plan.terminal)]
+    exit_states[routing.terminal]
 
-The key contract: ``state_summary`` is always called with consecutive entries of the span's own
-``plan.cu_seqlens`` (LOCAL), so every summary covers exactly one whole subsequence.
+The key contract: the routing hands ``state_summaries`` / ``state_grad_summaries`` exactly one
+whole subsequence per active fragment slot, as consecutive entries of the span's own
+``cu_seqlens`` (LOCAL). Direct callers must obey NOTE [Summary ranges are whole chunks of one
+subsequence] in ``kda.stages`` themselves; the bounds' shape and dtype are checked, their values
+are not.
 
 What the table does not constrain:
 
 - Ranks need not own equal token counts. Nothing is exchanged per token; the gather is over
   ``plan.slots`` fixed-shape summaries, so spans of different lengths are fine.
-- Zero-length subsequences are legal: the kernels treat a repeated ``cu_seqlens`` entry as an
-  ordinary empty sequence with an unused state row, and the plan never asks one for a summary.
+- Zero-length sequences are legal. An empty global sequence owns no tokens, so the plan has no
+  subsequence for it; the empty span segments that ``routing(max_subsequences=N)`` pads with are
+  repeated ``cu_seqlens`` entries, which the kernels treat as empty sequences with unused state
+  rows, and no summary is ever requested for them.
 - Summary work is bounded by fragments, not documents. Only a fragment's last subsequence can have
   a successor and only its first can have predecessors; interior subsequences are whole documents
-  that start from zero. So a rank computes at most one summary per fragment it owns, and no chain
-  is longer than the number of fragments in the table.
+  that start from zero. So a rank computes at most one summary per fragment it owns, the gather
+  is one slot per fragment, and no fragment has more predecessors or successors than there are
+  other fragments in the table.
 
-CUDA Graph capture is valid for one *plan*, not merely one set of shapes. Fixing shapes is the
-easy part: the loader pads the span with a padding *document* (its own sequence, loss-masked) and
-the subsequence count could be padded with empty ones. ``state_summaries(bounds)`` already reads
-its ranges on the device, but ``compose_entry_states`` bakes the ``(rank, slot)`` chains into
-indexing ops, so a replay also needs the same ``cu_seqlens_global`` and therefore the same
-subsequence layout. Replaying across sampled document layouts needs device-tensor routing as
-well; that does not exist yet.
+CUDA Graph replay follows from that bound. ``plan.routing(device)`` turns a layout into device
+tensors: the span's ``cu_seqlens``, one ``[start, stop)`` per fragment for the summary launches
+(empty when the fragment sends nothing), per-fragment predecessor and successor slots as flat
+indices padded with an identity slot, and per-segment source maps. Eager callers take the default
+sizes. For replay, pass the caps the loader promises never to exceed, ``routing(device, slots=S,
+max_subsequences=N)``: every layout within them, whatever its documents or fragment table, yields
+identically shaped tensors, so a recipe that reads every index from them is captured once and
+replayed after copying the next layout's tensors in place. The span length is the one shape the
+loader must hold fixed (pad a short batch with a loss-masked padding document).
 """
 
 from __future__ import annotations

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -414,8 +414,8 @@ Anything a plan is built from is **global**; anything that touches a tensor on a
 | span | the concatenation of a rank's fragments, in the order it listed them: the packed `q`/`k`/`v`/`output` tensors on that rank, with `cu_seqlens` marking its subsequence boundaries | local |
 | chunk | the `attn_gym.linear.kda.stages.CHUNK_SIZE` (64) token block the fused kernels work in (WY factors and one state step per block); every subsequence is chunked on its own, starting at its first token, so its last chunk may be partial and no fragment cut needs to be chunk-aligned | local |
 | summary | the `[bias; transition]` map of a token range of the span | local range |
-| slot | `gathered[rank][i]`: the summary of that rank's `i`-th subsequence, or the identity | (rank, index) |
-| predecessors / successors | subsequences of the same sequence earlier / later in global order | (rank, slot) |
+| slot | `gathered[cp_rank][f]`: one per fragment. Forward, the summary of fragment `f`'s last subsequence; backward, the reverse map of its first; the identity when nobody needs it | (cp_rank, fragment) |
+| predecessors / successors | the slots holding a fragment's sequence's earlier / later pieces, in token order | (cp_rank, fragment) |
 | terminal | subsequences that end their sequence; true final states live there | local index |
 
 Fragment cut points are arbitrary global tokens: chunking restarts at every subsequence, so they
@@ -430,7 +430,7 @@ rank 1                                 [ frag C ][= frag D ==]
 
 rank 0 span:  A∩s0 | A∩s1 | B∩s2     local cu_seqlens (0, 40, 96, 192)
 rank 1 span:  C∩s1 | D∩s1 | D∩s2     local cu_seqlens (0, 96, 136, 192)
-chains:       s1 = A∩s1 -> C∩s1 -> D∩s1        s2 = D∩s2 -> B∩s2
+slot order:   s1 = A∩s1 -> C∩s1 -> D∩s1        s2 = D∩s2 -> B∩s2
 ```
 
 `state_summaries(bounds)` takes an `int32 [R, 2]` device tensor of **local** span ranges and is
@@ -459,6 +459,26 @@ dq, dk, dv, dgate, dbeta, _ = grads.run(d_final_state)
 `start`/`stop` are host integers naming exactly one local `cu_seqlens` segment, so CUDA Graph
 capture never syncs. `attn_gym.linear.state_summary` holds the pure-PyTorch algebra on summaries
 (`merge_state`, `compose_summaries`, `neutral_summary`).
+
+**Ownership plans** (`attn_gym.linear.context_parallel.ContextParallelPlan.from_fragments`) take
+every rank's fragments. You choose them in plain Python; the plan cuts each fragment at sequence
+boundaries into `Subsequence`s, one span `cu_seqlens` segment each, and derives the routing:
+which fragments need a forward or reverse summary (one gather slot per fragment), which slots to
+fold for each entry state or exit cotangent, and which subsequences end their sequence and
+therefore hold true final states. Two pieces of one document on the same rank are simply two span
+segments whose entry states the routing supplies, so contiguous shards, zig-zag load balancing, and
+document-aligned partitions differ only in the fragment lists. The fragments must tile
+`[0, total_tokens)` exactly once. `plan.routing(device)` materializes the same routing as
+fixed-shape device tensors; `summary_slots` / `grad_summary_slots` fill a rank's `[slots, ...]`
+buffer from a prepared handle and a routing, and `compose_entry_states` /
+`compose_exit_cotangents` fold the gathered `[world, slots, ...]` buffers into each subsequence's
+entry state or exit cotangent; the collective in between is the caller's.
+
+::: attn_gym.linear.context_parallel.ContextParallelPlan
+
+::: attn_gym.linear.context_parallel.Subsequence
+
+::: attn_gym.linear.context_parallel.ContextParallelRouting
 
 ::: attn_gym.linear.kda.stages.chunk_kda_prepare
 

--- a/test/test_context_parallel_plan.py
+++ b/test/test_context_parallel_plan.py
@@ -1,0 +1,294 @@
+"""Small CPU tests for context-parallel ownership plans and state routing."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from attn_gym.linear.context_parallel import (
+    ContextParallelPlan,
+    Subsequence,
+    compose_conv_histories,
+    compose_entry_states,
+    compose_exit_cotangents,
+)
+
+VALUE_DIM = 2
+KEY_DIM = 2
+
+# Sequences [0,1), [1,7), [7,8) over four ranks of two contiguous tokens each, with a width-4
+# short convolution (three tokens of history).
+CONV_CU_SEQLENS = (0, 1, 7, 8)
+CONV_FRAGMENTS = [[(0, 2)], [(2, 4)], [(4, 6)], [(6, 8)]]
+CONV_ROUTINGS = [
+    ContextParallelPlan.from_fragments(CONV_CU_SEQLENS, CONV_FRAGMENTS, cp_rank).routing(
+        "cpu", conv_history=3
+    )
+    for cp_rank in range(4)
+]
+
+# Three ranks, five fragments, over stream layouts that cut them differently.
+FRAGMENTS = [[(0, 3), (13, 16)], [(3, 7), (11, 13)], [(7, 11)]]
+LAYOUTS = [
+    pytest.param((0, 5, 5, 12, 16), id="two-cuts-and-an-empty-sequence"),
+    pytest.param((0, 16), id="one-sequence"),
+    pytest.param((0, 1, 2, 3, 4, 8, 16), id="many-short-documents"),
+]
+
+
+def summary(transition: list[list[float]], bias: list[list[float]]) -> torch.Tensor:
+    """One-head ``[bias; transition]`` summary."""
+    return torch.cat(
+        (torch.tensor(bias, dtype=torch.float32), torch.tensor(transition, dtype=torch.float32))
+    ).unsqueeze(0)
+
+
+def apply(state: torch.Tensor, packed: torch.Tensor) -> torch.Tensor:
+    """Independent affine-map oracle for the routing tests."""
+    return state @ packed[:, VALUE_DIM:, :] + packed[:, :VALUE_DIM, :]
+
+
+def spans(plan: ContextParallelPlan) -> list[tuple[int, int]]:
+    """``(first, last)`` local subsequence index of each fragment, in slot order."""
+    result, first = [], 0
+    for fragment in plan.fragments:
+        result.append((first, first + len(fragment) - 1))
+        first += len(fragment)
+    return result
+
+
+@pytest.mark.parametrize(
+    ("cu_seqlens", "fragments", "message"),
+    [
+        pytest.param((0, 4), [[(0, 2)], [(3, 4)]], "tile", id="gap"),
+        pytest.param((0, 4), [[(0, 2)], [(1, 4)]], "tile", id="overlap"),
+        pytest.param((0, 4), [[(1, 4)]], "tile", id="missing-prefix"),
+        pytest.param((0, 4), [[(0, 3)]], "tile", id="missing-suffix"),
+        pytest.param((0, 4), [[(0, 2)], [(2, 4), (0, 2)]], "tile", id="duplicate"),
+        pytest.param((0, 4), [[(0, 4)], []], "at least one", id="empty-rank"),
+        pytest.param((0, 4), [[(2, 2), (0, 4)]], "empty", id="empty-fragment"),
+        pytest.param((0,), [[(0, 4)]], "at least one sequence", id="no-sequences"),
+        pytest.param((1, 4), [[(0, 4)]], "start at zero", id="offset-stream"),
+        pytest.param((0, 4, 2), [[(0, 4)]], "nondecreasing", id="decreasing-offsets"),
+        pytest.param((0, 0), [[(0, 0)]], "empty", id="empty-stream"),
+    ],
+)
+def test_plan_rejects_fragments_that_do_not_tile_the_stream(cu_seqlens, fragments, message):
+    with pytest.raises(ValueError, match=message):
+        ContextParallelPlan.from_fragments(cu_seqlens, fragments, cp_rank=0)
+
+
+def test_plan_rejects_rank_outside_table():
+    with pytest.raises(ValueError, match="cp_rank 2"):
+        ContextParallelPlan.from_fragments((0, 4), [[(0, 2)], [(2, 4)]], cp_rank=2)
+
+
+def test_plan_cuts_fragments_at_sequences_and_orders_neighbors():
+    # A = [0, 8), B = [8, 12); cp_rank 0 owns A[0:2], then the fragment [6, 10) spanning A and B.
+    fragments = [[(0, 2), (6, 10)], [(2, 6), (10, 12)]]
+
+    plan = ContextParallelPlan.from_fragments((0, 8, 12), fragments, cp_rank=0)
+    assert plan.subsequences == (Subsequence(0, 0, 2), Subsequence(0, 6, 8), Subsequence(1, 8, 10))
+    assert plan.fragments[1] == (Subsequence(0, 6, 8), Subsequence(1, 8, 10))
+    assert plan.table[1] == ((Subsequence(0, 2, 6),), (Subsequence(1, 10, 12),))
+    assert plan.cu_seqlens == (0, 2, 4, 6)
+    assert plan.slots == 2  # one per fragment, not per subsequence
+    # Per fragment. A's pieces sit in cp_rank 0 fragment 0, cp_rank 1 fragment 0, then cp_rank 0
+    # fragment 1, so fragment 1 has two predecessors and fragment 0 two successors.
+    assert plan.predecessors == ((), ((0, 0), (1, 0)))
+    assert plan.successors == (((0, 1), (1, 0)), ((1, 1),))
+    assert plan.terminal == (1,)
+    assert plan.global_token_ids("cpu").tolist() == [0, 1, 6, 7, 8, 9]
+
+    other = ContextParallelPlan.from_fragments((0, 8, 12), fragments, cp_rank=1)
+    assert other.slots == 2
+    assert other.predecessors == (((0, 0),), ((0, 1),))
+    assert other.successors == (((0, 1),), ())
+    assert other.terminal == (1,)
+
+
+def test_plan_skips_empty_sequences_and_links_adjacent_fragments_on_one_rank():
+    # Sequence 1 is empty, so it has no subsequence anywhere while sequence 2 keeps its index.
+    fragments = [[(0, 2), (2, 4)], [(4, 8)]]
+    plan = ContextParallelPlan.from_fragments((0, 4, 4, 8), fragments, cp_rank=0)
+    assert plan.subsequences == (Subsequence(0, 0, 2), Subsequence(0, 2, 4))
+    assert plan.predecessors == ((), ((0, 0),))
+    assert plan.terminal == (1,)
+    other = ContextParallelPlan.from_fragments((0, 4, 4, 8), fragments, cp_rank=1)
+    assert other.subsequences == (Subsequence(2, 4, 8),)
+    assert other.predecessors == ((),)
+    # Leading and trailing empty sequences leave one subsequence that ends its sequence.
+    plan = ContextParallelPlan.from_fragments((0, 0, 4, 4), [[(0, 4)]], cp_rank=0)
+    assert plan.subsequences == (Subsequence(1, 0, 4),)
+    assert plan.terminal == (0,)
+
+
+@pytest.mark.parametrize("cu_seqlens", LAYOUTS)
+def test_entry_and_exit_folds_follow_subsequence_geometry_for_every_subsequence(cu_seqlens):
+    """Independently derive each subsequence's neighbours from token order and compare both folds."""
+    plans = [
+        ContextParallelPlan.from_fragments(cu_seqlens, FRAGMENTS, cp_rank) for cp_rank in range(3)
+    ]
+    generator = torch.Generator().manual_seed(3)
+    gathered = torch.randn(3, max(p.slots for p in plans), 1, 4, 2, generator=generator)
+    everything = [
+        (r, s, piece)
+        for r, row in enumerate(plans[0].table)
+        for s, fragment in enumerate(row)
+        for piece in fragment
+    ]
+    zero = torch.zeros(1, VALUE_DIM, KEY_DIM)
+    for plan in plans:
+        routing = plan.routing("cpu")
+        count = len(plan.subsequences)
+        d_final_state = torch.randn(count, 1, VALUE_DIM, KEY_DIM, generator=generator)
+        entries = compose_entry_states(gathered, routing)
+        exits = compose_exit_cotangents(gathered, torch.zeros_like(d_final_state), routing)
+        exits_with_loss = compose_exit_cotangents(gathered, d_final_state, routing)
+        for index, subsequence in enumerate(plan.subsequences):
+            siblings = [(r, s, f) for r, s, f in everything if f.sequence == subsequence.sequence]
+            earlier = sorted(
+                (f.start, r, s) for r, s, f in siblings if f.start < subsequence.start
+            )
+            later = sorted((f.start, r, s) for r, s, f in siblings if f.start > subsequence.start)
+            entry = zero
+            for _, r, s in earlier:
+                entry = apply(entry, gathered[r, s])
+            exit_cotangent = zero
+            for _, r, s in reversed(later):
+                exit_cotangent = apply(exit_cotangent, gathered[r, s])
+            torch.testing.assert_close(entries[index], entry)
+            torch.testing.assert_close(exits[index], exit_cotangent)
+            # The loss's own cotangent adds to what flows back from the successors.
+            torch.testing.assert_close(
+                exits_with_loss[index], exit_cotangent + d_final_state[index]
+            )
+            assert (index in plan.terminal) == (not later)
+
+
+def test_tail_sources_pick_the_last_tokens_of_each_fragment_and_pad_short_ones():
+    # Rank 0's last subsequence is token 1 alone (sequence 1 starts there): the row is zero, zero,
+    # then span token 1; the zero row is index ``tokens`` (2). Rank 1's fragment is whole.
+    assert CONV_ROUTINGS[0].tail_sources.tolist() == [[2, 2, 1]]
+    assert CONV_ROUTINGS[1].tail_sources.tolist() == [[2, 0, 1]]
+
+
+def test_short_conv_histories_span_short_predecessors_and_reset_at_sequences():
+    # One slot per fragment (one per rank here) holding the tail of its last subsequence, gathered
+    # as [world * slots, history, C]: cp_rank 0's is token 1 alone (sequence 1 starts there),
+    # cp_ranks 1 and 2 hold two tokens, cp_rank 3's is token 7 (sequence 2).
+    tails = torch.tensor(
+        [
+            [[0.0], [0.0], [1.5]],
+            [[0.0], [2.0], [3.0]],
+            [[0.0], [4.0], [5.0]],
+            [[0.0], [0.0], [7.0]],
+        ]
+    )
+    rank_three = compose_conv_histories(tails, CONV_ROUTINGS[3])
+    torch.testing.assert_close(rank_three[0, :, 0], torch.tensor([3.0, 4.0, 5.0]))
+    torch.testing.assert_close(rank_three[1], torch.zeros_like(rank_three[1]))
+    torch.testing.assert_close(
+        compose_conv_histories(tails, CONV_ROUTINGS[1])[0, :, 0], torch.tensor([0.0, 0.0, 1.5])
+    )
+
+
+def test_short_conv_history_backward_is_the_transpose_of_forward_routing():
+    tails = torch.zeros(4, 3, 1, requires_grad=True)
+    rank_two = compose_conv_histories(tails, CONV_ROUTINGS[2])
+    rank_three = compose_conv_histories(tails, CONV_ROUTINGS[3])
+    loss = (rank_two[0, :, 0] * torch.tensor([10.0, 20.0, 30.0])).sum()
+    loss += (rank_three[0, :, 0] * torch.tensor([40.0, 50.0, 60.0])).sum()
+
+    (tail_gradients,) = torch.autograd.grad(loss, tails)
+
+    # Rank 1's last token feeds rank 2's history[2] (weight 30) and rank 3's history[0] (40).
+    torch.testing.assert_close(tail_gradients[1, :, 0], torch.tensor([0.0, 20.0, 70.0]))
+    # Rank 0 starts both of its sequences yet must stay connected to the gathered tails so its
+    # reduce-scatter participates in the collective's backward.
+    assert compose_conv_histories(tails, CONV_ROUTINGS[0]).requires_grad
+
+
+@pytest.mark.parametrize("cu_seqlens", LAYOUTS)
+def test_routing_tensors_follow_fragment_geometry(cu_seqlens):
+    """Bounds, predecessors/successors, and source maps are per fragment; padding is unrouted."""
+    plans = [
+        ContextParallelPlan.from_fragments(cu_seqlens, FRAGMENTS, cp_rank) for cp_rank in range(3)
+    ]
+    generator = torch.Generator().manual_seed(11)
+    gathered = torch.randn(3, 2, 1, 4, 2, generator=generator)
+    for plan in plans:
+        routing = plan.routing("cpu", max_subsequences=8)
+        count = len(plan.subsequences)
+        assert routing.slots == 2 and routing.world == 3
+        assert routing.predecessors.shape == routing.successors.shape == (2, 5)  # world*slots-1
+        assert routing.tail_sources.shape == (2, 0) and routing.conv_sources.shape == (8, 0)
+        assert routing.cu_seqlens.tolist() == [*plan.cu_seqlens] + [plan.cu_seqlens[-1]] * (
+            8 - count
+        )
+        assert routing.terminal.tolist() == [i in plan.terminal for i in range(8)]
+        entries = compose_entry_states(gathered, routing)
+        exits = compose_exit_cotangents(gathered, torch.zeros(8, 1, VALUE_DIM, KEY_DIM), routing)
+        assert entries.shape == exits.shape == (8, 1, VALUE_DIM, KEY_DIM)
+        assert torch.equal(entries[count:], torch.zeros_like(entries[count:]))
+        assert torch.equal(exits[count:], torch.zeros_like(exits[count:]))
+        firsts = {first for first, _ in spans(plan)}
+        lasts = {last for _, last in spans(plan)}
+        for slot, (first, last) in enumerate(spans(plan)):
+            # A forward slot summarizes the fragment's last subsequence iff it has successors, and
+            # only that subsequence receives the folded successors.
+            if plan.successors[slot]:
+                assert routing.forward_bounds[slot].tolist() == list(
+                    plan.cu_seqlens[last : last + 2]
+                )
+                assert routing.exit_sources[last].item() == slot
+            else:
+                assert routing.forward_bounds[slot].tolist() == [0, 0]
+                assert routing.exit_sources[last].item() == routing.slots
+            # A reverse slot covers the first subsequence iff it has predecessors; its entry state
+            # is the folded predecessors and its loss cotangent is what the slot folds in.
+            if plan.predecessors[slot]:
+                assert routing.reverse_bounds[slot].tolist() == list(
+                    plan.cu_seqlens[first : first + 2]
+                )
+                assert routing.reverse_sources[slot].item() == first
+                assert routing.entry_sources[first].item() == slot
+            else:
+                assert routing.reverse_bounds[slot].tolist() == [0, 0]
+                assert routing.entry_sources[first].item() == routing.slots
+        for index in range(count):
+            if index not in firsts:
+                assert routing.entry_sources[index].item() == routing.slots
+            if index not in lasts:
+                assert routing.exit_sources[index].item() == routing.slots
+
+
+def test_routing_rejects_layouts_beyond_the_caps():
+    plan = ContextParallelPlan.from_fragments((0, 1, 2, 3, 4, 8, 16), FRAGMENTS, cp_rank=0)
+    with pytest.raises(ValueError, match="max_subsequences"):
+        plan.routing("cpu", max_subsequences=len(plan.subsequences) - 1)
+    with pytest.raises(ValueError, match="slots"):
+        plan.routing("cpu", slots=1)
+
+
+def test_slots_cap_pads_every_rank_to_the_same_shapes_across_fragment_tables():
+    """Two tables with different fragment counts route identically shaped tensors under one cap."""
+    cu_seqlens = (0, 5, 12, 16)
+    tables = [FRAGMENTS, [[(0, 6)], [(6, 9), (12, 16)], [(9, 12)]]]  # 5 fragments, then 4
+    generator = torch.Generator().manual_seed(7)
+    gathered = torch.randn(3, 3, 1, 4, 2, generator=generator)
+    for table in tables:
+        for cp_rank in range(3):
+            plan = ContextParallelPlan.from_fragments(cu_seqlens, table, cp_rank)
+            capped = plan.routing("cpu", slots=3, max_subsequences=4, conv_history=2)
+            assert capped.slots == 3
+            assert capped.forward_bounds.shape == capped.reverse_bounds.shape == (3, 2)
+            assert capped.predecessors.shape == capped.successors.shape == (3, 8)  # 3 * 3 - 1
+            assert capped.tail_sources.shape == (3, 2) and capped.conv_sources.shape == (4, 2)
+            # Padding slots are empty and unrouted, so the folds match the uncapped routing.
+            exact = plan.routing("cpu", max_subsequences=4)
+            assert torch.equal(capped.forward_bounds[plan.slots :], torch.zeros(3 - plan.slots, 2))
+            torch.testing.assert_close(
+                compose_entry_states(gathered, capped),
+                compose_entry_states(gathered[:, : plan.slots], exact),
+            )

--- a/test/test_delta_rule_stages.py
+++ b/test/test_delta_rule_stages.py
@@ -1,4 +1,4 @@
-"""Staged KDA/GDN primitives: ``prepare`` / ``run`` / state summaries against the public ops."""
+"""Staged KDA/GDN primitives and the context-parallel routing simulated in one process."""
 
 from __future__ import annotations
 
@@ -11,6 +11,13 @@ import torch
 
 pytest.importorskip("cutlass")
 
+from attn_gym.linear.context_parallel import (
+    ContextParallelPlan,
+    compose_entry_states,
+    compose_exit_cotangents,
+    grad_summary_slots,
+    summary_slots,
+)
 from attn_gym.linear.gdn import chunk_gdn
 from attn_gym.linear.gdn.stages import chunk_gdn_prepare, chunk_gdn_prepare_backward
 from attn_gym.linear.kda import chunk_kda
@@ -49,6 +56,26 @@ class Op(NamedTuple):
         return self.factory(
             tokens, key_heads=self.key_heads, value_heads=self.value_heads, seed=seed, dtype=dtype
         )
+
+
+def relative_rms_error(actual: torch.Tensor, reference: torch.Tensor) -> float:
+    """Relative RMS error against an FP32 oracle."""
+    return ((actual.float() - reference).square().mean() / reference.square().mean()).sqrt().item()
+
+
+def assert_sharded_matches(
+    name: str, actual: torch.Tensor, reference: torch.Tensor, unsharded: torch.Tensor, *, dtype
+) -> None:
+    """Sharding must not cost accuracy.
+
+    Pointwise within the unsharded op's own budget against the FP32 oracle, and in aggregate
+    within 1.5x of the unsharded op's relative RMS error: sharding only reorders accumulation, so
+    a systematic precision loss in the summary path would show up as a multiple.
+    """
+    assert_matches_low_precision_reference(actual, reference, unsharded, name, source_dtype=dtype)
+    sharded = relative_rms_error(actual, reference)
+    baseline = relative_rms_error(unsharded, reference)
+    assert sharded <= 1.5 * baseline + 1e-6, (name, sharded, baseline)
 
 
 def kda_inputs(tokens: int, *, key_heads: int, value_heads: int, seed: int, dtype) -> Inputs:
@@ -409,3 +436,119 @@ def test_summaries_are_exact_over_whole_chunks_of_one_subsequence(op):
             label = f"{name} [{start}, {stop})"
             assert_matches_low_precision_reference(actual, expected, low, label)
             assert_relative_rms_within(actual, expected, label, max_eps=1.0)
+
+
+class RankResult(NamedTuple):
+    plan: ContextParallelPlan
+    token_ids: torch.Tensor
+    output: torch.Tensor
+    final_state: torch.Tensor
+    grads: tuple[torch.Tensor, ...]  # dq, dk, dv, dgate, dbeta
+
+
+def simulate_context_parallel(
+    op: Op, cu_seqlens_global, fragments, inputs, d_output, d_final_state
+) -> list[RankResult]:
+    """Run every rank's forward and backward in one process; a stack stands in for all-gather."""
+    device = inputs[0].device
+    ranks = range(len(fragments))
+    plans = [
+        ContextParallelPlan.from_fragments(cu_seqlens_global, fragments, cp_rank)
+        for cp_rank in ranks
+    ]
+    token_ids = [plan.global_token_ids(device) for plan in plans]
+    routings = [plan.routing(device) for plan in plans]
+    prepared = [
+        op.prepare(
+            *(tensor[:, token_ids[r]] for tensor in inputs), cu_seqlens=routings[r].cu_seqlens
+        )
+        for r in ranks
+    ]
+
+    gathered = torch.stack([summary_slots(prepared[r], routings[r]) for r in ranks])
+    initial_states = [compose_entry_states(gathered, routings[r]) for r in ranks]
+    forward = [prepared[r].run(initial_states[r], output_final_state=True) for r in ranks]
+
+    # The loss's state cotangent reaches only the subsequences that end their sequence.
+    d_exit_states = [
+        torch.stack(
+            [
+                d_final_state[subsequence.sequence]
+                if index in plan.terminal
+                else torch.zeros_like(d_final_state[0])
+                for index, subsequence in enumerate(plan.subsequences)
+            ]
+        )
+        for plan in plans
+    ]
+    grads = [
+        op.prepare_backward(
+            prepared[r].saved,
+            d_output[:, token_ids[r]],
+            initial_states[r],
+            scale=prepared[r].scale,
+        )
+        for r in ranks
+    ]
+    gathered = torch.stack(
+        [grad_summary_slots(grads[r], d_exit_states[r], routings[r]) for r in ranks]
+    )
+    input_grads = [
+        grads[r].run(compose_exit_cotangents(gathered, d_exit_states[r], routings[r]))[:5]
+        for r in ranks
+    ]
+    return [RankResult(plans[r], token_ids[r], *forward[r], input_grads[r]) for r in ranks]
+
+
+# Sequences [0, 40), [40, 232), [232, 384); each entry lists one rank's fragments.
+CU_SEQLENS = (0, 40, 232, 384)
+LAYOUTS = [
+    pytest.param([[(0, 192)], [(192, 384)]], id="contiguous-2"),
+    pytest.param([[(0, 96), (288, 384)], [(96, 192), (192, 288)]], id="zigzag-2"),
+    pytest.param(
+        [[(0, 64), (320, 384)], [(64, 128), (256, 320)], [(128, 192), (192, 256)]], id="zigzag-3"
+    ),
+    # Uneven ownership: rank 0 holds one short piece, rank 1 the rest in reversed order.
+    pytest.param([[(96, 160)], [(160, 384), (0, 96)]], id="uneven-reordered"),
+]
+
+
+@requires_kda_target
+@op_param
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "fp16"])
+@pytest.mark.parametrize("layout", LAYOUTS)
+def test_simulated_context_parallel_matches_unsharded_op(op, layout, dtype):
+    q, k, v, gate, beta = op.make_inputs(CU_SEQLENS[-1], seed=4, dtype=dtype)
+    inputs = tuple(tensor.detach().clone().requires_grad_() for tensor in (q, k, v, gate, beta))
+    offsets = torch.tensor(CU_SEQLENS, dtype=torch.int32, device="cuda")
+
+    output, final_state = op.chunk(*inputs, cu_seqlens=offsets, output_final_state=True)
+    generator = torch.Generator(device="cuda").manual_seed(5)
+    d_output = torch.randn(output.shape, device="cuda", generator=generator).to(output.dtype)
+    d_final_state = torch.randn(final_state.shape, device="cuda", generator=generator)
+    expected_grads = torch.autograd.grad(
+        (output, final_state), inputs, grad_outputs=(d_output, d_final_state)
+    )
+
+    # Sharding must not cost accuracy: measure both paths against the FP32 eager oracle.
+    f32 = tuple(tensor.detach().float().requires_grad_() for tensor in (q, k, v, gate, beta))
+    ref_output, ref_final = op.reference(*f32, cu_seqlens=offsets, output_final_state=True)
+    ref_grads = torch.autograd.grad(
+        (ref_output, ref_final), f32, grad_outputs=(d_output.float(), d_final_state)
+    )
+
+    results = simulate_context_parallel(
+        op, CU_SEQLENS, layout, (q, k, v, gate, beta), d_output, d_final_state
+    )
+    for result in results:
+        ids = result.token_ids
+        check = partial(assert_sharded_matches, dtype=dtype)
+        check("output", result.output, ref_output[:, ids], output[:, ids])
+        for index in result.plan.terminal:
+            sequence = result.plan.subsequences[index].sequence
+            check("state", result.final_state[index], ref_final[sequence], final_state[sequence])
+        names = ("dq", "dk", "dv", "dgate", "dbeta")
+        for name, actual, expected, reference in zip(
+            names, result.grads, expected_grads, ref_grads, strict=True
+        ):
+            check(name, actual, reference[:, ids], expected[:, ids])


### PR DESCRIPTION
Stacked PRs:
 * #474
 * #473
 * __->__#472


--- --- ---

Add context-parallel ownership plans and state routing

`attn_gym.linear.context_parallel.ContextParallelPlan.from_fragments(cu_seqlens_global, fragments,
cp_rank)` takes every rank's fragments (contiguous global token ranges, listed in span order), cuts
them at sequence boundaries into `Subsequence`s (one span `cu_seqlens` segment each; a `Fragment`
is that tuple), and derives the routing: per fragment, the predecessor chain of its first
subsequence and the successor chain of its last, and which subsequences end their sequence
(`terminal`). Contiguous shards, zig-zag, and
document-aligned partitions are just different fragment lists; cut points need no alignment to
sequences or chunks, and the fragments must tile the stream exactly once. Vocabulary follows
`NOTE [Terminology]` in `attn_gym.linear.state_summary`, which this PR extends with the nesting
picture and a rank walkthrough.

Communication is one gather slot per fragment, not per subsequence: forward, the summary of the
fragment's last subsequence (only it can continue on another fragment); backward, the reverse map
of its first. `plan.routing(device)` materializes a layout as device tensors
(`ContextParallelRouting`), sized for that layout by default. The keyword caps `slots=S` (fragments
per rank) and `max_subsequences=N` (segments per span) pad them so every layout within the caps and
with the same span length, whatever its documents or fragment table, has identical shapes: the
span's `cu_seqlens` padded with empty segments to `N`, one `[start, stop)` per slot for
`state_summaries` / `state_grad_summaries` (empty when the fragment sends nothing), per-slot `[S,
world * S - 1]` chains of flat slot indices padded with an identity slot, per-segment source maps
that place each fragment's folded state on its first (entry) or last (exit) subsequence, the
loss-cotangent source per reverse slot, and a terminal mask. A recipe that reads every index from
those tensors can be captured once and replayed across document layouts and fragment tables by
copying the next layout's tensors in place; eager callers never see the caps.

`summary_slots` / `grad_summary_slots` fill a rank's `[slots, ...]` buffer from a staged handle and
a routing, `fold_slots` is the only fold, and `compose_entry_states` /
`compose_exit_cotangents` turn the gathered `[world, slots, ...]` buffers into entry states and
exit cotangents. The short-convolution halo rides the same slots: with `conv_history`, the routing
also carries `tail_sources` / `conv_sources` index tensors and `compose_conv_histories` is one
gather of predecessor tails, so the halo replays across layouts like the states do. No collectives
live here; the exchange is the caller's.

Tests: plan validation and routing on CPU (bounds, chains, source maps, padding, the subsequence
cap, the slots cap across two fragment tables) for three layouts, an oracle that rederives every subsequence's entry state and exit
cotangent from token order over the same layouts, conv-history routing and its transpose, and a
single-process simulation of the full exchange (stack in place of all-gather) for KDA / GDN /
GQA GDN over contiguous, zig-zag, and uneven layouts in bf16 and fp16, measured against the FP32
oracle pointwise and in aggregate.

## Human Note

## Agent note

Fifth of seven. Every test here runs without a process group. The recipe over these pieces is the
next PR.