### PR TITLE
Read affine-summary ranges from the device: one launch per range table

### DIFF
--- a/attn_gym/linear/_delta_rule/cute/__init__.py
+++ b/attn_gym/linear/_delta_rule/cute/__init__.py
@@ -1,6 +1,11 @@
 """Native CuTeDSL kernels shared by delta-rule attention variants."""
 
-from .affine_summary_fwd import build_state_summary
-from .affine_summary_rev import build_state_grad_summary
+from .affine_summary_fwd import build_state_summaries, build_state_summary
+from .affine_summary_rev import build_state_grad_summaries, build_state_grad_summary
 
-__all__ = ["build_state_grad_summary", "build_state_summary"]
+__all__ = [
+    "build_state_grad_summaries",
+    "build_state_grad_summary",
+    "build_state_summaries",
+    "build_state_summary",
+]

--- a/attn_gym/linear/_delta_rule/cute/affine_summary_fwd.py
+++ b/attn_gym/linear/_delta_rule/cute/affine_summary_fwd.py
@@ -25,13 +25,38 @@ The output is the V-first packed transpose ``X^T`` of shape ``[H, V + K, K]``:
 rows ``[0:V]`` hold the state bias and rows ``[V:V+K]`` the state transition.
 These are distinct from KDA's token-token query/key matrix ``A``.
 
+Terms (see also NOTE [Terminology] in ``attn_gym.linear.state_summary``):
+
+    chunk         64 tokens (``BT``). The factor kernels lay chunks from each subsequence's
+                  first token, so every subsequence has its own chunk grid.
+    range         one row of ``bounds``: ``[start, stop)`` of whole chunks inside one
+                  subsequence of the span (NOTE [Summary ranges are whole chunks of one
+                  subsequence] in ``attn_gym.linear.kda.stages``), which gets its own
+                  ``[bias; transition]`` summary. ``R`` = number of rows. A range never spans
+                  two documents; a row with ``start == stop`` scans nothing and yields the
+                  identity.
+    column tile   a ``BN``-wide slice of the ``V + K = 256`` augmented-state columns. One
+                  CTA owns the ``[K, BN]`` state tile ``X[:, cols]`` for one head and one
+                  work item; tiles ``< V / BN`` hold bias columns, the rest transition
+                  columns.
+
+The context-parallel routing passes exactly one range per fragment a rank owns: that
+fragment's *last* subsequence, or an empty range when it ends its document. A fragment is one
+contiguous global token range, so only its last subsequence can continue on another rank and
+only its first can be continued; interior subsequences are whole documents that start from
+zero. ``R`` therefore equals the rank's fragment count, while each row is one subsequence's
+range (NOTE [Terminology], "Summary work is bounded by fragments").
+
+*work item* and *partial* are the ``work`` table contract between the planner and the
+kernels, defined in ``attn_gym.linear._delta_rule.triton.work_items``.
+
 Architecture (SM100 warp specialization, mirrors ``kda/bwd/cute/chunk_delta_h_bwd.py``):
-  - One CTA per (BN-column tile of the augmented state, head, chunk segment); 6 warps.
-    The recurrence is a serial latency chain (~1.1 us per chunk at BN=32), so when
-    ``heads * tiles`` leaves SMs idle the wrapper splits the chunks into segments that
-    each scan from ``[0 | I]`` and composes the segment maps on the host.
-  - CUDA warps (0-3) keep the fp32 ``[K, BN]`` state tile in registers across the
-    segment's chunks and produce the two SMEM MMA B operands per chunk.
+  - One CTA per (column tile, head, work item); 6 warps. The recurrence is a serial latency
+    chain (~1.1 us per chunk at BN=32), so when ``heads * tiles`` leaves SMs idle the wrapper
+    cuts the ranges' chunks into as many items as fill the machine (``plan_work_items``)
+    and ``compose_work_items`` folds the partials per range, both on the device.
+  - CUDA warps (0-3) keep the fp32 ``[K, BN]`` state tile in registers across the item's
+    chunks and produce the two SMEM MMA B operands per chunk.
   - Load warp (4) TMA-stages ``w``, ``kg^T``, ``u``, and the chunk-final gate row.
   - MMA warp (5) issues two SS-mode UMMA groups per chunk into TMEM:
       MMA1: W  @ X          -> wx  (BT=64, BN, K=128)
@@ -45,20 +70,22 @@ halves of the I/O dtype and accumulated in two UMMA passes. The A operands
 (``w``, ``kg``) and ``u`` retain their original bf16/fp16 storage.
 
 Limitations:
-  - B=1, dense complete chunks only (``T % 64 == 0``), fixed K=V=128, BT=64.
+  - B=1, fixed K=V=128, BT=64; any ``T``. Token ranges come from a device ``bounds`` tensor and
+    a partial last chunk is neutralized in-kernel (gate row clamped, over-read ``kg`` columns
+    zeroed), which assumes the over-read tokens are finite: ``0 * inf`` is NaN.
   - Contiguous inputs; SM100 (tcgen05) only.
 """
 
 # NOTE: no `from __future__ import annotations` — cute.struct requires
 # eager-evaluated annotations.
 
+import functools
 from enum import IntEnum
 from typing import NamedTuple
 
 import cutlass
 import cutlass.utils.blackwell_helpers as sm100_utils
 import torch
-import torch.nn.functional as F
 from cuda.bindings import driver as cuda
 from cutlass import cute, pipeline, utils
 from cutlass.cute.nvgpu import cpasync, tcgen05
@@ -69,6 +96,7 @@ from torch._subclasses.fake_tensor import FakeTensor
 from attn_gym._backends.cute import compile_tvm_ffi, get_device_properties, jit_cache
 from attn_gym._backends.cute.target import get_compile_target
 from attn_gym._backends.cute.utils import requires_int64_abi
+from attn_gym.linear._delta_rule.triton.work_items import compose_work_items, work_table
 from attn_gym.linear.kda.constants import is_sm100_kda_capability
 from attn_gym.utils import cdiv
 
@@ -99,6 +127,21 @@ def _feature_sequence_head_batch_view(tensor):
     """Re-rank ``[B,T,H,D]`` as ``[D,T,(H,B)]`` for a TMA operand."""
     layout = cute.group_modes(cute.select(tensor.layout, mode=[3, 1, 2, 0]), 2, 4)
     return cute.make_tensor(tensor.iterator, layout)
+
+
+@cute.jit
+def decode_work_row(work_table: cute.Tensor, work: Int32, whole_ranges: cutlass.Constexpr):
+    """Return ``(start, length, chunk_begin, chunk_end)`` of work item ``work``.
+
+    Rows are ``(start, chunk_begin, chunk_end, length)`` from ``plan_work_items``, or ``(start,
+    stop)`` of ``bounds`` itself under ``whole_ranges`` (one item per range, see
+    ``work_items.work_table``). An all-zero row scans nothing.
+    """
+    start = work_table[work, 0]
+    if cutlass.const_expr(whole_ranges):
+        length = work_table[work, 1] - start
+        return start, length, Int32(0), (length + BT - 1) // BT
+    return start, work_table[work, 3], work_table[work, 1], work_table[work, 2]
 
 
 class WarpRole(IntEnum):
@@ -164,6 +207,7 @@ class _AffineSummaryFwdOp:
         heads: int,
         state_bn: int,
         use_int64_offsets: bool,
+        whole_ranges: bool,
     ):
         assert state_bn in (32, 64), f"state_bn must be 32 or 64, got {state_bn}"
         assert SUMMARY_DIM % state_bn == 0
@@ -172,6 +216,9 @@ class _AffineSummaryFwdOp:
         self.heads = heads
         self.BN = state_bn
         self.use_int64_offsets = use_int64_offsets
+        # With ``whole_ranges`` the work table is ``bounds`` itself, ``[R, 2]`` token ranges,
+        # and every row is one item: the ``budget == 1`` case needs no planner and no fold.
+        self.whole_ranges = whole_ranges
 
         # MMA tile shapes (M, N, K).
         # MMA1: w @ X -> wx — w is (BT, K) K-major, X is (K, BN) snapshot in SMEM.
@@ -196,7 +243,7 @@ class _AffineSummaryFwdOp:
         """Return a stable profiler and artifact name for this specialization."""
         return (
             f"delta_affine_summary_fwd_h{self.heads}_bn{self.BN}_{self.dtype_name}"
-            f"_i64{int(self.use_int64_offsets)}"
+            f"_i64{int(self.use_int64_offsets)}_whole{int(self.whole_ranges)}"
         )
 
     # ------------------------------------------------------------------
@@ -210,11 +257,17 @@ class _AffineSummaryFwdOp:
         mW: cute.Tensor,
         mU: cute.Tensor,
         mG: cute.Tensor,
+        mWork: cute.Tensor,
         mOut: cute.Tensor,
-        chunks_per_segment: Int32,
         stream: cuda.CUstream,
     ):
-        """Launch one CTA per (augmented-state column tile, head, chunk segment)."""
+        """Launch one CTA per (augmented-state column tile, head, work item).
+
+        ``mWork[w] = (start, chunk_begin, chunk_end, length)`` names a run of chunks of one
+        range: token ``start`` of the ``[1, T, H, D]`` inputs begins the range, which is
+        ``length`` tokens long, and this item scans its chunks ``[chunk_begin, chunk_end)`` from
+        ``[0 | I]`` into ``mOut[w]``. An all-zero row scans nothing and stores the identity.
+        """
         # Re-rank the dense [1, T, H, D] inputs into the logical TMA views.
         g_w = _sequence_feature_head_batch_view(mW)
         g_kgt = _feature_sequence_head_batch_view(mKg)
@@ -368,7 +421,6 @@ class _AffineSummaryFwdOp:
 
         self.shared_type = Shared
 
-        num_chunks = Int32(cute.size(mW.shape[1])) // BT
         self.kernel.set_name_prefix(self.get_name())
         self.kernel(
             Mmas(mma_wx, mma_kt, mma_ktu),
@@ -378,6 +430,7 @@ class _AffineSummaryFwdOp:
                 TmaOp(atom_u, desc_u),
                 TmaOp(atom_gk, desc_gk),
             ),
+            mWork,
             mOut,
             SmemLayouts(
                 s_w_staged,
@@ -388,8 +441,6 @@ class _AffineSummaryFwdOp:
                 s_tmpb_staged,
                 s_tmpb_store_staged,
             ),
-            num_chunks,
-            chunks_per_segment,
         ).launch(
             grid=(SUMMARY_DIM // self.BN, self.heads, cute.size(mOut.shape[0])),
             block=(self.CTA_THREADS, 1, 1),
@@ -424,6 +475,8 @@ class _AffineSummaryFwdOp:
         head,
         col_tile,
         is_value,
+        start,
+        length,
         chunk_begin,
         chunk_end,
         tma,
@@ -439,12 +492,22 @@ class _AffineSummaryFwdOp:
         pu_P,
         pgk_P,
     ):
-        """Own the per-chunk TMA G2S loads for w, kg^T, u, and the gate row."""
+        """Own the per-chunk TMA G2S loads for w, kg^T, u, and the gate row.
+
+        The range starts at token ``start`` of the stream, so every descriptor is offset along
+        its token mode and chunk ``ct`` reads tokens ``start + ct * BT`` onward; a partial last
+        chunk over-reads into the next range's tokens (or TMA zero fill past ``T``), which the
+        MMA warp neutralizes through ``kg`` and the gate row clamp below.
+        """
         batch = Int32(0)
-        tWs, tWg = self._part_a(tma.w.atom, tma.w.desc, sW, self.wx_tile, mma_wx, batch, head)
-        tKgs, tKgg = self._part_a(tma.kg.atom, tma.kg.desc, sKg, self.kt_tile, mma_kt, batch, head)
-        sUp, gUp = self._part_b(tma.u.atom, tma.u.desc, sU, self.kt_tile, mma_ktu, batch, head)
-        gGK_l = tma.gk.desc[None, None, (head, batch)]
+        desc_w = cute.domain_offset((start, 0, (0, 0)), tma.w.desc)
+        desc_kg = cute.domain_offset((0, start, (0, 0)), tma.kg.desc)
+        desc_u = cute.domain_offset((0, start, (0, 0)), tma.u.desc)
+        desc_gk = cute.domain_offset((0, start, (0, 0)), tma.gk.desc)
+        tWs, tWg = self._part_a(tma.w.atom, desc_w, sW, self.wx_tile, mma_wx, batch, head)
+        tKgs, tKgg = self._part_a(tma.kg.atom, desc_kg, sKg, self.kt_tile, mma_kt, batch, head)
+        sUp, gUp = self._part_b(tma.u.atom, desc_u, sU, self.kt_tile, mma_ktu, batch, head)
+        gGK_l = desc_gk[None, None, (head, batch)]
         sGKp, gGKp = self._part_epi(tma.gk.atom, gGK_l, (KEY_DIM, 1), gk_3d)
 
         for ct in cutlass.range(chunk_begin, chunk_end, unroll=0):
@@ -470,10 +533,12 @@ class _AffineSummaryFwdOp:
                     dst=sUp[None, uh.index],
                     tma_bar_ptr=uh.barrier,
                 )
+            # The chunk-final gate row: the range's last token when the chunk is partial.
+            gk_t = cutlass.min(ct * BT + BT - 1, length - 1)
             gkh = pgk_P.acquire_and_advance()
             cute.copy(
                 atom=tma.gk.atom,
-                src=gGKp[(None, 0, ct * BT + BT - 1)],
+                src=gGKp[(None, 0, gk_t)],
                 dst=sGKp[None, gkh.index],
                 tma_bar_ptr=gkh.barrier,
             )
@@ -483,6 +548,9 @@ class _AffineSummaryFwdOp:
         self,
         is_value,
         num_chunks,
+        tail_chunk,
+        tail_valid_rows,
+        sKg,
         mma_wx,
         mma_kt,
         mma_ktu,
@@ -508,10 +576,18 @@ class _AffineSummaryFwdOp:
         TMA ring, off the recurrence critical path) plus two hi/lo accumulate
         passes over ``Kg^T @ (-wx)``; MMA1 likewise runs two passes over the
         hi/lo state snapshot, recovering ~fp32 operand precision.
+
+        Chunk ``tail_chunk`` (local index) holds only ``tail_valid_rows`` range tokens; its
+        remaining ``kg`` columns are zeroed before use so the over-read tokens contribute nothing
+        to either ``Kg^T @ U`` or ``Kg^T @ (-wx)``.
         """
-        for _ct in cutlass.range(0, num_chunks, unroll=0):
+        tid, _, _ = cute.arch.thread_idx()
+        mma_tid = tid - WarpRole.MMA * self.WARP_SZ
+        for ct in cutlass.range(0, num_chunks, unroll=0):
             # --- MMA2a: kg^T(SMEM A) × U(SMEM B) → kt(TMEM), value tiles only ---
             kgh = pkg_C.wait_and_advance()
+            if ct == tail_chunk and tail_valid_rows != 0:
+                self._neutralize_kg_tail(sKg, kgh.index, tail_valid_rows, mma_tid)
             ktd = pkt_P.acquire_and_advance()
             if is_value:
                 uh = pu_C.wait_and_advance()
@@ -564,10 +640,31 @@ class _AffineSummaryFwdOp:
             kgh.release()
 
     @cute.jit
+    def _neutralize_kg_tail(self, smem, stage, valid_rows, tid):
+        """Zero ``kg^T`` token columns ``>= valid_rows`` of one stage before UMMA reads it."""
+        row_atom = cute.size(smem, mode=[0, 0, 0])
+        token_atom = cute.size(smem, mode=[0, 1])
+        assert cute.size(smem, mode=[1]) == 1, "expected a single rest-M mode"
+        assert row_atom * cute.size(smem, mode=[0, 0, 1]) == KEY_DIM
+        assert token_atom * cute.size(smem, mode=[2]) == BT
+        for token in cutlass.range(valid_rows, BT, unroll=1):
+            for row_block in cutlass.range_constexpr(KEY_DIM // self.WARP_SZ):
+                row = tid + row_block * self.WARP_SZ
+                coordinate = (
+                    ((row % row_atom, row // row_atom), token % token_atom),
+                    0,
+                    token // token_atom,
+                    stage,
+                )
+                smem[coordinate] = self.io_type(0.0)
+        cute.arch.fence_view_async_shared()
+        cute.arch.sync_warp()
+
+    @cute.jit
     def run_state(
         self,
         head,
-        segment,
+        work,
         col_base,
         num_chunks,
         mOut,
@@ -606,7 +703,7 @@ class _AffineSummaryFwdOp:
         sl_kt = tc_t2r_kt.get_slice(local_tid)
         p_t_kt = sl_kt.partition_S(kt_flat)
 
-        # Identity tensors provide both coordinate maps and fragment shapes.
+        # Identity tensors provide both coordinate maps and range shapes.
         coords_tv = sl_wx.partition_D(cute.make_identity_tensor((BT, self.BN)))
         coords_kv = sl_kt.partition_D(cute.make_identity_tensor((KEY_DIM, self.BN)))
 
@@ -714,7 +811,7 @@ class _AffineSummaryFwdOp:
         # Epilogue: store the V-first packed transpose out[s, h, col, k] = X[k, col].
         for ei in cutlass.range(cute.size(st), unroll_full=True):
             kc, nc = coords_kv[ei]
-            mOut[segment, head, col_base + nc, kc] = st[ei]
+            mOut[work, head, col_base + nc, kc] = st[ei]
 
     # ------------------------------------------------------------------
     # Device kernel
@@ -725,10 +822,9 @@ class _AffineSummaryFwdOp:
         self,
         mmas: Mmas,
         tma: TmaOps,
+        mWork: cute.Tensor,
         mOut: cute.Tensor,
         smem_layouts: SmemLayouts,
-        num_chunks: Int32,
-        chunks_per_segment: Int32,
     ):
         mma_wx, mma_kt, mma_ktu = mmas
         (
@@ -880,19 +976,24 @@ class _AffineSummaryFwdOp:
         t_kt_acc = cute.make_tensor(tp + self.tm_kt, kt_fk.layout)
 
         # #
-        # Role dispatch: one CTA owns one (column tile, head, chunk segment) state slice.
+        # Role dispatch: one CTA owns one (column tile, head, work item) state slice.
         #
-        col_tile, head, segment = cute.arch.block_idx()
+        col_tile, head, work = cute.arch.block_idx()
         col_base = col_tile * self.BN
         is_value = col_base < VAL_DIM
-        # Each segment scans its own chunk range from [0 | I]; the host composes them.
-        chunk_begin = segment * chunks_per_segment  # < num_chunks: plan_segments drops empties
-        chunk_end = cutlass.min(chunk_begin + chunks_per_segment, num_chunks)
+        start, length, chunk_begin, chunk_end = decode_work_row(mWork, work, self.whole_ranges)
+        # The range's last chunk may be partial; only the item that scans it must neutralize
+        # the over-read rows. An all-zero row has num_chunks == 0 and stores the identity.
+        num_chunks = (length + BT - 1) // BT
+        tail_valid_rows = length - (num_chunks - 1) * BT  # == BT when the last chunk is full
+        if tail_valid_rows == BT:
+            tail_valid_rows = Int32(0)
+        tail_chunk = num_chunks - 1 - chunk_begin  # local index of the range's last chunk
 
         if warp_id in self.CUDA_WARP_IDS:
             self.run_state(
                 head=head,
-                segment=segment,
+                work=work,
                 col_base=col_base,
                 num_chunks=chunk_end - chunk_begin,
                 mOut=mOut,
@@ -912,6 +1013,8 @@ class _AffineSummaryFwdOp:
                 head=head,
                 col_tile=col_tile,
                 is_value=is_value,
+                start=start,
+                length=length,
                 chunk_begin=chunk_begin,
                 chunk_end=chunk_end,
                 tma=tma,
@@ -931,6 +1034,9 @@ class _AffineSummaryFwdOp:
             self.run_mma(
                 is_value=is_value,
                 num_chunks=chunk_end - chunk_begin,
+                tail_chunk=tail_chunk,
+                tail_valid_rows=tail_valid_rows,
+                sKg=sKg,
                 mma_wx=mma_wx,
                 mma_kt=mma_kt,
                 mma_ktu=mma_ktu,
@@ -1000,13 +1106,14 @@ def _compile_affine_summary(
     heads: int,
     state_bn: int,
     use_int64_offsets: bool,
+    whole_ranges: bool,
 ):
     """Compile one dtype/head-count specialization from fake tensors."""
     target = get_compile_target()
     if target.device_type != "cuda" or not is_sm100_kda_capability(target.effective_capability):
         raise ValueError(f"affine_summary_fwd requires an SM100/SM103 target; got {target}")
     sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
-    tokens = sym_int(divisibility=BT)
+    tokens = sym_int()
 
     def factor(dtype, last_dim: int):
         return make_fake_compact_tensor(
@@ -1017,6 +1124,9 @@ def _compile_affine_summary(
         )
 
     io_dtype = _CUTE_IO_TYPES[dtype_name]
+    work = make_fake_compact_tensor(
+        Int32, (sym_int(), 2 if whole_ranges else 4), stride_order=(1, 0)
+    )
     out = make_fake_compact_tensor(
         Float32,
         (sym_int(), heads, SUMMARY_DIM, KEY_DIM),
@@ -1024,90 +1134,74 @@ def _compile_affine_summary(
         assumed_align=DATA_ALIGN_BYTES,
     )
     return compile_tvm_ffi(
-        _AffineSummaryFwdOp(dtype_name, heads, state_bn, use_int64_offsets),
+        _AffineSummaryFwdOp(dtype_name, heads, state_bn, use_int64_offsets, whole_ranges),
         factor(io_dtype, KEY_DIM),
         factor(io_dtype, KEY_DIM),
         factor(io_dtype, VAL_DIM),
         factor(Float32, KEY_DIM),
+        work,
         out,
-        Int32(1),
     )
 
 
-# Each pairwise fold level costs two small launches (~8 us) while a chunk costs ~1.1-1.3 us, so a
-# segment must carry enough chunks for the shortened chain to pay for the fold. Measured crossover
-# on GB200 is ~32 chunks total; 16 chunks per segment keeps every split a win.
-MIN_CHUNKS_PER_SEGMENT = 16
+# Splitting adds the planner and the fold (two small launches) while a chunk costs ~1.1-1.3 us,
+# so a work item must carry enough chunks for the shortened chain to pay for them. Measured
+# crossover on GB200 is ~32 chunks total; 16 chunks per item keeps every split a win.
+MIN_CHUNKS_PER_ITEM = 16
+# The forward launches and both Triton fallbacks put ranges or work items on grid.z (limit
+# 65535); leave room for the work budget, which is at most the SM count.
+MAX_RANGES = 65535 - 1024
 
 
-def plan_segments(num_chunks: int, work_tiles: int, sm_count: int) -> tuple[int, int]:
-    """Return ``(segments, chunks_per_segment)`` filling idle SMs with chunk segments.
+def plan_work_budget(max_chunks: int, work_tiles: int, sm_count: int) -> int:
+    """Return how many work items to scan concurrently for a span of at most ``max_chunks``.
 
     The chunk recurrence is a serial chain per CTA, so when ``work_tiles`` (column tiles times
-    heads) leaves SMs idle the chunks are split into segments that each scan from ``[0 | I]``
-    and ``compose_segment_summaries`` folds the segment maps.
+    heads) leaves SMs idle the chunks are split into items that each scan from ``[0 | I]`` and
+    ``compose_work_items`` folds the range maps. ``max_chunks`` is a static upper bound (the span
+    length); the items themselves are cut on the device by ``plan_work_items``.
     """
-    # ``segments`` is an upper bound from available SMs and the minimum useful segment length.
-    # After rounding up the chunks per segment, recompute how many non-empty segments are needed.
-    segments = max(1, min(num_chunks // MIN_CHUNKS_PER_SEGMENT, sm_count // work_tiles))
-    chunks_per_segment = cdiv(num_chunks, segments)
-    return cdiv(num_chunks, chunks_per_segment), chunks_per_segment
-
-
-def compose_segment_summaries(summaries: torch.Tensor) -> torch.Tensor:
-    """Fold ``[S, H, V + K, K]`` consecutive segment maps into one, pairwise from the left.
-
-    ``(A0, B0)`` then ``(A1, B1)`` composes to ``(A0 @ A1, B0 @ A1 + B1)``; each level composes
-    adjacent pairs with two launches (one matmul, one bias add), so the fold costs log2(S) levels
-    rather than S - 1 sequential compositions. The fold runs in FP64 so its precision does not
-    depend on the caller's float32 matmul mode (TF32 would otherwise leak into the summary); the
-    operands are at most a few megabytes, so the cast is negligible next to the kernel.
-    """
-    if summaries.shape[0] == 1:
-        return summaries[0]
-    value_dim = summaries.shape[-2] - summaries.shape[-1]
-    summaries = summaries.double()
-    while summaries.shape[0] > 1:
-        pairs = 2 * (summaries.shape[0] // 2)
-        first, then = summaries[0:pairs:2], summaries[1:pairs:2]
-        composed = first @ then[..., value_dim:, :]
-        composed[..., :value_dim, :] += then[..., :value_dim, :]
-        summaries = (
-            composed if pairs == summaries.shape[0] else torch.cat((composed, summaries[pairs:]))
-        )
-    return summaries[0].float()
+    return max(1, min(max_chunks // MIN_CHUNKS_PER_ITEM, sm_count // work_tiles))
 
 
 @torch.compiler.disable
-def build_state_summary(
+def build_state_summaries(
     kg: torch.Tensor,
     w: torch.Tensor,
     u: torch.Tensor,
     cumulative_gate: torch.Tensor,
+    bounds: torch.Tensor,
 ) -> torch.Tensor:
-    """Compute one shard's packed affine state summary from its WY chunk factors.
+    """Compute one packed affine state summary per token range of a stream's WY chunk factors.
 
     Args:
-        kg: Gated keys ``k * exp2(gk_last - gk)``, shape ``[1, T, H, 128]``,
-            bf16 or fp16.
+        kg: Gated keys ``k * exp2(gk_last - gk)``, shape ``[1, T, H, 128]``, bf16 or fp16.
         w: WY factor ``w``, same shape and dtype as ``kg``.
         u: WY pseudo-values ``u``, shape ``[1, T, H, 128]``, same dtype as ``kg``.
         cumulative_gate: Cumulative log2 gates, shape ``[1, T, H, 128]``, fp32.
+        bounds: ``int32 [R, 2]`` device tensor of half-open token ranges ``[start, stop)`` with
+            ``0 <= start <= stop <= T``; ``start == stop`` yields the identity map. A range is
+            exact only over whole chunks of one packed sequence: ``start`` on that sequence's
+            64-token chunk grid, ``stop`` on the grid or at the sequence's end (a partial last
+            chunk is neutralized in-kernel). The values are not checked (that would sync);
+            other ranges return a plausible but wrong map.
 
     Returns:
-        FP32 tensor of shape ``[H, 256, 128]``, V-first packed as state bias then
-        state transition for ``H_out = H_in @ transition + bias``.
+        FP32 tensor of shape ``[R, H, 256, 128]``, V-first packed as state bias then state
+        transition for ``H_out = H_in @ transition + bias``, one per row of ``bounds``.
 
-    Supported scope: B=1, fixed K=V=128 and BT=64, contiguous CUDA inputs.
-    SM100 uses the native UMMA kernel; other capability 8.0+ targets use Triton.
-    A partial final chunk is neutral-padded by the wrapper.
+    The ranges are read on the device, so the launch is CUDA Graph capturable and replayable
+    across different ``bounds`` values of the same shape. The tokens right after a partial last
+    chunk are read and then cancelled, so they must be finite. Supported scope: B=1, fixed
+    K=V=128 and BT=64, contiguous CUDA inputs. SM100 uses the native UMMA kernel; other
+    capability 8.0+ targets use Triton.
     """
     assert kg.ndim == 4, f"kg must be 4D [1, T, H, K], got shape {tuple(kg.shape)}"
     batch, tokens, heads, key_dim = kg.shape
-    assert batch == 1, f"build_state_summary requires B=1, got B={batch}"
-    assert tokens > 0, "build_state_summary requires at least one token"
-    assert heads > 0, "build_state_summary requires at least one head"
-    assert key_dim == KEY_DIM, f"build_state_summary requires K={KEY_DIM}, got {key_dim}"
+    assert batch == 1, f"build_state_summaries requires B=1, got B={batch}"
+    assert tokens > 0, "build_state_summaries requires at least one token"
+    assert heads > 0, "build_state_summaries requires at least one head"
+    assert key_dim == KEY_DIM, f"build_state_summaries requires K={KEY_DIM}, got {key_dim}"
     assert w.shape == kg.shape, f"w must match kg shape {tuple(kg.shape)}, got {tuple(w.shape)}"
     assert u.shape == (1, tokens, heads, VAL_DIM), (
         f"u must have shape {(1, tokens, heads, VAL_DIM)}, got {tuple(u.shape)}"
@@ -1123,28 +1217,25 @@ def build_state_summary(
     assert cumulative_gate.dtype == torch.float32, (
         f"cumulative_gate must be fp32, got {cumulative_gate.dtype}"
     )
+    assert bounds.ndim == 2 and bounds.shape[1] == 2 and bounds.shape[0] > 0, (
+        f"bounds must have shape [R, 2] with R > 0, got {tuple(bounds.shape)}"
+    )
+    assert bounds.dtype == torch.int32, f"bounds must be int32, got {bounds.dtype}"
 
     if isinstance(kg, FakeTensor):
         raise TypeError(
-            "build_state_summary does not support torch.export; run the context-parallel "
+            "build_state_summaries does not support torch.export; run the context-parallel "
             "summary eagerly or under CUDA Graph capture"
         )
 
-    assert kg.is_cuda, "build_state_summary requires CUDA tensors"
-    for name, tensor in (("kg", kg), ("w", w), ("u", u), ("cumulative_gate", cumulative_gate)):
+    assert kg.is_cuda, "build_state_summaries requires CUDA tensors"
+    tensors = (("kg", kg), ("w", w), ("u", u), ("cumulative_gate", cumulative_gate))
+    for name, tensor in (*tensors, ("bounds", bounds)):
         assert tensor.device == kg.device, f"{name} must be on {kg.device}, got {tensor.device}"
         assert tensor.is_contiguous(), f"{name} must be contiguous, got strides {tensor.stride()}"
-    pad = (-tokens) % BT
-    if pad:
-        padding = (0, 0, 0, 0, 0, pad)
-        kg, w, u = (F.pad(tensor, padding) for tensor in (kg, w, u))
-        cumulative_gate = torch.cat(
-            (
-                cumulative_gate,
-                cumulative_gate[:, -1:].expand(-1, pad, -1, -1),
-            ),
-            dim=1,
-        )
+    ranges = bounds.shape[0]
+    if ranges > MAX_RANGES:
+        raise ValueError(f"at most {MAX_RANGES} ranges per launch, got {ranges}")
     properties = get_device_properties(kg.device)
     capability = (properties.major, properties.minor)
     if capability < (8, 0):
@@ -1159,8 +1250,10 @@ def build_state_summary(
             launch_affine_summary_fwd,
         )
 
-        out = torch.empty((heads, SUMMARY_DIM, KEY_DIM), dtype=torch.float32, device=kg.device)
-        launch_affine_summary_fwd(kg, w, u, cumulative_gate, out, capability)
+        out = torch.empty(
+            (ranges, heads, SUMMARY_DIM, KEY_DIM), dtype=torch.float32, device=kg.device
+        )
+        launch_affine_summary_fwd(kg, w, u, cumulative_gate, bounds, out, capability)
         return out
 
     kg, w, u, cumulative_gate = (_aligned(tensor) for tensor in (kg, w, u, cumulative_gate))
@@ -1168,23 +1261,57 @@ def build_state_summary(
     # BN=64 only when the extra column tiles would spill past one CTA wave and
     # serialize whole recurrence chains.
     sm_count = properties.multi_processor_count
-    state_bn = 32 if heads * (SUMMARY_DIM // 32) <= sm_count else 64
-    segments, chunks_per_segment = plan_segments(
-        kg.shape[1] // BT, heads * (SUMMARY_DIM // state_bn), sm_count
+    state_bn = 32 if ranges * heads * (SUMMARY_DIM // 32) <= sm_count else 64
+    # The bounds live on the device, so the budget comes from the span's chunk count (a static
+    # upper bound) and the device cuts the ranges' actual chunks into that many items.
+    budget = plan_work_budget(cdiv(tokens, BT), heads * (SUMMARY_DIM // state_bn), sm_count)
+    work, range_ids = work_table(bounds, budget)
+    partials = torch.empty(
+        (work.shape[0], heads, SUMMARY_DIM, KEY_DIM), dtype=torch.float32, device=kg.device
     )
-    segment_out = torch.empty(
-        (segments, heads, SUMMARY_DIM, KEY_DIM), dtype=torch.float32, device=kg.device
-    )
-    use_int64_offsets = requires_int64_abi(kg, w, u, cumulative_gate, segment_out)
+    use_int64_offsets = requires_int64_abi(kg, w, u, cumulative_gate, partials)
     compiled = _compile_affine_summary(
-        _IO_TYPE_NAMES[kg.dtype], heads, state_bn, use_int64_offsets
+        _IO_TYPE_NAMES[kg.dtype],
+        heads,
+        state_bn,
+        use_int64_offsets,
+        whole_ranges=range_ids is None,
     )
-    compiled(
-        kg.detach(),
-        w.detach(),
-        u.detach(),
-        cumulative_gate.detach(),
-        segment_out,
-        chunks_per_segment,
-    )
-    return compose_segment_summaries(segment_out)
+    compiled(kg.detach(), w.detach(), u.detach(), cumulative_gate.detach(), work, partials)
+    return compose_work_items(partials, range_ids, ranges, reverse=False)
+
+
+@functools.lru_cache(maxsize=64)
+def _cached_full_range(tokens: int, device: torch.device) -> torch.Tensor:
+    return (torch.arange(2, dtype=torch.int32, device=device) * tokens).view(1, 2)
+
+
+def full_range_bounds(like: torch.Tensor) -> torch.Tensor:
+    """``[[0, T]]`` for the single-range summaries of a ``[1, T, ...]`` tensor.
+
+    Built with ``arange`` so it never needs a host-to-device copy. The tensor is cached per
+    ``(T, device)`` because three tiny eager ops cost as much as the summary kernel itself, except
+    under CUDA Graph capture (the graph's pool must own it) and for fake inputs (a cached fake
+    tensor would be handed to real calls later).
+    """
+    tokens, device = like.shape[1], like.device
+    if torch.cuda.is_current_stream_capturing() or isinstance(like, FakeTensor):
+        return (torch.arange(2, dtype=torch.int32, device=device) * tokens).view(1, 2)
+    return _cached_full_range(tokens, device)
+
+
+@torch.compiler.disable
+def build_state_summary(
+    kg: torch.Tensor,
+    w: torch.Tensor,
+    u: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+) -> torch.Tensor:
+    """Compute one shard's packed affine state summary from its WY chunk factors.
+
+    The single-range form of :func:`build_state_summaries` over all ``T`` tokens (a partial
+    final chunk is handled in the kernel); see it for the argument contract. Returns FP32
+    ``[H, 256, 128]``.
+    """
+    bounds = full_range_bounds(kg)
+    return build_state_summaries(kg, w, u, cumulative_gate, bounds)[0]

--- a/attn_gym/linear/_delta_rule/cute/affine_summary_rev.py
+++ b/attn_gym/linear/_delta_rule/cute/affine_summary_rev.py
@@ -11,17 +11,20 @@ The local backward recurrence is affine in its incoming final-state cotangent:
 ``[K, BN]`` tiles of the augmented FP32 state ``X = [0 | I]`` and returns its
 V-first packed transpose ``[local_bias; reverse_transition]``.
 
-Each 224-thread CTA persistently owns work items, one (augmented-column tile,
-head, chunk segment) each. Four CUDA warps hold the FP32 state in registers, one
-warp issues TMA loads, one computes gate exponentials, and one issues the four
-UMMA operations. Bias tiles load the local output-gradient sources; transition
-tiles skip those streams entirely. Only the final FP32 summary is written to
-global memory.
+Terms (chunk, range, column tile, and why the routing sends one range per fragment) are defined
+in ``affine_summary_fwd``; *work item* and *partial* in
+``attn_gym.linear._delta_rule.triton.work_items``. Each 224-thread CTA is persistent: it walks a
+grid-strided sequence of flat tile indices, decodes each into (column tile, head, work item), and
+reads the item's token range from the device ``work`` table, so nothing about the layout is baked
+into the launch. Four CUDA warps hold the FP32 state in registers, one warp issues TMA loads, one
+computes gate exponentials, and one issues the four UMMA operations. Bias tiles load the local
+output-gradient sources; transition tiles skip those streams entirely. Only the final FP32
+partial is written to global memory.
 
-The chunk recurrence is a serial latency chain (~1.3 us per chunk at BN=32), so
-when ``heads * tiles`` leaves SMs idle the wrapper splits the chunks into
-segments that each scan from ``[0 | I]`` and composes the segment maps on the
-host; see ``compose_segment_summaries`` in the forward module.
+The chunk recurrence is a serial latency chain (~1.3 us per chunk at BN=32), so when
+``heads * tiles`` leaves SMs idle the wrapper cuts the ranges' chunks into work items that
+each scan from ``[0 | I]`` and ``compose_work_items`` folds the partials per range on the
+device.
 
 The fp32-valued MMA B operands (state ``X`` and the corrected write gradient
 ``dv``) are split into hi/lo halves of the I/O dtype and accumulated in two UMMA
@@ -38,7 +41,6 @@ from typing import NamedTuple
 import cutlass
 import cutlass.utils.blackwell_helpers as sm100_utils
 import torch
-import torch.nn.functional as F
 from cuda.bindings import driver as cuda
 from cutlass import Float32, Int32, cute, pipeline, utils
 from cutlass.cute.nvgpu import cpasync, tcgen05
@@ -50,10 +52,14 @@ from attn_gym._backends.cute import compile_tvm_ffi, get_device_properties, jit_
 from attn_gym._backends.cute.target import get_compile_target
 from attn_gym._backends.cute.utils import requires_int64_abi
 from attn_gym.linear._delta_rule.cute.affine_summary_fwd import (
-    compose_segment_summaries,
-    plan_segments,
+    MAX_RANGES,
+    decode_work_row,
+    full_range_bounds,
+    plan_work_budget,
 )
+from attn_gym.linear._delta_rule.triton.work_items import compose_work_items, work_table
 from attn_gym.linear.kda.constants import is_sm100_kda_capability
+from attn_gym.utils import cdiv
 
 BT = 64
 KEY_DIM = 128
@@ -142,7 +148,7 @@ class BlackwellDeltaAffineSummaryRev:
     WARP_SIZE = cute.arch.WARP_SIZE
     CTA_THREADS = WarpRole.END * WARP_SIZE
     # Augmented-state columns per CTA. A BN=16 tile covered half the columns for only ~25% less
-    # time per chunk; chunk segments fill idle SMs instead.
+    # time per chunk; work items fill idle SMs instead.
     BN = 32
 
     def __init__(
@@ -150,6 +156,7 @@ class BlackwellDeltaAffineSummaryRev:
         num_heads: int,
         io_type: type[cutlass.Numeric],
         use_int64_offsets: bool,
+        whole_ranges: bool,
     ):
         self.num_heads = num_heads
         self.io_type = io_type
@@ -157,6 +164,9 @@ class BlackwellDeltaAffineSummaryRev:
         self.BT = BT
         self.BK = KEY_DIM
         self.use_int64_offsets = use_int64_offsets
+        # With ``whole_ranges`` the work table is ``bounds`` itself, ``[R, 2]`` token ranges,
+        # and every row is one item: the ``budget == 1`` case needs no planner and no fold.
+        self.whole_ranges = whole_ranges
 
         self.state_regs = 160
         self.aux_regs = 40
@@ -189,7 +199,7 @@ class BlackwellDeltaAffineSummaryRev:
         dtype_name = "bf16" if self.io_type is cutlass.BFloat16 else "fp16"
         return (
             f"delta_affine_summary_rev_h{self.num_heads}_bn{self.BN}_{dtype_name}"
-            f"_i64{int(self.use_int64_offsets)}"
+            f"_i64{int(self.use_int64_offsets)}_whole{int(self.whole_ranges)}"
         )
 
     @cute.jit
@@ -201,12 +211,16 @@ class BlackwellDeltaAffineSummaryRev:
         dout: cute.Tensor,
         aqk: cute.Tensor,
         cumulative_gate: cute.Tensor,
+        work_table: cute.Tensor,
         out: cute.Tensor,
         scale: Float32,
-        chunks_per_segment: Int32,
         stream: cuda.CUstream,
     ):
-        """Construct TMA/UMMA descriptors and launch the persistent kernel."""
+        """Construct TMA/UMMA descriptors and launch the persistent kernel.
+
+        ``work_table[w] = (start, chunk_begin, chunk_end, length)`` names a run of chunks of one
+        range (see ``_decode_work``); ``out[w]`` receives its reverse map.
+        """
         g_k = _sequence_feature_head_batch_view(kg)
         g_qt = _feature_sequence_head_batch_view(qg)
         g_wt = _feature_sequence_head_batch_view(w)
@@ -459,11 +473,10 @@ class BlackwellDeltaAffineSummaryRev:
         self.kernel(
             mmas,
             tma_ops,
+            work_table,
             out,
             smem_layouts,
-            Int32(cute.size(w.shape[1])),
             scale,
-            chunks_per_segment,
         ).launch(
             grid=self._launch_grid(cute.size(out.shape[0])),
             block=(self.CTA_THREADS, 1, 1),
@@ -473,20 +486,74 @@ class BlackwellDeltaAffineSummaryRev:
         )
 
     @cute.jit
-    def _decode_work(self, work_index, chunks, chunks_per_segment):
-        """Return the augmented-column tile, head, and chunk range of a work item.
+    def _decode_work(self, work_index, work_table):
+        """Return the column tile, head, output row, token range, and chunk range of a work item.
 
-        Each segment scans its own chunk range from ``[0 | I]``; the host composes them.
+        The item scans its chunks from ``[0 | I]`` into output row ``w``; see ``decode_work_row``
+        for the row layout. An all-zero row stores the identity.
         """
         # ``column_tiles`` and ``num_heads`` are compile-time constants, so these divisions lower
         # to shifts and multiply-high sequences; they also run once per work item, not per chunk.
         column_tiles = SUMMARY_DIM // self.BN
         column_tile = work_index % column_tiles
         head = (work_index // column_tiles) % self.num_heads
-        segment = work_index // (column_tiles * self.num_heads)
-        chunk_begin = segment * chunks_per_segment  # < chunks: plan_segments drops empties
-        chunk_end = cutlass.min(chunk_begin + chunks_per_segment, chunks)
-        return column_tile, head, segment, chunk_begin, chunk_end
+        work = work_index // (column_tiles * self.num_heads)
+        start, length, chunk_begin, chunk_end = decode_work_row(
+            work_table, work, self.whole_ranges
+        )
+        return column_tile, head, work, start, length, chunk_begin, chunk_end
+
+    @cute.jit
+    def _neutralize_do_tail(self, smem, stage, valid_rows, tid):
+        """Zero ``dO`` token rows ``>= valid_rows`` of one B-operand stage before UMMA reads it."""
+        column_atom = cute.size(smem, mode=[0, 0])
+        token_atom = cute.size(smem, mode=[0, 1])
+        assert column_atom * cute.size(smem, mode=[1]) == self.BN, "column modes must tile BN"
+        assert token_atom * cute.size(smem, mode=[2]) == self.BT, "token modes must tile BT"
+        for token in cutlass.range(valid_rows, self.BT, unroll=1):
+            for column_block in cutlass.range_constexpr(
+                (self.BN + self.WARP_SIZE - 1) // self.WARP_SIZE
+            ):
+                column = tid + column_block * self.WARP_SIZE
+                if column < self.BN:
+                    coordinate = (
+                        (column % column_atom, token % token_atom),
+                        column // column_atom,
+                        token // token_atom,
+                        stage,
+                    )
+                    smem[coordinate] = self.io_type(0.0)
+        cute.arch.fence_view_async_shared()
+        cute.arch.sync_warp()
+
+    @cute.jit
+    def _neutralize_w_tail(self, smem, stage, valid_rows, tid):
+        """Zero ``w^T`` token columns ``>= valid_rows`` of one A-operand stage before UMMA reads it."""
+        row_atom = cute.size(smem, mode=[0, 0, 0])
+        token_atom = cute.size(smem, mode=[0, 1])
+        assert cute.size(smem, mode=[1]) == 1, "expected a single rest-M mode"
+        assert row_atom * cute.size(smem, mode=[0, 0, 1]) == self.BK
+        assert token_atom * cute.size(smem, mode=[2]) == self.BT
+        for token in cutlass.range(valid_rows, self.BT, unroll=1):
+            for row_block in cutlass.range_constexpr(self.BK // self.WARP_SIZE):
+                row = tid + row_block * self.WARP_SIZE
+                coordinate = (
+                    ((row % row_atom, row // row_atom), token % token_atom),
+                    0,
+                    token // token_atom,
+                    stage,
+                )
+                smem[coordinate] = self.io_type(0.0)
+        cute.arch.fence_view_async_shared()
+        cute.arch.sync_warp()
+
+    @cute.jit
+    def _tail_valid_rows(self, length):
+        """Valid token rows of a range's last chunk, or zero when that chunk is full."""
+        rows = length - ((length + self.BT - 1) // self.BT - 1) * self.BT
+        if rows == self.BT:
+            rows = Int32(0)
+        return rows
 
     @cute.jit
     def run_state(
@@ -494,8 +561,7 @@ class BlackwellDeltaAffineSummaryRev:
         block,
         grid,
         iterations,
-        chunks,
-        chunks_per_segment,
+        work_table,
         out,
         t_dv_acc,
         t_qdo_acc,
@@ -575,8 +641,8 @@ class BlackwellDeltaAffineSummaryRev:
         tile_index = Int32(0)
         has_work = tile_index < iterations
         while has_work:
-            column_tile, head, segment, chunk_begin, chunk_end = self._decode_work(
-                block + tile_index * grid, chunks, chunks_per_segment
+            column_tile, head, work, _start, _length, chunk_begin, chunk_end = self._decode_work(
+                block + tile_index * grid, work_table
             )
             has_source = column_tile < VAL_DIM // self.BN
 
@@ -679,7 +745,7 @@ class BlackwellDeltaAffineSummaryRev:
 
             for element in cutlass.range(cute.size(state), unroll_full=True):
                 key, column = state_coordinates[element]
-                out[segment, head, column_tile * self.BN + column, key] = state[element]
+                out[work, head, column_tile * self.BN + column, key] = state[element]
 
             tile_index = tile_index + 1
             has_work = tile_index < iterations
@@ -690,8 +756,7 @@ class BlackwellDeltaAffineSummaryRev:
         block,
         grid,
         iterations,
-        chunks,
-        chunks_per_segment,
+        work_table,
         mma_dv,
         mma_qdo,
         mma_aqdo,
@@ -722,15 +787,25 @@ class BlackwellDeltaAffineSummaryRev:
         tile_index = Int32(0)
         has_work = tile_index < iterations
         while has_work:
-            column_tile, head, _segment, chunk_begin, chunk_end = self._decode_work(
-                block + tile_index * grid, chunks, chunks_per_segment
+            column_tile, head, _work, start, length, chunk_begin, chunk_end = self._decode_work(
+                block + tile_index * grid, work_table
             )
             has_source = column_tile < VAL_DIM // self.BN
 
-            k_smem, k_gmem = self._partition_a(atom_k, desc_k, s_k, self.dv_tile, mma_dv, head)
+            # The range starts at token ``start``: offset every descriptor along its token mode
+            # so chunk ``ct`` reads tokens ``start + ct * BT`` onward. A partial last chunk
+            # over-reads the following tokens; the MMA warp neutralizes them through ``do`` and
+            # ``w`` and the gate row is clamped to the range's final token.
+            k_desc = cute.domain_offset((start, 0, (0, 0)), desc_k)
+            w_desc = cute.domain_offset((0, start, (0, 0)), desc_w)
+            gate_desc = cute.domain_offset((0, start, (0, 0)), desc_gate)
+            q_desc = cute.domain_offset((0, start, (0, 0)), desc_q)
+            do_desc = cute.domain_offset((0, start, (0, 0)), desc_do)
+            aqk_desc = cute.domain_offset((0, start, (0, 0)), desc_aqk)
+            k_smem, k_gmem = self._partition_a(atom_k, k_desc, s_k, self.dv_tile, mma_dv, head)
             w_smem, w_gmem = self._partition_a(
                 atom_w,
-                desc_w,
+                w_desc,
                 s_w,
                 self.wdv_tile,
                 mma_wdv,
@@ -738,13 +813,13 @@ class BlackwellDeltaAffineSummaryRev:
             )
             gate_smem, gate_gmem = self._partition_epilogue(
                 atom_gate,
-                desc_gate[None, None, (head, 0)],
+                gate_desc[None, None, (head, 0)],
                 (self.BK, 1),
                 s_gate,
             )
             q_smem, q_gmem = self._partition_a(
                 atom_q,
-                desc_q,
+                q_desc,
                 s_q,
                 self.qdo_tile,
                 mma_qdo,
@@ -752,7 +827,7 @@ class BlackwellDeltaAffineSummaryRev:
             )
             do_smem, do_gmem = self._partition_b(
                 atom_do,
-                desc_do,
+                do_desc,
                 s_do,
                 self.qdo_tile,
                 mma_qdo,
@@ -760,7 +835,7 @@ class BlackwellDeltaAffineSummaryRev:
             )
             aqk_smem, aqk_gmem = self._partition_a(
                 atom_aqk,
-                desc_aqk,
+                aqk_desc,
                 s_aqk,
                 self.aqdo_tile,
                 mma_aqdo,
@@ -773,7 +848,9 @@ class BlackwellDeltaAffineSummaryRev:
                 gate_handle = gate_producer.acquire_and_advance()
                 cute.copy(
                     atom=atom_gate,
-                    src=gate_gmem[(None, 0, reverse_chunk * self.BT + self.BT - 1)],
+                    src=gate_gmem[
+                        (None, 0, cutlass.min(reverse_chunk * self.BT + self.BT - 1, length - 1))
+                    ],
                     dst=gate_smem[None, gate_handle.index],
                     tma_bar_ptr=gate_handle.barrier,
                 )
@@ -825,8 +902,7 @@ class BlackwellDeltaAffineSummaryRev:
         block,
         grid,
         iterations,
-        chunks,
-        chunks_per_segment,
+        work_table,
         gate,
         gate_exp,
         gate_consumer,
@@ -840,8 +916,8 @@ class BlackwellDeltaAffineSummaryRev:
         tile_index = Int32(0)
         has_work = tile_index < iterations
         while has_work:
-            _, _, _, chunk_begin, chunk_end = self._decode_work(
-                block + tile_index * grid, chunks, chunks_per_segment
+            _, _, _, _, _, chunk_begin, chunk_end = self._decode_work(
+                block + tile_index * grid, work_table
             )
             for _chunk in cutlass.range(chunk_begin, chunk_end, unroll=0):
                 gate_handle = gate_consumer.wait_and_advance()
@@ -862,8 +938,7 @@ class BlackwellDeltaAffineSummaryRev:
         block,
         grid,
         iterations,
-        chunks,
-        chunks_per_segment,
+        work_table,
         mmas,
         t_dv_acc,
         t_k,
@@ -876,6 +951,8 @@ class BlackwellDeltaAffineSummaryRev:
         t_wdv_acc,
         t_w,
         t_dv,
+        s_do,
+        s_w,
         state_consumer,
         k_consumer,
         dv_producer,
@@ -890,20 +967,29 @@ class BlackwellDeltaAffineSummaryRev:
         """Issue the four UMMA operations for each reverse chunk.
 
         MMA1 (``kg @ X``) and MMA4 (``w^T @ dv``) each run two accumulate passes
-        over the hi/lo halves of their fp32-valued B operand.
+        over the hi/lo halves of their fp32-valued B operand. On a range's partial last
+        chunk the ``dO`` and ``w`` stages are zeroed past the valid rows before UMMA reads
+        them, so over-read tokens contribute nothing.
         """
         cute.arch.setmaxregister_decrease(self.aux_regs)
+        tid, _, _ = cute.arch.thread_idx()
+        mma_tid = tid - WarpRole.MMA * self.WARP_SIZE
         mma_dv, mma_qdo, mma_aqdo, mma_wdv = mmas
 
         tile_index = Int32(0)
         has_work = tile_index < iterations
         while has_work:
-            column_tile, _head, _segment, chunk_begin, chunk_end = self._decode_work(
-                block + tile_index * grid, chunks, chunks_per_segment
+            column_tile, _head, _work, _start, length, chunk_begin, chunk_end = self._decode_work(
+                block + tile_index * grid, work_table
             )
             has_source = column_tile < VAL_DIM // self.BN
+            # The range's last chunk is the first one this range visits when it owns it.
+            tail_valid_rows = self._tail_valid_rows(length)
+            last_chunk = (length + self.BT - 1) // self.BT - 1
 
-            for _chunk in cutlass.range(chunk_begin, chunk_end, unroll=0):
+            for chunk in cutlass.range(chunk_begin, chunk_end, unroll=0):
+                reverse_chunk = chunk_end - 1 - (chunk - chunk_begin)
+                is_tail = reverse_chunk == last_chunk and tail_valid_rows != 0
                 # The source products do not depend on the state, so they run while
                 # the state warps are still producing the X snapshot: Aqk^T dO seeds
                 # the dv accumulator and qg^T dO completes off the recurrence chain.
@@ -912,6 +998,9 @@ class BlackwellDeltaAffineSummaryRev:
                     q_handle = q_consumer.wait_and_advance()
                     do_handle = do_consumer.wait_and_advance()
                     aqk_handle = aqk_consumer.wait_and_advance()
+                    if is_tail:
+                        # Tokens past the range feed both Aqk^T dO and qg^T dO through dO.
+                        self._neutralize_do_tail(s_do, do_handle.index, tail_valid_rows, mma_tid)
                     for k_block in cutlass.range(cute.size(t_aqk, mode=[2]), unroll_full=True):
                         mma_aqdo.set(tcgen05.Field.ACCUMULATE, cutlass.Boolean(k_block != 0))
                         cute.gemm(
@@ -959,6 +1048,9 @@ class BlackwellDeltaAffineSummaryRev:
                 dv_handle.commit()
 
                 w_handle = w_consumer.wait_and_advance()
+                if is_tail:
+                    # dv rows past the range hold k @ X of foreign tokens; w^T drops them.
+                    self._neutralize_w_tail(s_w, w_handle.index, tail_valid_rows, mma_tid)
                 wdv_handle = wdv_producer.acquire_and_advance()
                 for split in cutlass.range_constexpr(2):
                     dv_operand_handle = dv_operand_consumer.wait_and_advance()
@@ -986,11 +1078,10 @@ class BlackwellDeltaAffineSummaryRev:
         self,
         mmas: Mmas,
         tma: TmaOps,
+        work_table: cute.Tensor,
         out: cute.Tensor,
         smem_layouts: SmemLayouts,
-        tokens: Int32,
         scale: Float32,
-        chunks_per_segment: Int32,
     ):
         """Dispatch the persistent state, TMA, gate, and MMA warp roles."""
         mma_dv, mma_qdo, mma_aqdo, mma_wdv = mmas
@@ -1184,15 +1275,13 @@ class BlackwellDeltaAffineSummaryRev:
         grid = cute.arch.grid_dim()[0]
         work_items = self.num_heads * (SUMMARY_DIM // self.BN) * cute.size(out.shape[0])
         iterations = (work_items - block + grid - 1) // grid
-        chunks = tokens // self.BT
 
         if warp_id in self.STATE_WARP_IDS:
             self.run_state(
                 block,
                 grid,
                 iterations,
-                chunks,
-                chunks_per_segment,
+                work_table,
                 out,
                 t_dv_acc,
                 t_qdo_acc,
@@ -1213,8 +1302,7 @@ class BlackwellDeltaAffineSummaryRev:
                 block,
                 grid,
                 iterations,
-                chunks,
-                chunks_per_segment,
+                work_table,
                 mma_dv,
                 mma_qdo,
                 mma_aqdo,
@@ -1238,8 +1326,7 @@ class BlackwellDeltaAffineSummaryRev:
                 block,
                 grid,
                 iterations,
-                chunks,
-                chunks_per_segment,
+                work_table,
                 gate,
                 gate_exp,
                 gate_consumer,
@@ -1250,8 +1337,7 @@ class BlackwellDeltaAffineSummaryRev:
                 block,
                 grid,
                 iterations,
-                chunks,
-                chunks_per_segment,
+                work_table,
                 mmas,
                 t_dv_acc,
                 t_k,
@@ -1264,6 +1350,8 @@ class BlackwellDeltaAffineSummaryRev:
                 t_wdv_acc,
                 t_w,
                 t_dv,
+                s_do,
+                s_w,
                 state_consumer,
                 k_consumer,
                 dv_producer,
@@ -1341,12 +1429,12 @@ class BlackwellDeltaAffineSummaryRev:
         assert total <= 512, f"TMEM overflow: {total}>512"
         return dv_offset, qdo_offset, wdv_offset, total
 
-    def _launch_grid(self, segments):
+    def _launch_grid(self, rows):
         """Bound the persistent launch to the work-item count and SM count."""
         sm_count = get_compile_target().sm_count
         if sm_count is None:
             raise RuntimeError("affine_summary_rev compilation requires an SM count")
-        work_items = self.num_heads * (SUMMARY_DIM // self.BN) * segments
+        work_items = self.num_heads * (SUMMARY_DIM // self.BN) * rows
         return (cutlass.min(Int32(sm_count), work_items), 1, 1)
 
 
@@ -1355,13 +1443,14 @@ def _compile_affine_summary_rev(
     dtype_name: str,
     heads: int,
     use_int64_offsets: bool,
+    whole_ranges: bool,
 ):
     """Compile one reverse-summary dtype/head specialization."""
     target = get_compile_target()
     if target.device_type != "cuda" or not is_sm100_kda_capability(target.effective_capability):
         raise ValueError(f"affine_summary_rev requires an SM100/SM103 target; got {target}")
     sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
-    tokens = sym_int(divisibility=BT)
+    tokens = sym_int()
 
     def factor(dtype, last_dim: int):
         return make_fake_compact_tensor(
@@ -1372,6 +1461,9 @@ def _compile_affine_summary_rev(
         )
 
     io_dtype = _CUTE_IO_TYPES[dtype_name]
+    work = make_fake_compact_tensor(
+        Int32, (sym_int(), 2 if whole_ranges else 4), stride_order=(1, 0)
+    )
     out = make_fake_compact_tensor(
         Float32,
         (sym_int(), heads, SUMMARY_DIM, KEY_DIM),
@@ -1379,25 +1471,21 @@ def _compile_affine_summary_rev(
         assumed_align=DATA_ALIGN_BYTES,
     )
     return compile_tvm_ffi(
-        BlackwellDeltaAffineSummaryRev(
-            heads,
-            io_dtype,
-            use_int64_offsets,
-        ),
+        BlackwellDeltaAffineSummaryRev(heads, io_dtype, use_int64_offsets, whole_ranges),
         factor(io_dtype, KEY_DIM),
         factor(io_dtype, KEY_DIM),
         factor(io_dtype, KEY_DIM),
         factor(io_dtype, VAL_DIM),
         factor(io_dtype, BT),
         factor(Float32, KEY_DIM),
+        work,
         out,
         Float32(1.0),
-        Int32(1),
     )
 
 
 @torch.compiler.disable
-def build_state_grad_summary(
+def build_state_grad_summaries(
     qg: torch.Tensor,
     kg: torch.Tensor,
     w: torch.Tensor,
@@ -1405,8 +1493,9 @@ def build_state_grad_summary(
     Aqk: torch.Tensor,
     cumulative_gate: torch.Tensor,
     scale: float,
+    bounds: torch.Tensor,
 ) -> torch.Tensor:
-    """Compute one shard's packed reverse affine summary.
+    """Compute one packed reverse affine summary per token range of a stream.
 
     Args:
         qg: Gated queries, shape ``[1, T, H, 128]``, bf16 or fp16.
@@ -1416,21 +1505,25 @@ def build_state_grad_summary(
         Aqk: Intra-chunk query/key factor, shape ``[1, T, H, 64]``, same dtype as ``qg``.
         cumulative_gate: Cumulative log2 gates, shape ``[1, T, H, 128]``, fp32.
         scale: Query scaling factor used by the local backward recurrence.
+        bounds: ``int32 [R, 2]`` device tensor of half-open token ranges ``[start, stop)``; the
+            same contract as ``build_state_summaries``.
 
     Returns:
-        FP32 tensor of shape ``[H, 256, 128]``, V-first packed as local bias then
-        reverse transition for ``dH_in = dH_out @ transition + bias``.
+        FP32 tensor of shape ``[R, H, 256, 128]``, V-first packed as local bias then reverse
+        transition for ``dH_in = dH_out @ transition + bias``, one per row of ``bounds``.
 
-    Supported scope: B=1, fixed K=V=128 and BT=64, contiguous CUDA inputs.
-    SM100 uses the native UMMA kernel; other capability 8.0+ targets use Triton.
-    A partial final chunk is neutral-padded by the wrapper.
+    The ranges are read on the device, so the launch is CUDA Graph capturable and replayable
+    across different ``bounds`` values of the same shape. The tokens right after a partial last
+    chunk are read and then cancelled (through zeroed ``dO`` rows and ``w`` columns), so they must
+    be finite. Supported scope: B=1, fixed K=V=128 and BT=64, contiguous CUDA inputs. SM100 uses
+    the native UMMA kernel; other capability 8.0+ targets use Triton.
     """
     assert qg.ndim == 4, f"qg must be 4D [1, T, H, K], got shape {tuple(qg.shape)}"
     batch, tokens, heads, key_dim = qg.shape
-    assert batch == 1, f"build_state_grad_summary requires B=1, got B={batch}"
-    assert tokens > 0, "build_state_grad_summary requires at least one token"
-    assert heads > 0, "build_state_grad_summary requires at least one head"
-    assert key_dim == KEY_DIM, f"build_state_grad_summary requires K={KEY_DIM}, got {key_dim}"
+    assert batch == 1, f"build_state_grad_summaries requires B=1, got B={batch}"
+    assert tokens > 0, "build_state_grad_summaries requires at least one token"
+    assert heads > 0, "build_state_grad_summaries requires at least one head"
+    assert key_dim == KEY_DIM, f"build_state_grad_summaries requires K={KEY_DIM}, got {key_dim}"
     for name, tensor in (("kg", kg), ("w", w), ("dout", dout)):
         assert tensor.shape == qg.shape, (
             f"{name} must match qg shape {tuple(qg.shape)}, got {tuple(tensor.shape)}"
@@ -1450,14 +1543,18 @@ def build_state_grad_summary(
     assert cumulative_gate.dtype == torch.float32, (
         f"cumulative_gate must be fp32, got {cumulative_gate.dtype}"
     )
+    assert bounds.ndim == 2 and bounds.shape[1] == 2 and bounds.shape[0] > 0, (
+        f"bounds must have shape [R, 2] with R > 0, got {tuple(bounds.shape)}"
+    )
+    assert bounds.dtype == torch.int32, f"bounds must be int32, got {bounds.dtype}"
 
     if isinstance(qg, FakeTensor):
         raise TypeError(
-            "build_state_grad_summary does not support torch.export; run the context-parallel "
+            "build_state_grad_summaries does not support torch.export; run the context-parallel "
             "summary eagerly or under CUDA Graph capture"
         )
 
-    assert qg.is_cuda, "build_state_grad_summary requires CUDA tensors"
+    assert qg.is_cuda, "build_state_grad_summaries requires CUDA tensors"
     inputs = (
         ("qg", qg),
         ("kg", kg),
@@ -1465,21 +1562,14 @@ def build_state_grad_summary(
         ("dout", dout),
         ("Aqk", Aqk),
         ("cumulative_gate", cumulative_gate),
+        ("bounds", bounds),
     )
     for name, tensor in inputs:
         assert tensor.device == qg.device, f"{name} must be on {qg.device}, got {tensor.device}"
         assert tensor.is_contiguous(), f"{name} must be contiguous, got strides {tensor.stride()}"
-    pad = (-tokens) % BT
-    if pad:
-        padding = (0, 0, 0, 0, 0, pad)
-        qg, kg, w, dout, Aqk = (F.pad(tensor, padding) for tensor in (qg, kg, w, dout, Aqk))
-        cumulative_gate = torch.cat(
-            (
-                cumulative_gate,
-                cumulative_gate[:, -1:].expand(-1, pad, -1, -1),
-            ),
-            dim=1,
-        )
+    ranges = bounds.shape[0]
+    if ranges > MAX_RANGES:
+        raise ValueError(f"at most {MAX_RANGES} ranges per launch, got {ranges}")
     properties = get_device_properties(qg.device)
     capability = (properties.major, properties.minor)
     if capability < (8, 0):
@@ -1494,7 +1584,9 @@ def build_state_grad_summary(
             launch_affine_summary_rev,
         )
 
-        out = torch.empty((heads, SUMMARY_DIM, KEY_DIM), dtype=torch.float32, device=qg.device)
+        out = torch.empty(
+            (ranges, heads, SUMMARY_DIM, KEY_DIM), dtype=torch.float32, device=qg.device
+        )
         launch_affine_summary_rev(
             qg,
             kg,
@@ -1503,6 +1595,7 @@ def build_state_grad_summary(
             Aqk,
             cumulative_gate,
             scale,
+            bounds,
             out,
             capability,
         )
@@ -1511,16 +1604,20 @@ def build_state_grad_summary(
     qg, kg, w, dout, Aqk, cumulative_gate = (
         _aligned(tensor) for tensor in (qg, kg, w, dout, Aqk, cumulative_gate)
     )
-    segments, chunks_per_segment = plan_segments(
-        qg.shape[1] // BT,
+    # As in the forward: a static budget from the span's chunk count, ranges cut on the device.
+    budget = plan_work_budget(
+        cdiv(tokens, BT),
         heads * (SUMMARY_DIM // BlackwellDeltaAffineSummaryRev.BN),
-        get_device_properties(qg.device).multi_processor_count,
+        properties.multi_processor_count,
     )
-    segment_out = torch.empty(
-        (segments, heads, SUMMARY_DIM, KEY_DIM), dtype=torch.float32, device=qg.device
+    work, range_ids = work_table(bounds, budget)
+    partials = torch.empty(
+        (work.shape[0], heads, SUMMARY_DIM, KEY_DIM), dtype=torch.float32, device=qg.device
     )
-    use_int64_offsets = requires_int64_abi(qg, kg, w, dout, Aqk, cumulative_gate, segment_out)
-    compiled = _compile_affine_summary_rev(_IO_TYPE_NAMES[qg.dtype], heads, use_int64_offsets)
+    use_int64_offsets = requires_int64_abi(qg, kg, w, dout, Aqk, cumulative_gate, partials)
+    compiled = _compile_affine_summary_rev(
+        _IO_TYPE_NAMES[qg.dtype], heads, use_int64_offsets, whole_ranges=range_ids is None
+    )
     compiled(
         qg.detach(),
         kg.detach(),
@@ -1528,11 +1625,28 @@ def build_state_grad_summary(
         dout.detach(),
         Aqk.detach(),
         cumulative_gate.detach(),
-        segment_out,
+        work,
+        partials,
         Float32(scale),
-        chunks_per_segment,
     )
-    if segments == 1:
-        return segment_out[0]
-    # The cotangent flows through the last segment first.
-    return compose_segment_summaries(segment_out.flip(0))
+    # The cotangent flows through the later item first.
+    return compose_work_items(partials, range_ids, ranges, reverse=True)
+
+
+@torch.compiler.disable
+def build_state_grad_summary(
+    qg: torch.Tensor,
+    kg: torch.Tensor,
+    w: torch.Tensor,
+    dout: torch.Tensor,
+    Aqk: torch.Tensor,
+    cumulative_gate: torch.Tensor,
+    scale: float,
+) -> torch.Tensor:
+    """Compute one shard's packed reverse affine summary over all ``T`` tokens.
+
+    The single-range form of :func:`build_state_grad_summaries` (a partial final chunk is
+    handled in the kernel); see it for the argument contract. Returns FP32 ``[H, 256, 128]``.
+    """
+    bounds = full_range_bounds(qg)
+    return build_state_grad_summaries(qg, kg, w, dout, Aqk, cumulative_gate, scale, bounds)[0]

--- a/attn_gym/linear/_delta_rule/triton/affine_summary_fwd.py
+++ b/attn_gym/linear/_delta_rule/triton/affine_summary_fwd.py
@@ -37,14 +37,14 @@ def _select_block_columns(heads: int, capability: tuple[int, int]) -> int:
     return 32
 
 
-@triton.jit(do_not_specialize=["T"])
+@triton.jit
 def affine_summary_fwd_kernel(
     kg,
     w,
     u,
     cumulative_gate,
+    bounds,
     out,
-    T,
     H: tl.constexpr,
     K: tl.constexpr,
     V: tl.constexpr,
@@ -52,37 +52,46 @@ def affine_summary_fwd_kernel(
     BN: tl.constexpr,
     USE_INT64_OFFSETS: tl.constexpr,
 ):
-    """Scan one head and augmented-state column tile through all BT64 chunks."""
+    """Scan one range, head, and augmented-state column tile through its BT64 chunks.
+
+    ``bounds[range] = (start, stop)`` are token offsets; the partial last chunk is masked so
+    tokens past ``stop`` contribute nothing and its gate row is the range's final token.
+    """
     head = tl.program_id(0)
     column_tile = tl.program_id(1)
+    range_id = tl.program_id(2)
     if USE_INT64_OFFSETS:
         head = head.to(tl.int64)
         column_tile = column_tile.to(tl.int64)
+        range_id = range_id.to(tl.int64)
+    start = tl.load(bounds + 2 * range_id)
+    stop = tl.load(bounds + 2 * range_id + 1)
+    if USE_INT64_OFFSETS:
+        start = start.to(tl.int64)
+        stop = stop.to(tl.int64)
 
     key = tl.arange(0, K)
     row = tl.arange(0, BT)
     column = column_tile * BN + tl.arange(0, BN)
     state = tl.where(column[None, :] == V + key[:, None], 1.0, 0.0).to(tl.float32)
 
-    for chunk in tl.range(0, T // BT):
-        if USE_INT64_OFFSETS:
-            token_start = chunk.to(tl.int64) * BT
-        else:
-            token_start = chunk * BT
+    for chunk in tl.range(0, (stop - start + BT - 1) // BT):
+        token_start = start + chunk * BT
         token = token_start + row
+        valid = token[:, None] < stop
 
         token_key_offset = ptr_offset(
             (token[:, None], head, key[None, :]),
             (H * K, K, 1),
         )
-        w_tile = tl.load(w + token_key_offset)
+        w_tile = tl.load(w + token_key_offset, mask=valid, other=0.0)
         u_tile = tl.load(
             u
             + ptr_offset(
                 (token[:, None], head, column[None, :]),
                 (H * V, V, 1),
             ),
-            mask=column[None, :] < V,
+            mask=valid & (column[None, :] < V),
             other=0.0,
         )
         state_hi = state.to(w_tile.dtype)
@@ -91,20 +100,20 @@ def affine_summary_fwd_kernel(
         tmp -= tl.dot(w_tile, state_lo)
 
         gate_offset = ptr_offset(
-            (token_start + BT - 1, head, key),
+            (tl.minimum(token_start + BT - 1, stop - 1), head, key),
             (H * K, K, 1),
         )
         state *= tl.exp2(tl.load(cumulative_gate + gate_offset))[:, None]
 
-        kg_tile = tl.load(kg + token_key_offset)
+        kg_tile = tl.load(kg + token_key_offset, mask=valid, other=0.0)
         tmp_hi = tmp.to(kg_tile.dtype)
         tmp_lo = (tmp - tmp_hi.to(tl.float32)).to(kg_tile.dtype)
         state = tl.dot(tl.trans(kg_tile), tmp_hi, acc=state)
         state = tl.dot(tl.trans(kg_tile), tmp_lo, acc=state)
 
     out_offset = ptr_offset(
-        (head, column[None, :], key[:, None]),
-        ((V + K) * K, K, 1),
+        (range_id, head, column[None, :], key[:, None]),
+        (H * (V + K) * K, (V + K) * K, K, 1),
     )
     tl.store(out + out_offset, state)
 
@@ -114,19 +123,20 @@ def launch_affine_summary_fwd(
     w: torch.Tensor,
     u: torch.Tensor,
     cumulative_gate: torch.Tensor,
+    bounds: torch.Tensor,
     out: torch.Tensor,
     capability: tuple[int, int],
 ) -> None:
-    """Launch a validated, BT64-padded summary into a preallocated FP32 output."""
-    _, tokens, heads, _ = kg.shape
+    """Launch validated inputs: one summary per ``bounds`` row into ``out[R, H, V + K, K]``."""
+    heads = kg.shape[2]
     block_columns = _select_block_columns(heads, capability)
-    affine_summary_fwd_kernel[(heads, _SUMMARY_DIM // block_columns)](
+    affine_summary_fwd_kernel[(heads, _SUMMARY_DIM // block_columns, bounds.shape[0])](
         kg,
         w,
         u,
         cumulative_gate,
+        bounds,
         out,
-        tokens,
         H=heads,
         K=_KEY_DIM,
         V=_VALUE_DIM,

--- a/attn_gym/linear/_delta_rule/triton/affine_summary_rev.py
+++ b/attn_gym/linear/_delta_rule/triton/affine_summary_rev.py
@@ -42,7 +42,7 @@ def _select_block_columns(heads: int, capability: tuple[int, int]) -> int:
     return 32
 
 
-@triton.jit(do_not_specialize=["T"])
+@triton.jit
 def affine_summary_rev_kernel(
     qg,
     kg,
@@ -50,9 +50,9 @@ def affine_summary_rev_kernel(
     dout,
     aqk,
     cumulative_gate,
+    bounds,
     out,
     scale,
-    T,
     H: tl.constexpr,
     K: tl.constexpr,
     V: tl.constexpr,
@@ -60,30 +60,39 @@ def affine_summary_rev_kernel(
     BN: tl.constexpr,
     USE_INT64_OFFSETS: tl.constexpr,
 ):
-    """Scan one head and augmented-state column tile backward through BT64 chunks."""
+    """Scan one range, head, and augmented-state column tile backward through its chunks.
+
+    ``bounds[range] = (start, stop)`` are token offsets; the partial last chunk is masked so
+    tokens past ``stop`` contribute nothing and its gate row is the range's final token.
+    """
     head = tl.program_id(0)
     column_tile = tl.program_id(1)
+    range_id = tl.program_id(2)
     if USE_INT64_OFFSETS:
         head = head.to(tl.int64)
         column_tile = column_tile.to(tl.int64)
+        range_id = range_id.to(tl.int64)
+    start = tl.load(bounds + 2 * range_id)
+    stop = tl.load(bounds + 2 * range_id + 1)
+    if USE_INT64_OFFSETS:
+        start = start.to(tl.int64)
+        stop = stop.to(tl.int64)
 
     key = tl.arange(0, K)
     row = tl.arange(0, BT)
     column = column_tile * BN + tl.arange(0, BN)
     state = tl.where(column[None, :] == V + key[:, None], 1.0, 0.0).to(tl.float32)
 
-    for chunk in range(T // BT - 1, -1, -1):
-        if USE_INT64_OFFSETS:
-            token_start = chunk.to(tl.int64) * BT
-        else:
-            token_start = chunk * BT
+    for chunk in range((stop - start + BT - 1) // BT - 1, -1, -1):
+        token_start = start + chunk * BT
         token = token_start + row
+        valid = token[:, None] < stop
 
         token_key_offset = ptr_offset(
             (token[:, None], head, key[None, :]),
             (H * K, K, 1),
         )
-        kg_tile = tl.load(kg + token_key_offset)
+        kg_tile = tl.load(kg + token_key_offset, mask=valid, other=0.0)
         state_hi = state.to(kg_tile.dtype)
         state_lo = (state - state_hi.to(tl.float32)).to(kg_tile.dtype)
         corrected = tl.dot(kg_tile, state_hi)
@@ -95,7 +104,7 @@ def affine_summary_rev_kernel(
                 (token[:, None], head, column[None, :]),
                 (H * V, V, 1),
             ),
-            mask=column[None, :] < V,
+            mask=valid & (column[None, :] < V),
             other=0.0,
         )
         aqk_tile = tl.load(
@@ -103,27 +112,29 @@ def affine_summary_rev_kernel(
             + ptr_offset(
                 (token[:, None], head, row[None, :]),
                 (H * BT, BT, 1),
-            )
+            ),
+            mask=valid,
+            other=0.0,
         )
         corrected = tl.dot(tl.trans(aqk_tile), dout_tile, acc=corrected)
 
         gate_offset = ptr_offset(
-            (token_start + BT - 1, head, key),
+            (tl.minimum(token_start + BT - 1, stop - 1), head, key),
             (H * K, K, 1),
         )
         state *= tl.exp2(tl.load(cumulative_gate + gate_offset))[:, None]
 
-        qg_tile = tl.load(qg + token_key_offset)
+        qg_tile = tl.load(qg + token_key_offset, mask=valid, other=0.0)
         state += tl.dot(tl.trans(qg_tile), dout_tile) * scale
-        w_tile = tl.load(w + token_key_offset)
+        w_tile = tl.load(w + token_key_offset, mask=valid, other=0.0)
         corrected_hi = corrected.to(w_tile.dtype)
         corrected_lo = (corrected - corrected_hi.to(tl.float32)).to(w_tile.dtype)
         state -= tl.dot(tl.trans(w_tile), corrected_hi)
         state -= tl.dot(tl.trans(w_tile), corrected_lo)
 
     out_offset = ptr_offset(
-        (head, column[None, :], key[:, None]),
-        ((V + K) * K, K, 1),
+        (range_id, head, column[None, :], key[:, None]),
+        (H * (V + K) * K, (V + K) * K, K, 1),
     )
     tl.store(out + out_offset, state)
 
@@ -136,22 +147,23 @@ def launch_affine_summary_rev(
     aqk: torch.Tensor,
     cumulative_gate: torch.Tensor,
     scale: float,
+    bounds: torch.Tensor,
     out: torch.Tensor,
     capability: tuple[int, int],
 ) -> None:
-    """Launch a validated, BT64-padded summary into a preallocated FP32 output."""
-    _, tokens, heads, _ = qg.shape
+    """Launch validated inputs: one summary per ``bounds`` row into ``out[R, H, V + K, K]``."""
+    heads = qg.shape[2]
     block_columns = _select_block_columns(heads, capability)
-    affine_summary_rev_kernel[(heads, _SUMMARY_DIM // block_columns)](
+    affine_summary_rev_kernel[(heads, _SUMMARY_DIM // block_columns, bounds.shape[0])](
         qg,
         kg,
         w,
         dout,
         aqk,
         cumulative_gate,
+        bounds,
         out,
         float(scale),
-        tokens,
         H=heads,
         K=_KEY_DIM,
         V=_VALUE_DIM,

--- a/attn_gym/linear/_delta_rule/triton/work_items.py
+++ b/attn_gym/linear/_delta_rule/triton/work_items.py
@@ -1,0 +1,216 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Device-side work planning and composition for the affine-summary kernels.
+
+The summary kernels (``_delta_rule/cute/affine_summary_fwd`` / ``_rev`` and the Triton fallbacks)
+scan chunks as a serial chain, one CTA per (column tile, head, work item). This module owns the
+``work`` table those kernels read and the fold that turns their outputs back into one summary per
+range. Both run on the device with static shapes, so a CUDA Graph captured around them replays
+for any layout with the same number of ranges. *Chunk*, *range*, and *column tile* are defined in
+``affine_summary_fwd``.
+
+    work item     a run of whole chunks ``[chunk_begin, chunk_end)`` of one range, the unit one
+                  CTA scans as a serial chain from ``[0 | I]``. Row ``w`` of the ``int32 [W, 4]``
+                  table is ``(start_token, chunk_begin, chunk_end, range_length)``;
+                  ``range_ids[w]`` names its range. Unused rows are zero with range id ``R`` and
+                  scan nothing.
+    budget        how many items to cut the span into; ``W = budget + R`` bounds the row count
+                  because every range boundary can split one more share.
+    partial       the ``[H, V + K, K]`` map one work item produces, indexed by ``w``.
+
+Planning splits the *flat* chunk axis (all ranges' chunks laid end to end) into ``budget`` equal
+shares and cuts a share wherever it crosses a range boundary, so a long range among short ones
+receives proportionally more items and every item stays inside one range::
+
+    bounds = [[0, 96], [96, 288]]        # chunks: 2 + 3 = 5 on the flat axis
+    budget = 3                           # shares [0, 2) [2, 4) [4, 5)
+    work   = [(0,   0, 2,  96),          # range 0, chunks [0, 2) = tokens [0, 96)
+              (96,  0, 2, 192),          # range 1, chunks [0, 2) = tokens [96, 224)
+              (96,  2, 3, 192),          # range 1, chunk  [2, 3) = tokens [224, 288)
+              (0, 0, 0, 0), (0, 0, 0, 0)]  # W = 3 + 2 = 5; unused rows have range id 2
+
+Composition is ``functools.reduce(compose_summaries, partials_of_range)`` from
+``attn_gym.linear.state_summary``, run on the device: ``(A0, B0)`` then ``(A1, B1)`` gives
+``(A0 @ A1, B0 @ A1 + B1)``. Forward folds a range's items in chunk order; reverse folds them
+backwards, the order a cotangent flows. A range with no items gets the identity.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+CHUNK_SIZE = 64
+
+
+@triton.jit
+def plan_work_items_kernel(
+    bounds,
+    work,
+    range_ids,
+    R,
+    BUDGET,
+    W,
+    BT: tl.constexpr,
+):
+    """One program cuts the ranges' chunks into ``BUDGET`` equal shares of the flat chunk axis.
+
+    A share that crosses a range boundary is cut there, so every item stays inside one range.
+    Items are emitted range-major, so one range's items are contiguous and in chunk order (the
+    module docstring has the row layout and a worked example). The flat chunk count and the
+    ``share * total`` products are int64: ``bounds`` is int32, but their sum times the budget need
+    not fit.
+    """
+    total = tl.zeros((), dtype=tl.int64)
+    for r_id in range(R):
+        total += (tl.load(bounds + 2 * r_id + 1) - tl.load(bounds + 2 * r_id) + BT - 1) // BT
+    row = 0
+    offset = tl.zeros((), dtype=tl.int64)
+    for r_id in range(R):
+        start = tl.load(bounds + 2 * r_id)
+        length = tl.load(bounds + 2 * r_id + 1) - start
+        chunks = (length + BT - 1) // BT
+        for share in range(BUDGET):
+            lo = tl.maximum(share * total // BUDGET, offset) - offset
+            hi = tl.minimum((share + 1) * total // BUDGET, offset + chunks) - offset
+            if hi > lo:
+                tl.store(work + 4 * row, start)
+                tl.store(work + 4 * row + 1, lo.to(tl.int32))
+                tl.store(work + 4 * row + 2, hi.to(tl.int32))
+                tl.store(work + 4 * row + 3, length)
+                tl.store(range_ids + row, r_id)
+                row += 1
+        offset += chunks
+    for w in range(row, W):
+        tl.store(work + 4 * w, 0)
+        tl.store(work + 4 * w + 1, 0)
+        tl.store(work + 4 * w + 2, 0)
+        tl.store(work + 4 * w + 3, 0)
+        tl.store(range_ids + w, R)
+
+
+def plan_work_items(bounds: torch.Tensor, budget: int) -> tuple[torch.Tensor, torch.Tensor]:
+    """Cut the ranges' chunks into ``budget`` work items on the device, none crossing a range.
+
+    Returns the ``work: int32 [W, 4]`` table and ``range_ids: int32 [W]``, ``W = budget + R``
+    (see the module docstring). Nothing reaches the host, so this composes under CUDA Graph
+    capture.
+    """
+    ranges = bounds.shape[0]
+    width = budget + ranges
+    work = torch.empty(width, 4, dtype=torch.int32, device=bounds.device)
+    range_ids = torch.empty(width, dtype=torch.int32, device=bounds.device)
+    plan_work_items_kernel[(1,)](
+        bounds, work, range_ids, ranges, budget, width, BT=CHUNK_SIZE, num_warps=1
+    )
+    return work, range_ids
+
+
+def work_table(bounds: torch.Tensor, budget: int) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """The kernels' work table for ``budget`` items, and each row's range id.
+
+    With one item per range the table is ``bounds`` itself and ``range_ids`` is ``None``:
+    the kernels' ``whole_ranges`` specialization reads ``(start, stop)`` rows and their
+    partials are the summaries, so a short single-range summary stays one launch.
+    """
+    if budget == 1:
+        return bounds, None
+    return plan_work_items(bounds, budget)
+
+
+@triton.jit
+def compose_work_items_kernel(
+    partials,
+    range_ids,
+    out,
+    W: tl.constexpr,
+    W_PADDED: tl.constexpr,
+    REVERSE: tl.constexpr,
+    H: tl.constexpr,
+    V: tl.constexpr,
+    K: tl.constexpr,
+    BM: tl.constexpr,
+):
+    """Compose one range's partials for one head and one row tile of the output map.
+
+    A *row tile* is ``BM`` rows of the range's ``[V + K, K]`` map: rows ``< V`` are bias rows
+    and pick up each item's bias, rows ``>= V`` are transition rows and do not. Because
+    ``(A0, B0) ∘ (A1, B1) = (A0 @ A1, B0 @ A1 + B1)`` right-multiplies by the next item's
+    transition, every output row depends only on the same row of the accumulator, so a program
+    needs its own ``BM`` rows plus each item's full ``[K, K]`` transition. A range's items are
+    contiguous in ``range_ids``, so the loop runs over ``[first, first + count)`` with no
+    branch and the transition loads pipeline. Dots run as three-pass TF32 (fp32-accurate), so the
+    caller's ``float32_matmul_precision`` never leaks in. Row offsets are int64 so large
+    ``[W, H, V + K, K]`` buffers address correctly.
+    """
+    range_id = tl.program_id(0)
+    head = tl.program_id(1).to(tl.int64)
+    row0 = tl.program_id(2) * BM
+    rows = row0 + tl.arange(0, BM)
+    cols = tl.arange(0, K)
+    is_bias = rows < V
+
+    slots = tl.arange(0, W_PADDED)
+    ids = tl.load(range_ids + slots, mask=slots < W, other=-1)
+    mine = ids == range_id
+    count = tl.sum(mine.to(tl.int32), axis=0)
+    first = tl.min(tl.where(mine, slots, W), axis=0)
+
+    # Identity: zero bias rows, a one on the diagonal of the transition rows.
+    acc = tl.where((rows[:, None] - V) == cols[None, :], 1.0, 0.0).to(tl.float32)
+    acc = tl.where(is_bias[:, None], 0.0, acc)
+    for step in tl.range(0, count, num_stages=2):
+        if REVERSE:
+            item = first + count - 1 - step
+        else:
+            item = first + step
+        base = partials + (item.to(tl.int64) * H + head) * (V + K) * K
+        transition = tl.load(base + (V + cols[:, None]) * K + cols[None, :])  # [K, K]
+        bias = tl.load(base + rows[:, None] * K + cols[None, :], mask=is_bias[:, None], other=0.0)
+        acc = tl.dot(acc, transition, input_precision="tf32x3") + bias
+    tl.store(
+        out + (range_id.to(tl.int64) * H + head) * (V + K) * K + rows[:, None] * K + cols[None, :],
+        acc,
+    )
+
+
+def compose_work_items(
+    partials: torch.Tensor, range_ids: torch.Tensor | None, ranges: int, *, reverse: bool
+) -> torch.Tensor:
+    """Fold ``[W, H, V + K, K]`` partials into one ``[R, H, V + K, K]`` summary per range.
+
+    The device form of ``reduce(compose_summaries, items)`` per range (see
+    ``attn_gym.linear.state_summary``); ``reverse`` applies the later item first, the order a
+    cotangent flows. A range with no items gets the identity. ``range_ids=None`` (one item
+    per range, see ``work_table``) returns the partials as they are.
+    """
+    if range_ids is None:
+        return partials
+    width, heads, packed, key_dim = partials.shape
+    value_dim = packed - key_dim
+    out = torch.empty(ranges, heads, packed, key_dim, dtype=torch.float32, device=partials.device)
+    # Measured on GB200 for an 18-item chain: 16-row tiles with 8 warps are 2x faster than 32-row
+    # tiles with 4; more warps hide the per-item transition load, more programs spread the chain.
+    block_rows = 16
+    compose_work_items_kernel[(ranges, heads, packed // block_rows)](
+        partials,
+        range_ids,
+        out,
+        W=width,
+        W_PADDED=triton.next_power_of_2(width),
+        REVERSE=reverse,
+        H=heads,
+        V=value_dim,
+        K=key_dim,
+        BM=block_rows,
+        num_warps=8,
+    )
+    return out
+
+
+__all__ = ["compose_work_items", "plan_work_items", "work_table"]

--- a/test/test_delta_affine_summary.py
+++ b/test/test_delta_affine_summary.py
@@ -15,7 +15,13 @@ import attn_gym.linear._delta_rule.cute.affine_summary_fwd as native_fwd
 import attn_gym.linear._delta_rule.cute.affine_summary_rev as native_rev
 import attn_gym.linear._delta_rule.triton.affine_summary_fwd as portable_fwd
 import attn_gym.linear._delta_rule.triton.affine_summary_rev as portable_rev
-from attn_gym.linear._delta_rule.cute import build_state_grad_summary, build_state_summary
+from attn_gym.linear._delta_rule.cute import (
+    build_state_grad_summaries,
+    build_state_grad_summary,
+    build_state_summaries,
+    build_state_summary,
+)
+from attn_gym.linear._delta_rule.triton.work_items import compose_work_items, plan_work_items
 from attn_gym.linear.kda.constants import is_sm100_kda_capability
 from attn_gym.testing.kda import assert_relative_rms_within
 
@@ -402,93 +408,147 @@ def test_reverse_transition_is_adjoint_of_forward_transition(dtype, tokens, head
 
 
 @pytest.mark.parametrize(
-    ("num_chunks", "work_tiles", "sm_count", "expected"),
+    ("max_chunks", "work_tiles", "sm_count", "expected"),
     [
-        pytest.param(512, 64, 148, (2, 256), id="two-segments"),
-        pytest.param(512, 128, 148, (1, 512), id="one-wave-already"),
-        pytest.param(512, 256, 148, (1, 512), id="oversubscribed"),
-        pytest.param(512, 8, 148, (18, 29), id="sm-bound"),
-        pytest.param(3, 8, 148, (1, 3), id="short-chain-stays-whole"),
-        pytest.param(31, 8, 148, (1, 31), id="just-below-two-segments"),
-        pytest.param(32, 8, 148, (2, 16), id="first-split"),
-        pytest.param(70, 8, 32, (4, 18), id="ragged-tail"),
-        pytest.param(65, 8, 32, (4, 17), id="rounding-drops-a-segment"),
+        pytest.param(512, 64, 148, 2, id="two-items"),
+        pytest.param(512, 128, 148, 1, id="one-wave-already"),
+        pytest.param(512, 256, 148, 1, id="oversubscribed"),
+        pytest.param(512, 8, 148, 18, id="sm-bound"),
+        pytest.param(3, 8, 148, 1, id="short-chain-stays-whole"),
+        pytest.param(31, 8, 148, 1, id="just-below-two-items"),
+        pytest.param(32, 8, 148, 2, id="first-split"),
     ],
 )
-def test_plan_segments_fills_one_wave_without_empty_or_tiny_segments(
-    num_chunks, work_tiles, sm_count, expected
+def test_plan_work_budget_fills_one_wave_without_tiny_items(
+    max_chunks, work_tiles, sm_count, expected
 ):
-    segments, chunks_per_segment = native_fwd.plan_segments(num_chunks, work_tiles, sm_count)
-    assert (segments, chunks_per_segment) == expected
-    assert (segments - 1) * chunks_per_segment < num_chunks <= segments * chunks_per_segment
-    # A fold level costs more than several chunks, so no split may produce short segments.
-    assert segments == 1 or chunks_per_segment >= native_fwd.MIN_CHUNKS_PER_SEGMENT
+    budget = native_fwd.plan_work_budget(max_chunks, work_tiles, sm_count)
+    assert budget == expected
+    # A scan level costs more than several chunks, so no split may produce short items.
+    assert budget == 1 or max_chunks // budget >= native_fwd.MIN_CHUNKS_PER_ITEM
 
 
-@pytest.mark.parametrize("segments", [1, 3, 5, 8])
-def test_compose_segment_summaries_matches_sequential_composition(segments):
-    """The pairwise fold, including its odd tail, equals left-to-right composition."""
-    generator = torch.Generator().manual_seed(5)
-    summaries = torch.randn(segments, 2, 256, 128, generator=generator) / 16
-    summaries[:, :, VALUE_DIM:] += torch.eye(128)
-    expected = reduce(compose_summaries, summaries.unbind(0))
-    torch.testing.assert_close(
-        native_fwd.compose_segment_summaries(summaries), expected, atol=1e-5, rtol=1e-5
-    )
+WORK_LAYOUTS = [
+    pytest.param([[0, 300], [300, 300], [300, 428], [428, 500], [500, 640]], 4, id="mixed"),
+    pytest.param([[0, 32768]] + [[32768, 32768]] * 7, 18, id="one-long-seven-empty"),
+    pytest.param([[0, 640]], 1, id="single-range-single-item"),
+    pytest.param([[0, 64], [64, 128]], 18, id="more-budget-than-chunks"),
+    pytest.param([[0, 100], [100, 30000], [30000, 32768]], 18, id="uneven"),
+]
 
 
-def test_compose_segment_summaries_ignores_the_float32_matmul_mode():
+@pytest.mark.parametrize(("layout", "budget"), WORK_LAYOUTS)
+def test_plan_work_items_tiles_every_range_in_order(layout, budget):
+    """Items cover each range's chunks exactly once, contiguously and in chunk order."""
+    bounds = torch.tensor(layout, dtype=torch.int32, device="cuda")
+    work, range_ids = (t.cpu() for t in plan_work_items(bounds, budget))
+    ranges = len(layout)
+    assert work.shape == (budget + ranges, 4) and range_ids.shape == (budget + ranges,)
+    assert torch.equal(work[range_ids == ranges], torch.zeros_like(work[range_ids == ranges]))
+    total = sum(-(-(stop - start) // 64) for start, stop in layout)
+    for range_id, (start, stop) in enumerate(layout):
+        rows = work[range_ids == range_id]
+        chunks = -(-(stop - start) // 64)
+        positions = (range_ids == range_id).nonzero().flatten().tolist()
+        assert (
+            positions == list(range(positions[0], positions[0] + len(positions)))
+            if positions
+            else chunks == 0
+        )
+        assert (rows[:, 0] == start).all() and (rows[:, 3] == stop - start).all()
+        begins, ends = rows[:, 1].tolist(), rows[:, 2].tolist()
+        assert begins == [0, *ends[:-1]][: len(ends)] and (ends[-1] if ends else 0) == chunks
+        # The flat split hands each range a share proportional to its length.
+        assert len(rows) >= min(chunks, max(1, budget * chunks // total - 1))
+
+
+@pytest.mark.parametrize(("layout", "budget"), WORK_LAYOUTS)
+@pytest.mark.parametrize("reverse", [False, True], ids=["forward", "reverse"])
+def test_compose_work_items_matches_sequential_composition(layout, budget, reverse):
+    """The segmented scan equals composing each range's items in (reverse) chunk order."""
+    bounds = torch.tensor(layout, dtype=torch.int32, device="cuda")
+    work, range_ids = plan_work_items(bounds, budget)
+    ranges = len(layout)
+    generator = torch.Generator(device="cuda").manual_seed(5)
+    partials = torch.randn(work.shape[0], 2, 256, 128, device="cuda", generator=generator) / 16
+    partials[:, :, VALUE_DIM:] += torch.eye(128, device="cuda")
+    identity = torch.cat(
+        (torch.zeros(2, 128, 128), torch.eye(128).expand(2, -1, -1)), dim=1
+    ).cuda()
+
+    composed = compose_work_items(partials, range_ids, ranges, reverse=reverse)
+    for range_id in range(ranges):
+        items = [partials[i].double() for i in range(work.shape[0]) if range_ids[i] == range_id]
+        if reverse:
+            items.reverse()
+        expected = reduce(compose_summaries, items, identity.double()).float()
+        # IEEE fp32 dots over up to ``budget`` chained maps: ~1e-5, far inside the bf16 summary
+        # error and two decades inside what TF32 operands would produce.
+        torch.testing.assert_close(composed[range_id], expected, atol=1e-4, rtol=1e-4)
+        assert_relative_rms_within(
+            composed[range_id],
+            expected,
+            f"range {range_id} compose",
+            max_eps=64,
+            source_dtype=torch.float32,
+        )
+
+
+def test_compose_work_items_ignores_the_float32_matmul_mode():
     """The fold must not pick up TF32 from ``torch.set_float32_matmul_precision("high")``."""
     generator = torch.Generator(device="cuda").manual_seed(6)
-    summaries = torch.randn(4, 2, 256, 128, device="cuda", generator=generator) / 16
-    summaries[:, :, VALUE_DIM:] += torch.eye(128, device="cuda")
-    exact = reduce(compose_summaries, summaries.double().unbind(0)).float()
+    partials = torch.randn(4, 2, 256, 128, device="cuda", generator=generator) / 16
+    partials[:, :, VALUE_DIM:] += torch.eye(128, device="cuda")
+    range_ids = torch.zeros(4, dtype=torch.int64, device="cuda")
+    exact = reduce(compose_summaries, partials.double().unbind(0)).float()
     precision = torch.get_float32_matmul_precision()
     torch.set_float32_matmul_precision("high")
     try:
-        folded = native_fwd.compose_segment_summaries(summaries)
+        folded = compose_work_items(partials, range_ids, 1, reverse=False)[0]
     finally:
         torch.set_float32_matmul_precision(precision)
-    # TF32 rounds operands to 10 mantissa bits (~1e-3 relative); an FP64 fold stays within a few
-    # FP32 ulps of the exact composition.
-    torch.testing.assert_close(folded, exact, atol=1e-6, rtol=1e-6)
+    # TF32 rounds operands to 10 mantissa bits (~1e-3 relative); IEEE fp32 dots stay at ~1e-5.
+    torch.testing.assert_close(folded, exact, atol=1e-4, rtol=1e-4)
+    assert_relative_rms_within(
+        folded, exact, "compose under matmul mode", max_eps=64, source_dtype=torch.float32
+    )
 
 
 @pytest.mark.skipif(
     not torch.cuda.is_available()
     or not is_sm100_kda_capability(torch.cuda.get_device_capability()),
-    reason="segmented launches are specific to the native SM100 kernels",
+    reason="work-item splitting is specific to the native SM100 kernels",
 )
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
-def test_native_segmented_summaries_match_single_segment_scans(dtype, monkeypatch):
+def test_native_split_summaries_match_single_item_scans(dtype, monkeypatch):
     """Splitting the chunk chain across idle SMs must only reorder FP32 composition."""
     qg, kg, w, u, dout, aqk, cumulative_gate = make_summary_inputs(
         43, dtype, tokens=2048, heads=1, divisor=16
     )
     reverse_summary = partial(build_state_grad_summary, scale=128**-0.5)
-    segmented = (
+    split = (
         build_state_summary(kg, w, u, cumulative_gate),
         reverse_summary(qg, kg, w, dout, aqk, cumulative_gate),
     )
 
-    plans = []
-    plan_segments = native_fwd.plan_segments
+    budgets = []
+    plan_work_budget = native_fwd.plan_work_budget
 
-    def single_segment(num_chunks, work_tiles, sm_count):
-        plans.append(plan_segments(num_chunks, work_tiles, sm_count))
-        return 1, num_chunks
+    def single_item(max_chunks, work_tiles, sm_count):
+        budgets.append(plan_work_budget(max_chunks, work_tiles, sm_count))
+        return 1
 
-    monkeypatch.setattr(native_fwd, "plan_segments", single_segment)
-    monkeypatch.setattr(native_rev, "plan_segments", single_segment)
-    unsegmented = (
+    monkeypatch.setattr(native_fwd, "plan_work_budget", single_item)
+    monkeypatch.setattr(native_rev, "plan_work_budget", single_item)
+    unsplit = (
         build_state_summary(kg, w, u, cumulative_gate),
         reverse_summary(qg, kg, w, dout, aqk, cumulative_gate),
     )
-    assert all(segments > 1 for segments, _ in plans), plans
-    for name, actual, expected in zip(("forward", "reverse"), segmented, unsegmented, strict=True):
+    assert all(budget > 1 for budget in budgets), budgets
+    for name, actual, expected in zip(("forward", "reverse"), split, unsplit, strict=True):
         torch.testing.assert_close(actual, expected, atol=2e-5, rtol=2e-5)
         assert_relative_rms_within(
-            actual, expected, f"segmented {name} summary", max_eps=64, source_dtype=torch.float32
+            actual, expected, f"split {name} summary", max_eps=64, source_dtype=torch.float32
         )
 
 
@@ -544,10 +604,12 @@ def test_affine_summaries_reject_torch_export_instead_of_emitting_empty_outputs(
     x = torch.zeros(shape, dtype=torch.bfloat16, device="cuda")
     gate = torch.zeros(shape, dtype=torch.float32, device="cuda")
     aqk = torch.zeros(1, 64, 1, 64, dtype=torch.bfloat16, device="cuda")
-    with pytest.raises(TypeError, match="build_state_summary does not support torch.export"):
+    with pytest.raises(TypeError, match="does not support torch.export"):
         torch.export.export(ForwardSummary(), (x, x, x, gate), strict=False)
-    with pytest.raises(TypeError, match="build_state_grad_summary does not support torch.export"):
+    with pytest.raises(TypeError, match="does not support torch.export"):
         torch.export.export(ReverseSummary(), (x, x, x, x, aqk, gate), strict=False)
+    # The rejected fake call must not poison the cached single-range bounds for real calls.
+    assert torch.isfinite(build_state_summary(x, x, x, gate)).all()
 
 
 def test_build_state_summary_cuda_graph_replay():
@@ -593,3 +655,168 @@ def test_build_state_grad_summary_cuda_graph_replay():
     graph.replay()
     torch.cuda.synchronize()
     torch.testing.assert_close(actual, expected, atol=2e-4, rtol=2e-4)
+
+
+RANGE_BOUNDS = [
+    (0, 300),  # partial tail chunk, five chunks
+    (300, 300),  # empty: the identity
+    (300, 428),  # two whole chunks starting mid-stream
+    (428, 500),  # one chunk plus an 8-token tail, ending inside the stream
+    (500, 640),  # to the end of the stream
+]
+
+
+def reference_summaries(tensors, start: int, stop: int) -> tuple[torch.Tensor, torch.Tensor]:
+    """Eager FP32 forward and reverse maps of one token range, computed on the slice."""
+    qg, kg, w, u, dout, aqk, cumulative_gate = (t[:, start:stop] for t in tensors)
+    return (
+        state_summary_reference(kg, w, u, cumulative_gate),
+        state_grad_summary_reference(qg, kg, w, dout, aqk, cumulative_gate, 128**-0.5),
+    )
+
+
+@pytest.mark.usefixtures("summary_backend")
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_range_summaries_match_per_range_launches(dtype):
+    """Device ``bounds`` reproduce slicing each range on the host, tails and empties included."""
+    tensors = make_summary_inputs(41, dtype, tokens=640, heads=2)
+    qg, kg, w, u, dout, aqk, cumulative_gate = tensors
+    bounds = torch.tensor(RANGE_BOUNDS, dtype=torch.int32, device="cuda")
+    scale = 128**-0.5
+
+    forward = build_state_summaries(kg, w, u, cumulative_gate, bounds)
+    reverse = build_state_grad_summaries(qg, kg, w, dout, aqk, cumulative_gate, scale, bounds)
+    assert forward.shape == reverse.shape == (len(RANGE_BOUNDS), 2, 256, 128)
+
+    identity = torch.cat((torch.zeros(2, 128, 128), torch.eye(128).expand(2, -1, -1)), dim=1)
+    for index, (start, stop) in enumerate(RANGE_BOUNDS):
+        if start == stop:
+            torch.testing.assert_close(forward[index].cpu(), identity, atol=0, rtol=0)
+            torch.testing.assert_close(reverse[index].cpu(), identity, atol=0, rtol=0)
+            continue
+        sliced = [t[:, start:stop] for t in tensors]
+        # Both launches pick one segment at these lengths, so the results are bitwise equal.
+        expected_forward = build_state_summary(sliced[1], sliced[2], sliced[3], sliced[6])
+        expected_reverse = build_state_grad_summary(
+            sliced[0], sliced[1], sliced[2], sliced[4], sliced[5], sliced[6], scale
+        )
+        torch.testing.assert_close(forward[index], expected_forward, atol=0, rtol=0)
+        torch.testing.assert_close(reverse[index], expected_reverse, atol=0, rtol=0)
+        # ...and exact against the eager FP32 recurrence on the slice, in both directions.
+        for name, actual, expected in zip(
+            ("forward", "reverse"),
+            (forward[index], reverse[index]),
+            reference_summaries(tensors, start, stop),
+            strict=True,
+        ):
+            torch.testing.assert_close(actual, expected, atol=2e-4, rtol=2e-4)
+            assert_relative_rms_within(
+                actual,
+                expected,
+                f"{name} [{start}, {stop})",
+                max_eps=64,
+                source_dtype=torch.float32,
+            )
+
+
+@pytest.mark.usefixtures("summary_backend")
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_range_tails_ignore_the_tokens_that_follow(dtype):
+    """A partial last chunk over-reads the next tokens; scaled-up neighbours must not leak in.
+
+    The single-range launch sees TMA zero fill past its slice instead of those tokens, so the two
+    must agree bitwise; the neighbours are finite, which the kernels require (``0 * inf`` is NaN).
+    """
+    tensors = make_summary_inputs(41, dtype, tokens=640, heads=2)
+    qg, kg, w, u, dout, aqk, cumulative_gate = tensors
+    for tensor in (qg, kg, w, u, dout, aqk):
+        tensor[:, 300:364] *= 64  # never inside a range below
+    bounds = torch.tensor([[0, 300], [172, 300]], dtype=torch.int32, device="cuda")
+    scale = 128**-0.5
+
+    forward = build_state_summaries(kg, w, u, cumulative_gate, bounds)
+    reverse = build_state_grad_summaries(qg, kg, w, dout, aqk, cumulative_gate, scale, bounds)
+    for index, (start, stop) in enumerate(bounds.tolist()):
+        sliced = [t[:, start:stop] for t in tensors]
+        expected_forward = build_state_summary(sliced[1], sliced[2], sliced[3], sliced[6])
+        expected_reverse = build_state_grad_summary(
+            sliced[0], sliced[1], sliced[2], sliced[4], sliced[5], sliced[6], scale
+        )
+        torch.testing.assert_close(forward[index], expected_forward, atol=0, rtol=0)
+        torch.testing.assert_close(reverse[index], expected_reverse, atol=0, rtol=0)
+        for name, actual, expected in zip(
+            ("forward", "reverse"),
+            (forward[index], reverse[index]),
+            reference_summaries(tensors, start, stop),
+            strict=True,
+        ):
+            torch.testing.assert_close(actual, expected, atol=2e-4, rtol=2e-4)
+            assert_relative_rms_within(
+                actual,
+                expected,
+                f"{name} [{start}, {stop})",
+                max_eps=64,
+                source_dtype=torch.float32,
+            )
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available()
+    or not is_sm100_kda_capability(torch.cuda.get_device_capability()),
+    reason="segmented launches are specific to the native SM100 kernels",
+)
+def test_range_summaries_survive_a_tiny_work_budget(monkeypatch):
+    """Three items over seven ranges: cuts inside ranges and one-chunk ranges compose."""
+    tensors = make_summary_inputs(47, tokens=640, heads=2)
+    qg, kg, w, u, dout, aqk, cumulative_gate = tensors
+    monkeypatch.setattr(native_fwd, "plan_work_budget", lambda chunks, tiles, sms: 3)
+    monkeypatch.setattr(native_rev, "plan_work_budget", lambda chunks, tiles, sms: 3)
+    ranges = [*RANGE_BOUNDS, (500, 501), (0, 65)]
+    bounds = torch.tensor(ranges, dtype=torch.int32, device="cuda")
+
+    forward = build_state_summaries(kg, w, u, cumulative_gate, bounds)
+    reverse = build_state_grad_summaries(qg, kg, w, dout, aqk, cumulative_gate, 128**-0.5, bounds)
+    for index, (start, stop) in enumerate(ranges):
+        if start == stop:
+            continue
+        for name, actual, expected in zip(
+            ("forward", "reverse"),
+            (forward[index], reverse[index]),
+            reference_summaries(tensors, start, stop),
+            strict=True,
+        ):
+            torch.testing.assert_close(actual, expected, atol=2e-4, rtol=2e-4)
+            assert_relative_rms_within(
+                actual,
+                expected,
+                f"{name} [{start}, {stop})",
+                max_eps=64,
+                source_dtype=torch.float32,
+            )
+
+
+@pytest.mark.usefixtures("summary_backend")
+def test_range_summaries_replay_across_layouts_in_one_cuda_graph():
+    """One captured graph serves any ``bounds`` values of the same shape: the routing is data."""
+    qg, kg, w, u, dout, aqk, cumulative_gate = make_summary_inputs(43, tokens=640, heads=2)
+    scale = 128**-0.5
+    bounds = torch.tensor([[0, 256], [256, 640], [640, 640]], dtype=torch.int32, device="cuda")
+
+    def launch():
+        return (
+            build_state_summaries(kg, w, u, cumulative_gate, bounds),
+            build_state_grad_summaries(qg, kg, w, dout, aqk, cumulative_gate, scale, bounds),
+        )
+
+    launch()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = launch()
+
+    for layout in ([[0, 256], [256, 640], [640, 640]], [[0, 100], [100, 300], [300, 640]]):
+        bounds.copy_(torch.tensor(layout, dtype=torch.int32, device="cuda"))
+        graph.replay()
+        torch.cuda.synchronize()
+        for actual, expected in zip(captured, launch(), strict=True):
+            torch.testing.assert_close(actual, expected, atol=0, rtol=0)


### PR DESCRIPTION
Stacked PRs:
 * #474
 * #473
 * #472
 * #478
 * __->__#477


--- --- ---

Read affine-summary ranges from the device: one launch per range table

`build_state_summaries(kg, w, u, gate, bounds)` and `build_state_grad_summaries(..., bounds)`
take an `int32 [R, 2]` device tensor of token ranges and return `[R, HV, V + K, K]` maps, one
per range, in a single launch. The ranges are read on the device, so a CUDA Graph captured once
replays across different layouts of the same shape; that is the missing piece for
context-parallel replay over sampled document boundaries, whose summary count is bounded by the
fragment table (one range per fragment, its last subsequence) while the offsets move every step.

Both SM100 kernels read their work from a device table instead of a host-shaped grid. The host
picks a static budget of concurrent chunk ranges from the span length and the SM count
(`plan_work_budget`); a one-program Triton kernel (`plan_work_items`) cuts the ranges' actual
chunks into that many items, none crossing a range, so a long range among short ones gets
proportionally more items; the summary kernels take `work[W, 4] = (start, chunk_begin, chunk_end,
length)` rows (forward grid `(tiles, heads, W)`, reverse persistent decode indexes the table) and
store one partial map per row; and `compose_work_items` folds each range's contiguous items in
one branch-free Triton launch (three-pass TF32 dots, fp32-accurate, never plain TF32). Empty rows
scan nothing and store the identity. When the budget is one item per range (short spans, busy
SMs) a `whole_ranges` kernel specialization reads `bounds` rows directly, so the common short
single-range summary stays one launch with no planner and no fold. All of it is device data with
static shapes, so a graph captured once replays across layouts. `work_items.py` defines the
vocabulary (work item, budget, partial) with a worked example; the kernel headers define chunk,
range, and column tile, and say why the routing sends exactly one range per fragment.

TMA descriptors are offset along the token mode per range (`cute.domain_offset`), so a
range's chunk grid starts at its own first token. A partial last chunk is handled the way
`chunk_delta_h_bwd` handles ragged tails: the gate row is clamped to the range's final token
and the MMA warp zeroes the over-read token columns of `kg` (forward) and of `dO` and `w`
(reverse) in SMEM before UMMA reads them, so the tokens that follow the range contribute nothing.
The Triton fallbacks mask the same rows and keep one program per range. One consequence: the
over-read tokens are read and then cancelled, so they must be finite (`0 * inf` is NaN); host
zero-padding was immune, TMA zero fill past `T` still is. The old host-side `F.pad` of every
factor tensor is gone: `build_state_summary` / `build_state_grad_summary` are now the single-range
case with the tail handled in-kernel, and the compile symbol for `T` no longer requires
64-divisibility. `plan_segments` / `compose_segment_summaries` are gone with them.

GB200, bf16, eager wall clock (forward / reverse), against launching each range separately:

| table                                   | one launch      | per-range launches |
|-----------------------------------------|-----------------|--------------------|
| 3 uneven ranges over 32k tokens, H=4    | 250 / 384 us    | 555 / 639 us       |
| 1 long range + 7 empty, 32k, H=1        | 141 / 152 us    | 205 / 236 us       |
| 8 x 4k tokens, H=4                      | 215 / 223 us    | 1551 / 1733 us     |
| 2 x 2k tokens (a zig-zag rank), H=8     | 128 / 141 us    | 366 / 419 us       |

The previous uniform-per-range segmentation measured 521 / 618 us on the first row. Single
ranges through `build_state_summary` / `build_state_grad_summary` (H=4): 64-512 tokens 52-57 us
eager, 8-16 us graph-replayed (main: 44-51 / 6-14); 2048 tokens 107 / 118 us (main: 191 / 208).
The planner widens its flat chunk arithmetic to int64, the compose addresses its buffers in
int64, and range tables beyond the grid.z limit are rejected up front.

Tests, on both the native and the Triton path: range bounds (partial tails, an empty range,
mid-stream starts) bitwise equal to the per-range launches and within 2e-4 of the eager recurrence
on each slice in both directions; a partial tail followed by tokens scaled by 64 still bitwise
equal to the zero-filled single-range launch; a forced three-item budget over seven ranges
including one-chunk and 65-token ones; the planner tiles every range's chunks exactly once in
order for mixed, skewed, and over-budgeted tables; the compose matches a sequential fp64 fold in
both directions and ignores `set_float32_matmul_precision("high")` (pointwise and relative-RMS);
capture-once replay across two layouts bitwise equal to eager; the existing suites are unchanged.

## Human Note

## Agent note

Third of seven. Next: `state_summaries(bounds)` on the staged handles, then the plans and the
recipe on top of them.