### PR TITLE
Replace the host-offset summaries with device-bounds summaries on the staged handles

### DIFF
--- a/attn_gym/linear/_delta_rule/cute/__init__.py
+++ b/attn_gym/linear/_delta_rule/cute/__init__.py
@@ -1,11 +1,9 @@
 """Native CuTeDSL kernels shared by delta-rule attention variants."""
 
-from .affine_summary_fwd import build_state_summaries, build_state_summary
-from .affine_summary_rev import build_state_grad_summaries, build_state_grad_summary
+from .affine_summary_fwd import build_state_summaries
+from .affine_summary_rev import build_state_grad_summaries
 
 __all__ = [
     "build_state_grad_summaries",
-    "build_state_grad_summary",
     "build_state_summaries",
-    "build_state_summary",
 ]

--- a/attn_gym/linear/_delta_rule/cute/affine_summary_fwd.py
+++ b/attn_gym/linear/_delta_rule/cute/affine_summary_fwd.py
@@ -79,7 +79,6 @@ Limitations:
 # NOTE: no `from __future__ import annotations` — cute.struct requires
 # eager-evaluated annotations.
 
-import functools
 from enum import IntEnum
 from typing import NamedTuple
 
@@ -1279,39 +1278,3 @@ def build_state_summaries(
     )
     compiled(kg.detach(), w.detach(), u.detach(), cumulative_gate.detach(), work, partials)
     return compose_work_items(partials, range_ids, ranges, reverse=False)
-
-
-@functools.lru_cache(maxsize=64)
-def _cached_full_range(tokens: int, device: torch.device) -> torch.Tensor:
-    return (torch.arange(2, dtype=torch.int32, device=device) * tokens).view(1, 2)
-
-
-def full_range_bounds(like: torch.Tensor) -> torch.Tensor:
-    """``[[0, T]]`` for the single-range summaries of a ``[1, T, ...]`` tensor.
-
-    Built with ``arange`` so it never needs a host-to-device copy. The tensor is cached per
-    ``(T, device)`` because three tiny eager ops cost as much as the summary kernel itself, except
-    under CUDA Graph capture (the graph's pool must own it) and for fake inputs (a cached fake
-    tensor would be handed to real calls later).
-    """
-    tokens, device = like.shape[1], like.device
-    if torch.cuda.is_current_stream_capturing() or isinstance(like, FakeTensor):
-        return (torch.arange(2, dtype=torch.int32, device=device) * tokens).view(1, 2)
-    return _cached_full_range(tokens, device)
-
-
-@torch.compiler.disable
-def build_state_summary(
-    kg: torch.Tensor,
-    w: torch.Tensor,
-    u: torch.Tensor,
-    cumulative_gate: torch.Tensor,
-) -> torch.Tensor:
-    """Compute one shard's packed affine state summary from its WY chunk factors.
-
-    The single-range form of :func:`build_state_summaries` over all ``T`` tokens (a partial
-    final chunk is handled in the kernel); see it for the argument contract. Returns FP32
-    ``[H, 256, 128]``.
-    """
-    bounds = full_range_bounds(kg)
-    return build_state_summaries(kg, w, u, cumulative_gate, bounds)[0]

--- a/attn_gym/linear/_delta_rule/cute/affine_summary_rev.py
+++ b/attn_gym/linear/_delta_rule/cute/affine_summary_rev.py
@@ -54,7 +54,6 @@ from attn_gym._backends.cute.utils import requires_int64_abi
 from attn_gym.linear._delta_rule.cute.affine_summary_fwd import (
     MAX_RANGES,
     decode_work_row,
-    full_range_bounds,
     plan_work_budget,
 )
 from attn_gym.linear._delta_rule.triton.work_items import compose_work_items, work_table
@@ -1631,22 +1630,3 @@ def build_state_grad_summaries(
     )
     # The cotangent flows through the later item first.
     return compose_work_items(partials, range_ids, ranges, reverse=True)
-
-
-@torch.compiler.disable
-def build_state_grad_summary(
-    qg: torch.Tensor,
-    kg: torch.Tensor,
-    w: torch.Tensor,
-    dout: torch.Tensor,
-    Aqk: torch.Tensor,
-    cumulative_gate: torch.Tensor,
-    scale: float,
-) -> torch.Tensor:
-    """Compute one shard's packed reverse affine summary over all ``T`` tokens.
-
-    The single-range form of :func:`build_state_grad_summaries` (a partial final chunk is
-    handled in the kernel); see it for the argument contract. Returns FP32 ``[H, 256, 128]``.
-    """
-    bounds = full_range_bounds(qg)
-    return build_state_grad_summaries(qg, kg, w, dout, Aqk, cumulative_gate, scale, bounds)[0]

--- a/attn_gym/linear/_delta_rule/validation.py
+++ b/attn_gym/linear/_delta_rule/validation.py
@@ -76,16 +76,6 @@ def validate_delta_rule_inputs(
         raise ValueError("all inputs must be on the same device")
 
 
-def check_summary_range(tokens: int, start: int, stop: int) -> None:
-    """Reject a summary range outside ``[0, tokens)``.
-
-    Only the bounds are checked; see NOTE [Summary ranges are whole chunks of one subsequence]
-    in ``attn_gym.linear.kda.stages``.
-    """
-    if not 0 <= start < stop <= tokens:
-        raise ValueError(f"summary range [{start}, {stop}) must lie inside [0, {tokens})")
-
-
 def resolve_scale(scale: float | None, key_dim: int) -> float:
     """Resolve a query-scale override to a validated float, defaulting to ``1/sqrt(K)``."""
     if scale is None:

--- a/attn_gym/linear/gdn/stages.py
+++ b/attn_gym/linear/gdn/stages.py
@@ -21,9 +21,8 @@ from typing import NamedTuple
 import torch
 
 from attn_gym._backends.cute import normalize_compact_tensor
-from attn_gym.linear._delta_rule.cute import build_state_grad_summary, build_state_summary
+from attn_gym.linear._delta_rule.cute import build_state_grad_summaries, build_state_summaries
 from attn_gym.linear._delta_rule.span import prepare_span, zero_state
-from attn_gym.linear._delta_rule.validation import check_summary_range
 from attn_gym.linear.gdn.bwd.triton.chunk_gdn_bwd_recompute import (
     chunk_gdn_recompute_aqk_dense,
     chunk_gdn_recompute_aqk_packed,
@@ -69,26 +68,25 @@ class ChunkGDNSaved(NamedTuple):
 
 @dataclass
 class ChunkGDNPrepared:
-    """Local forward factors shared by ``state_summary`` and ``run``."""
+    """Local forward factors shared by ``state_summaries`` and ``run``."""
 
     saved: ChunkGDNSaved
     factors: ChunkGDNFactors
     metadata: RaggedChunkMetadata | None
     scale: float
 
-    def state_summary(self, start: int, stop: int) -> torch.Tensor:
-        """Return the FP32 ``[HV, V + K, K]`` map of tokens ``[start, stop)`` from the zero state.
+    def state_summaries(self, bounds: torch.Tensor) -> torch.Tensor:
+        """Return one FP32 ``[HV, V + K, K]`` map per row of ``bounds`` in a single launch.
 
-        See NOTE [Summary ranges are whole chunks of one subsequence] in
-        ``attn_gym.linear.kda.stages``.
+        See ``attn_gym.linear.kda.stages.ChunkKDAPrepared.state_summaries`` for the contract.
         """
         saved = self.saved
-        check_summary_range(saved.q.shape[1], start, stop)
-        return build_state_summary(
-            self.factors.kg[:, start:stop],
-            self.factors.w[:, start:stop],
-            self.factors.u[:, start:stop],
-            _vector_gate(saved.cumulative_gate[:, start:stop], saved.q.shape[-1]),
+        return build_state_summaries(
+            self.factors.kg,
+            self.factors.w,
+            self.factors.u,
+            _vector_gate(saved.cumulative_gate, saved.q.shape[-1]),
+            bounds,
         )
 
     def run(
@@ -151,7 +149,7 @@ def chunk_gdn_prepare(
 
 @dataclass
 class ChunkGDNBackward:
-    """Recomputed local backward tensors shared by ``state_grad_summary`` and ``run``."""
+    """Recomputed local backward tensors shared by ``state_grad_summaries`` and ``run``."""
 
     saved: ChunkGDNSaved
     d_output: torch.Tensor
@@ -176,21 +174,21 @@ class ChunkGDNBackward:
             q, k, saved.cumulative_gate, self.scale, self.metadata
         )
 
-    def state_grad_summary(self, start: int, stop: int) -> torch.Tensor:
-        """Return the FP32 ``[HV, V + K, K]`` reverse map of tokens ``[start, stop)``.
+    def state_grad_summaries(self, bounds: torch.Tensor) -> torch.Tensor:
+        """Return one FP32 ``[HV, V + K, K]`` reverse map per row of ``bounds`` in one launch.
 
-        See ``ChunkKDABackward.state_grad_summary`` for the bias convention.
+        See ``attn_gym.linear.kda.stages.ChunkKDABackward.state_grad_summaries``.
         """
         saved = self.saved
-        check_summary_range(saved.q.shape[1], start, stop)
-        return build_state_grad_summary(
-            self.prepared.qg[:, start:stop],
-            self.prepared.kg[:, start:stop],
-            self.prepared.w[:, start:stop],
-            self.d_output[:, start:stop],
-            self.aqk[:, start:stop],
-            _vector_gate(saved.cumulative_gate[:, start:stop], saved.q.shape[-1]),
+        return build_state_grad_summaries(
+            self.prepared.qg,
+            self.prepared.kg,
+            self.prepared.w,
+            self.d_output,
+            self.aqk,
+            _vector_gate(saved.cumulative_gate, saved.q.shape[-1]),
             self.scale,
+            bounds,
         )
 
     def run(

--- a/attn_gym/linear/kda/stages.py
+++ b/attn_gym/linear/kda/stages.py
@@ -11,12 +11,12 @@ between devices (context parallelism, pipelined state handoff, ...) need the sam
 a communication point in both directions::
 
     prepared = chunk_kda_prepare(q, k, v, gate, beta, cu_seqlens=cu_seqlens)  # WY factors, once
-    summary = prepared.state_summary(start, stop)          # [bias; transition] of one subsequence
+    summaries = prepared.state_summaries(bounds)     # [bias; transition] per range, one launch
     ...exchange summaries, compose each subsequence's entry state...
     output, final_state = prepared.run(initial_state, output_final_state=True)
 
     grads = chunk_kda_prepare_backward(saved, d_output, initial_state, scale=prepared.scale)
-    grad_summary = grads.state_grad_summary(start, stop)
+    grad_summaries = grads.state_grad_summaries(bounds)
     ...exchange, compose each subsequence's exit cotangent...
     dq, dk, dv, dgate, dbeta, d_initial_state = grads.run(d_final_state)
 
@@ -34,9 +34,8 @@ from typing import NamedTuple
 import torch
 
 from attn_gym._backends.cute import normalize_compact_tensor
-from attn_gym.linear._delta_rule.cute import build_state_grad_summary, build_state_summary
+from attn_gym.linear._delta_rule.cute import build_state_grad_summaries, build_state_summaries
 from attn_gym.linear._delta_rule.span import CHUNK_SIZE, prepare_span
-from attn_gym.linear._delta_rule.validation import check_summary_range
 from attn_gym.linear.kda.bwd.cute.chunk_kda_bwd import (
     ChunkKDABwdPrepared,
     _finish_chunk_kda_bwd,
@@ -91,20 +90,20 @@ def _metadata_from_saved(saved: ChunkKDASaved) -> RaggedChunkMetadata | None:
 
 
 # NOTE [Summary ranges are whole chunks of one subsequence]
-# ``state_summary(start, stop)`` and ``state_grad_summary(start, stop)`` take LOCAL span offsets
-# (see NOTE [Terminology] in ``attn_gym.linear.state_summary``). The factor kernels lay 64-token
-# chunks from each subsequence's first token, and every chunk's factors are scaled toward that
-# chunk's last token, so a summary is exact only over whole chunks of one subsequence:
+# ``state_summaries(bounds)`` and ``state_grad_summaries(bounds)`` take an ``int32 [R, 2]``
+# device tensor of LOCAL span offsets (see NOTE [Terminology] in ``attn_gym.linear.state_summary``).
+# The factor kernels lay 64-token chunks from each subsequence's first token, and every chunk's
+# factors are scaled toward that chunk's last token, so a row is exact only over whole chunks of
+# one subsequence:
 #
 #     start = sub_start + CHUNK_SIZE * i
 #     stop  = sub_start + CHUNK_SIZE * j   or   stop = sub_end   (the partial tail chunk is fine)
-#     [start, stop) must not cross a ``cu_seqlens`` boundary
+#     [start, stop) must not cross a ``cu_seqlens`` boundary;  start == stop is the identity
 #
-# The recipe always passes one whole subsequence, ``(cu_seqlens[i], cu_seqlens[i + 1])``, which
-# satisfies this trivially. A range that starts or stops mid-chunk, or spans two subsequences,
-# returns a plausible but wrong map. The methods only bounds-check: the boundaries are host
-# integers the caller already holds, and comparing them against the device ``cu_seqlens`` would
-# force a sync inside CUDA Graph capture.
+# The context-parallel routing always passes whole subsequences, ``(cu_seqlens[i],
+# cu_seqlens[i + 1])``, which satisfies this trivially. A row that starts or stops mid-chunk, or
+# spans two subsequences, returns a plausible but wrong map. The values are not checked: they live
+# on the device so the launch replays under CUDA Graph capture, and reading them back would sync.
 
 
 def _normalize_state(state: torch.Tensor | None) -> torch.Tensor | None:
@@ -121,7 +120,7 @@ def _normalize_state(state: torch.Tensor | None) -> torch.Tensor | None:
 
 @dataclass
 class ChunkKDAPrepared:
-    """Local forward factors shared by ``state_summary`` and ``run``.
+    """Local forward factors shared by ``state_summaries`` and ``run``.
 
     The factors are large; release the handle once ``run`` has produced the output.
     """
@@ -132,17 +131,16 @@ class ChunkKDAPrepared:
     scale: float
     autotune: bool
 
-    def state_summary(self, start: int, stop: int) -> torch.Tensor:
-        """Return the FP32 ``[HV, V + K, K]`` map of tokens ``[start, stop)`` from the zero state.
+    def state_summaries(self, bounds: torch.Tensor) -> torch.Tensor:
+        """Return one FP32 ``[HV, V + K, K]`` map per row of ``bounds`` in a single launch.
 
-        See NOTE [Summary ranges are whole chunks of one subsequence].
+        ``bounds`` is an ``int32 [R, 2]`` device tensor of ``[start, stop)`` span offsets, each
+        obeying NOTE [Summary ranges are whole chunks of one subsequence]; ``start == stop``
+        yields the identity. The ranges are read on the device, so a CUDA Graph captured around
+        this call replays for any layout of the same shape.
         """
-        check_summary_range(self.saved.q.shape[1], start, stop)
-        return build_state_summary(
-            self.factors.kg[:, start:stop],
-            self.factors.w[:, start:stop],
-            self.factors.u[:, start:stop],
-            self.saved.cumulative_gate[:, start:stop],
+        return build_state_summaries(
+            self.factors.kg, self.factors.w, self.factors.u, self.saved.cumulative_gate, bounds
         )
 
     def run(
@@ -207,7 +205,7 @@ def chunk_kda_prepare(
 
 @dataclass
 class ChunkKDABackward:
-    """Recomputed local backward tensors shared by ``state_grad_summary`` and ``run``.
+    """Recomputed local backward tensors shared by ``state_grad_summaries`` and ``run``.
 
     ``run`` consumes the recomputed tensors at their last use, so call it once and last.
     """
@@ -221,24 +219,24 @@ class ChunkKDABackward:
     autotune: bool
     fastmath: bool
 
-    def state_grad_summary(self, start: int, stop: int) -> torch.Tensor:
-        """Return the FP32 ``[HV, V + K, K]`` reverse map of tokens ``[start, stop)``.
+    def state_grad_summaries(self, bounds: torch.Tensor) -> torch.Tensor:
+        """Return one FP32 ``[HV, V + K, K]`` reverse map per row of ``bounds`` in one launch.
 
         Packed as ``[C; R]`` with ``d_entry_state = d_exit_state @ R + C``, where ``C`` is the
-        cotangent the range's own ``d_output`` sends to its entry state. See
-        NOTE [Summary ranges are whole chunks of one subsequence].
+        cotangent the range's own ``d_output`` sends to its entry state. Rows follow the contract
+        of ``ChunkKDAPrepared.state_summaries``.
         """
-        check_summary_range(self.saved.q.shape[1], start, stop)
         assert self.prepared.qg is not None and self.prepared.kg is not None
         assert self.prepared.w is not None
-        return build_state_grad_summary(
-            self.prepared.qg[:, start:stop],
-            self.prepared.kg[:, start:stop],
-            self.prepared.w[:, start:stop],
-            self.d_output[:, start:stop],
-            self.saved.aqk[:, start:stop],
-            self.saved.cumulative_gate[:, start:stop],
+        return build_state_grad_summaries(
+            self.prepared.qg,
+            self.prepared.kg,
+            self.prepared.w,
+            self.d_output,
+            self.saved.aqk,
+            self.saved.cumulative_gate,
             self.scale,
+            bounds,
         )
 
     def run(

--- a/attn_gym/linear/state_summary.py
+++ b/attn_gym/linear/state_summary.py
@@ -85,9 +85,9 @@ host Python integers; the only offsets tensor the kernels ever see is the span's
     prepared = chunk_kda_prepare(q, k, v, gate, beta, cu_seqlens=cu_seqlens)
     slots = summary_slots(prepared, plan, neutral_summary(HV, 128, 128, device=device))
     #   one entry per local subsequence, in span order, padded to plan.slots:
-    #   slot 0: prepared.state_summary(0, 96)      C∩s1 has a successor (D∩s1)
-    #   slot 1: identity [0; I]                    D∩s1 ends s1, nobody needs it
-    #   slot 2: prepared.state_summary(136, 192)   D∩s2 has a successor (rank 0's B∩s2)
+    #   slot 0: state_summaries(bounds)[0] over [0, 96)     C∩s1 has a successor (D∩s1)
+    #   slot 1: identity [0; I]                             D∩s1 ends s1, nobody needs it
+    #   slot 2: state_summaries(bounds)[2] over [136, 192)  D∩s2 has a successor (rank 0's B∩s2)
     gathered = all_gather(slots)                              # [world, plan.slots, HV, V + K, K]
     initial_state = compose_entry_states(gathered, plan)      # one per subsequence
     #   C∩s1: merge(0, gathered[0][1])
@@ -115,11 +115,11 @@ What the table does not constrain:
 
 CUDA Graph capture is valid for one *plan*, not merely one set of shapes. Fixing shapes is the
 easy part: the loader pads the span with a padding *document* (its own sequence, loss-masked) and
-the subsequence count could be padded with empty ones. But ``state_summary(start, stop)`` bakes
-host offsets into the launch and ``compose_entry_states`` bakes the ``(rank, slot)`` chains into
+the subsequence count could be padded with empty ones. ``state_summaries(bounds)`` already reads
+its ranges on the device, but ``compose_entry_states`` bakes the ``(rank, slot)`` chains into
 indexing ops, so a replay also needs the same ``cu_seqlens_global`` and therefore the same
-subsequence layout. Replaying across sampled document layouts would need summaries over all
-``N`` local segments from device ``cu_seqlens`` and device-tensor routing; neither exists yet.
+subsequence layout. Replaying across sampled document layouts needs device-tensor routing as
+well; that does not exist yet.
 """
 
 from __future__ import annotations

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -433,10 +433,10 @@ rank 1 span:  C∩s1 | D∩s1 | D∩s2     local cu_seqlens (0, 96, 136, 192)
 chains:       s1 = A∩s1 -> C∩s1 -> D∩s1        s2 = D∩s2 -> B∩s2
 ```
 
-`state_summary(start, stop)` takes **local** span offsets and is exact over whole chunks of one
-subsequence: `start = sub_start + 64·i`, `stop = sub_start + 64·j` or the subsequence end, never
-crossing a `cu_seqlens` boundary. The recipe always passes one whole subsequence,
-`(cu_seqlens[i], cu_seqlens[i + 1])`.
+`state_summaries(bounds)` takes an `int32 [R, 2]` device tensor of **local** span ranges and is
+exact over whole chunks of one subsequence: `start = sub_start + 64·i`, `stop = sub_start + 64·j`
+or the subsequence end, never crossing a `cu_seqlens` boundary; `start == stop` is the identity.
+The recipe always passes whole subsequences, `(cu_seqlens[i], cu_seqlens[i + 1])`.
 
 `attn_gym.linear.kda.chunk_kda_prepare` / `chunk_kda_prepare_backward` and
 `attn_gym.linear.gdn.chunk_gdn_prepare` / `chunk_gdn_prepare_backward` do that split without
@@ -446,12 +446,12 @@ exposing the WY factors:
 from attn_gym.linear.kda import chunk_kda_prepare, chunk_kda_prepare_backward
 
 prepared = chunk_kda_prepare(q, k, v, gate, beta, cu_seqlens=cu_seqlens)
-summary = prepared.state_summary(start, stop)  # [bias; transition] of one local sequence
+summaries = prepared.state_summaries(bounds)  # [bias; transition] per range, one launch
 # ...exchange summaries and compose each sequence's entry state...
 output, final_state = prepared.run(initial_state, output_final_state=True)
 
 grads = chunk_kda_prepare_backward(prepared.saved, d_output, initial_state, scale=prepared.scale)
-grad_summary = grads.state_grad_summary(start, stop)  # reverse map [bias; transition]
+grad_summaries = grads.state_grad_summaries(bounds)  # reverse maps [bias; transition]
 # ...exchange and compose each sequence's exit cotangent...
 dq, dk, dv, dgate, dbeta, _ = grads.run(d_final_state)
 ```

--- a/examples/kda_context_parallel.py
+++ b/examples/kda_context_parallel.py
@@ -33,7 +33,7 @@ import typer
 from torch.distributed._functional_collectives import all_gather_single
 
 from attn_gym._backends.cute import normalize_compact_tensor
-from attn_gym.linear._delta_rule.cute import build_state_grad_summary, build_state_summary
+from attn_gym.linear._delta_rule.cute import build_state_grad_summaries, build_state_summaries
 from attn_gym.linear.kda.bwd.cute.chunk_kda_bwd import (
     _finish_chunk_kda_bwd,
     _prepare_chunk_kda_bwd,
@@ -221,14 +221,13 @@ class ContextParallelKDAFunction(torch.autograd.Function):
             rank + 1 < len(shards) and shard.sequence_ids[-1] == shards[rank + 1].sequence_ids[0]
         )
         if continues:
-            start = shard.cu_seqlens[-2]
+            # The last local sequence's range as a device row; ``full`` keeps it capturable.
+            bounds = torch.full((1, 2), q.shape[1], dtype=torch.int32, device=q.device)
+            bounds[0, 0] = shard.cu_seqlens[-2]
             with kernel_stage("cp/fwd/summary", annotate):
-                summary = build_state_summary(
-                    factors.kg[:, start:],
-                    factors.w[:, start:],
-                    factors.u[:, start:],
-                    cumulative_gate[:, start:],
-                )
+                summary = build_state_summaries(
+                    factors.kg, factors.w, factors.u, cumulative_gate, bounds
+                )[0]
         else:
             summary = q.new_zeros(
                 q.shape[2],
@@ -328,17 +327,19 @@ class ContextParallelKDAFunction(torch.autograd.Function):
             rank > 0 and shards[rank - 1].sequence_ids[-1] == shard.sequence_ids[0]
         )
         if continues_from_previous:
-            stop = shard.cu_seqlens[1]
+            bounds = torch.zeros((1, 2), dtype=torch.int32, device=q.device)
+            bounds[0, 1] = shard.cu_seqlens[1]  # the first local sequence's range
             with kernel_stage("cp/bwd/summary", ctx.annotate, backward=False):
-                summary = build_state_grad_summary(
-                    prepared.qg[:, :stop],
-                    prepared.kg[:, :stop],
-                    prepared.w[:, :stop],
-                    d_output[:, :stop],
-                    aqk[:, :stop],
-                    cumulative_gate[:, :stop],
+                summary = build_state_grad_summaries(
+                    prepared.qg,
+                    prepared.kg,
+                    prepared.w,
+                    d_output,
+                    aqk,
+                    cumulative_gate,
                     ctx.scale,
-                )
+                    bounds,
+                )[0]
             if d_final_state is not None:
                 value_dim = v.shape[-1]
                 bias = merge_state(d_final_state[0], summary)

--- a/test/test_delta_affine_summary.py
+++ b/test/test_delta_affine_summary.py
@@ -15,15 +15,27 @@ import attn_gym.linear._delta_rule.cute.affine_summary_fwd as native_fwd
 import attn_gym.linear._delta_rule.cute.affine_summary_rev as native_rev
 import attn_gym.linear._delta_rule.triton.affine_summary_fwd as portable_fwd
 import attn_gym.linear._delta_rule.triton.affine_summary_rev as portable_rev
-from attn_gym.linear._delta_rule.cute import (
-    build_state_grad_summaries,
-    build_state_grad_summary,
-    build_state_summaries,
-    build_state_summary,
-)
+from attn_gym.linear._delta_rule.cute import build_state_grad_summaries, build_state_summaries
 from attn_gym.linear._delta_rule.triton.work_items import compose_work_items, plan_work_items
 from attn_gym.linear.kda.constants import is_sm100_kda_capability
 from attn_gym.testing.kda import assert_relative_rms_within
+
+
+def whole_stream(like: torch.Tensor) -> torch.Tensor:
+    """``bounds`` covering all ``T`` tokens of a ``[1, T, ...]`` tensor; ``arange`` keeps it capturable."""
+    return (torch.arange(2, dtype=torch.int32, device=like.device) * like.shape[1]).view(1, 2)
+
+
+def build_state_summary(kg, w, u, cumulative_gate):
+    """The single whole-stream summary: ``R = 1`` of ``build_state_summaries``."""
+    return build_state_summaries(kg, w, u, cumulative_gate, whole_stream(kg))[0]
+
+
+def build_state_grad_summary(qg, kg, w, dout, aqk, cumulative_gate, scale):
+    """The single whole-stream reverse summary: ``R = 1`` of ``build_state_grad_summaries``."""
+    bounds = whole_stream(qg)
+    return build_state_grad_summaries(qg, kg, w, dout, aqk, cumulative_gate, scale, bounds)[0]
+
 
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available() or torch.cuda.get_device_capability() < (8, 0),
@@ -608,8 +620,6 @@ def test_affine_summaries_reject_torch_export_instead_of_emitting_empty_outputs(
         torch.export.export(ForwardSummary(), (x, x, x, gate), strict=False)
     with pytest.raises(TypeError, match="does not support torch.export"):
         torch.export.export(ReverseSummary(), (x, x, x, x, aqk, gate), strict=False)
-    # The rejected fake call must not poison the cached single-range bounds for real calls.
-    assert torch.isfinite(build_state_summary(x, x, x, gate)).all()
 
 
 def test_build_state_summary_cuda_graph_replay():

--- a/test/test_delta_rule_stages.py
+++ b/test/test_delta_rule_stages.py
@@ -208,10 +208,15 @@ def test_state_summary_matches_zero_and_identity_probes(op):
 
     fused = probe(op.chunk, q, k, v, gate, beta)
     oracle = probe(op.reference, q.float(), k.float(), v.float(), gate, beta)
-    for index, (start, stop) in enumerate(((0, 72), (72, 200))):
-        summary = prepared.state_summary(start, stop)
-        assert summary.shape == (op.value_heads, 2 * HEAD_DIM, HEAD_DIM)
-        assert_summary_parts_match(summary, fused, oracle, index)
+    summaries = prepared.state_summaries(bounds_of((0, 72), (72, 200)))
+    assert summaries.shape == (2, op.value_heads, 2 * HEAD_DIM, HEAD_DIM)
+    for index in range(2):
+        assert_summary_parts_match(summaries[index], fused, oracle, index)
+
+
+def bounds_of(*ranges: tuple[int, int]) -> torch.Tensor:
+    """``int32 [R, 2]`` device tensor of span ranges for ``state_summaries``."""
+    return torch.tensor(ranges, dtype=torch.int32, device="cuda")
 
 
 def assert_summary_parts_match(summary, fused, oracle, index: int) -> None:
@@ -277,7 +282,9 @@ def test_prepare_backward_run_matches_chunk_op_gradients(op, scale, loss, state,
     prepared = op.prepare(*inputs, cu_seqlens=cu_seqlens, scale=scale)
     prepared.run(initial_state, output_final_state=True)
     grads = op.prepare_backward(prepared.saved, d_output, initial_state, scale=prepared.scale)
-    grads.state_grad_summary(0, 64)  # The exchange order: summary first, so run reuses its Aqk.
+    grads.state_grad_summaries(
+        bounds_of((0, 64))
+    )  # Exchange order: summary first, run reuses Aqk.
     actual = grads.run(d_final_state)
 
     assert len(actual) == 6
@@ -323,10 +330,10 @@ def test_state_grad_summary_matches_zero_and_identity_probes(op):
     prepared = op.prepare(q, k, v, gate, beta, cu_seqlens=cu_seqlens)
     prepared.run(zero, output_final_state=True)
     grads = op.prepare_backward(prepared.saved, d_output.to(v.dtype), zero, scale=prepared.scale)
-    for index, (start, stop) in enumerate(((0, 72), (72, 200))):
-        summary = grads.state_grad_summary(start, stop)
-        assert summary.shape == (op.value_heads, 2 * HEAD_DIM, HEAD_DIM)
-        assert_summary_parts_match(summary, fused, oracle, index)
+    summaries = grads.state_grad_summaries(bounds_of((0, 72), (72, 200)))
+    assert summaries.shape == (2, op.value_heads, 2 * HEAD_DIM, HEAD_DIM)
+    for index in range(2):
+        assert_summary_parts_match(summaries[index], fused, oracle, index)
 
 
 @requires_kda_target
@@ -376,17 +383,25 @@ def test_summaries_are_exact_over_whole_chunks_of_one_subsequence(op):
         own_grads = op.prepare_backward(
             own.saved, d_output[:, start:stop].to(v.dtype), one, scale=own.scale
         )
-        return own.state_summary(0, stop - start), own_grads.state_grad_summary(0, stop - start)
+        whole = bounds_of((0, stop - start))
+        return own.state_summaries(whole)[0], own_grads.state_grad_summaries(whole)[0]
 
-    # (start, stop) pairs on the second subsequence's chunk grid: interior runs, a single chunk,
-    # a run ending at the subsequence end, and the first chunk alone. The interior summary must
-    # match the same range summarized on its own, pointwise within that run's own error against
-    # the FP32 oracle and in aggregate.
-    for start, stop in ((136, 264), (200, 456), (136, 200), (392, 520), (72, 136)):
+    # Rows on the second subsequence's chunk grid: interior runs, a single chunk, a run ending at
+    # the subsequence end, the first chunk alone, and an empty range. One launch summarizes them
+    # all; each interior summary must match the same range summarized on its own, pointwise
+    # within that run's own error against the FP32 oracle and in aggregate.
+    ranges = ((136, 264), (200, 456), (136, 200), (392, 520), (72, 136), (300, 300))
+    forward = prepared.state_summaries(bounds_of(*ranges))
+    reverse = grads.state_grad_summaries(bounds_of(*ranges))
+    assert forward.shape == reverse.shape == (len(ranges), op.value_heads, 2 * HEAD_DIM, HEAD_DIM)
+    empty = neutral_summary(op.value_heads, HEAD_DIM, HEAD_DIM, device="cuda")
+    torch.testing.assert_close(forward[-1], empty, atol=0, rtol=0)
+    torch.testing.assert_close(reverse[-1], empty, atol=0, rtol=0)
+    for index, (start, stop) in enumerate(ranges[:-1]):
         oracles = oracle(start, stop)
         for name, actual, expected, low in zip(
             ("forward", "reverse"),
-            (prepared.state_summary(start, stop), grads.state_grad_summary(start, stop)),
+            (forward[index], reverse[index]),
             oracles,
             standalone(start, stop),
             strict=True,
@@ -394,13 +409,3 @@ def test_summaries_are_exact_over_whole_chunks_of_one_subsequence(op):
             label = f"{name} [{start}, {stop})"
             assert_matches_low_precision_reference(actual, expected, low, label)
             assert_relative_rms_within(actual, expected, label, max_eps=1.0)
-
-
-@requires_kda_target
-def test_state_summary_rejects_ranges_outside_the_stream():
-    q, k, v, gate, beta = KDA.make_inputs(128, seed=3)
-    prepared = chunk_kda_prepare(q, k, v, gate, beta)
-    with pytest.raises(ValueError, match="summary range"):
-        prepared.state_summary(64, 200)
-    with pytest.raises(ValueError, match="summary range"):
-        prepared.state_summary(64, 64)


### PR DESCRIPTION
Stacked PRs:
 * #474
 * #473
 * #472
 * __->__#478


--- --- ---

Replace the host-offset summaries with device-bounds summaries on the staged handles

`ChunkKDAPrepared.state_summaries(bounds)` / `ChunkKDABackward.state_grad_summaries(bounds)` and
their GDN counterparts return one `[HV, V + K, K]` map per row of an `int32 [R, 2]` device tensor
of span ranges, in a single launch, on the range-table summary kernels. They replace
`state_summary(start, stop)` / `state_grad_summary(start, stop)`: the host-offset form sliced the
factor tensors on the host and was the `R = 1` case of the same kernel, nothing in the repo used
it outside tests, and keeping both meant two summary APIs per layer plus a cached
single-range `bounds` tensor that could leak a fake tensor into real calls. The kernel-level
`build_state_summary` / `build_state_grad_summary` and `check_summary_range` (a host-int bounds
check with nothing left to check) go with it; `build_state_summaries` /
`build_state_grad_summaries` are the only entry points.

NOTE [Summary ranges are whole chunks of one subsequence] now describes rows of `bounds`: the
values are not checked because they live on the device so the launch replays under capture.

Tests run every op (KDA, GDN, GQA GDN) over both subsequences, an interior chunk run, a single
chunk, a run ending at the subsequence end, the first chunk alone, and an empty range in one
launch, each interior row matching the same range summarized on its own within its FP32-oracle
error pointwise and in aggregate. The kernel tests build their single-range `bounds` locally.

## Human Note

## Agent note

Fourth of seven; the Mega handle gains the same methods when it arrives with Mega under CP.