### PR TITLE
Centralize packed chunk metadata restoration

### DIFF
--- a/attn_gym/linear/gdn/impl/chunk.py
+++ b/attn_gym/linear/gdn/impl/chunk.py
@@ -44,7 +44,7 @@ from attn_gym.linear.kda.bwd.cute.chunk_kda_bwd_wy_dqkg_fused import (
     chunk_kda_bwd_wy_dqkg,
 )
 from attn_gym.linear.kda.bwd.triton.chunk_kda_bwd_daqk import chunk_kda_bwd_daqk
-from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata, chunk_capacity
+from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata
 from attn_gym.linear.kda.fwd.triton.chunk_delta_h import chunk_gated_delta_rule_fwd_h
 
 
@@ -536,12 +536,7 @@ def resolve_backward_metadata(
         assert chunk_offsets is None
         return None
     assert chunk_offsets is not None
-    return RaggedChunkMetadata(
-        cu_seqlens,
-        chunk_offsets,
-        chunk_capacity(q.shape[1], cu_seqlens.shape[0] - 1, 64),
-        64,
-    )
+    return RaggedChunkMetadata.from_offsets(cu_seqlens, chunk_offsets, q.shape[1], 64)
 
 
 def _gdn_chunk_bwd_cuda(

--- a/attn_gym/linear/kda/chunk_schedule.py
+++ b/attn_gym/linear/kda/chunk_schedule.py
@@ -90,6 +90,26 @@ class RaggedChunkMetadata(NamedTuple):
     capacity: int
     chunk_size: int
 
+    @classmethod
+    def from_offsets(
+        cls,
+        cu_seqlens: torch.Tensor,
+        chunk_offsets: torch.Tensor,
+        tokens: int,
+        chunk_size: int,
+    ) -> RaggedChunkMetadata:
+        """Restore metadata from existing offsets without reading or regenerating device values.
+
+        ``tokens`` is the physical token capacity, not the runtime active endpoint. Callers
+        retain ownership of optional-input validation at their respective boundaries.
+        """
+        return cls(
+            cu_seqlens,
+            chunk_offsets,
+            chunk_capacity(tokens, cu_seqlens.shape[0] - 1, chunk_size),
+            chunk_size,
+        )
+
     def validate_chunk_size(self, chunk_size: int) -> None:
         """Reject consumers configured for a different logical chunk size."""
         if self.chunk_size != chunk_size:

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py
@@ -13,7 +13,7 @@ from attn_gym._backends.cute import (
     tensor_supports_tma_rows,
 )
 from attn_gym._backends.profiler import profiler_range
-from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata, chunk_capacity
+from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata
 from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd_intra import chunk_kda_fwd_intra
 from attn_gym.linear.kda.fwd.triton.chunk_delta_h import chunk_gated_delta_rule_fwd_h
 from attn_gym.linear.kda.fwd.triton.chunk_gla_fwd_o import chunk_gla_fwd_o_gk
@@ -341,12 +341,7 @@ def _chunk_kda_fwd_ragged_shared(
     """Run ragged forward with caller-prepared routing and fixed-schema factors."""
     q, k, v = (normalize_tma_rows(tensor) for tensor in (q, k, v))
     _validate_private_abi(q, k, v, cumulative_gate, beta, initial_state)
-    metadata = RaggedChunkMetadata(
-        cu_seqlens,
-        chunk_offsets,
-        chunk_capacity(q.shape[1], cu_seqlens.shape[0] - 1, _CHUNK_SIZE),
-        _CHUNK_SIZE,
-    )
+    metadata = RaggedChunkMetadata.from_offsets(cu_seqlens, chunk_offsets, q.shape[1], _CHUNK_SIZE)
     return _chunk_kda_fwd(
         q,
         k,
@@ -443,12 +438,7 @@ def _chunk_kda_fwd_ragged_paged_cuda(
         has_initial_state,
         cu_seqlens,
     )
-    metadata = RaggedChunkMetadata(
-        cu_seqlens,
-        chunk_offsets,
-        chunk_capacity(q.shape[1], cu_seqlens.shape[0] - 1, _CHUNK_SIZE),
-        _CHUNK_SIZE,
-    )
+    metadata = RaggedChunkMetadata.from_offsets(cu_seqlens, chunk_offsets, q.shape[1], _CHUNK_SIZE)
     output, _state, _aqk, _akk = _chunk_kda_fwd(
         q,
         k,
@@ -486,11 +476,8 @@ def _prepare_chunk_kda_backward(
     metadata = None
     if cu_seqlens is not None:
         assert chunk_offsets is not None
-        metadata = RaggedChunkMetadata(
-            cu_seqlens,
-            chunk_offsets,
-            chunk_capacity(q.shape[1], cu_seqlens.shape[0] - 1, _CHUNK_SIZE),
-            _CHUNK_SIZE,
+        metadata = RaggedChunkMetadata.from_offsets(
+            cu_seqlens, chunk_offsets, q.shape[1], _CHUNK_SIZE
         )
     q, k, v = (normalize_tma_rows(tensor) for tensor in (q, k, v))
     _validate_private_abi(q, k, v, cumulative_gate, beta, initial_state)

--- a/attn_gym/linear/kda/stages.py
+++ b/attn_gym/linear/kda/stages.py
@@ -44,10 +44,7 @@ from attn_gym.linear.kda.bwd.cute.chunk_kda_bwd import (
     _finish_chunk_kda_bwd,
     _prepare_chunk_kda_bwd,
 )
-from attn_gym.linear.kda.chunk_schedule import (
-    RaggedChunkMetadata,
-    chunk_capacity,
-)
+from attn_gym.linear.kda.chunk_schedule import RaggedChunkMetadata
 from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd import (
     ChunkKDAFactors,
     _finish_chunk_kda_fwd,
@@ -83,19 +80,6 @@ class ChunkKDASaved(NamedTuple):
     akk: torch.Tensor | None
     cu_seqlens: torch.Tensor | None
     chunk_offsets: torch.Tensor | None
-
-
-def _metadata_from_saved(saved: ChunkKDASaved) -> RaggedChunkMetadata | None:
-    if saved.cu_seqlens is None:
-        return None
-    assert saved.chunk_offsets is not None
-    tokens = saved.q.shape[1]
-    return RaggedChunkMetadata(
-        saved.cu_seqlens,
-        saved.chunk_offsets,
-        chunk_capacity(tokens, saved.cu_seqlens.shape[0] - 1, CHUNK_SIZE),
-        CHUNK_SIZE,
-    )
 
 
 # NOTE [Summary ranges are whole chunks of one subsequence]
@@ -394,7 +378,12 @@ def chunk_kda_prepare_backward(
     caller's autograd function owns them. ``fastmath`` applies to the gradient kernels as in
     ``chunk_kda``.
     """
-    metadata = _metadata_from_saved(saved)
+    metadata = None
+    if saved.cu_seqlens is not None:
+        assert saved.chunk_offsets is not None
+        metadata = RaggedChunkMetadata.from_offsets(
+            saved.cu_seqlens, saved.chunk_offsets, saved.q.shape[1], CHUNK_SIZE
+        )
     if d_output is None:
         d_output = torch.zeros_like(saved.v)
     else:

--- a/test/test_kda_chunk_metadata.py
+++ b/test/test_kda_chunk_metadata.py
@@ -1,0 +1,50 @@
+"""CPU/meta checks for restoring the packed schedule from saved device tensors."""
+
+from functools import partial
+
+import pytest
+import torch
+
+from attn_gym.linear.kda import chunk_schedule
+from attn_gym.linear.kda.chunk_schedule import RaggedChunkMetadata
+
+
+@pytest.mark.parametrize("device", ["cpu", "meta"])
+@pytest.mark.parametrize(
+    ("boundaries", "offsets", "tokens", "chunk_size", "capacity"),
+    [
+        pytest.param([0, 128], [0, 2], 128, 64, 2, id="complete-chunks"),
+        pytest.param([0, 65, 65, 128], [0, 2, 2, 3], 256, 64, 6, id="empty-and-slack"),
+        pytest.param([0, 0, 0], [0, 0, 0], 256, 64, 5, id="all-empty-with-capacity"),
+        pytest.param([0, 0, 0], [0, 0, 0], 0, 64, 0, id="zero-capacity"),
+        pytest.param([0, 5, 5, 12], [0, 2, 2, 4], 12, 4, 5, id="different-chunk-size"),
+    ],
+)
+def test_restore_metadata_preserves_offsets_and_physical_capacity(
+    monkeypatch, device, boundaries, offsets, tokens, chunk_size, capacity
+):
+    """Restoration preserves tensor identity and needs neither data reads nor a scheduler launch."""
+    monkeypatch.setattr(
+        chunk_schedule,
+        "prepare_chunk_offsets_op",
+        partial(pytest.fail, "restoring saved offsets must not run the scheduler"),
+    )
+    cu_seqlens = torch.tensor(boundaries, dtype=torch.int32, device=device)
+    chunk_offsets = torch.tensor(offsets, dtype=torch.int32, device=device)
+
+    metadata = RaggedChunkMetadata.from_offsets(cu_seqlens, chunk_offsets, tokens, chunk_size)
+
+    assert metadata.cu_seqlens is cu_seqlens
+    assert metadata.chunk_offsets is chunk_offsets
+    assert metadata.capacity == capacity
+    assert metadata.chunk_size == chunk_size
+
+
+@pytest.mark.parametrize(
+    ("tokens", "sequences", "chunk_size", "message"),
+    [(-1, 1, 64, "tokens"), (128, 0, 64, "num_sequences"), (128, 1, 0, "chunk_size")],
+)
+def test_restore_metadata_preserves_capacity_validation(tokens, sequences, chunk_size, message):
+    offsets = torch.empty(sequences + 1, dtype=torch.int32, device="meta")
+    with pytest.raises(ValueError, match=message):
+        RaggedChunkMetadata.from_offsets(offsets, offsets, tokens, chunk_size)


### PR DESCRIPTION
Stacked PRs:
 * #485
 * __->__#484


--- --- ---

Centralize packed chunk metadata restoration

Add RaggedChunkMetadata.from_offsets to reconstruct shape-derived metadata
from existing offset tensors. Five construction sites now share one recipe,
and the KDA saved-tape-specific helper disappears.

The constructor uses physical token capacity, preserves tensor identity, and
neither reads device values nor launches the scheduler again. Reuse it in
ordinary KDA forward/backward/paged paths, staged KDA, and GDN backward.
Keep optional-input policy at the existing callers: ordinary KDA's ValueError,
GDN's assertions, and staged KDA's absent-boundary behavior are unchanged.

Validation of this commit independently:
- CPU/meta metadata tests: 13 passed, covering identity, physical capacity,
  empty sequences, inactive slack, and capacity validation.
- B200: 164 passed (staged gradient matrix including Mega, metadata tests,
  public ragged fullgraph, empty-state and CUDA Graph replay cases).
- H100: 128 passed, 36 Blackwell-only cases skipped; both two-rank KDA/GDN
  CUDA Graph layout-replay tests passed.
- Applicable pre-commit hooks passed.

GPU environments used torch 2.15.0.dev20260904+cu132 and CuTeDSL 4.7.1.
No schema, kernel, or public result contract changes; no performance claim.