### PR TITLE
Make KDA backward preparation own intra factors

### DIFF
--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd.py
@@ -20,6 +20,7 @@ from attn_gym.linear.kda.bwd.triton.chunk_kda_bwd_delta_h_triton import (
 )
 from attn_gym.linear.kda.bwd.triton.chunk_kda_bwd_wy_triton import chunk_kda_bwd_wy_triton
 from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata
+from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd_intra import chunk_kda_fwd_factors
 from attn_gym.linear.kda.fwd.cute.recompute_w_u_fwd import recompute_w_u_fwd
 from attn_gym.linear.kda.fwd.triton.chunk_delta_h import chunk_gated_delta_rule_fwd_h
 from attn_gym.linear.kda.utils import is_sm100_kda_target
@@ -27,8 +28,10 @@ from attn_gym.linear.kda.utils import is_sm100_kda_target
 
 @dataclass
 class ChunkKDABwdPrepared:
-    """Consumable local tensors shared across the CP backward communication boundary."""
+    """Resolved intra factors and consumable tensors across the CP backward boundary."""
 
+    aqk: torch.Tensor | None
+    akk: torch.Tensor | None
     w: torch.Tensor | None
     qg: torch.Tensor | None
     kg: torch.Tensor | None
@@ -43,7 +46,8 @@ def _prepare_chunk_kda_bwd(
     v: torch.Tensor,
     g: torch.Tensor,
     beta: torch.Tensor,
-    Akk: torch.Tensor,
+    Aqk: torch.Tensor | None,
+    Akk: torch.Tensor | None,
     do: torch.Tensor,
     initial_state: torch.Tensor | None,
     metadata: RaggedChunkMetadata | None,
@@ -52,7 +56,10 @@ def _prepare_chunk_kda_bwd(
     chunk_size: int,
     autotune: bool,
 ) -> ChunkKDABwdPrepared:
-    """Recompute local forward state and output factors before CP communication."""
+    """Resolve intra factors and recompute local state before CP communication."""
+    if Aqk is None:
+        Aqk, Akk = chunk_kda_fwd_factors(q, k, g, beta, scale, metadata, chunk_size=chunk_size)
+    assert Akk is not None
     with profiler_range("kda/cute/backward_recompute_w_u"):
         w, u, qg, kg = recompute_w_u_fwd(
             q=q,
@@ -86,7 +93,7 @@ def _prepare_chunk_kda_bwd(
             chunk_size=chunk_size,
             metadata=metadata,
         )
-    return ChunkKDABwdPrepared(w, qg, kg, h, v_new, d_aqk)
+    return ChunkKDABwdPrepared(Aqk, Akk, w, qg, kg, h, v_new, d_aqk)
 
 
 def _finish_chunk_kda_bwd(
@@ -95,8 +102,6 @@ def _finish_chunk_kda_bwd(
     v: torch.Tensor,
     g: torch.Tensor,
     beta: torch.Tensor,
-    Aqk: torch.Tensor,
-    Akk: torch.Tensor,
     do: torch.Tensor,
     d_final_state: torch.Tensor | None,
     initial_state: torch.Tensor | None,
@@ -116,6 +121,7 @@ def _finish_chunk_kda_bwd(
     torch.Tensor | None,
 ]:
     """Finish local gradients while releasing prepared tensors at their last use."""
+    assert prepared.aqk is not None and prepared.akk is not None
     assert prepared.qg is not None and prepared.kg is not None and prepared.w is not None
     use_triton_backend = not is_sm100_kda_target(q.device)
     range_backend = "triton" if use_triton_backend else "cute"
@@ -126,7 +132,7 @@ def _finish_chunk_kda_bwd(
                 prepared.kg,
                 prepared.w,
                 do,
-                Aqk,
+                prepared.aqk,
                 gk=g,
                 initial_state=initial_state,
                 d_final_state=d_final_state,
@@ -139,7 +145,7 @@ def _finish_chunk_kda_bwd(
                 prepared.kg,
                 prepared.w,
                 do,
-                Aqk,
+                prepared.aqk,
                 gk=g,
                 h0=initial_state,
                 dht=d_final_state,
@@ -147,7 +153,7 @@ def _finish_chunk_kda_bwd(
                 chunk_size=chunk_size,
                 metadata=metadata,
             )
-    prepared.qg = prepared.kg = prepared.w = None
+    prepared.aqk = prepared.qg = prepared.kg = prepared.w = None
 
     assert prepared.v_new is not None and prepared.h is not None
     with profiler_range(f"kda/{range_backend}/backward_wy_dqkg"):
@@ -159,7 +165,7 @@ def _finish_chunk_kda_bwd(
                 prepared.v_new,
                 g,
                 beta,
-                Akk,
+                prepared.akk,
                 prepared.h,
                 do,
                 dh,
@@ -176,7 +182,7 @@ def _finish_chunk_kda_bwd(
                 prepared.v_new,
                 g,
                 beta,
-                Akk,
+                prepared.akk,
                 prepared.h,
                 do,
                 dh,
@@ -187,7 +193,7 @@ def _finish_chunk_kda_bwd(
                 fastmath=fastmath,
                 autotune=autotune,
             )
-    prepared.h = prepared.v_new = None
+    prepared.akk = prepared.h = prepared.v_new = None
     del dh
 
     assert prepared.d_aqk is not None
@@ -216,8 +222,8 @@ def chunk_kda_bwd(
     v: torch.Tensor,
     g: torch.Tensor,
     beta: torch.Tensor,
-    Aqk: torch.Tensor,
-    Akk: torch.Tensor,
+    Aqk: torch.Tensor | None,
+    Akk: torch.Tensor | None,
     do: torch.Tensor,
     d_final_state: torch.Tensor | None,
     initial_state: torch.Tensor | None,
@@ -253,6 +259,7 @@ def chunk_kda_bwd(
         v,
         g,
         beta,
+        Aqk,
         Akk,
         do,
         initial_state,
@@ -267,8 +274,6 @@ def chunk_kda_bwd(
         v,
         g,
         beta,
-        Aqk,
-        Akk,
         do,
         d_final_state,
         initial_state,

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py
@@ -528,20 +528,7 @@ def _chunk_kda_bwd_shared(
         d_final_state,
         initial_state,
     )
-    if Aqk is None:
-        assert Akk is None
-        from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd_intra import chunk_kda_fwd_factors
-
-        Aqk, Akk = chunk_kda_fwd_factors(
-            q,
-            k,
-            cumulative_gate,
-            beta,
-            scale,
-            metadata,
-        )
-    else:
-        assert Akk is not None
+    assert (Aqk is None) == (Akk is None)
     return chunk_kda_bwd(
         q,
         k,

--- a/attn_gym/linear/kda/stages.py
+++ b/attn_gym/linear/kda/stages.py
@@ -50,7 +50,6 @@ from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd import (
     _finish_chunk_kda_fwd,
     _prepare_chunk_kda_fwd,
 )
-from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd_intra import chunk_kda_fwd_factors
 from attn_gym.linear.kda.impl.fused import _validate_fused_constraints
 from attn_gym.linear.kda.impl.mega import validate_mega_constraints
 from attn_gym.linear.kda.impl.mega_ops import (
@@ -309,13 +308,13 @@ class ChunkKDABackward:
         of ``ChunkKDAPrepared.state_summaries``.
         """
         assert self.prepared.qg is not None and self.prepared.kg is not None
-        assert self.prepared.w is not None
+        assert self.prepared.w is not None and self.prepared.aqk is not None
         return build_state_grad_summaries(
             self.prepared.qg,
             self.prepared.kg,
             self.prepared.w,
             self.d_output,
-            self.saved.aqk,
+            self.prepared.aqk,
             self.saved.cumulative_gate,
             self.scale,
             bounds,
@@ -345,8 +344,6 @@ class ChunkKDABackward:
             saved.v,
             saved.cumulative_gate,
             saved.beta,
-            saved.aqk,
-            saved.akk,
             self.d_output,
             d_final_state,
             self.initial_state,
@@ -390,19 +387,13 @@ def chunk_kda_prepare_backward(
         d_output = normalize_compact_tensor(d_output.to(saved.v.dtype))
     initial_state = _normalize_state(initial_state)  # The backward recomputes the chain from it.
     scale = float(scale)
-    if saved.aqk is None:
-        # Mega forwards keep the intra factors on chip; rebuild them as Mega's backward does.
-        aqk, akk = chunk_kda_fwd_factors(
-            saved.q, saved.k, saved.cumulative_gate, saved.beta, scale, metadata
-        )
-        saved = saved._replace(aqk=aqk, akk=akk)
-    assert saved.akk is not None
     prepared = _prepare_chunk_kda_bwd(
         saved.q,
         saved.k,
         saved.v,
         saved.cumulative_gate,
         saved.beta,
+        saved.aqk,
         saved.akk,
         d_output,
         initial_state,

--- a/test/kda/mega/test_kda_recompute_factors_backward.py
+++ b/test/kda/mega/test_kda_recompute_factors_backward.py
@@ -9,8 +9,8 @@ from attn_gym.linear.kda.naive import chunk_cumsum_ref
 from attn_gym.testing.kda import cumulative_sequence_offsets, make_kda_test_inputs
 
 pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.get_device_capability() not in ((10, 0), (10, 3)),
-    reason="the fused KDA backward requires SM100 or SM103",
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (8, 0),
+    reason="the recomputed-factor bridge requires CUDA capability 8.0 or newer",
 )
 
 D = 128

--- a/test/test_delta_rule_stages.py
+++ b/test/test_delta_rule_stages.py
@@ -339,6 +339,41 @@ def test_prepare_backward_run_matches_chunk_op_gradients(op, scale, loss, state,
 
 
 @requires_kda_target
+@pytest.mark.parametrize("packing", ["dense", "packed"])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "fp16"])
+@pytest.mark.parametrize("with_state", [False, True], ids=["no-state", "with-state"])
+def test_backward_from_a_tape_without_factors_matches_saved_factors(packing, dtype, with_state):
+    """Recomputed intra factors must give bit-identical reverse summaries, gradients, and states."""
+    inputs = KDA.make_inputs(128, seed=31, dtype=dtype)
+    cu_seqlens = (
+        torch.tensor([0, 65, 65, 128], dtype=torch.int32, device="cuda")
+        if packing == "packed"
+        else None
+    )
+    sequences = cu_seqlens.shape[0] - 1 if cu_seqlens is not None else 1
+    generator = torch.Generator(device="cuda").manual_seed(32)
+    state = torch.randn(
+        sequences, KDA.value_heads, HEAD_DIM, HEAD_DIM, device="cuda", generator=generator
+    )
+    d_output = torch.randn(inputs[2].shape, device="cuda", dtype=dtype, generator=generator)
+    bounds = (
+        bounds_of((0, 65), (65, 65), (65, 128)) if packing == "packed" else bounds_of((0, 128))
+    )
+
+    prepared = chunk_kda_prepare(*inputs, cu_seqlens=cu_seqlens, scale=0.25, autotune=False)
+    # A Mega forward saves no factors; its backward must match one that did, bit for bit.
+    tapes = (prepared.saved, prepared.saved._replace(aqk=None, akk=None))
+    results = []
+    for saved in tapes:
+        backward = chunk_kda_prepare_backward(
+            saved, d_output, state if with_state else None, scale=prepared.scale, autotune=False
+        )
+        results.append((backward.state_grad_summaries(bounds), *backward.run(state)))
+    for expected, actual in zip(*results, strict=True):
+        torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+@requires_kda_target
 @op_param
 def test_state_grad_summary_matches_zero_and_identity_probes(op):
     """``d_entry = d_exit @ R + C``, so zero and identity exit cotangents recover ``[C; R]``."""


### PR DESCRIPTION
Make KDA backward preparation own intra factors

Resolve saved or recomputed Aqk/Akk once in shared backward preparation.
Reverse summaries and the finish phase consume these factors from the
existing prepared bundle, releasing references at their last use.

This removes the duplicate recomputation branch, the staged replacement
forward tape, and two separately threaded finish arguments. The tensor-only
forward tape stays unchanged; supplied factors remain zero-copy. Preserve
normalization, architecture dispatch, scales, registered schemas, and Mega's
mutation-sensitive uncached forward summaries.

Add a test that a tape saved without factors (as Mega forwards do) gives
bit-identical reverse summaries, gradients, and states to one saved with them,
across dense and packed inputs, BF16/FP16, and optional entry states. The shared recomputation
bridge tests now run on H100 as well as Blackwell; those tests exercise the
shared fused operators, not Mega-only forward kernels.

Validation:
- B200: 237 passed, 4 existing strict xfails for Mega FP16 gate overflow.
  Includes the complete staged suite, recomputation equivalence and opcheck,
  public ragged fullgraph/replay, and real Mega fullgraph six-gradient and
  state-only backward tests.
- Fresh two-H100 run: 19 factor-ownership/recomputation/opcheck/fullgraph/replay
  cases passed; all 14 distributed KDA/GDN gradient and CUDA Graph layout-replay
  tests passed. Results collected and reservation cancelled.
- Applicable pre-commit hooks passed.

GPU environments used torch 2.15.0.dev20260904+cu132 and CuTeDSL 4.7.1.
This changes ownership, not the numerical algorithm; no performance claim.
