### PR TITLE
CP example: profile a steady-state step with clock-aligned ranks

### DIFF
--- a/attn_gym/testing/profiling.py
+++ b/attn_gym/testing/profiling.py
@@ -24,8 +24,8 @@ def kernel_stage(name: str, annotate: bool, *, backward: bool = True) -> Iterato
 
 
 @contextmanager
-def profile_trace(path: Path) -> Iterator[torch.profiler.profile]:
-    """Record one native Perfetto trace per rank."""
+def profile_trace(path: Path, *, warmup: int = 0) -> Iterator[torch.profiler.profile]:
+    """Record one native Perfetto trace per rank, discarding ``warmup`` scheduled steps."""
     path.parent.mkdir(parents=True, exist_ok=True)
     try:
         profiler = import_module("transformer_nuggets.utils.benchmark").profiler
@@ -38,6 +38,7 @@ def profile_trace(path: Path) -> Iterator[torch.profiler.profile]:
         path.with_suffix(".pftrace"),
         record_shapes=True,
         trace_format="track_event",
+        warmup=warmup,
     ) as active_profiler:
         yield active_profiler
 
@@ -47,8 +48,17 @@ def record_distributed_profile(
     path: Path,
     label: str,
     device: torch.device,
+    *,
+    warmup_steps: int = 0,
 ) -> Path | None:
-    """Profile one synchronized world-group step and merge its native rank traces."""
+    """Profile one synchronized world-group step and merge its native rank traces.
+
+    ``warmup_steps`` extra steps run first with the profiler attached but are
+    dropped from the trace, so the recorded step is steady state: kernels,
+    NCCL communicators, allocator, and CUPTI are all hot, and the ranks
+    re-align on a barrier right before it. Without warmup the trace mostly
+    shows launch skew (ranks waiting inside the first collective).
+    """
     try:
         merge_traces = import_module("transformer_nuggets.utils.merge_traces").merge_traces
     except ImportError as error:
@@ -59,9 +69,18 @@ def record_distributed_profile(
     rank = dist.get_rank()
     world_size = dist.get_world_size()
     dist.barrier()
-    with profile_trace(path) as active_profiler:
-        # Profiler initialization is rank-local, so align again after every profiler is active.
-        dist.barrier()
+    with profile_trace(path, warmup=warmup_steps) as active_profiler:
+        for index in range(warmup_steps):
+            step()
+            if index == warmup_steps - 1:
+                # Still inside the discarded warmup phase: pay the re-alignment here so
+                # neither the barrier nor the skew it absorbs appears in the trace.
+                torch.cuda.synchronize(device)
+                dist.barrier()
+            active_profiler.step()
+        if warmup_steps == 0:
+            # Profiler initialization is rank-local, so align again after every profiler is active.
+            dist.barrier()
         torch.cuda.synchronize(device)
         with torch.profiler.record_function(f"cp/rank_{rank}/{label}"):
             step()
@@ -88,7 +107,7 @@ def record_distributed_profile(
             [str(rank_path) for rank_path in rank_paths],
             str(merged_path),
             labels=[f"Rank {index} · GPU {index}" for index in range(world_size)],
-            align_timestamps=False,
+            align_timestamps=True,
         )
     dist.barrier()
     return merged_path

--- a/examples/kda_context_parallel.py
+++ b/examples/kda_context_parallel.py
@@ -246,6 +246,7 @@ def validate_cuda_graph(
     annotations: bool,
     profile_path: Path | None,
     device: torch.device,
+    warmup_steps: int,
 ) -> None:
     """Capture the full distributed backward and compare a changed-input replay."""
     warmup_stream = torch.cuda.Stream()
@@ -302,6 +303,7 @@ def validate_cuda_graph(
                 profile_path,
                 "cuda_graph_replay",
                 device,
+                warmup_steps=warmup_steps,
             )
             if merged_path is not None:
                 print(f"profile={merged_path}", flush=True)
@@ -316,6 +318,7 @@ def profile_eager_step(
     batch: PackedTrainingBatch,
     profile_path: Path,
     device: torch.device,
+    warmup_steps: int,
 ) -> None:
     """Profile one complete eager context-parallel forward and backward."""
     hidden_states = batch.local_hidden.detach().clone().requires_grad_()
@@ -334,6 +337,7 @@ def profile_eager_step(
         profile_path,
         "iteration",
         device,
+        warmup_steps=warmup_steps,
     )
     step_peak = torch.cuda.max_memory_allocated(device) - resident
     print(
@@ -380,6 +384,14 @@ def main(
         bool,
         typer.Option(help="Export a merged native Perfetto trace with transformer-nuggets."),
     ] = False,
+    warmup_steps: Annotated[
+        int,
+        typer.Option(
+            min=0,
+            help="Steps run before the profiled one and dropped from the trace, so it shows "
+            "steady state (as if deep inside a model) rather than launch skew.",
+        ),
+    ] = 5,
 ) -> None:
     """Run and validate the complete packed context-parallel KDA module."""
     local_rank = int(os.environ["LOCAL_RANK"])
@@ -483,9 +495,10 @@ def main(
             graph_annotations_available,
             profile_path if profile else None,
             device,
+            warmup_steps,
         )
     elif profile:
-        profile_eager_step(model, batch, profile_path, device)
+        profile_eager_step(model, batch, profile_path, device, warmup_steps)
 
     mode = " with CUDA Graph replay" if cuda_graph else ""
     status = "passed" if validate else "ran"


### PR DESCRIPTION
Add --warmup-steps (default 5) to examples/kda_context_parallel.py:
record_distributed_profile runs them under the profiler's warmup schedule
so they are dropped from the trace, re-aligns ranks on a barrier inside the
last warmup step, and records exactly one step. The previous single-step
profile mostly showed launch skew: ranks sat inside the first all_gather
waiting for stragglers (10 ms of 'NCCL' for ~30 us of transfer).

Merge rank traces with align_timestamps=True so ranks on different hosts,
whose CUPTI clocks differ by hundreds of microseconds, line up on NCCL
collective ends (transformer_nuggets d0121e9).

Verified on 16 Nebius GB300 ranks, eager and CUDA-graph.