### PR TITLE
Split portable affine summaries into device-planned work items

### DIFF
--- a/attn_gym/linear/_delta_rule/cute/affine_summary_fwd.py
+++ b/attn_gym/linear/_delta_rule/cute/affine_summary_fwd.py
@@ -1193,7 +1193,8 @@ def build_state_summaries(
     across different ``bounds`` values of the same shape. The tokens right after a partial last
     chunk are read and then cancelled, so they must be finite. Supported scope: B=1, fixed
     K=V=128 and BT=64, contiguous CUDA inputs. SM100 uses the native UMMA kernel; other
-    capability 8.0+ targets use Triton.
+    capability 8.0+ targets use Triton. Both backends split long ranges into work items when
+    the static budget permits, then compose their partial maps on the device.
     """
     assert kg.ndim == 4, f"kg must be 4D [1, T, H, K], got shape {tuple(kg.shape)}"
     batch, tokens, heads, key_dim = kg.shape
@@ -1239,28 +1240,26 @@ def build_state_summaries(
     capability = (properties.major, properties.minor)
     if capability < (8, 0):
         raise ValueError(f"affine_summary_fwd requires CUDA capability 8.0+, got {capability}")
-    if not is_sm100_kda_capability(capability):
+    portable = not is_sm100_kda_capability(capability)
+    sm_count = properties.multi_processor_count
+    if portable:
         if capability[0] in (10, 12):
             from attn_gym._backends.triton.utils import configure_triton_allocator
 
             with torch.cuda.device(kg.device):
                 configure_triton_allocator()
         from attn_gym.linear._delta_rule.triton.affine_summary_fwd import (
+            _select_block_columns,
             launch_affine_summary_fwd,
         )
 
-        out = torch.empty(
-            (ranges, heads, SUMMARY_DIM, KEY_DIM), dtype=torch.float32, device=kg.device
-        )
-        launch_affine_summary_fwd(kg, w, u, cumulative_gate, bounds, out, capability)
-        return out
-
-    kg, w, u, cumulative_gate = (_aligned(tensor) for tensor in (kg, w, u, cumulative_gate))
-    # BN=32 is faster per CTA (measured ~1.5x vs BN=64 on GB200); fall back to
-    # BN=64 only when the extra column tiles would spill past one CTA wave and
-    # serialize whole recurrence chains.
-    sm_count = properties.multi_processor_count
-    state_bn = 32 if ranges * heads * (SUMMARY_DIM // 32) <= sm_count else 64
+        state_bn = _select_block_columns(heads, capability)
+    else:
+        kg, w, u, cumulative_gate = (_aligned(tensor) for tensor in (kg, w, u, cumulative_gate))
+        # BN=32 is faster per CTA (measured ~1.5x vs BN=64 on GB200); fall back to
+        # BN=64 only when the extra column tiles would spill past one CTA wave and
+        # serialize whole recurrence chains.
+        state_bn = 32 if ranges * heads * (SUMMARY_DIM // 32) <= sm_count else 64
     # The bounds live on the device, so the budget comes from the span's chunk count (a static
     # upper bound) and the device cuts the ranges' actual chunks into that many items.
     budget = plan_work_budget(cdiv(tokens, BT), heads * (SUMMARY_DIM // state_bn), sm_count)
@@ -1268,13 +1267,18 @@ def build_state_summaries(
     partials = torch.empty(
         (work.shape[0], heads, SUMMARY_DIM, KEY_DIM), dtype=torch.float32, device=kg.device
     )
-    use_int64_offsets = requires_int64_abi(kg, w, u, cumulative_gate, partials)
-    compiled = _compile_affine_summary(
-        _IO_TYPE_NAMES[kg.dtype],
-        heads,
-        state_bn,
-        use_int64_offsets,
-        whole_ranges=range_ids is None,
-    )
-    compiled(kg.detach(), w.detach(), u.detach(), cumulative_gate.detach(), work, partials)
+    if portable:
+        launch_affine_summary_fwd(
+            kg, w, u, cumulative_gate, work, partials, capability, whole_ranges=range_ids is None
+        )
+    else:
+        use_int64_offsets = requires_int64_abi(kg, w, u, cumulative_gate, partials)
+        compiled = _compile_affine_summary(
+            _IO_TYPE_NAMES[kg.dtype],
+            heads,
+            state_bn,
+            use_int64_offsets,
+            whole_ranges=range_ids is None,
+        )
+        compiled(kg.detach(), w.detach(), u.detach(), cumulative_gate.detach(), work, partials)
     return compose_work_items(partials, range_ids, ranges, reverse=False)

--- a/attn_gym/linear/_delta_rule/cute/affine_summary_rev.py
+++ b/attn_gym/linear/_delta_rule/cute/affine_summary_rev.py
@@ -1515,7 +1515,8 @@ def build_state_grad_summaries(
     across different ``bounds`` values of the same shape. The tokens right after a partial last
     chunk are read and then cancelled (through zeroed ``dO`` rows and ``w`` columns), so they must
     be finite. Supported scope: B=1, fixed K=V=128 and BT=64, contiguous CUDA inputs. SM100 uses
-    the native UMMA kernel; other capability 8.0+ targets use Triton.
+    the native UMMA kernel; other capability 8.0+ targets use Triton. Both backends split long
+    ranges into work items when the static budget permits, then compose on the device.
     """
     assert qg.ndim == 4, f"qg must be 4D [1, T, H, K], got shape {tuple(qg.shape)}"
     batch, tokens, heads, key_dim = qg.shape
@@ -1573,19 +1574,33 @@ def build_state_grad_summaries(
     capability = (properties.major, properties.minor)
     if capability < (8, 0):
         raise ValueError(f"affine_summary_rev requires CUDA capability 8.0+, got {capability}")
-    if not is_sm100_kda_capability(capability):
+    portable = not is_sm100_kda_capability(capability)
+    if portable:
         if capability[0] in (10, 12):
             from attn_gym._backends.triton.utils import configure_triton_allocator
 
             with torch.cuda.device(qg.device):
                 configure_triton_allocator()
         from attn_gym.linear._delta_rule.triton.affine_summary_rev import (
+            _select_block_columns,
             launch_affine_summary_rev,
         )
 
-        out = torch.empty(
-            (ranges, heads, SUMMARY_DIM, KEY_DIM), dtype=torch.float32, device=qg.device
+        state_bn = _select_block_columns(heads, capability)
+    else:
+        qg, kg, w, dout, Aqk, cumulative_gate = (
+            _aligned(tensor) for tensor in (qg, kg, w, dout, Aqk, cumulative_gate)
         )
+        state_bn = BlackwellDeltaAffineSummaryRev.BN
+    # As in the forward: a static budget from the span's chunk count, ranges cut on the device.
+    budget = plan_work_budget(
+        cdiv(tokens, BT), heads * (SUMMARY_DIM // state_bn), properties.multi_processor_count
+    )
+    work, range_ids = work_table(bounds, budget)
+    partials = torch.empty(
+        (work.shape[0], heads, SUMMARY_DIM, KEY_DIM), dtype=torch.float32, device=qg.device
+    )
+    if portable:
         launch_affine_summary_rev(
             qg,
             kg,
@@ -1594,39 +1609,26 @@ def build_state_grad_summaries(
             Aqk,
             cumulative_gate,
             scale,
-            bounds,
-            out,
+            work,
+            partials,
             capability,
+            whole_ranges=range_ids is None,
         )
-        return out
-
-    qg, kg, w, dout, Aqk, cumulative_gate = (
-        _aligned(tensor) for tensor in (qg, kg, w, dout, Aqk, cumulative_gate)
-    )
-    # As in the forward: a static budget from the span's chunk count, ranges cut on the device.
-    budget = plan_work_budget(
-        cdiv(tokens, BT),
-        heads * (SUMMARY_DIM // BlackwellDeltaAffineSummaryRev.BN),
-        properties.multi_processor_count,
-    )
-    work, range_ids = work_table(bounds, budget)
-    partials = torch.empty(
-        (work.shape[0], heads, SUMMARY_DIM, KEY_DIM), dtype=torch.float32, device=qg.device
-    )
-    use_int64_offsets = requires_int64_abi(qg, kg, w, dout, Aqk, cumulative_gate, partials)
-    compiled = _compile_affine_summary_rev(
-        _IO_TYPE_NAMES[qg.dtype], heads, use_int64_offsets, whole_ranges=range_ids is None
-    )
-    compiled(
-        qg.detach(),
-        kg.detach(),
-        w.detach(),
-        dout.detach(),
-        Aqk.detach(),
-        cumulative_gate.detach(),
-        work,
-        partials,
-        Float32(scale),
-    )
+    else:
+        use_int64_offsets = requires_int64_abi(qg, kg, w, dout, Aqk, cumulative_gate, partials)
+        compiled = _compile_affine_summary_rev(
+            _IO_TYPE_NAMES[qg.dtype], heads, use_int64_offsets, whole_ranges=range_ids is None
+        )
+        compiled(
+            qg.detach(),
+            kg.detach(),
+            w.detach(),
+            dout.detach(),
+            Aqk.detach(),
+            cumulative_gate.detach(),
+            work,
+            partials,
+            Float32(scale),
+        )
     # The cotangent flows through the later item first.
     return compose_work_items(partials, range_ids, ranges, reverse=True)

--- a/attn_gym/linear/_delta_rule/triton/affine_summary_fwd.py
+++ b/attn_gym/linear/_delta_rule/triton/affine_summary_fwd.py
@@ -6,8 +6,8 @@
 
 """Portable Triton forward affine summaries for delta-rule context parallelism.
 
-Each program keeps one FP32 ``[128, BN]`` augmented-state tile resident while
-scanning complete BT64 chunks. Raw compact-layout pointers avoid host tensor
+Each program scans one work item (row layout in ``work_items.py``), keeping one
+FP32 ``[128, BN]`` augmented-state tile resident while scanning BT64 chunks. Raw compact-layout pointers avoid host tensor
 descriptors, allocations, and synchronization in the launch path, so a warmed
 specialization can be captured directly by a CUDA Graph.
 """
@@ -43,39 +43,54 @@ def affine_summary_fwd_kernel(
     w,
     u,
     cumulative_gate,
-    bounds,
+    work,
     out,
     H: tl.constexpr,
     K: tl.constexpr,
     V: tl.constexpr,
     BT: tl.constexpr,
     BN: tl.constexpr,
+    WHOLE_RANGES: tl.constexpr,
     USE_INT64_OFFSETS: tl.constexpr,
 ):
-    """Scan one range, head, and augmented-state column tile through its BT64 chunks.
+    """Scan one work item, head, and augmented-state column tile through its BT64 chunks.
 
-    ``bounds[range] = (start, stop)`` are token offsets; the partial last chunk is masked so
-    tokens past ``stop`` contribute nothing and its gate row is the range's final token.
+    ``work_items.py`` defines the work-row layout. The partial last chunk is masked so
+    tokens past the range's end contribute nothing; unused rows store the identity.
     """
     head = tl.program_id(0)
     column_tile = tl.program_id(1)
-    range_id = tl.program_id(2)
+    work_index = tl.program_id(2)
     if USE_INT64_OFFSETS:
         head = head.to(tl.int64)
         column_tile = column_tile.to(tl.int64)
-        range_id = range_id.to(tl.int64)
-    start = tl.load(bounds + 2 * range_id)
-    stop = tl.load(bounds + 2 * range_id + 1)
-    if USE_INT64_OFFSETS:
-        start = start.to(tl.int64)
-        stop = stop.to(tl.int64)
+        work_index = work_index.to(tl.int64)
+    if WHOLE_RANGES:
+        start = tl.load(work + 2 * work_index)
+        stop = tl.load(work + 2 * work_index + 1)
+        if USE_INT64_OFFSETS:
+            start = start.to(tl.int64)
+            stop = stop.to(tl.int64)
+        chunk_begin = 0
+        chunk_end = (stop - start + BT - 1) // BT
+    else:
+        start = tl.load(work + 4 * work_index)
+        chunk_begin = tl.load(work + 4 * work_index + 1)
+        chunk_end = tl.load(work + 4 * work_index + 2)
+        length = tl.load(work + 4 * work_index + 3)
+        if USE_INT64_OFFSETS:
+            start = start.to(tl.int64)
+            chunk_begin = chunk_begin.to(tl.int64)
+            chunk_end = chunk_end.to(tl.int64)
+            length = length.to(tl.int64)
+        stop = start + length
 
     key = tl.arange(0, K)
     row = tl.arange(0, BT)
     column = column_tile * BN + tl.arange(0, BN)
     state = tl.where(column[None, :] == V + key[:, None], 1.0, 0.0).to(tl.float32)
 
-    for chunk in tl.range(0, (stop - start + BT - 1) // BT):
+    for chunk in tl.range(chunk_begin, chunk_end):
         token_start = start + chunk * BT
         token = token_start + row
         valid = token[:, None] < stop
@@ -112,7 +127,7 @@ def affine_summary_fwd_kernel(
         state = tl.dot(tl.trans(kg_tile), tmp_lo, acc=state)
 
     out_offset = ptr_offset(
-        (range_id, head, column[None, :], key[:, None]),
+        (work_index, head, column[None, :], key[:, None]),
         (H * (V + K) * K, (V + K) * K, K, 1),
     )
     tl.store(out + out_offset, state)
@@ -123,26 +138,29 @@ def launch_affine_summary_fwd(
     w: torch.Tensor,
     u: torch.Tensor,
     cumulative_gate: torch.Tensor,
-    bounds: torch.Tensor,
-    out: torch.Tensor,
+    work: torch.Tensor,
+    partials: torch.Tensor,
     capability: tuple[int, int],
+    *,
+    whole_ranges: bool,
 ) -> None:
-    """Launch validated inputs: one summary per ``bounds`` row into ``out[R, H, V + K, K]``."""
+    """Scan one item per work row into ``partials[W, H, V + K, K]``."""
     heads = kg.shape[2]
     block_columns = _select_block_columns(heads, capability)
-    affine_summary_fwd_kernel[(heads, _SUMMARY_DIM // block_columns, bounds.shape[0])](
+    affine_summary_fwd_kernel[(heads, _SUMMARY_DIM // block_columns, work.shape[0])](
         kg,
         w,
         u,
         cumulative_gate,
-        bounds,
-        out,
+        work,
+        partials,
         H=heads,
         K=_KEY_DIM,
         V=_VALUE_DIM,
         BT=_CHUNK_SIZE,
         BN=block_columns,
-        USE_INT64_OFFSETS=requires_int64_offsets(kg, w, u, cumulative_gate, out),
+        WHOLE_RANGES=whole_ranges,
+        USE_INT64_OFFSETS=requires_int64_offsets(kg, w, u, cumulative_gate, partials),
         num_warps=8 if block_columns == 32 else 4,
         num_stages=2,
     )

--- a/attn_gym/linear/_delta_rule/triton/affine_summary_fwd.py
+++ b/attn_gym/linear/_delta_rule/triton/affine_summary_fwd.py
@@ -19,6 +19,7 @@ import triton
 import triton.language as tl
 
 from attn_gym._backends.triton.utils import ptr_offset, requires_int64_offsets
+from attn_gym.linear._delta_rule.triton.work_items import load_work_item
 
 _CHUNK_SIZE = 64
 _KEY_DIM = 128
@@ -65,25 +66,9 @@ def affine_summary_fwd_kernel(
         head = head.to(tl.int64)
         column_tile = column_tile.to(tl.int64)
         work_index = work_index.to(tl.int64)
-    if WHOLE_RANGES:
-        start = tl.load(work + 2 * work_index)
-        stop = tl.load(work + 2 * work_index + 1)
-        if USE_INT64_OFFSETS:
-            start = start.to(tl.int64)
-            stop = stop.to(tl.int64)
-        chunk_begin = 0
-        chunk_end = (stop - start + BT - 1) // BT
-    else:
-        start = tl.load(work + 4 * work_index)
-        chunk_begin = tl.load(work + 4 * work_index + 1)
-        chunk_end = tl.load(work + 4 * work_index + 2)
-        length = tl.load(work + 4 * work_index + 3)
-        if USE_INT64_OFFSETS:
-            start = start.to(tl.int64)
-            chunk_begin = chunk_begin.to(tl.int64)
-            chunk_end = chunk_end.to(tl.int64)
-            length = length.to(tl.int64)
-        stop = start + length
+    start, stop, chunk_begin, chunk_end = load_work_item(
+        work, work_index, BT, WHOLE_RANGES, USE_INT64_OFFSETS
+    )
 
     key = tl.arange(0, K)
     row = tl.arange(0, BT)

--- a/attn_gym/linear/_delta_rule/triton/affine_summary_rev.py
+++ b/attn_gym/linear/_delta_rule/triton/affine_summary_rev.py
@@ -24,6 +24,7 @@ import triton
 import triton.language as tl
 
 from attn_gym._backends.triton.utils import ptr_offset, requires_int64_offsets
+from attn_gym.linear._delta_rule.triton.work_items import load_work_item
 
 _CHUNK_SIZE = 64
 _KEY_DIM = 128
@@ -73,25 +74,9 @@ def affine_summary_rev_kernel(
         head = head.to(tl.int64)
         column_tile = column_tile.to(tl.int64)
         work_index = work_index.to(tl.int64)
-    if WHOLE_RANGES:
-        start = tl.load(work + 2 * work_index)
-        stop = tl.load(work + 2 * work_index + 1)
-        if USE_INT64_OFFSETS:
-            start = start.to(tl.int64)
-            stop = stop.to(tl.int64)
-        chunk_begin = 0
-        chunk_end = (stop - start + BT - 1) // BT
-    else:
-        start = tl.load(work + 4 * work_index)
-        chunk_begin = tl.load(work + 4 * work_index + 1)
-        chunk_end = tl.load(work + 4 * work_index + 2)
-        length = tl.load(work + 4 * work_index + 3)
-        if USE_INT64_OFFSETS:
-            start = start.to(tl.int64)
-            chunk_begin = chunk_begin.to(tl.int64)
-            chunk_end = chunk_end.to(tl.int64)
-            length = length.to(tl.int64)
-        stop = start + length
+    start, stop, chunk_begin, chunk_end = load_work_item(
+        work, work_index, BT, WHOLE_RANGES, USE_INT64_OFFSETS
+    )
 
     key = tl.arange(0, K)
     row = tl.arange(0, BT)

--- a/attn_gym/linear/_delta_rule/triton/affine_summary_rev.py
+++ b/attn_gym/linear/_delta_rule/triton/affine_summary_rev.py
@@ -6,8 +6,8 @@
 
 """Portable Triton reverse affine summaries for delta-rule context parallelism.
 
-Each program keeps one FP32 ``[128, BN]`` augmented-state tile resident while
-scanning complete BT64 chunks backward. Raw compact-layout pointers avoid host
+Each program scans one work item (row layout in ``work_items.py``), keeping one
+FP32 ``[128, BN]`` augmented-state tile resident while scanning BT64 chunks backward. Raw compact-layout pointers avoid host
 tensor descriptors, allocations, and synchronization in the launch path, so a
 warmed specialization can be captured directly by a CUDA Graph.
 
@@ -50,7 +50,7 @@ def affine_summary_rev_kernel(
     dout,
     aqk,
     cumulative_gate,
-    bounds,
+    work,
     out,
     scale,
     H: tl.constexpr,
@@ -58,32 +58,47 @@ def affine_summary_rev_kernel(
     V: tl.constexpr,
     BT: tl.constexpr,
     BN: tl.constexpr,
+    WHOLE_RANGES: tl.constexpr,
     USE_INT64_OFFSETS: tl.constexpr,
 ):
-    """Scan one range, head, and augmented-state column tile backward through its chunks.
+    """Scan one work item, head, and augmented-state column tile backward through its chunks.
 
-    ``bounds[range] = (start, stop)`` are token offsets; the partial last chunk is masked so
-    tokens past ``stop`` contribute nothing and its gate row is the range's final token.
+    ``work_items.py`` defines the work-row layout. The partial last chunk is masked so
+    tokens past the range's end contribute nothing; unused rows store the identity.
     """
     head = tl.program_id(0)
     column_tile = tl.program_id(1)
-    range_id = tl.program_id(2)
+    work_index = tl.program_id(2)
     if USE_INT64_OFFSETS:
         head = head.to(tl.int64)
         column_tile = column_tile.to(tl.int64)
-        range_id = range_id.to(tl.int64)
-    start = tl.load(bounds + 2 * range_id)
-    stop = tl.load(bounds + 2 * range_id + 1)
-    if USE_INT64_OFFSETS:
-        start = start.to(tl.int64)
-        stop = stop.to(tl.int64)
+        work_index = work_index.to(tl.int64)
+    if WHOLE_RANGES:
+        start = tl.load(work + 2 * work_index)
+        stop = tl.load(work + 2 * work_index + 1)
+        if USE_INT64_OFFSETS:
+            start = start.to(tl.int64)
+            stop = stop.to(tl.int64)
+        chunk_begin = 0
+        chunk_end = (stop - start + BT - 1) // BT
+    else:
+        start = tl.load(work + 4 * work_index)
+        chunk_begin = tl.load(work + 4 * work_index + 1)
+        chunk_end = tl.load(work + 4 * work_index + 2)
+        length = tl.load(work + 4 * work_index + 3)
+        if USE_INT64_OFFSETS:
+            start = start.to(tl.int64)
+            chunk_begin = chunk_begin.to(tl.int64)
+            chunk_end = chunk_end.to(tl.int64)
+            length = length.to(tl.int64)
+        stop = start + length
 
     key = tl.arange(0, K)
     row = tl.arange(0, BT)
     column = column_tile * BN + tl.arange(0, BN)
     state = tl.where(column[None, :] == V + key[:, None], 1.0, 0.0).to(tl.float32)
 
-    for chunk in range((stop - start + BT - 1) // BT - 1, -1, -1):
+    for chunk in range(chunk_end - 1, chunk_begin - 1, -1):
         token_start = start + chunk * BT
         token = token_start + row
         valid = token[:, None] < stop
@@ -133,7 +148,7 @@ def affine_summary_rev_kernel(
         state -= tl.dot(tl.trans(w_tile), corrected_lo)
 
     out_offset = ptr_offset(
-        (range_id, head, column[None, :], key[:, None]),
+        (work_index, head, column[None, :], key[:, None]),
         (H * (V + K) * K, (V + K) * K, K, 1),
     )
     tl.store(out + out_offset, state)
@@ -147,28 +162,31 @@ def launch_affine_summary_rev(
     aqk: torch.Tensor,
     cumulative_gate: torch.Tensor,
     scale: float,
-    bounds: torch.Tensor,
-    out: torch.Tensor,
+    work: torch.Tensor,
+    partials: torch.Tensor,
     capability: tuple[int, int],
+    *,
+    whole_ranges: bool,
 ) -> None:
-    """Launch validated inputs: one summary per ``bounds`` row into ``out[R, H, V + K, K]``."""
+    """Scan one item per work row into ``partials[W, H, V + K, K]``."""
     heads = qg.shape[2]
     block_columns = _select_block_columns(heads, capability)
-    affine_summary_rev_kernel[(heads, _SUMMARY_DIM // block_columns, bounds.shape[0])](
+    affine_summary_rev_kernel[(heads, _SUMMARY_DIM // block_columns, work.shape[0])](
         qg,
         kg,
         w,
         dout,
         aqk,
         cumulative_gate,
-        bounds,
-        out,
+        work,
+        partials,
         float(scale),
         H=heads,
         K=_KEY_DIM,
         V=_VALUE_DIM,
         BT=_CHUNK_SIZE,
         BN=block_columns,
+        WHOLE_RANGES=whole_ranges,
         USE_INT64_OFFSETS=requires_int64_offsets(
             qg,
             kg,
@@ -176,7 +194,7 @@ def launch_affine_summary_rev(
             dout,
             aqk,
             cumulative_gate,
-            out,
+            partials,
         ),
         num_warps=8 if block_columns == 32 else 4,
         num_stages=2,

--- a/attn_gym/linear/_delta_rule/triton/work_items.py
+++ b/attn_gym/linear/_delta_rule/triton/work_items.py
@@ -49,6 +49,42 @@ CHUNK_SIZE = 64
 
 
 @triton.jit
+def load_work_item(
+    work,
+    work_index,
+    BT: tl.constexpr,
+    WHOLE_RANGES: tl.constexpr,
+    USE_INT64_OFFSETS: tl.constexpr,
+):
+    """Load ``(start, stop, chunk_begin, chunk_end)`` from a whole-range or planned row.
+
+    Chunk indices are relative to the range's ``start``; ``stop`` remains its full token end
+    so only its final chunk is masked. Unused planned rows return an empty chunk interval.
+    Callers widen ``work_index`` before indexing when ``USE_INT64_OFFSETS`` is set.
+    """
+    if WHOLE_RANGES:
+        start = tl.load(work + 2 * work_index)
+        stop = tl.load(work + 2 * work_index + 1)
+        if USE_INT64_OFFSETS:
+            start = start.to(tl.int64)
+            stop = stop.to(tl.int64)
+        chunk_begin = 0
+        chunk_end = (stop - start + BT - 1) // BT
+    else:
+        start = tl.load(work + 4 * work_index)
+        chunk_begin = tl.load(work + 4 * work_index + 1)
+        chunk_end = tl.load(work + 4 * work_index + 2)
+        length = tl.load(work + 4 * work_index + 3)
+        if USE_INT64_OFFSETS:
+            start = start.to(tl.int64)
+            chunk_begin = chunk_begin.to(tl.int64)
+            chunk_end = chunk_end.to(tl.int64)
+            length = length.to(tl.int64)
+        stop = start + length
+    return start, stop, chunk_begin, chunk_end
+
+
+@triton.jit
 def plan_work_items_kernel(
     bounds,
     work,
@@ -213,4 +249,4 @@ def compose_work_items(
     return out
 
 
-__all__ = ["compose_work_items", "plan_work_items", "work_table"]
+__all__ = ["compose_work_items", "load_work_item", "plan_work_items", "work_table"]

--- a/attn_gym/linear/_delta_rule/triton/work_items.py
+++ b/attn_gym/linear/_delta_rule/triton/work_items.py
@@ -58,6 +58,12 @@ def load_work_item(
 ):
     """Load ``(start, stop, chunk_begin, chunk_end)`` from a whole-range or planned row.
 
+    ``WHOLE_RANGES`` selects unsplit versus planned rows. When true (budget 1), ``work``
+    is the original ``(start, stop)`` bounds and each item scans
+    an entire range, without planning or composition. When false, rows contain
+    ``(start, chunk_begin, chunk_end, length)`` and the partial maps are composed afterward.
+    Both paths support variable-length ranges, empty ranges, and partial tail chunks.
+
     Chunk indices are relative to the range's ``start``; ``stop`` remains its full token end
     so only its final chunk is masked. Unused planned rows return an empty chunk interval.
     Callers widen ``work_index`` before indexing when ``USE_INT64_OFFSETS`` is set.

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -447,7 +447,7 @@ around the communication point without exposing its WY factors:
 from attn_gym.linear.kda import chunk_kda_prepare, chunk_kda_prepare_backward
 
 prepared = chunk_kda_prepare(q, k, v, gate, beta, cu_seqlens=cu_seqlens)
-summaries = prepared.state_summaries(bounds)  # [bias; transition] per range, one launch
+summaries = prepared.state_summaries(bounds)  # [bias; transition] per range
 # ...exchange summaries and compose each subsequence's entry state...
 output, final_state = prepared.run(initial_state, output_final_state=True)
 
@@ -458,7 +458,12 @@ dq, dk, dv, dgate, dbeta, _ = grads.run(d_final_state)
 ```
 
 Each `bounds` row names one local `cu_seqlens` segment (or a whole-chunk run inside one), and
-one launch returns every row's map; the context-parallel routing supplies the rows.
+one call returns every row's map; the context-parallel routing supplies the rows. Both the native
+SM100 summaries and the portable Triton summaries split long ranges into work items when their
+static budget permits, then compose the partial maps on the device. The budget depends on the
+span length, head count, backend tile size, and SM count; budget 1 scans whole ranges in one kernel
+without a planner or compose launch. Work planning reads only device values, preserving CUDA Graph
+replay across different `bounds` values of the same shape.
 `attn_gym.linear.state_summary` holds the pure-PyTorch algebra on summaries (`merge_state`,
 `compose_summaries`, `neutral_summary`).
 

--- a/test/test_delta_affine_summary.py
+++ b/test/test_delta_affine_summary.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from functools import partial, reduce
 from itertools import pairwise
+from unittest.mock import Mock
 
 import pytest
 import torch
@@ -226,13 +227,14 @@ def test_affine_summaries_support_int64_tensor_strides():
     torch.testing.assert_close(actual_reverse, expected_reverse, rtol=0, atol=0)
 
 
-def test_portable_affine_summaries_support_forced_int64_offsets(monkeypatch):
-    """Keep the portable launchers' wide-address specialization executable."""
-    capability = torch.cuda.get_device_capability()
-    if is_sm100_kda_capability(capability):
-        pytest.skip("SM100 uses the native CuTeDSL affine summaries")
-
-    qg, kg, w, u, dout, aqk, cumulative_gate = make_summary_inputs(20)
+@pytest.mark.parametrize("budget", [1, 3])
+def test_portable_affine_summaries_support_forced_int64_offsets(budget, monkeypatch):
+    """Keep the portable single-item and split wide-address specializations executable."""
+    plan_budget = Mock(return_value=budget)
+    for module in (native_fwd, native_rev):
+        monkeypatch.setattr(module, "is_sm100_kda_capability", lambda _capability: False)
+        monkeypatch.setattr(module, "plan_work_budget", plan_budget)
+    qg, kg, w, u, dout, aqk, cumulative_gate = make_summary_inputs(20, tokens=640)
 
     expected_forward = build_state_summary(kg, w, u, cumulative_gate)
     expected_reverse = build_state_grad_summary(
@@ -244,8 +246,11 @@ def test_portable_affine_summaries_support_forced_int64_offsets(monkeypatch):
         cumulative_gate,
         128**-0.5,
     )
-    monkeypatch.setattr(portable_fwd, "requires_int64_offsets", lambda *_tensors: True)
-    monkeypatch.setattr(portable_rev, "requires_int64_offsets", lambda *_tensors: True)
+    assert plan_budget.call_count == 2
+    plan_budget.reset_mock()
+    wide_offsets = Mock(return_value=True)
+    monkeypatch.setattr(portable_fwd, "requires_int64_offsets", wide_offsets)
+    monkeypatch.setattr(portable_rev, "requires_int64_offsets", wide_offsets)
 
     actual_forward = build_state_summary(kg, w, u, cumulative_gate)
     actual_reverse = build_state_grad_summary(
@@ -260,6 +265,8 @@ def test_portable_affine_summaries_support_forced_int64_offsets(monkeypatch):
 
     torch.testing.assert_close(actual_forward, expected_forward, rtol=0, atol=0)
     torch.testing.assert_close(actual_reverse, expected_reverse, rtol=0, atol=0)
+    assert plan_budget.call_count == 2
+    assert wide_offsets.call_count == 2
 
 
 def test_affine_summaries_accept_misaligned_contiguous_storage():
@@ -526,37 +533,31 @@ def test_compose_work_items_ignores_the_float32_matmul_mode():
     )
 
 
-@pytest.mark.skipif(
-    not torch.cuda.is_available()
-    or not is_sm100_kda_capability(torch.cuda.get_device_capability()),
-    reason="work-item splitting is specific to the native SM100 kernels",
-)
+@pytest.mark.usefixtures("summary_backend")
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
-def test_native_split_summaries_match_single_item_scans(dtype, monkeypatch):
+def test_split_summaries_match_single_item_scans(dtype, monkeypatch):
     """Splitting the chunk chain across idle SMs must only reorder FP32 composition."""
     qg, kg, w, u, dout, aqk, cumulative_gate = make_summary_inputs(
         43, dtype, tokens=2048, heads=1, divisor=16
     )
     reverse_summary = partial(build_state_grad_summary, scale=128**-0.5)
+    # Exercise splitting even on small devices where the production budget is one.
+    plan_budget = Mock(return_value=2)
+    monkeypatch.setattr(native_fwd, "plan_work_budget", plan_budget)
+    monkeypatch.setattr(native_rev, "plan_work_budget", plan_budget)
     split = (
         build_state_summary(kg, w, u, cumulative_gate),
         reverse_summary(qg, kg, w, dout, aqk, cumulative_gate),
     )
+    assert plan_budget.call_count == 2
 
-    budgets = []
-    plan_work_budget = native_fwd.plan_work_budget
-
-    def single_item(max_chunks, work_tiles, sm_count):
-        budgets.append(plan_work_budget(max_chunks, work_tiles, sm_count))
-        return 1
-
-    monkeypatch.setattr(native_fwd, "plan_work_budget", single_item)
-    monkeypatch.setattr(native_rev, "plan_work_budget", single_item)
+    plan_budget.reset_mock()
+    plan_budget.return_value = 1
     unsplit = (
         build_state_summary(kg, w, u, cumulative_gate),
         reverse_summary(qg, kg, w, dout, aqk, cumulative_gate),
     )
-    assert all(budget > 1 for budget in budgets), budgets
+    assert plan_budget.call_count == 2
     for name, actual, expected in zip(("forward", "reverse"), split, unsplit, strict=True):
         torch.testing.assert_close(actual, expected, atol=2e-5, rtol=2e-5)
         assert_relative_rms_within(
@@ -770,32 +771,30 @@ def test_range_tails_ignore_the_tokens_that_follow(dtype):
             )
 
 
-@pytest.mark.skipif(
-    not torch.cuda.is_available()
-    or not is_sm100_kda_capability(torch.cuda.get_device_capability()),
-    reason="segmented launches are specific to the native SM100 kernels",
-)
-def test_range_summaries_survive_a_tiny_work_budget(monkeypatch):
+@pytest.mark.usefixtures("summary_backend")
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_range_summaries_survive_a_tiny_work_budget(dtype, monkeypatch):
     """Three items over seven ranges: cuts inside ranges and one-chunk ranges compose."""
-    tensors = make_summary_inputs(47, tokens=640, heads=2)
+    tensors = make_summary_inputs(47, dtype, tokens=640, heads=2)
     qg, kg, w, u, dout, aqk, cumulative_gate = tensors
-    monkeypatch.setattr(native_fwd, "plan_work_budget", lambda chunks, tiles, sms: 3)
-    monkeypatch.setattr(native_rev, "plan_work_budget", lambda chunks, tiles, sms: 3)
+    plan_budget = Mock(return_value=3)
+    monkeypatch.setattr(native_fwd, "plan_work_budget", plan_budget)
+    monkeypatch.setattr(native_rev, "plan_work_budget", plan_budget)
     ranges = [*RANGE_BOUNDS, (500, 501), (0, 65)]
     bounds = torch.tensor(ranges, dtype=torch.int32, device="cuda")
 
     forward = build_state_summaries(kg, w, u, cumulative_gate, bounds)
     reverse = build_state_grad_summaries(qg, kg, w, dout, aqk, cumulative_gate, 128**-0.5, bounds)
+    assert plan_budget.call_count == 2
     for index, (start, stop) in enumerate(ranges):
-        if start == stop:
-            continue
         for name, actual, expected in zip(
             ("forward", "reverse"),
             (forward[index], reverse[index]),
             reference_summaries(tensors, start, stop),
             strict=True,
         ):
-            torch.testing.assert_close(actual, expected, atol=2e-4, rtol=2e-4)
+            tolerance = 0 if start == stop else 2e-4
+            torch.testing.assert_close(actual, expected, atol=tolerance, rtol=tolerance)
             assert_relative_rms_within(
                 actual,
                 expected,
@@ -806,9 +805,14 @@ def test_range_summaries_survive_a_tiny_work_budget(monkeypatch):
 
 
 @pytest.mark.usefixtures("summary_backend")
-def test_range_summaries_replay_across_layouts_in_one_cuda_graph():
-    """One captured graph serves any ``bounds`` values of the same shape: the routing is data."""
-    qg, kg, w, u, dout, aqk, cumulative_gate = make_summary_inputs(43, tokens=640, heads=2)
+@pytest.mark.parametrize("budget", [1, 3])
+def test_range_summaries_replay_across_layouts_in_one_cuda_graph(budget, monkeypatch):
+    """One captured graph serves changed bounds, including all-empty padded work tables."""
+    tensors = make_summary_inputs(43, tokens=640, heads=2)
+    qg, kg, w, u, dout, aqk, cumulative_gate = tensors
+    plan_budget = Mock(return_value=budget)
+    monkeypatch.setattr(native_fwd, "plan_work_budget", plan_budget)
+    monkeypatch.setattr(native_rev, "plan_work_budget", plan_budget)
     scale = 128**-0.5
     bounds = torch.tensor([[0, 256], [256, 640], [640, 640]], dtype=torch.int32, device="cuda")
 
@@ -824,9 +828,31 @@ def test_range_summaries_replay_across_layouts_in_one_cuda_graph():
     with torch.cuda.graph(graph):
         captured = launch()
 
-    for layout in ([[0, 256], [256, 640], [640, 640]], [[0, 100], [100, 300], [300, 640]]):
+    assert plan_budget.call_count == 4
+    for layout in (
+        [[0, 256], [256, 640], [640, 640]],
+        [[0, 100], [100, 300], [300, 640]],
+        [[0, 0], [300, 300], [640, 640]],
+        [[0, 65], [65, 65], [65, 640]],
+    ):
         bounds.copy_(torch.tensor(layout, dtype=torch.int32, device="cuda"))
         graph.replay()
         torch.cuda.synchronize()
         for actual, expected in zip(captured, launch(), strict=True):
             torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+        for index, (start, stop) in enumerate(layout):
+            for name, actual, expected in zip(
+                ("forward", "reverse"),
+                (captured[0][index], captured[1][index]),
+                reference_summaries(tensors, start, stop),
+                strict=True,
+            ):
+                tolerance = 0 if start == stop else 2e-4
+                torch.testing.assert_close(actual, expected, atol=tolerance, rtol=tolerance)
+                assert_relative_rms_within(
+                    actual,
+                    expected,
+                    f"replayed {name} [{start}, {stop})",
+                    max_eps=64,
+                    source_dtype=torch.float32,
+                )


### PR DESCRIPTION
## Human Note

## Agent note

The portable forward/reverse affine-summary kernels currently scan each whole range in one
serial chunk chain per head/column tile. Route them through the existing device work planner,
scan each item's chunk interval, and compose the partial maps in the appropriate direction.
The native SM100 path, public APIs, budget policy, and tile selectors are unchanged. Budget 1
still reads the original bounds and runs just the scan kernel.

This targets underfilled Hopper grids at low head counts, not a blanket Hopper speedup. On the
132-SM H100, H=1/2 select budgets 4/2, while H=4 selects budget 1. Tests now exercise portable
splits, partial tails, empty/padded rows, forced int64 addressing, and changed-layout graph replay.

**Draft pending SM100 runtime validation.** The B200 gpu-dev request stayed queued and was
cancelled; access to the existing GB200 host was denied. Review also needs to consider the
fragmented-range overhead below. No tile or budget-policy tuning is included in this PR.

## Performance

Full public-API subsystem timing, including device planning, partial allocation, scanning, and
composition: one 32K-token range at H=1 is **3.43× faster forward / 3.60× faster reverse**.
Unlike the earlier precomputed-subrange diagnostic, these measurements include the actual planner.

H100 80GB HBM3 (132 SMs), Python 3.13.13, PyTorch `2.15.0.dev20260905+cu132`, Triton 3.8.0,
CuTeDSL 4.7.1. Baseline `67ede83`; candidate uses this PR's kernels. B=1, T=32768, K=V=128,
BT=64, bf16 factors/FP32 gates, seed 2026. CUDA events over 20 calls after five warmups;
medians of three interleaved A/B rounds (AB, BA, AB), fixed/reused inputs, no cache flush or
clock/power changes. Post-run SM clocks were 1980 MHz. Compilation and setup are excluded;
eager numbers include Python dispatch gaps. These are summary microbenchmarks, not model throughput.

Latencies in µs, baseline → PR:

| Heads | Ranges | Forward | Reverse |
|---:|---|---:|---:|
| 1 | 1 × 32768 | 659 → 192 | 985 → 273 |
| 1 | 4096 / 20480 / 8192 | 383 → 200 | 612 → 371 |
| 1 | 8 × 4096 | 101 → 126 | 245 → 274 |
| 2 | 1 × 32768 | 788 → 445 | 969 → 514 |
| 2 | 4096 / 20480 / 8192 | 489 → 347 | 608 → 588 |
| 2 | 8 × 4096 | 227 → 260 | 467 → 497 |
| 4 | 1 × 32768 | 746 → 746 | 932 → 932 |
| 4 | 4096 / 20480 / 8192 | 502 → 504 | 893 → 892 |
| 4 | 8 × 4096 | 350 → 350 | 916 → 916 |

**Trade-off:** H=1/2 with eight short ranges incur roughly 25–33 µs extra planner/compose overhead;
the unchanged policy does not bypass that work based on the number/content of ranges. H=4 remains
on its original single-launch specialization. Small-percent differences are not claimed as wins.

Single-range CUDA Graph replay, excluding capture (fwd / rev, µs):
- H=1: 658 / 982 → 187 / 267
- H=2: 782 / 965 → 438 / 507
- H=4: 742 / 929 → 744 / 930

Profiler traces confirmed the planner → portable scan → compose kernels at H=1/2 and scan-only
at H=4. Budget-one outputs were bit-exact against the archived baseline launchers for bf16/fp16,
including empty ranges and partial tails; all nine long-sequence head/layout combinations passed
pointwise and relative-RMS parity in both directions.

## Test Plan

H100 nightly environment, independent editable install verified from outside the checkout:

```bash
gpu-run --timeout 30 auto -- timeout --signal=TERM --kill-after=5s 300s .venv/bin/pytest -q -n 6 test/test_delta_affine_summary.py test/test_delta_rule_stages.py test/test_context_parallel_plan.py -p no:cacheprovider
gpu-run --gpus 2 --timeout 30 auto -- timeout --signal=TERM --kill-after=5s 300s .venv/bin/pytest -q -n 2 test/test_context_parallel_distributed.py -p no:cacheprovider
```

- **335 passed, 76 skipped** in the affine-summary/stages/planner set.
- **14 passed** in distributed/public recipe coverage, including two-rank graph replay.
- Regression check against pre-change Hopper implementation: **8 failed**, proving the new tests
  detect bypassed planning; the same targeted set then **8 passed, 6 skipped** with this change.
- After review made the split test independent of physical SM count: **2 passed, 2 skipped**.
- Original-kernel parity script: 15 cases, each checking both directions; budget-one comparisons
  use `atol=rtol=0`. Split comparisons use `atol=rtol=2e-5` plus FP32-relative-RMS ≤64 eps.
- `ruff check`, changed-file `ruff format --check`, `git diff --check`, and all applicable
  changed-file `prek` hooks passed.
- SM100 execution remains unverified. Public staged summaries remain eager/CUDA-Graph APIs;
  no new `torch.compile`/export/autograd contract is introduced.

<details>
<summary>Benchmark reproduction scripts</summary>

The source trees at `/home/dev/hopper-baseline` and `/home/dev/attention-gym-hopper` are
archives of base and PR respectively. Both runs use the candidate environment, with imports
verified via the printed source path. Save the Python driver as `/home/dev/pr_benchmark.py`
and the runner as `/home/dev/run_pr_benchmark.sh`, then run:

```bash
gpu-run --timeout 30 auto -- bash /home/dev/run_pr_benchmark.sh
```

```python
"""Matched public-API affine-summary A/B, run with PYTHONPATH selecting one source tree."""
from __future__ import annotations

import json
import sys
from functools import partial
from pathlib import Path

import torch
import triton

import attn_gym
from attn_gym.linear._delta_rule.cute.affine_summary_fwd import build_state_summaries
from attn_gym.linear._delta_rule.cute.affine_summary_rev import build_state_grad_summaries

sys.path.insert(0, str(Path(attn_gym.__file__).resolve().parents[1] / "test"))
from test_delta_affine_summary import make_summary_inputs


def measure(fn) -> float:
    """Mean CUDA-event latency of 20 calls after five warmed calls, in microseconds."""
    for _ in range(5):
        fn()
    torch.cuda.synchronize()
    start, end = torch.cuda.Event(enable_timing=True), torch.cuda.Event(enable_timing=True)
    start.record()
    for _ in range(20):
        fn()
    end.record()
    end.synchronize()
    return start.elapsed_time(end) * 1000 / 20


def main() -> None:
    """Record full planner/scan/compose timing; graphs exclude capture and warmup."""
    label, round_id = sys.argv[1:]
    props = torch.cuda.get_device_properties(0)
    print(json.dumps({"label": label, "round": round_id, "torch": torch.__version__,
                      "triton": triton.__version__, "source": attn_gym.__file__,
                      "gpu": props.name, "uuid": str(props.uuid), "sms": props.multi_processor_count}), flush=True)
    layouts = {"one": [(0, 32768)], "uneven": [(0, 4096), (4096, 24576), (24576, 32768)],
               "eight": [(i * 4096, (i + 1) * 4096) for i in range(8)]}
    for heads in (1, 2, 4):
        qg, kg, w, u, dout, aqk, gate = make_summary_inputs(2026, tokens=32768, heads=heads)
        for name, rows in layouts.items():
            bounds = torch.tensor(rows, dtype=torch.int32, device="cuda")
            fns = {"fwd": partial(build_state_summaries, kg, w, u, gate, bounds),
                   "rev": partial(build_state_grad_summaries, qg, kg, w, dout, aqk, gate, 128**-0.5, bounds)}
            for direction, fn in fns.items():
                actual = fn()
                assert torch.isfinite(actual).all()
                record = {"label": label, "round": round_id, "heads": heads,
                          "layout": name, "direction": direction, "eager_us": measure(fn)}
                if name == "one":
                    graph = torch.cuda.CUDAGraph()
                    with torch.cuda.graph(graph):
                        captured = fn()
                    graph.replay()
                    torch.testing.assert_close(captured, actual, rtol=0, atol=0)
                    record["graph_us"] = measure(graph.replay)
                    if round_id == "0":
                        with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CPU, torch.profiler.ProfilerActivity.CUDA]) as prof:
                            fn()
                            torch.cuda.synchronize()
                        record["kernels"] = sorted({event.name for event in prof.events() if event.device_type == torch.autograd.DeviceType.CUDA})
                print(json.dumps(record), flush=True)


if __name__ == "__main__":
    main()
```

```bash
#!/usr/bin/env bash
set -euo pipefail
cd /tmp
for round in 0 1 2; do
    variants=(baseline candidate)
    if [[ "$round" == 1 ]]; then variants=(candidate baseline); fi
    for variant in "${variants[@]}"; do
        source_dir=/home/dev/hopper-baseline
        if [[ "$variant" == candidate ]]; then source_dir=/home/dev/attention-gym-hopper; fi
        PYTHONPATH="$source_dir" timeout --signal=TERM --kill-after=5s 60s /home/dev/attention-gym-hopper/.venv/bin/python -P /home/dev/pr_benchmark.py "$variant" "$round"
        nvidia-smi --query-gpu=uuid,clocks.sm,power.draw,temperature.gpu --format=csv,noheader
    done
done
```

</details>
