### PR TITLE
Pass context-parallel routing as a batch input

### DIFF
--- a/examples/kda_context_parallel.py
+++ b/examples/kda_context_parallel.py
@@ -35,7 +35,11 @@ import torch.distributed as dist
 import torch.nn.functional as F
 import typer
 
-from attn_gym.linear.context_parallel import ContextParallelPlan, context_parallel_conv_history
+from attn_gym.linear.context_parallel import (
+    ContextParallelPlan,
+    ContextParallelRouting,
+    context_parallel_conv_history,
+)
 from attn_gym.linear.kda.context_parallel import context_parallel_kda
 from attn_gym.linear.types import KernelOptions
 from attn_gym.testing import kernel_stage, record_distributed_profile
@@ -75,7 +79,7 @@ def fragments(
 
 @dataclass(frozen=True)
 class PackedTrainingBatch:
-    """Global reference tensors and this rank's span of them.
+    """Global reference tensors and this rank's span and per-call routing.
 
     ``token_ids`` maps span positions to global token ids; ``terminal_index`` lists the local
     subsequences that end their sequence and ``terminal_sequences`` the matching global sequence
@@ -87,7 +91,7 @@ class PackedTrainingBatch:
     global_offsets: torch.Tensor
     local_hidden: torch.Tensor
     local_target: torch.Tensor
-    local_offsets: torch.Tensor
+    routing: ContextParallelRouting
     token_ids: torch.Tensor
     terminal_index: torch.Tensor
     terminal_sequences: torch.Tensor
@@ -101,16 +105,52 @@ class ContextParallelKDAAttention(KDAAttention):
         self,
         *args,
         group: dist.ProcessGroup,
-        plan: ContextParallelPlan,
         kernel_options: KernelOptions | None = None,
         **kwargs,
     ) -> None:
         super().__init__(*args, **kwargs)
         self.cp_group = group
         self.kernel_options = kernel_options
-        self.routing = plan.routing(
-            torch.device("cuda", torch.cuda.current_device()),
-            conv_history=self.qkv_conv1d.kernel_size[0] - 1,
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        *,
+        routing: ContextParallelRouting,
+        return_final_state: bool = False,
+    ) -> KDAAttentionOutput:
+        """Apply packed KDA using this batch's routing for both distributed state exchanges.
+
+        Routing covers every local token; recurrent and convolution entry states are
+        constructed from the other ranks, not supplied by the caller.
+        """
+        if (
+            hidden_states.ndim != 3
+            or hidden_states.shape[0] != 1
+            or hidden_states.shape[-1] != self.hidden_size
+        ):
+            raise ValueError(
+                f"hidden_states must have shape [1, T, {self.hidden_size}], "
+                f"got {tuple(hidden_states.shape)}"
+            )
+        if hidden_states.shape[1] == 0:
+            raise ValueError("sequence length must be greater than zero")
+        if self.backend != "fused":
+            raise ValueError("packed context parallelism requires backend='fused'")
+        if routing.tail_sources.shape[1] != self.qkv_conv1d.kernel_size[0] - 1:
+            raise ValueError(
+                "routing conv_history must match the model's convolution width minus one"
+            )
+        # The base pipeline (projections, masking, normalization) is reused as is. Routing is
+        # passed per call and reaches only the two overrides below, short_convolution and
+        # kda_core, instead of being stored on the module.
+        return self.run_stages(
+            hidden_states,
+            None,
+            None,
+            cu_seqlens=routing.cu_seqlens,
+            return_final_state=return_final_state,
+            routing=routing,
         )
 
     def short_convolution(
@@ -120,11 +160,11 @@ class ContextParallelKDAAttention(KDAAttention):
         *,
         cu_seqlens: torch.Tensor | None = None,
         return_final_state: bool,
+        routing: ContextParallelRouting,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        if initial_state is not None:
-            raise ValueError("context parallelism constructs the short-convolution state")
+        assert initial_state is None, "context parallelism constructs the convolution history"
         with kernel_stage("cp/conv/halo", self.enable_graph_annotations):
-            initial_state = context_parallel_conv_history(qkv, self.routing, self.cp_group)
+            initial_state = context_parallel_conv_history(qkv, routing, self.cp_group)
         return super().short_convolution(
             qkv,
             initial_state,
@@ -143,16 +183,17 @@ class ContextParallelKDAAttention(KDAAttention):
         *,
         cu_seqlens: torch.Tensor | None = None,
         return_final_state: bool,
+        routing: ContextParallelRouting,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        if initial_state is not None:
-            raise ValueError("context parallelism constructs the KDA recurrent state")
+        assert initial_state is None, "context parallelism constructs the recurrent state"
+        del cu_seqlens  # routing.cu_seqlens is the same tensor
         output, final_state = context_parallel_kda(
             q,
             k,
             v,
             gate,
             beta,
-            routing=self.routing,
+            routing=routing,
             group=self.cp_group,
             fastmath=self.fastmath,
             kernel_options=self.kernel_options,
@@ -161,10 +202,10 @@ class ContextParallelKDAAttention(KDAAttention):
 
 
 def run_training_step(
-    module: KDAAttention,
+    module: ContextParallelKDAAttention,
     hidden_states: torch.Tensor,
     target: torch.Tensor,
-    cu_seqlens: torch.Tensor,
+    routing: ContextParallelRouting,
     state_index: torch.Tensor,
     loss_scale: float,
     *,
@@ -174,9 +215,25 @@ def run_training_step(
     module.enable_graph_annotations = annotate
     result = module(
         hidden_states,
-        cu_seqlens=cu_seqlens,
+        routing=routing,
         return_final_state=True,
     )
+    return result, training_gradients(
+        module, result, hidden_states, target, state_index, loss_scale, annotate=annotate
+    )
+
+
+def training_gradients(
+    module: KDAAttention,
+    result: KDAAttentionOutput,
+    hidden_states: torch.Tensor,
+    target: torch.Tensor,
+    state_index: torch.Tensor,
+    loss_scale: float,
+    *,
+    annotate: bool = False,
+) -> tuple[torch.Tensor, ...]:
+    """Differentiate the same token and true-endpoint losses in CP and unsharded runs."""
     assert result.final_state is not None
     assert result.final_conv_state is not None
     loss = F.mse_loss(result.hidden_states.float(), target, reduction="sum") * loss_scale
@@ -185,8 +242,7 @@ def run_training_step(
     loss = loss + 1e-4 * result.final_conv_state[state_index].float().square().sum()
     inputs = (hidden_states, *tuple(module.parameters()))
     with kernel_stage("cp/bwd", annotate, backward=False):
-        gradients = torch.autograd.grad(loss, inputs)
-    return result, gradients
+        return torch.autograd.grad(loss, inputs)
 
 
 def validate_against_reference(
@@ -199,7 +255,7 @@ def validate_against_reference(
         model,
         batch.local_hidden,
         batch.local_target,
-        batch.local_offsets,
+        batch.routing,
         batch.terminal_index,
         batch.loss_scale,
     )
@@ -209,11 +265,14 @@ def validate_against_reference(
     every_sequence = torch.arange(
         batch.global_offsets.shape[0] - 1, device=reference_hidden.device
     )
-    reference_result, reference_gradients = run_training_step(
+    reference_result = reference_model(
+        reference_hidden, cu_seqlens=batch.global_offsets, return_final_state=True
+    )
+    reference_gradients = training_gradients(
         reference_model,
+        reference_result,
         reference_hidden,
         batch.global_target,
-        batch.global_offsets,
         every_sequence,
         batch.loss_scale,
     )
@@ -265,7 +324,7 @@ def validate_cuda_graph(
             model,
             eager_hidden,
             batch.local_target,
-            batch.local_offsets,
+            batch.routing,
             batch.terminal_index,
             batch.loss_scale,
         )
@@ -281,7 +340,7 @@ def validate_cuda_graph(
                 model,
                 capture_hidden,
                 batch.local_target,
-                batch.local_offsets,
+                batch.routing,
                 batch.terminal_index,
                 batch.loss_scale,
                 annotate=annotations,
@@ -331,7 +390,7 @@ def profile_eager_step(
             model,
             hidden_states,
             batch.local_target,
-            batch.local_offsets,
+            batch.routing,
             batch.terminal_index,
             batch.loss_scale,
         ),
@@ -371,7 +430,7 @@ def capture_training_graph(
             model,
             static_hidden,
             batch.local_target,
-            batch.local_offsets,
+            batch.routing,
             batch.terminal_index,
             batch.loss_scale,
         )
@@ -387,7 +446,7 @@ def capture_training_graph(
             model,
             static_hidden,
             batch.local_target,
-            batch.local_offsets,
+            batch.routing,
             batch.terminal_index,
             batch.loss_scale,
         )
@@ -427,7 +486,7 @@ def run_benchmark(
                 model,
                 hidden_states,
                 batch.local_target,
-                batch.local_offsets,
+                batch.routing,
                 batch.terminal_index,
                 batch.loss_scale,
             )
@@ -596,7 +655,6 @@ def main(
         ContextParallelKDAAttention,
         **model_options,
         group=dist.group.WORLD,
-        plan=plan,
         kernel_options={"backend": kda_backend.value},
     )
     model = make_model()
@@ -628,7 +686,7 @@ def main(
         global_offsets=torch.tensor(cu_seqlens_global, dtype=torch.int32, device=device),
         local_hidden=global_hidden[:, shard_ids].to(device).requires_grad_(),
         local_target=global_target[:, shard_ids].to(device),
-        local_offsets=model.routing.cu_seqlens,
+        routing=plan.routing(device, conv_history=short_conv_kernel_size - 1),
         token_ids=token_ids,
         terminal_index=torch.tensor(plan.terminal, dtype=torch.long, device=device),
         terminal_sequences=torch.tensor(
@@ -650,7 +708,7 @@ def main(
             model,
             batch.local_hidden,
             batch.local_target,
-            batch.local_offsets,
+            batch.routing,
             batch.terminal_index,
             batch.loss_scale,
         )

--- a/examples/kda_training.py
+++ b/examples/kda_training.py
@@ -270,7 +270,31 @@ class KDAAttention(nn.Module):
                     f"initial_state must have shape {expected_state}, got {tuple(initial_state.shape)}"
                 )
             initial_state = initial_state.to(device=hidden_states.device, dtype=torch.float32)
+        return self.run_stages(
+            hidden_states,
+            initial_state,
+            initial_conv_state,
+            cu_seqlens=cu_seqlens,
+            return_final_state=return_final_state,
+        )
 
+    def run_stages(
+        self,
+        hidden_states: torch.Tensor,
+        initial_state: torch.Tensor | None,
+        initial_conv_state: torch.Tensor | None,
+        *,
+        cu_seqlens: torch.Tensor | None,
+        return_final_state: bool,
+        **stage_kwargs: Any,
+    ) -> KDAAttentionOutput:
+        """Run the validated stage pipeline shared by every ``forward`` variant.
+
+        ``stage_kwargs`` are forwarded to ``short_convolution`` and ``kda_core`` so a subclass
+        can thread per-call context (for example context-parallel routing) through those two
+        stateful stages without storing it on the module or re-spelling the pipeline.
+        """
+        batch, tokens, _ = hidden_states.shape
         # --8<-- [start:kda-fixed-capacity-masking]
         # Keep the endpoint on-device: a captured graph rebuilds this one mask on
         # replay, then every value mask and gradient barrier below reuses it.
@@ -290,6 +314,7 @@ class KDAAttention(nn.Module):
             initial_conv_state,
             cu_seqlens=cu_seqlens,
             return_final_state=return_final_state,
+            **stage_kwargs,
         )
         # Ordinary Q/K normalization reads and saves every physical row.
         qkv = mask_inactive_tokens(qkv, active_mask)
@@ -310,6 +335,7 @@ class KDAAttention(nn.Module):
             initial_state,
             cu_seqlens=cu_seqlens,
             return_final_state=return_final_state,
+            **stage_kwargs,
         )
         # KDA leaves its output suffix undefined; sanitize it before RMSNorm saves it.
         output = self.output_normalization(mask_inactive_tokens(output, active_mask))

--- a/test/test_kda_context_parallel_example.py
+++ b/test/test_kda_context_parallel_example.py
@@ -1,0 +1,209 @@
+"""Exercise per-batch routing on one complete KDA module with two NCCL ranks."""
+
+from __future__ import annotations
+
+from dataclasses import fields
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import torch.nn.functional as F
+
+pytest.importorskip("cutlass")
+pytest.importorskip("typer")
+
+from attn_gym.linear.context_parallel import ContextParallelPlan, ContextParallelRouting
+from examples.kda_context_parallel import ContextParallelKDAAttention
+from examples.kda_training import KDAAttention, KDAAttentionOutput
+
+pytestmark = [
+    pytest.mark.skipif(
+        torch.cuda.device_count() < 2
+        or any(
+            torch.cuda.get_device_capability(i) < (9, 0)
+            for i in range(min(2, torch.cuda.device_count()))
+        ),
+        reason="the complete CP KDA module needs two Hopper-or-newer GPUs and NCCL",
+    ),
+    pytest.mark.xdist_group("two-gpu"),
+]
+
+# Both layouts own 64 tokens per rank, but change document boundaries and fragment ownership.
+LAYOUTS = (
+    ((0, 17, 83, 128), [[(0, 64)], [(64, 128)]]),
+    ((0, 29, 91, 128), [[(0, 32), (96, 128)], [(32, 64), (64, 96)]]),
+)
+CAPS = {"slots": 2, "max_subsequences": 4, "conv_history": 3}
+
+
+def _gradients(
+    model: KDAAttention,
+    result: KDAAttentionOutput,
+    hidden: torch.Tensor,
+    target: torch.Tensor,
+    terminal: torch.Tensor,
+) -> tuple[torch.Tensor, ...]:
+    """Include both state losses, masking nonterminal and padding rows without dynamic shapes."""
+    assert result.final_state is not None and result.final_conv_state is not None
+    loss = F.mse_loss(result.hidden_states.float(), target, reduction="sum") / target.shape[-1]
+    loss = loss + 1e-4 * (result.final_state.square() * terminal[:, None, None, None]).sum()
+    loss = loss + 1e-4 * (result.final_conv_state.float().square() * terminal[:, None, None]).sum()
+    return torch.autograd.grad(loss, (hidden, *model.parameters()))
+
+
+def _step(
+    model: ContextParallelKDAAttention,
+    hidden: torch.Tensor,
+    target: torch.Tensor,
+    routing: ContextParallelRouting,
+) -> tuple[KDAAttentionOutput, tuple[torch.Tensor, ...]]:
+    """Run the public per-call routing ABI, including full-module backward."""
+    result = model(hidden, routing=routing, return_final_state=True)
+    return result, _gradients(model, result, hidden, target, routing.terminal)
+
+
+def _assert_matches_reference(
+    model: ContextParallelKDAAttention,
+    reference: KDAAttention,
+    plan: ContextParallelPlan,
+    global_hidden: torch.Tensor,
+    global_target: torch.Tensor,
+    offsets: tuple[int, ...],
+    actual: tuple[KDAAttentionOutput, tuple[torch.Tensor, ...]],
+) -> None:
+    """Check outputs, both endpoint states, input gradients, and every reduced parameter gradient."""
+    hidden = global_hidden.detach().clone().requires_grad_()
+    expected = reference(
+        hidden,
+        cu_seqlens=torch.tensor(offsets, device=hidden.device, dtype=torch.int32),
+        return_final_state=True,
+    )
+    expected_grads = _gradients(
+        reference, expected, hidden, global_target, hidden.new_ones(len(offsets) - 1)
+    )
+    result, grads = actual
+    ids = plan.global_token_ids(hidden.device)
+    terminal = torch.tensor(plan.terminal, device=hidden.device, dtype=torch.long)
+    sequences = torch.tensor(
+        [plan.subsequences[index].sequence for index in plan.terminal],
+        device=hidden.device,
+        dtype=torch.long,
+    )
+    pairs = [
+        ("output", result.hidden_states, expected.hidden_states[:, ids]),
+        ("input gradient", grads[0], expected_grads[0][:, ids]),
+        ("final state", result.final_state[terminal], expected.final_state[sequences]),
+        ("conv state", result.final_conv_state[terminal], expected.final_conv_state[sequences]),
+    ]
+    for (name, _), grad, expected_grad in zip(
+        model.named_parameters(), grads[1:], expected_grads[1:], strict=True
+    ):
+        reduced = grad.detach().clone()
+        dist.all_reduce(reduced, group=model.cp_group)
+        pairs.append((name, reduced, expected_grad))
+    # Match the full-module example's pointwise budget: partitioning changes low-precision rounding.
+    eps = torch.finfo(model.compute_dtype).eps
+    for name, value, expected_value in pairs:
+        torch.testing.assert_close(value, expected_value, atol=eps, rtol=eps, msg=name)
+
+
+def _rank_main(rank: int, rendezvous: str, dtype: torch.dtype, capture: bool) -> None:
+    """Keep one model across layouts; captured runs update only caller-owned tensor buffers."""
+    device = torch.device("cuda", rank)
+    torch.cuda.set_device(device)
+    dist.init_process_group(
+        "nccl",
+        init_method=rendezvous,
+        rank=rank,
+        world_size=2,
+        device_id=device,
+        timeout=timedelta(seconds=180),
+    )
+    graph = None
+    try:
+        # Keep parameter autograd nodes on the same stream for warmup, capture, and replay.
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(stream):
+            torch.manual_seed(7)
+            options = {
+                "hidden_size": 32,
+                "num_heads": 1,
+                "head_dim": 128,
+                "backend": "fused",
+                "compute_dtype": dtype,
+                "device": device,
+            }
+            model = ContextParallelKDAAttention(**options, group=dist.group.WORLD)
+            reference = KDAAttention(**options)
+            reference.load_state_dict(model.state_dict())
+            global_hidden = torch.randn(1, 128, 32, device=device)
+            global_target = torch.randn_like(global_hidden)
+            offsets, fragments = LAYOUTS[0]
+            plan = ContextParallelPlan.from_fragments(offsets, fragments, rank)
+            routing = plan.routing(device, **CAPS)
+            ids = plan.global_token_ids(device)
+            hidden = global_hidden[:, ids].clone().requires_grad_()
+            target = global_target[:, ids].clone()
+            with pytest.raises(ValueError, match="routing conv_history"):
+                model(hidden, routing=plan.routing(device))
+            if capture:
+                for _ in range(2):
+                    _step(model, hidden, target, routing)
+                stream.synchronize()
+                dist.barrier()
+                graph = torch.cuda.CUDAGraph()
+                with torch.cuda.graph(graph, stream=stream):
+                    captured = _step(model, hidden, target, routing)
+
+            # Return to the original routing too: no invocation may retain the preceding batch.
+            for offsets, fragments in (*LAYOUTS, LAYOUTS[0]):
+                plan = ContextParallelPlan.from_fragments(offsets, fragments, rank)
+                new_routing = plan.routing(device, **CAPS)
+                ids = plan.global_token_ids(device)
+                with torch.no_grad():
+                    hidden.copy_(global_hidden[:, ids])
+                    target.copy_(global_target[:, ids])
+                if capture:
+                    for field in fields(routing):
+                        destination = getattr(routing, field.name)
+                        source = getattr(new_routing, field.name)
+                        if isinstance(destination, torch.Tensor):
+                            destination.copy_(source)
+                        else:
+                            assert destination == source
+                    graph.replay()
+                    actual = captured
+                else:
+                    actual = _step(model, hidden, target, new_routing)
+                stream.synchronize()
+                _assert_matches_reference(
+                    model, reference, plan, global_hidden, global_target, offsets, actual
+                )
+                with torch.no_grad():
+                    output_only = model(hidden, routing=new_routing)
+                assert output_only.final_state is None and output_only.final_conv_state is None
+                torch.testing.assert_close(output_only.hidden_states, actual[0].hidden_states)
+        torch.cuda.current_stream().wait_stream(stream)
+        torch.cuda.synchronize(device)
+    finally:
+        if graph is not None:
+            graph.reset()
+        dist.destroy_process_group()
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("capture", [False, True], ids=["eager", "cuda-graph"])
+def test_same_module_uses_each_batch_routing(
+    tmp_path: Path, dtype: torch.dtype, capture: bool
+) -> None:
+    """One model must follow two incompatible layouts, including in-place graph metadata replay."""
+    mp.spawn(
+        _rank_main,
+        args=((tmp_path / "nccl-init").as_uri(), dtype, capture),
+        nprocs=2,
+        join=True,
+    )


### PR DESCRIPTION
Stacked PRs:
 * #499
 * __->__#492


--- --- ---

Pass context-parallel routing as a batch input

Make ContextParallelKDAAttention.forward take routing explicitly. The batch owns
routing; the model retains only its parameters, process group and backend choices.
Remove the constructor plan, hidden self.routing state, and overrides that accepted
but ignored cu_seqlens. The CP forward visibly composes the inherited model stages,
with convolution and attention reading the same routing.cu_seqlens.

Update training, reference validation, warmup, profiling and capture callsites.
Reject a routing whose convolution history width does not match the model, rather
than silently omitting the halo. Ordinary KDAAttention is unchanged.

Validation on two H100s (torch 2.15.0.dev20260904+cu132, CuTeDSL 4.7.1):
- Four BF16/FP16 x eager/CUDA Graph tests passed. The same model visits contiguous,
  zigzag, then contiguous routing with unequal, unaligned document boundaries.
- Compare outputs, terminal recurrent/convolution states, input gradients and every
  reduced parameter gradient against the unsharded model. Captured cases update
  caller-owned routing buffers in place; omitted state outputs are covered too.
- The two-rank example CLI passed reference validation and changed-input graph replay.
- An FP16 old-vs-new probe produced bitwise-identical outputs and all gradients for
  all three layout visits. Tests retain the example's established pointwise budget;
  an uncalibrated extra RMS assertion failed identically on the old implementation.
- Ruff check/format and scoped diff checks passed; simplifier review found no fixes.

A first uninstrumented smoke exceeded its 60-second watchdog. A bounded diagnostic
rerun completed, followed by the plain four-case suite. No kernel/order fix was made;
the first timeout's cause was not established. Diagnostic code is not in this patch.