### PR TITLE
Remove unused chunk-offset plumbing from GDN Mega

### DIFF
--- a/attn_gym/linear/gdn/impl/mega.py
+++ b/attn_gym/linear/gdn/impl/mega.py
@@ -16,11 +16,9 @@ from attn_gym.linear.gdn.impl.mega_ops import (
     chunk_gdn_mega_packed_fwd_with_state_op,
     validate_mega_available,
 )
-from attn_gym.linear.kda.chunk_schedule import prepare_ragged_chunk_metadata
 
 _SUPPORTED_IO_DTYPES = (torch.float16, torch.bfloat16)
 _MEGA_DIM = 128
-_CHUNK_SIZE = 64
 
 
 def _pack_dense(tensor: Tensor) -> Tensor:
@@ -62,16 +60,13 @@ class ChunkGdnMegaPacked(torch.autograd.Function):
         beta: Tensor,
         initial_state: Tensor | None,
         cu_seqlens: Tensor,
-        chunk_offsets: Tensor,
         scale: float,
         output_final_state: bool,
     ) -> Tensor | tuple[Tensor, Tensor]:
         ctx.has_initial_state = initial_state is not None
         ctx.scale = scale
         if initial_state is None:
-            output = chunk_gdn_mega_packed_fwd_op(
-                q, k, value, gate, beta, cu_seqlens, chunk_offsets, scale
-            )
+            output = chunk_gdn_mega_packed_fwd_op(q, k, value, gate, beta, cu_seqlens, scale)
             ctx.save_for_backward(q, k, value, gate, beta, cu_seqlens)
         elif output_final_state:
             output, final_state = chunk_gdn_mega_packed_fwd_with_state_op(
@@ -82,7 +77,6 @@ class ChunkGdnMegaPacked(torch.autograd.Function):
                 beta,
                 initial_state,
                 cu_seqlens,
-                chunk_offsets,
                 scale,
             )
             ctx.save_for_backward(q, k, value, gate, beta, initial_state, cu_seqlens)
@@ -95,7 +89,6 @@ class ChunkGdnMegaPacked(torch.autograd.Function):
                 beta,
                 initial_state,
                 cu_seqlens,
-                chunk_offsets,
                 scale,
             )
             ctx.save_for_backward(q, k, value, gate, beta, initial_state, cu_seqlens)
@@ -124,7 +117,7 @@ class ChunkGdnMegaPacked(torch.autograd.Function):
                 cu_seqlens,
                 ctx.scale,
             )
-            return *gradients, None, None, None, None, None
+            return *gradients, None, None, None, None
 
         q, k, value, gate, beta, initial_state, cu_seqlens = ctx.saved_tensors
         return (
@@ -140,7 +133,6 @@ class ChunkGdnMegaPacked(torch.autograd.Function):
                 cu_seqlens,
                 ctx.scale,
             ),
-            None,
             None,
             None,
             None,
@@ -178,10 +170,6 @@ def chunk_forward(
     if batch > 1:
         q, k, value, gate, beta = (_pack_dense(tensor) for tensor in (q, k, value, gate, beta))
 
-    metadata = prepare_ragged_chunk_metadata(cu_seqlens, q.shape[1], _CHUNK_SIZE)
-    cu_seqlens = metadata.cu_seqlens
-    chunk_offsets = metadata.chunk_offsets
-
     if output_final_state and initial_state is None:
         initial_state = torch.zeros(
             cu_seqlens.shape[0] - 1,
@@ -202,7 +190,6 @@ def chunk_forward(
         beta,
         initial_state,
         cu_seqlens,
-        chunk_offsets,
         scale,
         output_final_state,
     )

--- a/attn_gym/linear/gdn/impl/mega_ops.py
+++ b/attn_gym/linear/gdn/impl/mega_ops.py
@@ -3,7 +3,8 @@
 """Private registered operators around the optional scalar-GDN Mega launchers.
 
 The opaque operators keep CuTeDSL imports and launch-time setup outside captured graphs. Public
-input normalization and autograd live in :mod:`mega`; these operators own only fixed kernel ABIs.
+input normalization and autograd live in :mod:`mega`; these operators own fixed kernel ABIs and
+device-side boundary validation.
 """
 
 from __future__ import annotations
@@ -19,17 +20,17 @@ from attn_gym.linear._delta_rule.paged_state import PagedState
 torch.library.define(
     "attn_gym::gdn_chunk_mega_packed_fwd",
     "(Tensor q, Tensor k, Tensor value, Tensor gate, Tensor beta, Tensor cu_seqlens, "
-    "Tensor chunk_offsets, float scale) -> Tensor",
+    "float scale) -> Tensor",
 )
 torch.library.define(
     "attn_gym::gdn_chunk_mega_packed_fwd_with_initial_state",
     "(Tensor q, Tensor k, Tensor value, Tensor gate, Tensor beta, Tensor initial_state, "
-    "Tensor cu_seqlens, Tensor chunk_offsets, float scale) -> Tensor",
+    "Tensor cu_seqlens, float scale) -> Tensor",
 )
 torch.library.define(
     "attn_gym::gdn_chunk_mega_packed_fwd_with_state",
     "(Tensor q, Tensor k, Tensor value, Tensor gate, Tensor beta, Tensor initial_state, "
-    "Tensor cu_seqlens, Tensor chunk_offsets, float scale) -> (Tensor, Tensor)",
+    "Tensor cu_seqlens, float scale) -> (Tensor, Tensor)",
 )
 torch.library.define(
     "attn_gym::gdn_chunk_mega_packed_fwd_paged",
@@ -72,6 +73,21 @@ def _normalize_cu_seqlens(cu_seqlens: Tensor) -> Tensor:
     if cu_seqlens.is_contiguous() and cu_seqlens.data_ptr() % 8 == 0:
         return cu_seqlens
     return cu_seqlens.clone(memory_format=torch.contiguous_format)
+
+
+def _validate_packed_boundaries(cu_seqlens: Tensor, q: Tensor) -> None:
+    """Check metadata before device reads, inside the opaque op to prevent compiler DCE."""
+    if (
+        cu_seqlens.ndim != 1
+        or cu_seqlens.shape[0] < 2
+        or cu_seqlens.dtype != torch.int32
+        or not cu_seqlens.is_cuda
+        or cu_seqlens.device != q.device
+    ):
+        raise TypeError("cu_seqlens must be a contiguous int32 vector on q.device")
+    from attn_gym.linear.kda.chunk_scheduler import _prepare_ragged_chunk_offsets
+
+    _prepare_ragged_chunk_offsets(cu_seqlens, q.shape[1], 64)
 
 
 def _empty_with_layout(template: Tensor) -> Tensor:
@@ -119,14 +135,14 @@ def _packed_fwd_cuda(
     gate: Tensor,
     beta: Tensor,
     cu_seqlens: Tensor,
-    chunk_offsets: Tensor,
     scale: float,
 ) -> Tensor:
-    del chunk_offsets
+    """Validate packed boundaries and run the fixed-arity forward launcher."""
     value_template = value
     q, k, value = (_normalize_tma_tensor(tensor) for tensor in (q, k, value))
     gate, beta = (_normalize_scalar_tensor(tensor) for tensor in (gate, beta))
     cu_seqlens = _normalize_cu_seqlens(cu_seqlens)
+    _validate_packed_boundaries(cu_seqlens, q)
     output, _ = _forward_backend().run_forward(
         q,
         k,
@@ -149,16 +165,16 @@ def _packed_fwd_with_initial_state_cuda(
     beta: Tensor,
     initial_state: Tensor,
     cu_seqlens: Tensor,
-    chunk_offsets: Tensor,
     scale: float,
 ) -> Tensor:
-    del chunk_offsets
+    """Validate packed boundaries and run the fixed-arity forward launcher."""
     value_template = value
     q, k, value, initial_state = (
         _normalize_tma_tensor(tensor) for tensor in (q, k, value, initial_state)
     )
     gate, beta = (_normalize_scalar_tensor(tensor) for tensor in (gate, beta))
     cu_seqlens = _normalize_cu_seqlens(cu_seqlens)
+    _validate_packed_boundaries(cu_seqlens, q)
     output, _ = _forward_backend().run_forward(
         q,
         k,
@@ -181,16 +197,16 @@ def _packed_fwd_with_state_cuda(
     beta: Tensor,
     initial_state: Tensor,
     cu_seqlens: Tensor,
-    chunk_offsets: Tensor,
     scale: float,
 ) -> tuple[Tensor, Tensor]:
-    del chunk_offsets
+    """Validate packed boundaries and run the fixed-arity forward launcher."""
     value_template, state_template = value, initial_state
     q, k, value, initial_state = (
         _normalize_tma_tensor(tensor) for tensor in (q, k, value, initial_state)
     )
     gate, beta = (_normalize_scalar_tensor(tensor) for tensor in (gate, beta))
     cu_seqlens = _normalize_cu_seqlens(cu_seqlens)
+    _validate_packed_boundaries(cu_seqlens, q)
     output, final_state = _forward_backend().run_forward(
         q,
         k,
@@ -349,7 +365,6 @@ def _packed_fwd_fake(
     gate: Tensor,
     beta: Tensor,
     cu_seqlens: Tensor,
-    chunk_offsets: Tensor,
     scale: float,
 ) -> Tensor:
     """Describe the output allocation made by the no-state forward launcher."""
@@ -365,7 +380,6 @@ def _packed_fwd_with_initial_state_fake(
     beta: Tensor,
     initial_state: Tensor,
     cu_seqlens: Tensor,
-    chunk_offsets: Tensor,
     scale: float,
 ) -> Tensor:
     """Describe the output-only stateful forward launcher."""
@@ -381,7 +395,6 @@ def _packed_fwd_with_state_fake(
     beta: Tensor,
     initial_state: Tensor,
     cu_seqlens: Tensor,
-    chunk_offsets: Tensor,
     scale: float,
 ) -> tuple[Tensor, Tensor]:
     """Describe the forward output and launcher-cloned final state."""

--- a/test/gdn/mega/test_gdn_mega_metadata.py
+++ b/test/gdn/mega/test_gdn_mega_metadata.py
@@ -1,0 +1,52 @@
+"""Reject malformed Mega metadata before launching device-side validation on any CUDA GPU."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from attn_gym.linear.gdn.impl import mega_ops
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA tensors")
+
+
+@pytest.mark.parametrize(
+    "op",
+    [
+        mega_ops.chunk_gdn_mega_packed_fwd_op,
+        mega_ops.chunk_gdn_mega_packed_fwd_with_initial_state_op,
+        mega_ops.chunk_gdn_mega_packed_fwd_with_state_op,
+    ],
+    ids=["no-state", "initial-only", "with-state"],
+)
+@pytest.mark.parametrize("invalid", ["rank", "empty", "short", "dtype", "cpu"])
+def test_raw_forward_rejects_metadata_before_device_reads(op, invalid: str, monkeypatch):
+    """Raw callers must not reach the offset kernel with a malformed metadata tensor."""
+    from attn_gym.linear.kda import chunk_scheduler
+
+    scheduler = Mock(side_effect=AssertionError("malformed metadata reached the scheduler"))
+    backend = Mock(side_effect=AssertionError("malformed metadata reached the Mega backend"))
+    monkeypatch.setattr(chunk_scheduler, "_prepare_ragged_chunk_offsets", scheduler)
+    monkeypatch.setattr(mega_ops, "_forward_backend", backend)
+    q = torch.zeros(1, 8, 1, 128, dtype=torch.bfloat16, device="cuda")
+    gate = torch.zeros(1, 8, 1, device="cuda")
+    match invalid:
+        case "rank":
+            offsets = torch.empty(2, 0, dtype=torch.int32, device="cuda")
+        case "empty":
+            offsets = torch.empty(0, dtype=torch.int32, device="cuda")
+        case "short":
+            offsets = torch.zeros(1, dtype=torch.int32, device="cuda")
+        case "dtype":
+            offsets = torch.tensor([0, 8], dtype=torch.int64, device="cuda")
+        case "cpu":
+            offsets = torch.tensor([0, 8], dtype=torch.int32)
+    args = (q, q, q, gate, gate)
+    if op is not mega_ops.chunk_gdn_mega_packed_fwd_op:
+        args = (*args, torch.zeros(1, 1, 128, 128, device="cuda"))
+    with pytest.raises(TypeError, match="int32 vector on q.device"):
+        op(*args, offsets, 128**-0.5)
+    scheduler.assert_not_called()
+    backend.assert_not_called()

--- a/test/gdn/mega/test_gdn_mega_training.py
+++ b/test/gdn/mega/test_gdn_mega_training.py
@@ -22,7 +22,6 @@ from attn_gym.linear.gdn.impl.mega_ops import (
     chunk_gdn_mega_packed_fwd_with_initial_state_op,
     chunk_gdn_mega_packed_fwd_with_state_op,
 )
-from attn_gym.linear.kda.chunk_schedule import prepare_ragged_chunk_metadata
 from attn_gym.testing import make_gdn_test_inputs
 from attn_gym.testing.kda import assert_matches_low_precision_reference, clone_kda_inputs
 
@@ -231,22 +230,21 @@ def test_gdn_mega_raw_operator_registration() -> None:
     )
     d_output = torch.randn_like(value)
     d_state = torch.randn_like(state)
-    chunk_offsets = prepare_ragged_chunk_metadata(cu_seqlens, q.shape[1], 64).chunk_offsets
     scale = 128**-0.5
     test_utils = ("test_schema", "test_faketensor", "test_aot_dispatch_dynamic")
     torch.library.opcheck(
         chunk_gdn_mega_packed_fwd_op,
-        (q, k, value, gate, beta, cu_seqlens, chunk_offsets, scale),
+        (q, k, value, gate, beta, cu_seqlens, scale),
         test_utils=test_utils,
     )
     torch.library.opcheck(
         chunk_gdn_mega_packed_fwd_with_initial_state_op,
-        (q, k, value, gate, beta, state, cu_seqlens, chunk_offsets, scale),
+        (q, k, value, gate, beta, state, cu_seqlens, scale),
         test_utils=test_utils,
     )
     torch.library.opcheck(
         chunk_gdn_mega_packed_fwd_with_state_op,
-        (q, k, value, gate, beta, state, cu_seqlens, chunk_offsets, scale),
+        (q, k, value, gate, beta, state, cu_seqlens, scale),
         test_utils=test_utils,
     )
     torch.library.opcheck(
@@ -301,7 +299,11 @@ def test_gdn_mega_backward_fake_preserves_leading_strides() -> None:
 
 
 @pytest.mark.parametrize("offsets", ([1, 3], [0, 4, 3], [0, 9]))
-def test_public_gdn_mega_rejects_invalid_packed_offset_values(offsets: list[int]) -> None:
+@pytest.mark.parametrize("compiled", [False, True], ids=["eager", "compiled"])
+@pytest.mark.parametrize("mode", ["no_state", "initial_only", "with_state"])
+def test_public_gdn_mega_rejects_invalid_packed_offset_values(
+    offsets: list[int], compiled: bool, mode: str
+) -> None:
     """Device-side boundary validation must fail before invalid TMA descriptors execute."""
     code = f"""
 import torch
@@ -312,17 +314,21 @@ k = torch.randn_like(q)
 v = torch.randn_like(q)
 gate = -torch.rand(shape[:3], device='cuda')
 beta = torch.rand(shape[:3], device='cuda')
-cu = torch.tensor({offsets!r}, dtype=torch.int32, device='cuda')
-chunk_gdn(
-    q,
-    k,
-    v,
-    gate,
-    beta,
+cu = torch.tensor({[0] + [3] * (len(offsets) - 1)!r}, dtype=torch.int32, device='cuda')
+state = torch.zeros(({len(offsets) - 1}, 2, 128, 128), device='cuda')
+call = torch.compile(chunk_gdn, fullgraph=True) if {compiled!r} else chunk_gdn
+kwargs = dict(
+    initial_state=state if {mode!r} != 'no_state' else None,
+    output_final_state={mode!r} == 'with_state',
     cu_seqlens=cu,
     impl='fused',
     kernel_options={{"backend": "mega"}},
 )
+call(q, k, v, gate, beta, **kwargs)
+torch.cuda.synchronize()
+print('valid offsets completed', flush=True)
+cu.copy_(torch.tensor({offsets!r}, dtype=torch.int32, device='cuda'))
+call(q, k, v, gate, beta, **kwargs)
 torch.cuda.synchronize()
 """
     try:
@@ -336,7 +342,9 @@ torch.cuda.synchronize()
         )
     except subprocess.TimeoutExpired:
         pytest.fail("invalid packed offsets hung instead of failing validation")
+    assert "valid offsets completed" in result.stdout, result.stdout + result.stderr
     assert result.returncode != 0, "invalid packed offsets reached the Mega kernel"
+    assert "invalid packed cu_seqlens" in result.stderr, result.stdout + result.stderr
 
 
 def test_public_gdn_mega_casts_low_precision_gate_and_beta_with_gradients() -> None:


### PR DESCRIPTION
Stacked PRs:
 * #499
 * #492
 * __->__#493


--- --- ---

Remove unused chunk-offset plumbing from GDN Mega

The three nonpaged Mega forward operators discarded their chunk_offsets argument.
Remove it from schemas, fake/CUDA signatures, the autograd wrapper and direct test
callers. Keep actual Mega scheduling and the paged path unchanged.

Offset preparation also validates boundary values, so it cannot simply disappear.
Run the existing device validation inside the opaque forward launchers, where a
compiler cannot discard it as an unused graph-visible output. Reject malformed
metadata shape/dtype/device before that launch. The validation scratch remains;
this patch removes argument plumbing, not the validation kernel.

Extend invalid-value regressions to all three forward arities in eager and compiled
public calls, requiring a valid warmup followed by the specific validation error.

Validation:
- 15 raw metadata-rejection tests passed on H100 without entering the Mega backend.
- Removing the new host guard makes the rank-mismatch regression fail at its
  scheduler spy, proving malformed metadata would reach device reads.
- Ruff check/format and scoped diff checks passed.

DRAFT: Blackwell was unavailable through gpu-dev (B200/B300 reported zero total).
Mega numerical gradients, opcheck, fullgraph/dynamic execution, changed-boundary
CUDA Graph replay and the expanded invalid-value subprocess tests still need
SM100/SM103 validation. Hopper metadata checks are not Mega execution evidence.