### PR TITLE
Share one stage pipeline between KDA and its context-parallel module

### DIFF
--- a/attn_gym/linear/gdn/impl/mega.py
+++ b/attn_gym/linear/gdn/impl/mega.py
@@ -16,11 +16,9 @@ from attn_gym.linear.gdn.impl.mega_ops import (
     chunk_gdn_mega_packed_fwd_with_state_op,
     validate_mega_available,
 )
-from attn_gym.linear.kda.chunk_schedule import prepare_ragged_chunk_metadata
 
 _SUPPORTED_IO_DTYPES = (torch.float16, torch.bfloat16)
 _MEGA_DIM = 128
-_CHUNK_SIZE = 64
 
 
 def _pack_dense(tensor: Tensor) -> Tensor:
@@ -62,16 +60,13 @@ class ChunkGdnMegaPacked(torch.autograd.Function):
         beta: Tensor,
         initial_state: Tensor | None,
         cu_seqlens: Tensor,
-        chunk_offsets: Tensor,
         scale: float,
         output_final_state: bool,
     ) -> Tensor | tuple[Tensor, Tensor]:
         ctx.has_initial_state = initial_state is not None
         ctx.scale = scale
         if initial_state is None:
-            output = chunk_gdn_mega_packed_fwd_op(
-                q, k, value, gate, beta, cu_seqlens, chunk_offsets, scale
-            )
+            output = chunk_gdn_mega_packed_fwd_op(q, k, value, gate, beta, cu_seqlens, scale)
             ctx.save_for_backward(q, k, value, gate, beta, cu_seqlens)
         elif output_final_state:
             output, final_state = chunk_gdn_mega_packed_fwd_with_state_op(
@@ -82,7 +77,6 @@ class ChunkGdnMegaPacked(torch.autograd.Function):
                 beta,
                 initial_state,
                 cu_seqlens,
-                chunk_offsets,
                 scale,
             )
             ctx.save_for_backward(q, k, value, gate, beta, initial_state, cu_seqlens)
@@ -95,7 +89,6 @@ class ChunkGdnMegaPacked(torch.autograd.Function):
                 beta,
                 initial_state,
                 cu_seqlens,
-                chunk_offsets,
                 scale,
             )
             ctx.save_for_backward(q, k, value, gate, beta, initial_state, cu_seqlens)
@@ -124,7 +117,7 @@ class ChunkGdnMegaPacked(torch.autograd.Function):
                 cu_seqlens,
                 ctx.scale,
             )
-            return *gradients, None, None, None, None, None
+            return *gradients, None, None, None, None
 
         q, k, value, gate, beta, initial_state, cu_seqlens = ctx.saved_tensors
         return (
@@ -140,7 +133,6 @@ class ChunkGdnMegaPacked(torch.autograd.Function):
                 cu_seqlens,
                 ctx.scale,
             ),
-            None,
             None,
             None,
             None,
@@ -178,10 +170,6 @@ def chunk_forward(
     if batch > 1:
         q, k, value, gate, beta = (_pack_dense(tensor) for tensor in (q, k, value, gate, beta))
 
-    metadata = prepare_ragged_chunk_metadata(cu_seqlens, q.shape[1], _CHUNK_SIZE)
-    cu_seqlens = metadata.cu_seqlens
-    chunk_offsets = metadata.chunk_offsets
-
     if output_final_state and initial_state is None:
         initial_state = torch.zeros(
             cu_seqlens.shape[0] - 1,
@@ -202,7 +190,6 @@ def chunk_forward(
         beta,
         initial_state,
         cu_seqlens,
-        chunk_offsets,
         scale,
         output_final_state,
     )

--- a/attn_gym/linear/gdn/impl/mega_ops.py
+++ b/attn_gym/linear/gdn/impl/mega_ops.py
@@ -3,7 +3,8 @@
 """Private registered operators around the optional scalar-GDN Mega launchers.
 
 The opaque operators keep CuTeDSL imports and launch-time setup outside captured graphs. Public
-input normalization and autograd live in :mod:`mega`; these operators own only fixed kernel ABIs.
+input normalization and autograd live in :mod:`mega`; these operators own fixed kernel ABIs and
+device-side boundary validation.
 """
 
 from __future__ import annotations
@@ -19,17 +20,17 @@ from attn_gym.linear._delta_rule.paged_state import PagedState
 torch.library.define(
     "attn_gym::gdn_chunk_mega_packed_fwd",
     "(Tensor q, Tensor k, Tensor value, Tensor gate, Tensor beta, Tensor cu_seqlens, "
-    "Tensor chunk_offsets, float scale) -> Tensor",
+    "float scale) -> Tensor",
 )
 torch.library.define(
     "attn_gym::gdn_chunk_mega_packed_fwd_with_initial_state",
     "(Tensor q, Tensor k, Tensor value, Tensor gate, Tensor beta, Tensor initial_state, "
-    "Tensor cu_seqlens, Tensor chunk_offsets, float scale) -> Tensor",
+    "Tensor cu_seqlens, float scale) -> Tensor",
 )
 torch.library.define(
     "attn_gym::gdn_chunk_mega_packed_fwd_with_state",
     "(Tensor q, Tensor k, Tensor value, Tensor gate, Tensor beta, Tensor initial_state, "
-    "Tensor cu_seqlens, Tensor chunk_offsets, float scale) -> (Tensor, Tensor)",
+    "Tensor cu_seqlens, float scale) -> (Tensor, Tensor)",
 )
 torch.library.define(
     "attn_gym::gdn_chunk_mega_packed_fwd_paged",
@@ -72,6 +73,21 @@ def _normalize_cu_seqlens(cu_seqlens: Tensor) -> Tensor:
     if cu_seqlens.is_contiguous() and cu_seqlens.data_ptr() % 8 == 0:
         return cu_seqlens
     return cu_seqlens.clone(memory_format=torch.contiguous_format)
+
+
+def _validate_packed_boundaries(cu_seqlens: Tensor, q: Tensor) -> None:
+    """Check metadata before device reads, inside the opaque op to prevent compiler DCE."""
+    if (
+        cu_seqlens.ndim != 1
+        or cu_seqlens.shape[0] < 2
+        or cu_seqlens.dtype != torch.int32
+        or not cu_seqlens.is_cuda
+        or cu_seqlens.device != q.device
+    ):
+        raise TypeError("cu_seqlens must be a contiguous int32 vector on q.device")
+    from attn_gym.linear.kda.chunk_scheduler import _prepare_ragged_chunk_offsets
+
+    _prepare_ragged_chunk_offsets(cu_seqlens, q.shape[1], 64)
 
 
 def _empty_with_layout(template: Tensor) -> Tensor:
@@ -119,14 +135,14 @@ def _packed_fwd_cuda(
     gate: Tensor,
     beta: Tensor,
     cu_seqlens: Tensor,
-    chunk_offsets: Tensor,
     scale: float,
 ) -> Tensor:
-    del chunk_offsets
+    """Validate packed boundaries and run the fixed-arity forward launcher."""
     value_template = value
     q, k, value = (_normalize_tma_tensor(tensor) for tensor in (q, k, value))
     gate, beta = (_normalize_scalar_tensor(tensor) for tensor in (gate, beta))
     cu_seqlens = _normalize_cu_seqlens(cu_seqlens)
+    _validate_packed_boundaries(cu_seqlens, q)
     output, _ = _forward_backend().run_forward(
         q,
         k,
@@ -149,16 +165,16 @@ def _packed_fwd_with_initial_state_cuda(
     beta: Tensor,
     initial_state: Tensor,
     cu_seqlens: Tensor,
-    chunk_offsets: Tensor,
     scale: float,
 ) -> Tensor:
-    del chunk_offsets
+    """Validate packed boundaries and run the fixed-arity forward launcher."""
     value_template = value
     q, k, value, initial_state = (
         _normalize_tma_tensor(tensor) for tensor in (q, k, value, initial_state)
     )
     gate, beta = (_normalize_scalar_tensor(tensor) for tensor in (gate, beta))
     cu_seqlens = _normalize_cu_seqlens(cu_seqlens)
+    _validate_packed_boundaries(cu_seqlens, q)
     output, _ = _forward_backend().run_forward(
         q,
         k,
@@ -181,16 +197,16 @@ def _packed_fwd_with_state_cuda(
     beta: Tensor,
     initial_state: Tensor,
     cu_seqlens: Tensor,
-    chunk_offsets: Tensor,
     scale: float,
 ) -> tuple[Tensor, Tensor]:
-    del chunk_offsets
+    """Validate packed boundaries and run the fixed-arity forward launcher."""
     value_template, state_template = value, initial_state
     q, k, value, initial_state = (
         _normalize_tma_tensor(tensor) for tensor in (q, k, value, initial_state)
     )
     gate, beta = (_normalize_scalar_tensor(tensor) for tensor in (gate, beta))
     cu_seqlens = _normalize_cu_seqlens(cu_seqlens)
+    _validate_packed_boundaries(cu_seqlens, q)
     output, final_state = _forward_backend().run_forward(
         q,
         k,
@@ -349,7 +365,6 @@ def _packed_fwd_fake(
     gate: Tensor,
     beta: Tensor,
     cu_seqlens: Tensor,
-    chunk_offsets: Tensor,
     scale: float,
 ) -> Tensor:
     """Describe the output allocation made by the no-state forward launcher."""
@@ -365,7 +380,6 @@ def _packed_fwd_with_initial_state_fake(
     beta: Tensor,
     initial_state: Tensor,
     cu_seqlens: Tensor,
-    chunk_offsets: Tensor,
     scale: float,
 ) -> Tensor:
     """Describe the output-only stateful forward launcher."""
@@ -381,7 +395,6 @@ def _packed_fwd_with_state_fake(
     beta: Tensor,
     initial_state: Tensor,
     cu_seqlens: Tensor,
-    chunk_offsets: Tensor,
     scale: float,
 ) -> tuple[Tensor, Tensor]:
     """Describe the forward output and launcher-cloned final state."""

--- a/examples/kda_context_parallel.py
+++ b/examples/kda_context_parallel.py
@@ -141,20 +141,51 @@ class ContextParallelKDAAttention(KDAAttention):
             raise ValueError(
                 "routing conv_history must match the model's convolution width minus one"
             )
-
-        hidden_states_compute, qkv = self.qkv_projection(hidden_states)
-        with kernel_stage("cp/conv/halo", self.enable_graph_annotations):
-            initial_conv_state = context_parallel_conv_history(qkv, routing, self.cp_group)
-        qkv, final_conv_state = self.short_convolution(
-            qkv,
-            initial_conv_state,
+        # Only the two stateful stages differ from the single-device module; the shared
+        # pipeline (masking, normalization, projections) receives the routing per call.
+        return self.run_stages(
+            hidden_states,
+            None,
+            None,
             cu_seqlens=routing.cu_seqlens,
             return_final_state=return_final_state,
+            routing=routing,
         )
-        q, k, v = qkv.view(1, hidden_states.shape[1], 3, self.num_heads, self.head_dim).unbind(2)
-        q, k = self.qk_normalization(q, k)
-        raw_gate, beta = self.gate_projections(hidden_states_compute)
-        gate = self.gate_activation(raw_gate)
+
+    def short_convolution(
+        self,
+        qkv: torch.Tensor,
+        initial_state: torch.Tensor | None,
+        *,
+        cu_seqlens: torch.Tensor | None = None,
+        return_final_state: bool,
+        routing: ContextParallelRouting,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        assert initial_state is None, "context parallelism constructs the convolution history"
+        with kernel_stage("cp/conv/halo", self.enable_graph_annotations):
+            initial_state = context_parallel_conv_history(qkv, routing, self.cp_group)
+        return super().short_convolution(
+            qkv,
+            initial_state,
+            cu_seqlens=cu_seqlens,
+            return_final_state=return_final_state,
+        )
+
+    def kda_core(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        gate: torch.Tensor,
+        beta: torch.Tensor,
+        initial_state: torch.Tensor | None,
+        *,
+        cu_seqlens: torch.Tensor | None = None,
+        return_final_state: bool,
+        routing: ContextParallelRouting,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        assert initial_state is None, "context parallelism constructs the recurrent state"
+        del cu_seqlens  # routing.cu_seqlens is the same tensor
         output, final_state = context_parallel_kda(
             q,
             k,
@@ -166,14 +197,7 @@ class ContextParallelKDAAttention(KDAAttention):
             fastmath=self.fastmath,
             kernel_options=self.kernel_options,
         )
-        output = self.output_normalization(output)
-        output_gate = self.output_gate(hidden_states_compute, output)
-        output = self.output_projection(output, output_gate)
-        return KDAAttentionOutput(
-            output.to(hidden_states.dtype),
-            final_state if return_final_state else None,
-            final_conv_state,
-        )
+        return output, final_state if return_final_state else None
 
 
 def run_training_step(

--- a/examples/kda_context_parallel.py
+++ b/examples/kda_context_parallel.py
@@ -35,7 +35,11 @@ import torch.distributed as dist
 import torch.nn.functional as F
 import typer
 
-from attn_gym.linear.context_parallel import ContextParallelPlan, context_parallel_conv_history
+from attn_gym.linear.context_parallel import (
+    ContextParallelPlan,
+    ContextParallelRouting,
+    context_parallel_conv_history,
+)
 from attn_gym.linear.kda.context_parallel import context_parallel_kda
 from attn_gym.linear.types import KernelOptions
 from attn_gym.testing import kernel_stage, record_distributed_profile
@@ -75,7 +79,7 @@ def fragments(
 
 @dataclass(frozen=True)
 class PackedTrainingBatch:
-    """Global reference tensors and this rank's span of them.
+    """Global reference tensors and this rank's span and per-call routing.
 
     ``token_ids`` maps span positions to global token ids; ``terminal_index`` lists the local
     subsequences that end their sequence and ``terminal_sequences`` the matching global sequence
@@ -87,7 +91,7 @@ class PackedTrainingBatch:
     global_offsets: torch.Tensor
     local_hidden: torch.Tensor
     local_target: torch.Tensor
-    local_offsets: torch.Tensor
+    routing: ContextParallelRouting
     token_ids: torch.Tensor
     terminal_index: torch.Tensor
     terminal_sequences: torch.Tensor
@@ -101,70 +105,82 @@ class ContextParallelKDAAttention(KDAAttention):
         self,
         *args,
         group: dist.ProcessGroup,
-        plan: ContextParallelPlan,
         kernel_options: KernelOptions | None = None,
         **kwargs,
     ) -> None:
         super().__init__(*args, **kwargs)
         self.cp_group = group
         self.kernel_options = kernel_options
-        self.routing = plan.routing(
-            torch.device("cuda", torch.cuda.current_device()),
-            conv_history=self.qkv_conv1d.kernel_size[0] - 1,
-        )
 
-    def short_convolution(
+    def forward(
         self,
-        qkv: torch.Tensor,
-        initial_state: torch.Tensor | None,
+        hidden_states: torch.Tensor,
         *,
-        cu_seqlens: torch.Tensor | None = None,
-        return_final_state: bool,
-    ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        if initial_state is not None:
-            raise ValueError("context parallelism constructs the short-convolution state")
+        routing: ContextParallelRouting,
+        return_final_state: bool = False,
+    ) -> KDAAttentionOutput:
+        """Apply packed KDA using this batch's routing for both distributed state exchanges.
+
+        Routing covers every local token; recurrent and convolution entry states are
+        constructed from the other ranks, not supplied by the caller.
+        """
+        if (
+            hidden_states.ndim != 3
+            or hidden_states.shape[0] != 1
+            or hidden_states.shape[-1] != self.hidden_size
+        ):
+            raise ValueError(
+                f"hidden_states must have shape [1, T, {self.hidden_size}], "
+                f"got {tuple(hidden_states.shape)}"
+            )
+        if hidden_states.shape[1] == 0:
+            raise ValueError("sequence length must be greater than zero")
+        if self.backend != "fused":
+            raise ValueError("packed context parallelism requires backend='fused'")
+        if routing.tail_sources.shape[1] != self.qkv_conv1d.kernel_size[0] - 1:
+            raise ValueError(
+                "routing conv_history must match the model's convolution width minus one"
+            )
+
+        hidden_states_compute, qkv = self.qkv_projection(hidden_states)
         with kernel_stage("cp/conv/halo", self.enable_graph_annotations):
-            initial_state = context_parallel_conv_history(qkv, self.routing, self.cp_group)
-        return super().short_convolution(
+            initial_conv_state = context_parallel_conv_history(qkv, routing, self.cp_group)
+        qkv, final_conv_state = self.short_convolution(
             qkv,
-            initial_state,
-            cu_seqlens=cu_seqlens,
+            initial_conv_state,
+            cu_seqlens=routing.cu_seqlens,
             return_final_state=return_final_state,
         )
-
-    def kda_core(
-        self,
-        q: torch.Tensor,
-        k: torch.Tensor,
-        v: torch.Tensor,
-        gate: torch.Tensor,
-        beta: torch.Tensor,
-        initial_state: torch.Tensor | None,
-        *,
-        cu_seqlens: torch.Tensor | None = None,
-        return_final_state: bool,
-    ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        if initial_state is not None:
-            raise ValueError("context parallelism constructs the KDA recurrent state")
+        q, k, v = qkv.view(1, hidden_states.shape[1], 3, self.num_heads, self.head_dim).unbind(2)
+        q, k = self.qk_normalization(q, k)
+        raw_gate, beta = self.gate_projections(hidden_states_compute)
+        gate = self.gate_activation(raw_gate)
         output, final_state = context_parallel_kda(
             q,
             k,
             v,
             gate,
             beta,
-            routing=self.routing,
+            routing=routing,
             group=self.cp_group,
             fastmath=self.fastmath,
             kernel_options=self.kernel_options,
         )
-        return output, final_state if return_final_state else None
+        output = self.output_normalization(output)
+        output_gate = self.output_gate(hidden_states_compute, output)
+        output = self.output_projection(output, output_gate)
+        return KDAAttentionOutput(
+            output.to(hidden_states.dtype),
+            final_state if return_final_state else None,
+            final_conv_state,
+        )
 
 
 def run_training_step(
-    module: KDAAttention,
+    module: ContextParallelKDAAttention,
     hidden_states: torch.Tensor,
     target: torch.Tensor,
-    cu_seqlens: torch.Tensor,
+    routing: ContextParallelRouting,
     state_index: torch.Tensor,
     loss_scale: float,
     *,
@@ -174,9 +190,25 @@ def run_training_step(
     module.enable_graph_annotations = annotate
     result = module(
         hidden_states,
-        cu_seqlens=cu_seqlens,
+        routing=routing,
         return_final_state=True,
     )
+    return result, training_gradients(
+        module, result, hidden_states, target, state_index, loss_scale, annotate=annotate
+    )
+
+
+def training_gradients(
+    module: KDAAttention,
+    result: KDAAttentionOutput,
+    hidden_states: torch.Tensor,
+    target: torch.Tensor,
+    state_index: torch.Tensor,
+    loss_scale: float,
+    *,
+    annotate: bool = False,
+) -> tuple[torch.Tensor, ...]:
+    """Differentiate the same token and true-endpoint losses in CP and unsharded runs."""
     assert result.final_state is not None
     assert result.final_conv_state is not None
     loss = F.mse_loss(result.hidden_states.float(), target, reduction="sum") * loss_scale
@@ -185,8 +217,7 @@ def run_training_step(
     loss = loss + 1e-4 * result.final_conv_state[state_index].float().square().sum()
     inputs = (hidden_states, *tuple(module.parameters()))
     with kernel_stage("cp/bwd", annotate, backward=False):
-        gradients = torch.autograd.grad(loss, inputs)
-    return result, gradients
+        return torch.autograd.grad(loss, inputs)
 
 
 def validate_against_reference(
@@ -199,7 +230,7 @@ def validate_against_reference(
         model,
         batch.local_hidden,
         batch.local_target,
-        batch.local_offsets,
+        batch.routing,
         batch.terminal_index,
         batch.loss_scale,
     )
@@ -209,11 +240,14 @@ def validate_against_reference(
     every_sequence = torch.arange(
         batch.global_offsets.shape[0] - 1, device=reference_hidden.device
     )
-    reference_result, reference_gradients = run_training_step(
+    reference_result = reference_model(
+        reference_hidden, cu_seqlens=batch.global_offsets, return_final_state=True
+    )
+    reference_gradients = training_gradients(
         reference_model,
+        reference_result,
         reference_hidden,
         batch.global_target,
-        batch.global_offsets,
         every_sequence,
         batch.loss_scale,
     )
@@ -265,7 +299,7 @@ def validate_cuda_graph(
             model,
             eager_hidden,
             batch.local_target,
-            batch.local_offsets,
+            batch.routing,
             batch.terminal_index,
             batch.loss_scale,
         )
@@ -281,7 +315,7 @@ def validate_cuda_graph(
                 model,
                 capture_hidden,
                 batch.local_target,
-                batch.local_offsets,
+                batch.routing,
                 batch.terminal_index,
                 batch.loss_scale,
                 annotate=annotations,
@@ -331,7 +365,7 @@ def profile_eager_step(
             model,
             hidden_states,
             batch.local_target,
-            batch.local_offsets,
+            batch.routing,
             batch.terminal_index,
             batch.loss_scale,
         ),
@@ -371,7 +405,7 @@ def capture_training_graph(
             model,
             static_hidden,
             batch.local_target,
-            batch.local_offsets,
+            batch.routing,
             batch.terminal_index,
             batch.loss_scale,
         )
@@ -387,7 +421,7 @@ def capture_training_graph(
             model,
             static_hidden,
             batch.local_target,
-            batch.local_offsets,
+            batch.routing,
             batch.terminal_index,
             batch.loss_scale,
         )
@@ -427,7 +461,7 @@ def run_benchmark(
                 model,
                 hidden_states,
                 batch.local_target,
-                batch.local_offsets,
+                batch.routing,
                 batch.terminal_index,
                 batch.loss_scale,
             )
@@ -596,7 +630,6 @@ def main(
         ContextParallelKDAAttention,
         **model_options,
         group=dist.group.WORLD,
-        plan=plan,
         kernel_options={"backend": kda_backend.value},
     )
     model = make_model()
@@ -628,7 +661,7 @@ def main(
         global_offsets=torch.tensor(cu_seqlens_global, dtype=torch.int32, device=device),
         local_hidden=global_hidden[:, shard_ids].to(device).requires_grad_(),
         local_target=global_target[:, shard_ids].to(device),
-        local_offsets=model.routing.cu_seqlens,
+        routing=plan.routing(device, conv_history=short_conv_kernel_size - 1),
         token_ids=token_ids,
         terminal_index=torch.tensor(plan.terminal, dtype=torch.long, device=device),
         terminal_sequences=torch.tensor(
@@ -650,7 +683,7 @@ def main(
             model,
             batch.local_hidden,
             batch.local_target,
-            batch.local_offsets,
+            batch.routing,
             batch.terminal_index,
             batch.loss_scale,
         )

--- a/examples/kda_training.py
+++ b/examples/kda_training.py
@@ -270,7 +270,31 @@ class KDAAttention(nn.Module):
                     f"initial_state must have shape {expected_state}, got {tuple(initial_state.shape)}"
                 )
             initial_state = initial_state.to(device=hidden_states.device, dtype=torch.float32)
+        return self.run_stages(
+            hidden_states,
+            initial_state,
+            initial_conv_state,
+            cu_seqlens=cu_seqlens,
+            return_final_state=return_final_state,
+        )
 
+    def run_stages(
+        self,
+        hidden_states: torch.Tensor,
+        initial_state: torch.Tensor | None,
+        initial_conv_state: torch.Tensor | None,
+        *,
+        cu_seqlens: torch.Tensor | None,
+        return_final_state: bool,
+        **stage_kwargs: Any,
+    ) -> KDAAttentionOutput:
+        """Run the validated stage pipeline shared by every ``forward`` variant.
+
+        ``stage_kwargs`` are forwarded to ``short_convolution`` and ``kda_core`` so a subclass
+        can thread per-call context (for example context-parallel routing) through those two
+        stateful stages without storing it on the module or re-spelling the pipeline.
+        """
+        batch, tokens, _ = hidden_states.shape
         # --8<-- [start:kda-fixed-capacity-masking]
         # Keep the endpoint on-device: a captured graph rebuilds this one mask on
         # replay, then every value mask and gradient barrier below reuses it.
@@ -290,6 +314,7 @@ class KDAAttention(nn.Module):
             initial_conv_state,
             cu_seqlens=cu_seqlens,
             return_final_state=return_final_state,
+            **stage_kwargs,
         )
         # Ordinary Q/K normalization reads and saves every physical row.
         qkv = mask_inactive_tokens(qkv, active_mask)
@@ -310,6 +335,7 @@ class KDAAttention(nn.Module):
             initial_state,
             cu_seqlens=cu_seqlens,
             return_final_state=return_final_state,
+            **stage_kwargs,
         )
         # KDA leaves its output suffix undefined; sanitize it before RMSNorm saves it.
         output = self.output_normalization(mask_inactive_tokens(output, active_mask))

--- a/test/gdn/mega/test_gdn_mega_metadata.py
+++ b/test/gdn/mega/test_gdn_mega_metadata.py
@@ -1,0 +1,52 @@
+"""Reject malformed Mega metadata before launching device-side validation on any CUDA GPU."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from attn_gym.linear.gdn.impl import mega_ops
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA tensors")
+
+
+@pytest.mark.parametrize(
+    "op",
+    [
+        mega_ops.chunk_gdn_mega_packed_fwd_op,
+        mega_ops.chunk_gdn_mega_packed_fwd_with_initial_state_op,
+        mega_ops.chunk_gdn_mega_packed_fwd_with_state_op,
+    ],
+    ids=["no-state", "initial-only", "with-state"],
+)
+@pytest.mark.parametrize("invalid", ["rank", "empty", "short", "dtype", "cpu"])
+def test_raw_forward_rejects_metadata_before_device_reads(op, invalid: str, monkeypatch):
+    """Raw callers must not reach the offset kernel with a malformed metadata tensor."""
+    from attn_gym.linear.kda import chunk_scheduler
+
+    scheduler = Mock(side_effect=AssertionError("malformed metadata reached the scheduler"))
+    backend = Mock(side_effect=AssertionError("malformed metadata reached the Mega backend"))
+    monkeypatch.setattr(chunk_scheduler, "_prepare_ragged_chunk_offsets", scheduler)
+    monkeypatch.setattr(mega_ops, "_forward_backend", backend)
+    q = torch.zeros(1, 8, 1, 128, dtype=torch.bfloat16, device="cuda")
+    gate = torch.zeros(1, 8, 1, device="cuda")
+    match invalid:
+        case "rank":
+            offsets = torch.empty(2, 0, dtype=torch.int32, device="cuda")
+        case "empty":
+            offsets = torch.empty(0, dtype=torch.int32, device="cuda")
+        case "short":
+            offsets = torch.zeros(1, dtype=torch.int32, device="cuda")
+        case "dtype":
+            offsets = torch.tensor([0, 8], dtype=torch.int64, device="cuda")
+        case "cpu":
+            offsets = torch.tensor([0, 8], dtype=torch.int32)
+    args = (q, q, q, gate, gate)
+    if op is not mega_ops.chunk_gdn_mega_packed_fwd_op:
+        args = (*args, torch.zeros(1, 1, 128, 128, device="cuda"))
+    with pytest.raises(TypeError, match="int32 vector on q.device"):
+        op(*args, offsets, 128**-0.5)
+    scheduler.assert_not_called()
+    backend.assert_not_called()

--- a/test/gdn/mega/test_gdn_mega_training.py
+++ b/test/gdn/mega/test_gdn_mega_training.py
@@ -22,7 +22,6 @@ from attn_gym.linear.gdn.impl.mega_ops import (
     chunk_gdn_mega_packed_fwd_with_initial_state_op,
     chunk_gdn_mega_packed_fwd_with_state_op,
 )
-from attn_gym.linear.kda.chunk_schedule import prepare_ragged_chunk_metadata
 from attn_gym.testing import make_gdn_test_inputs
 from attn_gym.testing.kda import assert_matches_low_precision_reference, clone_kda_inputs
 
@@ -231,22 +230,21 @@ def test_gdn_mega_raw_operator_registration() -> None:
     )
     d_output = torch.randn_like(value)
     d_state = torch.randn_like(state)
-    chunk_offsets = prepare_ragged_chunk_metadata(cu_seqlens, q.shape[1], 64).chunk_offsets
     scale = 128**-0.5
     test_utils = ("test_schema", "test_faketensor", "test_aot_dispatch_dynamic")
     torch.library.opcheck(
         chunk_gdn_mega_packed_fwd_op,
-        (q, k, value, gate, beta, cu_seqlens, chunk_offsets, scale),
+        (q, k, value, gate, beta, cu_seqlens, scale),
         test_utils=test_utils,
     )
     torch.library.opcheck(
         chunk_gdn_mega_packed_fwd_with_initial_state_op,
-        (q, k, value, gate, beta, state, cu_seqlens, chunk_offsets, scale),
+        (q, k, value, gate, beta, state, cu_seqlens, scale),
         test_utils=test_utils,
     )
     torch.library.opcheck(
         chunk_gdn_mega_packed_fwd_with_state_op,
-        (q, k, value, gate, beta, state, cu_seqlens, chunk_offsets, scale),
+        (q, k, value, gate, beta, state, cu_seqlens, scale),
         test_utils=test_utils,
     )
     torch.library.opcheck(
@@ -301,7 +299,11 @@ def test_gdn_mega_backward_fake_preserves_leading_strides() -> None:
 
 
 @pytest.mark.parametrize("offsets", ([1, 3], [0, 4, 3], [0, 9]))
-def test_public_gdn_mega_rejects_invalid_packed_offset_values(offsets: list[int]) -> None:
+@pytest.mark.parametrize("compiled", [False, True], ids=["eager", "compiled"])
+@pytest.mark.parametrize("mode", ["no_state", "initial_only", "with_state"])
+def test_public_gdn_mega_rejects_invalid_packed_offset_values(
+    offsets: list[int], compiled: bool, mode: str
+) -> None:
     """Device-side boundary validation must fail before invalid TMA descriptors execute."""
     code = f"""
 import torch
@@ -312,17 +314,21 @@ k = torch.randn_like(q)
 v = torch.randn_like(q)
 gate = -torch.rand(shape[:3], device='cuda')
 beta = torch.rand(shape[:3], device='cuda')
-cu = torch.tensor({offsets!r}, dtype=torch.int32, device='cuda')
-chunk_gdn(
-    q,
-    k,
-    v,
-    gate,
-    beta,
+cu = torch.tensor({[0] + [3] * (len(offsets) - 1)!r}, dtype=torch.int32, device='cuda')
+state = torch.zeros(({len(offsets) - 1}, 2, 128, 128), device='cuda')
+call = torch.compile(chunk_gdn, fullgraph=True) if {compiled!r} else chunk_gdn
+kwargs = dict(
+    initial_state=state if {mode!r} != 'no_state' else None,
+    output_final_state={mode!r} == 'with_state',
     cu_seqlens=cu,
     impl='fused',
     kernel_options={{"backend": "mega"}},
 )
+call(q, k, v, gate, beta, **kwargs)
+torch.cuda.synchronize()
+print('valid offsets completed', flush=True)
+cu.copy_(torch.tensor({offsets!r}, dtype=torch.int32, device='cuda'))
+call(q, k, v, gate, beta, **kwargs)
 torch.cuda.synchronize()
 """
     try:
@@ -336,7 +342,9 @@ torch.cuda.synchronize()
         )
     except subprocess.TimeoutExpired:
         pytest.fail("invalid packed offsets hung instead of failing validation")
+    assert "valid offsets completed" in result.stdout, result.stdout + result.stderr
     assert result.returncode != 0, "invalid packed offsets reached the Mega kernel"
+    assert "invalid packed cu_seqlens" in result.stderr, result.stdout + result.stderr
 
 
 def test_public_gdn_mega_casts_low_precision_gate_and_beta_with_gradients() -> None:

--- a/test/test_kda_context_parallel_example.py
+++ b/test/test_kda_context_parallel_example.py
@@ -1,0 +1,209 @@
+"""Exercise per-batch routing on one complete KDA module with two NCCL ranks."""
+
+from __future__ import annotations
+
+from dataclasses import fields
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import torch.nn.functional as F
+
+pytest.importorskip("cutlass")
+pytest.importorskip("typer")
+
+from attn_gym.linear.context_parallel import ContextParallelPlan, ContextParallelRouting
+from examples.kda_context_parallel import ContextParallelKDAAttention
+from examples.kda_training import KDAAttention, KDAAttentionOutput
+
+pytestmark = [
+    pytest.mark.skipif(
+        torch.cuda.device_count() < 2
+        or any(
+            torch.cuda.get_device_capability(i) < (9, 0)
+            for i in range(min(2, torch.cuda.device_count()))
+        ),
+        reason="the complete CP KDA module needs two Hopper-or-newer GPUs and NCCL",
+    ),
+    pytest.mark.xdist_group("two-gpu"),
+]
+
+# Both layouts own 64 tokens per rank, but change document boundaries and fragment ownership.
+LAYOUTS = (
+    ((0, 17, 83, 128), [[(0, 64)], [(64, 128)]]),
+    ((0, 29, 91, 128), [[(0, 32), (96, 128)], [(32, 64), (64, 96)]]),
+)
+CAPS = {"slots": 2, "max_subsequences": 4, "conv_history": 3}
+
+
+def _gradients(
+    model: KDAAttention,
+    result: KDAAttentionOutput,
+    hidden: torch.Tensor,
+    target: torch.Tensor,
+    terminal: torch.Tensor,
+) -> tuple[torch.Tensor, ...]:
+    """Include both state losses, masking nonterminal and padding rows without dynamic shapes."""
+    assert result.final_state is not None and result.final_conv_state is not None
+    loss = F.mse_loss(result.hidden_states.float(), target, reduction="sum") / target.shape[-1]
+    loss = loss + 1e-4 * (result.final_state.square() * terminal[:, None, None, None]).sum()
+    loss = loss + 1e-4 * (result.final_conv_state.float().square() * terminal[:, None, None]).sum()
+    return torch.autograd.grad(loss, (hidden, *model.parameters()))
+
+
+def _step(
+    model: ContextParallelKDAAttention,
+    hidden: torch.Tensor,
+    target: torch.Tensor,
+    routing: ContextParallelRouting,
+) -> tuple[KDAAttentionOutput, tuple[torch.Tensor, ...]]:
+    """Run the public per-call routing ABI, including full-module backward."""
+    result = model(hidden, routing=routing, return_final_state=True)
+    return result, _gradients(model, result, hidden, target, routing.terminal)
+
+
+def _assert_matches_reference(
+    model: ContextParallelKDAAttention,
+    reference: KDAAttention,
+    plan: ContextParallelPlan,
+    global_hidden: torch.Tensor,
+    global_target: torch.Tensor,
+    offsets: tuple[int, ...],
+    actual: tuple[KDAAttentionOutput, tuple[torch.Tensor, ...]],
+) -> None:
+    """Check outputs, both endpoint states, input gradients, and every reduced parameter gradient."""
+    hidden = global_hidden.detach().clone().requires_grad_()
+    expected = reference(
+        hidden,
+        cu_seqlens=torch.tensor(offsets, device=hidden.device, dtype=torch.int32),
+        return_final_state=True,
+    )
+    expected_grads = _gradients(
+        reference, expected, hidden, global_target, hidden.new_ones(len(offsets) - 1)
+    )
+    result, grads = actual
+    ids = plan.global_token_ids(hidden.device)
+    terminal = torch.tensor(plan.terminal, device=hidden.device, dtype=torch.long)
+    sequences = torch.tensor(
+        [plan.subsequences[index].sequence for index in plan.terminal],
+        device=hidden.device,
+        dtype=torch.long,
+    )
+    pairs = [
+        ("output", result.hidden_states, expected.hidden_states[:, ids]),
+        ("input gradient", grads[0], expected_grads[0][:, ids]),
+        ("final state", result.final_state[terminal], expected.final_state[sequences]),
+        ("conv state", result.final_conv_state[terminal], expected.final_conv_state[sequences]),
+    ]
+    for (name, _), grad, expected_grad in zip(
+        model.named_parameters(), grads[1:], expected_grads[1:], strict=True
+    ):
+        reduced = grad.detach().clone()
+        dist.all_reduce(reduced, group=model.cp_group)
+        pairs.append((name, reduced, expected_grad))
+    # Match the full-module example's pointwise budget: partitioning changes low-precision rounding.
+    eps = torch.finfo(model.compute_dtype).eps
+    for name, value, expected_value in pairs:
+        torch.testing.assert_close(value, expected_value, atol=eps, rtol=eps, msg=name)
+
+
+def _rank_main(rank: int, rendezvous: str, dtype: torch.dtype, capture: bool) -> None:
+    """Keep one model across layouts; captured runs update only caller-owned tensor buffers."""
+    device = torch.device("cuda", rank)
+    torch.cuda.set_device(device)
+    dist.init_process_group(
+        "nccl",
+        init_method=rendezvous,
+        rank=rank,
+        world_size=2,
+        device_id=device,
+        timeout=timedelta(seconds=180),
+    )
+    graph = None
+    try:
+        # Keep parameter autograd nodes on the same stream for warmup, capture, and replay.
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(stream):
+            torch.manual_seed(7)
+            options = {
+                "hidden_size": 32,
+                "num_heads": 1,
+                "head_dim": 128,
+                "backend": "fused",
+                "compute_dtype": dtype,
+                "device": device,
+            }
+            model = ContextParallelKDAAttention(**options, group=dist.group.WORLD)
+            reference = KDAAttention(**options)
+            reference.load_state_dict(model.state_dict())
+            global_hidden = torch.randn(1, 128, 32, device=device)
+            global_target = torch.randn_like(global_hidden)
+            offsets, fragments = LAYOUTS[0]
+            plan = ContextParallelPlan.from_fragments(offsets, fragments, rank)
+            routing = plan.routing(device, **CAPS)
+            ids = plan.global_token_ids(device)
+            hidden = global_hidden[:, ids].clone().requires_grad_()
+            target = global_target[:, ids].clone()
+            with pytest.raises(ValueError, match="routing conv_history"):
+                model(hidden, routing=plan.routing(device))
+            if capture:
+                for _ in range(2):
+                    _step(model, hidden, target, routing)
+                stream.synchronize()
+                dist.barrier()
+                graph = torch.cuda.CUDAGraph()
+                with torch.cuda.graph(graph, stream=stream):
+                    captured = _step(model, hidden, target, routing)
+
+            # Return to the original routing too: no invocation may retain the preceding batch.
+            for offsets, fragments in (*LAYOUTS, LAYOUTS[0]):
+                plan = ContextParallelPlan.from_fragments(offsets, fragments, rank)
+                new_routing = plan.routing(device, **CAPS)
+                ids = plan.global_token_ids(device)
+                with torch.no_grad():
+                    hidden.copy_(global_hidden[:, ids])
+                    target.copy_(global_target[:, ids])
+                if capture:
+                    for field in fields(routing):
+                        destination = getattr(routing, field.name)
+                        source = getattr(new_routing, field.name)
+                        if isinstance(destination, torch.Tensor):
+                            destination.copy_(source)
+                        else:
+                            assert destination == source
+                    graph.replay()
+                    actual = captured
+                else:
+                    actual = _step(model, hidden, target, new_routing)
+                stream.synchronize()
+                _assert_matches_reference(
+                    model, reference, plan, global_hidden, global_target, offsets, actual
+                )
+                with torch.no_grad():
+                    output_only = model(hidden, routing=new_routing)
+                assert output_only.final_state is None and output_only.final_conv_state is None
+                torch.testing.assert_close(output_only.hidden_states, actual[0].hidden_states)
+        torch.cuda.current_stream().wait_stream(stream)
+        torch.cuda.synchronize(device)
+    finally:
+        if graph is not None:
+            graph.reset()
+        dist.destroy_process_group()
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("capture", [False, True], ids=["eager", "cuda-graph"])
+def test_same_module_uses_each_batch_routing(
+    tmp_path: Path, dtype: torch.dtype, capture: bool
+) -> None:
+    """One model must follow two incompatible layouts, including in-place graph metadata replay."""
+    mp.spawn(
+        _rank_main,
+        args=((tmp_path / "nccl-init").as_uri(), dtype, capture),
+        nprocs=2,
+        join=True,
+    )


### PR DESCRIPTION
Stacked PRs:
 * #499
 * __->__#496
 * #493
 * #492


--- --- ---

Share one stage pipeline between KDA and its context-parallel module

Move the body of KDAAttention.forward into run_stages, which forward calls after
input validation. Stage keyword arguments reach short_convolution and kda_core so a
subclass can thread per-call context through the two stateful stages.

ContextParallelKDAAttention.forward keeps routing as an explicit batch input and
now only validates, then runs the shared pipeline with routing=... Its overrides
of short_convolution and kda_core construct the convolution history and run the
context-parallel recurrence; the fixed-capacity masks, gradient barriers, Q/K
normalization metadata and projections come from the base module instead of a
duplicated forward. Routing is never stored on the module.

Validation on two GB200s (torch 2.15.0.dev20260905+cu132, CuTeDSL 4.7.1):
- pytest -n 4 test/test_kda_training_example.py test/test_kda_context_parallel_example.py:
  15 passed, including bf16/fp16 x eager/CUDA Graph routing changes against the
  unsharded reference.
- ruff check/format passed.