### PR TITLE
Add shared gate_transform op with fused softplus kernels

### DIFF
--- a/.agents/skills/validating-pytorch-custom-ops/SKILL.md
+++ b/.agents/skills/validating-pytorch-custom-ops/SKILL.md
@@ -56,6 +56,15 @@ Consequences for launch-bound paths (small kernels, high call rate):
 - Give each hot path at most one registered-operator boundary. Nested custom ops double the
   dispatch tax; share the Python launcher between entrypoint ops instead of calling one op from
   another.
+- One contract, one operator pair. When several backends (Triton portable, CuTeDSL fast) or
+  variants (a transform kind, a mode) implement the same public semantics, register a single
+  `fwd`/`bwd` pair, pass the variant as a schema argument (`str kind`, `bool`, `float`), and
+  select the backend inside the CUDA implementation on real tensors. Do not create one op pair
+  per backend or thread a `use_<backend>` flag through `autograd.Function.apply`: selection that
+  runs under Dynamo tracing specializes into the graph, trips the `functools.lru_cache` warning
+  for cached device-property helpers, and multiplies fakes, handles, and Functions. Make every
+  backend return the same output contract (e.g. already-reduced parameter gradients) so one fake
+  describes all of them. `attn_gym::_gate_transform_{fwd,bwd}` is the reference shape.
 - A `define`/`impl` op has no autograd kernel: backprop through a direct call warns and produces
   no gradient, so route all differentiable use through the `autograd.Function` wrapper.
 - `torch.library.opcheck` accepts `torch.ops.attn_gym.op.default`, so the validation workflow
@@ -172,7 +181,11 @@ Schema rules:
 The fake implementation describes output metadata without running the kernel. It must:
 
 - return the same output structure as the real implementation;
-- preserve shape, dtype, device, layout, and relevant strides;
+- preserve shape, dtype, device, layout, and relevant strides. For outputs the kernel allocates
+  fresh, use `x.new_empty(shape)` / `torch.empty(...)`, never `torch.empty_like(x)`:
+  `empty_like` preserves the strides of a dense-but-permuted input while the kernel writes a
+  contiguous result, and Inductor then fails `assert_size_stride`. Include a transposed
+  parameter (`p.t().contiguous().t()`) in the `opcheck` inputs to pin this;
 - avoid reading tensor values, storage, data pointers, or calling `.item()`;
 - use symbolic shape arithmetic rather than data-dependent Python branches.
 

--- a/attn_gym/_backends/triton/utils.py
+++ b/attn_gym/_backends/triton/utils.py
@@ -37,6 +37,11 @@ def ptr_offset(indices, strides):
 
     Only the tuple arity must be static; stride values may be runtime scalars
     (e.g. a strided token dimension), and compile-time values still fold.
+
+    Repo convention is to pass stride tuples as ``tl.constexpr``: one JIT per distinct stride
+    set (i.e. per new sequence length for a contiguous tensor) in exchange for folded address
+    math. Runtime strides measured 8-20% slower on the instruction-bound softplus gate kernel
+    (GB200, 128M elements); prefer them only when a kernel is launch-bound and sees many shapes.
     """
     tl.static_assert(len(indices) == len(strides), "indices and strides must have equal length")
     offset = 0

--- a/attn_gym/_backends/triton/utils.py
+++ b/attn_gym/_backends/triton/utils.py
@@ -11,6 +11,7 @@ import triton.language as tl
 # Kernels fold natural-log inputs into the faster exp2 with ``exp(x) == exp2(x * LOG2_E)``.
 # Wrapped as a constexpr so ``@triton.jit`` functions can reference it as a module global.
 LOG2_E = tl.constexpr(math.log2(math.e))
+LN_2 = tl.constexpr(math.log(2.0))
 
 SUPPORTS_AUTOTUNE_CACHE = "cache_results" in inspect.signature(triton.autotune).parameters
 autotune_cache_kwargs = {"cache_results": True} if SUPPORTS_AUTOTUNE_CACHE else {}

--- a/attn_gym/linear/__init__.py
+++ b/attn_gym/linear/__init__.py
@@ -9,6 +9,7 @@
 import importlib
 from typing import TYPE_CHECKING
 
+from attn_gym.linear._delta_rule.gate import gate_transform
 from attn_gym.linear.gdn import chunk_gdn, paged_chunk_gdn, recurrent_gdn, recurrent_gdn_decode
 from attn_gym.linear.kda import (
     KernelOptions,
@@ -21,7 +22,7 @@ from attn_gym.linear.kda import (
     recurrent_kda_decode,
 )
 from attn_gym.linear.short_conv import ops as _short_conv_ops
-from attn_gym.linear.types import Impl
+from attn_gym.linear.types import GateTransform, Impl
 
 # Note: Lazy Imports
 # Backend-backed names load on first use, keeping reference imports torch-only.
@@ -51,11 +52,13 @@ GDN_OPS = [
 
 # Model-agnostic building blocks.
 GENERIC_OPS = [
+    "GateTransform",
     "Impl",
     "KernelOptions",
     "active_token_mask",
     "causal_conv1d",
     "causal_conv1d_decode",
+    "gate_transform",
     "l2norm",
     "paged_causal_conv1d",
     "mask_inactive_token_gradients",

--- a/attn_gym/linear/_delta_rule/decode.py
+++ b/attn_gym/linear/_delta_rule/decode.py
@@ -31,8 +31,6 @@ gate stays per value head.
 
 from __future__ import annotations
 
-from enum import Enum
-
 import torch
 import triton
 import triton.language as tl
@@ -42,12 +40,8 @@ from attn_gym._backends.triton.utils import ptr_offset
 from attn_gym.linear._delta_rule.recurrent import GateKind
 from attn_gym.linear._delta_rule.triton.paged_state import resolve_paged_state
 
-
-class GateTransform(Enum):
-    """Pointwise transform applied to the raw gate projection in-kernel."""
-
-    BOUNDED = "bounded"  # lower_bound * sigmoid(exp(A_log) * (raw_gate + dt_bias))
-    SOFTPLUS = "softplus"  # -exp(A_log) * softplus(raw_gate + dt_bias)
+# The in-kernel transform shares its definition with the standalone ``gate_transform`` op.
+from attn_gym.linear.types import GateTransform
 
 
 def _decode_launch_config(

--- a/attn_gym/linear/_delta_rule/gate.py
+++ b/attn_gym/linear/_delta_rule/gate.py
@@ -274,7 +274,7 @@ def gate_transform(
         raise TypeError(f"fastmath must be bool, got {type(fastmath).__name__}")
     if raw_gate.dtype not in _SUPPORTED_FUSED_DTYPES or not raw_gate.is_cuda:
         raise ValueError("gate_transform(impl='fused') requires CUDA FP16, BF16, or FP32 raw_gate")
-    if not torch.compiler.is_compiling() and min(raw_gate.shape) < 1:
+    if min(raw_gate.shape) < 1:
         raise ValueError("gate_transform(impl='fused') requires nonzero raw_gate dimensions")
     if kind is GateTransform.BOUNDED and (raw_gate.ndim != 4 or raw_gate.shape[3] != 128):
         raise ValueError(

--- a/attn_gym/linear/_delta_rule/gate.py
+++ b/attn_gym/linear/_delta_rule/gate.py
@@ -1,0 +1,287 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Standalone gate transforms shared by the KDA and GDN training paths.
+
+The decode kernels evaluate the same two transforms in-kernel
+(``attn_gym.linear._delta_rule.decode``); this module is the materialized, differentiable
+version for training and prefill, where the gate is computed once and reused by the
+chunked recurrence. Transform kind and gate shape are independent axes: either kind applies
+to per-head ``[B, T, H]`` or per-channel ``[B, T, H, D]`` gates.
+"""
+
+from __future__ import annotations
+
+import importlib
+from functools import cache
+from numbers import Real
+from sys import float_info
+
+import torch
+import torch.nn.functional as F
+
+from attn_gym._backends.cute.utils import get_device_properties
+from attn_gym.linear.types import GateTransform, Impl, resolve_gate_transform, resolve_impl
+
+_SUPPORTED_FUSED_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
+
+# One operator pair covers both kinds and both fused backends; ``kind`` is an argument, so the
+# backend is chosen once per call inside the CUDA implementation on real tensors.
+torch.library.define(
+    "attn_gym::_gate_transform_fwd",
+    "(Tensor raw_gate, Tensor A_log, Tensor dt_bias, str kind, float lower_bound, bool fastmath)"
+    " -> Tensor",
+)
+torch.library.define(
+    "attn_gym::_gate_transform_bwd",
+    "(Tensor raw_gate, Tensor A_log, Tensor dt_bias, Tensor d_gate, str kind,"
+    " float lower_bound, bool fastmath) -> (Tensor, Tensor, Tensor)",
+)
+
+
+def _cute_backend(module: str):
+    try:
+        return importlib.import_module(module)
+    except ImportError as error:
+        raise ImportError(
+            "gate_transform(kind='bounded', impl='fused') requires the optional CuTeDSL backend: "
+            "pip install attn-gym[linear]"
+        ) from error
+
+
+def _triton_backend():
+    try:
+        return importlib.import_module("attn_gym.linear._delta_rule.triton.softplus_gate")
+    except ImportError as error:
+        raise ImportError(
+            "gate_transform(kind='softplus', impl='fused') requires CUDA with Triton support"
+        ) from error
+
+
+@cache
+def _cute_gate_backend_available() -> bool:
+    """Whether the CuTeDSL gate kernels import; probed once, only on an eligible call."""
+    try:
+        _cute_backend("attn_gym.linear.kda.fwd.cute.gate_fwd")
+        _cute_backend("attn_gym.linear.kda.bwd.cute.gate_bwd")
+    except ImportError:
+        return False
+    return True
+
+
+# NOTE [Softplus Backend Selection]
+# The Triton softplus kernel is portable (any CUDA device, both gate shapes, any strides) but
+# instruction-bound at roughly half of HBM bandwidth. The CuTeDSL bound-gate kernels reach the
+# bf16->fp32 cast roofline and gained a softplus specialization, but they keep the bound-gate
+# contract: per-channel gates with D=128, CUDA capability 9.0+, and the optional CuTeDSL
+# dependency. Selection runs inside the registered operator on real tensors, so it is invisible
+# to torch.compile tracing; tests pin the policy through ``_softplus_uses_cute``.
+def _softplus_uses_cute(raw_gate: torch.Tensor) -> bool:
+    """Route per-channel D=128 gates on sm90+ to the CuTeDSL kernels when they are installed."""
+    return (
+        raw_gate.ndim == 4
+        and raw_gate.shape[3] == 128
+        and get_device_properties(raw_gate.device).major >= 9
+        and _cute_gate_backend_available()
+    )
+
+
+def _gate_transform_fwd_cuda(raw_gate, A_log, dt_bias, kind, lower_bound, fastmath):
+    transform = GateTransform(kind)
+    if transform is GateTransform.SOFTPLUS and not _softplus_uses_cute(raw_gate):
+        return _triton_backend()._softplus_gate_fwd_cuda(raw_gate, A_log, dt_bias, fastmath)
+    return _cute_backend("attn_gym.linear.kda.fwd.cute.gate_fwd")._gate_transform_fwd_cuda(
+        raw_gate, A_log, dt_bias, lower_bound, fastmath, transform
+    )
+
+
+def _gate_transform_bwd_cuda(raw_gate, A_log, dt_bias, d_gate, kind, lower_bound, fastmath):
+    transform = GateTransform(kind)
+    if transform is GateTransform.SOFTPLUS and not _softplus_uses_cute(raw_gate):
+        return _triton_backend()._softplus_gate_bwd_cuda(
+            raw_gate, A_log, dt_bias, d_gate, fastmath
+        )
+    return _cute_backend("attn_gym.linear.kda.bwd.cute.gate_bwd")._gate_transform_bwd_cuda(
+        raw_gate, A_log, dt_bias, d_gate, lower_bound, fastmath, transform
+    )
+
+
+torch.library.impl("attn_gym::_gate_transform_fwd", "CUDA", _gate_transform_fwd_cuda)
+torch.library.impl("attn_gym::_gate_transform_bwd", "CUDA", _gate_transform_bwd_cuda)
+
+
+@torch.library.register_fake("attn_gym::_gate_transform_fwd")
+def _gate_transform_fwd_fake(
+    raw_gate: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    kind: str,
+    lower_bound: float,
+    fastmath: bool,
+) -> torch.Tensor:
+    """Describe the compact FP32 gate output."""
+    del A_log, dt_bias, kind, lower_bound, fastmath
+    return torch.empty(raw_gate.shape, device=raw_gate.device, dtype=torch.float32)
+
+
+@torch.library.register_fake("attn_gym::_gate_transform_bwd")
+def _gate_transform_bwd_fake(
+    raw_gate: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    d_gate: torch.Tensor,
+    kind: str,
+    lower_bound: float,
+    fastmath: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """``d_raw_gate`` in the input dtype; parameter gradients already reduced and contiguous."""
+    del d_gate, kind, lower_bound, fastmath
+    return (
+        torch.empty_like(raw_gate, memory_format=torch.contiguous_format),
+        A_log.new_empty(A_log.shape),
+        dt_bias.new_empty(dt_bias.shape),
+    )
+
+
+_gate_transform_fwd_op = torch.ops.attn_gym._gate_transform_fwd.default
+_gate_transform_bwd_op = torch.ops.attn_gym._gate_transform_bwd.default
+
+
+class _FusedGate(torch.autograd.Function):
+    """Attach the private fused forward and first-order backward operators."""
+
+    @staticmethod
+    def forward(ctx, raw_gate, A_log, dt_bias, kind, lower_bound, fastmath):
+        ctx.save_for_backward(raw_gate, A_log, dt_bias)
+        ctx.kind, ctx.lower_bound, ctx.fastmath = kind, lower_bound, fastmath
+        return _gate_transform_fwd_op(raw_gate, A_log, dt_bias, kind, lower_bound, fastmath)
+
+    @staticmethod
+    @torch.autograd.function.once_differentiable
+    def backward(ctx, d_gate):
+        raw_gate, A_log, dt_bias = ctx.saved_tensors
+        d_raw_gate, d_A_log, d_dt_bias = _gate_transform_bwd_op(
+            raw_gate, A_log, dt_bias, d_gate, ctx.kind, ctx.lower_bound, ctx.fastmath
+        )
+        return d_raw_gate, d_A_log, d_dt_bias, None, None, None
+
+
+def _validate_lower_bound(kind: GateTransform, lower_bound: float | None) -> float:
+    """Require a finite nonpositive floor for ``bounded`` and forbid one otherwise."""
+    if kind is GateTransform.SOFTPLUS:
+        if lower_bound is not None:
+            raise ValueError("lower_bound applies only to kind='bounded'")
+        # Softplus has no floor; a fixed 0.0 keeps the fused compile-cache key stable.
+        return 0.0
+    if isinstance(lower_bound, bool) or not isinstance(lower_bound, Real):
+        raise TypeError(
+            f"kind='bounded' requires a real lower_bound, got {type(lower_bound).__name__}"
+        )
+    lower_bound = float(lower_bound)
+    if not -float_info.max <= lower_bound <= 0.0:
+        raise ValueError(f"lower_bound must be finite and nonpositive, got {lower_bound}")
+    return lower_bound
+
+
+def _validate_gate_inputs(raw_gate: torch.Tensor, A_log: torch.Tensor, dt_bias: torch.Tensor):
+    """Validate the backend-neutral contract shared by both gate shapes."""
+    if raw_gate.ndim not in (3, 4):
+        raise ValueError(
+            f"raw_gate must have shape [B, T, H] or [B, T, H, D], got {tuple(raw_gate.shape)}"
+        )
+    if not raw_gate.dtype.is_floating_point:
+        raise TypeError("raw_gate must use a floating-point dtype")
+    heads = raw_gate.shape[2]
+    if A_log.shape != (heads,) or A_log.dtype != torch.float32:
+        raise ValueError(
+            f"A_log must be float32 with shape {(heads,)}, "
+            f"got {tuple(A_log.shape)} and {A_log.dtype}"
+        )
+    bias_shape = tuple(raw_gate.shape[2:])
+    if dt_bias.shape != bias_shape or dt_bias.dtype != torch.float32:
+        raise ValueError(
+            f"dt_bias must be float32 with shape {bias_shape}, "
+            f"got {tuple(dt_bias.shape)} and {dt_bias.dtype}"
+        )
+    if not all(tensor.device == raw_gate.device for tensor in (A_log, dt_bias)):
+        raise ValueError("gate_transform inputs must be on the same device")
+
+
+def _gate_transform_reference(
+    raw_gate: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    kind: GateTransform,
+    lower_bound: float,
+) -> torch.Tensor:
+    """Evaluate the transform as ordinary FP32 PyTorch operations."""
+    gate_input = raw_gate.float() + dt_bias
+    amplitude = A_log.exp().view(1, 1, -1, *([1] * (raw_gate.ndim - 3)))
+    if kind is GateTransform.BOUNDED:
+        return lower_bound * torch.sigmoid(amplitude * gate_input)
+    return -amplitude * F.softplus(gate_input)
+
+
+def gate_transform(
+    raw_gate: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    *,
+    kind: GateTransform | str,
+    lower_bound: float | None = None,
+    fastmath: bool = False,
+    impl: Impl | str = Impl.FUSED,
+) -> torch.Tensor:
+    """Map raw gate projections to per-token natural-log decays.
+
+    ``kind="bounded"`` computes ``lower_bound * sigmoid(exp(A_log) * (raw_gate + dt_bias))``
+    (Kimi/KDA convention, range ``(lower_bound, 0)``); ``kind="softplus"`` computes
+    ``-exp(A_log) * softplus(raw_gate + dt_bias)`` (Mamba2/GDN convention, unbounded below).
+    Arithmetic and output use FP32; a fused raw-gate gradient matches the input dtype. The
+    decode kernels evaluate the same transforms in-kernel from the raw projections.
+
+    Args:
+        raw_gate: Floating-point projection output shaped ``[B, T, H]`` (per-head gate) or
+            ``[B, T, H, D]`` (per-channel gate).
+        A_log: FP32 per-head log scale shaped ``[H]``.
+        dt_bias: FP32 bias shaped ``[H]`` or ``[H, D]`` to match ``raw_gate``.
+        kind: Transform kind; required so a default cannot silently select the wrong
+            recurrence convention.
+        lower_bound: Finite nonpositive floor, required by ``"bounded"`` and rejected by
+            ``"softplus"``.
+        fastmath: Use approximate fused exponentials; rejected by the reference path.
+        impl: ``"reference"`` uses ordinary PyTorch. ``"fused"`` uses private CuTeDSL kernels
+            for per-channel ``D=128`` gates on CUDA capability 9.0+ (both kinds) and a
+            portable Triton kernel for every other ``"softplus"`` configuration. Fused paths
+            require FP16, BF16, or FP32 ``raw_gate``; per-head ``"bounded"`` gates are
+            reference-only.
+
+    Raises:
+        ValueError: On shape, ``lower_bound``, or unsupported fused configurations.
+    """
+    kind = resolve_gate_transform(kind)
+    _validate_gate_inputs(raw_gate, A_log, dt_bias)
+    lower_bound = _validate_lower_bound(kind, lower_bound)
+    if resolve_impl(impl) is Impl.REFERENCE:
+        if fastmath:
+            raise ValueError("fastmath applies only to impl='fused'")
+        return _gate_transform_reference(raw_gate, A_log, dt_bias, kind, lower_bound)
+
+    if not isinstance(fastmath, bool):
+        raise TypeError(f"fastmath must be bool, got {type(fastmath).__name__}")
+    if raw_gate.dtype not in _SUPPORTED_FUSED_DTYPES or not raw_gate.is_cuda:
+        raise ValueError("gate_transform(impl='fused') requires CUDA FP16, BF16, or FP32 raw_gate")
+    if not torch.compiler.is_compiling() and min(raw_gate.shape) < 1:
+        raise ValueError("gate_transform(impl='fused') requires nonzero raw_gate dimensions")
+    if kind is GateTransform.BOUNDED and (raw_gate.ndim != 4 or raw_gate.shape[3] != 128):
+        raise ValueError(
+            "gate_transform(kind='bounded', impl='fused') requires raw_gate [B, T, H, 128]; "
+            "use impl='reference' for other shapes"
+        )
+    return _FusedGate.apply(raw_gate, A_log, dt_bias, kind.value, lower_bound, fastmath)
+
+
+__all__ = ["GateTransform", "gate_transform"]

--- a/attn_gym/linear/_delta_rule/triton/softplus_gate.py
+++ b/attn_gym/linear/_delta_rule/triton/softplus_gate.py
@@ -1,0 +1,295 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Portable fused softplus gate transform ``-exp(A_log) * softplus(raw_gate + dt_bias)``.
+
+One pointwise kernel serves per-head gates ``[B, T, H]`` and per-channel gates ``[B, T, H, D]``:
+the launcher views a per-head gate as ``D=1`` and the kernel tiles ``rows = B*T`` by
+``channels = H*D``, recovering ``(b, t, h, d)`` through compile-time strides so any input layout
+works without copies. Strides are constexpr as elsewhere in the repo: the kernel is
+instruction-bound, and runtime strides measured 8-20% slower; the cost is one JIT per distinct
+stride set (i.e. per new ``T`` for a contiguous gate). The backward is not purely pointwise:
+``d_dt_bias`` and ``d_A_log`` reduce over rows, so each program writes one FP32 partial per
+channel and the launcher finishes with ``torch.sum``, keeping the reduction deterministic
+without atomics.
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+import triton
+import triton.language as tl
+from triton.language.extra import libdevice
+
+from attn_gym._backends.triton.utils import LOG2_E, ptr_offset
+
+LN_2 = tl.constexpr(math.log(2.0))
+# Matches ``torch.nn.functional.softplus``: above this input the identity is exact in FP32.
+SOFTPLUS_THRESHOLD = tl.constexpr(20.0)
+# Elements per program with the channel block capped so narrow per-head gates (H=32) and wide
+# per-channel gates (H*128) both fill four warps; a sweep of 512-16K elements and 1-8 warps on
+# GB200 found no better point.
+ELEMENTS_PER_PROGRAM = 2048
+MAX_BLOCK_CHANNELS = 256
+
+# NOTE [Fastmath Softplus]
+# The accurate path (libdevice ``exp`` + ``log1p``, agreeing with ``F.softplus`` within FP32
+# rounding) issues ~60 instructions per element and caps this kernel at about half of HBM
+# bandwidth. The fastmath path uses the MUFU ``ex2.approx``/``lg2.approx`` intrinsics through the
+# overflow-free form ``max(s, 0) + log(1 + exp(-|s|))``, which needs no threshold branch and
+# reaches the memory roofline. Its absolute error matches FP32 eager (~6e-7 on N(0, 4) inputs);
+# relative error is large only where softplus underflows toward zero, which the downstream
+# ``exp(gate)`` cannot see. ``tl.log2`` is not a shortcut here: Triton lowers it to a
+# polynomial, not ``lg2.approx``.
+
+
+@triton.jit
+def _softplus(s, FASTMATH: tl.constexpr):
+    if FASTMATH:  # See NOTE [Fastmath Softplus]
+        return tl.maximum(s, 0.0) + libdevice.fast_log2f(1.0 + tl.exp2(-tl.abs(s) * LOG2_E)) * LN_2
+    return tl.where(s > SOFTPLUS_THRESHOLD, s, libdevice.log1p(libdevice.exp(s)))
+
+
+@triton.jit
+def _sigmoid(s, FASTMATH: tl.constexpr):
+    if FASTMATH:
+        return libdevice.fast_dividef(1.0, 1.0 + tl.exp2(-s * LOG2_E))
+    return 1.0 / (1.0 + libdevice.exp(-s))
+
+
+@triton.jit
+def _load_gate_operands(
+    raw_gate,
+    A_log,
+    dt_bias,
+    o_row,
+    o_c,
+    m_row,
+    m_c,
+    T,
+    RAW_STRIDES: tl.constexpr,
+    A_LOG_STRIDE: tl.constexpr,
+    DT_STRIDES: tl.constexpr,
+    D: tl.constexpr,
+):
+    """Return ``(s, amplitude)`` with ``s = raw + dt_bias`` in FP32 and ``amplitude = exp(A_log)``."""
+    o_h = o_c // D
+    o_d = o_c % D
+    raw = tl.load(
+        raw_gate
+        + ptr_offset(
+            ((o_row // T)[:, None], (o_row % T)[:, None], o_h[None, :], o_d[None, :]),
+            RAW_STRIDES,
+        ),
+        mask=m_row[:, None] & m_c[None, :],
+        other=0.0,
+    ).to(tl.float32)
+    bias = tl.load(dt_bias + ptr_offset((o_h, o_d), DT_STRIDES), mask=m_c, other=0.0)
+    amplitude = tl.exp(tl.load(A_log + o_h * A_LOG_STRIDE, mask=m_c, other=0.0))
+    return raw + bias[None, :], amplitude
+
+
+@triton.jit
+def softplus_gate_fwd_kernel(
+    raw_gate,
+    A_log,
+    dt_bias,
+    gate,
+    ROWS,
+    T,
+    RAW_STRIDES: tl.constexpr,
+    A_LOG_STRIDE: tl.constexpr,
+    DT_STRIDES: tl.constexpr,
+    GATE_STRIDES: tl.constexpr,
+    C: tl.constexpr,
+    D: tl.constexpr,
+    BLOCK_ROWS: tl.constexpr,
+    BLOCK_C: tl.constexpr,
+    FASTMATH: tl.constexpr,
+):
+    o_row = tl.program_id(0).to(tl.int64) * BLOCK_ROWS + tl.arange(0, BLOCK_ROWS)
+    o_c = (tl.program_id(1) * BLOCK_C + tl.arange(0, BLOCK_C)).to(tl.int64)
+    m_row = o_row < ROWS
+    m_c = o_c < C
+    s, amplitude = _load_gate_operands(
+        raw_gate,
+        A_log,
+        dt_bias,
+        o_row,
+        o_c,
+        m_row,
+        m_c,
+        T,
+        RAW_STRIDES,
+        A_LOG_STRIDE,
+        DT_STRIDES,
+        D,
+    )
+    value = -amplitude[None, :] * _softplus(s, FASTMATH)
+    tl.store(
+        gate
+        + ptr_offset(
+            ((o_row // T)[:, None], (o_row % T)[:, None], (o_c // D)[None, :], (o_c % D)[None, :]),
+            GATE_STRIDES,
+        ),
+        value,
+        mask=m_row[:, None] & m_c[None, :],
+    )
+
+
+@triton.jit
+def softplus_gate_bwd_kernel(
+    raw_gate,
+    A_log,
+    dt_bias,
+    d_gate,
+    d_raw_gate,
+    d_A_log_partial,
+    d_dt_bias_partial,
+    ROWS,
+    T,
+    RAW_STRIDES: tl.constexpr,
+    A_LOG_STRIDE: tl.constexpr,
+    DT_STRIDES: tl.constexpr,
+    D_GATE_STRIDES: tl.constexpr,
+    D_RAW_STRIDES: tl.constexpr,
+    C: tl.constexpr,
+    D: tl.constexpr,
+    BLOCK_ROWS: tl.constexpr,
+    BLOCK_C: tl.constexpr,
+    FASTMATH: tl.constexpr,
+):
+    i_row_block = tl.program_id(0).to(tl.int64)
+    o_row = i_row_block * BLOCK_ROWS + tl.arange(0, BLOCK_ROWS)
+    o_c = (tl.program_id(1) * BLOCK_C + tl.arange(0, BLOCK_C)).to(tl.int64)
+    m_row = o_row < ROWS
+    m_c = o_c < C
+    mask = m_row[:, None] & m_c[None, :]
+    s, amplitude = _load_gate_operands(
+        raw_gate,
+        A_log,
+        dt_bias,
+        o_row,
+        o_c,
+        m_row,
+        m_c,
+        T,
+        RAW_STRIDES,
+        A_LOG_STRIDE,
+        DT_STRIDES,
+        D,
+    )
+    element_offsets = (
+        (o_row // T)[:, None],
+        (o_row % T)[:, None],
+        (o_c // D)[None, :],
+        (o_c % D)[None, :],
+    )
+    grad = tl.load(d_gate + ptr_offset(element_offsets, D_GATE_STRIDES), mask=mask, other=0.0)
+    grad = grad.to(tl.float32)
+
+    # gate = -amplitude * softplus(s): d/ds = -amplitude * sigmoid(s); d/dA_log = gate.
+    d_s = -amplitude[None, :] * _sigmoid(s, FASTMATH) * grad
+    d_amplitude_log = -amplitude[None, :] * _softplus(s, FASTMATH) * grad
+    tl.store(
+        d_raw_gate + ptr_offset(element_offsets, D_RAW_STRIDES),
+        d_s.to(d_raw_gate.dtype.element_ty),
+        mask=mask,
+    )
+    # Masked rows loaded grad == 0, so they contribute exactly zero to the block partials.
+    tl.store(d_dt_bias_partial + i_row_block * C + o_c, tl.sum(d_s, 0), mask=m_c)
+    tl.store(d_A_log_partial + i_row_block * C + o_c, tl.sum(d_amplitude_log, 0), mask=m_c)
+
+
+def _launch_config(channels: int) -> tuple[int, int]:
+    """Pick ``(BLOCK_ROWS, BLOCK_C)`` so one program covers ``ELEMENTS_PER_PROGRAM`` elements."""
+    block_channels = min(triton.next_power_of_2(channels), MAX_BLOCK_CHANNELS)
+    return max(1, ELEMENTS_PER_PROGRAM // block_channels), block_channels
+
+
+def _softplus_gate_fwd_cuda(
+    raw_gate: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    fastmath: bool,
+) -> torch.Tensor:
+    """Launch the forward over any input layout and return a compact FP32 gate."""
+    shape = raw_gate.shape
+    if raw_gate.ndim == 3:  # Per-head gate: view as per-channel with D=1.
+        raw_gate, dt_bias = raw_gate.unsqueeze(-1), dt_bias.unsqueeze(-1)
+    batch, tokens, heads, head_dim = raw_gate.shape
+    rows, channels = batch * tokens, heads * head_dim
+    gate = torch.empty(raw_gate.shape, device=raw_gate.device, dtype=torch.float32)
+    block_rows, block_channels = _launch_config(channels)
+    softplus_gate_fwd_kernel[
+        (triton.cdiv(rows, block_rows), triton.cdiv(channels, block_channels))
+    ](
+        raw_gate,
+        A_log,
+        dt_bias,
+        gate,
+        rows,
+        tokens,
+        RAW_STRIDES=raw_gate.stride(),
+        A_LOG_STRIDE=A_log.stride(0),
+        DT_STRIDES=dt_bias.stride(),
+        GATE_STRIDES=gate.stride(),
+        C=channels,
+        D=head_dim,
+        BLOCK_ROWS=block_rows,
+        BLOCK_C=block_channels,
+        FASTMATH=fastmath,
+        num_warps=4,
+    )
+    return gate.view(shape)
+
+
+def _softplus_gate_bwd_cuda(
+    raw_gate: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    d_gate: torch.Tensor,
+    fastmath: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Launch the backward; returns ``(d_raw_gate, d_A_log, d_dt_bias)`` with reduced params."""
+    shape = raw_gate.shape
+    if raw_gate.ndim == 3:  # Per-head gate: view as per-channel with D=1.
+        raw_gate, dt_bias, d_gate = (t.unsqueeze(-1) for t in (raw_gate, dt_bias, d_gate))
+    batch, tokens, heads, head_dim = raw_gate.shape
+    rows, channels = batch * tokens, heads * head_dim
+    d_raw_gate = torch.empty_like(raw_gate, memory_format=torch.contiguous_format)
+    block_rows, block_channels = _launch_config(channels)
+    row_blocks = triton.cdiv(rows, block_rows)
+    d_A_log_partial = torch.empty(
+        row_blocks, channels, device=raw_gate.device, dtype=torch.float32
+    )
+    d_dt_bias_partial = torch.empty_like(d_A_log_partial)
+    softplus_gate_bwd_kernel[(row_blocks, triton.cdiv(channels, block_channels))](
+        raw_gate,
+        A_log,
+        dt_bias,
+        d_gate,
+        d_raw_gate,
+        d_A_log_partial,
+        d_dt_bias_partial,
+        rows,
+        tokens,
+        RAW_STRIDES=raw_gate.stride(),
+        A_LOG_STRIDE=A_log.stride(0),
+        DT_STRIDES=dt_bias.stride(),
+        D_GATE_STRIDES=d_gate.stride(),
+        D_RAW_STRIDES=d_raw_gate.stride(),
+        C=channels,
+        D=head_dim,
+        BLOCK_ROWS=block_rows,
+        BLOCK_C=block_channels,
+        FASTMATH=fastmath,
+        num_warps=4,
+    )
+    d_A_log = d_A_log_partial.view(row_blocks, heads, head_dim).sum((0, 2))
+    return d_raw_gate.view(shape), d_A_log, d_dt_bias_partial.sum(0).view(shape[2:])

--- a/attn_gym/linear/_delta_rule/triton/softplus_gate.py
+++ b/attn_gym/linear/_delta_rule/triton/softplus_gate.py
@@ -19,22 +19,21 @@ without atomics.
 
 from __future__ import annotations
 
-import math
-
 import torch
 import triton
 import triton.language as tl
 from triton.language.extra import libdevice
 
-from attn_gym._backends.triton.utils import LOG2_E, ptr_offset
+from attn_gym._backends.triton.utils import LN_2, LOG2_E, ptr_offset
 
-LN_2 = tl.constexpr(math.log(2.0))
 # Matches ``torch.nn.functional.softplus``: above this input the identity is exact in FP32.
 SOFTPLUS_THRESHOLD = tl.constexpr(20.0)
-# Elements per program with the channel block capped so narrow per-head gates (H=32) and wide
-# per-channel gates (H*128) both fill four warps; a sweep of 512-16K elements and 1-8 warps on
-# GB200 found no better point.
-ELEMENTS_PER_PROGRAM = 2048
+# (elements per program, warps): 16 elements per thread in both kernels, but the forward wants
+# many one-warp CTAs while the backward's per-program partial reductions want four warps. Swept
+# 256-16K elements x 1-8 warps on GB200 over per-head (H=32, 64) and per-channel (H*128) gates;
+# the channel block is capped so narrow gates still get several rows per program.
+FWD_PROGRAM = (512, 1)
+BWD_PROGRAM = (2048, 4)
 MAX_BLOCK_CHANNELS = 256
 
 # NOTE [Fastmath Softplus]
@@ -42,16 +41,21 @@ MAX_BLOCK_CHANNELS = 256
 # rounding) issues ~60 instructions per element and caps this kernel at about half of HBM
 # bandwidth. The fastmath path uses the MUFU ``ex2.approx``/``lg2.approx`` intrinsics through the
 # overflow-free form ``max(s, 0) + log(1 + exp(-|s|))``, which needs no threshold branch and
-# reaches the memory roofline. Its absolute error matches FP32 eager (~6e-7 on N(0, 4) inputs);
-# relative error is large only where softplus underflows toward zero, which the downstream
-# ``exp(gate)`` cannot see. ``tl.log2`` is not a shortcut here: Triton lowers it to a
-# polynomial, not ``lg2.approx``.
+# reaches the memory roofline. ``log2(1 + e)`` loses the tail once ``1 + e`` rounds to 1, and
+# ``exp(A_log)`` can be large enough to make that tail matter (``raw=-20, A_log=20`` gives a gate
+# of -1, not 0), so below ``SMALL_TAIL`` the tail uses its series ``e - e^2/2`` (relative error
+# ``e^2/3 < 1e-5``). With that branch the absolute error matches FP32 eager (~6e-7 on N(0, 4)
+# inputs). ``tl.log2`` is not a shortcut here: Triton lowers it to a polynomial, not
+# ``lg2.approx``.
+SMALL_TAIL = tl.constexpr(2.0**-8)
 
 
 @triton.jit
 def _softplus(s, FASTMATH: tl.constexpr):
     if FASTMATH:  # See NOTE [Fastmath Softplus]
-        return tl.maximum(s, 0.0) + libdevice.fast_log2f(1.0 + tl.exp2(-tl.abs(s) * LOG2_E)) * LN_2
+        e = tl.exp2(-tl.abs(s) * LOG2_E)
+        tail = tl.where(e < SMALL_TAIL, e - 0.5 * e * e, libdevice.fast_log2f(1.0 + e) * LN_2)
+        return tl.maximum(s, 0.0) + tail
     return tl.where(s > SOFTPLUS_THRESHOLD, s, libdevice.log1p(libdevice.exp(s)))
 
 
@@ -206,10 +210,10 @@ def softplus_gate_bwd_kernel(
     tl.store(d_A_log_partial + i_row_block * C + o_c, tl.sum(d_amplitude_log, 0), mask=m_c)
 
 
-def _launch_config(channels: int) -> tuple[int, int]:
-    """Pick ``(BLOCK_ROWS, BLOCK_C)`` so one program covers ``ELEMENTS_PER_PROGRAM`` elements."""
+def _launch_config(channels: int, elements_per_program: int) -> tuple[int, int]:
+    """Pick ``(BLOCK_ROWS, BLOCK_C)`` so one program covers ``elements_per_program`` elements."""
     block_channels = min(triton.next_power_of_2(channels), MAX_BLOCK_CHANNELS)
-    return max(1, ELEMENTS_PER_PROGRAM // block_channels), block_channels
+    return max(1, elements_per_program // block_channels), block_channels
 
 
 def _softplus_gate_fwd_cuda(
@@ -225,7 +229,8 @@ def _softplus_gate_fwd_cuda(
     batch, tokens, heads, head_dim = raw_gate.shape
     rows, channels = batch * tokens, heads * head_dim
     gate = torch.empty(raw_gate.shape, device=raw_gate.device, dtype=torch.float32)
-    block_rows, block_channels = _launch_config(channels)
+    elements_per_program, num_warps = FWD_PROGRAM
+    block_rows, block_channels = _launch_config(channels, elements_per_program)
     softplus_gate_fwd_kernel[
         (triton.cdiv(rows, block_rows), triton.cdiv(channels, block_channels))
     ](
@@ -244,7 +249,7 @@ def _softplus_gate_fwd_cuda(
         BLOCK_ROWS=block_rows,
         BLOCK_C=block_channels,
         FASTMATH=fastmath,
-        num_warps=4,
+        num_warps=num_warps,
     )
     return gate.view(shape)
 
@@ -263,7 +268,8 @@ def _softplus_gate_bwd_cuda(
     batch, tokens, heads, head_dim = raw_gate.shape
     rows, channels = batch * tokens, heads * head_dim
     d_raw_gate = torch.empty_like(raw_gate, memory_format=torch.contiguous_format)
-    block_rows, block_channels = _launch_config(channels)
+    elements_per_program, num_warps = BWD_PROGRAM
+    block_rows, block_channels = _launch_config(channels, elements_per_program)
     row_blocks = triton.cdiv(rows, block_rows)
     d_A_log_partial = torch.empty(
         row_blocks, channels, device=raw_gate.device, dtype=torch.float32
@@ -289,7 +295,7 @@ def _softplus_gate_bwd_cuda(
         BLOCK_ROWS=block_rows,
         BLOCK_C=block_channels,
         FASTMATH=fastmath,
-        num_warps=4,
+        num_warps=num_warps,
     )
     d_A_log = d_A_log_partial.view(row_blocks, heads, head_dim).sum((0, 2))
     return d_raw_gate.view(shape), d_A_log, d_dt_bias_partial.sum(0).view(shape[2:])

--- a/attn_gym/linear/kda/bwd/cute/gate_bwd.py
+++ b/attn_gym/linear/kda/bwd/cute/gate_bwd.py
@@ -4,7 +4,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""TMA CuTeDSL backward for the Kimi bounded-gate transform.
+"""TMA CuTeDSL backward for the bounded and softplus gate transforms.
+
+The softplus specialization (``gate = -a * softplus(z)``) shares the pipeline and differs only in
+the per-element math: ``d_raw = d_gate * (-a) * sigmoid(z)`` and ``dA_log = sum(d_gate * gate)``.
+The bounded transform is documented below.
 
 For raw projection output ``r``, per-head parameter ``A_log``, per-channel bias ``b``,
 and nonpositive lower bound ``L``, the model produces per-token natural-log decay as::
@@ -50,7 +54,12 @@ from attn_gym._backends.cute import (
 from attn_gym._backends.cute.device import cta_reduce_sum
 from attn_gym._backends.cute.target import get_compile_target
 from attn_gym._backends.cute.utils import requires_int64_abi
-from attn_gym.linear.kda.fwd.cute.gate_fwd import _BOUND_GATE_DTYPES, _BoundGateDType
+from attn_gym.linear.kda.fwd.cute.gate_fwd import (
+    _BOUND_GATE_DTYPES,
+    _BoundGateDType,
+    softplus_terms,
+)
+from attn_gym.linear.types import GateTransform
 from attn_gym.utils import ceildiv
 
 _TILE_TOKENS = 32
@@ -62,8 +71,8 @@ class _WarpRole(IntEnum):
     TMA_PRODUCER = 0
 
 
-class _BoundedGateBwdTmaOp:
-    """TMA-staged bounded-gate backward without a sequence scan."""
+class _GateTransformBwdTmaOp:
+    """TMA-staged gate-transform backward without a sequence scan."""
 
     def __init__(
         self,
@@ -73,13 +82,15 @@ class _BoundedGateBwdTmaOp:
         lower_bound: float,
         fastmath: bool,
         flatten_batch: bool,
-        use_int64_offsets: bool = False,
+        use_int64_offsets: bool,
+        transform: GateTransform,
     ):
         self.dtype = dtype
         self.heads = heads
         self.head_dim = head_dim
         self.chunk_size = _TILE_TOKENS
         self.lower_bound = lower_bound
+        self.transform = transform
         self.fastmath = fastmath
         self.flatten_batch = flatten_batch
         self.use_int64_offsets = use_int64_offsets
@@ -93,7 +104,7 @@ class _BoundedGateBwdTmaOp:
         """Return a stable profiler and artifact name for this specialization."""
         lower_bound = self.lower_bound.hex().replace("-", "m").replace("+", "p").replace(".", "_")
         return (
-            f"kda_bound_gate_bwd_{self.dtype.name}_h{self.heads}_d{self.head_dim}"
+            f"kda_{self.transform.value}_gate_bwd_{self.dtype.name}_h{self.heads}_d{self.head_dim}"
             f"_bt{self.chunk_size}"
             f"_lb{lower_bound}_tma_tps{self.tokens_per_stage}_s{self.stages}"
             f"_fb{int(self.flatten_batch)}_fm{int(self.fastmath)}"
@@ -267,12 +278,24 @@ class _BoundedGateBwdTmaOp:
                 local_token = subtile * self.tokens_per_stage + slot
                 if Int32(local_token) < valid:
                     z = sG[slot, tidx, stage].to(Float32) + dt_bias
-                    sigmoid = Float32(1.0) / (
-                        Float32(1.0) + cute.math.exp(-(gate_scale * z), fastmath=self.fastmath)
-                    )
-                    sigmoid_derivative = sigmoid + (-sigmoid) * sigmoid
-                    dg = sD[slot, tidx, stage] * (gradient_scale * sigmoid_derivative)
-                    dA_log = dA_log + dg * z
+                    if cutlass.const_expr(self.transform is GateTransform.SOFTPLUS):
+                        e, softplus = softplus_terms(z, self.fastmath)
+                        # sigmoid(z) from the same exponential: 1/(1+e) for z >= 0, else e/(1+e);
+                        # the product form keeps tiny gradients that 1 - 1/(1+e) would cancel.
+                        sigmoid = cute.math.rcp(Float32(1.0) + e, fastmath=self.fastmath)
+                        if z < Float32(0.0):
+                            sigmoid = e * sigmoid
+                        d_out = sD[slot, tidx, stage]
+                        dg = d_out * (-gate_scale * sigmoid)
+                        # d gate / d A_log is the gate itself.
+                        dA_log = dA_log + d_out * (-gate_scale * softplus)
+                    else:
+                        sigmoid = Float32(1.0) / (
+                            Float32(1.0) + cute.math.exp(-(gate_scale * z), fastmath=self.fastmath)
+                        )
+                        sigmoid_derivative = sigmoid + (-sigmoid) * sigmoid
+                        dg = sD[slot, tidx, stage] * (gradient_scale * sigmoid_derivative)
+                        dA_log = dA_log + dg * z
                     d_dt_bias = d_dt_bias + dg
                     mDg[batch, tile_start + Int64(local_token), head, tidx] = dg.to(
                         self.dtype.cute_type
@@ -363,17 +386,18 @@ class _BoundedGateBwdTmaOp:
 
 
 @jit_cache
-def _compile_bounded_gate_bwd(
+def _compile_gate_transform_bwd(
     dtype: _BoundGateDType,
     heads: int,
     head_dim: int,
     lower_bound: float,
     fastmath: bool,
     flatten_batch: bool,
-    use_int64_offsets: bool = False,
+    use_int64_offsets: bool,
+    transform: GateTransform,
 ):
     """Compile one fake-tensor TVM-FFI specialization."""
-    op = _BoundedGateBwdTmaOp(
+    op = _GateTransformBwdTmaOp(
         dtype,
         heads,
         head_dim,
@@ -381,6 +405,7 @@ def _compile_bounded_gate_bwd(
         fastmath,
         flatten_batch,
         use_int64_offsets=use_int64_offsets,
+        transform=transform,
     )
     target = get_compile_target()
     if target.device_type != "cuda" or target.capability is None or target.capability < (9, 0):
@@ -450,13 +475,14 @@ def _compile_bounded_gate_bwd(
     )
 
 
-def _bound_gate_bwd_cuda(
+def _gate_transform_bwd_cuda(
     raw_gate: torch.Tensor,
     A_log: torch.Tensor,
     dt_bias: torch.Tensor,
     d_gate: torch.Tensor,
     lower_bound: float,
     fastmath: bool,
+    transform: GateTransform,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Keep compilation and the CuTeDSL launcher behind an opaque operator."""
     if not tensor_supports_tma(raw_gate):
@@ -477,14 +503,14 @@ def _bound_gate_bwd_cuda(
     dtype = _BOUND_GATE_DTYPES.get(raw_gate.dtype)
     if dtype is None:
         raise TypeError(f"unsupported raw_gate dtype: {raw_gate.dtype}")
-    compiled = _compile_bounded_gate_bwd(
+    compiled = _compile_gate_transform_bwd(
         dtype,
         raw_gate.shape[2],
         raw_gate.shape[3],
         lower_bound,
         fastmath,
         raw_gate.shape[0] > 65535,
-        use_int64_offsets=requires_int64_abi(
+        requires_int64_abi(
             raw_gate,
             A_log,
             dt_bias,
@@ -493,6 +519,7 @@ def _bound_gate_bwd_cuda(
             dA_log_partial,
             d_dt_bias_partial,
         ),
+        transform,
     )
     compiled(
         raw_gate,
@@ -503,5 +530,6 @@ def _bound_gate_bwd_cuda(
         dA_log_partial,
         d_dt_bias_partial,
     )
-    # Reducing the per-chunk partials keeps the post-pass off the full [B, T, H, D] tensors.
-    return d_raw_gate, dA_log_partial, d_dt_bias_partial.sum((0, 1))
+    # Reducing the per-tile partials here keeps the post-pass off the full [B, T, H, D] tensors
+    # and gives every fused gate backend one reduced parameter-gradient contract.
+    return d_raw_gate, dA_log_partial.sum((0, 1)), d_dt_bias_partial.sum((0, 1))

--- a/attn_gym/linear/kda/fwd/cute/gate_fwd.py
+++ b/attn_gym/linear/kda/fwd/cute/gate_fwd.py
@@ -55,6 +55,9 @@ _THREADS = 128
 _VALUES_PER_THREAD = 8
 _ALIGNMENT = 16
 _LN_2 = math.log(2.0)
+# Below this ``exp(-|z|)`` the fastmath ``log2(1 + e)`` has lost the tail; see NOTE [Fastmath
+# Softplus] in attn_gym/linear/_delta_rule/triton/softplus_gate.py.
+_SMALL_TAIL = 2.0**-8
 
 
 @dataclass(frozen=True)
@@ -81,14 +84,22 @@ def softplus_terms(z, fastmath: cutlass.Constexpr[bool]):
     fastmath trades the accurate ``log1p`` for the MUFU ``ex2``/``lg2`` intrinsics.
     """
     magnitude = cute.math.abs(z)
+    is_vector = isinstance(z, cute.TensorSSA)
     if cutlass.const_expr(fastmath):
         e = cute.math.exp2(-magnitude * Float32(LOG2_E), fastmath=True)
-        tail = cute.math.log2(Float32(1.0) + e, fastmath=True) * Float32(_LN_2)
+        approx_tail = cute.math.log2(Float32(1.0) + e, fastmath=True) * Float32(_LN_2)
+        series_tail = e - Float32(0.5) * e * e
+        if cutlass.const_expr(is_vector):
+            tail = cute.where(e < Float32(_SMALL_TAIL), series_tail, approx_tail)
+        else:
+            tail = approx_tail
+            if e < Float32(_SMALL_TAIL):
+                tail = series_tail
     else:
         e = cute.math.exp(-magnitude)
         tail = cute.math.log1p(e)
     # cute.math.max needs operands of one kind: a TensorSSA zero for vectors, a scalar otherwise.
-    if cutlass.const_expr(isinstance(z, cute.TensorSSA)):
+    if cutlass.const_expr(is_vector):
         positive = cute.math.max(z, cute.zeros_like(z))
     else:
         positive = cute.math.max(z, Float32(0.0))

--- a/attn_gym/linear/kda/fwd/cute/gate_fwd.py
+++ b/attn_gym/linear/kda/fwd/cute/gate_fwd.py
@@ -4,7 +4,12 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""Direct-vector CuTeDSL forward for the Kimi bounded-gate transform.
+"""Direct-vector CuTeDSL forward for the bounded and softplus gate transforms.
+
+The transform kind is a compile-time specialization: ``lower_bound * sigmoid(a * z)`` (Kimi/KDA)
+or ``-a * softplus(z)`` (Mamba2/GDN) with ``z = raw + dt_bias`` and ``a = exp(A_log)``. Softplus
+uses the overflow-free form ``max(z, 0) + log1p(exp(-|z|))``; see NOTE [Fastmath Softplus] in
+``attn_gym/linear/_delta_rule/triton/softplus_gate.py`` for the fastmath accuracy contract.
 
 Each CTA owns eight heads of one physical token. The 128-thread/8-value thread-value map
 is::
@@ -24,6 +29,7 @@ Only an input whose last mode is noncontiguous is materialized into a supported 
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 
 import cutlass
@@ -39,6 +45,8 @@ from attn_gym._backends.cute import (
 )
 from attn_gym._backends.cute.target import get_compile_target
 from attn_gym._backends.cute.utils import requires_int64_abi
+from attn_gym.linear.kda.constants import LOG2_E
+from attn_gym.linear.types import GateTransform
 from attn_gym.utils import ceildiv
 
 _HEAD_DIM = 128
@@ -46,6 +54,7 @@ _HEADS_PER_BLOCK = 8
 _THREADS = 128
 _VALUES_PER_THREAD = 8
 _ALIGNMENT = 16
+_LN_2 = math.log(2.0)
 
 
 @dataclass(frozen=True)
@@ -63,8 +72,31 @@ _BOUND_GATE_DTYPES = {
 }
 
 
-class _BoundGateForward:
-    """Apply one bounded-gate specialization with direct vector loads and stores."""
+@cute.jit
+def softplus_terms(z, fastmath: cutlass.Constexpr[bool]):
+    """Return ``(e, softplus(z))`` with ``e = exp(-|z|)`` for scalars or vectors.
+
+    The overflow-free form ``softplus(z) = max(z, 0) + log(1 + e)`` shares its one bounded
+    exponential with ``sigmoid(|z|) = 1 / (1 + e)``, which the backward needs as well.
+    fastmath trades the accurate ``log1p`` for the MUFU ``ex2``/``lg2`` intrinsics.
+    """
+    magnitude = cute.math.abs(z)
+    if cutlass.const_expr(fastmath):
+        e = cute.math.exp2(-magnitude * Float32(LOG2_E), fastmath=True)
+        tail = cute.math.log2(Float32(1.0) + e, fastmath=True) * Float32(_LN_2)
+    else:
+        e = cute.math.exp(-magnitude)
+        tail = cute.math.log1p(e)
+    # cute.math.max needs operands of one kind: a TensorSSA zero for vectors, a scalar otherwise.
+    if cutlass.const_expr(isinstance(z, cute.TensorSSA)):
+        positive = cute.math.max(z, cute.zeros_like(z))
+    else:
+        positive = cute.math.max(z, Float32(0.0))
+    return e, positive + tail
+
+
+class _GateTransformForward:
+    """Apply one gate-transform specialization with direct vector loads and stores."""
 
     def __init__(
         self,
@@ -75,11 +107,13 @@ class _BoundGateForward:
         compact_layout: bool,
         flatten_batch: bool,
         use_int64_offsets: bool,
+        transform: GateTransform,
     ) -> None:
         self.dtype = dtype
         self.heads = heads
         self.head_groups = ceildiv(heads, _HEADS_PER_BLOCK)
         self.lower_bound = lower_bound
+        self.transform = transform
         self.fastmath = fastmath
         self.compact_layout = compact_layout
         self.flatten_batch = flatten_batch
@@ -89,7 +123,7 @@ class _BoundGateForward:
         """Return a stable profiler name for this specialization."""
         lower_bound = self.lower_bound.hex().replace("-", "m").replace("+", "p").replace(".", "_")
         return (
-            f"kda_bound_gate_fwd_{self.dtype.name}_h{self.heads}_d{_HEAD_DIM}"
+            f"kda_{self.transform.value}_gate_fwd_{self.dtype.name}_h{self.heads}_d{_HEAD_DIM}"
             f"_v{_VALUES_PER_THREAD}"
             f"_lb{lower_bound}_c{int(self.compact_layout)}_fb{int(self.flatten_batch)}"
             f"_fm{int(self.fastmath)}_i64{int(self.use_int64_offsets)}"
@@ -135,10 +169,15 @@ class _BoundGateForward:
             raw = raw_vector.load().to(Float32)
             bias = bias_vector.load()
             amplitude = cute.math.exp(A_log[head].to(Float32), fastmath=self.fastmath)
-            sigmoid = Float32(1.0) / (
-                Float32(1.0) + cute.math.exp(-(amplitude * (raw + bias)), fastmath=self.fastmath)
-            )
-            gate_vector.store(Float32(self.lower_bound) * sigmoid)
+            if cutlass.const_expr(self.transform is GateTransform.SOFTPLUS):
+                _, softplus = softplus_terms(raw + bias, self.fastmath)
+                gate_vector.store(-amplitude * softplus)
+            else:
+                sigmoid = Float32(1.0) / (
+                    Float32(1.0)
+                    + cute.math.exp(-(amplitude * (raw + bias)), fastmath=self.fastmath)
+                )
+                gate_vector.store(Float32(self.lower_bound) * sigmoid)
 
     @cute.jit
     def __call__(
@@ -171,7 +210,7 @@ def _fake_compact(dtype: type[cutlass.Numeric], shape: tuple[object, ...]):
 
 
 @jit_cache
-def _compile_bound_gate_fwd(
+def _compile_gate_transform_fwd(
     dtype: _BoundGateDType,
     heads: int,
     lower_bound: float,
@@ -179,12 +218,13 @@ def _compile_bound_gate_fwd(
     compact_layout: bool,
     flatten_batch: bool,
     use_int64_offsets: bool,
+    transform: GateTransform,
 ):
     """Compile one dynamic-batch/token TVM-FFI specialization."""
     target = get_compile_target()
     if target.device_type != "cuda" or target.capability is None or target.capability < (9, 0):
-        raise ValueError(f"bound_gate requires CUDA capability >= 9.0; got target={target}")
-    op = _BoundGateForward(
+        raise ValueError(f"gate_transform requires CUDA capability >= 9.0; got target={target}")
+    op = _GateTransformForward(
         dtype,
         heads,
         lower_bound,
@@ -192,6 +232,7 @@ def _compile_bound_gate_fwd(
         compact_layout,
         flatten_batch,
         use_int64_offsets,
+        transform,
     )
     sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
     batch = sym_int()
@@ -226,12 +267,13 @@ def _compile_bound_gate_fwd(
     )
 
 
-def _bound_gate_fwd_cuda(
+def _gate_transform_fwd_cuda(
     raw_gate: torch.Tensor,
     A_log: torch.Tensor,
     dt_bias: torch.Tensor,
     lower_bound: float,
     fastmath: bool,
+    transform: GateTransform,
 ) -> torch.Tensor:
     """Normalize vector alignment and launch the CuTeDSL forward."""
     dtype = _BOUND_GATE_DTYPES.get(raw_gate.dtype)
@@ -254,7 +296,7 @@ def _bound_gate_fwd_cuda(
         for tensor in inputs
     )
     gate = torch.empty(raw_gate.shape, device=raw_gate.device, dtype=torch.float32)
-    compiled = _compile_bound_gate_fwd(
+    compiled = _compile_gate_transform_fwd(
         dtype,
         raw_gate.shape[2],
         lower_bound,
@@ -262,6 +304,7 @@ def _bound_gate_fwd_cuda(
         compact_layout,
         raw_gate.shape[0] > 65535,
         requires_int64_abi(raw_gate, A_log, dt_bias, gate),
+        transform,
     )
     compiled(raw_gate, A_log, dt_bias, gate)
     return gate

--- a/attn_gym/linear/kda/gate.py
+++ b/attn_gym/linear/kda/gate.py
@@ -8,86 +8,10 @@
 
 from __future__ import annotations
 
-from numbers import Real
-from sys import float_info
-
 import torch
 
-from attn_gym.linear.kda.ops import _bound_gate_bwd_op, _bound_gate_fwd_op
-from attn_gym.linear.types import Impl, resolve_impl
-
-_SUPPORTED_FUSED_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
-
-
-def _validate_bound_gate_inputs(
-    raw_gate: torch.Tensor,
-    A_log: torch.Tensor,
-    dt_bias: torch.Tensor,
-    lower_bound: float,
-) -> tuple[int, int, float]:
-    """Validate the backend-neutral pointwise transform contract."""
-    if raw_gate.ndim != 4:
-        raise ValueError(f"raw_gate must have shape [B, T, H, D], got {tuple(raw_gate.shape)}")
-    _, _, heads, head_dim = raw_gate.shape
-    if not raw_gate.dtype.is_floating_point:
-        raise TypeError("raw_gate must use a floating-point dtype")
-    if A_log.shape != (heads,) or A_log.dtype != torch.float32:
-        raise ValueError(
-            f"A_log must be float32 with shape {(heads,)}, "
-            f"got {tuple(A_log.shape)} and {A_log.dtype}"
-        )
-    if dt_bias.shape != (heads, head_dim) or dt_bias.dtype != torch.float32:
-        raise ValueError(
-            f"dt_bias must be float32 with shape {(heads, head_dim)}, "
-            f"got {tuple(dt_bias.shape)} and {dt_bias.dtype}"
-        )
-    if not all(tensor.device == raw_gate.device for tensor in (A_log, dt_bias)):
-        raise ValueError("bound_gate inputs must be on the same device")
-    if isinstance(lower_bound, bool) or not isinstance(lower_bound, Real):
-        raise TypeError(f"lower_bound must be a real scalar, got {type(lower_bound).__name__}")
-    lower_bound = float(lower_bound)
-    if not -float_info.max <= lower_bound <= 0.0:
-        raise ValueError(f"lower_bound must be finite and nonpositive, got {lower_bound}")
-    return heads, head_dim, lower_bound
-
-
-def _bound_gate_reference(
-    raw_gate: torch.Tensor,
-    A_log: torch.Tensor,
-    dt_bias: torch.Tensor,
-    lower_bound: float,
-    heads: int,
-) -> torch.Tensor:
-    """Evaluate the transform as ordinary FP32 PyTorch operations."""
-    gate_input = raw_gate.float() + dt_bias
-    amplitude = A_log.exp().view(1, 1, heads, 1)
-    return lower_bound * torch.sigmoid(amplitude * gate_input)
-
-
-class _BoundGate(torch.autograd.Function):
-    """Attach the private CuTeDSL forward and first-order backward operators."""
-
-    @staticmethod
-    def forward(ctx, raw_gate, A_log, dt_bias, lower_bound, fastmath):
-        gate = _bound_gate_fwd_op(raw_gate, A_log, dt_bias, lower_bound, fastmath)
-        ctx.save_for_backward(raw_gate, A_log, dt_bias)
-        ctx.lower_bound = lower_bound
-        ctx.fastmath = fastmath
-        return gate
-
-    @staticmethod
-    @torch.autograd.function.once_differentiable
-    def backward(ctx, d_gate):
-        raw_gate, A_log, dt_bias = ctx.saved_tensors
-        d_raw_gate, dA_log_partial, d_dt_bias = _bound_gate_bwd_op(
-            raw_gate,
-            A_log,
-            dt_bias,
-            d_gate,
-            ctx.lower_bound,
-            ctx.fastmath,
-        )
-        return d_raw_gate, dA_log_partial.sum((0, 1)), d_dt_bias, None, None
+from attn_gym.linear._delta_rule.gate import gate_transform
+from attn_gym.linear.types import GateTransform, Impl
 
 
 def bound_gate(
@@ -99,8 +23,9 @@ def bound_gate(
     fastmath: bool = False,
     impl: Impl | str = Impl.FUSED,
 ) -> torch.Tensor:
-    """Map projection outputs to bounded per-token natural-log decays.
+    """Map projection outputs to bounded per-channel natural-log decays.
 
+    Equivalent to ``gate_transform(..., kind="bounded")`` restricted to per-channel gates.
     The transform is ``lower_bound * sigmoid(exp(A_log) * (raw_gate + dt_bias))``.
     Arithmetic and output use FP32; a fused raw-gate gradient matches the input dtype.
 
@@ -114,25 +39,14 @@ def bound_gate(
             kernels and requires CUDA capability 9.0 or newer, ``D=128``, and FP16, BF16,
             or FP32 logits.
     """
-    heads, head_dim, lower_bound = _validate_bound_gate_inputs(
+    if raw_gate.ndim != 4:
+        raise ValueError(f"raw_gate must have shape [B, T, H, D], got {tuple(raw_gate.shape)}")
+    return gate_transform(
         raw_gate,
         A_log,
         dt_bias,
-        lower_bound,
+        kind=GateTransform.BOUNDED,
+        lower_bound=lower_bound,
+        fastmath=fastmath,
+        impl=impl,
     )
-    selected_impl = resolve_impl(impl)
-    if selected_impl is Impl.REFERENCE:
-        if fastmath:
-            raise ValueError("fastmath applies only to impl='fused'")
-        return _bound_gate_reference(raw_gate, A_log, dt_bias, lower_bound, heads)
-
-    batch, tokens, _, _ = raw_gate.shape
-    if head_dim != 128:
-        raise ValueError("bound_gate(impl='fused') requires raw_gate with D=128")
-    if not torch.compiler.is_compiling() and min(batch, tokens, heads) < 1:
-        raise ValueError("raw_gate batch, token, and head dimensions must be nonzero")
-    if raw_gate.dtype not in _SUPPORTED_FUSED_DTYPES or not raw_gate.is_cuda:
-        raise ValueError("bound_gate(impl='fused') requires CUDA FP16, BF16, or FP32 raw_gate")
-    if not isinstance(fastmath, bool):
-        raise TypeError(f"fastmath must be bool, got {type(fastmath).__name__}")
-    return _BoundGate.apply(raw_gate, A_log, dt_bias, lower_bound, fastmath)

--- a/attn_gym/linear/kda/ops.py
+++ b/attn_gym/linear/kda/ops.py
@@ -11,9 +11,6 @@ import importlib
 
 import torch
 
-from attn_gym.utils import ceildiv
-
-_BOUND_GATE_TILE_TOKENS = 32
 _CHUNK_SIZE = 64
 
 
@@ -88,16 +85,6 @@ torch.library.define(
     "attn_gym::_kda_plain_gate_scan",
     "(Tensor values, Tensor? cu_seqlens, Tensor? chunk_offsets, bool reverse) -> Tensor",
 )
-torch.library.define(
-    "attn_gym::_kda_bound_gate_fwd",
-    "(Tensor raw_gate, Tensor A_log, Tensor dt_bias, float lower_bound, bool fastmath) -> Tensor",
-)
-torch.library.define(
-    "attn_gym::_kda_bound_gate_bwd",
-    "(Tensor raw_gate, Tensor A_log, Tensor dt_bias, Tensor d_gate, "
-    "float lower_bound, bool fastmath) -> (Tensor, Tensor, Tensor)",
-)
-
 _RECURRENT_FWD_ARGS = (
     "(Tensor q, Tensor k, Tensor v, Tensor gate, Tensor beta,"
     " Tensor? initial_state, Tensor? cu_seqlens, float scale, bool autotune)"
@@ -149,26 +136,6 @@ def _chunk_backend():
     except ImportError as error:
         raise ImportError(
             "chunk_kda(impl='fused') requires the optional CuTeDSL backend: "
-            "pip install attn-gym[linear]"
-        ) from error
-
-
-def _bound_gate_fwd_backend():
-    try:
-        return importlib.import_module("attn_gym.linear.kda.fwd.cute.gate_fwd")
-    except ImportError as error:
-        raise ImportError(
-            "bound_gate(impl='fused') requires the optional CuTeDSL backend: "
-            "pip install attn-gym[linear]"
-        ) from error
-
-
-def _bound_gate_bwd_backend():
-    try:
-        return importlib.import_module("attn_gym.linear.kda.bwd.cute.gate_bwd")
-    except ImportError as error:
-        raise ImportError(
-            "bound_gate(impl='fused') requires the optional CuTeDSL backend: "
             "pip install attn-gym[linear]"
         ) from error
 
@@ -236,14 +203,6 @@ def _plain_gate_scan_cuda(*args):
     return _plain_gate_backend()._plain_gate_scan_cuda(*args)
 
 
-def _bound_gate_fwd_cuda(*args):
-    return _bound_gate_fwd_backend()._bound_gate_fwd_cuda(*args)
-
-
-def _bound_gate_bwd_cuda(*args):
-    return _bound_gate_bwd_backend()._bound_gate_bwd_cuda(*args)
-
-
 def _recurrent_fwd_cuda(*args):
     return _recurrent_backend()._kda_recurrent_fwd_cuda(*args)
 
@@ -308,8 +267,6 @@ torch.library.impl(
     _chunk_bwd_recompute_factors_with_state_grad_cuda,
 )
 torch.library.impl("attn_gym::_kda_plain_gate_scan", "CUDA", _plain_gate_scan_cuda)
-torch.library.impl("attn_gym::_kda_bound_gate_fwd", "CUDA", _bound_gate_fwd_cuda)
-torch.library.impl("attn_gym::_kda_bound_gate_bwd", "CUDA", _bound_gate_bwd_cuda)
 torch.library.impl("attn_gym::kda_recurrent_fwd", "CUDA", _recurrent_fwd_cuda)
 torch.library.impl(
     "attn_gym::kda_recurrent_fwd_no_state",
@@ -557,42 +514,6 @@ def _plain_gate_scan_fake(
     return torch.empty_like(values, memory_format=torch.contiguous_format)
 
 
-@torch.library.register_fake("attn_gym::_kda_bound_gate_fwd")
-def _bound_gate_fwd_fake(
-    raw_gate: torch.Tensor,
-    A_log: torch.Tensor,
-    dt_bias: torch.Tensor,
-    lower_bound: float,
-    fastmath: bool,
-) -> torch.Tensor:
-    """Describe the compact FP32 gate output."""
-    del A_log, dt_bias, lower_bound, fastmath
-    return torch.empty(raw_gate.shape, device=raw_gate.device, dtype=torch.float32)
-
-
-@torch.library.register_fake("attn_gym::_kda_bound_gate_bwd")
-def _bound_gate_bwd_fake(
-    raw_gate: torch.Tensor,
-    A_log: torch.Tensor,
-    dt_bias: torch.Tensor,
-    d_gate: torch.Tensor,
-    lower_bound: float,
-    fastmath: bool,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Describe raw and reduced parameter-gradient metadata."""
-    del A_log, lower_bound, fastmath
-    partial_shape = (
-        raw_gate.shape[0],
-        ceildiv(raw_gate.shape[1], _BOUND_GATE_TILE_TOKENS),
-        raw_gate.shape[2],
-    )
-    return (
-        raw_gate.new_empty(raw_gate.shape),
-        d_gate.new_empty(partial_shape),
-        dt_bias.new_empty(dt_bias.shape),
-    )
-
-
 @torch.library.register_fake("attn_gym::kda_recurrent_fwd")
 def _recurrent_fwd_fake(
     q: torch.Tensor,
@@ -759,8 +680,6 @@ chunk_bwd_recompute_factors_with_state_grad_op = (
     torch.ops.attn_gym.kda_chunk_bwd_recompute_factors_with_state_grad.default
 )
 _plain_gate_scan_op = torch.ops.attn_gym._kda_plain_gate_scan.default
-_bound_gate_fwd_op = torch.ops.attn_gym._kda_bound_gate_fwd.default
-_bound_gate_bwd_op = torch.ops.attn_gym._kda_bound_gate_bwd.default
 recurrent_fwd_op = torch.ops.attn_gym.kda_recurrent_fwd.default
 recurrent_fwd_no_state_op = torch.ops.attn_gym.kda_recurrent_fwd_no_state.default
 recurrent_fwd_paged_op = torch.ops.attn_gym.kda_recurrent_fwd_paged.default

--- a/attn_gym/linear/types.py
+++ b/attn_gym/linear/types.py
@@ -43,4 +43,33 @@ def resolve_impl(impl: Impl | str) -> Impl:
         raise ValueError(f"unknown impl {impl!r}; expected one of {valid}") from None
 
 
-__all__ = ["BackendOptions", "Impl", "KernelOptions", "resolve_impl"]
+class GateTransform(str, Enum):
+    """Pointwise transform from a raw gate projection to a natural-log decay.
+
+    Both kinds apply to per-head (``[B, T, H]``) and per-channel (``[B, T, H, D]``) gates;
+    the kind is independent of the gate shape.
+    """
+
+    BOUNDED = "bounded"  # lower_bound * sigmoid(exp(A_log) * (raw_gate + dt_bias))
+    SOFTPLUS = "softplus"  # -exp(A_log) * softplus(raw_gate + dt_bias)
+
+
+def resolve_gate_transform(kind: GateTransform | str) -> GateTransform:
+    """Normalize a gate transform selector and report the valid values."""
+    try:
+        return GateTransform(kind)
+    except ValueError:
+        valid = ", ".join(repr(member.value) for member in GateTransform)
+        raise ValueError(
+            f"unknown gate transform kind {kind!r}; expected one of {valid}"
+        ) from None
+
+
+__all__ = [
+    "BackendOptions",
+    "GateTransform",
+    "Impl",
+    "KernelOptions",
+    "resolve_gate_transform",
+    "resolve_impl",
+]

--- a/attn_gym/testing/gdn.py
+++ b/attn_gym/testing/gdn.py
@@ -9,6 +9,8 @@ from typing import Literal
 import torch
 import torch.nn.functional as F
 
+from attn_gym.linear._delta_rule.gate import gate_transform
+
 from .kda import cumulative_sequence_offsets
 
 GatePattern = Literal[
@@ -97,7 +99,7 @@ def make_gdn_test_inputs(
             raw_gate = torch.randn(gate_shape, device="cuda", generator=generator)
             a_log = torch.linspace(-0.5, 0.5, value_heads, device="cuda")
             dt_bias = torch.linspace(-0.25, 0.25, value_heads, device="cuda")
-            gate = -a_log.exp().view(1, 1, -1) * F.softplus(raw_gate + dt_bias.view(1, 1, -1))
+            gate = gate_transform(raw_gate, a_log, dt_bias, kind="softplus", impl="reference")
         case _:
             raise ValueError(f"Unsupported gate pattern: {gate_pattern}")
 

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -134,6 +134,42 @@ elementwise kernels run per decode step.
 
 ::: attn_gym.linear.recurrent_gdn_decode
 
+## Gate Transforms
+
+`gate_transform` turns a raw gate projection into the FP32 natural-log decay consumed by the
+chunked and recurrent operations. The transform kind and the gate shape are independent:
+
+| `kind`       | formula                                              | range              |
+| ------------ | ---------------------------------------------------- | ------------------ |
+| `"bounded"`  | `lower_bound * sigmoid(exp(A_log) * (raw + dt_bias))` | `(lower_bound, 0)` |
+| `"softplus"` | `-exp(A_log) * softplus(raw + dt_bias)`              | `(-inf, 0)`        |
+
+Either kind applies to per-head gates (`raw [B, T, H]`, `dt_bias [H]`, the GDN convention) or
+per-channel gates (`raw [B, T, H, D]`, `dt_bias [H, D]`, the KDA convention). `kind` is
+required: a default could silently select the wrong recurrence convention. `bound_gate` is the
+KDA-specific spelling of `kind="bounded"` for per-channel gates with `lower_bound=-5.0`.
+
+`impl="fused"` has a portable and a fast route. Per-channel `D=128` gates on CUDA capability
+9.0+ use the CuTeDSL kernels for both kinds (near the bf16->fp32 cast roofline with
+`fastmath=True`); every other `"softplus"` configuration uses a portable Triton kernel, and
+per-head `"bounded"` gates are reference-only. Both backwards reduce the `A_log` and `dt_bias`
+gradients in FP32 from per-block partials, so they are deterministic. The
+decode kernels (`recurrent_kda_decode`, `recurrent_gdn_decode`) evaluate the same transforms
+in-kernel from the raw projections and do not call this operation. Unbounded softplus gates
+exceed the finite range some fused chunk-KDA schedules assume; keep per-channel softplus
+gates for backends that document support for it.
+
+```python
+from attn_gym.linear import chunk_gdn, gate_transform
+
+gate = gate_transform(raw_gate, A_log, dt_bias, kind="softplus")
+output, final_state = chunk_gdn(q, k, v, gate, beta, impl="fused")
+```
+
+::: attn_gym.linear.gate_transform
+
+::: attn_gym.linear.GateTransform
+
 ## Stateful Short Convolution
 
 `causal_conv1d` is the differentiable dense or packed operation. It accepts compact

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -19,3 +19,16 @@ shape/dtype/seed conventions of an existing one — add or extend it in
 style helpers are fine only for operand sets no shared factory covers. Numerical kernel
 contracts should pair a pointwise maximum-error check with an aggregate relative-RMS check;
 either metric alone can hide a different class of regression.
+
+## Optional backends and hardware gates
+
+The repo advertises portable fallbacks (Triton, reference) next to optional fast paths
+(CuTeDSL on sm90+/sm100). A test must not assume the fast path is selected just because the
+shape qualifies: gate fast-path-only tests with a module-level capability constant (see
+`CUTE_CAPABLE` in `test/test_kda_int64_offsets.py` and `test/test_gate_transform.py`) and assert
+the production selector's choice (`selector(inputs) == expected and CUTE_CAPABLE`) so the
+portable route is tested on machines without the optional dependency.
+
+Extreme-input tests must compare values, including every gradient, against the reference, not
+only `isfinite`. Overflow-safe rewrites (`max(z, 0) + log1p(exp(-|z|))`) and cancellation-prone
+forms (`1 - 1/(1+e)` for large negative logits) both pass a finiteness check while being wrong.

--- a/test/test_gate_transform.py
+++ b/test/test_gate_transform.py
@@ -198,18 +198,28 @@ def test_fused_softplus_matches_reference(shape: str, dtype: torch.dtype, fastma
 
 @pytest.mark.parametrize("shape", [SCALAR, VECTOR128])
 @pytest.mark.parametrize("fastmath", [False, True])
-def test_fused_softplus_extreme_logits(shape: str, fastmath: bool):
-    """Huge logits stay finite and tiny negative-logit gradients survive on both backends.
+@pytest.mark.parametrize(
+    ("logits", "a_log"),
+    [
+        pytest.param((3e38, -20.0, 80.0), 0.0, id="huge-logits"),
+        pytest.param((-20.0, -12.0, -8.0), 20.0, id="large-amplitude-small-tail"),
+    ],
+)
+def test_fused_softplus_extreme_logits(
+    shape: str, fastmath: bool, logits: tuple[float, ...], a_log: float
+):
+    """Extreme logits match the reference, with gradients, on both backends.
 
-    Regression: ``(z + |z|) / 2`` overflows for ``z > FLT_MAX / 2`` and ``1 - 1/(1+e)`` cancels
-    the ``sigmoid(z)`` factor to zero for ``z <= -17``.
+    Regressions: ``(z + |z|) / 2`` overflows for ``z > FLT_MAX / 2``; ``1 - 1/(1+e)`` cancels the
+    ``sigmoid(z)`` factor to zero for ``z <= -17``; fastmath ``log2(1 + e)`` rounds the softplus
+    tail to zero, which ``exp(A_log)`` amplifies (``raw=-20, A_log=20`` is a gate of -1, not 0).
     """
     raw_gate, A_log, dt_bias = make_gate_inputs(shape, dtype=torch.float32, requires_grad=True)
     with torch.no_grad():
-        raw_gate[:, 0::3] = 3e38
-        raw_gate[:, 1::3] = -20.0
-        raw_gate[:, 2::3] = 80.0
-        A_log.zero_()
+        for offset, logit in enumerate(logits):
+            raw_gate[:, offset::3] = logit
+        dt_bias.zero_()
+        A_log.fill_(a_log)
     actual = gate_transform(raw_gate, A_log, dt_bias, kind="softplus", fastmath=fastmath)
     expected = gate_transform(raw_gate, A_log, dt_bias, kind="softplus", impl="reference")
     assert torch.isfinite(actual).all()
@@ -217,8 +227,7 @@ def test_fused_softplus_extreme_logits(shape: str, fastmath: bool):
     cotangent = torch.ones_like(expected)
     expected_gradients = torch.autograd.grad(expected, (raw_gate, A_log, dt_bias), cotangent)
     actual_gradients = torch.autograd.grad(actual, (raw_gate, A_log, dt_bias), cotangent)
-    negative_rows = raw_gate[:, 1::3]
-    assert (expected_gradients[0][:, 1::3] != 0).all() and negative_rows.numel() > 0
+    assert (expected_gradients[0][:, 1::3] != 0).all()
     for actual_gradient, expected_gradient in zip(
         actual_gradients, expected_gradients, strict=True
     ):
@@ -368,7 +377,7 @@ def test_fused_softplus_fullgraph_dynamic_tokens(shape: str):
 def test_bound_gate_is_bounded_gate_transform():
     """``bound_gate`` keeps its per-channel contract and equals ``kind="bounded"``."""
     inputs = make_gate_inputs(VECTOR128)
-    for impl in ("reference", "fused"):
+    for impl in ("reference", "fused") if CUTE_CAPABLE else ("reference",):
         expected = gate_transform(*inputs, kind="bounded", lower_bound=-3.25, impl=impl)
         actual = bound_gate(*inputs, lower_bound=-3.25, impl=impl)
         torch.testing.assert_close(actual, expected, rtol=0, atol=0)

--- a/test/test_gate_transform.py
+++ b/test/test_gate_transform.py
@@ -1,0 +1,405 @@
+"""Shared gate transform semantics: kind x shape references and the fused softplus kernel."""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from attn_gym.linear import GateTransform, chunk_gdn, gate_transform
+from attn_gym.linear._delta_rule.gate import (
+    _gate_transform_bwd_op,
+    _gate_transform_fwd_op,
+    _softplus_uses_cute,
+)
+from attn_gym.linear.kda import bound_gate
+from attn_gym.testing.gdn import make_gdn_test_inputs
+from attn_gym.testing.kda import assert_relative_rms_within, clone_kda_inputs
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="gate ops require CUDA")
+
+SCALAR = "scalar"
+VECTOR = "vector"
+# Per-channel D=128 gates route to the CuTeDSL kernels on sm90+; other shapes use Triton.
+VECTOR128 = "vector128"
+FUSED_SHAPES = [SCALAR, VECTOR, VECTOR128]
+HEAD_DIMS = {SCALAR: None, VECTOR: 40, VECTOR128: 128}
+CUTE_CAPABLE = (
+    torch.cuda.is_available()
+    and torch.cuda.get_device_capability()[0] >= 9
+    and importlib.util.find_spec("cutlass") is not None
+)
+requires_cute = pytest.mark.skipif(
+    not CUTE_CAPABLE, reason="CuTeDSL gate kernels require CuTeDSL and CUDA capability >= 9.0"
+)
+
+
+def uses_cute(shape: str) -> bool:
+    """Expected backend routing for a fused softplus gate of this shape."""
+    return shape == VECTOR128 and CUTE_CAPABLE
+
+
+def make_gate_inputs(
+    shape: str,
+    *,
+    dtype: torch.dtype = torch.bfloat16,
+    batch: int = 2,
+    tokens: int = 65,
+    heads: int = 3,
+    head_dim: int = 40,
+    requires_grad: bool = False,
+    seed: int = 23,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Return ``(raw_gate, A_log, dt_bias)`` for a per-head or per-channel gate."""
+    torch.manual_seed(seed)
+    head_dim = HEAD_DIMS[shape] or head_dim
+    trailing = (heads,) if shape == SCALAR else (heads, head_dim)
+    return (
+        torch.randn(batch, tokens, *trailing, device="cuda", dtype=dtype).requires_grad_(
+            requires_grad
+        ),
+        torch.randn(heads, device="cuda").requires_grad_(requires_grad),
+        torch.randn(*trailing, device="cuda").requires_grad_(requires_grad),
+    )
+
+
+def expected_gate(raw_gate, A_log, dt_bias, kind, lower_bound=None):
+    """Independent formula in FP64."""
+    s = raw_gate.double() + dt_bias.double()
+    amplitude = A_log.double().exp().view(1, 1, -1, *([1] * (raw_gate.ndim - 3)))
+    if kind == "bounded":
+        return lower_bound * torch.sigmoid(amplitude * s)
+    return -amplitude * F.softplus(s)
+
+
+@pytest.mark.parametrize("shape", [SCALAR, VECTOR])
+@pytest.mark.parametrize("kind", ["bounded", "softplus"])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_reference_matches_formula(shape: str, kind: str, dtype: torch.dtype):
+    """Pin both formulas on both shapes; output is FP32 regardless of input precision."""
+    inputs = make_gate_inputs(shape, dtype=dtype)
+    lower_bound = -3.25 if kind == "bounded" else None
+    actual = gate_transform(*inputs, kind=kind, lower_bound=lower_bound, impl="reference")
+    assert actual.dtype == torch.float32
+    assert actual.shape == inputs[0].shape
+    expected = expected_gate(*inputs, kind, lower_bound)
+    torch.testing.assert_close(actual.double(), expected, rtol=1e-6, atol=1e-6)
+    if kind == "softplus":
+        assert (actual <= 0).all()
+    else:
+        assert ((actual >= lower_bound) & (actual <= 0)).all()
+
+
+def test_kind_is_required_and_validated():
+    inputs = make_gate_inputs(SCALAR)
+    with pytest.raises(TypeError):
+        gate_transform(*inputs)  # type: ignore[call-arg]
+    with pytest.raises(ValueError, match="gate transform kind"):
+        gate_transform(*inputs, kind="sigmoid")
+    assert gate_transform(*inputs, kind=GateTransform.SOFTPLUS, impl="reference").shape
+
+
+def test_lower_bound_rules():
+    inputs = make_gate_inputs(SCALAR)
+    with pytest.raises(ValueError, match="lower_bound applies only"):
+        gate_transform(*inputs, kind="softplus", lower_bound=-5.0, impl="reference")
+    with pytest.raises(TypeError, match="requires a real lower_bound"):
+        gate_transform(*inputs, kind="bounded", impl="reference")
+    for invalid in (1.0, float("-inf"), float("nan")):
+        with pytest.raises(ValueError, match="lower_bound"):
+            gate_transform(*inputs, kind="bounded", lower_bound=invalid, impl="reference")
+    with pytest.raises(TypeError, match="lower_bound"):
+        gate_transform(*inputs, kind="bounded", lower_bound=True, impl="reference")
+
+
+def test_shape_and_dtype_validation():
+    raw_gate, A_log, dt_bias = make_gate_inputs(VECTOR)
+    with pytest.raises(ValueError, match=r"raw_gate must have shape"):
+        gate_transform(raw_gate[0, 0], A_log, dt_bias, kind="softplus")
+    with pytest.raises(ValueError, match="A_log"):
+        gate_transform(raw_gate, A_log.half(), dt_bias, kind="softplus")
+    with pytest.raises(ValueError, match="dt_bias"):
+        gate_transform(raw_gate, A_log, dt_bias[:, 0], kind="softplus")
+    with pytest.raises(ValueError, match="dt_bias"):
+        gate_transform(raw_gate[..., 0], A_log, dt_bias, kind="softplus")
+    with pytest.raises(TypeError, match="floating-point"):
+        gate_transform(raw_gate.int(), A_log, dt_bias, kind="softplus")
+    with pytest.raises(ValueError, match="same device"):
+        gate_transform(raw_gate, A_log.cpu(), dt_bias, kind="softplus")
+    with pytest.raises(ValueError, match="fastmath"):
+        gate_transform(raw_gate, A_log, dt_bias, kind="softplus", impl="reference", fastmath=True)
+
+
+def test_fused_rejections():
+    raw_gate, A_log, dt_bias = make_gate_inputs(SCALAR)
+    with pytest.raises(ValueError, match="nonzero"):
+        gate_transform(raw_gate[:, :0], A_log, dt_bias, kind="softplus")
+    with pytest.raises(ValueError, match="CUDA FP16, BF16, or FP32"):
+        gate_transform(raw_gate.double(), A_log, dt_bias, kind="softplus")
+    with pytest.raises(ValueError, match="CUDA FP16, BF16, or FP32"):
+        gate_transform(raw_gate.cpu(), A_log.cpu(), dt_bias.cpu(), kind="softplus")
+    with pytest.raises(TypeError, match="fastmath"):
+        gate_transform(raw_gate, A_log, dt_bias, kind="softplus", fastmath=1)
+    # Stage 1 fuses bounded gates only through the CuTeDSL per-channel D=128 kernel.
+    with pytest.raises(ValueError, match="use impl='reference'"):
+        gate_transform(raw_gate, A_log, dt_bias, kind="bounded", lower_bound=-5.0)
+    vector = make_gate_inputs(VECTOR, head_dim=40)
+    with pytest.raises(ValueError, match="use impl='reference'"):
+        gate_transform(*vector, kind="bounded", lower_bound=-5.0)
+
+
+@pytest.mark.parametrize("shape", FUSED_SHAPES)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("fastmath", [False, True])
+def test_fused_softplus_matches_reference(shape: str, dtype: torch.dtype, fastmath: bool):
+    """Forward and all three gradients on partial row and channel blocks, both backends."""
+    expected_inputs = make_gate_inputs(shape, dtype=dtype, requires_grad=True)
+    assert _softplus_uses_cute(expected_inputs[0]) == uses_cute(shape)
+    actual_inputs = clone_kda_inputs(expected_inputs)
+    expected = gate_transform(*expected_inputs, kind="softplus", impl="reference")
+    actual = gate_transform(*actual_inputs, kind="softplus", fastmath=fastmath)
+    assert actual.dtype == torch.float32
+    forward_tolerance = 1e-5 if fastmath else 2e-6
+    torch.testing.assert_close(actual, expected, rtol=forward_tolerance, atol=forward_tolerance)
+    assert_relative_rms_within(actual, expected, "gate", max_eps=1.0, source_dtype=torch.float32)
+
+    cotangent = torch.randn_like(expected)
+    expected_gradients = torch.autograd.grad(expected, expected_inputs, cotangent)
+    actual_gradients = torch.autograd.grad(actual, actual_inputs, cotangent)
+    assert actual_gradients[0].dtype == dtype
+    assert actual_gradients[1].shape == expected_inputs[1].shape
+    assert actual_gradients[2].shape == expected_inputs[2].shape
+    # d_raw_gate rounds to the input dtype. The parameter gradients reduce over B*T (and D)
+    # in FP32 with a different summation order than eager, so their aggregate budget scales
+    # with sqrt(reduction size).
+    batch, tokens = expected.shape[:2]
+    reduction_sizes = (1, expected[0, 0, 0].numel() * batch * tokens, batch * tokens)
+    tolerances = (
+        {"rtol": 1e-2, "atol": 8e-3},
+        {"rtol": 3e-4, "atol": 3e-4},
+        {"rtol": 3e-4, "atol": 3e-4},
+    )
+    names = ("d_raw_gate", "d_A_log", "d_dt_bias")
+    for name, actual_gradient, expected_gradient, tolerance, reduction_size in zip(
+        names, actual_gradients, expected_gradients, tolerances, reduction_sizes, strict=True
+    ):
+        torch.testing.assert_close(actual_gradient, expected_gradient, **tolerance)
+        assert_relative_rms_within(
+            actual_gradient.float(),
+            expected_gradient.float(),
+            name,
+            max_eps=4.0 * math.sqrt(reduction_size),
+            source_dtype=dtype if name == "d_raw_gate" else torch.float32,
+        )
+
+
+@pytest.mark.parametrize("shape", [SCALAR, VECTOR128])
+@pytest.mark.parametrize("fastmath", [False, True])
+def test_fused_softplus_extreme_logits(shape: str, fastmath: bool):
+    """Huge logits stay finite and tiny negative-logit gradients survive on both backends.
+
+    Regression: ``(z + |z|) / 2`` overflows for ``z > FLT_MAX / 2`` and ``1 - 1/(1+e)`` cancels
+    the ``sigmoid(z)`` factor to zero for ``z <= -17``.
+    """
+    raw_gate, A_log, dt_bias = make_gate_inputs(shape, dtype=torch.float32, requires_grad=True)
+    with torch.no_grad():
+        raw_gate[:, 0::3] = 3e38
+        raw_gate[:, 1::3] = -20.0
+        raw_gate[:, 2::3] = 80.0
+        A_log.zero_()
+    actual = gate_transform(raw_gate, A_log, dt_bias, kind="softplus", fastmath=fastmath)
+    expected = gate_transform(raw_gate, A_log, dt_bias, kind="softplus", impl="reference")
+    assert torch.isfinite(actual).all()
+    torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-5)
+    cotangent = torch.ones_like(expected)
+    expected_gradients = torch.autograd.grad(expected, (raw_gate, A_log, dt_bias), cotangent)
+    actual_gradients = torch.autograd.grad(actual, (raw_gate, A_log, dt_bias), cotangent)
+    negative_rows = raw_gate[:, 1::3]
+    assert (expected_gradients[0][:, 1::3] != 0).all() and negative_rows.numel() > 0
+    for actual_gradient, expected_gradient in zip(
+        actual_gradients, expected_gradients, strict=True
+    ):
+        torch.testing.assert_close(actual_gradient, expected_gradient, rtol=1e-4, atol=1e-6)
+
+
+@requires_cute
+@pytest.mark.parametrize(
+    ("batch", "tokens", "heads"),
+    [
+        pytest.param(1, 1, 1, id="minimum"),
+        pytest.param(1, 32, 9, id="exact-token-tile-ragged-head-group"),
+        pytest.param(65536, 1, 1, id="flattened-batch-grid"),
+    ],
+)
+def test_cute_softplus_boundary_shapes(batch: int, tokens: int, heads: int):
+    """The CuTeDSL softplus specialization on the forward head-group and TMA tile boundaries."""
+    inputs = make_gate_inputs(
+        VECTOR128, batch=batch, tokens=tokens, heads=heads, requires_grad=True
+    )
+    assert _softplus_uses_cute(inputs[0])
+    actual_inputs = clone_kda_inputs(inputs)
+    expected = gate_transform(*inputs, kind="softplus", impl="reference")
+    actual = gate_transform(*actual_inputs, kind="softplus")
+    torch.testing.assert_close(actual, expected, rtol=2e-6, atol=2e-6)
+    cotangent = torch.randn_like(expected)
+    expected_gradients = torch.autograd.grad(expected, inputs, cotangent)
+    actual_gradients = torch.autograd.grad(actual, actual_inputs, cotangent)
+    for actual_gradient, expected_gradient in zip(
+        actual_gradients, expected_gradients, strict=True
+    ):
+        # d_raw_gate rounds to bf16 (one ulp at |g|~4 is 0.03); parameter gradients are FP32.
+        torch.testing.assert_close(
+            actual_gradient.float(), expected_gradient.float(), rtol=1e-2, atol=1e-2
+        )
+
+
+@pytest.mark.parametrize("shape", FUSED_SHAPES)
+def test_fused_softplus_supports_strided_inputs(shape: str):
+    """Strided raw gates and cotangents are handled (in place by Triton, normalized by CuTeDSL)."""
+    raw_gate, A_log, dt_bias = make_gate_inputs(shape, heads=4, head_dim=48, requires_grad=True)
+    # Slice heads and (for vector gates) channels out of a wider projection buffer; the
+    # views stay differentiable so both paths see identical strided operands.
+    views = [raw_gate[:, :, 1:3], A_log[1:3], dt_bias[1:3]]
+    if shape == VECTOR:
+        views[0] = views[0][..., ::2]
+        views[2] = views[2][:, ::2]
+    assert not views[0].is_contiguous()
+    assert _softplus_uses_cute(views[0]) == uses_cute(shape)
+    expected = gate_transform(*views, kind="softplus", impl="reference")
+    actual = gate_transform(*views, kind="softplus")
+    torch.testing.assert_close(actual, expected, rtol=2e-6, atol=2e-6)
+    cotangent = torch.randn(*expected.shape, 2, device="cuda")[..., 0]
+    assert not cotangent.is_contiguous()
+    expected_gradients = torch.autograd.grad(expected, views, cotangent)
+    actual_gradients = torch.autograd.grad(actual, views, cotangent)
+    assert actual_gradients[0].is_contiguous()
+    for actual_gradient, expected_gradient in zip(
+        actual_gradients, expected_gradients, strict=True
+    ):
+        torch.testing.assert_close(
+            actual_gradient.float(), expected_gradient.float(), rtol=3e-3, atol=8e-3
+        )
+
+
+@pytest.mark.parametrize("shape", FUSED_SHAPES)
+def test_operator_registration(shape: str):
+    """Validate the shared operators' schema and fakes, including a permuted ``dt_bias``."""
+    utilities = ("test_schema", "test_faketensor", "test_aot_dispatch_dynamic")
+    raw_gate, A_log, dt_bias = make_gate_inputs(shape, tokens=33)
+    d_gate = torch.randn(raw_gate.shape, device="cuda")
+    kinds = [("softplus", 0.0)]
+    if shape == VECTOR128 and CUTE_CAPABLE:
+        kinds.append(("bounded", -5.0))
+    if dt_bias.ndim == 2:
+        dt_bias = (
+            dt_bias.t().contiguous().t()
+        )  # Dense but permuted: the fake must still be compact.
+    for kind, lower_bound in kinds:
+        torch.library.opcheck(
+            _gate_transform_fwd_op,
+            (raw_gate, A_log, dt_bias, kind, lower_bound, False),
+            test_utils=utilities,
+        )
+        torch.library.opcheck(
+            _gate_transform_bwd_op,
+            (raw_gate, A_log, dt_bias, d_gate, kind, lower_bound, False),
+            test_utils=utilities,
+        )
+
+
+@requires_cute
+@pytest.mark.parametrize("fastmath", [False, True])
+def test_softplus_backends_agree_on_d128(fastmath: bool):
+    """The CuTeDSL and Triton softplus launchers implement one contract on the shared shape."""
+    from attn_gym.linear._delta_rule.triton import softplus_gate as triton_backend
+    from attn_gym.linear.kda.bwd.cute import gate_bwd as cute_bwd
+    from attn_gym.linear.kda.fwd.cute import gate_fwd as cute_fwd
+
+    raw_gate, A_log, dt_bias = make_gate_inputs(VECTOR128, tokens=97)
+    d_gate = torch.randn(raw_gate.shape, device="cuda")
+    softplus = GateTransform.SOFTPLUS
+    cute_gate = cute_fwd._gate_transform_fwd_cuda(
+        raw_gate, A_log, dt_bias, 0.0, fastmath, softplus
+    )
+    triton_gate = triton_backend._softplus_gate_fwd_cuda(raw_gate, A_log, dt_bias, fastmath)
+    torch.testing.assert_close(cute_gate, triton_gate, rtol=1e-5, atol=1e-5)
+    cute_grads = cute_bwd._gate_transform_bwd_cuda(
+        raw_gate, A_log, dt_bias, d_gate, 0.0, fastmath, softplus
+    )
+    triton_grads = triton_backend._softplus_gate_bwd_cuda(
+        raw_gate, A_log, dt_bias, d_gate, fastmath
+    )
+    for name, cute_grad, triton_grad in zip(
+        ("d_raw_gate", "d_A_log", "d_dt_bias"), cute_grads, triton_grads, strict=True
+    ):
+        torch.testing.assert_close(
+            cute_grad.float(), triton_grad.float(), rtol=3e-3, atol=3e-3, msg=name
+        )
+
+
+@pytest.mark.parametrize("shape", [SCALAR, VECTOR128])
+def test_fused_softplus_fullgraph_dynamic_tokens(shape: str):
+    """Reuse one fullgraph callable across batch and token sizes with backward, both backends."""
+    torch.compiler.reset()
+    with torch._dynamo.config.patch(error_on_recompile=True):
+        compiled = torch.compile(gate_transform, fullgraph=True, dynamic=True)
+        for batch, tokens in ((2, 65), (3, 97)):
+            expected_inputs = make_gate_inputs(
+                shape, batch=batch, tokens=tokens, requires_grad=True, seed=tokens
+            )
+            actual_inputs = clone_kda_inputs(expected_inputs)
+            expected = gate_transform(*expected_inputs, kind="softplus", impl="reference")
+            actual = compiled(*actual_inputs, kind="softplus")
+            torch.testing.assert_close(actual, expected, rtol=2e-6, atol=2e-6)
+            cotangent = torch.randn_like(expected)
+            expected_gradients = torch.autograd.grad(expected, expected_inputs, cotangent)
+            actual_gradients = torch.autograd.grad(actual, actual_inputs, cotangent)
+            for actual_gradient, expected_gradient in zip(
+                actual_gradients, expected_gradients, strict=True
+            ):
+                torch.testing.assert_close(
+                    actual_gradient.float(), expected_gradient.float(), rtol=3e-3, atol=8e-3
+                )
+
+
+def test_bound_gate_is_bounded_gate_transform():
+    """``bound_gate`` keeps its per-channel contract and equals ``kind="bounded"``."""
+    inputs = make_gate_inputs(VECTOR128)
+    for impl in ("reference", "fused"):
+        expected = gate_transform(*inputs, kind="bounded", lower_bound=-3.25, impl=impl)
+        actual = bound_gate(*inputs, lower_bound=-3.25, impl=impl)
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    scalar = make_gate_inputs(SCALAR)
+    with pytest.raises(ValueError, match=r"\[B, T, H, D\]"):
+        bound_gate(*scalar, impl="reference")
+    assert gate_transform(*scalar, kind="bounded", lower_bound=-5.0, impl="reference").shape
+
+
+def test_chunk_gdn_accepts_fused_softplus_gate():
+    """A fused gate feeds ``chunk_gdn`` identically to the hand-built eager gate, both ways."""
+    q, k, v, _, beta, initial_state, _ = make_gdn_test_inputs(
+        96, batch=2, value_heads=4, dtype=torch.bfloat16
+    )
+    raw_gate, A_log, dt_bias = make_gate_inputs(
+        SCALAR, dtype=torch.bfloat16, batch=2, tokens=96, heads=4, requires_grad=True
+    )
+    eager_leaves = clone_kda_inputs((raw_gate, A_log, dt_bias))
+    eager_gate = -eager_leaves[1].exp().view(1, 1, -1) * F.softplus(
+        eager_leaves[0].float() + eager_leaves[2].view(1, 1, -1)
+    )
+    fused_gate = gate_transform(raw_gate, A_log, dt_bias, kind="softplus")
+    expected, _ = chunk_gdn(q, k, v, eager_gate, beta, initial_state)
+    actual, _ = chunk_gdn(q, k, v, fused_gate, beta, initial_state)
+    torch.testing.assert_close(actual, expected, rtol=1e-3, atol=1e-3)
+    cotangent = torch.randn_like(expected)
+    expected_gradients = torch.autograd.grad(expected, eager_leaves, cotangent)
+    actual_gradients = torch.autograd.grad(actual, (raw_gate, A_log, dt_bias), cotangent)
+    for actual_gradient, expected_gradient in zip(
+        actual_gradients, expected_gradients, strict=True
+    ):
+        torch.testing.assert_close(
+            actual_gradient.float(), expected_gradient.float(), rtol=2e-3, atol=2e-3
+        )

--- a/test/test_kda_gate_semantics.py
+++ b/test/test_kda_gate_semantics.py
@@ -11,15 +11,12 @@ import torch.nn.functional as F
 
 pytest.importorskip("cutlass")
 
+from attn_gym.linear._delta_rule.gate import _gate_transform_bwd_op, _gate_transform_fwd_op
 from attn_gym.linear.kda import bound_gate, chunk_kda
 from attn_gym.linear.kda.chunk_scheduler import prepare_ragged_chunk_metadata
 from attn_gym.linear.kda.constants import LOG2_E, MAX_GATE_LOWER_BOUND_MAGNITUDE
 from attn_gym.linear.kda.naive import chunk_cumsum_ref
-from attn_gym.linear.kda.ops import (
-    _bound_gate_bwd_op,
-    _bound_gate_fwd_op,
-    _plain_gate_scan_op,
-)
+from attn_gym.linear.kda.ops import _plain_gate_scan_op
 from attn_gym.testing.kda import cumulative_sequence_offsets
 
 pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="KDA gate ops require CUDA")
@@ -253,13 +250,13 @@ def test_bound_gate_operator_registration():
     d_gate = torch.randn(shape, device="cuda")
     utilities = ("test_schema", "test_faketensor", "test_aot_dispatch_dynamic")
     torch.library.opcheck(
-        _bound_gate_fwd_op,
-        (raw_gate, a_log, dt_bias, -5.0, False),
+        _gate_transform_fwd_op,
+        (raw_gate, a_log, dt_bias, "bounded", -5.0, False),
         test_utils=utilities,
     )
     torch.library.opcheck(
-        _bound_gate_bwd_op,
-        (raw_gate, a_log, dt_bias, d_gate, -5.0, False),
+        _gate_transform_bwd_op,
+        (raw_gate, a_log, dt_bias, d_gate, "bounded", -5.0, False),
         test_utils=utilities,
     )
 

--- a/test/test_namespaces.py
+++ b/test/test_namespaces.py
@@ -1,6 +1,8 @@
 import subprocess
 import sys
 
+import pytest
+
 import attn_gym
 import attn_gym.linear
 import attn_gym.sparse
@@ -12,7 +14,6 @@ from attn_gym.linear import (
     paged_chunk_gdn,
     recurrent_gdn,
 )
-from attn_gym.linear._delta_rule.decode import GateTransform as DecodeGateTransform
 from attn_gym.linear.kda.api import Impl as KDAImpl
 from attn_gym.linear.types import Impl as SharedImpl
 from attn_gym.masks import (
@@ -37,11 +38,17 @@ def test_linear_impl_uses_shared_owner():
     assert KDAImpl is SharedImpl
 
 
-def test_gate_transform_is_shared_with_decode():
-    """The standalone op and the in-kernel decode transform use one public enum."""
+def test_gate_transform_is_exported():
     assert callable(gate_transform)
-    assert GateTransform is DecodeGateTransform
     assert {"gate_transform", "GateTransform"} <= set(attn_gym.linear.__all__)
+
+
+def test_gate_transform_enum_is_shared_with_decode():
+    """The standalone op and the in-kernel decode transform use one public enum."""
+    pytest.importorskip("triton")  # The decode module imports Triton eagerly.
+    from attn_gym.linear._delta_rule.decode import GateTransform as DecodeGateTransform
+
+    assert GateTransform is DecodeGateTransform
 
 
 def test_gdn_operations_are_exported():

--- a/test/test_namespaces.py
+++ b/test/test_namespaces.py
@@ -4,7 +4,15 @@ import sys
 import attn_gym
 import attn_gym.linear
 import attn_gym.sparse
-from attn_gym.linear import Impl, chunk_gdn, paged_chunk_gdn, recurrent_gdn
+from attn_gym.linear import (
+    GateTransform,
+    Impl,
+    chunk_gdn,
+    gate_transform,
+    paged_chunk_gdn,
+    recurrent_gdn,
+)
+from attn_gym.linear._delta_rule.decode import GateTransform as DecodeGateTransform
 from attn_gym.linear.kda.api import Impl as KDAImpl
 from attn_gym.linear.types import Impl as SharedImpl
 from attn_gym.masks import (
@@ -27,6 +35,13 @@ def test_attention_namespaces_are_exported():
 def test_linear_impl_uses_shared_owner():
     assert Impl is SharedImpl
     assert KDAImpl is SharedImpl
+
+
+def test_gate_transform_is_shared_with_decode():
+    """The standalone op and the in-kernel decode transform use one public enum."""
+    assert callable(gate_transform)
+    assert GateTransform is DecodeGateTransform
+    assert {"gate_transform", "GateTransform"} <= set(attn_gym.linear.__all__)
 
 
 def test_gdn_operations_are_exported():


### PR DESCRIPTION
## Human Note

## Agent note

KDA and GDN use the same two gate transforms (bounded sigmoid and softplus) on two gate shapes
(per-channel and per-head), and the decode kernels already select the transform independently of
the shape through `GateTransform`. On the training side, however, only KDA's `bound_gate` existed,
so GDN callers hand-rolled `-exp(A_log) * softplus(raw + dt_bias)` in eager PyTorch with no shared
definition and no fused backward.

This adds `attn_gym.linear.gate_transform(raw_gate, A_log, dt_bias, *, kind, ...)` as the single
training-time entry point for both kinds and both shapes. `kind` is required so a default cannot
silently pick the wrong recurrence convention; `lower_bound` is required by `bounded` and rejected
by `softplus`. `GateTransform` moves to `attn_gym.linear.types` and is re-exported by the decode
module, so the in-kernel decode transforms and the standalone op share one enum and one
mathematical contract while decode keeps evaluating the transform in-kernel.

The fused `softplus` path is a new portable Triton kernel that flattens either shape to
`rows x channels` and indexes through strides, so sliced projections need no copies. Its backward
is not purely pointwise: `d_dt_bias` and `d_A_log` reduce over rows, so each program writes FP32
per-block partials and the launcher finishes with `torch.sum`, keeping the reduction deterministic.
The accurate path (libdevice `exp` + `log1p`, bit-matching `F.softplus`) is instruction-bound at
about half of HBM bandwidth; `fastmath=True` uses the MUFU `ex2`/`lg2` intrinsics through the
overflow-free `max(s, 0) + log(1 + exp(-|s|))` form (`tl.log2` lowers to a polynomial, so it is
not a shortcut), with absolute error matching FP32 eager.
Softplus also gets a fast route: the CuTeDSL bound-gate forward (direct-vector) and backward (TMA)
kernels take a compile-time `GateTransform`, so per-channel `D=128` gates on sm90+ run the same
near-roofline kernels as `bound_gate`, with the softplus and sigmoid derived from one bounded
`exp(-|z|)` (`max(z, 0) + log1p(e)` and `e / (1 + e)` for negative logits, so huge logits stay
finite and tiny gradients are not cancelled). All fused work sits behind one operator pair,
`attn_gym::_gate_transform_{fwd,bwd}(..., str kind, float lower_bound, bool fastmath)`, and one
autograd Function; the CUDA implementation picks CuTeDSL or Triton once per call on real tensors
(`_softplus_uses_cute`: shape, cached device capability, and whether the CuTeDSL modules import),
so the choice is invisible to torch.compile. Both backends return already-reduced parameter
gradients. The fused `bounded` path is unchanged in numerics, layout handling, and autograd;
per-head bounded gates are reference-only in this change.

`bound_gate` keeps its `[B, T, H, D]` requirement and defaults and delegates to
`gate_transform(kind="bounded")`, so `test_kda_gate_semantics.py` runs unchanged. The GDN test input
builder's `model_softplus` pattern now goes through the shared reference definition.

## Performance

Kernel-only CUDA-graph replay on GB200, bf16 `[8, 8192, 16, 128]` (128M elements), byte model
fwd 6 B/elem and bwd 8 B/elem, roofline = bf16->fp32 cast at 6.8 TB/s:

| kernel                        | fwd us | GB/s | bwd us | GB/s |
| ----------------------------- | -----: | ---: | -----: | ---: |
| CuTeDSL softplus fastmath     |    117 | 6885 |    236 | 4542 |
| CuTeDSL softplus              |    175 | 4606 |    374 | 2870 |
| CuTeDSL `bound_gate` fastmath |    121 | 6661 |    220 | 4883 |
| CuTeDSL `bound_gate`          |    134 | 6016 |    243 | 4425 |
| Triton softplus fastmath      |    167 | 4812 |    301 | 3562 |
| Triton softplus               |    238 | 3386 |    418 | 2568 |

The accurate paths are instruction-bound on libdevice `exp` + `log1p`; fastmath reaches the roofline.

At the per-head GDN shape `[8, 4096, 32]` (1M elements) both Triton paths sit at the launch floor
(fwd 6.2 us, bwd 16.5 us including the two parameter-gradient `sum` kernels).

## Test Plan

```bash
gpu-run --timeout 240 auto -- pytest -q -n 24 test/test_gate_transform.py test/test_kda_gate_semantics.py test/test_namespaces.py test/test_kda_imports.py test/linear/test_gdn_decode.py test/linear/test_gdn_chunk_fused.py test/test_delta_rule_stages.py test/gdn/mega/test_gdn_mega_forward.py test/gdn/mega/test_gdn_mega_backward.py -p no:cacheprovider
gpu-run --timeout 240 auto -- pytest -q -n 16 test/test_kda_training_example.py test/test_kda_int64_offsets.py -p no:cacheprovider
ruff check && ruff format attn_gym test
mkdocs build
gpu-run --timeout 240 auto -- python agent_space/bench_gate_vs_cute.py
```




