### PR TITLE
Finish softplus gate backward partials with one row reduction

### DIFF
--- a/attn_gym/linear/_delta_rule/triton/softplus_gate.py
+++ b/attn_gym/linear/_delta_rule/triton/softplus_gate.py
@@ -13,8 +13,10 @@ works without copies. Strides are constexpr as elsewhere in the repo: the kernel
 instruction-bound, and runtime strides measured 8-20% slower; the cost is one JIT per distinct
 stride set (i.e. per new ``T`` for a contiguous gate). The backward is not purely pointwise:
 ``d_dt_bias`` and ``d_A_log`` reduce over rows, so each program writes one FP32 partial per
-channel and the launcher finishes with ``torch.sum``, keeping the reduction deterministic
-without atomics.
+channel into a shared ``[2, row_blocks, C]`` buffer and the launcher finishes with one row
+``sum``, keeping the reduction deterministic without atomics. (Accumulating several row tiles per
+program to shrink the partials was measured: it costs 24 registers, helps only the largest
+shapes, and doubles the small-shape backward.)
 """
 
 from __future__ import annotations
@@ -271,10 +273,12 @@ def _softplus_gate_bwd_cuda(
     elements_per_program, num_warps = BWD_PROGRAM
     block_rows, block_channels = _launch_config(channels, elements_per_program)
     row_blocks = triton.cdiv(rows, block_rows)
-    d_A_log_partial = torch.empty(
-        row_blocks, channels, device=raw_gate.device, dtype=torch.float32
-    )
-    d_dt_bias_partial = torch.empty_like(d_A_log_partial)
+    # Both parameter partials share one buffer so a single row reduction finishes them; the
+    # separate `view(rb, H, D).sum((0, 2))` pattern was a slow strided reduce (2x the time).
+    # d_dt_bias occupies row 0 so the returned view has the compact, zero-offset metadata the
+    # fake implementation describes.
+    partials = torch.empty(2, row_blocks, channels, device=raw_gate.device, dtype=torch.float32)
+    d_dt_bias_partial, d_A_log_partial = partials[0], partials[1]
     softplus_gate_bwd_kernel[(row_blocks, triton.cdiv(channels, block_channels))](
         raw_gate,
         A_log,
@@ -297,5 +301,6 @@ def _softplus_gate_bwd_cuda(
         FASTMATH=fastmath,
         num_warps=num_warps,
     )
-    d_A_log = d_A_log_partial.view(row_blocks, heads, head_dim).sum((0, 2))
-    return d_raw_gate.view(shape), d_A_log, d_dt_bias_partial.sum(0).view(shape[2:])
+    d_dt_bias, d_A_log_channels = partials.sum(1)
+    d_A_log = d_A_log_channels.view(heads, head_dim).sum(1)
+    return d_raw_gate.view(shape), d_A_log, d_dt_bias.view(shape[2:])


### PR DESCRIPTION
## Human Note

## Agent note

The Triton softplus backward writes per-program FP32 partials for `d_dt_bias` and `d_A_log` and
reduced them on the host as `partial.sum(0)` and `partial.view(rb, H, D).sum((0, 2))`. The second
is a strided reduce that ATen runs at about half bandwidth, and together the two launches were a
quarter of the backward at 128M elements (69 us of 302). Both partials now share one
`[2, row_blocks, C]` buffer finished by a single `sum(1)`; `d_dt_bias` sits in row 0 so the returned
view has the compact zero-offset metadata the fake describes, and `d_A_log` folds its `[C]` row over
`D`. Kernel and numerics are unchanged.

Accumulating several row tiles per program to shrink the partials was measured and rejected: it
costs 24 registers, helps only the largest shape (fastmath -14%), and doubles the small-shape
backward. Raising the CuTeDSL `_TILE_TOKENS` is not a constant flip (64/128 produce wrong gradients)
and its post-pass is already only 8% of that backward, so it is left alone.

## Performance

Triton softplus backward, kernel-only CUDA-graph replay on GB200, bf16, total including the
parameter-gradient reduction:

| shape                 | before acc / fm | after acc / fm |
| --------------------- | --------------: | -------------: |
| `[8, 8192, 16, 128]`  |       418 / 302 |      386 / 272 |
| `[2, 4096, 16, 128]`  |         80 / 65 |        68 / 52 |
| `[8, 4096, 32]`       |     16.4 / 16.4 |    16.4 / 16.5 |

## Test Plan

```bash
gpu-run --timeout 240 auto -- pytest -q -n 24 test/test_gate_transform.py test/test_kda_gate_semantics.py test/test_namespaces.py test/test_kda_imports.py test/linear/test_gdn_decode.py test/linear/test_gdn_chunk_fused.py test/test_delta_rule_stages.py test/test_kda_training_example.py test/test_kda_int64_offsets.py -p no:cacheprovider
ruff check
gpu-run --timeout 240 auto -- python agent_space/bench_gate_vs_cute.py
```

