### PR TITLE
Keep delta-rule training and capture recipes visible in examples

### DIFF
--- a/attn_gym/testing/__init__.py
+++ b/attn_gym/testing/__init__.py
@@ -2,13 +2,21 @@
 
 from .gdn import make_gdn_test_inputs
 from .kda import cumulative_sequence_offsets, strided_state_pool
-from .profiling import kernel_stage, profile_trace, record_distributed_profile
+from .profiling import (
+    annotate_kernels,
+    kernel_stage,
+    profile_trace,
+    record_distributed_profile,
+    record_function,
+)
 
 __all__ = [
+    "annotate_kernels",
     "cumulative_sequence_offsets",
     "kernel_stage",
     "make_gdn_test_inputs",
     "profile_trace",
     "record_distributed_profile",
+    "record_function",
     "strided_state_pool",
 ]

--- a/attn_gym/testing/delta_rule.py
+++ b/attn_gym/testing/delta_rule.py
@@ -1,0 +1,177 @@
+"""Numerical checks, profiling, and benchmark reporting for delta-rule examples.
+
+Batch construction, the training step, and capture lifetime are shown in the base training
+example. These helpers take tensors or a runnable step; they never import the examples.
+"""
+
+from __future__ import annotations
+
+import gc
+import json
+import os
+from collections.abc import Callable, Iterable, Sequence
+from functools import partial
+from pathlib import Path
+
+import torch
+import torch.distributed as dist
+
+from attn_gym.testing.profiling import record_distributed_profile
+
+
+def assert_context_parallel_matches_reference(
+    pairs: Sequence[tuple[torch.Tensor, torch.Tensor]],
+    parameter_gradients: Iterable[tuple[torch.Tensor, torch.Tensor]],
+    compute_dtype: torch.dtype,
+) -> None:
+    """Check outputs and world-summed parameter gradients at the input-precision budget."""
+    assert_close = partial(
+        torch.testing.assert_close,
+        atol=torch.finfo(compute_dtype).eps,
+        rtol=torch.finfo(compute_dtype).eps,
+    )
+    for actual, expected in pairs:
+        assert_close(actual, expected)
+    for actual, expected in parameter_gradients:
+        reduced = actual.detach().clone()
+        dist.all_reduce(reduced)
+        assert_close(reduced, expected)
+
+
+def profile_training_step(
+    step: Callable[[], object],
+    profile_path: Path,
+    device: torch.device,
+    warmup_steps: int,
+) -> None:
+    """Profile one eager step and report memory without owning its model or inputs."""
+    torch.cuda.synchronize(device)
+    torch.cuda.reset_peak_memory_stats(device)
+    resident = torch.cuda.memory_allocated(device)
+    merged_path = record_distributed_profile(
+        step,
+        profile_path,
+        "iteration",
+        device,
+        warmup_steps=warmup_steps,
+    )
+    step_peak = torch.cuda.max_memory_allocated(device) - resident
+    print(
+        f"rank {dist.get_rank()}: step peak {step_peak / 2**30:.2f} GiB above "
+        f"{resident / 2**30:.2f} GiB resident",
+        flush=True,
+    )
+    if merged_path is not None:
+        print(f"profile={merged_path}", flush=True)
+
+
+def measure_training_step(
+    step: Callable[[], object],
+    device: torch.device,
+    *,
+    steps: int,
+    warmup_steps: int,
+    local_tokens: int,
+) -> dict[str, object]:
+    """Measure steady-state CUDA event times and memory while the caller keeps inputs alive."""
+    for _ in range(warmup_steps):
+        step()
+    torch.cuda.synchronize(device)
+    gc.collect()
+    torch.cuda.empty_cache()
+    dist.barrier()
+    torch.cuda.reset_peak_memory_stats(device)
+    resident = torch.cuda.memory_allocated(device)
+
+    step_ms: list[float] = []
+    for _ in range(steps):
+        start, end = torch.cuda.Event(enable_timing=True), torch.cuda.Event(enable_timing=True)
+        start.record()
+        step()
+        end.record()
+        end.synchronize()
+        step_ms.append(start.elapsed_time(end))
+    peak = torch.cuda.max_memory_allocated(device)
+    reserved = torch.cuda.max_memory_reserved(device)
+    return {
+        "rank": dist.get_rank(),
+        "host": os.uname().nodename,
+        "local_tokens": local_tokens,
+        "step_ms": step_ms,
+        "resident_bytes": resident,
+        "peak_bytes": peak,
+        "step_peak_bytes": peak - resident,
+        "reserved_bytes": reserved,
+    }
+
+
+def write_benchmark_report(
+    local: dict[str, object],
+    model: torch.nn.Module,
+    device: torch.device,
+    *,
+    steps: int,
+    warmup_steps: int,
+    cuda_graph: bool,
+    sequence_lengths: tuple[int, ...],
+    partition: str,
+) -> None:
+    """Gather per-rank measurements and write the existing scaling-report schema on rank zero."""
+    rank, world_size = dist.get_rank(), dist.get_world_size()
+    gathered: list[dict | None] = [None] * world_size
+    dist.all_gather_object(gathered, local)
+    if rank != 0:
+        return
+    ranks = [entry for entry in gathered if entry is not None]
+    slowest = [max(entry["step_ms"][index] for entry in ranks) for index in range(steps)]
+    mean = sum(slowest) / steps
+    std = (sum((value - mean) ** 2 for value in slowest) / max(steps - 1, 1)) ** 0.5
+    tokens = sum(sequence_lengths)
+    variant = model.variant
+    core_backend = (model.kernel_options or {}).get("backend", "fused")
+    compute_dtype = str(model.compute_dtype).removeprefix("torch.")
+    report = {
+        "tokens": tokens,
+        "sequence_lengths": list(sequence_lengths),
+        "partition": partition,
+        "hidden_size": model.hidden_size,
+        "heads": model.num_heads,
+        "head_dim": model.head_dim,
+        "variant": variant,
+        "compute_dtype": compute_dtype,
+        "short_conv_kernel_size": model.qkv_conv1d.kernel_size[0],
+        "kda_backend": core_backend,
+        "device_name": torch.cuda.get_device_name(device),
+        "torch": torch.__version__,
+        "world_size": world_size,
+        "mode": "cuda_graph" if cuda_graph else "eager",
+        "steps": steps,
+        "warmup_steps": warmup_steps,
+        "step_ms_mean": mean,
+        "step_ms_std": std,
+        "step_ms_min": min(slowest),
+        "tokens_per_s": tokens / (mean / 1e3),
+        "step_peak_gib_max": max(entry["step_peak_bytes"] for entry in ranks) / 2**30,
+        "resident_gib_max": max(entry["resident_bytes"] for entry in ranks) / 2**30,
+        "peak_gib_max": max(entry["peak_bytes"] for entry in ranks) / 2**30,
+        # Graph replays allocate from the graph's private pool, which
+        # memory_allocated does not see; reserved is the footprint that matters there.
+        "reserved_gib_max": max(entry["reserved_bytes"] for entry in ranks) / 2**30,
+        "ranks": ranks,
+    }
+    output_path = Path(
+        "data",
+        f"{variant}_cp_scaling_{report['mode']}_{partition}_{core_backend}"
+        f"_{compute_dtype}_w{world_size}_t{tokens}_h{model.num_heads}_c{model.hidden_size}.json",
+    ).resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=1))
+    print(
+        f"benchmark: W={world_size} tokens={tokens} "
+        f"({min(entry['local_tokens'] for entry in ranks)}.."
+        f"{max(entry['local_tokens'] for entry in ranks)}/rank) "
+        f"{report['mode']} step {mean:.2f}±{std:.2f} ms  {report['tokens_per_s'] / 1e6:.2f} Mtok/s  "
+        f"peak {report['peak_gib_max']:.2f} GiB allocated (step +{report['step_peak_gib_max']:.2f}), "
+        f"{report['reserved_gib_max']:.2f} GiB reserved -> {output_path}",
+        flush=True,
+    )

--- a/attn_gym/testing/profiling.py
+++ b/attn_gym/testing/profiling.py
@@ -1,14 +1,58 @@
-"""Profiling helpers for distributed example validation."""
+"""Optional profiler ranges, CUDA Graph annotations, and example trace export."""
 
 from __future__ import annotations
 
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager, nullcontext
+from functools import wraps
 from importlib import import_module
+from inspect import signature
 from pathlib import Path
+from typing import Any
 
 import torch
 import torch.distributed as dist
+
+
+def record_function(enabled: bool, name: str):
+    """Create a profiler range only when profiling is requested."""
+    return torch.profiler.record_function(name) if enabled else nullcontext()
+
+
+def graph_annotations_available() -> bool:
+    """Check optional CUDA Graph annotation support without making it an import requirement."""
+    try:
+        from torch.cuda.graph_annotations import is_available
+    except ImportError:
+        return False
+    return is_available()
+
+
+def mark_kernels(*args: Any, **kwargs: Any):
+    """Load optional CUDA Graph annotations only when they are requested."""
+    from torch.cuda.graph_annotations import mark_kernels as annotate
+
+    return annotate(*args, **kwargs)
+
+
+def annotate_kernels(name: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Label a module method when ``module.enable_graph_annotations`` is true.
+
+    The label may reference attributes through ``{module.attribute}``; disabled annotations
+    bypass both label formatting and the optional CUDA Graph annotation API.
+    """
+
+    def decorate(function: Callable[..., Any]) -> Callable[..., Any]:
+        @wraps(function)
+        def annotated(self: Any, *args: Any, **kwargs: Any) -> Any:
+            if not self.enable_graph_annotations:
+                return function(self, *args, **kwargs)
+            with mark_kernels(name.format(module=self)):
+                return function(self, *args, **kwargs)
+
+        return annotated
+
+    return decorate
 
 
 @contextmanager
@@ -16,8 +60,6 @@ def kernel_stage(name: str, annotate: bool, *, backward: bool = True) -> Iterato
     """Label eager profiler ranges and optionally annotate captured CUDA Graph kernels."""
     annotation = nullcontext()
     if annotate:
-        from torch.cuda.graph_annotations import mark_kernels
-
         annotation = mark_kernels(name, backward=backward)
     with torch.profiler.record_function(name), annotation:
         yield
@@ -33,6 +75,12 @@ def profile_trace(path: Path, *, warmup: int = 0) -> Iterator[torch.profiler.pro
         raise RuntimeError(
             "profiling requires transformer-nuggets with native Perfetto support"
         ) from error
+
+    if "trace_format" not in signature(profiler).parameters:
+        raise RuntimeError(
+            "installed transformer-nuggets lacks native Perfetto support; "
+            "install it from https://github.com/drisspg/transformer_nuggets"
+        )
 
     with profiler(
         path.with_suffix(".pftrace"),
@@ -113,4 +161,11 @@ def record_distributed_profile(
     return merged_path
 
 
-__all__ = ["kernel_stage", "profile_trace", "record_distributed_profile"]
+__all__ = [
+    "annotate_kernels",
+    "graph_annotations_available",
+    "kernel_stage",
+    "profile_trace",
+    "record_distributed_profile",
+    "record_function",
+]

--- a/attn_gym/testing/profiling.py
+++ b/attn_gym/testing/profiling.py
@@ -151,11 +151,11 @@ def record_distributed_profile(
             if trace is not None and not rank_path.exists():
                 rank_path.write_bytes(trace)
         merged_path = path.with_name(f"{path.stem}_merged.pftrace")
+        # Native traces preserve their clock timestamps; JSON-style re-zeroing is unsupported.
         merge_traces(
             [str(rank_path) for rank_path in rank_paths],
             str(merged_path),
             labels=[f"Rank {index} · GPU {index}" for index in range(world_size)],
-            align_timestamps=True,
         )
     dist.barrier()
     return merged_path

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -97,9 +97,21 @@ fragments using the reference recipe in `attn_gym.linear.context_parallel` (see
 [Context Parallelism](linear.md#context-parallelism)). This includes projections, Q/K/V short
 convolution, the KDA or GDN core (`--variant`), normalization, gating, and the output projection.
 
-Each rank owns fragments (global token ranges) chosen in a dozen lines of plain Python (`fragments`
-in the example): `--partition contiguous` gives each rank one block, while `--partition zigzag`
-gives it two mirrored blocks, matching the layout hybrid models inherit from ring softmax attention.
+The input uses the same shared Zipf sampler as the base training example's `--packed` mode:
+`--batch-size` counts logical sequences and `--tokens` bounds their lengths. Use
+`--sequence-lengths` to override sampling with an explicit layout. `--num-heads` and
+`--core-backend` match the base example; `--heads` and `--kda-backend` remain aliases.
+
+Each rank owns fragments (global token ranges) from `partition_fragments` directly in the CP
+example. Edit this function to define your own rank mappings: `--partition contiguous` gives each
+rank one near-equal block, while `--partition zigzag` gives it two mirrored blocks, matching the
+layout hybrid models inherit from ring softmax attention.
+Uneven totals are partitioned without dropping or padding tokens. The model, batch construction,
+loss/backward, and capture recipes are shown in `examples/delta_rule_training.py` and imported
+by the CP example. Numerical assertions, profiling, and benchmark reporting stay in
+`attn_gym.testing.delta_rule` and `attn_gym.testing.profiling`.
+The example keeps the run-mode branches visible: validate first, then benchmark, capture/replay,
+or profile an eager step.
 The short convolution all-gathers one `W - 1` token tail per fragment (its last subsequence's) and
 routes its initial-state gradient back to the owning ranks. The delta-rule recurrence computes forward and
 reverse `[bias; transition]` state summaries with portable Triton kernels on Hopper or native
@@ -109,10 +121,15 @@ validates local outputs, convolution and recurrent endpoint states, input gradie
 parameter gradients against the complete unsharded module. It can also capture the full forward,
 NCCL communication, and backward in one CUDA Graph and validate a changed-input replay. Use
 `--compute-dtype=float16` to exercise the FP16 route. Add `--profile` to use transformer-nuggets to
-export one merged multi-rank trace in native Perfetto `.pftrace` format.
+export one merged multi-rank trace in native Perfetto `.pftrace` format. This requires a
+transformer-nuggets source revision with native Perfetto support; older releases lack the exporter:
 
 ```bash
-torchrun --standalone --nproc_per_node=2 examples/delta_rule_context_parallel.py
+uv pip install --python .venv/bin/python 'git+https://github.com/drisspg/transformer_nuggets.git'
+```
+
+```bash
+torchrun --standalone --nproc_per_node=2 examples/delta_rule_context_parallel.py --batch-size 4 --tokens 1024
 
 torchrun --standalone --nproc_per_node=2 examples/delta_rule_context_parallel.py --partition zigzag
 

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -335,7 +335,8 @@ while allowing
 Inductor to fuse the surrounding PyTorch normalization and remaining pointwise work.
 The bounded gate itself uses private CuTeDSL forward and backward operators. It can be
 combined with `--profile`; compilation warmups run before the
-trace starts. Like FLA's default training path, its backward recomputes the W/U,
+trace starts. Profiling requires transformer-nuggets and writes a native Perfetto `.pftrace`
+through the shared `attn_gym.testing.profile_trace` helper. Like FLA's default training path, its backward recomputes the W/U,
 gated Q/K, recurrent-state, and
 corrected-value intermediates instead of retaining them across the forward/backward
 boundary.

--- a/examples/delta_rule_context_parallel.py
+++ b/examples/delta_rule_context_parallel.py
@@ -1,39 +1,36 @@
-"""Train a complete packed delta-rule attention module (KDA or GDN) with context parallelism.
+"""Run the delta-rule training module (KDA or GDN) with packed context parallelism.
 
-This reuses the transformer-style module from ``delta_rule_training.py`` and distributes both stateful
-operations through the reference recipe in ``attn_gym.linear.context_parallel``: a halo
-exchange supplies the short convolution's finite history, and the delta-rule recurrence's initial state
-is composed from the affine summaries of the ranks that hold the preceding tokens. Each rank owns a list of fragments (global token ranges) chosen
-here in plain Python (``fragments``), so the same code validates contiguous shards and zig-zag load
-balancing; see NOTE [Terminology] in ``attn_gym.linear.context_parallel``. Launch with:
+Each rank owns fragments of one packed stream. The subclass below changes only the two stateful
+stages: a halo exchange supplies the short convolution's history, and affine summaries supply the
+recurrence's incoming state. Projections, gates, normalization, and output projection are inherited
+from ``delta_rule_training.py``.
 
-    torchrun --standalone --nproc-per-node=2 examples/delta_rule_context_parallel.py
+Like that example's ``--packed`` mode, ``--batch-size`` is the number of logical sequences and
+``--tokens`` bounds their Zipf-distributed lengths. CP is always packed and fused. Defaults use
+TorchTitan's K3 attention dimensions: hidden size 7168 and 96 heads of dimension 128, not a full
+K3 model. Launch with:
 
-Add ``--variant gdn`` to run the Gated DeltaNet recipe instead of KDA, ``--partition zigzag`` to
-give each rank two mirrored blocks, ``--compute-dtype=float16``
-to validate the FP16 route, ``--kda-backend mega`` to run each local pass with the Mega backend
-(SM100/SM103), ``--cuda-graph`` to capture forward and backward together and validate a replay
-with changed inputs, ``--profile`` to export a merged native Perfetto trace using
-transformer-nuggets, and ``--no-validate`` to skip the unsharded reference at scales where it does
-not fit. The example requires one Hopper or datacenter Blackwell GPU per rank.
+    torchrun --standalone --nproc-per-node=2 examples/delta_rule_context_parallel.py --batch-size 4 --tokens 1024
+
+Add ``--variant gdn``, ``--partition zigzag``, or ``--compute-dtype float16`` to vary the recipe.
+``--core-backend mega`` selects the KDA Mega backend (SM100/SM103). ``--cuda-graph`` checks a
+changed-input replay; ``--profile`` writes a merged native Perfetto trace. ``--no-validate`` skips
+the unsharded reference at scales where it does not fit. Batch construction, loss/backward, and
+capture are shown in ``delta_rule_training.py`` and imported here. Numerical assertions, trace
+export, and benchmark reporting live in ``attn_gym.testing``.
 """
 
 from __future__ import annotations
 
 import gc
-import json
-import os
-from collections.abc import Callable
-from dataclasses import dataclass
 from enum import Enum
 from functools import partial
 from itertools import accumulate
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Literal
 
 import torch
 import torch.distributed as dist
-import torch.nn.functional as F
 import typer
 
 from attn_gym.linear.context_parallel import (
@@ -44,60 +41,57 @@ from attn_gym.linear.context_parallel import (
 from attn_gym.linear.gdn.context_parallel import context_parallel_gdn
 from attn_gym.linear.kda.context_parallel import context_parallel_kda
 from attn_gym.testing import kernel_stage, record_distributed_profile
+from attn_gym.testing.profiling import graph_annotations_available
 from examples.delta_rule_training import (
     ComputeDTypeOption,
     CoreBackendOption,
     DeltaRuleAttention,
     DeltaRuleAttentionOutput,
     VariantOption,
+    capture_training_graph,
+    distributed_device,
+    make_context_parallel_batch,
+    packed_sequence_metadata,
+    profile_eager_step,
+    run_benchmark,
+    run_training_step,
+    validate_against_reference,
 )
 
 
 class PartitionOption(str, Enum):
+    """Rank ownership of the packed stream."""
+
     CONTIGUOUS = "contiguous"
     ZIGZAG = "zigzag"
 
 
-def fragments(
-    tokens: int, world_size: int, partition: PartitionOption
+def partition_fragments(
+    tokens: int,
+    world_size: int,
+    partition: Literal["contiguous", "zigzag"] = "contiguous",
 ) -> list[list[tuple[int, int]]]:
-    """Choose each rank's fragments (global token ranges), in span order.
+    """Example rank mappings; edit this function to assign your own global token ranges.
 
-    Contiguous gives rank ``r`` block ``r`` of ``W`` equal blocks. Zig-zag gives it blocks ``r``
-    and ``2W - 1 - r`` of ``2W``: the load-balanced layout ring softmax attention uses for causal
-    masks, which a hybrid model's KDA layers inherit. Any other assignment is just a different
-    list; the plan cuts fragments at sequence boundaries itself.
+    Contiguous assigns rank r block r of W near-balanced blocks. Zigzag assigns
+    blocks r and 2W - 1 - r of 2W blocks. Floor-based boundaries preserve equal
+    blocks for divisible totals without dropping or padding tokens otherwise.
     """
-    blocks = world_size if partition is PartitionOption.CONTIGUOUS else 2 * world_size
-    if tokens % blocks:
-        raise ValueError(f"{tokens} tokens do not split into {blocks} equal blocks")
-    size = tokens // blocks
+    if world_size < 1:
+        raise ValueError("world_size must be positive")
+    if partition not in ("contiguous", "zigzag"):
+        raise ValueError(f"partition must be 'contiguous' or 'zigzag', got {partition!r}")
+    blocks = world_size if partition == "contiguous" else 2 * world_size
+    if tokens < blocks:
+        raise ValueError(f"{tokens} tokens cannot fill {blocks} nonempty blocks")
     owned = [
-        [cp_rank] if partition is PartitionOption.CONTIGUOUS else [cp_rank, blocks - 1 - cp_rank]
-        for cp_rank in range(world_size)
+        [rank] if partition == "contiguous" else [rank, blocks - 1 - rank]
+        for rank in range(world_size)
     ]
-    return [[(block * size, (block + 1) * size) for block in blocks_of] for blocks_of in owned]
-
-
-@dataclass(frozen=True)
-class PackedTrainingBatch:
-    """Global reference tensors and this rank's span and per-call routing.
-
-    ``token_ids`` maps span positions to global token ids; ``terminal_index`` lists the local
-    subsequences that end their sequence and ``terminal_sequences`` the matching global sequence
-    ids, so endpoint states can be compared with the unsharded run.
-    """
-
-    global_hidden: torch.Tensor | None
-    global_target: torch.Tensor | None
-    global_offsets: torch.Tensor
-    local_hidden: torch.Tensor
-    local_target: torch.Tensor
-    routing: ContextParallelRouting
-    token_ids: torch.Tensor
-    terminal_index: torch.Tensor
-    terminal_sequences: torch.Tensor
-    loss_scale: float
+    return [
+        [(block * tokens // blocks, (block + 1) * tokens // blocks) for block in rank_blocks]
+        for rank_blocks in owned
+    ]
 
 
 class ContextParallelDeltaRuleAttention(DeltaRuleAttention):
@@ -138,9 +132,7 @@ class ContextParallelDeltaRuleAttention(DeltaRuleAttention):
             raise ValueError(
                 "routing conv_history must match the model's convolution width minus one"
             )
-        # The base pipeline (projections, masking, normalization) is reused as is. Routing is
-        # passed per call and reaches only the two overrides below, short_convolution and
-        # delta_rule_core, instead of being stored on the module.
+        # Pass CP routing info straight to internal stages in delta rule training examples
         return self.run_stages(
             hidden_states,
             None,
@@ -182,7 +174,6 @@ class ContextParallelDeltaRuleAttention(DeltaRuleAttention):
         return_final_state: bool,
         routing: ContextParallelRouting,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        # cu_seqlens is routing.cu_seqlens; context parallelism constructs the recurrent state.
         assert initial_state is None
         if self.variant == "kda":
             output, final_state = context_parallel_kda(
@@ -203,591 +194,176 @@ class ContextParallelDeltaRuleAttention(DeltaRuleAttention):
         return output, final_state if return_final_state else None
 
 
-def run_training_step(
-    module: ContextParallelDeltaRuleAttention,
-    hidden_states: torch.Tensor,
-    target: torch.Tensor,
-    routing: ContextParallelRouting,
-    state_index: torch.Tensor,
-    loss_scale: float,
-    *,
-    annotate: bool = False,
-) -> tuple[DeltaRuleAttentionOutput, tuple[torch.Tensor, ...]]:
-    """Run the complete module and differentiate its token and endpoint losses."""
-    module.enable_graph_annotations = annotate
-    result = module(
-        hidden_states,
-        routing=routing,
-        return_final_state=True,
-    )
-    return result, training_gradients(
-        module, result, hidden_states, target, state_index, loss_scale, annotate=annotate
-    )
-
-
-def training_gradients(
-    module: DeltaRuleAttention,
-    result: DeltaRuleAttentionOutput,
-    hidden_states: torch.Tensor,
-    target: torch.Tensor,
-    state_index: torch.Tensor,
-    loss_scale: float,
-    *,
-    annotate: bool = False,
-) -> tuple[torch.Tensor, ...]:
-    """Differentiate the same token and true-endpoint losses in CP and unsharded runs."""
-    assert result.final_state is not None
-    assert result.final_conv_state is not None
-    loss = F.mse_loss(result.hidden_states.float(), target, reduction="sum") * loss_scale
-    # Only true sequence ends carry a loss; intermediate subsequence states are handed downstream.
-    loss = loss + 1e-4 * result.final_state[state_index].square().sum()
-    loss = loss + 1e-4 * result.final_conv_state[state_index].float().square().sum()
-    inputs = (hidden_states, *tuple(module.parameters()))
-    with kernel_stage("cp/bwd", annotate, backward=False):
-        return torch.autograd.grad(loss, inputs)
-
-
-def validate_against_reference(
-    model: ContextParallelDeltaRuleAttention,
-    reference_model: DeltaRuleAttention,
-    batch: PackedTrainingBatch,
-) -> None:
-    """Compare one sharded full-module backward with the unsharded module."""
-    result, gradients = run_training_step(
-        model,
-        batch.local_hidden,
-        batch.local_target,
-        batch.routing,
-        batch.terminal_index,
-        batch.loss_scale,
-    )
-    assert batch.global_hidden is not None and batch.global_target is not None
-    reference_hidden = batch.global_hidden.detach().clone().requires_grad_()
-    # Unsharded, every sequence in the stream ends here, so every exit state is a true final state.
-    every_sequence = torch.arange(
-        batch.global_offsets.shape[0] - 1, device=reference_hidden.device
-    )
-    reference_result = reference_model(
-        reference_hidden, cu_seqlens=batch.global_offsets, return_final_state=True
-    )
-    reference_gradients = training_gradients(
-        reference_model,
-        reference_result,
-        reference_hidden,
-        batch.global_target,
-        every_sequence,
-        batch.loss_scale,
-    )
-
-    # Rank partitioning changes accumulation order, so compare at input-precision accuracy.
-    assert_close = partial(
-        torch.testing.assert_close,
-        atol=torch.finfo(model.compute_dtype).eps,
-        rtol=torch.finfo(model.compute_dtype).eps,
-    )
-    assert_close(result.hidden_states, reference_result.hidden_states[:, batch.token_ids])
-    assert_close(gradients[0], reference_gradients[0][:, batch.token_ids])
-    assert_close(
-        result.final_state[batch.terminal_index],
-        reference_result.final_state[batch.terminal_sequences],
-    )
-    assert_close(
-        result.final_conv_state[batch.terminal_index],
-        reference_result.final_conv_state[batch.terminal_sequences],
-    )
-    for actual, expected in zip(gradients[1:], reference_gradients[1:], strict=True):
-        reduced = actual.detach().clone()
-        dist.all_reduce(reduced)
-        assert_close(reduced, expected)
-
-
-def validate_cuda_graph(
-    make_model: Callable[[], ContextParallelDeltaRuleAttention],
-    eager_model: ContextParallelDeltaRuleAttention,
-    batch: PackedTrainingBatch,
-    annotations: bool,
-    profile_path: Path | None,
-    device: torch.device,
-    warmup_steps: int,
-) -> None:
-    """Capture the full distributed backward and compare a changed-input replay."""
-    warmup_stream = torch.cuda.Stream()
-    warmup_stream.wait_stream(torch.cuda.current_stream())
-    with torch.cuda.stream(warmup_stream):
-        # Parameter AccumulateGrad nodes retain their first stream, so the captured path needs
-        # a fresh model whose warmup and eager replay oracle both run on this stream.
-        model = make_model()
-        model.load_state_dict(eager_model.state_dict())
-        capture_hidden = batch.local_hidden.detach().clone().requires_grad_()
-        # The warmup step doubles as the replay oracle: run it on the changed input the replay
-        # will see, so its activations are gone before the graph pool holds the captured ones.
-        eager_hidden = (capture_hidden.detach() * 0.75).requires_grad_()
-        eager_result, eager_gradients = run_training_step(
-            model,
-            eager_hidden,
-            batch.local_target,
-            batch.routing,
-            batch.terminal_index,
-            batch.loss_scale,
-        )
-        del eager_hidden
-    warmup_stream.synchronize()
-    gc.collect()
-    dist.barrier()
-
-    graph = torch.cuda.CUDAGraph()
-    try:
-        with torch.cuda.graph(graph, stream=warmup_stream, enable_annotations=annotations):
-            graph_result, graph_gradients = run_training_step(
-                model,
-                capture_hidden,
-                batch.local_target,
-                batch.routing,
-                batch.terminal_index,
-                batch.loss_scale,
-                annotate=annotations,
-            )
-        torch.cuda.current_stream().wait_stream(warmup_stream)
-        captured_output = graph_result.hidden_states.clone()
-        torch.cuda.synchronize(device)
-
-        with torch.no_grad():
-            capture_hidden.mul_(0.75)
-        graph.replay()
-        torch.cuda.synchronize(device)
-        if torch.equal(graph_result.hidden_states, captured_output):
-            raise AssertionError("CUDA Graph replay did not observe changed inputs")
-        torch.testing.assert_close(graph_result, eager_result)
-        torch.testing.assert_close(graph_gradients, eager_gradients)
-        if profile_path is not None:
-            merged_path = record_distributed_profile(
-                graph.replay,
-                profile_path,
-                "cuda_graph_replay",
-                device,
-                warmup_steps=warmup_steps,
-            )
-            if merged_path is not None:
-                print(f"profile={merged_path}", flush=True)
-    finally:
-        torch.cuda.synchronize(device)
-        graph.reset()
-        gc.collect()
-
-
-def profile_eager_step(
-    model: ContextParallelDeltaRuleAttention,
-    batch: PackedTrainingBatch,
-    profile_path: Path,
-    device: torch.device,
-    warmup_steps: int,
-) -> None:
-    """Profile one complete eager context-parallel forward and backward."""
-    hidden_states = batch.local_hidden.detach().clone().requires_grad_()
-    torch.cuda.synchronize(device)
-    torch.cuda.reset_peak_memory_stats(device)
-    resident = torch.cuda.memory_allocated(device)
-    merged_path = record_distributed_profile(
-        lambda: run_training_step(
-            model,
-            hidden_states,
-            batch.local_target,
-            batch.routing,
-            batch.terminal_index,
-            batch.loss_scale,
-        ),
-        profile_path,
-        "iteration",
-        device,
-        warmup_steps=warmup_steps,
-    )
-    step_peak = torch.cuda.max_memory_allocated(device) - resident
-    print(
-        f"rank {dist.get_rank()}: step peak {step_peak / 2**30:.2f} GiB above "
-        f"{resident / 2**30:.2f} GiB resident",
-        flush=True,
-    )
-    if merged_path is not None:
-        print(f"profile={merged_path}", flush=True)
-
-
-def capture_training_graph(
-    make_model: Callable[[], ContextParallelDeltaRuleAttention],
-    eager_model: ContextParallelDeltaRuleAttention,
-    batch: PackedTrainingBatch,
-) -> tuple[torch.cuda.CUDAGraph, ContextParallelDeltaRuleAttention, torch.Tensor]:
-    """Capture one full training step.
-
-    Returns the graph with the model and static input it reads from; callers
-    must keep both alive for as long as they replay.
-    """
-    stream = torch.cuda.Stream()
-    stream.wait_stream(torch.cuda.current_stream())
-    with torch.cuda.stream(stream):
-        # See validate_cuda_graph: AccumulateGrad nodes pin their first stream.
-        model = make_model()
-        model.load_state_dict(eager_model.state_dict())
-        static_hidden = batch.local_hidden.detach().clone().requires_grad_()
-        run_training_step(
-            model,
-            static_hidden,
-            batch.local_target,
-            batch.routing,
-            batch.terminal_index,
-            batch.loss_scale,
-        )
-    stream.synchronize()
-    # The warmup's activations are dead; release their segments so the graph's
-    # private pool does not sit on top of a fragmented copy of the same peak.
-    gc.collect()
-    torch.cuda.empty_cache()
-    dist.barrier()
-    graph = torch.cuda.CUDAGraph()
-    with torch.cuda.graph(graph, stream=stream):
-        run_training_step(
-            model,
-            static_hidden,
-            batch.local_target,
-            batch.routing,
-            batch.terminal_index,
-            batch.loss_scale,
-        )
-    torch.cuda.current_stream().wait_stream(stream)
-    return graph, model, static_hidden
-
-
-def run_benchmark(
-    make_model: Callable[[], ContextParallelDeltaRuleAttention],
-    model: ContextParallelDeltaRuleAttention,
-    batch: PackedTrainingBatch,
-    device: torch.device,
-    *,
-    steps: int,
-    warmup_steps: int,
-    cuda_graph: bool,
-    output_path: Path,
-    config: dict[str, object],
-) -> None:
-    """Time steady-state training steps and record per-rank memory; rank 0 writes JSON.
-
-    Step time is measured per rank with CUDA events; the reported step time is
-    the slowest rank per iteration, which is what gates training. Memory is the
-    peak above what is resident before the timed steps (parameters, inputs, and
-    the graph's static buffers when captured).
-    """
-    rank = dist.get_rank()
-    world_size = dist.get_world_size()
-    hidden_states = batch.local_hidden.detach().clone().requires_grad_()
-    if cuda_graph:
-        graph, graph_model, static_hidden = capture_training_graph(make_model, model, batch)
-        step: Callable[[], object] = graph.replay
-    else:
-
-        def step() -> object:
-            return run_training_step(
-                model,
-                hidden_states,
-                batch.local_target,
-                batch.routing,
-                batch.terminal_index,
-                batch.loss_scale,
-            )
-
-    for _ in range(warmup_steps):
-        step()
-    torch.cuda.synchronize(device)
-    gc.collect()
-    torch.cuda.empty_cache()
-    dist.barrier()
-    torch.cuda.reset_peak_memory_stats(device)
-    resident = torch.cuda.memory_allocated(device)
-
-    step_ms: list[float] = []
-    for _ in range(steps):
-        start, end = torch.cuda.Event(enable_timing=True), torch.cuda.Event(enable_timing=True)
-        start.record()
-        step()
-        end.record()
-        end.synchronize()
-        step_ms.append(start.elapsed_time(end))
-    peak = torch.cuda.max_memory_allocated(device)
-    if cuda_graph:
-        del graph, graph_model, static_hidden
-    local = {
-        "rank": rank,
-        "host": os.uname().nodename,
-        "local_tokens": int(batch.token_ids.numel()),
-        "step_ms": step_ms,
-        "resident_bytes": resident,
-        "peak_bytes": peak,
-        "step_peak_bytes": peak - resident,
-        "reserved_bytes": torch.cuda.max_memory_reserved(device),
-    }
-    gathered: list[dict | None] = [None] * world_size
-    dist.all_gather_object(gathered, local)
-    if rank != 0:
-        return
-    ranks = [entry for entry in gathered if entry is not None]
-    slowest = [max(entry["step_ms"][index] for entry in ranks) for index in range(steps)]
-    mean = sum(slowest) / steps
-    std = (sum((value - mean) ** 2 for value in slowest) / max(steps - 1, 1)) ** 0.5
-    tokens = int(config["tokens"])
-    report = {
-        **config,
-        "world_size": world_size,
-        "mode": "cuda_graph" if cuda_graph else "eager",
-        "steps": steps,
-        "warmup_steps": warmup_steps,
-        "step_ms_mean": mean,
-        "step_ms_std": std,
-        "step_ms_min": min(slowest),
-        "tokens_per_s": tokens / (mean / 1e3),
-        "step_peak_gib_max": max(entry["step_peak_bytes"] for entry in ranks) / 2**30,
-        "resident_gib_max": max(entry["resident_bytes"] for entry in ranks) / 2**30,
-        "peak_gib_max": max(entry["peak_bytes"] for entry in ranks) / 2**30,
-        # Graph replays allocate from the graph's private pool, which
-        # memory_allocated does not see; reserved is the footprint that matters there.
-        "reserved_gib_max": max(entry["reserved_bytes"] for entry in ranks) / 2**30,
-        "ranks": ranks,
-    }
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(json.dumps(report, indent=1))
-    print(
-        f"benchmark: W={world_size} tokens={tokens} ({tokens // world_size}/rank) "
-        f"{report['mode']} step {mean:.2f}±{std:.2f} ms  {report['tokens_per_s'] / 1e6:.2f} Mtok/s  "
-        f"peak {report['peak_gib_max']:.2f} GiB allocated (step +{report['step_peak_gib_max']:.2f}), "
-        f"{report['reserved_gib_max']:.2f} GiB reserved -> {output_path}",
-        flush=True,
-    )
-
-
 def main(
-    sequence_lengths: Annotated[
-        str,
-        typer.Option(help="Comma-separated nonempty packed sequence lengths."),
-    ] = "256,1280,512",
-    partition: Annotated[
-        PartitionOption,
-        typer.Option(help="How ranks own fragments of the global stream."),
-    ] = PartitionOption.CONTIGUOUS,
     variant: Annotated[
-        VariantOption,
-        typer.Option(help="Run the KDA or GDN recipe."),
+        VariantOption, typer.Option(help="Run the KDA or GDN recipe.")
     ] = VariantOption.KDA,
-    hidden_size: Annotated[int, typer.Option(min=1, help="Transformer hidden size.")] = 256,
-    heads: Annotated[int, typer.Option(min=1, help="Number of attention heads.")] = 2,
     compute_dtype: Annotated[
         ComputeDTypeOption,
         typer.Option(help="Use float16 or bfloat16 projection and kernel inputs."),
     ] = ComputeDTypeOption.BFLOAT16,
-    short_conv_kernel_size: Annotated[
-        int,
-        typer.Option(min=1, help="Causal Q/K/V convolution width."),
-    ] = 4,
-    kda_backend: Annotated[
+    core_backend: Annotated[
         CoreBackendOption,
-        typer.Option(help="Chunk backend for each rank's local KDA pass (KDA variant only)."),
+        typer.Option(
+            "--core-backend",
+            "--kda-backend",
+            help="Local KDA chunk kernels: fused or Mega (SM100).",
+        ),
     ] = CoreBackendOption.FUSED,
     fastmath: Annotated[
         bool, typer.Option(help="Use approximate exponentials in the fused gate and KDA core.")
     ] = False,
+    batch_size: Annotated[
+        int, typer.Option(min=1, help="Number of packed logical sequences.")
+    ] = 4,
+    tokens: Annotated[
+        int,
+        typer.Option(min=1, help="Longest packed sequence; lengths follow a Zipf distribution."),
+    ] = 1024,
+    hidden_size: Annotated[int, typer.Option(min=1, help="Transformer hidden size.")] = 7168,
+    num_heads: Annotated[
+        int, typer.Option("--num-heads", "--heads", min=1, help="Number of attention heads.")
+    ] = 96,
+    short_conv_kernel_size: Annotated[
+        int, typer.Option(min=1, help="Causal Q/K/V convolution width.")
+    ] = 4,
+    partition: Annotated[
+        PartitionOption, typer.Option(help="How ranks own fragments of the global stream.")
+    ] = PartitionOption.CONTIGUOUS,
+    sequence_lengths: Annotated[
+        str | None,
+        typer.Option(help="Explicit comma-separated lengths, overriding batch-size/tokens."),
+    ] = None,
     cuda_graph: Annotated[
-        bool,
-        typer.Option(help="Capture forward and backward and validate a changed-input replay."),
+        bool, typer.Option(help="Capture forward/backward and validate a changed-input replay.")
     ] = False,
     validate: Annotated[
-        bool,
-        typer.Option(help="Compare against the unsharded module on the whole stream."),
+        bool, typer.Option(help="Compare against the unsharded module on the whole stream.")
     ] = True,
     profile: Annotated[
-        bool,
-        typer.Option(help="Export a merged native Perfetto trace with transformer-nuggets."),
+        bool, typer.Option(help="Export a merged native Perfetto trace with transformer-nuggets.")
     ] = False,
     warmup_steps: Annotated[
-        int,
-        typer.Option(
-            min=0,
-            help="Steps run before the profiled one and dropped from the trace, so it shows "
-            "steady state (as if deep inside a model) rather than launch skew.",
-        ),
+        int, typer.Option(min=0, help="Warmup steps before profiling or timing.")
     ] = 5,
     benchmark_steps: Annotated[
         int,
         typer.Option(
-            min=0,
-            help="Timed steady-state steps after warmup; rank 0 writes data/<variant>_cp_scaling_*.json "
-            "with step time, throughput, and per-rank memory (0 disables).",
+            min=0, help="Timed forward/backward steps; write a scaling report (0 disables)."
         ),
     ] = 0,
 ) -> None:
-    """Run and validate the complete packed context-parallel delta-rule module."""
-    local_rank = int(os.environ["LOCAL_RANK"])
-    device = torch.device(f"cuda:{local_rank}")
-    torch.cuda.set_device(device)
-    dist.init_process_group("nccl", device_id=device)
-    cp_rank = dist.get_rank()
-    world_size = dist.get_world_size()
-    graph_annotations_available = False
-    if cuda_graph:
-        try:
-            from torch.cuda.graph_annotations import is_available
-        except ImportError:
-            pass
+    """Run the same packed module recipe across one Hopper-or-newer GPU per rank."""
+    with distributed_device() as device:
+        torch.manual_seed(0)
+        if sequence_lengths is None:
+            lengths, offsets = packed_sequence_metadata(batch_size, tokens)
         else:
-            graph_annotations_available = is_available()
-        if cp_rank == 0 and not graph_annotations_available:
-            print(
-                "CUDA Graph capture is available, but kernel labels require PyTorch graph "
-                "annotations and CUDA >=13.1 tools-ID driver support.",
-                flush=True,
+            lengths = tuple(int(length) for length in sequence_lengths.split(","))
+            offsets = (0, *accumulate(lengths))
+        if dist.get_rank() == 0:
+            print(f"packed_sequence_lengths={lengths} cu_seqlens={offsets}", flush=True)
+        plan = ContextParallelPlan.from_fragments(
+            offsets,
+            partition_fragments(offsets[-1], dist.get_world_size(), partition.value),
+            dist.get_rank(),
+        )
+        batch = make_context_parallel_batch(
+            plan,
+            offsets,
+            hidden_size,
+            device,
+            conv_history=short_conv_kernel_size - 1,
+            validate=validate,
+        )
+        model_options = {
+            "hidden_size": hidden_size,
+            "num_heads": num_heads,
+            "head_dim": 128,
+            "variant": variant.value,
+            "short_conv_kernel_size": short_conv_kernel_size,
+            "backend": "fused",
+            "fastmath": fastmath,
+            "compute_dtype": getattr(torch, compute_dtype.value),
+            "device": device,
+        }
+        # The reference keeps the repo-local core; only each rank's local KDA pass may use Mega.
+        make_model = partial(
+            ContextParallelDeltaRuleAttention,
+            **model_options,
+            group=dist.group.WORLD,
+            kernel_options={"backend": core_backend.value}
+            if core_backend is CoreBackendOption.MEGA
+            else None,
+        )
+        model = make_model()
+
+        # --validate checks outputs and gradients against the complete unsharded model.
+        if validate:
+            reference = DeltaRuleAttention(**model_options)
+            reference.load_state_dict(model.state_dict())
+            validate_against_reference(model, reference, batch)
+            del reference  # Free the full-model oracle before capturing a graph pool.
+        else:
+            run_training_step(
+                model,
+                batch.local_hidden,
+                batch.local_target,
+                batch.routing,
+                batch.terminal_index,
+                batch.loss_scale,
             )
+        gc.collect()
 
-    lengths = tuple(int(length) for length in sequence_lengths.split(","))
-    cu_seqlens_global = tuple(accumulate(lengths, initial=0))
-    tokens = cu_seqlens_global[-1]
-    plan = ContextParallelPlan.from_fragments(
-        cu_seqlens_global, fragments(tokens, world_size, partition), cp_rank
-    )
-    token_ids = plan.global_token_ids(device)
+        mode = "cuda_graph" if cuda_graph else "eager"
+        profile_path = Path(
+            "data",
+            f"{variant.value}_context_parallel_{mode}_{partition.value}_{core_backend.value}"
+            f"_{compute_dtype.value}_w{dist.get_world_size()}_t{offsets[-1]}"
+            f"_h{num_heads}_c{hidden_size}_conv{short_conv_kernel_size}",
+        ).resolve()
+        if benchmark_steps:
+            run_benchmark(
+                make_model,
+                model,
+                batch,
+                device,
+                steps=benchmark_steps,
+                warmup_steps=warmup_steps,
+                cuda_graph=cuda_graph,
+                sequence_lengths=lengths,
+                partition=partition.value,
+            )
+        elif cuda_graph:
+            # Capture once; profiling below records replay, not graph construction.
+            annotations = graph_annotations_available()
+            if not annotations and dist.get_rank() == 0:
+                print(
+                    "Capturing without kernel labels: graph annotations need a supported PyTorch/driver."
+                )
+            with capture_training_graph(
+                make_model, model, batch, validate=True, annotations=annotations
+            ) as graph:
+                if profile:
+                    merged_path = record_distributed_profile(
+                        graph.replay,
+                        profile_path,
+                        "cuda_graph_replay",
+                        device,
+                        warmup_steps=warmup_steps,
+                    )
+                    if merged_path is not None:
+                        print(f"profile={merged_path}", flush=True)
+        elif profile:
+            profile_eager_step(model, batch, profile_path, device, warmup_steps)
 
-    torch.manual_seed(0)
-    model_options = {
-        "hidden_size": hidden_size,
-        "num_heads": heads,
-        "head_dim": 128,
-        "variant": variant.value,
-        "short_conv_kernel_size": short_conv_kernel_size,
-        "backend": "fused",
-        "fastmath": fastmath,
-        "compute_dtype": getattr(torch, compute_dtype.value),
-        "device": device,
-    }
-    # The unsharded reference keeps the repo-local core; only each rank's local pass may use Mega.
-    make_model = partial(
-        ContextParallelDeltaRuleAttention,
-        **model_options,
-        group=dist.group.WORLD,
-        kernel_options={"backend": kda_backend.value}
-        if kda_backend is CoreBackendOption.MEGA
-        else None,
-    )
-    model = make_model()
-
-    # Every rank draws the same global stream so shards agree with the reference. Only the
-    # reference needs it on the GPU; otherwise build it on the CPU and move just the shard.
-    # Materializing 2 x tokens x hidden fp32 on the device left tens of GiB of freed-but-pinned
-    # allocator segments behind at 1M tokens, which showed up as a spurious CUDA Graph "overhead".
-    stream_device = device if validate else torch.device("cpu")
-    global_hidden = torch.randn(
-        1,
-        tokens,
-        hidden_size,
-        device=stream_device,
-        generator=torch.Generator(stream_device).manual_seed(123),
-    )
-    global_target = torch.randn(
-        1,
-        tokens,
-        hidden_size,
-        device=stream_device,
-        generator=torch.Generator(stream_device).manual_seed(124),
-    )
-    shard_ids = token_ids.to(stream_device)
-    batch = PackedTrainingBatch(
-        # Only the reference needs the whole stream; drop it when not validating so large runs fit.
-        global_hidden=global_hidden if validate else None,
-        global_target=global_target if validate else None,
-        global_offsets=torch.tensor(cu_seqlens_global, dtype=torch.int32, device=device),
-        local_hidden=global_hidden[:, shard_ids].to(device).requires_grad_(),
-        local_target=global_target[:, shard_ids].to(device),
-        routing=plan.routing(device, conv_history=short_conv_kernel_size - 1),
-        token_ids=token_ids,
-        terminal_index=torch.tensor(plan.terminal, dtype=torch.long, device=device),
-        terminal_sequences=torch.tensor(
-            [plan.subsequences[index].sequence for index in plan.terminal],
-            dtype=torch.long,
-            device=device,
-        ),
-        loss_scale=1.0 / global_target.numel(),
-    )
-    del global_hidden, global_target, shard_ids
-    if validate:
-        reference_model = DeltaRuleAttention(**model_options)
-        reference_model.load_state_dict(model.state_dict())
-        validate_against_reference(model, reference_model, batch)
-        del reference_model
-    else:
-        # Warm up compilation and autotuning so the profiled step measures only the model.
-        run_training_step(
-            model,
-            batch.local_hidden,
-            batch.local_target,
-            batch.routing,
-            batch.terminal_index,
-            batch.loss_scale,
+        status = "passed" if validate else "ran"
+        print(
+            f"rank {dist.get_rank()}: full packed {variant.value.upper()} CP "
+            f"({partition.value}, {core_backend.value}) {status} [{mode}]",
+            flush=True,
         )
-    gc.collect()
-
-    profile_mode = "cuda_graph" if cuda_graph else "eager"
-    profile_path = Path(
-        "data",
-        f"{variant.value}_context_parallel_{profile_mode}_{partition.value}_{kda_backend.value}"
-        f"_{compute_dtype.value}_w{world_size}_t{tokens}_h{heads}_c{hidden_size}"
-        f"_conv{short_conv_kernel_size}",
-    ).resolve()
-    if benchmark_steps:
-        run_benchmark(
-            make_model,
-            model,
-            batch,
-            device,
-            steps=benchmark_steps,
-            warmup_steps=warmup_steps,
-            cuda_graph=cuda_graph,
-            output_path=Path(
-                "data",
-                f"{variant.value}_cp_scaling_{profile_mode}_{partition.value}_{kda_backend.value}"
-                f"_{compute_dtype.value}_w{world_size}_t{tokens}_h{heads}_c{hidden_size}.json",
-            ).resolve(),
-            config={
-                "tokens": tokens,
-                "sequence_lengths": list(lengths),
-                "partition": partition.value,
-                "hidden_size": hidden_size,
-                "heads": heads,
-                "head_dim": 128,
-                "variant": variant.value,
-                "compute_dtype": compute_dtype.value,
-                "short_conv_kernel_size": short_conv_kernel_size,
-                "kda_backend": kda_backend.value,
-                "device_name": torch.cuda.get_device_name(device),
-                "torch": torch.__version__,
-            },
-        )
-    elif cuda_graph:
-        validate_cuda_graph(
-            make_model,
-            model,
-            batch,
-            graph_annotations_available,
-            profile_path if profile else None,
-            device,
-            warmup_steps,
-        )
-    elif profile:
-        profile_eager_step(model, batch, profile_path, device, warmup_steps)
-
-    mode = " with CUDA Graph replay" if cuda_graph else ""
-    status = "passed" if validate else "ran"
-    print(
-        f"rank {cp_rank}: full packed {variant.value.upper()} CP ({partition.value}, {kda_backend.value}) {status}{mode}",
-        flush=True,
-    )
-    torch.cuda.synchronize(device)
-    dist.destroy_process_group()
 
 
 if __name__ == "__main__":
-    if "LOCAL_RANK" not in os.environ:
-        raise RuntimeError("launch with torchrun --standalone --nproc-per-node=<world_size>")
     typer.run(main)

--- a/examples/delta_rule_training.py
+++ b/examples/delta_rule_training.py
@@ -36,32 +36,38 @@ Pack Zipf-distributed sequence lengths into one physical batch with::
 
 In packed mode, ``batch-size`` is the number of logical sequences and ``tokens``
 is the longest sequence. Add ``--profile`` to export a backend- and shape-named
-Chrome trace. The trace
+native Perfetto trace (``.pftrace``, requires transformer-nuggets). The trace
 contains explicit ``forward`` and ``backward`` record-function ranges. Add
 ``--compile`` to compile the complete module with
 ``torch.compile(fullgraph=True)`` and fuse the PyTorch work around the custom
 delta-rule operator.
+
+The batch, loss/backward, and capture recipes below are also imported by the context-parallel
+example. Numerical assertions, trace export, and benchmark reporting stay in ``attn_gym.testing``.
 """
 
 from __future__ import annotations
 
+import gc
 import math
+import os
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager, nullcontext
+from dataclasses import dataclass
 from enum import Enum
-from functools import wraps
-from importlib import import_module
-from importlib.util import find_spec
+from functools import partial
 from itertools import accumulate
 from pathlib import Path
 from typing import Annotated, Any, Literal, NamedTuple
 
 import torch
+import torch.distributed as dist
 import torch.nn.functional as F
 import typer
 from torch import nn
 
 from attn_gym.linear import gate_transform
+from attn_gym.linear.context_parallel import ContextParallelPlan, ContextParallelRouting
 from attn_gym.linear.gdn import chunk_gdn
 from attn_gym.linear.kda import (
     MAX_GATE_LOWER_BOUND_MAGNITUDE,
@@ -73,6 +79,13 @@ from attn_gym.linear.kda import (
     mask_inactive_tokens,
 )
 from attn_gym.linear.types import KernelOptions
+from attn_gym.testing import annotate_kernels, kernel_stage, profile_trace, record_function
+from attn_gym.testing.delta_rule import (
+    assert_context_parallel_matches_reference,
+    measure_training_step,
+    profile_training_step,
+    write_benchmark_report,
+)
 
 Backend = Literal["reference", "fused"]
 Variant = Literal["kda", "gdn"]
@@ -106,64 +119,6 @@ class CoreBackendOption(str, Enum):
     MEGA = "mega"
 
 
-def _record_function(enabled: bool, name: str):
-    """Create a profiler range only when profiling is requested."""
-    return torch.profiler.record_function(name) if enabled else nullcontext()
-
-
-@contextmanager
-def _profile_trace(
-    enabled: bool,
-    path: Path,
-    activities: list[torch.profiler.ProfilerActivity],
-) -> Iterator[torch.profiler.profile | None]:
-    """Export an enhanced trace when transformer-nuggets is installed."""
-    if not enabled:
-        yield None
-        return
-
-    if find_spec("transformer_nuggets") is not None:
-        profiler = import_module("transformer_nuggets.utils.benchmark").profiler
-        with profiler(path, record_shapes=True, trace_format="chrome_json") as active_profiler:
-            yield active_profiler
-        return
-
-    with torch.profiler.profile(activities=activities) as active_profiler:
-        yield active_profiler
-    active_profiler.export_chrome_trace(str(path))
-
-
-def mark_kernels(*args: Any, **kwargs: Any):
-    """Load optional CUDA Graph annotations only when they are requested."""
-    from torch.cuda.graph_annotations import mark_kernels as annotate
-
-    return annotate(*args, **kwargs)
-
-
-def annotate_kernels(name: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-    """Label one stage during annotation-enabled CUDA Graph capture."""
-
-    def decorate(function: Callable[..., Any]) -> Callable[..., Any]:
-        @wraps(function)
-        def annotated(self: Any, *args: Any, **kwargs: Any) -> Any:
-            if not self.enable_graph_annotations:
-                return function(self, *args, **kwargs)
-            with mark_kernels(name.format(variant=self.variant, backend=self.backend)):
-                return function(self, *args, **kwargs)
-
-        return annotated
-
-    return decorate
-
-
-class DeltaRuleAttentionOutput(NamedTuple):
-    """Hidden states and optional recurrent and convolution states."""
-
-    hidden_states: torch.Tensor
-    final_state: torch.Tensor | None
-    final_conv_state: torch.Tensor | None
-
-
 def packed_sequence_metadata(
     num_sequences: int,
     max_tokens: int,
@@ -174,6 +129,35 @@ def packed_sequence_metadata(
     weights = torch.arange(1, max_tokens + 1, dtype=torch.float64).reciprocal()
     lengths = tuple(torch.multinomial(weights, num_sequences, replacement=True).add(1).tolist())
     return lengths, (0, *accumulate(lengths))
+
+
+class DeltaRuleAttentionOutput(NamedTuple):
+    """Hidden states and optional recurrent and convolution states."""
+
+    hidden_states: torch.Tensor
+    final_state: torch.Tensor | None
+    final_conv_state: torch.Tensor | None
+
+
+@dataclass(frozen=True)
+class PackedTrainingBatch:
+    """Global reference tensors and this rank's span and per-call routing.
+
+    ``token_ids`` maps span positions to global token ids; ``terminal_index`` lists the local
+    subsequences that end their sequence and ``terminal_sequences`` the matching global sequence
+    ids, so endpoint states can be compared with the unsharded run.
+    """
+
+    global_hidden: torch.Tensor | None
+    global_target: torch.Tensor | None
+    global_offsets: torch.Tensor
+    local_hidden: torch.Tensor
+    local_target: torch.Tensor
+    routing: ContextParallelRouting
+    token_ids: torch.Tensor
+    terminal_index: torch.Tensor
+    terminal_sequences: torch.Tensor
+    loss_scale: float
 
 
 class DeltaRuleAttention(nn.Module):
@@ -397,13 +381,13 @@ class DeltaRuleAttention(nn.Module):
             final_conv_state,
         )
 
-    @annotate_kernels("{variant}/qkv_projection")
+    @annotate_kernels("{module.variant}/qkv_projection")
     def qkv_projection(self, hidden_states: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         hidden_states = hidden_states.to(self.compute_dtype)
         qkv = F.linear(hidden_states, self.qkv_proj.weight.to(self.compute_dtype))
         return hidden_states, qkv
 
-    @annotate_kernels("{variant}/short_convolution")
+    @annotate_kernels("{module.variant}/short_convolution")
     def short_convolution(
         self,
         qkv: torch.Tensor,
@@ -447,7 +431,7 @@ class DeltaRuleAttention(nn.Module):
         final_state = conv_input[:, tokens:].clone() if return_final_state else None
         return qkv, final_state
 
-    @annotate_kernels("{variant}/qk_normalization")
+    @annotate_kernels("{module.variant}/qk_normalization")
     def qk_normalization(
         self,
         q: torch.Tensor,
@@ -462,7 +446,7 @@ class DeltaRuleAttention(nn.Module):
 
         return l2norm(q, cu_seqlens=cu_seqlens), l2norm(k, cu_seqlens=cu_seqlens)
 
-    @annotate_kernels("{variant}/gate_projections")
+    @annotate_kernels("{module.variant}/gate_projections")
     def gate_projections(self, hidden_states: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         batch, tokens, _ = hidden_states.shape
         if self.variant == "kda":
@@ -490,7 +474,7 @@ class DeltaRuleAttention(nn.Module):
         )
         return raw_gate.contiguous(), beta
 
-    @annotate_kernels("{variant}/gate_activation")
+    @annotate_kernels("{module.variant}/gate_activation")
     def gate_activation(self, raw_gate: torch.Tensor) -> torch.Tensor:
         """Map projection outputs to per-token natural-log decay."""
         if self.variant == "kda":
@@ -507,7 +491,7 @@ class DeltaRuleAttention(nn.Module):
             impl=self.backend,
         )
 
-    @annotate_kernels("{variant}/core/{backend}")
+    @annotate_kernels("{module.variant}/core/{module.backend}")
     def delta_rule_core(
         self,
         q: torch.Tensor,
@@ -548,7 +532,7 @@ class DeltaRuleAttention(nn.Module):
             kernel_options=self.kernel_options,
         )
 
-    @annotate_kernels("{variant}/output_normalization")
+    @annotate_kernels("{module.variant}/output_normalization")
     def output_normalization(self, output: torch.Tensor) -> torch.Tensor:
         # TODO: Consider a cu_seqlens-aware RMSNorm for fixed-capacity CUDA Graph
         # replay. Masking makes the inactive suffix numerically inert, but native
@@ -560,7 +544,7 @@ class DeltaRuleAttention(nn.Module):
             eps=self.rms_norm_eps,
         )
 
-    @annotate_kernels("{variant}/output_gate")
+    @annotate_kernels("{module.variant}/output_gate")
     def output_gate(self, hidden_states: torch.Tensor, output: torch.Tensor) -> torch.Tensor:
         gate_features = F.linear(
             hidden_states,
@@ -575,12 +559,324 @@ class DeltaRuleAttention(nn.Module):
             .sigmoid()
         )
 
-    @annotate_kernels("{variant}/output_projection")
+    @annotate_kernels("{module.variant}/output_projection")
     def output_projection(self, output: torch.Tensor, output_gate: torch.Tensor) -> torch.Tensor:
         return F.linear(
             (output * output_gate).flatten(-2).to(self.compute_dtype),
             self.out_proj.weight.to(self.compute_dtype),
         )
+
+
+@contextmanager
+def distributed_device() -> Iterator[torch.device]:
+    """Own the single-node NCCL world group launched by torchrun."""
+    if "LOCAL_RANK" not in os.environ:
+        raise RuntimeError("launch with torchrun --standalone --nproc-per-node=<world_size>")
+    device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+    torch.cuda.set_device(device)
+    dist.init_process_group("nccl", device_id=device)
+    try:
+        yield device
+    finally:
+        torch.cuda.synchronize(device)
+        dist.destroy_process_group()
+
+
+def make_context_parallel_batch(
+    plan: ContextParallelPlan,
+    offsets: tuple[int, ...],
+    hidden_size: int,
+    device: torch.device,
+    *,
+    conv_history: int,
+    validate: bool,
+) -> PackedTrainingBatch:
+    """Build a deterministic global stream, retaining only this rank's shard unless validating.
+
+    All ranks use the same data seeds. Without reference validation, generate on CPU and move
+    only the shard: allocating the whole stream on CUDA can leave large cached segments behind
+    and distort the captured benchmark's memory footprint.
+    """
+    token_ids = plan.global_token_ids(device)
+    stream_device = device if validate else torch.device("cpu")
+    global_hidden = torch.randn(
+        1,
+        offsets[-1],
+        hidden_size,
+        device=stream_device,
+        generator=torch.Generator(stream_device).manual_seed(123),
+    )
+    global_target = torch.randn(
+        1,
+        offsets[-1],
+        hidden_size,
+        device=stream_device,
+        generator=torch.Generator(stream_device).manual_seed(124),
+    )
+    shard_ids = token_ids.to(stream_device)
+    return PackedTrainingBatch(
+        global_hidden=global_hidden if validate else None,
+        global_target=global_target if validate else None,
+        global_offsets=torch.tensor(offsets, dtype=torch.int32, device=device),
+        local_hidden=global_hidden[:, shard_ids].to(device).requires_grad_(),
+        local_target=global_target[:, shard_ids].to(device),
+        routing=plan.routing(device, conv_history=conv_history),
+        token_ids=token_ids,
+        terminal_index=torch.tensor(plan.terminal, dtype=torch.long, device=device),
+        terminal_sequences=torch.tensor(
+            [plan.subsequences[index].sequence for index in plan.terminal],
+            dtype=torch.long,
+            device=device,
+        ),
+        loss_scale=1.0 / global_target.numel(),
+    )
+
+
+def run_training_step(
+    module: torch.nn.Module,
+    hidden_states: torch.Tensor,
+    target: torch.Tensor,
+    routing: ContextParallelRouting,
+    state_index: torch.Tensor,
+    loss_scale: float,
+    *,
+    annotate: bool = False,
+) -> tuple[DeltaRuleAttentionOutput, tuple[torch.Tensor, ...]]:
+    """Run the complete module and differentiate its token and endpoint losses."""
+    module.enable_graph_annotations = annotate
+    result = module(
+        hidden_states,
+        routing=routing,
+        return_final_state=True,
+    )
+    return result, training_gradients(
+        module, result, hidden_states, target, state_index, loss_scale, annotate=annotate
+    )
+
+
+def training_gradients(
+    module: torch.nn.Module,
+    result: DeltaRuleAttentionOutput,
+    hidden_states: torch.Tensor,
+    target: torch.Tensor,
+    state_index: torch.Tensor,
+    loss_scale: float,
+    *,
+    annotate: bool = False,
+) -> tuple[torch.Tensor, ...]:
+    """Differentiate the same token and true-endpoint losses in CP and unsharded runs."""
+    assert result.final_state is not None
+    assert result.final_conv_state is not None
+    loss = F.mse_loss(result.hidden_states.float(), target, reduction="sum") * loss_scale
+    # Only true sequence ends carry a loss; intermediate subsequence states are handed downstream.
+    loss = loss + 1e-4 * result.final_state[state_index].square().sum()
+    loss = loss + 1e-4 * result.final_conv_state[state_index].float().square().sum()
+    inputs = (hidden_states, *tuple(module.parameters()))
+    with kernel_stage("cp/bwd", annotate, backward=False):
+        return torch.autograd.grad(loss, inputs)
+
+
+def validate_against_reference(
+    model: torch.nn.Module,
+    reference_model: torch.nn.Module,
+    batch: PackedTrainingBatch,
+) -> None:
+    """Compare one sharded full-module backward with the unsharded module."""
+    result, gradients = run_training_step(
+        model,
+        batch.local_hidden,
+        batch.local_target,
+        batch.routing,
+        batch.terminal_index,
+        batch.loss_scale,
+    )
+    assert batch.global_hidden is not None and batch.global_target is not None
+    reference_hidden = batch.global_hidden.detach().clone().requires_grad_()
+    # Unsharded, every sequence in the stream ends here, so every exit state is a true final state.
+    every_sequence = torch.arange(
+        batch.global_offsets.shape[0] - 1, device=reference_hidden.device
+    )
+    reference_result = reference_model(
+        reference_hidden, cu_seqlens=batch.global_offsets, return_final_state=True
+    )
+    reference_gradients = training_gradients(
+        reference_model,
+        reference_result,
+        reference_hidden,
+        batch.global_target,
+        every_sequence,
+        batch.loss_scale,
+    )
+
+    assert_context_parallel_matches_reference(
+        [
+            (result.hidden_states, reference_result.hidden_states[:, batch.token_ids]),
+            (gradients[0], reference_gradients[0][:, batch.token_ids]),
+            (
+                result.final_state[batch.terminal_index],
+                reference_result.final_state[batch.terminal_sequences],
+            ),
+            (
+                result.final_conv_state[batch.terminal_index],
+                reference_result.final_conv_state[batch.terminal_sequences],
+            ),
+        ],
+        zip(gradients[1:], reference_gradients[1:], strict=True),
+        model.compute_dtype,
+    )
+
+
+@contextmanager
+def capture_training_graph(
+    make_model: Callable[[], torch.nn.Module],
+    eager_model: torch.nn.Module,
+    batch: PackedTrainingBatch,
+    *,
+    validate: bool = False,
+    annotations: bool = False,
+) -> Iterator[torch.cuda.CUDAGraph]:
+    """Own a captured training step and its backing model/input until the caller finishes.
+
+    Validation retains an eager oracle and captured outputs to check a changed-input replay.
+    Benchmarking discards step outputs and clears the cache before capture instead, so those
+    allocations do not inflate its graph-pool footprint. Both paths use the same stream lifecycle.
+    """
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        # Parameter AccumulateGrad nodes retain their first stream: use a fresh model and keep
+        # its warmup, eager oracle (if requested), and capture on this stream.
+        model = make_model()
+        model.load_state_dict(eager_model.state_dict())
+        static_hidden = batch.local_hidden.detach().clone().requires_grad_()
+        step = partial(
+            run_training_step,
+            model,
+            target=batch.local_target,
+            routing=batch.routing,
+            state_index=batch.terminal_index,
+            loss_scale=batch.loss_scale,
+        )
+        if validate:
+            # Warm up on the changed input that replay will see, before the graph pool exists.
+            eager_hidden = (static_hidden.detach() * 0.75).requires_grad_()
+            eager_result, eager_gradients = step(eager_hidden)
+            del eager_hidden
+        else:
+            step(static_hidden)
+    stream.synchronize()
+    gc.collect()
+    if not validate:
+        # The warmup activations are dead; do not layer the graph pool over their cached segments.
+        torch.cuda.empty_cache()
+    dist.barrier()
+
+    graph = torch.cuda.CUDAGraph()
+    try:
+        with torch.cuda.graph(graph, stream=stream, enable_annotations=annotations):
+            if validate:
+                graph_result, graph_gradients = step(static_hidden, annotate=annotations)
+            else:
+                step(static_hidden, annotate=annotations)
+        torch.cuda.current_stream().wait_stream(stream)
+        if validate:
+            captured_output = graph_result.hidden_states.clone()
+            torch.cuda.synchronize(static_hidden.device)
+            with torch.no_grad():
+                static_hidden.mul_(0.75)
+            graph.replay()
+            torch.cuda.synchronize(static_hidden.device)
+            if torch.equal(graph_result.hidden_states, captured_output):
+                raise AssertionError("CUDA Graph replay did not observe changed inputs")
+            torch.testing.assert_close(graph_result, eager_result)
+            torch.testing.assert_close(graph_gradients, eager_gradients)
+        yield graph
+    finally:
+        torch.cuda.synchronize(static_hidden.device)
+        graph.reset()
+        gc.collect()
+
+
+def profile_eager_step(
+    model: torch.nn.Module,
+    batch: PackedTrainingBatch,
+    profile_path: Path,
+    device: torch.device,
+    warmup_steps: int,
+) -> None:
+    """Profile a complete eager forward/backward on a fresh input leaf."""
+    hidden_states = batch.local_hidden.detach().clone().requires_grad_()
+    profile_training_step(
+        partial(
+            run_training_step,
+            model,
+            hidden_states,
+            batch.local_target,
+            batch.routing,
+            batch.terminal_index,
+            batch.loss_scale,
+        ),
+        profile_path,
+        device,
+        warmup_steps,
+    )
+
+
+def run_benchmark(
+    make_model: Callable[[], torch.nn.Module],
+    model: torch.nn.Module,
+    batch: PackedTrainingBatch,
+    device: torch.device,
+    *,
+    steps: int,
+    warmup_steps: int,
+    cuda_graph: bool,
+    sequence_lengths: tuple[int, ...],
+    partition: str,
+) -> None:
+    """Time steady-state training steps and record per-rank memory; rank 0 writes JSON.
+
+    Step time is measured per rank with CUDA events; the reported step time is
+    the slowest rank per iteration, which is what gates training. Memory is the
+    peak above what is resident before the timed steps (parameters, inputs, and
+    the graph's static buffers when captured).
+    """
+    hidden_states = batch.local_hidden.detach().clone().requires_grad_()
+    # The capture context owns its model and static input through timing and memory sampling.
+    with (
+        capture_training_graph(make_model, model, batch) if cuda_graph else nullcontext()
+    ) as graph:
+        step: Callable[[], object] = (
+            graph.replay
+            if graph is not None
+            else partial(
+                run_training_step,
+                model,
+                hidden_states,
+                batch.local_target,
+                batch.routing,
+                batch.terminal_index,
+                batch.loss_scale,
+            )
+        )
+        measurement = measure_training_step(
+            step,
+            device,
+            steps=steps,
+            warmup_steps=warmup_steps,
+            local_tokens=int(batch.token_ids.numel()),
+        )
+    # Release the graph pool before rank-report collectives allocate staging buffers.
+    write_benchmark_report(
+        measurement,
+        model,
+        device,
+        steps=steps,
+        warmup_steps=warmup_steps,
+        cuda_graph=cuda_graph,
+        sequence_lengths=sequence_lengths,
+        partition=partition,
+    )
 
 
 def main(
@@ -626,8 +922,8 @@ def main(
         bool,
         typer.Option(
             help=(
-                "Export a named Chrome trace with forward/backward ranges and optional "
-                "transformer-nuggets postprocessing."
+                "Export a native Perfetto .pftrace with forward/backward ranges "
+                "(requires transformer-nuggets)."
             )
         ),
     ] = False,
@@ -683,13 +979,13 @@ def main(
 
     def train_step() -> torch.Tensor:
         optimizer.zero_grad(set_to_none=True)
-        with _record_function(profile, f"{profile_name}/forward"):
+        with record_function(profile, f"{profile_name}/forward"):
             output = model(hidden_states, cu_seqlens=cu_seqlens).hidden_states
-        with _record_function(profile, f"{profile_name}/loss"):
+        with record_function(profile, f"{profile_name}/loss"):
             loss = F.mse_loss(output.float(), target)
-        with _record_function(profile, f"{profile_name}/backward"):
+        with record_function(profile, f"{profile_name}/backward"):
             grad_scaler.scale(loss).backward()
-        with _record_function(profile, f"{profile_name}/optimizer"):
+        with record_function(profile, f"{profile_name}/optimizer"):
             grad_scaler.step(optimizer)
             grad_scaler.update()
         return loss
@@ -700,11 +996,8 @@ def main(
         if hidden_states.is_cuda:
             torch.cuda.synchronize(hidden_states.device)
 
-    activities = [torch.profiler.ProfilerActivity.CPU]
-    if hidden_states.is_cuda:
-        activities.append(torch.profiler.ProfilerActivity.CUDA)
-    profile_path = Path(f"{profile_name}.json")
-    with _profile_trace(profile, profile_path, activities) as active_profiler:
+    profile_path = Path(f"{profile_name}.pftrace")
+    with profile_trace(profile_path) if profile else nullcontext() as active_profiler:
         for step in range(steps):
             loss = train_step()
             if active_profiler is not None:

--- a/test/test_delta_rule_context_parallel_cli.py
+++ b/test/test_delta_rule_context_parallel_cli.py
@@ -1,0 +1,120 @@
+"""Check CP command-line/data wiring without launching CUDA kernels or process groups."""
+
+from contextlib import nullcontext
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+pytest.importorskip("cutlass")
+typer = pytest.importorskip("typer")
+from typer.testing import CliRunner
+
+from examples import delta_rule_context_parallel as cp
+from examples.delta_rule_training import packed_sequence_metadata
+
+
+@pytest.mark.parametrize("explicit_lengths", [False, True])
+@pytest.mark.parametrize("legacy_names", [False, True])
+def test_cli_uses_shared_packed_data_and_familiar_options(
+    monkeypatch, explicit_lengths, legacy_names
+):
+    monkeypatch.setattr(cp, "distributed_device", lambda: nullcontext(torch.device("cpu")))
+    monkeypatch.setattr(cp.dist, "get_rank", lambda: 1)
+    monkeypatch.setattr(cp.dist, "get_world_size", lambda: 3)
+    run = Mock()
+    make_batch = Mock(wraps=cp.make_context_parallel_batch)
+    monkeypatch.setattr(cp, "run_training_step", run)
+    monkeypatch.setattr(cp, "make_context_parallel_batch", make_batch)
+    app = typer.Typer()
+    app.command()(cp.main)
+    args = [
+        "--batch-size",
+        "4",
+        "--tokens",
+        "31",
+        "--hidden-size",
+        "12",
+        "--heads" if legacy_names else "--num-heads",
+        "3",
+        "--kda-backend" if legacy_names else "--core-backend",
+        "fused",
+        "--partition",
+        "zigzag",
+        "--no-validate",
+    ]
+    if explicit_lengths:
+        args += ["--sequence-lengths", "5,12,14"]
+    result = CliRunner().invoke(app, args)
+    assert result.exit_code == 0, result.output
+    run.assert_called_once()
+    model, hidden, target, routing, terminal_index, loss_scale = run.call_args.args
+    if explicit_lengths:
+        lengths, offsets = (5, 12, 14), (0, 5, 17, 31)
+    else:
+        torch.manual_seed(0)
+        lengths, offsets = packed_sequence_metadata(4, 31)
+    plan, actual_offsets, hidden_size, device = make_batch.call_args.args
+    assert actual_offsets == offsets
+    assert not make_batch.call_args.kwargs["validate"]
+    assert routing.cp_rank == 1
+    assert len(plan.fragments) == 2
+    assert hidden.shape == target.shape == (1, routing.tokens, hidden_size)
+    assert loss_scale == 1.0 / (sum(lengths) * hidden_size)
+    assert terminal_index.tolist() == list(plan.terminal)
+    assert isinstance(model, cp.ContextParallelDeltaRuleAttention)
+    assert isinstance(model, cp.DeltaRuleAttention)
+    assert model.num_heads == 3 and model.hidden_size == 12
+    assert model.backend == "fused" and device.type == "cpu"
+
+
+@pytest.mark.parametrize("mode", ["eager-profile", "graph", "graph-profile", "benchmark"])
+def test_cli_shows_each_execution_mode(monkeypatch, mode):
+    monkeypatch.setattr(cp, "distributed_device", lambda: nullcontext(torch.device("cpu")))
+    monkeypatch.setattr(cp.dist, "get_rank", lambda: 0)
+    monkeypatch.setattr(cp.dist, "get_world_size", lambda: 2)
+    monkeypatch.setattr(cp, "run_training_step", Mock())
+    monkeypatch.setattr(cp, "graph_annotations_available", lambda: False)
+    graph = Mock()
+    capture = Mock(return_value=nullcontext(graph))
+    eager_profile = Mock()
+    replay_profile = Mock(return_value=None)
+    benchmark = Mock()
+    monkeypatch.setattr(cp, "capture_training_graph", capture)
+    monkeypatch.setattr(cp, "profile_eager_step", eager_profile)
+    monkeypatch.setattr(cp, "record_distributed_profile", replay_profile)
+    monkeypatch.setattr(cp, "run_benchmark", benchmark)
+    options = {
+        "eager-profile": ["--profile"],
+        "graph": ["--cuda-graph"],
+        "graph-profile": ["--cuda-graph", "--profile"],
+        "benchmark": ["--benchmark-steps", "2", "--cuda-graph", "--profile"],
+    }
+    app = typer.Typer()
+    app.command()(cp.main)
+    result = CliRunner().invoke(
+        app,
+        [
+            "--sequence-lengths",
+            "17,13,31",
+            "--hidden-size",
+            "12",
+            "--num-heads",
+            "1",
+            "--no-validate",
+            *options[mode],
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert capture.call_count == int(mode in ("graph", "graph-profile"))
+    assert eager_profile.call_count == int(mode == "eager-profile")
+    assert replay_profile.call_count == int(mode == "graph-profile")
+    assert benchmark.call_count == int(mode == "benchmark")
+    if capture.called:
+        assert capture.call_args.kwargs == {"validate": True, "annotations": False}
+    if replay_profile.called:
+        assert replay_profile.call_args.args[0] == graph.replay
+    if benchmark.called:
+        assert benchmark.call_args.kwargs["cuda_graph"]
+        assert benchmark.call_args.kwargs["steps"] == 2
+        assert benchmark.call_args.kwargs["sequence_lengths"] == (17, 13, 31)

--- a/test/test_delta_rule_context_parallel_example.py
+++ b/test/test_delta_rule_context_parallel_example.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from contextlib import nullcontext
 from dataclasses import fields
 from datetime import timedelta
+from functools import partial
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 import torch
@@ -18,7 +21,12 @@ pytest.importorskip("typer")
 from attn_gym.linear.context_parallel import ContextParallelPlan, ContextParallelRouting
 from attn_gym.testing.kda import assert_relative_rms_within
 from examples.delta_rule_context_parallel import ContextParallelDeltaRuleAttention
-from examples.delta_rule_training import DeltaRuleAttention, DeltaRuleAttentionOutput
+from examples.delta_rule_training import (
+    DeltaRuleAttention,
+    DeltaRuleAttentionOutput,
+    PackedTrainingBatch,
+    capture_training_graph,
+)
 
 pytestmark = [
     pytest.mark.skipif(
@@ -202,6 +210,45 @@ def _rank_main(
                 torch.testing.assert_close(output_only.hidden_states, actual[0].hidden_states)
         torch.cuda.current_stream().wait_stream(stream)
         torch.cuda.synchronize(device)
+        if capture:
+            # Exercise the example's shared lifecycle, not only the hand-captured ABI above.
+            batch = PackedTrainingBatch(
+                global_hidden=global_hidden,
+                global_target=global_target,
+                global_offsets=torch.tensor(offsets, device=device, dtype=torch.int32),
+                local_hidden=hidden,
+                local_target=target,
+                routing=new_routing,
+                token_ids=ids,
+                terminal_index=torch.tensor(plan.terminal, device=device, dtype=torch.long),
+                terminal_sequences=torch.tensor(
+                    [plan.subsequences[index].sequence for index in plan.terminal],
+                    device=device,
+                    dtype=torch.long,
+                ),
+                loss_scale=1.0 / global_target.numel(),
+            )
+            make_model = partial(
+                ContextParallelDeltaRuleAttention, **options, group=dist.group.WORLD
+            )
+            for validate in (True, False):
+                # Both normal exit and a caller failure must release the captured graph.
+                error = (
+                    nullcontext()
+                    if validate
+                    else pytest.raises(RuntimeError, match="caller failed")
+                )
+                with (
+                    error,
+                    capture_training_graph(make_model, model, batch, validate=validate) as replay,
+                ):
+                    reset = Mock(wraps=replay.reset)
+                    replay.reset = reset
+                    replay.replay()
+                    torch.cuda.synchronize(device)
+                    if not validate:
+                        raise RuntimeError("caller failed")
+                reset.assert_called_once_with()
     finally:
         if graph is not None:
             graph.reset()

--- a/test/test_delta_rule_example_utils.py
+++ b/test/test_delta_rule_example_utils.py
@@ -1,0 +1,118 @@
+"""CPU checks for the data and process-lifetime helpers used by the CP example."""
+
+from contextlib import nullcontext
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from attn_gym.linear.context_parallel import ContextParallelPlan
+from attn_gym.testing import delta_rule
+
+
+@pytest.fixture
+def training():
+    """Load example recipes only when their optional fused dependencies are installed."""
+    pytest.importorskip("cutlass")
+    pytest.importorskip("typer")
+    from examples import delta_rule_training
+
+    return delta_rule_training
+
+
+def test_reference_checks_reduce_copies_of_parameter_gradients(monkeypatch):
+    gradient = torch.tensor([0.25, -0.5, 2.0], requires_grad=True)
+    original = gradient.detach().clone()
+    reduce = Mock(side_effect=lambda value: value.mul_(2))
+    monkeypatch.setattr(delta_rule.dist, "all_reduce", reduce)
+    output = torch.tensor([1.0, -2.0])
+    delta_rule.assert_context_parallel_matches_reference(
+        [(output, output.clone())], [(gradient, original * 2)], torch.bfloat16
+    )
+    reduce.assert_called_once()
+    assert reduce.call_args.args[0].data_ptr() != gradient.data_ptr()
+    torch.testing.assert_close(gradient, original)
+
+
+@pytest.mark.parametrize("mismatch", ["output", "parameter"])
+def test_reference_checks_reject_mismatches(monkeypatch, mismatch):
+    monkeypatch.setattr(delta_rule.dist, "all_reduce", lambda value: None)
+    actual = torch.tensor([1.0, -2.0])
+    expected = actual + 1.0
+    pairs = [(actual, expected)] if mismatch == "output" else [(actual, actual)]
+    gradients = [(actual, expected)] if mismatch == "parameter" else [(actual, actual)]
+    with pytest.raises(AssertionError):
+        delta_rule.assert_context_parallel_matches_reference(pairs, gradients, torch.bfloat16)
+
+
+@pytest.mark.parametrize(
+    "fragments",
+    [
+        pytest.param([[(0, 15)], [(15, 31)]], id="contiguous-2"),
+        pytest.param([[(0, 10)], [(10, 20)], [(20, 31)]], id="contiguous-3"),
+        pytest.param([[(0, 7), (23, 31)], [(7, 15), (15, 23)]], id="zigzag-2"),
+        pytest.param(
+            [[(0, 5), (25, 31)], [(5, 10), (20, 25)], [(10, 15), (15, 20)]], id="zigzag-3"
+        ),
+    ],
+)
+@pytest.mark.parametrize("validate", [False, True])
+def test_batch_shards_the_same_global_stream(fragments, validate, training):
+    offsets = (0, 5, 17, 31)
+    world_size = len(fragments)
+    plans = [
+        ContextParallelPlan.from_fragments(offsets, fragments, rank) for rank in range(world_size)
+    ]
+    reference = training.make_context_parallel_batch(
+        plans[0], offsets, 4, torch.device("cpu"), conv_history=3, validate=True
+    )
+    rng_state = torch.get_rng_state()
+    batches = [
+        training.make_context_parallel_batch(
+            plan, offsets, 4, torch.device("cpu"), conv_history=3, validate=validate
+        )
+        for plan in plans
+    ]
+    # Batch construction has its own data seeds and must not perturb model initialization.
+    torch.testing.assert_close(torch.get_rng_state(), rng_state)
+    all_ids = torch.cat([batch.token_ids for batch in batches]).sort().values
+    torch.testing.assert_close(all_ids, torch.arange(offsets[-1]))
+    for rank, (plan, batch) in enumerate(zip(plans, batches, strict=True)):
+        torch.testing.assert_close(batch.local_hidden, reference.global_hidden[:, batch.token_ids])
+        torch.testing.assert_close(batch.local_target, reference.global_target[:, batch.token_ids])
+        assert (batch.global_hidden is not None) == validate
+        assert (batch.global_target is not None) == validate
+        assert batch.local_hidden.is_leaf and batch.local_hidden.requires_grad
+        assert not batch.local_target.requires_grad
+        assert batch.routing.cp_rank == rank
+        assert batch.loss_scale == 1.0 / (offsets[-1] * 4)
+        assert batch.terminal_index.tolist() == list(plan.terminal)
+        assert batch.terminal_sequences.tolist() == [
+            plan.subsequences[index].sequence for index in plan.terminal
+        ]
+        assert batch.routing.tail_sources.shape[-1] == 3
+
+
+@pytest.mark.parametrize("fail", [False, True])
+def test_distributed_device_cleans_up_on_caller_exit(monkeypatch, fail, training):
+    calls = Mock()
+    monkeypatch.setenv("LOCAL_RANK", "1")
+    monkeypatch.setattr(torch.cuda, "set_device", calls.set_device)
+    monkeypatch.setattr(torch.cuda, "synchronize", calls.synchronize)
+    monkeypatch.setattr(training.dist, "init_process_group", calls.init)
+    monkeypatch.setattr(training.dist, "destroy_process_group", calls.destroy)
+    error = pytest.raises(RuntimeError, match="caller failed") if fail else nullcontext()
+    with error, training.distributed_device() as device:
+        assert device == torch.device("cuda", 1)
+        calls.init.assert_called_once_with("nccl", device_id=device)
+        calls.destroy.assert_not_called()
+        if fail:
+            raise RuntimeError("caller failed")
+    calls.synchronize.assert_called_once_with(device)
+    calls.destroy.assert_called_once_with()
+    assert [entry[0] for entry in calls.mock_calls] == [
+        "set_device",
+        "init",
+        "synchronize",
+        "destroy",
+    ]

--- a/test/test_delta_rule_training_example.py
+++ b/test/test_delta_rule_training_example.py
@@ -15,6 +15,7 @@ pytest.importorskip("torch.cuda.graph_annotations", reason="the example requires
 
 from attn_gym.linear.context_parallel import ContextParallelRouting
 from attn_gym.linear.kda.constants import MAX_GATE_LOWER_BOUND_MAGNITUDE
+from attn_gym.testing import profiling
 from attn_gym.testing.kda import assert_relative_rms_within
 from examples import delta_rule_training
 from examples.delta_rule_context_parallel import ContextParallelDeltaRuleAttention
@@ -273,7 +274,7 @@ def test_example_marks_cuda_graph_kernel_stages(monkeypatch, variant):
         labels.append(annotation)
         yield
 
-    monkeypatch.setattr(delta_rule_training, "mark_kernels", record_mark_kernels)
+    monkeypatch.setattr(profiling, "mark_kernels", record_mark_kernels)
     model = DeltaRuleAttention(
         hidden_size=32,
         num_heads=1,

--- a/test/test_profiling.py
+++ b/test/test_profiling.py
@@ -1,0 +1,144 @@
+"""Portable coverage for optional example instrumentation, without CUDA or CuTeDSL."""
+
+import sys
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from attn_gym.testing import annotate_kernels, profile_trace, profiling, record_function
+
+
+class AnnotatedModule(torch.nn.Module):
+    """A non-delta-rule module exercising the shared method decorator."""
+
+    def __init__(self, enabled: bool):
+        super().__init__()
+        self.enable_graph_annotations = enabled
+        self.label = "example"
+
+    @annotate_kernels("{module.label}/forward")
+    def forward(self, value: torch.Tensor, *, offset: float = 1.0) -> torch.Tensor:
+        """Keep keyword arguments and autograd intact under the decorator."""
+        return value.square() + offset
+
+
+def unexpected_optional_dependency(*args, **kwargs):
+    """Fail if disabled instrumentation probes or invokes an optional dependency."""
+    pytest.fail("disabled instrumentation accessed an optional dependency")
+
+
+@pytest.mark.parametrize("compiled", [False, True])
+def test_disabled_annotations_preserve_fullgraph_autograd(monkeypatch, compiled):
+    monkeypatch.setattr(profiling, "mark_kernels", unexpected_optional_dependency)
+    module = AnnotatedModule(False)
+    # Disabled decoration must not even try to format its label.
+    del module.label
+    call = torch.compile(module, backend="eager", fullgraph=True) if compiled else module
+    value = torch.tensor([-2.0, 0.5, 3.0], requires_grad=True)
+    result = call(value, offset=2.0)
+    (grad,) = torch.autograd.grad(result.sum(), value)
+    torch.testing.assert_close(result, value.square() + 2.0)
+    torch.testing.assert_close(grad, 2.0 * value)
+
+
+def test_enabled_annotations_preserve_labels_and_autograd(monkeypatch):
+    labels = []
+
+    @contextmanager
+    def mark(name):
+        labels.append(name)
+        yield
+
+    monkeypatch.setattr(profiling, "mark_kernels", mark)
+    value = torch.tensor([-1.5, 2.0], requires_grad=True)
+    result = AnnotatedModule(True)(value, offset=3.0)
+    (grad,) = torch.autograd.grad(result.sum(), value)
+    assert labels == ["example/forward"]
+    assert AnnotatedModule.forward.__name__ == "forward"
+    torch.testing.assert_close(result, value.square() + 3.0)
+    torch.testing.assert_close(grad, 2.0 * value)
+
+
+def test_disabled_range_does_not_enter_profiler(monkeypatch):
+    monkeypatch.setattr(torch.profiler, "record_function", unexpected_optional_dependency)
+    with record_function(False, "ignored"):
+        pass
+
+
+def test_record_function_labels_cpu_trace():
+    with (
+        torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CPU]) as active,
+        record_function(True, "example/forward"),
+    ):
+        torch.arange(8).square()
+    assert "example/forward" in [event.key for event in active.key_averages()]
+
+
+def test_native_trace_reports_missing_dependency(monkeypatch, tmp_path):
+    def missing(name):
+        raise ImportError(name)
+
+    monkeypatch.setattr(profiling, "import_module", missing)
+    with (
+        pytest.raises(RuntimeError, match="requires transformer-nuggets"),
+        profile_trace(tmp_path / "missing.pftrace"),
+    ):
+        pytest.fail("missing profiler must not silently fall back to another format")
+
+
+def test_native_trace_uses_pftrace_and_forwards_warmup(monkeypatch, tmp_path):
+    calls = []
+    token = object()
+
+    @contextmanager
+    def profiler(path, *, record_shapes, trace_format, warmup):
+        calls.append((path, record_shapes, trace_format, warmup))
+        yield token
+
+    monkeypatch.setattr(
+        profiling, "import_module", lambda name: SimpleNamespace(profiler=profiler)
+    )
+    trace = tmp_path / "profiles" / "training"
+    with profile_trace(trace, warmup=2) as active:
+        assert active is token
+    assert trace.parent.is_dir()
+    assert calls == [(trace.with_suffix(".pftrace"), True, "track_event", 2)]
+
+
+def test_native_trace_rejects_outdated_profiler(monkeypatch, tmp_path):
+    def legacy_profiler(path, record_shapes=True):
+        pytest.fail("unsupported profiler must be rejected before entering it")
+
+    monkeypatch.setattr(
+        profiling, "import_module", lambda name: SimpleNamespace(profiler=legacy_profiler)
+    )
+    with (
+        pytest.raises(RuntimeError, match="lacks native Perfetto support"),
+        profile_trace(tmp_path / "outdated.pftrace"),
+    ):
+        pytest.fail("outdated profiler must not silently fall back to Chrome JSON")
+
+
+@pytest.mark.parametrize("available", [None, False, True])
+def test_graph_annotation_capability_is_optional(monkeypatch, available):
+    module = None if available is None else SimpleNamespace(is_available=lambda: available)
+    monkeypatch.setitem(sys.modules, "torch.cuda.graph_annotations", module)
+    assert profiling.graph_annotations_available() is bool(available)
+
+
+def test_kernel_stage_forwards_annotation_direction(monkeypatch):
+    labels = []
+
+    @contextmanager
+    def mark(name, *, backward):
+        labels.append((name, backward))
+        yield
+
+    monkeypatch.setattr(profiling, "mark_kernels", mark)
+    with profiling.kernel_stage("backward", True, backward=False):
+        pass
+    with profiling.kernel_stage("unannotated", False):
+        pass
+    assert labels == [("backward", False)]

--- a/test/test_profiling.py
+++ b/test/test_profiling.py
@@ -1,8 +1,9 @@
 """Portable coverage for optional example instrumentation, without CUDA or CuTeDSL."""
 
 import sys
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 import torch
@@ -126,6 +127,32 @@ def test_graph_annotation_capability_is_optional(monkeypatch, available):
     module = None if available is None else SimpleNamespace(is_available=lambda: available)
     monkeypatch.setitem(sys.modules, "torch.cuda.graph_annotations", module)
     assert profiling.graph_annotations_available() is bool(available)
+
+
+def test_distributed_native_merge_preserves_timestamps(monkeypatch, tmp_path):
+    path = tmp_path / "trace"
+    path.with_name("trace_rank_0.pftrace").write_bytes(b"rank0")
+    merge = Mock()
+    monkeypatch.setattr(
+        profiling, "import_module", lambda name: SimpleNamespace(merge_traces=merge)
+    )
+    monkeypatch.setattr(profiling, "profile_trace", lambda *args, **kwargs: nullcontext(Mock()))
+    monkeypatch.setattr(profiling.dist, "get_rank", lambda: 0)
+    monkeypatch.setattr(profiling.dist, "get_world_size", lambda: 2)
+    monkeypatch.setattr(profiling.dist, "barrier", lambda: None)
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda device: None)
+
+    def gather(value, outputs, dst):
+        assert value == b"rank0" and dst == 0
+        outputs[:] = [b"rank0", b"rank1"]
+
+    monkeypatch.setattr(profiling.dist, "gather_object", gather)
+    merged = profiling.record_distributed_profile(Mock(), path, "step", torch.device("cpu"))
+    assert merged == path.with_name("trace_merged.pftrace")
+    assert path.with_name("trace_rank_1.pftrace").read_bytes() == b"rank1"
+    merge.assert_called_once()
+    # Native merge rejects JSON's re-zeroing option; retain the native clock timestamps.
+    assert merge.call_args.kwargs.get("align_timestamps", False) is False
 
 
 def test_kernel_stage_forwards_annotation_direction(monkeypatch):

--- a/test/test_sequence_helpers.py
+++ b/test/test_sequence_helpers.py
@@ -1,0 +1,126 @@
+"""CPU contracts for the examples' Zipf sampling and user-editable rank mappings."""
+
+from itertools import pairwise
+
+import pytest
+import torch
+
+pytest.importorskip("cutlass", reason="the example modules import their optional fused kernels")
+pytest.importorskip("typer")
+
+from examples.delta_rule_context_parallel import partition_fragments
+from examples.delta_rule_training import packed_sequence_metadata
+
+
+@pytest.mark.parametrize("seed", [0, 7, 123])
+@pytest.mark.parametrize("num_sequences,max_tokens", [(1, 1), (4, 63), (32, 257)])
+def test_packed_sequence_metadata_matches_original_sampler(seed, num_sequences, max_tokens):
+    """Moving the sampler must preserve samples and consumption of the global RNG."""
+    with torch.random.fork_rng(devices=[]):
+        torch.manual_seed(seed)
+        weights = torch.arange(1, max_tokens + 1, dtype=torch.float64).reciprocal()
+        expected = tuple(
+            torch.multinomial(weights, num_sequences, replacement=True).add(1).tolist()
+        )
+        expected_next = torch.rand(8)
+
+        torch.manual_seed(seed)
+        lengths, offsets = packed_sequence_metadata(num_sequences, max_tokens)
+        actual_next = torch.rand(8)
+
+    assert lengths == expected
+    assert offsets == tuple(sum(expected[:index]) for index in range(num_sequences + 1))
+    torch.testing.assert_close(actual_next, expected_next, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("max_tokens", [1, 2, 31])
+def test_packed_sequence_metadata_bounds_and_offsets(max_tokens):
+    """Lengths stay in the truncated support and offsets describe every sampled token."""
+    with torch.random.fork_rng(devices=[]):
+        torch.manual_seed(42)
+        lengths, offsets = packed_sequence_metadata(64, max_tokens)
+    assert isinstance(lengths, tuple) and isinstance(offsets, tuple)
+    assert len(lengths) == 64
+    assert len(offsets) == 65
+    assert all(isinstance(length, int) and 1 <= length <= max_tokens for length in lengths)
+    assert offsets[0] == 0
+    assert offsets[-1] == sum(lengths)
+    assert tuple(end - start for start, end in pairwise(offsets)) == lengths
+
+
+@pytest.mark.parametrize("max_tokens", [0, -1])
+def test_packed_sequence_metadata_rejects_empty_support(max_tokens):
+    with pytest.raises(ValueError, match="at least one token"):
+        packed_sequence_metadata(4, max_tokens)
+
+
+@pytest.mark.parametrize("partition", ["contiguous", "zigzag"])
+@pytest.mark.parametrize("world_size", [1, 2, 3, 7])
+def test_partition_fragments_preserves_divisible_boundaries(partition, world_size):
+    """Divisible totals retain the original CP example's exact block ownership."""
+    blocks = world_size if partition == "contiguous" else 2 * world_size
+    size = 11
+    expected = []
+    for rank in range(world_size):
+        ranges = [(rank * size, (rank + 1) * size)]
+        if partition == "zigzag":
+            ranges.append(((blocks - 1 - rank) * size, (blocks - rank) * size))
+        expected.append(ranges)
+    assert partition_fragments(blocks * size, world_size, partition) == expected
+
+
+@pytest.mark.parametrize(
+    "partition,expected",
+    [
+        ("contiguous", [[(0, 4)], [(4, 8)], [(8, 13)]]),
+        ("zigzag", [[(0, 2), (10, 13)], [(2, 4), (8, 10)], [(4, 6), (6, 8)]]),
+    ],
+)
+def test_partition_fragments_odd_total_boundaries(partition, expected):
+    assert partition_fragments(13, 3, partition) == expected
+
+
+@pytest.mark.parametrize("partition", ["contiguous", "zigzag"])
+@pytest.mark.parametrize("world_size", [1, 2, 3, 7])
+@pytest.mark.parametrize("extra_tokens", [0, 1, 5, 16])
+def test_partition_fragments_tiles_all_tokens_in_local_order(partition, world_size, extra_tokens):
+    """Near-balanced blocks tile exactly, including minimal and non-divisible totals."""
+    blocks = world_size if partition == "contiguous" else 2 * world_size
+    tokens = blocks + extra_tokens
+    fragments = partition_fragments(tokens, world_size, partition)
+    assert len(fragments) == world_size
+    assert all(len(ranges) == blocks // world_size for ranges in fragments)
+    all_tokens = []
+    rank_sizes = []
+    block_sizes = []
+    for ranges in fragments:
+        local_tokens = [token for start, end in ranges for token in range(start, end)]
+        assert all(0 <= start < end <= tokens for start, end in ranges)
+        assert all(left < right for left, right in pairwise(local_tokens))
+        all_tokens.extend(local_tokens)
+        rank_sizes.append(len(local_tokens))
+        block_sizes.extend(end - start for start, end in ranges)
+    assert sorted(all_tokens) == list(range(tokens))
+    assert max(block_sizes) - min(block_sizes) <= 1
+    assert max(rank_sizes) - min(rank_sizes) <= (1 if partition == "contiguous" else 2)
+
+
+def test_partition_fragments_defaults_to_contiguous():
+    assert partition_fragments(13, 3) == [[(0, 4)], [(4, 8)], [(8, 13)]]
+
+
+@pytest.mark.parametrize(
+    "tokens,world_size,partition,message",
+    [
+        (13, 0, "contiguous", "world_size must be positive"),
+        (13, -1, "zigzag", "world_size must be positive"),
+        (13, 3, "unknown", "partition must be"),
+        (0, 1, "contiguous", "nonempty blocks"),
+        (-1, 1, "zigzag", "nonempty blocks"),
+        (2, 3, "contiguous", "nonempty blocks"),
+        (5, 3, "zigzag", "nonempty blocks"),
+    ],
+)
+def test_partition_fragments_rejects_invalid_inputs(tokens, world_size, partition, message):
+    with pytest.raises(ValueError, match=message):
+        partition_fragments(tokens, world_size, partition)


### PR DESCRIPTION
## Summary

- Keep the model, batch construction, loss/backward, reference comparison, and capture lifecycle visible in `examples/delta_rule_training.py`; the CP example imports those recipes and shows its run-mode branches explicitly.
- Keep rank mappings editable in the CP example and share its Zipf sampler from the base example. Align common CLI names while preserving the existing aliases and explicit sequence-length override.
- Limit `attn_gym.testing` helpers to numerical assertions, profiling, measurement, and report formatting. Preserve graph/input/model lifetime and release the graph before report collectives.
- Use native `.pftrace` export, report unsupported older transformer-nuggets installations clearly, and remove the JSON-only timestamp-alignment option from native rank-trace merging.
- Set CP attention dimensions to the current TorchTitan K3 preset: hidden size 7168, 96 heads, head dimension 128. This remains one attention module, not a full K3 model.

No attention kernels changed, and this PR makes no performance claim.

## Validation

On two H100s with PyTorch `2.15.0.dev20260905+cu132` and CuTeDSL `4.7.1`:

- 97 helper/CLI tests and 29 model/integration tests passed.
- KDA/GDN reference validation, CUDA Graph replay, and eager/captured benchmark CLI paths passed on uneven 61-token zigzag partitions; sampled-Zipf GDN replay passed.
- K3-width forward/backward and changed-input replay passed on an 8-token cross-rank sequence, including an uninstrumented run. The initial 60-second smoke budget expired during CPU compilation; stack dumps identified compilation, not a stuck GPU kernel.
- Single-device and merged two-rank native Perfetto exports passed and were decoded as nonempty protobuf traces using transformer-nuggets source revision `b8ae46b`.
- The native-merge regression failed before removing `align_timestamps=True` and passed afterward. All 13 portable profiling tests and scoped pre-commit checks passed.
