### PR TITLE
Route packed GDN recurrence through the KDA kernel and drop zero-filled intermediates

### DIFF
--- a/attn_gym/linear/_delta_rule/cute/affine_summary_fwd.py
+++ b/attn_gym/linear/_delta_rule/cute/affine_summary_fwd.py
@@ -70,9 +70,8 @@ halves of the I/O dtype and accumulated in two UMMA passes. The A operands
 (``w``, ``kg``) and ``u`` retain their original bf16/fp16 storage.
 
 Limitations:
-  - B=1, fixed K=V=128, BT=64; any ``T``. Token ranges come from a device ``bounds`` tensor and
-    a partial last chunk is neutralized in-kernel (gate row clamped, over-read ``kg`` columns
-    zeroed), which assumes the over-read tokens are finite: ``0 * inf`` is NaN.
+  - B=1, fixed K=V=128, BT=64; any ``T``. Token ranges come from a device ``bounds`` tensor;
+    partial last chunks clamp the gate row and zero every over-read UMMA operand in SMEM.
   - Contiguous inputs; SM100 (tcgen05) only.
 """
 
@@ -107,6 +106,45 @@ DATA_ALIGN_BYTES = 16
 
 _IO_TYPE_NAMES = {torch.bfloat16: "bf16", torch.float16: "fp16"}
 _CUTE_IO_TYPES = {"bf16": cutlass.BFloat16, "fp16": cutlass.Float16}
+
+
+def operand_view_layout(shape, token_mode: int):
+    """Map ``(rows, tokens)`` onto a staged UMMA operand's nested atom/rest modes.
+
+    Regrouping a CuTe identity layout preserves the stage's native coordinate space, including
+    its swizzle, without reconstructing compact strides.
+    """
+    identity = cute.make_identity_layout(shape)
+    (atom_0, atom_1), rest_0, rest_1 = identity.shape
+    (stride_a0, stride_a1), stride_r0, stride_r1 = identity.stride
+    modes = ((atom_0, rest_0), (atom_1, rest_1))
+    strides = ((stride_a0, stride_r0), (stride_a1, stride_r1))
+    row_mode = 1 - token_mode
+    return cute.make_layout(
+        (modes[row_mode], modes[token_mode]), stride=(strides[row_mode], strides[token_mode])
+    )
+
+
+@cute.jit
+def zero_tail_tokens(smem, stage, valid_rows, tid, io_type, token_mode: cutlass.Constexpr):
+    """Zero token rows ``>= valid_rows`` of one staged UMMA operand before the MMA reads it.
+
+    Selecting the over-read rows away in SMEM, rather than cancelling them with a ``0 *``
+    factor, keeps NaN/Inf garbage from uninitialized capacity slack out of the result.
+    ``token_mode`` names which atom/rest pair of the staged layout spans the tokens; one warp
+    (``tid`` in ``[0, 32)``) performs the stores.
+    """
+    stage_view = smem[None, None, None, stage]
+    view = cute.composition(stage_view, operand_view_layout(stage_view.shape, token_mode))
+    rows = cute.size(view, mode=[0])
+    warp_size = cute.arch.WARP_SIZE
+    assert cute.size(view, mode=[1]) == BT, "token modes must tile BT"
+    assert rows % warp_size == 0, "operand rows must be a multiple of the warp size"
+    for token in cutlass.range(valid_rows, BT, unroll=1):
+        for row_block in cutlass.range_constexpr(rows // warp_size):
+            view[tid + row_block * warp_size, token] = io_type(0.0)
+    cute.arch.fence_view_async_shared()
+    cute.arch.sync_warp()
 
 
 def _aligned(tensor: torch.Tensor) -> torch.Tensor:
@@ -494,9 +532,8 @@ class _AffineSummaryFwdOp:
         """Own the per-chunk TMA G2S loads for w, kg^T, u, and the gate row.
 
         The range starts at token ``start`` of the stream, so every descriptor is offset along
-        its token mode and chunk ``ct`` reads tokens ``start + ct * BT`` onward; a partial last
-        chunk over-reads into the next range's tokens (or TMA zero fill past ``T``), which the
-        MMA warp neutralizes through ``kg`` and the gate row clamp below.
+        its token mode and chunk ``ct`` reads tokens ``start + ct * BT`` onward. A partial last
+        chunk clamps the gate row here; the MMA warp zeroes each over-read operand stage.
         """
         batch = Int32(0)
         desc_w = cute.domain_offset((start, 0, (0, 0)), tma.w.desc)
@@ -549,7 +586,9 @@ class _AffineSummaryFwdOp:
         num_chunks,
         tail_chunk,
         tail_valid_rows,
+        sW,
         sKg,
+        sU,
         mma_wx,
         mma_kt,
         mma_ktu,
@@ -576,20 +615,23 @@ class _AffineSummaryFwdOp:
         passes over ``Kg^T @ (-wx)``; MMA1 likewise runs two passes over the
         hi/lo state snapshot, recovering ~fp32 operand precision.
 
-        Chunk ``tail_chunk`` (local index) holds only ``tail_valid_rows`` range tokens; its
-        remaining ``kg`` columns are zeroed before use so the over-read tokens contribute nothing
-        to either ``Kg^T @ U`` or ``Kg^T @ (-wx)``.
+        Chunk ``tail_chunk`` holds only ``tail_valid_rows`` range tokens. Its ``w``, ``kg^T``,
+        and ``u`` stages are zeroed past that boundary before UMMA reads them. Multiplying by a
+        zero mask would retain NaN/Inf from uninitialized capacity slack.
         """
         tid, _, _ = cute.arch.thread_idx()
         mma_tid = tid - WarpRole.MMA * self.WARP_SZ
         for ct in cutlass.range(0, num_chunks, unroll=0):
+            is_tail = ct == tail_chunk and tail_valid_rows != 0
             # --- MMA2a: kg^T(SMEM A) × U(SMEM B) → kt(TMEM), value tiles only ---
             kgh = pkg_C.wait_and_advance()
-            if ct == tail_chunk and tail_valid_rows != 0:
-                self._neutralize_kg_tail(sKg, kgh.index, tail_valid_rows, mma_tid)
+            if is_tail:
+                zero_tail_tokens(sKg, kgh.index, tail_valid_rows, mma_tid, self.io_type, 1)
             ktd = pkt_P.acquire_and_advance()
             if is_value:
                 uh = pu_C.wait_and_advance()
+                if is_tail:
+                    zero_tail_tokens(sU, uh.index, tail_valid_rows, mma_tid, self.io_type, 1)
                 for kp in cutlass.range_constexpr(cute.size(t_kg_au, mode=[2])):
                     mma_ktu.set(tcgen05.Field.ACCUMULATE, cutlass.Boolean(kp != 0))
                     cute.gemm(
@@ -603,6 +645,8 @@ class _AffineSummaryFwdOp:
 
             # --- MMA1: w(SMEM A) × X snapshot(SMEM B) → wx(TMEM) ---
             wh = pw_C.wait_and_advance()
+            if is_tail:
+                zero_tail_tokens(sW, wh.index, tail_valid_rows, mma_tid, self.io_type, 0)
             wxd = pwx_P.acquire_and_advance()
             for split in cutlass.range_constexpr(2):
                 # Each hi/lo half is one pipeline stage, published separately.
@@ -637,27 +681,6 @@ class _AffineSummaryFwdOp:
                 tmpbh.release()
             ktd.commit()
             kgh.release()
-
-    @cute.jit
-    def _neutralize_kg_tail(self, smem, stage, valid_rows, tid):
-        """Zero ``kg^T`` token columns ``>= valid_rows`` of one stage before UMMA reads it."""
-        row_atom = cute.size(smem, mode=[0, 0, 0])
-        token_atom = cute.size(smem, mode=[0, 1])
-        assert cute.size(smem, mode=[1]) == 1, "expected a single rest-M mode"
-        assert row_atom * cute.size(smem, mode=[0, 0, 1]) == KEY_DIM
-        assert token_atom * cute.size(smem, mode=[2]) == BT
-        for token in cutlass.range(valid_rows, BT, unroll=1):
-            for row_block in cutlass.range_constexpr(KEY_DIM // self.WARP_SZ):
-                row = tid + row_block * self.WARP_SZ
-                coordinate = (
-                    ((row % row_atom, row // row_atom), token % token_atom),
-                    0,
-                    token // token_atom,
-                    stage,
-                )
-                smem[coordinate] = self.io_type(0.0)
-        cute.arch.fence_view_async_shared()
-        cute.arch.sync_warp()
 
     @cute.jit
     def run_state(
@@ -1035,7 +1058,9 @@ class _AffineSummaryFwdOp:
                 num_chunks=chunk_end - chunk_begin,
                 tail_chunk=tail_chunk,
                 tail_valid_rows=tail_valid_rows,
+                sW=sW,
                 sKg=sKg,
+                sU=sU,
                 mma_wx=mma_wx,
                 mma_kt=mma_kt,
                 mma_ktu=mma_ktu,

--- a/attn_gym/linear/_delta_rule/cute/affine_summary_rev.py
+++ b/attn_gym/linear/_delta_rule/cute/affine_summary_rev.py
@@ -55,6 +55,7 @@ from attn_gym.linear._delta_rule.cute.affine_summary_fwd import (
     MAX_RANGES,
     decode_work_row,
     plan_work_budget,
+    zero_tail_tokens,
 )
 from attn_gym.linear._delta_rule.triton.work_items import compose_work_items, work_table
 from attn_gym.linear.kda.constants import is_sm100_kda_capability
@@ -503,50 +504,6 @@ class BlackwellDeltaAffineSummaryRev:
         return column_tile, head, work, start, length, chunk_begin, chunk_end
 
     @cute.jit
-    def _neutralize_do_tail(self, smem, stage, valid_rows, tid):
-        """Zero ``dO`` token rows ``>= valid_rows`` of one B-operand stage before UMMA reads it."""
-        column_atom = cute.size(smem, mode=[0, 0])
-        token_atom = cute.size(smem, mode=[0, 1])
-        assert column_atom * cute.size(smem, mode=[1]) == self.BN, "column modes must tile BN"
-        assert token_atom * cute.size(smem, mode=[2]) == self.BT, "token modes must tile BT"
-        for token in cutlass.range(valid_rows, self.BT, unroll=1):
-            for column_block in cutlass.range_constexpr(
-                (self.BN + self.WARP_SIZE - 1) // self.WARP_SIZE
-            ):
-                column = tid + column_block * self.WARP_SIZE
-                if column < self.BN:
-                    coordinate = (
-                        (column % column_atom, token % token_atom),
-                        column // column_atom,
-                        token // token_atom,
-                        stage,
-                    )
-                    smem[coordinate] = self.io_type(0.0)
-        cute.arch.fence_view_async_shared()
-        cute.arch.sync_warp()
-
-    @cute.jit
-    def _neutralize_w_tail(self, smem, stage, valid_rows, tid):
-        """Zero ``w^T`` token columns ``>= valid_rows`` of one A-operand stage before UMMA reads it."""
-        row_atom = cute.size(smem, mode=[0, 0, 0])
-        token_atom = cute.size(smem, mode=[0, 1])
-        assert cute.size(smem, mode=[1]) == 1, "expected a single rest-M mode"
-        assert row_atom * cute.size(smem, mode=[0, 0, 1]) == self.BK
-        assert token_atom * cute.size(smem, mode=[2]) == self.BT
-        for token in cutlass.range(valid_rows, self.BT, unroll=1):
-            for row_block in cutlass.range_constexpr(self.BK // self.WARP_SIZE):
-                row = tid + row_block * self.WARP_SIZE
-                coordinate = (
-                    ((row % row_atom, row // row_atom), token % token_atom),
-                    0,
-                    token // token_atom,
-                    stage,
-                )
-                smem[coordinate] = self.io_type(0.0)
-        cute.arch.fence_view_async_shared()
-        cute.arch.sync_warp()
-
-    @cute.jit
     def _tail_valid_rows(self, length):
         """Valid token rows of a range's last chunk, or zero when that chunk is full."""
         rows = length - ((length + self.BT - 1) // self.BT - 1) * self.BT
@@ -791,10 +748,8 @@ class BlackwellDeltaAffineSummaryRev:
             )
             has_source = column_tile < VAL_DIM // self.BN
 
-            # The range starts at token ``start``: offset every descriptor along its token mode
-            # so chunk ``ct`` reads tokens ``start + ct * BT`` onward. A partial last chunk
-            # over-reads the following tokens; the MMA warp neutralizes them through ``do`` and
-            # ``w`` and the gate row is clamped to the range's final token.
+            # A partial last chunk clamps the gate row here; the MMA warp zeroes every
+            # token-indexed operand stage past the range boundary.
             k_desc = cute.domain_offset((start, 0, (0, 0)), desc_k)
             w_desc = cute.domain_offset((0, start, (0, 0)), desc_w)
             gate_desc = cute.domain_offset((0, start, (0, 0)), desc_gate)
@@ -950,7 +905,10 @@ class BlackwellDeltaAffineSummaryRev:
         t_wdv_acc,
         t_w,
         t_dv,
+        s_k,
+        s_q,
         s_do,
+        s_aqk,
         s_w,
         state_consumer,
         k_consumer,
@@ -965,10 +923,10 @@ class BlackwellDeltaAffineSummaryRev:
     ):
         """Issue the four UMMA operations for each reverse chunk.
 
-        MMA1 (``kg @ X``) and MMA4 (``w^T @ dv``) each run two accumulate passes
-        over the hi/lo halves of their fp32-valued B operand. On a range's partial last
-        chunk the ``dO`` and ``w`` stages are zeroed past the valid rows before UMMA reads
-        them, so over-read tokens contribute nothing.
+        MMA1 (``kg @ X``) and MMA4 (``w^T @ dv``) each run two accumulate passes over the
+        hi/lo halves of their fp32-valued B operand. On a partial last chunk, ``kg``, ``qg^T``,
+        ``dO``, ``Aqk^T``, and ``w^T`` are zeroed past the range boundary before UMMA reads them.
+        Multiplying by a zero mask would retain NaN/Inf from uninitialized capacity slack.
         """
         cute.arch.setmaxregister_decrease(self.aux_regs)
         tid, _, _ = cute.arch.thread_idx()
@@ -998,8 +956,15 @@ class BlackwellDeltaAffineSummaryRev:
                     do_handle = do_consumer.wait_and_advance()
                     aqk_handle = aqk_consumer.wait_and_advance()
                     if is_tail:
-                        # Tokens past the range feed both Aqk^T dO and qg^T dO through dO.
-                        self._neutralize_do_tail(s_do, do_handle.index, tail_valid_rows, mma_tid)
+                        zero_tail_tokens(
+                            s_do, do_handle.index, tail_valid_rows, mma_tid, self.io_type, 1
+                        )
+                        zero_tail_tokens(
+                            s_q, q_handle.index, tail_valid_rows, mma_tid, self.io_type, 1
+                        )
+                        zero_tail_tokens(
+                            s_aqk, aqk_handle.index, tail_valid_rows, mma_tid, self.io_type, 1
+                        )
                     for k_block in cutlass.range(cute.size(t_aqk, mode=[2]), unroll_full=True):
                         mma_aqdo.set(tcgen05.Field.ACCUMULATE, cutlass.Boolean(k_block != 0))
                         cute.gemm(
@@ -1026,6 +991,10 @@ class BlackwellDeltaAffineSummaryRev:
                     do_handle.release()
 
                 k_handle = k_consumer.wait_and_advance()
+                if is_tail:
+                    zero_tail_tokens(
+                        s_k, k_handle.index, tail_valid_rows, mma_tid, self.io_type, 0
+                    )
                 for split in cutlass.range_constexpr(2):
                     # Each hi/lo half is one pipeline stage, published separately.
                     state_handle = state_consumer.wait_and_advance()
@@ -1048,8 +1017,9 @@ class BlackwellDeltaAffineSummaryRev:
 
                 w_handle = w_consumer.wait_and_advance()
                 if is_tail:
-                    # dv rows past the range hold k @ X of foreign tokens; w^T drops them.
-                    self._neutralize_w_tail(s_w, w_handle.index, tail_valid_rows, mma_tid)
+                    zero_tail_tokens(
+                        s_w, w_handle.index, tail_valid_rows, mma_tid, self.io_type, 1
+                    )
                 wdv_handle = wdv_producer.acquire_and_advance()
                 for split in cutlass.range_constexpr(2):
                     dv_operand_handle = dv_operand_consumer.wait_and_advance()
@@ -1349,7 +1319,10 @@ class BlackwellDeltaAffineSummaryRev:
                 t_wdv_acc,
                 t_w,
                 t_dv,
+                s_k,
+                s_q,
                 s_do,
+                s_aqk,
                 s_w,
                 state_consumer,
                 k_consumer,

--- a/attn_gym/linear/gdn/bwd/triton/chunk_gdn_bwd_intra.py
+++ b/attn_gym/linear/gdn/bwd/triton/chunk_gdn_bwd_intra.py
@@ -201,9 +201,11 @@ def chunk_gdn_bwd_intra_packed(
     if d_gate_raw.shape != q.shape:
         raise ValueError("d_gate_raw must match expanded q")
 
-    d_q = torch.zeros(q.shape, dtype=torch.float32, device=q.device)
-    d_k = torch.zeros(k.shape, dtype=torch.float32, device=k.device)
-    d_beta = torch.zeros_like(beta, dtype=torch.float32)
+    d_q = torch.empty(q.shape, dtype=torch.float32, device=q.device)
+    d_k = torch.empty(k.shape, dtype=torch.float32, device=k.device)
+    d_beta = torch.empty_like(beta, dtype=torch.float32)
+    # Returned as the gate cotangent without a reverse scan behind it, so inactive rows
+    # must be zero (docs/linear.md); the other outputs leave their suffix unspecified.
     d_gate = torch.zeros_like(cumulative_gate, dtype=torch.float32)
     chunk_gdn_bwd_intra_kernel[(metadata.capacity, heads)](
         q,

--- a/attn_gym/linear/gdn/bwd/triton/chunk_gdn_bwd_recompute.py
+++ b/attn_gym/linear/gdn/bwd/triton/chunk_gdn_bwd_recompute.py
@@ -134,7 +134,7 @@ def chunk_gdn_recompute_aqk_packed(
     batch, tokens, heads, key_dim = q.shape
     if batch != 1 or key_dim != 128 or k.shape != q.shape:
         raise ValueError("packed fused chunk GDN Aqk recompute requires B=1 and K=128")
-    aqk = torch.zeros(batch, tokens, heads, 64, dtype=q.dtype, device=q.device)
+    aqk = torch.empty(batch, tokens, heads, 64, dtype=q.dtype, device=q.device)
     chunk_gdn_recompute_aqk_kernel[(metadata.capacity, heads)](
         q,
         k,

--- a/attn_gym/linear/gdn/fwd/triton/chunk_gdn_fwd_intra.py
+++ b/attn_gym/linear/gdn/fwd/triton/chunk_gdn_fwd_intra.py
@@ -563,9 +563,11 @@ def chunk_gdn_fwd_intra_packed(
         BC=16,
     )
 
-    w = k.new_zeros(batch, tokens, value_heads, key_dim)
-    u = torch.zeros(v.shape, dtype=v.dtype, device=v.device)
-    restored_k = torch.zeros_like(w)
+    # Only active token rows are written; the inactive suffix is unspecified like every ragged
+    # primitive output (docs/linear.md).
+    w = k.new_empty(batch, tokens, value_heads, key_dim)
+    u = torch.empty(v.shape, dtype=v.dtype, device=v.device)
+    restored_k = torch.empty_like(w)
     scalar_recompute_w_u_kg_kernel[(metadata.capacity, value_heads)](
         q=None,
         k=k,
@@ -623,11 +625,10 @@ def chunk_gdn_recompute_w_u_qg_kg(
     elif tokens % 64:
         raise ValueError("dense fused chunk GDN recompute requires complete BT64 chunks")
 
-    factory = torch.zeros if metadata is not None else torch.empty
-    w = factory((batch, tokens, value_heads, key_dim), dtype=k.dtype, device=k.device)
-    u = factory(v.shape, dtype=v.dtype, device=v.device)
-    restored_k = factory(w.shape, dtype=w.dtype, device=w.device)
-    qg = factory(w.shape, dtype=w.dtype, device=w.device)
+    w = torch.empty(batch, tokens, value_heads, key_dim, dtype=k.dtype, device=k.device)
+    u = torch.empty(v.shape, dtype=v.dtype, device=v.device)
+    restored_k = torch.empty_like(w)
+    qg = torch.empty_like(w)
     chunks = tokens // 64 if metadata is None else metadata.capacity
     cu_seqlens = None if metadata is None else metadata.cu_seqlens
     chunk_offsets = None if metadata is None else metadata.chunk_offsets

--- a/attn_gym/linear/gdn/fwd/triton/chunk_gdn_fwd_recurrence.py
+++ b/attn_gym/linear/gdn/fwd/triton/chunk_gdn_fwd_recurrence.py
@@ -1,4 +1,8 @@
-"""Dense scalar-gate specialization of the KDA inter-chunk state recurrence."""
+"""Scalar-gate inter-chunk state recurrence.
+
+The dense path keeps its own BT64 kernel; the packed path reuses the KDA recurrence kernel,
+which already specializes on a per-head scalar gate.
+"""
 
 from __future__ import annotations
 
@@ -8,7 +12,8 @@ import triton.language as tl
 from triton.tools.tensor_descriptor import TensorDescriptor
 
 from attn_gym._backends.triton.utils import ptr_offset
-from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata, load_ragged_sequence_work
+from attn_gym.linear.kda.chunk_scheduler import RaggedChunkMetadata
+from attn_gym.linear.kda.fwd.triton.chunk_delta_h import _delta_h_launch
 
 
 @triton.jit(do_not_specialize=["T"])
@@ -103,73 +108,6 @@ def chunk_gdn_fwd_recurrence_dense(
     return h, v_new, final_state
 
 
-@triton.jit
-def chunk_gdn_fwd_recurrence_packed_kernel(
-    restored_k,
-    w,
-    u,
-    cumulative_gate,
-    initial_state,
-    h,
-    v_new,
-    final_state,
-    cu_seqlens,
-    chunk_offsets,
-    H: tl.constexpr,
-    K: tl.constexpr,
-    V: tl.constexpr,
-    BT: tl.constexpr,
-    BV: tl.constexpr,
-):
-    """Traverse one packed sequence/head/value tile with a resident FP32 state."""
-    sequence_head = tl.program_id(0)
-    value_tile = tl.program_id(1)
-    sequence = sequence_head // H
-    head = sequence_head % H
-
-    bos, eos, chunk_begin = load_ragged_sequence_work(cu_seqlens, chunk_offsets, sequence)
-    bos, eos, chunk_begin = bos.to(tl.int64), eos.to(tl.int64), chunk_begin.to(tl.int64)
-    chunks = (eos - bos + BT - 1) // BT
-    key = tl.arange(0, K)
-    value = value_tile * BV + tl.arange(0, BV)
-    state_offset = ptr_offset(
-        (sequence, head, value[None, :], key[:, None]), (H * V * K, V * K, K, 1)
-    )
-    state = tl.load(initial_state + state_offset).to(tl.float32)
-    row = tl.arange(0, BT)
-
-    for local_chunk in tl.range(0, chunks):
-        global_chunk = chunk_begin + local_chunk
-        token_start = bos + local_chunk * BT
-        token = token_start + row
-        token_mask = token < eos
-        h_offset = ptr_offset(
-            (global_chunk, head, key[:, None], value[None, :]), (H * K * V, K * V, V, 1)
-        )
-        tl.store(h + h_offset, state.to(h.dtype.element_ty))
-
-        w_offset = ptr_offset((token[:, None], head, key[None, :]), (H * K, K, 1))
-        u_offset = ptr_offset((token[:, None], head, value[None, :]), (H * V, V, 1))
-        w_tile = tl.load(w + w_offset, mask=token_mask[:, None], other=0.0)
-        u_tile = tl.load(u + u_offset, mask=token_mask[:, None], other=0.0)
-        corrected = u_tile.to(tl.float32) - tl.dot(w_tile, state.to(w_tile.dtype))
-        tl.store(
-            v_new + u_offset,
-            corrected.to(v_new.dtype.element_ty),
-            mask=token_mask[:, None],
-        )
-
-        final_token = tl.minimum(token_start + BT, eos) - 1
-        final_gate = tl.load(cumulative_gate + ptr_offset((final_token, head), (H, 1))).to(
-            tl.float32
-        )
-        state *= tl.exp2(final_gate)
-        restored = tl.load(restored_k + w_offset, mask=token_mask[:, None], other=0.0)
-        state = tl.dot(tl.trans(restored), corrected.to(restored.dtype), acc=state)
-
-    tl.store(final_state + state_offset, state)
-
-
 def chunk_gdn_fwd_recurrence_packed(
     restored_k: torch.Tensor,
     w: torch.Tensor,
@@ -189,28 +127,22 @@ def chunk_gdn_fwd_recurrence_packed(
     if initial_state.shape != expected_state:
         raise ValueError(f"initial_state must have shape {expected_state}")
 
-    h = restored_k.new_empty(1, metadata.capacity, heads, key_dim, value_dim)
-    v_new = torch.empty_like(u)
+    # The KDA recurrence kernel owns the scalar-gate specialization: on SM100 its warp-specialized
+    # TMA schedule steps a chunk in about half the time of a plain Triton loop, and it falls back
+    # to ordinary pipelining for FP32 inputs and other architectures.
     final_state = torch.empty_like(initial_state)
-    block_value = 64
-    chunk_gdn_fwd_recurrence_packed_kernel[(num_sequences * heads, value_dim // block_value)](
+    h, v_new = _delta_h_launch(
         restored_k,
         w,
         u,
         cumulative_gate,
         initial_state,
-        h,
-        v_new,
-        final_state,
+        None,
+        None,
         metadata.cu_seqlens,
         metadata.chunk_offsets,
-        H=heads,
-        K=key_dim,
-        V=value_dim,
-        BT=64,
-        BV=block_value,
-        num_warps=4,
-        num_stages=2,
+        metadata.capacity,
+        final_state,
     )
     return h, v_new, final_state
 

--- a/attn_gym/testing/__init__.py
+++ b/attn_gym/testing/__init__.py
@@ -3,6 +3,7 @@
 from .gdn import make_gdn_test_inputs
 from .kda import cumulative_sequence_offsets, strided_state_pool
 from .profiling import (
+    TraceFormat,
     annotate_kernels,
     kernel_stage,
     profile_trace,
@@ -11,6 +12,7 @@ from .profiling import (
 )
 
 __all__ = [
+    "TraceFormat",
     "annotate_kernels",
     "cumulative_sequence_offsets",
     "kernel_stage",

--- a/attn_gym/testing/delta_rule.py
+++ b/attn_gym/testing/delta_rule.py
@@ -16,7 +16,7 @@ from pathlib import Path
 import torch
 import torch.distributed as dist
 
-from attn_gym.testing.profiling import record_distributed_profile
+from attn_gym.testing.profiling import TraceFormat, record_distributed_profile
 
 
 def assert_context_parallel_matches_reference(
@@ -43,6 +43,7 @@ def profile_training_step(
     profile_path: Path,
     device: torch.device,
     warmup_steps: int,
+    trace_format: TraceFormat = "track_event",
 ) -> None:
     """Profile one eager step and report memory without owning its model or inputs."""
     torch.cuda.synchronize(device)
@@ -54,6 +55,7 @@ def profile_training_step(
         "iteration",
         device,
         warmup_steps=warmup_steps,
+        trace_format=trace_format,
     )
     step_peak = torch.cuda.max_memory_allocated(device) - resident
     print(

--- a/attn_gym/testing/profiling.py
+++ b/attn_gym/testing/profiling.py
@@ -8,10 +8,17 @@ from functools import wraps
 from importlib import import_module
 from inspect import signature
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import torch
 import torch.distributed as dist
+
+TraceFormat = Literal["track_event", "chrome_json"]
+
+
+def trace_suffix(trace_format: TraceFormat) -> str:
+    """File suffix transformer-nuggets writes for ``trace_format``."""
+    return ".pftrace" if trace_format == "track_event" else ".json.gz"
 
 
 def record_function(enabled: bool, name: str):
@@ -66,8 +73,14 @@ def kernel_stage(name: str, annotate: bool, *, backward: bool = True) -> Iterato
 
 
 @contextmanager
-def profile_trace(path: Path, *, warmup: int = 0) -> Iterator[torch.profiler.profile]:
-    """Record one native Perfetto trace per rank, discarding ``warmup`` scheduled steps."""
+def profile_trace(
+    path: Path, *, warmup: int = 0, trace_format: TraceFormat = "track_event"
+) -> Iterator[torch.profiler.profile]:
+    """Record one trace per rank, discarding ``warmup`` scheduled steps.
+
+    ``track_event`` writes native Perfetto; ``chrome_json`` writes gzipped Kineto JSON, which
+    keeps the shape metadata ``annotate-roofline`` needs (a later Perfetto merge drops it).
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
     try:
         profiler = import_module("transformer_nuggets.utils.benchmark").profiler
@@ -83,9 +96,10 @@ def profile_trace(path: Path, *, warmup: int = 0) -> Iterator[torch.profiler.pro
         )
 
     with profiler(
-        path.with_suffix(".pftrace"),
+        path.with_name(path.stem + trace_suffix(trace_format)),
         record_shapes=True,
-        trace_format="track_event",
+        trace_format=trace_format,
+        gzip_trace=trace_format == "chrome_json",
         warmup=warmup,
     ) as active_profiler:
         yield active_profiler
@@ -98,8 +112,9 @@ def record_distributed_profile(
     device: torch.device,
     *,
     warmup_steps: int = 0,
+    trace_format: TraceFormat = "track_event",
 ) -> Path | None:
-    """Profile one synchronized world-group step and merge its native rank traces.
+    """Profile one synchronized world-group step and merge its rank traces.
 
     ``warmup_steps`` extra steps run first with the profiler attached but are
     dropped from the trace, so the recorded step is steady state: kernels,
@@ -117,7 +132,7 @@ def record_distributed_profile(
     rank = dist.get_rank()
     world_size = dist.get_world_size()
     dist.barrier()
-    with profile_trace(path, warmup=warmup_steps) as active_profiler:
+    with profile_trace(path, warmup=warmup_steps, trace_format=trace_format) as active_profiler:
         for index in range(warmup_steps):
             step()
             if index == warmup_steps - 1:
@@ -138,8 +153,9 @@ def record_distributed_profile(
 
     # Ranks on other nodes may not share a filesystem with rank 0: ship the trace
     # bytes over the process group so the merge only needs rank 0's local disk.
+    suffix = trace_suffix(trace_format)
     rank_paths = [
-        path.with_name(f"{path.stem}_rank_{index}.pftrace") for index in range(world_size)
+        path.with_name(f"{path.stem}_rank_{index}{suffix}") for index in range(world_size)
     ]
     gathered: list[bytes | None] | None = [None] * world_size if rank == 0 else None
     dist.gather_object(rank_paths[rank].read_bytes(), gathered, dst=0)
@@ -162,6 +178,7 @@ def record_distributed_profile(
 
 
 __all__ = [
+    "TraceFormat",
     "annotate_kernels",
     "graph_annotations_available",
     "kernel_stage",

--- a/examples/delta_rule_context_parallel.py
+++ b/examples/delta_rule_context_parallel.py
@@ -40,7 +40,7 @@ from attn_gym.linear.context_parallel import (
 )
 from attn_gym.linear.gdn.context_parallel import context_parallel_gdn
 from attn_gym.linear.kda.context_parallel import context_parallel_kda
-from attn_gym.testing import kernel_stage, record_distributed_profile
+from attn_gym.testing import TraceFormat, kernel_stage, record_distributed_profile
 from attn_gym.testing.profiling import graph_annotations_available
 from examples.delta_rule_training import (
     ComputeDTypeOption,
@@ -64,6 +64,18 @@ class PartitionOption(str, Enum):
 
     CONTIGUOUS = "contiguous"
     ZIGZAG = "zigzag"
+
+
+class TraceFormatOption(str, Enum):
+    """Per-rank trace format for ``--profile``."""
+
+    PERFETTO = "perfetto"
+    KINETO = "kineto"
+
+    @property
+    def trace_format(self) -> TraceFormat:
+        """Return the transformer-nuggets trace format."""
+        return "track_event" if self is TraceFormatOption.PERFETTO else "chrome_json"
 
 
 def partition_fragments(
@@ -241,8 +253,12 @@ def main(
         bool, typer.Option(help="Compare against the unsharded module on the whole stream.")
     ] = True,
     profile: Annotated[
-        bool, typer.Option(help="Export a merged native Perfetto trace with transformer-nuggets.")
+        bool, typer.Option(help="Export a merged trace of one steady-state step.")
     ] = False,
+    trace_format: Annotated[
+        TraceFormatOption,
+        typer.Option(help="Per-rank format; kineto writes gzipped JSON for annotate-roofline."),
+    ] = TraceFormatOption.PERFETTO,
     warmup_steps: Annotated[
         int, typer.Option(min=0, help="Warmup steps before profiling or timing.")
     ] = 5,
@@ -351,11 +367,14 @@ def main(
                         "cuda_graph_replay",
                         device,
                         warmup_steps=warmup_steps,
+                        trace_format=trace_format.trace_format,
                     )
                     if merged_path is not None:
                         print(f"profile={merged_path}", flush=True)
         elif profile:
-            profile_eager_step(model, batch, profile_path, device, warmup_steps)
+            profile_eager_step(
+                model, batch, profile_path, device, warmup_steps, trace_format.trace_format
+            )
 
         status = "passed" if validate else "ran"
         print(

--- a/examples/delta_rule_training.py
+++ b/examples/delta_rule_training.py
@@ -79,7 +79,13 @@ from attn_gym.linear.kda import (
     mask_inactive_tokens,
 )
 from attn_gym.linear.types import KernelOptions
-from attn_gym.testing import annotate_kernels, kernel_stage, profile_trace, record_function
+from attn_gym.testing import (
+    TraceFormat,
+    annotate_kernels,
+    kernel_stage,
+    profile_trace,
+    record_function,
+)
 from attn_gym.testing.delta_rule import (
     assert_context_parallel_matches_reference,
     measure_training_step,
@@ -803,6 +809,7 @@ def profile_eager_step(
     profile_path: Path,
     device: torch.device,
     warmup_steps: int,
+    trace_format: TraceFormat = "track_event",
 ) -> None:
     """Profile a complete eager forward/backward on a fresh input leaf."""
     hidden_states = batch.local_hidden.detach().clone().requires_grad_()
@@ -819,6 +826,7 @@ def profile_eager_step(
         profile_path,
         device,
         warmup_steps,
+        trace_format=trace_format,
     )
 
 

--- a/test/test_delta_affine_summary.py
+++ b/test/test_delta_affine_summary.py
@@ -730,19 +730,31 @@ def test_range_summaries_match_per_range_launches(dtype):
             )
 
 
+def scale_up(neighbours: torch.Tensor) -> None:
+    neighbours *= 64
+
+
+def poison(neighbours: torch.Tensor) -> None:
+    neighbours[:, ::2] = torch.nan
+    neighbours[:, 1::2] = torch.inf
+
+
 @pytest.mark.usefixtures("summary_backend")
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
-def test_range_tails_ignore_the_tokens_that_follow(dtype):
-    """A partial last chunk over-reads the next tokens; scaled-up neighbours must not leak in.
+@pytest.mark.parametrize("corrupt", [scale_up, poison], ids=["scaled", "non-finite"])
+def test_range_tails_ignore_the_tokens_that_follow(dtype, corrupt):
+    """A partial last chunk over-reads the next tokens; they must not leak in, whatever they hold.
 
     The single-range launch sees TMA zero fill past its slice instead of those tokens, so the two
-    must agree bitwise; the neighbours are finite, which the kernels require (``0 * inf`` is NaN).
+    must agree bitwise. Producers allocate token-shaped intermediates with ``torch.empty`` and
+    write only the active prefix, so the over-read tokens may be NaN/Inf: the kernels must drop
+    them by selection, not by scaling (``0 * NaN`` is NaN).
     """
     tensors = make_summary_inputs(41, dtype, tokens=640, heads=2)
     qg, kg, w, u, dout, aqk, cumulative_gate = tensors
     for tensor in (qg, kg, w, u, dout, aqk):
-        tensor[:, 300:364] *= 64  # never inside a range below
-    bounds = torch.tensor([[0, 300], [172, 300]], dtype=torch.int32, device="cuda")
+        corrupt(tensor[:, 300:364])  # never inside a range below
+    bounds = torch.tensor([[0, 300], [172, 300], [364, 640]], dtype=torch.int32, device="cuda")
     scale = 128**-0.5
 
     forward = build_state_summaries(kg, w, u, cumulative_gate, bounds)

--- a/test/test_delta_rule_stages.py
+++ b/test/test_delta_rule_stages.py
@@ -242,6 +242,76 @@ def test_state_summary_matches_zero_and_identity_probes(op):
         assert_summary_parts_match(summaries[index], fused, oracle, index)
 
 
+@pytest.fixture
+def nan_filled_empty(monkeypatch):
+    """Fill every fresh floating-point tensor with NaN, the worst case ``torch.empty`` allows.
+
+    The caching allocator mostly recycles blocks, so a test cannot rely on real garbage: filling
+    at the allocation entry points the kernels use makes every unwritten element a NaN.
+    """
+
+    def nan_filled(allocate):
+        def allocate_nan_filled(*args, **kwargs):
+            tensor = allocate(*args, **kwargs)
+            return tensor.fill_(torch.nan) if tensor.is_floating_point() else tensor
+
+        return allocate_nan_filled
+
+    for owner, name in ((torch, "empty"), (torch, "empty_like"), (torch.Tensor, "new_empty")):
+        monkeypatch.setattr(owner, name, nan_filled(getattr(owner, name)))
+
+
+@requires_kda_target
+@pytest.mark.usefixtures("nan_filled_empty")
+@pytest.mark.parametrize(
+    "op",
+    [
+        pytest.param(KDA, id="kda"),
+        pytest.param(GDN, id="gdn"),
+        pytest.param(GDN._replace(key_heads=1), id="gdn-gqa"),
+    ],
+)
+def test_fixed_capacity_intermediates_may_be_uninitialized(op):
+    """Intermediates are ``torch.empty``: their inactive suffix may hold NaN and must not leak.
+
+    The last document ends mid-chunk at the active endpoint, so every kernel that TMA-loads whole
+    64-token tiles over-reads into the capacity slack of the factors (w, u, kg, qg, aqk, ...) it
+    produced itself. The forward, the CP summaries, and the staged backward must agree bitwise
+    with the same computation on a buffer with no slack, where TMA zero-fills instead.
+    """
+    tokens, active = 256, 191
+    inputs = op.make_inputs(tokens, seed=11)
+    cu_seqlens = torch.tensor([0, 65, active], dtype=torch.int32, device="cuda")
+    generator = torch.Generator(device="cuda").manual_seed(12)
+    d_output = torch.randn(
+        1, tokens, op.value_heads, HEAD_DIM, device="cuda", generator=generator
+    ).to(inputs[2].dtype)
+    d_final_state = torch.randn(2, op.value_heads, HEAD_DIM, HEAD_DIM, device="cuda")
+    ranges = bounds_of((0, 65), (65, active))
+
+    def run(inputs, d_output):
+        prepared = op.prepare(*inputs, cu_seqlens=cu_seqlens)
+        summaries = prepared.state_summaries(ranges)
+        output, final_state = prepared.run(None, output_final_state=True)
+        grads = op.prepare_backward(prepared.saved, d_output, None, scale=prepared.scale)
+        grad_summaries = grads.state_grad_summaries(ranges)
+        dq, dk, dv, dgate, dbeta, _ = grads.run(d_final_state)
+        return (summaries, final_state, grad_summaries), (output, dq, dk, dv, dgate, dbeta)
+
+    expected_states, expected_rows = run(
+        tuple(t[:, :active].clone() for t in inputs), d_output[:, :active].clone()
+    )
+    states, rows = run(inputs, d_output)
+    active_rows = tuple(t[:, :active] for t in rows)
+    for got, want in zip(states + active_rows, expected_states + expected_rows, strict=True):
+        torch.testing.assert_close(got, want, atol=0, rtol=0)
+    # Unlike the other token gradients, the gate cotangent must be zero past the active tokens:
+    # parameterized gate producers such as ``gate_transform`` reduce it over physical tokens
+    # (docs/linear.md, "the internal reverse scan returns zero cotangents for inactive gate rows").
+    dgate = rows[4]
+    assert not dgate[:, active:].any()
+
+
 def bounds_of(*ranges: tuple[int, int]) -> torch.Tensor:
     """``int32 [R, 2]`` device tensor of span ranges for ``state_summaries``."""
     return torch.tensor(ranges, dtype=torch.int32, device="cuda")

--- a/test/test_profiling.py
+++ b/test/test_profiling.py
@@ -89,23 +89,30 @@ def test_native_trace_reports_missing_dependency(monkeypatch, tmp_path):
         pytest.fail("missing profiler must not silently fall back to another format")
 
 
-def test_native_trace_uses_pftrace_and_forwards_warmup(monkeypatch, tmp_path):
+@pytest.mark.parametrize(
+    ("trace_format", "suffix", "gzip_trace"),
+    [("track_event", ".pftrace", False), ("chrome_json", ".json.gz", True)],
+    ids=["perfetto", "kineto"],
+)
+def test_profile_trace_forwards_format_and_warmup(
+    monkeypatch, tmp_path, trace_format, suffix, gzip_trace
+):
     calls = []
     token = object()
 
     @contextmanager
-    def profiler(path, *, record_shapes, trace_format, warmup):
-        calls.append((path, record_shapes, trace_format, warmup))
+    def profiler(path, *, record_shapes, trace_format, gzip_trace, warmup):
+        calls.append((path, record_shapes, trace_format, gzip_trace, warmup))
         yield token
 
     monkeypatch.setattr(
         profiling, "import_module", lambda name: SimpleNamespace(profiler=profiler)
     )
     trace = tmp_path / "profiles" / "training"
-    with profile_trace(trace, warmup=2) as active:
+    with profile_trace(trace, warmup=2, trace_format=trace_format) as active:
         assert active is token
     assert trace.parent.is_dir()
-    assert calls == [(trace.with_suffix(".pftrace"), True, "track_event", 2)]
+    assert calls == [(trace.with_name("training" + suffix), True, trace_format, gzip_trace, 2)]
 
 
 def test_native_trace_rejects_outdated_profiler(monkeypatch, tmp_path):


### PR DESCRIPTION
Speed up the packed GDN training path under context parallelism and make the affine-summary
kernels own the "over-read tokens must be finite" invariant, so producers can leave fixed-capacity
slack uninitialized.

Roofline-annotated traces of examples/delta_rule_context_parallel.py (2 x GB200, 64k tokens per
rank, hidden 2048, 16 heads; per-rank Kineto JSON decorated with transformer-nuggets
annotate-roofline) showed two cheap wins in the GDN step:

- chunk_gdn_fwd_recurrence_packed_kernel stepped a chunk in ~1.9 us with 32-64 CTAs (10-20% of
  the memory roofline) and ran twice per step. KDA's chunk_delta_h_kernel_k128_wsp computes the
  identical recurrence through its SCALAR_GATE path (same h/v_new/state layouts, same partial-tail
  and empty-sequence handling) at ~1.0 us per chunk thanks to warp specialization and TMA staging
  on SM100. The packed GDN recurrence now calls _delta_h_launch and the old kernel is deleted;
  _delta_h_launch already covers non-SM100 targets with its pipelined configuration, and fp32
  never reaches the fused path. Dense GDN keeps its descriptor kernel.
- The packed GDN Triton paths zero-filled every token-shaped output (w, u, kg, qg, aqk, d_q, d_k,
  d_beta): 26 memsets, 0.70 ms per rank. Ragged primitives only read [0, cu_seqlens[-1]) and
  leave the suffix unspecified (docs/linear.md), so these are torch.empty now. inverse keeps
  torch.zeros because kkt_solve writes only the block-lower-triangular part, and d_gate keeps
  torch.zeros because it is returned directly as the gate cotangent with no reverse scan behind
  it; the example puts its gradient barrier before gate_transform, so A_log/dt_bias gradients
  would otherwise see garbage rows (test_example_masked_capacity_* catches this).

Uninitialized slack exposes a latent bug in the CuTeDSL affine-summary kernels: a range's partial
last chunk is TMA-loaded as a full 64-row tile, and only kg (forward) and dO/w (reverse) were
zeroed in SMEM; the other operands relied on 0 * finite cancellation, which is NaN for NaN/Inf
garbage. KDA's factors were already new_empty, so this affected KDA fixed-capacity replay too.
Both kernels now zero every token-indexed operand stage of the tail chunk (fwd: w, kg, u; rev:
kg, qg, dO, Aqk, w) through one zero_tail_tokens helper. Instead of hand-decomposing each
operand's atom/rest coordinates, operand_view_layout regroups the stage's identity layout into a
logical (rows, tokens) layout and composes it with the swizzled SMEM slice, replacing five
per-operand helpers. The summary kernels' documented finiteness caveat is gone.

The example gains --trace-format kineto (per-rank gzipped Kineto JSON with shapes for
annotate-roofline; the merged output stays Perfetto), plumbed through
attn_gym.testing.profiling.

Tests:
- test_range_tails_ignore_the_tokens_that_follow[scaled|non-finite]: NaN and Inf in the tokens
  after a partial tail must give the bitwise same summaries as the single-range launch.
- test_fixed_capacity_intermediates_may_be_uninitialized[kda|gdn|gdn-gqa]: a fixture NaN-fills
  torch.empty; forward, CP summaries, staged backward and grad summaries on a padded buffer must
  match the compact buffer bitwise and dgate must be zero past the active endpoint. Both tests
  fail with the kernel neutralization reverted.

Validation on two GB200s (torch 2.15.0.dev20260902+cu132, CuTeDSL 4.7): 501 passed / 53 skipped
across test_delta_affine_summary, test_delta_rule_stages, linear/test_gdn*, test_kda_ragged_*,
test_context_parallel_distributed, the CP/training/CUDA-graph example tests; the CP example
validates against the unsharded module for contiguous and zigzag partitions. GDN CP eager step
21.9 -> 19.4-20.1 ms (30 steps); KDA unchanged (21.4 -> 21.2 ms); build_state_summaries /
build_state_grad_summaries on a 32k partial-tail range unchanged (858 / 1387 us). ruff check
and format pass.
