### PR TITLE
Release fused GDN backward workspace at last use

### DIFF
--- a/attn_gym/linear/gdn/impl/chunk.py
+++ b/attn_gym/linear/gdn/impl/chunk.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import NamedTuple
 
 import torch
@@ -300,14 +301,20 @@ def _gdn_chunk_fwd_packed_paged_cuda(
     return chunk_gdn_fwd_output_packed(q, k, v_new, h, cumulative_gate, scale, metadata)
 
 
-class ChunkGDNBwdPrepared(NamedTuple):
-    """Recomputed local tensors shared across the context-parallel backward boundary."""
+@dataclass
+class ChunkGDNBwdPrepared:
+    """Recomputed local tensors shared across the context-parallel backward boundary.
 
-    w: torch.Tensor
-    qg: torch.Tensor
-    kg: torch.Tensor
-    h: torch.Tensor
-    v_new: torch.Tensor
+    Mutable so ``_finish_chunk_gdn_bwd`` can release each field at its last use; the callers'
+    frames keep the container alive, so a ``None`` field is the only way to free the storage
+    before the later stages allocate. Fields are ``None`` after the backward finishes.
+    """
+
+    w: torch.Tensor | None
+    qg: torch.Tensor | None
+    kg: torch.Tensor | None
+    h: torch.Tensor | None
+    v_new: torch.Tensor | None
 
 
 def _prepare_chunk_gdn_bwd(
@@ -406,8 +413,16 @@ def _finish_chunk_gdn_bwd(
 
     ``aqk`` is the expanded-head intra-chunk Q/K factor when the caller already holds it (the
     staged reverse summary computes it first); the Blackwell path recomputes it otherwise.
+
+    The Blackwell path releases every recomputed tensor at its last use (``prepared`` fields
+    and the ``del`` statements) because the step's peak memory sits inside this function:
+    the wy/dqkg and intra stages each allocate several ``[T, H, K]`` FP32 buffers, and holding
+    the dead ``h``/``dh``/``w``/``qg``/``kg``/``vector_gate`` alongside them costs ~1 GiB per
+    16k tokens at 32 heads.
     """
-    w, qg, kg, h, v_new = prepared
+    w, qg, kg, h, v_new = prepared.w, prepared.qg, prepared.kg, prepared.h, prepared.v_new
+    assert w is not None and qg is not None and kg is not None
+    assert h is not None and v_new is not None
     if not use_blackwell_backward(q):
         dh, d_initial_state, dv = chunk_gdn_bwd_delta_h(
             q,
@@ -474,6 +489,8 @@ def _finish_chunk_gdn_bwd(
         chunk_size=64,
         metadata=metadata,
     )
+    prepared.w = prepared.qg = prepared.kg = None
+    del w, qg, kg, aqk
     dq, dk, dv, dg_raw, db, d_raw_akk = chunk_kda_bwd_wy_dqkg(
         expanded_q,
         expanded_k,
@@ -492,6 +509,8 @@ def _finish_chunk_gdn_bwd(
         fastmath=False,
         autotune=False,
     )
+    prepared.h = prepared.v_new = None
+    del h, v_new, dh, vector_gate
     intra = (
         chunk_gdn_bwd_intra_dense(
             expanded_q,
@@ -515,8 +534,13 @@ def _finish_chunk_gdn_bwd(
         )
     )
     intra_dq, intra_dk, intra_db, d_gate = intra
-    dq = dq.float() + intra_dq
-    dk = dk.float() + intra_dk
+    del d_aqk, d_raw_akk, dg_raw
+    # ``chunk_kda_bwd_wy_dqkg`` returns fresh FP32 ``dq``/``dk`` (allocated like the FP32 vector
+    # gate), so accumulating in place is the same FP32 add without a third full-size buffer.
+    assert dq.dtype == torch.float32 and dk.dtype == torch.float32
+    dq.add_(intra_dq)
+    dk.add_(intra_dk)
+    del intra_dq, intra_dk
     if groups > 1:
         dq = dq.view(*q.shape[:2], q.shape[2], groups, q.shape[3]).sum(3)
         dk = dk.view(*k.shape[:2], k.shape[2], groups, k.shape[3]).sum(3)


### PR DESCRIPTION
## Summary

The Blackwell chunk GDN backward (`_finish_chunk_gdn_bwd`) held every recomputed tensor (`h`, `v_new`, `w`, `qg`, `kg`, `aqk`, the expanded FP32 vector gate, `dh`, `d_aqk`, `dA`, `dg`) until it returned, so the layer-step peak sat ~2 GiB above Mega even though all three implementations save the same forward tensors.

- `ChunkGDNBwdPrepared` becomes a mutable `@dataclass` (like `ChunkKDABwdPrepared`) so fields can be released while `chunk_gdn_bwd` / `ChunkGDNBackward.run` still hold the container.
- Each recomputed tensor is dropped after its last consumer (`w/qg/kg/aqk` after delta_h, `h/v_new/dh/vector_gate` after wy_dqkg, `d_aqk/dA/dg` after intra).
- Intra dq/dk are accumulated in place into the FP32 buffers `chunk_kda_bwd_wy_dqkg` already returns.

Kernels, schemas, the forward, and the pre-Blackwell path are untouched. Gradients are bitwise identical.

## Numbers

`gdn_qwen3next_dense_b1_t16384`, GB200, torch 2.15 nightly, bf16, same env for both (lower is better):

| metric | main (08b87cc) | this PR |
|---|---|---|
| layer-step `max_memory_allocated` (eager fwd+bwd) | 5286 MiB | **4194 MiB** (-1092) |
| core backward-only transient (T=16384, H_qk=16, H_v=32) | 3528 MiB | **2436 MiB** (-1092) |
| core bwd, CUDA graph (`bench_core_vs_fla.py`) | 2539.2 us | 2538.3 us |
| core bwd, eager | 2608.2 us | 2610.2 us |

Ablation of the backward-only transient: in-place add alone 3400 MiB; lifetime releases alone 2436 MiB. The releases are the win; the in-place add is kept as a free tail improvement.

## Validation

- `torch.equal` on output, final_state, dq, dk, dv, d_gate, d_beta, d_initial_state vs main (with `initial_state` and `output_final_state=True`): all equal for dense B=1 T=4096 H_qk=16/H_v=32, packed Zipf 8 sequences, and dense B=2 T=2048 no-GQA.
- Full `pytest -n 6 test`: 2032 passed, 36 skipped, 13 xfailed.
- `ruff check` / `ruff format --check` clean.
