### PR TITLE
Keep the heavy ragged KDA kernels on the static grid under AUTO

### DIFF
--- a/attn_gym/linear/_delta_rule/triton/chunk_scheduler.py
+++ b/attn_gym/linear/_delta_rule/triton/chunk_scheduler.py
@@ -150,15 +150,23 @@ class GridScheduler:
         capacity_tasks: int,
         workers: int,
         requirement: str,
+        auto_persistent: bool = True,
     ) -> ResolvedSchedule:
-        """Translate caller policy into one concrete schedule."""
+        """Translate caller policy into one concrete schedule.
+
+        ``eligible`` says whether a persistent kernel exists for the input, so an explicit
+        PERSISTENT request fails without it. ``auto_persistent`` only steers AUTO; explicit
+        requests ignore it.
+        """
         validate_schedule_request(request)
         if request is ScheduleRequest.PERSISTENT and not eligible:
             raise ValueError(f"persistent scheduling requires {requirement}")
         if capacity_tasks == 0:
             return ResolvedSchedule(ScheduleKind.STATIC, workers, capacity_tasks)
         if request is ScheduleRequest.AUTO:
-            persistent = eligible and capacity_tasks > PERSISTENT_AUTO_WAVES * workers
+            persistent = (
+                eligible and auto_persistent and capacity_tasks > PERSISTENT_AUTO_WAVES * workers
+            )
         else:
             persistent = request is ScheduleRequest.PERSISTENT
         return ResolvedSchedule(
@@ -196,8 +204,28 @@ class GridScheduler:
         *,
         eligible: bool = True,
         requirement: str = "a persistent kernel for this input layout",
+        auto_persistent: bool = True,
     ) -> ResolvedSchedule:
-        """Resolve scheduling for a flattened ``(chunk, subtask)`` work list."""
+        """Resolve scheduling for a flattened ``(chunk, subtask)`` work list.
+
+        Args:
+            eligible: Whether a persistent kernel exists for this input; an explicit
+                PERSISTENT request fails without one.
+            auto_persistent: Whether AUTO may choose PERSISTENT past ``PERSISTENT_AUTO_WAVES``.
+                Heavy kernels pass ``False``: the persistent stride loop pays off for small
+                latency-bound kernels, but the 128x128 KDA output-composition and
+                W/U-recompute kernels lose with it because their persistent variants hold
+                more registers, so fewer CTAs stay resident per SM and realized DRAM
+                bandwidth roughly halves, while the static grid only pays launch time per
+                padding CTA. On SM100 a sweep from 1 to 325 bounded-worker waves over
+                single/uniform-8/Zipf-8/Zipf-16 layouts at H=32/96 with the buffer full found
+                persistent output 1.1-2.4x and persistent recompute 1.03-1.31x slower, with no
+                crossover; the output kernel had already measured slower on Hopper. PERSISTENT
+                wins again only when a captured graph replays with under ~1/4 (output) or
+                ~1/8 (recompute) of its capacity active. The scheduler sees only capacity, so
+                AUTO bets on mostly-full buffers, which is how packed training batches are
+                built; callers with sparse replays request PERSISTENT explicitly.
+        """
         workers = self.num_workers(subtasks_per_chunk, device)
         return self._resolve(
             request,
@@ -205,6 +233,7 @@ class GridScheduler:
             self.metadata.capacity * subtasks_per_chunk,
             workers,
             requirement,
+            auto_persistent,
         )
 
     def resolve_sequences(

--- a/attn_gym/linear/kda/fwd/triton/chunk_gla_fwd_o.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_gla_fwd_o.py
@@ -16,7 +16,6 @@ import triton
 import triton.language as tl
 from triton.tools.tensor_descriptor import TensorDescriptor
 
-from attn_gym._backends.cute.utils import get_device_properties
 from attn_gym._backends.triton.utils import (
     PinnedConfigKernel,
     can_use_tma,
@@ -503,17 +502,6 @@ def _can_use_tensor_descriptors(*tensors: torch.Tensor) -> bool:
 _PINNED_FWD_O = PinnedConfigKernel(chunk_gla_fwd_kernel_o)
 
 
-def _select_ragged_output_schedule_kind(
-    request: ScheduleRequest,
-    resolved_kind: ScheduleKind,
-    device_major: int,
-) -> ScheduleKind:
-    """Keep Hopper on its faster static ragged-TMA launch under automatic selection."""
-    if request is ScheduleRequest.AUTO and device_major == 9:
-        return ScheduleKind.STATIC
-    return resolved_kind
-
-
 def chunk_gla_fwd_o_gk(
     q: torch.Tensor,
     v: torch.Tensor,
@@ -574,6 +562,7 @@ def chunk_gla_fwd_o_gk(
             eligible=ragged_tma,
             requirement="the TMA path on packed inputs: batch=1, K=V=128, chunk_size=64, "
             "and TMA-capable tensors",
+            auto_persistent=False,  # heavy kernel; see GridScheduler.resolve_flat
         )
     if (
         metadata is None
@@ -643,12 +632,7 @@ def chunk_gla_fwd_o_gk(
                 # past the dense register budget and loses a resident CTA.
                 "maxnreg": 136,
             }
-            schedule_kind = _select_ragged_output_schedule_kind(
-                schedule,
-                resolved.kind,
-                get_device_properties(q.device).major,
-            )
-            if schedule_kind is ScheduleKind.PERSISTENT:
+            if resolved.kind is ScheduleKind.PERSISTENT:
                 chunk_gla_fwd_kernel_o_ragged_tma_persistent[(resolved.workers,)](
                     *args, num_workers=resolved.workers, **kwargs
                 )

--- a/attn_gym/linear/kda/fwd/triton/recompute_w_u.py
+++ b/attn_gym/linear/kda/fwd/triton/recompute_w_u.py
@@ -544,7 +544,12 @@ def recompute_w_u_fwd_triton(
     if metadata is None:
         kernel[(chunks, value_heads)](**kernel_kwargs)
         return w, u, qg, kg
-    resolved = GridScheduler(metadata).resolve_flat(schedule, value_heads, k.device)
+    resolved = GridScheduler(metadata).resolve_flat(
+        schedule,
+        value_heads,
+        k.device,
+        auto_persistent=False,  # heavy kernel; see GridScheduler.resolve_flat
+    )
     if resolved.kind is ScheduleKind.PERSISTENT:
         persistent_kernel = (
             recompute_w_u_fwd_kernel_persistent if autotune else _PINNED_W_U_PERSISTENT

--- a/test/test_kda_ragged_output.py
+++ b/test/test_kda_ragged_output.py
@@ -7,7 +7,6 @@ import torch
 
 import attn_gym.linear.kda.fwd.triton.chunk_gla_fwd_o as output_module
 from attn_gym.linear._delta_rule.triton.chunk_scheduler import (
-    ScheduleKind,
     ScheduleRequest,
     prepare_ragged_chunk_metadata,
 )
@@ -16,26 +15,6 @@ pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available(),
     reason="the KDA output kernel requires CUDA",
 )
-
-
-@pytest.mark.parametrize(
-    ("schedule_request", "resolved", "device_major", "expected"),
-    [
-        (ScheduleRequest.AUTO, ScheduleKind.PERSISTENT, 9, ScheduleKind.STATIC),
-        (ScheduleRequest.AUTO, ScheduleKind.PERSISTENT, 10, ScheduleKind.PERSISTENT),
-        (ScheduleRequest.PERSISTENT, ScheduleKind.PERSISTENT, 9, ScheduleKind.PERSISTENT),
-        (ScheduleRequest.STATIC, ScheduleKind.STATIC, 9, ScheduleKind.STATIC),
-    ],
-)
-def test_ragged_output_schedule_selection(schedule_request, resolved, device_major, expected):
-    assert (
-        output_module._select_ragged_output_schedule_kind(
-            schedule_request,
-            resolved,
-            device_major,
-        )
-        is expected
-    )
 
 
 def _reference(

--- a/test/test_kda_ragged_schedule_policy.py
+++ b/test/test_kda_ragged_schedule_policy.py
@@ -1,0 +1,57 @@
+"""Schedule policy for the heavy ragged KDA kernels (output composition, W/U recompute).
+
+These tests supply the SM count explicitly so they run without CUDA. Rationale:
+``GridScheduler.resolve_flat``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from attn_gym.linear._delta_rule.triton import chunk_scheduler
+from attn_gym.linear._delta_rule.triton.chunk_scheduler import (
+    GridScheduler,
+    RaggedChunkMetadata,
+    ScheduleKind,
+    ScheduleRequest,
+    chunk_capacity,
+)
+
+SM100_SM_COUNT = 152
+CHUNK_SIZE = 64
+# Output composition flattens (head, 64-wide value tile) pairs; recompute flattens heads.
+MANY_SEQUENCE_SHAPES = {
+    "uniform_b8_h96_t8192_output": (96 * 2, [8192] * 8),
+    "zipf_s8_h96_t11920_recompute": (96, [6148, 497, 46, 3832, 272, 1106, 3, 16]),
+}
+
+
+def resolve_on_sm100(monkeypatch, subtasks, lengths, request, *, auto_persistent):
+    """Resolve the flat plan for one packed shape as an SM100 device would."""
+    monkeypatch.setattr(chunk_scheduler, "_multiprocessor_count", lambda device: SM100_SM_COUNT)
+    metadata = RaggedChunkMetadata(
+        None, None, chunk_capacity(sum(lengths), len(lengths), CHUNK_SIZE), CHUNK_SIZE
+    )
+    return GridScheduler(metadata).resolve_flat(
+        request, subtasks, "cuda", auto_persistent=auto_persistent
+    )
+
+
+@pytest.mark.parametrize("shape", sorted(MANY_SEQUENCE_SHAPES))
+def test_heavy_ragged_kernels_stay_static_under_auto(monkeypatch, shape):
+    subtasks, lengths = MANY_SEQUENCE_SHAPES[shape]
+    generic = resolve_on_sm100(
+        monkeypatch, subtasks, lengths, ScheduleRequest.AUTO, auto_persistent=True
+    )
+    # The generic wave rule alone would pick the slower persistent variant here.
+    assert generic.kind is ScheduleKind.PERSISTENT
+    static = resolve_on_sm100(
+        monkeypatch, subtasks, lengths, ScheduleRequest.AUTO, auto_persistent=False
+    )
+    assert static == replace(generic, kind=ScheduleKind.STATIC)
+    explicit = resolve_on_sm100(
+        monkeypatch, subtasks, lengths, ScheduleRequest.PERSISTENT, auto_persistent=False
+    )
+    assert explicit.kind is ScheduleKind.PERSISTENT


### PR DESCRIPTION
Stacked PRs:
 * #508
 * __->__#507


--- --- ---

Keep the heavy ragged KDA kernels on the static grid under AUTO on SM100

The generic flat-task policy (PERSISTENT once capacity exceeds 4 bounded-worker
waves) loses for the ragged output-composition and W/U-recompute kernels on
SM100, as the output kernel already did on Hopper. An SM100 sweep from 1 to 325
waves over single/uniform-8/Zipf-8/Zipf-16 layouts at H=32/96 found no
crossover: persistent output ran 1.1-2.4x slower and persistent recompute
1.03-1.31x slower than the static grid, bitwise identical. NCU attributes it to
the persistent variants' register footprint (fewer resident CTAs, roughly half
the realized DRAM bandwidth).

Give resolve_flat an auto_persistent switch that only steers AUTO, and have both
kernels pass heavy_ragged_auto_persistent(device) (false on device majors 9 and
10), replacing the output kernel's Hopper-only post-hoc override so
ResolvedSchedule is authoritative again at both call sites. Explicit
ScheduleRequest.PERSISTENT still runs the persistent kernels. The generic
PERSISTENT_AUTO_WAVES rule and chunk_delta_h's own policy are unchanged. Public
chunk_kda forward outputs are bitwise identical to main on all swept shapes.

Graph forward (GB200, min of two interleaved runs, us): h96 B8 T8192
18307 -> 16792, h96 packed Zipf s8 3432 -> 2900, h32 B8 T4096 3052 -> 2599,
h32 B1 T16384 1280 -> 1278 (unchanged).

## Sweep: STATIC vs PERSISTENT on SM100 (GB200, 152 SMs, 608 bounded workers)

CUDA-graph replay, median of 50, µs, lower is better. `waves` = capacity_tasks / workers; the generic AUTO rule flips to PERSISTENT above 4. Every row is bitwise identical between the two schedules. Buffer full (active ≈ capacity).

<details><summary><b>output</b>: persistent/static 1.11–2.44 over 50 shapes</summary>

| heads | layout | tokens | waves | STATIC µs | PERSISTENT µs | P/S |
|---:|---|---:|---:|---:|---:|---:|
| 32 | single | 640 | 1.1 | 16.0 | 28.1 | 1.75 |
| 32 | single | 1216 | 2.0 | 22.5 | 30.9 | 1.37 |
| 32 | single | 2432 | 4.0 | 40.3 | 61.3 | 1.52 |
| 32 | single | 4864 | 8.0 | 69.6 | 113.0 | 1.62 |
| 32 | single | 9728 | 16.0 | 124.5 | 215.7 | 1.73 |
| 32 | single | 16384 | 26.9 | 198.5 | 355.5 | 1.79 |
| 32 | single | 38912 | 64.0 | 449.5 | 829.1 | 1.84 |
| 32 | uniform8 | 512 | 1.6 | 16.5 | 18.3 | 1.11 |
| 32 | uniform8 | 1024 | 2.4 | 23.4 | 30.8 | 1.32 |
| 32 | uniform8 | 2048 | 4.1 | 38.0 | 59.3 | 1.56 |
| 32 | uniform8 | 4608 | 8.3 | 67.7 | 113.0 | 1.67 |
| 32 | uniform8 | 9728 | 16.7 | 127.1 | 217.6 | 1.71 |
| 32 | uniform8 | 32768 | 54.6 | 389.2 | 705.1 | 1.81 |
| 32 | uniform8 | 38912 | 64.7 | 458.0 | 834.0 | 1.82 |
| 32 | zipf16 | 640 | 2.6 | 24.8 | 50.7 | 2.05 |
| 32 | zipf16 | 1216 | 3.6 | 28.5 | 64.7 | 2.27 |
| 32 | zipf16 | 2432 | 5.6 | 47.2 | 100.4 | 2.13 |
| 32 | zipf16 | 4864 | 9.6 | 75.6 | 156.2 | 2.06 |
| 32 | zipf16 | 9728 | 17.6 | 133.2 | 267.1 | 2.01 |
| 32 | zipf16 | 38912 | 65.6 | 467.0 | 880.0 | 1.88 |
| 32 | zipf8 | 640 | 1.8 | 21.7 | 38.4 | 1.77 |
| 32 | zipf8 | 1216 | 2.7 | 26.4 | 55.0 | 2.09 |
| 32 | zipf8 | 2432 | 4.7 | 42.3 | 98.2 | 2.32 |
| 32 | zipf8 | 4864 | 8.7 | 71.8 | 147.3 | 2.05 |
| 32 | zipf8 | 9728 | 16.7 | 128.9 | 250.6 | 1.94 |
| 32 | zipf8 | 38912 | 64.7 | 460.9 | 863.3 | 1.87 |
| 96 | single | 256 | 1.3 | 16.0 | 28.1 | 1.76 |
| 96 | single | 448 | 2.2 | 25.6 | 42.8 | 1.67 |
| 96 | single | 832 | 4.1 | 40.5 | 71.6 | 1.77 |
| 96 | single | 1664 | 8.2 | 69.8 | 122.9 | 1.76 |
| 96 | single | 3264 | 16.1 | 124.7 | 223.4 | 1.79 |
| 96 | single | 12992 | 64.1 | 454.4 | 835.6 | 1.84 |
| 96 | uniform8 | 512 | 4.7 | 27.2 | 44.8 | 1.65 |
| 96 | uniform8 | 1536 | 9.8 | 69.4 | 112.5 | 1.62 |
| 96 | uniform8 | 3072 | 17.4 | 122.5 | 212.8 | 1.74 |
| 96 | uniform8 | 12800 | 65.4 | 457.7 | 828.0 | 1.81 |
| 96 | uniform8 | 65536 | 325.6 | 2324.9 | 4183.7 | 1.80 |
| 96 | zipf16 | 256 | 6.0 | 44.7 | 109.2 | 2.44 |
| 96 | zipf16 | 448 | 6.9 | 51.2 | 119.1 | 2.33 |
| 96 | zipf16 | 832 | 8.8 | 58.2 | 140.6 | 2.42 |
| 96 | zipf16 | 1664 | 12.9 | 86.0 | 194.7 | 2.26 |
| 96 | zipf16 | 3264 | 20.8 | 145.3 | 312.2 | 2.15 |
| 96 | zipf16 | 12992 | 68.8 | 477.9 | 914.2 | 1.91 |
| 96 | zipf8 | 256 | 3.5 | 28.2 | 59.2 | 2.10 |
| 96 | zipf8 | 448 | 4.4 | 34.8 | 76.8 | 2.21 |
| 96 | zipf8 | 832 | 6.3 | 48.9 | 112.4 | 2.30 |
| 96 | zipf8 | 1664 | 10.4 | 79.9 | 170.5 | 2.13 |
| 96 | zipf8 | 3264 | 18.3 | 135.2 | 280.9 | 2.08 |
| 96 | zipf8 | 11920 | 61.3 | 431.0 | 838.9 | 1.95 |
| 96 | zipf8 | 12992 | 66.3 | 469.1 | 902.4 | 1.92 |

</details>

<details><summary><b>recompute</b>: persistent/static 0.91–1.31 over 50 shapes</summary>

| heads | layout | tokens | waves | STATIC µs | PERSISTENT µs | P/S |
|---:|---|---:|---:|---:|---:|---:|
| 32 | single | 640 | 1.0 | 18.1 | 21.3 | 1.18 |
| 32 | single | 1216 | 1.0 | 22.2 | 25.8 | 1.16 |
| 32 | single | 2432 | 2.0 | 42.3 | 53.1 | 1.25 |
| 32 | single | 4864 | 4.0 | 76.1 | 96.5 | 1.27 |
| 32 | single | 9728 | 8.0 | 141.5 | 182.5 | 1.29 |
| 32 | single | 16384 | 13.5 | 233.6 | 299.6 | 1.28 |
| 32 | single | 38912 | 32.0 | 537.6 | 697.2 | 1.30 |
| 32 | uniform8 | 512 | 1.0 | 18.3 | 16.5 | 0.91 |
| 32 | uniform8 | 1024 | 1.2 | 22.7 | 24.5 | 1.08 |
| 32 | uniform8 | 2048 | 2.1 | 38.9 | 51.0 | 1.31 |
| 32 | uniform8 | 4608 | 4.2 | 73.6 | 95.9 | 1.30 |
| 32 | uniform8 | 9728 | 8.4 | 143.9 | 184.6 | 1.28 |
| 32 | uniform8 | 32768 | 27.3 | 461.4 | 592.1 | 1.28 |
| 32 | uniform8 | 38912 | 32.4 | 541.6 | 703.6 | 1.30 |
| 32 | zipf16 | 640 | 1.3 | 24.1 | 26.4 | 1.09 |
| 32 | zipf16 | 1216 | 1.8 | 30.3 | 32.5 | 1.07 |
| 32 | zipf16 | 2432 | 2.8 | 49.8 | 61.0 | 1.23 |
| 32 | zipf16 | 4864 | 4.8 | 83.4 | 106.4 | 1.28 |
| 32 | zipf16 | 9728 | 8.8 | 147.7 | 193.3 | 1.31 |
| 32 | zipf16 | 38912 | 32.8 | 545.8 | 710.9 | 1.30 |
| 32 | zipf8 | 640 | 1.0 | 21.4 | 22.5 | 1.05 |
| 32 | zipf8 | 1216 | 1.4 | 28.3 | 30.2 | 1.07 |
| 32 | zipf8 | 2432 | 2.4 | 48.7 | 59.3 | 1.22 |
| 32 | zipf8 | 4864 | 4.4 | 80.4 | 102.8 | 1.28 |
| 32 | zipf8 | 9728 | 8.4 | 145.4 | 189.5 | 1.30 |
| 32 | zipf8 | 38912 | 32.4 | 543.1 | 705.4 | 1.30 |
| 96 | single | 256 | 1.0 | 18.1 | 22.1 | 1.22 |
| 96 | single | 448 | 1.1 | 27.9 | 31.1 | 1.12 |
| 96 | single | 832 | 2.1 | 48.6 | 59.3 | 1.22 |
| 96 | single | 1664 | 4.1 | 83.0 | 103.7 | 1.25 |
| 96 | single | 3264 | 8.1 | 148.8 | 188.1 | 1.26 |
| 96 | single | 12992 | 32.1 | 563.7 | 699.7 | 1.24 |
| 96 | uniform8 | 512 | 2.4 | 33.0 | 36.0 | 1.09 |
| 96 | uniform8 | 1536 | 4.9 | 75.6 | 95.9 | 1.27 |
| 96 | uniform8 | 3072 | 8.7 | 141.0 | 177.5 | 1.26 |
| 96 | uniform8 | 12800 | 32.7 | 550.0 | 696.9 | 1.27 |
| 96 | uniform8 | 65536 | 162.8 | 2824.7 | 3527.2 | 1.25 |
| 96 | zipf16 | 256 | 3.0 | 38.3 | 46.0 | 1.20 |
| 96 | zipf16 | 448 | 3.5 | 44.9 | 53.1 | 1.18 |
| 96 | zipf16 | 832 | 4.4 | 60.4 | 75.3 | 1.25 |
| 96 | zipf16 | 1664 | 6.5 | 91.3 | 118.9 | 1.30 |
| 96 | zipf16 | 3264 | 10.4 | 160.3 | 210.4 | 1.31 |
| 96 | zipf16 | 12992 | 34.4 | 568.2 | 725.1 | 1.28 |
| 96 | zipf8 | 256 | 1.7 | 27.9 | 28.7 | 1.03 |
| 96 | zipf8 | 448 | 2.2 | 33.3 | 39.0 | 1.17 |
| 96 | zipf8 | 832 | 3.2 | 51.4 | 64.1 | 1.25 |
| 96 | zipf8 | 1664 | 5.2 | 85.7 | 111.6 | 1.30 |
| 96 | zipf8 | 3264 | 9.2 | 153.0 | 193.4 | 1.26 |
| 96 | zipf8 | 11920 | 30.6 | 520.7 | 659.6 | 1.27 |
| 96 | zipf8 | 12992 | 33.2 | 562.6 | 716.6 | 1.27 |

</details>

### Padding regime (h96, capacity fixed by a 65536-token buffer, active tokens vary)

PERSISTENT wins only when a captured graph replays far below its capacity; the selector sees only capacity, so AUTO bets on mostly-full buffers. P/S < 1 means PERSISTENT faster.

| active / capacity | output STATIC | output PERSIST | P/S | recompute STATIC | recompute PERSIST | P/S |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 2342 | 4198 | 1.79 | 2785 | 3529 | 1.27 |
| 1/4 | 644 | 1054 | 1.64 | 783 | 888 | 1.13 |
| 1/16 | 212 | 278 | 1.31 | 376 | 234 | 0.62 |
| 1/64 | 117 | 86 | 0.74 | 337 | 70 | 0.21 |
| 1/256 | 114 | 61 | 0.54 | 326 | 29 | 0.09 |

## Before/after: `benchmarks/proof/bench_core_vs_fla.py`, graph replay, µs, lower is better

Min of two interleaved runs (per-run values in parentheses); FLA column is an unchanged-code control for GPU contention.

| case | phase | before | after | Δ | after/before | FLA before → after |
|---|---|---:|---:|---:|---:|---|
| h96 dense B8 T8192 | fwd | 18307 (20856, 18307) | 16792 (19184, 16792) | −1515 | 0.917 | 18081 → 20482 |
| h96 dense B8 T8192 | bwd | 32542 | 31876 | −666 | 0.980 | 51701 → 52478 |
| h96 packed Zipf s8 | fwd | 3432 (3444, 3432) | 2900 (2900, 2902) | −532 | 0.845 | 3453 → 3455 |
| h96 packed Zipf s8 | bwd | 6339 | 6185 | −155 | 0.976 | 9545 → 9544 |
| h32 dense B8 T4096 | fwd | 3052 (3433, 3052) | 2599 (3005, 2599) | −453 | 0.852 | 5894 → 6524 |
| h32 dense B8 T4096 | bwd | 5477 | 5459 | −18 | 0.997 | 10386 → 10398 |
| h32 dense B1 T16384 | fwd | 1280 (1280, 1280) | 1278 (1278, 1281) | −1 | 0.999 | 3058 → 3062 |
| h32 dense B1 T16384 | bwd | 2577 | 2584 | +6 | 1.002 | 5501 → 5505 |

Public `chunk_kda` forward outputs are `torch.equal` to `main` on all 7 checked shapes (the 4 above plus h96 zipf16 T3264, h32 uniform8 T9728, h96 single T832).