### PR TITLE
Expose the ragged launch schedule through chunk_kda kernel_options

### DIFF
--- a/attn_gym/linear/kda/api.py
+++ b/attn_gym/linear/kda/api.py
@@ -166,6 +166,7 @@ def chunk_kda(
             output_final_state=output_final_state,
             fastmath=fastmath,
             autotune=autotune,
+            schedule=options.schedule,
         )
     return reference_kda(
         partial(naive_chunk_kda, chunk_size=_CHUNK_SIZE),
@@ -219,7 +220,8 @@ def paged_chunk_kda(
             configurations when true; Mega uses its fixed schedule.
         kernel_options: Backend-specific options. ``{"backend": "mega"}`` selects
             the optional CuTeDSL 4.7 Mega backend. ``split_backward`` and
-            ``split_forward`` are not supported by this paged operation.
+            ``split_forward`` are not supported by this paged operation; ``schedule``
+            applies to the fused backend as in ``chunk_kda``.
 
     Returns:
         The output in ``q.dtype``. ``state_cache`` is advanced in place.
@@ -270,6 +272,7 @@ def paged_chunk_kda(
         cu_seqlens=cu_seqlens,
         has_initial_state=has_initial_state,
         autotune=autotune,
+        schedule=options.schedule,
     )
 
 

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 import torch
 
 from attn_gym._backends.profiler import profiler_range
-from attn_gym.linear._delta_rule.triton.chunk_scheduler import RaggedChunkMetadata
+from attn_gym.linear._delta_rule.triton.chunk_scheduler import RaggedChunkMetadata, ScheduleRequest
 from attn_gym.linear.kda.bwd.cute.chunk_delta_h_bwd import (
     blackwell_delta_h_bwd_dhu_dv_fused_dispatch,
 )
@@ -55,6 +55,7 @@ def _prepare_chunk_kda_bwd(
     scale: float,
     chunk_size: int,
     autotune: bool,
+    schedule: ScheduleRequest = ScheduleRequest.AUTO,
 ) -> ChunkKDABwdPrepared:
     """Resolve intra factors and recompute local state before CP communication."""
     if Aqk is None:
@@ -71,6 +72,7 @@ def _prepare_chunk_kda_bwd(
             metadata=metadata,
             chunk_size=chunk_size,
             autotune=autotune,
+            schedule=schedule,
         )
     assert qg is not None and kg is not None
     with profiler_range("kda/triton/backward_recompute_state"):
@@ -233,6 +235,7 @@ def chunk_kda_bwd(
     chunk_size: int = 64,
     fastmath: bool = False,
     autotune: bool = True,
+    schedule: ScheduleRequest = ScheduleRequest.AUTO,
 ) -> tuple[
     torch.Tensor,
     torch.Tensor,
@@ -267,6 +270,7 @@ def chunk_kda_bwd(
         scale=scale,
         chunk_size=chunk_size,
         autotune=autotune,
+        schedule=schedule,
     )
     return _finish_chunk_kda_bwd(
         q,

--- a/attn_gym/linear/kda/context_parallel.py
+++ b/attn_gym/linear/kda/context_parallel.py
@@ -19,6 +19,7 @@ from attn_gym.linear.context_parallel import (
     context_parallel_chunk,
 )
 from attn_gym.linear.kda.stages import chunk_kda_prepare, chunk_kda_prepare_backward
+from attn_gym.linear.kda.validation import resolve_kernel_options
 from attn_gym.linear.types import KernelOptions
 
 
@@ -46,7 +47,12 @@ def context_parallel_kda(
     """
     stages = StagedOp(
         partial(chunk_kda_prepare, scale=scale, autotune=autotune, kernel_options=kernel_options),
-        partial(chunk_kda_prepare_backward, autotune=autotune, fastmath=fastmath),
+        partial(
+            chunk_kda_prepare_backward,
+            autotune=autotune,
+            fastmath=fastmath,
+            schedule=resolve_kernel_options(kernel_options).schedule,
+        ),
     )
     return context_parallel_chunk(stages, q, k, v, gate, beta, routing=routing, group=group)
 

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd.py
@@ -13,7 +13,7 @@ from attn_gym._backends.cute import (
     tensor_supports_tma_rows,
 )
 from attn_gym._backends.profiler import profiler_range
-from attn_gym.linear._delta_rule.triton.chunk_scheduler import RaggedChunkMetadata
+from attn_gym.linear._delta_rule.triton.chunk_scheduler import RaggedChunkMetadata, ScheduleRequest
 from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd_intra import chunk_kda_fwd_intra
 from attn_gym.linear.kda.fwd.triton.chunk_delta_h import chunk_gated_delta_rule_fwd_h
 from attn_gym.linear.kda.fwd.triton.chunk_gla_fwd_o import chunk_gla_fwd_o_gk
@@ -145,6 +145,7 @@ def _prepare_chunk_kda_fwd(
     *,
     scale: float,
     autotune: bool,
+    schedule: ScheduleRequest,
 ) -> ChunkKDAFactors:
     """Compute the local factors needed by both CP summaries and ordinary output."""
     with profiler_range("kda/fused/chunk_kda_fwd_intra"):
@@ -160,6 +161,7 @@ def _prepare_chunk_kda_fwd(
                 chunk_size=_CHUNK_SIZE,
                 profile_ranges=torch.autograd.profiler._is_profiler_enabled,
                 autotune=autotune,
+                schedule=schedule,
             )
         )
 
@@ -176,6 +178,7 @@ def _finish_chunk_kda_fwd(
     scale: float,
     output_final_state: bool,
     autotune: bool,
+    schedule: ScheduleRequest,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Apply an initial state and compose token outputs from prepared local factors."""
     with profiler_range("kda/triton/inter_chunk_state"):
@@ -203,6 +206,7 @@ def _finish_chunk_kda_fwd(
             chunk_size=_CHUNK_SIZE,
             metadata=metadata,
             autotune=autotune,
+            schedule=schedule,
         )
     return output, final_state
 
@@ -221,6 +225,7 @@ def _chunk_kda_fwd(
     scale: float,
     output_final_state: bool,
     autotune: bool,
+    schedule: ScheduleRequest,
 ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor, torch.Tensor]:
     """Run the optimized KDA core using an already selected chunk schedule."""
     factors = _prepare_chunk_kda_fwd(
@@ -232,6 +237,7 @@ def _chunk_kda_fwd(
         metadata,
         scale=scale,
         autotune=autotune,
+        schedule=schedule,
     )
     output, final_state = _finish_chunk_kda_fwd(
         q,
@@ -244,6 +250,7 @@ def _chunk_kda_fwd(
         scale=scale,
         output_final_state=output_final_state,
         autotune=autotune,
+        schedule=schedule,
     )
     return output, final_state, factors.aqk, factors.akk
 
@@ -257,6 +264,7 @@ def _chunk_kda_fwd_shared(
     initial_state: torch.Tensor | None,
     scale: float,
     autotune: bool,
+    schedule: str,
     output_final_state: bool,
 ):
     """Keep the complete composed forward behind one compiler-opaque boundary."""
@@ -275,6 +283,7 @@ def _chunk_kda_fwd_shared(
         scale=scale,
         output_final_state=output_final_state,
         autotune=autotune,
+        schedule=ScheduleRequest(schedule),
     )
 
 
@@ -287,6 +296,7 @@ def _chunk_kda_fwd_cuda(
     initial_state: torch.Tensor | None,
     scale: float,
     autotune: bool,
+    schedule: str,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     output, _final_state, Aqk, Akk = _chunk_kda_fwd_shared(
         q,
@@ -297,6 +307,7 @@ def _chunk_kda_fwd_cuda(
         initial_state,
         scale,
         autotune,
+        schedule,
         False,
     )
     return output, Aqk, Akk
@@ -311,6 +322,7 @@ def _chunk_kda_fwd_with_state_cuda(
     initial_state: torch.Tensor | None,
     scale: float,
     autotune: bool,
+    schedule: str,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     return _chunk_kda_fwd_shared(
         q,
@@ -321,6 +333,7 @@ def _chunk_kda_fwd_with_state_cuda(
         initial_state,
         scale,
         autotune,
+        schedule,
         True,
     )
 
@@ -336,6 +349,7 @@ def _chunk_kda_fwd_ragged_shared(
     chunk_offsets: torch.Tensor,
     scale: float,
     autotune: bool,
+    schedule: str,
     output_final_state: bool,
 ):
     """Run ragged forward with caller-prepared routing and fixed-schema factors."""
@@ -355,6 +369,7 @@ def _chunk_kda_fwd_ragged_shared(
         scale=scale,
         output_final_state=output_final_state,
         autotune=autotune,
+        schedule=ScheduleRequest(schedule),
     )
 
 
@@ -369,6 +384,7 @@ def _chunk_kda_fwd_ragged_cuda(
     chunk_offsets: torch.Tensor,
     scale: float,
     autotune: bool,
+    schedule: str,
 ):
     output, _state, Aqk, Akk = _chunk_kda_fwd_ragged_shared(
         q,
@@ -381,6 +397,7 @@ def _chunk_kda_fwd_ragged_cuda(
         chunk_offsets,
         scale,
         autotune,
+        schedule,
         False,
     )
     return output, Aqk, Akk
@@ -397,6 +414,7 @@ def _chunk_kda_fwd_ragged_with_state_cuda(
     chunk_offsets: torch.Tensor,
     scale: float,
     autotune: bool,
+    schedule: str,
 ):
     return _chunk_kda_fwd_ragged_shared(
         q,
@@ -409,6 +427,7 @@ def _chunk_kda_fwd_ragged_with_state_cuda(
         chunk_offsets,
         scale,
         autotune,
+        schedule,
         True,
     )
 
@@ -425,6 +444,7 @@ def _chunk_kda_fwd_ragged_paged_cuda(
     cu_seqlens: torch.Tensor,
     chunk_offsets: torch.Tensor,
     autotune: bool,
+    schedule: str,
 ) -> torch.Tensor:
     q, k, v = (normalize_tma_rows(tensor) for tensor in (q, k, v))
     _validate_paged_private_abi(
@@ -452,6 +472,7 @@ def _chunk_kda_fwd_ragged_paged_cuda(
         scale=_HEAD_DIM**-0.5,
         output_final_state=False,
         autotune=autotune,
+        schedule=ScheduleRequest(schedule),
     )
     return output
 
@@ -512,6 +533,7 @@ def _chunk_kda_bwd_shared(
     scale: float,
     fastmath: bool,
     autotune: bool,
+    schedule: str,
 ):
     """Run the opaque composed backward with saved or recomputed factors."""
     from attn_gym.linear.kda.bwd.cute.chunk_kda_bwd import chunk_kda_bwd
@@ -544,6 +566,7 @@ def _chunk_kda_bwd_shared(
         scale=scale,
         fastmath=fastmath,
         autotune=autotune,
+        schedule=ScheduleRequest(schedule),
     )
 
 
@@ -561,6 +584,7 @@ def _chunk_kda_bwd_recompute_factors_shared(
     scale: float,
     fastmath: bool,
     autotune: bool,
+    schedule: str,
 ):
     """Keep the recomputed-factor backward opaque to AOTAutograd."""
     return _chunk_kda_bwd_shared(
@@ -579,6 +603,7 @@ def _chunk_kda_bwd_recompute_factors_shared(
         scale,
         fastmath,
         autotune,
+        schedule,
     )
 
 

--- a/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_intra.py
+++ b/attn_gym/linear/kda/fwd/cute/chunk_kda_fwd_intra.py
@@ -14,7 +14,7 @@ from contextlib import nullcontext
 import torch
 from torch._subclasses.fake_tensor import FakeTensor
 
-from attn_gym.linear._delta_rule.triton.chunk_scheduler import RaggedChunkMetadata
+from attn_gym.linear._delta_rule.triton.chunk_scheduler import RaggedChunkMetadata, ScheduleRequest
 from attn_gym.linear.kda.constants import DEFAULT_CHUNK_SIZE
 from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd_inter_solve import (
     chunk_kda_fwd_inter_solve_cute,
@@ -115,6 +115,7 @@ def chunk_kda_fwd_intra(
     chunk_size: int = DEFAULT_CHUNK_SIZE,
     profile_ranges: bool = False,
     autotune: bool = True,
+    schedule: ScheduleRequest = ScheduleRequest.AUTO,
 ) -> tuple[
     torch.Tensor,
     torch.Tensor,
@@ -142,6 +143,7 @@ def chunk_kda_fwd_intra(
     ):
         w, u, _qg, kg = recompute_w_u_fwd(
             autotune=autotune,
+            schedule=schedule,
             k=k,
             v=v,
             beta=beta,

--- a/attn_gym/linear/kda/fwd/triton/chunk_gla_fwd_o.py
+++ b/attn_gym/linear/kda/fwd/triton/chunk_gla_fwd_o.py
@@ -518,8 +518,9 @@ def chunk_gla_fwd_o_gk(
     """Compose fixed-length or packed KDA intra- and inter-chunk output terms.
 
     Args:
-        schedule: Internal scheduling request for tests. Automatic selection is
-            the default and dense inputs keep their exact launch grid.
+        schedule: Ragged launch geometry, as ``chunk_kda``'s ``kernel_options['schedule']``.
+            AUTO keeps the static grid; dense inputs always use
+            their exact launch grid.
 
     Raises:
         ValueError: If persistent scheduling is forced for a packed input outside

--- a/attn_gym/linear/kda/fwd/triton/recompute_w_u.py
+++ b/attn_gym/linear/kda/fwd/triton/recompute_w_u.py
@@ -439,8 +439,9 @@ def recompute_w_u_fwd_triton(
     """Launch the register-operand recompute for packed B=1 inputs.
 
     Args:
-        schedule: Internal scheduling request for tests; automatic selection is
-            the default and dense inputs keep their exact launch grid.
+        schedule: Ragged launch geometry, as ``chunk_kda``'s ``kernel_options['schedule']``.
+            AUTO keeps the static grid; dense inputs always use
+            their exact launch grid.
     """
     batch, tokens, key_heads, key_dim = k.shape
     value_heads, value_dim = v.shape[2], v.shape[3]

--- a/attn_gym/linear/kda/impl/fused.py
+++ b/attn_gym/linear/kda/impl/fused.py
@@ -6,7 +6,10 @@ import torch
 
 from attn_gym._backends.cute.utils import get_device_properties
 from attn_gym.linear._delta_rule.chunk_ops import _plain_gate_scan_op
-from attn_gym.linear._delta_rule.chunk_schedule import prepare_ragged_chunk_metadata
+from attn_gym.linear._delta_rule.chunk_schedule import (
+    ScheduleRequest,
+    prepare_ragged_chunk_metadata,
+)
 from attn_gym.linear.kda.ops import (
     chunk_bwd_op,
     chunk_bwd_with_state_grad_op,
@@ -49,6 +52,7 @@ class _ChunkKDA(torch.autograd.Function):
         output_final_state,
         fastmath,
         autotune,
+        schedule,
     ):
         cumulative_gate = _plain_gate_scan_op(
             gate,
@@ -60,11 +64,11 @@ class _ChunkKDA(torch.autograd.Function):
             assert chunk_offsets is None
             if output_final_state:
                 output, state, aqk, akk = chunk_fwd_with_state_op(
-                    q, k, v, cumulative_gate, beta, initial_state, scale, autotune
+                    q, k, v, cumulative_gate, beta, initial_state, scale, autotune, schedule
                 )
             else:
                 output, aqk, akk = chunk_fwd_op(
-                    q, k, v, cumulative_gate, beta, initial_state, scale, autotune
+                    q, k, v, cumulative_gate, beta, initial_state, scale, autotune, schedule
                 )
         elif output_final_state:
             assert chunk_offsets is not None
@@ -79,6 +83,7 @@ class _ChunkKDA(torch.autograd.Function):
                 chunk_offsets,
                 scale,
                 autotune,
+                schedule,
             )
         else:
             assert chunk_offsets is not None
@@ -93,6 +98,7 @@ class _ChunkKDA(torch.autograd.Function):
                 chunk_offsets,
                 scale,
                 autotune,
+                schedule,
             )
         ctx.save_for_backward(
             q,
@@ -109,6 +115,7 @@ class _ChunkKDA(torch.autograd.Function):
         ctx.scale = scale
         ctx.fastmath = fastmath
         ctx.autotune = autotune
+        ctx.schedule = schedule
         ctx.set_materialize_grads(False)
         if output_final_state:
             return output, state
@@ -145,6 +152,7 @@ class _ChunkKDA(torch.autograd.Function):
             ctx.scale,
             ctx.fastmath,
             ctx.autotune,
+            ctx.schedule,
         )
         if initial_state is not None:
             dq, dk, dv, d_cumulative, db, d_initial_state = chunk_bwd_with_state_grad_op(*args)
@@ -157,7 +165,7 @@ class _ChunkKDA(torch.autograd.Function):
             chunk_offsets,
             True,
         )
-        return dq, dk, dv, d_gate, db, d_initial_state, None, None, None, None, None, None
+        return dq, dk, dv, d_gate, db, d_initial_state, None, None, None, None, None, None, None
 
 
 def chunk_forward(
@@ -173,6 +181,7 @@ def chunk_forward(
     output_final_state: bool = False,
     fastmath: bool = False,
     autotune: bool = True,
+    schedule: ScheduleRequest = ScheduleRequest.AUTO,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Normalize per-token natural-log gates and invoke the fused chunk operators."""
     _validate_fused_constraints(q, v)
@@ -216,6 +225,7 @@ def chunk_forward(
             True,
             fastmath,
             autotune,
+            schedule.value,
         )
     else:
         output = _ChunkKDA.apply(
@@ -231,6 +241,7 @@ def chunk_forward(
             False,
             fastmath,
             autotune,
+            schedule.value,
         )
         state = None
     return output.reshape(output_shape).to(output_dtype), state
@@ -248,6 +259,7 @@ def paged_chunk_forward(
     cu_seqlens: torch.Tensor | None = None,
     has_initial_state: torch.Tensor | None = None,
     autotune: bool = True,
+    schedule: ScheduleRequest = ScheduleRequest.AUTO,
 ) -> torch.Tensor:
     """Normalize inputs and invoke the registered paged chunk operator."""
     _validate_fused_constraints(q, v)
@@ -289,6 +301,7 @@ def paged_chunk_forward(
         metadata.cu_seqlens,
         metadata.chunk_offsets,
         autotune,
+        schedule.value,
     )
     return output.reshape(output_shape).to(output_dtype)
 

--- a/attn_gym/linear/kda/impl/mega.py
+++ b/attn_gym/linear/kda/impl/mega.py
@@ -116,6 +116,7 @@ class ChunkKdaMegaDense(torch.autograd.Function):
             ctx.scale,
             False,
             False,
+            "auto",
         )
         d_gate = plain_gate_bwd_dense_cute_op(d_cumulative.contiguous())
         return dq, dk, dv, d_gate, d_beta, None, None, None, None
@@ -254,6 +255,7 @@ class ChunkKdaMegaPacked(torch.autograd.Function):
                     ctx.scale,
                     False,
                     False,
+                    "auto",
                 )
             )
         else:
@@ -272,6 +274,7 @@ class ChunkKdaMegaPacked(torch.autograd.Function):
                 ctx.scale,
                 False,
                 False,
+                "auto",
             )
             d_initial_state = None
         d_gate = _plain_gate_scan_op(d_cumulative.contiguous(), cu_seqlens, chunk_offsets, True)

--- a/attn_gym/linear/kda/ops.py
+++ b/attn_gym/linear/kda/ops.py
@@ -17,7 +17,7 @@ _CHUNK_SIZE = 64
 # Fixed-arity schema pairs avoid optional outputs on hot paths.
 _CHUNK_FWD_ARGS = (
     "(Tensor q, Tensor k, Tensor v, Tensor cumulative_gate, Tensor beta, Tensor? initial_state,"
-    " float scale, bool autotune)"
+    " float scale, bool autotune, str schedule)"
 )
 torch.library.define(
     "attn_gym::kda_chunk_fwd",
@@ -31,7 +31,7 @@ torch.library.define(
 _CHUNK_RAGGED_FWD_ARGS = (
     "(Tensor q, Tensor k, Tensor v, Tensor cumulative_gate, Tensor beta, "
     "Tensor? initial_state, Tensor cu_seqlens, Tensor chunk_offsets, float scale, "
-    "bool autotune)"
+    "bool autotune, str schedule)"
 )
 torch.library.define(
     "attn_gym::kda_chunk_fwd_ragged",
@@ -46,13 +46,14 @@ torch.library.define(
     "(Tensor q, Tensor k, Tensor v, Tensor cumulative_gate, Tensor beta, "
     "Tensor(a!) state_cache, Tensor state_indices, Tensor? has_initial_state, "
     "Tensor cu_seqlens, "
-    "Tensor chunk_offsets, bool autotune) -> Tensor",
+    "Tensor chunk_offsets, bool autotune, str schedule) -> Tensor",
 )
 
 _CHUNK_BWD_ARGS = (
     "(Tensor q, Tensor k, Tensor v, Tensor cumulative_gate, Tensor beta, Tensor Aqk, "
     "Tensor Akk, Tensor? cu_seqlens, Tensor? chunk_offsets, Tensor? d_output, "
-    "Tensor? d_final_state, {initial_state}, float scale, bool fastmath, bool autotune)"
+    "Tensor? d_final_state, {initial_state}, float scale, bool fastmath, bool autotune, "
+    "str schedule)"
 )
 torch.library.define(
     "attn_gym::kda_chunk_bwd",
@@ -68,7 +69,8 @@ torch.library.define(
 _CHUNK_BWD_RECOMPUTE_ARGS = (
     "(Tensor q, Tensor k, Tensor v, Tensor cumulative_gate, Tensor beta, "
     "Tensor? cu_seqlens, Tensor? chunk_offsets, Tensor? d_output, "
-    "Tensor? d_final_state, {initial_state}, float scale, bool fastmath, bool autotune)"
+    "Tensor? d_final_state, {initial_state}, float scale, bool fastmath, bool autotune, "
+    "str schedule)"
 )
 torch.library.define(
     "attn_gym::kda_chunk_bwd_recompute_factors",
@@ -277,8 +279,9 @@ def _chunk_fwd_fake(
     initial_state: torch.Tensor | None,
     scale: float,
     autotune: bool,
+    schedule: str,
 ):
-    del k, cumulative_gate, beta, initial_state, scale, autotune
+    del k, cumulative_gate, beta, initial_state, scale, autotune, schedule
     return _chunk_fwd_fake_common(q, v)
 
 
@@ -292,8 +295,9 @@ def _chunk_fwd_with_state_fake(
     initial_state: torch.Tensor | None,
     scale: float,
     autotune: bool,
+    schedule: str,
 ):
-    del k, cumulative_gate, beta, initial_state, scale, autotune
+    del k, cumulative_gate, beta, initial_state, scale, autotune, schedule
     output, aqk, akk = _chunk_fwd_fake_common(q, v)
     state = q.new_empty(
         (q.shape[0], q.shape[2], v.shape[-1], q.shape[3]),
@@ -314,8 +318,19 @@ def _chunk_fwd_ragged_fake(
     chunk_offsets: torch.Tensor,
     scale: float,
     autotune: bool,
+    schedule: str,
 ):
-    del k, cumulative_gate, beta, initial_state, cu_seqlens, chunk_offsets, scale, autotune
+    del (
+        k,
+        cumulative_gate,
+        beta,
+        initial_state,
+        cu_seqlens,
+        chunk_offsets,
+        scale,
+        autotune,
+        schedule,
+    )
     return _chunk_fwd_fake_common(q, v)
 
 
@@ -331,8 +346,9 @@ def _chunk_fwd_ragged_with_state_fake(
     chunk_offsets: torch.Tensor,
     scale: float,
     autotune: bool,
+    schedule: str,
 ):
-    del k, cumulative_gate, beta, initial_state, chunk_offsets, scale, autotune
+    del k, cumulative_gate, beta, initial_state, chunk_offsets, scale, autotune, schedule
     output, aqk, akk = _chunk_fwd_fake_common(q, v)
     state = q.new_empty(
         (cu_seqlens.shape[0] - 1, q.shape[2], v.shape[-1], q.shape[3]),
@@ -354,6 +370,7 @@ def _chunk_fwd_ragged_paged_fake(
     cu_seqlens: torch.Tensor,
     chunk_offsets: torch.Tensor,
     autotune: bool,
+    schedule: str,
 ) -> torch.Tensor:
     del (
         k,
@@ -365,6 +382,7 @@ def _chunk_fwd_ragged_paged_fake(
         cu_seqlens,
         chunk_offsets,
         autotune,
+        schedule,
     )
     return v.new_empty(v.shape, dtype=q.dtype)
 
@@ -396,9 +414,10 @@ def _chunk_bwd_fake(
     scale: float,
     fastmath: bool,
     autotune: bool,
+    schedule: str,
 ):
     del aqk, akk, cu_seqlens, chunk_offsets, d_output, d_final_state, initial_state
-    del scale, fastmath, autotune
+    del scale, fastmath, autotune, schedule
     return _chunk_bwd_fake_common(q, k, v, cumulative_gate, beta)
 
 
@@ -419,8 +438,20 @@ def _chunk_bwd_with_state_grad_fake(
     scale: float,
     fastmath: bool,
     autotune: bool,
+    schedule: str,
 ):
-    del aqk, akk, cu_seqlens, chunk_offsets, d_output, d_final_state, scale, fastmath, autotune
+    del (
+        aqk,
+        akk,
+        cu_seqlens,
+        chunk_offsets,
+        d_output,
+        d_final_state,
+        scale,
+        fastmath,
+        autotune,
+        schedule,
+    )
     return (
         *_chunk_bwd_fake_common(q, k, v, cumulative_gate, beta),
         torch.empty_like(initial_state),
@@ -442,9 +473,10 @@ def _chunk_bwd_recompute_factors_fake(
     scale: float,
     fastmath: bool,
     autotune: bool,
+    schedule: str,
 ):
     del cu_seqlens, chunk_offsets, d_output, d_final_state, initial_state
-    del scale, fastmath, autotune
+    del scale, fastmath, autotune, schedule
     return _chunk_bwd_fake_common(q, k, v, cumulative_gate, beta)
 
 
@@ -463,8 +495,9 @@ def _chunk_bwd_recompute_factors_with_state_grad_fake(
     scale: float,
     fastmath: bool,
     autotune: bool,
+    schedule: str,
 ):
-    del cu_seqlens, chunk_offsets, d_output, d_final_state, scale, fastmath, autotune
+    del cu_seqlens, chunk_offsets, d_output, d_final_state, scale, fastmath, autotune, schedule
     return (
         *_chunk_bwd_fake_common(q, k, v, cumulative_gate, beta),
         torch.empty_like(initial_state),

--- a/attn_gym/linear/kda/stages.py
+++ b/attn_gym/linear/kda/stages.py
@@ -38,7 +38,7 @@ import torch
 
 from attn_gym._backends.cute import normalize_compact_tensor, tensor_supports_tma
 from attn_gym.linear._delta_rule.chunk_ops import _plain_gate_scan_op
-from attn_gym.linear._delta_rule.chunk_schedule import RaggedChunkMetadata
+from attn_gym.linear._delta_rule.chunk_schedule import RaggedChunkMetadata, ScheduleRequest
 from attn_gym.linear._delta_rule.cute import build_state_grad_summaries, build_state_summaries
 from attn_gym.linear._delta_rule.span import CHUNK_SIZE, prepare_span, zero_state
 from attn_gym.linear.kda.bwd.cute.chunk_kda_bwd import (
@@ -122,6 +122,7 @@ class ChunkKDAPrepared:
     metadata: RaggedChunkMetadata | None
     scale: float
     autotune: bool
+    schedule: ScheduleRequest
 
     def state_summaries(self, bounds: torch.Tensor) -> torch.Tensor:
         """Return one FP32 ``[HV, V + K, K]`` map per row of ``bounds`` in a single launch.
@@ -153,6 +154,7 @@ class ChunkKDAPrepared:
             scale=self.scale,
             output_final_state=output_final_state,
             autotune=self.autotune,
+            schedule=self.schedule,
         )
 
 
@@ -170,6 +172,8 @@ class ChunkKDAMegaPrepared:
     metadata: RaggedChunkMetadata
     scale: float
     autotune: bool
+    # Mega rejects other schedules; kept so both handles feed chunk_kda_prepare_backward alike.
+    schedule: ScheduleRequest = ScheduleRequest.AUTO
 
     def state_summaries(self, bounds: torch.Tensor) -> torch.Tensor:
         """Return one FP32 ``[HV, V + K, K]`` map per row of ``bounds`` in a single launch.
@@ -188,6 +192,7 @@ class ChunkKDAMegaPrepared:
             self.metadata,
             scale=self.scale,
             autotune=self.autotune,
+            schedule=self.schedule,
         )
         return build_state_summaries(
             factors.kg, factors.w, factors.u, saved.cumulative_gate, bounds
@@ -245,7 +250,7 @@ def chunk_kda_prepare(
     ``kernel_options={"backend": "mega"}`` runs the local pass with Mega and computes fused factors
     only for the summaries; the split schedules are not available with entry states.
     """
-    backend, split_backward, split_forward = resolve_kernel_options(kernel_options)
+    backend, split_backward, split_forward, schedule = resolve_kernel_options(kernel_options)
     if split_backward or split_forward:
         raise ValueError("split schedules are not supported by chunk_kda_prepare")
     validate_kda_inputs(
@@ -276,12 +281,12 @@ def chunk_kda_prepare(
         )
         return ChunkKDAMegaPrepared(saved, gate, metadata, scale, autotune)
     factors = _prepare_chunk_kda_fwd(
-        q, k, v, cumulative_gate, beta, metadata, scale=scale, autotune=autotune
+        q, k, v, cumulative_gate, beta, metadata, scale=scale, autotune=autotune, schedule=schedule
     )
     saved = ChunkKDASaved(
         q, k, v, cumulative_gate, beta, factors.aqk, factors.akk, cu_seqlens, chunk_offsets
     )
-    return ChunkKDAPrepared(saved, factors, metadata, scale, autotune)
+    return ChunkKDAPrepared(saved, factors, metadata, scale, autotune, schedule)
 
 
 @dataclass
@@ -366,6 +371,7 @@ def chunk_kda_prepare_backward(
     scale: float,
     autotune: bool = True,
     fastmath: bool = False,
+    schedule: ScheduleRequest = ScheduleRequest.AUTO,
 ) -> ChunkKDABackward:
     """Recompute the local backward tensors before any reverse-summary exchange.
 
@@ -373,7 +379,8 @@ def chunk_kda_prepare_backward(
     forward handle's resolved ``prepared.scale``; there is no default because a silently
     re-derived scale would corrupt every gradient. Both live outside ``saved`` because the
     caller's autograd function owns them. ``fastmath`` applies to the gradient kernels as in
-    ``chunk_kda``.
+    ``chunk_kda``; pass the forward handle's ``prepared.schedule`` so the backward's factor
+    recompute uses the same launch geometry.
     """
     metadata = None
     if saved.cu_seqlens is not None:
@@ -401,6 +408,7 @@ def chunk_kda_prepare_backward(
         scale=scale,
         chunk_size=CHUNK_SIZE,
         autotune=autotune,
+        schedule=schedule,
     )
     return ChunkKDABackward(
         saved, d_output, initial_state, metadata, prepared, scale, autotune, fastmath

--- a/attn_gym/linear/kda/validation.py
+++ b/attn_gym/linear/kda/validation.py
@@ -17,17 +17,19 @@ from typing import Literal, NamedTuple
 
 import torch
 
+from attn_gym.linear._delta_rule.chunk_schedule import ScheduleRequest
 from attn_gym.linear._delta_rule.validation import validate_delta_rule_inputs
 
 SUPPORTED_INPUT_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
 
 
 class ResolvedKernelOptions(NamedTuple):
-    """Validated ``chunk_kda`` backend selection and its Mega scheduling switches."""
+    """Validated ``chunk_kda`` backend selection, Mega switches, and ragged launch schedule."""
 
     backend: Literal["fused", "mega"]
     split_backward: bool
     split_forward: bool
+    schedule: ScheduleRequest = ScheduleRequest.AUTO
 
 
 def resolve_kernel_options(
@@ -51,7 +53,14 @@ def resolve_kernel_options(
         if value and backend != "mega":
             raise ValueError(f"{name} requires kernel_options['backend']='mega'")
         splits[name] = value
-    return ResolvedKernelOptions(backend, splits["split_backward"], splits["split_forward"])
+    schedule = kernel_options.get("schedule", "auto")
+    if schedule not in ("auto", "static", "persistent"):
+        raise ValueError("kernel_options['schedule'] must be 'auto', 'static', or 'persistent'")
+    if schedule != "auto" and backend != "fused":
+        raise ValueError("schedule requires kernel_options['backend']='fused'")
+    return ResolvedKernelOptions(
+        backend, splits["split_backward"], splits["split_forward"], ScheduleRequest(schedule)
+    )
 
 
 def validate_kda_inputs(

--- a/attn_gym/linear/types.py
+++ b/attn_gym/linear/types.py
@@ -26,6 +26,13 @@ class KernelOptions(BackendOptions, total=False):
     split_forward: bool
     """Allow KDA Mega to use its approximate forgetting-horizon split forward schedule."""
 
+    schedule: Literal["auto", "static", "persistent"]
+    """Set ``"persistent"`` for CUDA graphs whose replays can carry far fewer tokens than the
+    captured capacity: the default static grid pays one CTA per capacity chunk even when empty,
+    while the persistent grid strides over active work only and wins below ~1/4 of capacity
+    active. Outputs are bitwise identical. Fused backend only; Hopper or newer for packed
+    inputs."""
+
 
 class Impl(str, Enum):
     """Select a fused or reference implementation without automatic fallback."""

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -430,6 +430,14 @@ currently require a no-state call, so context parallelism never uses them. `page
 same exact unsplit forward while updating selected cache slots directly; paged execution never uses
 forgetting-horizon splitting. Install the `mega` extra to use this backend.
 
+`kernel_options={"schedule": "persistent"}` is for CUDA graphs whose replays can carry far fewer
+tokens than the capacity they were captured for. The default static grid launches one CTA per
+capacity chunk, so a replay at 1/16 of capacity still pays for the empty CTAs; the persistent grid
+strides over only the active work. Below roughly a quarter of capacity active, persistent wins
+(measured 0.1-0.7x the static time on GB200); at full capacity it loses (1.1-2.4x). Outputs are
+bitwise identical. Requires the fused backend and, for packed inputs, the TMA output path (Hopper or
+newer).
+
 ::: attn_gym.linear.chunk_kda
 
 ::: attn_gym.linear.paged_chunk_kda
@@ -502,7 +510,9 @@ summaries = prepared.state_summaries(bounds)  # [bias; transition] per range
 # ...exchange summaries and compose each subsequence's entry state...
 output, final_state = prepared.run(initial_state, output_final_state=True)
 
-grads = chunk_kda_prepare_backward(prepared.saved, d_output, initial_state, scale=prepared.scale)
+grads = chunk_kda_prepare_backward(
+    prepared.saved, d_output, initial_state, scale=prepared.scale, schedule=prepared.schedule
+)
 grad_summaries = grads.state_grad_summaries(bounds)  # reverse maps [bias; transition]
 # ...exchange and compose each subsequence's exit cotangent...
 dq, dk, dv, dgate, dbeta, _ = grads.run(d_final_state)

--- a/test/kda/mega/test_kda_recompute_factors_backward.py
+++ b/test/kda/mega/test_kda_recompute_factors_backward.py
@@ -61,6 +61,7 @@ def test_recomputed_factors_backward_matches_saved_factors(lengths):
         D**-0.5,
         False,
         False,
+        "auto",
     )
     expected = chunk_bwd_op(*common[:5], Aqk, Akk, *common[5:])
     actual = chunk_bwd_recompute_factors_op(*common)
@@ -109,6 +110,7 @@ def test_ragged_backward_ignores_akk_capacity_slack():
         D**-0.5,
         False,
         False,
+        "auto",
     )
     expected = chunk_bwd_op(*common[:6], clean_akk, *common[6:])
     actual = chunk_bwd_op(*common[:6], poisoned_akk, *common[6:])
@@ -142,6 +144,7 @@ def test_recomputed_factors_backward_with_state_matches_saved_factors():
         D**-0.5,
         False,
         False,
+        "auto",
     )
     expected = chunk_bwd_with_state_grad_op(*common[:5], aqk, akk, *common[5:])
     actual = chunk_bwd_recompute_factors_with_state_grad_op(*common)
@@ -159,7 +162,7 @@ def test_recomputed_factors_backward_op_registration():
     d_output = torch.randn_like(v)
     torch.library.opcheck(
         chunk_bwd_recompute_factors_op,
-        (q, k, v, gate, beta, None, None, d_output, None, None, D**-0.5, False, False),
+        (q, k, v, gate, beta, None, None, d_output, None, None, D**-0.5, False, False, "auto"),
         test_utils=("test_schema", "test_faketensor", "test_aot_dispatch_dynamic"),
         rtol=2e-2,
         atol=2e-3,
@@ -181,6 +184,7 @@ def test_recomputed_factors_backward_op_registration():
             D**-0.5,
             False,
             False,
+            "auto",
         ),
         test_utils=("test_schema", "test_faketensor", "test_aot_dispatch_dynamic"),
         rtol=2e-2,

--- a/test/test_kda_cute_forward.py
+++ b/test/test_kda_cute_forward.py
@@ -153,7 +153,7 @@ def test_private_chunk_kda_forward_matches_reference(dtype: torch.dtype):
     q, k, v, gate, beta = _inputs(tokens=64, dtype=dtype)
     cumulative_gate = chunk_cumsum_ref(gate * LOG2_E, 64)
     actual, aqk, akk = _chunk_kda_fwd_op(
-        q, k, v, cumulative_gate, beta, None, _DEFAULT_SCALE, False
+        q, k, v, cumulative_gate, beta, None, _DEFAULT_SCALE, False, "auto"
     )
     golden, _ = naive_chunk_kda(
         q.double(),
@@ -177,7 +177,7 @@ def test_private_fp16_forward_factors_are_finite_at_gate_limit():
     cumulative_gate = chunk_cumsum_ref(gate * LOG2_E, 64)
 
     output, aqk, akk = _chunk_kda_fwd_op(
-        q, k, v, cumulative_gate, beta, None, _DEFAULT_SCALE, False
+        q, k, v, cumulative_gate, beta, None, _DEFAULT_SCALE, False, "auto"
     )
 
     for tensor in (output, aqk, akk):
@@ -596,12 +596,14 @@ def test_chunk_kda_selects_direct_dense_or_ragged_route(
     module = importlib.import_module("attn_gym.linear.kda.impl.fused")
     routes = []
 
-    def dense_forward(q, _k, v, _gate, _beta, _state, _scale, _tune):
+    def dense_forward(q, _k, v, _gate, _beta, _state, _scale, _tune, _schedule):
         routes.append("dense")
         factors = q.new_empty((*q.shape[:3], 64))
         return torch.empty_like(v), factors, factors
 
-    def ragged_forward(q, _k, v, _gate, _beta, _state, _cu_seqlens, _chunk_offsets, _scale, _tune):
+    def ragged_forward(
+        q, _k, v, _gate, _beta, _state, _cu_seqlens, _chunk_offsets, _scale, _tune, _schedule
+    ):
         routes.append("ragged")
         factors = q.new_empty((*q.shape[:3], 64))
         return torch.empty_like(v), factors, factors
@@ -890,6 +892,7 @@ def test_chunk_kda_op_registration(dtype):
         initial_state.detach(),
         _DEFAULT_SCALE,
         True,
+        "auto",
     )
     torch.library.opcheck(_chunk_kda_fwd_op, args, rtol=2e-2, atol=2e-3)
     torch.library.opcheck(_chunk_kda_fwd_with_state_op, args, rtol=2e-2, atol=2e-3)
@@ -919,6 +922,7 @@ def test_chunk_kda_paged_op_registration():
             cu_seqlens,
             metadata.chunk_offsets,
             True,
+            "auto",
         ),
         rtol=2e-2,
         atol=2e-3,
@@ -941,6 +945,7 @@ def test_chunk_kda_backward_op_registration(dtype):
             initial_state,
             _DEFAULT_SCALE,
             True,
+            "auto",
         )
     torch.library.opcheck(
         _chunk_kda_bwd_op,
@@ -960,6 +965,7 @@ def test_chunk_kda_backward_op_registration(dtype):
             _DEFAULT_SCALE,
             False,
             True,
+            "auto",
         ),
         test_utils=("test_schema", "test_faketensor", "test_aot_dispatch_dynamic"),
         rtol=2e-2,
@@ -983,6 +989,7 @@ def test_chunk_kda_backward_op_registration(dtype):
             _DEFAULT_SCALE,
             False,
             True,
+            "auto",
         ),
         test_utils=("test_schema", "test_faketensor", "test_aot_dispatch_dynamic"),
         rtol=2e-2,

--- a/test/test_kda_ragged_autograd_ops.py
+++ b/test/test_kda_ragged_autograd_ops.py
@@ -41,6 +41,7 @@ def test_ragged_custom_op_registrations():
         metadata.chunk_offsets,
         _DEFAULT_SCALE,
         True,
+        "auto",
     )
     torch.library.opcheck(
         _chunk_kda_fwd_ragged_with_state_op,
@@ -74,6 +75,7 @@ def test_ragged_custom_op_registrations():
             _DEFAULT_SCALE,
             False,
             True,
+            "auto",
         ),
         test_utils=("test_schema", "test_faketensor", "test_aot_dispatch_dynamic"),
         rtol=2e-2,
@@ -87,6 +89,7 @@ def test_ragged_custom_op_registrations():
         metadata.chunk_offsets,
         _DEFAULT_SCALE,
         True,
+        "auto",
     )
     with torch.no_grad():
         output, Aqk, Akk = _chunk_kda_fwd_ragged_op(*no_state_args)
@@ -104,6 +107,7 @@ def test_ragged_custom_op_registrations():
             _DEFAULT_SCALE,
             False,
             True,
+            "auto",
         ),
         test_utils=("test_schema", "test_faketensor", "test_aot_dispatch_dynamic"),
         rtol=2e-2,

--- a/test/test_kda_ragged_schedule_policy.py
+++ b/test/test_kda_ragged_schedule_policy.py
@@ -1,7 +1,7 @@
-"""Schedule policy for the heavy ragged KDA kernels (output composition, W/U recompute).
+"""Schedule policy and public ``schedule`` option for the heavy ragged KDA kernels.
 
-These tests supply the SM count explicitly so they run without CUDA. Rationale:
-``GridScheduler.resolve_flat``.
+The policy tests supply the SM count explicitly so they run without CUDA; only the
+end-to-end kernel spy needs a GPU. Rationale: ``GridScheduler.resolve_flat``.
 """
 
 from __future__ import annotations
@@ -9,7 +9,11 @@ from __future__ import annotations
 from dataclasses import replace
 
 import pytest
+import torch
 
+import attn_gym.linear.kda.fwd.triton.chunk_gla_fwd_o as output_module
+import attn_gym.linear.kda.fwd.triton.recompute_w_u as recompute_module
+from attn_gym.linear import chunk_kda
 from attn_gym.linear._delta_rule.triton import chunk_scheduler
 from attn_gym.linear._delta_rule.triton.chunk_scheduler import (
     GridScheduler,
@@ -18,6 +22,8 @@ from attn_gym.linear._delta_rule.triton.chunk_scheduler import (
     ScheduleRequest,
     chunk_capacity,
 )
+from attn_gym.linear.kda.validation import resolve_kernel_options
+from attn_gym.testing.kda import cumulative_sequence_offsets, make_kda_test_inputs
 
 SM100_SM_COUNT = 152
 CHUNK_SIZE = 64
@@ -55,3 +61,84 @@ def test_heavy_ragged_kernels_stay_static_under_auto(monkeypatch, shape):
         monkeypatch, subtasks, lengths, ScheduleRequest.PERSISTENT, auto_persistent=False
     )
     assert explicit.kind is ScheduleKind.PERSISTENT
+
+
+@pytest.mark.parametrize(
+    ("kernel_options", "expected_schedule"),
+    [
+        (None, ScheduleRequest.AUTO),
+        ({"schedule": "static"}, ScheduleRequest.STATIC),
+        ({"backend": "fused", "schedule": "persistent"}, ScheduleRequest.PERSISTENT),
+        ({"backend": "mega", "schedule": "auto"}, ScheduleRequest.AUTO),
+    ],
+)
+def test_kernel_options_resolve_schedule(kernel_options, expected_schedule):
+    assert resolve_kernel_options(kernel_options).schedule is expected_schedule
+
+
+@pytest.mark.parametrize(
+    ("kernel_options", "match"),
+    [
+        ({"schedule": "eager"}, "must be 'auto', 'static', or 'persistent'"),
+        (
+            {"backend": "mega", "schedule": "static"},
+            "requires kernel_options\\['backend'\\]='fused'",
+        ),
+    ],
+)
+def test_kernel_options_reject_invalid_schedule(kernel_options, match):
+    with pytest.raises(ValueError, match=match):
+        resolve_kernel_options(kernel_options)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] < 9,
+    reason="the persistent ragged kernels require the TMA path",
+)
+def test_public_chunk_kda_schedule_option_selects_kernels(monkeypatch):
+    """``kernel_options['schedule']`` reaches both heavy kernels in forward and backward."""
+    pytest.importorskip("cutlass", reason="the fused chunk_kda core is CuTeDSL-backed")
+    launches: list[str] = []
+
+    class RecordingKernel:
+        def __init__(self, name, kernel):
+            self.name, self.kernel = name, kernel
+
+        def __getitem__(self, grid):
+            launch = self.kernel[grid]
+
+            def record(*args, **kwargs):
+                launches.append(self.name)
+                return launch(*args, **kwargs)
+
+            return record
+
+    persistent_kernels = {
+        output_module: "chunk_gla_fwd_kernel_o_ragged_tma_persistent",
+        recompute_module: "recompute_w_u_fwd_kernel_persistent",
+    }
+    for module, name in persistent_kernels.items():
+        monkeypatch.setattr(module, name, RecordingKernel(name, getattr(module, name)))
+
+    q, k, v, gate, beta = make_kda_test_inputs(
+        2048, heads=2, normalize_qk=True, requires_grad=True
+    )
+    cu_seqlens = cumulative_sequence_offsets([700, 1348])
+    results = {}
+    for schedule in ("auto", "static", "persistent"):
+        launches.clear()
+        output = chunk_kda(
+            q, k, v, gate, beta, cu_seqlens=cu_seqlens, kernel_options={"schedule": schedule}
+        )[0]
+        forward_launches = list(launches)
+        grads = torch.autograd.grad(output.float().sum(), (q, k, v, gate, beta))
+        backward_launches = launches[len(forward_launches) :]
+        results[schedule] = (output, *grads)
+        if schedule == "persistent":
+            assert set(forward_launches) == set(persistent_kernels.values())
+            assert "recompute_w_u_fwd_kernel_persistent" in backward_launches
+        else:
+            assert not launches
+    for schedule in ("static", "persistent"):
+        for actual, expected in zip(results[schedule], results["auto"], strict=True):
+            assert torch.equal(actual, expected)


### PR DESCRIPTION
Expose the ragged launch schedule through chunk_kda kernel_options

Add kernel_options["schedule"] in {"auto", "static", "persistent"} for the
fused backend so callers can override the automatic geometry of the heavy
ragged output-composition and W/U-recompute stages. The default keeps the
static capacity grid on Hopper and Blackwell; "persistent" is for CUDA graphs
that replay well below their captured token capacity, where the static grid's
padding CTAs dominate (measured crossover around 1/4 of capacity active for
output and 1/8 for recompute on GB200). The three schedules are bitwise
identical.

The request rides alongside autotune as a `str schedule` argument in the nine
registered chunk fwd/bwd op schemas so it survives torch.compile, then reaches
chunk_gla_fwd_o_gk and recompute_w_u_fwd_triton in the forward and in the
backward's factor recompute. chunk_kda_prepare records it on the handle and
chunk_kda_prepare_backward accepts it, and context_parallel_kda binds it into
both stages. Mega always passes "auto" and rejects other values. GDN has its
own op schemas and is unchanged.