### PR TITLE
Dispatch dense kernels for single-subsequence context-parallel spans

### DIFF
--- a/attn_gym/linear/context_parallel.py
+++ b/attn_gym/linear/context_parallel.py
@@ -89,6 +89,8 @@ integers; ``plan.routing(device)`` turns it into the span-local tensors the kern
     # context_parallel_chunk does.
     routing = plan.routing(device)
     prepared = chunk_kda_prepare(q, k, v, gate, beta, cu_seqlens=routing.cu_seqlens)
+    #   a span that is one whole subsequence (cu_seqlens has one segment) passes None instead
+    #   and runs the dense kernels
     slots = summary_slots(prepared, routing)                  # state_summaries(forward_bounds)
     #   one entry per local fragment, in span order; routing.forward_bounds is
     #   slot 0 (frag C): [0, 96)      C∩s1 is C's last subsequence, continued by D∩s1
@@ -125,6 +127,10 @@ What the table does not constrain:
   that start from zero. So a rank computes at most one summary per fragment it owns, the gather
   is one slot per fragment, and no fragment has more predecessors or successors than there are
   other fragments in the table.
+- A span that is one whole subsequence needs no packed schedule. When the routing was built with
+  ``max_subsequences=1``, its ``cu_seqlens`` has one segment and the recipe prepares the span as an
+  unpacked ``chunk_*`` call would, on the dense kernels. That is a shape, not a value, so it is the
+  same for every layout a captured graph replays.
 
 CUDA Graph replay follows from that bound. ``plan.routing(device)`` turns a layout into device
 tensors: the span's ``cu_seqlens``, one ``[start, stop)`` per fragment for the summary launches
@@ -676,6 +682,9 @@ class StagedOp(NamedTuple):
     """A delta-rule variant's staged entry points with the op-specific options already bound.
 
     ``prepare(q, k, v, gate, beta, *, cu_seqlens)`` returns a :class:`PreparedForward`;
+    ``cu_seqlens`` is ``None`` when the routing has a single segment, so the op treats the span
+    exactly as an unpacked ``chunk_*`` call would (dense kernels for chunk-aligned spans) and the
+    backward handle inherits that choice through ``saved``.
     ``prepare_backward(saved, d_output, initial_state, *, scale)`` returns a
     :class:`PreparedBackward`, where ``saved`` is the forward handle's ``saved`` NamedTuple
     rebuilt from ``ctx.saved_tensors`` and ``scale`` is the forward handle's resolved value.
@@ -722,7 +731,10 @@ class _ContextParallelChunk(torch.autograd.Function):
 
     @staticmethod
     def forward(ctx, q, k, v, gate, beta, routing, group, stages):
-        prepared = stages.prepare(q, k, v, gate, beta, cu_seqlens=routing.cu_seqlens)
+        # A one-segment routing (max_subsequences=1) is one whole subsequence: run the dense
+        # kernels. The shape is host metadata of the cap, so a captured graph keeps the choice.
+        cu_seqlens = None if routing.cu_seqlens.shape[0] == 2 else routing.cu_seqlens
+        prepared = stages.prepare(q, k, v, gate, beta, cu_seqlens=cu_seqlens)
         gathered = _all_gather_slots(summary_slots(prepared, routing), group)
         initial_state = compose_entry_states(gathered, routing)
         with profiler_range("cp/run"):

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -558,7 +558,11 @@ point-to-point pipeline, a recursive-doubling scan over `compose_summaries`, DTe
 communication overlap, compose the staged primitives and the routing helpers (`summary_slots`,
 `compose_entry_states`, ...) around your own collective; the primitives and plans are unchanged.
 Sharding does not cost accuracy: against an FP32 reference, sharded gradients match the unsharded
-fused op's error to within noise for both ops.
+fused op's error to within noise for both ops. When a rank's span is one whole subsequence (a
+routing built with `max_subsequences=1`, the usual case for one long document over contiguous
+shards), the recipe passes `cu_seqlens=None` to the stages, so a chunk-aligned span runs the same
+dense kernels as an unpacked `chunk_kda` call; the choice follows the routing's shape, so it is
+fixed per captured graph.
 
 ```python
 from attn_gym.linear.context_parallel import ContextParallelPlan

--- a/test/test_context_parallel_distributed.py
+++ b/test/test_context_parallel_distributed.py
@@ -53,9 +53,11 @@ OPS = {"kda": (chunk_kda, context_parallel_kda), "gdn": (chunk_gdn, context_para
 # Fragment tables over two cp ranks. Zig-zag is the training layout; "uneven" is one 384-token
 # sequence where cp rank 0 owns three fragments and cp rank 1 two, so its chain alternates ranks
 # through all five slots and cp rank 1 gathers a padding slot; "empty-document" adds a
-# zero-length sequence to the stream.
+# zero-length sequence to the stream; "one-document" gives each rank one whole subsequence of
+# complete chunks, the layout that dispatches the dense kernels.
 TABLES = {
     "zigzag": (CU_SEQLENS, [[(0, 96), (288, 384)], [(96, 192), (192, 288)]]),
+    "one-document": ((0, 384), [[(0, 192)], [(192, 384)]]),
     "uneven": ((0, 384), [[(0, 64), (128, 192), (256, 384)], [(64, 128), (192, 256)]]),
     "empty-document": ((0, 40, 40, 100, 384), [[(0, 96), (288, 384)], [(96, 192), (192, 288)]]),
 }

--- a/test/test_delta_rule_stages.py
+++ b/test/test_delta_rule_stages.py
@@ -12,6 +12,7 @@ import torch
 
 pytest.importorskip("cutlass")
 
+from attn_gym.linear._delta_rule.span import CHUNK_SIZE
 from attn_gym.linear.context_parallel import (
     ContextParallelPlan,
     compose_entry_states,
@@ -595,7 +596,11 @@ class RankResult(NamedTuple):
 def simulate_context_parallel(
     op: Op, cu_seqlens_global, fragments, inputs, d_output, d_final_state
 ) -> list[RankResult]:
-    """Run every rank's forward and backward in one process; a stack stands in for all-gather."""
+    """Run every rank's forward and backward in one process; a stack stands in for all-gather.
+
+    Spans that are one whole subsequence take the dense kernels, as ``context_parallel_chunk``
+    does; the handle's ``metadata`` confirms which path ran.
+    """
     device = inputs[0].device
     ranks = range(len(fragments))
     plans = [
@@ -606,10 +611,15 @@ def simulate_context_parallel(
     routings = [plan.routing(device) for plan in plans]
     prepared = [
         op.prepare(
-            *(tensor[:, token_ids[r]] for tensor in inputs), cu_seqlens=routings[r].cu_seqlens
+            *(tensor[:, token_ids[r]] for tensor in inputs),
+            cu_seqlens=None if routings[r].cu_seqlens.shape[0] == 2 else routings[r].cu_seqlens,
         )
         for r in ranks
     ]
+    if op is not KDA_MEGA:  # Mega runs packed-only; the fused stages are dense iff chunk-aligned.
+        for handle, routing in zip(prepared, routings, strict=True):
+            dense = routing.cu_seqlens.shape[0] == 2 and routing.tokens % CHUNK_SIZE == 0
+            assert (handle.metadata is None) is dense
 
     gathered = torch.stack([summary_slots(prepared[r], routings[r]) for r in ranks])
     initial_states = [compose_entry_states(gathered, routings[r]) for r in ranks]
@@ -649,21 +659,28 @@ def simulate_context_parallel(
 # Sequences [0, 40), [40, 232), [232, 384); each entry lists one rank's fragments.
 CU_SEQLENS = (0, 40, 232, 384)
 LAYOUTS = [
-    pytest.param([[(0, 192)], [(192, 384)]], id="contiguous-2"),
-    pytest.param([[(0, 96), (288, 384)], [(96, 192), (192, 288)]], id="zigzag-2"),
+    pytest.param(CU_SEQLENS, [[(0, 192)], [(192, 384)]], id="contiguous-2"),
+    pytest.param(CU_SEQLENS, [[(0, 96), (288, 384)], [(96, 192), (192, 288)]], id="zigzag-2"),
     pytest.param(
-        [[(0, 64), (320, 384)], [(64, 128), (256, 320)], [(128, 192), (192, 256)]], id="zigzag-3"
+        CU_SEQLENS,
+        [[(0, 64), (320, 384)], [(64, 128), (256, 320)], [(128, 192), (192, 256)]],
+        id="zigzag-3",
     ),
     # Uneven ownership: rank 0 holds one short piece, rank 1 the rest in reversed order.
-    pytest.param([[(96, 160)], [(160, 384), (0, 96)]], id="uneven-reordered"),
+    pytest.param(CU_SEQLENS, [[(96, 160)], [(160, 384), (0, 96)]], id="uneven-reordered"),
+    # One document over two ranks: each span is one whole subsequence of complete chunks, so
+    # both ranks run the dense kernels and exchange summaries over the dense factor layout.
+    pytest.param((0, 384), [[(0, 192)], [(192, 384)]], id="one-document-dense"),
+    # Same, cut mid-chunk: whole subsequences that fall back to a packed schedule.
+    pytest.param((0, 384), [[(0, 200)], [(200, 384)]], id="one-document-partial-chunk"),
 ]
 
 
 @requires_kda_target
 @op_param
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "fp16"])
-@pytest.mark.parametrize("layout", LAYOUTS)
-def test_simulated_context_parallel_matches_unsharded_op(op, layout, dtype, request):
+@pytest.mark.parametrize(("cu_seqlens", "layout"), LAYOUTS)
+def test_simulated_context_parallel_matches_unsharded_op(op, cu_seqlens, layout, dtype, request):
     if op is KDA_MEGA and dtype is torch.float16:
         # The unsharded Mega op itself returns non-finite FP16 outputs for model-range gates:
         # exp(-cumulative gate) over a 16-token chunk exceeds the FP16 range once gates fall below
@@ -671,9 +688,9 @@ def test_simulated_context_parallel_matches_unsharded_op(op, layout, dtype, requ
         request.applymarker(
             pytest.mark.xfail(strict=True, raises=AssertionError, reason="Mega FP16 gate overflow")
         )
-    q, k, v, gate, beta = op.make_inputs(CU_SEQLENS[-1], seed=4, dtype=dtype)
+    q, k, v, gate, beta = op.make_inputs(cu_seqlens[-1], seed=4, dtype=dtype)
     inputs = tuple(tensor.detach().clone().requires_grad_() for tensor in (q, k, v, gate, beta))
-    offsets = torch.tensor(CU_SEQLENS, dtype=torch.int32, device="cuda")
+    offsets = torch.tensor(cu_seqlens, dtype=torch.int32, device="cuda")
 
     output, final_state = op.chunk(*inputs, cu_seqlens=offsets, output_final_state=True)
     generator = torch.Generator(device="cuda").manual_seed(5)
@@ -691,7 +708,7 @@ def test_simulated_context_parallel_matches_unsharded_op(op, layout, dtype, requ
     )
 
     results = simulate_context_parallel(
-        op, CU_SEQLENS, layout, (q, k, v, gate, beta), d_output, d_final_state
+        op, cu_seqlens, layout, (q, k, v, gate, beta), d_output, d_final_state
     )
     for result in results:
         ids = result.token_ids


### PR DESCRIPTION
Context-parallel spans always ran the packed kernel variants, even when a rank owns exactly
one whole subsequence: the common case of one long document over contiguous shards. With
#507 keeping the heavy ragged kernels on the static grid, the remaining packed-vs-dense gap
sits in the intra kernels, the backward W/U recompute, and the ragged backward's two 2 GiB
zero-fills, none of which a dense span needs.

A routing built with `max_subsequences=1` has a one-segment `cu_seqlens`, and every layout
within that cap is one whole subsequence. `context_parallel_chunk` reads that shape (host
metadata, so a captured graph keeps the choice; nothing is read from the device offsets) and
passes `cu_seqlens=None` to `StagedOp.prepare`; the KDA and GDN stages then build dense
handles (metadata=None) for the forward, the summaries and, through `saved`, the backward,
exactly as an unpacked `chunk_*` call would (spans that are not chunk-aligned and Mega fall
back to a packed schedule as they do there). Multi-subsequence spans are unchanged.

GPU kernel time per step on rank 0 vs main @ 17d15ec (us, GB200, KDA h32, 262k global tokens,
W=2 contiguous): 43,854 -> 41,317 (-2,537: chunk_kda_fwd_intra -430, chunk_kda_bwd_intra
-539, backward recompute_w_u -422, the ragged path's two 2 GiB memsets -638, output
composition and forward recompute near parity). CUDA-event step time 44.2 -> 41.7 ms.

Tests: the simulated (test_delta_rule_stages) and two-GPU (test_context_parallel_distributed)
CP tests gain one-document layouts, dense and partial-chunk, and the simulated one asserts
`handle.metadata is None` exactly on the dense path.


The ragged path's zero-fill removal is split out to #510 since it only affects spans that stay packed.

Proposed (not implemented) public opt-in for single-GPU packed callers: `chunk_kda(..., cu_seqlens=offsets, kernel_options={"dense_if_single_sequence": True})` (GDN twin), where the caller asserts `offsets == [0, T]` with `T % 64 == 0`. It has to be opt-in because the value cannot be checked without a host sync.
