### PR TITLE
Zero the packed reverse gate scan's inactive tail in-kernel and drop the dg zero-fill

### DIFF
--- a/attn_gym/linear/_delta_rule/triton/plain_gate.py
+++ b/attn_gym/linear/_delta_rule/triton/plain_gate.py
@@ -53,13 +53,43 @@ def _plain_gate_scan_dense_kernel(
     tl.store(output + output_offsets, cumulative, mask=mask)
 
 
-@triton.jit(do_not_specialize=["num_sequences"])
+@triton.jit
+def _zero_inactive_token_tail(
+    output,
+    cu_seqlens,
+    num_sequences,
+    T,
+    worker,
+    workers,
+    head,
+    channel,
+    Y_STRIDES: tl.constexpr,
+    BT: tl.constexpr,
+    BD: tl.constexpr,
+    D: tl.constexpr,
+):
+    """Zero this head/channel block of the inactive capacity ``[cu_seqlens[-1], T)``.
+
+    ``worker`` of ``workers`` programs takes every ``workers``-th ``BT`` token block of the tail,
+    so any positive number of programs covers it.
+    """
+    tail_begin = tl.load(cu_seqlens + num_sequences).to(tl.int64)
+    tail_blocks = tl.cdiv(T - tail_begin, BT)
+    zeros = tl.zeros((BT, BD), dtype=tl.float32)
+    for block in tl.range(worker, tail_blocks, workers):
+        token = tail_begin + block * BT + tl.arange(0, BT)[:, None]
+        mask = (token < T) & (channel < D)
+        tl.store(output + ptr_offset((0, token, head, channel), Y_STRIDES), zeros, mask=mask)
+
+
+@triton.jit(do_not_specialize=["num_sequences", "T"])
 def _plain_gate_scan_ragged_kernel(
     values,
     output,
     cu_seqlens,
     chunk_offsets,
     num_sequences,
+    T,
     scale,
     X_STRIDES: tl.constexpr,
     Y_STRIDES: tl.constexpr,
@@ -68,12 +98,33 @@ def _plain_gate_scan_ragged_kernel(
     BD: tl.constexpr,
     REVERSE: tl.constexpr,
 ):
-    """Scan one sequence-local packed chunk."""
+    """Scan one sequence-local packed chunk.
+
+    Programs past the active chunk count exit, except in a reverse scan, where they zero the
+    inactive capacity ``[cu_seqlens[-1], T)``: that gradient feeds parameter reductions and must
+    be defined. The launcher guarantees at least one such program.
+    """
     chunk = tl.program_id(0)
     head = tl.program_id(1).to(tl.int64)
     dim_block = tl.program_id(2).to(tl.int64)
+    channel = dim_block * BD + tl.arange(0, BD)[None, :]
     active_chunks = load_ragged_chunk_count(chunk_offsets, num_sequences)
     if chunk >= active_chunks:
+        if REVERSE:
+            _zero_inactive_token_tail(
+                output,
+                cu_seqlens,
+                num_sequences,
+                T,
+                chunk - active_chunks,
+                tl.num_programs(0) - active_chunks,
+                head,
+                channel,
+                Y_STRIDES,
+                BT,
+                BD,
+                D,
+            )
         return
 
     _, _, token_begin, valid_tokens = load_ragged_chunk_work(
@@ -85,7 +136,6 @@ def _plain_gate_scan_ragged_kernel(
     )
     token_offset = tl.arange(0, BT)[:, None]
     token = token_begin.to(tl.int64) + token_offset
-    channel = dim_block * BD + tl.arange(0, BD)[None, :]
     mask = (token_offset < valid_tokens) & (channel < D)
     input_offsets = ptr_offset((0, token, head, channel), X_STRIDES)
     output_offsets = ptr_offset((0, token, head, channel), Y_STRIDES)
@@ -104,21 +154,24 @@ def _plain_gate_scan_cuda(
     with torch.cuda.device(values.device):
         _, tokens, heads, head_dim = values.shape
         is_ragged = cu_seqlens is not None
-        # Packed reverse scans do not visit inactive capacity; its gradient must be zero
-        # before upstream parameter reductions consume it.
-        factory = torch.zeros_like if is_ragged and reverse else torch.empty_like
-        output = factory(values, memory_format=torch.contiguous_format)
+        output = torch.empty_like(values, memory_format=torch.contiguous_format)
         block_dim = 32
         if is_ragged:
             assert chunk_offsets is not None
             num_sequences = cu_seqlens.shape[0] - 1
             chunks = chunk_capacity(tokens, num_sequences, DEFAULT_CHUNK_SIZE)
+            # The reverse scan zeroes the inactive capacity from the programs past the active
+            # chunk count instead of a whole-output memset; one extra program guarantees such a
+            # program exists even when the active chunks fill the capacity.
+            if reverse:
+                chunks += 1
             _plain_gate_scan_ragged_kernel[(chunks, heads, triton.cdiv(head_dim, block_dim))](
                 values,
                 output,
                 cu_seqlens,
                 chunk_offsets,
                 num_sequences,
+                tokens,
                 LOG2_E,
                 X_STRIDES=(0, *values.stride()[1:]),
                 Y_STRIDES=(0, *output.stride()[1:]),

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_wy_dqkg_fused.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_wy_dqkg_fused.py
@@ -3664,13 +3664,9 @@ def chunk_kda_bwd_wy_dqkg(
         dq=torch.empty_like(g, memory_format=torch.contiguous_format),
         dk=torch.empty_like(g, memory_format=torch.contiguous_format),
         dv2=torch.empty_like(v, memory_format=torch.contiguous_format),
-        # Dense BT64 writes every dg element. Ragged execution preserves the
-        # zero initialization required by predicated tails and sanitizer runs.
-        dg=(
-            torch.empty_like(g, memory_format=torch.contiguous_format)
-            if metadata is None
-            else torch.zeros_like(g, memory_format=torch.contiguous_format)
-        ),
+        # Every active dg row is written (tail chunks store row-predicated); the inactive capacity
+        # is never loaded (intra stages predicate rows) and the reverse gate scan zeroes it.
+        dg=torch.empty_like(g, memory_format=torch.contiguous_format),
         db=torch.empty_like(beta, memory_format=torch.contiguous_format),
         dA=torch.empty_like(A, dtype=torch.float32, memory_format=torch.contiguous_format),
         cu_seqlens=cu_seqlens,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -88,3 +88,22 @@ def selected_attention_single_config(
         for tuner in tuners:
             tuner.cache.clear()
             tuner.cache.update(original_caches[id(tuner)])
+
+
+@pytest.fixture
+def nan_filled_empty(monkeypatch):
+    """Fill every fresh floating-point tensor with NaN, the worst case ``torch.empty`` allows.
+
+    The caching allocator mostly recycles blocks, so a test cannot rely on real garbage: filling
+    at the allocation entry points the kernels use makes every unwritten element a NaN.
+    """
+
+    def nan_filled(allocate):
+        def allocate_nan_filled(*args, **kwargs):
+            tensor = allocate(*args, **kwargs)
+            return tensor.fill_(torch.nan) if tensor.is_floating_point() else tensor
+
+        return allocate_nan_filled
+
+    for owner, name in ((torch, "empty"), (torch, "empty_like"), (torch.Tensor, "new_empty")):
+        monkeypatch.setattr(owner, name, nan_filled(getattr(owner, name)))

--- a/test/test_delta_rule_stages.py
+++ b/test/test_delta_rule_stages.py
@@ -243,25 +243,6 @@ def test_state_summary_matches_zero_and_identity_probes(op):
         assert_summary_parts_match(summaries[index], fused, oracle, index)
 
 
-@pytest.fixture
-def nan_filled_empty(monkeypatch):
-    """Fill every fresh floating-point tensor with NaN, the worst case ``torch.empty`` allows.
-
-    The caching allocator mostly recycles blocks, so a test cannot rely on real garbage: filling
-    at the allocation entry points the kernels use makes every unwritten element a NaN.
-    """
-
-    def nan_filled(allocate):
-        def allocate_nan_filled(*args, **kwargs):
-            tensor = allocate(*args, **kwargs)
-            return tensor.fill_(torch.nan) if tensor.is_floating_point() else tensor
-
-        return allocate_nan_filled
-
-    for owner, name in ((torch, "empty"), (torch, "empty_like"), (torch.Tensor, "new_empty")):
-        monkeypatch.setattr(owner, name, nan_filled(getattr(owner, name)))
-
-
 @requires_kda_target
 @pytest.mark.usefixtures("nan_filled_empty")
 @pytest.mark.parametrize(

--- a/test/test_kda_gate_semantics.py
+++ b/test/test_kda_gate_semantics.py
@@ -303,11 +303,25 @@ def test_plain_gate_scan_accepts_strided_dense_input():
     torch.testing.assert_close(actual_gradient, expected_gradient, rtol=2e-5, atol=2e-5)
 
 
-def test_plain_gate_scan_resets_packed_boundaries_and_zeros_inactive_gradient():
-    """Reset packed scans and keep inactive-capacity gradients out of reductions."""
-    lengths = [65, 0, 63]
+@pytest.mark.parametrize(
+    ("lengths", "capacity"),
+    [
+        pytest.param([65, 0, 63], 145, id="empty-sequence-and-slack"),
+        # Two active chunks fill the whole chunk capacity of 128 tokens, so only the launcher's
+        # one extra program is left to zero the 63-token inactive tail.
+        pytest.param([65], 128, id="full-capacity"),
+        # Every token is inactive: the tail spans the whole buffer.
+        pytest.param([0, 0], 200, id="all-inactive"),
+    ],
+)
+@pytest.mark.usefixtures("nan_filled_empty")
+def test_plain_gate_scan_resets_packed_boundaries_and_zeros_inactive_gradient(lengths, capacity):
+    """Reset packed scans and keep inactive-capacity gradients out of reductions.
+
+    The scan output is ``torch.empty``; with NaN-filled allocations the inactive tail is zero
+    only if the reverse kernel wrote it.
+    """
     active_tokens = sum(lengths)
-    capacity = active_tokens + 17
     offsets = cumulative_sequence_offsets(lengths)
     metadata = prepare_ragged_chunk_metadata(offsets, capacity, 64)
     torch.manual_seed(7)


### PR DESCRIPTION
The packed KDA/GDN backward paid two whole-output zero-fills (2 GiB each at 131k tokens x
32 heads) whose only purpose was the inactive capacity past cu_seqlens[-1]: the reverse gate
scan's output and the fused WY backward's dg.

- The reverse ragged gate scan launches capacity + 1 programs; those past the active chunk
  count (a device value) stride over the tail's 64-token blocks and zero them
  (`_zero_inactive_token_tail`), so the output is `torch.empty` like the forward scan's.
- dg is `torch.empty` on the ragged path too: the fused WY kernel writes every active row
  (tail chunks store row-predicated) and its consumers (`chunk_kda_bwd_intra`,
  `chunk_gdn_bwd_intra_packed`) load it row-predicated, so the inactive rows are never read.

W=1 131k packed op vs main @ 17d15ec, GPU kernel time per step (us, GB200, h32): KDA
35,010 -> 34,369 (memsets 320 + 318 gone, reverse scan 970 -> 970), GDN 31,485 -> 31,178.
Dense spans are unaffected.

Tests: the inactive-capacity gate-scan test is parameterized over slack, full-capacity
(active chunks fill the capacity, so only the extra program zeroes the tail) and all-inactive
layouts under NaN-filled allocations (`nan_filled_empty` moves to conftest); it and the
existing NaN-fill CP/public-backward tests fail if the in-kernel zeroing is removed.

