### PR TITLE
Support both CUTLASS NVVM weight-stationary MMA bindings

### DIFF
--- a/.agents/skills/worktree-env-setup/SKILL.md
+++ b/.agents/skills/worktree-env-setup/SKILL.md
@@ -29,17 +29,18 @@ Notes:
 - uv hard-links wheels from its cache, so after the first nightly download this
   takes seconds and costs almost no extra disk per worktree.
 - Activate `.venv` before installing so an already-active foreign environment is not modified.
-- `--prerelease allow` is required for the `flash-attn-4` beta in `[tests]`, but it also lets
-  the open `[linear]` bound resolve to `nvidia-cutlass-dsl` dev releases (4.8.0.dev0 breaks
-  `tcgen05_mma_ws(..., mma_kind=)` in the fused CuTeDSL backward). Pin it afterwards:
-  `uv pip install "nvidia-cutlass-dsl[cu13]==4.7.1"`.
+- `--prerelease allow` is required for the `flash-attn-4` beta in `[tests]`.
+  `[tests]` omits FlashAttention on aarch64, so its transitive CuTeDSL pin does not apply
+  there or to linear-only installs. When updating CuTeDSL, run
+  `pytest -n 6 test/test_kda_bwd_wy_compile.py` to catch NVVM binding changes without a
+  Blackwell GPU, then validate forward/backward numerics on supported hardware.
 - A `.venv` symlink into another worktree is not isolation: its editable `.pth` still
   points at that worktree, so pytest imports the other checkout's `attn_gym`. Replace it
   with a real per-worktree env.
 - Do not use `uv sync`/`uv.lock`: nightly torch churns daily and CI uses the
   imperative `uv pip` flow above, not a lockfile.
 - Drop `[linear]` if CuTeDSL/TVM-FFI kernels are not needed (CPU-only work).
-- `[tests]` currently brings FlashAttention's CuTeDSL 4.6 pin and cannot be combined with the
+- On x86_64 Linux, `[tests]` brings FlashAttention's CuTeDSL 4.6 pin and conflicts with the
   CuTeDSL 4.7+ `[mega]` extra. For Mega worktrees, install `-e '.[mega,dev]' pytest pytest-xdist`
   instead; Mega tests import-skip optional FlashAttention coverage.
 

--- a/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_wy_dqkg_fused.py
+++ b/attn_gym/linear/kda/bwd/cute/chunk_kda_bwd_wy_dqkg_fused.py
@@ -104,11 +104,12 @@ def tcgen05mma_ws_ss_f16(
             loc=loc,
             ip=ip,
         )
+        # CUTLASS 4.8 renamed these four parameters but preserved their positional order.
         _nvvm.tcgen05_mma_ws(
-            mma_kind=_nvvm.Tcgen05MMAKind.F16,
-            d=destination,
-            a=_ir(a_value, loc, ip),
-            b=_ir(b_value, loc, ip),
+            _nvvm.Tcgen05MMAKind.F16,
+            destination,
+            _ir(a_value, loc, ip),
+            _ir(b_value, loc, ip),
             idesc=_ir(idesc_value, loc, ip),
             enable_input_d=enable_d,
             collector_b_buffer=None,

--- a/test/test_kda_bwd_wy_compile.py
+++ b/test/test_kda_bwd_wy_compile.py
@@ -1,0 +1,37 @@
+"""Compile the Blackwell WY backward on any host with CuTeDSL installed."""
+
+from pathlib import Path
+
+import pytest
+import torch
+
+from attn_gym._backends.cute import target as cute_target
+from attn_gym._backends.cute.compile import precompile_many
+from attn_gym._backends.cute.target import CompileTarget
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("ragged", [False, True])
+def test_wy_backward_nvvm_compatibility(
+    dtype: torch.dtype, ragged: bool, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Catch NVVM binding changes without requiring a Blackwell GPU or a kernel launch."""
+    pytest.importorskip("cutlass")
+    from attn_gym.linear.kda.bwd.cute.chunk_kda_bwd_wy_dqkg_fused import (
+        _compile_chunk_kda_bwd_wy_dqkg,
+    )
+
+    target = CompileTarget("cuda", configured_arch="sm_100a", sm_count=132)
+    monkeypatch.setattr(cute_target, "_target", target)
+    monkeypatch.setenv("ATTN_GYM_CUTE_CACHE_DIR", str(tmp_path))
+    monkeypatch.delenv("CUTE_DSL_NO_CACHE", raising=False)
+    args = (2, 128, 64, dtype, 128**-0.5, True, 1, ragged)
+    assert not _compile_chunk_kda_bwd_wy_dqkg.is_cached(*args)
+    precompile_many(
+        _compile_chunk_kda_bwd_wy_dqkg,
+        [args],
+        workers=1,
+        target=target,
+        timeout=45,
+    )
+    assert _compile_chunk_kda_bwd_wy_dqkg.is_cached(*args)


### PR DESCRIPTION
## Summary

CUTLASS DSL 4.8 renamed the first four `tcgen05_mma_ws` parameters without changing their order or meaning. Pass those arguments positionally so fused WY backward supports the old and new bindings without a version guard or dependency cap.

- Add GPU-independent compilation regressions for dense/ragged BF16/FP16 specializations using the production compiler.
- Replace the manual environment-pin workaround with the compilation validation procedure.
- Leave dependency metadata, including Mega's existing version bound, unchanged.

Fixes #430.

## Validation

On aarch64/GB200 with PyTorch `2.15.0.dev20260908+cu132`:

| CUTLASS DSL | Compile regression | Numerical, fullgraph, CUDA Graph tests |
| --- | --- | --- |
| 4.6.3 | 4 passed | 18 passed |
| 4.7.1 | 4 passed | 18 passed |
| 4.8.0.dev0 | 4 passed | 18 passed |

Confirmed the new compilation regression fails against the original keyword call with the reported `mma_kind` TypeError. After rebasing onto current main, reran all 22 focused cases with 4.8.0.dev0; all passed. Applicable pre-commit hooks, including Ruff, passed.

The runtime checks cover output/state and input gradients against the reference/FP64 error budget, BF16/FP16, dense/packed fullgraph forward/backward, and backward CUDA Graph replay. No x86_64 hardware run or full repository test suite was performed locally.
