### PR TITLE
Pin the summary work partition and give the staged Mega handles a native stateful backward

### DIFF
--- a/attn_gym/linear/_delta_rule/cute/affine_summary_fwd.py
+++ b/attn_gym/linear/_delta_rule/cute/affine_summary_fwd.py
@@ -1195,6 +1195,8 @@ def build_state_summaries(
     u: torch.Tensor,
     cumulative_gate: torch.Tensor,
     bounds: torch.Tensor,
+    *,
+    deterministic_work: bool = False,
 ) -> torch.Tensor:
     """Compute one packed affine state summary per token range of a stream's WY chunk factors.
 
@@ -1209,6 +1211,10 @@ def build_state_summaries(
             64-token chunk grid, ``stop`` on the grid or at the sequence's end (a partial last
             chunk is neutralized in-kernel). The values are not checked (that would sync);
             other ranges return a plausible but wrong map.
+        deterministic_work: Scan each range in one work item with a fixed SM100 column tile,
+            so the recurrence partition does not depend on span length, range count, or SM
+            count. The upstream factor kernels are not pinned; disable their autotuning
+            separately.
 
     Returns:
         FP32 tensor of shape ``[R, H, 256, 128]``, V-first packed as state bias then state
@@ -1283,11 +1289,15 @@ def build_state_summaries(
         kg, w, u, cumulative_gate = (_aligned(tensor) for tensor in (kg, w, u, cumulative_gate))
         # BN=32 is faster per CTA (measured ~1.5x vs BN=64 on GB200); fall back to
         # BN=64 only when the extra column tiles would spill past one CTA wave and
-        # serialize whole recurrence chains.
-        state_bn = 32 if ranges * heads * (SUMMARY_DIM // 32) <= sm_count else 64
+        # serialize whole recurrence chains. Deterministic work pins BN=32.
+        one_wave = ranges * heads * (SUMMARY_DIM // 32) <= sm_count
+        state_bn = 32 if deterministic_work or one_wave else 64
     # The bounds live on the device, so the budget comes from the span's chunk count (a static
     # upper bound) and the device cuts the ranges' actual chunks into that many items.
-    budget = plan_work_budget(cdiv(tokens, BT), heads * (SUMMARY_DIM // state_bn), sm_count)
+    if deterministic_work:
+        budget = 1
+    else:
+        budget = plan_work_budget(cdiv(tokens, BT), heads * (SUMMARY_DIM // state_bn), sm_count)
     work, range_ids = work_table(bounds, budget)
     partials = torch.empty(
         (work.shape[0], heads, SUMMARY_DIM, KEY_DIM), dtype=torch.float32, device=kg.device

--- a/attn_gym/linear/_delta_rule/cute/affine_summary_rev.py
+++ b/attn_gym/linear/_delta_rule/cute/affine_summary_rev.py
@@ -1466,6 +1466,8 @@ def build_state_grad_summaries(
     cumulative_gate: torch.Tensor,
     scale: float,
     bounds: torch.Tensor,
+    *,
+    deterministic_work: bool = False,
 ) -> torch.Tensor:
     """Compute one packed reverse affine summary per token range of a stream.
 
@@ -1479,6 +1481,10 @@ def build_state_grad_summaries(
         scale: Query scaling factor used by the local backward recurrence.
         bounds: ``int32 [R, 2]`` device tensor of half-open token ranges ``[start, stop)``; the
             same contract as ``build_state_summaries``.
+        deterministic_work: Scan each range in one work item, so the recurrence partition does
+            not depend on span length, range count, or SM count (the SM100 column tile is
+            already fixed). The upstream factor kernels are not pinned; disable their autotuning
+            separately.
 
     Returns:
         FP32 tensor of shape ``[R, H, 256, 128]``, V-first packed as local bias then reverse
@@ -1566,9 +1572,12 @@ def build_state_grad_summaries(
         )
         state_bn = BlackwellDeltaAffineSummaryRev.BN
     # As in the forward: a static budget from the span's chunk count, ranges cut on the device.
-    budget = plan_work_budget(
-        cdiv(tokens, BT), heads * (SUMMARY_DIM // state_bn), properties.multi_processor_count
-    )
+    if deterministic_work:
+        budget = 1
+    else:
+        budget = plan_work_budget(
+            cdiv(tokens, BT), heads * (SUMMARY_DIM // state_bn), properties.multi_processor_count
+        )
     work, range_ids = work_table(bounds, budget)
     partials = torch.empty(
         (work.shape[0], heads, SUMMARY_DIM, KEY_DIM), dtype=torch.float32, device=qg.device

--- a/attn_gym/linear/_delta_rule/mega/backward.py
+++ b/attn_gym/linear/_delta_rule/mega/backward.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Torch launcher for the CuTeDSL 4.7 Mega no-state long-context backward."""
+"""Torch launcher for the CuTeDSL 4.7 Mega long-context backward, with or without state."""
 
 from __future__ import annotations
 
@@ -32,11 +32,29 @@ def chunk_delta_rule_bwd_mega_packed(
     *,
     scale: float | None = None,
     split: bool = False,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Run checkpoint recompute followed by exact or forgetting-horizon backward."""
+    initial_state: torch.Tensor | None = None,
+    d_final_state: torch.Tensor | None = None,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor | None,
+]:
+    """Run checkpoint recompute followed by exact or forgetting-horizon backward.
+
+    ``initial_state`` and ``d_final_state`` are optional FP32 ``[N, H, V, K]`` entry states
+    and exit cotangents per packed sequence. ``None`` skips state loads, with token gradients
+    bitwise equal to an explicit zero tensor. Returns ``(dq, dk, dv, dgate, dbeta,
+    d_initial_state)``; the last is ``None`` unless ``initial_state`` was given.
+    The approximate forgetting-horizon ``split`` schedule requires a no-state call.
+    """
     scale = resolve_scale(scale, q.shape[-1])
     if not q.is_cuda:
         raise ValueError("q must be a CUDA tensor")
+    if split and (initial_state is not None or d_final_state is not None):
+        raise ValueError("the split backward schedule requires a no-state call")
     with initialized_cuda_device(q):
         if q.ndim != 4 or q.shape[0] != 1 or q.shape[-1] != 128:
             raise ValueError("q must have shape [1, T, H, 128]")
@@ -69,6 +87,16 @@ def chunk_delta_rule_bwd_mega_packed(
         ):
             raise TypeError("cu_seqlens must be aligned contiguous int32 on q.device")
         num_sequences = cu_seqlens.shape[0] - 1
+        state_shape = (num_sequences, heads, value.shape[-1], dim)
+        for name, state in (("initial_state", initial_state), ("d_final_state", d_final_state)):
+            if state is None:
+                continue
+            if state.shape != state_shape or state.dtype != torch.float32:
+                raise TypeError(f"{name} must be float32 with shape {state_shape}")
+            if state.device != q.device:
+                raise ValueError(f"{name} must be on q.device")
+            if not tensor_supports_tma(state):
+                raise TypeError(f"{name} requires a TMA-compatible inner mode")
         stream = torch.cuda.current_stream(q.device).cuda_stream
         schedule = prepare_mega_schedule(
             gate,
@@ -102,11 +130,12 @@ def chunk_delta_rule_bwd_mega_packed(
             dtype=torch.int64,
             device=q.device,
         )
-        dq = torch.empty_like(q[0])
-        dk = torch.empty_like(k[0])
-        dv = torch.empty_like(value[0])
-        dgate = torch.empty_like(gate[0])
-        dbeta = torch.empty_like(beta[0])
+        gradients = tuple(torch.empty_like(t[0]) for t in (q, k, value, gate, beta))
+        d_initial_state = (
+            None
+            if initial_state is None
+            else torch.empty(state_shape, dtype=torch.float32, device=q.device)
+        )
 
         kda_recompute_f16.chunk_kda_recompute_sm100(
             k[0],
@@ -114,7 +143,7 @@ def chunk_delta_rule_bwd_mega_packed(
             gate[0],
             beta[0],
             cu_seqlens,
-            None,
+            initial_state,
             None,
             checkpoint_every_n_tokens=16,
             output_state_checkpoints=checkpoints,
@@ -137,29 +166,19 @@ def chunk_delta_rule_bwd_mega_packed(
             beta[0],
             d_output[0],
             checkpoints,
-            dq,
-            dk,
-            dv,
-            dgate,
-            dbeta,
+            *gradients,
             cu_seqlens,
             scale,
-            use_initial_state=False,
-            d_initial_state=None,
-            d_final_state=None,
+            use_initial_state=initial_state is not None,
+            d_initial_state=d_initial_state,
+            d_final_state=d_final_state,
             work_items=schedule.work_items,
             work_count=schedule.work_count,
             sched_ctr=bwd_scheduler,
             order_in_prologue=False,
             tensormap_workspace=backward_workspace,
         )
-        return (
-            dq.unsqueeze(0),
-            dk.unsqueeze(0),
-            dv.unsqueeze(0),
-            dgate.unsqueeze(0),
-            dbeta.unsqueeze(0),
-        )
+        return (*(grad.unsqueeze(0) for grad in gradients), d_initial_state)
 
 
 __all__ = ["chunk_delta_rule_bwd_mega_packed"]

--- a/attn_gym/linear/context_parallel.py
+++ b/attn_gym/linear/context_parallel.py
@@ -652,8 +652,15 @@ class PreparedForward(Protocol):
         """The resolved query scale; the backward must reuse it."""
         ...
 
-    def state_summaries(self, bounds: torch.Tensor) -> torch.Tensor:
-        """One ``[HV, V + K, K]`` affine summary per ``[start, stop)`` row of ``bounds``."""
+    def state_summaries(
+        self, bounds: torch.Tensor, *, deterministic_work: bool = False
+    ) -> torch.Tensor:
+        """One ``[HV, V + K, K]`` affine summary per ``[start, stop)`` row of ``bounds``.
+
+        ``deterministic_work=True`` pins the summary kernels' work partition so the result does
+        not depend on the span length, the range count, or the device (the deterministic CP
+        recipe requires it); the default keeps the throughput-oriented planner.
+        """
         ...
 
     def run(
@@ -666,8 +673,13 @@ class PreparedForward(Protocol):
 class PreparedBackward(Protocol):
     """Backward handle of a staged delta-rule op (``chunk_*_prepare_backward``)."""
 
-    def state_grad_summaries(self, bounds: torch.Tensor) -> torch.Tensor:
-        """One ``[C; R]`` reverse map per row of ``bounds``: ``d_entry = d_exit @ R + C``."""
+    def state_grad_summaries(
+        self, bounds: torch.Tensor, *, deterministic_work: bool = False
+    ) -> torch.Tensor:
+        """One ``[C; R]`` reverse map per row of ``bounds``: ``d_entry = d_exit @ R + C``.
+
+        ``deterministic_work`` as in :meth:`PreparedForward.state_summaries`.
+        """
         ...
 
     def run(self, d_final_state: torch.Tensor | None) -> tuple[torch.Tensor, ...]:

--- a/attn_gym/linear/gdn/stages.py
+++ b/attn_gym/linear/gdn/stages.py
@@ -75,7 +75,9 @@ class ChunkGDNPrepared:
     metadata: RaggedChunkMetadata | None
     scale: float
 
-    def state_summaries(self, bounds: torch.Tensor) -> torch.Tensor:
+    def state_summaries(
+        self, bounds: torch.Tensor, *, deterministic_work: bool = False
+    ) -> torch.Tensor:
         """Return one FP32 ``[HV, V + K, K]`` map per row of ``bounds`` in a single launch.
 
         See ``attn_gym.linear.kda.stages.ChunkKDAPrepared.state_summaries`` for the contract.
@@ -87,6 +89,7 @@ class ChunkGDNPrepared:
             self.factors.u,
             _vector_gate(saved.cumulative_gate, saved.q.shape[-1]),
             bounds,
+            deterministic_work=deterministic_work,
         )
 
     def run(
@@ -174,7 +177,9 @@ class ChunkGDNBackward:
             q, k, saved.cumulative_gate, self.scale, self.metadata
         )
 
-    def state_grad_summaries(self, bounds: torch.Tensor) -> torch.Tensor:
+    def state_grad_summaries(
+        self, bounds: torch.Tensor, *, deterministic_work: bool = False
+    ) -> torch.Tensor:
         """Return one FP32 ``[HV, V + K, K]`` reverse map per row of ``bounds`` in one launch.
 
         See ``attn_gym.linear.kda.stages.ChunkKDABackward.state_grad_summaries``.
@@ -189,6 +194,7 @@ class ChunkGDNBackward:
             _vector_gate(saved.cumulative_gate, saved.q.shape[-1]),
             self.scale,
             bounds,
+            deterministic_work=deterministic_work,
         )
 
     def run(

--- a/attn_gym/linear/kda/__init__.py
+++ b/attn_gym/linear/kda/__init__.py
@@ -34,6 +34,7 @@ _BACKEND_EXPORTS = {
     # Staged primitives around the affine state boundary (stages.py) and the all-gather recipe
     # over them. Ownership plans live in attn_gym.linear.context_parallel.
     "ChunkKDASaved": "attn_gym.linear.kda.stages",
+    "ChunkKDAMegaSaved": "attn_gym.linear.kda.stages",
     "chunk_kda_prepare": "attn_gym.linear.kda.stages",
     "chunk_kda_prepare_backward": "attn_gym.linear.kda.stages",
     "context_parallel_kda": "attn_gym.linear.kda.context_parallel",

--- a/attn_gym/linear/kda/impl/mega_ops.py
+++ b/attn_gym/linear/kda/impl/mega_ops.py
@@ -48,6 +48,12 @@ torch.library.define(
     "-> (Tensor, Tensor, Tensor, Tensor, Tensor)",
 )
 torch.library.define(
+    "attn_gym::kda_chunk_mega_packed_bwd_with_state",
+    "(Tensor q, Tensor k, Tensor v, Tensor gate, Tensor beta, Tensor d_output, "
+    "Tensor cu_seqlens, Tensor? initial_state, Tensor? d_final_state, float scale) "
+    "-> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor?)",
+)
+torch.library.define(
     "attn_gym::kda_plain_gate_bwd_dense_cute",
     "(Tensor d_cumulative) -> Tensor",
 )
@@ -220,6 +226,25 @@ def _packed_local_bwd_cuda(q, k, value, gate, beta, d_output, cu_seqlens, split,
         cu_seqlens,
         scale=scale,
         split=split,
+    )[:5]
+
+
+def _packed_bwd_with_state_cuda(
+    q, k, value, gate, beta, d_output, cu_seqlens, initial_state, d_final_state, scale
+):
+    from attn_gym.linear._delta_rule.mega.backward import chunk_delta_rule_bwd_mega_packed
+
+    return chunk_delta_rule_bwd_mega_packed(
+        q,
+        k,
+        value,
+        gate,
+        beta,
+        d_output,
+        cu_seqlens,
+        scale=scale,
+        initial_state=initial_state,
+        d_final_state=d_final_state,
     )
 
 
@@ -246,6 +271,9 @@ torch.library.impl(
 )
 torch.library.impl("attn_gym::kda_chunk_mega_packed_fwd_paged", "CUDA", _packed_fwd_paged_cuda)
 torch.library.impl("attn_gym::kda_chunk_mega_packed_local_bwd", "CUDA", _packed_local_bwd_cuda)
+torch.library.impl(
+    "attn_gym::kda_chunk_mega_packed_bwd_with_state", "CUDA", _packed_bwd_with_state_cuda
+)
 torch.library.impl("attn_gym::kda_plain_gate_bwd_dense_cute", "CUDA", _plain_gate_bwd_cuda)
 
 
@@ -301,6 +329,21 @@ def _packed_local_bwd_fake(q, k, value, gate, beta, d_output, cu_seqlens, split,
     return tuple(torch.empty_like(tensor[0]).unsqueeze(0) for tensor in (q, k, value, gate, beta))
 
 
+@torch.library.register_fake("attn_gym::kda_chunk_mega_packed_bwd_with_state")
+def _packed_bwd_with_state_fake(
+    q, k, value, gate, beta, d_output, cu_seqlens, initial_state, d_final_state, scale
+):
+    del d_output, cu_seqlens, d_final_state, scale
+    gradients = tuple(
+        torch.empty_like(tensor[0]).unsqueeze(0) for tensor in (q, k, value, gate, beta)
+    )
+    # The launcher allocates a compact FP32 cotangent whatever the entry state's outer strides.
+    d_initial_state = (
+        None if initial_state is None else initial_state.new_empty(initial_state.shape)
+    )
+    return (*gradients, d_initial_state)
+
+
 @torch.library.register_fake("attn_gym::kda_plain_gate_bwd_dense_cute")
 def _plain_gate_bwd_fake(d_cumulative):
     return torch.empty_like(d_cumulative)
@@ -317,11 +360,15 @@ chunk_mega_packed_fwd_with_state_op = (
     torch.ops.attn_gym.kda_chunk_mega_packed_fwd_with_state.default
 )
 chunk_mega_packed_local_bwd_op = torch.ops.attn_gym.kda_chunk_mega_packed_local_bwd.default
+chunk_mega_packed_bwd_with_state_op = (
+    torch.ops.attn_gym.kda_chunk_mega_packed_bwd_with_state.default
+)
 plain_gate_bwd_dense_cute_op = torch.ops.attn_gym.kda_plain_gate_bwd_dense_cute.default
 
 
 __all__ = [
     "chunk_mega_dense_training_fwd_op",
+    "chunk_mega_packed_bwd_with_state_op",
     "chunk_mega_packed_fwd_op",
     "chunk_mega_packed_fwd_paged_op",
     "chunk_mega_packed_fwd_with_initial_state_op",

--- a/attn_gym/linear/kda/stages.py
+++ b/attn_gym/linear/kda/stages.py
@@ -54,6 +54,7 @@ from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd import (
 from attn_gym.linear.kda.impl.fused import _validate_fused_constraints
 from attn_gym.linear.kda.impl.mega import validate_mega_constraints
 from attn_gym.linear.kda.impl.mega_ops import (
+    chunk_mega_packed_bwd_with_state_op,
     chunk_mega_packed_fwd_with_initial_state_op,
     chunk_mega_packed_fwd_with_state_op,
     validate_mega_available,
@@ -67,7 +68,7 @@ class ChunkKDASaved(NamedTuple):
 
     Every field is a tensor or ``None`` so the tuple can be splatted into
     ``ctx.save_for_backward`` and rebuilt from ``ctx.saved_tensors``. ``aqk``/``akk`` are
-    ``None`` when the forward did not materialize them (Mega); backward recomputes them.
+    ``None`` when the forward did not materialize them; backward recomputes them.
     """
 
     q: torch.Tensor
@@ -79,6 +80,24 @@ class ChunkKDASaved(NamedTuple):
     akk: torch.Tensor | None
     cu_seqlens: torch.Tensor | None
     chunk_offsets: torch.Tensor | None
+
+
+class ChunkKDAMegaSaved(NamedTuple):
+    """Forward tensors a Mega ``chunk_kda_prepare`` stores for ``chunk_kda_prepare_backward``.
+
+    The type routes ``chunk_kda_prepare_backward`` to the native Mega backward, which reads the
+    raw ``gate`` and keeps its factors on chip; ``cumulative_gate`` feeds only the fused factor
+    pass behind the reverse summaries. Mega always runs packed, so the offsets are never ``None``.
+    """
+
+    q: torch.Tensor
+    k: torch.Tensor
+    v: torch.Tensor
+    gate: torch.Tensor
+    cumulative_gate: torch.Tensor
+    beta: torch.Tensor
+    cu_seqlens: torch.Tensor
+    chunk_offsets: torch.Tensor
 
 
 # NOTE [Summary ranges are whole chunks of one subsequence]
@@ -110,6 +129,15 @@ def _normalize_state(state: torch.Tensor | None) -> torch.Tensor | None:
     return state if state.stride(-1) == 1 else state.contiguous()
 
 
+def _normalize_mega_state(state: torch.Tensor) -> torch.Tensor:
+    """FP32 state as Mega's launchers read it through TMA.
+
+    Unit-stride keys and 16-byte-aligned outer strides suffice, so only other layouts are copied.
+    """
+    state = state.float()
+    return state if tensor_supports_tma(state) else state.contiguous()
+
+
 @dataclass
 class ChunkKDAPrepared:
     """Local forward factors shared by ``state_summaries`` and ``run``.
@@ -124,16 +152,25 @@ class ChunkKDAPrepared:
     autotune: bool
     schedule: ScheduleRequest
 
-    def state_summaries(self, bounds: torch.Tensor) -> torch.Tensor:
+    def state_summaries(
+        self, bounds: torch.Tensor, *, deterministic_work: bool = False
+    ) -> torch.Tensor:
         """Return one FP32 ``[HV, V + K, K]`` map per row of ``bounds`` in a single launch.
 
         ``bounds`` is an ``int32 [R, 2]`` device tensor of ``[start, stop)`` span offsets, each
         obeying NOTE [Summary ranges are whole chunks of one subsequence]; ``start == stop``
         yields the identity. The ranges are read on the device, so a CUDA Graph captured around
-        this call replays for any layout of the same shape.
+        this call replays for any layout of the same shape. ``deterministic_work=True`` pins
+        each range's recurrence partition for canonical tile batching; factor preparation
+        must also use ``autotune=False``.
         """
         return build_state_summaries(
-            self.factors.kg, self.factors.w, self.factors.u, self.saved.cumulative_gate, bounds
+            self.factors.kg,
+            self.factors.w,
+            self.factors.u,
+            self.saved.cumulative_gate,
+            bounds,
+            deterministic_work=deterministic_work,
         )
 
     def run(
@@ -164,18 +201,19 @@ class ChunkKDAMegaPrepared:
 
     Mega never materializes the WY factors, so ``run`` executes the Mega with-state kernel over the
     whole local stream and ``state_summaries`` computes the fused factors once for the whole stream
-    (its ranges are device values). Backward recomputes the intra factors, as Mega does today.
+    (its ranges are device values). The backward handle is :class:`ChunkKDAMegaBackward`.
     """
 
-    saved: ChunkKDASaved  # aqk/akk are None: Mega keeps them on chip
-    gate: torch.Tensor
+    saved: ChunkKDAMegaSaved
     metadata: RaggedChunkMetadata
     scale: float
     autotune: bool
     # Mega rejects other schedules; kept so both handles feed chunk_kda_prepare_backward alike.
     schedule: ScheduleRequest = ScheduleRequest.AUTO
 
-    def state_summaries(self, bounds: torch.Tensor) -> torch.Tensor:
+    def state_summaries(
+        self, bounds: torch.Tensor, *, deterministic_work: bool = False
+    ) -> torch.Tensor:
         """Return one FP32 ``[HV, V + K, K]`` map per row of ``bounds`` in a single launch.
 
         Mega keeps no WY factors, so this factors the whole local stream once (the fused
@@ -195,7 +233,12 @@ class ChunkKDAMegaPrepared:
             schedule=self.schedule,
         )
         return build_state_summaries(
-            factors.kg, factors.w, factors.u, saved.cumulative_gate, bounds
+            factors.kg,
+            factors.w,
+            factors.u,
+            saved.cumulative_gate,
+            bounds,
+            deterministic_work=deterministic_work,
         )
 
     def run(
@@ -209,19 +252,15 @@ class ChunkKDAMegaPrepared:
         if initial_state is None:
             initial_state = zero_state(saved.q, saved.v, self.metadata)
         else:
-            # Mega's launcher reads the state through TMA: unit-stride keys and 16-byte-aligned
-            # outer strides suffice, so only other layouts are copied.
-            initial_state = initial_state.float()
-            if not tensor_supports_tma(initial_state):
-                initial_state = initial_state.contiguous()
+            initial_state = _normalize_mega_state(initial_state)
         args = (
             saved.q,
             saved.k,
             saved.v,
-            self.gate,
+            saved.gate,
             saved.beta,
             initial_state,
-            self.metadata.cu_seqlens,
+            saved.cu_seqlens,
             self.scale,
         )
         if output_final_state:
@@ -276,10 +315,9 @@ def chunk_kda_prepare(
         assert metadata is not None
         gate = normalize_compact_tensor(gate)
         validate_mega_constraints(q, k, v, gate, beta, None, metadata.cu_seqlens)
-        saved = ChunkKDASaved(
-            q, k, v, cumulative_gate, beta, None, None, cu_seqlens, chunk_offsets
-        )
-        return ChunkKDAMegaPrepared(saved, gate, metadata, scale, autotune)
+        assert cu_seqlens is not None and chunk_offsets is not None
+        saved = ChunkKDAMegaSaved(q, k, v, gate, cumulative_gate, beta, cu_seqlens, chunk_offsets)
+        return ChunkKDAMegaPrepared(saved, metadata, scale, autotune)
     factors = _prepare_chunk_kda_fwd(
         q, k, v, cumulative_gate, beta, metadata, scale=scale, autotune=autotune, schedule=schedule
     )
@@ -305,7 +343,9 @@ class ChunkKDABackward:
     autotune: bool
     fastmath: bool
 
-    def state_grad_summaries(self, bounds: torch.Tensor) -> torch.Tensor:
+    def state_grad_summaries(
+        self, bounds: torch.Tensor, *, deterministic_work: bool = False
+    ) -> torch.Tensor:
         """Return one FP32 ``[HV, V + K, K]`` reverse map per row of ``bounds`` in one launch.
 
         Packed as ``[C; R]`` with ``d_entry_state = d_exit_state @ R + C``, where ``C`` is the
@@ -323,6 +363,7 @@ class ChunkKDABackward:
             self.saved.cumulative_gate,
             self.scale,
             bounds,
+            deterministic_work=deterministic_work,
         )
 
     def run(
@@ -363,8 +404,101 @@ class ChunkKDABackward:
         return dq, dk, dv, dgate, dbeta, d_initial_state
 
 
+@dataclass
+class ChunkKDAMegaBackward:
+    """Mega backward handle: native stateful kernels for ``run``, fused factors for summaries.
+
+    ``run`` is the native Mega backward (checkpoint recompute + BT16 backward) from the saved
+    entry state and the exit cotangent: given the states Mega itself hands over, fragments cut at
+    16-token document offsets reproduce the unsharded Mega gradients bit for bit (the summaries'
+    FP32 maps round the handed-over values differently). ``state_grad_summaries``
+    still recomputes the fused factors over the whole local stream, as the forward handle's
+    ``state_summaries`` does; Mega emits no per-range reverse maps yet, and this pass includes the
+    fused state recompute the summaries do not read. Unlike :class:`ChunkKDABackward`, nothing is
+    consumed, so ``run`` and ``state_grad_summaries`` may be called in either order.
+    """
+
+    saved: ChunkKDAMegaSaved
+    d_output: torch.Tensor
+    initial_state: torch.Tensor | None
+    metadata: RaggedChunkMetadata
+    scale: float
+    autotune: bool
+    schedule: ScheduleRequest
+
+    def state_grad_summaries(
+        self, bounds: torch.Tensor, *, deterministic_work: bool = False
+    ) -> torch.Tensor:
+        """Return one FP32 ``[HV, V + K, K]`` reverse map per row of ``bounds`` in one launch.
+
+        Same contract as ``ChunkKDABackward.state_grad_summaries``.
+        """
+        saved = self.saved
+        prepared = _prepare_chunk_kda_bwd(
+            saved.q,
+            saved.k,
+            saved.v,
+            saved.cumulative_gate,
+            saved.beta,
+            None,
+            None,
+            self.d_output,
+            self.initial_state,
+            self.metadata,
+            scale=self.scale,
+            chunk_size=CHUNK_SIZE,
+            autotune=self.autotune,
+            schedule=self.schedule,
+        )
+        assert prepared.qg is not None and prepared.kg is not None
+        assert prepared.w is not None and prepared.aqk is not None
+        return build_state_grad_summaries(
+            prepared.qg,
+            prepared.kg,
+            prepared.w,
+            self.d_output,
+            prepared.aqk,
+            saved.cumulative_gate,
+            self.scale,
+            bounds,
+            deterministic_work=deterministic_work,
+        )
+
+    def run(
+        self, d_final_state: torch.Tensor | None = None
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor | None,
+    ]:
+        """Run Mega's backward from one FP32 ``[N, HV, V, K]`` exit cotangent per sequence.
+
+        Returns ``(dq, dk, dv, dgate, dbeta, d_initial_state)``; the last is ``None`` when the
+        forward ran without an entry state. An absent ``d_final_state`` skips the cotangent load
+        and gives the token gradients of an explicit zero.
+        """
+        saved = self.saved
+        if d_final_state is not None:
+            d_final_state = _normalize_mega_state(d_final_state)
+        return chunk_mega_packed_bwd_with_state_op(
+            saved.q,
+            saved.k,
+            saved.v,
+            saved.gate,
+            saved.beta,
+            self.d_output,
+            saved.cu_seqlens,
+            self.initial_state,
+            d_final_state,
+            self.scale,
+        )
+
+
 def chunk_kda_prepare_backward(
-    saved: ChunkKDASaved,
+    saved: ChunkKDASaved | ChunkKDAMegaSaved,
     d_output: torch.Tensor | None,
     initial_state: torch.Tensor | None,
     *,
@@ -372,7 +506,7 @@ def chunk_kda_prepare_backward(
     autotune: bool = True,
     fastmath: bool = False,
     schedule: ScheduleRequest = ScheduleRequest.AUTO,
-) -> ChunkKDABackward:
+) -> ChunkKDABackward | ChunkKDAMegaBackward:
     """Recompute the local backward tensors before any reverse-summary exchange.
 
     ``initial_state`` is the entry state the forward ``run`` consumed and ``scale`` is the
@@ -380,20 +514,31 @@ def chunk_kda_prepare_backward(
     re-derived scale would corrupt every gradient. Both live outside ``saved`` because the
     caller's autograd function owns them. ``fastmath`` applies to the gradient kernels as in
     ``chunk_kda``; pass the forward handle's ``prepared.schedule`` so the backward's factor
-    recompute uses the same launch geometry.
+    recompute uses the same launch geometry. A Mega tape (:class:`ChunkKDAMegaSaved`) returns
+    :class:`ChunkKDAMegaBackward`, whose native ``run`` ignores ``fastmath`` and defers the fused
+    factor recompute to ``state_grad_summaries``.
     """
+    if d_output is None:
+        d_output = torch.zeros_like(saved.v)
+    else:
+        d_output = normalize_compact_tensor(d_output.to(saved.v.dtype))
+    scale = float(scale)
+    if isinstance(saved, ChunkKDAMegaSaved):
+        metadata = RaggedChunkMetadata.from_offsets(
+            saved.cu_seqlens, saved.chunk_offsets, saved.q.shape[1], CHUNK_SIZE
+        )
+        if initial_state is not None:
+            initial_state = _normalize_mega_state(initial_state)
+        return ChunkKDAMegaBackward(
+            saved, d_output, initial_state, metadata, scale, autotune, schedule
+        )
     metadata = None
     if saved.cu_seqlens is not None:
         assert saved.chunk_offsets is not None
         metadata = RaggedChunkMetadata.from_offsets(
             saved.cu_seqlens, saved.chunk_offsets, saved.q.shape[1], CHUNK_SIZE
         )
-    if d_output is None:
-        d_output = torch.zeros_like(saved.v)
-    else:
-        d_output = normalize_compact_tensor(d_output.to(saved.v.dtype))
     initial_state = _normalize_state(initial_state)  # The backward recomputes the chain from it.
-    scale = float(scale)
     prepared = _prepare_chunk_kda_bwd(
         saved.q,
         saved.k,
@@ -417,7 +562,9 @@ def chunk_kda_prepare_backward(
 
 __all__ = [
     "ChunkKDABackward",
+    "ChunkKDAMegaBackward",
     "ChunkKDAMegaPrepared",
+    "ChunkKDAMegaSaved",
     "ChunkKDAPrepared",
     "ChunkKDASaved",
     "chunk_kda_prepare",

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -610,10 +610,12 @@ local pass with Mega from the composed entry state. Because Mega keeps WY factor
 `state_summaries` computes the fused factors once over the whole local stream and summarizes
 every range from them; that factor pass is paid even when every fragment ends its document and
 the summaries are identities, since which ranges are empty is a device value under replay. A
-layout that never continues a document across ranks does not need this recipe. Backward
-recomputes the local fused factors and uses Mega's existing with-state route through the fused
-staged backward. The staged handles and this recipe are eager-only; `torch.compile` is not
-supported through them.
+layout that never continues a document across ranks does not need this recipe. The backward
+handle's `run` is Mega's own stateful backward (`attn_gym::kda_chunk_mega_packed_bwd_with_state`:
+checkpoint recompute from the saved entry state, then the BT16 backward folding in the exit
+cotangent), so a document cut at 16-token boundaries reproduces the unsharded Mega gradients bit
+for bit; only `state_grad_summaries` still recomputes the fused factors over the local stream. The
+staged handles and this recipe are eager-only; `torch.compile` is not supported through them.
 
 ::: attn_gym.linear.context_parallel.context_parallel_chunk
 

--- a/test/kda/mega/test_kda_mega_stateful_bwd.py
+++ b/test/kda/mega/test_kda_mega_stateful_bwd.py
@@ -1,0 +1,298 @@
+"""Native stateful Mega backward: registration, fragment handoff parity, and reference accuracy."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+from attn_gym.testing.kda import (
+    assert_matches_low_precision_reference,
+    cumulative_sequence_offsets,
+    kda_reference,
+    make_kda_test_inputs,
+)
+
+pytest.importorskip(
+    "cutlass.experimental",
+    reason="the CuTeDSL 4.7 KDA path requires nvidia-cutlass-dsl>=4.7",
+)
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() not in ((10, 0), (10, 3)),
+    reason="the CuTeDSL 4.7 KDA path requires SM100 or SM103",
+)
+
+D = 128
+SCALE = D**-0.5
+OPCHECK_UTILITIES = ("test_schema", "test_faketensor", "test_aot_dispatch_dynamic")
+MILD_GATE = 0.05  # Decay per token in [e^-0.05, 1): the entry state still matters 4096 tokens in.
+
+
+def _ops():
+    from attn_gym.linear.kda.impl import mega_ops
+
+    return mega_ops
+
+
+def _make_inputs(
+    lengths: list[int], *, heads: int, gate_scale: float, seed: int
+) -> tuple[torch.Tensor, ...]:
+    """Public Mega operands, a nonzero FP32 entry state, and an output cotangent per token."""
+    q, k, value, gate, beta = make_kda_test_inputs(
+        sum(lengths),
+        heads=heads,
+        seed=seed,
+        gate_scale=gate_scale,
+        sigmoid_beta=True,
+        normalize_qk=True,
+        dtype=torch.bfloat16,
+    )
+    generator = torch.Generator(device="cuda").manual_seed(seed + 1)
+    initial_state = torch.randn(len(lengths), heads, D, D, device="cuda", generator=generator)
+    d_output = torch.randn(value.shape, device="cuda", generator=generator).to(value.dtype)
+    d_final_state = torch.randn_like(initial_state)
+    return q, k, value, gate, beta, initial_state, d_output, d_final_state
+
+
+def _swap_state_head_value_storage(tensor: torch.Tensor) -> torch.Tensor:
+    """Copy `[N,H,V,K]` data into dense TMA-compatible `[N,V,H,K]` storage order."""
+    _, heads, value_dim, key_dim = tensor.shape
+    storage = torch.empty(tensor.numel(), dtype=tensor.dtype, device=tensor.device)
+    return torch.as_strided(
+        storage,
+        tensor.shape,
+        (heads * value_dim * key_dim, key_dim, heads * key_dim, 1),
+    ).copy_(tensor)
+
+
+@pytest.mark.parametrize("outer_strided", [False, True], ids=["compact", "outer-strided"])
+def test_stateful_backward_op_registration(outer_strided: bool) -> None:
+    ops = _ops()
+    q, k, value, gate, beta, initial_state, d_output, d_final_state = _make_inputs(
+        [65, 0, 63], heads=2, gate_scale=math.log(2.0), seed=97
+    )
+    cu_seqlens = cumulative_sequence_offsets([65, 0, 63])
+    if outer_strided:
+        initial_state = _swap_state_head_value_storage(initial_state)
+        d_final_state = _swap_state_head_value_storage(d_final_state)
+        assert not initial_state.is_contiguous()
+    operands = (q, k, value, gate, beta, d_output, cu_seqlens)
+
+    grads = ops.chunk_mega_packed_bwd_with_state_op(*operands, initial_state, d_final_state, SCALE)
+    assert len(grads) == 6
+    assert grads[5].shape == initial_state.shape and grads[5].is_contiguous()
+    assert grads[5].dtype == torch.float32
+    torch.library.opcheck(
+        ops.chunk_mega_packed_bwd_with_state_op,
+        (*operands, initial_state, d_final_state, SCALE),
+        test_utils=OPCHECK_UTILITIES,
+    )
+    torch.library.opcheck(
+        ops.chunk_mega_packed_bwd_with_state_op,
+        (*operands, None, None, SCALE),
+        test_utils=OPCHECK_UTILITIES,
+    )
+    torch.library.opcheck(
+        ops.chunk_mega_packed_bwd_with_state_op,
+        (*operands, initial_state, None, SCALE),
+        test_utils=OPCHECK_UTILITIES,
+    )
+
+
+def test_stateful_backward_without_state_is_the_local_backward() -> None:
+    """``None`` keeps the no-state kernel specializations, so the two ops agree bit for bit."""
+    ops = _ops()
+    q, k, value, gate, beta, _, d_output, _ = _make_inputs(
+        [65, 0, 63], heads=2, gate_scale=math.log(2.0), seed=11
+    )
+    cu_seqlens = cumulative_sequence_offsets([65, 0, 63])
+    *grads, d_initial_state = ops.chunk_mega_packed_bwd_with_state_op(
+        q, k, value, gate, beta, d_output, cu_seqlens, None, None, SCALE
+    )
+    assert d_initial_state is None
+    expected = ops.chunk_mega_packed_local_bwd_op(
+        q, k, value, gate, beta, d_output, cu_seqlens, False, SCALE
+    )
+    for actual, reference in zip(grads, expected, strict=True):
+        torch.testing.assert_close(actual, reference, atol=0, rtol=0)
+
+
+def _slice(tensors: tuple[torch.Tensor, ...], start: int, stop: int) -> tuple[torch.Tensor, ...]:
+    return tuple(tensor[:, start:stop].contiguous() for tensor in tensors)
+
+
+def _fragments(cu_seqlens: list[int], cut: int) -> tuple[list[int], list[int], int]:
+    """Split packed boundaries at ``cut``; returns both fragments' local offsets and the cut doc."""
+    document = max(index for index, start in enumerate(cu_seqlens[:-1]) if start <= cut)
+    assert cu_seqlens[document] < cut < cu_seqlens[document + 1], "cut must be inside a document"
+    assert (cut - cu_seqlens[document]) % 16 == 0, "cut must be 16-aligned to the document"
+    first = [*cu_seqlens[: document + 1], cut]
+    second = [offset - cut for offset in (cut, *cu_seqlens[document + 1 :])]
+    return first, second, document
+
+
+@pytest.mark.parametrize(
+    ("lengths", "cut", "heads", "gate_scale"),
+    [
+        pytest.param([4096], 2064, 64, MILD_GATE, id="h64-t4096-mild"),
+        # Documents start at 0, 17, 82, 211, 468, 981; cuts are 16-aligned to their document.
+        pytest.param([17, 65, 129, 257, 513, 1025], 211 + 16 * 5, 4, MILD_GATE, id="ragged-mild"),
+        pytest.param([17, 65, 129, 257, 513, 1025], 468 + 16 * 3, 4, 5.0, id="ragged-strong"),
+    ],
+)
+def test_two_aligned_fragments_with_state_handoff_match_one_native_call(
+    lengths: list[int], cut: int, heads: int, gate_scale: float
+) -> None:
+    """A document cut at a 16-token offset and continued from the actual states is bit-exact.
+
+    Rank 0 owns ``[0, cut)`` and rank 1 ``[cut, T)``; the cut document's exit state travels
+    forward and its entry cotangent travels backward, as the context-parallel recipe does.
+    """
+    ops = _ops()
+    q, k, value, gate, beta, initial_state, d_output, d_final_state = _make_inputs(
+        lengths, heads=heads, gate_scale=gate_scale, seed=3
+    )
+    cu_seqlens = [0, *torch.tensor(lengths).cumsum(0).tolist()]
+    tokens = cu_seqlens[-1]
+    offsets = cumulative_sequence_offsets(lengths)
+    first, second, document = _fragments(cu_seqlens, cut)
+    first_offsets = torch.tensor(first, dtype=torch.int32, device="cuda")
+    second_offsets = torch.tensor(second, dtype=torch.int32, device="cuda")
+
+    operands = (q, k, value, gate, beta)
+    output, final_state = ops.chunk_mega_packed_fwd_with_state_op(
+        *operands, initial_state, offsets, SCALE
+    )
+    expected = ops.chunk_mega_packed_bwd_with_state_op(
+        *operands, d_output, offsets, initial_state, d_final_state, SCALE
+    )
+
+    head, tail = _slice(operands, 0, cut), _slice(operands, cut, tokens)
+    head_output, head_states = ops.chunk_mega_packed_fwd_with_state_op(
+        *head, initial_state[: document + 1], first_offsets, SCALE
+    )
+    tail_entry = torch.cat((head_states[document:], initial_state[document + 1 :]))
+    tail_output, tail_states = ops.chunk_mega_packed_fwd_with_state_op(
+        *tail, tail_entry, second_offsets, SCALE
+    )
+    torch.testing.assert_close(torch.cat((head_output, tail_output), 1), output, atol=0, rtol=0)
+    torch.testing.assert_close(head_states[:document], final_state[:document], atol=0, rtol=0)
+    torch.testing.assert_close(tail_states, final_state[document:], atol=0, rtol=0)
+
+    tail_grads = ops.chunk_mega_packed_bwd_with_state_op(
+        *tail,
+        d_output[:, cut:].contiguous(),
+        second_offsets,
+        tail_entry,
+        d_final_state[document:],
+        SCALE,
+    )
+    head_exit = torch.cat((d_final_state[:document], tail_grads[5][:1]))
+    head_grads = ops.chunk_mega_packed_bwd_with_state_op(
+        *head,
+        d_output[:, :cut].contiguous(),
+        first_offsets,
+        initial_state[: document + 1],
+        head_exit,
+        SCALE,
+    )
+    for name, head_grad, tail_grad, reference in zip(
+        ("dq", "dk", "dv", "dgate", "dbeta"),
+        head_grads[:5],
+        tail_grads[:5],
+        expected[:5],
+        strict=True,
+    ):
+        torch.testing.assert_close(
+            torch.cat((head_grad, tail_grad), 1), reference, atol=0, rtol=0, msg=name
+        )
+    d_initial_state = torch.cat((head_grads[5], tail_grads[5][1:]))
+    torch.testing.assert_close(d_initial_state, expected[5], atol=0, rtol=0)
+
+
+def test_staged_mega_backward_is_the_native_op() -> None:
+    """``chunk_kda_prepare_backward`` on a Mega tape runs the stateful op, not the fused recompute."""
+    from attn_gym.linear.kda.stages import (
+        ChunkKDAMegaBackward,
+        ChunkKDAMegaSaved,
+        chunk_kda_prepare,
+        chunk_kda_prepare_backward,
+    )
+
+    ops = _ops()
+    lengths = [100, 156]
+    q, k, value, gate, beta, initial_state, d_output, d_final_state = _make_inputs(
+        lengths, heads=2, gate_scale=MILD_GATE, seed=5
+    )
+    offsets = cumulative_sequence_offsets(lengths)
+    prepared = chunk_kda_prepare(
+        q, k, value, gate, beta, cu_seqlens=offsets, kernel_options={"backend": "mega"}
+    )
+    assert isinstance(prepared.saved, ChunkKDAMegaSaved)
+    prepared.run(initial_state, output_final_state=True)
+    grads = chunk_kda_prepare_backward(
+        prepared.saved, d_output, initial_state, scale=prepared.scale
+    )
+    assert isinstance(grads, ChunkKDAMegaBackward)
+    expected = ops.chunk_mega_packed_bwd_with_state_op(
+        q, k, value, gate, beta, d_output, offsets, initial_state, d_final_state, SCALE
+    )
+    for actual, reference in zip(grads.run(d_final_state), expected, strict=True):
+        torch.testing.assert_close(actual, reference, atol=0, rtol=0)
+
+    # The reverse summaries still come from the fused factors, so they match the fused handle.
+    fused = chunk_kda_prepare(q, k, value, gate, beta, cu_seqlens=offsets)
+    fused_grads = chunk_kda_prepare_backward(
+        fused.saved, d_output, initial_state, scale=fused.scale
+    )
+    bounds = torch.tensor([[0, 100], [100, 256]], dtype=torch.int32, device="cuda")
+    torch.testing.assert_close(
+        grads.state_grad_summaries(bounds),
+        fused_grads.state_grad_summaries(bounds),
+        atol=0,
+        rtol=0,
+    )
+    # Without an entry state the tape's backward keeps Mega's no-state arithmetic.
+    no_state = chunk_kda_prepare_backward(prepared.saved, d_output, None, scale=prepared.scale)
+    *no_state_grads, d_initial_state = no_state.run(None)
+    assert d_initial_state is None
+    local = ops.chunk_mega_packed_local_bwd_op(
+        q, k, value, gate, beta, d_output, offsets, False, SCALE
+    )
+    for actual, reference in zip(no_state_grads, local, strict=True):
+        torch.testing.assert_close(actual, reference, atol=0, rtol=0)
+
+
+def test_stateful_backward_matches_fp64_reference_including_d_initial_state() -> None:
+    """All six gradients, including the entry-state cotangent, sit within the reference budget."""
+    ops = _ops()
+    lengths = [100, 156]
+    q, k, value, gate, beta, initial_state, d_output, d_final_state = _make_inputs(
+        lengths, heads=1, gate_scale=MILD_GATE, seed=7
+    )
+    offsets = cumulative_sequence_offsets(lengths)
+    actual = ops.chunk_mega_packed_bwd_with_state_op(
+        q, k, value, gate, beta, d_output, offsets, initial_state, d_final_state, SCALE
+    )
+
+    def reference(dtype: torch.dtype) -> tuple[torch.Tensor, ...]:
+        leaves = tuple(
+            tensor.detach().to(dtype).requires_grad_()
+            for tensor in (q, k, value, gate, beta, initial_state)
+        )
+        output, final_state = kda_reference(
+            *leaves, cu_seqlens=offsets, scale=SCALE, output_final_state=True
+        )
+        assert final_state is not None
+        return torch.autograd.grad(
+            (output, final_state), leaves, (d_output.to(dtype), d_final_state.to(dtype))
+        )
+
+    high, low = reference(torch.float64), reference(torch.float32)
+    names = ("dq", "dk", "dv", "dgate", "dbeta", "d_initial_state")
+    for name, actual_grad, high_grad, low_grad in zip(names, actual, high, low, strict=True):
+        assert_matches_low_precision_reference(actual_grad, high_grad, low_grad, name)
+    # The entry state must actually reach the gradient: a dead state makes the check vacuous.
+    assert high[5].abs().max() > 1e-3

--- a/test/test_canonical_tile_batching.py
+++ b/test/test_canonical_tile_batching.py
@@ -1,0 +1,161 @@
+"""Bitwise ownership invariance of the fused canonical-tile staged primitives.
+
+The reference uses independent per-tile calls, including the dense dispatch for complete
+single tiles and the production summary defaults used by the prototype. The candidate
+packs those same tiles as separate subsequences in one call with pinned summary work.
+Random nonzero entry states and exit cotangents exercise both affine boundary terms.
+"""
+
+from __future__ import annotations
+
+import math
+from itertools import accumulate, pairwise
+
+import pytest
+import torch
+
+pytest.importorskip("cutlass")
+
+from attn_gym.linear.kda.stages import (
+    ChunkKDAPrepared,
+    chunk_kda_prepare,
+    chunk_kda_prepare_backward,
+)
+from attn_gym.testing.kda import make_kda_test_inputs
+
+pytestmark = pytest.mark.skipif(
+    not (torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 8),
+    reason="fused canonical tiles require CUDA capability 8.0+",
+)
+
+
+def assert_bitwise_equal(actual: torch.Tensor, expected: torch.Tensor, name: str) -> None:
+    """Check numerical equality and storage bits, including the sign of zero."""
+    assert torch.isfinite(actual).all(), name
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0, msg=name)
+    integer_dtype = torch.int16 if actual.element_size() == 2 else torch.int32
+    torch.testing.assert_close(
+        actual.contiguous().view(integer_dtype),
+        expected.contiguous().view(integer_dtype),
+        rtol=0,
+        atol=0,
+        msg=f"{name}: integer view",
+    )
+
+
+@torch.no_grad()
+def run_tiles(
+    inputs: tuple[torch.Tensor, ...],
+    d_output: torch.Tensor,
+    lengths: list[int],
+    entry: torch.Tensor,
+    exit_grad: torch.Tensor,
+    *,
+    packed: bool,
+) -> dict[str, torch.Tensor]:
+    """Snapshot each stage before backward consumes its prepared intermediates."""
+    offsets = [0, *accumulate(lengths)]
+    cu_seqlens = torch.tensor(offsets, dtype=torch.int32, device="cuda") if packed else None
+    prepared = chunk_kda_prepare(
+        *inputs,
+        cu_seqlens=cu_seqlens,
+        autotune=False,
+        kernel_options={"backend": "fused"},
+    )
+    assert isinstance(prepared, ChunkKDAPrepared)
+    bounds = torch.tensor(list(pairwise(offsets)), dtype=torch.int32, device="cuda")
+    result = {f"factor/{name}": value for name, value in prepared.factors._asdict().items()}
+    result["cumulative_gate"] = prepared.saved.cumulative_gate
+    result["summary"] = prepared.state_summaries(bounds, deterministic_work=packed)
+    output, final_state = prepared.run(entry, output_final_state=True)
+    assert final_state is not None
+    result["output"] = output
+    result["final_state"] = final_state
+    backward = chunk_kda_prepare_backward(
+        prepared.saved,
+        d_output,
+        entry,
+        scale=prepared.scale,
+        autotune=False,
+        schedule=prepared.schedule,
+    )
+    for name in ("w", "qg", "kg", "aqk", "akk", "v_new", "d_aqk"):
+        value = vars(backward.prepared)[name]
+        assert value is not None
+        result[f"backward/{name}"] = value
+    assert backward.prepared.h is not None
+    # Packed allocation capacity can exceed the active chunks; never inspect padding.
+    chunks = sum(math.ceil(length / 64) for length in lengths)
+    result["backward/h"] = backward.prepared.h[:, :chunks]
+    result["grad_summary"] = backward.state_grad_summaries(bounds, deterministic_work=packed)
+    gradients = backward.run(exit_grad)
+    for name, value in zip(
+        ("dq", "dk", "dv", "dgate", "dbeta", "d_entry"), gradients, strict=True
+    ):
+        assert value is not None
+        result[name] = value
+    return result
+
+
+@pytest.mark.parametrize("tile_size", [64, 128])
+@pytest.mark.parametrize("heads", [4, 64])
+@pytest.mark.parametrize("gate", ["mild", "strong"])
+def test_canonical_tile_batching(tile_size: int, heads: int, gate: str) -> None:
+    """Packing rank-owned ragged tiles must preserve every forward/backward stage bit."""
+    torch.manual_seed(41)
+    doc_offsets = [0, *accumulate([17, 65, 129, 257, 513])]
+    tiles = [
+        (start, min(start + tile_size, end))
+        for begin, end in pairwise(doc_offsets)
+        for start in range(begin, end, tile_size)
+    ]
+    inputs = make_kda_test_inputs(
+        doc_offsets[-1],
+        heads=heads,
+        seed=41,
+        normalize_qk=True,
+        sigmoid_beta=True,
+        gate_scale=math.log(2) if gate == "strong" else 0.02,
+        log_uniform_gate=gate == "strong",
+    )
+    d_output = torch.randn_like(inputs[2])
+    entry = torch.randn(len(tiles), heads, 128, 128, device="cuda") * 0.1
+    exit_grad = torch.randn_like(entry) * 0.1
+    reference = [
+        run_tiles(
+            tuple(value[:, start:stop].clone() for value in inputs),
+            d_output[:, start:stop].clone(),
+            [stop - start],
+            entry[i : i + 1],
+            exit_grad[i : i + 1],
+            packed=False,
+        )
+        for i, (start, stop) in enumerate(tiles)
+    ]
+    # Three independent copies cross the summary-budget and short-sequence recurrence
+    # thresholds. Rotation makes the default budget split inside a two-chunk tile.
+    owners = [
+        list(range(len(tiles))),
+        list(range(0, len(tiles), 2)),
+        list(range(1, len(tiles), 2))[::-1],
+        (list(range(4, len(tiles))) + list(range(4))) * 3,
+    ]
+    owners.append([next(i for i, (start, stop) in enumerate(tiles) if stop - start == tile_size)])
+    state_names = {"summary", "grad_summary", "final_state", "d_entry"}
+    for owned in owners:
+        batched = run_tiles(
+            tuple(
+                torch.cat([value[:, tiles[i][0] : tiles[i][1]] for i in owned], dim=1)
+                for value in inputs
+            ),
+            torch.cat([d_output[:, tiles[i][0] : tiles[i][1]] for i in owned], dim=1),
+            [tiles[i][1] - tiles[i][0] for i in owned],
+            entry[owned],
+            exit_grad[owned],
+            packed=True,
+        )
+        for name, value in batched.items():
+            expected = torch.cat(
+                [reference[i][name] for i in owned], dim=0 if name in state_names else 1
+            )
+            assert_bitwise_equal(value, expected, f"{name}, owned={owned}")

--- a/test/test_delta_rule_stages.py
+++ b/test/test_delta_rule_stages.py
@@ -55,11 +55,73 @@ class Op(NamedTuple):
     factory: Callable[..., Inputs]  # (tokens, *, key_heads, value_heads, seed, dtype)
     key_heads: int
     value_heads: int
+    # The unsharded kernels the staged backward reproduces bitwise; ``None`` is autograd through
+    # ``chunk``. Mega's staged backward is the native stateful kernel, while the public op's
+    # stateful backward is the fused recompute, so Mega names the native op here.
+    backward: Callable[..., tuple[torch.Tensor, ...]] | None = None
 
     def make_inputs(self, tokens: int, seed: int, dtype: torch.dtype = torch.bfloat16) -> Inputs:
         return self.factory(
             tokens, key_heads=self.key_heads, value_heads=self.value_heads, seed=seed, dtype=dtype
         )
+
+    def gradients(
+        self,
+        inputs: Inputs,
+        initial_state: torch.Tensor | None,
+        cu_seqlens: torch.Tensor | None,
+        d_output: torch.Tensor | None,
+        d_final_state: torch.Tensor | None,
+        *,
+        scale: float | None = None,
+    ) -> tuple[torch.Tensor, ...]:
+        """``(dq, dk, dv, dgate, dbeta[, d_initial_state])`` of the unsharded op.
+
+        A ``None`` cotangent drops that term of the loss.
+        """
+        if self.backward is not None:
+            return self.backward(
+                inputs, initial_state, cu_seqlens, d_output, d_final_state, scale=scale
+            )
+        leaves = tuple(tensor.detach().clone().requires_grad_() for tensor in inputs)
+        if initial_state is not None:
+            leaves += (initial_state.detach().clone().requires_grad_(),)
+        output, final_state = self.chunk(
+            *leaves, cu_seqlens=cu_seqlens, output_final_state=True, scale=scale
+        )
+        terms = [(output, d_output), (final_state, d_final_state)]
+        outputs, cotangents = zip(*(term for term in terms if term[1] is not None), strict=True)
+        return torch.autograd.grad(outputs, leaves, cotangents)
+
+
+def mega_native_gradients(
+    inputs: Inputs,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+    d_output: torch.Tensor | None,
+    d_final_state: torch.Tensor | None,
+    *,
+    scale: float | None = None,
+) -> tuple[torch.Tensor, ...]:
+    """The native stateful Mega backward, which the Mega staged handle runs."""
+    from attn_gym.linear.kda.impl.mega_ops import chunk_mega_packed_bwd_with_state_op
+
+    q, k, v, gate, beta = inputs
+    if cu_seqlens is None:
+        cu_seqlens = torch.tensor([0, q.shape[1]], dtype=torch.int32, device=q.device)
+    grads = chunk_mega_packed_bwd_with_state_op(
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        torch.zeros_like(v) if d_output is None else d_output,
+        cu_seqlens,
+        None if initial_state is None else initial_state.contiguous(),
+        d_final_state,
+        HEAD_DIM**-0.5 if scale is None else scale,
+    )
+    return grads if initial_state is not None else grads[:5]
 
 
 def relative_rms_error(actual: torch.Tensor, reference: torch.Tensor) -> float:
@@ -123,6 +185,7 @@ requires_mega = pytest.mark.skipif(
 KDA_MEGA = KDA._replace(
     chunk=partial(chunk_kda, kernel_options=MEGA),
     prepare=partial(chunk_kda_prepare, kernel_options=MEGA),
+    backward=mega_native_gradients,
 )
 op_param = pytest.mark.parametrize(
     "op",
@@ -319,7 +382,7 @@ def assert_summary_parts_match(summary, fused, oracle, index: int) -> None:
 def test_prepare_backward_run_matches_chunk_op_gradients(op, scale, loss, state, packing):
     """The staged backward is the op's own kernel sequence, so all six gradients are bitwise.
 
-    Covers the cotangents the staged API makes optional (``d_output=None``, no final-state loss),
+    For Mega the sequence is the native stateful backward (``Op.backward``). Covers the cotangents the staged API makes optional (``d_output=None``, no final-state loss),
     the entry-state layouts ``run`` accepts (none, contiguous, a key-strided view), and both chunk
     schedules: packed ``cu_seqlens`` and a dense span of complete chunks (``metadata is None``).
     """
@@ -343,21 +406,16 @@ def test_prepare_backward_run_matches_chunk_op_gradients(op, scale, loss, state,
         sequences, op.value_heads, HEAD_DIM, HEAD_DIM, device="cuda", generator=generator
     )
 
-    leaves = tuple(tensor.detach().clone().requires_grad_() for tensor in inputs) + (
-        () if initial_state is None else (initial_state.detach().clone().requires_grad_(),)
-    )
-    output, final_state = op.chunk(
-        *leaves, cu_seqlens=cu_seqlens, output_final_state=True, scale=scale
-    )
-    d_output = torch.randn(output.shape, device="cuda", generator=generator).to(output.dtype)
+    d_output = torch.randn(inputs[2].shape, device="cuda", generator=generator).to(inputs[2].dtype)
+    gradients = partial(op.gradients, inputs, initial_state, cu_seqlens, scale=scale)
     if loss == "output-only":
-        expected = torch.autograd.grad(output, leaves, d_output)
+        expected = gradients(d_output, None)
         d_final_state = torch.zeros_like(d_final_state)
     elif loss == "final-state-only":
-        expected = torch.autograd.grad(final_state, leaves, d_final_state)
+        expected = gradients(None, d_final_state)
         d_output = None
     else:
-        expected = torch.autograd.grad((output, final_state), leaves, (d_output, d_final_state))
+        expected = gradients(d_output, d_final_state)
 
     prepared = op.prepare(*inputs, cu_seqlens=cu_seqlens, scale=scale)
     prepared.run(initial_state, output_final_state=True)
@@ -677,9 +735,7 @@ def test_simulated_context_parallel_matches_unsharded_op(op, cu_seqlens, layout,
     generator = torch.Generator(device="cuda").manual_seed(5)
     d_output = torch.randn(output.shape, device="cuda", generator=generator).to(output.dtype)
     d_final_state = torch.randn(final_state.shape, device="cuda", generator=generator)
-    expected_grads = torch.autograd.grad(
-        (output, final_state), inputs, grad_outputs=(d_output, d_final_state)
-    )
+    expected_grads = op.gradients((q, k, v, gate, beta), None, offsets, d_output, d_final_state)
 
     # Sharding must not cost accuracy: measure both paths against the FP32 eager oracle.
     f32 = tuple(tensor.detach().float().requires_grad_() for tensor in (q, k, v, gate, beta))


### PR DESCRIPTION
Stacked PRs:
 * #519
 * #518
 * #517
 * #516
 * #515
 * #514
 * #513
 * __->__#512


--- --- ---

Pin the summary work partition and give the staged Mega handles a native stateful backward

build_state_summaries / build_state_grad_summaries gain deterministic_work=True: one work
item per range with a fixed SM100 column tile, so the recurrence partition (and therefore the
FP32 composition of partial maps) no longer depends on total tokens, range count, or SM count.
A negative control showed the default planner splitting a two-chunk range when a share boundary
landed inside it, which changes the summary bits; the default planner is unchanged. The kwarg
is carried through the PreparedForward/PreparedBackward protocols and the KDA and GDN handles.

Mega under the staged (CP) handles now runs its own backward: a registered
kda_chunk_mega_packed_bwd_with_state op threads the entry state and exit-state cotangent
through the existing recompute/bprop launchers and returns the entry-state gradient, and
ChunkKDAMegaBackward (dispatched on the new ChunkKDAMegaSaved tape) replaces the fused
recompute the Mega tape previously fell back to. None is preserved as None so the no-state
specializations are untouched (verified bitwise against the existing local op). Two 16-aligned
fragments exchanging Mega's own state and cotangent reproduce one native call bit for bit; the
staged test also checks the native gradients against the public op within a BF16 budget.
state_grad_summaries still uses the fused factors (documented interim).