### PR TITLE
Add CP-degree-invariant KDA context parallelism over canonical tiles

### DIFF
--- a/attn_gym/linear/context_parallel_deterministic.py
+++ b/attn_gym/linear/context_parallel_deterministic.py
@@ -1,0 +1,395 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Context parallelism whose numerics do not depend on the CP degree.
+
+NOTE [Canonical Tiles]
+The standard recipe (``context_parallel_chunk``) summarizes each rank's fragment with one affine
+map. Changing the number of ranks changes the fragments, which changes which token ranges are
+summarized and how the FP32 maps are composed, so the rounded result moves. This module fixes
+the whole arithmetic graph before ranks are assigned:
+
+    tile      ``[start, min(start + tile_size, doc_end))`` within one document, aligned to the
+              document's first token; the last tile of a document may be short. Tile size is a
+              multiple of the 64-token summary chunk and is part of the numerical contract.
+    leaf map  every tile's ``[bias; transition]`` forward map and ``[C; R]`` reverse map, computed
+              by the staged op on that tile alone (no other tile's tokens are visible).
+    scan      per document, a work-efficient (Blelloch) inclusive prefix over the leaf maps in
+              tile order (forward) and reverse tile order (backward). The prefix at tile ``j`` is
+              a function of that document's leaves ``0..j`` and of ``j`` alone.
+    entry     ``merge_state(0, prefix[i - 1])`` for tile ``i``; the first tile of a document enters
+              with zero. Exits are the reverse analogue.
+
+Ranks own whole tiles; ownership changes which leaves a rank computes and where the scan runs,
+never the leaf arithmetic or the tree. The result for CP=1 with this recipe is therefore bitwise
+identical to CP=N (verified for fused and Mega forwards, see the deterministic tests), and a
+document's result does not depend on which other documents are packed around it. It is a
+distinct numerical contract from the unsharded ``chunk_kda`` call.
+
+A rank prepares all its tiles in one staged call, each tile a packed subsequence, with the
+summary kernels' work partition pinned (``deterministic_work=True``); this is bitwise equal to
+preparing every tile alone (``test/test_canonical_tile_batching.py``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from itertools import accumulate, pairwise
+from typing import NamedTuple
+
+import torch
+import torch.distributed as dist
+
+from attn_gym._backends.profiler import profiler_range
+from attn_gym.linear.context_parallel import StagedOp, _ieee_fp32_matmul
+
+SUMMARY_CHUNK = 64
+
+
+class Tile(NamedTuple):
+    """One canonical tile: global token range ``[start, stop)`` of ``document``."""
+
+    document: int
+    start: int
+    stop: int
+
+    @property
+    def length(self) -> int:
+        return self.stop - self.start
+
+
+@dataclass(frozen=True)
+class CanonicalTiling:
+    """Fixed tiles of a packed stream plus this rank's ownership.
+
+    Attributes:
+        tiles: Every tile of the stream in global token order.
+        owned: ``owned[rank]`` lists the tile ids that rank computes, in its span order.
+        cp_rank: This rank.
+    """
+
+    tiles: tuple[Tile, ...]
+    owned: tuple[tuple[int, ...], ...]
+    cp_rank: int
+
+    @classmethod
+    def from_fragments(
+        cls,
+        cu_seqlens_global: Sequence[int],
+        fragments: Sequence[Sequence[tuple[int, int]]],
+        cp_rank: int,
+        *,
+        tile_size: int,
+    ) -> CanonicalTiling:
+        """Tile the stream and assign whole tiles to the ranks that own their tokens.
+
+        ``fragments[rank]`` are that rank's global token ranges. Every fragment boundary must fall
+        on a tile boundary (a document boundary or ``doc_start + k * tile_size``), otherwise the
+        ownership would cut a tile and the leaf arithmetic would depend on the fragment table.
+        """
+        if tile_size <= 0 or tile_size % SUMMARY_CHUNK:
+            raise ValueError(f"tile_size must be a positive multiple of {SUMMARY_CHUNK}")
+        if not 0 <= cp_rank < len(fragments):
+            raise ValueError(f"cp_rank {cp_rank} is outside a table of {len(fragments)} ranks")
+        tiles = tile_stream(cu_seqlens_global, tile_size)
+        starts = {tile.start: index for index, tile in enumerate(tiles)}
+        boundaries = set(starts) | {cu_seqlens_global[-1]}
+        owned: list[list[int]] = []
+        for rank_fragments in fragments:
+            ids: list[int] = []
+            for start, stop in rank_fragments:
+                if start >= stop:
+                    raise ValueError(f"fragment [{start}, {stop}) is empty or reversed")
+                if start not in boundaries or stop not in boundaries:
+                    raise ValueError(
+                        f"fragment [{start}, {stop}) does not fall on canonical tile boundaries"
+                    )
+                index = starts.get(start)
+                while index is not None and index < len(tiles) and tiles[index].stop <= stop:
+                    ids.append(index)
+                    index += 1
+            owned.append(ids)
+        seen = sorted(index for ids in owned for index in ids)
+        if seen != list(range(len(tiles))):
+            raise ValueError("fragments must cover every tile exactly once")
+        return cls(tiles=tuple(tiles), owned=tuple(tuple(ids) for ids in owned), cp_rank=cp_rank)
+
+    @property
+    def mine(self) -> tuple[int, ...]:
+        return self.owned[self.cp_rank]
+
+    @property
+    def slots(self) -> int:
+        """Gather width: the most tiles any rank owns."""
+        return max(len(ids) for ids in self.owned)
+
+    def global_token_ids(self, device: torch.device | str) -> torch.Tensor:
+        """Global token id of every span token of this rank (tiles concatenated in span order)."""
+        pieces = [
+            torch.arange(self.tiles[i].start, self.tiles[i].stop, device=device) for i in self.mine
+        ]
+        return torch.cat(pieces) if pieces else torch.empty(0, dtype=torch.int64, device=device)
+
+    def span_offsets(self) -> tuple[int, ...]:
+        """Span-local ``[start, stop)`` of each owned tile, in span order."""
+        return tuple(accumulate((self.tiles[i].length for i in self.mine), initial=0))
+
+
+def tile_stream(cu_seqlens_global: Sequence[int], tile_size: int) -> list[Tile]:
+    """Cut every document into ``tile_size`` tiles from its first token; the last may be short."""
+    tiles = []
+    for document, (start, stop) in enumerate(pairwise(cu_seqlens_global)):
+        tiles.extend(
+            Tile(document, begin, min(begin + tile_size, stop))
+            for begin in range(start, stop, tile_size)
+        )
+    return tiles
+
+
+@_ieee_fp32_matmul()
+def _compose_into(right: torch.Tensor, left: torch.Tensor) -> None:
+    """``right <- [B_L @ A_R + B_R; A_L @ A_R]`` in place on ``[..., V + K, K]`` packed maps."""
+    value_dim = left.shape[-2] - left.shape[-1]
+    composed = left @ right[..., value_dim:, :]
+    composed[..., :value_dim, :] += right[..., :value_dim, :]
+    right.copy_(composed)
+
+
+def canonical_scan(maps: torch.Tensor) -> torch.Tensor:
+    """Inclusive prefix along dim 1 of ``[D, L, H, V + K, K]`` maps, one independent row per document.
+
+    Work-efficient (Blelloch) scan: an up-sweep folds pairs at strides 1, 2, 4, ... into the
+    right element, then a down-sweep pushes each node's prefix into the elements it did not
+    cover. Every stage is one batched IEEE-FP32 matmul over strided views of the buffer. The
+    prefix at position ``j`` reads positions ``<= j`` only, so it is a function of the leaves
+    ``0..j`` and of ``j`` alone: padding a row on the right (with any maps) does not change it,
+    and neither does which rank produced a leaf or how leaves were transported. About ``2L``
+    compositions per row in ``2 log2 L`` stages.
+    """
+    length = maps.shape[1]
+    stage = maps.clone()
+    stride = 1
+    while 2 * stride - 1 < length:
+        right = stage[:, 2 * stride - 1 :: 2 * stride]
+        _compose_into(right, stage[:, stride - 1 :: 2 * stride][:, : right.shape[1]])
+        stride *= 2
+    stride //= 2
+    while stride >= 1:
+        if 3 * stride - 1 < length:
+            right = stage[:, 3 * stride - 1 :: 2 * stride]
+            _compose_into(right, stage[:, 2 * stride - 1 :: 2 * stride][:, : right.shape[1]])
+        stride //= 2
+    return stage
+
+
+def boundary_states(maps: torch.Tensor, tiles: Sequence[Tile], *, reverse: bool) -> torch.Tensor:
+    """Entry (or exit when ``reverse``) FP32 ``[N, H, V, K]`` state of every tile in tile order.
+
+    Documents are scanned independently, so a document's states depend only on its own tiles,
+    not on its position in the packed stream or on its neighbours. Documents are batched by the
+    power-of-two bucket of their tile count and right-padded with identity maps to the bucket
+    length; the prefix at a position never reads past it (see ``canonical_scan``), so the padding
+    and the batching are numerically inert and only bound the wasted work to under 2x. Single-tile
+    documents need no scan. The first tile of a document (last when ``reverse``) enters with zero;
+    every other tile enters with the bias of the exclusive prefix (``merge_state(0, prefix)``).
+    """
+    count, heads, packed, key_dim = maps.shape
+    value_dim = packed - key_dim
+    rows: dict[int, list[int]] = {}
+    for index, tile in enumerate(tiles):
+        rows.setdefault(tile.document, []).append(index)
+    entries = maps.new_zeros((count, heads, value_dim, key_dim))
+    buckets: dict[int, list[list[int]]] = {}
+    for ids in rows.values():
+        if len(ids) > 1:
+            ordered = list(reversed(ids)) if reverse else list(ids)
+            buckets.setdefault(1 << (len(ids) - 1).bit_length(), []).append(ordered)
+    identity = torch.eye(key_dim, device=maps.device)
+    for length, documents in sorted(buckets.items()):
+        padded = maps.new_zeros((len(documents), length, heads, packed, key_dim))
+        padded[:, :, :, value_dim:, :] = identity
+        row_index = torch.tensor(
+            [d for d, ids in enumerate(documents) for _ in ids[1:]], device=maps.device
+        )
+        col_index = torch.tensor(
+            [j for ids in documents for j in range(1, len(ids))], device=maps.device
+        )
+        tile_index = torch.tensor([i for ids in documents for i in ids[1:]], device=maps.device)
+        leaf_index = torch.tensor([i for ids in documents for i in ids], device=maps.device)
+        padded[
+            torch.tensor([d for d, ids in enumerate(documents) for _ in ids], device=maps.device),
+            torch.tensor([j for ids in documents for j in range(len(ids))], device=maps.device),
+        ] = maps[leaf_index]
+        prefix = canonical_scan(padded)
+        entries[tile_index] = prefix[row_index, col_index - 1, :, :value_dim, :]
+    return entries
+
+
+def all_gather_tile_maps(
+    local: torch.Tensor | None,
+    tiling: CanonicalTiling,
+    like: torch.Tensor,
+    group: dist.ProcessGroup,
+) -> torch.Tensor:
+    """Exchange every rank's leaf maps and return them as ``[N, H, V + K, K]`` in tile order.
+
+    ``local`` holds this rank's maps in ``tiling.mine`` order (``None`` for an empty rank).
+    Packets are zero-padded to ``tiling.slots`` rows so the collective is a plain equal-size
+    all-gather; the padding rows never enter a scan. When every rank owns a contiguous run of
+    tiles in rank order and no padding is needed, the gathered buffer already is the tile order
+    and is returned without a copy.
+    """
+    width = tiling.slots
+    world = len(tiling.owned)
+    if local is not None and local.shape[0] == width:
+        packet = local
+    else:
+        packet = like.new_zeros((width, *like.shape[1:]))
+        if local is not None:
+            packet[: local.shape[0]] = local
+    gathered = like.new_empty((world * width, *like.shape[1:]))
+    with profiler_range("cp/all_gather_tiles"):
+        dist.all_gather_into_tensor(gathered, packet, group=group)
+    order = [index for ids in tiling.owned for index in ids]
+    if order == list(range(len(order))) and len(order) == world * width:
+        return gathered
+    rows = [rank * width + row for rank, ids in enumerate(tiling.owned) for row in range(len(ids))]
+    placed = torch.empty_like(gathered[: len(tiling.tiles)])
+    placed[torch.tensor(order, device=like.device)] = gathered[
+        torch.tensor(rows, device=like.device)
+    ]
+    return placed
+
+
+class _CanonicalContextParallel(torch.autograd.Function):
+    """One batched staged forward/backward per rank glued by fixed per-document scans.
+
+    Every owned tile is one packed subsequence of the rank's span (``cu_seqlens`` at tile
+    boundaries), so the leaf kernels see each tile exactly as an independent call would; the
+    summary kernels run with ``deterministic_work=True`` so their work partition cannot depend on
+    how many tiles the rank owns (see ``build_state_summaries``). Batching is bitwise equal to
+    per-tile calls for the fused kernels (``test/test_canonical_tile_batching.py``).
+    """
+
+    @staticmethod
+    def forward(ctx, q, k, v, gate, beta, tiling: CanonicalTiling, group, stages: StagedOp):
+        offsets = tiling.span_offsets()
+        heads, dim, value_dim = q.shape[2], q.shape[3], v.shape[3]
+        zero = q.new_zeros((1, heads, value_dim, dim), dtype=torch.float32)
+        like = zero.new_empty((1, heads, value_dim + dim, dim))  # one packed map
+        n = len(tiling.mine)
+        if n:
+            cu = torch.tensor(offsets, dtype=torch.int32, device=q.device)
+            bounds = torch.tensor(list(pairwise(offsets)), dtype=torch.int32, device=q.device)
+            prepared = stages.prepare(q, k, v, gate, beta, cu_seqlens=cu)
+            maps = prepared.state_summaries(bounds, deterministic_work=True)
+        else:
+            prepared = None
+            maps = None
+        entries = boundary_states(
+            all_gather_tile_maps(maps, tiling, like, group), tiling.tiles, reverse=False
+        )
+        if n:
+            entry = entries[list(tiling.mine)]
+            with profiler_range("cp/run"):
+                output, _ = prepared.run(entry, output_final_state=False)
+            saved = tuple(prepared.saved)
+            ctx.saved_type = type(prepared.saved)
+            ctx.scale = prepared.scale
+        else:
+            output = v[:, :0]
+            entry = zero[:0]
+            saved = ()
+            ctx.saved_type = None
+            ctx.scale = None
+        ctx.tiling = tiling
+        ctx.group = group
+        ctx.stages = stages
+        ctx.input_meta = tuple((t.shape, t.dtype) for t in (q, k, v, gate, beta))
+        ctx.output_meta = (output.shape, output.dtype)
+        # ``zero`` and ``like`` give an empty rank the map shapes its collective must match.
+        ctx.save_for_backward(*saved, entry, zero, like)
+        ctx.set_materialize_grads(False)
+        return output
+
+    @staticmethod
+    @torch.autograd.function.once_differentiable
+    def backward(ctx, d_output):
+        tiling: CanonicalTiling = ctx.tiling
+        offsets = tiling.span_offsets()
+        *saved, entry, zero, like = ctx.saved_tensors
+        if d_output is None:
+            d_output = zero.new_zeros(*ctx.output_meta)
+        n = len(tiling.mine)
+        if n:
+            bounds = torch.tensor(list(pairwise(offsets)), dtype=torch.int32, device=zero.device)
+            backward = ctx.stages.prepare_backward(
+                ctx.saved_type._make(saved), d_output, entry, scale=ctx.scale
+            )
+            maps = backward.state_grad_summaries(bounds, deterministic_work=True)
+        else:
+            backward = None
+            maps = None
+        exits = boundary_states(
+            all_gather_tile_maps(maps, tiling, like, ctx.group), tiling.tiles, reverse=True
+        )
+        if n:
+            exit_cotangent = exits[list(tiling.mine)]
+            with profiler_range("cp/run"):
+                grads = backward.run(exit_cotangent)[:5]
+        else:
+            grads = tuple(zero.new_empty(shape, dtype=dtype) for shape, dtype in ctx.input_meta)
+        return (*grads, None, None, None)
+
+
+def context_parallel_chunk_deterministic(
+    stages: StagedOp,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    *,
+    tiling: CanonicalTiling,
+    group: dist.ProcessGroup,
+) -> torch.Tensor:
+    """Run a staged delta-rule op over this rank's canonical tiles (NOTE [Canonical Tiles]).
+
+    Args:
+        stages: The op's staged entry points, as for ``context_parallel_chunk``.
+        q: This rank's span: its owned tiles concatenated in ``tiling.mine`` order; ``k``, ``v``,
+            ``gate``, ``beta`` follow the same layout.
+        tiling: The stream's canonical tiling and this rank's ownership.
+        group: Process group containing exactly the tiling's ranks, in order.
+
+    Returns:
+        The span's output. Final states are not returned: every document's exit state is a
+        function of the scan and can be recovered from the gathered maps if needed.
+
+    Every rank in ``group`` must call this, and run its backward, the same number of times,
+    including ranks that own no tiles: both directions all-gather maps, so an empty rank still
+    contributes an all-zero packet (and gets an empty output and empty gradients).
+    """
+    world, cp_rank = dist.get_world_size(group), dist.get_rank(group)
+    if world != len(tiling.owned) or cp_rank != tiling.cp_rank:
+        raise ValueError("tiling was built for a different group or rank")
+    expected = sum(tiling.tiles[i].length for i in tiling.mine)
+    if q.shape[1] != expected:
+        raise ValueError(f"tiling owns {expected} local tokens but the input has {q.shape[1]}")
+    return _CanonicalContextParallel.apply(q, k, v, gate, beta, tiling, group, stages)
+
+
+__all__ = [
+    "SUMMARY_CHUNK",
+    "CanonicalTiling",
+    "Tile",
+    "all_gather_tile_maps",
+    "boundary_states",
+    "canonical_scan",
+    "context_parallel_chunk_deterministic",
+    "tile_stream",
+]

--- a/attn_gym/linear/kda/__init__.py
+++ b/attn_gym/linear/kda/__init__.py
@@ -38,6 +38,7 @@ _BACKEND_EXPORTS = {
     "chunk_kda_prepare": "attn_gym.linear.kda.stages",
     "chunk_kda_prepare_backward": "attn_gym.linear.kda.stages",
     "context_parallel_kda": "attn_gym.linear.kda.context_parallel",
+    "context_parallel_kda_deterministic": "attn_gym.linear.kda.context_parallel",
 }
 # Backward compat: these moved to attn_gym.linear.short_conv, whose own lazy resolution supplies
 # the error message; import them from attn_gym.linear instead.

--- a/attn_gym/linear/kda/context_parallel.py
+++ b/attn_gym/linear/kda/context_parallel.py
@@ -18,6 +18,10 @@ from attn_gym.linear.context_parallel import (
     StagedOp,
     context_parallel_chunk,
 )
+from attn_gym.linear.context_parallel_deterministic import (
+    CanonicalTiling,
+    context_parallel_chunk_deterministic,
+)
 from attn_gym.linear.kda.stages import chunk_kda_prepare, chunk_kda_prepare_backward
 from attn_gym.linear.kda.validation import resolve_kernel_options
 from attn_gym.linear.types import KernelOptions
@@ -42,10 +46,40 @@ def context_parallel_kda(
     See ``attn_gym.linear.context_parallel.context_parallel_chunk`` for the argument contract;
     ``scale``, ``autotune``, and ``kernel_options`` follow ``chunk_kda``. With
     ``kernel_options={"backend": "mega"}`` the local pass runs on Mega and the fused factors are
-    computed once over the span for the summaries; ``fastmath`` applies to the staged backward,
-    which is the fused one for either backend.
+    computed once over the span for the summaries; its backward is Mega's native stateful kernel,
+    so ``fastmath`` applies only to the fused backend's backward.
     """
-    stages = StagedOp(
+    stages = _kda_stages(scale, autotune, fastmath, kernel_options)
+    return context_parallel_chunk(stages, q, k, v, gate, beta, routing=routing, group=group)
+
+
+def context_parallel_kda_deterministic(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    *,
+    tiling: CanonicalTiling,
+    group: dist.ProcessGroup,
+    scale: float | None = None,
+    fastmath: bool = False,
+    kernel_options: KernelOptions | None = None,
+) -> torch.Tensor:
+    """Run KDA over this rank's canonical tiles; results do not depend on the CP degree.
+
+    See NOTE [Canonical Tiles] in ``attn_gym.linear.context_parallel_deterministic``. Autotuning
+    is disabled because a tuned configuration is part of the arithmetic and would have to be
+    identical on every rank; ``fastmath`` and ``kernel_options`` follow ``chunk_kda``.
+    """
+    stages = _kda_stages(scale, False, fastmath, kernel_options)
+    return context_parallel_chunk_deterministic(
+        stages, q, k, v, gate, beta, tiling=tiling, group=group
+    )
+
+
+def _kda_stages(scale, autotune, fastmath, kernel_options) -> StagedOp:
+    return StagedOp(
         partial(chunk_kda_prepare, scale=scale, autotune=autotune, kernel_options=kernel_options),
         partial(
             chunk_kda_prepare_backward,
@@ -54,7 +88,6 @@ def context_parallel_kda(
             schedule=resolve_kernel_options(kernel_options).schedule,
         ),
     )
-    return context_parallel_chunk(stages, q, k, v, gate, beta, routing=routing, group=group)
 
 
-__all__ = ["context_parallel_kda"]
+__all__ = ["context_parallel_kda", "context_parallel_kda_deterministic"]

--- a/benchmarks/kda_cp_deterministic.py
+++ b/benchmarks/kda_cp_deterministic.py
@@ -1,0 +1,232 @@
+"""Overhead of CP-degree-invariant KDA against the standard CP recipe and the unsharded op.
+
+    torchrun --standalone --nproc-per-node=2 benchmarks/kda_cp_deterministic.py --heads 64 --tokens 8192
+
+Every rank times its own fwd and bwd with CUDA events; the reported time per iteration is the
+slowest rank, which is what gates a training step. Rounds interleave the variants (A,B,C / C,B,A)
+so clock drift hits them evenly. Rank 0 prints a table and writes JSON to ``--out``.
+
+Variants:
+  unsharded    ``chunk_kda`` over the whole packed stream on every rank (CP=1 reference cost).
+  cp           ``context_parallel_kda`` with contiguous fragments cut at tile boundaries.
+  det-<T>      ``context_parallel_kda_deterministic`` with canonical tile size T.
+
+The document layout is a fixed Zipf-like ragged set scaled to ``--tokens``; the standard CP
+fragments are cut on the deterministic tile grid so both recipes move the same tokens.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import statistics
+from functools import partial
+from itertools import accumulate
+from pathlib import Path
+from typing import Annotated
+
+import torch
+import torch.distributed as dist
+import typer
+
+from attn_gym.linear.context_parallel import ContextParallelPlan
+from attn_gym.linear.context_parallel_deterministic import CanonicalTiling, tile_stream
+from attn_gym.linear.kda import chunk_kda, context_parallel_kda
+from attn_gym.linear.kda.context_parallel import context_parallel_kda_deterministic
+from attn_gym.testing.kda import make_kda_test_inputs
+
+ZIPF_FRACTIONS = (0.5, 0.25, 0.125, 0.0625)
+
+
+def document_lengths(tokens: int, grid: int) -> tuple[int, ...]:
+    """Zipf-like documents on a ``grid`` so every recipe can share fragment boundaries.
+
+    Fractions are floored to the grid, so the last document absorbs the rounding; ``tokens``
+    must leave it at least one grid step (e.g. tokens >= 16 * grid).
+    """
+    lengths = [int(tokens * f) // grid * grid for f in ZIPF_FRACTIONS]
+    remainder = tokens - sum(lengths)
+    if min(lengths) < grid or remainder < grid:
+        raise ValueError(f"tokens={tokens} is too small for grid={grid}")
+    return (*lengths, remainder)
+
+
+def balanced_cut(cu: tuple[int, ...], tile: int, world: int) -> list[list[tuple[int, int]]]:
+    """Contiguous fragments with boundaries on the canonical tile grid, balanced by tokens."""
+    tiles = tile_stream(cu, tile)
+    stops = [t.stop for t in tiles]
+    fragments, start = [], 0
+    for rank in range(world):
+        target = cu[-1] * (rank + 1) // world
+        stop = cu[-1] if rank == world - 1 else min(stops, key=lambda s: abs(s - target))
+        fragments.append([(start, stop)] if stop > start else [])
+        start = stop
+    return fragments
+
+
+def timed(fn, *, iters: int, device) -> list[float]:
+    """Per-iteration milliseconds from CUDA events, synchronized across ranks each iteration."""
+    samples = []
+    for _ in range(iters):
+        dist.barrier()
+        start, end = torch.cuda.Event(enable_timing=True), torch.cuda.Event(enable_timing=True)
+        start.record()
+        fn()
+        end.record()
+        torch.cuda.synchronize(device)
+        local = torch.tensor([start.elapsed_time(end)], device=device)
+        dist.all_reduce(local, op=dist.ReduceOp.MAX)
+        samples.append(local.item())
+    return samples
+
+
+def main(
+    tokens: Annotated[int, typer.Option(help="Total packed tokens.")] = 8192,
+    heads: Annotated[int, typer.Option()] = 64,
+    backend: Annotated[str, typer.Option(help="fused or mega (forward core).")] = "fused",
+    tiles: Annotated[str, typer.Option(help="Comma-separated canonical tile sizes.")] = "64,256",
+    rounds: Annotated[int, typer.Option()] = 5,
+    iters: Annotated[int, typer.Option(help="Timed iterations per round per variant.")] = 10,
+    out_path: Annotated[Path | None, typer.Option("--out")] = None,
+) -> None:
+    rank, world = int(os.environ["RANK"]), int(os.environ["WORLD_SIZE"])
+    device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+    torch.cuda.set_device(device)
+    dist.init_process_group("nccl", device_id=device)
+    tile_sizes = [int(t) for t in tiles.split(",")]
+    grid = max(tile_sizes)
+    lengths = document_lengths(tokens, grid)
+    cu = (0, *accumulate(lengths))
+    options = {"backend": backend} if backend != "fused" else None
+    torch.manual_seed(0)
+    inputs = make_kda_test_inputs(
+        tokens,
+        heads=heads,
+        seed=0,
+        normalize_qk=True,
+        sigmoid_beta=True,
+        gate_scale=0.02,
+        log_uniform_gate=False,
+    )
+    grad = torch.randn_like(inputs[2])
+    cu_dev = torch.tensor(cu, dtype=torch.int32, device=device)
+    fragments = balanced_cut(cu, grid, world)
+
+    variants: dict[str, tuple] = {}
+
+    def unsharded_fwd():
+        leaves = tuple(v.detach().requires_grad_() for v in inputs)
+        out, _ = chunk_kda(*leaves, cu_seqlens=cu_dev, kernel_options=options, autotune=False)
+        return out, leaves, grad
+
+    variants["unsharded"] = unsharded_fwd
+
+    plan = ContextParallelPlan.from_fragments(cu, fragments, rank)
+    routing = plan.routing(device)
+    cp_ids = plan.global_token_ids(device)
+    cp_local = tuple(v[:, cp_ids].contiguous() for v in inputs)
+    cp_grad = grad[:, cp_ids].contiguous()
+
+    def cp_fwd():
+        leaves = tuple(v.detach().requires_grad_() for v in cp_local)
+        out, _ = context_parallel_kda(
+            *leaves,
+            routing=routing,
+            group=dist.group.WORLD,
+            kernel_options=options,
+            autotune=False,
+        )
+        return out, leaves, cp_grad
+
+    variants["cp"] = cp_fwd
+
+    for tile in tile_sizes:
+        tiling = CanonicalTiling.from_fragments(cu, fragments, rank, tile_size=tile)
+        ids = tiling.global_token_ids(device)
+        local = tuple(v[:, ids].contiguous() for v in inputs)
+        local_grad = grad[:, ids].contiguous()
+
+        def det_fwd(tiling=tiling, local=local, local_grad=local_grad):
+            leaves = tuple(v.detach().requires_grad_() for v in local)
+            out = context_parallel_kda_deterministic(
+                *leaves, tiling=tiling, group=dist.group.WORLD, kernel_options=options
+            )
+            return out, leaves, local_grad
+
+        variants[f"det-{tile}"] = det_fwd
+
+    # Warm up (compiles) and keep one retained graph per variant for backward timing.
+    retained = {}
+    for name, fwd in variants.items():
+        for _ in range(2):
+            out, leaves, g = fwd()
+            torch.autograd.grad(out, leaves, g)
+        retained[name] = fwd()
+    torch.cuda.synchronize(device)
+
+    fwd_ms: dict[str, list[float]] = {name: [] for name in variants}
+    bwd_ms: dict[str, list[float]] = {name: [] for name in variants}
+    names = list(variants)
+    for r in range(rounds):
+        order = names if r % 2 == 0 else names[::-1]
+        for name in order:
+            fwd_ms[name] += timed(variants[name], iters=iters, device=device)
+            out, leaves, g = retained[name]
+            bwd_ms[name] += timed(
+                partial(torch.autograd.grad, out, leaves, g, retain_graph=True),
+                iters=iters,
+                device=device,
+            )
+
+    if rank == 0:
+        rows = []
+        for name in names:
+            rows.append(
+                {
+                    "variant": name,
+                    "fwd_ms": statistics.median(fwd_ms[name]),
+                    "bwd_ms": statistics.median(bwd_ms[name]),
+                    "fwd_p05": sorted(fwd_ms[name])[len(fwd_ms[name]) // 20],
+                    "fwd_p95": sorted(fwd_ms[name])[-1 - len(fwd_ms[name]) // 20],
+                    "bwd_p05": sorted(bwd_ms[name])[len(bwd_ms[name]) // 20],
+                    "bwd_p95": sorted(bwd_ms[name])[-1 - len(bwd_ms[name]) // 20],
+                }
+            )
+        base = next(r for r in rows if r["variant"] == "cp")
+        print(
+            f"tokens={tokens} heads={heads} backend={backend} world={world} lengths={lengths}\n"
+            f"fragments={fragments}\n"
+            f"{'variant':<12}{'fwd ms':>10}{'bwd ms':>10}{'fwd/cp':>9}{'bwd/cp':>9}"
+        )
+        for row in rows:
+            print(
+                f"{row['variant']:<12}{row['fwd_ms']:>10.3f}{row['bwd_ms']:>10.3f}"
+                f"{row['fwd_ms'] / base['fwd_ms']:>9.2f}{row['bwd_ms'] / base['bwd_ms']:>9.2f}"
+            )
+        if out_path:
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            out_path.write_text(
+                json.dumps(
+                    {
+                        "tokens": tokens,
+                        "heads": heads,
+                        "backend": backend,
+                        "world": world,
+                        "lengths": lengths,
+                        "fragments": fragments,
+                        "rounds": rounds,
+                        "iters": iters,
+                        "device": torch.cuda.get_device_name(device),
+                        "torch": torch.__version__,
+                        "rows": rows,
+                        "samples": {"fwd_ms": fwd_ms, "bwd_ms": bwd_ms},
+                    },
+                    indent=2,
+                )
+                + "\n"
+            )
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -613,13 +613,57 @@ the summaries are identities, since which ranges are empty is a device value und
 layout that never continues a document across ranks does not need this recipe. The backward
 handle's `run` is Mega's own stateful backward (`attn_gym::kda_chunk_mega_packed_bwd_with_state`:
 checkpoint recompute from the saved entry state, then the BT16 backward folding in the exit
-cotangent), so a document cut at 16-token boundaries reproduces the unsharded Mega gradients bit
-for bit; only `state_grad_summaries` still recomputes the fused factors over the local stream. The
-staged handles and this recipe are eager-only; `torch.compile` is not supported through them.
+cotangent). Given Mega's own entry state and exit cotangent, two fragments of a document cut on a
+16-token boundary reproduce the unsharded Mega gradients bit for bit; under this recipe the entry
+states are composed from the fused summaries, whose FP32 rounding differs from Mega's, so the
+sharded result is close to but not bitwise the unsharded one. `state_grad_summaries` still
+recomputes the fused factors over the local stream. The staged handles and this recipe are
+eager-only; `torch.compile` is not supported through them.
+
+### Deterministic mode: results independent of the CP degree
+
+`attn_gym.linear.kda.context_parallel_kda_deterministic` fixes the whole arithmetic graph before
+ranks are assigned, so output and every input gradient are **bitwise identical for any CP degree
+and any ownership of whole tiles**, including CP=1. It is a different numerical contract from the
+unsharded `chunk_kda` call (the same recurrence, composed through fixed FP32 affine maps; the
+error against an FP64 reference stays within the BF16 budget the tests use), and from the
+standard recipe above, whose summaries depend on the fragment table.
+
+- **Tiles.** Every document is cut from its first token into `tile_size` tiles (a multiple of
+  64; the last tile of a document may be short). `CanonicalTiling.from_fragments(cu_seqlens,
+  fragments, rank, tile_size=...)` assigns whole tiles to ranks and rejects a fragment boundary
+  that does not fall on a tile boundary. Ranks may own different numbers of tiles or none.
+- **Leaves.** A rank prepares its tiles in one staged call, each tile a packed subsequence, and
+  builds one `[bias; transition]` map per tile with `deterministic_work=True`, which pins the
+  summary kernels' work partition so it cannot depend on how many tiles the rank owns.
+- **Scan.** All maps are all-gathered and composed per document with a work-efficient scan
+  whose tree depends only on the tile count; the backward mirrors it over the reverse maps.
+
+```python
+from attn_gym.linear.context_parallel_deterministic import CanonicalTiling
+from attn_gym.linear.kda import context_parallel_kda_deterministic
+
+tiling = CanonicalTiling.from_fragments(cu_seqlens_global, fragments, rank, tile_size=1024)
+ids = tiling.global_token_ids(device)  # this rank's tiles, in span order
+output = context_parallel_kda_deterministic(
+    q[:, ids], k[:, ids], v[:, ids], gate[:, ids], beta[:, ids], tiling=tiling, group=group
+)
+```
+
+Every rank calls the forward and its backward the same number of times, including ranks that own
+no tiles. Autotuning is disabled in this mode. The tile size is the performance knob: maps are
+`H x 256 x 128` FP32 (128 KiB per tile per head), so the scan's bandwidth grows with the tile
+count; 1024-token tiles cost about 2-3x the standard recipe on GB200 at 32k tokens, 64-token
+tiles far more (`benchmarks/kda_cp_deterministic.py`). Works with the fused and the Mega
+forward; the backward is the staged one of the chosen backend.
 
 ::: attn_gym.linear.context_parallel.context_parallel_chunk
 
 ::: attn_gym.linear.kda.context_parallel.context_parallel_kda
+
+::: attn_gym.linear.kda.context_parallel.context_parallel_kda_deterministic
+
+::: attn_gym.linear.context_parallel_deterministic.CanonicalTiling
 
 ::: attn_gym.linear.gdn.context_parallel.context_parallel_gdn
 

--- a/test/test_canonical_tile_batching.py
+++ b/test/test_canonical_tile_batching.py
@@ -1,8 +1,7 @@
 """Bitwise ownership invariance of the fused canonical-tile staged primitives.
 
-The reference uses independent per-tile calls, including the dense dispatch for complete
-single tiles and the production summary defaults used by the prototype. The candidate
-packs those same tiles as separate subsequences in one call with pinned summary work.
+Independent per-tile calls use dense dispatch for complete tiles and default summary work.
+The candidate packs the same tiles as subsequences in one call with pinned summary work.
 Random nonzero entry states and exit cotangents exercise both affine boundary terms.
 """
 
@@ -16,6 +15,7 @@ import torch
 
 pytest.importorskip("cutlass")
 
+from attn_gym.linear.context_parallel_deterministic import tile_stream
 from attn_gym.linear.kda.stages import (
     ChunkKDAPrepared,
     chunk_kda_prepare,
@@ -104,11 +104,7 @@ def test_canonical_tile_batching(tile_size: int, heads: int, gate: str) -> None:
     """Packing rank-owned ragged tiles must preserve every forward/backward stage bit."""
     torch.manual_seed(41)
     doc_offsets = [0, *accumulate([17, 65, 129, 257, 513])]
-    tiles = [
-        (start, min(start + tile_size, end))
-        for begin, end in pairwise(doc_offsets)
-        for start in range(begin, end, tile_size)
-    ]
+    tiles = tile_stream(doc_offsets, tile_size)
     inputs = make_kda_test_inputs(
         doc_offsets[-1],
         heads=heads,
@@ -123,14 +119,14 @@ def test_canonical_tile_batching(tile_size: int, heads: int, gate: str) -> None:
     exit_grad = torch.randn_like(entry) * 0.1
     reference = [
         run_tiles(
-            tuple(value[:, start:stop].clone() for value in inputs),
-            d_output[:, start:stop].clone(),
-            [stop - start],
+            tuple(value[:, tile.start : tile.stop].clone() for value in inputs),
+            d_output[:, tile.start : tile.stop].clone(),
+            [tile.length],
             entry[i : i + 1],
             exit_grad[i : i + 1],
             packed=False,
         )
-        for i, (start, stop) in enumerate(tiles)
+        for i, tile in enumerate(tiles)
     ]
     # Three independent copies cross the summary-budget and short-sequence recurrence
     # thresholds. Rotation makes the default budget split inside a two-chunk tile.
@@ -139,17 +135,17 @@ def test_canonical_tile_batching(tile_size: int, heads: int, gate: str) -> None:
         list(range(0, len(tiles), 2)),
         list(range(1, len(tiles), 2))[::-1],
         (list(range(4, len(tiles))) + list(range(4))) * 3,
+        [next(i for i, tile in enumerate(tiles) if tile.length == tile_size)],
     ]
-    owners.append([next(i for i, (start, stop) in enumerate(tiles) if stop - start == tile_size)])
     state_names = {"summary", "grad_summary", "final_state", "d_entry"}
     for owned in owners:
         batched = run_tiles(
             tuple(
-                torch.cat([value[:, tiles[i][0] : tiles[i][1]] for i in owned], dim=1)
+                torch.cat([value[:, tiles[i].start : tiles[i].stop] for i in owned], dim=1)
                 for value in inputs
             ),
-            torch.cat([d_output[:, tiles[i][0] : tiles[i][1]] for i in owned], dim=1),
-            [tiles[i][1] - tiles[i][0] for i in owned],
+            torch.cat([d_output[:, tiles[i].start : tiles[i].stop] for i in owned], dim=1),
+            [tiles[i].length for i in owned],
             entry[owned],
             exit_grad[owned],
             packed=True,

--- a/test/test_context_parallel_deterministic.py
+++ b/test/test_context_parallel_deterministic.py
@@ -1,0 +1,349 @@
+"""CP-degree-invariant KDA: canonical tiles give bitwise-equal results for any rank ownership.
+
+The reference for every case is a fresh single-process canonical run (CP=1) over the same tiles.
+Two-rank cases use NCCL when two GPUs exist, otherwise Gloo between two processes on one GPU (the
+transport carries FP32 maps bit-for-bit either way). Ownership tables cover contiguous, cyclic,
+uneven, and empty-rank layouts on ragged packed documents.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import socket
+from itertools import accumulate, pairwise
+from unittest.mock import patch
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+pytest.importorskip("cutlass")
+
+import attn_gym.linear.context_parallel_deterministic as det
+from attn_gym.linear.context_parallel_deterministic import (
+    CanonicalTiling,
+    Tile,
+    boundary_states,
+    canonical_scan,
+    tile_stream,
+)
+from attn_gym.linear.kda.context_parallel import _kda_stages, context_parallel_kda_deterministic
+from attn_gym.testing.kda import kda_reference, make_kda_test_inputs
+
+pytestmark = [
+    pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA"),
+    pytest.mark.xdist_group("two-gpu"),
+]
+
+HEADS, DIM = 4, 128
+RAGGED = (17, 65, 129, 257, 513)
+ELEPHANT = (800, 31, 33, 31, 33, 31, 33)
+NAMES = ("output", "dq", "dk", "dv", "dgate", "dbeta")
+
+
+# ---------------------------------------------------------------- planner (CPU)
+
+
+def test_tiles_align_to_document_starts_and_keep_tails():
+    cu = (0, *accumulate(RAGGED))
+    tiles = tile_stream(cu, 64)
+    assert [t.length for t in tiles if t.document == 0] == [17]
+    assert [t.length for t in tiles if t.document == 1] == [64, 1]
+    assert [t.length for t in tiles if t.document == 4] == [64] * 8 + [1]
+    assert all((t.start - cu[t.document]) % 64 == 0 for t in tiles)
+    assert tiles[-1].stop == cu[-1]
+
+
+def test_fragments_must_fall_on_tile_boundaries():
+    cu = (0, *accumulate(RAGGED))
+    CanonicalTiling.from_fragments(
+        cu, [[(0, 17), (82, 211)], [(17, 82), (211, 981)]], 0, tile_size=64
+    )
+    with pytest.raises(ValueError, match="tile boundaries"):
+        CanonicalTiling.from_fragments(cu, [[(0, 100)], [(100, 981)]], 0, tile_size=64)
+    with pytest.raises(ValueError, match="multiple of 64"):
+        CanonicalTiling.from_fragments(cu, [[(0, 981)], []], 0, tile_size=48)
+    with pytest.raises(ValueError, match="exactly once"):
+        CanonicalTiling.from_fragments(cu, [[(0, 17)], [(82, 981)]], 0, tile_size=64)
+    with pytest.raises(ValueError, match="reversed"):
+        CanonicalTiling.from_fragments(cu, [[(17, 0)], [(17, 981)]], 0, tile_size=64)
+    with pytest.raises(ValueError, match="outside"):
+        CanonicalTiling.from_fragments(cu, [[(0, 981)], []], 2, tile_size=64)
+
+
+def test_non_contiguous_ownership_keeps_span_order_consistent():
+    """A rank owning tiles from two places lists them in fragment order; ids follow that order."""
+    cu = (0, *accumulate(RAGGED))
+    fragments = [[(0, 17), (211, 981)], [(17, 211)]]
+    tiling = CanonicalTiling.from_fragments(cu, fragments, 0, tile_size=64)
+    ids = tiling.global_token_ids("cpu").tolist()
+    assert ids == list(range(17)) + list(range(211, 981))
+    offsets = tiling.span_offsets()
+    assert offsets[0] == 0 and offsets[-1] == len(ids)
+    assert [tiling.tiles[i].length for i in tiling.mine] == [b - a for a, b in pairwise(offsets)]
+
+
+def _serial_entries(leaves: torch.Tensor, documents: list[int]) -> torch.Tensor:
+    """Exclusive prefix bias per tile by serial composition, restarting at each document."""
+    from attn_gym.linear.context_parallel import compose_summaries
+
+    value_dim = leaves.shape[2] - leaves.shape[3]
+    entries = torch.zeros(leaves.shape[0], leaves.shape[1], value_dim, leaves.shape[3])
+    prefix = None
+    for i, doc in enumerate(documents):
+        if i == 0 or doc != documents[i - 1]:
+            prefix = leaves[i]
+        else:
+            entries[i] = prefix[:, :value_dim, :]
+            prefix = compose_summaries(prefix, leaves[i])
+    return entries
+
+
+def _leaves(n: int, seed: int) -> torch.Tensor:
+    torch.manual_seed(seed)
+    leaves = torch.randn(n, 2, 8, 4)
+    leaves[:, :, 4:, :] = torch.eye(4) + 0.01 * torch.randn(n, 2, 4, 4)
+    return leaves
+
+
+@pytest.mark.parametrize("documents", [[0] * 9, [0, 0, 0, 1, 2, 2, 2], [0, 1, 2, 3], [0] * 1])
+def test_scan_matches_serial_composition_per_document(documents):
+    """The Blelloch scan restarts at documents and equals serial composition (fp32 rounding)."""
+    leaves = _leaves(len(documents), 0)
+    tiles = [Tile(d, 0, 0) for d in documents]
+    torch.testing.assert_close(
+        boundary_states(leaves, tiles, reverse=False), _serial_entries(leaves, documents)
+    )
+    reversed_docs = documents[::-1]
+    expected = _serial_entries(leaves.flip(0), reversed_docs).flip(0)
+    torch.testing.assert_close(boundary_states(leaves, tiles, reverse=True), expected)
+
+
+def test_scan_of_a_document_is_independent_of_its_neighbours():
+    """A document's entry states are bitwise the same wherever it sits in the packed stream."""
+    document = _leaves(5, 1)
+    reference = None
+    for before, after in ((0, 0), (1, 0), (3, 2), (7, 5)):
+        others = _leaves(before + after, 2 + before)
+        leaves = torch.cat((others[:before], document, others[before:]))
+        tiles = [Tile(0, 0, 0)] * before + [Tile(1, 0, 0)] * 5 + [Tile(2, 0, 0)] * after
+        for reverse in (False, True):
+            entries = boundary_states(leaves, tiles, reverse=reverse)[before : before + 5]
+            key = (reverse,)
+            if reference is None:
+                reference = {}
+            if key not in reference:
+                reference[key] = entries
+            assert torch.equal(entries, reference[key]), (before, after, reverse)
+
+
+def test_scan_prefix_ignores_right_padding():
+    """Blelloch reads only positions <= j, so padding a row on the right never changes bits."""
+    row = _leaves(6, 3)
+    identity = torch.zeros(1, 2, 8, 4)
+    identity[:, :, 4:, :] = torch.eye(4)
+    base = canonical_scan(row[None])[0]
+    for pad in (1, 2, 5, 10):
+        padded = torch.cat((row, identity.expand(pad, -1, -1, -1)))
+        assert torch.equal(canonical_scan(padded[None])[0, :6], base)
+
+
+# ---------------------------------------------------------------- transports
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+_REAL_ALL_GATHER = dist.all_gather_into_tensor
+
+
+def _cpu_all_gather_into_tensor(gathered, packet, group=None):
+    """Gloo path: gather CPU copies, then place them into the CUDA output buffer."""
+    staging = torch.empty(gathered.shape, dtype=gathered.dtype)
+    _REAL_ALL_GATHER(staging, packet.cpu(), group=group)
+    gathered.copy_(staging)
+
+
+def _init(cp_rank: int, world: int, port: int) -> torch.device:
+    shared = torch.cuda.device_count() == 1
+    device = torch.device("cuda", 0 if shared else cp_rank)
+    torch.cuda.set_device(device)
+    os.environ.update(MASTER_ADDR="127.0.0.1", MASTER_PORT=str(port))
+    dist.init_process_group(
+        "gloo" if shared else "nccl",
+        rank=cp_rank,
+        world_size=world,
+        device_id=None if shared else device,
+    )
+    if shared:
+        patcher = patch.object(det.dist, "all_gather_into_tensor", _cpu_all_gather_into_tensor)
+        patcher.start()
+    return device
+
+
+# ---------------------------------------------------------------- canonical CP1 reference
+
+
+def _inputs(lengths, gate: str, seed: int, device):
+    torch.manual_seed(seed)
+    values = make_kda_test_inputs(
+        sum(lengths),
+        heads=HEADS,
+        seed=seed,
+        normalize_qk=True,
+        sigmoid_beta=True,
+        gate_scale=math.log(2) if gate == "strong" else 0.02,
+        log_uniform_gate=gate == "strong",
+        gate_value=0.0 if gate == "zero" else None,
+    )
+    values = tuple(v.to(device) for v in values)
+    return values, torch.randn_like(values[2])
+
+
+@torch.no_grad()
+def _canonical_cp1(inputs, grad, lengths, tile_size: int, kernel_options):
+    """Single-process canonical run over the same tiles: the contract every ownership reproduces.
+
+    Every tile is prepared by its own staged call (the strictest form of the leaf contract); the
+    batched production path must match this bitwise.
+    """
+    cu = (0, *accumulate(lengths))
+    tiles = tile_stream(cu, tile_size)
+    stages = _kda_stages(None, False, False, kernel_options)
+    device = inputs[0].device
+
+    def bounds(t):
+        return torch.tensor([[0, t.length]], dtype=torch.int32, device=device)
+
+    prepared = [
+        stages.prepare(*(v[:, t.start : t.stop] for v in inputs), cu_seqlens=None) for t in tiles
+    ]
+    maps = torch.cat(
+        [
+            p.state_summaries(bounds(t), deterministic_work=True)
+            for p, t in zip(prepared, tiles, strict=True)
+        ]
+    )
+    entries = boundary_states(maps, tiles, reverse=False)
+    outputs, backwards = [], []
+    for i, (p, t) in enumerate(zip(prepared, tiles, strict=True)):
+        outputs.append(p.run(entries[i : i + 1], output_final_state=False)[0])
+        backwards.append(
+            stages.prepare_backward(
+                p.saved, grad[:, t.start : t.stop], entries[i : i + 1], scale=p.scale
+            )
+        )
+    rmaps = torch.cat(
+        [
+            b.state_grad_summaries(bounds(t), deterministic_work=True)
+            for b, t in zip(backwards, tiles, strict=True)
+        ]
+    )
+    exits = boundary_states(rmaps, tiles, reverse=True)
+    grads = [b.run(exits[i : i + 1])[:5] for i, b in enumerate(backwards)]
+    return (
+        torch.cat(outputs, dim=1),
+        *(torch.cat([g[c] for g in grads], dim=1) for c in range(5)),
+    )
+
+
+def _bits_equal(actual: torch.Tensor, expected: torch.Tensor) -> int:
+    assert actual.shape == expected.shape and actual.dtype == expected.dtype
+    assert torch.isfinite(actual).all() and torch.isfinite(expected).all()
+    view = torch.int16 if actual.dtype == torch.bfloat16 else torch.int32
+    return int((actual.contiguous().view(view) != expected.contiguous().view(view)).sum())
+
+
+# ---------------------------------------------------------------- two-rank cases
+
+OWNERSHIPS = {
+    "contiguous": lambda cu, n: [[(0, cu[len(cu) // 2])], [(cu[len(cu) // 2], cu[-1])]],
+    "empty_rank": lambda cu, n: [[], [(0, cu[-1])]],
+}
+
+
+def _rank_main(cp_rank, world, port, lengths, tile_size, ownership, gate, backend):
+    device = _init(cp_rank, world, port)
+    try:
+        kernel_options = {"backend": backend} if backend != "fused" else None
+        inputs, grad = _inputs(lengths, gate, 97, device)
+        cu = (0, *accumulate(lengths))
+        expected = _canonical_cp1(inputs, grad, lengths, tile_size, kernel_options)
+        if ownership == "cyclic":
+            tiles = tile_stream(cu, tile_size)
+            fragments = [
+                [(t.start, t.stop) for i, t in enumerate(tiles) if i % 2 == r] for r in range(2)
+            ]
+        else:
+            fragments = OWNERSHIPS[ownership](cu, len(lengths))
+        tiling = CanonicalTiling.from_fragments(cu, fragments, cp_rank, tile_size=tile_size)
+        ids = tiling.global_token_ids(device)
+        local = tuple(v[:, ids].contiguous().requires_grad_() for v in inputs)
+        output = context_parallel_kda_deterministic(
+            *local, tiling=tiling, group=dist.group.WORLD, kernel_options=kernel_options
+        )
+        # Every rank runs the backward: its all-gather is a collective even for an empty rank.
+        grads = torch.autograd.grad(output, local, grad[:, ids])
+        mismatches = {
+            name: _bits_equal(a, e[:, ids])
+            for name, a, e in zip(NAMES, (output, *grads), expected, strict=True)
+        }
+        assert all(v == 0 for v in mismatches.values()), mismatches
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.parametrize("backend", ["fused", "mega"])
+@pytest.mark.parametrize("gate", ["strong", "mild", "zero"])
+@pytest.mark.parametrize(
+    "lengths,tile_size,ownership",
+    [
+        (RAGGED, 64, "contiguous"),
+        (RAGGED, 64, "cyclic"),
+        (RAGGED, 128, "empty_rank"),
+        (ELEPHANT, 64, "cyclic"),
+    ],
+    ids=["ragged-contig", "ragged-cyclic", "ragged-empty", "elephant-cyclic"],
+)
+def test_two_ranks_match_canonical_cp1_bitwise(lengths, tile_size, ownership, gate, backend):
+    if backend == "mega":
+        pytest.importorskip("cutlass.experimental")
+        if torch.cuda.get_device_capability() not in ((10, 0), (10, 3)):
+            pytest.skip("Mega needs SM100/103")
+    mp.spawn(
+        _rank_main,
+        args=(2, _free_port(), lengths, tile_size, ownership, gate, backend),
+        nprocs=2,
+        join=True,
+    )
+
+
+# ---------------------------------------------------------------- accuracy vs FP64
+
+
+def test_canonical_cp1_matches_fp64_reference_within_bf16_budget():
+    """The new contract is checked against an independent FP64 recurrence, not only self-consistency."""
+    lengths = (17, 65, 129)
+    inputs, grad = _inputs(lengths, "mild", 41, torch.device("cuda"))
+    inputs = tuple(v[:, :, :1].contiguous() for v in inputs)
+    grad = grad[:, :, :1].contiguous()
+    actual = _canonical_cp1(inputs, grad, lengths, 64, None)
+    cu = torch.tensor((0, *accumulate(lengths)), dtype=torch.int32, device="cuda")
+    high = tuple(v.detach().cpu().double().requires_grad_() for v in inputs)
+    out_high, _ = kda_reference(*high, cu_seqlens=cu.cpu(), output_final_state=False)
+    grads_high = torch.autograd.grad(out_high, high, grad.cpu().double())
+    low = tuple(v.detach().cpu().float().requires_grad_() for v in inputs)
+    out_low, _ = kda_reference(*low, cu_seqlens=cu.cpu(), output_final_state=False)
+    grads_low = torch.autograd.grad(out_low, low, grad.cpu().float())
+    for name, a, h, lo in zip(
+        NAMES, actual, (out_high, *grads_high), (out_low, *grads_low), strict=True
+    ):
+        err = (a.cpu().double() - h.double()).abs().max().item()
+        eager = (lo.double() - h.double()).abs().max().item()
+        budget = 2 * (eager + torch.finfo(torch.bfloat16).eps * h.abs().max().item())
+        assert err <= budget, f"{name}: {err} > {budget}"

--- a/test/test_delta_rule_stages.py
+++ b/test/test_delta_rule_stages.py
@@ -83,6 +83,21 @@ class Op(NamedTuple):
             return self.backward(
                 inputs, initial_state, cu_seqlens, d_output, d_final_state, scale=scale
             )
+        return self.public_gradients(
+            inputs, initial_state, cu_seqlens, d_output, d_final_state, scale=scale
+        )
+
+    def public_gradients(
+        self,
+        inputs: Inputs,
+        initial_state: torch.Tensor | None,
+        cu_seqlens: torch.Tensor | None,
+        d_output: torch.Tensor | None,
+        d_final_state: torch.Tensor | None,
+        *,
+        scale: float | None = None,
+    ) -> tuple[torch.Tensor, ...]:
+        """Gradients by autograd through the public ``chunk`` op, whatever backward it selects."""
         leaves = tuple(tensor.detach().clone().requires_grad_() for tensor in inputs)
         if initial_state is not None:
             leaves += (initial_state.detach().clone().requires_grad_(),)
@@ -434,6 +449,16 @@ def test_prepare_backward_run_matches_chunk_op_gradients(op, scale, loss, state,
         torch.testing.assert_close(
             got, want, atol=0, rtol=0, msg=lambda m, name=name: f"{name}: {m}"
         )
+    if op.backward is not None:
+        # The native kernel is not the public op's backward; it must still agree with it to
+        # within the two kernels' BF16 rounding (both are FP32-accumulated over the same graph).
+        public = op.public_gradients(
+            inputs, initial_state, cu_seqlens, d_output, d_final_state, scale=scale
+        )
+        for name, got, want in zip(names, actual, public, strict=True):
+            assert_relative_rms_within(
+                got.float(), want.float(), f"{name} vs public op", max_eps=4.0
+            )
 
 
 @requires_kda_target


### PR DESCRIPTION
Stacked PRs:
 * #519
 * #518
 * #517
 * #516
 * #515
 * #514
 * __->__#513
 * #512


--- --- ---

Add CP-degree-invariant KDA context parallelism over canonical tiles

context_parallel_chunk_deterministic (bound as context_parallel_kda_deterministic) fixes the
arithmetic graph before ranks are assigned. Every document is cut from its first token into
tiles of a fixed size (a multiple of 64; the last tile may be short); a rank prepares all its
tiles in one staged call with each tile a packed subsequence and builds one [bias; transition]
map per tile with deterministic_work=True; the maps are all-gathered and composed per document
with a work-efficient (Blelloch) scan whose tree depends only on the document's tile count, and
the backward mirrors it over the reverse maps. Rank ownership changes which leaves a rank
computes and nothing else, so CP=1 and CP=N are bitwise identical (output and all input
gradients), and a document's result does not depend on which other documents are packed around
it. This is a new numerical contract, distinct from the unsharded chunk_kda call; an FP64
reference test bounds its error with the repository's BF16 budget.

Tests cover fused and Mega forwards on ragged packed documents with contiguous, cyclic, and
empty-rank ownership across strong/mild/zero gates (bitwise against a per-tile CP=1 reference),
the planner's boundary/ownership validation, and the scan's packing- and padding-independence.
benchmarks/kda_cp_deterministic.py times CP=2 forward and backward against the standard recipe
and the unsharded op; on GB200 at 32k tokens / 64 heads the deterministic recipe costs about
3x/2x the standard one with 1024-token tiles (the map payload is 128 KiB per tile per head, so
the tile size is the performance knob). docs/linear.md documents the mode and corrects the
Mega-under-CP bitwise claim.