### PR TITLE
Build canonical Mega summaries with Mega's own kernels instead of the fused BT64 factors

### DIFF
--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_recompute_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_recompute_f16.py
@@ -361,7 +361,8 @@ def tmaldg_warp(
         desc_gate_slot = (desc_gate_base + slot).tospace(cutlass.AddressSpace.generic)
         if elect_one:
             tma_tensormap_acquire(desc_k_slot)
-            tma_tensormap_acquire(desc_v_slot)
+            if cutlass.const_expr(not cfg.transition_only):
+                tma_tensormap_acquire(desc_v_slot)
             tma_tensormap_acquire(desc_gate_slot)
         use_packed_coords = batch_end == packed_tokens
         for chunk_idx in cutlass.range(cstart, wend, 1, unroll=1):
@@ -389,13 +390,14 @@ def tmaldg_warp(
             tma_load_tile(sGate_tma[raw_index.idx], gate_slice, bars.mb_gate_ready[raw_index.idx].smem_ptr)
 
             # ---- V load ----------------------------------------------------------
-            bars.mb_v_done[raw_index.idx].wait(raw_index.phase)
-            if elect_one:
-                bars.mb_v_ready[raw_index.idx].arrive(n_bytes=cfg.tma_v_bytes)
-            v_slice = tma_slice_runtime_desc(
-                desc_v_slot, cutlass.Int32(0), head_v, input_chunk_start
-            )
-            tma_load_tile(sV_tma[raw_index.idx], v_slice, bars.mb_v_ready[raw_index.idx].smem_ptr)
+            if cutlass.const_expr(not cfg.transition_only):
+                bars.mb_v_done[raw_index.idx].wait(raw_index.phase)
+                if elect_one:
+                    bars.mb_v_ready[raw_index.idx].arrive(n_bytes=cfg.tma_v_bytes)
+                v_slice = tma_slice_runtime_desc(
+                    desc_v_slot, cutlass.Int32(0), head_v, input_chunk_start
+                )
+                tma_load_tile(sV_tma[raw_index.idx], v_slice, bars.mb_v_ready[raw_index.idx].smem_ptr)
 
             raw_index = advance(raw_index, cfg.smem_raw_stages)
         tile_idx, sched_state = sched_publish_next(cfg, bars, sSched, mSched, sched_state, tile_idx, num_ctas)
@@ -715,7 +717,7 @@ def tcgen05_mma_warp(
         num_chunks_tile = wend - cstart
         for local_chunk_idx in cutlass.range(num_chunks_tile, unroll=1):
             cum_chunk = cum_chunk_base + local_chunk_idx
-            have_state = cutlass.Boolean(True) if cutlass.const_expr(cfg.use_initial_state) else local_chunk_idx > 0
+            have_state = cutlass.Boolean(True) if cutlass.const_expr(cfg.use_initial_state or cfg.transition_only) else local_chunk_idx > 0
             decay_stage = k_decay_ready.idx
             state_scale_diag_stage = qk_scale_index.idx
             intermediate_stage = t_inv_ready.idx
@@ -1306,6 +1308,16 @@ def compute1_warp_group(
         if num_chunks_tile > 0:
             # ---- first chunk: seed state TMEM from mState_init ----------
             seed_from_initial_state = cstart == 0
+            if cutlass.const_expr(cfg.transition_only):
+                for key_block_start in cutlass.range_constexpr(0, cfg.d_k, 32):
+                    identity_block = cute.make_rmem_tensor((32,), cutlass.Float32)
+                    for col in cutlass.range_constexpr(32):
+                        identity_block[col] = (value_dim == key_block_start + col).to(cutlass.Float32)
+                    nvvm.tcgen05_st(
+                        "32x32b",
+                        nvvm.make_tmem_ptr((row_id << 16) + (tmem_col + cfg.tmem_state_acc_offset + key_block_start), cutlass.Float32),
+                        identity_block.load(),
+                    )
             if cutlass.const_expr(mState_init is not None):
                 if seed_from_initial_state:
                     seed_vw = 16 // (mState_init.element_type.width // 8)
@@ -1333,13 +1345,13 @@ def compute1_warp_group(
                             nvvm.make_tmem_ptr((row_id << 16) + (tmem_col + cfg.tmem_state_acc_offset + key_block_start), cutlass.Float32),
                             state_block.load(),
                         )
-            if cutlass.const_expr(mState_init is not None):
+            if cutlass.const_expr(mState_init is not None or cfg.transition_only):
                 nvvm.tcgen05_wait("store")
             sV_ptr = smem_data_ptr(sV_raw) + raw_index.idx * (cfg.d_v * cfg.b_t)
             sBeta_ptr = smem_data_ptr(sBeta_raw) + raw_index.idx * cfg.b_t
 
             # ---- state repack: acc TMEM -> packed b16 TMEM ----------------------
-            if cutlass.const_expr(mState_init is not None):
+            if cutlass.const_expr(mState_init is not None or cfg.transition_only):
                 state_vecs = []
                 for sub in cutlass.range_constexpr(cfg.d_k // 16):
                     state_vecs.append(nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(row_addr + state_col_id + sub * 16, cutlass.Float32), num=16))
@@ -1400,19 +1412,23 @@ def compute1_warp_group(
                     bars.mb_checkpoint_tmastg_ready[checkpoint_stage].arrive()
 
             # ---- Y staging: Y = Beta * (V - State*K) -----------------------------
-            bars.mb_v_ready[raw_index.idx].wait(raw_index.phase)
-            raw_v_frag0 = nvvm.ldmatrix(
-                sV_ptr + v_swz_off0,
-                4,
-                nvvm.MMALayout.COL,
-            )
-            raw_v_frag1 = nvvm.ldmatrix(
-                sV_ptr + v_swz_off,
-                4,
-                nvvm.MMALayout.COL,
-            )
+            if cutlass.const_expr(cfg.transition_only):
+                raw_v_frag0 = tuple(cutlass.Int32(0) for _ in range(4))
+                raw_v_frag1 = tuple(cutlass.Int32(0) for _ in range(4))
+            else:
+                bars.mb_v_ready[raw_index.idx].wait(raw_index.phase)
+                raw_v_frag0 = nvvm.ldmatrix(
+                    sV_ptr + v_swz_off0,
+                    4,
+                    nvvm.MMALayout.COL,
+                )
+                raw_v_frag1 = nvvm.ldmatrix(
+                    sV_ptr + v_swz_off,
+                    4,
+                    nvvm.MMALayout.COL,
+                )
             bars.mb_beta_ready[raw_index.idx].wait(raw_index.phase)
-            if cutlass.const_expr(mState_init is not None):
+            if cutlass.const_expr(mState_init is not None or cfg.transition_only):
                 bars.mb_state_k_acc_ready.wait(state_k_acc_index.phase)
 
                 state_k_vec0 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr(row_addr + statek_col_id, cutlass.Float32), num=2)
@@ -1427,7 +1443,7 @@ def compute1_warp_group(
             for reg_idx in cutlass.range_constexpr(4):
                 raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
                 frag_pair = (reg_idx ^ 2) * 2
-                if cutlass.const_expr(mState_init is not None):
+                if cutlass.const_expr(mState_init is not None or cfg.transition_only):
                     y_inp_pack0[reg_idx], _, _ = beta_residual_f16x2(
                         raw_v_frag0[raw_matrix],
                         beta_regs[2 * reg_idx],
@@ -1448,7 +1464,7 @@ def compute1_warp_group(
             for reg_idx in cutlass.range_constexpr(4):
                 raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
                 frag_pair = (reg_idx ^ 2) * 2
-                if cutlass.const_expr(mState_init is not None):
+                if cutlass.const_expr(mState_init is not None or cfg.transition_only):
                     y_inp_pack1[reg_idx], _, _ = beta_residual_f16x2(
                         raw_v_frag1[raw_matrix],
                         beta_regs[2 * reg_idx],
@@ -1468,9 +1484,10 @@ def compute1_warp_group(
             nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row_addr + y_inp_col_id, cutlass.Int8), y_inp_pack0.load())
             nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row16_addr + y_inp_col_id, cutlass.Int8), y_inp_pack1.load())
             nvvm.tcgen05_wait("store")
-            if cutlass.const_expr(mState_init is not None):
+            if cutlass.const_expr(mState_init is not None or cfg.transition_only):
                 state_k_acc_index = advance(state_k_acc_index, 1)
-            bars.mb_v_done[raw_index.idx].arrive()
+            if cutlass.const_expr(not cfg.transition_only):
+                bars.mb_v_done[raw_index.idx].arrive()
             bars.mb_beta_done[raw_index.idx].arrive()
             bars.mb_y_inp_ready.arrive()
 
@@ -1563,17 +1580,21 @@ def compute1_warp_group(
                     bars.mb_state_acc_read_done.arrive()
 
             # ---- Y staging: Y = Beta * (V - State*K) -----------------------------
-            bars.mb_v_ready[raw_index.idx].wait(raw_index.phase)
-            raw_v_frag0 = nvvm.ldmatrix(
-                sV_ptr + v_swz_off0,
-                4,
-                nvvm.MMALayout.COL,
-            )
-            raw_v_frag1 = nvvm.ldmatrix(
-                sV_ptr + v_swz_off,
-                4,
-                nvvm.MMALayout.COL,
-            )
+            if cutlass.const_expr(cfg.transition_only):
+                raw_v_frag0 = tuple(cutlass.Int32(0) for _ in range(4))
+                raw_v_frag1 = tuple(cutlass.Int32(0) for _ in range(4))
+            else:
+                bars.mb_v_ready[raw_index.idx].wait(raw_index.phase)
+                raw_v_frag0 = nvvm.ldmatrix(
+                    sV_ptr + v_swz_off0,
+                    4,
+                    nvvm.MMALayout.COL,
+                )
+                raw_v_frag1 = nvvm.ldmatrix(
+                    sV_ptr + v_swz_off,
+                    4,
+                    nvvm.MMALayout.COL,
+                )
             bars.mb_beta_ready[raw_index.idx].wait(raw_index.phase)
 
             # ---- read back State*K acc -------------------------------------------
@@ -1616,7 +1637,8 @@ def compute1_warp_group(
             nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row16_addr + y_inp_col_id, cutlass.Int8), y_inp_pack1.load())
             nvvm.tcgen05_wait("store")
             state_k_acc_index = advance(state_k_acc_index, 1)
-            bars.mb_v_done[raw_index.idx].arrive()
+            if cutlass.const_expr(not cfg.transition_only):
+                bars.mb_v_done[raw_index.idx].arrive()
             bars.mb_beta_done[raw_index.idx].arrive()
             bars.mb_y_inp_ready.arrive()
 
@@ -1681,7 +1703,9 @@ def compute1_warp_group(
                 for key_block_start in cutlass.range_constexpr(0, cfg.d_k, 32):
                     for col in cutlass.range_constexpr(32):
                         key_dim = key_block_start + col
-                        if cutlass.const_expr(mState_init is not None):
+                        if cutlass.const_expr(cfg.transition_only):
+                            mState_out[batch_idx, head_o, value_dim, key_dim] = (value_dim == key_dim).to(mState_out.element_type)
+                        elif cutlass.const_expr(mState_init is not None):
                             mState_out[batch_idx, head_o, value_dim, key_dim] = mState_init[batch_idx, head_o, value_dim, key_dim]
                         else:
                             mState_out[batch_idx, head_o, value_dim, key_dim] = cutlass.Float32(0.0).to(mState_out.element_type)
@@ -1715,6 +1739,7 @@ class KdaRecomputeOp:
             f"c{int(cfg.enable_checkpoints)}l{int(cfg.l2norm)}"
             f"g{int(cfg.safe_gate)}b{int(cfg.beta_sigmoid)}d{int(cfg.dyn_sched)}"
             f"_sm{cfg.max_active_clusters}_i64{int(self.use_int64_offsets)}{gate_scale}"
+            + ("_transition" if cfg.transition_only else "")
         )
 
     @cute.jit
@@ -1870,7 +1895,10 @@ def kernel(
         cute.make_layout((cfg.intermediate_cosize,))
     )
     sK_raw = storage.k.get_tensor(cute.make_layout((cfg.k_cosize,)))
-    sV_raw = storage.v.get_tensor(cute.make_layout((cfg.v_cosize,)))
+    sV_raw = (
+        sK_raw if cutlass.const_expr(cfg.transition_only)
+        else storage.v.get_tensor(cute.make_layout((cfg.v_cosize,)))
+    )
     sGate_raw = storage.gate.get_tensor(cute.make_layout((cfg.gate_cosize,)))
     sState_scale_diag_raw = storage.state_scale_diag.get_tensor(
         cute.make_layout((cfg.state_scale_diag_cosize,))
@@ -2105,6 +2133,7 @@ class KdaRecomputeCfg:
     n_heads_out: int
     max_active_clusters: int
     dyn_sched: bool = False
+    transition_only: bool = False
     sched_stages: int = CFG.SMEM_SCHED_STAGES
 
     compute_group_0_warp_ids: tuple[int, ...] = CFG.COMPUTE_GROUP_0_WARP_IDS
@@ -2179,6 +2208,7 @@ def build_cfg(
     n_heads_out: int,
     max_active_clusters: int,
     dyn_sched: bool = False,
+    transition_only: bool = False,
 ) -> KdaRecomputeCfg:
     """Build the per-compile ``KdaRecomputeCfg`` (io_dtype in {Float16, BFloat16});
     fills the derived TMEM column offsets and SMEM buffer cosizes."""
@@ -2199,6 +2229,7 @@ def build_cfg(
         n_heads_out=n_heads_out,
         max_active_clusters=max_active_clusters,
         dyn_sched=dyn_sched,
+        transition_only=transition_only,
     )
     if enable_checkpoints:
         cfg.smem_raw_stages = 6
@@ -2252,7 +2283,7 @@ def build_cfg(
     assert (cfg.tmem_u_inp_offset + (cfg.b_t // 2)) <= 512
 
     cfg.k_cosize = cfg.smem_raw_stages * cfg.d_k * cfg.b_t
-    cfg.v_cosize = cfg.smem_raw_stages * cfg.d_v * cfg.b_t
+    cfg.v_cosize = 0 if transition_only else cfg.smem_raw_stages * cfg.d_v * cfg.b_t
     cfg.gate_cosize = cfg.smem_raw_stages * cfg.d_k * cfg.b_t
     cfg.beta_cosize = cfg.smem_raw_stages * cfg.b_t
     cfg.k_inv_cosize = cfg.smem_decay_stages * cfg.b_t * cfg.d_k
@@ -2516,6 +2547,7 @@ def get_compiled_cache(
     device_major: int,
     device_minor: int,
     num_sm: int,
+    transition_only: bool = False,
 ):
     """Return a mutable dict that lazily stores the compiled kernel."""
     return {}
@@ -2539,6 +2571,7 @@ def compile(
     *,
     num_sm: int,
     checkpoint_every_n_tokens: int,
+    transition_only: bool = False,
 ):
     """JIT-compile one fake-tensor TVM-FFI recompute signature."""
     cfg = build_cfg(
@@ -2556,6 +2589,7 @@ def compile(
         n_heads_out=n_heads_out,
         max_active_clusters=num_sm,
         dyn_sched=dyn_sched,
+        transition_only=transition_only,
     )
     op = KdaRecomputeOp(cfg, use_int64_offsets)
     sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
@@ -2623,6 +2657,7 @@ def chunk_kda_recompute_sm100(
     order_in_prologue: bool = False,
     *,
     tensormap_workspace,
+    transition_only: bool = False,
 ) -> None:
     """Execute the Blackwell BT=16 chunked KDA recompute (state/checkpoints-only)
     kernel.
@@ -2633,7 +2668,7 @@ def chunk_kda_recompute_sm100(
 
     Args:
         k: ``(total_tokens, HK, DK)`` float16/bfloat16
-        v: ``(total_tokens, HV, DV)`` float16/bfloat16
+        v: ``(total_tokens, HV, DV)`` float16/bfloat16; ignored for transition_only
         gate: ``(total_tokens, HO, DK)`` float32.  Natural-log decay unless
               ``safe_gate``, which applies the safe-gate transform
               ``lower_bound * sigmoid(exp(a_log) * (gate + dt_bias))``.
@@ -2650,6 +2685,9 @@ def chunk_kda_recompute_sm100(
         output_state_checkpoints: ``(total_checkpoints, HO, DV, DK)`` io-dtype (VK, K
             contiguous); per-sequence entry offsets are derived on device from
             ``cu_seqlens``, so there is no separate checkpoint-offset tensor.
+        transition_only: seed identity on chip and use zero V, defining the native approximate
+            right transition in ``state_next = state @ A + B``. Requires unsplit work items,
+            no initial state/checkpoints and a final-state output.
         use_qk_l2norm_in_kernel: L2-normalize k rows inside the kernel
         safe_gate: interpret ``gate`` through the safe-gate transform
         a_log: ``(HO,)`` float32, safe-gate per-head log-amplitude (None = 0)
@@ -2665,6 +2703,11 @@ def chunk_kda_recompute_sm100(
             every launch (``build_split_table`` does this when it is passed as
             ``sched_ctr``).  None keeps the static CTA stride.
     """
+    if transition_only:
+        if initial_state is not None or checkpoint_every_n_tokens or output_state is None:
+            raise ValueError("transition_only requires final state, no initial state or checkpoints")
+        # Keep the tensor ABI, but never read V or allocate its SMEM ring.
+        v = k
     for name, tensor in (("k", k), ("v", v), ("gate", gate)):
         validate_tma_tensor(name, tensor)
     for name, tensor in (
@@ -2782,6 +2825,7 @@ def chunk_kda_recompute_sm100(
         device_properties.major,
         device_properties.minor,
         num_sm,
+        transition_only,
     )
 
     io_dtype = get_dtype(k.dtype)
@@ -2803,6 +2847,7 @@ def chunk_kda_recompute_sm100(
             use_int64_offsets,
             num_sm=num_sm,
             checkpoint_every_n_tokens=checkpoint_every_n_tokens,
+            transition_only=transition_only,
         )
 
     if "prologue" not in cache:

--- a/attn_gym/linear/_delta_rule/mega/state_summary.py
+++ b/attn_gym/linear/_delta_rule/mega/state_summary.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Native BT16 affine probes for canonical Mega context-parallel tiles.
+
+B is the no-state final state; A is the identity-seeded, zero-value final state. Native
+state/operand rounding makes this an approximate affine map, not bitwise reconstruction of
+an ordinary unsharded Mega run. Fixed whole-sequence work items define the canonical baseline.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from attn_gym._backends.cute.utils import initialized_cuda_device
+from attn_gym.utils import ceildiv
+
+from .forward import validate_available
+from .kernels import kda_recompute_f16
+from .kernels.common.host import tensormap_workspace_bytes
+from .schedule import prepare_mega_schedule
+
+
+def build_mega_state_summaries(
+    k: torch.Tensor,
+    value: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+) -> torch.Tensor:
+    """Return FP32 ``[N, H, 256, 128]`` maps packed as ``[B; A]`` for whole sequences.
+
+    Inputs use the staged ``[1, T, H, 128]`` layout, with FP32 gate/beta and already
+    normalized keys. Each packed sequence is one canonical tile. Both passes are unsplit,
+    independent of packed token count or ownership; empty sequences return ``[0; I]``.
+    The transition pass synthesizes identity and zero values on chip, without reading V.
+    """
+    validate_available(k)
+    if k.ndim != 4 or k.shape[0] != 1 or k.shape[-1] != 128:
+        raise ValueError("k must have shape [1, T, H, 128]")
+    if value.shape != k.shape or gate.shape != k.shape or beta.shape != k.shape[:3]:
+        raise ValueError("value, gate, and beta must match k's token and head extents")
+    if k.dtype not in (torch.float16, torch.bfloat16) or value.dtype != k.dtype:
+        raise TypeError("k and value must share dtype float16 or bfloat16")
+    if gate.dtype != torch.float32 or beta.dtype != torch.float32:
+        raise TypeError("gate and beta must be float32")
+    if any(t.device != k.device for t in (value, gate, beta, cu_seqlens)):
+        raise ValueError("all inputs must be on k.device")
+
+    with initialized_cuda_device(k):
+        num_sequences, heads = cu_seqlens.shape[0] - 1, k.shape[2]
+        summaries = torch.zeros(
+            num_sequences, heads, 256, 128, dtype=torch.float32, device=k.device
+        )
+        summaries[:, :, 128:, :].diagonal(dim1=-2, dim2=-1).fill_(1)
+        if k.shape[1] == 0:
+            return summaries
+        schedule = prepare_mega_schedule(
+            gate,
+            cu_seqlens,
+            tile_tokens=16,
+            counter_count=2,
+            split=False,
+            stream=torch.cuda.current_stream(k.device).cuda_stream,
+        )
+        workspace = torch.empty(
+            ceildiv(tensormap_workspace_bytes(kda_recompute_f16, num_sequences), 8),
+            dtype=torch.int64,
+            device=k.device,
+        )
+        for transition_only in (False, True):
+            kda_recompute_f16.chunk_kda_recompute_sm100(
+                k[0],
+                None if transition_only else value[0],
+                gate[0],
+                beta[0],
+                cu_seqlens,
+                initial_state=None,
+                output_state=summaries[:, :, 128:, :]
+                if transition_only
+                else summaries[:, :, :128, :],
+                work_items=schedule.work_items,
+                work_count=schedule.work_count,
+                sched_ctr=schedule.counters,
+                sched_all=schedule.counters,
+                order_in_prologue=True,
+                tensormap_workspace=workspace,
+                transition_only=transition_only,
+            )
+        return summaries

--- a/attn_gym/linear/kda/stages.py
+++ b/attn_gym/linear/kda/stages.py
@@ -197,11 +197,11 @@ class ChunkKDAPrepared:
 
 @dataclass
 class ChunkKDAMegaPrepared:
-    """Mega forward handle: on-chip factors for ``run``, fused factors only for summaries.
+    """Mega forward handle with native whole-sequence summaries for canonical CP.
 
-    Mega never materializes the WY factors, so ``run`` executes the Mega with-state kernel over the
-    whole local stream and ``state_summaries`` computes the fused factors once for the whole stream
-    (its ranges are device values). The backward handle is :class:`ChunkKDAMegaBackward`.
+    ``deterministic_work=True`` uses native BT16 state probes, without materializing WY factors.
+    Arbitrary chunk-aligned ranges retain the fused summary path. The backward handle is
+    :class:`ChunkKDAMegaBackward`.
     """
 
     saved: ChunkKDAMegaSaved
@@ -214,13 +214,24 @@ class ChunkKDAMegaPrepared:
     def state_summaries(
         self, bounds: torch.Tensor, *, deterministic_work: bool = False
     ) -> torch.Tensor:
-        """Return one FP32 ``[HV, V + K, K]`` map per row of ``bounds`` in a single launch.
+        """Return FP32 ``[B; A]`` maps, using native probes for canonical whole sequences.
 
-        Mega keeps no WY factors, so this factors the whole local stream once (the fused
-        forward's factor half) and summarizes every range from it; see
-        ``ChunkKDAPrepared.state_summaries`` for the contract.
+        With ``deterministic_work=True``, bounds must be exactly the consecutive pairs of
+        ``saved.cu_seqlens``, in order. Values are a caller contract (no device-to-host sync).
+        Native BT16 rounding defines a new canonical baseline, not unsharded Mega bit parity.
+        Otherwise arbitrary chunk-aligned bounds use the fused summary contract described by
+        ``ChunkKDAPrepared.state_summaries``.
         """
         saved = self.saved
+        if deterministic_work:
+            # Lazy import keeps the optional CuTeDSL 4.7 backend out of the fused import path.
+            from attn_gym.linear._delta_rule.mega.state_summary import build_mega_state_summaries
+
+            if bounds.shape != (saved.cu_seqlens.shape[0] - 1, 2):
+                raise ValueError("native Mega summaries require one bound per whole subsequence")
+            return build_mega_state_summaries(
+                saved.k, saved.v, saved.gate, saved.beta, saved.cu_seqlens
+            )
         factors = _prepare_chunk_kda_fwd(
             saved.q,
             saved.k,
@@ -286,8 +297,9 @@ def chunk_kda_prepare(
     float16 or bfloat16 dtype (no silent cast, because the caller owns autograd), and the batch
     dimension must be one so token offsets index one packed span (NOTE [Terminology] in
     ``attn_gym.linear.context_parallel``).
-    ``kernel_options={"backend": "mega"}`` runs the local pass with Mega and computes fused factors
-    only for the summaries; the split schedules are not available with entry states.
+    ``kernel_options={"backend": "mega"}`` runs the local pass with Mega; canonical whole-sequence
+    summaries (``deterministic_work=True``) also use Mega, while arbitrary-range summaries retain
+    fused factors. Split schedules are not available with entry states.
     """
     backend, split_backward, split_forward, schedule = resolve_kernel_options(kernel_options)
     if split_backward or split_forward:

--- a/test/kda/mega/test_kda_mega_native_summary.py
+++ b/test/kda/mega/test_kda_mega_native_summary.py
@@ -1,0 +1,171 @@
+"""Native Mega affine probes define an ownership-invariant canonical CP baseline."""
+
+from __future__ import annotations
+
+from itertools import pairwise
+
+import pytest
+import torch
+
+pytest.importorskip("cutlass.experimental", reason="native Mega summaries require CuTeDSL 4.7")
+
+from attn_gym.linear._delta_rule.mega.kernels import kda_prefill_f16
+from attn_gym.linear._delta_rule.mega.kernels.common.host import tensormap_workspace_bytes
+from attn_gym.linear._delta_rule.mega.schedule import prepare_mega_schedule
+from attn_gym.linear._delta_rule.mega.state_summary import build_mega_state_summaries
+from attn_gym.linear.context_parallel import merge_state
+from attn_gym.linear.kda.stages import chunk_kda_prepare
+from attn_gym.testing.kda import (
+    assert_matches_low_precision_reference,
+    clone_kda_inputs,
+    cumulative_sequence_offsets,
+    kda_reference,
+    make_kda_test_inputs,
+)
+from attn_gym.utils import ceildiv
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() not in ((10, 0), (10, 3)),
+    reason="native Mega summaries require SM100 or SM103",
+)
+
+
+def _native_no_state_final(
+    inputs: tuple[torch.Tensor, ...], cu_seqlens: torch.Tensor
+) -> torch.Tensor:
+    """Run the output-producing native no-state specialization as an independent B oracle."""
+    q, k, value, gate, beta = inputs
+    sequences = cu_seqlens.numel() - 1
+    state = torch.zeros(sequences, q.shape[2], 128, 128, device=q.device)
+    schedule = prepare_mega_schedule(
+        gate,
+        cu_seqlens,
+        tile_tokens=16,
+        counter_count=2,
+        split=False,
+        stream=torch.cuda.current_stream().cuda_stream,
+    )
+    workspace = torch.empty(
+        ceildiv(tensormap_workspace_bytes(kda_prefill_f16, sequences), 8),
+        device=q.device,
+        dtype=torch.int64,
+    )
+    kda_prefill_f16.chunk_kda_sm100(
+        q[0],
+        k[0],
+        value[0],
+        gate[0],
+        beta[0],
+        torch.empty_like(value[0]),
+        cu_seqlens,
+        None,
+        state,
+        128**-0.5,
+        work_items=schedule.work_items,
+        work_count=schedule.work_count,
+        sched_ctr=schedule.counters,
+        tensormap_workspace=workspace,
+    )
+    return state
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_native_bias_matches_no_state_final_bitwise(dtype: torch.dtype) -> None:
+    lengths = [17, 0, 65, 129]
+    inputs = make_kda_test_inputs(sum(lengths), dtype=dtype, gate_scale=0.02, normalize_qk=True)
+    cu = cumulative_sequence_offsets(lengths)
+    maps = build_mega_state_summaries(*inputs[1:], cu)
+    expected = _native_no_state_final(inputs, cu)
+    assert torch.equal(maps[:, :, :128].contiguous().view(torch.int32), expected.view(torch.int32))
+    torch.testing.assert_close(maps[1, 0, 128:], torch.eye(128, device="cuda"), rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("gate_value,beta_value", [(0.0, None), (-0.002, 0.0), (-0.02, 1.0)])
+def test_native_transition_matches_basis_reference(
+    dtype: torch.dtype, gate_value: float, beta_value: float | None
+) -> None:
+    inputs = list(make_kda_test_inputs(17, dtype=dtype, gate_value=gate_value, normalize_qk=True))
+    if beta_value is not None:
+        inputs[-1].fill_(beta_value)
+    cu = cumulative_sequence_offsets([17])
+    actual = build_mega_state_summaries(*inputs[1:], cu)[:, :, 128:]
+    inputs[2] = torch.zeros_like(inputs[2])
+    references = []
+    for precision in (torch.float64, torch.float32):
+        # Every V row carries a different basis vector e_i: the final rows are A, not A.T.
+        basis = torch.eye(128, device="cuda", dtype=precision)[None, None]
+        _, final = kda_reference(*clone_kda_inputs(inputs, dtype=precision), basis)
+        assert final is not None
+        references.append(final)
+    assert_matches_low_precision_reference(actual, *references, "transition A", source_dtype=dtype)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_native_two_tile_composition_matches_reference(dtype: torch.dtype, monkeypatch) -> None:
+    inputs = make_kda_test_inputs(128, dtype=dtype, gate_scale=0.02, normalize_qk=True)
+    cu = cumulative_sequence_offsets([64, 64])
+    prepared = chunk_kda_prepare(
+        *inputs, cu_seqlens=cu, autotune=False, kernel_options={"backend": "mega"}
+    )
+    monkeypatch.setattr(
+        "attn_gym.linear.kda.stages._prepare_chunk_kda_fwd",
+        lambda *args, **kwargs: pytest.fail("native summaries must not prepare fused factors"),
+    )
+    bounds = torch.tensor([[0, 64], [64, 128]], device="cuda", dtype=torch.int32)
+    maps = prepared.state_summaries(bounds, deterministic_work=True)
+    entry0 = torch.zeros_like(maps[0, :, :128])
+    entry1 = merge_state(entry0, maps[0])
+    output, final = prepared.run(torch.stack((entry0, entry1)), output_final_state=True)
+    assert final is not None
+    composed_final = merge_state(entry1, maps[1])
+    high_output, high_final = kda_reference(*clone_kda_inputs(inputs, dtype=torch.float64))
+    low_output, low_final = kda_reference(*clone_kda_inputs(inputs, dtype=torch.float32))
+    assert high_final is not None and low_final is not None
+    assert_matches_low_precision_reference(
+        output, high_output, low_output, "two-tile output", source_dtype=dtype
+    )
+    for name, actual in (("native final", final[-1:]), ("composed final", composed_final[None])):
+        assert_matches_low_precision_reference(
+            actual, high_final, low_final, name, source_dtype=dtype
+        )
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_native_summary_ownership_is_bitwise_invariant(dtype: torch.dtype) -> None:
+    lengths = [17, 0, 65, 129]
+    inputs = make_kda_test_inputs(sum(lengths), dtype=dtype, gate_scale=0.02, normalize_qk=True)
+    cu = cumulative_sequence_offsets(lengths)
+    packed = build_mega_state_summaries(*inputs[1:], cu)
+    for index, (start, stop) in enumerate(pairwise(cu.tolist())):
+        alone = build_mega_state_summaries(
+            *(tensor[:, start:stop] for tensor in inputs[1:]),
+            cumulative_sequence_offsets([stop - start]),
+        )
+        assert torch.equal(packed[index : index + 1].view(torch.int32), alone.view(torch.int32))
+
+
+def test_native_summary_persistent_waves_are_bitwise_invariant() -> None:
+    """Exercise more than four nonempty work items per physical CTA, including empty tiles."""
+    lengths = [17, 0, 65, 129]
+    repeats = 4 * torch.cuda.get_device_properties(0).multi_processor_count // 3 + 1
+    inputs = make_kda_test_inputs(sum(lengths), gate_scale=0.02, normalize_qk=True)[1:]
+    expected = build_mega_state_summaries(*inputs, cumulative_sequence_offsets(lengths))
+    repeated = tuple(tensor.repeat(1, repeats, *([1] * (tensor.ndim - 2))) for tensor in inputs)
+    cu = cumulative_sequence_offsets(lengths * repeats)
+    for _ in range(2):
+        actual = build_mega_state_summaries(*repeated, cu).reshape(repeats, *expected.shape)
+        assert torch.equal(
+            actual.view(torch.int32), expected[None].expand_as(actual).view(torch.int32)
+        )
+
+
+def test_native_summary_cuda_graph_replay() -> None:
+    inputs = make_kda_test_inputs(81, gate_scale=0.02, normalize_qk=True)
+    cu = cumulative_sequence_offsets([17, 0, 64])
+    expected = build_mega_state_summaries(*inputs[1:], cu)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        actual = build_mega_state_summaries(*inputs[1:], cu)
+    graph.replay()
+    assert torch.equal(actual.view(torch.int32), expected.view(torch.int32))


### PR DESCRIPTION
Stacked PRs:
 * #519
 * #518
 * #517
 * #516
 * #515
 * __->__#514
 * #513
 * #512


--- --- ---

Build canonical Mega summaries with Mega's own kernels instead of the fused BT64 factors

Under the deterministic CP recipe the Mega forward handle used to recompute the fused BT64
factors just to produce its per-tile [bias; transition] maps. It now runs two unsplit native
recompute passes per tile: the existing no-state state-only pass gives the bias, and a new
transition_only specialization of kda_recompute_f16 (identity seeded in TMEM, synthetic zero
values through the existing residual path, V loads and their handshakes compiled out) gives
the transition. The existing recompute specializations are bitwise unchanged (8/8 configs vs
the previous commit). Arbitrary-range summaries and the reverse summaries still use the fused
factors. The summary phase at 32k tokens / 64 heads drops from 4.20 to 1.93 ms (graph replay,
1024-token tiles); this is a new canonical Mega-CP baseline, validated against FP64 basis
states and the repository's low-precision budget, and bitwise invariant to tile ownership.