### PR TITLE
Fuse the canonical scan into one launch and cut the recipe's fixed costs

### DIFF
--- a/attn_gym/linear/_delta_rule/triton/canonical_scan.py
+++ b/attn_gym/linear/_delta_rule/triton/canonical_scan.py
@@ -1,0 +1,134 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Fused per-document prefix of affine state maps for the deterministic CP recipe.
+
+The maps are ``[N, H, V + K, K]`` packed ``[bias; transition]`` (see
+``attn_gym.linear.context_parallel``). Tile ``i`` of a document enters with the bias of the
+composition of all earlier tiles' maps. Composition right-multiplies by the next transition,
+``(A0, B0) ∘ (A1, B1) = (A0 @ A1, B0 @ A1 + B1)``, so the running bias steps as
+``B @ A_tile + B_tile`` and every row depends only on the same row before it: a program owns
+``BM`` bias rows and walks its document's tiles serially with one ``[BM, K] @ [K, K]`` dot per
+tile, storing the rows before each step. The running transition is never needed, there are no
+intermediate buffers, and the whole scan is one launch.
+
+The tree is the serial fold in three-pass TF32 (``tf32x3``, fp32-accurate), the same arithmetic
+``compose_work_items`` uses. It is a fixed function of the document's tile count, so the result
+does not depend on which rank produced a leaf, on the document's position in the packed stream,
+or on the CP degree.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from attn_gym.linear._delta_rule.triton.work_items import compose_work_items
+
+
+@triton.jit
+def canonical_scan_kernel(
+    maps,
+    doc_offsets,
+    initial,
+    entries,
+    HAS_INITIAL: tl.constexpr,
+    H: tl.constexpr,
+    V: tl.constexpr,
+    K: tl.constexpr,
+    BM: tl.constexpr,
+    REVERSE: tl.constexpr,
+):
+    """Entry states of one document, one head, ``BM`` rows of the ``[V, K]`` state.
+
+    ``doc_offsets[d]:doc_offsets[d + 1]`` are the tile ids of document ``d``, contiguous in
+    tile order; ``REVERSE`` walks them from the last tile (the exit-cotangent scan). The fold
+    starts from ``initial[d]`` (``[D, H, V, K]``) when ``HAS_INITIAL``, else from zero.
+    """
+    doc = tl.program_id(0)
+    head = tl.program_id(1).to(tl.int64)
+    row0 = tl.program_id(2) * BM
+    rows = row0 + tl.arange(0, BM)
+    cols = tl.arange(0, K)
+    first = tl.load(doc_offsets + doc)
+    stop = tl.load(doc_offsets + doc + 1)
+
+    if HAS_INITIAL:
+        acc = tl.load(
+            initial + (doc.to(tl.int64) * H + head) * V * K + rows[:, None] * K + cols[None, :]
+        )
+    else:
+        acc = tl.zeros([BM, K], dtype=tl.float32)  # entry state of the first tile
+    for step in tl.range(0, stop - first, num_stages=2):
+        if REVERSE:
+            tile = stop - 1 - step
+        else:
+            tile = first + step
+        base = maps + (tile.to(tl.int64) * H + head) * (V + K) * K
+        tl.store(
+            entries + (tile.to(tl.int64) * H + head) * V * K + rows[:, None] * K + cols[None, :],
+            acc,
+        )
+        transition = tl.load(base + (V + cols[:, None]) * K + cols[None, :])  # [K, K]
+        bias = tl.load(base + rows[:, None] * K + cols[None, :])
+        acc = tl.dot(acc, transition, input_precision="tf32x3") + bias
+
+
+def canonical_scan_entries(
+    maps: torch.Tensor,
+    doc_offsets: torch.Tensor,
+    *,
+    reverse: bool = False,
+    initial: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Entry state ``[N, H, V, K]`` of every tile from one fused per-document serial scan.
+
+    ``maps`` are ``[N, H, V + K, K]`` FP32 in tile order (tiles of one document contiguous);
+    ``doc_offsets`` is ``int32 [D + 1]`` on the device. ``reverse`` folds each document from its
+    last tile, giving exit cotangents from reverse maps. The first tile folded receives
+    ``initial[d]`` (``[D, H, V, K]``) or zero. One launch covers every document, head, and row
+    tile.
+    """
+    count, heads, packed, key_dim = maps.shape
+    value_dim = packed - key_dim
+    entries = torch.empty(
+        count, heads, value_dim, key_dim, dtype=torch.float32, device=maps.device
+    )
+    block_rows = 16
+    documents = doc_offsets.shape[0] - 1
+    canonical_scan_kernel[(documents, heads, value_dim // block_rows)](
+        maps.contiguous(),
+        doc_offsets,
+        entries if initial is None else initial.contiguous(),
+        entries,
+        HAS_INITIAL=initial is not None,
+        H=heads,
+        V=value_dim,
+        K=key_dim,
+        BM=block_rows,
+        REVERSE=reverse,
+        num_warps=8,
+    )
+    return entries
+
+
+def fold_ranges(maps: torch.Tensor, offsets: torch.Tensor, *, reverse: bool) -> torch.Tensor:
+    """Fold each range ``offsets[r]:offsets[r + 1]`` of ``[N, H, V + K, K]`` maps into one map.
+
+    The left-to-right (or right-to-left when ``reverse``) serial fold in three-pass TF32 of
+    ``compose_work_items``; an empty range gives the identity. Used to reduce a block of tiles to
+    one map before it crosses ranks (NOTE [Scan Blocks] in ``context_parallel_deterministic``).
+    """
+    ranges = offsets.shape[0] - 1
+    lengths = offsets[1:] - offsets[:-1]
+    range_ids = torch.repeat_interleave(
+        torch.arange(ranges, device=maps.device, dtype=torch.int32), lengths
+    )
+    return compose_work_items(maps.contiguous(), range_ids, ranges, reverse=reverse)
+
+
+__all__ = ["canonical_scan_entries", "fold_ranges"]

--- a/attn_gym/linear/context_parallel_deterministic.py
+++ b/attn_gym/linear/context_parallel_deterministic.py
@@ -17,11 +17,25 @@ the whole arithmetic graph before ranks are assigned:
               multiple of the 64-token summary chunk and is part of the numerical contract.
     leaf map  every tile's ``[bias; transition]`` forward map and ``[C; R]`` reverse map, computed
               by the staged op on that tile alone (no other tile's tokens are visible).
-    scan      per document, a work-efficient (Blelloch) inclusive prefix over the leaf maps in
-              tile order (forward) and reverse tile order (backward). The prefix at tile ``j`` is
-              a function of that document's leaves ``0..j`` and of ``j`` alone.
+    scan      per document, a left-to-right serial fold of the leaf maps in tile order
+              (forward) and reverse tile order (backward), in three-pass TF32 (fp32-accurate),
+              fused in one launch. The state entering tile ``j`` is a function of that
+              document's leaves ``0..j-1`` alone.
     entry     ``merge_state(0, prefix[i - 1])`` for tile ``i``; the first tile of a document enters
               with zero. Exits are the reverse analogue.
+
+NOTE [Scan Blocks]
+Exchanging every tile's map costs 128 KiB per tile per head per rank. Consecutive tiles of a
+document are therefore grouped into blocks of ``scan_block`` tiles (document-relative, the last
+block of a document may be short); only block maps cross ranks. A block map is the serial fold
+of its tiles' maps, the per-document scan runs over block maps, and each rank folds its own
+tiles from the block entry state. Every operation is a function of tile indices only, so the
+tree is still fixed; it is a different tree from the flat fold (``scan_block=1``), hence a
+different numerical contract, and ``scan_block`` is part of the recipe. Ranks must own whole
+blocks (a block split across ranks would need its tiles exchanged); block-aligned fragments make
+the exchange ``scan_block`` times smaller with identical bits. The block folds cost about as much
+as a full scan, so blocks pay off only when the gather dominates (many ranks, slow interconnect,
+many tiles per rank); on two NVLink GPUs ``scan_block=1`` is faster and is the default.
 
 Ranks own whole tiles; ownership changes which leaves a rank computes and where the scan runs,
 never the leaf arithmetic or the tree. The result for CP=1 with this recipe is therefore bitwise
@@ -45,7 +59,8 @@ import torch
 import torch.distributed as dist
 
 from attn_gym._backends.profiler import profiler_range
-from attn_gym.linear.context_parallel import StagedOp, _ieee_fp32_matmul
+from attn_gym.linear._delta_rule.triton.canonical_scan import canonical_scan_entries, fold_ranges
+from attn_gym.linear.context_parallel import StagedOp
 
 SUMMARY_CHUNK = 64
 
@@ -70,11 +85,13 @@ class CanonicalTiling:
         tiles: Every tile of the stream in global token order.
         owned: ``owned[rank]`` lists the tile ids that rank computes, in its span order.
         cp_rank: This rank.
+        scan_block: Tiles per exchanged block (NOTE [Scan Blocks]); 1 exchanges every tile.
     """
 
     tiles: tuple[Tile, ...]
     owned: tuple[tuple[int, ...], ...]
     cp_rank: int
+    scan_block: int = 1
 
     @classmethod
     def from_fragments(
@@ -84,15 +101,20 @@ class CanonicalTiling:
         cp_rank: int,
         *,
         tile_size: int,
+        scan_block: int = 1,
     ) -> CanonicalTiling:
         """Tile the stream and assign whole tiles to the ranks that own their tokens.
 
         ``fragments[rank]`` are that rank's global token ranges. Every fragment boundary must fall
         on a tile boundary (a document boundary or ``doc_start + k * tile_size``), otherwise the
         ownership would cut a tile and the leaf arithmetic would depend on the fragment table.
+        With ``scan_block > 1`` the boundaries must fall on block boundaries
+        (``doc_start + k * scan_block * tile_size``) for the same reason (NOTE [Scan Blocks]).
         """
         if tile_size <= 0 or tile_size % SUMMARY_CHUNK:
             raise ValueError(f"tile_size must be a positive multiple of {SUMMARY_CHUNK}")
+        if scan_block <= 0:
+            raise ValueError("scan_block must be positive")
         if not 0 <= cp_rank < len(fragments):
             raise ValueError(f"cp_rank {cp_rank} is outside a table of {len(fragments)} ranks")
         tiles = tile_stream(cu_seqlens_global, tile_size)
@@ -116,7 +138,41 @@ class CanonicalTiling:
         seen = sorted(index for ids in owned for index in ids)
         if seen != list(range(len(tiles))):
             raise ValueError("fragments must cover every tile exactly once")
-        return cls(tiles=tuple(tiles), owned=tuple(tuple(ids) for ids in owned), cp_rank=cp_rank)
+        tiling = cls(
+            tiles=tuple(tiles),
+            owned=tuple(tuple(ids) for ids in owned),
+            cp_rank=cp_rank,
+            scan_block=scan_block,
+        )
+        owner = {index: rank for rank, ids in enumerate(owned) for index in ids}
+        for block in tiling.blocks:
+            if len({owner[index] for index in block}) != 1:
+                raise ValueError(
+                    f"tiles {block[0]}..{block[-1]} form one scan block but are owned by "
+                    "several ranks; cut fragments on block boundaries or use scan_block=1"
+                )
+        return tiling
+
+    @property
+    def blocks(self) -> tuple[tuple[int, ...], ...]:
+        """Tile ids of every scan block, in tile order (NOTE [Scan Blocks])."""
+        blocks: list[tuple[int, ...]] = []
+        start = 0
+        for index in range(1, len(self.tiles) + 1):
+            if (
+                index == len(self.tiles)
+                or self.tiles[index].document != self.tiles[start].document
+            ):
+                for begin in range(start, index, self.scan_block):
+                    blocks.append(tuple(range(begin, min(begin + self.scan_block, index))))
+                start = index
+        return tuple(blocks)
+
+    @property
+    def my_blocks(self) -> tuple[int, ...]:
+        """Ids (into ``blocks``) of the blocks this rank owns, in its span order."""
+        first_tile = {block[0]: b for b, block in enumerate(self.blocks)}
+        return tuple(first_tile[index] for index in self.mine if index in first_tile)
 
     @property
     def mine(self) -> tuple[int, ...]:
@@ -124,8 +180,9 @@ class CanonicalTiling:
 
     @property
     def slots(self) -> int:
-        """Gather width: the most tiles any rank owns."""
-        return max(len(ids) for ids in self.owned)
+        """Gather width: the most blocks any rank owns."""
+        first_tile = {block[0] for block in self.blocks}
+        return max(sum(index in first_tile for index in ids) for ids in self.owned)
 
     def global_token_ids(self, device: torch.device | str) -> torch.Tensor:
         """Global token id of every span token of this rank (tiles concatenated in span order)."""
@@ -137,6 +194,61 @@ class CanonicalTiling:
     def span_offsets(self) -> tuple[int, ...]:
         """Span-local ``[start, stop)`` of each owned tile, in span order."""
         return tuple(accumulate((self.tiles[i].length for i in self.mine), initial=0))
+
+    def routing(self, device: torch.device | str) -> CanonicalRouting:
+        """Materialize the index tensors the recipe reads, once per layout and device."""
+        offsets = self.span_offsets()
+        blocks = self.blocks
+        return CanonicalRouting(
+            cu_seqlens=torch.tensor(offsets, dtype=torch.int32, device=device),
+            bounds=torch.tensor(list(pairwise(offsets)), dtype=torch.int32, device=device),
+            mine=_selection(self.mine, device),
+            tile_document_offsets=_document_offsets(
+                [tile.document for tile in self.tiles], device
+            ),
+            block_document_offsets=_document_offsets(
+                [self.tiles[block[0]].document for block in blocks], device
+            ),
+            my_block_offsets=torch.tensor(
+                [0, *accumulate(len(blocks[b]) for b in self.my_blocks)],
+                dtype=torch.int32,
+                device=device,
+            ),
+            my_blocks=_selection(self.my_blocks, device),
+        )
+
+
+def _document_offsets(documents: Sequence[int], device: torch.device) -> torch.Tensor:
+    """``int32 [D + 1]`` boundaries of consecutive equal ``documents`` entries."""
+    offsets = [0]
+    offsets += [i for i in range(1, len(documents)) if documents[i] != documents[i - 1]]
+    offsets.append(len(documents))
+    return torch.tensor(offsets, dtype=torch.int32, device=device)
+
+
+class CanonicalRouting(NamedTuple):
+    """Device tensors of a :class:`CanonicalTiling` for one rank, built once per layout.
+
+    ``cu_seqlens``/``bounds`` describe the rank's span with one segment per owned tile;
+    ``mine`` (and ``my_blocks``) select the rank's tiles (blocks) in a tile-order (block-order)
+    buffer, as a slice when they are consecutive so no gather copy is made; the document
+    offsets give the per-document scans their restart points.
+    """
+
+    cu_seqlens: torch.Tensor
+    bounds: torch.Tensor
+    mine: torch.Tensor | slice
+    tile_document_offsets: torch.Tensor
+    block_document_offsets: torch.Tensor
+    my_block_offsets: torch.Tensor
+    my_blocks: torch.Tensor | slice
+
+
+def _selection(ids: Sequence[int], device: torch.device | str) -> torch.Tensor | slice:
+    """A slice when ``ids`` are consecutive (no gather copy), else an index tensor."""
+    if ids and list(ids) == list(range(ids[0], ids[0] + len(ids))):
+        return slice(ids[0], ids[0] + len(ids))
+    return torch.tensor(list(ids), dtype=torch.int64, device=device)
 
 
 def tile_stream(cu_seqlens_global: Sequence[int], tile_size: int) -> list[Tile]:
@@ -150,101 +262,26 @@ def tile_stream(cu_seqlens_global: Sequence[int], tile_size: int) -> list[Tile]:
     return tiles
 
 
-@_ieee_fp32_matmul()
-def _compose_into(right: torch.Tensor, left: torch.Tensor) -> None:
-    """``right <- [B_L @ A_R + B_R; A_L @ A_R]`` in place on ``[..., V + K, K]`` packed maps."""
-    value_dim = left.shape[-2] - left.shape[-1]
-    composed = left @ right[..., value_dim:, :]
-    composed[..., :value_dim, :] += right[..., :value_dim, :]
-    right.copy_(composed)
-
-
-def canonical_scan(maps: torch.Tensor) -> torch.Tensor:
-    """Inclusive prefix along dim 1 of ``[D, L, H, V + K, K]`` maps, one independent row per document.
-
-    Work-efficient (Blelloch) scan: an up-sweep folds pairs at strides 1, 2, 4, ... into the
-    right element, then a down-sweep pushes each node's prefix into the elements it did not
-    cover. Every stage is one batched IEEE-FP32 matmul over strided views of the buffer. The
-    prefix at position ``j`` reads positions ``<= j`` only, so it is a function of the leaves
-    ``0..j`` and of ``j`` alone: padding a row on the right (with any maps) does not change it,
-    and neither does which rank produced a leaf or how leaves were transported. About ``2L``
-    compositions per row in ``2 log2 L`` stages.
-    """
-    length = maps.shape[1]
-    stage = maps.clone()
-    stride = 1
-    while 2 * stride - 1 < length:
-        right = stage[:, 2 * stride - 1 :: 2 * stride]
-        _compose_into(right, stage[:, stride - 1 :: 2 * stride][:, : right.shape[1]])
-        stride *= 2
-    stride //= 2
-    while stride >= 1:
-        if 3 * stride - 1 < length:
-            right = stage[:, 3 * stride - 1 :: 2 * stride]
-            _compose_into(right, stage[:, 2 * stride - 1 :: 2 * stride][:, : right.shape[1]])
-        stride //= 2
-    return stage
-
-
-def boundary_states(maps: torch.Tensor, tiles: Sequence[Tile], *, reverse: bool) -> torch.Tensor:
-    """Entry (or exit when ``reverse``) FP32 ``[N, H, V, K]`` state of every tile in tile order.
-
-    Documents are scanned independently, so a document's states depend only on its own tiles,
-    not on its position in the packed stream or on its neighbours. Documents are batched by the
-    power-of-two bucket of their tile count and right-padded with identity maps to the bucket
-    length; the prefix at a position never reads past it (see ``canonical_scan``), so the padding
-    and the batching are numerically inert and only bound the wasted work to under 2x. Single-tile
-    documents need no scan. The first tile of a document (last when ``reverse``) enters with zero;
-    every other tile enters with the bias of the exclusive prefix (``merge_state(0, prefix)``).
-    """
-    count, heads, packed, key_dim = maps.shape
-    value_dim = packed - key_dim
-    rows: dict[int, list[int]] = {}
-    for index, tile in enumerate(tiles):
-        rows.setdefault(tile.document, []).append(index)
-    entries = maps.new_zeros((count, heads, value_dim, key_dim))
-    buckets: dict[int, list[list[int]]] = {}
-    for ids in rows.values():
-        if len(ids) > 1:
-            ordered = list(reversed(ids)) if reverse else list(ids)
-            buckets.setdefault(1 << (len(ids) - 1).bit_length(), []).append(ordered)
-    identity = torch.eye(key_dim, device=maps.device)
-    for length, documents in sorted(buckets.items()):
-        padded = maps.new_zeros((len(documents), length, heads, packed, key_dim))
-        padded[:, :, :, value_dim:, :] = identity
-        row_index = torch.tensor(
-            [d for d, ids in enumerate(documents) for _ in ids[1:]], device=maps.device
-        )
-        col_index = torch.tensor(
-            [j for ids in documents for j in range(1, len(ids))], device=maps.device
-        )
-        tile_index = torch.tensor([i for ids in documents for i in ids[1:]], device=maps.device)
-        leaf_index = torch.tensor([i for ids in documents for i in ids], device=maps.device)
-        padded[
-            torch.tensor([d for d, ids in enumerate(documents) for _ in ids], device=maps.device),
-            torch.tensor([j for ids in documents for j in range(len(ids))], device=maps.device),
-        ] = maps[leaf_index]
-        prefix = canonical_scan(padded)
-        entries[tile_index] = prefix[row_index, col_index - 1, :, :value_dim, :]
-    return entries
-
-
-def all_gather_tile_maps(
+def all_gather_block_maps(
     local: torch.Tensor | None,
     tiling: CanonicalTiling,
     like: torch.Tensor,
-    group: dist.ProcessGroup,
+    group: dist.ProcessGroup | None,
 ) -> torch.Tensor:
-    """Exchange every rank's leaf maps and return them as ``[N, H, V + K, K]`` in tile order.
+    """Exchange every rank's block maps and return them as ``[blocks, H, V + K, K]`` in block order.
 
-    ``local`` holds this rank's maps in ``tiling.mine`` order (``None`` for an empty rank).
-    Packets are zero-padded to ``tiling.slots`` rows so the collective is a plain equal-size
-    all-gather; the padding rows never enter a scan. When every rank owns a contiguous run of
-    tiles in rank order and no padding is needed, the gathered buffer already is the tile order
-    and is returned without a copy.
+    ``local`` holds this rank's block maps in ``tiling.my_blocks`` order (``None`` for an empty
+    rank). Packets are zero-padded to ``tiling.slots`` rows so the collective is a plain
+    equal-size all-gather; padding rows never enter a scan. When every rank's blocks are
+    contiguous in rank order and no padding is needed, the gathered buffer already is the block
+    order and is returned without a copy. ``group=None`` (a single rank owning everything, the
+    CP=1 reference) skips the collective.
     """
     width = tiling.slots
     world = len(tiling.owned)
+    if group is None:
+        assert world == 1 and local is not None and local.shape[0] == len(tiling.blocks)
+        return local
     if local is not None and local.shape[0] == width:
         packet = local
     else:
@@ -252,21 +289,68 @@ def all_gather_tile_maps(
         if local is not None:
             packet[: local.shape[0]] = local
     gathered = like.new_empty((world * width, *like.shape[1:]))
-    with profiler_range("cp/all_gather_tiles"):
+    with profiler_range("cp/all_gather_blocks"):
         dist.all_gather_into_tensor(gathered, packet, group=group)
-    order = [index for ids in tiling.owned for index in ids]
+    per_rank = [
+        [b for b, block in enumerate(tiling.blocks) if block[0] in set(ids)]
+        for ids in tiling.owned
+    ]
+    order = [b for blocks in per_rank for b in blocks]
     if order == list(range(len(order))) and len(order) == world * width:
         return gathered
-    rows = [rank * width + row for rank, ids in enumerate(tiling.owned) for row in range(len(ids))]
-    placed = torch.empty_like(gathered[: len(tiling.tiles)])
+    rows = [
+        rank * width + row for rank, blocks in enumerate(per_rank) for row in range(len(blocks))
+    ]
+    placed = torch.empty_like(gathered[: len(tiling.blocks)])
     placed[torch.tensor(order, device=like.device)] = gathered[
         torch.tensor(rows, device=like.device)
     ]
     return placed
 
 
+def canonical_entries(
+    tile_maps: torch.Tensor | None,
+    tiling: CanonicalTiling,
+    routing: CanonicalRouting,
+    like: torch.Tensor,
+    group: dist.ProcessGroup | None,
+    *,
+    reverse: bool,
+) -> torch.Tensor | None:
+    """Entry (or exit when ``reverse``) FP32 states of this rank's tiles, in ``tiling.mine`` order.
+
+    With ``scan_block == 1`` every tile map is gathered and scanned per document. Otherwise the
+    fixed three-level tree of NOTE [Scan Blocks]: fold each owned block's tile maps into one block
+    map; all-gather block maps; scan them per document for the block entry states; fold each
+    owned block's tiles again from its entry state for the tile states. Every fold is the
+    left-to-right (right-to-left when ``reverse``) serial fold in three-pass TF32, so the result
+    is a function of the tiles' maps and indices only.
+    """
+    if tiling.scan_block == 1:
+        gathered = all_gather_block_maps(tile_maps, tiling, like, group)
+        entries = canonical_scan_entries(gathered, routing.tile_document_offsets, reverse=reverse)
+        return entries[routing.mine] if tile_maps is not None else None
+    block_maps = (
+        fold_ranges(tile_maps, routing.my_block_offsets, reverse=reverse)
+        if tile_maps is not None
+        else None
+    )
+    gathered = all_gather_block_maps(block_maps, tiling, like, group)
+    block_entries = canonical_scan_entries(
+        gathered, routing.block_document_offsets, reverse=reverse
+    )
+    if tile_maps is None:
+        return None
+    return canonical_scan_entries(
+        tile_maps,
+        routing.my_block_offsets,
+        reverse=reverse,
+        initial=block_entries[routing.my_blocks],
+    )
+
+
 class _CanonicalContextParallel(torch.autograd.Function):
-    """One batched staged forward/backward per rank glued by fixed per-document scans.
+    """One batched staged forward/backward per rank glued by the fixed scan tree.
 
     Every owned tile is one packed subsequence of the rank's span (``cu_seqlens`` at tile
     boundaries), so the leaf kernels see each tile exactly as an independent call would; the
@@ -276,25 +360,19 @@ class _CanonicalContextParallel(torch.autograd.Function):
     """
 
     @staticmethod
-    def forward(ctx, q, k, v, gate, beta, tiling: CanonicalTiling, group, stages: StagedOp):
-        offsets = tiling.span_offsets()
+    def forward(ctx, q, k, v, gate, beta, tiling, routing, group, stages: StagedOp):
         heads, dim, value_dim = q.shape[2], q.shape[3], v.shape[3]
         zero = q.new_zeros((1, heads, value_dim, dim), dtype=torch.float32)
         like = zero.new_empty((1, heads, value_dim + dim, dim))  # one packed map
         n = len(tiling.mine)
         if n:
-            cu = torch.tensor(offsets, dtype=torch.int32, device=q.device)
-            bounds = torch.tensor(list(pairwise(offsets)), dtype=torch.int32, device=q.device)
-            prepared = stages.prepare(q, k, v, gate, beta, cu_seqlens=cu)
-            maps = prepared.state_summaries(bounds, deterministic_work=True)
+            prepared = stages.prepare(q, k, v, gate, beta, cu_seqlens=routing.cu_seqlens)
+            maps = prepared.state_summaries(routing.bounds, deterministic_work=True)
         else:
             prepared = None
             maps = None
-        entries = boundary_states(
-            all_gather_tile_maps(maps, tiling, like, group), tiling.tiles, reverse=False
-        )
+        entry = canonical_entries(maps, tiling, routing, like, group, reverse=False)
         if n:
-            entry = entries[list(tiling.mine)]
             with profiler_range("cp/run"):
                 output, _ = prepared.run(entry, output_final_state=False)
             saved = tuple(prepared.saved)
@@ -307,6 +385,7 @@ class _CanonicalContextParallel(torch.autograd.Function):
             ctx.saved_type = None
             ctx.scale = None
         ctx.tiling = tiling
+        ctx.routing = routing
         ctx.group = group
         ctx.stages = stages
         ctx.input_meta = tuple((t.shape, t.dtype) for t in (q, k, v, gate, beta))
@@ -320,30 +399,26 @@ class _CanonicalContextParallel(torch.autograd.Function):
     @torch.autograd.function.once_differentiable
     def backward(ctx, d_output):
         tiling: CanonicalTiling = ctx.tiling
-        offsets = tiling.span_offsets()
+        routing: CanonicalRouting = ctx.routing
         *saved, entry, zero, like = ctx.saved_tensors
         if d_output is None:
             d_output = zero.new_zeros(*ctx.output_meta)
         n = len(tiling.mine)
         if n:
-            bounds = torch.tensor(list(pairwise(offsets)), dtype=torch.int32, device=zero.device)
             backward = ctx.stages.prepare_backward(
                 ctx.saved_type._make(saved), d_output, entry, scale=ctx.scale
             )
-            maps = backward.state_grad_summaries(bounds, deterministic_work=True)
+            maps = backward.state_grad_summaries(routing.bounds, deterministic_work=True)
         else:
             backward = None
             maps = None
-        exits = boundary_states(
-            all_gather_tile_maps(maps, tiling, like, ctx.group), tiling.tiles, reverse=True
-        )
+        exit_cotangent = canonical_entries(maps, tiling, routing, like, ctx.group, reverse=True)
         if n:
-            exit_cotangent = exits[list(tiling.mine)]
             with profiler_range("cp/run"):
                 grads = backward.run(exit_cotangent)[:5]
         else:
             grads = tuple(zero.new_empty(shape, dtype=dtype) for shape, dtype in ctx.input_meta)
-        return (*grads, None, None, None)
+        return (*grads, None, None, None, None)
 
 
 def context_parallel_chunk_deterministic(
@@ -356,6 +431,7 @@ def context_parallel_chunk_deterministic(
     *,
     tiling: CanonicalTiling,
     group: dist.ProcessGroup,
+    routing: CanonicalRouting | None = None,
 ) -> torch.Tensor:
     """Run a staged delta-rule op over this rank's canonical tiles (NOTE [Canonical Tiles]).
 
@@ -365,6 +441,8 @@ def context_parallel_chunk_deterministic(
             ``gate``, ``beta`` follow the same layout.
         tiling: The stream's canonical tiling and this rank's ownership.
         group: Process group containing exactly the tiling's ranks, in order.
+        routing: ``tiling.routing(device)``; pass it to reuse the index tensors across calls
+            with the same layout (built here otherwise).
 
     Returns:
         The span's output. Final states are not returned: every document's exit state is a
@@ -380,16 +458,18 @@ def context_parallel_chunk_deterministic(
     expected = sum(tiling.tiles[i].length for i in tiling.mine)
     if q.shape[1] != expected:
         raise ValueError(f"tiling owns {expected} local tokens but the input has {q.shape[1]}")
-    return _CanonicalContextParallel.apply(q, k, v, gate, beta, tiling, group, stages)
+    if routing is None:
+        routing = tiling.routing(q.device)
+    return _CanonicalContextParallel.apply(q, k, v, gate, beta, tiling, routing, group, stages)
 
 
 __all__ = [
     "SUMMARY_CHUNK",
+    "CanonicalRouting",
     "CanonicalTiling",
     "Tile",
-    "all_gather_tile_maps",
-    "boundary_states",
-    "canonical_scan",
+    "all_gather_block_maps",
+    "canonical_entries",
     "context_parallel_chunk_deterministic",
     "tile_stream",
 ]

--- a/attn_gym/linear/kda/context_parallel.py
+++ b/attn_gym/linear/kda/context_parallel.py
@@ -19,6 +19,7 @@ from attn_gym.linear.context_parallel import (
     context_parallel_chunk,
 )
 from attn_gym.linear.context_parallel_deterministic import (
+    CanonicalRouting,
     CanonicalTiling,
     context_parallel_chunk_deterministic,
 )
@@ -62,6 +63,7 @@ def context_parallel_kda_deterministic(
     *,
     tiling: CanonicalTiling,
     group: dist.ProcessGroup,
+    routing: CanonicalRouting | None = None,
     scale: float | None = None,
     fastmath: bool = False,
     kernel_options: KernelOptions | None = None,
@@ -74,7 +76,7 @@ def context_parallel_kda_deterministic(
     """
     stages = _kda_stages(scale, False, fastmath, kernel_options)
     return context_parallel_chunk_deterministic(
-        stages, q, k, v, gate, beta, tiling=tiling, group=group
+        stages, q, k, v, gate, beta, tiling=tiling, group=group, routing=routing
     )
 
 

--- a/benchmarks/kda_cp_deterministic.py
+++ b/benchmarks/kda_cp_deterministic.py
@@ -20,8 +20,9 @@ from __future__ import annotations
 import json
 import os
 import statistics
+from collections.abc import Callable
 from functools import partial
-from itertools import accumulate
+from itertools import accumulate, pairwise
 from pathlib import Path
 from typing import Annotated
 
@@ -41,9 +42,11 @@ ZIPF_FRACTIONS = (0.5, 0.25, 0.125, 0.0625)
 def document_lengths(tokens: int, grid: int) -> tuple[int, ...]:
     """Zipf-like documents on a ``grid`` so every recipe can share fragment boundaries.
 
-    Fractions are floored to the grid, so the last document absorbs the rounding; ``tokens``
-    must leave it at least one grid step (e.g. tokens >= 16 * grid).
+    Fractions are floored to the grid and the last document absorbs rounding. For small
+    workloads, shrink the document grid (not the canonical tiles) to keep all five nonempty.
+    Document boundaries are always valid tile boundaries, even for documents shorter than a tile.
     """
+    grid = min(grid, max(64, tokens // 16 // 64 * 64))
     lengths = [int(tokens * f) // grid * grid for f in ZIPF_FRACTIONS]
     remainder = tokens - sum(lengths)
     if min(lengths) < grid or remainder < grid:
@@ -64,37 +67,98 @@ def balanced_cut(cu: tuple[int, ...], tile: int, world: int) -> list[list[tuple[
     return fragments
 
 
-def timed(fn, *, iters: int, device) -> list[float]:
-    """Per-iteration milliseconds from CUDA events, synchronized across ranks each iteration."""
-    samples = []
+class PhaseClock:
+    """CUDA-event intervals named by their closing mark; read only after synchronization."""
+
+    def __init__(self) -> None:
+        self.marks: list[tuple[str, torch.cuda.Event]] = []
+
+    def mark(self, name: str) -> None:
+        """Record a phase boundary on the current stream."""
+        event = torch.cuda.Event(enable_timing=True)
+        event.record()
+        self.marks.append((name, event))
+
+    def elapsed(self) -> dict[str, float]:
+        """Return local phase durations in milliseconds."""
+        return {
+            name: prev.elapsed_time(event) for (_, prev), (name, event) in pairwise(self.marks)
+        }
+
+
+def timed(
+    step: Callable[[PhaseClock], object],
+    *,
+    iters: int,
+    device: torch.device,
+    distributed: bool = True,
+) -> tuple[list[dict[str, float]], list[float], list[float]]:
+    """Local phase samples and slowest-rank fwd/bwd ms, with a barrier before each step.
+
+    Unlike single-device graph timing, these eager measurements include launch gaps and
+    collective waits. ``distributed=False`` measures the single-GPU split benchmark.
+    """
+    phases, fwd, bwd = [], [], []
     for _ in range(iters):
-        dist.barrier()
-        start, end = torch.cuda.Event(enable_timing=True), torch.cuda.Event(enable_timing=True)
-        start.record()
-        fn()
-        end.record()
+        if distributed:
+            dist.barrier()
+        clock = PhaseClock()
+        step(clock)
         torch.cuda.synchronize(device)
-        local = torch.tensor([start.elapsed_time(end)], device=device)
-        dist.all_reduce(local, op=dist.ReduceOp.MAX)
-        samples.append(local.item())
-    return samples
+        local = clock.elapsed()
+        phases.append(local)
+        totals = torch.tensor(
+            [
+                sum(v for k, v in local.items() if k.startswith(prefix))
+                for prefix in ("fwd", "bwd")
+            ],
+            device=device,
+        )
+        if distributed:
+            dist.all_reduce(totals, op=dist.ReduceOp.MAX)
+        f, b = totals.tolist()
+        fwd.append(f)
+        bwd.append(b)
+    return phases, fwd, bwd
+
+
+def clocked(fn: Callable[[], object], clock: PhaseClock, *, phase: str) -> None:
+    """Time a public operation as a single phase."""
+    clock.mark("start")
+    fn()
+    clock.mark(phase)
+
+
+def forward(
+    op: Callable[..., torch.Tensor | tuple[torch.Tensor, torch.Tensor | None]],
+    inputs: tuple[torch.Tensor, ...],
+    grad: torch.Tensor,
+) -> tuple[torch.Tensor, tuple[torch.Tensor, ...], torch.Tensor]:
+    """Run a KDA public API with fresh autograd leaves; ignore optional final states."""
+    leaves = tuple(v.detach().requires_grad_() for v in inputs)
+    result = op(*leaves)
+    return (result[0] if isinstance(result, tuple) else result), leaves, grad
 
 
 def main(
     tokens: Annotated[int, typer.Option(help="Total packed tokens.")] = 8192,
     heads: Annotated[int, typer.Option()] = 64,
-    backend: Annotated[str, typer.Option(help="fused or mega (forward core).")] = "fused",
+    backend: Annotated[str, typer.Option(help="fused or mega staged backend.")] = "fused",
     tiles: Annotated[str, typer.Option(help="Comma-separated canonical tile sizes.")] = "64,256",
+    scan_block: Annotated[
+        int, typer.Option(help="Tiles per exchanged scan block; fragments must be block-aligned.")
+    ] = 1,
     rounds: Annotated[int, typer.Option()] = 5,
     iters: Annotated[int, typer.Option(help="Timed iterations per round per variant.")] = 10,
     out_path: Annotated[Path | None, typer.Option("--out")] = None,
 ) -> None:
+    """Compare unsharded, standard CP, and canonical CP forward/backward costs."""
     rank, world = int(os.environ["RANK"]), int(os.environ["WORLD_SIZE"])
     device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
     torch.cuda.set_device(device)
     dist.init_process_group("nccl", device_id=device)
     tile_sizes = [int(t) for t in tiles.split(",")]
-    grid = max(tile_sizes)
+    grid = max(tile_sizes) * scan_block
     lengths = document_lengths(tokens, grid)
     cu = (0, *accumulate(lengths))
     options = {"backend": backend} if backend != "fused" else None
@@ -112,14 +176,14 @@ def main(
     cu_dev = torch.tensor(cu, dtype=torch.int32, device=device)
     fragments = balanced_cut(cu, grid, world)
 
-    variants: dict[str, tuple] = {}
-
-    def unsharded_fwd():
-        leaves = tuple(v.detach().requires_grad_() for v in inputs)
-        out, _ = chunk_kda(*leaves, cu_seqlens=cu_dev, kernel_options=options, autotune=False)
-        return out, leaves, grad
-
-    variants["unsharded"] = unsharded_fwd
+    variants = {
+        "unsharded": partial(
+            forward,
+            partial(chunk_kda, cu_seqlens=cu_dev, kernel_options=options, autotune=False),
+            inputs,
+            grad,
+        )
+    }
 
     plan = ContextParallelPlan.from_fragments(cu, fragments, rank)
     routing = plan.routing(device)
@@ -127,33 +191,41 @@ def main(
     cp_local = tuple(v[:, cp_ids].contiguous() for v in inputs)
     cp_grad = grad[:, cp_ids].contiguous()
 
-    def cp_fwd():
-        leaves = tuple(v.detach().requires_grad_() for v in cp_local)
-        out, _ = context_parallel_kda(
-            *leaves,
+    variants["cp"] = partial(
+        forward,
+        partial(
+            context_parallel_kda,
             routing=routing,
             group=dist.group.WORLD,
             kernel_options=options,
             autotune=False,
-        )
-        return out, leaves, cp_grad
-
-    variants["cp"] = cp_fwd
+        ),
+        cp_local,
+        cp_grad,
+    )
 
     for tile in tile_sizes:
-        tiling = CanonicalTiling.from_fragments(cu, fragments, rank, tile_size=tile)
+        tiling = CanonicalTiling.from_fragments(
+            cu, fragments, rank, tile_size=tile, scan_block=scan_block
+        )
+        det_routing = tiling.routing(device)
         ids = tiling.global_token_ids(device)
         local = tuple(v[:, ids].contiguous() for v in inputs)
         local_grad = grad[:, ids].contiguous()
 
-        def det_fwd(tiling=tiling, local=local, local_grad=local_grad):
-            leaves = tuple(v.detach().requires_grad_() for v in local)
-            out = context_parallel_kda_deterministic(
-                *leaves, tiling=tiling, group=dist.group.WORLD, kernel_options=options
-            )
-            return out, leaves, local_grad
-
-        variants[f"det-{tile}"] = det_fwd
+        name = f"det-{tile}" + (f"-b{scan_block}" if scan_block > 1 else "")
+        variants[name] = partial(
+            forward,
+            partial(
+                context_parallel_kda_deterministic,
+                tiling=tiling,
+                routing=det_routing,
+                group=dist.group.WORLD,
+                kernel_options=options,
+            ),
+            local,
+            local_grad,
+        )
 
     # Warm up (compiles) and keep one retained graph per variant for backward timing.
     retained = {}
@@ -170,13 +242,21 @@ def main(
     for r in range(rounds):
         order = names if r % 2 == 0 else names[::-1]
         for name in order:
-            fwd_ms[name] += timed(variants[name], iters=iters, device=device)
+            _, f, _ = timed(
+                partial(clocked, variants[name], phase="fwd/run"), iters=iters, device=device
+            )
+            fwd_ms[name] += f
             out, leaves, g = retained[name]
-            bwd_ms[name] += timed(
-                partial(torch.autograd.grad, out, leaves, g, retain_graph=True),
+            _, _, b = timed(
+                partial(
+                    clocked,
+                    partial(torch.autograd.grad, out, leaves, g, retain_graph=True),
+                    phase="bwd/run",
+                ),
                 iters=iters,
                 device=device,
             )
+            bwd_ms[name] += b
 
     if rank == 0:
         rows = []
@@ -214,6 +294,7 @@ def main(
                         "world": world,
                         "lengths": lengths,
                         "fragments": fragments,
+                        "scan_block": scan_block,
                         "rounds": rounds,
                         "iters": iters,
                         "device": torch.cuda.get_device_name(device),

--- a/test/test_context_parallel_deterministic.py
+++ b/test/test_context_parallel_deterministic.py
@@ -22,11 +22,10 @@ import torch.multiprocessing as mp
 pytest.importorskip("cutlass")
 
 import attn_gym.linear.context_parallel_deterministic as det
+from attn_gym.linear._delta_rule.triton.canonical_scan import canonical_scan_entries
 from attn_gym.linear.context_parallel_deterministic import (
     CanonicalTiling,
-    Tile,
-    boundary_states,
-    canonical_scan,
+    canonical_entries,
     tile_stream,
 )
 from attn_gym.linear.kda.context_parallel import _kda_stages, context_parallel_kda_deterministic
@@ -71,6 +70,12 @@ def test_fragments_must_fall_on_tile_boundaries():
         CanonicalTiling.from_fragments(cu, [[(17, 0)], [(17, 981)]], 0, tile_size=64)
     with pytest.raises(ValueError, match="outside"):
         CanonicalTiling.from_fragments(cu, [[(0, 981)], []], 2, tile_size=64)
+    # Document 4 (tokens 468..981) has tiles at 468, 532, ...; a 2-tile block boundary is 596.
+    CanonicalTiling.from_fragments(cu, [[(0, 596)], [(596, 981)]], 0, tile_size=64, scan_block=2)
+    with pytest.raises(ValueError, match="one scan block"):
+        CanonicalTiling.from_fragments(
+            cu, [[(0, 532)], [(532, 981)]], 0, tile_size=64, scan_block=2
+        )
 
 
 def test_non_contiguous_ownership_keeps_span_order_consistent():
@@ -90,7 +95,9 @@ def _serial_entries(leaves: torch.Tensor, documents: list[int]) -> torch.Tensor:
     from attn_gym.linear.context_parallel import compose_summaries
 
     value_dim = leaves.shape[2] - leaves.shape[3]
-    entries = torch.zeros(leaves.shape[0], leaves.shape[1], value_dim, leaves.shape[3])
+    entries = torch.zeros(
+        leaves.shape[0], leaves.shape[1], value_dim, leaves.shape[3], device=leaves.device
+    )
     prefix = None
     for i, doc in enumerate(documents):
         if i == 0 or doc != documents[i - 1]:
@@ -103,51 +110,81 @@ def _serial_entries(leaves: torch.Tensor, documents: list[int]) -> torch.Tensor:
 
 def _leaves(n: int, seed: int) -> torch.Tensor:
     torch.manual_seed(seed)
-    leaves = torch.randn(n, 2, 8, 4)
-    leaves[:, :, 4:, :] = torch.eye(4) + 0.01 * torch.randn(n, 2, 4, 4)
+    leaves = torch.randn(n, 2, 256, 128, device="cuda")
+    leaves[:, :, 128:, :] = torch.eye(128, device="cuda") + 0.01 * torch.randn(
+        n, 2, 128, 128, device="cuda"
+    )
     return leaves
 
 
-@pytest.mark.parametrize("documents", [[0] * 9, [0, 0, 0, 1, 2, 2, 2], [0, 1, 2, 3], [0] * 1])
-def test_scan_matches_serial_composition_per_document(documents):
-    """The Blelloch scan restarts at documents and equals serial composition (fp32 rounding)."""
-    leaves = _leaves(len(documents), 0)
-    tiles = [Tile(d, 0, 0) for d in documents]
-    torch.testing.assert_close(
-        boundary_states(leaves, tiles, reverse=False), _serial_entries(leaves, documents)
+def _doc_offsets(documents: list[int]) -> torch.Tensor:
+    offsets = [0] + [i for i in range(1, len(documents)) if documents[i] != documents[i - 1]]
+    return torch.tensor([*offsets, len(documents)], dtype=torch.int32, device="cuda")
+
+
+def _single_rank_tiling(documents: list[int], scan_block: int) -> CanonicalTiling:
+    """One rank owning every tile of documents with the given tile counts (64-token tiles)."""
+    lengths = []
+    for doc in dict.fromkeys(documents):
+        lengths.append(64 * documents.count(doc))
+    cu = (0, *accumulate(lengths))
+    return CanonicalTiling.from_fragments(
+        cu, [[(0, cu[-1])]], 0, tile_size=64, scan_block=scan_block
     )
-    reversed_docs = documents[::-1]
-    expected = _serial_entries(leaves.flip(0), reversed_docs).flip(0)
-    torch.testing.assert_close(boundary_states(leaves, tiles, reverse=True), expected)
 
 
-def test_scan_of_a_document_is_independent_of_its_neighbours():
+@pytest.mark.parametrize("documents", [[0] * 9, [0, 0, 0, 1, 2, 2, 2], [0, 1, 2, 3], [0] * 1])
+def test_fused_scan_matches_serial_composition_per_document(documents):
+    """The fused scan restarts at documents and equals serial composition to fp32 accuracy."""
+    leaves = _leaves(len(documents), 0)
+    offsets = _doc_offsets(documents)
+    torch.testing.assert_close(
+        canonical_scan_entries(leaves, offsets),
+        _serial_entries(leaves, documents),
+        atol=1e-4,
+        rtol=1e-5,
+    )
+    expected = _serial_entries(leaves.flip(0), documents[::-1]).flip(0)
+    torch.testing.assert_close(
+        canonical_scan_entries(leaves, offsets, reverse=True), expected, atol=1e-4, rtol=1e-5
+    )
+
+
+@pytest.mark.parametrize("scan_block", [1, 2, 4])
+def test_blocked_entries_match_serial_composition(scan_block):
+    """The three-level block tree equals serial composition to fp32 accuracy, both directions."""
+    documents = [0] * 7 + [1] * 3 + [2] * 5
+    leaves = _leaves(len(documents), 5)
+    tiling = _single_rank_tiling(documents, scan_block)
+    like = leaves[:1]
+    for reverse in (False, True):
+        got = canonical_entries(
+            leaves, tiling, tiling.routing("cuda"), like, None, reverse=reverse
+        )
+        if reverse:
+            expected = _serial_entries(leaves.flip(0), documents[::-1]).flip(0)
+        else:
+            expected = _serial_entries(leaves, documents)
+        torch.testing.assert_close(got, expected, atol=1e-4, rtol=1e-5)
+
+
+@pytest.mark.parametrize("scan_block", [1, 4])
+def test_entries_of_a_document_are_independent_of_its_neighbours(scan_block):
     """A document's entry states are bitwise the same wherever it sits in the packed stream."""
     document = _leaves(5, 1)
-    reference = None
+    reference: dict[bool, torch.Tensor] = {}
     for before, after in ((0, 0), (1, 0), (3, 2), (7, 5)):
         others = _leaves(before + after, 2 + before)
         leaves = torch.cat((others[:before], document, others[before:]))
-        tiles = [Tile(0, 0, 0)] * before + [Tile(1, 0, 0)] * 5 + [Tile(2, 0, 0)] * after
+        documents = [0] * before + [1] * 5 + [2] * after
+        tiling = _single_rank_tiling(documents, scan_block)
         for reverse in (False, True):
-            entries = boundary_states(leaves, tiles, reverse=reverse)[before : before + 5]
-            key = (reverse,)
-            if reference is None:
-                reference = {}
-            if key not in reference:
-                reference[key] = entries
-            assert torch.equal(entries, reference[key]), (before, after, reverse)
-
-
-def test_scan_prefix_ignores_right_padding():
-    """Blelloch reads only positions <= j, so padding a row on the right never changes bits."""
-    row = _leaves(6, 3)
-    identity = torch.zeros(1, 2, 8, 4)
-    identity[:, :, 4:, :] = torch.eye(4)
-    base = canonical_scan(row[None])[0]
-    for pad in (1, 2, 5, 10):
-        padded = torch.cat((row, identity.expand(pad, -1, -1, -1)))
-        assert torch.equal(canonical_scan(padded[None])[0, :6], base)
+            entries = canonical_entries(
+                leaves, tiling, tiling.routing("cuda"), leaves[:1], None, reverse=reverse
+            )
+            entries = entries[before : before + 5]
+            reference.setdefault(reverse, entries)
+            assert torch.equal(entries, reference[reverse]), (before, after, reverse)
 
 
 # ---------------------------------------------------------------- transports
@@ -206,14 +243,17 @@ def _inputs(lengths, gate: str, seed: int, device):
 
 
 @torch.no_grad()
-def _canonical_cp1(inputs, grad, lengths, tile_size: int, kernel_options):
+def _canonical_cp1(inputs, grad, lengths, tile_size: int, scan_block: int, kernel_options):
     """Single-process canonical run over the same tiles: the contract every ownership reproduces.
 
     Every tile is prepared by its own staged call (the strictest form of the leaf contract); the
-    batched production path must match this bitwise.
+    batched production path must match this bitwise. The scan tree is the production one.
     """
     cu = (0, *accumulate(lengths))
     tiles = tile_stream(cu, tile_size)
+    tiling = CanonicalTiling.from_fragments(
+        cu, [[(0, cu[-1])]], 0, tile_size=tile_size, scan_block=scan_block
+    )
     stages = _kda_stages(None, False, False, kernel_options)
     device = inputs[0].device
 
@@ -229,7 +269,8 @@ def _canonical_cp1(inputs, grad, lengths, tile_size: int, kernel_options):
             for p, t in zip(prepared, tiles, strict=True)
         ]
     )
-    entries = boundary_states(maps, tiles, reverse=False)
+    routing = tiling.routing(device)
+    entries = canonical_entries(maps, tiling, routing, maps[:1], None, reverse=False)
     outputs, backwards = [], []
     for i, (p, t) in enumerate(zip(prepared, tiles, strict=True)):
         outputs.append(p.run(entries[i : i + 1], output_final_state=False)[0])
@@ -244,7 +285,7 @@ def _canonical_cp1(inputs, grad, lengths, tile_size: int, kernel_options):
             for b, t in zip(backwards, tiles, strict=True)
         ]
     )
-    exits = boundary_states(rmaps, tiles, reverse=True)
+    exits = canonical_entries(rmaps, tiling, routing, maps[:1], None, reverse=True)
     grads = [b.run(exits[i : i + 1])[:5] for i, b in enumerate(backwards)]
     return (
         torch.cat(outputs, dim=1),
@@ -267,21 +308,32 @@ OWNERSHIPS = {
 }
 
 
-def _rank_main(cp_rank, world, port, lengths, tile_size, ownership, gate, backend):
+def _rank_main(cp_rank, world, port, lengths, tile_size, scan_block, ownership, gate, backend):
     device = _init(cp_rank, world, port)
     try:
         kernel_options = {"backend": backend} if backend != "fused" else None
         inputs, grad = _inputs(lengths, gate, 97, device)
         cu = (0, *accumulate(lengths))
-        expected = _canonical_cp1(inputs, grad, lengths, tile_size, kernel_options)
+        expected = _canonical_cp1(inputs, grad, lengths, tile_size, scan_block, kernel_options)
         if ownership == "cyclic":
+            # Alternate whole blocks between the ranks (tiles when scan_block == 1).
+            blocks = CanonicalTiling.from_fragments(
+                cu, [[(0, cu[-1])]], 0, tile_size=tile_size, scan_block=scan_block
+            ).blocks
             tiles = tile_stream(cu, tile_size)
             fragments = [
-                [(t.start, t.stop) for i, t in enumerate(tiles) if i % 2 == r] for r in range(2)
+                [
+                    (tiles[block[0]].start, tiles[block[-1]].stop)
+                    for b, block in enumerate(blocks)
+                    if b % 2 == r
+                ]
+                for r in range(2)
             ]
         else:
             fragments = OWNERSHIPS[ownership](cu, len(lengths))
-        tiling = CanonicalTiling.from_fragments(cu, fragments, cp_rank, tile_size=tile_size)
+        tiling = CanonicalTiling.from_fragments(
+            cu, fragments, cp_rank, tile_size=tile_size, scan_block=scan_block
+        )
         ids = tiling.global_token_ids(device)
         local = tuple(v[:, ids].contiguous().requires_grad_() for v in inputs)
         output = context_parallel_kda_deterministic(
@@ -301,23 +353,34 @@ def _rank_main(cp_rank, world, port, lengths, tile_size, ownership, gate, backen
 @pytest.mark.parametrize("backend", ["fused", "mega"])
 @pytest.mark.parametrize("gate", ["strong", "mild", "zero"])
 @pytest.mark.parametrize(
-    "lengths,tile_size,ownership",
+    "lengths,tile_size,scan_block,ownership",
     [
-        (RAGGED, 64, "contiguous"),
-        (RAGGED, 64, "cyclic"),
-        (RAGGED, 128, "empty_rank"),
-        (ELEPHANT, 64, "cyclic"),
+        (RAGGED, 64, 1, "contiguous"),
+        (RAGGED, 64, 1, "cyclic"),
+        (RAGGED, 128, 1, "empty_rank"),
+        (ELEPHANT, 64, 1, "cyclic"),
+        (RAGGED, 64, 4, "cyclic"),
+        (ELEPHANT, 64, 4, "contiguous"),
     ],
-    ids=["ragged-contig", "ragged-cyclic", "ragged-empty", "elephant-cyclic"],
+    ids=[
+        "ragged-contig",
+        "ragged-cyclic",
+        "ragged-empty",
+        "elephant-cyclic",
+        "ragged-cyclic-block4",
+        "elephant-contig-block4",
+    ],
 )
-def test_two_ranks_match_canonical_cp1_bitwise(lengths, tile_size, ownership, gate, backend):
+def test_two_ranks_match_canonical_cp1_bitwise(
+    lengths, tile_size, scan_block, ownership, gate, backend
+):
     if backend == "mega":
         pytest.importorskip("cutlass.experimental")
         if torch.cuda.get_device_capability() not in ((10, 0), (10, 3)):
             pytest.skip("Mega needs SM100/103")
     mp.spawn(
         _rank_main,
-        args=(2, _free_port(), lengths, tile_size, ownership, gate, backend),
+        args=(2, _free_port(), lengths, tile_size, scan_block, ownership, gate, backend),
         nprocs=2,
         join=True,
     )
@@ -332,7 +395,7 @@ def test_canonical_cp1_matches_fp64_reference_within_bf16_budget():
     inputs, grad = _inputs(lengths, "mild", 41, torch.device("cuda"))
     inputs = tuple(v[:, :, :1].contiguous() for v in inputs)
     grad = grad[:, :, :1].contiguous()
-    actual = _canonical_cp1(inputs, grad, lengths, 64, None)
+    actual = _canonical_cp1(inputs, grad, lengths, 64, 2, None)
     cu = torch.tensor((0, *accumulate(lengths)), dtype=torch.int32, device="cuda")
     high = tuple(v.detach().cpu().double().requires_grad_() for v in inputs)
     out_high, _ = kda_reference(*high, cu_seqlens=cu.cpu(), output_final_state=False)


### PR DESCRIPTION
Stacked PRs:
 * #519
 * #518
 * #517
 * #516
 * __->__#515
 * #514
 * #513
 * #512


--- --- ---

Fuse the canonical scan into one launch and cut the recipe's fixed costs

The per-document scan of the deterministic CP recipe is now one Triton launch
(canonical_scan_entries): each program owns 16 bias rows of one document and head and walks the
document's tiles serially with three-pass TF32 dots. Only bias rows are needed, so the running
transition is never formed; REVERSE walks the tiles in place for the exit-cotangent scan, so no
permuted copy of the maps is made. This replaces the bucketed Blelloch scan (a different fixed
tree; results stay a function of tile indices only and bitwise invariant to ownership).

CanonicalTiling.routing(device) builds the cu_seqlens/bounds/document-offset/selection tensors
once per layout, and context_parallel_chunk_deterministic accepts it, mirroring
ContextParallelPlan.routing; consecutive ownership selects with slices instead of index gathers.

scan_block adds an opt-in block level to the tree for large CP degrees: consecutive tiles of a
document form blocks, only block maps cross ranks, and each rank folds its own tiles from the
block entry state (NOTE [Scan Blocks]; ranks must own whole blocks, which the planner checks).
On two NVLink GB200s the block folds cost about what they save on the gather, so the default
stays scan_block=1, which takes the flat path with no extra kernels.

Two GB200s, 32k tokens, 64 heads, fused staged backend, deterministic vs standard CP (ms
fwd/bwd, lower is better): det-1024 8.02/11.43 -> 4.15/7.40 (1.51x/1.21x of standard CP);
det-256 16.4/19.8 -> 6.76/10.17; det-64 52.9/56.5 -> 16.9/20.7. Mega det-1024 6.60/11.20 ->
about 2.7/6.9 with the following Mega summary changes.