### PR TITLE
Use native Mega summaries for standard CP forward and canonical reverse maps

### DIFF
--- a/attn_gym/linear/_delta_rule/mega/state_summary.py
+++ b/attn_gym/linear/_delta_rule/mega/state_summary.py
@@ -1,23 +1,65 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Native BT16 affine probes for canonical Mega context-parallel tiles.
+"""Native BT16 affine probes for Mega context-parallel subsequences.
 
 B is the no-state final state; A is the identity-seeded, zero-value final state. Native
 state/operand rounding makes this an approximate affine map, not bitwise reconstruction of
-an ordinary unsharded Mega run. Fixed whole-sequence work items define the canonical baseline.
+an ordinary unsharded Mega run. C is the native zero-exit entry cotangent. The cheaper reverse
+transition A.T is opt-in: it is not the identity-seeded native backward's rounding.
 """
 
 from __future__ import annotations
 
 import torch
+import triton
+import triton.language as tl
 
 from attn_gym._backends.cute.utils import initialized_cuda_device
 from attn_gym.utils import ceildiv
 
 from .forward import validate_available
-from .kernels import kda_recompute_f16
+from .kernels import kda_bprop_f16, kda_recompute_f16
 from .kernels.common.host import tensormap_workspace_bytes
 from .schedule import prepare_mega_schedule
+
+
+@triton.jit
+def _select_summary_work(cu, bounds, work, count, HEADS: tl.constexpr, ROWS: tl.constexpr):
+    """Keep one native work item per sequence/head, neutralizing unrequested sequences."""
+    seq = tl.program_id(0)
+    head = tl.program_id(1)
+    start, stop = tl.load(cu + seq), tl.load(cu + seq + 1)
+    rows = tl.arange(0, triton.next_power_of_2(ROWS))
+    lo = tl.load(bounds + 2 * rows, rows < ROWS, other=-1)
+    hi = tl.load(bounds + 2 * rows + 1, rows < ROWS, other=-1)
+    selected = tl.sum(((lo == start) & (hi == stop) & (lo < hi)).to(tl.int32), 0) > 0
+    stop = tl.where(selected, stop, start)
+    chunks = tl.cdiv(stop - start, 16)
+    fields = tl.arange(0, 8)
+    row = tl.where(fields == 0, seq, tl.where(fields == 1, head, 0))
+    row = tl.where((fields == 3) | (fields == 5), chunks, row)
+    row = tl.where(fields == 6, start, tl.where(fields == 7, stop, row))
+    tl.store(work + (seq * HEADS + head) * 8 + fields, row)
+    if (seq == 0) & (head == 0):
+        tl.store(count, tl.num_programs(0) * HEADS)
+
+
+@triton.jit
+def _gather_summary_rows(
+    maps, cu, bounds, output, HEADS: tl.constexpr, SEQUENCES: tl.constexpr, BLOCK: tl.constexpr
+):
+    """Map each whole-sequence bound to its probe, or synthesize the empty identity."""
+    row, head, block = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    start, stop = tl.load(bounds + row * 2), tl.load(bounds + row * 2 + 1)
+    seqs = tl.arange(0, triton.next_power_of_2(SEQUENCES))
+    lo = tl.load(cu + seqs, seqs < SEQUENCES, other=-1)
+    hi = tl.load(cu + seqs + 1, seqs < SEQUENCES, other=-1)
+    seq = tl.max(tl.where((lo == start) & (hi == stop), seqs, 0), 0)
+    offsets = block * BLOCK + tl.arange(0, BLOCK)
+    value = tl.load(maps + (seq * HEADS + head) * 32768 + offsets)
+    identity = (offsets // 128 - 128 == offsets % 128).to(tl.float32)
+    value = tl.where(start == stop, identity, value)
+    tl.store(output + (row * HEADS + head) * 32768 + offsets, value)
 
 
 def build_mega_state_summaries(
@@ -26,14 +68,30 @@ def build_mega_state_summaries(
     gate: torch.Tensor,
     beta: torch.Tensor,
     cu_seqlens: torch.Tensor,
+    *,
+    bounds: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Return FP32 ``[N, H, 256, 128]`` maps packed as ``[B; A]`` for whole sequences.
 
     Inputs use the staged ``[1, T, H, 128]`` layout, with FP32 gate/beta and already
-    normalized keys. Each packed sequence is one canonical tile. Both passes are unsplit,
-    independent of packed token count or ownership; empty sequences return ``[0; I]``.
-    The transition pass synthesizes identity and zero values on chip, without reading V.
+    normalized keys. Both passes are unsplit, independent of packed token count or ownership.
+    Optional bounds select/reorder whole consecutive cu_seqlens pairs (a caller contract);
+    empty bounds return ``[0; I]``. Selection stays on device for CUDA Graph replay.
     """
+    return _build_mega_state_probes(k, value, gate, beta, cu_seqlens, bounds, bias=True)
+
+
+def _build_mega_state_probes(
+    k: torch.Tensor,
+    value: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    bounds: torch.Tensor | None,
+    *,
+    bias: bool,
+) -> torch.Tensor:
+    """Run the native transition probe and, when requested, the zero-state bias probe."""
     validate_available(k)
     if k.ndim != 4 or k.shape[0] != 1 or k.shape[-1] != 128:
         raise ValueError("k must have shape [1, T, H, 128]")
@@ -45,6 +103,14 @@ def build_mega_state_summaries(
         raise TypeError("gate and beta must be float32")
     if any(t.device != k.device for t in (value, gate, beta, cu_seqlens)):
         raise ValueError("all inputs must be on k.device")
+    if bounds is not None and (
+        bounds.ndim != 2
+        or bounds.shape[1] != 2
+        or bounds.dtype != torch.int32
+        or bounds.device != k.device
+        or not bounds.is_contiguous()
+    ):
+        raise ValueError("bounds must be contiguous int32 [R, 2] on k.device")
 
     with initialized_cuda_device(k):
         num_sequences, heads = cu_seqlens.shape[0] - 1, k.shape[2]
@@ -52,38 +118,140 @@ def build_mega_state_summaries(
             num_sequences, heads, 256, 128, dtype=torch.float32, device=k.device
         )
         summaries[:, :, 128:, :].diagonal(dim1=-2, dim2=-1).fill_(1)
-        if k.shape[1] == 0:
+        if k.shape[1] != 0 and (bounds is None or bounds.shape[0] != 0):
+            schedule = prepare_mega_schedule(
+                gate,
+                cu_seqlens,
+                tile_tokens=16,
+                counter_count=2,
+                split=False,
+                stream=torch.cuda.current_stream(k.device).cuda_stream,
+            )
+            if bounds is not None:
+                _select_summary_work[(num_sequences, heads)](
+                    cu_seqlens,
+                    bounds,
+                    schedule.work_items,
+                    schedule.work_count,
+                    heads,
+                    bounds.shape[0],
+                )
+            workspace = torch.empty(
+                ceildiv(tensormap_workspace_bytes(kda_recompute_f16, num_sequences), 8),
+                dtype=torch.int64,
+                device=k.device,
+            )
+            for transition_only in (False, True) if bias else (True,):
+                if bounds is not None:
+                    schedule.counters.zero_()
+                kda_recompute_f16.chunk_kda_recompute_sm100(
+                    k[0],
+                    None if transition_only else value[0],
+                    gate[0],
+                    beta[0],
+                    cu_seqlens,
+                    initial_state=None,
+                    output_state=summaries[:, :, 128:, :]
+                    if transition_only
+                    else summaries[:, :, :128, :],
+                    work_items=schedule.work_items,
+                    work_count=schedule.work_count,
+                    sched_ctr=schedule.counters,
+                    sched_all=schedule.counters,
+                    order_in_prologue=bounds is None,
+                    tensormap_workspace=workspace,
+                    transition_only=transition_only,
+                )
+        if bounds is None:
             return summaries
+        selected = torch.empty(
+            bounds.shape[0], heads, 256, 128, device=k.device, dtype=torch.float32
+        )
+        if bounds.shape[0]:
+            _gather_summary_rows[(bounds.shape[0], heads, 32)](
+                summaries, cu_seqlens, bounds, selected, heads, num_sequences, 1024
+            )
+        return selected
+
+
+def build_mega_state_grad_summaries(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    value: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    d_output: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    scale: float,
+    *,
+    transpose_forward_transition: bool = False,
+) -> torch.Tensor:
+    """Return whole-sequence FP32 ``[C; R]`` probes for ``d_entry = d_exit @ R + C``.
+
+    C uses native bprop with zero exit cotangent. Its dH recurrence does not read V or the
+    checkpoints, so broadcast zero checkpoints avoid a forward state recompute and its large
+    checkpoint allocation. The unchanged kernel still computes/discards token gradients.
+
+    By default R is one native backward pass with all 128 identity rows seeded together and
+    zero d_output. ``transpose_forward_transition=True`` instead uses the cheaper forward
+    A.T probe: algebraically the adjoint, but NOT native backward rounding. Canonical Mega CP
+    explicitly selects this approximate numerical baseline; it remains ownership-invariant.
+    """
+    validate_available(q)
+    with initialized_cuda_device(q):
+        sequences, heads = cu_seqlens.numel() - 1, q.shape[2]
+        if transpose_forward_transition:
+            maps = _build_mega_state_probes(k, value, gate, beta, cu_seqlens, None, bias=False)
+            maps[:, :, 128:].copy_(maps[:, :, 128:].transpose(-1, -2).contiguous())
+        else:
+            maps = torch.zeros(sequences, heads, 256, 128, device=q.device)
+            maps[:, :, 128:].diagonal(dim1=-2, dim2=-1).fill_(1)
+        if q.shape[1] == 0:
+            return maps
         schedule = prepare_mega_schedule(
             gate,
             cu_seqlens,
             tile_tokens=16,
             counter_count=2,
             split=False,
-            stream=torch.cuda.current_stream(k.device).cuda_stream,
+            stream=torch.cuda.current_stream(q.device).cuda_stream,
         )
         workspace = torch.empty(
-            ceildiv(tensormap_workspace_bytes(kda_recompute_f16, num_sequences), 8),
+            ceildiv(tensormap_workspace_bytes(kda_bprop_f16, sequences), 8),
             dtype=torch.int64,
-            device=k.device,
+            device=q.device,
         )
-        for transition_only in (False, True):
-            kda_recompute_f16.chunk_kda_recompute_sm100(
+        # Zero-stride checkpoint rows are legal in the native TMA ABI. All sequence-local
+        # checkpoint descriptors address this single tile, regardless of packed token count.
+        checkpoints = torch.zeros(1, heads, 128, 128, device=q.device, dtype=q.dtype).expand(
+            q.shape[1] // 16 + sequences, -1, -1, -1
+        )
+        scratch = [torch.empty_like(t[0]) for t in (q, k, value, gate, beta)]
+        for transition in (False,) if transpose_forward_transition else (False, True):
+            exit_state = None
+            do = d_output
+            if transition:
+                exit_state = torch.eye(128, device=q.device).expand(sequences, heads, 128, 128)
+                do = torch.zeros_like(d_output[:, :1]).expand_as(d_output)
+            kda_bprop_f16.chunk_kda_bwd_sm100(
+                q[0],
                 k[0],
-                None if transition_only else value[0],
+                value[0],
                 gate[0],
                 beta[0],
+                do[0],
+                checkpoints,
+                *scratch,
                 cu_seqlens,
-                initial_state=None,
-                output_state=summaries[:, :, 128:, :]
-                if transition_only
-                else summaries[:, :, :128, :],
+                scale,
+                use_initial_state=True,
+                d_initial_state=maps[:, :, 128:] if transition else maps[:, :, :128],
+                d_final_state=exit_state,
                 work_items=schedule.work_items,
                 work_count=schedule.work_count,
-                sched_ctr=schedule.counters,
+                sched_ctr=schedule.counters if sequences * heads <= schedule.num_sms else None,
                 sched_all=schedule.counters,
                 order_in_prologue=True,
                 tensormap_workspace=workspace,
-                transition_only=transition_only,
             )
-        return summaries
+        return maps

--- a/attn_gym/linear/context_parallel.py
+++ b/attn_gym/linear/context_parallel.py
@@ -653,13 +653,18 @@ class PreparedForward(Protocol):
         ...
 
     def state_summaries(
-        self, bounds: torch.Tensor, *, deterministic_work: bool = False
+        self,
+        bounds: torch.Tensor,
+        *,
+        deterministic_work: bool = False,
+        whole_sequences: bool = False,
     ) -> torch.Tensor:
         """One ``[HV, V + K, K]`` affine summary per ``[start, stop)`` row of ``bounds``.
 
-        ``deterministic_work=True`` pins the summary kernels' work partition so the result does
-        not depend on the span length, the range count, or the device (the deterministic CP
-        recipe requires it); the default keeps the throughput-oriented planner.
+        ``deterministic_work`` pins the summary kernels' work partition so the maps do not
+        depend on span length, range count, or SM count (the deterministic recipe needs this).
+        ``whole_sequences`` promises every nonempty row is a complete subsequence, letting an op
+        substitute a whole-sequence kernel.
         """
         ...
 
@@ -712,7 +717,7 @@ def summary_slots(prepared: PreparedForward, routing: ContextParallelRouting) ->
     Fragments whose last subsequence ends its sequence have an empty range and send the identity.
     """
     with profiler_range("cp/state_summaries"):
-        return prepared.state_summaries(routing.forward_bounds)
+        return prepared.state_summaries(routing.forward_bounds, whole_sequences=True)
 
 
 def grad_summary_slots(

--- a/attn_gym/linear/gdn/stages.py
+++ b/attn_gym/linear/gdn/stages.py
@@ -76,7 +76,11 @@ class ChunkGDNPrepared:
     scale: float
 
     def state_summaries(
-        self, bounds: torch.Tensor, *, deterministic_work: bool = False
+        self,
+        bounds: torch.Tensor,
+        *,
+        deterministic_work: bool = False,
+        whole_sequences: bool = False,
     ) -> torch.Tensor:
         """Return one FP32 ``[HV, V + K, K]`` map per row of ``bounds`` in a single launch.
 

--- a/attn_gym/linear/kda/context_parallel.py
+++ b/attn_gym/linear/kda/context_parallel.py
@@ -46,9 +46,10 @@ def context_parallel_kda(
 
     See ``attn_gym.linear.context_parallel.context_parallel_chunk`` for the argument contract;
     ``scale``, ``autotune``, and ``kernel_options`` follow ``chunk_kda``. With
-    ``kernel_options={"backend": "mega"}`` the local pass runs on Mega and the fused factors are
-    computed once over the span for the summaries; its backward is Mega's native stateful kernel,
-    so ``fastmath`` applies only to the fused backend's backward.
+    ``kernel_options={"backend": "mega"}`` the local pass and forward summaries run on Mega
+    (native BT16 probes define a new standard-CP numerical baseline); only reverse summaries
+    still use fused factors. Its backward is Mega's native stateful kernel, so ``fastmath``
+    applies only to the fused backend's backward.
     """
     stages = _kda_stages(scale, autotune, fastmath, kernel_options)
     return context_parallel_chunk(stages, q, k, v, gate, beta, routing=routing, group=group)

--- a/attn_gym/linear/kda/stages.py
+++ b/attn_gym/linear/kda/stages.py
@@ -153,7 +153,11 @@ class ChunkKDAPrepared:
     schedule: ScheduleRequest
 
     def state_summaries(
-        self, bounds: torch.Tensor, *, deterministic_work: bool = False
+        self,
+        bounds: torch.Tensor,
+        *,
+        deterministic_work: bool = False,
+        whole_sequences: bool = False,
     ) -> torch.Tensor:
         """Return one FP32 ``[HV, V + K, K]`` map per row of ``bounds`` in a single launch.
 
@@ -162,7 +166,8 @@ class ChunkKDAPrepared:
         yields the identity. The ranges are read on the device, so a CUDA Graph captured around
         this call replays for any layout of the same shape. ``deterministic_work=True`` pins
         each range's recurrence partition for canonical tile batching; factor preparation
-        must also use ``autotune=False``.
+        must also use ``autotune=False``. ``whole_sequences=True`` additionally promises
+        whole subsequences, enabling native probes on Mega (no effect on fused KDA).
         """
         return build_state_summaries(
             self.factors.kg,
@@ -197,9 +202,10 @@ class ChunkKDAPrepared:
 
 @dataclass
 class ChunkKDAMegaPrepared:
-    """Mega forward handle with native whole-sequence summaries for canonical CP.
+    """Mega forward handle with native whole-sequence summaries for both CP recipes.
 
-    ``deterministic_work=True`` uses native BT16 state probes, without materializing WY factors.
+    ``whole_sequences=True`` or ``deterministic_work=True`` uses native BT16 state probes,
+    without materializing WY factors.
     Arbitrary chunk-aligned ranges retain the fused summary path. The backward handle is
     :class:`ChunkKDAMegaBackward`.
     """
@@ -212,25 +218,35 @@ class ChunkKDAMegaPrepared:
     schedule: ScheduleRequest = ScheduleRequest.AUTO
 
     def state_summaries(
-        self, bounds: torch.Tensor, *, deterministic_work: bool = False
+        self,
+        bounds: torch.Tensor,
+        *,
+        deterministic_work: bool = False,
+        whole_sequences: bool = False,
     ) -> torch.Tensor:
         """Return FP32 ``[B; A]`` maps, using native probes for canonical whole sequences.
 
         With ``deterministic_work=True``, bounds must be exactly the consecutive pairs of
         ``saved.cu_seqlens``, in order. Values are a caller contract (no device-to-host sync).
-        Native BT16 rounding defines a new canonical baseline, not unsharded Mega bit parity.
-        Otherwise arbitrary chunk-aligned bounds use the fused summary contract described by
-        ``ChunkKDAPrepared.state_summaries``.
+        ``whole_sequences=True`` accepts any selection/reordering of those pairs, plus empty
+        rows. Native BT16 rounding defines new standard and canonical Mega-CP baselines,
+        not unsharded Mega bit parity. Otherwise arbitrary chunk-aligned bounds use the fused
+        summary contract described by ``ChunkKDAPrepared.state_summaries``.
         """
         saved = self.saved
-        if deterministic_work:
+        if deterministic_work or whole_sequences:
             # Lazy import keeps the optional CuTeDSL 4.7 backend out of the fused import path.
             from attn_gym.linear._delta_rule.mega.state_summary import build_mega_state_summaries
 
-            if bounds.shape != (saved.cu_seqlens.shape[0] - 1, 2):
+            if deterministic_work and bounds.shape != (saved.cu_seqlens.shape[0] - 1, 2):
                 raise ValueError("native Mega summaries require one bound per whole subsequence")
             return build_mega_state_summaries(
-                saved.k, saved.v, saved.gate, saved.beta, saved.cu_seqlens
+                saved.k,
+                saved.v,
+                saved.gate,
+                saved.beta,
+                saved.cu_seqlens,
+                bounds=None if deterministic_work else bounds,
             )
         factors = _prepare_chunk_kda_fwd(
             saved.q,
@@ -298,7 +314,7 @@ def chunk_kda_prepare(
     dimension must be one so token offsets index one packed span (NOTE [Terminology] in
     ``attn_gym.linear.context_parallel``).
     ``kernel_options={"backend": "mega"}`` runs the local pass with Mega; canonical whole-sequence
-    summaries (``deterministic_work=True``) also use Mega, while arbitrary-range summaries retain
+    summaries (``whole_sequences=True`` or ``deterministic_work=True``) also use Mega, while arbitrary-range summaries retain
     fused factors. Split schedules are not available with entry states.
     """
     backend, split_backward, split_forward, schedule = resolve_kernel_options(kernel_options)
@@ -418,16 +434,12 @@ class ChunkKDABackward:
 
 @dataclass
 class ChunkKDAMegaBackward:
-    """Mega backward handle: native stateful kernels for ``run``, fused factors for summaries.
+    """Native stateful backward, with native canonical or fused arbitrary-range summaries.
 
-    ``run`` is the native Mega backward (checkpoint recompute + BT16 backward) from the saved
-    entry state and the exit cotangent: given the states Mega itself hands over, fragments cut at
-    16-token document offsets reproduce the unsharded Mega gradients bit for bit (the summaries'
-    FP32 maps round the handed-over values differently). ``state_grad_summaries``
-    still recomputes the fused factors over the whole local stream, as the forward handle's
-    ``state_summaries`` does; Mega emits no per-range reverse maps yet, and this pass includes the
-    fused state recompute the summaries do not read. Unlike :class:`ChunkKDABackward`, nothing is
-    consumed, so ``run`` and ``state_grad_summaries`` may be called in either order.
+    Canonical reverse maps use native zero-exit C and the forward transition A.T, explicitly
+    not the native identity-seeded adjoint rounding. This is a new canonical Mega-CP baseline.
+    Arbitrary-range and standard-CP reverse maps retain fused factors. Nothing is consumed, so
+    ``run`` and ``state_grad_summaries`` may be called in either order.
     """
 
     saved: ChunkKDAMegaSaved
@@ -443,9 +455,29 @@ class ChunkKDAMegaBackward:
     ) -> torch.Tensor:
         """Return one FP32 ``[HV, V + K, K]`` reverse map per row of ``bounds`` in one launch.
 
-        Same contract as ``ChunkKDABackward.state_grad_summaries``.
+        Same range contract as ``ChunkKDABackward.state_grad_summaries``. With
+        ``deterministic_work=True``, bounds must equal the consecutive cu_seqlens pairs
+        in order, and native C plus forward A.T replace the fused numerical baseline.
         """
         saved = self.saved
+        if deterministic_work:
+            from attn_gym.linear._delta_rule.mega.state_summary import (
+                build_mega_state_grad_summaries,
+            )
+
+            if bounds.shape != (saved.cu_seqlens.shape[0] - 1, 2):
+                raise ValueError("native Mega summaries require one bound per whole subsequence")
+            return build_mega_state_grad_summaries(
+                saved.q,
+                saved.k,
+                saved.v,
+                saved.gate,
+                saved.beta,
+                self.d_output,
+                saved.cu_seqlens,
+                self.scale,
+                transpose_forward_transition=True,
+            )
         prepared = _prepare_chunk_kda_bwd(
             saved.q,
             saved.k,

--- a/test/kda/mega/test_kda_mega_native_summary.py
+++ b/test/kda/mega/test_kda_mega_native_summary.py
@@ -12,9 +12,12 @@ pytest.importorskip("cutlass.experimental", reason="native Mega summaries requir
 from attn_gym.linear._delta_rule.mega.kernels import kda_prefill_f16
 from attn_gym.linear._delta_rule.mega.kernels.common.host import tensormap_workspace_bytes
 from attn_gym.linear._delta_rule.mega.schedule import prepare_mega_schedule
-from attn_gym.linear._delta_rule.mega.state_summary import build_mega_state_summaries
+from attn_gym.linear._delta_rule.mega.state_summary import (
+    build_mega_state_grad_summaries,
+    build_mega_state_summaries,
+)
 from attn_gym.linear.context_parallel import merge_state
-from attn_gym.linear.kda.stages import chunk_kda_prepare
+from attn_gym.linear.kda.stages import chunk_kda_prepare, chunk_kda_prepare_backward
 from attn_gym.testing.kda import (
     assert_matches_low_precision_reference,
     clone_kda_inputs,
@@ -169,3 +172,197 @@ def test_native_summary_cuda_graph_replay() -> None:
         actual = build_mega_state_summaries(*inputs[1:], cu)
     graph.replay()
     assert torch.equal(actual.view(torch.int32), expected.view(torch.int32))
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_native_selected_forward_bounds(dtype: torch.dtype, monkeypatch) -> None:
+    """Standard CP selects whole subsequences, reordered/duplicated or empty, on device."""
+    inputs = make_kda_test_inputs(211, dtype=dtype, gate_scale=0.02, normalize_qk=True)
+    cu = cumulative_sequence_offsets([17, 0, 65, 129])
+    prepared = chunk_kda_prepare(
+        *inputs, cu_seqlens=cu, autotune=False, kernel_options={"backend": "mega"}
+    )
+    monkeypatch.setattr(
+        "attn_gym.linear.kda.stages._prepare_chunk_kda_fwd",
+        lambda *args, **kwargs: pytest.fail("whole-sequence summaries must stay native"),
+    )
+    all_maps = build_mega_state_summaries(*inputs[1:], cu)
+    bounds = torch.tensor(
+        [[82, 211], [0, 0], [17, 82], [82, 211]], device="cuda", dtype=torch.int32
+    )
+    expected = all_maps[[3, 1, 2, 3]]
+    actual = prepared.state_summaries(bounds, whole_sequences=True)
+    assert torch.equal(actual.view(torch.int32), expected.view(torch.int32))
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = prepared.state_summaries(bounds, whole_sequences=True)
+    graph.replay()
+    assert torch.equal(captured.view(torch.int32), expected.view(torch.int32))
+    bounds.copy_(torch.tensor([[0, 17], [17, 17], [82, 211], [0, 0]], device="cuda"))
+    graph.replay()
+    assert torch.equal(captured.view(torch.int32), all_maps[[0, 1, 3, 1]].view(torch.int32))
+    bounds.zero_()
+    graph.replay()
+    assert torch.equal(captured, all_maps[1:2].expand_as(captured))
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("transpose_forward_transition", [False, True])
+def test_native_reverse_bias_and_ownership(
+    dtype: torch.dtype, transpose_forward_transition: bool, monkeypatch
+) -> None:
+    """C is exactly native dH0 and neither reverse probe depends on tile ownership/state."""
+    lengths = [17, 0, 65, 129]
+    inputs = make_kda_test_inputs(sum(lengths), dtype=dtype, gate_scale=0.02, normalize_qk=True)
+    cu = cumulative_sequence_offsets(lengths)
+    d_output = torch.randn_like(inputs[2])
+    prepared = chunk_kda_prepare(
+        *inputs, cu_seqlens=cu, autotune=False, kernel_options={"backend": "mega"}
+    )
+    initial = torch.randn(4, 1, 128, 128, device="cuda")
+    backward = chunk_kda_prepare_backward(
+        prepared.saved, d_output, initial, scale=prepared.scale, autotune=False
+    )
+    maps = build_mega_state_grad_summaries(
+        *inputs,
+        d_output,
+        cu,
+        prepared.scale,
+        transpose_forward_transition=transpose_forward_transition,
+    )
+    expected = backward.run()[-1]
+    assert torch.equal(maps[:, :, :128], expected)
+    monkeypatch.setattr(
+        "attn_gym.linear.kda.stages._prepare_chunk_kda_bwd",
+        lambda *args, **kwargs: pytest.fail("canonical reverse summaries must stay native"),
+    )
+    if transpose_forward_transition:
+        bounds = torch.stack((cu[:-1], cu[1:]), dim=1)
+        assert torch.equal(backward.state_grad_summaries(bounds, deterministic_work=True), maps)
+    else:
+        zero_backward = chunk_kda_prepare_backward(
+            prepared.saved,
+            torch.zeros_like(d_output),
+            initial,
+            scale=prepared.scale,
+            autotune=False,
+        )
+        identity = torch.eye(128, device="cuda").expand_as(initial).contiguous()
+        assert torch.equal(maps[:, :, 128:], zero_backward.run(identity)[-1])
+    for index, (start, stop) in enumerate(pairwise(cu.tolist())):
+        alone = build_mega_state_grad_summaries(
+            *(tensor[:, start:stop] for tensor in inputs),
+            d_output[:, start:stop],
+            cumulative_sequence_offsets([stop - start]),
+            prepared.scale,
+            transpose_forward_transition=transpose_forward_transition,
+        )
+        assert torch.equal(maps[index : index + 1].view(torch.int32), alone.view(torch.int32))
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("gate_value", [0.0, -0.002, -0.02])
+def test_native_reverse_matches_fp64(dtype: torch.dtype, gate_value: float) -> None:
+    """Both reverse recipes and fused maps are measured against an independent FP64 oracle."""
+    inputs = make_kda_test_inputs(129, dtype=dtype, gate_value=gate_value, normalize_qk=True)
+    cu = cumulative_sequence_offsets([129])
+    do = torch.randn_like(inputs[2])
+    scale = 0.25
+    maps = [
+        build_mega_state_grad_summaries(
+            *inputs, do, cu, scale, transpose_forward_transition=transpose
+        )
+        for transpose in (False, True)
+    ]
+    prepared = chunk_kda_prepare(*inputs, cu_seqlens=cu, scale=scale, autotune=False)
+    backward = chunk_kda_prepare_backward(prepared.saved, do, None, scale=scale, autotune=False)
+    maps.append(
+        backward.state_grad_summaries(torch.tensor([[0, 129]], device="cuda", dtype=torch.int32))
+    )
+    references = []
+    for precision in (torch.float64, torch.float32):
+        state = torch.zeros(1, 1, 128, 128, device="cuda", dtype=precision, requires_grad=True)
+        output, _ = kda_reference(*clone_kda_inputs(inputs, dtype=precision), state, scale=scale)
+        (bias,) = torch.autograd.grad(output, state, do.to(precision))
+        basis_inputs = list(clone_kda_inputs(inputs, dtype=precision))
+        basis_inputs[2] = torch.zeros_like(basis_inputs[2])
+        _, transition = kda_reference(
+            *basis_inputs, torch.eye(128, device="cuda", dtype=precision)[None, None], scale=scale
+        )
+        references.append(torch.cat((bias, transition.transpose(-1, -2)), dim=-2))
+    for label, actual in zip(("native bprop", "native C + A.T", "fused"), maps, strict=True):
+        for offset, part in ((0, "C"), (128, "R")):
+            high = references[0][:, :, offset : offset + 128]
+            low = references[1][:, :, offset : offset + 128]
+            got = actual[:, :, offset : offset + 128]
+            if part == "R" and label != "fused":
+                # Native R rounds the recurrent state/decay every BT16, not just at the
+                # output. A uniform gate can bias those roundings in the same direction;
+                # allow one source epsilon per chunk, rather than the single-round budget.
+                allowance = ceildiv(inputs[0].shape[1], 16) * torch.finfo(dtype).eps
+                budget = (low.double() - high).abs().max() + allowance * high.abs().max()
+                assert torch.isfinite(got).all()
+                assert (got.double() - high).abs().max() <= budget
+            else:
+                assert_matches_low_precision_reference(
+                    got, high, low, f"{label} {part}", source_dtype=dtype
+                )
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_native_two_tile_backward_matches_fp64(dtype: torch.dtype) -> None:
+    """Native forward/reverse maps hand off both states while all five gradients track FP64."""
+    inputs = make_kda_test_inputs(129, dtype=dtype, gate_scale=0.02, normalize_qk=True)
+    cu = cumulative_sequence_offsets([64, 65])
+    bounds = torch.tensor([[0, 64], [64, 129]], device="cuda", dtype=torch.int32)
+    prepared = chunk_kda_prepare(
+        *inputs, cu_seqlens=cu, autotune=False, kernel_options={"backend": "mega"}
+    )
+    maps = prepared.state_summaries(bounds, deterministic_work=True)
+    entry0 = torch.zeros_like(maps[0, :, :128])
+    entries = torch.stack((entry0, merge_state(entry0, maps[0])))
+    output, final = prepared.run(entries, output_final_state=True)
+    do = torch.randn_like(output)
+    exit1 = torch.randn_like(entry0) * 0.1
+    backward = chunk_kda_prepare_backward(
+        prepared.saved, do, entries, scale=prepared.scale, autotune=False
+    )
+    reverse = backward.state_grad_summaries(bounds, deterministic_work=True)
+    exits = torch.stack((merge_state(exit1, reverse[1]), exit1))
+    gradients = backward.run(exits)[:5]
+    references = []
+    for precision in (torch.float64, torch.float32):
+        leaves = tuple(t.requires_grad_() for t in clone_kda_inputs(inputs, dtype=precision))
+        ref_output, ref_final = kda_reference(*leaves, scale=prepared.scale)
+        ref_gradients = torch.autograd.grad(
+            (ref_output, ref_final), leaves, (do.to(precision), exit1[None].to(precision))
+        )
+        references.append((ref_output, ref_final, *ref_gradients))
+    for name, actual, high, low in zip(
+        ("output", "final", "dq", "dk", "dv", "dgate", "dbeta"),
+        (output, final[-1:], *gradients),
+        *references,
+        strict=True,
+    ):
+        assert_matches_low_precision_reference(actual, high, low, name, source_dtype=dtype)
+
+
+def test_native_reverse_cuda_graph_replay() -> None:
+    inputs = make_kda_test_inputs(81, gate_scale=0.02, normalize_qk=True)
+    cu = cumulative_sequence_offsets([17, 0, 64])
+    do = torch.randn_like(inputs[2])
+    expected = build_mega_state_grad_summaries(
+        *inputs, do, cu, 128**-0.5, transpose_forward_transition=True
+    )
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        actual = build_mega_state_grad_summaries(
+            *inputs, do, cu, 128**-0.5, transpose_forward_transition=True
+        )
+    do.mul_(0.5)
+    graph.replay()
+    fresh = build_mega_state_grad_summaries(
+        *inputs, do, cu, 128**-0.5, transpose_forward_transition=True
+    )
+    assert not torch.equal(actual, expected)
+    assert torch.equal(actual.view(torch.int32), fresh.view(torch.int32))


### PR DESCRIPTION
Stacked PRs:
 * #519
 * #518
 * #517
 * __->__#516
 * #515
 * #514
 * #513
 * #512


--- --- ---

Use native Mega summaries for standard CP forward and canonical reverse maps

build_mega_state_summaries now also builds whole-subsequence reverse maps [C; R]: C is the
native backward's zero-exit entry cotangent (bitwise the ordinary stateful backward), and R is
either one native backward pass seeded with the identity or, on the canonical path, the
transpose of the forward transition (an exact adjoint algebraically, cheaper than a second
backward pass; the choice is documented in agent_space/B5_mega_reverse_report.md).

ChunkKDAMegaPrepared.state_summaries(..., whole_sequences=True) selects native [B; A] for any
ordering or subset of whole cu_seqlens pairs, including duplicate and empty bounds, through a
device work table; summary_slots() passes that promise, so standard Mega CP forward summaries no
longer recompute fused factors. This is a new standard-CP numerical baseline for the Mega
backend, not fused parity; tolerances are unchanged. Fused KDA and GDN accept the flag without
changing their arithmetic.

Two GB200s, 32k tokens, 64 heads: standard Mega CP forward 2.80 -> 2.23 ms; canonical Mega
reverse summaries 6.73 -> 5.89 ms.