### PR TITLE
Skip single-tile documents in the deterministic recipe and document its cost model

### DIFF
--- a/attn_gym/linear/_delta_rule/mega/state_summary.py
+++ b/attn_gym/linear/_delta_rule/mega/state_summary.py
@@ -185,8 +185,12 @@ def build_mega_state_grad_summaries(
     scale: float,
     *,
     transpose_forward_transition: bool = False,
+    bounds: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Return whole-sequence FP32 ``[C; R]`` probes for ``d_entry = d_exit @ R + C``.
+
+    Optional ``bounds`` (``int32 [R, 2]`` device tensor of whole consecutive cu_seqlens pairs)
+    select and order the returned rows on device; every sequence is still probed.
 
     C uses native bprop with zero exit cotangent. Its dH recurrence does not read V or the
     checkpoints, so broadcast zero checkpoints avoid a forward state recompute and its large
@@ -254,4 +258,13 @@ def build_mega_state_grad_summaries(
                 order_in_prologue=True,
                 tensormap_workspace=workspace,
             )
-        return maps
+        if bounds is None:
+            return maps
+        selected = torch.empty(
+            bounds.shape[0], heads, 256, 128, device=q.device, dtype=torch.float32
+        )
+        if bounds.shape[0]:
+            _gather_summary_rows[(bounds.shape[0], heads, 32)](
+                maps, cu_seqlens, bounds, selected, heads, sequences, 1024
+            )
+        return selected

--- a/attn_gym/linear/context_parallel_deterministic.py
+++ b/attn_gym/linear/context_parallel_deterministic.py
@@ -24,6 +24,13 @@ the whole arithmetic graph before ranks are assigned:
     entry     ``merge_state(0, prefix[i - 1])`` for tile ``i``; the first tile of a document enters
               with zero. Exits are the reverse analogue.
 
+NOTE [Single-Tile Documents]
+A document that fits in one tile has no state to carry: its tile enters with the zero state and
+nothing reads its map. Such tiles are excluded from the summaries, the exchange, and the scan
+(``CanonicalTiling.summarized``). The exclusion is a function of the tiling only, so the
+contract is unchanged, and on packings with many short documents it removes most of the
+recipe's overhead (``agent_space/friendly_fragments/REPORT.md``).
+
 NOTE [Scan Blocks]
 Exchanging every tile's map costs 128 KiB per tile per head per rank. Consecutive tiles of a
 document are therefore grouped into blocks of ``scan_block`` tiles (document-relative, the last
@@ -50,6 +57,7 @@ preparing every tile alone (``test/test_canonical_tile_batching.py``).
 
 from __future__ import annotations
 
+from collections import Counter
 from collections.abc import Sequence
 from dataclasses import dataclass
 from itertools import accumulate, pairwise
@@ -154,18 +162,25 @@ class CanonicalTiling:
         return tiling
 
     @property
+    def summarized(self) -> tuple[int, ...]:
+        """Tile ids whose maps take part in the scan: those of multi-tile documents."""
+        counts = Counter(tile.document for tile in self.tiles)
+        return tuple(i for i, tile in enumerate(self.tiles) if counts[tile.document] > 1)
+
+    @property
     def blocks(self) -> tuple[tuple[int, ...], ...]:
         """Tile ids of every scan block, in tile order (NOTE [Scan Blocks])."""
         blocks: list[tuple[int, ...]] = []
-        start = 0
-        for index in range(1, len(self.tiles) + 1):
-            if (
-                index == len(self.tiles)
-                or self.tiles[index].document != self.tiles[start].document
+        run: list[int] = []
+        for index in (*self.summarized, None):
+            if run and (
+                index is None or self.tiles[index].document != self.tiles[run[0]].document
             ):
-                for begin in range(start, index, self.scan_block):
-                    blocks.append(tuple(range(begin, min(begin + self.scan_block, index))))
-                start = index
+                for begin in range(0, len(run), self.scan_block):
+                    blocks.append(tuple(run[begin : begin + self.scan_block]))
+                run = []
+            if index is not None:
+                run.append(index)
         return tuple(blocks)
 
     @property
@@ -199,22 +214,55 @@ class CanonicalTiling:
         """Materialize the index tensors the recipe reads, once per layout and device."""
         offsets = self.span_offsets()
         blocks = self.blocks
+        my_blocks = self.my_blocks
+        summarized = set(self.summarized)
+        positions = [p for p, index in enumerate(self.mine) if index in summarized]
+        first_tile = {block[0]: b for b, block in enumerate(blocks)}
+        per_rank = [[first_tile[i] for i in ids if i in first_tile] for ids in self.owned]
+        order = [b for ranks_blocks in per_rank for b in ranks_blocks]
+        width = self.slots
+        if order == list(range(len(blocks))) and len(order) == width * len(self.owned):
+            gather_place = None
+        else:
+            rows = [
+                rank * width + row
+                for rank, ranks_blocks in enumerate(per_rank)
+                for row in range(len(ranks_blocks))
+            ]
+            gather_place = (
+                torch.tensor(order, dtype=torch.int64, device=device),
+                torch.tensor(rows, dtype=torch.int64, device=device),
+            )
+        bounds = list(pairwise(offsets))
         return CanonicalRouting(
             cu_seqlens=torch.tensor(offsets, dtype=torch.int32, device=device),
-            bounds=torch.tensor(list(pairwise(offsets)), dtype=torch.int32, device=device),
-            mine=_selection(self.mine, device),
-            tile_document_offsets=_document_offsets(
-                [tile.document for tile in self.tiles], device
+            bounds=torch.tensor(bounds, dtype=torch.int32, device=device),
+            summary_bounds=torch.tensor(
+                [bounds[p] for p in positions], dtype=torch.int32, device=device
+            ).reshape(-1, 2),
+            summarized_positions=(
+                None
+                if len(positions) == len(self.mine)
+                else torch.tensor(positions, dtype=torch.int64, device=device)
             ),
             block_document_offsets=_document_offsets(
                 [self.tiles[block[0]].document for block in blocks], device
             ),
             my_block_offsets=torch.tensor(
-                [0, *accumulate(len(blocks[b]) for b in self.my_blocks)],
+                [0, *accumulate(len(blocks[b]) for b in my_blocks)],
                 dtype=torch.int32,
                 device=device,
             ),
-            my_blocks=_selection(self.my_blocks, device),
+            my_blocks=_selection(my_blocks, device),
+            my_block_tiles=_selection(
+                [
+                    sum(len(blocks[b]) for b in range(block)) + offset
+                    for block in my_blocks
+                    for offset in range(len(blocks[block]))
+                ],
+                device,
+            ),
+            gather_place=gather_place,
         )
 
 
@@ -230,18 +278,22 @@ class CanonicalRouting(NamedTuple):
     """Device tensors of a :class:`CanonicalTiling` for one rank, built once per layout.
 
     ``cu_seqlens``/``bounds`` describe the rank's span with one segment per owned tile;
-    ``mine`` (and ``my_blocks``) select the rank's tiles (blocks) in a tile-order (block-order)
-    buffer, as a slice when they are consecutive so no gather copy is made; the document
-    offsets give the per-document scans their restart points.
+    ``summary_bounds`` are the rows of ``bounds`` whose tiles take part in the scan and
+    ``summarized_positions`` their positions among the owned tiles (``None`` when all do).
+    ``my_blocks`` / ``my_block_tiles`` select this rank's blocks / block tiles in the block-order
+    exchange buffer, as a slice when consecutive so no gather copy is made; ``gather_place``
+    reorders the all-gather packets into block order (``None`` when they already are).
     """
 
     cu_seqlens: torch.Tensor
     bounds: torch.Tensor
-    mine: torch.Tensor | slice
-    tile_document_offsets: torch.Tensor
+    summary_bounds: torch.Tensor
+    summarized_positions: torch.Tensor | None
     block_document_offsets: torch.Tensor
     my_block_offsets: torch.Tensor
     my_blocks: torch.Tensor | slice
+    my_block_tiles: torch.Tensor | slice
+    gather_place: tuple[torch.Tensor, torch.Tensor] | None
 
 
 def _selection(ids: Sequence[int], device: torch.device | str) -> torch.Tensor | slice:
@@ -265,6 +317,7 @@ def tile_stream(cu_seqlens_global: Sequence[int], tile_size: int) -> list[Tile]:
 def all_gather_block_maps(
     local: torch.Tensor | None,
     tiling: CanonicalTiling,
+    routing: CanonicalRouting,
     like: torch.Tensor,
     group: dist.ProcessGroup | None,
 ) -> torch.Tensor:
@@ -291,25 +344,16 @@ def all_gather_block_maps(
     gathered = like.new_empty((world * width, *like.shape[1:]))
     with profiler_range("cp/all_gather_blocks"):
         dist.all_gather_into_tensor(gathered, packet, group=group)
-    per_rank = [
-        [b for b, block in enumerate(tiling.blocks) if block[0] in set(ids)]
-        for ids in tiling.owned
-    ]
-    order = [b for blocks in per_rank for b in blocks]
-    if order == list(range(len(order))) and len(order) == world * width:
+    if routing.gather_place is None:
         return gathered
-    rows = [
-        rank * width + row for rank, blocks in enumerate(per_rank) for row in range(len(blocks))
-    ]
+    order, rows = routing.gather_place
     placed = torch.empty_like(gathered[: len(tiling.blocks)])
-    placed[torch.tensor(order, device=like.device)] = gathered[
-        torch.tensor(rows, device=like.device)
-    ]
+    placed[order] = gathered[rows]
     return placed
 
 
 def canonical_entries(
-    tile_maps: torch.Tensor | None,
+    summary_maps: torch.Tensor | None,
     tiling: CanonicalTiling,
     routing: CanonicalRouting,
     like: torch.Tensor,
@@ -319,34 +363,47 @@ def canonical_entries(
 ) -> torch.Tensor | None:
     """Entry (or exit when ``reverse``) FP32 states of this rank's tiles, in ``tiling.mine`` order.
 
-    With ``scan_block == 1`` every tile map is gathered and scanned per document. Otherwise the
-    fixed three-level tree of NOTE [Scan Blocks]: fold each owned block's tile maps into one block
-    map; all-gather block maps; scan them per document for the block entry states; fold each
-    owned block's tiles again from its entry state for the tile states. Every fold is the
-    left-to-right (right-to-left when ``reverse``) serial fold in three-pass TF32, so the result
-    is a function of the tiles' maps and indices only.
+    ``summary_maps`` are the maps of the rank's summarized tiles (NOTE [Single-Tile Documents])
+    in span order, or ``None`` for an empty rank (which still joins the collective). Tiles of
+    single-tile documents get the zero state.
+
+    With ``scan_block == 1`` every summarized tile map is gathered and scanned per document.
+    Otherwise the fixed three-level tree of NOTE [Scan Blocks]: fold each owned block's tile maps
+    into one block map; all-gather block maps; scan them per document for the block entry states;
+    fold each owned block's tiles again from its entry state for the tile states. Every fold is
+    the left-to-right (right-to-left when ``reverse``) serial fold in three-pass TF32, so the
+    result is a function of the tiles' maps and indices only.
     """
+    if summary_maps is None or summary_maps.shape[0] == 0:
+        # An empty rank, or one owning only single-tile documents, still joins the collective.
+        all_gather_block_maps(None, tiling, routing, like, group)
+        if summary_maps is None:
+            return None
+        return like.new_zeros(
+            (len(tiling.mine), like.shape[1], like.shape[2] - like.shape[3], like.shape[3])
+        )
     if tiling.scan_block == 1:
-        gathered = all_gather_block_maps(tile_maps, tiling, like, group)
-        entries = canonical_scan_entries(gathered, routing.tile_document_offsets, reverse=reverse)
-        return entries[routing.mine] if tile_maps is not None else None
-    block_maps = (
-        fold_ranges(tile_maps, routing.my_block_offsets, reverse=reverse)
-        if tile_maps is not None
-        else None
-    )
-    gathered = all_gather_block_maps(block_maps, tiling, like, group)
-    block_entries = canonical_scan_entries(
-        gathered, routing.block_document_offsets, reverse=reverse
-    )
-    if tile_maps is None:
-        return None
-    return canonical_scan_entries(
-        tile_maps,
-        routing.my_block_offsets,
-        reverse=reverse,
-        initial=block_entries[routing.my_blocks],
-    )
+        gathered = all_gather_block_maps(summary_maps, tiling, routing, like, group)
+        entries = canonical_scan_entries(
+            gathered, routing.block_document_offsets, reverse=reverse
+        )[routing.my_block_tiles]
+    else:
+        block_maps = fold_ranges(summary_maps, routing.my_block_offsets, reverse=reverse)
+        gathered = all_gather_block_maps(block_maps, tiling, routing, like, group)
+        block_entries = canonical_scan_entries(
+            gathered, routing.block_document_offsets, reverse=reverse
+        )
+        entries = canonical_scan_entries(
+            summary_maps,
+            routing.my_block_offsets,
+            reverse=reverse,
+            initial=block_entries[routing.my_blocks],
+        )
+    if routing.summarized_positions is None:
+        return entries
+    full = entries.new_zeros((len(tiling.mine), *entries.shape[1:]))
+    full[routing.summarized_positions] = entries
+    return full
 
 
 class _CanonicalContextParallel(torch.autograd.Function):
@@ -367,7 +424,11 @@ class _CanonicalContextParallel(torch.autograd.Function):
         n = len(tiling.mine)
         if n:
             prepared = stages.prepare(q, k, v, gate, beta, cu_seqlens=routing.cu_seqlens)
-            maps = prepared.state_summaries(routing.bounds, deterministic_work=True)
+            maps = (
+                prepared.state_summaries(routing.summary_bounds, deterministic_work=True)
+                if routing.summary_bounds.shape[0]
+                else like[:0]
+            )
         else:
             prepared = None
             maps = None
@@ -408,7 +469,11 @@ class _CanonicalContextParallel(torch.autograd.Function):
             backward = ctx.stages.prepare_backward(
                 ctx.saved_type._make(saved), d_output, entry, scale=ctx.scale
             )
-            maps = backward.state_grad_summaries(routing.bounds, deterministic_work=True)
+            maps = (
+                backward.state_grad_summaries(routing.summary_bounds, deterministic_work=True)
+                if routing.summary_bounds.shape[0]
+                else like[:0]
+            )
         else:
             backward = None
             maps = None

--- a/attn_gym/linear/kda/stages.py
+++ b/attn_gym/linear/kda/stages.py
@@ -226,27 +226,20 @@ class ChunkKDAMegaPrepared:
     ) -> torch.Tensor:
         """Return FP32 ``[B; A]`` maps, using native probes for canonical whole sequences.
 
-        With ``deterministic_work=True``, bounds must be exactly the consecutive pairs of
-        ``saved.cu_seqlens``, in order. Values are a caller contract (no device-to-host sync).
-        ``whole_sequences=True`` accepts any selection/reordering of those pairs, plus empty
-        rows. Native BT16 rounding defines new standard and canonical Mega-CP baselines,
-        not unsharded Mega bit parity. Otherwise arbitrary chunk-aligned bounds use the fused
-        summary contract described by ``ChunkKDAPrepared.state_summaries``.
+        With ``deterministic_work=True`` or ``whole_sequences=True``, bounds must be whole
+        ``saved.cu_seqlens`` pairs in any selection or order, plus empty rows; the values are a
+        caller contract (no device-to-host sync). Native BT16 rounding defines new standard and
+        canonical Mega-CP baselines, not unsharded Mega bit parity. Otherwise arbitrary
+        chunk-aligned bounds use the fused summary contract described by
+        ``ChunkKDAPrepared.state_summaries``.
         """
         saved = self.saved
         if deterministic_work or whole_sequences:
             # Lazy import keeps the optional CuTeDSL 4.7 backend out of the fused import path.
             from attn_gym.linear._delta_rule.mega.state_summary import build_mega_state_summaries
 
-            if deterministic_work and bounds.shape != (saved.cu_seqlens.shape[0] - 1, 2):
-                raise ValueError("native Mega summaries require one bound per whole subsequence")
             return build_mega_state_summaries(
-                saved.k,
-                saved.v,
-                saved.gate,
-                saved.beta,
-                saved.cu_seqlens,
-                bounds=None if deterministic_work else bounds,
+                saved.k, saved.v, saved.gate, saved.beta, saved.cu_seqlens, bounds=bounds
             )
         factors = _prepare_chunk_kda_fwd(
             saved.q,
@@ -456,8 +449,8 @@ class ChunkKDAMegaBackward:
         """Return one FP32 ``[HV, V + K, K]`` reverse map per row of ``bounds`` in one launch.
 
         Same range contract as ``ChunkKDABackward.state_grad_summaries``. With
-        ``deterministic_work=True``, bounds must equal the consecutive cu_seqlens pairs
-        in order, and native C plus forward A.T replace the fused numerical baseline.
+        ``deterministic_work=True``, bounds must be whole cu_seqlens pairs (any selection or
+        order), and native C plus forward A.T replace the fused numerical baseline.
         """
         saved = self.saved
         if deterministic_work:
@@ -465,8 +458,6 @@ class ChunkKDAMegaBackward:
                 build_mega_state_grad_summaries,
             )
 
-            if bounds.shape != (saved.cu_seqlens.shape[0] - 1, 2):
-                raise ValueError("native Mega summaries require one bound per whole subsequence")
             return build_mega_state_grad_summaries(
                 saved.q,
                 saved.k,
@@ -477,6 +468,7 @@ class ChunkKDAMegaBackward:
                 saved.cu_seqlens,
                 self.scale,
                 transpose_forward_transition=True,
+                bounds=bounds,
             )
         prepared = _prepare_chunk_kda_bwd(
             saved.q,

--- a/benchmarks/kda_cp_fragment_study.py
+++ b/benchmarks/kda_cp_fragment_study.py
@@ -1,0 +1,674 @@
+"""Fragment-plan study for CP-degree-invariant KDA: ownership, tile size, and Mega splitting.
+
+    torchrun --standalone --nproc-per-node=2 benchmarks/kda_cp_fragment_study.py ownership
+    torchrun --standalone --nproc-per-node=2 benchmarks/kda_cp_fragment_study.py tile-sweep
+    torchrun --standalone --nproc-per-node=2 benchmarks/kda_cp_fragment_study.py crossover
+    python benchmarks/kda_cp_fragment_study.py split      # single process
+
+Canonical variants mirror ``_CanonicalContextParallel`` using staged handles and CUDA events
+between phases, including the single-tile-document skip. Each is checked bitwise against the
+public autograd API before timing. Standard CP and unsharded baselines use that API directly;
+``@module`` rows expose the canonical autograd overhead. Rounds alternate variant order; tables
+report slowest-rank forward/backward medians and local phase medians, in milliseconds.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import statistics
+from collections.abc import Callable, Sequence
+from functools import partial
+from itertools import accumulate, pairwise
+from pathlib import Path
+from typing import Annotated
+
+import torch
+import torch.distributed as dist
+import typer
+from kda_cp_deterministic import (
+    PhaseClock,
+    balanced_cut,
+    clocked,
+    document_lengths,
+    forward,
+    timed,
+)
+
+from attn_gym.linear._delta_rule.triton.canonical_scan import canonical_scan_entries, fold_ranges
+from attn_gym.linear.context_parallel import ContextParallelPlan, StagedOp
+from attn_gym.linear.context_parallel_deterministic import (
+    CanonicalRouting,
+    CanonicalTiling,
+    all_gather_block_maps,
+    tile_stream,
+)
+from attn_gym.linear.kda import chunk_kda, context_parallel_kda
+from attn_gym.linear.kda.context_parallel import _kda_stages, context_parallel_kda_deterministic
+from attn_gym.testing.kda import make_kda_test_inputs
+
+app = typer.Typer(add_completion=False, pretty_exceptions_enable=False)
+
+Fragments = list[list[tuple[int, int]]]
+GRAD_NAMES = ("out", "dq", "dk", "dv", "dgate", "dbeta")
+FWD_PHASES = ("fwd/prepare", "fwd/summary", "fwd/fold", "fwd/gather", "fwd/scan", "fwd/run")
+BWD_PHASES = ("bwd/prepare", "bwd/summary", "bwd/fold", "bwd/gather", "bwd/scan", "bwd/run")
+
+
+def zipf_many_lengths(tokens: int) -> tuple[int, ...]:
+    """One long document plus six tiers of ``2**j`` documents of ``tokens / (8 * 2**j)`` each.
+
+    32k gives 8192 + 2x2048 + 4x1024 + 8x512 + 16x256 + 32x128 + 64x64: 127 documents, most
+    shorter than any practical tile.
+    """
+    if tokens <= 0 or tokens % 8192:
+        raise ValueError(
+            "zipf-many needs a positive multiple of 8192 tokens (shortest tier is 16)"
+        )
+    lengths = [tokens // 4]
+    for j in range(1, 7):
+        lengths += [tokens // (8 * 2**j)] * 2**j
+    assert sum(lengths) == tokens
+    return tuple(lengths)
+
+
+def ownership_lengths(tokens: int) -> tuple[int, ...]:
+    """Nine ragged documents whose whole-document LPT packing differs from a contiguous cut."""
+    if tokens % 32768:
+        raise ValueError("ownership set needs a multiple of 32768 tokens")
+    unit = tokens // 32
+    return tuple(unit * n for n in (12, 6, 4, 3, 2, 2, 1, 1, 1))
+
+
+def cyclic_fragments(cu: Sequence[int], tile: int, world: int) -> Fragments:
+    """Assign successive tiles round-robin."""
+    tiles = tile_stream(cu, tile)
+    return [
+        [(t.start, t.stop) for i, t in enumerate(tiles) if i % world == r] for r in range(world)
+    ]
+
+
+def halves_fragments(cu: Sequence[int], tile: int, world: int) -> Fragments:
+    """Every document cut into ``world`` tile-aligned pieces; odd leftovers alternate ranks."""
+    out: Fragments = [[] for _ in range(world)]
+    for doc, (start, stop) in enumerate(pairwise(cu)):
+        n = math.ceil((stop - start) / tile)
+        base, extra = divmod(n, world)
+        counts = [base + (1 if (r + doc) % world < extra else 0) for r in range(world)]
+        edges = [start + c * tile for c in accumulate(counts, initial=0)]
+        for r, (a, b) in enumerate(pairwise(edges)):
+            if b > a:
+                out[r].append((a, min(b, stop)))
+    return out
+
+
+def lpt_document_fragments(cu: Sequence[int], world: int) -> Fragments:
+    """Whole documents, longest first, each onto the least-loaded rank."""
+    loads = [0] * world
+    out: Fragments = [[] for _ in range(world)]
+    for start, stop in sorted(pairwise(cu), key=lambda d: d[0] - d[1]):
+        r = loads.index(min(loads))
+        out[r].append((start, stop))
+        loads[r] += stop - start
+    return [sorted(f) for f in out]
+
+
+def skew_fragments(cu: Sequence[int], tile: int, world: int, share: float) -> Fragments:
+    """Rank 0 owns a contiguous ``share`` of the tiles; the others split the rest evenly."""
+    tiles = tile_stream(cu, tile)
+    first = round(len(tiles) * share)
+    cuts = [
+        0,
+        first,
+        *(first + (len(tiles) - first) * (r + 1) // (world - 1) for r in range(world - 1)),
+    ]
+    return [[(tiles[a].start, tiles[b - 1].stop)] if b > a else [] for a, b in pairwise(cuts)]
+
+
+def layout_fragments(name: str, cu: Sequence[int], tile: int, world: int) -> Fragments:
+    """Build the selected ownership table without changing the canonical tile grid."""
+    match name:
+        case "contiguous":
+            return balanced_cut(tuple(cu), tile, world)
+        case "halves":
+            return halves_fragments(cu, tile, world)
+        case "cyclic":
+            return cyclic_fragments(cu, tile, world)
+        case "lpt-docs":
+            return lpt_document_fragments(cu, world)
+        case "all-on-0":
+            return [[(0, cu[-1])]] + [[] for _ in range(world - 1)]
+        case _ if name.startswith("skew-"):
+            return skew_fragments(cu, tile, world, int(name[5:]) / 100)
+        case _:
+            raise ValueError(f"unknown layout {name}")
+
+
+def bits_differ(actual: torch.Tensor, expected: torch.Tensor) -> int:
+    """Count unequal storage representations, including signed zeros."""
+    assert actual.shape == expected.shape and actual.dtype == expected.dtype, (
+        actual.shape,
+        expected.shape,
+    )
+    view = torch.int16 if actual.dtype == torch.bfloat16 else torch.int32
+    return int((actual.contiguous().view(view) != expected.contiguous().view(view)).sum())
+
+
+def canonical_states(
+    summary_maps: torch.Tensor,
+    tiling: CanonicalTiling,
+    routing: CanonicalRouting,
+    like: torch.Tensor,
+    group: dist.ProcessGroup,
+    clock: PhaseClock,
+    *,
+    reverse: bool,
+) -> torch.Tensor:
+    """``canonical_entries`` with a clock mark after the block fold, the gather, and the scan.
+
+    Same statements as the module function, in the same order; the marks are the only addition
+    (checked bitwise against the module's autograd path in ``Study.add_canonical``).
+    """
+    prefix = "bwd" if reverse else "fwd"
+    if summary_maps.shape[0] == 0:
+        clock.mark(f"{prefix}/fold")
+        all_gather_block_maps(summary_maps, tiling, routing, like, group)
+        clock.mark(f"{prefix}/gather")
+        states = like.new_zeros(
+            (len(tiling.mine), like.shape[1], like.shape[2] - like.shape[3], like.shape[3])
+        )
+        clock.mark(f"{prefix}/scan")
+        return states
+    if tiling.scan_block == 1:
+        clock.mark(f"{prefix}/fold")
+        gathered = all_gather_block_maps(summary_maps, tiling, routing, like, group)
+        clock.mark(f"{prefix}/gather")
+        entries = canonical_scan_entries(
+            gathered, routing.block_document_offsets, reverse=reverse
+        )[routing.my_blocks]
+    else:
+        block_maps = fold_ranges(summary_maps, routing.my_block_offsets, reverse=reverse)
+        clock.mark(f"{prefix}/fold")
+        gathered = all_gather_block_maps(block_maps, tiling, routing, like, group)
+        clock.mark(f"{prefix}/gather")
+        block_entries = canonical_scan_entries(
+            gathered, routing.block_document_offsets, reverse=reverse
+        )
+        entries = canonical_scan_entries(
+            summary_maps,
+            routing.my_block_offsets,
+            reverse=reverse,
+            initial=block_entries[routing.my_blocks],
+        )
+    if routing.summarized_positions is not None:
+        full = entries.new_zeros((len(tiling.mine), *entries.shape[1:]))
+        full[routing.summarized_positions] = entries
+        entries = full
+    clock.mark(f"{prefix}/scan")
+    return entries
+
+
+def canonical_step(
+    stages: StagedOp,
+    local: tuple[torch.Tensor, ...],
+    grad: torch.Tensor,
+    tiling: CanonicalTiling,
+    routing: CanonicalRouting,
+    group: dist.ProcessGroup,
+    clock: PhaseClock,
+) -> tuple[torch.Tensor, ...]:
+    """``context_parallel_chunk_deterministic`` fwd+bwd by hand, one clock mark per phase.
+
+    Keeps the module's arithmetic and collective order; omits autograd tape bookkeeping.
+    """
+    q, k, v, gate, beta = local
+    heads, dim, value_dim = v.shape[2], q.shape[3], v.shape[3]
+    n = len(tiling.mine)
+    like = q.new_empty((0, heads, value_dim + dim, dim), dtype=torch.float32)
+    summarized = routing.summary_bounds.shape[0]
+    prepared = backward = None
+    clock.mark("start")
+    if n:
+        prepared = stages.prepare(q, k, v, gate, beta, cu_seqlens=routing.cu_seqlens)
+    clock.mark("fwd/prepare")
+    maps = like
+    if n and summarized:
+        maps = prepared.state_summaries(routing.summary_bounds, deterministic_work=True)
+    clock.mark("fwd/summary")
+    entry = canonical_states(maps, tiling, routing, like, group, clock, reverse=False)
+    output = prepared.run(entry, output_final_state=False)[0] if n else v[:, :0]
+    clock.mark("fwd/run")
+
+    if n:
+        backward = stages.prepare_backward(prepared.saved, grad, entry, scale=prepared.scale)
+    clock.mark("bwd/prepare")
+    rmaps = like
+    if n and summarized:
+        rmaps = backward.state_grad_summaries(routing.summary_bounds, deterministic_work=True)
+    clock.mark("bwd/summary")
+    exit_cotangent = canonical_states(rmaps, tiling, routing, like, group, clock, reverse=True)
+    grads = backward.run(exit_cotangent)[:5] if n else tuple(t[:, :0] for t in local)
+    clock.mark("bwd/run")
+    return (output, *grads)
+
+
+def autograd_step(
+    fwd: Callable[[], tuple[torch.Tensor, tuple[torch.Tensor, ...], torch.Tensor]],
+    clock: PhaseClock,
+) -> tuple[torch.Tensor, ...]:
+    """Public-API fwd+bwd: two intervals, ``fwd/run`` and ``bwd/run``."""
+    clock.mark("start")
+    out, leaves, grad = fwd()
+    clock.mark("fwd/run")
+    grads = torch.autograd.grad(out, leaves, grad)
+    clock.mark("bwd/run")
+    return (out.detach(), *grads)
+
+
+class Study:
+    """Inputs, group, and the variant table of one torchrun session."""
+
+    def __init__(self, tokens: int, heads: int, backend: str, lengths: Sequence[int]) -> None:
+        """Initialize a two-or-more-rank study with identical seeded global inputs."""
+        self.rank, self.world = int(os.environ["RANK"]), int(os.environ["WORLD_SIZE"])
+        self.device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+        torch.cuda.set_device(self.device)
+        dist.init_process_group("nccl", device_id=self.device)
+        self.group = dist.group.WORLD
+        self.tokens, self.heads, self.backend = tokens, heads, backend
+        self.options = {"backend": backend} if backend != "fused" else None
+        self.stages = _kda_stages(None, False, False, self.options)
+        self.lengths = tuple(lengths)
+        self.cu = (0, *accumulate(self.lengths))
+        torch.manual_seed(0)
+        self.inputs = make_kda_test_inputs(
+            tokens,
+            heads=heads,
+            seed=0,
+            normalize_qk=True,
+            sigmoid_beta=True,
+            gate_scale=0.02,
+            log_uniform_gate=False,
+        )
+        self.grad = torch.randn_like(self.inputs[2])
+        self.variants: dict[str, Callable[[PhaseClock], tuple[torch.Tensor, ...]]] = {}
+        self.checks: dict[str, dict[str, int]] = {}
+
+    def log(self, *args) -> None:
+        """Print layout information once across ranks."""
+        if self.rank == 0:
+            print(*args, flush=True)
+
+    def gather_local(self, ids: torch.Tensor) -> tuple[tuple[torch.Tensor, ...], torch.Tensor]:
+        """Copy inputs and output cotangents into the rank-local span order."""
+        return tuple(v[:, ids].contiguous() for v in self.inputs), self.grad[:, ids].contiguous()
+
+    def add_unsharded(self) -> None:
+        """Register the CP=1 reference cost on every rank."""
+        op = partial(
+            chunk_kda,
+            cu_seqlens=torch.tensor(self.cu, dtype=torch.int32, device=self.device),
+            kernel_options=self.options,
+            autotune=False,
+        )
+        self.variants["unsharded"] = partial(
+            autograd_step, partial(forward, op, self.inputs, self.grad)
+        )
+
+    def add_standard(self, name: str, fragments: Fragments) -> None:
+        """Register the public standard recipe, which does not support empty spans."""
+        if any(not f for f in fragments):
+            return
+        plan = ContextParallelPlan.from_fragments(self.cu, fragments, self.rank)
+        local, grad = self.gather_local(plan.global_token_ids(self.device))
+        op = partial(
+            context_parallel_kda,
+            routing=plan.routing(self.device),
+            group=self.group,
+            kernel_options=self.options,
+            autotune=False,
+        )
+        self.variants[name] = partial(autograd_step, partial(forward, op, local, grad))
+
+    def add_canonical(
+        self,
+        name: str,
+        fragments: Fragments,
+        tile: int,
+        *,
+        scan_block: int = 1,
+        module: bool = False,
+    ) -> None:
+        """Register the hand-run canonical recipe (and, with ``module``, the autograd path)."""
+        tiling = CanonicalTiling.from_fragments(
+            self.cu, fragments, self.rank, tile_size=tile, scan_block=scan_block
+        )
+        routing = tiling.routing(self.device)
+        ids = tiling.global_token_ids(self.device)
+        local, grad = self.gather_local(ids)
+        self.variants[name] = partial(
+            canonical_step, self.stages, local, grad, tiling, routing, self.group
+        )
+
+        op = partial(
+            context_parallel_kda_deterministic,
+            tiling=tiling,
+            routing=routing,
+            group=self.group,
+            kernel_options=self.options,
+        )
+        fwd = partial(forward, op, local, grad)
+        expected = autograd_step(fwd, PhaseClock())
+        actual = self.variants[name](PhaseClock())
+        self.checks[name] = {
+            k: bits_differ(a, e) for k, a, e in zip(GRAD_NAMES, actual, expected, strict=True)
+        }
+        if module:
+            self.variants[f"{name}@module"] = partial(autograd_step, fwd)
+
+    def run(self, rounds: int, iters: int, out_path: Path | None, header: str) -> None:
+        """Validate all ranks, warm up, then time interleaved variants and emit JSON."""
+        checks = [None] * self.world
+        dist.all_gather_object(checks, self.checks)
+        merged_checks = {
+            n: {k: sum(c[n][k] for c in checks) for k in GRAD_NAMES} for n in self.checks
+        }
+        assert not any(v for check in merged_checks.values() for v in check.values()), (
+            merged_checks
+        )
+        names = list(self.variants)
+        for name in names:  # warm-up / compile
+            for _ in range(2):
+                self.variants[name](PhaseClock())
+        torch.cuda.synchronize(self.device)
+        phases = {n: [] for n in names}
+        fwd = {n: [] for n in names}
+        bwd = {n: [] for n in names}
+        for r in range(rounds):
+            for name in names if r % 2 == 0 else names[::-1]:
+                p, f, b = timed(self.variants[name], iters=iters, device=self.device)
+                phases[name] += p
+                fwd[name] += f
+                bwd[name] += b
+        # Every rank's phase medians to rank 0.
+        local_medians = {
+            n: {k: statistics.median(p[k] for p in phases[n]) for k in phases[n][0]} for n in names
+        }
+        all_medians = [None] * self.world
+        dist.all_gather_object(all_medians, local_medians)
+        rows = []
+        if self.rank == 0:
+            for name in names:
+                rows.append(
+                    {
+                        "variant": name,
+                        "fwd_ms": statistics.median(fwd[name]),
+                        "bwd_ms": statistics.median(bwd[name]),
+                        "fwd_p95": sorted(fwd[name])[-1 - len(fwd[name]) // 20],
+                        "bwd_p95": sorted(bwd[name])[-1 - len(bwd[name]) // 20],
+                        "ranks": [m[name] for m in all_medians],
+                        "check_bits_differ": merged_checks.get(name),
+                    }
+                )
+            self.print_table(rows, header)
+            if out_path:
+                out_path.parent.mkdir(parents=True, exist_ok=True)
+                out_path.write_text(
+                    json.dumps(
+                        {
+                            "header": header,
+                            "tokens": self.tokens,
+                            "heads": self.heads,
+                            "backend": self.backend,
+                            "world": self.world,
+                            "lengths": self.lengths,
+                            "rounds": rounds,
+                            "iters": iters,
+                            "device": torch.cuda.get_device_name(self.device),
+                            "torch": torch.__version__,
+                            "rows": rows,
+                            "samples": {"fwd_ms": fwd, "bwd_ms": bwd},
+                        },
+                        indent=1,
+                    )
+                    + "\n"
+                )
+        dist.barrier()
+
+    def print_table(self, rows: list[dict], header: str) -> None:
+        """Report slowest-rank totals and each rank's local phase medians (ms)."""
+        print(f"\n{header}\ntokens={self.tokens} heads={self.heads} backend={self.backend}")
+        print(f"{'variant':<22}{'fwd ms':>9}{'bwd ms':>9}{'fwd p95':>9}{'bwd p95':>9}  checks")
+        for row in rows:
+            chk = row["check_bits_differ"]
+            chk_s = "-" if chk is None else ("bitwise" if not any(chk.values()) else str(chk))
+            print(
+                f"{row['variant']:<22}{row['fwd_ms']:>9.3f}{row['bwd_ms']:>9.3f}"
+                f"{row['fwd_p95']:>9.3f}{row['bwd_p95']:>9.3f}  {chk_s}"
+            )
+        print("\nper-rank phase medians (ms):")
+        head = f"{'variant':<22}{'rank':>5}" + "".join(
+            f"{p.split('/')[1]:>9}" for p in FWD_PHASES + BWD_PHASES
+        )
+        print(head + f"{'fwd':>9}{'bwd':>9}")
+        for row in rows:
+            for r, m in enumerate(row["ranks"]):
+                cells = "".join(f"{m.get(p, 0.0):>9.3f}" for p in FWD_PHASES + BWD_PHASES)
+                f = sum(v for k, v in m.items() if k.startswith("fwd"))
+                b = sum(v for k, v in m.items() if k.startswith("bwd"))
+                print(f"{row['variant']:<22}{r:>5}{cells}{f:>9.3f}{b:>9.3f}")
+
+
+OUT_DIR = Path("agent_space/friendly_fragments")
+
+
+@app.command()
+def ownership(
+    tokens: Annotated[int, typer.Option()] = 32768,
+    heads: Annotated[int, typer.Option()] = 64,
+    backend: Annotated[str, typer.Option()] = "mega",
+    tile: Annotated[int, typer.Option()] = 1024,
+    layouts: Annotated[str, typer.Option()] = (
+        "contiguous,halves,cyclic,lpt-docs,skew-62,skew-75,all-on-0"
+    ),
+    scan_blocks: Annotated[str, typer.Option(help="Tiles per exchanged block.")] = "1,4",
+    rounds: Annotated[int, typer.Option()] = 5,
+    iters: Annotated[int, typer.Option()] = 10,
+    out_path: Annotated[Path | None, typer.Option("--out")] = None,
+) -> None:
+    """Q1: does ownership shape matter at a fixed tile size? Standard vs canonical per layout."""
+    study = Study(tokens, heads, backend, ownership_lengths(tokens))
+    study.add_unsharded()
+    for name in layouts.split(","):
+        fragments = layout_fragments(name, study.cu, tile, study.world)
+        study.log(f"{name}: {fragments}")
+        study.add_standard(f"cp/{name}", fragments)
+        for block in (int(b) for b in scan_blocks.split(",")):
+            suffix = f"/b{block}" if block > 1 else ""
+            try:
+                study.add_canonical(
+                    f"det/{name}{suffix}", fragments, tile, scan_block=block, module=block == 1
+                )
+            except ValueError as error:  # fragments cut a scan block
+                study.log(f"det/{name}{suffix}: skipped ({error})")
+    study.run(
+        rounds,
+        iters,
+        out_path or OUT_DIR / f"ownership_{backend}_{tokens}_t{tile}.json",
+        f"Q1 ownership, tile={tile}, docs={study.lengths}",
+    )
+    dist.destroy_process_group()
+
+
+@app.command()
+def tile_sweep(
+    tokens: Annotated[int, typer.Option()] = 32768,
+    heads: Annotated[int, typer.Option()] = 64,
+    backend: Annotated[str, typer.Option()] = "mega",
+    tiles: Annotated[str, typer.Option()] = "256,512,1024,2048,4096,8192",
+    docs: Annotated[str, typer.Option(help="zipf-many or zipf5")] = "zipf-many",
+    layout: Annotated[str, typer.Option()] = "contiguous",
+    rounds: Annotated[int, typer.Option()] = 5,
+    iters: Annotated[int, typer.Option()] = 10,
+    out_path: Annotated[Path | None, typer.Option("--out")] = None,
+) -> None:
+    """Q2: tile size against a Zipf-like document mix (many single-tile documents)."""
+    tile_sizes = [int(t) for t in tiles.split(",")]
+    lengths = (
+        zipf_many_lengths(tokens)
+        if docs == "zipf-many"
+        else document_lengths(tokens, max(tile_sizes))
+    )
+    study = Study(tokens, heads, backend, lengths)
+    grid = max(tile_sizes)
+    fragments = layout_fragments(layout, study.cu, grid, study.world)
+    study.log(f"fragments={fragments}")
+    study.add_unsharded()
+    study.add_standard("cp", fragments)
+    for tile in tile_sizes:
+        tiles_all = tile_stream(study.cu, tile)
+        single = sum(length <= tile for length in lengths)
+        study.log(f"tile {tile}: {len(tiles_all)} tiles, {single} in single-tile documents")
+        study.add_canonical(f"det-{tile}", fragments, tile, module=True)
+    study.run(
+        rounds,
+        iters,
+        out_path or OUT_DIR / f"tile_sweep_{backend}_{docs}_{tokens}.json",
+        f"Q2 tile sweep, docs={docs}, layout={layout}",
+    )
+    dist.destroy_process_group()
+
+
+@app.command()
+def crossover(
+    tokens: Annotated[int, typer.Option()] = 32768,
+    heads: Annotated[int, typer.Option()] = 64,
+    backend: Annotated[str, typer.Option()] = "mega",
+    doc_len: Annotated[int, typer.Option(help="Every document has this length.")] = 512,
+    tile: Annotated[int, typer.Option()] = 1024,
+    rounds: Annotated[int, typer.Option()] = 5,
+    iters: Annotated[int, typer.Option()] = 10,
+    out_path: Annotated[Path | None, typer.Option("--out")] = None,
+) -> None:
+    """Q3: many equal short documents, none crossing ranks: when is canonical CP cheaper?"""
+    if tokens % doc_len or doc_len > tile:
+        raise typer.BadParameter("doc_len must divide tokens and not exceed tile")
+    study = Study(tokens, heads, backend, [doc_len] * (tokens // doc_len))
+    fragments = balanced_cut(study.cu, tile, study.world)
+    study.log(f"fragments={fragments}")
+    study.add_unsharded()
+    study.add_standard("cp", fragments)
+    study.add_canonical(f"det-{tile}", fragments, tile, module=True)
+    study.run(
+        rounds,
+        iters,
+        out_path or OUT_DIR / f"crossover_{backend}_{tokens}_d{doc_len}_t{tile}.json",
+        f"Q3 crossover, {tokens // doc_len} documents of {doc_len}, tile={tile}",
+    )
+    dist.destroy_process_group()
+
+
+@app.command()
+def split(
+    tokens: Annotated[int, typer.Option()] = 32768,
+    heads: Annotated[str, typer.Option()] = "64,16,8",
+    gates: Annotated[str, typer.Option(help="mild (bench gate) and/or strong.")] = "mild,strong",
+    tile: Annotated[int, typer.Option(help="Packing whose split table is also counted.")] = 1024,
+    rounds: Annotated[int, typer.Option()] = 5,
+    iters: Annotated[int, typer.Option()] = 20,
+    out_path: Annotated[Path | None, typer.Option("--out")] = None,
+) -> None:
+    """Q4: Mega unsplit vs forgetting-horizon split forward on one dense stream (single process)."""
+    from attn_gym.linear._delta_rule.mega.schedule import prepare_mega_schedule
+
+    device = torch.device("cuda", torch.cuda.current_device())
+    results = []
+    for h in (int(x) for x in heads.split(",")):
+        for gate_name in gates.split(","):
+            strong = gate_name == "strong"
+            inputs = make_kda_test_inputs(
+                tokens,
+                heads=h,
+                seed=0,
+                normalize_qk=True,
+                sigmoid_beta=True,
+                gate_scale=5.0 if strong else 0.02,
+                log_uniform_gate=strong,
+            )
+            variants = {
+                "unsplit": {"backend": "mega"},
+                "split": {"backend": "mega", "split_forward": True},
+            }
+            outs = {}
+            with torch.no_grad():
+                for name, opts in variants.items():
+                    for _ in range(3):
+                        outs[name] = chunk_kda(*inputs, kernel_options=opts, autotune=False)[0]
+                torch.cuda.synchronize()
+                samples = {n: [] for n in variants}
+                for r in range(rounds):
+                    order = list(variants) if r % 2 == 0 else list(variants)[::-1]
+                    for name in order:
+                        op = partial(
+                            chunk_kda, *inputs, kernel_options=variants[name], autotune=False
+                        )
+                        _, fwd, _ = timed(
+                            partial(clocked, op, phase="fwd/run"),
+                            iters=iters,
+                            device=device,
+                            distributed=False,
+                        )
+                        samples[name] += fwd
+            gate, cu_dense = inputs[3], torch.tensor([0, tokens], dtype=torch.int32, device=device)
+            cu_tiles = torch.arange(0, tokens + 1, tile, dtype=torch.int32, device=device)
+            stream = torch.cuda.current_stream().cuda_stream
+            items = {}
+            for label, cu in (("dense", cu_dense), (f"tiles-{tile}", cu_tiles)):
+                sched = prepare_mega_schedule(
+                    gate, cu, tile_tokens=16, counter_count=2, split=True, stream=stream
+                )
+                torch.cuda.synchronize()
+                items[label] = (int(sched.work_count.item()), (cu.numel() - 1) * h)
+            row = {
+                "heads": h,
+                "gate": gate_name,
+                "unsplit_ms": statistics.median(samples["unsplit"]),
+                "split_ms": statistics.median(samples["split"]),
+                "rel_l2": (
+                    (outs["split"].float() - outs["unsplit"].float()).norm()
+                    / outs["unsplit"].float().norm().clamp_min(1e-30)
+                ).item(),
+                "max_abs": (outs["split"].float() - outs["unsplit"].float()).abs().max().item(),
+                "bits_differ": bits_differ(outs["split"], outs["unsplit"]),
+                "work_items": items,
+            }
+            results.append(row)
+            print(
+                f"H={h:<3} gate={gate_name:<6} unsplit {row['unsplit_ms']:.3f} ms  "
+                f"split {row['split_ms']:.3f} ms  speedup {row['unsplit_ms'] / row['split_ms']:.2f}x"
+                f"  rel-L2 {row['rel_l2']:.2e} max|d| {row['max_abs']:.2e}"
+                f"  bits differ {row['bits_differ']}  items {items}",
+                flush=True,
+            )
+    path = out_path or OUT_DIR / f"split_{tokens}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "tokens": tokens,
+                "tile": tile,
+                "rounds": rounds,
+                "iters": iters,
+                "device": torch.cuda.get_device_name(device),
+                "torch": torch.__version__,
+                "rows": results,
+            },
+            indent=1,
+        )
+        + "\n"
+    )
+
+
+if __name__ == "__main__":
+    app()

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -605,39 +605,27 @@ between complete forward/backward steps, not while backward still needs the prev
 
 ### Mega local execution
 
-`kernel_options={"backend": "mega"}` makes `chunk_kda_prepare` and `context_parallel_kda` run each
-local pass with Mega from the composed entry state. Because Mega keeps WY factors on chip,
-`state_summaries` computes the fused factors once over the whole local stream and summarizes
-every range from them; that factor pass is paid even when every fragment ends its document and
-the summaries are identities, since which ranges are empty is a device value under replay. A
-layout that never continues a document across ranks does not need this recipe. The backward
-handle's `run` is Mega's own stateful backward (`attn_gym::kda_chunk_mega_packed_bwd_with_state`:
-checkpoint recompute from the saved entry state, then the BT16 backward folding in the exit
-cotangent). Given Mega's own entry state and exit cotangent, two fragments of a document cut on a
-16-token boundary reproduce the unsharded Mega gradients bit for bit; under this recipe the entry
-states are composed from the fused summaries, whose FP32 rounding differs from Mega's, so the
-sharded result is close to but not bitwise the unsharded one. `state_grad_summaries` still
-recomputes the fused factors over the local stream. The staged handles and this recipe are
-eager-only; `torch.compile` is not supported through them.
+`kernel_options={"backend": "mega"}` selects Mega's local forward and native stateful backward.
+Standard CP forward summaries use native BT16 probes for whole subsequences; arbitrary-range
+forward summaries and standard CP reverse summaries still recompute fused BT64 factors. Native
+summaries define a new Mega-CP numerical baseline, not bitwise parity with fused summaries or
+unsharded Mega. Two 16-token-aligned fragments exchanging Mega's *own* state and cotangent do
+reproduce one native backward bitwise, but composed summaries have different FP32 rounding.
+The staged handles and CP recipes are eager-only; `torch.compile` is not supported.
 
 ### Deterministic mode: results independent of the CP degree
 
-`attn_gym.linear.kda.context_parallel_kda_deterministic` fixes the whole arithmetic graph before
-ranks are assigned, so output and every input gradient are **bitwise identical for any CP degree
-and any ownership of whole tiles**, including CP=1. It is a different numerical contract from the
-unsharded `chunk_kda` call (the same recurrence, composed through fixed FP32 affine maps; the
-error against an FP64 reference stays within the BF16 budget the tests use), and from the
-standard recipe above, whose summaries depend on the fragment table.
+`context_parallel_kda_deterministic` gives **bitwise-identical output and all input gradients
+across CP degrees**, including CP=1, for fixed backend/settings, `tile_size`, and `scan_block`.
+Whole-tile ownership and neighboring packed documents do not change a document's result. This is
+a distinct numerical baseline from standard CP and unsharded `chunk_kda`; FP64 reference tests
+bound its error with the repository's BF16 budget.
 
-- **Tiles.** Every document is cut from its first token into `tile_size` tiles (a multiple of
-  64; the last tile of a document may be short). `CanonicalTiling.from_fragments(cu_seqlens,
-  fragments, rank, tile_size=...)` assigns whole tiles to ranks and rejects a fragment boundary
-  that does not fall on a tile boundary. Ranks may own different numbers of tiles or none.
-- **Leaves.** A rank prepares its tiles in one staged call, each tile a packed subsequence, and
-  builds one `[bias; transition]` map per tile with `deterministic_work=True`, which pins the
-  summary kernels' work partition so it cannot depend on how many tiles the rank owns.
-- **Scan.** All maps are all-gathered and composed per document with a work-efficient scan
-  whose tree depends only on the tile count; the backward mirrors it over the reverse maps.
+Each document is tiled from its first token with `tile_size` a positive multiple of 64; its last
+tile may be short. Fragment boundaries must coincide with tile boundaries. Each rank prepares
+its tiles as packed subsequences, using `deterministic_work=True` to pin summary arithmetic.
+The all-gathered maps are folded in document order with three-pass TF32; backward mirrors the
+fold over reverse maps. Single-tile documents need no summaries, exchange payload, or scan.
 
 ```python
 from attn_gym.linear.context_parallel_deterministic import CanonicalTiling
@@ -645,17 +633,43 @@ from attn_gym.linear.kda import context_parallel_kda_deterministic
 
 tiling = CanonicalTiling.from_fragments(cu_seqlens_global, fragments, rank, tile_size=1024)
 ids = tiling.global_token_ids(device)  # this rank's tiles, in span order
+routing = tiling.routing(device)  # index tensors; reuse while the layout is fixed
 output = context_parallel_kda_deterministic(
-    q[:, ids], k[:, ids], v[:, ids], gate[:, ids], beta[:, ids], tiling=tiling, group=group
+    q[:, ids],
+    k[:, ids],
+    v[:, ids],
+    gate[:, ids],
+    beta[:, ids],
+    tiling=tiling,
+    routing=routing,
+    group=group,
 )
 ```
 
-Every rank calls the forward and its backward the same number of times, including ranks that own
-no tiles. Autotuning is disabled in this mode. The tile size is the performance knob: maps are
-`H x 256 x 128` FP32 (128 KiB per tile per head), so the scan's bandwidth grows with the tile
-count; 1024-token tiles cost about 2-3x the standard recipe on GB200 at 32k tokens, 64-token
-tiles far more (`benchmarks/kda_cp_deterministic.py`). Works with the fused and the Mega
-forward; the backward is the staged one of the chosen backend.
+Every rank must call forward and backward equally often, including empty ranks. The API returns
+only local output, not final states. Autotuning is disabled. Fused and Mega use their own staged
+backwards; Mega's canonical reverse maps use native zero-exit cotangents plus the transposed
+forward transition, not fused-map or native backward-probe rounding. Mega's `split_forward` and
+`split_backward` are rejected: approximate horizon cuts would change the FP32 summary leaves.
+
+**Cost and fragment plans.** With `K = V = 128`, every summarized tile contributes an
+`H x 256 x 128` FP32 map (128 KiB per head). Every rank holds the gathered maps, including
+collective padding, plus entry states for its own tiles. Larger tiles reduce map overhead but
+can reduce leaf parallelism. Balance both tokens and tiles of multi-tile documents across ranks;
+cutting long documents on tile boundaries adds no summaries. Contiguous rank-order ownership
+with equal exchanged block counts avoids the gathered-map placement copy.
+
+Recorded runs on two GB200s at 32k tokens / 64 heads / five documents measured tile 1024 at
+1.22x / 0.85x standard CP forward/backward time for Mega, and 1.52x / 1.20x for fused (lower is
+better). With many short documents, tile 2048 can beat standard CP in both directions. These
+are eager KDA-operation timings, not end-to-end model measurements. Reproduce for your packing with
+`benchmarks/kda_cp_deterministic.py` or `benchmarks/kda_cp_fragment_study.py`.
+
+**`scan_block`** groups consecutive document-relative tiles, exchanging one map per block;
+ranks must own whole blocks. Keep the default `1` on two NVLink GPUs: extra folds offset the
+exchange savings there. Benefits at larger CP degrees or slower interconnects remain unmeasured.
+Changing either `scan_block` or `tile_size` changes the numerical contract; keep both fixed when
+comparing CP degrees.
 
 ::: attn_gym.linear.context_parallel.context_parallel_chunk
 

--- a/test/test_context_parallel_deterministic.py
+++ b/test/test_context_parallel_deterministic.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import math
 import os
 import socket
+import time
 from itertools import accumulate, pairwise
 from unittest.mock import patch
 
@@ -70,6 +71,12 @@ def test_fragments_must_fall_on_tile_boundaries():
         CanonicalTiling.from_fragments(cu, [[(17, 0)], [(17, 981)]], 0, tile_size=64)
     with pytest.raises(ValueError, match="outside"):
         CanonicalTiling.from_fragments(cu, [[(0, 981)], []], 2, tile_size=64)
+    tiling = CanonicalTiling.from_fragments(cu, [[(0, 981)]], 0, tile_size=64, scan_block=2)
+    # The 17-token document fits one tile and is not summarized; blocks never span documents.
+    single = {i for i, t in enumerate(tiling.tiles) if t.document == 0}
+    assert set(tiling.summarized) == set(range(len(tiling.tiles))) - single
+    assert all(len({tiling.tiles[i].document for i in block}) == 1 for block in tiling.blocks)
+    assert [i for block in tiling.blocks for i in block] == list(tiling.summarized)
     # Document 4 (tokens 468..981) has tiles at 468, 532, ...; a 2-tile block boundary is 596.
     CanonicalTiling.from_fragments(cu, [[(0, 596)], [(596, 981)]], 0, tile_size=64, scan_block=2)
     with pytest.raises(ValueError, match="one scan block"):
@@ -178,9 +185,15 @@ def test_entries_of_a_document_are_independent_of_its_neighbours(scan_block):
         leaves = torch.cat((others[:before], document, others[before:]))
         documents = [0] * before + [1] * 5 + [2] * after
         tiling = _single_rank_tiling(documents, scan_block)
+        summarized = torch.tensor(tiling.summarized, device="cuda")
         for reverse in (False, True):
             entries = canonical_entries(
-                leaves, tiling, tiling.routing("cuda"), leaves[:1], None, reverse=reverse
+                leaves[summarized],
+                tiling,
+                tiling.routing("cuda"),
+                leaves[:1],
+                None,
+                reverse=reverse,
             )
             entries = entries[before : before + 5]
             reference.setdefault(reverse, entries)
@@ -263,10 +276,12 @@ def _canonical_cp1(inputs, grad, lengths, tile_size: int, scan_block: int, kerne
     prepared = [
         stages.prepare(*(v[:, t.start : t.stop] for v in inputs), cu_seqlens=None) for t in tiles
     ]
+    # Single-tile documents are not summarized (NOTE [Single-Tile Documents]).
+    summarized = tiling.summarized
     maps = torch.cat(
         [
-            p.state_summaries(bounds(t), deterministic_work=True)
-            for p, t in zip(prepared, tiles, strict=True)
+            prepared[i].state_summaries(bounds(tiles[i]), deterministic_work=True)
+            for i in summarized
         ]
     )
     routing = tiling.routing(device)
@@ -281,8 +296,8 @@ def _canonical_cp1(inputs, grad, lengths, tile_size: int, scan_block: int, kerne
         )
     rmaps = torch.cat(
         [
-            b.state_grad_summaries(bounds(t), deterministic_work=True)
-            for b, t in zip(backwards, tiles, strict=True)
+            backwards[i].state_grad_summaries(bounds(tiles[i]), deterministic_work=True)
+            for i in summarized
         ]
     )
     exits = canonical_entries(rmaps, tiling, routing, maps[:1], None, reverse=True)
@@ -316,16 +331,23 @@ def _rank_main(cp_rank, world, port, lengths, tile_size, scan_block, ownership, 
         cu = (0, *accumulate(lengths))
         expected = _canonical_cp1(inputs, grad, lengths, tile_size, scan_block, kernel_options)
         if ownership == "cyclic":
-            # Alternate whole blocks between the ranks (tiles when scan_block == 1).
-            blocks = CanonicalTiling.from_fragments(
+            # Alternate whole blocks between the ranks (tiles when scan_block == 1); tiles of
+            # single-tile documents form no block and alternate on their own.
+            tiling = CanonicalTiling.from_fragments(
                 cu, [[(0, cu[-1])]], 0, tile_size=tile_size, scan_block=scan_block
-            ).blocks
-            tiles = tile_stream(cu, tile_size)
+            )
+            units = sorted(
+                [
+                    *tiling.blocks,
+                    *((i,) for i in range(len(tiling.tiles)) if i not in tiling.summarized),
+                ]
+            )
+            tiles = tiling.tiles
             fragments = [
                 [
-                    (tiles[block[0]].start, tiles[block[-1]].stop)
-                    for b, block in enumerate(blocks)
-                    if b % 2 == r
+                    (tiles[unit[0]].start, tiles[unit[-1]].stop)
+                    for u, unit in enumerate(units)
+                    if u % 2 == r
                 ]
                 for r in range(2)
             ]
@@ -378,12 +400,23 @@ def test_two_ranks_match_canonical_cp1_bitwise(
         pytest.importorskip("cutlass.experimental")
         if torch.cuda.get_device_capability() not in ((10, 0), (10, 3)):
             pytest.skip("Mega needs SM100/103")
-    mp.spawn(
+    # A rank that raises leaves its peer blocked in a collective; poll the context so the
+    # failure surfaces instead of the case hanging until the outer timeout.
+    context = mp.spawn(
         _rank_main,
         args=(2, _free_port(), lengths, tile_size, scan_block, ownership, gate, backend),
         nprocs=2,
-        join=True,
+        join=False,
     )
+    deadline = time.monotonic() + 300
+    try:
+        # join(timeout) returns after each process exits (raising if it failed); loop until all did.
+        while not context.join(timeout=max(0.0, deadline - time.monotonic())):
+            assert time.monotonic() < deadline, "two-rank case did not finish within 300 s"
+    finally:
+        for process in context.processes:
+            if process.is_alive():
+                process.kill()
 
 
 # ---------------------------------------------------------------- accuracy vs FP64


### PR DESCRIPTION
Stacked PRs:
 * #519
 * #518
 * __->__#517
 * #516
 * #515
 * #514
 * #513
 * #512


--- --- ---

Skip single-tile documents in the deterministic recipe and document its cost model

A document that fits in one canonical tile enters with the zero state and nothing reads its map,
so its tile is left out of the summary kernels, the all-gather, and the scan
(CanonicalTiling.summarized; NOTE [Single-Tile Documents]). The exclusion depends on the tiling
only, so results stay bitwise invariant to ownership. Ranks that own only single-tile documents
(or nothing) still join the collective. The routing precomputes the summary bounds, the
positions of summarized tiles, and the all-gather placement; the Mega handles accept a row
subset of whole-sequence bounds for both forward and reverse native summaries.

The two-rank test harness now polls mp.spawn's context with a deadline (join(timeout) returns
after each process exits), so a raising rank fails the case instead of leaving its peer blocked
in NCCL until the outer timeout.

benchmarks/kda_cp_fragment_study.py measures ownership shapes, tile sizes against a Zipf-like
document mix, the crossover with standard CP on many short documents, and the Mega
forgetting-horizon split (not admissible with canonical tiles: fp32 summaries would change);
docs/linear.md gains the resulting cost model and fragment-plan guidance.

Two GB200s, 32k tokens, 64 heads, CP2, 127-document Zipf stream, halves ownership (ms fwd/bwd,
lower is better): Mega tile-1024 8.2/12.9 -> 2.17/6.98 (0.97x/1.00x of standard CP), tile-2048
1.66/6.54 (0.74x/0.94x); fused tile-2048 3.18/6.00 (0.95x/0.93x). With equal short documents
none of which crosses ranks, deterministic CP is cheaper than standard CP for both backends
(Mega 0.55x/0.54x, fused 0.94x/0.96x). The 5-document benchmark has no single-tile documents
and is unchanged.