### PR TITLE
Probe only the selected sequences in the native Mega reverse summaries

### DIFF
--- a/attn_gym/linear/_delta_rule/mega/state_summary.py
+++ b/attn_gym/linear/_delta_rule/mega/state_summary.py
@@ -1,14 +1,16 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Native BT16 affine probes for Mega context-parallel subsequences.
+"""Native BT16 affine probes for whole packed sequences.
 
-B is the no-state final state; A is the identity-seeded, zero-value final state. Native
-state/operand rounding makes this an approximate affine map, not bitwise reconstruction of
-an ordinary unsharded Mega run. C is the native zero-exit entry cotangent. The cheaper reverse
-transition A.T is opt-in: it is not the identity-seeded native backward's rounding.
+Forward maps pack [B; A] for ``exit = entry @ A + B``; reverse maps pack [C; R] for
+``d_entry = d_exit @ R + C``. Native state/operand rounding makes these approximate affine
+maps, not bitwise reconstruction of an ordinary unsharded Mega run. Every probe is unsplit,
+so its arithmetic is independent of sequence ownership and packed token count.
 """
 
 from __future__ import annotations
+
+from types import ModuleType
 
 import torch
 import triton
@@ -20,7 +22,7 @@ from attn_gym.utils import ceildiv
 from .forward import validate_available
 from .kernels import kda_bprop_f16, kda_recompute_f16
 from .kernels.common.host import tensormap_workspace_bytes
-from .schedule import prepare_mega_schedule
+from .schedule import MegaSchedule, prepare_mega_schedule
 
 
 @triton.jit
@@ -35,6 +37,7 @@ def _select_summary_work(cu, bounds, work, count, HEADS: tl.constexpr, ROWS: tl.
     selected = tl.sum(((lo == start) & (hi == stop) & (lo < hi)).to(tl.int32), 0) > 0
     stop = tl.where(selected, stop, start)
     chunks = tl.cdiv(stop - start, 16)
+    # Native row: [seq, head, wstart, wend, cstart, cend, token_start, token_stop].
     fields = tl.arange(0, 8)
     row = tl.where(fields == 0, seq, tl.where(fields == 1, head, 0))
     row = tl.where((fields == 3) | (fields == 5), chunks, row)
@@ -56,10 +59,11 @@ def _gather_summary_rows(
     hi = tl.load(cu + seqs + 1, seqs < SEQUENCES, other=-1)
     seq = tl.max(tl.where((lo == start) & (hi == stop), seqs, 0), 0)
     offsets = block * BLOCK + tl.arange(0, BLOCK)
-    value = tl.load(maps + (seq * HEADS + head) * 32768 + offsets)
-    identity = (offsets // 128 - 128 == offsets % 128).to(tl.float32)
+    value = tl.load(maps + (seq * HEADS + head) * (256 * 128) + offsets)
+    # [0; I]: diagonal ones live only in the lower 128 rows.
+    identity = (offsets // 128 == 128 + offsets % 128).to(tl.float32)
     value = tl.where(start == stop, identity, value)
-    tl.store(output + (row * HEADS + head) * 32768 + offsets, value)
+    tl.store(output + (row * HEADS + head) * (256 * 128) + offsets, value)
 
 
 def build_mega_state_summaries(
@@ -73,12 +77,62 @@ def build_mega_state_summaries(
 ) -> torch.Tensor:
     """Return FP32 ``[N, H, 256, 128]`` maps packed as ``[B; A]`` for whole sequences.
 
-    Inputs use the staged ``[1, T, H, 128]`` layout, with FP32 gate/beta and already
-    normalized keys. Both passes are unsplit, independent of packed token count or ownership.
-    Optional bounds select/reorder whole consecutive cu_seqlens pairs (a caller contract);
-    empty bounds return ``[0; I]``. Selection stays on device for CUDA Graph replay.
+    B is the no-state final state; A is the identity-seeded, zero-value final state.
+    Inputs use staged ``[1, T, H, 128]`` layout, FP32 gate/beta, and normalized keys.
+    Optional contiguous int32 ``bounds[R, 2]`` on k.device select, reorder, or duplicate
+    consecutive cu_seqlens pairs. Empty intervals yield ``[0; I]``; zero rows yield no maps.
+    Bounds values stay on device and may change during CUDA Graph replay.
     """
-    return _build_mega_state_probes(k, value, gate, beta, cu_seqlens, bounds, bias=True)
+    maps = _build_mega_state_probes(k, value, gate, beta, cu_seqlens, bounds, bias=True)
+    return _summary_rows(maps, cu_seqlens, bounds)
+
+
+def _summary_rows(
+    maps: torch.Tensor, cu_seqlens: torch.Tensor, bounds: torch.Tensor | None
+) -> torch.Tensor:
+    """Gather selected probes only after native kernels finish writing by sequence index."""
+    if bounds is None:
+        return maps
+    sequences, heads = maps.shape[:2]
+    selected = torch.empty(bounds.shape[0], heads, 256, 128, device=maps.device, dtype=maps.dtype)
+    if bounds.shape[0]:
+        with initialized_cuda_device(maps):
+            _gather_summary_rows[(bounds.shape[0], heads, 32)](
+                maps, cu_seqlens, bounds, selected, heads, sequences, 1024
+            )
+    return selected
+
+
+def _prepare_summary_launch(
+    gate: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    bounds: torch.Tensor | None,
+    kernel: ModuleType,
+) -> tuple[MegaSchedule, torch.Tensor]:
+    """Allocate native launch buffers and select whole-sequence work without a host sync.
+
+    With bounds, the caller must reset counters before each probe and disable prologue
+    ordering; otherwise the prologue generates all work and resets counters itself.
+    """
+    sequences, heads = cu_seqlens.shape[0] - 1, gate.shape[2]
+    schedule = prepare_mega_schedule(
+        gate,
+        cu_seqlens,
+        tile_tokens=16,
+        counter_count=2,
+        split=False,
+        stream=torch.cuda.current_stream(gate.device).cuda_stream,
+    )
+    if bounds is not None:
+        _select_summary_work[(sequences, heads)](
+            cu_seqlens, bounds, schedule.work_items, schedule.work_count, heads, bounds.shape[0]
+        )
+    workspace = torch.empty(
+        ceildiv(tensormap_workspace_bytes(kernel, sequences), 8),
+        dtype=torch.int64,
+        device=gate.device,
+    )
+    return schedule, workspace
 
 
 def _build_mega_state_probes(
@@ -91,7 +145,7 @@ def _build_mega_state_probes(
     *,
     bias: bool,
 ) -> torch.Tensor:
-    """Run the native transition probe and, when requested, the zero-state bias probe."""
+    """Probe selected sequences into full-size storage indexed by the native sequence IDs."""
     validate_available(k)
     if k.ndim != 4 or k.shape[0] != 1 or k.shape[-1] != 128:
         raise ValueError("k must have shape [1, T, H, 128]")
@@ -119,27 +173,8 @@ def _build_mega_state_probes(
         )
         summaries[:, :, 128:, :].diagonal(dim1=-2, dim2=-1).fill_(1)
         if k.shape[1] != 0 and (bounds is None or bounds.shape[0] != 0):
-            schedule = prepare_mega_schedule(
-                gate,
-                cu_seqlens,
-                tile_tokens=16,
-                counter_count=2,
-                split=False,
-                stream=torch.cuda.current_stream(k.device).cuda_stream,
-            )
-            if bounds is not None:
-                _select_summary_work[(num_sequences, heads)](
-                    cu_seqlens,
-                    bounds,
-                    schedule.work_items,
-                    schedule.work_count,
-                    heads,
-                    bounds.shape[0],
-                )
-            workspace = torch.empty(
-                ceildiv(tensormap_workspace_bytes(kda_recompute_f16, num_sequences), 8),
-                dtype=torch.int64,
-                device=k.device,
+            schedule, workspace = _prepare_summary_launch(
+                gate, cu_seqlens, bounds, kda_recompute_f16
             )
             for transition_only in (False, True) if bias else (True,):
                 if bounds is not None:
@@ -162,16 +197,7 @@ def _build_mega_state_probes(
                     tensormap_workspace=workspace,
                     transition_only=transition_only,
                 )
-        if bounds is None:
-            return summaries
-        selected = torch.empty(
-            bounds.shape[0], heads, 256, 128, device=k.device, dtype=torch.float32
-        )
-        if bounds.shape[0]:
-            _gather_summary_rows[(bounds.shape[0], heads, 32)](
-                summaries, cu_seqlens, bounds, selected, heads, num_sequences, 1024
-            )
-        return selected
+        return summaries
 
 
 def build_mega_state_grad_summaries(
@@ -187,51 +213,35 @@ def build_mega_state_grad_summaries(
     transpose_forward_transition: bool = False,
     bounds: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    """Return whole-sequence FP32 ``[C; R]`` probes for ``d_entry = d_exit @ R + C``.
+    """Return whole-sequence FP32 ``[N, H, 256, 128]`` maps packed as ``[C; R]``.
 
-    Optional ``bounds`` (``int32 [R, 2]`` device tensor of whole consecutive cu_seqlens pairs)
-    select and order the returned rows on device; every sequence is still probed.
-
-    C uses native bprop with zero exit cotangent. Its dH recurrence does not read V or the
-    checkpoints, so broadcast zero checkpoints avoid a forward state recompute and its large
-    checkpoint allocation. The unchanged kernel still computes/discards token gradients.
-
-    By default R is one native backward pass with all 128 identity rows seeded together and
-    zero d_output. ``transpose_forward_transition=True`` instead uses the cheaper forward
-    A.T probe: algebraically the adjoint, but NOT native backward rounding. Canonical Mega CP
-    explicitly selects this approximate numerical baseline; it remains ownership-invariant.
+    C is the native entry cotangent with zero exit cotangent. R uses an identity exit
+    cotangent and zero d_output. ``transpose_forward_transition=True`` instead uses A.T
+    from the forward probe: algebraically the adjoint, but not native backward rounding.
+    Inputs and bounds follow :func:`build_mega_state_summaries`; selection applies to both
+    probes and empty intervals yield ``[0; I]``.
     """
     validate_available(q)
     with initialized_cuda_device(q):
         sequences, heads = cu_seqlens.numel() - 1, q.shape[2]
         if transpose_forward_transition:
-            maps = _build_mega_state_probes(k, value, gate, beta, cu_seqlens, None, bias=False)
+            maps = _build_mega_state_probes(k, value, gate, beta, cu_seqlens, bounds, bias=False)
             maps[:, :, 128:].copy_(maps[:, :, 128:].transpose(-1, -2).contiguous())
         else:
             maps = torch.zeros(sequences, heads, 256, 128, device=q.device)
             maps[:, :, 128:].diagonal(dim1=-2, dim2=-1).fill_(1)
-        if q.shape[1] == 0:
-            return maps
-        schedule = prepare_mega_schedule(
-            gate,
-            cu_seqlens,
-            tile_tokens=16,
-            counter_count=2,
-            split=False,
-            stream=torch.cuda.current_stream(q.device).cuda_stream,
-        )
-        workspace = torch.empty(
-            ceildiv(tensormap_workspace_bytes(kda_bprop_f16, sequences), 8),
-            dtype=torch.int64,
-            device=q.device,
-        )
-        # Zero-stride checkpoint rows are legal in the native TMA ABI. All sequence-local
-        # checkpoint descriptors address this single tile, regardless of packed token count.
+        if q.shape[1] == 0 or (bounds is not None and bounds.shape[0] == 0):
+            return _summary_rows(maps, cu_seqlens, bounds)
+        schedule, workspace = _prepare_summary_launch(gate, cu_seqlens, bounds, kda_bprop_f16)
+        # The dH recurrence ignores V/checkpoints; token gradients are computed but discarded.
+        # Zero-stride TMA checkpoint rows all address one tile, avoiding a state recompute.
         checkpoints = torch.zeros(1, heads, 128, 128, device=q.device, dtype=q.dtype).expand(
             q.shape[1] // 16 + sequences, -1, -1, -1
         )
         scratch = [torch.empty_like(t[0]) for t in (q, k, value, gate, beta)]
         for transition in (False,) if transpose_forward_transition else (False, True):
+            if bounds is not None:
+                schedule.counters.zero_()
             exit_state = None
             do = d_output
             if transition:
@@ -255,16 +265,7 @@ def build_mega_state_grad_summaries(
                 work_count=schedule.work_count,
                 sched_ctr=schedule.counters if sequences * heads <= schedule.num_sms else None,
                 sched_all=schedule.counters,
-                order_in_prologue=True,
+                order_in_prologue=bounds is None,
                 tensormap_workspace=workspace,
             )
-        if bounds is None:
-            return maps
-        selected = torch.empty(
-            bounds.shape[0], heads, 256, 128, device=q.device, dtype=torch.float32
-        )
-        if bounds.shape[0]:
-            _gather_summary_rows[(bounds.shape[0], heads, 32)](
-                maps, cu_seqlens, bounds, selected, heads, sequences, 1024
-            )
-        return selected
+        return _summary_rows(maps, cu_seqlens, bounds)

--- a/test/kda/mega/test_kda_mega_native_summary.py
+++ b/test/kda/mega/test_kda_mega_native_summary.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from functools import partial
 from itertools import pairwise
 
 import pytest
@@ -9,7 +10,11 @@ import torch
 
 pytest.importorskip("cutlass.experimental", reason="native Mega summaries require CuTeDSL 4.7")
 
-from attn_gym.linear._delta_rule.mega.kernels import kda_prefill_f16
+from attn_gym.linear._delta_rule.mega.kernels import (
+    kda_bprop_f16,
+    kda_prefill_f16,
+    kda_recompute_f16,
+)
 from attn_gym.linear._delta_rule.mega.kernels.common.host import tensormap_workspace_bytes
 from attn_gym.linear._delta_rule.mega.schedule import prepare_mega_schedule
 from attn_gym.linear._delta_rule.mega.state_summary import (
@@ -31,6 +36,50 @@ pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available() or torch.cuda.get_device_capability() not in ((10, 0), (10, 3)),
     reason="native Mega summaries require SM100 or SM103",
 )
+
+DTYPES = [torch.bfloat16, torch.float16]
+# Ragged packed span with an empty sequence; cu_seqlens = 0, 17, 17, 82, 211.
+LENGTHS = [17, 0, 65, 129]
+SCALE = 128**-0.5
+MEGA = {"backend": "mega"}
+
+
+def _packed_inputs(
+    lengths: list[int],
+    dtype: torch.dtype = torch.bfloat16,
+    *,
+    heads: int = 1,
+    gate_value: float | None = None,
+) -> tuple[tuple[torch.Tensor, ...], torch.Tensor]:
+    """Normalized-QK inputs with mild gates, plus their packed boundaries."""
+    inputs = make_kda_test_inputs(
+        sum(lengths),
+        heads=heads,
+        dtype=dtype,
+        gate_scale=0.02,
+        gate_value=gate_value,
+        normalize_qk=True,
+    )
+    return inputs, cumulative_sequence_offsets(lengths)
+
+
+def _bounds(rows: list[list[int]]) -> torch.Tensor:
+    """Device ``int32 [R, 2]`` token bounds, one whole (or empty) sequence per row."""
+    return torch.tensor(rows, device="cuda", dtype=torch.int32)
+
+
+def _assert_bitwise_equal(actual: torch.Tensor, expected: torch.Tensor) -> None:
+    """Bit-exact FP32 comparison; unlike ``torch.equal`` it distinguishes signed zeros."""
+    assert torch.equal(actual.view(torch.int32), expected.view(torch.int32))
+
+
+def _forbid_fused_factors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fail if a staged handle materializes fused WY factors on a native-summary path."""
+    for name in ("_prepare_chunk_kda_fwd", "_prepare_chunk_kda_bwd"):
+        monkeypatch.setattr(
+            f"attn_gym.linear.kda.stages.{name}",
+            lambda *args, **kwargs: pytest.fail("native summaries must not prepare fused factors"),
+        )
 
 
 def _native_no_state_final(
@@ -63,7 +112,7 @@ def _native_no_state_final(
         cu_seqlens,
         None,
         state,
-        128**-0.5,
+        SCALE,
         work_items=schedule.work_items,
         work_count=schedule.work_count,
         sched_ctr=schedule.counters,
@@ -72,26 +121,23 @@ def _native_no_state_final(
     return state
 
 
-@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("dtype", DTYPES)
 def test_native_bias_matches_no_state_final_bitwise(dtype: torch.dtype) -> None:
-    lengths = [17, 0, 65, 129]
-    inputs = make_kda_test_inputs(sum(lengths), dtype=dtype, gate_scale=0.02, normalize_qk=True)
-    cu = cumulative_sequence_offsets(lengths)
+    inputs, cu = _packed_inputs(LENGTHS, dtype)
     maps = build_mega_state_summaries(*inputs[1:], cu)
-    expected = _native_no_state_final(inputs, cu)
-    assert torch.equal(maps[:, :, :128].contiguous().view(torch.int32), expected.view(torch.int32))
-    torch.testing.assert_close(maps[1, 0, 128:], torch.eye(128, device="cuda"), rtol=0, atol=0)
+    _assert_bitwise_equal(maps[:, :, :128].contiguous(), _native_no_state_final(inputs, cu))
+    _assert_bitwise_equal(maps[1, 0, 128:], torch.eye(128, device="cuda"))
 
 
-@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("gate_value,beta_value", [(0.0, None), (-0.002, 0.0), (-0.02, 1.0)])
 def test_native_transition_matches_basis_reference(
     dtype: torch.dtype, gate_value: float, beta_value: float | None
 ) -> None:
-    inputs = list(make_kda_test_inputs(17, dtype=dtype, gate_value=gate_value, normalize_qk=True))
+    inputs, cu = _packed_inputs([17], dtype, gate_value=gate_value)
+    inputs = list(inputs)
     if beta_value is not None:
         inputs[-1].fill_(beta_value)
-    cu = cumulative_sequence_offsets([17])
     actual = build_mega_state_summaries(*inputs[1:], cu)[:, :, 128:]
     inputs[2] = torch.zeros_like(inputs[2])
     references = []
@@ -104,224 +150,19 @@ def test_native_transition_matches_basis_reference(
     assert_matches_low_precision_reference(actual, *references, "transition A", source_dtype=dtype)
 
 
-@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
-def test_native_two_tile_composition_matches_reference(dtype: torch.dtype, monkeypatch) -> None:
-    inputs = make_kda_test_inputs(128, dtype=dtype, gate_scale=0.02, normalize_qk=True)
-    cu = cumulative_sequence_offsets([64, 64])
-    prepared = chunk_kda_prepare(
-        *inputs, cu_seqlens=cu, autotune=False, kernel_options={"backend": "mega"}
-    )
-    monkeypatch.setattr(
-        "attn_gym.linear.kda.stages._prepare_chunk_kda_fwd",
-        lambda *args, **kwargs: pytest.fail("native summaries must not prepare fused factors"),
-    )
-    bounds = torch.tensor([[0, 64], [64, 128]], device="cuda", dtype=torch.int32)
-    maps = prepared.state_summaries(bounds, deterministic_work=True)
-    entry0 = torch.zeros_like(maps[0, :, :128])
-    entry1 = merge_state(entry0, maps[0])
-    output, final = prepared.run(torch.stack((entry0, entry1)), output_final_state=True)
-    assert final is not None
-    composed_final = merge_state(entry1, maps[1])
-    high_output, high_final = kda_reference(*clone_kda_inputs(inputs, dtype=torch.float64))
-    low_output, low_final = kda_reference(*clone_kda_inputs(inputs, dtype=torch.float32))
-    assert high_final is not None and low_final is not None
-    assert_matches_low_precision_reference(
-        output, high_output, low_output, "two-tile output", source_dtype=dtype
-    )
-    for name, actual in (("native final", final[-1:]), ("composed final", composed_final[None])):
-        assert_matches_low_precision_reference(
-            actual, high_final, low_final, name, source_dtype=dtype
-        )
-
-
-@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
-def test_native_summary_ownership_is_bitwise_invariant(dtype: torch.dtype) -> None:
-    lengths = [17, 0, 65, 129]
-    inputs = make_kda_test_inputs(sum(lengths), dtype=dtype, gate_scale=0.02, normalize_qk=True)
-    cu = cumulative_sequence_offsets(lengths)
-    packed = build_mega_state_summaries(*inputs[1:], cu)
-    for index, (start, stop) in enumerate(pairwise(cu.tolist())):
-        alone = build_mega_state_summaries(
-            *(tensor[:, start:stop] for tensor in inputs[1:]),
-            cumulative_sequence_offsets([stop - start]),
-        )
-        assert torch.equal(packed[index : index + 1].view(torch.int32), alone.view(torch.int32))
-
-
-def test_native_summary_persistent_waves_are_bitwise_invariant() -> None:
-    """Exercise more than four nonempty work items per physical CTA, including empty tiles."""
-    lengths = [17, 0, 65, 129]
-    repeats = 4 * torch.cuda.get_device_properties(0).multi_processor_count // 3 + 1
-    inputs = make_kda_test_inputs(sum(lengths), gate_scale=0.02, normalize_qk=True)[1:]
-    expected = build_mega_state_summaries(*inputs, cumulative_sequence_offsets(lengths))
-    repeated = tuple(tensor.repeat(1, repeats, *([1] * (tensor.ndim - 2))) for tensor in inputs)
-    cu = cumulative_sequence_offsets(lengths * repeats)
-    for _ in range(2):
-        actual = build_mega_state_summaries(*repeated, cu).reshape(repeats, *expected.shape)
-        assert torch.equal(
-            actual.view(torch.int32), expected[None].expand_as(actual).view(torch.int32)
-        )
-
-
-def test_native_summary_cuda_graph_replay() -> None:
-    inputs = make_kda_test_inputs(81, gate_scale=0.02, normalize_qk=True)
-    cu = cumulative_sequence_offsets([17, 0, 64])
-    expected = build_mega_state_summaries(*inputs[1:], cu)
-    graph = torch.cuda.CUDAGraph()
-    with torch.cuda.graph(graph):
-        actual = build_mega_state_summaries(*inputs[1:], cu)
-    graph.replay()
-    assert torch.equal(actual.view(torch.int32), expected.view(torch.int32))
-
-
-@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
-def test_native_selected_forward_bounds(dtype: torch.dtype, monkeypatch) -> None:
-    """Standard CP selects whole subsequences, reordered/duplicated or empty, on device."""
-    inputs = make_kda_test_inputs(211, dtype=dtype, gate_scale=0.02, normalize_qk=True)
-    cu = cumulative_sequence_offsets([17, 0, 65, 129])
-    prepared = chunk_kda_prepare(
-        *inputs, cu_seqlens=cu, autotune=False, kernel_options={"backend": "mega"}
-    )
-    monkeypatch.setattr(
-        "attn_gym.linear.kda.stages._prepare_chunk_kda_fwd",
-        lambda *args, **kwargs: pytest.fail("whole-sequence summaries must stay native"),
-    )
-    all_maps = build_mega_state_summaries(*inputs[1:], cu)
-    bounds = torch.tensor(
-        [[82, 211], [0, 0], [17, 82], [82, 211]], device="cuda", dtype=torch.int32
-    )
-    expected = all_maps[[3, 1, 2, 3]]
-    actual = prepared.state_summaries(bounds, whole_sequences=True)
-    assert torch.equal(actual.view(torch.int32), expected.view(torch.int32))
-    graph = torch.cuda.CUDAGraph()
-    with torch.cuda.graph(graph):
-        captured = prepared.state_summaries(bounds, whole_sequences=True)
-    graph.replay()
-    assert torch.equal(captured.view(torch.int32), expected.view(torch.int32))
-    bounds.copy_(torch.tensor([[0, 17], [17, 17], [82, 211], [0, 0]], device="cuda"))
-    graph.replay()
-    assert torch.equal(captured.view(torch.int32), all_maps[[0, 1, 3, 1]].view(torch.int32))
-    bounds.zero_()
-    graph.replay()
-    assert torch.equal(captured, all_maps[1:2].expand_as(captured))
-
-
-@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
-@pytest.mark.parametrize("transpose_forward_transition", [False, True])
-def test_native_reverse_bias_and_ownership(
-    dtype: torch.dtype, transpose_forward_transition: bool, monkeypatch
-) -> None:
-    """C is exactly native dH0 and neither reverse probe depends on tile ownership/state."""
-    lengths = [17, 0, 65, 129]
-    inputs = make_kda_test_inputs(sum(lengths), dtype=dtype, gate_scale=0.02, normalize_qk=True)
-    cu = cumulative_sequence_offsets(lengths)
-    d_output = torch.randn_like(inputs[2])
-    prepared = chunk_kda_prepare(
-        *inputs, cu_seqlens=cu, autotune=False, kernel_options={"backend": "mega"}
-    )
-    initial = torch.randn(4, 1, 128, 128, device="cuda")
-    backward = chunk_kda_prepare_backward(
-        prepared.saved, d_output, initial, scale=prepared.scale, autotune=False
-    )
-    maps = build_mega_state_grad_summaries(
-        *inputs,
-        d_output,
-        cu,
-        prepared.scale,
-        transpose_forward_transition=transpose_forward_transition,
-    )
-    expected = backward.run()[-1]
-    assert torch.equal(maps[:, :, :128], expected)
-    monkeypatch.setattr(
-        "attn_gym.linear.kda.stages._prepare_chunk_kda_bwd",
-        lambda *args, **kwargs: pytest.fail("canonical reverse summaries must stay native"),
-    )
-    if transpose_forward_transition:
-        bounds = torch.stack((cu[:-1], cu[1:]), dim=1)
-        assert torch.equal(backward.state_grad_summaries(bounds, deterministic_work=True), maps)
-    else:
-        zero_backward = chunk_kda_prepare_backward(
-            prepared.saved,
-            torch.zeros_like(d_output),
-            initial,
-            scale=prepared.scale,
-            autotune=False,
-        )
-        identity = torch.eye(128, device="cuda").expand_as(initial).contiguous()
-        assert torch.equal(maps[:, :, 128:], zero_backward.run(identity)[-1])
-    for index, (start, stop) in enumerate(pairwise(cu.tolist())):
-        alone = build_mega_state_grad_summaries(
-            *(tensor[:, start:stop] for tensor in inputs),
-            d_output[:, start:stop],
-            cumulative_sequence_offsets([stop - start]),
-            prepared.scale,
-            transpose_forward_transition=transpose_forward_transition,
-        )
-        assert torch.equal(maps[index : index + 1].view(torch.int32), alone.view(torch.int32))
-
-
-@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
-@pytest.mark.parametrize("gate_value", [0.0, -0.002, -0.02])
-def test_native_reverse_matches_fp64(dtype: torch.dtype, gate_value: float) -> None:
-    """Both reverse recipes and fused maps are measured against an independent FP64 oracle."""
-    inputs = make_kda_test_inputs(129, dtype=dtype, gate_value=gate_value, normalize_qk=True)
-    cu = cumulative_sequence_offsets([129])
-    do = torch.randn_like(inputs[2])
-    scale = 0.25
-    maps = [
-        build_mega_state_grad_summaries(
-            *inputs, do, cu, scale, transpose_forward_transition=transpose
-        )
-        for transpose in (False, True)
-    ]
-    prepared = chunk_kda_prepare(*inputs, cu_seqlens=cu, scale=scale, autotune=False)
-    backward = chunk_kda_prepare_backward(prepared.saved, do, None, scale=scale, autotune=False)
-    maps.append(
-        backward.state_grad_summaries(torch.tensor([[0, 129]], device="cuda", dtype=torch.int32))
-    )
-    references = []
-    for precision in (torch.float64, torch.float32):
-        state = torch.zeros(1, 1, 128, 128, device="cuda", dtype=precision, requires_grad=True)
-        output, _ = kda_reference(*clone_kda_inputs(inputs, dtype=precision), state, scale=scale)
-        (bias,) = torch.autograd.grad(output, state, do.to(precision))
-        basis_inputs = list(clone_kda_inputs(inputs, dtype=precision))
-        basis_inputs[2] = torch.zeros_like(basis_inputs[2])
-        _, transition = kda_reference(
-            *basis_inputs, torch.eye(128, device="cuda", dtype=precision)[None, None], scale=scale
-        )
-        references.append(torch.cat((bias, transition.transpose(-1, -2)), dim=-2))
-    for label, actual in zip(("native bprop", "native C + A.T", "fused"), maps, strict=True):
-        for offset, part in ((0, "C"), (128, "R")):
-            high = references[0][:, :, offset : offset + 128]
-            low = references[1][:, :, offset : offset + 128]
-            got = actual[:, :, offset : offset + 128]
-            if part == "R" and label != "fused":
-                # Native R rounds the recurrent state/decay every BT16, not just at the
-                # output. A uniform gate can bias those roundings in the same direction;
-                # allow one source epsilon per chunk, rather than the single-round budget.
-                allowance = ceildiv(inputs[0].shape[1], 16) * torch.finfo(dtype).eps
-                budget = (low.double() - high).abs().max() + allowance * high.abs().max()
-                assert torch.isfinite(got).all()
-                assert (got.double() - high).abs().max() <= budget
-            else:
-                assert_matches_low_precision_reference(
-                    got, high, low, f"{label} {part}", source_dtype=dtype
-                )
-
-
-@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
-def test_native_two_tile_backward_matches_fp64(dtype: torch.dtype) -> None:
-    """Native forward/reverse maps hand off both states while all five gradients track FP64."""
-    inputs = make_kda_test_inputs(129, dtype=dtype, gate_scale=0.02, normalize_qk=True)
-    cu = cumulative_sequence_offsets([64, 65])
-    bounds = torch.tensor([[0, 64], [64, 129]], device="cuda", dtype=torch.int32)
-    prepared = chunk_kda_prepare(
-        *inputs, cu_seqlens=cu, autotune=False, kernel_options={"backend": "mega"}
-    )
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_native_two_tile_handoff_matches_fp64(dtype: torch.dtype, monkeypatch) -> None:
+    """Native forward/reverse maps hand off both states; outputs, finals, and grads track FP64."""
+    inputs, cu = _packed_inputs([64, 65], dtype)
+    prepared = chunk_kda_prepare(*inputs, cu_seqlens=cu, autotune=False, kernel_options=MEGA)
+    _forbid_fused_factors(monkeypatch)
+    bounds = torch.stack((cu[:-1], cu[1:]), dim=1)
     maps = prepared.state_summaries(bounds, deterministic_work=True)
     entry0 = torch.zeros_like(maps[0, :, :128])
     entries = torch.stack((entry0, merge_state(entry0, maps[0])))
     output, final = prepared.run(entries, output_final_state=True)
+    assert final is not None
+    composed_final = merge_state(entries[1], maps[1])
     do = torch.randn_like(output)
     exit1 = torch.randn_like(entry0) * 0.1
     backward = chunk_kda_prepare_backward(
@@ -337,32 +178,236 @@ def test_native_two_tile_backward_matches_fp64(dtype: torch.dtype) -> None:
         ref_gradients = torch.autograd.grad(
             (ref_output, ref_final), leaves, (do.to(precision), exit1[None].to(precision))
         )
-        references.append((ref_output, ref_final, *ref_gradients))
+        references.append((ref_output, ref_final, ref_final, *ref_gradients))
     for name, actual, high, low in zip(
-        ("output", "final", "dq", "dk", "dv", "dgate", "dbeta"),
-        (output, final[-1:], *gradients),
+        ("output", "native final", "composed final", "dq", "dk", "dv", "dgate", "dbeta"),
+        (output, final[-1:], composed_final[None], *gradients),
         *references,
         strict=True,
     ):
         assert_matches_low_precision_reference(actual, high, low, name, source_dtype=dtype)
 
 
-def test_native_reverse_cuda_graph_replay() -> None:
-    inputs = make_kda_test_inputs(81, gate_scale=0.02, normalize_qk=True)
-    cu = cumulative_sequence_offsets([17, 0, 64])
-    do = torch.randn_like(inputs[2])
-    expected = build_mega_state_grad_summaries(
-        *inputs, do, cu, 128**-0.5, transpose_forward_transition=True
-    )
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_native_summary_ownership_is_bitwise_invariant(dtype: torch.dtype) -> None:
+    inputs, cu = _packed_inputs(LENGTHS, dtype)
+    packed = build_mega_state_summaries(*inputs[1:], cu)
+    for index, (start, stop) in enumerate(pairwise(cu.tolist())):
+        alone = build_mega_state_summaries(
+            *(tensor[:, start:stop] for tensor in inputs[1:]),
+            cumulative_sequence_offsets([stop - start]),
+        )
+        _assert_bitwise_equal(packed[index : index + 1], alone)
+
+
+def test_native_summary_persistent_waves_are_bitwise_invariant() -> None:
+    """Exercise more than four nonempty work items per physical CTA, including empty tiles."""
+    repeats = 4 * torch.cuda.get_device_properties(0).multi_processor_count // 3 + 1
+    inputs, cu = _packed_inputs(LENGTHS)
+    expected = build_mega_state_summaries(*inputs[1:], cu)
+    repeated = tuple(t.repeat(1, repeats, *([1] * (t.ndim - 2))) for t in inputs[1:])
+    cu = cumulative_sequence_offsets(LENGTHS * repeats)
+    for _ in range(2):
+        actual = build_mega_state_summaries(*repeated, cu).reshape(repeats, *expected.shape)
+        _assert_bitwise_equal(actual, expected[None].expand_as(actual))
+
+
+def test_native_summary_cuda_graph_replay() -> None:
+    inputs, cu = _packed_inputs([17, 0, 64])
+    expected = build_mega_state_summaries(*inputs[1:], cu)
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
-        actual = build_mega_state_grad_summaries(
-            *inputs, do, cu, 128**-0.5, transpose_forward_transition=True
+        actual = build_mega_state_summaries(*inputs[1:], cu)
+    graph.replay()
+    _assert_bitwise_equal(actual, expected)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("heads", [1, 64])
+@pytest.mark.parametrize("probe", ["forward", "reverse", "reverse_bprop"])
+def test_native_selected_bounds(dtype: torch.dtype, heads: int, probe: str, monkeypatch) -> None:
+    """Selecting whole sequences (reordered, duplicated, or empty) on device preserves the bits.
+
+    The staged handles stay native, and bounds may change between CUDA Graph replays.
+    """
+    inputs, cu = _packed_inputs(LENGTHS, dtype, heads=heads)
+    do = torch.randn_like(inputs[2])
+    prepared = chunk_kda_prepare(*inputs, cu_seqlens=cu, autotune=False, kernel_options=MEGA)
+    backward = chunk_kda_prepare_backward(
+        prepared.saved, do, None, scale=prepared.scale, autotune=False
+    )
+    _forbid_fused_factors(monkeypatch)
+    grad_summaries = partial(build_mega_state_grad_summaries, *inputs, do, cu, prepared.scale)
+    match probe:
+        case "forward":
+            full = build_mega_state_summaries(*inputs[1:], cu)
+            selected = partial(prepared.state_summaries, whole_sequences=True)
+        case "reverse":
+            full = grad_summaries(transpose_forward_transition=True)
+            selected = partial(backward.state_grad_summaries, deterministic_work=True)
+        case "reverse_bprop":
+            full = grad_summaries()
+            selected = grad_summaries
+    cases = (
+        ([[82, 211], [17, 17], [17, 82], [82, 211]], [3, 1, 2, 3]),
+        ([[0, 17], [17, 17], [82, 211], [0, 0]], [0, 1, 3, 1]),
+        ([[17, 17]] * 4, [1] * 4),
+        ([[17, 82], [82, 211], [0, 17], [17, 82]], [2, 3, 0, 2]),
+    )
+    bounds = _bounds(cases[0][0])
+    _assert_bitwise_equal(selected(bounds=bounds), full[cases[0][1]])
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = selected(bounds=bounds)
+    for rows, indices in cases:
+        bounds.copy_(_bounds(rows))
+        graph.replay()
+        _assert_bitwise_equal(captured, full[indices])
+    assert selected(bounds=bounds[:0]).shape == (0, heads, 256, 128)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("transpose_forward_transition", [False, True])
+def test_native_reverse_bias_and_ownership(
+    dtype: torch.dtype, transpose_forward_transition: bool, monkeypatch
+) -> None:
+    """C is exactly native dH0 and neither reverse probe depends on tile ownership/state."""
+    inputs, cu = _packed_inputs(LENGTHS, dtype)
+    d_output = torch.randn_like(inputs[2])
+    prepared = chunk_kda_prepare(*inputs, cu_seqlens=cu, autotune=False, kernel_options=MEGA)
+    initial = torch.randn(4, 1, 128, 128, device="cuda")
+    backward = chunk_kda_prepare_backward(
+        prepared.saved, d_output, initial, scale=prepared.scale, autotune=False
+    )
+    _forbid_fused_factors(monkeypatch)
+    grad_summaries = partial(
+        build_mega_state_grad_summaries,
+        transpose_forward_transition=transpose_forward_transition,
+    )
+    maps = grad_summaries(*inputs, d_output, cu, prepared.scale)
+    assert torch.equal(maps[:, :, :128], backward.run()[-1])
+    if transpose_forward_transition:
+        bounds = torch.stack((cu[:-1], cu[1:]), dim=1)
+        assert torch.equal(backward.state_grad_summaries(bounds, deterministic_work=True), maps)
+    else:
+        zero_backward = chunk_kda_prepare_backward(
+            prepared.saved,
+            torch.zeros_like(d_output),
+            initial,
+            scale=prepared.scale,
+            autotune=False,
         )
+        identity = torch.eye(128, device="cuda").expand_as(initial).contiguous()
+        assert torch.equal(maps[:, :, 128:], zero_backward.run(identity)[-1])
+    for index, (start, stop) in enumerate(pairwise(cu.tolist())):
+        alone = grad_summaries(
+            *(tensor[:, start:stop] for tensor in (*inputs, d_output)),
+            cumulative_sequence_offsets([stop - start]),
+            prepared.scale,
+        )
+        _assert_bitwise_equal(maps[index : index + 1], alone)
+
+
+def test_native_reverse_selection_skips_unrequested_work(monkeypatch) -> None:
+    """The native kernels consume the selected work table, not a prologue-generated full one."""
+    inputs, cu = _packed_inputs(LENGTHS)
+    do = torch.randn_like(inputs[2])
+    bounds = _bounds([[82, 211], [17, 17], [82, 211]])
+    tables = []
+    for module, name in (
+        (kda_bprop_f16, "chunk_kda_bwd_sm100"),
+        (kda_recompute_f16, "chunk_kda_recompute_sm100"),
+    ):
+        original = getattr(module, name)
+
+        def checked(*args, original=original, **kwargs):
+            assert not kwargs["order_in_prologue"]
+            tables.append(kwargs["work_items"].clone())
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(module, name, checked)
+    grad_summaries = partial(
+        build_mega_state_grad_summaries, *inputs, do, cu, SCALE, transpose_forward_transition=True
+    )
+    grad_summaries(bounds=bounds)
+    assert len(tables) == 2
+    expected = torch.tensor(
+        [
+            [0, 0, 0, 0, 0, 0, 0, 0],
+            [1, 0, 0, 0, 0, 0, 17, 17],
+            [2, 0, 0, 0, 0, 0, 17, 17],
+            [3, 0, 0, 9, 0, 9, 82, 211],
+        ],
+        device="cuda",
+        dtype=torch.int32,
+    )
+    for table in tables:
+        assert torch.equal(table, expected)
+    tables.clear()
+    assert grad_summaries(bounds=bounds[:0]).shape == (0, 1, 256, 128)
+    assert not tables
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("gate_value", [0.0, -0.002, -0.02])
+def test_native_reverse_matches_fp64(dtype: torch.dtype, gate_value: float) -> None:
+    """Both reverse recipes and fused maps are measured against an independent FP64 oracle."""
+    inputs, cu = _packed_inputs([129], dtype, gate_value=gate_value)
+    do = torch.randn_like(inputs[2])
+    scale = 0.25
+    maps = [
+        build_mega_state_grad_summaries(
+            *inputs, do, cu, scale, transpose_forward_transition=transpose
+        )
+        for transpose in (False, True)
+    ]
+    prepared = chunk_kda_prepare(*inputs, cu_seqlens=cu, scale=scale, autotune=False)
+    backward = chunk_kda_prepare_backward(prepared.saved, do, None, scale=scale, autotune=False)
+    maps.append(backward.state_grad_summaries(_bounds([[0, 129]])))
+    references = []
+    for precision in (torch.float64, torch.float32):
+        state = torch.zeros(1, 1, 128, 128, device="cuda", dtype=precision, requires_grad=True)
+        output, _ = kda_reference(*clone_kda_inputs(inputs, dtype=precision), state, scale=scale)
+        (bias,) = torch.autograd.grad(output, state, do.to(precision))
+        basis_inputs = list(clone_kda_inputs(inputs, dtype=precision))
+        basis_inputs[2] = torch.zeros_like(basis_inputs[2])
+        _, transition = kda_reference(
+            *basis_inputs, torch.eye(128, device="cuda", dtype=precision)[None, None], scale=scale
+        )
+        references.append(torch.cat((bias, transition.transpose(-1, -2)), dim=-2))
+    high, low = references
+    for label, actual in zip(("native bprop", "native C + A.T", "fused"), maps, strict=True):
+        for part, rows in (("C", slice(0, 128)), ("R", slice(128, None))):
+            if part == "R" and label != "fused":
+                # Native R rounds the recurrent state/decay every BT16, not just at the
+                # output. A uniform gate can bias those roundings in the same direction;
+                # allow one source epsilon per chunk, rather than the single-round budget.
+                allowance = ceildiv(inputs[0].shape[1], 16) * torch.finfo(dtype).eps
+                error = (low[:, :, rows].double() - high[:, :, rows]).abs().max()
+                budget = error + allowance * high[:, :, rows].abs().max()
+                assert torch.isfinite(actual[:, :, rows]).all()
+                assert (actual[:, :, rows].double() - high[:, :, rows]).abs().max() <= budget
+            else:
+                assert_matches_low_precision_reference(
+                    actual[:, :, rows],
+                    high[:, :, rows],
+                    low[:, :, rows],
+                    f"{label} {part}",
+                    source_dtype=dtype,
+                )
+
+
+def test_native_reverse_cuda_graph_replay() -> None:
+    inputs, cu = _packed_inputs([17, 0, 64])
+    do = torch.randn_like(inputs[2])
+    grad_summaries = partial(
+        build_mega_state_grad_summaries, *inputs, do, cu, SCALE, transpose_forward_transition=True
+    )
+    expected = grad_summaries()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        actual = grad_summaries()
     do.mul_(0.5)
     graph.replay()
-    fresh = build_mega_state_grad_summaries(
-        *inputs, do, cu, 128**-0.5, transpose_forward_transition=True
-    )
     assert not torch.equal(actual, expected)
-    assert torch.equal(actual.view(torch.int32), fresh.view(torch.int32))
+    _assert_bitwise_equal(actual, grad_summaries())


### PR DESCRIPTION
Stacked PRs:
 * #519
 * __->__#518
 * #517
 * #516
 * #515
 * #514
 * #513
 * #512


--- --- ---

Probe only the selected sequences in the native Mega reverse summaries

build_mega_state_grad_summaries(..., bounds=) reuses the forward's device work table so the
native backward probe (C) and the forward A.T probe run only for the requested whole sequences;
unrequested sequences get zero chunks, the prologue no longer regenerates all-sequence work
(order_in_prologue=False, counters reset per probe), and the rows are gathered afterwards. A
selected sequence's arithmetic is unchanged, so the maps are bitwise the full-stream ones
(tests compare subsets, reordered, duplicate, and empty bounds against the full stream).
bounds=None keeps the previous behaviour.

127-document Zipf stream, 32k tokens, 64 heads, CP2 (halves ownership): Mega bwd summary
3.46 -> 1.96 ms at tile 1024 and 3.40 -> 1.53 ms at tile 2048; total backward 6.96 -> 5.46 and
6.57 -> 4.68 ms. With every sequence selected (5-document benchmark) the extra selection launches
cost about 1% of the backward. Details in agent_space/B6_mega_reverse_select_report.md.