### PR TITLE
Close the review leftovers on the deterministic recipe

### DIFF
--- a/attn_gym/linear/context_parallel_deterministic.py
+++ b/attn_gym/linear/context_parallel_deterministic.py
@@ -8,51 +8,50 @@
 
 NOTE [Canonical Tiles]
 The standard recipe (``context_parallel_chunk``) summarizes each rank's fragment with one affine
-map. Changing the number of ranks changes the fragments, which changes which token ranges are
-summarized and how the FP32 maps are composed, so the rounded result moves. This module fixes
-the whole arithmetic graph before ranks are assigned:
+map, so changing the number of ranks changes which token ranges are summarized and how the FP32
+maps compose, and the rounded result moves. This module fixes the whole arithmetic graph before
+ranks are assigned:
 
     tile      ``[start, min(start + tile_size, doc_end))`` within one document, aligned to the
-              document's first token; the last tile of a document may be short. Tile size is a
-              multiple of the 64-token summary chunk and is part of the numerical contract.
-    leaf map  every tile's ``[bias; transition]`` forward map and ``[C; R]`` reverse map, computed
+              document's first token; a document's last tile may be short. ``tile_size`` is a
+              multiple of the 64-token summary chunk and part of the numerical contract.
+    leaf map  each tile's ``[bias; transition]`` forward map and ``[C; R]`` reverse map, computed
               by the staged op on that tile alone (no other tile's tokens are visible).
-    scan      per document, a left-to-right serial fold of the leaf maps in tile order
-              (forward) and reverse tile order (backward), in three-pass TF32 (fp32-accurate),
-              fused in one launch. The state entering tile ``j`` is a function of that
-              document's leaves ``0..j-1`` alone.
-    entry     ``merge_state(0, prefix[i - 1])`` for tile ``i``; the first tile of a document enters
+    scan      per document, a serial fold of the leaf maps in tile order (forward) or reverse
+              tile order (backward), in three-pass TF32 (fp32-accurate), fused in one launch. The
+              state entering tile ``j`` depends on that document's leaves ``0..j-1`` alone.
+    entry     ``merge_state(0, prefix[i - 1])`` for tile ``i``; a document's first tile enters
               with zero. Exits are the reverse analogue.
 
-NOTE [Single-Tile Documents]
-A document that fits in one tile has no state to carry: its tile enters with the zero state and
-nothing reads its map. Such tiles are excluded from the summaries, the exchange, and the scan
-(``CanonicalTiling.summarized``). The exclusion is a function of the tiling only, so the
-contract is unchanged, and on packings with many short documents it removes most of the
-recipe's overhead (``agent_space/friendly_fragments/REPORT.md``).
-
-NOTE [Scan Blocks]
-Exchanging every tile's map costs 128 KiB per tile per head per rank. Consecutive tiles of a
-document are therefore grouped into blocks of ``scan_block`` tiles (document-relative, the last
-block of a document may be short); only block maps cross ranks. A block map is the serial fold
-of its tiles' maps, the per-document scan runs over block maps, and each rank folds its own
-tiles from the block entry state. Every operation is a function of tile indices only, so the
-tree is still fixed; it is a different tree from the flat fold (``scan_block=1``), hence a
-different numerical contract, and ``scan_block`` is part of the recipe. Ranks must own whole
-blocks (a block split across ranks would need its tiles exchanged); block-aligned fragments make
-the exchange ``scan_block`` times smaller with identical bits. The block folds cost about as much
-as a full scan, so blocks pay off only when the gather dominates (many ranks, slow interconnect,
-many tiles per rank); on two NVLink GPUs ``scan_block=1`` is faster and is the default.
-
 Ranks own whole tiles; ownership changes which leaves a rank computes and where the scan runs,
-never the leaf arithmetic or the tree. The result for CP=1 with this recipe is therefore bitwise
-identical to CP=N (verified for fused and Mega forwards, see the deterministic tests), and a
-document's result does not depend on which other documents are packed around it. It is a
-distinct numerical contract from the unsharded ``chunk_kda`` call.
+never the leaf arithmetic or the tree. CP=1 is therefore bitwise identical to CP=N (verified for
+the fused and Mega forwards in ``test/test_context_parallel_deterministic.py``), and a document's
+result does not depend on the documents packed around it. It is a distinct numerical contract
+from the unsharded ``chunk_kda`` call.
 
 A rank prepares all its tiles in one staged call, each tile a packed subsequence, with the
 summary kernels' work partition pinned (``deterministic_work=True``); this is bitwise equal to
 preparing every tile alone (``test/test_canonical_tile_batching.py``).
+
+NOTE [Single-Tile Documents]
+A document that fits in one tile has no state to carry: its tile enters with zero and nothing
+reads its map, so it is excluded from the summaries, the exchange, and the scan
+(``CanonicalTiling.summarized``). The exclusion depends on the tiling only, so the contract is
+unchanged, and on packings with many short documents it removes most of the recipe's overhead
+(measured by ``benchmarks/kda_cp_fragment_study.py``).
+
+NOTE [Scan Blocks]
+Exchanging every tile's map costs 128 KiB per tile per head per rank, so consecutive tiles of a
+document can be grouped into blocks of ``scan_block`` tiles (document-relative; a document's
+last block may be short) and only block maps cross ranks: each rank folds its blocks' tile maps
+into block maps, the per-document scan runs over block maps, and each rank folds its own tiles
+again from the block entry states. Every operation is a function of tile indices only, so the
+tree is still fixed, but it differs from the flat fold (``scan_block=1``) and is a different
+numerical contract; ``scan_block`` is part of the recipe. Ranks must own whole blocks (a block
+split across ranks would need its tiles exchanged); block-aligned fragments make the exchange
+``scan_block`` times smaller with identical bits. The block folds cost about as much as a full
+scan, so blocks pay off only when the gather dominates (many ranks, slow interconnect, many
+tiles per rank); on two NVLink GPUs ``scan_block=1`` is faster and is the default.
 """
 
 from __future__ import annotations
@@ -60,7 +59,7 @@ from __future__ import annotations
 from collections import Counter
 from collections.abc import Sequence
 from dataclasses import dataclass
-from itertools import accumulate, pairwise
+from itertools import accumulate, groupby, pairwise
 from typing import NamedTuple
 
 import torch
@@ -114,10 +113,9 @@ class CanonicalTiling:
         """Tile the stream and assign whole tiles to the ranks that own their tokens.
 
         ``fragments[rank]`` are that rank's global token ranges. Every fragment boundary must fall
-        on a tile boundary (a document boundary or ``doc_start + k * tile_size``), otherwise the
-        ownership would cut a tile and the leaf arithmetic would depend on the fragment table.
-        With ``scan_block > 1`` the boundaries must fall on block boundaries
-        (``doc_start + k * scan_block * tile_size``) for the same reason (NOTE [Scan Blocks]).
+        on a tile boundary (a document boundary or ``doc_start + k * tile_size``), and with
+        ``scan_block > 1`` on a block boundary, otherwise the ownership would cut a tile or block
+        and the arithmetic would depend on the fragment table (NOTE [Scan Blocks]).
         """
         if tile_size <= 0 or tile_size % SUMMARY_CHUNK:
             raise ValueError(f"tile_size must be a positive multiple of {SUMMARY_CHUNK}")
@@ -126,32 +124,24 @@ class CanonicalTiling:
         if not 0 <= cp_rank < len(fragments):
             raise ValueError(f"cp_rank {cp_rank} is outside a table of {len(fragments)} ranks")
         tiles = tile_stream(cu_seqlens_global, tile_size)
-        starts = {tile.start: index for index, tile in enumerate(tiles)}
-        boundaries = set(starts) | {cu_seqlens_global[-1]}
-        owned: list[list[int]] = []
+        # Tile boundaries -> id of the tile starting there; the stream's end closes the last one.
+        boundary = {tile.start: index for index, tile in enumerate(tiles)}
+        boundary[cu_seqlens_global[-1]] = len(tiles)
+        owned: list[tuple[int, ...]] = []
         for rank_fragments in fragments:
             ids: list[int] = []
             for start, stop in rank_fragments:
                 if start >= stop:
                     raise ValueError(f"fragment [{start}, {stop}) is empty or reversed")
-                if start not in boundaries or stop not in boundaries:
+                if start not in boundary or stop not in boundary:
                     raise ValueError(
                         f"fragment [{start}, {stop}) does not fall on canonical tile boundaries"
                     )
-                index = starts.get(start)
-                while index is not None and index < len(tiles) and tiles[index].stop <= stop:
-                    ids.append(index)
-                    index += 1
-            owned.append(ids)
-        seen = sorted(index for ids in owned for index in ids)
-        if seen != list(range(len(tiles))):
+                ids.extend(range(boundary[start], boundary[stop]))
+            owned.append(tuple(ids))
+        if sorted(index for ids in owned for index in ids) != list(range(len(tiles))):
             raise ValueError("fragments must cover every tile exactly once")
-        tiling = cls(
-            tiles=tuple(tiles),
-            owned=tuple(tuple(ids) for ids in owned),
-            cp_rank=cp_rank,
-            scan_block=scan_block,
-        )
+        tiling = cls(tuple(tiles), tuple(owned), cp_rank=cp_rank, scan_block=scan_block)
         owner = {index: rank for rank, ids in enumerate(owned) for index in ids}
         for block in tiling.blocks:
             if len({owner[index] for index in block}) != 1:
@@ -160,6 +150,10 @@ class CanonicalTiling:
                     "several ranks; cut fragments on block boundaries or use scan_block=1"
                 )
         return tiling
+
+    @property
+    def mine(self) -> tuple[int, ...]:
+        return self.owned[self.cp_rank]
 
     @property
     def summarized(self) -> tuple[int, ...]:
@@ -171,33 +165,23 @@ class CanonicalTiling:
     def blocks(self) -> tuple[tuple[int, ...], ...]:
         """Tile ids of every scan block, in tile order (NOTE [Scan Blocks])."""
         blocks: list[tuple[int, ...]] = []
-        run: list[int] = []
-        for index in (*self.summarized, None):
-            if run and (
-                index is None or self.tiles[index].document != self.tiles[run[0]].document
-            ):
-                for begin in range(0, len(run), self.scan_block):
-                    blocks.append(tuple(run[begin : begin + self.scan_block]))
-                run = []
-            if index is not None:
-                run.append(index)
+        for _, run in groupby(self.summarized, key=lambda i: self.tiles[i].document):
+            ids = list(run)
+            blocks.extend(
+                tuple(ids[b : b + self.scan_block]) for b in range(0, len(ids), self.scan_block)
+            )
         return tuple(blocks)
 
     @property
-    def my_blocks(self) -> tuple[int, ...]:
-        """Ids (into ``blocks``) of the blocks this rank owns, in its span order."""
+    def blocks_by_rank(self) -> tuple[tuple[int, ...], ...]:
+        """``blocks_by_rank[rank]``: ids (into ``blocks``) of that rank's blocks, in span order."""
         first_tile = {block[0]: b for b, block in enumerate(self.blocks)}
-        return tuple(first_tile[index] for index in self.mine if index in first_tile)
-
-    @property
-    def mine(self) -> tuple[int, ...]:
-        return self.owned[self.cp_rank]
+        return tuple(tuple(first_tile[i] for i in ids if i in first_tile) for ids in self.owned)
 
     @property
     def slots(self) -> int:
         """Gather width: the most blocks any rank owns."""
-        first_tile = {block[0] for block in self.blocks}
-        return max(sum(index in first_tile for index in ids) for ids in self.owned)
+        return max(map(len, self.blocks_by_rank))
 
     def global_token_ids(self, device: torch.device | str) -> torch.Tensor:
         """Global token id of every span token of this rank (tiles concatenated in span order)."""
@@ -213,87 +197,58 @@ class CanonicalTiling:
     def routing(self, device: torch.device | str) -> CanonicalRouting:
         """Materialize the index tensors the recipe reads, once per layout and device."""
         offsets = self.span_offsets()
-        blocks = self.blocks
-        my_blocks = self.my_blocks
         summarized = set(self.summarized)
-        positions = [p for p, index in enumerate(self.mine) if index in summarized]
-        first_tile = {block[0]: b for b, block in enumerate(blocks)}
-        per_rank = [[first_tile[i] for i in ids if i in first_tile] for ids in self.owned]
-        order = [b for ranks_blocks in per_rank for b in ranks_blocks]
-        width = self.slots
-        if order == list(range(len(blocks))) and len(order) == width * len(self.owned):
-            gather_place = None
-        else:
-            rows = [
-                rank * width + row
-                for rank, ranks_blocks in enumerate(per_rank)
-                for row in range(len(ranks_blocks))
-            ]
-            gather_place = (
-                torch.tensor(order, dtype=torch.int64, device=device),
-                torch.tensor(rows, dtype=torch.int64, device=device),
-            )
-        bounds = list(pairwise(offsets))
+        positions = [p for p, i in enumerate(self.mine) if i in summarized]
+        blocks, by_rank, width = self.blocks, self.blocks_by_rank, self.slots
+        my_blocks = by_rank[self.cp_rank]
+        # Row of each block in the all-gather buffer: rank-major, ``width`` rows per rank.
+        row = {b: rank * width + r for rank, ids in enumerate(by_rank) for r, b in enumerate(ids)}
+        source = [row[b] for b in range(len(blocks))]
+        block_documents = [self.tiles[block[0]].document for block in blocks]
+
+        def int32(values: Sequence[int] | Sequence[tuple[int, int]]) -> torch.Tensor:
+            return torch.tensor(values, dtype=torch.int32, device=device)
+
         return CanonicalRouting(
-            cu_seqlens=torch.tensor(offsets, dtype=torch.int32, device=device),
-            bounds=torch.tensor(bounds, dtype=torch.int32, device=device),
-            summary_bounds=torch.tensor(
-                [bounds[p] for p in positions], dtype=torch.int32, device=device
-            ).reshape(-1, 2),
+            cu_seqlens=int32(offsets),
+            summary_bounds=int32([offsets[p : p + 2] for p in positions]).reshape(-1, 2),
             summarized_positions=(
                 None
                 if len(positions) == len(self.mine)
                 else torch.tensor(positions, dtype=torch.int64, device=device)
             ),
-            block_document_offsets=_document_offsets(
-                [self.tiles[block[0]].document for block in blocks], device
+            block_document_offsets=int32(
+                [0, *accumulate(len(list(run)) for _, run in groupby(block_documents))]
             ),
-            my_block_offsets=torch.tensor(
-                [0, *accumulate(len(blocks[b]) for b in my_blocks)],
-                dtype=torch.int32,
-                device=device,
-            ),
+            my_block_offsets=int32([0, *accumulate(len(blocks[b]) for b in my_blocks)]),
             my_blocks=_selection(my_blocks, device),
-            my_block_tiles=_selection(
-                [
-                    sum(len(blocks[b]) for b in range(block)) + offset
-                    for block in my_blocks
-                    for offset in range(len(blocks[block]))
-                ],
-                device,
+            gather_source=(
+                None
+                if source == list(range(len(blocks)))
+                else torch.tensor(source, dtype=torch.int64, device=device)
             ),
-            gather_place=gather_place,
         )
-
-
-def _document_offsets(documents: Sequence[int], device: torch.device) -> torch.Tensor:
-    """``int32 [D + 1]`` boundaries of consecutive equal ``documents`` entries."""
-    offsets = [0]
-    offsets += [i for i in range(1, len(documents)) if documents[i] != documents[i - 1]]
-    offsets.append(len(documents))
-    return torch.tensor(offsets, dtype=torch.int32, device=device)
 
 
 class CanonicalRouting(NamedTuple):
     """Device tensors of a :class:`CanonicalTiling` for one rank, built once per layout.
 
-    ``cu_seqlens``/``bounds`` describe the rank's span with one segment per owned tile;
-    ``summary_bounds`` are the rows of ``bounds`` whose tiles take part in the scan and
-    ``summarized_positions`` their positions among the owned tiles (``None`` when all do).
-    ``my_blocks`` / ``my_block_tiles`` select this rank's blocks / block tiles in the block-order
-    exchange buffer, as a slice when consecutive so no gather copy is made; ``gather_place``
-    reorders the all-gather packets into block order (``None`` when they already are).
+    ``cu_seqlens`` cuts the rank's span into one segment per owned tile; ``summary_bounds`` are
+    the segments whose tiles take part in the scan and ``summarized_positions`` their positions
+    among the owned tiles (``None`` when all do). ``block_document_offsets`` groups the blocks by
+    document; ``my_block_offsets`` groups this rank's summarized tiles by block. ``my_blocks``
+    selects this rank's blocks in the block-order exchange buffer, as a slice when consecutive so
+    no gather copy is made; ``gather_source`` is each block's row in the all-gather buffer
+    (``None`` when the buffer already is the block order).
     """
 
     cu_seqlens: torch.Tensor
-    bounds: torch.Tensor
     summary_bounds: torch.Tensor
     summarized_positions: torch.Tensor | None
     block_document_offsets: torch.Tensor
     my_block_offsets: torch.Tensor
     my_blocks: torch.Tensor | slice
-    my_block_tiles: torch.Tensor | slice
-    gather_place: tuple[torch.Tensor, torch.Tensor] | None
+    gather_source: torch.Tensor | None
 
 
 def _selection(ids: Sequence[int], device: torch.device | str) -> torch.Tensor | slice:
@@ -305,17 +260,19 @@ def _selection(ids: Sequence[int], device: torch.device | str) -> torch.Tensor |
 
 def tile_stream(cu_seqlens_global: Sequence[int], tile_size: int) -> list[Tile]:
     """Cut every document into ``tile_size`` tiles from its first token; the last may be short."""
-    tiles = []
-    for document, (start, stop) in enumerate(pairwise(cu_seqlens_global)):
-        tiles.extend(
-            Tile(document, begin, min(begin + tile_size, stop))
-            for begin in range(start, stop, tile_size)
-        )
-    return tiles
+    return [
+        Tile(document, begin, min(begin + tile_size, stop))
+        for document, (start, stop) in enumerate(pairwise(cu_seqlens_global))
+        for begin in range(start, stop, tile_size)
+    ]
+
+
+# Module-level name so tests without a second GPU can substitute a CPU-staged collective.
+_all_gather_into_tensor = dist.all_gather_into_tensor
 
 
 def all_gather_block_maps(
-    local: torch.Tensor | None,
+    local: torch.Tensor,
     tiling: CanonicalTiling,
     routing: CanonicalRouting,
     like: torch.Tensor,
@@ -323,62 +280,52 @@ def all_gather_block_maps(
 ) -> torch.Tensor:
     """Exchange every rank's block maps and return them as ``[blocks, H, V + K, K]`` in block order.
 
-    ``local`` holds this rank's block maps in ``tiling.my_blocks`` order (``None`` for an empty
-    rank). Packets are zero-padded to ``tiling.slots`` rows so the collective is a plain
-    equal-size all-gather; padding rows never enter a scan. When every rank's blocks are
-    contiguous in rank order and no padding is needed, the gathered buffer already is the block
-    order and is returned without a copy. ``group=None`` (a single rank owning everything, the
-    CP=1 reference) skips the collective.
+    ``local`` holds this rank's block maps in its span order (zero rows for a rank without
+    blocks). Packets are zero-padded to ``tiling.slots`` rows so the collective is a plain
+    equal-size all-gather; padding rows never enter a scan. When the gathered buffer already is
+    the block order it is returned without a copy. ``group=None`` (a single rank owning
+    everything, the CP=1 reference) skips the collective.
     """
-    width = tiling.slots
-    world = len(tiling.owned)
+    width, world = tiling.slots, len(tiling.owned)
     if group is None:
-        assert world == 1 and local is not None and local.shape[0] == len(tiling.blocks)
+        assert world == 1 and local.shape[0] == len(tiling.blocks)
         return local
-    if local is not None and local.shape[0] == width:
+    if local.shape[0] == width:
         packet = local
     else:
         packet = like.new_zeros((width, *like.shape[1:]))
-        if local is not None:
-            packet[: local.shape[0]] = local
+        packet[: local.shape[0]] = local
     gathered = like.new_empty((world * width, *like.shape[1:]))
     with profiler_range("cp/all_gather_blocks"):
-        dist.all_gather_into_tensor(gathered, packet, group=group)
-    if routing.gather_place is None:
-        return gathered
-    order, rows = routing.gather_place
-    placed = torch.empty_like(gathered[: len(tiling.blocks)])
-    placed[order] = gathered[rows]
-    return placed
+        _all_gather_into_tensor(gathered, packet, group=group)
+    if routing.gather_source is None:
+        return gathered[: len(tiling.blocks)]
+    return gathered[routing.gather_source]
 
 
 def canonical_entries(
-    summary_maps: torch.Tensor | None,
+    summary_maps: torch.Tensor,
     tiling: CanonicalTiling,
     routing: CanonicalRouting,
     like: torch.Tensor,
     group: dist.ProcessGroup | None,
     *,
     reverse: bool,
-) -> torch.Tensor | None:
+) -> torch.Tensor:
     """Entry (or exit when ``reverse``) FP32 states of this rank's tiles, in ``tiling.mine`` order.
 
     ``summary_maps`` are the maps of the rank's summarized tiles (NOTE [Single-Tile Documents])
-    in span order, or ``None`` for an empty rank (which still joins the collective). Tiles of
-    single-tile documents get the zero state.
+    in span order; a rank with none (possibly no tiles at all) passes zero rows and still joins
+    the collective. Tiles of single-tile documents get the zero state.
 
     With ``scan_block == 1`` every summarized tile map is gathered and scanned per document.
-    Otherwise the fixed three-level tree of NOTE [Scan Blocks]: fold each owned block's tile maps
-    into one block map; all-gather block maps; scan them per document for the block entry states;
-    fold each owned block's tiles again from its entry state for the tile states. Every fold is
-    the left-to-right (right-to-left when ``reverse``) serial fold in three-pass TF32, so the
-    result is a function of the tiles' maps and indices only.
+    Otherwise the three-level tree of NOTE [Scan Blocks]: fold each owned block's tile maps into
+    one block map; all-gather block maps; scan them per document for the block entry states;
+    fold each owned block's tiles again from its entry state. Every fold is the serial fold in
+    three-pass TF32, so the result is a function of the tiles' maps and indices only.
     """
-    if summary_maps is None or summary_maps.shape[0] == 0:
-        # An empty rank, or one owning only single-tile documents, still joins the collective.
-        all_gather_block_maps(None, tiling, routing, like, group)
-        if summary_maps is None:
-            return None
+    if summary_maps.shape[0] == 0:
+        all_gather_block_maps(summary_maps, tiling, routing, like, group)
         return like.new_zeros(
             (len(tiling.mine), like.shape[1], like.shape[2] - like.shape[3], like.shape[3])
         )
@@ -386,7 +333,7 @@ def canonical_entries(
         gathered = all_gather_block_maps(summary_maps, tiling, routing, like, group)
         entries = canonical_scan_entries(
             gathered, routing.block_document_offsets, reverse=reverse
-        )[routing.my_block_tiles]
+        )[routing.my_blocks]
     else:
         block_maps = fold_ranges(summary_maps, routing.my_block_offsets, reverse=reverse)
         gathered = all_gather_block_maps(block_maps, tiling, routing, like, group)
@@ -410,50 +357,38 @@ class _CanonicalContextParallel(torch.autograd.Function):
     """One batched staged forward/backward per rank glued by the fixed scan tree.
 
     Every owned tile is one packed subsequence of the rank's span (``cu_seqlens`` at tile
-    boundaries), so the leaf kernels see each tile exactly as an independent call would; the
+    boundaries), so the leaf kernels see each tile exactly as an independent call would, and the
     summary kernels run with ``deterministic_work=True`` so their work partition cannot depend on
-    how many tiles the rank owns (see ``build_state_summaries``). Batching is bitwise equal to
-    per-tile calls for the fused kernels (``test/test_canonical_tile_batching.py``).
+    how many tiles the rank owns. A rank without tiles skips the kernels but still joins both
+    collectives.
     """
 
     @staticmethod
     def forward(ctx, q, k, v, gate, beta, tiling, routing, group, stages: StagedOp):
-        heads, dim, value_dim = q.shape[2], q.shape[3], v.shape[3]
-        zero = q.new_zeros((1, heads, value_dim, dim), dtype=torch.float32)
-        like = zero.new_empty((1, heads, value_dim + dim, dim))  # one packed map
-        n = len(tiling.mine)
-        if n:
+        heads, dim, value_dim = v.shape[2], q.shape[3], v.shape[3]  # maps are per value head
+        # Zero rows of the packed map shape: the collectives' shape anchor, and the summaries
+        # of a rank with nothing to summarize.
+        like = q.new_empty((0, heads, value_dim + dim, dim), dtype=torch.float32)
+        maps = like
+        if tiling.mine:
             prepared = stages.prepare(q, k, v, gate, beta, cu_seqlens=routing.cu_seqlens)
-            maps = (
-                prepared.state_summaries(routing.summary_bounds, deterministic_work=True)
-                if routing.summary_bounds.shape[0]
-                else like[:0]
-            )
-        else:
-            prepared = None
-            maps = None
+            if routing.summary_bounds.shape[0]:
+                maps = prepared.state_summaries(routing.summary_bounds, deterministic_work=True)
         entry = canonical_entries(maps, tiling, routing, like, group, reverse=False)
-        if n:
+        if tiling.mine:
             with profiler_range("cp/run"):
                 output, _ = prepared.run(entry, output_final_state=False)
-            saved = tuple(prepared.saved)
+            ctx.save_for_backward(*prepared.saved, entry, like)
             ctx.saved_type = type(prepared.saved)
             ctx.scale = prepared.scale
         else:
             output = v[:, :0]
-            entry = zero[:0]
-            saved = ()
-            ctx.saved_type = None
-            ctx.scale = None
+            ctx.save_for_backward(entry, like)
+            ctx.input_meta = tuple((t.shape, t.dtype) for t in (q, k, v, gate, beta))
         ctx.tiling = tiling
         ctx.routing = routing
         ctx.group = group
         ctx.stages = stages
-        ctx.input_meta = tuple((t.shape, t.dtype) for t in (q, k, v, gate, beta))
-        ctx.output_meta = (output.shape, output.dtype)
-        # ``zero`` and ``like`` give an empty rank the map shapes its collective must match.
-        ctx.save_for_backward(*saved, entry, zero, like)
-        ctx.set_materialize_grads(False)
         return output
 
     @staticmethod
@@ -461,28 +396,22 @@ class _CanonicalContextParallel(torch.autograd.Function):
     def backward(ctx, d_output):
         tiling: CanonicalTiling = ctx.tiling
         routing: CanonicalRouting = ctx.routing
-        *saved, entry, zero, like = ctx.saved_tensors
-        if d_output is None:
-            d_output = zero.new_zeros(*ctx.output_meta)
-        n = len(tiling.mine)
-        if n:
+        *saved, entry, like = ctx.saved_tensors
+        maps = like
+        if tiling.mine:
             backward = ctx.stages.prepare_backward(
                 ctx.saved_type._make(saved), d_output, entry, scale=ctx.scale
             )
-            maps = (
-                backward.state_grad_summaries(routing.summary_bounds, deterministic_work=True)
-                if routing.summary_bounds.shape[0]
-                else like[:0]
-            )
-        else:
-            backward = None
-            maps = None
+            if routing.summary_bounds.shape[0]:
+                maps = backward.state_grad_summaries(
+                    routing.summary_bounds, deterministic_work=True
+                )
         exit_cotangent = canonical_entries(maps, tiling, routing, like, ctx.group, reverse=True)
-        if n:
+        if tiling.mine:
             with profiler_range("cp/run"):
                 grads = backward.run(exit_cotangent)[:5]
         else:
-            grads = tuple(zero.new_empty(shape, dtype=dtype) for shape, dtype in ctx.input_meta)
+            grads = tuple(like.new_empty(shape, dtype=dtype) for shape, dtype in ctx.input_meta)
         return (*grads, None, None, None, None)
 
 
@@ -516,6 +445,10 @@ def context_parallel_chunk_deterministic(
     Every rank in ``group`` must call this, and run its backward, the same number of times,
     including ranks that own no tiles: both directions all-gather maps, so an empty rank still
     contributes an all-zero packet (and gets an empty output and empty gradients).
+
+    Memory: every rank holds the gathered maps of all summarized tiles, ``H x (V + K) x K``
+    FP32 each (128 KiB per head for K = V = 128), plus one entry state per owned tile; the tile
+    size sets that footprint (NOTE [Single-Tile Documents], NOTE [Scan Blocks]).
     """
     world, cp_rank = dist.get_world_size(group), dist.get_rank(group)
     if world != len(tiling.owned) or cp_rank != tiling.cp_rank:

--- a/attn_gym/linear/kda/context_parallel.py
+++ b/attn_gym/linear/kda/context_parallel.py
@@ -73,15 +73,26 @@ def context_parallel_kda_deterministic(
 
     See NOTE [Canonical Tiles] in ``attn_gym.linear.context_parallel_deterministic``. Autotuning
     is disabled because a tuned configuration is part of the arithmetic and would have to be
-    identical on every rank; ``fastmath`` and ``kernel_options`` follow ``chunk_kda``.
+    identical on every rank; ``fastmath`` and ``kernel_options`` follow ``chunk_kda``, except
+    that Mega's forgetting-horizon split (``split_forward``/``split_backward``) is rejected: the
+    canonical tiles already bound every leaf, and a split leaf would change the FP32 summaries.
     """
+    options = resolve_kernel_options(kernel_options)
+    if options.split_forward or options.split_backward:
+        raise ValueError(
+            "context_parallel_kda_deterministic does not support split_forward/split_backward: "
+            "canonical tiles fix every leaf, and a horizon split would change the summaries"
+        )
     stages = _kda_stages(scale, False, fastmath, kernel_options)
     return context_parallel_chunk_deterministic(
         stages, q, k, v, gate, beta, tiling=tiling, group=group, routing=routing
     )
 
 
-def _kda_stages(scale, autotune, fastmath, kernel_options) -> StagedOp:
+def _kda_stages(
+    scale: float | None, autotune: bool, fastmath: bool, kernel_options: KernelOptions | None
+) -> StagedOp:
+    """Bind ``chunk_kda``'s options to its staged entry points."""
     return StagedOp(
         partial(chunk_kda_prepare, scale=scale, autotune=autotune, kernel_options=kernel_options),
         partial(

--- a/attn_gym/linear/kda/impl/mega_ops.py
+++ b/attn_gym/linear/kda/impl/mega_ops.py
@@ -47,11 +47,18 @@ torch.library.define(
     "Tensor cu_seqlens, bool split, float scale) "
     "-> (Tensor, Tensor, Tensor, Tensor, Tensor)",
 )
+# Fixed-arity pair over one launcher: only the with-state backward returns the entry cotangent.
 torch.library.define(
     "attn_gym::kda_chunk_mega_packed_bwd_with_state",
     "(Tensor q, Tensor k, Tensor v, Tensor gate, Tensor beta, Tensor d_output, "
-    "Tensor cu_seqlens, Tensor? initial_state, Tensor? d_final_state, float scale) "
-    "-> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor?)",
+    "Tensor cu_seqlens, Tensor initial_state, Tensor? d_final_state, float scale) "
+    "-> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor)",
+)
+torch.library.define(
+    "attn_gym::kda_chunk_mega_packed_bwd_with_exit_cotangent",
+    "(Tensor q, Tensor k, Tensor v, Tensor gate, Tensor beta, Tensor d_output, "
+    "Tensor cu_seqlens, Tensor? d_final_state, float scale) "
+    "-> (Tensor, Tensor, Tensor, Tensor, Tensor)",
 )
 torch.library.define(
     "attn_gym::kda_plain_gate_bwd_dense_cute",
@@ -248,6 +255,14 @@ def _packed_bwd_with_state_cuda(
     )
 
 
+def _packed_bwd_with_exit_cotangent_cuda(
+    q, k, value, gate, beta, d_output, cu_seqlens, d_final_state, scale
+):
+    return _packed_bwd_with_state_cuda(
+        q, k, value, gate, beta, d_output, cu_seqlens, None, d_final_state, scale
+    )[:5]
+
+
 def _plain_gate_bwd_cuda(d_cumulative):
     from attn_gym.linear._delta_rule.mega.kernels.kda_plain_gate_bwd import (
         plain_gate_cumsum_dense_bwd_cute,
@@ -273,6 +288,11 @@ torch.library.impl("attn_gym::kda_chunk_mega_packed_fwd_paged", "CUDA", _packed_
 torch.library.impl("attn_gym::kda_chunk_mega_packed_local_bwd", "CUDA", _packed_local_bwd_cuda)
 torch.library.impl(
     "attn_gym::kda_chunk_mega_packed_bwd_with_state", "CUDA", _packed_bwd_with_state_cuda
+)
+torch.library.impl(
+    "attn_gym::kda_chunk_mega_packed_bwd_with_exit_cotangent",
+    "CUDA",
+    _packed_bwd_with_exit_cotangent_cuda,
 )
 torch.library.impl("attn_gym::kda_plain_gate_bwd_dense_cute", "CUDA", _plain_gate_bwd_cuda)
 
@@ -323,25 +343,32 @@ def _packed_fwd_paged_fake(
     return torch.empty_like(value)
 
 
+def _token_gradients_fake(q, k, value, gate, beta):
+    """One compact gradient per token operand, as the backward launchers allocate them."""
+    return tuple(torch.empty_like(tensor[0]).unsqueeze(0) for tensor in (q, k, value, gate, beta))
+
+
 @torch.library.register_fake("attn_gym::kda_chunk_mega_packed_local_bwd")
 def _packed_local_bwd_fake(q, k, value, gate, beta, d_output, cu_seqlens, split, scale):
-    del d_output, cu_seqlens, split, scale
-    return tuple(torch.empty_like(tensor[0]).unsqueeze(0) for tensor in (q, k, value, gate, beta))
+    return _token_gradients_fake(q, k, value, gate, beta)
 
 
 @torch.library.register_fake("attn_gym::kda_chunk_mega_packed_bwd_with_state")
 def _packed_bwd_with_state_fake(
     q, k, value, gate, beta, d_output, cu_seqlens, initial_state, d_final_state, scale
 ):
-    del d_output, cu_seqlens, d_final_state, scale
-    gradients = tuple(
-        torch.empty_like(tensor[0]).unsqueeze(0) for tensor in (q, k, value, gate, beta)
-    )
     # The launcher allocates a compact FP32 cotangent whatever the entry state's outer strides.
-    d_initial_state = (
-        None if initial_state is None else initial_state.new_empty(initial_state.shape)
+    return (
+        *_token_gradients_fake(q, k, value, gate, beta),
+        initial_state.new_empty(initial_state.shape),
     )
-    return (*gradients, d_initial_state)
+
+
+@torch.library.register_fake("attn_gym::kda_chunk_mega_packed_bwd_with_exit_cotangent")
+def _packed_bwd_with_exit_cotangent_fake(
+    q, k, value, gate, beta, d_output, cu_seqlens, d_final_state, scale
+):
+    return _token_gradients_fake(q, k, value, gate, beta)
 
 
 @torch.library.register_fake("attn_gym::kda_plain_gate_bwd_dense_cute")
@@ -363,11 +390,15 @@ chunk_mega_packed_local_bwd_op = torch.ops.attn_gym.kda_chunk_mega_packed_local_
 chunk_mega_packed_bwd_with_state_op = (
     torch.ops.attn_gym.kda_chunk_mega_packed_bwd_with_state.default
 )
+chunk_mega_packed_bwd_with_exit_cotangent_op = (
+    torch.ops.attn_gym.kda_chunk_mega_packed_bwd_with_exit_cotangent.default
+)
 plain_gate_bwd_dense_cute_op = torch.ops.attn_gym.kda_plain_gate_bwd_dense_cute.default
 
 
 __all__ = [
     "chunk_mega_dense_training_fwd_op",
+    "chunk_mega_packed_bwd_with_exit_cotangent_op",
     "chunk_mega_packed_bwd_with_state_op",
     "chunk_mega_packed_fwd_op",
     "chunk_mega_packed_fwd_paged_op",

--- a/attn_gym/linear/kda/stages.py
+++ b/attn_gym/linear/kda/stages.py
@@ -54,6 +54,7 @@ from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd import (
 from attn_gym.linear.kda.impl.fused import _validate_fused_constraints
 from attn_gym.linear.kda.impl.mega import validate_mega_constraints
 from attn_gym.linear.kda.impl.mega_ops import (
+    chunk_mega_packed_bwd_with_exit_cotangent_op,
     chunk_mega_packed_bwd_with_state_op,
     chunk_mega_packed_fwd_with_initial_state_op,
     chunk_mega_packed_fwd_with_state_op,
@@ -85,9 +86,9 @@ class ChunkKDASaved(NamedTuple):
 class ChunkKDAMegaSaved(NamedTuple):
     """Forward tensors a Mega ``chunk_kda_prepare`` stores for ``chunk_kda_prepare_backward``.
 
-    The type routes ``chunk_kda_prepare_backward`` to the native Mega backward, which reads the
-    raw ``gate`` and keeps its factors on chip; ``cumulative_gate`` feeds only the fused factor
-    pass behind the reverse summaries. Mega always runs packed, so the offsets are never ``None``.
+    Mega's backward reads the raw ``gate`` and keeps its factors on chip, so the tape carries the
+    gate instead of WY factors; ``cumulative_gate`` only feeds the fused factor pass behind
+    arbitrary-range summaries. Mega always runs packed, so the offsets are never ``None``.
     """
 
     q: torch.Tensor
@@ -129,11 +130,13 @@ def _normalize_state(state: torch.Tensor | None) -> torch.Tensor | None:
     return state if state.stride(-1) == 1 else state.contiguous()
 
 
-def _normalize_mega_state(state: torch.Tensor) -> torch.Tensor:
+def _normalize_mega_state(state: torch.Tensor | None) -> torch.Tensor | None:
     """FP32 state as Mega's launchers read it through TMA.
 
     Unit-stride keys and 16-byte-aligned outer strides suffice, so only other layouts are copied.
     """
+    if state is None:
+        return None
     state = state.float()
     return state if tensor_supports_tma(state) else state.contiguous()
 
@@ -202,12 +205,11 @@ class ChunkKDAPrepared:
 
 @dataclass
 class ChunkKDAMegaPrepared:
-    """Mega forward handle with native whole-sequence summaries for both CP recipes.
+    """Mega forward handle: ``run`` is Mega's with-state kernel, summaries pick their source.
 
-    ``whole_sequences=True`` or ``deterministic_work=True`` uses native BT16 state probes,
-    without materializing WY factors.
-    Arbitrary chunk-aligned ranges retain the fused summary path. The backward handle is
-    :class:`ChunkKDAMegaBackward`.
+    Whole-sequence ranges (``whole_sequences`` or ``deterministic_work``) are probed natively
+    without materializing WY factors; arbitrary chunk-aligned ranges fall back to the fused
+    factors of the whole local stream. The backward handle is :class:`ChunkKDAMegaBackward`.
     """
 
     saved: ChunkKDAMegaSaved
@@ -224,14 +226,13 @@ class ChunkKDAMegaPrepared:
         deterministic_work: bool = False,
         whole_sequences: bool = False,
     ) -> torch.Tensor:
-        """Return FP32 ``[B; A]`` maps, using native probes for canonical whole sequences.
+        """Return one FP32 ``[HV, V + K, K]`` map per row of ``bounds`` in a single launch.
 
-        With ``deterministic_work=True`` or ``whole_sequences=True``, bounds must be whole
-        ``saved.cu_seqlens`` pairs in any selection or order, plus empty rows; the values are a
-        caller contract (no device-to-host sync). Native BT16 rounding defines new standard and
-        canonical Mega-CP baselines, not unsharded Mega bit parity. Otherwise arbitrary
-        chunk-aligned bounds use the fused summary contract described by
-        ``ChunkKDAPrepared.state_summaries``.
+        With ``deterministic_work`` or ``whole_sequences`` every nonempty row must be a whole
+        ``saved.cu_seqlens`` pair (any selection or order; unchecked, since checking would sync)
+        and the maps come from Mega's native probes, whose rounding differs from an unsharded
+        Mega pass. Otherwise rows follow ``ChunkKDAPrepared.state_summaries`` and come from the
+        fused factors.
         """
         saved = self.saved
         if deterministic_work or whole_sequences:
@@ -253,12 +254,7 @@ class ChunkKDAMegaPrepared:
             schedule=self.schedule,
         )
         return build_state_summaries(
-            factors.kg,
-            factors.w,
-            factors.u,
-            saved.cumulative_gate,
-            bounds,
-            deterministic_work=deterministic_work,
+            factors.kg, factors.w, factors.u, saved.cumulative_gate, bounds
         )
 
     def run(
@@ -306,9 +302,9 @@ def chunk_kda_prepare(
     float16 or bfloat16 dtype (no silent cast, because the caller owns autograd), and the batch
     dimension must be one so token offsets index one packed span (NOTE [Terminology] in
     ``attn_gym.linear.context_parallel``).
-    ``kernel_options={"backend": "mega"}`` runs the local pass with Mega; canonical whole-sequence
-    summaries (``whole_sequences=True`` or ``deterministic_work=True``) also use Mega, while arbitrary-range summaries retain
-    fused factors. Split schedules are not available with entry states.
+    ``kernel_options={"backend": "mega"}`` runs the local pass with Mega; whole-sequence summaries
+    (``whole_sequences=True`` or ``deterministic_work=True``) also use Mega, while arbitrary-range
+    summaries use fused factors. Split schedules are not available with entry states.
     """
     backend, split_backward, split_forward, schedule = resolve_kernel_options(kernel_options)
     if split_backward or split_forward:
@@ -333,10 +329,9 @@ def chunk_kda_prepare(
     gate = gate.float()
     cumulative_gate = _plain_gate_scan_op(gate, cu_seqlens, chunk_offsets, False)
     if backend == "mega":
-        assert metadata is not None
+        assert metadata is not None and cu_seqlens is not None and chunk_offsets is not None
         gate = normalize_compact_tensor(gate)
-        validate_mega_constraints(q, k, v, gate, beta, None, metadata.cu_seqlens)
-        assert cu_seqlens is not None and chunk_offsets is not None
+        validate_mega_constraints(q, k, v, gate, beta, None, cu_seqlens)
         saved = ChunkKDAMegaSaved(q, k, v, gate, cumulative_gate, beta, cu_seqlens, chunk_offsets)
         return ChunkKDAMegaPrepared(saved, metadata, scale, autotune)
     factors = _prepare_chunk_kda_fwd(
@@ -427,18 +422,18 @@ class ChunkKDABackward:
 
 @dataclass
 class ChunkKDAMegaBackward:
-    """Native stateful backward, with native canonical or fused arbitrary-range summaries.
+    """Mega backward handle: ``run`` is Mega's stateful backward, summaries pick their source.
 
-    Canonical reverse maps use native zero-exit C and the forward transition A.T, explicitly
-    not the native identity-seeded adjoint rounding. This is a new canonical Mega-CP baseline.
-    Arbitrary-range and standard-CP reverse maps retain fused factors. Nothing is consumed, so
-    ``run`` and ``state_grad_summaries`` may be called in either order.
+    ``deterministic_work`` probes whole sequences natively: the bias is Mega's zero-exit
+    cotangent and the reverse transition is the forward transition transposed (not a natively
+    probed adjoint, whose rounding would differ). Other ranges, including the standard CP
+    recipe's, recompute the fused factors on demand. Nothing is consumed, so ``run`` and
+    ``state_grad_summaries`` may be called in either order.
     """
 
     saved: ChunkKDAMegaSaved
     d_output: torch.Tensor
     initial_state: torch.Tensor | None
-    metadata: RaggedChunkMetadata
     scale: float
     autotune: bool
     schedule: ScheduleRequest
@@ -448,9 +443,8 @@ class ChunkKDAMegaBackward:
     ) -> torch.Tensor:
         """Return one FP32 ``[HV, V + K, K]`` reverse map per row of ``bounds`` in one launch.
 
-        Same range contract as ``ChunkKDABackward.state_grad_summaries``. With
-        ``deterministic_work=True``, bounds must be whole cu_seqlens pairs (any selection or
-        order), and native C plus forward A.T replace the fused numerical baseline.
+        With ``deterministic_work`` every nonempty row must be a whole ``saved.cu_seqlens`` pair
+        (any selection or order); otherwise rows follow ``ChunkKDABackward.state_grad_summaries``.
         """
         saved = self.saved
         if deterministic_work:
@@ -470,7 +464,8 @@ class ChunkKDAMegaBackward:
                 transpose_forward_transition=True,
                 bounds=bounds,
             )
-        prepared = _prepare_chunk_kda_bwd(
+        # The fused backward over the equivalent tape (no materialized factors) owns the recompute.
+        fused_saved = ChunkKDASaved(
             saved.q,
             saved.k,
             saved.v,
@@ -478,27 +473,17 @@ class ChunkKDAMegaBackward:
             saved.beta,
             None,
             None,
+            saved.cu_seqlens,
+            saved.chunk_offsets,
+        )
+        return chunk_kda_prepare_backward(
+            fused_saved,
             self.d_output,
             self.initial_state,
-            self.metadata,
             scale=self.scale,
-            chunk_size=CHUNK_SIZE,
             autotune=self.autotune,
             schedule=self.schedule,
-        )
-        assert prepared.qg is not None and prepared.kg is not None
-        assert prepared.w is not None and prepared.aqk is not None
-        return build_state_grad_summaries(
-            prepared.qg,
-            prepared.kg,
-            prepared.w,
-            self.d_output,
-            prepared.aqk,
-            saved.cumulative_gate,
-            self.scale,
-            bounds,
-            deterministic_work=deterministic_work,
-        )
+        ).state_grad_summaries(bounds)
 
     def run(
         self, d_final_state: torch.Tensor | None = None
@@ -517,19 +502,15 @@ class ChunkKDAMegaBackward:
         and gives the token gradients of an explicit zero.
         """
         saved = self.saved
-        if d_final_state is not None:
-            d_final_state = _normalize_mega_state(d_final_state)
+        d_final_state = _normalize_mega_state(d_final_state)
+        operands = (saved.q, saved.k, saved.v, saved.gate, saved.beta, self.d_output)
+        if self.initial_state is None:
+            grads = chunk_mega_packed_bwd_with_exit_cotangent_op(
+                *operands, saved.cu_seqlens, d_final_state, self.scale
+            )
+            return (*grads, None)
         return chunk_mega_packed_bwd_with_state_op(
-            saved.q,
-            saved.k,
-            saved.v,
-            saved.gate,
-            saved.beta,
-            self.d_output,
-            saved.cu_seqlens,
-            self.initial_state,
-            d_final_state,
-            self.scale,
+            *operands, saved.cu_seqlens, self.initial_state, d_final_state, self.scale
         )
 
 
@@ -551,8 +532,8 @@ def chunk_kda_prepare_backward(
     caller's autograd function owns them. ``fastmath`` applies to the gradient kernels as in
     ``chunk_kda``; pass the forward handle's ``prepared.schedule`` so the backward's factor
     recompute uses the same launch geometry. A Mega tape (:class:`ChunkKDAMegaSaved`) returns
-    :class:`ChunkKDAMegaBackward`, whose native ``run`` ignores ``fastmath`` and defers the fused
-    factor recompute to ``state_grad_summaries``.
+    :class:`ChunkKDAMegaBackward`, whose native ``run`` ignores ``fastmath``; it recomputes fused
+    factors only if ``state_grad_summaries`` needs them.
     """
     if d_output is None:
         d_output = torch.zeros_like(saved.v)
@@ -560,13 +541,8 @@ def chunk_kda_prepare_backward(
         d_output = normalize_compact_tensor(d_output.to(saved.v.dtype))
     scale = float(scale)
     if isinstance(saved, ChunkKDAMegaSaved):
-        metadata = RaggedChunkMetadata.from_offsets(
-            saved.cu_seqlens, saved.chunk_offsets, saved.q.shape[1], CHUNK_SIZE
-        )
-        if initial_state is not None:
-            initial_state = _normalize_mega_state(initial_state)
         return ChunkKDAMegaBackward(
-            saved, d_output, initial_state, metadata, scale, autotune, schedule
+            saved, d_output, _normalize_mega_state(initial_state), scale, autotune, schedule
         )
     metadata = None
     if saved.cu_seqlens is not None:

--- a/test/kda/mega/test_kda_mega_stateful_bwd.py
+++ b/test/kda/mega/test_kda_mega_stateful_bwd.py
@@ -3,20 +3,33 @@
 from __future__ import annotations
 
 import math
+from collections.abc import Sequence
 
 import pytest
 import torch
 
+pytest.importorskip(
+    "cutlass.experimental",
+    reason="the CuTeDSL 4.7 KDA path requires nvidia-cutlass-dsl>=4.7",
+)
+
+from attn_gym.linear.kda.impl.mega_ops import (
+    chunk_mega_packed_bwd_with_exit_cotangent_op,
+    chunk_mega_packed_bwd_with_state_op,
+    chunk_mega_packed_fwd_with_state_op,
+    chunk_mega_packed_local_bwd_op,
+)
+from attn_gym.linear.kda.stages import (
+    ChunkKDAMegaBackward,
+    ChunkKDAMegaSaved,
+    chunk_kda_prepare,
+    chunk_kda_prepare_backward,
+)
 from attn_gym.testing.kda import (
     assert_matches_low_precision_reference,
     cumulative_sequence_offsets,
     kda_reference,
     make_kda_test_inputs,
-)
-
-pytest.importorskip(
-    "cutlass.experimental",
-    reason="the CuTeDSL 4.7 KDA path requires nvidia-cutlass-dsl>=4.7",
 )
 
 pytestmark = pytest.mark.skipif(
@@ -28,12 +41,7 @@ D = 128
 SCALE = D**-0.5
 OPCHECK_UTILITIES = ("test_schema", "test_faketensor", "test_aot_dispatch_dynamic")
 MILD_GATE = 0.05  # Decay per token in [e^-0.05, 1): the entry state still matters 4096 tokens in.
-
-
-def _ops():
-    from attn_gym.linear.kda.impl import mega_ops
-
-    return mega_ops
+GRADIENT_NAMES = ("dq", "dk", "dv", "dgate", "dbeta", "d_initial_state")
 
 
 def _make_inputs(
@@ -67,56 +75,55 @@ def _swap_state_head_value_storage(tensor: torch.Tensor) -> torch.Tensor:
     ).copy_(tensor)
 
 
+def _assert_gradients_equal(
+    actual: Sequence[torch.Tensor], expected: Sequence[torch.Tensor]
+) -> None:
+    """Bit-exact comparison of ``(dq, dk, dv, dgate, dbeta[, d_initial_state])`` tuples."""
+    names = GRADIENT_NAMES[: len(expected)]
+    for name, got, reference in zip(names, actual, expected, strict=True):
+        torch.testing.assert_close(got, reference, atol=0, rtol=0, msg=name)
+
+
 @pytest.mark.parametrize("outer_strided", [False, True], ids=["compact", "outer-strided"])
 def test_stateful_backward_op_registration(outer_strided: bool) -> None:
-    ops = _ops()
+    """Both fixed-arity ops register cleanly with and without an exit cotangent."""
     q, k, value, gate, beta, initial_state, d_output, d_final_state = _make_inputs(
         [65, 0, 63], heads=2, gate_scale=math.log(2.0), seed=97
     )
-    cu_seqlens = cumulative_sequence_offsets([65, 0, 63])
     if outer_strided:
         initial_state = _swap_state_head_value_storage(initial_state)
         d_final_state = _swap_state_head_value_storage(d_final_state)
         assert not initial_state.is_contiguous()
-    operands = (q, k, value, gate, beta, d_output, cu_seqlens)
-
-    grads = ops.chunk_mega_packed_bwd_with_state_op(*operands, initial_state, d_final_state, SCALE)
-    assert len(grads) == 6
-    assert grads[5].shape == initial_state.shape and grads[5].is_contiguous()
-    assert grads[5].dtype == torch.float32
-    torch.library.opcheck(
-        ops.chunk_mega_packed_bwd_with_state_op,
-        (*operands, initial_state, d_final_state, SCALE),
-        test_utils=OPCHECK_UTILITIES,
-    )
-    torch.library.opcheck(
-        ops.chunk_mega_packed_bwd_with_state_op,
-        (*operands, None, None, SCALE),
-        test_utils=OPCHECK_UTILITIES,
-    )
-    torch.library.opcheck(
-        ops.chunk_mega_packed_bwd_with_state_op,
-        (*operands, initial_state, None, SCALE),
-        test_utils=OPCHECK_UTILITIES,
-    )
+    operands = (q, k, value, gate, beta, d_output, cumulative_sequence_offsets([65, 0, 63]))
+    for exit_cotangent in (d_final_state, None):
+        with_state = (*operands, initial_state, exit_cotangent, SCALE)
+        grads = chunk_mega_packed_bwd_with_state_op(*with_state)
+        assert len(grads) == 6
+        assert grads[5].shape == initial_state.shape and grads[5].is_contiguous()
+        assert grads[5].dtype == torch.float32
+        torch.library.opcheck(
+            chunk_mega_packed_bwd_with_state_op, with_state, test_utils=OPCHECK_UTILITIES
+        )
+        # Without an entry state the fixed-arity sibling returns the five token gradients.
+        without_state = (*operands, exit_cotangent, SCALE)
+        assert len(chunk_mega_packed_bwd_with_exit_cotangent_op(*without_state)) == 5
+        torch.library.opcheck(
+            chunk_mega_packed_bwd_with_exit_cotangent_op,
+            without_state,
+            test_utils=OPCHECK_UTILITIES,
+        )
 
 
 def test_stateful_backward_without_state_is_the_local_backward() -> None:
     """``None`` keeps the no-state kernel specializations, so the two ops agree bit for bit."""
-    ops = _ops()
     q, k, value, gate, beta, _, d_output, _ = _make_inputs(
         [65, 0, 63], heads=2, gate_scale=math.log(2.0), seed=11
     )
-    cu_seqlens = cumulative_sequence_offsets([65, 0, 63])
-    *grads, d_initial_state = ops.chunk_mega_packed_bwd_with_state_op(
-        q, k, value, gate, beta, d_output, cu_seqlens, None, None, SCALE
+    operands = (q, k, value, gate, beta, d_output, cumulative_sequence_offsets([65, 0, 63]))
+    _assert_gradients_equal(
+        chunk_mega_packed_bwd_with_exit_cotangent_op(*operands, None, SCALE),
+        chunk_mega_packed_local_bwd_op(*operands, False, SCALE),
     )
-    assert d_initial_state is None
-    expected = ops.chunk_mega_packed_local_bwd_op(
-        q, k, value, gate, beta, d_output, cu_seqlens, False, SCALE
-    )
-    for actual, reference in zip(grads, expected, strict=True):
-        torch.testing.assert_close(actual, reference, atol=0, rtol=0)
 
 
 def _slice(tensors: tuple[torch.Tensor, ...], start: int, stop: int) -> tuple[torch.Tensor, ...]:
@@ -150,83 +157,57 @@ def test_two_aligned_fragments_with_state_handoff_match_one_native_call(
     Rank 0 owns ``[0, cut)`` and rank 1 ``[cut, T)``; the cut document's exit state travels
     forward and its entry cotangent travels backward, as the context-parallel recipe does.
     """
-    ops = _ops()
     q, k, value, gate, beta, initial_state, d_output, d_final_state = _make_inputs(
         lengths, heads=heads, gate_scale=gate_scale, seed=3
     )
-    cu_seqlens = [0, *torch.tensor(lengths).cumsum(0).tolist()]
-    tokens = cu_seqlens[-1]
     offsets = cumulative_sequence_offsets(lengths)
+    cu_seqlens = offsets.tolist()
     first, second, document = _fragments(cu_seqlens, cut)
     first_offsets = torch.tensor(first, dtype=torch.int32, device="cuda")
     second_offsets = torch.tensor(second, dtype=torch.int32, device="cuda")
 
-    operands = (q, k, value, gate, beta)
-    output, final_state = ops.chunk_mega_packed_fwd_with_state_op(
-        *operands, initial_state, offsets, SCALE
+    operands = (q, k, value, gate, beta, d_output)
+    output, final_state = chunk_mega_packed_fwd_with_state_op(
+        *operands[:5], initial_state, offsets, SCALE
     )
-    expected = ops.chunk_mega_packed_bwd_with_state_op(
-        *operands, d_output, offsets, initial_state, d_final_state, SCALE
+    expected = chunk_mega_packed_bwd_with_state_op(
+        *operands, offsets, initial_state, d_final_state, SCALE
     )
 
-    head, tail = _slice(operands, 0, cut), _slice(operands, cut, tokens)
-    head_output, head_states = ops.chunk_mega_packed_fwd_with_state_op(
-        *head, initial_state[: document + 1], first_offsets, SCALE
+    head, tail = _slice(operands, 0, cut), _slice(operands, cut, cu_seqlens[-1])
+    head_output, head_states = chunk_mega_packed_fwd_with_state_op(
+        *head[:5], initial_state[: document + 1], first_offsets, SCALE
     )
     tail_entry = torch.cat((head_states[document:], initial_state[document + 1 :]))
-    tail_output, tail_states = ops.chunk_mega_packed_fwd_with_state_op(
-        *tail, tail_entry, second_offsets, SCALE
+    tail_output, tail_states = chunk_mega_packed_fwd_with_state_op(
+        *tail[:5], tail_entry, second_offsets, SCALE
     )
     torch.testing.assert_close(torch.cat((head_output, tail_output), 1), output, atol=0, rtol=0)
     torch.testing.assert_close(head_states[:document], final_state[:document], atol=0, rtol=0)
     torch.testing.assert_close(tail_states, final_state[document:], atol=0, rtol=0)
 
-    tail_grads = ops.chunk_mega_packed_bwd_with_state_op(
-        *tail,
-        d_output[:, cut:].contiguous(),
-        second_offsets,
-        tail_entry,
-        d_final_state[document:],
-        SCALE,
+    tail_grads = chunk_mega_packed_bwd_with_state_op(
+        *tail, second_offsets, tail_entry, d_final_state[document:], SCALE
     )
     head_exit = torch.cat((d_final_state[:document], tail_grads[5][:1]))
-    head_grads = ops.chunk_mega_packed_bwd_with_state_op(
-        *head,
-        d_output[:, :cut].contiguous(),
-        first_offsets,
-        initial_state[: document + 1],
-        head_exit,
-        SCALE,
+    head_grads = chunk_mega_packed_bwd_with_state_op(
+        *head, first_offsets, initial_state[: document + 1], head_exit, SCALE
     )
-    for name, head_grad, tail_grad, reference in zip(
-        ("dq", "dk", "dv", "dgate", "dbeta"),
-        head_grads[:5],
-        tail_grads[:5],
-        expected[:5],
-        strict=True,
-    ):
-        torch.testing.assert_close(
-            torch.cat((head_grad, tail_grad), 1), reference, atol=0, rtol=0, msg=name
-        )
-    d_initial_state = torch.cat((head_grads[5], tail_grads[5][1:]))
-    torch.testing.assert_close(d_initial_state, expected[5], atol=0, rtol=0)
+    joined = [
+        *(torch.cat(pair, 1) for pair in zip(head_grads[:5], tail_grads[:5], strict=True)),
+        torch.cat((head_grads[5], tail_grads[5][1:])),
+    ]
+    _assert_gradients_equal(joined, expected)
 
 
 def test_staged_mega_backward_is_the_native_op() -> None:
     """``chunk_kda_prepare_backward`` on a Mega tape runs the stateful op, not the fused recompute."""
-    from attn_gym.linear.kda.stages import (
-        ChunkKDAMegaBackward,
-        ChunkKDAMegaSaved,
-        chunk_kda_prepare,
-        chunk_kda_prepare_backward,
-    )
-
-    ops = _ops()
     lengths = [100, 156]
     q, k, value, gate, beta, initial_state, d_output, d_final_state = _make_inputs(
         lengths, heads=2, gate_scale=MILD_GATE, seed=5
     )
     offsets = cumulative_sequence_offsets(lengths)
+    operands = (q, k, value, gate, beta, d_output, offsets)
     prepared = chunk_kda_prepare(
         q, k, value, gate, beta, cu_seqlens=offsets, kernel_options={"backend": "mega"}
     )
@@ -236,13 +217,12 @@ def test_staged_mega_backward_is_the_native_op() -> None:
         prepared.saved, d_output, initial_state, scale=prepared.scale
     )
     assert isinstance(grads, ChunkKDAMegaBackward)
-    expected = ops.chunk_mega_packed_bwd_with_state_op(
-        q, k, value, gate, beta, d_output, offsets, initial_state, d_final_state, SCALE
+    _assert_gradients_equal(
+        grads.run(d_final_state),
+        chunk_mega_packed_bwd_with_state_op(*operands, initial_state, d_final_state, SCALE),
     )
-    for actual, reference in zip(grads.run(d_final_state), expected, strict=True):
-        torch.testing.assert_close(actual, reference, atol=0, rtol=0)
 
-    # The reverse summaries still come from the fused factors, so they match the fused handle.
+    # Arbitrary-range reverse summaries still come from the fused factors.
     fused = chunk_kda_prepare(q, k, value, gate, beta, cu_seqlens=offsets)
     fused_grads = chunk_kda_prepare_backward(
         fused.saved, d_output, initial_state, scale=fused.scale
@@ -258,41 +238,42 @@ def test_staged_mega_backward_is_the_native_op() -> None:
     no_state = chunk_kda_prepare_backward(prepared.saved, d_output, None, scale=prepared.scale)
     *no_state_grads, d_initial_state = no_state.run(None)
     assert d_initial_state is None
-    local = ops.chunk_mega_packed_local_bwd_op(
-        q, k, value, gate, beta, d_output, offsets, False, SCALE
+    _assert_gradients_equal(
+        no_state_grads, chunk_mega_packed_local_bwd_op(*operands, False, SCALE)
     )
-    for actual, reference in zip(no_state_grads, local, strict=True):
-        torch.testing.assert_close(actual, reference, atol=0, rtol=0)
 
 
 def test_stateful_backward_matches_fp64_reference_including_d_initial_state() -> None:
     """All six gradients, including the entry-state cotangent, sit within the reference budget."""
-    ops = _ops()
     lengths = [100, 156]
     q, k, value, gate, beta, initial_state, d_output, d_final_state = _make_inputs(
         lengths, heads=1, gate_scale=MILD_GATE, seed=7
     )
     offsets = cumulative_sequence_offsets(lengths)
-    actual = ops.chunk_mega_packed_bwd_with_state_op(
+    actual = chunk_mega_packed_bwd_with_state_op(
         q, k, value, gate, beta, d_output, offsets, initial_state, d_final_state, SCALE
     )
-
-    def reference(dtype: torch.dtype) -> tuple[torch.Tensor, ...]:
+    references = []
+    for precision in (torch.float64, torch.float32):
         leaves = tuple(
-            tensor.detach().to(dtype).requires_grad_()
+            tensor.detach().to(precision).requires_grad_()
             for tensor in (q, k, value, gate, beta, initial_state)
         )
         output, final_state = kda_reference(
             *leaves, cu_seqlens=offsets, scale=SCALE, output_final_state=True
         )
         assert final_state is not None
-        return torch.autograd.grad(
-            (output, final_state), leaves, (d_output.to(dtype), d_final_state.to(dtype))
+        references.append(
+            torch.autograd.grad(
+                (output, final_state),
+                leaves,
+                (d_output.to(precision), d_final_state.to(precision)),
+            )
         )
-
-    high, low = reference(torch.float64), reference(torch.float32)
-    names = ("dq", "dk", "dv", "dgate", "dbeta", "d_initial_state")
-    for name, actual_grad, high_grad, low_grad in zip(names, actual, high, low, strict=True):
+    high, low = references
+    for name, actual_grad, high_grad, low_grad in zip(
+        GRADIENT_NAMES, actual, high, low, strict=True
+    ):
         assert_matches_low_precision_reference(actual_grad, high_grad, low_grad, name)
     # The entry state must actually reach the gradient: a dead state makes the check vacuous.
     assert high[5].abs().max() > 1e-3

--- a/test/test_context_parallel_deterministic.py
+++ b/test/test_context_parallel_deterministic.py
@@ -12,6 +12,8 @@ import math
 import os
 import socket
 import time
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
 from itertools import accumulate, pairwise
 from unittest.mock import patch
 
@@ -24,12 +26,14 @@ pytest.importorskip("cutlass")
 
 import attn_gym.linear.context_parallel_deterministic as det
 from attn_gym.linear._delta_rule.triton.canonical_scan import canonical_scan_entries
+from attn_gym.linear.context_parallel import compose_summaries
 from attn_gym.linear.context_parallel_deterministic import (
     CanonicalTiling,
     canonical_entries,
     tile_stream,
 )
 from attn_gym.linear.kda.context_parallel import _kda_stages, context_parallel_kda_deterministic
+from attn_gym.linear.types import KernelOptions
 from attn_gym.testing.kda import kda_reference, make_kda_test_inputs
 
 pytestmark = [
@@ -37,7 +41,7 @@ pytestmark = [
     pytest.mark.xdist_group("two-gpu"),
 ]
 
-HEADS, DIM = 4, 128
+HEADS = 4
 RAGGED = (17, 65, 129, 257, 513)
 ELEPHANT = (800, 31, 33, 31, 33, 31, 33)
 NAMES = ("output", "dq", "dk", "dv", "dgate", "dbeta")
@@ -97,25 +101,25 @@ def test_non_contiguous_ownership_keeps_span_order_consistent():
     assert [tiling.tiles[i].length for i in tiling.mine] == [b - a for a, b in pairwise(offsets)]
 
 
-def _serial_entries(leaves: torch.Tensor, documents: list[int]) -> torch.Tensor:
-    """Exclusive prefix bias per tile by serial composition, restarting at each document."""
-    from attn_gym.linear.context_parallel import compose_summaries
-
+def _serial_entries(
+    leaves: torch.Tensor, offsets: Sequence[int], *, reverse: bool
+) -> torch.Tensor:
+    """Exclusive serial prefix bias, restarting at each document in either direction."""
     value_dim = leaves.shape[2] - leaves.shape[3]
     entries = torch.zeros(
         leaves.shape[0], leaves.shape[1], value_dim, leaves.shape[3], device=leaves.device
     )
-    prefix = None
-    for i, doc in enumerate(documents):
-        if i == 0 or doc != documents[i - 1]:
-            prefix = leaves[i]
-        else:
+    for start, stop in pairwise(offsets):
+        indices = range(stop - 1, start - 1, -1) if reverse else range(start, stop)
+        prefix = leaves[indices[0]]
+        for i in indices[1:]:
             entries[i] = prefix[:, :value_dim, :]
             prefix = compose_summaries(prefix, leaves[i])
     return entries
 
 
 def _leaves(n: int, seed: int) -> torch.Tensor:
+    """Random affine maps with near-identity transitions to keep long prefixes nontrivial."""
     torch.manual_seed(seed)
     leaves = torch.randn(n, 2, 256, 128, device="cuda")
     leaves[:, :, 128:, :] = torch.eye(128, device="cuda") + 0.01 * torch.randn(
@@ -124,54 +128,42 @@ def _leaves(n: int, seed: int) -> torch.Tensor:
     return leaves
 
 
-def _doc_offsets(documents: list[int]) -> torch.Tensor:
-    offsets = [0] + [i for i in range(1, len(documents)) if documents[i] != documents[i - 1]]
-    return torch.tensor([*offsets, len(documents)], dtype=torch.int32, device="cuda")
-
-
-def _single_rank_tiling(documents: list[int], scan_block: int) -> CanonicalTiling:
-    """One rank owning every tile of documents with the given tile counts (64-token tiles)."""
-    lengths = []
-    for doc in dict.fromkeys(documents):
-        lengths.append(64 * documents.count(doc))
+def _single_rank_tiling(
+    lengths: Sequence[int], tile_size: int = 64, scan_block: int = 1
+) -> CanonicalTiling:
+    """Tile packed document lengths with every token owned by one rank."""
     cu = (0, *accumulate(lengths))
     return CanonicalTiling.from_fragments(
-        cu, [[(0, cu[-1])]], 0, tile_size=64, scan_block=scan_block
+        cu, [[(0, cu[-1])]], 0, tile_size=tile_size, scan_block=scan_block
     )
 
 
-@pytest.mark.parametrize("documents", [[0] * 9, [0, 0, 0, 1, 2, 2, 2], [0, 1, 2, 3], [0] * 1])
-def test_fused_scan_matches_serial_composition_per_document(documents):
+@pytest.mark.parametrize("tile_counts", [(9,), (3, 1, 3), (1, 1, 1, 1), (1,)])
+def test_fused_scan_matches_serial_composition_per_document(tile_counts):
     """The fused scan restarts at documents and equals serial composition to fp32 accuracy."""
-    leaves = _leaves(len(documents), 0)
-    offsets = _doc_offsets(documents)
-    torch.testing.assert_close(
-        canonical_scan_entries(leaves, offsets),
-        _serial_entries(leaves, documents),
-        atol=1e-4,
-        rtol=1e-5,
-    )
-    expected = _serial_entries(leaves.flip(0), documents[::-1]).flip(0)
-    torch.testing.assert_close(
-        canonical_scan_entries(leaves, offsets, reverse=True), expected, atol=1e-4, rtol=1e-5
-    )
+    leaves = _leaves(sum(tile_counts), 0)
+    offsets = [0, *accumulate(tile_counts)]
+    device_offsets = torch.tensor(offsets, dtype=torch.int32, device="cuda")
+    for reverse in (False, True):
+        torch.testing.assert_close(
+            canonical_scan_entries(leaves, device_offsets, reverse=reverse),
+            _serial_entries(leaves, offsets, reverse=reverse),
+            atol=1e-4,
+            rtol=1e-5,
+        )
 
 
 @pytest.mark.parametrize("scan_block", [1, 2, 4])
 def test_blocked_entries_match_serial_composition(scan_block):
     """The three-level block tree equals serial composition to fp32 accuracy, both directions."""
-    documents = [0] * 7 + [1] * 3 + [2] * 5
-    leaves = _leaves(len(documents), 5)
-    tiling = _single_rank_tiling(documents, scan_block)
-    like = leaves[:1]
+    tile_counts = (7, 3, 5)
+    leaves = _leaves(sum(tile_counts), 5)
+    tiling = _single_rank_tiling([64 * count for count in tile_counts], scan_block=scan_block)
     for reverse in (False, True):
         got = canonical_entries(
-            leaves, tiling, tiling.routing("cuda"), like, None, reverse=reverse
+            leaves, tiling, tiling.routing("cuda"), leaves[:1], None, reverse=reverse
         )
-        if reverse:
-            expected = _serial_entries(leaves.flip(0), documents[::-1]).flip(0)
-        else:
-            expected = _serial_entries(leaves, documents)
+        expected = _serial_entries(leaves, [0, *accumulate(tile_counts)], reverse=reverse)
         torch.testing.assert_close(got, expected, atol=1e-4, rtol=1e-5)
 
 
@@ -183,8 +175,9 @@ def test_entries_of_a_document_are_independent_of_its_neighbours(scan_block):
     for before, after in ((0, 0), (1, 0), (3, 2), (7, 5)):
         others = _leaves(before + after, 2 + before)
         leaves = torch.cat((others[:before], document, others[before:]))
-        documents = [0] * before + [1] * 5 + [2] * after
-        tiling = _single_rank_tiling(documents, scan_block)
+        tiling = _single_rank_tiling(
+            [64 * count for count in (before, 5, after) if count], scan_block=scan_block
+        )
         summarized = torch.tensor(tiling.summarized, device="cuda")
         for reverse in (False, True):
             entries = canonical_entries(
@@ -203,24 +196,19 @@ def test_entries_of_a_document_are_independent_of_its_neighbours(scan_block):
 # ---------------------------------------------------------------- transports
 
 
-def _free_port() -> int:
-    with socket.socket() as sock:
-        sock.bind(("127.0.0.1", 0))
-        return sock.getsockname()[1]
-
-
-_REAL_ALL_GATHER = dist.all_gather_into_tensor
-
-
-def _cpu_all_gather_into_tensor(gathered, packet, group=None):
+def _cpu_all_gather_into_tensor(
+    gathered: torch.Tensor, packet: torch.Tensor, group: dist.ProcessGroup | None = None
+) -> None:
     """Gloo path: gather CPU copies, then place them into the CUDA output buffer."""
     staging = torch.empty(gathered.shape, dtype=gathered.dtype)
-    _REAL_ALL_GATHER(staging, packet.cpu(), group=group)
+    dist.all_gather_into_tensor(staging, packet.cpu(), group=group)
     gathered.copy_(staging)
 
 
-def _init(cp_rank: int, world: int, port: int) -> torch.device:
-    shared = torch.cuda.device_count() == 1
+@contextmanager
+def _process_group(cp_rank: int, world: int, port: int) -> Iterator[torch.device]:
+    """NCCL on one GPU per rank, or Gloo with the module's collective staged through the CPU."""
+    shared = torch.cuda.device_count() < world
     device = torch.device("cuda", 0 if shared else cp_rank)
     torch.cuda.set_device(device)
     os.environ.update(MASTER_ADDR="127.0.0.1", MASTER_PORT=str(port))
@@ -230,16 +218,23 @@ def _init(cp_rank: int, world: int, port: int) -> torch.device:
         world_size=world,
         device_id=None if shared else device,
     )
-    if shared:
-        patcher = patch.object(det.dist, "all_gather_into_tensor", _cpu_all_gather_into_tensor)
-        patcher.start()
-    return device
+    try:
+        if shared:
+            with patch.object(det, "_all_gather_into_tensor", _cpu_all_gather_into_tensor):
+                yield device
+        else:
+            yield device
+    finally:
+        dist.destroy_process_group()
 
 
 # ---------------------------------------------------------------- canonical CP1 reference
 
 
-def _inputs(lengths, gate: str, seed: int, device):
+def _inputs(
+    lengths: Sequence[int], gate: str, seed: int
+) -> tuple[tuple[torch.Tensor, ...], torch.Tensor]:
+    """Seeded KDA inputs and output cotangent on the current rank device."""
     torch.manual_seed(seed)
     values = make_kda_test_inputs(
         sum(lengths),
@@ -251,27 +246,25 @@ def _inputs(lengths, gate: str, seed: int, device):
         log_uniform_gate=gate == "strong",
         gate_value=0.0 if gate == "zero" else None,
     )
-    values = tuple(v.to(device) for v in values)
     return values, torch.randn_like(values[2])
 
 
 @torch.no_grad()
-def _canonical_cp1(inputs, grad, lengths, tile_size: int, scan_block: int, kernel_options):
-    """Single-process canonical run over the same tiles: the contract every ownership reproduces.
-
-    Every tile is prepared by its own staged call (the strictest form of the leaf contract); the
-    batched production path must match this bitwise. The scan tree is the production one.
-    """
-    cu = (0, *accumulate(lengths))
-    tiles = tile_stream(cu, tile_size)
-    tiling = CanonicalTiling.from_fragments(
-        cu, [[(0, cu[-1])]], 0, tile_size=tile_size, scan_block=scan_block
-    )
+def _canonical_cp1(
+    inputs: tuple[torch.Tensor, ...],
+    grad: torch.Tensor,
+    lengths: Sequence[int],
+    tile_size: int,
+    scan_block: int,
+    kernel_options: KernelOptions | None,
+) -> tuple[torch.Tensor, ...]:
+    """Independent per-tile staged calls with the production scan: the bitwise CP contract."""
+    tiling = _single_rank_tiling(lengths, tile_size, scan_block)
+    tiles = tiling.tiles
     stages = _kda_stages(None, False, False, kernel_options)
     device = inputs[0].device
 
-    def bounds(t):
-        return torch.tensor([[0, t.length]], dtype=torch.int32, device=device)
+    bounds = [torch.tensor([[0, t.length]], dtype=torch.int32, device=device) for t in tiles]
 
     prepared = [
         stages.prepare(*(v[:, t.start : t.stop] for v in inputs), cu_seqlens=None) for t in tiles
@@ -279,10 +272,7 @@ def _canonical_cp1(inputs, grad, lengths, tile_size: int, scan_block: int, kerne
     # Single-tile documents are not summarized (NOTE [Single-Tile Documents]).
     summarized = tiling.summarized
     maps = torch.cat(
-        [
-            prepared[i].state_summaries(bounds(tiles[i]), deterministic_work=True)
-            for i in summarized
-        ]
+        [prepared[i].state_summaries(bounds[i], deterministic_work=True) for i in summarized]
     )
     routing = tiling.routing(device)
     entries = canonical_entries(maps, tiling, routing, maps[:1], None, reverse=False)
@@ -295,10 +285,7 @@ def _canonical_cp1(inputs, grad, lengths, tile_size: int, scan_block: int, kerne
             )
         )
     rmaps = torch.cat(
-        [
-            backwards[i].state_grad_summaries(bounds(tiles[i]), deterministic_work=True)
-            for i in summarized
-        ]
+        [backwards[i].state_grad_summaries(bounds[i], deterministic_work=True) for i in summarized]
     )
     exits = canonical_entries(rmaps, tiling, routing, maps[:1], None, reverse=True)
     grads = [b.run(exits[i : i + 1])[:5] for i, b in enumerate(backwards)]
@@ -308,7 +295,8 @@ def _canonical_cp1(inputs, grad, lengths, tile_size: int, scan_block: int, kerne
     )
 
 
-def _bits_equal(actual: torch.Tensor, expected: torch.Tensor) -> int:
+def _bit_mismatches(actual: torch.Tensor, expected: torch.Tensor) -> int:
+    """Count unequal storage elements, including signed zeros; reject non-finite values."""
     assert actual.shape == expected.shape and actual.dtype == expected.dtype
     assert torch.isfinite(actual).all() and torch.isfinite(expected).all()
     view = torch.int16 if actual.dtype == torch.bfloat16 else torch.int32
@@ -317,42 +305,34 @@ def _bits_equal(actual: torch.Tensor, expected: torch.Tensor) -> int:
 
 # ---------------------------------------------------------------- two-rank cases
 
-OWNERSHIPS = {
-    "contiguous": lambda cu, n: [[(0, cu[len(cu) // 2])], [(cu[len(cu) // 2], cu[-1])]],
-    "empty_rank": lambda cu, n: [[], [(0, cu[-1])]],
-}
 
-
-def _rank_main(cp_rank, world, port, lengths, tile_size, scan_block, ownership, gate, backend):
-    device = _init(cp_rank, world, port)
-    try:
+def _rank_main(
+    cp_rank: int,
+    world: int,
+    port: int,
+    lengths: Sequence[int],
+    tile_size: int,
+    scan_block: int,
+    ownership: str,
+    gate: str,
+    backend: str,
+) -> None:
+    """Compare each rank's output and five gradients to independent per-tile CP=1 calls."""
+    with _process_group(cp_rank, world, port) as device:
         kernel_options = {"backend": backend} if backend != "fused" else None
-        inputs, grad = _inputs(lengths, gate, 97, device)
+        inputs, grad = _inputs(lengths, gate, 97)
         cu = (0, *accumulate(lengths))
         expected = _canonical_cp1(inputs, grad, lengths, tile_size, scan_block, kernel_options)
         if ownership == "cyclic":
-            # Alternate whole blocks between the ranks (tiles when scan_block == 1); tiles of
-            # single-tile documents form no block and alternate on their own.
-            tiling = CanonicalTiling.from_fragments(
-                cu, [[(0, cu[-1])]], 0, tile_size=tile_size, scan_block=scan_block
-            )
-            units = sorted(
-                [
-                    *tiling.blocks,
-                    *((i,) for i in range(len(tiling.tiles)) if i not in tiling.summarized),
-                ]
-            )
-            tiles = tiling.tiles
-            fragments = [
-                [
-                    (tiles[unit[0]].start, tiles[unit[-1]].stop)
-                    for u, unit in enumerate(units)
-                    if u % 2 == r
-                ]
-                for r in range(2)
-            ]
+            # Whole document-relative scan blocks alternate, including single-tile documents.
+            units = tile_stream(cu, tile_size * scan_block)
+            fragments = [[(t.start, t.stop) for t in units[r::world]] for r in range(world)]
         else:
-            fragments = OWNERSHIPS[ownership](cu, len(lengths))
+            fragments = {
+                "contiguous": [[(0, cu[len(cu) // 2])], [(cu[len(cu) // 2], cu[-1])]],
+                "empty_rank": [[], [(0, cu[-1])]],
+                "single": [[(0, cu[-1])]],
+            }[ownership]
         tiling = CanonicalTiling.from_fragments(
             cu, fragments, cp_rank, tile_size=tile_size, scan_block=scan_block
         )
@@ -364,59 +344,74 @@ def _rank_main(cp_rank, world, port, lengths, tile_size, scan_block, ownership, 
         # Every rank runs the backward: its all-gather is a collective even for an empty rank.
         grads = torch.autograd.grad(output, local, grad[:, ids])
         mismatches = {
-            name: _bits_equal(a, e[:, ids])
+            name: _bit_mismatches(a, e[:, ids])
             for name, a, e in zip(NAMES, (output, *grads), expected, strict=True)
         }
         assert all(v == 0 for v in mismatches.values()), mismatches
-    finally:
-        dist.destroy_process_group()
 
 
-@pytest.mark.parametrize("backend", ["fused", "mega"])
+@pytest.fixture(params=["fused", "mega"])
+def backend(request: pytest.FixtureRequest) -> str:
+    """Skip Mega before spawning when its DSL or GPU architecture is unavailable."""
+    if request.param == "mega":
+        pytest.importorskip("cutlass.experimental")
+        if torch.cuda.get_device_capability() not in ((10, 0), (10, 3)):
+            pytest.skip("Mega needs SM100/103")
+    return request.param
+
+
 @pytest.mark.parametrize("gate", ["strong", "mild", "zero"])
 @pytest.mark.parametrize(
     "lengths,tile_size,scan_block,ownership",
     [
-        (RAGGED, 64, 1, "contiguous"),
-        (RAGGED, 64, 1, "cyclic"),
-        (RAGGED, 128, 1, "empty_rank"),
-        (ELEPHANT, 64, 1, "cyclic"),
-        (RAGGED, 64, 4, "cyclic"),
-        (ELEPHANT, 64, 4, "contiguous"),
-    ],
-    ids=[
-        "ragged-contig",
-        "ragged-cyclic",
-        "ragged-empty",
-        "elephant-cyclic",
-        "ragged-cyclic-block4",
-        "elephant-contig-block4",
+        pytest.param(RAGGED, 64, 1, "contiguous", id="ragged-contig"),
+        pytest.param(RAGGED, 64, 1, "cyclic", id="ragged-cyclic"),
+        pytest.param(RAGGED, 128, 1, "empty_rank", id="ragged-empty"),
+        pytest.param(ELEPHANT, 64, 1, "cyclic", id="elephant-cyclic"),
+        pytest.param(RAGGED, 64, 4, "cyclic", id="ragged-cyclic-block4"),
+        pytest.param(ELEPHANT, 64, 4, "contiguous", id="elephant-contig-block4"),
     ],
 )
 def test_two_ranks_match_canonical_cp1_bitwise(
     lengths, tile_size, scan_block, ownership, gate, backend
 ):
-    if backend == "mega":
-        pytest.importorskip("cutlass.experimental")
-        if torch.cuda.get_device_capability() not in ((10, 0), (10, 3)):
-            pytest.skip("Mega needs SM100/103")
-    # A rank that raises leaves its peer blocked in a collective; poll the context so the
-    # failure surfaces instead of the case hanging until the outer timeout.
-    context = mp.spawn(
-        _rank_main,
-        args=(2, _free_port(), lengths, tile_size, scan_block, ownership, gate, backend),
-        nprocs=2,
-        join=False,
-    )
+    _spawn(2, (lengths, tile_size, scan_block, ownership, gate, backend))
+
+
+def _spawn(nprocs: int, args: tuple) -> None:
+    """Surface failed ranks promptly and bound each case to 300 seconds, including compilation."""
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+    context = mp.spawn(_rank_main, args=(nprocs, port, *args), nprocs=nprocs, join=False)
     deadline = time.monotonic() + 300
     try:
-        # join(timeout) returns after each process exits (raising if it failed); loop until all did.
+        # join() reports failed ranks immediately, but may reap only one successful rank at a time.
         while not context.join(timeout=max(0.0, deadline - time.monotonic())):
-            assert time.monotonic() < deadline, "two-rank case did not finish within 300 s"
+            assert time.monotonic() < deadline, "spawned case did not finish within 300 s"
     finally:
         for process in context.processes:
             if process.is_alive():
                 process.kill()
+
+
+@pytest.mark.parametrize("option", ["split_forward", "split_backward"])
+def test_split_schedules_are_rejected_before_any_collective(option):
+    """Reject Mega splits before collecting: they would change the canonical FP32 summaries."""
+    tiling = _single_rank_tiling(RAGGED)
+    inputs, _ = _inputs(RAGGED, "mild", 3)
+    with pytest.raises(ValueError, match="split_forward/split_backward"):
+        context_parallel_kda_deterministic(
+            *inputs,
+            tiling=tiling,
+            group=None,
+            kernel_options={"backend": "mega", option: True},
+        )
+
+
+def test_single_rank_public_api_matches_canonical_cp1_bitwise(backend):
+    """CP=1 through the public entry point is the same contract the two-rank cases reproduce."""
+    _spawn(1, (RAGGED, 64, 1, "single", "strong", backend))
 
 
 # ---------------------------------------------------------------- accuracy vs FP64
@@ -425,7 +420,7 @@ def test_two_ranks_match_canonical_cp1_bitwise(
 def test_canonical_cp1_matches_fp64_reference_within_bf16_budget():
     """The new contract is checked against an independent FP64 recurrence, not only self-consistency."""
     lengths = (17, 65, 129)
-    inputs, grad = _inputs(lengths, "mild", 41, torch.device("cuda"))
+    inputs, grad = _inputs(lengths, "mild", 41)
     inputs = tuple(v[:, :, :1].contiguous() for v in inputs)
     grad = grad[:, :, :1].contiguous()
     actual = _canonical_cp1(inputs, grad, lengths, 64, 2, None)

--- a/test/test_delta_rule_stages.py
+++ b/test/test_delta_rule_stages.py
@@ -55,36 +55,13 @@ class Op(NamedTuple):
     factory: Callable[..., Inputs]  # (tokens, *, key_heads, value_heads, seed, dtype)
     key_heads: int
     value_heads: int
-    # The unsharded kernels the staged backward reproduces bitwise; ``None`` is autograd through
-    # ``chunk``. Mega's staged backward is the native stateful kernel, while the public op's
-    # stateful backward is the fused recompute, so Mega names the native op here.
+    # Mega stages reproduce its native backward bitwise, not the public op's fused recompute.
+    # Other variants use public_gradients directly.
     backward: Callable[..., tuple[torch.Tensor, ...]] | None = None
 
     def make_inputs(self, tokens: int, seed: int, dtype: torch.dtype = torch.bfloat16) -> Inputs:
         return self.factory(
             tokens, key_heads=self.key_heads, value_heads=self.value_heads, seed=seed, dtype=dtype
-        )
-
-    def gradients(
-        self,
-        inputs: Inputs,
-        initial_state: torch.Tensor | None,
-        cu_seqlens: torch.Tensor | None,
-        d_output: torch.Tensor | None,
-        d_final_state: torch.Tensor | None,
-        *,
-        scale: float | None = None,
-    ) -> tuple[torch.Tensor, ...]:
-        """``(dq, dk, dv, dgate, dbeta[, d_initial_state])`` of the unsharded op.
-
-        A ``None`` cotangent drops that term of the loss.
-        """
-        if self.backward is not None:
-            return self.backward(
-                inputs, initial_state, cu_seqlens, d_output, d_final_state, scale=scale
-            )
-        return self.public_gradients(
-            inputs, initial_state, cu_seqlens, d_output, d_final_state, scale=scale
         )
 
     def public_gradients(
@@ -97,7 +74,7 @@ class Op(NamedTuple):
         *,
         scale: float | None = None,
     ) -> tuple[torch.Tensor, ...]:
-        """Gradients by autograd through the public ``chunk`` op, whatever backward it selects."""
+        """Public-op gradients; a None cotangent drops that loss term."""
         leaves = tuple(tensor.detach().clone().requires_grad_() for tensor in inputs)
         if initial_state is not None:
             leaves += (initial_state.detach().clone().requires_grad_(),)
@@ -119,24 +96,20 @@ def mega_native_gradients(
     scale: float | None = None,
 ) -> tuple[torch.Tensor, ...]:
     """The native stateful Mega backward, which the Mega staged handle runs."""
-    from attn_gym.linear.kda.impl.mega_ops import chunk_mega_packed_bwd_with_state_op
+    from attn_gym.linear.kda.impl import mega_ops
 
     q, k, v, gate, beta = inputs
     if cu_seqlens is None:
         cu_seqlens = torch.tensor([0, q.shape[1]], dtype=torch.int32, device=q.device)
-    grads = chunk_mega_packed_bwd_with_state_op(
-        q,
-        k,
-        v,
-        gate,
-        beta,
-        torch.zeros_like(v) if d_output is None else d_output,
-        cu_seqlens,
-        None if initial_state is None else initial_state.contiguous(),
-        d_final_state,
-        HEAD_DIM**-0.5 if scale is None else scale,
+    operands = (q, k, v, gate, beta, torch.zeros_like(v) if d_output is None else d_output)
+    scale = HEAD_DIM**-0.5 if scale is None else scale
+    if initial_state is None:
+        return mega_ops.chunk_mega_packed_bwd_with_exit_cotangent_op(
+            *operands, cu_seqlens, d_final_state, scale
+        )
+    return mega_ops.chunk_mega_packed_bwd_with_state_op(
+        *operands, cu_seqlens, initial_state.contiguous(), d_final_state, scale
     )
-    return grads if initial_state is not None else grads[:5]
 
 
 def relative_rms_error(actual: torch.Tensor, reference: torch.Tensor) -> float:
@@ -395,11 +368,10 @@ def assert_summary_parts_match(summary, fused, oracle, index: int) -> None:
 @pytest.mark.parametrize("state", ["contiguous", "strided-key", "none"])
 @pytest.mark.parametrize("packing", ["packed", "dense"])
 def test_prepare_backward_run_matches_chunk_op_gradients(op, scale, loss, state, packing):
-    """The staged backward is the op's own kernel sequence, so all six gradients are bitwise.
+    """All six staged gradients match the selected backward bitwise, including optional losses.
 
-    For Mega the sequence is the native stateful backward (``Op.backward``). Covers the cotangents the staged API makes optional (``d_output=None``, no final-state loss),
-    the entry-state layouts ``run`` accepts (none, contiguous, a key-strided view), and both chunk
-    schedules: packed ``cu_seqlens`` and a dense span of complete chunks (``metadata is None``).
+    Mega uses its native stateful backward and also checks BF16 agreement with the public op.
+    The matrix covers entry-state layouts, packed/dense schedules, and default/custom scales.
     """
     inputs = op.make_inputs(320, seed=7)
     if packing == "packed":
@@ -422,7 +394,9 @@ def test_prepare_backward_run_matches_chunk_op_gradients(op, scale, loss, state,
     )
 
     d_output = torch.randn(inputs[2].shape, device="cuda", generator=generator).to(inputs[2].dtype)
-    gradients = partial(op.gradients, inputs, initial_state, cu_seqlens, scale=scale)
+    gradients = partial(
+        op.backward or op.public_gradients, inputs, initial_state, cu_seqlens, scale=scale
+    )
     if loss == "output-only":
         expected = gradients(d_output, None)
         d_final_state = torch.zeros_like(d_final_state)
@@ -760,7 +734,9 @@ def test_simulated_context_parallel_matches_unsharded_op(op, cu_seqlens, layout,
     generator = torch.Generator(device="cuda").manual_seed(5)
     d_output = torch.randn(output.shape, device="cuda", generator=generator).to(output.dtype)
     d_final_state = torch.randn(final_state.shape, device="cuda", generator=generator)
-    expected_grads = op.gradients((q, k, v, gate, beta), None, offsets, d_output, d_final_state)
+    expected_grads = (op.backward or op.public_gradients)(
+        (q, k, v, gate, beta), None, offsets, d_output, d_final_state
+    )
 
     # Sharding must not cost accuracy: measure both paths against the FP32 eager oracle.
     f32 = tuple(tensor.detach().float().requires_grad_() for tensor in (q, k, v, gate, beta))


### PR DESCRIPTION
Stacked PRs:
 * __->__#519
 * #518
 * #517
 * #516
 * #515
 * #514
 * #513
 * #512


--- --- ---

Close the review leftovers on the deterministic recipe

kda_chunk_mega_packed_bwd_with_state now requires the entry state and returns six tensors; the
no-entry-state case has its own kda_chunk_mega_packed_bwd_with_exit_cotangent returning five
(exit cotangent still optional), following the repo's custom-op convention of two schemas over
one launcher instead of a Tensor? return that every caller narrows. ChunkKDAMegaBackward.run
dispatches on the saved entry state; the registration test covers all four combinations.

context_parallel_kda_deterministic refuses Mega's split_forward/split_backward up front with the
reason: canonical tiles already bound every leaf, and a horizon split would change the FP32
summaries (measured in agent_space/friendly_fragments/REPORT.md: the scheduler places no cut
inside 1024-token tiles at 64 heads, and where it would, the warmup error is below a BF16 ulp
but above the FP32 summaries' precision). The public docstring states the per-rank footprint.

The deterministic test-suite pins the public entry point at CP=1 (a single-rank run must equal
the per-tile canonical reference bitwise, which the two-rank cases also reproduce), stages the
one-GPU Gloo fallback through a module-level collective name instead of patching
torch.distributed globally, and stops the patch and the process group in a context manager.