### PR TITLE
Ship README.md and docs/ into the Modal test image

### DIFF
--- a/modal_tests.py
+++ b/modal_tests.py
@@ -43,8 +43,12 @@ def configure_local_image(
         )
     else:
         configured = configured.add_local_python_source("attn_gym")
-    return configured.add_local_dir(ROOT_PATH / "test", remote_path="/root/test").add_local_dir(
-        ROOT_PATH / "examples", remote_path="/root/examples"
+    # test_examples_layout checks README.md and docs/ against examples/, so ship them too.
+    return (
+        configured.add_local_dir(ROOT_PATH / "test", remote_path="/root/test")
+        .add_local_dir(ROOT_PATH / "examples", remote_path="/root/examples")
+        .add_local_dir(ROOT_PATH / "docs", remote_path="/root/docs")
+        .add_local_file(ROOT_PATH / "README.md", remote_path="/root/README.md")
     )
 
 


### PR DESCRIPTION
Stacked PRs:
 * #526
 * #525
 * #524
 * #523
 * #522
 * #521
 * __->__#520


--- --- ---

Ship README.md and docs/ into the Modal test image

test_examples_layout parametrizes over README.md and docs/**/*.md and reads
them from the repo root, so the B200 run failed with FileNotFoundError on
/root/README.md (and silently skipped the docs cases).