### PR TITLE
Use the cute.arch packed fp32 wrappers in the Mega pointwise helpers

### DIFF
--- a/attn_gym/linear/_delta_rule/mega/kernels/tile_dsl/pointwise.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/tile_dsl/pointwise.py
@@ -2,30 +2,12 @@
 # SPDX-License-Identifier: MIT
 #
 # Modified by Attention Gym in 2026: TMEM reduction loads, vector helpers, and packed-half math
-# unused by the vendored kernels were removed.
+# unused by the vendored kernels were removed; packed fp32 math uses the cute.arch wrappers.
 
-
-import inspect
 
 import cutlass
 from cutlass import cute
-from cutlass._mlir.dialects import nvvm as nvvm_ops
 from cutlass.cute.arch.nvvm_wrappers import inline_ptx
-
-# nvidia-cutlass-dsl 4.7.0a0 nightlies from 2026-07-27 (6986e65) on regenerated
-# the nvvm bindings to take an explicit result type -- *_packed_f32x2(res,
-# src_a, src_b) -- but the cutlass.experimental.primitives wrappers still call
-# the two-positional form, so going through them raises "missing 1 required
-# positional argument: 'src_b'".  Call the dialect ops directly and adapt to
-# whichever binding generation is installed; older ones infer the result type.
-_PACKED_RES_FIRST = "res" in inspect.signature(nvvm_ops.mul_packed_f32x2).parameters
-
-
-def _packed_f32x2(op, vec_a, vec_b):
-    """``op(vec_a, vec_b)`` for nvvm.{mul,add}_packed_f32x2 on f32x2 IR values."""
-    if _PACKED_RES_FIRST:
-        return op(vec_a.type, vec_a, vec_b, rnd=nvvm_ops.FPRoundingMode.RN)
-    return op(vec_a, vec_b, rnd=nvvm_ops.FPRoundingMode.RN)
 
 
 @cute.jit
@@ -70,51 +52,28 @@ def f16x2_to_f32(word, *, dtype=cutlass.Float16):
 def opaque_f32_zero():
     """A 0.0f the optimizer cannot prove constant.
 
-    Use for values that feed packed-asm operands (:func:`fmul2` /
-    :func:`ffma2`) and could otherwise fold to a literal: the
-    ``nvvm.inline_ptx`` lowering gives constant float operands the ``n``
-    immediate constraint, which ICEs libNVVM."""
+    Kept for the kernels' inline-PTX operands that could otherwise fold to a
+    literal: the ``nvvm.inline_ptx`` lowering gives constant float operands the
+    ``n`` immediate constraint, which ICEs libNVVM."""
     return inline_ptx("mov.b32 $0, 0;", write_only_types=[cutlass.Float32])
 
 
 @cute.jit
 def fmul2(a_lo, a_hi, b_lo, b_hi):
-    """Packed fp32 multiply (SM100 FMUL2): ``(a_lo * b_lo, a_hi * b_hi)``.
-
-    ``mul.f32x2`` operates on register pairs; the ``mov.b64`` packs map to
-    register-pair allocation and usually fold away in SASS."""
-    return inline_ptx(
-        "{ .reg .b64 pa, pb, pc; mov.b64 pa, {$2, $3}; mov.b64 pb, {$4, $5}; "
-        "mul.f32x2 pc, pa, pb; mov.b64 {$0, $1}, pc; }",
-        write_only_types=[cutlass.Float32, cutlass.Float32],
-        read_only_args=[a_lo, a_hi, b_lo, b_hi],
-    )
+    """Packed fp32 multiply (SM100 FMUL2): ``(a_lo * b_lo, a_hi * b_hi)``."""
+    return cute.arch.mul_packed_f32x2((a_lo, a_hi), (b_lo, b_hi))
 
 
 @cute.jit
 def fadd2(a_lo, a_hi, b_lo, b_hi):
-    """Packed fp32 add (SM100 FADD2): ``(a_lo + b_lo, a_hi + b_hi)``.
-
-    Native NVVM op, not inline asm: libNVVM rejects ``add.f32x2`` in asm
-    blocks (mul/fma made it in, add did not)."""
-    vec_a = cutlass.Vector.from_elements((a_lo, a_hi), cutlass.Float32)
-    vec_b = cutlass.Vector.from_elements((b_lo, b_hi), cutlass.Float32)
-    res = cutlass.Vector(
-        _packed_f32x2(nvvm_ops.add_packed_f32x2, vec_a.ir_value(), vec_b.ir_value()),
-        dtype=cutlass.Float32,
-    )
-    return cutlass.Float32(res[0]), cutlass.Float32(res[1])
+    """Packed fp32 add (SM100 FADD2): ``(a_lo + b_lo, a_hi + b_hi)``."""
+    return cute.arch.add_packed_f32x2((a_lo, a_hi), (b_lo, b_hi))
 
 
 @cute.jit
 def ffma2(a_lo, a_hi, b_lo, b_hi, c_lo, c_hi):
     """Packed fp32 fma (SM100 FFMA2): ``(a_lo*b_lo + c_lo, a_hi*b_hi + c_hi)``."""
-    return inline_ptx(
-        "{ .reg .b64 pa, pb, pc, pd; mov.b64 pa, {$2, $3}; mov.b64 pb, {$4, $5}; "
-        "mov.b64 pc, {$6, $7}; fma.rn.f32x2 pd, pa, pb, pc; mov.b64 {$0, $1}, pd; }",
-        write_only_types=[cutlass.Float32, cutlass.Float32],
-        read_only_args=[a_lo, a_hi, b_lo, b_hi, c_lo, c_hi],
-    )
+    return cute.arch.fma_packed_f32x2((a_lo, a_hi), (b_lo, b_hi), (c_lo, c_hi))
 
 
 @cute.jit
@@ -128,15 +87,29 @@ def movmatrix_16b(value: cutlass.Int32) -> cutlass.Int32:
 
 
 @cute.jit
-def sub_f16x2(lhs: cutlass.Int32, rhs: cutlass.Int32, input_dtype: cutlass.Constexpr) -> cutlass.Int32:
+def sub_f16x2(
+    lhs: cutlass.Int32, rhs: cutlass.Int32, input_dtype: cutlass.Constexpr
+) -> cutlass.Int32:
     """Subtract two packed pairs using the compile-time input dtype."""
     if cutlass.const_expr(input_dtype is cutlass.BFloat16):
-        return inline_ptx("sub.bf16x2 $0, $1, $2;", write_only_types=[cutlass.Int32], read_only_args=[lhs, rhs])
-    return inline_ptx("sub.f16x2 $0, $1, $2;", write_only_types=[cutlass.Int32], read_only_args=[lhs, rhs])
+        return inline_ptx(
+            "sub.bf16x2 $0, $1, $2;", write_only_types=[cutlass.Int32], read_only_args=[lhs, rhs]
+        )
+    return inline_ptx(
+        "sub.f16x2 $0, $1, $2;", write_only_types=[cutlass.Int32], read_only_args=[lhs, rhs]
+    )
 
 
 @cute.jit
-def beta_residual_f16x2(v_pair: cutlass.Int32, beta_lo, beta_hi, state_k_lo=None, state_k_hi=None, *, dtype=cutlass.Float16):
+def beta_residual_f16x2(
+    v_pair: cutlass.Int32,
+    beta_lo,
+    beta_hi,
+    state_k_lo=None,
+    state_k_hi=None,
+    *,
+    dtype=cutlass.Float16,
+):
     """Stage the delta-rule update ``beta * (v - state_k)`` for one packed pair.
 
     ``v`` arrives as a packed b16 pair and ``state_k`` as the fp32 MMA


### PR DESCRIPTION
Stacked PRs:
 * #526
 * #525
 * #524
 * #523
 * __->__#522


--- --- ---

Use the cute.arch packed fp32 wrappers in the Mega pointwise helpers

fadd2/fmul2/ffma2 were hand-rolled inline PTX and a direct MLIR dialect call
that had to adapt to the nvvm binding signature. cute.arch.{add,mul,fma}_packed_f32x2
build the same f32x2 vector ops.