### PR TITLE
Run the staged Mega backward on Mega's stateful kernels

### DIFF
--- a/attn_gym/linear/_delta_rule/mega/backward.py
+++ b/attn_gym/linear/_delta_rule/mega/backward.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Torch launcher for the CuTeDSL 4.7 Mega no-state long-context backward."""
+"""Torch launcher for the CuTeDSL 4.7 Mega long-context backward, with or without state."""
 
 from __future__ import annotations
 
@@ -32,11 +32,29 @@ def chunk_delta_rule_bwd_mega_packed(
     *,
     scale: float | None = None,
     split: bool = False,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Run checkpoint recompute followed by exact or forgetting-horizon backward."""
+    initial_state: torch.Tensor | None = None,
+    d_final_state: torch.Tensor | None = None,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor | None,
+]:
+    """Run checkpoint recompute followed by exact or forgetting-horizon backward.
+
+    ``initial_state`` and ``d_final_state`` are optional FP32 ``[N, H, V, K]`` entry states
+    and exit cotangents per packed sequence. ``None`` skips state loads, with token gradients
+    bitwise equal to an explicit zero tensor. Returns ``(dq, dk, dv, dgate, dbeta,
+    d_initial_state)``; the last is ``None`` unless ``initial_state`` was given.
+    The approximate forgetting-horizon ``split`` schedule requires a no-state call.
+    """
     scale = resolve_scale(scale, q.shape[-1])
     if not q.is_cuda:
         raise ValueError("q must be a CUDA tensor")
+    if split and (initial_state is not None or d_final_state is not None):
+        raise ValueError("the split backward schedule requires a no-state call")
     with initialized_cuda_device(q):
         if q.ndim != 4 or q.shape[0] != 1 or q.shape[-1] != 128:
             raise ValueError("q must have shape [1, T, H, 128]")
@@ -69,6 +87,16 @@ def chunk_delta_rule_bwd_mega_packed(
         ):
             raise TypeError("cu_seqlens must be aligned contiguous int32 on q.device")
         num_sequences = cu_seqlens.shape[0] - 1
+        state_shape = (num_sequences, heads, value.shape[-1], dim)
+        for name, state in (("initial_state", initial_state), ("d_final_state", d_final_state)):
+            if state is None:
+                continue
+            if state.shape != state_shape or state.dtype != torch.float32:
+                raise TypeError(f"{name} must be float32 with shape {state_shape}")
+            if state.device != q.device:
+                raise ValueError(f"{name} must be on q.device")
+            if not tensor_supports_tma(state):
+                raise TypeError(f"{name} requires a TMA-compatible inner mode")
         stream = torch.cuda.current_stream(q.device).cuda_stream
         schedule = prepare_mega_schedule(
             gate,
@@ -102,11 +130,12 @@ def chunk_delta_rule_bwd_mega_packed(
             dtype=torch.int64,
             device=q.device,
         )
-        dq = torch.empty_like(q[0])
-        dk = torch.empty_like(k[0])
-        dv = torch.empty_like(value[0])
-        dgate = torch.empty_like(gate[0])
-        dbeta = torch.empty_like(beta[0])
+        gradients = tuple(torch.empty_like(t[0]) for t in (q, k, value, gate, beta))
+        d_initial_state = (
+            None
+            if initial_state is None
+            else torch.empty(state_shape, dtype=torch.float32, device=q.device)
+        )
 
         kda_recompute_f16.chunk_kda_recompute_sm100(
             k[0],
@@ -114,7 +143,7 @@ def chunk_delta_rule_bwd_mega_packed(
             gate[0],
             beta[0],
             cu_seqlens,
-            None,
+            initial_state,
             None,
             checkpoint_every_n_tokens=16,
             output_state_checkpoints=checkpoints,
@@ -137,29 +166,19 @@ def chunk_delta_rule_bwd_mega_packed(
             beta[0],
             d_output[0],
             checkpoints,
-            dq,
-            dk,
-            dv,
-            dgate,
-            dbeta,
+            *gradients,
             cu_seqlens,
             scale,
-            use_initial_state=False,
-            d_initial_state=None,
-            d_final_state=None,
+            use_initial_state=initial_state is not None,
+            d_initial_state=d_initial_state,
+            d_final_state=d_final_state,
             work_items=schedule.work_items,
             work_count=schedule.work_count,
             sched_ctr=bwd_scheduler,
             order_in_prologue=False,
             tensormap_workspace=backward_workspace,
         )
-        return (
-            dq.unsqueeze(0),
-            dk.unsqueeze(0),
-            dv.unsqueeze(0),
-            dgate.unsqueeze(0),
-            dbeta.unsqueeze(0),
-        )
+        return (*(grad.unsqueeze(0) for grad in gradients), d_initial_state)
 
 
 __all__ = ["chunk_delta_rule_bwd_mega_packed"]

--- a/attn_gym/linear/kda/__init__.py
+++ b/attn_gym/linear/kda/__init__.py
@@ -34,6 +34,7 @@ _BACKEND_EXPORTS = {
     # Staged primitives around the affine state boundary (stages.py) and the all-gather recipe
     # over them. Ownership plans live in attn_gym.linear.context_parallel.
     "ChunkKDASaved": "attn_gym.linear.kda.stages",
+    "ChunkKDAMegaSaved": "attn_gym.linear.kda.stages",
     "chunk_kda_prepare": "attn_gym.linear.kda.stages",
     "chunk_kda_prepare_backward": "attn_gym.linear.kda.stages",
     "context_parallel_kda": "attn_gym.linear.kda.context_parallel",

--- a/attn_gym/linear/kda/context_parallel.py
+++ b/attn_gym/linear/kda/context_parallel.py
@@ -42,8 +42,8 @@ def context_parallel_kda(
     See ``attn_gym.linear.context_parallel.context_parallel_chunk`` for the argument contract;
     ``scale``, ``autotune``, and ``kernel_options`` follow ``chunk_kda``. With
     ``kernel_options={"backend": "mega"}`` the local pass runs on Mega and the fused factors are
-    computed once over the span for the summaries; ``fastmath`` applies to the staged backward,
-    which is the fused one for either backend.
+    computed once over the span for the summaries. Its backward is Mega's native stateful kernel,
+    so ``fastmath`` applies only to the fused backend's backward.
     """
     stages = StagedOp(
         partial(chunk_kda_prepare, scale=scale, autotune=autotune, kernel_options=kernel_options),

--- a/attn_gym/linear/kda/impl/mega_ops.py
+++ b/attn_gym/linear/kda/impl/mega_ops.py
@@ -47,6 +47,19 @@ torch.library.define(
     "Tensor cu_seqlens, bool split, float scale) "
     "-> (Tensor, Tensor, Tensor, Tensor, Tensor)",
 )
+# Fixed-arity pair over one launcher: only the with-state backward returns the entry cotangent.
+torch.library.define(
+    "attn_gym::kda_chunk_mega_packed_bwd_with_state",
+    "(Tensor q, Tensor k, Tensor v, Tensor gate, Tensor beta, Tensor d_output, "
+    "Tensor cu_seqlens, Tensor initial_state, Tensor? d_final_state, float scale) "
+    "-> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor)",
+)
+torch.library.define(
+    "attn_gym::kda_chunk_mega_packed_bwd_with_exit_cotangent",
+    "(Tensor q, Tensor k, Tensor v, Tensor gate, Tensor beta, Tensor d_output, "
+    "Tensor cu_seqlens, Tensor? d_final_state, float scale) "
+    "-> (Tensor, Tensor, Tensor, Tensor, Tensor)",
+)
 torch.library.define(
     "attn_gym::kda_plain_gate_bwd_dense_cute",
     "(Tensor d_cumulative) -> Tensor",
@@ -220,7 +233,34 @@ def _packed_local_bwd_cuda(q, k, value, gate, beta, d_output, cu_seqlens, split,
         cu_seqlens,
         scale=scale,
         split=split,
+    )[:5]
+
+
+def _packed_bwd_with_state_cuda(
+    q, k, value, gate, beta, d_output, cu_seqlens, initial_state, d_final_state, scale
+):
+    from attn_gym.linear._delta_rule.mega.backward import chunk_delta_rule_bwd_mega_packed
+
+    return chunk_delta_rule_bwd_mega_packed(
+        q,
+        k,
+        value,
+        gate,
+        beta,
+        d_output,
+        cu_seqlens,
+        scale=scale,
+        initial_state=initial_state,
+        d_final_state=d_final_state,
     )
+
+
+def _packed_bwd_with_exit_cotangent_cuda(
+    q, k, value, gate, beta, d_output, cu_seqlens, d_final_state, scale
+):
+    return _packed_bwd_with_state_cuda(
+        q, k, value, gate, beta, d_output, cu_seqlens, None, d_final_state, scale
+    )[:5]
 
 
 def _plain_gate_bwd_cuda(d_cumulative):
@@ -246,6 +286,14 @@ torch.library.impl(
 )
 torch.library.impl("attn_gym::kda_chunk_mega_packed_fwd_paged", "CUDA", _packed_fwd_paged_cuda)
 torch.library.impl("attn_gym::kda_chunk_mega_packed_local_bwd", "CUDA", _packed_local_bwd_cuda)
+torch.library.impl(
+    "attn_gym::kda_chunk_mega_packed_bwd_with_state", "CUDA", _packed_bwd_with_state_cuda
+)
+torch.library.impl(
+    "attn_gym::kda_chunk_mega_packed_bwd_with_exit_cotangent",
+    "CUDA",
+    _packed_bwd_with_exit_cotangent_cuda,
+)
 torch.library.impl("attn_gym::kda_plain_gate_bwd_dense_cute", "CUDA", _plain_gate_bwd_cuda)
 
 
@@ -295,10 +343,32 @@ def _packed_fwd_paged_fake(
     return torch.empty_like(value)
 
 
+def _token_gradients_fake(q, k, value, gate, beta):
+    """One compact gradient per token operand, as the backward launchers allocate them."""
+    return tuple(torch.empty_like(tensor[0]).unsqueeze(0) for tensor in (q, k, value, gate, beta))
+
+
 @torch.library.register_fake("attn_gym::kda_chunk_mega_packed_local_bwd")
 def _packed_local_bwd_fake(q, k, value, gate, beta, d_output, cu_seqlens, split, scale):
-    del d_output, cu_seqlens, split, scale
-    return tuple(torch.empty_like(tensor[0]).unsqueeze(0) for tensor in (q, k, value, gate, beta))
+    return _token_gradients_fake(q, k, value, gate, beta)
+
+
+@torch.library.register_fake("attn_gym::kda_chunk_mega_packed_bwd_with_state")
+def _packed_bwd_with_state_fake(
+    q, k, value, gate, beta, d_output, cu_seqlens, initial_state, d_final_state, scale
+):
+    # The launcher allocates a compact FP32 cotangent whatever the entry state's outer strides.
+    return (
+        *_token_gradients_fake(q, k, value, gate, beta),
+        initial_state.new_empty(initial_state.shape),
+    )
+
+
+@torch.library.register_fake("attn_gym::kda_chunk_mega_packed_bwd_with_exit_cotangent")
+def _packed_bwd_with_exit_cotangent_fake(
+    q, k, value, gate, beta, d_output, cu_seqlens, d_final_state, scale
+):
+    return _token_gradients_fake(q, k, value, gate, beta)
 
 
 @torch.library.register_fake("attn_gym::kda_plain_gate_bwd_dense_cute")
@@ -317,11 +387,19 @@ chunk_mega_packed_fwd_with_state_op = (
     torch.ops.attn_gym.kda_chunk_mega_packed_fwd_with_state.default
 )
 chunk_mega_packed_local_bwd_op = torch.ops.attn_gym.kda_chunk_mega_packed_local_bwd.default
+chunk_mega_packed_bwd_with_state_op = (
+    torch.ops.attn_gym.kda_chunk_mega_packed_bwd_with_state.default
+)
+chunk_mega_packed_bwd_with_exit_cotangent_op = (
+    torch.ops.attn_gym.kda_chunk_mega_packed_bwd_with_exit_cotangent.default
+)
 plain_gate_bwd_dense_cute_op = torch.ops.attn_gym.kda_plain_gate_bwd_dense_cute.default
 
 
 __all__ = [
     "chunk_mega_dense_training_fwd_op",
+    "chunk_mega_packed_bwd_with_exit_cotangent_op",
+    "chunk_mega_packed_bwd_with_state_op",
     "chunk_mega_packed_fwd_op",
     "chunk_mega_packed_fwd_paged_op",
     "chunk_mega_packed_fwd_with_initial_state_op",

--- a/attn_gym/linear/kda/stages.py
+++ b/attn_gym/linear/kda/stages.py
@@ -54,6 +54,8 @@ from attn_gym.linear.kda.fwd.cute.chunk_kda_fwd import (
 from attn_gym.linear.kda.impl.fused import _validate_fused_constraints
 from attn_gym.linear.kda.impl.mega import validate_mega_constraints
 from attn_gym.linear.kda.impl.mega_ops import (
+    chunk_mega_packed_bwd_with_exit_cotangent_op,
+    chunk_mega_packed_bwd_with_state_op,
     chunk_mega_packed_fwd_with_initial_state_op,
     chunk_mega_packed_fwd_with_state_op,
     validate_mega_available,
@@ -67,7 +69,7 @@ class ChunkKDASaved(NamedTuple):
 
     Every field is a tensor or ``None`` so the tuple can be splatted into
     ``ctx.save_for_backward`` and rebuilt from ``ctx.saved_tensors``. ``aqk``/``akk`` are
-    ``None`` when the forward did not materialize them (Mega); backward recomputes them.
+    ``None`` when the forward did not materialize them; backward recomputes them.
     """
 
     q: torch.Tensor
@@ -79,6 +81,24 @@ class ChunkKDASaved(NamedTuple):
     akk: torch.Tensor | None
     cu_seqlens: torch.Tensor | None
     chunk_offsets: torch.Tensor | None
+
+
+class ChunkKDAMegaSaved(NamedTuple):
+    """Forward tensors a Mega ``chunk_kda_prepare`` stores for ``chunk_kda_prepare_backward``.
+
+    Mega's backward reads the raw ``gate`` and keeps its factors on chip, so the tape carries the
+    gate instead of WY factors; ``cumulative_gate`` only feeds the fused factor pass behind
+    arbitrary-range summaries. Mega always runs packed, so the offsets are never ``None``.
+    """
+
+    q: torch.Tensor
+    k: torch.Tensor
+    v: torch.Tensor
+    gate: torch.Tensor
+    cumulative_gate: torch.Tensor
+    beta: torch.Tensor
+    cu_seqlens: torch.Tensor
+    chunk_offsets: torch.Tensor
 
 
 # NOTE [Summary ranges are whole chunks of one subsequence]
@@ -108,6 +128,21 @@ def _normalize_state(state: torch.Tensor | None) -> torch.Tensor | None:
         return None
     state = state.float()
     return state if state.stride(-1) == 1 else state.contiguous()
+
+
+def _normalize_mega_state(state: torch.Tensor | None) -> torch.Tensor | None:
+    """FP32 state as Mega's launchers read it through TMA.
+
+    Unit-stride keys and 16-byte-aligned outer strides suffice, so only other layouts are copied.
+    The copy is a ``clone``: ``.contiguous()`` returns a contiguous view unchanged even when its
+    storage offset breaks the alignment.
+    """
+    if state is None:
+        return None
+    state = state.float()
+    if tensor_supports_tma(state):
+        return state
+    return state.clone(memory_format=torch.contiguous_format)
 
 
 @dataclass
@@ -164,11 +199,10 @@ class ChunkKDAMegaPrepared:
 
     Mega never materializes the WY factors, so ``run`` executes the Mega with-state kernel over the
     whole local stream and ``state_summaries`` computes the fused factors once for the whole stream
-    (its ranges are device values). Backward recomputes the intra factors, as Mega does today.
+    (its ranges are device values). The backward handle is :class:`ChunkKDAMegaBackward`.
     """
 
-    saved: ChunkKDASaved  # aqk/akk are None: Mega keeps them on chip
-    gate: torch.Tensor
+    saved: ChunkKDAMegaSaved
     metadata: RaggedChunkMetadata
     scale: float
     autotune: bool
@@ -209,19 +243,15 @@ class ChunkKDAMegaPrepared:
         if initial_state is None:
             initial_state = zero_state(saved.q, saved.v, self.metadata)
         else:
-            # Mega's launcher reads the state through TMA: unit-stride keys and 16-byte-aligned
-            # outer strides suffice, so only other layouts are copied.
-            initial_state = initial_state.float()
-            if not tensor_supports_tma(initial_state):
-                initial_state = initial_state.contiguous()
+            initial_state = _normalize_mega_state(initial_state)
         args = (
             saved.q,
             saved.k,
             saved.v,
-            self.gate,
+            saved.gate,
             saved.beta,
             initial_state,
-            self.metadata.cu_seqlens,
+            saved.cu_seqlens,
             self.scale,
         )
         if output_final_state:
@@ -273,13 +303,11 @@ def chunk_kda_prepare(
     gate = gate.float()
     cumulative_gate = _plain_gate_scan_op(gate, cu_seqlens, chunk_offsets, False)
     if backend == "mega":
-        assert metadata is not None
+        assert metadata is not None and cu_seqlens is not None and chunk_offsets is not None
         gate = normalize_compact_tensor(gate)
-        validate_mega_constraints(q, k, v, gate, beta, None, metadata.cu_seqlens)
-        saved = ChunkKDASaved(
-            q, k, v, cumulative_gate, beta, None, None, cu_seqlens, chunk_offsets
-        )
-        return ChunkKDAMegaPrepared(saved, gate, metadata, scale, autotune)
+        validate_mega_constraints(q, k, v, gate, beta, None, cu_seqlens)
+        saved = ChunkKDAMegaSaved(q, k, v, gate, cumulative_gate, beta, cu_seqlens, chunk_offsets)
+        return ChunkKDAMegaPrepared(saved, metadata, scale, autotune)
     factors = _prepare_chunk_kda_fwd(
         q, k, v, cumulative_gate, beta, metadata, scale=scale, autotune=autotune, schedule=schedule
     )
@@ -363,8 +391,80 @@ class ChunkKDABackward:
         return dq, dk, dv, dgate, dbeta, d_initial_state
 
 
+@dataclass
+class ChunkKDAMegaBackward:
+    """Mega backward handle: ``run`` is Mega's stateful backward, summaries use fused factors.
+
+    ``state_grad_summaries`` recomputes the fused factors on demand over the whole local stream,
+    as the forward handle's ``state_summaries`` does. Nothing is consumed, so ``run`` and
+    ``state_grad_summaries`` may be called in either order.
+    """
+
+    saved: ChunkKDAMegaSaved
+    d_output: torch.Tensor
+    initial_state: torch.Tensor | None
+    scale: float
+    autotune: bool
+    schedule: ScheduleRequest
+
+    def state_grad_summaries(self, bounds: torch.Tensor) -> torch.Tensor:
+        """Return one FP32 ``[HV, V + K, K]`` reverse map per row of ``bounds`` in one launch.
+
+        Same contract as ``ChunkKDABackward.state_grad_summaries``.
+        """
+        saved = self.saved
+        # The fused backward over the equivalent tape (no materialized factors) owns the recompute.
+        fused_saved = ChunkKDASaved(
+            saved.q,
+            saved.k,
+            saved.v,
+            saved.cumulative_gate,
+            saved.beta,
+            None,
+            None,
+            saved.cu_seqlens,
+            saved.chunk_offsets,
+        )
+        return chunk_kda_prepare_backward(
+            fused_saved,
+            self.d_output,
+            self.initial_state,
+            scale=self.scale,
+            autotune=self.autotune,
+            schedule=self.schedule,
+        ).state_grad_summaries(bounds)
+
+    def run(
+        self, d_final_state: torch.Tensor | None = None
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor | None,
+    ]:
+        """Run Mega's backward from one FP32 ``[N, HV, V, K]`` exit cotangent per sequence.
+
+        Returns ``(dq, dk, dv, dgate, dbeta, d_initial_state)``; the last is ``None`` when the
+        forward ran without an entry state. An absent ``d_final_state`` skips the cotangent load
+        and gives the token gradients of an explicit zero.
+        """
+        saved = self.saved
+        d_final_state = _normalize_mega_state(d_final_state)
+        operands = (saved.q, saved.k, saved.v, saved.gate, saved.beta, self.d_output)
+        if self.initial_state is None:
+            grads = chunk_mega_packed_bwd_with_exit_cotangent_op(
+                *operands, saved.cu_seqlens, d_final_state, self.scale
+            )
+            return (*grads, None)
+        return chunk_mega_packed_bwd_with_state_op(
+            *operands, saved.cu_seqlens, self.initial_state, d_final_state, self.scale
+        )
+
+
 def chunk_kda_prepare_backward(
-    saved: ChunkKDASaved,
+    saved: ChunkKDASaved | ChunkKDAMegaSaved,
     d_output: torch.Tensor | None,
     initial_state: torch.Tensor | None,
     *,
@@ -372,7 +472,7 @@ def chunk_kda_prepare_backward(
     autotune: bool = True,
     fastmath: bool = False,
     schedule: ScheduleRequest = ScheduleRequest.AUTO,
-) -> ChunkKDABackward:
+) -> ChunkKDABackward | ChunkKDAMegaBackward:
     """Recompute the local backward tensors before any reverse-summary exchange.
 
     ``initial_state`` is the entry state the forward ``run`` consumed and ``scale`` is the
@@ -380,20 +480,26 @@ def chunk_kda_prepare_backward(
     re-derived scale would corrupt every gradient. Both live outside ``saved`` because the
     caller's autograd function owns them. ``fastmath`` applies to the gradient kernels as in
     ``chunk_kda``; pass the forward handle's ``prepared.schedule`` so the backward's factor
-    recompute uses the same launch geometry.
+    recompute uses the same launch geometry. A Mega tape (:class:`ChunkKDAMegaSaved`) returns
+    :class:`ChunkKDAMegaBackward`, whose native ``run`` ignores ``fastmath``; it recomputes fused
+    factors only if ``state_grad_summaries`` needs them.
     """
+    if d_output is None:
+        d_output = torch.zeros_like(saved.v)
+    else:
+        d_output = normalize_compact_tensor(d_output.to(saved.v.dtype))
+    scale = float(scale)
+    if isinstance(saved, ChunkKDAMegaSaved):
+        return ChunkKDAMegaBackward(
+            saved, d_output, _normalize_mega_state(initial_state), scale, autotune, schedule
+        )
     metadata = None
     if saved.cu_seqlens is not None:
         assert saved.chunk_offsets is not None
         metadata = RaggedChunkMetadata.from_offsets(
             saved.cu_seqlens, saved.chunk_offsets, saved.q.shape[1], CHUNK_SIZE
         )
-    if d_output is None:
-        d_output = torch.zeros_like(saved.v)
-    else:
-        d_output = normalize_compact_tensor(d_output.to(saved.v.dtype))
     initial_state = _normalize_state(initial_state)  # The backward recomputes the chain from it.
-    scale = float(scale)
     prepared = _prepare_chunk_kda_bwd(
         saved.q,
         saved.k,
@@ -417,7 +523,9 @@ def chunk_kda_prepare_backward(
 
 __all__ = [
     "ChunkKDABackward",
+    "ChunkKDAMegaBackward",
     "ChunkKDAMegaPrepared",
+    "ChunkKDAMegaSaved",
     "ChunkKDAPrepared",
     "ChunkKDASaved",
     "chunk_kda_prepare",

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -610,10 +610,12 @@ local pass with Mega from the composed entry state. Because Mega keeps WY factor
 `state_summaries` computes the fused factors once over the whole local stream and summarizes
 every range from them; that factor pass is paid even when every fragment ends its document and
 the summaries are identities, since which ranges are empty is a device value under replay. A
-layout that never continues a document across ranks does not need this recipe. Backward
-recomputes the local fused factors and uses Mega's existing with-state route through the fused
-staged backward. The staged handles and this recipe are eager-only; `torch.compile` is not
-supported through them.
+layout that never continues a document across ranks does not need this recipe. The backward
+handle's `run` is Mega's own stateful backward (`attn_gym::kda_chunk_mega_packed_bwd_with_state`:
+checkpoint recompute from the saved entry state, then the BT16 backward folding in the exit
+cotangent), so a document cut at 16-token boundaries reproduces the unsharded Mega gradients bit
+for bit; only `state_grad_summaries` still recomputes the fused factors over the local stream. The
+staged handles and this recipe are eager-only; `torch.compile` is not supported through them.
 
 ::: attn_gym.linear.context_parallel.context_parallel_chunk
 

--- a/test/kda/mega/test_kda_mega_stateful_bwd.py
+++ b/test/kda/mega/test_kda_mega_stateful_bwd.py
@@ -1,0 +1,309 @@
+"""Native stateful Mega backward: registration, fragment handoff parity, and reference accuracy."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+import pytest
+import torch
+
+pytest.importorskip(
+    "cutlass.experimental",
+    reason="the CuTeDSL 4.7 KDA path requires nvidia-cutlass-dsl>=4.7",
+)
+
+from attn_gym.linear.kda.impl.mega_ops import (
+    chunk_mega_packed_bwd_with_exit_cotangent_op,
+    chunk_mega_packed_bwd_with_state_op,
+    chunk_mega_packed_fwd_with_state_op,
+    chunk_mega_packed_local_bwd_op,
+)
+from attn_gym.linear.kda.stages import (
+    ChunkKDAMegaBackward,
+    ChunkKDAMegaSaved,
+    chunk_kda_prepare,
+    chunk_kda_prepare_backward,
+)
+from attn_gym.testing.kda import (
+    assert_matches_low_precision_reference,
+    cumulative_sequence_offsets,
+    kda_reference,
+    make_kda_test_inputs,
+)
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() not in ((10, 0), (10, 3)),
+    reason="the CuTeDSL 4.7 KDA path requires SM100 or SM103",
+)
+
+D = 128
+SCALE = D**-0.5
+OPCHECK_UTILITIES = ("test_schema", "test_faketensor", "test_aot_dispatch_dynamic")
+MILD_GATE = 0.05  # Decay per token in [e^-0.05, 1): the entry state still matters 4096 tokens in.
+GRADIENT_NAMES = ("dq", "dk", "dv", "dgate", "dbeta", "d_initial_state")
+
+
+def _make_inputs(
+    lengths: list[int], *, heads: int, gate_scale: float, seed: int
+) -> tuple[torch.Tensor, ...]:
+    """Public Mega operands, a nonzero FP32 entry state, and an output cotangent per token."""
+    q, k, value, gate, beta = make_kda_test_inputs(
+        sum(lengths),
+        heads=heads,
+        seed=seed,
+        gate_scale=gate_scale,
+        sigmoid_beta=True,
+        normalize_qk=True,
+        dtype=torch.bfloat16,
+    )
+    generator = torch.Generator(device="cuda").manual_seed(seed + 1)
+    initial_state = torch.randn(len(lengths), heads, D, D, device="cuda", generator=generator)
+    d_output = torch.randn(value.shape, device="cuda", generator=generator).to(value.dtype)
+    d_final_state = torch.randn_like(initial_state)
+    return q, k, value, gate, beta, initial_state, d_output, d_final_state
+
+
+def _swap_state_head_value_storage(tensor: torch.Tensor) -> torch.Tensor:
+    """Copy `[N,H,V,K]` data into dense TMA-compatible `[N,V,H,K]` storage order."""
+    _, heads, value_dim, key_dim = tensor.shape
+    storage = torch.empty(tensor.numel(), dtype=tensor.dtype, device=tensor.device)
+    return torch.as_strided(
+        storage,
+        tensor.shape,
+        (heads * value_dim * key_dim, key_dim, heads * key_dim, 1),
+    ).copy_(tensor)
+
+
+def _assert_gradients_equal(
+    actual: Sequence[torch.Tensor], expected: Sequence[torch.Tensor]
+) -> None:
+    """Bit-exact comparison of ``(dq, dk, dv, dgate, dbeta[, d_initial_state])`` tuples."""
+    names = GRADIENT_NAMES[: len(expected)]
+    for name, got, reference in zip(names, actual, expected, strict=True):
+        torch.testing.assert_close(got, reference, atol=0, rtol=0, msg=name)
+
+
+@pytest.mark.parametrize("outer_strided", [False, True], ids=["compact", "outer-strided"])
+def test_stateful_backward_op_registration(outer_strided: bool) -> None:
+    """Both fixed-arity ops register cleanly with and without an exit cotangent."""
+    q, k, value, gate, beta, initial_state, d_output, d_final_state = _make_inputs(
+        [65, 0, 63], heads=2, gate_scale=math.log(2.0), seed=97
+    )
+    if outer_strided:
+        initial_state = _swap_state_head_value_storage(initial_state)
+        d_final_state = _swap_state_head_value_storage(d_final_state)
+        assert not initial_state.is_contiguous()
+    operands = (q, k, value, gate, beta, d_output, cumulative_sequence_offsets([65, 0, 63]))
+    for exit_cotangent in (d_final_state, None):
+        with_state = (*operands, initial_state, exit_cotangent, SCALE)
+        grads = chunk_mega_packed_bwd_with_state_op(*with_state)
+        assert len(grads) == 6
+        assert grads[5].shape == initial_state.shape and grads[5].is_contiguous()
+        assert grads[5].dtype == torch.float32
+        torch.library.opcheck(
+            chunk_mega_packed_bwd_with_state_op, with_state, test_utils=OPCHECK_UTILITIES
+        )
+        # Without an entry state the fixed-arity sibling returns the five token gradients.
+        without_state = (*operands, exit_cotangent, SCALE)
+        assert len(chunk_mega_packed_bwd_with_exit_cotangent_op(*without_state)) == 5
+        torch.library.opcheck(
+            chunk_mega_packed_bwd_with_exit_cotangent_op,
+            without_state,
+            test_utils=OPCHECK_UTILITIES,
+        )
+
+
+def test_staged_backward_copies_misaligned_contiguous_states() -> None:
+    """A contiguous view whose storage offset breaks TMA alignment is cloned, not passed through.
+
+    ``.contiguous()`` would return such a view unchanged and the launcher would reject it.
+    """
+    lengths = [65, 63]
+    q, k, value, gate, beta, initial_state, d_output, d_final_state = _make_inputs(
+        lengths, heads=2, gate_scale=MILD_GATE, seed=7
+    )
+    offsets = cumulative_sequence_offsets(lengths)
+
+    def misaligned(state: torch.Tensor) -> torch.Tensor:
+        storage = torch.empty(state.numel() + 1, dtype=state.dtype, device=state.device)
+        view = storage[1:].view(state.shape).copy_(state)
+        assert view.is_contiguous() and view.data_ptr() % 16 != 0
+        return view
+
+    prepared = chunk_kda_prepare(
+        q, k, value, gate, beta, cu_seqlens=offsets, kernel_options={"backend": "mega"}
+    )
+    prepared.run(initial_state, output_final_state=True)
+    expected = chunk_kda_prepare_backward(
+        prepared.saved, d_output, initial_state, scale=prepared.scale
+    ).run(d_final_state)
+    actual = chunk_kda_prepare_backward(
+        prepared.saved, d_output, misaligned(initial_state), scale=prepared.scale
+    ).run(misaligned(d_final_state))
+    _assert_gradients_equal(actual, expected)
+
+
+def test_stateful_backward_without_state_is_the_local_backward() -> None:
+    """``None`` keeps the no-state kernel specializations, so the two ops agree bit for bit."""
+    q, k, value, gate, beta, _, d_output, _ = _make_inputs(
+        [65, 0, 63], heads=2, gate_scale=math.log(2.0), seed=11
+    )
+    operands = (q, k, value, gate, beta, d_output, cumulative_sequence_offsets([65, 0, 63]))
+    _assert_gradients_equal(
+        chunk_mega_packed_bwd_with_exit_cotangent_op(*operands, None, SCALE),
+        chunk_mega_packed_local_bwd_op(*operands, False, SCALE),
+    )
+
+
+def _slice(tensors: tuple[torch.Tensor, ...], start: int, stop: int) -> tuple[torch.Tensor, ...]:
+    return tuple(tensor[:, start:stop].contiguous() for tensor in tensors)
+
+
+def _fragments(cu_seqlens: list[int], cut: int) -> tuple[list[int], list[int], int]:
+    """Split packed boundaries at ``cut``; returns both fragments' local offsets and the cut doc."""
+    document = max(index for index, start in enumerate(cu_seqlens[:-1]) if start <= cut)
+    assert cu_seqlens[document] < cut < cu_seqlens[document + 1], "cut must be inside a document"
+    assert (cut - cu_seqlens[document]) % 16 == 0, "cut must be 16-aligned to the document"
+    first = [*cu_seqlens[: document + 1], cut]
+    second = [offset - cut for offset in (cut, *cu_seqlens[document + 1 :])]
+    return first, second, document
+
+
+@pytest.mark.parametrize(
+    ("lengths", "cut", "heads", "gate_scale"),
+    [
+        pytest.param([4096], 2064, 64, MILD_GATE, id="h64-t4096-mild"),
+        # Documents start at 0, 17, 82, 211, 468, 981; cuts are 16-aligned to their document.
+        pytest.param([17, 65, 129, 257, 513, 1025], 211 + 16 * 5, 4, MILD_GATE, id="ragged-mild"),
+        pytest.param([17, 65, 129, 257, 513, 1025], 468 + 16 * 3, 4, 5.0, id="ragged-strong"),
+    ],
+)
+def test_two_aligned_fragments_with_state_handoff_match_one_native_call(
+    lengths: list[int], cut: int, heads: int, gate_scale: float
+) -> None:
+    """A document cut at a 16-token offset and continued from the actual states is bit-exact.
+
+    Rank 0 owns ``[0, cut)`` and rank 1 ``[cut, T)``; the cut document's exit state travels
+    forward and its entry cotangent travels backward, as the context-parallel recipe does.
+    """
+    q, k, value, gate, beta, initial_state, d_output, d_final_state = _make_inputs(
+        lengths, heads=heads, gate_scale=gate_scale, seed=3
+    )
+    offsets = cumulative_sequence_offsets(lengths)
+    cu_seqlens = offsets.tolist()
+    first, second, document = _fragments(cu_seqlens, cut)
+    first_offsets = torch.tensor(first, dtype=torch.int32, device="cuda")
+    second_offsets = torch.tensor(second, dtype=torch.int32, device="cuda")
+
+    operands = (q, k, value, gate, beta, d_output)
+    output, final_state = chunk_mega_packed_fwd_with_state_op(
+        *operands[:5], initial_state, offsets, SCALE
+    )
+    expected = chunk_mega_packed_bwd_with_state_op(
+        *operands, offsets, initial_state, d_final_state, SCALE
+    )
+
+    head, tail = _slice(operands, 0, cut), _slice(operands, cut, cu_seqlens[-1])
+    head_output, head_states = chunk_mega_packed_fwd_with_state_op(
+        *head[:5], initial_state[: document + 1], first_offsets, SCALE
+    )
+    tail_entry = torch.cat((head_states[document:], initial_state[document + 1 :]))
+    tail_output, tail_states = chunk_mega_packed_fwd_with_state_op(
+        *tail[:5], tail_entry, second_offsets, SCALE
+    )
+    torch.testing.assert_close(torch.cat((head_output, tail_output), 1), output, atol=0, rtol=0)
+    torch.testing.assert_close(head_states[:document], final_state[:document], atol=0, rtol=0)
+    torch.testing.assert_close(tail_states, final_state[document:], atol=0, rtol=0)
+
+    tail_grads = chunk_mega_packed_bwd_with_state_op(
+        *tail, second_offsets, tail_entry, d_final_state[document:], SCALE
+    )
+    head_exit = torch.cat((d_final_state[:document], tail_grads[5][:1]))
+    head_grads = chunk_mega_packed_bwd_with_state_op(
+        *head, first_offsets, initial_state[: document + 1], head_exit, SCALE
+    )
+    joined = [
+        *(torch.cat(pair, 1) for pair in zip(head_grads[:5], tail_grads[:5], strict=True)),
+        torch.cat((head_grads[5], tail_grads[5][1:])),
+    ]
+    _assert_gradients_equal(joined, expected)
+
+
+def test_staged_mega_backward_is_the_native_op() -> None:
+    """``chunk_kda_prepare_backward`` on a Mega tape runs the stateful op, not the fused recompute."""
+    lengths = [100, 156]
+    q, k, value, gate, beta, initial_state, d_output, d_final_state = _make_inputs(
+        lengths, heads=2, gate_scale=MILD_GATE, seed=5
+    )
+    offsets = cumulative_sequence_offsets(lengths)
+    operands = (q, k, value, gate, beta, d_output, offsets)
+    prepared = chunk_kda_prepare(
+        q, k, value, gate, beta, cu_seqlens=offsets, kernel_options={"backend": "mega"}
+    )
+    assert isinstance(prepared.saved, ChunkKDAMegaSaved)
+    prepared.run(initial_state, output_final_state=True)
+    grads = chunk_kda_prepare_backward(
+        prepared.saved, d_output, initial_state, scale=prepared.scale
+    )
+    assert isinstance(grads, ChunkKDAMegaBackward)
+    _assert_gradients_equal(
+        grads.run(d_final_state),
+        chunk_mega_packed_bwd_with_state_op(*operands, initial_state, d_final_state, SCALE),
+    )
+
+    # Arbitrary-range reverse summaries still come from the fused factors.
+    fused = chunk_kda_prepare(q, k, value, gate, beta, cu_seqlens=offsets)
+    fused_grads = chunk_kda_prepare_backward(
+        fused.saved, d_output, initial_state, scale=fused.scale
+    )
+    bounds = torch.tensor([[0, 100], [100, 256]], dtype=torch.int32, device="cuda")
+    torch.testing.assert_close(
+        grads.state_grad_summaries(bounds),
+        fused_grads.state_grad_summaries(bounds),
+        atol=0,
+        rtol=0,
+    )
+    # Without an entry state the tape's backward keeps Mega's no-state arithmetic.
+    no_state = chunk_kda_prepare_backward(prepared.saved, d_output, None, scale=prepared.scale)
+    *no_state_grads, d_initial_state = no_state.run(None)
+    assert d_initial_state is None
+    _assert_gradients_equal(
+        no_state_grads, chunk_mega_packed_local_bwd_op(*operands, False, SCALE)
+    )
+
+
+def test_stateful_backward_matches_fp64_reference_including_d_initial_state() -> None:
+    """All six gradients, including the entry-state cotangent, sit within the reference budget."""
+    lengths = [100, 156]
+    q, k, value, gate, beta, initial_state, d_output, d_final_state = _make_inputs(
+        lengths, heads=1, gate_scale=MILD_GATE, seed=7
+    )
+    offsets = cumulative_sequence_offsets(lengths)
+    actual = chunk_mega_packed_bwd_with_state_op(
+        q, k, value, gate, beta, d_output, offsets, initial_state, d_final_state, SCALE
+    )
+    references = []
+    for precision in (torch.float64, torch.float32):
+        leaves = tuple(
+            tensor.detach().to(precision).requires_grad_()
+            for tensor in (q, k, value, gate, beta, initial_state)
+        )
+        output, final_state = kda_reference(
+            *leaves, cu_seqlens=offsets, scale=SCALE, output_final_state=True
+        )
+        assert final_state is not None
+        references.append(
+            torch.autograd.grad(
+                (output, final_state),
+                leaves,
+                (d_output.to(precision), d_final_state.to(precision)),
+            )
+        )
+    high, low = references
+    for name, actual_grad, high_grad, low_grad in zip(
+        GRADIENT_NAMES, actual, high, low, strict=True
+    ):
+        assert_matches_low_precision_reference(actual_grad, high_grad, low_grad, name)
+    # The entry state must actually reach the gradient: a dead state makes the check vacuous.
+    assert high[5].abs().max() > 1e-3

--- a/test/test_delta_rule_stages.py
+++ b/test/test_delta_rule_stages.py
@@ -55,11 +55,61 @@ class Op(NamedTuple):
     factory: Callable[..., Inputs]  # (tokens, *, key_heads, value_heads, seed, dtype)
     key_heads: int
     value_heads: int
+    # Mega stages reproduce its native backward bitwise, not the public op's fused recompute.
+    # Other variants use public_gradients directly.
+    backward: Callable[..., tuple[torch.Tensor, ...]] | None = None
 
     def make_inputs(self, tokens: int, seed: int, dtype: torch.dtype = torch.bfloat16) -> Inputs:
         return self.factory(
             tokens, key_heads=self.key_heads, value_heads=self.value_heads, seed=seed, dtype=dtype
         )
+
+    def public_gradients(
+        self,
+        inputs: Inputs,
+        initial_state: torch.Tensor | None,
+        cu_seqlens: torch.Tensor | None,
+        d_output: torch.Tensor | None,
+        d_final_state: torch.Tensor | None,
+        *,
+        scale: float | None = None,
+    ) -> tuple[torch.Tensor, ...]:
+        """Public-op gradients; a None cotangent drops that loss term."""
+        leaves = tuple(tensor.detach().clone().requires_grad_() for tensor in inputs)
+        if initial_state is not None:
+            leaves += (initial_state.detach().clone().requires_grad_(),)
+        output, final_state = self.chunk(
+            *leaves, cu_seqlens=cu_seqlens, output_final_state=True, scale=scale
+        )
+        terms = [(output, d_output), (final_state, d_final_state)]
+        outputs, cotangents = zip(*(term for term in terms if term[1] is not None), strict=True)
+        return torch.autograd.grad(outputs, leaves, cotangents)
+
+
+def mega_native_gradients(
+    inputs: Inputs,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+    d_output: torch.Tensor | None,
+    d_final_state: torch.Tensor | None,
+    *,
+    scale: float | None = None,
+) -> tuple[torch.Tensor, ...]:
+    """The native stateful Mega backward, which the Mega staged handle runs."""
+    from attn_gym.linear.kda.impl import mega_ops
+
+    q, k, v, gate, beta = inputs
+    if cu_seqlens is None:
+        cu_seqlens = torch.tensor([0, q.shape[1]], dtype=torch.int32, device=q.device)
+    operands = (q, k, v, gate, beta, torch.zeros_like(v) if d_output is None else d_output)
+    scale = HEAD_DIM**-0.5 if scale is None else scale
+    if initial_state is None:
+        return mega_ops.chunk_mega_packed_bwd_with_exit_cotangent_op(
+            *operands, cu_seqlens, d_final_state, scale
+        )
+    return mega_ops.chunk_mega_packed_bwd_with_state_op(
+        *operands, cu_seqlens, initial_state.contiguous(), d_final_state, scale
+    )
 
 
 def relative_rms_error(actual: torch.Tensor, reference: torch.Tensor) -> float:
@@ -123,6 +173,7 @@ requires_mega = pytest.mark.skipif(
 KDA_MEGA = KDA._replace(
     chunk=partial(chunk_kda, kernel_options=MEGA),
     prepare=partial(chunk_kda_prepare, kernel_options=MEGA),
+    backward=mega_native_gradients,
 )
 op_param = pytest.mark.parametrize(
     "op",
@@ -317,11 +368,10 @@ def assert_summary_parts_match(summary, fused, oracle, index: int) -> None:
 @pytest.mark.parametrize("state", ["contiguous", "strided-key", "none"])
 @pytest.mark.parametrize("packing", ["packed", "dense"])
 def test_prepare_backward_run_matches_chunk_op_gradients(op, scale, loss, state, packing):
-    """The staged backward is the op's own kernel sequence, so all six gradients are bitwise.
+    """All six staged gradients match the selected backward bitwise, including optional losses.
 
-    Covers the cotangents the staged API makes optional (``d_output=None``, no final-state loss),
-    the entry-state layouts ``run`` accepts (none, contiguous, a key-strided view), and both chunk
-    schedules: packed ``cu_seqlens`` and a dense span of complete chunks (``metadata is None``).
+    Mega uses its native stateful backward and also checks BF16 agreement with the public op.
+    The matrix covers entry-state layouts, packed/dense schedules, and default/custom scales.
     """
     inputs = op.make_inputs(320, seed=7)
     if packing == "packed":
@@ -343,21 +393,18 @@ def test_prepare_backward_run_matches_chunk_op_gradients(op, scale, loss, state,
         sequences, op.value_heads, HEAD_DIM, HEAD_DIM, device="cuda", generator=generator
     )
 
-    leaves = tuple(tensor.detach().clone().requires_grad_() for tensor in inputs) + (
-        () if initial_state is None else (initial_state.detach().clone().requires_grad_(),)
+    d_output = torch.randn(inputs[2].shape, device="cuda", generator=generator).to(inputs[2].dtype)
+    gradients = partial(
+        op.backward or op.public_gradients, inputs, initial_state, cu_seqlens, scale=scale
     )
-    output, final_state = op.chunk(
-        *leaves, cu_seqlens=cu_seqlens, output_final_state=True, scale=scale
-    )
-    d_output = torch.randn(output.shape, device="cuda", generator=generator).to(output.dtype)
     if loss == "output-only":
-        expected = torch.autograd.grad(output, leaves, d_output)
+        expected = gradients(d_output, None)
         d_final_state = torch.zeros_like(d_final_state)
     elif loss == "final-state-only":
-        expected = torch.autograd.grad(final_state, leaves, d_final_state)
+        expected = gradients(None, d_final_state)
         d_output = None
     else:
-        expected = torch.autograd.grad((output, final_state), leaves, (d_output, d_final_state))
+        expected = gradients(d_output, d_final_state)
 
     prepared = op.prepare(*inputs, cu_seqlens=cu_seqlens, scale=scale)
     prepared.run(initial_state, output_final_state=True)
@@ -376,6 +423,16 @@ def test_prepare_backward_run_matches_chunk_op_gradients(op, scale, loss, state,
         torch.testing.assert_close(
             got, want, atol=0, rtol=0, msg=lambda m, name=name: f"{name}: {m}"
         )
+    if op.backward is not None:
+        # The native kernel is not the public op's backward; it must still agree with it to
+        # within the two kernels' BF16 rounding (both are FP32-accumulated over the same graph).
+        public = op.public_gradients(
+            inputs, initial_state, cu_seqlens, d_output, d_final_state, scale=scale
+        )
+        for name, got, want in zip(names, actual, public, strict=True):
+            assert_relative_rms_within(
+                got.float(), want.float(), f"{name} vs public op", max_eps=4.0
+            )
 
 
 @requires_kda_target
@@ -677,8 +734,8 @@ def test_simulated_context_parallel_matches_unsharded_op(op, cu_seqlens, layout,
     generator = torch.Generator(device="cuda").manual_seed(5)
     d_output = torch.randn(output.shape, device="cuda", generator=generator).to(output.dtype)
     d_final_state = torch.randn(final_state.shape, device="cuda", generator=generator)
-    expected_grads = torch.autograd.grad(
-        (output, final_state), inputs, grad_outputs=(d_output, d_final_state)
+    expected_grads = (op.backward or op.public_gradients)(
+        (q, k, v, gate, beta), None, offsets, d_output, d_final_state
     )
 
     # Sharding must not cost accuracy: measure both paths against the FP32 eager oracle.


### PR DESCRIPTION
Stacked PRs:
 * #531
 * #530
 * #529
 * #528
 * __->__#527


--- --- ---

Run the staged Mega backward on Mega's stateful kernels

The staged Mega handles' backward (ChunkKDAMegaBackward.run) now runs Mega's own checkpoint
recompute and BT16 backward with an entry state and exit cotangent instead of the fused with-state
backward, so a Mega forward under context parallelism is paired with a Mega backward. Two
fixed-arity ops share the launcher: kda_chunk_mega_packed_bwd_with_state requires the entry state
and returns its cotangent; kda_chunk_mega_packed_bwd_with_exit_cotangent has no entry state and
returns the five token gradients. Two fragments of a document cut on a 16-token boundary that
exchange Mega's own state and cotangent reproduce one native call bitwise.

This is a new numerical baseline for Mega gradients under CP (native BT16 dgate is up to about
2x less accurate than the fused staged backward on some inputs, still under one bf16 eps and
inside the pointwise budget); no standard-CP tolerance changed. Reverse summaries still use the
fused factors.