### PR TITLE
Summarize subsequences with Mega's own kernels and use them for standard Mega CP

### DIFF
--- a/attn_gym/linear/_delta_rule/cute/affine_summary_fwd.py
+++ b/attn_gym/linear/_delta_rule/cute/affine_summary_fwd.py
@@ -30,8 +30,9 @@ Terms (see also NOTE [Terminology] in ``attn_gym.linear.context_parallel``):
     chunk         64 tokens (``BT``). The factor kernels lay chunks from each subsequence's
                   first token, so every subsequence has its own chunk grid.
     range         one row of ``bounds``: ``[start, stop)`` of whole chunks inside one
-                  subsequence of the span (NOTE [Summary ranges are whole chunks of one
-                  subsequence] in ``attn_gym.linear.kda.stages``), which gets its own
+                  subsequence of the span (the staged contract only promises whole
+                  subsequences, NOTE [Summary ranges are subsequences] in
+                  ``attn_gym.linear.kda.stages``), which gets its own
                   ``[bias; transition]`` summary. ``R`` = number of rows. A range never spans
                   two documents; a row with ``start == stop`` scans nothing and yields the
                   identity.

--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_recompute_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_recompute_f16.py
@@ -361,7 +361,8 @@ def tmaldg_warp(
         desc_gate_slot = (desc_gate_base + slot).tospace(cutlass.AddressSpace.generic)
         if elect_one:
             tma_tensormap_acquire(desc_k_slot)
-            tma_tensormap_acquire(desc_v_slot)
+            if cutlass.const_expr(not cfg.transition_only):
+                tma_tensormap_acquire(desc_v_slot)
             tma_tensormap_acquire(desc_gate_slot)
         use_packed_coords = batch_end == packed_tokens
         for chunk_idx in cutlass.range(cstart, wend, 1, unroll=1):
@@ -389,13 +390,14 @@ def tmaldg_warp(
             tma_load_tile(sGate_tma[raw_index.idx], gate_slice, bars.mb_gate_ready[raw_index.idx].smem_ptr)
 
             # ---- V load ----------------------------------------------------------
-            bars.mb_v_done[raw_index.idx].wait(raw_index.phase)
-            if elect_one:
-                bars.mb_v_ready[raw_index.idx].arrive(n_bytes=cfg.tma_v_bytes)
-            v_slice = tma_slice_runtime_desc(
-                desc_v_slot, cutlass.Int32(0), head_v, input_chunk_start
-            )
-            tma_load_tile(sV_tma[raw_index.idx], v_slice, bars.mb_v_ready[raw_index.idx].smem_ptr)
+            if cutlass.const_expr(not cfg.transition_only):
+                bars.mb_v_done[raw_index.idx].wait(raw_index.phase)
+                if elect_one:
+                    bars.mb_v_ready[raw_index.idx].arrive(n_bytes=cfg.tma_v_bytes)
+                v_slice = tma_slice_runtime_desc(
+                    desc_v_slot, cutlass.Int32(0), head_v, input_chunk_start
+                )
+                tma_load_tile(sV_tma[raw_index.idx], v_slice, bars.mb_v_ready[raw_index.idx].smem_ptr)
 
             raw_index = advance(raw_index, cfg.smem_raw_stages)
         tile_idx, sched_state = sched_publish_next(cfg, bars, sSched, mSched, sched_state, tile_idx, num_ctas)
@@ -715,7 +717,7 @@ def tcgen05_mma_warp(
         num_chunks_tile = wend - cstart
         for local_chunk_idx in cutlass.range(num_chunks_tile, unroll=1):
             cum_chunk = cum_chunk_base + local_chunk_idx
-            have_state = cutlass.Boolean(True) if cutlass.const_expr(cfg.use_initial_state) else local_chunk_idx > 0
+            have_state = cutlass.Boolean(True) if cutlass.const_expr(cfg.use_initial_state or cfg.transition_only) else local_chunk_idx > 0
             decay_stage = k_decay_ready.idx
             state_scale_diag_stage = qk_scale_index.idx
             intermediate_stage = t_inv_ready.idx
@@ -1306,6 +1308,16 @@ def compute1_warp_group(
         if num_chunks_tile > 0:
             # ---- first chunk: seed state TMEM from mState_init ----------
             seed_from_initial_state = cstart == 0
+            if cutlass.const_expr(cfg.transition_only):
+                for key_block_start in cutlass.range_constexpr(0, cfg.d_k, 32):
+                    identity_block = cute.make_rmem_tensor((32,), cutlass.Float32)
+                    for col in cutlass.range_constexpr(32):
+                        identity_block[col] = (value_dim == key_block_start + col).to(cutlass.Float32)
+                    nvvm.tcgen05_st(
+                        "32x32b",
+                        nvvm.make_tmem_ptr((row_id << 16) + (tmem_col + cfg.tmem_state_acc_offset + key_block_start), cutlass.Float32),
+                        identity_block.load(),
+                    )
             if cutlass.const_expr(mState_init is not None):
                 if seed_from_initial_state:
                     seed_vw = 16 // (mState_init.element_type.width // 8)
@@ -1333,13 +1345,13 @@ def compute1_warp_group(
                             nvvm.make_tmem_ptr((row_id << 16) + (tmem_col + cfg.tmem_state_acc_offset + key_block_start), cutlass.Float32),
                             state_block.load(),
                         )
-            if cutlass.const_expr(mState_init is not None):
+            if cutlass.const_expr(mState_init is not None or cfg.transition_only):
                 nvvm.tcgen05_wait("store")
             sV_ptr = smem_data_ptr(sV_raw) + raw_index.idx * (cfg.d_v * cfg.b_t)
             sBeta_ptr = smem_data_ptr(sBeta_raw) + raw_index.idx * cfg.b_t
 
             # ---- state repack: acc TMEM -> packed b16 TMEM ----------------------
-            if cutlass.const_expr(mState_init is not None):
+            if cutlass.const_expr(mState_init is not None or cfg.transition_only):
                 state_vecs = []
                 for sub in cutlass.range_constexpr(cfg.d_k // 16):
                     state_vecs.append(nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(row_addr + state_col_id + sub * 16, cutlass.Float32), num=16))
@@ -1400,19 +1412,23 @@ def compute1_warp_group(
                     bars.mb_checkpoint_tmastg_ready[checkpoint_stage].arrive()
 
             # ---- Y staging: Y = Beta * (V - State*K) -----------------------------
-            bars.mb_v_ready[raw_index.idx].wait(raw_index.phase)
-            raw_v_frag0 = nvvm.ldmatrix(
-                sV_ptr + v_swz_off0,
-                4,
-                nvvm.MMALayout.COL,
-            )
-            raw_v_frag1 = nvvm.ldmatrix(
-                sV_ptr + v_swz_off,
-                4,
-                nvvm.MMALayout.COL,
-            )
+            if cutlass.const_expr(cfg.transition_only):
+                raw_v_frag0 = tuple(cutlass.Int32(0) for _ in range(4))
+                raw_v_frag1 = tuple(cutlass.Int32(0) for _ in range(4))
+            else:
+                bars.mb_v_ready[raw_index.idx].wait(raw_index.phase)
+                raw_v_frag0 = nvvm.ldmatrix(
+                    sV_ptr + v_swz_off0,
+                    4,
+                    nvvm.MMALayout.COL,
+                )
+                raw_v_frag1 = nvvm.ldmatrix(
+                    sV_ptr + v_swz_off,
+                    4,
+                    nvvm.MMALayout.COL,
+                )
             bars.mb_beta_ready[raw_index.idx].wait(raw_index.phase)
-            if cutlass.const_expr(mState_init is not None):
+            if cutlass.const_expr(mState_init is not None or cfg.transition_only):
                 bars.mb_state_k_acc_ready.wait(state_k_acc_index.phase)
 
                 state_k_vec0 = nvvm.tcgen05_ld("16x256b", nvvm.make_tmem_ptr(row_addr + statek_col_id, cutlass.Float32), num=2)
@@ -1427,7 +1443,7 @@ def compute1_warp_group(
             for reg_idx in cutlass.range_constexpr(4):
                 raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
                 frag_pair = (reg_idx ^ 2) * 2
-                if cutlass.const_expr(mState_init is not None):
+                if cutlass.const_expr(mState_init is not None or cfg.transition_only):
                     y_inp_pack0[reg_idx], _, _ = beta_residual_f16x2(
                         raw_v_frag0[raw_matrix],
                         beta_regs[2 * reg_idx],
@@ -1448,7 +1464,7 @@ def compute1_warp_group(
             for reg_idx in cutlass.range_constexpr(4):
                 raw_matrix = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
                 frag_pair = (reg_idx ^ 2) * 2
-                if cutlass.const_expr(mState_init is not None):
+                if cutlass.const_expr(mState_init is not None or cfg.transition_only):
                     y_inp_pack1[reg_idx], _, _ = beta_residual_f16x2(
                         raw_v_frag1[raw_matrix],
                         beta_regs[2 * reg_idx],
@@ -1468,9 +1484,10 @@ def compute1_warp_group(
             nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row_addr + y_inp_col_id, cutlass.Int8), y_inp_pack0.load())
             nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row16_addr + y_inp_col_id, cutlass.Int8), y_inp_pack1.load())
             nvvm.tcgen05_wait("store")
-            if cutlass.const_expr(mState_init is not None):
+            if cutlass.const_expr(mState_init is not None or cfg.transition_only):
                 state_k_acc_index = advance(state_k_acc_index, 1)
-            bars.mb_v_done[raw_index.idx].arrive()
+            if cutlass.const_expr(not cfg.transition_only):
+                bars.mb_v_done[raw_index.idx].arrive()
             bars.mb_beta_done[raw_index.idx].arrive()
             bars.mb_y_inp_ready.arrive()
 
@@ -1563,17 +1580,21 @@ def compute1_warp_group(
                     bars.mb_state_acc_read_done.arrive()
 
             # ---- Y staging: Y = Beta * (V - State*K) -----------------------------
-            bars.mb_v_ready[raw_index.idx].wait(raw_index.phase)
-            raw_v_frag0 = nvvm.ldmatrix(
-                sV_ptr + v_swz_off0,
-                4,
-                nvvm.MMALayout.COL,
-            )
-            raw_v_frag1 = nvvm.ldmatrix(
-                sV_ptr + v_swz_off,
-                4,
-                nvvm.MMALayout.COL,
-            )
+            if cutlass.const_expr(cfg.transition_only):
+                raw_v_frag0 = tuple(cutlass.Int32(0) for _ in range(4))
+                raw_v_frag1 = tuple(cutlass.Int32(0) for _ in range(4))
+            else:
+                bars.mb_v_ready[raw_index.idx].wait(raw_index.phase)
+                raw_v_frag0 = nvvm.ldmatrix(
+                    sV_ptr + v_swz_off0,
+                    4,
+                    nvvm.MMALayout.COL,
+                )
+                raw_v_frag1 = nvvm.ldmatrix(
+                    sV_ptr + v_swz_off,
+                    4,
+                    nvvm.MMALayout.COL,
+                )
             bars.mb_beta_ready[raw_index.idx].wait(raw_index.phase)
 
             # ---- read back State*K acc -------------------------------------------
@@ -1616,7 +1637,8 @@ def compute1_warp_group(
             nvvm.tcgen05_st("16x128b", nvvm.make_tmem_ptr(st_row16_addr + y_inp_col_id, cutlass.Int8), y_inp_pack1.load())
             nvvm.tcgen05_wait("store")
             state_k_acc_index = advance(state_k_acc_index, 1)
-            bars.mb_v_done[raw_index.idx].arrive()
+            if cutlass.const_expr(not cfg.transition_only):
+                bars.mb_v_done[raw_index.idx].arrive()
             bars.mb_beta_done[raw_index.idx].arrive()
             bars.mb_y_inp_ready.arrive()
 
@@ -1681,7 +1703,9 @@ def compute1_warp_group(
                 for key_block_start in cutlass.range_constexpr(0, cfg.d_k, 32):
                     for col in cutlass.range_constexpr(32):
                         key_dim = key_block_start + col
-                        if cutlass.const_expr(mState_init is not None):
+                        if cutlass.const_expr(cfg.transition_only):
+                            mState_out[batch_idx, head_o, value_dim, key_dim] = (value_dim == key_dim).to(mState_out.element_type)
+                        elif cutlass.const_expr(mState_init is not None):
                             mState_out[batch_idx, head_o, value_dim, key_dim] = mState_init[batch_idx, head_o, value_dim, key_dim]
                         else:
                             mState_out[batch_idx, head_o, value_dim, key_dim] = cutlass.Float32(0.0).to(mState_out.element_type)
@@ -1715,6 +1739,7 @@ class KdaRecomputeOp:
             f"c{int(cfg.enable_checkpoints)}l{int(cfg.l2norm)}"
             f"g{int(cfg.safe_gate)}b{int(cfg.beta_sigmoid)}d{int(cfg.dyn_sched)}"
             f"_sm{cfg.max_active_clusters}_i64{int(self.use_int64_offsets)}{gate_scale}"
+            + ("_transition" if cfg.transition_only else "")
         )
 
     @cute.jit
@@ -1870,7 +1895,10 @@ def kernel(
         cute.make_layout((cfg.intermediate_cosize,))
     )
     sK_raw = storage.k.get_tensor(cute.make_layout((cfg.k_cosize,)))
-    sV_raw = storage.v.get_tensor(cute.make_layout((cfg.v_cosize,)))
+    sV_raw = (
+        sK_raw if cutlass.const_expr(cfg.transition_only)
+        else storage.v.get_tensor(cute.make_layout((cfg.v_cosize,)))
+    )
     sGate_raw = storage.gate.get_tensor(cute.make_layout((cfg.gate_cosize,)))
     sState_scale_diag_raw = storage.state_scale_diag.get_tensor(
         cute.make_layout((cfg.state_scale_diag_cosize,))
@@ -2105,6 +2133,7 @@ class KdaRecomputeCfg:
     n_heads_out: int
     max_active_clusters: int
     dyn_sched: bool = False
+    transition_only: bool = False
     sched_stages: int = CFG.SMEM_SCHED_STAGES
 
     compute_group_0_warp_ids: tuple[int, ...] = CFG.COMPUTE_GROUP_0_WARP_IDS
@@ -2179,6 +2208,7 @@ def build_cfg(
     n_heads_out: int,
     max_active_clusters: int,
     dyn_sched: bool = False,
+    transition_only: bool = False,
 ) -> KdaRecomputeCfg:
     """Build the per-compile ``KdaRecomputeCfg`` (io_dtype in {Float16, BFloat16});
     fills the derived TMEM column offsets and SMEM buffer cosizes."""
@@ -2199,6 +2229,7 @@ def build_cfg(
         n_heads_out=n_heads_out,
         max_active_clusters=max_active_clusters,
         dyn_sched=dyn_sched,
+        transition_only=transition_only,
     )
     if enable_checkpoints:
         cfg.smem_raw_stages = 6
@@ -2252,7 +2283,7 @@ def build_cfg(
     assert (cfg.tmem_u_inp_offset + (cfg.b_t // 2)) <= 512
 
     cfg.k_cosize = cfg.smem_raw_stages * cfg.d_k * cfg.b_t
-    cfg.v_cosize = cfg.smem_raw_stages * cfg.d_v * cfg.b_t
+    cfg.v_cosize = 0 if transition_only else cfg.smem_raw_stages * cfg.d_v * cfg.b_t
     cfg.gate_cosize = cfg.smem_raw_stages * cfg.d_k * cfg.b_t
     cfg.beta_cosize = cfg.smem_raw_stages * cfg.b_t
     cfg.k_inv_cosize = cfg.smem_decay_stages * cfg.b_t * cfg.d_k
@@ -2516,6 +2547,7 @@ def get_compiled_cache(
     device_major: int,
     device_minor: int,
     num_sm: int,
+    transition_only: bool = False,
 ):
     """Return a mutable dict that lazily stores the compiled kernel."""
     return {}
@@ -2539,6 +2571,7 @@ def compile(
     *,
     num_sm: int,
     checkpoint_every_n_tokens: int,
+    transition_only: bool = False,
 ):
     """JIT-compile one fake-tensor TVM-FFI recompute signature."""
     cfg = build_cfg(
@@ -2556,6 +2589,7 @@ def compile(
         n_heads_out=n_heads_out,
         max_active_clusters=num_sm,
         dyn_sched=dyn_sched,
+        transition_only=transition_only,
     )
     op = KdaRecomputeOp(cfg, use_int64_offsets)
     sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
@@ -2623,6 +2657,7 @@ def chunk_kda_recompute_sm100(
     order_in_prologue: bool = False,
     *,
     tensormap_workspace,
+    transition_only: bool = False,
 ) -> None:
     """Execute the Blackwell BT=16 chunked KDA recompute (state/checkpoints-only)
     kernel.
@@ -2633,7 +2668,7 @@ def chunk_kda_recompute_sm100(
 
     Args:
         k: ``(total_tokens, HK, DK)`` float16/bfloat16
-        v: ``(total_tokens, HV, DV)`` float16/bfloat16
+        v: ``(total_tokens, HV, DV)`` float16/bfloat16; ignored for transition_only
         gate: ``(total_tokens, HO, DK)`` float32.  Natural-log decay unless
               ``safe_gate``, which applies the safe-gate transform
               ``lower_bound * sigmoid(exp(a_log) * (gate + dt_bias))``.
@@ -2650,6 +2685,9 @@ def chunk_kda_recompute_sm100(
         output_state_checkpoints: ``(total_checkpoints, HO, DV, DK)`` io-dtype (VK, K
             contiguous); per-sequence entry offsets are derived on device from
             ``cu_seqlens``, so there is no separate checkpoint-offset tensor.
+        transition_only: seed identity on chip and use zero V, defining the native approximate
+            right transition in ``state_next = state @ A + B``. Requires unsplit work items,
+            no initial state/checkpoints and a final-state output.
         use_qk_l2norm_in_kernel: L2-normalize k rows inside the kernel
         safe_gate: interpret ``gate`` through the safe-gate transform
         a_log: ``(HO,)`` float32, safe-gate per-head log-amplitude (None = 0)
@@ -2665,6 +2703,11 @@ def chunk_kda_recompute_sm100(
             every launch (``build_split_table`` does this when it is passed as
             ``sched_ctr``).  None keeps the static CTA stride.
     """
+    if transition_only:
+        if initial_state is not None or checkpoint_every_n_tokens or output_state is None:
+            raise ValueError("transition_only requires final state, no initial state or checkpoints")
+        # Keep the tensor ABI, but never read V or allocate its SMEM ring.
+        v = k
     for name, tensor in (("k", k), ("v", v), ("gate", gate)):
         validate_tma_tensor(name, tensor)
     for name, tensor in (
@@ -2782,6 +2825,7 @@ def chunk_kda_recompute_sm100(
         device_properties.major,
         device_properties.minor,
         num_sm,
+        transition_only,
     )
 
     io_dtype = get_dtype(k.dtype)
@@ -2803,6 +2847,7 @@ def chunk_kda_recompute_sm100(
             use_int64_offsets,
             num_sm=num_sm,
             checkpoint_every_n_tokens=checkpoint_every_n_tokens,
+            transition_only=transition_only,
         )
 
     if "prologue" not in cache:

--- a/attn_gym/linear/_delta_rule/mega/state_summary.py
+++ b/attn_gym/linear/_delta_rule/mega/state_summary.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Native BT16 affine probes for whole packed sequences.
+
+Forward maps pack [B; A] for ``exit = entry @ A + B``.
+Native state/operand rounding makes these approximate affine
+maps, not bitwise reconstruction of an ordinary unsharded Mega run. Every probe is unsplit,
+so its arithmetic is independent of sequence ownership and packed token count.
+"""
+
+from __future__ import annotations
+
+from types import ModuleType
+
+import torch
+import triton
+import triton.language as tl
+
+from attn_gym._backends.cute.utils import initialized_cuda_device
+from attn_gym.utils import ceildiv
+
+from .forward import validate_available
+from .kernels import kda_recompute_f16
+from .kernels.common.host import tensormap_workspace_bytes
+from .schedule import MegaSchedule, prepare_mega_schedule
+
+
+@triton.jit
+def _select_summary_work(cu, bounds, work, count, HEADS: tl.constexpr, ROWS: tl.constexpr):
+    """Keep one native work item per sequence/head, neutralizing unrequested sequences."""
+    seq = tl.program_id(0)
+    head = tl.program_id(1)
+    start, stop = tl.load(cu + seq), tl.load(cu + seq + 1)
+    rows = tl.arange(0, triton.next_power_of_2(ROWS))
+    lo = tl.load(bounds + 2 * rows, rows < ROWS, other=-1)
+    hi = tl.load(bounds + 2 * rows + 1, rows < ROWS, other=-1)
+    selected = tl.sum(((lo == start) & (hi == stop) & (lo < hi)).to(tl.int32), 0) > 0
+    stop = tl.where(selected, stop, start)
+    chunks = tl.cdiv(stop - start, 16)
+    # Native row: [seq, head, wstart, wend, cstart, cend, token_start, token_stop].
+    fields = tl.arange(0, 8)
+    row = tl.where(fields == 0, seq, tl.where(fields == 1, head, 0))
+    row = tl.where((fields == 3) | (fields == 5), chunks, row)
+    row = tl.where(fields == 6, start, tl.where(fields == 7, stop, row))
+    tl.store(work + (seq * HEADS + head) * 8 + fields, row)
+    if (seq == 0) & (head == 0):
+        tl.store(count, tl.num_programs(0) * HEADS)
+
+
+@triton.jit
+def _gather_summary_rows(
+    maps, cu, bounds, output, HEADS: tl.constexpr, SEQUENCES: tl.constexpr, BLOCK: tl.constexpr
+):
+    """Map each subsequence bound to its summary, or synthesize the empty identity.
+
+    A nonempty row that is not a subsequence (NOTE [Summary ranges are subsequences] in
+    ``attn_gym.linear.kda.stages``) is filled with NaN so the mistake surfaces at the first
+    compose instead of silently using another subsequence's map.
+    """
+    row, head, block = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    start, stop = tl.load(bounds + row * 2), tl.load(bounds + row * 2 + 1)
+    seqs = tl.arange(0, triton.next_power_of_2(SEQUENCES))
+    lo = tl.load(cu + seqs, seqs < SEQUENCES, other=-1)
+    hi = tl.load(cu + seqs + 1, seqs < SEQUENCES, other=-1)
+    matches = (lo == start) & (hi == stop)
+    seq = tl.max(tl.where(matches, seqs, 0), 0)
+    offsets = block * BLOCK + tl.arange(0, BLOCK)
+    value = tl.load(maps + (seq * HEADS + head) * (256 * 128) + offsets)
+    # [0; I]: diagonal ones live only in the lower 128 rows.
+    identity = (offsets // 128 == 128 + offsets % 128).to(tl.float32)
+    value = tl.where(start == stop, identity, value)
+    valid = (start == stop) | (tl.sum(matches.to(tl.int32), 0) > 0)
+    value = tl.where(valid, value, float("nan"))
+    tl.store(output + (row * HEADS + head) * (256 * 128) + offsets, value)
+
+
+def build_mega_state_summaries(
+    k: torch.Tensor,
+    value: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    *,
+    bounds: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Return FP32 ``[N, H, 256, 128]`` maps packed as ``[B; A]`` for subsequences.
+
+    B is the no-state final state; A is the identity-seeded, zero-value final state.
+    Inputs use staged ``[1, T, H, 128]`` layout, FP32 gate/beta, and normalized keys.
+    Optional contiguous int32 ``bounds[R, 2]`` on k.device select, reorder, or duplicate
+    consecutive cu_seqlens pairs. Empty intervals yield ``[0; I]``; zero rows yield no maps.
+    Bounds values stay on device and may change during CUDA Graph replay.
+    """
+    maps = _build_mega_state_probes(k, value, gate, beta, cu_seqlens, bounds)
+    return _summary_rows(maps, cu_seqlens, bounds)
+
+
+def _summary_rows(
+    maps: torch.Tensor, cu_seqlens: torch.Tensor, bounds: torch.Tensor | None
+) -> torch.Tensor:
+    """Gather selected probes only after native kernels finish writing by sequence index."""
+    if bounds is None:
+        return maps
+    sequences, heads = maps.shape[:2]
+    selected = torch.empty(bounds.shape[0], heads, 256, 128, device=maps.device, dtype=maps.dtype)
+    if bounds.shape[0]:
+        with initialized_cuda_device(maps):
+            _gather_summary_rows[(bounds.shape[0], heads, 32)](
+                maps, cu_seqlens, bounds, selected, heads, sequences, 1024
+            )
+    return selected
+
+
+def _prepare_summary_launch(
+    gate: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    bounds: torch.Tensor | None,
+    kernel: ModuleType,
+) -> tuple[MegaSchedule, torch.Tensor]:
+    """Allocate native launch buffers and select subsequence work without a host sync.
+
+    With bounds, the caller must reset counters before each probe and disable prologue
+    ordering; otherwise the prologue generates all work and resets counters itself.
+    """
+    sequences, heads = cu_seqlens.shape[0] - 1, gate.shape[2]
+    schedule = prepare_mega_schedule(
+        gate,
+        cu_seqlens,
+        tile_tokens=16,
+        counter_count=2,
+        split=False,
+        stream=torch.cuda.current_stream(gate.device).cuda_stream,
+    )
+    if bounds is not None:
+        _select_summary_work[(sequences, heads)](
+            cu_seqlens, bounds, schedule.work_items, schedule.work_count, heads, bounds.shape[0]
+        )
+    workspace = torch.empty(
+        ceildiv(tensormap_workspace_bytes(kernel, sequences), 8),
+        dtype=torch.int64,
+        device=gate.device,
+    )
+    return schedule, workspace
+
+
+def _build_mega_state_probes(
+    k: torch.Tensor,
+    value: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    bounds: torch.Tensor | None,
+) -> torch.Tensor:
+    """Probe selected sequences into full-size storage indexed by the native sequence IDs."""
+    validate_available(k)
+    if k.ndim != 4 or k.shape[0] != 1 or k.shape[-1] != 128:
+        raise ValueError("k must have shape [1, T, H, 128]")
+    if value.shape != k.shape or gate.shape != k.shape or beta.shape != k.shape[:3]:
+        raise ValueError("value, gate, and beta must match k's token and head extents")
+    if k.dtype not in (torch.float16, torch.bfloat16) or value.dtype != k.dtype:
+        raise TypeError("k and value must share dtype float16 or bfloat16")
+    if gate.dtype != torch.float32 or beta.dtype != torch.float32:
+        raise TypeError("gate and beta must be float32")
+    if any(t.device != k.device for t in (value, gate, beta, cu_seqlens)):
+        raise ValueError("all inputs must be on k.device")
+    if bounds is not None and (
+        bounds.ndim != 2
+        or bounds.shape[1] != 2
+        or bounds.dtype != torch.int32
+        or bounds.device != k.device
+        or not bounds.is_contiguous()
+    ):
+        raise ValueError("bounds must be contiguous int32 [R, 2] on k.device")
+
+    with initialized_cuda_device(k):
+        num_sequences, heads = cu_seqlens.shape[0] - 1, k.shape[2]
+        summaries = torch.zeros(
+            num_sequences, heads, 256, 128, dtype=torch.float32, device=k.device
+        )
+        summaries[:, :, 128:, :].diagonal(dim1=-2, dim2=-1).fill_(1)
+        if k.shape[1] != 0 and (bounds is None or bounds.shape[0] != 0):
+            schedule, workspace = _prepare_summary_launch(
+                gate, cu_seqlens, bounds, kda_recompute_f16
+            )
+            for transition_only in (False, True):
+                if bounds is not None:
+                    schedule.counters.zero_()
+                kda_recompute_f16.chunk_kda_recompute_sm100(
+                    k[0],
+                    None if transition_only else value[0],
+                    gate[0],
+                    beta[0],
+                    cu_seqlens,
+                    initial_state=None,
+                    output_state=summaries[:, :, 128:, :]
+                    if transition_only
+                    else summaries[:, :, :128, :],
+                    work_items=schedule.work_items,
+                    work_count=schedule.work_count,
+                    sched_ctr=schedule.counters,
+                    sched_all=schedule.counters,
+                    order_in_prologue=bounds is None,
+                    tensormap_workspace=workspace,
+                    transition_only=transition_only,
+                )
+        return summaries

--- a/attn_gym/linear/context_parallel.py
+++ b/attn_gym/linear/context_parallel.py
@@ -110,9 +110,8 @@ integers; ``plan.routing(device)`` turns it into the span-local tensors the kern
 
 The key contract: the routing hands ``state_summaries`` / ``state_grad_summaries`` exactly one
 whole subsequence per active fragment slot, as consecutive entries of the span's own
-``cu_seqlens`` (LOCAL). Direct callers must obey NOTE [Summary ranges are whole chunks of one
-subsequence] in ``kda.stages`` themselves; the bounds' shape and dtype are checked, their values
-are not.
+``cu_seqlens`` (LOCAL). Direct callers must obey NOTE [Summary ranges are subsequences] in
+``kda.stages`` themselves; the bounds' shape and dtype are checked, their values are not.
 
 What the table does not constrain:
 
@@ -653,7 +652,11 @@ class PreparedForward(Protocol):
         ...
 
     def state_summaries(self, bounds: torch.Tensor) -> torch.Tensor:
-        """One ``[HV, V + K, K]`` affine summary per ``[start, stop)`` row of ``bounds``."""
+        """One ``[HV, V + K, K]`` affine summary per ``[start, stop)`` row of ``bounds``.
+
+        Every nonempty row is one subsequence of the span (NOTE [Summary ranges are subsequences]
+        in ``attn_gym.linear.kda.stages``); ``start == stop`` is the identity.
+        """
         ...
 
     def run(

--- a/attn_gym/linear/kda/context_parallel.py
+++ b/attn_gym/linear/kda/context_parallel.py
@@ -41,11 +41,20 @@ def context_parallel_kda(
 
     See ``attn_gym.linear.context_parallel.context_parallel_chunk`` for the argument contract;
     ``scale``, ``autotune``, and ``kernel_options`` follow ``chunk_kda``. With
-    ``kernel_options={"backend": "mega"}`` the local pass runs on Mega and the fused factors are
-    computed once over the span for the summaries. Its backward is Mega's native stateful kernel,
-    so ``fastmath`` applies only to the fused backend's backward.
+    ``kernel_options={"backend": "mega"}`` the local pass and forward summaries run on Mega
+    (native BT16 probes define a new standard-CP numerical baseline); only reverse summaries
+    still use fused factors. Its backward is Mega's native stateful kernel, so ``fastmath``
+    applies only to the fused backend's backward.
     """
-    stages = StagedOp(
+    stages = _kda_stages(scale, autotune, fastmath, kernel_options)
+    return context_parallel_chunk(stages, q, k, v, gate, beta, routing=routing, group=group)
+
+
+def _kda_stages(
+    scale: float | None, autotune: bool, fastmath: bool, kernel_options: KernelOptions | None
+) -> StagedOp:
+    """Bind ``chunk_kda``'s options to its staged entry points."""
+    return StagedOp(
         partial(chunk_kda_prepare, scale=scale, autotune=autotune, kernel_options=kernel_options),
         partial(
             chunk_kda_prepare_backward,
@@ -54,7 +63,6 @@ def context_parallel_kda(
             schedule=resolve_kernel_options(kernel_options).schedule,
         ),
     )
-    return context_parallel_chunk(stages, q, k, v, gate, beta, routing=routing, group=group)
 
 
 __all__ = ["context_parallel_kda"]

--- a/attn_gym/linear/kda/stages.py
+++ b/attn_gym/linear/kda/stages.py
@@ -101,21 +101,17 @@ class ChunkKDAMegaSaved(NamedTuple):
     chunk_offsets: torch.Tensor
 
 
-# NOTE [Summary ranges are whole chunks of one subsequence]
+# NOTE [Summary ranges are subsequences]
 # ``state_summaries(bounds)`` and ``state_grad_summaries(bounds)`` take an ``int32 [R, 2]``
 # device tensor of LOCAL span offsets (see NOTE [Terminology] in ``attn_gym.linear.context_parallel``).
-# The factor kernels lay 64-token chunks from each subsequence's first token, and every chunk's
-# factors are scaled toward that chunk's last token, so a row is exact only over whole chunks of
-# one subsequence:
-#
-#     start = sub_start + CHUNK_SIZE * i
-#     stop  = sub_start + CHUNK_SIZE * j   or   stop = sub_end   (the partial tail chunk is fine)
-#     [start, stop) must not cross a ``cu_seqlens`` boundary;  start == stop is the identity
-#
-# The context-parallel routing always passes whole subsequences, ``(cu_seqlens[i],
-# cu_seqlens[i + 1])``, which satisfies this trivially. A row that starts or stops mid-chunk, or
-# spans two subsequences, returns a plausible but wrong map. The values are not checked: they live
-# on the device so the launch replays under CUDA Graph capture, and reading them back would sync.
+# Every nonempty row must be one subsequence, ``(cu_seqlens[i], cu_seqlens[i + 1])``, in any
+# order and selection; ``start == stop`` is the identity map. That is what the context-parallel
+# routing produces: a rank summarizes its whole piece of a document, never part of it. The fused
+# kernels would also sum an interior run of 64-token chunks of one subsequence, but that is not
+# part of the contract and Mega's kernels cannot do it. The values are not checked: they live on
+# the device so the launch replays under CUDA Graph capture, and reading them back would sync; a
+# row that matches no subsequence is filled with NaN on Mega and returns a plausible but wrong map
+# on the fused kernels.
 
 
 def _normalize_state(state: torch.Tensor | None) -> torch.Tensor | None:
@@ -163,12 +159,16 @@ class ChunkKDAPrepared:
         """Return one FP32 ``[HV, V + K, K]`` map per row of ``bounds`` in a single launch.
 
         ``bounds`` is an ``int32 [R, 2]`` device tensor of ``[start, stop)`` span offsets, each
-        obeying NOTE [Summary ranges are whole chunks of one subsequence]; ``start == stop``
-        yields the identity. The ranges are read on the device, so a CUDA Graph captured around
-        this call replays for any layout of the same shape.
+        obeying NOTE [Summary ranges are subsequences]; ``start == stop`` yields the identity. The
+        ranges are read on the device, so a CUDA Graph captured around this call replays for any
+        layout of the same shape.
         """
         return build_state_summaries(
-            self.factors.kg, self.factors.w, self.factors.u, self.saved.cumulative_gate, bounds
+            self.factors.kg,
+            self.factors.w,
+            self.factors.u,
+            self.saved.cumulative_gate,
+            bounds,
         )
 
     def run(
@@ -195,11 +195,11 @@ class ChunkKDAPrepared:
 
 @dataclass
 class ChunkKDAMegaPrepared:
-    """Mega forward handle: on-chip factors for ``run``, fused factors only for summaries.
+    """Mega forward handle: ``run`` is Mega's with-state kernel and summaries are Mega's too.
 
-    Mega never materializes the WY factors, so ``run`` executes the Mega with-state kernel over the
-    whole local stream and ``state_summaries`` computes the fused factors once for the whole stream
-    (its ranges are device values). The backward handle is :class:`ChunkKDAMegaBackward`.
+    Mega keeps its WY factors on chip, so each subsequence's ``[B; A]`` map comes from two runs
+    of Mega's state-only pass over it (from a zero entry state for ``B``, from the identity with
+    the value term disabled for ``A``). The backward handle is :class:`ChunkKDAMegaBackward`.
     """
 
     saved: ChunkKDAMegaSaved
@@ -212,24 +212,15 @@ class ChunkKDAMegaPrepared:
     def state_summaries(self, bounds: torch.Tensor) -> torch.Tensor:
         """Return one FP32 ``[HV, V + K, K]`` map per row of ``bounds`` in a single launch.
 
-        Mega keeps no WY factors, so this factors the whole local stream once (the fused
-        forward's factor half) and summarizes every range from it; see
-        ``ChunkKDAPrepared.state_summaries`` for the contract.
+        Rows follow NOTE [Summary ranges are subsequences]. The maps carry Mega's 16-token-chunk
+        rounding, which differs from the fused maps and from an unsharded Mega pass.
         """
+        # Lazy import keeps the optional CuTeDSL 4.7 backend out of the fused import path.
+        from attn_gym.linear._delta_rule.mega.state_summary import build_mega_state_summaries
+
         saved = self.saved
-        factors = _prepare_chunk_kda_fwd(
-            saved.q,
-            saved.k,
-            saved.v,
-            saved.cumulative_gate,
-            saved.beta,
-            self.metadata,
-            scale=self.scale,
-            autotune=self.autotune,
-            schedule=self.schedule,
-        )
-        return build_state_summaries(
-            factors.kg, factors.w, factors.u, saved.cumulative_gate, bounds
+        return build_mega_state_summaries(
+            saved.k, saved.v, saved.gate, saved.beta, saved.cu_seqlens, bounds=bounds
         )
 
     def run(
@@ -277,8 +268,8 @@ def chunk_kda_prepare(
     float16 or bfloat16 dtype (no silent cast, because the caller owns autograd), and the batch
     dimension must be one so token offsets index one packed span (NOTE [Terminology] in
     ``attn_gym.linear.context_parallel``).
-    ``kernel_options={"backend": "mega"}`` runs the local pass with Mega and computes fused factors
-    only for the summaries; the split schedules are not available with entry states.
+    ``kernel_options={"backend": "mega"}`` runs the local pass and the forward summaries with
+    Mega's kernels. Split schedules are not available with entry states.
     """
     backend, split_backward, split_forward, schedule = resolve_kernel_options(kernel_options)
     if split_backward or split_forward:
@@ -393,10 +384,9 @@ class ChunkKDABackward:
 
 @dataclass
 class ChunkKDAMegaBackward:
-    """Mega backward handle: ``run`` is Mega's stateful backward, summaries use fused factors.
+    """Mega backward handle: ``run`` is Mega's stateful backward.
 
-    ``state_grad_summaries`` recomputes the fused factors on demand over the whole local stream,
-    as the forward handle's ``state_summaries`` does. Nothing is consumed, so ``run`` and
+    Summaries recompute the fused factors on demand. Nothing is consumed, so ``run`` and
     ``state_grad_summaries`` may be called in either order.
     """
 
@@ -410,7 +400,7 @@ class ChunkKDAMegaBackward:
     def state_grad_summaries(self, bounds: torch.Tensor) -> torch.Tensor:
         """Return one FP32 ``[HV, V + K, K]`` reverse map per row of ``bounds`` in one launch.
 
-        Same contract as ``ChunkKDABackward.state_grad_summaries``.
+        Rows follow ``ChunkKDABackward.state_grad_summaries``.
         """
         saved = self.saved
         # The fused backward over the equivalent tape (no materialized factors) owns the recompute.

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -605,17 +605,31 @@ between complete forward/backward steps, not while backward still needs the prev
 
 ### Mega local execution
 
-`kernel_options={"backend": "mega"}` makes `chunk_kda_prepare` and `context_parallel_kda` run each
-local pass with Mega from the composed entry state. Because Mega keeps WY factors on chip,
-`state_summaries` computes the fused factors once over the whole local stream and summarizes
-every range from them; that factor pass is paid even when every fragment ends its document and
-the summaries are identities, since which ranges are empty is a device value under replay. A
-layout that never continues a document across ranks does not need this recipe. The backward
-handle's `run` is Mega's own stateful backward (`attn_gym::kda_chunk_mega_packed_bwd_with_state`:
-checkpoint recompute from the saved entry state, then the BT16 backward folding in the exit
-cotangent), so a document cut at 16-token boundaries reproduces the unsharded Mega gradients bit
-for bit; only `state_grad_summaries` still recomputes the fused factors over the local stream. The
-staged handles and this recipe are eager-only; `torch.compile` is not supported through them.
+`kernel_options={"backend": "mega"}` runs each rank's local passes with Mega's kernels. The
+recipe is the same as for the fused backend: summarize every local range as an affine map of its
+entry state, exchange and compose the maps, then run the local pass from the composed state.
+
+*Forward.* `prepare` stores only the inputs; Mega keeps its WY factors on chip and never writes
+them out. `state_summaries` produces each range's `[B; A]` map (`S_exit = S_entry @ A + B`) by
+running Mega's state-only pass over the range twice: from a zero entry state, whose final state
+is `B`, and from an identity entry state with the value term disabled, whose final state is `A`.
+Which ranges are probed and how their rows are ordered is decided on the device, so the call is
+CUDA Graph replayable and an empty range yields the identity map. This requires every range to be
+a subsequence (one rank's piece of a document, one segment of the local `cu_seqlens`),
+which the CP recipe guarantees; a caller passing arbitrary 64-aligned ranges gets maps computed
+from the fused factors instead. `run` is Mega's forward from the composed entry state.
+
+*Backward.* `run` is Mega's own stateful backward (`kda_chunk_mega_packed_bwd_with_state`):
+the state pass from the saved entry state writes checkpoints, then the BT16 backward consumes
+them together with the exit cotangent, returning the token gradients and the entry-state
+cotangent. `state_grad_summaries` still computes the reverse maps from the fused factors, so the
+Mega backward under CP pays one fused factor pass over the local span in addition to its own.
+
+*Numerics.* A document cut on 16-token boundaries whose fragments exchange Mega's own state and
+cotangent reproduces the unsharded Mega gradients bit for bit. The composed entry states do not:
+the maps carry Mega's 16-token-chunk rounding, so Mega under CP is its own numerical baseline,
+neither the fused CP baseline nor unsharded Mega. The staged handles and this recipe are
+eager-only; `torch.compile` is not supported through them.
 
 ::: attn_gym.linear.context_parallel.context_parallel_chunk
 

--- a/test/kda/mega/test_kda_mega_native_summary.py
+++ b/test/kda/mega/test_kda_mega_native_summary.py
@@ -1,0 +1,236 @@
+"""Native Mega affine probes define a standard Mega CP baseline."""
+
+from __future__ import annotations
+
+from itertools import pairwise
+
+import pytest
+import torch
+
+pytest.importorskip("cutlass.experimental", reason="native Mega summaries require CuTeDSL 4.7")
+
+from attn_gym.linear._delta_rule.mega.kernels import kda_prefill_f16
+from attn_gym.linear._delta_rule.mega.kernels.common.host import tensormap_workspace_bytes
+from attn_gym.linear._delta_rule.mega.schedule import prepare_mega_schedule
+from attn_gym.linear._delta_rule.mega.state_summary import build_mega_state_summaries
+from attn_gym.linear.context_parallel import merge_state
+from attn_gym.linear.kda.stages import chunk_kda_prepare
+from attn_gym.testing.kda import (
+    assert_matches_low_precision_reference,
+    clone_kda_inputs,
+    cumulative_sequence_offsets,
+    kda_reference,
+    make_kda_test_inputs,
+)
+from attn_gym.utils import ceildiv
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() not in ((10, 0), (10, 3)),
+    reason="native Mega summaries require SM100 or SM103",
+)
+
+DTYPES = [torch.bfloat16, torch.float16]
+# Ragged packed span with an empty sequence; cu_seqlens = 0, 17, 17, 82, 211.
+LENGTHS = [17, 0, 65, 129]
+SCALE = 128**-0.5
+MEGA = {"backend": "mega"}
+
+
+def _packed_inputs(
+    lengths: list[int],
+    dtype: torch.dtype = torch.bfloat16,
+    *,
+    heads: int = 1,
+    gate_value: float | None = None,
+) -> tuple[tuple[torch.Tensor, ...], torch.Tensor]:
+    """Normalized-QK inputs with mild gates, plus their packed boundaries."""
+    inputs = make_kda_test_inputs(
+        sum(lengths),
+        heads=heads,
+        dtype=dtype,
+        gate_scale=0.02,
+        gate_value=gate_value,
+        normalize_qk=True,
+    )
+    return inputs, cumulative_sequence_offsets(lengths)
+
+
+def _bounds(rows: list[list[int]]) -> torch.Tensor:
+    """Device ``int32 [R, 2]`` token bounds, one whole (or empty) sequence per row."""
+    return torch.tensor(rows, device="cuda", dtype=torch.int32)
+
+
+def _assert_bitwise_equal(actual: torch.Tensor, expected: torch.Tensor) -> None:
+    """Bit-exact FP32 comparison; unlike ``torch.equal`` it distinguishes signed zeros."""
+    assert torch.equal(actual.view(torch.int32), expected.view(torch.int32))
+
+
+def _forbid_fused_factors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fail if a staged handle materializes fused WY factors on a native-summary path."""
+    for name in ("_prepare_chunk_kda_fwd", "_prepare_chunk_kda_bwd"):
+        monkeypatch.setattr(
+            f"attn_gym.linear.kda.stages.{name}",
+            lambda *args, **kwargs: pytest.fail("native summaries must not prepare fused factors"),
+        )
+
+
+def _native_no_state_final(
+    inputs: tuple[torch.Tensor, ...], cu_seqlens: torch.Tensor
+) -> torch.Tensor:
+    """Run the output-producing native no-state specialization as an independent B oracle."""
+    q, k, value, gate, beta = inputs
+    sequences = cu_seqlens.numel() - 1
+    state = torch.zeros(sequences, q.shape[2], 128, 128, device=q.device)
+    schedule = prepare_mega_schedule(
+        gate,
+        cu_seqlens,
+        tile_tokens=16,
+        counter_count=2,
+        split=False,
+        stream=torch.cuda.current_stream().cuda_stream,
+    )
+    workspace = torch.empty(
+        ceildiv(tensormap_workspace_bytes(kda_prefill_f16, sequences), 8),
+        device=q.device,
+        dtype=torch.int64,
+    )
+    kda_prefill_f16.chunk_kda_sm100(
+        q[0],
+        k[0],
+        value[0],
+        gate[0],
+        beta[0],
+        torch.empty_like(value[0]),
+        cu_seqlens,
+        None,
+        state,
+        SCALE,
+        work_items=schedule.work_items,
+        work_count=schedule.work_count,
+        sched_ctr=schedule.counters,
+        tensormap_workspace=workspace,
+    )
+    return state
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_native_bias_matches_no_state_final_bitwise(dtype: torch.dtype) -> None:
+    inputs, cu = _packed_inputs(LENGTHS, dtype)
+    maps = build_mega_state_summaries(*inputs[1:], cu)
+    _assert_bitwise_equal(maps[:, :, :128].contiguous(), _native_no_state_final(inputs, cu))
+    _assert_bitwise_equal(maps[1, 0, 128:], torch.eye(128, device="cuda"))
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("gate_value,beta_value", [(0.0, None), (-0.002, 0.0), (-0.02, 1.0)])
+def test_native_transition_matches_basis_reference(
+    dtype: torch.dtype, gate_value: float, beta_value: float | None
+) -> None:
+    inputs, cu = _packed_inputs([17], dtype, gate_value=gate_value)
+    inputs = list(inputs)
+    if beta_value is not None:
+        inputs[-1].fill_(beta_value)
+    actual = build_mega_state_summaries(*inputs[1:], cu)[:, :, 128:]
+    inputs[2] = torch.zeros_like(inputs[2])
+    references = []
+    for precision in (torch.float64, torch.float32):
+        # Every V row carries a different basis vector e_i: the final rows are A, not A.T.
+        basis = torch.eye(128, device="cuda", dtype=precision)[None, None]
+        _, final = kda_reference(*clone_kda_inputs(inputs, dtype=precision), basis)
+        assert final is not None
+        references.append(final)
+    assert_matches_low_precision_reference(actual, *references, "transition A", source_dtype=dtype)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_native_two_tile_handoff_matches_fp64(dtype: torch.dtype, monkeypatch) -> None:
+    """Native forward maps hand off states; outputs and finals track FP64."""
+    inputs, cu = _packed_inputs([64, 65], dtype)
+    prepared = chunk_kda_prepare(*inputs, cu_seqlens=cu, autotune=False, kernel_options=MEGA)
+    _forbid_fused_factors(monkeypatch)
+    bounds = torch.stack((cu[:-1], cu[1:]), dim=1)
+    maps = prepared.state_summaries(bounds)
+    entry0 = torch.zeros_like(maps[0, :, :128])
+    entries = torch.stack((entry0, merge_state(entry0, maps[0])))
+    output, final = prepared.run(entries, output_final_state=True)
+    assert final is not None
+    composed_final = merge_state(entries[1], maps[1])
+    references = []
+    for precision in (torch.float64, torch.float32):
+        leaves = tuple(t.requires_grad_() for t in clone_kda_inputs(inputs, dtype=precision))
+        ref_output, ref_final = kda_reference(*leaves, scale=prepared.scale)
+        references.append((ref_output, ref_final, ref_final))
+    for name, actual, high, low in zip(
+        ("output", "native final", "composed final"),
+        (output, final[-1:], composed_final[None]),
+        *references,
+        strict=True,
+    ):
+        assert_matches_low_precision_reference(actual, high, low, name, source_dtype=dtype)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_native_summary_ownership_is_bitwise_invariant(dtype: torch.dtype) -> None:
+    inputs, cu = _packed_inputs(LENGTHS, dtype)
+    packed = build_mega_state_summaries(*inputs[1:], cu)
+    for index, (start, stop) in enumerate(pairwise(cu.tolist())):
+        alone = build_mega_state_summaries(
+            *(tensor[:, start:stop] for tensor in inputs[1:]),
+            cumulative_sequence_offsets([stop - start]),
+        )
+        _assert_bitwise_equal(packed[index : index + 1], alone)
+
+
+def test_native_summary_persistent_waves_are_bitwise_invariant() -> None:
+    """Exercise more than four nonempty work items per physical CTA, including empty tiles."""
+    repeats = 4 * torch.cuda.get_device_properties(0).multi_processor_count // 3 + 1
+    inputs, cu = _packed_inputs(LENGTHS)
+    expected = build_mega_state_summaries(*inputs[1:], cu)
+    repeated = tuple(t.repeat(1, repeats, *([1] * (t.ndim - 2))) for t in inputs[1:])
+    cu = cumulative_sequence_offsets(LENGTHS * repeats)
+    for _ in range(2):
+        actual = build_mega_state_summaries(*repeated, cu).reshape(repeats, *expected.shape)
+        _assert_bitwise_equal(actual, expected[None].expand_as(actual))
+
+
+def test_native_summary_cuda_graph_replay() -> None:
+    inputs, cu = _packed_inputs([17, 0, 64])
+    expected = build_mega_state_summaries(*inputs[1:], cu)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        actual = build_mega_state_summaries(*inputs[1:], cu)
+    graph.replay()
+    _assert_bitwise_equal(actual, expected)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("heads", [1, 64])
+def test_native_selected_bounds(dtype: torch.dtype, heads: int, monkeypatch) -> None:
+    """Selecting subsequences (reordered, duplicated, or empty) on device preserves the bits.
+
+    The staged handles stay native, and bounds may change between CUDA Graph replays.
+    """
+    inputs, cu = _packed_inputs(LENGTHS, dtype, heads=heads)
+    prepared = chunk_kda_prepare(*inputs, cu_seqlens=cu, autotune=False, kernel_options=MEGA)
+    _forbid_fused_factors(monkeypatch)
+    full = build_mega_state_summaries(*inputs[1:], cu)
+    selected = prepared.state_summaries
+    cases = (
+        ([[82, 211], [17, 17], [17, 82], [82, 211]], [3, 1, 2, 3]),
+        ([[0, 17], [17, 17], [82, 211], [0, 0]], [0, 1, 3, 1]),
+        ([[17, 17]] * 4, [1] * 4),
+        ([[17, 82], [82, 211], [0, 17], [17, 82]], [2, 3, 0, 2]),
+    )
+    bounds = _bounds(cases[0][0])
+    _assert_bitwise_equal(selected(bounds=bounds), full[cases[0][1]])
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = selected(bounds=bounds)
+    for rows, indices in cases:
+        bounds.copy_(_bounds(rows))
+        graph.replay()
+        _assert_bitwise_equal(captured, full[indices])
+    assert selected(bounds=bounds[:0]).shape == (0, heads, 256, 128)
+    # A nonempty row that is not a subsequence is poisoned with NaN rather than silently mapped.
+    poisoned = selected(bounds=_bounds([[17, 82], [20, 82], [0, 17]]))
+    assert not poisoned[[0, 2]].isnan().any() and poisoned[1].isnan().all()

--- a/test/test_delta_rule_stages.py
+++ b/test/test_delta_rule_stages.py
@@ -20,7 +20,6 @@ from attn_gym.linear.context_parallel import (
     compose_summaries,
     grad_summary_slots,
     merge_state,
-    neutral_summary,
     summary_slots,
 )
 from attn_gym.linear.gdn import chunk_gdn
@@ -506,81 +505,6 @@ def test_state_grad_summary_matches_zero_and_identity_probes(op):
     assert summaries.shape == (2, op.value_heads, 2 * HEAD_DIM, HEAD_DIM)
     for index in range(2):
         assert_summary_parts_match(summaries[index], fused, oracle, index)
-
-
-@requires_kda_target
-@op_param
-def test_summaries_are_exact_over_whole_chunks_of_one_subsequence(op):
-    """NOTE [Summary ranges are whole chunks of one subsequence]: interior chunk runs compose."""
-    q, k, v, gate, beta = op.make_inputs(520, seed=11)
-    gate = gate / 50
-    # Subsequences [0, 72) and [72, 520); the second has chunk boundaries at 72 + 64 * i.
-    cu_seqlens = torch.tensor([0, 72, 520], dtype=torch.int32, device="cuda")
-    d_output = torch.randn(
-        v.shape, device="cuda", generator=torch.Generator(device="cuda").manual_seed(12)
-    )
-    zero = torch.zeros(2, op.value_heads, HEAD_DIM, HEAD_DIM, device="cuda")
-    prepared = op.prepare(q, k, v, gate, beta, cu_seqlens=cu_seqlens)
-    prepared.run(zero, output_final_state=True)
-    grads = op.prepare_backward(prepared.saved, d_output.to(v.dtype), zero, scale=prepared.scale)
-
-    one = torch.zeros(1, op.value_heads, HEAD_DIM, HEAD_DIM, device="cuda")
-    identity = torch.eye(HEAD_DIM, device="cuda").expand_as(one).contiguous()
-
-    def oracle(start, stop):
-        """Run the FP32 reference on the token range as a sequence of its own and probe it."""
-        sliced = [tensor[:, start:stop] for tensor in (q, k, v, gate, beta)]
-        inputs = [tensor.float() for tensor in sliced[:3]] + sliced[3:]
-
-        def d_entry_state(d_exit_state):
-            entry = one.clone().requires_grad_()
-            output, final_state = op.reference(*inputs, entry, output_final_state=True)
-            (grad,) = torch.autograd.grad(
-                (output, final_state), entry, (d_output[:, start:stop], d_exit_state)
-            )
-            return grad
-
-        _, bias = op.reference(*inputs, one, output_final_state=True)
-        _, shifted = op.reference(*inputs, identity, output_final_state=True)
-        reverse_bias = d_entry_state(one)
-        forward = torch.cat((bias, shifted - bias), dim=-2)[0]
-        reverse = torch.cat((reverse_bias, d_entry_state(identity) - reverse_bias), dim=-2)[0]
-        return forward, reverse
-
-    def standalone(start, stop):
-        """The staged summaries of the token range run as a stream of its own."""
-        sliced = [tensor[:, start:stop] for tensor in (q, k, v, gate, beta)]
-        own = op.prepare(*sliced)
-        own.run(one, output_final_state=True)
-        own_grads = op.prepare_backward(
-            own.saved, d_output[:, start:stop].to(v.dtype), one, scale=own.scale
-        )
-        whole = bounds_of((0, stop - start))
-        return own.state_summaries(whole)[0], own_grads.state_grad_summaries(whole)[0]
-
-    # Rows on the second subsequence's chunk grid: interior runs, a single chunk, a run ending at
-    # the subsequence end, the first chunk alone, and an empty range. One launch summarizes them
-    # all; each interior summary must match the same range summarized on its own, pointwise
-    # within that run's own error against the FP32 oracle and in aggregate.
-    ranges = ((136, 264), (200, 456), (136, 200), (392, 520), (72, 136), (300, 300))
-    forward = prepared.state_summaries(bounds_of(*ranges))
-    reverse = grads.state_grad_summaries(bounds_of(*ranges))
-    assert forward.shape == reverse.shape == (len(ranges), op.value_heads, 2 * HEAD_DIM, HEAD_DIM)
-    empty = neutral_summary(op.value_heads, HEAD_DIM, HEAD_DIM, device="cuda")
-    torch.testing.assert_close(forward[-1], empty, atol=0, rtol=0)
-    torch.testing.assert_close(reverse[-1], empty, atol=0, rtol=0)
-    for index, (start, stop) in enumerate(ranges[:-1]):
-        oracles = oracle(start, stop)
-        for name, actual, expected, low in zip(
-            ("forward", "reverse"),
-            (forward[index], reverse[index]),
-            oracles,
-            standalone(start, stop),
-            strict=True,
-        ):
-            label = f"{name} [{start}, {stop})"
-            assert_matches_low_precision_reference(actual, expected, low, label)
-            assert_relative_rms_within(actual, expected, label, max_eps=1.0)
 
 
 @requires_kda_target


### PR DESCRIPTION
Stacked PRs:
 * #531
 * #530
 * #529
 * __->__#528


--- --- ---

Build whole-sequence Mega summaries natively and use them for standard Mega CP

build_mega_state_summaries emits the FP32 [B; A] map of every packed sequence with Mega's own
kernels: B from a zero-state recompute pass and A from a transition-only recompute specialization
(identity-seeded, no V load) of kda_recompute_f16. Optional device-side bounds select, reorder, or
leave empty whole sequences without a host sync, so the standard CP recipe's summary_slots()
passes whole_sequences=True and Mega CP forward no longer recomputes fused BT64 factors for its
summaries. The fused KDA and GDN handles accept the flag without changing their arithmetic.

Native BT16 probing is a new standard-Mega-CP numerical baseline, not fused parity; tolerances
are unchanged. Two GB200s, 32k tokens, 64 heads, CP2: standard Mega CP forward 2.82 -> 2.18 ms.