### PR TITLE
Add CP-degree-invariant KDA context parallelism over canonical tiles

### DIFF
--- a/attn_gym/linear/_delta_rule/cute/affine_summary_fwd.py
+++ b/attn_gym/linear/_delta_rule/cute/affine_summary_fwd.py
@@ -1196,6 +1196,8 @@ def build_state_summaries(
     u: torch.Tensor,
     cumulative_gate: torch.Tensor,
     bounds: torch.Tensor,
+    *,
+    deterministic_work: bool = False,
 ) -> torch.Tensor:
     """Compute one packed affine state summary per token range of a stream's WY chunk factors.
 
@@ -1210,6 +1212,10 @@ def build_state_summaries(
             64-token chunk grid, ``stop`` on the grid or at the sequence's end (a partial last
             chunk is neutralized in-kernel). The values are not checked (that would sync);
             other ranges return a plausible but wrong map.
+        deterministic_work: Scan each range in one work item with a fixed SM100 column tile,
+            so the recurrence partition does not depend on span length, range count, or SM
+            count. The upstream factor kernels are not pinned; disable their autotuning
+            separately.
 
     Returns:
         FP32 tensor of shape ``[R, H, 256, 128]``, V-first packed as state bias then state
@@ -1284,11 +1290,15 @@ def build_state_summaries(
         kg, w, u, cumulative_gate = (_aligned(tensor) for tensor in (kg, w, u, cumulative_gate))
         # BN=32 is faster per CTA (measured ~1.5x vs BN=64 on GB200); fall back to
         # BN=64 only when the extra column tiles would spill past one CTA wave and
-        # serialize whole recurrence chains.
-        state_bn = 32 if ranges * heads * (SUMMARY_DIM // 32) <= sm_count else 64
+        # serialize whole recurrence chains. Deterministic work pins BN=32.
+        one_wave = ranges * heads * (SUMMARY_DIM // 32) <= sm_count
+        state_bn = 32 if deterministic_work or one_wave else 64
     # The bounds live on the device, so the budget comes from the span's chunk count (a static
     # upper bound) and the device cuts the ranges' actual chunks into that many items.
-    budget = plan_work_budget(cdiv(tokens, BT), heads * (SUMMARY_DIM // state_bn), sm_count)
+    if deterministic_work:
+        budget = 1
+    else:
+        budget = plan_work_budget(cdiv(tokens, BT), heads * (SUMMARY_DIM // state_bn), sm_count)
     work, range_ids = work_table(bounds, budget)
     partials = torch.empty(
         (work.shape[0], heads, SUMMARY_DIM, KEY_DIM), dtype=torch.float32, device=kg.device

--- a/attn_gym/linear/_delta_rule/cute/affine_summary_rev.py
+++ b/attn_gym/linear/_delta_rule/cute/affine_summary_rev.py
@@ -1466,6 +1466,8 @@ def build_state_grad_summaries(
     cumulative_gate: torch.Tensor,
     scale: float,
     bounds: torch.Tensor,
+    *,
+    deterministic_work: bool = False,
 ) -> torch.Tensor:
     """Compute one packed reverse affine summary per token range of a stream.
 
@@ -1479,6 +1481,10 @@ def build_state_grad_summaries(
         scale: Query scaling factor used by the local backward recurrence.
         bounds: ``int32 [R, 2]`` device tensor of half-open token ranges ``[start, stop)``; the
             same contract as ``build_state_summaries``.
+        deterministic_work: Scan each range in one work item, so the recurrence partition does
+            not depend on span length, range count, or SM count (the SM100 column tile is
+            already fixed). The upstream factor kernels are not pinned; disable their autotuning
+            separately.
 
     Returns:
         FP32 tensor of shape ``[R, H, 256, 128]``, V-first packed as local bias then reverse
@@ -1566,9 +1572,12 @@ def build_state_grad_summaries(
         )
         state_bn = BlackwellDeltaAffineSummaryRev.BN
     # As in the forward: a static budget from the span's chunk count, ranges cut on the device.
-    budget = plan_work_budget(
-        cdiv(tokens, BT), heads * (SUMMARY_DIM // state_bn), properties.multi_processor_count
-    )
+    if deterministic_work:
+        budget = 1
+    else:
+        budget = plan_work_budget(
+            cdiv(tokens, BT), heads * (SUMMARY_DIM // state_bn), properties.multi_processor_count
+        )
     work, range_ids = work_table(bounds, budget)
     partials = torch.empty(
         (work.shape[0], heads, SUMMARY_DIM, KEY_DIM), dtype=torch.float32, device=qg.device

--- a/attn_gym/linear/_delta_rule/triton/canonical_scan.py
+++ b/attn_gym/linear/_delta_rule/triton/canonical_scan.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Fused per-document prefix of affine state maps for the deterministic CP recipe.
+
+The maps are ``[N, H, V + K, K]`` packed ``[bias; transition]`` (see
+``attn_gym.linear.context_parallel``). Tile ``i`` of a document enters with the bias of the
+composition of all earlier tiles' maps. Composition right-multiplies by the next transition,
+``(A0, B0) ∘ (A1, B1) = (A0 @ A1, B0 @ A1 + B1)``, so the running bias steps as
+``B @ A_tile + B_tile`` and every row depends only on the same row before it: a program owns
+``BM`` bias rows and walks its document's tiles serially with one ``[BM, K] @ [K, K]`` dot per
+tile, storing the rows before each step. The running transition is never needed, there are no
+intermediate buffers, and the whole scan is one launch.
+
+The tree is the serial fold in three-pass TF32 (``tf32x3``, fp32-accurate), the same arithmetic
+``compose_work_items`` uses. It is a fixed function of the document's tile count, so the result
+does not depend on which rank produced a leaf, on the document's position in the packed stream,
+or on the CP degree.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def canonical_scan_kernel(
+    maps,
+    doc_offsets,
+    entries,
+    H: tl.constexpr,
+    V: tl.constexpr,
+    K: tl.constexpr,
+    BM: tl.constexpr,
+    REVERSE: tl.constexpr,
+):
+    """Entry states of one document, one head, ``BM`` rows of the ``[V, K]`` state.
+
+    ``doc_offsets[d]:doc_offsets[d + 1]`` are the tile ids of document ``d``, contiguous in
+    tile order; ``REVERSE`` walks them from the last tile (the exit-cotangent scan).
+    """
+    doc = tl.program_id(0)
+    head = tl.program_id(1).to(tl.int64)
+    row0 = tl.program_id(2) * BM
+    rows = row0 + tl.arange(0, BM)
+    cols = tl.arange(0, K)
+    first = tl.load(doc_offsets + doc)
+    stop = tl.load(doc_offsets + doc + 1)
+
+    acc = tl.zeros([BM, K], dtype=tl.float32)  # entry state of the first tile
+    for step in tl.range(0, stop - first, num_stages=2):
+        if REVERSE:
+            tile = stop - 1 - step
+        else:
+            tile = first + step
+        base = maps + (tile.to(tl.int64) * H + head) * (V + K) * K
+        tl.store(
+            entries + (tile.to(tl.int64) * H + head) * V * K + rows[:, None] * K + cols[None, :],
+            acc,
+        )
+        transition = tl.load(base + (V + cols[:, None]) * K + cols[None, :])  # [K, K]
+        bias = tl.load(base + rows[:, None] * K + cols[None, :])
+        acc = tl.dot(acc, transition, input_precision="tf32x3") + bias
+
+
+def canonical_scan_entries(
+    maps: torch.Tensor,
+    doc_offsets: torch.Tensor,
+    *,
+    reverse: bool = False,
+) -> torch.Tensor:
+    """Entry state ``[N, H, V, K]`` of every tile from one fused per-document serial scan.
+
+    ``maps`` are ``[N, H, V + K, K]`` FP32 in tile order (tiles of one document contiguous);
+    ``doc_offsets`` is ``int32 [D + 1]`` on the device. ``reverse`` folds each document from its
+    last tile, giving exit cotangents from reverse maps. One launch covers every document, head,
+    and row tile.
+    """
+    count, heads, packed, key_dim = maps.shape
+    value_dim = packed - key_dim
+    entries = torch.empty(
+        count, heads, value_dim, key_dim, dtype=torch.float32, device=maps.device
+    )
+    block_rows = 16
+    documents = doc_offsets.shape[0] - 1
+    canonical_scan_kernel[(documents, heads, value_dim // block_rows)](
+        maps.contiguous(),
+        doc_offsets,
+        entries,
+        H=heads,
+        V=value_dim,
+        K=key_dim,
+        BM=block_rows,
+        REVERSE=reverse,
+        num_warps=8,
+    )
+    return entries
+
+
+__all__ = ["canonical_scan_entries"]

--- a/attn_gym/linear/context_parallel.py
+++ b/attn_gym/linear/context_parallel.py
@@ -647,9 +647,16 @@ class PreparedForward(Protocol):
         """The resolved query scale; the backward must reuse it."""
         ...
 
-    def state_summaries(self, bounds: torch.Tensor) -> torch.Tensor:
+    def state_summaries(
+        self,
+        bounds: torch.Tensor,
+        *,
+        deterministic_work: bool = False,
+    ) -> torch.Tensor:
         """One ``[HV, V + K, K]`` affine summary per ``[start, stop)`` row of ``bounds``.
 
+        ``deterministic_work`` pins the summary kernels' work partition so the maps do not
+        depend on span length, range count, or SM count (the deterministic recipe needs this).
         Every nonempty row is one subsequence of the span (NOTE [Summary ranges are subsequences]
         in ``attn_gym.linear.kda.stages``); ``start == stop`` is the identity.
         """
@@ -665,8 +672,13 @@ class PreparedForward(Protocol):
 class PreparedBackward(Protocol):
     """Backward handle of a staged delta-rule op (``chunk_*_prepare_backward``)."""
 
-    def state_grad_summaries(self, bounds: torch.Tensor) -> torch.Tensor:
-        """One ``[C; R]`` reverse map per row of ``bounds``: ``d_entry = d_exit @ R + C``."""
+    def state_grad_summaries(
+        self, bounds: torch.Tensor, *, deterministic_work: bool = False
+    ) -> torch.Tensor:
+        """One ``[C; R]`` reverse map per row of ``bounds``: ``d_entry = d_exit @ R + C``.
+
+        ``deterministic_work`` as in :meth:`PreparedForward.state_summaries`.
+        """
         ...
 
     def run(self, d_final_state: torch.Tensor | None) -> tuple[torch.Tensor, ...]:

--- a/attn_gym/linear/context_parallel_deterministic.py
+++ b/attn_gym/linear/context_parallel_deterministic.py
@@ -1,0 +1,416 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Context parallelism whose numerics do not depend on the CP degree.
+
+NOTE [Canonical Tiles]
+The standard recipe (``context_parallel_chunk``) summarizes each rank's fragment with one affine
+map, so changing the number of ranks changes which token ranges are summarized and how the FP32
+maps compose, and the rounded result moves. This module fixes the whole arithmetic graph before
+ranks are assigned:
+
+    tile      ``[start, min(start + tile_size, doc_end))`` within one document, aligned to the
+              document's first token; a document's last tile may be short. ``tile_size`` is a
+              multiple of the 64-token summary chunk and part of the numerical contract.
+    leaf map  each tile's ``[bias; transition]`` forward map and ``[C; R]`` reverse map, computed
+              by the staged op on that tile alone (no other tile's tokens are visible).
+    scan      per document, a serial fold of the leaf maps in tile order (forward) or reverse
+              tile order (backward), in three-pass TF32 (fp32-accurate), fused in one launch. The
+              state entering tile ``j`` depends on that document's leaves ``0..j-1`` alone.
+    entry     ``merge_state(0, prefix[i - 1])`` for tile ``i``; a document's first tile enters
+              with zero. Exits are the reverse analogue.
+
+Ranks own whole tiles; ownership changes which leaves a rank computes and where the scan runs,
+never the leaf arithmetic or the tree. CP=1 is therefore bitwise identical to CP=N (verified for
+the fused and Mega forwards in ``test/test_context_parallel_deterministic.py``), and a document's
+result does not depend on the documents packed around it. It is a distinct numerical contract
+from the unsharded ``chunk_kda`` call.
+
+A rank prepares all its tiles in one staged call, each tile a packed subsequence, with the
+summary kernels' work partition pinned (``deterministic_work=True``); this is bitwise equal to
+preparing every tile alone (``test/test_canonical_tile_batching.py``).
+
+NOTE [Single-Tile Documents]
+A document that fits in one tile has no state to carry: its tile enters with zero and nothing
+reads its map, so it is excluded from the summaries, the exchange, and the scan
+(``CanonicalTiling.summarized``). The exclusion depends on the tiling only, so the contract is
+unchanged, and on packings with many short documents it removes most of the recipe's overhead
+(measured by ``benchmarks/kda_cp_fragment_study.py``).
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Sequence
+from dataclasses import dataclass
+from itertools import accumulate, groupby, pairwise
+from typing import NamedTuple
+
+import torch
+import torch.distributed as dist
+
+from attn_gym._backends.profiler import profiler_range
+from attn_gym.linear._delta_rule.triton.canonical_scan import canonical_scan_entries
+from attn_gym.linear.context_parallel import StagedOp
+
+SUMMARY_CHUNK = 64
+
+
+class Tile(NamedTuple):
+    """One canonical tile: global token range ``[start, stop)`` of ``document``."""
+
+    document: int
+    start: int
+    stop: int
+
+    @property
+    def length(self) -> int:
+        return self.stop - self.start
+
+
+@dataclass(frozen=True)
+class CanonicalTiling:
+    """Fixed tiles of a packed stream plus this rank's ownership.
+
+    Attributes:
+        tiles: Every tile of the stream in global token order.
+        owned: ``owned[rank]`` lists the tile ids that rank computes, in its span order.
+        cp_rank: This rank.
+    """
+
+    tiles: tuple[Tile, ...]
+    owned: tuple[tuple[int, ...], ...]
+    cp_rank: int
+
+    @classmethod
+    def from_fragments(
+        cls,
+        cu_seqlens_global: Sequence[int],
+        fragments: Sequence[Sequence[tuple[int, int]]],
+        cp_rank: int,
+        *,
+        tile_size: int,
+    ) -> CanonicalTiling:
+        """Tile the stream and assign whole tiles to the ranks that own their tokens.
+
+        ``fragments[rank]`` are that rank's global token ranges. Every fragment boundary must fall
+        on a tile boundary (a document boundary or ``doc_start + k * tile_size``), otherwise the
+        ownership would cut a tile and the arithmetic would depend on the fragment table.
+        """
+        if tile_size <= 0 or tile_size % SUMMARY_CHUNK:
+            raise ValueError(f"tile_size must be a positive multiple of {SUMMARY_CHUNK}")
+        if not 0 <= cp_rank < len(fragments):
+            raise ValueError(f"cp_rank {cp_rank} is outside a table of {len(fragments)} ranks")
+        tiles = tile_stream(cu_seqlens_global, tile_size)
+        # Tile boundaries -> id of the tile starting there; the stream's end closes the last one.
+        boundary = {tile.start: index for index, tile in enumerate(tiles)}
+        boundary[cu_seqlens_global[-1]] = len(tiles)
+        owned: list[tuple[int, ...]] = []
+        for rank_fragments in fragments:
+            ids: list[int] = []
+            for start, stop in rank_fragments:
+                if start >= stop:
+                    raise ValueError(f"fragment [{start}, {stop}) is empty or reversed")
+                if start not in boundary or stop not in boundary:
+                    raise ValueError(
+                        f"fragment [{start}, {stop}) does not fall on canonical tile boundaries"
+                    )
+                ids.extend(range(boundary[start], boundary[stop]))
+            owned.append(tuple(ids))
+        if sorted(index for ids in owned for index in ids) != list(range(len(tiles))):
+            raise ValueError("fragments must cover every tile exactly once")
+        return cls(tuple(tiles), tuple(owned), cp_rank=cp_rank)
+
+    @property
+    def mine(self) -> tuple[int, ...]:
+        return self.owned[self.cp_rank]
+
+    @property
+    def summarized(self) -> tuple[int, ...]:
+        """Tile ids whose maps take part in the scan: those of multi-tile documents."""
+        counts = Counter(tile.document for tile in self.tiles)
+        return tuple(i for i, tile in enumerate(self.tiles) if counts[tile.document] > 1)
+
+    @property
+    def summarized_by_rank(self) -> tuple[tuple[int, ...], ...]:
+        """``summarized_by_rank[rank]``: that rank's indices into ``summarized``, in span order."""
+        position = {i: s for s, i in enumerate(self.summarized)}
+        return tuple(tuple(position[i] for i in ids if i in position) for ids in self.owned)
+
+    @property
+    def slots(self) -> int:
+        """Gather width: the most summarized tiles any rank owns."""
+        return max(map(len, self.summarized_by_rank))
+
+    def global_token_ids(self, device: torch.device | str) -> torch.Tensor:
+        """Global token id of every span token of this rank (tiles concatenated in span order)."""
+        pieces = [
+            torch.arange(self.tiles[i].start, self.tiles[i].stop, device=device) for i in self.mine
+        ]
+        return torch.cat(pieces) if pieces else torch.empty(0, dtype=torch.int64, device=device)
+
+    def span_offsets(self) -> tuple[int, ...]:
+        """Span-local ``[start, stop)`` of each owned tile, in span order."""
+        return tuple(accumulate((self.tiles[i].length for i in self.mine), initial=0))
+
+    def routing(self, device: torch.device | str) -> CanonicalRouting:
+        """Materialize the index tensors the recipe reads, once per layout and device."""
+        offsets = self.span_offsets()
+        summarized = self.summarized
+        in_scan = set(summarized)
+        positions = [p for p, i in enumerate(self.mine) if i in in_scan]
+        by_rank, width = self.summarized_by_rank, self.slots
+        # Row of each summarized tile in the all-gather buffer: rank-major, ``width`` per rank.
+        row = {s: rank * width + r for rank, ids in enumerate(by_rank) for r, s in enumerate(ids)}
+        source = [row[s] for s in range(len(summarized))]
+        documents = [self.tiles[i].document for i in summarized]
+
+        def int32(values: Sequence[int] | Sequence[tuple[int, int]]) -> torch.Tensor:
+            return torch.tensor(values, dtype=torch.int32, device=device)
+
+        return CanonicalRouting(
+            cu_seqlens=int32(offsets),
+            summary_bounds=int32([offsets[p : p + 2] for p in positions]).reshape(-1, 2),
+            summarized_positions=(
+                None
+                if len(positions) == len(self.mine)
+                else torch.tensor(positions, dtype=torch.int64, device=device)
+            ),
+            document_offsets=int32(
+                [0, *accumulate(len(list(run)) for _, run in groupby(documents))]
+            ),
+            mine=_selection(by_rank[self.cp_rank], device),
+            gather_source=(
+                None
+                if source == list(range(len(summarized)))
+                else torch.tensor(source, dtype=torch.int64, device=device)
+            ),
+        )
+
+
+class CanonicalRouting(NamedTuple):
+    """Device tensors of a :class:`CanonicalTiling` for one rank, built once per layout.
+
+    ``cu_seqlens`` cuts the rank's span into one segment per owned tile; ``summary_bounds`` are
+    the segments whose tiles take part in the scan and ``summarized_positions`` their positions
+    among the owned tiles (``None`` when all do). ``document_offsets`` groups the gathered
+    summarized-tile maps by document. ``mine`` selects this rank's summarized tiles in the
+    gathered order, as a slice when consecutive so no gather copy is made; ``gather_source`` is
+    each summarized tile's row in the all-gather buffer (``None`` when the buffer already is the
+    summarized order).
+    """
+
+    cu_seqlens: torch.Tensor
+    summary_bounds: torch.Tensor
+    summarized_positions: torch.Tensor | None
+    document_offsets: torch.Tensor
+    mine: torch.Tensor | slice
+    gather_source: torch.Tensor | None
+
+
+def _selection(ids: Sequence[int], device: torch.device | str) -> torch.Tensor | slice:
+    """A slice when ``ids`` are consecutive (no gather copy), else an index tensor."""
+    if ids and list(ids) == list(range(ids[0], ids[0] + len(ids))):
+        return slice(ids[0], ids[0] + len(ids))
+    return torch.tensor(list(ids), dtype=torch.int64, device=device)
+
+
+def tile_stream(cu_seqlens_global: Sequence[int], tile_size: int) -> list[Tile]:
+    """Cut every document into ``tile_size`` tiles from its first token; the last may be short."""
+    return [
+        Tile(document, begin, min(begin + tile_size, stop))
+        for document, (start, stop) in enumerate(pairwise(cu_seqlens_global))
+        for begin in range(start, stop, tile_size)
+    ]
+
+
+# Module-level name so tests without a second GPU can substitute a CPU-staged collective.
+_all_gather_into_tensor = dist.all_gather_into_tensor
+
+
+def all_gather_tile_maps(
+    local: torch.Tensor,
+    tiling: CanonicalTiling,
+    routing: CanonicalRouting,
+    like: torch.Tensor,
+    group: dist.ProcessGroup | None,
+) -> torch.Tensor:
+    """Exchange every rank's summarized tile maps; ``[tiles, H, V + K, K]`` in summarized order.
+
+    ``local`` holds this rank's summarized tile maps in its span order (zero rows for a rank
+    without any). Packets are zero-padded to ``tiling.slots`` rows so the collective is a plain
+    equal-size all-gather; padding rows never enter a scan. When the gathered buffer already is
+    the summarized order it is returned without a copy. ``group=None`` (a single rank owning
+    everything, the CP=1 reference) skips the collective.
+    """
+    width, world = tiling.slots, len(tiling.owned)
+    if group is None:
+        assert world == 1 and local.shape[0] == len(tiling.summarized)
+        return local
+    if local.shape[0] == width:
+        packet = local
+    else:
+        packet = like.new_zeros((width, *like.shape[1:]))
+        packet[: local.shape[0]] = local
+    gathered = like.new_empty((world * width, *like.shape[1:]))
+    with profiler_range("cp/all_gather_tiles"):
+        _all_gather_into_tensor(gathered, packet, group=group)
+    if routing.gather_source is None:
+        return gathered[: len(tiling.summarized)]
+    return gathered[routing.gather_source]
+
+
+def canonical_entries(
+    summary_maps: torch.Tensor,
+    tiling: CanonicalTiling,
+    routing: CanonicalRouting,
+    like: torch.Tensor,
+    group: dist.ProcessGroup | None,
+    *,
+    reverse: bool,
+) -> torch.Tensor:
+    """Entry (or exit when ``reverse``) FP32 states of this rank's tiles, in ``tiling.mine`` order.
+
+    ``summary_maps`` are the maps of the rank's summarized tiles (NOTE [Single-Tile Documents])
+    in span order; a rank with none (possibly no tiles at all) passes zero rows and still joins
+    the collective. Tiles of single-tile documents get the zero state.
+
+    Every summarized tile's map is all-gathered and scanned per document: the serial fold in
+    three-pass TF32, so the result is a function of the tiles' maps and indices only.
+    """
+    if summary_maps.shape[0] == 0:
+        all_gather_tile_maps(summary_maps, tiling, routing, like, group)
+        return like.new_zeros(
+            (len(tiling.mine), like.shape[1], like.shape[2] - like.shape[3], like.shape[3])
+        )
+    gathered = all_gather_tile_maps(summary_maps, tiling, routing, like, group)
+    entries = canonical_scan_entries(gathered, routing.document_offsets, reverse=reverse)
+    entries = entries[routing.mine]
+    if routing.summarized_positions is None:
+        return entries
+    full = entries.new_zeros((len(tiling.mine), *entries.shape[1:]))
+    full[routing.summarized_positions] = entries
+    return full
+
+
+class _CanonicalContextParallel(torch.autograd.Function):
+    """One batched staged forward/backward per rank glued by the fixed scan tree.
+
+    Every owned tile is one packed subsequence of the rank's span (``cu_seqlens`` at tile
+    boundaries), so the leaf kernels see each tile exactly as an independent call would, and the
+    summary kernels run with ``deterministic_work=True`` so their work partition cannot depend on
+    how many tiles the rank owns. A rank without tiles skips the kernels but still joins both
+    collectives.
+    """
+
+    @staticmethod
+    def forward(ctx, q, k, v, gate, beta, tiling, routing, group, stages: StagedOp):
+        heads, dim, value_dim = v.shape[2], q.shape[3], v.shape[3]  # maps are per value head
+        # Zero rows of the packed map shape: the collectives' shape anchor, and the summaries
+        # of a rank with nothing to summarize.
+        like = q.new_empty((0, heads, value_dim + dim, dim), dtype=torch.float32)
+        maps = like
+        if tiling.mine:
+            prepared = stages.prepare(q, k, v, gate, beta, cu_seqlens=routing.cu_seqlens)
+            if routing.summary_bounds.shape[0]:
+                maps = prepared.state_summaries(routing.summary_bounds, deterministic_work=True)
+        entry = canonical_entries(maps, tiling, routing, like, group, reverse=False)
+        if tiling.mine:
+            with profiler_range("cp/run"):
+                output, _ = prepared.run(entry, output_final_state=False)
+            ctx.save_for_backward(*prepared.saved, entry, like)
+            ctx.saved_type = type(prepared.saved)
+            ctx.scale = prepared.scale
+        else:
+            output = v[:, :0]
+            ctx.save_for_backward(entry, like)
+            ctx.input_meta = tuple((t.shape, t.dtype) for t in (q, k, v, gate, beta))
+        ctx.tiling = tiling
+        ctx.routing = routing
+        ctx.group = group
+        ctx.stages = stages
+        return output
+
+    @staticmethod
+    @torch.autograd.function.once_differentiable
+    def backward(ctx, d_output):
+        tiling: CanonicalTiling = ctx.tiling
+        routing: CanonicalRouting = ctx.routing
+        *saved, entry, like = ctx.saved_tensors
+        maps = like
+        if tiling.mine:
+            backward = ctx.stages.prepare_backward(
+                ctx.saved_type._make(saved), d_output, entry, scale=ctx.scale
+            )
+            if routing.summary_bounds.shape[0]:
+                maps = backward.state_grad_summaries(
+                    routing.summary_bounds, deterministic_work=True
+                )
+        exit_cotangent = canonical_entries(maps, tiling, routing, like, ctx.group, reverse=True)
+        if tiling.mine:
+            with profiler_range("cp/run"):
+                grads = backward.run(exit_cotangent)[:5]
+        else:
+            grads = tuple(like.new_empty(shape, dtype=dtype) for shape, dtype in ctx.input_meta)
+        return (*grads, None, None, None, None)
+
+
+def context_parallel_chunk_deterministic(
+    stages: StagedOp,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    *,
+    tiling: CanonicalTiling,
+    group: dist.ProcessGroup,
+    routing: CanonicalRouting | None = None,
+) -> torch.Tensor:
+    """Run a staged delta-rule op over this rank's canonical tiles (NOTE [Canonical Tiles]).
+
+    Args:
+        stages: The op's staged entry points, as for ``context_parallel_chunk``.
+        q: This rank's span: its owned tiles concatenated in ``tiling.mine`` order; ``k``, ``v``,
+            ``gate``, ``beta`` follow the same layout.
+        tiling: The stream's canonical tiling and this rank's ownership.
+        group: Process group containing exactly the tiling's ranks, in order.
+        routing: ``tiling.routing(device)``; pass it to reuse the index tensors across calls
+            with the same layout (built here otherwise).
+
+    Returns:
+        The span's output. Final states are not returned: every document's exit state is a
+        function of the scan and can be recovered from the gathered maps if needed.
+
+    Every rank in ``group`` must call this, and run its backward, the same number of times,
+    including ranks that own no tiles: both directions all-gather maps, so an empty rank still
+    contributes an all-zero packet (and gets an empty output and empty gradients).
+
+    Memory: every rank holds the gathered maps of all summarized tiles, ``H x (V + K) x K``
+    FP32 each (128 KiB per head for K = V = 128), plus one entry state per owned tile; the tile
+    size sets that footprint (NOTE [Single-Tile Documents]).
+    """
+    world, cp_rank = dist.get_world_size(group), dist.get_rank(group)
+    if world != len(tiling.owned) or cp_rank != tiling.cp_rank:
+        raise ValueError("tiling was built for a different group or rank")
+    expected = sum(tiling.tiles[i].length for i in tiling.mine)
+    if q.shape[1] != expected:
+        raise ValueError(f"tiling owns {expected} local tokens but the input has {q.shape[1]}")
+    if routing is None:
+        routing = tiling.routing(q.device)
+    return _CanonicalContextParallel.apply(q, k, v, gate, beta, tiling, routing, group, stages)
+
+
+__all__ = [
+    "SUMMARY_CHUNK",
+    "CanonicalRouting",
+    "CanonicalTiling",
+    "Tile",
+    "all_gather_tile_maps",
+    "canonical_entries",
+    "context_parallel_chunk_deterministic",
+    "tile_stream",
+]

--- a/attn_gym/linear/gdn/stages.py
+++ b/attn_gym/linear/gdn/stages.py
@@ -75,7 +75,12 @@ class ChunkGDNPrepared:
     metadata: RaggedChunkMetadata | None
     scale: float
 
-    def state_summaries(self, bounds: torch.Tensor) -> torch.Tensor:
+    def state_summaries(
+        self,
+        bounds: torch.Tensor,
+        *,
+        deterministic_work: bool = False,
+    ) -> torch.Tensor:
         """Return one FP32 ``[HV, V + K, K]`` map per row of ``bounds`` in a single launch.
 
         See ``attn_gym.linear.kda.stages.ChunkKDAPrepared.state_summaries`` for the contract.
@@ -87,6 +92,7 @@ class ChunkGDNPrepared:
             self.factors.u,
             _vector_gate(saved.cumulative_gate, saved.q.shape[-1]),
             bounds,
+            deterministic_work=deterministic_work,
         )
 
     def run(
@@ -174,7 +180,9 @@ class ChunkGDNBackward:
             q, k, saved.cumulative_gate, self.scale, self.metadata
         )
 
-    def state_grad_summaries(self, bounds: torch.Tensor) -> torch.Tensor:
+    def state_grad_summaries(
+        self, bounds: torch.Tensor, *, deterministic_work: bool = False
+    ) -> torch.Tensor:
         """Return one FP32 ``[HV, V + K, K]`` reverse map per row of ``bounds`` in one launch.
 
         See ``attn_gym.linear.kda.stages.ChunkKDABackward.state_grad_summaries``.
@@ -189,6 +197,7 @@ class ChunkGDNBackward:
             _vector_gate(saved.cumulative_gate, saved.q.shape[-1]),
             self.scale,
             bounds,
+            deterministic_work=deterministic_work,
         )
 
     def run(

--- a/attn_gym/linear/kda/__init__.py
+++ b/attn_gym/linear/kda/__init__.py
@@ -38,6 +38,7 @@ _BACKEND_EXPORTS = {
     "chunk_kda_prepare": "attn_gym.linear.kda.stages",
     "chunk_kda_prepare_backward": "attn_gym.linear.kda.stages",
     "context_parallel_kda": "attn_gym.linear.kda.context_parallel",
+    "context_parallel_kda_deterministic": "attn_gym.linear.kda.context_parallel",
 }
 # Backward compat: these moved to attn_gym.linear.short_conv, whose own lazy resolution supplies
 # the error message; import them from attn_gym.linear instead.

--- a/attn_gym/linear/kda/context_parallel.py
+++ b/attn_gym/linear/kda/context_parallel.py
@@ -18,6 +18,11 @@ from attn_gym.linear.context_parallel import (
     StagedOp,
     context_parallel_chunk,
 )
+from attn_gym.linear.context_parallel_deterministic import (
+    CanonicalRouting,
+    CanonicalTiling,
+    context_parallel_chunk_deterministic,
+)
 from attn_gym.linear.kda.stages import chunk_kda_prepare, chunk_kda_prepare_backward
 from attn_gym.linear.kda.validation import resolve_kernel_options
 from attn_gym.linear.types import KernelOptions
@@ -50,6 +55,40 @@ def context_parallel_kda(
     return context_parallel_chunk(stages, q, k, v, gate, beta, routing=routing, group=group)
 
 
+def context_parallel_kda_deterministic(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    *,
+    tiling: CanonicalTiling,
+    group: dist.ProcessGroup,
+    routing: CanonicalRouting | None = None,
+    scale: float | None = None,
+    fastmath: bool = False,
+    kernel_options: KernelOptions | None = None,
+) -> torch.Tensor:
+    """Run KDA over this rank's canonical tiles; results do not depend on the CP degree.
+
+    See NOTE [Canonical Tiles] in ``attn_gym.linear.context_parallel_deterministic``. Autotuning
+    is disabled because a tuned configuration is part of the arithmetic and would have to be
+    identical on every rank; ``fastmath`` and ``kernel_options`` follow ``chunk_kda``, except
+    that Mega's forgetting-horizon split (``split_forward``/``split_backward``) is rejected: the
+    canonical tiles already bound every leaf, and a split leaf would change the FP32 summaries.
+    """
+    options = resolve_kernel_options(kernel_options)
+    if options.split_forward or options.split_backward:
+        raise ValueError(
+            "context_parallel_kda_deterministic does not support split_forward/split_backward: "
+            "canonical tiles fix every leaf, and a horizon split would change the summaries"
+        )
+    stages = _kda_stages(scale, False, fastmath, kernel_options)
+    return context_parallel_chunk_deterministic(
+        stages, q, k, v, gate, beta, tiling=tiling, group=group, routing=routing
+    )
+
+
 def _kda_stages(
     scale: float | None, autotune: bool, fastmath: bool, kernel_options: KernelOptions | None
 ) -> StagedOp:
@@ -65,4 +104,4 @@ def _kda_stages(
     )
 
 
-__all__ = ["context_parallel_kda"]
+__all__ = ["context_parallel_kda", "context_parallel_kda_deterministic"]

--- a/attn_gym/linear/kda/stages.py
+++ b/attn_gym/linear/kda/stages.py
@@ -155,13 +155,20 @@ class ChunkKDAPrepared:
     autotune: bool
     schedule: ScheduleRequest
 
-    def state_summaries(self, bounds: torch.Tensor) -> torch.Tensor:
+    def state_summaries(
+        self,
+        bounds: torch.Tensor,
+        *,
+        deterministic_work: bool = False,
+    ) -> torch.Tensor:
         """Return one FP32 ``[HV, V + K, K]`` map per row of ``bounds`` in a single launch.
 
         ``bounds`` is an ``int32 [R, 2]`` device tensor of ``[start, stop)`` span offsets, each
         obeying NOTE [Summary ranges are subsequences]; ``start == stop`` yields the identity. The
         ranges are read on the device, so a CUDA Graph captured around this call replays for any
-        layout of the same shape.
+        layout of the same shape. ``deterministic_work=True`` pins each range's recurrence
+        partition for canonical tile batching; factor preparation must also use
+        ``autotune=False``.
         """
         return build_state_summaries(
             self.factors.kg,
@@ -169,6 +176,7 @@ class ChunkKDAPrepared:
             self.factors.u,
             self.saved.cumulative_gate,
             bounds,
+            deterministic_work=deterministic_work,
         )
 
     def run(
@@ -209,11 +217,18 @@ class ChunkKDAMegaPrepared:
     # Mega rejects other schedules; kept so both handles feed chunk_kda_prepare_backward alike.
     schedule: ScheduleRequest = ScheduleRequest.AUTO
 
-    def state_summaries(self, bounds: torch.Tensor) -> torch.Tensor:
+    def state_summaries(
+        self,
+        bounds: torch.Tensor,
+        *,
+        deterministic_work: bool = False,
+    ) -> torch.Tensor:
         """Return one FP32 ``[HV, V + K, K]`` map per row of ``bounds`` in a single launch.
 
         Rows follow NOTE [Summary ranges are subsequences]. The maps carry Mega's 16-token-chunk
         rounding, which differs from the fused maps and from an unsharded Mega pass.
+        ``deterministic_work`` is accepted for the protocol and has nothing to pin: each map is
+        one subsequence's own pass, independent of the rest of the span.
         """
         # Lazy import keeps the optional CuTeDSL 4.7 backend out of the fused import path.
         from attn_gym.linear._delta_rule.mega.state_summary import build_mega_state_summaries
@@ -324,7 +339,9 @@ class ChunkKDABackward:
     autotune: bool
     fastmath: bool
 
-    def state_grad_summaries(self, bounds: torch.Tensor) -> torch.Tensor:
+    def state_grad_summaries(
+        self, bounds: torch.Tensor, *, deterministic_work: bool = False
+    ) -> torch.Tensor:
         """Return one FP32 ``[HV, V + K, K]`` reverse map per row of ``bounds`` in one launch.
 
         Packed as ``[C; R]`` with ``d_entry_state = d_exit_state @ R + C``, where ``C`` is the
@@ -342,6 +359,7 @@ class ChunkKDABackward:
             self.saved.cumulative_gate,
             self.scale,
             bounds,
+            deterministic_work=deterministic_work,
         )
 
     def run(
@@ -399,10 +417,13 @@ class ChunkKDAMegaBackward:
     autotune: bool
     schedule: ScheduleRequest
 
-    def state_grad_summaries(self, bounds: torch.Tensor) -> torch.Tensor:
+    def state_grad_summaries(
+        self, bounds: torch.Tensor, *, deterministic_work: bool = False
+    ) -> torch.Tensor:
         """Return one FP32 ``[HV, V + K, K]`` reverse map per row of ``bounds`` in one launch.
 
-        Rows follow NOTE [Summary ranges are subsequences].
+        Rows follow NOTE [Summary ranges are subsequences]. ``deterministic_work`` is accepted for
+        the protocol and has nothing to pin: each map is one subsequence's own pass.
         """
         from attn_gym.linear._delta_rule.mega.state_summary import build_mega_state_grad_summaries
 

--- a/benchmarks/kda_cp_deterministic.py
+++ b/benchmarks/kda_cp_deterministic.py
@@ -1,0 +1,306 @@
+"""Overhead of CP-degree-invariant KDA against the standard CP recipe and the unsharded op.
+
+    torchrun --standalone --nproc-per-node=2 benchmarks/kda_cp_deterministic.py --heads 64 --tokens 8192
+
+Every rank times its own fwd and bwd with CUDA events; the reported time per iteration is the
+slowest rank, which is what gates a training step. Rounds interleave the variants (A,B,C / C,B,A)
+so clock drift hits them evenly. Rank 0 prints a table and writes JSON to ``--out``.
+
+Variants:
+  unsharded    ``chunk_kda`` over the whole packed stream on every rank (CP=1 reference cost).
+  cp           ``context_parallel_kda`` with contiguous fragments cut at tile boundaries.
+  det-<T>      ``context_parallel_kda_deterministic`` with canonical tile size T.
+
+The document layout is a fixed Zipf-like ragged set scaled to ``--tokens``; the standard CP
+fragments are cut on the deterministic tile grid so both recipes move the same tokens.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import statistics
+from collections.abc import Callable
+from functools import partial
+from itertools import accumulate, pairwise
+from pathlib import Path
+from typing import Annotated
+
+import torch
+import torch.distributed as dist
+import typer
+
+from attn_gym.linear.context_parallel import ContextParallelPlan
+from attn_gym.linear.context_parallel_deterministic import CanonicalTiling, tile_stream
+from attn_gym.linear.kda import chunk_kda, context_parallel_kda
+from attn_gym.linear.kda.context_parallel import context_parallel_kda_deterministic
+from attn_gym.testing.kda import make_kda_test_inputs
+
+ZIPF_FRACTIONS = (0.5, 0.25, 0.125, 0.0625)
+
+
+def document_lengths(tokens: int, grid: int) -> tuple[int, ...]:
+    """Zipf-like documents on a ``grid`` so every recipe can share fragment boundaries.
+
+    Fractions are floored to the grid and the last document absorbs rounding. For small
+    workloads, shrink the document grid (not the canonical tiles) to keep all five nonempty.
+    Document boundaries are always valid tile boundaries, even for documents shorter than a tile.
+    """
+    grid = min(grid, max(64, tokens // 16 // 64 * 64))
+    lengths = [int(tokens * f) // grid * grid for f in ZIPF_FRACTIONS]
+    remainder = tokens - sum(lengths)
+    if min(lengths) < grid or remainder < grid:
+        raise ValueError(f"tokens={tokens} is too small for grid={grid}")
+    return (*lengths, remainder)
+
+
+def balanced_cut(cu: tuple[int, ...], tile: int, world: int) -> list[list[tuple[int, int]]]:
+    """Contiguous fragments with boundaries on the canonical tile grid, balanced by tokens."""
+    tiles = tile_stream(cu, tile)
+    stops = [t.stop for t in tiles]
+    fragments, start = [], 0
+    for rank in range(world):
+        target = cu[-1] * (rank + 1) // world
+        stop = cu[-1] if rank == world - 1 else min(stops, key=lambda s: abs(s - target))
+        fragments.append([(start, stop)] if stop > start else [])
+        start = stop
+    return fragments
+
+
+class PhaseClock:
+    """CUDA-event intervals named by their closing mark; read only after synchronization."""
+
+    def __init__(self) -> None:
+        self.marks: list[tuple[str, torch.cuda.Event]] = []
+
+    def mark(self, name: str) -> None:
+        """Record a phase boundary on the current stream."""
+        event = torch.cuda.Event(enable_timing=True)
+        event.record()
+        self.marks.append((name, event))
+
+    def elapsed(self) -> dict[str, float]:
+        """Return local phase durations in milliseconds."""
+        return {
+            name: prev.elapsed_time(event) for (_, prev), (name, event) in pairwise(self.marks)
+        }
+
+
+def timed(
+    step: Callable[[PhaseClock], object],
+    *,
+    iters: int,
+    device: torch.device,
+    distributed: bool = True,
+) -> tuple[list[dict[str, float]], list[float], list[float]]:
+    """Local phase samples and slowest-rank fwd/bwd ms, with a barrier before each step.
+
+    Unlike single-device graph timing, these eager measurements include launch gaps and
+    collective waits. ``distributed=False`` measures the single-GPU split benchmark.
+    """
+    phases, fwd, bwd = [], [], []
+    for _ in range(iters):
+        if distributed:
+            dist.barrier()
+        clock = PhaseClock()
+        step(clock)
+        torch.cuda.synchronize(device)
+        local = clock.elapsed()
+        phases.append(local)
+        totals = torch.tensor(
+            [
+                sum(v for k, v in local.items() if k.startswith(prefix))
+                for prefix in ("fwd", "bwd")
+            ],
+            device=device,
+        )
+        if distributed:
+            dist.all_reduce(totals, op=dist.ReduceOp.MAX)
+        f, b = totals.tolist()
+        fwd.append(f)
+        bwd.append(b)
+    return phases, fwd, bwd
+
+
+def clocked(fn: Callable[[], object], clock: PhaseClock, *, phase: str) -> None:
+    """Time a public operation as a single phase."""
+    clock.mark("start")
+    fn()
+    clock.mark(phase)
+
+
+def forward(
+    op: Callable[..., torch.Tensor | tuple[torch.Tensor, torch.Tensor | None]],
+    inputs: tuple[torch.Tensor, ...],
+    grad: torch.Tensor,
+) -> tuple[torch.Tensor, tuple[torch.Tensor, ...], torch.Tensor]:
+    """Run a KDA public API with fresh autograd leaves; ignore optional final states."""
+    leaves = tuple(v.detach().requires_grad_() for v in inputs)
+    result = op(*leaves)
+    return (result[0] if isinstance(result, tuple) else result), leaves, grad
+
+
+def main(
+    tokens: Annotated[int, typer.Option(help="Total packed tokens.")] = 8192,
+    heads: Annotated[int, typer.Option()] = 64,
+    backend: Annotated[str, typer.Option(help="fused or mega staged backend.")] = "fused",
+    tiles: Annotated[str, typer.Option(help="Comma-separated canonical tile sizes.")] = "64,256",
+    rounds: Annotated[int, typer.Option()] = 5,
+    iters: Annotated[int, typer.Option(help="Timed iterations per round per variant.")] = 10,
+    out_path: Annotated[Path | None, typer.Option("--out")] = None,
+) -> None:
+    """Compare unsharded, standard CP, and canonical CP forward/backward costs."""
+    rank, world = int(os.environ["RANK"]), int(os.environ["WORLD_SIZE"])
+    device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+    torch.cuda.set_device(device)
+    dist.init_process_group("nccl", device_id=device)
+    tile_sizes = [int(t) for t in tiles.split(",")]
+    grid = max(tile_sizes)
+    lengths = document_lengths(tokens, grid)
+    cu = (0, *accumulate(lengths))
+    options = {"backend": backend} if backend != "fused" else None
+    torch.manual_seed(0)
+    inputs = make_kda_test_inputs(
+        tokens,
+        heads=heads,
+        seed=0,
+        normalize_qk=True,
+        sigmoid_beta=True,
+        gate_scale=0.02,
+        log_uniform_gate=False,
+    )
+    grad = torch.randn_like(inputs[2])
+    cu_dev = torch.tensor(cu, dtype=torch.int32, device=device)
+    fragments = balanced_cut(cu, grid, world)
+
+    variants = {
+        "unsharded": partial(
+            forward,
+            partial(chunk_kda, cu_seqlens=cu_dev, kernel_options=options, autotune=False),
+            inputs,
+            grad,
+        )
+    }
+
+    plan = ContextParallelPlan.from_fragments(cu, fragments, rank)
+    routing = plan.routing(device)
+    cp_ids = plan.global_token_ids(device)
+    cp_local = tuple(v[:, cp_ids].contiguous() for v in inputs)
+    cp_grad = grad[:, cp_ids].contiguous()
+
+    variants["cp"] = partial(
+        forward,
+        partial(
+            context_parallel_kda,
+            routing=routing,
+            group=dist.group.WORLD,
+            kernel_options=options,
+            autotune=False,
+        ),
+        cp_local,
+        cp_grad,
+    )
+
+    for tile in tile_sizes:
+        tiling = CanonicalTiling.from_fragments(cu, fragments, rank, tile_size=tile)
+        det_routing = tiling.routing(device)
+        ids = tiling.global_token_ids(device)
+        local = tuple(v[:, ids].contiguous() for v in inputs)
+        local_grad = grad[:, ids].contiguous()
+
+        variants[f"det-{tile}"] = partial(
+            forward,
+            partial(
+                context_parallel_kda_deterministic,
+                tiling=tiling,
+                routing=det_routing,
+                group=dist.group.WORLD,
+                kernel_options=options,
+            ),
+            local,
+            local_grad,
+        )
+
+    # Warm up (compiles) and keep one retained graph per variant for backward timing.
+    retained = {}
+    for name, fwd in variants.items():
+        for _ in range(2):
+            out, leaves, g = fwd()
+            torch.autograd.grad(out, leaves, g)
+        retained[name] = fwd()
+    torch.cuda.synchronize(device)
+
+    fwd_ms: dict[str, list[float]] = {name: [] for name in variants}
+    bwd_ms: dict[str, list[float]] = {name: [] for name in variants}
+    names = list(variants)
+    for r in range(rounds):
+        order = names if r % 2 == 0 else names[::-1]
+        for name in order:
+            _, f, _ = timed(
+                partial(clocked, variants[name], phase="fwd/run"), iters=iters, device=device
+            )
+            fwd_ms[name] += f
+            out, leaves, g = retained[name]
+            _, _, b = timed(
+                partial(
+                    clocked,
+                    partial(torch.autograd.grad, out, leaves, g, retain_graph=True),
+                    phase="bwd/run",
+                ),
+                iters=iters,
+                device=device,
+            )
+            bwd_ms[name] += b
+
+    if rank == 0:
+        rows = []
+        for name in names:
+            rows.append(
+                {
+                    "variant": name,
+                    "fwd_ms": statistics.median(fwd_ms[name]),
+                    "bwd_ms": statistics.median(bwd_ms[name]),
+                    "fwd_p05": sorted(fwd_ms[name])[len(fwd_ms[name]) // 20],
+                    "fwd_p95": sorted(fwd_ms[name])[-1 - len(fwd_ms[name]) // 20],
+                    "bwd_p05": sorted(bwd_ms[name])[len(bwd_ms[name]) // 20],
+                    "bwd_p95": sorted(bwd_ms[name])[-1 - len(bwd_ms[name]) // 20],
+                }
+            )
+        base = next(r for r in rows if r["variant"] == "cp")
+        print(
+            f"tokens={tokens} heads={heads} backend={backend} world={world} lengths={lengths}\n"
+            f"fragments={fragments}\n"
+            f"{'variant':<12}{'fwd ms':>10}{'bwd ms':>10}{'fwd/cp':>9}{'bwd/cp':>9}"
+        )
+        for row in rows:
+            print(
+                f"{row['variant']:<12}{row['fwd_ms']:>10.3f}{row['bwd_ms']:>10.3f}"
+                f"{row['fwd_ms'] / base['fwd_ms']:>9.2f}{row['bwd_ms'] / base['bwd_ms']:>9.2f}"
+            )
+        if out_path:
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            out_path.write_text(
+                json.dumps(
+                    {
+                        "tokens": tokens,
+                        "heads": heads,
+                        "backend": backend,
+                        "world": world,
+                        "lengths": lengths,
+                        "fragments": fragments,
+                        "rounds": rounds,
+                        "iters": iters,
+                        "device": torch.cuda.get_device_name(device),
+                        "torch": torch.__version__,
+                        "rows": rows,
+                        "samples": {"fwd_ms": fwd_ms, "bwd_ms": bwd_ms},
+                    },
+                    indent=2,
+                )
+                + "\n"
+            )
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/benchmarks/kda_cp_fragment_study.py
+++ b/benchmarks/kda_cp_fragment_study.py
@@ -1,0 +1,645 @@
+"""Fragment-plan study for CP-degree-invariant KDA: ownership, tile size, and Mega splitting.
+
+    torchrun --standalone --nproc-per-node=2 benchmarks/kda_cp_fragment_study.py ownership
+    torchrun --standalone --nproc-per-node=2 benchmarks/kda_cp_fragment_study.py tile-sweep
+    torchrun --standalone --nproc-per-node=2 benchmarks/kda_cp_fragment_study.py crossover
+    python benchmarks/kda_cp_fragment_study.py split      # single process
+
+Canonical variants mirror ``_CanonicalContextParallel`` using staged handles and CUDA events
+between phases, including the single-tile-document skip. Each is checked bitwise against the
+public autograd API before timing. Standard CP and unsharded baselines use that API directly;
+``@module`` rows expose the canonical autograd overhead. Rounds alternate variant order; tables
+report slowest-rank forward/backward medians and local phase medians, in milliseconds.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import statistics
+from collections.abc import Callable, Sequence
+from functools import partial
+from itertools import accumulate, pairwise
+from pathlib import Path
+from typing import Annotated
+
+import torch
+import torch.distributed as dist
+import typer
+from kda_cp_deterministic import (
+    PhaseClock,
+    balanced_cut,
+    clocked,
+    document_lengths,
+    forward,
+    timed,
+)
+
+from attn_gym.linear._delta_rule.triton.canonical_scan import canonical_scan_entries
+from attn_gym.linear.context_parallel import ContextParallelPlan, StagedOp
+from attn_gym.linear.context_parallel_deterministic import (
+    CanonicalRouting,
+    CanonicalTiling,
+    all_gather_tile_maps,
+    tile_stream,
+)
+from attn_gym.linear.kda import chunk_kda, context_parallel_kda
+from attn_gym.linear.kda.context_parallel import _kda_stages, context_parallel_kda_deterministic
+from attn_gym.testing.kda import make_kda_test_inputs
+
+app = typer.Typer(add_completion=False, pretty_exceptions_enable=False)
+
+Fragments = list[list[tuple[int, int]]]
+GRAD_NAMES = ("out", "dq", "dk", "dv", "dgate", "dbeta")
+FWD_PHASES = ("fwd/prepare", "fwd/summary", "fwd/gather", "fwd/scan", "fwd/run")
+BWD_PHASES = ("bwd/prepare", "bwd/summary", "bwd/gather", "bwd/scan", "bwd/run")
+
+
+def zipf_many_lengths(tokens: int) -> tuple[int, ...]:
+    """One long document plus six tiers of ``2**j`` documents of ``tokens / (8 * 2**j)`` each.
+
+    32k gives 8192 + 2x2048 + 4x1024 + 8x512 + 16x256 + 32x128 + 64x64: 127 documents, most
+    shorter than any practical tile.
+    """
+    if tokens <= 0 or tokens % 8192:
+        raise ValueError(
+            "zipf-many needs a positive multiple of 8192 tokens (shortest tier is 16)"
+        )
+    lengths = [tokens // 4]
+    for j in range(1, 7):
+        lengths += [tokens // (8 * 2**j)] * 2**j
+    assert sum(lengths) == tokens
+    return tuple(lengths)
+
+
+def ownership_lengths(tokens: int) -> tuple[int, ...]:
+    """Nine ragged documents whose whole-document LPT packing differs from a contiguous cut."""
+    if tokens % 32768:
+        raise ValueError("ownership set needs a multiple of 32768 tokens")
+    unit = tokens // 32
+    return tuple(unit * n for n in (12, 6, 4, 3, 2, 2, 1, 1, 1))
+
+
+def cyclic_fragments(cu: Sequence[int], tile: int, world: int) -> Fragments:
+    """Assign successive tiles round-robin."""
+    tiles = tile_stream(cu, tile)
+    return [
+        [(t.start, t.stop) for i, t in enumerate(tiles) if i % world == r] for r in range(world)
+    ]
+
+
+def halves_fragments(cu: Sequence[int], tile: int, world: int) -> Fragments:
+    """Every document cut into ``world`` tile-aligned pieces; odd leftovers alternate ranks."""
+    out: Fragments = [[] for _ in range(world)]
+    for doc, (start, stop) in enumerate(pairwise(cu)):
+        n = math.ceil((stop - start) / tile)
+        base, extra = divmod(n, world)
+        counts = [base + (1 if (r + doc) % world < extra else 0) for r in range(world)]
+        edges = [start + c * tile for c in accumulate(counts, initial=0)]
+        for r, (a, b) in enumerate(pairwise(edges)):
+            if b > a:
+                out[r].append((a, min(b, stop)))
+    return out
+
+
+def lpt_document_fragments(cu: Sequence[int], world: int) -> Fragments:
+    """Whole documents, longest first, each onto the least-loaded rank."""
+    loads = [0] * world
+    out: Fragments = [[] for _ in range(world)]
+    for start, stop in sorted(pairwise(cu), key=lambda d: d[0] - d[1]):
+        r = loads.index(min(loads))
+        out[r].append((start, stop))
+        loads[r] += stop - start
+    return [sorted(f) for f in out]
+
+
+def skew_fragments(cu: Sequence[int], tile: int, world: int, share: float) -> Fragments:
+    """Rank 0 owns a contiguous ``share`` of the tiles; the others split the rest evenly."""
+    tiles = tile_stream(cu, tile)
+    first = round(len(tiles) * share)
+    cuts = [
+        0,
+        first,
+        *(first + (len(tiles) - first) * (r + 1) // (world - 1) for r in range(world - 1)),
+    ]
+    return [[(tiles[a].start, tiles[b - 1].stop)] if b > a else [] for a, b in pairwise(cuts)]
+
+
+def layout_fragments(name: str, cu: Sequence[int], tile: int, world: int) -> Fragments:
+    """Build the selected ownership table without changing the canonical tile grid."""
+    match name:
+        case "contiguous":
+            return balanced_cut(tuple(cu), tile, world)
+        case "halves":
+            return halves_fragments(cu, tile, world)
+        case "cyclic":
+            return cyclic_fragments(cu, tile, world)
+        case "lpt-docs":
+            return lpt_document_fragments(cu, world)
+        case "all-on-0":
+            return [[(0, cu[-1])]] + [[] for _ in range(world - 1)]
+        case _ if name.startswith("skew-"):
+            return skew_fragments(cu, tile, world, int(name[5:]) / 100)
+        case _:
+            raise ValueError(f"unknown layout {name}")
+
+
+def bits_differ(actual: torch.Tensor, expected: torch.Tensor) -> int:
+    """Count unequal storage representations, including signed zeros."""
+    assert actual.shape == expected.shape and actual.dtype == expected.dtype, (
+        actual.shape,
+        expected.shape,
+    )
+    view = torch.int16 if actual.dtype == torch.bfloat16 else torch.int32
+    return int((actual.contiguous().view(view) != expected.contiguous().view(view)).sum())
+
+
+def canonical_states(
+    summary_maps: torch.Tensor,
+    tiling: CanonicalTiling,
+    routing: CanonicalRouting,
+    like: torch.Tensor,
+    group: dist.ProcessGroup,
+    clock: PhaseClock,
+    *,
+    reverse: bool,
+) -> torch.Tensor:
+    """``canonical_entries`` with a clock mark after the gather and after the scan.
+
+    Same statements as the module function, in the same order; the marks are the only addition
+    (checked bitwise against the module's autograd path in ``Study.add_canonical``).
+    """
+    prefix = "bwd" if reverse else "fwd"
+    if summary_maps.shape[0] == 0:
+        all_gather_tile_maps(summary_maps, tiling, routing, like, group)
+        clock.mark(f"{prefix}/gather")
+        states = like.new_zeros(
+            (len(tiling.mine), like.shape[1], like.shape[2] - like.shape[3], like.shape[3])
+        )
+        clock.mark(f"{prefix}/scan")
+        return states
+    gathered = all_gather_tile_maps(summary_maps, tiling, routing, like, group)
+    clock.mark(f"{prefix}/gather")
+    entries = canonical_scan_entries(gathered, routing.document_offsets, reverse=reverse)
+    entries = entries[routing.mine]
+    if routing.summarized_positions is not None:
+        full = entries.new_zeros((len(tiling.mine), *entries.shape[1:]))
+        full[routing.summarized_positions] = entries
+        entries = full
+    clock.mark(f"{prefix}/scan")
+    return entries
+
+
+def canonical_step(
+    stages: StagedOp,
+    local: tuple[torch.Tensor, ...],
+    grad: torch.Tensor,
+    tiling: CanonicalTiling,
+    routing: CanonicalRouting,
+    group: dist.ProcessGroup,
+    clock: PhaseClock,
+) -> tuple[torch.Tensor, ...]:
+    """``context_parallel_chunk_deterministic`` fwd+bwd by hand, one clock mark per phase.
+
+    Keeps the module's arithmetic and collective order; omits autograd tape bookkeeping.
+    """
+    q, k, v, gate, beta = local
+    heads, dim, value_dim = v.shape[2], q.shape[3], v.shape[3]
+    n = len(tiling.mine)
+    like = q.new_empty((0, heads, value_dim + dim, dim), dtype=torch.float32)
+    summarized = routing.summary_bounds.shape[0]
+    prepared = backward = None
+    clock.mark("start")
+    if n:
+        prepared = stages.prepare(q, k, v, gate, beta, cu_seqlens=routing.cu_seqlens)
+    clock.mark("fwd/prepare")
+    maps = like
+    if n and summarized:
+        maps = prepared.state_summaries(routing.summary_bounds, deterministic_work=True)
+    clock.mark("fwd/summary")
+    entry = canonical_states(maps, tiling, routing, like, group, clock, reverse=False)
+    output = prepared.run(entry, output_final_state=False)[0] if n else v[:, :0]
+    clock.mark("fwd/run")
+
+    if n:
+        backward = stages.prepare_backward(prepared.saved, grad, entry, scale=prepared.scale)
+    clock.mark("bwd/prepare")
+    rmaps = like
+    if n and summarized:
+        rmaps = backward.state_grad_summaries(routing.summary_bounds, deterministic_work=True)
+    clock.mark("bwd/summary")
+    exit_cotangent = canonical_states(rmaps, tiling, routing, like, group, clock, reverse=True)
+    grads = backward.run(exit_cotangent)[:5] if n else tuple(t[:, :0] for t in local)
+    clock.mark("bwd/run")
+    return (output, *grads)
+
+
+def autograd_step(
+    fwd: Callable[[], tuple[torch.Tensor, tuple[torch.Tensor, ...], torch.Tensor]],
+    clock: PhaseClock,
+) -> tuple[torch.Tensor, ...]:
+    """Public-API fwd+bwd: two intervals, ``fwd/run`` and ``bwd/run``."""
+    clock.mark("start")
+    out, leaves, grad = fwd()
+    clock.mark("fwd/run")
+    grads = torch.autograd.grad(out, leaves, grad)
+    clock.mark("bwd/run")
+    return (out.detach(), *grads)
+
+
+class Study:
+    """Inputs, group, and the variant table of one torchrun session."""
+
+    def __init__(self, tokens: int, heads: int, backend: str, lengths: Sequence[int]) -> None:
+        """Initialize a two-or-more-rank study with identical seeded global inputs."""
+        self.rank, self.world = int(os.environ["RANK"]), int(os.environ["WORLD_SIZE"])
+        self.device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+        torch.cuda.set_device(self.device)
+        dist.init_process_group("nccl", device_id=self.device)
+        self.group = dist.group.WORLD
+        self.tokens, self.heads, self.backend = tokens, heads, backend
+        self.options = {"backend": backend} if backend != "fused" else None
+        self.stages = _kda_stages(None, False, False, self.options)
+        self.lengths = tuple(lengths)
+        self.cu = (0, *accumulate(self.lengths))
+        torch.manual_seed(0)
+        self.inputs = make_kda_test_inputs(
+            tokens,
+            heads=heads,
+            seed=0,
+            normalize_qk=True,
+            sigmoid_beta=True,
+            gate_scale=0.02,
+            log_uniform_gate=False,
+        )
+        self.grad = torch.randn_like(self.inputs[2])
+        self.variants: dict[str, Callable[[PhaseClock], tuple[torch.Tensor, ...]]] = {}
+        self.checks: dict[str, dict[str, int]] = {}
+
+    def log(self, *args) -> None:
+        """Print layout information once across ranks."""
+        if self.rank == 0:
+            print(*args, flush=True)
+
+    def gather_local(self, ids: torch.Tensor) -> tuple[tuple[torch.Tensor, ...], torch.Tensor]:
+        """Copy inputs and output cotangents into the rank-local span order."""
+        return tuple(v[:, ids].contiguous() for v in self.inputs), self.grad[:, ids].contiguous()
+
+    def add_unsharded(self) -> None:
+        """Register the CP=1 reference cost on every rank."""
+        op = partial(
+            chunk_kda,
+            cu_seqlens=torch.tensor(self.cu, dtype=torch.int32, device=self.device),
+            kernel_options=self.options,
+            autotune=False,
+        )
+        self.variants["unsharded"] = partial(
+            autograd_step, partial(forward, op, self.inputs, self.grad)
+        )
+
+    def add_standard(self, name: str, fragments: Fragments) -> None:
+        """Register the public standard recipe, which does not support empty spans."""
+        if any(not f for f in fragments):
+            return
+        plan = ContextParallelPlan.from_fragments(self.cu, fragments, self.rank)
+        local, grad = self.gather_local(plan.global_token_ids(self.device))
+        op = partial(
+            context_parallel_kda,
+            routing=plan.routing(self.device),
+            group=self.group,
+            kernel_options=self.options,
+            autotune=False,
+        )
+        self.variants[name] = partial(autograd_step, partial(forward, op, local, grad))
+
+    def add_canonical(
+        self,
+        name: str,
+        fragments: Fragments,
+        tile: int,
+        *,
+        module: bool = False,
+    ) -> None:
+        """Register the hand-run canonical recipe (and, with ``module``, the autograd path)."""
+        tiling = CanonicalTiling.from_fragments(self.cu, fragments, self.rank, tile_size=tile)
+        routing = tiling.routing(self.device)
+        ids = tiling.global_token_ids(self.device)
+        local, grad = self.gather_local(ids)
+        self.variants[name] = partial(
+            canonical_step, self.stages, local, grad, tiling, routing, self.group
+        )
+
+        op = partial(
+            context_parallel_kda_deterministic,
+            tiling=tiling,
+            routing=routing,
+            group=self.group,
+            kernel_options=self.options,
+        )
+        fwd = partial(forward, op, local, grad)
+        expected = autograd_step(fwd, PhaseClock())
+        actual = self.variants[name](PhaseClock())
+        self.checks[name] = {
+            k: bits_differ(a, e) for k, a, e in zip(GRAD_NAMES, actual, expected, strict=True)
+        }
+        if module:
+            self.variants[f"{name}@module"] = partial(autograd_step, fwd)
+
+    def run(self, rounds: int, iters: int, out_path: Path | None, header: str) -> None:
+        """Validate all ranks, warm up, then time interleaved variants and emit JSON."""
+        checks = [None] * self.world
+        dist.all_gather_object(checks, self.checks)
+        merged_checks = {
+            n: {k: sum(c[n][k] for c in checks) for k in GRAD_NAMES} for n in self.checks
+        }
+        assert not any(v for check in merged_checks.values() for v in check.values()), (
+            merged_checks
+        )
+        names = list(self.variants)
+        for name in names:  # warm-up / compile
+            for _ in range(2):
+                self.variants[name](PhaseClock())
+        torch.cuda.synchronize(self.device)
+        phases = {n: [] for n in names}
+        fwd = {n: [] for n in names}
+        bwd = {n: [] for n in names}
+        for r in range(rounds):
+            for name in names if r % 2 == 0 else names[::-1]:
+                p, f, b = timed(self.variants[name], iters=iters, device=self.device)
+                phases[name] += p
+                fwd[name] += f
+                bwd[name] += b
+        # Every rank's phase medians to rank 0.
+        local_medians = {
+            n: {k: statistics.median(p[k] for p in phases[n]) for k in phases[n][0]} for n in names
+        }
+        all_medians = [None] * self.world
+        dist.all_gather_object(all_medians, local_medians)
+        rows = []
+        if self.rank == 0:
+            for name in names:
+                rows.append(
+                    {
+                        "variant": name,
+                        "fwd_ms": statistics.median(fwd[name]),
+                        "bwd_ms": statistics.median(bwd[name]),
+                        "fwd_p95": sorted(fwd[name])[-1 - len(fwd[name]) // 20],
+                        "bwd_p95": sorted(bwd[name])[-1 - len(bwd[name]) // 20],
+                        "ranks": [m[name] for m in all_medians],
+                        "check_bits_differ": merged_checks.get(name),
+                    }
+                )
+            self.print_table(rows, header)
+            if out_path:
+                out_path.parent.mkdir(parents=True, exist_ok=True)
+                out_path.write_text(
+                    json.dumps(
+                        {
+                            "header": header,
+                            "tokens": self.tokens,
+                            "heads": self.heads,
+                            "backend": self.backend,
+                            "world": self.world,
+                            "lengths": self.lengths,
+                            "rounds": rounds,
+                            "iters": iters,
+                            "device": torch.cuda.get_device_name(self.device),
+                            "torch": torch.__version__,
+                            "rows": rows,
+                            "samples": {"fwd_ms": fwd, "bwd_ms": bwd},
+                        },
+                        indent=1,
+                    )
+                    + "\n"
+                )
+        dist.barrier()
+
+    def print_table(self, rows: list[dict], header: str) -> None:
+        """Report slowest-rank totals and each rank's local phase medians (ms)."""
+        print(f"\n{header}\ntokens={self.tokens} heads={self.heads} backend={self.backend}")
+        print(f"{'variant':<22}{'fwd ms':>9}{'bwd ms':>9}{'fwd p95':>9}{'bwd p95':>9}  checks")
+        for row in rows:
+            chk = row["check_bits_differ"]
+            chk_s = "-" if chk is None else ("bitwise" if not any(chk.values()) else str(chk))
+            print(
+                f"{row['variant']:<22}{row['fwd_ms']:>9.3f}{row['bwd_ms']:>9.3f}"
+                f"{row['fwd_p95']:>9.3f}{row['bwd_p95']:>9.3f}  {chk_s}"
+            )
+        print("\nper-rank phase medians (ms):")
+        head = f"{'variant':<22}{'rank':>5}" + "".join(
+            f"{p.split('/')[1]:>9}" for p in FWD_PHASES + BWD_PHASES
+        )
+        print(head + f"{'fwd':>9}{'bwd':>9}")
+        for row in rows:
+            for r, m in enumerate(row["ranks"]):
+                cells = "".join(f"{m.get(p, 0.0):>9.3f}" for p in FWD_PHASES + BWD_PHASES)
+                f = sum(v for k, v in m.items() if k.startswith("fwd"))
+                b = sum(v for k, v in m.items() if k.startswith("bwd"))
+                print(f"{row['variant']:<22}{r:>5}{cells}{f:>9.3f}{b:>9.3f}")
+
+
+OUT_DIR = Path("agent_space/friendly_fragments")
+
+
+@app.command()
+def ownership(
+    tokens: Annotated[int, typer.Option()] = 32768,
+    heads: Annotated[int, typer.Option()] = 64,
+    backend: Annotated[str, typer.Option()] = "mega",
+    tile: Annotated[int, typer.Option()] = 1024,
+    layouts: Annotated[str, typer.Option()] = (
+        "contiguous,halves,cyclic,lpt-docs,skew-62,skew-75,all-on-0"
+    ),
+    rounds: Annotated[int, typer.Option()] = 5,
+    iters: Annotated[int, typer.Option()] = 10,
+    out_path: Annotated[Path | None, typer.Option("--out")] = None,
+) -> None:
+    """Q1: does ownership shape matter at a fixed tile size? Standard vs canonical per layout."""
+    study = Study(tokens, heads, backend, ownership_lengths(tokens))
+    study.add_unsharded()
+    for name in layouts.split(","):
+        fragments = layout_fragments(name, study.cu, tile, study.world)
+        study.log(f"{name}: {fragments}")
+        study.add_standard(f"cp/{name}", fragments)
+        study.add_canonical(f"det/{name}", fragments, tile, module=True)
+    study.run(
+        rounds,
+        iters,
+        out_path or OUT_DIR / f"ownership_{backend}_{tokens}_t{tile}.json",
+        f"Q1 ownership, tile={tile}, docs={study.lengths}",
+    )
+    dist.destroy_process_group()
+
+
+@app.command()
+def tile_sweep(
+    tokens: Annotated[int, typer.Option()] = 32768,
+    heads: Annotated[int, typer.Option()] = 64,
+    backend: Annotated[str, typer.Option()] = "mega",
+    tiles: Annotated[str, typer.Option()] = "256,512,1024,2048,4096,8192",
+    docs: Annotated[str, typer.Option(help="zipf-many or zipf5")] = "zipf-many",
+    layout: Annotated[str, typer.Option()] = "contiguous",
+    rounds: Annotated[int, typer.Option()] = 5,
+    iters: Annotated[int, typer.Option()] = 10,
+    out_path: Annotated[Path | None, typer.Option("--out")] = None,
+) -> None:
+    """Q2: tile size against a Zipf-like document mix (many single-tile documents)."""
+    tile_sizes = [int(t) for t in tiles.split(",")]
+    lengths = (
+        zipf_many_lengths(tokens)
+        if docs == "zipf-many"
+        else document_lengths(tokens, max(tile_sizes))
+    )
+    study = Study(tokens, heads, backend, lengths)
+    grid = max(tile_sizes)
+    fragments = layout_fragments(layout, study.cu, grid, study.world)
+    study.log(f"fragments={fragments}")
+    study.add_unsharded()
+    study.add_standard("cp", fragments)
+    for tile in tile_sizes:
+        tiles_all = tile_stream(study.cu, tile)
+        single = sum(length <= tile for length in lengths)
+        study.log(f"tile {tile}: {len(tiles_all)} tiles, {single} in single-tile documents")
+        study.add_canonical(f"det-{tile}", fragments, tile, module=True)
+    study.run(
+        rounds,
+        iters,
+        out_path or OUT_DIR / f"tile_sweep_{backend}_{docs}_{tokens}.json",
+        f"Q2 tile sweep, docs={docs}, layout={layout}",
+    )
+    dist.destroy_process_group()
+
+
+@app.command()
+def crossover(
+    tokens: Annotated[int, typer.Option()] = 32768,
+    heads: Annotated[int, typer.Option()] = 64,
+    backend: Annotated[str, typer.Option()] = "mega",
+    doc_len: Annotated[int, typer.Option(help="Every document has this length.")] = 512,
+    tile: Annotated[int, typer.Option()] = 1024,
+    rounds: Annotated[int, typer.Option()] = 5,
+    iters: Annotated[int, typer.Option()] = 10,
+    out_path: Annotated[Path | None, typer.Option("--out")] = None,
+) -> None:
+    """Q3: many equal short documents, none crossing ranks: when is canonical CP cheaper?"""
+    if tokens % doc_len or doc_len > tile:
+        raise typer.BadParameter("doc_len must divide tokens and not exceed tile")
+    study = Study(tokens, heads, backend, [doc_len] * (tokens // doc_len))
+    fragments = balanced_cut(study.cu, tile, study.world)
+    study.log(f"fragments={fragments}")
+    study.add_unsharded()
+    study.add_standard("cp", fragments)
+    study.add_canonical(f"det-{tile}", fragments, tile, module=True)
+    study.run(
+        rounds,
+        iters,
+        out_path or OUT_DIR / f"crossover_{backend}_{tokens}_d{doc_len}_t{tile}.json",
+        f"Q3 crossover, {tokens // doc_len} documents of {doc_len}, tile={tile}",
+    )
+    dist.destroy_process_group()
+
+
+@app.command()
+def split(
+    tokens: Annotated[int, typer.Option()] = 32768,
+    heads: Annotated[str, typer.Option()] = "64,16,8",
+    gates: Annotated[str, typer.Option(help="mild (bench gate) and/or strong.")] = "mild,strong",
+    tile: Annotated[int, typer.Option(help="Packing whose split table is also counted.")] = 1024,
+    rounds: Annotated[int, typer.Option()] = 5,
+    iters: Annotated[int, typer.Option()] = 20,
+    out_path: Annotated[Path | None, typer.Option("--out")] = None,
+) -> None:
+    """Q4: Mega unsplit vs forgetting-horizon split forward on one dense stream (single process)."""
+    from attn_gym.linear._delta_rule.mega.schedule import prepare_mega_schedule
+
+    device = torch.device("cuda", torch.cuda.current_device())
+    results = []
+    for h in (int(x) for x in heads.split(",")):
+        for gate_name in gates.split(","):
+            strong = gate_name == "strong"
+            inputs = make_kda_test_inputs(
+                tokens,
+                heads=h,
+                seed=0,
+                normalize_qk=True,
+                sigmoid_beta=True,
+                gate_scale=5.0 if strong else 0.02,
+                log_uniform_gate=strong,
+            )
+            variants = {
+                "unsplit": {"backend": "mega"},
+                "split": {"backend": "mega", "split_forward": True},
+            }
+            outs = {}
+            with torch.no_grad():
+                for name, opts in variants.items():
+                    for _ in range(3):
+                        outs[name] = chunk_kda(*inputs, kernel_options=opts, autotune=False)[0]
+                torch.cuda.synchronize()
+                samples = {n: [] for n in variants}
+                for r in range(rounds):
+                    order = list(variants) if r % 2 == 0 else list(variants)[::-1]
+                    for name in order:
+                        op = partial(
+                            chunk_kda, *inputs, kernel_options=variants[name], autotune=False
+                        )
+                        _, fwd, _ = timed(
+                            partial(clocked, op, phase="fwd/run"),
+                            iters=iters,
+                            device=device,
+                            distributed=False,
+                        )
+                        samples[name] += fwd
+            gate, cu_dense = inputs[3], torch.tensor([0, tokens], dtype=torch.int32, device=device)
+            cu_tiles = torch.arange(0, tokens + 1, tile, dtype=torch.int32, device=device)
+            stream = torch.cuda.current_stream().cuda_stream
+            items = {}
+            for label, cu in (("dense", cu_dense), (f"tiles-{tile}", cu_tiles)):
+                sched = prepare_mega_schedule(
+                    gate, cu, tile_tokens=16, counter_count=2, split=True, stream=stream
+                )
+                torch.cuda.synchronize()
+                items[label] = (int(sched.work_count.item()), (cu.numel() - 1) * h)
+            row = {
+                "heads": h,
+                "gate": gate_name,
+                "unsplit_ms": statistics.median(samples["unsplit"]),
+                "split_ms": statistics.median(samples["split"]),
+                "rel_l2": (
+                    (outs["split"].float() - outs["unsplit"].float()).norm()
+                    / outs["unsplit"].float().norm().clamp_min(1e-30)
+                ).item(),
+                "max_abs": (outs["split"].float() - outs["unsplit"].float()).abs().max().item(),
+                "bits_differ": bits_differ(outs["split"], outs["unsplit"]),
+                "work_items": items,
+            }
+            results.append(row)
+            print(
+                f"H={h:<3} gate={gate_name:<6} unsplit {row['unsplit_ms']:.3f} ms  "
+                f"split {row['split_ms']:.3f} ms  speedup {row['unsplit_ms'] / row['split_ms']:.2f}x"
+                f"  rel-L2 {row['rel_l2']:.2e} max|d| {row['max_abs']:.2e}"
+                f"  bits differ {row['bits_differ']}  items {items}",
+                flush=True,
+            )
+    path = out_path or OUT_DIR / f"split_{tokens}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "tokens": tokens,
+                "tile": tile,
+                "rounds": rounds,
+                "iters": iters,
+                "device": torch.cuda.get_device_name(device),
+                "torch": torch.__version__,
+                "rows": results,
+            },
+            indent=1,
+        )
+        + "\n"
+    )
+
+
+if __name__ == "__main__":
+    app()

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -606,8 +606,8 @@ fragment table, including CP=1**; for KDA they are also bitwise the public `chun
 else is required: no flag, no tiling, no change to the kernels. `document_aligned_fragments` in
 `examples/linear/delta_rule_context_parallel.py` (`--partition documents`) assigns whole documents
 to ranks, longest first onto the least-loaded rank, so ranks stay within one document's length of
-each other. What it cannot do is split a document that does not fit on one rank; that is what
-the summaries above are for.
+each other. What it cannot do is split a document that does not fit on one rank; that case is
+the deterministic mode below.
 
 ### Mega local execution
 
@@ -639,9 +639,66 @@ the maps carry Mega's 16-token-chunk rounding, so Mega under CP is its own numer
 neither the fused CP baseline nor unsharded Mega. The staged handles and this recipe are
 eager-only; `torch.compile` is not supported through them.
 
+### Deterministic mode: results independent of the CP degree
+
+`context_parallel_kda_deterministic` gives **bitwise-identical output and all input gradients
+across CP degrees**: pick a `tile_size`, cut fragments on its grid, call this entry point at
+every CP degree including 1 with the same backend and settings, and the bits are identical.
+Whole-tile ownership and neighboring packed documents do not change a document's result. This is
+a distinct numerical baseline from standard CP and unsharded `chunk_kda`; FP64 reference tests
+bound its error with the repository's BF16 budget.
+
+Each document is tiled from its first token with `tile_size` a positive multiple of 64; its last
+tile may be short. Fragment boundaries must coincide with tile boundaries. Each rank prepares
+its tiles as packed subsequences, using `deterministic_work=True` to pin summary arithmetic.
+The all-gathered maps are folded in document order with three-pass TF32; backward mirrors the
+fold over reverse maps. Single-tile documents need no summaries, exchange payload, or scan.
+
+```python
+from attn_gym.linear.context_parallel_deterministic import CanonicalTiling
+from attn_gym.linear.kda import context_parallel_kda_deterministic
+
+tiling = CanonicalTiling.from_fragments(cu_seqlens_global, fragments, rank, tile_size=1024)
+ids = tiling.global_token_ids(device)  # this rank's tiles, in span order
+routing = tiling.routing(device)  # index tensors; reuse while the layout is fixed
+output = context_parallel_kda_deterministic(
+    q[:, ids],
+    k[:, ids],
+    v[:, ids],
+    gate[:, ids],
+    beta[:, ids],
+    tiling=tiling,
+    routing=routing,
+    group=group,
+)
+```
+
+Every rank must call forward and backward equally often, including empty ranks. The API returns
+only local output, not final states. Autotuning is disabled. Fused and Mega use their own staged
+backwards; Mega's canonical reverse maps use native zero-exit cotangents plus the transposed
+forward transition, not fused-map or native backward-probe rounding. Mega's `split_forward` and
+`split_backward` are rejected: approximate horizon cuts would change the FP32 summary leaves.
+
+**Cost and fragment plans.** With `K = V = 128`, every summarized tile contributes an
+`H x 256 x 128` FP32 map (128 KiB per head). Every rank holds the gathered maps, including
+collective padding, plus entry states for its own tiles. Larger tiles reduce map overhead but
+can reduce leaf parallelism. Balance both tokens and tiles of multi-tile documents across ranks;
+cutting long documents on tile boundaries adds no summaries. Contiguous rank-order ownership
+with equal summarized-tile counts avoids the gathered-map placement copy.
+
+Recorded runs on two GB200s at 32k tokens / 64 heads / five documents measured tile 1024 at
+1.22x / 0.85x standard CP forward/backward time for Mega, and 1.52x / 1.20x for fused (lower is
+better). With many short documents, tile 2048 can beat standard CP in both directions. These
+are eager KDA-operation timings, not end-to-end model measurements. Reproduce for your packing with
+`benchmarks/kda_cp_deterministic.py` or `benchmarks/kda_cp_fragment_study.py`.
+
 ::: attn_gym.linear.context_parallel.context_parallel_chunk
 
 ::: attn_gym.linear.kda.context_parallel.context_parallel_kda
+
+::: attn_gym.linear.kda.context_parallel.context_parallel_kda_deterministic
+
+::: attn_gym.linear.context_parallel_deterministic.CanonicalTiling
 
 ::: attn_gym.linear.gdn.context_parallel.context_parallel_gdn
 

--- a/test/kda/mega/test_kda_mega_native_summary.py
+++ b/test/kda/mega/test_kda_mega_native_summary.py
@@ -1,4 +1,4 @@
-"""Native Mega affine probes define a standard Mega CP baseline."""
+"""Native Mega affine probes define an ownership-invariant canonical CP baseline."""
 
 from __future__ import annotations
 
@@ -157,20 +157,31 @@ def test_native_two_tile_handoff_matches_fp64(dtype: torch.dtype, monkeypatch) -
     prepared = chunk_kda_prepare(*inputs, cu_seqlens=cu, autotune=False, kernel_options=MEGA)
     _forbid_fused_factors(monkeypatch)
     bounds = torch.stack((cu[:-1], cu[1:]), dim=1)
-    maps = prepared.state_summaries(bounds)
+    maps = prepared.state_summaries(bounds, deterministic_work=True)
     entry0 = torch.zeros_like(maps[0, :, :128])
     entries = torch.stack((entry0, merge_state(entry0, maps[0])))
     output, final = prepared.run(entries, output_final_state=True)
     assert final is not None
     composed_final = merge_state(entries[1], maps[1])
+    do = torch.randn_like(output)
+    exit1 = torch.randn_like(entry0) * 0.1
+    backward = chunk_kda_prepare_backward(
+        prepared.saved, do, entries, scale=prepared.scale, autotune=False
+    )
+    reverse = backward.state_grad_summaries(bounds, deterministic_work=True)
+    exits = torch.stack((merge_state(exit1, reverse[1]), exit1))
+    gradients = backward.run(exits)[:5]
     references = []
     for precision in (torch.float64, torch.float32):
         leaves = tuple(t.requires_grad_() for t in clone_kda_inputs(inputs, dtype=precision))
         ref_output, ref_final = kda_reference(*leaves, scale=prepared.scale)
-        references.append((ref_output, ref_final, ref_final))
+        ref_gradients = torch.autograd.grad(
+            (ref_output, ref_final), leaves, (do.to(precision), exit1[None].to(precision))
+        )
+        references.append((ref_output, ref_final, ref_final, *ref_gradients))
     for name, actual, high, low in zip(
-        ("output", "native final", "composed final"),
-        (output, final[-1:], composed_final[None]),
+        ("output", "native final", "composed final", "dq", "dk", "dv", "dgate", "dbeta"),
+        (output, final[-1:], composed_final[None], *gradients),
         *references,
         strict=True,
     ):
@@ -281,6 +292,7 @@ def test_native_reverse_bias_and_ownership(
     if transpose_forward_transition:
         bounds = torch.stack((cu[:-1], cu[1:]), dim=1)
         assert torch.equal(backward.state_grad_summaries(bounds), maps)
+        assert torch.equal(backward.state_grad_summaries(bounds, deterministic_work=True), maps)
     else:
         zero_backward = chunk_kda_prepare_backward(
             prepared.saved,

--- a/test/test_canonical_tile_batching.py
+++ b/test/test_canonical_tile_batching.py
@@ -1,0 +1,157 @@
+"""Bitwise ownership invariance of the fused canonical-tile staged primitives.
+
+Independent per-tile calls use dense dispatch for complete tiles and default summary work.
+The candidate packs the same tiles as subsequences in one call with pinned summary work.
+Random nonzero entry states and exit cotangents exercise both affine boundary terms.
+"""
+
+from __future__ import annotations
+
+import math
+from itertools import accumulate, pairwise
+
+import pytest
+import torch
+
+pytest.importorskip("cutlass")
+
+from attn_gym.linear.context_parallel_deterministic import tile_stream
+from attn_gym.linear.kda.stages import (
+    ChunkKDAPrepared,
+    chunk_kda_prepare,
+    chunk_kda_prepare_backward,
+)
+from attn_gym.testing.kda import make_kda_test_inputs
+
+pytestmark = pytest.mark.skipif(
+    not (torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 8),
+    reason="fused canonical tiles require CUDA capability 8.0+",
+)
+
+
+def assert_bitwise_equal(actual: torch.Tensor, expected: torch.Tensor, name: str) -> None:
+    """Check numerical equality and storage bits, including the sign of zero."""
+    assert torch.isfinite(actual).all(), name
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0, msg=name)
+    integer_dtype = torch.int16 if actual.element_size() == 2 else torch.int32
+    torch.testing.assert_close(
+        actual.contiguous().view(integer_dtype),
+        expected.contiguous().view(integer_dtype),
+        rtol=0,
+        atol=0,
+        msg=f"{name}: integer view",
+    )
+
+
+@torch.no_grad()
+def run_tiles(
+    inputs: tuple[torch.Tensor, ...],
+    d_output: torch.Tensor,
+    lengths: list[int],
+    entry: torch.Tensor,
+    exit_grad: torch.Tensor,
+    *,
+    packed: bool,
+) -> dict[str, torch.Tensor]:
+    """Snapshot each stage before backward consumes its prepared intermediates."""
+    offsets = [0, *accumulate(lengths)]
+    cu_seqlens = torch.tensor(offsets, dtype=torch.int32, device="cuda") if packed else None
+    prepared = chunk_kda_prepare(
+        *inputs,
+        cu_seqlens=cu_seqlens,
+        autotune=False,
+        kernel_options={"backend": "fused"},
+    )
+    assert isinstance(prepared, ChunkKDAPrepared)
+    bounds = torch.tensor(list(pairwise(offsets)), dtype=torch.int32, device="cuda")
+    result = {f"factor/{name}": value for name, value in prepared.factors._asdict().items()}
+    result["cumulative_gate"] = prepared.saved.cumulative_gate
+    result["summary"] = prepared.state_summaries(bounds, deterministic_work=packed)
+    output, final_state = prepared.run(entry, output_final_state=True)
+    assert final_state is not None
+    result["output"] = output
+    result["final_state"] = final_state
+    backward = chunk_kda_prepare_backward(
+        prepared.saved,
+        d_output,
+        entry,
+        scale=prepared.scale,
+        autotune=False,
+        schedule=prepared.schedule,
+    )
+    for name in ("w", "qg", "kg", "aqk", "akk", "v_new", "d_aqk"):
+        value = vars(backward.prepared)[name]
+        assert value is not None
+        result[f"backward/{name}"] = value
+    assert backward.prepared.h is not None
+    # Packed allocation capacity can exceed the active chunks; never inspect padding.
+    chunks = sum(math.ceil(length / 64) for length in lengths)
+    result["backward/h"] = backward.prepared.h[:, :chunks]
+    result["grad_summary"] = backward.state_grad_summaries(bounds, deterministic_work=packed)
+    gradients = backward.run(exit_grad)
+    for name, value in zip(
+        ("dq", "dk", "dv", "dgate", "dbeta", "d_entry"), gradients, strict=True
+    ):
+        assert value is not None
+        result[name] = value
+    return result
+
+
+@pytest.mark.parametrize("tile_size", [64, 128])
+@pytest.mark.parametrize("heads", [4, 64])
+@pytest.mark.parametrize("gate", ["mild", "strong"])
+def test_canonical_tile_batching(tile_size: int, heads: int, gate: str) -> None:
+    """Packing rank-owned ragged tiles must preserve every forward/backward stage bit."""
+    torch.manual_seed(41)
+    doc_offsets = [0, *accumulate([17, 65, 129, 257, 513])]
+    tiles = tile_stream(doc_offsets, tile_size)
+    inputs = make_kda_test_inputs(
+        doc_offsets[-1],
+        heads=heads,
+        seed=41,
+        normalize_qk=True,
+        sigmoid_beta=True,
+        gate_scale=math.log(2) if gate == "strong" else 0.02,
+        log_uniform_gate=gate == "strong",
+    )
+    d_output = torch.randn_like(inputs[2])
+    entry = torch.randn(len(tiles), heads, 128, 128, device="cuda") * 0.1
+    exit_grad = torch.randn_like(entry) * 0.1
+    reference = [
+        run_tiles(
+            tuple(value[:, tile.start : tile.stop].clone() for value in inputs),
+            d_output[:, tile.start : tile.stop].clone(),
+            [tile.length],
+            entry[i : i + 1],
+            exit_grad[i : i + 1],
+            packed=False,
+        )
+        for i, tile in enumerate(tiles)
+    ]
+    # Three independent copies cross the summary-budget and short-sequence recurrence
+    # thresholds. Rotation makes the default budget split inside a two-chunk tile.
+    owners = [
+        list(range(len(tiles))),
+        list(range(0, len(tiles), 2)),
+        list(range(1, len(tiles), 2))[::-1],
+        (list(range(4, len(tiles))) + list(range(4))) * 3,
+        [next(i for i, tile in enumerate(tiles) if tile.length == tile_size)],
+    ]
+    state_names = {"summary", "grad_summary", "final_state", "d_entry"}
+    for owned in owners:
+        batched = run_tiles(
+            tuple(
+                torch.cat([value[:, tiles[i].start : tiles[i].stop] for i in owned], dim=1)
+                for value in inputs
+            ),
+            torch.cat([d_output[:, tiles[i].start : tiles[i].stop] for i in owned], dim=1),
+            [tiles[i].length for i in owned],
+            entry[owned],
+            exit_grad[owned],
+            packed=True,
+        )
+        for name, value in batched.items():
+            expected = torch.cat(
+                [reference[i][name] for i in owned], dim=0 if name in state_names else 1
+            )
+            assert_bitwise_equal(value, expected, f"{name}, owned={owned}")

--- a/test/test_context_parallel_deterministic.py
+++ b/test/test_context_parallel_deterministic.py
@@ -1,0 +1,410 @@
+"""CP-degree-invariant KDA: canonical tiles give bitwise-equal results for any rank ownership.
+
+The reference for every case is a fresh single-process canonical run (CP=1) over the same tiles.
+Two-rank cases use NCCL when two GPUs exist, otherwise Gloo between two processes on one GPU (the
+transport carries FP32 maps bit-for-bit either way). Ownership tables cover contiguous, cyclic,
+uneven, and empty-rank layouts on ragged packed documents.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import socket
+import time
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from itertools import accumulate, pairwise
+from unittest.mock import patch
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+pytest.importorskip("cutlass")
+
+import attn_gym.linear.context_parallel_deterministic as det
+from attn_gym.linear._delta_rule.triton.canonical_scan import canonical_scan_entries
+from attn_gym.linear.context_parallel import compose_summaries
+from attn_gym.linear.context_parallel_deterministic import (
+    CanonicalTiling,
+    canonical_entries,
+    tile_stream,
+)
+from attn_gym.linear.kda.context_parallel import _kda_stages, context_parallel_kda_deterministic
+from attn_gym.linear.types import KernelOptions
+from attn_gym.testing.kda import kda_reference, make_kda_test_inputs
+
+pytestmark = [
+    pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA"),
+    pytest.mark.xdist_group("two-gpu"),
+]
+
+HEADS = 4
+RAGGED = (17, 65, 129, 257, 513)
+ELEPHANT = (800, 31, 33, 31, 33, 31, 33)
+NAMES = ("output", "dq", "dk", "dv", "dgate", "dbeta")
+
+
+# ---------------------------------------------------------------- planner (CPU)
+
+
+def test_tiles_align_to_document_starts_and_keep_tails():
+    cu = (0, *accumulate(RAGGED))
+    tiles = tile_stream(cu, 64)
+    assert [t.length for t in tiles if t.document == 0] == [17]
+    assert [t.length for t in tiles if t.document == 1] == [64, 1]
+    assert [t.length for t in tiles if t.document == 4] == [64] * 8 + [1]
+    assert all((t.start - cu[t.document]) % 64 == 0 for t in tiles)
+    assert tiles[-1].stop == cu[-1]
+
+
+def test_fragments_must_fall_on_tile_boundaries():
+    cu = (0, *accumulate(RAGGED))
+    CanonicalTiling.from_fragments(
+        cu, [[(0, 17), (82, 211)], [(17, 82), (211, 981)]], 0, tile_size=64
+    )
+    with pytest.raises(ValueError, match="tile boundaries"):
+        CanonicalTiling.from_fragments(cu, [[(0, 100)], [(100, 981)]], 0, tile_size=64)
+    with pytest.raises(ValueError, match="multiple of 64"):
+        CanonicalTiling.from_fragments(cu, [[(0, 981)], []], 0, tile_size=48)
+    with pytest.raises(ValueError, match="exactly once"):
+        CanonicalTiling.from_fragments(cu, [[(0, 17)], [(82, 981)]], 0, tile_size=64)
+    with pytest.raises(ValueError, match="reversed"):
+        CanonicalTiling.from_fragments(cu, [[(17, 0)], [(17, 981)]], 0, tile_size=64)
+    with pytest.raises(ValueError, match="outside"):
+        CanonicalTiling.from_fragments(cu, [[(0, 981)], []], 2, tile_size=64)
+    tiling = CanonicalTiling.from_fragments(cu, [[(0, 981)]], 0, tile_size=64)
+    # The 17-token document fits one tile and is not summarized.
+    single = {i for i, t in enumerate(tiling.tiles) if t.document == 0}
+    assert set(tiling.summarized) == set(range(len(tiling.tiles))) - single
+
+
+def test_non_contiguous_ownership_keeps_span_order_consistent():
+    """A rank owning tiles from two places lists them in fragment order; ids follow that order."""
+    cu = (0, *accumulate(RAGGED))
+    fragments = [[(0, 17), (211, 981)], [(17, 211)]]
+    tiling = CanonicalTiling.from_fragments(cu, fragments, 0, tile_size=64)
+    ids = tiling.global_token_ids("cpu").tolist()
+    assert ids == list(range(17)) + list(range(211, 981))
+    offsets = tiling.span_offsets()
+    assert offsets[0] == 0 and offsets[-1] == len(ids)
+    assert [tiling.tiles[i].length for i in tiling.mine] == [b - a for a, b in pairwise(offsets)]
+
+
+def _serial_entries(
+    leaves: torch.Tensor, offsets: Sequence[int], *, reverse: bool
+) -> torch.Tensor:
+    """Exclusive serial prefix bias, restarting at each document in either direction."""
+    value_dim = leaves.shape[2] - leaves.shape[3]
+    entries = torch.zeros(
+        leaves.shape[0], leaves.shape[1], value_dim, leaves.shape[3], device=leaves.device
+    )
+    for start, stop in pairwise(offsets):
+        indices = range(stop - 1, start - 1, -1) if reverse else range(start, stop)
+        prefix = leaves[indices[0]]
+        for i in indices[1:]:
+            entries[i] = prefix[:, :value_dim, :]
+            prefix = compose_summaries(prefix, leaves[i])
+    return entries
+
+
+def _leaves(n: int, seed: int) -> torch.Tensor:
+    """Random affine maps with near-identity transitions to keep long prefixes nontrivial."""
+    torch.manual_seed(seed)
+    leaves = torch.randn(n, 2, 256, 128, device="cuda")
+    leaves[:, :, 128:, :] = torch.eye(128, device="cuda") + 0.01 * torch.randn(
+        n, 2, 128, 128, device="cuda"
+    )
+    return leaves
+
+
+def _single_rank_tiling(lengths: Sequence[int], tile_size: int = 64) -> CanonicalTiling:
+    """Tile packed document lengths with every token owned by one rank."""
+    cu = (0, *accumulate(lengths))
+    return CanonicalTiling.from_fragments(cu, [[(0, cu[-1])]], 0, tile_size=tile_size)
+
+
+@pytest.mark.parametrize("tile_counts", [(9,), (3, 1, 3), (1, 1, 1, 1), (1,)])
+def test_fused_scan_matches_serial_composition_per_document(tile_counts):
+    """The fused scan restarts at documents and equals serial composition to fp32 accuracy."""
+    leaves = _leaves(sum(tile_counts), 0)
+    offsets = [0, *accumulate(tile_counts)]
+    device_offsets = torch.tensor(offsets, dtype=torch.int32, device="cuda")
+    for reverse in (False, True):
+        torch.testing.assert_close(
+            canonical_scan_entries(leaves, device_offsets, reverse=reverse),
+            _serial_entries(leaves, offsets, reverse=reverse),
+            atol=1e-4,
+            rtol=1e-5,
+        )
+
+
+def test_entries_of_a_document_are_independent_of_its_neighbours():
+    """A document's entry states are bitwise the same wherever it sits in the packed stream."""
+    document = _leaves(5, 1)
+    reference: dict[bool, torch.Tensor] = {}
+    for before, after in ((0, 0), (1, 0), (3, 2), (7, 5)):
+        others = _leaves(before + after, 2 + before)
+        leaves = torch.cat((others[:before], document, others[before:]))
+        tiling = _single_rank_tiling([64 * count for count in (before, 5, after) if count])
+        summarized = torch.tensor(tiling.summarized, device="cuda")
+        for reverse in (False, True):
+            entries = canonical_entries(
+                leaves[summarized],
+                tiling,
+                tiling.routing("cuda"),
+                leaves[:1],
+                None,
+                reverse=reverse,
+            )
+            entries = entries[before : before + 5]
+            reference.setdefault(reverse, entries)
+            assert torch.equal(entries, reference[reverse]), (before, after, reverse)
+
+
+# ---------------------------------------------------------------- transports
+
+
+def _cpu_all_gather_into_tensor(
+    gathered: torch.Tensor, packet: torch.Tensor, group: dist.ProcessGroup | None = None
+) -> None:
+    """Gloo path: gather CPU copies, then place them into the CUDA output buffer."""
+    staging = torch.empty(gathered.shape, dtype=gathered.dtype)
+    dist.all_gather_into_tensor(staging, packet.cpu(), group=group)
+    gathered.copy_(staging)
+
+
+@contextmanager
+def _process_group(cp_rank: int, world: int, port: int) -> Iterator[torch.device]:
+    """NCCL on one GPU per rank, or Gloo with the module's collective staged through the CPU."""
+    shared = torch.cuda.device_count() < world
+    device = torch.device("cuda", 0 if shared else cp_rank)
+    torch.cuda.set_device(device)
+    os.environ.update(MASTER_ADDR="127.0.0.1", MASTER_PORT=str(port))
+    dist.init_process_group(
+        "gloo" if shared else "nccl",
+        rank=cp_rank,
+        world_size=world,
+        device_id=None if shared else device,
+    )
+    try:
+        if shared:
+            with patch.object(det, "_all_gather_into_tensor", _cpu_all_gather_into_tensor):
+                yield device
+        else:
+            yield device
+    finally:
+        dist.destroy_process_group()
+
+
+# ---------------------------------------------------------------- canonical CP1 reference
+
+
+def _inputs(
+    lengths: Sequence[int], gate: str, seed: int
+) -> tuple[tuple[torch.Tensor, ...], torch.Tensor]:
+    """Seeded KDA inputs and output cotangent on the current rank device."""
+    torch.manual_seed(seed)
+    values = make_kda_test_inputs(
+        sum(lengths),
+        heads=HEADS,
+        seed=seed,
+        normalize_qk=True,
+        sigmoid_beta=True,
+        gate_scale=math.log(2) if gate == "strong" else 0.02,
+        log_uniform_gate=gate == "strong",
+        gate_value=0.0 if gate == "zero" else None,
+    )
+    return values, torch.randn_like(values[2])
+
+
+@torch.no_grad()
+def _canonical_cp1(
+    inputs: tuple[torch.Tensor, ...],
+    grad: torch.Tensor,
+    lengths: Sequence[int],
+    tile_size: int,
+    kernel_options: KernelOptions | None,
+) -> tuple[torch.Tensor, ...]:
+    """Independent per-tile staged calls with the production scan: the bitwise CP contract."""
+    tiling = _single_rank_tiling(lengths, tile_size)
+    tiles = tiling.tiles
+    stages = _kda_stages(None, False, False, kernel_options)
+    device = inputs[0].device
+
+    bounds = [torch.tensor([[0, t.length]], dtype=torch.int32, device=device) for t in tiles]
+
+    prepared = [
+        stages.prepare(*(v[:, t.start : t.stop] for v in inputs), cu_seqlens=None) for t in tiles
+    ]
+    # Single-tile documents are not summarized (NOTE [Single-Tile Documents]).
+    summarized = tiling.summarized
+    maps = torch.cat(
+        [prepared[i].state_summaries(bounds[i], deterministic_work=True) for i in summarized]
+    )
+    routing = tiling.routing(device)
+    entries = canonical_entries(maps, tiling, routing, maps[:1], None, reverse=False)
+    outputs, backwards = [], []
+    for i, (p, t) in enumerate(zip(prepared, tiles, strict=True)):
+        outputs.append(p.run(entries[i : i + 1], output_final_state=False)[0])
+        backwards.append(
+            stages.prepare_backward(
+                p.saved, grad[:, t.start : t.stop], entries[i : i + 1], scale=p.scale
+            )
+        )
+    rmaps = torch.cat(
+        [backwards[i].state_grad_summaries(bounds[i], deterministic_work=True) for i in summarized]
+    )
+    exits = canonical_entries(rmaps, tiling, routing, maps[:1], None, reverse=True)
+    grads = [b.run(exits[i : i + 1])[:5] for i, b in enumerate(backwards)]
+    return (
+        torch.cat(outputs, dim=1),
+        *(torch.cat([g[c] for g in grads], dim=1) for c in range(5)),
+    )
+
+
+def _bit_mismatches(actual: torch.Tensor, expected: torch.Tensor) -> int:
+    """Count unequal storage elements, including signed zeros; reject non-finite values."""
+    assert actual.shape == expected.shape and actual.dtype == expected.dtype
+    assert torch.isfinite(actual).all() and torch.isfinite(expected).all()
+    view = torch.int16 if actual.dtype == torch.bfloat16 else torch.int32
+    return int((actual.contiguous().view(view) != expected.contiguous().view(view)).sum())
+
+
+# ---------------------------------------------------------------- two-rank cases
+
+Case = tuple[Sequence[int], int, str, str]  # lengths, tile_size, ownership, gate
+
+TWO_RANK_CASES: dict[str, Case] = {
+    f"{layout}-{gate}": (lengths, tile_size, ownership, gate)
+    for layout, lengths, tile_size, ownership in (
+        ("ragged-contig", RAGGED, 64, "contiguous"),
+        ("ragged-cyclic", RAGGED, 64, "cyclic"),
+        ("ragged-empty", RAGGED, 128, "empty_rank"),
+        ("elephant-cyclic", ELEPHANT, 64, "cyclic"),
+    )
+    for gate in ("strong", "mild", "zero")
+}
+
+
+def _case_mismatches(
+    cp_rank: int, world: int, device: torch.device, case: Case, backend: str
+) -> dict[str, int]:
+    """Bit mismatches of this rank's output and five gradients against per-tile CP=1 calls."""
+    lengths, tile_size, ownership, gate = case
+    kernel_options = {"backend": backend} if backend != "fused" else None
+    inputs, grad = _inputs(lengths, gate, 97)
+    cu = (0, *accumulate(lengths))
+    expected = _canonical_cp1(inputs, grad, lengths, tile_size, kernel_options)
+    if ownership == "cyclic":
+        # Whole tiles alternate between the ranks, including single-tile documents.
+        tiles = tile_stream(cu, tile_size)
+        fragments = [[(t.start, t.stop) for t in tiles[r::world]] for r in range(world)]
+    else:
+        fragments = {
+            "contiguous": [[(0, cu[len(cu) // 2])], [(cu[len(cu) // 2], cu[-1])]],
+            "empty_rank": [[], [(0, cu[-1])]],
+            "single": [[(0, cu[-1])]],
+        }[ownership]
+    tiling = CanonicalTiling.from_fragments(cu, fragments, cp_rank, tile_size=tile_size)
+    ids = tiling.global_token_ids(device)
+    local = tuple(v[:, ids].contiguous().requires_grad_() for v in inputs)
+    output = context_parallel_kda_deterministic(
+        *local, tiling=tiling, group=dist.group.WORLD, kernel_options=kernel_options
+    )
+    # Every rank runs the backward: its all-gather is a collective even for an empty rank.
+    grads = torch.autograd.grad(output, local, grad[:, ids])
+    return {
+        name: _bit_mismatches(a, e[:, ids])
+        for name, a, e in zip(NAMES, (output, *grads), expected, strict=True)
+    }
+
+
+def _rank_main(cp_rank: int, world: int, port: int, cases: dict[str, Case], backend: str) -> None:
+    """Run every case in one process group (both ranks in the same order); report all failures."""
+    with _process_group(cp_rank, world, port) as device:
+        failures = {}
+        for case_id, case in cases.items():
+            mismatches = _case_mismatches(cp_rank, world, device, case, backend)
+            if any(mismatches.values()):
+                failures[case_id] = mismatches
+        assert not failures, failures
+
+
+@pytest.fixture(params=["fused", "mega"])
+def backend(request: pytest.FixtureRequest) -> str:
+    """Skip Mega before spawning when its DSL or GPU architecture is unavailable."""
+    if request.param == "mega":
+        pytest.importorskip("cutlass.experimental")
+        if torch.cuda.get_device_capability() not in ((10, 0), (10, 3)):
+            pytest.skip("Mega needs SM100/103")
+    return request.param
+
+
+def test_two_ranks_match_canonical_cp1_bitwise(backend):
+    """One spawn per backend covers every layout and gate; a failure names each failing case."""
+    _spawn(2, (TWO_RANK_CASES, backend))
+
+
+def _spawn(nprocs: int, args: tuple) -> None:
+    """Surface failed ranks promptly and bound the run to 600 seconds, including compilation."""
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+    context = mp.spawn(_rank_main, args=(nprocs, port, *args), nprocs=nprocs, join=False)
+    deadline = time.monotonic() + 600
+    try:
+        # join() reports failed ranks immediately, but may reap only one successful rank at a time.
+        while not context.join(timeout=max(0.0, deadline - time.monotonic())):
+            assert time.monotonic() < deadline, "spawned cases did not finish within 600 s"
+    finally:
+        for process in context.processes:
+            if process.is_alive():
+                process.kill()
+
+
+@pytest.mark.parametrize("option", ["split_forward", "split_backward"])
+def test_split_schedules_are_rejected_before_any_collective(option):
+    """Reject Mega splits before collecting: they would change the canonical FP32 summaries."""
+    tiling = _single_rank_tiling(RAGGED)
+    inputs, _ = _inputs(RAGGED, "mild", 3)
+    with pytest.raises(ValueError, match="split_forward/split_backward"):
+        context_parallel_kda_deterministic(
+            *inputs,
+            tiling=tiling,
+            group=None,
+            kernel_options={"backend": "mega", option: True},
+        )
+
+
+def test_single_rank_public_api_matches_canonical_cp1_bitwise(backend):
+    """CP=1 through the public entry point is the same contract the two-rank cases reproduce."""
+    _spawn(1, ({"ragged-single-strong": (RAGGED, 64, "single", "strong")}, backend))
+
+
+# ---------------------------------------------------------------- accuracy vs FP64
+
+
+def test_canonical_cp1_matches_fp64_reference_within_bf16_budget():
+    """The new contract is checked against an independent FP64 recurrence, not only self-consistency."""
+    lengths = (17, 65, 129)
+    inputs, grad = _inputs(lengths, "mild", 41)
+    inputs = tuple(v[:, :, :1].contiguous() for v in inputs)
+    grad = grad[:, :, :1].contiguous()
+    actual = _canonical_cp1(inputs, grad, lengths, 64, None)
+    cu = torch.tensor((0, *accumulate(lengths)), dtype=torch.int32, device="cuda")
+    high = tuple(v.detach().cpu().double().requires_grad_() for v in inputs)
+    out_high, _ = kda_reference(*high, cu_seqlens=cu.cpu(), output_final_state=False)
+    grads_high = torch.autograd.grad(out_high, high, grad.cpu().double())
+    low = tuple(v.detach().cpu().float().requires_grad_() for v in inputs)
+    out_low, _ = kda_reference(*low, cu_seqlens=cu.cpu(), output_final_state=False)
+    grads_low = torch.autograd.grad(out_low, low, grad.cpu().float())
+    for name, a, h, lo in zip(
+        NAMES, actual, (out_high, *grads_high), (out_low, *grads_low), strict=True
+    ):
+        err = (a.cpu().double() - h.double()).abs().max().item()
+        eager = (lo.double() - h.double()).abs().max().item()
+        budget = 2 * (eager + torch.finfo(torch.bfloat16).eps * h.abs().max().item())
+        assert err <= budget, f"{name}: {err} > {budget}"


### PR DESCRIPTION
Add CP-degree-invariant KDA context parallelism over canonical tiles
need to decide If I want to land this;



context_parallel_kda_deterministic fixes the whole arithmetic graph before ranks are assigned:
every document is cut into fixed tiles, each tile is one packed subsequence of its rank's span,
the summary kernels run with deterministic_work=True (a pinned SM100 planner, so the work
partition cannot depend on how many tiles a rank owns), the tile maps are all-gathered, and one
fused Triton kernel folds them per document left to right in three-pass TF32. Output and all
input gradients are bitwise identical for any CP degree and any ownership of whole tiles,
including CP=1, and a document's result does not depend on its neighbours in the packed stream.
It is a different numerical contract from the unsharded chunk_kda call (FP64 error stays within
the BF16 budget).

Cost is set by the tile size and by the number of tiles in multi-tile documents: single-tile
documents take no part in the summaries, exchange, or scan; CanonicalRouting is built once per
layout; scan_block optionally exchanges one map per block of tiles for large CP degrees. Ranks
that own nothing still join the collectives. Mega's forgetting-horizon split is rejected because
it would change the FP32 summaries.

Two GB200s, 32k tokens, 64 heads, CP2 (ms fwd/bwd, ratio to standard CP): fused tile-1024
4.07/7.38 (1.5x/1.2x); with many short documents and block-balanced ownership the recipe is
cheaper than standard CP. Tests: 36 two-rank bitwise cases (6 layouts x 3 gates x 2 backends),
the CP=1 public API against a per-tile reference, batching equivalence, FP64 accuracy, planner
validation; benchmarks/kda_cp_deterministic.py; docs/linear.md.