### PR TITLE
Build the Mega reverse maps with Mega's own kernels

### DIFF
--- a/attn_gym/linear/_delta_rule/mega/state_summary.py
+++ b/attn_gym/linear/_delta_rule/mega/state_summary.py
@@ -2,8 +2,8 @@
 
 """Native BT16 affine probes for whole packed sequences.
 
-Forward maps pack [B; A] for ``exit = entry @ A + B``.
-Native state/operand rounding makes these approximate affine
+Forward maps pack [B; A] for ``exit = entry @ A + B``; reverse maps pack [C; R] for
+``d_entry = d_exit @ R + C``. Native state/operand rounding makes these approximate affine
 maps, not bitwise reconstruction of an ordinary unsharded Mega run. Every probe is unsplit,
 so its arithmetic is independent of sequence ownership and packed token count.
 """
@@ -20,7 +20,7 @@ from attn_gym._backends.cute.utils import initialized_cuda_device
 from attn_gym.utils import ceildiv
 
 from .forward import validate_available
-from .kernels import kda_recompute_f16
+from .kernels import kda_bprop_f16, kda_recompute_f16
 from .kernels.common.host import tensormap_workspace_bytes
 from .schedule import MegaSchedule, prepare_mega_schedule
 
@@ -91,7 +91,7 @@ def build_mega_state_summaries(
     consecutive cu_seqlens pairs. Empty intervals yield ``[0; I]``; zero rows yield no maps.
     Bounds values stay on device and may change during CUDA Graph replay.
     """
-    maps = _build_mega_state_probes(k, value, gate, beta, cu_seqlens, bounds)
+    maps = _build_mega_state_probes(k, value, gate, beta, cu_seqlens, bounds, bias=True)
     return _summary_rows(maps, cu_seqlens, bounds)
 
 
@@ -150,8 +150,13 @@ def _build_mega_state_probes(
     beta: torch.Tensor,
     cu_seqlens: torch.Tensor,
     bounds: torch.Tensor | None,
+    *,
+    bias: bool,
 ) -> torch.Tensor:
-    """Probe selected sequences into full-size storage indexed by the native sequence IDs."""
+    """Probe selected sequences into full-size storage indexed by the native sequence IDs.
+
+    ``bias=False`` skips the zero-state probe and returns only the transition ``A``.
+    """
     validate_available(k)
     if k.ndim != 4 or k.shape[0] != 1 or k.shape[-1] != 128:
         raise ValueError("k must have shape [1, T, H, 128]")
@@ -182,7 +187,7 @@ def _build_mega_state_probes(
             schedule, workspace = _prepare_summary_launch(
                 gate, cu_seqlens, bounds, kda_recompute_f16
             )
-            for transition_only in (False, True):
+            for transition_only in (False, True) if bias else (True,):
                 if bounds is not None:
                     schedule.counters.zero_()
                 kda_recompute_f16.chunk_kda_recompute_sm100(
@@ -204,3 +209,74 @@ def _build_mega_state_probes(
                     transition_only=transition_only,
                 )
         return summaries
+
+
+def build_mega_state_grad_summaries(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    value: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    d_output: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    scale: float,
+    *,
+    transpose_forward_transition: bool = False,
+    bounds: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Return subsequence FP32 ``[N, H, 256, 128]`` maps packed as ``[C; R]``.
+
+    C is the native entry cotangent with zero exit cotangent. R uses an identity exit
+    cotangent and zero d_output. ``transpose_forward_transition=True`` instead uses A.T
+    from the forward probe: algebraically the adjoint, but not native backward rounding.
+    Inputs and bounds follow :func:`build_mega_state_summaries`; selection applies to both
+    probes and empty intervals yield ``[0; I]``.
+    """
+    validate_available(q)
+    with initialized_cuda_device(q):
+        sequences, heads = cu_seqlens.numel() - 1, q.shape[2]
+        if transpose_forward_transition:
+            maps = _build_mega_state_probes(k, value, gate, beta, cu_seqlens, bounds, bias=False)
+            maps[:, :, 128:].copy_(maps[:, :, 128:].transpose(-1, -2).contiguous())
+        else:
+            maps = torch.zeros(sequences, heads, 256, 128, device=q.device)
+            maps[:, :, 128:].diagonal(dim1=-2, dim2=-1).fill_(1)
+        if q.shape[1] == 0 or (bounds is not None and bounds.shape[0] == 0):
+            return _summary_rows(maps, cu_seqlens, bounds)
+        schedule, workspace = _prepare_summary_launch(gate, cu_seqlens, bounds, kda_bprop_f16)
+        # The dH recurrence ignores V/checkpoints; token gradients are computed but discarded.
+        # Zero-stride TMA checkpoint rows all address one tile, avoiding a state recompute.
+        checkpoints = torch.zeros(1, heads, 128, 128, device=q.device, dtype=q.dtype).expand(
+            q.shape[1] // 16 + sequences, -1, -1, -1
+        )
+        scratch = [torch.empty_like(t[0]) for t in (q, k, value, gate, beta)]
+        for transition in (False,) if transpose_forward_transition else (False, True):
+            if bounds is not None:
+                schedule.counters.zero_()
+            exit_state = None
+            do = d_output
+            if transition:
+                exit_state = torch.eye(128, device=q.device).expand(sequences, heads, 128, 128)
+                do = torch.zeros_like(d_output[:, :1]).expand_as(d_output)
+            kda_bprop_f16.chunk_kda_bwd_sm100(
+                q[0],
+                k[0],
+                value[0],
+                gate[0],
+                beta[0],
+                do[0],
+                checkpoints,
+                *scratch,
+                cu_seqlens,
+                scale,
+                use_initial_state=True,
+                d_initial_state=maps[:, :, 128:] if transition else maps[:, :, :128],
+                d_final_state=exit_state,
+                work_items=schedule.work_items,
+                work_count=schedule.work_count,
+                sched_ctr=schedule.counters if sequences * heads <= schedule.num_sms else None,
+                sched_all=schedule.counters,
+                order_in_prologue=bounds is None,
+                tensormap_workspace=workspace,
+            )
+        return _summary_rows(maps, cu_seqlens, bounds)

--- a/attn_gym/linear/kda/stages.py
+++ b/attn_gym/linear/kda/stages.py
@@ -268,8 +268,8 @@ def chunk_kda_prepare(
     float16 or bfloat16 dtype (no silent cast, because the caller owns autograd), and the batch
     dimension must be one so token offsets index one packed span (NOTE [Terminology] in
     ``attn_gym.linear.context_parallel``).
-    ``kernel_options={"backend": "mega"}`` runs the local pass and the forward summaries with
-    Mega's kernels. Split schedules are not available with entry states.
+    ``kernel_options={"backend": "mega"}`` runs the local pass and both summaries with Mega's
+    kernels. Split schedules are not available with entry states.
     """
     backend, split_backward, split_forward, schedule = resolve_kernel_options(kernel_options)
     if split_backward or split_forward:
@@ -384,9 +384,11 @@ class ChunkKDABackward:
 
 @dataclass
 class ChunkKDAMegaBackward:
-    """Mega backward handle: ``run`` is Mega's stateful backward.
+    """Mega backward handle: ``run`` is Mega's stateful backward and the reverse maps are Mega's.
 
-    Summaries recompute the fused factors on demand. Nothing is consumed, so ``run`` and
+    Each subsequence's ``[C; R]`` map is the entry cotangent of Mega's backward run with a zero
+    exit cotangent (``C``) and the forward transition transposed (``R``, the exact adjoint; a
+    natively probed adjoint would round differently). Nothing is consumed, so ``run`` and
     ``state_grad_summaries`` may be called in either order.
     """
 
@@ -400,29 +402,23 @@ class ChunkKDAMegaBackward:
     def state_grad_summaries(self, bounds: torch.Tensor) -> torch.Tensor:
         """Return one FP32 ``[HV, V + K, K]`` reverse map per row of ``bounds`` in one launch.
 
-        Rows follow ``ChunkKDABackward.state_grad_summaries``.
+        Rows follow NOTE [Summary ranges are subsequences].
         """
+        from attn_gym.linear._delta_rule.mega.state_summary import build_mega_state_grad_summaries
+
         saved = self.saved
-        # The fused backward over the equivalent tape (no materialized factors) owns the recompute.
-        fused_saved = ChunkKDASaved(
+        return build_mega_state_grad_summaries(
             saved.q,
             saved.k,
             saved.v,
-            saved.cumulative_gate,
+            saved.gate,
             saved.beta,
-            None,
-            None,
-            saved.cu_seqlens,
-            saved.chunk_offsets,
-        )
-        return chunk_kda_prepare_backward(
-            fused_saved,
             self.d_output,
-            self.initial_state,
-            scale=self.scale,
-            autotune=self.autotune,
-            schedule=self.schedule,
-        ).state_grad_summaries(bounds)
+            saved.cu_seqlens,
+            self.scale,
+            transpose_forward_transition=True,
+            bounds=bounds,
+        )
 
     def run(
         self, d_final_state: torch.Tensor | None = None

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -620,16 +620,18 @@ them out. `state_summaries` produces each range's `[B; A]` map (`S_exit = S_entr
 running Mega's state-only pass over the range twice: from a zero entry state, whose final state
 is `B`, and from an identity entry state with the value term disabled, whose final state is `A`.
 Which ranges are probed and how their rows are ordered is decided on the device, so the call is
-CUDA Graph replayable and an empty range yields the identity map. This requires every range to be
-a subsequence (one rank's piece of a document, one segment of the local `cu_seqlens`),
-which the CP recipe guarantees; a caller passing arbitrary 64-aligned ranges gets maps computed
-from the fused factors instead. `run` is Mega's forward from the composed entry state.
+CUDA Graph replayable and an empty range yields the identity map. Every range must be a
+subsequence (one rank's piece of a document, one segment of the local `cu_seqlens`), which is
+all the CP recipes ever request; a nonempty range that is not one is filled with NaN. `run` is
+Mega's forward from the composed entry state.
 
 *Backward.* `run` is Mega's own stateful backward (`kda_chunk_mega_packed_bwd_with_state`):
 the state pass from the saved entry state writes checkpoints, then the BT16 backward consumes
 them together with the exit cotangent, returning the token gradients and the entry-state
-cotangent. `state_grad_summaries` still computes the reverse maps from the fused factors, so the
-Mega backward under CP pays one fused factor pass over the local span in addition to its own.
+cotangent. `state_grad_summaries` produces each subsequence's `[C; R]` map with the same
+kernels: `C` is the entry-state cotangent of Mega's backward run with a zero exit cotangent, and
+`R` is the forward transition transposed. No fused factors are computed anywhere on the Mega
+path.
 
 *Numerics.* A document cut on 16-token boundaries whose fragments exchange Mega's own state and
 cotangent reproduces the unsharded Mega gradients bit for bit. The composed entry states do not:

--- a/test/kda/mega/test_kda_mega_native_summary.py
+++ b/test/kda/mega/test_kda_mega_native_summary.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from functools import partial
 from itertools import pairwise
 
 import pytest
@@ -9,12 +10,19 @@ import torch
 
 pytest.importorskip("cutlass.experimental", reason="native Mega summaries require CuTeDSL 4.7")
 
-from attn_gym.linear._delta_rule.mega.kernels import kda_prefill_f16
+from attn_gym.linear._delta_rule.mega.kernels import (
+    kda_bprop_f16,
+    kda_prefill_f16,
+    kda_recompute_f16,
+)
 from attn_gym.linear._delta_rule.mega.kernels.common.host import tensormap_workspace_bytes
 from attn_gym.linear._delta_rule.mega.schedule import prepare_mega_schedule
-from attn_gym.linear._delta_rule.mega.state_summary import build_mega_state_summaries
+from attn_gym.linear._delta_rule.mega.state_summary import (
+    build_mega_state_grad_summaries,
+    build_mega_state_summaries,
+)
 from attn_gym.linear.context_parallel import merge_state
-from attn_gym.linear.kda.stages import chunk_kda_prepare
+from attn_gym.linear.kda.stages import chunk_kda_prepare, chunk_kda_prepare_backward
 from attn_gym.testing.kda import (
     assert_matches_low_precision_reference,
     clone_kda_inputs,
@@ -144,7 +152,7 @@ def test_native_transition_matches_basis_reference(
 
 @pytest.mark.parametrize("dtype", DTYPES)
 def test_native_two_tile_handoff_matches_fp64(dtype: torch.dtype, monkeypatch) -> None:
-    """Native forward maps hand off states; outputs and finals track FP64."""
+    """Native forward/reverse maps hand off both states; outputs, finals, and grads track FP64."""
     inputs, cu = _packed_inputs([64, 65], dtype)
     prepared = chunk_kda_prepare(*inputs, cu_seqlens=cu, autotune=False, kernel_options=MEGA)
     _forbid_fused_factors(monkeypatch)
@@ -205,16 +213,30 @@ def test_native_summary_cuda_graph_replay() -> None:
 
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("heads", [1, 64])
-def test_native_selected_bounds(dtype: torch.dtype, heads: int, monkeypatch) -> None:
+@pytest.mark.parametrize("probe", ["forward", "reverse", "reverse_bprop"])
+def test_native_selected_bounds(dtype: torch.dtype, heads: int, probe: str, monkeypatch) -> None:
     """Selecting subsequences (reordered, duplicated, or empty) on device preserves the bits.
 
     The staged handles stay native, and bounds may change between CUDA Graph replays.
     """
     inputs, cu = _packed_inputs(LENGTHS, dtype, heads=heads)
+    do = torch.randn_like(inputs[2])
     prepared = chunk_kda_prepare(*inputs, cu_seqlens=cu, autotune=False, kernel_options=MEGA)
+    backward = chunk_kda_prepare_backward(
+        prepared.saved, do, None, scale=prepared.scale, autotune=False
+    )
     _forbid_fused_factors(monkeypatch)
-    full = build_mega_state_summaries(*inputs[1:], cu)
-    selected = prepared.state_summaries
+    grad_summaries = partial(build_mega_state_grad_summaries, *inputs, do, cu, prepared.scale)
+    match probe:
+        case "forward":
+            full = build_mega_state_summaries(*inputs[1:], cu)
+            selected = prepared.state_summaries
+        case "reverse":
+            full = grad_summaries(transpose_forward_transition=True)
+            selected = backward.state_grad_summaries
+        case "reverse_bprop":
+            full = grad_summaries()
+            selected = grad_summaries
     cases = (
         ([[82, 211], [17, 17], [17, 82], [82, 211]], [3, 1, 2, 3]),
         ([[0, 17], [17, 17], [82, 211], [0, 0]], [0, 1, 3, 1]),
@@ -234,3 +256,150 @@ def test_native_selected_bounds(dtype: torch.dtype, heads: int, monkeypatch) -> 
     # A nonempty row that is not a subsequence is poisoned with NaN rather than silently mapped.
     poisoned = selected(bounds=_bounds([[17, 82], [20, 82], [0, 17]]))
     assert not poisoned[[0, 2]].isnan().any() and poisoned[1].isnan().all()
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("transpose_forward_transition", [False, True])
+def test_native_reverse_bias_and_ownership(
+    dtype: torch.dtype, transpose_forward_transition: bool, monkeypatch
+) -> None:
+    """C is exactly native dH0 and neither reverse probe depends on tile ownership/state."""
+    inputs, cu = _packed_inputs(LENGTHS, dtype)
+    d_output = torch.randn_like(inputs[2])
+    prepared = chunk_kda_prepare(*inputs, cu_seqlens=cu, autotune=False, kernel_options=MEGA)
+    initial = torch.randn(4, 1, 128, 128, device="cuda")
+    backward = chunk_kda_prepare_backward(
+        prepared.saved, d_output, initial, scale=prepared.scale, autotune=False
+    )
+    _forbid_fused_factors(monkeypatch)
+    grad_summaries = partial(
+        build_mega_state_grad_summaries,
+        transpose_forward_transition=transpose_forward_transition,
+    )
+    maps = grad_summaries(*inputs, d_output, cu, prepared.scale)
+    assert torch.equal(maps[:, :, :128], backward.run()[-1])
+    if transpose_forward_transition:
+        bounds = torch.stack((cu[:-1], cu[1:]), dim=1)
+        assert torch.equal(backward.state_grad_summaries(bounds), maps)
+    else:
+        zero_backward = chunk_kda_prepare_backward(
+            prepared.saved,
+            torch.zeros_like(d_output),
+            initial,
+            scale=prepared.scale,
+            autotune=False,
+        )
+        identity = torch.eye(128, device="cuda").expand_as(initial).contiguous()
+        assert torch.equal(maps[:, :, 128:], zero_backward.run(identity)[-1])
+    for index, (start, stop) in enumerate(pairwise(cu.tolist())):
+        alone = grad_summaries(
+            *(tensor[:, start:stop] for tensor in (*inputs, d_output)),
+            cumulative_sequence_offsets([stop - start]),
+            prepared.scale,
+        )
+        _assert_bitwise_equal(maps[index : index + 1], alone)
+
+
+def test_native_reverse_selection_skips_unrequested_work(monkeypatch) -> None:
+    """The native kernels consume the selected work table, not a prologue-generated full one."""
+    inputs, cu = _packed_inputs(LENGTHS)
+    do = torch.randn_like(inputs[2])
+    bounds = _bounds([[82, 211], [17, 17], [82, 211]])
+    tables = []
+    for module, name in (
+        (kda_bprop_f16, "chunk_kda_bwd_sm100"),
+        (kda_recompute_f16, "chunk_kda_recompute_sm100"),
+    ):
+        original = getattr(module, name)
+
+        def checked(*args, original=original, **kwargs):
+            assert not kwargs["order_in_prologue"]
+            tables.append(kwargs["work_items"].clone())
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(module, name, checked)
+    grad_summaries = partial(
+        build_mega_state_grad_summaries, *inputs, do, cu, SCALE, transpose_forward_transition=True
+    )
+    grad_summaries(bounds=bounds)
+    assert len(tables) == 2
+    expected = torch.tensor(
+        [
+            [0, 0, 0, 0, 0, 0, 0, 0],
+            [1, 0, 0, 0, 0, 0, 17, 17],
+            [2, 0, 0, 0, 0, 0, 17, 17],
+            [3, 0, 0, 9, 0, 9, 82, 211],
+        ],
+        device="cuda",
+        dtype=torch.int32,
+    )
+    for table in tables:
+        assert torch.equal(table, expected)
+    tables.clear()
+    assert grad_summaries(bounds=bounds[:0]).shape == (0, 1, 256, 128)
+    assert not tables
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("gate_value", [0.0, -0.002, -0.02])
+def test_native_reverse_matches_fp64(dtype: torch.dtype, gate_value: float) -> None:
+    """Both reverse recipes and fused maps are measured against an independent FP64 oracle."""
+    inputs, cu = _packed_inputs([129], dtype, gate_value=gate_value)
+    do = torch.randn_like(inputs[2])
+    scale = 0.25
+    maps = [
+        build_mega_state_grad_summaries(
+            *inputs, do, cu, scale, transpose_forward_transition=transpose
+        )
+        for transpose in (False, True)
+    ]
+    prepared = chunk_kda_prepare(*inputs, cu_seqlens=cu, scale=scale, autotune=False)
+    backward = chunk_kda_prepare_backward(prepared.saved, do, None, scale=scale, autotune=False)
+    maps.append(backward.state_grad_summaries(_bounds([[0, 129]])))
+    references = []
+    for precision in (torch.float64, torch.float32):
+        state = torch.zeros(1, 1, 128, 128, device="cuda", dtype=precision, requires_grad=True)
+        output, _ = kda_reference(*clone_kda_inputs(inputs, dtype=precision), state, scale=scale)
+        (bias,) = torch.autograd.grad(output, state, do.to(precision))
+        basis_inputs = list(clone_kda_inputs(inputs, dtype=precision))
+        basis_inputs[2] = torch.zeros_like(basis_inputs[2])
+        _, transition = kda_reference(
+            *basis_inputs, torch.eye(128, device="cuda", dtype=precision)[None, None], scale=scale
+        )
+        references.append(torch.cat((bias, transition.transpose(-1, -2)), dim=-2))
+    high, low = references
+    for label, actual in zip(("native bprop", "native C + A.T", "fused"), maps, strict=True):
+        for part, rows in (("C", slice(0, 128)), ("R", slice(128, None))):
+            if part == "R" and label != "fused":
+                # Native R rounds the recurrent state/decay every BT16, not just at the
+                # output. A uniform gate can bias those roundings in the same direction;
+                # allow one source epsilon per chunk, rather than the single-round budget.
+                allowance = ceildiv(inputs[0].shape[1], 16) * torch.finfo(dtype).eps
+                error = (low[:, :, rows].double() - high[:, :, rows]).abs().max()
+                budget = error + allowance * high[:, :, rows].abs().max()
+                assert torch.isfinite(actual[:, :, rows]).all()
+                assert (actual[:, :, rows].double() - high[:, :, rows]).abs().max() <= budget
+            else:
+                assert_matches_low_precision_reference(
+                    actual[:, :, rows],
+                    high[:, :, rows],
+                    low[:, :, rows],
+                    f"{label} {part}",
+                    source_dtype=dtype,
+                )
+
+
+def test_native_reverse_cuda_graph_replay() -> None:
+    inputs, cu = _packed_inputs([17, 0, 64])
+    do = torch.randn_like(inputs[2])
+    grad_summaries = partial(
+        build_mega_state_grad_summaries, *inputs, do, cu, SCALE, transpose_forward_transition=True
+    )
+    expected = grad_summaries()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        actual = grad_summaries()
+    do.mul_(0.5)
+    graph.replay()
+    assert not torch.equal(actual, expected)
+    _assert_bitwise_equal(actual, grad_summaries())

--- a/test/kda/mega/test_kda_mega_stateful_bwd.py
+++ b/test/kda/mega/test_kda_mega_stateful_bwd.py
@@ -252,18 +252,9 @@ def test_staged_mega_backward_is_the_native_op() -> None:
         chunk_mega_packed_bwd_with_state_op(*operands, initial_state, d_final_state, SCALE),
     )
 
-    # Arbitrary-range reverse summaries still come from the fused factors.
-    fused = chunk_kda_prepare(q, k, value, gate, beta, cu_seqlens=offsets)
-    fused_grads = chunk_kda_prepare_backward(
-        fused.saved, d_output, initial_state, scale=fused.scale
-    )
+    # Reverse maps are Mega's own probes (test_kda_mega_native_summary covers their contents).
     bounds = torch.tensor([[0, 100], [100, 256]], dtype=torch.int32, device="cuda")
-    torch.testing.assert_close(
-        grads.state_grad_summaries(bounds),
-        fused_grads.state_grad_summaries(bounds),
-        atol=0,
-        rtol=0,
-    )
+    assert grads.state_grad_summaries(bounds).shape == (2, 2, 256, 128)
     # Without an entry state the tape's backward keeps Mega's no-state arithmetic.
     no_state = chunk_kda_prepare_backward(prepared.saved, d_output, None, scale=prepared.scale)
     *no_state_grads, d_initial_state = no_state.run(None)


### PR DESCRIPTION
Stacked PRs:
 * #531
 * #529
 * __->__#530


--- --- ---

Build the canonical Mega reverse maps natively

build_mega_state_grad_summaries emits whole-sequence [C; R] reverse maps with Mega's kernels: C
is the native backward's zero-exit entry cotangent (bitwise the ordinary stateful backward) and R
the transposed forward transition, an exact adjoint algebraically and cheaper than a second
backward pass. The probes run only for the sequences a rank's bounds select, through the same
device work table as the forward, so skipped single-tile documents cost nothing. The canonical
Mega path (deterministic_work=True) uses them instead of recomputing fused factors; a selected
sequence's map is bitwise its full-stream map, and the deterministic two-rank cases stay bitwise.

Two GB200s, 32k tokens, 64 heads, CP2: Mega tile-1024 backward 11.2 -> 7.0 ms (0.85x of standard
Mega CP, whose reverse summaries still recompute fused factors); on a 127-document stream the
reverse-summary phase drops 3.46 -> 1.96 ms.