### PR TITLE
Add document-parallel KDA: fragments cut on document boundaries need no summaries

### DIFF
--- a/attn_gym/linear/document_parallel.py
+++ b/attn_gym/linear/document_parallel.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Context parallelism that never splits a document: no summaries, no collectives, exact bits.
+
+NOTE [Document-aligned fragments]
+If every fragment boundary is a document boundary, no rank ever needs another rank's state: each
+document runs from the zero state to its end on one rank, exactly as an unsharded call would run
+it. There is nothing to summarize, exchange, or compose, so the result is bitwise the same for
+any CP degree and any document-aligned fragment table, including CP=1, and it costs less than the
+standard recipe (which still computes and gathers summaries for such fragments).
+
+What the recipe pins is the kernels, not the sharding: a document's bits must not depend on the
+documents packed around it. The staged handles guarantee that (``test/test_canonical_tile_batching.py``
+for the fused kernels; ``test/test_document_parallel.py`` for both) as long as autotuning is off and
+Mega's forgetting-horizon split is not used. The public ``chunk_kda`` is not a substitute: it picks
+kernels from the span's physical length. With the fused backend the recipe's output and gradients
+are bitwise those of ``chunk_kda(autotune=False)``; with Mega the output is, and the gradients come
+from Mega's own backward where the public op still runs the fused one.
+
+Balance is the cost: cutting only at document boundaries can leave a rank a document's worth of
+tokens out of balance, and a document longer than a rank can hold has no document-aligned cut at
+all; that case needs the sequence split across ranks (``context_parallel_chunk``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import torch
+
+from attn_gym._backends.profiler import profiler_range
+from attn_gym.linear.context_parallel import StagedOp
+
+
+def check_document_aligned(
+    cu_seqlens_global: Sequence[int], fragments: Sequence[Sequence[tuple[int, int]]]
+) -> None:
+    """Raise unless every fragment of every rank starts and stops on a document boundary."""
+    boundaries = set(cu_seqlens_global)
+    for rank, rank_fragments in enumerate(fragments):
+        for start, stop in rank_fragments:
+            if start not in boundaries or stop not in boundaries:
+                raise ValueError(
+                    f"rank {rank} fragment [{start}, {stop}) splits a document; document-parallel"
+                    " context parallelism needs fragments cut on document boundaries"
+                )
+
+
+class _DocumentParallel(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, q, k, v, gate, beta, cu_seqlens, stages: StagedOp):
+        prepared = stages.prepare(q, k, v, gate, beta, cu_seqlens=cu_seqlens)
+        with profiler_range("dp/run"):
+            output, _ = prepared.run(None, output_final_state=False)
+        ctx.save_for_backward(*prepared.saved)
+        ctx.saved_type = type(prepared.saved)
+        ctx.scale = prepared.scale
+        ctx.stages = stages
+        return output
+
+    @staticmethod
+    @torch.autograd.function.once_differentiable
+    def backward(ctx, d_output):
+        saved = ctx.saved_type._make(ctx.saved_tensors)
+        grads = ctx.stages.prepare_backward(saved, d_output, None, scale=ctx.scale)
+        with profiler_range("dp/run"):
+            dq, dk, dv, dgate, dbeta, _ = grads.run(None)
+        return dq, dk, dv, dgate, dbeta, None, None
+
+
+def document_parallel_chunk(
+    stages: StagedOp,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    *,
+    cu_seqlens: torch.Tensor | None,
+) -> torch.Tensor:
+    """Run a staged delta-rule op over this rank's whole documents (NOTE [Document-aligned fragments]).
+
+    ``q``/``k``/``v``/``gate``/``beta`` are the rank's span and ``cu_seqlens`` its packed document
+    boundaries (``ContextParallelPlan.routing(device).cu_seqlens``). No collective runs, so ranks
+    need not call this the same number of times; a rank with no documents simply skips it.
+    """
+    return _DocumentParallel.apply(q, k, v, gate, beta, cu_seqlens, stages)
+
+
+__all__ = ["check_document_aligned", "document_parallel_chunk"]

--- a/attn_gym/linear/kda/__init__.py
+++ b/attn_gym/linear/kda/__init__.py
@@ -38,6 +38,7 @@ _BACKEND_EXPORTS = {
     "chunk_kda_prepare": "attn_gym.linear.kda.stages",
     "chunk_kda_prepare_backward": "attn_gym.linear.kda.stages",
     "context_parallel_kda": "attn_gym.linear.kda.context_parallel",
+    "document_parallel_kda": "attn_gym.linear.kda.context_parallel",
 }
 # Backward compat: these moved to attn_gym.linear.short_conv, whose own lazy resolution supplies
 # the error message; import them from attn_gym.linear instead.

--- a/attn_gym/linear/kda/context_parallel.py
+++ b/attn_gym/linear/kda/context_parallel.py
@@ -18,6 +18,7 @@ from attn_gym.linear.context_parallel import (
     StagedOp,
     context_parallel_chunk,
 )
+from attn_gym.linear.document_parallel import document_parallel_chunk
 from attn_gym.linear.kda.stages import chunk_kda_prepare, chunk_kda_prepare_backward
 from attn_gym.linear.kda.validation import resolve_kernel_options
 from attn_gym.linear.types import KernelOptions
@@ -50,6 +51,35 @@ def context_parallel_kda(
     return context_parallel_chunk(stages, q, k, v, gate, beta, routing=routing, group=group)
 
 
+def document_parallel_kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    *,
+    cu_seqlens: torch.Tensor | None,
+    scale: float | None = None,
+    fastmath: bool = False,
+    kernel_options: KernelOptions | None = None,
+) -> torch.Tensor:
+    """Run KDA over this rank's whole documents; bits do not depend on the CP degree or packing.
+
+    See NOTE [Document-aligned fragments] in ``attn_gym.linear.document_parallel``. Autotuning is
+    off and Mega's split schedules are rejected, since both would let a document's bits depend on
+    the span it is packed into; ``fastmath`` and the remaining ``kernel_options`` follow
+    ``chunk_kda``.
+    """
+    options = resolve_kernel_options(kernel_options)
+    if options.split_backward or options.split_forward:
+        raise ValueError(
+            "document_parallel_kda does not support split_forward/split_backward: the horizon"
+            " split depends on the span length, so a document's bits would depend on its packing"
+        )
+    stages = _kda_stages(scale, False, fastmath, kernel_options)
+    return document_parallel_chunk(stages, q, k, v, gate, beta, cu_seqlens=cu_seqlens)
+
+
 def _kda_stages(
     scale: float | None, autotune: bool, fastmath: bool, kernel_options: KernelOptions | None
 ) -> StagedOp:
@@ -65,4 +95,4 @@ def _kda_stages(
     )
 
 
-__all__ = ["context_parallel_kda"]
+__all__ = ["context_parallel_kda", "document_parallel_kda"]

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -631,9 +631,46 @@ the maps carry Mega's 16-token-chunk rounding, so Mega under CP is its own numer
 neither the fused CP baseline nor unsharded Mega. The staged handles and this recipe are
 eager-only; `torch.compile` is not supported through them.
 
+### Document-parallel mode: never split a document
+
+If every fragment boundary is a document boundary, no rank needs another rank's state: each
+document runs from the zero state to its end on one rank, exactly as an unsharded call runs it.
+`document_parallel_kda` is that case with everything else removed: no summaries, no collectives,
+no compose. Its output and gradients are bitwise identical for any CP degree and any
+document-aligned fragment table, including CP=1, and with the fused backend they are bitwise the
+public `chunk_kda(autotune=False)`; with Mega the output is, and the gradients are Mega's own
+backward. It is also cheaper than the standard recipe, which computes and gathers summaries even
+for fragments that end their documents.
+
+```python
+from attn_gym.linear.context_parallel import ContextParallelPlan
+from attn_gym.linear.document_parallel import check_document_aligned
+from attn_gym.linear.kda import document_parallel_kda
+
+check_document_aligned(cu_seqlens_global, fragments)  # every cut is a document boundary
+plan = ContextParallelPlan.from_fragments(cu_seqlens_global, fragments, rank)
+ids = plan.global_token_ids(device)
+output = document_parallel_kda(
+    q[:, ids],
+    k[:, ids],
+    v[:, ids],
+    gate[:, ids],
+    beta[:, ids],
+    cu_seqlens=plan.routing(device).cu_seqlens,
+)
+```
+
+What it pins is the kernels: autotuning is off and Mega's forgetting-horizon split is rejected,
+because both let a document's bits depend on the span it is packed into. What it costs is
+balance: the loader can only cut at document boundaries, so a rank can be a document's worth of
+tokens off, and a document longer than a rank can hold has no document-aligned cut at all. That
+case needs the sequence to be split across ranks, which is what the standard recipe above does.
+
 ::: attn_gym.linear.context_parallel.context_parallel_chunk
 
 ::: attn_gym.linear.kda.context_parallel.context_parallel_kda
+
+::: attn_gym.linear.kda.context_parallel.document_parallel_kda
 
 ::: attn_gym.linear.gdn.context_parallel.context_parallel_gdn
 

--- a/test/test_document_parallel.py
+++ b/test/test_document_parallel.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Document-aligned fragments give the unsharded bits at any CP degree, with no collectives."""
+
+from __future__ import annotations
+
+import math
+from itertools import accumulate
+
+import pytest
+import torch
+
+from attn_gym.linear.context_parallel import ContextParallelPlan
+from attn_gym.linear.document_parallel import check_document_aligned
+from attn_gym.linear.kda import chunk_kda, document_parallel_kda
+from attn_gym.testing.kda import make_kda_test_inputs
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+
+LENGTHS = (17, 65, 129, 257, 513)
+NAMES = ("output", "dq", "dk", "dv", "dgate", "dbeta")
+# Every fragment table cuts only at document boundaries; the CP degree and shape vary freely.
+TABLES = {
+    "cp1": [[(0, 981)]],
+    "cp2-contiguous": [[(0, 211)], [(211, 981)]],
+    "cp2-interleaved": [[(0, 17), (82, 211), (468, 981)], [(17, 82), (211, 468)]],
+    "cp3-uneven": [[(0, 17)], [(17, 468)], [(468, 981)]],
+    "cp5-one-each": [[(a, b)] for a, b in zip((0, 17, 82, 211, 468), (17, 82, 211, 468, 981))],
+}
+
+
+def _step(inputs, grad, cu_seqlens, kernel_options):
+    leaves = tuple(t.detach().requires_grad_() for t in inputs)
+    output = document_parallel_kda(*leaves, cu_seqlens=cu_seqlens, kernel_options=kernel_options)
+    return (output, *torch.autograd.grad(output, leaves, grad))
+
+
+def _bits_differ(actual: torch.Tensor, expected: torch.Tensor) -> int:
+    return int((actual.view(torch.int32) != expected.view(torch.int32)).sum())
+
+
+@pytest.mark.parametrize("backend", ["fused", "mega"])
+@pytest.mark.parametrize("gate", ["strong", "mild"])
+def test_document_aligned_fragments_reproduce_the_unsharded_bits(backend, gate):
+    """Every document-aligned table, at every CP degree, equals the single-span run bitwise."""
+    if backend == "mega":
+        pytest.importorskip("cutlass.experimental")
+        if torch.cuda.get_device_capability() not in ((10, 0), (10, 3)):
+            pytest.skip("Mega needs SM100/103")
+    kernel_options = {"backend": backend} if backend != "fused" else None
+    cu = (0, *accumulate(LENGTHS))
+    torch.manual_seed(7)
+    inputs = make_kda_test_inputs(
+        cu[-1],
+        heads=2,
+        seed=7,
+        normalize_qk=True,
+        sigmoid_beta=True,
+        gate_scale=math.log(2) if gate == "strong" else 0.02,
+        log_uniform_gate=gate == "strong",
+    )
+    grad = torch.randn_like(inputs[2])
+    device = inputs[0].device
+    expected = _step(
+        inputs, grad, torch.tensor(cu, dtype=torch.int32, device=device), kernel_options
+    )
+    for name, fragments in TABLES.items():
+        check_document_aligned(cu, fragments)
+        for rank in range(len(fragments)):
+            plan = ContextParallelPlan.from_fragments(cu, fragments, rank)
+            ids = plan.global_token_ids(device)
+            actual = _step(
+                tuple(t[:, ids].contiguous() for t in inputs),
+                grad[:, ids].contiguous(),
+                plan.routing(device).cu_seqlens,
+                kernel_options,
+            )
+            mismatches = {
+                n: _bits_differ(a, e[:, ids])
+                for n, a, e in zip(NAMES, actual, expected, strict=True)
+            }
+            assert all(v == 0 for v in mismatches.values()), (name, rank, mismatches)
+
+
+def test_fragments_that_split_a_document_are_rejected():
+    cu = (0, *accumulate(LENGTHS))
+    check_document_aligned(cu, [[(0, 211)], [(211, 981)]])
+    with pytest.raises(ValueError, match="splits a document"):
+        check_document_aligned(cu, [[(0, 300)], [(300, 981)]])
+
+
+def test_split_schedules_are_rejected():
+    inputs = make_kda_test_inputs(128, heads=1, seed=1)
+    with pytest.raises(ValueError, match="split_forward/split_backward"):
+        document_parallel_kda(
+            *inputs, cu_seqlens=None, kernel_options={"backend": "mega", "split_forward": True}
+        )
+
+
+@pytest.mark.parametrize("backend", ["fused", "mega"])
+def test_matches_the_public_op(backend):
+    """Fused: the public ``chunk_kda`` bits. Mega: its forward bits; the backward is Mega's own
+    (the public op still runs the fused backward on a Mega forward), so gradients are close."""
+    if backend == "mega":
+        pytest.importorskip("cutlass.experimental")
+        if torch.cuda.get_device_capability() not in ((10, 0), (10, 3)):
+            pytest.skip("Mega needs SM100/103")
+    kernel_options = {"backend": backend} if backend != "fused" else None
+    inputs = make_kda_test_inputs(512, heads=2, seed=3, normalize_qk=True, sigmoid_beta=True)
+    grad = torch.randn_like(inputs[2])
+    actual = _step(inputs, grad, None, kernel_options)
+    leaves = tuple(t.detach().requires_grad_() for t in inputs)
+    output, _ = chunk_kda(*leaves, autotune=False, kernel_options=kernel_options)
+    expected = (output, *torch.autograd.grad(output, leaves, grad))
+    assert _bits_differ(actual[0], expected[0]) == 0
+    for name, a, e in zip(NAMES[1:], actual[1:], expected[1:], strict=True):
+        if backend == "fused":
+            assert _bits_differ(a, e) == 0, name
+        else:
+            torch.testing.assert_close(a, e, atol=2e-2, rtol=2e-2, msg=name)


### PR DESCRIPTION
Stacked PRs:
 * #531
 * #530
 * #529
 * __->__#532


--- --- ---

Add document-parallel KDA: fragments cut on document boundaries need no summaries

If every fragment boundary is a document boundary, no rank needs another rank's state: each
document runs from the zero state to its end on one rank, exactly as an unsharded call runs it.
document_parallel_kda is that case with everything else removed: the staged forward and backward
on the rank's span, no summaries, no collectives, no compose. Its output and gradients are bitwise
identical for any CP degree and any document-aligned fragment table, including CP=1; with the
fused backend they are bitwise the public chunk_kda(autotune=False), and with Mega the output is
while the gradients are Mega's own backward (the public op still runs the fused one).

What the recipe pins is the kernels: autotuning is off and Mega's forgetting-horizon split is
rejected, because both let a document's bits depend on the span it is packed into. The staged
handles are packing-invariant (test_canonical_tile_batching for fused; the new test runs five
document-aligned fragment tables at CP 1, 2, 3, and 5 on both backends and checks every tensor
bitwise against the single-span run). check_document_aligned validates a fragment table.

The cost is balance: cuts only at document boundaries, and a document longer than a rank can hold
has no document-aligned cut. Two GB200s, 32 documents of 1024 tokens, 64 heads, CP2, fwd+bwd
(slowest rank): fused 7.56 ms vs 8.01 ms standard CP; Mega 3.66 ms vs 5.92 ms.