### PR TITLE
Run Mega's own backward for every no-state span and show document-aligned CP fragments

### DIFF
--- a/attn_gym/linear/kda/impl/mega.py
+++ b/attn_gym/linear/kda/impl/mega.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Autograd integration for the experimental CuTeDSL 4.7 KDA forward."""
+"""Autograd integration for the experimental CuTeDSL 4.7 KDA kernels."""
 
 from __future__ import annotations
 
@@ -11,36 +11,17 @@ from attn_gym.linear._delta_rule.chunk_ops import _plain_gate_scan_op
 from attn_gym.linear._delta_rule.chunk_schedule import prepare_ragged_chunk_metadata
 from attn_gym.linear._delta_rule.validation import resolve_scale
 from attn_gym.linear.kda.impl.mega_ops import (
-    chunk_mega_dense_training_fwd_op,
     chunk_mega_packed_fwd_op,
     chunk_mega_packed_fwd_paged_op,
     chunk_mega_packed_fwd_with_initial_state_op,
     chunk_mega_packed_fwd_with_state_op,
     chunk_mega_packed_local_bwd_op,
-    chunk_mega_packed_training_fwd_op,
-    plain_gate_bwd_dense_cute_op,
     validate_mega_available,
 )
-from attn_gym.linear.kda.ops import (
-    chunk_bwd_recompute_factors_op,
-    chunk_bwd_recompute_factors_with_state_grad_op,
-)
+from attn_gym.linear.kda.ops import chunk_bwd_recompute_factors_with_state_grad_op
 
 _CHUNK_SIZE = 64
 _SUPPORTED_IO_DTYPES = (torch.float16, torch.bfloat16)
-
-# NOTE [Mega backward crossover]
-# These thresholds correspond to the dense and packed crossover cases in benchmarks/kda.py.
-# Re-run those boundary cases before changing the policy; the public approximation policy remains
-# independent and is controlled only by split_backward.
-_DENSE_LOCAL_BACKWARD_MIN_TOKENS = 32768
-_PACKED_LOCAL_BACKWARD_MIN_TOKENS = 4096
-_LOCAL_BACKWARD_MIN_HEADS = 64
-
-
-def use_local_backward(q: torch.Tensor, min_tokens: int) -> bool:
-    """Select the Mega backward where its launch savings amortize setup."""
-    return q.shape[1] >= min_tokens and q.shape[2] >= _LOCAL_BACKWARD_MIN_HEADS
 
 
 def normalize_output_grad(d_output: torch.Tensor | None, value: torch.Tensor) -> torch.Tensor:
@@ -48,197 +29,62 @@ def normalize_output_grad(d_output: torch.Tensor | None, value: torch.Tensor) ->
     return torch.zeros_like(value) if d_output is None else d_output.contiguous()
 
 
-class ChunkKdaMegaDense(torch.autograd.Function):
-    """Attach autograd to the dense no-state Mega path."""
+class ChunkKdaMega(torch.autograd.Function):
+    """Attach a backward to Mega's forward: Mega's own without an entry state, fused with one.
 
-    @staticmethod
-    def forward(ctx, q, k, value, gate, beta, cu_seqlens, scale, split_backward, split_forward):
-        ctx.use_local_backward = split_backward and use_local_backward(
-            q, _DENSE_LOCAL_BACKWARD_MIN_TOKENS
-        )
-        ctx.split_backward = split_backward
-        ctx.scale = scale
-        if ctx.use_local_backward:
-            output = chunk_mega_packed_fwd_op(
-                q, k, value, gate, beta, cu_seqlens, split_forward, scale
-            )
-            ctx.save_for_backward(q, k, value, gate, beta, cu_seqlens)
-        else:
-            output, cumulative_gate = chunk_mega_dense_training_fwd_op(
-                q,
-                k,
-                value,
-                gate,
-                beta,
-                cu_seqlens,
-                split_forward,
-                scale,
-            )
-            ctx.save_for_backward(q, k, value, cumulative_gate, beta)
-        ctx.set_materialize_grads(False)
-        return output
-
-    @staticmethod
-    @torch.autograd.function.once_differentiable
-    def backward(ctx, d_output):
-        if ctx.use_local_backward:
-            q, k, value, gate, beta, cu_seqlens = ctx.saved_tensors
-            return (
-                *chunk_mega_packed_local_bwd_op(
-                    q,
-                    k,
-                    value,
-                    gate,
-                    beta,
-                    normalize_output_grad(d_output, value),
-                    cu_seqlens,
-                    ctx.split_backward,
-                    ctx.scale,
-                ),
-                None,
-                None,
-                None,
-                None,
-            )
-
-        q, k, value, cumulative_gate, beta = ctx.saved_tensors
-        dq, dk, dv, d_cumulative, d_beta = chunk_bwd_recompute_factors_op(
-            q,
-            k,
-            value,
-            cumulative_gate,
-            beta,
-            None,
-            None,
-            normalize_output_grad(d_output, value),
-            None,
-            None,
-            ctx.scale,
-            False,
-            False,
-            "auto",
-        )
-        d_gate = plain_gate_bwd_dense_cute_op(d_cumulative.contiguous())
-        return dq, dk, dv, d_gate, d_beta, None, None, None, None
-
-
-class ChunkKdaMegaPacked(torch.autograd.Function):
-    """Attach autograd to packed Mega calls with optional recurrent state."""
+    The kernel choice depends only on whether an entry state is present, never on the span
+    length, so a document's bits do not depend on the span it is packed into. With an entry
+    state the fused stateful backward carries the state cotangent in FP32 between chunks
+    (``test/linear/test_delta_rule_state_precision.py``); Mega's BT16 backward requantizes it.
+    """
 
     @staticmethod
     def forward(
         ctx,
-        q,
-        k,
-        value,
-        gate,
-        beta,
-        initial_state,
-        cu_seqlens,
-        chunk_offsets,
-        scale,
-        split_backward,
-        split_forward,
-        output_final_state,
-    ):
-        ctx.has_initial_state = initial_state is not None
-        ctx.use_local_backward = not ctx.has_initial_state and use_local_backward(
-            q, _PACKED_LOCAL_BACKWARD_MIN_TOKENS
-        )
+        q: torch.Tensor,
+        k: torch.Tensor,
+        value: torch.Tensor,
+        gate: torch.Tensor,
+        beta: torch.Tensor,
+        initial_state: torch.Tensor | None,
+        cu_seqlens: torch.Tensor,
+        chunk_offsets: torch.Tensor,
+        scale: float,
+        split_backward: bool,
+        split_forward: bool,
+        output_final_state: bool,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         ctx.split_backward = split_backward
         ctx.scale = scale
-        if ctx.use_local_backward:
+        if initial_state is None:
             output = chunk_mega_packed_fwd_op(
-                q,
-                k,
-                value,
-                gate,
-                beta,
-                cu_seqlens,
-                split_forward,
-                scale,
+                q, k, value, gate, beta, cu_seqlens, split_forward, scale
             )
-            ctx.save_for_backward(q, k, value, gate, beta, cu_seqlens)
-        elif ctx.has_initial_state:
-            if output_final_state:
-                output, final_state = chunk_mega_packed_fwd_with_state_op(
-                    q,
-                    k,
-                    value,
-                    gate,
-                    beta,
-                    initial_state,
-                    cu_seqlens,
-                    scale,
-                )
-            else:
-                output = chunk_mega_packed_fwd_with_initial_state_op(
-                    q,
-                    k,
-                    value,
-                    gate,
-                    beta,
-                    initial_state,
-                    cu_seqlens,
-                    scale,
-                )
-            ctx.save_for_backward(
-                q,
-                k,
-                value,
-                gate,
-                beta,
-                initial_state,
-                cu_seqlens,
-                chunk_offsets,
+        elif output_final_state:
+            output, final_state = chunk_mega_packed_fwd_with_state_op(
+                q, k, value, gate, beta, initial_state, cu_seqlens, scale
             )
         else:
-            output, cumulative_gate = chunk_mega_packed_training_fwd_op(
-                q,
-                k,
-                value,
-                gate,
-                beta,
-                cu_seqlens,
-                chunk_offsets,
-                split_forward,
-                scale,
+            output = chunk_mega_packed_fwd_with_initial_state_op(
+                q, k, value, gate, beta, initial_state, cu_seqlens, scale
             )
-            ctx.save_for_backward(q, k, value, cumulative_gate, beta, cu_seqlens, chunk_offsets)
+        ctx.save_for_backward(q, k, value, gate, beta, initial_state, cu_seqlens, chunk_offsets)
         ctx.set_materialize_grads(False)
         if output_final_state:
-            assert ctx.has_initial_state
             return output, final_state
         return output
 
     @staticmethod
     @torch.autograd.function.once_differentiable
-    def backward(ctx, d_output, d_final_state=None):
-        if ctx.use_local_backward:
-            q, k, value, gate, beta, cu_seqlens = ctx.saved_tensors
-            return (
-                *chunk_mega_packed_local_bwd_op(
-                    q,
-                    k,
-                    value,
-                    gate,
-                    beta,
-                    normalize_output_grad(d_output, value),
-                    cu_seqlens,
-                    ctx.split_backward,
-                    ctx.scale,
-                ),
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
+    def backward(ctx, d_output: torch.Tensor | None, d_final_state: torch.Tensor | None = None):
+        q, k, value, gate, beta, initial_state, cu_seqlens, chunk_offsets = ctx.saved_tensors
+        d_output = normalize_output_grad(d_output, value)
+        if initial_state is None:
+            dq, dk, dv, d_gate, d_beta = chunk_mega_packed_local_bwd_op(
+                q, k, value, gate, beta, d_output, cu_seqlens, ctx.split_backward, ctx.scale
             )
-
-        if ctx.has_initial_state:
-            q, k, value, gate, beta, initial_state, cu_seqlens, chunk_offsets = ctx.saved_tensors
+            d_initial_state = None
+        else:
             cumulative_gate = _plain_gate_scan_op(gate, cu_seqlens, chunk_offsets, False)
             dq, dk, dv, d_cumulative, d_beta, d_initial_state = (
                 chunk_bwd_recompute_factors_with_state_grad_op(
@@ -249,7 +95,7 @@ class ChunkKdaMegaPacked(torch.autograd.Function):
                     beta,
                     cu_seqlens,
                     chunk_offsets,
-                    normalize_output_grad(d_output, value),
+                    d_output,
                     d_final_state,
                     initial_state,
                     ctx.scale,
@@ -258,40 +104,10 @@ class ChunkKdaMegaPacked(torch.autograd.Function):
                     "auto",
                 )
             )
-        else:
-            q, k, value, cumulative_gate, beta, cu_seqlens, chunk_offsets = ctx.saved_tensors
-            dq, dk, dv, d_cumulative, d_beta = chunk_bwd_recompute_factors_op(
-                q,
-                k,
-                value,
-                cumulative_gate,
-                beta,
-                cu_seqlens,
-                chunk_offsets,
-                normalize_output_grad(d_output, value),
-                None,
-                None,
-                ctx.scale,
-                False,
-                False,
-                "auto",
+            d_gate = _plain_gate_scan_op(
+                d_cumulative.contiguous(), cu_seqlens, chunk_offsets, True
             )
-            d_initial_state = None
-        d_gate = _plain_gate_scan_op(d_cumulative.contiguous(), cu_seqlens, chunk_offsets, True)
-        return (
-            dq,
-            dk,
-            dv,
-            d_gate,
-            d_beta,
-            d_initial_state,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        )
+        return dq, dk, dv, d_gate, d_beta, d_initial_state, None, None, None, None, None, None
 
 
 def validate_mega_constraints(
@@ -354,31 +170,6 @@ def chunk_forward(
     if not torch.compiler.is_compiling():
         validate_mega_available(q)
 
-    # The dense kernels specialize for complete BT64 chunks; a partial tail takes the packed path
-    # with synthesized boundaries, as the fused backend does.
-    if (
-        cu_seqlens is None
-        and initial_state is None
-        and not output_final_state
-        and q.shape[1] % _CHUNK_SIZE == 0
-    ):
-        validate_mega_constraints(q, k, value, gate, beta, None, None)
-        dense_cu_seqlens = torch.arange(2, dtype=torch.int32, device=q.device) * q.shape[1]
-        return (
-            ChunkKdaMegaDense.apply(
-                q,
-                k,
-                value,
-                gate,
-                beta,
-                dense_cu_seqlens,
-                scale,
-                split_backward,
-                split_forward,
-            ),
-            None,
-        )
-
     if cu_seqlens is None:
         cu_seqlens = torch.arange(2, dtype=torch.int32, device=q.device) * q.shape[1]
     if output_final_state and initial_state is None:
@@ -391,8 +182,9 @@ def chunk_forward(
             device=q.device,
         )
     validate_mega_constraints(q, k, value, gate, beta, initial_state, cu_seqlens)
+    # The fused stateful backward chunks each subsequence on its own 64-token grid.
     metadata = prepare_ragged_chunk_metadata(cu_seqlens, q.shape[1], _CHUNK_SIZE)
-    result = ChunkKdaMegaPacked.apply(
+    result = ChunkKdaMega.apply(
         q,
         k,
         value,

--- a/attn_gym/linear/kda/impl/mega_ops.py
+++ b/attn_gym/linear/kda/impl/mega_ops.py
@@ -9,22 +9,11 @@ import importlib
 import torch
 
 from attn_gym.linear._delta_rule.paged_state import PagedState
-from attn_gym.utils import fork_join_streams
 
 torch.library.define(
     "attn_gym::kda_chunk_mega_packed_fwd",
     "(Tensor q, Tensor k, Tensor v, Tensor gate, Tensor beta, Tensor cu_seqlens, "
     "bool split, float scale) -> Tensor",
-)
-torch.library.define(
-    "attn_gym::kda_chunk_mega_dense_training_fwd",
-    "(Tensor q, Tensor k, Tensor v, Tensor gate, Tensor beta, Tensor cu_seqlens, "
-    "bool split, float scale) -> (Tensor, Tensor)",
-)
-torch.library.define(
-    "attn_gym::kda_chunk_mega_packed_training_fwd",
-    "(Tensor q, Tensor k, Tensor v, Tensor gate, Tensor beta, "
-    "Tensor cu_seqlens, Tensor chunk_offsets, bool split, float scale) -> (Tensor, Tensor)",
 )
 torch.library.define(
     "attn_gym::kda_chunk_mega_packed_fwd_with_initial_state",
@@ -60,13 +49,6 @@ torch.library.define(
     "Tensor cu_seqlens, Tensor? d_final_state, float scale) "
     "-> (Tensor, Tensor, Tensor, Tensor, Tensor)",
 )
-torch.library.define(
-    "attn_gym::kda_plain_gate_bwd_dense_cute",
-    "(Tensor d_cumulative) -> Tensor",
-)
-
-_GATE_STREAMS: dict[int, torch.cuda.Stream] = {}
-_MAIN_STREAMS: dict[int, torch.cuda.Stream] = {}
 
 
 def _backend(q: torch.Tensor):
@@ -84,17 +66,8 @@ def validate_mega_available(q: torch.Tensor) -> None:
     _backend(q)
 
 
-def _stream(cache: dict[int, torch.cuda.Stream], device: torch.device, priority: int = 0):
-    index = torch.cuda.current_device() if device.index is None else device.index
-    stream = cache.get(index)
-    if stream is None:
-        stream = torch.cuda.Stream(device=index, priority=priority)
-        cache[index] = stream
-    return stream
-
-
-def _packed_fwd_cuda(q, k, value, gate, beta, cu_seqlens, split, scale, *, backend=None):
-    backend = _backend(q) if backend is None else backend
+def _packed_fwd_cuda(q, k, value, gate, beta, cu_seqlens, split, scale):
+    backend = _backend(q)
     return backend.chunk_delta_rule_fwd_mega(
         q,
         k,
@@ -105,53 +78,6 @@ def _packed_fwd_cuda(q, k, value, gate, beta, cu_seqlens, split, scale, *, backe
         scale,
         split=split,
     )
-
-
-def _dense_training_fwd_cuda(q, k, value, gate, beta, cu_seqlens, split, scale):
-    from attn_gym.linear._delta_rule.triton.plain_gate import _plain_gate_scan_cuda
-
-    backend = _backend(q)
-    # Prioritize the persistent one-CTA-per-SM Mega grid; the scan can fill its drain tail.
-    cumulative_gate, output = fork_join_streams(
-        torch.cuda.current_stream(q.device),
-        _stream(_MAIN_STREAMS, q.device, priority=-1),
-        lambda: _packed_fwd_cuda(
-            q,
-            k,
-            value,
-            gate,
-            beta,
-            cu_seqlens,
-            split,
-            scale,
-            backend=backend,
-        ),
-        lambda: _plain_gate_scan_cuda(gate, None, None, False),
-    )
-    return output, cumulative_gate
-
-
-def _packed_training_fwd_cuda(q, k, value, gate, beta, cu_seqlens, chunk_offsets, split, scale):
-    from attn_gym.linear._delta_rule.triton.plain_gate import _plain_gate_scan_cuda
-
-    backend = _backend(q)
-    output, cumulative_gate = fork_join_streams(
-        torch.cuda.current_stream(q.device),
-        _stream(_GATE_STREAMS, q.device),
-        lambda: _plain_gate_scan_cuda(gate, cu_seqlens, chunk_offsets, False),
-        lambda: _packed_fwd_cuda(
-            q,
-            k,
-            value,
-            gate,
-            beta,
-            cu_seqlens,
-            split,
-            scale,
-            backend=backend,
-        ),
-    )
-    return output, cumulative_gate
 
 
 def _packed_fwd_with_initial_state_cuda(q, k, value, gate, beta, initial_state, cu_seqlens, scale):
@@ -263,19 +189,7 @@ def _packed_bwd_with_exit_cotangent_cuda(
     )[:5]
 
 
-def _plain_gate_bwd_cuda(d_cumulative):
-    from attn_gym.linear._delta_rule.mega.kernels.kda_plain_gate_bwd import (
-        plain_gate_cumsum_dense_bwd_cute,
-    )
-
-    return plain_gate_cumsum_dense_bwd_cute(d_cumulative)
-
-
 torch.library.impl("attn_gym::kda_chunk_mega_packed_fwd", "CUDA", _packed_fwd_cuda)
-torch.library.impl("attn_gym::kda_chunk_mega_dense_training_fwd", "CUDA", _dense_training_fwd_cuda)
-torch.library.impl(
-    "attn_gym::kda_chunk_mega_packed_training_fwd", "CUDA", _packed_training_fwd_cuda
-)
 torch.library.impl(
     "attn_gym::kda_chunk_mega_packed_fwd_with_initial_state",
     "CUDA",
@@ -294,25 +208,12 @@ torch.library.impl(
     "CUDA",
     _packed_bwd_with_exit_cotangent_cuda,
 )
-torch.library.impl("attn_gym::kda_plain_gate_bwd_dense_cute", "CUDA", _plain_gate_bwd_cuda)
 
 
 @torch.library.register_fake("attn_gym::kda_chunk_mega_packed_fwd")
 def _packed_fwd_fake(q, k, value, gate, beta, cu_seqlens, split, scale):
     del q, k, gate, beta, cu_seqlens, split, scale
     return torch.empty_like(value)
-
-
-@torch.library.register_fake("attn_gym::kda_chunk_mega_dense_training_fwd")
-def _dense_training_fwd_fake(q, k, value, gate, beta, cu_seqlens, split, scale):
-    del q, k, beta, cu_seqlens, split, scale
-    return torch.empty_like(value), gate.new_empty(gate.shape)
-
-
-@torch.library.register_fake("attn_gym::kda_chunk_mega_packed_training_fwd")
-def _packed_training_fwd_fake(q, k, value, gate, beta, cu_seqlens, chunk_offsets, split, scale):
-    del q, k, beta, cu_seqlens, chunk_offsets, split, scale
-    return torch.empty_like(value), gate.new_empty(gate.shape)
 
 
 @torch.library.register_fake("attn_gym::kda_chunk_mega_packed_fwd_with_initial_state")
@@ -371,15 +272,8 @@ def _packed_bwd_with_exit_cotangent_fake(
     return _token_gradients_fake(q, k, value, gate, beta)
 
 
-@torch.library.register_fake("attn_gym::kda_plain_gate_bwd_dense_cute")
-def _plain_gate_bwd_fake(d_cumulative):
-    return torch.empty_like(d_cumulative)
-
-
 chunk_mega_packed_fwd_op = torch.ops.attn_gym.kda_chunk_mega_packed_fwd.default
 chunk_mega_packed_fwd_paged_op = torch.ops.attn_gym.kda_chunk_mega_packed_fwd_paged.default
-chunk_mega_dense_training_fwd_op = torch.ops.attn_gym.kda_chunk_mega_dense_training_fwd.default
-chunk_mega_packed_training_fwd_op = torch.ops.attn_gym.kda_chunk_mega_packed_training_fwd.default
 chunk_mega_packed_fwd_with_initial_state_op = (
     torch.ops.attn_gym.kda_chunk_mega_packed_fwd_with_initial_state.default
 )
@@ -393,11 +287,9 @@ chunk_mega_packed_bwd_with_state_op = (
 chunk_mega_packed_bwd_with_exit_cotangent_op = (
     torch.ops.attn_gym.kda_chunk_mega_packed_bwd_with_exit_cotangent.default
 )
-plain_gate_bwd_dense_cute_op = torch.ops.attn_gym.kda_plain_gate_bwd_dense_cute.default
 
 
 __all__ = [
-    "chunk_mega_dense_training_fwd_op",
     "chunk_mega_packed_bwd_with_exit_cotangent_op",
     "chunk_mega_packed_bwd_with_state_op",
     "chunk_mega_packed_fwd_op",
@@ -405,7 +297,5 @@ __all__ = [
     "chunk_mega_packed_fwd_with_initial_state_op",
     "chunk_mega_packed_fwd_with_state_op",
     "chunk_mega_packed_local_bwd_op",
-    "chunk_mega_packed_training_fwd_op",
-    "plain_gate_bwd_dense_cute_op",
     "validate_mega_available",
 ]

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -603,6 +603,19 @@ updates that cotangent buffer before each replay, setting nonterminal rows to ze
 an index selection from them does **not** make it follow later layouts. Update routing only
 between complete forward/backward steps, not while backward still needs the previous layout.
 
+### Document-aligned fragments: CP-invariant bits
+
+If every fragment boundary is a document boundary, no rank needs another rank's state: each
+document runs from the zero state to its end on the rank that owns it, exactly as the unsharded
+op runs it. The recipe above then composes nothing (every entry state is zero), and its output,
+gradients, and final states are **bitwise identical for any CP degree and any document-aligned
+fragment table, including CP=1**; for KDA they are also bitwise the public `chunk_kda`. Nothing
+else is required: no flag, no tiling, no change to the kernels. `document_aligned_fragments` in
+`examples/linear/delta_rule_context_parallel.py` (`--partition documents`) assigns whole documents
+to ranks, longest first onto the least-loaded rank, so ranks stay within one document's length of
+each other. What it cannot do is split a document that does not fit on one rank; that is what
+the summaries above are for.
+
 ### Mega local execution
 
 `kernel_options={"backend": "mega"}` runs each rank's local passes with Mega's kernels. The

--- a/examples/linear/delta_rule_context_parallel.py
+++ b/examples/linear/delta_rule_context_parallel.py
@@ -13,6 +13,9 @@ K3 model. Launch with:
     torchrun --standalone --nproc-per-node=2 examples/linear/delta_rule_context_parallel.py --batch-size 4 --tokens 1024
 
 Add ``--variant gdn``, ``--partition zigzag``, or ``--compute-dtype float16`` to vary the recipe.
+``--partition documents`` assigns whole documents to ranks (``document_aligned_fragments``): no
+document crosses ranks, so the delta-rule op exchanges no state and its result is bitwise
+independent of the CP degree (``test/test_context_parallel_distributed.py``, table ``documents``).
 ``--core-backend mega`` selects the KDA Mega backend (SM100/SM103). ``--cuda-graph`` checks a
 changed-input replay; ``--profile`` writes a merged native Perfetto trace. ``--no-validate`` skips
 the unsharded reference at scales where it does not fit. Batch construction, loss/backward, and
@@ -25,7 +28,7 @@ from __future__ import annotations
 import gc
 from enum import Enum
 from functools import partial
-from itertools import accumulate
+from itertools import accumulate, pairwise
 from pathlib import Path
 from typing import Annotated, Literal
 
@@ -64,6 +67,7 @@ class PartitionOption(str, Enum):
 
     CONTIGUOUS = "contiguous"
     ZIGZAG = "zigzag"
+    DOCUMENTS = "documents"
 
 
 class TraceFormatOption(str, Enum):
@@ -104,6 +108,38 @@ def partition_fragments(
         [(block * tokens // blocks, (block + 1) * tokens // blocks) for block in rank_blocks]
         for rank_blocks in owned
     ]
+
+
+def document_aligned_fragments(
+    offsets: tuple[int, ...], world_size: int
+) -> list[list[tuple[int, int]]]:
+    """Assign whole documents to ranks so no fragment ever splits one.
+
+    Every document then runs from the zero state to its end on the rank that owns it, exactly as
+    the unsharded op runs it: the recipe exchanges nothing across ranks and its result is bitwise
+    the same for any CP degree, including 1. The price is balance: longest documents first onto
+    the least-loaded rank keeps ranks within one document's length of each other, and a document
+    longer than a rank can hold has no document-aligned cut at all. Consecutive documents on one
+    rank merge into one fragment.
+    """
+    if world_size < 1:
+        raise ValueError("world_size must be positive")
+    documents = list(pairwise(offsets))
+    if len(documents) < world_size:
+        raise ValueError(f"{len(documents)} documents cannot give {world_size} ranks work")
+    loads = [0] * world_size
+    owner = [0] * len(documents)
+    for index in sorted(range(len(documents)), key=lambda i: documents[i][0] - documents[i][1]):
+        rank = loads.index(min(loads))
+        owner[index] = rank
+        loads[rank] += documents[index][1] - documents[index][0]
+    fragments: list[list[tuple[int, int]]] = [[] for _ in range(world_size)]
+    for (start, stop), rank in zip(documents, owner, strict=True):
+        if fragments[rank] and fragments[rank][-1][1] == start:
+            fragments[rank][-1] = (fragments[rank][-1][0], stop)
+        else:
+            fragments[rank].append((start, stop))
+    return fragments
 
 
 class ContextParallelDeltaRuleAttention(DeltaRuleAttention):
@@ -279,11 +315,13 @@ def main(
             offsets = (0, *accumulate(lengths))
         if dist.get_rank() == 0:
             print(f"packed_sequence_lengths={lengths} cu_seqlens={offsets}", flush=True)
-        plan = ContextParallelPlan.from_fragments(
-            offsets,
-            partition_fragments(offsets[-1], dist.get_world_size(), partition.value),
-            dist.get_rank(),
-        )
+        if partition is PartitionOption.DOCUMENTS:
+            fragments = document_aligned_fragments(offsets, dist.get_world_size())
+        else:
+            fragments = partition_fragments(offsets[-1], dist.get_world_size(), partition.value)
+        if dist.get_rank() == 0:
+            print(f"fragments={fragments}", flush=True)
+        plan = ContextParallelPlan.from_fragments(offsets, fragments, dist.get_rank())
         batch = make_context_parallel_batch(
             plan,
             offsets,

--- a/test/kda/mega/test_kda_mega_training.py
+++ b/test/kda/mega/test_kda_mega_training.py
@@ -1,4 +1,4 @@
-"""Training integration for the CuTeDSL 4.7 KDA forward."""
+"""Training integration for the CuTeDSL 4.7 KDA kernels."""
 
 from __future__ import annotations
 
@@ -10,7 +10,6 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from attn_gym.linear._delta_rule.chunk_schedule import prepare_ragged_chunk_metadata
 from attn_gym.testing.kda import (
     assert_matches_low_precision_reference,
     clone_kda_inputs,
@@ -549,8 +548,6 @@ def test_mega_packed_local_backward_matches_exact_gradients(
 def test_mega_public_packed_unsplit_local_backward_matches_exact_gradients(monkeypatch) -> None:
     from attn_gym.linear.kda.impl import mega as backend
 
-    monkeypatch.setattr(backend, "_PACKED_LOCAL_BACKWARD_MIN_TOKENS", 1)
-    monkeypatch.setattr(backend, "_LOCAL_BACKWARD_MIN_HEADS", 1)
     selected = []
     local_backward_op = backend.chunk_mega_packed_local_bwd_op
 
@@ -581,6 +578,45 @@ def test_mega_public_packed_unsplit_local_backward_matches_exact_gradients(monke
             f"public packed unsplit gradient {index}",
             torch.bfloat16,
         )
+
+
+def test_mega_document_aligned_spans_are_bitwise_equal() -> None:
+    """A document's output and gradients must not depend on its enclosing span length."""
+    from attn_gym.linear import chunk_kda
+
+    lengths = (64, 128, 4096)
+    offsets = (0, *accumulate(lengths))
+    inputs = make_kda_test_inputs(
+        sum(lengths), heads=64, seed=109, normalize_qk=True, requires_grad=True
+    )
+    output, _ = chunk_kda(
+        *inputs,
+        cu_seqlens=cumulative_sequence_offsets(lengths),
+        kernel_options={"backend": "mega"},
+    )
+    d_output = torch.randn_like(output)
+    gradients = torch.autograd.grad(output, inputs, d_output)
+    for first, last in ((0, 1), (1, 2), (2, 3), (0, 2)):
+        start, end = offsets[first], offsets[last]
+        for packed in (False, True) if last == first + 1 else (True,):
+            local_inputs = tuple(
+                tensor[:, start:end].detach().clone().requires_grad_() for tensor in inputs
+            )
+            local_output, _ = chunk_kda(
+                *local_inputs,
+                cu_seqlens=cumulative_sequence_offsets(lengths[first:last]) if packed else None,
+                kernel_options={"backend": "mega"},
+            )
+            local_gradients = torch.autograd.grad(
+                local_output, local_inputs, d_output[:, start:end]
+            )
+            for name, actual, expected in zip(
+                ("output", "dq", "dk", "dv", "dgate", "dbeta"),
+                (local_output, *local_gradients),
+                (output, *gradients),
+                strict=True,
+            ):
+                assert torch.equal(actual, expected[:, start:end]), (name, first, last, packed)
 
 
 def test_mega_kernel_options_are_strict() -> None:
@@ -687,9 +723,6 @@ def test_mega_dense_and_packed_split_share_auto_scheduler(monkeypatch) -> None:
     from attn_gym.linear._delta_rule.mega import schedule
     from attn_gym.linear.kda.impl import mega as backend
 
-    monkeypatch.setattr(backend, "_DENSE_LOCAL_BACKWARD_MIN_TOKENS", 1)
-    monkeypatch.setattr(backend, "_PACKED_LOCAL_BACKWARD_MIN_TOKENS", 1)
-    monkeypatch.setattr(backend, "_LOCAL_BACKWARD_MIN_HEADS", 1)
     local_backward = backend.chunk_mega_packed_local_bwd_op
     compute_ideal_chunks = schedule.compute_ideal_chunks
     selected = []
@@ -723,16 +756,12 @@ def test_mega_dense_and_packed_split_share_auto_scheduler(monkeypatch) -> None:
     )
     torch.autograd.grad(packed_output, packed_inputs[:5], torch.randn_like(packed_output))
 
-    assert selected == [True, True]
+    assert selected == [False, True, True]
     assert len(geometries) == 2 and geometries[0] == geometries[1]
 
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
-def test_mega_local_backward_fullgraph(monkeypatch, dtype: torch.dtype) -> None:
-    from attn_gym.linear.kda.impl import mega as backend
-
-    monkeypatch.setattr(backend, "_DENSE_LOCAL_BACKWARD_MIN_TOKENS", 1)
-    monkeypatch.setattr(backend, "_LOCAL_BACKWARD_MIN_HEADS", 1)
+def test_mega_local_backward_fullgraph(dtype: torch.dtype) -> None:
     expected_inputs = list(_make_inputs(requires_grad=True, dtype=dtype))
     actual_inputs = list(_make_inputs(requires_grad=True, dtype=dtype))
     dense_cu = torch.tensor([0, expected_inputs[0].shape[1]], dtype=torch.int32, device="cuda")
@@ -977,13 +1006,10 @@ def test_mega_packed_tail_isolated_from_next_sequence() -> None:
 @pytest.mark.parametrize("outer_strided", [False, True])
 def test_mega_forward_op_registration(dtype: torch.dtype, outer_strided: bool) -> None:
     from attn_gym.linear.kda.impl.mega_ops import (
-        chunk_mega_dense_training_fwd_op,
         chunk_mega_packed_fwd_op,
         chunk_mega_packed_fwd_with_initial_state_op,
         chunk_mega_packed_fwd_with_state_op,
         chunk_mega_packed_local_bwd_op,
-        chunk_mega_packed_training_fwd_op,
-        plain_gate_bwd_dense_cute_op,
     )
 
     inputs = _make_inputs(requires_grad=False, heads=2, dtype=dtype)
@@ -991,18 +1017,10 @@ def test_mega_forward_op_registration(dtype: torch.dtype, outer_strided: bool) -
         q, k, value, gate = (_swap_token_head_storage(tensor) for tensor in inputs[:4])
         initial_state = _swap_state_head_value_storage(inputs[5])
         inputs = (q, k, value, gate, inputs[4], initial_state, inputs[6])
-    dense_cu_seqlens = cumulative_sequence_offsets([inputs[0].shape[1]])
     test_utils = ("test_schema", "test_faketensor", "test_aot_dispatch_dynamic")
     torch.library.opcheck(
         chunk_mega_packed_fwd_op,
         (*inputs[:5], inputs[-1], False, SCALE),
-        test_utils=test_utils,
-        rtol=2e-2,
-        atol=2e-2,
-    )
-    torch.library.opcheck(
-        chunk_mega_dense_training_fwd_op,
-        (*inputs[:5], dense_cu_seqlens, False, SCALE),
         test_utils=test_utils,
         rtol=2e-2,
         atol=2e-2,
@@ -1022,20 +1040,6 @@ def test_mega_forward_op_registration(dtype: torch.dtype, outer_strided: bool) -
         rtol=2e-2,
         atol=2e-2,
     )
-    backward_metadata = prepare_ragged_chunk_metadata(inputs[-1], inputs[0].shape[1], 64)
-    torch.library.opcheck(
-        chunk_mega_packed_training_fwd_op,
-        (
-            *inputs[:5],
-            backward_metadata.cu_seqlens,
-            backward_metadata.chunk_offsets,
-            False,
-            SCALE,
-        ),
-        test_utils=test_utils,
-        rtol=2e-2,
-        atol=2e-2,
-    )
     torch.library.opcheck(
         chunk_mega_packed_fwd_with_initial_state_op,
         (*inputs, SCALE),
@@ -1046,13 +1050,6 @@ def test_mega_forward_op_registration(dtype: torch.dtype, outer_strided: bool) -
     torch.library.opcheck(
         chunk_mega_packed_fwd_with_state_op,
         (*inputs, SCALE),
-        test_utils=test_utils,
-        rtol=2e-2,
-        atol=2e-2,
-    )
-    torch.library.opcheck(
-        plain_gate_bwd_dense_cute_op,
-        (torch.randn(1, 128, 1, D, device="cuda"),),
         test_utils=test_utils,
         rtol=2e-2,
         atol=2e-2,
@@ -1073,7 +1070,7 @@ def test_mega_initial_state_forward_op_fullgraph() -> None:
 
 
 @pytest.mark.parametrize("candidate", [_candidate_dense, _candidate_no_state])
-def test_mega_multistream_fullgraph_cuda_graph_replay(candidate) -> None:
+def test_mega_no_state_fullgraph_cuda_graph_replay(candidate) -> None:
     inputs = _make_inputs(requires_grad=False)
     compiled = torch.compile(candidate, fullgraph=True)
     expected = compiled(*inputs)
@@ -1106,10 +1103,7 @@ def test_mega_forced_int64_forward_backward_matches_int32(monkeypatch) -> None:
         kda_prefill_f16,
         kda_recompute_f16,
     )
-    from attn_gym.linear.kda.impl import mega as backend
 
-    monkeypatch.setattr(backend, "_PACKED_LOCAL_BACKWARD_MIN_TOKENS", 1)
-    monkeypatch.setattr(backend, "_LOCAL_BACKWARD_MIN_HEADS", 1)
     expected_inputs = _make_inputs(requires_grad=True, dtype=torch.float16)
     actual_inputs = _make_inputs(requires_grad=True, dtype=torch.float16)
     d_output = torch.randn_like(expected_inputs[2])

--- a/test/test_context_parallel_distributed.py
+++ b/test/test_context_parallel_distributed.py
@@ -54,12 +54,14 @@ OPS = {"kda": (chunk_kda, context_parallel_kda), "gdn": (chunk_gdn, context_para
 # sequence where cp rank 0 owns three fragments and cp rank 1 two, so its chain alternates ranks
 # through all five slots and cp rank 1 gathers a padding slot; "empty-document" adds a
 # zero-length sequence to the stream; "one-document" gives each rank one whole subsequence of
-# complete chunks, the layout that dispatches the dense kernels.
+# complete chunks, the layout that dispatches the dense kernels; "documents" cuts only on
+# document boundaries, so no state crosses ranks and the result must be the unsharded bits.
 TABLES = {
     "zigzag": (CU_SEQLENS, [[(0, 96), (288, 384)], [(96, 192), (192, 288)]]),
     "one-document": ((0, 384), [[(0, 192)], [(192, 384)]]),
     "uneven": ((0, 384), [[(0, 64), (128, 192), (256, 384)], [(64, 128), (192, 256)]]),
     "empty-document": ((0, 40, 40, 100, 384), [[(0, 96), (288, 384)], [(96, 192), (192, 288)]]),
+    "documents": ((0, 100, 260, 384), [[(0, 100), (260, 384)], [(100, 260)]]),
 }
 
 
@@ -196,6 +198,40 @@ def _rank_main(
         _assert_matches_unsharded(
             plan, ids, (local_output, grads, exit_states), (output, expected_grads, final)
         )
+        if table == "documents":
+            # No document crosses ranks, so every document runs from the zero state on the rank
+            # that owns it: the recipe at CP=2 is bitwise the recipe at CP=1 (a one-rank group
+            # over the whole stream), and for KDA also the public op, whose kernels the staged
+            # path shares. GDN's staged path is not the public op's kernel sequence.
+            alone = ContextParallelPlan.from_fragments(cu_seqlens, [[(0, cu_seqlens[-1])]], 0)
+            solo = tuple(t.clone().requires_grad_() for t in operands)
+            solo_output, solo_exit = cp(
+                *solo, routing=alone.routing(device), group=dist.new_group([cp_rank])
+            )
+            solo_grads = torch.autograd.grad(
+                (solo_output, solo_exit),
+                solo,
+                grad_outputs=(d_output, _exit_cotangent(alone, d_final, solo_exit.shape[0])),
+            )
+            if not final_state_loss:
+                solo_grads = torch.autograd.grad(
+                    cp(*solo, routing=alone.routing(device), group=dist.new_group([cp_rank]))[0],
+                    solo,
+                    grad_outputs=(d_output,),
+                )
+            references = [(solo_output, solo_grads)]
+            if op_name == "kda":
+                references.append((output, expected_grads))
+            for ref_output, ref_grads in references:
+                for actual, expected in zip(
+                    (local_output, *grads), (ref_output, *ref_grads), strict=True
+                ):
+                    assert torch.equal(actual, expected[:, ids])
+            for index in plan.terminal:
+                sequence = plan.subsequences[index].sequence
+                assert torch.equal(exit_states[index], solo_exit[sequence])
+                if op_name == "kda":
+                    assert torch.equal(exit_states[index], final[sequence])
 
         # Unlike the attention summaries, the halo uses a differentiable functional all-gather.
         qkv = torch.randn(1, cu_seqlens[-1], CHANNELS, device=device, generator=generator)

--- a/test/test_delta_rule_stages.py
+++ b/test/test_delta_rule_stages.py
@@ -54,7 +54,8 @@ class Op(NamedTuple):
     factory: Callable[..., Inputs]  # (tokens, *, key_heads, value_heads, seed, dtype)
     key_heads: int
     value_heads: int
-    # Mega stages reproduce its native backward bitwise, not the public op's fused recompute.
+    # Mega stages reproduce its native stateful backward bitwise (public_gradients would route
+    # the no-state case through the no-state op).
     # Other variants use public_gradients directly.
     backward: Callable[..., tuple[torch.Tensor, ...]] | None = None
 


### PR DESCRIPTION
Stacked PRs:
 * #531
 * #530
 * #529
 * __->__#533


--- --- ---

Run Mega's own backward for every no-state span and show document-aligned CP fragments

The public Mega op used to pick its backward from the span's physical length: Mega's own kernel
above 4096 packed / 32768 dense tokens with 64+ heads, the fused backward (fed by a "training"
forward that also emitted the cumulative gate) below. On document-aligned context-parallel
fragments that made a rank holding one short document produce different gradient bits than the
same document inside a long span. One autograd Function now chooses only on whether an entry
state is present: without one, Mega's backward always; with one, the fused stateful backward as
before, because it carries the state cotangent in FP32 between chunks where Mega's BT16 backward
requantizes it (test/linear/test_delta_rule_state_precision.py). The thresholds, the two
training forward ops, the dense gate-scan backward op, and their stream fork/join go.

With that, fragments cut on document boundaries need nothing else to be CP-invariant: every
document runs from the zero state to its end on the rank that owns it, the recipe composes
nothing, and the result is bitwise the same for any CP degree and any document-aligned table,
including CP=1; for KDA it is also the public op's bits. document_aligned_fragments in the CP
example (--partition documents) assigns whole documents to ranks, longest first onto the
least-loaded rank. test_context_parallel_distributed gains a document-aligned table asserting
CP=2 == CP=1 bitwise for KDA and GDN (and == the public op for KDA); the Mega training tests gain
the sub-span bitwise check that failed before this change.