### PR TITLE
Default chunk_gdn to the fused implementation like chunk_kda

### DIFF
--- a/attn_gym/linear/gdn/api.py
+++ b/attn_gym/linear/gdn/api.py
@@ -33,7 +33,7 @@ def chunk_gdn(
     cu_seqlens: torch.Tensor | None = None,
     scale: float | None = None,
     output_final_state: bool = False,
-    impl: Impl | str = Impl.REFERENCE,
+    impl: Impl | str = Impl.FUSED,
     kernel_options: KernelOptions | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Apply chunk-parallel gated delta rule attention for training and prefill.
@@ -58,8 +58,9 @@ def chunk_gdn(
             unspecified.
         scale: Query scale. Defaults to ``1 / sqrt(K)``.
         output_final_state: Return the final recurrent state with the output.
-        impl: ``"reference"`` uses eager PyTorch. ``"fused"`` uses the repo-local scalar chunk
-            pipeline on CUDA capability 8.0+ with FP16/BF16 QKV and ``K = V = 128``.
+        impl: ``"fused"`` (default) uses the repo-local scalar chunk pipeline on CUDA
+            capability 8.0+ with FP16/BF16 QKV and ``K = V = 128``, as ``chunk_kda`` does;
+            ``"reference"`` uses eager PyTorch.
         kernel_options: Backend-specific options for fused execution. The repo-local path is the
             default; ``{"backend": "mega"}`` selects the optional CuTeDSL 4.7 Mega backend.
 

--- a/docs/linear.md
+++ b/docs/linear.md
@@ -29,23 +29,16 @@ output = scale * state @ query
 Public and persistent state uses axis order `[N, H, V, K]`; paged pools replace `N` with the
 slot count. `chunk_gdn` uses a chunk-parallel decomposition for training and prefill.
 `recurrent_gdn` consumes
-tokens in order for decoding, inference prefill, and state-carrying correctness checks. `chunk_gdn`
-defaults to eager PyTorch (`impl="reference"`); `chunk_gdn(..., impl="fused")` selects the
-repo-local scalar chunk pipeline. Pass `kernel_options={"backend": "mega"}` to select the optional
-Mega CuTeDSL backend. `recurrent_gdn(..., impl="fused")` selects the inference-only Triton scan.
+tokens in order for decoding, inference prefill, and state-carrying correctness checks. Like
+`chunk_kda`, `chunk_gdn` defaults to the repo-local fused chunk pipeline (`impl="fused"`);
+`impl="reference"` selects eager PyTorch. Pass `kernel_options={"backend": "mega"}` to select the
+optional Mega CuTeDSL backend. `recurrent_gdn(..., impl="fused")` selects the inference-only
+Triton scan.
 
 ```python
 from attn_gym.linear import chunk_gdn
 
-output, final_state = chunk_gdn(
-    query,
-    key,
-    value,
-    gate,
-    beta,
-    impl="fused",
-    output_final_state=True,
-)
+output, final_state = chunk_gdn(query, key, value, gate, beta, output_final_state=True)
 ```
 
 ### Supported capabilities
@@ -163,7 +156,7 @@ gates for backends that document support for it.
 from attn_gym.linear import chunk_gdn, gate_transform
 
 gate = gate_transform(raw_gate, A_log, dt_bias, kind="softplus")
-output, final_state = chunk_gdn(q, k, v, gate, beta, impl="fused")
+output, final_state = chunk_gdn(q, k, v, gate, beta)
 ```
 
 ::: attn_gym.linear.gate_transform

--- a/test/linear/test_gdn.py
+++ b/test/linear/test_gdn.py
@@ -2,7 +2,8 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from attn_gym.linear import Impl, chunk_gdn
+from attn_gym.linear import Impl
+from attn_gym.linear import chunk_gdn as _chunk_gdn
 from attn_gym.linear import recurrent_gdn as _recurrent_gdn
 from attn_gym.linear._delta_rule.validation import validate_paged_state
 from attn_gym.linear.gdn.validation import resolve_kernel_options
@@ -12,6 +13,11 @@ from attn_gym.testing import cumulative_sequence_offsets
 def recurrent_gdn(*args, **kwargs):
     kwargs.setdefault("impl", Impl.REFERENCE)
     return _recurrent_gdn(*args, **kwargs)
+
+
+def chunk_gdn(*args, **kwargs):
+    kwargs.setdefault("impl", Impl.REFERENCE)
+    return _chunk_gdn(*args, **kwargs)
 
 
 REFERENCE_CASES = [recurrent_gdn, chunk_gdn]


### PR DESCRIPTION
Stacked PRs:
 * #531
 * #530
 * #529
 * #534
 * __->__#535


--- --- ---

Default chunk_gdn to the fused implementation like chunk_kda

chunk_gdn was the only public delta-rule entry point defaulting to impl="reference" (eager
PyTorch); chunk_kda, recurrent_kda, and recurrent_gdn all default to the fused kernels. The
mismatch made chunk_gdn(...) with default arguments a different, much slower computation than its
siblings and turned "compare against the public op" into "compare against the eager reference"
in tests. The reference-semantics tests (test/linear/test_gdn.py, test_gate_transform) now ask
for impl="reference" explicitly, the same way that file already wraps recurrent_gdn.