### PR TITLE
Persist the Mega kernels in the CuTeDSL compile cache

### DIFF
--- a/attn_gym/linear/_delta_rule/mega/kernels/gdn_bprop_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/gdn_bprop_f16.py
@@ -107,6 +107,7 @@ Warp assignments (12 warps = 384 threads):
 
 from dataclasses import dataclass
 from functools import cache, partial
+from pathlib import Path
 from typing import NamedTuple
 
 import cuda.bindings.driver as cuda_driver
@@ -116,7 +117,7 @@ import cutlass.experimental.primitives as nvvm
 from cutlass import cute
 from cutlass.experimental import cuda
 
-from attn_gym._backends.cute import compile_tvm_ffi
+from attn_gym._backends.cute import compile_tvm_ffi, jit_cache
 from attn_gym._backends.cute.utils import get_device_properties, requires_int64_abi, validate_tma_tensor
 
 from .common.elementwise import softplus
@@ -5444,6 +5445,135 @@ def _validate_scalar_fp32(name, tensor, expected_shape) -> None:
         raise ValueError(f"{name} outer strides must be nonnegative")
 
 
+@jit_cache(extra_sources=(Path(__file__).parent,))
+def compile(
+    io_dtype: type[cutlass.Numeric],
+    h_q: int,
+    h_k: int,
+    h_v: int,
+    h_out: int,
+    use_initial_state: bool,
+    use_dstate_in: bool,
+    use_dstate0: bool,
+    dyn_sched: bool,
+    use_int64_offsets: bool,
+    num_sm: int,
+    scale: float,
+):
+    """JIT-compile one fake-tensor TVM-FFI backward signature."""
+    sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
+    cfg = build_cfg(
+        io_dtype,
+        use_initial_state=use_initial_state,
+        use_dstate_in=use_dstate_in,
+        use_dstate0=use_dstate0,
+        q_ratio=h_out // h_q,
+        k_ratio=h_out // h_k,
+        v_ratio=h_out // h_v,
+        n_heads_out=h_out,
+        max_active_clusters=num_sm,
+        dyn_sched=dyn_sched,
+    )
+    op = GdnBpropOp(cfg, use_int64_offsets)
+    tokens_sym, sequence_entries, sequences, work_rows, sched_entries, workspace_words = (
+        sym_int() for _ in range(6)
+    )
+    scalar_tensor = partial(
+        make_strided_signature_tensor,
+        assumed_align=4,
+        use_int64_offsets=use_int64_offsets,
+    )
+    return compile_tvm_ffi(
+        op,
+        scalar_tensor(cutlass.Float32, (tokens_sym, h_out)),
+        None,
+        None,
+        scalar_tensor(cutlass.Float32, (tokens_sym, h_out)),
+        scalar_tensor(cutlass.Float32, (tokens_sym, h_out)),
+        scalar_tensor(cutlass.Float32, (tokens_sym, h_out)),
+        make_cu_seqlens_signature(sequence_entries),
+        make_strided_signature_tensor(
+            cutlass.Float32,
+            (sequences, h_out, CFG.D_V, CFG.D_K),
+            assumed_align=16,
+            use_int64_offsets=use_int64_offsets,
+        )
+        if use_dstate0
+        else None,
+        make_strided_signature_tensor(
+            cutlass.Float32,
+            (sequences, h_out, CFG.D_V, CFG.D_K),
+            assumed_align=16,
+            use_int64_offsets=use_int64_offsets,
+        )
+        if use_dstate_in
+        else None,
+        make_work_items_signature(work_rows),
+        make_counter_signature(),
+        make_counter_signature(sched_entries) if dyn_sched else None,
+        make_workspace_signature(workspace_words),
+        cutlass.Float32(scale),
+    )
+
+
+@jit_cache(extra_sources=(Path(__file__).parent,))
+def compile_prologue(
+    io_dtype: type[cutlass.Numeric],
+    h_q: int,
+    h_k: int,
+    h_v: int,
+    h_out: int,
+    run_order: bool,
+    order_gen: bool,
+    has_sched: bool,
+    dyn_sched: bool,
+    use_int64_offsets: bool,
+):
+    """JIT-compile the prologue from static specialization arguments."""
+    sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
+    (
+        tokens_sym,
+        checkpoint_rows,
+        sequence_entries,
+        work_rows,
+        sched_entries,
+        workspace_words,
+    ) = (sym_int() for _ in range(6))
+    tma_tensor = partial(
+        make_strided_signature_tensor,
+        assumed_align=16,
+        use_int64_offsets=use_int64_offsets,
+    )
+    work_items_signature = make_work_items_signature(work_rows)
+    return compile_tvm_ffi(
+        prologue,
+        io_dtype,
+        CFG.B_T,
+        run_order,
+        order_gen,
+        has_sched,
+        tma_tensor(io_dtype, (tokens_sym, h_q, CFG.D_K)),
+        tma_tensor(io_dtype, (tokens_sym, h_k, CFG.D_K)),
+        tma_tensor(io_dtype, (tokens_sym, h_v, CFG.D_V)),
+        tma_tensor(io_dtype, (tokens_sym, h_out, CFG.D_V)),
+        tma_tensor(io_dtype, (tokens_sym, h_q, CFG.D_K)),
+        tma_tensor(io_dtype, (tokens_sym, h_k, CFG.D_K)),
+        tma_tensor(io_dtype, (tokens_sym, h_v, CFG.D_V)),
+        tma_tensor(io_dtype, (checkpoint_rows, h_out, CFG.D_V, CFG.D_K)),
+        make_cu_seqlens_signature(sequence_entries),
+        work_items_signature if run_order and not order_gen else None,
+        make_counter_signature(),
+        work_items_signature,
+        make_counter_signature(sched_entries) if has_sched else None,
+        make_workspace_signature(workspace_words),
+        name=(
+            f"gdn_mega_bprop_prologue_{io_dtype.__name__.lower()}"
+            f"_hq{h_q}_hk{h_k}_hv{h_v}_ho{h_out}_r{int(run_order)}"
+            f"o{int(order_gen)}d{int(dyn_sched)}_i64{int(use_int64_offsets)}"
+        ),
+    )
+
+
 def chunk_gdn_bwd_sm100(
     q,
     k,
@@ -5628,104 +5758,35 @@ def chunk_gdn_bwd_sm100(
     )
 
     io_dtype = get_dtype(q.dtype)
-    sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
     if "compiled" not in cache:
-        cfg = build_cfg(
+        cache["compiled"] = compile(
             io_dtype,
-            use_initial_state=use_initial_state,
-            use_dstate_in=use_dstate_in,
-            use_dstate0=use_dstate0,
-            q_ratio=h_out // h_q,
-            k_ratio=h_out // h_k,
-            v_ratio=h_out // h_v,
-            n_heads_out=h_out,
-            max_active_clusters=num_sm,
-            dyn_sched=dyn_sched,
-        )
-        op = GdnBpropOp(cfg, use_int64_offsets)
-        tokens_sym, sequence_entries, sequences, work_rows, sched_entries, workspace_words = (
-            sym_int() for _ in range(6)
-        )
-        scalar_tensor = partial(
-            make_strided_signature_tensor,
-            assumed_align=4,
-            use_int64_offsets=use_int64_offsets,
-        )
-        cache["compiled"] = compile_tvm_ffi(
-            op,
-            scalar_tensor(cutlass.Float32, (tokens_sym, h_out)),
-            None,
-            None,
-            scalar_tensor(cutlass.Float32, (tokens_sym, h_out)),
-            scalar_tensor(cutlass.Float32, (tokens_sym, h_out)),
-            scalar_tensor(cutlass.Float32, (tokens_sym, h_out)),
-            make_cu_seqlens_signature(sequence_entries),
-            make_strided_signature_tensor(
-                cutlass.Float32,
-                (sequences, h_out, CFG.D_V, CFG.D_K),
-                assumed_align=16,
-                use_int64_offsets=use_int64_offsets,
-            )
-            if use_dstate0
-            else None,
-            make_strided_signature_tensor(
-                cutlass.Float32,
-                (sequences, h_out, CFG.D_V, CFG.D_K),
-                assumed_align=16,
-                use_int64_offsets=use_int64_offsets,
-            )
-            if use_dstate_in
-            else None,
-            make_work_items_signature(work_rows),
-            make_counter_signature(),
-            make_counter_signature(sched_entries) if dyn_sched else None,
-            make_workspace_signature(workspace_words),
-            cutlass.Float32(scale),
+            h_q,
+            h_k,
+            h_v,
+            h_out,
+            use_initial_state,
+            use_dstate_in,
+            use_dstate0,
+            dyn_sched,
+            use_int64_offsets,
+            num_sm,
+            scale,
         )
 
     if "prologue" not in cache:
-        (
-            tokens_sym,
-            checkpoint_rows,
-            sequence_entries,
-            work_rows,
-            sched_entries,
-            workspace_words,
-        ) = (sym_int() for _ in range(6))
-        tma_tensor = partial(
-            make_strided_signature_tensor,
-            assumed_align=16,
-            use_int64_offsets=use_int64_offsets,
-        )
-        work_items_signature = make_work_items_signature(work_rows)
-        cache["prologue"] = compile_tvm_ffi(
-            prologue,
+        cache["prologue"] = compile_prologue(
             io_dtype,
-            CFG.B_T,
+            h_q,
+            h_k,
+            h_v,
+            h_out,
             run_order,
             order_gen,
             has_sched,
-            tma_tensor(io_dtype, (tokens_sym, h_q, CFG.D_K)),
-            tma_tensor(io_dtype, (tokens_sym, h_k, CFG.D_K)),
-            tma_tensor(io_dtype, (tokens_sym, h_v, CFG.D_V)),
-            tma_tensor(io_dtype, (tokens_sym, h_out, CFG.D_V)),
-            tma_tensor(io_dtype, (tokens_sym, h_q, CFG.D_K)),
-            tma_tensor(io_dtype, (tokens_sym, h_k, CFG.D_K)),
-            tma_tensor(io_dtype, (tokens_sym, h_v, CFG.D_V)),
-            tma_tensor(io_dtype, (checkpoint_rows, h_out, CFG.D_V, CFG.D_K)),
-            make_cu_seqlens_signature(sequence_entries),
-            work_items_signature if run_order and not order_gen else None,
-            make_counter_signature(),
-            work_items_signature,
-            make_counter_signature(sched_entries) if has_sched else None,
-            make_workspace_signature(workspace_words),
-            name=(
-                f"gdn_mega_bprop_prologue_{io_dtype.__name__.lower()}"
-                f"_hq{h_q}_hk{h_k}_hv{h_v}_ho{h_out}_r{int(run_order)}"
-                f"o{int(order_gen)}d{int(dyn_sched)}_i64{int(use_int64_offsets)}"
-            ),
+            dyn_sched,
+            use_int64_offsets,
         )
-
     cache["prologue"](
         q,
         k,

--- a/attn_gym/linear/_delta_rule/mega/kernels/gdn_prefill_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/gdn_prefill_f16.py
@@ -84,6 +84,7 @@ Warp assignments (12 warps = 384 threads):
 
 from dataclasses import dataclass
 from functools import lru_cache, partial
+from pathlib import Path
 from typing import NamedTuple, Optional, Tuple, Type
 
 import cuda.bindings.driver as cuda_driver
@@ -94,7 +95,7 @@ import cutlass.experimental.cuda as cuda
 import cutlass.experimental.primitives as nvvm
 from cutlass.cutlass_dsl import min
 
-from attn_gym._backends.cute import compile_tvm_ffi
+from attn_gym._backends.cute import compile_tvm_ffi, jit_cache
 from attn_gym._backends.cute.utils import get_device_properties, requires_int64_abi, validate_tma_tensor
 
 from .common.elementwise import softplus
@@ -3809,6 +3810,7 @@ def get_compiled_cache(
     return {}
 
 
+@jit_cache(extra_sources=(Path(__file__).parent,))
 def compile(
     io_dtype,
     state_dtype,
@@ -3925,6 +3927,59 @@ def compile(
             f"_l{int(log_gate)}s{int(safe_gate)}b{int(beta_sigmoid)}"
             f"_d{int(dyn_sched)}_i64{int(use_int64_offsets)}"
             f"_p{int(paged_state)}m{int(has_initial_state_mask)}"
+        ),
+    )
+
+
+@jit_cache(extra_sources=(Path(__file__).parent,))
+def compile_prologue(
+    io_dtype: type[cutlass.Numeric],
+    h_q: int,
+    h_k: int,
+    h_v: int,
+    h_out: int,
+    enable_checkpoints: bool,
+    order_gen: bool,
+    dyn_sched: bool,
+    checkpoint_every_n_tokens: int,
+    use_int64_offsets: bool,
+):
+    """JIT-compile the prologue from static specialization arguments."""
+    sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
+    tokens, sequence_entries, checkpoint_rows, work_rows, sched_entries, workspace_words = (
+        sym_int() for _ in range(6)
+    )
+    tma_tensor = partial(
+        make_strided_signature_tensor,
+        assumed_align=16,
+        use_int64_offsets=use_int64_offsets,
+    )
+    work_items_signature = make_work_items_signature(work_rows)
+    return compile_tvm_ffi(
+        prologue,
+        io_dtype,
+        CFG.B_T,
+        order_gen,
+        dyn_sched,
+        tma_tensor(io_dtype, (tokens, h_q, 128)),
+        tma_tensor(io_dtype, (tokens, h_k, 128)),
+        tma_tensor(io_dtype, (tokens, h_v, 128)),
+        tma_tensor(io_dtype, (tokens, h_out, 128)),
+        make_cu_seqlens_signature(sequence_entries),
+        tma_tensor(io_dtype, (checkpoint_rows, h_out, 128, 128))
+        if enable_checkpoints
+        else None,
+        work_items_signature if not order_gen else None,
+        make_counter_signature(),
+        work_items_signature,
+        make_counter_signature(sched_entries) if dyn_sched else None,
+        cutlass.Int32(checkpoint_every_n_tokens),
+        make_workspace_signature(workspace_words),
+        name=(
+            f"gdn_mega_prefill_prologue_{io_dtype.__name__.lower()}"
+            f"_hq{h_q}_hk{h_k}_hv{h_v}_ho{h_out}"
+            f"_c{int(enable_checkpoints)}o{int(order_gen)}d{int(dyn_sched)}"
+            f"_i64{int(use_int64_offsets)}"
         ),
     )
 
@@ -4135,42 +4190,17 @@ def chunk_gdn_sm100(
         )
 
     if "prologue" not in cache:
-        sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
-        tokens, sequence_entries, checkpoint_rows, work_rows, sched_entries, workspace_words = (
-            sym_int() for _ in range(6)
-        )
-        tma_tensor = partial(
-            make_strided_signature_tensor,
-            assumed_align=16,
-            use_int64_offsets=use_int64_offsets,
-        )
-        work_items_signature = make_work_items_signature(work_rows)
-        cache["prologue"] = compile_tvm_ffi(
-            prologue,
+        cache["prologue"] = compile_prologue(
             io_dtype,
-            CFG.B_T,
+            h_q,
+            h_k,
+            h_v,
+            h_out,
+            enable_checkpoints,
             order_gen,
             dyn_sched,
-            tma_tensor(io_dtype, (tokens, h_q, 128)),
-            tma_tensor(io_dtype, (tokens, h_k, 128)),
-            tma_tensor(io_dtype, (tokens, h_v, 128)),
-            tma_tensor(io_dtype, (tokens, h_out, 128)),
-            make_cu_seqlens_signature(sequence_entries),
-            tma_tensor(io_dtype, (checkpoint_rows, h_out, 128, 128))
-            if checkpoints_for_descs is not None
-            else None,
-            work_items_signature if not order_gen else None,
-            make_counter_signature(),
-            work_items_signature,
-            make_counter_signature(sched_entries) if dyn_sched else None,
-            cutlass.Int32(checkpoint_every_n_tokens),
-            make_workspace_signature(workspace_words),
-            name=(
-                f"gdn_mega_prefill_prologue_{io_dtype.__name__.lower()}"
-                f"_hq{h_q}_hk{h_k}_hv{h_v}_ho{h_out}"
-                f"_c{int(enable_checkpoints)}o{int(order_gen)}d{int(dyn_sched)}"
-                f"_i64{int(use_int64_offsets)}"
-            ),
+            checkpoint_every_n_tokens,
+            use_int64_offsets,
         )
     cache["prologue"](
         q,

--- a/attn_gym/linear/_delta_rule/mega/kernels/gdn_recompute_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/gdn_recompute_f16.py
@@ -74,6 +74,7 @@ Warp assignments (12 warps = 384 threads):
 
 from dataclasses import dataclass
 from functools import lru_cache, partial
+from pathlib import Path
 from typing import NamedTuple, Optional, Tuple, Type
 
 import cuda.bindings.driver as cuda_driver
@@ -84,7 +85,7 @@ import cutlass.experimental.cuda as cuda
 import cutlass.experimental.primitives as nvvm
 from cutlass.cutlass_dsl import min
 
-from attn_gym._backends.cute import compile_tvm_ffi
+from attn_gym._backends.cute import compile_tvm_ffi, jit_cache
 from attn_gym._backends.cute.utils import get_device_properties, requires_int64_abi, validate_tma_tensor
 
 from .common.elementwise import softplus
@@ -3172,6 +3173,7 @@ def get_compiled_cache(
     return {}
 
 
+@jit_cache(extra_sources=(Path(__file__).parent,))
 def compile(
     io_dtype,
     state_dtype,
@@ -3252,6 +3254,63 @@ def compile(
             f"_g{int(is_gqa)}_i{int(use_initial_state)}f{int(store_final_state)}"
             f"c{int(enable_checkpoints)}_l{int(log_gate)}s{int(safe_gate)}"
             f"b{int(beta_sigmoid)}_d{int(dyn_sched)}_i64{int(use_int64_offsets)}"
+        ),
+    )
+
+
+@jit_cache(extra_sources=(Path(__file__).parent,))
+def compile_prologue(
+    io_dtype: type[cutlass.Numeric],
+    h_k: int,
+    h_v: int,
+    h_out: int,
+    enable_checkpoints: bool,
+    run_order: bool,
+    order_gen: bool,
+    dyn_sched: bool,
+    checkpoint_every_n_tokens: int,
+    use_int64_offsets: bool,
+):
+    """JIT-compile the prologue from static specialization arguments."""
+    sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
+    tokens, sequence_entries, checkpoint_rows, work_rows, sched_entries, workspace_words = (
+        sym_int() for _ in range(6)
+    )
+    tma_tensor = partial(
+        make_strided_signature_tensor,
+        assumed_align=16,
+        use_int64_offsets=use_int64_offsets,
+    )
+    work_items_signature = make_work_items_signature(work_rows)
+    return compile_tvm_ffi(
+        prologue,
+        io_dtype,
+        CFG.B_T,
+        run_order,
+        order_gen,
+        tma_tensor(io_dtype, (tokens, h_k, 128)),
+        tma_tensor(io_dtype, (tokens, h_v, 128)),
+        make_strided_signature_tensor(
+            cutlass.Float32,
+            (tokens, h_out),
+            assumed_align=4,
+            use_int64_offsets=use_int64_offsets,
+        ),
+        make_cu_seqlens_signature(sequence_entries),
+        tma_tensor(io_dtype, (checkpoint_rows, h_out, 128, 128))
+        if enable_checkpoints
+        else None,
+        work_items_signature if run_order and not order_gen else None,
+        make_counter_signature(),
+        work_items_signature,
+        make_counter_signature(sched_entries) if run_order else None,
+        cutlass.Int32(checkpoint_every_n_tokens),
+        make_workspace_signature(workspace_words),
+        name=(
+            f"gdn_mega_recompute_prologue_{io_dtype.__name__.lower()}"
+            f"_hk{h_k}_hv{h_v}_ho{h_out}_c{int(enable_checkpoints)}"
+            f"_r{int(run_order)}o{int(order_gen)}d{int(dyn_sched)}"
+            f"_i64{int(use_int64_offsets)}"
         ),
     )
 
@@ -3450,46 +3509,17 @@ def chunk_gdn_recompute_sm100(
         )
 
     if "prologue" not in cache:
-        sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
-        tokens, sequence_entries, checkpoint_rows, work_rows, sched_entries, workspace_words = (
-            sym_int() for _ in range(6)
-        )
-        tma_tensor = partial(
-            make_strided_signature_tensor,
-            assumed_align=16,
-            use_int64_offsets=use_int64_offsets,
-        )
-        work_items_signature = make_work_items_signature(work_rows)
-        cache["prologue"] = compile_tvm_ffi(
-            prologue,
+        cache["prologue"] = compile_prologue(
             io_dtype,
-            CFG.B_T,
+            h_k,
+            h_v,
+            h_out,
+            enable_checkpoints,
             run_order,
             order_gen,
-            tma_tensor(io_dtype, (tokens, h_k, 128)),
-            tma_tensor(io_dtype, (tokens, h_v, 128)),
-            make_strided_signature_tensor(
-                cutlass.Float32,
-                (tokens, h_out),
-                assumed_align=4,
-                use_int64_offsets=use_int64_offsets,
-            ),
-            make_cu_seqlens_signature(sequence_entries),
-            tma_tensor(io_dtype, (checkpoint_rows, h_out, 128, 128))
-            if checkpoints_for_descs is not None
-            else None,
-            work_items_signature if run_order and not order_gen else None,
-            make_counter_signature(),
-            work_items_signature,
-            make_counter_signature(sched_entries) if run_order else None,
-            cutlass.Int32(checkpoint_every_n_tokens),
-            make_workspace_signature(workspace_words),
-            name=(
-                f"gdn_mega_recompute_prologue_{io_dtype.__name__.lower()}"
-                f"_hk{h_k}_hv{h_v}_ho{h_out}_c{int(enable_checkpoints)}"
-                f"_r{int(run_order)}o{int(order_gen)}d{int(dyn_sched)}"
-                f"_i64{int(use_int64_offsets)}"
-            ),
+            dyn_sched,
+            checkpoint_every_n_tokens,
+            use_int64_offsets,
         )
     cache["prologue"](
         k,

--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_bprop_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_bprop_f16.py
@@ -73,6 +73,7 @@ Warp assignments (16 warps = 512 threads):
 
 from dataclasses import dataclass
 from functools import lru_cache, partial
+from pathlib import Path
 from typing import NamedTuple, Type
 
 import cuda.bindings.driver as cuda_driver
@@ -82,7 +83,7 @@ import cutlass.experimental.cuda as cuda
 import cutlass.experimental.primitives as nvvm
 import cutlass.cute as cute
 
-from attn_gym._backends.cute import compile_tvm_ffi
+from attn_gym._backends.cute import compile_tvm_ffi, jit_cache
 from attn_gym._backends.cute.utils import get_device_properties, requires_int64_abi, validate_tma_tensor
 from attn_gym.linear._delta_rule.mega.kernels.common.split_k import ORDER_CAPACITY, ORDER_ELEMS, ORDER_THREADS, decode_work_item, order_body
 from attn_gym.linear._delta_rule.mega.kernels.common.host import checkpoint_capacity_bound, get_dtype
@@ -4145,6 +4146,151 @@ def get_compiled_cache(
     return {}
 
 
+@jit_cache(extra_sources=(Path(__file__).parent,))
+def compile(
+    io_dtype: type[cutlass.Numeric],
+    HQ: int,
+    HK: int,
+    HV: int,
+    HO: int,
+    use_dstate_in: bool,
+    use_dstate0: bool,
+    use_qk_l2norm_in_kernel: bool,
+    safe_gate: bool,
+    gate_scale_log2: float,
+    use_beta_sigmoid: bool,
+    use_initial_state: bool,
+    dyn_sched: bool,
+    use_int64_offsets: bool,
+    num_sm: int,
+    scale: float,
+):
+    """JIT-compile one fake-tensor TVM-FFI backward signature."""
+    sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
+    cfg = build_cfg(
+        io_dtype,
+        use_dstate_in=use_dstate_in,
+        use_dstate0=use_dstate0,
+        l2norm=use_qk_l2norm_in_kernel,
+        safe_gate=safe_gate,
+        gate_scale_log2=gate_scale_log2,
+        beta_sigmoid=use_beta_sigmoid,
+        use_initial_state=use_initial_state,
+        q_ratio=HO // HQ,
+        k_ratio=HO // HK,
+        v_ratio=HO // HV,
+        n_heads_out=HO,
+        max_active_clusters=num_sm,
+        dyn_sched=dyn_sched,
+    )
+    op = KdaBpropOp(cfg, use_int64_offsets)
+    (
+        tokens,
+        checkpoint_rows,
+        sequence_entries,
+        sequences,
+        work_rows,
+        sched_entries,
+        workspace_words,
+    ) = (sym_int() for _ in range(7))
+
+    tma_tensor = partial(
+        make_strided_signature_tensor,
+        assumed_align=16,
+        use_int64_offsets=use_int64_offsets,
+    )
+    beta_dtype = io_dtype if use_beta_sigmoid else cutlass.Float32
+    return compile_tvm_ffi(
+        op,
+        make_compact_signature_tensor(
+            cutlass.Float32,
+            (HO,),
+            assumed_align=4,
+        )
+        if safe_gate
+        else None,
+        tma_tensor(cutlass.Float32, (HO, 128)) if safe_gate else None,
+        make_strided_signature_tensor(
+            beta_dtype,
+            (tokens, HO),
+            assumed_align=beta_dtype.width // 8,
+            use_int64_offsets=use_int64_offsets,
+        ),
+        tma_tensor(io_dtype, (checkpoint_rows, HO, 128, 128)),
+        tma_tensor(cutlass.Float32, (tokens, HO, 128)),
+        make_strided_signature_tensor(
+            beta_dtype,
+            (tokens, HO),
+            assumed_align=beta_dtype.width // 8,
+            use_int64_offsets=use_int64_offsets,
+        ),
+        make_cu_seqlens_signature(sequence_entries),
+        tma_tensor(cutlass.Float32, (sequences, HO, 128, 128)) if use_dstate0 else None,
+        tma_tensor(cutlass.Float32, (sequences, HO, 128, 128)) if use_dstate_in else None,
+        make_work_items_signature(work_rows),
+        make_counter_signature(),
+        make_counter_signature(sched_entries) if dyn_sched else None,
+        make_workspace_signature(workspace_words),
+        cutlass.Float32(scale),
+    )
+
+
+@jit_cache(extra_sources=(Path(__file__).parent,))
+def compile_prologue(
+    io_dtype: type[cutlass.Numeric],
+    HQ: int,
+    HK: int,
+    HV: int,
+    HO: int,
+    run_order: bool,
+    order_gen: bool,
+    has_sched: bool,
+    dyn_sched: bool,
+    use_int64_offsets: bool,
+):
+    """JIT-compile the prologue from static specialization arguments."""
+    sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
+    tokens, checkpoint_rows, sequence_entries, work_rows, sched_entries, workspace_words = (
+        sym_int() for _ in range(6)
+    )
+
+    tma_tensor = partial(
+        make_strided_signature_tensor,
+        assumed_align=16,
+        use_int64_offsets=use_int64_offsets,
+    )
+    work_items_signature = make_work_items_signature(work_rows)
+    return compile_tvm_ffi(
+        prologue,
+        io_dtype,
+        CFG.B_T,
+        run_order,
+        order_gen,
+        has_sched,
+        tma_tensor(io_dtype, (tokens, HQ, 128)),
+        tma_tensor(io_dtype, (tokens, HK, 128)),
+        tma_tensor(io_dtype, (tokens, HV, 128)),
+        tma_tensor(cutlass.Float32, (tokens, HO, 128)),
+        tma_tensor(io_dtype, (tokens, HO, 128)),
+        tma_tensor(io_dtype, (tokens, HQ, 128)),
+        tma_tensor(io_dtype, (tokens, HK, 128)),
+        tma_tensor(io_dtype, (tokens, HV, 128)),
+        tma_tensor(cutlass.Float32, (tokens, HO, 128)),
+        tma_tensor(io_dtype, (checkpoint_rows, HO, 128, 128)),
+        make_cu_seqlens_signature(sequence_entries),
+        work_items_signature if run_order and not order_gen else None,
+        make_counter_signature(),
+        work_items_signature,
+        make_counter_signature(sched_entries) if has_sched else None,
+        make_workspace_signature(workspace_words),
+        name=(
+            f"kda_mega_bprop_prologue_{io_dtype.__name__.lower()}"
+            f"_hq{HQ}_hk{HK}_hv{HV}_ho{HO}_r{int(run_order)}"
+            f"o{int(order_gen)}d{int(dyn_sched)}_i64{int(use_int64_offsets)}"
+        ),
+    )
+
+
 def chunk_kda_bwd_sm100(
     q,
     k,
@@ -4347,114 +4493,38 @@ def chunk_kda_bwd_sm100(
     )
 
     io_dtype = get_dtype(q.dtype)
-    sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
     if "compiled" not in cache:
-        cfg = build_cfg(
+        cache["compiled"] = compile(
             io_dtype,
-            use_dstate_in=use_dstate_in,
-            use_dstate0=use_dstate0,
-            l2norm=use_qk_l2norm_in_kernel,
-            safe_gate=safe_gate,
-            gate_scale_log2=gate_scale_log2,
-            beta_sigmoid=use_beta_sigmoid,
-            use_initial_state=use_initial_state,
-            q_ratio=HO // HQ,
-            k_ratio=HO // HK,
-            v_ratio=HO // HV,
-            n_heads_out=HO,
-            max_active_clusters=num_sm,
-            dyn_sched=dyn_sched,
-        )
-        op = KdaBpropOp(cfg, use_int64_offsets)
-        (
-            tokens,
-            checkpoint_rows,
-            sequence_entries,
-            sequences,
-            work_rows,
-            sched_entries,
-            workspace_words,
-        ) = (sym_int() for _ in range(7))
-
-        tma_tensor = partial(
-            make_strided_signature_tensor,
-            assumed_align=16,
-            use_int64_offsets=use_int64_offsets,
-        )
-        beta_dtype = io_dtype if use_beta_sigmoid else cutlass.Float32
-        cache["compiled"] = compile_tvm_ffi(
-            op,
-            make_compact_signature_tensor(
-                cutlass.Float32,
-                (HO,),
-                assumed_align=4,
-            )
-            if safe_gate
-            else None,
-            tma_tensor(cutlass.Float32, (HO, 128)) if safe_gate else None,
-            make_strided_signature_tensor(
-                beta_dtype,
-                (tokens, HO),
-                assumed_align=beta_dtype.width // 8,
-                use_int64_offsets=use_int64_offsets,
-            ),
-            tma_tensor(io_dtype, (checkpoint_rows, HO, 128, 128)),
-            tma_tensor(cutlass.Float32, (tokens, HO, 128)),
-            make_strided_signature_tensor(
-                beta_dtype,
-                (tokens, HO),
-                assumed_align=beta_dtype.width // 8,
-                use_int64_offsets=use_int64_offsets,
-            ),
-            make_cu_seqlens_signature(sequence_entries),
-            tma_tensor(cutlass.Float32, (sequences, HO, 128, 128)) if use_dstate0 else None,
-            tma_tensor(cutlass.Float32, (sequences, HO, 128, 128)) if use_dstate_in else None,
-            make_work_items_signature(work_rows),
-            make_counter_signature(),
-            make_counter_signature(sched_entries) if dyn_sched else None,
-            make_workspace_signature(workspace_words),
-            cutlass.Float32(scale),
+            HQ,
+            HK,
+            HV,
+            HO,
+            use_dstate_in,
+            use_dstate0,
+            use_qk_l2norm_in_kernel,
+            safe_gate,
+            gate_scale_log2,
+            use_beta_sigmoid,
+            use_initial_state,
+            dyn_sched,
+            use_int64_offsets,
+            num_sm,
+            scale,
         )
 
     if "prologue" not in cache:
-        tokens, checkpoint_rows, sequence_entries, work_rows, sched_entries, workspace_words = (
-            sym_int() for _ in range(6)
-        )
-
-        tma_tensor = partial(
-            make_strided_signature_tensor,
-            assumed_align=16,
-            use_int64_offsets=use_int64_offsets,
-        )
-        work_items_signature = make_work_items_signature(work_rows)
-        cache["prologue"] = compile_tvm_ffi(
-            prologue,
+        cache["prologue"] = compile_prologue(
             io_dtype,
-            CFG.B_T,
+            HQ,
+            HK,
+            HV,
+            HO,
             run_order,
             order_gen,
             has_sched,
-            tma_tensor(io_dtype, (tokens, HQ, 128)),
-            tma_tensor(io_dtype, (tokens, HK, 128)),
-            tma_tensor(io_dtype, (tokens, HV, 128)),
-            tma_tensor(cutlass.Float32, (tokens, HO, 128)),
-            tma_tensor(io_dtype, (tokens, HO, 128)),
-            tma_tensor(io_dtype, (tokens, HQ, 128)),
-            tma_tensor(io_dtype, (tokens, HK, 128)),
-            tma_tensor(io_dtype, (tokens, HV, 128)),
-            tma_tensor(cutlass.Float32, (tokens, HO, 128)),
-            tma_tensor(io_dtype, (checkpoint_rows, HO, 128, 128)),
-            make_cu_seqlens_signature(sequence_entries),
-            work_items_signature if run_order and not order_gen else None,
-            make_counter_signature(),
-            work_items_signature,
-            make_counter_signature(sched_entries) if has_sched else None,
-            make_workspace_signature(workspace_words),
-            name=(
-                f"kda_mega_bprop_prologue_{io_dtype.__name__.lower()}"
-                f"_hq{HQ}_hk{HK}_hv{HV}_ho{HO}_r{int(run_order)}"
-                f"o{int(order_gen)}d{int(dyn_sched)}_i64{int(use_int64_offsets)}"
-            ),
+            dyn_sched,
+            use_int64_offsets,
         )
     cache["prologue"](
         q,

--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_prefill_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_prefill_f16.py
@@ -88,6 +88,7 @@ Requires the public CuTeDSL 4.7 API, including `cutlass.experimental.*`.
 
 from dataclasses import dataclass
 from functools import lru_cache, partial
+from pathlib import Path
 from typing import NamedTuple, Type
 
 import cuda.bindings.driver as cuda_driver
@@ -97,7 +98,7 @@ import cutlass.experimental.cuda as cuda
 import cutlass.experimental.primitives as nvvm
 import cutlass.cute as cute
 
-from attn_gym._backends.cute import compile_tvm_ffi
+from attn_gym._backends.cute import compile_tvm_ffi, jit_cache
 from attn_gym._backends.cute.utils import get_device_properties, requires_int64_abi, validate_tma_tensor
 
 from .common.split_k import ORDER_CAPACITY, ORDER_ELEMS, ORDER_THREADS, decode_work_item, order_body
@@ -2836,6 +2837,7 @@ def get_compiled_cache(
     return {}
 
 
+@jit_cache(extra_sources=(Path(__file__).parent,))
 def compile(
     io_dtype,
     state_dtype,
@@ -2938,6 +2940,55 @@ def compile(
         make_counter_signature(sched_entries) if dyn_sched else None,
         make_workspace_signature(workspace_words),
         cutlass.Float32(scale),
+    )
+
+
+@jit_cache(extra_sources=(Path(__file__).parent,))
+def compile_prologue(
+    io_dtype: type[cutlass.Numeric],
+    HQ: int,
+    HK: int,
+    HV: int,
+    HO: int,
+    order_gen: bool,
+    has_sched: bool,
+    dyn_sched: bool,
+    use_int64_offsets: bool,
+):
+    """JIT-compile the prologue from static specialization arguments."""
+    sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
+    tokens, sequence_entries, work_rows, sched_entries, workspace_words = (
+        sym_int() for _ in range(5)
+    )
+
+    tma_tensor = partial(
+        make_strided_signature_tensor,
+        assumed_align=16,
+        use_int64_offsets=use_int64_offsets,
+    )
+    work_items_signature = make_work_items_signature(work_rows)
+    return compile_tvm_ffi(
+        prologue,
+        io_dtype,
+        CFG.B_T,
+        order_gen,
+        has_sched,
+        tma_tensor(io_dtype, (tokens, HQ, 128)),
+        tma_tensor(io_dtype, (tokens, HK, 128)),
+        tma_tensor(io_dtype, (tokens, HV, 128)),
+        tma_tensor(cutlass.Float32, (tokens, HO, 128)),
+        tma_tensor(io_dtype, (tokens, HO, 128)),
+        make_cu_seqlens_signature(sequence_entries),
+        work_items_signature if not order_gen else None,
+        make_counter_signature(),
+        work_items_signature,
+        make_counter_signature(sched_entries) if has_sched else None,
+        make_workspace_signature(workspace_words),
+        name=(
+            f"kda_mega_prefill_prologue_{io_dtype.__name__.lower()}"
+            f"_hq{HQ}_hk{HK}_hv{HV}_ho{HO}"
+            f"_o{int(order_gen)}d{int(dyn_sched)}_i64{int(use_int64_offsets)}"
+        ),
     )
 
 
@@ -3136,39 +3187,16 @@ def chunk_kda_sm100(
         )
 
     if "prologue" not in cache:
-        sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
-        tokens, sequence_entries, work_rows, sched_entries, workspace_words = (
-            sym_int() for _ in range(5)
-        )
-
-        tma_tensor = partial(
-            make_strided_signature_tensor,
-            assumed_align=16,
-            use_int64_offsets=use_int64_offsets,
-        )
-        work_items_signature = make_work_items_signature(work_rows)
-        cache["prologue"] = compile_tvm_ffi(
-            prologue,
+        cache["prologue"] = compile_prologue(
             io_dtype,
-            CFG.B_T,
+            HQ,
+            HK,
+            HV,
+            HO,
             order_gen,
             has_sched,
-            tma_tensor(io_dtype, (tokens, HQ, 128)),
-            tma_tensor(io_dtype, (tokens, HK, 128)),
-            tma_tensor(io_dtype, (tokens, HV, 128)),
-            tma_tensor(cutlass.Float32, (tokens, HO, 128)),
-            tma_tensor(io_dtype, (tokens, HO, 128)),
-            make_cu_seqlens_signature(sequence_entries),
-            work_items_signature if not order_gen else None,
-            make_counter_signature(),
-            work_items_signature,
-            make_counter_signature(sched_entries) if has_sched else None,
-            make_workspace_signature(workspace_words),
-            name=(
-                f"kda_mega_prefill_prologue_{io_dtype.__name__.lower()}"
-                f"_hq{HQ}_hk{HK}_hv{HV}_ho{HO}"
-                f"_o{int(order_gen)}d{int(dyn_sched)}_i64{int(use_int64_offsets)}"
-            ),
+            dyn_sched,
+            use_int64_offsets,
         )
     cache["prologue"](
         q,

--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_recompute_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_recompute_f16.py
@@ -85,6 +85,7 @@ Requires the public CuTeDSL 4.7 API, including `cutlass.experimental.*`.
 
 from dataclasses import dataclass
 from functools import lru_cache, partial
+from pathlib import Path
 from typing import NamedTuple, Type
 
 import cuda.bindings.driver as cuda_driver
@@ -94,7 +95,7 @@ import cutlass.experimental.cuda as cuda
 import cutlass.experimental.primitives as nvvm
 import cutlass.cute as cute
 
-from attn_gym._backends.cute import compile_tvm_ffi
+from attn_gym._backends.cute import compile_tvm_ffi, jit_cache
 from attn_gym._backends.cute.utils import get_device_properties, requires_int64_abi, validate_tma_tensor
 from attn_gym.linear._delta_rule.mega.kernels.common.split_k import ORDER_CAPACITY, ORDER_ELEMS, ORDER_THREADS, decode_work_item, order_body
 from attn_gym.linear._delta_rule.mega.kernels.common.host import checkpoint_capacity_bound, get_dtype
@@ -2553,6 +2554,7 @@ def get_compiled_cache(
     return {}
 
 
+@jit_cache(extra_sources=(Path(__file__).parent,))
 def compile(
     io_dtype,
     state_dtype,
@@ -2630,6 +2632,61 @@ def compile(
         make_counter_signature(sched_entries) if dyn_sched else None,
         make_workspace_signature(workspace_words),
         cutlass.Int32(checkpoint_every_n_tokens),
+    )
+
+
+@jit_cache(extra_sources=(Path(__file__).parent,))
+def compile_prologue(
+    io_dtype: type[cutlass.Numeric],
+    HK: int,
+    HV: int,
+    HO: int,
+    enable_checkpoints: bool,
+    run_order: bool,
+    order_gen: bool,
+    has_sched: bool,
+    dyn_sched: bool,
+    checkpoint_every_n_tokens: int,
+    use_int64_offsets: bool,
+):
+    """JIT-compile the prologue from static specialization arguments."""
+    sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
+    tokens, sequence_entries, checkpoint_rows, work_rows, sched_entries, workspace_words = (
+        sym_int() for _ in range(6)
+    )
+
+    tma_tensor = partial(
+        make_strided_signature_tensor,
+        assumed_align=16,
+        use_int64_offsets=use_int64_offsets,
+    )
+    work_items_signature = make_work_items_signature(work_rows)
+    return compile_tvm_ffi(
+        prologue,
+        io_dtype,
+        CFG.B_T,
+        run_order,
+        order_gen,
+        has_sched,
+        tma_tensor(io_dtype, (tokens, HK, 128)),
+        tma_tensor(io_dtype, (tokens, HV, 128)),
+        tma_tensor(cutlass.Float32, (tokens, HO, 128)),
+        tma_tensor(io_dtype, (checkpoint_rows, HO, 128, 128))
+        if enable_checkpoints
+        else None,
+        make_cu_seqlens_signature(sequence_entries),
+        work_items_signature if run_order and not order_gen else None,
+        make_counter_signature(),
+        work_items_signature,
+        make_counter_signature(sched_entries) if has_sched else None,
+        make_workspace_signature(workspace_words),
+        cutlass.Int32(checkpoint_every_n_tokens),
+        name=(
+            f"kda_mega_recompute_prologue_{io_dtype.__name__.lower()}"
+            f"_hk{HK}_hv{HV}_ho{HO}_c{int(enable_checkpoints)}"
+            f"_r{int(run_order)}o{int(order_gen)}d{int(dyn_sched)}"
+            f"_i64{int(use_int64_offsets)}"
+        ),
     )
 
 
@@ -2851,43 +2908,18 @@ def chunk_kda_recompute_sm100(
         )
 
     if "prologue" not in cache:
-        sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
-        tokens, sequence_entries, checkpoint_rows, work_rows, sched_entries, workspace_words = (
-            sym_int() for _ in range(6)
-        )
-
-        tma_tensor = partial(
-            make_strided_signature_tensor,
-            assumed_align=16,
-            use_int64_offsets=use_int64_offsets,
-        )
-        work_items_signature = make_work_items_signature(work_rows)
-        cache["prologue"] = compile_tvm_ffi(
-            prologue,
+        cache["prologue"] = compile_prologue(
             io_dtype,
-            CFG.B_T,
+            HK,
+            HV,
+            HO,
+            enable_checkpoints,
             run_order,
             order_gen,
             has_sched,
-            tma_tensor(io_dtype, (tokens, HK, 128)),
-            tma_tensor(io_dtype, (tokens, HV, 128)),
-            tma_tensor(cutlass.Float32, (tokens, HO, 128)),
-            tma_tensor(io_dtype, (checkpoint_rows, HO, 128, 128))
-            if state_checkpoints_for_descs is not None
-            else None,
-            make_cu_seqlens_signature(sequence_entries),
-            work_items_signature if run_order and not order_gen else None,
-            make_counter_signature(),
-            work_items_signature,
-            make_counter_signature(sched_entries) if has_sched else None,
-            make_workspace_signature(workspace_words),
-            cutlass.Int32(checkpoint_every_n_tokens),
-            name=(
-                f"kda_mega_recompute_prologue_{io_dtype.__name__.lower()}"
-                f"_hk{HK}_hv{HV}_ho{HO}_c{int(enable_checkpoints)}"
-                f"_r{int(run_order)}o{int(order_gen)}d{int(dyn_sched)}"
-                f"_i64{int(use_int64_offsets)}"
-            ),
+            dyn_sched,
+            checkpoint_every_n_tokens,
+            use_int64_offsets,
         )
     cache["prologue"](
         k,


### PR DESCRIPTION
Stacked PRs:
 * #531
 * #529
 * #530
 * __->__#536


--- --- ---

Persist the Mega kernels in the CuTeDSL compile cache

Cache main kernels and prologues behind static-argument compile helpers while retaining the process-local launch fast path. Include Mega kernel dependencies in source invalidation so exported TVM-FFI artifacts remain safe to reuse across processes.