### PR TITLE
Bring the Mega kernels onto the CuTeDSL kernel template and persist their compiles

### DIFF
--- a/attn_gym/linear/_delta_rule/mega/kernels/gdn_bprop_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/gdn_bprop_f16.py
@@ -105,8 +105,9 @@ Warp assignments (12 warps = 384 threads):
   warp  11      : epilogue warp   - store dQ, dK, dV to global memory
 """
 
-from dataclasses import dataclass
-from functools import cache, partial
+from dataclasses import dataclass, replace
+from functools import partial
+from pathlib import Path
 from typing import NamedTuple
 
 import cuda.bindings.driver as cuda_driver
@@ -116,7 +117,7 @@ import cutlass.experimental.primitives as nvvm
 from cutlass import cute
 from cutlass.experimental import cuda
 
-from attn_gym._backends.cute import compile_tvm_ffi
+from attn_gym._backends.cute import compile_tvm_ffi, jit_cache
 from attn_gym._backends.cute.utils import get_device_properties, requires_int64_abi, validate_tma_tensor
 
 from .common.elementwise import softplus
@@ -5235,7 +5236,7 @@ def kernel(
         )
 
 
-@dataclass
+@dataclass(frozen=True)
 class GdnBwdCfg:
     """Static BT=64 scalar-GDN backward-kernel configuration."""
 
@@ -5369,66 +5370,53 @@ def build_cfg(
         if len(group) != 4 or group != tuple(range(group[0], group[-1] + 1)):
             raise ValueError("the fixed schedule requires contiguous four-warp compute groups")
 
-    cfg.threads_per_cta = len(role_ids) * cfg.threads_per_warp
-    cfg.tmem_alloc_barrier_threads = (
-        1 + len(cfg.compute_group_0_warp_ids) + len(cfg.compute_group_1_warp_ids)
-    ) * cfg.threads_per_warp
-    cfg.inverse_barrier_threads = len(cfg.compute_group_0_warp_ids) * cfg.threads_per_warp
-    cfg.inverse_inner_barrier_threads = 2 * cfg.threads_per_warp
-    cfg.init_state_store_barrier_threads = len(cfg.compute_group_1_warp_ids) * cfg.threads_per_warp
-    cfg.cg1_barrier_threads = len(cfg.compute_group_1_warp_ids) * cfg.threads_per_warp
-
-    cfg.tmem_dstate_acc_offset = 0
-    cfg.tmem_dvdk_acc_offset = cfg.tmem_dstate_acc_offset + cfg.tmem_dstate_acc_stages * 128
-    cfg.tmem_dstate_inp_offset = cfg.tmem_dvdk_acc_offset + cfg.tmem_dvdk_acc_stages * 64
-    cfg.tmem_shared_acc_offset = cfg.tmem_dstate_inp_offset + cfg.tmem_dstate_inp_stages * 64
-    cfg.tmem_shared_inp_offset = cfg.tmem_shared_acc_offset + cfg.tmem_shared_acc_stages * 64
-    cfg.tmem_y_offset = cfg.tmem_shared_inp_offset + cfg.tmem_shared_inp_stages * (cfg.b_t // 2)
-    if cfg.tmem_y_offset + cfg.b_t // 2 > 512:
+    tmem_dstate_acc_offset = 0
+    tmem_dvdk_acc_offset = tmem_dstate_acc_offset + cfg.tmem_dstate_acc_stages * 128
+    tmem_dstate_inp_offset = tmem_dvdk_acc_offset + cfg.tmem_dvdk_acc_stages * 64
+    tmem_shared_acc_offset = tmem_dstate_inp_offset + cfg.tmem_dstate_inp_stages * 64
+    tmem_shared_inp_offset = tmem_shared_acc_offset + cfg.tmem_shared_acc_stages * 64
+    tmem_y_offset = tmem_shared_inp_offset + cfg.tmem_shared_inp_stages * (cfg.b_t // 2)
+    if tmem_y_offset + cfg.b_t // 2 > 512:
         raise ValueError("BT=64 GDN TMEM layout exceeds 512 columns")
 
-    cfg.q_cosize = cfg.smem_q_stages * cfg.b_t * cfg.d_k
-    cfg.k_cosize = cfg.smem_k_stages * cfg.b_t * cfg.d_k
-    cfg.v_cosize = cfg.smem_v_stages * cfg.b_t * cfg.d_v
-    cfg.do_cosize = cfg.smem_do_stages * cfg.b_t * cfg.d_v
-    cfg.state_cosize = cfg.smem_state_stages * cfg.d_k * cfg.d_v
-    cfg.t_inv_cosize = cfg.smem_t_inv_stages * cfg.b_t * cfg.b_t
-    cfg.a_cosize = cfg.smem_a_stages * cfg.b_t * cfg.b_t
-    cfg.dq_cosize = cfg.smem_dq_stages * cfg.b_t * cfg.d_k
-    cfg.dk_cosize = cfg.smem_dk_stages * cfg.b_t * cfg.d_k
-    cfg.dv_cosize = cfg.smem_dv_stages * cfg.b_t * cfg.d_v
     element_bytes = io_dtype.width // 8
-    cfg.tma_q_bytes = cfg.b_t * cfg.d_k * element_bytes
-    cfg.tma_k_bytes = cfg.b_t * cfg.d_k * element_bytes
-    cfg.tma_v_bytes = cfg.b_t * cfg.d_v * element_bytes
-    cfg.tma_do_bytes = cfg.b_t * cfg.d_v * element_bytes
-    cfg.tma_state_bytes = cfg.d_k * cfg.d_v * element_bytes
-    return cfg
+    return replace(
+        cfg,
+        threads_per_cta=len(role_ids) * cfg.threads_per_warp,
+        tmem_alloc_barrier_threads=(
+            1 + len(cfg.compute_group_0_warp_ids) + len(cfg.compute_group_1_warp_ids)
+        )
+        * cfg.threads_per_warp,
+        inverse_barrier_threads=len(cfg.compute_group_0_warp_ids) * cfg.threads_per_warp,
+        inverse_inner_barrier_threads=2 * cfg.threads_per_warp,
+        init_state_store_barrier_threads=len(cfg.compute_group_1_warp_ids) * cfg.threads_per_warp,
+        cg1_barrier_threads=len(cfg.compute_group_1_warp_ids) * cfg.threads_per_warp,
+        tmem_dstate_acc_offset=tmem_dstate_acc_offset,
+        tmem_dvdk_acc_offset=tmem_dvdk_acc_offset,
+        tmem_dstate_inp_offset=tmem_dstate_inp_offset,
+        tmem_shared_acc_offset=tmem_shared_acc_offset,
+        tmem_shared_inp_offset=tmem_shared_inp_offset,
+        tmem_y_offset=tmem_y_offset,
+        q_cosize=cfg.smem_q_stages * cfg.b_t * cfg.d_k,
+        k_cosize=cfg.smem_k_stages * cfg.b_t * cfg.d_k,
+        v_cosize=cfg.smem_v_stages * cfg.b_t * cfg.d_v,
+        do_cosize=cfg.smem_do_stages * cfg.b_t * cfg.d_v,
+        state_cosize=cfg.smem_state_stages * cfg.d_k * cfg.d_v,
+        t_inv_cosize=cfg.smem_t_inv_stages * cfg.b_t * cfg.b_t,
+        a_cosize=cfg.smem_a_stages * cfg.b_t * cfg.b_t,
+        dq_cosize=cfg.smem_dq_stages * cfg.b_t * cfg.d_k,
+        dk_cosize=cfg.smem_dk_stages * cfg.b_t * cfg.d_k,
+        dv_cosize=cfg.smem_dv_stages * cfg.b_t * cfg.d_v,
+        tma_q_bytes=cfg.b_t * cfg.d_k * element_bytes,
+        tma_k_bytes=cfg.b_t * cfg.d_k * element_bytes,
+        tma_v_bytes=cfg.b_t * cfg.d_v * element_bytes,
+        tma_do_bytes=cfg.b_t * cfg.d_v * element_bytes,
+        tma_state_bytes=cfg.d_k * cfg.d_v * element_bytes,
+    )
 
 
 TENSORMAP_DESC_ARRAYS = 8
 TENSORMAP_STATIC_SLOTS = 0
-
-
-@cache
-def get_compiled_cache(
-    io_dtype_str: str,
-    h_q: int,
-    h_k: int,
-    h_v: int,
-    use_dstate_in: bool,
-    use_dstate0: bool,
-    use_initial_state: bool,
-    dyn_sched: bool,
-    run_order: bool,
-    order_gen: bool,
-    use_int64_offsets: bool,
-    device_index: int,
-    device_major: int,
-    device_minor: int,
-    num_sm: int,
-):
-    return {}
 
 
 def _validate_scalar_fp32(name, tensor, expected_shape) -> None:
@@ -5442,6 +5430,135 @@ def _validate_scalar_fp32(name, tensor, expected_shape) -> None:
         raise ValueError(f"{name} innermost stride must be one")
     if any(stride < 0 for stride in tensor.stride()[:-1]):
         raise ValueError(f"{name} outer strides must be nonnegative")
+
+
+@jit_cache(extra_sources=(Path(__file__).parent,))
+def _compile_gdn_bprop(
+    io_dtype: type[cutlass.Numeric],
+    h_q: int,
+    h_k: int,
+    h_v: int,
+    h_out: int,
+    use_initial_state: bool,
+    use_dstate_in: bool,
+    use_dstate0: bool,
+    dyn_sched: bool,
+    use_int64_offsets: bool,
+    num_sm: int,
+    scale: float,
+):
+    """JIT-compile one fake-tensor TVM-FFI backward signature."""
+    sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
+    cfg = build_cfg(
+        io_dtype,
+        use_initial_state=use_initial_state,
+        use_dstate_in=use_dstate_in,
+        use_dstate0=use_dstate0,
+        q_ratio=h_out // h_q,
+        k_ratio=h_out // h_k,
+        v_ratio=h_out // h_v,
+        n_heads_out=h_out,
+        max_active_clusters=num_sm,
+        dyn_sched=dyn_sched,
+    )
+    op = GdnBpropOp(cfg, use_int64_offsets)
+    tokens_sym, sequence_entries, sequences, work_rows, sched_entries, workspace_words = (
+        sym_int() for _ in range(6)
+    )
+    scalar_tensor = partial(
+        make_strided_signature_tensor,
+        assumed_align=4,
+        use_int64_offsets=use_int64_offsets,
+    )
+    return compile_tvm_ffi(
+        op,
+        scalar_tensor(cutlass.Float32, (tokens_sym, h_out)),
+        None,
+        None,
+        scalar_tensor(cutlass.Float32, (tokens_sym, h_out)),
+        scalar_tensor(cutlass.Float32, (tokens_sym, h_out)),
+        scalar_tensor(cutlass.Float32, (tokens_sym, h_out)),
+        make_cu_seqlens_signature(sequence_entries),
+        make_strided_signature_tensor(
+            cutlass.Float32,
+            (sequences, h_out, CFG.D_V, CFG.D_K),
+            assumed_align=16,
+            use_int64_offsets=use_int64_offsets,
+        )
+        if use_dstate0
+        else None,
+        make_strided_signature_tensor(
+            cutlass.Float32,
+            (sequences, h_out, CFG.D_V, CFG.D_K),
+            assumed_align=16,
+            use_int64_offsets=use_int64_offsets,
+        )
+        if use_dstate_in
+        else None,
+        make_work_items_signature(work_rows),
+        make_counter_signature(),
+        make_counter_signature(sched_entries) if dyn_sched else None,
+        make_workspace_signature(workspace_words),
+        cutlass.Float32(scale),
+    )
+
+
+@jit_cache(extra_sources=(Path(__file__).parent,))
+def _compile_gdn_bprop_prologue(
+    io_dtype: type[cutlass.Numeric],
+    h_q: int,
+    h_k: int,
+    h_v: int,
+    h_out: int,
+    run_order: bool,
+    order_gen: bool,
+    has_sched: bool,
+    dyn_sched: bool,
+    use_int64_offsets: bool,
+):
+    """JIT-compile the prologue from static specialization arguments."""
+    sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
+    (
+        tokens_sym,
+        checkpoint_rows,
+        sequence_entries,
+        work_rows,
+        sched_entries,
+        workspace_words,
+    ) = (sym_int() for _ in range(6))
+    tma_tensor = partial(
+        make_strided_signature_tensor,
+        assumed_align=16,
+        use_int64_offsets=use_int64_offsets,
+    )
+    work_items_signature = make_work_items_signature(work_rows)
+    return compile_tvm_ffi(
+        prologue,
+        io_dtype,
+        CFG.B_T,
+        run_order,
+        order_gen,
+        has_sched,
+        tma_tensor(io_dtype, (tokens_sym, h_q, CFG.D_K)),
+        tma_tensor(io_dtype, (tokens_sym, h_k, CFG.D_K)),
+        tma_tensor(io_dtype, (tokens_sym, h_v, CFG.D_V)),
+        tma_tensor(io_dtype, (tokens_sym, h_out, CFG.D_V)),
+        tma_tensor(io_dtype, (tokens_sym, h_q, CFG.D_K)),
+        tma_tensor(io_dtype, (tokens_sym, h_k, CFG.D_K)),
+        tma_tensor(io_dtype, (tokens_sym, h_v, CFG.D_V)),
+        tma_tensor(io_dtype, (checkpoint_rows, h_out, CFG.D_V, CFG.D_K)),
+        make_cu_seqlens_signature(sequence_entries),
+        work_items_signature if run_order and not order_gen else None,
+        make_counter_signature(),
+        work_items_signature,
+        make_counter_signature(sched_entries) if has_sched else None,
+        make_workspace_signature(workspace_words),
+        name=(
+            f"gdn_mega_bprop_prologue_{io_dtype.__name__.lower()}"
+            f"_hq{h_q}_hk{h_k}_hv{h_v}_ho{h_out}_r{int(run_order)}"
+            f"o{int(order_gen)}d{int(dyn_sched)}_i64{int(use_int64_offsets)}"
+        ),
+    )
 
 
 def chunk_gdn_bwd_sm100(
@@ -5609,124 +5726,35 @@ def chunk_gdn_bwd_sm100(
         raise ValueError("the active CUDA device must match q.device")
     device_properties = get_device_properties(device_index)
     num_sm = device_properties.multi_processor_count
-    cache = get_compiled_cache(
-        str(q.dtype),
+    io_dtype = get_dtype(q.dtype)
+    compiled = _compile_gdn_bprop(
+        io_dtype,
         h_q,
         h_k,
         h_v,
+        h_out,
+        use_initial_state,
         use_dstate_in,
         use_dstate0,
-        use_initial_state,
         dyn_sched,
-        run_order,
-        order_gen,
         use_int64_offsets,
-        device_index,
-        device_properties.major,
-        device_properties.minor,
         num_sm,
+        scale,
     )
 
-    io_dtype = get_dtype(q.dtype)
-    sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
-    if "compiled" not in cache:
-        cfg = build_cfg(
-            io_dtype,
-            use_initial_state=use_initial_state,
-            use_dstate_in=use_dstate_in,
-            use_dstate0=use_dstate0,
-            q_ratio=h_out // h_q,
-            k_ratio=h_out // h_k,
-            v_ratio=h_out // h_v,
-            n_heads_out=h_out,
-            max_active_clusters=num_sm,
-            dyn_sched=dyn_sched,
-        )
-        op = GdnBpropOp(cfg, use_int64_offsets)
-        tokens_sym, sequence_entries, sequences, work_rows, sched_entries, workspace_words = (
-            sym_int() for _ in range(6)
-        )
-        scalar_tensor = partial(
-            make_strided_signature_tensor,
-            assumed_align=4,
-            use_int64_offsets=use_int64_offsets,
-        )
-        cache["compiled"] = compile_tvm_ffi(
-            op,
-            scalar_tensor(cutlass.Float32, (tokens_sym, h_out)),
-            None,
-            None,
-            scalar_tensor(cutlass.Float32, (tokens_sym, h_out)),
-            scalar_tensor(cutlass.Float32, (tokens_sym, h_out)),
-            scalar_tensor(cutlass.Float32, (tokens_sym, h_out)),
-            make_cu_seqlens_signature(sequence_entries),
-            make_strided_signature_tensor(
-                cutlass.Float32,
-                (sequences, h_out, CFG.D_V, CFG.D_K),
-                assumed_align=16,
-                use_int64_offsets=use_int64_offsets,
-            )
-            if use_dstate0
-            else None,
-            make_strided_signature_tensor(
-                cutlass.Float32,
-                (sequences, h_out, CFG.D_V, CFG.D_K),
-                assumed_align=16,
-                use_int64_offsets=use_int64_offsets,
-            )
-            if use_dstate_in
-            else None,
-            make_work_items_signature(work_rows),
-            make_counter_signature(),
-            make_counter_signature(sched_entries) if dyn_sched else None,
-            make_workspace_signature(workspace_words),
-            cutlass.Float32(scale),
-        )
-
-    if "prologue" not in cache:
-        (
-            tokens_sym,
-            checkpoint_rows,
-            sequence_entries,
-            work_rows,
-            sched_entries,
-            workspace_words,
-        ) = (sym_int() for _ in range(6))
-        tma_tensor = partial(
-            make_strided_signature_tensor,
-            assumed_align=16,
-            use_int64_offsets=use_int64_offsets,
-        )
-        work_items_signature = make_work_items_signature(work_rows)
-        cache["prologue"] = compile_tvm_ffi(
-            prologue,
-            io_dtype,
-            CFG.B_T,
-            run_order,
-            order_gen,
-            has_sched,
-            tma_tensor(io_dtype, (tokens_sym, h_q, CFG.D_K)),
-            tma_tensor(io_dtype, (tokens_sym, h_k, CFG.D_K)),
-            tma_tensor(io_dtype, (tokens_sym, h_v, CFG.D_V)),
-            tma_tensor(io_dtype, (tokens_sym, h_out, CFG.D_V)),
-            tma_tensor(io_dtype, (tokens_sym, h_q, CFG.D_K)),
-            tma_tensor(io_dtype, (tokens_sym, h_k, CFG.D_K)),
-            tma_tensor(io_dtype, (tokens_sym, h_v, CFG.D_V)),
-            tma_tensor(io_dtype, (checkpoint_rows, h_out, CFG.D_V, CFG.D_K)),
-            make_cu_seqlens_signature(sequence_entries),
-            work_items_signature if run_order and not order_gen else None,
-            make_counter_signature(),
-            work_items_signature,
-            make_counter_signature(sched_entries) if has_sched else None,
-            make_workspace_signature(workspace_words),
-            name=(
-                f"gdn_mega_bprop_prologue_{io_dtype.__name__.lower()}"
-                f"_hq{h_q}_hk{h_k}_hv{h_v}_ho{h_out}_r{int(run_order)}"
-                f"o{int(order_gen)}d{int(dyn_sched)}_i64{int(use_int64_offsets)}"
-            ),
-        )
-
-    cache["prologue"](
+    compiled_prologue = _compile_gdn_bprop_prologue(
+        io_dtype,
+        h_q,
+        h_k,
+        h_v,
+        h_out,
+        run_order,
+        order_gen,
+        has_sched,
+        dyn_sched,
+        use_int64_offsets,
+    )
+    compiled_prologue(
         q,
         k,
         v,
@@ -5742,7 +5770,7 @@ def chunk_gdn_bwd_sm100(
         sched_all if run_order else None,
         tensormap_workspace,
     )
-    cache["compiled"](
+    compiled(
         gate,
         None,
         None,

--- a/attn_gym/linear/_delta_rule/mega/kernels/gdn_prefill_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/gdn_prefill_f16.py
@@ -82,8 +82,9 @@ Warp assignments (12 warps = 384 threads):
   warp  11      : epilogue warp  - O then checkpoint TMA stores
 """
 
-from dataclasses import dataclass
-from functools import lru_cache, partial
+from dataclasses import dataclass, replace
+from functools import partial
+from pathlib import Path
 from typing import NamedTuple, Optional, Tuple, Type
 
 import cuda.bindings.driver as cuda_driver
@@ -94,7 +95,7 @@ import cutlass.experimental.cuda as cuda
 import cutlass.experimental.primitives as nvvm
 from cutlass.cutlass_dsl import min
 
-from attn_gym._backends.cute import compile_tvm_ffi
+from attn_gym._backends.cute import compile_tvm_ffi, jit_cache
 from attn_gym._backends.cute.utils import get_device_properties, requires_int64_abi, validate_tma_tensor
 
 from .common.elementwise import softplus
@@ -3056,230 +3057,226 @@ def prologue(
     ).launch(grid=(1, 1, 1), block=(ORDER_THREADS, 1, 1), stream=stream)
 
 
-@cute.jit
-def host(
-    cfg: cutlass.Constexpr,
-    q: cute.Tensor,
-    k: cute.Tensor,
-    v: cute.Tensor,
-    gate: cute.Tensor,
-    a_log: Optional[cute.Tensor],
-    dt_bias: Optional[cute.Tensor],
-    beta: cute.Tensor,
-    o: Optional[cute.Tensor],
-    cu_seqlens: cute.Tensor,
-    state_in: Optional[cute.Tensor],
-    state_out: Optional[cute.Tensor],
-    state_indices: Optional[cute.Tensor],
-    has_initial_state: Optional[cute.Tensor],
-    work_items: Optional[cute.Tensor],
-    work_count: Optional[cute.Tensor],
-    sched_ctr: Optional[cute.Tensor],
-    checkpoint_every_n_tokens: cutlass.Int32,
-    scale: cutlass.Float32,
-    tensormap_workspace: cute.Tensor,
-    stream: cuda_driver.CUstream,
-):
-    h_q = q.shape[1]
-    h_k = k.shape[1]
-    h_v = v.shape[1]
-    batch_size = cu_seqlens.shape[0] - 1
-    heads_out = h_q if h_q >= h_v else h_v
+class GdnPrefillOp:
+    """Compile and launch one static mega GDN prefill configuration."""
 
-    # ---- GQA reshapes: fold the head group into a --------------------------------
-    if cutlass.const_expr(cfg.is_GQA):
-        h_r = h_q // h_v
-        h_qv = h_v
-        q = cute.make_tensor(
-            q.iterator,
-            cute.make_layout(
-                (q.shape[0], q.shape[2], (h_r, h_v)),
-                stride=(q.stride[0], q.stride[2], (q.stride[1], h_r * q.stride[1])),
-            ),
-        )
-        k = cute.make_tensor(
-            k.iterator,
-            cute.make_layout(
-                (k.shape[0], k.shape[2], (h_r, h_v)),
-                stride=(k.stride[0], k.stride[2], (0, k.stride[1])),
-            ),
-        )
-        v = cute.make_tensor(
-            v.iterator,
-            cute.make_layout(
-                (v.shape[2], v.shape[0], (h_r, h_v)),
-                stride=(v.stride[2], v.stride[0], (0, v.stride[1])),
-            ),
-        )
-    else:
-        h_r = h_v // h_q
-        h_qv = h_q
-        q = cute.make_tensor(
-            q.iterator,
-            cute.make_layout(
-                (q.shape[0], q.shape[2], (h_r, h_q)),
-                stride=(q.stride[0], q.stride[2], (0, q.stride[1])),
-            ),
-        )
-        k = cute.make_tensor(
-            k.iterator,
-            cute.make_layout(
-                (k.shape[0], k.shape[2], (h_r, h_q)),
-                stride=(k.stride[0], k.stride[2], (0, k.stride[1])),
-            ),
-        )
-        v = cute.make_tensor(
-            v.iterator,
-            cute.make_layout(
-                (v.shape[2], v.shape[0], (h_r, h_q)),
-                stride=(v.stride[2], v.stride[0], (v.stride[1], h_r * v.stride[1])),
-            ),
+    def __init__(self, cfg: "GdnCfg", use_int64_offsets: bool = False):
+        self.cfg = cfg
+        self.use_int64_offsets = use_int64_offsets
+
+    def get_name(self) -> str:
+        cfg = self.cfg
+        return (
+            f"gdn_mega_prefill_{cfg.io_dtype.__name__.lower()}_{cfg.state_dtype.__name__.lower()}"
+            f"_hq{cfg.n_heads_out // cfg.q_ratio}_hk{cfg.n_heads_out // cfg.k_ratio}"
+            f"_hv{cfg.n_heads_out // cfg.v_ratio}_g{int(cfg.is_GQA)}"
+            f"_i{int(cfg.use_initial_state)}f{int(cfg.store_final_state)}c{int(cfg.enable_checkpoints)}"
+            f"_l{int(cfg.log_gate)}s{int(cfg.safe_gate)}b{int(cfg.beta_sigmoid)}"
+            f"_d{int(cfg.dyn_sched)}_i64{int(self.use_int64_offsets)}"
+            f"_p{int(cfg.paged_state)}m{int(cfg.has_initial_state_mask)}"
         )
 
-    gate = cute.make_tensor(
-        gate.iterator,
-        cute.make_layout(
-            (gate.shape[0], (h_r, h_qv)),
-            stride=(gate.stride[0], (gate.stride[1], h_r * gate.stride[1])),
-        ),
-    )
-    beta = cute.make_tensor(
-        beta.iterator,
-        cute.make_layout(
-            (beta.shape[0], (h_r, h_qv)),
-            stride=(beta.stride[0], (beta.stride[1], h_r * beta.stride[1])),
-        ),
-    )
-    if cutlass.const_expr(o is not None):
-        o = cute.make_tensor(
-            o.iterator,
-            cute.make_layout(
-                (o.shape[2], o.shape[0], (h_r, h_qv)),
-                stride=(o.stride[2], o.stride[0], (o.stride[1], h_r * o.stride[1])),
-            ),
-        )
-    if cutlass.const_expr(state_in is not None):
-        state_in = cute.make_tensor(
-            state_in.iterator,
-            cute.make_layout(
-                (state_in.shape[2], state_in.shape[3], (h_r, h_qv), state_in.shape[0]),
-                stride=(
-                    state_in.stride[2],
-                    state_in.stride[3],
-                    (state_in.stride[1], h_r * state_in.stride[1]),
-                    state_in.stride[0],
+    @cute.jit
+    def __call__(
+        self,
+        q: cute.Tensor,
+        k: cute.Tensor,
+        v: cute.Tensor,
+        gate: cute.Tensor,
+        a_log: Optional[cute.Tensor],
+        dt_bias: Optional[cute.Tensor],
+        beta: cute.Tensor,
+        o: Optional[cute.Tensor],
+        cu_seqlens: cute.Tensor,
+        state_in: Optional[cute.Tensor],
+        state_out: Optional[cute.Tensor],
+        state_indices: Optional[cute.Tensor],
+        has_initial_state: Optional[cute.Tensor],
+        work_items: Optional[cute.Tensor],
+        work_count: Optional[cute.Tensor],
+        sched_ctr: Optional[cute.Tensor],
+        checkpoint_every_n_tokens: cutlass.Int32,
+        scale: cutlass.Float32,
+        tensormap_workspace: cute.Tensor,
+        stream: cuda_driver.CUstream,
+    ):
+        cfg = self.cfg
+        h_q = q.shape[1]
+        h_v = v.shape[1]
+        batch_size = cu_seqlens.shape[0] - 1
+
+        # ---- GQA reshapes: fold the head group into a --------------------------------
+        if cutlass.const_expr(cfg.is_GQA):
+            h_r = h_q // h_v
+            h_qv = h_v
+            q = cute.make_tensor(
+                q.iterator,
+                cute.make_layout(
+                    (q.shape[0], q.shape[2], (h_r, h_v)),
+                    stride=(q.stride[0], q.stride[2], (q.stride[1], h_r * q.stride[1])),
                 ),
-            ),
-        )
-    if cutlass.const_expr(state_out is not None):
-        state_out = cute.make_tensor(
-            state_out.iterator,
-            cute.make_layout(
-                (state_out.shape[2], state_out.shape[3], (h_r, h_qv), state_out.shape[0]),
-                stride=(
-                    state_out.stride[2],
-                    state_out.stride[3],
-                    (state_out.stride[1], h_r * state_out.stride[1]),
-                    state_out.stride[0],
+            )
+            k = cute.make_tensor(
+                k.iterator,
+                cute.make_layout(
+                    (k.shape[0], k.shape[2], (h_r, h_v)),
+                    stride=(k.stride[0], k.stride[2], (0, k.stride[1])),
                 ),
+            )
+            v = cute.make_tensor(
+                v.iterator,
+                cute.make_layout(
+                    (v.shape[2], v.shape[0], (h_r, h_v)),
+                    stride=(v.stride[2], v.stride[0], (0, v.stride[1])),
+                ),
+            )
+        else:
+            h_r = h_v // h_q
+            h_qv = h_q
+            q = cute.make_tensor(
+                q.iterator,
+                cute.make_layout(
+                    (q.shape[0], q.shape[2], (h_r, h_q)),
+                    stride=(q.stride[0], q.stride[2], (0, q.stride[1])),
+                ),
+            )
+            k = cute.make_tensor(
+                k.iterator,
+                cute.make_layout(
+                    (k.shape[0], k.shape[2], (h_r, h_q)),
+                    stride=(k.stride[0], k.stride[2], (0, k.stride[1])),
+                ),
+            )
+            v = cute.make_tensor(
+                v.iterator,
+                cute.make_layout(
+                    (v.shape[2], v.shape[0], (h_r, h_q)),
+                    stride=(v.stride[2], v.stride[0], (v.stride[1], h_r * v.stride[1])),
+                ),
+            )
+
+        gate = cute.make_tensor(
+            gate.iterator,
+            cute.make_layout(
+                (gate.shape[0], (h_r, h_qv)),
+                stride=(gate.stride[0], (gate.stride[1], h_r * gate.stride[1])),
             ),
         )
+        beta = cute.make_tensor(
+            beta.iterator,
+            cute.make_layout(
+                (beta.shape[0], (h_r, h_qv)),
+                stride=(beta.stride[0], (beta.stride[1], h_r * beta.stride[1])),
+            ),
+        )
+        if cutlass.const_expr(o is not None):
+            o = cute.make_tensor(
+                o.iterator,
+                cute.make_layout(
+                    (o.shape[2], o.shape[0], (h_r, h_qv)),
+                    stride=(o.stride[2], o.stride[0], (o.stride[1], h_r * o.stride[1])),
+                ),
+            )
+        if cutlass.const_expr(state_in is not None):
+            state_in = cute.make_tensor(
+                state_in.iterator,
+                cute.make_layout(
+                    (state_in.shape[2], state_in.shape[3], (h_r, h_qv), state_in.shape[0]),
+                    stride=(
+                        state_in.stride[2],
+                        state_in.stride[3],
+                        (state_in.stride[1], h_r * state_in.stride[1]),
+                        state_in.stride[0],
+                    ),
+                ),
+            )
+        if cutlass.const_expr(state_out is not None):
+            state_out = cute.make_tensor(
+                state_out.iterator,
+                cute.make_layout(
+                    (state_out.shape[2], state_out.shape[3], (h_r, h_qv), state_out.shape[0]),
+                    stride=(
+                        state_out.stride[2],
+                        state_out.stride[3],
+                        (state_out.stride[1], h_r * state_out.stride[1]),
+                        state_out.stride[0],
+                    ),
+                ),
+            )
 
-    # ---- SMEM sizing: per-buffer element cosizes ---------------------------------
-    bpe = cfg.io_dtype.width // 8
-    kq_tile_elems = 2 * cfg.b_t * cfg.d_k
-    v_tile_elems = cfg.d_v * cfg.b_t
-    tinv_tile_elems = cfg.b_t * cfg.b_t
-    a_tile_elems = cfg.b_t * cfg.b_t
-    o_tile_elems = cfg.d_v * cfg.b_t
-    cfg.kq_cosize = kq_tile_elems * cfg.smem_kq_stages
-    cfg.v_cosize = v_tile_elems * cfg.smem_v_stages
-    cfg.t_inv_cosize = tinv_tile_elems * cfg.smem_t_inv_stages
-    cfg.a_cosize = a_tile_elems * cfg.smem_a_stages
-    cfg.o_cosize = o_tile_elems * cfg.smem_o_stages
-    cfg.checkpoint_cosize = (
-        cfg.d_k * cfg.d_v * cfg.smem_checkpoint_stages if cfg.enable_checkpoints else 1
-    )
+        cumsumlog_smem_layout_staged = cute.make_layout((cfg.b_t, 1, cfg.smem_gate_stages))
+        beta_smem_layout_staged = cute.make_layout((cfg.b_t, 1, cfg.smem_beta_stages))
 
-    cumsumlog_smem_layout_staged = cute.make_layout((cfg.b_t, 1, cfg.smem_gate_stages))
-    beta_smem_layout_staged = cute.make_layout((cfg.b_t, 1, cfg.smem_beta_stages))
+        num_descs = batch_size
 
-    cfg.tma_kq_bytes = kq_tile_elems * bpe
-    cfg.tma_v_bytes = v_tile_elems * bpe
-    cfg.tma_o_bytes = o_tile_elems * bpe
+        # ---- launch ------------------------------------------------------------------
+        # CUDA-graph-stable launch: fixed SM-count grid; shapes ride on buffer contents
+        grid_shape = (cfg.max_active_clusters, 1, 1)
 
-    cfg.n_heads_out = heads_out
-    cfg.q_ratio = heads_out // h_q
-    cfg.k_ratio = heads_out // h_k
-    cfg.v_ratio = heads_out // h_v
-    num_descs = batch_size
+        @cute.struct
+        class SharedStorage:
+            output: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.o_cosize], cfg.buffer_align_bytes
+            ]
+            checkpoint: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.checkpoint_cosize], cfg.buffer_align_bytes
+            ]
+            kq: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.kq_cosize], cfg.buffer_align_bytes
+            ]
+            cumsumlog: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, cute.cosize(cumsumlog_smem_layout_staged)],
+                128,
+            ]
+            cumprod: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, cute.cosize(cumsumlog_smem_layout_staged)],
+                128,
+            ]
+            beta: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, cute.cosize(beta_smem_layout_staged)], 128
+            ]
+            t_inv: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.t_inv_cosize], cfg.buffer_align_bytes
+            ]
+            a: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.a_cosize], cfg.buffer_align_bytes
+            ]
+            v: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.v_cosize], cfg.buffer_align_bytes
+            ]
 
-    # ---- launch ------------------------------------------------------------------
-    # CUDA-graph-stable launch: fixed SM-count grid; shapes ride on buffer contents
-    grid_shape = (cfg.max_active_clusters, 1, 1)
-
-    @cute.struct
-    class SharedStorage:
-        output: cute.struct.Align[
-            cute.struct.MemRange[cfg.io_dtype, cfg.o_cosize], cfg.buffer_align_bytes
-        ]
-        checkpoint: cute.struct.Align[
-            cute.struct.MemRange[cfg.io_dtype, cfg.checkpoint_cosize], cfg.buffer_align_bytes
-        ]
-        kq: cute.struct.Align[
-            cute.struct.MemRange[cfg.io_dtype, cfg.kq_cosize], cfg.buffer_align_bytes
-        ]
-        cumsumlog: cute.struct.Align[
-            cute.struct.MemRange[cutlass.Float32, cute.cosize(cumsumlog_smem_layout_staged)], 128
-        ]
-        cumprod: cute.struct.Align[
-            cute.struct.MemRange[cutlass.Float32, cute.cosize(cumsumlog_smem_layout_staged)], 128
-        ]
-        beta: cute.struct.Align[
-            cute.struct.MemRange[cutlass.Float32, cute.cosize(beta_smem_layout_staged)], 128
-        ]
-        t_inv: cute.struct.Align[
-            cute.struct.MemRange[cfg.io_dtype, cfg.t_inv_cosize], cfg.buffer_align_bytes
-        ]
-        a: cute.struct.Align[
-            cute.struct.MemRange[cfg.io_dtype, cfg.a_cosize], cfg.buffer_align_bytes
-        ]
-        v: cute.struct.Align[
-            cute.struct.MemRange[cfg.io_dtype, cfg.v_cosize], cfg.buffer_align_bytes
-        ]
-
-    kernel(
-        cfg,
-        SharedStorage,
-        gate,
-        a_log,
-        dt_bias,
-        beta,
-        cu_seqlens,
-        state_in,
-        state_out,
-        state_indices,
-        has_initial_state,
-        work_items,
-        work_count,
-        sched_ctr,
-        checkpoint_every_n_tokens,
-        scale,
-        cumsumlog_smem_layout_staged,
-        beta_smem_layout_staged,
-        q,
-        k,
-        v,
-        o,
-        tensormap_workspace,
-        cutlass.Int32(num_descs),
-    ).launch(
-        grid=grid_shape,
-        block=(cfg.threads_per_cta, 1, 1),
-        cluster=cfg.cluster_shape_mnk,
-        stream=stream,
-        min_blocks_per_mp=1,
-    )
+        kernel(
+            cfg,
+            SharedStorage,
+            gate,
+            a_log,
+            dt_bias,
+            beta,
+            cu_seqlens,
+            state_in,
+            state_out,
+            state_indices,
+            has_initial_state,
+            work_items,
+            work_count,
+            sched_ctr,
+            checkpoint_every_n_tokens,
+            scale,
+            cumsumlog_smem_layout_staged,
+            beta_smem_layout_staged,
+            q,
+            k,
+            v,
+            o,
+            tensormap_workspace,
+            cutlass.Int32(num_descs),
+        ).launch(
+            grid=grid_shape,
+            block=(cfg.threads_per_cta, 1, 1),
+            cluster=cfg.cluster_shape_mnk,
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
 
 
 @cute.kernel
@@ -3624,15 +3621,14 @@ def kernel(
         )
 
 
-@dataclass
+@dataclass(frozen=True)
 class GdnCfg:
     """Per-compile GDN kernel knob, built by ``build_cfg``.
 
     The per-compile parameters (dtypes, GQA, state flags) are the
     ``cute.compile`` cache keys; the rest is derived from the module-global
-    ``CFG`` constants.  ``host`` stamps the shape-derived fields at trace
-    time.  Passed ``cfg``-first (a ``cutlass.Constexpr``) into ``host`` /
-    ``kernel`` and every warp body.
+    ``CFG`` constants. ``build_cfg`` computes all derived fields before tracing.
+    Owned by ``GdnPrefillOp`` and passed into ``kernel`` and every warp body.
     """
 
     io_dtype: Type[cutlass.Numeric]
@@ -3644,6 +3640,7 @@ class GdnCfg:
     store_final_state: bool
     enable_checkpoints: bool
     paged_state: bool = False
+    has_initial_state_mask: bool = False
     log_gate: bool = False
     safe_gate: bool = False
     beta_sigmoid: bool = False
@@ -3697,7 +3694,7 @@ class GdnCfg:
     tmem_y_decay_u_inp_offset: int = 0
     buffer_align_bytes: int = CFG.BUFFER_ALIGN_BYTES
 
-    # ---- stamped by host at trace time (shape-derived) --------------------------
+    # ---- shape-derived sizes and head ratios set by build_cfg -------------------
     kq_cosize: int = 0
     v_cosize: int = 0
     t_inv_cosize: int = 0
@@ -3727,6 +3724,11 @@ def build_cfg(
     beta_sigmoid: bool = False,
     dyn_sched: bool = False,
     paged_state: bool = False,
+    n_heads_out: int = 0,
+    k_ratio: int = 1,
+    v_ratio: int = 1,
+    q_ratio: int = 1,
+    has_initial_state_mask: bool = False,
 ) -> GdnCfg:
     """Build the per-compile ``GdnCfg`` (io_dtype ∈ {Float16, BFloat16};
     acc is always Float32)."""
@@ -3750,28 +3752,60 @@ def build_cfg(
         safe_gate=safe_gate,
         beta_sigmoid=beta_sigmoid,
         dyn_sched=dyn_sched,
+        n_heads_out=n_heads_out,
+        k_ratio=k_ratio,
+        v_ratio=v_ratio,
+        q_ratio=q_ratio,
+        has_initial_state_mask=has_initial_state_mask,
     )
-    cfg.smem_checkpoint_stages = 1
+    smem_checkpoint_stages = 1
     # The base four-stage KQ allocation exceeds SM100's 227 KiB dynamic-SMEM limit
     # after the structured shared-storage alignment required by the current DSL.
     # Checkpointing needs one additional 128x128 state tile, so it uses two stages.
-    cfg.smem_kq_stages = 2 if enable_checkpoints else 3
+    smem_kq_stages = 2 if enable_checkpoints else 3
     if not use_initial_state:
-        cfg.num_regs_compute_group_1 = 232
-        cfg.num_regs_other = 48
+        cfg = replace(cfg, num_regs_compute_group_1=232, num_regs_other=48)
     n_cg0 = len(cfg.compute_group_0_warp_ids)
     n_cg1 = len(cfg.compute_group_1_warp_ids)
-    cfg.threads_per_cta = cfg.threads_per_warp * (4 + n_cg0 + n_cg1)
-    cfg.tmem_alloc_barrier_threads = cfg.threads_per_warp * (1 + n_cg0 + n_cg1)
-    cfg.inverse_barrier_threads = cfg.threads_per_warp * n_cg0
-    cfg.init_state_store_barrier_threads = cfg.threads_per_warp * n_cg1
-    cfg.tmem_state_acc_offset = 0
-    cfg.tmem_q_state_acc_offset = cfg.tmem_state_acc_offset + cfg.tmem_state_acc_stages * 128
-    cfg.tmem_state_inp_offset = cfg.tmem_q_state_acc_offset + cfg.tmem_q_state_acc_stages * 64
-    cfg.tmem_cg0_acc_offset = cfg.tmem_state_inp_offset + cfg.tmem_state_inp_stages * 64
-    cfg.tmem_cg1_acc_offset = cfg.tmem_cg0_acc_offset + cfg.tmem_cg0_acc_stages * 64
-    cfg.tmem_y_decay_u_inp_offset = cfg.tmem_cg1_acc_offset + cfg.tmem_cg1_acc_stages * 64
-    return cfg
+    tmem_state_acc_offset = 0
+    tmem_q_state_acc_offset = tmem_state_acc_offset + cfg.tmem_state_acc_stages * 128
+    tmem_state_inp_offset = tmem_q_state_acc_offset + cfg.tmem_q_state_acc_stages * 64
+    tmem_cg0_acc_offset = tmem_state_inp_offset + cfg.tmem_state_inp_stages * 64
+    tmem_cg1_acc_offset = tmem_cg0_acc_offset + cfg.tmem_cg0_acc_stages * 64
+    # ---- SMEM sizing: per-buffer element cosizes ---------------------------------
+    bpe = cfg.io_dtype.width // 8
+    kq_tile_elems = 2 * cfg.b_t * cfg.d_k
+    v_tile_elems = cfg.d_v * cfg.b_t
+    tinv_tile_elems = cfg.b_t * cfg.b_t
+    a_tile_elems = cfg.b_t * cfg.b_t
+    o_tile_elems = cfg.d_v * cfg.b_t
+
+    return replace(
+        cfg,
+        smem_checkpoint_stages=smem_checkpoint_stages,
+        smem_kq_stages=smem_kq_stages,
+        threads_per_cta=cfg.threads_per_warp * (4 + n_cg0 + n_cg1),
+        tmem_alloc_barrier_threads=cfg.threads_per_warp * (1 + n_cg0 + n_cg1),
+        inverse_barrier_threads=cfg.threads_per_warp * n_cg0,
+        init_state_store_barrier_threads=cfg.threads_per_warp * n_cg1,
+        tmem_state_acc_offset=tmem_state_acc_offset,
+        tmem_q_state_acc_offset=tmem_q_state_acc_offset,
+        tmem_state_inp_offset=tmem_state_inp_offset,
+        tmem_cg0_acc_offset=tmem_cg0_acc_offset,
+        tmem_cg1_acc_offset=tmem_cg1_acc_offset,
+        tmem_y_decay_u_inp_offset=tmem_cg1_acc_offset + cfg.tmem_cg1_acc_stages * 64,
+        kq_cosize=kq_tile_elems * smem_kq_stages,
+        v_cosize=v_tile_elems * cfg.smem_v_stages,
+        t_inv_cosize=tinv_tile_elems * cfg.smem_t_inv_stages,
+        a_cosize=a_tile_elems * cfg.smem_a_stages,
+        o_cosize=o_tile_elems * cfg.smem_o_stages,
+        checkpoint_cosize=cfg.d_k * cfg.d_v * smem_checkpoint_stages
+        if cfg.enable_checkpoints
+        else 1,
+        tma_kq_bytes=kq_tile_elems * bpe,
+        tma_v_bytes=v_tile_elems * bpe,
+        tma_o_bytes=o_tile_elems * bpe,
+    )
 
 
 TENSORMAP_DESC_ARRAYS = 5  # per-batch runtime TMA descriptors: Q, K, V, O, checkpoints
@@ -3781,35 +3815,8 @@ TENSORMAP_STATIC_SLOTS = 0
 # ---------------------------------------------------------------------------
 
 
-@lru_cache(maxsize=None)
-def get_compiled_cache(
-    io_dtype_str: str,
-    state_dtype_str: str,
-    HQ: int,
-    HK: int,
-    HV: int,
-    is_gqa: bool,
-    use_initial_state: bool,
-    store_final_state: bool,
-    enable_checkpoints: bool,
-    log_gate: bool,
-    safe_gate: bool,
-    beta_sigmoid: bool,
-    dyn_sched: bool,
-    order_gen: bool,
-    use_int64_offsets: bool,
-    paged_state: bool,
-    has_initial_state_mask: bool,
-    device_index: int,
-    device_major: int,
-    device_minor: int,
-    num_sm: int,
-):
-    """Return a mutable dict that lazily stores the compiled kernel."""
-    return {}
-
-
-def compile(
+@jit_cache(extra_sources=(Path(__file__).parent,))
+def _compile_gdn_prefill(
     io_dtype,
     state_dtype,
     is_gqa: bool,
@@ -3849,8 +3856,14 @@ def compile(
         safe_gate=safe_gate,
         beta_sigmoid=beta_sigmoid,
         dyn_sched=dyn_sched,
+        n_heads_out=n_heads_out,
+        k_ratio=k_ratio,
+        v_ratio=v_ratio,
+        q_ratio=q_ratio,
+        has_initial_state_mask=has_initial_state_mask,
         paged_state=paged_state,
     )
+    op = GdnPrefillOp(cfg, use_int64_offsets)
     sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
     tokens, sequence_entries, sequences, work_rows, sched_entries, workspace_words = (
         sym_int() for _ in range(6)
@@ -3882,8 +3895,7 @@ def compile(
     else:
         state_indices_signature = state_mask_signature = None
     return compile_tvm_ffi(
-        host,
-        cfg,
+        op,
         tma_tensor(io_dtype, (tokens, n_heads_out // q_ratio, 128)),
         tma_tensor(io_dtype, (tokens, n_heads_out // k_ratio, 128)),
         tma_tensor(io_dtype, (tokens, n_heads_out // v_ratio, 128)),
@@ -3917,14 +3929,58 @@ def compile(
         cutlass.Int32(checkpoint_every_n_tokens),
         cutlass.Float32(scale),
         make_workspace_signature(workspace_words),
+    )
+
+
+@jit_cache(extra_sources=(Path(__file__).parent,))
+def _compile_gdn_prefill_prologue(
+    io_dtype: type[cutlass.Numeric],
+    h_q: int,
+    h_k: int,
+    h_v: int,
+    h_out: int,
+    enable_checkpoints: bool,
+    order_gen: bool,
+    dyn_sched: bool,
+    checkpoint_every_n_tokens: int,
+    use_int64_offsets: bool,
+):
+    """JIT-compile the prologue from static specialization arguments."""
+    sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
+    tokens, sequence_entries, checkpoint_rows, work_rows, sched_entries, workspace_words = (
+        sym_int() for _ in range(6)
+    )
+    tma_tensor = partial(
+        make_strided_signature_tensor,
+        assumed_align=16,
+        use_int64_offsets=use_int64_offsets,
+    )
+    work_items_signature = make_work_items_signature(work_rows)
+    return compile_tvm_ffi(
+        prologue,
+        io_dtype,
+        CFG.B_T,
+        order_gen,
+        dyn_sched,
+        tma_tensor(io_dtype, (tokens, h_q, 128)),
+        tma_tensor(io_dtype, (tokens, h_k, 128)),
+        tma_tensor(io_dtype, (tokens, h_v, 128)),
+        tma_tensor(io_dtype, (tokens, h_out, 128)),
+        make_cu_seqlens_signature(sequence_entries),
+        tma_tensor(io_dtype, (checkpoint_rows, h_out, 128, 128))
+        if enable_checkpoints
+        else None,
+        work_items_signature if not order_gen else None,
+        make_counter_signature(),
+        work_items_signature,
+        make_counter_signature(sched_entries) if dyn_sched else None,
+        cutlass.Int32(checkpoint_every_n_tokens),
+        make_workspace_signature(workspace_words),
         name=(
-            f"gdn_mega_prefill_{io_dtype.__name__.lower()}_{state_dtype.__name__.lower()}"
-            f"_hq{n_heads_out // q_ratio}_hk{n_heads_out // k_ratio}"
-            f"_hv{n_heads_out // v_ratio}_g{int(is_gqa)}"
-            f"_i{int(use_initial_state)}f{int(store_final_state)}c{int(enable_checkpoints)}"
-            f"_l{int(log_gate)}s{int(safe_gate)}b{int(beta_sigmoid)}"
-            f"_d{int(dyn_sched)}_i64{int(use_int64_offsets)}"
-            f"_p{int(paged_state)}m{int(has_initial_state_mask)}"
+            f"gdn_mega_prefill_prologue_{io_dtype.__name__.lower()}"
+            f"_hq{h_q}_hk{h_k}_hv{h_v}_ho{h_out}"
+            f"_c{int(enable_checkpoints)}o{int(order_gen)}d{int(dyn_sched)}"
+            f"_i64{int(use_int64_offsets)}"
         ),
     )
 
@@ -4085,12 +4141,10 @@ def chunk_gdn_sm100(
         raise ValueError("the active CUDA device must match q.device")
     device_properties = get_device_properties(device_index)
     num_sm = device_properties.multi_processor_count
-    cache = get_compiled_cache(
-        str(q.dtype),
-        str(state_dtype_src),
-        h_q,
-        h_k,
-        h_v,
+    io_dtype = get_dtype(q.dtype)
+    compiled = _compile_gdn_prefill(
+        io_dtype,
+        get_dtype(state_dtype_src),
         is_gqa,
         use_initial_state,
         store_final_state,
@@ -4098,81 +4152,32 @@ def chunk_gdn_sm100(
         log_gate,
         safe_gate,
         use_beta_sigmoid,
+        q_ratio,
+        k_ratio,
+        v_ratio,
+        h_out,
         dyn_sched,
-        order_gen,
         use_int64_offsets,
-        paged_state,
-        has_initial_state_mask,
-        device_index,
-        device_properties.major,
-        device_properties.minor,
-        num_sm,
+        num_sm=num_sm,
+        checkpoint_every_n_tokens=checkpoint_every_n_tokens,
+        scale=scale,
+        paged_state=paged_state,
+        has_initial_state_mask=has_initial_state_mask,
     )
 
-    io_dtype = get_dtype(q.dtype)
-    if "compiled" not in cache:
-        cache["compiled"] = compile(
-            io_dtype,
-            get_dtype(state_dtype_src),
-            is_gqa,
-            use_initial_state,
-            store_final_state,
-            enable_checkpoints,
-            log_gate,
-            safe_gate,
-            use_beta_sigmoid,
-            q_ratio,
-            k_ratio,
-            v_ratio,
-            h_out,
-            dyn_sched,
-            use_int64_offsets,
-            num_sm=num_sm,
-            checkpoint_every_n_tokens=checkpoint_every_n_tokens,
-            scale=scale,
-            paged_state=paged_state,
-            has_initial_state_mask=has_initial_state_mask,
-        )
-
-    if "prologue" not in cache:
-        sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
-        tokens, sequence_entries, checkpoint_rows, work_rows, sched_entries, workspace_words = (
-            sym_int() for _ in range(6)
-        )
-        tma_tensor = partial(
-            make_strided_signature_tensor,
-            assumed_align=16,
-            use_int64_offsets=use_int64_offsets,
-        )
-        work_items_signature = make_work_items_signature(work_rows)
-        cache["prologue"] = compile_tvm_ffi(
-            prologue,
-            io_dtype,
-            CFG.B_T,
-            order_gen,
-            dyn_sched,
-            tma_tensor(io_dtype, (tokens, h_q, 128)),
-            tma_tensor(io_dtype, (tokens, h_k, 128)),
-            tma_tensor(io_dtype, (tokens, h_v, 128)),
-            tma_tensor(io_dtype, (tokens, h_out, 128)),
-            make_cu_seqlens_signature(sequence_entries),
-            tma_tensor(io_dtype, (checkpoint_rows, h_out, 128, 128))
-            if checkpoints_for_descs is not None
-            else None,
-            work_items_signature if not order_gen else None,
-            make_counter_signature(),
-            work_items_signature,
-            make_counter_signature(sched_entries) if dyn_sched else None,
-            cutlass.Int32(checkpoint_every_n_tokens),
-            make_workspace_signature(workspace_words),
-            name=(
-                f"gdn_mega_prefill_prologue_{io_dtype.__name__.lower()}"
-                f"_hq{h_q}_hk{h_k}_hv{h_v}_ho{h_out}"
-                f"_c{int(enable_checkpoints)}o{int(order_gen)}d{int(dyn_sched)}"
-                f"_i64{int(use_int64_offsets)}"
-            ),
-        )
-    cache["prologue"](
+    compiled_prologue = _compile_gdn_prefill_prologue(
+        io_dtype,
+        h_q,
+        h_k,
+        h_v,
+        h_out,
+        enable_checkpoints,
+        order_gen,
+        dyn_sched,
+        checkpoint_every_n_tokens,
+        use_int64_offsets,
+    )
+    compiled_prologue(
         q,
         k,
         v,
@@ -4186,7 +4191,7 @@ def chunk_gdn_sm100(
         checkpoint_every_n_tokens,
         tensormap_workspace,
     )
-    cache["compiled"](
+    compiled(
         q,
         k,
         v,

--- a/attn_gym/linear/_delta_rule/mega/kernels/gdn_recompute_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/gdn_recompute_f16.py
@@ -72,8 +72,9 @@ Warp assignments (12 warps = 384 threads):
   warp  11      : epilogue warp  - checkpoint TMA stores
 """
 
-from dataclasses import dataclass
-from functools import lru_cache, partial
+from dataclasses import dataclass, replace
+from functools import partial
+from pathlib import Path
 from typing import NamedTuple, Optional, Tuple, Type
 
 import cuda.bindings.driver as cuda_driver
@@ -84,7 +85,7 @@ import cutlass.experimental.cuda as cuda
 import cutlass.experimental.primitives as nvvm
 from cutlass.cutlass_dsl import min
 
-from attn_gym._backends.cute import compile_tvm_ffi
+from attn_gym._backends.cute import compile_tvm_ffi, jit_cache
 from attn_gym._backends.cute.utils import get_device_properties, requires_int64_abi, validate_tma_tensor
 
 from .common.elementwise import softplus
@@ -2532,184 +2533,192 @@ def prologue(
     ).launch(grid=(1, 1, 1), block=(ORDER_THREADS, 1, 1), stream=stream)
 
 
-@cute.jit
-def host(
-    cfg: cutlass.Constexpr,
-    k: cute.Tensor,
-    v: cute.Tensor,
-    gate: cute.Tensor,
-    a_log: Optional[cute.Tensor],
-    dt_bias: Optional[cute.Tensor],
-    beta: cute.Tensor,
-    cu_seqlens: cute.Tensor,
-    state_in: Optional[cute.Tensor],
-    state_out: Optional[cute.Tensor],
-    work_items: Optional[cute.Tensor],
-    work_count: Optional[cute.Tensor],
-    sched_ctr: Optional[cute.Tensor],
-    checkpoint_every_n_tokens: cutlass.Int32,
-    tensormap_workspace: cute.Tensor,
-    stream: cuda_driver.CUstream,
-):
-    h_k = k.shape[1]
-    h_v = v.shape[1]
-    batch_size = cu_seqlens.shape[0] - 1
-    heads_out = gate.shape[1]
+class GdnRecomputeOp:
+    """Compile and launch one static mega GDN recompute configuration."""
 
-    # ---- GQA reshapes: fold the head group into a --------------------------------
-    if cutlass.const_expr(cfg.is_GQA):
-        h_ratio = heads_out // h_v
-        h_native = h_v
-        k = cute.make_tensor(
-            k.iterator,
-            cute.make_layout(
-                (k.shape[0], k.shape[2], (h_ratio, h_v)),
-                stride=(k.stride[0], k.stride[2], (0, k.stride[1])),
-            ),
-        )
-        v = cute.make_tensor(
-            v.iterator,
-            cute.make_layout(
-                (v.shape[2], v.shape[0], (h_ratio, h_v)),
-                stride=(v.stride[2], v.stride[0], (0, v.stride[1])),
-            ),
-        )
-    else:
-        h_ratio = h_v // h_k
-        h_native = h_k
-        k = cute.make_tensor(
-            k.iterator,
-            cute.make_layout(
-                (k.shape[0], k.shape[2], (h_ratio, h_k)),
-                stride=(k.stride[0], k.stride[2], (0, k.stride[1])),
-            ),
-        )
-        v = cute.make_tensor(
-            v.iterator,
-            cute.make_layout(
-                (v.shape[2], v.shape[0], (h_ratio, h_k)),
-                stride=(v.stride[2], v.stride[0], (v.stride[1], h_ratio * v.stride[1])),
-            ),
+    def __init__(self, cfg: "GdnRecomputeCfg", use_int64_offsets: bool = False):
+        self.cfg = cfg
+        self.use_int64_offsets = use_int64_offsets
+
+    def get_name(self) -> str:
+        cfg = self.cfg
+        return (
+            f"gdn_mega_recompute_{cfg.io_dtype.__name__.lower()}_{cfg.state_dtype.__name__.lower()}"
+            f"_hk{cfg.n_heads_out // cfg.k_ratio}_hv{cfg.n_heads_out // cfg.v_ratio}"
+            f"_ho{cfg.n_heads_out}"
+            f"_g{int(cfg.is_GQA)}_i{int(cfg.use_initial_state)}f{int(cfg.store_final_state)}"
+            f"c{int(cfg.enable_checkpoints)}_l{int(cfg.log_gate)}s{int(cfg.safe_gate)}"
+            f"b{int(cfg.beta_sigmoid)}_d{int(cfg.dyn_sched)}_i64{int(self.use_int64_offsets)}"
         )
 
-    gate = cute.make_tensor(
-        gate.iterator,
-        cute.make_layout(
-            (gate.shape[0], (h_ratio, h_native)),
-            stride=(gate.stride[0], (gate.stride[1], h_ratio * gate.stride[1])),
-        ),
-    )
-    beta = cute.make_tensor(
-        beta.iterator,
-        cute.make_layout(
-            (beta.shape[0], (h_ratio, h_native)),
-            stride=(beta.stride[0], (beta.stride[1], h_ratio * beta.stride[1])),
-        ),
-    )
-    if cutlass.const_expr(state_in is not None):
-        state_in = cute.make_tensor(
-            state_in.iterator,
-            cute.make_layout(
-                (state_in.shape[2], state_in.shape[3], (h_ratio, h_native), state_in.shape[0]),
-                stride=(
-                    state_in.stride[2],
-                    state_in.stride[3],
-                    (state_in.stride[1], h_ratio * state_in.stride[1]),
-                    state_in.stride[0],
+    @cute.jit
+    def __call__(
+        self,
+        k: cute.Tensor,
+        v: cute.Tensor,
+        gate: cute.Tensor,
+        a_log: Optional[cute.Tensor],
+        dt_bias: Optional[cute.Tensor],
+        beta: cute.Tensor,
+        cu_seqlens: cute.Tensor,
+        state_in: Optional[cute.Tensor],
+        state_out: Optional[cute.Tensor],
+        work_items: Optional[cute.Tensor],
+        work_count: Optional[cute.Tensor],
+        sched_ctr: Optional[cute.Tensor],
+        checkpoint_every_n_tokens: cutlass.Int32,
+        tensormap_workspace: cute.Tensor,
+        stream: cuda_driver.CUstream,
+    ):
+        cfg = self.cfg
+        h_k = k.shape[1]
+        h_v = v.shape[1]
+        batch_size = cu_seqlens.shape[0] - 1
+        heads_out = gate.shape[1]
+
+        # ---- GQA reshapes: fold the head group into a --------------------------------
+        if cutlass.const_expr(cfg.is_GQA):
+            h_ratio = heads_out // h_v
+            h_native = h_v
+            k = cute.make_tensor(
+                k.iterator,
+                cute.make_layout(
+                    (k.shape[0], k.shape[2], (h_ratio, h_v)),
+                    stride=(k.stride[0], k.stride[2], (0, k.stride[1])),
                 ),
-            ),
-        )
-    if cutlass.const_expr(state_out is not None):
-        state_out = cute.make_tensor(
-            state_out.iterator,
-            cute.make_layout(
-                (state_out.shape[2], state_out.shape[3], (h_ratio, h_native), state_out.shape[0]),
-                stride=(
-                    state_out.stride[2],
-                    state_out.stride[3],
-                    (state_out.stride[1], h_ratio * state_out.stride[1]),
-                    state_out.stride[0],
+            )
+            v = cute.make_tensor(
+                v.iterator,
+                cute.make_layout(
+                    (v.shape[2], v.shape[0], (h_ratio, h_v)),
+                    stride=(v.stride[2], v.stride[0], (0, v.stride[1])),
                 ),
+            )
+        else:
+            h_ratio = h_v // h_k
+            h_native = h_k
+            k = cute.make_tensor(
+                k.iterator,
+                cute.make_layout(
+                    (k.shape[0], k.shape[2], (h_ratio, h_k)),
+                    stride=(k.stride[0], k.stride[2], (0, k.stride[1])),
+                ),
+            )
+            v = cute.make_tensor(
+                v.iterator,
+                cute.make_layout(
+                    (v.shape[2], v.shape[0], (h_ratio, h_k)),
+                    stride=(v.stride[2], v.stride[0], (v.stride[1], h_ratio * v.stride[1])),
+                ),
+            )
+
+        gate = cute.make_tensor(
+            gate.iterator,
+            cute.make_layout(
+                (gate.shape[0], (h_ratio, h_native)),
+                stride=(gate.stride[0], (gate.stride[1], h_ratio * gate.stride[1])),
             ),
         )
+        beta = cute.make_tensor(
+            beta.iterator,
+            cute.make_layout(
+                (beta.shape[0], (h_ratio, h_native)),
+                stride=(beta.stride[0], (beta.stride[1], h_ratio * beta.stride[1])),
+            ),
+        )
+        if cutlass.const_expr(state_in is not None):
+            state_in = cute.make_tensor(
+                state_in.iterator,
+                cute.make_layout(
+                    (state_in.shape[2], state_in.shape[3], (h_ratio, h_native), state_in.shape[0]),
+                    stride=(
+                        state_in.stride[2],
+                        state_in.stride[3],
+                        (state_in.stride[1], h_ratio * state_in.stride[1]),
+                        state_in.stride[0],
+                    ),
+                ),
+            )
+        if cutlass.const_expr(state_out is not None):
+            state_out = cute.make_tensor(
+                state_out.iterator,
+                cute.make_layout(
+                    (
+                        state_out.shape[2],
+                        state_out.shape[3],
+                        (h_ratio, h_native),
+                        state_out.shape[0],
+                    ),
+                    stride=(
+                        state_out.stride[2],
+                        state_out.stride[3],
+                        (state_out.stride[1], h_ratio * state_out.stride[1]),
+                        state_out.stride[0],
+                    ),
+                ),
+            )
 
-    # ---- SMEM sizing: per-buffer element cosizes ---------------------------------
-    bpe = cfg.io_dtype.width // 8
-    kq_tile_elems = 2 * cfg.b_t * cfg.d_k
-    v_tile_elems = cfg.d_v * cfg.b_t
-    tinv_tile_elems = cfg.b_t * cfg.b_t
-    cfg.kq_cosize = kq_tile_elems * cfg.smem_kq_stages
-    cfg.v_cosize = v_tile_elems * cfg.smem_v_stages
-    cfg.t_inv_cosize = tinv_tile_elems * cfg.smem_t_inv_stages
-    cfg.checkpoint_cosize = (
-        cfg.d_k * cfg.d_v * cfg.smem_checkpoint_stages if cfg.enable_checkpoints else 1
-    )
+        cumsumlog_smem_layout_staged = cute.make_layout((cfg.b_t, 1, cfg.smem_gate_stages))
+        beta_smem_layout_staged = cute.make_layout((cfg.b_t, 1, cfg.smem_beta_stages))
 
-    cumsumlog_smem_layout_staged = cute.make_layout((cfg.b_t, 1, cfg.smem_gate_stages))
-    beta_smem_layout_staged = cute.make_layout((cfg.b_t, 1, cfg.smem_beta_stages))
+        num_descs = batch_size
 
-    cfg.tma_kq_bytes = (kq_tile_elems // 2) * bpe
-    cfg.tma_v_bytes = v_tile_elems * bpe
+        # ---- launch ------------------------------------------------------------------
+        grid_shape = (cfg.max_active_clusters, 1, 1)
 
-    cfg.n_heads_out = heads_out
-    cfg.k_ratio = heads_out // h_k
-    cfg.v_ratio = heads_out // h_v
-    num_descs = batch_size
+        @cute.struct
+        class SharedStorage:
+            checkpoint: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.checkpoint_cosize], cfg.buffer_align_bytes
+            ]
+            kq: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.kq_cosize], cfg.buffer_align_bytes
+            ]
+            cumsumlog: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, cute.cosize(cumsumlog_smem_layout_staged)],
+                128,
+            ]
+            cumprod: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, cute.cosize(cumsumlog_smem_layout_staged)],
+                128,
+            ]
+            beta: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, cute.cosize(beta_smem_layout_staged)], 128
+            ]
+            t_inv: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.t_inv_cosize], cfg.buffer_align_bytes
+            ]
+            v: cute.struct.Align[
+                cute.struct.MemRange[cfg.io_dtype, cfg.v_cosize], cfg.buffer_align_bytes
+            ]
 
-    # ---- launch ------------------------------------------------------------------
-    grid_shape = (cfg.max_active_clusters, 1, 1)
-
-    @cute.struct
-    class SharedStorage:
-        checkpoint: cute.struct.Align[
-            cute.struct.MemRange[cfg.io_dtype, cfg.checkpoint_cosize], cfg.buffer_align_bytes
-        ]
-        kq: cute.struct.Align[
-            cute.struct.MemRange[cfg.io_dtype, cfg.kq_cosize], cfg.buffer_align_bytes
-        ]
-        cumsumlog: cute.struct.Align[
-            cute.struct.MemRange[cutlass.Float32, cute.cosize(cumsumlog_smem_layout_staged)], 128
-        ]
-        cumprod: cute.struct.Align[
-            cute.struct.MemRange[cutlass.Float32, cute.cosize(cumsumlog_smem_layout_staged)], 128
-        ]
-        beta: cute.struct.Align[
-            cute.struct.MemRange[cutlass.Float32, cute.cosize(beta_smem_layout_staged)], 128
-        ]
-        t_inv: cute.struct.Align[
-            cute.struct.MemRange[cfg.io_dtype, cfg.t_inv_cosize], cfg.buffer_align_bytes
-        ]
-        v: cute.struct.Align[
-            cute.struct.MemRange[cfg.io_dtype, cfg.v_cosize], cfg.buffer_align_bytes
-        ]
-
-    kernel(
-        cfg,
-        SharedStorage,
-        gate,
-        a_log,
-        dt_bias,
-        beta,
-        cu_seqlens,
-        state_in,
-        state_out,
-        work_items,
-        work_count,
-        sched_ctr,
-        checkpoint_every_n_tokens,
-        cumsumlog_smem_layout_staged,
-        beta_smem_layout_staged,
-        k,
-        v,
-        tensormap_workspace,
-        cutlass.Int32(num_descs),
-    ).launch(
-        grid=grid_shape,
-        block=(cfg.threads_per_cta, 1, 1),
-        cluster=cfg.cluster_shape_mnk,
-        stream=stream,
-        min_blocks_per_mp=1,
-    )
+        kernel(
+            cfg,
+            SharedStorage,
+            gate,
+            a_log,
+            dt_bias,
+            beta,
+            cu_seqlens,
+            state_in,
+            state_out,
+            work_items,
+            work_count,
+            sched_ctr,
+            checkpoint_every_n_tokens,
+            cumsumlog_smem_layout_staged,
+            beta_smem_layout_staged,
+            k,
+            v,
+            tensormap_workspace,
+            cutlass.Int32(num_descs),
+        ).launch(
+            grid=grid_shape,
+            block=(cfg.threads_per_cta, 1, 1),
+            cluster=cfg.cluster_shape_mnk,
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
 
 
 @cute.kernel
@@ -3004,15 +3013,14 @@ def kernel(
         )
 
 
-@dataclass
+@dataclass(frozen=True)
 class GdnRecomputeCfg:
     """Per-compile GDN kernel knob, built by ``build_cfg``.
 
     The per-compile parameters (dtypes, GQA, state flags) are the
     ``cute.compile`` cache keys; the rest is derived from the module-global
-    ``CFG`` constants.  ``host`` stamps the shape-derived fields at trace
-    time.  Passed ``cfg``-first (a ``cutlass.Constexpr``) into ``host`` /
-    ``kernel`` and every warp body.
+    ``CFG`` constants. ``build_cfg`` computes all derived fields before tracing.
+    Owned by ``GdnRecomputeOp`` and passed into ``kernel`` and every warp body.
     """
 
     io_dtype: Type[cutlass.Numeric]
@@ -3072,7 +3080,7 @@ class GdnRecomputeCfg:
     tmem_y_decay_u_inp_offset: int = 0
     buffer_align_bytes: int = CFG.BUFFER_ALIGN_BYTES
 
-    # ---- stamped by host at trace time (shape-derived) --------------------------
+    # ---- shape-derived sizes and head ratios set by build_cfg -------------------
     kq_cosize: int = 0
     v_cosize: int = 0
     t_inv_cosize: int = 0
@@ -3097,6 +3105,9 @@ def build_cfg(
     safe_gate: bool = False,
     beta_sigmoid: bool = False,
     dyn_sched: bool = False,
+    n_heads_out: int = 0,
+    k_ratio: int = 1,
+    v_ratio: int = 1,
 ) -> GdnRecomputeCfg:
     """Build the per-compile ``GdnRecomputeCfg`` (io_dtype ∈ {Float16, BFloat16};
     acc is always Float32)."""
@@ -3117,25 +3128,48 @@ def build_cfg(
         safe_gate=safe_gate,
         beta_sigmoid=beta_sigmoid,
         dyn_sched=dyn_sched,
+        n_heads_out=n_heads_out,
+        k_ratio=k_ratio,
+        v_ratio=v_ratio,
     )
-    cfg.smem_checkpoint_stages = 1
+    smem_checkpoint_stages = 1
     if enable_checkpoints:
-        cfg.smem_kq_stages = 3
+        cfg = replace(cfg, smem_kq_stages=3)
     if not use_initial_state:
-        cfg.num_regs_compute_group_1 = 232
-        cfg.num_regs_other = 48
+        cfg = replace(cfg, num_regs_compute_group_1=232, num_regs_other=48)
     n_cg0 = len(cfg.compute_group_0_warp_ids)
     n_cg1 = len(cfg.compute_group_1_warp_ids)
-    cfg.threads_per_cta = cfg.threads_per_warp * (4 + n_cg0 + n_cg1)
-    cfg.tmem_alloc_barrier_threads = cfg.threads_per_warp * (1 + n_cg0 + n_cg1)
-    cfg.inverse_barrier_threads = cfg.threads_per_warp * n_cg0
-    cfg.init_state_store_barrier_threads = cfg.threads_per_warp * n_cg1
-    cfg.tmem_state_acc_offset = 0
-    cfg.tmem_state_inp_offset = cfg.tmem_state_acc_offset + cfg.tmem_state_acc_stages * 128
-    cfg.tmem_cg0_acc_offset = cfg.tmem_state_inp_offset + cfg.tmem_state_inp_stages * 64
-    cfg.tmem_cg1_acc_offset = cfg.tmem_cg0_acc_offset + cfg.tmem_cg0_acc_stages * 64
-    cfg.tmem_y_decay_u_inp_offset = cfg.tmem_cg1_acc_offset + cfg.tmem_cg1_acc_stages * 64
-    return cfg
+    tmem_state_acc_offset = 0
+    tmem_state_inp_offset = tmem_state_acc_offset + cfg.tmem_state_acc_stages * 128
+    tmem_cg0_acc_offset = tmem_state_inp_offset + cfg.tmem_state_inp_stages * 64
+    tmem_cg1_acc_offset = tmem_cg0_acc_offset + cfg.tmem_cg0_acc_stages * 64
+    # ---- SMEM sizing: per-buffer element cosizes ---------------------------------
+    bpe = cfg.io_dtype.width // 8
+    kq_tile_elems = 2 * cfg.b_t * cfg.d_k
+    v_tile_elems = cfg.d_v * cfg.b_t
+    tinv_tile_elems = cfg.b_t * cfg.b_t
+
+    return replace(
+        cfg,
+        smem_checkpoint_stages=smem_checkpoint_stages,
+        threads_per_cta=cfg.threads_per_warp * (4 + n_cg0 + n_cg1),
+        tmem_alloc_barrier_threads=cfg.threads_per_warp * (1 + n_cg0 + n_cg1),
+        inverse_barrier_threads=cfg.threads_per_warp * n_cg0,
+        init_state_store_barrier_threads=cfg.threads_per_warp * n_cg1,
+        tmem_state_acc_offset=tmem_state_acc_offset,
+        tmem_state_inp_offset=tmem_state_inp_offset,
+        tmem_cg0_acc_offset=tmem_cg0_acc_offset,
+        tmem_cg1_acc_offset=tmem_cg1_acc_offset,
+        tmem_y_decay_u_inp_offset=tmem_cg1_acc_offset + cfg.tmem_cg1_acc_stages * 64,
+        kq_cosize=kq_tile_elems * cfg.smem_kq_stages,
+        v_cosize=v_tile_elems * cfg.smem_v_stages,
+        t_inv_cosize=tinv_tile_elems * cfg.smem_t_inv_stages,
+        checkpoint_cosize=cfg.d_k * cfg.d_v * smem_checkpoint_stages
+        if cfg.enable_checkpoints
+        else 1,
+        tma_kq_bytes=(kq_tile_elems // 2) * bpe,
+        tma_v_bytes=v_tile_elems * bpe,
+    )
 
 
 TENSORMAP_DESC_ARRAYS = 3  # per-batch runtime TMA descriptors: K, V, checkpoints
@@ -3145,34 +3179,8 @@ TENSORMAP_STATIC_SLOTS = 0
 # ---------------------------------------------------------------------------
 
 
-@lru_cache(maxsize=None)
-def get_compiled_cache(
-    io_dtype_str: str,
-    state_dtype_str: str,
-    HK: int,
-    HV: int,
-    HO: int,
-    is_gqa: bool,
-    use_initial_state: bool,
-    store_final_state: bool,
-    enable_checkpoints: bool,
-    log_gate: bool,
-    safe_gate: bool,
-    beta_sigmoid: bool,
-    dyn_sched: bool,
-    run_order: bool,
-    order_gen: bool,
-    use_int64_offsets: bool,
-    device_index: int,
-    device_major: int,
-    device_minor: int,
-    num_sm: int,
-):
-    """Return a mutable dict that lazily stores compiled entry points."""
-    return {}
-
-
-def compile(
+@jit_cache(extra_sources=(Path(__file__).parent,))
+def _compile_gdn_recompute(
     io_dtype,
     state_dtype,
     is_gqa: bool,
@@ -3204,7 +3212,11 @@ def compile(
         safe_gate=safe_gate,
         beta_sigmoid=beta_sigmoid,
         dyn_sched=dyn_sched,
+        n_heads_out=n_heads_out,
+        k_ratio=k_ratio,
+        v_ratio=v_ratio,
     )
+    op = GdnRecomputeOp(cfg, use_int64_offsets)
     sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
     tokens, sequence_entries, sequences, work_rows, sched_entries, workspace_words = (
         sym_int() for _ in range(6)
@@ -3216,8 +3228,7 @@ def compile(
     )
     beta_dtype = io_dtype if beta_sigmoid else cutlass.Float32
     return compile_tvm_ffi(
-        host,
-        cfg,
+        op,
         tma_tensor(io_dtype, (tokens, n_heads_out // k_ratio, 128)),
         tma_tensor(io_dtype, (tokens, n_heads_out // v_ratio, 128)),
         make_strided_signature_tensor(
@@ -3246,12 +3257,62 @@ def compile(
         make_counter_signature(sched_entries) if dyn_sched else None,
         cutlass.Int32(checkpoint_every_n_tokens),
         make_workspace_signature(workspace_words),
+    )
+
+
+@jit_cache(extra_sources=(Path(__file__).parent,))
+def _compile_gdn_recompute_prologue(
+    io_dtype: type[cutlass.Numeric],
+    h_k: int,
+    h_v: int,
+    h_out: int,
+    enable_checkpoints: bool,
+    run_order: bool,
+    order_gen: bool,
+    dyn_sched: bool,
+    checkpoint_every_n_tokens: int,
+    use_int64_offsets: bool,
+):
+    """JIT-compile the prologue from static specialization arguments."""
+    sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
+    tokens, sequence_entries, checkpoint_rows, work_rows, sched_entries, workspace_words = (
+        sym_int() for _ in range(6)
+    )
+    tma_tensor = partial(
+        make_strided_signature_tensor,
+        assumed_align=16,
+        use_int64_offsets=use_int64_offsets,
+    )
+    work_items_signature = make_work_items_signature(work_rows)
+    return compile_tvm_ffi(
+        prologue,
+        io_dtype,
+        CFG.B_T,
+        run_order,
+        order_gen,
+        tma_tensor(io_dtype, (tokens, h_k, 128)),
+        tma_tensor(io_dtype, (tokens, h_v, 128)),
+        make_strided_signature_tensor(
+            cutlass.Float32,
+            (tokens, h_out),
+            assumed_align=4,
+            use_int64_offsets=use_int64_offsets,
+        ),
+        make_cu_seqlens_signature(sequence_entries),
+        tma_tensor(io_dtype, (checkpoint_rows, h_out, 128, 128))
+        if enable_checkpoints
+        else None,
+        work_items_signature if run_order and not order_gen else None,
+        make_counter_signature(),
+        work_items_signature,
+        make_counter_signature(sched_entries) if run_order else None,
+        cutlass.Int32(checkpoint_every_n_tokens),
+        make_workspace_signature(workspace_words),
         name=(
-            f"gdn_mega_recompute_{io_dtype.__name__.lower()}_{state_dtype.__name__.lower()}"
-            f"_hk{n_heads_out // k_ratio}_hv{n_heads_out // v_ratio}_ho{n_heads_out}"
-            f"_g{int(is_gqa)}_i{int(use_initial_state)}f{int(store_final_state)}"
-            f"c{int(enable_checkpoints)}_l{int(log_gate)}s{int(safe_gate)}"
-            f"b{int(beta_sigmoid)}_d{int(dyn_sched)}_i64{int(use_int64_offsets)}"
+            f"gdn_mega_recompute_prologue_{io_dtype.__name__.lower()}"
+            f"_hk{h_k}_hv{h_v}_ho{h_out}_c{int(enable_checkpoints)}"
+            f"_r{int(run_order)}o{int(order_gen)}d{int(dyn_sched)}"
+            f"_i64{int(use_int64_offsets)}"
         ),
     )
 
@@ -3405,12 +3466,10 @@ def chunk_gdn_recompute_sm100(
         raise ValueError("the active CUDA device must match k.device")
     device_properties = get_device_properties(device_index)
     num_sm = device_properties.multi_processor_count
-    cache = get_compiled_cache(
-        str(k.dtype),
-        str(state_dtype_src),
-        h_k,
-        h_v,
-        h_out,
+    io_dtype = get_dtype(k.dtype)
+    compiled = _compile_gdn_recompute(
+        io_dtype,
+        get_dtype(state_dtype_src),
         is_gqa,
         use_initial_state,
         store_final_state,
@@ -3418,80 +3477,28 @@ def chunk_gdn_recompute_sm100(
         log_gate,
         safe_gate,
         use_beta_sigmoid,
+        k_ratio,
+        v_ratio,
+        h_out,
         dyn_sched,
-        run_order,
-        order_gen,
         use_int64_offsets,
-        device_index,
-        device_properties.major,
-        device_properties.minor,
-        num_sm,
+        num_sm=num_sm,
+        checkpoint_every_n_tokens=checkpoint_every_n_tokens,
     )
 
-    io_dtype = get_dtype(k.dtype)
-    if "compiled" not in cache:
-        cache["compiled"] = compile(
-            io_dtype,
-            get_dtype(state_dtype_src),
-            is_gqa,
-            use_initial_state,
-            store_final_state,
-            enable_checkpoints,
-            log_gate,
-            safe_gate,
-            use_beta_sigmoid,
-            k_ratio,
-            v_ratio,
-            h_out,
-            dyn_sched,
-            use_int64_offsets,
-            num_sm=num_sm,
-            checkpoint_every_n_tokens=checkpoint_every_n_tokens,
-        )
-
-    if "prologue" not in cache:
-        sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
-        tokens, sequence_entries, checkpoint_rows, work_rows, sched_entries, workspace_words = (
-            sym_int() for _ in range(6)
-        )
-        tma_tensor = partial(
-            make_strided_signature_tensor,
-            assumed_align=16,
-            use_int64_offsets=use_int64_offsets,
-        )
-        work_items_signature = make_work_items_signature(work_rows)
-        cache["prologue"] = compile_tvm_ffi(
-            prologue,
-            io_dtype,
-            CFG.B_T,
-            run_order,
-            order_gen,
-            tma_tensor(io_dtype, (tokens, h_k, 128)),
-            tma_tensor(io_dtype, (tokens, h_v, 128)),
-            make_strided_signature_tensor(
-                cutlass.Float32,
-                (tokens, h_out),
-                assumed_align=4,
-                use_int64_offsets=use_int64_offsets,
-            ),
-            make_cu_seqlens_signature(sequence_entries),
-            tma_tensor(io_dtype, (checkpoint_rows, h_out, 128, 128))
-            if checkpoints_for_descs is not None
-            else None,
-            work_items_signature if run_order and not order_gen else None,
-            make_counter_signature(),
-            work_items_signature,
-            make_counter_signature(sched_entries) if run_order else None,
-            cutlass.Int32(checkpoint_every_n_tokens),
-            make_workspace_signature(workspace_words),
-            name=(
-                f"gdn_mega_recompute_prologue_{io_dtype.__name__.lower()}"
-                f"_hk{h_k}_hv{h_v}_ho{h_out}_c{int(enable_checkpoints)}"
-                f"_r{int(run_order)}o{int(order_gen)}d{int(dyn_sched)}"
-                f"_i64{int(use_int64_offsets)}"
-            ),
-        )
-    cache["prologue"](
+    compiled_prologue = _compile_gdn_recompute_prologue(
+        io_dtype,
+        h_k,
+        h_v,
+        h_out,
+        enable_checkpoints,
+        run_order,
+        order_gen,
+        dyn_sched,
+        checkpoint_every_n_tokens,
+        use_int64_offsets,
+    )
+    compiled_prologue(
         k,
         v,
         gate,
@@ -3504,7 +3511,7 @@ def chunk_gdn_recompute_sm100(
         checkpoint_every_n_tokens,
         tensormap_workspace,
     )
-    cache["compiled"](
+    compiled(
         k,
         v,
         gate,

--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_bprop_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_bprop_f16.py
@@ -71,8 +71,9 @@ Warp assignments (16 warps = 512 threads):
   warp  15   : epilogue - dQ/dK/dV/dGate TMA stores
 """
 
-from dataclasses import dataclass
-from functools import lru_cache, partial
+from dataclasses import dataclass, replace
+from functools import partial
+from pathlib import Path
 from typing import NamedTuple, Type
 
 import cuda.bindings.driver as cuda_driver
@@ -82,7 +83,7 @@ import cutlass.experimental.cuda as cuda
 import cutlass.experimental.primitives as nvvm
 import cutlass.cute as cute
 
-from attn_gym._backends.cute import compile_tvm_ffi
+from attn_gym._backends.cute import compile_tvm_ffi, jit_cache
 from attn_gym._backends.cute.utils import get_device_properties, requires_int64_abi, validate_tma_tensor
 from attn_gym.linear._delta_rule.mega.kernels.common.split_k import ORDER_CAPACITY, ORDER_ELEMS, ORDER_THREADS, decode_work_item, order_body
 from attn_gym.linear._delta_rule.mega.kernels.common.host import checkpoint_capacity_bound, get_dtype
@@ -3901,7 +3902,7 @@ def kernel(
         )
 
 
-@dataclass
+@dataclass(frozen=True)
 class KdaBwdCfg:
     """Kernel cfg (fixed BT=16 schedule constants; derived TMEM column offsets
     and SMEM buffer cosizes are stamped by ``build_cfg``)."""
@@ -4021,7 +4022,9 @@ def build_cfg(
     dyn_sched: bool = False,
 ) -> KdaBwdCfg:
     if io_dtype not in (cutlass.Float16, cutlass.BFloat16):
-        raise ValueError(f"io_dtype={io_dtype} not supported; only Float16 and BFloat16 are supported")
+        raise ValueError(
+            f"io_dtype={io_dtype} not supported; only Float16 and BFloat16 are supported"
+        )
     cfg = KdaBwdCfg(
         io_dtype=io_dtype,
         use_dstate_in=use_dstate_in,
@@ -4056,61 +4059,82 @@ def build_cfg(
     ):
         if len(group) != 4 or group != tuple(range(group[0], group[-1] + 1)):
             raise ValueError("the fixed schedule requires contiguous four-warp compute groups")
-    cfg.threads_per_cta = len(role_ids) * cfg.threads_per_warp
-    cfg.cg0_threads = len(cfg.compute_group_0_warp_ids) * cfg.threads_per_warp
-    cfg.cg2_threads = len(cfg.compute_group_2_warp_ids) * cfg.threads_per_warp
-    cfg.cg1_threads = len(cfg.compute_group_1_warp_ids) * cfg.threads_per_warp
-    cfg.tmem_user_threads = (
-        1 + len(cfg.compute_group_2_warp_ids) + len(cfg.compute_group_1_warp_ids) + len(cfg.compute_group_0_warp_ids)
-    ) * cfg.threads_per_warp
     named_barrier_ids = (
         cfg.cg0_sync_barrier_id,
         cfg.cg2_sync_barrier_id,
         cfg.tmem_lifecycle_barrier_id,
         cfg.cg1_sync_barrier_id,
     )
-    if (
-        any(not 1 <= barrier_id <= 15 for barrier_id in named_barrier_ids)
-        or len(set(named_barrier_ids)) != len(named_barrier_ids)
-    ):
+    if any(not 1 <= barrier_id <= 15 for barrier_id in named_barrier_ids) or len(
+        set(named_barrier_ids)
+    ) != len(named_barrier_ids):
         raise ValueError("named barrier IDs must be disjoint values in [1, 15]")
 
-    cfg.tmem_dstate_acc_offset = 0
-    cfg.tmem_dstate_inp_offset = cfg.d_k
-    cfg.tmem_state_inp_offset = cfg.tmem_dstate_inp_offset + cfg.d_k // 2
-    cfg.tmem_state_k_acc_offset = cfg.tmem_state_inp_offset + cfg.d_v
-    cfg.tmem_u_acc_offset = cfg.tmem_state_k_acc_offset + cfg.b_t
-    cfg.tmem_du_acc_offset = cfg.tmem_u_acc_offset + cfg.b_t
-    cfg.tmem_dy_acc_offset = cfg.tmem_state_k_acc_offset
-    cfg.tmem_dq_acc_offset = cfg.tmem_du_acc_offset + cfg.b_t
-    cfg.tmem_dk_decay_acc_offset = cfg.tmem_dq_acc_offset + cfg.b_t
-    cfg.tmem_dk_inv_acc_offset = cfg.tmem_dk_decay_acc_offset + cfg.b_t
-    cfg.tmem_dk_restore_acc_offset = cfg.tmem_dk_inv_acc_offset + cfg.b_t
-    cfg.tmem_y_inp_offset = cfg.tmem_dk_restore_acc_offset + cfg.b_t
-    cfg.tmem_neg_beta_dy_inp_offset = cfg.tmem_y_inp_offset
-    cfg.tmem_du_inp_offset = cfg.tmem_y_inp_offset + cfg.b_t // 2
-    cfg.tmem_qraw_inp_offset = cfg.tmem_du_inp_offset + cfg.b_t // 2
-    cfg.tmem_kraw_inp_offset = cfg.tmem_qraw_inp_offset + cfg.tmem_qk_raw_stages * (cfg.b_t // 2)
-    assert cfg.tmem_kraw_inp_offset + cfg.tmem_qk_raw_stages * (cfg.b_t // 2) <= 512
+    tmem_dstate_inp_offset = cfg.d_k
+    tmem_state_inp_offset = tmem_dstate_inp_offset + cfg.d_k // 2
+    tmem_state_k_acc_offset = tmem_state_inp_offset + cfg.d_v
+    tmem_u_acc_offset = tmem_state_k_acc_offset + cfg.b_t
+    tmem_du_acc_offset = tmem_u_acc_offset + cfg.b_t
+    tmem_dq_acc_offset = tmem_du_acc_offset + cfg.b_t
+    tmem_dk_decay_acc_offset = tmem_dq_acc_offset + cfg.b_t
+    tmem_dk_inv_acc_offset = tmem_dk_decay_acc_offset + cfg.b_t
+    tmem_dk_restore_acc_offset = tmem_dk_inv_acc_offset + cfg.b_t
+    tmem_y_inp_offset = tmem_dk_restore_acc_offset + cfg.b_t
+    tmem_du_inp_offset = tmem_y_inp_offset + cfg.b_t // 2
+    tmem_qraw_inp_offset = tmem_du_inp_offset + cfg.b_t // 2
+    tmem_kraw_inp_offset = tmem_qraw_inp_offset + cfg.tmem_qk_raw_stages * (cfg.b_t // 2)
+    assert tmem_kraw_inp_offset + cfg.tmem_qk_raw_stages * (cfg.b_t // 2) <= 512
 
-    cfg.raw_qk_cosize = cfg.smem_raw_stages * cfg.d_k * cfg.b_t
-    cfg.raw_v_cosize = cfg.smem_raw_stages * cfg.d_v * cfg.b_t
-    cfg.raw_gate_cosize = cfg.smem_raw_stages * cfg.d_k * cfg.b_t
-    cfg.operand_cosize = cfg.smem_decay_stages * cfg.b_t * cfg.d_k
-    cfg.diag_cosize = cfg.smem_decay_stages * (cfg.d_k // 16) * 256
-    cfg.intermediate_cosize = cfg.smem_intermediate_stages * cfg.intermediate_tiles * cfg.b_t * cfg.b_t
-    cfg.state_cosize = cfg.smem_state_stages * cfg.d_k * cfg.d_v
-    cfg.dq_cosize = cfg.smem_dq_stages * cfg.b_t * cfg.d_k
-    cfg.dk_cosize = cfg.smem_dk_stages * cfg.b_t * cfg.d_k
-    cfg.dgate_cosize = cfg.smem_dgate_stages * cfg.b_t * cfg.d_k
-    cfg.dv_cosize = cfg.smem_dv_stages * cfg.b_t * cfg.d_v
-    cfg.tma_state_bytes = cfg.d_k * cfg.d_v * (io_dtype.width // 8)
-    cfg.tma_q_bytes = cfg.d_k * cfg.b_t * (cfg.io_dtype.width // 8)
-    cfg.tma_k_bytes = cfg.d_k * cfg.b_t * (cfg.io_dtype.width // 8)
-    cfg.tma_gate_bytes = cfg.d_k * cfg.b_t * 4
-    cfg.tma_do_bytes = cfg.d_v * cfg.b_t * (cfg.io_dtype.width // 8)
-    cfg.tma_v_bytes = cfg.d_v * cfg.b_t * (cfg.io_dtype.width // 8)
-    return cfg
+    return replace(
+        cfg,
+        threads_per_cta=len(role_ids) * cfg.threads_per_warp,
+        cg0_threads=len(cfg.compute_group_0_warp_ids) * cfg.threads_per_warp,
+        cg2_threads=len(cfg.compute_group_2_warp_ids) * cfg.threads_per_warp,
+        cg1_threads=len(cfg.compute_group_1_warp_ids) * cfg.threads_per_warp,
+        tmem_user_threads=(
+            1
+            + len(cfg.compute_group_2_warp_ids)
+            + len(cfg.compute_group_1_warp_ids)
+            + len(cfg.compute_group_0_warp_ids)
+        )
+        * cfg.threads_per_warp,
+        tmem_dstate_acc_offset=0,
+        tmem_dstate_inp_offset=tmem_dstate_inp_offset,
+        tmem_state_inp_offset=tmem_state_inp_offset,
+        tmem_state_k_acc_offset=tmem_state_k_acc_offset,
+        tmem_u_acc_offset=tmem_u_acc_offset,
+        tmem_du_acc_offset=tmem_du_acc_offset,
+        tmem_dy_acc_offset=tmem_state_k_acc_offset,
+        tmem_dq_acc_offset=tmem_dq_acc_offset,
+        tmem_dk_decay_acc_offset=tmem_dk_decay_acc_offset,
+        tmem_dk_inv_acc_offset=tmem_dk_inv_acc_offset,
+        tmem_dk_restore_acc_offset=tmem_dk_restore_acc_offset,
+        tmem_y_inp_offset=tmem_y_inp_offset,
+        tmem_neg_beta_dy_inp_offset=tmem_y_inp_offset,
+        tmem_du_inp_offset=tmem_du_inp_offset,
+        tmem_qraw_inp_offset=tmem_qraw_inp_offset,
+        tmem_kraw_inp_offset=tmem_kraw_inp_offset,
+        raw_qk_cosize=cfg.smem_raw_stages * cfg.d_k * cfg.b_t,
+        raw_v_cosize=cfg.smem_raw_stages * cfg.d_v * cfg.b_t,
+        raw_gate_cosize=cfg.smem_raw_stages * cfg.d_k * cfg.b_t,
+        operand_cosize=cfg.smem_decay_stages * cfg.b_t * cfg.d_k,
+        diag_cosize=cfg.smem_decay_stages * (cfg.d_k // 16) * 256,
+        intermediate_cosize=cfg.smem_intermediate_stages
+        * cfg.intermediate_tiles
+        * cfg.b_t
+        * cfg.b_t,
+        state_cosize=cfg.smem_state_stages * cfg.d_k * cfg.d_v,
+        dq_cosize=cfg.smem_dq_stages * cfg.b_t * cfg.d_k,
+        dk_cosize=cfg.smem_dk_stages * cfg.b_t * cfg.d_k,
+        dgate_cosize=cfg.smem_dgate_stages * cfg.b_t * cfg.d_k,
+        dv_cosize=cfg.smem_dv_stages * cfg.b_t * cfg.d_v,
+        tma_state_bytes=cfg.d_k * cfg.d_v * (io_dtype.width // 8),
+        tma_q_bytes=cfg.d_k * cfg.b_t * (cfg.io_dtype.width // 8),
+        tma_k_bytes=cfg.d_k * cfg.b_t * (cfg.io_dtype.width // 8),
+        tma_gate_bytes=cfg.d_k * cfg.b_t * 4,
+        tma_do_bytes=cfg.d_v * cfg.b_t * (cfg.io_dtype.width // 8),
+        tma_v_bytes=cfg.d_v * cfg.b_t * (cfg.io_dtype.width // 8),
+    )
 
 
 TENSORMAP_DESC_ARRAYS = 10  # per-batch runtime TMA descriptors: Q, K, V, Gate, dO, state_checkpoints, dQ, dK, dV, dGate
@@ -4120,29 +4144,149 @@ TENSORMAP_STATIC_SLOTS = 0
 # ---- Torch adapter / host-side compilation ---------------------------------------
 
 
-@lru_cache(maxsize=None)
-def get_compiled_cache(
-    io_dtype_str: str,
+@jit_cache(extra_sources=(Path(__file__).parent,))
+def _compile_kda_bprop(
+    io_dtype: type[cutlass.Numeric],
     HQ: int,
     HK: int,
     HV: int,
+    HO: int,
     use_dstate_in: bool,
     use_dstate0: bool,
-    l2norm: bool,
+    use_qk_l2norm_in_kernel: bool,
     safe_gate: bool,
-    gate_lower_bound: float,
-    beta_sigmoid: bool,
+    gate_scale_log2: float,
+    use_beta_sigmoid: bool,
     use_initial_state: bool,
     dyn_sched: bool,
+    use_int64_offsets: bool,
+    num_sm: int,
+    scale: float,
+):
+    """JIT-compile one fake-tensor TVM-FFI backward signature."""
+    sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
+    cfg = build_cfg(
+        io_dtype,
+        use_dstate_in=use_dstate_in,
+        use_dstate0=use_dstate0,
+        l2norm=use_qk_l2norm_in_kernel,
+        safe_gate=safe_gate,
+        gate_scale_log2=gate_scale_log2,
+        beta_sigmoid=use_beta_sigmoid,
+        use_initial_state=use_initial_state,
+        q_ratio=HO // HQ,
+        k_ratio=HO // HK,
+        v_ratio=HO // HV,
+        n_heads_out=HO,
+        max_active_clusters=num_sm,
+        dyn_sched=dyn_sched,
+    )
+    op = KdaBpropOp(cfg, use_int64_offsets)
+    (
+        tokens,
+        checkpoint_rows,
+        sequence_entries,
+        sequences,
+        work_rows,
+        sched_entries,
+        workspace_words,
+    ) = (sym_int() for _ in range(7))
+
+    tma_tensor = partial(
+        make_strided_signature_tensor,
+        assumed_align=16,
+        use_int64_offsets=use_int64_offsets,
+    )
+    beta_dtype = io_dtype if use_beta_sigmoid else cutlass.Float32
+    return compile_tvm_ffi(
+        op,
+        make_compact_signature_tensor(
+            cutlass.Float32,
+            (HO,),
+            assumed_align=4,
+        )
+        if safe_gate
+        else None,
+        tma_tensor(cutlass.Float32, (HO, 128)) if safe_gate else None,
+        make_strided_signature_tensor(
+            beta_dtype,
+            (tokens, HO),
+            assumed_align=beta_dtype.width // 8,
+            use_int64_offsets=use_int64_offsets,
+        ),
+        tma_tensor(io_dtype, (checkpoint_rows, HO, 128, 128)),
+        tma_tensor(cutlass.Float32, (tokens, HO, 128)),
+        make_strided_signature_tensor(
+            beta_dtype,
+            (tokens, HO),
+            assumed_align=beta_dtype.width // 8,
+            use_int64_offsets=use_int64_offsets,
+        ),
+        make_cu_seqlens_signature(sequence_entries),
+        tma_tensor(cutlass.Float32, (sequences, HO, 128, 128)) if use_dstate0 else None,
+        tma_tensor(cutlass.Float32, (sequences, HO, 128, 128)) if use_dstate_in else None,
+        make_work_items_signature(work_rows),
+        make_counter_signature(),
+        make_counter_signature(sched_entries) if dyn_sched else None,
+        make_workspace_signature(workspace_words),
+        cutlass.Float32(scale),
+    )
+
+
+@jit_cache(extra_sources=(Path(__file__).parent,))
+def _compile_kda_bprop_prologue(
+    io_dtype: type[cutlass.Numeric],
+    HQ: int,
+    HK: int,
+    HV: int,
+    HO: int,
     run_order: bool,
     order_gen: bool,
+    has_sched: bool,
+    dyn_sched: bool,
     use_int64_offsets: bool,
-    device_index: int,
-    device_major: int,
-    device_minor: int,
-    num_sm: int,
 ):
-    return {}
+    """JIT-compile the prologue from static specialization arguments."""
+    sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
+    tokens, checkpoint_rows, sequence_entries, work_rows, sched_entries, workspace_words = (
+        sym_int() for _ in range(6)
+    )
+
+    tma_tensor = partial(
+        make_strided_signature_tensor,
+        assumed_align=16,
+        use_int64_offsets=use_int64_offsets,
+    )
+    work_items_signature = make_work_items_signature(work_rows)
+    return compile_tvm_ffi(
+        prologue,
+        io_dtype,
+        CFG.B_T,
+        run_order,
+        order_gen,
+        has_sched,
+        tma_tensor(io_dtype, (tokens, HQ, 128)),
+        tma_tensor(io_dtype, (tokens, HK, 128)),
+        tma_tensor(io_dtype, (tokens, HV, 128)),
+        tma_tensor(cutlass.Float32, (tokens, HO, 128)),
+        tma_tensor(io_dtype, (tokens, HO, 128)),
+        tma_tensor(io_dtype, (tokens, HQ, 128)),
+        tma_tensor(io_dtype, (tokens, HK, 128)),
+        tma_tensor(io_dtype, (tokens, HV, 128)),
+        tma_tensor(cutlass.Float32, (tokens, HO, 128)),
+        tma_tensor(io_dtype, (checkpoint_rows, HO, 128, 128)),
+        make_cu_seqlens_signature(sequence_entries),
+        work_items_signature if run_order and not order_gen else None,
+        make_counter_signature(),
+        work_items_signature,
+        make_counter_signature(sched_entries) if has_sched else None,
+        make_workspace_signature(workspace_words),
+        name=(
+            f"kda_mega_bprop_prologue_{io_dtype.__name__.lower()}"
+            f"_hq{HQ}_hk{HK}_hv{HV}_ho{HO}_r{int(run_order)}"
+            f"o{int(order_gen)}d{int(dyn_sched)}_i64{int(use_int64_offsets)}"
+        ),
+    )
 
 
 def chunk_kda_bwd_sm100(
@@ -4324,139 +4468,39 @@ def chunk_kda_bwd_sm100(
         raise ValueError("the active CUDA device must match q.device")
     device_properties = get_device_properties(device_index)
     num_sm = device_properties.multi_processor_count
-    cache = get_compiled_cache(
-        str(q.dtype),
+    io_dtype = get_dtype(q.dtype)
+    compiled = _compile_kda_bprop(
+        io_dtype,
         HQ,
         HK,
         HV,
+        HO,
         use_dstate_in,
         use_dstate0,
         use_qk_l2norm_in_kernel,
         safe_gate,
-        gate_lower_bound,
+        gate_scale_log2,
         use_beta_sigmoid,
         use_initial_state,
         dyn_sched,
-        run_order,
-        order_gen,
         use_int64_offsets,
-        device_index,
-        device_properties.major,
-        device_properties.minor,
         num_sm,
+        scale,
     )
 
-    io_dtype = get_dtype(q.dtype)
-    sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
-    if "compiled" not in cache:
-        cfg = build_cfg(
-            io_dtype,
-            use_dstate_in=use_dstate_in,
-            use_dstate0=use_dstate0,
-            l2norm=use_qk_l2norm_in_kernel,
-            safe_gate=safe_gate,
-            gate_scale_log2=gate_scale_log2,
-            beta_sigmoid=use_beta_sigmoid,
-            use_initial_state=use_initial_state,
-            q_ratio=HO // HQ,
-            k_ratio=HO // HK,
-            v_ratio=HO // HV,
-            n_heads_out=HO,
-            max_active_clusters=num_sm,
-            dyn_sched=dyn_sched,
-        )
-        op = KdaBpropOp(cfg, use_int64_offsets)
-        (
-            tokens,
-            checkpoint_rows,
-            sequence_entries,
-            sequences,
-            work_rows,
-            sched_entries,
-            workspace_words,
-        ) = (sym_int() for _ in range(7))
-
-        tma_tensor = partial(
-            make_strided_signature_tensor,
-            assumed_align=16,
-            use_int64_offsets=use_int64_offsets,
-        )
-        beta_dtype = io_dtype if use_beta_sigmoid else cutlass.Float32
-        cache["compiled"] = compile_tvm_ffi(
-            op,
-            make_compact_signature_tensor(
-                cutlass.Float32,
-                (HO,),
-                assumed_align=4,
-            )
-            if safe_gate
-            else None,
-            tma_tensor(cutlass.Float32, (HO, 128)) if safe_gate else None,
-            make_strided_signature_tensor(
-                beta_dtype,
-                (tokens, HO),
-                assumed_align=beta_dtype.width // 8,
-                use_int64_offsets=use_int64_offsets,
-            ),
-            tma_tensor(io_dtype, (checkpoint_rows, HO, 128, 128)),
-            tma_tensor(cutlass.Float32, (tokens, HO, 128)),
-            make_strided_signature_tensor(
-                beta_dtype,
-                (tokens, HO),
-                assumed_align=beta_dtype.width // 8,
-                use_int64_offsets=use_int64_offsets,
-            ),
-            make_cu_seqlens_signature(sequence_entries),
-            tma_tensor(cutlass.Float32, (sequences, HO, 128, 128)) if use_dstate0 else None,
-            tma_tensor(cutlass.Float32, (sequences, HO, 128, 128)) if use_dstate_in else None,
-            make_work_items_signature(work_rows),
-            make_counter_signature(),
-            make_counter_signature(sched_entries) if dyn_sched else None,
-            make_workspace_signature(workspace_words),
-            cutlass.Float32(scale),
-        )
-
-    if "prologue" not in cache:
-        tokens, checkpoint_rows, sequence_entries, work_rows, sched_entries, workspace_words = (
-            sym_int() for _ in range(6)
-        )
-
-        tma_tensor = partial(
-            make_strided_signature_tensor,
-            assumed_align=16,
-            use_int64_offsets=use_int64_offsets,
-        )
-        work_items_signature = make_work_items_signature(work_rows)
-        cache["prologue"] = compile_tvm_ffi(
-            prologue,
-            io_dtype,
-            CFG.B_T,
-            run_order,
-            order_gen,
-            has_sched,
-            tma_tensor(io_dtype, (tokens, HQ, 128)),
-            tma_tensor(io_dtype, (tokens, HK, 128)),
-            tma_tensor(io_dtype, (tokens, HV, 128)),
-            tma_tensor(cutlass.Float32, (tokens, HO, 128)),
-            tma_tensor(io_dtype, (tokens, HO, 128)),
-            tma_tensor(io_dtype, (tokens, HQ, 128)),
-            tma_tensor(io_dtype, (tokens, HK, 128)),
-            tma_tensor(io_dtype, (tokens, HV, 128)),
-            tma_tensor(cutlass.Float32, (tokens, HO, 128)),
-            tma_tensor(io_dtype, (checkpoint_rows, HO, 128, 128)),
-            make_cu_seqlens_signature(sequence_entries),
-            work_items_signature if run_order and not order_gen else None,
-            make_counter_signature(),
-            work_items_signature,
-            make_counter_signature(sched_entries) if has_sched else None,
-            make_workspace_signature(workspace_words),
-            name=(
-                f"kda_mega_bprop_prologue_{io_dtype.__name__.lower()}"
-                f"_hq{HQ}_hk{HK}_hv{HV}_ho{HO}_r{int(run_order)}"
-                f"o{int(order_gen)}d{int(dyn_sched)}_i64{int(use_int64_offsets)}"
-            ),
-        )
-    cache["prologue"](
+    compiled_prologue = _compile_kda_bprop_prologue(
+        io_dtype,
+        HQ,
+        HK,
+        HV,
+        HO,
+        run_order,
+        order_gen,
+        has_sched,
+        dyn_sched,
+        use_int64_offsets,
+    )
+    compiled_prologue(
         q,
         k,
         v,
@@ -4474,7 +4518,7 @@ def chunk_kda_bwd_sm100(
         sched_all if run_order else None,
         tensormap_workspace,
     )
-    cache["compiled"](
+    compiled(
         a_log,
         dt_bias,
         beta,

--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_prefill_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_prefill_f16.py
@@ -86,8 +86,9 @@ GEMM schedule (tcgen05-MMA warp, in issue order per chunk):
 Requires the public CuTeDSL 4.7 API, including `cutlass.experimental.*`.
 """
 
-from dataclasses import dataclass
-from functools import lru_cache, partial
+from dataclasses import dataclass, replace
+from functools import partial
+from pathlib import Path
 from typing import NamedTuple, Type
 
 import cuda.bindings.driver as cuda_driver
@@ -97,7 +98,7 @@ import cutlass.experimental.cuda as cuda
 import cutlass.experimental.primitives as nvvm
 import cutlass.cute as cute
 
-from attn_gym._backends.cute import compile_tvm_ffi
+from attn_gym._backends.cute import compile_tvm_ffi, jit_cache
 from attn_gym._backends.cute.utils import get_device_properties, requires_int64_abi, validate_tma_tensor
 
 from .common.split_k import ORDER_CAPACITY, ORDER_ELEMS, ORDER_THREADS, decode_work_item, order_body
@@ -2367,7 +2368,7 @@ def kernel(
         )
 
 
-@dataclass
+@dataclass(frozen=True)
 class KdaCfg:
     """Kernel cfg (fixed BT=16 schedule constants; derived TMEM column offsets
     and SMEM buffer cosizes are stamped by ``build_cfg``; per-stage sizes are
@@ -2477,7 +2478,9 @@ def build_cfg(
     """Build the per-compile ``KdaCfg`` (io_dtype in {Float16, BFloat16});
     fills the derived TMEM column offsets and SMEM buffer cosizes."""
     if io_dtype not in (cutlass.Float16, cutlass.BFloat16):
-        raise ValueError(f"io_dtype={io_dtype} not supported; only Float16 and BFloat16 are supported")
+        raise ValueError(
+            f"io_dtype={io_dtype} not supported; only Float16 and BFloat16 are supported"
+        )
     if paged_state and not (use_initial_state and store_final_state):
         raise ValueError("paged_state requires an aliased input/output state pool")
     cfg = KdaCfg(
@@ -2498,7 +2501,7 @@ def build_cfg(
         max_active_clusters=max_active_clusters,
         dyn_sched=dyn_sched,
     )
-    cfg.smem_raw_bar_stages = cfg.smem_raw_stages + (cfg.smem_raw_stages % 2)
+    smem_raw_bar_stages = cfg.smem_raw_stages + (cfg.smem_raw_stages % 2)
     role_ids = (
         *cfg.compute_group_0_warp_ids,
         *cfg.compute_group_1_warp_ids,
@@ -2512,57 +2515,66 @@ def build_cfg(
     for group in (cfg.compute_group_0_warp_ids, cfg.compute_group_1_warp_ids):
         if not group or group != tuple(range(group[0], group[-1] + 1)):
             raise ValueError("compute warp groups must be nonempty and use contiguous IDs")
-    cfg.threads_per_cta = len(role_ids) * cfg.threads_per_warp
     if cfg.cg0_warps_per_group != 4:
         raise ValueError("the fixed schedule requires four warps per compute group 0 subgroup")
     if len(cfg.compute_group_0_warp_ids) % cfg.cg0_warps_per_group:
         raise ValueError("compute group 0 must divide evenly into ping-pong warp groups")
-    cfg.cg0_group_count = len(cfg.compute_group_0_warp_ids) // cfg.cg0_warps_per_group
-    if cfg.cg0_group_count != 2:
+    cg0_group_count = len(cfg.compute_group_0_warp_ids) // cfg.cg0_warps_per_group
+    if cg0_group_count != 2:
         raise ValueError("the fixed schedule requires two compute group 0 ping-pong subgroups")
-    cfg.cg0_threads_per_group = cfg.cg0_warps_per_group * cfg.threads_per_warp
-    cfg.tmem_user_threads = (1 + len(cfg.compute_group_1_warp_ids)) * cfg.threads_per_warp
     named_barrier_ids = (
         *range(
             cfg.cg0_group_sync_barrier_base_id,
-            cfg.cg0_group_sync_barrier_base_id + cfg.cg0_group_count,
+            cfg.cg0_group_sync_barrier_base_id + cg0_group_count,
         ),
         cfg.tmem_lifecycle_barrier_id,
         cfg.cg0_tile_entry_barrier_id,
     )
-    if (
-        any(not 1 <= barrier_id <= 15 for barrier_id in named_barrier_ids)
-        or len(set(named_barrier_ids)) != len(named_barrier_ids)
-    ):
+    if any(not 1 <= barrier_id <= 15 for barrier_id in named_barrier_ids) or len(
+        set(named_barrier_ids)
+    ) != len(named_barrier_ids):
         raise ValueError("named barrier IDs must be disjoint values in [1, 15]")
     if cfg.smem_state_scale_diag_stages != cfg.qk_scale_ready_stages:
         raise ValueError("diag and qk-scale ready rings must share their rolling stage")
 
-    cfg.tmem_state_inp_offset = cfg.tmem_state_acc_offset + cfg.d_k
-    cfg.tmem_q_state_acc_offset = cfg.tmem_state_inp_offset + (cfg.d_k // 2)
-    cfg.tmem_state_k_acc_offset = cfg.tmem_q_state_acc_offset + cfg.tmem_q_state_acc_stages * cfg.b_t
-    cfg.tmem_u_acc_offset = cfg.tmem_state_k_acc_offset + cfg.b_t
-    cfg.tmem_y_inp_offset = cfg.tmem_u_acc_offset + cfg.b_t
-    cfg.tmem_u_inp_offset = cfg.tmem_y_inp_offset + (cfg.b_t // 2)
-    assert (cfg.tmem_u_inp_offset + (cfg.b_t // 2)) <= 512
+    tmem_state_inp_offset = cfg.tmem_state_acc_offset + cfg.d_k
+    tmem_q_state_acc_offset = tmem_state_inp_offset + (cfg.d_k // 2)
+    tmem_state_k_acc_offset = tmem_q_state_acc_offset + cfg.tmem_q_state_acc_stages * cfg.b_t
+    tmem_u_acc_offset = tmem_state_k_acc_offset + cfg.b_t
+    tmem_y_inp_offset = tmem_u_acc_offset + cfg.b_t
+    tmem_u_inp_offset = tmem_y_inp_offset + (cfg.b_t // 2)
+    assert (tmem_u_inp_offset + (cfg.b_t // 2)) <= 512
 
-    cfg.q_cosize = cfg.smem_raw_stages * cfg.d_k * cfg.b_t
-    cfg.k_cosize = cfg.smem_raw_stages * cfg.d_k * cfg.b_t
-    cfg.v_cosize = cfg.smem_raw_stages * cfg.d_v * cfg.b_t
-    cfg.gate_cosize = cfg.smem_raw_stages * cfg.d_k * cfg.b_t
-    cfg.beta_cosize = cfg.smem_raw_bar_stages * cfg.b_t
-    cfg.k_inv_cosize = cfg.smem_decay_stages * cfg.b_t * cfg.d_k
-    cfg.k_decay_cosize = cfg.smem_decay_stages * cfg.d_k * cfg.b_t
-    cfg.q_decay_cosize = cfg.smem_decay_stages * cfg.d_k * cfg.b_t
-    cfg.k_restore_cosize = cfg.smem_decay_stages * cfg.d_k * cfg.b_t
-    cfg.state_scale_diag_cosize = cfg.smem_state_scale_diag_stages * (cfg.d_k // 16) * 256
-    cfg.o_cosize = cfg.smem_o_stages * cfg.b_t * cfg.d_v
-    cfg.intermediate_cosize = cfg.smem_intermediate_stages * 2 * cfg.b_t * cfg.b_t
-    cfg.tma_q_bytes = cfg.d_k * cfg.b_t * (cfg.io_dtype.width // 8)
-    cfg.tma_k_bytes = cfg.d_k * cfg.b_t * (cfg.io_dtype.width // 8)
-    cfg.tma_v_bytes = cfg.d_v * cfg.b_t * (cfg.io_dtype.width // 8)
-    cfg.tma_gate_bytes = cfg.d_k * cfg.b_t * 4
-    return cfg
+    return replace(
+        cfg,
+        smem_raw_bar_stages=smem_raw_bar_stages,
+        threads_per_cta=len(role_ids) * cfg.threads_per_warp,
+        cg0_group_count=cg0_group_count,
+        cg0_threads_per_group=cfg.cg0_warps_per_group * cfg.threads_per_warp,
+        tmem_user_threads=(1 + len(cfg.compute_group_1_warp_ids)) * cfg.threads_per_warp,
+        tmem_state_inp_offset=tmem_state_inp_offset,
+        tmem_q_state_acc_offset=tmem_q_state_acc_offset,
+        tmem_state_k_acc_offset=tmem_state_k_acc_offset,
+        tmem_u_acc_offset=tmem_u_acc_offset,
+        tmem_y_inp_offset=tmem_y_inp_offset,
+        tmem_u_inp_offset=tmem_u_inp_offset,
+        q_cosize=cfg.smem_raw_stages * cfg.d_k * cfg.b_t,
+        k_cosize=cfg.smem_raw_stages * cfg.d_k * cfg.b_t,
+        v_cosize=cfg.smem_raw_stages * cfg.d_v * cfg.b_t,
+        gate_cosize=cfg.smem_raw_stages * cfg.d_k * cfg.b_t,
+        beta_cosize=smem_raw_bar_stages * cfg.b_t,
+        k_inv_cosize=cfg.smem_decay_stages * cfg.b_t * cfg.d_k,
+        k_decay_cosize=cfg.smem_decay_stages * cfg.d_k * cfg.b_t,
+        q_decay_cosize=cfg.smem_decay_stages * cfg.d_k * cfg.b_t,
+        k_restore_cosize=cfg.smem_decay_stages * cfg.d_k * cfg.b_t,
+        state_scale_diag_cosize=cfg.smem_state_scale_diag_stages * (cfg.d_k // 16) * 256,
+        o_cosize=cfg.smem_o_stages * cfg.b_t * cfg.d_v,
+        intermediate_cosize=cfg.smem_intermediate_stages * 2 * cfg.b_t * cfg.b_t,
+        tma_q_bytes=cfg.d_k * cfg.b_t * (cfg.io_dtype.width // 8),
+        tma_k_bytes=cfg.d_k * cfg.b_t * (cfg.io_dtype.width // 8),
+        tma_v_bytes=cfg.d_v * cfg.b_t * (cfg.io_dtype.width // 8),
+        tma_gate_bytes=cfg.d_k * cfg.b_t * 4,
+    )
 
 
 TENSORMAP_DESC_ARRAYS = 5  # per-batch runtime TMA descriptors: Q, K, V, Gate, O
@@ -2809,34 +2821,8 @@ def prologue(
 # ---- Torch adapter / host-side compilation ---------------------------------------
 
 
-@lru_cache(maxsize=None)
-def get_compiled_cache(
-    io_dtype_str: str,
-    state_dtype_str: str,
-    HQ: int,
-    HK: int,
-    HV: int,
-    use_initial_state: bool,
-    store_final_state: bool,
-    l2norm: bool,
-    safe_gate: bool,
-    gate_lower_bound: float,
-    beta_sigmoid: bool,
-    dyn_sched: bool,
-    order_gen: bool,
-    use_int64_offsets: bool,
-    paged_state: bool,
-    has_initial_state_mask: bool,
-    device_index: int,
-    device_major: int,
-    device_minor: int,
-    num_sm: int,
-):
-    """Return a mutable dict that lazily stores the compiled kernel."""
-    return {}
-
-
-def compile(
+@jit_cache(extra_sources=(Path(__file__).parent,))
+def _compile_kda_prefill(
     io_dtype,
     state_dtype,
     use_initial_state: bool,
@@ -2938,6 +2924,55 @@ def compile(
         make_counter_signature(sched_entries) if dyn_sched else None,
         make_workspace_signature(workspace_words),
         cutlass.Float32(scale),
+    )
+
+
+@jit_cache(extra_sources=(Path(__file__).parent,))
+def _compile_kda_prefill_prologue(
+    io_dtype: type[cutlass.Numeric],
+    HQ: int,
+    HK: int,
+    HV: int,
+    HO: int,
+    order_gen: bool,
+    has_sched: bool,
+    dyn_sched: bool,
+    use_int64_offsets: bool,
+):
+    """JIT-compile the prologue from static specialization arguments."""
+    sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
+    tokens, sequence_entries, work_rows, sched_entries, workspace_words = (
+        sym_int() for _ in range(5)
+    )
+
+    tma_tensor = partial(
+        make_strided_signature_tensor,
+        assumed_align=16,
+        use_int64_offsets=use_int64_offsets,
+    )
+    work_items_signature = make_work_items_signature(work_rows)
+    return compile_tvm_ffi(
+        prologue,
+        io_dtype,
+        CFG.B_T,
+        order_gen,
+        has_sched,
+        tma_tensor(io_dtype, (tokens, HQ, 128)),
+        tma_tensor(io_dtype, (tokens, HK, 128)),
+        tma_tensor(io_dtype, (tokens, HV, 128)),
+        tma_tensor(cutlass.Float32, (tokens, HO, 128)),
+        tma_tensor(io_dtype, (tokens, HO, 128)),
+        make_cu_seqlens_signature(sequence_entries),
+        work_items_signature if not order_gen else None,
+        make_counter_signature(),
+        work_items_signature,
+        make_counter_signature(sched_entries) if has_sched else None,
+        make_workspace_signature(workspace_words),
+        name=(
+            f"kda_mega_prefill_prologue_{io_dtype.__name__.lower()}"
+            f"_hq{HQ}_hk{HK}_hv{HV}_ho{HO}"
+            f"_o{int(order_gen)}d{int(dyn_sched)}_i64{int(use_int64_offsets)}"
+        ),
     )
 
 
@@ -3089,88 +3124,40 @@ def chunk_kda_sm100(
         raise ValueError("the active CUDA device must match q.device")
     device_properties = get_device_properties(device_index)
     num_sm = device_properties.multi_processor_count
-    cache = get_compiled_cache(
-        str(q.dtype),
-        str(state_dtype_src),
-        HQ,
-        HK,
-        HV,
+    io_dtype = get_dtype(q.dtype)
+    compiled = _compile_kda_prefill(
+        io_dtype,
+        get_dtype(state_dtype_src),
         use_initial_state,
         store_final_state,
         use_qk_l2norm_in_kernel,
         safe_gate,
-        gate_lower_bound,
+        gate_scale_log2,
         use_beta_sigmoid_in_kernel,
+        q_ratio,
+        k_ratio,
+        v_ratio,
+        HO,
         dyn_sched,
-        order_gen,
         use_int64_offsets,
-        paged_state,
-        has_initial_state_mask,
-        device_index,
-        device_properties.major,
-        device_properties.minor,
-        num_sm,
+        num_sm=num_sm,
+        scale=scale,
+        paged_state=paged_state,
+        has_initial_state_mask=has_initial_state_mask,
     )
 
-    io_dtype = get_dtype(q.dtype)
-    if "compiled" not in cache:
-        cache["compiled"] = compile(
-            io_dtype,
-            get_dtype(state_dtype_src),
-            use_initial_state,
-            store_final_state,
-            use_qk_l2norm_in_kernel,
-            safe_gate,
-            gate_scale_log2,
-            use_beta_sigmoid_in_kernel,
-            q_ratio,
-            k_ratio,
-            v_ratio,
-            HO,
-            dyn_sched,
-            use_int64_offsets,
-            num_sm=num_sm,
-            scale=scale,
-            paged_state=paged_state,
-            has_initial_state_mask=has_initial_state_mask,
-        )
-
-    if "prologue" not in cache:
-        sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
-        tokens, sequence_entries, work_rows, sched_entries, workspace_words = (
-            sym_int() for _ in range(5)
-        )
-
-        tma_tensor = partial(
-            make_strided_signature_tensor,
-            assumed_align=16,
-            use_int64_offsets=use_int64_offsets,
-        )
-        work_items_signature = make_work_items_signature(work_rows)
-        cache["prologue"] = compile_tvm_ffi(
-            prologue,
-            io_dtype,
-            CFG.B_T,
-            order_gen,
-            has_sched,
-            tma_tensor(io_dtype, (tokens, HQ, 128)),
-            tma_tensor(io_dtype, (tokens, HK, 128)),
-            tma_tensor(io_dtype, (tokens, HV, 128)),
-            tma_tensor(cutlass.Float32, (tokens, HO, 128)),
-            tma_tensor(io_dtype, (tokens, HO, 128)),
-            make_cu_seqlens_signature(sequence_entries),
-            work_items_signature if not order_gen else None,
-            make_counter_signature(),
-            work_items_signature,
-            make_counter_signature(sched_entries) if has_sched else None,
-            make_workspace_signature(workspace_words),
-            name=(
-                f"kda_mega_prefill_prologue_{io_dtype.__name__.lower()}"
-                f"_hq{HQ}_hk{HK}_hv{HV}_ho{HO}"
-                f"_o{int(order_gen)}d{int(dyn_sched)}_i64{int(use_int64_offsets)}"
-            ),
-        )
-    cache["prologue"](
+    compiled_prologue = _compile_kda_prefill_prologue(
+        io_dtype,
+        HQ,
+        HK,
+        HV,
+        HO,
+        order_gen,
+        has_sched,
+        dyn_sched,
+        use_int64_offsets,
+    )
+    compiled_prologue(
         q,
         k,
         v,
@@ -3183,7 +3170,7 @@ def chunk_kda_sm100(
         sched_ctr,
         tensormap_workspace,
     )
-    cache["compiled"](
+    compiled(
         q,
         k,
         v,

--- a/attn_gym/linear/_delta_rule/mega/kernels/kda_recompute_f16.py
+++ b/attn_gym/linear/_delta_rule/mega/kernels/kda_recompute_f16.py
@@ -83,8 +83,9 @@ GEMM schedule (tcgen05-MMA warp, in issue order per chunk):
 Requires the public CuTeDSL 4.7 API, including `cutlass.experimental.*`.
 """
 
-from dataclasses import dataclass
-from functools import lru_cache, partial
+from dataclasses import dataclass, replace
+from functools import partial
+from pathlib import Path
 from typing import NamedTuple, Type
 
 import cuda.bindings.driver as cuda_driver
@@ -94,7 +95,7 @@ import cutlass.experimental.cuda as cuda
 import cutlass.experimental.primitives as nvvm
 import cutlass.cute as cute
 
-from attn_gym._backends.cute import compile_tvm_ffi
+from attn_gym._backends.cute import compile_tvm_ffi, jit_cache
 from attn_gym._backends.cute.utils import get_device_properties, requires_int64_abi, validate_tma_tensor
 from attn_gym.linear._delta_rule.mega.kernels.common.split_k import ORDER_CAPACITY, ORDER_ELEMS, ORDER_THREADS, decode_work_item, order_body
 from attn_gym.linear._delta_rule.mega.kernels.common.host import checkpoint_capacity_bound, get_dtype
@@ -2112,7 +2113,7 @@ def kernel(
         )
 
 
-@dataclass
+@dataclass(frozen=True)
 class KdaRecomputeCfg:
     """Kernel cfg (fixed BT=16 schedule constants; derived TMEM column offsets
     and SMEM buffer cosizes are stamped by ``build_cfg``; per-stage sizes are
@@ -2213,7 +2214,9 @@ def build_cfg(
     """Build the per-compile ``KdaRecomputeCfg`` (io_dtype in {Float16, BFloat16});
     fills the derived TMEM column offsets and SMEM buffer cosizes."""
     if io_dtype not in (cutlass.Float16, cutlass.BFloat16):
-        raise ValueError(f"io_dtype={io_dtype} not supported; only Float16 and BFloat16 are supported")
+        raise ValueError(
+            f"io_dtype={io_dtype} not supported; only Float16 and BFloat16 are supported"
+        )
     cfg = KdaRecomputeCfg(
         io_dtype=io_dtype,
         state_dtype=state_dtype,
@@ -2232,10 +2235,11 @@ def build_cfg(
         transition_only=transition_only,
     )
     if enable_checkpoints:
-        cfg.smem_raw_stages = 6
-        cfg.smem_checkpoint_stages = 2
+        cfg = replace(cfg, smem_raw_stages=6, smem_checkpoint_stages=2)
     if cfg.smem_raw_stages % 2 != 0:
-        raise ValueError("smem_raw_stages must be even: the CG0 ping-pong groups alias parity waits on odd rings")
+        raise ValueError(
+            "smem_raw_stages must be even: the CG0 ping-pong groups alias parity waits on odd rings"
+        )
     role_ids = (
         *cfg.compute_group_0_warp_ids,
         *cfg.compute_group_1_warp_ids,
@@ -2253,48 +2257,55 @@ def build_cfg(
         raise ValueError("the fixed schedule requires four warps per compute group 0 subgroup")
     if len(cfg.compute_group_0_warp_ids) % cfg.cg0_warps_per_group:
         raise ValueError("compute group 0 must divide evenly into ping-pong warp groups")
-    cfg.cg0_group_count = len(cfg.compute_group_0_warp_ids) // cfg.cg0_warps_per_group
-    if cfg.cg0_group_count != 2:
+    cg0_group_count = len(cfg.compute_group_0_warp_ids) // cfg.cg0_warps_per_group
+    if cg0_group_count != 2:
         raise ValueError("the fixed schedule requires two compute group 0 ping-pong subgroups")
-    cfg.threads_per_cta = len(role_ids) * cfg.threads_per_warp
-    cfg.cg0_threads_per_group = cfg.cg0_warps_per_group * cfg.threads_per_warp
-    cfg.tmem_user_threads = (1 + len(cfg.compute_group_1_warp_ids)) * cfg.threads_per_warp
     named_barrier_ids = (
         *range(
             cfg.cg0_group_sync_barrier_base_id,
-            cfg.cg0_group_sync_barrier_base_id + cfg.cg0_group_count,
+            cfg.cg0_group_sync_barrier_base_id + cg0_group_count,
         ),
         cfg.tmem_lifecycle_barrier_id,
         cfg.cg0_tile_entry_barrier_id,
     )
-    if (
-        any(not 1 <= barrier_id <= 15 for barrier_id in named_barrier_ids)
-        or len(set(named_barrier_ids)) != len(named_barrier_ids)
-    ):
+    if any(not 1 <= barrier_id <= 15 for barrier_id in named_barrier_ids) or len(
+        set(named_barrier_ids)
+    ) != len(named_barrier_ids):
         raise ValueError("named barrier IDs must be disjoint values in [1, 15]")
     if cfg.smem_state_scale_diag_stages != cfg.qk_scale_ready_stages:
         raise ValueError("diag and qk-scale ready rings must share their rolling stage")
 
-    cfg.tmem_state_inp_offset = cfg.tmem_state_acc_offset + cfg.d_k
-    cfg.tmem_state_k_acc_offset = cfg.tmem_state_inp_offset + (cfg.d_k // 2)
-    cfg.tmem_u_acc_offset = cfg.tmem_state_k_acc_offset + cfg.b_t
-    cfg.tmem_y_inp_offset = cfg.tmem_u_acc_offset + cfg.b_t
-    cfg.tmem_u_inp_offset = cfg.tmem_y_inp_offset + (cfg.b_t // 2)
-    assert (cfg.tmem_u_inp_offset + (cfg.b_t // 2)) <= 512
+    tmem_state_inp_offset = cfg.tmem_state_acc_offset + cfg.d_k
+    tmem_state_k_acc_offset = tmem_state_inp_offset + (cfg.d_k // 2)
+    tmem_u_acc_offset = tmem_state_k_acc_offset + cfg.b_t
+    tmem_y_inp_offset = tmem_u_acc_offset + cfg.b_t
+    tmem_u_inp_offset = tmem_y_inp_offset + (cfg.b_t // 2)
+    assert (tmem_u_inp_offset + (cfg.b_t // 2)) <= 512
 
-    cfg.k_cosize = cfg.smem_raw_stages * cfg.d_k * cfg.b_t
-    cfg.v_cosize = 0 if transition_only else cfg.smem_raw_stages * cfg.d_v * cfg.b_t
-    cfg.gate_cosize = cfg.smem_raw_stages * cfg.d_k * cfg.b_t
-    cfg.beta_cosize = cfg.smem_raw_stages * cfg.b_t
-    cfg.k_inv_cosize = cfg.smem_decay_stages * cfg.b_t * cfg.d_k
-    cfg.k_decay_cosize = cfg.smem_decay_stages * cfg.d_k * cfg.b_t
-    cfg.k_restore_cosize = cfg.smem_decay_stages * cfg.d_k * cfg.b_t
-    cfg.state_scale_diag_cosize = cfg.smem_state_scale_diag_stages * (cfg.d_k // 16) * 256
-    cfg.intermediate_cosize = cfg.smem_intermediate_stages * 2 * cfg.b_t * cfg.b_t
-    cfg.tma_k_bytes = cfg.d_k * cfg.b_t * (cfg.io_dtype.width // 8)
-    cfg.tma_v_bytes = cfg.d_v * cfg.b_t * (cfg.io_dtype.width // 8)
-    cfg.tma_gate_bytes = cfg.d_k * cfg.b_t * 4
-    return cfg
+    return replace(
+        cfg,
+        cg0_group_count=cg0_group_count,
+        threads_per_cta=len(role_ids) * cfg.threads_per_warp,
+        cg0_threads_per_group=cfg.cg0_warps_per_group * cfg.threads_per_warp,
+        tmem_user_threads=(1 + len(cfg.compute_group_1_warp_ids)) * cfg.threads_per_warp,
+        tmem_state_inp_offset=tmem_state_inp_offset,
+        tmem_state_k_acc_offset=tmem_state_k_acc_offset,
+        tmem_u_acc_offset=tmem_u_acc_offset,
+        tmem_y_inp_offset=tmem_y_inp_offset,
+        tmem_u_inp_offset=tmem_u_inp_offset,
+        k_cosize=cfg.smem_raw_stages * cfg.d_k * cfg.b_t,
+        v_cosize=0 if transition_only else cfg.smem_raw_stages * cfg.d_v * cfg.b_t,
+        gate_cosize=cfg.smem_raw_stages * cfg.d_k * cfg.b_t,
+        beta_cosize=cfg.smem_raw_stages * cfg.b_t,
+        k_inv_cosize=cfg.smem_decay_stages * cfg.b_t * cfg.d_k,
+        k_decay_cosize=cfg.smem_decay_stages * cfg.d_k * cfg.b_t,
+        k_restore_cosize=cfg.smem_decay_stages * cfg.d_k * cfg.b_t,
+        state_scale_diag_cosize=cfg.smem_state_scale_diag_stages * (cfg.d_k // 16) * 256,
+        intermediate_cosize=cfg.smem_intermediate_stages * 2 * cfg.b_t * cfg.b_t,
+        tma_k_bytes=cfg.d_k * cfg.b_t * (cfg.io_dtype.width // 8),
+        tma_v_bytes=cfg.d_v * cfg.b_t * (cfg.io_dtype.width // 8),
+        tma_gate_bytes=cfg.d_k * cfg.b_t * 4,
+    )
 
 
 TENSORMAP_DESC_ARRAYS = 4  # per-batch runtime TMA descriptors: K, V, Gate, state_checkpoints
@@ -2525,35 +2536,8 @@ def prologue(
 # ---- Torch adapter / host-side compilation ---------------------------------------
 
 
-@lru_cache(maxsize=None)
-def get_compiled_cache(
-    io_dtype_str: str,
-    state_dtype_str: str,
-    HO: int,
-    HK: int,
-    HV: int,
-    use_initial_state: bool,
-    store_final_state: bool,
-    enable_checkpoints: bool,
-    l2norm: bool,
-    safe_gate: bool,
-    gate_lower_bound: float,
-    beta_sigmoid: bool,
-    dyn_sched: bool,
-    run_order: bool,
-    order_gen: bool,
-    use_int64_offsets: bool,
-    device_index: int,
-    device_major: int,
-    device_minor: int,
-    num_sm: int,
-    transition_only: bool = False,
-):
-    """Return a mutable dict that lazily stores the compiled kernel."""
-    return {}
-
-
-def compile(
+@jit_cache(extra_sources=(Path(__file__).parent,))
+def _compile_kda_recompute(
     io_dtype,
     state_dtype,
     use_initial_state: bool,
@@ -2630,6 +2614,61 @@ def compile(
         make_counter_signature(sched_entries) if dyn_sched else None,
         make_workspace_signature(workspace_words),
         cutlass.Int32(checkpoint_every_n_tokens),
+    )
+
+
+@jit_cache(extra_sources=(Path(__file__).parent,))
+def _compile_kda_recompute_prologue(
+    io_dtype: type[cutlass.Numeric],
+    HK: int,
+    HV: int,
+    HO: int,
+    enable_checkpoints: bool,
+    run_order: bool,
+    order_gen: bool,
+    has_sched: bool,
+    dyn_sched: bool,
+    checkpoint_every_n_tokens: int,
+    use_int64_offsets: bool,
+):
+    """JIT-compile the prologue from static specialization arguments."""
+    sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
+    tokens, sequence_entries, checkpoint_rows, work_rows, sched_entries, workspace_words = (
+        sym_int() for _ in range(6)
+    )
+
+    tma_tensor = partial(
+        make_strided_signature_tensor,
+        assumed_align=16,
+        use_int64_offsets=use_int64_offsets,
+    )
+    work_items_signature = make_work_items_signature(work_rows)
+    return compile_tvm_ffi(
+        prologue,
+        io_dtype,
+        CFG.B_T,
+        run_order,
+        order_gen,
+        has_sched,
+        tma_tensor(io_dtype, (tokens, HK, 128)),
+        tma_tensor(io_dtype, (tokens, HV, 128)),
+        tma_tensor(cutlass.Float32, (tokens, HO, 128)),
+        tma_tensor(io_dtype, (checkpoint_rows, HO, 128, 128))
+        if enable_checkpoints
+        else None,
+        make_cu_seqlens_signature(sequence_entries),
+        work_items_signature if run_order and not order_gen else None,
+        make_counter_signature(),
+        work_items_signature,
+        make_counter_signature(sched_entries) if has_sched else None,
+        make_workspace_signature(workspace_words),
+        cutlass.Int32(checkpoint_every_n_tokens),
+        name=(
+            f"kda_mega_recompute_prologue_{io_dtype.__name__.lower()}"
+            f"_hk{HK}_hv{HV}_ho{HO}_c{int(enable_checkpoints)}"
+            f"_r{int(run_order)}o{int(order_gen)}d{int(dyn_sched)}"
+            f"_i64{int(use_int64_offsets)}"
+        ),
     )
 
 
@@ -2804,92 +2843,41 @@ def chunk_kda_recompute_sm100(
     device_properties = get_device_properties(device_index)
     num_sm = device_properties.multi_processor_count
 
-    cache = get_compiled_cache(
-        str(k.dtype),
-        str(state_dtype_src),
-        HO,
-        HK,
-        HV,
+    io_dtype = get_dtype(k.dtype)
+    compiled = _compile_kda_recompute(
+        io_dtype,
+        get_dtype(state_dtype_src),
         use_initial_state,
         store_final_state,
         enable_checkpoints,
         use_qk_l2norm_in_kernel,
         safe_gate,
-        gate_lower_bound,
+        gate_scale_log2,
         use_beta_sigmoid,
+        k_ratio,
+        v_ratio,
+        HO,
         dyn_sched,
-        run_order,
-        order_gen,
         use_int64_offsets,
-        device_index,
-        device_properties.major,
-        device_properties.minor,
-        num_sm,
-        transition_only,
+        num_sm=num_sm,
+        checkpoint_every_n_tokens=checkpoint_every_n_tokens,
+        transition_only=transition_only,
     )
 
-    io_dtype = get_dtype(k.dtype)
-    if "compiled" not in cache:
-        cache["compiled"] = compile(
-            io_dtype,
-            get_dtype(state_dtype_src),
-            use_initial_state,
-            store_final_state,
-            enable_checkpoints,
-            use_qk_l2norm_in_kernel,
-            safe_gate,
-            gate_scale_log2,
-            use_beta_sigmoid,
-            k_ratio,
-            v_ratio,
-            HO,
-            dyn_sched,
-            use_int64_offsets,
-            num_sm=num_sm,
-            checkpoint_every_n_tokens=checkpoint_every_n_tokens,
-            transition_only=transition_only,
-        )
-
-    if "prologue" not in cache:
-        sym_int = cute.sym_int64 if use_int64_offsets else cute.sym_int
-        tokens, sequence_entries, checkpoint_rows, work_rows, sched_entries, workspace_words = (
-            sym_int() for _ in range(6)
-        )
-
-        tma_tensor = partial(
-            make_strided_signature_tensor,
-            assumed_align=16,
-            use_int64_offsets=use_int64_offsets,
-        )
-        work_items_signature = make_work_items_signature(work_rows)
-        cache["prologue"] = compile_tvm_ffi(
-            prologue,
-            io_dtype,
-            CFG.B_T,
-            run_order,
-            order_gen,
-            has_sched,
-            tma_tensor(io_dtype, (tokens, HK, 128)),
-            tma_tensor(io_dtype, (tokens, HV, 128)),
-            tma_tensor(cutlass.Float32, (tokens, HO, 128)),
-            tma_tensor(io_dtype, (checkpoint_rows, HO, 128, 128))
-            if state_checkpoints_for_descs is not None
-            else None,
-            make_cu_seqlens_signature(sequence_entries),
-            work_items_signature if run_order and not order_gen else None,
-            make_counter_signature(),
-            work_items_signature,
-            make_counter_signature(sched_entries) if has_sched else None,
-            make_workspace_signature(workspace_words),
-            cutlass.Int32(checkpoint_every_n_tokens),
-            name=(
-                f"kda_mega_recompute_prologue_{io_dtype.__name__.lower()}"
-                f"_hk{HK}_hv{HV}_ho{HO}_c{int(enable_checkpoints)}"
-                f"_r{int(run_order)}o{int(order_gen)}d{int(dyn_sched)}"
-                f"_i64{int(use_int64_offsets)}"
-            ),
-        )
-    cache["prologue"](
+    compiled_prologue = _compile_kda_recompute_prologue(
+        io_dtype,
+        HK,
+        HV,
+        HO,
+        enable_checkpoints,
+        run_order,
+        order_gen,
+        has_sched,
+        dyn_sched,
+        checkpoint_every_n_tokens,
+        use_int64_offsets,
+    )
+    compiled_prologue(
         k,
         v,
         gate,
@@ -2902,7 +2890,7 @@ def chunk_kda_recompute_sm100(
         tensormap_workspace,
         checkpoint_every_n_tokens,
     )
-    cache["compiled"](
+    compiled(
         k,
         v,
         gate,


### PR DESCRIPTION
Stacked PRs:
 * #531
 * #529
 * #530
 * __->__#537


--- --- ---

Bring the Mega kernels onto the CuTeDSL kernel template and persist their compiles

Freeze Mega configurations, use class-based GDN entrypoints, and route launches directly through named persistent compile helpers. Cache main kernels and prologues while preserving tensor signatures, launch semantics, and kernel names.