### PR TITLE
Update Selected Attention to use attention sinks in the CuTe backend and added a scale parameter 

### DIFF
--- a/attn_gym/sparse/selected_attention/api.py
+++ b/attn_gym/sparse/selected_attention/api.py
@@ -179,6 +179,7 @@ def selected_attention(
     backend: str = ...,
     mode: str = ...,
     *,
+    scale: float | None = None,
     return_aux: None = ...,
 ) -> Tensor: ...
 
@@ -195,6 +196,7 @@ def selected_attention(
     backend: str = ...,
     mode: str = ...,
     *,
+    scale: float | None = None,
     return_aux: AuxRequest,
 ) -> tuple[Tensor, SelectedAttentionAux]: ...
 
@@ -210,6 +212,7 @@ def selected_attention(
     backend: str = "triton",
     mode: str = "auto",
     *,
+    scale: float | None = None,
     return_aux: AuxRequest | None = None,
 ) -> Tensor | tuple[Tensor, SelectedAttentionAux]:
     """
@@ -256,6 +259,9 @@ def selected_attention(
 
         mode: Currently only chunked is supported; auto defaults to chunked
 
+        scale: Positive multiplier for query-key logits. Defaults to 1 / sqrt(head_dim).
+            Attention sink logits are not scaled.
+
         return_aux: If None (default), return only the output tensor. If an AuxRequest
             instance, return a tuple of (output, SelectedAttentionAux) containing the
             requested auxiliary outputs (e.g. LSE when return_aux.lse is True).
@@ -282,6 +288,10 @@ def selected_attention(
         share_kv,
     )
 
+    if scale is not None and not scale > 0:
+        raise ValueError("scale must be greater than 0.")
+    scale = query.shape[-1] ** -0.5 if scale is None else scale
+
     match backend:
         case "eager":
             from .impl import reference
@@ -299,6 +309,7 @@ def selected_attention(
                 doc_ids,
                 sliding_window_size,
                 share_kv,
+                scale=scale,
             )
         case "triton":
             from .impl import triton as triton_backend
@@ -316,6 +327,7 @@ def selected_attention(
                 doc_ids,
                 sliding_window_size,
                 share_kv,
+                scale=scale,
             )
         case "cute":
             from .impl import cute as cute_backend
@@ -329,6 +341,7 @@ def selected_attention(
                 doc_ids,
                 sliding_window_size,
                 share_kv,
+                scale=scale,
             )
         case _:
             raise NotImplementedError(f"Backend {backend!r} is not supported yet.")

--- a/attn_gym/sparse/selected_attention/impl/cute.py
+++ b/attn_gym/sparse/selected_attention/impl/cute.py
@@ -16,8 +16,6 @@ Constraints
 
 from __future__ import annotations
 
-import math
-
 import torch
 from flash_attn.cute.interface import flash_attn_func
 
@@ -117,6 +115,8 @@ def selected_attention(
     doc_ids: torch.Tensor | None,
     sliding_window_size: int,
     share_kv: bool = True,
+    *,
+    scale: float,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """CuTe DSL (SM100) forward+backward for selected attention.
 
@@ -131,7 +131,7 @@ def selected_attention(
         query, local_kv, sparse_kv, kv_indices, attention_sink, sliding_window_size, share_kv
     )
 
-    _b, _h, s, d = query.shape
+    _b, _h, s, _d = query.shape
     device = query.device
     local_kv_len = local_kv.shape[2]
 
@@ -153,8 +153,6 @@ def selected_attention(
     qv_bshd = query.permute(0, 2, 1, 3)
     v_bshd = unified_kv.permute(0, 2, 1, 3)
 
-    softmax_scale = 1.0 / math.sqrt(d)
-
     # Call FA4's public interface.
     # Passing k=v (same object) with hdim=512 triggers MLA mode internally:
     # FA4 moves q into qv and nulls q/k, then routes to the sparse MLA kernels.
@@ -163,7 +161,7 @@ def selected_attention(
         k=v_bshd,
         v=v_bshd,
         gather_kv_indices=gather_indices,
-        softmax_scale=softmax_scale,
+        softmax_scale=scale,
         learnable_sink=attention_sink,
         causal=False,
         pack_gqa=True,

--- a/attn_gym/sparse/selected_attention/impl/cute.py
+++ b/attn_gym/sparse/selected_attention/impl/cute.py
@@ -11,8 +11,7 @@ Constraints
 -----------
 - head_dim = 512, nheads = 128, share_kv = True
 - dtype = bfloat16, SM100 (compute capability 10.0)
-- Attention sinks are not supported
-- Requires FA4 with the -1 sentinel backward fix (commit c68c592+)
+- Requires FA4 with sparse MLA attention sink support (commit 62892fe+)
 """
 
 from __future__ import annotations
@@ -94,8 +93,6 @@ def _validate_cute_constraints(
         raise TypeError("CuTe backend requires bfloat16.")
     if not share_kv:
         raise ValueError("CuTe backend requires share_kv=True.")
-    if attention_sink is not None:
-        raise NotImplementedError("CuTe backend does not support attention sinks.")
 
     _b, h, _s, d = query.shape
     if d != 512:
@@ -124,7 +121,7 @@ def selected_attention(
     """CuTe DSL (SM100) forward+backward for selected attention.
 
     Eager-only — torch.compile is not supported for this backend.
-    Attention sinks are not supported (assumes sink weight ≈ 0).
+    Optional per-head attention sinks are forwarded to FA4, which owns their gradients.
 
     Returns:
         Tuple of (output, lse) where output has shape (batch, heads, seq, head_dim)
@@ -167,6 +164,7 @@ def selected_attention(
         v=v_bshd,
         gather_kv_indices=gather_indices,
         softmax_scale=softmax_scale,
+        learnable_sink=attention_sink,
         causal=False,
         pack_gqa=True,
         return_lse=True,

--- a/attn_gym/sparse/selected_attention/impl/reference.py
+++ b/attn_gym/sparse/selected_attention/impl/reference.py
@@ -72,6 +72,8 @@ def selected_attention(
     doc_ids: Tensor | None,
     sliding_window_size: int,
     share_kv: bool,
+    *,
+    scale: float,
 ) -> tuple[Tensor, Tensor]:
     """
     Performs selected attention as follows:
@@ -81,7 +83,7 @@ def selected_attention(
             first_token_of_document = torch.where(doc_ids == doc_ids[i])[0].min()
             farthest_past_token_index = max(i - sliding_window, first_token_of_document)
             KV = cat([local_kv[farthest_past_token_index: i + 1], sparse_kv[indices]])
-            P = Q @ KV.T / head_dim ** 0.5
+            P = (Q @ KV.T) * scale
             P = softmax(cat([P, sink]))[:P.sequence_length]
             return P @ V
 
@@ -115,6 +117,7 @@ def selected_attention(
         sliding_window_size: Integer, size of sliding window
 
         share_kv: bool, true iff all query heads attend to the same KV head
+        scale: Multiplier for query-key logits; does not scale sink logits.
     Returns:
         Tuple of (output, lse) where output has shape (batch_size, num_heads, sequence_length,
         head_dim) and lse has shape (batch_size, num_heads, sequence_length).
@@ -122,7 +125,7 @@ def selected_attention(
     device = query.device
     dtype = query.dtype
     accumulation_dtype = torch.promote_types(dtype, torch.float32)
-    b, h, s, head_dim = query.shape
+    b, h, s, _head_dim = query.shape
     sparse_seq_len = sparse_kv.shape[2]
     if share_kv:
         local_kv = local_kv.expand(-1, h, -1, -1)
@@ -162,12 +165,10 @@ def selected_attention(
     query_acc = query.to(accumulation_dtype)
     attention_kv_acc = attention_kv.to(accumulation_dtype)
 
-    scale = head_dim**0.5
-
     # Match the optimized backends' mixed-precision boundaries: accumulate QK and
     # softmax in FP32 for low-precision inputs, then quantize P for the PV dot.
     logits = (
-        torch.matmul(query_acc, torch.permute(attention_kv_acc, (0, 1, 3, 2))) / scale
+        torch.matmul(query_acc, torch.permute(attention_kv_acc, (0, 1, 3, 2))) * scale
         + attention_mask
     )
 

--- a/attn_gym/sparse/selected_attention/impl/triton/__init__.py
+++ b/attn_gym/sparse/selected_attention/impl/triton/__init__.py
@@ -20,6 +20,7 @@ class _SelectedAttentionFunction(torch.autograd.Function):
         doc_ids: torch.Tensor | None,
         sliding_window_size: int,
         share_kv: bool,
+        scale: float,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         if share_kv:
             sparse_kv = sparse_kv.expand(-1, query.shape[1], -1, -1)
@@ -33,6 +34,7 @@ class _SelectedAttentionFunction(torch.autograd.Function):
             attention_sink,
             doc_ids,
             sliding_window_size,
+            scale,
         )
         # Keep the output-owned fallback available if deterministic mode is enabled before backward.
         selected_queries, block_offsets = _build_index_query_map(kv_indices, sparse_kv.shape[2])
@@ -50,6 +52,7 @@ class _SelectedAttentionFunction(torch.autograd.Function):
         ctx.doc_ids = doc_ids
         ctx.sliding_window_size = sliding_window_size
         ctx.share_kv = share_kv
+        ctx.scale = scale
         ctx.mark_non_differentiable(lse)
         return output, lse
 
@@ -80,8 +83,9 @@ class _SelectedAttentionFunction(torch.autograd.Function):
             grad_output,
             ctx.sliding_window_size,
             ctx.share_kv,
+            ctx.scale,
         )
-        return grad_query, grad_sparse_kv, grad_local_kv, None, grad_sink, None, None, None
+        return grad_query, grad_sparse_kv, grad_local_kv, None, grad_sink, None, None, None, None
 
 
 def selected_attention(
@@ -93,6 +97,8 @@ def selected_attention(
     doc_ids: torch.Tensor | None,
     sliding_window_size: int,
     share_kv: bool,
+    *,
+    scale: float,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Triton implementation of selected attention.
 
@@ -105,6 +111,7 @@ def selected_attention(
         doc_ids: (batch, seq_len) or None — document IDs for packing isolation.
         sliding_window_size: size of the causal sliding window.
         share_kv: if True, broadcast single-head KV and return single-head gradients.
+        scale: Multiplier for query-key logits; does not scale sink logits.
 
     Returns:
         Tuple of (output, lse) where output has same shape as query and lse has
@@ -138,11 +145,12 @@ def selected_attention(
             doc_ids,
             sliding_window_size,
             share_kv,
+            scale,
         )
 
     if share_kv:
         local_kv = local_kv.expand(-1, heads, -1, -1)
         sparse_kv = sparse_kv.expand(-1, heads, -1, -1)
     return _launch_forward(
-        query, sparse_kv, local_kv, kv_indices, attention_sink, doc_ids, sliding_window_size
+        query, sparse_kv, local_kv, kv_indices, attention_sink, doc_ids, sliding_window_size, scale
     )

--- a/attn_gym/sparse/selected_attention/impl/triton/backward.py
+++ b/attn_gym/sparse/selected_attention/impl/triton/backward.py
@@ -1,7 +1,5 @@
 """Backward kernels and launcher for Triton selected attention."""
 
-import math
-
 import torch
 import triton
 import triton.language as tl
@@ -543,6 +541,7 @@ def _launch_backward(
     grad_output: torch.Tensor,
     sliding_window_size: int,
     share_kv: bool,
+    scale: float,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """Launch backward kernels for selected attention."""
     batch, heads, seq_len, head_dim = query.shape
@@ -551,7 +550,6 @@ def _launch_backward(
     block_m = 64
     block_n = 32
     block_d = max(16, triton.next_power_of_2(head_dim))
-    scale = 1.0 / math.sqrt(head_dim)
     grad_output = grad_output.contiguous()
 
     grad_query = torch.empty_like(query)

--- a/attn_gym/sparse/selected_attention/impl/triton/forward.py
+++ b/attn_gym/sparse/selected_attention/impl/triton/forward.py
@@ -1,7 +1,5 @@
 """Forward kernels and launcher for Triton selected attention."""
 
-import math
-
 import torch
 import triton
 import triton.language as tl
@@ -426,6 +424,7 @@ def _launch_forward(
     attention_sink: torch.Tensor,
     doc_ids: torch.Tensor | None,
     sliding_window_size: int,
+    scale: float,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Launch the forward kernel and return its output and log-sum-exp state."""
     batch, heads, seq_len, head_dim = query.shape
@@ -470,7 +469,7 @@ def _launch_forward(
             SPARSE_SEQ_LEN=sparse_seq_len,
             TOPK=topk,
             WINDOW=sliding_window_size,
-            SCALE=1.0 / math.sqrt(head_dim),
+            SCALE=scale,
             HAS_DOC_IDS=has_doc_ids,
             BLOCK_H=block_h,
             BLOCK_K=block_k,
@@ -507,7 +506,7 @@ def _launch_forward(
             SPARSE_SEQ_LEN=sparse_seq_len,
             TOPK=topk,
             WINDOW=sliding_window_size,
-            SCALE=1.0 / math.sqrt(head_dim),
+            SCALE=scale,
             HAS_DOC_IDS=has_doc_ids,
             NUM_LOCAL_TILES=num_local_tiles,
             BLOCK_M=block_m,
@@ -536,7 +535,7 @@ def _launch_forward(
             SPARSE_SEQ_LEN=sparse_seq_len,
             TOPK=topk,
             WINDOW=sliding_window_size,
-            SCALE=1.0 / math.sqrt(head_dim),
+            SCALE=scale,
             HAS_DOC_IDS=has_doc_ids,
             NUM_LOCAL_TILES=num_local_tiles,
             BLOCK_M=block_m,

--- a/test/test_selected_attention_cute.py
+++ b/test/test_selected_attention_cute.py
@@ -53,6 +53,7 @@ def assert_matches_low_precision_eager(
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize("scale", [None, 0.025, 0.125])
 @pytest.mark.parametrize("sink_dtype", [None, torch.bfloat16, torch.float32])
 @pytest.mark.parametrize("num_topk", [16, 32, 64, 128])
 @pytest.mark.parametrize("test_docids", [False, True], ids=["no_docids", "with_docids"])
@@ -63,7 +64,7 @@ def assert_matches_low_precision_eager(
 )
 @pytest.mark.parametrize("sliding_window_size", [64, 128])
 def test_cute_precision_vs_fp64(
-    num_topk, test_docids, seq_len, sparse_seq_len, sliding_window_size, sink_dtype
+    num_topk, test_docids, seq_len, sparse_seq_len, sliding_window_size, sink_dtype, scale
 ):
     """CuTe bf16 error bounded by low-precision eager error vs FP64.
 
@@ -142,6 +143,7 @@ def test_cute_precision_vs_fp64(
         doc_ids,
         sliding_window_size,
         backend="eager",
+        scale=scale,
     )
     out_lp_ref = selected_attention(
         query_lp_ref,
@@ -152,6 +154,7 @@ def test_cute_precision_vs_fp64(
         doc_ids,
         sliding_window_size,
         backend="eager",
+        scale=scale,
     )
     out_lp_cute = selected_attention(
         query_lp_cute,
@@ -162,6 +165,7 @@ def test_cute_precision_vs_fp64(
         doc_ids,
         sliding_window_size,
         backend="cute",
+        scale=scale,
     )
 
     # --- Backward ---
@@ -230,8 +234,9 @@ def test_cute_precision_vs_fp64(
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize("scale", [None, 0.025, 0.125])
 @pytest.mark.parametrize("sink_dtype", [None, torch.bfloat16, torch.float32])
-def test_cute_lse_matches_manual_computation(sink_dtype):
+def test_cute_lse_matches_manual_computation(sink_dtype, scale):
     """Returned LSE from CuTe backend matches manual logsumexp over all logits."""
     _skip_no_sm100()
     device = torch.device("cuda")
@@ -261,6 +266,7 @@ def test_cute_lse_matches_manual_computation(sink_dtype):
         None,
         window,
         backend="cute",
+        scale=scale,
         return_aux=AuxRequest(lse=True),
     )
     lse_cute = aux_cute.lse
@@ -275,6 +281,7 @@ def test_cute_lse_matches_manual_computation(sink_dtype):
         None,
         window,
         backend="eager",
+        scale=scale,
         return_aux=AuxRequest(lse=True),
     )
     lse_eager = aux_eager.lse

--- a/test/test_selected_attention_cute.py
+++ b/test/test_selected_attention_cute.py
@@ -29,6 +29,7 @@ def assert_matches_low_precision_eager(
     low_precision_expected,
     high_precision_expected,
     reduction_sizes,
+    computation_dtype=None,
 ):
     """Bound kernel error by low-precision eager error against an FP64 measuring stick."""
     assert torch.isfinite(actual).all()
@@ -37,7 +38,7 @@ def assert_matches_low_precision_eager(
     accumulation_eps = (
         sum(math.sqrt(size) for size in reduction_sizes) * torch.finfo(torch.float32).eps
     )
-    output_rounding_eps = torch.finfo(actual.dtype).eps
+    output_rounding_eps = torch.finfo(computation_dtype or actual.dtype).eps
     rounding_eps = accumulation_eps + output_rounding_eps
     mean_atol = rounding_eps * high_precision_expected.abs().mean().item()
     max_atol = (accumulation_eps + len(reduction_sizes) * output_rounding_eps) * (
@@ -52,6 +53,7 @@ def assert_matches_low_precision_eager(
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize("sink_dtype", [None, torch.bfloat16, torch.float32])
 @pytest.mark.parametrize("num_topk", [16, 32, 64, 128])
 @pytest.mark.parametrize("test_docids", [False, True], ids=["no_docids", "with_docids"])
 @pytest.mark.parametrize(
@@ -61,7 +63,7 @@ def assert_matches_low_precision_eager(
 )
 @pytest.mark.parametrize("sliding_window_size", [64, 128])
 def test_cute_precision_vs_fp64(
-    num_topk, test_docids, seq_len, sparse_seq_len, sliding_window_size
+    num_topk, test_docids, seq_len, sparse_seq_len, sliding_window_size, sink_dtype
 ):
     """CuTe bf16 error bounded by low-precision eager error vs FP64.
 
@@ -106,7 +108,11 @@ def test_cute_precision_vs_fp64(
     scores = torch.randn(batch, seq_len, sparse_seq_len, dtype=dtype, device=device, generator=gen)
     _, kv_indices = torch.topk(scores, k=min(num_topk, sparse_seq_len), dim=-1)
 
-    sink = None
+    sink = (
+        torch.linspace(-2, 8, heads * 2, device=device, dtype=sink_dtype)[::2]
+        if sink_dtype is not None
+        else None
+    )
 
     # --- Derive FP64 inputs from the same quantized values ---
     query_64 = query_lp.double().requires_grad_(True)
@@ -122,13 +128,17 @@ def test_cute_precision_vs_fp64(
     local_kv_lp_cute = local_kv_lp.clone().requires_grad_(True)
     sparse_kv_lp_cute = sparse_kv_lp.clone().requires_grad_(True)
 
+    sink_64 = sink.double().requires_grad_(True) if sink is not None else None
+    sink_ref = sink.detach().requires_grad_(True) if sink is not None else None
+    sink_cute = sink.detach().requires_grad_(True) if sink is not None else None
+
     # --- Forward ---
     out_64 = selected_attention(
         query_64,
         local_kv_64,
         sparse_kv_64,
         kv_indices,
-        sink,
+        sink_64,
         doc_ids,
         sliding_window_size,
         backend="eager",
@@ -138,7 +148,7 @@ def test_cute_precision_vs_fp64(
         local_kv_lp_ref,
         sparse_kv_lp_ref,
         kv_indices,
-        sink,
+        sink_ref,
         doc_ids,
         sliding_window_size,
         backend="eager",
@@ -148,7 +158,7 @@ def test_cute_precision_vs_fp64(
         local_kv_lp_cute,
         sparse_kv_lp_cute,
         kv_indices,
-        sink,
+        sink_cute,
         doc_ids,
         sliding_window_size,
         backend="cute",
@@ -202,13 +212,26 @@ def test_cute_precision_vs_fp64(
             reduction_sizes=dsparse_kv_reduction_sizes,
         )
 
+    if sink is not None:
+        assert sink_cute.grad.dtype == sink_dtype
+        assert_matches_low_precision_eager(
+            sink_cute.grad,
+            sink_ref.grad,
+            sink_64.grad,
+            reduction_sizes=fwd_reduction_sizes + (head_dim, batch * seq_len),
+            # FA4 computes dsink from the BF16 output and upstream gradient,
+            # even when the sink parameter and its gradient are stored in FP32.
+            computation_dtype=dtype,
+        )
+
 
 # ---------------------------------------------------------------------------
 # LSE correctness
 # ---------------------------------------------------------------------------
 
 
-def test_cute_lse_matches_manual_computation():
+@pytest.mark.parametrize("sink_dtype", [None, torch.bfloat16, torch.float32])
+def test_cute_lse_matches_manual_computation(sink_dtype):
     """Returned LSE from CuTe backend matches manual logsumexp over all logits."""
     _skip_no_sm100()
     device = torch.device("cuda")
@@ -223,7 +246,11 @@ def test_cute_lse_matches_manual_computation():
     local_kv = torch.randn(batch, 1, seq_len, head_dim, device=device, dtype=dtype)
     sparse_kv = torch.randn(batch, 1, sparse_seq_len, head_dim, device=device, dtype=dtype)
     kv_indices = torch.randint(0, sparse_seq_len, (batch, seq_len, num_topk), device=device)
-    sink = None
+    sink = (
+        torch.linspace(-2, 8, heads, device=device, dtype=sink_dtype)
+        if sink_dtype is not None
+        else None
+    )
 
     _, aux_cute = selected_attention(
         query,
@@ -244,7 +271,7 @@ def test_cute_lse_matches_manual_computation():
         local_kv.double(),
         sparse_kv.double(),
         kv_indices,
-        sink,
+        sink.double() if sink is not None else None,
         None,
         window,
         backend="eager",

--- a/test/test_selected_attention_semantics.py
+++ b/test/test_selected_attention_semantics.py
@@ -205,7 +205,8 @@ def test_selected_block_only_manual(backend):
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
-def test_joint_normalization(backend):
+@pytest.mark.parametrize("scale", [None, 0.125, 0.25])
+def test_joint_normalization(backend, scale):
     """When both local and sparse branches are active, they share normalization.
 
     We verify against a manual computation that runs a single softmax over the
@@ -226,11 +227,11 @@ def test_joint_normalization(backend):
     kv_indices = torch.tensor([[[0, 1], [1, 2], [0, 2], [1, 0]]], device=device)
 
     out = selected_attention(
-        query, local_kv, sparse_kv, kv_indices, sink, None, window, backend=backend
+        query, local_kv, sparse_kv, kv_indices, sink, None, window, backend=backend, scale=scale
     )
 
     # --- Manual: single softmax over gathered sparse + local window + sink ---
-    scale = d**0.5
+    resolved_scale = d**-0.5 if scale is None else scale
     q = query[0, 0]  # (s, d)
     lkv = local_kv[0, 0]  # (s, d)
     skv = sparse_kv[0, 0]  # (sparse_seq_len, d)
@@ -249,7 +250,7 @@ def test_joint_normalization(backend):
         all_kv = torch.cat([gathered_sparse, local_entries], dim=0)  # (num_topk + window_len, d)
 
         # Compute logits over all entries + sink
-        logits = (q[seq] @ all_kv.T) / scale  # (num_topk + window_len,)
+        logits = (q[seq] @ all_kv.T) * resolved_scale  # (num_topk + window_len,)
         logits_with_sink = torch.cat([logits, sink_val.unsqueeze(0)])
         probs_with_sink = torch.softmax(logits_with_sink, dim=0)
 
@@ -928,7 +929,8 @@ def test_shared_kv_blackwell_torch_compile_fullgraph(shared_kv_blackwell_inputs)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for compile test")
-def test_torch_compile_fullgraph_forward():
+@pytest.mark.parametrize("scale", [None, 0.125, 0.25])
+def test_torch_compile_fullgraph_forward(scale):
     """The Triton inference path compiles with torch.compile(fullgraph=True)."""
     backend = "triton"
     device = torch.device("cuda")
@@ -948,7 +950,15 @@ def test_torch_compile_fullgraph_forward():
 
     def fn(query, local_kv, sparse_kv, kv_indices, sink):
         return selected_attention(
-            query, local_kv, sparse_kv, kv_indices, sink, None, window, backend=backend
+            query,
+            local_kv,
+            sparse_kv,
+            kv_indices,
+            sink,
+            None,
+            window,
+            backend=backend,
+            scale=scale,
         )
 
     compiled_fn = torch.compile(fn, fullgraph=True)
@@ -962,7 +972,8 @@ def test_torch_compile_fullgraph_forward():
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for compile test")
 @pytest.mark.parametrize("backend", BACKENDS)
-def test_torch_compile_fullgraph_backward(backend):
+@pytest.mark.parametrize("scale", [None, 0.125, 0.25])
+def test_torch_compile_fullgraph_backward(backend, scale):
     """selected_attention backward works under torch.compile(fullgraph=True)."""
     device = torch.device("cuda")
     dtype = _dtype_for_backend(backend)
@@ -977,7 +988,15 @@ def test_torch_compile_fullgraph_backward(backend):
 
     def fn(query, local_kv, sparse_kv, sink):
         return selected_attention(
-            query, local_kv, sparse_kv, kv_indices, sink, None, window, backend=backend
+            query,
+            local_kv,
+            sparse_kv,
+            kv_indices,
+            sink,
+            None,
+            window,
+            backend=backend,
+            scale=scale,
         )
 
     compiled_fn = torch.compile(fn, fullgraph=True)

--- a/test/test_selected_attention_triton.py
+++ b/test/test_selected_attention_triton.py
@@ -121,7 +121,8 @@ def _make_inputs(
 @pytest.mark.parametrize("share_kv", [False, True])
 @pytest.mark.parametrize("num_topk", [0, 1, 4])
 @pytest.mark.parametrize("head_dim", [32, 64, 128])
-def test_triton_forward_matches_reference(share_kv, num_topk, head_dim):
+@pytest.mark.parametrize("scale", [None, 0.125, 0.25])
+def test_triton_forward_matches_reference(share_kv, num_topk, head_dim, scale):
     """Triton forward matches the eager reference implementation."""
     _skip_no_cuda()
     inputs = _make_inputs(
@@ -129,8 +130,8 @@ def test_triton_forward_matches_reference(share_kv, num_topk, head_dim):
     )
 
     with torch.inference_mode():
-        expected = selected_attention(**inputs, backend="eager")
-        actual = selected_attention(**inputs, backend="triton")
+        expected = selected_attention(**inputs, backend="eager", scale=scale)
+        actual = selected_attention(**inputs, backend="triton", scale=scale)
 
     torch.testing.assert_close(actual, expected, atol=ATOL_FWD, rtol=RTOL_FWD)
 
@@ -164,7 +165,8 @@ def test_triton_forward_with_doc_ids(share_kv, num_topk):
 @pytest.mark.parametrize("share_kv", [False, True])
 @pytest.mark.parametrize("num_topk", [0, 1, 2, 3])
 @pytest.mark.parametrize("sliding_window_size", [0, 8])
-def test_triton_backward(share_kv, num_topk, sliding_window_size):
+@pytest.mark.parametrize("scale", [None, 0.125, 0.25])
+def test_triton_backward(share_kv, num_topk, sliding_window_size, scale):
     """Triton backward produces correct gradients for all differentiable inputs."""
     _skip_no_cuda()
 
@@ -183,8 +185,8 @@ def test_triton_backward(share_kv, num_topk, sliding_window_size):
         seed=42,
     )
 
-    out_ref = selected_attention(**inputs_ref, backend="eager")
-    out_tri = selected_attention(**inputs_tri, backend="triton")
+    out_ref = selected_attention(**inputs_ref, backend="eager", scale=scale)
+    out_tri = selected_attention(**inputs_tri, backend="triton", scale=scale)
 
     grad_gen = torch.Generator(device=out_ref.device).manual_seed(7777)
     grad_output = torch.randn(out_ref.shape, device=out_ref.device, generator=grad_gen)
@@ -304,7 +306,8 @@ def test_triton_larger_sequence():
 @pytest.mark.parametrize("share_kv", [False, True])
 @pytest.mark.parametrize("num_topk", [0, 2, 4])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32, torch.float16])
-def test_precision_vs_fp64(share_kv, num_topk, dtype):
+@pytest.mark.parametrize("scale", [None, 0.025, 0.25])
+def test_precision_vs_fp64(share_kv, num_topk, dtype, scale):
     """Report max forward/backward diffs between a lower-precision dtype and fp64.
 
     This characterizes the numerical error introduced by the given precision so that
@@ -368,6 +371,7 @@ def test_precision_vs_fp64(share_kv, num_topk, dtype):
         None,
         sliding_window_size,
         backend="eager",
+        scale=scale,
     )
     out_lp_ref = selected_attention(
         query_lp_ref,
@@ -378,6 +382,7 @@ def test_precision_vs_fp64(share_kv, num_topk, dtype):
         None,
         sliding_window_size,
         backend="eager",
+        scale=scale,
     )
     out_lp_tri = selected_attention(
         query_lp_tri,
@@ -388,6 +393,7 @@ def test_precision_vs_fp64(share_kv, num_topk, dtype):
         None,
         sliding_window_size,
         backend="triton",
+        scale=scale,
     )
 
     # --- Backward ---


### PR DESCRIPTION
Since the flash attention attention sink update got merged, I updated selected attention to pass attention sinks to the CuTeDSL backend. There are also some new tests for attention sinks with CuTe. This requires a flash attention version `62892fe4a7582f1837ef72a206639a8563498e9e` or later. 

This PR also adds an optional `scale` parameter for the softmax; ie `softmax(Q @ K.T * scale)`. `scale` defaults to `(1/head_dim)**0.5` to match the standard value. 

Relevant tests pass, and linting works too. 