### PR TITLE
Add Triton lightning indexer and automatic device dispatch

### DIFF
--- a/attn_gym/sparse/indexer/api.py
+++ b/attn_gym/sparse/indexer/api.py
@@ -1,7 +1,9 @@
+"""Public weighted-ReLU Top-K selection and backend-independent validation."""
+
 import torch
 from torch import Tensor
 
-from .ops import _indexer_cute_op
+from .ops import _indexer_op
 
 
 def _validate_inputs(
@@ -11,6 +13,7 @@ def _validate_inputs(
     topk: int,
     causal: bool,
 ) -> None:
+    """Validate metadata without synchronizing or inspecting tensor values."""
     # --- type checks ---
     for name, tensor in {"q": q, "k": k, "weights": weights}.items():
         if not isinstance(tensor, torch.Tensor):
@@ -97,25 +100,42 @@ def lightning_indexer(
         output[b, t, :]  = topk(score[b, t, :]).indices
 
     Args:
-        q: Query tensor, [B, T, H, D].
+        q: Finite query tensor, [B, T, H, D].
 
-        k: Key candidate pool shared across heads, [B, S, D].
+        k: Finite key candidate pool shared across heads, [B, S, D].
             Nonsquare inputs (S != T) are not supported yet.
 
-        weights: Per-head weights, [B, T, H].  May be negative.
+        weights: Finite per-head weights, [B, T, H]. May be negative.
 
         topk: Number of candidates to select per query.  Must be in [0, S].
 
         causal: If True, query at position t can only attend to candidates
             at positions <= t.  Requires S == T.
 
-        impl: One of "reference" or "fused". Defaults to "fused".
+        impl: ``"reference"`` uses eager PyTorch on CPU or CUDA; ``"fused"`` uses
+            optimized CUDA kernels. Defaults to ``"fused"``.
 
-        kernel_options: Fused kernel options; the supported backend is "cute".
+        kernel_options: Fused backend override: ``{"backend": "cute"}`` or
+            ``{"backend": "triton"}``. Omitted options or ``"auto"`` select CuTe
+            on SM100 and Triton on other Hopper-or-newer NVIDIA GPUs. There is
+            no fallback when the selected backend rejects a shape or layout.
 
     Returns:
-        [B, T, topk] INT32 tensor of selected candidate indices.
-        Not guaranteed to be sorted
+        Contiguous [B, T, topk] INT32 indices. Order and tie-breaking are not
+        guaranteed across backends. Causal rows with fewer than topk candidates
+        contain -1 padding; topk=0 returns an empty last dimension.
+
+    Fused backends support ``torch.compile(fullgraph=True)`` and CUDA Graph replay.
+    Both require FP16/BF16 inputs, T <= 2**20, and topk <= 512. CuTe requires SM100,
+    even H, D divisible by 16, and contiguous, 16-byte-aligned inputs. Triton requires
+    SM90 or newer, H <= 256, D <= 256 divisible by 8, and Q/K with unit last strides
+    and 16-byte-aligned bases and outer strides; weights may be strided.
+
+    Inputs and intermediate FP32 scores must remain finite. NaN/Inf behavior is
+    unsupported and may differ across backends; values are not checked at runtime.
+    Indices are nondifferentiable even when inputs require gradients. Training
+    attention over the selected positions does not propagate gradients through
+    selection into q, k, or weights; scoring weights need a separate training loss.
     """
 
     _validate_inputs(q, k, weights, topk, causal)
@@ -126,10 +146,19 @@ def lightning_indexer(
                 raise ValueError("kernel_options are not supported with impl='reference'")
             from .impl import reference
 
-            return reference.index(q, k, weights, topk, causal)
+            return reference.launch(q, k, weights, topk, causal)
         case "fused":
-            if kernel_options not in (None, {}, {"backend": "cute"}):
+            if kernel_options not in (
+                None,
+                {},
+                {"backend": "auto"},
+                {"backend": "cute"},
+                {"backend": "triton"},
+            ):
                 raise ValueError(f"unsupported lightning_indexer kernel options: {kernel_options}")
-            return _indexer_cute_op(q, k, weights, topk, causal)
+            if not q.is_cuda:
+                raise ValueError("the fused lightning_indexer requires CUDA tensors")
+            backend = (kernel_options or {}).get("backend", "auto")
+            return _indexer_op(q, k, weights, topk, causal, backend)
         case _:
             raise ValueError(f"unknown impl {impl!r}; expected 'reference' or 'fused'")

--- a/attn_gym/sparse/indexer/api.py
+++ b/attn_gym/sparse/indexer/api.py
@@ -150,7 +150,6 @@ def lightning_indexer(
             if kernel_options not in (
                 None,
                 {},
-                {"backend": "auto"},
                 {"backend": "cute"},
                 {"backend": "triton"},
             ):

--- a/attn_gym/sparse/indexer/api.py
+++ b/attn_gym/sparse/indexer/api.py
@@ -100,12 +100,12 @@ def lightning_indexer(
         output[b, t, :]  = topk(score[b, t, :]).indices
 
     Args:
-        q: Finite query tensor, [B, T, H, D].
+        q: Query tensor, [B, T, H, D].
 
-        k: Finite key candidate pool shared across heads, [B, S, D].
+        k: Key candidate pool shared across heads, [B, S, D].
             Nonsquare inputs (S != T) are not supported yet.
 
-        weights: Finite per-head weights, [B, T, H]. May be negative.
+        weights: Per-head weights, [B, T, H]. May be negative.
 
         topk: Number of candidates to select per query.  Must be in [0, S].
 
@@ -116,7 +116,7 @@ def lightning_indexer(
             optimized CUDA kernels. Defaults to ``"fused"``.
 
         kernel_options: Fused backend override: ``{"backend": "cute"}`` or
-            ``{"backend": "triton"}``. Omitted options or ``"auto"`` select CuTe
+            ``{"backend": "triton"}``. Omit options to select CuTe
             on SM100 and Triton on other Hopper-or-newer NVIDIA GPUs. There is
             no fallback when the selected backend rejects a shape or layout.
 
@@ -131,8 +131,7 @@ def lightning_indexer(
     SM90 or newer, H <= 256, D <= 256 divisible by 8, and Q/K with unit last strides
     and 16-byte-aligned bases and outer strides; weights may be strided.
 
-    Inputs and intermediate FP32 scores must remain finite. NaN/Inf behavior is
-    unsupported and may differ across backends; values are not checked at runtime.
+    Selection with NaN/Inf scores is unspecified and may differ across backends.
     Indices are nondifferentiable even when inputs require gradients. Training
     attention over the selected positions does not propagate gradients through
     selection into q, k, or weights; scoring weights need a separate training loss.

--- a/attn_gym/sparse/indexer/impl/cute.py
+++ b/attn_gym/sparse/indexer/impl/cute.py
@@ -8,7 +8,8 @@ kernel.  The launcher is guarded by an
 in-process and persistent TVM-FFI compile cache keyed on the static shape/dtype
 contract (dtype, heads, head_dim, topk, causal) and compile target. Batch and
 sequence dimensions are symbolic. The public API invokes it through the private operator in
-``attn_gym.sparse.indexer.ops``; there is no fallback implementation.
+``attn_gym.sparse.indexer.ops``. ``launch`` is a private backend entrypoint;
+``lightning_indexer`` is the public API. This launcher never falls back to another backend.
 """
 
 import math
@@ -1553,7 +1554,7 @@ def _compile_indexer(
     )
 
 
-def index(
+def launch(
     q: torch.Tensor,
     k: torch.Tensor,
     weights: torch.Tensor,
@@ -1595,4 +1596,4 @@ def index(
     return output
 
 
-__all__ = ["index"]
+__all__ = ["launch"]

--- a/attn_gym/sparse/indexer/impl/cute.py
+++ b/attn_gym/sparse/indexer/impl/cute.py
@@ -7,9 +7,7 @@ entirely in shared memory.  There are no global partial lists and no merge
 kernel.  The launcher is guarded by an
 in-process and persistent TVM-FFI compile cache keyed on the static shape/dtype
 contract (dtype, heads, head_dim, topk, causal) and compile target. Batch and
-sequence dimensions are symbolic. The public API invokes it through the private operator in
-``attn_gym.sparse.indexer.ops``. ``launch`` is a private backend entrypoint;
-``lightning_indexer`` is the public API. This launcher never falls back to another backend.
+sequence dimensions are symbolic.
 """
 
 import math

--- a/attn_gym/sparse/indexer/impl/cute/__init__.py
+++ b/attn_gym/sparse/indexer/impl/cute/__init__.py
@@ -1,5 +1,0 @@
-"""CuTe DSL (SM100) backend for the multi-head weighted ReLU Top-K indexer."""
-
-from .impl import index
-
-__all__ = ["index"]

--- a/attn_gym/sparse/indexer/impl/reference.py
+++ b/attn_gym/sparse/indexer/impl/reference.py
@@ -1,4 +1,4 @@
-"""Pure-PyTorch reference indexer implementation."""
+"""Private PyTorch launcher for the public ``lightning_indexer`` API."""
 
 import math
 
@@ -6,7 +6,7 @@ import torch
 from torch import Tensor
 
 
-def index(
+def launch(
     q: Tensor,
     k: Tensor,
     weights: Tensor,

--- a/attn_gym/sparse/indexer/impl/triton.py
+++ b/attn_gym/sparse/indexer/impl/triton.py
@@ -1,0 +1,125 @@
+"""Memory-bounded TMA/tensor-core indexer for Hopper and newer NVIDIA GPUs.
+
+Each CTA owns one query and retains only its running Top-K while streaming key
+tiles. The tensor-core product is candidate-by-head so the head reduction leaves
+candidate indices distributed across warps, rather than replicating selection
+across head warps. No scores or partial selections are stored in global memory.
+"""
+
+import torch
+import triton
+import triton.language as tl
+from torch import Tensor
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+from attn_gym._backends.triton.utils import ptr_offset, requires_int64_offsets
+
+
+@triton.jit
+def _index_kernel(
+    Q,
+    K,
+    W,
+    Out,
+    T: tl.constexpr,
+    H: tl.constexpr,
+    D: tl.constexpr,
+    TOPK: tl.constexpr,
+    WB: tl.constexpr,
+    WT: tl.constexpr,
+    WH: tl.constexpr,
+    CAUSAL: tl.constexpr,
+    BH: tl.constexpr,
+    BD: tl.constexpr,
+    BN: tl.constexpr,
+    KEEP: tl.constexpr,
+    WIDE: tl.constexpr,
+):
+    """Stream TMA key tiles through tensor cores and a register-resident Top-K."""
+    batch = tl.program_id(1)
+    query = tl.program_id(0)
+    if WIDE:
+        batch = batch.to(tl.int64)
+        query = query.to(tl.int64)
+    heads = tl.arange(0, BH)
+    if WIDE:
+        heads = heads.to(tl.int64)
+    weights = tl.load(W + ptr_offset((batch, query, heads), (WB, WT, WH)), heads < H, 0).to(
+        tl.float32
+    )
+    # TMA coordinates are int32; the descriptor handles wide byte strides.
+    q = Q.load([batch.to(tl.int32), query.to(tl.int32), 0, 0]).reshape(BH, BD)
+    best = tl.full((KEEP,), -9223372036854775808, tl.int64)
+    rank = tl.arange(0, KEEP)
+    end = query + 1 if CAUSAL else T
+    for start in tl.range(0, end, BN):
+        k = K.load([batch.to(tl.int32), start.to(tl.int32), 0]).reshape(BN, BD)
+        dots = tl.dot(k, tl.trans(q))
+        scores = tl.sum(tl.maximum(dots, 0.0) * weights[None, :], axis=1)
+        scores = scores * (H * D) ** -0.5
+        scores = tl.gather(scores, rank % BN, axis=0)
+        bits = tl.where(scores == 0.0, 0.0, scores).to(tl.int32, bitcast=True)
+        ordinal = bits ^ ((bits >> 31) & 0x7FFFFFFF)
+        candidate = start + rank
+        packed = (ordinal.to(tl.int64) << 32) | (0xFFFFFFFF - candidate.to(tl.int64))
+        packed = tl.where((rank < BN) & (candidate < end), packed, -9223372036854775808)
+        best = tl.topk(tl.join(best, packed).reshape(2 * KEEP), KEEP)
+    indices = (0xFFFFFFFF - (best & 0xFFFFFFFF)).to(tl.int32)
+    indices = tl.where(best == -9223372036854775808, -1, indices)
+    tl.store(Out + ptr_offset((batch, query, rank), (T * TOPK, TOPK, 1)), indices, rank < TOPK)
+
+
+def launch(q: Tensor, k: Tensor, weights: Tensor, topk: int, causal: bool) -> Tensor:
+    """Return nondifferentiable INT32 indices without a quadratic workspace.
+
+    Q/K require contiguous last dimensions and 16-byte-aligned bases/outer
+    strides. FP16/BF16, H/D <= 256, T <= 2**20, and Top-K <= 512 are supported.
+    Inputs and FP32 intermediate scores must be finite. Gradient-requiring
+    inputs are allowed: selection returns indices, not trainable scores.
+    The public registered operator keeps host descriptors outside graph tracing.
+    """
+    if torch.version.hip or not q.is_cuda or torch.cuda.get_device_capability(q.device)[0] < 9:
+        raise ValueError("The Triton TMA indexer requires Hopper or newer NVIDIA GPUs.")
+    if q.dtype not in (torch.float16, torch.bfloat16):
+        raise TypeError("The Triton indexer requires FP16 or BF16 inputs.")
+    batch, tokens, heads, dim = q.shape
+    if heads > 256 or dim > 256 or dim % 8 or topk > 512 or tokens > 2**20:
+        raise ValueError(
+            "The Triton indexer requires H <= 256, D <= 256 divisible by 8, "
+            "K <= 512, and T <= 2**20."
+        )
+    for tensor in (q, k):
+        if tensor.stride(-1) != 1 or any(s % 8 for s in tensor.stride()[:-1]):
+            raise ValueError("TMA requires a contiguous last dimension and 16-byte outer strides.")
+        if tensor.data_ptr() % 16:
+            raise ValueError("TMA requires 16-byte-aligned Q/K base pointers.")
+    output = torch.empty((batch, tokens, topk), dtype=torch.int32, device=q.device)
+    if topk == 0:
+        return output
+    bh = max(16, triton.next_power_of_2(heads))
+    bd = max(16, triton.next_power_of_2(dim))
+    bn = 128
+    keep = max(bn, triton.next_power_of_2(topk))
+    with torch.cuda.device(q.device):
+        q_desc = TensorDescriptor.from_tensor(q, [1, 1, bh, bd])
+        k_desc = TensorDescriptor.from_tensor(k, [1, bn, bd])
+        _index_kernel[(tokens, batch)](
+            q_desc,
+            k_desc,
+            weights,
+            output,
+            tokens,
+            heads,
+            dim,
+            topk,
+            *weights.stride(),
+            causal,
+            bh,
+            bd,
+            bn,
+            keep,
+            requires_int64_offsets(q, k, weights, output),
+            num_warps=8,
+            num_stages=1,
+        )
+    return output

--- a/attn_gym/sparse/indexer/impl/triton.py
+++ b/attn_gym/sparse/indexer/impl/triton.py
@@ -74,8 +74,7 @@ def launch(q: Tensor, k: Tensor, weights: Tensor, topk: int, causal: bool) -> Te
 
     Q/K require contiguous last dimensions and 16-byte-aligned bases/outer
     strides. FP16/BF16, H/D <= 256, T <= 2**20, and Top-K <= 512 are supported.
-    Inputs and FP32 intermediate scores must be finite. Gradient-requiring
-    inputs are allowed: selection returns indices, not trainable scores.
+    Gradient-requiring inputs are allowed: selection returns indices, not trainable scores.
     The public registered operator keeps host descriptors outside graph tracing.
     """
     if torch.version.hip or not q.is_cuda or torch.cuda.get_device_capability(q.device)[0] < 9:

--- a/attn_gym/sparse/indexer/ops.py
+++ b/attn_gym/sparse/indexer/ops.py
@@ -1,30 +1,43 @@
-"""Torch-only private operator contract for the CuTeDSL indexer.
+"""Private operator boundary shared by the fused indexer backends.
 
-Registration exists before graph capture; optional backend imports and runtime
-layout checks happen only when the CUDA implementation executes.
+Dispatch happens on real CUDA tensors, outside Dynamo tracing. This keeps CuTeDSL
+compilation and Triton's host TMA descriptors behind one fake-tensor contract.
 """
 
 import torch
 from torch import Tensor
 
 torch.library.define(
-    "attn_gym::_indexer_cute",
-    "(Tensor q, Tensor k, Tensor weights, int topk, bool causal) -> Tensor",
+    "attn_gym::_indexer",
+    "(Tensor q, Tensor k, Tensor weights, int topk, bool causal, str backend) -> Tensor",
 )
 
 
-def _indexer_cute_cuda(q: Tensor, k: Tensor, weights: Tensor, topk: int, causal: bool) -> Tensor:
-    from .impl.cute.impl import index as launch
-
+def _indexer_cuda(
+    q: Tensor, k: Tensor, weights: Tensor, topk: int, causal: bool, backend: str
+) -> Tensor:
+    """Select a launcher on the input device without tracing device queries."""
+    if backend == "auto":
+        backend = "cute" if torch.cuda.get_device_capability(q.device) == (10, 0) else "triton"
+    match backend:
+        case "cute":
+            from .impl.cute import launch
+        case "triton":
+            from .impl.triton import launch
+        case _:
+            raise ValueError(f"unknown indexer backend {backend!r}")
     return launch(q, k, weights, topk, causal)
 
 
-torch.library.impl("attn_gym::_indexer_cute", "CUDA", _indexer_cute_cuda)
+torch.library.impl("attn_gym::_indexer", "CUDA", _indexer_cuda)
 
 
-@torch.library.register_fake("attn_gym::_indexer_cute")
-def _indexer_cute_fake(q: Tensor, k: Tensor, weights: Tensor, topk: int, causal: bool) -> Tensor:
+@torch.library.register_fake("attn_gym::_indexer")
+def _indexer_fake(
+    q: Tensor, k: Tensor, weights: Tensor, topk: int, causal: bool, backend: str
+) -> Tensor:
+    """Describe the common contiguous, nondifferentiable index output."""
     return q.new_empty((q.shape[0], q.shape[1], topk), dtype=torch.int32)
 
 
-_indexer_cute_op = torch.ops.attn_gym._indexer_cute.default
+_indexer_op = torch.ops.attn_gym._indexer.default

--- a/attn_gym/testing/indexer.py
+++ b/attn_gym/testing/indexer.py
@@ -1,0 +1,124 @@
+"""Shared operands and score-selection error checks for lightning indexers."""
+
+import math
+
+import torch
+
+from attn_gym.sparse.indexer import lightning_indexer
+
+
+def make_indexer_test_inputs(
+    tokens: int,
+    heads: int,
+    head_dim: int,
+    dtype: torch.dtype,
+    *,
+    batch: int = 2,
+    device: str | torch.device = "cuda",
+    seed: int = 77,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Generate reproducible quantized operands with both signs of head weights."""
+    generator = torch.Generator(device=device).manual_seed(seed)
+    q = torch.randn(
+        batch, tokens, heads, head_dim, device=device, dtype=dtype, generator=generator
+    )
+    k = torch.randn(batch, tokens, head_dim, device=device, dtype=dtype, generator=generator)
+    weights = torch.randn(batch, tokens, heads, device=device, dtype=dtype, generator=generator)
+    weights[..., 0] = weights[..., 0].abs() + 0.25
+    if heads > 1:
+        weights[..., 1] = -weights[..., 1].abs() - 0.25
+    return q, k, weights
+
+
+def assert_selection_regret_within(
+    actual: torch.Tensor,
+    reference: torch.Tensor,
+    magnitude: torch.Tensor,
+    valid: torch.Tensor,
+    rounding_factor: float,
+) -> None:
+    """Bound maximum regret and relative RMS against reference rounding error.
+
+    Normalize each query by its absolute scoring magnitude before aggregation,
+    so high-magnitude rows cannot hide relative errors in low-magnitude rows.
+    Padded entries must already have zero regret, but their positions need not
+    match between outputs. Zero-score rows keep an exact zero pointwise budget
+    when the reference regret is zero.
+    """
+    allowance = rounding_factor * magnitude
+    assert (actual.amax(-1, keepdim=True) <= reference.amax(-1, keepdim=True) + allowance).all(), (
+        "selection regret exceeds the pointwise error budget"
+    )
+    assert actual.mean() <= reference.mean() + allowance.mean(), (
+        "selection regret exceeds the mean absolute error budget"
+    )
+    scale = torch.where(magnitude > 0, magnitude, 1)
+    count = valid.sum()
+    relative_rms = ((actual / scale).square().sum() / count).sqrt()
+    reference_rms = ((reference / scale).square().sum() / count).sqrt()
+    assert relative_rms <= reference_rms + rounding_factor, (
+        f"selection relative RMS {relative_rms.item():.6g} exceeds "
+        f"reference {reference_rms.item():.6g} + rounding allowance {rounding_factor:.6g}"
+    )
+
+
+def assert_indexer_selection(
+    actual: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    weights: torch.Tensor,
+    topk: int,
+    causal: bool,
+) -> None:
+    """Check index invariants and FP64 boundary regret against eager's regret.
+
+    Absolute products bound FP32 dot, weighting, head reduction and scaling
+    errors without cancellation shrinking the budget. Twice that score error
+    bounds a selection boundary swap; scores have no FP16/BF16 output rounding.
+    """
+    batch, tokens, heads, dim = q.shape
+    assert actual.shape == (batch, tokens, topk)
+    assert actual.dtype == torch.int32
+    assert actual.device == q.device
+    assert actual.is_contiguous()
+    assert not actual.requires_grad
+    valid = actual >= 0
+    assert not ((actual < -1) | (actual >= tokens)).any()
+    row = torch.arange(tokens, device=q.device).view(1, tokens, 1)
+    counts = (row + 1).clamp_max(topk) if causal else torch.full_like(row, topk)
+    assert torch.equal(valid.sum(-1, keepdim=True), counts.expand(batch, -1, -1))
+    if causal:
+        assert not (valid & (actual > row)).any()
+    ordered = actual.sort(-1).values
+    assert not ((ordered[..., 1:] == ordered[..., :-1]) & (ordered[..., 1:] >= 0)).any()
+    if topk == 0:
+        return
+
+    q64, k64, w64 = q.double(), k.double(), weights.double()
+    dots = q64.permute(0, 2, 1, 3) @ k64.transpose(-1, -2).unsqueeze(1)
+    scores = (dots.relu() * w64.transpose(1, 2).unsqueeze(-1)).sum(1)
+    scores /= math.sqrt(heads * dim)
+    assert torch.isfinite(scores).all()
+    absolute_dots = q64.abs().permute(0, 2, 1, 3) @ k64.abs().transpose(-1, -2).unsqueeze(1)
+    magnitude = (absolute_dots * w64.abs().transpose(1, 2).unsqueeze(-1)).sum(1)
+    magnitude /= math.sqrt(heads * dim)
+    if causal:
+        future = torch.arange(tokens, device=q.device).view(1, 1, tokens) > row
+        scores.masked_fill_(future, -torch.inf)
+        magnitude.masked_fill_(future, 0)
+    boundary = scores.sort(-1, descending=True).values.gather(
+        -1, (counts - 1).expand(batch, -1, -1)
+    )
+    eager = lightning_indexer(q, k, weights, topk, causal=causal, impl="reference")
+    actual_scores = scores.gather(-1, actual.long().clamp_min(0))
+    eager_scores = scores.gather(-1, eager.long().clamp_min(0))
+    actual_error = (boundary - actual_scores).clamp_min(0).masked_fill(~valid, 0)
+    eager_error = (boundary - eager_scores).clamp_min(0).masked_fill(eager < 0, 0)
+    reduction_eps = (dim + heads + 2) * torch.finfo(torch.float32).eps
+    assert_selection_regret_within(
+        actual_error,
+        eager_error,
+        magnitude.amax(-1, keepdim=True),
+        valid,
+        2 * reduction_eps / (1 - reduction_eps),
+    )

--- a/benchmarks/sparse/indexer_benchmark.py
+++ b/benchmarks/sparse/indexer_benchmark.py
@@ -7,9 +7,10 @@ Usage:
 """
 
 import argparse
+from functools import partial
 
 import torch
-import triton
+from transformer_nuggets.utils.benchmark import benchmark_cuda_function_stats
 
 from attn_gym.sparse.indexer import lightning_indexer
 
@@ -64,18 +65,19 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--causal", action=argparse.BooleanOptionalAction, default=True)
     parser.add_argument("--dtype", choices=DTYPES, default="bfloat16")
     parser.add_argument("--impl", nargs="+", default=["fused"], choices=["reference", "fused"])
-    parser.add_argument("--warmup", type=int, default=200, help="Warmup duration in ms")
-    parser.add_argument("--rep", type=int, default=1000, help="Measurement duration in ms")
+    parser.add_argument(
+        "--backend", nargs="+", choices=["auto", "cute", "triton"], default=["auto"]
+    )
+    parser.add_argument(
+        "--warmup", type=int, default=25, help="Warmup iterations before/after capture"
+    )
+    parser.add_argument("--rep", type=int, default=100, help="Number of timed graph replays")
     parser.add_argument("--seed", type=int, default=123)
     return parser.parse_args()
 
 
 def main() -> None:
     args = parse_args()
-    if "fused" in args.impl:
-        assert args.heads % 2 == 0, "cute backend requires an even number of heads"
-        assert args.head_dim % 16 == 0, "cute backend requires head_dim divisible by 16"
-        assert args.dtype in ("float16", "bfloat16"), "cute backend requires fp16 or bf16"
     if not torch.cuda.is_available():
         raise RuntimeError("This benchmark requires a CUDA GPU.")
 
@@ -85,19 +87,32 @@ def main() -> None:
 
     fwd_flops = useful_flops(args)
 
+    print(
+        "contract: warm fixed-pointer CUDA graph replay; forward only (indices have no backward)"
+    )
+    q, k, weights = make_inputs(args)
     for impl in args.impl:
-        q, k, weights = make_inputs(args)
-
-        def fwd(_q=q, _k=k, _weights=weights, _impl=impl):
-            return lightning_indexer(_q, _k, _weights, args.topk, causal=args.causal, impl=_impl)
-
-        fwd()
-        fwd_ms = triton.testing.do_bench(
-            fwd, warmup=args.warmup, rep=args.rep, return_mode="median"
-        )
-        fwd_tflops = fwd_flops / (fwd_ms * 1e9)
-
-        print(f"[{impl}] forward: {fwd_ms:.3f} ms  ({fwd_tflops:.2f} TFLOP/s)")
+        for backend in args.backend if impl == "fused" else [None]:
+            fwd = partial(
+                lightning_indexer,
+                q,
+                k,
+                weights,
+                args.topk,
+                causal=args.causal,
+                impl=impl,
+                kernel_options={"backend": backend} if backend else None,
+            )
+            stats = benchmark_cuda_function_stats(
+                fwd,
+                USE_CUDA_GRAPHS=True,
+                NUM_ITERS=args.rep,
+                CUDAGRAPH_WARMUP_ITERS=args.warmup,
+            )
+            fwd_ms = stats.median_us / 1000
+            fwd_tflops = fwd_flops / (fwd_ms * 1e9)
+            route = f"{impl}/{backend}" if backend else impl
+            print(f"[{route}] forward: {fwd_ms:.3f} ms  ({fwd_tflops:.2f} useful TFLOP/s)")
 
 
 if __name__ == "__main__":

--- a/benchmarks/sparse/indexer_benchmark.py
+++ b/benchmarks/sparse/indexer_benchmark.py
@@ -37,10 +37,11 @@ def useful_flops(args: argparse.Namespace) -> int:
     if not args.causal:
         return b * h * s * s * d * 2
     else:
-        return b * h * s * s * d
+        return b * h * s * (s + 1) * d
 
 
 def make_inputs(args: argparse.Namespace):
+    """Create one shared set of inputs for every measured implementation."""
     device = torch.device("cuda")
     dtype = DTYPES[args.dtype]
     generator = torch.Generator(device=device).manual_seed(args.seed)
@@ -56,6 +57,7 @@ def make_inputs(args: argparse.Namespace):
 
 
 def parse_args() -> argparse.Namespace:
+    """Parse shapes, implementations, and graph-replay iteration counts."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--batch", type=int, default=8)
     parser.add_argument("--heads", type=int, default=128)
@@ -77,6 +79,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> None:
+    """Measure public forward selection with setup excluded from graph replay."""
     args = parse_args()
     if not torch.cuda.is_available():
         raise RuntimeError("This benchmark requires a CUDA GPU.")

--- a/benchmarks/sparse/indexer_benchmark.py
+++ b/benchmarks/sparse/indexer_benchmark.py
@@ -1,5 +1,8 @@
 """Benchmark the indexer's Top-K selection across backends and shapes.
 
+Requires Transformer Nuggets with CUDA graph sample statistics:
+    uv pip install "git+https://github.com/drisspg/transformer_nuggets.git@b8ae46be93f7c9d2133c025a7f15310484df8685"
+
 Usage:
     python benchmarks/sparse/indexer_benchmark.py
     python benchmarks/sparse/indexer_benchmark.py --impl reference fused
@@ -10,7 +13,6 @@ import argparse
 from functools import partial
 
 import torch
-from transformer_nuggets.utils.benchmark import benchmark_cuda_function_stats
 
 from attn_gym.sparse.indexer import lightning_indexer
 
@@ -68,7 +70,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--dtype", choices=DTYPES, default="bfloat16")
     parser.add_argument("--impl", nargs="+", default=["fused"], choices=["reference", "fused"])
     parser.add_argument(
-        "--backend", nargs="+", choices=["auto", "cute", "triton"], default=["auto"]
+        "--backend",
+        nargs="+",
+        choices=["auto", "cute", "triton"],
+        default=[None],
+        help="Override fused backend selection; omit to select by device",
     )
     parser.add_argument(
         "--warmup", type=int, default=25, help="Warmup iterations before/after capture"
@@ -81,6 +87,13 @@ def parse_args() -> argparse.Namespace:
 def main() -> None:
     """Measure public forward selection with setup excluded from graph replay."""
     args = parse_args()
+    try:
+        from transformer_nuggets.utils.benchmark import benchmark_cuda_function_stats
+    except ImportError:
+        raise SystemExit(
+            "This benchmark requires Transformer Nuggets with benchmark_cuda_function_stats. "
+            "Install the compatible revision using the uv pip install command in --help."
+        ) from None
     if not torch.cuda.is_available():
         raise RuntimeError("This benchmark requires a CUDA GPU.")
 

--- a/benchmarks/sparse/indexer_benchmark.py
+++ b/benchmarks/sparse/indexer_benchmark.py
@@ -72,7 +72,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--backend",
         nargs="+",
-        choices=["auto", "cute", "triton"],
+        choices=["cute", "triton"],
         default=[None],
         help="Override fused backend selection; omit to select by device",
     )

--- a/docs/sparse.md
+++ b/docs/sparse.md
@@ -30,8 +30,8 @@ Output order and tie-breaking are not guaranteed to match between implementation
   with compute capability 9.0 or newer**, including Hopper. Both optimized implementations
   keep their selection state on chip and allocate no quadratic global score workspace.
 - `kernel_options={"backend": "cute"}` or `{"backend": "triton"}` overrides that choice.
-  `{"backend": "auto"}` is equivalent to omitting the options. Options are rejected for
-  `impl="reference"`. Unsupported shapes, missing dependencies, and launch errors propagate;
+  Omit options for automatic selection. Options are rejected for `impl="reference"`.
+  Unsupported shapes, missing dependencies, and launch errors propagate;
   there is no retry with another backend.
 
 | Restriction | CuTe | Triton |
@@ -67,14 +67,6 @@ these indices held fixed. It does **not** propagate gradients through the select
 into the indexer's queries, keys, or scoring weights. Train those scoring parameters with
 a separate objective; this API supplies no surrogate gradient or indexer-training loss.
 
-**Only finite inputs and finite intermediate FP32 scores are supported.** NaN and infinity
-handling may differ between implementations (including ReLU NaN behavior). These value
-constraints are the caller's responsibility and are not checked with a device-to-host sync.
-
-### Backend organization
-
-`lightning_indexer` is the sole exported indexer API. The private implementations are flat
-modules under `attn_gym/sparse/indexer/impl/{cute,triton,reference}.py`, each with a `launch`
-entrypoint. There is no separate backend-package re-export or `impl/cute/impl.py` wrapper.
+Selection with NaN/Inf scores is unspecified and may differ across backends.
 
 ::: attn_gym.sparse.indexer.lightning_indexer

--- a/docs/sparse.md
+++ b/docs/sparse.md
@@ -1,0 +1,80 @@
+# Sparse attention
+
+## Lightning indexer
+
+`lightning_indexer` selects a shared pool of key positions using multi-head weighted
+ReLU scores. It returns indices, not attention outputs or differentiable scores:
+
+```python
+from attn_gym.sparse import lightning_indexer
+
+indices = lightning_indexer(q, k, weights, topk=128, causal=True)
+# q: [B, T, H, D], k: [B, T, D], weights: [B, T, H]
+# indices: [B, T, 128], int32
+```
+
+The score for a query/candidate pair is
+`sum_h(weights[h] * relu(dot(q[h], k))) / sqrt(H * D)`.
+Weights may be negative. Query and candidate lengths must match. With causal selection,
+query `t` considers only candidates `0..t`; rows with fewer than `topk` candidates contain
+`-1` padding. Mask padding before gathering: a raw PyTorch index of `-1` selects the last
+position rather than an invalid position. `topk=0` returns an empty last dimension.
+Output order and tie-breaking are not guaranteed to match between implementations.
+
+### Implementations and device dispatch
+
+- `impl="reference"` evaluates PyTorch scoring and Top-K on CPU or CUDA. FP16/BF16/FP32
+  inputs accumulate in FP32; FP64 inputs retain FP64. It materializes the score intermediates
+  and is intended for correctness checks and small inputs.
+- `impl="fused"` (the default) selects **CuTe on SM100**, or **Triton on other NVIDIA GPUs
+  with compute capability 9.0 or newer**, including Hopper. Both optimized implementations
+  keep their selection state on chip and allocate no quadratic global score workspace.
+- `kernel_options={"backend": "cute"}` or `{"backend": "triton"}` overrides that choice.
+  `{"backend": "auto"}` is equivalent to omitting the options. Options are rejected for
+  `impl="reference"`. Unsupported shapes, missing dependencies, and launch errors propagate;
+  there is no retry with another backend.
+
+| Restriction | CuTe | Triton |
+|---|---|---|
+| GPU | SM100 | SM90 or newer |
+| Input dtype | FP16 or BF16, shared by all inputs | FP16 or BF16, shared by all inputs |
+| Heads `H` | Positive and even | `1..256` |
+| Head dimension `D` | Positive, divisible by 16 | `8..256`, divisible by 8 |
+| Sequence length `T` | `1..2**20` | `1..2**20` |
+| `topk` | `0..min(T, 512)` | `0..min(T, 512)` |
+| Layout | All inputs contiguous, with 16-byte-aligned bases | Q/K last stride 1, bases and outer strides 16-byte aligned; weights may be strided |
+
+CuTe additionally requires the optional `linear` dependencies. Its support is specifically
+SM100, not every Blackwell variant; other supported devices use Triton by default.
+
+### Compilation and training scope
+
+Both fused backends support the **public API** under `torch.compile(fullgraph=True)`,
+including changing batch/sequence sizes with `dynamic=True`. Backend selection and TMA
+setup happen inside a private operator on real CUDA tensors, rather than during tracing.
+Static-shape CUDA Graph capture/replay is supported after warming up compilation:
+
+```python
+import torch
+
+compiled_indexer = torch.compile(lightning_indexer, fullgraph=True, dynamic=True)
+indices = compiled_indexer(q, k, weights, 128, causal=True)
+```
+
+**Selection is nondifferentiable.** Inputs may require gradients, but the integer result
+has no gradient function. Selected attention can train its own Q/K/V computation with
+these indices held fixed. It does **not** propagate gradients through the selection step
+into the indexer's queries, keys, or scoring weights. Train those scoring parameters with
+a separate objective; this API supplies no surrogate gradient or indexer-training loss.
+
+**Only finite inputs and finite intermediate FP32 scores are supported.** NaN and infinity
+handling may differ between implementations (including ReLU NaN behavior). These value
+constraints are the caller's responsibility and are not checked with a device-to-host sync.
+
+### Backend organization
+
+`lightning_indexer` is the sole exported indexer API. The private implementations are flat
+modules under `attn_gym/sparse/indexer/impl/{cute,triton,reference}.py`, each with a `launch`
+entrypoint. There is no separate backend-package re-export or `impl/cute/impl.py` wrapper.
+
+::: attn_gym.sparse.indexer.lightning_indexer

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ nav:
       - Masks: masks.md
       - Score Mods: mods.md
       - Linear Attention: linear.md
+      - Sparse Attention: sparse.md
       - Utilities: utilities.md
   - Examples: examples.md
   - Development:

--- a/modal_tests.py
+++ b/modal_tests.py
@@ -47,6 +47,7 @@ def configure_local_image(
     return (
         configured.add_local_dir(ROOT_PATH / "test", remote_path="/root/test")
         .add_local_dir(ROOT_PATH / "examples", remote_path="/root/examples")
+        .add_local_dir(ROOT_PATH / "benchmarks", remote_path="/root/benchmarks")
         .add_local_dir(ROOT_PATH / "docs", remote_path="/root/docs")
         .add_local_file(ROOT_PATH / "README.md", remote_path="/root/README.md")
     )

--- a/test/test_indexer_benchmark.py
+++ b/test/test_indexer_benchmark.py
@@ -1,0 +1,28 @@
+"""The optional benchmark dependency must not block CLI help or hide installation guidance."""
+
+import sys
+from types import ModuleType
+
+import pytest
+
+from benchmarks.sparse import indexer_benchmark
+
+
+@pytest.mark.parametrize("dependency", [None, ModuleType("transformer_nuggets.utils.benchmark")])
+def test_benchmark_help_without_compatible_nuggets(monkeypatch, capsys, dependency):
+    """Help remains available when Nuggets is absent or lacks graph sample statistics."""
+    monkeypatch.setitem(sys.modules, "transformer_nuggets.utils.benchmark", dependency)
+    monkeypatch.setattr(sys, "argv", ["indexer_benchmark.py", "--help"])
+    with pytest.raises(SystemExit) as exc:
+        indexer_benchmark.main()
+    assert exc.value.code == 0
+    assert "uv pip install" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("dependency", [None, ModuleType("transformer_nuggets.utils.benchmark")])
+def test_benchmark_reports_missing_or_old_nuggets(monkeypatch, dependency):
+    """An unavailable statistics helper reports a compatible installation before GPU setup."""
+    monkeypatch.setitem(sys.modules, "transformer_nuggets.utils.benchmark", dependency)
+    monkeypatch.setattr(sys, "argv", ["indexer_benchmark.py"])
+    with pytest.raises(SystemExit, match="Install the compatible revision"):
+        indexer_benchmark.main()

--- a/test/test_indexer_benchmark.py
+++ b/test/test_indexer_benchmark.py
@@ -8,6 +8,20 @@ import pytest
 from benchmarks.sparse import indexer_benchmark
 
 
+def test_benchmark_rejects_explicit_auto(monkeypatch):
+    """Automatic dispatch is requested by omission, not an explicit backend value."""
+    monkeypatch.setattr(sys, "argv", ["indexer_benchmark.py", "--backend", "auto"])
+    with pytest.raises(SystemExit) as exc:
+        indexer_benchmark.parse_args()
+    assert exc.value.code == 2
+
+
+def test_benchmark_omitted_backend_uses_device_selection(monkeypatch):
+    """The default CLI leaves the backend override unset."""
+    monkeypatch.setattr(sys, "argv", ["indexer_benchmark.py"])
+    assert indexer_benchmark.parse_args().backend == [None]
+
+
 @pytest.mark.parametrize("dependency", [None, ModuleType("transformer_nuggets.utils.benchmark")])
 def test_benchmark_help_without_compatible_nuggets(monkeypatch, capsys, dependency):
     """Help remains available when Nuggets is absent or lacks graph sample statistics."""

--- a/test/test_indexer_cute.py
+++ b/test/test_indexer_cute.py
@@ -12,7 +12,7 @@ import pytest
 import torch
 
 from attn_gym.sparse.indexer import lightning_indexer
-from attn_gym.sparse.indexer.ops import _indexer_cute_op
+from attn_gym.sparse.indexer.ops import _indexer_op
 
 
 def _skip_no_sm100():
@@ -355,7 +355,7 @@ def test_cute_op_registration(causal, dtype, topk, requires_grad):
     q = torch.randn(2, 65, 64, 128, device="cuda", dtype=dtype, requires_grad=requires_grad)
     k = torch.randn(2, 65, 128, device="cuda", dtype=dtype, requires_grad=requires_grad)
     w = torch.randn(2, 65, 64, device="cuda", dtype=dtype, requires_grad=requires_grad)
-    torch.library.opcheck(_indexer_cute_op, (q, k, w, topk, causal))
+    torch.library.opcheck(_indexer_op, (q, k, w, topk, causal, "cute"))
     result = lightning_indexer(q, k, w, topk, causal=causal, impl="fused")
     assert not result.requires_grad
     assert result.grad_fn is None
@@ -363,7 +363,7 @@ def test_cute_op_registration(causal, dtype, topk, requires_grad):
 
 def test_cute_artifact_reused_across_batch_and_tokens(monkeypatch, tmp_path):
     _skip_no_sm100()
-    from attn_gym.sparse.indexer.impl.cute import impl
+    from attn_gym.sparse.indexer.impl import cute as impl
 
     monkeypatch.setenv("ATTN_GYM_CUTE_CACHE_DIR", str(tmp_path / "cache"))
     monkeypatch.delenv("CUTE_DSL_NO_CACHE", raising=False)

--- a/test/test_indexer_dispatch.py
+++ b/test/test_indexer_dispatch.py
@@ -100,7 +100,8 @@ def test_auto_fullgraph_uses_device_backend():
     expected_backend = "cute" if capability == (10, 0) else "triton"
     counter = CompileCounterWithBackend("inductor")
     compiled = torch.compile(lightning_indexer, fullgraph=True, dynamic=True, backend=counter)
-    for batch, tokens in ((2, 17), (3, 33), (4, 65)):
+    # Distinct initial dimensions avoid Dynamo's incidental batch == heads duck-shape guard.
+    for batch, tokens in ((3, 17), (4, 33), (5, 65)):
         q = torch.randn(batch, tokens, 2, 16, device="cuda", dtype=torch.bfloat16)
         k = torch.randn(batch, tokens, 16, device="cuda", dtype=torch.bfloat16)
         weights = torch.randn(batch, tokens, 2, device="cuda", dtype=torch.bfloat16)

--- a/test/test_indexer_dispatch.py
+++ b/test/test_indexer_dispatch.py
@@ -2,12 +2,31 @@
 
 import sys
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 import torch
 from torch._dynamo.testing import CompileCounterWithBackend
 
 from attn_gym.sparse.indexer import lightning_indexer, ops
+from attn_gym.testing.indexer import make_indexer_test_inputs
+
+
+def require_backend(backend: str | None = None) -> str:
+    """Gate only the dependencies and hardware used by this test's selected route."""
+    if torch.version.hip or not torch.cuda.is_available():
+        pytest.skip("NVIDIA CUDA required")
+    capability = torch.cuda.get_device_capability()
+    selected = backend or ("cute" if capability == (10, 0) else "triton")
+    if selected == "cute":
+        if capability != (10, 0):
+            pytest.skip("SM100 required for CuTe")
+        pytest.importorskip("cutlass.cute")
+    else:
+        if capability[0] < 9:
+            pytest.skip("Hopper or newer required for Triton")
+        pytest.importorskip("triton.tools.tensor_descriptor")
+    return selected
 
 
 @pytest.mark.parametrize(
@@ -21,39 +40,49 @@ from attn_gym.sparse.indexer import lightning_indexer, ops
         ((9, 0), "cute", "cute"),
     ],
 )
-def test_backend_dispatch_uses_input_device(monkeypatch, capability, backend, expected):
-    """Route by the input device, allowing explicit overrides without retrying."""
+@pytest.mark.parametrize("fails", [False, True])
+def test_backend_dispatch_uses_input_device(monkeypatch, capability, backend, expected, fails):
+    """Dispatch once on the input device and propagate launch errors without retrying."""
     q = torch.empty(1, 2, 2, 16)
     k = torch.empty(1, 2, 16)
     weights = torch.empty(1, 2, 2)
-    calls = []
-
-    def device_capability(device):
-        assert device == q.device
-        return capability
-
-    def launch(*args):
-        calls.append(args)
-        return torch.empty(1, 2, 1, dtype=torch.int32)
-
-    def reject(*args):
-        pytest.fail("the nonselected backend ran")
-
+    failure = RuntimeError("selected backend failed")
+    launch = Mock(
+        return_value=torch.empty(1, 2, 1, dtype=torch.int32),
+        side_effect=failure if fails else None,
+    )
+    other = Mock(side_effect=AssertionError("the nonselected backend ran"))
+    device_capability = Mock(return_value=capability)
     monkeypatch.setattr(torch.cuda, "get_device_capability", device_capability)
     for name in ("cute", "triton"):
         monkeypatch.setitem(
             sys.modules,
             f"attn_gym.sparse.indexer.impl.{name}",
-            SimpleNamespace(launch=launch if name == expected else reject),
+            SimpleNamespace(launch=launch if name == expected else other),
         )
-    actual = ops._indexer_cuda(q, k, weights, 1, True, backend)
-    assert actual.shape == (1, 2, 1)
-    assert len(calls) == 1
-    assert all(a is b for a, b in zip(calls[0][:3], (q, k, weights)))
-    assert calls[0][3:] == (1, True)
+    if fails:
+        with pytest.raises(RuntimeError) as exc:
+            ops._indexer_cuda(q, k, weights, 1, True, backend)
+        assert exc.value is failure
+    else:
+        assert ops._indexer_cuda(q, k, weights, 1, True, backend) is launch.return_value
+    launch.assert_called_once_with(q, k, weights, 1, True)
+    other.assert_not_called()
+    if backend == "auto":
+        device_capability.assert_called_once_with(q.device)
+    else:
+        device_capability.assert_not_called()
 
 
-@pytest.mark.parametrize("options", [{"backend": "missing"}, {"other": "triton"}])
+@pytest.mark.parametrize(
+    "options",
+    [
+        {"backend": "missing"},
+        {"other": "triton"},
+        {"backend": "triton", "other": "x"},
+        {"backend": None},
+    ],
+)
 def test_invalid_backend_options(options):
     """Reject unknown options before launching a backend."""
     q, k, weights = torch.zeros(1, 2, 2, 16), torch.zeros(1, 2, 16), torch.zeros(1, 2, 2)
@@ -72,10 +101,8 @@ def test_fused_cpu_rejected():
 @pytest.mark.parametrize("impl", ["reference", "fused"])
 def test_selection_does_not_train_scoring_weights(impl):
     """Gathered values train, but no gradient flows through integer selection."""
-    if impl == "fused" and (
-        not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] < 9
-    ):
-        pytest.skip("fused indexer requires Hopper or newer")
+    if impl == "fused":
+        require_backend()
     device = "cuda" if impl == "fused" else "cpu"
     q = torch.randn(1, 16, 2, 16, device=device, dtype=torch.bfloat16, requires_grad=True)
     k = torch.randn(1, 16, 16, device=device, dtype=torch.bfloat16, requires_grad=True)
@@ -94,10 +121,7 @@ def test_selection_does_not_train_scoring_weights(impl):
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_auto_fullgraph_uses_device_backend():
     """One dynamic public graph matches the explicitly selected device backend."""
-    capability = torch.cuda.get_device_capability()
-    if capability[0] < 9:
-        pytest.skip("fused indexer requires Hopper or newer")
-    expected_backend = "cute" if capability == (10, 0) else "triton"
+    expected_backend = require_backend()
     counter = CompileCounterWithBackend("inductor")
     compiled = torch.compile(lightning_indexer, fullgraph=True, dynamic=True, backend=counter)
     # Distinct initial dimensions avoid Dynamo's incidental batch == heads duck-shape guard.
@@ -114,21 +138,24 @@ def test_auto_fullgraph_uses_device_backend():
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
-@pytest.mark.parametrize("backend", ["auto", "cute", "triton"])
+@pytest.mark.parametrize(
+    "backend,dtype,tokens,heads,dim,topk",
+    [
+        (None, torch.bfloat16, 65, 2, 16, 16),
+        ("cute", torch.bfloat16, 65, 2, 16, 16),
+        ("triton", torch.bfloat16, 65, 2, 16, 16),
+        ("triton", torch.float16, 129, 3, 48, 37),
+    ],
+)
 @pytest.mark.parametrize("causal", [False, True])
-def test_backend_cuda_graph_replay(backend, causal):
+def test_backend_cuda_graph_replay(backend, dtype, tokens, heads, dim, topk, causal):
     """All public fused routes replay after static inputs change."""
-    capability = torch.cuda.get_device_capability()
-    if capability[0] < 9 or (backend == "cute" and capability != (10, 0)):
-        pytest.skip("backend is unsupported on this GPU")
-    inputs = (
-        torch.randn(2, 65, 2, 16, device="cuda", dtype=torch.bfloat16),
-        torch.randn(2, 65, 16, device="cuda", dtype=torch.bfloat16),
-        torch.randn(2, 65, 2, device="cuda", dtype=torch.bfloat16),
-    )
+    require_backend(backend)
+    inputs = make_indexer_test_inputs(tokens, heads, dim, dtype)
+    options = {"backend": backend} if backend else None
 
     def run():
-        return lightning_indexer(*inputs, 16, causal=causal, kernel_options={"backend": backend})
+        return lightning_indexer(*inputs, topk, causal=causal, kernel_options=options)
 
     stream = torch.cuda.Stream()
     stream.wait_stream(torch.cuda.current_stream())

--- a/test/test_indexer_dispatch.py
+++ b/test/test_indexer_dispatch.py
@@ -1,0 +1,109 @@
+"""Public selection policy and nondifferentiable output contracts."""
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from attn_gym.sparse.indexer import lightning_indexer, ops
+
+
+@pytest.mark.parametrize(
+    "capability,backend,expected",
+    [
+        ((9, 0), "auto", "triton"),
+        ((10, 0), "auto", "cute"),
+        ((10, 3), "auto", "triton"),
+        ((12, 0), "auto", "triton"),
+        ((10, 0), "triton", "triton"),
+        ((9, 0), "cute", "cute"),
+    ],
+)
+def test_backend_dispatch_uses_input_device(monkeypatch, capability, backend, expected):
+    """Route by the input device, allowing explicit overrides without retrying."""
+    q = torch.empty(1, 2, 2, 16)
+    k = torch.empty(1, 2, 16)
+    weights = torch.empty(1, 2, 2)
+    calls = []
+
+    def device_capability(device):
+        assert device == q.device
+        return capability
+
+    def launch(*args):
+        calls.append(args)
+        return torch.empty(1, 2, 1, dtype=torch.int32)
+
+    def reject(*args):
+        pytest.fail("the nonselected backend ran")
+
+    monkeypatch.setattr(torch.cuda, "get_device_capability", device_capability)
+    for name in ("cute", "triton"):
+        monkeypatch.setitem(
+            sys.modules,
+            f"attn_gym.sparse.indexer.impl.{name}",
+            SimpleNamespace(launch=launch if name == expected else reject),
+        )
+    actual = ops._indexer_cuda(q, k, weights, 1, True, backend)
+    assert actual.shape == (1, 2, 1)
+    assert len(calls) == 1
+    assert all(a is b for a, b in zip(calls[0][:3], (q, k, weights)))
+    assert calls[0][3:] == (1, True)
+
+
+@pytest.mark.parametrize("options", [{"backend": "missing"}, {"other": "triton"}])
+def test_invalid_backend_options(options):
+    """Reject unknown options before launching a backend."""
+    q, k, weights = torch.zeros(1, 2, 2, 16), torch.zeros(1, 2, 16), torch.zeros(1, 2, 2)
+    with pytest.raises(ValueError, match="unsupported lightning_indexer kernel options"):
+        lightning_indexer(q, k, weights, 1, kernel_options=options)
+    with pytest.raises(ValueError, match="kernel_options are not supported"):
+        lightning_indexer(q, k, weights, 1, impl="reference", kernel_options=options)
+
+
+def test_fused_cpu_rejected():
+    """CPU callers receive a clear error rather than a dispatcher implementation dump."""
+    with pytest.raises(ValueError, match="requires CUDA tensors"):
+        lightning_indexer(torch.zeros(1, 2, 2, 16), torch.zeros(1, 2, 16), torch.zeros(1, 2, 2), 1)
+
+
+@pytest.mark.parametrize("impl", ["reference", "fused"])
+def test_selection_does_not_train_scoring_weights(impl):
+    """Gathered values train, but no gradient flows through integer selection."""
+    if impl == "fused" and (
+        not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] < 9
+    ):
+        pytest.skip("fused indexer requires Hopper or newer")
+    device = "cuda" if impl == "fused" else "cpu"
+    q = torch.randn(1, 16, 2, 16, device=device, dtype=torch.bfloat16, requires_grad=True)
+    k = torch.randn(1, 16, 16, device=device, dtype=torch.bfloat16, requires_grad=True)
+    weights = torch.randn(1, 16, 2, device=device, dtype=torch.bfloat16, requires_grad=True)
+    indices = lightning_indexer(q, k, weights, 4, impl=impl)
+    assert indices.dtype == torch.int32
+    assert not indices.requires_grad and indices.grad_fn is None
+    values = torch.randn(1, 16, device=device, requires_grad=True)
+    selected = values[:, None, :].expand(-1, 16, -1).gather(-1, indices.long())
+    gradients = torch.autograd.grad(selected.sum(), (values, q, k, weights), allow_unused=True)
+    assert gradients[0] is not None
+    assert gradients[0].sum() == indices.numel()
+    assert gradients[1:] == (None, None, None)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_auto_fullgraph_uses_device_backend():
+    """One dynamic public graph matches the explicitly selected device backend."""
+    capability = torch.cuda.get_device_capability()
+    if capability[0] < 9:
+        pytest.skip("fused indexer requires Hopper or newer")
+    expected_backend = "cute" if capability == (10, 0) else "triton"
+    compiled = torch.compile(lightning_indexer, fullgraph=True, dynamic=True)
+    for tokens in (17, 33):
+        q = torch.randn(1, tokens, 2, 16, device="cuda", dtype=torch.bfloat16)
+        k = torch.randn(1, tokens, 16, device="cuda", dtype=torch.bfloat16)
+        weights = torch.randn(1, tokens, 2, device="cuda", dtype=torch.bfloat16)
+        expected = lightning_indexer(
+            q, k, weights, 4, causal=True, kernel_options={"backend": expected_backend}
+        )
+        actual = compiled(q, k, weights, 4, causal=True)
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)

--- a/test/test_indexer_dispatch.py
+++ b/test/test_indexer_dispatch.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+from torch._dynamo.testing import CompileCounterWithBackend
 
 from attn_gym.sparse.indexer import lightning_indexer, ops
 
@@ -97,13 +98,48 @@ def test_auto_fullgraph_uses_device_backend():
     if capability[0] < 9:
         pytest.skip("fused indexer requires Hopper or newer")
     expected_backend = "cute" if capability == (10, 0) else "triton"
-    compiled = torch.compile(lightning_indexer, fullgraph=True, dynamic=True)
-    for tokens in (17, 33):
-        q = torch.randn(1, tokens, 2, 16, device="cuda", dtype=torch.bfloat16)
-        k = torch.randn(1, tokens, 16, device="cuda", dtype=torch.bfloat16)
-        weights = torch.randn(1, tokens, 2, device="cuda", dtype=torch.bfloat16)
+    counter = CompileCounterWithBackend("inductor")
+    compiled = torch.compile(lightning_indexer, fullgraph=True, dynamic=True, backend=counter)
+    for batch, tokens in ((2, 17), (3, 33), (4, 65)):
+        q = torch.randn(batch, tokens, 2, 16, device="cuda", dtype=torch.bfloat16)
+        k = torch.randn(batch, tokens, 16, device="cuda", dtype=torch.bfloat16)
+        weights = torch.randn(batch, tokens, 2, device="cuda", dtype=torch.bfloat16)
         expected = lightning_indexer(
             q, k, weights, 4, causal=True, kernel_options={"backend": expected_backend}
         )
         actual = compiled(q, k, weights, 4, causal=True)
         torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    assert counter.frame_count == 1
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("backend", ["auto", "cute", "triton"])
+@pytest.mark.parametrize("causal", [False, True])
+def test_backend_cuda_graph_replay(backend, causal):
+    """All public fused routes replay after static inputs change."""
+    capability = torch.cuda.get_device_capability()
+    if capability[0] < 9 or (backend == "cute" and capability != (10, 0)):
+        pytest.skip("backend is unsupported on this GPU")
+    inputs = (
+        torch.randn(2, 65, 2, 16, device="cuda", dtype=torch.bfloat16),
+        torch.randn(2, 65, 16, device="cuda", dtype=torch.bfloat16),
+        torch.randn(2, 65, 2, device="cuda", dtype=torch.bfloat16),
+    )
+
+    def run():
+        return lightning_indexer(*inputs, 16, causal=causal, kernel_options={"backend": backend})
+
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(3):
+            run()
+    torch.cuda.current_stream().wait_stream(stream)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        actual = run()
+    for _ in range(3):
+        for tensor in inputs:
+            tensor.normal_()
+        graph.replay()
+        torch.testing.assert_close(actual, run(), rtol=0, atol=0)

--- a/test/test_indexer_dispatch.py
+++ b/test/test_indexer_dispatch.py
@@ -77,6 +77,7 @@ def test_backend_dispatch_uses_input_device(monkeypatch, capability, backend, ex
 @pytest.mark.parametrize(
     "options",
     [
+        {"backend": "auto"},
         {"backend": "missing"},
         {"other": "triton"},
         {"backend": "triton", "other": "x"},

--- a/test/test_indexer_helpers.py
+++ b/test/test_indexer_helpers.py
@@ -1,0 +1,75 @@
+"""Regression coverage for shared indexer inputs and selection error budgets."""
+
+import pytest
+import torch
+
+from attn_gym.sparse.indexer import lightning_indexer
+from attn_gym.testing.indexer import (
+    assert_indexer_selection,
+    assert_selection_regret_within,
+    make_indexer_test_inputs,
+)
+
+
+@pytest.mark.parametrize("heads", [1, 3])
+def test_indexer_inputs_are_reproducible_without_changing_global_rng(heads):
+    """The shared factory preserves its seed and signed weights without global RNG mutation."""
+    state = torch.random.get_rng_state()
+    inputs = make_indexer_test_inputs(17, heads, 8, torch.bfloat16, device="cpu")
+    repeated = make_indexer_test_inputs(17, heads, 8, torch.bfloat16, device="cpu")
+    assert torch.equal(torch.random.get_rng_state(), state)
+    for actual, expected in zip(inputs, repeated):
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    assert (inputs[2][..., 0] >= 0.25).all()
+    if heads > 1:
+        assert (inputs[2][..., 1] <= -0.25).all()
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("causal,topk", [(False, 5), (True, 5), (True, 0)])
+def test_selection_oracle_handles_different_row_magnitudes(dtype, causal, topk):
+    """Check normalized errors with six orders of score magnitude, padding and empty output."""
+    q, k, weights = make_indexer_test_inputs(17, 3, 8, dtype, device="cpu")
+    q.mul_(torch.logspace(-3, 3, 17).view(1, 17, 1, 1))
+    actual = lightning_indexer(q, k, weights, topk, causal=causal, impl="reference")
+    assert_indexer_selection(actual.roll(1, dims=-1), q, k, weights, topk, causal)
+
+
+def test_relative_rms_detects_distributed_errors_hidden_by_absolute_mean():
+    """The old maximum/absolute-mean gates pass this case; relative RMS must reject it."""
+    actual = torch.tensor([[0.0, 0, 0, 0], [0.02, 0.02, 0.02, 0.02]], dtype=torch.float64)
+    reference = torch.tensor([[0.0, 0, 0, 0], [0.02, 0, 0, 0]], dtype=torch.float64)
+    magnitude = torch.tensor([[1e8], [1.0]], dtype=torch.float64)
+    rounding_factor = 1e-3
+    allowance = rounding_factor * magnitude
+    assert (actual.amax(-1, keepdim=True) <= reference.amax(-1, keepdim=True) + allowance).all()
+    assert actual.mean() <= reference.mean() + allowance.mean()
+    with pytest.raises(AssertionError, match="relative RMS"):
+        assert_selection_regret_within(
+            actual,
+            reference,
+            magnitude,
+            torch.ones_like(actual, dtype=torch.bool),
+            rounding_factor,
+        )
+
+
+def test_relative_rms_ignores_padding_position():
+    """Different padding locations do not change aggregate reference regret."""
+    assert_selection_regret_within(
+        torch.tensor([[0.0, 0.02]]),
+        torch.tensor([[0.02, 0.0]]),
+        torch.ones(1, 1),
+        torch.tensor([[False, True]]),
+        0.0,
+    )
+
+
+def test_zero_score_regret_requires_exact_zero():
+    """Zero-magnitude rows keep an exact error budget rather than dividing by zero."""
+    zeros = torch.zeros(1, 2, dtype=torch.float64)
+    magnitude = torch.zeros(1, 1, dtype=torch.float64)
+    valid = torch.ones_like(zeros, dtype=torch.bool)
+    assert_selection_regret_within(zeros, zeros, magnitude, valid, 1e-3)
+    with pytest.raises(AssertionError, match="pointwise"):
+        assert_selection_regret_within(zeros + 1e-12, zeros, magnitude, valid, 1e-3)

--- a/test/test_indexer_triton.py
+++ b/test/test_indexer_triton.py
@@ -1,0 +1,272 @@
+"""Exercise TMA index selection without requiring the optional CuTeDSL backend."""
+
+import math
+
+import pytest
+import torch
+
+from attn_gym.sparse.indexer import lightning_indexer
+
+
+@pytest.fixture(autouse=True)
+def require_hopper() -> None:
+    """Skip before importing Triton on hosts without a supported NVIDIA GPU."""
+    if torch.version.hip or not torch.cuda.is_available():
+        pytest.skip("NVIDIA CUDA required")
+    if torch.cuda.get_device_capability()[0] < 9:
+        pytest.skip("Hopper or newer required")
+    pytest.importorskip("triton")
+    pytest.importorskip("triton.tools.tensor_descriptor")
+
+
+def make_inputs(
+    tokens: int, heads: int, dim: int, dtype: torch.dtype
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Use quantized random inputs and guarantee both signs of head weights."""
+    torch.manual_seed(77)
+    q = torch.randn(2, tokens, heads, dim, device="cuda", dtype=dtype)
+    k = torch.randn(2, tokens, dim, device="cuda", dtype=dtype)
+    weights = torch.randn(2, tokens, heads, device="cuda", dtype=dtype)
+    weights[..., 0] = weights[..., 0].abs() + 0.25
+    weights[..., 1] = -weights[..., 1].abs() - 0.25
+    return q, k, weights
+
+
+def assert_selection(
+    actual: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    weights: torch.Tensor,
+    topk: int,
+    causal: bool,
+) -> None:
+    """Check index invariants and FP64 boundary regret against eager's regret.
+
+    The allowance bounds FP32 dot, weighting, head reduction and scaling errors
+    using absolute products (so cancellation cannot shrink the budget). Twice
+    that score error bounds a selection boundary swap; no FP16/BF16 output
+    rounding is allowed because the kernel retains scores in FP32.
+    """
+    batch, tokens, heads, dim = q.shape
+    assert actual.shape == (batch, tokens, topk)
+    assert actual.dtype == torch.int32
+    assert actual.device == q.device
+    assert not actual.requires_grad
+    valid = actual >= 0
+    assert not ((actual < -1) | (actual >= tokens)).any()
+    row = torch.arange(tokens, device=q.device).view(1, tokens, 1)
+    counts = (row + 1).clamp_max(topk) if causal else torch.full_like(row, topk)
+    assert torch.equal(valid.sum(-1, keepdim=True), counts.expand(batch, -1, -1))
+    if causal:
+        assert not (valid & (actual > row)).any()
+    ordered = actual.sort(-1).values
+    assert not ((ordered[..., 1:] == ordered[..., :-1]) & (ordered[..., 1:] >= 0)).any()
+    if topk == 0:
+        return
+
+    q64, k64, w64 = q.double(), k.double(), weights.double()
+    dots = q64.permute(0, 2, 1, 3) @ k64.transpose(-1, -2).unsqueeze(1)
+    scores = (dots.relu() * w64.transpose(1, 2).unsqueeze(-1)).sum(1)
+    scores /= math.sqrt(heads * dim)
+    assert torch.isfinite(scores).all()
+    absolute_dots = q64.abs().permute(0, 2, 1, 3) @ k64.abs().transpose(-1, -2).unsqueeze(1)
+    magnitude = (absolute_dots * w64.abs().transpose(1, 2).unsqueeze(-1)).sum(1)
+    magnitude /= math.sqrt(heads * dim)
+    if causal:
+        future = torch.arange(tokens, device=q.device).view(1, 1, tokens) > row
+        scores.masked_fill_(future, -torch.inf)
+        magnitude.masked_fill_(future, 0)
+    boundary = scores.sort(-1, descending=True).values.gather(
+        -1, (counts - 1).expand(batch, -1, -1)
+    )
+    eager = lightning_indexer(q, k, weights, topk, causal=causal, impl="reference")
+    actual_scores = scores.gather(-1, actual.long().clamp_min(0))
+    eager_scores = scores.gather(-1, eager.long().clamp_min(0))
+    actual_error = (boundary - actual_scores).clamp_min(0).masked_fill(~valid, 0)
+    eager_error = (boundary - eager_scores).clamp_min(0).masked_fill(eager < 0, 0)
+    reduction_eps = (dim + heads + 2) * torch.finfo(torch.float32).eps
+    allowance = 2 * reduction_eps / (1 - reduction_eps) * magnitude.amax(-1, keepdim=True)
+    assert (
+        actual_error.amax(-1, keepdim=True) <= eager_error.amax(-1, keepdim=True) + allowance
+    ).all()
+    assert actual_error.mean() <= eager_error.mean() + allowance.mean()
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize(
+    "tokens,heads,dim,topk,causal",
+    [
+        (65, 3, 16, 0, True),
+        (65, 5, 48, 1, False),
+        (129, 17, 128, 37, True),
+        (129, 3, 48, 37, False),
+        (257, 5, 16, 129, False),
+        (513, 3, 128, 512, True),
+        (1, 2, 8, 1, True),
+        (65, 256, 256, 37, False),
+    ],
+)
+def test_triton_selection(dtype, tokens, heads, dim, topk, causal):
+    """Cover partial tiles, multi-tile selection and all supported score dtypes."""
+    q, k, weights = make_inputs(tokens, heads, dim, dtype)
+    actual = lightning_indexer(
+        q, k, weights, topk, causal=causal, impl="fused", kernel_options={"backend": "triton"}
+    )
+    assert_selection(actual, q, k, weights, topk, causal)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("causal", [False, True])
+def test_triton_zero_weight_ties(dtype, causal):
+    """Exact ties select ascending indices and leave causal tail slots as -1."""
+    q, k, weights = make_inputs(129, 3, 48, dtype)
+    weights.zero_()
+    actual = lightning_indexer(
+        q, k, weights, 37, causal=causal, impl="fused", kernel_options={"backend": "triton"}
+    )
+    expected = torch.arange(37, device=q.device, dtype=torch.int32).expand(2, 129, -1)
+    if causal:
+        expected = expected.masked_fill(
+            expected > torch.arange(129, device=q.device).view(1, 129, 1), -1
+        )
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("causal", [False, True])
+def test_triton_strided_inputs(causal):
+    """Aligned noncompact outer strides and nonunit weight strides are supported."""
+    q, k, weights = make_inputs(130, 6, 48, torch.bfloat16)
+    q, k, weights = q[:, ::2, ::2], k[:, ::2], weights[:, ::2, ::2]
+    assert all(not tensor.is_contiguous() for tensor in (q, k, weights))
+    actual = lightning_indexer(
+        q, k, weights, 37, causal=causal, impl="fused", kernel_options={"backend": "triton"}
+    )
+    assert_selection(actual, q, k, weights, 37, causal)
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "dtype",
+        "dim_unaligned",
+        "dim_large",
+        "heads",
+        "topk",
+        "q_layout",
+        "k_layout",
+        "outer_stride",
+    ],
+)
+def test_triton_unsupported_inputs(case):
+    """Reject unsupported arithmetic and TMA layouts at the public boundary."""
+    dim = {"dim_unaligned": 18, "dim_large": 264, "outer_stride": 17}.get(case, 16)
+    q, k, weights = make_inputs(
+        513 if case == "topk" else 65, 257 if case == "heads" else 3, dim, torch.bfloat16
+    )
+    topk = 513 if case == "topk" else 1
+    match case:
+        case "dtype":
+            q, k, weights = q.float(), k.float(), weights.float()
+        case "q_layout":
+            q = q.transpose(-1, -2).contiguous().transpose(-1, -2)
+        case "k_layout":
+            k = k.transpose(-1, -2).contiguous().transpose(-1, -2)
+        case "outer_stride":
+            q, k = q[..., :16], k[..., :16]
+    error = TypeError if case == "dtype" else ValueError
+    message = (
+        "FP16 or BF16"
+        if case == "dtype"
+        else "contiguous last dimension|16-byte outer strides"
+        if case in ("q_layout", "k_layout", "outer_stride")
+        else "H <= 256"
+    )
+    with pytest.raises(error, match=message):
+        lightning_indexer(q, k, weights, topk, impl="fused", kernel_options={"backend": "triton"})
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("requires_grad", [False, True])
+@pytest.mark.parametrize("topk", [0, 37])
+def test_triton_opcheck(dtype, requires_grad, topk):
+    """Validate schema, autograd, fake tensors and dynamic AOT dispatch."""
+    from attn_gym.sparse.indexer.ops import _indexer_op
+
+    inputs = make_inputs(65, 3, 48, dtype)
+    for tensor in inputs:
+        tensor.requires_grad_(requires_grad)
+    torch.library.opcheck(_indexer_op, (*inputs, topk, True, "triton"))
+    actual = lightning_indexer(
+        *inputs, topk, causal=True, impl="fused", kernel_options={"backend": "triton"}
+    )
+    assert not actual.requires_grad
+    assert actual.grad_fn is None
+
+
+@pytest.mark.parametrize("topk", [0, 37])
+def test_triton_dynamic_fullgraph(topk):
+    """Reuse the compiled public callable across odd sequence lengths."""
+    compiled = torch.compile(lightning_indexer, fullgraph=True, dynamic=True)
+    for tokens in (65, 129):
+        inputs = make_inputs(tokens, 3, 48, torch.bfloat16)
+        expected = lightning_indexer(
+            *inputs, topk, causal=True, impl="fused", kernel_options={"backend": "triton"}
+        )
+        actual = compiled(
+            *inputs, topk, causal=True, impl="fused", kernel_options={"backend": "triton"}
+        )
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_triton_wide_offsets(monkeypatch):
+    """Exercise the wide specialization even when all actual offsets fit int32."""
+    from attn_gym.sparse.indexer.impl import triton as implementation
+
+    inputs = make_inputs(65, 3, 48, torch.bfloat16)
+    assert not implementation.requires_int64_offsets(*inputs)
+    expected = lightning_indexer(
+        *inputs, 37, causal=True, impl="fused", kernel_options={"backend": "triton"}
+    )
+    monkeypatch.setattr(implementation, "requires_int64_offsets", lambda *tensors: True)
+    actual = lightning_indexer(
+        *inputs, 37, causal=True, impl="fused", kernel_options={"backend": "triton"}
+    )
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("operand", [0, 1])
+def test_triton_misaligned_base(operand):
+    """A compact tensor with an offset of one element is not a valid TMA base."""
+    inputs = list(make_inputs(65, 3, 48, torch.bfloat16))
+    tensor = inputs[operand]
+    storage = torch.empty(tensor.numel() + 1, device=tensor.device, dtype=tensor.dtype)
+    inputs[operand] = storage[1:].view(tensor.shape).copy_(tensor)
+    with pytest.raises(ValueError, match="16-byte-aligned Q/K"):
+        lightning_indexer(*inputs, 37, impl="fused", kernel_options={"backend": "triton"})
+
+
+@pytest.mark.parametrize("causal", [False, True])
+def test_triton_cuda_graph(causal):
+    """Replay captured selection after changing static inputs, not just once."""
+    inputs = make_inputs(129, 3, 48, torch.float16)
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(3):
+            lightning_indexer(
+                *inputs, 37, causal=causal, impl="fused", kernel_options={"backend": "triton"}
+            )
+    torch.cuda.current_stream().wait_stream(stream)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        actual = lightning_indexer(
+            *inputs, 37, causal=causal, impl="fused", kernel_options={"backend": "triton"}
+        )
+    for _ in range(2):
+        for tensor in inputs:
+            tensor.normal_()
+        graph.replay()
+        expected = lightning_indexer(
+            *inputs, 37, causal=causal, impl="fused", kernel_options={"backend": "triton"}
+        )
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)

--- a/test/test_indexer_triton.py
+++ b/test/test_indexer_triton.py
@@ -1,11 +1,10 @@
 """Exercise TMA index selection without requiring the optional CuTeDSL backend."""
 
-import math
-
 import pytest
 import torch
 
 from attn_gym.sparse.indexer import lightning_indexer
+from attn_gym.testing.indexer import assert_indexer_selection, make_indexer_test_inputs
 
 
 @pytest.fixture(autouse=True)
@@ -17,79 +16,6 @@ def require_hopper() -> None:
         pytest.skip("Hopper or newer required")
     pytest.importorskip("triton")
     pytest.importorskip("triton.tools.tensor_descriptor")
-
-
-def make_inputs(
-    tokens: int, heads: int, dim: int, dtype: torch.dtype
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Use quantized random inputs and guarantee both signs of head weights."""
-    torch.manual_seed(77)
-    q = torch.randn(2, tokens, heads, dim, device="cuda", dtype=dtype)
-    k = torch.randn(2, tokens, dim, device="cuda", dtype=dtype)
-    weights = torch.randn(2, tokens, heads, device="cuda", dtype=dtype)
-    weights[..., 0] = weights[..., 0].abs() + 0.25
-    weights[..., 1] = -weights[..., 1].abs() - 0.25
-    return q, k, weights
-
-
-def assert_selection(
-    actual: torch.Tensor,
-    q: torch.Tensor,
-    k: torch.Tensor,
-    weights: torch.Tensor,
-    topk: int,
-    causal: bool,
-) -> None:
-    """Check index invariants and FP64 boundary regret against eager's regret.
-
-    The allowance bounds FP32 dot, weighting, head reduction and scaling errors
-    using absolute products (so cancellation cannot shrink the budget). Twice
-    that score error bounds a selection boundary swap; no FP16/BF16 output
-    rounding is allowed because the kernel retains scores in FP32.
-    """
-    batch, tokens, heads, dim = q.shape
-    assert actual.shape == (batch, tokens, topk)
-    assert actual.dtype == torch.int32
-    assert actual.device == q.device
-    assert not actual.requires_grad
-    valid = actual >= 0
-    assert not ((actual < -1) | (actual >= tokens)).any()
-    row = torch.arange(tokens, device=q.device).view(1, tokens, 1)
-    counts = (row + 1).clamp_max(topk) if causal else torch.full_like(row, topk)
-    assert torch.equal(valid.sum(-1, keepdim=True), counts.expand(batch, -1, -1))
-    if causal:
-        assert not (valid & (actual > row)).any()
-    ordered = actual.sort(-1).values
-    assert not ((ordered[..., 1:] == ordered[..., :-1]) & (ordered[..., 1:] >= 0)).any()
-    if topk == 0:
-        return
-
-    q64, k64, w64 = q.double(), k.double(), weights.double()
-    dots = q64.permute(0, 2, 1, 3) @ k64.transpose(-1, -2).unsqueeze(1)
-    scores = (dots.relu() * w64.transpose(1, 2).unsqueeze(-1)).sum(1)
-    scores /= math.sqrt(heads * dim)
-    assert torch.isfinite(scores).all()
-    absolute_dots = q64.abs().permute(0, 2, 1, 3) @ k64.abs().transpose(-1, -2).unsqueeze(1)
-    magnitude = (absolute_dots * w64.abs().transpose(1, 2).unsqueeze(-1)).sum(1)
-    magnitude /= math.sqrt(heads * dim)
-    if causal:
-        future = torch.arange(tokens, device=q.device).view(1, 1, tokens) > row
-        scores.masked_fill_(future, -torch.inf)
-        magnitude.masked_fill_(future, 0)
-    boundary = scores.sort(-1, descending=True).values.gather(
-        -1, (counts - 1).expand(batch, -1, -1)
-    )
-    eager = lightning_indexer(q, k, weights, topk, causal=causal, impl="reference")
-    actual_scores = scores.gather(-1, actual.long().clamp_min(0))
-    eager_scores = scores.gather(-1, eager.long().clamp_min(0))
-    actual_error = (boundary - actual_scores).clamp_min(0).masked_fill(~valid, 0)
-    eager_error = (boundary - eager_scores).clamp_min(0).masked_fill(eager < 0, 0)
-    reduction_eps = (dim + heads + 2) * torch.finfo(torch.float32).eps
-    allowance = 2 * reduction_eps / (1 - reduction_eps) * magnitude.amax(-1, keepdim=True)
-    assert (
-        actual_error.amax(-1, keepdim=True) <= eager_error.amax(-1, keepdim=True) + allowance
-    ).all()
-    assert actual_error.mean() <= eager_error.mean() + allowance.mean()
 
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
@@ -108,48 +34,62 @@ def assert_selection(
 )
 def test_triton_selection(dtype, tokens, heads, dim, topk, causal):
     """Cover partial tiles, multi-tile selection and all supported score dtypes."""
-    q, k, weights = make_inputs(tokens, heads, dim, dtype)
+    q, k, weights = make_indexer_test_inputs(tokens, heads, dim, dtype)
     actual = lightning_indexer(
         q, k, weights, topk, causal=causal, impl="fused", kernel_options={"backend": "triton"}
     )
-    assert_selection(actual, q, k, weights, topk, causal)
+    assert_indexer_selection(actual, q, k, weights, topk, causal)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_triton_selection_across_score_magnitudes(dtype):
+    """Exercise relative-RMS budgets when query rows span six orders of magnitude."""
+    q, k, weights = make_indexer_test_inputs(65, 3, 48, dtype)
+    q.mul_(torch.logspace(-3, 3, 65, device=q.device).view(1, 65, 1, 1))
+    actual = lightning_indexer(q, k, weights, 37, kernel_options={"backend": "triton"})
+    assert_indexer_selection(actual, q, k, weights, 37, False)
 
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.parametrize("causal", [False, True])
 def test_triton_zero_weight_ties(dtype, causal):
-    """Exact ties select ascending indices and leave causal tail slots as -1."""
-    q, k, weights = make_inputs(129, 3, 48, dtype)
+    """Ties preserve validity, counts, uniqueness and padding without fixing order."""
+    q, k, weights = make_indexer_test_inputs(129, 3, 48, dtype)
     weights.zero_()
     actual = lightning_indexer(
         q, k, weights, 37, causal=causal, impl="fused", kernel_options={"backend": "triton"}
     )
-    expected = torch.arange(37, device=q.device, dtype=torch.int32).expand(2, 129, -1)
-    if causal:
-        expected = expected.masked_fill(
-            expected > torch.arange(129, device=q.device).view(1, 129, 1), -1
-        )
-    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    assert_indexer_selection(actual, q, k, weights, 37, causal)
 
 
 @pytest.mark.parametrize("causal", [False, True])
 def test_triton_strided_inputs(causal):
     """Aligned noncompact outer strides and nonunit weight strides are supported."""
-    q, k, weights = make_inputs(130, 6, 48, torch.bfloat16)
+    q, k, weights = make_indexer_test_inputs(130, 6, 48, torch.bfloat16)
     q, k, weights = q[:, ::2, ::2], k[:, ::2], weights[:, ::2, ::2]
     assert all(not tensor.is_contiguous() for tensor in (q, k, weights))
     actual = lightning_indexer(
         q, k, weights, 37, causal=causal, impl="fused", kernel_options={"backend": "triton"}
     )
-    assert_selection(actual, q, k, weights, 37, causal)
+    assert_indexer_selection(actual, q, k, weights, 37, causal)
     from attn_gym.sparse.indexer.ops import _indexer_op
 
     torch.library.opcheck(_indexer_op, (q, k, weights, 37, causal, "triton"))
 
 
 @pytest.mark.parametrize(
-    "case",
+    "layout,tokens,heads,dim,topk,dtype,error,message",
     [
+        (None, 65, 3, 16, 1, torch.float32, TypeError, "FP16 or BF16"),
+        (None, 65, 3, 18, 1, torch.bfloat16, ValueError, "H <= 256"),
+        (None, 65, 3, 264, 1, torch.bfloat16, ValueError, "H <= 256"),
+        (None, 65, 257, 16, 1, torch.bfloat16, ValueError, "H <= 256"),
+        (None, 513, 3, 16, 513, torch.bfloat16, ValueError, "K <= 512"),
+        ("q", 65, 3, 16, 1, torch.bfloat16, ValueError, "contiguous last dimension"),
+        ("k", 65, 3, 16, 1, torch.bfloat16, ValueError, "contiguous last dimension"),
+        ("outer", 65, 3, 17, 1, torch.bfloat16, ValueError, "16-byte outer strides"),
+    ],
+    ids=[
         "dtype",
         "dim_unaligned",
         "dim_large",
@@ -160,30 +100,16 @@ def test_triton_strided_inputs(causal):
         "outer_stride",
     ],
 )
-def test_triton_unsupported_inputs(case):
+def test_triton_unsupported_inputs(layout, tokens, heads, dim, topk, dtype, error, message):
     """Reject unsupported arithmetic and TMA layouts at the public boundary."""
-    dim = {"dim_unaligned": 18, "dim_large": 264, "outer_stride": 17}.get(case, 16)
-    q, k, weights = make_inputs(
-        513 if case == "topk" else 65, 257 if case == "heads" else 3, dim, torch.bfloat16
-    )
-    topk = 513 if case == "topk" else 1
-    match case:
-        case "dtype":
-            q, k, weights = q.float(), k.float(), weights.float()
-        case "q_layout":
+    q, k, weights = make_indexer_test_inputs(tokens, heads, dim, dtype)
+    match layout:
+        case "q":
             q = q.transpose(-1, -2).contiguous().transpose(-1, -2)
-        case "k_layout":
+        case "k":
             k = k.transpose(-1, -2).contiguous().transpose(-1, -2)
-        case "outer_stride":
+        case "outer":
             q, k = q[..., :16], k[..., :16]
-    error = TypeError if case == "dtype" else ValueError
-    message = (
-        "FP16 or BF16"
-        if case == "dtype"
-        else "contiguous last dimension|16-byte outer strides"
-        if case in ("q_layout", "k_layout", "outer_stride")
-        else "H <= 256"
-    )
     with pytest.raises(error, match=message):
         lightning_indexer(q, k, weights, topk, impl="fused", kernel_options={"backend": "triton"})
 
@@ -195,7 +121,7 @@ def test_triton_opcheck(dtype, requires_grad, topk):
     """Validate schema, autograd, fake tensors and dynamic AOT dispatch."""
     from attn_gym.sparse.indexer.ops import _indexer_op
 
-    inputs = make_inputs(65, 3, 48, dtype)
+    inputs = make_indexer_test_inputs(65, 3, 48, dtype)
     for tensor in inputs:
         tensor.requires_grad_(requires_grad)
     torch.library.opcheck(_indexer_op, (*inputs, topk, True, "triton"))
@@ -211,7 +137,7 @@ def test_triton_dynamic_fullgraph(topk):
     """Reuse the compiled public callable across odd sequence lengths."""
     compiled = torch.compile(lightning_indexer, fullgraph=True, dynamic=True)
     for tokens in (65, 129):
-        inputs = make_inputs(tokens, 3, 48, torch.bfloat16)
+        inputs = make_indexer_test_inputs(tokens, 3, 48, torch.bfloat16)
         expected = lightning_indexer(
             *inputs, topk, causal=True, impl="fused", kernel_options={"backend": "triton"}
         )
@@ -225,7 +151,7 @@ def test_triton_wide_offsets(monkeypatch):
     """Exercise the wide specialization even when all actual offsets fit int32."""
     from attn_gym.sparse.indexer.impl import triton as implementation
 
-    inputs = make_inputs(65, 3, 48, torch.bfloat16)
+    inputs = make_indexer_test_inputs(65, 3, 48, torch.bfloat16)
     assert not implementation.requires_int64_offsets(*inputs)
     expected = lightning_indexer(
         *inputs, 37, causal=True, impl="fused", kernel_options={"backend": "triton"}
@@ -240,36 +166,9 @@ def test_triton_wide_offsets(monkeypatch):
 @pytest.mark.parametrize("operand", [0, 1])
 def test_triton_misaligned_base(operand):
     """A compact tensor with an offset of one element is not a valid TMA base."""
-    inputs = list(make_inputs(65, 3, 48, torch.bfloat16))
+    inputs = list(make_indexer_test_inputs(65, 3, 48, torch.bfloat16))
     tensor = inputs[operand]
     storage = torch.empty(tensor.numel() + 1, device=tensor.device, dtype=tensor.dtype)
     inputs[operand] = storage[1:].view(tensor.shape).copy_(tensor)
     with pytest.raises(ValueError, match="16-byte-aligned Q/K"):
         lightning_indexer(*inputs, 37, impl="fused", kernel_options={"backend": "triton"})
-
-
-@pytest.mark.parametrize("causal", [False, True])
-def test_triton_cuda_graph(causal):
-    """Replay captured selection after changing static inputs, not just once."""
-    inputs = make_inputs(129, 3, 48, torch.float16)
-    stream = torch.cuda.Stream()
-    stream.wait_stream(torch.cuda.current_stream())
-    with torch.cuda.stream(stream):
-        for _ in range(3):
-            lightning_indexer(
-                *inputs, 37, causal=causal, impl="fused", kernel_options={"backend": "triton"}
-            )
-    torch.cuda.current_stream().wait_stream(stream)
-    graph = torch.cuda.CUDAGraph()
-    with torch.cuda.graph(graph, stream=stream):
-        actual = lightning_indexer(
-            *inputs, 37, causal=causal, impl="fused", kernel_options={"backend": "triton"}
-        )
-    for _ in range(2):
-        for tensor in inputs:
-            tensor.normal_()
-        graph.replay()
-        expected = lightning_indexer(
-            *inputs, 37, causal=causal, impl="fused", kernel_options={"backend": "triton"}
-        )
-        torch.testing.assert_close(actual, expected, rtol=0, atol=0)

--- a/test/test_indexer_triton.py
+++ b/test/test_indexer_triton.py
@@ -142,6 +142,9 @@ def test_triton_strided_inputs(causal):
         q, k, weights, 37, causal=causal, impl="fused", kernel_options={"backend": "triton"}
     )
     assert_selection(actual, q, k, weights, 37, causal)
+    from attn_gym.sparse.indexer.ops import _indexer_op
+
+    torch.library.opcheck(_indexer_op, (q, k, weights, 37, causal, "triton"))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Follow up on #449, based on merged `main` (`8df9975`): add the previously validated streaming Triton implementation and address the indexer API/documentation review.

- `lightning_indexer(..., impl="fused")` now selects **CuTe on SM100** and **Triton on other supported NVIDIA GPUs (SM90+)**, including Hopper. Explicit `kernel_options={"backend": "cute" | "triton"}` overrides remain available. Unsupported devices/layouts/shapes raise; there is no fallback on a backend error.
- Preserve the streaming Triton arithmetic and fixed schedule: TMA input tiles, tensor-core scoring, on-chip running Top-K, and no quadratic global score workspace. Keep int32 addressing for ordinary layouts and int64 specialization when needed.
- Flatten `impl/cute/impl.py` to `impl/cute.py`, remove its package re-export, and consistently name private backend entrypoints `launch`. `lightning_indexer` remains the public export.
- Document `impl="fused"`/`"reference"`, fullgraph/dynamic compilation, CUDA Graph replay, backend restrictions, and `-1` causal padding in the API and new Sparse Attention reference page.
- Define **finite inputs and finite intermediate FP32 scores** as the supported contract. NaN/Inf behavior may differ across backends and is not host-validated; this does not claim NaN parity.
- Clarify training: integer indices are nondifferentiable. Selected attention trains its own computation, but gradients do not propagate through selection into indexer scoring weights; those require a separate objective.

## Final-head validation

All results below cover **`f7b8a98`**, including the API, module reorganization, automatic dispatch, and final tests—not the older `02237158` revision.

Environment on both GPUs: Python 3.13.13, PyTorch `2.15.0.dev20260909+cu132`, CUDA 13.2, Triton `3.8.0+gitc01b6774`, CuTeDSL 4.6.3, TVM-FFI 0.1.14rc4, cuda-python 13.4.1. Exact source imports verified in isolated per-checkout environments.

- **B200:** 174 focused tests passed (170 with six workers, four large FP64-oracle cases with two workers).
- **H100:** 64 passed, 106 skipped (CuTe-specific coverage is unsupported on Hopper).
- Separate automatic-dispatch/fullgraph smoke test and actual active weight offset at `2**31`: passed on both GPUs.
- Coverage includes FP16/BF16 reference accuracy, causal bounds/padding/ties, TMA alignment and supported striding, all opcheck utilities including grad-requiring and strided inputs, forced-int64 equivalence, public fullgraph, dynamic batch/sequence reuse with a compilation counter, and changed-input CUDA Graph replay for automatic and explicit routes.
- A graph-reuse test initially encountered Dynamo's incidental `batch == heads` duck-shape guard. The final fixture starts with distinct dimensions and verifies one graph across `(B,T)=(3,17),(4,33),(5,65)`; no production workaround was added.
- Independently reran the merged #449 revision (`8df9975`) on B200 before applying this follow-up: all 111 focused tests passed. Its Ruff checks and formatter checks passed, confirming the later lint commits resolved the two prior formatting findings.
- Final Ruff/pre-commit checks passed; documentation builds with `mkdocs build --strict`.

## Performance

Public-API **forward selection microbenchmark**, not end-to-end attention/training. Latency is in microseconds, **lower is better**. B=1, D=128, contiguous BF16 inputs, uniform[-1,1], seed 449. Frozen nine-case matrix; five alternating-order rounds, 30 samples per round, 25 eager and 25 replay warmups. Reported values are medians of round medians. Fixed-pointer CUDA Graph replay measures warm/reused buffers; capture, compilation, setup and allocation are excluded from timing. Default clocks/DVFS; before/after clock/power/temperature snapshots and raw samples retained, without claiming locked clocks or cold-DRAM behavior. One-second cooldown between shapes. Transformer Nuggets source `b8ae46b` provides timing and route inspection.

| Tokens T | Heads H | Top-K | Causal | H100 Triton µs ↓ | B200 Triton µs ↓ | B200 CuTe µs ↓ |
|---:|---:|---:|:---:|---:|---:|---:|
| 512 | 64 | 128 | no | 36.06 | 52.93 | 35.81 |
| 512 | 64 | 128 | yes | 29.47 | 38.06 | 30.03 |
| 2048 | 64 | 128 | no | 402.51 | 581.92 | 203.71 |
| 2048 | 64 | 128 | yes | 233.15 | 339.58 | 154.96 |
| 4096 | 64 | 128 | no | 1518.24 | 2254.77 | 632.61 |
| 4096 | 64 | 128 | yes | 825.68 | 1216.13 | 412.11 |
| 2048 | 128 | 128 | yes | 420.86 | 367.34 | 183.38 |
| 2048 | 64 | 512 | yes | 664.53 | 609.54 | 502.78 |
| 1025 | 64 | 128 | yes | 75.63 | 107.78 | 60.98 |

On this matrix, H100 reference/Triton latency ratios are **6.18–17.95×** (higher means Triton is faster); B200 Triton/CuTe ratios are **1.21–3.56×** (higher means CuTe is faster). CuTe therefore stays the SM100 default. No tuning or cross-hardware performance guarantee is introduced.

Every timed route passed full index invariants and 17 sampled FP64-row selection checks; observed boundary regret was zero. Profiler kernel names verified that automatic dispatch used Triton on H100 and CuTe on B200. Both optimized paths allocated only their output in the measured calls. No backward kernel is timed or promised.

The two ephemeral gpu-dev reservations were cancelled after collecting the test logs, JUnit reports, raw timing samples and environment metadata.
