### PR TITLE
Enable time splitting for long one-wave affine summaries

### DIFF
--- a/attn_gym/linear/_delta_rule/cute/affine_summary_fwd.py
+++ b/attn_gym/linear/_delta_rule/cute/affine_summary_fwd.py
@@ -1173,6 +1173,8 @@ def _compile_affine_summary(
 # so a work item must carry enough chunks for the shortened chain to pay for them. Measured
 # crossover on GB200 is ~32 chunks total; 16 chunks per item keeps every split a win.
 MIN_CHUNKS_PER_ITEM = 16
+# Widening an otherwise one-wave scan pays for the extra planner/fold at long spans.
+MIN_CHUNKS_FOR_WIDE_SPLIT = 128
 # The forward launches and both Triton fallbacks put ranges or work items on grid.z (limit
 # 65535); leave room for the work budget, which is at most the SM count.
 MAX_RANGES = 65535 - 1024
@@ -1187,6 +1189,18 @@ def plan_work_budget(max_chunks: int, work_tiles: int, sm_count: int) -> int:
     length); the items themselves are cut on the device by ``plan_work_items``.
     """
     return max(1, min(max_chunks // MIN_CHUNKS_PER_ITEM, sm_count // work_tiles))
+
+
+def select_state_columns(max_chunks: int, heads: int, ranges: int, sm_count: int) -> int:
+    """Choose the native state tile from span capacity and available time parallelism."""
+    narrow_tiles = heads * (SUMMARY_DIM // 32)
+    if ranges * narrow_tiles > sm_count:
+        return 64
+    # BN32 is faster per chunk, but BN64 can split a long otherwise-unsplit recurrence
+    # while keeping its active pieces in one wave. Already-split scans keep the narrower tile.
+    if max_chunks >= MIN_CHUNKS_FOR_WIDE_SPLIT and sm_count // narrow_tiles == 1:
+        return 64
+    return 32
 
 
 @torch.compiler.disable
@@ -1282,10 +1296,7 @@ def build_state_summaries(
         state_bn = _select_block_columns(heads, capability)
     else:
         kg, w, u, cumulative_gate = (_aligned(tensor) for tensor in (kg, w, u, cumulative_gate))
-        # BN=32 is faster per CTA (measured ~1.5x vs BN=64 on GB200); fall back to
-        # BN=64 only when the extra column tiles would spill past one CTA wave and
-        # serialize whole recurrence chains.
-        state_bn = 32 if ranges * heads * (SUMMARY_DIM // 32) <= sm_count else 64
+        state_bn = select_state_columns(cdiv(tokens, BT), heads, ranges, sm_count)
     # The bounds live on the device, so the budget comes from the span's chunk count (a static
     # upper bound) and the device cuts the ranges' actual chunks into that many items.
     budget = plan_work_budget(cdiv(tokens, BT), heads * (SUMMARY_DIM // state_bn), sm_count)

--- a/test/test_delta_affine_summary.py
+++ b/test/test_delta_affine_summary.py
@@ -447,6 +447,65 @@ def test_plan_work_budget_fills_one_wave_without_tiny_items(
     assert budget == 1 or max_chunks // budget >= native_fwd.MIN_CHUNKS_PER_ITEM
 
 
+@pytest.mark.parametrize(
+    ("max_chunks", "heads", "ranges", "sm_count", "expected"),
+    [
+        (127, 16, 1, 152, 32),  # The wider split must pay for planning and composition.
+        (128, 16, 1, 152, 64),
+        (129, 16, 1, 152, 64),
+        (512, 9, 1, 152, 32),  # Narrow tiles already leave room for time splitting.
+        (512, 10, 1, 152, 64),
+        (512, 19, 1, 152, 64),
+        (512, 20, 1, 152, 64),  # Narrow tiles already overflow one wave.
+        (512, 18, 1, 148, 64),
+        (512, 19, 1, 148, 64),
+        (127, 16, 2, 152, 64),  # Preserve the packed-range choice.
+        (512, 16, 2, 152, 64),
+        (512, 1, 1, 152, 32),
+    ],
+)
+def test_state_columns_leave_room_for_long_time_splits(
+    max_chunks, heads, ranges, sm_count, expected
+):
+    assert native_fwd.select_state_columns(max_chunks, heads, ranges, sm_count) == expected
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("tokens", [8128, 8193])
+def test_native_summary_tile_choice_and_layout_replay(dtype, tokens, monkeypatch):
+    """The public selector preserves tail arithmetic and replay across empty/short ranges."""
+    if not is_sm100_kda_capability(torch.cuda.get_device_capability()):
+        pytest.skip("native state tile selection requires SM100/SM103")
+    heads = torch.cuda.get_device_properties().multi_processor_count // 8
+    _, kg, w, u, _, _, gate = make_summary_inputs(89, dtype, tokens, heads)
+    bounds = whole_stream(kg)
+    compile_summary = Mock(wraps=native_fwd._compile_affine_summary)
+    monkeypatch.setattr(native_fwd, "_compile_affine_summary", compile_summary)
+    expected_bn = 32 if tokens == 8128 else 64
+    for _ in range(2):
+        native_fwd.build_state_summaries(kg, w, u, gate, bounds)
+    assert compile_summary.call_args.args[2] == expected_bn
+    assert compile_summary.call_args.kwargs["whole_ranges"] == (expected_bn == 32)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        actual = native_fwd.build_state_summaries(kg, w, u, gate, bounds)
+    for start, stop in ((0, tokens), (0, 0), ((tokens // 64 - 1) * 64, tokens)):
+        bounds.copy_(torch.tensor([[start, stop]], device=kg.device, dtype=torch.int32))
+        graph.replay()
+        if start == stop:
+            expected = torch.cat(
+                (
+                    torch.zeros(heads, 128, 128, device=kg.device),
+                    torch.eye(128, device=kg.device).expand(heads, -1, -1),
+                ),
+                dim=1,
+            )
+        else:
+            expected = state_summary_reference(*(t[:, start:stop] for t in (kg, w, u, gate)))
+        torch.testing.assert_close(actual[0], expected, atol=2e-4, rtol=2e-4)
+
+
 WORK_LAYOUTS = [
     pytest.param([[0, 300], [300, 300], [300, 428], [428, 500], [500, 640]], 4, id="mixed"),
     pytest.param([[0, 32768]] + [[32768, 32768]] * 7, 18, id="one-long-seven-empty"),


### PR DESCRIPTION
## Summary

Choose the native forward-summary state tile with time splitting in mind. BN32 is faster per chunk, but when its tiles already fill one SM wave it prevents the existing work planner from shortening a long recurrence. At 128+ chunks, BN64 permits two or three concurrent pieces instead.

This is a host-selector change only: it reuses the existing BN64 kernel, device work planner and composition. No new public options, kernel math, dependencies, reverse changes or portable-backend changes. Short spans and already-split narrow scans retain their existing selection.

Tests cover the length/head/SM boundaries and actual public dispatch, numerical tails and full→empty→short-range CUDA Graph replay for BF16/FP16. A focused simplifier review kept the patch to one selector and one threshold; its test-current-device finding was fixed.

## Performance

GB200 (152 SMs), torch 2.15.0.dev20260902+cu132, Triton 3.8, CuTeDSL 4.6.2. Fixed-pointer CUDA Graph replay, same inputs/env/GPU reservation for A/B, alternating rounds, compilation/capture excluded. GPU clocks sampled at 2062 MHz during >=50%-utilization intervals; factory DVFS, not a cold-DRAM benchmark.

Prepared forward-summary latency, **µs; lower is better** (median of three rounds, 40 samples/round):

| Heads / dtype / tokens | Before | After |
|---|---:|---:|
| 10 / BF16 / 8192 | 150.5 | 102.8 |
| 10 / BF16 / 32768 | 568.4 | 307.8 |
| 16 / BF16 / 8192 | 149.5 | 130.6 |
| 16 / BF16 / 32768 | 572.0 | 439.1 |
| 19 / BF16 / 32768 | 570.4 | 439.2 |
| 19 / FP16 / 32768 | 492.1 | 359.8 |

The frozen 21-case sweep also covers H9/H20 controls, 8128/8129-token boundary, equal/unequal packed ranges and short/empty selection from a large buffer. Controls that retain the same route were unchanged within noise.

Real NCCL CP2 **complete core** timings, H16/K=V128/BF16, one 65536-token document, 32768 tokens/rank, log gate -0.01 and nonzero terminal-state loss. **Forward / backward µs; lower is better**. Five alternating rounds of 40 samples; aggregate max-rank time per iteration. This excludes projections/convolution and is not a full-model speedup claim.

| Variant | Before fwd / bwd | After fwd / bwd |
|---|---:|---:|
| KDA | 1982.2 / 3564.1 | 1846.8 / 3564.6 |
| GDN | 1777.3 / 3450.5 | 1643.1 / 3449.9 |

### Tradeoff

Selection uses static buffer capacity, not device-resident bounds. Summarizing only 64 tokens from a 32768-token/H16 buffer costs about **14 µs extra**; an empty range costs about **5 µs extra**. A packed CP2 workload with only a 128-token document crossing the rank boundary adds about **12 µs to forward** (~0.8% KDA / 1.0% GDN). No universal packed-workload improvement is claimed. The H16/one-range split adds approximately 6 MiB of transient map storage; allocator peak was not measured. Numerical association may change within the existing accuracy contract.

## Validation

- `uv run --no-sync pytest -n 6 -v -rA test/test_delta_affine_summary.py test/test_delta_rule_stages.py`: **299 passed, 55 skipped**. Skips are optional cuDNN tests requiring DSL >=4.7; this changes the default fused path.
- `uv run --no-sync pytest -n 6 -v -rA test/test_context_parallel_distributed.py test/test_delta_affine_summary.py::test_native_summary_tile_choice_and_layout_replay`: **8 passed** on two GPUs, including real NCCL and changing-document-layout replay.
- Full KDA module validation: `torchrun --standalone --nproc-per-node=2 examples/linear/delta_rule_context_parallel.py --sequence-lengths 65536 --hidden-size 512 --heads 16 --cuda-graph`: both ranks passed unsharded output/gradient and changed-input replay checks.
- Restoring the old selector makes the new 8193-token dispatch regression fail at `32 == 64`; it passes with this patch.
- All six CP2 benchmark cases compare before/after output, final states and five input gradients before timing; all 21 summary cases pass before/after numerical checks.
- Applicable `prek` hooks and `git diff --check` passed. GPU commands ran through `gpu-run` with process timeouts; no hangs.

Benchmark scripts, raw samples, telemetry and the exact baseline snapshot are retained in the investigation artifacts under `agent_space/cp_summary_joint_pr/` and the agent-notes findings bundle.
