### PR TITLE
Replace CuTe lightning indexer with bounded-workspace radix Top-K

### DIFF
--- a/.agents/skills/validating-pytorch-custom-ops/SKILL.md
+++ b/.agents/skills/validating-pytorch-custom-ops/SKILL.md
@@ -400,6 +400,12 @@ for utility, result in results.items():
 `opcheck` does not validate numerical correctness. A kernel can pass every utility and still compute
 wrong values. Pair it with reference forward tests and gradient tests.
 
+For unordered index outputs, AOT opcheck's exact tensor comparison can reject a valid permutation.
+Keep all utilities on a stable-output case (for example, selecting every candidate), then test the
+selective production path under fullgraph/dynamic compilation and replay with range, uniqueness,
+valid-count and reference-score checks. Do not widen integer tolerances or require deterministic
+ordering merely to satisfy opcheck when ordering and boundary tie choices are unspecified.
+
 ## Numerical correctness
 
 Every optimized backend needs a trusted eager/reference oracle. Compare:

--- a/attn_gym/_backends/cute/utils.py
+++ b/attn_gym/_backends/cute/utils.py
@@ -95,26 +95,28 @@ def make_fake_strided_tensor(
     dtype: Any,
     shape: tuple[Any, ...],
     *,
-    contiguous_dim: int = -1,
+    contiguous_dim: int | None = -1,
     stride_divisibility: int = 1,
     assumed_align: int | None = None,
     use_int64_strides: bool = True,
 ) -> Any:
-    """Create a fake tensor with one contiguous mode and dynamic other strides.
+    """Create a fake tensor with dynamic strides and an optional contiguous mode.
 
+    ``contiguous_dim=None`` leaves every stride dynamic, for ordinary scalar loads.
     ``stride_divisibility`` is measured in elements. When ``assumed_align`` is omitted,
     it is derived from that divisibility and the element width, matching the weakest
     alignment promised by the dynamic stride layout.
     """
     if not shape:
         raise ValueError("make_fake_strided_tensor requires at least one dimension")
-    if not -len(shape) <= contiguous_dim < len(shape):
+    if contiguous_dim is not None and not -len(shape) <= contiguous_dim < len(shape):
         raise ValueError(f"contiguous_dim is out of range for rank {len(shape)}")
     if not 1 <= stride_divisibility:
         raise ValueError("stride_divisibility must be positive")
     if assumed_align is not None and assumed_align < 1:
         raise ValueError("assumed_align must be positive")
-    contiguous_dim %= len(shape)
+    if contiguous_dim is not None:
+        contiguous_dim %= len(shape)
     from cutlass import cute
 
     sym_int = cute.sym_int64 if use_int64_strides else cute.sym_int

--- a/attn_gym/sparse/indexer/api.py
+++ b/attn_gym/sparse/indexer/api.py
@@ -127,9 +127,11 @@ def lightning_indexer(
 
     Fused backends support ``torch.compile(fullgraph=True)`` and CUDA Graph replay.
     Both require FP16/BF16 inputs, T <= 2**20, and topk <= 512. CuTe requires SM100,
-    even H, D divisible by 16, and contiguous, 16-byte-aligned inputs. Triton requires
-    SM90 or newer, H <= 256, D <= 256 divisible by 8, and Q/K with unit last strides
-    and 16-byte-aligned bases and outer strides; weights may be strided.
+    even H, D divisible by 16, and Q/K with unit last strides and 16-byte-aligned
+    bases and non-singleton outer strides. Other Q/K strides may vary independently;
+    weights may have arbitrary strides and need only element alignment.
+    Triton requires SM90 or newer, H <= 256, D <= 256 divisible by 8, and Q/K with
+    unit last strides and 16-byte-aligned bases and outer strides; weights may be strided.
     CuTe reuses a per-call FP32 score workspace capped at 32 MiB and 1024 query
     rows. Large inputs use slabs rather than an unbounded quadratic score allocation.
     This workspace is additional to the returned indices and is not shared across calls.
@@ -137,7 +139,7 @@ def lightning_indexer(
     Selection with NaN/Inf scores is unspecified and may differ across backends.
     Indices are nondifferentiable even when inputs require gradients. Training
     attention over the selected positions does not propagate gradients through
-    selection into q, k, or weights; scoring weights need a separate training loss.
+    selection into q, k, or weights.
     """
 
     _validate_inputs(q, k, weights, topk, causal)

--- a/attn_gym/sparse/indexer/api.py
+++ b/attn_gym/sparse/indexer/api.py
@@ -122,7 +122,7 @@ def lightning_indexer(
 
     Returns:
         Contiguous [B, T, topk] INT32 indices. Order and tie-breaking are not
-        guaranteed across backends. Causal rows with fewer than topk candidates
+        guaranteed, including across repeated calls. Causal rows with fewer than topk candidates
         contain -1 padding; topk=0 returns an empty last dimension.
 
     Fused backends support ``torch.compile(fullgraph=True)`` and CUDA Graph replay.
@@ -130,6 +130,9 @@ def lightning_indexer(
     even H, D divisible by 16, and contiguous, 16-byte-aligned inputs. Triton requires
     SM90 or newer, H <= 256, D <= 256 divisible by 8, and Q/K with unit last strides
     and 16-byte-aligned bases and outer strides; weights may be strided.
+    CuTe reuses a per-call FP32 score workspace capped at 32 MiB and 1024 query
+    rows. Large inputs use slabs rather than an unbounded quadratic score allocation.
+    This workspace is additional to the returned indices and is not shared across calls.
 
     Selection with NaN/Inf scores is unspecified and may differ across backends.
     Indices are nondifferentiable even when inputs require gradients. Training

--- a/attn_gym/sparse/indexer/impl/LICENSE.Apache-2.0
+++ b/attn_gym/sparse/indexer/impl/LICENSE.Apache-2.0
@@ -1,0 +1,204 @@
+Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/attn_gym/sparse/indexer/impl/NOTICE.cudnn
+++ b/attn_gym/sparse/indexer/impl/NOTICE.cudnn
@@ -1,0 +1,13 @@
+The score-generation and radix-selection kernels in cute_score.py,
+cute_score_generic.py and cute_topk.py adapt cuDNN Frontend source at commit
+1ab7d63be81f1ef2eb3b2dea5367219cf9674a5f. Attention Gym changes their interfaces,
+workspace layout, scheduling and outputs; they do not depend on the cuDNN
+Frontend package. The applicable license is in LICENSE.Apache-2.0.
+
+Upstream attribution:
+
+cudnn-frontend
+Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+This product includes software developed at NVIDIA CORPORATION
+(https://www.nvidia.com/).

--- a/attn_gym/sparse/indexer/impl/cute.py
+++ b/attn_gym/sparse/indexer/impl/cute.py
@@ -4,7 +4,7 @@ A slab contains at most 1024 query rows and 32 MiB of FP32 scores, independent
 of batch size and sequence length. Consecutive launches reuse that per-call
 allocation on the current stream; the only retained result is the INT32 index
 array. Slabs contain whole query pairs, including a masked second row for odd T.
-The existing registered operator calls this launcher; there is no backend fallback.
+The registered operator calls this launcher; there is no backend fallback.
 """
 
 import math
@@ -13,28 +13,33 @@ from pathlib import Path
 
 import torch
 
-from attn_gym._backends.cute import compile_tvm_ffi, get_device_properties, jit_cache
+from attn_gym._backends.cute import (
+    TMA_ALIGNMENT_BYTES,
+    compile_tvm_ffi,
+    get_device_properties,
+    jit_cache,
+    make_fake_strided_tensor,
+    tensor_supports_tma,
+)
 from attn_gym._backends.cute.target import (
     detect_compile_target,
     get_compile_target,
     set_compile_target,
 )
 from attn_gym._backends.cute.utils import initialized_cuda_device, requires_int64_abi
+from attn_gym.utils import cdiv
 
-# Limit both the row count (linear storage as T grows) and absolute scratch bytes.
 _HEAD_DIM_GRANULARITY = 16
-_ALIGNMENT = 16
 _MAX_SEQUENCE = 1 << 20
 _MAX_SUPPORTED_TOPK = 512
+# Limit both the row count (linear storage as T grows) and absolute scratch bytes.
 _MAX_SCORE_PAIRS = 512
 _SCORE_WORKSPACE_BYTES = 32 * 1024 * 1024
 
 
 def score_workspace_pairs(batch: int, tokens: int) -> int:
     """Size a slab for positive B and the validated CuTe domain 1 <= T <= 2**20."""
-    return min(
-        _MAX_SCORE_PAIRS, batch * ((tokens + 1) // 2), _SCORE_WORKSPACE_BYTES // (8 * tokens)
-    )
+    return min(_MAX_SCORE_PAIRS, batch * cdiv(tokens, 2), _SCORE_WORKSPACE_BYTES // (8 * tokens))
 
 
 @jit_cache(
@@ -44,9 +49,14 @@ def score_workspace_pairs(batch: int, tokens: int) -> int:
     )
 )
 def _compile_scores(
-    dtype: torch.dtype, heads: int, head_dim: int, causal: bool, use_int64_offsets: bool
+    dtype: torch.dtype,
+    heads: int,
+    head_dim: int,
+    causal: bool,
+    use_int64_offsets: bool,
+    contiguous_weight_heads: bool,
 ) -> Callable[..., None]:
-    """Compile score production with symbolic B, T and slab capacity."""
+    """Compile symbolic B/T/strides, specializing only an available unit weight-head stride."""
     import cutlass
     from cutlass import cute
 
@@ -54,38 +64,42 @@ def _compile_scores(
     from .cute_score_generic import IndexerGenericScoreKernel
 
     operation = (
-        IndexerScoreKernel(heads, head_dim, causal, use_int64_offsets)
-        if heads in (32, 64) and head_dim == 128
-        else IndexerGenericScoreKernel(heads, head_dim, causal, use_int64_offsets)
+        IndexerScoreKernel if heads in (32, 64) and head_dim == 128 else IndexerGenericScoreKernel
+    )(
+        heads,
+        head_dim,
+        causal,
+        use_int64_offsets,
+        contiguous_weight_heads=contiguous_weight_heads,
     )
     io_dtype = cutlass.BFloat16 if dtype == torch.bfloat16 else cutlass.Float16
     sym = cute.sym_int64 if use_int64_offsets else cute.sym_int
     integer = cutlass.Int64 if use_int64_offsets else cutlass.Int32
     batch, tokens, pairs = sym(), sym(), sym()
-    # The public compact-input contract permits arbitrary singleton batch strides.
-    q = cute.runtime.make_fake_tensor(
+    q = make_fake_strided_tensor(
         io_dtype,
         (batch, tokens, heads, head_dim),
-        stride=(sym(divisibility=8), heads * head_dim, head_dim, 1),
-        assumed_align=16,
+        stride_divisibility=TMA_ALIGNMENT_BYTES // (io_dtype.width // 8),
+        use_int64_strides=use_int64_offsets,
     )
-    k = cute.runtime.make_fake_tensor(
+    k = make_fake_strided_tensor(
         io_dtype,
         (batch, tokens, head_dim),
-        stride=(sym(divisibility=8), head_dim, 1),
-        assumed_align=16,
+        stride_divisibility=TMA_ALIGNMENT_BYTES // (io_dtype.width // 8),
+        use_int64_strides=use_int64_offsets,
     )
-    weights = cute.runtime.make_fake_tensor(
+    weights = make_fake_strided_tensor(
         io_dtype,
         (batch, tokens, heads),
-        stride=(sym(), heads, 1),
-        assumed_align=16,
+        contiguous_dim=-1 if contiguous_weight_heads else None,
+        use_int64_strides=use_int64_offsets,
     )
     scores = cute.runtime.make_fake_compact_tensor(
         cutlass.Float32,
         (pairs, 2, tokens),
         stride_order=(2, 1, 0),
-        assumed_align=16,
+        assumed_align=TMA_ALIGNMENT_BYTES,
+        use_32bit_stride=not use_int64_offsets,
     )
     return compile_tvm_ffi(
         operation,
@@ -113,13 +127,15 @@ def _compile_topk(topk: int, causal: bool, use_int64_offsets: bool) -> Callable[
         cutlass.Float32,
         (pairs, 2, tokens),
         stride_order=(2, 1, 0),
-        assumed_align=16,
+        assumed_align=TMA_ALIGNMENT_BYTES,
+        use_32bit_stride=not use_int64_offsets,
     )
     output = cute.runtime.make_fake_compact_tensor(
         cutlass.Int32,
         (batch, tokens, topk),
         stride_order=(2, 1, 0),
-        assumed_align=16,
+        assumed_align=TMA_ALIGNMENT_BYTES,
+        use_32bit_stride=not use_int64_offsets,
     )
     return compile_tvm_ffi(
         IndexerTopKKernel(topk, causal, use_int64_offsets), scores, output, integer(0)
@@ -127,7 +143,7 @@ def _compile_topk(topk: int, causal: bool, use_int64_offsets: bool) -> Callable[
 
 
 def _validate(q: torch.Tensor, k: torch.Tensor, weights: torch.Tensor, topk: int) -> None:
-    """Preserve the CuTe input and error contract without inspecting tensor values."""
+    """Validate SM100 indexer tensor metadata and base alignment."""
     if q.ndim != 4:
         raise ValueError(f"q must have shape [B,T,H,D], got {tuple(q.shape)}")
     if k.ndim != 3:
@@ -176,10 +192,12 @@ def _validate(q: torch.Tensor, k: torch.Tensor, weights: torch.Tensor, topk: int
         raise TypeError(
             f"q, k, and weights must have one dtype, got {q.dtype}, {k.dtype}, {weights.dtype}"
         )
-    if any(not tensor.is_contiguous() for tensor in tensors):
-        raise ValueError("q, k, and weights must be contiguous")
-    if any(tensor.data_ptr() % _ALIGNMENT for tensor in tensors):
-        raise ValueError(f"q, k, and weights must be {_ALIGNMENT}-byte aligned")
+    # Singleton strides do not address another slice; TVM-FFI normalizes them for TMA.
+    if any(not tensor_supports_tma(tensor.squeeze()) for tensor in (q, k)):
+        raise ValueError(
+            f"q and k require unit last strides and {TMA_ALIGNMENT_BYTES}-byte aligned "
+            "bases and non-singleton outer strides"
+        )
     properties = get_device_properties(q.device)
     if (properties.major, properties.minor) != (10, 0):
         raise RuntimeError("this tcgen05 kernel requires an SM100 GPU")
@@ -192,7 +210,7 @@ def launch(
     topk: int,
     causal: bool = False,
 ) -> torch.Tensor:
-    """Run bounded score generation and radix selection for the existing CuTe domain."""
+    """Compute weighted-ReLU Top-K with bounded per-call score storage."""
     import cutlass
 
     _validate(q, k, weights, topk)
@@ -208,17 +226,22 @@ def launch(
     previous = get_compile_target()
     try:
         set_compile_target(detect_compile_target(q.device.index))
-        score_kernel = _compile_scores(q.dtype, heads, head_dim, causal, use_int64_offsets)
+        # A unit head stride avoids the generic reducer's measured strided-load overhead.
+        score_kernel = _compile_scores(
+            q.dtype, heads, head_dim, causal, use_int64_offsets, weights.stride(-1) == 1
+        )
         topk_kernel = _compile_topk(topk, causal, use_int64_offsets)
     finally:
         set_compile_target(previous)
 
     q, k, weights = q.detach(), k.detach(), weights.detach()
     scale = cutlass.Float32(1.0 / math.sqrt(heads * head_dim))
+    total_pairs = batch * cdiv(tokens, 2)
     with initialized_cuda_device(q):
-        for start in range(0, batch * ((tokens + 1) // 2), pairs):
-            score_kernel(q, k, weights, scores, integer(start), scale)
-            topk_kernel(scores, output, integer(start))
+        for start in range(0, total_pairs, pairs):
+            active_scores = scores[: min(pairs, total_pairs - start)]
+            score_kernel(q, k, weights, active_scores, integer(start), scale)
+            topk_kernel(active_scores, output, integer(start))
     return output
 
 

--- a/attn_gym/sparse/indexer/impl/cute.py
+++ b/attn_gym/sparse/indexer/impl/cute.py
@@ -1,1470 +1,133 @@
-"""Two-queries-per-CTA tensor-core DSA/CSA prefill indexer for SM100.
+"""Bounded-workspace indexer for SM100 score generation followed by radix Top-K.
 
-Each CTA owns two adjacent query rows, reuses every staged key tile across both
-queries for each 64-head tile, and overlaps the tensor-core producer with two
-independent CUDA-warpgroup Top-K consumers.  Both final Top-K lists remain
-entirely in shared memory.  There are no global partial lists and no merge
-kernel.  The launcher is guarded by an
-in-process and persistent TVM-FFI compile cache keyed on the static shape/dtype
-contract (dtype, heads, head_dim, topk, causal) and compile target. Batch and
-sequence dimensions are symbolic.
+A slab contains at most 1024 query rows and 32 MiB of FP32 scores, independent
+of batch size and sequence length. Consecutive launches reuse that per-call
+allocation on the current stream; the only retained result is the INT32 index
+array. Slabs contain whole query pairs, including a masked second row for odd T.
+The existing registered operator calls this launcher; there is no backend fallback.
 """
 
 import math
-from dataclasses import dataclass
-from enum import IntEnum
+from collections.abc import Callable
+from pathlib import Path
 
-import cuda.bindings.driver as cuda_driver
-import cutlass
-import cutlass.utils.blackwell_helpers as sm100_utils
 import torch
-from cutlass import Float32, Int32, Int64, cute, pipeline, utils
-from cutlass._mlir.dialects import llvm
-from cutlass.cute.nvgpu import cpasync, tcgen05
-from cutlass.cutlass_dsl import T, dsl_user_op
 
-from attn_gym._backends.cute import compile_tvm_ffi, jit_cache
+from attn_gym._backends.cute import compile_tvm_ffi, get_device_properties, jit_cache
 from attn_gym._backends.cute.target import (
     detect_compile_target,
     get_compile_target,
     set_compile_target,
 )
+from attn_gym._backends.cute.utils import initialized_cuda_device, requires_int64_abi
 
+# Limit both the row count (linear storage as T grows) and absolute scratch bytes.
 _HEAD_DIM_GRANULARITY = 16
 _ALIGNMENT = 16
 _MAX_SEQUENCE = 1 << 20
 _MAX_SUPPORTED_TOPK = 512
-_INVALID_KEY = -(1 << 63)
-_INVALID_ORDINAL = -(1 << 31)
-_WARP_SIZE = 32
-
-
-@dataclass(frozen=True)
-class IndexerDType:
-    """Map a Torch storage dtype to its compile-time CuTeDSL type and artifact tag."""
-
-    cute_type: type[cutlass.Numeric]
-    name: str
-
-
-INDEXER_DTYPES = {
-    torch.float16: IndexerDType(cutlass.Float16, "fp16"),
-    torch.bfloat16: IndexerDType(cutlass.BFloat16, "bf16"),
-}
-_INDEXER_DTYPES_BY_NAME = {dtype.name: dtype for dtype in INDEXER_DTYPES.values()}
-
-
-@dataclass(frozen=True)
-class IndexerConfig:
-    """Tunable D tiling and pipeline/launch settings for the prefill kernel."""
-
-    tile_d: int = 64
-    k_stages: int = 2
-    q_stages: int = 4
-    mailbox_stages: int = 4
-    # Each M128xN64 FP32 accumulator occupies 64 TMEM columns.  Four stages per
-    # query hide reducer latency while remaining within the SM100 512-column
-    # TMEM allocation.  Reducer and selector warps are permanently disjoint.
-    acc_stages: int = 4
-    min_blocks_per_mp: int = 1
-
-
-class IndexerWarpRole(IntEnum):
-    """Fixed starting warp indices; reducer and selector roles span four warps."""
-
-    REDUCER_Q0 = 0
-    REDUCER_Q1 = 4
-    SELECTOR_Q0 = 8
-    SELECTOR_Q1 = 12
-    MMA = 16
-    LOAD = 17
-    END = 18
-
-
-@dsl_user_op
-def _bitcast_f32_to_i32(value, *, loc=None, ip=None) -> Int32:
-    return Int32(llvm.bitcast(T.i32(), Float32(value).ir_value()))
-
-
-@cute.jit
-def _make_score_ordinal(score: Float32) -> Int32:
-    """Map an FP32 score to the signed ordering used by packed keys."""
-    bits = _bitcast_f32_to_i32(score)
-    magnitude = bits & Int32(0x7FFFFFFF)
-    bits = Int32(0) if magnitude == Int32(0) else bits
-    ordinal = bits ^ ((bits >> Int32(31)) & Int32(0x7FFFFFFF))
-    return Int32(0x7FFFFFFF) if magnitude > Int32(0x7F800000) else ordinal
-
-
-@cute.jit
-def _pack_key(ordinal: Int32, index: Int32) -> Int64:
-    """Append the ascending-index tie break to a signed score ordinal."""
-    inverse_index = Int64(~index) & Int64(0xFFFFFFFF)
-    return ((Int64(ordinal) & Int64(0xFFFFFFFF)) << Int64(32)) | inverse_index
-
-
-@cute.jit
-def _bitonic_lane_value(
-    value: Int64,
-    other: Int64,
-    lower: cutlass.Boolean,
-    descending: cutlass.Boolean,
-) -> Int64:
-    """Select this lane's value for one descending bitonic comparator."""
-    larger = value if value > other else other  # noqa: FURB136
-    smaller = other if value > other else value  # noqa: FURB136
-    keep_larger = lower == descending
-    return larger if keep_larger else smaller
-
-
-class IndexerPrefillKernel:
-    tile_candidates = 128
-    tile_heads = 64
-    queries_per_cta = 2
-    selection_warps = 4
-    selection_threads = selection_warps * _WARP_SIZE
-    mma_instruction = (128, 64, 16)
-
-    @property
-    def acc_tmem_stages(self) -> int:
-        return self.queries_per_cta * self.config.acc_stages
-
-    @property
-    def mma_tile(self) -> tuple[int, int, int]:
-        return (self.tile_candidates, self.tile_heads, self.config.tile_d)
-
-    def __init__(
-        self,
-        heads: int,
-        head_dim: int,
-        topk: int,
-        causal: bool,
-        dtype: IndexerDType,
-        config: IndexerConfig | None = None,
-    ):
-        self.heads = heads
-        self.head_dim = head_dim
-        self.topk = topk
-        self.causal = causal
-        self.dtype = dtype
-        self.config = config if config is not None else IndexerConfig()
-
-        @cute.struct
-        class SharedStorage:
-            k_barriers: cute.struct.MemRange[Int64, self.config.k_stages * 2]
-            q_barriers: cute.struct.MemRange[Int64, self.config.q_stages * 2]
-            acc0_barriers: cute.struct.MemRange[Int64, self.config.acc_stages * 2]
-            acc1_barriers: cute.struct.MemRange[Int64, self.config.acc_stages * 2]
-            mailbox0_barriers: cute.struct.MemRange[Int64, self.config.mailbox_stages * 2]
-            mailbox1_barriers: cute.struct.MemRange[Int64, self.config.mailbox_stages * 2]
-            tmem_holding: Int32
-
-        self.SharedStorage = SharedStorage
-
-    @property
-    def run_size(self) -> int:
-        """Return the padded power-of-two persistent-run size for one query's Top-K.
-
-        Floored at ``tile_candidates`` (the incoming candidate-tile
-        granularity) and capped at ``_MAX_SUPPORTED_TOPK``. ``topk <=
-        tile_candidates`` always floors to ``tile_candidates``, so it reuses
-        the exact same specialized fast path as ``topk == tile_candidates``
-        -- there is no separate "small topk" case.
-        """
-        if self.topk > _MAX_SUPPORTED_TOPK:
-            raise NotImplementedError(
-                f"topk > {_MAX_SUPPORTED_TOPK} is not supported by the CuTeDSL "
-                f"indexer, got {self.topk}."
-            )
-        padded = 1 << (max(self.topk, 1) - 1).bit_length()
-        return max(self.tile_candidates, padded)
-
-    @property
-    def sort_span(self) -> int:
-        """Return each query's compile-time shared selection-workspace stride.
-
-        The workspace holds four runs of the padded run size: one persistent
-        run plus three buffer runs (raw accept buffer, plus the two scratch
-        runs a drain needs to sort and merge that buffer against the
-        persistent run).
-        """
-        return 4 * self.run_size
-
-    @property
-    def threads(self) -> int:
-        """Total CTA thread count for the fixed warp-role schedule."""
-        return int(IndexerWarpRole.END) * _WARP_SIZE
-
-    def get_name(self) -> str:
-        """Return the stable compiled-artifact name, including the schedule."""
-        return (
-            f"indexer_prefill_{self.dtype.name}_"
-            f"h{self.heads}_d{self.head_dim}_k{self.topk}_c{int(self.causal)}_"
-            f"sw{self.selection_warps}_ks{self.config.k_stages}_"
-            f"qs{self.config.q_stages}_ms{self.config.mailbox_stages}_"
-            f"as{self.config.acc_stages}"
-        )
-
-    @cute.kernel
-    def kernel(
-        self,
-        tiled_mma: cute.TiledMma,
-        tma_atom_k: cute.CopyAtom,
-        mK_sdb: cute.Tensor,
-        tma_atom_q: cute.CopyAtom,
-        mQ_hdtb: cute.Tensor,
-        mW_bth: cute.Tensor,
-        mOut_btk: cute.Tensor,
-        k_smem_layout: cute.ComposedLayout,
-        q_smem_layout: cute.ComposedLayout,
-        score_scale: Float32,
-    ):
-        """Dispatch the reducer, selector, MMA, and load warp roles."""
-        config = self.config
-        causal = self.causal
-        io_dtype = self.dtype.cute_type
-        tile_candidates = self.tile_candidates
-        tile_heads = self.tile_heads
-        tile_d = config.tile_d
-        queries_per_cta = self.queries_per_cta
-        selection_warps = self.selection_warps
-        selection_threads = self.selection_threads
-        mma_tile = self.mma_tile
-        threads = self.threads
-
-        reducer_q1_start = int(IndexerWarpRole.REDUCER_Q1)
-        selector_q0_start = int(IndexerWarpRole.SELECTOR_Q0)
-        selector_q1_start = int(IndexerWarpRole.SELECTOR_Q1)
-        mma_warp = int(IndexerWarpRole.MMA)
-        load_warp = int(IndexerWarpRole.LOAD)
-
-        tidx, _, _ = cute.arch.thread_idx()
-        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
-        lane = tidx & Int32(_WARP_SIZE - 1)
-        query_pair, batch, _ = cute.arch.block_idx()
-
-        num_candidates = cute.size(mK_sdb.shape[0])
-        num_heads = cute.size(mQ_hdtb.shape[0])
-        num_queries = cute.size(mQ_hdtb.shape[2])
-        query0 = query_pair * Int32(queries_per_cta)
-        query1 = query0 + Int32(1)
-        query1_active = query1 < num_queries
-        query1_load = query1 if query1_active else query0
-        mK_sd = mK_sdb[None, None, batch]
-        mQ0_hd = mQ_hdtb[None, None, query0, batch]
-        mQ1_hd = mQ_hdtb[None, None, query1_load, batch]
-
-        smem = utils.SmemAllocator()
-        storage = smem.allocate(self.SharedStorage)
-        sK = smem.allocate_tensor(
-            element_type=io_dtype,
-            layout=k_smem_layout.outer,
-            byte_alignment=128,
-            swizzle=k_smem_layout.inner,
-        )
-        sQ = smem.allocate_tensor(
-            element_type=io_dtype,
-            layout=q_smem_layout.outer,
-            byte_alignment=128,
-            swizzle=q_smem_layout.inner,
-        )
-        selection_keys = smem.allocate_tensor(
-            Int64,
-            cute.make_layout(
-                (queries_per_cta * self.sort_span + queries_per_cta * 2 * tile_candidates,)
-            ),
-            byte_alignment=128,
-        )
-        buffer_counts = smem.allocate_tensor(
-            Int32,
-            cute.make_layout((queries_per_cta,)),
-            byte_alignment=16,
-        )
-        drain_flags = smem.allocate_tensor(
-            Int32,
-            cute.make_layout((queries_per_cta,)),
-            byte_alignment=16,
-        )
-        mailbox_ordinals = smem.allocate_tensor(
-            Int32,
-            cute.make_layout((queries_per_cta * config.mailbox_stages * tile_candidates,)),
-            byte_alignment=128,
-        )
-
-        if warp_idx == Int32(load_warp):
-            cpasync.prefetch_descriptor(tma_atom_k)
-            cpasync.prefetch_descriptor(tma_atom_q)
-
-        k_bytes_per_stage = cute.size_in_bytes(
-            io_dtype,
-            cute.select(k_smem_layout, mode=[0, 1, 2]),
-        )
-        q_bytes_per_stage = cute.size_in_bytes(
-            io_dtype,
-            cute.select(q_smem_layout, mode=[0, 1, 2]),
-        )
-        k_producer, k_consumer = pipeline.PipelineTmaUmma.create(
-            num_stages=config.k_stages,
-            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
-            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
-            tx_count=k_bytes_per_stage,
-            barrier_storage=storage.k_barriers.data_ptr(),
-            defer_sync=True,
-        ).make_participants()
-        q_producer, q_consumer = pipeline.PipelineTmaUmma.create(
-            num_stages=config.q_stages,
-            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
-            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
-            tx_count=q_bytes_per_stage,
-            barrier_storage=storage.q_barriers.data_ptr(),
-            defer_sync=True,
-        ).make_participants()
-        acc0_producer, acc0_consumer = pipeline.PipelineUmmaAsync.create(
-            num_stages=config.acc_stages,
-            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
-            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, selection_threads),
-            barrier_storage=storage.acc0_barriers.data_ptr(),
-            defer_sync=True,
-        ).make_participants()
-        acc1_producer, acc1_consumer = pipeline.PipelineUmmaAsync.create(
-            num_stages=config.acc_stages,
-            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
-            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, selection_threads),
-            barrier_storage=storage.acc1_barriers.data_ptr(),
-            defer_sync=True,
-        ).make_participants()
-        mailbox0_producer, mailbox0_consumer = pipeline.PipelineAsync.create(
-            num_stages=config.mailbox_stages,
-            producer_group=pipeline.CooperativeGroup(
-                pipeline.Agent.Thread,
-                selection_threads,
-            ),
-            consumer_group=pipeline.CooperativeGroup(
-                pipeline.Agent.Thread,
-                selection_threads,
-            ),
-            barrier_storage=storage.mailbox0_barriers.data_ptr(),
-            defer_sync=True,
-        ).make_participants()
-        mailbox1_producer, mailbox1_consumer = pipeline.PipelineAsync.create(
-            num_stages=config.mailbox_stages,
-            producer_group=pipeline.CooperativeGroup(
-                pipeline.Agent.Thread,
-                selection_threads,
-            ),
-            consumer_group=pipeline.CooperativeGroup(
-                pipeline.Agent.Thread,
-                selection_threads,
-            ),
-            barrier_storage=storage.mailbox1_barriers.data_ptr(),
-            defer_sync=True,
-        ).make_participants()
-
-        # All pipeline barriers are now initialized.  One fence and CTA
-        # rendezvous replaces the otherwise redundant synchronization
-        # performed by every individual pipeline constructor.
-        cute.arch.mbarrier_init_fence()
-        cute.arch.barrier()
-
-        fragment_k = tiled_mma.make_fragment_A(sK)
-        fragment_q = tiled_mma.make_fragment_B(sQ)
-        accumulator_shape = tiled_mma.partition_shape_C(mma_tile[:2])
-        accumulator_template = tiled_mma.make_fragment_C(
-            cute.append(accumulator_shape, self.acc_tmem_stages)
-        )
-
-        tmem_barrier = pipeline.NamedBarrier(barrier_id=1, num_threads=threads)
-        tmem = utils.TmemAllocator(
-            storage.tmem_holding.ptr,
-            barrier_for_retrieve=tmem_barrier,
-            allocator_warp_id=mma_warp,
-        )
-        tmem.allocate(utils.get_num_tmem_alloc_cols(accumulator_template))
-        tmem.wait_for_alloc()
-        tmem_ptr = tmem.retrieve_ptr(Float32)
-        accumulator = cute.make_tensor(tmem_ptr, accumulator_template.layout)
-
-        candidate_tiles = (
-            cute.ceil_div(query1_load + Int32(1), tile_candidates)
-            if causal
-            else cute.ceil_div(num_candidates, tile_candidates)
-        )
-        head_tiles = cute.ceil_div(num_heads, tile_heads)
-
-        if warp_idx < Int32(reducer_q1_start):
-            self._run_query_reducer_mailbox(
-                accumulator,
-                acc0_consumer,
-                mailbox_ordinals,
-                mailbox0_producer,
-                mW_bth,
-                tidx,
-                warp_idx,
-                lane,
-                batch,
-                query0,
-                query0 < num_queries,
-                0,
-                num_candidates,
-                num_heads,
-                candidate_tiles,
-                head_tiles,
-                score_scale,
-            )
-        elif warp_idx < Int32(selector_q0_start):
-            self._run_query_reducer_mailbox(
-                accumulator,
-                acc1_consumer,
-                mailbox_ordinals,
-                mailbox1_producer,
-                mW_bth,
-                tidx - Int32(selection_threads),
-                warp_idx - Int32(reducer_q1_start),
-                lane,
-                batch,
-                query1_load,
-                query1_active,
-                1,
-                num_candidates,
-                num_heads,
-                candidate_tiles,
-                head_tiles,
-                score_scale,
-            )
-        elif warp_idx < Int32(selector_q1_start):
-            self._run_query_selector_mailbox(
-                mailbox_ordinals,
-                mailbox0_consumer,
-                selection_keys,
-                buffer_counts,
-                drain_flags,
-                tidx - Int32(selector_q0_start * _WARP_SIZE),
-                warp_idx - Int32(selector_q0_start),
-                lane,
-                0,
-                candidate_tiles,
-            )
-        elif warp_idx < Int32(mma_warp):
-            self._run_query_selector_mailbox(
-                mailbox_ordinals,
-                mailbox1_consumer,
-                selection_keys,
-                buffer_counts,
-                drain_flags,
-                tidx - Int32(selector_q1_start * _WARP_SIZE),
-                warp_idx - Int32(selector_q1_start),
-                lane,
-                1,
-                candidate_tiles,
-            )
-
-        if warp_idx == Int32(load_warp):
-            self._run_paired_load(
-                tiled_mma,
-                tma_atom_k,
-                tma_atom_q,
-                mK_sd,
-                mQ0_hd,
-                mQ1_hd,
-                sK,
-                sQ,
-                candidate_tiles,
-                head_tiles,
-                k_producer,
-                q_producer,
-            )
-        elif warp_idx == Int32(mma_warp):
-            self._run_paired_mma(
-                tiled_mma,
-                accumulator,
-                fragment_k,
-                fragment_q,
-                candidate_tiles,
-                head_tiles,
-                cute.ceil_div(cute.size(mK_sd, mode=[1]), tile_d),
-                k_consumer,
-                q_consumer,
-                acc0_producer,
-                acc1_producer,
-            )
-        # Every selection group has already performed its mandatory final
-        # drain, so it may write its disjoint output rows without waiting
-        # for other roles.
-        selection_query = (warp_idx - Int32(selector_q0_start)) // Int32(selection_warps)
-        selection_tid = (tidx - Int32(selector_q0_start * _WARP_SIZE)) & Int32(
-            selection_threads - 1
-        )
-        selection_base = selection_query * Int32(self.sort_span)
-        query_index = query0 if selection_query == Int32(0) else query1
-        query_active = selection_query == Int32(0) or query1_active
-        is_selection_warp = warp_idx >= Int32(selector_q0_start) and warp_idx < Int32(mma_warp)
-        if is_selection_warp:
-            for write_round in cutlass.range_constexpr(
-                cute.ceil_div(self.topk, selection_threads)
-            ):
-                slot = selection_tid + Int32(write_round * selection_threads)
-                if query_active and slot < Int32(self.topk):
-                    key = Int64(selection_keys[selection_base + slot])
-                    mOut_btk[batch, query_index, slot] = ~Int32(key & Int64(0xFFFFFFFF))
-        tmem.relinquish_alloc_permit()
-        tmem_free_barrier = pipeline.NamedBarrier(barrier_id=2, num_threads=threads)
-        tmem_free_barrier.arrive_and_wait()
-        tmem.free(tmem_ptr)
-
-    @cute.jit
-    def _gemm_query_tile(
-        self,
-        tiled_mma: cute.TiledMma,
-        accumulator: cute.Tensor,
-        accumulator_stage: Int32,
-        fragment_k: cute.Tensor,
-        k_stage: Int32,
-        fragment_q: cute.Tensor,
-        q_stage: Int32,
-        d_tile: Int32,
-    ):
-        """Accumulate one candidate-tile by head-tile tensor-core tile."""
-        for d_block in cutlass.range_constexpr(cute.size(fragment_k, mode=[2])):
-            # TiledMma.set mutates its Python trait wrapper.  Clone it so an
-            # SSA value emitted in the MMA-warp branch cannot leak into
-            # another warp-role branch during CuTeDSL IR construction.
-            issue_mma = tiled_mma.with_()
-            issue_mma.set(
-                tcgen05.Field.ACCUMULATE,
-                cutlass.Boolean(d_tile != Int32(0) or d_block != 0),
-            )
-            cute.gemm(
-                issue_mma,
-                accumulator[(None, None, None, accumulator_stage)],
-                fragment_k[(None, None, d_block, k_stage)],
-                fragment_q[(None, None, d_block, q_stage)],
-                accumulator[(None, None, None, accumulator_stage)],
-            )
-
-    @cute.jit
-    def _sort_warp_quarter_desc(
-        self,
-        keys: cute.Tensor,
-        run_base: Int32,
-        lane: Int32,
-    ):
-        """Sort one ``tile_candidates``-key run using one warp, four keys per lane."""
-        values = cute.make_rmem_tensor(cute.make_layout((4,)), Int64)
-        for item in cutlass.range_constexpr(4):
-            values[item] = Int64(keys[run_base + lane + Int32(item * _WARP_SIZE)])
-
-        for level in cutlass.range_constexpr(7):
-            network_size = 1 << (level + 1)
-            for reverse_stage in cutlass.range_constexpr(level + 1):
-                distance = 1 << (level - reverse_stage)
-                if cutlass.const_expr(distance < _WARP_SIZE):
-                    for item in cutlass.range_constexpr(4):
-                        local_index = lane + Int32(item * _WARP_SIZE)
-                        other = Int64(cute.arch.shuffle_sync_bfly(values[item], distance))
-                        lower = (local_index & Int32(distance)) == Int32(0)
-                        descending = (local_index & Int32(network_size)) == Int32(0)
-                        values[item] = _bitonic_lane_value(
-                            values[item],
-                            other,
-                            lower,
-                            descending,
-                        )
-                else:
-                    register_distance = distance // _WARP_SIZE
-                    for item in cutlass.range_constexpr(4):
-                        partner_item = item ^ register_distance
-                        if cutlass.const_expr(partner_item > item):
-                            local_index = lane + Int32(item * _WARP_SIZE)
-                            value = Int64(values[item])
-                            other = Int64(values[partner_item])
-                            descending = (local_index & Int32(network_size)) == Int32(0)
-                            larger = value if value > other else other  # noqa: FURB136
-                            smaller = other if value > other else value  # noqa: FURB136
-                            values[item] = larger if descending else smaller
-                            values[partner_item] = smaller if descending else larger
-
-        for item in cutlass.range_constexpr(4):
-            keys[run_base + lane + Int32(item * _WARP_SIZE)] = values[item]
-
-    @cute.jit
-    def _merge_two_sorted_128_at_rank(
-        self,
-        keys: cute.Tensor,
-        a_base: Int32,
-        b_base: Int32,
-        rank: Int32,
-    ) -> Int64:
-        """Return one rank of a stable descending merge of two ``tile_candidates``-key runs."""
-        tile_candidates = self.tile_candidates
-        diagonal = rank + Int32(1)
-        lower = Int32(0)
-        upper = diagonal
-
-        # Find how many A elements occur in the first diagonal outputs.
-        # A wins equal-key ties.  Eight fixed iterations cover the full
-        # [0, tile_candidates] partition interval and avoid a divergent
-        # data-dependent loop backedge.
-        for _iteration in cutlass.range_constexpr(8):
-            if lower < upper:
-                a_count = (lower + upper) >> Int32(1)
-                b_count = diagonal - a_count
-                move_right = cutlass.Boolean(False)
-                if a_count < Int32(tile_candidates) and b_count > Int32(0):
-                    move_right = Int64(keys[a_base + a_count]) >= Int64(
-                        keys[b_base + b_count - Int32(1)]
-                    )
-                if move_right:
-                    lower = a_count + Int32(1)
-                else:
-                    upper = a_count
-
-        a_count = lower
-        b_count = diagonal - a_count
-        result = Int64(_INVALID_KEY)
-        if a_count == Int32(0):
-            result = Int64(keys[b_base + b_count - Int32(1)])
-        elif b_count == Int32(0):
-            result = Int64(keys[a_base + a_count - Int32(1)])
-        else:
-            a_value = Int64(keys[a_base + a_count - Int32(1)])
-            b_value = Int64(keys[b_base + b_count - Int32(1)])
-            result = a_value if a_value < b_value else b_value  # noqa: FURB136
-        return result
-
-    @cute.jit
-    def _drain_hierarchical_512_128(
-        self,
-        keys: cute.Tensor,
-        buffer_counts: cute.Tensor,
-        query_base: Int32,
-        logical_tid: Int32,
-        query_slot: cutlass.Constexpr,
-        selection_barrier,
-    ):
-        """Retain Top-128 from 512 keys with warp-local runs and two merge levels."""
-        tile_candidates = self.tile_candidates
-        selection_threads = self.selection_threads
-        warp = logical_tid >> Int32(5)
-        lane = logical_tid & Int32(_WARP_SIZE - 1)
-        run_base = query_base + warp * Int32(tile_candidates)
-        self._sort_warp_quarter_desc(keys, run_base, lane)
-        selection_barrier.arrive_and_wait()
-
-        # Two pairs merge concurrently.  Each 64-thread pair group emits two
-        # ranks per thread into a disjoint tile_candidates-key scratch run.
-        pair = logical_tid >> Int32(6)
-        pair_tid = logical_tid & Int32(63)
-        pair_a_base = query_base + pair * Int32(2 * tile_candidates)
-        pair_b_base = pair_a_base + Int32(tile_candidates)
-        scratch_base = Int32(self.queries_per_cta * self.sort_span) + Int32(
-            query_slot * 2 * tile_candidates
-        )
-        pair_output_base = scratch_base + pair * Int32(tile_candidates)
-        for output_round in cutlass.range_constexpr(2):
-            rank = pair_tid + Int32(output_round * 64)
-            keys[pair_output_base + rank] = self._merge_two_sorted_128_at_rank(
-                keys,
-                pair_a_base,
-                pair_b_base,
-                rank,
-            )
-        selection_barrier.arrive_and_wait()
-
-        # Merge the pair results directly into the persistent long-term
-        # buffer.  Clearing all tail slots makes it safe to discard every
-        # loser rather than persisting a fully sorted 512-key permutation.
-        final_value = self._merge_two_sorted_128_at_rank(
-            keys,
-            scratch_base,
-            scratch_base + Int32(tile_candidates),
-            logical_tid,
-        )
-        keys[query_base + logical_tid] = final_value
-        for item in cutlass.range_constexpr(3):
-            keys[
-                query_base + Int32(tile_candidates) + logical_tid + Int32(item * selection_threads)
-            ] = Int64(_INVALID_KEY)
-        if logical_tid == Int32(0):
-            buffer_counts[query_slot] = Int32(0)
-        selection_barrier.arrive_and_wait()
-
-    @cute.jit
-    def _drain_long_term_buffer(
-        self,
-        keys: cute.Tensor,
-        buffer_counts: cute.Tensor,
-        query_base: Int32,
-        logical_tid: Int32,
-        query_slot: cutlass.Constexpr,
-        selection_barrier,
-    ):
-        """Sort the long-term-buffer/buffer2 union and retain its first run_size keys.
-
-        ``run_size`` is the padded persistent-run size (a power of two, >= the
-        fixed ``tile_candidates``; equal to the caller's requested topk
-        only when topk is itself such a power of two). Global indices are
-        striped across the selector warp-group's threads. Distances below a
-        warp use shuffles, distances of 32/64 exchange through shared memory,
-        and distances of at least one warp-group width compare register pairs
-        owned by the same thread.
-        """
-        selection_threads = self.selection_threads
-        if cutlass.const_expr(self.run_size == 128 and self.sort_span == 512):
-            self._drain_hierarchical_512_128(
-                keys,
-                buffer_counts,
-                query_base,
-                logical_tid,
-                query_slot,
-                selection_barrier,
-            )
-            return
-
-        items_per_thread = self.sort_span // selection_threads
-        levels = int(math.log2(self.sort_span))
-        values = cute.make_rmem_tensor(cute.make_layout((items_per_thread,)), Int64)
-        for item in cutlass.range_constexpr(items_per_thread):
-            global_index = logical_tid + Int32(item * selection_threads)
-            values[item] = Int64(keys[query_base + global_index])
-
-        for level in cutlass.range_constexpr(levels):
-            network_size = 1 << (level + 1)
-            for reverse_stage in cutlass.range_constexpr(level + 1):
-                distance = 1 << (level - reverse_stage)
-                if cutlass.const_expr(distance < _WARP_SIZE):
-                    for item in cutlass.range_constexpr(items_per_thread):
-                        global_index = logical_tid + Int32(item * selection_threads)
-                        other = Int64(cute.arch.shuffle_sync_bfly(values[item], distance))
-                        lower = (global_index & Int32(distance)) == Int32(0)
-                        descending = (global_index & Int32(network_size)) == Int32(0)
-                        values[item] = _bitonic_lane_value(
-                            values[item],
-                            other,
-                            lower,
-                            descending,
-                        )
-                elif cutlass.const_expr(distance < selection_threads):
-                    for item in cutlass.range_constexpr(items_per_thread):
-                        global_index = logical_tid + Int32(item * selection_threads)
-                        keys[query_base + global_index] = values[item]
-                    selection_barrier.arrive_and_wait()
-                    for item in cutlass.range_constexpr(items_per_thread):
-                        global_index = logical_tid + Int32(item * selection_threads)
-                        other_index = global_index ^ Int32(distance)
-                        other = Int64(keys[query_base + other_index])
-                        lower = (global_index & Int32(distance)) == Int32(0)
-                        descending = (global_index & Int32(network_size)) == Int32(0)
-                        values[item] = _bitonic_lane_value(
-                            values[item],
-                            other,
-                            lower,
-                            descending,
-                        )
-                    selection_barrier.arrive_and_wait()
-                else:
-                    register_distance = distance // selection_threads
-                    for item in cutlass.range_constexpr(items_per_thread):
-                        partner_item = item ^ register_distance
-                        if cutlass.const_expr(partner_item > item):
-                            global_index = logical_tid + Int32(item * selection_threads)
-                            value = Int64(values[item])
-                            other = Int64(values[partner_item])
-                            descending = (global_index & Int32(network_size)) == Int32(0)
-                            larger = value if value > other else other  # noqa: FURB136
-                            smaller = other if value > other else value  # noqa: FURB136
-                            values[item] = larger if descending else smaller
-                            values[partner_item] = smaller if descending else larger
-
-        # Persist the whole final permutation.  In particular, buffer2 must
-        # hold only true losers after a drain; leaving an intermediate
-        # permutation can duplicate a retained key in the next union.
-        for item in cutlass.range_constexpr(items_per_thread):
-            global_index = logical_tid + Int32(item * selection_threads)
-            keys[query_base + global_index] = values[item]
-        if logical_tid == Int32(0):
-            buffer_counts[query_slot] = Int32(0)
-        selection_barrier.arrive_and_wait()
-
-    @cute.jit
-    def _run_paired_load(
-        self,
-        tiled_mma,
-        tma_atom_k,
-        tma_atom_q,
-        mK_sd,
-        mQ0_hd,
-        mQ1_hd,
-        sK,
-        sQ,
-        candidate_tiles,
-        head_tiles,
-        k_producer,
-        q_producer,
-    ):
-        """TMA warp: reuse each staged K tile across two head tiles."""
-        mma_tile = self.mma_tile
-        mma_zero = tiled_mma.get_slice(0)
-        head_pairs = head_tiles // Int32(2)
-        for candidate_tile in cutlass.range(candidate_tiles, unroll=0):
-            for head_pair in cutlass.range(head_pairs, unroll=0):
-                head0 = head_pair * Int32(2)
-                head1 = head0 + Int32(1)
-                k_coord = (candidate_tile, head0, None)
-                q0_coord = (candidate_tile, head0, None)
-                q1_coord = (candidate_tile, head1, None)
-                gK = cute.local_tile(mK_sd, mma_tile, k_coord, proj=(1, None, 1))
-                gQ0_h0 = cute.local_tile(mQ0_hd, mma_tile, q0_coord, proj=(None, 1, 1))
-                gQ1_h0 = cute.local_tile(mQ1_hd, mma_tile, q0_coord, proj=(None, 1, 1))
-                gQ0_h1 = cute.local_tile(mQ0_hd, mma_tile, q1_coord, proj=(None, 1, 1))
-                gQ1_h1 = cute.local_tile(mQ1_hd, mma_tile, q1_coord, proj=(None, 1, 1))
-
-                mma_k = mma_zero.partition_A(gK)
-                mma_q0_h0 = mma_zero.partition_B(gQ0_h0)
-                mma_q1_h0 = mma_zero.partition_B(gQ1_h0)
-                mma_q0_h1 = mma_zero.partition_B(gQ0_h1)
-                mma_q1_h1 = mma_zero.partition_B(gQ1_h1)
-                part_s_k, part_g_k = cpasync.tma_partition(
-                    tma_atom_k,
-                    0,
-                    cute.make_layout(1),
-                    cute.group_modes(sK, 0, 3),
-                    cute.group_modes(mma_k, 0, 3),
-                )
-                part_s_q, part_g_q0_h0 = cpasync.tma_partition(
-                    tma_atom_q,
-                    0,
-                    cute.make_layout(1),
-                    cute.group_modes(sQ, 0, 3),
-                    cute.group_modes(mma_q0_h0, 0, 3),
-                )
-                _, part_g_q1_h0 = cpasync.tma_partition(
-                    tma_atom_q,
-                    0,
-                    cute.make_layout(1),
-                    cute.group_modes(sQ, 0, 3),
-                    cute.group_modes(mma_q1_h0, 0, 3),
-                )
-                _, part_g_q0_h1 = cpasync.tma_partition(
-                    tma_atom_q,
-                    0,
-                    cute.make_layout(1),
-                    cute.group_modes(sQ, 0, 3),
-                    cute.group_modes(mma_q0_h1, 0, 3),
-                )
-                _, part_g_q1_h1 = cpasync.tma_partition(
-                    tma_atom_q,
-                    0,
-                    cute.make_layout(1),
-                    cute.group_modes(sQ, 0, 3),
-                    cute.group_modes(mma_q1_h1, 0, 3),
-                )
-
-                for d_tile in cutlass.range(cute.size(gK, mode=[2]), unroll=0):
-                    k_empty = k_producer.acquire_and_advance()
-                    cute.copy(
-                        tma_atom_k,
-                        part_g_k[(None, d_tile)],
-                        part_s_k[(None, k_empty.index)],
-                        tma_bar_ptr=k_empty.barrier,
-                    )
-                    q0_h0_empty = q_producer.acquire_and_advance()
-                    cute.copy(
-                        tma_atom_q,
-                        part_g_q0_h0[(None, d_tile)],
-                        part_s_q[(None, q0_h0_empty.index)],
-                        tma_bar_ptr=q0_h0_empty.barrier,
-                    )
-                    q1_h0_empty = q_producer.acquire_and_advance()
-                    cute.copy(
-                        tma_atom_q,
-                        part_g_q1_h0[(None, d_tile)],
-                        part_s_q[(None, q1_h0_empty.index)],
-                        tma_bar_ptr=q1_h0_empty.barrier,
-                    )
-                    q0_h1_empty = q_producer.acquire_and_advance()
-                    cute.copy(
-                        tma_atom_q,
-                        part_g_q0_h1[(None, d_tile)],
-                        part_s_q[(None, q0_h1_empty.index)],
-                        tma_bar_ptr=q0_h1_empty.barrier,
-                    )
-                    q1_h1_empty = q_producer.acquire_and_advance()
-                    cute.copy(
-                        tma_atom_q,
-                        part_g_q1_h1[(None, d_tile)],
-                        part_s_q[(None, q1_h1_empty.index)],
-                        tma_bar_ptr=q1_h1_empty.barrier,
-                    )
-
-            # An odd head-tile tail keeps the original singleton K/Q stage semantics.
-            if (head_tiles & Int32(1)) != Int32(0):
-                head_tile = head_pairs * Int32(2)
-                mma_coord = (candidate_tile, head_tile, None)
-                gK = cute.local_tile(mK_sd, mma_tile, mma_coord, proj=(1, None, 1))
-                gQ0 = cute.local_tile(mQ0_hd, mma_tile, mma_coord, proj=(None, 1, 1))
-                gQ1 = cute.local_tile(mQ1_hd, mma_tile, mma_coord, proj=(None, 1, 1))
-                mma_k = mma_zero.partition_A(gK)
-                mma_q0 = mma_zero.partition_B(gQ0)
-                mma_q1 = mma_zero.partition_B(gQ1)
-                part_s_k, part_g_k = cpasync.tma_partition(
-                    tma_atom_k,
-                    0,
-                    cute.make_layout(1),
-                    cute.group_modes(sK, 0, 3),
-                    cute.group_modes(mma_k, 0, 3),
-                )
-                part_s_q, part_g_q0 = cpasync.tma_partition(
-                    tma_atom_q,
-                    0,
-                    cute.make_layout(1),
-                    cute.group_modes(sQ, 0, 3),
-                    cute.group_modes(mma_q0, 0, 3),
-                )
-                _, part_g_q1 = cpasync.tma_partition(
-                    tma_atom_q,
-                    0,
-                    cute.make_layout(1),
-                    cute.group_modes(sQ, 0, 3),
-                    cute.group_modes(mma_q1, 0, 3),
-                )
-                for d_tile in cutlass.range(cute.size(gK, mode=[2]), unroll=0):
-                    k_empty = k_producer.acquire_and_advance()
-                    cute.copy(
-                        tma_atom_k,
-                        part_g_k[(None, d_tile)],
-                        part_s_k[(None, k_empty.index)],
-                        tma_bar_ptr=k_empty.barrier,
-                    )
-                    q0_empty = q_producer.acquire_and_advance()
-                    cute.copy(
-                        tma_atom_q,
-                        part_g_q0[(None, d_tile)],
-                        part_s_q[(None, q0_empty.index)],
-                        tma_bar_ptr=q0_empty.barrier,
-                    )
-                    q1_empty = q_producer.acquire_and_advance()
-                    cute.copy(
-                        tma_atom_q,
-                        part_g_q1[(None, d_tile)],
-                        part_s_q[(None, q1_empty.index)],
-                        tma_bar_ptr=q1_empty.barrier,
-                    )
-        k_producer.tail()
-        q_producer.tail()
-
-    @cute.jit
-    def _run_paired_mma(
-        self,
-        tiled_mma,
-        accumulator,
-        fragment_k,
-        fragment_q,
-        candidate_tiles,
-        head_tiles,
-        d_tiles,
-        k_consumer,
-        q_consumer,
-        acc0_producer,
-        acc1_producer,
-    ):
-        """UMMA warp: reuse each staged K tile across adjacent head tiles."""
-        acc_stages = self.config.acc_stages
-        head_pairs = head_tiles // Int32(2)
-        for _candidate_tile in cutlass.range(candidate_tiles, unroll=0):
-            for _head_pair in cutlass.range(head_pairs, unroll=0):
-                q0_acc_h0 = acc0_producer.acquire_and_advance()
-                q1_acc_h0 = acc1_producer.acquire_and_advance()
-                q0_acc_h1 = acc0_producer.acquire_and_advance()
-                q1_acc_h1 = acc1_producer.acquire_and_advance()
-
-                for d_tile in cutlass.range(d_tiles, unroll=0):
-                    k_full = k_consumer.wait_and_advance()
-
-                    q0_h0_full = q_consumer.wait_and_advance()
-                    self._gemm_query_tile(
-                        tiled_mma,
-                        accumulator,
-                        q0_acc_h0.index,
-                        fragment_k,
-                        k_full.index,
-                        fragment_q,
-                        q0_h0_full.index,
-                        d_tile,
-                    )
-                    if d_tile == d_tiles - Int32(1):
-                        q0_acc_h0.commit()
-                    q0_h0_full.release()
-
-                    q1_h0_full = q_consumer.wait_and_advance()
-                    self._gemm_query_tile(
-                        tiled_mma,
-                        accumulator,
-                        Int32(acc_stages) + q1_acc_h0.index,
-                        fragment_k,
-                        k_full.index,
-                        fragment_q,
-                        q1_h0_full.index,
-                        d_tile,
-                    )
-                    if d_tile == d_tiles - Int32(1):
-                        q1_acc_h0.commit()
-                    q1_h0_full.release()
-
-                    q0_h1_full = q_consumer.wait_and_advance()
-                    self._gemm_query_tile(
-                        tiled_mma,
-                        accumulator,
-                        q0_acc_h1.index,
-                        fragment_k,
-                        k_full.index,
-                        fragment_q,
-                        q0_h1_full.index,
-                        d_tile,
-                    )
-                    if d_tile == d_tiles - Int32(1):
-                        q0_acc_h1.commit()
-                    q0_h1_full.release()
-
-                    q1_h1_full = q_consumer.wait_and_advance()
-                    self._gemm_query_tile(
-                        tiled_mma,
-                        accumulator,
-                        Int32(acc_stages) + q1_acc_h1.index,
-                        fragment_k,
-                        k_full.index,
-                        fragment_q,
-                        q1_h1_full.index,
-                        d_tile,
-                    )
-                    if d_tile == d_tiles - Int32(1):
-                        q1_acc_h1.commit()
-                    q1_h1_full.release()
-                    k_full.release()
-
-            # An odd head-tile tail publishes one accumulator per query, as before.
-            if (head_tiles & Int32(1)) != Int32(0):
-                q0_acc = acc0_producer.acquire_and_advance()
-                q1_acc = acc1_producer.acquire_and_advance()
-                for d_tile in cutlass.range(d_tiles, unroll=0):
-                    k_full = k_consumer.wait_and_advance()
-                    q0_full = q_consumer.wait_and_advance()
-                    self._gemm_query_tile(
-                        tiled_mma,
-                        accumulator,
-                        q0_acc.index,
-                        fragment_k,
-                        k_full.index,
-                        fragment_q,
-                        q0_full.index,
-                        d_tile,
-                    )
-                    if d_tile == d_tiles - Int32(1):
-                        q0_acc.commit()
-                    q0_full.release()
-
-                    q1_full = q_consumer.wait_and_advance()
-                    self._gemm_query_tile(
-                        tiled_mma,
-                        accumulator,
-                        Int32(acc_stages) + q1_acc.index,
-                        fragment_k,
-                        k_full.index,
-                        fragment_q,
-                        q1_full.index,
-                        d_tile,
-                    )
-                    if d_tile == d_tiles - Int32(1):
-                        q1_acc.commit()
-                    q1_full.release()
-                    k_full.release()
-        acc0_producer.tail()
-        acc1_producer.tail()
-
-    @cute.jit
-    def _run_query_reducer_mailbox(
-        self,
-        accumulator,
-        acc_consumer,
-        mailbox_ordinals,
-        mailbox_producer,
-        mW_bth,
-        tidx,
-        warp_idx,
-        lane,
-        batch,
-        query_index,
-        query_active,
-        query_slot: cutlass.Constexpr,
-        num_candidates,
-        num_heads,
-        candidate_tiles,
-        head_tiles,
-        score_scale,
-    ):
-        """Reduce every score tile and publish one ordinal per reducer thread."""
-        causal = self.causal
-        tile_candidates = self.tile_candidates
-        tile_heads = self.tile_heads
-        acc_stages = self.config.acc_stages
-        mailbox_stages = self.config.mailbox_stages
-        mma_tile = self.mma_tile
-        accumulator_flat = accumulator[((None, None), 0, 0, None)]
-        tmem_load_atom = cute.make_copy_atom(
-            tcgen05.Ld16x256bOp(tcgen05.Repetition.x8, tcgen05.Pack.NONE),
-            Float32,
-        )
-        tmem_copy = tcgen05.make_tmem_copy(
-            tmem_load_atom,
-            accumulator_flat[(None, None, 0)],
-        )
-        tmem_thread = tmem_copy.get_slice(tidx)
-        tmem_source = tmem_thread.partition_S(accumulator_flat)
-        coord_fragment = tmem_thread.partition_D(cute.make_identity_tensor(mma_tile[:2]))
-        head_logits = cute.make_rmem_tensor(coord_fragment.shape, Float32)
-        lane_in_group = lane & Int32(3)
-        candidate_group = lane >> Int32(2)
-        candidate_offset = (
-            warp_idx * Int32(_WARP_SIZE) + candidate_group + (lane_in_group << Int32(3))
-        )
-        stage_offset = Int32(query_slot * acc_stages)
-        mailbox_query_base = Int32(query_slot * mailbox_stages * tile_candidates)
-
-        for candidate_tile in cutlass.range(candidate_tiles, unroll=0):
-            score0 = Float32(0.0)
-            score1 = Float32(0.0)
-            score2 = Float32(0.0)
-            score3 = Float32(0.0)
-
-            for head_tile in cutlass.range(head_tiles, unroll=0):
-                acc_full = acc_consumer.wait_and_advance()
-                cute.copy(
-                    tmem_copy,
-                    tmem_source[(None, None, None, stage_offset + acc_full.index)],
-                    head_logits,
-                )
-                cute.arch.fence_view_async_tmem_load()
-                # Release TMEM before any mailbox acquire can backpressure this
-                # reducer group, so the MMA producer can immediately reuse a stage.
-                acc_full.release()
-
-                for head_block in cutlass.range_constexpr(8):
-                    for head_pair in cutlass.range_constexpr(2):
-                        local_head = (
-                            Int32(8 * head_block) + (lane_in_group << Int32(1)) + Int32(head_pair)
-                        )
-                        global_head = head_tile * Int32(tile_heads) + local_head
-                        if global_head < num_heads:
-                            weight = Float32(mW_bth[batch, query_index, global_head])
-                            item0 = head_block * 4 + head_pair
-                            item1 = head_block * 4 + 2 + head_pair
-                            item2 = 32 + head_block * 4 + head_pair
-                            item3 = 32 + head_block * 4 + 2 + head_pair
-                            logit0 = Float32(head_logits[item0])
-                            logit1 = Float32(head_logits[item1])
-                            logit2 = Float32(head_logits[item2])
-                            logit3 = Float32(head_logits[item3])
-                            logit0 = logit0 if logit0 > Float32(0.0) else Float32(0.0)  # noqa: FURB136
-                            logit1 = logit1 if logit1 > Float32(0.0) else Float32(0.0)  # noqa: FURB136
-                            logit2 = logit2 if logit2 > Float32(0.0) else Float32(0.0)  # noqa: FURB136
-                            logit3 = logit3 if logit3 > Float32(0.0) else Float32(0.0)  # noqa: FURB136
-                            score0 = score0 + weight * logit0
-                            score1 = score1 + weight * logit1
-                            score2 = score2 + weight * logit2
-                            score3 = score3 + weight * logit3
-
-            for shuffle_stage in cutlass.range_constexpr(2):
-                shuffle_mask = 1 << shuffle_stage
-                score0 = score0 + Float32(cute.arch.shuffle_sync_bfly(score0, shuffle_mask))
-                score1 = score1 + Float32(cute.arch.shuffle_sync_bfly(score1, shuffle_mask))
-                score2 = score2 + Float32(cute.arch.shuffle_sync_bfly(score2, shuffle_mask))
-                score3 = score3 + Float32(cute.arch.shuffle_sync_bfly(score3, shuffle_mask))
-            reduced_score = score0
-            if lane_in_group == Int32(1):
-                reduced_score = score1
-            elif lane_in_group == Int32(2):
-                reduced_score = score2
-            elif lane_in_group == Int32(3):
-                reduced_score = score3
-
-            candidate_index = candidate_tile * Int32(tile_candidates) + candidate_offset
-            candidate_is_valid = (
-                candidate_index <= query_index if causal else candidate_index < num_candidates
-            ) and query_active
-            candidate_ordinal = Int32(_INVALID_ORDINAL)
-            if candidate_is_valid:
-                candidate_ordinal = _make_score_ordinal(reduced_score * score_scale)
-
-            mailbox_empty = mailbox_producer.acquire_and_advance()
-            mailbox_stage_base = mailbox_query_base + mailbox_empty.index * Int32(tile_candidates)
-            mailbox_ordinals[mailbox_stage_base + tidx] = candidate_ordinal
-            cute.arch.fence_view_async_shared()
-            mailbox_empty.commit()
-
-        mailbox_producer.tail()
-
-    @cute.jit
-    def _run_query_selector_mailbox(
-        self,
-        mailbox_ordinals,
-        mailbox_consumer,
-        selection_keys,
-        buffer_counts,
-        drain_flags,
-        tidx,
-        warp_idx,
-        lane,
-        query_slot: cutlass.Constexpr,
-        candidate_tiles,
-    ):
-        """Consume reduced ordinals and maintain the exact shared-memory Top-run_size.
-
-        ``run_size`` is the padded persistent-run size; the caller truncates
-        the final sorted run to its requested ``topk`` when writing output.
-        The unsorted direct-seed shortcut below is only safe when the caller
-        reads back the *entire* persistent run (topk == run_size); otherwise
-        the output truncation would read an arbitrary, unsorted subset.
-        """
-        tile_candidates = self.tile_candidates
-        selection_warps = self.selection_warps
-        selection_threads = self.selection_threads
-        mailbox_stages = self.config.mailbox_stages
-        selection_barrier_id = 3
-        if cutlass.const_expr(query_slot == 1):
-            selection_barrier_id = 4
-        selection_barrier = pipeline.NamedBarrier(
-            barrier_id=selection_barrier_id,
-            num_threads=selection_threads,
-        )
-        query_base = Int32(query_slot * self.sort_span)
-        items_per_thread = self.sort_span // selection_threads
-        for item in cutlass.range_constexpr(items_per_thread):
-            if cutlass.const_expr(
-                not (
-                    self.topk == self.run_size
-                    and self.run_size == tile_candidates
-                    and self.sort_span == 4 * tile_candidates
-                    and item == 0
-                )
-            ):
-                selection_keys[query_base + tidx + Int32(item * selection_threads)] = Int64(
-                    _INVALID_KEY
-                )
-        if tidx == Int32(0):
-            buffer_counts[query_slot] = Int32(0)
-        if cutlass.const_expr(
-            not (
-                self.topk == self.run_size
-                and self.run_size == tile_candidates
-                and self.sort_span == 4 * tile_candidates
-            )
-        ):
-            selection_barrier.arrive_and_wait()
-
-        cutoff_key = Int64(_INVALID_KEY)
-        cutoff_ordinal = Int32(_INVALID_ORDINAL)
-        buffer_capacity = self.sort_span - self.run_size
-        drain_threshold = buffer_capacity - tile_candidates
-        lane_in_group = lane & Int32(3)
-        candidate_group = lane >> Int32(2)
-        candidate_offset = (
-            warp_idx * Int32(_WARP_SIZE) + candidate_group + (lane_in_group << Int32(3))
-        )
-        mailbox_query_base = Int32(query_slot * mailbox_stages * tile_candidates)
-
-        for candidate_tile in cutlass.range(candidate_tiles, unroll=0):
-            mailbox_full = mailbox_consumer.wait_and_advance()
-            mailbox_stage_base = mailbox_query_base + mailbox_full.index * Int32(tile_candidates)
-            candidate_ordinal = Int32(mailbox_ordinals[mailbox_stage_base + tidx])
-            # Once every lane has copied its ordinal to a register, this
-            # stage may be overwritten while the selector group performs
-            # Top-K maintenance.
-            mailbox_full.release()
-
-            candidate_index = candidate_tile * Int32(tile_candidates) + candidate_offset
-            candidate_is_valid = candidate_ordinal != Int32(_INVALID_ORDINAL)
-            candidate_key = Int64(_INVALID_KEY)
-            accept = cutlass.Boolean(False)
-            might_beat_cutoff = candidate_is_valid and candidate_ordinal >= cutoff_ordinal
-            if might_beat_cutoff:
-                candidate_key = _pack_key(candidate_ordinal, candidate_index)
-                accept = candidate_key > cutoff_key
-
-            direct_seed = cutlass.Boolean(False)
-            if cutlass.const_expr(
-                self.topk == self.run_size
-                and self.run_size == tile_candidates
-                and self.sort_span == 4 * tile_candidates
-            ):
-                direct_seed = candidate_tile == Int32(0)
-
-            if direct_seed:
-                # The first tile_candidates candidates are already a
-                # complete Top-K set.  Put them directly in the long-term
-                # buffer and compute its cutoff; otherwise two full tiles
-                # would be appended before the first drain merely to
-                # rediscover the same initial set.
-                selection_keys[query_base + tidx] = candidate_key
-                seed_min = candidate_key
-                for shuffle_stage in cutlass.range_constexpr(5):
-                    other = Int64(cute.arch.shuffle_sync_bfly(seed_min, 1 << shuffle_stage))
-                    seed_min = other if other < seed_min else seed_min  # noqa: FURB136
-                seed_scratch_base = Int32(
-                    self.queries_per_cta * self.sort_span + query_slot * 2 * tile_candidates
-                )
-                if lane == Int32(0):
-                    selection_keys[seed_scratch_base + warp_idx] = seed_min
-                selection_barrier.arrive_and_wait()
-                cutoff_key = Int64(_INVALID_KEY)
-                if lane < Int32(selection_warps):
-                    cutoff_key = Int64(selection_keys[seed_scratch_base + lane])
-                for shuffle_stage in cutlass.range_constexpr(2):
-                    other = Int64(cute.arch.shuffle_sync_bfly(cutoff_key, 1 << shuffle_stage))
-                    cutoff_key = other if other < cutoff_key else cutoff_key  # noqa: FURB136
-                cutoff_key = Int64(cute.arch.shuffle_sync(cutoff_key, 0))
-                cutoff_ordinal = Int32(cutoff_key >> Int64(32))
-            else:
-                accepted_mask = cutlass.Uint32(cute.arch.vote_ballot_sync(accept))
-                warp_accepted = Int32(cute.arch.popc(accepted_mask))
-                lane_rank = Int32(cute.arch.popc(accepted_mask & cute.arch.lanemask_lt()))
-                warp_base = Int32(0)
-                if lane == Int32(0) and warp_accepted > Int32(0):
-                    count_ptr = buffer_counts.iterator + buffer_counts.layout(query_slot)
-                    warp_base = Int32(
-                        cute.arch.atomic_add(
-                            count_ptr,
-                            warp_accepted,
-                            sem="relaxed",
-                            scope="cta",
-                        )
-                    )
-                warp_base = Int32(cute.arch.shuffle_sync(warp_base, 0))
-                if accept:
-                    selection_keys[query_base + Int32(self.run_size) + warp_base + lane_rank] = (
-                        candidate_key
-                    )
-
-                selection_barrier.arrive_and_wait()
-                # A fast sibling thread can already be past this point and
-                # into the next tile's atomic_add on this same
-                # buffer_counts cell before a slower sibling reads it here
-                # for *this* tile (the accumulator is a relaxed, unordered
-                # atomic). Different threads in the group could then
-                # independently read different values and disagree on
-                # whether to drain. Elect a single reader, broadcast its
-                # decision through shared memory, and force every thread
-                # through a second barrier before any of them acts on it,
-                # so the whole selector warp-group takes the drain/no-drain
-                # branch together and no thread starts next-tile work
-                # until every thread has observed the same decision.
-                if tidx == Int32(0):
-                    occupied = Int32(buffer_counts[query_slot])
-                    drain_flags[query_slot] = (
-                        Int32(1)
-                        if occupied > Int32(0) and occupied >= Int32(drain_threshold)
-                        else Int32(0)
-                    )
-                selection_barrier.arrive_and_wait()
-                should_drain = drain_flags[query_slot] != Int32(0)
-                if should_drain:
-                    self._drain_long_term_buffer(
-                        selection_keys,
-                        buffer_counts,
-                        query_base,
-                        tidx,
-                        query_slot,
-                        selection_barrier,
-                    )
-                    cutoff_key = Int64(selection_keys[query_base + Int32(self.run_size - 1)])
-                    cutoff_ordinal = Int32(cutoff_key >> Int64(32))
-
-        occupied = Int32(buffer_counts[query_slot])
-        if occupied > Int32(0):
-            self._drain_long_term_buffer(
-                selection_keys,
-                buffer_counts,
-                query_base,
-                tidx,
-                query_slot,
-                selection_barrier,
-            )
-
-    @cute.jit
-    def __call__(
-        self,
-        q: cute.Tensor,
-        k: cute.Tensor,
-        weights: cute.Tensor,
-        output: cute.Tensor,
-        score_scale: Float32,
-        stream: cuda_driver.CUstream,
-    ):
-        """Build the SM100 TMA/MMA objects and launch exactly one kernel."""
-        config = self.config
-        mma_tile = self.mma_tile
-
-        q_hdtb = cute.make_tensor(q.iterator, cute.select(q.layout, mode=[2, 3, 1, 0]))
-        k_sdb = cute.make_tensor(k.iterator, cute.select(k.layout, mode=[1, 2, 0]))
-
-        mma_op = tcgen05.MmaF16BF16Op(
-            q.element_type,
-            Float32,
-            self.mma_instruction,
-            tcgen05.CtaGroup.ONE,
-            tcgen05.OperandSource.SMEM,
-            cute.nvgpu.OperandMajorMode.K,
-            cute.nvgpu.OperandMajorMode.K,
-        )
-        tiled_mma = cute.make_tiled_mma(mma_op)
-        k_smem_layout = sm100_utils.make_smem_layout_a(
-            tiled_mma,
-            mma_tile,
-            k.element_type,
-            config.k_stages,
-        )
-        q_smem_layout = sm100_utils.make_smem_layout_b(
-            tiled_mma,
-            mma_tile,
-            q.element_type,
-            config.q_stages,
-        )
-
-        tma_load = cpasync.CopyBulkTensorTileG2SOp(tcgen05.CtaGroup.ONE)
-        tma_atom_k, k_tma_tensor = cute.nvgpu.make_tiled_tma_atom_A(
-            tma_load,
-            k_sdb,
-            cute.select(k_smem_layout, mode=[0, 1, 2]),
-            mma_tile,
-            tiled_mma,
-        )
-        tma_atom_q, q_tma_tensor = cute.nvgpu.make_tiled_tma_atom_B(
-            tma_load,
-            q_hdtb,
-            cute.select(q_smem_layout, mode=[0, 1, 2]),
-            mma_tile,
-            tiled_mma,
-        )
-
-        self.kernel.set_name_prefix(self.get_name())
-        self.kernel(
-            tiled_mma,
-            tma_atom_k,
-            k_tma_tensor,
-            tma_atom_q,
-            q_tma_tensor,
-            weights,
-            output,
-            k_smem_layout,
-            q_smem_layout,
-            score_scale,
-        ).launch(
-            grid=(cute.ceil_div(q.shape[1], self.queries_per_cta), q.shape[0], 1),
-            block=(self.threads, 1, 1),
-            min_blocks_per_mp=config.min_blocks_per_mp,
-            stream=stream,
-        )
+_MAX_SCORE_PAIRS = 512
+_SCORE_WORKSPACE_BYTES = 32 * 1024 * 1024
+
+
+def score_workspace_pairs(batch: int, tokens: int) -> int:
+    """Size a slab for positive B and the validated CuTe domain 1 <= T <= 2**20."""
+    return min(
+        _MAX_SCORE_PAIRS, batch * ((tokens + 1) // 2), _SCORE_WORKSPACE_BYTES // (8 * tokens)
+    )
+
+
+@jit_cache(
+    extra_sources=(
+        Path(__file__).with_name("cute_score.py"),
+        Path(__file__).with_name("cute_score_generic.py"),
+    )
+)
+def _compile_scores(
+    dtype: torch.dtype, heads: int, head_dim: int, causal: bool, use_int64_offsets: bool
+) -> Callable[..., None]:
+    """Compile score production with symbolic B, T and slab capacity."""
+    import cutlass
+    from cutlass import cute
+
+    from .cute_score import IndexerScoreKernel
+    from .cute_score_generic import IndexerGenericScoreKernel
+
+    operation = (
+        IndexerScoreKernel(heads, head_dim, causal, use_int64_offsets)
+        if heads in (32, 64) and head_dim == 128
+        else IndexerGenericScoreKernel(heads, head_dim, causal, use_int64_offsets)
+    )
+    io_dtype = cutlass.BFloat16 if dtype == torch.bfloat16 else cutlass.Float16
+    sym = cute.sym_int64 if use_int64_offsets else cute.sym_int
+    integer = cutlass.Int64 if use_int64_offsets else cutlass.Int32
+    batch, tokens, pairs = sym(), sym(), sym()
+    # The public compact-input contract permits arbitrary singleton batch strides.
+    q = cute.runtime.make_fake_tensor(
+        io_dtype,
+        (batch, tokens, heads, head_dim),
+        stride=(sym(divisibility=8), heads * head_dim, head_dim, 1),
+        assumed_align=16,
+    )
+    k = cute.runtime.make_fake_tensor(
+        io_dtype,
+        (batch, tokens, head_dim),
+        stride=(sym(divisibility=8), head_dim, 1),
+        assumed_align=16,
+    )
+    weights = cute.runtime.make_fake_tensor(
+        io_dtype,
+        (batch, tokens, heads),
+        stride=(sym(), heads, 1),
+        assumed_align=16,
+    )
+    scores = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (pairs, 2, tokens),
+        stride_order=(2, 1, 0),
+        assumed_align=16,
+    )
+    return compile_tvm_ffi(
+        operation,
+        q,
+        k,
+        weights,
+        scores,
+        integer(0),
+        cutlass.Float32(1.0),
+    )
+
+
+@jit_cache(extra_sources=(Path(__file__).with_name("cute_topk.py"),))
+def _compile_topk(topk: int, causal: bool, use_int64_offsets: bool) -> Callable[..., None]:
+    """Compile indices-only radix selection with symbolic B, T and slab capacity."""
+    import cutlass
+    from cutlass import cute
+
+    from .cute_topk import IndexerTopKKernel
+
+    sym = cute.sym_int64 if use_int64_offsets else cute.sym_int
+    integer = cutlass.Int64 if use_int64_offsets else cutlass.Int32
+    batch, tokens, pairs = sym(), sym(), sym()
+    scores = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (pairs, 2, tokens),
+        stride_order=(2, 1, 0),
+        assumed_align=16,
+    )
+    output = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (batch, tokens, topk),
+        stride_order=(2, 1, 0),
+        assumed_align=16,
+    )
+    return compile_tvm_ffi(
+        IndexerTopKKernel(topk, causal, use_int64_offsets), scores, output, integer(0)
+    )
 
 
 def _validate(q: torch.Tensor, k: torch.Tensor, weights: torch.Tensor, topk: int) -> None:
+    """Preserve the CuTe input and error contract without inspecting tensor values."""
     if q.ndim != 4:
         raise ValueError(f"q must have shape [B,T,H,D], got {tuple(q.shape)}")
     if k.ndim != 3:
@@ -1517,39 +180,9 @@ def _validate(q: torch.Tensor, k: torch.Tensor, weights: torch.Tensor, topk: int
         raise ValueError("q, k, and weights must be contiguous")
     if any(tensor.data_ptr() % _ALIGNMENT for tensor in tensors):
         raise ValueError(f"q, k, and weights must be {_ALIGNMENT}-byte aligned")
-    if torch.cuda.get_device_capability(q.device) != (10, 0):
+    properties = get_device_properties(q.device)
+    if (properties.major, properties.minor) != (10, 0):
         raise RuntimeError("this tcgen05 kernel requires an SM100 GPU")
-
-
-@jit_cache
-def _compile_indexer(
-    dtype_name: str,
-    heads: int,
-    head_dim: int,
-    topk: int,
-    causal: bool,
-):
-    dtype = _INDEXER_DTYPES_BY_NAME[dtype_name]
-    operation = IndexerPrefillKernel(heads, head_dim, topk, causal, dtype)
-    batch = cute.sym_int()
-    queries = cute.sym_int()
-
-    def tensor(cute_type, shape):
-        return cute.runtime.make_fake_compact_tensor(
-            cute_type,
-            shape,
-            stride_order=tuple(reversed(range(len(shape)))),
-            assumed_align=_ALIGNMENT,
-        )
-
-    return compile_tvm_ffi(
-        operation,
-        tensor(dtype.cute_type, (batch, queries, heads, head_dim)),
-        tensor(dtype.cute_type, (batch, queries, head_dim)),
-        tensor(dtype.cute_type, (batch, queries, heads)),
-        tensor(cutlass.Int32, (batch, queries, topk)),
-        Float32(1.0),
-    )
 
 
 def launch(
@@ -1559,38 +192,33 @@ def launch(
     topk: int,
     causal: bool = False,
 ) -> torch.Tensor:
-    """Return the shared-key Top-K for every full-sequence query.
+    """Run bounded score generation and radix selection for the existing CuTe domain."""
+    import cutlass
 
-    Inputs are contiguous BF16/FP16 tensors with layouts q[B,T,H,D],
-    k[B,T,D], and weights[B,T,H].  The INT32 result has shape
-    [B,T,topk].  Invalid contracts, compilation errors, shared-memory
-    exhaustion, and launch errors propagate; there is no fallback.
-
-    The shared CuTeDSL cache keys dtype, heads, head_dim, topk, causal mode,
-    and compile target. Batch and sequence dimensions are symbolic, so changes
-    to either reuse the same specialization. Process-local hits reuse the loaded
-    TVM-FFI callable; warm processes can load its persisted object without retracing.
-    """
     _validate(q, k, weights, topk)
+    batch, tokens, heads, head_dim = q.shape
+    output = torch.empty((batch, tokens, topk), dtype=torch.int32, device=q.device)
     if topk == 0:
-        return torch.empty((*q.shape[:2], 0), dtype=torch.int32, device=q.device)
+        return output
 
-    output = torch.empty((*q.shape[:2], topk), dtype=torch.int32, device=q.device)
-    heads, head_dim = q.shape[2:]
-    score_scale = 1.0 / math.sqrt(heads * head_dim)
+    pairs = score_workspace_pairs(batch, tokens)
+    scores = torch.empty((pairs, 2, tokens), dtype=torch.float32, device=q.device)
+    use_int64_offsets = requires_int64_abi(q, k, weights, scores, output)
+    integer = cutlass.Int64 if use_int64_offsets else cutlass.Int32
     previous = get_compile_target()
     try:
         set_compile_target(detect_compile_target(q.device.index))
-        compiled = _compile_indexer(
-            INDEXER_DTYPES[q.dtype].name,
-            heads,
-            head_dim,
-            topk,
-            causal,
-        )
+        score_kernel = _compile_scores(q.dtype, heads, head_dim, causal, use_int64_offsets)
+        topk_kernel = _compile_topk(topk, causal, use_int64_offsets)
     finally:
         set_compile_target(previous)
-    compiled(q.detach(), k.detach(), weights.detach(), output, Float32(score_scale))
+
+    q, k, weights = q.detach(), k.detach(), weights.detach()
+    scale = cutlass.Float32(1.0 / math.sqrt(heads * head_dim))
+    with initialized_cuda_device(q):
+        for start in range(0, batch * ((tokens + 1) // 2), pairs):
+            score_kernel(q, k, weights, scores, integer(start), scale)
+            topk_kernel(scores, output, integer(start))
     return output
 
 

--- a/attn_gym/sparse/indexer/impl/cute_score.py
+++ b/attn_gym/sparse/indexer/impl/cute_score.py
@@ -10,16 +10,14 @@ the epilogue independently computes ``scale * sum_h(weight * ReLU(Q @ K))``
 for each query. This module owns only score generation, not Top-K or allocation
 of the caller's [P, 2, T] FP32 slab.
 
-The schedule uses one TMA warp, one UMMA warp, and a 128-thread epilogue, with
-no persistent scheduler. Q remains resident for the CTA's entire candidate
-scan; two K stages and two accumulator stages connect the warp roles. Batch
-is a separate TMA mode, so packing heads with tokens cannot overfetch another
-batch when T is odd. Only valid rows/candidates are written.
+Head, query, and batch remain separate TMA modes despite the logical packing,
+so their physical strides are independent and odd query tails are zero-filled.
+Only valid rows/candidates are written.
 """
 
-import cuda.bindings.driver as cuda_driver
 import cutlass
 import cutlass.utils.blackwell_helpers as sm100_utils
+from cuda.bindings import driver as cuda
 from cutlass import Float32, Int32, Int64, cute, pipeline, utils
 from cutlass.cute.nvgpu import cpasync, tcgen05
 
@@ -27,11 +25,21 @@ from cutlass.cute.nvgpu import cpasync, tcgen05
 class IndexerScoreKernel:
     """Generate a slab of scores for H=32/64, D=128, FP16/BF16 inputs on SM100.
 
-    Inputs must be contiguous and 16-byte aligned. ``pair_start`` is a dynamic
-    Int32 scalar, or Int64 when ``use_int64_offsets`` is enabled; the latter
-    also requires int64 dynamic shapes/strides in the caller's fake signature.
-    Each CTA owns flattened pair ``pair_start + blockIdx.x``. Pair numbering
-    restarts at each batch boundary, including an unpaired final query for odd T.
+    Each CTA scores two adjacent queries against M128 candidate tiles. UMMA
+    computes ``K[128,D] @ Q[2*H,D].T``; each of the 128 epilogue threads owns
+    one candidate and separately reduces ``weight * ReLU(dot)`` for each query.
+    Warp 5 loads Q once and streams K through two shared-memory stages; warp 4
+    issues UMMA into a two-stage TMEM ring consumed by warps 0--3. Warps 6--7
+    participate only in CTA synchronization. There is no persistent scheduler.
+
+    Q/K require unit D strides and 16-byte-aligned bases and outer slice origins;
+    their remaining strides are independent. Weights may have arbitrary strides
+    and require only element alignment; ``contiguous_weight_heads`` records whether
+    the caller's ABI promises a unit head stride. ``pair_start`` is a dynamic Int32
+    scalar, or Int64 when ``use_int64_offsets`` is enabled; the latter also requires
+    int64 dynamic shapes/strides in the caller's fake signature. Each CTA owns
+    flattened pair ``pair_start + blockIdx.x``. Pair numbering restarts at each
+    batch boundary, including an unpaired final query for odd T.
     """
 
     tile_candidates = 128
@@ -48,6 +56,8 @@ class IndexerScoreKernel:
         head_dim: int,
         causal: bool,
         use_int64_offsets: bool = False,
+        *,
+        contiguous_weight_heads: bool,
     ):
         if heads not in (32, 64) or head_dim != 128:
             raise ValueError("IndexerScoreKernel requires H=32/64 and D=128")
@@ -55,6 +65,7 @@ class IndexerScoreKernel:
         self.head_dim = head_dim
         self.causal = causal
         self.use_int64_offsets = use_int64_offsets
+        self.contiguous_weight_heads = contiguous_weight_heads
         self.packed_heads = 2 * heads
         self.mma_tile = (self.tile_candidates, self.packed_heads, head_dim)
 
@@ -68,10 +79,10 @@ class IndexerScoreKernel:
         self.SharedStorage = SharedStorage
 
     def get_name(self) -> str:
-        """Return a stable name for the static shape, mask, and offset width."""
+        """Return a stable name for the shape, mask, weight layout, and offset width."""
         return (
             f"indexer_score_h{self.heads}_d{self.head_dim}_c{int(self.causal)}_"
-            f"i64{int(self.use_int64_offsets)}"
+            f"i64{int(self.use_int64_offsets)}_wh{int(self.contiguous_weight_heads)}"
         )
 
     @cute.jit
@@ -88,22 +99,17 @@ class IndexerScoreKernel:
         scores: cute.Tensor,
         pair_start,
         score_scale: Float32,
-        stream: cuda_driver.CUstream,
+        stream: cuda.CUstream,
     ):
         """Build TMA descriptors and launch one CTA per output-slab query pair."""
         assert q.element_type in (cutlass.Float16, cutlass.BFloat16)
         assert k.element_type == q.element_type and weights.element_type == q.element_type
         assert scores.element_type == Float32
 
-        # Flatten only heads and tokens, retaining an independent batch mode
-        # for TMA's tail zero-fill. Widen before forming the packed extent.
-        q_packed = cute.make_tensor(
-            q.iterator,
-            cute.make_layout(
-                (self.upcast_offset(q.shape[1]) * self.heads, self.head_dim, q.shape[0]),
-                stride=(q.stride[2], q.stride[3], q.stride[0]),
-            ),
-        )
+        # The logical N coordinate is h + H*t, but H/T retain independent physical strides.
+        # TMA sees their separate extents, including the zero-filled query of an odd tail.
+        q_htdb = cute.make_tensor(q.iterator, cute.select(q.layout, mode=[2, 1, 3, 0]))
+        q_packed = cute.group_modes(q_htdb, 0, 2)
         k_sdb = cute.make_tensor(k.iterator, cute.select(k.layout, mode=[1, 2, 0]))
         tiled_mma = cute.make_tiled_mma(
             tcgen05.MmaF16BF16Op(

--- a/attn_gym/sparse/indexer/impl/cute_score.py
+++ b/attn_gym/sparse/indexer/impl/cute_score.py
@@ -1,0 +1,440 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Packed two-query SM100 score generation for bounded indexer score slabs.
+
+Adapted from cuDNN Frontend's ``dense_score_recompute_sm100.py`` and
+``indexer_score_unified_sm100.py``: K is the M128 A operand, while two queries'
+heads are packed into the B operand. One FP32 MMA tile has shape [128, 2*H];
+the epilogue independently computes ``scale * sum_h(weight * ReLU(Q @ K))``
+for each query. This module owns only score generation, not Top-K or allocation
+of the caller's [P, 2, T] FP32 slab.
+
+The schedule uses one TMA warp, one UMMA warp, and a 128-thread epilogue, with
+no persistent scheduler. Q remains resident for the CTA's entire candidate
+scan; two K stages and two accumulator stages connect the warp roles. Batch
+is a separate TMA mode, so packing heads with tokens cannot overfetch another
+batch when T is odd. Only valid rows/candidates are written.
+"""
+
+import cuda.bindings.driver as cuda_driver
+import cutlass
+import cutlass.utils.blackwell_helpers as sm100_utils
+from cutlass import Float32, Int32, Int64, cute, pipeline, utils
+from cutlass.cute.nvgpu import cpasync, tcgen05
+
+
+class IndexerScoreKernel:
+    """Generate a slab of scores for H=32/64, D=128, FP16/BF16 inputs on SM100.
+
+    Inputs must be contiguous and 16-byte aligned. ``pair_start`` is a dynamic
+    Int32 scalar, or Int64 when ``use_int64_offsets`` is enabled; the latter
+    also requires int64 dynamic shapes/strides in the caller's fake signature.
+    Each CTA owns flattened pair ``pair_start + blockIdx.x``. Pair numbering
+    restarts at each batch boundary, including an unpaired final query for odd T.
+    """
+
+    tile_candidates = 128
+    k_stages = 2
+    acc_stages = 2
+    epilogue_threads = 128
+    mma_warp = 4
+    load_warp = 5
+    threads = 256
+
+    def __init__(
+        self,
+        heads: int,
+        head_dim: int,
+        causal: bool,
+        use_int64_offsets: bool = False,
+    ):
+        if heads not in (32, 64) or head_dim != 128:
+            raise ValueError("IndexerScoreKernel requires H=32/64 and D=128")
+        self.heads = heads
+        self.head_dim = head_dim
+        self.causal = causal
+        self.use_int64_offsets = use_int64_offsets
+        self.packed_heads = 2 * heads
+        self.mma_tile = (self.tile_candidates, self.packed_heads, head_dim)
+
+        @cute.struct
+        class SharedStorage:
+            k_barriers: cute.struct.MemRange[Int64, self.k_stages * 2]
+            q_barriers: cute.struct.MemRange[Int64, 2]
+            acc_barriers: cute.struct.MemRange[Int64, self.acc_stages * 2]
+            tmem_holding: Int32
+
+        self.SharedStorage = SharedStorage
+
+    def get_name(self) -> str:
+        """Return a stable name for the static shape, mask, and offset width."""
+        return (
+            f"indexer_score_h{self.heads}_d{self.head_dim}_c{int(self.causal)}_"
+            f"i64{int(self.use_int64_offsets)}"
+        )
+
+    @cute.jit
+    def upcast_offset(self, value):
+        """Widen origins before address arithmetic in the wide specialization."""
+        return Int64(value) if cutlass.const_expr(self.use_int64_offsets) else Int32(value)
+
+    @cute.jit
+    def __call__(
+        self,
+        q: cute.Tensor,
+        k: cute.Tensor,
+        weights: cute.Tensor,
+        scores: cute.Tensor,
+        pair_start,
+        score_scale: Float32,
+        stream: cuda_driver.CUstream,
+    ):
+        """Build TMA descriptors and launch one CTA per output-slab query pair."""
+        assert q.element_type in (cutlass.Float16, cutlass.BFloat16)
+        assert k.element_type == q.element_type and weights.element_type == q.element_type
+        assert scores.element_type == Float32
+
+        # Flatten only heads and tokens, retaining an independent batch mode
+        # for TMA's tail zero-fill. Widen before forming the packed extent.
+        q_packed = cute.make_tensor(
+            q.iterator,
+            cute.make_layout(
+                (self.upcast_offset(q.shape[1]) * self.heads, self.head_dim, q.shape[0]),
+                stride=(q.stride[2], q.stride[3], q.stride[0]),
+            ),
+        )
+        k_sdb = cute.make_tensor(k.iterator, cute.select(k.layout, mode=[1, 2, 0]))
+        tiled_mma = cute.make_tiled_mma(
+            tcgen05.MmaF16BF16Op(
+                q.element_type,
+                Float32,
+                (self.tile_candidates, self.packed_heads, 16),
+                tcgen05.CtaGroup.ONE,
+                tcgen05.OperandSource.SMEM,
+                cute.nvgpu.OperandMajorMode.K,
+                cute.nvgpu.OperandMajorMode.K,
+            )
+        )
+        k_layout = sm100_utils.make_smem_layout_a(
+            tiled_mma, self.mma_tile, k.element_type, self.k_stages
+        )
+        q_layout = sm100_utils.make_smem_layout_b(tiled_mma, self.mma_tile, q.element_type, 1)
+        tma_load = cpasync.CopyBulkTensorTileG2SOp(tcgen05.CtaGroup.ONE)
+        tma_atom_k, k_tma = cute.nvgpu.make_tiled_tma_atom_A(
+            tma_load,
+            k_sdb,
+            cute.select(k_layout, mode=[0, 1, 2]),
+            self.mma_tile,
+            tiled_mma,
+        )
+        tma_atom_q, q_tma = cute.nvgpu.make_tiled_tma_atom_B(
+            tma_load,
+            q_packed,
+            cute.select(q_layout, mode=[0, 1, 2]),
+            self.mma_tile,
+            tiled_mma,
+        )
+        self.kernel.set_name_prefix(f"{self.get_name()}_{q.element_type.__name__.lower()}")
+        self.kernel(
+            tiled_mma,
+            tma_atom_k,
+            k_tma,
+            tma_atom_q,
+            q_tma,
+            weights,
+            scores,
+            q.element_type,
+            k_layout,
+            q_layout,
+            self.upcast_offset(pair_start),
+            score_scale,
+        ).launch(grid=(scores.shape[0], 1, 1), block=(self.threads, 1, 1), stream=stream)
+
+    @cute.kernel
+    def kernel(
+        self,
+        tiled_mma: cute.TiledMma,
+        tma_atom_k: cute.CopyAtom,
+        k: cute.Tensor,
+        tma_atom_q: cute.CopyAtom,
+        q: cute.Tensor,
+        weights: cute.Tensor,
+        scores: cute.Tensor,
+        io_dtype: cutlass.Constexpr,
+        k_layout: cute.ComposedLayout,
+        q_layout: cute.ComposedLayout,
+        pair_start,
+        score_scale: Float32,
+    ):
+        """Initialize stage ownership, dispatch warp roles, and retire TMEM."""
+        tidx, _, _ = cute.arch.thread_idx()
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        local_pair, _, _ = cute.arch.block_idx()
+        num_queries = self.upcast_offset(weights.shape[1])
+        pairs_per_batch = cute.ceil_div(num_queries, 2)
+        global_pair = pair_start + self.upcast_offset(local_pair)
+        batch = global_pair // pairs_per_batch
+        batch_pair = global_pair % pairs_per_batch
+        query0 = batch_pair * 2
+        active = global_pair < self.upcast_offset(weights.shape[0]) * pairs_per_batch
+        query_last = query0 + 1 if query0 + 1 < num_queries else query0
+        candidate_tiles = (
+            cute.ceil_div(query_last + 1, self.tile_candidates)
+            if self.causal
+            else cute.ceil_div(num_queries, self.tile_candidates)
+        )
+
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(self.SharedStorage)
+        sK = smem.allocate_tensor(
+            io_dtype, k_layout.outer, byte_alignment=128, swizzle=k_layout.inner
+        )
+        sQ = smem.allocate_tensor(
+            io_dtype, q_layout.outer, byte_alignment=128, swizzle=q_layout.inner
+        )
+        sW = smem.allocate_tensor(Float32, cute.make_layout((self.packed_heads,)))
+        if active and tidx < self.packed_heads:
+            query = query0 + tidx // self.heads
+            value = Float32(0.0)
+            if query < num_queries:
+                value = Float32(weights[batch, query, tidx % self.heads])
+            sW[tidx] = value
+
+        k_producer, k_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=self.k_stages,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            tx_count=cute.size_in_bytes(io_dtype, cute.select(k_layout, mode=[0, 1, 2])),
+            barrier_storage=storage.k_barriers.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        q_producer, q_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=1,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            tx_count=cute.size_in_bytes(io_dtype, cute.select(q_layout, mode=[0, 1, 2])),
+            barrier_storage=storage.q_barriers.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        acc_producer, acc_consumer = pipeline.PipelineUmmaAsync.create(
+            num_stages=self.acc_stages,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, self.epilogue_threads),
+            barrier_storage=storage.acc_barriers.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        cute.arch.mbarrier_init_fence()
+        cute.arch.barrier()
+
+        accumulator_shape = tiled_mma.partition_shape_C(self.mma_tile[:2])
+        accumulator_template = tiled_mma.make_fragment_C(
+            cute.append(accumulator_shape, self.acc_stages)
+        )
+        tmem = utils.TmemAllocator(
+            storage.tmem_holding.ptr,
+            barrier_for_retrieve=pipeline.NamedBarrier(barrier_id=1, num_threads=self.threads),
+            allocator_warp_id=self.mma_warp,
+        )
+        tmem.allocate(utils.get_num_tmem_alloc_cols(accumulator_template))
+        tmem.wait_for_alloc()
+        tmem_ptr = tmem.retrieve_ptr(Float32)
+        accumulator = cute.make_tensor(tmem_ptr, accumulator_template.layout)
+
+        if active:
+            if warp_idx < self.mma_warp:
+                self.run_epilogue(
+                    tiled_mma,
+                    accumulator,
+                    acc_consumer,
+                    sW,
+                    scores,
+                    self.upcast_offset(local_pair),
+                    tidx,
+                    query0,
+                    num_queries,
+                    candidate_tiles,
+                    score_scale,
+                )
+            elif warp_idx == self.mma_warp:
+                self.run_mma(
+                    tiled_mma,
+                    accumulator,
+                    sK,
+                    sQ,
+                    candidate_tiles,
+                    k_consumer,
+                    q_consumer,
+                    acc_producer,
+                )
+            elif warp_idx == self.load_warp:
+                self.run_load(
+                    tiled_mma,
+                    tma_atom_k,
+                    k[None, None, batch],
+                    tma_atom_q,
+                    q[None, None, batch],
+                    sK,
+                    sQ,
+                    batch_pair,
+                    candidate_tiles,
+                    k_producer,
+                    q_producer,
+                )
+
+        tmem.relinquish_alloc_permit()
+        pipeline.NamedBarrier(barrier_id=2, num_threads=self.threads).arrive_and_wait()
+        tmem.free(tmem_ptr)
+
+    @cute.jit
+    def run_load(
+        self,
+        tiled_mma: cute.TiledMma,
+        tma_atom_k: cute.CopyAtom,
+        k: cute.Tensor,
+        tma_atom_q: cute.CopyAtom,
+        q: cute.Tensor,
+        sK: cute.Tensor,
+        sQ: cute.Tensor,
+        batch_pair,
+        candidate_tiles,
+        k_producer,
+        q_producer,
+    ):
+        """Load packed Q once, then stream candidate K tiles with TMA tail zero-fill."""
+        cpasync.prefetch_descriptor(tma_atom_k)
+        cpasync.prefetch_descriptor(tma_atom_q)
+        mma_zero = tiled_mma.get_slice(0)
+        gQ = cute.local_tile(q, self.mma_tile, (0, batch_pair, 0), proj=(None, 1, 1))
+        s_q, g_q = cpasync.tma_partition(
+            tma_atom_q,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(sQ, 0, 3),
+            cute.group_modes(mma_zero.partition_B(gQ), 0, 3),
+        )
+        q_empty = q_producer.acquire_and_advance()
+        cute.copy(tma_atom_q, g_q, s_q[(None, q_empty.index)], tma_bar_ptr=q_empty.barrier)
+
+        for candidate_tile in cutlass.range(candidate_tiles, unroll=0):
+            gK = cute.local_tile(k, self.mma_tile, (candidate_tile, 0, 0), proj=(1, None, 1))
+            s_k, g_k = cpasync.tma_partition(
+                tma_atom_k,
+                0,
+                cute.make_layout(1),
+                cute.group_modes(sK, 0, 3),
+                cute.group_modes(mma_zero.partition_A(gK), 0, 3),
+            )
+            k_empty = k_producer.acquire_and_advance()
+            cute.copy(tma_atom_k, g_k, s_k[(None, k_empty.index)], tma_bar_ptr=k_empty.barrier)
+        k_producer.tail()
+        q_producer.tail()
+
+    @cute.jit
+    def run_mma(
+        self,
+        tiled_mma: cute.TiledMma,
+        accumulator: cute.Tensor,
+        sK: cute.Tensor,
+        sQ: cute.Tensor,
+        candidate_tiles,
+        k_consumer,
+        q_consumer,
+        acc_producer,
+    ):
+        """Compute [128, D] @ [2*H, D].T into a two-stage FP32 TMEM ring."""
+        fragment_k = tiled_mma.make_fragment_A(sK)
+        fragment_q = tiled_mma.make_fragment_B(sQ)
+        q_full = q_consumer.wait_and_advance()
+        for _candidate_tile in cutlass.range(candidate_tiles, unroll=0):
+            acc_empty = acc_producer.acquire_and_advance()
+            k_full = k_consumer.wait_and_advance()
+            for d_block in cutlass.range_constexpr(cute.size(fragment_k, mode=[2])):
+                issue_mma = tiled_mma.with_()
+                issue_mma.set(tcgen05.Field.ACCUMULATE, d_block != 0)
+                cute.gemm(
+                    issue_mma,
+                    accumulator[(None, None, None, acc_empty.index)],
+                    fragment_k[(None, None, d_block, k_full.index)],
+                    fragment_q[(None, None, d_block, q_full.index)],
+                    accumulator[(None, None, None, acc_empty.index)],
+                )
+            acc_empty.commit()
+            k_full.release()
+        q_full.release()
+        acc_producer.tail()
+
+    @cute.jit
+    def run_epilogue(
+        self,
+        tiled_mma: cute.TiledMma,
+        accumulator: cute.Tensor,
+        acc_consumer,
+        sW: cute.Tensor,
+        scores: cute.Tensor,
+        local_pair,
+        tidx: Int32,
+        query0,
+        num_queries,
+        candidate_tiles,
+        score_scale: Float32,
+    ):
+        """Load one full head row per thread, independently reduce each packed query."""
+        acc_tile = accumulator[(None, None, None, 0)]
+        tmem_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(self.packed_heads // 4)),
+            Float32,
+        )
+        tmem_copy = tcgen05.make_tmem_copy(tmem_atom, acc_tile)
+        tmem_thread = tmem_copy.get_slice(tidx)
+        coordinates = tmem_thread.partition_D(
+            tiled_mma.get_slice(tidx).partition_C(cute.make_identity_tensor(self.mma_tile[:2]))
+        )
+        logits = cute.make_rmem_tensor(
+            tmem_thread.partition_D(cute.make_identity_tensor(acc_tile.shape)).shape, Float32
+        )
+        assert cute.size(logits) == self.packed_heads
+        rW = cute.make_rmem_tensor((self.packed_heads,), Float32)
+        cute.autovec_copy(sW, rW)
+
+        for candidate_tile in cutlass.range(candidate_tiles, unroll=0):
+            acc_full = acc_consumer.wait_and_advance()
+            cute.copy(
+                tmem_copy,
+                tmem_thread.partition_S(accumulator[(None, None, None, acc_full.index)]),
+                logits,
+            )
+            cute.arch.fence_view_async_tmem_load()
+            acc_full.release()
+            candidate = (
+                self.upcast_offset(candidate_tile) * self.tile_candidates + coordinates[0][0]
+            )
+            for qi in cutlass.range_constexpr(2):
+                query = query0 + qi
+                valid = query < num_queries and candidate < num_queries
+                if cutlass.const_expr(self.causal):
+                    valid = valid and candidate <= query
+                if valid:
+                    # Four independent FP32 chains keep head reduction latency
+                    # bounded without packed-PTX or cross-thread reductions.
+                    sum0 = Float32(0.0)
+                    sum1 = Float32(0.0)
+                    sum2 = Float32(0.0)
+                    sum3 = Float32(0.0)
+                    for group in cutlass.range_constexpr(self.heads // 4):
+                        offset = qi * self.heads + group * 4
+                        x0 = Float32(logits[offset])
+                        x1 = Float32(logits[offset + 1])
+                        x2 = Float32(logits[offset + 2])
+                        x3 = Float32(logits[offset + 3])
+                        x0 = x0 if x0 > Float32(0.0) else Float32(0.0)  # noqa: FURB136
+                        x1 = x1 if x1 > Float32(0.0) else Float32(0.0)  # noqa: FURB136
+                        x2 = x2 if x2 > Float32(0.0) else Float32(0.0)  # noqa: FURB136
+                        x3 = x3 if x3 > Float32(0.0) else Float32(0.0)  # noqa: FURB136
+                        sum0 = sum0 + x0 * rW[offset]
+                        sum1 = sum1 + x1 * rW[offset + 1]
+                        sum2 = sum2 + x2 * rW[offset + 2]
+                        sum3 = sum3 + x3 * rW[offset + 3]
+                    scores[local_pair, qi, candidate] = (
+                        (sum0 + sum1) + (sum2 + sum3)
+                    ) * score_scale

--- a/attn_gym/sparse/indexer/impl/cute_score_generic.py
+++ b/attn_gym/sparse/indexer/impl/cute_score_generic.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+# Modified by Attention Gym in 2026: bounded score slabs and general head/dimension tiling.
 
 """Tiled SM100 indexer score generation without shape-sized shared buffers.
 
@@ -10,9 +11,9 @@ another query or batch. This module allocates no global workspace and performs
 no selection; masked and inactive slab entries remain untouched.
 """
 
-import cuda.bindings.driver as cuda_driver
 import cutlass
 import cutlass.utils.blackwell_helpers as sm100_utils
+from cuda.bindings import driver as cuda
 from cutlass import Float32, Int32, Int64, cute, pipeline, utils
 from cutlass.cute.nvgpu import cpasync, tcgen05
 
@@ -27,9 +28,12 @@ class IndexerGenericScoreKernel:
 
     Warps 0--3 each own 32 candidates, warp 4 issues UMMA, warp 5 loads both
     operands with TMA, and warps 6--7 participate only in CTA synchronization.
-    Two combined operand stages feed a two-stage accumulator ring. Inputs are
-    contiguous, 16-byte-aligned FP16/BF16. The caller supplies Int32 pair_start
-    and dynamic shapes/strides, or their Int64 equivalents for wide offsets.
+    Two combined operand stages feed a two-stage accumulator ring. Q/K require
+    unit D strides and 16-byte-aligned bases and outer slice origins. Remaining
+    strides are independent; weights need only element alignment and may be strided,
+    with ``contiguous_weight_heads`` recording a promised unit head stride. The caller
+    supplies Int32 pair_start and dynamic shapes/strides, or their Int64 equivalents
+    for wide offsets.
     """
 
     tile_candidates = 128
@@ -48,6 +52,8 @@ class IndexerGenericScoreKernel:
         head_dim: int,
         causal: bool,
         use_int64_offsets: bool = False,
+        *,
+        contiguous_weight_heads: bool,
     ):
         if heads <= 0 or heads % 2 != 0:
             raise ValueError("IndexerGenericScoreKernel requires positive even H")
@@ -57,6 +63,7 @@ class IndexerGenericScoreKernel:
         self.head_dim = head_dim
         self.causal = causal
         self.use_int64_offsets = use_int64_offsets
+        self.contiguous_weight_heads = contiguous_weight_heads
         self.head_tiles = (heads + self.tile_heads - 1) // self.tile_heads
         self.d_tiles = (head_dim + self.tile_dim - 1) // self.tile_dim
         self.mma_tile = (self.tile_candidates, self.tile_heads, self.tile_dim)
@@ -70,10 +77,10 @@ class IndexerGenericScoreKernel:
         self.SharedStorage = SharedStorage
 
     def get_name(self) -> str:
-        """Return a stable name for the static shape, mask, and offset width."""
+        """Return a stable name for the shape, mask, weight layout, and offset width."""
         return (
             f"indexer_score_generic_h{self.heads}_d{self.head_dim}_c{int(self.causal)}_"
-            f"i64{int(self.use_int64_offsets)}"
+            f"i64{int(self.use_int64_offsets)}_wh{int(self.contiguous_weight_heads)}"
         )
 
     @cute.jit
@@ -90,7 +97,7 @@ class IndexerGenericScoreKernel:
         scores: cute.Tensor,
         pair_start,
         score_scale: Float32,
-        stream: cuda_driver.CUstream,
+        stream: cuda.CUstream,
     ):
         """Build boundary-preserving TMA descriptors and launch two CTAs per pair."""
         assert q.element_type in (cutlass.Float16, cutlass.BFloat16)

--- a/attn_gym/sparse/indexer/impl/cute_score_generic.py
+++ b/attn_gym/sparse/indexer/impl/cute_score_generic.py
@@ -1,0 +1,442 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tiled SM100 indexer score generation without shape-sized shared buffers.
+
+One CTA owns one query in the caller's [P, 2, T] FP32 score slab. Candidate,
+head, and reduction tiles bound shared-memory and TMEM usage independently of
+H and D. Separate head/query/batch TMA modes zero-fill tails without reading
+another query or batch. This module allocates no global workspace and performs
+no selection; masked and inactive slab entries remain untouched.
+"""
+
+import cuda.bindings.driver as cuda_driver
+import cutlass
+import cutlass.utils.blackwell_helpers as sm100_utils
+from cutlass import Float32, Int32, Int64, cute, pipeline, utils
+from cutlass.cute.nvgpu import cpasync, tcgen05
+
+
+class IndexerGenericScoreKernel:
+    """Generate scores for positive even H and positive D divisible by 16.
+
+    For each candidate tile M128 and head tile N64, UMMA accumulates
+    ``L[m,h] = sum_d K[m,d] * Q[h,d]`` in FP32 across K64 chunks. Only after
+    completing D does the epilogue accumulate ``weight[h] * max(L[m,h], 0)``
+    across head tiles, then multiply the final FP32 sum by ``score_scale``.
+
+    Warps 0--3 each own 32 candidates, warp 4 issues UMMA, warp 5 loads both
+    operands with TMA, and warps 6--7 participate only in CTA synchronization.
+    Two combined operand stages feed a two-stage accumulator ring. Inputs are
+    contiguous, 16-byte-aligned FP16/BF16. The caller supplies Int32 pair_start
+    and dynamic shapes/strides, or their Int64 equivalents for wide offsets.
+    """
+
+    tile_candidates = 128
+    tile_heads = 64
+    tile_dim = 64
+    ab_stages = 2
+    acc_stages = 2
+    epilogue_threads = 128
+    mma_warp = 4
+    load_warp = 5
+    threads = 256
+
+    def __init__(
+        self,
+        heads: int,
+        head_dim: int,
+        causal: bool,
+        use_int64_offsets: bool = False,
+    ):
+        if heads <= 0 or heads % 2 != 0:
+            raise ValueError("IndexerGenericScoreKernel requires positive even H")
+        if head_dim <= 0 or head_dim % 16 != 0:
+            raise ValueError("IndexerGenericScoreKernel requires positive D divisible by 16")
+        self.heads = heads
+        self.head_dim = head_dim
+        self.causal = causal
+        self.use_int64_offsets = use_int64_offsets
+        self.head_tiles = (heads + self.tile_heads - 1) // self.tile_heads
+        self.d_tiles = (head_dim + self.tile_dim - 1) // self.tile_dim
+        self.mma_tile = (self.tile_candidates, self.tile_heads, self.tile_dim)
+
+        @cute.struct
+        class SharedStorage:
+            ab_barriers: cute.struct.MemRange[Int64, self.ab_stages * 2]
+            acc_barriers: cute.struct.MemRange[Int64, self.acc_stages * 2]
+            tmem_holding: Int32
+
+        self.SharedStorage = SharedStorage
+
+    def get_name(self) -> str:
+        """Return a stable name for the static shape, mask, and offset width."""
+        return (
+            f"indexer_score_generic_h{self.heads}_d{self.head_dim}_c{int(self.causal)}_"
+            f"i64{int(self.use_int64_offsets)}"
+        )
+
+    @cute.jit
+    def upcast_offset(self, value):
+        """Widen origins before address arithmetic in the wide specialization."""
+        return Int64(value) if cutlass.const_expr(self.use_int64_offsets) else Int32(value)
+
+    @cute.jit
+    def __call__(
+        self,
+        q: cute.Tensor,
+        k: cute.Tensor,
+        weights: cute.Tensor,
+        scores: cute.Tensor,
+        pair_start,
+        score_scale: Float32,
+        stream: cuda_driver.CUstream,
+    ):
+        """Build boundary-preserving TMA descriptors and launch two CTAs per pair."""
+        assert q.element_type in (cutlass.Float16, cutlass.BFloat16)
+        assert k.element_type == q.element_type and weights.element_type == q.element_type
+        assert scores.element_type == Float32
+        q_hdtb = cute.make_tensor(q.iterator, cute.select(q.layout, mode=[2, 3, 1, 0]))
+        k_sdb = cute.make_tensor(k.iterator, cute.select(k.layout, mode=[1, 2, 0]))
+        tiled_mma = cute.make_tiled_mma(
+            tcgen05.MmaF16BF16Op(
+                q.element_type,
+                Float32,
+                (self.tile_candidates, self.tile_heads, 16),
+                tcgen05.CtaGroup.ONE,
+                tcgen05.OperandSource.SMEM,
+                cute.nvgpu.OperandMajorMode.K,
+                cute.nvgpu.OperandMajorMode.K,
+            )
+        )
+        k_layout = sm100_utils.make_smem_layout_a(
+            tiled_mma, self.mma_tile, k.element_type, self.ab_stages
+        )
+        q_layout = sm100_utils.make_smem_layout_b(
+            tiled_mma, self.mma_tile, q.element_type, self.ab_stages
+        )
+        tma_load = cpasync.CopyBulkTensorTileG2SOp(tcgen05.CtaGroup.ONE)
+        tma_atom_k, k_tma = cute.nvgpu.make_tiled_tma_atom_A(
+            tma_load,
+            k_sdb,
+            cute.select(k_layout, mode=[0, 1, 2]),
+            self.mma_tile,
+            tiled_mma,
+        )
+        tma_atom_q, q_tma = cute.nvgpu.make_tiled_tma_atom_B(
+            tma_load,
+            q_hdtb,
+            cute.select(q_layout, mode=[0, 1, 2]),
+            self.mma_tile,
+            tiled_mma,
+        )
+        self.kernel.set_name_prefix(f"{self.get_name()}_{q.element_type.__name__.lower()}")
+        self.kernel(
+            tiled_mma,
+            tma_atom_k,
+            k_tma,
+            tma_atom_q,
+            q_tma,
+            weights,
+            scores,
+            q.element_type,
+            k_layout,
+            q_layout,
+            self.upcast_offset(pair_start),
+            score_scale,
+        ).launch(
+            grid=(self.upcast_offset(scores.shape[0]) * 2, 1, 1),
+            block=(self.threads, 1, 1),
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        tiled_mma: cute.TiledMma,
+        tma_atom_k: cute.CopyAtom,
+        k: cute.Tensor,
+        tma_atom_q: cute.CopyAtom,
+        q: cute.Tensor,
+        weights: cute.Tensor,
+        scores: cute.Tensor,
+        io_dtype: cutlass.Constexpr,
+        k_layout: cute.ComposedLayout,
+        q_layout: cute.ComposedLayout,
+        pair_start,
+        score_scale: Float32,
+    ):
+        """Guard the whole CTA, initialize pipelines, dispatch roles, and retire TMEM."""
+        tidx, _, _ = cute.arch.thread_idx()
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        block_id, _, _ = cute.arch.block_idx()
+        slab_pair = self.upcast_offset(block_id) // 2
+        qi = block_id % 2
+        num_queries = self.upcast_offset(weights.shape[1])
+        pairs_per_batch = cute.ceil_div(num_queries, 2)
+        global_pair = pair_start + slab_pair
+        batch = global_pair // pairs_per_batch
+        query = (global_pair % pairs_per_batch) * 2 + qi
+        active = batch < self.upcast_offset(weights.shape[0]) and query < num_queries
+
+        if active:
+            candidate_tiles = (
+                cute.ceil_div(query + 1, self.tile_candidates)
+                if self.causal
+                else cute.ceil_div(num_queries, self.tile_candidates)
+            )
+            smem = utils.SmemAllocator()
+            storage = smem.allocate(self.SharedStorage)
+            sK = smem.allocate_tensor(
+                io_dtype, k_layout.outer, byte_alignment=128, swizzle=k_layout.inner
+            )
+            sQ = smem.allocate_tensor(
+                io_dtype, q_layout.outer, byte_alignment=128, swizzle=q_layout.inner
+            )
+            ab_producer, ab_consumer = pipeline.PipelineTmaUmma.create(
+                num_stages=self.ab_stages,
+                producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+                consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+                tx_count=(
+                    cute.size_in_bytes(io_dtype, cute.select(k_layout, mode=[0, 1, 2]))
+                    + cute.size_in_bytes(io_dtype, cute.select(q_layout, mode=[0, 1, 2]))
+                ),
+                barrier_storage=storage.ab_barriers.data_ptr(),
+                defer_sync=True,
+            ).make_participants()
+            acc_producer, acc_consumer = pipeline.PipelineUmmaAsync.create(
+                num_stages=self.acc_stages,
+                producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+                consumer_group=pipeline.CooperativeGroup(
+                    pipeline.Agent.Thread, self.epilogue_threads
+                ),
+                barrier_storage=storage.acc_barriers.data_ptr(),
+                defer_sync=True,
+            ).make_participants()
+            cute.arch.mbarrier_init_fence()
+            cute.arch.barrier()
+
+            accumulator_shape = tiled_mma.partition_shape_C(self.mma_tile[:2])
+            accumulator_template = tiled_mma.make_fragment_C(
+                cute.append(accumulator_shape, self.acc_stages)
+            )
+            tmem = utils.TmemAllocator(
+                storage.tmem_holding.ptr,
+                barrier_for_retrieve=pipeline.NamedBarrier(barrier_id=1, num_threads=self.threads),
+                allocator_warp_id=self.mma_warp,
+            )
+            tmem.allocate(utils.get_num_tmem_alloc_cols(accumulator_template))
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(Float32)
+            accumulator = cute.make_tensor(tmem_ptr, accumulator_template.layout)
+
+            if warp_idx < self.mma_warp:
+                self.run_epilogue(
+                    tiled_mma,
+                    accumulator,
+                    acc_consumer,
+                    weights[batch, query, None],
+                    scores,
+                    slab_pair,
+                    qi,
+                    tidx,
+                    query,
+                    num_queries,
+                    candidate_tiles,
+                    score_scale,
+                )
+            elif warp_idx == self.mma_warp:
+                self.run_mma(
+                    tiled_mma,
+                    accumulator,
+                    sK,
+                    sQ,
+                    candidate_tiles,
+                    ab_consumer,
+                    acc_producer,
+                )
+            elif warp_idx == self.load_warp:
+                self.run_load(
+                    tiled_mma,
+                    tma_atom_k,
+                    k[None, None, batch],
+                    tma_atom_q,
+                    q[None, None, query, batch],
+                    sK,
+                    sQ,
+                    candidate_tiles,
+                    ab_producer,
+                )
+
+            tmem.relinquish_alloc_permit()
+            pipeline.NamedBarrier(barrier_id=2, num_threads=self.threads).arrive_and_wait()
+            tmem.free(tmem_ptr)
+
+    @cute.jit
+    def run_load(
+        self,
+        tiled_mma: cute.TiledMma,
+        tma_atom_k: cute.CopyAtom,
+        k: cute.Tensor,
+        tma_atom_q: cute.CopyAtom,
+        q: cute.Tensor,
+        sK: cute.Tensor,
+        sQ: cute.Tensor,
+        candidate_tiles,
+        ab_producer,
+    ):
+        """Stream paired K/Q boxes, including zero-filled head and reduction tails."""
+        cpasync.prefetch_descriptor(tma_atom_k)
+        cpasync.prefetch_descriptor(tma_atom_q)
+        mma_zero = tiled_mma.get_slice(0)
+        for candidate_tile in cutlass.range(candidate_tiles, unroll=0):
+            for head_tile in cutlass.range(self.head_tiles, unroll=0):
+                tile_coord = (
+                    self.upcast_offset(candidate_tile),
+                    self.upcast_offset(head_tile),
+                    None,
+                )
+                gK = cute.local_tile(k, self.mma_tile, tile_coord, proj=(1, None, 1))
+                gQ = cute.local_tile(q, self.mma_tile, tile_coord, proj=(None, 1, 1))
+                s_k, g_k = cpasync.tma_partition(
+                    tma_atom_k,
+                    0,
+                    cute.make_layout(1),
+                    cute.group_modes(sK, 0, 3),
+                    cute.group_modes(mma_zero.partition_A(gK), 0, 3),
+                )
+                s_q, g_q = cpasync.tma_partition(
+                    tma_atom_q,
+                    0,
+                    cute.make_layout(1),
+                    cute.group_modes(sQ, 0, 3),
+                    cute.group_modes(mma_zero.partition_B(gQ), 0, 3),
+                )
+                for d_tile in cutlass.range(self.d_tiles, unroll=0):
+                    ab_empty = ab_producer.acquire_and_advance()
+                    cute.copy(
+                        tma_atom_k,
+                        g_k[(None, self.upcast_offset(d_tile))],
+                        s_k[(None, ab_empty.index)],
+                        tma_bar_ptr=ab_empty.barrier,
+                    )
+                    cute.copy(
+                        tma_atom_q,
+                        g_q[(None, self.upcast_offset(d_tile))],
+                        s_q[(None, ab_empty.index)],
+                        tma_bar_ptr=ab_empty.barrier,
+                    )
+        ab_producer.tail()
+
+    @cute.jit
+    def run_mma(
+        self,
+        tiled_mma: cute.TiledMma,
+        accumulator: cute.Tensor,
+        sK: cute.Tensor,
+        sQ: cute.Tensor,
+        candidate_tiles,
+        ab_consumer,
+        acc_producer,
+    ):
+        """Complete D before publishing each [128, 64] FP32 accumulator tile."""
+        fragment_k = tiled_mma.make_fragment_A(sK)
+        fragment_q = tiled_mma.make_fragment_B(sQ)
+        for _candidate_tile in cutlass.range(candidate_tiles, unroll=0):
+            for _head_tile in cutlass.range(self.head_tiles, unroll=0):
+                acc_empty = acc_producer.acquire_and_advance()
+                for d_tile in cutlass.range(self.d_tiles, unroll=0):
+                    ab_full = ab_consumer.wait_and_advance()
+                    for d_block in cutlass.range_constexpr(cute.size(fragment_k, mode=[2])):
+                        issue_mma = tiled_mma.with_()
+                        issue_mma.set(
+                            tcgen05.Field.ACCUMULATE,
+                            cutlass.Boolean(d_tile != Int32(0) or d_block != 0),
+                        )
+                        cute.gemm(
+                            issue_mma,
+                            accumulator[(None, None, None, acc_empty.index)],
+                            fragment_k[(None, None, d_block, ab_full.index)],
+                            fragment_q[(None, None, d_block, ab_full.index)],
+                            accumulator[(None, None, None, acc_empty.index)],
+                        )
+                    ab_full.release()
+                acc_empty.commit()
+        acc_producer.tail()
+
+    @cute.jit
+    def run_epilogue(
+        self,
+        tiled_mma: cute.TiledMma,
+        accumulator: cute.Tensor,
+        acc_consumer,
+        weights: cute.Tensor,
+        scores: cute.Tensor,
+        slab_pair,
+        qi: Int32,
+        tidx: Int32,
+        query,
+        num_queries,
+        candidate_tiles,
+        score_scale: Float32,
+    ):
+        """Keep one candidate's FP32 head sum in registers until its final slab store."""
+        acc_tile = accumulator[(None, None, None, 0)]
+        tmem_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(self.tile_heads // 4)),
+            Float32,
+        )
+        tmem_copy = tcgen05.make_tmem_copy(tmem_atom, acc_tile)
+        tmem_thread = tmem_copy.get_slice(tidx)
+        coordinates = tmem_thread.partition_D(
+            tiled_mma.get_slice(tidx).partition_C(cute.make_identity_tensor(self.mma_tile[:2]))
+        )
+        logits = cute.make_rmem_tensor(
+            tmem_thread.partition_D(cute.make_identity_tensor(acc_tile.shape)).shape, Float32
+        )
+        assert cute.size(logits) == self.tile_heads
+        rW = cute.make_rmem_tensor((self.tile_heads,), Float32)
+
+        for candidate_tile in cutlass.range(candidate_tiles, unroll=0):
+            candidate = (
+                self.upcast_offset(candidate_tile) * self.tile_candidates + coordinates[0][0]
+            )
+            valid = candidate < num_queries
+            if cutlass.const_expr(self.causal):
+                valid = valid and candidate <= query
+            sum0 = Float32(0.0)
+            sum1 = Float32(0.0)
+            sum2 = Float32(0.0)
+            sum3 = Float32(0.0)
+            for head_tile in cutlass.range(self.head_tiles, unroll=0):
+                acc_full = acc_consumer.wait_and_advance()
+                cute.copy(
+                    tmem_copy,
+                    tmem_thread.partition_S(accumulator[(None, None, None, acc_full.index)]),
+                    logits,
+                )
+                cute.arch.fence_view_async_tmem_load()
+                acc_full.release()
+                if valid:
+                    for offset in cutlass.range_constexpr(self.tile_heads):
+                        head = self.upcast_offset(head_tile) * self.tile_heads + offset
+                        weight = Float32(0.0)
+                        if head < self.heads:
+                            weight = Float32(weights[head])
+                        rW[offset] = weight
+                    for group in cutlass.range_constexpr(self.tile_heads // 4):
+                        offset = group * 4
+                        x0 = Float32(logits[offset])
+                        x1 = Float32(logits[offset + 1])
+                        x2 = Float32(logits[offset + 2])
+                        x3 = Float32(logits[offset + 3])
+                        x0 = x0 if x0 > Float32(0.0) else Float32(0.0)  # noqa: FURB136
+                        x1 = x1 if x1 > Float32(0.0) else Float32(0.0)  # noqa: FURB136
+                        x2 = x2 if x2 > Float32(0.0) else Float32(0.0)  # noqa: FURB136
+                        x3 = x3 if x3 > Float32(0.0) else Float32(0.0)  # noqa: FURB136
+                        sum0 = sum0 + x0 * rW[offset]
+                        sum1 = sum1 + x1 * rW[offset + 1]
+                        sum2 = sum2 + x2 * rW[offset + 2]
+                        sum3 = sum3 + x3 * rW[offset + 3]
+            if valid:
+                scores[slab_pair, qi, candidate] = ((sum0 + sum1) + (sum2 + sum3)) * score_scale

--- a/attn_gym/sparse/indexer/impl/cute_topk.py
+++ b/attn_gym/sparse/indexer/impl/cute_topk.py
@@ -15,8 +15,8 @@ score reads at all. Output ordering and selection among ties are unspecified;
 the monotonic key supports signed finite FP32 scores.
 """
 
-import cuda.bindings.driver as cuda_driver
 import cutlass
+from cuda.bindings import driver as cuda
 from cutlass import Float32, Int32, Int64, Uint32, cute
 from cutlass._mlir.dialects import llvm
 from cutlass.cutlass_dsl import dsl_user_op
@@ -298,7 +298,7 @@ class IndexerTopKKernel:
         scores: cute.Tensor,
         output: cute.Tensor,
         pair_start: Int32 | Int64,
-        stream: cuda_driver.CUstream,
+        stream: cuda.CUstream,
     ):
         """Launch one 512-thread CTA per physical query row in the score slab."""
         self.kernel.set_name_prefix(self.get_name())

--- a/attn_gym/sparse/indexer/impl/cute_topk.py
+++ b/attn_gym/sparse/indexer/impl/cute_topk.py
@@ -1,0 +1,309 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Indices-only radix selection over bounded FP32 indexer score slabs.
+
+Adapted from NVIDIA cuDNN Frontend's ``compress_top_k_sm100.py`` at
+1ab7d63be81f1ef2eb3b2dea5367219cf9674a5f. Each CTA selects one query row:
+(1) histogram the highest 11 ordered-float bits; (2) emit strict winners and
+stage the boundary bin; (3) refine its next 11 bits; (4) refine the final 10
+bits and emit only the required number of exact ties. The fixed shared shrink
+buffer avoids full-row refinement scans unless its boundary bin overflows.
+
+Only valid causal scores are read. Rows with at most K candidates require no
+score reads at all. Output ordering and selection among ties are unspecified;
+the monotonic key supports signed finite FP32 scores.
+"""
+
+import cuda.bindings.driver as cuda_driver
+import cutlass
+from cutlass import Float32, Int32, Int64, Uint32, cute
+from cutlass._mlir.dialects import llvm
+from cutlass.cutlass_dsl import dsl_user_op
+from cutlass.utils.smem_allocator import SmemAllocator
+
+_NUM_BINS_11 = 2048
+_NUM_BINS_10 = 1024
+_SHRINK_MAX = 2048  # 16 KiB for ordered keys and local KV indices.
+
+
+@dsl_user_op
+def _float_bits(value: Float32, *, loc=None, ip=None) -> Uint32:
+    """Reinterpret an FP32 register as unsigned bits without numerical conversion."""
+    return Uint32(llvm.bitcast(Uint32.mlir_type, value.ir_value(), loc=loc, ip=ip))
+
+
+@cute.jit
+def _ordered_key(value: Float32) -> Uint32:
+    """Map signed finite FP32 values to monotonically increasing unsigned keys."""
+    bits = _float_bits(value)
+    return bits ^ Uint32(0xFFFFFFFF) if bits & Uint32(0x80000000) else bits | Uint32(0x80000000)
+
+
+@cute.jit
+def _warp_scan_inclusive(value: Int32, lane_id: Int32, lanes: cutlass.Constexpr) -> Int32:
+    """Inclusive sum across the first power-of-two number of participating lanes."""
+    mask = cutlass.const_expr(((1 << lanes) - 1) & 0xFFFFFFFF)
+    for i in cutlass.range_constexpr(lanes.bit_length() - 1):
+        offset = 1 << i
+        other = cute.arch.shuffle_sync_up(value, offset, mask=mask, mask_and_clamp=0)
+        if lane_id >= offset:
+            value += other
+    return value
+
+
+@cute.jit
+def _block_scan_inclusive(
+    value: Int32,
+    warp_sums: cute.Tensor,
+    tidx: Int32,
+    threads: cutlass.Constexpr,
+) -> Int32:
+    """Inclusive CTA sum using one shared partial per warp and two barriers."""
+    warp_id = tidx // 32
+    lane_id = tidx % 32
+    value = _warp_scan_inclusive(value, lane_id, 32)
+    if lane_id == 31:
+        warp_sums[warp_id] = value
+    cute.arch.barrier()
+    if warp_id == 0 and lane_id < threads // 32:
+        partial = _warp_scan_inclusive(warp_sums[lane_id], lane_id, threads // 32)
+        warp_sums[lane_id] = partial
+    cute.arch.barrier()
+    if warp_id > 0:
+        value += warp_sums[warp_id - 1]
+    return value
+
+
+class IndexerTopKKernel:
+    """Select static K indices per row from a contiguous symbolic [P, 2, T] slab.
+
+    ``pair_start`` locates the slab in flattened (batch, query-pair) order; odd
+    sequence tails do not share pairs across batches. The caller handles K=0
+    without launching and selects the wide ABI when score/output offsets or
+    strides exceed int32. Sequence lengths and returned local IDs fit int32.
+    """
+
+    block_threads = 512
+
+    def __init__(self, topk: int, causal: bool, use_int64_offsets: bool = False):
+        self.topk = topk
+        self.causal = causal
+        self.use_int64_offsets = use_int64_offsets
+
+    def get_name(self) -> str:
+        """Return a stable artifact name including all static specialization fields."""
+        return (
+            f"indexer_topk_k{self.topk}_c{int(self.causal)}_"
+            f"i64{int(self.use_int64_offsets)}_th{self.block_threads}"
+        )
+
+    @cute.jit
+    def upcast_offset(self, value):
+        """Widen indices before any address arithmetic in the wide specialization."""
+        return Int64(value) if cutlass.const_expr(self.use_int64_offsets) else value
+
+    @cute.jit
+    def find_threshold(
+        self,
+        histogram: cute.Tensor,
+        bins: cutlass.Constexpr,
+        need: Int32,
+        warp_sums: cute.Tensor,
+        threshold: cute.Tensor,
+        tidx: Int32,
+    ):
+        """Find the descending cumulative-count boundary and clear the histogram.
+
+        Exactly one bin crosses positive ``need``. Its owner publishes the bin
+        ID and the number still needed from that bin for the next radix pass.
+        """
+        items = cutlass.const_expr(bins // self.block_threads)
+        counts = [Int32(0) for _ in range(items)]
+        local_sum = Int32(0)
+        for i in cutlass.range_constexpr(items):
+            bin_id = bins - 1 - (tidx * items + i)
+            counts[i] = histogram[bin_id]
+            histogram[bin_id] = Int32(0)
+            local_sum += counts[i]
+
+        inclusive = _block_scan_inclusive(local_sum, warp_sums, tidx, self.block_threads)
+        running = inclusive - local_sum
+        for i in cutlass.range_constexpr(items):
+            count = counts[i]
+            if count > 0 and running < need and running + count >= need:
+                threshold[0] = Int32(bins - 1 - (tidx * items + i))
+                threshold[1] = need - running
+            running += count
+        cute.arch.barrier()
+        return threshold[0], threshold[1]
+
+    @cute.kernel
+    def kernel(
+        self,
+        scores: cute.Tensor,
+        output: cute.Tensor,
+        pair_start: Int32 | Int64,
+    ):
+        """Run the four-pass selection with CTA-uniform row and short-row guards."""
+        tidx = cute.arch.thread_idx()[0]
+        block_id = self.upcast_offset(cute.arch.block_idx()[0])
+        slab_pair = block_id // 2
+        qi = block_id % 2
+        seq_len = self.upcast_offset(scores.shape[2])
+        pairs_per_batch = cute.ceil_div(seq_len, 2)
+        global_pair = self.upcast_offset(pair_start) + slab_pair
+        batch = global_pair // pairs_per_batch
+        q = (global_pair % pairs_per_batch) * 2 + qi
+
+        smem = SmemAllocator()
+        histogram = smem.allocate_tensor(
+            Int32, cute.make_layout((_NUM_BINS_11,)), byte_alignment=128
+        )
+        warp_sums = smem.allocate_tensor(
+            Int32, cute.make_layout((self.block_threads // 32,)), byte_alignment=128
+        )
+        threshold = smem.allocate_tensor(Int32, cute.make_layout((2,)), byte_alignment=128)
+        # Counters: emitted winners, accepted exact ties, boundary-bin size.
+        counters = smem.allocate_tensor(Int32, cute.make_layout((3,)), byte_alignment=128)
+        shrink_keys = smem.allocate_tensor(
+            Uint32, cute.make_layout((_SHRINK_MAX,)), byte_alignment=128
+        )
+        shrink_indices = smem.allocate_tensor(
+            Int32, cute.make_layout((_SHRINK_MAX,)), byte_alignment=128
+        )
+
+        if batch < output.shape[0] and q < seq_len:
+            row_output = output[batch, q, None]
+            seg_len = Int32(seq_len)
+            if cutlass.const_expr(self.causal):
+                seg_len = Int32(q + 1)
+
+            if seg_len <= self.topk:
+                for slot in range(tidx, self.topk, self.block_threads):
+                    row_output[slot] = Int32(slot) if slot < seg_len else Int32(-1)
+            else:
+                row = scores[slab_pair, qi, None]
+                if tidx == 0:
+                    counters[0] = Int32(0)
+                    counters[1] = Int32(0)
+                    counters[2] = Int32(0)
+                for i in range(tidx, _NUM_BINS_11, self.block_threads):
+                    histogram[i] = Int32(0)
+                cute.arch.barrier()
+
+                # Pass 1: highest 11-bit histogram over exactly the valid row.
+                for i in range(tidx, seg_len, self.block_threads):
+                    key = _ordered_key(row[i])
+                    bin0 = Int32((key >> 21) & Uint32(0x7FF))
+                    cute.arch.atomic_add(
+                        histogram.iterator + bin0, Int32(1), sem="relaxed", scope="cta"
+                    )
+                cute.arch.barrier()
+                bin0_threshold, need0 = self.find_threshold(
+                    histogram, _NUM_BINS_11, Int32(self.topk), warp_sums, threshold, tidx
+                )
+
+                # Pass 2: emit strict winners and stage the first boundary bin.
+                for i in range(tidx, seg_len, self.block_threads):
+                    key = _ordered_key(row[i])
+                    bin0 = Int32((key >> 21) & Uint32(0x7FF))
+                    if bin0 > bin0_threshold:
+                        dst = cute.arch.atomic_add(
+                            counters.iterator, Int32(1), sem="relaxed", scope="cta"
+                        )
+                        row_output[dst] = Int32(i)
+                    elif bin0 == bin0_threshold:
+                        bin1 = Int32((key >> 10) & Uint32(0x7FF))
+                        cute.arch.atomic_add(
+                            histogram.iterator + bin1, Int32(1), sem="relaxed", scope="cta"
+                        )
+                        slot = cute.arch.atomic_add(
+                            counters.iterator + 2, Int32(1), sem="relaxed", scope="cta"
+                        )
+                        if slot < _SHRINK_MAX:
+                            shrink_keys[slot] = key
+                            shrink_indices[slot] = Int32(i)
+                cute.arch.barrier()
+                bin1_threshold, need1 = self.find_threshold(
+                    histogram, _NUM_BINS_11, need0, warp_sums, threshold, tidx
+                )
+
+                # Derive overflow from the atomic count after the barrier: no
+                # concurrently written non-atomic overflow flag is necessary.
+                shrink_count = counters[2]
+                use_shrink = shrink_count <= _SHRINK_MAX
+                scan_len = shrink_count if use_shrink else seg_len
+
+                # Pass 3: refine the middle 11 bits, falling back to a full scan.
+                for i in range(tidx, scan_len, self.block_threads):
+                    key = Uint32(0)
+                    idx = Int32(0)
+                    if use_shrink:
+                        key = shrink_keys[i]
+                        idx = shrink_indices[i]
+                    else:
+                        key = _ordered_key(row[i])
+                        idx = Int32(i)
+                    bin0 = Int32((key >> 21) & Uint32(0x7FF))
+                    if bin0 == bin0_threshold:
+                        bin1 = Int32((key >> 10) & Uint32(0x7FF))
+                        if bin1 > bin1_threshold:
+                            dst = cute.arch.atomic_add(
+                                counters.iterator, Int32(1), sem="relaxed", scope="cta"
+                            )
+                            row_output[dst] = idx
+                        elif bin1 == bin1_threshold:
+                            bin2 = Int32(key & Uint32(0x3FF))
+                            cute.arch.atomic_add(
+                                histogram.iterator + bin2, Int32(1), sem="relaxed", scope="cta"
+                            )
+                cute.arch.barrier()
+                bin2_threshold, need2 = self.find_threshold(
+                    histogram, _NUM_BINS_10, need1, warp_sums, threshold, tidx
+                )
+
+                # Pass 4: emit the final strict winners and exactly need2 ties.
+                for i in range(tidx, scan_len, self.block_threads):
+                    key = Uint32(0)
+                    idx = Int32(0)
+                    if use_shrink:
+                        key = shrink_keys[i]
+                        idx = shrink_indices[i]
+                    else:
+                        key = _ordered_key(row[i])
+                        idx = Int32(i)
+                    bin0 = Int32((key >> 21) & Uint32(0x7FF))
+                    bin1 = Int32((key >> 10) & Uint32(0x7FF))
+                    if bin0 == bin0_threshold and bin1 == bin1_threshold:
+                        bin2 = Int32(key & Uint32(0x3FF))
+                        if bin2 > bin2_threshold:
+                            dst = cute.arch.atomic_add(
+                                counters.iterator, Int32(1), sem="relaxed", scope="cta"
+                            )
+                            row_output[dst] = idx
+                        elif bin2 == bin2_threshold:
+                            slot = cute.arch.atomic_add(
+                                counters.iterator + 1, Int32(1), sem="relaxed", scope="cta"
+                            )
+                            if slot < need2:
+                                dst = cute.arch.atomic_add(
+                                    counters.iterator, Int32(1), sem="relaxed", scope="cta"
+                                )
+                                row_output[dst] = idx
+
+    @cute.jit
+    def __call__(
+        self,
+        scores: cute.Tensor,
+        output: cute.Tensor,
+        pair_start: Int32 | Int64,
+        stream: cuda_driver.CUstream,
+    ):
+        """Launch one 512-thread CTA per physical query row in the score slab."""
+        self.kernel.set_name_prefix(self.get_name())
+        self.kernel(scores, output, pair_start).launch(
+            grid=(scores.shape[0] * 2, 1, 1),
+            block=(self.block_threads, 1, 1),
+            stream=stream,
+        )

--- a/docs/sparse.md
+++ b/docs/sparse.md
@@ -46,7 +46,10 @@ Output order and tie-breaking are unspecified, including between repeated calls.
 | Head dimension `D` | Positive, divisible by 16 | `8..256`, divisible by 8 |
 | Sequence length `T` | `1..2**20` | `1..2**20` |
 | `topk` | `0..min(T, 512)` | `0..min(T, 512)` |
-| Layout | All inputs contiguous, with 16-byte-aligned bases | Q/K last stride 1, bases and outer strides 16-byte aligned; weights may be strided |
+| Layout | Q/K last stride 1, bases and non-singleton outer strides 16-byte aligned; weights may be strided | Q/K last stride 1, bases and outer strides 16-byte aligned; weights may be strided |
+
+CuTe accepts independently permuted or padded outer dimensions and broadcast inputs without
+materializing contiguous copies. Weights need only element alignment, not TMA alignment.
 
 CuTe additionally requires the optional `linear` dependencies. Its support is specifically
 SM100, not every Blackwell variant; other supported devices use Triton by default.
@@ -68,8 +71,8 @@ indices = compiled_indexer(q, k, weights, 128, causal=True)
 **Selection is nondifferentiable.** Inputs may require gradients, but the integer result
 has no gradient function. Selected attention can train its own Q/K/V computation with
 these indices held fixed. It does **not** propagate gradients through the selection step
-into the indexer's queries, keys, or scoring weights. Train those scoring parameters with
-a separate objective; this API supplies no surrogate gradient or indexer-training loss.
+into the indexer's queries, keys, or scoring weights. This API supplies no surrogate gradient
+or indexer-training loss.
 
 Selection with NaN/Inf scores is unspecified and may differ across backends.
 

--- a/docs/sparse.md
+++ b/docs/sparse.md
@@ -19,7 +19,7 @@ Weights may be negative. Query and candidate lengths must match. With causal sel
 query `t` considers only candidates `0..t`; rows with fewer than `topk` candidates contain
 `-1` padding. Mask padding before gathering: a raw PyTorch index of `-1` selects the last
 position rather than an invalid position. `topk=0` returns an empty last dimension.
-Output order and tie-breaking are not guaranteed to match between implementations.
+Output order and tie-breaking are unspecified, including between repeated calls.
 
 ### Implementations and device dispatch
 
@@ -28,7 +28,11 @@ Output order and tie-breaking are not guaranteed to match between implementation
   and is intended for correctness checks and small inputs.
 - `impl="fused"` (the default) selects **CuTe on SM100**, or **Triton on other NVIDIA GPUs
   with compute capability 9.0 or newer**, including Hopper. Both optimized implementations
-  keep their selection state on chip and allocate no quadratic global score workspace.
+  keep their selection state on chip. CuTe separates score generation from radix Top-K and
+  reuses a per-call FP32 score slab capped at **32 MiB and 1024 query rows**, independent of
+  batch size. Large inputs are processed in slabs rather than an unbounded quadratic score
+  allocation. This scratch is additional to the returned indices; Triton needs no global
+  score scratch.
 - `kernel_options={"backend": "cute"}` or `{"backend": "triton"}` overrides that choice.
   Omit options for automatic selection. Options are rejected for `impl="reference"`.
   Unsupported shapes, missing dependencies, and launch errors propagate;

--- a/test/test_cute_utils.py
+++ b/test/test_cute_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pytest
 import torch
 
 from attn_gym._backends.cute.utils import (
@@ -42,3 +43,19 @@ def test_make_fake_strided_tensor_keeps_only_one_static_stride():
     assert fake.stride[-1] == 1
     assert fake._assumed_align == 16
     assert "div=8" in str(fake)
+
+
+@pytest.mark.parametrize("use_int64_strides", [False, True])
+def test_make_fake_strided_tensor_all_dynamic(use_int64_strides):
+    """Scalar-load tensors need no unit stride or stronger-than-element base alignment."""
+    from cutlass import Float16, cute
+
+    fake = make_fake_strided_tensor(
+        Float16,
+        (cute.sym_int(), 3, 128),
+        contiguous_dim=None,
+        use_int64_strides=use_int64_strides,
+    )
+    assert fake._assumed_align == 2
+    assert all(stride.width == (64 if use_int64_strides else 32) for stride in fake.stride)
+    assert all(stride.divisibility == 1 for stride in fake.stride)

--- a/test/test_indexer_cute.py
+++ b/test/test_indexer_cute.py
@@ -382,12 +382,16 @@ def test_cute_artifact_reused_across_batch_and_tokens(monkeypatch, tmp_path):
             q = torch.randn(batch, tokens, 64, 128, device="cuda", dtype=torch.bfloat16)
             k = torch.randn(batch, tokens, 128, device="cuda", dtype=torch.bfloat16)
             w = torch.randn(batch, tokens, 64, device="cuda", dtype=torch.bfloat16)
+            if batch == 3:
+                q = q.transpose(1, 2).contiguous().transpose(1, 2)
+                k = k.transpose(0, 1).contiguous().transpose(0, 1)
+                w = torch.empty(batch, tokens, 65, device="cuda", dtype=w.dtype)[..., :64].copy_(w)
             actual = lightning_indexer(q, k, w, 16, causal=True, impl="fused")
             assert_indexer_selection(actual, q, k, w, 16, True)
             for compiler in compilers:
                 assert compiler.cache_info().misses == 1
                 assert compiler.cache_info().currsize == 1
-        assert impl._compile_scores.is_cached(torch.bfloat16, 64, 128, True, False)
+        assert impl._compile_scores.is_cached(torch.bfloat16, 64, 128, True, False, True)
         assert impl._compile_topk.is_cached(16, True, False)
         for compiler in compilers:
             assert compiler.cache_info().hits == 3
@@ -403,14 +407,20 @@ def test_cute_artifact_reused_across_batch_and_tokens(monkeypatch, tmp_path):
             compiler.cache_clear()
 
 
-def test_cute_dynamic_fullgraph():
-    """Reuse a symbolic public graph across sequence lengths with semantic selection checks."""
+@pytest.mark.parametrize("strided", [False, True])
+@pytest.mark.parametrize("heads,dim", [(64, 128), (66, 96)])
+def test_cute_dynamic_fullgraph(strided, heads, dim):
+    """Reuse a symbolic public graph across sequence lengths and independent input strides."""
     _skip_no_sm100()
     compiled = torch.compile(lightning_indexer, fullgraph=True, dynamic=True)
     for tokens in (65, 129):
-        q = torch.randn(2, tokens, 64, 128, device="cuda", dtype=torch.bfloat16)
-        k = torch.randn(2, tokens, 128, device="cuda", dtype=torch.bfloat16)
-        w = torch.randn(2, tokens, 64, device="cuda", dtype=torch.bfloat16)
+        q = torch.randn(2, tokens, heads, dim, device="cuda", dtype=torch.bfloat16)
+        k = torch.randn(2, tokens, dim, device="cuda", dtype=torch.bfloat16)
+        w = torch.randn(2, tokens, heads, device="cuda", dtype=torch.bfloat16)
+        if strided:
+            q = q.transpose(1, 2).contiguous().transpose(1, 2)
+            k = k.transpose(0, 1).contiguous().transpose(0, 1)
+            w = w.transpose(1, 2).contiguous().transpose(1, 2)
         actual = compiled(q, k, w, 16, causal=True, impl="fused")
         expected = lightning_indexer(q, k, w, 16, causal=True, impl="fused")
         assert_indexer_selection(expected, q, k, w, 16, True)

--- a/test/test_indexer_cute.py
+++ b/test/test_indexer_cute.py
@@ -13,6 +13,7 @@ import torch
 
 from attn_gym.sparse.indexer import lightning_indexer
 from attn_gym.sparse.indexer.ops import _indexer_op
+from attn_gym.testing.indexer import assert_indexer_selection
 
 
 def _skip_no_sm100():
@@ -342,12 +343,14 @@ def test_cute_backend_under_torch_compile(causal, dtype, topk):
     assert compiled_out.shape == (batch, queries, topk)
     assert compiled_out.dtype == torch.int32
 
-    torch.testing.assert_close(compiled_out, eager_out, rtol=0, atol=0)
+    # Selection order and exact boundary ties are not part of the API contract.
+    assert_indexer_selection(eager_out, q, k, w, topk, causal)
+    assert_indexer_selection(compiled_out, q, k, w, topk, causal)
 
 
 @pytest.mark.parametrize("causal", [False, True])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
-@pytest.mark.parametrize("topk", [0, 16])
+@pytest.mark.parametrize("topk", [0, 65])
 @pytest.mark.parametrize("requires_grad", [False, True])
 def test_cute_op_registration(causal, dtype, topk, requires_grad):
     """Check registration, including partial tiles and nondifferentiable indices."""
@@ -355,6 +358,8 @@ def test_cute_op_registration(causal, dtype, topk, requires_grad):
     q = torch.randn(2, 65, 64, 128, device="cuda", dtype=dtype, requires_grad=requires_grad)
     k = torch.randn(2, 65, 128, device="cuda", dtype=dtype, requires_grad=requires_grad)
     w = torch.randn(2, 65, 64, device="cuda", dtype=dtype, requires_grad=requires_grad)
+    # AOT opcheck compares integer outputs exactly. Full selection has a stable
+    # output order; selective rows are checked semantically in the compile tests.
     torch.library.opcheck(_indexer_op, (q, k, w, topk, causal, "cute"))
     result = lightning_indexer(q, k, w, topk, causal=causal, impl="fused")
     assert not result.requires_grad
@@ -362,12 +367,15 @@ def test_cute_op_registration(causal, dtype, topk, requires_grad):
 
 
 def test_cute_artifact_reused_across_batch_and_tokens(monkeypatch, tmp_path):
+    """Reuse both score and selection artifacts, including after a persistent reload."""
     _skip_no_sm100()
     from attn_gym.sparse.indexer.impl import cute as impl
 
     monkeypatch.setenv("ATTN_GYM_CUTE_CACHE_DIR", str(tmp_path / "cache"))
     monkeypatch.delenv("CUTE_DSL_NO_CACHE", raising=False)
-    impl._compile_indexer.cache_clear()
+    compilers = (impl._compile_scores, impl._compile_topk)
+    for compiler in compilers:
+        compiler.cache_clear()
     torch.manual_seed(2026)
     try:
         for batch, tokens in ((2, 65), (3, 65), (3, 129), (1, 257)):
@@ -375,29 +383,28 @@ def test_cute_artifact_reused_across_batch_and_tokens(monkeypatch, tmp_path):
             k = torch.randn(batch, tokens, 128, device="cuda", dtype=torch.bfloat16)
             w = torch.randn(batch, tokens, 64, device="cuda", dtype=torch.bfloat16)
             actual = lightning_indexer(q, k, w, 16, causal=True, impl="fused")
-            torch.cuda.synchronize()
-            assert actual.shape == (batch, tokens, 16)
-            assert actual.dtype == torch.int32
-            _validate_indices(actual, _reference_scores(q.float(), k.float(), w.float()), 16, True)
-            cache_info = impl._compile_indexer.cache_info()
-            assert cache_info.misses == 1
-            assert cache_info.currsize == 1
-        assert impl._compile_indexer.cache_info().hits == 3
-        assert impl._compile_indexer.is_cached("bf16", 64, 128, 16, True)
-        impl._compile_indexer.cache_clear()
+            assert_indexer_selection(actual, q, k, w, 16, True)
+            for compiler in compilers:
+                assert compiler.cache_info().misses == 1
+                assert compiler.cache_info().currsize == 1
+        assert impl._compile_scores.is_cached(torch.bfloat16, 64, 128, True, False)
+        assert impl._compile_topk.is_cached(16, True, False)
+        for compiler in compilers:
+            assert compiler.cache_info().hits == 3
+            compiler.cache_clear()
         actual = lightning_indexer(q, k, w, 16, causal=True, impl="fused")
-        torch.cuda.synchronize()
-        _validate_indices(actual, _reference_scores(q.float(), k.float(), w.float()), 16, True)
-        cache_info = impl._compile_indexer.cache_info()
-        assert cache_info.hits == 1
-        assert cache_info.misses == 0
-        assert cache_info.currsize == 1
+        assert_indexer_selection(actual, q, k, w, 16, True)
+        for compiler in compilers:
+            assert compiler.cache_info().hits == 1
+            assert compiler.cache_info().misses == 0
+            assert compiler.cache_info().currsize == 1
     finally:
-        impl._compile_indexer.cache_clear()
+        for compiler in compilers:
+            compiler.cache_clear()
 
 
 def test_cute_dynamic_fullgraph():
-    """Reuse a public graph while the launcher specializes for each sequence length."""
+    """Reuse a symbolic public graph across sequence lengths with semantic selection checks."""
     _skip_no_sm100()
     compiled = torch.compile(lightning_indexer, fullgraph=True, dynamic=True)
     for tokens in (65, 129):
@@ -406,4 +413,5 @@ def test_cute_dynamic_fullgraph():
         w = torch.randn(2, tokens, 64, device="cuda", dtype=torch.bfloat16)
         actual = compiled(q, k, w, 16, causal=True, impl="fused")
         expected = lightning_indexer(q, k, w, 16, causal=True, impl="fused")
-        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+        assert_indexer_selection(expected, q, k, w, 16, True)
+        assert_indexer_selection(actual, q, k, w, 16, True)

--- a/test/test_indexer_dispatch.py
+++ b/test/test_indexer_dispatch.py
@@ -9,7 +9,7 @@ import torch
 from torch._dynamo.testing import CompileCounterWithBackend
 
 from attn_gym.sparse.indexer import lightning_indexer, ops
-from attn_gym.testing.indexer import make_indexer_test_inputs
+from attn_gym.testing.indexer import assert_indexer_selection, make_indexer_test_inputs
 
 
 def require_backend(backend: str | None = None) -> str:
@@ -134,7 +134,8 @@ def test_auto_fullgraph_uses_device_backend():
             q, k, weights, 4, causal=True, kernel_options={"backend": expected_backend}
         )
         actual = compiled(q, k, weights, 4, causal=True)
-        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+        assert_indexer_selection(expected, q, k, weights, 4, True)
+        assert_indexer_selection(actual, q, k, weights, 4, True)
     assert counter.frame_count == 1
 
 
@@ -171,4 +172,5 @@ def test_backend_cuda_graph_replay(backend, dtype, tokens, heads, dim, topk, cau
         for tensor in inputs:
             tensor.normal_()
         graph.replay()
-        torch.testing.assert_close(actual, run(), rtol=0, atol=0)
+        assert_indexer_selection(actual, *inputs, topk, causal)
+        assert_indexer_selection(run(), *inputs, topk, causal)

--- a/test/test_indexer_radix.py
+++ b/test/test_indexer_radix.py
@@ -1,6 +1,7 @@
 """Reference and slab-boundary checks for the bounded-workspace CuTe indexer."""
 
 import os
+from unittest.mock import Mock
 
 import pytest
 import torch
@@ -55,12 +56,139 @@ def test_radix_generic_scores(radix_impl, dtype, causal, heads, head_dim):
 
 
 @pytest.mark.parametrize("causal", [False, True])
-def test_radix_reuses_slab_across_batches(radix_impl, monkeypatch, causal):
-    """An odd tail in one batch never aliases the next batch or a previous slab."""
-    monkeypatch.setattr(radix_impl, "_MAX_SCORE_PAIRS", 3)
-    inputs = make_indexer_test_inputs(17, 32, 128, torch.bfloat16, batch=3)
+@pytest.mark.parametrize("heads,dim", [(32, 128), (66, 48)])
+def test_radix_reuses_slab_across_batches(radix_impl, monkeypatch, causal, heads, dim):
+    """Odd batch tails and a partial final slab never alias other score rows."""
+    monkeypatch.setattr(radix_impl, "_MAX_SCORE_PAIRS", 4)
+    inputs = make_indexer_test_inputs(17, heads, dim, torch.bfloat16, batch=3)
     actual = lightning_indexer(*inputs, 7, causal=causal, kernel_options={"backend": "cute"})
     assert_indexer_selection(actual, *inputs, 7, causal)
+
+
+@pytest.mark.parametrize("batch,tokens,capacity", [(1, 1025, 512), (3, 17, 4)])
+def test_radix_launches_only_active_pairs(radix_impl, monkeypatch, batch, tokens, capacity):
+    """Both launch grids use the final slab's live extent, not its allocation capacity."""
+    monkeypatch.setattr(radix_impl, "_MAX_SCORE_PAIRS", capacity)
+    score_kernel, topk_kernel = Mock(), Mock()
+    monkeypatch.setattr(radix_impl, "_compile_scores", lambda *args: score_kernel)
+    monkeypatch.setattr(radix_impl, "_compile_topk", lambda *args: topk_kernel)
+    q, k, weights = make_indexer_test_inputs(tokens, 32, 128, torch.bfloat16, batch=batch)
+    inputs = (
+        q.transpose(1, 2).contiguous().transpose(1, 2),
+        k.transpose(0, 1).contiguous().transpose(0, 1),
+        weights.transpose(1, 2).contiguous().transpose(1, 2),
+    )
+    lightning_indexer(*inputs, 7, causal=True, kernel_options={"backend": "cute"})
+    total_pairs = batch * ((tokens + 1) // 2)
+    expected = [min(capacity, total_pairs - start) for start in range(0, total_pairs, capacity)]
+    assert [call.args[3].shape[0] for call in score_kernel.call_args_list] == expected
+    assert [call.args[0].shape[0] for call in topk_kernel.call_args_list] == expected
+    for call in score_kernel.call_args_list:
+        for actual, original in zip(call.args[:3], inputs):
+            assert actual.data_ptr() == original.data_ptr()
+            assert actual.stride() == original.stride()
+    assert all(
+        score.args[3] is topk.args[0]
+        for score, topk in zip(score_kernel.call_args_list, topk_kernel.call_args_list)
+    )
+
+
+@pytest.mark.parametrize("use_int64_offsets", [False, True])
+@pytest.mark.parametrize("contiguous_weight_heads", [False, True])
+def test_radix_fake_tensor_abi(monkeypatch, use_int64_offsets, contiguous_weight_heads):
+    """Only Q/K's D stride and an available unit weight-head stride are static."""
+    pytest.importorskip("cutlass.cute")
+    monkeypatch.setattr(impl, "compile_tvm_ffi", lambda operation, *args: args)
+    q, k, weights, scores, *_ = impl._compile_scores.__wrapped__(
+        torch.bfloat16, 32, 128, True, use_int64_offsets, contiguous_weight_heads
+    )
+    topk_scores, output, _ = impl._compile_topk.__wrapped__(37, True, use_int64_offsets)
+    width = 64 if use_int64_offsets else 32
+    assert q._assumed_align == k._assumed_align == 16
+    assert weights._assumed_align == 2
+    for tensor in (q, k):
+        assert tensor.stride[-1] == 1
+        assert all(
+            stride.width == width and stride.divisibility == 8 for stride in tensor.stride[:-1]
+        )
+    if contiguous_weight_heads:
+        assert weights.stride[-1] == 1
+    dynamic_weight_strides = weights.stride[:-1] if contiguous_weight_heads else weights.stride
+    assert all(
+        stride.width == width and stride.divisibility == 1 for stride in dynamic_weight_strides
+    )
+    for tensor in (scores, topk_scores, output):
+        assert tensor.stride[-1] == 1
+        assert tensor.stride[0].width == width
+
+
+@pytest.mark.parametrize("operand", [0, 1, 2], ids=["q", "k", "weights"])
+@pytest.mark.parametrize("heads,dim", [(32, 128), (66, 48)])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_radix_input_alignment(radix_impl, operand, heads, dim, dtype):
+    """Only TMA operands require 16-byte bases; contiguous weights may start at any element."""
+    inputs = list(make_indexer_test_inputs(65, heads, dim, dtype))
+    tensor = inputs[operand]
+    shifted = torch.empty(tensor.numel() + 1, device=tensor.device, dtype=dtype)[1:]
+    inputs[operand] = shifted.view_as(tensor).copy_(tensor)
+    assert inputs[operand].is_contiguous() and inputs[operand].data_ptr() % 16 == 2
+    if operand < 2:
+        with pytest.raises(ValueError, match="16-byte aligned"):
+            lightning_indexer(*inputs, 16, causal=True, kernel_options={"backend": "cute"})
+    else:
+        actual = lightning_indexer(*inputs, 16, causal=True, kernel_options={"backend": "cute"})
+        assert_indexer_selection(actual, *inputs, 16, True)
+
+
+@pytest.mark.parametrize("layout", ["permuted", "padded", "broadcast"])
+@pytest.mark.parametrize("heads,dim", [(32, 128), (64, 128), (66, 96)])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("causal", [False, True])
+def test_radix_strided_inputs(radix_impl, monkeypatch, layout, heads, dim, dtype, causal):
+    """Packed and generic scorers preserve independent outer strides without input copies."""
+    batch, tokens = 3, 257
+    monkeypatch.setattr(radix_impl, "_MAX_SCORE_PAIRS", 5)
+    q, k, weights = make_indexer_test_inputs(tokens, heads, dim, dtype, batch=batch)
+    match layout:
+        case "permuted":
+            q = q.permute(2, 0, 1, 3).contiguous().permute(1, 2, 0, 3)
+            k = k.transpose(0, 1).contiguous().transpose(0, 1)
+            weights = weights.permute(2, 1, 0).contiguous().permute(2, 1, 0)
+        case "padded":
+            q = torch.full(
+                (batch, tokens + 1, heads + 2, dim + 16), torch.nan, device="cuda", dtype=dtype
+            )[:, :tokens, :heads, :dim].copy_(q)
+            k = torch.full((batch, tokens + 1, dim + 16), torch.nan, device="cuda", dtype=dtype)[
+                :, :tokens, :dim
+            ].copy_(k)
+            weights = torch.full(
+                (batch, tokens + 1, heads + 1), torch.nan, device="cuda", dtype=dtype
+            )[:, :tokens, :heads].copy_(weights)
+        case "broadcast":
+            q = q[:, :, :1, :].expand_as(q)
+            k = k[:1].expand_as(k)
+            weights = weights[:, :1, :1].expand_as(weights)
+    assert not q.is_contiguous() and not k.is_contiguous() and not weights.is_contiguous()
+    actual = lightning_indexer(
+        q, k, weights, 37, causal=causal, kernel_options={"backend": "cute"}
+    )
+    assert_indexer_selection(actual, q, k, weights, 37, causal)
+
+
+@pytest.mark.parametrize("operand", [0, 1], ids=["q", "k"])
+@pytest.mark.parametrize("layout", ["strided_reduction", "unaligned_rows"])
+def test_radix_rejects_non_tma_layout(radix_impl, operand, layout):
+    """Reject only the last-stride/alignment requirements needed by TMA."""
+    inputs = list(make_indexer_test_inputs(65, 32, 128, torch.bfloat16))
+    tensor = inputs[operand]
+    if layout == "strided_reduction":
+        inputs[operand] = tensor.transpose(-1, -2).contiguous().transpose(-1, -2)
+    else:
+        inputs[operand] = torch.empty(
+            (*tensor.shape[:-1], tensor.shape[-1] + 1), device="cuda", dtype=tensor.dtype
+        )[..., :-1].copy_(tensor)
+    with pytest.raises(ValueError, match="unit last strides and 16-byte aligned"):
+        lightning_indexer(*inputs, 16, kernel_options={"backend": "cute"})
 
 
 @pytest.mark.parametrize("distribution", ["random", "ties", "clustered", "signed_zero"])
@@ -167,10 +295,18 @@ def test_radix_active_int64_offset(radix_impl):
     torch.testing.assert_close(actual, expected, rtol=0, atol=0)
 
 
-def test_radix_graph_replay(radix_impl, monkeypatch):
-    """Captured slab reuse reads updated operands rather than stale score storage."""
-    monkeypatch.setattr(radix_impl, "_MAX_SCORE_PAIRS", 3)
+@pytest.mark.parametrize("strided", [False, True])
+def test_radix_graph_replay(radix_impl, monkeypatch, strided):
+    """Captured partial-slab reuse reads updated operands, including independent outer strides."""
+    monkeypatch.setattr(radix_impl, "_MAX_SCORE_PAIRS", 4)
     inputs = make_indexer_test_inputs(17, 64, 128, torch.bfloat16, batch=2)
+    if strided:
+        q, k, weights = inputs
+        inputs = (
+            q.transpose(1, 2).contiguous().transpose(1, 2),
+            k.transpose(0, 1).contiguous().transpose(0, 1),
+            weights.transpose(1, 2).contiguous().transpose(1, 2),
+        )
     stream = torch.cuda.Stream()
     stream.wait_stream(torch.cuda.current_stream())
     with torch.cuda.stream(stream):

--- a/test/test_indexer_radix.py
+++ b/test/test_indexer_radix.py
@@ -1,0 +1,187 @@
+"""Reference and slab-boundary checks for the bounded-workspace CuTe indexer."""
+
+import os
+
+import pytest
+import torch
+
+from attn_gym._backends.cute.utils import requires_int64_abi
+from attn_gym.sparse.indexer import lightning_indexer
+from attn_gym.sparse.indexer.impl import cute as impl
+from attn_gym.testing.indexer import assert_indexer_selection, make_indexer_test_inputs
+
+SM100 = torch.cuda.is_available() and torch.cuda.get_device_capability() == (10, 0)
+
+
+@pytest.mark.parametrize("batch", [1, 3, 64])
+@pytest.mark.parametrize("tokens", [1, 65, 1023, 1024, 1025, 4096, 65537, 2**20])
+def test_score_workspace_bound(batch, tokens):
+    """Score scratch has both an absolute cap and a sequence-independent row cap."""
+    pairs = impl.score_workspace_pairs(batch, tokens)
+    assert 1 <= pairs <= min(512, batch * ((tokens + 1) // 2))
+    assert pairs * 2 * tokens * 4 <= 32 * 1024 * 1024
+
+
+@pytest.fixture
+def radix_impl():
+    """Load the optional backend only on compatible hardware."""
+    if not SM100:
+        pytest.skip("SM100 required for the CuTe radix port")
+    pytest.importorskip("cutlass.cute")
+    return impl
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("heads", [32, 64])
+@pytest.mark.parametrize("tokens,topk", [(1, 1), (65, 0), (129, 37), (257, 128)])
+def test_radix_selection(radix_impl, dtype, causal, heads, tokens, topk):
+    """Both precisions and masks preserve indices and FP64 selection-regret bounds."""
+    q, k, weights = make_indexer_test_inputs(tokens, heads, 128, dtype)
+    actual = lightning_indexer(
+        q, k, weights, topk, causal=causal, kernel_options={"backend": "cute"}
+    )
+    assert_indexer_selection(actual, q, k, weights, topk, causal)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("heads,head_dim", [(2, 16), (66, 48), (128, 128), (130, 96), (258, 384)])
+def test_radix_generic_scores(radix_impl, dtype, causal, heads, head_dim):
+    """Tiled score generation covers head/reduction tails without shape-sized SMEM."""
+    inputs = make_indexer_test_inputs(65, heads, head_dim, dtype)
+    actual = lightning_indexer(*inputs, 16, causal=causal, kernel_options={"backend": "cute"})
+    assert_indexer_selection(actual, *inputs, 16, causal)
+
+
+@pytest.mark.parametrize("causal", [False, True])
+def test_radix_reuses_slab_across_batches(radix_impl, monkeypatch, causal):
+    """An odd tail in one batch never aliases the next batch or a previous slab."""
+    monkeypatch.setattr(radix_impl, "_MAX_SCORE_PAIRS", 3)
+    inputs = make_indexer_test_inputs(17, 32, 128, torch.bfloat16, batch=3)
+    actual = lightning_indexer(*inputs, 7, causal=causal, kernel_options={"backend": "cute"})
+    assert_indexer_selection(actual, *inputs, 7, causal)
+
+
+@pytest.mark.parametrize("distribution", ["random", "ties", "clustered", "signed_zero"])
+@pytest.mark.parametrize("topk", [1, 37, 512])
+def test_radix_threshold_and_overflow(radix_impl, distribution, topk):
+    """Radix refinement handles negative scores, exact ties and shrink-buffer overflow."""
+    import cutlass
+
+    from attn_gym._backends.cute.target import (
+        detect_compile_target,
+        get_compile_target,
+        set_compile_target,
+    )
+
+    tokens = 4097
+    generator = torch.Generator(device="cuda").manual_seed(32)
+    scores = torch.randn(2, 2, tokens, device="cuda", generator=generator)
+    match distribution:
+        case "ties":
+            scores.fill_(-1)
+        case "clustered":
+            # All 4097 candidates land in bin0, overflowing the 2048-entry shrink slab;
+            # tiny spacings also force refinement through the low ten key bits.
+            scores = 1 + scores.abs() * 1e-5
+        case "signed_zero":
+            scores = torch.copysign(torch.zeros_like(scores), scores)
+    output = torch.empty((1, tokens, topk), device="cuda", dtype=torch.int32)
+    previous = get_compile_target()
+    try:
+        set_compile_target(detect_compile_target(torch.cuda.current_device()))
+        kernel = radix_impl._compile_topk(topk, False, False)
+    finally:
+        set_compile_target(previous)
+    kernel(scores, output, cutlass.Int32(0))
+    indices = output[0, :4].long()
+    assert ((indices >= 0) & (indices < tokens)).all()
+    ordered = indices.sort(-1).values
+    assert not (ordered[:, 1:] == ordered[:, :-1]).any()
+    rows = scores.view(4, tokens)
+    actual = rows.gather(1, indices).sort(-1).values
+    expected = rows.topk(topk, sorted=False).values.sort(-1).values
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("heads,head_dim", [(64, 128), (66, 48)])
+def test_radix_forced_int64(radix_impl, monkeypatch, heads, head_dim):
+    """The wide ABI agrees with the ordinary address path on real data."""
+    inputs = make_indexer_test_inputs(65, heads, head_dim, torch.float16)
+    assert not requires_int64_abi(*inputs)
+    expected = radix_impl.launch(*inputs, 16, True)
+    monkeypatch.setattr(radix_impl, "requires_int64_abi", lambda *args: True)
+    actual = radix_impl.launch(*inputs, 16, True)
+    assert_indexer_selection(actual, *inputs, 16, True)
+    torch.testing.assert_close(actual.sort(-1).values, expected.sort(-1).values)
+
+
+@pytest.mark.parametrize(
+    "tokens,heads,dim,unused_stride",
+    [
+        (65, 32, 128, 2**31 + 16),
+        (65, 32, 128, 1),
+        (1, 32, 128, 2**31 + 3),
+        (65, 32, 128, 1 << 40),
+        (65, 2, 16, 1),
+        (65, 2, 16, 1 << 40),
+    ],
+)
+def test_radix_singleton_stride(radix_impl, tokens, heads, dim, unused_stride):
+    """Contiguous singleton modes may carry unaligned or unrepresentable unused strides."""
+    inputs = make_indexer_test_inputs(tokens, heads, dim, torch.bfloat16, batch=1)
+    views = tuple(
+        x.as_strided(
+            x.shape,
+            (unused_stride, unused_stride if tokens == 1 else x.stride(1), *x.stride()[2:]),
+        )
+        for x in inputs
+    )
+    assert all(x.is_contiguous() for x in views)
+    assert requires_int64_abi(*views) == (unused_stride > 2**31 - 1)
+    topk = min(16, tokens)
+    actual = radix_impl.launch(*views, topk, False)
+    assert_indexer_selection(actual, *inputs, topk, False)
+
+
+@pytest.mark.skipif(
+    os.environ.get("ATTN_GYM_RUN_LARGE_INDEXER_TESTS") != "1",
+    reason="set ATTN_GYM_RUN_LARGE_INDEXER_TESTS=1 for the 4 GiB active-offset test",
+)
+def test_radix_active_int64_offset(radix_impl):
+    """Read meaningful Q values beyond signed-int32 element offsets, not just wide strides."""
+    if torch.cuda.mem_get_info()[0] < 8 * 2**30:
+        pytest.skip("8 GiB free device memory required")
+    batch, tokens, heads, dim = 65, 2, 1024, 16384
+    q = torch.zeros((batch, tokens, heads, dim), device="cuda", dtype=torch.float16)
+    k = torch.zeros((batch, tokens, dim), device="cuda", dtype=q.dtype)
+    weights = torch.zeros((batch, tokens, heads), device="cuda", dtype=q.dtype)
+    signal = torch.where(torch.arange(batch * tokens, device="cuda") % 3 == 0, -1, 1)
+    q[:, :, -1, -1] = signal.reshape(batch, tokens)
+    k[:, 0, -1], k[:, 1, -1] = -1, 1
+    weights[:, :, -1] = 1
+    assert q.numel() > 2**31 and requires_int64_abi(q, k, weights)
+    actual = lightning_indexer(q, k, weights, 1, kernel_options={"backend": "cute"})
+    expected = (signal > 0).to(torch.int32).reshape(batch, tokens, 1)
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_radix_graph_replay(radix_impl, monkeypatch):
+    """Captured slab reuse reads updated operands rather than stale score storage."""
+    monkeypatch.setattr(radix_impl, "_MAX_SCORE_PAIRS", 3)
+    inputs = make_indexer_test_inputs(17, 64, 128, torch.bfloat16, batch=2)
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        radix_impl.launch(*inputs, 7, True)
+    torch.cuda.current_stream().wait_stream(stream)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        actual = radix_impl.launch(*inputs, 7, True)
+    for seed in (81, 82):
+        updated = make_indexer_test_inputs(17, 64, 128, torch.bfloat16, batch=2, seed=seed)
+        for target, source in zip(inputs, updated):
+            target.copy_(source)
+        graph.replay()
+        assert_indexer_selection(actual, *inputs, 7, True)


### PR DESCRIPTION
## Summary

Replace the SM100 CuTe lightning indexer with tensor-core score generation followed by indices-only radix Top-K, adapted from cuDNN Frontend's algorithm. Keep the Triton implementation and the existing single registered operator unchanged.

- Pack two queries for H32/H64, D128; use bounded M128/N64/K64 tiling for the remaining supported H/D shapes.
- Preserve FP16/BF16, positive-even H, D divisible by 16, both masks, batched square inputs, topk=0..min(T,512), causal -1 padding, nondifferentiable indices, and symbolic batch/sequence dimensions.
- Reuse one per-call FP32 score slab capped at **32 MiB and 1024 query rows**, rather than an unbounded quadratic allocation. Radix refinement uses fixed shared-memory histograms and a bounded shrink buffer, with a full-row rescan on overflow. No extra logits/LSE outputs or frontend dependency.
- Document that index order and boundary tie choices are unspecified, including across repeated calls. Compile/replay tests now check selection semantics rather than raw index ordering; registration opcheck uses stable empty/full-selection cases without loosening integer tolerances.
- Retain the upstream Apache-2.0 license and attribution.

## B200 performance

Complete index generation, **GPU microseconds; lower is better**. B1, BF16, D128, square causal; the same six fixed workloads and quantized inputs as the baseline investigation. Median of five interleaved round medians, 30 CUDA Graph samples/round, 25 eager and graph warmups. Fixed-pointer warm/reused buffers, default DVFS; compilation, input transfers, Python dispatch and capture excluded. All score and selection kernels, including slab writes, are included. These are primitive microbenchmarks, not model timings.

| Sequence | Heads | Top-K | Old CuTe us ↓ | New CuTe us ↓ | Old/new latency ratio ↑ |
|---:|---:|---:|---:|---:|---:|
|512|32|128|29.20|20.74|1.41|
|512|64|512|103.14|16.93|6.09|
|2048|32|512|500.94|70.67|7.09|
|2049|64|128|152.29|100.40|1.52|
|4096|32|128|378.06|193.12|1.96|
|4096|64|512|1237.34|229.17|5.40|

Memory tradeoff: at sequence4096/heads64/topk512, warm-call PyTorch allocator peak above live inputs/cached state increases from **8 MiB to 24 MiB**. External driver allocations are not included. The score-slab cap is additional to the returned indices. Broader H/D performance and cold-DRAM behavior were not measured.

Environment: B200/SM100, driver615.71.09, Python3.13.13, torch2.15.0.dev20260909+cu132/CUDA13.2, CuTeDSL4.6.3, TVM-FFI0.1.14rc4, cuda-python13.4.1. Old CuTe baseline: b16d6d3; the final public path and archived baseline ran in the same process/environment. Source hashes and actual kernel routes were verified. The newer main change #543 is unrelated to the indexer.

## Validation

**237 distinct cases passed** across `test_indexer_cute.py` (108), `test_indexer_radix.py` (100, including the separately enabled large-offset case), and `test_indexer_dispatch.py` (29).

- FP64 whole-row/reference selection checks and maximum/relative-RMS error budgets, both dtypes/masks, head/D/token tails, slab reuse across odd batches, signed/tied/clustered scores, and shrink-buffer overflow.
- All four default opcheck utilities on 16 empty/full-selection dtype/mask/requires-grad cases; selective public `torch.compile(fullgraph=True)` and CUDA Graph replay checked independently.
- Dynamic B/T reuse, one-graph auto-dispatch across B/T=(3,17),(4,33),(5,65), persistent compiled-object reload, and changed-input replay.
- Forced-int64, singleton strides through 1<<40, and a 4.0625 GiB Q tensor with meaningful active element offsets beyond INT32_MAX.
- CUTracer random 20us delays and deadlock detection passed on packed H64/D128 and generic H66/D96 at T1025, including repeated launches, ring wraps, odd tails and overcapture; instrumentation covered TMA/MMA/barrier handoffs.
- Ruff, targeted complete prek hooks, and `git diff --check` passed.

Pytest ran with six workers in bounded groups; the four large T4096 FP64 references used `--dist loadfile` to avoid simultaneous multi-GiB intermediates. The large-address test is enabled with `ATTN_GYM_RUN_LARGE_INDEXER_TESTS=1`. No SM120, multi-GPU, or end-to-end performance claim is made.
