### PR TITLE
Add compress_ratio to lightning_indexer and lift topk to 1024

### DIFF
--- a/attn_gym/sparse/indexer/api.py
+++ b/attn_gym/sparse/indexer/api.py
@@ -12,6 +12,7 @@ def _validate_inputs(
     weights: Tensor,
     topk: int,
     causal: bool,
+    compress_ratio: int,
 ) -> None:
     """Validate metadata without synchronizing or inspecting tensor values."""
     # --- type checks ---
@@ -24,6 +25,15 @@ def _validate_inputs(
 
     if not isinstance(causal, bool):
         raise TypeError(f"causal must be a bool, got {type(causal).__name__}.")
+
+    if not isinstance(compress_ratio, int) or isinstance(compress_ratio, bool):
+        raise TypeError(
+            f"compress_ratio must be a Python int, got {type(compress_ratio).__name__}."
+        )
+    if compress_ratio < 1:
+        raise ValueError(f"compress_ratio must be positive, got {compress_ratio}.")
+    if compress_ratio != 1 and not causal:
+        raise ValueError("compress_ratio != 1 requires causal selection; pass causal=True.")
 
     # --- ndim ---
     if q.ndim != 4:
@@ -72,10 +82,11 @@ def _validate_inputs(
     if topk < 0 or topk > candidates:
         raise ValueError(f"topk must be in [0, {candidates}], got {topk}.")
 
-    # --- square constraint (nonsquare not yet supported) ---
-    if candidates != queries:
-        raise NotImplementedError(
-            f"Nonsquare inputs are not supported yet (T={queries}, S={candidates})."
+    # --- candidate count: one key per completed window of compress_ratio tokens ---
+    if candidates != queries // compress_ratio:
+        raise ValueError(
+            f"k must hold S = T // compress_ratio = {queries // compress_ratio} candidates, "
+            f"got S={candidates} (T={queries}, compress_ratio={compress_ratio})."
         )
 
 
@@ -86,6 +97,7 @@ def lightning_indexer(
     topk: int,
     *,
     causal: bool = False,
+    compress_ratio: int = 1,
     impl: str = "fused",
     kernel_options: dict[str, str] | None = None,
 ) -> Tensor:
@@ -102,15 +114,21 @@ def lightning_indexer(
     Args:
         q: Query tensor, [B, T, H, D].
 
-        k: Key candidate pool shared across heads, [B, S, D].
-            Nonsquare inputs (S != T) are not supported yet.
+        k: Key candidate pool shared across heads, [B, S, D], with
+            ``S = T // compress_ratio``.
 
         weights: Per-head weights, [B, T, H]. May be negative.
 
         topk: Number of candidates to select per query.  Must be in [0, S].
 
-        causal: If True, query at position t can only attend to candidates
-            at positions <= t.  Requires S == T.
+        causal: If True, query t can only select candidates
+            ``s < (t + 1) // compress_ratio``, i.e. those whose covered tokens all
+            lie at positions <= t (candidates ``0..t`` when ``compress_ratio=1``).
+
+        compress_ratio: Number of consecutive tokens summarized by each
+            candidate, as in DeepSeek compressed sparse attention. A trailing
+            partial window forms no candidate, so ``S = T // compress_ratio``.
+            Values other than 1 require ``causal=True``.
 
         impl: ``"reference"`` uses eager PyTorch on CPU or CUDA; ``"fused"`` uses
             optimized CUDA kernels. Defaults to ``"fused"``.
@@ -126,12 +144,13 @@ def lightning_indexer(
         contain -1 padding; topk=0 returns an empty last dimension.
 
     Fused backends support ``torch.compile(fullgraph=True)`` and CUDA Graph replay.
-    Both require FP16/BF16 inputs, T <= 2**20, and topk <= 512. CuTe requires SM100,
-    even H, D divisible by 16, and Q/K with unit last strides and 16-byte-aligned
+    Both require FP16/BF16 inputs and T <= 2**20 and accept any topk <= S. CuTe requires
+    SM100, even H, D divisible by 16, and Q/K with unit last strides and 16-byte-aligned
     bases and non-singleton outer strides. Other Q/K strides may vary independently;
     weights may have arbitrary strides and need only element alignment.
     Triton requires SM90 or newer, H <= 256, D <= 256 divisible by 8, and Q/K with
     unit last strides and 16-byte-aligned bases and outer strides; weights may be strided.
+    Its register-resident selection makes per-tile cost grow with topk.
     CuTe reuses a per-call FP32 score workspace capped at 32 MiB and 1024 query
     rows. Large inputs use slabs rather than an unbounded quadratic score allocation.
     This workspace is additional to the returned indices and is not shared across calls.
@@ -142,7 +161,7 @@ def lightning_indexer(
     selection into q, k, or weights.
     """
 
-    _validate_inputs(q, k, weights, topk, causal)
+    _validate_inputs(q, k, weights, topk, causal, compress_ratio)
 
     match impl:
         case "reference":
@@ -150,7 +169,7 @@ def lightning_indexer(
                 raise ValueError("kernel_options are not supported with impl='reference'")
             from .impl import reference
 
-            return reference.launch(q, k, weights, topk, causal)
+            return reference.launch(q, k, weights, topk, causal, compress_ratio)
         case "fused":
             if kernel_options not in (
                 None,
@@ -162,6 +181,6 @@ def lightning_indexer(
             if not q.is_cuda:
                 raise ValueError("the fused lightning_indexer requires CUDA tensors")
             backend = (kernel_options or {}).get("backend", "auto")
-            return _indexer_op(q, k, weights, topk, causal, backend)
+            return _indexer_op(q, k, weights, topk, causal, compress_ratio, backend)
         case _:
             raise ValueError(f"unknown impl {impl!r}; expected 'reference' or 'fused'")

--- a/attn_gym/sparse/indexer/impl/cute.py
+++ b/attn_gym/sparse/indexer/impl/cute.py
@@ -31,15 +31,16 @@ from attn_gym.utils import cdiv
 
 _HEAD_DIM_GRANULARITY = 16
 _MAX_SEQUENCE = 1 << 20
-_MAX_SUPPORTED_TOPK = 512
 # Limit both the row count (linear storage as T grows) and absolute scratch bytes.
 _MAX_SCORE_PAIRS = 512
 _SCORE_WORKSPACE_BYTES = 32 * 1024 * 1024
 
 
-def score_workspace_pairs(batch: int, tokens: int) -> int:
-    """Size a slab for positive B and the validated CuTe domain 1 <= T <= 2**20."""
-    return min(_MAX_SCORE_PAIRS, batch * cdiv(tokens, 2), _SCORE_WORKSPACE_BYTES // (8 * tokens))
+def score_workspace_pairs(batch: int, tokens: int, candidates: int) -> int:
+    """Size a slab for positive B and the validated CuTe domain 1 <= S <= T <= 2**20."""
+    return min(
+        _MAX_SCORE_PAIRS, batch * cdiv(tokens, 2), _SCORE_WORKSPACE_BYTES // (8 * candidates)
+    )
 
 
 @jit_cache(
@@ -53,10 +54,11 @@ def _compile_scores(
     heads: int,
     head_dim: int,
     causal: bool,
+    compress_ratio: int,
     use_int64_offsets: bool,
     contiguous_weight_heads: bool,
 ) -> Callable[..., None]:
-    """Compile symbolic B/T/strides, specializing only an available unit weight-head stride."""
+    """Compile symbolic B/T/S/strides, specializing only an available unit weight-head stride."""
     import cutlass
     from cutlass import cute
 
@@ -70,12 +72,13 @@ def _compile_scores(
         head_dim,
         causal,
         use_int64_offsets,
+        compress_ratio=compress_ratio,
         contiguous_weight_heads=contiguous_weight_heads,
     )
     io_dtype = cutlass.BFloat16 if dtype == torch.bfloat16 else cutlass.Float16
     sym = cute.sym_int64 if use_int64_offsets else cute.sym_int
     integer = cutlass.Int64 if use_int64_offsets else cutlass.Int32
-    batch, tokens, pairs = sym(), sym(), sym()
+    batch, tokens, candidates, pairs = sym(), sym(), sym(), sym()
     q = make_fake_strided_tensor(
         io_dtype,
         (batch, tokens, heads, head_dim),
@@ -84,7 +87,7 @@ def _compile_scores(
     )
     k = make_fake_strided_tensor(
         io_dtype,
-        (batch, tokens, head_dim),
+        (batch, candidates, head_dim),
         stride_divisibility=TMA_ALIGNMENT_BYTES // (io_dtype.width // 8),
         use_int64_strides=use_int64_offsets,
     )
@@ -96,7 +99,7 @@ def _compile_scores(
     )
     scores = cute.runtime.make_fake_compact_tensor(
         cutlass.Float32,
-        (pairs, 2, tokens),
+        (pairs, 2, candidates),
         stride_order=(2, 1, 0),
         assumed_align=TMA_ALIGNMENT_BYTES,
         use_32bit_stride=not use_int64_offsets,
@@ -113,8 +116,10 @@ def _compile_scores(
 
 
 @jit_cache(extra_sources=(Path(__file__).with_name("cute_topk.py"),))
-def _compile_topk(topk: int, causal: bool, use_int64_offsets: bool) -> Callable[..., None]:
-    """Compile indices-only radix selection with symbolic B, T and slab capacity."""
+def _compile_topk(
+    topk: int, causal: bool, compress_ratio: int, use_int64_offsets: bool
+) -> Callable[..., None]:
+    """Compile indices-only radix selection with symbolic B, T, S and slab capacity."""
     import cutlass
     from cutlass import cute
 
@@ -122,10 +127,10 @@ def _compile_topk(topk: int, causal: bool, use_int64_offsets: bool) -> Callable[
 
     sym = cute.sym_int64 if use_int64_offsets else cute.sym_int
     integer = cutlass.Int64 if use_int64_offsets else cutlass.Int32
-    batch, tokens, pairs = sym(), sym(), sym()
+    batch, tokens, candidates, pairs = sym(), sym(), sym(), sym()
     scores = cute.runtime.make_fake_compact_tensor(
         cutlass.Float32,
-        (pairs, 2, tokens),
+        (pairs, 2, candidates),
         stride_order=(2, 1, 0),
         assumed_align=TMA_ALIGNMENT_BYTES,
         use_32bit_stride=not use_int64_offsets,
@@ -138,24 +143,32 @@ def _compile_topk(topk: int, causal: bool, use_int64_offsets: bool) -> Callable[
         use_32bit_stride=not use_int64_offsets,
     )
     return compile_tvm_ffi(
-        IndexerTopKKernel(topk, causal, use_int64_offsets), scores, output, integer(0)
+        IndexerTopKKernel(topk, causal, use_int64_offsets, compress_ratio=compress_ratio),
+        scores,
+        output,
+        integer(0),
     )
 
 
-def _validate(q: torch.Tensor, k: torch.Tensor, weights: torch.Tensor, topk: int) -> None:
+def _validate(
+    q: torch.Tensor, k: torch.Tensor, weights: torch.Tensor, topk: int, compress_ratio: int
+) -> None:
     """Validate SM100 indexer tensor metadata and base alignment."""
     if q.ndim != 4:
         raise ValueError(f"q must have shape [B,T,H,D], got {tuple(q.shape)}")
     if k.ndim != 3:
-        raise ValueError(f"k must have shape [B,T,D], got {tuple(k.shape)}")
+        raise ValueError(f"k must have shape [B,S,D], got {tuple(k.shape)}")
     if weights.ndim != 3:
         raise ValueError(f"weights must have shape [B,T,H], got {tuple(weights.shape)}")
 
     batch, queries, heads, head_dim = q.shape
-    if tuple(k.shape) != (batch, queries, head_dim):
+    if compress_ratio < 1:
+        raise ValueError(f"compress_ratio must be positive, got {compress_ratio}")
+    candidates = queries // compress_ratio
+    if tuple(k.shape) != (batch, candidates, head_dim):
         raise ValueError(
-            "prefill requires equal query/key lengths and matching B,D: "
-            f"q={tuple(q.shape)}, k={tuple(k.shape)}"
+            f"k must have shape {(batch, candidates, head_dim)} for T={queries} and "
+            f"compress_ratio={compress_ratio}, got {tuple(k.shape)}"
         )
     if tuple(weights.shape) != (batch, queries, heads):
         raise ValueError(
@@ -174,12 +187,8 @@ def _validate(q: torch.Tensor, k: torch.Tensor, weights: torch.Tensor, topk: int
         )
     if not isinstance(topk, int) or isinstance(topk, bool):
         raise TypeError(f"topk must be an int, got {type(topk).__name__}")
-    if topk < 0 or topk > queries:
-        raise ValueError(f"topk must be in [0, {queries}], got {topk}")
-    if topk > _MAX_SUPPORTED_TOPK:
-        raise ValueError(
-            f"topk must be <= {_MAX_SUPPORTED_TOPK} for the CuTeDSL indexer, got {topk}"
-        )
+    if topk < 0 or topk > candidates:
+        raise ValueError(f"topk must be in [0, {candidates}], got {topk}")
 
     tensors = (q, k, weights)
     if any(not tensor.is_cuda for tensor in tensors):
@@ -209,18 +218,20 @@ def launch(
     weights: torch.Tensor,
     topk: int,
     causal: bool = False,
+    compress_ratio: int = 1,
 ) -> torch.Tensor:
     """Compute weighted-ReLU Top-K with bounded per-call score storage."""
     import cutlass
 
-    _validate(q, k, weights, topk)
+    _validate(q, k, weights, topk, compress_ratio)
     batch, tokens, heads, head_dim = q.shape
+    candidates = k.shape[1]
     output = torch.empty((batch, tokens, topk), dtype=torch.int32, device=q.device)
     if topk == 0:
         return output
 
-    pairs = score_workspace_pairs(batch, tokens)
-    scores = torch.empty((pairs, 2, tokens), dtype=torch.float32, device=q.device)
+    pairs = score_workspace_pairs(batch, tokens, candidates)
+    scores = torch.empty((pairs, 2, candidates), dtype=torch.float32, device=q.device)
     use_int64_offsets = requires_int64_abi(q, k, weights, scores, output)
     integer = cutlass.Int64 if use_int64_offsets else cutlass.Int32
     previous = get_compile_target()
@@ -228,9 +239,15 @@ def launch(
         set_compile_target(detect_compile_target(q.device.index))
         # A unit head stride avoids the generic reducer's measured strided-load overhead.
         score_kernel = _compile_scores(
-            q.dtype, heads, head_dim, causal, use_int64_offsets, weights.stride(-1) == 1
+            q.dtype,
+            heads,
+            head_dim,
+            causal,
+            compress_ratio,
+            use_int64_offsets,
+            weights.stride(-1) == 1,
         )
-        topk_kernel = _compile_topk(topk, causal, use_int64_offsets)
+        topk_kernel = _compile_topk(topk, causal, compress_ratio, use_int64_offsets)
     finally:
         set_compile_target(previous)
 

--- a/attn_gym/sparse/indexer/impl/cute_score.py
+++ b/attn_gym/sparse/indexer/impl/cute_score.py
@@ -8,7 +8,7 @@ Adapted from cuDNN Frontend's ``dense_score_recompute_sm100.py`` and
 heads are packed into the B operand. One FP32 MMA tile has shape [128, 2*H];
 the epilogue independently computes ``scale * sum_h(weight * ReLU(Q @ K))``
 for each query. This module owns only score generation, not Top-K or allocation
-of the caller's [P, 2, T] FP32 slab.
+of the caller's [P, 2, S] FP32 slab.
 
 Head, query, and batch remain separate TMA modes despite the logical packing,
 so their physical strides are independent and odd query tails are zero-filled.
@@ -57,6 +57,7 @@ class IndexerScoreKernel:
         causal: bool,
         use_int64_offsets: bool = False,
         *,
+        compress_ratio: int = 1,
         contiguous_weight_heads: bool,
     ):
         if heads not in (32, 64) or head_dim != 128:
@@ -64,6 +65,7 @@ class IndexerScoreKernel:
         self.heads = heads
         self.head_dim = head_dim
         self.causal = causal
+        self.compress_ratio = compress_ratio
         self.use_int64_offsets = use_int64_offsets
         self.contiguous_weight_heads = contiguous_weight_heads
         self.packed_heads = 2 * heads
@@ -82,13 +84,21 @@ class IndexerScoreKernel:
         """Return a stable name for the shape, mask, weight layout, and offset width."""
         return (
             f"indexer_score_h{self.heads}_d{self.head_dim}_c{int(self.causal)}_"
-            f"i64{int(self.use_int64_offsets)}_wh{int(self.contiguous_weight_heads)}"
+            f"r{self.compress_ratio}_i64{int(self.use_int64_offsets)}_"
+            f"wh{int(self.contiguous_weight_heads)}"
         )
 
     @cute.jit
     def upcast_offset(self, value):
         """Widen origins before address arithmetic in the wide specialization."""
         return Int64(value) if cutlass.const_expr(self.use_int64_offsets) else Int32(value)
+
+    @cute.jit
+    def visible_candidates(self, query):
+        """Causal candidate count for query; the static ratio keeps r=1 division-free."""
+        if cutlass.const_expr(self.compress_ratio == 1):
+            return query + 1
+        return (query + 1) // self.compress_ratio
 
     @cute.jit
     def __call__(
@@ -178,6 +188,7 @@ class IndexerScoreKernel:
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
         local_pair, _, _ = cute.arch.block_idx()
         num_queries = self.upcast_offset(weights.shape[1])
+        num_candidates = self.upcast_offset(scores.shape[2])
         pairs_per_batch = cute.ceil_div(num_queries, 2)
         global_pair = pair_start + self.upcast_offset(local_pair)
         batch = global_pair // pairs_per_batch
@@ -186,9 +197,9 @@ class IndexerScoreKernel:
         active = global_pair < self.upcast_offset(weights.shape[0]) * pairs_per_batch
         query_last = query0 + 1 if query0 + 1 < num_queries else query0
         candidate_tiles = (
-            cute.ceil_div(query_last + 1, self.tile_candidates)
+            cute.ceil_div(self.visible_candidates(query_last), self.tile_candidates)
             if self.causal
-            else cute.ceil_div(num_queries, self.tile_candidates)
+            else cute.ceil_div(num_candidates, self.tile_candidates)
         )
 
         smem = utils.SmemAllocator()
@@ -259,6 +270,7 @@ class IndexerScoreKernel:
                     tidx,
                     query0,
                     num_queries,
+                    num_candidates,
                     candidate_tiles,
                     score_scale,
                 )
@@ -382,6 +394,7 @@ class IndexerScoreKernel:
         tidx: Int32,
         query0,
         num_queries,
+        num_candidates,
         candidate_tiles,
         score_scale: Float32,
     ):
@@ -417,9 +430,9 @@ class IndexerScoreKernel:
             )
             for qi in cutlass.range_constexpr(2):
                 query = query0 + qi
-                valid = query < num_queries and candidate < num_queries
+                valid = query < num_queries and candidate < num_candidates
                 if cutlass.const_expr(self.causal):
-                    valid = valid and candidate <= query
+                    valid = valid and candidate < self.visible_candidates(query)
                 if valid:
                     # Four independent FP32 chains keep head reduction latency
                     # bounded without packed-PTX or cross-thread reductions.

--- a/attn_gym/sparse/indexer/impl/cute_score_generic.py
+++ b/attn_gym/sparse/indexer/impl/cute_score_generic.py
@@ -4,7 +4,7 @@
 
 """Tiled SM100 indexer score generation without shape-sized shared buffers.
 
-One CTA owns one query in the caller's [P, 2, T] FP32 score slab. Candidate,
+One CTA owns one query in the caller's [P, 2, S] FP32 score slab. Candidate,
 head, and reduction tiles bound shared-memory and TMEM usage independently of
 H and D. Separate head/query/batch TMA modes zero-fill tails without reading
 another query or batch. This module allocates no global workspace and performs
@@ -53,6 +53,7 @@ class IndexerGenericScoreKernel:
         causal: bool,
         use_int64_offsets: bool = False,
         *,
+        compress_ratio: int = 1,
         contiguous_weight_heads: bool,
     ):
         if heads <= 0 or heads % 2 != 0:
@@ -62,6 +63,7 @@ class IndexerGenericScoreKernel:
         self.heads = heads
         self.head_dim = head_dim
         self.causal = causal
+        self.compress_ratio = compress_ratio
         self.use_int64_offsets = use_int64_offsets
         self.contiguous_weight_heads = contiguous_weight_heads
         self.head_tiles = (heads + self.tile_heads - 1) // self.tile_heads
@@ -80,13 +82,21 @@ class IndexerGenericScoreKernel:
         """Return a stable name for the shape, mask, weight layout, and offset width."""
         return (
             f"indexer_score_generic_h{self.heads}_d{self.head_dim}_c{int(self.causal)}_"
-            f"i64{int(self.use_int64_offsets)}_wh{int(self.contiguous_weight_heads)}"
+            f"r{self.compress_ratio}_i64{int(self.use_int64_offsets)}_"
+            f"wh{int(self.contiguous_weight_heads)}"
         )
 
     @cute.jit
     def upcast_offset(self, value):
         """Widen origins before address arithmetic in the wide specialization."""
         return Int64(value) if cutlass.const_expr(self.use_int64_offsets) else Int32(value)
+
+    @cute.jit
+    def visible_candidates(self, query):
+        """Causal candidate count for query; the static ratio keeps r=1 division-free."""
+        if cutlass.const_expr(self.compress_ratio == 1):
+            return query + 1
+        return (query + 1) // self.compress_ratio
 
     @cute.jit
     def __call__(
@@ -180,6 +190,7 @@ class IndexerGenericScoreKernel:
         slab_pair = self.upcast_offset(block_id) // 2
         qi = block_id % 2
         num_queries = self.upcast_offset(weights.shape[1])
+        num_candidates = self.upcast_offset(scores.shape[2])
         pairs_per_batch = cute.ceil_div(num_queries, 2)
         global_pair = pair_start + slab_pair
         batch = global_pair // pairs_per_batch
@@ -187,11 +198,8 @@ class IndexerGenericScoreKernel:
         active = batch < self.upcast_offset(weights.shape[0]) and query < num_queries
 
         if active:
-            candidate_tiles = (
-                cute.ceil_div(query + 1, self.tile_candidates)
-                if self.causal
-                else cute.ceil_div(num_queries, self.tile_candidates)
-            )
+            candidate_end = self.visible_candidates(query) if self.causal else num_candidates
+            candidate_tiles = cute.ceil_div(candidate_end, self.tile_candidates)
             smem = utils.SmemAllocator()
             storage = smem.allocate(self.SharedStorage)
             sK = smem.allocate_tensor(
@@ -248,7 +256,7 @@ class IndexerGenericScoreKernel:
                     qi,
                     tidx,
                     query,
-                    num_queries,
+                    num_candidates,
                     candidate_tiles,
                     score_scale,
                 )
@@ -383,7 +391,7 @@ class IndexerGenericScoreKernel:
         qi: Int32,
         tidx: Int32,
         query,
-        num_queries,
+        num_candidates,
         candidate_tiles,
         score_scale: Float32,
     ):
@@ -408,9 +416,9 @@ class IndexerGenericScoreKernel:
             candidate = (
                 self.upcast_offset(candidate_tile) * self.tile_candidates + coordinates[0][0]
             )
-            valid = candidate < num_queries
+            valid = candidate < num_candidates
             if cutlass.const_expr(self.causal):
-                valid = valid and candidate <= query
+                valid = valid and candidate < self.visible_candidates(query)
             sum0 = Float32(0.0)
             sum1 = Float32(0.0)
             sum2 = Float32(0.0)

--- a/attn_gym/sparse/indexer/impl/cute_topk.py
+++ b/attn_gym/sparse/indexer/impl/cute_topk.py
@@ -76,7 +76,7 @@ def _block_scan_inclusive(
 
 
 class IndexerTopKKernel:
-    """Select static K indices per row from a contiguous symbolic [P, 2, T] slab.
+    """Select static K indices per row from a contiguous symbolic [P, 2, S] slab.
 
     ``pair_start`` locates the slab in flattened (batch, query-pair) order; odd
     sequence tails do not share pairs across batches. The caller handles K=0
@@ -86,15 +86,23 @@ class IndexerTopKKernel:
 
     block_threads = 512
 
-    def __init__(self, topk: int, causal: bool, use_int64_offsets: bool = False):
+    def __init__(
+        self,
+        topk: int,
+        causal: bool,
+        use_int64_offsets: bool = False,
+        *,
+        compress_ratio: int = 1,
+    ):
         self.topk = topk
         self.causal = causal
+        self.compress_ratio = compress_ratio
         self.use_int64_offsets = use_int64_offsets
 
     def get_name(self) -> str:
         """Return a stable artifact name including all static specialization fields."""
         return (
-            f"indexer_topk_k{self.topk}_c{int(self.causal)}_"
+            f"indexer_topk_k{self.topk}_c{int(self.causal)}_r{self.compress_ratio}_"
             f"i64{int(self.use_int64_offsets)}_th{self.block_threads}"
         )
 
@@ -102,6 +110,13 @@ class IndexerTopKKernel:
     def upcast_offset(self, value):
         """Widen indices before any address arithmetic in the wide specialization."""
         return Int64(value) if cutlass.const_expr(self.use_int64_offsets) else value
+
+    @cute.jit
+    def visible_candidates(self, query):
+        """Causal candidate count for query; the static ratio keeps r=1 division-free."""
+        if cutlass.const_expr(self.compress_ratio == 1):
+            return query + 1
+        return (query + 1) // self.compress_ratio
 
     @cute.jit
     def find_threshold(
@@ -150,8 +165,9 @@ class IndexerTopKKernel:
         block_id = self.upcast_offset(cute.arch.block_idx()[0])
         slab_pair = block_id // 2
         qi = block_id % 2
-        seq_len = self.upcast_offset(scores.shape[2])
-        pairs_per_batch = cute.ceil_div(seq_len, 2)
+        num_queries = self.upcast_offset(output.shape[1])
+        num_candidates = self.upcast_offset(scores.shape[2])
+        pairs_per_batch = cute.ceil_div(num_queries, 2)
         global_pair = self.upcast_offset(pair_start) + slab_pair
         batch = global_pair // pairs_per_batch
         q = (global_pair % pairs_per_batch) * 2 + qi
@@ -173,11 +189,11 @@ class IndexerTopKKernel:
             Int32, cute.make_layout((_SHRINK_MAX,)), byte_alignment=128
         )
 
-        if batch < output.shape[0] and q < seq_len:
+        if batch < output.shape[0] and q < num_queries:
             row_output = output[batch, q, None]
-            seg_len = Int32(seq_len)
+            seg_len = Int32(num_candidates)
             if cutlass.const_expr(self.causal):
-                seg_len = Int32(q + 1)
+                seg_len = Int32(self.visible_candidates(q))
 
             if seg_len <= self.topk:
                 for slot in range(tidx, self.topk, self.block_threads):

--- a/attn_gym/sparse/indexer/impl/reference.py
+++ b/attn_gym/sparse/indexer/impl/reference.py
@@ -12,6 +12,7 @@ def launch(
     weights: Tensor,
     topk: int,
     causal: bool,
+    compress_ratio: int,
 ) -> Tensor:
     """Multi-head weighted ReLU Top-K, reference implementation.
 
@@ -25,7 +26,8 @@ def launch(
         k: [B, S, D]
         weights: [B, T, H]
         topk: number of candidates to select per query
-        causal: mask out candidates at positions beyond the query position
+        causal: keep only the ``(t + 1) // compress_ratio`` leading candidates of query t
+        compress_ratio: tokens summarized per candidate; ``S == T // compress_ratio``
 
     Returns:
         [B, T, topk] INT32 tensor of selected candidate indices.
@@ -51,17 +53,15 @@ def launch(
     scores = (torch.relu(dots) * weights.unsqueeze(-1)).sum(dim=2) * scale
 
     if causal:
-        query_positions = torch.arange(queries, device=q.device)[:, None]
+        visible = (torch.arange(1, queries + 1, device=q.device) // compress_ratio)[:, None]
         key_positions = torch.arange(candidates, device=q.device)[None, :]
-        scores.masked_fill_(key_positions > query_positions, float("-inf"))
+        scores.masked_fill_(key_positions >= visible, float("-inf"))
 
     indices = scores.topk(topk, dim=-1).indices.to(torch.int32)
 
     # Slots that selected a causally invalid candidate are replaced with -1.
-    # This happens when topk exceeds the number of valid candidates for a row
-    # (i.e. query position t < topk).
+    # This happens when topk exceeds the number of visible candidates for a row.
     if causal:
-        row = torch.arange(queries, device=q.device).view(1, queries, 1)
-        indices.masked_fill_(indices > row, -1)
+        indices.masked_fill_(indices >= visible.view(1, queries, 1), -1)
 
     return indices

--- a/attn_gym/sparse/indexer/impl/triton.py
+++ b/attn_gym/sparse/indexer/impl/triton.py
@@ -14,6 +14,11 @@ from triton.tools.tensor_descriptor import TensorDescriptor
 
 from attn_gym._backends.triton.utils import ptr_offset, requires_int64_offsets
 
+# Measured shared memory is (2 * BN + BH) * BD * elem_size: Triton double-buffers the TMA key
+# tile even at num_stages=1, plus one Q tile. Hopper/Blackwell allow 227 KiB per block; 192 KiB
+# leaves headroom for reduction scratch and only bounds how far the key tile widens.
+_TILE_SMEM_BUDGET = 192 * 1024
+
 
 @triton.jit
 def _index_kernel(
@@ -22,6 +27,7 @@ def _index_kernel(
     W,
     Out,
     T: tl.constexpr,
+    S: tl.constexpr,
     H: tl.constexpr,
     D: tl.constexpr,
     TOPK: tl.constexpr,
@@ -29,6 +35,7 @@ def _index_kernel(
     WT: tl.constexpr,
     WH: tl.constexpr,
     CAUSAL: tl.constexpr,
+    RATIO: tl.constexpr,
     BH: tl.constexpr,
     BD: tl.constexpr,
     BN: tl.constexpr,
@@ -51,7 +58,7 @@ def _index_kernel(
     q = Q.load([batch.to(tl.int32), query.to(tl.int32), 0, 0]).reshape(BH, BD)
     best = tl.full((KEEP,), -9223372036854775808, tl.int64)
     rank = tl.arange(0, KEEP)
-    end = query + 1 if CAUSAL else T
+    end = (query + 1) // RATIO if CAUSAL else S
     for start in tl.range(0, end, BN):
         k = K.load([batch.to(tl.int32), start.to(tl.int32), 0]).reshape(BN, BD)
         dots = tl.dot(k, tl.trans(q))
@@ -69,11 +76,14 @@ def _index_kernel(
     tl.store(Out + ptr_offset((batch, query, rank), (T * TOPK, TOPK, 1)), indices, rank < TOPK)
 
 
-def launch(q: Tensor, k: Tensor, weights: Tensor, topk: int, causal: bool) -> Tensor:
+def launch(
+    q: Tensor, k: Tensor, weights: Tensor, topk: int, causal: bool, compress_ratio: int
+) -> Tensor:
     """Return nondifferentiable INT32 indices without a quadratic workspace.
 
     Q/K require contiguous last dimensions and 16-byte-aligned bases/outer
-    strides. FP16/BF16, H/D <= 256, T <= 2**20, and Top-K <= 512 are supported.
+    strides. FP16/BF16, H/D <= 256, T <= 2**20, and any Top-K <= S are supported; the
+    register-resident selection makes each key tile cost grow with Top-K.
     Gradient-requiring inputs are allowed: selection returns indices, not trainable scores.
     The public registered operator keeps host descriptors outside graph tracing.
     """
@@ -82,10 +92,17 @@ def launch(q: Tensor, k: Tensor, weights: Tensor, topk: int, causal: bool) -> Te
     if q.dtype not in (torch.float16, torch.bfloat16):
         raise TypeError("The Triton indexer requires FP16 or BF16 inputs.")
     batch, tokens, heads, dim = q.shape
-    if heads > 256 or dim > 256 or dim % 8 or topk > 512 or tokens > 2**20:
+    candidates = k.shape[1]
+    if heads > 256 or dim > 256 or dim % 8 or tokens > 2**20:
         raise ValueError(
-            "The Triton indexer requires H <= 256, D <= 256 divisible by 8, "
-            "K <= 512, and T <= 2**20."
+            "The Triton indexer requires H <= 256, D <= 256 divisible by 8, and T <= 2**20."
+        )
+    if compress_ratio < 1:
+        raise ValueError(f"compress_ratio must be positive, got {compress_ratio}.")
+    if candidates != tokens // compress_ratio:
+        raise ValueError(
+            f"k must hold T // compress_ratio candidates, got T={tokens}, S={candidates}, "
+            f"compress_ratio={compress_ratio}."
         )
     for tensor in (q, k):
         if tensor.stride(-1) != 1 or any(s % 8 for s in tensor.stride()[:-1]):
@@ -97,8 +114,11 @@ def launch(q: Tensor, k: Tensor, weights: Tensor, topk: int, causal: bool) -> Te
         return output
     bh = max(16, triton.next_power_of_2(heads))
     bd = max(16, triton.next_power_of_2(dim))
+    keep = max(128, triton.next_power_of_2(topk))
+    # Wider key tiles amortize the O(KEEP) merge (2.4-3.8x for K >= 512 on GB200).
     bn = 128
-    keep = max(bn, triton.next_power_of_2(topk))
+    while bn < keep and (2 * bn + bh) * bd * q.element_size() <= _TILE_SMEM_BUDGET:
+        bn *= 2
     with torch.cuda.device(q.device):
         q_desc = TensorDescriptor.from_tensor(q, [1, 1, bh, bd])
         k_desc = TensorDescriptor.from_tensor(k, [1, bn, bd])
@@ -108,11 +128,13 @@ def launch(q: Tensor, k: Tensor, weights: Tensor, topk: int, causal: bool) -> Te
             weights,
             output,
             tokens,
+            candidates,
             heads,
             dim,
             topk,
             *weights.stride(),
             causal,
+            compress_ratio,
             bh,
             bd,
             bn,

--- a/attn_gym/sparse/indexer/ops.py
+++ b/attn_gym/sparse/indexer/ops.py
@@ -9,12 +9,19 @@ from torch import Tensor
 
 torch.library.define(
     "attn_gym::_indexer",
-    "(Tensor q, Tensor k, Tensor weights, int topk, bool causal, str backend) -> Tensor",
+    "(Tensor q, Tensor k, Tensor weights, int topk, bool causal, int compress_ratio, "
+    "str backend) -> Tensor",
 )
 
 
 def _indexer_cuda(
-    q: Tensor, k: Tensor, weights: Tensor, topk: int, causal: bool, backend: str
+    q: Tensor,
+    k: Tensor,
+    weights: Tensor,
+    topk: int,
+    causal: bool,
+    compress_ratio: int,
+    backend: str,
 ) -> Tensor:
     """Select a launcher on the input device without tracing device queries."""
     if backend == "auto":
@@ -26,7 +33,7 @@ def _indexer_cuda(
             from .impl.triton import launch
         case _:
             raise ValueError(f"unknown indexer backend {backend!r}")
-    return launch(q, k, weights, topk, causal)
+    return launch(q, k, weights, topk, causal, compress_ratio)
 
 
 torch.library.impl("attn_gym::_indexer", "CUDA", _indexer_cuda)
@@ -34,7 +41,13 @@ torch.library.impl("attn_gym::_indexer", "CUDA", _indexer_cuda)
 
 @torch.library.register_fake("attn_gym::_indexer")
 def _indexer_fake(
-    q: Tensor, k: Tensor, weights: Tensor, topk: int, causal: bool, backend: str
+    q: Tensor,
+    k: Tensor,
+    weights: Tensor,
+    topk: int,
+    causal: bool,
+    compress_ratio: int,
+    backend: str,
 ) -> Tensor:
     """Describe the common contiguous, nondifferentiable index output."""
     return q.new_empty((q.shape[0], q.shape[1], topk), dtype=torch.int32)

--- a/attn_gym/testing/indexer.py
+++ b/attn_gym/testing/indexer.py
@@ -14,6 +14,7 @@ def make_indexer_test_inputs(
     dtype: torch.dtype,
     *,
     batch: int = 2,
+    compress_ratio: int = 1,
     device: str | torch.device = "cuda",
     seed: int = 77,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -22,7 +23,8 @@ def make_indexer_test_inputs(
     q = torch.randn(
         batch, tokens, heads, head_dim, device=device, dtype=dtype, generator=generator
     )
-    k = torch.randn(batch, tokens, head_dim, device=device, dtype=dtype, generator=generator)
+    candidates = tokens // compress_ratio
+    k = torch.randn(batch, candidates, head_dim, device=device, dtype=dtype, generator=generator)
     weights = torch.randn(batch, tokens, heads, device=device, dtype=dtype, generator=generator)
     weights[..., 0] = weights[..., 0].abs() + 0.25
     if heads > 1:
@@ -69,6 +71,7 @@ def assert_indexer_selection(
     weights: torch.Tensor,
     topk: int,
     causal: bool,
+    compress_ratio: int = 1,
 ) -> None:
     """Check index invariants and FP64 boundary regret against eager's regret.
 
@@ -77,18 +80,21 @@ def assert_indexer_selection(
     bounds a selection boundary swap; scores have no FP16/BF16 output rounding.
     """
     batch, tokens, heads, dim = q.shape
+    candidates = k.shape[1]
+    assert candidates == tokens // compress_ratio
     assert actual.shape == (batch, tokens, topk)
     assert actual.dtype == torch.int32
     assert actual.device == q.device
     assert actual.is_contiguous()
     assert not actual.requires_grad
     valid = actual >= 0
-    assert not ((actual < -1) | (actual >= tokens)).any()
+    assert not ((actual < -1) | (actual >= candidates)).any()
     row = torch.arange(tokens, device=q.device).view(1, tokens, 1)
-    counts = (row + 1).clamp_max(topk) if causal else torch.full_like(row, topk)
+    visible = (row + 1) // compress_ratio
+    counts = visible.clamp_max(topk) if causal else torch.full_like(row, topk)
     assert torch.equal(valid.sum(-1, keepdim=True), counts.expand(batch, -1, -1))
     if causal:
-        assert not (valid & (actual > row)).any()
+        assert not (valid & (actual >= visible)).any()
     ordered = actual.sort(-1).values
     assert not ((ordered[..., 1:] == ordered[..., :-1]) & (ordered[..., 1:] >= 0)).any()
     if topk == 0:
@@ -103,13 +109,15 @@ def assert_indexer_selection(
     magnitude = (absolute_dots * w64.abs().transpose(1, 2).unsqueeze(-1)).sum(1)
     magnitude /= math.sqrt(heads * dim)
     if causal:
-        future = torch.arange(tokens, device=q.device).view(1, 1, tokens) > row
+        future = torch.arange(candidates, device=q.device).view(1, 1, candidates) >= visible
         scores.masked_fill_(future, -torch.inf)
         magnitude.masked_fill_(future, 0)
     boundary = scores.sort(-1, descending=True).values.gather(
-        -1, (counts - 1).expand(batch, -1, -1)
+        -1, (counts - 1).clamp_min(0).expand(batch, -1, -1)
     )
-    eager = lightning_indexer(q, k, weights, topk, causal=causal, impl="reference")
+    eager = lightning_indexer(
+        q, k, weights, topk, causal=causal, compress_ratio=compress_ratio, impl="reference"
+    )
     actual_scores = scores.gather(-1, actual.long().clamp_min(0))
     eager_scores = scores.gather(-1, eager.long().clamp_min(0))
     actual_error = (boundary - actual_scores).clamp_min(0).masked_fill(~valid, 0)

--- a/docs/sparse.md
+++ b/docs/sparse.md
@@ -11,13 +11,20 @@ from attn_gym.sparse import lightning_indexer
 indices = lightning_indexer(q, k, weights, topk=128, causal=True)
 # q: [B, T, H, D], k: [B, T, D], weights: [B, T, H]
 # indices: [B, T, 128], int32
+
+# DeepSeek compressed sparse attention: one candidate per 4 consecutive tokens.
+indices = lightning_indexer(q, k_compressed, weights, topk=128, causal=True, compress_ratio=4)
+# k_compressed: [B, T // 4, D]; query t may select candidates s < (t + 1) // 4
 ```
 
 The score for a query/candidate pair is
 `sum_h(weights[h] * relu(dot(q[h], k))) / sqrt(H * D)`.
-Weights may be negative. Query and candidate lengths must match. With causal selection,
-query `t` considers only candidates `0..t`; rows with fewer than `topk` candidates contain
-`-1` padding. Mask padding before gathering: a raw PyTorch index of `-1` selects the last
+Weights may be negative. `k` holds `S = T // compress_ratio` candidates, each summarizing
+`compress_ratio` consecutive tokens (a trailing partial window forms no candidate). With
+causal selection, query `t` considers only candidates `s < (t + 1) // compress_ratio`, those
+whose tokens all lie at positions `<= t` (candidates `0..t` with the default ratio of 1);
+rows with fewer than `topk` candidates contain `-1` padding. `compress_ratio != 1` requires
+`causal=True`. Mask padding before gathering: a raw PyTorch index of `-1` selects the last
 position rather than an invalid position. `topk=0` returns an empty last dimension.
 Output order and tie-breaking are unspecified, including between repeated calls.
 
@@ -45,7 +52,7 @@ Output order and tie-breaking are unspecified, including between repeated calls.
 | Heads `H` | Positive and even | `1..256` |
 | Head dimension `D` | Positive, divisible by 16 | `8..256`, divisible by 8 |
 | Sequence length `T` | `1..2**20` | `1..2**20` |
-| `topk` | `0..min(T, 512)` | `0..min(T, 512)` |
+| `topk` | `0..S` | `0..S`; per-tile cost grows with `topk` |
 | Layout | Q/K last stride 1, bases and non-singleton outer strides 16-byte aligned; weights may be strided | Q/K last stride 1, bases and outer strides 16-byte aligned; weights may be strided |
 
 CuTe accepts independently permuted or padded outer dimensions and broadcast inputs without

--- a/test/test_indexer_cute.py
+++ b/test/test_indexer_cute.py
@@ -187,8 +187,8 @@ def test_cute_matches_eager(batch, queries, heads, head_dim, topk, causal):
         "topk_127",
         "topk_129",
         "topk_512",
-        "topk_1024",
-        "topk_4096",
+        "candidates_1024",
+        "candidates_4096",
     ],
 )
 def test_cute_topk_scores_vs_fp64(batch, queries, heads, head_dim, topk, causal, dtype):
@@ -360,7 +360,7 @@ def test_cute_op_registration(causal, dtype, topk, requires_grad):
     w = torch.randn(2, 65, 64, device="cuda", dtype=dtype, requires_grad=requires_grad)
     # AOT opcheck compares integer outputs exactly. Full selection has a stable
     # output order; selective rows are checked semantically in the compile tests.
-    torch.library.opcheck(_indexer_op, (q, k, w, topk, causal, "cute"))
+    torch.library.opcheck(_indexer_op, (q, k, w, topk, causal, 1, "cute"))
     result = lightning_indexer(q, k, w, topk, causal=causal, impl="fused")
     assert not result.requires_grad
     assert result.grad_fn is None
@@ -391,8 +391,8 @@ def test_cute_artifact_reused_across_batch_and_tokens(monkeypatch, tmp_path):
             for compiler in compilers:
                 assert compiler.cache_info().misses == 1
                 assert compiler.cache_info().currsize == 1
-        assert impl._compile_scores.is_cached(torch.bfloat16, 64, 128, True, False, True)
-        assert impl._compile_topk.is_cached(16, True, False)
+        assert impl._compile_scores.is_cached(torch.bfloat16, 64, 128, True, 1, False, True)
+        assert impl._compile_topk.is_cached(16, True, 1, False)
         for compiler in compilers:
             assert compiler.cache_info().hits == 3
             compiler.cache_clear()

--- a/test/test_indexer_dispatch.py
+++ b/test/test_indexer_dispatch.py
@@ -62,11 +62,11 @@ def test_backend_dispatch_uses_input_device(monkeypatch, capability, backend, ex
         )
     if fails:
         with pytest.raises(RuntimeError) as exc:
-            ops._indexer_cuda(q, k, weights, 1, True, backend)
+            ops._indexer_cuda(q, k, weights, 1, True, 1, backend)
         assert exc.value is failure
     else:
-        assert ops._indexer_cuda(q, k, weights, 1, True, backend) is launch.return_value
-    launch.assert_called_once_with(q, k, weights, 1, True)
+        assert ops._indexer_cuda(q, k, weights, 1, True, 1, backend) is launch.return_value
+    launch.assert_called_once_with(q, k, weights, 1, True, 1)
     other.assert_not_called()
     if backend == "auto":
         device_capability.assert_called_once_with(q.device)
@@ -174,3 +174,78 @@ def test_backend_cuda_graph_replay(backend, dtype, tokens, heads, dim, topk, cau
         graph.replay()
         assert_indexer_selection(actual, *inputs, topk, causal)
         assert_indexer_selection(run(), *inputs, topk, causal)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("backend", ["cute", "triton"])
+@pytest.mark.parametrize(
+    "tokens,heads,dim,topk,compress_ratio",
+    [
+        (10, 32, 128, 2, 4),
+        (1027, 64, 128, 16, 4),
+        (1027, 66, 96, 37, 4),
+        (1027, 32, 128, 37, 3),
+        (4099, 64, 128, 1024, 4),
+        (2048, 32, 128, 1024, 1),
+        (8200, 32, 128, 2048, 1),
+        (3, 2, 16, 1, 3),
+    ],
+    ids=[
+        "zero_tile_rows",
+        "packed",
+        "generic",
+        "odd_ratio",
+        "topk_1024_all_candidates",
+        "topk_1024",
+        "topk_2048",
+        "one_candidate",
+    ],
+)
+def test_compressed_candidates(backend, tokens, heads, dim, topk, compress_ratio):
+    """Both fused backends score T queries against T // compress_ratio candidates.
+
+    Rows before the first completed window select nothing, the last window is
+    dropped when T is not a multiple of the ratio, and any topk <= S is accepted.
+    """
+    require_backend(backend)
+    inputs = make_indexer_test_inputs(
+        tokens, heads, dim, torch.bfloat16, compress_ratio=compress_ratio
+    )
+    actual = lightning_indexer(
+        *inputs,
+        topk,
+        causal=True,
+        compress_ratio=compress_ratio,
+        kernel_options={"backend": backend},
+    )
+    assert_indexer_selection(actual, *inputs, topk, True, compress_ratio)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_compressed_candidates_fullgraph_and_graph_replay():
+    """The public compressed route reuses one dynamic graph and replays under CUDA Graphs."""
+    require_backend()
+    counter = CompileCounterWithBackend("inductor")
+    compiled = torch.compile(lightning_indexer, fullgraph=True, dynamic=True, backend=counter)
+    # S must differ from B, H and D on the first call to avoid Dynamo's duck-shape guard.
+    for tokens in (65, 131):
+        inputs = make_indexer_test_inputs(tokens, 2, 32, torch.bfloat16, compress_ratio=4)
+        actual = compiled(*inputs, 7, causal=True, compress_ratio=4)
+        assert_indexer_selection(actual, *inputs, 7, True, 4)
+    assert counter.frame_count == 1
+
+    def run():
+        return lightning_indexer(*inputs, 7, causal=True, compress_ratio=4)
+
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        run()
+    torch.cuda.current_stream().wait_stream(stream)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        replayed = run()
+    for tensor in inputs:
+        tensor.normal_()
+    graph.replay()
+    assert_indexer_selection(replayed, *inputs, 7, True, 4)

--- a/test/test_indexer_radix.py
+++ b/test/test_indexer_radix.py
@@ -18,9 +18,11 @@ SM100 = torch.cuda.is_available() and torch.cuda.get_device_capability() == (10,
 @pytest.mark.parametrize("tokens", [1, 65, 1023, 1024, 1025, 4096, 65537, 2**20])
 def test_score_workspace_bound(batch, tokens):
     """Score scratch has both an absolute cap and a sequence-independent row cap."""
-    pairs = impl.score_workspace_pairs(batch, tokens)
+    pairs = impl.score_workspace_pairs(batch, tokens, tokens)
     assert 1 <= pairs <= min(512, batch * ((tokens + 1) // 2))
     assert pairs * 2 * tokens * 4 <= 32 * 1024 * 1024
+    # Compressed candidates shrink each row, so more pairs fit in the same bytes.
+    assert impl.score_workspace_pairs(batch, tokens, max(1, tokens // 4)) >= pairs
 
 
 @pytest.fixture
@@ -100,9 +102,9 @@ def test_radix_fake_tensor_abi(monkeypatch, use_int64_offsets, contiguous_weight
     pytest.importorskip("cutlass.cute")
     monkeypatch.setattr(impl, "compile_tvm_ffi", lambda operation, *args: args)
     q, k, weights, scores, *_ = impl._compile_scores.__wrapped__(
-        torch.bfloat16, 32, 128, True, use_int64_offsets, contiguous_weight_heads
+        torch.bfloat16, 32, 128, True, 1, use_int64_offsets, contiguous_weight_heads
     )
-    topk_scores, output, _ = impl._compile_topk.__wrapped__(37, True, use_int64_offsets)
+    topk_scores, output, _ = impl._compile_topk.__wrapped__(37, True, 1, use_int64_offsets)
     width = 64 if use_int64_offsets else 32
     assert q._assumed_align == k._assumed_align == 16
     assert weights._assumed_align == 2
@@ -192,7 +194,7 @@ def test_radix_rejects_non_tma_layout(radix_impl, operand, layout):
 
 
 @pytest.mark.parametrize("distribution", ["random", "ties", "clustered", "signed_zero"])
-@pytest.mark.parametrize("topk", [1, 37, 512])
+@pytest.mark.parametrize("topk", [1, 37, 512, 1024, 4096])
 def test_radix_threshold_and_overflow(radix_impl, distribution, topk):
     """Radix refinement handles negative scores, exact ties and shrink-buffer overflow."""
     import cutlass
@@ -219,7 +221,7 @@ def test_radix_threshold_and_overflow(radix_impl, distribution, topk):
     previous = get_compile_target()
     try:
         set_compile_target(detect_compile_target(torch.cuda.current_device()))
-        kernel = radix_impl._compile_topk(topk, False, False)
+        kernel = radix_impl._compile_topk(topk, False, 1, False)
     finally:
         set_compile_target(previous)
     kernel(scores, output, cutlass.Int32(0))
@@ -233,15 +235,18 @@ def test_radix_threshold_and_overflow(radix_impl, distribution, topk):
     torch.testing.assert_close(actual, expected, rtol=0, atol=0)
 
 
+@pytest.mark.parametrize("compress_ratio", [1, 4])
 @pytest.mark.parametrize("heads,head_dim", [(64, 128), (66, 48)])
-def test_radix_forced_int64(radix_impl, monkeypatch, heads, head_dim):
+def test_radix_forced_int64(radix_impl, monkeypatch, heads, head_dim, compress_ratio):
     """The wide ABI agrees with the ordinary address path on real data."""
-    inputs = make_indexer_test_inputs(65, heads, head_dim, torch.float16)
+    inputs = make_indexer_test_inputs(
+        65, heads, head_dim, torch.float16, compress_ratio=compress_ratio
+    )
     assert not requires_int64_abi(*inputs)
-    expected = radix_impl.launch(*inputs, 16, True)
+    expected = radix_impl.launch(*inputs, 16, True, compress_ratio)
     monkeypatch.setattr(radix_impl, "requires_int64_abi", lambda *args: True)
-    actual = radix_impl.launch(*inputs, 16, True)
-    assert_indexer_selection(actual, *inputs, 16, True)
+    actual = radix_impl.launch(*inputs, 16, True, compress_ratio)
+    assert_indexer_selection(actual, *inputs, 16, True, compress_ratio)
     torch.testing.assert_close(actual.sort(-1).values, expected.sort(-1).values)
 
 

--- a/test/test_indexer_reference.py
+++ b/test/test_indexer_reference.py
@@ -1,5 +1,6 @@
 """Tests for the indexer reference implementation."""
 
+import pytest
 import torch
 
 from attn_gym.sparse.indexer import lightning_indexer
@@ -71,3 +72,65 @@ def test_output_dtype_and_shape():
 
     assert out.dtype == torch.int32
     assert out.shape == (B, T, K)
+
+
+def test_compressed_candidates_causal_masking():
+    """Each candidate summarizes compress_ratio tokens; a row sees only completed windows.
+
+    With T=10 and compress_ratio=4 there are S=2 candidates: tokens 0..3 and 4..7.
+    Tokens 8..9 form no candidate. Query t sees (t + 1) // 4 candidates.
+    """
+    torch.manual_seed(0)
+    T, ratio, topk = 10, 4, 2
+    q = torch.randn(1, T, 2, 8, dtype=torch.float64)
+    k = torch.randn(1, T // ratio, 8, dtype=torch.float64)
+    w = torch.ones(1, T, 2, dtype=torch.float64)
+
+    actual = lightning_indexer(q, k, w, topk, causal=True, compress_ratio=ratio, impl="reference")
+
+    for t in range(T):
+        row = actual[0, t]
+        visible = (t + 1) // ratio
+        valid = row[row >= 0]
+        assert len(valid) == min(visible, topk), f"t={t}"
+        assert (valid < visible).all(), f"t={t}: candidate not yet complete"
+        assert (row == -1).sum() == topk - len(valid), f"t={t}"
+    assert (actual[0, :3] == -1).all()
+    assert set(actual[0, 7].tolist()) == {0, 1}
+
+
+def test_compressed_candidates_rank_within_visible_prefix():
+    """Selection ranks by score among the visible candidates, not merely masks them."""
+    torch.manual_seed(1)
+    T, ratio = 13, 4
+    q = torch.randn(1, T, 2, 8, dtype=torch.float64)
+    k = torch.randn(1, T // ratio, 8, dtype=torch.float64)
+    w = torch.randn(1, T, 2, dtype=torch.float64).abs() + 0.25
+    scores = (torch.einsum("bthd,bsd->bths", q, k).relu() * w.unsqueeze(-1)).sum(2)[0]
+
+    actual = lightning_indexer(q, k, w, 1, causal=True, compress_ratio=ratio, impl="reference")
+
+    assert actual[0, 7, 0] == scores[7, :2].argmax()
+    assert actual[0, 11, 0] == scores[11, :3].argmax()
+    assert actual[0, 12, 0] == scores[12, :3].argmax()
+
+
+@pytest.mark.parametrize(
+    "kwargs,candidates,error,message",
+    [
+        ({"causal": True, "compress_ratio": 4}, 3, ValueError, "S = T // compress_ratio"),
+        ({"causal": True, "compress_ratio": 3}, 2, ValueError, "S = T // compress_ratio"),
+        ({"compress_ratio": 4}, 2, ValueError, "pass causal=True"),
+        ({"causal": True, "compress_ratio": 0}, 2, ValueError, "must be positive"),
+        ({"causal": True, "compress_ratio": 4.0}, 2, TypeError, "Python int"),
+        ({"causal": True}, 2, ValueError, "S = T // compress_ratio"),
+    ],
+    ids=["too_many", "not_ratio", "noncausal", "zero", "float", "square_required"],
+)
+def test_compress_ratio_validation(kwargs, candidates, error, message):
+    """Reject mismatched candidate counts, noncausal ratios, and non-int ratios."""
+    q = torch.randn(1, 10, 2, 8)
+    k = torch.randn(1, candidates, 8)
+    w = torch.randn(1, 10, 2)
+    with pytest.raises(error, match=message):
+        lightning_indexer(q, k, w, 1, impl="reference", **kwargs)

--- a/test/test_indexer_triton.py
+++ b/test/test_indexer_triton.py
@@ -74,7 +74,7 @@ def test_triton_strided_inputs(causal):
     assert_indexer_selection(actual, q, k, weights, 37, causal)
     from attn_gym.sparse.indexer.ops import _indexer_op
 
-    torch.library.opcheck(_indexer_op, (q, k, weights, 37, causal, "triton"))
+    torch.library.opcheck(_indexer_op, (q, k, weights, 37, causal, 1, "triton"))
 
 
 @pytest.mark.parametrize(
@@ -84,7 +84,6 @@ def test_triton_strided_inputs(causal):
         (None, 65, 3, 18, 1, torch.bfloat16, ValueError, "H <= 256"),
         (None, 65, 3, 264, 1, torch.bfloat16, ValueError, "H <= 256"),
         (None, 65, 257, 16, 1, torch.bfloat16, ValueError, "H <= 256"),
-        (None, 513, 3, 16, 513, torch.bfloat16, ValueError, "K <= 512"),
         ("q", 65, 3, 16, 1, torch.bfloat16, ValueError, "contiguous last dimension"),
         ("k", 65, 3, 16, 1, torch.bfloat16, ValueError, "contiguous last dimension"),
         ("outer", 65, 3, 17, 1, torch.bfloat16, ValueError, "16-byte outer strides"),
@@ -94,7 +93,6 @@ def test_triton_strided_inputs(causal):
         "dim_unaligned",
         "dim_large",
         "heads",
-        "topk",
         "q_layout",
         "k_layout",
         "outer_stride",
@@ -124,7 +122,7 @@ def test_triton_opcheck(dtype, requires_grad, topk):
     inputs = make_indexer_test_inputs(65, 3, 48, dtype)
     for tensor in inputs:
         tensor.requires_grad_(requires_grad)
-    torch.library.opcheck(_indexer_op, (*inputs, topk, True, "triton"))
+    torch.library.opcheck(_indexer_op, (*inputs, topk, True, 1, "triton"))
     actual = lightning_indexer(
         *inputs, topk, causal=True, impl="fused", kernel_options={"backend": "triton"}
     )


### PR DESCRIPTION
## Summary

DeepSeek compressed sparse attention (torchtitan DSv4 `Indexer.select`) scores T queries against `S = T // r` compressed candidates, each summarizing r consecutive tokens. A query may only select candidates whose tokens are all in its past, so with `causal=True` row t sees the `(t + 1) // r` leading candidates. This PR adds `compress_ratio: int = 1` to `lightning_indexer` and lifts the fused `topk` cap from 512 to 1024 (DeepSeek-V4 pro uses 1024).

- `k` is `[B, S, D]` with `S = T // compress_ratio` (a trailing partial window forms no candidate); candidate extents now come from `k`/the score slab everywhere, so the CuTe slab shrinks to `[P, 2, S]`.
- `compress_ratio` is a compile-time constant in the CuTe score/topk kernels and the Triton kernel; `r = 1` reproduces the previous causal rule exactly (`s <= t`).
- `compress_ratio != 1` requires `causal=True`. Decode-time query offsets (per-batch `query_start`) are left for a follow-up.
- Reference implementation, op schema, docs, and shared test helpers updated; kernel artifact names gain `_r{ratio}`.

Why a ratio rather than a per-row limit tensor: r is fixed per model and the caller already divided S by it; FLA's NSA makes the same choice (`int block_size`). No library exposes a slope-1/r causal diagonal natively, so lower-right causal cannot express this mask.

## Validation (GB200, torch 2.15 nightly, CuTeDSL 4.6.2)

- 382 indexer tests pass (`test_indexer_{reference,helpers,dispatch,radix,triton,cute}.py`) plus the gated large cases (`candidates_4096`, `active_int64_offset`).
- New: reference semantics/ranking tests, validation errors, `test_compressed_candidates` on both fused backends (zero-visible rows, T not a multiple of r, odd ratio 3, topk == S, topk 1024, single candidate), and a compressed fullgraph + CUDA-graph replay test.
- Parity with torchtitan's eager `Indexer.select` at the DSv4 pro indexer shape (H64 x D128, r=4, topk=1024): identical selected sets at T=4096; 13x faster at T=4096 (1.28 ms -> 98 us) and 20x at T=16384 (17.5 ms -> 0.85 ms).
- r=1 performance is unchanged within noise on packed H64 (T=4096/16384), generic H66/D96 and H128/D128. One reviewer-suggested simplification (threading a single `candidate_end` into the generic epilogue) cost +9% on H128 and was reverted.
- Full suite: 2260 passed; the 71 failures are all `test_selected_attention_cute.py` raising `Expects a static layout` inside the local flash-attention checkout's `flash_fwd_mla_sm100.py` (updated today), independent of this change.
