### PR TITLE
Enable D512 training in Triton selected attention

### DIFF
--- a/attn_gym/sparse/selected_attention/impl/triton/__init__.py
+++ b/attn_gym/sparse/selected_attention/impl/triton/__init__.py
@@ -130,11 +130,6 @@ def selected_attention(
     requires_grad = torch.is_grad_enabled() and any(
         tensor.requires_grad for tensor in (query, local_kv, sparse_kv, attention_sink)
     )
-    if requires_grad and query.shape[-1] == 512:
-        raise NotImplementedError(
-            "The Triton selected-attention backend currently supports head_dim=512 only for "
-            "inference."
-        )
     if requires_grad:
         return _SelectedAttentionFunction.apply(
             query,

--- a/attn_gym/sparse/selected_attention/impl/triton/backward.py
+++ b/attn_gym/sparse/selected_attention/impl/triton/backward.py
@@ -12,6 +12,7 @@ from .primitives import (
     causal_window_mask,
     load_bhsd,
     load_bs,
+    prune_wide_backward_configs,
     store_bhsd,
 )
 from .shared_backward import (
@@ -156,7 +157,14 @@ def _selected_attention_bwd_dq(
     sink = tl.load(attention_sink_ptr + head)
     sink_probability = tl.exp(sink - lse)
     sink_gradient = tl.where(query_mask, -sink_probability * delta, 0.0)
-    tl.atomic_add(grad_sink_ptr + head, tl.sum(sink_gradient, axis=0))
+    if D == 512:
+        # Output-owned partials also keep the generic D=512 fallback deterministic.
+        tl.store(
+            grad_sink_ptr + batch_head * tl.cdiv(S, BLOCK_M) + query_block,
+            tl.sum(sink_gradient, axis=0),
+        )
+    else:
+        tl.atomic_add(grad_sink_ptr + head, tl.sum(sink_gradient, axis=0))
 
 
 @triton.jit
@@ -380,6 +388,7 @@ def _selected_attention_bwd_dlocal_kv_tma(
         for num_stages in (1, 3)
     ],
     key=["H", "S", "D", "SPARSE_SEQ_LEN", "TOPK"],
+    prune_configs_by={"early_config_prune": prune_wide_backward_configs},
     cache_results=True,
 )
 @triton.jit
@@ -548,8 +557,9 @@ def _launch_backward(
     batch, heads, seq_len, head_dim = query.shape
     sparse_seq_len = sparse_kv.shape[2]
     topk = kv_indices.shape[-1]
-    block_m = 64
-    block_n = 32
+    # Full-width D=512 operands otherwise exceed per-block shared-memory limits.
+    block_m = 16 if head_dim == 512 else 64
+    block_n = 16 if head_dim == 512 else 32
     block_d = max(16, triton.next_power_of_2(head_dim))
     grad_output = grad_output.contiguous()
 
@@ -570,11 +580,11 @@ def _launch_backward(
     use_shared_schedule = (
         share_kv
         and can_use_shared_kv_schedule(query, sparse_kv, local_kv, sliding_window_size)
-        and head_dim <= 128
+        and (head_dim <= 128 or head_dim == 512)
     )
     if use_shared_schedule:
-        block_h = min(32, triton.next_power_of_2(heads))
-        block_k = max(16, min(64, triton.next_power_of_2(topk)))
+        block_h = 16 if head_dim == 512 else min(32, triton.next_power_of_2(heads))
+        block_k = 16 if head_dim == 512 else max(16, min(64, triton.next_power_of_2(topk)))
         grad_sink_partials = torch.empty(
             batch, heads, seq_len, device=query.device, dtype=torch.float32
         )
@@ -615,7 +625,17 @@ def _launch_backward(
         num_local_key_tiles = (
             triton.cdiv(sliding_window_size + block_m - 1, block_n) if sliding_window_size else 0
         )
-        grad_sink_fp32 = torch.zeros(heads, device=query.device, dtype=torch.float32)
+        grad_sink_fp32 = (
+            torch.empty(
+                batch,
+                heads,
+                triton.cdiv(seq_len, block_m),
+                device=query.device,
+                dtype=torch.float32,
+            )
+            if head_dim == 512
+            else torch.zeros(heads, device=query.device, dtype=torch.float32)
+        )
         _selected_attention_bwd_dq[(triton.cdiv(seq_len, block_m), batch * heads)](
             query,
             sparse_kv,
@@ -646,9 +666,11 @@ def _launch_backward(
             BLOCK_M=block_m,
             BLOCK_N=block_n,
             BLOCK_D=block_d,
-            num_warps=8,
-            num_stages=3,
+            num_warps=4 if head_dim == 512 else 8,
+            num_stages=1 if head_dim == 512 else 3,
         )
+        if head_dim == 512:
+            grad_sink_fp32 = grad_sink_fp32.sum(dim=(0, 2))
 
     local_grid = (triton.cdiv(seq_len, block_n), batch * heads)
     if use_tma:
@@ -702,8 +724,8 @@ def _launch_backward(
             BLOCK_M=block_m,
             BLOCK_N=block_n,
             BLOCK_D=block_d,
-            num_warps=8,
-            num_stages=3,
+            num_warps=4 if head_dim == 512 else 8,
+            num_stages=1 if head_dim == 512 else 3,
         )
 
     if topk == 0:
@@ -754,7 +776,9 @@ def _launch_backward(
         )
         grad_sparse_kv = grad_sparse_kv_fp32.to(sparse_kv.dtype)
     else:
-        if use_shared_schedule:
+        # The shared CSR schedule flattens heads x query rows into a large D-wide tile.
+        # Use the per-head output-owned kernel for deterministic D=512 gradients instead.
+        if use_shared_schedule and head_dim != 512:
             grad_sparse_kv_partials = torch.zeros(
                 sparse_kv.shape,
                 device=sparse_kv.device,

--- a/attn_gym/sparse/selected_attention/impl/triton/backward.py
+++ b/attn_gym/sparse/selected_attention/impl/triton/backward.py
@@ -558,8 +558,7 @@ def _launch_backward(
     sparse_seq_len = sparse_kv.shape[2]
     topk = kv_indices.shape[-1]
     # Full-width D=512 operands otherwise exceed per-block shared-memory limits.
-    block_m = 16 if head_dim == 512 else 64
-    block_n = 16 if head_dim == 512 else 32
+    block_m, block_n, num_warps, num_stages = (16, 16, 4, 1) if head_dim == 512 else (64, 32, 8, 3)
     block_d = max(16, triton.next_power_of_2(head_dim))
     grad_output = grad_output.contiguous()
 
@@ -577,10 +576,8 @@ def _launch_backward(
     )
 
     # Zero head strides share values; share_kv also guarantees autograd will sum dKV heads.
-    use_shared_schedule = (
-        share_kv
-        and can_use_shared_kv_schedule(query, sparse_kv, local_kv, sliding_window_size)
-        and (head_dim <= 128 or head_dim == 512)
+    use_shared_schedule = share_kv and can_use_shared_kv_schedule(
+        query, sparse_kv, local_kv, sliding_window_size
     )
     if use_shared_schedule:
         block_h = 16 if head_dim == 512 else min(32, triton.next_power_of_2(heads))
@@ -666,8 +663,8 @@ def _launch_backward(
             BLOCK_M=block_m,
             BLOCK_N=block_n,
             BLOCK_D=block_d,
-            num_warps=4 if head_dim == 512 else 8,
-            num_stages=1 if head_dim == 512 else 3,
+            num_warps=num_warps,
+            num_stages=num_stages,
         )
         if head_dim == 512:
             grad_sink_fp32 = grad_sink_fp32.sum(dim=(0, 2))
@@ -724,8 +721,8 @@ def _launch_backward(
             BLOCK_M=block_m,
             BLOCK_N=block_n,
             BLOCK_D=block_d,
-            num_warps=4 if head_dim == 512 else 8,
-            num_stages=1 if head_dim == 512 else 3,
+            num_warps=num_warps,
+            num_stages=num_stages,
         )
 
     if topk == 0:

--- a/attn_gym/sparse/selected_attention/impl/triton/forward.py
+++ b/attn_gym/sparse/selected_attention/impl/triton/forward.py
@@ -438,9 +438,7 @@ def _launch_forward(
     doc_ids = query if doc_ids is None else doc_ids
 
     # This head-major schedule is tuned for shared KV on Blackwell.
-    if can_use_shared_kv_schedule(query, sparse_kv, local_kv, sliding_window_size) and (
-        head_dim <= 128 or head_dim == 512
-    ):
+    if can_use_shared_kv_schedule(query, sparse_kv, local_kv, sliding_window_size):
         # A smaller head tile keeps D=512 accumulators within Blackwell's resources.
         block_h = (
             triton.next_power_of_2(heads)
@@ -479,8 +477,9 @@ def _launch_forward(
         return output, lse
 
     # D=512 must also fit the generic path (non-Blackwell, FP16/FP32, or unshared KV).
-    block_m = 16 if head_dim == 512 else 64
-    block_n = 16 if head_dim == 512 else 128
+    block_m, block_n, num_warps, num_stages = (
+        (16, 16, 4, 1) if head_dim == 512 else (64, 128, 8, 3)
+    )
     num_local_tiles = (
         triton.cdiv(sliding_window_size + block_m - 1, block_n) if sliding_window_size else 0
     )
@@ -543,7 +542,7 @@ def _launch_forward(
             BLOCK_M=block_m,
             BLOCK_N=block_n,
             BLOCK_D=block_d,
-            num_warps=4 if head_dim == 512 else 8,
-            num_stages=1 if head_dim == 512 else 3,
+            num_warps=num_warps,
+            num_stages=num_stages,
         )
     return output, lse

--- a/attn_gym/sparse/selected_attention/impl/triton/forward.py
+++ b/attn_gym/sparse/selected_attention/impl/triton/forward.py
@@ -478,8 +478,9 @@ def _launch_forward(
         )
         return output, lse
 
-    block_m = 64
-    block_n = 128
+    # D=512 must also fit the generic path (non-Blackwell, FP16/FP32, or unshared KV).
+    block_m = 16 if head_dim == 512 else 64
+    block_n = 16 if head_dim == 512 else 128
     num_local_tiles = (
         triton.cdiv(sliding_window_size + block_m - 1, block_n) if sliding_window_size else 0
     )
@@ -542,7 +543,7 @@ def _launch_forward(
             BLOCK_M=block_m,
             BLOCK_N=block_n,
             BLOCK_D=block_d,
-            num_warps=8,
-            num_stages=3,
+            num_warps=4 if head_dim == 512 else 8,
+            num_stages=1 if head_dim == 512 else 3,
         )
     return output, lse

--- a/attn_gym/sparse/selected_attention/impl/triton/primitives.py
+++ b/attn_gym/sparse/selected_attention/impl/triton/primitives.py
@@ -32,6 +32,19 @@ def can_use_shared_kv_schedule(
     )
 
 
+def prune_wide_backward_configs(configs, _named_args, D, **_):
+    """Bound full-width D=512 gradient tiles without changing smaller-head tuning."""
+    if D != 512:
+        return configs
+    return [
+        config
+        for config in configs
+        if config.num_warps == 4
+        and config.num_stages == 1
+        and all(size <= 16 for size in config.kwargs.values())
+    ]
+
+
 @triton.jit
 def load_bhsd(
     tensor_ptr,

--- a/attn_gym/sparse/selected_attention/impl/triton/primitives.py
+++ b/attn_gym/sparse/selected_attention/impl/triton/primitives.py
@@ -13,10 +13,7 @@ def can_use_shared_kv_schedule(
     local_kv: torch.Tensor,
     sliding_window_size: int,
 ) -> bool:
-    """Check Blackwell shared-KV constraints common to forward and backward.
-
-    Callers enforce the head-dimension limits supported by their kernel.
-    """
+    """Check the shared Blackwell forward/backward schedule's layout and shape limits."""
     _, heads, _, head_dim = query.shape
     return (
         torch.cuda.get_device_capability(query.device)[0] >= 10
@@ -28,6 +25,7 @@ def can_use_shared_kv_schedule(
         and local_kv.stride(-1) == 1
         and 16 <= heads <= 128
         and head_dim % 16 == 0
+        and (head_dim <= 128 or head_dim == 512)
         and sliding_window_size <= 2048
     )
 

--- a/attn_gym/sparse/selected_attention/impl/triton/shared_backward.py
+++ b/attn_gym/sparse/selected_attention/impl/triton/shared_backward.py
@@ -10,14 +10,23 @@ import triton.language as tl
 
 from attn_gym._backends.triton.utils import ptr_offset
 
+from .primitives import prune_wide_backward_configs
+
+
+def prune_shared_dq_configs(configs, named_args, D, **kwargs):
+    if D == 512:
+        return prune_wide_backward_configs(configs, named_args, D=D, **kwargs)
+    return [config for config in configs if config.kwargs["BLOCK_N"] != 16]
+
 
 @triton.autotune(
     configs=[
         triton.Config({"BLOCK_N": block_n}, num_warps=num_warps, num_stages=1)
-        for block_n in (64, 128)
+        for block_n in (16, 64, 128)
         for num_warps in (4, 8)
     ],
     key=["B", "H", "S", "D", "SPARSE_SEQ_LEN", "TOPK", "WINDOW", "HAS_DOC_IDS"],
+    prune_configs_by={"early_config_prune": prune_shared_dq_configs},
     cache_results=True,
 )
 @triton.jit
@@ -211,6 +220,7 @@ def _selected_attention_bwd_dq_shared(
     ],
     key=["B", "H", "S", "D", "SPARSE_SEQ_LEN", "TOPK"],
     reset_to_zero=["grad_sparse_kv_ptr"],
+    prune_configs_by={"early_config_prune": prune_wide_backward_configs},
     cache_results=True,
 )
 @triton.jit

--- a/test/test_selected_attention_d512.py
+++ b/test/test_selected_attention_d512.py
@@ -1,12 +1,14 @@
 """D=512 training coverage for portable and Blackwell shared-KV Triton schedules."""
 
-import math
 from collections.abc import Callable
 from typing import NamedTuple
 
 import pytest
 import torch
-from test_selected_attention_triton import assert_matches_low_precision_eager
+from test_selected_attention_triton import (
+    assert_matches_low_precision_eager,
+    assert_sink_gradient_fp32,
+)
 
 from attn_gym.sparse.selected_attention import (
     AuxRequest,
@@ -71,33 +73,6 @@ def make_inputs(
         else None
     )
     return AttentionInputs(query, local_kv, sparse_kv, kv_indices, attention_sink, doc_ids)
-
-
-def assert_sink_matches_reference(
-    actual: torch.Tensor,
-    low_precision_expected: torch.Tensor,
-    high_precision_expected: torch.Tensor,
-    query_dtype: torch.dtype,
-    reduction_sizes: tuple[int, ...],
-) -> None:
-    # NOTE [Sink Gradient Delta Rounding] in test_selected_attention_triton applies to
-    # the saved output and PV probabilities, not the FP32 sink's output dtype.
-    accumulation_eps = (
-        sum(math.sqrt(size) for size in reduction_sizes) * torch.finfo(torch.float32).eps
-    )
-    intermediate_eps = 2 * torch.finfo(query_dtype).eps
-    output_eps = torch.finfo(actual.dtype).eps
-    actual_error = (actual.double() - high_precision_expected).abs()
-    eager_error = (low_precision_expected.double() - high_precision_expected).abs()
-    scale = high_precision_expected.abs()
-    mean_allowance = (accumulation_eps + output_eps + intermediate_eps) * scale.mean()
-    max_allowance = (
-        accumulation_eps + len(reduction_sizes) * output_eps + intermediate_eps
-    ) * scale.max()
-    assert actual.dtype == torch.float32
-    assert torch.isfinite(actual).all()
-    assert actual_error.mean() <= eager_error.mean() + mean_allowance
-    assert actual_error.max() <= eager_error.max() + max_allowance
 
 
 def check_training(
@@ -178,21 +153,17 @@ def check_training(
             high_precision_grads[index],
             reductions,
         )
-    assert_sink_matches_reference(
+    assert_matches_low_precision_eager(
         actual_grads[3],
         low_precision_grads[3],
         high_precision_grads[3],
-        query.dtype,
         forward_reductions + (head_dim, seq_len),
+        quantized_intermediates=2,
+        intermediate_dtype=query.dtype,
     )
 
-    # Independently isolate FP32 sink arithmetic from the legitimate BF16 saved-state error.
     assert aux.lse is not None
-    delta = (actual.double() * grad_output.double()).sum(-1)
-    sink_partials = -torch.exp(sink.double()[None, :, None] - aux.lse.double()) * delta
-    sink_expected = sink_partials.sum((0, 2))
-    allowance = 32 * torch.finfo(torch.float32).eps * sink_partials.abs().sum((0, 2))
-    assert ((actual_grads[3].double() - sink_expected).abs() <= allowance).all()
+    assert_sink_gradient_fp32(sink, aux.lse, actual, grad_output, actual_grads[3])
     if topk == 0:
         assert actual_grads[2].count_nonzero() == 0
     if window == 0:
@@ -236,6 +207,19 @@ def test_d512_torch_compile_fullgraph(heads, share_kv):
     for seq_len in (17, 33):
         inputs = make_inputs(heads, share_kv, torch.bfloat16, seq_len=seq_len)
         check_training(inputs, 19, operation=compiled)
+
+
+@pytest.mark.parametrize("head_dim", [16, 64, 128, 144, 256, 496, 512, 528])
+def test_shared_schedule_head_dimensions(monkeypatch, head_dim):
+    pytest.importorskip("triton")
+    from attn_gym.sparse.selected_attention.impl.triton.primitives import (
+        can_use_shared_kv_schedule,
+    )
+
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device: (10, 0))
+    query = torch.empty(1, 16, 1, head_dim, dtype=torch.bfloat16, device="meta")
+    kv = torch.empty(1, 1, 1, head_dim, dtype=query.dtype, device="meta").expand(-1, 16, -1, -1)
+    assert can_use_shared_kv_schedule(query, kv, kv, 128) == (head_dim in (16, 64, 128, 512))
 
 
 @pytest.mark.full_autotune

--- a/test/test_selected_attention_d512.py
+++ b/test/test_selected_attention_d512.py
@@ -1,0 +1,264 @@
+"""D=512 training coverage for portable and Blackwell shared-KV Triton schedules."""
+
+import math
+from collections.abc import Callable
+from typing import NamedTuple
+
+import pytest
+import torch
+from test_selected_attention_triton import assert_matches_low_precision_eager
+
+from attn_gym.sparse.selected_attention import (
+    AuxRequest,
+    SelectedAttentionAux,
+    selected_attention,
+)
+
+pytestmark = pytest.mark.usefixtures("selected_attention_single_config")
+
+
+class AttentionInputs(NamedTuple):
+    query: torch.Tensor
+    local_kv: torch.Tensor
+    sparse_kv: torch.Tensor
+    kv_indices: torch.Tensor
+    attention_sink: torch.Tensor
+    doc_ids: torch.Tensor | None
+
+
+def make_inputs(
+    heads: int,
+    share_kv: bool,
+    dtype: torch.dtype,
+    seq_len: int = 33,
+    topk: int = 19,
+    with_docs: bool = True,
+    batch: int = 1,
+) -> AttentionInputs:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required for Triton")
+    if heads >= 16 and torch.cuda.get_device_capability()[0] < 10:
+        pytest.skip("Blackwell required for the shared-KV schedule")
+
+    generator = torch.Generator(device="cuda").manual_seed(2026)
+    kv_heads = 1 if share_kv else heads
+    sparse_seq_len = max(23, topk)
+
+    def randn(*shape: int) -> torch.Tensor:
+        return torch.randn(
+            *shape, device="cuda", dtype=dtype, generator=generator, requires_grad=True
+        )
+
+    query = randn(batch, heads, seq_len, 512)
+    local_kv = randn(batch, kv_heads, seq_len, 512)
+    sparse_kv = randn(batch, kv_heads, sparse_seq_len, 512)
+    kv_indices = torch.randint(
+        sparse_seq_len, (batch, seq_len, topk), device="cuda", generator=generator
+    )
+    if topk:
+        kv_indices[:, :, 1] = kv_indices[:, :, 0]
+        kv_indices[:, ::3, -1] = -1
+        kv_indices[:, 0, :] = -1
+    # Keep the sink and its gradient in FP32: BF16 casts would hide delta-reduction errors.
+    attention_sink = torch.randn(
+        heads, device="cuda", dtype=torch.float32, generator=generator, requires_grad=True
+    )
+    doc_ids = (
+        (torch.arange(seq_len, device="cuda", dtype=torch.int32) // 11)
+        .unsqueeze(0)
+        .expand(batch, -1)
+        if with_docs
+        else None
+    )
+    return AttentionInputs(query, local_kv, sparse_kv, kv_indices, attention_sink, doc_ids)
+
+
+def assert_sink_matches_reference(
+    actual: torch.Tensor,
+    low_precision_expected: torch.Tensor,
+    high_precision_expected: torch.Tensor,
+    query_dtype: torch.dtype,
+    reduction_sizes: tuple[int, ...],
+) -> None:
+    # NOTE [Sink Gradient Delta Rounding] in test_selected_attention_triton applies to
+    # the saved output and PV probabilities, not the FP32 sink's output dtype.
+    accumulation_eps = (
+        sum(math.sqrt(size) for size in reduction_sizes) * torch.finfo(torch.float32).eps
+    )
+    intermediate_eps = 2 * torch.finfo(query_dtype).eps
+    output_eps = torch.finfo(actual.dtype).eps
+    actual_error = (actual.double() - high_precision_expected).abs()
+    eager_error = (low_precision_expected.double() - high_precision_expected).abs()
+    scale = high_precision_expected.abs()
+    mean_allowance = (accumulation_eps + output_eps + intermediate_eps) * scale.mean()
+    max_allowance = (
+        accumulation_eps + len(reduction_sizes) * output_eps + intermediate_eps
+    ) * scale.max()
+    assert actual.dtype == torch.float32
+    assert torch.isfinite(actual).all()
+    assert actual_error.mean() <= eager_error.mean() + mean_allowance
+    assert actual_error.max() <= eager_error.max() + max_allowance
+
+
+def check_training(
+    inputs: AttentionInputs,
+    window: int,
+    operation: Callable[..., tuple[torch.Tensor, SelectedAttentionAux]] = selected_attention,
+    *,
+    repeat_backward: bool = False,
+) -> None:
+    from attn_gym.sparse.selected_attention.impl.triton.primitives import (
+        can_use_shared_kv_schedule,
+    )
+
+    query, local_kv, sparse_kv, kv_indices, sink, _ = inputs
+    heads, seq_len, head_dim = query.shape[1:]
+    shared = local_kv.shape[1] == 1
+    assert can_use_shared_kv_schedule(
+        query,
+        sparse_kv.expand(-1, heads, -1, -1),
+        local_kv.expand(-1, heads, -1, -1),
+        window,
+    ) == (heads >= 16)
+    differentiable = query, local_kv, sparse_kv, sink
+    high_precision_tensors = tuple(
+        tensor.detach().double().requires_grad_() for tensor in differentiable
+    )
+    high_precision_inputs = inputs._replace(
+        query=high_precision_tensors[0],
+        local_kv=high_precision_tensors[1],
+        sparse_kv=high_precision_tensors[2],
+        attention_sink=high_precision_tensors[3],
+    )
+    high_precision_output = selected_attention(*high_precision_inputs, window, backend="eager")
+    low_precision_output = selected_attention(*inputs, window, backend="eager")
+    actual, aux = operation(*inputs, window, backend="triton", return_aux=AuxRequest(lse=True))
+    generator = torch.Generator(device="cuda").manual_seed(1234)
+    grad_output = torch.randn(
+        query.shape, device=query.device, dtype=query.dtype, generator=generator
+    )
+    high_precision_grads = torch.autograd.grad(
+        high_precision_output, high_precision_tensors, grad_output.double()
+    )
+    low_precision_grads = torch.autograd.grad(low_precision_output, differentiable, grad_output)
+
+    was_enabled = torch.are_deterministic_algorithms_enabled()
+    was_warn_only = torch.is_deterministic_algorithms_warn_only_enabled()
+    try:
+        if repeat_backward:
+            # Forward already ran: switching modes must still use the output-owned fallback.
+            torch.use_deterministic_algorithms(True)
+        actual_grads = torch.autograd.grad(
+            actual, differentiable, grad_output, retain_graph=repeat_backward
+        )
+        if repeat_backward:
+            for repeat in range(3):
+                repeated_grads = torch.autograd.grad(
+                    actual, differentiable, grad_output, retain_graph=repeat < 2
+                )
+                for repeated, first in zip(repeated_grads, actual_grads, strict=True):
+                    torch.testing.assert_close(repeated, first, atol=0, rtol=0)
+    finally:
+        torch.use_deterministic_algorithms(was_enabled, warn_only=was_warn_only)
+
+    topk = kv_indices.shape[-1]
+    forward_reductions = (head_dim, topk + window, topk + window)
+    assert_matches_low_precision_eager(
+        actual, low_precision_output, high_precision_output, forward_reductions
+    )
+    gradient_reductions = (
+        forward_reductions + (head_dim, topk + window),
+        forward_reductions + (head_dim, window, heads if shared else 1),
+        forward_reductions + (head_dim, seq_len, heads if shared else 1),
+    )
+    for index, reductions in enumerate(gradient_reductions):
+        assert_matches_low_precision_eager(
+            actual_grads[index],
+            low_precision_grads[index],
+            high_precision_grads[index],
+            reductions,
+        )
+    assert_sink_matches_reference(
+        actual_grads[3],
+        low_precision_grads[3],
+        high_precision_grads[3],
+        query.dtype,
+        forward_reductions + (head_dim, seq_len),
+    )
+
+    # Independently isolate FP32 sink arithmetic from the legitimate BF16 saved-state error.
+    assert aux.lse is not None
+    delta = (actual.double() * grad_output.double()).sum(-1)
+    sink_partials = -torch.exp(sink.double()[None, :, None] - aux.lse.double()) * delta
+    sink_expected = sink_partials.sum((0, 2))
+    allowance = 32 * torch.finfo(torch.float32).eps * sink_partials.abs().sum((0, 2))
+    assert ((actual_grads[3].double() - sink_expected).abs() <= allowance).all()
+    if topk == 0:
+        assert actual_grads[2].count_nonzero() == 0
+    if window == 0:
+        assert actual_grads[1].count_nonzero() == 0
+    if topk == window == 0:
+        assert actual.count_nonzero() == 0
+        assert all(gradient.count_nonzero() == 0 for gradient in actual_grads)
+
+
+@pytest.mark.parametrize(
+    "heads,share_kv,dtype,seq_len,topk,window,with_docs",
+    [
+        pytest.param(17, True, torch.bfloat16, 33, 19, 19, True, id="shared-bf16"),
+        pytest.param(2, True, torch.bfloat16, 257, 32, 33, True, id="generic-bf16-shared"),
+        pytest.param(2, False, torch.bfloat16, 17, 19, 19, True, id="generic-bf16-unshared"),
+        pytest.param(2, True, torch.float16, 17, 19, 19, True, id="generic-fp16-shared"),
+        pytest.param(2, False, torch.float16, 33, 19, 19, True, id="generic-fp16-unshared"),
+        pytest.param(2, True, torch.float32, 33, 19, 19, True, id="generic-fp32-shared"),
+        pytest.param(2, False, torch.float32, 17, 19, 19, True, id="generic-fp32-unshared"),
+        pytest.param(2, True, torch.bfloat16, 17, 19, 0, False, id="selected-only"),
+        pytest.param(17, True, torch.bfloat16, 33, 0, 19, True, id="local-only"),
+        pytest.param(2, False, torch.float32, 17, 0, 0, False, id="sink-only"),
+        pytest.param(16, True, torch.bfloat16, 17, 512, 128, False, id="dsv4-topk512"),
+    ],
+)
+def test_d512_training(heads, share_kv, dtype, seq_len, topk, window, with_docs):
+    inputs = make_inputs(heads, share_kv, dtype, seq_len, topk, with_docs)
+    check_training(inputs, window)
+
+
+@pytest.mark.parametrize("heads,share_kv", [(2, False), (17, True)], ids=["generic", "shared"])
+def test_d512_deterministic_backward(heads, share_kv):
+    inputs = make_inputs(heads, share_kv, torch.bfloat16, batch=2)
+    check_training(inputs, 19, repeat_backward=True)
+
+
+@pytest.mark.parametrize("heads,share_kv", [(2, False), (17, True)], ids=["generic", "shared"])
+def test_d512_torch_compile_fullgraph(heads, share_kv):
+    # Stride tuples are Triton constexpr arguments, so each shape specializes independently.
+    compiled = torch.compile(selected_attention, fullgraph=True, dynamic=False)
+    for seq_len in (17, 33):
+        inputs = make_inputs(heads, share_kv, torch.bfloat16, seq_len=seq_len)
+        check_training(inputs, 19, operation=compiled)
+
+
+@pytest.mark.full_autotune
+@pytest.mark.parametrize("kernel_name", ["dq_shared", "dsparse_shared_atomic", "dsparse_generic"])
+def test_d512_backward_config_pruning(kernel_name):
+    pytest.importorskip("triton")
+    from attn_gym.sparse.selected_attention.impl.triton import backward, shared_backward
+
+    kernels = {
+        "dq_shared": shared_backward._selected_attention_bwd_dq_shared,
+        "dsparse_shared_atomic": shared_backward._selected_attention_bwd_dsparse_kv_shared_atomic,
+        "dsparse_generic": backward._selected_attention_bwd_dsparse_kv,
+    }
+    kernel = kernels[kernel_name]
+    wide_configs = kernel.early_config_prune(kernel.configs, {}, D=512)
+    assert len(wide_configs) == 1
+    config = wide_configs[0]
+    assert config.num_warps == 4
+    assert config.num_stages == 1
+    assert all(size == 16 for size in config.kwargs.values())
+    narrow_configs = kernel.early_config_prune(kernel.configs, {}, D=128)
+    assert len(narrow_configs) > 1
+    if kernel_name == "dq_shared":
+        assert {config.kwargs["BLOCK_N"] for config in narrow_configs} == {64, 128}
+    else:
+        assert narrow_configs == kernel.configs

--- a/test/test_selected_attention_semantics.py
+++ b/test/test_selected_attention_semantics.py
@@ -870,17 +870,6 @@ def test_shared_kv_blackwell_dsv4_forward():
         high_precision_expected,
         reduction_sizes=(head_dim, topk + window, topk + window),
     )
-    with pytest.raises(NotImplementedError, match="head_dim=512 only for inference"):
-        selected_attention(
-            query.requires_grad_(),
-            local_kv,
-            sparse_kv,
-            kv_indices,
-            attention_sink,
-            None,
-            window,
-            backend="triton",
-        )
 
 
 # ---------------------------------------------------------------------------

--- a/test/test_selected_attention_triton.py
+++ b/test/test_selected_attention_triton.py
@@ -40,12 +40,14 @@ def assert_matches_low_precision_eager(
     high_precision_expected,
     reduction_sizes,
     quantized_intermediates=0,
+    intermediate_dtype: torch.dtype | None = None,
 ):
     """Bound kernel error by low-precision eager error against an FP64 measuring stick.
 
     ``quantized_intermediates`` counts low-precision rounding events inside the kernel's
     numerical tree beyond the final output cast that the eager oracle computes in FP32;
-    see NOTE [Sink Gradient Delta Rounding].
+    see NOTE [Sink Gradient Delta Rounding]. ``intermediate_dtype`` defaults to the output
+    dtype; set it when, for example, an FP32 sink gradient uses BF16 saved intermediates.
     """
     assert torch.isfinite(actual).all()
     actual_difference = (actual.double() - high_precision_expected).abs()
@@ -54,13 +56,33 @@ def assert_matches_low_precision_eager(
         sum(math.sqrt(size) for size in reduction_sizes) * torch.finfo(torch.float32).eps
     )
     output_rounding_eps = torch.finfo(actual.dtype).eps
-    rounding_eps = accumulation_eps + (1 + quantized_intermediates) * output_rounding_eps
+    intermediate_eps = (
+        quantized_intermediates
+        * torch.finfo(actual.dtype if intermediate_dtype is None else intermediate_dtype).eps
+    )
+    rounding_eps = accumulation_eps + output_rounding_eps + intermediate_eps
     mean_atol = rounding_eps * high_precision_expected.abs().mean().item()
     max_atol = (
-        accumulation_eps + (len(reduction_sizes) + quantized_intermediates) * output_rounding_eps
+        accumulation_eps + len(reduction_sizes) * output_rounding_eps + intermediate_eps
     ) * high_precision_expected.abs().max().item()
     assert actual_difference.mean().item() <= eager_difference.mean().item() + mean_atol
     assert actual_difference.max().item() <= eager_difference.max().item() + max_atol
+
+
+def assert_sink_gradient_fp32(
+    sink: torch.Tensor,
+    lse: torch.Tensor,
+    output: torch.Tensor,
+    grad_output: torch.Tensor,
+    grad_sink: torch.Tensor,
+) -> None:
+    """Check FP32 sink arithmetic independently of the saved output's quantization error."""
+    delta = (output.double() * grad_output.double()).sum(-1)
+    sink_partials = -torch.exp(sink.double()[None, :, None] - lse.double()) * delta
+    # Bound FP32 reduction error by the sum of magnitudes, not the cancellation-prone result.
+    allowance = 32 * torch.finfo(torch.float32).eps * sink_partials.abs().sum((0, 2))
+    assert torch.isfinite(grad_sink).all()
+    assert ((grad_sink.double() - sink_partials.sum((0, 2))).abs() <= allowance).all()
 
 
 def _make_inputs(
@@ -566,13 +588,6 @@ def test_triton_fp32_row_reductions(heads, head_dim, share_kv):
         output.shape, dtype=output.dtype, device=output.device, generator=generator
     )
     output.backward(grad_output)
-    delta = (output.double() * grad_output.double()).sum(-1)
-    sink_partials = (
-        -torch.exp(inputs["attention_sink"].double()[None, :, None] - aux.lse.double()) * delta
+    assert_sink_gradient_fp32(
+        inputs["attention_sink"], aux.lse, output, grad_output, inputs["attention_sink"].grad
     )
-    expected_sink = sink_partials.sum((0, 2))
-    # Bound FP32 reduction error by the sum of magnitudes, not the cancellation-prone result.
-    allowance = 32 * fp32_eps * sink_partials.abs().sum((0, 2))
-    actual_sink = inputs["attention_sink"].grad.double()
-    assert torch.isfinite(actual_sink).all()
-    assert ((actual_sink - expected_sink).abs() <= allowance).all()


### PR DESCRIPTION
## Summary

Enable D=512 training in the Triton selected-attention backend so callers have a CUDA fallback when FA4 is unavailable.

The generic backward's original tiles exceed shared-memory limits at D=512. Use smaller forward/backward tiles, enable the Blackwell shared-KV backward schedule with bounded configurations, and preserve the existing autotune choices for smaller head dimensions. Deterministic D512 backward uses output-owned sparse-KV gradients and FP32 sink-gradient partials instead of cross-block sink atomics.

Add 18 focused cases covering generic FP16/BF16/FP32, shared/unshared KV, packed documents, repeated/invalid indices, empty branches, top-k 512, deterministic backward, and static fullgraph compilation.

## Validation

- GB200: 168 selected-attention regression tests passed, followed by passing strengthened B=2 deterministic cases and the S=257 generic case.
- Compared outputs and all four gradients against FP64 plus low-precision eager; checked FP32 sink arithmetic separately.
- Verified the new regression fails on the parent revision's D512 training rejection.
- Generic kernels compiled within resource limits for SM80 BF16/FP32 and SM90 FP16/FP32; physical A100/H100 execution was not tested.
- Ruff, formatting, and applicable pre-commit hooks passed.

```sh
.venv/bin/pytest -n 6 -v -rA --show-capture=no --tb=short --maxfail=3 test/test_selected_attention_d512.py test/test_selected_attention_triton.py test/test_selected_attention_semantics.py test/test_selected_attention_validation.py
```

This is a correctness fallback, not a FA4-performance replacement. Fully dynamic compilation retains the existing symbolic-stride-tuple limitation; fullgraph coverage uses `dynamic=False`.
